### PR TITLE
feat(when): X::Undeclared for an undeclared type in a when clause

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,7 +125,7 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 71/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
+  - 72/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
     broad compile-time-error/exception file covering ~40 distinct features.
   - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
     (gist mentions the name) — test 453 (462 in misc.t numbering). New

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -994,6 +994,14 @@ impl Interpreter {
             } if custom_traits.iter().any(|(t, _)| t == "__constant") => {
                 self.find_undeclared_name_in_expr(expr, local_classes, declared)
             }
+            // `given X { when SomeUndeclaredType {...} }`: a `when` whose condition
+            // is an undeclared (bare uppercase) type name is X::Undeclared.
+            Stmt::Given { body, .. } => body
+                .iter()
+                .find_map(|s| self.find_undeclared_name_in_stmt(s, local_classes, declared)),
+            Stmt::When { cond, .. } => {
+                self.find_undeclared_name_in_expr(cond, local_classes, declared)
+            }
             _ => None,
         }
     }

--- a/t/undeclared-when-type.t
+++ b/t/undeclared-when-type.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 6;
+
+# `when SomeUndeclaredType` where the type is undeclared is a compile-time
+# X::Undeclared (an X::Comp subtype) whose message names the type.
+throws-like 'given 42 { when SomeUndeclaredType { 1 }; default { 0 } }',
+    X::Comp::Group, 'undeclared type in a when clause',
+    :message(/SomeUndeclaredType/);
+
+# Valid `when` forms still work.
+{
+    my $r;
+    given 5 { when Int { $r = 'int' }; default { $r = 'no' } }
+    is $r, 'int', 'when against a built-in type';
+}
+{
+    class Foo { }
+    my $r;
+    given Foo.new { when Foo { $r = 'foo' } }
+    is $r, 'foo', 'when against a declared class';
+}
+{
+    my $r;
+    given 5 { when 5 { $r = 'five' }; when * > 3 { $r = 'big' } }
+    is $r, 'five', 'when against a literal';
+}
+{
+    my $r;
+    given 'ab' { when /a/ { $r = 'match' } }
+    is $r, 'match', 'when against a regex';
+}
+{
+    lives-ok { EVAL 'given 1 { when Int { } }' }, 'EVAL of a valid when lives';
+}


### PR DESCRIPTION
## Summary

`given X { when SomeUndeclaredType { ... } }` where the type is undeclared now
throws a compile-time `X::Undeclared` (an `X::Comp` subtype, so
`throws-like X::Comp::Group` matches), with a message naming the type. mutsu
previously ran the block, silently treating the unknown bareword as a failed
smartmatch.

## Mechanism

`find_undeclared_name_in_stmt` now descends into `given` bodies and checks each
`when` condition for an undeclared (bare uppercase) type name, reusing the
existing bareword-undeclared logic. Built-in types, declared classes, literals,
regexes, and `WhateverCode` conditions are unaffected.

## Tests

- Fixes `roast/S32-exceptions/misc.t` test **33** (71 → 72).
- New `t/undeclared-when-type.t` (6): undeclared-when throws; `when Int` /
  `when <declared class>` / `when 5` / `when * > 3` / `when /rx/` all still work.
- `make test`: PASS; whitelisted given/for/gather suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)