### PR TITLE
feat(single-store): write a pair-value element mutation through to the aliased source's local slot (Slice F coherence)

### DIFF
--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -298,6 +298,14 @@ impl Interpreter {
             }
         }
         for key in keys {
+            // Slice F (env<->locals coherence): this writes the replacement into
+            // `env` by name, but the caller's local slot still holds the old Arc.
+            // Record the name so the call-site `apply_pending_rw_writeback` drains
+            // it into the local slot — otherwise a mutation through a Pair value
+            // (`$p = ($a => $a); $p.value[0] = x`) updates `env` `$a` but leaves
+            // the locals `$a` stale without the reverse pull.
+            self.pending_rw_writeback_sources
+                .push(key.resolve().to_string());
             self.env.insert_sym(key, replacement.clone());
         }
         for cell in cells {
@@ -328,6 +336,9 @@ impl Interpreter {
             }
         }
         for key in keys {
+            // Slice F (env<->locals coherence): see the array counterpart above.
+            self.pending_rw_writeback_sources
+                .push(key.resolve().to_string());
             self.env.insert_sym(key, replacement.clone());
         }
         for cell in cells {

--- a/t/pair-value-writethrough-coherence.t
+++ b/t/pair-value-writethrough-coherence.t
@@ -1,0 +1,58 @@
+use Test;
+
+# Pin: mutating an Array/Hash element *through* a Pair value (`$p.value<k> = v`,
+# `$p.value[i] = v`) writes back to the source variable the Pair aliases, and
+# must stay coherent WITHOUT relying on reverse-sync (`MUTSU_NO_REVERSE_SYNC=1`).
+# The lvalue-method element-assign builtin clones the container and replaces all
+# bindings holding the old Arc via `overwrite_{hash,array}_bindings_by_identity`,
+# which writes the env entry by name; it now also records those names so the
+# call-site `apply_pending_rw_writeback` refreshes the caller's local slot. This
+# must hold identically whether or not reverse-sync runs (raku is the oracle).
+
+plan 9;
+
+# Hash value: $p.value<f> = 3 reaches the source hash.
+{
+    my $h = { :d(1), :e(2) };
+    my $p = ($h => $h);
+    $p.value<f> = 3;
+    is $p.value<f>, 3, 'hash element assigned through pair value';
+    is $h<f>, 3, 'pair-value hash write reaches source var (locals coherent)';
+    ok $p.value =:= $h, 'pair value and source stay the same container';
+}
+
+# Array value: $p.value[3] = "x" reaches the source array.
+{
+    my @src = <a b c>;
+    my $a = @src;
+    my $p = (k => $a);
+    $p.value[3] = "x";
+    is $p.value[3], "x", 'array element assigned through pair value';
+    is $a[3], "x", 'pair-value array write reaches source var (locals coherent)';
+}
+
+# Repeated writes accumulate coherently through the source var.
+{
+    my $h = { :a(1) };
+    my $p = ($h => $h);
+    $p.value<b> = 2;
+    $p.value<c> = 3;
+    is $h<b>, 2, 'first pair-value write visible via source';
+    is $h<c>, 3, 'second pair-value write visible via source';
+}
+
+# Source-side write is still visible through the pair value (regression guard).
+{
+    my $h = { :x(1) };
+    my $p = ($h => $h);
+    $h<y> = 9;
+    is $p.value<y>, 9, 'source-side write reaches pair value';
+}
+
+# Array key: push $p.key reaches the source array.
+{
+    my $a = [< a b c >];
+    my $p = ($a => 1);
+    push $p.key, "d";
+    is ~$p.key, ~$a, 'pushing the pair key reaches the source array';
+}


### PR DESCRIPTION
## What

Mutating an Array/Hash element through a Pair value — `my $a = [...]; my $p = ($a => $a); $p.value[0] = x` (or `$p.value<k> = v`) — must write back to the source variable the Pair aliases.

The lvalue-method element-assign builtin (`__mutsu_index_assign_method_lvalue`)
clones the container and replaces every binding holding the old `Arc` via
`overwrite_{array,hash}_bindings_by_identity`, which writes the env entry **by
name**. The caller's matching **local** slot still held the old `Arc`;
reverse-sync ON re-converged it via the `env_dirty` barrier pull, but with
reverse-sync off (`MUTSU_NO_REVERSE_SYNC=1`) the source variable read stale —
`$p.value<f> = 3` left `$h<f>` undefined and detached `$p.value` from `$h`.
`t/pair-value-element-writethrough.t` failed 2 subtests off.

The lvalue builtin already writes its own method-target var (args[4], `$p`)
through to locals; the gap was the **aliased** source `$h`, found only by the
by-identity `Arc` scan.

## Fix

Record each by-identity-overwritten env name into `pending_rw_writeback_sources`
so the existing call-site `apply_pending_rw_writeback` drains it into the
caller's local slot (the mechanism every other write-through slice uses). Names
that are not a local in the current frame are skipped by `find_local_slot`, and
the drain copies the env value — byte-identical to the reverse pull, so ON
behavior is unchanged.

## Result

- `t/pair-value-element-writethrough.t` is now **OFF-clean** (was 2
  reverse-sync-dependent failures), ON unchanged.
- `make test`: PASS (979 files, 9566 tests, 0 failures).
- pin: `t/pair-value-writethrough-coherence.t` (9 subtests, ON = OFF = raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)