### PR TITLE
feat(single-store): write a submethod BUILD/TWEAK's captured-outer mutations through to the caller slot (Slice F)

### DIFF
--- a/docs/slice-f-reverse-sync-deps.txt
+++ b/docs/slice-f-reverse-sync-deps.txt
@@ -63,8 +63,6 @@ roast/S12-attributes/instance.t
 roast/S12-attributes/mutators.t
 roast/S12-class/basic.t
 roast/S12-coercion/coercion-methods.t
-roast/S12-construction/BUILD.t
-roast/S12-construction/TWEAK.t
 roast/S12-construction/destruction.t
 roast/S12-construction/roles-6e.t
 roast/S12-introspection/attributes.t

--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -635,6 +635,17 @@ write-site does not yet write through to the caller's local slot.
    (S02-types/{set,pair}, etc.) fail OFF on a `.gist`/stringification subtest —
    likely a `$_`/loop-topic or `$/`-list slot left stale by a path not yet
    write-through'd. Probe individually; several may share mechanism 2/5.
+8. **construction captured-outer (`submethod BUILD`/`TWEAK`) — DONE.** A
+   `.new`/`.bless` that runs a `submethod BUILD`/`TWEAK` via the interpreter's
+   `run_build_phase`/`run_tweak_phase` bypasses the compiled-method
+   `merge_method_env` writeback, so a body like `my $n; submethod TWEAK { $n++ }`
+   left the caller slot reconciled only by the barrier pull. Fix:
+   `reconcile_locals_from_env_at_site` mirrors the pull at the `.new`/`.bless`
+   call site (CallMethod + CallMethodMut tails), and `mro_has_build_or_tweak`
+   stops the native-construct fast path from marking a BUILD/TWEAK class env-pure
+   (it isn't — TWEAK can mutate caller env). Removed S12-construction/{BUILD,TWEAK}.t
+   deps. pin: t/construction-captured-outer-coherence.t. (Remaining S12-construction
+   deps: destruction.t #3 is `DESTROY`-at-GC, a different mechanism.)
 
 ### Order of attack (next sessions)
 dynamic-var env-read (2) → `our` (3) → method-call `pending_local_updates`

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -240,6 +240,21 @@ impl Interpreter {
         }
     }
 
+    /// True if any class in `cn`'s MRO declares a `BUILD` or `TWEAK` submethod.
+    /// The native construction path (`build_native_default_instance`) runs those
+    /// phases via `run_build_phase`/`run_tweak_phase`, and such a submethod body
+    /// can mutate a *captured-outer* caller lexical (`my $n; submethod TWEAK {
+    /// $n++ }`). So a construction of such a class is NOT env-pure — the caller's
+    /// slot must be reconciled at the call site (Slice F). Used by the VM `.new`
+    /// dispatch to set `method_dispatch_pure` correctly.
+    pub(crate) fn mro_has_build_or_tweak(&self, cn: &str) -> bool {
+        self.mro_readonly(cn).iter().any(|cls| {
+            self.registry().classes.get(cls).is_some_and(|cd| {
+                cd.methods.contains_key("BUILD") || cd.methods.contains_key("TWEAK")
+            })
+        })
+    }
+
     /// Default-construct `class_name` natively when it is eligible (see
     /// `is_native_default_constructible`). Returns `None` for ineligible
     /// classes so callers fall through to the full constructor dispatch.

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -104,9 +104,14 @@ impl Interpreter {
             && let Value::Package(class_name) = &target
             && let Some(result) = loan_env!(self, try_native_default_construct(*class_name, &args))
         {
-            // Native construction is pure data assembly: it returns a fresh
-            // instance and writes nothing to the caller env (Slice 6.3).
-            self.method_dispatch_pure = true;
+            // Native construction of an attribute-only class is pure data assembly
+            // (named args + defaults; writes nothing to the caller env, Slice 6.3).
+            // BUT if the class has a `submethod BUILD`/`TWEAK`, the native path runs
+            // that phase, whose body can mutate a captured-outer caller lexical
+            // (`my $n; submethod TWEAK { $n++ }`) — so that construction is NOT
+            // env-pure: leave the dispatch impure so the call site reconciles the
+            // caller's slot (Slice F, `reconcile_locals_from_env_at_site`).
+            self.method_dispatch_pure = !self.mro_has_build_or_tweak(&class_name.resolve());
             return result;
         }
         // Native built-in construction: `Buf`/`Blob` (byte overlay), `utf8`/
@@ -1477,8 +1482,12 @@ impl Interpreter {
             && let Value::Package(class_name) = &target
             && let Some(result) = loan_env!(self, try_native_default_construct(*class_name, &args))
         {
-            // Pure construction: fresh instance, no caller-env write (Slice 6.3).
-            self.method_dispatch_pure = true;
+            // Pure construction: fresh instance, no caller-env write (Slice 6.3) —
+            // UNLESS the class has a `submethod BUILD`/`TWEAK` whose body can mutate
+            // a captured-outer caller lexical, in which case the dispatch is impure
+            // and the call site must reconcile the caller slot (Slice F twin of the
+            // non-mut path; `reconcile_locals_from_env_at_site`).
+            self.method_dispatch_pure = !self.mro_has_build_or_tweak(&class_name.resolve());
             return result;
         }
         // Native built-in construction (mut path twin of the above).

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1528,6 +1528,14 @@ impl Interpreter {
                         }
                     }
                 }
+                // Slice F: reconcile a captured-outer lexical mutated by an
+                // interpreter-dispatched construction (`.new`/`.bless` running a
+                // `submethod BUILD`/`TWEAK`) at the call site, since that path
+                // bypasses the compiled-method writeback. See the CallMethod twin
+                // and `reconcile_locals_from_env_at_site`.
+                if mark_dirty && matches!(method.as_str(), "new" | "bless") {
+                    self.reconcile_locals_from_env_at_site(code);
+                }
             }
         }
         Ok(())

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1233,6 +1233,17 @@ impl Interpreter {
                         }
                     }
                 }
+                // Slice F: an interpreter-dispatched construction (`.new`/`.bless`
+                // running a `submethod BUILD`/`TWEAK`) may mutate a captured-outer
+                // lexical by name. That interpreter build path bypasses the
+                // compiled-method `merge_method_env` writeback, so the caller slot
+                // is otherwise only reconciled by the blanket `sync_locals_from_env`
+                // barrier pull. Reconcile it here at the call site instead (gated on
+                // `mark_dirty`, i.e. only when ON would have pulled) so the slot
+                // stays coherent without the reverse pull.
+                if mark_dirty && matches!(method, "new" | "bless") {
+                    self.reconcile_locals_from_env_at_site(code);
+                }
                 // Wrap map/grep results back into HyperSeq/RaceSeq
                 if let Some(is_hyper) = hyper_race_wrap
                     && let Some(result) = self.stack.pop()

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -369,6 +369,42 @@ impl Interpreter {
         }
     }
 
+    /// Slice F write-through for an interpreter-dispatched construction
+    /// (`.new`/`.bless` that runs a `submethod BUILD`/`TWEAK` via the
+    /// interpreter's `run_build_phase`). Those submethods can mutate a
+    /// captured-outer lexical by name (`my $n; submethod BUILD { $n++ }`), but —
+    /// unlike a compiled method (whose `merge_method_env` records
+    /// `pending_rw_writeback_sources`) — the interpreter build path never reaches
+    /// that machinery, so the caller's slot is only reconciled by the blanket
+    /// `sync_locals_from_env` barrier pull (`env_dirty`). This mirrors that pull
+    /// *at the construction call site* and unconditionally (not gated by the
+    /// campaign toggle), so the slot stays coherent without the reverse pull. The
+    /// per-slot skips match `sync_locals_from_env` exactly (HashSlotRef binding
+    /// cells / `!attr` locals), so under reverse-sync ON it is byte-identical to
+    /// the barrier pull it duplicates. Only called on the impure path
+    /// (`!method_dispatch_pure`), i.e. exactly when ON would have pulled.
+    pub(super) fn reconcile_locals_from_env_at_site(&mut self, code: &CompiledCode) {
+        for (i, name) in code.locals.iter().enumerate() {
+            if matches!(self.locals[i], Value::HashSlotRef { .. }) {
+                continue;
+            }
+            if name.starts_with('!') {
+                continue;
+            }
+            if let Some(val) = self.env().get(name).cloned() {
+                self.locals[i] = val;
+            } else if let Some(bare) = name
+                .strip_prefix('$')
+                .or_else(|| name.strip_prefix('@'))
+                .or_else(|| name.strip_prefix('%'))
+                .or_else(|| name.strip_prefix('&'))
+                && let Some(val) = self.env().get(bare).cloned()
+            {
+                self.locals[i] = val;
+            }
+        }
+    }
+
     /// Record a by-name caller-lexical env write that did NOT flow through
     /// `set_env_with_main_alias` (the single by-name writer that auto-logs). Some
     /// ops mutate a caller lexical with a direct `env_mut().insert` — e.g. the

--- a/t/construction-captured-outer-coherence.t
+++ b/t/construction-captured-outer-coherence.t
@@ -1,0 +1,84 @@
+use Test;
+
+# Slice F coherence pin: a `submethod BUILD`/`TWEAK` run during `.new` can mutate
+# a *captured-outer* caller lexical by name. Unlike a compiled method (whose
+# `merge_method_env` records the write-through), the interpreter build phase
+# bypasses that machinery, so the caller's slot was previously only reconciled by
+# the blanket reverse `sync_locals_from_env` pull. These cases must stay coherent
+# WITHOUT that pull (run the file with MUTSU_NO_REVERSE_SYNC=1 to verify).
+
+plan 9;
+
+# 1. BUILD mutates a captured-outer scalar counter.
+{
+    my $counter = 0;
+    class B1 { submethod BUILD { $counter++ } }
+    B1.new;
+    is $counter, 1, 'BUILD captured-outer scalar increment is visible to caller';
+}
+
+# 2. TWEAK mutates a captured-outer string (no attributes).
+{
+    my $log = '';
+    class T1 { submethod TWEAK { $log ~= 'T1' } }
+    T1.new;
+    is $log, 'T1', 'TWEAK captured-outer string append (no attrs) is visible';
+}
+
+# 3. TWEAK on an attribute-bearing class (native construction path).
+{
+    my $log = '';
+    class T2 { has $.x; submethod TWEAK { $log ~= 'T2' } }
+    T2.new;
+    is $log, 'T2', 'TWEAK captured-outer write through the attribute native path';
+}
+
+# 4. Inheritance: parent + child BUILD both append, in order.
+{
+    my $calls = '';
+    class P3 { submethod BUILD { $calls ~= 'P' } }
+    class C3 is P3 { submethod BUILD { $calls ~= 'C' } }
+    C3.new;
+    is $calls, 'PC', 'inherited BUILD submethods both mutate the captured-outer var';
+}
+
+# 5. Inheritance with attributes: parent + child TWEAK, in order.
+{
+    my $tracker = '';
+    class P4 { has $.x; submethod TWEAK { $tracker ~= "P4\n" } }
+    class C4 is P4 { has $.y; submethod TWEAK { $tracker ~= "C4\n" } }
+    C4.new(x => 1, y => 2);
+    is $tracker, "P4\nC4\n", 'inherited TWEAK with attributes preserves order + captured-outer';
+}
+
+# 6. BUILD mutates a captured-outer array via push.
+{
+    my @seen;
+    class B5 { submethod BUILD { @seen.push('built') } }
+    B5.new;
+    is @seen.join(','), 'built', 'BUILD captured-outer array push is visible';
+}
+
+# 7. Multiple constructions accumulate into the same captured-outer var.
+{
+    my $n = 0;
+    class B6 { submethod TWEAK { $n++ } }
+    B6.new; B6.new; B6.new;
+    is $n, 3, 'repeated construction accumulates captured-outer mutations';
+}
+
+# 8. Construction assigned into a variable (`my $obj = Class.new`) still reconciles.
+{
+    my $hit = 0;
+    class B7 { has $.v; submethod BUILD { $hit = 42 } }
+    my $obj = B7.new;
+    is $hit, 42, 'assigned-construction captured-outer write is visible';
+}
+
+# 9. The constructed instance itself is still correct (no collateral damage).
+{
+    my $side = '';
+    class B8 { has $.v is rw; submethod TWEAK { $side = 'tweaked'; $!v = 99 } }
+    my $o = B8.new;
+    is $o.v ~ '|' ~ $side, '99|tweaked', 'attribute set in TWEAK and captured-outer both hold';
+}


### PR DESCRIPTION
## Summary

Slice F coherence step (single-store campaign): remove the roast-level reverse-sync dependency for **construction-time captured-outer mutations**.

A `.new`/`.bless` that runs a `submethod BUILD`/`TWEAK` executes that phase via the interpreter's `run_build_phase`/`run_tweak_phase`. Unlike a compiled method (whose `merge_method_env` records the write-through, #3322), this interpreter build path never reaches the captured-outer writeback machinery. So a body like `my $n; submethod TWEAK { $n++ }` left the caller's local slot reconciled only by the blanket reverse `sync_locals_from_env` barrier pull (`env_dirty`) — a dependency this campaign is removing.

## Fix

Two coordinated changes:

1. **`reconcile_locals_from_env_at_site`** (`vm_env_helpers.rs`) mirrors the barrier pull *at the `.new`/`.bless` call site* (CallMethod + CallMethodMut tails), with the exact per-slot skips of `sync_locals_from_env` (HashSlotRef binding cells / `!attr`). Gated on `mark_dirty` — only runs when reverse-sync ON would have pulled, so it is byte-identical to the pull it duplicates.
2. **`mro_has_build_or_tweak`** stops the native-construct fast path from marking a BUILD/TWEAK class env-pure. Such a construction is *not* pure (TWEAK can mutate a captured-outer caller lexical), so the dispatch must stay impure to trigger the reconcile. Applied to both the CallMethod and CallMethodMut native-construct twins (`.new` on a variable receiver routes through the mut path).

Removes the `S12-construction/{BUILD,TWEAK}.t` reverse-sync deps (117 → 115). ON behavior is unchanged: the blanket net is kept; the reconcile duplicates the pull it will eventually replace when `env_dirty` is deleted.

## Validation

- `BUILD.t` / `TWEAK.t` pass with `MUTSU_NO_REVERSE_SYNC=1` **and** ON.
- New pin `t/construction-captured-outer-coherence.t` (9 cases) passes both ways.
- Full ON whitelist scan of S12/S14 (116 files): 0 regressions.
- `make test`: PASS. clippy/fmt clean.

Remaining `S12-construction` dep `destruction.t #3` is `DESTROY`-at-GC, a separate mechanism (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)