### PR TITLE
fix(concurrency): uniform worker panic boundary for hyper/race

### DIFF
--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -55,7 +55,18 @@ impl Interpreter {
                     if error.is_some() {
                         break;
                     }
-                    match vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None) {
+                    // Route the per-item user-code call through the same
+                    // panic->X::AdHoc boundary that `start{}`/Promise workers use
+                    // (`guard_worker_panic`). Without it, a Rust panic raised by
+                    // user code in this batch thread only surfaces as a generic
+                    // "Thread panicked in hyper/race" at `join()` and leaks the raw
+                    // Rust panic message to stderr; the guard converts it into a
+                    // catchable X::AdHoc and suppresses the default backtrace dump,
+                    // making worker panic handling uniform across all spawn sites.
+                    let call_result = crate::vm::guard_worker_panic(|| {
+                        vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None)
+                    });
+                    match call_result {
                         Ok(val) => {
                             if is_map_flag {
                                 if let Value::Slip(ref s) = val {

--- a/t/hyper-race-panic-boundary.t
+++ b/t/hyper-race-panic-boundary.t
@@ -1,0 +1,42 @@
+# A Rust-level panic (integer overflow, capacity overflow, index OOB, ...)
+# triggered by user code inside a `hyper`/`race` worker thread must NOT crash the
+# process or leak a raw Rust panic message: each per-item call runs under the same
+# panic->X::AdHoc boundary `start{}`/Promise workers use (see start-panic-boundary.t).
+# The panic surfaces as a catchable X::AdHoc carrying the internal-error message.
+use Test;
+
+plan 6;
+
+# 1-2: a panicking hyper.map is catchable (no crash/hang) and is an X::AdHoc.
+{
+    my $caught;
+    try {
+        my @r = (1..2).hyper.map({ my @a; @a[2**64 - 1] = 1; 1 });
+        CATCH { default { $caught = $_ } }
+    }
+    ok $caught.defined, 'hyper.map worker panic surfaces as a catchable exception';
+    ok $caught ~~ X::AdHoc,
+        'the converted exception is an X::AdHoc';
+}
+
+# 3: the message carries the internal-error prefix (uniform with start{}).
+{
+    my $msg;
+    try {
+        my @r = (1..2).race.map({ my @a; @a[2**64 - 1] = 1; 1 });
+        CATCH { default { $msg = .message } }
+    }
+    ok $msg.defined && $msg.contains('Internal error'),
+        'race.map worker panic message carries the internal-error prefix';
+}
+
+# 4: dies-ok sees the panic as a thrown exception.
+dies-ok {
+    my @r = (1..2).hyper.map({ my @a; @a[2**64 - 1] = 1; 1 });
+}, 'dies-ok sees the hyper.map worker panic as a throw';
+
+# 5-6: ordinary hyper/race are unaffected by the boundary.
+is (1..5).hyper.map(* * 2).List, (2, 4, 6, 8, 10),
+    'ordinary hyper.map still produces correct results';
+is (1..5).race.map(* + 1).sort.List, (2, 3, 4, 5, 6),
+    'ordinary race.map still produces correct results';


### PR DESCRIPTION
## Summary

While starting on the ANALYSIS.md "worker-thread panic boundary" roadmap item, investigation showed the boundary is **already in place** for `start{}`/`Promise` workers (`guard_worker_panic`, see `t/start-panic-boundary.t`). The remaining gap is that the `hyper`/`race` parallel workers do **not** use it.

Before this PR, a Rust panic raised by user code inside a hyper/race batch thread:
- was caught at `join()` only as a generic `"Thread panicked in hyper/race"`, and
- leaked the raw `thread '<unnamed>' panicked at ...` message to stderr even though the failure was ultimately caught (no process crash/hang).

This wraps each per-item `vm_call_on_value` in `guard_worker_panic`, so worker panic handling is now **uniform across all user-code spawn sites**: the panic is caught inside the batch thread, converted to the same catchable `X::AdHoc` (`"Internal error: ..."`) the main thread and `start{}` produce, and the default backtrace dump is suppressed. Normal hyper/race results are unaffected.

```raku
# before: leaks `thread '<unnamed>' panicked at ...: attempt to add with overflow` to stderr,
#         caught only as "Thread panicked in hyper/race"
# after:  caught X::AdHoc: Internal error: attempt to add with overflow  (no stderr leak)
try { (1..2).hyper.map({ my @a; @a[2**64-1]=1; 1 }); CATCH { default { say .message } } }
```

### Note (corrected scope)
The ANALYSIS.md example `@a[9999999999999]=1` is a separate matter: it triggers an **allocation-failure abort** (not a Rust unwind), which `catch_unwind` cannot intercept on any thread — and raku aborts on it too (`MoarVM panic: Memory allocation failed`). That is unbounded array autovivification, not a worker-thread issue; left out of scope here.

## Test
`t/hyper-race-panic-boundary.t` (6 subtests, mirrors `t/start-panic-boundary.t`). Whitelisted `roast/S07-hyperrace/{for,stress}.t` and existing `t/{start,vm}-panic-boundary.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)