### PR TITLE
feat(WALK): WalkList dual list+callable return with all orderings & submethods

### DIFF
--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -46,29 +46,32 @@ impl Interpreter {
         // Parse arguments.
         let mut method_name: Option<String> = None;
         let mut want_roles = false;
-        let mut want_super = true; // default: walk class MRO
+        let mut order = WalkOrder::Canonical; // default ordering
         for arg in args {
-            match arg {
-                Value::Pair(k, v) => match k.as_str() {
-                    "name" => method_name = Some(v.to_string_value()),
-                    "roles" => want_roles = v.truthy(),
-                    "super" => want_super = v.truthy(),
-                    "method" | "submethod" | "omit" => { /* accepted; default behaviour */ }
-                    _ => {}
-                },
-                Value::ValuePair(k, v) => {
-                    let key = k.to_string_value();
-                    match key.as_str() {
-                        "name" => method_name = Some(v.to_string_value()),
-                        "roles" => want_roles = v.truthy(),
-                        "super" => want_super = v.truthy(),
-                        "method" | "submethod" | "omit" => {}
-                        _ => {}
-                    }
-                }
+            let named: Option<(String, &Value)> = match arg {
+                Value::Pair(k, v) => Some((k.clone(), v.as_ref())),
+                Value::ValuePair(k, v) => Some((k.to_string_value(), v.as_ref())),
                 other => {
                     if method_name.is_none() {
                         method_name = Some(other.to_string_value());
+                    }
+                    None
+                }
+            };
+            if let Some((key, v)) = named {
+                match key.as_str() {
+                    "name" => method_name = Some(v.to_string_value()),
+                    "roles" => want_roles = v.truthy(),
+                    _ => {
+                        // `:canonical`/`:super`/`:breadth`/`:ascendant`/`:descendant`
+                        // /`:preorder`/`:postorder` select the ordering.
+                        // `:method`/`:submethod`/`:omit`/`:include` accepted; handled
+                        // elsewhere or defaulted.
+                        if let Some(o) = WalkOrder::from_adverb(&key)
+                            && v.truthy()
+                        {
+                            order = o;
+                        }
                     }
                 }
             }
@@ -77,9 +80,9 @@ impl Interpreter {
             return Ok(None);
         };
 
-        // Build the walk order: BFS over class MRO, optionally including
-        // composed roles via `class_composed_roles` and `role_parents`.
-        let walk_targets = self.build_walk_targets(&receiver_class_name, want_super, want_roles);
+        // Build the walk order over the class hierarchy in the requested order,
+        // optionally including composed roles.
+        let walk_targets = self.build_walk_targets(&receiver_class_name, order, want_roles);
 
         // For each (kind, owner-name), look up an "own" MethodDef for the
         // named method and invoke it on the original invocant.
@@ -123,23 +126,16 @@ impl Interpreter {
     fn build_walk_targets(
         &self,
         class_name: &str,
-        want_super: bool,
+        order: WalkOrder,
         want_roles: bool,
     ) -> Vec<(WalkKind, String)> {
         let mut out: Vec<(WalkKind, String)> = Vec::new();
         let mut visited_classes: HashSet<String> = HashSet::new();
         let mut visited_roles: HashSet<String> = HashSet::new();
 
-        // Walk classes in MRO order. For each class, add the class itself
-        // and (if `:roles`) BFS over its composed roles.
-        let mro = self
-            .class_mro_readonly(class_name)
-            .unwrap_or_else(|| vec![class_name.to_string()]);
-        let class_chain: Vec<String> = if want_super {
-            mro
-        } else {
-            vec![class_name.to_string()]
-        };
+        // Walk classes in the requested order. For each class, add the class
+        // itself and (if `:roles`) BFS over its composed roles.
+        let class_chain: Vec<String> = self.walk_class_order(class_name, order);
 
         for cn in &class_chain {
             if cn == "Mu" || cn == "Any" || cn == "Cool" {
@@ -187,6 +183,96 @@ impl Interpreter {
     /// Read-only variant of class_mro for use from non-mut helpers.
     fn class_mro_readonly(&self, class_name: &str) -> Option<Vec<String>> {
         self.registry().class_mro_cached(class_name)
+    }
+
+    /// Direct (declared) parent classes of `class_name`, in declaration order,
+    /// restricted to user/builtin class definitions and excluding the implicit
+    /// `Any`/`Mu`/`Cool` roots (which never carry WALKable methods here).
+    fn walk_direct_parents(&self, class_name: &str) -> Vec<String> {
+        let registry = self.registry();
+        let Some(def) = registry.classes.get(class_name) else {
+            return Vec::new();
+        };
+        def.parents
+            .iter()
+            .filter(|p| !matches!(p.as_str(), "Any" | "Mu" | "Cool"))
+            .filter(|p| registry.classes.contains_key(*p))
+            .cloned()
+            .collect()
+    }
+
+    /// Compute the ordered list of class names to walk for the requested
+    /// ordering. All walks dedup keeping the FIRST occurrence. `Any`/`Mu`/`Cool`
+    /// are excluded. Reverse-engineered from S12-introspection/walk.t:
+    /// for `E is C is D`, `C is A is B`, `D is A` the receiver `E` yields
+    /// canonical=ECDAB, super=CD, breadth=ECDAB, ascendant/preorder=ECABD,
+    /// descendant=ABCDE.
+    fn walk_class_order(&self, receiver: &str, ordering: WalkOrder) -> Vec<String> {
+        let exclude = |n: &str| matches!(n, "Any" | "Mu" | "Cool");
+        match ordering {
+            WalkOrder::Canonical => self
+                .class_mro_readonly(receiver)
+                .unwrap_or_else(|| vec![receiver.to_string()])
+                .into_iter()
+                .filter(|n| !exclude(n))
+                .collect(),
+            WalkOrder::Super => self.walk_direct_parents(receiver),
+            WalkOrder::Breadth => {
+                let mut out = Vec::new();
+                let mut seen = HashSet::new();
+                let mut queue: std::collections::VecDeque<String> =
+                    std::collections::VecDeque::new();
+                queue.push_back(receiver.to_string());
+                while let Some(c) = queue.pop_front() {
+                    if exclude(&c) || !seen.insert(c.clone()) {
+                        continue;
+                    }
+                    out.push(c.clone());
+                    for p in self.walk_direct_parents(&c) {
+                        queue.push_back(p);
+                    }
+                }
+                out
+            }
+            WalkOrder::Ascendant => {
+                // DFS preorder, dedup keeping first.
+                let mut out = Vec::new();
+                let mut seen = HashSet::new();
+                self.walk_preorder(receiver, &mut out, &mut seen);
+                out
+            }
+            WalkOrder::Descendant => {
+                // DFS postorder, dedup keeping first.
+                let mut out = Vec::new();
+                let mut seen = HashSet::new();
+                self.walk_postorder(receiver, &mut out, &mut seen);
+                out
+            }
+        }
+    }
+
+    fn walk_preorder(&self, class_name: &str, out: &mut Vec<String>, seen: &mut HashSet<String>) {
+        if matches!(class_name, "Any" | "Mu" | "Cool") {
+            return;
+        }
+        if seen.insert(class_name.to_string()) {
+            out.push(class_name.to_string());
+        }
+        for p in self.walk_direct_parents(class_name) {
+            self.walk_preorder(&p, out, seen);
+        }
+    }
+
+    fn walk_postorder(&self, class_name: &str, out: &mut Vec<String>, seen: &mut HashSet<String>) {
+        if matches!(class_name, "Any" | "Mu" | "Cool") {
+            return;
+        }
+        for p in self.walk_direct_parents(class_name) {
+            self.walk_postorder(&p, out, seen);
+        }
+        if seen.insert(class_name.to_string()) {
+            out.push(class_name.to_string());
+        }
     }
 
     /// Look up the "own" MethodDef for `method_name` on the given class or role.
@@ -248,4 +334,27 @@ impl Interpreter {
 enum WalkKind {
     Class,
     Role,
+}
+
+/// Traversal ordering for `WALK`. `:preorder` is an alias for `:ascendant`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WalkOrder {
+    Canonical,
+    Super,
+    Breadth,
+    Ascendant,
+    Descendant,
+}
+
+impl WalkOrder {
+    fn from_adverb(name: &str) -> Option<WalkOrder> {
+        match name {
+            "canonical" => Some(WalkOrder::Canonical),
+            "super" => Some(WalkOrder::Super),
+            "breadth" => Some(WalkOrder::Breadth),
+            "ascendant" | "preorder" => Some(WalkOrder::Ascendant),
+            "descendant" | "postorder" => Some(WalkOrder::Descendant),
+            _ => None,
+        }
+    }
 }

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -84,43 +84,176 @@ impl Interpreter {
         // optionally including composed roles.
         let walk_targets = self.build_walk_targets(&receiver_class_name, order, want_roles);
 
-        // For each (kind, owner-name), look up an "own" MethodDef for the
-        // named method and invoke it on the original invocant.
-        let mut results: Vec<Value> = Vec::new();
+        // For each (kind, owner-name) that has an "own" candidate for the named
+        // method, build a candidate closure `-> $inst, *@a { $inst.OWNER::name(|@a) }`.
+        // Reusing qualified method-call dispatch (which already handles
+        // submethods) means `$cand($instance)` and the batch-invoke share one
+        // code path.
+        let mut candidates: Vec<Value> = Vec::new();
+        let mut matched: Vec<(WalkKind, String)> = Vec::new();
         for (kind, owner) in &walk_targets {
-            if let Some(method_def) =
-                self.lookup_own_walk_method(kind, owner, &receiver_class_name, &method_name)
+            if self
+                .lookup_own_walk_method(kind, owner, &receiver_class_name, &method_name)
+                .is_some()
             {
-                let attributes = match target {
-                    Value::Instance { attributes, .. } => attributes.to_map(),
-                    _ => std::collections::HashMap::new(),
-                };
-                let result = self.run_instance_method_resolved(
-                    &receiver_class_name,
-                    owner,
-                    method_def,
-                    attributes,
-                    Vec::new(),
-                    Some(target.clone()),
-                )?;
-                results.push(result.0);
+                candidates.push(Self::make_walk_candidate(owner, &method_name));
+                matched.push((kind.clone(), owner.clone()));
             }
         }
 
-        // Wrap the precomputed results in a no-arg Sub whose body is the
-        // list literal `(v1, v2, ..., vN)`.
-        let body_exprs: Vec<Expr> = results.into_iter().map(Expr::Literal).collect();
-        let body = vec![Stmt::Expr(Expr::ArrayLiteral(body_exprs))];
-        let sub = Value::make_sub(
+        Ok(Some(self.make_walk_list(
+            candidates,
+            target.clone(),
+            &receiver_class_name,
+            &method_name,
+            &matched,
+        )))
+    }
+
+    /// Build a candidate closure that invokes `owner::method_name` on its first
+    /// argument, forwarding any additional arguments: `-> $inst, *@a { $inst.OWNER::name(|@a) }`.
+    fn make_walk_candidate(owner: &str, method_name: &str) -> Value {
+        let qualified = Symbol::intern(&format!("{owner}::{method_name}"));
+        let body = vec![Stmt::Expr(Expr::MethodCall {
+            target: Box::new(Expr::Var("__walk_inst".to_string())),
+            name: qualified,
+            args: vec![Expr::Unary {
+                op: crate::token_kind::TokenKind::Pipe,
+                expr: Box::new(Expr::ArrayVar("__walk_args".to_string())),
+            }],
+            modifier: None,
+            quoted: false,
+        })];
+        let inst_param = walk_param("__walk_inst", false);
+        let slurpy_param = walk_param("@__walk_args", true);
+        Value::make_sub(
             Symbol::intern(""),
-            Symbol::intern("WALK"),
-            Vec::new(),
-            Vec::new(),
+            Symbol::intern("WALK-candidate"),
+            vec!["__walk_inst".to_string(), "@__walk_args".to_string()],
+            vec![inst_param, slurpy_param],
             body,
             false,
             Env::new(),
+        )
+    }
+
+    /// Construct a `WalkList` instance. Stored as a built-in `WalkList` class
+    /// instance so it can be both list-iterated (its candidate closures, for
+    /// `my @cands = $x.WALK(...)`) and invoked (`()`/`.invoke`). The matched
+    /// targets (`kind|owner` pairs) plus the receiver class and method name are
+    /// stored so the invoke path can resolve and call each method DIRECTLY —
+    /// which is correct for role submethods, where a qualified-call closure would
+    /// not resolve.
+    fn make_walk_list(
+        &self,
+        candidates: Vec<Value>,
+        invocant: Value,
+        receiver_class: &str,
+        method_name: &str,
+        matched: &[(WalkKind, String)],
+    ) -> Value {
+        let targets: Vec<Value> = matched
+            .iter()
+            .map(|(kind, owner)| {
+                let tag = match kind {
+                    WalkKind::Class => "C",
+                    WalkKind::Role => "R",
+                };
+                Value::str(format!("{tag}|{owner}"))
+            })
+            .collect();
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("candidates".to_string(), Value::real_array(candidates));
+        attrs.insert("invocant".to_string(), invocant);
+        attrs.insert("reversed".to_string(), Value::Bool(false));
+        attrs.insert("quiet".to_string(), Value::Bool(false));
+        attrs.insert("targets".to_string(), Value::real_array(targets));
+        attrs.insert(
+            "receiver_class".to_string(),
+            Value::str(receiver_class.to_string()),
         );
-        Ok(Some(sub))
+        attrs.insert(
+            "method_name".to_string(),
+            Value::str(method_name.to_string()),
+        );
+        Value::make_instance(Symbol::intern("WalkList"), attrs)
+    }
+
+    /// Invoke a WalkList: resolve and call each matched method DIRECTLY on the
+    /// original invocant (correct for both class methods/submethods and role
+    /// submethods), forwarding `args`. In quiet mode a thrown exception becomes a
+    /// `Failure` in that slot. Slips are returned as-is.
+    pub(crate) fn walk_list_invoke_direct(
+        &mut self,
+        walk_list: &Value,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let Value::Instance { attributes, .. } = walk_list else {
+            return Ok(Value::real_array(Vec::new()));
+        };
+        let (targets, invocant, receiver_class, method_name, reversed, quiet) = {
+            let map = attributes.as_map();
+            let targets: Vec<String> = match map.get("targets") {
+                Some(Value::Array(items, ..)) => {
+                    items.iter().map(|v| v.to_string_value()).collect()
+                }
+                _ => Vec::new(),
+            };
+            let invocant = map.get("invocant").cloned().unwrap_or(Value::Nil);
+            let receiver_class = map
+                .get("receiver_class")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            let method_name = map
+                .get("method_name")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            let reversed = matches!(map.get("reversed"), Some(Value::Bool(true)));
+            let quiet = matches!(map.get("quiet"), Some(Value::Bool(true)));
+            (
+                targets,
+                invocant,
+                receiver_class,
+                method_name,
+                reversed,
+                quiet,
+            )
+        };
+        let attributes_map = match &invocant {
+            Value::Instance { attributes, .. } => attributes.to_map(),
+            _ => std::collections::HashMap::new(),
+        };
+        let mut order: Vec<String> = targets;
+        if reversed {
+            order.reverse();
+        }
+        let mut results: Vec<Value> = Vec::with_capacity(order.len());
+        for tag in &order {
+            let (kind, owner) = match tag.split_once('|') {
+                Some(("C", o)) => (WalkKind::Class, o.to_string()),
+                Some(("R", o)) => (WalkKind::Role, o.to_string()),
+                _ => continue,
+            };
+            let Some(method_def) =
+                self.lookup_own_walk_method(&kind, &owner, &receiver_class, &method_name)
+            else {
+                continue;
+            };
+            let call = self.run_instance_method_resolved(
+                &receiver_class,
+                &owner,
+                method_def,
+                attributes_map.clone(),
+                args.clone(),
+                Some(invocant.clone()),
+            );
+            match call {
+                Ok((v, _)) => results.push(v),
+                Err(e) if quiet => results.push(self.fail_error_to_failure_value(&e)),
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Value::real_array(results))
     }
 
     fn build_walk_targets(
@@ -297,9 +430,14 @@ impl Interpreter {
                         .find(|m| m.role_origin.is_none() && !m.is_private)
                         .cloned()
                 } else {
+                    // Submethods are not inherited (often flagged `is_my` so normal
+                    // dispatch skips them on subclasses), but WALK explicitly visits
+                    // each level's OWN submethods, so they must not be filtered here.
                     overloads
                         .iter()
-                        .find(|m| m.role_origin.is_none() && !m.is_private && !m.is_my)
+                        .find(|m| {
+                            m.role_origin.is_none() && !m.is_private && (!m.is_my || m.is_submethod)
+                        })
                         .cloned()
                 }
             }
@@ -327,6 +465,32 @@ impl Interpreter {
                     .cloned()
             }
         }
+    }
+}
+
+/// Build a minimal `ParamDef` for a WALK candidate closure: a single positional
+/// `$name`, or a slurpy `*@name` when `slurpy` is true.
+fn walk_param(name: &str, slurpy: bool) -> crate::ast::ParamDef {
+    crate::ast::ParamDef {
+        name: name.to_string(),
+        default: None,
+        multi_invocant: true,
+        required: false,
+        named: false,
+        slurpy,
+        double_slurpy: false,
+        onearg: false,
+        sigilless: false,
+        type_constraint: None,
+        literal_value: None,
+        sub_signature: None,
+        where_constraint: None,
+        traits: Vec::new(),
+        optional_marker: false,
+        outer_sub_signature: None,
+        code_signature: None,
+        is_invocant: false,
+        shape_constraints: None,
     }
 }
 

--- a/src/runtime/ops.rs
+++ b/src/runtime/ops.rs
@@ -1598,6 +1598,15 @@ impl Interpreter {
                 })
                 .collect(),
             Value::Slip(items) => items.to_vec(),
+            // A WalkList flattens to its candidate closures in list context.
+            Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name.resolve() == "WalkList" => {
+                crate::runtime::utils::walk_list_candidates(attributes)
+                    .unwrap_or_else(|| vec![val.clone()])
+            }
             // Nil is a single scalar item in list context (e.g. `for Nil { }`
             // does one iteration); it is not an empty list.
             other => vec![other.clone()],

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -867,6 +867,16 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
                 })
                 .collect(),
         ),
+        // A WalkList assigned to an `@` variable flattens to its candidate
+        // closures, so `my @cands = $x.WALK(...)` yields the per-level candidates.
+        Value::Instance {
+            ref class_name,
+            ref attributes,
+            ..
+        } if class_name.resolve() == "WalkList" => match walk_list_candidates(attributes) {
+            Some(cands) => Value::real_array(cands),
+            None => Value::real_array(vec![value.clone()]),
+        },
         other => Value::real_array(vec![other]),
     }
 }
@@ -1910,6 +1920,21 @@ pub(crate) fn pair_as_positional(val: &Value) -> Value {
     }
 }
 
+/// Extract the candidate closures from a `WalkList` instance's attributes,
+/// honoring its `reversed` flag. Returns `None` if the attributes are not
+/// shaped like a WalkList.
+pub(crate) fn walk_list_candidates(attributes: &crate::value::InstanceAttrs) -> Option<Vec<Value>> {
+    let map = attributes.as_map();
+    let Some(Value::Array(items, ..)) = map.get("candidates") else {
+        return None;
+    };
+    let mut cands = items.to_vec();
+    if matches!(map.get("reversed"), Some(Value::Bool(true))) {
+        cands.reverse();
+    }
+    Some(cands)
+}
+
 pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
     match val {
         Value::Array(items, kind) if kind.is_itemized() => vec![val.clone()],
@@ -2233,7 +2258,18 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
             .map(|(k, v)| Value::Pair(k.clone(), Box::new(crate::value::mix_weight_to_value(*v))))
             .collect(),
         Value::Slip(items) => items.to_vec(),
-        Value::Instance { attributes, .. } => {
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } => {
+            // A WalkList flattens to its candidate closures in list context, so
+            // `my @cands = $x.WALK(...)` yields the per-level candidates.
+            if class_name.resolve() == "WalkList"
+                && let Some(items) = walk_list_candidates(attributes)
+            {
+                return items;
+            }
             if let Some(Value::Array(items, ..)) = attributes.as_map().get("__array_items") {
                 return items.to_vec();
             }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -327,6 +327,14 @@ impl Interpreter {
             target
         };
 
+        // A WalkList is invoked (`$x.WALK(...)()`) by calling each candidate on
+        // the original invocant, forwarding any arguments.
+        if let Value::Instance { class_name, .. } = &target
+            && class_name.resolve() == "WalkList"
+        {
+            return self.walk_list_invoke_direct(&target, args);
+        }
+
         // Fast path: Sub with compiled_code
         if let Value::Sub(ref data) = target
             && let Some(ref cc) = data.compiled_code

--- a/t/walk-orderings.t
+++ b/t/walk-orderings.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 11;
+
+# Mu.WALK walks the class hierarchy in a requested order and returns a WalkList
+# that is both list-iterable (the per-level candidate closures) and invocable
+# (calls each candidate on the original invocant). Mirrors the orderings in
+# roast S12-introspection/walk.t.
+class A { method m {'A'}; submethod sm {'a'} }
+class B { method m {'B'}; submethod sm {'b'} }
+class C is A is B { method m {'C'}; submethod sm {'c'} }
+class D is A { method m {'D'}; submethod sm {'d'} }
+class E is C is D { method m {'E'}; submethod sm {'e'} }
+
+sub cand_order(@cands, $instance) {
+    my $r = '';
+    $r ~= $_($instance) for @cands;
+    $r;
+}
+
+my $x = E.new;
+
+my @cands;
+@cands = $x.WALK(:name<m>, :canonical);  is cand_order(@cands, $x), 'ECDAB', ':canonical (C3 MRO)';
+@cands = $x.WALK(:name<m>);              is cand_order(@cands, $x), 'ECDAB', ':canonical is the default';
+@cands = $x.WALK(:name<m>, :super);      is cand_order(@cands, $x), 'CD',    ':super (direct parents)';
+@cands = $x.WALK(:name<m>, :breadth);    is cand_order(@cands, $x), 'ECDAB', ':breadth (BFS)';
+@cands = $x.WALK(:name<m>, :descendant); is cand_order(@cands, $x), 'ABCDE', ':descendant';
+@cands = $x.WALK(:name<m>, :ascendant);  is cand_order(@cands, $x), 'ECABD', ':ascendant';
+@cands = $x.WALK(:name<m>, :preorder);   is cand_order(@cands, $x), 'ECABD', ':preorder is :ascendant';
+
+# Submethods are walked per level too (not inherited via normal dispatch).
+@cands = $x.WALK(:name<sm>);             is cand_order(@cands, $x), 'ecdab', ':canonical works with submethods';
+
+# Invoking the WalkList calls each method on the original invocant.
+is $x.WALK(:name<m>)().join, 'ECDAB', 'invoking the WalkList runs each method';
+
+# A method found on only one level yields a single candidate.
+class N is A { method only-here {'N!'} }
+my $n = N.new;
+is $n.WALK(:name<only-here>).elems, 1, 'a single-level method yields one candidate';
+is $n.WALK(:name<only-here>)().join, 'N!', 'and invokes to that one result';


### PR DESCRIPTION
## Summary

Implements the core of `Mu.WALK` + `WalkList` (roast `S12-introspection/walk.t`, the "Hard but self-contained MOP" feature). `WALK` now returns a `WalkList` — a built-in-class instance that is **both list-iterable and callable**, matching Raku.

- **All 6 orderings** (`walk_class_order`): `:canonical` (C3 MRO), `:super` (direct parents), `:breadth` (BFS), `:ascendant`=`:preorder` (DFS preorder), `:descendant` (DFS postorder) — all dedup-first. Verified exact: ECDAB / CD / ECDAB / ECABD / ABCDE.
- **List form** `my @cands = $x.WALK(...)`: `coerce_to_array` (the @-assignment coercion) + both `value_to_list` functions flatten a WalkList to its per-level candidate closures `-> $inst, *@a { $inst.OWNER::name(|@a) }`, so `$cand($instance)` invokes that level's method via qualified-call dispatch (handles submethods).
- **Invoke form** `$x.WALK(...)()`: `vm_call_on_value` routes a WalkList to `walk_list_invoke_direct`, which resolves+calls each matched method **directly** via `run_instance_method_resolved`. Direct resolution (not the qualified-call closures) is required for **role submethods** — a `$inst.Role::method` closure doesn't resolve — so the WalkList stores the matched `kind|owner` targets, receiver class, and method name. This keeps the whitelisted `S14-roles/attributes-6e.t` (`WALK('attr-val', :roles)()`) green.
- **Submethods** walked per level: `lookup_own_walk_method` accepts a non-receiver candidate when `!is_my || is_submethod` (submethods are flagged `is_my` to block normal inheritance, but WALK must still visit them).

## Scope

walk.t Basics now passes its ordering (1-8), `:name<n>`/`:name<sn>` (12-15), and submethod (3) assertions. **Not yet whitelistable** — remaining for a later increment: `:omit`/`:include` filters, `Grammar.WALK` on builtin types, `isa-ok WalkList`, `.reverse`/`.quiet`/`.invoke` methods, Slip pass-through, role `$?PACKAGE` context, and the lazy subtest. Tracked in memory.

## Safety / tests

- `coerce_to_array`/`value_to_list` additions are **guarded by the `WalkList` class name** → non-WalkList list coercion unchanged.
- `t/walk-orderings.t` (11 tests) locks the working behaviors.
- `make test` passes (921 files, 8861 tests). Full `make roast` left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)