### PR TITLE
feat(single-store): drop blanket env_dirty on a fully-reconciled EVAL carrier

### DIFF
--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -276,12 +276,61 @@ for wall-clock.
   > explicit (the bind reverse-write-throughs or sets its own precise signal),
   > plus the open-question-#2 audit that no carrier write bypasses the log.
 
-- **Slice C — R1 reverse write-through.**
-  Route the by-name var/control/register setters through
-  `set_env_through_slot(code, …)` (env write + `locals_set_by_name`). Drop their
-  `env_dirty` marks. Gate: `S02-magicals`, `S04-declarations` (our/dynamic),
-  `S10-packages`, `&sub` registration; pins `t/our-env-dirty.t`,
-  `t/dynamic-write-through.t`.
+- **Slice C — R1 reverse write-through. SUPERSEDED by measurement (2026-06-17).**
+  A `MUTSU_VM_STATS` sweep of the canonical R1 patterns in a hot loop (our-var
+  `$c=`, dynamic `$*dyn=`, by-name container `@a.push`, bareword→call) found each
+  already does **only ~1–2 reverse-sync pulls total, effective=0** — the pure
+  scalar by-name writers do **not** set `env_dirty` on the hot path, so there is
+  no standalone pull traffic for Slice C to remove. The only large spurious pull
+  source measured was the **EVAL/carrier** site (≈1001 pulls / 1000 EVALs,
+  effective=0), so the real lever moved to the Slice F prereq below. The cold R1
+  declaration/registration sites (`is Trait` handlers, class/enum/module reg)
+  still set `env_dirty`, but they are metric-neutral and several are not simple
+  R1 (module load imports an unknown name-set; enum reg writes many variant
+  names) — they convert as part of the Slice F audit, not as a standalone slice.
+
+- **Slice F prereq — EVAL carrier precise reconcile + drop its blanket. DONE (2026-06-17).**
+  The per-EVAL blanket `env_dirty` is not set at the carrier site itself but by
+  `with_nested_registers` (`src/vm.rs`), which unconditionally flags dirty after
+  *any* nested run so the restored outer locals re-pull. For EVAL this is
+  spurious: EVAL writes caller lexicals exclusively through
+  `SetGlobal → set_env_with_main_alias`, which the Slice B carrier log already
+  captures, so `writeback_carrier_writes` reconciles every scalar it wrote on
+  return. `writeback_carrier_writes` is now **cell-aware** and returns a
+  `fully_reconciled` bool: it copies plain scalars from env, **never overwrites a
+  container/instance slot** (env may hold a COW-detached copy with live interior
+  `:=` cells — the S03-binding/nested.t hazard), treating a container as coherent
+  only when env and the slot share the same `Arc` (`cheaply_unchanged`), else
+  leaving it to the barrier (`fully=false`). The EVAL carrier site
+  (`vm_call_exec_ops.rs`) then restores the *pre-carrier* `env_dirty` (preserving
+  a dirty the caller already owed) instead of the blanket when `fully && name ==
+  "EVAL"`. Result: the EVAL-in-a-hot-loop benchmark drops **1001 → 2** pulls,
+  output unchanged. Pinned by `t/eval-carrier-precise-writeback.t` (14:
+  same-frame / ancestor-bare-GetLocal / two-deep / per-iteration / whole-array &
+  whole-hash reassignment / in-place push / regex-`:let`-inside-EVAL /
+  interleaved-hot-local). Gate: `S29-context/eval.t`, `S05-modifier/my.t`,
+  `S03-binding/nested.t`, `t/eval-env-dirty.t` green.
+
+  > **Why EVAL-only (the frame-scoping + open-q#2 lesson).** `env_dirty` is
+  > **frame-scoped** (`push_call_frame` saves+resets it, `pop_call_frame`
+  > restores), so a carrier's write reaches the caller only because the caller's
+  > frame re-flags dirty after the call returns. The writeback is **local to the
+  > current frame's `code.locals`**, so it can only reconcile names the carrier
+  > wrote that the *current* frame slots — ancestor lexicals are read from env
+  > (no stale slot) and self-contained. Dropping the blanket for **all** carriers
+  > regressed `S05-modifier/my.t` / `S03-binding/nested.t` (8+1 subtests) because
+  > regex `:let $a = …` writes a caller lexical **without** going through
+  > `set_env_with_main_alias` — it bypasses the carrier log (open-question #2).
+  > So the drop is restricted to EVAL, whose write path is fully logged; the
+  > remaining carriers keep the net until open-q#2 (complete write logging) is
+  > closed, which generalizes this drop to them.
+
+- **Slice C′ (remaining) — close open-question #2, then generalize the drop.**
+  Audit every env-write path reachable from a carrier (regex `:let`/named
+  captures, `where {…}`, interpreter method/function fallbacks) and route the
+  caller-lexical writes through the carrier log (or a precise reconcile), so
+  `writeback_carrier_writes` becomes complete for non-EVAL carriers and they can
+  drop their blanket `env_dirty` too. Then convert the cold R1 declaration sites.
 
 - **Slice D — finish R3 blanket-mark removal.**
   Audit each remaining post-dispatch blanket against its tier's precise flag;

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -78,20 +78,36 @@ impl Interpreter {
         } else {
             self.set_pending_call_arg_sources(arg_sources);
             // Carrier may write the caller env by name (e.g. EVAL'd lexicals).
-            // Slice B: log those writes and *precisely* reconcile the plain-scalar
-            // ones into the caller's slots on return (so the reverse sync becomes
-            // precise — the pull finds them already coherent). `env_dirty` is kept
-            // as the safety net for non-scalar / implicit-dependency reconciles
-            // (e.g. a prior `:=` bind cell the carrier did not itself write); its
-            // removal is Slice F, once every such dependency is made explicit. See
+            // Slice B logs those writes (`begin_carrier`) and reconciles them into
+            // the caller's slots on return (`writeback_carrier_writes`), so the
+            // reverse sync is precise. For a fully-reconciled EVAL we then drop the
+            // blanket `env_dirty` net (see below); other carriers keep it. See
             // docs/vm-single-store.md.
+            let pre_dirty = self.env_dirty;
             let carrier_saved = self.begin_carrier();
             let exec_result = loan_env!(self, exec_call_values(&name, args));
             self.set_pending_call_arg_sources(None);
             let written = self.end_carrier(carrier_saved);
             exec_result?;
-            self.writeback_carrier_writes(code, &written);
-            self.env_dirty = true;
+            let fully = self.writeback_carrier_writes(code, &written);
+            // EVAL writes caller lexicals exclusively through SetGlobal ->
+            // set_env_with_main_alias, so the carrier log is complete for it and
+            // the writeback above reconciled every scalar it touched (a diverged
+            // container leaves `fully` false). When the writeback was fully
+            // precise we can drop the blanket env_dirty net that the nested run
+            // (`with_nested_registers`) sets unconditionally — eliminating the
+            // spurious per-EVAL barrier pull (docs/vm-single-store.md Slice F
+            // prereq: 1001 -> ~1 pulls on an EVAL-in-a-hot-loop). Restoring the
+            // *pre-carrier* dirty (not a blind clear) preserves a dirty the
+            // caller already owed. Scoped to EVAL because other carriers (regex
+            // subrule calls, interpreter fallbacks) can write caller lexicals
+            // through paths that bypass the log (e.g. regex `:let`); they keep
+            // the net until open-question #2 (complete write logging) is closed.
+            if fully && name == "EVAL" {
+                self.env_dirty = pre_dirty;
+            } else {
+                self.env_dirty = true;
+            }
         }
         Ok(())
     }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -441,15 +441,15 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         written: &std::collections::HashSet<String>,
-    ) {
+    ) -> bool {
         if written.is_empty() {
-            return;
+            return true;
         }
+        // Tracks whether every written name with a caller slot was made coherent
+        // here (so the caller can drop the blanket `env_dirty` net). A name left
+        // to the barrier pull flips this to false.
+        let mut fully = true;
         for (i, name) in code.locals.iter().enumerate() {
-            // Only reconcile plain-scalar slots (no live cells to clobber).
-            if !Self::is_writeback_safe_scalar(&self.locals[i]) {
-                continue;
-            }
             if name.starts_with('!') {
                 continue;
             }
@@ -462,16 +462,35 @@ impl Interpreter {
             if !written.contains(name) && !bare.is_some_and(|b| written.contains(b)) {
                 continue;
             }
-            if let Some(val) = self.env().get(name).cloned() {
-                self.locals[i] = val;
+            let env_val = self
+                .env()
+                .get(name)
+                .cloned()
+                .or_else(|| bare.and_then(|b| self.env().get(b).cloned()));
+            let Some(env_val) = env_val else {
+                // The carrier logged the name but env no longer holds it (e.g. a
+                // scoped key dropped on block exit). Nothing to reconcile.
+                continue;
+            };
+            // A plain scalar is safe to copy from env: it carries no live `:=`
+            // cell, so overwriting the slot cannot clobber shared state. This is
+            // the common EVAL case (`$x = scalar`).
+            if Self::is_writeback_safe_scalar(&self.locals[i]) {
+                self.locals[i] = env_val;
                 continue;
             }
-            if let Some(bare) = bare
-                && let Some(val) = self.env().get(bare).cloned()
-            {
-                self.locals[i] = val;
+            // A container/instance slot is NEVER overwritten from env: env may
+            // hold a COW-detached copy whose write would destroy a live interior
+            // `:=` cell (regressed S03-binding/nested.t). It is coherent already
+            // iff env and the slot share the same Arc (an in-place mutation the
+            // slot observes through the shared container). If they diverge (a
+            // whole-container reassignment, or a detached copy), leave it to the
+            // `env_dirty` barrier pull and signal "not fully reconciled".
+            if !crate::vm::vm_method_dispatch::cheaply_unchanged(&self.locals[i], &env_val) {
+                fully = false;
             }
         }
+        fully
     }
 
     pub(super) fn sync_env_from_locals(&mut self, code: &CompiledCode) {

--- a/t/eval-carrier-precise-writeback.t
+++ b/t/eval-carrier-precise-writeback.t
@@ -1,0 +1,89 @@
+use Test;
+
+# Slice F prereq (docs/vm-single-store.md): the EVAL carrier reconciles the
+# caller lexicals it wrote *precisely* on return, so the blanket per-EVAL
+# `env_dirty` barrier pull can be dropped. These pins assert the reconcile stays
+# correct across the frame arrangements that make the drop subtle: same-frame
+# slots, ancestor lexicals read via a bare GetLocal, diverged containers, and an
+# EVAL whose body writes a caller lexical through a non-logged path (regex :let).
+
+plan 14;
+
+# 1. same-frame scalar
+{
+    my $x = 0;
+    EVAL '$x = 5';
+    is $x, 5, 'same-frame scalar reconciled after EVAL';
+    is $x + 1, 6, 'bare GetLocal sees the reconciled value';
+}
+
+# 2. ancestor lexical written from a descendant frame, read via bare GetLocal
+{
+    my $x = 0;
+    sub set_x() { EVAL '$x = 5' }
+    set_x();
+    is $x, 5, 'ancestor lexical reconciled after descendant EVAL';
+    is $x + 1, 6, 'ancestor bare GetLocal sees the EVAL write';
+}
+
+# 3. two-deep nesting
+{
+    my $deep = 7;
+    sub inner_eval() { EVAL '$deep = 42' }
+    sub outer_call() { inner_eval() }
+    outer_call();
+    is $deep * 2, 84, 'two-deep nested EVAL write reaches the bare read';
+}
+
+# 4. loop-body lexical (fresh slot each iteration)
+{
+    my @log;
+    for ^3 -> $i {
+        my $z = $i;
+        EVAL '$z = $z * 100';
+        @log.push($z);
+    }
+    is-deeply @log.List, (0, 100, 200), 'per-iteration EVAL writes reconciled';
+}
+
+# 5. container whole-reassignment via EVAL (must NOT be silently lost)
+{
+    my @a = 1, 2, 3;
+    EVAL '@a = (10, 20)';
+    is-deeply @a.List, (10, 20), 'EVAL whole-array reassignment reconciled';
+    my $h = %(:x(1));
+    my %hh = $h;
+    EVAL '%hh = (y => 2)';
+    is %hh<y>, 2, 'EVAL whole-hash reassignment reconciled';
+    nok %hh<x>.defined, 'old hash key gone after reassignment';
+}
+
+# 6. in-place container mutation through EVAL
+{
+    my @a = 1, 2, 3;
+    EVAL '@a.push(4)';
+    is-deeply @a.List, (1, 2, 3, 4), 'EVAL in-place push reconciled';
+}
+
+# 7. EVAL body writes a caller lexical through a bypass path (regex :let)
+{
+    my $a = 1;
+    my regex la { :let $a = 5; <&lma> };
+    my regex lma { $a $a };
+    my $m = EVAL 'so "55" ~~ m/ ^ <la> $ /';
+    ok $m, 'EVAL-run regex matched';
+    is $a + 0, 5, ':let write inside EVAL still visible to bare read';
+}
+
+# 8. interleaved EVAL + unrelated hot local (the benchmark shape)
+{
+    my $x = 0;
+    my $acc = 0;
+    my $hot = 5;
+    for ^10 {
+        EVAL '$x = $x + 1';
+        $acc = $acc + $hot;
+    }
+    is $x, 10, 'interleaved EVAL writes accumulate correctly';
+    is $acc, 50, 'interleaved hot local untouched by the carrier drop';
+}


### PR DESCRIPTION
## Summary

Slice F prerequisite for the single-authority store redesign (docs/vm-single-store.md).

A `MUTSU_VM_STATS` measurement of the canonical R1 patterns in a hot loop showed the pure scalar by-name writers (`our $c=`, dynamic `$*dyn=`, by-name `@a.push`, bareword→call) **already do only ~1–2 reverse-sync pulls, effective=0** — they don't set `env_dirty` on the hot path, so the planned "Slice C R1 scalar write-through" has no standalone pull traffic to remove. The single large spurious-pull source was the **EVAL carrier** (~1001 pulls / 1000 EVALs, all effective=0), set not at the carrier site but by `with_nested_registers`, which blanket-flags `env_dirty` after any nested run.

EVAL writes caller lexicals exclusively through `SetGlobal → set_env_with_main_alias`, which the Slice B carrier log already captures, so the return-boundary writeback reconciles them precisely and the blanket can be dropped.

## Changes

- `writeback_carrier_writes` is now **cell-aware** and returns `fully_reconciled`: copies plain scalars from env, **never overwrites a container/instance slot** (env may hold a COW-detached copy with live interior `:=` cells — the `S03-binding/nested.t` hazard), treats a container as coherent only when env and the slot share the same `Arc`, else leaves it to the barrier (`fully=false`).
- The EVAL carrier site restores the **pre-carrier** `env_dirty` (preserving a dirty the caller already owed) instead of the blanket when `fully && name == "EVAL"`.

Result: EVAL-in-a-hot-loop drops **1001 → 2** pulls, output unchanged.

## Why EVAL-only

`env_dirty` is **frame-scoped** and the writeback is **local to the current frame's `code.locals`**. Dropping the blanket for *all* carriers regressed `S05-modifier/my.t` / `S03-binding/nested.t` (8+1 subtests): regex `:let $a = …` writes a caller lexical **without** going through `set_env_with_main_alias`, bypassing the carrier log (open-question #2 in the design doc). The drop is therefore restricted to EVAL, whose write path is fully logged; other carriers keep the net until that audit closes (Slice C′).

## Testing

- New pin `t/eval-carrier-precise-writeback.t` (14): same-frame / ancestor bare-GetLocal / two-deep nesting / per-iteration / whole-array & whole-hash reassignment / in-place push / regex-`:let`-inside-EVAL / interleaved hot local — all match `raku`.
- `make test` PASS (901 files, 8689 tests).
- `S29-context/eval.t`, `S05-modifier/my.t`, `S03-binding/nested.t`, `t/eval-env-dirty.t` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)