### PR TITLE
ci(release): publish SHA256 checksums with the release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,15 @@ jobs:
         with:
           merge-multiple: true
 
+      # Publish SHA256 checksums alongside the tarballs so downloaders (and the
+      # mise GitHub backend) can verify the binaries.
+      - name: Generate checksums
+        run: sha256sum mutsu-*.tar.gz > mutsu-${{ github.ref_name }}-SHA256SUMS.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: mutsu-*.tar.gz
+          files: |
+            mutsu-*.tar.gz
+            mutsu-${{ github.ref_name }}-SHA256SUMS.txt


### PR DESCRIPTION
## Summary

Attaches a `mutsu-<tag>-SHA256SUMS.txt` asset to each GitHub Release so downloaders — and the **mise GitHub backend** — can verify the binary tarballs (PLAN.md §E "mise GitHub バックエンドのインストール検証" prep).

Generated with `sha256sum mutsu-*.tar.gz` in the existing `release` job and added to the `action-gh-release` `files` list alongside the per-target archives. No change to the build matrix.

Pairs with #3270 (tagpr release automation): once a release tag is produced, `release.yml` now publishes verifiable checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)