### PR TITLE
feat(lazy): throw X::Cannot::Lazy on .Int/.Numeric/.end/prefix-+ of a lazy array (L5b)

### DIFF
--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -21,8 +21,14 @@
 - **L5 — lazy `.elems` → X::Cannot::Lazy (DONE, #3310).** A lazy
   `ArrayKind::Lazy` array's `.elems` now throws (was returning the 100k cap).
   Guard added before `as_list_items` in `dispatch_core_numeric`, reusing
-  `range_elems_lazy_failure`. **Still capped (follow-up):** `.Numeric`/`.Int`/
-  `.end`/prefix-`+` on a lazy array return the cap (separate dispatch paths).
+  `range_elems_lazy_failure`. **L5b (DONE):** `.Numeric`/`.Int`/`.Real`/`.end`
+  and prefix-`+` on a lazy array now also throw `X::Cannot::Lazy` (action
+  `.elems`, matching raku). Shared `runtime::utils::cannot_lazy_failure(action)`
+  builds the Failure value; guards in `dispatch_core_coerce` (numeric coercions),
+  `dispatch_core_list` (`.end`), and `vm_misc_ops::exec_num_coerce_op` (prefix
+  `+`). t/lazy-array-numeric.t. **Still capped:** `.elems` on a *finite* `lazy
+  gather` LazyList returns the realized count (raku throws — is-lazy True); the
+  gather `.elems` path special-cases `__mutsu_lazylist_from_gather`, left alone.
 - **L1b — coroutine `Value::LazyList` gist + dual-rep wart (DONE).** A genuinely
   lazy `Value::LazyList` (gather coroutine with the `lazy` marker, infinite
   sequence/closure/scan spec, lazy map/grep pipeline) now renders raku's

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -45,6 +45,17 @@ pub(super) fn dispatch(
     if target.is_range() && matches!(method, "Int" | "Numeric" | "Real" | "Num") {
         return Some(Some(range_numeric_coercion(target, method)));
     }
+    // A lazy (infinite-backed) array numerifies to its element count, which it
+    // cannot report: raku throws `X::Cannot::Lazy` (`Cannot .elems a lazy list`)
+    // for every numeric coercion (`.Int`/`.Numeric`/`.Real`/`.Num`/prefix `+`).
+    // Guard before the per-method arms, which would return the capped backing
+    // length. (`.elems` itself is handled in `dispatch_core_numeric`.)
+    if let Value::Array(_, kind) = target
+        && kind.is_lazy()
+        && matches!(method, "Int" | "Numeric" | "Real" | "Num")
+    {
+        return Some(super::range_elems_lazy_failure("elems"));
+    }
     match method {
         "self" => {
             // For unhandled Failures, .self throws the exception

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -12,6 +12,14 @@ pub(super) fn dispatch(
 ) -> Option<Option<Result<Value, RuntimeError>>> {
     match method {
         "end" => {
+            // A lazy (infinite-backed) array has no last index; raku throws
+            // `X::Cannot::Lazy` (`Cannot .elems a lazy list`) rather than
+            // returning the capped backing's last index.
+            if let Value::Array(_, kind) = target
+                && kind.is_lazy()
+            {
+                return Some(super::range_elems_lazy_failure("elems"));
+            }
             if let Some(items) = target.as_list_items() {
                 return Some(Some(Ok(Value::Int(items.len() as i64 - 1))));
             }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -645,20 +645,7 @@ fn dispatch_capture(
 
 /// Create a X::Cannot::Lazy Failure for .elems on an infinite range.
 fn range_elems_lazy_failure(action: &str) -> Option<Result<Value, RuntimeError>> {
-    let mut ex_attrs = std::collections::HashMap::new();
-    ex_attrs.insert(
-        "message".to_string(),
-        Value::str(format!("Cannot .{} a lazy list", action)),
-    );
-    ex_attrs.insert("action".to_string(), Value::str(format!(".{}", action)));
-    let exception = Value::make_instance(Symbol::intern("X::Cannot::Lazy"), ex_attrs);
-    let mut failure_attrs = std::collections::HashMap::new();
-    failure_attrs.insert("exception".to_string(), exception);
-    failure_attrs.insert("handled".to_string(), Value::Bool(false));
-    Some(Ok(Value::make_instance(
-        Symbol::intern("Failure"),
-        failure_attrs,
-    )))
+    Some(Ok(crate::runtime::utils::cannot_lazy_failure(action)))
 }
 
 fn is_infinite_endpoint(v: &Value) -> bool {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -10,6 +10,23 @@ use num_traits::{Signed, ToPrimitive, Zero};
 /// Maximum number of elements when expanding an infinite range to a list.
 pub(crate) const MAX_RANGE_EXPAND: i64 = 1_000_000;
 
+/// Build the `Failure` value raku yields when a count/numeric coercion is
+/// attempted on a lazy iterable (e.g. `(1..*).elems` / `.Int` / `+@a`):
+/// `X::Cannot::Lazy` with the message `Cannot .<action> a lazy list`.
+pub(crate) fn cannot_lazy_failure(action: &str) -> Value {
+    let mut ex_attrs = HashMap::new();
+    ex_attrs.insert(
+        "message".to_string(),
+        Value::str(format!("Cannot .{} a lazy list", action)),
+    );
+    ex_attrs.insert("action".to_string(), Value::str(format!(".{}", action)));
+    let exception = Value::make_instance(Symbol::intern("X::Cannot::Lazy"), ex_attrs);
+    let mut failure_attrs = HashMap::new();
+    failure_attrs.insert("exception".to_string(), exception);
+    failure_attrs.insert("handled".to_string(), Value::Bool(false));
+    Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+}
+
 /// Saturating conversion of an arbitrary-precision BigInt to i64.
 /// Bag/Set arithmetic helpers operate on i64 maps (min/max/diff semantics
 /// don't need arbitrary precision); a count that overflows i64 saturates.

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -725,6 +725,16 @@ impl Interpreter {
             self.stack.push(Value::junction(kind, results));
             return Ok(());
         }
+        // A lazy (infinite-backed) array numerifies to its element count, which
+        // it cannot report: raku yields an `X::Cannot::Lazy` Failure for
+        // prefix `+` (`Cannot .elems a lazy list`).
+        if let Value::Array(_, kind) = &val
+            && kind.is_lazy()
+        {
+            self.stack
+                .push(crate::runtime::utils::cannot_lazy_failure("elems"));
+            return Ok(());
+        }
         // Type objects (Mu, Any, etc.) cannot be numerically coerced
         if let Value::Package(name) = &val
             && matches!(name.resolve().as_str(), "Mu" | "Any")

--- a/t/lazy-array-numeric.t
+++ b/t/lazy-array-numeric.t
@@ -1,0 +1,47 @@
+use Test;
+
+# A lazy (infinite-backed) array cannot report a finite element count, so every
+# numeric/count coercion throws X::Cannot::Lazy (message `Cannot .elems a lazy
+# list`) rather than returning the internally-capped backing length. This is the
+# L5b follow-up to #3310 (which covered `.elems`).
+
+plan 14;
+
+# --- numeric coercions on an infinite-range array -----------------------
+{
+    my @a = 1..*;
+    throws-like { @a.Int },     X::Cannot::Lazy, '.Int on lazy array throws';
+    throws-like { @a.Numeric }, X::Cannot::Lazy, '.Numeric on lazy array throws';
+    throws-like { @a.Real },    X::Cannot::Lazy, '.Real on lazy array throws';
+    throws-like { @a.end },     X::Cannot::Lazy, '.end on lazy array throws';
+    throws-like { +@a },        X::Cannot::Lazy, 'prefix + on lazy array throws';
+    throws-like { @a.elems },   X::Cannot::Lazy, '.elems on lazy array throws';
+}
+
+# --- the failure is a soft Failure until sunk: // recovers --------------
+{
+    my @a = 1..*;
+    my $n = @a.Int // 'fallback';
+    is $n, 'fallback', '.Int Failure is recoverable with //';
+}
+
+# --- a finite (non-lazy) array still reports its count normally ---------
+{
+    my @a = 1, 2, 3, 4;
+    is +@a,        4, 'prefix + on finite array is the count';
+    is @a.Int,     4, '.Int on finite array is the count';
+    is @a.Numeric, 4, '.Numeric on finite array is the count';
+    is @a.end,     3, '.end on finite array is last index';
+}
+
+{
+    my @a = 1..10;
+    is +@a,    10, 'prefix + on finite range array';
+    is @a.end,  9, '.end on finite range array';
+}
+
+# --- an explicitly-bounded range array is NOT lazy ---------------------
+{
+    my @a = ^5;
+    is +@a, 5, 'prefix + on ^N array';
+}


### PR DESCRIPTION
## Summary

Follow-up to #3310 (which covered `.elems`). A lazy (infinite-backed) `ArrayKind::Lazy` array numerifies to its element count, which it cannot report: raku throws `X::Cannot::Lazy` (`Cannot .elems a lazy list`) for **every** numeric/count coercion. mutsu was returning the internally-capped 100k backing length instead.

| expr | raku | mutsu before | mutsu after |
|---|---|---|---|
| `my @a = 1..*; @a.Int` | `X::Cannot::Lazy` | `100001` | `X::Cannot::Lazy` |
| `@a.Numeric` / `@a.Real` | `X::Cannot::Lazy` | `100001` | `X::Cannot::Lazy` |
| `@a.end` | `X::Cannot::Lazy` | `100000` | `X::Cannot::Lazy` |
| `+@a` | `X::Cannot::Lazy` | `100001` | `X::Cannot::Lazy` |

All of these resolve to `.elems` internally, so the error action is always `.elems` (verified against raku).

### Changes
- `dispatch_core_coerce` — guard `.Int`/`.Numeric`/`.Real`/`.Num` before the per-method arms that read the capped backing.
- `dispatch_core_list` — guard `.end` before `as_list_items`.
- `vm_misc_ops::exec_num_coerce_op` — guard prefix `+` (compiles to `NumCoerce`, which does **not** route through `.Numeric` method dispatch).
- The Failure value is now built by a single shared helper `runtime::utils::cannot_lazy_failure(action)`; the existing `range_elems_lazy_failure` delegates to it.

Finite (non-lazy) arrays are unaffected — `+@a` / `.end` / `.Int` still report the count. The `X::Cannot::Lazy` Failure is soft (recoverable with `//`) until sunk, matching raku.

### Out of scope
`.elems` on a *finite* `lazy gather` LazyList still returns its realized count (raku throws — is-lazy True); the gather elems path special-cases `__mutsu_lazylist_from_gather` and is left alone.

## Test
- `t/lazy-array-numeric.t` (new, 14 subtests)
- `make test` — all 9363 pass
- `roast/S03-operators/range.t`, `range-basic.t`, `S07-iterators/range-iterator.t`, set-op tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)