### PR TITLE
feat(single-store): reconcile caller slots on env_dirty at call tails, replacing the args_callable gate (Slice F coherence)

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -471,13 +471,6 @@ impl Interpreter {
         } else {
             self.auto_fetch_proxy_args(args)?
         };
-        // Slice F: snapshot whether a callable was passed before `args` is moved
-        // into dispatch. A native builtin that runs a caller-supplied thunk (the
-        // X/Z-metaop thunks `__mutsu_reverse_xx`/`__mutsu_*_shortcircuit`, which
-        // run the thunk via the interpreter and write its captured-outer
-        // mutation into env *by name*) leaves the caller's local slot stale; the
-        // tail reconciles it from env when this flag is set.
-        let args_callable = Self::args_have_callable(&args);
         loan_env!(self, set_pending_callsite_line(callsite_line));
         // Check if there's a CALL-ME override from trait_mod mixin
         let call_me_override =
@@ -584,14 +577,14 @@ impl Interpreter {
         // Slice F: write any `is rw` parameter writeback through to the caller's
         // local slot (see `apply_pending_rw_writeback`).
         self.apply_pending_rw_writeback(code);
-        // Slice F: a native builtin that ran a caller-supplied thunk (X/Z-metaop
-        // thunks) wrote the thunk's captured-outer mutation into env by name but
-        // recorded no `pending_rw_writeback_sources` (it dispatches via the
-        // interpreter, not the VM closure path). Reconcile the caller's slots
-        // from env so the write is visible without the reverse pull. Gated on a
-        // callable argument + `env_dirty`, i.e. exactly when ON would have
-        // pulled, so ON behavior is unchanged.
-        if args_callable && self.env_dirty {
+        // Slice F: a function call that dirtied env may have mutated a caller's
+        // captured-outer lexical by name — a native builtin running a thunk
+        // (X/Z-metaop thunks), a `multi sub` candidate body (`$reached = True`),
+        // an interpreter fallback, ... Reconcile the caller's slots from env so
+        // the write is visible without the reverse pull. Gated on `env_dirty`,
+        // exactly when the barrier would have pulled, so ON behavior is
+        // unchanged; a pure compiled call (env not dirtied) pays nothing.
+        if self.env_dirty {
             self.reconcile_locals_from_env_at_site(code);
         }
         self.stack.push(result);

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -349,9 +349,6 @@ impl Interpreter {
         } else {
             raw_args
         };
-        // Slice F: snapshot whether a callable was passed before `args` is moved
-        // into dispatch, for the caller-slot reconcile at the call tail.
-        let args_callable = Self::args_have_callable(&args);
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethodMut target".to_string())
         })?;
@@ -1532,13 +1529,12 @@ impl Interpreter {
                     }
                 }
                 // Slice F: reconcile the caller's local slots from env after a
-                // method that may have mutated a captured-outer lexical — an
-                // interpreter-dispatched construction (`.new`/`.bless` running a
-                // `submethod BUILD`/`TWEAK`), or a list method run with a block
-                // argument (`.map`/`.grep`/`.sort`/...) whose block mutates an
-                // outer lexical. See the CallMethod twin and
-                // `reconcile_locals_from_env_at_site`.
-                if mark_dirty && (matches!(method.as_str(), "new" | "bless") || args_callable) {
+                // method that dirtied env (a `submethod BUILD`/`TWEAK` during
+                // `.new`, a `.map`/`.grep`/`.sort` block, a `.gist`/`.Str`
+                // closure run by `say`/`note`, ...). Gated on `env_dirty`,
+                // exactly when the barrier would have pulled. See the CallMethod
+                // twin and `reconcile_locals_from_env_at_site`.
+                if self.env_dirty {
                     self.reconcile_locals_from_env_at_site(code);
                 }
             }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -229,9 +229,6 @@ impl Interpreter {
         } else {
             raw_args
         };
-        // Slice F: snapshot whether a callable was passed before `args` is moved
-        // into dispatch, for the caller-slot reconcile at the call tail.
-        let args_callable = Self::args_have_callable(&args);
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethod target".to_string())
         })?;
@@ -1237,20 +1234,15 @@ impl Interpreter {
                     }
                 }
                 // Slice F: reconcile the caller's local slots from env after a
-                // method call that may have mutated a captured-outer lexical, so
-                // the write is coherent without the blanket `sync_locals_from_env`
-                // barrier pull. Two shapes need this:
-                //   * a construction (`.new`/`.bless`) running an interpreter
-                //     `submethod BUILD`/`TWEAK` that mutates an outer lexical by
-                //     name (bypasses the compiled-method `merge_method_env`);
-                //   * a list method run with a block argument (`.map`/`.grep`/
-                //     `.sort`/`.first`/...) whose block mutates a captured-outer
-                //     lexical (`$c` in `@a.map({$c++})`) — the native block loop
-                //     writes it to env but not the caller slot.
-                // Gated on `mark_dirty` (only when ON would have pulled) and, for
-                // the block case, on the presence of a callable argument, so a
-                // plain method call keeps paying nothing extra.
-                if mark_dirty && (matches!(method, "new" | "bless") || args_callable) {
+                // method call that dirtied env, so any captured-outer lexical the
+                // call mutated by name (a `submethod BUILD`/`TWEAK` during `.new`,
+                // a `.map`/`.grep`/`.sort` block, a `.gist`/`.Str` closure run by
+                // `say`/`note`, ...) is coherent without the blanket reverse
+                // `sync_locals_from_env` pull. Gated on `env_dirty` — exactly when
+                // the barrier would have pulled — so this is byte-identical to the
+                // barrier under reverse-sync ON; a pure method call (env not
+                // dirtied) pays nothing.
+                if self.env_dirty {
                     self.reconcile_locals_from_env_at_site(code);
                 }
                 // Wrap map/grep results back into HyperSeq/RaceSeq

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -339,6 +339,11 @@ impl Interpreter {
         let n = n as usize;
         let start = self.stack.len() - n;
         let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+        // Slice F: a user `.gist`/`.Str` closure run below can mutate a
+        // captured-outer caller lexical (`say $x but role { method gist {$seen=1} }`).
+        // `say` is a dedicated op (no `code` param), so capture the caller frame's
+        // code before any dispatch clobbers `current_code` and reconcile after.
+        let caller_code = self.current_code;
         let mut parts = Vec::new();
         for v in &values {
             let v = loan_env!(self, auto_fetch_proxy(v))?;
@@ -351,6 +356,7 @@ impl Interpreter {
                 parts.push(runtime::gist_value(&v));
             }
         }
+        self.reconcile_caller_after_lazy_force(caller_code);
         let line = parts.join("");
         loan_env!(self, write_to_named_handle("$*OUT", &line, true))?;
         Ok(())
@@ -363,6 +369,8 @@ impl Interpreter {
         } else {
             let start = self.stack.len() - n;
             let values: Vec<Value> = Self::flatten_slip_args(self.stack.drain(start..).collect());
+            // Slice F: see exec_say_op — reconcile after a user `.gist` closure.
+            let caller_code = self.current_code;
             let mut parts = Vec::new();
             for v in &values {
                 if needs_method_dispatch(v) {
@@ -371,6 +379,7 @@ impl Interpreter {
                     parts.push(runtime::gist_value(v));
                 }
             }
+            self.reconcile_caller_after_lazy_force(caller_code);
             parts.join("")
         };
         loan_env!(self, write_to_named_handle("$*ERR", &content, true))?;

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,28 +1,6 @@
 use super::*;
 
 impl Interpreter {
-    /// True if any argument is a callable (a block/closure/routine value), or a
-    /// list/array argument that *directly contains* one. Used by the method- and
-    /// function-call ops to decide whether a call may have run a caller-captured
-    /// block that mutated an outer lexical, and therefore whether the caller's
-    /// local slots need reconciling from env (Slice F). The one-level descent
-    /// into list args catches the X/Z-metaop short-circuit thunks, which are
-    /// passed as an `(thunk, ...)` list to `__mutsu_zip_shortcircuit` &c.
-    pub(super) fn args_have_callable(args: &[Value]) -> bool {
-        fn is_callable(v: &Value) -> bool {
-            matches!(v, Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. })
-        }
-        args.iter().any(|a| {
-            is_callable(a)
-                || match a {
-                    Value::Array(items, _) => items.items.iter().any(is_callable),
-                    Value::Seq(items) => items.iter().any(is_callable),
-                    Value::Slip(items) => items.iter().any(is_callable),
-                    _ => false,
-                }
-        })
-    }
-
     /// Slice 2a: clear the aggregate held inside a shared `ContainerRef` cell
     /// (`undefine @ary` where `my $r = @ary` promoted `@ary` to a cell). Uses
     /// `Arc::make_mut` so a copy taken out of the cell (`my @copy = @ary`) is
@@ -666,7 +644,14 @@ impl Interpreter {
     ///
     /// Both are byte-identical to the work reverse-sync ON would do (the call-op
     /// drain + the barrier pull), so ON behavior is unchanged.
-    fn reconcile_caller_after_lazy_force(&mut self, caller_code: usize) {
+    ///
+    /// Also used by op handlers that run user code without a `code` parameter in
+    /// hand (`say`/`note`, which dispatch a `.gist`/`.Str` closure that can
+    /// mutate a captured-outer lexical): they capture `self.current_code` before
+    /// the dispatch and pass it here afterwards. `caller_code` is the address of
+    /// the caller frame's `CompiledCode`, captured before the inner `exec_one`
+    /// runs clobbered `current_code`.
+    pub(super) fn reconcile_caller_after_lazy_force(&mut self, caller_code: usize) {
         // The force body's own `exec_one` runs reset `current_code` to the lazy
         // body; restore it to the caller so a subsequent force in the same op
         // handler reconciles the right frame.

--- a/t/env-dirty-reconcile-coherence.t
+++ b/t/env-dirty-reconcile-coherence.t
@@ -1,0 +1,70 @@
+use Test;
+
+# Slice F coherence pin: the method-call / function-call / say-note op tails
+# reconcile the caller's local slots from env whenever the call dirtied env, so
+# a captured-outer lexical mutated by user code run *inside* a call (without a
+# callable argument) is coherent without the blanket reverse `sync_locals_from_env`
+# pull. These shapes have no callable argument, so the older `args_have_callable`
+# gate missed them. Run with MUTSU_NO_REVERSE_SYNC=1 to verify the write-through.
+
+plan 8;
+
+# 1. say() calls .gist on its argument, whose method mutates a captured-outer var.
+{
+    my $seen = 0;
+    say "" but role { method gist() { $seen = 1; "" } };
+    is $seen, 1, 'say() .gist captured-outer mutation is visible to caller';
+}
+
+# 2. note() likewise (writes to $*ERR, .gist side effect must still propagate).
+{
+    my $seen = 0;
+    note "" but role { method gist() { $seen = 1; "" } };
+    is $seen, 1, 'note() .gist captured-outer mutation is visible to caller';
+}
+
+# 3. A multi sub candidate body mutates a captured-outer var; no callable arg.
+{
+    my ($m1, $m2);
+    multi sub pick(Int $) { $m1 = True }
+    multi sub pick(Str $) { $m2 = True }
+    pick(42);
+    pick("x");
+    ok $m1 && $m2, 'multi sub candidate bodies mutate captured-outer vars';
+}
+
+# 4. A plain sub call returning through an interpreter path, mutating an outer var.
+{
+    my $hit = 0;
+    sub bump() { $hit++ }
+    bump(); bump(); bump();
+    is $hit, 3, 'plain sub captured-outer increment is visible to caller';
+}
+
+# 5. .Str method side effect via a stringifying builtin.
+{
+    my $called = 0;
+    my $s = ("" but role { method Str() { $called = 1; "z" } }).Str;
+    is $called, 1, '.Str captured-outer mutation is visible to caller';
+}
+
+# 6. say with multiple args, the side-effecting one in the middle.
+{
+    my $seen = 0;
+    say 1, ("" but role { method gist() { $seen = 1; "" } }), 2;
+    is $seen, 1, 'say() reaches a side-effecting .gist among several args';
+}
+
+# 7. map block (regression guard for the previous slice, still works).
+{
+    my $c = 0;
+    (1, 2, 3).map({ $c++; $_ }).eager;
+    is $c, 3, '.map captured-outer counter still coherent';
+}
+
+# 8. metaop thunk (regression guard for the previous slice, still works).
+{
+    my $s = 0;
+    (($s++,),) Xxx 3;
+    is $s, 3, 'X-metaop thunk captured-outer counter still coherent';
+}


### PR DESCRIPTION
## Summary

#3334/#3336 reconciled the caller's local slots after a method/function call **only when the call passed a callable argument** (`args_have_callable`). That was an incomplete proxy for "the call ran user code that may have mutated a caller lexical": a call can run user code with **no** callable argument —

- `say`/`note` call `.gist`/`.Str` on their argument (a method, not an arg);
- a `multi sub` candidate body mutates a captured-outer var (`$reached = True`);
- any builtin that dispatches a method on its argument.

Under `MUTSU_NO_REVERSE_SYNC=1` those writes were lost (`say "" but role { method gist {$seen=1} }; say \$seen` printed `0`).

## Change

Replace the `args_have_callable` gate with the precise signal the reverse pull itself uses — `env_dirty`:

- **CallMethod / CallMethodMut** op tails: reconcile when `self.env_dirty` (drop the `mark_dirty && (new|bless || args_callable)` approximation).
- **CallFunc** op tail: reconcile when `self.env_dirty` (drop `args_callable && env_dirty`).
- **`say`/`note`** are dedicated ops with no `code` parameter: capture `self.current_code` before the `.gist` dispatch and reconcile after, reusing the lazy-force helper.
- Remove the now-unused `args_have_callable` helper.

## Why it's safe + perf-neutral

Byte-identical to the barrier under reverse-sync **ON** (reconciles exactly when the barrier would pull), so ON behavior — and the whitelist — is unchanged. It is also **perf-neutral**: `env_dirty` is rarely set in hot compiled code (the dual-store keeps locals/env coherent by write-through), so the tail reconcile fires only on the rare calls where the barrier would have been needed.

Bench (debug, `tmp/bench-slicef.raku`): `locals_pulls=3`, wall-clock ~10.7s vs ~11.5s baseline (no regression).

## Effect

Removes the reverse-sync deps of `S16-io/{say,note}.t`, `S06-multi/{positional-vs-named,proto,subsignature}.t`, and captured-outer parts of several S02/S03 tests. OFF-dep count in the touched synopses dropped **26 → 11**. Remaining deps are distinct mechanisms (roles `does` in-place mixin writeback — tangled with a pre-existing ON bug; gather take-rw lvalue; QuantHash).

## Tests

- New pin `t/env-dirty-reconcile-coherence.t` (8 cases incl. say/note `.gist` and multi sub) passes ON and with `MUTSU_NO_REVERSE_SYNC=1`.
- All three prior coherence pins still pass ON+OFF.
- `make test` PASS (977 files, 9547 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)