### PR TITLE
fix(regex): `$x ~~ s///` inside a `for ^N` loop wrongly threw "Cannot modify an immutable Str"

### DIFF
--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1218,6 +1218,28 @@ impl Interpreter {
         self.pending_local_updates.clear();
         let saved_topic = self.env().get("_").cloned();
         self.env_mut().insert("_".to_string(), left.clone());
+        // While the RHS runs, `$_` is *aliased* to the LHS variable (`$x ~~ s///`
+        // topicalizes `$x`). A destructive `s///`/`tr///` checks `$_`'s readonly
+        // status, but the enclosing scope may have marked `_` readonly for an
+        // unrelated reason — e.g. a `for ^N { $x ~~ s/// }` loop marks its *topic*
+        // `_` readonly. The match's `_` must instead reflect the *aliased
+        // variable*'s mutability: mutable `my $x` allows the write, a readonly
+        // param still blocks it. Save and override `_`'s readonly flag for the
+        // duration when the LHS is an explicit variable other than the topic.
+        let topic_ro_override = match lhs_var {
+            Some(v) if v != "_" => {
+                let saved = self.is_readonly("_");
+                let bare = v.trim_start_matches(['$', '@', '%', '&']);
+                let target_ro = self.is_readonly(v) || self.is_readonly(bare);
+                if target_ro {
+                    self.mark_readonly("_");
+                } else {
+                    self.unmark_readonly("_");
+                }
+                Some(saved)
+            }
+            _ => None,
+        };
         // Sync env->locals first so that any values modified by interpreter
         // calls (e.g. EVAL modifying $GLOBAL:: variables) are picked up
         // before we overwrite env with local values for regex interpolation.
@@ -1236,6 +1258,15 @@ impl Interpreter {
         let was_substitution = self.substitution_in_smartmatch;
         self.transliterate_in_smartmatch = false;
         self.substitution_in_smartmatch = false;
+        // Restore the topic's readonly flag (overridden above for an aliased LHS
+        // variable) on every path, including the error path below.
+        if let Some(saved) = topic_ro_override {
+            if saved {
+                self.mark_readonly("_");
+            } else {
+                self.unmark_readonly("_");
+            }
+        }
         rhs_run?;
         let right = self.stack.pop().unwrap_or(Value::Nil);
         // A destructive `s///`/`tr///` that actually matched against a string

--- a/t/loop-subst-readonly-topic.t
+++ b/t/loop-subst-readonly-topic.t
@@ -1,0 +1,70 @@
+use Test;
+
+# Regression: a `for ^N { ... }` / `for 0..N { ... }` loop (the int-range fast
+# path) marks its implicit topic `$_` readonly for the loop body. A `$x ~~ s///`
+# inside the body topicalizes `$x` — `$_` is *aliased* to `$x` for the match — so
+# the substitution's readonly check must reflect `$x`'s mutability, not the
+# loop topic's. Previously the stale readonly mark on `_` made the s/// throw
+# "Cannot modify an immutable Str" even though `$x` is a mutable `my` variable.
+
+plan 9;
+
+# 1. the core case: explicit mutable LHS in an int-range loop
+{
+    my $x = "0000";
+    for ^2 { $x ~~ s/0/1/; }
+    is $x, "1100", '$x ~~ s/// inside for ^N mutates the mutable $x';
+}
+
+# 2. single iteration
+{
+    my $x = "00";
+    for ^1 { $x ~~ s/0/1/; }
+    is $x, "10", 'for ^1 { $x ~~ s/// } works';
+}
+
+# 3. explicit range form
+{
+    my $x = "aaaa";
+    for 0..2 { $x ~~ s/a/b/; }   # 0,1,2 = 3 iterations, one leftmost `a` each
+    is $x, "bbba", 'for 0..N { $x ~~ s/// } mutates $x once per iteration (first match)';
+}
+
+# 4. global substitution per iteration
+{
+    my $x = "aaaa";
+    for ^2 { $x ~~ s:g/a/b/; }
+    is $x, "bbbb", 'for ^N { $x ~~ s:g/// } works';
+}
+
+# 5. nested int-range loops
+{
+    my $x = "0000";
+    for ^2 { for ^2 { $x ~~ s/0/9/; } }
+    is $x, "9999", 'nested for ^N loops mutate $x';
+}
+
+# 6. tr/// with explicit var in an int-range loop (was already OK; guard it)
+{
+    my $x = "aaa";
+    for ^2 { $x ~~ tr/a/b/; }
+    is $x, "bbb", 'for ^N { $x ~~ tr/// } works';
+}
+
+# 7. interleave with an unrelated hot local
+{
+    my $x = "0000";
+    my $acc = 0;
+    for ^3 { $x ~~ s/0/1/; $acc++; }
+    is "$x/$acc", "1110/3", 's/// + hot local in for ^N both correct';
+}
+
+# 8. the implicit topic is STILL readonly: `s///` on the loop topic must throw
+{
+    dies-ok { for ^2 { s/0/1/; } }, 'bare s/// on the readonly int-range topic still dies';
+}
+
+# 9. explicit `$_ ~~ s///` on the loop topic must also still throw
+{
+    dies-ok { for ^2 { $_ ~~ s/0/1/; } }, '$_ ~~ s/// on the readonly int-range topic still dies';
+}


### PR DESCRIPTION
## Summary

A pre-existing bug (found during the single-store investigation): a `$x ~~ s///` substitution inside a `for ^N` / `for 0..N` loop threw **"Cannot modify an immutable Str"** even though `$x` is a mutable `my` variable.

```raku
my $x = "0000";
for ^2 { $x ~~ s/0/1/; }
say $x;   # threw — now prints "1100" (matches raku)
```

### Root cause
The int-range for-loop fast path (`exec_for_loop_int_range`) marks its implicit topic `$_` readonly for the loop body — which is *correct* for the loop topic itself (`for ^2 { $_ = 5 }` and a bare `s///` must die). But a `$x ~~ s///` inside the body **topicalizes `$x`**: during the smartmatch RHS, `$_` is aliased to `$x`. The substitution's readonly check (`write_subst_topic_checked` reads `readonly_vars().contains("_")`) was seeing the loop topic's stale readonly mark and throwing, instead of checking the aliased variable's mutability.

(Only the int-range fast path marks the topic readonly; `for 1,2 {...}` over a list did not hit it, which is why the bug was source-shape-specific.)

### Fix
In `exec_smart_match_expr_op`, when the LHS is an explicit variable other than the topic, override `$_`'s readonly flag for the duration of the match to reflect the **aliased variable's** mutability (mutable → allow; a readonly param still blocks), saving/restoring it on every path including the error path.

### Verified against raku
- `for ^2 { $x ~~ s/0/1/ }` → `1100` ✓
- bare `s///` and `$_ ~~ s///` on the readonly loop topic **still die** ✓
- readonly-param `$x ~~ s///` **still dies** ✓
- `tr///` with explicit var, nested loops — unaffected ✓

## Test plan
- New pin `t/loop-subst-readonly-topic.t` (9), including the must-still-die cases via `dies-ok`.
- `make test` PASS (cargo 462 + prove 914 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)