### PR TITLE
fix(vm): `$0`/`$1`/... derive from a directly bound/assigned `$/`

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -73,21 +73,22 @@
 - [ ] roast/S05-match/basics.t
 - [ ] roast/S05-match/blocks.t
 - [ ] roast/S05-match/capturing-contexts.t
-  - 57/64 pass. Test 29 (binding `$/`, `my $/ := 42`) now passes: a block-final
-    `:=` scalar bind to a readonly RHS used to throw "Cannot assign to a readonly
-    variable" because the block-final store went through the assignment path
-    (rejecting the readonly mark) instead of the declaration path — fixed in
-    `compile_block_inline` (see `t/block-final-scalar-bind.t`).
-    Remaining blockers: test 30 (`my $/ := "foobar"; $0` should be `$/[0]` =
-    `foobar`) — mutsu stores `$0`/`$1` as separate env keys set only by a real
-    match, so a directly-bound `$/` leaves `$0` Nil; the proper fix derives the
-    digit vars by indexing the current `$/` (self-index for non-Match scalars),
-    which touches the hot `GetGlobal` digit path; `(y)?`/`(z)*` zero-match needs
-    index-stable positional capture slots so `?`→Nil and `*`→empty-list can
-    coexist (test 46 — mutsu does not reserve slots for unmatched optional
-    captures); `%%` separator backtracking against an outer anchor (tests 53-56,
-    where the native separator path falls back to string expansion); capture
-    markers `<(`/`)>` in some grammar combinations (test 64).
+  - 58/64 pass. Test 29 (`my $/ := 42`) now passes: a block-final `:=` scalar
+    bind to a readonly RHS used to throw "Cannot assign to a readonly variable"
+    because the block-final store went through the assignment path (rejecting the
+    readonly mark) instead of the declaration path — fixed in
+    `compile_block_inline` (see `t/block-final-scalar-bind.t`). Test 30
+    (`my $/ := "foobar"; $0` should be `$/[0]` = `foobar`) now passes: `$0`/`$1`/
+    ... derive from the current `$/` by indexing when no digit env key exists (a
+    match exports digit keys, but a directly bound/assigned `$/` does not); a
+    non-Match scalar self-indexes (`.[0]` is the value, `.[N>0]` is Nil) and a
+    bound Array indexes positionally (see `t/digit-var-from-bound-slash.t`).
+    Remaining blockers: `(y)?`/`(z)*` zero-match needs index-stable positional
+    capture slots so `?`→Nil and `*`→empty-list can coexist (test 46 — mutsu does
+    not reserve slots for unmatched optional captures); `%%` separator
+    backtracking against an outer anchor (tests 53-56, where the native separator
+    path falls back to string expansion); capture markers `<(`/`)>` in some
+    grammar combinations (test 64).
 - [ ] roast/S05-match/make.t
 - [ ] roast/S05-match/non-capturing.t
 - [ ] roast/S05-match/positions.t

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1300,6 +1300,23 @@ impl Interpreter {
                     // Anonymous state variable (`$`): fall back to persisted
                     // state so the value survives across closure calls.
                     .or_else(|| self.anon_state_value(name))
+                    // `$0`/`$1`/... are `$/[0]`/`$/[1]`/...  A successful match
+                    // exports each positional capture as its own digit env key,
+                    // but a directly bound/assigned `$/` (`my $/ := "foobar"`)
+                    // has none — derive the value by indexing the current `$/`,
+                    // matching Raku's `$0 == $/[0]` for any object (a non-Match
+                    // scalar self-indexes: `.[0]` is the value, `.[N>0]` is Nil).
+                    .or_else(|| {
+                        if name.is_empty() || !name.bytes().all(|b| b.is_ascii_digit()) {
+                            return None;
+                        }
+                        let slash = self.get_env_with_main_alias("/")?;
+                        if matches!(slash, Value::Nil) {
+                            return None;
+                        }
+                        let i: usize = name.parse().ok()?;
+                        Some(Self::bound_slash_positional(&slash, i))
+                    })
                     .map(Ok)
                     .unwrap_or_else(|| {
                         if name.starts_with('^') {

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -21,6 +21,26 @@ impl Interpreter {
         }
     }
 
+    /// Index the current `$/` for a positional capture variable (`$0`, `$1`, ...)
+    /// when no digit env key exists (i.e. `$/` was bound/assigned directly rather
+    /// than set by a match). Mirrors Raku's `$N == $/[N]`: an Array indexes
+    /// positionally, and any non-Match scalar self-indexes (`.[0]` is the value,
+    /// `.[N>0]` is Nil). A real Match exports its captures as digit keys, so this
+    /// is only reached for a non-Match `$/`; Instances/Match fall through to Nil.
+    pub(super) fn bound_slash_positional(slash: &Value, i: usize) -> Value {
+        slash.with_deref(|v| match v {
+            Value::Array(data, _) => data.get(i).cloned().unwrap_or(Value::Nil),
+            Value::Instance { .. } => Value::Nil,
+            _ => {
+                if i == 0 {
+                    v.clone()
+                } else {
+                    Value::Nil
+                }
+            }
+        })
+    }
+
     fn superscript_digit_value(c: char) -> Option<u32> {
         match c {
             '\u{2070}' => Some(0), // ⁰

--- a/t/digit-var-from-bound-slash.t
+++ b/t/digit-var-from-bound-slash.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 9;
+
+# `$0`/`$1`/... are `$/[0]`/`$/[1]`/...  A match exports each positional
+# capture as its own env key, but a directly bound/assigned `$/` has none —
+# the digit vars must derive by indexing the current `$/`.
+
+# A non-Match scalar self-indexes: `.[0]` is the value, `.[N>0]` is Nil.
+{
+    my $/ := 'foobar';
+    is $0, 'foobar', '$0 works like $/[0] for a non-Match $/';
+    nok $1.defined, '$1 is not defined for a scalar $/';
+}
+
+# A bound Array indexes positionally.
+{
+    my $/ := [10, 20, 30];
+    is $0, 10, '$0 indexes a bound Array';
+    is $1, 20, '$1 indexes a bound Array';
+    is $2, 30, '$2 indexes a bound Array';
+    nok $3.defined, '$3 past the end is not defined';
+}
+
+# A real match still works (the fast digit-key path).
+{
+    'abc' ~~ /(.)(.)/;
+    is ~$0, 'a', '$0 still works after a match';
+    is ~$1, 'b', '$1 still works after a match';
+}
+
+# With $/ bound to an undefined value, digit vars are undefined.
+{
+    my $/ := Any;
+    nok $0.defined, '$0 is undefined when $/ is undefined';
+}


### PR DESCRIPTION
## Summary
In Raku `$N` is `$/[N]` for any object — including a `$/` that was bound or assigned directly rather than set by a match:

```raku
my $/ := "foobar";
say $0;            # "foobar"   (== $/[0]; a scalar self-indexes)
say $1.defined;    # False

my $/ := [10, 20, 30];
say $0, $1, $2;    # 10 20 30  (Array indexes positionally)
```

A successful match exports each positional capture as its own digit env key, so reading `$0` is a fast key lookup. But a directly bound/assigned `$/` leaves no digit keys, so `$0` wrongly read `Nil`.

## Fix
Add a fallback in `GetGlobal`: for an all-digit name with no env entry, index the current `$/` (`Self::bound_slash_positional`). A non-Match scalar self-indexes (`.[0]` is the value, `.[N>0]` is Nil, matching `42[0] === 42`); a bound Array indexes positionally. A real Match already has its digit keys, so the fallback is only reached for a non-Match `$/` (Instances/Match fall through to Nil).

## Tests
- New `t/digit-var-from-bound-slash.t` (9 cases): scalar/array bound `$/`, real match still works, undefined `$/`.
- roast `S05-match/capturing-contexts.t` test 30 now passes (together with test 29 from #3275, the file is now 58/64).
- `make test` passes; no regressions in `S05-capture/{alias,caps,dot}.t`, `S05-match/basics.t`, `S05-interpolation/regex-in-variable.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)