### PR TITLE
feat(types): X::Undeclared::Symbols for an undeclared type-parameter argument

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,8 +125,14 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 65/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 66/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
+  - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
+    (gist mentions the name) — test 453 (462 in misc.t numbering). New
+    `check_eval_undeclared_type_args` pre-pass walks VarDecl/param/return type constraints,
+    extracts inner `[...]` args, flags undeclared uppercase types (forward-ref + builtins ok).
+    ALSO fixed throws-like: the `gist => /.../` matcher now falls back to the exception's
+    message (gist isn't a stored attribute), so any `gist` matcher across roast can match.
   - Done: X::Undeclared for `trusts T` where T is undeclared in the compilation unit
     (`class C { trusts Bar }`) — test 43. New `check_eval_undeclared_trusts` pre-pass
     (eval_check) collects all declared types first so forward references

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -98,6 +98,106 @@ impl Interpreter {
         walk_validate_sub_param_types(self, stmts, &declared, &packages, &classes)
     }
 
+    /// Reject a type-parameter argument that names an undeclared type, e.g.
+    /// `my Array[Numerix] $x` -> X::Undeclared::Symbols (gist mentions `Numerix`).
+    /// Only the inner `[...]` arguments are checked here (the base type's
+    /// parametric-ness is X::NotParametric, handled elsewhere). All declared type
+    /// names are collected first so forward references are honored.
+    pub(crate) fn check_eval_undeclared_type_args(
+        &self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        let mut declared = std::collections::HashSet::new();
+        let mut packages = std::collections::HashSet::new();
+        let mut classes = std::collections::HashSet::new();
+        collect_declared_type_names(stmts, &mut declared, &mut packages, &mut classes);
+        self.walk_validate_type_args(stmts, &declared)
+    }
+
+    /// If `tc` is `Base[arg, ...]`, return the first inner argument that names an
+    /// undeclared type (an uppercase bareword that is neither declared nor a known
+    /// built-in / resolvable type). `::T` capture args and lowercase/native args
+    /// are ignored.
+    fn first_undeclared_type_arg(
+        &self,
+        tc: &str,
+        declared: &std::collections::HashSet<String>,
+    ) -> Option<String> {
+        let open = tc.find('[')?;
+        let close = tc.rfind(']')?;
+        if close <= open + 1 {
+            return None;
+        }
+        let inner = &tc[open + 1..close];
+        for raw in inner.split(',') {
+            // Strip type smileys (`:D`/`:U`/`:_`) and surrounding whitespace.
+            let arg = raw.split(':').next().unwrap_or(raw).trim();
+            if arg.is_empty() || arg.starts_with("::") {
+                continue;
+            }
+            // Only consider a bare uppercase type identifier.
+            if !arg.starts_with(|c: char| c.is_ascii_uppercase())
+                || !arg
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ':')
+            {
+                continue;
+            }
+            if declared.contains(arg) || self.has_type(arg) || self.is_resolvable_type(arg) {
+                continue;
+            }
+            return Some(arg.to_string());
+        }
+        None
+    }
+
+    fn walk_validate_type_args(
+        &self,
+        stmts: &[Stmt],
+        declared: &std::collections::HashSet<String>,
+    ) -> Result<(), RuntimeError> {
+        let check = |tc: Option<&str>| -> Option<String> {
+            tc.and_then(|t| self.first_undeclared_type_arg(t, declared))
+        };
+        for stmt in stmts {
+            let bad = match stmt {
+                Stmt::VarDecl {
+                    type_constraint, ..
+                } => check(type_constraint.as_deref()),
+                Stmt::SubDecl {
+                    param_defs,
+                    return_type,
+                    ..
+                } => param_defs
+                    .iter()
+                    .find_map(|pd| check(pd.type_constraint.as_deref()))
+                    .or_else(|| check(return_type.as_deref())),
+                _ => None,
+            };
+            if let Some(name) = bad {
+                let suggestions = self.suggest_type_names(&name);
+                return Err(RuntimeError::undeclared_type_symbols(
+                    &name,
+                    format!("Undeclared name:\n    {} used at line 1", name),
+                    suggestions,
+                ));
+            }
+            // Recurse into nested bodies.
+            match stmt {
+                Stmt::ClassDecl { body, .. }
+                | Stmt::RoleDecl { body, .. }
+                | Stmt::Package { body, .. }
+                | Stmt::Block(body)
+                | Stmt::SyntheticBlock(body)
+                | Stmt::SubDecl { body, .. } => {
+                    self.walk_validate_type_args(body, declared)?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
     /// Reject a `trusts T` declaration whose target type `T` is not declared
     /// anywhere in this compilation unit (nor a known built-in type)
     /// -> X::Undeclared (symbol => T, what => "Type"). Forward references are
@@ -167,6 +267,7 @@ impl Interpreter {
             Ok((stmts, _)) => {
                 self.check_eval_class_redeclarations(&stmts)?;
                 self.check_eval_undeclared_trusts(&stmts)?;
+                self.check_eval_undeclared_type_args(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
                 let mut stmts = self.inject_eval_methods_into_class(stmts);

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -130,8 +130,16 @@ impl Interpreter {
         }
         let inner = &tc[open + 1..close];
         for raw in inner.split(',') {
-            // Strip type smileys (`:D`/`:U`/`:_`) and surrounding whitespace.
-            let arg = raw.split(':').next().unwrap_or(raw).trim();
+            let mut arg = raw.trim();
+            // Strip a trailing type smiley (`:D`/`:U`/`:_`) ONLY — must not split a
+            // `::`-qualified name like `Ber::Meow` (which contains `:`).
+            for smiley in [":D", ":U", ":_"] {
+                if let Some(stripped) = arg.strip_suffix(smiley) {
+                    arg = stripped;
+                    break;
+                }
+            }
+            let arg = arg.trim();
             if arg.is_empty() || arg.starts_with("::") {
                 continue;
             }

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -95,6 +95,7 @@ impl Interpreter {
             Ok((stmts, _)) => {
                 self.check_eval_class_redeclarations(&stmts)?;
                 self.check_eval_undeclared_trusts(&stmts)?;
+                self.check_eval_undeclared_type_args(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
                 self.check_eval_param_type_constraints(&stmts)?;

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -73,6 +73,7 @@ impl Interpreter {
                             .check_eval_mainline_placeholders(&stmts)
                             .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
+                            .and_then(|()| nested.check_eval_undeclared_type_args(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
                         Err(mut e) => {
@@ -260,12 +261,15 @@ impl Interpreter {
                     None
                 }
             });
-            // Fall back to err.message for "message" attribute
+            // Fall back to err.message for the "message" and "gist" matchers:
+            // neither is stored as an attribute, and an X:: exception's `.gist`
+            // renders its message (plus suggestions), so the message text is the
+            // substring the `gist => /.../` matchers look for.
             let actual_str = actual_val
                 .as_ref()
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| {
-                    if attr_name == "message" {
+                    if attr_name == "message" || attr_name == "gist" {
                         err_message.clone()
                     } else {
                         String::new()
@@ -423,6 +427,7 @@ impl Interpreter {
                             .check_eval_mainline_placeholders(&stmts)
                             .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
+                            .and_then(|()| nested.check_eval_undeclared_type_args(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
                         Err(mut e) => {

--- a/t/undeclared-type-arg.t
+++ b/t/undeclared-type-arg.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 5;
+
+# An undeclared type used as a type-parameter argument is X::Undeclared::Symbols.
+throws-like Q/my Array[Numerix] $x;/, X::Undeclared::Symbols,
+    'undeclared type arg in a variable declaration',
+    gist => /Numerix/;
+throws-like 'sub f(Array[NoSuchT] $x) { }', X::Undeclared::Symbols,
+    'undeclared type arg in a parameter';
+
+# Declared / built-in type args are fine (forward references too).
+{
+    lives-ok { EVAL 'my Array[Int] @a;' }, 'built-in type arg is allowed';
+    lives-ok { EVAL 'class C { }; my Array[C] @a;' },
+        'declared-class type arg is allowed';
+    lives-ok { EVAL 'my Array[D] @a; class D { }' },
+        'forward-referenced type arg is allowed';
+}


### PR DESCRIPTION
## Summary

`my Array[Numerix] $x` (and `sub f(Array[NoSuchT] $x)`) now throws
`X::Undeclared::Symbols` whose gist names the offending type, matching Rakudo.
mutsu previously accepted the unknown inner type silently.

## Mechanism

- New `check_eval_undeclared_type_args` pre-pass (`eval_check`) walks VarDecl /
  parameter / return type constraints, extracts the inner `[...]` arguments, and
  flags an uppercase argument that names no declared type and no known built-in.
  All declared types are collected first (forward references honored); built-in
  containers and `::T` capture args are skipped. Wired into the throws-like and
  EVAL pre-pass chains.
- **Also fixed the `throws-like` harness**: a `gist => /.../` matcher now falls
  back to the exception's message when there's no stored `gist` attribute (`gist`
  is a computed method, not an attribute, and an X:: exception's gist renders its
  message). Previously every `gist` matcher compared against an empty string and
  could never pass — this benefits any `gist` matcher across roast.

## Tests

- Fixes `roast/S32-exceptions/misc.t` test **453** (65 → 66).
- New `t/undeclared-type-arg.t` (5): undeclared type arg in var/param throws with
  a `Numerix`-bearing gist; built-in / declared / forward-referenced type args pass.
- `make test`: PASS (no regression from the broad throws-like change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)