### PR TITLE
feat(lazy): make `my @a = 1..*` truly O(1)-memory lazy (L2b)

### DIFF
--- a/docs/lazy-arrays.md
+++ b/docs/lazy-arrays.md
@@ -73,7 +73,30 @@
   `.head`/`.first`/`.map`/`.grep` to extend a `sequence_spec` `LazyList`) is the
   L2b follow-up (planned below).
 
-## L2b — true memory-laziness (READY TO EXECUTE, scoped 2026-06-20)
+## L2b — true memory-laziness (DONE 2026-06-20, PR #3319)
+
+**Shipped.** `infinite_int_range_to_lazy_array` now seeds `[start]`, so
+`my @a = 1..*` is O(1) memory. Read ops extend the sequence on demand:
+- `.head(n)`/`.first` → bounded incremental pull (`force_lazy_list_vm_n` /
+  `try_lazy_gather_first`);
+- `.map`/`.grep` → lazy pipe (`is_lazy_pipe_source` now true for
+  `sequence_spec`/`closure_seq`; the VM force gates + the interpreter force block
+  in `methods.rs` + the `@a.map` rw fast path in `methods_mut.rs` all exclude
+  infinite specs for map/grep/coercions);
+- `.elems`/`.Int`/`.Numeric` → soft `X::Cannot::Lazy` `Failure` (unchanged);
+- `.sort`/`.reverse`/… → `X::Cannot::Lazy` hard throw.
+
+The gate is expressed by new `LazyList::{is_from_gather,is_infinite_spec,
+needs_vm_lazy_dispatch}`. **The catch (handled):** `force_lazy_list_vm` and
+`reify_lazy_array_slot` now *extend* a sequence spec to the 100k cap rather than
+reading the O(1) seed cache, so a strict force / front mutation still gets a real
+prefix. t/lazy-array-reify.t gained 3 fresh-`1..*` map/grep cases; the reify test
+runs in 0.06 CPU (was 1.8) — confirming the O(1) read path. **Still deferred to
+step 6:** converting `(1...*)`/closure-seq arrays at `@`-assign (gated on
+S32-array/create.t partial-reify surviving). Original plan kept below for
+reference.
+
+### Original plan (executed above)
 
 **Goal:** seed `infinite_int_range_to_lazy_array` with `[start]` instead of the
 100k prefix, so `my @a = 1..*` is O(1) memory. This requires `.head`/`.first`/

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3134,11 +3134,12 @@ impl Interpreter {
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target
             && Self::should_force_lazy_list(method)
-            // A chained `.map`/`.grep` on a lazy map/grep pipeline appends
-            // another lazy stage (`dispatch_map_method`/`dispatch_grep`); a
-            // laziness-preserving coercion returns the pipeline unchanged.
-            // Neither forces the (possibly infinite) pipeline.
-            && !(ll.lazy_pipe.is_some()
+            // A chained `.map`/`.grep` on a lazy map/grep pipeline OR an infinite
+            // sequence/closure spec appends another lazy stage
+            // (`dispatch_map_method`/`dispatch_grep` via `is_lazy_pipe_source`); a
+            // laziness-preserving coercion returns the list unchanged. Neither
+            // forces the (possibly infinite) sequence (L2b).
+            && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && (matches!(method, "map" | "grep")
                     || crate::runtime::Interpreter::lazy_pipe_preserving_coercion(method)))
         {

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -62,7 +62,11 @@ impl Interpreter {
                 let end_f = end.to_f64();
                 end_f.is_infinite() && end_f.is_sign_positive()
             }
-            Value::LazyList(ll) => ll.lazy_pipe.is_some(),
+            // A lazy pipe, or an infinite arithmetic/geometric/closure sequence
+            // (`1..*`, `1,2,3...*`, `1,1,*+*...*`): `.map`/`.grep` append another
+            // pipe stage that pulls from the sequence on demand (L2b), instead of
+            // materializing the (now O(1)-seeded) cache.
+            Value::LazyList(ll) => ll.lazy_pipe.is_some() || ll.is_infinite_spec(),
             _ => false,
         }
     }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -3070,7 +3070,14 @@ impl Interpreter {
 
         // map with rw binding: mutations to $_ inside map should write back to the
         // source array elements (Raku semantics: $_ is rw-bound in map).
-        if method == "map" && target_var.starts_with('@') {
+        // The rw-map fast path materializes the source (for `$_`-mutating blocks
+        // like `@a.map({ $_++ })`). An infinite sequence/closure spec must stay
+        // lazy — fall through to the lazy `map` pipeline in `call_method_with_values`
+        // (L2b). Writeback is meaningless on an unbounded array anyway.
+        if method == "map"
+            && target_var.starts_with('@')
+            && !matches!(&target, Value::LazyList(ll) if ll.is_infinite_spec())
+        {
             let mut items = if crate::runtime::utils::is_shaped_array(&target) {
                 crate::runtime::utils::shaped_array_leaves(&target)
             } else {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -50,13 +50,12 @@ pub(crate) fn infinite_int_range_to_lazy_array(value: &Value) -> Option<Value> {
         }
         _ => return None,
     };
-    // Seed the cache with the same bounded prefix `coerce_to_array` would have
-    // materialized, so eager read operations that consume the cache (`.head`,
-    // `.first`, `.map`, `.grep`, ...) behave exactly as today. The
-    // `SequenceSpec` lets `@a[N]` for `N` past the prefix reify on demand
-    // (`force_lazy_list_vm_n`), which a capped `ArrayKind::Lazy` Array could not.
-    let end = start.saturating_add(MAX_ARRAY_EXPAND);
-    let seeds: Vec<Value> = (start..=end).map(Value::Int).collect();
+    // Seed the cache with just the start element — true memory-laziness (L2b).
+    // The `SequenceSpec` lets every read op extend the cache on demand:
+    // `@a[N]` (`force_lazy_list_vm_n`), `.head(n)`/`.first` (bounded pull),
+    // `.map`/`.grep` (lazy pipe over the sequence). This makes `my @a = 1..*`
+    // O(1) memory instead of materializing a 100k-element prefix.
+    let seeds: Vec<Value> = vec![Value::Int(start)];
     let ll = LazyList::new_sequence(
         seeds,
         SequenceSpec::Arithmetic {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1985,6 +1985,30 @@ impl LazyList {
             && self.is_lazy_marked()
     }
 
+    /// Whether this list was produced from a `gather` block (carries the
+    /// `__mutsu_lazylist_from_gather` env marker).
+    pub(crate) fn is_from_gather(&self) -> bool {
+        matches!(
+            self.env.get("__mutsu_lazylist_from_gather"),
+            Some(Value::Bool(true))
+        )
+    }
+
+    /// Whether this list is an infinite arithmetic/geometric sequence
+    /// (`1..*`, `1,2,3...*`) or an infinite closure sequence (`1,1,*+*...*`).
+    /// These reify on demand via `force_lazy_list_vm_n` (`extend_sequence_cache`
+    /// / `extend_closure_sequence`), so a method that needs the whole list must
+    /// raise `X::Cannot::Lazy` rather than read the (tiny) seed cache (L2b).
+    pub(crate) fn is_infinite_spec(&self) -> bool {
+        self.sequence_spec.is_some() || self.closure_seq.is_some()
+    }
+
+    /// Gate for the VM force/incremental-pull dispatch block: a gather-sourced
+    /// list (eager or `lazy`) or an infinite sequence/closure spec.
+    pub(crate) fn needs_vm_lazy_dispatch(&self) -> bool {
+        self.is_from_gather() || self.is_infinite_spec()
+    }
+
     /// Whether this list carries the `lazy` prefix marker (set by the `lazy`
     /// statement prefix / `.lazy` method).
     fn is_lazy_marked(&self) -> bool {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -415,10 +415,7 @@ impl Interpreter {
         // Lazy `.first` over a gather coroutine: pull incrementally instead of
         // forcing the (possibly infinite) list to completion.
         if let Value::LazyList(ref ll) = target
-            && matches!(
-                ll.env.get("__mutsu_lazylist_from_gather"),
-                Some(crate::value::Value::Bool(true))
-            )
+            && ll.needs_vm_lazy_dispatch()
             && method == "first"
             && let Some(result) = self.try_lazy_gather_first(ll, &args)
         {
@@ -426,26 +423,29 @@ impl Interpreter {
             return Ok(());
         }
         let target = if let Value::LazyList(ref ll) = target
-            && matches!(
-                ll.env.get("__mutsu_lazylist_from_gather"),
-                Some(crate::value::Value::Bool(true))
-            )
+            && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(&method)
-            // A chained `.map`/`.grep` on a lazy pipeline appends another stage
-            // (interpreter dispatch); laziness-preserving coercions return the
-            // pipeline unchanged (native dispatch) — neither forces.
-            && !(ll.lazy_pipe.is_some()
+            // A chained `.map`/`.grep` on a lazy pipeline OR an infinite
+            // sequence/closure spec appends another stage (interpreter dispatch
+            // via `is_lazy_pipe_source`); laziness-preserving coercions return
+            // the list unchanged (native dispatch) — neither forces.
+            && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && (matches!(method.as_str(), "map" | "grep")
                     || Self::lazy_pipe_preserving_coercion(&method)))
+            // On an infinite sequence/closure spec the count/numeric coercions
+            // produce a *soft* X::Cannot::Lazy Failure (recoverable with `//`),
+            // emitted by the 0-arg native dispatch — they must not be hard-forced.
+            && !(ll.is_infinite_spec() && matches!(method.as_str(), "elems" | "Int" | "Numeric"))
         {
             let saved_env = self.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so
             // an infinite gather does not hang.
             let items = match Self::gather_head_bound(&method, &args) {
                 Some(n) => self.force_lazy_list_vm_n(ll, n)?,
-                // A strict force of an infinite lazy pipeline cannot terminate:
-                // raise X::Cannot::Lazy with this method's name.
-                None if ll.lazy_pipe.is_some() => {
+                // A strict force of an infinite list (lazy pipeline / infinite
+                // sequence / closure spec) cannot terminate: raise
+                // X::Cannot::Lazy with this method's name.
+                None if ll.lazy_pipe.is_some() || ll.is_infinite_spec() => {
                     return Err(RuntimeError::cannot_lazy(&method));
                 }
                 None => self.force_lazy_list_vm(ll)?,

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -604,10 +604,7 @@ impl Interpreter {
         // Lazy `.first` over a gather coroutine: pull incrementally instead of
         // forcing the (possibly infinite) list to completion.
         if let Value::LazyList(ref ll) = target
-            && matches!(
-                ll.env.get("__mutsu_lazylist_from_gather"),
-                Some(crate::value::Value::Bool(true))
-            )
+            && ll.needs_vm_lazy_dispatch()
             && method == "first"
             && let Some(result) = self.try_lazy_gather_first(ll, &args)
         {
@@ -615,26 +612,29 @@ impl Interpreter {
             return Ok(());
         }
         let target = if let Value::LazyList(ref ll) = target
-            && matches!(
-                ll.env.get("__mutsu_lazylist_from_gather"),
-                Some(crate::value::Value::Bool(true))
-            )
+            && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(method)
             && !(ll.coroutine.is_some() && matches!(method, "List" | "values"))
-            // A chained `.map`/`.grep` on a lazy pipeline appends another stage
-            // (interpreter dispatch); laziness-preserving coercions return the
-            // pipeline unchanged (native dispatch) — neither forces.
-            && !(ll.lazy_pipe.is_some()
+            // A chained `.map`/`.grep` on a lazy pipeline OR an infinite
+            // sequence/closure spec appends another stage (interpreter dispatch
+            // via `is_lazy_pipe_source`); laziness-preserving coercions return
+            // the list unchanged (native dispatch) — neither forces.
+            && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && (matches!(method, "map" | "grep") || Self::lazy_pipe_preserving_coercion(method)))
+            // On an infinite sequence/closure spec the count/numeric coercions
+            // produce a *soft* X::Cannot::Lazy Failure (recoverable with `//`),
+            // emitted by the 0-arg native dispatch — they must not be hard-forced.
+            && !(ll.is_infinite_spec() && matches!(method, "elems" | "Int" | "Numeric"))
         {
             let saved_env = self.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so
             // an infinite gather does not hang.
             let items = match Self::gather_head_bound(method, &args) {
                 Some(n) => self.force_lazy_list_vm_n(ll, n)?,
-                // A strict force of an infinite lazy pipeline cannot terminate:
-                // raise X::Cannot::Lazy with this method's name.
-                None if ll.lazy_pipe.is_some() => {
+                // A strict force of an infinite list (lazy pipeline / infinite
+                // sequence / closure spec) cannot terminate: raise
+                // X::Cannot::Lazy with this method's name.
+                None if ll.lazy_pipe.is_some() || ll.is_infinite_spec() => {
                     return Err(RuntimeError::cannot_lazy(method));
                 }
                 None => self.force_lazy_list_vm(ll)?,

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -327,7 +327,12 @@ impl Interpreter {
             _ => None,
         };
         if let Some(ll) = lazy {
-            let items = self.force_lazy_list_vm(&ll)?;
+            // Reify a bounded prefix (matching the historical reify-to-cap of a
+            // capped `ArrayKind::Lazy` Array). With the L2b `[start]` seed the
+            // cache holds only one element, so `force_lazy_list_vm` (cache read)
+            // would lose the prefix on a front-mutation — extend to the cap.
+            const MAX_ARRAY_EXPAND: usize = 100_000;
+            let items = self.force_lazy_list_vm_n(&ll, MAX_ARRAY_EXPAND)?;
             self.env_mut()
                 .insert(name.to_string(), Value::real_array(items));
             self.env_dirty = true;
@@ -441,11 +446,15 @@ impl Interpreter {
             ));
         }
 
-        // For sequence-spec lazy lists, return current cache (infinite lists
-        // are never fully materialized)
-        if list.sequence_spec.is_some() {
-            let cache = list.cache.lock().unwrap();
-            return Ok(cache.as_ref().cloned().unwrap_or_default());
+        // For sequence-spec lazy lists, a strict force cannot materialize the
+        // infinite tail, so return a bounded prefix (the historical 100k cap).
+        // With the L2b `[start]` seed the cache is O(1), so extend it to the cap
+        // here — every strict-force caller (front mutation reify, eager coerce,
+        // ...) expects the prefix, not the seed. Lazy *read* paths (index, head,
+        // first, map/grep pipes) use `force_lazy_list_vm_n` / pull and stay O(1).
+        if let Some(ref spec) = list.sequence_spec {
+            const MAX_ARRAY_EXPAND: usize = 100_000;
+            return Self::extend_sequence_cache(list, spec, MAX_ARRAY_EXPAND);
         }
 
         // Check cache first

--- a/t/lazy-array-reify.t
+++ b/t/lazy-array-reify.t
@@ -6,7 +6,7 @@ use Test;
 # while front mutations (unshift/prepend/shift/splice/elem-assign) reify the
 # prefix and operate on it.
 
-plan 22;
+plan 25;
 
 # --- reads past the old 100k cap reify on demand ------------------------
 {
@@ -19,6 +19,18 @@ plan 22;
     is @a.head(3).List, (1, 2, 3), 'head reifies the prefix';
     is @a.first(* > 3), 4, 'first pulls until the predicate matches';
     is @a.map(* * 2).head(3).List, (2, 4, 6), 'map keeps laziness';
+}
+
+# --- L2b: map/grep stay lazy even when the cache was NOT pre-extended -----
+# (A fresh `1..*` is seeded with `[1]` only; the lazy `map`/`grep` pipeline
+# must pull from the sequence on demand, not read the O(1) seed cache.)
+{
+    my @a = 1..*;
+    is @a.map(* * 2).head(5).List, (2, 4, 6, 8, 10), 'fresh map pulls past the seed';
+    my @b = 1..*;
+    is @b.grep(* %% 3).head(4).List, (3, 6, 9, 12), 'fresh grep pulls past the seed';
+    my @c = 1..*;
+    is @c.map(* * 2).grep(* > 5).head(3).List, (6, 8, 10), 'chained map/grep stays lazy';
 }
 
 # --- `.elems`/numeric coercions still throw X::Cannot::Lazy ------------


### PR DESCRIPTION
## Summary

Completes the lazy-array campaign's **L2b** step (`docs/lazy-arrays.md`): `my @a = 1..*` is now **O(1) memory** instead of materializing a 100k-element prefix.

L2a (#3315) kept `1..*` a reify-on-demand `LazyList` but seeded it with the same 100k prefix `coerce_to_array` produced, so the array still cost 100k `Int`s up front. L2b seeds it with just `[start]` and teaches every read path to extend the sequence on demand — same observable behavior, O(1) memory.

## Changes

- **Seed `[start]`** in `infinite_int_range_to_lazy_array`.
- New `LazyList` helpers (`is_from_gather` / `is_infinite_spec` / `needs_vm_lazy_dispatch`) express the VM force-dispatch gate cleanly.
- **Broaden the lazy-dispatch gates** (both `vm_call_method*_ops.rs` and the interpreter force block in `methods.rs`) from the `__mutsu_lazylist_from_gather` marker to also cover infinite sequence/closure specs:
  - `.head(n)` / `.first` → bounded incremental pull
  - `.map` / `.grep` + laziness-preserving coercions → fall through to the lazy pipe (`is_lazy_pipe_source` now true for sequence/closure specs)
  - `.elems` / `.Int` / `.Numeric` → existing soft-`Failure` path
  - other whole-list methods (`.sort` / `.reverse` / ...) → `X::Cannot::Lazy`
- **Skip the `@a.map` rw-writeback fast path** (`methods_mut.rs`) for infinite specs so map stays lazy instead of materializing the seed cache.
- `force_lazy_list_vm` extends a sequence spec to the 100k cap (a strict force can't materialize the infinite tail); `reify_lazy_array_slot` extends rather than reading the now-O(1) cache, so front mutations (`shift`/`unshift`/`@a[i]=v`) still reify a real prefix.

## Tests

- `t/lazy-array-reify.t` (+3 cases): map/grep stay lazy on a *fresh* `1..*` (cache not pre-extended). The reify test now runs in 0.06 CPU vs 1.8 CPU before — confirming the O(1) read path.
- `make test`: all 962 files / 9388 tests pass.
- Targeted roast (create / flat / join / grep / map / first / head / delete-adverb / range-iterator / S03-sequence) all pass; `S09-subscript/slice.t` failures (infinite-sequence subscript indices) are pre-existing and identical on `main`.

No whitelist payoff — this is a pure memory optimization closing out the lazy-array plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)