### PR TITLE
feat(lazy): render lazy infinite arrays as bounded placeholders

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -338,6 +338,11 @@ pub(super) fn dispatch(
             }
             Value::Package(_) | Value::Instance { .. } => None,
             Value::LazyList(_) => None, // fall through to runtime to force the list
+            // A lazy (infinite-backed) array stringifies to a bounded `...`
+            // placeholder rather than materializing its capped backing.
+            Value::Array(_, kind) if *kind == crate::value::ArrayKind::Lazy => {
+                Some(Ok(Value::str_from("...")))
+            }
             Value::Enum { .. } => None, // fall through to enum dispatch for string enum support
             Value::Str(s) if s.as_str() == "IO::Special" => Some(Ok(Value::str_from(""))),
             Value::Rat(_, 0) | Value::FatRat(_, 0) => {

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -438,11 +438,20 @@ pub(super) fn dispatch(
         Value::Seq(_) if method == "raku" || method == "perl" => {
             Some(Ok(Value::str(raku_value(target))))
         }
+        Value::Array(_, kind) if method == "gist" && *kind == crate::value::ArrayKind::Lazy => {
+            // A lazy (infinite-backed) array renders a bounded placeholder
+            // rather than materializing its (possibly capped 100k) backing,
+            // matching Rakudo's `[...]`.
+            Some(Ok(Value::str_from("[...]")))
+        }
         Value::Array(items, kind) if method == "gist" => {
             fn gist_item(v: &Value) -> String {
                 match v {
                     Value::Nil => "Nil".to_string(),
                     Value::ContainerRef(cell) => gist_item(&cell.lock().unwrap()),
+                    Value::Array(_, k) if *k == crate::value::ArrayKind::Lazy => {
+                        "[...]".to_string()
+                    }
                     Value::Array(inner, kind) => {
                         let elems = inner.iter().map(gist_item).collect::<Vec<_>>().join(" ");
                         gist_array_wrap(&elems, *kind)
@@ -509,6 +518,9 @@ pub(super) fn dispatch(
                 match v {
                     Value::Nil => "Nil".to_string(),
                     Value::ContainerRef(cell) => gist_item(&cell.lock().unwrap()),
+                    Value::Array(_, k) if *k == crate::value::ArrayKind::Lazy => {
+                        "[...]".to_string()
+                    }
                     Value::Array(inner, kind) => {
                         let elems = inner.iter().map(gist_item).collect::<Vec<_>>().join(" ");
                         gist_array_wrap(&elems, *kind)

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -975,6 +975,11 @@ pub(crate) fn gist_value(value: &Value) -> String {
             // Rat.gist is identical to Rat.Str in Raku
             value.to_string_value()
         }
+        Value::Array(_, crate::value::ArrayKind::Lazy) => {
+            // A lazy (infinite-backed) array renders a bounded placeholder
+            // rather than materializing its capped backing (Rakudo: `[...]`).
+            "[...]".to_string()
+        }
         Value::Array(items, kind) => {
             let ptr = std::sync::Arc::as_ptr(items) as usize;
             let is_cycle = SEEN_PTRS.with(|seen| check_and_push(seen, ptr));

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -418,6 +418,7 @@ impl Value {
                     end.to_string_value()
                 )
             }
+            Value::Array(_, crate::value::ArrayKind::Lazy) => "...".to_string(),
             Value::Array(items, ..) => {
                 // Cycle detection for recursive array structures
                 thread_local! {

--- a/t/lazy-array-gist.t
+++ b/t/lazy-array-gist.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A lazy (infinite-backed) array must render a bounded placeholder instead of
+# materializing (and dumping) its capped backing store.
+
+plan 12;
+
+# my @a = 1..* keeps the array lazy
+{
+    my @a = 1..*;
+    ok @a.is-lazy, '@a = 1..* is lazy';
+    is @a.gist, '[...]', 'lazy array .gist is [...]';
+    is @a.raku, '[...]', 'lazy array .raku is [...]';
+    is @a.Str, '...', 'lazy array .Str is ...';
+}
+
+# say / put / print render via gist / Str
+{
+    my @a = 1..*;
+    is-deeply (try { @a.gist }), '[...]', 'gist does not hang or dump';
+    my $interp = "@a[]";
+    is $interp, '...', 'interpolated lazy array is ...';
+}
+
+# nested lazy array inside a normal array renders [...] for the inner one
+{
+    my @a = 1..*;
+    my @b = 5, @a;
+    is @b.gist, '[5 [...]]', 'nested lazy array gist';
+}
+
+# a normal (finite) array is unaffected
+{
+    my @n = 1, 2, 3;
+    is @n.gist, '[1 2 3]', 'finite array gist unchanged';
+    is @n.Str, '1 2 3', 'finite array Str unchanged';
+    is @n.raku, '[1, 2, 3]', 'finite array raku unchanged';
+    my @r = 1..10;
+    is @r.gist, '[1 2 3 4 5 6 7 8 9 10]', 'finite range materializes';
+    is @r.elems, 10, 'finite range elems';
+}


### PR DESCRIPTION
## Summary

`.gist` / `say` / `.Str` / `print` / interpolation on a **lazy (infinite-backed) array** (`my @a = 1..*`) materialized its capped 100k backing store and dumped every element, instead of rendering Rakudo's bounded placeholder. `.raku` already short-circuited to `[...]`; the gist/Str paths did not.

This is **slice L1** of the lazy-infinite-array campaign ([docs/lazy-arrays.md](../blob/main/docs/lazy-arrays.md)) — an isolated, mutation-free prerequisite for later preserving lazy lists through `@`-assignment (L2) without `.gist` hanging.

## Behavior

| expr | before | after / raku |
|---|---|---|
| `my @a = 1..*; say @a` | dumps 100k ints | `[...]` |
| `@a.gist` | dumps 100k ints | `[...]` |
| `@a.Str` / `~@a` | dumps | `...` |
| `@a.raku` | `[...]` (already ok) | `[...]` |
| `my @b = 5, @a; @b.gist` | dumps inner | `[5 [...]]` |

Finite arrays are unaffected — only `b == i64::MAX` ranges become `ArrayKind::Lazy`.

## Changes

`ArrayKind::Lazy` short-circuit added to the four rendering sites:
- `dispatch_core_repr` gist arm + both nested `gist_item` closures → `[...]`
- `dispatch_core_coerce` `Str`/`Stringy` → `...`
- `runtime::utils::gist_value` (say/print path) → `[...]`
- `value::display::to_string_value` → `...`

## Tests

- New `t/lazy-array-gist.t` (12 subtests), all passing.
- `make test` → PASS (no regressions). `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)