### PR TITLE
fix(parser): scalar item assignment `$x = 1, 2` binds tighter than comma

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,9 +125,9 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 123/180 pass (plan 182). This is a very broad compile-time-error/exception file
+  - 124/180 pass (plan 182). This is a very broad compile-time-error/exception file
     covering ~40 distinct features.
-  - Done: "Useless use of X in sink context" warnings (tests 111-114, 116-120,
+  - Done: "Useless use of X in sink context" warnings (tests 111-120,
     122-138 — the bulk of the 111-142 cluster). New parser post-pass
     `parser::sink_warn` walks the mainline (all-sink) statement list, recursing
     into bare blocks, comma lists, and the bodies of loop/conditional/topicalizer
@@ -137,13 +137,22 @@
     "(use Nil instead...)" hint. A separate `scan_gathers_*` traversal walks the
     WHOLE tree for `gather { ... }` blocks (always sink-context wherever they
     appear) and warns their bodies — test 138 (`gather 43`). t/sink-warning.t.
-    Still failing in the cluster: 115 (`$y = 1,2,3` — mutsu mis-parses item
-    assignment as `$y = (1,2,3)` so the trailing `123` is not sunk; a separate
-    precedence bug), 121 (`:foo(42)` — mutsu parses the colonpair identically to
-    `foo => 42`, losing the `:foo()` syntax), 139-142 (special-Num glyph `∞` and
-    source-format preservation for `0xFF`/big-int/long-num literals, which mutsu
-    does not retain — would require threading literal source text through the AST,
-    which has 600+ `Expr::Literal` construction/match sites).
+  - Done: test 115 (`$x = 1, 2` item-assignment precedence). Item assignment to a
+    bare `$`-scalar binds tighter than comma, so `$x = 1, 2` is `($x = 1), 2` —
+    only the first element is assigned, the rest are sunk. `assign_stmt` now parses
+    a single RHS operand via `expression` for a bare `$` lvalue and builds a
+    sink-distributing comma list on a trailing comma; `@`/`%`/element-subscript and
+    `$x = (1, 2)` keep the whole list. (The paren-vs-bare distinction is only
+    available at parse time — both collapse to the same `ArrayLiteral` in the AST.)
+    t/scalar-item-assign-precedence.t. NOTE: nested `$x = $y = 1, 2` still absorbs
+    (the embedded-assignment path in `expr/precedence.rs::assign_not_expr_mode`
+    keeps the comma-absorbing RHS); a follow-up could mirror the same sigil check
+    there.
+    Still failing in the cluster: 121 (`:foo(42)` — mutsu parses the colonpair
+    identically to `foo => 42`, losing the `:foo()` syntax), 139-142 (special-Num
+    glyph `∞` and source-format preservation for `0xFF`/big-int/long-num literals,
+    which mutsu does not retain — would require threading literal source text
+    through the AST, which has 600+ `Expr::Literal` construction/match sites).
   - Done: `fail`/`die`/`throw`/`rethrow`/`resume` called on an Exception *type
     object* (`X::NYI.throw`) -> X::Parameter::InvalidConcreteness (was "no such
     method"). Shared `exception_concreteness_error` helper, wired into BOTH the

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -2472,6 +2472,62 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             &rest[1..]
         };
         let (rest, _) = ws(rest)?;
+
+        // Item assignment (`=`) to a scalar variable binds TIGHTER than the comma
+        // operator: `$x = 1, 2` parses as `($x = 1), 2`, so only the first element
+        // is assigned and the remaining elements form a (sink-context) list. The
+        // parenthesized form `$x = (1, 2)` is a single grouped operand and is
+        // assigned whole — and that distinction is *only* available here at parse
+        // time, since both collapse to the same `ArrayLiteral` in the AST. List
+        // assignment to an `@`/`%` container keeps the comma-absorbing RHS so
+        // `@x = 1, 2, 3` assigns the whole list. Atomic `⚛=` is always a scalar
+        // store and is handled below.
+        if sigil == b'$' && !is_atomic {
+            let (after_rhs, rhs) = expression(rest).map_err(|err| PError {
+                messages: merge_expected_messages(
+                    "expected right-hand expression after '='",
+                    &err.messages,
+                ),
+                remaining_len: err.remaining_len.or(Some(rest.len())),
+                exception: None,
+            })?;
+            let (after_ws, _) = ws(after_rhs)?;
+            if after_ws.starts_with(',') && !after_ws.starts_with(",,") {
+                // `($x = rhs), <rest...>` — assign the first element, sink the rest.
+                let assign_expr = Expr::AssignExpr {
+                    name,
+                    expr: Box::new(rhs),
+                    is_bind: false,
+                };
+                let mut items = vec![assign_expr];
+                let mut r = after_ws;
+                while r.starts_with(',') && !r.starts_with(",,") {
+                    let (r2, _) = parse_char(r, ',')?;
+                    let (r2, _) = ws(r2)?;
+                    if r2.is_empty()
+                        || r2.starts_with(';')
+                        || r2.starts_with('}')
+                        || r2.starts_with(')')
+                    {
+                        r = r2;
+                        break;
+                    }
+                    let (r2, next) = expression(r2)?;
+                    items.push(next);
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                }
+                let stmt = Stmt::Expr(Expr::ArrayLiteral(items));
+                return parse_statement_modifier(r, stmt);
+            }
+            let stmt = Stmt::Assign {
+                name,
+                expr: rhs,
+                op: AssignOp::Assign,
+            };
+            return parse_statement_modifier(after_rhs, stmt);
+        }
+
         let (rest, expr) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
             messages: merge_expected_messages(
                 "expected right-hand expression after '='",

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -1940,6 +1940,50 @@ mod tests {
     }
 
     #[test]
+    fn assign_stmt_scalar_item_assignment_stops_at_comma() {
+        // `$x = 1, 2` is `($x = 1), 2`: only the first element is assigned, and
+        // the rest become a sink-context comma list.
+        let (rest, stmt) = assign::assign_stmt("$x = 1, 2;").unwrap();
+        assert_eq!(rest, "");
+        match stmt {
+            Stmt::Expr(Expr::ArrayLiteral(items)) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(
+                    &items[0],
+                    Expr::AssignExpr { name, expr, .. }
+                        if name == "x" && matches!(expr.as_ref(), Expr::Literal(Value::Int(1)))
+                ));
+                assert!(matches!(&items[1], Expr::Literal(Value::Int(2))));
+            }
+            other => panic!("expected comma-list expr statement, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn assign_stmt_scalar_plain_assignment_has_no_comma() {
+        // Without a trailing comma the assignment is a plain `Stmt::Assign`.
+        let (rest, stmt) = assign::assign_stmt("$x = 1;").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            stmt,
+            Stmt::Assign { name, expr, .. }
+                if name == "x" && matches!(expr, Expr::Literal(Value::Int(1)))
+        ));
+    }
+
+    #[test]
+    fn assign_stmt_array_list_assignment_absorbs_comma() {
+        // `@a = 1, 2` keeps the comma-absorbing RHS (list assignment).
+        let (rest, stmt) = assign::assign_stmt("@a = 1, 2;").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            stmt,
+            Stmt::Assign { name, expr, .. }
+                if name == "@a" && matches!(&expr, Expr::ArrayLiteral(items) if items.len() == 2)
+        ));
+    }
+
+    #[test]
     fn assign_expr_parses_reverse_bracket_metaop_assign() {
         let (rest, expr) = assign::try_parse_assign_expr("$y [R/]= 1").unwrap();
         assert_eq!(rest, "");

--- a/t/scalar-item-assign-precedence.t
+++ b/t/scalar-item-assign-precedence.t
@@ -1,0 +1,70 @@
+use Test;
+
+plan 10;
+
+# Item assignment (`=`) to a bare scalar variable binds TIGHTER than the comma
+# operator: `$x = 1, 2` parses as `($x = 1), 2`, so only the first element is
+# assigned and the rest form a (sink-context) list.
+{
+    my $x;
+    $x = 1, 99;
+    is $x, 1, 'scalar item assignment takes only the first comma element';
+}
+
+# The parenthesized form is a single grouped operand and is assigned whole.
+{
+    my $x;
+    $x = (1, 2, 3);
+    is $x.elems, 3, 'parenthesized list RHS is assigned whole to a scalar';
+}
+
+# List assignment to an @-container absorbs the whole comma list.
+{
+    my @a;
+    @a = 1, 2, 3;
+    is @a.elems, 3, 'array list assignment absorbs the whole comma list';
+}
+
+# List assignment to a %-container absorbs the whole comma list.
+{
+    my %h;
+    %h = a => 1, b => 2;
+    is %h.elems, 2, 'hash list assignment absorbs the whole comma list';
+}
+
+# A hash/array element subscript is list assignment (leading sigil %/@).
+{
+    my %h;
+    %h<k> = 1, 2;
+    is %h<k>.elems, 2, 'hash element subscript assignment is list assignment';
+}
+
+# Chained scalar assignment still works.
+{
+    my ($x, $y);
+    $x = $y = 5;
+    is $x, 5, 'chained scalar assignment assigns the left';
+    is $y, 5, 'chained scalar assignment assigns the right';
+}
+
+# Statement modifiers still attach after a bare scalar assignment.
+{
+    my $x = 0;
+    $x = 7 if True;
+    is $x, 7, 'statement modifier applies to a bare scalar assignment';
+}
+
+# A function call result followed by a comma assigns only the call result.
+{
+    sub gimme { 42 }
+    my $x;
+    $x = gimme(), 99;
+    is $x, 42, 'scalar item assignment from a call takes only the first element';
+}
+
+# Compound RHS expressions bind as a single operand.
+{
+    my $x;
+    $x = 1 + 2, 99;
+    is $x, 3, 'scalar item assignment evaluates the first operand expression';
+}


### PR DESCRIPTION
## Summary

Raku item assignment (`=`) to a **bare scalar variable** binds TIGHTER than the comma operator, so `$x = 1, 2` parses as `($x = 1), 2`: only the first element is assigned to `$x` and the remaining elements form a (sink-context) list. mutsu's statement-level assignment parser (`assign_stmt`) instead fed the RHS through the comma-absorbing `parse_assign_expr_or_comma`, so `$x = 1, 2` wrongly assigned the whole list `(1, 2)` to the scalar.

List assignment to an `@`/`%` container — and the parenthesized form `$x = (1, 2)` — must still take the whole list. Crucially, `$x = (1, 2)` and `$x = 1, 2` collapse to the **same** `ArrayLiteral` in the AST, so the distinction can only be drawn at parse time.

## Fix

In the plain-`=` branch of `assign_stmt`, special-case a bare `$`-sigil lvalue:
- parse a **single** RHS operand via `expression` (keeps a parenthesized list whole; stops at a bare top-level comma);
- on a trailing comma, build `Stmt::Expr(ArrayLiteral([AssignExpr{...}, <rest>]))` so the assignment runs first and the discarded elements flow through the sink-warning pass.

`@`/`%`/element-subscript lvalues (Raku decides item-vs-list by the **leading sigil**, so `%h<a> = 1, 2` and `@a[0] = 1, 2` are list assignment) and atomic `⚛=` keep their existing comma-absorbing behavior.

Verified against `raku`:
- `$x = 1, 2` → `$x` is `1`, `2` sunk (Int)
- `$x = (1, 2)` → `$x` is the 3-elem... 2-elem list
- `@x = 1, 2, 3` / `%h = a => 1, b => 2` → whole list
- `%h<k> = 1, 2` → list (leading sigil `%`)
- chained `$x = $y = 5`, `$x = 1 if cond` → unchanged

## Result

Fixes roast `S32-exceptions/misc.t` test 115 ("sink distributes to comma list when first is item assignment"). With the already-merged gather fix (#3244), misc.t is now **124/180**.

### Known follow-up

Nested `$x = $y = 1, 2` still absorbs the comma in the inner assignment — the embedded-assignment path (`expr/precedence.rs::assign_not_expr_mode`) keeps the comma-absorbing RHS. A follow-up can mirror the same sigil check there.

## Tests

`t/scalar-item-assign-precedence.t` (10 cases) + 3 parser unit tests in `stmt/mod.rs`. `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)