### PR TITLE
fix(io): IO::Path.gist shows SPEC-normalized absolute path (Win32 backslashes)

### DIFF
--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -171,9 +171,24 @@ impl Interpreter {
         match method {
             "Str" => Ok(Value::str(p.clone())),
             "gist" => {
-                // IO::Path.gist returns "path".IO with the path quoted
-                // Only escape double quotes, not backslashes
-                Ok(Value::str(format!("\"{}\".IO", p.replace('"', "\\\""))))
+                // IO::Path.gist returns `"<str>".IO`, where <str> is the
+                // absolute path (SPEC-normalized separators) when the path is
+                // absolute, else the path string verbatim. So an absolute Win32
+                // path gists with backslashes: `IO::Path::Win32.new('/foo')` →
+                // `"\foo".IO` (Cygwin normalizes to forward slashes).
+                let shown = if Self::io_path_is_absolute_spec(attributes, &p, original) {
+                    if Self::is_win32_spec(attributes) {
+                        Self::canonpath_win32(&p, false)
+                    } else if Self::is_cygwin_spec(attributes) {
+                        Self::canonpath_cygwin(&p.replace('\\', "/"), false)
+                    } else {
+                        p.clone()
+                    }
+                } else {
+                    p.clone()
+                };
+                // Only escape double quotes, not backslashes.
+                Ok(Value::str(format!("\"{}\".IO", shown.replace('"', "\\\""))))
             }
             "raku" | "perl" => {
                 let escape = |s: &str| {
@@ -589,26 +604,12 @@ impl Interpreter {
                 let (volume, _, _) = Self::io_path_parts_spec(&p, attributes);
                 Ok(Value::str(volume))
             }
-            "is-absolute" => {
-                let abs = if Self::is_win32_spec(attributes) {
-                    Self::io_path_is_absolute_win32(&p)
-                } else if Self::is_cygwin_spec(attributes) {
-                    Self::io_path_is_absolute_win32(&p.replace('\\', "/"))
-                } else {
-                    original.is_absolute()
-                };
-                Ok(Value::Bool(abs))
-            }
-            "is-relative" => {
-                let abs = if Self::is_win32_spec(attributes) {
-                    Self::io_path_is_absolute_win32(&p)
-                } else if Self::is_cygwin_spec(attributes) {
-                    Self::io_path_is_absolute_win32(&p.replace('\\', "/"))
-                } else {
-                    original.is_absolute()
-                };
-                Ok(Value::Bool(!abs))
-            }
+            "is-absolute" => Ok(Value::Bool(Self::io_path_is_absolute_spec(
+                attributes, &p, original,
+            ))),
+            "is-relative" => Ok(Value::Bool(!Self::io_path_is_absolute_spec(
+                attributes, &p, original,
+            ))),
             "succ" => {
                 let (volume, dirname, basename) = Self::io_path_parts(&p);
                 let new_basename = crate::builtins::str_increment::string_succ(&basename);
@@ -1335,6 +1336,23 @@ impl Interpreter {
                 name == "IO::Spec::Cygwin" || name.ends_with("Cygwin")
             })
             .unwrap_or(false)
+    }
+
+    /// Whether `p` is absolute under the receiver's SPEC. Win32/Cygwin use
+    /// drive-letter / UNC / leading-separator rules; other SPECs defer to the
+    /// platform's `Path::is_absolute`.
+    fn io_path_is_absolute_spec(
+        attributes: &HashMap<String, Value>,
+        p: &str,
+        original: &Path,
+    ) -> bool {
+        if Self::is_win32_spec(attributes) {
+            Self::io_path_is_absolute_win32(p)
+        } else if Self::is_cygwin_spec(attributes) {
+            Self::io_path_is_absolute_win32(&p.replace('\\', "/"))
+        } else {
+            original.is_absolute()
+        }
     }
 
     /// Split a path into (volume, dirname, basename), honoring the Cygwin SPEC

--- a/t/io-path-gist-spec.t
+++ b/t/io-path-gist-spec.t
@@ -1,0 +1,20 @@
+use Test;
+
+# IO::Path.gist shows the absolute path (with the SPEC's separators) when the
+# path is absolute, else the path string verbatim. So an absolute Win32 path
+# gists with backslashes; Cygwin normalizes to forward slashes.
+
+plan 10;
+
+is IO::Path::Unix.new('foo').gist,       '"foo".IO',       'Unix relative';
+is IO::Path::Unix.new('/foo').gist,      '"/foo".IO',      'Unix absolute';
+is IO::Path::Win32.new('foo').gist,      '"foo".IO',       'Win32 relative';
+is IO::Path::Win32.new('/foo').gist,     '"\foo".IO',      'Win32 absolute uses backslash';
+is IO::Path::Win32.new(｢\foo\bar｣).gist, '"\foo\bar".IO',  'Win32 backslash absolute';
+is IO::Path::Win32.new('bar/ber').gist,  '"bar/ber".IO',   'Win32 relative keeps slashes';
+is IO::Path::Cygwin.new('/foo').gist,    '"/foo".IO',      'Cygwin absolute forward slash';
+is IO::Path::QNX.new('/foo').gist,       '"/foo".IO',      'QNX absolute';
+
+# .gist is unaffected by directory changes (uses the stored path, not CWD).
+is IO::Path::Unix.new('rel/path').gist,  '"rel/path".IO',  'relative gist verbatim';
+is '/abs/path'.IO.gist,                  '"/abs/path".IO', '.IO absolute gist';


### PR DESCRIPTION
## Summary

`IO::Path::Win32.new('/foo').gist` returned `"/foo".IO` but Rakudo gives `"\foo".IO`. `IO::Path.gist` shows the **absolute** path with the SPEC's separators when the path is absolute, else the path string verbatim — so an absolute Win32 path gists with backslashes (Cygwin normalizes to forward slashes; Unix/QNX keep forward slashes).

## Fix

The gist arm now mirrors `.absolute`: when the path is absolute under its SPEC it emits `canonpath_win32` / `canonpath_cygwin` / the path; otherwise the raw path. Extracted the SPEC-aware absoluteness check into `io_path_is_absolute_spec` and routed `is-absolute`/`is-relative` through it too.

## Result

- Fixes `roast/S32-io/io-path.t` `.gist` subtest (test 31).
- `t/io-path-gist-spec.t` pins per-SPEC gist (Unix/Win32/Cygwin/QNX, relative vs absolute).
- No regressions in io-path t/ tests or whitelisted IO tests.

Independent of #3287 (subclass preservation); both touch `native_io.rs` but in different arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)