### PR TITLE
feat(single-store): write a block-method/gather captured-outer mutation through to the caller slot (Slice F coherence)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1183,6 +1183,17 @@ pub struct Interpreter {
     pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,
     pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
     pub(crate) env_dirty: bool,
+    /// Address of the `CompiledCode` of the bytecode frame currently executing
+    /// in `exec_one` (set at the top of every dispatch). Used by the lazy-force
+    /// machinery to reconcile the *caller's* local slots from env after a reify
+    /// mutated a captured-outer lexical (Slice F: the lazy body runs at reify
+    /// time, deep inside an op handler, so its captured-outer write reaches env
+    /// but not the caller slot under reverse-sync OFF). Stored as an address
+    /// (not a raw pointer) so the interpreter stays `Send` for worker threads;
+    /// it is only dereferenced synchronously within the same call tree, where
+    /// the pointed-to `CompiledCode` is an ancestor stack frame and therefore
+    /// alive. `0` before any frame runs. Reset across thread clones.
+    pub(crate) current_code: usize,
     /// When `Some`, a *carrier* (EVAL / interpreter fallback) is running and
     /// every by-name env write through `set_env_with_main_alias` logs its name
     /// here. On carrier return, exactly these names are written back into the
@@ -3368,6 +3379,7 @@ impl Interpreter {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             env_dirty: false,
+            current_code: 0,
             carrier_writes: None,
             method_dispatch_pure: false,
             resume_ip: None,
@@ -5927,6 +5939,7 @@ impl Interpreter {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             env_dirty: false,
+            current_code: 0,
             carrier_writes: None,
             method_dispatch_pure: false,
             resume_ip: None,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1118,6 +1118,10 @@ impl Interpreter {
             ip,
             std::mem::discriminant(&code.ops[*ip])
         );
+        // Track the currently-executing frame's code so the lazy-force machinery
+        // can reconcile this (caller) frame's local slots from env after a reify
+        // that mutated a captured-outer lexical (Slice F). See `current_code`.
+        self.current_code = code as *const CompiledCode as usize;
         match &code.ops[*ip] {
             // -- Constants --
             OpCode::LoadConst(idx) => {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -349,6 +349,9 @@ impl Interpreter {
         } else {
             raw_args
         };
+        // Slice F: snapshot whether a callable was passed before `args` is moved
+        // into dispatch, for the caller-slot reconcile at the call tail.
+        let args_callable = Self::args_have_callable(&args);
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethodMut target".to_string())
         })?;
@@ -1528,12 +1531,14 @@ impl Interpreter {
                         }
                     }
                 }
-                // Slice F: reconcile a captured-outer lexical mutated by an
+                // Slice F: reconcile the caller's local slots from env after a
+                // method that may have mutated a captured-outer lexical — an
                 // interpreter-dispatched construction (`.new`/`.bless` running a
-                // `submethod BUILD`/`TWEAK`) at the call site, since that path
-                // bypasses the compiled-method writeback. See the CallMethod twin
-                // and `reconcile_locals_from_env_at_site`.
-                if mark_dirty && matches!(method.as_str(), "new" | "bless") {
+                // `submethod BUILD`/`TWEAK`), or a list method run with a block
+                // argument (`.map`/`.grep`/`.sort`/...) whose block mutates an
+                // outer lexical. See the CallMethod twin and
+                // `reconcile_locals_from_env_at_site`.
+                if mark_dirty && (matches!(method.as_str(), "new" | "bless") || args_callable) {
                     self.reconcile_locals_from_env_at_site(code);
                 }
             }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -229,6 +229,9 @@ impl Interpreter {
         } else {
             raw_args
         };
+        // Slice F: snapshot whether a callable was passed before `args` is moved
+        // into dispatch, for the caller-slot reconcile at the call tail.
+        let args_callable = Self::args_have_callable(&args);
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethod target".to_string())
         })?;
@@ -1233,15 +1236,21 @@ impl Interpreter {
                         }
                     }
                 }
-                // Slice F: an interpreter-dispatched construction (`.new`/`.bless`
-                // running a `submethod BUILD`/`TWEAK`) may mutate a captured-outer
-                // lexical by name. That interpreter build path bypasses the
-                // compiled-method `merge_method_env` writeback, so the caller slot
-                // is otherwise only reconciled by the blanket `sync_locals_from_env`
-                // barrier pull. Reconcile it here at the call site instead (gated on
-                // `mark_dirty`, i.e. only when ON would have pulled) so the slot
-                // stays coherent without the reverse pull.
-                if mark_dirty && matches!(method, "new" | "bless") {
+                // Slice F: reconcile the caller's local slots from env after a
+                // method call that may have mutated a captured-outer lexical, so
+                // the write is coherent without the blanket `sync_locals_from_env`
+                // barrier pull. Two shapes need this:
+                //   * a construction (`.new`/`.bless`) running an interpreter
+                //     `submethod BUILD`/`TWEAK` that mutates an outer lexical by
+                //     name (bypasses the compiled-method `merge_method_env`);
+                //   * a list method run with a block argument (`.map`/`.grep`/
+                //     `.sort`/`.first`/...) whose block mutates a captured-outer
+                //     lexical (`$c` in `@a.map({$c++})`) — the native block loop
+                //     writes it to env but not the caller slot.
+                // Gated on `mark_dirty` (only when ON would have pulled) and, for
+                // the block case, on the presence of a callable argument, so a
+                // plain method call keeps paying nothing extra.
+                if mark_dirty && (matches!(method, "new" | "bless") || args_callable) {
                     self.reconcile_locals_from_env_at_site(code);
                 }
                 // Wrap map/grep results back into HyperSeq/RaceSeq

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,6 +1,15 @@
 use super::*;
 
 impl Interpreter {
+    /// True if any argument is a callable (a block/closure/routine value). Used
+    /// by the method-call ops to decide whether a `mark_dirty` method may have
+    /// run a caller-captured block that mutated an outer lexical, and therefore
+    /// whether the caller's local slots need reconciling from env (Slice F).
+    pub(super) fn args_have_callable(args: &[Value]) -> bool {
+        args.iter()
+            .any(|a| matches!(a, Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }))
+    }
+
     /// Slice 2a: clear the aggregate held inside a shared `ContainerRef` cell
     /// (`undefine @ary` where `my $r = @ary` promoted `@ary` to a cell). Uses
     /// `Arc::make_mut` so a copy taken out of the cell (`my @copy = @ary`) is
@@ -416,6 +425,13 @@ impl Interpreter {
         &mut self,
         list: &LazyList,
     ) -> Result<Vec<Value>, RuntimeError> {
+        let caller_code = self.current_code;
+        let r = self.force_lazy_list_vm_inner(list);
+        self.reconcile_caller_after_lazy_force(caller_code);
+        r
+    }
+
+    fn force_lazy_list_vm_inner(&mut self, list: &LazyList) -> Result<Vec<Value>, RuntimeError> {
         // Handle scan-based lazy lists: compute elements on demand
         if list.scan_spec.is_some() {
             return self.force_scan_lazy_list(list, 200_000);
@@ -611,6 +627,55 @@ impl Interpreter {
     /// Side effects (e.g. `$count++`) are correctly scoped because we pause
     /// mid-execution rather than re-running from scratch.
     pub(super) fn force_lazy_list_vm_n(
+        &mut self,
+        list: &LazyList,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let caller_code = self.current_code;
+        let r = self.force_lazy_list_vm_n_inner(list, needed);
+        self.reconcile_caller_after_lazy_force(caller_code);
+        r
+    }
+
+    /// Reconcile the caller frame's local slots after a lazy force, so a
+    /// captured-outer lexical mutated at reify time (e.g. `map({$c++})`,
+    /// `gather`) is visible in the caller's slots even when the blanket reverse
+    /// pull (`sync_locals_from_env`) is disabled (Slice F campaign). Two reify
+    /// shapes record their writes differently and both must be drained here —
+    /// the force machinery is the effective "call site" for the callbacks it
+    /// runs, but unlike a real call op it never drains them:
+    ///
+    /// - a `map`/`grep` callback runs via `call_compiled_closure`, which logs
+    ///   the changed caller free-vars into `pending_rw_writeback_sources`
+    ///   (drained by `apply_pending_rw_writeback`, as every call op does);
+    /// - a `gather` body merges its env changes and sets `env_dirty`, mirrored
+    ///   by `reconcile_locals_from_env_at_site` (the #3331 helper).
+    ///
+    /// Both are byte-identical to the work reverse-sync ON would do (the call-op
+    /// drain + the barrier pull), so ON behavior is unchanged.
+    fn reconcile_caller_after_lazy_force(&mut self, caller_code: usize) {
+        // The force body's own `exec_one` runs reset `current_code` to the lazy
+        // body; restore it to the caller so a subsequent force in the same op
+        // handler reconciles the right frame.
+        self.current_code = caller_code;
+        if caller_code == 0 {
+            return;
+        }
+        if self.env_dirty || !self.pending_rw_writeback_sources.is_empty() {
+            // SAFETY: `caller_code` is the address of the `CompiledCode` of the
+            // bytecode frame that invoked this force. That frame is an ancestor
+            // on the call stack (the op handler driving the force) and is alive
+            // for the whole synchronous duration of the force, so the pointer is
+            // valid here.
+            let code = unsafe { &*(caller_code as *const CompiledCode) };
+            self.apply_pending_rw_writeback(code);
+            if self.env_dirty {
+                self.reconcile_locals_from_env_at_site(code);
+            }
+        }
+    }
+
+    fn force_lazy_list_vm_n_inner(
         &mut self,
         list: &LazyList,
         needed: usize,

--- a/t/lazy-reify-captured-outer-coherence.t
+++ b/t/lazy-reify-captured-outer-coherence.t
@@ -1,0 +1,102 @@
+use Test;
+
+# Slice F coherence pin: a list method run with a block argument
+# (`.map`/`.grep`/`.sort`/`.first`) — and a `gather` body — can mutate a
+# *captured-outer* caller lexical (`$c` in `@a.map({ $c++ })`). The native block
+# loop / gather reify writes the new value into env, but the caller's local slot
+# was previously only reconciled by the blanket reverse `sync_locals_from_env`
+# pull. These cases must stay coherent WITHOUT that pull (run the file with
+# MUTSU_NO_REVERSE_SYNC=1 to verify the write-through reconcile at the call site).
+
+plan 12;
+
+# 1. .map over a List literal, captured-outer counter.
+{
+    my $c = 0;
+    my @r = (1, 2, 3).map({ $c++; $_ * 2 });
+    @r.elems;
+    is $c, 3, '.map over a List mutates a captured-outer counter';
+}
+
+# 2. .map over a real @-array variable.
+{
+    my @a = 1, 2, 3;
+    my $c = 0;
+    @a.map({ $c++; $_ }).eager;
+    is $c, 3, '.map over an @-array mutates a captured-outer counter';
+}
+
+# 3. .grep captured-outer counter.
+{
+    my $c = 0;
+    my @r = (1, 2, 3).grep({ $c++; $_ > 0 });
+    @r.elems;
+    is $c, 3, '.grep mutates a captured-outer counter';
+}
+
+# 4. .sort with a comparator block.
+{
+    my $c = 0;
+    (3, 1, 2).sort({ $c++; $^a <=> $^b });
+    ok $c >= 2, '.sort comparator mutates a captured-outer counter';
+}
+
+# 5. .first runs the block until a match.
+{
+    my $c = 0;
+    (1, 2, 3).first({ $c++; $_ > 5 });
+    is $c, 3, '.first mutates a captured-outer counter (no match: all visited)';
+}
+
+# 6. gather/take with a captured-outer counter, forced via .elems.
+{
+    my $c = 0;
+    my @g = gather { for 1..3 { $c++; take $_ } };
+    @g.elems;
+    is $c, 3, 'gather body mutates a captured-outer counter';
+}
+
+# 7. .map accumulating into a captured-outer array.
+{
+    my @seen;
+    (1, 2, 3).map({ @seen.push($_); $_ }).eager;
+    is @seen.elems, 3, '.map captured-outer array push is visible to caller';
+}
+
+# 8. .map accumulating into a captured-outer sum.
+{
+    my $sum = 0;
+    (1, 2, 3, 4).map({ $sum += $_; $_ }).eager;
+    is $sum, 10, '.map captured-outer += is visible to caller';
+}
+
+# 9. nested: outer .map whose block calls an inner .map mutating the same var.
+{
+    my $c = 0;
+    (1, 2).map({ (10, 20).map({ $c++; $_ }).eager; $_ }).eager;
+    is $c, 4, 'nested .map mutates the shared captured-outer counter';
+}
+
+# 10. .grep result count is still correct (functional behavior intact).
+{
+    my $c = 0;
+    my @r = (1, 2, 3, 4, 5).grep({ $c++; $_ %% 2 });
+    is @r.elems, 2, '.grep still returns the correct filtered list';
+}
+
+# 11. .map result values are still correct.
+{
+    my $c = 0;
+    my @r = (1, 2, 3).map({ $c++; $_ * 10 });
+    is @r.join(','), '10,20,30', '.map still returns the correct mapped values';
+}
+
+# 12. counter read mid-pipeline after a forced force.
+{
+    my $c = 0;
+    my @r = (1, 2, 3).map({ $c++; $_ });
+    @r.elems;
+    my $first = $c;
+    @r.elems;
+    is $first, 3, 'captured-outer counter is final after the first force';
+}


### PR DESCRIPTION
## Summary

A list method run with a block argument (`@a.map({\$c++})`, `.grep`/`.sort`/`.first`) or a `gather` body can mutate a *captured-outer* caller lexical. The native block loop / gather reify writes the new value into env, but the caller's local slot was previously reconciled only by the blanket reverse `sync_locals_from_env` pull — so under `MUTSU_NO_REVERSE_SYNC=1` the write was lost (`@a.map({\$c++}); say \$c` printed `0` instead of `3`).

This continues the Slice F campaign (removing roast-level reverse-sync dependencies so `env_dirty`/`sync_locals_from_env` can eventually be deleted), mirroring the construction write-through (#3331) at the call site.

## Mechanism

- Track the currently-executing frame's `CompiledCode` in a new `Interpreter::current_code` (stored as an address so the interpreter stays `Send`; set at the top of `exec_one`). The lazy-force machinery captures it on entry and, after a reify that mutated env, reconciles the caller's slots via `reconcile_caller_after_lazy_force` — draining `pending_rw_writeback_sources` (map/grep pipe callbacks) and pulling env→locals (gather bodies).
- At the `CallMethod`/`CallMethodMut` op tails, reconcile the caller's slots when the call dirtied env (`mark_dirty`) and either is a construction (`new`/`bless`) or passed a callable argument (`args_have_callable`) — i.e. exactly the calls whose body/block could mutate a caller lexical. A plain method call (no callable arg) pays nothing extra.

Both reconciles are byte-identical to the work reverse-sync ON would do (the call-op drain + the barrier pull), so **ON behavior — and the whitelist — is unchanged**.

## Effect

Removes the `S32-list/{map,grep}.t` reverse-sync dependencies (and the captured-outer parts of sort/first/gather). The X-metaop thunks (`cross.t`) and `gather` take-rw lvalue tests are separate dispatch sites left for follow-on slices.

## Tests

- New pin `t/lazy-reify-captured-outer-coherence.t` (12 cases) passes both ON and with `MUTSU_NO_REVERSE_SYNC=1`.
- `make test` PASS (973 files, 9501 tests).
- ON whitelist scan of touched/method-heavy dirs: no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)