### PR TITLE
feat(container): share array/hash into a method's readonly scalar $ param (Slice 2d method follow-up)

### DIFF
--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -12,6 +12,13 @@ impl Interpreter {
         self.pending_call_arg_sources.take()
     }
 
+    /// Non-consuming peek at the pending call arg-source names, used by the
+    /// method dispatch gate to decide whether a container argument shares the
+    /// caller's container with a plain scalar `$` param (Slice 2d).
+    pub(crate) fn pending_call_arg_sources(&self) -> Option<&Vec<Option<String>>> {
+        self.pending_call_arg_sources.as_ref()
+    }
+
     pub(crate) fn exec_call_values(
         &mut self,
         name: &str,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -843,7 +843,7 @@ impl Interpreter {
     /// and a non-variable literal (`f([1,2])`) has no caller to share with — both
     /// must keep the fast path. A variable arg reaches the binder as a
     /// `__mutsu_varref_*` capture, so peek inside without cloning.
-    fn arg_is_container_value(arg: &Value) -> bool {
+    pub(super) fn arg_is_container_value(arg: &Value) -> bool {
         let Value::Capture { positional, named } = arg else {
             return false;
         };
@@ -856,6 +856,60 @@ impl Interpreter {
                 named.get("__mutsu_varref_value"),
                 Some(Value::Array(..)) | Some(Value::Hash(..))
             )
+    }
+
+    /// Method analogue of `call_shares_container_into_scalar_param`: true when
+    /// an array/hash *variable* argument is passed into a plain readonly scalar
+    /// `$` param of a method. Raku binds the same mutable container, so such a
+    /// call must take the slow `bind_function_args_values` path (which promotes
+    /// the param to a shared cell and writes it back) instead of the slot-only
+    /// fast path that detaches a copy. The alignment differs from the sub case:
+    /// a method's `param_defs` include the invocant, but `args` do not — so we
+    /// skip invocant (and named) params and align positional params to `args`
+    /// by an independent counter.
+    pub(super) fn method_shares_container_into_scalar_param(
+        &self,
+        method_def: &crate::runtime::MethodDef,
+        args: &[Value],
+    ) -> bool {
+        // Unlike the sub path, method-call arguments are NOT wrapped in varref
+        // captures — the source variable name lives in the separate
+        // `arg_sources` table (`set_pending_call_arg_sources`). So a plain
+        // `Array`/`Hash` value paired with an `@`/`%` source name in that table
+        // is the method-call equivalent of the sub path's varref container arg.
+        let arg_sources = self.pending_call_arg_sources();
+        let mut arg_idx = 0usize;
+        for pd in &method_def.param_defs {
+            if pd.is_invocant || pd.traits.iter().any(|t| t == "invocant") || pd.named {
+                continue;
+            }
+            let Some(arg) = args.get(arg_idx) else {
+                break;
+            };
+            let src = arg_sources
+                .and_then(|s| s.get(arg_idx))
+                .and_then(|n| n.as_ref());
+            arg_idx += 1;
+            let eligible_scalar_param = Self::is_plain_scalar_param_name(&pd.name)
+                && !pd.slurpy
+                && !pd.double_slurpy
+                && !pd.sigilless
+                && pd.traits.is_empty()
+                && pd.sub_signature.is_none();
+            if !eligible_scalar_param {
+                continue;
+            }
+            // A varref capture carries its own `@`/`%` source name; a plain
+            // container value needs the source name from `arg_sources`. Either
+            // way the binder promotes the bound value to a shared cell.
+            let varref_container = Self::arg_is_container_value(arg);
+            let plain_container_with_source = matches!(arg, Value::Array(..) | Value::Hash(..))
+                && src.is_some_and(|n| n.starts_with('@') || n.starts_with('%'));
+            if varref_container || plain_container_with_source {
+                return true;
+            }
+        }
+        false
     }
 
     /// A plain readonly scalar (`$`) parameter is stored sigil-less in

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -322,7 +322,14 @@ impl Interpreter {
                         .any(|k| k.starts_with(super::vm_method_dispatch::ATTR_ALIAS_META_PREFIX)),
                     _ => false,
                 };
-                if !needs_default_eval && !has_attr_aliases {
+                // Slice 2d (method follow-up): a container variable passed into a
+                // plain scalar `$` param must share the caller's container, which
+                // only the slow `bind_function_args_values` path realizes. Skip
+                // the cached fast path so it falls through to the full resolve
+                // (which dispatches with `None` -> `call_compiled_method`).
+                let shares_scalar_container =
+                    self.method_shares_container_into_scalar_param(&entry.method_def, &args);
+                if !needs_default_eval && !has_attr_aliases && !shares_scalar_container {
                     let owner_class = entry.owner_class.resolve();
                     let method_def = entry.method_def.clone();
                     let cc = entry.compiled_code.clone();

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -70,13 +70,23 @@ impl Interpreter {
                 && (pd.name.starts_with('@') || pd.name.starts_with('%'))
                 && !pd.name[1..].starts_with(['!', '.'])
         });
-        let can_skip_merge =
-            !has_rw_params && !has_aliasable_container_params && !cc.has_env_writes;
+        // Slice 2d (method follow-up): an array/hash variable passed into a
+        // plain readonly scalar `$` param shares the caller's container in Raku
+        // (`method m($n) { $n.push }` mutates the caller's `@z`). The promotion
+        // + rw-writeback lives only on the slow `bind_function_args_values`
+        // path, so such a call must avoid the fast path and the merge skip —
+        // mirroring how `has_aliasable_container_params` handles `@`/`%` params.
+        let shares_scalar_container =
+            self.method_shares_container_into_scalar_param(method_def, &args);
+        let can_skip_merge = !has_rw_params
+            && !has_aliasable_container_params
+            && !shares_scalar_container
+            && !cc.has_env_writes;
 
         // Fast path: bypass env entirely and populate locals directly from
         // source data. Avoids the ~12μs Arc::make_mut deep clone that the
         // first env_mut() call triggers.
-        if !has_rw_params && !has_aliasable_container_params {
+        if !has_rw_params && !has_aliasable_container_params && !shares_scalar_container {
             let has_invocant_constraint = method_def.param_defs.iter().any(|pd| {
                 (pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
                     && pd.type_constraint.is_some()

--- a/t/scalar-param-container-share-method.t
+++ b/t/scalar-param-container-share-method.t
@@ -1,0 +1,104 @@
+use Test;
+
+# Slice 2d (method follow-up): passing an array/hash *variable* to a readonly
+# scalar `$` param of a *method* binds the same mutable container, just like the
+# sub case (`t/scalar-param-container-share.t`). `$n.push`, `$n[0]=`, and
+# `my @a := @$n` all mutate the caller's container; only `$n = …` rebinding is
+# forbidden. Method dispatch has its own fast paths and a static method cache,
+# so the share gate had to be wired into both the cache lookup and the full
+# dispatch path. Method args are not varref-wrapped — the source variable name
+# comes from the separate `arg_sources` table.
+#
+# NOTE: each case uses a distinct class name; a method dispatch cache keys on
+# (class, method), so reusing one name would serve a stale body across cases.
+
+plan 18;
+
+# --- canonical deref-bind ---
+class M1 { method m($n) { my @a := @$n; @a.push(99) } }
+my @z1 = (1, 2);
+M1.new.m(@z1);
+is @z1.gist, '[1 2 99]', 'deref-bind push propagates to caller';
+is @z1.elems, 3, 'deref-bind push changes elems';
+
+# --- direct push, robust regardless of statement order ---
+class M2 { method m($n) { my $x = $n.elems; $n.push(99); $x } }
+my @z2 = (10, 20);
+M2.new.m(@z2);
+is @z2.gist, '[10 20 99]', '$n.push propagates even after a read';
+
+# --- a read between bind and push must not break propagation ---
+class M3 { method m($n) { $n.elems.sink; $n.push(5) } }
+my @z3 = (1,);
+M3.new.m(@z3);
+is @z3.gist, '[1 5]', 'push robust to intervening statement';
+
+# --- element assignment ---
+class M4 { method m($n) { $n[0] = 100 } }
+my @z4 = (1, 2);
+M4.new.m(@z4);
+is @z4.gist, '[100 2]', '$n[0]= propagates to caller';
+
+# --- hash param ---
+class M5 { method m($h) { $h<x> = 9 } }
+my %g5 = (a => 1);
+M5.new.m(%g5);
+is %g5<x>, 9, 'hash $h<k>= propagates to caller';
+is %g5<a>, 1, 'untouched hash key preserved';
+
+# --- hash deref-bind ---
+class M6 { method m($h) { my %m := %$h; %m<y> = 2 } }
+my %g6 = (a => 1);
+M6.new.m(%g6);
+is %g6<y>, 2, 'hash deref-bind propagates to caller';
+
+# --- other mutators (append/unshift) propagate too ---
+class M7 { method m($n) { $n.append(7, 8); $n.unshift(0) } }
+my @z7 = (1, 2);
+M7.new.m(@z7);
+is @z7.gist, '[0 1 2 7 8]', 'append/unshift mutators propagate to caller';
+
+# --- rebinding the scalar param itself is forbidden (readonly) ---
+class M8 { method m($n) { $n = 5 } }
+my @z8 = (1, 2);
+dies-ok { M8.new.m(@z8) }, '$n = 5 rebinding the param dies';
+is @z8.gist, '[1 2]', 'caller container unchanged after failed rebind';
+
+# --- a literal (non-variable) container arg has no caller to share with ---
+class M9 { method m($n) { $n.push(3); $n.elems } }
+is M9.new.m([1, 2]), 3, 'literal array arg works (no leak/crash)';
+
+# --- multiple params, container in second position ---
+class M10 { method m($x, $n) { $n.push($x) } }
+my @z10 = (1, 2);
+M10.new.m(99, @z10);
+is @z10.gist, '[1 2 99]', 'container second positional shares correctly';
+
+# --- the param's type is still Array (no ContainerRef leak to reads) ---
+class M11 { method m($n) { $n.WHAT.^name } }
+my @z11 = (1, 2);
+is M11.new.m(@z11), 'Array', '$n.WHAT is Array (no ContainerRef leak)';
+
+# --- repeated calls (exercises the static method cache fast path) ---
+class M12 { method m($n) { $n.push(1) } }
+my @z12 = (0,);
+M12.new.m(@z12);
+M12.new.m(@z12);
+M12.new.m(@z12);
+is @z12.gist, '[0 1 1 1]', 'cached repeated calls all propagate';
+
+# --- typed scalar param (Array $n) still shares ---
+class M13 { method m(Array $n) { $n.push(9) } }
+my @z13 = (1, 2);
+M13.new.m(@z13);
+is @z13.gist, '[1 2 9]', 'typed Array $n param shares';
+
+# --- a plain scalar-source arg ($s holding an array) still mutates by reference ---
+class M14 { method m($n) { $n[1] = 50 } }
+my $s14 = [1, 2];
+M14.new.m($s14);
+is $s14.gist, '[1 50]', 'scalar-source element assign still works by reference';
+
+# --- non-container args are unaffected (fast path preserved) ---
+class M15 { method add($a, $b) { $a + $b } }
+is M15.new.add(2, 3), 5, 'plain numeric method args still work';


### PR DESCRIPTION
## Summary

Brings **method** dispatch to parity with the sub path (#3283): passing an `@`/`%` *variable* into a plain readonly scalar `$` param of a method now binds the same mutable container.

```raku
class C { method m($n) { $n.push(99) } }
my @z = 1, 2;
C.new.m(@z);
say @z;   # before: [1 2]   now: [1 2 99]  (matches raku)
```

`$n.push`, `$n[0]=`, `my @a := @$n`, and other in-place mutators all propagate to the caller; only `$n = …` rebinding is forbidden (dies, as in raku).

## How

Method dispatch has its own slot-only fast paths and a static `fast_method_cache`, both of which detached a copy into the param slot. A new args-aware gate `method_shares_container_into_scalar_param` routes such calls to the slow `bind_function_args_values` path, which already promotes the bound value to a shared `ContainerRef` cell and registers the exit-time rw writeback (the same machinery subs use). The gate is wired into both the cache lookup and the full dispatch path.

Two method-specific subtleties vs the sub gate:
- a method's `param_defs` include the invocant, but `args` do not → positional alignment uses an independent counter that skips invocant and named params;
- method-call arguments are NOT varref-wrapped — the source variable name lives in the separate `arg_sources` table, so a plain `Array`/`Hash` value paired with an `@`/`%` source name there is the method-call equivalent of the sub path's varref container arg.

## Tests

- Pin: `t/scalar-param-container-share-method.t` (18) — deref-bind, order-robust push, element/hash assign, hash deref-bind, append/unshift, readonly rebind dies, literal arg, second-position container, `.WHAT` no-leak, cached repeated calls, typed `Array $n`, scalar-source element assign, plain numeric args.
- `make test` 9142 passing; targeted S06-signature / S12-methods roast PASS (the one local S12 fail, `qualified.t`, is a pre-existing non-whitelisted parametric-role failure, unrelated).

## Known follow-ups (pre-existing, not regressions)

`is copy` $-param sharing, named `:$n` param sharing, forwarding a shared `$n` onward to another method, and `$`-scalar-source content propagation — left for a later slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)