### PR TITLE
docs(single-store): record Slice D (R3 blanket-mark removal) as audited-complete

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -115,12 +115,15 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
 要旨: reverse sync を**削除せず**、per-`GetLocal` の coarse な `env_dirty`+全 locals スキャンから
 **carrier 境界での精密な書き込み名のみ writeback** へ再配置 → hot path から同期ロジックを消す。スライス順:
 
-- [ ] **Slice A** — invariant guard + 計測（`MUTSU_VM_STATS` で stale slot / 書き手を記録、挙動不変）。
-- [ ] **Slice B** — `EVAL` 精密 writeback（R2 旗艦・CP-2 ブロッカーが解けることの証明）。
-- [ ] **Slice C** — R1 reverse write-through（our/dynamic/`&sub` 登録等の by-name 書き手を slot 経由化）。
-- [ ] **Slice D** — R3 blanket-mark 撲滅（dispatch tier の精密 flag で冗長な post-dispatch mark を削除）。
+- [x] **Slice A** — invariant guard + 計測（#3219, MERGED）。
+- [x] **Slice B** — `EVAL` 精密 writeback（#3222, MERGED）+ EVAL carrier env_dirty drop（#3227）。
+- [~] **Slice C** — R1 reverse write-through。**実測で SUPERSEDED**（our/dynamic/push/call は既に pull 1–2・effective=0）。
+- [~] **Slice C′** — open-q#2 の regex 経路 + bareword carrier 一般化（#3231）+ EVAL内 `$x ~~ s///` writeback 穴修正（#3237）。
+      **残: `pairs`/`slip` 一般化 = deep `:=` bind-cell coherence（CP-2 壁）の解決が前提＝延期。**
+- [x] **Slice D** — R3 blanket-mark 撲滅。**監査で完了確認（2026-06-18）**: 明確な冗長は #2709/method_dispatch_pure で既に除去済。
+      残る ≈140 の `env_dirty=true` は ①精密ゲート本体 ②正当な mutation（push/mut-method/registration）③carrier/block net（精密化＝carrier-drop 領域）で、安全に削除できる冗長は無し。測定でも spurious は全ベンチ 1〜4 pull。詳細＝docs/vm-single-store.md。
 - [ ] **Slice E** — closure upvalue 化（prereq①・`compute_needs_env_sync` 撤去・最高リスク・最後）。
-- [ ] **Slice F** — coarse 機構削除（`env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`/`saved_env_dirty`）。
+- [ ] **Slice F** — coarse 機構削除（`env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`/`saved_env_dirty`）。**真の前提＝deep `:=` cell coherence の env↔locals 乖離解決（CP-2 壁）。**
 - [ ] **Slice G**（後続・任意）— env の on-demand materialization（per-call `clone_env` を lazy overlay 化）。
 
 ### 第一級コンテナ Phase 2 → Phase 3（要素セル → 属性セル）

--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -393,11 +393,35 @@ for wall-clock.
   > `pairs`/`slip` generalization needs not just complete write-logging but a
   > solution to deep-cell env↔locals coherence — deferred.
 
-- **Slice D — finish R3 blanket-mark removal.**
-  Audit each remaining post-dispatch blanket against its tier's precise flag;
-  delete the redundant ones. Gate: method/function/closure roast; the existing
-  `t/method-env-dirty.t` / `t/named-call-env-dirty.t` / `t/zeroarg-env-dirty.t`
-  pins must stay green with `locals_pulls` unchanged or lower.
+- **Slice D — finish R3 blanket-mark removal. AUDITED COMPLETE (2026-06-18).**
+  A full audit of every `self.env_dirty = true` site (≈140 across `src/vm/`)
+  against `MUTSU_VM_STATS` reverse-sync counters found **no significant redundant
+  blanket left to remove**: the clear post-precise-dispatch redundancies were
+  already deleted in #2709 (compiled-function `changed`-merge signal) and the
+  Slice 6.3 `method_dispatch_pure` gate. The remaining marks fall into three
+  categories, **none of which is redundant**:
+  1. *The precise gate itself* — `let mark_dirty = !self.method_dispatch_pure; if
+     mark_dirty { self.env_dirty = true }` (the CallMethod/CallMethodMut tails,
+     `vm_call_method_ops.rs` / `vm_call_method_mut_ops.rs`) and the compiled-call
+     `env_dirty = saved || changed` in `call_compiled_function_named`. These *are*
+     the precision; deleting them loses correctness, not redundancy.
+  2. *Legitimate mutations* — `@a.push` and friends (`vm_data_ops.rs`), mutating
+     methods (`vm_call_method_mut_ops.rs`), declaration registration
+     (`vm_register_ops.rs`). These genuinely write a caller variable in `env`, so
+     the mark is required until the writer self-reports per-name (Slice F).
+  3. *Carrier / block nets* — bareword-resolved-to-call (`vm_var_get_ops.rs`),
+     interpreter fallbacks (`exec_call_*`), and control-flow block bodies
+     (`vm_control_ops.rs`). Making these precise is the **carrier-drop** work
+     (Slice B/C′), not a blanket *removal* — and it is gated by the same
+     completeness + deep-`:=`-cell-coherence wall that defers `pairs`/`slip`.
+  *Measurement:* `method-call` reverse-sync `locals_pulls=1`, `bench-class` 2,
+  `bench-array` 4, `bench-hash`/`bench-string` 3 — i.e. single-digit pulls per
+  *entire* benchmark, ~all one-time boundary marks, not per-iteration. The
+  spurious traffic Slice D set out to remove is already gone. **Conclusion: Slice
+  D needs no code change; advancing further means Slice E (upvalues) or the
+  deferred carrier-drop completeness work, not more blanket deletion.** Pins
+  (`t/method-env-dirty.t` / `t/named-call-env-dirty.t` / `t/zeroarg-env-dirty.t`)
+  remain the regression guard for the precise gates.
 
 - **Slice E — closure upvalues (prereq #1).**
   Capture free vars as indexed upvalue cells; remove `compute_needs_env_sync`

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1006,3 +1006,7 @@ drop で喪失（`EVAL '$x ~~ s/ab/xy/'` が `$x` を変えない）。汎用ヘ
   bound scalar 経由の cell 書込が name-trackable でない aliased container（`$struct`）を変異させ、carrier の reconcile/pull と
   cell-linked container の env↔locals 表現乖離の相互作用が container を能動的に破壊（`Nil` 読み戻し）。CP-2 と同じ壁。
   ゆえに `pairs`/`slip` 一般化は完全な write-logging だけでなく deep-cell coherence の解決も要する＝延期。
+
+### 2026-06-18: Slice D（R3 blanket-mark 撲滅）— 監査で完了確認（コード変更なし）
+
+`src/vm/` の全 `self.env_dirty = true`（≈140 箇所）を `MUTSU_VM_STATS` reverse-sync カウンタと照合して監査。**安全に削除できる冗長 blanket は残っていない**と確認: 明確な post-precise-dispatch 冗長は #2709（compiled-fn の `changed`-merge signal）と Slice 6.3 の `method_dispatch_pure` ゲートで既に除去済み。残る marks は3カテゴリで**いずれも冗長でない**: ①精密ゲート本体（`if mark_dirty { env_dirty=true }`・compiled-call の `saved||changed`＝精密そのもの）②正当な mutation（`@a.push`/mut-method/宣言 registration＝実際に caller 変数を env で書く）③carrier/block net（bareword→call・interpreter fallback・control-flow ブロック＝精密化は carrier-drop 作業で、`pairs`/`slip` と同じ deep-cell 壁でゲート）。測定: `method-call` reverse-sync pull=1・`bench-class`=2・`bench-array`=4・`bench-hash`/`bench-string`=3＝ベンチ全体で一桁（per-iteration でなく境界の一度きり）。Slice D が狙った spurious traffic は既に枯渇。**結論: Slice D はコード変更不要。次の前進は Slice E（upvalue）か延期中の carrier-drop completeness。** docs/vm-single-store.md / PLAN.md に記録。


### PR DESCRIPTION
## Summary

Proceeding with **Slice D — R3 blanket-mark removal** ([docs/vm-single-store.md](../blob/main/docs/vm-single-store.md)) independently, I audited every `self.env_dirty = true` site (~140 across `src/vm/`) against `MUTSU_VM_STATS` reverse-sync counters. **Finding: no significant redundant blanket is left to remove** — so this is a docs-only PR recording that conclusion (rather than manufacturing risky removals for zero gain).

### Why nothing remains to remove
The clear post-precise-dispatch redundancies were already deleted in #2709 (the compiled-function `changed`-merge signal) and the Slice 6.3 `method_dispatch_pure` gate. The remaining marks are all one of:

1. **The precise gate itself** — `let mark_dirty = !self.method_dispatch_pure; if mark_dirty { env_dirty = true }` (CallMethod/CallMethodMut tails) and `env_dirty = saved || changed` in `call_compiled_function_named`. These *are* the precision.
2. **Legitimate mutations** — `@a.push`, mutating methods, declaration registration. They genuinely write a caller variable in `env`.
3. **Carrier / block nets** — bareword-resolved-to-call (`vm_var_get_ops`), interpreter fallbacks (`exec_call_*`), control-flow block bodies (`vm_control_ops`). Making these precise is the **carrier-drop** work (Slice B/C′), not a blanket *removal* — gated by the same completeness + deep-`:=`-cell-coherence wall that defers `pairs`/`slip`.

### Measurement
reverse-sync `locals_pulls` per *entire* benchmark: `method-call` 1, `bench-class` 2, `bench-array` 4, `bench-hash`/`bench-string` 3 — single-digit, ~all one-time boundary marks (not per-iteration). The spurious traffic Slice D set out to remove is already gone.

**Conclusion:** Slice D needs no code change; advancing the single-store campaign further means Slice E (upvalues) or the deferred carrier-drop completeness work, not more blanket deletion.

## Test plan
Docs-only (`docs/vm-single-store.md`, `PLAN.md`, `news/2026-06.md`); no code change. CI runs `make test` + `make roast` as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)