### PR TITLE
fix(signature): nested Pair sub-signature keeps a string-key Pair value

### DIFF
--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -511,7 +511,15 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
                 .or_else(|| sub_pd.name.strip_prefix('@'))
                 .or_else(|| sub_pd.name.strip_prefix('%'))
                 .unwrap_or(sub_pd.name.as_str());
-            if sub_pd.named || bind_name == key {
+            // Only unwrap a positional `key => val` pair whose key matches this
+            // positional parameter's name. A NAMED sub-param's candidate already
+            // came from `extract_named_from_unpack_target` (the source pair's
+            // `.value`), so unwrapping it again would wrongly strip a value that
+            // is itself a `Value::Pair` — e.g. `Pair :value((...))` nested
+            // destructuring or `:value($v)` where the value is a Pair (the
+            // `ValuePair` form already skips this unwrap; this aligns the
+            // string-key `Value::Pair` form with it).
+            if !sub_pd.named && bind_name == key {
                 candidate = *inner.clone();
             }
         }

--- a/t/nested-pair-subsignature.t
+++ b/t/nested-pair-subsignature.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 7;
+
+# Nested Pair sub-signature destructuring must not drop the inner value when
+# the destructured value is itself a string-key `Pair`. A named sub-param's
+# candidate already comes from the source pair's `.value`, so it must not be
+# unwrapped again. Previously a chained `a => "b" => c` (whose inner pair is a
+# string-key Pair) bound the innermost value to the outer param, throwing
+# "expected Pair, got ...". The parenthesised form (a ValuePair inner) already
+# worked; this aligns the string-key form with it.
+
+# Two-level destructuring, chained listop call (the form roast / Test::Util use).
+{
+    sub f(Pair (Int:D :key($plan), Pair :value((Str:D :key($desc), :value($val))))) {
+        "$plan|$desc|$val"
+    }
+    is f(2 => "g" => 5),   '2|g|5', 'chained pair, paren call';
+    is (f 2 => "g" => 5),  '2|g|5', 'chained pair, listop call';
+}
+
+# The inner value may itself be a block/callable (the Test::Util `group-of` shape).
+{
+    my $ran = 0;
+    sub run-group(Pair (Int:D :key($n), Pair :value((Str:D :key($d), :value(&code))))) {
+        "$n|$d|" ~ code()
+    }
+    is (run-group 3 => "desc" => { 42 }), '3|desc|42', 'inner block value runs';
+}
+
+# A non-nested `:value($v)` whose value is a Pair keeps the whole Pair.
+{
+    sub h(Pair (:key($k), :value($v))) { "$k|" ~ $v.^name ~ "|" ~ $v.key ~ "|" ~ $v.value }
+    is (h 1 => "a" => 2), '1|Pair|a|2', 'listop: value stays a Pair';
+    is h(1 => ("a" => 2)), '1|Pair|a|2', 'paren: value stays a Pair';
+}
+
+# Plain (non-pair) inner values still bind correctly.
+{
+    sub p(Pair (:key($k), Pair :value((:key($k2), :value($v2))))) { "$k|$k2|$v2" }
+    is (p 2 => 3 => 5), '2|3|5', 'all-Int chained pair';
+    is p(2 => (3 => 5)), '2|3|5', 'all-Int paren pair';
+}


### PR DESCRIPTION
## Summary
A named sub-signature parameter's candidate already comes from the source pair's `.value` (via `extract_named_from_unpack_target`), so it must not be unwrapped again in `bind_sub_signature_from_value`. The unconditional unwrap for named params wrongly stripped a value that is itself a string-key `Value::Pair`:

```raku
sub f(Pair (Int:D :key($p), Pair :value((Str:D :key($d), :value(&t))))) { ... }
f 2 => "g" => { ... };   # before: "expected Pair, got Block"
f(2 => ("g" => { ... })); # worked (inner is a ValuePair)
```

The parenthesised form already worked because its inner pair is a `ValuePair` (built via `ContainerizePair`), which the unwrap arm never matched. The chained listop form builds a string-key `Value::Pair` for the inner pair, which hit the unwrap and lost the value.

## Fix
Restrict the unwrap to the positional `key => val` case whose key matches the parameter name, aligning the string-key `Value::Pair` form with the already-correct `ValuePair` form. Named sub-params are never re-unwrapped.

This is the shape used by `Test::Util`'s `group-of N => 'desc' => { ... }` and by chained-Pair destructuring generally.

## Tests
- New `t/nested-pair-subsignature.t` (7 cases): two-level chained destructuring (paren + listop), inner block/callable value, non-nested `:value($v)` keeping a Pair, all-Int chained pairs.
- `make test` passes; no regressions in `S06-signature/{unpack-array,unpack-object,named-renaming,positional,named-parameters,tree-node-parameters,multidimensional}.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)