### PR TITLE
feat(single-store): write a light/positional-light sub's captured-outer mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -1257,6 +1257,21 @@ impl Interpreter {
             }
         }
 
+        // Slice F (env<->locals coherence): record the captured-outer variables
+        // this body writes so the call-site op writes their new env values straight
+        // through to the caller's local slots, dropping the dependency on the
+        // reverse `sync_locals_from_env` pull. Mirrors the fast-call (#3317) and
+        // named-dispatch (#3323) paths: `sub take($n) { $seen = $n }` writes its
+        // enclosing `$seen` by name. `free_var_writes` is empty for a pure body
+        // (no cost); the topic is excluded as a per-call alias.
+        for sym in &cf.code.free_var_writes {
+            sym.with_str(|fname| {
+                if fname != "_" && fname != "@_" && fname != "%_" {
+                    self.pending_rw_writeback_sources.push(fname.to_string());
+                }
+            });
+        }
+
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),
             Ok(()) => {
@@ -1636,6 +1651,17 @@ impl Interpreter {
                     self.env_dirty = true;
                 }
             }
+        }
+
+        // Slice F (env<->locals coherence): record the captured-outer variables
+        // this body writes so the call-site op writes them straight through to the
+        // caller's local slots (see `call_compiled_function_positional_light`).
+        for sym in &cf.code.free_var_writes {
+            sym.with_str(|fname| {
+                if fname != "_" && fname != "@_" && fname != "%_" {
+                    self.pending_rw_writeback_sources.push(fname.to_string());
+                }
+            });
         }
 
         match result {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -164,6 +164,11 @@ impl Interpreter {
                                 name_str,
                             )?;
                             self.stack.push(result);
+                            // Slice F: drain any captured-outer writes the body
+                            // recorded through to this caller frame's local slots
+                            // (the slow dispatch path drains too; the cached fast
+                            // path must as well or a second call's write is lost).
+                            self.apply_pending_rw_writeback(code);
                             // Compiled path: positional_light's scoped-overlay
                             // merge already sets env_dirty iff a captured-outer
                             // write happened. A blanket set here would force a
@@ -217,6 +222,10 @@ impl Interpreter {
                         }
                         let result = self.call_compiled_function_light(cf, args, compiled_fns)?;
                         self.stack.push(result);
+                        // Slice F: drain captured-outer writes through to this
+                        // caller frame's local slots (see the positional-light
+                        // cached path above).
+                        self.apply_pending_rw_writeback(code);
                         // Compiled path: light's scoped-overlay merge already
                         // signals env_dirty only on a captured-outer write.
                         return Ok(());

--- a/t/light-call-captured-var-writeback-coherence.t
+++ b/t/light-call-captured-var-writeback-coherence.t
@@ -1,0 +1,109 @@
+use Test;
+
+# Slice F (env<->locals coherence): a sub that mutates a captured outer lexical
+# (`sub take($n) { $seen = $n }`) reaches `env` by name, but the caller's local
+# slot was kept coherent only by the reverse `sync_locals_from_env` pull. The
+# 0-arg fast path (#3317), named/qualified path (#3323), and method path (#3322)
+# already write such mutations through; this covers the positional-light and
+# named-light dispatch paths (the common `sub f($n) { ... }` / `sub f(:$v) { ... }`
+# shapes) AND their cached fast paths (a second call hits the cache, which must
+# also drain the write-through or the second call's mutation is lost). Run with
+# `MUTSU_NO_REVERSE_SYNC=1` to confirm coherence without the reverse pull.
+
+plan 12;
+
+# Positional param, single captured-outer write.
+{
+    my $seen = 0;
+    sub take($n) { $seen = $n }
+    take(5);
+    is $seen, 5, 'positional-light captured-outer write visible';
+}
+
+# Named param, single captured-outer write.
+{
+    my $got;
+    sub with-named(:$value) { $got = $value }
+    with-named(value => 7);
+    is $got, 7, 'named-light captured-outer write visible';
+}
+
+# Two pure overwrites through the cached positional-light path.
+{
+    my $last = 0;
+    sub setit($n) { $last = $n }
+    setit(1);
+    setit(9);
+    is $last, 9, 'second cached positional-light call overwrites caller';
+}
+
+# Compound accumulation across calls (callee reads then writes the captured var).
+{
+    my $acc = 0;
+    sub addto($n) { $acc += $n }
+    addto(3);
+    addto(4);
+    is $acc, 7, 'compound += accumulates across cached positional-light calls';
+}
+
+# Read-modify-write accumulation.
+{
+    my $c = 10;
+    sub bump($x) { $c = $c + $x }
+    bump(1);
+    bump(1);
+    is $c, 12, 'read-modify-write accumulates across calls';
+}
+
+# Two captured-outer scalars written in one positional call.
+{
+    my $p = 0;
+    my $q = 0;
+    sub setpq($a, $b) { $p = $a; $q = $b }
+    setpq(5, 9);
+    is $p, 5, 'first captured-outer scalar written via positional-light';
+    is $q, 9, 'second captured-outer scalar written via positional-light';
+}
+
+# Captured-outer array push.
+{
+    my @log;
+    sub rec($x) { @log.push($x) }
+    rec("a");
+    rec("b");
+    is @log.join(","), "a,b", 'captured-outer array push via positional-light';
+}
+
+# Captured-outer string mutate.
+{
+    my $name = "x";
+    sub setname($s) { $name = $s }
+    setname("hi");
+    is $name, "hi", 'captured-outer string write via positional-light';
+}
+
+# Named param accumulation across cached calls.
+{
+    my $total = 0;
+    sub addn(:$by) { $total += $by }
+    addn(by => 2);
+    addn(by => 3);
+    is $total, 5, 'named-light captured-outer accumulates across cached calls';
+}
+
+# Caller slot stays coherent for a later expression.
+{
+    my $base = 0;
+    sub setbase($n) { $base = $n }
+    setbase(40);
+    is $base + 2, 42, 'caller slot coherent in a later expression';
+}
+
+# Post-increment of a captured-outer scalar across calls.
+{
+    my $ticks = 0;
+    sub tick($unused) { $ticks++ }
+    tick(0);
+    tick(0);
+    is $ticks, 2, 'post-increment of captured-outer var accumulates across calls';
+}


### PR DESCRIPTION
## Summary

The common `sub f(\$n) { \$captured = \$n }` / `sub f(:\$v) { \$captured = \$v }` shapes dispatch through the **positional-light / light** fast paths, not the 0-arg fast path (#3317), named/qualified path (#3323), or method path (#3322) that already write captured-outer mutations through. So under `MUTSU_NO_REVERSE_SYNC=1` the caller's captured scalar stayed stale.

This continues the dual-store write-through grind (#3304–#3311, #3317, #3318, #3320, #3322, #3323).

## Change

Two parts, mirroring the other dispatch paths:
- **Record** the body's compile-time `free_var_writes` (minus the topic `_`/`@_`/`%_`) in `pending_rw_writeback_sources` at the exit of `call_compiled_function_light` and `call_compiled_function_positional_light`. Pure bodies record nothing.
- **Drain** `apply_pending_rw_writeback` at the *cached* light / positional-light dispatch paths in `exec_call_func_op`, which call the light functions directly but previously did not drain — so a **second (cache-hit) call's mutation was silently lost** (a pure overwrite reverted, an accumulation stalled). The slow dispatch path already drained.

Removes `t/reverse-metaop-regression.t`, `t/catch-in-blocks.t`, and `t/scalar-param-container-share.t` from the reverse-sync dependency surface. Single-level only; cross-frame propagation still relies on the reverse pull.

## Tests

- pin: `t/light-call-captured-var-writeback-coherence.t` (12 cases, `ON == OFF == raku`) — single write, two-call overwrite, `+=`/RMW accumulation across cached calls, `++`, multi-var, array push, string, named-param accumulation
- `make test` PASS (9463), no regressions; `fib(27)` perf neutral (drain is a no-op early-return for pure bodies)

This touches hot dispatch fast paths; the release-build roast CI is the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)