### PR TITLE
feat(warnings): "Useless use of X in sink context" inside gather blocks

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,23 +125,25 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 122/180 pass (plan 182). This is a very broad compile-time-error/exception file
+  - 123/180 pass (plan 182). This is a very broad compile-time-error/exception file
     covering ~40 distinct features.
   - Done: "Useless use of X in sink context" warnings (tests 111-114, 116-120,
-    122-137 — the bulk of the 111-142 cluster). New parser post-pass
+    122-138 — the bulk of the 111-142 cluster). New parser post-pass
     `parser::sink_warn` walks the mainline (all-sink) statement list, recursing
     into bare blocks, comma lists, and the bodies of loop/conditional/topicalizer
     statements (NOT routine/package bodies). Flags only pure side-effect-free
     forms: literals, plain variable reads, pure operators over useless operands,
     pairs, and empty `()`. Loop/`given` modifier bodies append the
-    "(use Nil instead...)" hint. t/sink-warning.t.
+    "(use Nil instead...)" hint. A separate `scan_gathers_*` traversal walks the
+    WHOLE tree for `gather { ... }` blocks (always sink-context wherever they
+    appear) and warns their bodies — test 138 (`gather 43`). t/sink-warning.t.
     Still failing in the cluster: 115 (`$y = 1,2,3` — mutsu mis-parses item
     assignment as `$y = (1,2,3)` so the trailing `123` is not sunk; a separate
     precedence bug), 121 (`:foo(42)` — mutsu parses the colonpair identically to
-    `foo => 42`, losing the `:foo()` syntax), 138 (`gather 43` — gather bodies are
-    always-sink but appear as a VarDecl RHS expression the pass does not descend
-    into), 139-142 (special-Num glyph `∞` and source-format preservation for
-    `0xFF`/big-int/long-num literals, which mutsu does not retain).
+    `foo => 42`, losing the `:foo()` syntax), 139-142 (special-Num glyph `∞` and
+    source-format preservation for `0xFF`/big-int/long-num literals, which mutsu
+    does not retain — would require threading literal source text through the AST,
+    which has 600+ `Expr::Literal` construction/match sites).
   - Done: `fail`/`die`/`throw`/`rethrow`/`resume` called on an Exception *type
     object* (`X::NYI.throw`) -> X::Parameter::InvalidConcreteness (was "no such
     method"). Shared `exception_concreteness_error` helper, wired into BOTH the

--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -12,13 +12,206 @@
 //! Anything that may have a side effect (calls, method calls, assignments,
 //! declarations, `say`/`print`, regex matches, ...) is never flagged.
 
-use crate::ast::{Expr, Stmt};
+use crate::ast::{CallArg, Expr, Stmt};
 use crate::token_kind::TokenKind;
 use crate::value::Value;
 
 /// Entry point: emit sink-context warnings for the mainline statement list.
 pub(super) fn add_sink_warnings(stmts: &[Stmt]) {
     walk_stmts(stmts, false);
+    // A `gather { ... }` block evaluates its body in sink context regardless of
+    // where the `gather` appears (mainline, an initializer, inside a sub, an
+    // argument, ...). Scan the whole tree for gather blocks and warn their
+    // bodies, independently of the enclosing statement's own context.
+    scan_gathers_stmts(stmts);
+}
+
+/// Walk the entire program looking for `gather` blocks. For each one, emit sink
+/// warnings for its body. Only `Gather` nodes trigger a warning; every other
+/// node is traversed purely to reach nested gathers, so an unhandled variant can
+/// at worst miss a warning (a false negative), never produce a spurious one.
+fn scan_gathers_stmts(stmts: &[Stmt]) {
+    for stmt in stmts {
+        scan_gathers_stmt(stmt);
+    }
+}
+
+fn scan_gathers_stmt(stmt: &Stmt) {
+    match stmt {
+        Stmt::Expr(e)
+        | Stmt::Return(e)
+        | Stmt::Die(e)
+        | Stmt::Fail(e)
+        | Stmt::Take(e, _)
+        | Stmt::Goto(e) => scan_gathers_expr(e),
+        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => scan_gathers_expr(expr),
+        Stmt::Call { args, .. } => {
+            for arg in args {
+                match arg {
+                    CallArg::Positional(e) | CallArg::Invocant(e) | CallArg::Slip(e) => {
+                        scan_gathers_expr(e)
+                    }
+                    CallArg::Named { value: Some(e), .. } => scan_gathers_expr(e),
+                    CallArg::Named { value: None, .. } => {}
+                }
+            }
+        }
+        Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
+            for e in es {
+                scan_gathers_expr(e);
+            }
+        }
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            scan_gathers_expr(cond);
+            scan_gathers_stmts(then_branch);
+            scan_gathers_stmts(else_branch);
+        }
+        Stmt::While { cond, body, .. } => {
+            scan_gathers_expr(cond);
+            scan_gathers_stmts(body);
+        }
+        Stmt::For { iterable, body, .. } => {
+            scan_gathers_expr(iterable);
+            scan_gathers_stmts(body);
+        }
+        Stmt::Given { topic, body } => {
+            scan_gathers_expr(topic);
+            scan_gathers_stmts(body);
+        }
+        Stmt::When { cond, body } => {
+            scan_gathers_expr(cond);
+            scan_gathers_stmts(body);
+        }
+        Stmt::Whenever { supply, body, .. } => {
+            scan_gathers_expr(supply);
+            scan_gathers_stmts(body);
+        }
+        Stmt::Loop { body, .. }
+        | Stmt::React { body }
+        | Stmt::Block(body)
+        | Stmt::SyntheticBlock(body)
+        | Stmt::Default(body)
+        | Stmt::Catch(body)
+        | Stmt::Control(body)
+        | Stmt::Phaser { body, .. }
+        | Stmt::SubDecl { body, .. }
+        | Stmt::MethodDecl { body, .. }
+        | Stmt::ClassDecl { body, .. }
+        | Stmt::RoleDecl { body, .. }
+        | Stmt::Package { body, .. } => scan_gathers_stmts(body),
+        Stmt::Label { stmt, .. } => scan_gathers_stmt(stmt),
+        _ => {}
+    }
+}
+
+fn scan_gathers_expr(expr: &Expr) {
+    match expr {
+        Expr::Gather(body) => {
+            // The gather body is in sink context. Warn its useless statements,
+            // then keep scanning for gathers nested inside it.
+            walk_stmts(body, false);
+            scan_gathers_stmts(body);
+        }
+        Expr::Grouped(e)
+        | Expr::PositionalPair(e)
+        | Expr::ZenSlice(e)
+        | Expr::Itemize(e)
+        | Expr::Eager(e)
+        | Expr::Unary { expr: e, .. }
+        | Expr::PostfixOp { expr: e, .. }
+        | Expr::AssignExpr { expr: e, .. }
+        | Expr::Reduction { expr: e, .. }
+        | Expr::IndirectTypeLookup(e)
+        | Expr::SymbolicDeref { expr: e, .. } => scan_gathers_expr(e),
+        Expr::Binary { left, right, .. }
+        | Expr::HyperOp { left, right, .. }
+        | Expr::HyperFuncOp { left, right, .. }
+        | Expr::MetaOp { left, right, .. } => {
+            scan_gathers_expr(left);
+            scan_gathers_expr(right);
+        }
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            scan_gathers_expr(cond);
+            scan_gathers_expr(then_expr);
+            scan_gathers_expr(else_expr);
+        }
+        Expr::Index { target, index, .. } => {
+            scan_gathers_expr(target);
+            scan_gathers_expr(index);
+        }
+        Expr::IndexAssign {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            scan_gathers_expr(target);
+            scan_gathers_expr(index);
+            scan_gathers_expr(value);
+        }
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+            scan_gathers_expr(target);
+            for a in args {
+                scan_gathers_expr(a);
+            }
+        }
+        Expr::CallOn { target, args } => {
+            scan_gathers_expr(target);
+            for a in args {
+                scan_gathers_expr(a);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                scan_gathers_expr(a);
+            }
+        }
+        Expr::ArrayLiteral(es)
+        | Expr::BracketArray(es, _)
+        | Expr::CaptureLiteral(es)
+        | Expr::StringInterpolation(es) => {
+            for e in es {
+                scan_gathers_expr(e);
+            }
+        }
+        Expr::Hash(pairs) => {
+            for (_, v) in pairs {
+                if let Some(e) = v {
+                    scan_gathers_expr(e);
+                }
+            }
+        }
+        Expr::InfixFunc { left, right, .. } => {
+            scan_gathers_expr(left);
+            for e in right {
+                scan_gathers_expr(e);
+            }
+        }
+        Expr::Block(body)
+        | Expr::AnonSub { body, .. }
+        | Expr::AnonSubParams { body, .. }
+        | Expr::Lambda { body, .. }
+        | Expr::DoBlock { body, .. }
+        | Expr::PhaserExpr { body, .. }
+        | Expr::Once { body } => scan_gathers_stmts(body),
+        Expr::Try { body, catch } => {
+            scan_gathers_stmts(body);
+            if let Some(c) = catch {
+                scan_gathers_stmts(c);
+            }
+        }
+        Expr::DoStmt(stmt) => scan_gathers_stmt(stmt),
+        _ => {}
+    }
 }
 
 /// Walk a sink-context statement list. `nil_hint` is true when these statements

--- a/t/sink-warning.t
+++ b/t/sink-warning.t
@@ -2,7 +2,7 @@ use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 
-plan 16;
+plan 19;
 
 # A pure value evaluated in sink (void) context warns.
 is_run 'say "hi"; 42', { :0status, :out("hi\n"), :err(/"Useless use" .* 42/) },
@@ -47,3 +47,11 @@ is_run 'my $y; $y = 10', { :0status, :err('') },
     'assignment in sink does not warn';
 is_run 'say 1+2', { :0status, :out("3\n"), :err('') },
     'value consumed by say does not warn';
+
+# A `gather` body is in sink context wherever the gather appears.
+is_run 'my @x = gather 43', { :0status, :err(/"Useless use" .* 43/) },
+    'gather body as initializer warns its useless statements';
+is_run 'sub f { my @x = gather 43 }; f()', { :0status, :err(/"Useless use" .* 43/) },
+    'gather body inside a sub warns';
+is_run 'my @x = gather { take 1 }; say @x.elems', { :0status, :out("1\n"), :err('') },
+    'gather body with only a take does not warn';


### PR DESCRIPTION
## Summary

A `gather { ... }` block evaluates its body in sink (void) context **regardless of where the `gather` expression appears** — at the mainline, as a variable initializer (`my @x = gather 43`), inside a sub, as a call argument, or nested in another gather. The existing sink-warning pass (`parser::sink_warn`) only walked the mainline statement list and the bodies of bare blocks / control-flow statements, so it never descended into a gather sitting on a VarDecl/assignment RHS or inside a routine body.

This adds a `scan_gathers_*` traversal that walks the whole AST looking **only** for `Gather` nodes and emits sink warnings for each gather body (reusing the existing `walk_stmts`/`warn_expr_sink` machinery). Because only `Gather` nodes trigger a warning, an unhandled expression/statement variant can at worst miss a warning, never produce a spurious one.

## Result

Fixes roast `S32-exceptions/misc.t` test 138 ("sink warns inside of gather"). misc.t **122 → 123** passing.

Verified against `raku`:
- `my @x = gather 43` → warns `constant integer 43`
- `sub f { my @x = gather 43 }` → warns (gather inside sub)
- `my @x = gather { gather 99 }` → warns `99` (nested)
- `my @x = gather { take 1 }` → no warning (only a `take`)

## Tests

`t/sink-warning.t` extended (16 → 19) with gather cases. `make test` passes locally (917 files, 8818 tests).

Still failing in the 139-142 cluster (deferred): special-Num glyph `∞` and source-format preservation for `0xFF`/big-int/long-num literals, which would require threading literal source text through the AST (600+ `Expr::Literal` sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)