### PR TITLE
feat(grammar): X::Redeclaration for duplicate my/our tokens in one grammar

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,7 +125,7 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 69/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 71/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
   - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
     (gist mentions the name) — test 453 (462 in misc.t numbering). New
@@ -135,8 +135,7 @@
     message (gist isn't a stored attribute), so any `gist` matcher across roast can match.
   - Done: X::Redeclaration for two `my`/`our`-scoped methods of the same name in one
     class/role body — tests 64-65 (`dup_scoped_method` in check_eval_class_redeclarations,
-    uses MethodDecl is_my/is_our). Tokens (66-67) still fail: TokenDecl drops the my/our
-    scope at parse time (plain vs my/our token = X::Method::Duplicate vs X::Redeclaration).
+    uses MethodDecl is_my/is_our). Tokens (66-67) also done: TokenDecl now carries is_my/is_our (set in the my/our dispatch).
   - Done: `constant foo = bar` (initializer references an undeclared bareword) ->
     X::Undeclared::Symbols — test 442. `find_undeclared_name_in_stmt` now also walks a
     `constant` VarDecl's initializer (scoped to `__constant` to avoid flagging ordinary

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -546,6 +546,10 @@ pub(crate) enum Stmt {
         param_defs: Vec<ParamDef>,
         body: Vec<Stmt>,
         multi: bool,
+        /// `my token foo` — lexically scoped; a duplicate is X::Redeclaration.
+        is_my: bool,
+        /// `our token foo` — package scoped; a duplicate is X::Redeclaration.
+        is_our: bool,
     },
     RuleDecl {
         name: Symbol,

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -1681,6 +1681,8 @@ pub(super) fn token_decl(input: &str) -> PResult<'_, Stmt> {
                 param_defs,
                 body,
                 multi: false,
+                is_my: false,
+                is_our: false,
             },
         ))
     }

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -234,7 +234,19 @@ pub(super) fn try_keyword_dispatch(
         || keyword("token", rest).is_some()
         || keyword("rule", rest).is_some()
     {
-        let (rest, stmt) = super::super::class::token_decl(rest)?;
+        let (rest, mut stmt) = super::super::class::token_decl(rest)?;
+        // Record the `my`/`our` scope so a duplicate `my token`/`our token` in one
+        // grammar body is detected as X::Redeclaration. `my` is the default
+        // declarator here (not `state`, not `our`).
+        if let Stmt::TokenDecl {
+            is_my: tok_is_my,
+            is_our: tok_is_our,
+            ..
+        } = &mut stmt
+        {
+            *tok_is_our = is_our;
+            *tok_is_my = !_is_state && !is_our;
+        }
         if apply_modifier {
             return parse_statement_modifier(rest, stmt).map(Some);
         }

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -266,36 +266,44 @@ impl Interpreter {
                     if *fn_name == "__mutsu_stub_die" || *fn_name == "__mutsu_stub_warn")
         };
 
-        // Within one class/role/grammar body, two `my`/`our`-scoped methods of the
-        // same name are an X::Redeclaration (a plain `method foo` redeclared is the
-        // separate X::Method::Duplicate, not handled here). Mirrors Rakudo.
+        // Within one class/role/grammar body, two `my`/`our`-scoped methods (or
+        // tokens) of the same name are an X::Redeclaration (a plain `method`/`token`
+        // redeclared is the separate X::Method::Duplicate, not handled here).
+        // Mirrors Rakudo.
         let dup_scoped_method = |body: &[Stmt]| -> Option<RuntimeError> {
             let mut seen_my: HashSet<String> = HashSet::new();
             let mut seen_our: HashSet<String> = HashSet::new();
             for s in body {
-                if let Stmt::MethodDecl {
-                    name,
-                    is_my,
-                    is_our,
-                    ..
-                } = s
-                {
-                    let n = name.resolve().to_string();
-                    if n.is_empty() {
-                        continue;
-                    }
-                    let dup = (*is_my && !seen_my.insert(n.clone()))
-                        || (*is_our && !seen_our.insert(n.clone()));
-                    if dup {
-                        let mut attrs = std::collections::HashMap::new();
-                        attrs.insert("symbol".to_string(), Value::str(n.clone()));
-                        attrs.insert("what".to_string(), Value::str("method".to_string()));
-                        attrs.insert(
-                            "message".to_string(),
-                            Value::str(format!("Redeclaration of method '{}'", n)),
-                        );
-                        return Some(RuntimeError::typed("X::Redeclaration", attrs));
-                    }
+                let (name, is_my, is_our, what) = match s {
+                    Stmt::MethodDecl {
+                        name,
+                        is_my,
+                        is_our,
+                        ..
+                    } => (name, *is_my, *is_our, "method"),
+                    Stmt::TokenDecl {
+                        name,
+                        is_my,
+                        is_our,
+                        ..
+                    } => (name, *is_my, *is_our, "regex"),
+                    _ => continue,
+                };
+                let n = name.resolve().to_string();
+                if n.is_empty() {
+                    continue;
+                }
+                let dup = (is_my && !seen_my.insert(n.clone()))
+                    || (is_our && !seen_our.insert(n.clone()));
+                if dup {
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert("symbol".to_string(), Value::str(n.clone()));
+                    attrs.insert("what".to_string(), Value::str(what.to_string()));
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!("Redeclaration of {} '{}'", what, n)),
+                    );
+                    return Some(RuntimeError::typed("X::Redeclaration", attrs));
                 }
             }
             None

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -550,6 +550,7 @@ impl Interpreter {
                 param_defs,
                 body,
                 multi,
+                ..
             }
             | Stmt::RuleDecl {
                 name,

--- a/t/token-redeclaration.t
+++ b/t/token-redeclaration.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 5;
+
+# Two `my`/`our`-scoped tokens of the same name in one grammar body are an
+# X::Redeclaration (a plain `token foo` redeclared is X::Method::Duplicate).
+throws-like 'my grammar G { my token foo { x }; my token foo { y } }',
+    X::Redeclaration, 'duplicate my token';
+throws-like 'my grammar G { our token foo { x }; our token foo { y } }',
+    X::Redeclaration, 'duplicate our token';
+
+# Distinct token names are fine, and a working grammar still parses.
+{
+    lives-ok { EVAL 'my grammar G { my token a { x }; my token b { y } }' },
+        'distinct my tokens are allowed';
+}
+{
+    grammar G { token TOP { \d+ } }
+    ok G.parse('42'), 'an ordinary grammar still parses';
+}
+{
+    grammar H { token a { 'x' }; token b { 'y' }; token TOP { <a><b> } }
+    ok H.parse('xy'), 'distinct plain tokens still compose';
+}


### PR DESCRIPTION
## Summary

A duplicate `my token`/`our token` of the same name in one grammar/class body now
throws `X::Redeclaration`, completing the method/token redeclaration cluster
(methods landed in the previous PR):

```raku
my grammar G { my token foo { x }; my token foo { y } }   # X::Redeclaration
```

## Mechanism

- `TokenDecl` gains `is_my` / `is_our` fields, set in the `my`/`our` declaration
  dispatch (`my_decl_dispatch`); the bare-`token` path leaves them `false`.
- `dup_scoped_method` (the method-dup check from the prior PR) now also scans
  `TokenDecl`, flagging a scoped-token duplicate exactly like a scoped-method one.
  Plain `token foo` redeclared (X::Method::Duplicate) and distinct token names are
  unaffected.

## Tests

- Fixes `roast/S32-exceptions/misc.t` tests **66–67** (69 → 71).
- New `t/token-redeclaration.t` (5). `make test`: PASS; whitelisted grammar suite
  (parse/action/inheritance/namespace) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)