### PR TITLE
feat(single-store): write a method's captured-outer mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -662,7 +662,7 @@ impl Interpreter {
             // mutate the caller env in place without a deep copy.
             let frame = self.pop_call_frame();
             let current_env = self.take_env();
-            let (mut merged_env, wrote_caller) =
+            let (mut merged_env, wrote_caller, changed_caller_locals) =
                 merge_method_env(frame.saved_env, current_env, &method_local_keys);
             // Precise dirty signal (Slice 6.3): the caller only needs an
             // env->locals re-sync when this method actually merged a
@@ -671,6 +671,18 @@ impl Interpreter {
             // caller's slots coherent -> stays "pure" so the opcode skips the
             // env_dirty mark (no per-call locals pull).
             self.method_dispatch_pure = !wrote_caller && rw_writeback.is_empty();
+
+            // Slice F (env<->locals coherence): a method that mutated a captured
+            // outer lexical (`method bar { $Foo++ }` closing over an outer-block
+            // `$Foo`) merged the new value into `merged_env` (which becomes
+            // `self.env` below). Record those changed caller-visible names so the
+            // CallMethod / CallMethodMut op — which holds the caller's `code` —
+            // writes each value straight through to the caller's local slot,
+            // dropping the dependency on the reverse `sync_locals_from_env` pull.
+            for k in &changed_caller_locals {
+                self.pending_rw_writeback_sources
+                    .push(k.resolve().to_string());
+            }
 
             for (source_name, val) in &rw_writeback {
                 merged_env.insert(source_name.clone(), val.clone());
@@ -1336,11 +1348,17 @@ impl Interpreter {
                 // Own both envs (frame already popped above; take the live callee
                 // env) so the merge mutates the caller env in place, no deep copy.
                 let current_env = self.take_env();
-                let (merged, wrote_caller) =
+                let (merged, wrote_caller, changed_caller_locals) =
                     merge_method_env(frame.saved_env, current_env, &method_local_keys);
                 // Precise dirty signal (Slice 6.3): re-sync the caller's locals
                 // only when the method merged a caller-visible write.
                 self.method_dispatch_pure = !wrote_caller;
+                // Slice F: write captured-outer mutations straight through to the
+                // caller's local slot (see the primary merge path above).
+                for k in &changed_caller_locals {
+                    self.pending_rw_writeback_sources
+                        .push(k.resolve().to_string());
+                }
                 self.set_env(merged);
             }
         }
@@ -1459,7 +1477,7 @@ fn merge_method_env(
     mut saved: Env,
     current: Env,
     method_local_keys: &HashSet<String>,
-) -> (Env, bool) {
+) -> (Env, bool, Vec<Symbol>) {
     let writes: Vec<(Symbol, Value)> = current
         .overlay_iter()
         .filter_map(|(k, v)| {
@@ -1486,7 +1504,12 @@ fn merge_method_env(
     // equality in O(1) (Arc-ptr identity for containers/Str, scalar compare for
     // immutables); anything it cannot prove unchanged counts as dirty
     // (conservative -> at worst a redundant pull, never a stale read).
-    let wrote = writes.iter().any(|(k, v)| {
+    // Collect the keys whose merged value can name a caller compiled-local slot
+    // and actually changed. `wrote` (the precise env_dirty signal) is just
+    // "this list is non-empty"; the list itself drives the Slice F call-site
+    // write-through so the caller's slot stays coherent without the reverse pull.
+    let mut changed_caller_locals: Vec<Symbol> = Vec::new();
+    for (k, v) in &writes {
         // Only a key that can name a caller compiled-local slot obliges a pull:
         // `sync_locals_from_env` iterates exactly `code.locals`. Compile-time
         // location vars (`?LINE`/`?FILE`/`?CLASS`...), pod (`=...`), dynamic /
@@ -1496,17 +1519,21 @@ fn merge_method_env(
         // and the method-body line, which would otherwise flip env_dirty on every
         // multi-line nested method call.
         if !k.with_str(could_name_caller_local) {
-            return false;
+            continue;
         }
-        match saved.get_sym(*k) {
+        let changed = match saved.get_sym(*k) {
             Some(old) => !cheaply_unchanged(old, v),
             None => true,
+        };
+        if changed {
+            changed_caller_locals.push(*k);
         }
-    });
+    }
+    let wrote = !changed_caller_locals.is_empty();
     for (k, v) in writes {
         saved.insert_sym(k, v);
     }
-    (saved, wrote)
+    (saved, wrote, changed_caller_locals)
 }
 
 #[cfg(test)]

--- a/t/method-captured-var-writeback-coherence.t
+++ b/t/method-captured-var-writeback-coherence.t
@@ -1,0 +1,93 @@
+use Test;
+
+# Slice F (env<->locals coherence): a method that mutates a captured outer
+# lexical (`method bar { $Foo++ }` closing over an outer-block `$Foo`) merges the
+# new value into the caller's env, but the caller's local slot was kept coherent
+# only by the reverse `sync_locals_from_env` pull. This pins that the method
+# call-site drains the captured-outer write through to the caller's local slot,
+# so the behavior no longer depends on the reverse pull. Run with
+# `MUTSU_NO_REVERSE_SYNC=1` to confirm coherence without the reverse pull.
+
+plan 11;
+
+# Post-increment of a captured outer scalar across two method calls.
+{
+    my $Foo = 0;
+    class C1 { method bar { $Foo++ } }
+    C1.new.bar;
+    C1.new.bar;
+    is $Foo, 2, 'captured-outer post-increment via method visible to caller';
+}
+
+# Compound assignment of a captured outer scalar.
+{
+    my $sum = 0;
+    class C2 { method add($n) { $sum += $n } }
+    C2.new.add(3);
+    C2.new.add(4);
+    is $sum, 7, 'captured-outer compound += via method accumulates';
+}
+
+# Plain assignment of two captured outer scalars in one method.
+{
+    my $p = 0;
+    my $q = 0;
+    class C3 { method both { $p = 5; $q = 9 } }
+    C3.new.both;
+    is $p, 5, 'first captured-outer scalar assigned via method';
+    is $q, 9, 'second captured-outer scalar assigned via method';
+}
+
+# Captured outer array, pushed via a method.
+{
+    my @log;
+    class C4 { method rec($x) { @log.push($x) } }
+    C4.new.rec("a");
+    C4.new.rec("b");
+    is @log.join(","), "a,b", 'captured-outer array push via method visible';
+    is @log.elems, 2, 'caller array slot is coherent for a later method call';
+}
+
+# Captured outer string, mutated via a method.
+{
+    my $msg = "x";
+    class C5 { method app { $msg ~= "!" } }
+    C5.new.app;
+    C5.new.app;
+    is $msg, "x!!", 'captured-outer string mutate via method visible';
+}
+
+# Read-modify-write reading back the value a prior method call left.
+{
+    my $v = 21;
+    class C6 { method dbl { $v = $v * 2 } }
+    C6.new.dbl;
+    is $v, 42, 'captured-outer read-modify-write via method visible';
+}
+
+# Captured outer scalar used in a later arithmetic expression in the caller.
+{
+    my $base = 0;
+    class C7 { method set { $base = 40 } }
+    C7.new.set;
+    is $base + 2, 42, 'caller slot coherent in a later expression';
+}
+
+# Captured outer hash, keyed-write via a method.
+{
+    my %h;
+    class C8 { method put($k, $val) { %h{$k} = $val } }
+    C8.new.put("a", 1);
+    C8.new.put("b", 2);
+    is %h<a> + %h<b>, 3, 'captured-outer hash element write via method visible';
+}
+
+# Mixed: one method increments, then the caller reads and a second call reads it.
+{
+    my $count = 0;
+    class C9 { method tick { $count++ } }
+    C9.new.tick;
+    my $mid = $count;
+    C9.new.tick;
+    is "$mid/$count", "1/2", 'caller observes each captured-outer tick coherently';
+}


### PR DESCRIPTION
## Summary

A method that mutates a captured outer lexical (`class Foo { method bar { \$Foo++ } }` closing over an outer-block `$Foo`) merges the new value into the caller's env via `merge_method_env`, but the caller's **local slot** was kept coherent only by the reverse `sync_locals_from_env` pull. Under `MUTSU_NO_REVERSE_SYNC=1` the caller's captured scalar stayed stale (`Foo.new.bar` twice → 1 instead of 2).

This continues the dual-store write-through grind (#3304–#3311, #3317, #3318, #3320) and is the **method-dispatch analog** of the closure captured-var slice (#3307).

## Change

`merge_method_env` already computes a precise "wrote a caller-visible value" bool (gated by `could_name_caller_local`, which excludes `?LINE`/`$*...`/globals/`__mutsu_` plumbing). Return the **list** of changed caller-local names it found, and have both method-dispatch exit paths record them in `pending_rw_writeback_sources`. The existing CallMethod / CallMethodMut call-site drain (`apply_pending_rw_writeback`) then writes each new value straight through to the caller's local slot, skipping `HashSlotRef` binding slots like the reverse pull.

This is purely additive to the existing precise env_dirty signal — `wrote` is now just "the list is non-empty", so the dirty-tracking behavior is unchanged.

This removes `t/class-var-namespace-separation.t` from the reverse-sync dependency surface.

## Tests

- pin: `t/method-captured-var-writeback-coherence.t` (11 cases, `ON == OFF == raku`) — covers `++`, `+=`, multi-var, captured array push, captured hash element write, string mutate, RMW
- `make test` PASS (9435), no regressions
- `t/class-var-namespace-separation.t` now passes with `MUTSU_NO_REVERSE_SYNC=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)