### PR TITLE
docs(plan): record eager .map/.grep captured write-through (#3335) in Slice F coherence

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -190,13 +190,17 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
         第32–33セッションで実依存を多数発見・write-through 化: 0-arg fast-call 捕捉（#3317）・dynamic var callee write（#3320）・
         regex `~~` match（#3321）・method 捕捉（#3322）・qualified/our sub 捕捉（#3323）・dynamic var env-read（#3324）・
         light/positional-light 捕捉（#3326）・**deferred role body 捕捉（#3327）**・**deferred class body 捕捉（#3328）**・
-        **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）・**例外脱出 UNDO/LEAVE 捕捉（#3332）**。
+        **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）・**例外脱出 UNDO/LEAVE 捕捉（#3332）**・
+        **junction autothread 捕捉（#3333）**・**eager `.map`/`.grep`（literal/Range/Seq）の捕捉（#3335）**。
       pin: `t/{rw-param,method-rw-param,closure-captured-var,rw-sub-lvalue,mut-method-receiver,sigilless-alias,dynamic-var,
       qualified-sub-captured-var,method-captured-var,light-call-captured-var,run-nested-role-body,class-body-captured-var,
-      import-constant,undo-phaser}-writeback-coherence.t` 他。
+      import-constant,undo-phaser,junction-autothread,eager-map-grep-captured}-writeback-coherence.t` 他。
       **残る OFF 依存（roast/`t/` 共通）= 次セッション以降のグラインド対象**:
-      - carrier（EVAL/regex/`s///`・require BEGIN EVAL）・supply/concurrent（done/react/whenever）・attribute trait_mod・slurpy-junction。
-      DEFERRED（壁）= multi-frame retention（caller→mid→writer・lazy-eval 衝突 #3317）・range map/grep（lazy-eval）・
+      - carrier（EVAL/regex/`s///`・require BEGIN EVAL・**`Xorelse`/`Zorelse` の `__mutsu_cross_shortcircuit` thunk**＝interpreter
+        builtin が thunk を `call_function`→carrier 経路で呼ぶ・`writeback_carrier_writes` が outer-frame slot を reconcile しない）・
+        supply/concurrent（done/react/whenever）・attribute trait_mod・slurpy-junction。
+      DEFERRED（壁）= multi-frame retention（caller→mid→writer・lazy-eval 衝突 #3317・**attribute default `has $.v = nn()` の捕捉副作用＝
+        `.new`→BUILDALL 跨ぎ multi-frame**）・range map/grep（lazy-eval）・
       pair-value hash（§4-A container-identity deep wall）・**nested-sub の例外脱出 UNDO 捕捉**（`outer(){ my $ng; sub fails(){ UNDO {$ng~=...}; die }; ...}`：
       nested named sub は compiled_fns 不在で OTF/interpreter fallback 経路へ → pending 未記録。top-level sub は #3332 で解消済・roast keep-undo.t は top-level のみ使用）。
       詳細・手順 = memory `project_dual_store_unification_next`。


### PR DESCRIPTION
Docs-only. Adds #3333 (junction autothread) and #3335 (eager `.map`/`.grep` over literal/Range/Seq receivers) to the Slice F coherence write-through family list and pins in PLAN.md.

Also records the two walls investigated alongside #3335 as DEFERRED:
- `Xorelse`/`Zorelse` `__mutsu_cross_shortcircuit` thunks — carrier path (`call_function`), `writeback_carrier_writes` does not reconcile outer-frame slots.
- attribute-default captured side effects (`has $.v = nn()`) — `.new` → BUILDALL multi-frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)