### PR TITLE
feat(single-store): write a deferred class body's captured-outer mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1011,6 +1011,40 @@ impl Interpreter {
         // `vm_run_block_raw`. `run_nested` saves/resets/restores the per-execution
         // registers and flags env_dirty so the outer locals re-sync from env.
         let result = self.run_nested(&code, &compiled_fns);
+        // Slice F (env<->locals coherence): a deferred class/role body that
+        // mutates an outer lexical (`class C { $tracker = 99 }`) writes it into
+        // `env` by name; record those names so the caller (the class/role
+        // registration opcode, which holds the outer `code`) writes them through
+        // to the outer frame's local slots, dropping the dependency on the
+        // reverse pull. The topic is excluded as a per-call alias. Mirrors the
+        // VM-side `vm_run_block_raw`.
+        // A class/role body runs with `current_package` set to the package name,
+        // so a write to an outer lexical `$tracker` is recorded in
+        // `free_var_writes` as the qualified `Pkg::tracker` even though the
+        // caller's local slot (and the copied-back env entry) is the bare
+        // `tracker`. Strip the active package prefix so the drain matches the
+        // caller slot.
+        let pkg_prefix = {
+            let pkg = self.current_package();
+            if pkg == "GLOBAL" {
+                String::new()
+            } else {
+                format!("{pkg}::")
+            }
+        };
+        for sym in &code.free_var_writes {
+            sym.with_str(|fname| {
+                let unqualified = if !pkg_prefix.is_empty() {
+                    fname.strip_prefix(&pkg_prefix).unwrap_or(fname)
+                } else {
+                    fname
+                };
+                if unqualified != "_" && unqualified != "@_" && unqualified != "%_" {
+                    self.pending_rw_writeback_sources
+                        .push(unqualified.to_string());
+                }
+            });
+        }
         self.run_pending_instance_destroys()?;
         result.map(|_| ())
     }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1447,6 +1447,13 @@ impl Interpreter {
                 }
             }
 
+            // Slice F: write the deferred body's outer-lexical mutations through
+            // to this caller frame's local slots (`register_class_decl` ran the
+            // body via `run_block_raw`, which recorded them); keeps e.g.
+            // `$tracker` coherent without the reverse pull. This op holds the
+            // outer `code`.
+            self.apply_pending_rw_writeback(code);
+
             self.env_dirty = true;
             Ok(())
         } else {

--- a/t/class-body-captured-var-writeback-coherence.t
+++ b/t/class-body-captured-var-writeback-coherence.t
@@ -1,0 +1,70 @@
+use Test;
+
+# Slice F (env<->locals coherence): a deferred class-body statement that mutates
+# an outer lexical writes it into `env` by name (qualified by the class package
+# while the body runs); the caller frame's local slot must be written through so
+# the value is coherent even with the reverse env->locals pull disabled
+# (MUTSU_NO_REVERSE_SYNC=1). This pins the class-body analogue of the role-body
+# write-through (the `RegisterClass` opcode drains the recorded sources).
+
+plan 10;
+
+# Bare scalar assignment in a class body.
+{
+    my $tracker = 0;
+    class C1 { $tracker = 99; }
+    is $tracker, 99, 'class body bare scalar assignment writes through';
+}
+
+# Expression value (a Method object) assigned to an outer lexical.
+{
+    my $m;
+    class C2 { $m = method foo {}; }
+    isa-ok $m, Method, 'class body method-expression value writes through';
+    is $m.name, 'foo', 'method-expression name visible to caller';
+}
+
+# Reading another outer lexical inside the class body and writing through.
+{
+    my $base = 3;
+    my $side = 0;
+    class C3 { $side = $base * 100; }
+    is $side, 300, 'class body reads outer scalar and writes outer scalar through';
+    is $base, 3, 'outer scalar read is intact after class body';
+}
+
+# Compound assignment (+=) accumulating into an outer lexical.
+{
+    my $sum = 5;
+    class C4 { $sum += 37; }
+    is $sum, 42, 'class body += writes accumulated value through';
+}
+
+# Multiple distinct outer lexicals mutated in one class body.
+{
+    my $a = 0;
+    my $b = 0;
+    class C5 {
+        $a = 1;
+        $b = 2;
+    }
+    is $a, 1, 'first outer lexical writes through';
+    is $b, 2, 'second outer lexical writes through';
+}
+
+# String assignment.
+{
+    my $name = '';
+    class C6 { $name = 'composed'; }
+    is $name, 'composed', 'class body string assignment writes through';
+}
+
+# The class itself remains usable after the body wrote outer state.
+{
+    my $hit = 0;
+    class C7 {
+        $hit = 1;
+        method who { 'C7' }
+    }
+    is C7.new.who ~ ":$hit", 'C7:1', 'class is usable and body side effect visible';
+}


### PR DESCRIPTION
## Summary

A deferred class-body statement that mutates an outer lexical — `class C { $tracker = method foo {} }` or `class C { $x = 99 }` — runs during class registration via `register_class_decl` → `run_block_raw`, writing the lexical into `env` **by name**. The caller frame's local slot stays stale unless the reverse pull (`sync_locals_from_env`) repairs it. This is the **class-body analogue of the role-body write-through (#3327)**, closing the same captured-outer gap already handled for fast/named/method/light dispatch (#3317 / #3322 / #3323 / #3326).

## How

- `run_block_raw` now records the body's `free_var_writes` (topic `$_`/`@_`/`%_` excluded) into `pending_rw_writeback_sources`, mirroring the VM-side `vm_run_block_raw`.
- A class/role body runs with `current_package` set to the package name, so an outer write is recorded **qualified** (`Pkg::tracker`) even though the caller's slot — and the copied-back env entry — is the bare `tracker`. The active package prefix is stripped so the drain matches the caller slot.
- `exec_register_class_op` (the `RegisterClass` opcode), which holds the outer `code`, drains them via `apply_pending_rw_writeback(code)`.

## Verification

- Pin: `t/class-body-captured-var-writeback-coherence.t` (10 cases; ON = OFF = raku). The isolated probe goes `0` → `99` under `MUTSU_NO_REVERSE_SYNC=1` with this change.
- Fixes `t/methods-instance-regressions.t` subtests 4–5 under OFF.
- `make test` PASS (9474), no regressions.

## Out of scope (deferred)

- A nested method **declared inside a method body** that captures an outer lexical (`method foo { my $a=42; method bar { $tracker=$a } }`) remains OFF-stale — the multi-frame retention wall.
- Reading an outer **array** inside a class body (`@data.elems` returning 1) is a separate pre-existing visibility bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)