### PR TITLE
feat(lazy): render coroutine LazyList gist as context-aware placeholder (L1b)

### DIFF
--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -23,6 +23,27 @@
   Guard added before `as_list_items` in `dispatch_core_numeric`, reusing
   `range_elems_lazy_failure`. **Still capped (follow-up):** `.Numeric`/`.Int`/
   `.end`/prefix-`+` on a lazy array return the cap (separate dispatch paths).
+- **L1b — coroutine `Value::LazyList` gist + dual-rep wart (DONE).** A genuinely
+  lazy `Value::LazyList` (gather coroutine with the `lazy` marker, infinite
+  sequence/closure/scan spec, lazy map/grep pipeline) now renders raku's
+  placeholder under gist/Str/raku/perl/say/print/`~`/interpolation instead of
+  forcing (which hung for an infinite gather held in a variable) or returning
+  empty. **Dual-rep wart resolved:** the `@`-assign preserve sites tag the
+  LazyList with an `ARRAY_CONTEXT_MARKER` env flag, so gist renders `[...]`
+  (held in `@a`) vs `(...)` (bare `$s` Seq) and `.WHAT` reports `Array` vs `Seq`.
+  Key helpers: `LazyList::is_genuinely_lazy()` (gates on the `lazy` marker for
+  the gather family — a *plain* `gather` is `.is-lazy` `False` and must
+  materialize, the regression that gated this), `with_array_context()`,
+  `in_array_context()`, and the shared `value::lazy_list_placeholder()`. Guards
+  added to BOTH method-dispatch paths (`vm_call_method_ops` for direct calls,
+  `vm_call_method_mut_ops` for variable-target calls — the latter was the hang,
+  since `@a.gist`/`$s.gist` route through CallMethodMut) plus the runtime slow
+  path, `runtime::utils::gist_value`, and `value::display::to_string_value`.
+  t/lazy-list-gist-context.t. **Known follow-up:** `@a[]` zen-slice
+  interpolation of a lazy array still renders empty (the list-flatten interp
+  path, separate from `.Str`); no hang. With the dual-rep wart resolved, **L2**
+  (preserve infinite Range / closure_seq / lazy_pipe as a reify `LazyList` on
+  `@`-assign instead of capping to an Array) is now unblocked.
 
 ## Open findings / blockers discovered this session
 

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3124,13 +3124,12 @@ impl Interpreter {
         // which materializes its elements.)
         if let Value::LazyList(ll) = &target
             && matches!(method, "gist" | "Str" | "raku" | "perl")
-            && (ll.lazy_pipe.is_some() || ll.sequence_spec.is_some())
+            && ll.is_genuinely_lazy()
         {
-            return Ok(Value::str(if method == "Str" {
-                "...".to_string()
-            } else {
-                "(...)".to_string()
-            }));
+            return Ok(Value::str(crate::value::lazy_list_placeholder(
+                method,
+                ll.in_array_context(),
+            )));
         }
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -43,6 +43,9 @@ impl Interpreter {
             | Value::GenericRange { .. } => "Range",
             Value::Array(_, kind) if kind.is_real_array() => "Array",
             Value::Array(_, _) => "List",
+            // A lazy list assigned into an `@` array reports `Array`; a bare Seq
+            // (scalar-held) reports `Seq`.
+            Value::LazyList(ll) if ll.in_array_context() => "Array",
             Value::LazyList(_) => "Seq",
             Value::Hash(_) => "Hash",
             Value::Rat(_, _) => "Rat",

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -980,6 +980,11 @@ pub(crate) fn gist_value(value: &Value) -> String {
             // rather than materializing its capped backing (Rakudo: `[...]`).
             "[...]".to_string()
         }
+        Value::LazyList(ll) if ll.is_genuinely_lazy() => {
+            // A genuinely-lazy list renders raku's placeholder without forcing:
+            // `[...]` held in `@` array context, `(...)` for a bare Seq.
+            crate::value::lazy_list_placeholder("gist", ll.in_array_context())
+        }
         Value::Array(items, kind) => {
             let ptr = std::sync::Arc::as_ptr(items) as usize;
             let is_cycle = SEEN_PTRS.with(|seen| check_and_push(seen, ptr));

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -446,7 +446,26 @@ impl Value {
                 });
                 result
             }
-            Value::LazyList(_) => "LazyList".to_string(),
+            Value::LazyList(ll) => {
+                if ll.is_genuinely_lazy() {
+                    // Str/interpolation of a genuinely-lazy list renders `...`
+                    // (Rakudo) rather than materializing the sequence.
+                    "...".to_string()
+                } else {
+                    // A fully-realized cached lazy list stringifies like a list.
+                    ll.cache
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .map_or_else(String::new, |items| {
+                            items
+                                .iter()
+                                .map(|v| v.to_string_value())
+                                .collect::<Vec<_>>()
+                                .join(" ")
+                        })
+                }
+            }
             Value::LazyIoLines { .. } => "(...)".to_string(),
             Value::Uni(u) => u.text.clone(),
             Value::Hash(items) => {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1936,7 +1936,73 @@ impl Clone for LazyList {
     }
 }
 
+/// Placeholder string rendered for a genuinely-lazy list under
+/// gist/Str/raku/perl, matching Rakudo: `...` for `.Str`, `[...]` for a list
+/// held in `@` array context, `(...)` for a bare Seq.
+pub(crate) fn lazy_list_placeholder(method: &str, array_context: bool) -> String {
+    if method == "Str" {
+        "...".to_string()
+    } else if array_context {
+        "[...]".to_string()
+    } else {
+        "(...)".to_string()
+    }
+}
+
 impl LazyList {
+    /// Marker key inserted into `env` when a lazy list is bound/assigned into
+    /// an `@` array slot. A `Value::LazyList` carries no `[`-vs-`(` context on
+    /// its own, so this flag lets gist/`.WHAT` render `[...]`/`Array` (held in
+    /// `@a`) instead of `(...)`/`Seq` (a bare `$s` Seq).
+    pub(crate) const ARRAY_CONTEXT_MARKER: &'static str = "__mutsu_lazylist_array_context";
+
+    /// Whether this lazy list was assigned into an `@` array (see marker above).
+    pub(crate) fn in_array_context(&self) -> bool {
+        matches!(
+            self.env.get(Self::ARRAY_CONTEXT_MARKER),
+            Some(Value::Bool(true))
+        )
+    }
+
+    /// True when this list is genuinely lazy (`.is-lazy`), so gist/Str/raku
+    /// render a placeholder instead of materializing it.
+    ///
+    /// An infinite sequence/closure/scan/map-grep generator is only ever stored
+    /// as a *live* `LazyList` when actually infinite (finite ones materialize to
+    /// a `Seq`), so those specs are unconditionally lazy. A gather coroutine (or
+    /// unevaluated body), however, is lazy **only** when explicitly marked
+    /// `lazy` — a plain `gather` is `.is-lazy` `False` in Rakudo and must
+    /// materialize on gist/Str rather than render a placeholder.
+    pub(crate) fn is_genuinely_lazy(&self) -> bool {
+        if self.sequence_spec.is_some()
+            || self.lazy_pipe.is_some()
+            || self.closure_seq.is_some()
+            || self.scan_spec.is_some()
+        {
+            return true;
+        }
+        (self.coroutine.is_some() || !self.body.is_empty() || self.compiled_code.is_some())
+            && self.is_lazy_marked()
+    }
+
+    /// Whether this list carries the `lazy` prefix marker (set by the `lazy`
+    /// statement prefix / `.lazy` method).
+    fn is_lazy_marked(&self) -> bool {
+        matches!(
+            self.env.get("__mutsu_preserve_lazy_on_array_assign"),
+            Some(Value::Bool(true))
+        )
+    }
+
+    /// Return a clone of this list tagged as living in `@` array context.
+    pub(crate) fn with_array_context(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned
+            .env
+            .insert(Self::ARRAY_CONTEXT_MARKER.to_string(), Value::Bool(true));
+        cloned
+    }
+
     /// Create a pre-cached lazy list (no body to evaluate).
     pub(crate) fn new_cached(items: Vec<Value>) -> Self {
         Self {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -366,6 +366,21 @@ impl Interpreter {
         } else {
             target
         };
+        // gist/Str/raku/perl of a genuinely-lazy list renders raku's placeholder
+        // (`[...]` in `@` array context, `(...)` for a bare Seq, `...` for Str)
+        // rather than forcing the (possibly infinite) sequence. Must run before
+        // the gather-coroutine force below, which would hang on an infinite list.
+        if let Value::LazyList(ref ll) = target
+            && matches!(method.as_str(), "gist" | "Str" | "raku" | "perl")
+            && ll.is_genuinely_lazy()
+        {
+            self.stack
+                .push(Value::str(crate::value::lazy_list_placeholder(
+                    method.as_str(),
+                    ll.in_array_context(),
+                )));
+            return Ok(());
+        }
         // Lazy `.first` over a gather coroutine: pull incrementally instead of
         // forcing the (possibly infinite) list to completion.
         if let Value::LazyList(ref ll) = target

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -586,11 +586,13 @@ impl Interpreter {
         // `lazy_pipe` and is forced & rendered normally below.
         if let Value::LazyList(ref ll) = target
             && matches!(method, "gist" | "Str" | "raku" | "perl")
-            && (ll.lazy_pipe.is_some() || ll.sequence_spec.is_some())
+            && ll.is_genuinely_lazy()
         {
-            self.stack.push(Value::str(
-                if method == "Str" { "..." } else { "(...)" }.to_string(),
-            ));
+            self.stack
+                .push(Value::str(crate::value::lazy_list_placeholder(
+                    method,
+                    ll.in_array_context(),
+                )));
             return Ok(());
         }
         // Force gather-sourced LazyList before method dispatch for methods that need

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -6254,8 +6254,10 @@ impl Interpreter {
                 }
                 match raw_popped {
                     Value::LazyList(ref list) if list.coroutine.is_some() => {
-                        // Gather-based lazy list with coroutine: preserve laziness
-                        raw_popped
+                        // Gather-based lazy list with coroutine: preserve laziness,
+                        // tagging it as living in `@` array context so gist/`.WHAT`
+                        // render `[...]`/`Array` rather than `(...)`/`Seq`.
+                        Value::LazyList(std::sync::Arc::new(list.with_array_context()))
                     }
                     Value::LazyList(list) => Value::real_array(self.force_lazy_list_vm(&list)?),
                     Value::LazyIoLines { .. } => {
@@ -6268,7 +6270,11 @@ impl Interpreter {
                 match raw_popped {
                     Value::LazyList(list) => {
                         match list.env.get(Self::LAZY_ASSIGN_PRESERVE_MARKER) {
-                            Some(Value::Bool(true)) => Value::LazyList(list),
+                            // Preserved into an `@` array: keep it lazy but tag
+                            // array context so gist/`.WHAT` render `[...]`/`Array`.
+                            Some(Value::Bool(true)) => {
+                                Value::LazyList(std::sync::Arc::new(list.with_array_context()))
+                            }
                             _ => Value::real_array(self.force_lazy_list_vm(&list)?),
                         }
                     }

--- a/t/lazy-list-gist-context.t
+++ b/t/lazy-list-gist-context.t
@@ -1,0 +1,53 @@
+use Test;
+
+# A genuinely-lazy `Value::LazyList` (gather coroutine, sequence, pipeline)
+# renders a bounded placeholder instead of forcing the (possibly infinite)
+# sequence. The placeholder is context-sensitive: `[...]` when held in an `@`
+# array, `(...)` for a bare Seq scalar, `...` under Str/interpolation.
+
+plan 17;
+
+# --- infinite gather held in an @ array ---------------------------------
+{
+    my @a = lazy gather { for 1..* { take $_ } };
+    is @a.WHAT.gist, '(Array)', 'lazy gather in @a reports Array';
+    is @a.gist, '[...]', 'lazy gather array gist is [...]';
+    is @a.Str, '...', 'lazy gather array Str is ...';
+    is @a.raku, '[...]', 'lazy gather array raku is [...]';
+    is @a[5], 6, 'lazy gather array still reifies on index';
+    is @a.head(3).gist, '(1 2 3)', 'lazy gather array head still works';
+}
+
+# --- infinite gather held in a $ scalar (Seq) ---------------------------
+{
+    my $s = lazy gather { for 1..* { take $_ } };
+    is $s.WHAT.gist, '(Seq)', 'lazy gather in $s reports Seq';
+    is $s.gist, '(...)', 'lazy gather scalar gist is (...)';
+    is $s.Str, '...', 'lazy gather scalar Str is ...';
+    is "val=$s", 'val=...', 'lazy gather scalar interpolates as ...';
+}
+
+# --- a FINITE lazy gather is still is-lazy, so it also placeholders ------
+{
+    my @a = lazy gather { take 1; take 2; take 3 };
+    is @a.gist, '[...]', 'finite lazy gather array gist is [...]';
+    my $s = lazy gather { take 1; take 2; take 3 };
+    is $s.gist, '(...)', 'finite lazy gather scalar gist is (...)';
+}
+
+# --- a PLAIN (non-lazy) gather still materializes -----------------------
+{
+    my @a = gather { take 1; take 2 };
+    is @a.is-lazy, False, 'plain gather is not lazy';
+    is @a.gist, '[1 2]', 'plain gather array gist materializes';
+}
+
+# --- infinite range / sequence / map placeholders unchanged -------------
+{
+    my @a = 1..*;
+    is @a.gist, '[...]', 'infinite range array gist is [...]';
+    my $seq = (1 ... *);
+    is $seq.gist, '(...)', 'infinite sequence scalar gist is (...)';
+    my $m = (1..*).map(* + 1);
+    is $m.gist, '(...)', 'infinite map pipeline scalar gist is (...)';
+}


### PR DESCRIPTION
## Summary

Closes the **L1b** blocker in the lazy-infinite-array campaign (`docs/lazy-arrays.md`): a genuinely-lazy `Value::LazyList` (a `lazy gather` coroutine, an infinite sequence/closure/scan spec, or a lazy map/grep pipeline) now renders Rakudo's bounded placeholder under gist/Str/raku/perl/say/print/`~`/interpolation instead of **hanging** (`my @a = lazy gather {...}; @a.gist`) or returning **empty**.

Resolves the **dual-representation wart**: a bare `Value::LazyList` carried no `[`-vs-`(` context, so it could not know whether it lived in an `@` array (`[...]`, `.WHAT` `Array`) or a `$` scalar Seq (`(...)`, `.WHAT` `Seq`). The `@`-assign preserve sites now tag the list with an `ARRAY_CONTEXT_MARKER` env flag, read back via `in_array_context()`.

### Before / after

| expr | raku | mutsu before | mutsu after |
|---|---|---|---|
| `my @a = lazy gather {for 1..* {take \$_}}; @a.gist` | `[...]` | **hang** | `[...]` |
| `…; @a.WHAT` | `(Array)` | `(Seq)` | `(Array)` |
| `my \$s = lazy gather {…}; \$s.gist` | `(...)` | **hang** | `(...)` |
| `"v=\$s"` | `v=...` | `v=LazyList` | `v=...` |
| `my @a = lazy gather {take 1; take 2}; @a.gist` | `[...]` | `(1 2)` | `[...]` |

### Key points
- `is_genuinely_lazy()` gates the **gather family** on the `lazy` prefix marker: a *plain* `gather` is `.is-lazy` `False` in Rakudo and must materialize on gist/Str. This was the regression that gated correctness — `my \list := gather {…}; ~list` must stay `2 4 6 8 10`, not `...` (verified against `roast/S04-statements/gather.t`). Infinite sequence/closure/scan/pipe specs are only stored as a *live* LazyList when actually infinite, so they are unconditionally lazy.
- Guards added to **both** method-dispatch paths — `vm_call_method_ops` (direct calls) and `vm_call_method_mut_ops` (variable-target calls; the latter is the path that hung, since `@a.gist`/`$s.gist` route through `CallMethodMut`) — plus the runtime slow path, `runtime::utils::gist_value`, and `value::display::to_string_value`.
- Indexing (`@a[5]`), `.head(n)`, `for @a {…}` on a lazy list are unchanged (still reify on demand).

Unblocks **L2** (preserving infinite sources as reify LazyLists on `@`-assign instead of capping to an Array).

### Known follow-up
`@a[]` zen-slice **interpolation** of a lazy array still renders empty (the list-flatten interp path, separate from `.Str`); no hang.

## Test
- `t/lazy-list-gist-context.t` (new, 17 subtests)
- `make test` — all 9337 pass
- `roast/S04-statements/gather.t` PASS (regression guard), `S07-iterators/range-iterator.t`, `S03-sequence/misc.t`, `S32-array/create.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)