### PR TITLE
feat(container): share array/hash into a readonly scalar named $ param (Slice 2d named follow-up)

### DIFF
--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -27,6 +27,27 @@ fn legacy_has_plain_positional_param(params: &[String]) -> bool {
 }
 
 impl Interpreter {
+    /// Whether a named parameter is a plain readonly scalar `$` param eligible
+    /// for container sharing (Slice 2d named follow-up). A scalar named param is
+    /// stored sigil-less in `ParamDef::name` (`:$n` -> "n"), unlike `:@l`/`:%h`
+    /// which keep their sigil; exclude attribute twigils (`:$!x` -> "!x"), `$_`,
+    /// `is copy`/`is rw`/`is raw`, slurpy, and sub-signature params.
+    fn named_scalar_container_share_eligible(&self, pd: &crate::ast::ParamDef) -> bool {
+        !pd.traits
+            .iter()
+            .any(|t| t == "copy" || t == "rw" || t == "raw")
+            && !pd.slurpy
+            && !pd.double_slurpy
+            && pd.sub_signature.is_none()
+            && pd.name != "_"
+            && !pd.name.starts_with(['@', '%', '&', '!', '.'])
+            && pd
+                .name
+                .as_bytes()
+                .first()
+                .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+    }
+
     fn parameter_binding_error(message: String) -> RuntimeError {
         let mut err = RuntimeError::new(message);
         let mut ex_attrs = std::collections::HashMap::new();
@@ -631,8 +652,8 @@ impl Interpreter {
                 let mut found = false;
                 // Iterate in reverse so that the rightmost named argument wins
                 // when the same key is provided multiple times.
-                for arg in args.iter().rev() {
-                    let arg = unwrap_varref_value(arg.clone());
+                for (arg_idx, raw_arg) in args.iter().enumerate().rev() {
+                    let arg = unwrap_varref_value(raw_arg.clone());
                     if let Value::Pair(key, val) = arg
                         && key == match_key
                     {
@@ -653,7 +674,35 @@ impl Interpreter {
                             err.exception = Some(Box::new(exception));
                             return Err(err);
                         }
-                        self.bind_param_value(&pd.name, *val.clone());
+                        // Slice 2d (named follow-up): an `@`/`%` *variable* passed by
+                        // name to a plain readonly scalar `$` named param binds the
+                        // same mutable container in Raku (`sub f(:$n){ $n.push }`
+                        // mutates the caller's `@a`), exactly like the positional
+                        // case. The source variable name is encoded "key=source" in
+                        // `arg_sources` (`positional_arg_source_name`). Promote the
+                        // bound value to a shared `ContainerRef` cell and register the
+                        // exit-time rw writeback. Only `=` rebinding stays forbidden
+                        // (named scalar params are readonly). A `$`-scalar source
+                        // (`:$n` shorthand over `my $n = @a`) is excluded — it shares
+                        // by reference already, like the positional scalar source.
+                        let mut bound_value = *val.clone();
+                        if self.named_scalar_container_share_eligible(pd)
+                            && matches!(bound_value, Value::Array(..) | Value::Hash(..))
+                            && let Some(source_name) = arg_sources
+                                .as_ref()
+                                .and_then(|names| names.get(arg_idx))
+                                .and_then(|n| n.as_ref())
+                                .and_then(|encoded| {
+                                    encoded.split_once('=').map(|(_, s)| s.to_string())
+                                })
+                                .filter(|s| s.starts_with('@') || s.starts_with('%'))
+                        {
+                            bound_value = Value::ContainerRef(std::sync::Arc::new(
+                                std::sync::Mutex::new(bound_value),
+                            ));
+                            rw_bindings.push((pd.name.clone(), source_name));
+                        }
+                        self.bind_param_value(&pd.name, bound_value);
                         self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
                         if let Some(sub_params) = &pd.sub_signature {
                             bind_named_rename_sub_signature(self, sub_params, &val)?;

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -925,6 +925,73 @@ impl Interpreter {
                 .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
     }
 
+    /// True when an `@`/`%` *variable* is passed by name to a plain readonly
+    /// scalar `$` *named* param (`sub f(:$n) { $n.push }` called as
+    /// `f(n => @a)`). Raku binds the same mutable container; the slot-only
+    /// named light-call path binds a copy whose `.push` COW-detaches, so such a
+    /// call must take the slow `bind_function_args_values` path (which promotes
+    /// the bound value to a shared cell and registers the rw writeback — see the
+    /// named branch in binding.rs). The source variable name is encoded
+    /// "key=source" in `arg_sources` (`positional_arg_source_name`); a
+    /// `$`-scalar source (`:$n` over `my $n = @a`) is excluded (it shares by
+    /// reference already, like the positional scalar source).
+    pub(super) fn call_shares_container_into_named_scalar_param(
+        cf: &CompiledFunction,
+        args: &[Value],
+        arg_sources: Option<&[Option<String>]>,
+    ) -> bool {
+        let Some(sources) = arg_sources else {
+            return false;
+        };
+        args.iter().enumerate().any(|(i, arg)| {
+            let unwrapped = unwrap_varref_value(arg.clone());
+            let Value::Pair(key, val) = &unwrapped else {
+                return false;
+            };
+            if !matches!(**val, Value::Array(..) | Value::Hash(..)) {
+                return false;
+            }
+            let has_container_source = sources
+                .get(i)
+                .and_then(|s| s.as_ref())
+                .and_then(|enc| enc.split_once('='))
+                .is_some_and(|(_, src)| src.starts_with('@') || src.starts_with('%'));
+            if !has_container_source {
+                return false;
+            }
+            cf.param_defs.iter().any(|pd| {
+                pd.named
+                    && Self::named_param_share_match_key(pd) == key.as_str()
+                    && Self::is_eligible_named_scalar_share_param(pd)
+            })
+        })
+    }
+
+    /// The Pair key a named param matches (`:$n` -> "n", `:foo($x)` -> "foo").
+    /// Scalar named params are stored sigil-less, so this strips a leading `:`.
+    fn named_param_share_match_key(pd: &crate::ast::ParamDef) -> &str {
+        pd.name.strip_prefix(':').unwrap_or(&pd.name)
+    }
+
+    /// Eligibility mirror of binding.rs `named_scalar_container_share_eligible`:
+    /// a plain readonly scalar named param (not `@`/`%`/`&`, no attr twigil, not
+    /// `$_`, no `is copy`/`is rw`/`is raw`, not slurpy, no sub-signature).
+    fn is_eligible_named_scalar_share_param(pd: &crate::ast::ParamDef) -> bool {
+        let bare = Self::named_param_share_match_key(pd);
+        !pd.traits
+            .iter()
+            .any(|t| t == "copy" || t == "rw" || t == "raw")
+            && !pd.slurpy
+            && !pd.double_slurpy
+            && pd.sub_signature.is_none()
+            && bare != "_"
+            && !bare.starts_with(['@', '%', '&', '!', '.'])
+            && bare
+                .as_bytes()
+                .first()
+                .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+    }
+
     /// Ultra-fast call for simple positional-only functions (e.g. `sub fib($n)`).
     /// Avoids push_call_frame, Sub value creation, block/routine push,
     /// callable_id lookup, and full bind_function_args_values. Parameters are

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -188,7 +188,21 @@ impl Interpreter {
                     && cf.fingerprint == *cached_fp
                 {
                     let arity_usize = arity as usize;
+                    // Slice 2d (named follow-up): an `@`/`%` variable passed by
+                    // name to a plain `$` named param must share the caller's
+                    // container; the named light path binds a copy. Decode the
+                    // arg sources lazily (only on a named-cache hit) so the
+                    // common path pays nothing.
+                    let named_share = self.stack.len() >= arity_usize && {
+                        let decoded = self.decode_arg_sources(code, arg_sources_idx);
+                        Self::call_shares_container_into_named_scalar_param(
+                            cf,
+                            &self.stack[self.stack.len() - arity_usize..],
+                            decoded.as_deref(),
+                        )
+                    };
                     if self.stack.len() >= arity_usize
+                        && !named_share
                         && !Self::call_shares_container_into_scalar_param(
                             cf,
                             &self.stack[self.stack.len() - arity_usize..],
@@ -246,38 +260,54 @@ impl Interpreter {
                         // Slice 2d: array/hash passed to a plain `$` param must
                         // share the caller's container -> force the slow binding
                         // path (the slot-only fast paths bind a detached copy).
+                        // The named variant (`f(n => @a)` into `:$n`) needs the
+                        // arg-source table to find the caller variable, so decode
+                        // it here (only on an otf-cache hit).
+                        let decoded_sources = self.decode_arg_sources(code, arg_sources_idx);
                         let share_into_scalar =
                             Self::call_shares_container_into_scalar_param(&cf, &args);
-                        let result =
-                            if !share_into_scalar && Self::is_light_call_eligible(&cf, name_str) {
-                                self.call_compiled_function_light(&cf, args, compiled_fns)
-                            } else if !share_into_scalar
-                                && Self::is_positional_light_call_eligible(&cf, name_str)
-                            {
-                                self.call_compiled_function_positional_light(
-                                    &cf,
-                                    &args,
-                                    compiled_fns,
-                                    name_str,
-                                )
-                            } else {
-                                let pkg = self.current_package().to_string();
-                                self.push_samewith_context(name_str, None);
-                                let pushed_dispatch =
-                                    loan_env!(self, push_multi_dispatch_frame(name_str, &args));
-                                let r = self.call_compiled_function_named(
-                                    &cf,
-                                    args,
-                                    compiled_fns,
-                                    &pkg,
-                                    name_str,
-                                );
-                                self.pop_samewith_context();
-                                if pushed_dispatch {
-                                    self.pop_multi_dispatch();
-                                }
-                                r
-                            };
+                        let named_share = Self::call_shares_container_into_named_scalar_param(
+                            &cf,
+                            &args,
+                            decoded_sources.as_deref(),
+                        );
+                        let result = if !share_into_scalar
+                            && !named_share
+                            && Self::is_light_call_eligible(&cf, name_str)
+                        {
+                            self.call_compiled_function_light(&cf, args, compiled_fns)
+                        } else if !share_into_scalar
+                            && !named_share
+                            && Self::is_positional_light_call_eligible(&cf, name_str)
+                        {
+                            self.call_compiled_function_positional_light(
+                                &cf,
+                                &args,
+                                compiled_fns,
+                                name_str,
+                            )
+                        } else {
+                            let pkg = self.current_package().to_string();
+                            self.push_samewith_context(name_str, None);
+                            let pushed_dispatch =
+                                loan_env!(self, push_multi_dispatch_frame(name_str, &args));
+                            // The named-share writeback reads the arg sources;
+                            // make them available to bind_function_args_values.
+                            self.set_pending_call_arg_sources(decoded_sources);
+                            let r = self.call_compiled_function_named(
+                                &cf,
+                                args,
+                                compiled_fns,
+                                &pkg,
+                                name_str,
+                            );
+                            self.set_pending_call_arg_sources(None);
+                            self.pop_samewith_context();
+                            if pushed_dispatch {
+                                self.pop_multi_dispatch();
+                            }
+                            r
+                        };
                         // Put CF back in cache
                         self.otf_call_cache.insert(name_sym, cf);
                         self.stack.push(result?);
@@ -804,6 +834,11 @@ impl Interpreter {
                 // This avoids the expensive env clone/restore cycle.
                 if Self::is_light_call_eligible(cf, name)
                     && !Self::call_shares_container_into_scalar_param(cf, &args)
+                    && !Self::call_shares_container_into_named_scalar_param(
+                        cf,
+                        &args,
+                        arg_sources.as_deref(),
+                    )
                     && !loan_env!(self, routine_is_test_assertion_by_name(name, &args))
                     && self.wrap_sub_id_for_name(name).is_none()
                 {

--- a/t/named-param-container-share.t
+++ b/t/named-param-container-share.t
@@ -1,0 +1,94 @@
+use Test;
+
+# Slice 2d (named follow-up): passing an `@`/`%` *variable* by name to a plain
+# readonly scalar `$` *named* param binds the same mutable container, just like
+# the positional/method cases (`t/scalar-param-container-share*.t`). `$n.push`,
+# `$n[0]=`, and `my @a := @$n` all mutate the caller's container; only `$n = …`
+# rebinding is forbidden (named scalar params are readonly).
+#
+# Named-param subs take a dedicated "light" dispatch (all params named) plus two
+# name-keyed caches; the share gate is wired into all three so a container arg
+# falls through to the slow `bind_function_args_values` path which promotes the
+# bound value to a shared cell. The source variable name comes from the
+# `arg_sources` table encoded "key=source".
+
+plan 16;
+
+# --- sub: push through a named scalar param ---
+sub f1(:$n) { $n.push(99) }
+my @z1 = (1, 2);
+f1(n => @z1);
+is @z1.gist, '[1 2 99]', 'named $n.push propagates to caller';
+
+# --- sub: element assignment ---
+sub f2(:$n) { $n[0] = 100 }
+my @z2 = (1, 2);
+f2(n => @z2);
+is @z2.gist, '[100 2]', 'named $n[0]= propagates';
+
+# --- sub: deref-bind inside body ---
+sub f3(:$n) { my @a := @$n; @a.push(7) }
+my @z3 = (1, 2);
+f3(n => @z3);
+is @z3.gist, '[1 2 7]', 'named deref-bind push propagates';
+
+# --- sub: read before push (order robustness) ---
+sub f4(:$n) { $n.elems.sink; $n.push(5) }
+my @z4 = (1,);
+f4(n => @z4);
+is @z4.gist, '[1 5]', 'named push robust to intervening read';
+
+# --- sub: hash named param element assign ---
+sub f5(:$h) { $h<x> = 9 }
+my %g5 = (a => 1);
+f5(h => %g5);
+is %g5<x>, 9, 'named hash $h<k>= propagates';
+is %g5<a>, 1, 'untouched hash key preserved';
+
+# --- sub: rebinding the named scalar param dies (readonly) ---
+sub f6(:$n) { $n = 5 }
+my @z6 = (1, 2);
+dies-ok { f6(n => @z6) }, 'rebinding a named scalar param dies';
+is @z6.gist, '[1 2]', 'caller unchanged after failed rebind';
+
+# --- sub: repeated calls (light_call_cache fast path) ---
+sub f7(:$n) { $n.push(1) }
+my @z7 = (0,);
+f7(n => @z7);
+f7(n => @z7);
+f7(n => @z7);
+is @z7.gist, '[0 1 1 1]', 'cached repeated named calls all propagate';
+
+# --- sub: mixed positional + named container ---
+sub f8($x, :$n) { $n.push($x) }
+my @z8 = (1,);
+f8(9, n => @z8);
+is @z8.gist, '[1 9]', 'mixed positional + named container shares';
+
+# --- sub: two named container params ---
+sub f9(:$a, :$b) { $a.push(1); $b.push(2) }
+my @p9 = (0,);
+my @q9 = (0,);
+f9(a => @p9, b => @q9);
+is @p9.gist, '[0 1]', 'first named container shares';
+is @q9.gist, '[0 2]', 'second named container shares';
+
+# --- sub: typed named param ---
+sub f10(Array :$n) { $n.push(7) }
+my @z10 = (1,);
+f10(n => @z10);
+is @z10.gist, '[1 7]', 'typed named Array param shares';
+
+# --- sub: literal passed by name (no caller, no crash) ---
+sub f11(:$n) { $n.push(3); $n.elems }
+is f11(n => [1, 2]), 3, 'literal named container arg works';
+
+# --- method: named scalar param push ---
+class K { method m(:$n) { $n.push(7) } }
+my @z12 = (1, 2);
+K.new.m(n => @z12);
+is @z12.gist, '[1 2 7]', 'method named $n.push propagates';
+
+# --- sub: non-container named arg unaffected ---
+sub f13(:$n) { $n + 1 }
+is f13(n => 5), 6, 'non-container named arg still works';


### PR DESCRIPTION
## Summary

Passing an `@`/`%` *variable* by name to a plain readonly scalar `$` named param now binds the same mutable container, matching the positional (#3283) and method (#3289) cases.

```raku
sub f(:$n) { $n.push(99) }
my @a = 1, 2;
f(n => @a);
say @a;   # before: [1 2]   now: [1 2 99]  (matches raku)
```

`$n.push`, `$n[0]=`, and `my @a := @$n` propagate to the caller; only `$n = …` rebinding stays forbidden (named scalar params are readonly). Works for subs and methods, hashes, typed params, mixed positional+named, and multiple named container params.

## How

- **binding.rs named-param branch**: when an `@`/`%`-variable Pair arg binds a plain readonly scalar named param, promote the bound value to a shared `ContainerRef` cell and register the exit-time rw writeback (the same machinery the positional path uses). The source variable name comes from the `arg_sources` table, encoded `"key=source"` by `positional_arg_source_name`.
- **Fast-path gating**: named-param subs take a dedicated all-named "light" dispatch plus two name-keyed caches (`light_call_cache`, `otf_call_cache`), all of which bind a detached copy into the slot. A new gate `call_shares_container_into_named_scalar_param` routes such calls to the slow `bind_function_args_values` path. The arg-source table is decoded lazily (only on a named-cache hit) so the common path pays nothing; the otf-cache slow branch now sets pending arg sources so the writeback can find the caller variable.

## Tests

- Pin: `t/named-param-container-share.t` (16) — push, element/hash assign, deref-bind, order robustness, readonly rebind dies, cached repeated calls, mixed positional+named, two named containers, typed named, literal arg, method named, non-container named arg.
- `make test` 9189 passing; targeted S06-signature / S12-methods roast PASS.

## Known follow-ups (pre-existing, shared with positional; not regressions)

`:$n` shorthand over a `$`-scalar source, `is copy`, and element post-increment (`$h<k>++`) writeback through a scalar-bound container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)