### PR TITLE
docs(lazy): record L1b/L5b/L2a + ready-to-execute L2b plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -57,11 +57,16 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
 
 - [ ] **残りの型付き例外**（X::Str::Numeric / X::Method::NotFound / X::Undeclared / X::Cannot::Lazy /
       X::EXPORTHOW::InvalidDirective 等）。詳細は BLOCKERS.md "throws-like / Exception Types"。
-- [ ] **真の lazy 無限配列**（`my @a = 1..*` の reify-on-demand）。設計＝[docs/lazy-arrays.md](docs/lazy-arrays.md)。
-      reify 基盤（scalar/gather coroutine 経由の index pull）は既存。残＝① 無限 Range/`...` 列を `@` 代入時に
-      capped Array へ潰さず reify LazyList のまま保持（L2）② mutation chokepoint で reify-on-write（L3・~10箇所・回帰注意）
-      ③ lazy `.gist`/`.is-lazy`（L1/L5）④ slurpy 真 lazy 化（L4）。**slurpy `*@`/`+@` 無限 Range ハングは cap で解消済**
-      （#3302 予定・docs L4 の暫定）。unblock: slurpy-params.t / slice.t / eqv.t lazy。
+- [ ] **真の lazy 無限配列**（`my @a = 1..*` の reify-on-demand）。設計＋次の一手＝[docs/lazy-arrays.md](docs/lazy-arrays.md)。
+      **DONE（→ news/2026-06）**: L1/L1b（lazy `.gist`/`.Str`/dual-rep `[`vs`(`・#3306/#3313）、
+      L5/L5b（lazy `.elems`/`.Int`/`.Numeric`/`.end`/`+@a`→X::Cannot::Lazy・#3310/#3314）、
+      **L2a**（`my @a = 1..*` を reify LazyList で保持し `@a[200000]`→200001。整数レンジのみ。
+      mutation: push/pop/append→throw、front-mut→reify-prefix・#3315）。
+      **NEXT = L2b**（真のメモリ遅延化: seed `[1]`・docs/lazy-arrays.md「L2b」節に実行プラン確定済。
+      拡張機構は全て既存＝`from_gather` ゲートを `is_genuinely_lazy` に拡張するだけ。落とし穴=
+      `reify_lazy_array_slot` を `force_lazy_list_vm_n(MAX_ARRAY_EXPAND)` に。whitelist payoff なし）。
+      残＝L2b → `(1...*)`/closure 配列も変換 → L4 slurpy 真 lazy 化。**slurpy 無限 Range ハングは cap 解消済**。
+      whitelist payoff（slurpy-params.t/slice.t）は別軸＝Seq single-pass consumption（`X::Seq::Consumed`）。
 - [ ] **Match キャプチャ番号付け / コンテナ kind**: (1) `$<x>=(...)` が positional スロットにも重複格納され番号がずれる
       （`/$<x>=(\w)(\d)/`）、(2) `m:g//` を `my @m` 代入後 `@m.gist` が `(…)` を返す（receiver の List-kind dual-store ナンス）。
 - [ ] Lookbehind assertions (`<!after>`) / `:Perl5` modifier edge cases。

--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -71,7 +71,77 @@
   too would regress S32-array/create.t's partial-reify, which the capped Array
   fakes). True memory-laziness (seed `[1]` instead of the 100k prefix, requires
   `.head`/`.first`/`.map`/`.grep` to extend a `sequence_spec` `LazyList`) is the
-  L2b follow-up.
+  L2b follow-up (planned below).
+
+## L2b — true memory-laziness (READY TO EXECUTE, scoped 2026-06-20)
+
+**Goal:** seed `infinite_int_range_to_lazy_array` with `[start]` instead of the
+100k prefix, so `my @a = 1..*` is O(1) memory. This requires `.head`/`.first`/
+`.map`/`.grep` (and any cache-reading mutation reify) to *extend* a
+`sequence_spec`/`closure_seq` `LazyList` on demand instead of reading its (now
+tiny) cache.
+
+**Feasibility CONFIRMED — all extension machinery already exists; L2b is mostly
+broadening `__mutsu_lazylist_from_gather` gates to `is_genuinely_lazy()`:**
+- `force_lazy_list_vm_n(list, n)` (`vm_helpers.rs:604`) already extends EVERY lazy
+  kind to `n` elements: cache → `sequence_spec` (`extend_sequence_cache`) →
+  `closure_seq` (`extend_closure_sequence`) → `lazy_pipe` (`force_lazy_pipe`) →
+  coroutine. This is the universal bounded pull. (Proven: `@a[200000]`→200001.)
+- `pull_source_element` (`vm_helpers.rs:1028`) already has a `Value::LazyList`
+  arm that calls `force_lazy_list_vm_n(ll, idx+1)` — so a `lazy_pipe` whose
+  *source* is a `sequence_spec` LazyList pulls correctly.
+- `try_lazy_gather_first` (`vm_native_first.rs:97`) already pulls one element at a
+  time via `force_lazy_list_vm_n` and tests the matcher — generic over ANY
+  LazyList, only the *call site* is gated on `from_gather`.
+
+**The catch (don't miss):** `reify_lazy_array_slot` (`vm_helpers.rs`) currently
+calls `force_lazy_list_vm` (returns the CACHE). With seed `[1]` the cache is
+`[1]`, so a front-mutation (`@a.shift`/`@a[2]=99`) would reify to `[1]`, losing
+the prefix. **Change it to `force_lazy_list_vm_n(ll, MAX_ARRAY_EXPAND)`** so the
+reify materializes a 100k prefix (matching today's reify-to-cap). Same for any
+other site that read the cache assuming it held the prefix.
+
+**Concrete edits:**
+1. `runtime::utils::infinite_int_range_to_lazy_array` — seed `vec![Value::Int(start)]`.
+2. `.head`: broaden the force-block gate in BOTH `vm_call_method_ops.rs` (the
+   `lazy_list_needs_forcing` block, ~line 619 on main 2026-06-20) and
+   `vm_call_method_mut_ops.rs` (~line 430) from the `__mutsu_lazylist_from_gather`
+   marker to `ll.is_genuinely_lazy()`. `gather_head_bound`→`Some(n)`→
+   `force_lazy_list_vm_n` already does the right thing. The `None =>`
+   unbounded-force arm must throw `cannot_lazy` for an infinite list
+   (`sequence_spec`/`closure_seq`/`lazy_pipe`) instead of `force_lazy_list_vm`
+   (which returns the small cache → wrong for `.sort`/`.reverse`/...).
+3. `.first`: broaden the `.first` gate in BOTH `vm_call_method_ops.rs` (~line 608,
+   the block guarding `try_lazy_gather_first`) and `vm_call_method_mut_ops.rs`
+   (~line 419) from `from_gather` to `is_genuinely_lazy()`. Handler is already
+   generic. (Infinite + unsatisfiable predicate loops forever — raku hangs too;
+   acceptable.)  [verify the 4 `__mutsu_lazylist_from_gather` sites with
+   `grep -n __mutsu_lazylist_from_gather src/vm/vm_call_method*.rs`.]
+4. `.map`/`.grep`: `Interpreter::is_lazy_pipe_source` (`methods_collection.rs:53`)
+   — add `Value::LazyList(ll) if ll.sequence_spec.is_some() || ll.closure_seq.is_some()`.
+   `force_lazy_pipe`+`pull_source_element` then pull from the sequence on demand.
+5. `reify_lazy_array_slot` — switch `force_lazy_list_vm` → `force_lazy_list_vm_n(ll,
+   MAX_ARRAY_EXPAND)` (see "the catch" above).
+6. Once steps 1–5 land for integer ranges, **also convert `(1...*)`/closure-seq
+   arrays** in the `@`-assign LazyList arm (re-add the `is_genuinely_lazy()`
+   preserve that L2a reverted) — but ONLY after confirming S32-array/create.t's
+   partial-reify still passes (the create.t `1,{rand}…*` closure array does
+   `@a[^20]` then unshift/shift/`@b[5]=42`; the reify-prefix fix in step 5 should
+   make it pass since reify now materializes a real prefix).
+
+**Validation (expect the L2a 6-wave tail to re-surface — re-run ALL of these):**
+`make test` + `t/lazy-array-reify.t` + `t/lazy-array-gist.t` +
+`t/lazy-array-numeric.t`, then targeted roast S32-array/create.t,
+delete-adverb*.t, S09-subscript/{array,slice}.t, S32-list/{flat,join,grep,map,
+first,head-tail}.t, S03-sequence/misc.t, S07-iterators/range-iterator.t. The
+high-blast-radius rendering/interp paths (`flat_val`, `builtin_join`, nested
+`gist_item`) already handle a genuinely-lazy LazyList regardless of cache size,
+so they should NOT regress — but `make test` is the net; let CI's full roast be
+the comprehensive one (L2a passed CI with no 7th wave).
+
+**No whitelist payoff** (memory optimization). The slurpy-params.t (6 fails) /
+slice.t (9 fails) payoff needs a *different* track (Seq single-pass consumption /
+`X::Seq::Consumed`), not lazy arrays.
 
 ## Open findings / blockers discovered this session
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1097,3 +1097,25 @@ write-through。topic（`$_++`/`$_=X`）/ named rw（`-> $v is rw`）/ kv（`-> 
 を網羅、非-bound hash の writeback は不変。pin=`t/bound-hash-for-values-rw.t`(11)。**∴ bound array/hash の for-rw site A は
 両方完了。Stage 1 の残=bug②（deref bind `my @a := @$n`＝writeback でなく bind 確立の問題）と、その他 write サイト（push/
 delete/junction index assign の bound-container 経路）。**
+
+### 2026-06-19〜20: 遅延無限配列キャンペーン L1b / L5b / L2a（3 PR）
+
+`docs/lazy-arrays.md` の reify-on-demand キャンペーンを大きく前進。
+
+- **#3313 L1b** — 変数に入った coroutine `LazyList` への `.gist`/`.Str` が CallMethodMut 経由で**ハング**していたのを修正。
+  コンテキスト依存プレースホルダ（`@a`内→`[...]`、bare `$s`→`(...)`、`LazyList::ARRAY_CONTEXT_MARKER` で判別）。
+  **dual-rep wart 解消**: `Value::LazyList` は `[`vs`(` 文脈を持たないため、`@`代入の保存サイトで env マーカーを付与し
+  gist/`.WHAT` が読む。`is_genuinely_lazy()` は gather 系を `lazy` マーカーでゲート（素の gather は is-lazy False →
+  実体化。`gather.t` t14/t17 が初回実装の回帰を検出）。`value::lazy_list_placeholder` 共有。t/lazy-list-gist-context.t。
+- **#3314 L5b** — lazy 配列の `.Int`/`.Numeric`/`.Real`/`.end`/前置 `+` も `X::Cannot::Lazy`（従来 100k cap を返却）。
+  共有 `runtime::utils::cannot_lazy_failure`。t/lazy-array-numeric.t。
+- **#3315 L2a 本丸** — `my @a = 1..*` が 100k で打ち切られず **reify `SequenceSpec::Arithmetic` LazyList** のまま保持。
+  `@a[200000]`→200001（従来 Nil）。100k プレフィックスをシードするため `.head`/`.first`/`.map`/`.grep` は従来通り。
+  **6 波の回帰テールを全解消**（read-ops→mutation→exists/delete→numeric→nested-gist→interp）。
+  mutation: push/pop/append→throw（末尾なし）、unshift/shift/splice/`@a[i]=v`/`:delete`→reify-prefix
+  （`reify_lazy_array_slot`）。`@a[i]:exists` は index から回答（非負→True）。レンダリング網羅を genuinely-lazy LazyList へ
+  拡張（`flat_val`/`builtin_join` opaque 化、nested `gist_item`）。**整数レンジのみ変換**（`(1...*)`/closure は create.t の
+  partial-reify を守るため capped Array 維持）。高ブラスト半径だが CI full roast を 7 波目なしで通過。t/lazy-array-reify.t。
+
+**次の一手 = L2b**（真のメモリ遅延化: seed `[1]`）は `docs/lazy-arrays.md`「L2b」節に実行プラン確定済（拡張機構は全て既存・
+`from_gather` ゲートを `is_genuinely_lazy` に拡張するだけ・落とし穴は `reify_lazy_array_slot` の prefix プル化）。


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the lazy-infinite-array PRs #3313 (L1b) / #3314 (L5b) / #3315 (L2a). Prepares the next session to pick up **L2b** (true memory-laziness) without re-investigation.

- **docs/lazy-arrays.md** — adds the L2a progress entry and a full, line-referenced **L2b execution plan**. Key finding: L2b's extension machinery already exists (`force_lazy_list_vm_n` extends every lazy kind; `pull_source_element` already has a `LazyList` arm; `try_lazy_gather_first` is generic), so L2b is mostly broadening the `__mutsu_lazylist_from_gather` dispatch gates to `is_genuinely_lazy()` + seeding `[1]`. Records the one subtle catch (`reify_lazy_array_slot` must pull a prefix via `force_lazy_list_vm_n`, not read the now-tiny cache) and the L2a 6-wave regression-tail validation watch-list.
- **PLAN.md** — marks L1/L1b/L5/L5b/L2a done; NEXT = L2b.
- **news/2026-06.md** — records the three merged PRs.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)