### PR TITLE
feat(single-store): write a qualified/our sub's captured-outer mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1561,6 +1561,10 @@ impl Interpreter {
             }
             OpCode::GetBareWord(name_idx) => {
                 self.exec_get_bare_word_op(code, *name_idx, compiled_fns)?;
+                // Slice F: a bareword that resolved to a qualified/`our` sub call
+                // (`M::foo`) may have recorded captured-outer writes; drain them
+                // through to this caller frame's local slots.
+                self.apply_pending_rw_writeback(code);
                 *ip += 1;
             }
             OpCode::GetPseudoStash(name_idx) => {

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -2092,6 +2092,25 @@ impl Interpreter {
         }
         self.env_dirty = saved_env_dirty || changed;
 
+        // Slice F (env<->locals coherence): record the captured-outer variables
+        // this body writes so the call-site op writes their new env values
+        // straight through to the caller's local slots (`apply_pending_rw_writeback`),
+        // dropping the dependency on the reverse `sync_locals_from_env` pull. This
+        // mirrors the 0-arg fast-call path (#3317): a qualified/`our` sub reached by
+        // name (`module M { our sub foo() { $called = True } }`) goes through this
+        // path rather than the fast path, but writes its enclosing `$called` the
+        // same way. `free_var_writes` is the compile-time set of free vars this
+        // body writes, so a pure body records nothing and pays no cost. The topic
+        // (`_`/`@_`/`%_`) is excluded — it is a per-call alias, never a caller
+        // lexical. (Cross-frame propagation still relies on the reverse pull.)
+        for sym in &cf.code.free_var_writes {
+            sym.with_str(|fname| {
+                if fname != "_" && fname != "@_" && fname != "%_" {
+                    self.pending_rw_writeback_sources.push(fname.to_string());
+                }
+            });
+        }
+
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),
             Ok(()) => {

--- a/t/qualified-sub-captured-var-writeback-coherence.t
+++ b/t/qualified-sub-captured-var-writeback-coherence.t
@@ -1,0 +1,88 @@
+use Test;
+
+# Slice F (env<->locals coherence): a qualified / `our` sub reached by name
+# (`module M { our sub foo() { $called = True } }; M::foo`) is dispatched as a
+# BareWord through `call_compiled_function_named`, not the 0-arg fast path. When
+# its body mutates a captured outer lexical the new value reaches `env` by name,
+# but the caller's local slot was kept coherent only by the reverse
+# `sync_locals_from_env` pull. This pins that the BareWord call-site drains the
+# captured-outer write through to the caller's local slot. Run with
+# `MUTSU_NO_REVERSE_SYNC=1` to confirm coherence without the reverse pull.
+
+plan 9;
+
+# Plain assignment to a captured outer scalar via a qualified sub.
+{
+    my $called = False;
+    module M1 { our sub foo() { $called = True } }
+    M1::foo;
+    ok $called, 'qualified sub captured-outer assignment is visible';
+}
+
+# Post-increment across two qualified-sub calls.
+{
+    my $count = 10;
+    module M2 { our sub up() { $count++ } }
+    M2::up;
+    M2::up;
+    is $count, 12, 'qualified sub captured-outer post-increment accumulates';
+}
+
+# Compound assignment.
+{
+    my $acc = 100;
+    module M3 { our sub add() { $acc += 7 } }
+    M3::add;
+    is $acc, 107, 'qualified sub captured-outer compound += is visible';
+}
+
+# Two captured outer scalars written in one qualified-sub call.
+{
+    my $a = 0;
+    my $b = 0;
+    module M4 { our sub both() { $a = 5; $b = 9 } }
+    M4::both;
+    is "$a/$b", "5/9", 'qualified sub writes two captured-outer scalars';
+}
+
+# String value.
+{
+    my $msg = "x";
+    module M5 { our sub app() { $msg = $msg ~ "!" } }
+    M5::app;
+    M5::app;
+    is $msg, "x!!", 'qualified sub captured-outer string mutate is visible';
+}
+
+# Captured outer array, pushed via a qualified sub.
+{
+    my @log;
+    module M6 { our sub rec() { @log.push(1) } }
+    M6::rec;
+    M6::rec;
+    is @log.elems, 2, 'qualified sub captured-outer array push is visible';
+}
+
+# Postfix-if guarding a qualified-sub call (the original roast-style case).
+{
+    my $ran = False;
+    module M7 { our sub go() { $ran = True } }
+    M7::go if True;
+    ok $ran, 'qualified sub call in postfix if writes captured-outer var';
+}
+
+# Read-modify-write reading back the value a prior call left.
+{
+    my $v = 21;
+    module M8 { our sub dbl() { $v = $v * 2 } }
+    M8::dbl;
+    is $v, 42, 'qualified sub captured-outer read-modify-write is visible';
+}
+
+# Caller slot stays coherent for a later expression.
+{
+    my $base = 0;
+    module M9 { our sub set() { $base = 40 } }
+    M9::set;
+    is $base + 2, 42, 'caller slot coherent in a later expression';
+}


### PR DESCRIPTION
## Summary

A qualified / `our` sub reached by name (`module M { our sub foo() { \$called = True } }; M::foo`) is compiled as a **BareWord** and dispatched through `call_compiled_function_named`, not the 0-arg fast path that #3317 covered. When its body mutates a captured outer lexical the new value reaches `env` by name, but the caller's **local slot** was kept coherent only by the reverse `sync_locals_from_env` pull. Under `MUTSU_NO_REVERSE_SYNC=1` the caller's captured scalar stayed stale.

This continues the dual-store write-through grind (#3304–#3311, #3317, #3318, #3320, #3322).

## Change

Two parts, mirroring the fast-call path (#3317):
- **Record** the body's compile-time `free_var_writes` (minus the topic `_`/`@_`/`%_`) in `pending_rw_writeback_sources` at the `call_compiled_function_named` exit. A pure sub has an empty set and pays no cost.
- **Drain** `apply_pending_rw_writeback` at the `GetBareWord` opcode — the bareword call-site that resolves and calls a qualified sub — which previously did not drain. The existing `ExecCall` / `CallMethod` etc. drains already cover the other call-sites.

This removes `t/statement-modifiers.t` from the reverse-sync dependency surface. Single-level only; cross-frame propagation still relies on the reverse pull.

## Tests

- pin: `t/qualified-sub-captured-var-writeback-coherence.t` (9 cases, `ON == OFF == raku`) — assign, `++`, `+=`, multi-var, string mutate, array push, postfix-if, RMW
- `make test` PASS (9451), no regressions
- `t/statement-modifiers.t` now passes with `MUTSU_NO_REVERSE_SYNC=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)