### PR TITLE
feat(exceptions): X::Parameter::InvalidConcreteness for fail/die/throw on a type object

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,8 +125,14 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 88/180 pass (plan 182). This is a very broad compile-time-error/exception file
+  - 93/180 pass (plan 182). This is a very broad compile-time-error/exception file
     covering ~40 distinct features.
+  - Done: `fail`/`die`/`throw`/`rethrow`/`resume` called on an Exception *type
+    object* (`X::NYI.throw`) -> X::Parameter::InvalidConcreteness (was "no such
+    method"). Shared `exception_concreteness_error` helper, wired into BOTH the
+    CallMethod and CallMethodMut dispatch (a bareword-target `X::Foo.throw`
+    compiles to CallMethodMut). Recognizes Exception/X::*/CX::* and user
+    subclasses via `class_inherits_from_exception` (parent-chain walk). Tests 90-94.
   - Done: Backtrace/Backtrace::Frame methods — `.code`(->Routine), `.name`,
     `.is-routine`, `.is-hidden`, `.is-setting` on a frame; `.concise`/`.summary`/`.flat`
     on a Backtrace; Backtrace list-iteration (`.grep`/`.map`/`.first`/... delegate to

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5419,6 +5419,36 @@ impl Interpreter {
     }
 
     /// Check if a class inherits from an immutable Setty type (Set, Bag, Mix).
+    /// Whether a user-declared class `name` inherits (transitively) from the base
+    /// `Exception` type (or a built-in `X::`/`CX::` exception). Walks the registry
+    /// parent chain with a shared borrow.
+    pub(crate) fn class_inherits_from_exception(&self, name: &str) -> bool {
+        let parents = {
+            let reg = self.registry();
+            reg.classes
+                .get(name)
+                .or_else(|| {
+                    reg.classes
+                        .iter()
+                        .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
+                        .map(|(_, v)| v)
+                })
+                .map(|cd| cd.parents.clone())
+        };
+        if let Some(parents) = parents {
+            for parent in &parents {
+                if parent == "Exception"
+                    || parent.starts_with("X::")
+                    || parent.starts_with("CX::")
+                    || self.class_inherits_from_exception(parent)
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     pub(crate) fn class_inherits_from_immutable_setty(&self, name: &str) -> bool {
         const IMMUTABLE_SETTY: &[&str] = &["Set", "Bag", "Mix"];
         if IMMUTABLE_SETTY.contains(&name) {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -352,6 +352,12 @@ impl Interpreter {
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethodMut target".to_string())
         })?;
+        // `X::Foo.throw`/`.fail`/... on an Exception type object (compiled here
+        // because the bareword target routes through CallMethodMut) requires a
+        // concrete invocant: X::Parameter::InvalidConcreteness.
+        if let Some(err) = self.exception_concreteness_error(&method, &args, &target) {
+            return Err(err);
+        }
         // Force lazy IO lines for non-lazy-preserving methods
         let target = if matches!(&target, Value::LazyIoLines { .. })
             && !matches!(method.as_str(), "kv" | "iterator" | "lazy")

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -159,6 +159,42 @@ impl Interpreter {
         }
     }
 
+    /// `fail`/`die`/`throw`/`rethrow`/`resume` require a concrete (instance)
+    /// invocant. Calling one on an Exception *type object* (e.g. `X::NYI.throw`)
+    /// is `X::Parameter::InvalidConcreteness`, not "no such method". Shared by the
+    /// CallMethod and CallMethodMut dispatch paths (a bareword-target method call
+    /// like `X::NYI.throw` compiles to CallMethodMut).
+    pub(super) fn exception_concreteness_error(
+        &self,
+        method: &str,
+        args: &[Value],
+        target: &Value,
+    ) -> Option<RuntimeError> {
+        if !matches!(method, "fail" | "die" | "throw" | "rethrow" | "resume") || !args.is_empty() {
+            return None;
+        }
+        let Value::Package(type_name) = target else {
+            return None;
+        };
+        let name = type_name.resolve();
+        let is_exc = name == "Exception"
+            || name.starts_with("X::")
+            || name.starts_with("CX::")
+            || self.class_inherits_from_exception(&name);
+        if is_exc {
+            Some(RuntimeError::parameter_invalid_concreteness(
+                "Exception",
+                &name,
+                method,
+                "",
+                true,
+                true,
+            ))
+        } else {
+            None
+        }
+    }
+
     pub(super) fn exec_call_method_op(
         &mut self,
         code: &CompiledCode,
@@ -253,6 +289,12 @@ impl Interpreter {
         } else {
             target
         };
+        // `fail`/`die`/`throw`/`rethrow`/`resume` require a concrete (instance)
+        // invocant. Calling one on an Exception *type object* (e.g. `X::NYI.throw`)
+        // is X::Parameter::InvalidConcreteness, not "no such method".
+        if let Some(err) = self.exception_concreteness_error(method, &args, &target) {
+            return Err(err);
+        }
         // Autovivify a typed array element when a mutating array method is called
         // on its (undefined) type object, e.g. `my Array of Int @x; @x[0].push(3)`
         // reads `@x[0]` as the `Array[Int]` type object — pushing builds a fresh

--- a/t/exception-concreteness.t
+++ b/t/exception-concreteness.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 9;
+
+# fail/die/throw/rethrow/resume on an Exception *type object* require a concrete
+# invocant -> X::Parameter::InvalidConcreteness (not "no such method").
+
+for <fail die throw rethrow resume> -> $meth {
+    throws-like 'X::AdHoc.' ~ $meth, X::Parameter::InvalidConcreteness,
+        should-be-concrete => 'True',
+        param-is-invocant  => 'True',
+        routine            => $meth;
+}
+
+# A concrete exception instance still throws/carries its message.
+my $caught;
+{ X::AdHoc.new(payload => "boom").throw; CATCH { default { $caught = .message } } }
+is $caught, 'boom', 'thrown instance carries message';
+
+# die/fail as plain functions are unaffected.
+my $d;
+{ die "func die"; CATCH { default { $d = .message } } }
+is $d, 'func die', 'die function still works';
+
+# A non-exception type object stays X::Method::NotFound (not InvalidConcreteness).
+throws-like 'Int.throw', X::Method::NotFound, 'non-exception type object stays NotFound';
+
+# A user-declared Exception subclass type object is also caught.
+throws-like 'class MyErr is Exception {}; MyErr.throw', X::Parameter::InvalidConcreteness,
+    'user Exception subclass type object';


### PR DESCRIPTION
## Summary

`X::NYI.throw` (and `.fail`/`.die`/`.rethrow`/`.resume`) called on an Exception **type object** require a concrete invocant. mutsu reported `No such method 'throw' for invocant of type 'X::NYI'`; raku throws **X::Parameter::InvalidConcreteness**:

> Invocant of method 'throw' must be an object instance of type 'Exception', not a type object of type 'X::NYI'.  Did you forget a '.new'?

## Changes

- New shared `exception_concreteness_error(method, args, target)` helper, wired into **both** the `CallMethod` and `CallMethodMut` dispatch paths — a bareword-target method call like `X::NYI.throw` compiles to `CallMethodMut`, which is why a single-path check did not fire.
- Recognizes `Exception` / `X::*` / `CX::*` by name, and **user-declared subclasses** via a new `class_inherits_from_exception` (registry parent-chain walk, shared-borrow, mirrors `class_inherits_from_immutable_setty`).
- A concrete instance (`$exc.throw`), a non-exception type object (`Int.throw` stays `X::Method::NotFound`), and the `die`/`fail` **functions** are all unaffected.

## Result

Fixes `S32-exceptions/misc.t` tests 90–94 (the `for <fail die throw rethrow resume>` loop). misc.t now passes **93/180** (was 88). New test `t/exception-concreteness.t` (9 subtests). `make test` passes; whitelisted `misc2.t`, `exceptions-alternatives.t`, `fail-6e.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)