### PR TITLE
feat(single-store): write bare s/// topic and :let regex modifier through to the caller's slot (Slice F regex carrier coherence)

### DIFF
--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -454,6 +454,24 @@ impl Interpreter {
         self.restore_env_entries(restore_always);
         if !matched {
             self.restore_env_entries(restore_on_fail);
+        } else {
+            // Slice F (regex carrier): a `:let $x = ...` declarative modifier that
+            // survives a successful match wrote a caller lexical straight into
+            // `env` (the `restore_on_fail` keys are the `:let` names), bypassing
+            // `set_env_with_main_alias` and the VM's slot write-through. Log each
+            // persisted name (+ carrier) so the smartmatch site reconciles the
+            // caller's compiled local slot via `writeback_match_locals`, without
+            // relying on the reverse `sync_locals_from_env` pull. Logging a
+            // superset is safe — the writeback filters by the caller's slots.
+            let persisted: Vec<String> = restore_on_fail.keys().cloned().collect();
+            for name in persisted {
+                if let Some(v) = self.env.get(&name).cloned() {
+                    if let Some(set) = self.carrier_writes.as_mut() {
+                        set.insert(name.clone());
+                    }
+                    self.pending_local_updates.push((name, v));
+                }
+            }
         }
         result
     }

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -491,7 +491,7 @@ impl Interpreter {
                         samespace,
                     );
                     let result = Value::str(out);
-                    self.write_subst_topic_checked(result)?;
+                    self.write_subst_topic_checked(code, result)?;
                     // Create Match object and set $/
                     let match_obj = Self::make_subst_match(&text, start, end);
                     self.env_mut().insert("/".to_string(), match_obj.clone());
@@ -533,7 +533,7 @@ impl Interpreter {
                         )
                     };
                     let result = Value::str(out);
-                    self.write_subst_topic_checked(result)?;
+                    self.write_subst_topic_checked(code, result)?;
                     // Create Match object and set $/
                     let match_obj = Self::make_subst_match(&text, start, end);
                     self.env_mut().insert("/".to_string(), match_obj.clone());
@@ -654,7 +654,7 @@ impl Interpreter {
             )
         };
         let result = Value::str(out);
-        self.write_subst_topic_checked(result)?;
+        self.write_subst_topic_checked(code, result)?;
         // For :g / :x, $/ and the substitution result are a List of Match
         // objects; otherwise a single Match for the first (and only) range.
         if result_is_list {
@@ -682,7 +682,11 @@ impl Interpreter {
     /// `method ro($_) {...}` / `sub ($x is readonly) {...}` parameter). Only
     /// reached after a substitution actually occurred, so a non-matching
     /// `s///` against a read-only topic stays a no-op.
-    fn write_subst_topic_checked(&mut self, result: Value) -> Result<(), RuntimeError> {
+    fn write_subst_topic_checked(
+        &mut self,
+        code: &CompiledCode,
+        result: Value,
+    ) -> Result<(), RuntimeError> {
         if self.readonly_vars().contains("_") {
             let mut attrs = std::collections::HashMap::new();
             attrs.insert(
@@ -695,7 +699,25 @@ impl Interpreter {
         self.env_mut().insert("_".to_string(), result.clone());
         self.env_mut().insert("$_".to_string(), result.clone());
         self.env_mut()
-            .insert("__mutsu_rw_map_topic__".to_string(), result);
+            .insert("__mutsu_rw_map_topic__".to_string(), result.clone());
+        // Slice F (regex carrier): a bare `s///` modifies the topic `$_` by name
+        // in `env`. When `my $_` makes `_` a compiled local slot, write the new
+        // value through to that slot so it stays coherent without the reverse
+        // `sync_locals_from_env` pull. If `$_` aliases a `given`/`for` source
+        // scalar (`topic_source_var`), mirror the modified topic back to it too,
+        // matching the `$x ~~ s///` smartmatch writeback path. Both `_` and the
+        // source name are flagged for the carrier (env_dirty) so an enclosing
+        // EVAL/carrier dropping its blanket net still reconciles the slot.
+        self.update_local_if_exists(code, "_", &result);
+        self.note_caller_env_write("_");
+        if let Some(source_var) = self.topic_source_var.clone()
+            && !source_var.starts_with('@')
+            && !source_var.starts_with('%')
+        {
+            self.set_env_with_main_alias(&source_var, result.clone());
+            self.update_local_if_exists(code, &source_var, &result);
+            self.note_caller_env_write(&source_var);
+        }
         Ok(())
     }
 

--- a/t/regex-carrier-writeback-coherence.t
+++ b/t/regex-carrier-writeback-coherence.t
@@ -1,0 +1,55 @@
+# Slice F (regex carrier) coherence: a bare `s///`, `$x ~~ s///`, and a `:let`
+# declarative regex modifier write a caller lexical straight into `env` by name.
+# When that lexical is a compiled local slot, the value must be written through
+# to the slot so it stays coherent WITHOUT the reverse `sync_locals_from_env`
+# pull. These tests pin ON == OFF == raku; run with MUTSU_NO_REVERSE_SYNC=1 to
+# exercise the write-through path directly.
+use Test;
+
+plan 10;
+
+# --- bare s/// updates the lexical topic $_ ---------------------------------
+{
+    my $_ = "abc";
+    ok s/ab/xy/, 'bare s/// returns truthy on match';
+    is $_, "xyc", 'bare s/// updates the lexical $_ slot';
+}
+
+# --- bare s///  with no match leaves $_ unchanged --------------------------
+{
+    my $_ = "hello";
+    nok s/zzz/Q/, 'bare s/// returns falsy on no match';
+    is $_, "hello", 'bare s/// leaves $_ unchanged on no match';
+}
+
+# --- bare s:g/// global substitution --------------------------------------
+{
+    my $_ = "a-a-a";
+    ok s:g/a/b/, 's:g/// returns truthy';
+    is $_, "b-b-b", 's:g/// updates the $_ slot for every match';
+}
+
+# --- $x ~~ s/// updates the named lexical ----------------------------------
+{
+    my $s = "foobar";
+    $s ~~ s/foo/baz/;
+    is $s, "bazbar", '$x ~~ s/// updates the named lexical slot';
+}
+
+# --- :let updates the caller lexical on a successful match -----------------
+{
+    my $a = 1;
+    my regex lma { $a $a };
+    my regex la { :let $a = 5; <&lma> };
+    ok '55' ~~ m/^ <la> $/, ':let successful match';
+    is $a, 5, ':let keeps the updated value in the caller slot after success';
+}
+
+# --- :let on an unsuccessful match (value restore semantics differ across
+#     implementations; only the match result is asserted here for coherence) --
+{
+    my $b = 1;
+    my regex bma { $b $b };
+    my regex ba { :let $b = 5; <&bma> };
+    nok '23' ~~ m/^ <ba> $/, ':let unsuccessful match returns falsy';
+}


### PR DESCRIPTION
## Summary

Clears the last two **regex-carrier walls** of the locals↔env dual store. A bare `s///` and a `:let \$x = ...` declarative regex modifier both write a caller lexical straight into `env` by name, bypassing the VM's slot write-through. When that lexical is a compiled local slot (`my \$_`, or a `:let`-targeted caller variable), the slot stays stale unless the reverse `sync_locals_from_env` pull runs — so both cases were **OFF-dependent** (failed under `MUTSU_NO_REVERSE_SYNC=1`).

## Changes

- **bare `s///` topic write-through** (`vm_string_regex_ops.rs`): `write_subst_topic_checked` now takes `code` and, after writing the modified topic into `env`, writes it through to the `_` local slot and flags it for the carrier (`note_caller_env_write`). When `\$_` aliases a `given`/`for` source scalar (`topic_source_var`), the modified topic is mirrored back to that source too — matching the existing `\$x ~~ s///` smartmatch writeback path.
- **`:let` declarative modifier write-through** (`runtime/regex/regex_match_public.rs`): the declarative-regex prefix handler logs each `:let` name that survives a successful match (the `restore_on_fail` keys) into `pending_local_updates` (+ carrier), so the smartmatch site reconciles the caller's compiled slot via `writeback_match_locals` without the reverse pull.

## Test

`t/regex-carrier-writeback-coherence.t` (10 tests: bare `s///` / `s:g///` / `\$x ~~ s///` / `:let` success / `:let` fail) — asserts **ON == OFF == raku**.

`make test` PASS (984 files / 9614 tests). OFF scan: **7 → 5** (remaining = the 5 concurrent-cell walls, which require shared-cell capture across threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)