### PR TITLE
ci: automate releases with tagpr (SemVer, Cargo.toml-linked)

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,32 @@
+name: tagpr
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ vars.TAGPR_APP_ID }}
+          private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      # tagpr bumps the version in Cargo.toml; keep Cargo.lock's `mutsu` entry in
+      # sync so the release PR (and merged main) carries a coherent lockfile.
+      - uses: dtolnay/rust-toolchain@b5826f8eb73f40ac7c19ef631dce17a9680f8129 # 1.92.0
+
+      - uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,10 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial tag and release.
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = Cargo.toml
+	# After bumping the version in Cargo.toml, sync the `mutsu` entry in
+	# Cargo.lock so the release PR carries a coherent lockfile (release.yml
+	# builds without --locked, but a matched lock keeps `git status` clean).
+	command = "cargo update -p mutsu"


### PR DESCRIPTION
## Summary

Automates the binary-release flow (PLAN.md §E "GitHub Releases 自動化") with [tagpr](https://github.com/Songmu/tagpr).

On every push to `main`, tagpr maintains a **"Release vX.Y.Z" PR** that bumps the version in `Cargo.toml` (and syncs `Cargo.lock`) and aggregates the changelog. Merging that PR creates the `vX.Y.Z` tag, which triggers the **existing `release.yml`** to build per-target binaries (linux-x64, macos-x64, macos-arm64) and publish a GitHub Release with tarballs.

This closes the loop: there is currently no automated versioning/tagging, so `release.yml` never fires and no releases/tags exist.

## Choices

- **SemVer, Cargo.toml-linked** (continues the current `0.1.0`): `versionFile = Cargo.toml`, `vPrefix = true`. Natural for a Rust crate; communicates compatibility.
- **GitHub App token pattern** (skill-mandated): the default `GITHUB_TOKEN` does **not** trigger downstream workflows, so a tag push by tagpr would *not* fire `release.yml`. A GitHub App token does. A Rust toolchain step is included so the `command` hook (`cargo update -p mutsu`) can keep `Cargo.lock` coherent after the version bump.
- Actions pinned to commit SHAs (pinact).

## ⚠️ Maintainer setup required before this runs

Configure for a GitHub App with `contents:write` + `pull-requests:write`:
- Repo/org **variable** `TAGPR_APP_ID`
- Repo/org **secret** `TAGPR_APP_PRIVATE_KEY`

Without these, the `tagpr` job fails at the `create-github-app-token` step (the rest of CI is unaffected).

## Follow-up (not in this PR)

- Verify the mise GitHub backend can install the published release assets (needs a real release to exist first — chicken-and-egg, so it follows the first tagpr release).
- Consider adding `aarch64-unknown-linux-gnu` + SHA256 checksums to `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)