### PR TITLE
feat(single-store): drain captured-outer writeback on the exception-escape path (Slice F coherence)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -190,7 +190,7 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
         第32–33セッションで実依存を多数発見・write-through 化: 0-arg fast-call 捕捉（#3317）・dynamic var callee write（#3320）・
         regex `~~` match（#3321）・method 捕捉（#3322）・qualified/our sub 捕捉（#3323）・dynamic var env-read（#3324）・
         light/positional-light 捕捉（#3326）・**deferred role body 捕捉（#3327）**・**deferred class body 捕捉（#3328）**・
-        **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）・**例外脱出 UNDO/LEAVE 捕捉（#3331）**。
+        **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）・**例外脱出 UNDO/LEAVE 捕捉（#3332）**。
       pin: `t/{rw-param,method-rw-param,closure-captured-var,rw-sub-lvalue,mut-method-receiver,sigilless-alias,dynamic-var,
       qualified-sub-captured-var,method-captured-var,light-call-captured-var,run-nested-role-body,class-body-captured-var,
       import-constant,undo-phaser}-writeback-coherence.t` 他。
@@ -198,7 +198,7 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
       - carrier（EVAL/regex/`s///`・require BEGIN EVAL）・supply/concurrent（done/react/whenever）・attribute trait_mod・slurpy-junction。
       DEFERRED（壁）= multi-frame retention（caller→mid→writer・lazy-eval 衝突 #3317）・range map/grep（lazy-eval）・
       pair-value hash（§4-A container-identity deep wall）・**nested-sub の例外脱出 UNDO 捕捉**（`outer(){ my $ng; sub fails(){ UNDO {$ng~=...}; die }; ...}`：
-      nested named sub は compiled_fns 不在で OTF/interpreter fallback 経路へ → pending 未記録。top-level sub は #3331 で解消済・roast keep-undo.t は top-level のみ使用）。
+      nested named sub は compiled_fns 不在で OTF/interpreter fallback 経路へ → pending 未記録。top-level sub は #3332 で解消済・roast keep-undo.t は top-level のみ使用）。
       詳細・手順 = memory `project_dual_store_unification_next`。
       別途 ON-mode 既存バグ（dual-store 無関係・別 PR）: class body 内で `@outer.elems` が 1（outer array visibility）。
 - [ ] **Slice F（収束点）** — coarse 機構削除（`env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`/`saved_env_dirty`）。

--- a/PLAN.md
+++ b/PLAN.md
@@ -190,17 +190,16 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
         第32–33セッションで実依存を多数発見・write-through 化: 0-arg fast-call 捕捉（#3317）・dynamic var callee write（#3320）・
         regex `~~` match（#3321）・method 捕捉（#3322）・qualified/our sub 捕捉（#3323）・dynamic var env-read（#3324）・
         light/positional-light 捕捉（#3326）・**deferred role body 捕捉（#3327）**・**deferred class body 捕捉（#3328）**・
-        **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）。
+        **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）・**例外脱出 UNDO/LEAVE 捕捉（#3331）**。
       pin: `t/{rw-param,method-rw-param,closure-captured-var,rw-sub-lvalue,mut-method-receiver,sigilless-alias,dynamic-var,
       qualified-sub-captured-var,method-captured-var,light-call-captured-var,run-nested-role-body,class-body-captured-var,
-      import-constant}-writeback-coherence.t` 他。
+      import-constant,undo-phaser}-writeback-coherence.t` 他。
       **残る OFF 依存（roast/`t/` 共通）= 次セッション以降のグラインド対象**:
-      - **keep-undo / 例外脱出 writeback（root cause 判明・slice6-8 より大）**: call dispatch の Err 経路で free-var writeback 記録も
-        env merge もスキップ（`run_leave_queue_guarded` が UNDO を sub `code` 内実行→`$ng` を sub env に書くが Err 返りで writeback 未到達）。
-        要 = 各 dispatch variant の Err 経路で pending 記録 + call-site が Err 伝播前に drain。probe=`tmp/probe-undo.p6`。
       - carrier（EVAL/regex/`s///`・require BEGIN EVAL）・supply/concurrent（done/react/whenever）・attribute trait_mod・slurpy-junction。
       DEFERRED（壁）= multi-frame retention（caller→mid→writer・lazy-eval 衝突 #3317）・range map/grep（lazy-eval）・
-      pair-value hash（§4-A container-identity deep wall）。詳細・手順 = memory `project_dual_store_unification_next`。
+      pair-value hash（§4-A container-identity deep wall）・**nested-sub の例外脱出 UNDO 捕捉**（`outer(){ my $ng; sub fails(){ UNDO {$ng~=...}; die }; ...}`：
+      nested named sub は compiled_fns 不在で OTF/interpreter fallback 経路へ → pending 未記録。top-level sub は #3331 で解消済・roast keep-undo.t は top-level のみ使用）。
+      詳細・手順 = memory `project_dual_store_unification_next`。
       別途 ON-mode 既存バグ（dual-store 無関係・別 PR）: class body 内で `@outer.elems` が 1（outer array visibility）。
 - [ ] **Slice F（収束点）** — coarse 機構削除（`env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`/`saved_env_dirty`）。
       **前提 = roast-level reverse-sync 依存（carrier/supply）も write-through 化 or cell 共有で解消。** ここで初めて pairs/slip

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -392,7 +392,21 @@ impl Interpreter {
                         loan_env!(self, set_pending_callsite_line(cl));
                     }
                 }
-                let result = self.call_compiled_function_fast(cf, compiled_fns)?;
+                let result = match self.call_compiled_function_fast(cf, compiled_fns) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Slice F (exception-escape coherence): an exceptional exit
+                        // (`die`/`fail`) still ran the callee's UNDO/LEAVE phasers,
+                        // which can mutate a captured-outer variable (e.g. `UNDO {
+                        // $ng ~= "U" }`). The body recorded those writes into
+                        // `pending_rw_writeback_sources`; drain them to this caller's
+                        // local slots *before* propagating the error, exactly as the
+                        // Ok path does, so the reverse `sync_locals_from_env` pull is
+                        // not required for coherence.
+                        self.apply_pending_rw_writeback(code);
+                        return Err(e);
+                    }
+                };
                 self.stack.push(result);
                 // Slice F: write any captured-outer variables the callee mutated
                 // straight through to this caller's local slots, so they stay
@@ -528,14 +542,24 @@ impl Interpreter {
                 .filter(|s| !s.is_empty()),
             _ => None,
         };
-        let result = self.dispatch_func_call_inner(
+        let result = match self.dispatch_func_call_inner(
             code,
             &name,
             args,
             arg_sources,
             call_me_override,
             compiled_fns,
-        )?;
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                // Slice F (exception-escape coherence): an exceptional exit still
+                // ran the callee's UNDO/LEAVE phasers, which can mutate a
+                // captured-outer variable. Drain those recorded writes to the
+                // caller's local slots before propagating the error.
+                self.apply_pending_rw_writeback(code);
+                return Err(e);
+            }
+        };
         if let Some(target) = lvalue_writeback_target
             && let Some(slot) = self.find_local_slot(code, &target)
             // Mirror the reverse pull's invariant: never clobber a live

--- a/t/undo-phaser-writeback-coherence.t
+++ b/t/undo-phaser-writeback-coherence.t
@@ -1,0 +1,118 @@
+use Test;
+
+# Slice F (env<->locals coherence): an *exceptional* exit (`die`/`fail`) still
+# runs a routine's UNDO/LEAVE phasers, which can mutate a captured-outer lexical
+# (e.g. `UNDO { $ng ~= "U" }`). The body records those captured-outer writes into
+# `pending_rw_writeback_sources`, but the call-site op used `?` to propagate the
+# error, short-circuiting the drain that writes the new env value through to the
+# caller's local slot. With the reverse env->locals pull disabled
+# (MUTSU_NO_REVERSE_SYNC=1) the caller's slot then stayed stale. This pins the
+# exception-escape drain: the call site now drains pending writeback sources
+# before propagating the error, exactly as the success path does.
+
+plan 12;
+
+# --- UNDO after die, value caught by an outer `try` -------------------------
+my $ng1 = "";
+sub fails1() {
+    UNDO { $ng1 ~= "U"; }
+    die "boom";
+}
+try { fails1(); }
+is $ng1, "U", 'UNDO captured-outer write after die writes through';
+
+# --- UNDO after fail --------------------------------------------------------
+my $ng2 = "";
+sub fails2() {
+    UNDO { $ng2 ~= "F"; }
+    fail "nope";
+}
+try { fails2(); }
+is $ng2, "F", 'UNDO captured-outer write after fail writes through';
+
+# --- LEAVE (runs on every exit, including exceptional) ----------------------
+my $log3 = "";
+sub leaver3() {
+    LEAVE { $log3 ~= "L"; }
+    die "x";
+}
+try { leaver3(); }
+is $log3, "L", 'LEAVE captured-outer write after die writes through';
+
+# --- Compound mutation (+=) in UNDO ----------------------------------------
+my $count4 = 0;
+sub fails4() {
+    UNDO { $count4 += 5; }
+    die "x";
+}
+try { fails4(); }
+is $count4, 5, 'UNDO compound += writes through';
+
+# --- UNDO fires twice across two failing calls (accumulation) ---------------
+my $acc5 = 0;
+sub fails5() {
+    UNDO { $acc5++; }
+    die "x";
+}
+try { fails5(); }
+try { fails5(); }
+is $acc5, 2, 'UNDO accumulation across two failing calls writes through';
+
+# --- Captured-outer string append in UNDO ----------------------------------
+my $trail6 = "";
+sub fails6() {
+    UNDO { $trail6 ~= "a"; }
+    die "x";
+}
+try { fails6(); }
+try { fails6(); }
+is $trail6, "aa", 'UNDO string append accumulation writes through';
+
+# --- Both KEEP (skipped on failure) and UNDO (run) --------------------------
+my $kept7 = 0;
+my $undone7 = 0;
+sub fails7() {
+    KEEP { $kept7++; }
+    UNDO { $undone7++; }
+    die "x";
+}
+try { fails7(); }
+is $kept7, 0, 'KEEP does not run on failure (caller slot stays 0)';
+is $undone7, 1, 'UNDO runs on failure and writes through';
+
+# --- KEEP on SUCCESS still writes through (control) -------------------------
+my $kept8 = 0;
+sub ok8() {
+    KEEP { $kept8++; }
+    42;
+}
+ok8();
+is $kept8, 1, 'KEEP captured-outer write on success writes through';
+
+# --- LEAVE on success still writes through (control) ------------------------
+my $log9 = "";
+sub ok9() {
+    LEAVE { $log9 ~= "L"; }
+    1;
+}
+ok9();
+is $log9, "L", 'LEAVE captured-outer write on success writes through';
+
+# --- die directly (no phaser) leaves outer write before die visible ---------
+my $pre10 = 0;
+sub fails10() {
+    $pre10 = 7;
+    die "x";
+}
+try { fails10(); }
+is $pre10, 7, 'captured-outer write before die writes through on exception';
+
+# --- Multiple captured vars mutated in UNDO ---------------------------------
+my $a11 = 0;
+my $b11 = 0;
+sub fails11() {
+    UNDO { $a11 = 1; $b11 = 2; }
+    die "x";
+}
+try { fails11(); }
+is "$a11,$b11", "1,2", 'multiple captured-outer writes in UNDO write through';


### PR DESCRIPTION
## Summary

An exceptional exit (`die`/`fail`) still runs a routine's `UNDO`/`LEAVE` phasers, which can mutate a captured-outer lexical (e.g. `UNDO { \$ng ~= \"U\" }`). The callee dispatch records those captured-outer writes into `pending_rw_writeback_sources`, but both the 0-arg fast-call site and the general `dispatch_func_call_inner` call site used `?` to propagate the error, short-circuiting the `apply_pending_rw_writeback` drain that writes the new env value through to the caller's local slot. With the reverse env→locals pull disabled (`MUTSU_NO_REVERSE_SYNC=1`) the caller's slot then stayed stale.

This drains the recorded sources **before** propagating the error, exactly as the success path already does — the exception-escape analogue of the existing write-through family (#3300–#3329).

Makes `roast/S04-phasers/keep-undo.t` (and `enter-leave.t` / `try.t`) pass with reverse-sync **OFF** (they already passed ON).

## Limitation (deferred)

A *nested* named sub (declared inside another sub) is not in `compiled_fns`, so it dispatches via the OTF/interpreter fallback path which does not record pending sources; that case still relies on the reverse pull and is deferred (noted in `PLAN.md`). The roast `keep-undo` test exercises only top-level subs, which this fixes.

## Test

`t/undo-phaser-writeback-coherence.t` (12 cases; ON == OFF == raku). `make test` PASS (9492).

🤖 Generated with [Claude Code](https://claude.com/claude-code)