### PR TITLE
feat(single-store): read dynamic vars `$*x` from env, not a local slot (Slice F)

### DIFF
--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -556,6 +556,16 @@ impl Compiler {
         } else if (name == "?CLASS" || name == "?ROLE") && !self.local_map.contains_key(name) {
             let name_idx = self.code.add_constant(Value::str(name.to_string()));
             self.code.emit(OpCode::GetGlobal(name_idx));
+        } else if name.starts_with('*') {
+            // Dynamic variables (`$*x`) are dynamic-scope: even when `my $*x`
+            // allocated a local slot, read straight from `env` by name so a
+            // callee's `$*x = …` (which always writes env — dynamic scope) is
+            // visible here WITHOUT the reverse `sync_locals_from_env` pull
+            // (Slice F). Writes already reach env; the slot is now read-vestigial.
+            let name_idx = self
+                .code
+                .add_constant(Value::str(self.qualify_variable_name(name)));
+            self.code.emit(OpCode::GetGlobal(name_idx));
         } else if let Some(&slot) = self.local_map.get(name) {
             self.code.emit(OpCode::GetLocal(slot));
         } else {

--- a/t/dynamic-var-writeback-coherence.t
+++ b/t/dynamic-var-writeback-coherence.t
@@ -1,18 +1,17 @@
 use Test;
 
-# Slice F (env<->locals coherence): a callee assigning to a dynamic variable
-# (`$*foo`) declared in the caller writes the value into `env` by name, but the
-# caller's local slot was kept coherent only by the reverse `sync_locals_from_env`
-# pull. This pins that the call-site drains the dynamic write through to the
-# caller's local slot, so the behavior no longer depends on the reverse pull.
-# Run with `MUTSU_NO_REVERSE_SYNC=1` to confirm coherence without the reverse pull.
+# Slice F (env<->locals coherence): a dynamic variable (`$*foo`) is dynamic-scope.
+# Reads of a `my $*foo`-declared dynamic var now go straight to `env` by name
+# (the compiler emits GetGlobal, not GetLocal — `compile_expr_var`), and dynamic
+# writes always reach env, so a callee's `$*foo = …` is visible to the declaring
+# scope WITHOUT the reverse `sync_locals_from_env` pull. Run with
+# `MUTSU_NO_REVERSE_SYNC=1` to confirm coherence without the reverse pull.
 #
-# NOTE: only single-level (the writer's immediate caller declared the dynamic) is
-# covered. Multi-frame propagation (caller -> mid -> writer) still relies on the
-# reverse pull; folding it in needs cross-frame retention, which conflicts with
-# lazy iteration (the same wall as the 0-arg captured-write slice, PR #3317).
+# Reading dynamic vars from env (vs the single-level call-site drain of PR #3320)
+# also makes MULTI-FRAME propagation (caller -> mid -> writer) work, since env is
+# the one dynamic-scope store — see the multi-frame case below.
 
-plan 10;
+plan 11;
 
 # Plain assignment to a caller-declared dynamic var.
 sub setter() { $*shared = 5 }
@@ -67,3 +66,11 @@ is outer-rmw(), 42, 'callee read-modify-write of caller dynamic var is visible';
 sub set-base() { $*base = 40 }
 sub outer-expr() { my $*base = 0; set-base(); $*base + 2 }
 is outer-expr(), 42, 'caller dynamic var slot is coherent in a later expression';
+
+# Multi-frame propagation: the writer is two frames below the declaring scope.
+# (The earlier single-level call-site drain could not do this; reading from env
+# does, because env is the one dynamic-scope store.)
+sub deep-writer() { $*md = 99 }
+sub middle() { deep-writer() }
+sub outer-multiframe() { my $*md = 0; middle(); $*md }
+is outer-multiframe(), 99, 'multi-frame callee write to caller dynamic var is visible';


### PR DESCRIPTION
## Summary

A step in the **single-store / Slice F** campaign (`docs/vm-single-store.md`) toward deleting `env_dirty` + the reverse `sync_locals_from_env` pull.

A dynamic variable is dynamic-scope: a callee's `$*x = …` always writes `env` (that's how dynamic scope crosses the call stack). But `my $*x` allocated the declaring scope a **local slot** read via `GetLocal`, and `flush_local_to_env` deliberately skips dynamic vars — so that slot stayed coherent with env only via the reverse pull.

This makes `compile_expr_var` emit **`GetGlobal`** (read from env by name) for any `*`-prefixed dynamic variable, even when a local slot exists. Writes already reach env, so the value is visible to the declaring scope **without** the reverse pull; the slot becomes read-vestigial.

## Supersedes #3320's limitation

PR #3320 added a single-level call-site *drain* of dynamic writes to the caller's local slot, but explicitly **could not** do multi-frame propagation (caller → mid → writer). Reading from the one dynamic-scope store (env) makes multi-frame work for free:

```raku
sub w { $*z = 7 }; sub mid { w() }; sub top { my $*z = 0; mid(); $*z }
say top();   # 7  (now works under MUTSU_NO_REVERSE_SYNC=1)
```

(#3320's drain is now redundant for the read path; left in place — harmless — pending follow-up cleanup.)

## Tests

- `t/dynamic-var-writeback-coherence.t`: caveat dropped, +1 multi-frame case (11 total) — passes ON and `MUTSU_NO_REVERSE_SYNC=1`.
- Removes the reverse-sync dependency of `S02-names/is_dynamic.t` and the dynamic-var portion of others.
- `make test` green (967 files / 9442 tests); **no ON regression** across the S02/S04/S06/S11/S12 whitelist. CI runs the full roast.

Part of the dependency map in `docs/vm-single-store.md` §9 (mechanism 2, the largest remaining class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)