### PR TITLE
fix(junction): don't auto-thread a Junction captured by a slurpy hash (*%h)

### DIFF
--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -121,7 +121,10 @@ impl Interpreter {
             .filter(|&idx| {
                 // Check if the arg is a named arg (Pair) — find matching named param
                 if let Value::Pair(key, _) = &args[idx] {
-                    if let Some(pd) = pds.iter().find(|pd| pd.named && pd.name == *key) {
+                    if let Some(pd) = pds
+                        .iter()
+                        .find(|pd| pd.named && !pd.slurpy && !pd.double_slurpy && pd.name == *key)
+                    {
                         if let Some(tc) = &pd.type_constraint {
                             if matches!(tc.as_str(), "Mu" | "Junction") {
                                 return false;
@@ -131,7 +134,17 @@ impl Interpreter {
                         }
                         return true; // No type constraint = default Any
                     }
-                    return true; // No matching named param found, auto-thread
+                    // No explicit named param matched. A slurpy hash (`*%h`, the
+                    // implicit `%_`, `+%h`) captures the named argument as a raw
+                    // value, so a Junction is stored as-is rather than threaded.
+                    // A slurpy hash is a slurpy param whose sigil is `%` (a
+                    // slurpy `*@a` only collects positionals, not named args).
+                    if pds.iter().any(|pd| {
+                        (pd.slurpy || pd.double_slurpy || pd.onearg) && pd.name.starts_with('%')
+                    }) {
+                        return false;
+                    }
+                    return true; // No slurpy hash to collect it — auto-thread
                 }
 
                 // Positional arg — find corresponding positional param

--- a/t/junction-slurpy-no-autothread.t
+++ b/t/junction-slurpy-no-autothread.t
@@ -1,0 +1,31 @@
+use Test;
+
+# A Junction passed as a named argument that is collected by a slurpy hash
+# (`*%h`, `+%h`, the implicit `%_`) must NOT auto-thread the call: the slurpy
+# captures it as a raw value. Only a Junction bound to an ordinary (Any-typed)
+# parameter auto-threads. Regression: mutsu used to auto-thread named junction
+# args with no explicit matching named param, even when a `*%h` would catch them
+# — so `check-parts($p, $d, :basename(｢\｣|｢/｣), ...)` ran 2×N times.
+
+plan 4;
+
+sub slurpy-hash($x, *%h) { %h }
+is-deeply slurpy-hash('a', :k(1|2))<k>, (1|2),
+    'junction into *%h is captured raw (no autothread)';
+
+my @calls;
+sub count-slurpy($x, *%h) { @calls.push: %h<k>; 'r' }
+count-slurpy('a', :k(1|2));
+is @calls.elems, 1, '*%h call runs once, not once-per-eigenstate';
+
+## A junction bound to an ordinary Any parameter still auto-threads.
+my @pos;
+sub pos-any($x, $y) { @pos.push: $y; 'r' }
+pos-any('a', 1|2);
+is @pos.elems, 2, 'positional junction into $y still auto-threads';
+
+# A junction named arg matching an explicit Any-typed named param auto-threads.
+my @named;
+sub named-any($x, :$y) { @named.push: $y; 'r' }
+named-any('a', :y(1|2));
+is @named.elems, 2, 'explicit Any named param still auto-threads';


### PR DESCRIPTION
## Summary

A `Junction` passed as a **named** argument with no matching explicit named parameter was always auto-threaded — even when a slurpy hash (`*%h`, the implicit `%_`) would collect it. So a call like `check-parts($p, $desc, :basename(｢\｣|｢/｣), :dirname(...))` auto-threaded over the junction named args and ran the whole sub **2×N times** (once per eigenstate combination) instead of capturing the junctions as raw values in `%h`.

Rakudo only auto-threads a Junction bound to an *ordinary* parameter; a slurpy hash stores it verbatim (`*%h` → `%h<k> === any(1,2)`).

## Fix

The named-arg branch of `maybe_autothread_func_call` now returns `false` (no auto-thread) when no explicit named param matches **and** the signature has a slurpy hash param — identified by a slurpy param whose sigil is `%` (a slurpy `*@a` only collects positionals, not named args).

## Result

- Fixes `roast/S32-io/io-path.t` `.parts` subtest (test 33) — its test helper passes junction-valued `*%parts`. io-path.t goes **5→4** failures (this is the underlying root cause, not a Win32-path bug: mutsu's `.parts` values were already correct).
- `t/junction-slurpy-no-autothread.t` pins `*%h` raw capture + that ordinary positional/named Any params still auto-thread.
- `make test` passes; all whitelisted junction tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)