### PR TITLE
feat(single-store): drain captured-outer writeback after junction auto-threading (Slice F coherence)

### DIFF
--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -195,6 +195,19 @@ impl Interpreter {
 
         // Thread over the chosen junction: call the function for each eigenstate
         let mut results = Vec::with_capacity(values.len());
+        // Slice F (env<->locals coherence): each eigenstate call dispatches the
+        // function afresh, and each dispatch *clears* `pending_rw_writeback_sources`
+        // on entry, so only the final iteration's captured-outer writes would
+        // survive to the call site. Accumulate the union across all iterations
+        // here so the call site's `apply_pending_rw_writeback` writes every
+        // captured-outer variable the threaded calls mutated (e.g. `$count++` in
+        // `sub j($x) { $count++ }; j(3|4|5)`) straight through to the caller's
+        // local slot, keeping it coherent without the reverse `sync_locals_from_env`
+        // pull. The forward env merge already accumulates the running value in env
+        // across the N calls; this just ensures the final value is pulled into the
+        // caller's slot.
+        let mut accumulated_writeback: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         for eigenstate in values.iter() {
             let mut threaded_args = args.to_vec();
             if let Some(ref pair_key) = is_pair {
@@ -227,7 +240,14 @@ impl Interpreter {
                 )?;
                 results.push(result);
             }
+            // Capture this iteration's recorded captured-outer writes before the
+            // next iteration's dispatch clears the list.
+            accumulated_writeback.extend(std::mem::take(&mut self.pending_rw_writeback_sources));
         }
+
+        // Re-publish the accumulated sources so the call site drains them.
+        self.pending_rw_writeback_sources
+            .extend(accumulated_writeback);
 
         Ok(Some(Value::junction(kind, results)))
     }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -496,6 +496,11 @@ impl Interpreter {
             self.maybe_autothread_func_call(code, &name, &args, &arg_sources, compiled_fns)?
         {
             self.stack.push(autothread_result);
+            // Slice F: the threaded eigenstate calls may have mutated captured-outer
+            // variables (`sub j($x) { $count++ }`); write their accumulated final
+            // env values through to this caller's local slots so they stay coherent
+            // without the reverse `sync_locals_from_env` pull.
+            self.apply_pending_rw_writeback(code);
             self.env_dirty = true;
             return Ok(());
         }

--- a/t/junction-autothread-writeback-coherence.t
+++ b/t/junction-autothread-writeback-coherence.t
@@ -1,0 +1,73 @@
+use Test;
+
+# Slice F (env<->locals coherence): when a Junction argument auto-threads a
+# function call, the call is dispatched once per eigenstate. Each eigenstate
+# dispatch clears `pending_rw_writeback_sources` on entry, so a captured-outer
+# variable mutated by the threaded body (`sub j($x) { $count++ }`) only had the
+# final iteration's write recorded — and the auto-thread call site never drained
+# it at all, relying on the reverse env->locals pull. With that pull disabled
+# (MUTSU_NO_REVERSE_SYNC=1) the caller's slot stayed stale. This pins the fix:
+# the auto-thread loop accumulates the captured-outer writes across all
+# eigenstate calls and the call site writes the final env value through to the
+# caller's local slot.
+
+plan 8;
+
+# A Junction in an untyped scalar param auto-threads; the body increments a
+# captured-outer counter once per eigenstate.
+{
+    my $count = 0;
+    sub j1($x) { $count++ }
+    j1(3 | 4 | 5);
+    is $count, 3, 'autothreaded ++ accumulates through to caller slot';
+}
+
+# Leading scalar param auto-threads even with a trailing slurpy.
+{
+    my $count = 0;
+    sub j2($x, *@a) { $count++ }
+    j2(3 | 4 | 5, 6);
+    is $count, 3, 'autothread with trailing slurpy accumulates to caller slot';
+}
+
+# Compound += accumulation.
+{
+    my $sum = 0;
+    sub j3($x) { $sum += $x }
+    j3(1 | 10 | 100);
+    is $sum, 111, 'autothreaded += sums all eigenstates into caller slot';
+}
+
+# A 2-element junction threads exactly twice.
+{
+    my $count = 0;
+    sub j4($x) { $count++ }
+    j4(1 | 2);
+    is $count, 2, 'two-element junction threads twice';
+}
+
+# String append captured-outer write.
+{
+    my $trail = "";
+    sub j5($x) { $trail ~= $x }
+    j5("a" | "b" | "c");
+    is $trail.comb.sort.join, "abc", 'autothreaded string append reaches caller slot';
+}
+
+# The auto-thread result value itself is still a Junction (unchanged behavior).
+{
+    my $count = 0;
+    sub j6($x) { $count++; $x * 2 }
+    my $r = j6(1 | 2 | 3);
+    ok $r ~~ Junction, 'autothread still returns a Junction result';
+    is $count, 3, 'side-effect counter still accumulates alongside the result';
+}
+
+# Two captured-outer vars mutated by the threaded body.
+{
+    my $n = 0;
+    my $last = 0;
+    sub j7($x) { $n++; $last = $x }
+    j7(7 | 8 | 9);
+    is $n, 3, 'first captured-outer var accumulates under autothread';
+}


### PR DESCRIPTION
## Summary

When a Junction argument auto-threads a function call, the call is dispatched once per eigenstate. Each eigenstate dispatch *clears* `pending_rw_writeback_sources` on entry, so a captured-outer variable mutated by the threaded body (`sub j(\$x) { \$count++ }; j(3|4|5)`) only had the final iteration's write recorded — and the auto-thread call site never drained pending sources at all, instead setting `env_dirty = true` and relying on the reverse env→locals pull. With that pull disabled (`MUTSU_NO_REVERSE_SYNC=1`) the caller's `\$count` slot stayed stale.

The auto-thread loop now accumulates the **union** of captured-outer writes across all eigenstate calls (the forward env merge already accumulates the running value in env across the N calls), and the call site drains them via `apply_pending_rw_writeback`, writing the final env value through to the caller's local slot — the auto-thread analogue of the existing write-through family (#3300–#3332).

This makes `t/slurpy-junction-no-autothread.t` tests 5–6 pass with reverse-sync **OFF** (they already passed ON).

## Test

`t/junction-autothread-writeback-coherence.t` (8 cases; ON == OFF == raku). `make test` PASS (9500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)