### PR TITLE
feat(types): X::*::BadType when a package/module is used as a type

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -127,6 +127,15 @@
 - [ ] roast/S32-exceptions/misc.t
   - 52/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
+  - Done (impl): X::Syntax::Variable::BadType / X::Parameter::BadType now thrown
+    when a `package`/`module` (not type-like) is used as a variable/parameter type
+    (`my package A {}; my A $a` / `sub foo(A $a)`). `is_declared_package` + static
+    package-name collection in eval_check. Verified standalone (t/package-as-type-badtype.t),
+    BUT tests 48/49 STILL fail in-file: blocked by EVAL my-class leakage — an
+    earlier `EVAL q[my class A {...}]` (line 13) leaks class `A` into the shared
+    registry, so by line 227 `A` resolves as a type and the BadType branch is
+    skipped. Real fix = EVAL compilation-unit isolation for `my`-scoped types
+    (same family as lexical-subs.t#9, my-6e.t EVAL scope).
   - Done: X::Syntax::Extension::SpecialForm now thrown when a `sub`/`multi sub`
     redefines a reserved special-form operator (`infix:<=>`, `infix:<:=>`,
     `infix:<::=>`, `infix:<~~>`, `prefix:<|>`) — tests 54-58 (compile-time check in

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -4,18 +4,37 @@ use crate::ast::{PhaserKind, Stmt};
 /// Collect the names of all types (class/role/enum/subset) declared anywhere in
 /// `stmts`, descending into block-like bodies. Used so a sub parameter type that
 /// names a type declared in the same compilation unit is not falsely rejected.
-fn collect_declared_type_names(stmts: &[Stmt], out: &mut std::collections::HashSet<String>) {
+fn collect_declared_type_names(
+    stmts: &[Stmt],
+    out: &mut std::collections::HashSet<String>,
+    packages: &mut std::collections::HashSet<String>,
+) {
     for stmt in stmts {
         match stmt {
             Stmt::ClassDecl { name, body, .. } | Stmt::RoleDecl { name, body, .. } => {
                 out.insert(name.resolve().to_string());
-                collect_declared_type_names(body, out);
+                collect_declared_type_names(body, out, packages);
             }
             Stmt::EnumDecl { name, .. } | Stmt::SubsetDecl { name, .. } => {
                 out.insert(name.resolve().to_string());
             }
-            Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
-                collect_declared_type_names(body, out);
+            Stmt::Package {
+                name, kind, body, ..
+            } => {
+                // `module`/`package` are not type-like (a parameter typed by one
+                // is X::Parameter::BadType); `grammar` is a real type.
+                if matches!(
+                    kind,
+                    crate::ast::PackageKind::Module | crate::ast::PackageKind::Package
+                ) {
+                    packages.insert(name.resolve().to_string());
+                } else {
+                    out.insert(name.resolve().to_string());
+                }
+                collect_declared_type_names(body, out, packages);
+            }
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
+                collect_declared_type_names(body, out, packages);
             }
             _ => {}
         }
@@ -29,6 +48,7 @@ fn walk_validate_sub_param_types(
     interp: &Interpreter,
     stmts: &[Stmt],
     declared: &std::collections::HashSet<String>,
+    packages: &std::collections::HashSet<String>,
 ) -> Result<(), RuntimeError> {
     for stmt in stmts {
         match stmt {
@@ -38,16 +58,16 @@ fn walk_validate_sub_param_types(
                 return_type,
                 ..
             } => {
-                interp.validate_param_type_constraints(param_defs, declared)?;
+                interp.validate_param_type_constraints(param_defs, declared, packages)?;
                 interp.validate_return_type_constraint(
                     return_type.as_deref(),
                     param_defs,
                     declared,
                 )?;
-                walk_validate_sub_param_types(interp, body, declared)?;
+                walk_validate_sub_param_types(interp, body, declared, packages)?;
             }
             Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
-                walk_validate_sub_param_types(interp, body, declared)?;
+                walk_validate_sub_param_types(interp, body, declared, packages)?;
             }
             _ => {}
         }
@@ -63,8 +83,9 @@ impl Interpreter {
         stmts: &[Stmt],
     ) -> Result<(), RuntimeError> {
         let mut declared = std::collections::HashSet::new();
-        collect_declared_type_names(stmts, &mut declared);
-        walk_validate_sub_param_types(self, stmts, &declared)
+        let mut packages = std::collections::HashSet::new();
+        collect_declared_type_names(stmts, &mut declared, &mut packages);
+        walk_validate_sub_param_types(self, stmts, &declared, &packages)
     }
 
     /// Parse and run only BEGIN/CHECK phasers from EVAL'd code (`:check` mode).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5325,6 +5325,16 @@ impl Interpreter {
         self.registry().classes.contains_key(name)
     }
 
+    /// True when `name` was declared via the `package`/`module` declarator (and
+    /// is therefore not type-like enough to constrain a variable/parameter).
+    /// Used to raise X::Syntax::Variable::BadType / X::Parameter::BadType instead
+    /// of a generic "not declared" error. A `class`/`role`/`enum`/`subset` is a
+    /// real type and is NOT recorded here (it goes through the class registry).
+    pub(crate) fn is_declared_package(&self, name: &str) -> bool {
+        self.chain_declared_packages.contains(name)
+            || matches!(self.env.get(name), Some(Value::Package(_)))
+    }
+
     /// Check if a class name refers to a user-defined class that inherits from
     /// a container type (Hash, Array, etc.). Used to skip element-level type
     /// checking for container subclasses.

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -122,6 +122,7 @@ impl Interpreter {
         &self,
         param_defs: &[ParamDef],
         declared_types: &std::collections::HashSet<String>,
+        declared_packages: &std::collections::HashSet<String>,
     ) -> Result<(), RuntimeError> {
         // Type-capture names declared in this signature (e.g. `::T`) are valid
         // type names for the rest of the signature.
@@ -156,6 +157,20 @@ impl Interpreter {
                 || self.has_type(tc)
             {
                 continue;
+            }
+            // A `package`/`module` named `tc` exists but is not type-like enough
+            // to qualify a parameter: throw X::Parameter::BadType, not the generic
+            // invalid-typename error. Packages are gathered statically because this
+            // pre-pass runs before the package is registered at runtime.
+            if declared_packages.contains(tc) || self.is_declared_package(tc) {
+                let msg = format!(
+                    "Package '{}' is insufficiently type-like to qualify a parameter.  Did you mean 'class'?",
+                    tc
+                );
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("type".to_string(), Value::str(tc.to_string()));
+                attrs.insert("message".to_string(), Value::str(msg));
+                return Err(RuntimeError::typed("X::Parameter::BadType", attrs));
             }
             let suggestions = self.suggest_type_names(tc);
             let mut attrs = std::collections::HashMap::new();

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2672,6 +2672,20 @@ impl Interpreter {
         {
             // Check if this is a suppressed nested class name that can be resolved
             if self.resolve_suppressed_type(declared_constraint).is_none() {
+                // A `package`/`module` declared with this name exists but is not
+                // type-like enough to constrain a variable (only `class`/`role`/
+                // `enum`/`subset` are): throw X::Syntax::Variable::BadType, not the
+                // generic "not declared" error.
+                if self.is_declared_package(declared_constraint) {
+                    let msg = format!(
+                        "Package '{}' is insufficiently type-like to qualify a variable.  Did you mean 'class'?",
+                        constraint
+                    );
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("type".to_string(), Value::str(constraint.to_string()));
+                    attrs.insert("message".to_string(), Value::str(msg));
+                    return Err(RuntimeError::typed("X::Syntax::Variable::BadType", attrs));
+                }
                 // Unknown user-defined type — reject it.
                 // In Raku this is a compile-time failure grouped into an
                 // X::Comp::Group whose `.sorrows` holds the underlying

--- a/t/package-as-type-badtype.t
+++ b/t/package-as-type-badtype.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 8;
+
+# Using a `package`/`module` (which is not type-like) to constrain a variable or
+# parameter throws X::Syntax::Variable::BadType / X::Parameter::BadType, not a
+# generic "not declared" error — a `package`/`module` IS declared, just not a type.
+
+throws-like 'my package A {}; my A $a;', X::Syntax::Variable::BadType,
+    'package used as variable type';
+throws-like 'my module M {}; my M $a;', X::Syntax::Variable::BadType,
+    'module used as variable type';
+throws-like 'my package A {}; sub foo(A $a) { }', X::Parameter::BadType,
+    'package used as parameter type';
+throws-like 'my module M {}; sub foo(M $a) { }', X::Parameter::BadType,
+    'module used as parameter type';
+
+# A real type (class/role/grammar/built-in) is fine as a constraint.
+{
+    my class C { }
+    my C $c;
+    pass 'class is type-like enough to qualify a variable';
+}
+{
+    sub takes(Int $x) { $x }
+    is takes(5), 5, 'built-in type parameter works';
+}
+{
+    my role R { }
+    sub takes-r(R $x) { 'ok' }
+    pass 'role is type-like enough to qualify a parameter';
+}
+
+# A genuinely undeclared type name is still an undeclared/invalid-type error,
+# NOT BadType.
+{
+    my $err;
+    try { EVAL 'sub f(NoSuchTypeXYZ $x) { }'; CATCH { default { $err = $_ } } }
+    nok $err ~~ X::Parameter::BadType,
+        'an undeclared type name is not reported as BadType';
+}


### PR DESCRIPTION
## Summary

Constraining a variable or parameter with a `package`/`module` name (which is
not type-like) now throws the correct typed error instead of a generic
"not declared" / "Invalid typename" message:

```raku
my package A {}; my A $a;          # X::Syntax::Variable::BadType
my package A {}; sub foo(A $a) {}  # X::Parameter::BadType
```

A `package`/`module` IS declared — it is just insufficiently type-like — so the
old "Type 'A' is not declared" was wrong (only `class`/`role`/`enum`/`subset`/
`grammar` are type-like).

## Mechanism

- `Interpreter::is_declared_package(name)`: true when `name` was declared via
  `package`/`module` (env holds a `Value::Package`, or it is in
  `chain_declared_packages`). Real types go through the class registry and are
  not recorded here.
- **Variable decls** (`my A $a`): the `vm_misc_ops` type-constraint check throws
  `X::Syntax::Variable::BadType` before the generic undeclared-type error.
- **Parameter types** (`sub f(A $a)`): the eval-time pre-pass (`eval_check`) now
  also collects `module`/`package` names statically — they are not registered at
  pre-pass time — and `validate_param_type_constraints` throws
  `X::Parameter::BadType`. `grammar` is treated as a real type.

## Tests

- New `t/package-as-type-badtype.t` (8 subtests): package/module → BadType for
  both variable and parameter; real `class`/`role`/built-in constraints still
  work; a genuinely undeclared name is NOT reported as BadType.
- `make test`: PASS.
- Note: `roast/S32-exceptions/misc.t` tests 48/49 verify this but still fail
  *in-file* because an earlier `EVAL q[my class A {...}]` leaks class `A` into the
  shared registry (EVAL compilation-unit isolation gap, tracked in
  `TODO_roast/S32.md`). The fix itself is verified correct standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)