### PR TITLE
feat(signature): reject typed slurpy array/hash params (X::Parameter::TypedSlurpy)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -198,13 +198,20 @@ files occasionally).
 
 - **S04-statements/for.t** — **Medium**, 22/111. No exception on bad loop-var
   binding (`for 1,2 -> $a, $b, $c`) + topic-aliasing edge cases (VM control ops).
-- **S06-signature/slurpy-params.t** — **78/86** (was aborting at 51 on a slurpy
+- **S06-signature/slurpy-params.t** — **80/86** (was aborting at 51 on a slurpy
   `1..*` hang; the infinite-range expansion is now capped in `flatten_into_slurpy`,
-  so tests 52–69 run). Remaining 8: `+@`/`*@` passing a **Seq through unscathed**
-  (70-71, 76-77) + **Seq single-pass consumption** dies-on-second-iteration (74-75)
-  + **X::Parameter::TypedSlurpy** for `Int *@a` / `Int *%h` (80-81). The lazy tests
-  (52 etc.) pass within the 100k cap; a truly lazy slurpy (`.is-lazy` True, `.gist`
-  no-hang) is the lazy-array campaign — see `docs/lazy-arrays.md` Slice L4.
+  so tests 52–69 run; **tests 80-81 X::Parameter::TypedSlurpy now pass**, a
+  parse-time check on `*@`/`*%`/`+@`/`+%` slurpies with a type constraint). The
+  remaining 6 all need the **Seq single-pass-consumption** feature: `+@`/`*@`
+  passing a **Seq through unscathed** (70-71, 76-77) + dies-on-second-iteration
+  with `X::Seq::Consumed` (74-75). mutsu currently materializes every Seq so a
+  Seq is silently re-iterable — implementing real single-pass Seq consumption is
+  the blocker (broad blast radius). The lazy tests (52 etc.) pass within the 100k
+  cap; a truly lazy slurpy (`.is-lazy` True, `.gist` no-hang) is the lazy-array
+  campaign — see `docs/lazy-arrays.md` Slice L4. NOTE: `Type **@a` / `Type +@a`
+  (typed double/onearg slurpy) still fail to *parse* (a separate pre-existing
+  limitation; even `Array **@AoA` does not parse), so the TypedSlurpy check only
+  fires on the single-star `*@`/`*%` forms today.
 - **S04-declarations/my-6e.t** — **Medium**. EVAL scope visibility (EVAL'd code must
   see the enclosing lexical scope).
 - **Parser operators** — `ff`/`fff` flipflop, `==>`/`<==` feed precedence, hyper

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -196,6 +196,36 @@ pub(super) fn validate_signature_params(params: &[ParamDef]) -> Result<(), PErro
                 "X::Trait::Invalid: Cannot make an 'is rw' parameter optional".to_string(),
             ));
         }
+        // X::Parameter::TypedSlurpy: a slurpy *array* (`*@`, `**@`, `+@`) or
+        // *hash* (`*%`, `+%`) parameter may not carry an explicit type
+        // constraint -- even `Mu`/`Any`. (A slurpy *scalar* `*$x` / `*&f` IS
+        // allowed to be typed, so this is gated on the `@`/`%` sigil.) The
+        // implicit slurpy type is recorded as `None`, so any `Some` is explicit.
+        if (pd.slurpy || pd.double_slurpy || pd.onearg)
+            && pd.type_constraint.is_some()
+            && (pd.name.starts_with('@') || pd.name.starts_with('%'))
+        {
+            let kind = if pd.name.starts_with('%') {
+                "named"
+            } else {
+                "positional"
+            };
+            let msg = format!(
+                "Slurpy {} parameters with type constraints are not supported",
+                kind
+            );
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "kind".to_string(),
+                crate::value::Value::str(kind.to_string()),
+            );
+            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Parameter::TypedSlurpy"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+        }
         // X::Parameter::Default: a default value is illegal on a slurpy parameter
         // (`*@a = 2`, `*@ = 2`) or a required parameter (`$x! = 3`, `:$x! = 3`).
         if pd.default.is_some() {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1517,6 +1517,7 @@ pub(crate) fn is_known_compound_type(name: &str) -> bool {
             | "X::Parameter::Placeholder"
             | "X::Parameter::RW"
             | "X::Parameter::Twigil"
+            | "X::Parameter::TypedSlurpy"
             | "X::Parameter::WrongOrder"
             | "X::Phaser::Multiple"
             | "X::Phaser::PrePost"

--- a/t/typed-slurpy.t
+++ b/t/typed-slurpy.t
@@ -1,0 +1,39 @@
+use Test;
+
+# X::Parameter::TypedSlurpy: a slurpy parameter may not carry an explicit type
+# constraint (even Mu/Any). See roast/S06-signature/slurpy-params.t lines 267-273.
+#
+# NOTE: only the single-star forms (`Type *@`, `Type *%`) are exercised here.
+# mutsu's parser cannot yet parse a type constraint before a `**`/`+` slurpy
+# (`Type **@a`, `Type +@a` fail to parse outright -- a separate pre-existing
+# limitation), so those never reach the validation below. The check in
+# parser/stmt/sub.rs already covers `**`/`+` for when the parser is fixed.
+
+plan 10;
+
+# positional single-star slurpy
+throws-like 'sub f(Int *@a) { }', X::Parameter::TypedSlurpy, kind => 'positional',
+    '*@ with type constraint';
+throws-like 'sub f(Mu *@a) { }', X::Parameter::TypedSlurpy, kind => 'positional',
+    'even Mu is rejected on a slurpy';
+throws-like 'sub f(Cool *@a) { }', X::Parameter::TypedSlurpy, kind => 'positional',
+    'Cool *@ with type constraint';
+
+# named single-star slurpy
+throws-like 'sub f(Int *%h) { }', X::Parameter::TypedSlurpy, kind => 'named',
+    '*% with type constraint';
+
+# untyped slurpies are fine
+lives-ok { EVAL 'sub f(*@a) { }' }, 'untyped *@ ok';
+lives-ok { EVAL 'sub f(*%h) { }' }, 'untyped *% ok';
+lives-ok { EVAL 'sub f(**@a) { }' }, 'untyped **@ ok';
+lives-ok { EVAL 'sub f(+@a) { }' }, 'untyped +@ ok';
+
+# a type constraint on a non-slurpy positional is fine
+lives-ok { EVAL 'sub f(Int $x, *@a) { }' }, 'typed required + untyped slurpy ok';
+
+# implicit slurpy placeholders are not typed
+{
+    sub uses-args { @_ }
+    is uses-args(1, 2, 3).elems, 3, 'implicit @_ slurpy is not rejected';
+}


### PR DESCRIPTION
## Summary

A slurpy **array** (`*@`, `**@`, `+@`) or **hash** (`*%`, `+%`) parameter may not carry an explicit type constraint — even `Mu`/`Any`. Rakudo rejects this at compile time with `X::Parameter::TypedSlurpy` (`kind => 'positional'` / `'named'`); mutsu silently accepted it.

Fixes **roast S06-signature/slurpy-params.t tests 80-81** (78 → 80/86).

## Behavior

| signature | before | after / raku |
|---|---|---|
| `sub f(Int *@a) {}` | accepted | `X::Parameter::TypedSlurpy`, kind `positional` |
| `sub f(Int *%h) {}` | accepted | `X::Parameter::TypedSlurpy`, kind `named` |
| `sub f(Code *$block) {}` | accepted | accepted (typed slurpy **scalar** is legal) |
| `sub f(*@a) {}` | accepted | accepted |

## Changes

- `parser/stmt/sub.rs`: parse-time check in the signature validator — when a slurpy `@`/`%` param has a type constraint, throw `X::Parameter::TypedSlurpy` (mirrors the existing `X::Parameter::WrongOrder` pattern). Gated on the `@`/`%` sigil so a typed slurpy *scalar* `*$x`/`*&f` stays legal.
- `runtime/utils.rs`: register `X::Parameter::TypedSlurpy` in `is_known_compound_type`.

## Caveat (documented in BLOCKERS.md)

`Type **@a` / `Type +@a` (typed double/onearg slurpy) still fail to **parse** — a separate pre-existing limitation (even `Array **@AoA` does not parse). So the check only fires on the single-star `*@`/`*%` forms today; the `**`/`+` branches are covered for when the parser gains that syntax.

## Tests

- New `t/typed-slurpy.t` (10 subtests), all passing.
- `make test` → PASS (the pre-existing `parse_sub_decl_with_typed_slurpy_param` unit test, which uses a typed slurpy *scalar* `Code *$block`, still passes — confirming scalars are correctly exempt). `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)