### PR TITLE
feat(regex): reject unspace (backslash + whitespace) with X::Syntax::Regex::Unspace

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -127,6 +127,9 @@
 - [ ] roast/S32-exceptions/misc.t
   - 52/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
+  - Done: X::Syntax::Regex::Unspace now thrown for an "unspace" (`\` directly
+    followed by whitespace) inside a regex — test 19 (regex_parse.rs Validate-mode
+    escape dispatch, carries `.char`).
   - Done (impl): X::Syntax::Variable::BadType / X::Parameter::BadType now thrown
     when a `package`/`module` (not type-like) is used as a variable/parameter type
     (`my package A {}; my A $a` / `sub foo(A $a)`). `is_declared_package` + static

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -345,6 +345,24 @@ fn make_backslash_unrecognized_error(esc: char) -> RuntimeError {
     err
 }
 
+/// A backslash directly followed by whitespace (`\ `, `\<tab>`, ...) is an
+/// "unspace" — a main-slang construct that is not allowed in a regex; Raku
+/// rejects it with X::Syntax::Regex::Unspace. `ch` is the offending whitespace
+/// character (exposed as the `.char` attribute).
+fn make_unspace_error(ch: char) -> RuntimeError {
+    let msg = format!(
+        "No unspace allowed in regex; if you meant to match the literal character, please enclose in single quotes ('{}') or use a backslashed form like \\x{:02x}",
+        ch, ch as u32
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    attrs.insert("char".to_string(), Value::str(ch.to_string()));
+    let ex = Value::make_instance(Symbol::intern("X::Syntax::Regex::Unspace"), attrs);
+    let mut err = RuntimeError::new(msg);
+    err.exception = Some(Box::new(ex));
+    err
+}
+
 /// Detect a missing `+`/`-` operator between parts of a compound character
 /// class assertion (e.g. `<[abc] [def]>`, `<:Kata :Hira>`). Ported from the
 /// former validator; used only at parse time (`Validate` mode).
@@ -2986,6 +3004,16 @@ impl Interpreter {
                                 ));
                             });
                             return None;
+                        }
+                        // `\ ` (backslash + whitespace) is an "unspace", a main-slang
+                        // construct not allowed in a regex -> X::Syntax::Regex::Unspace.
+                        ws if ws.is_whitespace() => {
+                            if mode == RegexParseMode::Validate {
+                                PENDING_REGEX_ERROR
+                                    .with(|e| *e.borrow_mut() = Some(make_unspace_error(ws)));
+                                return None;
+                            }
+                            RegexAtom::Literal(ws)
                         }
                         other => {
                             // Validate mode: an unknown *alphabetic* backslash escape

--- a/t/regex-unspace.t
+++ b/t/regex-unspace.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 6;
+
+# A backslash directly followed by whitespace (`\ `) is an "unspace" — a main-slang
+# construct that is not allowed inside a regex. Raku rejects it at compile time
+# with X::Syntax::Regex::Unspace.
+
+throws-like '/\ X/', X::Syntax::Regex::Unspace,
+    'backslash-space in a regex throws Unspace';
+throws-like '/\ X/', X::Syntax::Regex::Unspace,
+    message => / 'No unspace allowed in regex' /,
+    'Unspace message mentions the rule';
+
+{
+    my $err;
+    try { EVAL '/\ X/'; CATCH { default { $err = $_ } } }
+    is $err.char, ' ', 'the .char attribute is the offending whitespace';
+}
+
+# Legitimate forms that match a literal space still work.
+{
+    ok 'a b' ~~ / a \x20 b /, '\x20 matches a literal space';
+    ok "a b" ~~ / a ' ' b /, "quoted ' ' matches a literal space";
+    ok 'ab' ~~ / a b /, 'sigspace regex with real whitespace is unaffected';
+}


### PR DESCRIPTION
## Summary

`\ ` — a backslash directly followed by whitespace — is an "unspace", a
main-slang construct that is **not** allowed inside a regex. mutsu previously
treated it as a literal-space escape; Raku rejects it at compile time with
`X::Syntax::Regex::Unspace`.

```raku
/\ X/   # before: matched a literal space
        # after:  X::Syntax::Regex::Unspace
```

## Mechanism

The regex escape dispatch (`regex_parse.rs`) now matches a whitespace escape
char and, in `Validate` mode (compile-time regex-literal parsing), raises
`X::Syntax::Regex::Unspace` via the new `make_unspace_error` helper. The
exception carries:

- `.char` — the offending whitespace character
- `.message` — `No unspace allowed in regex; if you meant to match the literal character, please enclose in single quotes (' ') or use a backslashed form like \x20`

Legitimate literal-space forms (`\x20`, quoted `' '`, sigspace whitespace) are
unaffected — verified against whitelisted `S05-metasyntax/litvar.t` and the
existing regex suite.

## Tests

- Fixes `roast/S32-exceptions/misc.t` test 19 — file 52 → 53.
- New `t/regex-unspace.t` (6 subtests): unspace throws with the right type /
  message / `.char`; `\x20`, quoted `' '`, and sigspace whitespace still match a
  literal space.
- `make test`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)