### PR TITLE
feat(single-store): Slice E Part 2 — closures read upvalues from the slot store; drop the closure flush

### DIFF
--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -455,11 +455,18 @@ for wall-clock.
   > whole-env fallback for provably-incomplete frames). Pinned by
   > `t/single-store-slice-e.t` (13).
 
-  **PART 2 (next, after #3245 merges — touches the same files):** remove the
-  `compute_needs_env_sync` closure flush (branch #2) by reading free-var values
-  from the slot store in `capture_closure_env` instead of from the
-  (branch-#2-flushed) env. This is the actual machinery deletion §3 wants; Part 1
-  deliberately kept branch #2 so the capture reads correct values from env.
+  **PART 2 DONE (2026-06-18).** `compute_needs_env_sync`'s closure flush (branch
+  #2 — the `for nested in closure_compiled_codes { needs_env_sync[slot] = true }`
+  loop) is removed: `capture_closure_env` now reads a free variable that is one of
+  this frame's own locals straight from the slot store (`self.locals[slot]`, the
+  live upvalue) instead of from the (formerly flushed) env. A slot-only local is
+  no longer mirrored into env for closure visibility — the closure is fully
+  decoupled from the forward-flush machinery. Mutation propagation is unchanged
+  (reverse `env_dirty` path + the `box_captured_lexicals` `ContainerRef` cell).
+  `make test` green; closure/phaser/state/pointy/gather/supply roast PASS.
+  `compute_needs_env_sync` now only marks slots that are read/written *by name in
+  this frame* (own-local GetGlobal-family) — plus the `captures_env_by_name`
+  whole-frame blanket for inline-body frames.
 
 - **Slice F — delete the coarse machinery. THE CONVERGENCE POINT (2026-06-18).**
   With every setter precise (A–E), remove `env_dirty`, `saved_env_dirty`,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1445,20 +1445,15 @@ impl CompiledCode {
             .enumerate()
             .map(|(i, name)| (name.as_str(), i))
             .collect();
-        // A nested closure created in this frame captures the env at creation
-        // time and later reads its free variables from that snapshot by name.
-        // Any local of *this* frame that is a free variable of some nested
-        // closure must therefore be flushed to env before the capture. This
-        // replaces the old conservative `fill(true)` (which mirrored *every*
-        // local to env whenever any closure existed) with the exact set of
-        // locals a closure can actually observe.
-        for nested in &self.closure_compiled_codes {
-            for sym in &nested.free_var_syms {
-                if let Some(slot) = sym.with_str(|s| locals_map.get(s).copied()) {
-                    self.needs_env_sync[slot] = true;
-                }
-            }
-        }
+        // Single-store Slice E Part 2: a nested closure no longer reads its free
+        // variables from this frame's flushed env — `capture_closure_env` reads
+        // this frame's own locals straight from the slot store (the live upvalue).
+        // So a local being a closure free variable no longer forces an env flush
+        // here. (Mutation propagation back to the parent still flows through the
+        // reverse env_dirty path, and a captured-and-mutated local is boxed into a
+        // shared `ContainerRef` cell by `box_captured_lexicals`, so the closure and
+        // parent share one cell.) Only a local genuinely read/written *by name* in
+        // this frame (below) still needs the slot mirrored into env.
         for op in &self.ops {
             let name_idx = match op {
                 OpCode::GetGlobal(idx)

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -97,7 +97,7 @@ impl Interpreter {
                 is_raw: false,
                 // Upvalue snapshot (single-store Slice E): capture only free vars,
                 // shadow-meta, and system names; see `capture_closure_env`.
-                env: self.capture_closure_env(&compiled_code),
+                env: self.capture_closure_env(code, &compiled_code),
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
@@ -138,7 +138,7 @@ impl Interpreter {
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
-            let mut env = self.capture_closure_env(&compiled_code);
+            let mut env = self.capture_closure_env(code, &compiled_code);
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -227,7 +227,23 @@ impl Interpreter {
     ///   by name through a path the op-scan misses (`whenever`/`gather` bodies
     ///   stashed in the `stmt_pool`, loop/block control temps) — see the field on
     ///   [`CompiledCode`].
-    fn capture_closure_env(&self, cc: &Option<std::sync::Arc<CompiledCode>>) -> Env {
+    ///
+    /// **Slice E Part 2 (the upvalue read):** a free variable that is one of *this*
+    /// frame's own locals is read straight from the slot store
+    /// (`self.locals[slot]`, the live upvalue), not from `env`. This is what lets
+    /// `compute_needs_env_sync` drop its closure-driven flush (branch #2): the
+    /// closure no longer depends on the parent frame mirroring that local into
+    /// `env` before capture. Ancestor free variables (no slot here) and the system
+    /// names still come from the flattened env, where they always live. Mutation
+    /// *propagation* back to the parent is unchanged — it flows through the reverse
+    /// `env_dirty` path and, for captured-and-mutated locals, the shared
+    /// `ContainerRef` cell that `box_captured_lexicals` installs in both the slot
+    /// and `env`.
+    fn capture_closure_env(
+        &self,
+        code: &CompiledCode,
+        cc: &Option<std::sync::Arc<CompiledCode>>,
+    ) -> Env {
         let Some(cc) = cc else {
             return self.clone_env();
         };
@@ -244,6 +260,16 @@ impl Interpreter {
             let keep = free.contains(k) || k.with_str(|s| !crate::env::is_plain_user_lexical(s));
             if keep {
                 map.insert(*k, v.clone());
+            }
+        }
+        // Upvalue read: override this frame's own free-var slots with the live
+        // local value. Authoritative even after the closure-driven env flush is
+        // gone (a slot-only local is no longer mirrored into `env`).
+        for sym in &cc.free_var_syms {
+            if let Some(slot) = sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+                && let Some(val) = self.locals.get(slot)
+            {
+                map.insert(*sym, val.clone());
             }
         }
         crate::env::Env::from_symbol_map(map)
@@ -390,7 +416,7 @@ impl Interpreter {
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
-            let mut env = self.capture_closure_env(&compiled_code);
+            let mut env = self.capture_closure_env(code, &compiled_code);
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -457,7 +483,7 @@ impl Interpreter {
                 is_rw: false,
                 is_raw: false,
                 // Upvalue snapshot (single-store Slice E); see capture_closure_env.
-                env: self.capture_closure_env(&compiled_code),
+                env: self.capture_closure_env(code, &compiled_code),
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),


### PR DESCRIPTION
## Single-store Slice E Part 2 (architecture / maintainability)

Completes Slice E by removing `compute_needs_env_sync`'s **closure-driven env flush** (branch #2 — the `for nested in closure_compiled_codes { needs_env_sync[slot] = true }` loop that forced every local captured by a nested closure to be mirrored into `env` before capture).

`capture_closure_env` now reads a free variable that is one of **this frame's own locals** straight from the **slot store** (`self.locals[slot]`, the live upvalue), instead of from the (formerly flushed) env. A slot-only local is no longer mirrored into `env` for closure visibility — the closure is fully decoupled from the forward-flush machinery, and `env` is a derived view (§3 of `docs/vm-single-store.md`).

### Unchanged
- **Ancestor free vars** (no slot in this frame) and **system names** still come from the flattened env, where they always live.
- **Mutation propagation** back to the parent: reverse `env_dirty` path + the shared `ContainerRef` cell `box_captured_lexicals` installs in both the slot and `env`.
- `compute_needs_env_sync` now marks only slots read/written **by name in this frame** (own-local GetGlobal-family), plus the `captures_env_by_name` whole-frame blanket for inline-body frames.

### Builds on
Slice E Part 1 (#3245, merged), which switched closure capture to an upvalue snapshot but deliberately kept branch #2 so capture could read correct values from the flushed env. Part 2 reads from the slot store instead and deletes branch #2.

### Tests
`make test` green (full `t/`, 918 files); clippy/fmt clean; closure/phaser/state/pointy/gather/supply roast PASS locally; full roast via CI. Pins: `t/single-store-slice-e.t`, `t/closure-attr-element-write.t`, `t/supply-await-static-whenever.t`, `t/closure-captured-state.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)