### PR TITLE
feat(backtrace): Backtrace::Frame methods + throw-time backtrace capture

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,8 +125,18 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 72/157 pass (plan 182; 25 subtests never reached due to compile errors). This is a very
-    broad compile-time-error/exception file covering ~40 distinct features.
+  - 88/180 pass (plan 182). This is a very broad compile-time-error/exception file
+    covering ~40 distinct features.
+  - Done: Backtrace/Backtrace::Frame methods — `.code`(->Routine), `.name`,
+    `.is-routine`, `.is-hidden`, `.is-setting` on a frame; `.concise`/`.summary`/`.flat`
+    on a Backtrace; Backtrace list-iteration (`.grep`/`.map`/`.first`/... delegate to
+    its frames). ALSO: `ExceptionObject.throw`/`.rethrow` now attach a real backtrace
+    (built from the call stack) like the die/fail opcodes do — previously a thrown
+    object's `.backtrace.list` was empty, which ABORTED the file mid-run (only 157 of
+    182 subtests ran). Now 180 run. Tests 156,158,159,160,162-164 pass.
+  - Still failing: tests 157 & 161 hard-code `$bt.list.elems == 4` (raku captures 4
+    internal frames incl. the `.throw` invocation + an anonymous block; mutsu's call
+    stack yields 2) — implementation-detail counts, not worth matching.
   - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
     (gist mentions the name) — test 453 (462 in misc.t numbering). New
     `check_eval_undeclared_type_args` pre-pass walks VarDecl/param/return type constraints,

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -834,6 +834,41 @@ fn format_temporal_num(f: f64) -> String {
     }
 }
 
+/// Render a `Backtrace::Frame` instance as its `.Str`/`.gist` text.
+/// Shared by the frame's `.Str` handler and by `Backtrace.concise`/`.summary`
+/// so the natively-computed strings stay byte-identical to a `.grep(...).join`.
+fn backtrace_frame_str(attributes: &std::sync::Arc<crate::value::InstanceAttrs>) -> String {
+    let map = attributes.as_map();
+    let subname = map
+        .get("subname")
+        .map(|v| v.to_string_value())
+        .unwrap_or_default();
+    let file = map
+        .get("file")
+        .map(|v| v.to_string_value())
+        .unwrap_or_default();
+    let line = map
+        .get("line")
+        .map(|v| v.to_string_value())
+        .unwrap_or_else(|| "0".to_string());
+    if subname == "<unit>" {
+        format!("  in block <unit> at {} line {}", file, line)
+    } else {
+        format!("  in sub {} at {} line {}", subname, file, line)
+    }
+}
+
+/// A `Backtrace::Frame` is a "routine" frame when it has a real subname
+/// (not the synthetic `<unit>` bottom frame and not an anonymous block).
+fn backtrace_frame_is_routine(attributes: &std::sync::Arc<crate::value::InstanceAttrs>) -> bool {
+    let subname = attributes
+        .as_map()
+        .get("subname")
+        .map(|v| v.to_string_value())
+        .unwrap_or_default();
+    !subname.is_empty() && subname != "<unit>"
+}
+
 /// Re-export raku_value for backward compatibility.
 pub use raku_repr::raku_value;
 
@@ -1280,11 +1315,35 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         .unwrap_or(0);
                     return Some(Ok(Value::str(format!("Backtrace({} frames)", count))));
                 }
-                "list" | "List" => {
+                "list" | "List" | "flat" | "Seq" => {
                     if let Some(frames) = attributes.as_map().get("frames") {
                         return Some(Ok(frames.clone()));
                     }
                     return Some(Ok(Value::array(vec![])));
+                }
+                "concise" | "summary" => {
+                    let frames = attributes
+                        .as_map()
+                        .get("frames")
+                        .map(crate::runtime::utils::value_to_list)
+                        .unwrap_or_default();
+                    let want_summary = method == "summary";
+                    let mut out = String::new();
+                    for frame in &frames {
+                        if let Value::Instance { attributes: fa, .. } = frame {
+                            let is_routine = backtrace_frame_is_routine(fa);
+                            // is-hidden / is-setting are always false here (mutsu
+                            // does not track hidden or CORE-setting frames).
+                            // concise: only non-hidden, non-setting routines.
+                            // summary: non-hidden items that are routines or
+                            // non-setting (i.e. everything here).
+                            let keep = if want_summary { true } else { is_routine };
+                            if keep {
+                                out.push_str(&backtrace_frame_str(fa));
+                            }
+                        }
+                    }
+                    return Some(Ok(Value::str(out)));
                 }
                 "elems" => {
                     if let Some(frames) = attributes.as_map().get("frames") {
@@ -1319,32 +1378,36 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         .unwrap_or(Value::Int(0))));
                 }
                 "Str" | "gist" => {
+                    return Some(Ok(Value::str(backtrace_frame_str(attributes))));
+                }
+                "code" => {
+                    // The Code object for this frame. mutsu does not retain the
+                    // actual routine, so synthesize a Routine carrying the name
+                    // (`.code.name` is the documented use).
                     let subname = attributes
                         .as_map()
                         .get("subname")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
-                    let file = attributes
+                    return Some(Ok(Value::Routine {
+                        package: Symbol::intern("GLOBAL"),
+                        name: Symbol::intern(&subname),
+                        is_regex: false,
+                    }));
+                }
+                "name" => {
+                    return Some(Ok(attributes
                         .as_map()
-                        .get("file")
-                        .map(|v| v.to_string_value())
-                        .unwrap_or_default();
-                    let line = attributes
-                        .as_map()
-                        .get("line")
-                        .map(|v| v.to_string_value())
-                        .unwrap_or_else(|| "0".to_string());
-                    if subname == "<unit>" {
-                        return Some(Ok(Value::str(format!(
-                            "  in block <unit> at {} line {}",
-                            file, line
-                        ))));
-                    } else {
-                        return Some(Ok(Value::str(format!(
-                            "  in sub {} at {} line {}",
-                            subname, file, line
-                        ))));
-                    }
+                        .get("subname")
+                        .cloned()
+                        .unwrap_or(Value::str(String::new()))));
+                }
+                "is-routine" => {
+                    return Some(Ok(Value::Bool(backtrace_frame_is_routine(attributes))));
+                }
+                "is-hidden" | "is-setting" => {
+                    // mutsu does not track hidden or CORE-setting frames.
+                    return Some(Ok(Value::Bool(false)));
                 }
                 _ => {}
             }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -339,6 +339,37 @@ impl Interpreter {
         {
             return self.call_method_with_values(target, "sum", Vec::new());
         }
+        // A Backtrace is a List of Backtrace::Frame: list-iteration methods
+        // (grep/map/first/...) operate on its frames, not the Backtrace itself.
+        if let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = &target
+            && class_name.resolve() == "Backtrace"
+            && matches!(
+                method,
+                "grep"
+                    | "map"
+                    | "first"
+                    | "join"
+                    | "sort"
+                    | "reverse"
+                    | "head"
+                    | "tail"
+                    | "kv"
+                    | "pairs"
+                    | "Array"
+                    | "cache"
+            )
+        {
+            let frames = attributes
+                .as_map()
+                .get("frames")
+                .cloned()
+                .unwrap_or_else(|| Value::array(vec![]));
+            return self.call_method_with_values(frames, method, args);
+        }
         // Scalar containers are transparent for method dispatch (except .item and .VAR)
         if let Value::Scalar(inner) = target {
             if method == "VAR" {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -212,6 +212,47 @@ impl Interpreter {
             err.return_value = Some(target);
             return Err(err);
         }
+        // `.throw`/`.rethrow` on an exception instance: attach a backtrace built
+        // from the current call stack. The `die`/`fail` opcodes do this, but an
+        // explicit `ExceptionObject.throw` goes through method dispatch and would
+        // otherwise carry no frames (so `.backtrace.list` would be empty).
+        let target = if matches!(method, "throw" | "rethrow")
+            && args.is_empty()
+            && matches!(
+                &target,
+                Value::Instance { class_name, attributes, .. }
+                    if {
+                        let cn = class_name.resolve();
+                        (cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::"))
+                            && !attributes.as_map().contains_key("backtrace")
+                    }
+            ) {
+            if let Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } = &target
+            {
+                let backtrace_val = self.build_backtrace_value();
+                let mut new_attrs = attributes.as_map().clone();
+                new_attrs.insert("backtrace".to_string(), backtrace_val);
+                if let Some(line) = self.current_source_line() {
+                    new_attrs
+                        .entry("line".to_string())
+                        .or_insert_with(|| Value::Int(line as i64));
+                }
+                if let Some(file) = self.current_source_file() {
+                    new_attrs
+                        .entry("file".to_string())
+                        .or_insert_with(|| Value::str_from(&file));
+                }
+                Value::make_instance(*class_name, new_attrs)
+            } else {
+                target
+            }
+        } else {
+            target
+        };
         // Autovivify a typed array element when a mutating array method is called
         // on its (undefined) type object, e.g. `my Array of Int @x; @x[0].push(3)`
         // reads `@x[0]` as the `Array[Int]` type object — pushing builds a fresh

--- a/t/backtrace-frame.t
+++ b/t/backtrace-frame.t
@@ -1,0 +1,55 @@
+use Test;
+
+plan 14;
+
+# Backtrace::Frame methods and Backtrace list-iteration.
+
+{
+    my sub foo { fail }();
+    CATCH { default {
+        my $bt = .backtrace;
+        isa-ok $bt.list[0], Backtrace::Frame, '.list yields Backtrace::Frame objects';
+        is $bt.list[0].code.name, 'foo', '.code.name returns the routine name';
+        ok $bt.list[0].is-routine, 'named frame .is-routine is True';
+        nok $bt.list[0].is-hidden, '.is-hidden is False';
+        nok $bt.list[0].is-setting, '.is-setting is False';
+        is-deeply $bt.flat, $bt.list, '.flat returns the same as .list';
+    }}
+}
+
+{
+    my sub bar { die }();
+    CATCH { default {
+        my $bt = .backtrace;
+        # .concise == grep(routine, non-hidden, non-setting).join
+        is $bt.concise,
+            $bt.grep({ !.is-hidden && .is-routine && !.is-setting }).join,
+            '.concise matches the documented grep';
+        is $bt.summary,
+            $bt.grep({ !.is-hidden && (.is-routine || !.is-setting) }).join,
+            '.summary matches the documented grep';
+        ok $bt.list.elems >= 1, 'die backtrace has at least one frame';
+    }}
+}
+
+# A thrown exception object carries a non-empty backtrace.
+{
+    my sub baz { X::AdHoc.new(payload => "boom").throw }();
+    CATCH { default {
+        my $bt = .backtrace;
+        ok $bt.list.elems >= 1, 'thrown exception has a backtrace';
+        ok $bt.list.all ~~ Backtrace::Frame, 'thrown backtrace frames are Backtrace::Frame';
+        ok $bt.list.grep(*.is-routine).elems >= 1, 'thrown backtrace has a routine frame';
+    }}
+}
+
+# <unit> frame: not a routine, code.name is <unit>.
+{
+    my sub qux { die }();
+    CATCH { default {
+        my $bt = .backtrace;
+        my @units = $bt.list.grep({ .subname eq '<unit>' });
+        ok @units.elems >= 1, 'a <unit> frame exists';
+        nok @units[0].is-routine, '<unit> frame is not a routine';
+    }}
+}


### PR DESCRIPTION
## Summary

`Backtrace::Frame` instances lacked `.code`, `.is-routine`, `.is-hidden`, `.is-setting`, and `.name`. Calling `.code.name` inside a `CATCH` block threw `No such method 'code' for invocant of type 'Backtrace::Frame'`, which propagated out and **aborted the whole file mid-run**. In `S32-exceptions/misc.t` this silently killed the tail 25 subtests (only 157 of 182 ran).

## Changes

- **Backtrace::Frame**: `.code` (synthesized `Routine` carrying the subname — `.code.name` is the documented use), `.name`, `.is-routine` (true for a real subname, not `<unit>`/anon), `.is-hidden`/`.is-setting` (always `False`; mutsu tracks neither). `.Str`/`.gist` refactored onto a shared `backtrace_frame_str` helper.
- **Backtrace**: `.concise`/`.summary` (computed via the same helper so they stay byte-identical to a `.grep(...).join`), plus `.flat`/`.Seq` aliases of `.list`.
- A `Backtrace` now delegates list-iteration methods (`grep`/`map`/`first`/`join`/...) to its `frames`, so `$bt.grep({ .is-routine })` works instead of treating the whole Backtrace as one element.
- **`ExceptionObject.throw`/`.rethrow`** now attach a backtrace built from the call stack (mirroring the `die`/`fail` opcodes), preserving any existing `.line`/`.file`. Previously a thrown object's `.backtrace.list` was empty (`("",)`).

## Result

`S32-exceptions/misc.t` now runs **180/182** (was 157) and passes **88** (was 72). Tests 156, 158, 159, 160, 162–164 now pass. The two still failing hard-code `$bt.list.elems == 4` — an implementation-detail frame count (raku captures the `.throw` invocation + an anonymous block) that mutsu's call stack does not reproduce.

New test `t/backtrace-frame.t` (14 subtests). `make test` passes (8769); whitelisted `misc2.t` (265) and `constant-6.d.t` (25) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)