### PR TITLE
fix(dispatch): lexical &-sigil parameter shadows a same-named package routine

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1198,6 +1198,13 @@ pub struct Interpreter {
     pub(crate) light_call_cache_gen: u64,
     pub(crate) pos_light_call_cache: HashMap<Symbol, (String, u64)>,
     pub(crate) pos_light_call_cache_gen: u64,
+    /// Bare names that appear as a `&`-sigil parameter in some registered sub
+    /// (e.g. `foo` from `sub callit(&foo) {...}`). A call to such a name may be
+    /// shadowed by a lexical `&name` binding in the current frame, so the
+    /// name-keyed light-call caches must be bypassed for it (the slow path's
+    /// `lexical_override` check resolves the correct callable). Populated at sub
+    /// registration; checked cheaply (guarded by `is_empty()`) on each call.
+    pub(crate) amp_param_shadowed_names: std::collections::HashSet<Symbol>,
     pub(crate) method_resolve_cache: HashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
     #[allow(clippy::type_complexity)]
     pub(crate) last_method_resolve: Option<(Symbol, Symbol, String, Arc<MethodDef>)>,
@@ -3341,6 +3348,7 @@ impl Interpreter {
             light_call_cache_gen: 0,
             pos_light_call_cache: HashMap::new(),
             pos_light_call_cache_gen: 0,
+            amp_param_shadowed_names: std::collections::HashSet::new(),
             method_resolve_cache: HashMap::new(),
             last_method_resolve: None,
             fast_method_cache: HashMap::new(),
@@ -5798,6 +5806,7 @@ impl Interpreter {
             light_call_cache_gen: 0,
             pos_light_call_cache: HashMap::new(),
             pos_light_call_cache_gen: 0,
+            amp_param_shadowed_names: std::collections::HashSet::new(),
             method_resolve_cache: HashMap::new(),
             last_method_resolve: None,
             fast_method_cache: HashMap::new(),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -92,6 +92,21 @@ impl Interpreter {
         candidate.filter(|v| matches!(v, Value::Sub(_) | Value::WeakSub(_)))
     }
 
+    /// Resolve a lexical `&infix:<op>` override (a `&infix:<op>` parameter or a
+    /// `my &infix:<op>` binding) that shadows the package-level operator. Returns
+    /// the bound callable when present, else `None`.
+    pub(super) fn lexical_infix_override(
+        &mut self,
+        code: &CompiledCode,
+        infix_name: &str,
+    ) -> Option<Value> {
+        let ampname = format!("&{}", infix_name);
+        let candidate = self
+            .locals_get_by_name(code, &ampname)
+            .or_else(|| self.env().get(&ampname).cloned());
+        candidate.filter(|v| matches!(v, Value::Sub(_) | Value::WeakSub(_) | Value::Mixin(..)))
+    }
+
     pub(super) fn exec_call_func_op(
         &mut self,
         code: &CompiledCode,
@@ -101,8 +116,20 @@ impl Interpreter {
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_function_dispatch();
+        // If this name is used as a `&`-sigil parameter anywhere, a lexical
+        // `&name` binding in the current frame may shadow a same-named package
+        // sub. The name-keyed light-call caches cannot represent that, so bypass
+        // them and let the slow path's `lexical_override` resolve correctly.
+        // Guarded by `is_empty()` so the common (no `&`-param) case is free.
+        let skip_name_caches = if self.amp_param_shadowed_names.is_empty() {
+            false
+        } else {
+            let name_str = Self::const_str(code, name_idx);
+            self.amp_param_shadowed_names
+                .contains(&Symbol::intern(name_str))
+        };
         // Ultra-fast path: positional light-call cache for positional-only functions.
-        {
+        if !skip_name_caches {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = Symbol::intern(name_str);
             if self.pos_light_call_cache_gen == self.fn_resolve_gen {
@@ -147,7 +174,7 @@ impl Interpreter {
         }
 
         // Light-call cache check for named-param functions.
-        {
+        if !skip_name_caches {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = Symbol::intern(name_str);
             if self.light_call_cache_gen == self.fn_resolve_gen {
@@ -182,7 +209,7 @@ impl Interpreter {
         // compiled form to avoid the expensive interpreter fallback.
         // We take() the CF from the cache to avoid holding a borrow on self,
         // then put it back after the call.
-        {
+        if !skip_name_caches {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = Symbol::intern(name_str);
             if self.otf_call_cache_gen == self.fn_resolve_gen {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -485,6 +485,18 @@ impl Interpreter {
             self.method_resolve_cache.clear();
             self.last_method_resolve = None;
             self.fast_method_cache.clear();
+            // Record `&`-sigil parameter names so calls to a same-named routine
+            // inside this sub bypass the name-keyed light-call caches (the param
+            // can shadow a package sub of the same name).
+            for pd in param_defs {
+                if let Some(bare) = pd.name.strip_prefix('&')
+                    && !bare.is_empty()
+                {
+                    // Records both plain names (`foo`) and operator categories
+                    // (`infix:<@@>`); both can shadow a same-named package routine.
+                    self.amp_param_shadowed_names.insert(Symbol::intern(bare));
+                }
+            }
             if *is_export && !self.suppress_exports {
                 let pkg = self.current_package().to_string();
                 self.register_exported_sub(pkg.clone(), resolved_name.clone(), export_tags.clone());

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -2375,6 +2375,19 @@ impl Interpreter {
             }
             let lookup_name = Self::canonical_infix_lookup_name(&name);
             let infix_name = format!("infix:<{}>", lookup_name.as_ref());
+            // A lexical `&infix:<op>` binding (e.g. a `&infix:<@@>` parameter)
+            // shadows the package-level operator of the same name. Guarded by the
+            // shadow-name set so the common case (no operator param) is free.
+            if !self.amp_param_shadowed_names.is_empty()
+                && self
+                    .amp_param_shadowed_names
+                    .contains(&Symbol::intern(&infix_name))
+                && let Some(callable) = self.lexical_infix_override(code, &infix_name)
+            {
+                let result = self.call_sub_value(callable, call_args, false)?;
+                self.stack.push(result);
+                return Ok(());
+            }
             let assoc = self
                 .infix_associativity(&infix_name)
                 .unwrap_or_else(|| "left".to_string());

--- a/t/lexical-amp-param-shadow.t
+++ b/t/lexical-amp-param-shadow.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+# A `&foo` parameter shadows a same-named package sub *even after* the package
+# sub has already been called (which previously primed the name-keyed call cache
+# and made the cache wrongly win over the lexical parameter).
+{
+    sub foo($x) { $x + 1 }
+    sub callit(&foo) { foo(1) }
+
+    is foo(1), 2, 'package foo called first (primes the call cache)';
+    is callit({ $^x + 2 }), 3, '&foo parameter shadows package foo inside callit';
+    is foo(1), 2, 'package foo still resolves correctly outside callit';
+}
+
+# Same for an `&infix:<op>` operator parameter shadowing a package operator.
+{
+    sub infix:<@@> ($x, $y) { $x + $y }
+    sub op2(&infix:<@@>) { 2 @@ 3 }
+
+    is 2 @@ 3, 5, 'package operator called first';
+    is op2({ $^a * $^b }), 6, '&infix:<@@> parameter shadows the package operator';
+    is 2 @@ 3, 5, 'package operator still resolves outside op2';
+}


### PR DESCRIPTION
A `&foo` / `&infix:<op>` parameter must shadow a same-named package sub or
operator, **even after** the package routine has already been called (which
primes the name-keyed light-call caches). Previously the global, name-keyed call
caches (`pos_light`/`light`/`otf`) and the operator-dispatch path ignored the
lexical binding, so the package routine wrongly won.

## Changes

- Record the bare names of all `&`-sigil parameters (`foo`, `infix:<op>`) at sub
  registration in a new `amp_param_shadowed_names` set.
- In `exec_call_func_op`, bypass the three name-keyed light-call caches for any
  name in that set (guarded by `is_empty()`, so the common no-`&`-param case is
  free). The slow path's existing `lexical_override` check then resolves the
  correct callable.
- In `exec_infix_func_op`, when an operator name is shadowed, resolve a lexical
  `&infix:<op>` binding (parameter or `my &infix:<op>`) and call it directly.

## Impact

- `S06-advanced/lexical-subs.t`: tests 4 and 6 now pass (file 9/13 → 11/13). The
  remaining 2 need compile-time undeclared-symbol checking and lexical-sub
  block-scope cleanup.
- No regression: `S17-supply/categorize.t` / `classify.t`,
  `S06-operator-overloading/sub.t` still pass.

## Tests

- `t/lexical-amp-param-shadow.t`

`make test` passes (8578 tests); `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)