### PR TITLE
fix(regex): quantified angle-bracket char-class alias captures as a list

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -84,7 +84,12 @@
   - 15/15 pass.
 - [ ] roast/S05-metachars/tilde.t
 - [ ] roast/S05-metasyntax/angle-brackets.t
-  - 51/51 of the runnable subtests pass; the run aborts at test 52 because the
+  - 51/51 of the runnable subtests now pass (test 23 `=[...] renaming worked`
+    fixed: a *quantified* angle-bracket char-class/property alias `<foo=[bao]>+`
+    now yields a List with one Match per repetition like a builtin subrule,
+    instead of a single whole-span Match — only the sigil-prefix alias
+    `$<foo>=...` wraps the span. See `t/regex-angle-alias-quantified-capture.t`);
+    the run still aborts at test 52 because the
     `<$subrule>` block (lines 206-217) compiles a string containing a `{...}`
     code block as a regex, which raises "Prohibited regex interpolation"
     (X::SecurityPolicy). Real `raku` dies at this exact point too (no

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -2182,6 +2182,12 @@ impl Interpreter {
         let mut anchor_start = false;
         let mut anchor_end = false;
         let mut pending_named_capture: Option<String> = None;
+        // Set when `pending_named_capture` came from an angle-bracket alias of a
+        // char class / Unicode property (`<foo=[bao]>`, `<bar=:Letter>`) rather
+        // than a sigil-prefix alias (`$<foo>=...`). The angle form quantifies
+        // per-iteration (Raku yields a List of Matches for `<foo=[bao]>+`), like
+        // a builtin subrule; the sigil form captures the whole quantified span.
+        let mut pending_named_capture_is_angle_alias = false;
         let mut pending_builtin_named_capture: Option<String> = None;
         let mut pending_hash_capture: Option<String> = None;
         while let Some(c) = chars.next() {
@@ -3510,6 +3516,7 @@ impl Interpreter {
                                             || rhs.starts_with("!:");
                                         if lhs_is_ident && rhs_is_class_or_prop {
                                             pending_named_capture = Some(lhs.to_string());
+                                            pending_named_capture_is_angle_alias = true;
                                             name = rhs.to_string();
                                         }
                                     }
@@ -4610,6 +4617,8 @@ impl Interpreter {
             // When both a user alias ($<name>=) and a builtin class name are pending,
             // the alias becomes the primary capture and the builtin name becomes secondary.
             let user_alias = pending_named_capture.take();
+            let user_alias_is_angle = pending_named_capture_is_angle_alias;
+            pending_named_capture_is_angle_alias = false;
             let primary_is_user_alias = user_alias.is_some();
             let secondary_named = if primary_is_user_alias {
                 // Alias takes precedence; builtin name (if any) becomes secondary capture.
@@ -4631,7 +4640,13 @@ impl Interpreter {
             // quantifies the subrule itself, producing a LIST with one Match per
             // repetition. So only wrap when the primary name is a user alias; a
             // bare builtin keeps its per-iteration captures via the quantifier loop.
+            //
+            // An *angle-bracket* alias of a char class / property (`<foo=[bao]>+`,
+            // `<bar=:Letter>+`) is the builtin case, not the sigil case: Raku
+            // quantifies the class per-iteration and yields a List, so it must NOT
+            // be wrapped (only the sigil-prefix alias `$<foo>=...` wraps).
             let wrap_named_quant = primary_is_user_alias
+                && !user_alias_is_angle
                 && hash_capture.is_none()
                 && token_separator.is_none()
                 && matches!(

--- a/t/regex-angle-alias-quantified-capture.t
+++ b/t/regex-angle-alias-quantified-capture.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 10;
+
+# An angle-bracket alias of a character class or Unicode property
+# (`<name=[...]>`, `<name=:Prop>`) is quantified *per iteration* like a builtin
+# subrule, so `$<name>` is a List with one Match per repetition — NOT a single
+# Match spanning the whole run. (The sigil-prefix alias `$<name>=...` is the
+# opposite: it captures the whole quantified span as one Match.)
+# roast S05-metasyntax/angle-brackets.t test "=[...] renaming worked".
+
+# Char-class alias, quantified -> list of per-iteration matches.
+ok 'foobar' ~~ / <foo=[bao]>+ /, 'angle char-class alias matches';
+is $<foo>.elems, 4, 'quantified angle char-class alias yields a List';
+is $<foo>.join(','), 'o,o,b,a', 'each repetition is a separate capture';
+
+# Unicode-property alias, quantified -> list.
+ok 'abc' ~~ / <ltr=:Letter>+ /, 'angle property alias matches';
+is $<ltr>.elems, 3, 'quantified angle property alias yields a List';
+
+# Non-quantified angle char-class alias -> single Match (unchanged).
+ok 'b' ~~ / <one=[bao]> /, 'single angle char-class alias matches';
+is ~$<one>, 'b', 'non-quantified alias is a single Match';
+
+# The sigil-prefix alias on a quantified atom stays a single whole-span Match.
+ok 'abc' ~~ / $<all>=\w+ /, 'sigil alias matches';
+is ~$<all>, 'abc', 'quantified sigil alias captures the whole span';
+
+# A negated char-class alias also lists per iteration.
+'foobar' ~~ / <fb=-[aeiou]>+ /;
+is $<fb>.elems, 1, 'negated char-class alias lists per iteration (leading f)';


### PR DESCRIPTION
## Summary

A quantified angle-bracket alias of a character class or Unicode property — `<foo=[bao]>+`, `<bar=:Letter>+` — now yields a **List** with one Match per repetition, matching Raku. Previously it produced a single Match spanning the whole quantified run.

```raku
"foobar" ~~ / <foo=[bao]>+ /;
say $<foo>.elems;   # before: 1 (one merged Match)   after: 4 (o, o, b, a)
```

## Root cause

The parser treated the angle-bracket alias (`<name=class>`) identically to the sigil-prefix alias (`$<name>=...`), wrapping both quantified atoms in a non-capturing group so the capture spanned the entire run. But only the **sigil** form behaves that way (`$<x>=\w+` → one Match for `"abc"`); the **angle** form quantifies per-iteration like a builtin subrule (`<alpha>+` → list). A new `pending_named_capture_is_angle_alias` flag (set when the alias is parsed from `<name=[...]>` / `<name=:Prop>`) excludes the angle form from span-wrapping, so its quantifier loop accumulates the per-iteration list.

## Scope / tests

- Fixes roast `S05-metasyntax/angle-brackets.t` test "=[...] renaming worked".
- That file still cannot whitelist: like real `raku` it aborts at test 52 on `<$subrule>` code-string interpolation (X::SecurityPolicy / no MONKEY-SEE-NO-EVAL), so it never reaches `plan 95`. This is a focused correctness fix, not a whitelist.
- New pin `t/regex-angle-alias-quantified-capture.t` (10 cases: char-class & property aliases quantified→list, non-quantified→single, sigil-form span unchanged, negated class).
- No regressions: `make test` PASS (930 files / 8978 tests), related regex suites (named/positional captures, charset, repeat) green, `cargo test` 466/0, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)