### PR TITLE
feat(proto): run `proto method` bodies and dispatch `{*}` to multi candidates

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -159,9 +159,11 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 
 目標: **mutsu でウェブブログシステムが構築できる**。現状 **0% 稼働**。
 
-- [ ] **★grammar action dispatch（最大ブロッカー）**: proto regex in alternation の action 呼び出しが不正。
-      Template::Mustache だけでなく grammar 重用モジュール全般に波及。`.meta` 等を修正。
-- [ ] **Template::Mustache**（上記が前提）。
+- [~] **Template::Mustache** — 基本レンダリングは**動作**（`render('Hello {{name}}!', {name=>'World'})`→OK・セクション/
+      イテレーションも描画。旧記載「grammar action dispatch が最大ブロッカー」は陳腐化＝proto regex の action は基本動作）。
+      `proto method` 本体実行は landed（#3358）。残ギャップ: ① `handles` 委譲経由の proto method（ログフィルタ・stderr のみ・
+      非致命）、② デリミタ変更 `{{=..=}}`（`$*LEFT/$*RIGHT` 動的変数の finalizer 再代入が次パースに伝播しない）。
+      詳細＝メモリ `project-template-mustache-status`。ハーネス＝`tmp/mustache/`。
 - [ ] **HTTP::Server::Tiny** の依存（HTTP::Parser / IO::Blob / HTTP::Status）→ 本体。
 - [ ] DB アクセス — pure Raku 簡易実装 or qqx ベースの SQLite wrapper（NativeCall 不可）。
 - [ ] File::Temp / MIME::Base64 (pure Raku) / File::Directory::Tree。

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -844,6 +844,11 @@ pub(crate) enum Stmt {
         body: Vec<Stmt>,
         is_export: bool,
         custom_traits: Vec<String>,
+        /// True when declared as `proto method`/`proto submethod` (inside a
+        /// class/role body). Such a proto registers a method-level proto body
+        /// whose `{*}` dispatches to the matching multi method candidate,
+        /// rather than a package-level proto sub.
+        is_method: bool,
     },
     Let {
         name: String,

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -2088,6 +2088,7 @@ pub(super) fn proto_decl(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws1(rest)?;
     // proto token | proto rule | proto sub | proto method
     let _is_token = keyword("token", rest).is_some() || keyword("rule", rest).is_some();
+    let is_method = keyword("method", rest).is_some() || keyword("submethod", rest).is_some();
     let rest = if let Some(r) = keyword("token", rest)
         .or_else(|| keyword("rule", rest))
         .or_else(|| keyword("sub", rest))
@@ -2137,6 +2138,7 @@ pub(super) fn proto_decl(input: &str) -> PResult<'_, Stmt> {
                     .iter()
                     .map(|(n, _)| n.clone())
                     .collect(),
+                is_method,
             },
         ));
     }
@@ -2154,6 +2156,7 @@ pub(super) fn proto_decl(input: &str) -> PResult<'_, Stmt> {
                 .iter()
                 .map(|(n, _)| n.clone())
                 .collect(),
+            is_method,
         },
     ))
 }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1357,7 +1357,7 @@ impl Interpreter {
             is_block: false,
         });
         self.proto_dispatch_stack
-            .push((proto_name.to_string(), args.to_vec()));
+            .push((proto_name.to_string(), args.to_vec(), None));
         let result = if def.body.is_empty() {
             // Bodyless proto behaves as implicit {*} dispatch.
             self.call_proto_dispatch()
@@ -1377,12 +1377,125 @@ impl Interpreter {
         }
     }
 
+    /// Look up a `proto method` body for `method_name` in `class_name`'s MRO.
+    /// Returns the nearest (owner_class, proto `FunctionDef`). Cheap no-op when
+    /// no proto methods are declared anywhere.
+    pub(crate) fn lookup_proto_method(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<(String, FunctionDef)> {
+        if self.registry().proto_methods.is_empty() {
+            return None;
+        }
+        let mro = self.class_mro(class_name);
+        for cn in mro {
+            if let Some(f) = self
+                .registry()
+                .proto_methods
+                .get(&(cn.clone(), method_name.to_string()))
+            {
+                return Some((cn, f.clone()));
+            }
+        }
+        None
+    }
+
+    /// Run a `proto method` body, with `{*}` dispatching to the matching multi
+    /// candidate on `invocant`. Reuses the normal resolved-method runner so the
+    /// proto body gets `self`, attributes, and parameter binding like any method.
+    pub(crate) fn run_proto_method(
+        &mut self,
+        invocant: Value,
+        receiver_class: &str,
+        owner_class: &str,
+        method_name: &str,
+        args: Vec<Value>,
+        proto: FunctionDef,
+    ) -> Result<Value, RuntimeError> {
+        let rewritten = Self::rewrite_proto_dispatch_stmts(&proto.body);
+        let method_def = MethodDef {
+            params: proto.params.clone(),
+            param_defs: proto.param_defs.clone(),
+            body: std::sync::Arc::new(rewritten),
+            is_rw: false,
+            is_private: false,
+            is_multi: false,
+            is_my: false,
+            role_origin: None,
+            original_role: None,
+            return_type: None,
+            compiled_code: None,
+            delegation: None,
+            is_default: false,
+            deprecated_message: None,
+            is_submethod: false,
+        };
+        let attributes = match &invocant {
+            Value::Instance { attributes, .. } => attributes.as_map().clone(),
+            _ => std::collections::HashMap::new(),
+        };
+        self.proto_dispatch_stack.push((
+            method_name.to_string(),
+            args.clone(),
+            Some(ProtoMethodCtx {
+                invocant: invocant.clone(),
+            }),
+        ));
+        let result = self.run_instance_method_resolved(
+            receiver_class,
+            owner_class,
+            method_def,
+            attributes,
+            args,
+            Some(invocant),
+        );
+        self.proto_dispatch_stack.pop();
+        result.map(|(v, _)| v)
+    }
+
+    /// Proto-method-body interception shared by all method-call op handlers and
+    /// `call_method_with_values`. If `target`'s class (or an ancestor) declares a
+    /// `proto method`/`proto submethod` body for `method`, run that body (its
+    /// `{*}` dispatches to the matching multi candidate) and return `Some(result)`.
+    /// Returns `None` when the caller should dispatch normally — including the
+    /// one-shot redispatch case, where the `proto_method_skip` flag is consumed.
+    ///
+    /// TODO: methods reached via `handles` delegation forwarders run through
+    /// `assign_method_lvalue_with_values` rather than the method-call op handlers
+    /// or `call_method_with_values`, so a delegated proto method's body is not yet
+    /// intercepted here. Cover that path when delegation dispatch is unified.
+    pub(crate) fn try_proto_method_body(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let cn = match target {
+            Value::Instance { class_name, .. } => class_name.resolve(),
+            _ => return None,
+        };
+        if self.proto_method_skip.as_deref() == Some(method) {
+            self.proto_method_skip = None;
+            return None;
+        }
+        let (owner, proto) = self.lookup_proto_method(&cn, method)?;
+        Some(self.run_proto_method(target.clone(), &cn, &owner, method, args.to_vec(), proto))
+    }
+
     pub(super) fn call_proto_dispatch(&mut self) -> Result<Value, RuntimeError> {
-        let (proto_name, args) = self
+        let (proto_name, args, method_ctx) = self
             .proto_dispatch_stack
             .last()
             .cloned()
             .ok_or_else(|| RuntimeError::new("{*} used outside proto".to_string()))?;
+        // `proto method` body: `{*}` redispatches to the matching multi *method*
+        // candidate on the invocant. The one-shot `proto_method_skip` flag makes
+        // the re-entry bypass proto interception so it reaches the real candidate.
+        if let Some(ctx) = method_ctx {
+            self.proto_method_skip = Some(proto_name.clone());
+            return self.call_method_with_values(ctx.invocant, &proto_name, args);
+        }
         self.clear_pending_dispatch_error();
         let Some(def) = self.resolve_proto_candidate_with_types(&proto_name, &args) else {
             if let Some(err) = self.take_pending_dispatch_error() {

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -378,6 +378,10 @@ impl Interpreter {
             }
             return self.call_method_with_values(*inner, method, args);
         }
+        // `proto method` body dispatch (see try_proto_method_body).
+        if let Some(result) = self.try_proto_method_body(&target, method, &args) {
+            return result;
+        }
         // Operations that need the full (finite) list cannot run on a lazy or
         // infinite source: throw X::Cannot::Lazy instead of hanging while
         // materializing it, matching raku.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -395,6 +395,12 @@ pub(crate) struct MethodDef {
     pub(crate) is_submethod: bool,
 }
 
+/// Invocant context for an active `proto method` `{*}` dispatch.
+#[derive(Debug, Clone)]
+pub(crate) struct ProtoMethodCtx {
+    pub(crate) invocant: Value,
+}
+
 #[derive(Debug, Clone)]
 struct MethodDispatchFrame {
     receiver_class: String,
@@ -906,7 +912,16 @@ pub struct Interpreter {
     /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
     registry: Arc<RwLock<Registry>>,
-    proto_dispatch_stack: Vec<(String, Vec<Value>)>,
+    /// Active `{*}` proto dispatch frames: (proto_name, args, method_ctx).
+    /// `method_ctx` is `Some` when the active proto is a `proto method` body, so
+    /// `{*}` redispatches to a multi *method* candidate on the invocant rather
+    /// than a proto sub candidate.
+    proto_dispatch_stack: Vec<(String, Vec<Value>, Option<ProtoMethodCtx>)>,
+    /// One-shot guard set by a proto method's `{*}` redispatch: the next method
+    /// call of this name bypasses proto-body interception (so it reaches the
+    /// real multi candidate). Recursive calls from within the candidate, which
+    /// happen after this flag is consumed, run the proto body again (matching raku).
+    pub(crate) proto_method_skip: Option<String>,
     pending_dispatch_error: Option<RuntimeError>,
     end_phasers: Vec<(Vec<Stmt>, Env)>,
     /// Tracks END phaser site_ids to ensure each is registered only once.
@@ -3274,6 +3289,7 @@ impl Interpreter {
                 Arc::new(RwLock::new(registry))
             },
             proto_dispatch_stack: Vec::new(),
+            proto_method_skip: None,
             pending_dispatch_error: None,
             end_phasers: Vec::new(),
             end_phaser_sites: HashSet::new(),
@@ -5822,6 +5838,7 @@ impl Interpreter {
             // child sees parent declarations but its own new ones don't leak back).
             registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
             proto_dispatch_stack: Vec::new(),
+            proto_method_skip: None,
             pending_dispatch_error: None,
             end_phasers: Vec::new(),
             end_phaser_sites: HashSet::new(),

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2323,6 +2323,38 @@ impl Interpreter {
                         class_def = updated;
                     }
                 }
+                Stmt::ProtoDecl {
+                    name: proto_name,
+                    param_defs,
+                    body: proto_body,
+                    is_method: true,
+                    ..
+                } => {
+                    let method_name = proto_name.resolve();
+                    let effective_param_defs = Self::effective_method_param_defs(param_defs, false);
+                    let effective_params: Vec<String> = effective_param_defs
+                        .iter()
+                        .map(|p| p.name.clone())
+                        .collect();
+                    let fdef = FunctionDef {
+                        package: Symbol::intern(name),
+                        name: *proto_name,
+                        params: effective_params,
+                        param_defs: effective_param_defs,
+                        body: proto_body.clone(),
+                        is_test_assertion: false,
+                        is_rw: false,
+                        is_raw: false,
+                        is_method: true,
+                        empty_sig: false,
+                        return_type: None,
+                        is_default: false,
+                        deprecated_message: None,
+                    };
+                    self.registry_mut()
+                        .proto_methods
+                        .insert((name.to_string(), method_name), fdef);
+                }
                 _ => {
                     // BEGIN phasers and EVAL calls in class bodies may fail
                     // (e.g. `BEGIN EVAL q[has $.x]` or `EVAL q[has $.x]`).

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -122,6 +122,11 @@ pub(crate) struct Registry {
     pub(crate) proto_subs: HashSet<String>,
     /// `proto token`/`proto rule` declaration markers (existence set).
     pub(crate) proto_tokens: HashSet<String>,
+    /// `proto method`/`proto submethod` bodies: (class_name, method_name) ->
+    /// proto `FunctionDef`. When a multi method is dispatched and its class (or
+    /// an ancestor in the MRO) has a proto body here, the body runs first and
+    /// its `{*}` dispatches to the matching multi candidate.
+    pub(crate) proto_methods: HashMap<(String, String), FunctionDef>,
 }
 
 /// Structural lookups over the declaration registry (PR-B: read-side migration).

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -397,6 +397,12 @@ impl Interpreter {
         } else {
             target
         };
+        // `proto method` body dispatch (see try_proto_method_body).
+        if let Some(result) = self.try_proto_method_body(&target, &method, &args) {
+            let v = result?;
+            self.stack.push(v);
+            return Ok(());
+        }
         // gist/Str/raku/perl of a genuinely-lazy list renders raku's placeholder
         // (`[...]` in `@` array context, `(...)` for a bare Seq, `...` for Str)
         // rather than forcing the (possibly infinite) sequence. Must run before

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -241,6 +241,12 @@ impl Interpreter {
         } else {
             target
         };
+        // `proto method` body dispatch (see try_proto_method_body).
+        if let Some(result) = self.try_proto_method_body(&target, method, &args) {
+            let v = result?;
+            self.stack.push(v);
+            return Ok(());
+        }
         // .return method: triggers a return from the enclosing sub with the invocant
         // as the return value. Does NOT auto-thread over junctions.
         if method == "return" && args.is_empty() {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -650,6 +650,7 @@ impl Interpreter {
             body,
             is_export,
             custom_traits,
+            ..
         } = stmt
         {
             let name_str = name.resolve();

--- a/t/proto-method-body.t
+++ b/t/proto-method-body.t
@@ -1,0 +1,64 @@
+use Test;
+
+# A `proto method` with a real body must run that body, and `{*}` inside it
+# must dispatch to the matching multi candidate. (Bodyless `proto method m {*}`
+# already works; this covers the body-with-statements case.)
+
+plan 6;
+
+# 1. Proto body runs before {*} and can guard dispatch with `return`.
+{
+    my @log;
+    class C {
+        has $.threshold = 5;
+        proto method note(Int $level, |) {
+            return 'suppressed' if $level < $.threshold;
+            {*}
+        }
+        multi method note(Int $level, Str $msg) { "[{$level}] $msg" }
+    }
+    my $c = C.new;
+    is $c.note(7, 'hi'), '[7] hi', 'proto body passes through to multi when guard ok';
+    is $c.note(2, 'lo'), 'suppressed', 'proto body can short-circuit before {*}';
+}
+
+# 2. Proto body can compute and the multi sees the original args.
+{
+    class D {
+        proto method f(|) {
+            # side effect in proto body, then dispatch
+            {*}
+        }
+        multi method f(Int $x) { "int:$x" }
+        multi method f(Str $x) { "str:$x" }
+    }
+    my $d = D.new;
+    is $d.f(3), 'int:3', 'multi dispatch by Int through proto body';
+    is $d.f('x'), 'str:x', 'multi dispatch by Str through proto body';
+}
+
+# 3. Proto body with a leading statement before {*}.
+{
+    class E {
+        proto method g(|) {
+            my $prefix = 'g=';
+            $prefix ~ ({*});
+        }
+        multi method g(Int $x) { "$x" }
+    }
+    is E.new.g(9), 'g=9', 'proto body return value wraps {*} result';
+}
+
+# 4. Inherited proto method body applies to subclass multis.
+{
+    class Base {
+        proto method h(Int $n, |) {
+            return 0 if $n < 0;
+            {*}
+        }
+    }
+    class Sub is Base {
+        multi method h(Int $n) { $n * 2 }
+    }
+    is Sub.new.h(-1), 0, 'inherited proto body guards subclass multi';
+}


### PR DESCRIPTION
## Summary

A `proto method`/`proto submethod` with a real body was silently dropped during class registration — it fell through to proto-**sub** registration, so a method call dispatched straight to the multi candidates and never ran the proto body. Bodyless `proto method m {*}` worked only because normal multi dispatch already selects a candidate; a body with statements (a `return`/guard before `{*}`, or code wrapping the `{*}` result) was lost.

This wires proto method bodies end to end:

- **Parser/AST**: `Stmt::ProtoDecl` carries `is_method`, set for `proto method`/`proto submethod`.
- **Registration**: `register_class_decl` stores the proto body in a new registry map `proto_methods: (class, method) -> FunctionDef`.
- **Dispatch**: a shared `try_proto_method_body` intercepts instance method calls (in the `CallMethod`/`CallMethodMut` op handlers and `call_method_with_values`). When the receiver's MRO declares a proto body, it runs via the normal resolved-method runner (so the body gets `self`, attributes, params) with `{*}` rewritten. `{*}` redispatches to the matching multi candidate, guarded by a one-shot `proto_method_skip` flag so the redispatch reaches the real candidate while recursive calls re-run the proto (matching raku).

Motivation: a step toward Template::Mustache compatibility (PLAN.md §E web-blog stack) — its `Logger` uses a `proto method log` whose body filters by log level.

## Known gap

Methods reached via `handles` delegation forwarders run through a different invoke path (`assign_method_lvalue_with_values`) and are **not yet** intercepted (TODO in code). Inherited proto bodies on subclass multis **are** covered.

## Test

- New `t/proto-method-body.t` (6 cases: short-circuit guard, by-type dispatch, `{*}`-result wrapping, inheritance).
- `make test` green (989 files / 9640 tests).
- Whitelisted S06 proto tests still pass: `dispatching.t`, `syntax.t`, `callsame.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)