### PR TITLE
fix(grep): flatten a Seq argument so `grep BLOCK, @a.sort` iterates elements

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1453,6 +1453,13 @@ impl Interpreter {
                 {
                     list_items.extend(items.iter().cloned());
                 }
+                // A Seq (e.g. the result of `@a.sort`) is an iterable sequence and
+                // is flattened into grep's list, mirroring `map` (which already
+                // handles `Value::Seq`). Without this, `grep { ... }, @a.sort`
+                // greps over a single one-element list.
+                Value::Seq(items) => {
+                    list_items.extend(items.iter().cloned());
+                }
                 v if v.is_range() => {
                     // Route ranges through the unified pull iterator so an
                     // open-ended range (`1..Inf` == `Range(1, i64::MAX)`) is

--- a/t/grep-flattens-seq.t
+++ b/t/grep-flattens-seq.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 6;
+
+# `grep BLOCK, <Seq>` must flatten the (eager) Seq into the list to grep over,
+# the same way `map` and an Array argument already do. `@a.sort` returns a Seq.
+{
+    my @a = 3, 1, 2;
+    is (grep { 1 }, @a.sort).elems, 3, 'grep flattens a Seq from .sort (count)';
+    is-deeply (grep { $_ > 1 }, @a.sort).List, (2, 3),
+        'grep filters over a flattened Seq';
+}
+
+# The classic for-loop form from S04-statements/for.t test 46.
+{
+    my @array = 1, 2, 3, 4;
+    my $output = '';
+    for (grep { 1 }, @array.sort) -> $elem {
+        $output ~= "$elem,";
+    }
+    is $output, "1,2,3,4,", 'grep and sort work in a for loop';
+}
+
+# A Seq held in a scalar is still flattened by grep (matches Rakudo).
+{
+    my @a = 1, 2, 3;
+    my $s = @a.sort;
+    is (grep { $_ > 1 }, $s).elems, 2, 'grep flattens a Seq held in a scalar';
+}
+
+# An explicit comma list and an array argument keep working unchanged.
+{
+    is (grep { $_ %% 2 }, 1, 2, 3, 4).elems, 2, 'grep over an explicit comma list';
+    my @a = 1, 2, 3, 4, 5, 6;
+    is (grep { $_ %% 2 }, @a).elems, 3, 'grep over an array variable';
+}


### PR DESCRIPTION
## Summary

`builtin_grep` flattened `Value::Array` list arguments but fed a `Value::Seq` (e.g. the result of `@a.sort`) through the catch-all `other` arm, pushing the whole sequence as a single item. So `grep { 1 }, @a.sort` grepped over a one-element list instead of the sorted elements, and `for (grep { 1 }, @a.sort)` iterated once over the stringified list.

## Fix

Add a `Value::Seq` arm to `builtin_grep`'s list-flattening loop that extends the list with the sequence's elements — mirroring `builtin_map`, which already handles `Value::Seq`. A Seq held in a scalar is flattened too, matching Rakudo (`my $s = @a.sort; grep {…}, $s` → flattens).

Verified against `raku`:
- `grep { 1 }, @a.sort` → all elements (was 1)
- `grep { $_ > 1 }, @a.sort` → filtered elements
- `for (grep { 1 }, @a.sort)` → iterates each

## Result

Fixes roast `S04-statements/for.t` test 46 ("grep and sort work in for") — for.t 12 → 11 failing. `grep.t` / `map.t` / `first.t` still pass.

### Note

A *lazy* gather Seq (unmaterialized `items`) still yields nothing through grep — that is a separate lazy-Seq materialization limitation shared with `map`, out of scope here.

## Tests

`t/grep-flattens-seq.t` (6 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)