### PR TITLE
feat(constant): X::Undeclared::Symbols for a constant from an undeclared name

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,7 +125,7 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 66/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 67/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
   - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
     (gist mentions the name) — test 453 (462 in misc.t numbering). New
@@ -133,6 +133,10 @@
     extracts inner `[...]` args, flags undeclared uppercase types (forward-ref + builtins ok).
     ALSO fixed throws-like: the `gist => /.../` matcher now falls back to the exception's
     message (gist isn't a stored attribute), so any `gist` matcher across roast can match.
+  - Done: `constant foo = bar` (initializer references an undeclared bareword) ->
+    X::Undeclared::Symbols — test 442. `find_undeclared_name_in_stmt` now also walks a
+    `constant` VarDecl's initializer (scoped to `__constant` to avoid flagging ordinary
+    `my $x = ...` inits that resolve at runtime).
   - Done: X::Undeclared for `trusts T` where T is undeclared in the compilation unit
     (`class C { trusts Bar }`) — test 43. New `check_eval_undeclared_trusts` pre-pass
     (eval_check) collects all declared types first so forward references

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -934,6 +934,17 @@ impl Interpreter {
     ) -> Option<String> {
         match stmt {
             Stmt::Expr(expr) => self.find_undeclared_name_in_expr(expr, local_classes, declared),
+            // A `constant NAME = <init>` whose initializer references an undeclared
+            // bareword (`constant foo = bar`) is X::Undeclared::Symbols. Scoped to
+            // `constant` only (custom trait `__constant`) to avoid false positives
+            // on ordinary `my $x = ...` initializers that resolve at runtime.
+            Stmt::VarDecl {
+                expr,
+                custom_traits,
+                ..
+            } if custom_traits.iter().any(|(t, _)| t == "__constant") => {
+                self.find_undeclared_name_in_expr(expr, local_classes, declared)
+            }
             _ => None,
         }
     }

--- a/t/undeclared-constant-init.t
+++ b/t/undeclared-constant-init.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 6;
+
+# A `constant` whose initializer references an undeclared bareword is
+# X::Undeclared::Symbols.
+throws-like 'constant foo = bar', X::Undeclared::Symbols,
+    'constant initialized from an undeclared name';
+
+# Valid constant initializers still work.
+{
+    constant x = 42;
+    is x, 42, 'literal constant';
+}
+{
+    constant z = 1 + 2 * 3;
+    is z, 7, 'expression constant';
+}
+{
+    constant w = "hello";
+    is w, 'hello', 'string constant';
+}
+{
+    sub g() { 5 }
+    constant y = g();
+    is y, 5, 'constant from a declared sub call';
+}
+{
+    constant p = pi;
+    ok p > 3 && p < 4, 'constant from a built-in term';
+}


### PR DESCRIPTION
## Summary

`constant foo = bar` where `bar` is undeclared now throws `X::Undeclared::Symbols`,
matching Rakudo. mutsu previously accepted it silently.

## Mechanism

`find_undeclared_name_in_stmt` now also walks a `constant` declaration's
initializer expression for undeclared barewords (reusing the existing
`find_undeclared_name_in_expr`). The walk is **scoped to `constant`** (the
`__constant` custom trait) so ordinary `my $x = ...` initializers — which may
legitimately reference names resolved at runtime — are unaffected.

## Tests

- Fixes `roast/S32-exceptions/misc.t` test **442** (66 → 67).
- New `t/undeclared-constant-init.t` (6): undeclared-init throws; literal /
  expression / string / declared-sub-call / built-in-term initializers all work.
- `make test`: PASS. Whitelisted `S04-declarations/constant-6.d.t` still 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)