### PR TITLE
feat(metaops): reversed range meta-ops (R../R^../R..^/R^..^) + precedence worry

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -388,8 +388,9 @@ motivate.
   values. See S32.md.
 
 **Broad / no single root cause (re-measure before investing):**
-- S02-types/range.t (56 failing), S03-operators/range.t (18 failing) — broad range
-  coercion/typecheck/lazy issues, well beyond a single fix.
+- S02-types/range.t (56 failing) — broad range coercion/typecheck/lazy issues, well beyond a
+  single fix. (S03-operators/range.t is now whitelisted: Range +/- Real #3209, reversed-range
+  meta-ops `R..` + precedence worry, do-stmt-modifier `;` fix #3210.)
 
 ---
 

--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -199,18 +199,16 @@
   - 6/115 pass.
 - [ ] roast/S03-operators/range-int.t
   - 0/? pass. Crashes mid-run.
-- [ ] roast/S03-operators/range.t
-  - 165/181 pass (16 fail). The remaining failures (tests 154-176) are all one blocker:
-    **`X::Worry::Precedence::Range`** (lines 268-276): compile-time worry when a Range
-    endpoint is prefixed by a looser-precedence op (`|4..5`/`~4..5`); with `use fatal` it
-    throws. Must NOT warn when parenthesized (`|(4..5)`). Parser feature.
-  - The `do $_ for <range> + offset` rvalue subtests (lines 318-337) now pass: `Range +/- Real`
-    arithmetic produces a canonical Range matching raku via the shared `range_offset` helper
-    (PR #3209), and `(2..4)*2`/`(^4)*2`/`(^4)/2` were FIXED earlier by canonical-int-range
-    PR #3205. (Separately, a general `do STMT for LIST; <listop>` parser misparse — `do STMT`
-    let its inner statement parser swallow the trailing `;`, so a following listop like
-    `say @a` was misread as an infix op on the `do` result — was also fixed; range.t's own
-    subtests used `is-deeply`, which was not absorbed, so they were unaffected.)
+- [x] roast/S03-operators/range.t
+  - 181/181, whitelisted. The last 16 failures (`X::Worry::Precedence::Range` block, lines
+    268-276) needed the reversed-range meta-ops (`R..`/`R^..`/`R..^`/`R^..^`) to (a) parse +
+    evaluate and (b) carry the same precedence worry as a plain range. Fixed by adding the
+    range ops to `parse_meta_op`'s symbolic list, handling them in `exec_meta_op`'s `R` arm
+    (reuse the dedicated range builders with operands swapped), and firing
+    `check_range_precedence_worry` off the original input when a meta-op's base is a range op.
+    The `do $_ for <range> + offset` rvalue subtests (lines 318-337) were unblocked earlier by
+    `Range +/- Real` arithmetic (`range_offset` helper, PR #3209) + canonical-int-range PR #3205.
+    (A general `do STMT for LIST; <listop>` parser misparse was also fixed separately in #3210.)
 - [ ] roast/S03-operators/reduce-le1arg.t
   - 10/54 pass.
 - [ ] roast/S03-operators/relational.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -231,6 +231,7 @@ roast/S03-operators/overflow.t
 roast/S03-operators/precedence.t
 roast/S03-operators/range-basic.t
 roast/S03-operators/range-int.t
+roast/S03-operators/range.t
 roast/S03-operators/reduce-le1arg.t
 roast/S03-operators/relational.t
 roast/S03-operators/repeat.t

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -1218,7 +1218,7 @@ fn junctive_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
 fn list_infix_expr(input: &str) -> PResult<'_, Expr> {
     let (mut rest, mut left) = range_expr(input)?;
     let mut current_assoc_key = None;
-    rest = parse_list_infix_loop(rest, &mut left, &mut current_assoc_key)?;
+    rest = parse_list_infix_loop(rest, input, &mut left, &mut current_assoc_key)?;
     Ok((rest, left))
 }
 
@@ -1268,7 +1268,7 @@ fn sequence_expr(input: &str) -> PResult<'_, Expr> {
             continue;
         }
         // Try Z/X/meta/infix-func operators
-        let new_rest = parse_list_infix_loop(rest, &mut left, &mut current_assoc_key)?;
+        let new_rest = parse_list_infix_loop(rest, input, &mut left, &mut current_assoc_key)?;
         if new_rest.len() < rest.len() {
             rest = new_rest;
             continue;
@@ -1282,6 +1282,7 @@ fn sequence_expr(input: &str) -> PResult<'_, Expr> {
 /// Modifies `left` in place and returns the remaining input.
 fn parse_list_infix_loop<'a>(
     input: &'a str,
+    orig_input: &str,
     left: &mut Expr,
     current_assoc_key: &mut Option<String>,
 ) -> Result<&'a str, PError> {
@@ -1578,6 +1579,14 @@ fn parse_list_infix_loop<'a>(
             continue;
         }
         if let Some((meta, op, len)) = parse_meta_op(r) {
+            // A reversed range meta-op (`R..`, `R^..`, `R..^`, `R^..^`) carries the
+            // same precedence worry as a plain range: `|4 R.. 5` / `~4 R.. 5` mean
+            // `|(4 R.. 5)` / `~(4 R.. 5)`, not `(|4) R.. 5`. Fire the worry off the
+            // ORIGINAL input text (parentheses are transparent in the AST), matching
+            // the direct-range path in `range_expr`.
+            if matches!(op.as_str(), ".." | "..^" | "^.." | "^..^") {
+                check_range_precedence_worry(orig_input)?;
+            }
             let op_key = format!("{meta}{op}");
             if let Some(prev) = current_assoc_key.as_deref()
                 && prev != op_key

--- a/src/parser/expr/precedence_meta_ops.rs
+++ b/src/parser/expr/precedence_meta_ops.rs
@@ -229,9 +229,13 @@ pub(super) fn parse_meta_op(input: &str) -> Option<(String, String, usize)> {
 
     // Try symbolic operators first (multi-char then single-char)
     let ops: &[&str] = &[
-        "...^", "...", "…^", "…", "**", "=>", "==", "!=:=", "=:=", "!=", "<=", ">=", "~~", "%%",
-        "//", "&&", "||", "+&", "+|", "+^", "+<", "+>", "~&", "~|", "~^", "~", "+", "-", "*", "/",
-        "%", "<", ">", ",",
+        // Sequence (`...`/`...^`) and range (`..`/`..^`/`^..`/`^..^`) operators must
+        // precede the shorter forms: `...` before `..`, `^..^` before `^..`, `..^`
+        // before `..`. This lets `R..`/`R^..^`/etc. (reversed range) parse as a
+        // meta-op over the range base op.
+        "...^", "...", "…^", "…", "^..^", "^..", "..^", "..", "**", "=>", "==", "!=:=", "=:=", "!=",
+        "<=", ">=", "~~", "%%", "//", "&&", "||", "+&", "+|", "+^", "+<", "+>", "~&", "~|", "~^",
+        "~", "+", "-", "*", "/", "%", "<", ">", ",",
     ];
     for op in ops {
         if r.starts_with(op) {

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -2051,6 +2051,21 @@ impl Interpreter {
                     loan_env!(self, eval_sequence_values(right, left, exclude_end))?
                 } else if op == "~~" {
                     Value::Bool(self.vm_smart_match(&right, &left))
+                } else if matches!(op.as_str(), ".." | "..^" | "^.." | "^..^") {
+                    // `a R.. b` == `b .. a`: build the range with operands
+                    // reversed. Reuse the dedicated range builders (which pop
+                    // `left`/`right` off the stack) so endpoint coercion and
+                    // canonical Range-variant selection stay in one place.
+                    self.stack.push(right);
+                    self.stack.push(left);
+                    match op.as_str() {
+                        ".." => self.exec_make_range_op()?,
+                        "..^" => self.exec_make_range_excl_op()?,
+                        "^.." => self.exec_make_range_excl_start_op()?,
+                        "^..^" => self.exec_make_range_excl_both_op()?,
+                        _ => unreachable!(),
+                    }
+                    return Ok(());
                 } else {
                     self.eval_reduction_operator_values(&op, &right, &left)?
                 }

--- a/t/range-reverse-metaop.t
+++ b/t/range-reverse-metaop.t
@@ -1,0 +1,30 @@
+use Test;
+
+# The reverse meta-operator `R` applied to a range operator (`R..`, `R^..`,
+# `R..^`, `R^..^`) swaps the endpoints: `a R.. b` is `b .. a`. Such a range also
+# carries the precedence worry: a bare `|`/`~` prefix means `|(a R.. b)`, so
+# `use fatal; |4 R.. 5` must throw X::Worry::Precedence::Range, but a
+# parenthesized form must not.
+
+plan 13;
+
+# reversed-range construction
+is-deeply (4 R..  5), (5 ..  4), 'R.. swaps endpoints (inclusive)';
+is-deeply (4 R^.. 5), (5 ^.. 4), 'R^.. swaps endpoints (exclusive start)';
+is-deeply (4 R..^ 5), (5 ..^ 4), 'R..^ swaps endpoints (exclusive end)';
+is-deeply (4 R^..^ 5), (5 ^..^ 4), 'R^..^ swaps endpoints (exclusive both)';
+
+# a non-empty reversed range iterates
+is-deeply (5 R.. 2).list, (2, 3, 4, 5), 'R.. produces an iterable range';
+
+# the precedence worry fires (under use fatal) for a bare prefix on a reversed range
+for «R.. R^.. R..^ R^..^» -> $op {
+    throws-like "\{ use fatal; |4 $op 5 }", X::Worry::Precedence::Range,
+        "$op warns on bare Slip-flatten prefix";
+}
+
+# parenthesized forms do not warn
+eval-lives-ok '{ use fatal; |(4 R.. 5) }', 'parenthesized range does not warn (flatten)';
+eval-lives-ok '{ use fatal; (|4) R.. 5 }', 'parenthesized endpoint does not warn (flatten)';
+eval-lives-ok '{ use fatal; ~(4 R.. 5) }', 'parenthesized range does not warn (stringify)';
+eval-lives-ok '{ use fatal; (~4) R.. 5 }', 'parenthesized endpoint does not warn (stringify)';


### PR DESCRIPTION
## Summary

The reverse meta-operator `R` did not work with the range operators: `4 R.. 5` failed to parse because `parse_meta_op`'s symbolic-op list had no range entries. As a result `S03-operators/range.t`'s `X::Worry::Precedence::Range` block (16 subtests over the 8 `R`-prefixed range-op variants) failed — both the `throws-like` cases (no reversed range to warn about) and the `eval-lives-ok` parenthesized cases (`|(4 R.. 5)` died on the parse error).

Three changes:

1. **Parser** (`precedence_meta_ops.rs`): add `..`/`..^`/`^..`/`^..^` to `parse_meta_op`'s symbolic-op list, ordered after `...`/`...^` and longest-first so `R..`/`R^..^`/etc. parse correctly.
2. **VM** (`vm_string_regex_ops.rs`): handle the range base ops in `exec_meta_op`'s `R` arm by pushing the operands swapped and reusing the dedicated range builders, so `a R.. b` == `b .. a` with canonical Range-variant selection and endpoint coercion shared (not duplicated).
3. **Worry** (`precedence.rs`): a reversed range carries the same precedence worry as a plain range (`|4 R.. 5` means `|(4 R.. 5)`, not `(|4) R.. 5`). Fire `check_range_precedence_worry` off the **original input text** when a meta-op's base op is a range op, matching the direct-range path. The original input is threaded through `parse_list_infix_loop`.

```
4 R..  5  →  5..4       4 R^.. 5  →  5^..4
4 R..^ 5  →  5..^4       4 R^..^ 5  →  5^..^4
{ use fatal; |4 R.. 5 }   → throws X::Worry::Precedence::Range
{ use fatal; |(4 R.. 5) } → lives
```

## Tests

- Whitelists `roast/S03-operators/range.t` (now 181/181).
- New `t/range-reverse-metaop.t` (13 cases).
- `make test` passes locally (cargo + full `t/` suite).
- No regression: `S03-metaops/reduce.t`/`cross.t`/`zip.t`/`infix.t`/`reverse.t`, `range-int.t`/`range-basic.t`, `S03-sequence/basic.t` all pass; `S03-metaops/hyper.t` shows the same 8 pre-existing failures with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)