### PR TITLE
ci: make roast failures visible despite parallel run + log truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,51 @@ jobs:
         # Do not oversubscribe past the core count: the S17 scheduler/promise
         # tests assert on real wall-clock scheduling and flake under CPU
         # starvation.
-        run: prove -j4 -e 'scripts/run-roast-test.sh' $(cat roast-whitelist.txt)
+        #
+        # `--state=save` records pass/fail in `.prove` so the failure-summary
+        # step below can re-run only the failures, serially and verbosely.
+        # `--merge` folds each test's stderr into its stdout so a Rust panic or
+        # `expected/got` diagnostic stays attached to its own test under -j
+        # instead of scattering across the interleaved parallel output. The full
+        # output is tee'd to tmp/roast.log and uploaded as an artifact, because
+        # the GitHub web log viewer truncates this long step and hides prove's
+        # end-of-run "Test Summary Report" (the clean failed-files list).
+        run: |
+          set -o pipefail
+          mkdir -p tmp
+          prove -j4 --state=save --merge -e 'scripts/run-roast-test.sh' \
+            $(cat roast-whitelist.txt) 2>&1 | tee tmp/roast.log
         env:
           MUTSU_BIN: target/release/mutsu
+
+      - name: Roast failure summary
+        # Only runs when the roast step failed. Re-runs just the failed files
+        # (from `.prove`) serially and verbosely, so the actionable failure
+        # output is grouped at the end of the job log instead of buried in the
+        # truncated parallel run. A flaky concurrency test that passes here is
+        # itself a useful signal (intermittent, not a hard regression).
+        if: failure()
+        run: |
+          echo "::group::Failed roast files — Test Summary Report"
+          grep -E "Result:|Failed |Test Summary|Dubious|wstat|Files=" tmp/roast.log || true
+          echo "::endgroup::"
+          echo "::group::Failed roast files — serial verbose re-run"
+          prove --state=failed -v --merge -e 'scripts/run-roast-test.sh' || true
+          echo "::endgroup::"
+        env:
+          MUTSU_BIN: target/release/mutsu
+
+      - name: Upload roast log
+        # Always upload the full (untruncated) roast log so a failure can be
+        # diagnosed from the artifact even when the web log viewer truncates the
+        # step. Retained briefly; this is a debugging aid, not a release artifact.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roast-log
+          path: tmp/roast.log
+          retention-days: 7
+          if-no-files-found: ignore
 
   wasm-e2e:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ _tmp-io-colon-invocant-*
 
 target-local/
 .claude/worktrees/
+
+# prove --state=save state file (CI roast failure-summary re-run; ephemeral)
+.prove


### PR DESCRIPTION
## Problem

During the Stage 3 work, diagnosing a failing whitelisted roast test was painful because two things hid the failure:

1. The roast step runs \`prove -j4\`, which **interleaves** the parallel tests' output.
2. The GitHub web log viewer **truncates** this long step, hiding prove's end-of-run **Test Summary Report** (the clean failed-files list).

The only reliable way to find which test failed was a full local \`make roast\` (release) just to read the summary — a ~20 min round trip per failure.

## Changes (additive; pass-path behavior unchanged)

- **\`--state=save\` + \`tee tmp/roast.log\`** — record pass/fail and keep the full output.
- **\`--merge\`** — fold each test's stderr into its stdout so a Rust panic / \`expected/got\` diagnostic stays attached to its own test even under \`-j\`.
- **New \`Roast failure summary\` step** (\`if: failure()\`) — greps the Test Summary from the log, then re-runs **only the failed files** (\`prove --state=failed -v\`) **serially and verbosely**, grouped at the end of the job log. A flaky concurrency test that passes on this re-run is itself a useful signal.
- **New \`Upload roast log\` step** (\`if: always()\`) — uploads \`tmp/roast.log\` as an artifact so the untruncated output is downloadable even when the web viewer truncates.
- \`.prove\` (the \`--state\` file) is gitignored.

## Validation

The \`--state=save\` → \`--state=failed -v\` flow was validated locally with a passing + failing test pair: the re-run re-executes only the failed file, serially and verbose. The \`if: failure()\` steps are inert on a green build; the artifact upload runs and can be confirmed on this PR's green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)