### PR TITLE
fix(parser+slip): whitelist S32-list/skip.t

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -440,17 +440,23 @@
 - [ ] roast/S32-list/roll.t
 - [ ] roast/S32-list/rotor.t
 - [ ] roast/S32-list/seq.t
-- [ ] roast/S32-list/skip.t
-  - **54/55 (2026-06-17).** Only test 53 (`.skip-all and .push-all on slipping
-    slippy iterators`) fails. Two remaining blockers: (1) its `plan +my @tests = ...`
-    line needs lexical `&`-sub listop-call precedence (`my (&plan,...)`; a `&`-sub
-    must attach a following prefix term as its argument) — deferred, the naive parser
-    registration regresses whitelisted S17-supply categorize/classify (the same name
-    later used as a sigilless `\mapper` var); (2) first-class container identity:
-    the custom `TimesIterator` does `$!times := times` (binds a private scalar
-    attribute to a passed-in container) and `$!times++` must write *through* to the
-    caller's `$times` — Phase 3 attribute-container binding. NOT whitelistable until
-    both land.
+- [x] roast/S32-list/skip.t
+  - **55/55 (2026-06-18) — WHITELISTED.** Test 53 (`.skip-all and .push-all on
+    slipping slippy iterators`) fixed via four general improvements (NOT the
+    container-identity work the old note assumed — `$!times := times` write-through
+    already worked):
+    1. Method bodies now register sigilless `\name` params as term symbols (parser),
+       so `method m(\times) { times }` reads `times` as the param, not the `times`
+       builtin.
+    2. `my &name` / `my (&plan,...)` now registers `name` as a listop user-sub, so
+       `plan +my @tests = ...` parses `+` as a prefix on the argument. The
+       categorize/classify regression (a later sigilless `\mapper` reusing the name)
+       is avoided by registering for-loop sigilless params as term symbols, which
+       shadow the outer `&name` (`is_user_declared_sub` checks term symbols first).
+    3. `MakeSlip` (`|EXPR`) now deconts/descalarizes its operand so `|$_` flattens an
+       itemized Seq element.
+    4. `MakeSlip` materializes a deferred-iterator `Seq` (`Seq.new($user_iterator)`),
+       driving user-defined `Iterator.pull-one` — so `($seq,).map(|*)` expands it.
   - Fixed 2026-06-17: (a) `.skip` on an uncached Seq now consumes the original
     (X::Seq::Consumed on re-iteration — test 54); (b) `@$s` array-context read of a
     Seq caches it / throws if already consumed.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1109,6 +1109,7 @@ roast/S32-list/reverse.t
 roast/S32-list/roll.t
 roast/S32-list/rotor.t
 roast/S32-list/seq.t
+roast/S32-list/skip.t
 roast/S32-list/snip.t
 roast/S32-list/sort.t
 roast/S32-list/squish.t

--- a/roast/S16-io/lines.testing
+++ b/roast/S16-io/lines.testing
@@ -1,5 +1,0 @@
-zero:
-:one:
-:two:
-:three:
-:four

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -1258,25 +1258,34 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
     // Collect &-sigil parameter names so they can be registered as user subs
     // inside the block scope — this prevents `m()` from being misread as `m//`
     // (a regex match) when `m` is bound via `-> &m { m() }`.
-    let code_param_names: Vec<String> = {
-        let mut names = Vec::new();
-        if let Some(ref p) = param
-            && let Some(bare) = p.strip_prefix('&')
-        {
-            names.push(bare.to_string());
+    // Also collect sigilless `\name` params (stored with a leading `\`) so they
+    // can be registered as term symbols, shadowing any outer `&name` sub — keeps
+    // `my &mapper = {...}; for ... -> \mapper { mapper.WHAT }` reading `mapper` as
+    // the loop variable, not as a call to the outer `&mapper`.
+    let mut code_param_names: Vec<String> = Vec::new();
+    let mut sigilless_param_names: Vec<String> = Vec::new();
+    for p in param.iter().chain(params.iter()) {
+        if let Some(bare) = p.strip_prefix('&') {
+            code_param_names.push(bare.to_string());
+        } else if let Some(bare) = p.strip_prefix('\\') {
+            sigilless_param_names.push(bare.to_string());
         }
-        for p in &params {
-            if let Some(bare) = p.strip_prefix('&') {
-                names.push(bare.to_string());
-            }
+    }
+    // The single-param form stores a sigilless `\name` without the leading `\`
+    // (multi-param form keeps it), so consult the ParamDef sigilless flags too.
+    for pd in param_def.iter().chain(params_def.iter()) {
+        if pd.sigilless && !sigilless_param_names.contains(&pd.name) {
+            sigilless_param_names.push(pd.name.clone());
         }
-        names
-    };
-    let (rest, body) = if !code_param_names.is_empty() {
+    }
+    let (rest, body) = if !code_param_names.is_empty() || !sigilless_param_names.is_empty() {
         let (r, _) = parse_char(rest, '{')?;
         super::simple::push_scope();
         for name in &code_param_names {
             super::simple::register_user_sub(name);
+        }
+        for name in &sigilless_param_names {
+            super::simple::register_user_term_symbol(name);
         }
         let result = block_inner(r);
         super::simple::pop_scope();

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -152,6 +152,11 @@ pub(in crate::parser::stmt) fn parse_destructuring_decl(
             };
             let (r2, n) = var_name(r)?;
             let full_name = format!("{}{}", prefix, n);
+            if sigil == b'&' {
+                // A `&name` destructure target (e.g. `my (&plan, &is) = ...`)
+                // makes a bare `name` callable as a list-op afterwards.
+                register_term_symbol_from_decl_name(&full_name);
+            }
             let (r2, _) = ws(r2)?;
 
             // Check for optional suffix '?'

--- a/src/parser/stmt/decl/helpers.rs
+++ b/src/parser/stmt/decl/helpers.rs
@@ -189,6 +189,11 @@ pub(super) fn register_term_symbol_from_decl_name(name: &str) {
             || callable_name.starts_with("postcircumfix:")
         {
             super::super::simple::register_user_sub(callable_name);
+        } else if is_plain_sub_name(callable_name) {
+            // A plain `&name` declaration (e.g. `my &plan = ...`) makes a bare
+            // `name` callable as a list-op, so `name +EXPR` parses the `+` as a
+            // prefix on the argument rather than as a binary operator term.
+            super::super::simple::register_user_sub(callable_name);
         }
     } else {
         // Don't register keywords as term symbols — they must be handled
@@ -199,6 +204,15 @@ pub(super) fn register_term_symbol_from_decl_name(name: &str) {
             super::super::simple::register_user_term_symbol(name);
         }
     }
+}
+
+/// Whether `name` is a plain sub identifier (letter/underscore start, no `:<...>`
+/// operator-category marker), as opposed to an operator declaration.
+fn is_plain_sub_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_alphabetic() || c == '_')
+        && !name.contains(':')
+        && !is_parser_keyword(name)
 }
 
 pub(super) fn normalize_language_version(version_token: &str) -> String {

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -1809,7 +1809,23 @@ fn method_decl_body_with_my(
 
     let (rest, traits) = parse_sub_traits(rest)?;
     let return_type = traits.return_type.or(param_return_type);
-    let (rest, body) = block(rest)?;
+    let (rest, body) = if param_defs.iter().any(|p| p.sigilless) {
+        // When there are sigilless params, register them as term symbols in the
+        // block scope so bare references resolve to the parameter rather than to
+        // a builtin/keyword of the same name (e.g. `method m(\times) { times }`).
+        let (r, _) = parse_char(rest, '{')?;
+        super::simple::push_scope();
+        for pd in &param_defs {
+            if pd.sigilless {
+                super::simple::register_user_term_symbol(&pd.name);
+            }
+        }
+        let result = super::block_inner(r);
+        super::simple::pop_scope();
+        result?
+    } else {
+        block(rest)?
+    };
     // When no explicit signature is given, collect placeholder variables
     // (@_, $^a, $^b, etc.) from the body as implicit parameters.
     let (params, param_defs) = if params.is_empty() && param_defs.is_empty() {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -443,8 +443,43 @@ impl Interpreter {
         self.stack.push(new_val);
     }
 
+    /// Pull every element from a deferred-iterator `Seq` (as stored by
+    /// `Seq.new($iterator)`), driving the iterator's `pull-one` until
+    /// `IterationEnd`. Works for both built-in and user-defined `Iterator`
+    /// classes. The deferred iterator is removed and the Seq is marked consumed.
+    pub(super) fn materialize_deferred_seq(&mut self, items_arc: &Arc<Vec<Value>>) -> Vec<Value> {
+        let Some(iterator) = crate::value::seq_take_deferred_iter(items_arc) else {
+            return (**items_arc).clone();
+        };
+        crate::value::seq_consume(items_arc).ok();
+        let mut pulled = Vec::new();
+        while let Ok(val) = self.call_method_with_values(iterator.clone(), "pull-one", vec![]) {
+            if matches!(&val, Value::Str(s) if s.as_str() == "IterationEnd")
+                || matches!(&val, Value::Package(name) if *name == crate::symbol::Symbol::intern("IterationEnd"))
+            {
+                break;
+            }
+            pulled.push(val);
+        }
+        pulled
+    }
+
     pub(super) fn exec_make_slip_op(&mut self) {
         let val = self.stack.pop().unwrap();
+        // Slipping (`|EXPR`) always flattens through containers/itemization, e.g.
+        // `|$_` where the topic is an itemized Seq element must expand the Seq's
+        // values (`($seq,).map(|*)`), not wrap the Seq as a single slip item.
+        let val = val.into_deref().into_descalarized();
+        // A `Seq.new($iterator)` stores its iterator deferred (empty backing vec).
+        // Slipping such a Seq must first pull all elements from the iterator
+        // (including user-defined `Iterator` classes), else `|$seq` yields nothing.
+        if let Value::Seq(items_arc) = &val
+            && crate::value::seq_has_deferred_iter(items_arc)
+        {
+            let pulled = self.materialize_deferred_seq(items_arc);
+            self.stack.push(Value::slip(pulled));
+            return;
+        }
         let items = match &val {
             Value::Array(items, ..) => (*items).to_vec(),
             Value::Slip(items) => (*items).to_vec(),


### PR DESCRIPTION
Passes `roast/S32-list/skip.t` fully (54/55 → 55/55, now whitelisted). Test 53
(".skip-all and .push-all on slipping slippy iterators") exercised four
independent gaps, each fixed as a general improvement:

1. **Method sigilless params as term symbols.** A `method m(\times) { times }`
   now reads bare `times` as the sigilless param, not the `times` builtin (subs
   already did this; methods didn't).

2. **`my &name` listop-call precedence.** `my &plan = ...` / `my (&plan, ...)`
   now register `plan` as a list-op user-sub, so `plan +my @tests = ...` parses
   `+` as a prefix on the argument rather than a binary operator. To avoid the
   categorize/classify regression flagged in prior attempts (a later sigilless
   `\mapper` reusing the same name), **for-loop sigilless params are also
   registered as term symbols**; `declared_term_symbol` (checked first in
   primary parsing) reads a bare `\mapper` as the loop variable, while `name()`
   with parens still dispatches to the sub (keeps `constant foo0` + `sub foo0`
   working).

3. **`|EXPR` deconts its operand.** `MakeSlip` now descalarizes/derefs so `|$_`
   flattens an itemized Seq element (`($seq,).map(|*)`).

4. **`|EXPR` materializes a deferred-iterator Seq.** `Seq.new($iterator)` stores
   its iterator without pulling; slipping it now drives `pull-one` to
   `IterationEnd`, including **user-defined `Iterator` classes**.

## Testing

- `roast/S32-list/skip.t` 55/55 (whitelisted)
- No regressions: `S17-supply/categorize.t`, `S32-list/classify-list.t`,
  `t/constant.t` all pass; broad sweep of 1146 whitelisted files clean (the only
  pre-existing failures — 3 `S32-str/*-encode-decode.t` — fail identically on
  `main` due to a local CWD/sample-path dependency, unrelated to this change).
- `cargo test --lib` 466 pass, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)