### PR TITLE
feat(lazy): throw X::Cannot::Lazy on .elems of a lazy infinite array

### DIFF
--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -1,12 +1,47 @@
 # Lazy infinite arrays — `my @a = 1..*` reify-on-demand (design)
 
-> **Status:** DESIGN (2026-06-19). Captures the analysis behind the "lazy
+> **Status:** IN PROGRESS (2026-06-19). Captures the analysis behind the "lazy
 > infinite sequence" track (PLAN.md §C / BLOCKERS "Real lazy infinite
 > sequences"). The reify-on-demand machinery already works for **scalar-held**
 > and **gather-coroutine** lazy values; the gap is that infinite **ranges and
 > `...` sequences assigned to an `@` array are materialized (capped at 100k)**
 > at assignment, losing laziness. Closing it is a multi-slice campaign because
 > array *mutation* ops assume a materialized backing.
+
+## Progress log
+
+- **L1 — lazy `.gist`/`.Str`/`.raku` (DONE, #3306).** A
+  `Value::Array(_, ArrayKind::Lazy)` now renders `[...]` (gist/raku/say) /
+  `...` (Str/print/interp) instead of dumping its capped 100k backing. Four
+  sites: `dispatch_core_repr` gist arm + both nested `gist_item` closures,
+  `dispatch_core_coerce` Str, `runtime::utils::gist_value` (say path),
+  `value::display::to_string_value`. **Finding:** Rakudo's lazy-array gist is a
+  flat `[...]`/`(...)`, NOT the bounded-prefix `(1 2 3 … )` this doc originally
+  assumed — much simpler.
+- **L5 — lazy `.elems` → X::Cannot::Lazy (DONE, #3310).** A lazy
+  `ArrayKind::Lazy` array's `.elems` now throws (was returning the 100k cap).
+  Guard added before `as_list_items` in `dispatch_core_numeric`, reusing
+  `range_elems_lazy_failure`. **Still capped (follow-up):** `.Numeric`/`.Int`/
+  `.end`/prefix-`+` on a lazy array return the cap (separate dispatch paths).
+
+## Open findings / blockers discovered this session
+
+- **L1b — `Value::LazyList` gist still HANGS for the coroutine case.** L1 fixed
+  `ArrayKind::Lazy` *arrays*; but `my @a = lazy gather { … }` stores a preserved
+  `Value::LazyList` (mutsu reports its `.WHAT` as `Seq`), and `@a.gist` /
+  `@a.map(…)` on it forces → **hangs**. A `sequence_spec` LazyList held in a
+  scalar already gists `(...)` without forcing, so the gap is specifically the
+  *coroutine* LazyList gist path. **Dual-representation wart:** a lazy
+  `Value::LazyList` carries no `[`-vs-`(` context, so it cannot know whether to
+  render `[...]` (held in `@a`) or `(...)` (a bare `$s` Seq). This must be
+  resolved before **L2** (preserving an infinite Range as a reify `LazyList` at
+  `@`-assign) is viable — else `my @a = 1..*; @a.gist` would hang.
+- **slurpy-params.t is NOT just a lazy problem.** Its remaining 6 fails
+  (70-71, 74-77) need real **Seq single-pass consumption** (`X::Seq::Consumed`
+  on second iteration) + Seq pass-through (`+a`→Seq, `+@a`→List). mutsu
+  materializes every Seq so a Seq is silently re-iterable; implementing true
+  single-pass consumption is a broad-blast-radius feature. (Tests 80-81
+  X::Parameter::TypedSlurpy DONE #3308; the slurpy `1..*` hang DONE #3303.)
 
 ---
 

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -94,6 +94,14 @@ pub(super) fn dispatch(
                     failure_attrs,
                 ))));
             }
+            // A lazy (infinite-backed) array cannot report its element count;
+            // raku throws X::Cannot::Lazy. Check before `as_list_items`, which
+            // would otherwise return the capped backing length.
+            if let Value::Array(_, kind) = target
+                && kind.is_lazy()
+            {
+                return Some(range_elems_lazy_failure("elems"));
+            }
             if let Some(items) = target.as_list_items() {
                 return Some(Some(Ok(Value::Int(items.len() as i64))));
             }

--- a/t/lazy-array-elems.t
+++ b/t/lazy-array-elems.t
@@ -1,0 +1,36 @@
+use Test;
+
+# A lazy (infinite-backed) array cannot report its element count: raku throws
+# X::Cannot::Lazy ("Cannot .elems a lazy list") rather than returning the capped
+# backing length.
+
+plan 8;
+
+{
+    my @a = 1..*;
+    throws-like { @a.elems }, X::Cannot::Lazy, 'lazy array .elems throws X::Cannot::Lazy';
+}
+
+{
+    my @a = 1..*;
+    my $caught;
+    my $r = try { @a.elems; CATCH { default { $caught = $_ } } };
+    is $caught.message, 'Cannot .elems a lazy list', 'message matches';
+}
+
+# the lazy array remains usable for indexing / iteration after the failed .elems
+{
+    my @a = 1..*;
+    is @a[5], 6, 'lazy array still indexable';
+    is-deeply @a[^4], (1, 2, 3, 4), 'lazy array slice works';
+    ok @a.is-lazy, 'still lazy';
+}
+
+# finite arrays / ranges are unaffected
+{
+    my @b = 1, 2, 3;
+    is @b.elems, 3, 'finite array .elems works';
+    is (1..10).elems, 10, 'finite range .elems works';
+    my @c = 1..100;
+    is @c.elems, 100, 'finite range-assigned array .elems works';
+}


### PR DESCRIPTION
## Summary

`.elems` on a lazy (infinite-backed) array (`my @a = 1..*`) returned the capped 100k backing length instead of throwing — Rakudo throws `X::Cannot::Lazy` ("Cannot .elems a lazy list").

The `elems` arm already handled infinite `Range`s and lazy `LazyList`s, but a `Value::Array(_, ArrayKind::Lazy)` fell through to the generic `as_list_items().len()` path and reported `100001`.

Slice **L5** of the lazy-infinite-array campaign ([docs/lazy-arrays.md](../blob/main/docs/lazy-arrays.md)).

## Behavior

| expr | before | after / raku |
|---|---|---|
| `my @a = 1..*; @a.elems` | `100001` | `X::Cannot::Lazy` |
| `@a[5]` / `@a[^4]` / `@a.head(3)` / `@a.first(...)` / `@a.map(...)` | work | unchanged |
| `(1..10).elems` / `my @b=1,2,3; @b.elems` | `10` / `3` | unchanged |

## Changes

`builtins/methods_0arg/dispatch_core_numeric.rs`: add an `ArrayKind::Lazy` guard before `as_list_items`, reusing the existing `range_elems_lazy_failure` helper (produces the `X::Cannot::Lazy` Failure).

## Scope note

`.Numeric`/`.Int`/`.end`/prefix `+` on a lazy array still return the capped count (separate dispatch paths) — left as follow-up so this stays a focused, low-risk change.

## Tests

- New `t/lazy-array-elems.t` (8 subtests), all passing.
- `make test` → PASS (9302 tests; lazy array indexing/iteration unaffected). `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)