### PR TITLE
feat(single-store): reconcile caller slots after react/whenever + gather-coroutine captured writes (Slice F; OFF surface -> 0)

### DIFF
--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -557,5 +557,70 @@ make test PASS（981 files/9587 tests）。OFF scan: **13→7**（残＝regex ca
 - **並行 cell（5）**: `done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
   `supply-on-demand-closing`/`supply-sync-infinite-emit`（別スレッド→caller slot 到達不可・§4-A cell 共有前提）。
 
-次の substrate＝ regex carrier（s///-topic / :let の caller-lexical 書込を carrier ログ化）か
-並行 cell 共有（§4-A）。multi-frame accumulation の壁は本セッションで消滅。
+### 6.7 ★第38セッション — regex carrier を解決（OFF 7→5・PR #3347）
+
+§6.6 の残 regex carrier 2 件を畳んだ。両者とも callee（substitution engine / declarative
+regex prefix）が caller lexical を `env` に**名前で**書き、VM の slot write-through を迂回していた。
+
+- **bare `s///` の `$_` topic（`regex-m-s`）**: `write_subst_topic_checked`（`vm_string_regex_ops.rs`）が
+  modified topic を `env["_"]` に insert するだけで、`my $_` が `_` を compiled local slot に
+  していると slot が stale。修正＝同関数に `code` を渡し、env insert の後で
+  `update_local_if_exists(code, "_", &result)` で slot へ write-through ＋ `note_caller_env_write("_")`
+  で carrier/env_dirty を立てる。`$_` が `given`/`for` の source scalar を alias している
+  （`topic_source_var`）場合は、その source 名にも mirror（`$x ~~ s///` smartmatch path と対称）。
+- **`:let $x = ...` declarative modifier（`regex-declarative-modifiers`）**: declarative-regex prefix
+  handler（`runtime/regex/regex_match_public.rs`）が `:let` 値を `self.env` に直書き。match 成功時は
+  `restore_on_fail` を適用しないので値が永続するが、caller slot は未更新。修正＝match 成功時に
+  `restore_on_fail` のキー（＝`:let` 名）を現 env 値とともに `pending_local_updates`（+ carrier）へ
+  log → smartmatch site の `writeback_match_locals` が caller slot を reverse pull 抜きで再収束。
+  - **★注**: `t/regex-declarative-modifiers.t` test 4（`:let` 不成功 match 後の変数 restore で
+    `$a==1` を期待）は **raku 自身が `$a==5` を返す**＝`:let` の restore-on-overall-fail セマンティクスが
+    mutsu と Rakudo で乖離（dual-store とは無関係の別件）。pin test ではこの contested な値検査を外し、
+    match 結果（nok）のみ assert。
+
+pin=`t/regex-carrier-writeback-coherence.t`（10・bare `s///`/`s:g///`/`$x ~~ s///`/`:let` 成功/`:let` 失敗・
+ON=OFF=raku）。make test PASS（984 files/9614 tests）。OFF scan: **7→5**。
+
+**残 5 内訳（第38末）— 全て並行 cell（§4-A cell 共有前提）**:
+`done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
+`supply-on-demand-closing`/`supply-sync-infinite-emit`。callee が別スレッドで走り、caller の
+local slot は別フレーム／別スタックにあるため write-through が物理的に届かない。唯一の解は
+captured outer を **shared cell（`Arc<Mutex<Value>>` 様）に昇格**し、両スレッドが同一 cell を
+参照する設計（§4-A）。これは single-frame write-through ファミリーとは別物の substrate 変更。
+
+次の substrate＝ 並行 cell 共有（§4-A）。single-frame / multi-frame / carrier の write-through 壁は
+これで全て消滅し、残るのはスレッド境界を跨ぐ cell 共有のみ。
+
+### 6.8 ★第38セッション後半 — 「並行 cell」は実は同期だった（OFF 5→0・PR #XXXX）
+
+§6.6/§6.7 が「並行 cell（別スレッド→caller slot 到達不可・§4-A 前提）」と分類していた残 5 件は、
+**実測で全て同一 VM 上の同期実行**と判明した（reverse-sync ON が pull で直すのが動かぬ証拠＝
+別スレッド・別 env なら ON でも直らない）。`Supply.from-list` / `supply { emit }` の whenever
+callback も `gather` coroutine body も `&mut self` 上で compiled bytecode として走り、captured-outer
+caller lexical を `env` に名前で書く。よって single-frame write-through ファミリーと同じ機構で畳めた。
+
+- **react/whenever（4 件: `done-paren-stmt-modifier` / `react-whenever-last-next` /
+  `supply-on-demand-closing` / `supply-sync-infinite-emit`）**: `exec_react_scope_op`
+  （`vm_register_ops.rs`）の event-loop 後 reconcile が `sync_locals_from_env`（toggle 対象＝OFF で no-op）
+  だった。これを **toggle 非依存の `reconcile_locals_from_env_at_site(code)`** に差し替え（ON で byte-identical・
+  同一 HashSlotRef/`!attr` skip）。1 行で 4 件解決。
+- **gather coroutine（1 件: `gather-infinite-coroutine` の `.first` captured-`$c`）**: `try_lazy_gather_first`
+  （`vm_native_first.rs`）の incremental-pull ループで、matcher closure（`* >= 3`）が `exec` 経由で
+  `self.current_code` を**自フレームに上書き**して戻さない。`force_lazy_list_vm_n` はこの `current_code` を
+  「captured-outer write を reconcile する caller フレーム」として捕捉する（`reconcile_caller_after_lazy_force`）ので、
+  2 回目以降の force が matcher のフレームを reconcile し caller の `$c` slot が OFF で stale（c=1 のまま）。
+  ON では post-method の barrier pull がマスクしていた。修正＝ループ入口で caller `current_code` を pin し
+  **各 force の直前に restore**。`.head(n)` 系の captured-`$c` は ON でも 0（別件の gather-head 副作用
+  可視性の制約・dual-store 無関係・test も未アサート）。
+
+pin=`t/concurrent-cell-writeback-coherence.t`（8・react `++`/`+=`/`done()` 境界・supply emit・gather
+`.first` captured accumulation・ON=OFF=raku）。OFF scan（全 t/）: 残失敗は #3347 が直す regex 2 件のみ＝
+**両 PR 合算で OFF surface 7→0**。
+
+**★結論: locals↔env coherence の write-through グラインドは完了**。第27〜38セッションで single-frame /
+multi-frame / carrier / 並行(=実は同期) の全カテゴリを `pending_rw_writeback_sources` /
+`reconcile_locals_from_env_at_site` / carrier ログの 3 機構へ畳み、OFF（`MUTSU_NO_REVERSE_SYNC=1`）で
+全 t/ が pass。`sync_locals_from_env`（reverse pull）は **もはや correctness に必要な箇所が無い**＝
+Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射程に入った。第32セッションで 65 ファイル
+回帰した壁は、本グラインドで全て write-through 化された。次の大物＝Stage 3 再挑戦
+（`sync_locals_from_env` デフォルト無効化を全 t/ + roast CI で検証）。

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -122,8 +122,19 @@ impl Interpreter {
         // chunks) keeps the gather body's side effects in step with the match
         // position, matching Rakudo (`.first(* >= 3)` runs the body exactly as
         // far as the first match, no further).
+        //
+        // Slice F (gather coroutine coherence): the matcher closure (`* >= 3`)
+        // runs via `exec` and leaves `self.current_code` pointing at *its* frame.
+        // `force_lazy_list_vm_n` captures `self.current_code` as the frame to
+        // reconcile a captured-outer write into (`my $c; gather { loop { $c++ } }`),
+        // so without restoring it each iteration the second-and-later forces
+        // reconcile the matcher's frame instead of the caller's, leaving the
+        // caller's `$c` slot stale under reverse-sync OFF. Pin the caller frame
+        // captured at entry and restore it before every force.
+        let caller_code = self.current_code;
         let mut idx = 0usize;
         loop {
+            self.current_code = caller_code;
             let items = match self.force_lazy_list_vm_n(list, idx + 1) {
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1734,7 +1734,16 @@ impl Interpreter {
         } else {
             self.run_react_event_loop()
         };
-        self.sync_locals_from_env(code);
+        // Slice F (react/whenever coherence): the `whenever` callbacks ran as
+        // compiled bytecode on *this* VM (synchronous `from-list` emit) and
+        // mutated captured-outer caller lexicals (`my $i; whenever ... { $i++ }`)
+        // straight into `env` by name. Reconcile the caller's local slots from
+        // env unconditionally (not gated by the reverse-sync campaign toggle), so
+        // the slot stays coherent without relying on the speculative reverse
+        // `sync_locals_from_env` pull. Under reverse-sync ON this is byte-identical
+        // to the barrier pull it replaces (same HashSlotRef / `!attr` per-slot
+        // skips); under OFF it is what keeps `$i` correct.
+        self.reconcile_locals_from_env_at_site(code);
         self.env_dirty = true;
 
         *ip = end;

--- a/t/concurrent-cell-writeback-coherence.t
+++ b/t/concurrent-cell-writeback-coherence.t
@@ -1,0 +1,66 @@
+# Slice F (concurrent / lazy-coroutine cell) coherence: a `whenever` callback and
+# a `gather` coroutine body both run synchronously on the same VM and mutate a
+# captured-outer caller lexical (`my $i; whenever ... { $i++ }`,
+# `my $c; gather { loop { $c++; take ... } }`) straight into `env` by name. When
+# that lexical is a compiled local slot, the value must be written through to the
+# slot so it stays coherent WITHOUT the reverse `sync_locals_from_env` pull. These
+# pin ON == OFF == raku; run with MUTSU_NO_REVERSE_SYNC=1 to exercise the
+# write-through path directly.
+use Test;
+
+plan 8;
+
+# --- react/whenever captured-outer accumulation ----------------------------
+{
+    my $i = 0;
+    react whenever Supply.from-list(0, 1, 2, 3, 4, 5) {
+        done() if $_ == 3;
+        $i++;
+    }
+    is $i, 3, 'blockless react: $i accumulates to the done() boundary';
+}
+
+{
+    my $i = 0;
+    react {
+        whenever Supply.from-list(10, 20, 30) {
+            $i++;
+            done();
+        }
+    }
+    is $i, 1, 'block react: $i sees the single iteration before bare done()';
+}
+
+{
+    my $sum = 0;
+    react whenever Supply.from-list(1, 2, 3, 4) {
+        $sum += $_;
+        done() if $_ == 4;
+    }
+    is $sum, 10, 'react: += accumulates the captured outer across all emits';
+}
+
+# --- supply on-demand / sync-emit captured-outer ---------------------------
+{
+    my $seen = 0;
+    my $s = supply {
+        for 1..3 { emit $_ }
+    }
+    react whenever $s { $seen++ }
+    is $seen, 3, 'supply block: whenever counter accumulates over the emits';
+}
+
+# --- gather coroutine captured-outer side effect via .first ----------------
+{
+    my $c = 0;
+    my $g = gather { my $i = 0; loop { $c++; take $i++ } };
+    is $g.first(* >= 3), 3, 'gather .first returns the first matching value';
+    is $c, 4, 'gather .first runs the body exactly to the match (captured $c)';
+}
+
+{
+    my $c = 0;
+    my $g = gather { my $i = 0; loop { $c++; take $i++ } };
+    is $g.first(* > 7), 8, 'gather .first(* > 7) returns 8';
+    is $c, 9, 'gather .first(* > 7) accumulates the captured $c to 9';
+}


### PR DESCRIPTION
## Summary

Clears the **last 5 OFF-dependent walls** of the locals↔env dual store. They were classified as *"concurrent cell (separate thread → caller slot unreachable, requires shared-cell capture)"* — but all 5 actually run **synchronously on the same VM**. The proof: reverse-sync ON repairs them via the barrier pull, which a separate thread with a separate `env` could not. A `Supply.from-list` / `supply { emit }` `whenever` callback and a `gather` coroutine body both run as compiled bytecode on `&mut self` and write a captured-outer caller lexical into `env` by name — so the same write-through family that handled single-frame / multi-frame / carrier writes applies.

## Changes

- **react/whenever (4 walls)** (`vm_register_ops.rs`): `exec_react_scope_op` reconciled caller slots after the event loop via `sync_locals_from_env`, which the reverse-sync campaign toggle turns into a no-op (OFF). Swapped for the toggle-independent `reconcile_locals_from_env_at_site(code)` — byte-identical under ON (same `HashSlotRef` / `!attr` per-slot skips), correct under OFF. One line, 4 walls.
- **gather coroutine (1 wall)** (`vm_native_first.rs`): the lazy `.first` incremental-pull loop in `try_lazy_gather_first` let the matcher closure (`* >= 3`) overwrite `self.current_code` without restoring it. `force_lazy_list_vm_n` captures `current_code` as the frame to reconcile a captured-outer write into, so the 2nd-and-later forces reconciled the matcher's frame instead of the caller's, leaving `\$c` stale under OFF (ON masked it via the post-method barrier pull). Pin the caller frame at loop entry and restore it before every force.

## Test

`t/concurrent-cell-writeback-coherence.t` (8 tests: react `++` / `+=` / `done()` boundary / supply emit / gather `.first` captured accumulation) — asserts **ON == OFF == raku**.

`make test` PASS (984 files / 9612 tests). Full `t/` OFF scan: **0 remaining failures** (the regex-carrier 2 were fixed in #3347). Combined across both PRs the locals↔env **OFF surface reaches 0** — the write-through grind is complete and Stage 3 (default-disabling the reverse sync) is in range again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)