### PR TITLE
feat(single-store): write an X/Z-metaop thunk's captured-outer mutation through to the caller slot (Slice F coherence)

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -471,6 +471,13 @@ impl Interpreter {
         } else {
             self.auto_fetch_proxy_args(args)?
         };
+        // Slice F: snapshot whether a callable was passed before `args` is moved
+        // into dispatch. A native builtin that runs a caller-supplied thunk (the
+        // X/Z-metaop thunks `__mutsu_reverse_xx`/`__mutsu_*_shortcircuit`, which
+        // run the thunk via the interpreter and write its captured-outer
+        // mutation into env *by name*) leaves the caller's local slot stale; the
+        // tail reconciles it from env when this flag is set.
+        let args_callable = Self::args_have_callable(&args);
         loan_env!(self, set_pending_callsite_line(callsite_line));
         // Check if there's a CALL-ME override from trait_mod mixin
         let call_me_override =
@@ -577,6 +584,16 @@ impl Interpreter {
         // Slice F: write any `is rw` parameter writeback through to the caller's
         // local slot (see `apply_pending_rw_writeback`).
         self.apply_pending_rw_writeback(code);
+        // Slice F: a native builtin that ran a caller-supplied thunk (X/Z-metaop
+        // thunks) wrote the thunk's captured-outer mutation into env by name but
+        // recorded no `pending_rw_writeback_sources` (it dispatches via the
+        // interpreter, not the VM closure path). Reconcile the caller's slots
+        // from env so the write is visible without the reverse pull. Gated on a
+        // callable argument + `env_dirty`, i.e. exactly when ON would have
+        // pulled, so ON behavior is unchanged.
+        if args_callable && self.env_dirty {
+            self.reconcile_locals_from_env_at_site(code);
+        }
         self.stack.push(result);
         // env_dirty is now managed inside dispatch_func_call_inner: the
         // interpreter / native fallback branches set it (they mutate env by

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,13 +1,26 @@
 use super::*;
 
 impl Interpreter {
-    /// True if any argument is a callable (a block/closure/routine value). Used
-    /// by the method-call ops to decide whether a `mark_dirty` method may have
-    /// run a caller-captured block that mutated an outer lexical, and therefore
-    /// whether the caller's local slots need reconciling from env (Slice F).
+    /// True if any argument is a callable (a block/closure/routine value), or a
+    /// list/array argument that *directly contains* one. Used by the method- and
+    /// function-call ops to decide whether a call may have run a caller-captured
+    /// block that mutated an outer lexical, and therefore whether the caller's
+    /// local slots need reconciling from env (Slice F). The one-level descent
+    /// into list args catches the X/Z-metaop short-circuit thunks, which are
+    /// passed as an `(thunk, ...)` list to `__mutsu_zip_shortcircuit` &c.
     pub(super) fn args_have_callable(args: &[Value]) -> bool {
-        args.iter()
-            .any(|a| matches!(a, Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }))
+        fn is_callable(v: &Value) -> bool {
+            matches!(v, Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. })
+        }
+        args.iter().any(|a| {
+            is_callable(a)
+                || match a {
+                    Value::Array(items, _) => items.items.iter().any(is_callable),
+                    Value::Seq(items) => items.iter().any(is_callable),
+                    Value::Slip(items) => items.iter().any(is_callable),
+                    _ => false,
+                }
+        })
     }
 
     /// Slice 2a: clear the aggregate held inside a shared `ContainerRef` cell

--- a/t/metaop-thunk-captured-outer-coherence.t
+++ b/t/metaop-thunk-captured-outer-coherence.t
@@ -1,0 +1,88 @@
+use Test;
+
+# Slice F coherence pin: an X/Z meta-op whose operand is a thunk
+# (`(($s++,),) Xxx 3`, `1 Zand ($s++,)`) mutates a *captured-outer* caller
+# lexical when the thunk fires. The thunk runs via a native builtin
+# (`__mutsu_reverse_xx` / `__mutsu_*_shortcircuit`) which writes the mutation
+# into env by name; the caller's local slot was previously reconciled only by
+# the blanket reverse `sync_locals_from_env` pull. These cases must stay coherent
+# WITHOUT that pull (run with MUTSU_NO_REVERSE_SYNC=1 to verify), and the
+# short-circuit thunks must still NOT run when the operator does not need them.
+
+plan 12;
+
+# 1-2. Xxx: thunk fires once per repeat; captured-outer counter visible.
+{
+    my $s = 0;
+    (($s++,),) Xxx 1;
+    is $s, 1, 'Xxx thunk runs once: captured-outer counter visible';
+}
+{
+    my $s = 0;
+    (($s++,),) Xxx 9;
+    is $s, 9, 'Xxx thunk runs repeatedly: captured-outer counter visible';
+}
+
+# 3. Xxx with count 0: thunk must NOT run.
+{
+    my $s = 0;
+    (($s++,),) Xxx 0;
+    is $s, 0, 'Xxx with count 0 does not run the thunk';
+}
+
+# 4-5. Zand short-circuit: runs the thunk only when the left side is true.
+{
+    my Mu $s = 0;
+    1 Zand ($s++,);
+    is $s, 1, 'Zand runs the thunk when the left operand is true';
+}
+{
+    my Mu $s = 0;
+    0 Zand ($s++,);
+    is $s, 0, 'Zand does not run the thunk when the left operand is false';
+}
+
+# 6-7. Zor short-circuit: runs the thunk only when the left side is false.
+{
+    my Mu $s = 0;
+    0 Zor ($s++,);
+    is $s, 1, 'Zor runs the thunk when the left operand is false';
+}
+{
+    my Mu $s = 0;
+    1 Zor ($s++,);
+    is $s, 0, 'Zor does not run the thunk when the left operand is true';
+}
+
+# 8. Z&& alias of Zand.
+{
+    my Mu $s = 0;
+    1 Z&& ($s++,);
+    is $s, 1, 'Z&& runs the thunk when the left operand is true';
+}
+
+# 9. Z|| alias of Zor.
+{
+    my Mu $s = 0;
+    0 Z|| ($s++,);
+    is $s, 1, 'Z|| runs the thunk when the left operand is false';
+}
+
+# 10-11. Xand / Xor cross short-circuit.
+{
+    my $s = 0;
+    (1,) Xand ($s++,);
+    is $s, 1, 'Xand runs the thunk when needed';
+}
+{
+    my $s = 0;
+    (0,) Xor ($s++,);
+    is $s, 1, 'Xor runs the thunk when needed';
+}
+
+# 12. Zxx: list left side thunked, captured-outer counter visible.
+{
+    my $s = 0;
+    ($s++,) Zxx 3;
+    is $s, 3, 'Zxx thunk runs repeatedly: captured-outer counter visible';
+}


### PR DESCRIPTION
## Summary

An X/Z meta-op whose operand is a thunk (`(($s++,),) Xxx 3`, `1 Zand ($s++,)`) mutates a *captured-outer* caller lexical when the thunk fires. The thunk runs via a native builtin (`__mutsu_reverse_xx` / `__mutsu_*_shortcircuit`), which dispatches it through the **interpreter** (not the VM closure path) and writes the mutation into env by name — recording no `pending_rw_writeback_sources`. So the native-function arm of the CallFunc op never reconciled the caller's local slot, and under `MUTSU_NO_REVERSE_SYNC=1` the write was lost (`1 Zand ($s++,); say \$s` printed `0` instead of `1`).

Continues the Slice F campaign (removing roast-level reverse-sync dependencies), mirroring the #3334 method-op fix on the function-call path.

## Mechanism

- At the `exec_call_func_op` tail, when the call passed a callable argument (`args_have_callable`) and dirtied env (`env_dirty`) — i.e. exactly when ON would have pulled — `reconcile_locals_from_env_at_site(code)`. A plain function call (no callable arg) pays nothing extra.
- Broaden `args_have_callable` to also look one level inside a list/array arg, since the Z-metaop short-circuit thunks are passed as a `(thunk, ...)` list to `__mutsu_zip_shortcircuit` rather than as a top-level callable. (Also covers the method-op callers from #3334; harmless there.)

Byte-identical to the barrier pull under reverse-sync ON, so **ON behavior — and the whitelist — is unchanged**. The short-circuit thunks still correctly DO NOT run when the operator does not need them.

## Effect

Removes the `S03-metaops/{cross,reverse,zip}.t` reverse-sync dependencies.

## Tests

- New pin `t/metaop-thunk-captured-outer-coherence.t` (12 cases) passes both ON and with `MUTSU_NO_REVERSE_SYNC=1`.
- `make test` PASS (976 files, 9533 tests).
- ON whitelist scan (~400 files incl. all metaops/list/operators dirs): no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)