### PR TITLE
fix(parser): embedded scalar item assignment binds tighter than comma

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -491,7 +491,18 @@ fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
 
     let r = &r[1..];
     let (r, _) = ws(r)?;
-    let (r, rhs) = parse_assignment_rhs_mode(r, mode)?;
+    // Item assignment (`=`) to a bare scalar variable binds TIGHTER than the
+    // comma operator, so an embedded `$x = 1, 2` parses as `($x = 1), 2`. List
+    // assignment to an `@`/`%` container — and the parenthesized list-lvalue form
+    // `($x) = 1, 2` — keeps the comma-absorbing RHS. We test the pre-unwrap
+    // expression so a grouped `($x)` stays on the list-assignment path. (The
+    // statement-level counterpart lives in `stmt/assign.rs::assign_stmt`.)
+    let scalar_item_assign = matches!(&expr, Expr::Var(_));
+    let (r, rhs) = if scalar_item_assign {
+        ternary_mode(r, mode)?
+    } else {
+        parse_assignment_rhs_mode(r, mode)?
+    };
 
     let expr = unwrap_grouped_lvalue(expr);
     match expr {

--- a/t/scalar-item-assign-precedence.t
+++ b/t/scalar-item-assign-precedence.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 10;
+plan 13;
 
 # Item assignment (`=`) to a bare scalar variable binds TIGHTER than the comma
 # operator: `$x = 1, 2` parses as `($x = 1), 2`, so only the first element is
@@ -67,4 +67,22 @@ plan 10;
     my $x;
     $x = 1 + 2, 99;
     is $x, 3, 'scalar item assignment evaluates the first operand expression';
+}
+
+# Embedded scalar assignment (inside an expression / argument list) also binds
+# item assignment tighter than comma.
+{
+    my ($x, $y);
+    $x = $y = 1, 2;
+    is $x, 1, 'nested scalar assignment assigns the outer the first element';
+    is $y, 1, 'nested scalar assignment assigns the inner the first element';
+}
+
+# A scalar item assignment inside a call's argument list contributes one
+# argument; the trailing comma starts the next argument.
+{
+    sub two-args($a, $b) { "$a|$b" }
+    my $x;
+    is two-args($x = 1, 2), "1|2",
+        'embedded scalar assignment in an argument list yields two arguments';
 }


### PR DESCRIPTION
## Summary

Completes the scalar item-assignment precedence fix from #3246 (which handled the statement-level `assign_stmt` path). The **embedded** assignment path — `expr/precedence.rs::assign_not_expr_mode`, used when an assignment appears inside an expression or argument list — still fed the RHS through the comma-absorbing `parse_assignment_rhs_mode`, so `$x = $y = 1, 2` and `func($x = 1, 2)` wrongly absorbed the whole comma list into the inner scalar assignment.

## Fix

Mirror the rule used at statement level: for a bare `$`-variable lvalue, parse a single RHS operand via `ternary_mode` (keeps a parenthesized list whole, stops at a bare top-level comma) instead of comma-absorbing `parse_assignment_rhs_mode`. The pre-unwrap expression is tested so a grouped `($x)` list-lvalue stays on the comma-absorbing path; `@`/`%` containers are unchanged.

Now matches `raku`:
- `$x = $y = 1, 2` → `($x = ($y = 1)), 2` (both scalars get `1`, `2` sunk)
- `func($x = 1, 2)` → two arguments `($x = 1)` and `2`

## Validation

- `make test` (t/ + cargo test): PASS
- `make roast` (**full whitelist: 1281 files, 207,771 tests**): PASS — zero regressions from this broad parser change
- `t/scalar-item-assign-precedence.t` +3 embedded cases (13 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)