### PR TITLE
feat(class): X::Redeclaration for duplicate my/our methods in one body

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,7 +125,7 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 67/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 69/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
   - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
     (gist mentions the name) — test 453 (462 in misc.t numbering). New
@@ -133,6 +133,10 @@
     extracts inner `[...]` args, flags undeclared uppercase types (forward-ref + builtins ok).
     ALSO fixed throws-like: the `gist => /.../` matcher now falls back to the exception's
     message (gist isn't a stored attribute), so any `gist` matcher across roast can match.
+  - Done: X::Redeclaration for two `my`/`our`-scoped methods of the same name in one
+    class/role body — tests 64-65 (`dup_scoped_method` in check_eval_class_redeclarations,
+    uses MethodDecl is_my/is_our). Tokens (66-67) still fail: TokenDecl drops the my/our
+    scope at parse time (plain vs my/our token = X::Method::Duplicate vs X::Redeclaration).
   - Done: `constant foo = bar` (initializer references an undeclared bareword) ->
     X::Undeclared::Symbols — test 442. `find_undeclared_name_in_stmt` now also walks a
     `constant` VarDecl's initializer (scoped to `__constant` to avoid flagging ordinary

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -266,6 +266,41 @@ impl Interpreter {
                     if *fn_name == "__mutsu_stub_die" || *fn_name == "__mutsu_stub_warn")
         };
 
+        // Within one class/role/grammar body, two `my`/`our`-scoped methods of the
+        // same name are an X::Redeclaration (a plain `method foo` redeclared is the
+        // separate X::Method::Duplicate, not handled here). Mirrors Rakudo.
+        let dup_scoped_method = |body: &[Stmt]| -> Option<RuntimeError> {
+            let mut seen_my: HashSet<String> = HashSet::new();
+            let mut seen_our: HashSet<String> = HashSet::new();
+            for s in body {
+                if let Stmt::MethodDecl {
+                    name,
+                    is_my,
+                    is_our,
+                    ..
+                } = s
+                {
+                    let n = name.resolve().to_string();
+                    if n.is_empty() {
+                        continue;
+                    }
+                    let dup = (*is_my && !seen_my.insert(n.clone()))
+                        || (*is_our && !seen_our.insert(n.clone()));
+                    if dup {
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("symbol".to_string(), Value::str(n.clone()));
+                        attrs.insert("what".to_string(), Value::str("method".to_string()));
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!("Redeclaration of method '{}'", n)),
+                        );
+                        return Some(RuntimeError::typed("X::Redeclaration", attrs));
+                    }
+                }
+            }
+            None
+        };
+
         let type_redeclaration = |name: &str| -> RuntimeError {
             let mut attrs = std::collections::HashMap::new();
             attrs.insert("symbol".to_string(), Value::str(name.to_string()));
@@ -347,6 +382,9 @@ impl Interpreter {
                     is_lexical,
                     ..
                 } => {
+                    if let Some(err) = dup_scoped_method(body) {
+                        return Err(err);
+                    }
                     let name = name.resolve().to_string();
                     class_nested
                         .entry(name.clone())
@@ -365,6 +403,9 @@ impl Interpreter {
                     (name, is_stub)
                 }
                 Stmt::RoleDecl { name, body, .. } => {
+                    if let Some(err) = dup_scoped_method(body) {
+                        return Err(err);
+                    }
                     (name.resolve().to_string(), body_is_stub(body))
                 }
                 Stmt::SubsetDecl { name, .. } => (name.resolve().to_string(), false),

--- a/t/method-redeclaration.t
+++ b/t/method-redeclaration.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+# Two `my`/`our`-scoped methods of the same name in one class/role body are an
+# X::Redeclaration (a plain `method foo` redeclared is the separate
+# X::Method::Duplicate, not covered here).
+throws-like 'my class C { my method foo { 1 }; my method foo { 2 } }',
+    X::Redeclaration, 'duplicate my method';
+throws-like 'my class C { our method foo { 1 }; our method foo { 2 } }',
+    X::Redeclaration, 'duplicate our method';
+throws-like 'my role R { my method foo { 1 }; my method foo { 2 } }',
+    X::Redeclaration, 'duplicate my method in a role';
+
+# Distinct method names — and a single method — are fine.
+{
+    lives-ok { EVAL 'my class C { my method a { 1 }; my method b { 2 } }' },
+        'distinct my methods are allowed';
+    lives-ok { EVAL 'my class C { our method a { 1 }; my method a { 2 } }' },
+        'same name in different scopes is allowed';
+}
+{
+    class D { method hi { 'hi' } }
+    is D.new.hi, 'hi', 'an ordinary single method still works';
+}


### PR DESCRIPTION
## Summary

Two `my`- or `our`-scoped methods of the same name in a single class/role body
now throw `X::Redeclaration`, matching Rakudo:

```raku
my class C { my method foo { 1 }; my method foo { 2 } }   # X::Redeclaration
```

mutsu previously accepted the duplicate silently.

## Mechanism

`check_eval_class_redeclarations` gains a `dup_scoped_method` helper, called on
every class/role body it processes. It keys on `MethodDecl`'s `is_my`/`is_our`
flags, so:
- a plain `method foo` redeclared (the separate `X::Method::Duplicate`, not yet
  implemented) is left alone, and
- the same name in different scopes (`our method a` + `my method a`) is allowed.

## Tests

- Fixes `roast/S32-exceptions/misc.t` tests **64–65** (67 → 69).
- The `my`/`our token` cases (66–67) remain unhandled: `TokenDecl` drops the
  my/our scope at parse time, so the plain-vs-scoped distinction
  (`X::Method::Duplicate` vs `X::Redeclaration`) is currently unavailable.
- New `t/method-redeclaration.t` (6). `make test`: PASS; whitelisted
  `S32-exceptions/misc2.t` (the redeclaration campaign file) still 265/265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)