### PR TITLE
feat(lazy): keep `my @a = 1..*` a reify LazyList so `@a[N]` reifies past the cap (L2a)

### DIFF
--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -50,6 +50,28 @@
   path, separate from `.Str`); no hang. With the dual-rep wart resolved, **L2**
   (preserve infinite Range / closure_seq / lazy_pipe as a reify `LazyList` on
   `@`-assign instead of capping to an Array) is now unblocked.
+- **L2a — `my @a = 1..*` stays a reify `LazyList` (DONE).** An infinite *integer*
+  range assigned to `@a` is converted to a `SequenceSpec::Arithmetic` `LazyList`
+  (array-context tagged) by `runtime::utils::infinite_int_range_to_lazy_array`,
+  seeded with the same 100k prefix `coerce_to_array` would have produced — so
+  eager reads that consume the cache (`.head`/`.first`/`.map`/`.grep`) behave
+  exactly as before, while `@a[N]` past the prefix reifies on demand
+  (`@a[200000]` → 200001, was `Nil`). `.is-lazy`/`.gist`/`.WHAT` and the
+  X::Cannot::Lazy numeric guards (extended to `LazyList` via `is_lazy_count_source`)
+  all stay correct. **Mutation:** end-mutations raku rejects (push/pop/append)
+  throw `X::Cannot::Lazy`; front mutations (unshift/prepend/shift/splice,
+  `@a[i]=v`, `@a[i]:delete`) reify the cached prefix to a real Array first via
+  `reify_lazy_array_slot` (no worse than the pre-L2 capped Array). `@a[i]:exists`
+  answers from the index (any non-negative index exists) without forcing.
+  Chokepoints: `vm_call_method_mut_ops` (method mutators), `vm_data_ops`
+  (ArrayPush opcode), `vm_var_assign_ops` (`@a[i]=v`), `vm_var_delete_ops`
+  (`:delete`), `vm_var_exists_ops` (`:exists`). t/lazy-array-reify.t.
+  **Scope:** only the integer-range case is converted; `(1...*)`/closure-seq/
+  gather arrays are still forced to a capped Array on `@`-assign (converting them
+  too would regress S32-array/create.t's partial-reify, which the capped Array
+  fakes). True memory-laziness (seed `[1]` instead of the 100k prefix, requires
+  `.head`/`.first`/`.map`/`.grep` to extend a `sequence_spec` `LazyList`) is the
+  L2b follow-up.
 
 ## Open findings / blockers discovered this session
 

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -134,10 +134,14 @@ pub(crate) fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
         }
         // Itemized containers — don't descend
         Value::Array(_, kind) if kind.is_itemized() => out.push(v.clone()),
-        // Already-realized lazy lists flatten their cached items; an un-forced
-        // lazy list stays opaque (we don't force here).
+        // A genuinely-lazy `@`-array (`my @a = 1..*`) stays opaque so it renders
+        // as `...`/`[...]` (e.g. in `"@a[]"` interpolation) rather than spilling
+        // its capped backing prefix. Already-realized lazy lists flatten their
+        // cached items; an un-forced lazy list stays opaque (we don't force here).
         Value::LazyList(ll) => {
-            if let Some(cached) = ll.cache.lock().unwrap().clone() {
+            if ll.in_array_context() && ll.is_genuinely_lazy() {
+                out.push(v.clone());
+            } else if let Some(cached) = ll.cache.lock().unwrap().clone() {
                 for item in &cached {
                     flat_val(item, out, flatten_arrays);
                 }

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -50,10 +50,7 @@ pub(super) fn dispatch(
     // for every numeric coercion (`.Int`/`.Numeric`/`.Real`/`.Num`/prefix `+`).
     // Guard before the per-method arms, which would return the capped backing
     // length. (`.elems` itself is handled in `dispatch_core_numeric`.)
-    if let Value::Array(_, kind) = target
-        && kind.is_lazy()
-        && matches!(method, "Int" | "Numeric" | "Real" | "Num")
-    {
+    if matches!(method, "Int" | "Numeric" | "Real" | "Num") && super::is_lazy_count_source(target) {
         return Some(super::range_elems_lazy_failure("elems"));
     }
     match method {

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -12,12 +12,10 @@ pub(super) fn dispatch(
 ) -> Option<Option<Result<Value, RuntimeError>>> {
     match method {
         "end" => {
-            // A lazy (infinite-backed) array has no last index; raku throws
+            // A lazy (infinite-backed) array/list has no last index; raku throws
             // `X::Cannot::Lazy` (`Cannot .elems a lazy list`) rather than
             // returning the capped backing's last index.
-            if let Value::Array(_, kind) = target
-                && kind.is_lazy()
-            {
+            if super::is_lazy_count_source(target) {
                 return Some(super::range_elems_lazy_failure("elems"));
             }
             if let Some(items) = target.as_list_items() {

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -452,6 +452,9 @@ pub(super) fn dispatch(
                     Value::Array(_, k) if *k == crate::value::ArrayKind::Lazy => {
                         "[...]".to_string()
                     }
+                    Value::LazyList(ll) if ll.is_genuinely_lazy() => {
+                        crate::value::lazy_list_placeholder("gist", ll.in_array_context())
+                    }
                     Value::Array(inner, kind) => {
                         let elems = inner.iter().map(gist_item).collect::<Vec<_>>().join(" ");
                         gist_array_wrap(&elems, *kind)
@@ -520,6 +523,9 @@ pub(super) fn dispatch(
                     Value::ContainerRef(cell) => gist_item(&cell.lock().unwrap()),
                     Value::Array(_, k) if *k == crate::value::ArrayKind::Lazy => {
                         "[...]".to_string()
+                    }
+                    Value::LazyList(ll) if ll.is_genuinely_lazy() => {
+                        crate::value::lazy_list_placeholder("gist", ll.in_array_context())
                     }
                     Value::Array(inner, kind) => {
                         let elems = inner.iter().map(gist_item).collect::<Vec<_>>().join(" ");

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -648,6 +648,18 @@ fn range_elems_lazy_failure(action: &str) -> Option<Result<Value, RuntimeError>>
     Some(Ok(crate::runtime::utils::cannot_lazy_failure(action)))
 }
 
+/// True for a value whose element count cannot be reported, so numeric/count
+/// coercions (`.elems`/`.Int`/`.Numeric`/`.end`/prefix `+`) throw
+/// `X::Cannot::Lazy`: a lazy-backed Array or a genuinely-lazy `LazyList`
+/// (infinite sequence/closure/pipe or a `lazy`-marked gather).
+pub(crate) fn is_lazy_count_source(target: &Value) -> bool {
+    match target {
+        Value::Array(_, kind) => kind.is_lazy(),
+        Value::LazyList(ll) => ll.is_genuinely_lazy(),
+        _ => false,
+    }
+}
+
 fn is_infinite_endpoint(v: &Value) -> bool {
     match v {
         Value::Whatever | Value::HyperWhatever => true,

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1059,7 +1059,14 @@ impl Interpreter {
         // list args doesn't panic on an empty slice.
         for v in args.get(1..).unwrap_or(&[]) {
             if let Value::LazyList(list) = v {
-                rest.push(Value::array(self.force_lazy_list(list)?));
+                // A genuinely-lazy `@`-array stays opaque (rendered `...` by
+                // `flat_val`) rather than forcing its capped prefix — this is the
+                // `"@a[]"` interpolation path (`join " ", @a`). (L2)
+                if list.in_array_context() && list.is_genuinely_lazy() {
+                    rest.push(v.clone());
+                } else {
+                    rest.push(Value::array(self.force_lazy_list(list)?));
+                }
             } else {
                 rest.push(v.clone());
             }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -27,6 +27,47 @@ pub(crate) fn cannot_lazy_failure(action: &str) -> Value {
     Value::make_instance(Symbol::intern("Failure"), failure_attrs)
 }
 
+/// If `value` is an infinite *integer* range (`1..*`, `^Inf`, `0..^*`, …),
+/// return a reify-on-demand `LazyList` (arithmetic sequence, step 1) tagged as
+/// living in `@` array context, so `my @a = 1..*` stays lazy (`@a[200000]`
+/// reifies, `@a.gist` is `[...]`, `.elems` throws) instead of being capped to a
+/// 100k `ArrayKind::Lazy` Array. Returns `None` for finite or non-integer
+/// ranges (the caller falls back to `coerce_to_array`).
+pub(crate) fn infinite_int_range_to_lazy_array(value: &Value) -> Option<Value> {
+    use crate::value::{LazyList, SequenceSpec};
+    let start = match value {
+        Value::Range(a, b) | Value::RangeExcl(a, b) if *b == i64::MAX => *a,
+        Value::RangeExclStart(a, b) | Value::RangeExclBoth(a, b) if *b == i64::MAX => *a + 1,
+        Value::GenericRange { start, end, .. } => {
+            let end_f = end.to_f64();
+            if !(end_f.is_infinite() && end_f.is_sign_positive()) {
+                return None;
+            }
+            match start.as_ref() {
+                Value::Int(a) => *a,
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+    // Seed the cache with the same bounded prefix `coerce_to_array` would have
+    // materialized, so eager read operations that consume the cache (`.head`,
+    // `.first`, `.map`, `.grep`, ...) behave exactly as today. The
+    // `SequenceSpec` lets `@a[N]` for `N` past the prefix reify on demand
+    // (`force_lazy_list_vm_n`), which a capped `ArrayKind::Lazy` Array could not.
+    let end = start.saturating_add(MAX_ARRAY_EXPAND);
+    let seeds: Vec<Value> = (start..=end).map(Value::Int).collect();
+    let ll = LazyList::new_sequence(
+        seeds,
+        SequenceSpec::Arithmetic {
+            step: 1,
+            all_int: true,
+        },
+    )
+    .with_array_context();
+    Some(Value::LazyList(Arc::new(ll)))
+}
+
 /// Saturating conversion of an arbitrary-precision BigInt to i64.
 /// Bag/Set arithmetic helpers operate on i64 maps (min/max/diff semantics
 /// don't need arbitrary precision); a count that overflows i64 saturates.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -366,6 +366,37 @@ impl Interpreter {
         } else {
             target
         };
+        // Mutating a lazy `@`-array (infinite source). raku rejects operations
+        // that touch the (non-existent) end — push/pop/append — with
+        // `X::Cannot::Lazy`, but allows front operations (unshift/prepend/shift/
+        // splice), which reify the cached prefix to a real Array first
+        // (no worse than the pre-L2 capped Array). Restricted to cache-backed
+        // specs so the reify never runs user code or hangs. (L2)
+        if let Value::LazyList(ref ll) = target
+            && ll.in_array_context()
+            && ll.is_genuinely_lazy()
+            && let Some(action) = match method.as_str() {
+                "push" => Some("push to"),
+                "pop" => Some("pop from"),
+                "append" => Some("append to"),
+                _ => None,
+            }
+        {
+            return Err(RuntimeError::cannot_lazy_with_action(action, "Array"));
+        }
+        let target = if let Value::LazyList(ref ll) = target
+            && ll.in_array_context()
+            && (ll.sequence_spec.is_some() || ll.closure_seq.is_some() || ll.scan_spec.is_some())
+            && matches!(method.as_str(), "shift" | "unshift" | "prepend" | "splice")
+        {
+            let items = self.force_lazy_list_vm(ll)?;
+            let reified = Value::real_array(items);
+            self.env_mut().insert(target_name.clone(), reified.clone());
+            self.env_dirty = true;
+            reified
+        } else {
+            target
+        };
         // gist/Str/raku/perl of a genuinely-lazy list renders raku's placeholder
         // (`[...]` in `@` array context, `(...)` for a bare Seq, `...` for Str)
         // rather than forcing the (possibly infinite) sequence. Must run before

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -473,6 +473,16 @@ impl Interpreter {
         value_source_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let target_name = Self::const_str(code, target_name_idx);
+        // A lazy `@`-array (infinite source) cannot be pushed to: there is no
+        // end to append after. raku throws `X::Cannot::Lazy`
+        // ("Cannot push to a lazy list onto a Array"). (L2)
+        if let Some(Value::LazyList(ll)) = self.env().get(target_name)
+            && ll.in_array_context()
+            && ll.is_genuinely_lazy()
+        {
+            let _ = self.stack.pop();
+            return Err(RuntimeError::cannot_lazy_with_action("push to", "Array"));
+        }
         // Shared (threaded) context: route an Array push through the atomic
         // shared store so concurrent `@a.push` from multiple threads serialize
         // under the shared_vars write lock instead of clobbering each other's

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -307,6 +307,34 @@ impl Interpreter {
         )
     }
 
+    /// If the variable `name` holds a lazy `@`-array backed by a cache-bearing
+    /// spec (infinite sequence/closure/scan), reify its cached prefix into a
+    /// real Array and write it back, so a subsequent element mutation
+    /// (`@a[i] = v`, `:delete`) operates on a materialized backing. Front
+    /// mutations collapse the list to its prefix (no worse than the pre-L2
+    /// capped Array); reads keep it lazy. Reifies only cache-backed specs, so it
+    /// never runs user code or hangs. (L2)
+    pub(super) fn reify_lazy_array_slot(&mut self, name: &str) -> Result<(), RuntimeError> {
+        let lazy = match self.env().get(name) {
+            Some(Value::LazyList(ll))
+                if ll.in_array_context()
+                    && (ll.sequence_spec.is_some()
+                        || ll.closure_seq.is_some()
+                        || ll.scan_spec.is_some()) =>
+            {
+                Some(ll.clone())
+            }
+            _ => None,
+        };
+        if let Some(ll) = lazy {
+            let items = self.force_lazy_list_vm(&ll)?;
+            self.env_mut()
+                .insert(name.to_string(), Value::real_array(items));
+            self.env_dirty = true;
+        }
+        Ok(())
+    }
+
     pub(super) fn lazy_list_needs_forcing(method: &str) -> bool {
         matches!(
             method,

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -725,12 +725,10 @@ impl Interpreter {
             self.stack.push(Value::junction(kind, results));
             return Ok(());
         }
-        // A lazy (infinite-backed) array numerifies to its element count, which
-        // it cannot report: raku yields an `X::Cannot::Lazy` Failure for
+        // A lazy (infinite-backed) array/list numerifies to its element count,
+        // which it cannot report: raku yields an `X::Cannot::Lazy` Failure for
         // prefix `+` (`Cannot .elems a lazy list`).
-        if let Value::Array(_, kind) = &val
-            && kind.is_lazy()
-        {
+        if crate::builtins::methods_0arg::is_lazy_count_source(&val) {
             self.stack
                 .push(crate::runtime::utils::cannot_lazy_failure("elems"));
             return Ok(());

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2777,6 +2777,9 @@ impl Interpreter {
         name_idx: u32,
         is_positional: bool,
     ) -> Result<(), RuntimeError> {
+        // A lazy `@`-array must reify its prefix before an element assignment
+        // (`@a[i] = v`) — the assign machinery needs a materialized backing. (L2)
+        self.reify_lazy_array_slot(Self::const_str(code, name_idx))?;
         // Slice 2b: `@aoa[i] = @row` / `%h<k> = @row` was compiled as a `:=` bind
         // (so the bind machinery installs a shared `ContainerRef` cell and
         // promotes the source) plus a `MarkElementShare` flag. Capture which
@@ -6281,6 +6284,11 @@ impl Interpreter {
                     Value::LazyIoLines { .. } => {
                         let forced = self.force_if_lazy_io_lines(raw_popped)?;
                         runtime::coerce_to_array(forced)
+                    }
+                    // An infinite integer range (`1..*`) stays a reify LazyList
+                    // instead of being capped to a 100k `ArrayKind::Lazy` Array. (L2)
+                    other if runtime::utils::infinite_int_range_to_lazy_array(&other).is_some() => {
+                        runtime::utils::infinite_int_range_to_lazy_array(&other).unwrap()
                     }
                     other => {
                         // Resolve bound-element sentinels before coercing to

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -160,6 +160,9 @@ impl Interpreter {
         // back through the cell (so every alias observes the delete) and restore
         // the cell in env and the local slot.
         let var_name = Self::const_str(code, name_idx).to_string();
+        // A lazy `@`-array reifies its prefix before an element delete
+        // (`@a[i]:delete`) — delete needs a materialized backing. (L2)
+        self.reify_lazy_array_slot(&var_name)?;
         let bound_cell = match self.env().get(&var_name) {
             Some(Value::ContainerRef(cell)) => Some(cell.clone()),
             _ => None,

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -507,6 +507,27 @@ impl Interpreter {
             (target, idxs)
         };
 
+        // A lazy `@`-array (infinite source) is conceptually unbounded: any
+        // non-negative index exists, without forcing the list (raku). Only the
+        // plain `:exists` form (no :kv/:p adverbs) is special-cased here. (L2)
+        if let Value::LazyList(ll) = &target
+            && ll.in_array_context()
+            && ll.is_genuinely_lazy()
+            && matches!(adverb_bits, 0 | 5)
+            && !is_zen
+        {
+            let vals: Vec<Value> = indices
+                .iter()
+                .map(|&i| Value::Bool((i >= 0) ^ effective_negated))
+                .collect();
+            self.stack.push(if vals.len() == 1 {
+                vals.into_iter().next().unwrap()
+            } else {
+                Value::array(vals)
+            });
+            return Ok(());
+        }
+
         // Uni: check exists based on codepoint count
         if let Value::Uni(u) = &target {
             let len = u.text.chars().count() as i64;

--- a/t/lazy-array-reify.t
+++ b/t/lazy-array-reify.t
@@ -1,0 +1,67 @@
+use Test;
+
+# L2: `my @a = 1..*` keeps `@a` a reify-on-demand lazy array instead of capping
+# it at 100k elements. `@a[N]` reifies past the old cap; reads stay lazy; the
+# mutators raku rejects on a lazy list (push/pop/append) throw X::Cannot::Lazy,
+# while front mutations (unshift/prepend/shift/splice/elem-assign) reify the
+# prefix and operate on it.
+
+plan 22;
+
+# --- reads past the old 100k cap reify on demand ------------------------
+{
+    my @a = 1..*;
+    is @a[200000], 200001, 'index past the cap reifies';
+    is @a.is-lazy,  True,  'infinite-range array is lazy';
+    is @a.gist,     '[...]', 'lazy array gist is [...]';
+    is @a.WHAT.gist, '(Array)', 'lazy array WHAT is Array';
+    is-deeply @a[^5].List, (1, 2, 3, 4, 5), 'leading slice reifies';
+    is @a.head(3).List, (1, 2, 3), 'head reifies the prefix';
+    is @a.first(* > 3), 4, 'first pulls until the predicate matches';
+    is @a.map(* * 2).head(3).List, (2, 4, 6), 'map keeps laziness';
+}
+
+# --- `.elems`/numeric coercions still throw X::Cannot::Lazy ------------
+{
+    my @a = 1..*;
+    throws-like { @a.elems }, X::Cannot::Lazy, '.elems throws';
+    throws-like { @a.Int },   X::Cannot::Lazy, '.Int throws';
+    throws-like { +@a },      X::Cannot::Lazy, 'prefix + throws';
+}
+
+# --- end-mutations raku rejects on a lazy list throw -------------------
+{
+    throws-like { my @a = 1..*; @a.push(9) },   X::Cannot::Lazy, 'push throws';
+    throws-like { my @a = 1..*; @a.pop },        X::Cannot::Lazy, 'pop throws';
+    throws-like { my @a = 1..*; @a.append(9) },  X::Cannot::Lazy, 'append throws';
+}
+
+# --- front-mutations reify the prefix and operate -----------------------
+{
+    my @a = 1..*;
+    @a.unshift(100);
+    is @a[0], 100, 'unshift prepends';
+    is @a[1], 1,   'unshift keeps the prefix';
+}
+{
+    my @a = 1..*;
+    is @a.shift, 1, 'shift returns the head';
+    is @a[0], 2,    'shift advances the front';
+}
+{
+    my @a = 1..*;
+    @a[2] = 99;
+    is-deeply @a[^5].List, (1, 2, 99, 4, 5), 'elem-assign partially reifies';
+}
+
+# --- :exists / :delete on a lazy array ---------------------------------
+{
+    my @a = 1..*;
+    is @a[3]:exists,        True, ':exists is True within reach';
+    is @a[1000000]:exists,  True, ':exists is True past the old cap';
+}
+{
+    my @a = 1..*;
+    @a[3]:delete;
+    is-deeply @a[^5].List, (1, 2, 3, Any, 5), ':delete reifies and removes';
+}


### PR DESCRIPTION
## Summary

Continues the lazy-infinite-array campaign (`docs/lazy-arrays.md`, **L2a**). `my @a = 1..*` was capped to a 100k `ArrayKind::Lazy` Array, so `@a[200000]` returned `Nil` (raku: `200001`). It now stays a reify-on-demand `SequenceSpec::Arithmetic` `LazyList` (array-context tagged), **seeded with the same 100k prefix** `coerce_to_array` produced — so eager reads that consume the cache (`.head`/`.first`/`.map`/`.grep`) behave exactly as before, while indexing past the prefix reifies on demand.

| expr | raku | before | after |
|---|---|---|---|
| `my @a = 1..*; @a[200000]` | `200001` | `Nil` | `200001` |
| `@a.is-lazy` / `.gist` / `.WHAT` | `True` / `[...]` / `Array` | ✓ | ✓ |
| `@a.head(3)` / `.first(*>3)` / `.map(*×2).head(3)` | works | works | works |
| `@a.elems` / `.Int` / `+@a` / `.end` | `X::Cannot::Lazy` | mixed | `X::Cannot::Lazy` |
| `@a.push(9)` / `.pop` / `.append` | `X::Cannot::Lazy` | (succeeded) | `X::Cannot::Lazy` |
| `@a.unshift(100)` / `.shift` / `@a[2]=99` | works (partial-reify) | works | works |
| `@a[3]:exists` / `@a[1000000]:exists` | `True` | `True`/`False` | `True`/`True` |

## How

- **Conversion**: `runtime::utils::infinite_int_range_to_lazy_array`, applied at the `@`-assign site (NOT in `coerce_to_array`, which stays Array-returning).
- **Numeric guards**: the L5b `X::Cannot::Lazy` guards now also fire for a genuinely-lazy `LazyList` via the shared `is_lazy_count_source`.
- **Mutation**: push/pop/append throw (no end to append to); unshift/prepend/shift/splice + `@a[i]=v` + `@a[i]:delete` reify the cached prefix first via `reify_lazy_array_slot` (no worse than the pre-L2 capped Array). `@a[i]:exists` answers from the index without forcing.
- **Rendering coverage** extended to a genuinely-lazy `LazyList` so the type switch is invisible: nested gist, `"@a[]"` interpolation (`flat_val` + `builtin_join` keep it opaque), `gist_value`, `to_string_value`.

## Scope / follow-up

Only the **integer-range** case is converted. `(1...*)`/closure-seq/gather arrays are still forced to a capped Array on `@`-assign — converting them too would regress `S32-array/create.t`'s partial-reify (which the capped Array fakes). True memory-laziness (seed `[1]` + `.head`/`.first`/`.map`/`.grep` extending a `sequence_spec` `LazyList`) is the **L2b** follow-up. This PR has no whitelist payoff on its own; it is a foundational correctness step (`@a[N>cap]` reify + correct lazy mutation/coercion semantics).

## Test
- `t/lazy-array-reify.t` (new, 22 subtests) + `t/lazy-array-gist.t`/`t/lazy-array-numeric.t`/`t/lazy-list-gist-context.t` still green.
- `make test` — all 9385 pass.
- Targeted roast (S32-array create/delete/push/unshift, S09-subscript array/slice, S32-list flat/join/grep/map/first, S03 range/reduce/eqv, S07-iterators) — no new regressions (slice.t/for.t/array.t/eqv.t failures are pre-existing, identical on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)