### PR TITLE
feat(grammar): `my grammar {...}` expression + capture markers in tokens

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -73,8 +73,17 @@
 - [ ] roast/S05-match/basics.t
 - [ ] roast/S05-match/blocks.t
 - [ ] roast/S05-match/capturing-contexts.t
-  - 59/64 pass. Test 29 (`my $/ := 42`), test 30 (`$0` from a bound `$/`), and
-    test 46 (index-stable capture slots) now pass. Test 29: a block-final `:=`
+  - 60/64 pass. Test 64 (capture markers in grammar tokens) now passes via two
+    fixes: (1) `my grammar { ... }` / `my class { ... }` parse as an anonymous
+    lexical package *expression* (`my grammar {...}.parse: $s`) — the expr-context
+    `my`/`our`/`state` arm in `primary/ident.rs` now falls back to the
+    `anon_grammar_expr`/`anon_class_expr`/`anon_role_expr` parsers; (2) a token's
+    own capture markers `<(` / `)>` restrict its `<subrule>` submatch — the subrule
+    body matches against the tail (0-based), so `build_named_candidates_from_inner`
+    rebases the inner `capture_start`/`capture_end` by `pos` when setting the
+    subcap's from/to (`t/grammar-capture-markers.t`).
+    Tests 29 (`my $/ := 42`), 30 (`$0` from a bound `$/`), and 46 (index-stable
+    capture slots) also pass. Test 29: a block-final `:=`
     scalar bind to a readonly RHS used to throw "Cannot assign to a readonly
     variable" (fixed in `compile_block_inline`, `t/block-final-scalar-bind.t`).
     Test 30: `$0`/`$1`/... derive from the current `$/` by indexing when no digit
@@ -86,10 +95,16 @@
     `$0=Nil,$1=b` and `(y)?(z)*` on "x" is `$0=Nil,$1=[]` (matches Rakudo; see
     `t/quantified-capture-slots.t`). NOTE: one-iteration `(z)*` still yields a
     single Match, not `List(1)` (Rakudo folds it — wider blast radius, deferred).
-    Remaining blockers: `%%` separator
-    backtracking against an outer anchor (tests 53-56, where the native separator
-    path falls back to string expansion); capture markers `<(`/`)>` in some
-    grammar combinations (test 64).
+    Remaining blockers (tests 53-56, both deep regex backtracking):
+    - 53-54: `( 'rule1' || 'rule2' )* %% (.+?)` — `%%` separator-quantifier with
+      captures on both sides + `||` backtracking; the whole match succeeds but the
+      per-iteration captures are wrong.
+    - 55-56: `(a | b | bc | cde)+»` — LTM-alternation `+` must backtrack into
+      *shorter* per-iteration alternatives to satisfy the trailing `»` word
+      boundary (`a,b,cde`); mutsu commits to the longest alternative per iteration
+      and gives up to a later start (`cde`) instead of backtracking. `(a|b|bc|cde)+`
+      *without* `»` already matches correctly (`abc`, 2 caps) — only the
+      backtrack-into-quantified-alternation-on-anchor-failure path is missing.
 - [ ] roast/S05-match/make.t
 - [ ] roast/S05-match/non-capturing.t
 - [ ] roast/S05-match/positions.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1830,7 +1830,24 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             match super::super::stmt::my_decl_expr_pub(input) {
                 Ok((r, stmt)) => return Ok((r, Expr::DoStmt(Box::new(stmt)))),
                 Err(err) if err.is_fatal() => return Err(err),
-                Err(_) => {}
+                Err(_) => {
+                    // `my grammar { ... }` / `my class { ... }` / `my role { ... }`:
+                    // an *anonymous* lexical package declarator used as an
+                    // expression (e.g. `my grammar { ... }.parse: $s`). The named
+                    // declarator parser above can't parse the no-name form, so
+                    // delegate to the anonymous-package expression parsers on the
+                    // text after the `my`/`our`/`state` keyword.
+                    if let Some(after_kw) = keyword("my", input)
+                        .or_else(|| keyword("our", input))
+                        .or_else(|| keyword("state", input))
+                        && let Ok((after_kw, _)) = ws1(after_kw)
+                        && let Ok(res) = super::misc::anon_grammar_expr(after_kw)
+                            .or_else(|_| super::misc::anon_class_expr(after_kw))
+                            .or_else(|_| super::misc::anon_role_expr(after_kw))
+                    {
+                        return Ok(res);
+                    }
+                }
             }
         }
         "constant" => {

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -498,11 +498,20 @@ impl Interpreter {
                 .as_deref()
                 .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
             if let Some(capture_name) = capture_name {
-                let captured: String = chars[pos..end].iter().collect();
+                // Apply the subrule's own capture markers (`<(` / `)>`): a token
+                // like `token foo { 12345 <( 67890 }` restricts its `<foo>`
+                // submatch to `67890`. The subrule body is matched against the
+                // tail starting at `pos`, so its `capture_start`/`capture_end` are
+                // tail-relative (0-based); rebase them by `pos`. They are `None`
+                // when the subrule used no markers, so this is a no-op otherwise.
+                let inner_len = end - pos;
+                let cs = (pos + inner_caps.capture_start.unwrap_or(0)).clamp(pos, end);
+                let ce = (pos + inner_caps.capture_end.unwrap_or(inner_len)).clamp(cs, end);
+                let captured: String = chars[cs..ce].iter().collect();
                 let mut subcap = inner_caps;
                 subcap.matched = captured.clone();
-                subcap.from = pos;
-                subcap.to = end;
+                subcap.from = cs;
+                subcap.to = ce;
                 // sym is already set on subcap from raw_out collection loop.
                 // Fall back to sym_key parameter for the is_active (seed) path.
                 if subcap.sym.is_none() && sym_key.is_some() {

--- a/t/grammar-capture-markers.t
+++ b/t/grammar-capture-markers.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 10;
+
+# `my grammar { ... }` / `my class { ... }` as an *expression* (anonymous lexical
+# package declarator), e.g. `my grammar { ... }.parse: $s`.
+{
+    my $r = my grammar { token TOP { \d+ } }.parse("123");
+    isa-ok $r, Match, 'my grammar {...}.parse returns a Match';
+    is ~$r, '123', 'my grammar {...}.parse matched text';
+}
+{
+    my $o = my class { method greet { "hi" } }.new;
+    is $o.greet, 'hi', 'my class {...}.new works as an expression';
+}
+
+# Capture markers `<(` / `)>` inside grammar tokens restrict the token's submatch.
+constant $s = '1234567890foobarMEOW';
+{
+    my $r = my grammar {
+        token TOP { <foo><bar><ber> }
+        token foo { 12345 <( 67890 }
+        token bar { foo   )> bar   }
+        token ber { M <(EO)>  W    }
+    }.parse: $s;
+    isa-ok $r, Match, 'grammar with capture markers parses';
+    is ~$r<foo>, '67890', '<( restricts <foo> start';
+    is ~$r<bar>, 'foo',   ')> restricts <bar> end';
+    is ~$r<ber>, 'EO',    '<( ... )> restricts <ber> on both sides';
+}
+{
+    my $r = my grammar {
+        token TOP { <foo><bar><ber> }
+        token foo { \d**5 <( \d+ }
+        token bar { <:lower>**3 )> <:lower>+ }
+        token ber { <:upper> <(.**2)> .+  }
+    }.parse: $s;
+    is ~$r<foo>, '67890', '<( with \d (grammar 2)';
+    is ~$r<bar>, 'foo',   ')> with <:lower> (grammar 2)';
+    is ~$r<ber>, 'EO',    '<( )> with <:upper> (grammar 2)';
+}


### PR DESCRIPTION
## Summary
Two fixes that together make roast `S05-match/capturing-contexts.t` **test 64** pass (59/64 → 60/64):

### 1. `my grammar { ... }` as an expression
`my grammar { ... }` / `my class { ... }` / `my role { ... }` now parse as an anonymous lexical package **expression**:
```raku
my $r = my grammar { token TOP { \d+ } }.parse: $s;   # was misparsed
```
The named-declarator parser can't handle the no-name form, so the expr-context `my`/`our`/`state` arm in `primary/ident.rs` falls back to the existing `anon_grammar_expr`/`anon_class_expr`/`anon_role_expr` parsers when it fails. Previously `my $r = my grammar {...}.parse(...)` misparsed as `$r = my` (bareword) plus a separate `grammar {...}.parse(...)` statement.

### 2. Capture markers `<(` / `)>` inside grammar tokens
A token's own capture markers now restrict its `<subrule>` submatch:
```raku
token foo { 12345 <( 67890 }   # <foo> is now "67890", was "1234567890"
token bar { foo   )> bar   }   # <bar> is now "foo"
token ber { M <(EO)>  W    }   # <ber> is now "EO"
```
The subrule body is matched against the tail starting at `pos`, so its `capture_start`/`capture_end` are tail-relative (0-based); `build_named_candidates_from_inner` rebases them by `pos` when setting the subcap's matched/from/to. (Plain top-level `<(`/`)>` already worked; the in-subrule case was off because `pos` happened to be 0 in single-subrule cases.)

## Tests
- New `t/grammar-capture-markers.t` (10 cases).
- `S05-match/capturing-contexts.t`: 59/64 → 60/64 (test 64 passes). Remaining 53-56 are deep regex backtracking (`%%` separator captures, LTM-alternation `+` backtracking into the trailing `»`) — documented in `TODO_roast/S05.md`.
- `make test` passes; no regressions across `S05-capture/*` and `S05-grammar/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)