### PR TITLE
feat(single-store): write an eager .map/.grep block's captured-outer mutations through to the caller slot (Slice F coherence)

### DIFF
--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1967,6 +1967,36 @@ impl Interpreter {
         result.map(|last_value| last_value.unwrap_or(value))
     }
 
+    /// Slice F (env<->locals coherence): record an eager block-iteration's
+    /// captured-outer free-var writes so the call-site method op drains each new
+    /// value straight through to the caller's local slot, keeping it coherent
+    /// without the reverse `sync_locals_from_env` pull.
+    ///
+    /// The eager `.map`/`.grep` loops (`(1,2,3).map({ $sum += $_ })`) run the
+    /// block body via `run_reuse` rather than `call_compiled_closure_with_topic`,
+    /// so they bypass the closure-dispatch recording (#3307): a mutated captured
+    /// lexical lands in `env` but is never recorded for write-through. Replay the
+    /// block's compile-time `free_var_writes` here. Topic/param names are
+    /// loop-local (restored by the caller) and excluded.
+    fn record_eager_block_free_var_writeback(
+        &mut self,
+        code: &crate::opcode::CompiledCode,
+        params: &[String],
+    ) {
+        for sym in &code.free_var_writes {
+            sym.with_str(|fname| {
+                if fname != "_"
+                    && fname != "$_"
+                    && fname != "@_"
+                    && fname != "%_"
+                    && !params.iter().any(|p| p == fname)
+                {
+                    self.pending_rw_writeback_sources.push(fname.to_string());
+                }
+            });
+        }
+    }
+
     pub(super) fn eval_map_over_items(
         &mut self,
         func: Option<Value>,
@@ -2206,6 +2236,9 @@ impl Interpreter {
                         self.env.remove(&k);
                     }
                 }
+            }
+            if loop_result.is_ok() {
+                self.record_eager_block_free_var_writeback(&code, &data.params);
             }
             return loop_result;
         }
@@ -2615,6 +2648,9 @@ impl Interpreter {
                         self.env.remove(&k);
                     }
                 }
+            }
+            if loop_result.is_ok() {
+                self.record_eager_block_free_var_writeback(&code, &data.params);
             }
             loop_result?;
             return Ok((Value::array(result), list_items));

--- a/t/eager-map-grep-captured-writeback-coherence.t
+++ b/t/eager-map-grep-captured-writeback-coherence.t
@@ -1,0 +1,97 @@
+use Test;
+
+# Slice F (env<->locals coherence): an eager `.map`/`.grep` over a literal list
+# (or Range / Seq) runs the block body through the interpreter's `run_reuse`
+# loop rather than `call_compiled_closure_with_topic`, so a captured outer
+# lexical mutated inside the block must still be written through to the caller's
+# local slot without relying on the reverse `sync_locals_from_env` pull.
+#
+# `@a.map` over a concrete array variable already went through the VM native
+# path (#3307); the gap was the literal-list / Range / Seq receiver, which falls
+# back to the eager interpreter loop. Results below must hold identically with
+# the reverse-sync pull enabled (default) and disabled (MUTSU_NO_REVERSE_SYNC=1).
+
+plan 14;
+
+# --- map: scalar accumulation over a literal list ---
+{
+    my $sum = 0;
+    (1, 2, 3).map({ $sum += $_ });
+    is $sum, 6, 'literal-list map: captured scalar accumulation';
+}
+
+# --- map: ++ on a captured scalar ---
+{
+    my $count = 0;
+    (1, 2, 3, 4).map({ $count++ });
+    is $count, 4, 'literal-list map: captured scalar ++';
+}
+
+# --- map: push onto a captured array ---
+{
+    my @collected;
+    (10, 20, 30).map({ @collected.push($_ * 2) });
+    is-deeply @collected, [20, 40, 60], 'literal-list map: captured array push';
+}
+
+# --- map: string concatenation onto a captured scalar ---
+{
+    my $s = '';
+    ('x', 'y', 'z').map({ $s ~= $_ });
+    is $s, 'xyz', 'literal-list map: captured string concat';
+}
+
+# --- map over a Range mutates a captured scalar ---
+{
+    my $acc = 0;
+    (1 .. 4).map({ $acc += $_ });
+    is $acc, 10, 'Range map: captured scalar accumulation';
+}
+
+# --- map over a Seq mutates a captured scalar ---
+{
+    my $tot = 0;
+    (1, 2, 3).Seq.map({ $tot += $_ });
+    is $tot, 6, 'Seq map: captured scalar accumulation';
+}
+
+# --- grep: scalar accumulation while filtering ---
+{
+    my $seen = 0;
+    my @evens = (1, 2, 3, 4).grep({ $seen += $_; $_ %% 2 });
+    is $seen, 10, 'literal-list grep: captured scalar accumulation';
+    is-deeply @evens, [2, 4], 'literal-list grep: filter result is correct';
+}
+
+# --- grep: ++ counter ---
+{
+    my $calls = 0;
+    (<a b c d>).grep({ $calls++; .chars });
+    is $calls, 4, 'word-list grep: captured counter ++';
+}
+
+# --- grep over a Range mutates a captured scalar ---
+{
+    my $sum = 0;
+    my @big = (1 .. 5).grep({ $sum += $_; $_ > 3 });
+    is $sum, 15, 'Range grep: captured scalar accumulation';
+    is-deeply @big, [4, 5], 'Range grep: filter result is correct';
+}
+
+# --- result of the map/grep is still correct alongside the side effect ---
+{
+    my $sum = 0;
+    my @doubled = (1, 2, 3).map({ $sum += $_; $_ * 2 });
+    is $sum, 6, 'map: side effect and return value coexist (side effect)';
+    is-deeply @doubled.List, (2, 4, 6), 'map: side effect and return value coexist (result)';
+}
+
+# --- the array-var native path stays coherent too (regression guard) ---
+{
+    my $sum = 0;
+    my @a = 1, 2, 3;
+    @a.map({ $sum += $_ });
+    is $sum, 6, 'array-var map: captured scalar accumulation (native path)';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

Continues the **Slice F coherence** write-through family (#3300–#3333): folds another reverse-`sync_locals_from_env` dependency into the `pending_rw_writeback_sources` + `apply_pending_rw_writeback(code)` mechanism so it can eventually be removed.

`(1,2,3).map({ $sum += $_ })` and `(1,2,3).grep({ $n += $_; ... })` over a **literal list, Range, or Seq** lost the captured-outer mutation under `MUTSU_NO_REVERSE_SYNC=1`. The eager interpreter loops (`eval_map_over_items` / `eval_grep_over_items_with_mutated`) run the block body via `run_reuse` inside `with_nested_registers` rather than `call_compiled_closure_with_topic`, so they bypass the closure-dispatch write-through recording added in #3307. The mutation landed in `env` but was never recorded, leaving the caller's local slot stale.

(`@a.map` over a concrete array *variable* already worked — it takes the VM-native `try_native_array_map` path which uses `call_compiled_closure_with_topic`.)

## Fix

Record the block's compile-time `free_var_writes` (topic/param names excluded — they are loop-local and restored by the caller) after each eager loop completes, via a shared helper `record_eager_block_free_var_writeback`. The call-site method op then drains each new value straight through to the caller's local slot.

The lazy / `return`-deferred map paths return early *before* the eager loop (`make_lazy_pipe` / `create_lazy_map_list`), so infinite-range `.map`/`.grep` stay lazy and are unaffected (no lazy-eval conflict).

## Tests

- New pin `t/eager-map-grep-captured-writeback-coherence.t` (14 subtests, identical ON / `MUTSU_NO_REVERSE_SYNC=1` / raku).
- `make test` PASS (9523).
- clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)