### PR TITLE
fix(compiler): block-final `my $x := <literal>` no longer dies as readonly

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -73,7 +73,21 @@
 - [ ] roast/S05-match/basics.t
 - [ ] roast/S05-match/blocks.t
 - [ ] roast/S05-match/capturing-contexts.t
-  - 56/64 pass. Remaining blockers: binding `$/` (`my $/ := 42`, tests 29-30); `(y)?`/`(z)*` zero-match needs index-stable positional capture slots so `?`→Nil and `*`→empty-list can coexist (tests 45/46 — mutsu does not reserve slots for unmatched optional captures); `%%` separator backtracking against an outer anchor (tests 53-56, where the native separator path falls back to string expansion); capture markers `<(`/`)>` in some grammar combinations (test 64).
+  - 57/64 pass. Test 29 (binding `$/`, `my $/ := 42`) now passes: a block-final
+    `:=` scalar bind to a readonly RHS used to throw "Cannot assign to a readonly
+    variable" because the block-final store went through the assignment path
+    (rejecting the readonly mark) instead of the declaration path — fixed in
+    `compile_block_inline` (see `t/block-final-scalar-bind.t`).
+    Remaining blockers: test 30 (`my $/ := "foobar"; $0` should be `$/[0]` =
+    `foobar`) — mutsu stores `$0`/`$1` as separate env keys set only by a real
+    match, so a directly-bound `$/` leaves `$0` Nil; the proper fix derives the
+    digit vars by indexing the current `$/` (self-index for non-Match scalars),
+    which touches the hot `GetGlobal` digit path; `(y)?`/`(z)*` zero-match needs
+    index-stable positional capture slots so `?`→Nil and `*`→empty-list can
+    coexist (test 46 — mutsu does not reserve slots for unmatched optional
+    captures); `%%` separator backtracking against an outer anchor (tests 53-56,
+    where the native separator path falls back to string expansion); capture
+    markers `<(`/`)>` in some grammar combinations (test 64).
 - [ ] roast/S05-match/make.t
 - [ ] roast/S05-match/non-capturing.t
 - [ ] roast/S05-match/positions.t

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -23,6 +23,19 @@ impl Compiler {
             )
         });
         let has_mark_bind = stmts.iter().any(|s| matches!(s, Stmt::MarkBind));
+        // Names marked readonly by a preceding `MarkReadonly` statement. A `:=`
+        // scalar bind to a readonly RHS (`my $x := 42`) is lowered to
+        // `[MarkReadonly(x), VarDecl{__scalar_bind}]`; when that VarDecl is in
+        // block-final (value) position, its store must use the declaration path
+        // (SetLocal + MarkVarDeclContext) rather than the assignment path, which
+        // would wrongly trip the readonly check just set by MarkReadonly.
+        let readonly_marked_names: Vec<&str> = stmts
+            .iter()
+            .filter_map(|s| match s {
+                Stmt::MarkReadonly(n) => Some(n.as_str()),
+                _ => None,
+            })
+            .collect();
         // Hoist sub declarations
         self.hoist_sub_decls(stmts, true);
         for (i, stmt) in stmts.iter().enumerate() {
@@ -165,7 +178,21 @@ impl Compiler {
                                 }
                             }
                             self.code.emit(OpCode::Dup);
-                            self.emit_set_named_var(name);
+                            if readonly_marked_names.contains(&name.as_str()) {
+                                // The var was just marked readonly (a `:=` scalar
+                                // bind to a readonly RHS). Store via the
+                                // declaration path so the readonly check is
+                                // bypassed for this declaration's own initializer,
+                                // mirroring the @/% bind path above.
+                                if custom_traits.iter().any(|(t, _)| t == "__scalar_bind") {
+                                    self.code.emit(OpCode::MarkScalarBindContext);
+                                }
+                                self.code.emit(OpCode::MarkVarDeclContext);
+                                let slot = self.alloc_local(name);
+                                self.code.emit(OpCode::SetLocal(slot));
+                            } else {
+                                self.emit_set_named_var(name);
+                            }
                         }
                         self.pop_dynamic_scope_lexical(saved);
                         return;

--- a/t/block-final-scalar-bind.t
+++ b/t/block-final-scalar-bind.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 8;
+
+# A `:=` scalar bind to a readonly RHS (`my $x := 42`) in block-final (value)
+# position used to throw "Cannot assign to a readonly variable" because the
+# block-final store went through the assignment path (which rejects the
+# readonly mark emitted for the bind) instead of the declaration path.
+
+# do-block tail
+is (do { my $x := 42 }), 42, 'do-block tail: my $x := <literal>';
+
+# bare block called as a sub
+my $r = { my $x := 42 };
+is $r(), 42, 'sub tail: my $x := <literal>';
+
+# the special match variable $/ can be bound the same way
+lives-ok { my $/ := 42 }, 'can bind $/ in block-final position';
+
+# binding still makes the variable readonly (initializer aside)
+my $err;
+{
+    my $x := 7;
+    $x = 9 unless True;  # never runs, just ensures parse
+    CATCH { default { $err = .message } }
+}
+ok True, 'readonly bind parses';
+
+# a subsequent assignment to a literal-bound scalar must still die
+dies-ok {
+    my $y := 5;
+    $y = 6;
+}, 'assigning to a literal-bound scalar dies';
+
+# bind to a variable still works in tail position
+my $src = 11;
+is (do { my $z := $src }), 11, 'do-block tail: my $z := $var';
+
+# bind to an array still works in tail position
+my @a = 1, 2, 3;
+is (do { my $w := @a }).elems, 3, 'do-block tail: my $w := @arr';
+
+# plain assignment in tail position still works
+is (do { my $p = 99 }), 99, 'do-block tail: my $p = <literal>';


### PR DESCRIPTION
## Summary
A `:=` scalar bind to a readonly RHS (`my $x := 42`) is lowered to `[MarkReadonly(name), VarDecl{__scalar_bind}]`. In statement position the `VarDecl` stores via the *declaration* path (`SetLocal` + `MarkVarDeclContext`), which bypasses the readonly check. But when that synthetic block is the **block-final** (value-producing) statement of a `do {}` / bare block / sub, `compile_block_inline` stored the result via the *assignment* path (`emit_set_named_var` → `SetGlobal`), which performs a readonly check and rejected the declaration's own initializer with `Cannot assign to a readonly variable`.

```raku
my $v = do { my $x := 42 };   # before: dies "Cannot assign to a readonly variable (x)"
my $r = { my $x := 42 }; $r();# before: dies
lives-ok { my $/ := 42 };     # before: not ok
```

## Fix
In `compile_block_inline`, collect names marked readonly by a preceding `MarkReadonly` statement. For a block-final scalar `VarDecl` whose name was so marked, store via the declaration path (`MarkScalarBindContext` + `MarkVarDeclContext` + `SetLocal`) instead of `emit_set_named_var`, mirroring the existing `@`/`%` bind path. The readonly mark still stands, so a later `$x = ...` assignment correctly dies.

## Tests
- New `t/block-final-scalar-bind.t` (8 cases): do-block / sub tail, `$/` bind, readonly still enforced, bind-to-var / bind-to-array / plain-assign tails unaffected.
- roast `S05-match/capturing-contexts.t` test 29 (`my $/ := 42`) now passes: 56/64 → 57/64.
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)