### PR TITLE
docs: cross-link ANALYSIS §1.2 and fallback-ledger to the live single-store design

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -68,6 +68,9 @@ per-slot 書き戻しは `flush_local_to_env` (`vm/vm_env_helpers.rs`) が `code
 これは「設計された register モデル」ではなく「同じデータを 2 箇所に持つのを糊付けしている」症状で、
 単一権威ストアにすれば丸ごと消える。CP-3 で `Interpreter` への統合は済んだので、次の論理ステップは
 この二重ストアの一本化である。書き込み集中点 `vm_var_assign_ops.rs` が最大肥大ファイル (§6) なのも同根。
+この一本化は現在「Slice F」キャンペーンとして進行中 — 設計は
+[docs/vm-single-store.md](docs/vm-single-store.md)、収束点の前提となる env↔locals コヒーレンスは
+[docs/env-locals-coherence.md](docs/env-locals-coherence.md) を参照（[docs/vm-dual-store.md](docs/vm-dual-store.md) は撤回試行の履歴）。
 
 ### 1.3 クロージャが env ベース (upvalue 不在)
 

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -3,7 +3,9 @@
 最終ゴール「tree-walking Interpreter 実行パスの撤去 → dual-store 削除」（[PLAN.md](../PLAN.md) ①〜⑤）の
 **進捗台帳**。VM (`src/vm/`) が今も Interpreter (`src/runtime/`) に委譲しているサイトを 1 箇所ずつ列挙し、
 撲滅のたびに行を消す。関連: [vm-interpreter-dedup.md](vm-interpreter-dedup.md)（重複削除）、
-[vm-dual-store.md](vm-dual-store.md)（locals↔env）、[vm-decoupling.md](vm-decoupling.md)（dispatch）。
+[vm-single-store.md](vm-single-store.md)（locals↔env 一本化の**現行設計** = Slice F）、
+[vm-dual-store.md](vm-dual-store.md)（同・撤回試行の履歴）、[vm-decoupling.md](vm-decoupling.md)（dispatch）。
+個々のフォールバック撲滅は今や Slice F（単一ストア収束）の前段ステップとして理解する。
 
 ## 用語
 


### PR DESCRIPTION
## Summary

Follow-up to the docs staleness audit (#3355). On closer reading, the "deeper" content updates I'd flagged turned out to be **unnecessary** — the docs were more accurate than a sampled audit suggested:

- `ANALYSIS.md` §1.2 already frames the `locals`↔`env` dual store as collapsible and names single-store unification as the next step (it does **not** claim the dual store is permanent).
- `docs/container-identity.md` already records Phase 2 as landed (#2922/#2925, nested.t 43/43; `is rw` #2928, scalars.t 33/33) — no change needed.
- `docs/vm-interpreter-fallback-ledger.md` self-maintains by deleting rows as fallbacks are eliminated.

The one genuine gap was that these docs didn't link to **where** the `locals`↔`env` unification is now actually being designed (the "Slice F" campaign). This adds those cross-links so readers land on `vm-single-store.md` / `env-locals-coherence.md`.

Two-line, docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)