### PR TITLE
feat(single-store): reconcile local slots after a let/temp restore (Slice F coherence)

### DIFF
--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -3293,6 +3293,11 @@ impl Interpreter {
                 // Exception — restore let saves
                 loan_env!(self, restore_let_saves(let_mark));
                 self.env_dirty = true;
+                // The restore wrote the saved values back into `env` only;
+                // reconcile this frame's local slots so a later read sees the
+                // restored value without relying on reverse-sync (byte-identical
+                // to the env_dirty barrier pull in reverse-sync ON mode).
+                self.reconcile_locals_from_env_at_site(code);
                 if catch_begin >= control_begin {
                     return Err(e);
                 }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3413,10 +3413,18 @@ impl Interpreter {
                 let success = Self::is_let_success(&topic);
                 loan_env!(self, resolve_let_saves_on_success(mark, success));
                 self.env_dirty = true;
+                // `let`/`temp` restore writes the saved value back into `env`
+                // only; the matching local slot still holds the in-block value.
+                // Without reverse-sync a later read through the locals store would
+                // see the un-restored value, so reconcile the frame's slots from
+                // env here (byte-identical to the reverse pull the env_dirty net
+                // would trigger in reverse-sync ON mode).
+                self.reconcile_locals_from_env_at_site(code);
             }
             Err(e) => {
                 loan_env!(self, restore_let_saves(mark));
                 self.env_dirty = true;
+                self.reconcile_locals_from_env_at_site(code);
                 return Err(e);
             }
         }

--- a/t/let-temp-restore-writeback-coherence.t
+++ b/t/let-temp-restore-writeback-coherence.t
@@ -1,0 +1,75 @@
+use Test;
+
+# Pin: a `let`/`temp` restore (on block exit or exception) writes the saved
+# value back into the env store; the matching local slot must be reconciled so a
+# later read sees the restored value WITHOUT relying on reverse-sync
+# (`MUTSU_NO_REVERSE_SYNC=1`). Previously the restore was env-only and the locals
+# slot kept the in-block value, so with reverse-sync off `temp`/`let` appeared
+# not to restore. This must hold identically whether or not reverse-sync runs
+# (raku is the oracle).
+
+plan 10;
+
+# temp: always restores at scope exit
+{
+    my $x = 1;
+    { temp $x = 42; }
+    is $x, 1, 'temp: restored after block (locals coherent)';
+}
+
+# temp: bare form, mutate inside, restore on exit
+{
+    my $x = 10;
+    { temp $x; $x = 99; }
+    is $x, 10, 'bare temp: restored after block (locals coherent)';
+}
+
+# let: kept on success
+{
+    my $x = 1;
+    { let $x = 42; }
+    is $x, 42, 'let: kept on successful exit (locals coherent)';
+}
+
+# let: restored when the block yields a falsy value (Nil)
+{
+    my $x = 1;
+    { let $x = 42; Nil }
+    is $x, 1, 'let: restored on Nil result (locals coherent)';
+}
+
+# let: restored on exception (try)
+{
+    my $x = 1;
+    try { let $x = 42; die "oops" }
+    is $x, 1, 'let: restored after exception (locals coherent)';
+}
+
+# nested temp: inner and outer restored independently
+{
+    my $x = 1;
+    { temp $x = 2; { temp $x = 3; }; is $x, 2, 'nested temp: inner restored'; }
+    is $x, 1, 'nested temp: outer restored (locals coherent)';
+}
+
+# temp restore is visible to subsequent arithmetic on the restored local
+{
+    my $n = 5;
+    { temp $n = 100; }
+    my $after = $n + 1;
+    is $after, 6, 'temp-restored local feeds later expression';
+}
+
+# let with bare form kept on success, readable afterwards
+{
+    my $s = "a";
+    { let $s; $s = "b"; 1 }
+    is $s, "b", 'bare let: kept on success (locals coherent)';
+}
+
+# temp on a hash element restores the whole container coherently
+{
+    my %h = a => 1;
+    { temp %h<a> = 9; }
+    is %h<a>, 1, 'temp hash element restored (locals coherent)';
+}


### PR DESCRIPTION
## What

A `let`/`temp` restore (on block exit, falsy result, or exception) writes the
saved value back into the **env** store only — `restore_let_value` does
`self.env.insert(...)`. The matching **local** slot still held the in-block
value, and reverse-sync ON re-converged it via the `env_dirty` barrier pull.

With reverse-sync off (`MUTSU_NO_REVERSE_SYNC=1`) the pull never ran, so a later
read through the locals store saw the un-restored value — `temp \$x = 42` left
`\$x` at 42 after the block (raku restores it to 1). `t/let-temp.t` failed 6
subtests (2, 5, 6, 8, 10, 11) with reverse-sync off.

## Fix

Reconcile the frame's local slots from env right after the restore at the two
sites the failing cases exercise:

- the bare `let`/`temp` block op (`exec_let_block_op`, both success and
  exception branches), and
- the `try` exception restore (`vm_control_ops.rs`).

Both run the body inline against the enclosing frame's `code` (so the let/temp
variable is in `code.locals`) and already set `env_dirty = true`, so the explicit
`reconcile_locals_from_env_at_site` is byte-identical to the reverse pull that
net would trigger in reverse-sync ON mode (ON behavior unchanged).

The 30 other restore call sites are sub/method/closure dispatch returns whose
`let_saves` belong to the callee frame discarded on return, so they need no
locals write-through.

## Result

- `t/let-temp.t` is now **OFF-clean** (was 6 reverse-sync-dependent failures),
  ON unchanged.
- `make test`: PASS (978 files, 9557 tests, 0 failures).
- pin: `t/let-temp-restore-writeback-coherence.t` (10 subtests, ON = OFF = raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)