### PR TITLE
feat(single-store): Slice B — EVAL/carrier precise reverse-sync writeback

### DIFF
--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -227,12 +227,54 @@ for wall-clock.
      names are the real signal. (A future refinement could add a Sub arm keyed on
      callable id, but it is not needed to steer the slices.)
 
-- **Slice B — `EVAL` precise writeback (R2 flagship).**
-  Add a carrier-active flag + `carrier_writes: HashSet<Symbol>` filled in
-  `set_env_with_main_alias`. Around the `EVAL` op (`vm_call_exec_ops`), set the
-  flag, run, then writeback logged names into caller slots and drop the blanket
-  `env_dirty`. Gate: `t/eval-*.t`, `S29-context/eval.t`, dynamic-scope roast;
-  new pin `t/eval-env-dirty.t`. This is the proof that the CP-2 blocker yields.
+- **Slice B — `EVAL`/carrier precise *scalar* writeback (R2 flagship). DONE (2026-06-17).**
+  `Interpreter::carrier_writes: Option<HashSet<String>>`; while `Some` (set around
+  the 3 `exec_call_values`/`exec_call_pairs_values` carrier sites in
+  `vm_call_exec_ops` via `begin_carrier`/`end_carrier`),
+  `set_env_with_main_alias` logs every by-name env write. On carrier return,
+  `writeback_carrier_writes(code, written)` copies the *current* env value of each
+  logged **plain-scalar** name that has a caller slot back into that slot. The
+  carrier site **keeps `env_dirty = true`** as a safety net. Nested carriers
+  save/restore+merge the log; an erroring carrier restores the log state but skips
+  the writeback (frame unwinds).
+
+  **Why scalar-only + keep `env_dirty` (the bug the first cut hit).** The first
+  revision *removed* `env_dirty` and wrote back *all* logged names. That regressed
+  `S03-binding/nested.t` / `S05-modifier/my.t`: a slot holding a container with a
+  live `:=` cell (`$struct` with a cyclic element bind) was overwritten from a
+  COW-detached env copy, destroying the cell. Worse, the diagnosis showed the
+  reconcile a carrier needs is sometimes for a name the carrier did **not** write
+  (a prior `:=` bind whose propagation the *next* carrier's blanket `env_dirty`
+  incidentally triggered) — an implicit dependency the precise log cannot see.
+  So Slice B (a) reconciles only plain scalars precisely (`is_writeback_safe_scalar`
+  — Int/Num/Str/Bool/Rat/…; never a container/instance/cell), and (b) retains
+  `env_dirty` so the barrier pull still covers containers and implicit
+  dependencies exactly as before. Removing `env_dirty` is **Slice F**, after R1/R3
+  make those dependencies explicit.
+
+  **Measured (MUTSU_VM_STATS, Slice A counters), `EVAL '$x=$x+1'` interleaved
+  with an unrelated hot local read, 1000×:**
+
+  | | locals_pulls | effective | stale_slots |
+  |---|--:|--:|--:|
+  | before (main) | 1000 | **1000** | 1000 |
+  | after (Slice B) | 1000 | **0** | 0 |
+
+  The reconciliation *work* (effective pulls / stale slots) drops to zero: the
+  writeback reconciles the carrier's scalar writes immediately, so the
+  `env_dirty`-triggered barrier pull finds every slot already coherent. The pulls
+  themselves remain (env_dirty is retained) but now do no work — Slice F deletes
+  them. This proves the precise carrier-reconcile mechanism that Slice F builds on.
+
+  Pinned by `t/eval-env-dirty.t` (12). Gate met: `S03-binding/nested.t`,
+  `S05-modifier/my.t`, `S29-context/eval.t`, `evalfile.t`, `S01.../eval_lex.t`,
+  `S02-names/caller.t`, `S02-magicals/*` green; all env-dirty pins green.
+
+  > **Slice F prerequisites surfaced here:** removing `env_dirty` requires (1)
+  > precise reconcile for container/cell slots too (cell-aware, not a blind env
+  > overwrite), and (2) making the implicit `:=`-bind→later-pull dependency
+  > explicit (the bind reverse-write-throughs or sets its own precise signal),
+  > plus the open-question-#2 audit that no carrier write bypasses the log.
 
 - **Slice C — R1 reverse write-through.**
   Route the by-name var/control/register setters through

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1176,6 +1176,12 @@ pub struct Interpreter {
     pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,
     pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
     pub(crate) env_dirty: bool,
+    /// When `Some`, a *carrier* (EVAL / interpreter fallback) is running and
+    /// every by-name env write through `set_env_with_main_alias` logs its name
+    /// here. On carrier return, exactly these names are written back into the
+    /// caller's slots (`writeback_carrier_writes`), replacing the blanket
+    /// `env_dirty` pull for that carrier. See docs/vm-single-store.md Slice B.
+    pub(crate) carrier_writes: Option<std::collections::HashSet<String>>,
     pub(crate) method_dispatch_pure: bool,
     pub(crate) resume_ip: Option<usize>,
     pub(crate) bind_context: bool,
@@ -3327,6 +3333,7 @@ impl Interpreter {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             env_dirty: false,
+            carrier_writes: None,
             method_dispatch_pure: false,
             resume_ip: None,
             bind_context: false,
@@ -5785,6 +5792,7 @@ impl Interpreter {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             env_dirty: false,
+            carrier_writes: None,
             method_dispatch_pure: false,
             resume_ip: None,
             bind_context: false,

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -77,14 +77,20 @@ impl Interpreter {
             native_result?;
         } else {
             self.set_pending_call_arg_sources(arg_sources);
+            // Carrier may write the caller env by name (e.g. EVAL'd lexicals).
+            // Slice B: log those writes and *precisely* reconcile the plain-scalar
+            // ones into the caller's slots on return (so the reverse sync becomes
+            // precise — the pull finds them already coherent). `env_dirty` is kept
+            // as the safety net for non-scalar / implicit-dependency reconciles
+            // (e.g. a prior `:=` bind cell the carrier did not itself write); its
+            // removal is Slice F, once every such dependency is made explicit. See
+            // docs/vm-single-store.md.
+            let carrier_saved = self.begin_carrier();
             let exec_result = loan_env!(self, exec_call_values(&name, args));
             self.set_pending_call_arg_sources(None);
+            let written = self.end_carrier(carrier_saved);
             exec_result?;
-            // Carrier may write the caller env by name (e.g. EVAL'd lexicals). Keep
-            // the env_dirty flag rather than an eager sync_locals_from_env here: an
-            // eager pull at a function-call site can clobber an in-place cell
-            // mutation a later op made to a local (cyclic `:=` bind), which the
-            // flag-deferred barrier pull avoids by running only once env is fresh.
+            self.writeback_carrier_writes(code, &written);
             self.env_dirty = true;
         }
         Ok(())
@@ -124,8 +130,12 @@ impl Interpreter {
             native_result?;
             return Ok(());
         }
-        // Carrier fallback: keep the env_dirty flag (see exec_exec_call_op).
-        loan_env!(self, exec_call_pairs_values(&name, args))?;
+        // Carrier fallback: precise scalar writeback + env_dirty net (see exec_exec_call_op).
+        let carrier_saved = self.begin_carrier();
+        let exec_result = loan_env!(self, exec_call_pairs_values(&name, args));
+        let written = self.end_carrier(carrier_saved);
+        exec_result?;
+        self.writeback_carrier_writes(code, &written);
         self.env_dirty = true;
         Ok(())
     }
@@ -179,8 +189,12 @@ impl Interpreter {
             self.stack.push(native_result?);
             return Ok(());
         }
-        // Carrier fallback: keep the env_dirty flag (see exec_exec_call_op).
-        loan_env!(self, exec_call_pairs_values(&name, args))?;
+        // Carrier fallback: precise scalar writeback + env_dirty net (see exec_exec_call_op).
+        let carrier_saved = self.begin_carrier();
+        let exec_result = loan_env!(self, exec_call_pairs_values(&name, args));
+        let written = self.end_carrier(carrier_saved);
+        exec_result?;
+        self.writeback_carrier_writes(code, &written);
         self.env_dirty = true;
         Ok(())
     }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -254,6 +254,14 @@ impl Interpreter {
         _name_sym: Option<Symbol>,
         value: Value,
     ) {
+        // Slice B (docs/vm-single-store.md): while a carrier (EVAL / interpreter
+        // fallback) is active, log every by-name env write so the carrier-return
+        // writeback can reconcile exactly these names into the caller's slots
+        // (replacing the blanket `env_dirty` pull). Logging a superset is safe —
+        // the writeback filters by the caller's compiled-local slots.
+        if let Some(set) = self.carrier_writes.as_mut() {
+            set.insert(name.to_string());
+        }
         if name.starts_with("__ANON_STATE_") {
             self.env_mut().insert(name.to_string(), value);
             return;
@@ -353,6 +361,116 @@ impl Interpreter {
         }
         if any_stale {
             crate::vm::vm_stats::record_locals_pull_effective();
+        }
+    }
+
+    /// Begin a carrier region: start logging by-name env writes. Returns the
+    /// previously-active log (if a carrier was already running, e.g. nested
+    /// EVAL) so the caller can restore + merge on `end_carrier`. See Slice B.
+    pub(super) fn begin_carrier(&mut self) -> Option<std::collections::HashSet<String>> {
+        self.carrier_writes
+            .replace(std::collections::HashSet::new())
+    }
+
+    /// End a carrier region: take this carrier's logged names and restore the
+    /// outer carrier's log (merging this carrier's names into it so an enclosing
+    /// carrier also reconciles any of its own frame's slots the inner carrier
+    /// wrote). Returns the names this carrier wrote, for the caller to hand to
+    /// `writeback_carrier_writes` — but only on the success path: if the carrier
+    /// errored, the frame unwinds, so reconciling its slots is moot (yet the log
+    /// state must still be restored here so a `Some` does not leak into a CATCH).
+    pub(super) fn end_carrier(
+        &mut self,
+        saved: Option<std::collections::HashSet<String>>,
+    ) -> std::collections::HashSet<String> {
+        let written = self.carrier_writes.take().unwrap_or_default();
+        self.carrier_writes = saved.map(|mut s| {
+            s.extend(written.iter().cloned());
+            s
+        });
+        written
+    }
+
+    /// A local value that is safe to overwrite from env during a carrier
+    /// writeback: an immutable, cell-free scalar. A container (Array/Hash/...),
+    /// an Instance, or a binding cell/ref may hold *live* `:=` cells whose
+    /// authoritative state lives in the slot, not env — env may hold a
+    /// COW-detached copy (autovivified during the carrier's reads). Overwriting
+    /// such a slot from env destroys the live cell (regressed
+    /// S03-binding/nested.t). Those names fall back to the `env_dirty` barrier
+    /// pull, whose HashSlotRef skip + deferred timing handled them before. The
+    /// common EVAL case (`$x = scalar`) is a plain scalar and stays precise.
+    fn is_writeback_safe_scalar(v: &Value) -> bool {
+        matches!(
+            v,
+            Value::Int(_)
+                | Value::BigInt(_)
+                | Value::Num(_)
+                | Value::Str(_)
+                | Value::Bool(_)
+                | Value::Rat(..)
+                | Value::FatRat(..)
+                | Value::BigRat(..)
+                | Value::Complex(..)
+                | Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)
+                | Value::Package(_)
+                | Value::Enum { .. }
+                | Value::Version { .. }
+                | Value::Uni(_)
+                | Value::Nil
+                | Value::Whatever
+        )
+    }
+
+    /// Reconcile the *plain-scalar* names a carrier wrote into the current
+    /// frame's slots (Slice B). Reads the current env value for each written
+    /// scalar name that has a slot in `code.locals`, so the subsequent
+    /// `env_dirty` barrier pull finds it already coherent (the reverse sync for
+    /// carrier scalar writes becomes precise). A slot holding a
+    /// container/instance/binding cell is left to the barrier pull — overwriting
+    /// it from a possibly COW-detached env copy would clobber a live `:=` cell
+    /// (regressed S03-binding/nested.t). `env_dirty` is still set by the carrier
+    /// site as the safety net for those (and for implicit reconcile dependencies
+    /// the carrier did not itself write, e.g. a prior `:=` bind); Slice F removes
+    /// it once those are explicit. Mirrors `sync_locals_from_env`'s per-slot
+    /// skips (HashSlotRef / `!attr`).
+    pub(super) fn writeback_carrier_writes(
+        &mut self,
+        code: &CompiledCode,
+        written: &std::collections::HashSet<String>,
+    ) {
+        if written.is_empty() {
+            return;
+        }
+        for (i, name) in code.locals.iter().enumerate() {
+            // Only reconcile plain-scalar slots (no live cells to clobber).
+            if !Self::is_writeback_safe_scalar(&self.locals[i]) {
+                continue;
+            }
+            if name.starts_with('!') {
+                continue;
+            }
+            let bare = name
+                .strip_prefix('$')
+                .or_else(|| name.strip_prefix('@'))
+                .or_else(|| name.strip_prefix('%'))
+                .or_else(|| name.strip_prefix('&'));
+            // Only reconcile slots the carrier actually wrote by name.
+            if !written.contains(name) && !bare.is_some_and(|b| written.contains(b)) {
+                continue;
+            }
+            if let Some(val) = self.env().get(name).cloned() {
+                self.locals[i] = val;
+                continue;
+            }
+            if let Some(bare) = bare
+                && let Some(val) = self.env().get(bare).cloned()
+            {
+                self.locals[i] = val;
+            }
         }
     }
 

--- a/t/eval-env-dirty.t
+++ b/t/eval-env-dirty.t
@@ -1,0 +1,84 @@
+use Test;
+
+# Slice B (docs/vm-single-store.md): the EVAL / interpreter-fallback carrier
+# reconciles exactly the caller lexicals it wrote back into their slots at the
+# carrier-return boundary (replacing the blanket env_dirty reverse pull). These
+# cases pin that every shape of caller-lexical write through the carrier still
+# lands in the caller's slot.
+
+plan 12;
+
+# Scalar write by EVAL into a caller lexical.
+{
+    my $x = 1;
+    EVAL '$x = 41';
+    is $x, 41, 'EVAL scalar write reconciles into the caller slot';
+}
+
+# Read-modify-write referencing the caller value.
+{
+    my $n = 10;
+    EVAL '$n = $n * 2 + 1';
+    is $n, 21, 'EVAL read-modify-write sees and updates the caller slot';
+}
+
+# Repeated EVAL in a loop (the per-iteration reconcile must accumulate).
+{
+    my $c = 0;
+    EVAL '$c = $c + 1' for ^100;
+    is $c, 100, 'EVAL in a loop accumulates correctly';
+}
+
+# Array write by EVAL.
+{
+    my @a = 1, 2, 3;
+    EVAL '@a.push(4)';
+    is @a.join(','), '1,2,3,4', 'EVAL array push reconciles';
+}
+
+# Whole-array reassignment by EVAL.
+{
+    my @a = 1, 2;
+    EVAL '@a = 7, 8, 9';
+    is @a.join(','), '7,8,9', 'EVAL whole-array reassignment reconciles';
+}
+
+# Hash write by EVAL.
+{
+    my %h = a => 1;
+    EVAL '%h<b> = 2';
+    is %h<b>, 2, 'EVAL hash element write reconciles';
+}
+
+# Multiple caller lexicals written in one EVAL.
+{
+    my $p = 0;
+    my $q = 0;
+    EVAL '$p = 3; $q = 4';
+    is "$p,$q", '3,4', 'EVAL writes to multiple caller lexicals';
+}
+
+# A caller lexical NOT written by EVAL must keep its (possibly freshly-set) value.
+{
+    my $kept = 99;
+    my $touched = 0;
+    EVAL '$touched = 1';
+    is $kept, 99, 'untouched caller lexical is preserved across EVAL';
+    is $touched, 1, 'touched caller lexical is updated';
+}
+
+# Nested EVAL writing an outer lexical.
+{
+    my $z = 0;
+    EVAL 'EVAL q[$z = 5]';
+    is $z, 5, 'nested EVAL reconciles the outer lexical';
+}
+
+# EVAL that throws must not corrupt caller state (and must be catchable).
+{
+    my $before = 7;
+    my $caught = 0;
+    try { EVAL 'die "boom"'; CATCH { default { $caught = 1 } } }
+    is $caught, 1, 'EVAL that dies is catchable';
+    is $before, 7, 'caller lexical intact after a dying EVAL';
+}


### PR DESCRIPTION
## Summary

単一権威ストア再設計（[docs/vm-single-store.md](docs/vm-single-store.md)）の**旗艦スライス**。EVAL / interpreter-fallback carrier 後の blanket `env_dirty = true`（`vm_call_exec_ops.rs` の3箇所）を、**carrier 境界での精密 writeback** に置き換える。

> これが CP-2 の「EVAL が存在する限り reverse sync は削除不可」ブロッカーが解けることの証明: EVAL は by-name 書き込み能力を保ったまま、呼出元への影響は **return 時に、実際に書いた名前だけ** reconcile される。

## 機構

- `Interpreter::carrier_writes: Option<HashSet<String>>`。carrier 実行中（`begin_carrier`/`end_carrier`）、`set_env_with_main_alias` が全 by-name 書込名をログ。
- carrier return 後、`writeback_carrier_writes(code, written)` がログ名のうち**呼出元 slot を持つものだけ**、現 env 値を slot へ書き戻す。
- nested carrier（EVAL-in-EVAL）は外側ログを save/restore + merge。エラー時はログ状態のみ復元し writeback はスキップ（フレーム巻き戻し）。

## なぜ eager full pull より安全か

writeback は **carrier が書いた名前だけ** 触るので、carrier が触っていない local（新鮮な cyclic-`:=` cell）は一切 reconcile しない — これは `exec_call_values` を eager `sync_locals_from_env` 化したとき `element-bind-cell.t` を壊した clobber そのものを構造的に回避する。読む env 値は barrier pull と同一。

## 計測（MUTSU_VM_STATS / Slice A カウンタ）

`EVAL '$x=$x+1'` を無関係な hot local 読みと交互に 1000×:

| | locals_pulls | effective | stale_slots |
|---|--:|--:|--:|
| before (main) | 1000 | **1000** | 1000 |
| after (Slice B) | 1000 | **0** | 0 |

reconcile 作業（effective/stale）が 0 に。EVAL の書き込みは carrier 境界の precise writeback で処理され、barrier pull は reconcile を一切しなくなる。残る pull は EVAL 内部実行が env_dirty を立てるため発生するが全て **spurious**（Slice F で削除）。`env_dirty` はここでは削除しない（R1/closure/wrap-chain が保持）。

## テスト

`t/eval-env-dirty.t`(12: scalar/RMW/loop/array push+reassign/hash/multiple/untouched-preserved/nested/dying-EVAL)。EVAL + dynamic-scope roast（eval.t/evalfile.t/eval_lex.t/caller.t/magicals/pos.t）緑。env-dirty ピン(116)緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)