### PR TITLE
feat(single-store): Slice E — closures capture an upvalue snapshot, not the whole env

### DIFF
--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -423,12 +423,43 @@ for wall-clock.
   (`t/method-env-dirty.t` / `t/named-call-env-dirty.t` / `t/zeroarg-env-dirty.t`)
   remain the regression guard for the precise gates.
 
-- **Slice E — closure upvalues (prereq #1).**
-  Capture free vars as indexed upvalue cells; remove `compute_needs_env_sync`
-  whole-frame writeback and the per-call captured-env loops. Highest risk; lands
-  only after A–D. Gate: 193 closure/block/routine/sort/gather/sigilless roast
-  files (vm-dual-store.md Slice 3 set), `t/closure-captured-state.t`,
-  `bench-array`/`array-ops` `env_deep_copies` → target 0.
+- **Slice E — closure upvalue snapshot. PART 1 DONE (2026-06-18, #3245).**
+  A closure no longer flattens the *whole* lexical env into its captured
+  `data.env` (`clone_env`); `capture_closure_env` snapshots only an **upvalue
+  set**: the body's free variables (`free_var_syms`), the `__mutsu_*` shadow-meta,
+  and the *system names* a body reads through a dedicated opcode (`self`,
+  `$_`/`$/`/`$!`, `$?FILE`/`$?LINE`/`$?CLASS`, dynamic `$*…`, match captures,
+  `&?ROUTINE`/`&?BLOCK`, type names — everything `env::is_plain_user_lexical`
+  rejects). The bulk non-free plain user lexicals are dropped: a user lexical is
+  reached only through a `GetGlobal`-family opcode, which `free_var_syms` already
+  lists, so the body provably cannot reference a dropped name. `env` is now a
+  *derived view* for the common closure.
+
+  > **Two whole-env fallbacks, because `free_var_syms` is not complete.** The
+  > GetGlobal-scan misses names read by other means, so these keep `clone_env`:
+  > (1) **reflective** programs (`EVAL`/`CALLER::`/symbolic deref), and (2)
+  > **`captures_env_by_name`** frames — an inline body that reads lexicals by name
+  > through a path the op-scan can't see: `whenever`/`gather` bodies stashed in the
+  > `stmt_pool` and compiled/run at runtime against the live env, plus loop/block
+  > control temps. This is now a stored `CompiledCode` flag (was a local in
+  > `compute_needs_env_sync`), **extended to include `WheneverScope`**, reused by
+  > both the dual-store flush blanket and the capture path.
+
+  > **Measurement reframed the slice (2026-06-18).** Slice E was assumed to cut
+  > `env_deep_copies`; measurement showed those are *already* ~1–2 entries each
+  > (GLOBAL_BASE hoists ~70 entries; chain-aware `entry_or_insert` no-ops the
+  > co-scoped merge), so the slice is **perf-neutral**. Its value is
+  > architectural — closures stop capturing the whole env. The naive "free vars
+  > only" capture was found unsafe (dropped `self`/attributes and `whenever`/
+  > `gather` outer refs); Part 1 is the correct form (system-name keep-rule +
+  > whole-env fallback for provably-incomplete frames). Pinned by
+  > `t/single-store-slice-e.t` (13).
+
+  **PART 2 (next, after #3245 merges — touches the same files):** remove the
+  `compute_needs_env_sync` closure flush (branch #2) by reading free-var values
+  from the slot store in `capture_closure_env` instead of from the
+  (branch-#2-flushed) env. This is the actual machinery deletion §3 wants; Part 1
+  deliberately kept branch #2 so the capture reads correct values from env.
 
 - **Slice F — delete the coarse machinery. THE CONVERGENCE POINT (2026-06-18).**
   With every setter precise (A–E), remove `env_dirty`, `saved_env_dirty`,

--- a/src/env.rs
+++ b/src/env.rs
@@ -32,6 +32,48 @@ fn global_base() -> Option<&'static HashMap<Symbol, Value>> {
     GLOBAL_BASE.get()
 }
 
+/// True if `name` is a *plain user lexical* env key — a `my`/`our`-declared
+/// scalar/array/hash/sub whose name is an ordinary lowercase identifier (stored
+/// scalar-sigilless, e.g. `$x` → `"x"`, `@a` → `"@a"`). These are the only env
+/// keys a closure body reaches exclusively through a `GetGlobal`-family opcode,
+/// so the compiler's `free_var_syms` set already lists every one a closure can
+/// reference. The closure-capture upvalue path
+/// ([`crate::runtime::Interpreter::capture_closure_env`], single-store Slice E)
+/// uses this to drop the *non-free* plain lexicals from a closure's captured env
+/// while keeping everything else.
+///
+/// Everything that is NOT a plain user lexical is kept by the capture, because a
+/// closure body may read it through a dedicated opcode the free-var scan cannot
+/// see: `self` (attribute access), special vars (`$_`→`"_"`, `$/`→`"/"`,
+/// `$!`→`"!"`, `$?FILE`→`"?FILE"`, …), dynamic vars (`$*x`→`"*x"`/`"$*x"`), match
+/// captures (`$0`→`"0"`, `$<n>`→`"<n>"`), `&?ROUTINE`/`&?BLOCK`, the `__mutsu_*`
+/// shadow-meta, and type names (uppercase-initial). The classification is
+/// therefore deliberately conservative: it returns `true` (droppable) only for a
+/// lowercase-identifier-shaped name (optionally `@`/`%`/`&`-sigiled), and `self`
+/// — the one lowercase system name read via a dedicated opcode — is excluded.
+#[inline]
+pub(crate) fn is_plain_user_lexical(name: &str) -> bool {
+    if name == "self" {
+        return false;
+    }
+    let b = name.as_bytes();
+    let Some(&first) = b.first() else {
+        return false;
+    };
+    // The character that decides the name's "kind": for a sigiled array/hash/sub
+    // key it is the char after the sigil; otherwise the first char (scalars are
+    // stored sigil-less). A plain user lexical starts there with a lowercase
+    // ASCII letter. Anything else — uppercase (types), `?`/`*`/`/`/`!`/`<`
+    // (specials/dynamics/captures), a digit (positional captures), `_` (`$_`,
+    // `@_`), or `__mutsu_*` — is a system name the capture must keep.
+    let decider = if matches!(first, b'@' | b'%' | b'&') {
+        b.get(1).copied()
+    } else {
+        Some(first)
+    };
+    matches!(decider, Some(c) if c.is_ascii_lowercase())
+}
+
 /// Monotonic, process-global flag: set the first time any closure-writeback
 /// metadata key is inserted into *any* env. These keys --
 /// `__mutsu_sigilless_readonly::*`, `__mutsu_sigilless_alias::*`,
@@ -140,6 +182,22 @@ impl Env {
     pub(crate) fn new() -> Self {
         Self {
             inner: Arc::new(HashMap::new()),
+            parent: None,
+            tombstones: None,
+            depth: 0,
+        }
+    }
+
+    /// Build a flat (`parent=None`) env directly from a pre-built overlay map.
+    /// Name lookups still fall through to [`GLOBAL_BASE`] at the tail, so the
+    /// built-in enum constants remain reachable without copying them in. Used by
+    /// the closure-capture upvalue path (single-store Slice E) to materialize a
+    /// snapshot holding only a closure's free variables, the shadow-meta, and the
+    /// system names a body may read through a dedicated opcode — not a flatten of
+    /// every plain user lexical in scope.
+    pub(crate) fn from_symbol_map(map: HashMap<Symbol, Value>) -> Self {
+        Self {
+            inner: Arc::new(map),
             parent: None,
             tombstones: None,
             depth: 0,
@@ -522,6 +580,49 @@ mod tests {
 
     fn s(name: &str) -> Symbol {
         Symbol::intern(name)
+    }
+
+    #[test]
+    fn plain_user_lexical_classification() {
+        // Plain user lexicals (droppable by the closure upvalue capture): a
+        // lowercase-identifier scalar (stored sigil-less) or @/%/&-sigiled var.
+        for k in ["x", "c", "count", "@arr", "%h", "&helper", "longname"] {
+            assert!(
+                is_plain_user_lexical(k),
+                "{k} should be a plain user lexical"
+            );
+        }
+        // System names the capture must keep: self, topic/match/error, compile-time
+        // `?` vars, dynamic `*` vars, match captures, &?ROUTINE, types, meta.
+        for k in [
+            "self",
+            "_",
+            "/",
+            "!",
+            "?FILE",
+            "?LINE",
+            "?CLASS",
+            "*REPO",
+            "@*ARGS",
+            "%*ENV",
+            "$*HOME",
+            "0",
+            "1",
+            "<name>",
+            "&?ROUTINE",
+            "&?BLOCK",
+            "@_",
+            "Cache",
+            "Any",
+            "__mutsu_type::x",
+        ] {
+            assert!(
+                !is_plain_user_lexical(k),
+                "{k} should be kept (not a plain user lexical)"
+            );
+        }
+        // Empty string is not a plain user lexical.
+        assert!(!is_plain_user_lexical(""));
     }
 
     fn scoped_with(parent: Env, writes: &[(&str, i64)]) -> Env {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1289,6 +1289,18 @@ pub(crate) struct CompiledCode {
     /// the caller writeback even when its own free variables are unchanged.
     /// Distinct from `has_env_writes`, which lists only *some* call opcodes.
     pub(crate) has_calls: bool,
+    /// True if this code runs an inline body that reads the frame's lexicals *by
+    /// name* through a path the `free_var_syms` op-scan cannot see: loop/block
+    /// bodies that thread control temps through `env` by name (`ForLoop`,
+    /// `BlockScope`, `BlockLocalScope`), and the two ops that stash a body in the
+    /// `stmt_pool` and compile/run it at runtime against the live env
+    /// (`MakeGather`, `WheneverScope`). For such a frame `free_var_syms` is
+    /// *incomplete*, so two consumers fall back to the whole env: the dual-store
+    /// flush blanket (`compute_needs_env_sync`) marks every local env-synced, and
+    /// the closure upvalue capture (`capture_closure_env`, single-store Slice E)
+    /// snapshots the whole env instead of just the free vars. Set during
+    /// `compute_needs_env_sync`.
+    pub(crate) captures_env_by_name: bool,
 }
 
 impl CompiledCode {
@@ -1316,6 +1328,7 @@ impl CompiledCode {
             needs_cell_locals: Vec::new(),
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
+            captures_env_by_name: false,
         }
     }
 
@@ -1389,35 +1402,40 @@ impl CompiledCode {
         // needs_env_sync early returns below), so the global flag is set even for
         // loop/block or zero-local frames.
         self.scan_reflective_name_access();
-        let n = self.locals.len();
-        self.needs_env_sync = vec![false; n];
-        if n == 0 {
-            return;
-        }
         // Conservative fallback: code that runs inline control-flow bodies with
         // their own env/locals juggling (for/while/loop bodies, which the
         // loop-phaser desugaring threads state through by name via `env`, e.g.
         // the `__mutsu_loop_first_`/`__mutsu_loop_ran_` control temps) cannot
         // safely treat any local as slot-only -- a slot value may not survive the
-        // loop's per-iteration env round-trips. The same applies to `MakeGather`:
-        // a gather block compiles its body inline and snapshots the *whole*
-        // interpreter env by name (vm_register_ops::exec_make_gather_op), but the
-        // body is not registered in `closure_compiled_codes`, so the nested-closure
-        // free-var scan below cannot see which locals it reads. Mark every local
-        // env-synced so the dual-store flush gate (vm_env_helpers) keeps the full
-        // flush for such frames. Recursion-heavy code without loops/gather (e.g.
-        // `fib`) is unaffected and still skips the per-call flush for its slot-only
-        // params.
-        let captures_env_by_name = self.ops.iter().any(|op| {
+        // loop's per-iteration env round-trips. The same applies to the two ops
+        // that stash a body in the `stmt_pool` and compile/run it at runtime
+        // against the live env by name -- `MakeGather` (a gather block,
+        // vm_register_ops::exec_make_gather_op) and `WheneverScope` (a
+        // `whenever`/`supply` body, exec_whenever_scope_op): the body is not in
+        // `closure_compiled_codes`, so the nested-closure free-var scan below
+        // cannot see which lexicals it reads. For such a frame `free_var_syms` is
+        // incomplete, so this flag drives the whole-env fallback in two places:
+        // the dual-store flush blanket here, and the closure upvalue capture
+        // (`capture_closure_env`). Computed unconditionally (before the n==0
+        // early return) so zero-local closures wrapping a `whenever`/`gather` are
+        // covered too. Recursion-heavy code without these (e.g. `fib`) is
+        // unaffected and still skips the per-call flush for its slot-only params.
+        self.captures_env_by_name = self.ops.iter().any(|op| {
             matches!(
                 op,
                 OpCode::ForLoop { .. }
                     | OpCode::BlockScope { .. }
                     | OpCode::BlockLocalScope { .. }
                     | OpCode::MakeGather(_)
+                    | OpCode::WheneverScope { .. }
             )
         });
-        if captures_env_by_name {
+        let n = self.locals.len();
+        self.needs_env_sync = vec![false; n];
+        if n == 0 {
+            return;
+        }
+        if self.captures_env_by_name {
             self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             return;
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -95,11 +95,9 @@ impl Interpreter {
                 body: body.clone(),
                 is_rw: false,
                 is_raw: false,
-                // Flatten: a closure stored in a Value::Sub is dispatched later,
-                // possibly from a different scope, and its captured env is seeded
-                // overlay-only at dispatch -- so it must hold the full lexical view
-                // now, not a scoped overlay whose parent tier would be lost.
-                env: self.clone_env(),
+                // Upvalue snapshot (single-store Slice E): capture only free vars,
+                // shadow-meta, and system names; see `capture_closure_env`.
+                env: self.capture_closure_env(&compiled_code),
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
@@ -139,9 +137,8 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
-            // Flatten: closure env captured into a Value::Sub for later (possibly
-            // cross-scope) dispatch must hold the full lexical view (see above).
-            let mut env = self.clone_env();
+            // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
+            let mut env = self.capture_closure_env(&compiled_code);
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -203,6 +200,53 @@ impl Interpreter {
             .filter(|sym| sym.with_str(|s| self.loop_local_vars.iter().any(|set| set.contains(s))))
             .copied()
             .collect()
+    }
+
+    /// Capture the closure's environment as an *upvalue snapshot* (single-store
+    /// Slice E): instead of flattening the whole lexical env into the closure
+    /// (`clone_env`), capture only the names the closure body (and its nested
+    /// closures) can actually observe.
+    ///
+    /// The invariant that makes this safe: a closure body references an outer
+    /// **user lexical** only through a `GetGlobal`-family opcode, so the compiler's
+    /// `free_var_syms` set already lists every such name. The *other* names a body
+    /// can read — `self` (attribute access), special vars (`$_`, `$/`, `$!`,
+    /// `$?FILE`, …), dynamic vars (`$*…`), match captures, `&?ROUTINE`/`&?BLOCK`,
+    /// and type names — go through dedicated opcodes the free-var scan cannot see,
+    /// but they are all *system* names rather than plain user lexicals. So the
+    /// capture keeps: free variables, the `__mutsu_*` shadow-meta, and every name
+    /// that is not a plain user lexical ([`crate::env::is_plain_user_lexical`]). It
+    /// drops only the bulk non-free plain user lexicals, which the body provably
+    /// cannot reference.
+    ///
+    /// Two cases keep the whole-env snapshot (`clone_env`) because `free_var_syms`
+    /// is *not* a complete account of the names the body reads:
+    /// - **reflective** programs (`EVAL` / `CALLER::` / symbolic deref) can read a
+    ///   caller lexical under any name (process-global flag, set at finalize);
+    /// - **`captures_env_by_name`** frames run an inline body that reads lexicals
+    ///   by name through a path the op-scan misses (`whenever`/`gather` bodies
+    ///   stashed in the `stmt_pool`, loop/block control temps) — see the field on
+    ///   [`CompiledCode`].
+    fn capture_closure_env(&self, cc: &Option<std::sync::Arc<CompiledCode>>) -> Env {
+        let Some(cc) = cc else {
+            return self.clone_env();
+        };
+        if cc.captures_env_by_name || crate::opcode::reflective_name_access_possible() {
+            return self.clone_env();
+        }
+        let free: std::collections::HashSet<Symbol> = cc.free_var_syms.iter().copied().collect();
+        // Flatten once (same as `clone_env`), then keep only the upvalue set,
+        // shadow-meta, and system names. The base tier (GLOBAL_BASE) is never in
+        // the overlay and stays reachable through the flat env's tail lookup.
+        let flat = self.clone_env();
+        let mut map: std::collections::HashMap<Symbol, Value> = std::collections::HashMap::new();
+        for (k, v) in flat.iter() {
+            let keep = free.contains(k) || k.with_str(|s| !crate::env::is_plain_user_lexical(s));
+            if keep {
+                map.insert(*k, v.clone());
+            }
+        }
+        crate::env::Env::from_symbol_map(map)
     }
 
     /// Box-on-capture (lever C Slice 2): a closure captures the *container* of a
@@ -345,9 +389,8 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
-            // Flatten: closure env captured into a Value::Sub for later (possibly
-            // cross-scope) dispatch must hold the full lexical view (see above).
-            let mut env = self.clone_env();
+            // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
+            let mut env = self.capture_closure_env(&compiled_code);
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -413,8 +456,8 @@ impl Interpreter {
                 body: body.clone(),
                 is_rw: false,
                 is_raw: false,
-                // Flatten: long-lived closure capture (see above).
-                env: self.clone_env(),
+                // Upvalue snapshot (single-store Slice E); see capture_closure_env.
+                env: self.capture_closure_env(&compiled_code),
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),

--- a/t/single-store-slice-e.t
+++ b/t/single-store-slice-e.t
@@ -1,0 +1,103 @@
+use v6;
+use Test;
+
+# Single-store Slice E: closures capture an *upvalue snapshot* (free variables +
+# shadow-meta + system names) rather than a flatten of the whole lexical env.
+# These cases exercise the names the GetGlobal-based free-var scan can and cannot
+# see, so they pin the capture's correctness:
+#   - plain user lexicals (free vars), captured by name;
+#   - `self` / attributes, read via a dedicated opcode (kept by the system-name
+#     rule);
+#   - `whenever`/`gather` bodies stashed in the stmt_pool (whole-env fallback via
+#     `captures_env_by_name`).
+
+plan 13;
+
+# --- plain free-var capture ---------------------------------------------------
+{
+    my $count = 0;
+    my $inc = { $count++ };
+    $inc(); $inc(); $inc();
+    is $count, 3, 'captured-and-mutated scalar accumulates';
+}
+{
+    my $v = 0;
+    my $get = { $v };
+    my $set = -> $n { $v = $n };
+    $set(42);
+    is $get(), 42, 'sibling closures share one cell';
+}
+{
+    sub make-counter() {
+        my $c = 0;
+        return (-> { $c }, -> { $c++ });
+    }
+    my ($g, $i) = make-counter();
+    $i(); $i();
+    is $g(), 2, 'escaping getter/setter factory shares state';
+}
+{
+    my @subs;
+    for 1..3 -> $x { @subs.push({ $x }) }
+    is @subs.map({ $_() }).join(','), '1,2,3', 'per-iteration loop binding';
+}
+
+# --- closures dropping non-free lexicals --------------------------------------
+{
+    # `$noise` is in scope but not referenced by the closure: dropping it from the
+    # capture must not change the result.
+    my $noise = 'unused';
+    my $a = 10;
+    my $f = { $a * 2 };
+    is $f(), 20, 'non-free lexical dropped without affecting result';
+    is $noise, 'unused', 'dropped lexical still intact in the caller';
+}
+
+# --- system names read via dedicated opcodes (kept) ---------------------------
+class Cache {
+    has %!h;
+    has @!a;
+    method h-writer() { -> $k, $v { %!h{$k} = $v } }
+    method a-pusher() { -> $v { @!a.push($v) } }
+    method get($k) { %!h{$k} }
+    method a() { @!a.List }
+}
+{
+    my $c = Cache.new;
+    my $w = $c.h-writer;
+    $w('x', 1); $w('y', 2);
+    is $c.get('x'), 1, 'attribute closure write (self kept) survives';
+    is $c.get('y'), 2, 'second attribute closure write survives';
+    my $p = $c.a-pusher;
+    $p(7); $p(8);
+    is $c.a.join(','), '7,8', 'attribute push closure accumulates';
+}
+
+# typed captured var keeps its constraint after escaping its scope
+{
+    sub make-typed() {
+        my Int $t = 0;
+        return -> $n { $t = $n; $t };
+    }
+    my $ts = make-typed();
+    is $ts(5), 5, 'escaped typed closure assigns a valid value';
+    my $err = 'none';
+    { $ts('nope'); CATCH { default { $err = 'caught' } } }
+    is $err, 'caught', 'escaped typed closure still enforces Int constraint';
+}
+
+# --- captures_env_by_name fallback (whenever / gather) ------------------------
+{
+    sub foo($a) {
+        supply {
+            whenever Supply.from-list() { LAST emit $a }
+        }
+    }
+    is await(foo(42)), 42, 'whenever/LAST closure sees outer (whole-env fallback)';
+}
+{
+    sub gen($base) {
+        gather { take $base + $_ for 1..3 }
+    }
+    is gen(10).join(','), '11,12,13', 'gather body sees outer (whole-env fallback)';
+}


### PR DESCRIPTION
## Single-store Slice E (architecture / maintainability — not perf)

A closure no longer flattens the **whole** lexical env into its captured `data.env` (`clone_env`). It now captures an **upvalue snapshot** holding only the names the body can actually observe:

- its **free variables** (`free_var_syms`),
- the `__mutsu_*` **shadow-meta**, and
- the **system names** a body reads through a dedicated opcode (`self` for attribute access, special vars `$_`/`$/`/`$!`, `$?FILE`/`$?LINE`/`$?CLASS`, dynamic `$*…`, match captures, `&?ROUTINE`/`&?BLOCK`, type names).

The bulk **non-free plain user lexicals** are dropped — the body provably cannot reference them, since a user lexical is reached only through a `GetGlobal`-family opcode that `free_var_syms` already lists. So `env` becomes a *derived view* for the common closure rather than a store every closure snapshots in full.

### Why two whole-env fallbacks

`free_var_syms` (a `GetGlobal`-scan) is not a complete account of the names a body reads in two cases, so those keep the whole-env snapshot:

1. **reflective** programs (`EVAL` / `CALLER::` / symbolic deref) — can read a caller lexical under any name (process-global flag);
2. **`captures_env_by_name`** frames — an inline body reads lexicals by name through a path the op-scan misses: `whenever`/`gather` bodies stashed in the `stmt_pool` and compiled/run at runtime against the live env, plus loop/block control temps. This was a local in `compute_needs_env_sync`; it is now a stored `CompiledCode` flag, **extended to include `WheneverScope`**, and reused by both the dual-store flush blanket and the capture path.

### Investigation note

Measurement showed Slice E is **perf-neutral** (per-closure env deep copies are already ~1–2 entries via `GLOBAL_BASE` hoisting + chain-aware `entry_or_insert`); the value here is architectural — closures stop capturing the whole env. The naive "free vars only" capture was found to be unsafe (it dropped `self`/attributes and `whenever`/`gather` outer refs); this PR is the correct form: a conservative keep-rule for system names + a whole-env fallback for the frames where the free-var analysis is provably incomplete.

### New
- `env::is_plain_user_lexical` (keep/drop classifier, unit-tested)
- `Env::from_symbol_map`
- `Interpreter::capture_closure_env`
- `t/single-store-slice-e.t` (13 cases)

### Tests
`make test` green (full `t/`); representative closure/phaser/supply/gather/sort/map roast files PASS locally; full roast via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)