### PR TITLE
feat(regex): greedy backtracking into quantified alternations

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -73,7 +73,7 @@
 - [ ] roast/S05-match/basics.t
 - [ ] roast/S05-match/blocks.t
 - [ ] roast/S05-match/capturing-contexts.t
-  - 60/64 pass. Test 64 (capture markers in grammar tokens) now passes via two
+  - 62/64 pass. Test 64 (capture markers in grammar tokens) now passes via two
     fixes: (1) `my grammar { ... }` / `my class { ... }` parse as an anonymous
     lexical package *expression* (`my grammar {...}.parse: $s`) — the expr-context
     `my`/`our`/`state` arm in `primary/ident.rs` now falls back to the
@@ -95,16 +95,18 @@
     `$0=Nil,$1=b` and `(y)?(z)*` on "x" is `$0=Nil,$1=[]` (matches Rakudo; see
     `t/quantified-capture-slots.t`). NOTE: one-iteration `(z)*` still yields a
     single Match, not `List(1)` (Rakudo folds it — wider blast radius, deferred).
-    Remaining blockers (tests 53-56, both deep regex backtracking):
-    - 53-54: `( 'rule1' || 'rule2' )* %% (.+?)` — `%%` separator-quantifier with
-      captures on both sides + `||` backtracking; the whole match succeeds but the
-      per-iteration captures are wrong.
-    - 55-56: `(a | b | bc | cde)+»` — LTM-alternation `+` must backtrack into
-      *shorter* per-iteration alternatives to satisfy the trailing `»` word
-      boundary (`a,b,cde`); mutsu commits to the longest alternative per iteration
-      and gives up to a later start (`cde`) instead of backtracking. `(a|b|bc|cde)+`
-      *without* `»` already matches correctly (`abc`, 2 caps) — only the
-      backtrack-into-quantified-alternation-on-anchor-failure path is missing.
+    Tests 55-56 (LTM-alternation `+` backtracking) now pass: a greedy `*`/`+` over
+    a variable-length alternation does full greedy backtracking
+    (`quant_expand_greedy`, gated on `atom_contains_alternation`) so a later
+    constraint can force a shorter per-iteration choice — `(a|b|bc|cde)+»` →
+    `a,b,cde` (`t/quantifier-alternation-backtrack.t`).
+    Remaining blocker (tests 53-54, deep regex backtracking):
+    - 53-54: `( 'rule1' || 'rule2' )* %% (.+?)` — the `%%` separator path
+      (`match_separated_quantifier`) builds a single greedy chain and does NOT
+      backtrack the frugal separator `(.+?)` to admit MORE atoms, so it matches
+      only `rule1` + a trailing sep instead of `rule1,rule2` with seps
+      ` foo `/` bar`. Needs separator-path backtracking (analogous to
+      `quant_expand_greedy` but for the separated quantifier).
 - [ ] roast/S05-match/make.t
 - [ ] roast/S05-match/non-capturing.t
 - [ ] roast/S05-match/positions.t

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -397,6 +397,28 @@ pub(super) fn count_capture_groups(atom: &RegexAtom) -> usize {
     }
 }
 
+/// Whether matching `atom` involves an alternation whose branches can have
+/// different lengths — the case where a greedy quantifier (`*`/`+`/`**`) must be
+/// able to backtrack into a *shorter* per-iteration choice to satisfy a later
+/// constraint (e.g. `(a | b | bc | cde)+»`). Used to gate the (more expensive)
+/// full backtracking quantifier expansion so simple atoms keep the fast greedy
+/// chain.
+pub(super) fn atom_contains_alternation(atom: &RegexAtom) -> bool {
+    match atom {
+        RegexAtom::Alternation(alts) | RegexAtom::SequentialAlternation(alts) => {
+            alts.len() > 1 || alts.iter().any(pattern_contains_alternation)
+        }
+        RegexAtom::Group(pat) | RegexAtom::CaptureGroup(pat) => pattern_contains_alternation(pat),
+        _ => false,
+    }
+}
+
+fn pattern_contains_alternation(pat: &RegexPattern) -> bool {
+    pat.tokens
+        .iter()
+        .any(|t| atom_contains_alternation(&t.atom))
+}
+
 /// Count positional capture groups in a pattern (non-recursive into nested groups).
 fn count_pattern_capture_groups(pat: &RegexPattern) -> usize {
     let mut count = 0;

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::regex_helpers::{
-    count_capture_groups, fold_quantified_captures, is_named_atom_no_args, is_silent_named_atom,
-    is_simple_atom, reserve_nil_capture_slots,
+    atom_contains_alternation, count_capture_groups, fold_quantified_captures,
+    is_named_atom_no_args, is_silent_named_atom, is_simple_atom, reserve_nil_capture_slots,
 };
 use std::collections::HashSet;
 
@@ -50,6 +50,77 @@ impl Interpreter {
         }
         Self::collect_named_captures_in_atom(&token.atom, &mut names);
         names
+    }
+
+    /// Greedy backtracking expansion of a `*`/`+` quantified atom. Unlike the
+    /// fast greedy *chain* (which commits to a single highest-priority match per
+    /// iteration), this explores every per-iteration alternative so a later
+    /// constraint can force a shorter choice (`(a|b|bc|cde)+»` → `a,b,cde`).
+    ///
+    /// Results are appended to `out` in HIGHEST-priority-first order: at each
+    /// position the highest-priority atom match is tried first, and within a match
+    /// *more* iterations (deeper) outrank stopping there — matching Rakudo's
+    /// greedy semantics. Only used when the atom contains a variable-length
+    /// alternation (see `atom_contains_alternation`), so simple atoms keep the
+    /// cheap chain. Bounded to avoid catastrophic backtracking.
+    #[allow(clippy::too_many_arguments)]
+    fn quant_expand_greedy<FN, FH>(
+        &self,
+        token: &RegexToken,
+        chars: &[char],
+        pos: usize,
+        caps: &RegexCaptures,
+        pos_base: usize,
+        pkg: &str,
+        ignore_case: bool,
+        apply_named: &FN,
+        apply_hash: &FH,
+        out: &mut Vec<(usize, RegexCaptures)>,
+    ) where
+        FN: Fn(&RegexToken, usize, usize, usize, RegexCaptures) -> RegexCaptures,
+        FH: Fn(&RegexToken, usize, usize, usize, RegexCaptures) -> RegexCaptures,
+    {
+        if out.len() > 20_000 {
+            return;
+        }
+        // All atom matches at `pos`. `_all_` returns LOWEST-priority first; we
+        // want HIGHEST first so reverse.
+        let mut matches = self.regex_match_atom_all_with_capture_in_pkg(
+            &token.atom,
+            chars,
+            pos,
+            caps,
+            pkg,
+            ignore_case,
+        );
+        matches.reverse();
+        for (next, new_caps) in matches {
+            if next == pos {
+                continue; // zero-width: would loop forever
+            }
+            let iter_pos_base = caps.positional.len();
+            let new_caps = apply_hash(
+                token,
+                pos,
+                next,
+                iter_pos_base,
+                apply_named(token, pos, next, pos_base, new_caps),
+            );
+            // Greedy: prefer extending with more iterations before stopping here.
+            self.quant_expand_greedy(
+                token,
+                chars,
+                next,
+                &new_caps,
+                pos_base,
+                pkg,
+                ignore_case,
+                apply_named,
+                apply_hash,
+                out,
+            );
+            out.push((next, new_caps));
+        }
     }
     /// Match a separator quantifier (`atom +% sep`, `atom **N..M %% sep`, ...).
     /// The atom is matched repeatedly with `sep` interleaved between iterations.
@@ -742,33 +813,57 @@ impl Interpreter {
                         caps.named_quantified
                             .extend(Self::collect_quantified_names_for_token(token));
                         let mut positions = Vec::new();
+                        // Zero-match candidate (lowest priority for greedy `*`).
                         positions.push((pos, caps.clone()));
-                        let mut current = pos;
-                        let mut current_caps = caps.clone();
-                        while let Some((next, new_caps)) = self
-                            .regex_match_atom_with_capture_in_pkg(
-                                &token.atom,
+                        if atom_contains_alternation(&token.atom) {
+                            // Full greedy backtracking so a later constraint can
+                            // force a shorter per-iteration alternative.
+                            let mut hi_first = Vec::new();
+                            self.quant_expand_greedy(
+                                token,
                                 chars,
-                                current,
-                                &current_caps,
+                                pos,
+                                &caps,
+                                pos_base,
                                 pkg,
                                 pattern.ignore_case,
-                            )
-                        {
-                            if next == current {
-                                break;
-                            }
-                            let iter_pos_base = current_caps.positional.len();
-                            let new_caps = apply_hash_capture(
-                                token,
-                                current,
-                                next,
-                                iter_pos_base,
-                                apply_named_capture(token, current, next, pos_base, new_caps),
+                                &apply_named_capture,
+                                &apply_hash_capture,
+                                &mut hi_first,
                             );
-                            current_caps = new_caps.clone();
-                            positions.push((next, new_caps));
-                            current = next;
+                            // hi_first is HIGHEST-first; `positions` is LOWEST-first
+                            // (greediest last, pushed to the LIFO stack last → tried
+                            // first), so reverse before appending after the zero entry.
+                            hi_first.reverse();
+                            positions.extend(hi_first);
+                        } else {
+                            let mut current = pos;
+                            let mut current_caps = caps.clone();
+                            while let Some((next, new_caps)) = self
+                                .regex_match_atom_with_capture_in_pkg(
+                                    &token.atom,
+                                    chars,
+                                    current,
+                                    &current_caps,
+                                    pkg,
+                                    pattern.ignore_case,
+                                )
+                            {
+                                if next == current {
+                                    break;
+                                }
+                                let iter_pos_base = current_caps.positional.len();
+                                let new_caps = apply_hash_capture(
+                                    token,
+                                    current,
+                                    next,
+                                    iter_pos_base,
+                                    apply_named_capture(token, current, next, pos_base, new_caps),
+                                );
+                                current_caps = new_caps.clone();
+                                positions.push((next, new_caps));
+                                current = next;
+                            }
                         }
                         if token.ratchet
                             && let Some(last) = positions.last().cloned()
@@ -928,53 +1023,78 @@ impl Interpreter {
                         let mut caps = caps;
                         caps.named_quantified
                             .extend(Self::collect_quantified_names_for_token(token));
-                        let (mut current, mut current_caps) = match self
-                            .regex_match_atom_with_capture_in_pkg(
-                                &token.atom,
+                        let mut positions = Vec::new();
+                        if atom_contains_alternation(&token.atom) {
+                            // Full greedy backtracking (`+` of a variable-length
+                            // alternation): explore every per-iteration choice so a
+                            // later constraint can force a shorter one.
+                            let mut hi_first = Vec::new();
+                            self.quant_expand_greedy(
+                                token,
                                 chars,
                                 pos,
                                 &caps,
+                                pos_base,
                                 pkg,
                                 pattern.ignore_case,
-                            ) {
-                            Some((next, new_caps)) => {
+                                &apply_named_capture,
+                                &apply_hash_capture,
+                                &mut hi_first,
+                            );
+                            if hi_first.is_empty() {
+                                continue; // no match → `+` fails here
+                            }
+                            // HIGHEST-first → LOWEST-first (greediest last for LIFO).
+                            hi_first.reverse();
+                            positions = hi_first;
+                        } else {
+                            let (mut current, mut current_caps) = match self
+                                .regex_match_atom_with_capture_in_pkg(
+                                    &token.atom,
+                                    chars,
+                                    pos,
+                                    &caps,
+                                    pkg,
+                                    pattern.ignore_case,
+                                ) {
+                                Some((next, new_caps)) => {
+                                    let new_caps = apply_hash_capture(
+                                        token,
+                                        pos,
+                                        next,
+                                        pos_base,
+                                        apply_named_capture(token, pos, next, pos_base, new_caps),
+                                    );
+                                    (next, new_caps)
+                                }
+                                None => continue,
+                            };
+                            positions.push((current, current_caps.clone()));
+                            while let Some((next, new_caps)) = self
+                                .regex_match_atom_with_capture_in_pkg(
+                                    &token.atom,
+                                    chars,
+                                    current,
+                                    &current_caps,
+                                    pkg,
+                                    pattern.ignore_case,
+                                )
+                            {
+                                if next == current {
+                                    break;
+                                }
+                                let iter_pos_base = current_caps.positional.len();
                                 let new_caps = apply_hash_capture(
                                     token,
-                                    pos,
+                                    current,
                                     next,
-                                    pos_base,
-                                    apply_named_capture(token, pos, next, pos_base, new_caps),
+                                    iter_pos_base,
+                                    apply_named_capture(token, current, next, pos_base, new_caps),
                                 );
-                                (next, new_caps)
+                                current_caps = new_caps.clone();
+                                positions.push((next, new_caps));
+                                current = next;
                             }
-                            None => continue,
-                        };
-                        let mut positions = Vec::new();
-                        positions.push((current, current_caps.clone()));
-                        while let Some((next, new_caps)) = self
-                            .regex_match_atom_with_capture_in_pkg(
-                                &token.atom,
-                                chars,
-                                current,
-                                &current_caps,
-                                pkg,
-                                pattern.ignore_case,
-                            )
-                        {
-                            if next == current {
-                                break;
-                            }
-                            let iter_pos_base = current_caps.positional.len();
-                            let new_caps = apply_hash_capture(
-                                token,
-                                current,
-                                next,
-                                iter_pos_base,
-                                apply_named_capture(token, current, next, pos_base, new_caps),
-                            );
-                            current_caps = new_caps.clone();
-                            positions.push((next, new_caps));
-                            current = next;
                         }
                         if token.ratchet
                             && let Some(last) = positions.last().cloned()

--- a/t/quantifier-alternation-backtrack.t
+++ b/t/quantifier-alternation-backtrack.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 8;
+
+# A greedy `*`/`+` over a variable-length alternation must be able to backtrack
+# into a *shorter* per-iteration choice to satisfy a later constraint. Verified
+# against Rakudo.
+
+# LTM alternation backtracking to satisfy a trailing word boundary.
+{
+    my $m = "abcde" ~~ / (a | b | bc | cde)+»/;
+    ok $m, 'LTM alternation + » matches';
+    is $m[0].elems, 3, 'three captures (a, b, cde)';
+    is join(" ", $m[0]), 'a b cde', 'correct captures after backtracking';
+}
+
+# Without the anchor, greedy per-step LTM wins (a, bc) — no backtracking.
+{
+    my $m = "abcde" ~~ / (a | b | bc | cde)+/;
+    is join(" ", $m[0]), 'a bc', 'greedy per-step LTM without anchor';
+}
+
+# Anchored alternation `+` must consume the whole string.
+{
+    my $m = "abab" ~~ / (a | b)+ $/;
+    is $m[0].elems, 4, 'anchored (a|b)+ consumes all';
+}
+
+# Backtrack into a shorter alternative to let a following literal match.
+{
+    ok "aXb" ~~ / (a | aX)+ b /, '(a|aX)+ b backtracks aX->a? no: matches';
+    my $m = "aab" ~~ / (a | ab)+ b $/;
+    is join(" ", $m[0]), 'a a', '(a|ab)+ b backtracks last ab->a';
+}
+
+# A plain (non-alternation) quantifier is unaffected.
+{
+    "aaab" ~~ / (a)+ b $/;
+    is $/[0].elems, 3, 'plain (a)+ still greedy';
+}


### PR DESCRIPTION
## Summary
A greedy `*`/`+` over a variable-length alternation now backtracks into a **shorter** per-iteration choice when a later constraint requires it:

```raku
"abcde" ~~ / (a | b | bc | cde)+» /;
# was: $0 = "cde"        (1 capture) — gave up to a later start
# now: $0 = [a, b, cde]  (3 captures) — backtracked a,bc -> a,b,cde to satisfy »
```

The fast quantifier path commits to a single highest-priority (LTM-longest) atom match per iteration and only exposes that greedy chain for backtracking, so it never tries a shorter alternative at an intermediate iteration.

## Fix
Add `quant_expand_greedy`: a recursive expansion that explores every per-iteration atom match, emitting states in greedy priority order (longest alternative first, more iterations before stopping). Gated on `atom_contains_alternation` so simple atoms (`.`, char classes, literals) keep the cheap chain; bounded to avoid catastrophic backtracking. Wired into both the `ZeroOrMore` and `OneOrMore` general paths.

`(a|b|bc|cde)+` without the anchor still matches greedily per-step (`a,bc`); only the anchor-forced backtracking path changes.

## Tests
- New `t/quantifier-alternation-backtrack.t` (8 cases, verified against Rakudo).
- `S05-match/capturing-contexts.t`: 60/64 → 62/64 (tests 55-56 pass). Last remaining 53-54 = `%%` separator-path backtracking (documented in `TODO_roast/S05.md`).
- `make test` passes; no regressions across `S05-mass/*`, `S05-grammar/*`, `S05-capture/*`, `S05-metasyntax/*`, `S05-interpolation/*` (S05-mass/rx.t fails identically on main — pre-existing `<commit>` NYI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)