### PR TITLE
fix(typecheck): .expected is the Nil type object for type-check exceptions

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -137,6 +137,12 @@
   - Still failing: tests 157 & 161 hard-code `$bt.list.elems == 4` (raku captures 4
     internal frames incl. the `.throw` invocation + an anonymous block; mutsu's call
     stack yields 2) — implementation-detail counts, not worth matching.
+  - Done: `.expected` of type-check exceptions is now the expected type OBJECT for
+    `Nil` too — tests 108/109 (`my Nil $a = 3`, `sub aa(Nil $a){}; aa(3)`). The Nil
+    type object is `Value::Nil`, not `Package("Nil")`, so `expected => Nil` matchers
+    failed (`Package("Nil") !~~ Nil`). New `value::error::expected_type_object(name)`
+    maps "Nil" -> Value::Nil, used by the assignment/binding(:=)/binding-parameter
+    type-check constructors.
   - Done: undeclared type-PARAMETER argument (`my Array[Numerix] $x`) -> X::Undeclared::Symbols
     (gist mentions the name) — test 453 (462 in misc.t numbering). New
     `check_eval_undeclared_type_args` pre-pass walks VarDecl/param/return type constraints,

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3625,7 +3625,7 @@ pub(crate) fn type_check_binding_typed_error(expected: &str, val: &Value) -> Run
     let mut attrs = std::collections::HashMap::new();
     attrs.insert(
         "expected".to_string(),
-        Value::Package(crate::symbol::Symbol::intern(expected)),
+        crate::value::expected_type_object(expected),
     );
     attrs.insert("got".to_string(), val.clone());
     attrs.insert("operation".to_string(), Value::str("bind".to_string()));
@@ -3661,7 +3661,7 @@ pub(crate) fn type_check_assignment_typed_error(
     // `expected => Int` / `got => 'foo'` succeed.
     attrs.insert(
         "expected".to_string(),
-        Value::Package(crate::symbol::Symbol::intern(expected)),
+        crate::value::expected_type_object(expected),
     );
     attrs.insert("got".to_string(), val.clone());
     attrs.insert("symbol".to_string(), Value::str(display_name));

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -71,6 +71,18 @@ pub struct RuntimeError {
     pub backtrace: Option<String>,
 }
 
+/// The runtime type-object Value for a type *name*, used as the `.expected`
+/// attribute of type-check exceptions. Most types map to `Package(name)`
+/// (`Package("Int") ~~ Int` is True), but a few core type objects have a
+/// dedicated Value representation — notably `Nil`, whose type object is
+/// `Value::Nil` (so a `Package("Nil")` would fail `~~ Nil` / `=== Nil`).
+pub(crate) fn expected_type_object(name: &str) -> Value {
+    match name {
+        "Nil" => Value::Nil,
+        _ => Value::Package(Symbol::intern(name)),
+    }
+}
+
 impl RuntimeError {
     pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
@@ -821,10 +833,7 @@ impl RuntimeError {
             )
         };
         let mut attrs = HashMap::new();
-        attrs.insert(
-            "expected".to_string(),
-            Value::Package(crate::symbol::Symbol::intern(expected)),
-        );
+        attrs.insert("expected".to_string(), expected_type_object(expected));
         attrs.insert("got".to_string(), got_value.clone());
         if let Some(sym) = symbol {
             attrs.insert("symbol".to_string(), Value::str(sym.to_string()));
@@ -957,7 +966,8 @@ impl RuntimeError {
         });
         let mut attrs = HashMap::new();
         attrs.insert("parameter".to_string(), Value::str(param.to_string()));
-        attrs.insert("expected".to_string(), Value::str(expected.to_string()));
+        // raku exposes `.expected` as the expected type OBJECT.
+        attrs.insert("expected".to_string(), expected_type_object(expected));
         attrs.insert("got".to_string(), Value::str(got.to_string()));
         attrs.insert("message".to_string(), Value::str(msg.clone()));
         Self::typed("X::TypeCheck::Binding::Parameter", attrs)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -483,6 +483,7 @@ pub(crate) fn current_time_secs_f64() -> f64 {
 
 pub(crate) use display::is_internal_anon_type_name;
 pub use display::{format_complex, tclc_str, wordcase_str};
+pub(crate) use error::expected_type_object;
 pub use error::{RuntimeError, RuntimeErrorCode};
 // SubData is re-exported so callers can destructure Value::Sub(data)
 

--- a/t/typecheck-expected-nil.t
+++ b/t/typecheck-expected-nil.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 6;
+
+# The `.expected` attribute of a type-check exception is the expected type
+# OBJECT, so a `expected => Nil` matcher (Nil's type object is special) works.
+
+throws-like 'my Nil $a = 3', X::TypeCheck::Assignment, expected => Nil,
+    'assignment to a Nil-typed scalar';
+
+throws-like 'sub aa (Nil $a) { }; my $b = 3; aa($b)', X::TypeCheck::Binding,
+    expected => Nil, 'binding to a Nil-typed parameter';
+
+throws-like 'my Nil $a := 3', X::TypeCheck::Binding, expected => Nil,
+    'binding (:=) to a Nil-typed scalar';
+
+# Non-Nil expected types still compare correctly (Package-backed type objects).
+throws-like 'my Int $a = "x"', X::TypeCheck::Assignment, expected => Int,
+    'Int expected still matches';
+
+# .expected identity / smartmatch against the real Nil type object.
+{
+    my $ex;
+    { my Nil $a = 3; CATCH { default { $ex = $_ } } }
+    ok $ex.expected === Nil, '.expected === Nil';
+    ok $ex.expected ~~ Nil, '.expected ~~ Nil';
+}


### PR DESCRIPTION
## Summary

A `expected => Nil` matcher on `X::TypeCheck::Assignment` / `X::TypeCheck::Binding` failed because mutsu stored `.expected` as `Package("Nil")`, but Nil's runtime type object is `Value::Nil` — so `Package("Nil") !~~ Nil` and `!=== Nil`. Most types are fine as `Package(name)` (`Package("Int") ~~ Int` is True); `Nil` is the special case.

## Changes

- New `value::error::expected_type_object(name)` maps `"Nil"` → `Value::Nil` (else `Package(name)`).
- Used by the assignment, binding (`:=`), and binding-parameter type-check constructors so `.expected` of a Nil-typed failure now `=== Nil` and `~~ Nil`.

## Result

Fixes `S32-exceptions/misc.t` tests 108–109 (`my Nil $a = 3`, `sub aa(Nil $a){}; aa(3)`). New test `t/typecheck-expected-nil.t` (6 subtests). `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)