### PR TITLE
feat(types): X::NotParametric for 'of T' params + share is_non_parametric_type

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,14 +125,16 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 62/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 64/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
   - Done: X::NotParametric for parameterizing a non-parametric class/package/module
     (`C[Int]`, `P[Int]`, `M[Int]`) — tests 79-81. The check (vm_var_index_ops type
     parameterization arm) allow-lists built-in container types (Array/Hash/Buf/Blob/...)
     and `is_container_subclass` (`class A is Array`), so only plain classes/packages/
-    modules throw. The `of Int` variants (82-84) go through param-type validation and
-    are NOT yet handled.
+    modules throw. The `of Int` variants — tests 82-83 — are also handled via the
+    param-type pre-pass (`is_non_parametric_type` shared helper + statically-collected
+    class/package names). Test 84 (`sub foo(C of Int)` with NO body) still fails: the
+    missing-body parse error (X::AdHoc) fires before the NotParametric pre-pass.
   - Done: malformed C-style loop spec (`loop (a;b;c;d)`, `loop ()`, comma-instead-
     of-semicolon) throws X::Syntax::Malformed with `.what` ("loop spec (expected 3
     semicolon-separated expressions[ but got N|more])") — tests 74-78. Gated on

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -8,12 +8,20 @@ fn collect_declared_type_names(
     stmts: &[Stmt],
     out: &mut std::collections::HashSet<String>,
     packages: &mut std::collections::HashSet<String>,
+    classes: &mut std::collections::HashSet<String>,
 ) {
     for stmt in stmts {
         match stmt {
-            Stmt::ClassDecl { name, body, .. } | Stmt::RoleDecl { name, body, .. } => {
+            Stmt::ClassDecl { name, body, .. } => {
+                // A plain `class` is type-like but NOT parametric (parameterizing
+                // it with `[T]`/`of T` is X::NotParametric); roles ARE parametric.
                 out.insert(name.resolve().to_string());
-                collect_declared_type_names(body, out, packages);
+                classes.insert(name.resolve().to_string());
+                collect_declared_type_names(body, out, packages, classes);
+            }
+            Stmt::RoleDecl { name, body, .. } => {
+                out.insert(name.resolve().to_string());
+                collect_declared_type_names(body, out, packages, classes);
             }
             Stmt::EnumDecl { name, .. } | Stmt::SubsetDecl { name, .. } => {
                 out.insert(name.resolve().to_string());
@@ -31,10 +39,10 @@ fn collect_declared_type_names(
                 } else {
                     out.insert(name.resolve().to_string());
                 }
-                collect_declared_type_names(body, out, packages);
+                collect_declared_type_names(body, out, packages, classes);
             }
             Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
-                collect_declared_type_names(body, out, packages);
+                collect_declared_type_names(body, out, packages, classes);
             }
             _ => {}
         }
@@ -49,6 +57,7 @@ fn walk_validate_sub_param_types(
     stmts: &[Stmt],
     declared: &std::collections::HashSet<String>,
     packages: &std::collections::HashSet<String>,
+    classes: &std::collections::HashSet<String>,
 ) -> Result<(), RuntimeError> {
     for stmt in stmts {
         match stmt {
@@ -58,16 +67,16 @@ fn walk_validate_sub_param_types(
                 return_type,
                 ..
             } => {
-                interp.validate_param_type_constraints(param_defs, declared, packages)?;
+                interp.validate_param_type_constraints(param_defs, declared, packages, classes)?;
                 interp.validate_return_type_constraint(
                     return_type.as_deref(),
                     param_defs,
                     declared,
                 )?;
-                walk_validate_sub_param_types(interp, body, declared, packages)?;
+                walk_validate_sub_param_types(interp, body, declared, packages, classes)?;
             }
             Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
-                walk_validate_sub_param_types(interp, body, declared, packages)?;
+                walk_validate_sub_param_types(interp, body, declared, packages, classes)?;
             }
             _ => {}
         }
@@ -84,8 +93,9 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let mut declared = std::collections::HashSet::new();
         let mut packages = std::collections::HashSet::new();
-        collect_declared_type_names(stmts, &mut declared, &mut packages);
-        walk_validate_sub_param_types(self, stmts, &declared, &packages)
+        let mut classes = std::collections::HashSet::new();
+        collect_declared_type_names(stmts, &mut declared, &mut packages, &mut classes);
+        walk_validate_sub_param_types(self, stmts, &declared, &packages, &classes)
     }
 
     /// Parse and run only BEGIN/CHECK phasers from EVAL'd code (`:check` mode).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5345,6 +5345,48 @@ impl Interpreter {
     /// Check if a class name refers to a user-defined class that inherits from
     /// a container type (Hash, Array, etc.). Used to skip element-level type
     /// checking for container subclasses.
+    /// True when `name` is a user-declared class / package / module that is NOT
+    /// parametric — i.e. parameterizing it with `[T]` (or `of T`) is an error
+    /// (X::NotParametric). Roles, built-in container types (Array/Hash/Buf/Blob/
+    /// ...), and subclasses of containers ARE parametric and return false.
+    pub(crate) fn is_non_parametric_type(&self, name: &str) -> bool {
+        // Built-in parametric container types accept `[T]`. Some (Buf, Blob, ...)
+        // are registered as classes, so they must be allow-listed here.
+        let parametric_builtin = matches!(
+            name,
+            "Array"
+                | "Hash"
+                | "Map"
+                | "List"
+                | "Slip"
+                | "Seq"
+                | "Range"
+                | "Set"
+                | "Bag"
+                | "Mix"
+                | "SetHash"
+                | "BagHash"
+                | "MixHash"
+                | "Buf"
+                | "Blob"
+                | "buf8"
+                | "buf16"
+                | "buf32"
+                | "buf64"
+                | "blob8"
+                | "blob16"
+                | "blob32"
+                | "blob64"
+                | "Positional"
+                | "Associative"
+                | "Iterable"
+        );
+        !parametric_builtin
+            && !self.is_role(name)
+            && !self.is_container_subclass(name)
+            && (self.has_class(name) || self.is_declared_package(name))
+    }
+
     pub(crate) fn is_container_subclass(&self, name: &str) -> bool {
         const CONTAINER_TYPES: &[&str] = &[
             "Hash", "Array", "Map", "List", "Bag", "Set", "Mix", "BagHash", "SetHash", "MixHash",

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -123,6 +123,7 @@ impl Interpreter {
         param_defs: &[ParamDef],
         declared_types: &std::collections::HashSet<String>,
         declared_packages: &std::collections::HashSet<String>,
+        declared_classes: &std::collections::HashSet<String>,
     ) -> Result<(), RuntimeError> {
         // Type-capture names declared in this signature (e.g. `::T`) are valid
         // type names for the rest of the signature.
@@ -132,15 +133,38 @@ impl Interpreter {
             .filter_map(|tc| tc.strip_prefix("::"))
             .collect();
         for pd in param_defs {
+            let Some(tc) = pd.type_constraint.as_deref() else {
+                continue;
+            };
+            // A parameterized form `Base[...]` (also how `Base of T` is stored,
+            // including the type-only `(Base of T)` param named `__type_only__`)
+            // on a non-parametric type (a plain class or a package/module) is
+            // X::NotParametric. Built-in containers and roles are parametric and
+            // not in these statically-collected sets. (Runtime `is_non_parametric_type`
+            // can't be used here: this pre-pass runs before the type is registered.)
+            // This is checked before the synthetic-param skip below because a
+            // `(Base of T)` term param IS named `__type_only__`.
+            if let Some(base) = tc.split_once('[').map(|(b, _)| b.trim())
+                && !base.is_empty()
+                && (declared_packages.contains(base) || declared_classes.contains(base))
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!("{} cannot be parameterized", base)),
+                );
+                attrs.insert(
+                    "type".to_string(),
+                    Value::Package(crate::symbol::Symbol::intern(base)),
+                );
+                return Err(RuntimeError::typed("X::NotParametric", attrs));
+            }
             // Skip synthetic params (`__type_only__`, `__literal__`): a bare
             // `(Inf)` / `(True)` term param smartmatches a value, so its
             // "constraint" is not necessarily a type name.
             if pd.name.starts_with("__") {
                 continue;
             }
-            let Some(tc) = pd.type_constraint.as_deref() else {
-                continue;
-            };
             // Only a bare identifier (letters/digits/_/-) starting uppercase is
             // considered; anything decorated is skipped as potentially valid.
             if tc.is_empty()

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1608,45 +1608,7 @@ impl Interpreter {
             // Parameterizing a user-declared class / package / module that is NOT
             // parametric throws X::NotParametric. Roles (handled above), built-in
             // container types, and subclasses of them DO accept `[T]`.
-            (Value::Package(name), _)
-                if {
-                    let nm = name.resolve();
-                    // Built-in parametric container types accept `[T]`. Some (Buf,
-                    // Blob, ...) are registered as classes, so allow-list them.
-                    let parametric_builtin = matches!(
-                        nm.as_str(),
-                        "Array"
-                            | "Hash"
-                            | "Map"
-                            | "List"
-                            | "Slip"
-                            | "Seq"
-                            | "Range"
-                            | "Set"
-                            | "Bag"
-                            | "Mix"
-                            | "SetHash"
-                            | "BagHash"
-                            | "MixHash"
-                            | "Buf"
-                            | "Blob"
-                            | "buf8"
-                            | "buf16"
-                            | "buf32"
-                            | "buf64"
-                            | "blob8"
-                            | "blob16"
-                            | "blob32"
-                            | "blob64"
-                            | "Positional"
-                            | "Associative"
-                            | "Iterable"
-                    );
-                    !parametric_builtin
-                        && !self.is_container_subclass(&nm)
-                        && (self.has_class(&nm) || self.is_declared_package(&nm))
-                } =>
-            {
+            (Value::Package(name), _) if self.is_non_parametric_type(&name.resolve()) => {
                 let nm = name.resolve();
                 return Err(RuntimeError::typed(
                     "X::NotParametric",

--- a/t/not-parametric.t
+++ b/t/not-parametric.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 7;
+plan 10;
 
 # Parameterizing a non-parametric type (a plain class / package / module) with
 # `[T]` throws X::NotParametric. Only roles and built-in container types accept
@@ -12,6 +12,14 @@ throws-like 'my module M { }; M[Int]', X::NotParametric,
     'module is not parameterizable';
 throws-like 'my class C { }; C[Int]', X::NotParametric,
     'plain class is not parameterizable';
+
+# The `of T` form on a non-parametric parameter type is equally rejected.
+throws-like 'my package P { }; sub foo(P of Int) { }', X::NotParametric,
+    'package "of" parameter is not parameterizable';
+throws-like 'my module M { }; sub foo(M of Int) { }', X::NotParametric,
+    'module "of" parameter is not parameterizable';
+throws-like 'my class C { }; sub foo(C of Int) { }', X::NotParametric,
+    'class "of" parameter is not parameterizable';
 
 # Built-in container types and roles ARE parameterizable.
 {


### PR DESCRIPTION
## Summary

Extends `X::NotParametric` (#3226) to the `of T` parameter form, and factors the
"is this type parametric?" predicate into a single shared helper.

```raku
my package P { }; sub foo(P of Int) { }   # X::NotParametric
my class C { };   sub foo(C of Int) { }   # X::NotParametric
```

## Mechanism

- New `Interpreter::is_non_parametric_type(name)` — a user class / package / module
  that is **not** a role, **not** a built-in container type (Array/Hash/Buf/Blob/...),
  and **not** a container subclass. The `Index`-opcode parameterization arm
  (`C[Int]` as an expression) now calls it instead of its inline copy
  (1-operation-1-implementation).
- `sub foo(C of Int)` stores the type constraint as `C[Int]`, so the EVAL-time
  param-type pre-pass now rejects a `Base[...]` constraint whose base is a
  statically-collected plain class or package/module. The check runs **before** the
  synthetic-param skip, because a `(Base of T)` term param is named `__type_only__`.
  Built-in containers and roles aren't in the collected sets, so `Array[Int]` /
  `R[Int]` params are unaffected.

## Tests

- Fixes `roast/S32-exceptions/misc.t` tests **82–83** (62 → 64).
- Test **84** (`sub foo(C of Int)` with *no body*) still fails — the missing-body
  parse error (X::AdHoc) fires before the NotParametric pre-pass.
- `t/not-parametric.t` extended with the `of T` forms (now 10 subtests).
- `make test`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)