### PR TITLE
feat(single-store): write a sigilless param's caller-alias mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1652,6 +1652,12 @@ impl Interpreter {
             self.set_env_with_main_alias(&current_alias, val.clone());
             self.update_local_if_exists(code, &current_alias, val);
             self.write_self_attr_cell(&current_alias, val.clone());
+            // Slice F: an inc/dec through a sigilless param (`\target`) aliases a
+            // caller variable; record it so the call-site drain writes the env
+            // value through to the caller's local slot (without relying on the
+            // reverse `sync_locals_from_env` pull).
+            self.pending_rw_writeback_sources
+                .push(current_alias.clone());
             let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
             alias_name = self.env().get(&next_key).and_then(|v| {
                 if let Value::Str(n) = v {
@@ -6849,6 +6855,11 @@ impl Interpreter {
             // Sigilless attribute write: mirror an attr-twigil alias (`!x`) into
             // self's shared cell (no-op for non-attribute aliases). Stage 2c (ii).
             self.write_self_attr_cell(&current_alias, val.clone());
+            // Slice F: a sigilless param (`\target`) aliases a caller variable;
+            // record it so the call-site drain writes the env value through to the
+            // caller's local slot (without relying on the reverse pull).
+            self.pending_rw_writeback_sources
+                .push(current_alias.clone());
             let next_key = format!("__mutsu_sigilless_alias::{}", current_alias);
             alias_name = self.env().get(&next_key).and_then(|v| {
                 if let Value::Str(name) = v {
@@ -7260,7 +7271,12 @@ impl Interpreter {
             }
         }) {
             self.update_local_if_exists(code, &alias_name, &val);
-            self.env_mut().insert(alias_name, val.clone());
+            self.env_mut().insert(alias_name.clone(), val.clone());
+            // Slice F: a sigilless param (`\target`) aliases a caller variable;
+            // the env write above is the only thing that reaches it. Record the
+            // alias target so the call-site drain writes it through to the
+            // caller's local slot (no-op if it is not a caller local).
+            self.pending_rw_writeback_sources.push(alias_name);
         }
         if let Some(attr) = name.strip_prefix('.') {
             self.env_mut().insert(format!("!{}", attr), val.clone());

--- a/t/sigilless-alias-writeback-coherence.t
+++ b/t/sigilless-alias-writeback-coherence.t
@@ -1,0 +1,76 @@
+use Test;
+
+# Slice F (env<->locals coherence): a sigilless parameter (`\target`) aliases the
+# caller's variable. Writing to the alias inside the sub must update the caller's
+# variable. The write reaches `env` by name; this pins that the call-site drains
+# the write through to the caller's local slot, so the behavior no longer depends
+# on the reverse `sync_locals_from_env` pull. Run with `MUTSU_NO_REVERSE_SYNC=1`
+# to confirm coherence without the reverse pull.
+
+plan 16;
+
+# Bare-statement assignment through a sigilless alias (SetLocal opcode).
+sub set-str(\t) { t = "hi" }
+my $s = "x";
+set-str($s);
+is $s, "hi", 'bare assign through sigilless alias updates caller';
+
+# Parenthesized-expression assignment (AssignExprLocal opcode).
+sub set-in-parens(\t) { my $r = (t = 100); $r }
+my $p = 0;
+is set-in-parens($p), 100, 'parenthesized assign returns value';
+is $p, 100, 'parenthesized assign updates caller';
+
+# `try` wrapping an assignment to a mutable alias.
+sub try-assign(\target, \value) { (try target = value) }
+my $x = 10;
+is try-assign($x, 999), 999, 'try-assign returns assigned value';
+is $x, 999, 'try-assign updates caller scalar';
+
+# Immutable literal target: assignment fails, try returns Nil, caller untouched.
+is try-assign(42, 7), Nil, 'try-assign to immutable returns Nil';
+
+# Post-increment through a sigilless alias.
+sub bump(\t) { t++ }
+my $a = 5;
+bump($a);
+is $a, 6, 'post-increment through sigilless alias updates caller';
+
+# Post-decrement through a sigilless alias.
+sub dec1(\t) { t-- }
+my $d = 5;
+dec1($d);
+is $d, 4, 'post-decrement through sigilless alias updates caller';
+
+# Compound assignment through a sigilless alias.
+sub addit(\t) { t += 10 }
+my $c = 1;
+addit($c);
+is $c, 11, 'compound += through sigilless alias updates caller';
+
+# Two sigilless params both mutated in one call.
+sub set-both(\p, \q) { p = 1; q = 2 }
+my $u = 0;
+my $v = 0;
+set-both($u, $v);
+is $u, 1, 'first sigilless param updated';
+is $v, 2, 'second sigilless param updated';
+
+# Alias write used as part of an argument list (return-value coherence).
+sub multi-arg(\target, \value) { my @r = ((try target = value), value); @r }
+my $z = 0;
+is-deeply multi-arg($z, 42), [42, 42], 'alias assignment inside an argument list';
+is $z, 42, 'caller updated via alias assignment in argument list';
+
+# String value, then read back twice (no stale slot between reads).
+sub append-x(\t) { t = t ~ "!" }
+my $w = "go";
+append-x($w);
+is $w, "go!", 'read-modify-write through alias updates caller';
+is $w.chars, 3, 'caller slot is coherent for a subsequent method call';
+
+# Mutating a caller scalar that is itself read afterwards in a larger expression.
+sub set42(\t) { t = 42 }
+my $n = 0;
+set42($n);
+is $n + 8, 50, 'caller slot coherent inside a later arithmetic expression';


### PR DESCRIPTION
## Summary

A sigilless parameter (`\target`) aliases the caller's variable. Mutating the alias inside the sub (`target = v`, `target++`, `target += n`) follows the `__mutsu_sigilless_alias::` chain and writes the new value into `env` by the caller's name, but the caller's **local slot** was only kept coherent by the reverse `sync_locals_from_env` pull. Under `MUTSU_NO_REVERSE_SYNC=1` the caller scalar stayed stale.

This is the next slice of the dual-store write-through grind (continuing #3304–#3311, #3317): fold the sigilless-alias by-name writer into the `pending_rw_writeback_sources` call-site write-through mechanism so the behavior no longer depends on the reverse pull.

## Change

Record each alias target in `pending_rw_writeback_sources` from the three sigilless-alias write paths:
- `propagate_sigilless_alias_chain` — inc/dec (`target++` / `target--`)
- `exec_set_local_op_inner` slow-path alias chain — bare-statement assign (`target = v`)
- `exec_assign_expr_local_op_inner` slow path — parenthesized-expression assign (`(target = v)`)

The existing call-site drain (`apply_pending_rw_writeback`, wired on ExecCall etc.) writes the env value straight through to the caller's local slot, skipping `HashSlotRef` binding slots exactly like the reverse pull. Names that are not a caller local are dropped.

This removes `t/bareword-assign-expr.t` from the reverse-sync dependency surface.

## Tests

- pin: `t/sigilless-alias-writeback-coherence.t` (16 cases, `ON == OFF == raku`)
- `make test` PASS (9411 tests), no regressions
- `t/bareword-assign-expr.t` now passes with `MUTSU_NO_REVERSE_SYNC=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)