### PR TITLE
feat(single-store): write a deferred role body's captured-outer mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -851,6 +851,19 @@ impl Interpreter {
         // this Interpreter via `run_nested`, sharing the same interpreter + env directly.
         let (code, compiled_fns) = self.compile_block_raw(stmts);
         let result = self.run_nested(&code, &compiled_fns);
+        // Slice F (env<->locals coherence): a deferred role body that mutates an
+        // outer lexical (`role R { $side = @outer.elems * 100 }`) writes it into
+        // `env` by name; record those names so the caller (the role-registration
+        // opcode, which holds the outer `code`) writes them through to the outer
+        // frame's local slots, dropping the dependency on the reverse pull. The
+        // topic is excluded as a per-call alias.
+        for sym in &code.free_var_writes {
+            sym.with_str(|fname| {
+                if fname != "_" && fname != "@_" && fname != "%_" {
+                    self.pending_rw_writeback_sources.push(fname.to_string());
+                }
+            });
+        }
         // Mirror `run_block_raw`'s trailing DESTROY pass (may run user code, so
         // it needs the env loaned).
         self.loan_env_for(|i| i.run_pending_instance_destroys())?;

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1584,6 +1584,10 @@ impl Interpreter {
                 for stmt in &deferred {
                     self.vm_run_block_raw(std::slice::from_ref(stmt))?;
                 }
+                // Slice F: write the deferred body's outer-lexical mutations
+                // through to this caller frame's local slots (vm_run_block_raw
+                // recorded them); keeps `$side` coherent without the reverse pull.
+                self.apply_pending_rw_writeback(code);
             }
 
             // Gather deferred custom traits from role registration


### PR DESCRIPTION
## Summary

A deferred role body that mutates an outer lexical — `role R { $side = @outer.elems * 100 }` — runs in-place via `vm_run_block_raw` → `run_nested`, writing `$side` into `env` **by name**. The outer frame's local slot stays stale unless the reverse pull (`sync_locals_from_env`) repairs it. This closes that captured-outer write-through gap for the **role-registration path**, mirroring the same fix already landed for fast/named/method/light dispatch (#3317 / #3322 / #3323 / #3326).

## How

- `vm_run_block_raw` records the nested body's `free_var_writes` (topic `$_`/`@_`/`%_` excluded) into `pending_rw_writeback_sources`.
- `exec_register_role_op`, which holds the outer `code`, drains them via `apply_pending_rw_writeback(code)` after the deferred-body loop — writing the changed outer lexicals through to the caller frame's local slots.

Both halves are load-bearing: recording without draining (or vice versa) is inert.

## Verification

- Pin: `t/run-nested-role-body.t` (already present from #3095) now passes under `MUTSU_NO_REVERSE_SYNC=1`. Confirmed it **fails** `is $side, 300` without this change (toggle sanity-checked).
- `make test` PASS (9464), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)