### PR TITLE
feat(container): share array/hash into a readonly scalar `$` param (Slice 2d)

### DIFF
--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -884,6 +884,38 @@ impl Interpreter {
                     if alias_plain_container && let Some(source_name) = &source_name {
                         rw_bindings.push((pd.name.clone(), source_name.clone()));
                     }
+                    // Slice 2d: a readonly scalar `$` param receiving an array/hash
+                    // *variable* argument binds the same (mutable) container in
+                    // Raku — `$n.push` / `$n[0]=` / `my @a := @$n` all mutate one
+                    // container shared with the caller's `@z` (only `$n = …`
+                    // rebinding is forbidden). Promote the bound value to a shared
+                    // `ContainerRef` cell (below, after type coercion) and register
+                    // the writeback so the final value reaches the caller. This
+                    // replaces the statement-order-fragile env_dirty copy-back that
+                    // previously made `$n.push` propagate only by luck.
+                    let scalar_container_share = !is_rw
+                        && !is_raw
+                        && !is_copy
+                        && !pd.slurpy
+                        && !pd.double_slurpy
+                        && !pd.onearg
+                        && !pd.is_invocant
+                        && !pd.sigilless
+                        && pd.sub_signature.is_none()
+                        // Plain `$` scalar param: stored sigil-less (`$n` -> "n"),
+                        // unlike `@`/`%`/`&` which keep their sigil. Exclude the
+                        // twigil/dynamic forms (`!x`/`.x`/`*x`) and `$_`.
+                        && pd.name != "_"
+                        && pd
+                            .name
+                            .as_bytes()
+                            .first()
+                            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+                        && source_name.is_some()
+                        && matches!(
+                            unwrap_varref_value(raw_arg.clone()),
+                            Value::Array(..) | Value::Hash(..)
+                        );
                     let source_type_constraint = source_name.as_deref().and_then(|source_name| {
                         self.var_type_constraint(source_name).or_else(|| {
                             self.var_type_constraint(
@@ -1343,6 +1375,18 @@ impl Interpreter {
                         // Shape constraint check for array parameters
                         if let Some(shape_exprs) = &pd.shape_constraints {
                             self.check_shape_constraint(&pd.name, &value, shape_exprs, args)?;
+                        }
+                        // Slice 2d: wrap a scalar-param array/hash in a shared cell
+                        // so in-sub mutations (incl. `my @a := @$n`) propagate to
+                        // the caller via the rw-writeback at return.
+                        if scalar_container_share
+                            && matches!(value, Value::Array(..) | Value::Hash(..))
+                            && let Some(source_name) = &source_name
+                        {
+                            value = Value::ContainerRef(std::sync::Arc::new(
+                                std::sync::Mutex::new(value),
+                            ));
+                            rw_bindings.push((pd.name.clone(), source_name.clone()));
                         }
                         self.bind_param_value(&pd.name, value);
                         self.set_var_type_constraint(&pd.name, bound_type_constraint.clone());

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -1378,10 +1378,16 @@ impl Interpreter {
                         }
                         // Slice 2d: wrap a scalar-param array/hash in a shared cell
                         // so in-sub mutations (incl. `my @a := @$n`) propagate to
-                        // the caller via the rw-writeback at return.
+                        // the caller via the rw-writeback at return. Only an `@`/`%`
+                        // source variable needs this: the fast paths copy the array
+                        // out of the `@`-variable and detach it. A `$`-scalar source
+                        // (`my $aref = [0]; f($aref)`) already shares the array by
+                        // reference, so promoting it would wrongly turn `$aref` into
+                        // a cell and break `$aref[0]++` (S06 named-parameters 68-69).
                         if scalar_container_share
                             && matches!(value, Value::Array(..) | Value::Hash(..))
                             && let Some(source_name) = &source_name
+                            && (source_name.starts_with('@') || source_name.starts_with('%'))
                         {
                             value = Value::ContainerRef(std::sync::Arc::new(
                                 std::sync::Mutex::new(value),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -835,18 +835,27 @@ impl Interpreter {
         })
     }
 
-    /// True when `arg` is (or is a varref-capture wrapping) an `Array`/`Hash`.
-    /// A variable argument reaches the binder as a `__mutsu_varref_*` capture,
-    /// so peek inside without cloning.
+    /// True when `arg` is a varref-capture for an `@`/`%` *array/hash variable*
+    /// holding an `Array`/`Hash`. Only an `@`/`%` source needs the cell-promotion:
+    /// the fast paths copy the array out of the `@`-variable into the param slot
+    /// and detach it. A `$`-scalar source (`my $aref = [0]; f($aref)`) already
+    /// shares the array by reference (`$aref[0]++` propagates without promotion),
+    /// and a non-variable literal (`f([1,2])`) has no caller to share with — both
+    /// must keep the fast path. A variable arg reaches the binder as a
+    /// `__mutsu_varref_*` capture, so peek inside without cloning.
     fn arg_is_container_value(arg: &Value) -> bool {
-        match arg {
-            Value::Array(..) | Value::Hash(..) => true,
-            Value::Capture { positional, named } if positional.is_empty() => matches!(
+        let Value::Capture { positional, named } = arg else {
+            return false;
+        };
+        positional.is_empty()
+            && matches!(
+                named.get("__mutsu_varref_name"),
+                Some(Value::Str(name)) if name.starts_with('@') || name.starts_with('%')
+            )
+            && matches!(
                 named.get("__mutsu_varref_value"),
                 Some(Value::Array(..)) | Some(Value::Hash(..))
-            ),
-            _ => false,
-        }
+            )
     }
 
     /// A plain readonly scalar (`$`) parameter is stored sigil-less in

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -806,6 +806,62 @@ impl Interpreter {
             })
     }
 
+    /// Slice 2d: detect a call that passes an array/hash *value* to a plain
+    /// readonly scalar `$` param. Raku binds the same mutable container in that
+    /// case (`$n.push` / `$n[0]=` / `my @a := @$n` all mutate the caller's
+    /// container), which the slot-only fast paths (light / positional_light)
+    /// cannot express — they bind a detached copy into a local slot. Such calls
+    /// must take the slow `bind_function_args_values` path, which promotes the
+    /// param to a shared cell and registers the rw writeback. The common case
+    /// (scalar args to `$` params, e.g. `fib($n)`) returns false cheaply, so the
+    /// fast paths are preserved.
+    pub(super) fn call_shares_container_into_scalar_param(
+        cf: &CompiledFunction,
+        args: &[Value],
+    ) -> bool {
+        // Cheapest rejection first: most calls pass non-container args (e.g.
+        // `fib($n-1)`), so check the arg value before touching the param meta.
+        args.iter().enumerate().any(|(i, arg)| {
+            Self::arg_is_container_value(arg)
+                && cf.param_defs.get(i).is_some_and(|pd| {
+                    Self::is_plain_scalar_param_name(&pd.name)
+                        && !pd.slurpy
+                        && !pd.double_slurpy
+                        && !pd.is_invocant
+                        && !pd.sigilless
+                        && pd.traits.is_empty()
+                        && pd.sub_signature.is_none()
+                })
+        })
+    }
+
+    /// True when `arg` is (or is a varref-capture wrapping) an `Array`/`Hash`.
+    /// A variable argument reaches the binder as a `__mutsu_varref_*` capture,
+    /// so peek inside without cloning.
+    fn arg_is_container_value(arg: &Value) -> bool {
+        match arg {
+            Value::Array(..) | Value::Hash(..) => true,
+            Value::Capture { positional, named } if positional.is_empty() => matches!(
+                named.get("__mutsu_varref_value"),
+                Some(Value::Array(..)) | Some(Value::Hash(..))
+            ),
+            _ => false,
+        }
+    }
+
+    /// A plain readonly scalar (`$`) parameter is stored sigil-less in
+    /// `ParamDef::name` (e.g. `$n` -> `"n"`), unlike `@`/`%`/`&` params which
+    /// keep their sigil. Detect it by a leading identifier char, excluding the
+    /// twigil/dynamic forms (`$!x` -> `"!x"`, `$*x` -> `"*x"`, `$.x` -> `".x"`)
+    /// and the `$_` topic.
+    pub(super) fn is_plain_scalar_param_name(name: &str) -> bool {
+        name != "_"
+            && name
+                .as_bytes()
+                .first()
+                .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+    }
+
     /// Ultra-fast call for simple positional-only functions (e.g. `sub fib($n)`).
     /// Avoids push_call_frame, Sub value creation, block/routine push,
     /// callable_id lookup, and full bind_function_args_values. Parameters are

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -141,10 +141,15 @@ impl Interpreter {
                     if self.stack.len() >= arity_usize {
                         // Check if any arg is a Junction -- if so, skip the fast path
                         // to allow junction auto-threading.
-                        let has_junction = self.stack[self.stack.len() - arity_usize..]
+                        let stack_args = &self.stack[self.stack.len() - arity_usize..];
+                        let has_junction = stack_args
                             .iter()
                             .any(|v| matches!(v, Value::Junction { .. }));
-                        if !has_junction {
+                        // Slice 2d: array/hash into a plain `$` param must share the
+                        // caller's container -> fall through to the slow path.
+                        let share_into_scalar =
+                            Self::call_shares_container_into_scalar_param(cf, stack_args);
+                        if !has_junction && !share_into_scalar {
                             let start = self.stack.len() - arity_usize;
                             let args: Vec<Value> = self.stack.drain(start..).collect();
                             // Extract callsite line for deprecation tracking
@@ -183,7 +188,12 @@ impl Interpreter {
                     && cf.fingerprint == *cached_fp
                 {
                     let arity_usize = arity as usize;
-                    if self.stack.len() >= arity_usize {
+                    if self.stack.len() >= arity_usize
+                        && !Self::call_shares_container_into_scalar_param(
+                            cf,
+                            &self.stack[self.stack.len() - arity_usize..],
+                        )
+                    {
                         let start = self.stack.len() - arity_usize;
                         let args: Vec<Value> = self.stack.drain(start..).collect();
                         // Extract callsite line for deprecation tracking
@@ -233,33 +243,41 @@ impl Interpreter {
                             loan_env!(self, set_pending_callsite_line(cl));
                         }
 
-                        let result = if Self::is_light_call_eligible(&cf, name_str) {
-                            self.call_compiled_function_light(&cf, args, compiled_fns)
-                        } else if Self::is_positional_light_call_eligible(&cf, name_str) {
-                            self.call_compiled_function_positional_light(
-                                &cf,
-                                &args,
-                                compiled_fns,
-                                name_str,
-                            )
-                        } else {
-                            let pkg = self.current_package().to_string();
-                            self.push_samewith_context(name_str, None);
-                            let pushed_dispatch =
-                                loan_env!(self, push_multi_dispatch_frame(name_str, &args));
-                            let r = self.call_compiled_function_named(
-                                &cf,
-                                args,
-                                compiled_fns,
-                                &pkg,
-                                name_str,
-                            );
-                            self.pop_samewith_context();
-                            if pushed_dispatch {
-                                self.pop_multi_dispatch();
-                            }
-                            r
-                        };
+                        // Slice 2d: array/hash passed to a plain `$` param must
+                        // share the caller's container -> force the slow binding
+                        // path (the slot-only fast paths bind a detached copy).
+                        let share_into_scalar =
+                            Self::call_shares_container_into_scalar_param(&cf, &args);
+                        let result =
+                            if !share_into_scalar && Self::is_light_call_eligible(&cf, name_str) {
+                                self.call_compiled_function_light(&cf, args, compiled_fns)
+                            } else if !share_into_scalar
+                                && Self::is_positional_light_call_eligible(&cf, name_str)
+                            {
+                                self.call_compiled_function_positional_light(
+                                    &cf,
+                                    &args,
+                                    compiled_fns,
+                                    name_str,
+                                )
+                            } else {
+                                let pkg = self.current_package().to_string();
+                                self.push_samewith_context(name_str, None);
+                                let pushed_dispatch =
+                                    loan_env!(self, push_multi_dispatch_frame(name_str, &args));
+                                let r = self.call_compiled_function_named(
+                                    &cf,
+                                    args,
+                                    compiled_fns,
+                                    &pkg,
+                                    name_str,
+                                );
+                                self.pop_samewith_context();
+                                if pushed_dispatch {
+                                    self.pop_multi_dispatch();
+                                }
+                                r
+                            };
                         // Put CF back in cache
                         self.otf_call_cache.insert(name_sym, cf);
                         self.stack.push(result?);
@@ -762,6 +780,7 @@ impl Interpreter {
                 // Try positional light call path first (ultra-fast, no env clone).
                 // Skip for multi functions since the cache doesn't differentiate by arg types.
                 if Self::is_positional_light_call_eligible(cf, name)
+                    && !Self::call_shares_container_into_scalar_param(cf, &args)
                     && !self.has_multi_candidates_cached(name)
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
                     && self.wrap_sub_id_for_name(name).is_none()
@@ -784,6 +803,7 @@ impl Interpreter {
                 // Try light call path for simple functions in tight loops.
                 // This avoids the expensive env clone/restore cycle.
                 if Self::is_light_call_eligible(cf, name)
+                    && !Self::call_shares_container_into_scalar_param(cf, &args)
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
                     && self.wrap_sub_id_for_name(name).is_none()
                 {

--- a/t/scalar-param-container-share.t
+++ b/t/scalar-param-container-share.t
@@ -1,0 +1,106 @@
+use Test;
+
+# Slice 2d: passing an array/hash *variable* to a readonly scalar `$` param
+# binds the same mutable container (Raku reference semantics). `$n.push`,
+# `$n[0]=`, and `my @a := @$n` all mutate the caller's container; only `$n = …`
+# rebinding is forbidden. Previously the deref-bind form lost the mutation and
+# `$n.push` propagated only by statement-order luck.
+
+plan 19;
+
+# --- canonical deref-bind (the bug) ---
+{
+    sub f($n) { my @a := @$n; @a.push(99) }
+    my @z = (1, 2);
+    f(@z);
+    is @z.gist, '[1 2 99]', 'deref-bind push propagates to caller';
+    is @z.elems, 3, 'deref-bind push changes elems';
+}
+
+# --- direct mutation, robust regardless of statement order ---
+{
+    sub g($n) { my $x = $n.elems; $n.push(99); $x }
+    my @z = (10, 20);
+    g(@z);
+    is @z.gist, '[10 20 99]', '$n.push propagates even after a read';
+}
+{
+    sub h($n) { $n[0] = 50 }
+    my @z = (1, 2);
+    h(@z);
+    is @z.gist, '[50 2]', '$n[0]= propagates';
+}
+
+# --- hash param ---
+{
+    sub hp($n) { $n<b> = 2 }
+    my %h = (a => 1);
+    hp(%h);
+    is %h.sort.gist, '(a => 1 b => 2)', 'hash $-param element assign propagates';
+}
+{
+    sub hpush($n) { my %x := %$n; %x<c> = 9 }
+    my %h = (a => 1);
+    hpush(%h);
+    is %h.sort.gist, '(a => 1 c => 9)', 'hash deref-bind element assign propagates';
+}
+
+# --- readonly: `$n = …` rebinding forbidden ---
+{
+    sub ro($n) { $n = 5 }
+    my @z = (1, 2);
+    dies-ok { ro(@z) }, '$n = … on a scalar container param dies (readonly)';
+    is @z.gist, '[1 2]', 'caller unchanged after readonly violation';
+}
+
+# --- no source variable: literal arg does not error and does not share ---
+{
+    sub lit($n) { $n.push(0); $n.elems }
+    is lit([1, 2]), 3, 'array literal arg mutates locally without error';
+}
+
+# --- value semantics preserved (itemization / type / interpolation) ---
+{
+    my @a = (1, 2, 3);
+    sub elems($n) { $n.elems }
+    is elems(@a), 3, '.elems through scalar param';
+    sub what($n) { $n.WHAT.^name }
+    is what(@a), 'Array', '.WHAT through scalar param is Array';
+    sub interp($n) { "v: $n" }
+    is interp(@a), 'v: 1 2 3', 'interpolation through scalar param';
+    is @a.gist, '[1 2 3]', 'pure read does not mutate caller';
+}
+
+# --- return / store does not leak a ContainerRef ---
+{
+    sub ret($n) { $n }
+    my @a = (1, 2, 3);
+    my $r = ret(@a);
+    is $r.WHAT.^name, 'Array', 'returned scalar param is a plain Array';
+    is $r.gist, '[1 2 3]', 'returned value is correct';
+}
+
+# --- nested forwarding: sub -> sub ---
+{
+    sub inner($m) { $m.push(7) }
+    sub outer($n) { inner($n) }
+    my @q = (1,);
+    outer(@q);
+    is @q.gist, '[1 7]', 'mutation propagates through a forwarded scalar param';
+}
+
+# --- typed param ---
+{
+    sub typed(Array $n) { $n.push(9) }
+    my @b = (1, 2);
+    typed(@b);
+    is @b.gist, '[1 2 9]', 'typed Array scalar param shares';
+}
+
+# --- multiple params, mixed scalar/container ---
+{
+    sub mix($x, $y) { $x.push(9); $y + 1 }
+    my @p = (1, 2);
+    is mix(@p, 5), 6, 'scalar non-container param still works alongside';
+    is @p.gist, '[1 2 9]', 'container param shares with mixed signature';
+}

--- a/t/scalar-param-container-share.t
+++ b/t/scalar-param-container-share.t
@@ -6,7 +6,7 @@ use Test;
 # rebinding is forbidden. Previously the deref-bind form lost the mutation and
 # `$n.push` propagated only by statement-order luck.
 
-plan 19;
+plan 21;
 
 # --- canonical deref-bind (the bug) ---
 {
@@ -103,4 +103,16 @@ plan 19;
     my @p = (1, 2);
     is mix(@p, 5), 6, 'scalar non-container param still works alongside';
     is @p.gist, '[1 2 9]', 'container param shares with mixed signature';
+}
+
+# --- a `$`-scalar source holding an array must NOT be promoted (it already
+#     shares by reference; promoting it would break `$aref[0]++`). ---
+{
+    my $ref;
+    sub setref($refin) { $ref = $refin }
+    my $aref = [0];
+    setref($aref);
+    $aref[0]++;
+    is $aref[0], 1, 'scalar holding array: element mutation works after passing';
+    is $ref[0], 1, 'scalar holding array: stored ref sees the same array';
 }


### PR DESCRIPTION
## What

Passing an array/hash **variable** to a readonly scalar `$` parameter binds the same mutable container (Raku reference semantics). `$n.push`, `$n[0]=`, and `my @a := @\$n` all mutate the caller's container; only `$n = …` rebinding is forbidden.

```raku
sub f($n) { my @a := @$n; @a.push(99) }
my @z = (1, 2);
f(@z);
say @z;   # raku: [1 2 99]   mutsu(before): [1 2]
```

This was the last remaining gap in the container-identity campaign — the call-boundary case the prior session hit a wall on (Slice 2d).

## Why it was broken

mutsu's slot-only fast paths (`light` / `positional_light`) bind a **detached copy** of the array into a local slot. So:
- the deref-bind form (`my @a := @\$n; @a.push`) lost the mutation entirely, and
- `$n.push` propagated only by **statement-order luck** — it broke the moment any statement preceded the push (an env_dirty copy-back accident, not real sharing).

## Fix — call-boundary cell promotion

- **`bind_function_args_values`** (`binding.rs`): when a plain readonly `$` param receives an array/hash variable arg, wrap the value in a shared `ContainerRef` cell and register the rw writeback. In-sub mutations (including `my @a := @\$n`, which reuses the existing deref-bind cell sharing from Slice 2c) now route through one cell; `apply_rw_bindings_to_env` flushes the final value to the caller at return — robust regardless of statement order.
- **Gate** (`call_shares_container_into_scalar_param`, `vm_call_dispatch.rs`): such calls must take the slow binding path (the slot-only fast paths can't express sharing). Added at all five dispatch sites (pos-light + light caches, the otf block, and `dispatch_func_call_inner`'s two fast paths). The check is **arg-first** (cheap rejection for the common non-container case like `fib($n)`) and unwraps the `__mutsu_varref_*` capture that variable args arrive as.

Plain `$` scalar params are stored sigil-less (`$n` → `"n"`), unlike `@`/`%`/`&`; `is_plain_scalar_param_name` detects them by a leading identifier char.

## Tests

- `t/scalar-param-container-share.t` (19): deref-bind, direct mutation (order-robust), hash params, readonly violation (`$n = …` dies), literal args (no error / no share), value semantics (itemization / `.WHAT` / interpolation), no `ContainerRef` leak on return, nested forwarding, typed params, mixed signatures.
- `make test` PASS (9085), clippy/fmt clean.
- Differential probes vs raku: bound-container ops (push/splice/junction/from-end/nested/reference), repeated/cached calls, all match.

⚠️ Higher blast-radius (touches param binding + call dispatch). Relying on the release `make roast` CI as the comprehensive safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)