### PR TITLE
fix(container): propagate element ++/-- through a shared container

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2064,6 +2064,64 @@ impl Interpreter {
                 return Ok(());
             }
         }
+        // `$n[0]++` / `$h<k>++` where `$n`/`$h` is itself a shared `ContainerRef`
+        // cell (a scalar-bound container param, `my $s = @a`, etc.): increment the
+        // element *through* the cell so the caller's container observes it. The
+        // generic Array/Hash read/writeback paths below only match plain
+        // containers, so a `ContainerRef` would otherwise read `Nil` and discard
+        // the write (unlike `$n[0] = …` / `$n[0] += …`, which descend the cell).
+        // `$n[0]++` / `$h<k>++` where the variable resolves to a raw `ContainerRef`
+        // cell (a positional scalar-bound container param, `my $s := @a`, etc.):
+        // increment the element *through* the cell so the caller observes it. The
+        // generic Array/Hash read/writeback paths below match plain containers
+        // only, so a raw cell would read `Nil` and discard the write. (Named
+        // params resolve to a deref'd-but-Arc-shared plain container instead, which
+        // the strong_count>1 in-place writeback below handles.)
+        if let Some(Value::ContainerRef(arc)) = container.as_ref() {
+            let inner = arc.lock().unwrap().clone();
+            let current = match &inner {
+                Value::Hash(h) => h.get(&key).cloned().unwrap_or(Value::Nil),
+                Value::Array(arr, ..) => key
+                    .parse::<usize>()
+                    .ok()
+                    .and_then(|i| arr.get(i).cloned())
+                    .unwrap_or(Value::Nil),
+                _ => Value::Nil,
+            };
+            let effective = Self::normalize_incdec_source(match current {
+                Value::Nil => Value::Int(0),
+                other => other,
+            });
+            let new_val = if increment {
+                self.increment_value_smart(&effective)?
+            } else {
+                self.decrement_value_smart(&effective)?
+            };
+            let mut updated = inner;
+            match &mut updated {
+                Value::Hash(h) => {
+                    Value::hash_insert_through(
+                        &mut Arc::make_mut(h).map,
+                        key.clone(),
+                        new_val.clone(),
+                    );
+                }
+                Value::Array(arr, ..) => {
+                    if let Ok(i) = key.parse::<usize>() {
+                        let a = Arc::make_mut(arr);
+                        while a.len() <= i {
+                            a.push(Value::Nil);
+                        }
+                        a[i] = new_val.clone();
+                    }
+                }
+                _ => {}
+            }
+            *arc.lock().unwrap() = updated;
+            self.stack
+                .push(if return_new { new_val } else { effective });
+            return Ok(());
+        }
         let current = if let Some(container_value) = container.as_ref() {
             match container_value {
                 Value::Hash(h) => h.get(&key).cloned().unwrap_or(Value::Nil),
@@ -2171,11 +2229,26 @@ impl Interpreter {
         let modified_in_place = if let Some(container_value) = self.env_mut().get_mut(&name) {
             match container_value {
                 Value::Hash(h) => {
-                    Value::hash_insert_through(
-                        &mut Arc::make_mut(h).map,
-                        key.clone(),
-                        new_val.clone(),
-                    );
+                    // Mirror the array arm below: when the hash Arc is shared
+                    // (strong_count > 1) via a scalar-bound `ContainerRef` cell
+                    // (`sub f($h){ $h<k>++ }` / `my $s = %h; $s<k>++`), mutate it
+                    // in place so the caller observes the change. `Arc::make_mut`
+                    // would COW-detach and silently drop the write (the array
+                    // path already special-cased this; the hash path did not).
+                    let use_inplace = Arc::strong_count(h) > 1 && !name.starts_with('%');
+                    if use_inplace {
+                        // SAFETY: aliased in-place mutation of a shared hash
+                        // (strong_count > 1, the shared-cell case); mirrors the
+                        // array arm's `arc_contents_mut` usage.
+                        let h = unsafe { crate::value::arc_contents_mut(h) };
+                        Value::hash_insert_through(&mut h.map, key.clone(), new_val.clone());
+                    } else {
+                        Value::hash_insert_through(
+                            &mut Arc::make_mut(h).map,
+                            key.clone(),
+                            new_val.clone(),
+                        );
+                    }
                     true
                 }
                 Value::Array(arr, ..) => {

--- a/t/element-incr-shared-container.t
+++ b/t/element-incr-shared-container.t
@@ -1,0 +1,114 @@
+use Test;
+
+# Post/pre increment and decrement on an *element* of a container that is shared
+# through a `ContainerRef` cell (a scalar-bound container param, `my $s = @a`,
+# Slice 2a/2d) must mutate the caller's container, like `$n[0] = …` and
+# `$n[0] += …` already did. Two representations occur:
+#   * a raw `ContainerRef` cell (positional scalar-bound param, `:=` deref bind)
+#     -> handled by incrementing through the cell;
+#   * a deref'd-but-Arc-shared plain container (named param, `my $s = @a`)
+#     -> handled by the strong_count>1 in-place writeback (the array path always
+#        did this; the hash path used to `Arc::make_mut`-detach and drop the
+#        write).
+
+plan 14;
+
+# --- scalar holding an array (Slice 2a) ---
+{
+    my @a = (5, 6);
+    my $s = @a;
+    $s[0]++;
+    is @a.gist, '[6 6]', '$s[0]++ through scalar-array share propagates';
+}
+{
+    my @a = (5, 6);
+    my $s = @a;
+    $s[1]--;
+    is @a.gist, '[5 5]', '$s[1]-- through scalar-array share propagates';
+}
+{
+    my @a = (5,);
+    my $s = @a;
+    ++$s[0];
+    is @a.gist, '[6]', 'pre-increment ++$s[0] propagates';
+}
+
+# --- scalar holding a hash ---
+{
+    my %h = (k => 0);
+    my $s = %h;
+    $s<k>++;
+    is %h<k>, 1, '$s<k>++ through scalar-hash share propagates';
+}
+{
+    my %h = (k => 3);
+    my $s = %h;
+    $s<k>--;
+    is %h<k>, 2, '$s<k>-- through scalar-hash share propagates';
+}
+{
+    my %h = (k => "aa");
+    my $s = %h;
+    $s<k>++;
+    is %h<k>, "ab", 'string magical increment through shared hash propagates';
+}
+
+# --- positional scalar param holding an array ---
+sub pa($n) { $n[0]++ }
+{
+    my @a = (10, 20);
+    pa(@a);
+    is @a.gist, '[11 20]', '$n[0]++ through positional $-param array propagates';
+}
+
+# --- positional scalar param holding a hash ---
+sub ph($h) { $h<k>++ }
+{
+    my %h = (k => 7);
+    ph(%h);
+    is %h<k>, 8, '$h<k>++ through positional $-param hash propagates';
+}
+
+# --- multiple increments in one call ---
+sub multi($n) { $n[0]++; $n[0]++; $n[1]++ }
+{
+    my @a = (10, 20);
+    multi(@a);
+    is @a.gist, '[12 21]', 'repeated element increments all propagate';
+}
+
+# --- plain (unshared) array/hash element increment still works ---
+{
+    my @a = (1, 2);
+    @a[0]++;
+    is @a.gist, '[2 2]', 'plain @a[0]++ still works';
+}
+{
+    my %h = (k => 1);
+    %h<k>++;
+    is %h<k>, 2, 'plain %h<k>++ still works';
+}
+
+# --- `:=`-bound deref scalar (raw ContainerRef cell) ---
+{
+    my @a = (5,);
+    my $s := @a;
+    $s[0]++;
+    is @a.gist, '[6]', '$s[0]++ through := deref bind propagates';
+}
+
+# --- compound assign on a shared element still works (regression guard) ---
+{
+    my @a = (5,);
+    my $s = @a;
+    $s[0] += 10;
+    is @a.gist, '[15]', '$s[0] += 10 still propagates';
+}
+
+# --- increment return value is the pre-increment value (post) ---
+{
+    my @a = (5,);
+    my $s = @a;
+    my $r = $s[0]++;
+    is $r, 5, 'post-increment returns the original value';
+}


### PR DESCRIPTION
## Summary

`$n[0]++` / `$h<k>++` (and `--`, and the pre-forms) on an *element* of a container shared through a scalar — a scalar-bound container param, `my $s = @a`, `my $s := @a` (Slice 2a/2d) — now mutate the caller's container, matching `$n[0] = …` and `$n[0] += …` which already worked. Previously the increment was silently dropped:

```raku
my @a = 5; my $s = @a; $s[0]++; say @a;   # before: [5]   now: [6]

sub f($h) { $h<k>++ }
my %h = k => 0; f(%h); say %h<k>;          # before: 0     now: 1
```

## Root cause

The element inc/dec handler resolves the container two ways, and both dropped the write for a shared container:

- **raw `ContainerRef` cell** (positional scalar-bound param, `:=` deref bind): the generic Array/Hash read + writeback arms match plain containers only, so the cell read `Nil` and discarded the write. Added a branch that increments through the cell.
- **deref'd-but-Arc-shared plain container** (named param, `my $s = @a`): the array writeback already did a `strong_count > 1` aliased in-place mutation to preserve sharing, but the hash writeback used an unconditional `Arc::make_mut`, which COW-detached and dropped the write. Made the hash arm mirror the array arm.

`+=` (compound assign) and `=` (plain assign) already propagated; only `++`/`--` were affected.

## Tests

- Pin: `t/element-incr-shared-container.t` (14) — post/pre inc/dec through scalar-array and scalar-hash shares, positional `$`-param array/hash, `:=` deref bind, multiple increments, string magical increment, post-increment return value, and plain `@a[0]++`/`%h<k>++` regression guards.
- `make test` 9191 passing; `roast/S03-operators/autoincrement.t`, `increment.t`, `S02-types/hash.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)