### PR TITLE
docs(env-locals): value-alias design for `$n = @z` ref-sharing + Arc-identity ripple gating it on Sub-slice 1a

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -157,10 +157,18 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
         - [~] **Stage 1**（escape-aware outer cell 化）着手 = audit（#3258）で blast radius を ~14 write サイトに特定。
               **for-rw writeback "site A" を array（#3259）/ hash（#3260）とも ContainerRef-aware 化**（`my @a:=@b`/`my %h:=%g` は
               既に同一 cell なのに writeback が deref せず取りこぼしていた＝`deref_container()`+共有 cell write-through で解決）。
-        - [ ] **bug ②（`$x = @arr` 参照共有）= 設計済（#3263・[docs/scalar-array-sharing.md](docs/scalar-array-sharing.md)）・実装は次セッション**:
+        - [~] **bug ②（`$x = @arr` 参照共有）= 設計済（#3263・[docs/scalar-array-sharing.md](docs/scalar-array-sharing.md)）・実装試行で順序確定（#3265）**:
               array を scalar スロットに代入するとコピーする（raku は同一 Array 参照共有）。`$n=@z` は既に同 Arc 共有だが `.push`
               構造変異が COW detach するのが真因。正準解＝source/target を共有 cell に昇格（escape-aware）。難所＝rebind（`$n=5`）vs
               mutate-through（`@z=(9)`）の区別で `:=` scalar を壊さないこと。Slice 2a（scalar var）→2b（要素/hash 値）→2c（bug②）→2d（args）。
+              - **[2026-06-18 実装試行で判明＝順序が逆だった]** Slice 2a（value-alias）を実装すると **core は全て動く**
+                （`MarkValueAliasSource` opcode + 共有 cell + detach、18-case pin 全 PASS・cargo 466/0・実装は
+                [docs/scalar-array-sharing.md](docs/scalar-array-sharing.md) §8）が、**`$a` を `ContainerRef` 化すると
+                source を Arc identity で追跡する既存 write-through が壊れる**（`t/pair-value-element-writethrough.t` #2943 が回帰）。
+                ∴ **2a の前に「Arc-identity write-through サイトの ContainerRef-aware 化」を完了させる必要**＝下記 Stage 1 の
+                残りはまさにこれ。**次セッションの正しい着手順序: (1) Arc-identity write-through サイト（pair-value #2943 を起点に
+                棚卸し）を decont 化 → (2) value-alias を §8 のまま再適用 → 2b/2c/2d。** Stage 0 が `[x]` でも write 側の
+                Arc-identity 機構が未網羅だったのが盲点。
       - Phase 0.5 第2段（任意・実挙動変化）: `GetArrayVar`/`Index` の auto-decont + 新 lvalue opcode の本配線。
       - Phase 3 機会的残: 属性束縛（`$!x :=` / per-attribute container template、S03-binding/attributes・S14-traits 5-8）。
 - [ ] **Slice F（収束点）** — coarse 機構削除（`env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`/`saved_env_dirty`）。

--- a/docs/scalar-array-sharing.md
+++ b/docs/scalar-array-sharing.md
@@ -146,9 +146,53 @@ method-call wall-clock**(#2746 教訓: perf 回帰は roast timeout でしか出
 
 ---
 
-## 7. 参照
+## 8. 実装試行の結果(2026-06-18) — Slice 2a は動くが Arc-identity ripple で revert
+
+Slice 2a(scalar `$n = @z` の cell 共有 = "value-alias")を実装し検証した。**設計は正しく、§5 の
+スライス順序を裏付けた。** 結論: **value-alias は Sub-slice 1a(write-chokepoint decont)を先に landing
+しないと既存の Arc-identity 機構を壊す。** revert 済み。
+
+### 動いた実装(次回そのまま再利用可)
+
+- 新 opcode `MarkValueAliasSource(name_idx)`(`opcode.rs`)を compiler が `my $n = @z`/`$n = @z`
+  (scalar = whole `@`/`%` var)で SetLocal 直前に emit(`compiler/stmt.rs` VarDecl else 分岐 ＋
+  Stmt::Assign plain-assign 分岐、**local scalar 限定**＝SetLocal が flag を消費するため・SetGlobal だと
+  flag が dangling)。**gotcha**: `Expr::ArrayVar(s)` の `s` は **sigil 無し**("z")。src は
+  `format!("@{}", s)` で sigil 付与しないと local slot "@z" にマッチしない(これで最初 share せず空振り)。
+- VM: `value_alias_source: Option<String>` field(`runtime/mod.rs`)。SetLocal 冒頭で take し
+  `setup_scalar_value_alias` を呼ぶ: src を共有 `ContainerRef` cell 化(bind path
+  `vm_var_assign_ops.rs:6192` と同型 — slot+env+saved frames へ書き戻し)、$n に同 cell、
+  `__mutsu_value_alias::$n` marker を env へ。snapshot(GetArrayVar の deref 値)は cell 不在時の初期値。
+- detach(§5 Slice 2a の「scalar への非-array 代入 = slot 置換」): value-alias marker 持ち ContainerRef
+  scalar への再代入は **cell write-through せず slot 置換**(`$n = 5` が @z を壊さない)。**gotcha**:
+  value-alias scalar は `simple_locals=false` になり read が env 経由になるため、detach は
+  `flush_local_to_env`(simple 限定で no-op)ではなく `env_mut().insert(name, v)` で env を直接上書き
+  しないと stale な ContainerRef が残り `say $n` が旧 array を読む。
+
+### 検証結果
+
+- **core 全 PASS**(`t/scalar-array-ref-sharing.t` 18 ケース): `my $n=@z; $n.push(99)` → @z 3 件、
+  element/push 両方向伝播、detach(push 後含む)、hash 版、itemized copy(`my @c=$n` → `[[1 2] 3]` raku 一致)。
+- `cargo test` 466/0、array/binding/list/signature roast spread clean。
+
+### revert 理由 — open-q#1/#2 が現実の壁
+
+`my $a = @src` が $a を **ContainerRef にすると、source を Arc identity で追跡する既存機構が壊れる**:
+**`t/pair-value-element-writethrough.t`(#2943)が回帰** — `$p = (k => $a); $p.value[3] = "x"` の
+write-through は @src/$a の **plain Array Arc を identity で照合**するが、cell 化で `Value::ContainerRef`
+になると照合に失敗し空書き込みになる。これは §5 が「2a の前に Stage 0 チョークポイント先行」と書いた
+依存そのもの＝**全 mutation/write-through サイトを ContainerRef-aware(decont)化する Sub-slice 1a が前提**。
+open-q#1(scalar-value-method dispatch の decont)も同根: cell が漏れない監査が要る。
+
+**∴ 次回の正しい順序: (1) Sub-slice 1a を behavior-invariant に landing(全 write-chokepoint で
+ContainerRef を decont、roast byte 一致が合格) → (2) その上に value-alias(本実装を再適用)。**
+value-alias 単独 PR は Arc-identity 機構を壊すので不可。
+
+---
+
+## 9. 参照
 
 - `docs/env-locals-coherence.md` — Stage 1 outer cell 化(for-rw site A 完了)。本書はその格納側の延長。
 - `docs/container-identity.md` — 第一級コンテナ台帳(Phase 1 scalar cell / Phase 2 要素 cell)。
 - `docs/vm-single-store.md` — 二重ストア統合(Slice F)。scalar-array 共有も env↔locals 同一 cell が前提。
-- 実証 probe: §1 の表(2026-06-18)。
+- 実証 probe: §1 の表(2026-06-18)。実装試行: §8(2026-06-18)。


### PR DESCRIPTION
## Summary

Records the design and findings from attempting **bug②** — `$n = @z` reference
sharing (the largest first-class-container lever per `TODO_roast/BLOCKERS.md`).
In Raku an Array/Hash is a reference type: `my $n = @z` makes `$n` hold the same
Array object as `@z`, so `$n.push` mutates `@z` (mutsu currently copies). This is
docs-only — the implementation was validated then reverted (see below).

## What was implemented & validated (then reverted)

A "value-alias" mechanism:
- new `MarkValueAliasSource` opcode emitted for `my $n = @z` / `$n = @z` (scalar = whole `@`/`%` var);
- `setup_scalar_value_alias` shares the source's `ContainerRef` cell with the scalar (so `$n.push` mutates `@z`);
- a marker-driven **detach** so `$n = 5` replaces `$n`'s slot without touching `@z`.

A 18-case pin test passed (push/element both directions, detach incl. post-push,
hash, itemized-copy matching raku); `cargo test` 466/0; array/binding/list roast
spread clean.

## Why reverted — the Arc-identity ripple

Turning `$a` into a `ContainerRef` breaks existing mechanisms that track the
source array by **Arc identity** — concretely the Pair-value element
write-through (#2943, `t/pair-value-element-writethrough.t`) regressed. This is
exactly the broad ripple the `docs/env-locals-coherence.md` Stage 1 section
predicted: value-alias needs **Sub-slice 1a (write-chokepoint decont — make every
mutation site `ContainerRef`-aware)** landed FIRST.

This PR documents the full working design + the two implementation gotchas
(sigilless `ArrayVar` name; non-simple-local env write on detach) so the next
session can land 1a first, then re-apply value-alias cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)