### PR TITLE
fix(container): `%h.push` / `.append` through a `:=`-bound hash

### DIFF
--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1259,6 +1259,20 @@ impl Interpreter {
                     self.env_dirty = true;
                     return Ok(());
                 }
+                // Symmetric bound-cell fast path for hash mutators (`%h.push` /
+                // `.append`) where `%h := %g` holds a shared `ContainerRef` cell.
+                // The array mutator above descends the cell via
+                // `env_root_descended_mut`; hashes need the same so the mutation
+                // propagates to the bind source instead of detaching into the
+                // receiver's own slot.
+                if modifier.is_none()
+                    && let Some(result) =
+                        self.try_native_hash_mut_bound(&target_name, &method, &args)
+                {
+                    self.stack.push(result?);
+                    self.env_dirty = true;
+                    return Ok(());
+                }
                 // Native fast path for the simple (non-erroring) forms of `splice`
                 // on a plain, untyped `@`-array (ledger §1: native receiver
                 // dispatch -> Interpreter-native).
@@ -1510,6 +1524,39 @@ impl Interpreter {
         let mut bytes = name.bytes();
         matches!(bytes.next(), Some(b'@') | Some(b'%'))
             && matches!(bytes.next(), Some(c) if c.is_ascii_alphabetic() || c == b'_')
+    }
+
+    /// Bound-hash twin of `try_native_array_mut`: `%h.push((k => v))` /
+    /// `%h.append(...)` where `%h := %g` holds a shared `ContainerRef` cell.
+    /// Only the bound case is intercepted — a plain hash has no cell to detach,
+    /// so its existing interpreter writeback (into the receiver's slot) is
+    /// already correct. Hash push/append semantics (existing-key value becomes a
+    /// list) are non-trivial, so we delegate to the interpreter on the *inner*
+    /// hash and write the result back through the cell, keeping every alias
+    /// coherent.
+    fn try_native_hash_mut_bound(
+        &mut self,
+        target_name: &str,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(method, "push" | "append") {
+            return None;
+        }
+        let cell = match self.env().get(target_name) {
+            Some(Value::ContainerRef(cell)) => cell.clone(),
+            _ => return None,
+        };
+        let inner = cell.lock().unwrap().clone();
+        if !matches!(inner, Value::Hash(_)) {
+            return None;
+        }
+        let result = match loan_env!(self, call_method_with_values(inner, method, args.to_vec())) {
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
+        };
+        *cell.lock().unwrap() = result.clone();
+        Some(Ok(result))
     }
 
     fn try_native_array_mut(

--- a/t/hash-push-bound.t
+++ b/t/hash-push-bound.t
@@ -1,0 +1,59 @@
+use Test;
+
+# `%h.push` / `%h.append` through a `:=`-bound hash must propagate to the
+# shared bind source (regression: it detached into the receiver's own slot, so
+# the bind source never saw the new pair).
+
+plan 9;
+
+{
+    my %g = (a => 1);
+    my %h := %g;
+    %h.push((b => 2));
+    is %h.sort.gist, '(a => 1 b => 2)', 'push visible through bound alias';
+    is %g.sort.gist, '(a => 1 b => 2)', 'push propagates to bind source';
+}
+
+{
+    my %g = (a => 1);
+    my %h := %g;
+    %h.push((a => 2));
+    is %g.gist, '{a => [1 2]}', 'existing-key push promotes to list on bind source';
+}
+
+{
+    my %g = (a => 1);
+    my %h := %g;
+    %h.append((b => 5));
+    is %g.sort.gist, '(a => 1 b => 5)', 'append propagates to bind source';
+}
+
+{
+    my %g = (a => 1);
+    my %h := %g;
+    %h.push((b => 2), (c => 3));
+    is %g.sort.gist, '(a => 1 b => 2 c => 3)', 'multi-pair push propagates';
+}
+
+{
+    my %g = (a => 1);
+    my %m := %g;
+    my %h := %m;
+    %h.push((z => 9));
+    is %g.sort.gist, '(a => 1 z => 9)', 'push reaches chained bind root';
+}
+
+# plain (non-bound) hash push/append must stay correct
+{
+    my %h = (a => 1);
+    %h.push((b => 2));
+    is %h.sort.gist, '(a => 1 b => 2)', 'plain hash push';
+
+    my %k = (a => 1);
+    %k.push((a => 2));
+    is %k.gist, '{a => [1 2]}', 'plain hash existing-key push promotes to list';
+
+    my %j = (a => 1);
+    %j.append((b => 5));
+    is %j.sort.gist, '(a => 1 b => 5)', 'plain hash append';
+}


### PR DESCRIPTION
## What

`%h.push((k => v))` / `%h.append(...)` where `%h := %g` mutated only the receiver's own slot and **detached the bind** — the new pair never reached the bind source:

```raku
my %g = (a => 1); my %h := %g;
%h.push((b => 2));
say %g.sort;   # raku: (a => 2 ... ) -> (a => 1 b => 2)   mutsu(before): (a => 1)
```

## Why

The array mutator fast path (`try_native_array_mut`) already descends a whole-container `:=`-bound `ContainerRef` cell via `env_root_descended_mut`, so `@a.push` on a bound array propagates. Hashes had **no symmetric path**: `%h.push` fell through to the interpreter, which computed a fresh hash and wrote it back into the receiver's slot, replacing (detaching) the shared cell.

## Fix

Add `try_native_hash_mut_bound`, called right after the array mutator fast path. For the **bound-cell case only** (plain hashes keep their already-correct interpreter writeback), it delegates `push`/`append` to the interpreter on the *inner* hash and writes the result back **through** the shared cell, keeping every alias coherent. Hash semantics (existing key promotes its value to a list) are preserved by reusing the interpreter logic rather than reimplementing them.

This is the method-dispatch sibling of the index-assign bound-container fixes in #3279 (junction / from-end index).

## Tests
- `t/hash-push-bound.t` (9) — push/append/multi-pair/existing-key-list/chained-bind propagation + plain-hash regression guards.
- `make test` PASS (9047), clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)