### PR TITLE
fix(range): Range +/- Real shifts both bounds, preserving variant

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -200,14 +200,18 @@
 - [ ] roast/S03-operators/range-int.t
   - 0/? pass. Crashes mid-run.
 - [ ] roast/S03-operators/range.t
-  - 164/181 pass (17 fail). Two distinct blockers:
+  - 165/181 pass (16 fail). Two distinct blockers:
     1. **`X::Worry::Precedence::Range`** (16 subtests, lines 268-276): compile-time worry
        when a Range endpoint is prefixed by a looser-precedence op (`|4..5`/`~4..5`); with
        `use fatal` it throws. Must NOT warn when parenthesized (`|(4..5)`). Parser feature.
-    2. **`do $_ for <Num/BigInt range>` rvalue collection** (offset subtest g/h, lines 323-328):
-       `my @a = do $_ for (2..4) + 5e-1` yields `[Bool::True]` instead of `[2.5,3.5,4.5]` —
-       the do-statement-modifier rvalue loses the per-iteration values for Num/BigInt ranges.
-       (`(2..4)*2`/`(^4)*2`/`(^4)/2` cases FIXED by canonical-int-range PR #3205.)
+    2. **`do $_ for LIST` rvalue collection** (offset subtests, lines 323-328):
+       `my @a = do $_ for (2..4) + 5e-1` yields `[]` instead of `[2.5,3.5,4.5]` — the
+       do-statement-modifier rvalue is sunk instead of collected. NOT range-specific: it
+       reproduces for plain `my @a = do $_ for 2..4` (any LIST). Separate sink/statement-modifier
+       bug, unrelated to Range arithmetic.
+       (`Range +/- Real` arithmetic — `(2..4)+5e-1`, `(2.5..4.5)-1`, GenericRange offset, etc.
+       — now produces a canonical Range matching raku, via the shared `range_offset` helper;
+       `(2..4)*2`/`(^4)*2`/`(^4)/2` were FIXED earlier by canonical-int-range PR #3205.)
 - [ ] roast/S03-operators/reduce-le1arg.t
   - 10/54 pass.
 - [ ] roast/S03-operators/relational.t

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -330,14 +330,11 @@ fn make_fat_rat(num: i64, den: i64) -> Value {
 
 /// Scale a Range by a numeric factor. Returns Some(range) if `range_val` is a Range
 /// and `factor` is numeric, None otherwise.
-fn range_scale(range_val: &Value, factor: &Value) -> Option<Value> {
-    let n = match factor {
-        Value::Int(i) => Some(*i as f64),
-        Value::Num(f) => Some(*f),
-        Value::Rat(n, d) if *d != 0 => Some(*n as f64 / *d as f64),
-        _ => None,
-    }?;
-    let (start, end, excl_start, excl_end) = match range_val {
+/// Extract `(start, end, excl_start, excl_end)` from any Range variant
+/// (the int-endpoint variants or a `GenericRange`). Returns `None` for
+/// non-Range values.
+fn range_bounds(range_val: &Value) -> Option<(Value, Value, bool, bool)> {
+    Some(match range_val {
         Value::Range(a, b) => (Value::Int(*a), Value::Int(*b), false, false),
         Value::RangeExcl(a, b) => (Value::Int(*a), Value::Int(*b), false, true),
         Value::RangeExclStart(a, b) => (Value::Int(*a), Value::Int(*b), true, false),
@@ -354,7 +351,42 @@ fn range_scale(range_val: &Value, factor: &Value) -> Option<Value> {
             *excl_end,
         ),
         _ => return None,
-    };
+    })
+}
+
+/// Offset both bounds of a Range by `delta` using `op` (add or subtract),
+/// preserving exclusivity. Returns `Some(range)` when `range_val` is a Range and
+/// `delta` is a real number (Int/Num/Rat/FatRat/BigInt). Collapses to a
+/// canonical integer range when both endpoints remain `Int` (so `(2..4) + 1`
+/// is `eqv` to the literal `3..5`); falls back to `GenericRange` otherwise.
+fn range_offset(
+    range_val: &Value,
+    delta: &Value,
+    op: impl Fn(Value, Value) -> Value,
+) -> Option<Value> {
+    if !matches!(
+        delta,
+        Value::Int(_) | Value::Num(_) | Value::Rat(_, _) | Value::FatRat(_, _) | Value::BigInt(_)
+    ) {
+        return None;
+    }
+    let (start, end, excl_start, excl_end) = range_bounds(range_val)?;
+    Some(canonical_int_range(
+        op(start, delta.clone()),
+        op(end, delta.clone()),
+        excl_start,
+        excl_end,
+    ))
+}
+
+fn range_scale(range_val: &Value, factor: &Value) -> Option<Value> {
+    let n = match factor {
+        Value::Int(i) => Some(*i as f64),
+        Value::Num(f) => Some(*f),
+        Value::Rat(n, d) if *d != 0 => Some(*n as f64 / *d as f64),
+        _ => None,
+    }?;
+    let (start, end, excl_start, excl_end) = range_bounds(range_val)?;
     let scale_val = |v: Value| -> Value {
         match v {
             Value::Int(i) => {
@@ -533,25 +565,12 @@ pub(crate) fn arith_add(left: Value, right: Value) -> Result<Value, RuntimeError
     {
         return result;
     }
-    // Range + Int: shift both bounds
-    match (&left, &right) {
-        (Value::Range(a, b), Value::Int(n)) => return Ok(Value::Range(a + n, b + n)),
-        (Value::RangeExcl(a, b), Value::Int(n)) => return Ok(Value::RangeExcl(a + n, b + n)),
-        (Value::RangeExclStart(a, b), Value::Int(n)) => {
-            return Ok(Value::RangeExclStart(a + n, b + n));
-        }
-        (Value::RangeExclBoth(a, b), Value::Int(n)) => {
-            return Ok(Value::RangeExclBoth(a + n, b + n));
-        }
-        (Value::Int(n), Value::Range(a, b)) => return Ok(Value::Range(a + n, b + n)),
-        (Value::Int(n), Value::RangeExcl(a, b)) => return Ok(Value::RangeExcl(a + n, b + n)),
-        (Value::Int(n), Value::RangeExclStart(a, b)) => {
-            return Ok(Value::RangeExclStart(a + n, b + n));
-        }
-        (Value::Int(n), Value::RangeExclBoth(a, b)) => {
-            return Ok(Value::RangeExclBoth(a + n, b + n));
-        }
-        _ => {}
+    // Range + Real (commutative): shift both bounds, preserving exclusivity.
+    let add_endpoint = |a: Value, b: Value| arith_add(a, b).unwrap_or(Value::Int(0));
+    if let Some(range) = range_offset(&left, &right, add_endpoint)
+        .or_else(|| range_offset(&right, &left, add_endpoint))
+    {
+        return Ok(range);
     }
     // Date + Int: add days
     if let Some(days) = instance_days(&left)
@@ -784,27 +803,10 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
     if let Some(result) = mixin_range_arith_val(left.clone(), right.clone(), arith_sub) {
         return result;
     }
-    match (&left, &right) {
-        (Value::Range(a, b), Value::Int(n)) => return Value::Range(a - n, b - n),
-        (Value::RangeExcl(a, b), Value::Int(n)) => return Value::RangeExcl(a - n, b - n),
-        (Value::RangeExclStart(a, b), Value::Int(n)) => return Value::RangeExclStart(a - n, b - n),
-        (Value::RangeExclBoth(a, b), Value::Int(n)) => return Value::RangeExclBoth(a - n, b - n),
-        (Value::Range(a, b), rhs)
-        | (Value::RangeExcl(a, b), rhs)
-        | (Value::RangeExclStart(a, b), rhs)
-        | (Value::RangeExclBoth(a, b), rhs)
-            if rhs.is_numeric() =>
-        {
-            let excl_start = matches!(&left, Value::RangeExclStart(..) | Value::RangeExclBoth(..));
-            let excl_end = matches!(&left, Value::RangeExcl(..) | Value::RangeExclBoth(..));
-            return Value::GenericRange {
-                start: Arc::new(arith_sub(Value::Int(*a), rhs.clone())),
-                end: Arc::new(arith_sub(Value::Int(*b), rhs.clone())),
-                excl_start,
-                excl_end,
-            };
-        }
-        _ => {}
+    // Range - Real: shift both bounds (only when the Range is on the left;
+    // `Real - Range` numifies the Range, matching Raku).
+    if let Some(range) = range_offset(&left, &right, arith_sub) {
+        return range;
     }
     let (l, r) = runtime::coerce_numeric(left, right);
     if matches!(l, Value::Complex(_, _)) || matches!(r, Value::Complex(_, _)) {

--- a/t/range-add-sub-real.t
+++ b/t/range-add-sub-real.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `Range +/- Real` must shift both endpoints, preserving exclusivity, and
+# collapse to a canonical integer Range when both endpoints stay Int (so the
+# result is `eqv` to a literal range). Previously only `Range + Int` worked;
+# `Range + Num/Rat` and `GenericRange +/- Real` fell through to numification.
+
+plan 16;
+
+# Int offset stays a canonical integer Range
+is-deeply (2..4)   + 2, 4..6,    'inclusive Range + Int';
+is-deeply (2..^5)  + 1, 3..^6,   'exclusive-end Range + Int';
+is-deeply (2^..5)  + 1, 3^..6,   'exclusive-start Range + Int';
+is-deeply (2^..^5) + 1, 3^..^6,  'exclusive-both Range + Int';
+is-deeply 2 + (2..4),   4..6,    'Int + Range (commutative)';
+is-deeply (2..4)   - 1, 1..3,    'inclusive Range - Int';
+is-deeply (2..^5)  - 1, 1..^4,   'exclusive-end Range - Int';
+
+# Rat offset produces Rat endpoints
+is-deeply (2..4)   + 0.5, 2.5..4.5,   'Range + Rat';
+is-deeply 0.5 + (2..4),   2.5..4.5,   'Rat + Range (commutative)';
+is-deeply (2..4)   - 0.5, 1.5..3.5,   'Range - Rat';
+is-deeply (2..^4)  + 0.5, 2.5..^4.5,  'exclusive-end Range + Rat';
+
+# Num offset produces Num endpoints
+is-deeply (2..4) + 5e-1, 2.5e0..4.5e0, 'Range + Num';
+
+# Offsetting a GenericRange (non-Int endpoints) keeps shifting
+is-deeply (2.5..4.5) + 1, 3.5..5.5, 'GenericRange + Int';
+is-deeply (2.5..4.5) - 1, 1.5..3.5, 'GenericRange - Int';
+
+# `Real - Range` numifies the Range (NOT a range), matching Raku
+is 0.5 - (2..4), -2.5, 'Real - Range numifies';
+
+# role mixin is preserved across the offset
+my role Meows {}
+my $r := (2..^5) but Meows;
+ok ($r + 1) ~~ Meows, 'role preserved through Range + Int';


### PR DESCRIPTION
## Summary

`arith_add` only handled `Range + Int` (and `arith_sub` only collapsed `Range - Int`), so `(2..4) + 5e-1` fell through to numeric coercion and returned a bare `Num` (`3.5`) instead of the Range `2.5e0..4.5e0`. `GenericRange +/- Real` (e.g. `(2.5..4.5) - 1`) was likewise unhandled.

This introduces a shared `range_offset` helper (mirroring the existing `range_scale`) that offsets both endpoints with a given op, preserving exclusivity and collapsing to a canonical integer Range when both endpoints stay `Int` (so `(2..4) + 1` is `eqv` to the literal `3..5`), falling back to `GenericRange` for non-Int endpoints. A `range_bounds` extractor is added and reused in `range_scale` to drop the duplicated bound-matching.

`Real - Range` still numifies the Range (matching raku: `0.5 - (2..4)` is `-2.5`, not a Range), since subtraction only treats a left-hand Range specially.

### Before / after

| expr | before | after / raku |
|------|--------|------|
| `(2..4) + 5e-1` | `3.5` (Num) | `2.5e0..4.5e0` |
| `(2..4) + 0.5` | numified | `2.5..4.5` |
| `(2.5..4.5) - 1` | unhandled | `1.5..3.5` |
| `0.5 - (2..4)` | `-2.5` | `-2.5` (unchanged) |

## Tests

- New `t/range-add-sub-real.t` (16 cases: Int/Rat/Num offsets, commutativity, GenericRange offset, `Real - Range` numification, role-mixin preservation).
- `roast/S03-operators/range.t` improves 164 -> 165 (the remaining 16 fails are the unrelated `X::Worry::Precedence::Range` parser feature and a `do $_ for LIST` rvalue-collection bug that is not range-specific).
- No regressions in `arith.t`, `div.t`, `range-basic.t`, `range-int.t`, `autoincrement-range.t`, `range-mul-canonical.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)