### PR TITLE
feat(single-store): write a callee's caller-dynamic-var mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2001,6 +2001,16 @@ impl Interpreter {
                 } else {
                     self.set_env_with_main_alias(&name, val.clone());
                 }
+                // Slice F (env<->locals coherence): a callee assigning to a
+                // caller-declared dynamic variable (`$*foo = v`) reaches SetGlobal
+                // and writes only `env` by name; the caller's local slot was kept
+                // coherent solely by the reverse `sync_locals_from_env` pull.
+                // Record the dynamic name so the call-site drain writes it through
+                // to the caller frame's slot (no-op when the caller has no such
+                // slot, e.g. a built-in like `$*OUT` that lives only in `env`).
+                if name.starts_with('*') {
+                    self.pending_rw_writeback_sources.push(name.clone());
+                }
                 // Persist anonymous state variable (`$`) so it survives
                 // across closure calls (e.g. `$ ~= $_` in classify block).
                 self.sync_anon_state_value(&name, &val);

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1689,6 +1689,12 @@ impl Interpreter {
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
+        // Slice F: an inc/dec (`$*foo++`) of a caller-declared dynamic variable
+        // writes only `env` by name; record it so the call-site drain writes it
+        // through to the caller frame's slot (mirrors the SetGlobal path).
+        if name.starts_with('*') {
+            self.pending_rw_writeback_sources.push(name.to_string());
+        }
         // Propagate via local_bind_pairs (for `:=` bindings within this scope
         // or cross-scope bindings resolved by resolve_pending_alias_binds).
         if let Some(source_idx) = code.locals.iter().position(|n| n == name) {

--- a/t/dynamic-var-writeback-coherence.t
+++ b/t/dynamic-var-writeback-coherence.t
@@ -1,0 +1,69 @@
+use Test;
+
+# Slice F (env<->locals coherence): a callee assigning to a dynamic variable
+# (`$*foo`) declared in the caller writes the value into `env` by name, but the
+# caller's local slot was kept coherent only by the reverse `sync_locals_from_env`
+# pull. This pins that the call-site drains the dynamic write through to the
+# caller's local slot, so the behavior no longer depends on the reverse pull.
+# Run with `MUTSU_NO_REVERSE_SYNC=1` to confirm coherence without the reverse pull.
+#
+# NOTE: only single-level (the writer's immediate caller declared the dynamic) is
+# covered. Multi-frame propagation (caller -> mid -> writer) still relies on the
+# reverse pull; folding it in needs cross-frame retention, which conflicts with
+# lazy iteration (the same wall as the 0-arg captured-write slice, PR #3317).
+
+plan 10;
+
+# Plain assignment to a caller-declared dynamic var.
+sub setter() { $*shared = 5 }
+sub outer-assign() { my $*shared = 99; setter(); $*shared }
+is outer-assign(), 5, 'callee assignment to caller dynamic var is visible';
+
+# Post-increment.
+sub inc-it() { $*counter++ }
+sub outer-inc() { my $*counter = 10; inc-it(); $*counter }
+is outer-inc(), 11, 'post-increment of caller dynamic var is visible';
+
+# Post-decrement.
+sub dec-it() { $*counter-- }
+sub outer-dec() { my $*counter = 10; dec-it(); $*counter }
+is outer-dec(), 9, 'post-decrement of caller dynamic var is visible';
+
+# Compound assignment.
+sub add-it() { $*acc += 7 }
+sub outer-add() { my $*acc = 100; add-it(); $*acc }
+is outer-add(), 107, 'compound += of caller dynamic var is visible';
+
+# Two dynamic vars written in one call.
+sub set-two() { $*a = 1; $*b = 2 }
+sub outer-two() { my $*a = 0; my $*b = 0; set-two(); "$*a/$*b" }
+is outer-two(), "1/2", 'two caller dynamic vars written in one call';
+
+# String value.
+sub set-name() { $*name = "raku" }
+sub outer-name() { my $*name = "x"; set-name(); $*name }
+is outer-name(), "raku", 'string assignment to caller dynamic var is visible';
+
+# Multiple writers, accumulating across calls.
+sub bump() { $*total += 1 }
+sub outer-multi() {
+    my $*total = 0;
+    bump(); bump(); bump();
+    $*total
+}
+is outer-multi(), 3, 'repeated callee bumps accumulate in caller dynamic var';
+
+# Caller slot stays coherent for a subsequent method call on it.
+sub stretch() { $*word = $*word ~ "!!!" }
+sub outer-method() { my $*word = "hi"; stretch(); $*word.chars }
+is outer-method(), 5, 'caller dynamic var slot is coherent for a later method call';
+
+# Read-modify-write from the value the callee left.
+sub double() { $*v = $*v * 2 }
+sub outer-rmw() { my $*v = 21; double(); $*v }
+is outer-rmw(), 42, 'callee read-modify-write of caller dynamic var is visible';
+
+# Dynamic var used inside a later arithmetic expression in the caller.
+sub set-base() { $*base = 40 }
+sub outer-expr() { my $*base = 0; set-base(); $*base + 2 }
+is outer-expr(), 42, 'caller dynamic var slot is coherent in a later expression';


### PR DESCRIPTION
## Summary

A callee assigning to a dynamic variable (`$*foo = v`, `$*foo++`, `$*foo += n`) that was declared in its **caller** writes the new value into `env` by name, but the caller's **local slot** was kept coherent only by the reverse `sync_locals_from_env` pull. Under `MUTSU_NO_REVERSE_SYNC=1` the caller's dynamic var stayed stale.

This continues the dual-store write-through grind (#3304–#3311, #3317, #3318): fold the dynamic-var by-name writer into the `pending_rw_writeback_sources` call-site write-through mechanism.

## Change

Record the dynamic name (`*`-twigil) in `pending_rw_writeback_sources` from:
- the `SetGlobal` store (plain `$*foo = v` and the desugared `$*foo += n`)
- `store_named_scalar_rmw_result` (inc/dec `$*foo++` / `$*foo--`)

The existing call-site drain (`apply_pending_rw_writeback`) writes the env value straight through to the caller frame's slot, skipping `HashSlotRef` binding slots like the reverse pull. The drain is a no-op for built-in dynamics like `$*OUT` that live only in `env`.

This removes `t/dynamic-var-not-found.t` from the reverse-sync dependency surface.

**Single-level only** (the writer's immediate caller). Multi-frame propagation (caller → mid → writer) still relies on the reverse pull; folding it in needs cross-frame retention, which conflicts with lazy iteration — the same wall documented for the 0-arg captured-write slice (#3317).

## Tests

- pin: `t/dynamic-var-writeback-coherence.t` (10 cases, `ON == OFF == raku`)
- `make test` PASS (9421), no regressions
- `t/dynamic-var-not-found.t` now passes with `MUTSU_NO_REVERSE_SYNC=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)