### PR TITLE
feat(class): X::Undeclared for trusts of an undeclared type

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,8 +125,12 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 64/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 65/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
+  - Done: X::Undeclared for `trusts T` where T is undeclared in the compilation unit
+    (`class C { trusts Bar }`) — test 43. New `check_eval_undeclared_trusts` pre-pass
+    (eval_check) collects all declared types first so forward references
+    (`trusts B; class B {}`) are honored; built-ins pass via has_type/is_resolvable_type.
   - Done: X::NotParametric for parameterizing a non-parametric class/package/module
     (`C[Int]`, `P[Int]`, `M[Int]`) — tests 79-81. The check (vm_var_index_ops type
     parameterization arm) allow-lists built-in container types (Array/Hash/Buf/Blob/...)

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -98,6 +98,56 @@ impl Interpreter {
         walk_validate_sub_param_types(self, stmts, &declared, &packages, &classes)
     }
 
+    /// Reject a `trusts T` declaration whose target type `T` is not declared
+    /// anywhere in this compilation unit (nor a known built-in type)
+    /// -> X::Undeclared (symbol => T, what => "Type"). Forward references are
+    /// honored because all declared type names are collected first.
+    pub(crate) fn check_eval_undeclared_trusts(&self, stmts: &[Stmt]) -> Result<(), RuntimeError> {
+        let mut declared = std::collections::HashSet::new();
+        let mut packages = std::collections::HashSet::new();
+        let mut classes = std::collections::HashSet::new();
+        collect_declared_type_names(stmts, &mut declared, &mut packages, &mut classes);
+        self.walk_validate_trusts(stmts, &declared)
+    }
+
+    fn walk_validate_trusts(
+        &self,
+        stmts: &[Stmt],
+        declared: &std::collections::HashSet<String>,
+    ) -> Result<(), RuntimeError> {
+        for stmt in stmts {
+            match stmt {
+                Stmt::TrustsDecl { name } => {
+                    let target = name.resolve();
+                    // A bare identifier (e.g. `Bar`) that names no declared type and
+                    // is not a known built-in/resolvable type is undeclared.
+                    let known = declared.contains(target.as_str())
+                        || self.has_type(&target)
+                        || self.is_resolvable_type(&target);
+                    if !known {
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("symbol".to_string(), Value::str(target.to_string()));
+                        attrs.insert("what".to_string(), Value::str("Type".to_string()));
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!("Type '{}' is not declared", target)),
+                        );
+                        return Err(RuntimeError::typed("X::Undeclared", attrs));
+                    }
+                }
+                Stmt::ClassDecl { body, .. }
+                | Stmt::RoleDecl { body, .. }
+                | Stmt::Package { body, .. }
+                | Stmt::Block(body)
+                | Stmt::SyntheticBlock(body) => {
+                    self.walk_validate_trusts(body, declared)?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
     /// Parse and run only BEGIN/CHECK phasers from EVAL'd code (`:check` mode).
     fn parse_and_check_only_with_operators(
         &mut self,
@@ -116,6 +166,7 @@ impl Interpreter {
         ) {
             Ok((stmts, _)) => {
                 self.check_eval_class_redeclarations(&stmts)?;
+                self.check_eval_undeclared_trusts(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
                 let mut stmts = self.inject_eval_methods_into_class(stmts);

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -94,6 +94,7 @@ impl Interpreter {
         match parse_result {
             Ok((stmts, _)) => {
                 self.check_eval_class_redeclarations(&stmts)?;
+                self.check_eval_undeclared_trusts(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
                 self.check_eval_param_type_constraints(&stmts)?;

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -72,6 +72,7 @@ impl Interpreter {
                         Ok((stmts, _)) => nested
                             .check_eval_mainline_placeholders(&stmts)
                             .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
+                            .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
                         Err(mut e) => {
@@ -421,6 +422,7 @@ impl Interpreter {
                         Ok((stmts, _)) => nested
                             .check_eval_mainline_placeholders(&stmts)
                             .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
+                            .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
                         Err(mut e) => {

--- a/t/trusts-undeclared.t
+++ b/t/trusts-undeclared.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 5;
+
+# `trusts T` where T is not declared anywhere in the compilation unit (nor a
+# built-in type) is X::Undeclared (symbol => T, what => Type).
+
+throws-like 'class RT117859 { trusts Bar }', X::Undeclared,
+    'trusts an undeclared type', :symbol<Bar>, :what<Type>;
+
+{
+    my $err;
+    try { EVAL 'class C { trusts NopeNope }'; CATCH { default { $err = $_ } } }
+    is $err.symbol, 'NopeNope', 'the .symbol names the undeclared trusted type';
+}
+
+# A trusted type declared elsewhere — even later (forward reference) — is fine.
+{
+    lives-ok { EVAL 'class A { trusts B }; class B { }' },
+        'forward-referenced trusted type is allowed';
+    lives-ok { EVAL 'class B { }; class A { trusts B }' },
+        'already-declared trusted type is allowed';
+}
+
+# Trusting a built-in type is allowed.
+{
+    lives-ok { EVAL 'class A { trusts Int }' },
+        'trusting a built-in type is allowed';
+}


### PR DESCRIPTION
## Summary

`class C { trusts Bar }` where `Bar` is not declared anywhere in the compilation
unit (nor a built-in type) now throws `X::Undeclared` (symbol => Bar, what => Type),
matching Rakudo. mutsu previously accepted the trust silently.

## Mechanism

New `Interpreter::check_eval_undeclared_trusts` pre-pass (`eval_check`) collects all
declared type names in the unit *first*, so forward references
(`class A { trusts B }; class B {}`) are honored; built-in / resolvable types pass
via `has_type` / `is_resolvable_type`. Wired into the throws-like and EVAL pre-pass
chains alongside the existing undeclared checks.

## Tests

- Fixes `roast/S32-exceptions/misc.t` test **43** (64 → 65).
- New `t/trusts-undeclared.t` (5): undeclared trust throws with symbol/what;
  forward-referenced and already-declared and built-in trust targets all allowed.
- `make test`: PASS. Whitelisted `S12-methods/trusts.t` still 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)