### PR TITLE
fix(exceptions): typed X::Bind / X::InvalidType / X::Str::Numeric source-indicator (misc.t)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,8 +125,24 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 124/180 pass (plan 182). This is a very broad compile-time-error/exception file
+  - 129/180 pass (plan 182). This is a very broad compile-time-error/exception file
     covering ~40 distinct features.
+  - Done (PR #3345): X::Bind binding into an immutable subscript target (tests 148,
+    151, 152: `(1,2)[0] := 3`, `10[0] := 1`, `"Hi"[0] := 1` — parser-level check in
+    `simple_expr_stmt` on the `Index :=` path); X::InvalidType for `hides`-ing an
+    unknown type (test 96 — added `hidden_parents` to the `does`-style check in
+    `registration_class`); X::Str::Numeric.source-indicator (test 68 — prefix `+`
+    on a bad string now builds the full Failure via `str_numeric_failure`).
+  - Remaining single-types are all fiddly parser/signature edge cases (cheap wins
+    exhausted, as BLOCKERS.md predicts): 84 (`sub foo(C of Int)` no-body — needs
+    X::NotParametric to fire during signature parse BEFORE the missing-body parse
+    error), 95 (`sub foo() returns Bar` → X::InvalidType, needs a `-->` vs
+    `returns`/`of` trait-origin flag on the SubDecl AST, ~26 construction sites),
+    102 (`.map: * xx 2` — Whatever-currying treats `* xx 2` as callable; blocked on
+    the whatever.t track), 105 (`my $x :a` → X::Syntax::Adverb, undetected),
+    107 (`$bar:D` smiley on an untyped param → X::Parameter::InvalidType typename
+    'D', silently accepted), 167 (undeclared bareword param type with enum-value
+    suggestions). t/typed-exceptions-misc.t.
   - Done: "Useless use of X in sink context" warnings (tests 111-120,
     122-138 — the bulk of the 111-142 cluster). New parser post-pass
     `parser::sink_warn` walks the mainline (all-sink) statement list, recursing

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -11,6 +11,26 @@ use super::parse_raku_int_from_str;
 /// Build a lazy `Failure` wrapping an `X::Str::Numeric` exception for a string
 /// that cannot be numified — the shape raku's `.Int`/`.Num` produce on a bad
 /// string (the exception only fires when the Failure is sunk/used).
+/// Escape control characters the way Raku renders them inside an
+/// `X::Str::Numeric.source-indicator` (backspace → `\b`, tab → `\t`, …),
+/// leaving printable characters untouched.
+fn escape_for_source_indicator(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        match c {
+            '\u{8}' => out.push_str("\\b"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{c}' => out.push_str("\\f"),
+            '\0' => out.push_str("\\0"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\x[{:X}]", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 pub(crate) fn str_numeric_failure(s: &str) -> Value {
     let mut ex_attrs = std::collections::HashMap::new();
     ex_attrs.insert("source".to_string(), Value::str(s.to_string()));
@@ -19,6 +39,15 @@ pub(crate) fn str_numeric_failure(s: &str) -> Value {
         Value::str("base-10 number must begin with valid digits or '.'".to_string()),
     );
     ex_attrs.insert("pos".to_string(), Value::Int(0));
+    // The visual indicator marks where numification failed with `⏏` (U+23CF).
+    // The bad string follows the marker (pos 0), with control characters escaped.
+    ex_attrs.insert(
+        "source-indicator".to_string(),
+        Value::str(format!(
+            "in '\u{23CF}{}' (indicated by \u{23CF})",
+            escape_for_source_indicator(s)
+        )),
+    );
     ex_attrs.insert(
         "message".to_string(),
         Value::str(format!(

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -874,6 +874,9 @@ pub use raku_repr::raku_value;
 /// Re-export complex_trig for external use.
 pub(crate) use complex_math::complex_trig;
 
+/// Re-export the X::Str::Numeric Failure builder for the VM's prefix-`+` op.
+pub(crate) use dispatch_core_coerce::str_numeric_failure;
+
 /// Unicode case folding for `.fc` and `fc()`.
 pub(crate) fn unicode_foldcase(s: &str) -> String {
     let mut lowered = String::with_capacity(s.len());

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -97,6 +97,26 @@ fn is_literal_expr(expr: &Expr) -> bool {
     matches!(expr, Expr::Literal(_))
 }
 
+/// True when the LHS of an indexed `:=` bind targets an immutable container:
+/// a literal scalar (`10[0] := 1`, `"Hi"[0] := 1`) or an all-literal list
+/// (`(1,2)[0] := 3`). Binding into such a target is illegal → X::Bind.
+fn index_bind_target_is_immutable(target: &Expr) -> bool {
+    match target {
+        Expr::Literal(v) => matches!(
+            v,
+            crate::value::Value::Int(_)
+                | crate::value::Value::Str(_)
+                | crate::value::Value::Num(_)
+                | crate::value::Value::Rat(..)
+                | crate::value::Value::Bool(_)
+        ),
+        Expr::ArrayLiteral(elems) => {
+            !elems.is_empty() && elems.iter().all(|e| matches!(e, Expr::Literal(_)))
+        }
+        _ => false,
+    }
+}
+
 /// True for the Raku pseudo-package names (lexical/dynamic scope pseudo-stashes).
 /// Binding to one of these (`OUTER := 5`) is illegal → X::Bind.
 fn is_pseudo_package(name: &str) -> bool {
@@ -915,6 +935,21 @@ pub(super) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
         return parse_statement_modifier(rest, stmt);
     }
     if matches!(expr, Expr::Index { .. } | Expr::MultiDimIndex { .. }) && rest.starts_with(":=") {
+        // Binding into an immutable subscript target (`(1,2)[0] := 3`,
+        // `10[0] := 1`, `"Hi"[0] := 1`) is illegal — Raku raises X::Bind.
+        if let Expr::Index { target, .. } = &expr
+            && index_bind_target_is_immutable(target)
+        {
+            let message = "Cannot use bind operator with this left-hand side".to_string();
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Bind"),
+                std::collections::HashMap::from([(
+                    "message".to_string(),
+                    crate::value::Value::str(message.clone()),
+                )]),
+            );
+            return Err(PError::fatal_with_exception(message, Box::new(ex)));
+        }
         let rest = &rest[2..];
         let (rest, _) = ws(rest)?;
         let (rest, value) = parse_comma_or_expr(rest).map_err(|err| PError {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -881,9 +881,9 @@ impl Interpreter {
                 && !self.registry().roles.contains_key(base_parent)
                 && !self.registry().enum_types.contains_key(base_parent)
             {
-                // Use X::InvalidType for `does` parents, X::Inheritance::UnknownParent
-                // for `is` parents.
-                if does_parents.contains(parent) {
+                // Use X::InvalidType for `does`/`hides` parents,
+                // X::Inheritance::UnknownParent for `is` parents.
+                if does_parents.contains(parent) || hidden_parents.contains(parent) {
                     return Err(RuntimeError::new(format!(
                         "X::InvalidType: Invalid typename '{}'",
                         resolved_parent_name

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -787,22 +787,10 @@ impl Interpreter {
             if let Some(v) = crate::runtime::str_numeric::parse_raku_str_to_numeric(trimmed) {
                 self.stack.push(v);
             } else {
-                let mut ex_attrs = std::collections::HashMap::new();
-                ex_attrs.insert(
-                    "message".to_string(),
-                    Value::str(format!(
-                        "Cannot convert string to number: base-10 number must begin with valid digits or '.' in '{}'",
-                        s
-                    )),
-                );
-                let ex = Value::make_instance(Symbol::intern("X::Str::Numeric"), ex_attrs);
-                let mut failure_attrs = std::collections::HashMap::new();
-                failure_attrs.insert("exception".to_string(), ex);
-                failure_attrs.insert("handled".to_string(), Value::Bool(false));
-                self.stack.push(Value::make_instance(
-                    Symbol::intern("Failure"),
-                    failure_attrs,
-                ));
+                // A bad numeric string yields a lazy `X::Str::Numeric` Failure
+                // carrying `source`/`pos`/`reason`/`source-indicator` attributes.
+                self.stack
+                    .push(crate::builtins::methods_0arg::str_numeric_failure(s));
             }
             return Ok(());
         }

--- a/t/typed-exceptions-misc.t
+++ b/t/typed-exceptions-misc.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Typed exceptions covered by S32-exceptions/misc.t that mutsu previously
+# threw as plain (untyped / attribute-less) runtime errors.
+
+plan 7;
+
+# X::Bind: binding into an immutable subscript target.
+throws-like '(1,2)[0] := 3', X::Bind, 'bind into all-literal list element';
+throws-like '10[0] := 1',   X::Bind, 'bind into a defined Int';
+throws-like '"Hi"[0] := 1', X::Bind, 'bind into a defined Str';
+
+# X::InvalidType: `hides` an unknown type (mirrors `does` and `returns`).
+throws-like 'my class C hides Baz { }', X::InvalidType,
+    typename => 'Baz', 'hides unknown type';
+
+# X::Str::Numeric.source-indicator carries the offending source string.
+throws-like 'use fatal; +("\b" x 10)', X::Str::Numeric,
+    source-indicator => /'\b'/, 'prefix + on a bad string carries source-indicator';
+
+# A bad numeric string still produces a *lazy* Failure (not an eager throw)
+# without `use fatal`.
+{
+    my $f = +"abc";
+    is $f.defined, False, 'prefix + on a bad string is an undefined Failure';
+}
+
+# Legitimate subscript binds still alias and write through.
+{
+    my @a;
+    my $s = 5;
+    @a[0] := $s;
+    $s = 9;
+    is @a[0], 9, 'legitimate @a[0] := $s aliases the source container';
+}


### PR DESCRIPTION
Part of PLAN.md §C roast backlog item ① (残りの型付き例外), driven by BLOCKERS.md §B `S32-exceptions/misc.t`.

Three independent typed-exception gaps, each turning a plain/attribute-less runtime error into the correct catchable typed exception:

- **X::Bind** — binding into an immutable subscript target now throws at parse time. `(1,2)[0] := 3` (all-literal list), `10[0] := 1`, `"Hi"[0] := 1` (literal scalars) previously succeeded silently or produced garbage. (tests 148, 151, 152)
- **X::InvalidType** — `class C hides UnknownType` now throws X::InvalidType (typename carried via the message-extraction path, like `does`), instead of X::Inheritance::UnknownParent. (test 96)
- **X::Str::Numeric.source-indicator** — prefix `+` on a bad numeric string now builds a Failure carrying `source`/`pos`/`reason`/`source-indicator` attributes (reusing `str_numeric_failure`) instead of a message-only exception. (test 68)

**misc.t: 124 → 129 passing.** Adds `t/typed-exceptions-misc.t`.

Deferred (out of scope): `sub foo() returns Bar` → X::InvalidType (test 95) needs a `-->` vs `returns`/`of` trait-origin flag on the SubDecl AST (~26 construction sites), too broad for one test.

Local: `make test` PASS (982 files / 9594 tests); related roast (misc2.t, nested.t, num.t, inheritance.t) PASS; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)