### PR TITLE
fix(io): IO::Spec::Win32.join separates a bare volume from the directory

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1492,6 +1492,7 @@ impl Interpreter {
                             .unwrap_or_default();
                         let dir = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
                         let file = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                        let dir_nonempty = !dir.is_empty();
                         if is_win32 {
                             let path_part = if file.is_empty() {
                                 if dir.is_empty() { String::new() } else { dir }
@@ -1518,7 +1519,23 @@ impl Interpreter {
                                         format!("{}{}", vol, path_part)
                                     }
                                 } else {
-                                    format!("{}{}", vol, path_part)
+                                    // Insert a separator between a bare volume and
+                                    // the directory when the directory is non-empty
+                                    // and neither side already carries a boundary
+                                    // separator. A drive volume (`C:`) joins
+                                    // directly (`C:` + `bar` => `C:bar`), but a bare
+                                    // volume gets a separator (`foo` + `bar` =>
+                                    // `foo\bar`).
+                                    let vol_has_boundary = vol.ends_with(':')
+                                        || vol.ends_with('/')
+                                        || vol.ends_with('\\');
+                                    let path_has_boundary =
+                                        path_part.starts_with('/') || path_part.starts_with('\\');
+                                    if dir_nonempty && !vol_has_boundary && !path_has_boundary {
+                                        format!("{}\\{}", vol, path_part)
+                                    } else {
+                                        format!("{}{}", vol, path_part)
+                                    }
                                 }
                             } else {
                                 path_part

--- a/t/io-spec-win32-join.t
+++ b/t/io-spec-win32-join.t
@@ -1,0 +1,19 @@
+use Test;
+
+# IO::Spec::Win32.join($volume, $dir, $file) inserts a `\` between a *bare*
+# volume and a non-empty directory, but joins a drive volume (`C:`) directly.
+# Regression: mutsu concatenated volume + dir without a separator, so
+# join('foo','bar','ber') gave "foobar\ber" instead of "foo\bar\ber".
+
+plan 10;
+
+is IO::Spec::Win32.join('foo', 'bar', 'ber'),  'foo\bar\ber', 'bare volume gets a separator';
+is IO::Spec::Win32.join('foo', 'bar', ''),     'foo\bar',     'bare volume + dir, no file';
+is IO::Spec::Win32.join('foo', '', 'ber'),     'foober',      'empty dir: volume + file directly';
+is IO::Spec::Win32.join('foo', '/bar', 'ber'), 'foo/bar\ber', 'dir with leading sep: no extra';
+is IO::Spec::Win32.join('foo', '\bar', 'ber'), 'foo\bar\ber', 'dir with leading backslash';
+is IO::Spec::Win32.join('C:', 'bar', 'ber'),   'C:bar\ber',   'drive volume joins directly';
+is IO::Spec::Win32.join('C:', '/', 'foo'),     'C:/foo',      'drive + root + file';
+is IO::Spec::Win32.join('C:', '\foo', 'bar'),  'C:\foo\bar',  'drive + backslash dir';
+is IO::Spec::Win32.join('', '/foo', 'bar'),    '/foo\bar',    'empty volume';
+is IO::Spec::Win32.join('foo', '', ''),        'foo',         'volume only';


### PR DESCRIPTION
## Summary

`IO::Spec::Win32.join('foo', 'bar', 'ber')` returned `"foobar\ber"` instead of `"foo\bar\ber"` — it concatenated the volume and directory with no separator. A drive volume (`C:`) joins directly (`C:` + `bar` => `C:bar`), but a bare volume needs a separator before a non-empty directory (`foo` + `bar` => `foo\bar`).

## Fix

The Win32 `join` now inserts a `\` between the volume and the joined dir/file when the directory is non-empty and neither the volume (no trailing `:`/`/`/`\`) nor the path part (no leading `/`/`\`) already carries a boundary separator.

## Result

- Fixes `roast/S32-io/io-path.t` `.path` subtest (test 36), which compares a `.new(:volume :dirname :basename)` path against `IO::Spec::Win32.join`.
- `t/io-spec-win32-join.t` pins all the volume/dir boundary cases against Rakudo.
- No regressions in IO::Spec / io-path t/ tests.

Independent of #3290 (junction autothreading, test 33). With both, io-path.t is down to tests 34-35 (custom IO::Spec, `:CWD`/RO accessors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)