### PR TITLE
test(roast): whitelist GraphemeBreakTest-3.t via Unicode 17 grapheme data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ unicode_names2 = "2.0.0"
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 num-integer = "0.1"
-unicode-segmentation = "1.12.0"
+unicode-segmentation = "1.13.3"
 unicode-normalization = "0.1"
 rustyline = { version = "15", optional = true }
 emojis = "0.7"

--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -94,10 +94,9 @@ without colliding, pick from the **top**:
   primary-ignorable; UCA-17/MoarVM assign implicit primary weights by codepoint.
   Needs sort-key-level weight injection (`icu_collator::write_sort_key_to`) or a
   partial UCA reimplementation. 2-test payoff.
-- **S15-nfg/GraphemeBreakTest-3.t** — **Hard**, 157/166. 9 failures are GB9c (Indic
-  conjunct: Myanmar/Balinese/Khmer virama) and GB11 (emoji-ZWJ). The
-  `unicode-segmentation` crate's bundled Unicode version lacks these UAX-29 rules
-  for Unicode 17.0. Needs GB9c/GB11 post-processing or a crate upgrade.
+  - *(DONE: S15-nfg/GraphemeBreakTest-3.t whitelisted #3294 — the 9 GB9c/GB11
+    failures were the `unicode-segmentation` 1.12.0 GCB tables predating Unicode
+    17.0; bumping the crate to 1.13.3 fixed all of them.)*
 
 ### IO (`runtime/io*`, IO builtins)
 

--- a/TODO_roast/S15.md
+++ b/TODO_roast/S15.md
@@ -12,10 +12,11 @@
 - [ ] roast/S15-nfg/from-file.t
 - [x] roast/S15-nfg/grapheme-break.t
   - 1/1 pass.
-- [ ] roast/S15-nfg/GraphemeBreakTest-0.t
-- [ ] roast/S15-nfg/GraphemeBreakTest-1.t
-- [ ] roast/S15-nfg/GraphemeBreakTest-2.t
-- [ ] roast/S15-nfg/GraphemeBreakTest-3.t
+- [x] roast/S15-nfg/GraphemeBreakTest-0.t
+- [x] roast/S15-nfg/GraphemeBreakTest-1.t
+- [x] roast/S15-nfg/GraphemeBreakTest-2.t
+- [x] roast/S15-nfg/GraphemeBreakTest-3.t
+  - 166/166 pass since unicode-segmentation 1.13.3 (Unicode 17.0.0 grapheme data).
 - [ ] roast/S15-nfg/long-uni.t
 - [ ] roast/S15-nfg/many-combiners.t
 - [ ] roast/S15-nfg/many-threads.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -715,6 +715,7 @@ roast/S15-literals/numbers.t
 roast/S15-nfg/GraphemeBreakTest-0.t
 roast/S15-nfg/GraphemeBreakTest-1.t
 roast/S15-nfg/GraphemeBreakTest-2.t
+roast/S15-nfg/GraphemeBreakTest-3.t
 roast/S15-nfg/case-change.t
 roast/S15-nfg/cgj.t
 roast/S15-nfg/concat-stable.t


### PR DESCRIPTION
## Summary
`roast/S15-nfg/GraphemeBreakTest-3.t` is generated from the official **Unicode 17.0.0** `GraphemeBreakTest.txt`. It had 9 failing subtests (145, 159-166) covering:
- ZWJ + a non-pictographic codepoint (`\x[2701,200D,2701]` — U+2701 is *not* `Extended_Pictographic`, so it must break)
- Khmer (`17D2` coeng), Balinese (`1B44` adeg-adeg) and Myanmar (`1039` virama / `103A` asat) grapheme-cluster boundaries

The root cause was the grapheme-cluster boundary (GCB) tables in **`unicode-segmentation` 1.12.0**, which predate Unicode 17.0.0. Bumping the crate to **1.13.3** (Unicode 17.0.0 GCB data) fixes all 9 cases — mutsu now segments these strings exactly as the official test expects (in several cases more correctly than the locally-installed `raku`, which is on an older Unicode version).

## Changes
- `Cargo.toml` / `Cargo.lock`: `unicode-segmentation` 1.12.0 → 1.13.3
- `roast-whitelist.txt`: add `GraphemeBreakTest-3.t`
- `TODO_roast/S15.md`: mark the GraphemeBreakTest files done

## Verification
- `GraphemeBreakTest-3.t`: 166/166 pass
- `GraphemeBreakTest-0/1/2` and the full `S15-nfg` + `S15-unicode-information` + `S15-string-types` suites: still pass (no GCB regressions)
- `make test`: PASS (948 files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)