### PR TITLE
feat(single-store): Stage 3 — disable reverse sync_locals_from_env by default (WIP, fix-forward roast)

### DIFF
--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -654,7 +654,12 @@ Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射
 | 13 | S03-operators/notandthen | `andthen`/`notandthen` の `OpCode::CallDefined` が **user `method defined`** を dispatch→captured `$calls++` | CallDefined の user-method 枝のみ reconcile（native check は pure 維持） |
 | **14** | **S32-str/val.t（解決済・第39セッション）** | **内側 `for (...) -> $string, \value` の multi-param 復元が env のみで local slot を復元せず**。当初「subtest closure の read-coherence 壁」と診断したが、最小化すると closure 不在の `for ... -> \value` 本体での bare read 自体が既に stale（`outer-read: 4_2 => -42`）＝診断は誤り。真因＝内側 for の sigilless `\value` 多パラメタが**外側 `\value` と同名＝同一 local slot を共有**し、ループ末の `saved_multi_params` 復元が env binding だけ戻して local slot を最終イテレーション値（-42）のまま残す→reverse pull OFF で次の外側イテレーションが element list を stale な `value` で再評価 | 多パラメタ復元ループ（`exec_for_loop_body`, vm_control_ops.rs:1218）に **local slot への write-through** を追加（`find_local_slot(code, name)` があれば `locals[slot] = v`）。ON で byte-identical。pin=`t/multiframe-sigilless-for-rebind-coherence.t`（4） |
 
-make test PASS（986 files / 9626 tests）。**Stage 3 の roast OFF 依存 14/14 全解決**。**val.t は当初 multi-frame
+| **15** | **S03-junctions/autothreading.t（解決済・第39セッション・CI surface）** | **invocant junction の method autothread が captured-outer / `our` 変異を最後の eigenstate しか伝播しない**。`$junc.a`（`method a { $cnt++ }`）で各 eigenstate は env に正しく累積する（threaded 戻り値 `any(0,1,0)` が証明）が、per-call の pending writeback は**最後の eigenstate の source しか運ばない**→eigenstate が**異なる変数**を書くと（earlier=$cnt1・last=$cnt2）earlier の $cnt1 が caller local slot に届かず stale（0）。当初「method-invocant autothread `our`-var 蓄積壁」（第34節 deferred）と認識されローカル survey で「junctions flaky」と誤分類 | CallMethod / CallMethodMut **両** junction loop（vm_call_method_ops.rs / vm_call_method_mut_ops.rs）は normal post-dispatch reconcile の前に early-return するため、threading 後に `reconcile_locals_from_env_at_site(code)` を 1 回追加（env は全 eigenstate の累積値を保持済）。ON で byte-identical。pin=`t/junction-invocant-autothread-writeback-coherence.t`（6） |
+
+make test PASS（987 files / 9632 tests）。**Stage 3 の roast OFF 依存 15/15 全解決**（CI が val.t commit 後に
+14 の survey から漏れていた autothreading.t を surface＝junctions は flaky でなく実依存だった。flaky 除外していた
+set/baghash/mix は OFF 全 PASS を再確認・sethash.t は ON/OFF 両方 exit255 の非 whitelist plan-abort でスコープ外）。
+**val.t は当初 multi-frame
 read-coherence 壁と思われたが、実態は #13 までと同じ単一パターン（interpreter-run/loop path が caller lexical
 を共有 slot に書くが復元/reconcile で slot を戻さない）の一発現**で、多パラメタ復元の env-only 復元に local
 write-through を足すだけで解けた（read-direction の独立 substrate ではなかった）。**Stage 3（reverse-sync

--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -652,12 +652,13 @@ Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射
 | 10-11 | S14-roles/{mixin-6e,submethods-6e} | `$obj does/but Role` の `submethod BUILD/TWEAK` が captured outer を名前書き。`exec_does_op`/`exec_does_var_op` は **toggle-gated** `sync_locals_from_env`、`exec_but_mixin_op` は **sync 皆無** | does×2 を toggle 非依存 reconcile に差替、but に reconcile 追加（`ButMixin` op に `code` 渡す） |
 | 12 | S32-str/substr-rw | `$r := substr-rw($s); $r = v` の **Proxy STORE** が referent `$s` を名前書き | scalar-assign の Proxy STORE 3 サイト（`assign_proxy_lvalue` 後）に reconcile |
 | 13 | S03-operators/notandthen | `andthen`/`notandthen` の `OpCode::CallDefined` が **user `method defined`** を dispatch→captured `$calls++` | CallDefined の user-method 枝のみ reconcile（native check は pure 維持） |
-| **14** | **S32-str/val.t（未解決）** | **多段 sigilless-alias chain**: `for @ok -> \value,@strings { ok-val(value,@strings) }` → `ok-val(\value)` param → 内側 `for ... -> $string,\value` → subtest closure が `value` を**読む**。OFF で深いフレーム跨ぎの sigilless `\value` が subtest closure 内で stale（661 subtest fail）。**= multi-frame retention 壁（read-coherence）**・write-back 系の reconcile では届かない | **未解決**。次セッションの focused 課題。sigilless for-rebind の env flush + nested-closure capture 同期 or shared-cell が要る |
+| **14** | **S32-str/val.t（解決済・第39セッション）** | **内側 `for (...) -> $string, \value` の multi-param 復元が env のみで local slot を復元せず**。当初「subtest closure の read-coherence 壁」と診断したが、最小化すると closure 不在の `for ... -> \value` 本体での bare read 自体が既に stale（`outer-read: 4_2 => -42`）＝診断は誤り。真因＝内側 for の sigilless `\value` 多パラメタが**外側 `\value` と同名＝同一 local slot を共有**し、ループ末の `saved_multi_params` 復元が env binding だけ戻して local slot を最終イテレーション値（-42）のまま残す→reverse pull OFF で次の外側イテレーションが element list を stale な `value` で再評価 | 多パラメタ復元ループ（`exec_for_loop_body`, vm_control_ops.rs:1218）に **local slot への write-through** を追加（`find_local_slot(code, name)` があれば `locals[slot] = v`）。ON で byte-identical。pin=`t/multiframe-sigilless-for-rebind-coherence.t`（4） |
 
-make test PASS（985 files / 9622 tests）。**Stage 3 は val.t 1 件で merge blocked**（whitelisted）。draft PR #3349
-に 13/14 着地。**val.t は multi-frame sigilless retention＝独立 substrate**（earlier memory の「multi-frame
-retention 壁」と同根）で、本セッションの「interpreter-run path が caller lexical を名前書き→call-site で
-toggle 非依存 reconcile」パターンとは別系。次セッション＝val.t（sigilless multi-frame）を focused に。
+make test PASS（986 files / 9626 tests）。**Stage 3 の roast OFF 依存 14/14 全解決**。**val.t は当初 multi-frame
+read-coherence 壁と思われたが、実態は #13 までと同じ単一パターン（interpreter-run/loop path が caller lexical
+を共有 slot に書くが復元/reconcile で slot を戻さない）の一発現**で、多パラメタ復元の env-only 復元に local
+write-through を足すだけで解けた（read-direction の独立 substrate ではなかった）。**Stage 3（reverse-sync
+デフォルト無効化）は全 t/ + roast OFF 依存クリアで merge 可能。**
 
 **教訓**: Stage 3 で surface した 14 件は t/ scan 非代表だったが、**13 件は単一パターン**（interpreter-run
 op が caller lexical を名前書きするが call-site で reconcile しない）の異なる発現で、各 op site に

--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -624,3 +624,21 @@ multi-frame / carrier / 並行(=実は同期) の全カテゴリを `pending_rw_
 Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射程に入った。第32セッションで 65 ファイル
 回帰した壁は、本グラインドで全て write-through 化された。次の大物＝Stage 3 再挑戦
 （`sync_locals_from_env` デフォルト無効化を全 t/ + roast CI で検証）。
+
+## 7. Stage 3 — reverse-sync デフォルト無効化（第38セッション末・進行中）
+
+`reverse_sync_disabled()`（`vm_stats.rs`）の判定を反転＝**reverse pull はデフォルト OFF**。旧 escape hatch
+`MUTSU_NO_REVERSE_SYNC` は撤去し、opt-IN `MUTSU_REVERSE_SYNC=1`（旧挙動の再有効化＝A/B 診断用）に置換。
+
+- **make test（全 t/）= PASS**（985 files / 9622 tests・OFF scan が clean だった通り）。
+- **★roast 側に t/ scan 非代表の OFF 依存が残存**（ローカル sample で判明）。t/ は exercise しない
+  rw-aliasing / coroutine-rw / lvalue-method-rw を roast が突く:
+  - `roast/S04-statements/gather.t` test 36: `my $l = gather { take-rw my $ = 1 }; lives-ok { $l.AT-POS(0) = 42 }`
+    → **closure（`lives-ok {}`）内の take-rw gather 要素への rw 代入が OFF で外に伝播しない**。bare block
+    `{ }` / bare statement では伝播する（frame 跨ぎが壁）。coroutine が rw 取った匿名コンテナが
+    shared cell でなく coroutine env 経由＝reverse pull 前提。
+  - `roast/S04-blocks-and-statements/pointy-rw.t` test 8: `$pair.values should be rw (2)`＝lvalue-method
+    rw alias の frame 跨ぎ。
+- **方針（ユーザー選択: full Stage 3・CI を net に fix-forward）**: draft PR で full roast CI を回し、
+  roast-only OFF 依存の完全リストを取得→各々 write-through / shared-cell 化で fix-forward→green で ready。
+  これら rw-alias-through-frame は「first-class container / shared cell」substrate（§4-A 系）に接続。

--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -656,9 +656,13 @@ Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射
 
 | **15** | **S03-junctions/autothreading.t（解決済・第39セッション・CI surface）** | **invocant junction の method autothread が captured-outer / `our` 変異を最後の eigenstate しか伝播しない**。`$junc.a`（`method a { $cnt++ }`）で各 eigenstate は env に正しく累積する（threaded 戻り値 `any(0,1,0)` が証明）が、per-call の pending writeback は**最後の eigenstate の source しか運ばない**→eigenstate が**異なる変数**を書くと（earlier=$cnt1・last=$cnt2）earlier の $cnt1 が caller local slot に届かず stale（0）。当初「method-invocant autothread `our`-var 蓄積壁」（第34節 deferred）と認識されローカル survey で「junctions flaky」と誤分類 | CallMethod / CallMethodMut **両** junction loop（vm_call_method_ops.rs / vm_call_method_mut_ops.rs）は normal post-dispatch reconcile の前に early-return するため、threading 後に `reconcile_locals_from_env_at_site(code)` を 1 回追加（env は全 eigenstate の累積値を保持済）。ON で byte-identical。pin=`t/junction-invocant-autothread-writeback-coherence.t`（6） |
 
-make test PASS（987 files / 9632 tests）。**Stage 3 の roast OFF 依存 15/15 全解決**（CI が val.t commit 後に
-14 の survey から漏れていた autothreading.t を surface＝junctions は flaky でなく実依存だった。flaky 除外していた
-set/baghash/mix は OFF 全 PASS を再確認・sethash.t は ON/OFF 両方 exit255 の非 whitelist plan-abort でスコープ外）。
+| **15.5** | **val.t 修正の過剰適用回帰（解決済・第39セッション・CI surface）** | #14 の local-slot write-through が `multi_param_names`（sigil 付き名も含む）全体に効き、**全 `for ... -> $a, $b` ループ**で実行→sigil 付き param の slot が保持していた **live rw/element alias を env-only 復元値で上書き**→文字列/ループ破損（`expected bc got c`/`expected abecd got abec`）。並列 CI ログが読めず（gh log 切り詰め）、**ローカル release `make roast` の Test Summary で特定** | write-through を **sigilless 名のみ**（`!name.starts_with(['$','@','%','&'])`）に制限。val.t バグは sigilless `\value` 固有なので保たれ、sigil 付きは（既に coherent な）env-only 復元へ戻る |
+| **16** | **S32-io/IO-Socket-Async.t（解決済・第39セッション）test 40 'listen tap is a Tap'** | `my $tap = do whenever $sup {…}` が tap を `env[target_var]` に直接書く（`run_whenever_with_value` 4 サイト）が caller local slot 未更新→**同 react block 内の後続 read**（`isa-ok $tap, Tap`）が stale slot（`do` block 自身の結果＝Supply）を読む。#3348 の react-scope-end reconcile は block 内 read に間に合わない。これも survey で「IO-Socket-Async flaky」と誤分類された決定論 OFF 依存 | `exec_whenever_scope_op`（env_dirty set 済）に `reconcile_locals_from_env_at_site(code)` 追加。ON で byte-identical。pin=`t/react-do-whenever-tap-coherence.t`（2） |
+
+make test PASS（988 files / 9634 tests）。**Stage 3 の roast OFF 依存 16/16 全解決**（CI が val.t commit 後に
+14 survey から漏れた autothreading.t を、その後ローカル release roast が IO-Socket-Async.t を surface＝junctions/
+IO-Socket-Async は flaky でなく実依存だった。教訓: 並列 CI ログは gh で切り詰められ失敗特定不能→**ローカル release
+`make roast` の末尾 Test Summary が権威的**。set/baghash/mix は OFF 全 PASS・sethash.t は非 whitelist plan-abort でスコープ外）。
 **val.t は当初 multi-frame
 read-coherence 壁と思われたが、実態は #13 までと同じ単一パターン（interpreter-run/loop path が caller lexical
 を共有 slot に書くが復元/reconcile で slot を戻さない）の一発現**で、多パラメタ復元の env-only 復元に local

--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -639,6 +639,27 @@ Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射
     shared cell でなく coroutine env 経由＝reverse pull 前提。
   - `roast/S04-blocks-and-statements/pointy-rw.t` test 8: `$pair.values should be rw (2)`＝lvalue-method
     rw alias の frame 跨ぎ。
-- **方針（ユーザー選択: full Stage 3・CI を net に fix-forward）**: draft PR で full roast CI を回し、
-  roast-only OFF 依存の完全リストを取得→各々 write-through / shared-cell 化で fix-forward→green で ready。
-  これら rw-alias-through-frame は「first-class container / shared cell」substrate（§4-A 系）に接続。
+- **方針（ユーザー選択: full Stage 3・CI を net に fix-forward）**: draft PR #3349。local `make roast`
+  で roast-only OFF 依存の完全リストを取得（**14 件**・flaky 除外後）→各々 toggle 非依存 reconcile で fix-forward。
+
+### 7.1 roast OFF 依存 14 件の fix-forward（13/14 解決）
+
+完全リスト（OFF=fail ON=pass を `MUTSU_REVERSE_SYNC=1` で確認・flaky の set/baghash/junctions/IO-Socket-Async 除外）:
+
+| # | file | 真因 | 修正 |
+|---|------|------|------|
+| 1-9 | pointy-rw, gather(take-rw), S14-roles/{anonymous,parameterized-mixin,rw}, S12-meta/primitives, S04-terminator, S02-symbolic-deref, S32-hash/kv | **block-taking Test 関数**（`lives-ok{}`/`subtest`/`throws-like`）が `__mutsu_test_callsite_line` named arg のため `exec_exec_call_pairs_op` 経由→block を interpreter で実行→`is rw` for-alias 等を env に名前書き（carrier 未ログ）。pairs op の carrier fallback が env_dirty=true だけで reconcile せず | `exec_exec_call_pairs_op`（無条件）+ `exec_exec_call_op` の `!fully` 枝に `reconcile_locals_from_env_at_site` |
+| 10-11 | S14-roles/{mixin-6e,submethods-6e} | `$obj does/but Role` の `submethod BUILD/TWEAK` が captured outer を名前書き。`exec_does_op`/`exec_does_var_op` は **toggle-gated** `sync_locals_from_env`、`exec_but_mixin_op` は **sync 皆無** | does×2 を toggle 非依存 reconcile に差替、but に reconcile 追加（`ButMixin` op に `code` 渡す） |
+| 12 | S32-str/substr-rw | `$r := substr-rw($s); $r = v` の **Proxy STORE** が referent `$s` を名前書き | scalar-assign の Proxy STORE 3 サイト（`assign_proxy_lvalue` 後）に reconcile |
+| 13 | S03-operators/notandthen | `andthen`/`notandthen` の `OpCode::CallDefined` が **user `method defined`** を dispatch→captured `$calls++` | CallDefined の user-method 枝のみ reconcile（native check は pure 維持） |
+| **14** | **S32-str/val.t（未解決）** | **多段 sigilless-alias chain**: `for @ok -> \value,@strings { ok-val(value,@strings) }` → `ok-val(\value)` param → 内側 `for ... -> $string,\value` → subtest closure が `value` を**読む**。OFF で深いフレーム跨ぎの sigilless `\value` が subtest closure 内で stale（661 subtest fail）。**= multi-frame retention 壁（read-coherence）**・write-back 系の reconcile では届かない | **未解決**。次セッションの focused 課題。sigilless for-rebind の env flush + nested-closure capture 同期 or shared-cell が要る |
+
+make test PASS（985 files / 9622 tests）。**Stage 3 は val.t 1 件で merge blocked**（whitelisted）。draft PR #3349
+に 13/14 着地。**val.t は multi-frame sigilless retention＝独立 substrate**（earlier memory の「multi-frame
+retention 壁」と同根）で、本セッションの「interpreter-run path が caller lexical を名前書き→call-site で
+toggle 非依存 reconcile」パターンとは別系。次セッション＝val.t（sigilless multi-frame）を focused に。
+
+**教訓**: Stage 3 で surface した 14 件は t/ scan 非代表だったが、**13 件は単一パターン**（interpreter-run
+op が caller lexical を名前書きするが call-site で reconcile しない）の異なる発現で、各 op site に
+`reconcile_locals_from_env_at_site(code)` を足すだけで解けた（ON で byte-identical）。残り val.t だけが
+read-direction の multi-frame retention で質的に異なる。

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2563,7 +2563,7 @@ impl Interpreter {
 
             // -- Mixin / Type check --
             OpCode::ButMixin => {
-                self.exec_but_mixin_op()?;
+                self.exec_but_mixin_op(code)?;
                 *ip += 1;
             }
             OpCode::ButMixinTupleElem => {
@@ -2833,6 +2833,15 @@ impl Interpreter {
                 } else {
                     Value::Bool(runtime::types::value_is_defined(&val))
                 };
+                // Stage 3: a user-defined `.defined` (dispatched above for
+                // `andthen`/`notandthen`) runs interpreter code that can mutate a
+                // captured-outer caller lexical by name (`my $calls; method
+                // defined { $calls++ }`). Reconcile the caller's slots so the
+                // write is visible without the reverse `sync_locals_from_env`
+                // pull (only on the user-method path; the native check is pure).
+                if has_user_defined {
+                    self.reconcile_locals_from_env_at_site(code);
+                }
                 self.stack.push(defined);
                 *ip += 1;
             }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -999,7 +999,7 @@ impl Interpreter {
         self.stack.push(composed);
     }
 
-    pub(super) fn exec_but_mixin_op(&mut self) -> Result<(), RuntimeError> {
+    pub(super) fn exec_but_mixin_op(&mut self, code: &CompiledCode) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
         // `but` composing a role or another type into a type-object invocant is
@@ -1029,7 +1029,14 @@ impl Interpreter {
             if let Some(tn) = &left_type_object {
                 return Err(Self::does_type_object_error("but", tn));
             }
-            self.stack.push(composed?);
+            let composed = composed?;
+            // Stage 3: `$obj but R` runs role R's `submethod TWEAK`/`BUILD` via the
+            // interpreter (`eval_does_values`), which can mutate a captured-outer
+            // caller lexical by name (`my $invoked; role R { submethod TWEAK {
+            // $invoked = True } }`). Reconcile the caller's slots from env so the
+            // write is visible without the reverse `sync_locals_from_env` pull.
+            self.reconcile_locals_from_env_at_site(code);
+            self.stack.push(composed);
             return Ok(());
         }
         // A type object / class (not a role) on the RHS: into a type-object
@@ -1259,7 +1266,10 @@ impl Interpreter {
         self.sync_env_from_locals(code);
         let result = self.vm_does_values(left, right)?;
         // Sync back: BUILD submethods may have modified closure variables.
-        self.sync_locals_from_env(code);
+        // Stage 3: use the toggle-independent reconcile so the BUILD submethod's
+        // captured-outer writes reach the caller's slots even with the reverse
+        // `sync_locals_from_env` pull disabled (byte-identical under ON).
+        self.reconcile_locals_from_env_at_site(code);
         // Capture Mixin value for trait_mod writeback (same as DoesVar path)
         if matches!(&result, Value::Mixin(..)) && self.trait_mod_writeback_key.is_some() {
             self.trait_mod_writeback_value = Some(result.clone());
@@ -1280,7 +1290,8 @@ impl Interpreter {
         self.sync_env_from_locals(code);
         let updated = self.vm_does_values(left, right)?;
         // Sync back: BUILD submethods may have modified closure variables.
-        self.sync_locals_from_env(code);
+        // Stage 3: toggle-independent reconcile (see exec_does_op).
+        self.reconcile_locals_from_env_at_site(code);
         let name = Self::const_str(code, name_idx).to_string();
         self.env_mut().insert(name.clone(), updated.clone());
         self.update_local_if_exists(code, &name, &updated);

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -116,6 +116,17 @@ impl Interpreter {
                 self.env_dirty = pre_dirty;
             } else {
                 self.env_dirty = true;
+                // Stage 3: the carrier writeback was not fully precise — an
+                // interpreter routine wrote a caller lexical by name through a
+                // path the carrier set does not log (e.g. an `is rw` for-loop
+                // alias mutated inside a `lives-ok { }` block, or a role/mixin
+                // composition). Reconcile the caller's slots from env here, at
+                // the call site, since the reverse `sync_locals_from_env` pull is
+                // no longer there to do it at the next sync point. Byte-identical
+                // to that pull under reverse-sync ON (same per-slot skips); only
+                // runs on the imprecise carrier path, never for a fully-reconciled
+                // EVAL (which restores `pre_dirty` above).
+                self.reconcile_locals_from_env_at_site(code);
             }
         }
         Ok(())
@@ -167,6 +178,15 @@ impl Interpreter {
         exec_result?;
         self.writeback_carrier_writes(code, &written);
         self.env_dirty = true;
+        // Stage 3: a block-taking Test function (`lives-ok { ... }`,
+        // `throws-like`, ...) routes here (its `__mutsu_test_callsite_line`
+        // named arg makes it a pairs call) and runs its block through the
+        // interpreter, which can mutate a caller lexical by name through a path
+        // the carrier set does not log (an `is rw` for-loop alias inside the
+        // block). Reconcile the caller's slots from env at the call site, since
+        // the reverse `sync_locals_from_env` pull is gone. Byte-identical to that
+        // pull under reverse-sync ON (same per-slot HashSlotRef/`!attr` skips).
+        self.reconcile_locals_from_env_at_site(code);
         Ok(())
     }
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -559,6 +559,18 @@ impl Interpreter {
             };
             self.stack.push(junction_result);
             self.env_dirty = true;
+            // Slice F (env<->locals coherence): an invocant junction that threads
+            // a *user* method mutating a captured outer / `our` variable (e.g.
+            // `$junc.a` with `method a { $cnt++ }`) accumulates each eigenstate's
+            // write into env correctly, but the per-call pending writeback only
+            // carries the *last* eigenstate's source — so a different variable
+            // written by an earlier eigenstate (`$cnt1` vs the last `$cnt2`) never
+            // reaches the caller's local slot. This junction path returns before
+            // the normal post-dispatch reconcile, so with the reverse env->locals
+            // pull disabled reconcile the caller's slots from env once here; env
+            // already holds every eigenstate's accumulated value. Byte-identical
+            // with the reverse pull enabled (gated on the env_dirty just set).
+            self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }
 

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -403,6 +403,14 @@ impl Interpreter {
             };
             self.stack.push(junction_result);
             self.env_dirty = true;
+            // Slice F (env<->locals coherence): see the matching CallMethodMut
+            // junction path. An invocant junction threading a user method that
+            // mutates a captured-outer / `our` variable accumulates into env, but
+            // only the last eigenstate's pending writeback reaches the caller's
+            // slots; this path returns before the normal post-dispatch reconcile,
+            // so reconcile the caller's local slots from env here (env already
+            // holds every eigenstate's value). Byte-identical with reverse-sync on.
+            self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }
 

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1217,15 +1217,21 @@ impl Interpreter {
         // Restore saved multi-param values and readonly state
         for (name, saved_val, was_readonly, sigilless_ro) in saved_multi_params {
             if let Some(v) = saved_val {
-                // Slice F (env<->locals coherence): a multi-param loop variable
-                // shares its name (and therefore its local slot) with an
-                // enclosing binding of the same name — e.g. an outer `\value`
-                // re-bound by an inner `for (...) -> $string, \value`. Restoring
-                // only the env binding leaves the local slot clobbered with the
-                // last iteration value, so a later read of the outer name (with
-                // the reverse env->locals pull disabled) sees stale data. Write
-                // the restored value straight through to the local slot too.
-                if let Some(slot) = self.find_local_slot(code, &name) {
+                // Slice F (env<->locals coherence): a *sigilless* multi-param loop
+                // variable (`-> \value`) shares its bare name — and therefore its
+                // local slot — with an enclosing binding of the same name (an
+                // outer `\value` re-bound by an inner `for (...) -> $string,
+                // \value`). Restoring only the env binding leaves the local slot
+                // clobbered with the last iteration value, so a later read of the
+                // outer name (with the reverse env->locals pull disabled) sees
+                // stale data. Write the restored value through to the local slot
+                // too. Restricted to sigilless names: a sigil'd param (`$a`/`@a`/
+                // `%a`) keeps its own slot and may hold a live rw/element alias the
+                // env-only restore must not overwrite — those cases were already
+                // coherent without the write-through.
+                if !name.starts_with(['$', '@', '%', '&'])
+                    && let Some(slot) = self.find_local_slot(code, &name)
+                {
                     self.locals[slot] = v.clone();
                 }
                 self.env_mut().insert(name.clone(), v);

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1217,6 +1217,17 @@ impl Interpreter {
         // Restore saved multi-param values and readonly state
         for (name, saved_val, was_readonly, sigilless_ro) in saved_multi_params {
             if let Some(v) = saved_val {
+                // Slice F (env<->locals coherence): a multi-param loop variable
+                // shares its name (and therefore its local slot) with an
+                // enclosing binding of the same name — e.g. an outer `\value`
+                // re-bound by an inner `for (...) -> $string, \value`. Restoring
+                // only the env binding leaves the local slot clobbered with the
+                // last iteration value, so a later read of the outer name (with
+                // the reverse env->locals pull disabled) sees stale data. Write
+                // the restored value straight through to the local slot too.
+                if let Some(slot) = self.find_local_slot(code, &name) {
+                    self.locals[slot] = v.clone();
+                }
                 self.env_mut().insert(name.clone(), v);
             } else {
                 self.env_mut().remove(&name);

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1778,6 +1778,16 @@ impl Interpreter {
                 run_whenever_with_value(supply_val, target_var, &param, body)
             )?;
             self.env_dirty = true;
+            // Slice F (env<->locals coherence): a `my $tap = do whenever $sup {…}`
+            // binds the tap handle by writing `env[target_var]` directly (see
+            // `run_whenever_with_value`), but never updates the caller's local
+            // slot. With the reverse env->locals pull disabled, a later read of
+            // that variable *within the same react block* (e.g.
+            // `isa-ok $tap, Tap`) sees the stale slot (the `do` block's own
+            // result) instead of the bound tap. Reconcile the caller's slots from
+            // env here so the binding is visible immediately. Byte-identical with
+            // the reverse pull enabled.
+            self.reconcile_locals_from_env_at_site(code);
             Ok(())
         } else {
             Err(RuntimeError::new("WheneverScope expects Block body"))

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -82,16 +82,20 @@ pub(crate) fn enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("MUTSU_VM_STATS").is_some())
 }
 
-/// Campaign diagnostic (docs/env-locals-coherence.md, Slice F): when
-/// `MUTSU_NO_REVERSE_SYNC` is set, `sync_locals_from_env` skips its write-back
-/// body so the reverse pull no longer backstops by-name env writes. Used to
-/// verify that a coherence slice has made a given test no longer *depend* on the
-/// reverse pull (the precondition for eventually deleting `env_dirty`). Cached
-/// once; a single bool load when unset (zero release-build cost).
+/// Stage 3 (docs/env-locals-coherence.md §6.8): the reverse `sync_locals_from_env`
+/// pull is **disabled by default**. The Slice F write-through campaign reached an
+/// OFF surface of 0 across all `t/` — every by-name caller-lexical env write is
+/// now reconciled by a precise write-through (`pending_rw_writeback_sources` /
+/// `reconcile_locals_from_env_at_site` / carrier logging), so the blanket reverse
+/// pull is no longer load-bearing for correctness. It is retained only as an
+/// opt-in escape hatch (`MUTSU_REVERSE_SYNC=1`) for A/B diagnosis during the
+/// transition; once CI's full roast confirms no remaining dependence the pull and
+/// its `env_dirty` net will be deleted outright. Cached once; a single bool load
+/// (zero steady-state cost).
 #[inline]
 pub(crate) fn reverse_sync_disabled() -> bool {
     static OFF: OnceLock<bool> = OnceLock::new();
-    *OFF.get_or_init(|| std::env::var_os("MUTSU_NO_REVERSE_SYNC").is_some())
+    *OFF.get_or_init(|| std::env::var_os("MUTSU_REVERSE_SYNC").is_none())
 }
 
 /// Record that an explicit method-call opcode (`.foo(...)`) was executed.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5860,6 +5860,12 @@ impl Interpreter {
             {
                 let proxy_val = self.locals[idx].clone();
                 loan_env!(self, assign_proxy_lvalue(proxy_val, val))?;
+                // Stage 3: a Proxy STORE (e.g. `$r := substr-rw($str, ...); $r = ...`)
+                // mutates the referent caller lexical (`$str`) by name in env via
+                // the interpreter STORE closure. Reconcile the caller's slots so
+                // the write is visible without the reverse `sync_locals_from_env`
+                // pull (byte-identical under ON).
+                self.reconcile_locals_from_env_at_site(code);
                 return Ok(());
             }
             // First write through a missing-key `:=` bind (a local holding a
@@ -6729,6 +6735,10 @@ impl Interpreter {
         {
             let proxy_val = self.locals[idx].clone();
             loan_env!(self, assign_proxy_lvalue(proxy_val, val))?;
+            // Stage 3: a Proxy STORE mutates the referent caller lexical by name
+            // (e.g. substr-rw); reconcile the caller's slots (see the other
+            // Proxy-STORE assign site).
+            self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }
         // First write through a missing-key `:=` bind: materialize the path into
@@ -7074,6 +7084,9 @@ impl Interpreter {
             let val = self.stack.pop().unwrap_or(Value::Nil);
             let proxy_val = self.locals[idx].clone();
             loan_env!(self, assign_proxy_lvalue(proxy_val, val))?;
+            // Stage 3: reconcile the referent caller lexical the Proxy STORE wrote
+            // by name (see the other Proxy-STORE assign site).
+            self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }
 

--- a/t/junction-invocant-autothread-writeback-coherence.t
+++ b/t/junction-invocant-autothread-writeback-coherence.t
@@ -1,0 +1,54 @@
+use Test;
+
+# Slice F (env<->locals coherence): auto-threading a method call over an
+# invocant junction (`$junc.a`) where the threaded user method mutates a
+# captured-outer / `our` variable must propagate *every* eigenstate's mutation
+# to the caller, not just the last one. Each eigenstate call records its own
+# pending writeback; the next call clears it, so an earlier eigenstate writing a
+# different variable than the last would be lost. With the reverse env->locals
+# pull disabled (single-store default), the junction dispatch path must reconcile
+# the caller's local slots from env after threading. Regression:
+# roast/S03-junctions/autothreading.t ('basic auto-threading over invocant').
+
+plan 6;
+
+# Two eigenstates writing the SAME var: accumulates.
+{
+    our $c = 0;
+    class JA1 { method a { $c++ } }
+    my Mu $x = JA1.new | JA1.new;
+    $x.a;
+    is $c, 2, 'same-var accumulation across two eigenstates';
+}
+
+# Eigenstates writing DIFFERENT vars: both preserved (the core regression).
+{
+    our $cnt1 = 0;
+    our $cnt2 = 0;
+    class JB1 { method a { $cnt1++ } }
+    class JB2 { method a { $cnt2++ } }
+    my Mu $x = JB1.new | JB1.new | JB2.new;
+    $x.a;
+    is $cnt1, 2, 'two eigenstates writing $cnt1 preserved';
+    is $cnt2, 1, 'last eigenstate writing $cnt2 preserved';
+}
+
+# Nested junction (junction & junction) over invocant.
+{
+    our $n1 = 0;
+    our $n2 = 0;
+    class JC1 { method a { $n1++ } }
+    class JC2 { method a { $n2++ } }
+    my Mu $x = JC1.new | JC2.new & JC2.new;
+    $x.a;
+    is $n1, 1, 'nested-junction invocant: $n1';
+    is $n2, 2, 'nested-junction invocant: $n2';
+}
+
+# Method call on a literal junction (non-mut receiver path).
+{
+    my $total = 0;
+    class JD { method bump { $total++ } }
+    (JD.new | JD.new | JD.new).bump;
+    is $total, 3, 'literal junction invocant accumulates';
+}

--- a/t/multiframe-sigilless-for-rebind-coherence.t
+++ b/t/multiframe-sigilless-for-rebind-coherence.t
@@ -1,0 +1,72 @@
+use Test;
+
+# Slice F (env<->locals coherence): an inner `for (...) -> $x, \value` that
+# re-binds a sigilless loop variable sharing its name (and local slot) with an
+# enclosing `\value` must not leave the outer binding clobbered after the loop.
+# With the reverse env->locals pull disabled (single-store default), the
+# multi-param restore must write the saved value through to the local slot too,
+# otherwise the next outer iteration re-evaluates the loop's element list with a
+# stale `value`. Regression: roast/S32-str/val.t (661 subtests).
+
+plan 4;
+
+# Minimal: outer `\value` read inside the list expression on each outer pass.
+{
+    my \value = 42;
+    my @got;
+    for 1..2 -> $i {
+        for (
+           "a$i",  value,
+          "b$i", -value,
+        ) -> $string, \value {
+            @got.push("$string=" ~ value);
+        }
+    }
+    is-deeply @got, ["a1=42", "b1=-42", "a2=42", "b2=-42"],
+      "inner sigilless \\value rebind does not clobber outer \\value across outer iterations";
+}
+
+# Via a sub param `\value` (the val.t shape).
+{
+    sub probe(\value, @strings) {
+        my @got;
+        for @strings -> $string {
+            for (
+               "$string",  value,
+              "-$string", -value,
+            ) -> $string, \value {
+                @got.push("$string=" ~ value);
+            }
+        }
+        @got;
+    }
+    is-deeply probe(42, ["42", "4_2"]),
+      ["42=42", "-42=-42", "4_2=42", "-4_2=-42"],
+      "sub param \\value preserved across @strings iterations";
+}
+
+# Closure inside the inner loop reads the correct rebound value.
+{
+    my \value = 7;
+    my @got;
+    for 1..2 -> $i {
+        for ("x", value, "y", value * 10) -> $s, \value {
+            my $c = { value };
+            @got.push($c());
+        }
+    }
+    is-deeply @got, [7, 70, 7, 70], "closure capture reads rebound sigilless value";
+}
+
+# Three outer iterations to ensure it is not a one-shot fix.
+{
+    my \base = 100;
+    my @got;
+    for 1..3 -> $i {
+        for ("p", base + $i, "q", base - $i) -> $s, \base {
+            @got.push(base);
+        }
+    }
+    is-deeply @got, [101, 99, 102, 98, 103, 97],
+      "outer \\base re-read correctly across three iterations";
+}

--- a/t/react-do-whenever-tap-coherence.t
+++ b/t/react-do-whenever-tap-coherence.t
@@ -1,0 +1,21 @@
+use Test;
+
+# Slice F (env<->locals coherence): `my $tap = do whenever $sup {…}` inside a
+# react block binds the tap handle by writing env[target_var] directly (see
+# run_whenever_with_value), without updating the caller's local slot. With the
+# reverse env->locals pull disabled (single-store default), a read of that
+# variable later in the SAME react block saw the stale slot. The whenever scope
+# op must reconcile the caller's slots from env after binding. Regression:
+# roast/S32-io/IO-Socket-Async.t ('listen tap is a Tap').
+
+plan 2;
+
+{
+    my $listen-socket = IO::Socket::Async.listen('0.0.0.0', 0);
+    react {
+        my $listen-tap = do whenever $listen-socket -> $socket { … }
+        ok $listen-tap.defined, "listen tap is defined";
+        isa-ok $listen-tap, Tap, "do-whenever bound tap is visible as a Tap in-block";
+        done;
+    }
+}


### PR DESCRIPTION
## Summary (DRAFT — fix-forward in progress)

Stage 3 of the locals↔env single-store campaign: **disable the reverse `sync_locals_from_env` pull by default**. The Slice F write-through campaign reached an OFF surface of 0 across all `t/` (PRs #3304–#3348), so the blanket reverse pull is no longer load-bearing for correctness. `reverse_sync_disabled()` now defaults to true; the old pull is retained only behind an opt-in `MUTSU_REVERSE_SYNC=1` escape hatch for A/B diagnosis.

- `make test` (all `t/`) **PASS** (985 files / 9622 tests).
- **Known roast-only OFF dependencies remain** — `t/` was not representative of roast's rw-aliasing coverage. This draft PR is up to get CI's full roast failure list; each will be fixed forward on this branch (write-through / shared-cell). Known so far:
  - `S04-statements/gather.t` test 36 — `take-rw` gather element rw-assigned inside `lives-ok { }` closure.
  - `S04-blocks-and-statements/pointy-rw.t` test 8 — `$pair.values` rw alias across a frame.

This PR is **draft** until CI roast is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)