### PR TITLE
ci(release): add aarch64-linux build on a native ARM runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_name: linux-x64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive_name: linux-arm64
           - target: x86_64-apple-darwin
             os: macos-latest
             archive_name: macos-x64


### PR DESCRIPTION
## Summary

Adds an `aarch64-unknown-linux-gnu` target to the release matrix, built **natively** on GitHub's free `ubuntu-24.04-arm` runner (this repo is public). No cross-compilation — the vendored PCRE2 and the rest of the native build compile with the host ARM toolchain exactly like the existing x64 Linux build.

Produces a `linux-arm64` tarball (plus its SHA256 from #3271) alongside linux-x64 / macos-x64 / macos-arm64, covering ARM Linux for the mise GitHub backend: AWS Graviton, Raspberry Pi, ARM dev machines.

Completes the binary-release matrix started by #3270 (tagpr automation) and #3271 (checksums).

## Notes

- `runs-on: ubuntu-24.04-arm`; the existing `if: runner.os == 'Linux'` dependency step and `dtolnay/rust-toolchain` setup apply unchanged on ARM.
- Native build (`--target aarch64-unknown-linux-gnu` on an aarch64 host), so no cross-linker / sysroot is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)