### PR TITLE
fix(parser): do STMT must not swallow the trailing statement terminator

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -200,18 +200,17 @@
 - [ ] roast/S03-operators/range-int.t
   - 0/? pass. Crashes mid-run.
 - [ ] roast/S03-operators/range.t
-  - 165/181 pass (16 fail). Two distinct blockers:
-    1. **`X::Worry::Precedence::Range`** (16 subtests, lines 268-276): compile-time worry
-       when a Range endpoint is prefixed by a looser-precedence op (`|4..5`/`~4..5`); with
-       `use fatal` it throws. Must NOT warn when parenthesized (`|(4..5)`). Parser feature.
-    2. **`do $_ for LIST` rvalue collection** (offset subtests, lines 323-328):
-       `my @a = do $_ for (2..4) + 5e-1` yields `[]` instead of `[2.5,3.5,4.5]` — the
-       do-statement-modifier rvalue is sunk instead of collected. NOT range-specific: it
-       reproduces for plain `my @a = do $_ for 2..4` (any LIST). Separate sink/statement-modifier
-       bug, unrelated to Range arithmetic.
-       (`Range +/- Real` arithmetic — `(2..4)+5e-1`, `(2.5..4.5)-1`, GenericRange offset, etc.
-       — now produces a canonical Range matching raku, via the shared `range_offset` helper;
-       `(2..4)*2`/`(^4)*2`/`(^4)/2` were FIXED earlier by canonical-int-range PR #3205.)
+  - 165/181 pass (16 fail). The remaining failures (tests 154-176) are all one blocker:
+    **`X::Worry::Precedence::Range`** (lines 268-276): compile-time worry when a Range
+    endpoint is prefixed by a looser-precedence op (`|4..5`/`~4..5`); with `use fatal` it
+    throws. Must NOT warn when parenthesized (`|(4..5)`). Parser feature.
+  - The `do $_ for <range> + offset` rvalue subtests (lines 318-337) now pass: `Range +/- Real`
+    arithmetic produces a canonical Range matching raku via the shared `range_offset` helper
+    (PR #3209), and `(2..4)*2`/`(^4)*2`/`(^4)/2` were FIXED earlier by canonical-int-range
+    PR #3205. (Separately, a general `do STMT for LIST; <listop>` parser misparse — `do STMT`
+    let its inner statement parser swallow the trailing `;`, so a following listop like
+    `say @a` was misread as an infix op on the `do` result — was also fixed; range.t's own
+    subtests used `is-deeply`, which was not absorbed, so they were unaffected.)
 - [ ] roast/S03-operators/reduce-le1arg.t
   - 10/54 pass.
 - [ ] roast/S03-operators/relational.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -8,6 +8,22 @@ use crate::value::Value;
 
 use super::super::stmt::{keyword, statement_pub};
 
+/// When `do STMT` parses its inner statement via the full statement parser, a
+/// statement modifier (`do $_ for @list`) or assignment consumes the trailing
+/// `;`. In expression context the `;` belongs to the *outer* statement, so if it
+/// were swallowed the surrounding expression parser would keep going and treat a
+/// following listop (`my @a = do $_ for 2..4; say @a`) as an infix operator on
+/// the `do` result. Give the terminator back by returning a remaining slice that
+/// starts at the consumed `;`.
+fn restore_do_stmt_terminator<'a>(orig: &'a str, after: &'a str) -> &'a str {
+    let consumed = orig.len().saturating_sub(after.len());
+    if consumed > 0 && orig.as_bytes()[consumed - 1] == b';' {
+        &orig[consumed - 1..]
+    } else {
+        after
+    }
+}
+
 fn is_superscript_digit(c: char) -> bool {
     matches!(
         c,
@@ -1745,14 +1761,16 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     false
                 };
                 if is_ctrl(r)
-                    && let Ok((r, stmt)) = super::super::stmt::statement_pub(r)
+                    && let Ok((r_after, stmt)) = super::super::stmt::statement_pub(r)
                 {
-                    return Ok((r, Expr::DoStmt(Box::new(stmt))));
+                    let r_after = restore_do_stmt_terminator(r, r_after);
+                    return Ok((r_after, Expr::DoStmt(Box::new(stmt))));
                 }
             }
             // do STMT — wrap an assignment or other statement
-            if let Ok((r, stmt)) = super::super::stmt::statement_pub(r) {
-                return Ok((r, Expr::DoStmt(Box::new(stmt))));
+            if let Ok((r_after, stmt)) = super::super::stmt::statement_pub(r) {
+                let r_after = restore_do_stmt_terminator(r, r_after);
+                return Ok((r_after, Expr::DoStmt(Box::new(stmt))));
             }
             // do EXPR — just evaluate the expression
             let (r, expr) = expression(r)?;

--- a/t/do-stmt-modifier-rvalue.t
+++ b/t/do-stmt-modifier-rvalue.t
@@ -1,0 +1,43 @@
+use Test;
+
+# `do STMT` in expression context wraps a single statement. When that statement
+# carries a statement modifier (`do $_ for @list`) or is an assignment, the inner
+# statement parser used to consume the trailing `;`, so a following listop was
+# misparsed as an infix operator on the `do` result
+# (`my @a = do $_ for 2..4; say @a` became `my @a = say(do(...), @a)`).
+# The `;` belongs to the outer statement and must terminate the `do` expression.
+
+plan 9;
+
+# do EXPR for LIST collects each iteration's value as an rvalue
+my @a = do $_ for 2..4;
+is-deeply @a, [2, 3, 4], 'do $_ for <int range> collects values';
+
+my @b = do $_ * 2 for 2..4;
+is-deeply @b, [4, 6, 8], 'do EXPR for <range> collects computed values';
+
+# the range-arithmetic interaction from S03-operators/range.t
+my @c = do $_ for (2..4) + 5e-1;
+is-deeply @c, [2.5e0, 3.5e0, 4.5e0], 'do $_ for <Num range> collects per-iteration values';
+
+# a following listop must NOT be absorbed as an infix operator on the do result
+my @d = do $_ for 2..4;
+say 99 for ();  # no-op; just ensure the previous statement terminated
+is-deeply @d, [2, 3, 4], 'do-for terminates before a following statement';
+
+# do for as a scalar rvalue holds the collected List
+my $last = do $_ for 1..3;
+is $last.gist, '(1 2 3)', 'do $_ for as scalar rvalue is the collected List';
+
+# do EXPR if COND
+my $x = do 42 if True;
+is $x, 42, 'do EXPR if True returns the value';
+
+my $y = do 42 if False;
+ok !$y.defined, 'do EXPR if False is undefined';
+
+# do ASSIGN; following statement stays separate
+my $p;
+my $q = do $p = 7;
+is $q, 7, 'do ASSIGN returns the assigned value';
+is $p, 7, 'do ASSIGN performed the assignment';


### PR DESCRIPTION
## Summary

`do STMT` in expression context parses its inner statement with the full statement parser. When that statement carries a statement modifier (`do $_ for @list`) or is an assignment, the modifier path consumes the trailing `;`. In expression context the `;` belongs to the **outer** statement, so swallowing it left the surrounding expression parser running past the boundary — a following listop was misread as an infix operator on the `do` result.

`my @a = do $_ for 2..4; say @a` parsed as `my @a = say(do(...), @a)`, printing the loop values and assigning `[True]` to `@a` instead of `[2 3 4]`. (`@a.say` worked because a postfix method call is not absorbed as infix; the bug only bit listops like `say`.)

`do STMT` now restores the consumed terminator via `restore_do_stmt_terminator`, returning a remaining slice that starts at the `;`, so the outer expression ends cleanly. Applies to both the `do if/for/while/...` control path and the generic `do STMT` (assignment) path.

### Before / after

```
my @a = do $_ for 2..4; say @a;
# before: prints "(2 3 4)", @a is [True]
# after:  @a is [2 3 4]   (matches raku)
```

## Tests

- New `t/do-stmt-modifier-rvalue.t` (9 cases: do-for over int/computed/Num ranges, listop after the do-for, scalar rvalue, `do EXPR if COND`, `do ASSIGN`).
- `make test` passes locally (cargo + full `t/` suite).
- No regression: `S04-statements/for.t` shows the same 12 pre-existing failures with and without this change; `given.t`/`if.t`/`unless.t`/`loop.t`/`repeat.t`/`while.t`/`until.t`/`gather.t` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)