### PR TITLE
feat(single-store): write a deep `:=` element bind/write through to the local slot (Slice F coherence)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -191,10 +191,11 @@ VM decoupling 完結（下記）で実行エンジンは単一 struct `Interpret
         regex `~~` match（#3321）・method 捕捉（#3322）・qualified/our sub 捕捉（#3323）・dynamic var env-read（#3324）・
         light/positional-light 捕捉（#3326）・**deferred role body 捕捉（#3327）**・**deferred class body 捕捉（#3328）**・
         **import された symbol/`constant`（#3329）**・sigilless param alias（#3318）・**例外脱出 UNDO/LEAVE 捕捉（#3332）**・
-        **junction autothread 捕捉（#3333）**・**eager `.map`/`.grep`（literal/Range/Seq）の捕捉（#3335）**。
+        **junction autothread 捕捉（#3333）**・**eager `.map`/`.grep`（literal/Range/Seq）の捕捉（#3335）**・
+        **deep `:=` element bind/write（`$s[1]<k>[2]=v` / `:=$src`・`IndexAssignDeepNested`）の locals write-through（#3340）**。
       pin: `t/{rw-param,method-rw-param,closure-captured-var,rw-sub-lvalue,mut-method-receiver,sigilless-alias,dynamic-var,
       qualified-sub-captured-var,method-captured-var,light-call-captured-var,run-nested-role-body,class-body-captured-var,
-      import-constant,undo-phaser,junction-autothread,eager-map-grep-captured}-writeback-coherence.t` 他。
+      import-constant,undo-phaser,junction-autothread,eager-map-grep-captured,deep-element-bind}-writeback-coherence.t` 他。
       **残る OFF 依存（roast/`t/` 共通）= 次セッション以降のグラインド対象**:
       - carrier（EVAL/regex/`s///`・require BEGIN EVAL・**`Xorelse`/`Zorelse` の `__mutsu_cross_shortcircuit` thunk**＝interpreter
         builtin が thunk を `call_function`→carrier 経路で呼ぶ・`writeback_carrier_writes` が outer-frame slot を reconcile しない）・

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -4893,6 +4893,20 @@ impl Interpreter {
             self.update_local_if_exists(code, &src, &cell_val);
         }
 
+        // Write the updated root container back into the local slot. The descent
+        // above mutated `env`'s root in place (possibly COW-detaching its outer
+        // `Arc` via `make_mut`), then the slot was invalidated to `Nil` (above)
+        // on the assumption reverse-sync would re-pull it. Without reverse-sync a
+        // later read through the locals store would see that stale `Nil` (or an
+        // outer `Arc` that no longer reaches the freshly bound cell). Refreshing
+        // the local from `env` here makes both stores share the same outer `Arc`
+        // spine, so deep `:=` binds and writes stay coherent without a pull.
+        if let Some(slot) = self.find_local_slot(code, &var_name)
+            && let Some(updated) = self.env().get(&var_name).cloned()
+        {
+            self.locals[slot] = updated;
+        }
+
         self.stack.push(val);
         Ok(())
     }

--- a/t/deep-element-bind-writeback-coherence.t
+++ b/t/deep-element-bind-writeback-coherence.t
@@ -1,0 +1,63 @@
+use Test;
+
+# Pin: a deep `:=` element bind (and a deep element write afterwards) must keep
+# the locals store and the env store coherent WITHOUT relying on reverse-sync
+# (`MUTSU_NO_REVERSE_SYNC=1`). The deep nested index-assign op descends from the
+# env copy of the root scalar (COW-detaching its outer Arc) and previously
+# invalidated the locals slot to Nil, trusting reverse-sync to re-pull it. It now
+# write-throughs the updated root back into the local slot, so a later read via
+# the locals store sees the freshly bound cell / mutated path. This must hold
+# identically whether or not reverse-sync is active (raku is the oracle).
+
+plan 13;
+
+# --- RHS bind, deep mixed array/hash path ---
+{
+    my $struct = [ "ignored", { key => { subkey => [ "ignored", 42 ] } } ];
+    my $abbrev := $struct[1]<key><subkey>[1];
+    is $abbrev, 42, 'RHS deep bind reads through binding';
+    $struct[1]<key><subkey>[1] = 43;
+    is $abbrev, 43, 'RHS deep: element write -> binding';
+    $abbrev = 44;
+    is $struct[1]<key><subkey>[1], 44, 'RHS deep: binding write -> element (locals coherent)';
+}
+
+# --- LHS bind, deep mixed array/hash path ---
+{
+    my $struct = [ "ignored", { key => { subkey => [ "ignored", 42 ] } } ];
+    my $abbrev = 30;
+    $struct[1]<key><subkey>[1] := $abbrev;
+    is $abbrev, 30, 'LHS bind leaves the source value unchanged';
+    $struct[1]<key><subkey>[1] = 31;
+    is $abbrev, 31, 'LHS deep: element write -> source';
+    $abbrev = 32;
+    is $struct[1]<key><subkey>[1], 32, 'LHS deep: source write -> element (locals coherent)';
+}
+
+# --- LHS bind, deep array-of-array path, sibling untouched ---
+{
+    my $s = [ 0, [ 0, [ 5, 99 ] ] ];
+    my $v = 7;
+    $s[1][1][0] := $v;
+    is $v, 7, 'LHS deep array bind leaves source unchanged';
+    $s[1][1][0] = 8;
+    is $v, 8, 'LHS deep array: element write -> source';
+    $v = 9;
+    is $s[1][1][0], 9, 'LHS deep array: source write -> element (locals coherent)';
+    is $s[1][1][1], 99, 'LHS deep array: sibling element untouched';
+}
+
+# --- Plain deep write (no bind) stays coherent without reverse-sync ---
+{
+    my $g = { outer => { inner => 10 } };
+    $g<outer><inner> = 55;
+    is $g<outer><inner>, 55, 'deep hash write read-back (locals coherent)';
+}
+
+# --- Deep write through an intermediate array, then read ---
+{
+    my $a = [ [ 1, 2 ], [ 3, 4 ] ];
+    $a[1][0] = 99;
+    is $a[1][0], 99, 'deep array write read-back (locals coherent)';
+    is $a[0][1], 2, 'deep array write: sibling untouched';
+}


### PR DESCRIPTION
## What

The deep nested index-assign op (`exec_index_assign_deep_nested_op`, handling
`\$struct[1]<key><subkey>[1] = v` and `... := \$src`) descends from the **env**
copy of the root scalar, COW-detaching its outer `Arc` via `Arc::make_mut`,
then invalidated the matching **locals** slot to `Nil` on the assumption that
reverse-sync would re-pull the updated container.

Without reverse-sync (`MUTSU_NO_REVERSE_SYNC=1`) a later read through the locals
store saw that stale `Nil` (or an outer `Arc` that no longer reached the freshly
bound cell), so deep `:=` binds and deep element writes lost coherence.

This is the deep `:=` element-bind substrate identified in the env↔locals
coherence design (`docs/env-locals-coherence.md` §3/§5) as the remaining
deep-cell wall for `t/element-bind-cell.t`.

## Fix

Refresh the local slot from the (now-updated) env root at the end of the op so
both stores share the same outer `Arc` spine. The deep-bind path is now coherent
without a reverse pull.

## Result

- `t/element-bind-cell.t` is now **OFF-clean** (was 11 reverse-sync-dependent
  failures: tests 9, 28, 30/31, 41-47), ON unchanged (0 failures).
- `make test`: PASS (978 files, 9560 tests, 0 failures).
- pin: `t/deep-element-bind-writeback-coherence.t` (13 subtests, ON = OFF = raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)