### PR TITLE
feat(single-store): write imported symbols through to the caller slot (Slice F coherence)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4345,6 +4345,19 @@ impl Interpreter {
                 if !target.contains("::") {
                     self.unsuppress_name(&target);
                 }
+                // Slice F (env<->locals coherence): `import` writes the symbol
+                // into env by name, but a later bare reference (e.g. an imported
+                // `constant c`) may read a stale caller local slot when the
+                // reverse env->locals pull is disabled. Record the imported
+                // name (sigil stripped to match the local-slot key) so the
+                // ImportModule opcode writes it through to the caller slot.
+                if !target.contains("::") {
+                    let slot_name = match target.chars().next() {
+                        Some('$' | '@' | '%') => target[1..].to_string(),
+                        _ => target.clone(),
+                    };
+                    self.pending_rw_writeback_sources.push(slot_name);
+                }
                 self.env.insert(target, value);
             }
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -772,6 +772,10 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        // Slice F: write imported symbols through to the caller's local slots
+        // (import_module recorded their names); keeps an imported `constant c`
+        // coherent without the reverse pull. This op holds the outer `code`.
+        self.apply_pending_rw_writeback(code);
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place

--- a/t/import-constant-writeback-coherence.t
+++ b/t/import-constant-writeback-coherence.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Slice F (env<->locals coherence): `import` writes the imported symbols into
+# `env` by name; a later bare reference (e.g. an imported `constant c`) must be
+# written through to the caller's local slot so it is coherent even with the
+# reverse env->locals pull disabled (MUTSU_NO_REVERSE_SYNC=1). The ImportModule
+# opcode drains the names import_module recorded.
+
+plan 6;
+
+{
+    module A {
+        sub a() is export { 41 }
+        constant c is export = 10;
+    }
+    import A;
+    is a(), 41, 'imported sub is callable';
+    is c, 10, 'imported constant is visible to the caller';
+}
+
+{
+    module B {
+        constant PI is export = 3;
+        constant E is export = 2;
+    }
+    import B;
+    is PI, 3, 'first imported constant visible';
+    is E, 2, 'second imported constant visible';
+}
+
+{
+    module D {
+        constant greeting is export = 'hi';
+    }
+    import D;
+    # Use the imported constant in an expression to exercise the local slot read.
+    is greeting ~ '!', 'hi!', 'imported constant usable in an expression';
+}
+
+{
+    module F {
+        constant SIX is export = 6;
+    }
+    import F;
+    my $doubled = SIX * 2;
+    is $doubled, 12, 'imported constant participates in arithmetic';
+}


### PR DESCRIPTION
## Summary

`import A` writes a module's exported symbols (subs, vars, `constant`s) into `env` **by name**, then relies on the reverse env→locals pull (`sync_locals_from_env`) to make a later bare reference see them. With the pull disabled, an imported `constant c` reads a stale caller local slot (`Nil`) instead of the imported value. This closes that gap the same way as the rest of the Slice F write-through family (#3317 / #3322 / #3323 / #3326 / #3327 / #3328).

## How

- `import_module` records each imported symbol's name — sigil stripped to match the local-slot key, qualified (`::`) names skipped — into `pending_rw_writeback_sources`.
- `exec_import_module_op` (the `ImportModule` opcode), which holds the outer `code`, drains them via `apply_pending_rw_writeback(code)` right after the import.

## Verification

- Pin: `t/import-constant-writeback-coherence.t` (6 cases; ON = OFF = raku). The probe `c` goes `Nil` → `10` under `MUTSU_NO_REVERSE_SYNC=1` with this change.
- Fixes `t/import-statement.t` subtest 2 under OFF.
- `make test` PASS (9470), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)