### PR TITLE
fix(warnings): no spurious "Useless use of $@a in sink context" on array := bind

### DIFF
--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -301,6 +301,13 @@ fn describe_useless(expr: &Expr) -> Option<String> {
         Expr::Grouped(inner) => describe_useless(inner),
         Expr::PositionalPair(inner) => describe_useless(inner),
         Expr::Literal(v) => describe_literal(v),
+        // A `Var` node whose name already carries a sigil (`@a`, `%h`) is a
+        // synthetic artifact of `:=` bind desugaring — the trailing result
+        // expression a container bind leaves in its SyntheticBlock — not a
+        // user-written bare scalar. A real bare `@a` parses to `ArrayVar("a")`,
+        // so this never suppresses a genuine sink warning; it only stops the
+        // spurious "Useless use of $@a in sink context" on `my @a := @b`.
+        Expr::Var(n) if n.starts_with(['$', '@', '%', '&']) => None,
         Expr::Var(n) => Some(format!("${}", n)),
         Expr::ArrayVar(n) => Some(format!("@{}", n)),
         Expr::HashVar(n) => Some(format!("%{}", n)),

--- a/t/doesnt-warn.t
+++ b/t/doesnt-warn.t
@@ -2,10 +2,18 @@ use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 
-plan 4;
+plan 7;
 
 # Code without warnings passes
 doesn't-warn 'say 42', 'say does not warn';
+
+# A `:=` bind of a container variable is a binding (a side effect), not a
+# useless value. The array-bind desugaring leaves a trailing `@a` result
+# expression in its SyntheticBlock; sink analysis must not flag it (it used
+# to spuriously warn "Useless use of $@a in sink context").
+doesn't-warn 'my @b = (1, 2, 3); my @a := @b', 'my array := bind does not warn';
+doesn't-warn 'our @b = (1, 2, 3); our @a := @b', 'our array := bind does not warn';
+doesn't-warn 'my %b = (x => 1); my %a := %b', 'my hash := bind does not warn';
 
 # Simple expression whose value is consumed does not warn.
 # (A bare `1 + 2` in sink context DOES warn: "Useless use of ... in sink context".)


### PR DESCRIPTION
## Problem

`my @a := @b;` (and `our @a := @b;`) emitted a bogus warning:

```
Useless use of $@a in sink context (line 1)
```

Rakudo emits **no** warning — a `:=` bind is a side effect, not a useless value. The name `$@a` is itself malformed (double sigil).

## Root cause

The array-bind desugaring leaves a trailing `@a` result expression in its `SyntheticBlock` (so the bind evaluates to the bound array):

```
SyntheticBlock([
    VarDecl { name: "@a", expr: ArrayVar("b"), .. },
    Expr(Call { name: "__mutsu_record_bound_array_len", .. }),
    Expr(Call { name: "__mutsu_record_shaped_array_dims", .. }),
    Expr(Var("@a")),   # <-- trailing result, sink-analysed as useless
])
```

That trailing reference is an `Expr::Var("@a")` — a `Var` node whose name carries the `@` sigil. `describe_useless` rendered it via `format!("${}", n)` → `$@a` and flagged it.

## Fix

A genuine bare `@a` in sink context parses to `Expr::ArrayVar("a")`, **not** `Expr::Var("@a")` — so a `Var` whose name already carries a sigil is exclusively a bind-desugar artifact. `describe_useless` now returns `None` for such nodes. This suppresses only the synthetic case; real bare-variable sink warnings (`@a;`, `$x;`, `%h;`, `42;`) stay intact.

## Tests

- `t/doesnt-warn.t` (+3: `my`/`our` array bind, `my` hash bind)
- Verified genuine `@a;`/`$x;`/`%h;`/`42;` bare-sink warnings still fire (match Rakudo)
- `make test` PASS (8853 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)