### PR TITLE
feat(regex): index-stable positional capture slots for unmatched optionals

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -73,19 +73,20 @@
 - [ ] roast/S05-match/basics.t
 - [ ] roast/S05-match/blocks.t
 - [ ] roast/S05-match/capturing-contexts.t
-  - 58/64 pass. Test 29 (`my $/ := 42`) now passes: a block-final `:=` scalar
-    bind to a readonly RHS used to throw "Cannot assign to a readonly variable"
-    because the block-final store went through the assignment path (rejecting the
-    readonly mark) instead of the declaration path — fixed in
-    `compile_block_inline` (see `t/block-final-scalar-bind.t`). Test 30
-    (`my $/ := "foobar"; $0` should be `$/[0]` = `foobar`) now passes: `$0`/`$1`/
-    ... derive from the current `$/` by indexing when no digit env key exists (a
-    match exports digit keys, but a directly bound/assigned `$/` does not); a
-    non-Match scalar self-indexes (`.[0]` is the value, `.[N>0]` is Nil) and a
-    bound Array indexes positionally (see `t/digit-var-from-bound-slash.t`).
-    Remaining blockers: `(y)?`/`(z)*` zero-match needs index-stable positional
-    capture slots so `?`→Nil and `*`→empty-list can coexist (test 46 — mutsu does
-    not reserve slots for unmatched optional captures); `%%` separator
+  - 59/64 pass. Test 29 (`my $/ := 42`), test 30 (`$0` from a bound `$/`), and
+    test 46 (index-stable capture slots) now pass. Test 29: a block-final `:=`
+    scalar bind to a readonly RHS used to throw "Cannot assign to a readonly
+    variable" (fixed in `compile_block_inline`, `t/block-final-scalar-bind.t`).
+    Test 30: `$0`/`$1`/... derive from the current `$/` by indexing when no digit
+    env key exists (`t/digit-var-from-bound-slash.t`). Test 46: an unmatched
+    optional capture now reserves an index-stable positional slot — `(x)?` zero
+    match → Nil (`reserve_nil_capture_slots` + `positional_nil` in `RegexCaptures`,
+    rendered as Nil by the Match builder), `(x)*` zero match → empty List (the
+    `new_entries == 0` arm of `fold_quantified_captures`). So `(a)?(b)` on "b" is
+    `$0=Nil,$1=b` and `(y)?(z)*` on "x" is `$0=Nil,$1=[]` (matches Rakudo; see
+    `t/quantified-capture-slots.t`). NOTE: one-iteration `(z)*` still yields a
+    single Match, not `List(1)` (Rakudo folds it — wider blast radius, deferred).
+    Remaining blockers: `%%` separator
     backtracking against an outer anchor (tests 53-56, where the native separator
     path falls back to string expansion); capture markers `<(`/`)>` in some
     grammar combinations (test 64).

--- a/src/builtins/split.rs
+++ b/src/builtins/split.rs
@@ -322,6 +322,7 @@ fn separator_value(m: &SplitMatch) -> Value {
             &HashMap::new(),
             &[],
             &[],
+            &[],
             orig,
         )
     } else {

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -373,6 +373,7 @@ impl Interpreter {
             &std::collections::HashMap::new(),
             &[],
             &[],
+            &[],
             Some(text),
         )
     }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -228,6 +228,7 @@ impl Interpreter {
                 &captures.named_subcaps,
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
+                &captures.positional_nil,
                 Some(&text),
                 &captures.named_quantified,
             );

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -118,6 +118,7 @@ impl Interpreter {
                         &c.named_subcaps,
                         &c.positional_subcaps,
                         &c.positional_quantified,
+                        &c.positional_nil,
                         Some(&text),
                     )
                 })
@@ -164,6 +165,7 @@ impl Interpreter {
                 &captures.named_subcaps,
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
+                &captures.positional_nil,
                 Some(&text),
             );
             // Set positional capture env vars ($0, $1, ...) from match object

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -593,6 +593,7 @@ impl Interpreter {
                 &c.named_subcaps,
                 &c.positional_subcaps,
                 &c.positional_quantified,
+                &c.positional_nil,
                 Some(text),
             )
         };
@@ -859,6 +860,7 @@ impl Interpreter {
                         &captures.named_subcaps,
                         &captures.positional_subcaps,
                         &captures.positional_quantified,
+                        &captures.positional_nil,
                         Some(&text),
                     );
                     self.env.insert("/".to_string(), match_obj);
@@ -1028,6 +1030,7 @@ impl Interpreter {
                 &captures.named_subcaps,
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
+                        &captures.positional_nil,
                 orig_text,
             );
             self.env.insert("/".to_string(), match_obj.clone());

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -1030,7 +1030,7 @@ impl Interpreter {
                 &captures.named_subcaps,
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
-                        &captures.positional_nil,
+                &captures.positional_nil,
                 orig_text,
             );
             self.env.insert("/".to_string(), match_obj.clone());

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -617,6 +617,13 @@ pub(crate) struct RegexCaptures {
     pub(crate) positional_quantified: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
     /// Character offsets (start, end) for each entry in `positional`.
     pub(crate) positional_offsets: Vec<(usize, usize)>,
+    /// Marks a positional slot as an *unmatched optional* capture (`(x)?` that
+    /// matched zero times) which must render as `Nil` (not an empty Match). Only
+    /// the zero-match reservation arms set entries here; they pad with `false` up
+    /// to the current `positional` length before pushing `true`, so matched
+    /// captures (which never touch this vec) stay aligned. The Match builder reads
+    /// it via `.get(i)` — a missing/`false` entry renders normally.
+    pub(crate) positional_nil: Vec<bool>,
     /// Unnamed capture slots by capture index (for $0, $1, ...), where `None`
     /// represents an unmatched capture.
     pub(crate) positional_slots: Vec<Option<(String, usize, usize)>>,

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -414,16 +414,24 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
         return;
     }
     let new_entries = caps.positional.len() - base_len;
+    if new_entries == 0 {
+        // A zero-iteration `*` / `**0..` quantified capture group reserves an
+        // empty-list slot per inner capture (Raku: `(z)*` matching 0 times yields
+        // `[]`). Index stability is preserved because an earlier unmatched `(...)?`
+        // reserves its own Nil slot (see `reserve_nil_capture_slots`), so both
+        // `(y)?`→Nil and `(z)*`→[] coexist at their correct positions.
+        for _ in 0..stride {
+            caps.positional.push(String::new());
+            caps.positional_subcaps.push(None);
+            caps.positional_quantified.push(Some(Vec::new()));
+            caps.positional_offsets.push((0, 0));
+        }
+        return;
+    }
     if new_entries <= stride {
-        // Only one iteration or fewer — nothing to fold.
-        //
-        // NOTE: a zero-iteration `*`/`+` quantified capture group should ideally
-        // reserve an empty-list slot (Raku: `(z)*` matching 0 times yields `[]`),
-        // but mutsu does not yet reserve index-stable positional capture slots
-        // for unmatched optional captures, so emitting an empty slot here would
-        // misalign indices when an earlier `(...)?` also matched zero times.
-        // TODO: reserve index-stable positional slots for all capture groups so
-        // both `(y)?`→Nil and `(z)*`→[] can coexist.
+        // Exactly one iteration — mutsu keeps the single capture un-folded.
+        // TODO: Raku makes `*`/`+` always a List even for one match (`(z)*`
+        // matching once yields `List(1)`); folding here has wider blast radius.
         return;
     }
     let iterations = new_entries / stride;
@@ -476,6 +484,30 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
     // Also truncate offsets if present
     if caps.positional_offsets.len() > base_len {
         caps.positional_offsets.truncate(base_len);
+    }
+}
+
+/// Reserve `stride` index-stable Nil slots for an unmatched optional capture
+/// group (`(x)?` that matched zero times). The slots render as `Nil` in the
+/// resulting Match (Raku: `(a)?(b)` on "b" yields `$0 = Nil`, `$1 = b`).
+///
+/// `positional_nil` is padded with `false` up to the current `positional` length
+/// before the `true` entries are pushed, so the matched captures that precede
+/// this group (which never touch `positional_nil`) stay index-aligned.
+pub(super) fn reserve_nil_capture_slots(caps: &mut RegexCaptures, stride: usize) {
+    if stride == 0 {
+        return;
+    }
+    while caps.positional_nil.len() < caps.positional.len() {
+        caps.positional_nil.push(false);
+    }
+    let at = caps.to;
+    for _ in 0..stride {
+        caps.positional.push(String::new());
+        caps.positional_subcaps.push(None);
+        caps.positional_quantified.push(None);
+        caps.positional_offsets.push((at, at));
+        caps.positional_nil.push(true);
     }
 }
 

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::regex_helpers::{
     count_capture_groups, fold_quantified_captures, is_named_atom_no_args, is_silent_named_atom,
-    is_simple_atom,
+    is_simple_atom, reserve_nil_capture_slots,
 };
 use std::collections::HashSet;
 
@@ -569,6 +569,14 @@ impl Interpreter {
                     }
                 }
                 RegexQuant::ZeroOrOne => {
+                    // An unmatched `(x)?` reserves `zo_stride` Nil positional slots
+                    // so following captures keep their index (`(a)?(b)` → $0=Nil,$1=b).
+                    let zo_stride = count_capture_groups(&token.atom);
+                    let zero_caps = || {
+                        let mut zc = caps.clone();
+                        reserve_nil_capture_slots(&mut zc, zo_stride);
+                        zc
+                    };
                     let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
                         &token.atom,
                         chars,
@@ -585,7 +593,7 @@ impl Interpreter {
                             candidates = vec![best];
                         } else {
                             // Atom didn't match — commit to "zero" (no match)
-                            stack.push((idx + 1, pos, caps.clone()));
+                            stack.push((idx + 1, pos, zero_caps()));
                             candidates.clear();
                         }
                     } else if token.frugal {
@@ -610,10 +618,10 @@ impl Interpreter {
                                 ),
                             ));
                         }
-                        stack.push((idx + 1, pos, caps.clone()));
+                        stack.push((idx + 1, pos, zero_caps()));
                         candidates.clear();
                     } else {
-                        stack.push((idx + 1, pos, caps.clone()));
+                        stack.push((idx + 1, pos, zero_caps()));
                     }
                     for (next, new_caps) in candidates {
                         stack.push((

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -668,6 +668,7 @@ impl Interpreter {
                         &captures.named_subcaps,
                         &captures.positional_subcaps,
                         &captures.positional_quantified,
+                        &captures.positional_nil,
                         Some(&text),
                         &captures.named_quantified,
                     );

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -3687,6 +3687,7 @@ impl Value {
             &HashMap::new(),
             &[],
             &[],
+            &[],
             None,
         )
     }
@@ -3702,6 +3703,7 @@ impl Value {
         named_subcaps: &HashMap<String, Vec<crate::runtime::RegexCaptures>>,
         positional_subcaps: &[Option<crate::runtime::RegexCaptures>],
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
+        positional_nil: &[bool],
         orig: Option<&str>,
     ) -> Self {
         Self::make_match_object_full_q(
@@ -3713,6 +3715,7 @@ impl Value {
             named_subcaps,
             positional_subcaps,
             positional_quantified,
+            positional_nil,
             orig,
             &HashSet::new(),
         )
@@ -3729,6 +3732,7 @@ impl Value {
         named_subcaps: &HashMap<String, Vec<crate::runtime::RegexCaptures>>,
         positional_subcaps: &[Option<crate::runtime::RegexCaptures>],
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
+        positional_nil: &[bool],
         orig: Option<&str>,
         named_quantified: &HashSet<String>,
     ) -> Self {
@@ -3775,6 +3779,10 @@ impl Value {
                 .iter()
                 .enumerate()
                 .map(|(i, s)| {
+                    // An unmatched optional capture (`(x)?` zero match) renders as Nil.
+                    if caps.positional_nil.get(i) == Some(&true) {
+                        return Value::Nil;
+                    }
                     // Check if this positional entry is a quantified list
                     if let Some(Some(qlist)) = caps.positional_quantified.get(i) {
                         let arr: Vec<Value> = qlist
@@ -3870,6 +3878,10 @@ impl Value {
             .iter()
             .enumerate()
             .map(|(i, s)| {
+                // An unmatched optional capture (`(x)?` zero match) renders as Nil.
+                if positional_nil.get(i) == Some(&true) {
+                    return Value::Nil;
+                }
                 // Check if this positional entry is a quantified list
                 if let Some(Some(qlist)) = positional_quantified.get(i) {
                     let arr: Vec<Value> = qlist

--- a/src/vm/vm_native_subst.rs
+++ b/src/vm/vm_native_subst.rs
@@ -172,6 +172,7 @@ impl Interpreter {
                 &HashMap::new(),
                 &[],
                 &[],
+                &[],
                 Some(text),
             )
         };

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -439,6 +439,7 @@ impl Interpreter {
             &std::collections::HashMap::new(),
             &[],
             &[],
+            &[],
             Some(text),
         )
     }
@@ -1127,6 +1128,7 @@ impl Interpreter {
                 caps,
                 &std::collections::HashMap::new(),
                 &std::collections::HashMap::new(),
+                &[],
                 &[],
                 &[],
                 Some(text),

--- a/t/quantified-capture-slots.t
+++ b/t/quantified-capture-slots.t
@@ -1,0 +1,69 @@
+use Test;
+
+plan 21;
+
+# Index-stable positional capture slots: an unmatched optional capture reserves
+# its slot so following captures keep their number. A `(x)?` matching zero times
+# yields Nil; a `(x)*` / `(x)+` (zero or more) always yields a List (empty when
+# it matched zero times). Verified against Rakudo.
+
+# (a)?(b) on "b": $0 = Nil, $1 = Match(b)
+{
+    'b' ~~ /(a)?(b)/;
+    is $/.list.elems, 2, '(a)?(b): two positional slots';
+    nok $/[0].defined,   '(a)?(b): $0 is Nil (unmatched optional)';
+    is ~$/[1], 'b',      '(a)?(b): $1 is b';
+}
+
+# (a)?(b) on "ab": both match
+{
+    'ab' ~~ /(a)?(b)/;
+    is ~$/[0], 'a', '(a)?(b) on ab: $0 = a';
+    is ~$/[1], 'b', '(a)?(b) on ab: $1 = b';
+}
+
+# (z)* matching zero times yields an empty list
+{
+    'x' ~~ /(z)*/;
+    is $/.list.elems, 1,            '(z)* on x: one slot';
+    ok $/[0] ~~ Positional,         '(z)* on x: $0 is Positional';
+    is $/[0].elems, 0,              '(z)* on x: $0 is empty list';
+}
+
+# (z)* matching twice yields a 2-element list
+{
+    'zz' ~~ /(z)*/;
+    ok $/[0] ~~ Positional, '(z)* on zz: $0 is Positional';
+    is $/[0].elems, 2,      '(z)* on zz: two elements';
+}
+
+# (y)?(z)* on "x": $0 = Nil, $1 = empty list
+{
+    'x' ~~ /(y)?(z)*/;
+    is $/.list.elems, 2,    '(y)?(z)* on x: two slots';
+    nok $/[0].defined,      '(y)?(z)* on x: $0 Nil';
+    ok $/[1] ~~ Positional && $/[1].elems == 0, '(y)?(z)* on x: $1 empty list';
+}
+
+# (a)?(b)?(c) on "c": $0 = Nil, $1 = Nil, $2 = c
+{
+    'c' ~~ /(a)?(b)?(c)/;
+    is $/.list.elems, 3, '(a)?(b)?(c) on c: three slots';
+    nok $/[0].defined,   '(a)?(b)?(c) on c: $0 Nil';
+    nok $/[1].defined,   '(a)?(b)?(c) on c: $1 Nil';
+    is ~$/[2], 'c',      '(a)?(b)?(c) on c: $2 = c';
+}
+
+# (z)*(a)? on "a": $0 = empty list, $1 = a
+{
+    'a' ~~ /(z)*(a)?/;
+    ok $/[0] ~~ Positional && $/[0].elems == 0, '(z)*(a)? on a: $0 empty list';
+    is ~$/[1], 'a',     '(z)*(a)? on a: $1 = a';
+}
+
+# Alternation does NOT reserve across branches (Rakudo: elems == 1).
+{
+    'b' ~~ /(a)|(b)/;
+    is $/.list.elems, 1, '(a)|(b) on b: one slot (branch-reset numbering)';
+    is ~$/[0], 'b',      '(a)|(b) on b: $0 = b';
+}


### PR DESCRIPTION
## Summary
An unmatched optional capture group now reserves its positional slot so the following captures keep their index, matching Rakudo:

```raku
'b' ~~ /(a)?(b)/;   # was $0=Match(b) (WRONG); now $0=Nil, $1=b
'x' ~~ /(z)*/;      # was $0 absent;            now $0=[] (empty List)
'x' ~~ /(y)?(z)*/;  # now $0=Nil, $1=[]
'c' ~~ /(a)?(b)?(c)/; # now $0=Nil, $1=Nil, $2=c
```

This was a general capture-misalignment bug (any unmatched optional shifted every later `$N`), and it blocked roast `S05-match/capturing-contexts.t` **test 46**.

## Mechanism
Surgical — avoids touching all ~59 `positional` mutation sites:
- `RegexCaptures` gains `positional_nil: Vec<bool>`. Only the zero-match reservation pads it (`false` up to the current `positional` length, then `true`), so matched captures that never touch it stay index-aligned.
- `reserve_nil_capture_slots` reserves Nil slots for a `(x)?` that matched zero times (the three `ZeroOrOne` zero-match arms).
- `fold_quantified_captures` reserves an empty-List slot per inner capture when a `*` / `**0..` group matched zero times (the `new_entries == 0` arm).
- The Match builder (`make_match_object_full_q` / `make_subcap_match`) renders a `positional_nil[i]` slot as `Nil`. The new slice is threaded through `make_match_object_full`; manual builders pass `&[]`.

Alternation numbering is unchanged (`(a)|(b)` stays branch-reset: `elems == 1`). One-iteration `(z)*` still yields a single Match rather than `List(1)` (Rakudo folds it; wider blast radius, deferred — noted in code).

## Tests
- New `t/quantified-capture-slots.t` (21 cases, all verified against Rakudo via an oracle script).
- `S05-match/capturing-contexts.t`: 58/64 → 59/64 (test 46 now passes).
- `make test` passes; no regressions across a broad S05 sampling (`S05-capture/{alias,caps,dot,named,subrule,match-object}`, `S05-grammar/*`, `S05-metasyntax/*`, `S05-mass/*`, `S05-match/*`). Pre-existing failures in `S05-capture/array-alias.t` and `hash.t` are unrelated (fail identically on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)