### PR TITLE
fix(symbols): failed ::() symbolic lookup throws X::NoSuchSymbol

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1614,7 +1614,10 @@ impl Interpreter {
             "message".to_string(),
             Value::str(format!("No such symbol '{name}'")),
         );
-        let exception = Value::make_instance(Symbol::intern("X::AdHoc"), ex_attrs);
+        // A failed symbolic lookup (`::('NoSuchName')`, `::('')`) is
+        // X::NoSuchSymbol in Raku, not a bare X::AdHoc. `symbol` carries the name.
+        ex_attrs.insert("symbol".to_string(), Value::str(name.to_string()));
+        let exception = Value::make_instance(Symbol::intern("X::NoSuchSymbol"), ex_attrs);
         let mut failure_attrs = HashMap::new();
         failure_attrs.insert("exception".to_string(), exception);
         failure_attrs.insert("handled".to_string(), Value::Bool(false));

--- a/t/no-such-symbol.t
+++ b/t/no-such-symbol.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 4;
+
+# A failed symbolic lookup via `::(...)` produces an X::NoSuchSymbol failure
+# (Raku semantics), not a bare X::AdHoc.
+
+throws-like { ::('') }, X::NoSuchSymbol,
+    'empty symbolic lookup ::(\'\') throws X::NoSuchSymbol';
+throws-like { ::('NoSuchSymbolNameXYZ') }, X::NoSuchSymbol,
+    'unknown symbolic lookup throws X::NoSuchSymbol';
+
+{
+    my $err;
+    try { ::(''); CATCH { default { $err = $_ } } }
+    is $err.symbol, '', 'the .symbol attribute carries the looked-up name';
+}
+
+# A successful symbolic lookup still resolves normally.
+{
+    my class Foo { }
+    ok ::('Foo') === Foo, 'a declared type still resolves via ::(name)';
+}


### PR DESCRIPTION
## Summary

A failed indirect/symbolic lookup produced a Failure wrapping a bare `X::AdHoc`.
Raku uses `X::NoSuchSymbol`:

```raku
::('')                 # X::NoSuchSymbol (was X::AdHoc)
::('NoSuchNameXYZ')     # X::NoSuchSymbol
```

## Mechanism

`no_such_symbol_failure` (accessors.rs) now wraps `X::NoSuchSymbol` instead of
`X::AdHoc` and carries the looked-up name as `.symbol`. The message
("No such symbol '...'") is unchanged, and every symbolic-lookup failure path
shares this helper, so all `::(name)` misses get the correct type.

## Tests

- Fixes `roast/S32-exceptions/misc.t` test 42 — file 53 → 54.
- New `t/no-such-symbol.t` (4 subtests): empty + unknown lookups throw
  X::NoSuchSymbol with `.symbol`; a declared type still resolves via `::(name)`.
- `make test`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)