### PR TITLE
fix(self): restore caller's env `self` across stringify, dynamic-call, and grammar-action dispatch

### DIFF
--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -268,7 +268,22 @@ impl Interpreter {
 
             // Invoke action methods if :actions was provided
             let match_obj = if let Some(ref mut actions) = actions_obj {
-                let result = self.invoke_grammar_actions(match_obj, actions, &start_rule)?;
+                // Action methods run with `self` bound to the actions object.
+                // Restore the caller's `self` afterwards so a nested sub in the
+                // caller (which resolves `self` from env via `GetSelfOrNoSelf`)
+                // doesn't see the actions object leaked in. (Same hazard the
+                // stringify path fixes for `try_compiled_method_or_interpret`.)
+                let saved_self = self.env.get("self").cloned();
+                let result = self.invoke_grammar_actions(match_obj, actions, &start_rule);
+                match saved_self {
+                    Some(s) => {
+                        self.env.insert("self".to_string(), s);
+                    }
+                    None => {
+                        self.env.remove("self");
+                    }
+                }
+                let result = result?;
                 // Update the actions attribute on the final Match to reflect
                 // any mutations that occurred during action method dispatch.
                 if let Value::Instance {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -89,7 +89,31 @@ impl Interpreter {
     }
 
     /// Try compiled method fast path; fall back to interpreter.
+    ///
+    /// Wrapper that preserves the caller's env `self`: the inner dispatch can run
+    /// an interpreted instance method, which binds `self` in env without the
+    /// save/restore that `call_method_with_values` performs. Without this, a bare
+    /// stringification (`"$obj"` → `StringConcat` → this) leaves the caller's
+    /// `self` pointing at `$obj`, breaking a later `self` read in an enclosing
+    /// nested sub (which resolves `self` from env via `GetSelfOrNoSelf`).
     pub(super) fn try_compiled_method_or_interpret(
+        &mut self,
+        target: Value,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let saved_self = self.get_env_with_main_alias("self");
+        let result = self.try_compiled_method_or_interpret_inner(target, method, args);
+        match saved_self {
+            Some(s) => self.set_env_with_main_alias("self", s),
+            None => {
+                self.env_mut().remove("self");
+            }
+        }
+        result
+    }
+
+    fn try_compiled_method_or_interpret_inner(
         &mut self,
         target: Value,
         method: &str,

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -295,6 +295,12 @@ impl Interpreter {
             }
             _ => {}
         }
+        // Preserve the caller's env `self` across the dispatch: a dynamic method
+        // call (`$obj."$name"()`) binds `self` to `$obj` for the callee, and the
+        // mut dispatch path does not restore it. Without this, a later `self` read
+        // in an enclosing nested sub (resolved from env via `GetSelfOrNoSelf`)
+        // would see `$obj` leaked in. See try_compiled_method_or_interpret.
+        let saved_self = self.get_env_with_main_alias("self");
         let call_result = if matches!(
             &name_val,
             Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
@@ -302,11 +308,18 @@ impl Interpreter {
             let mut call_args = Vec::with_capacity(args.len() + 1);
             call_args.push(target);
             call_args.extend(args);
-            self.vm_call_on_value(name_val, call_args, None)?
+            self.vm_call_on_value(name_val, call_args, None)
         } else {
             // TODO: compile to bytecode — generic mut method fork (ledger §1).
-            self.vm_call_method_mut_with_values(&target_name, target, &method, args)?
+            self.vm_call_method_mut_with_values(&target_name, target, &method, args)
         };
+        match saved_self {
+            Some(s) => self.set_env_with_main_alias("self", s),
+            None => {
+                self.env_mut().remove("self");
+            }
+        }
+        let call_result = call_result?;
         self.stack.push(call_result);
         self.env_dirty = true;
         Ok(())

--- a/t/self-in-nested-sub-coherence.t
+++ b/t/self-in-nested-sub-coherence.t
@@ -1,0 +1,79 @@
+use Test;
+
+# `self` inside a nested sub is resolved from the dynamic env. A method/action
+# call on ANOTHER object binds `self` to that object; if the dispatch path does
+# not restore the caller's `self`, a later `self` read in the enclosing nested
+# sub sees the wrong invocant. These cover the dispatch paths that used to leak.
+
+plan 4;
+
+# 1. String interpolation of an object (StringConcat -> Str) must not leak self.
+{
+    class OtherS { method Str() { "O" } }
+    class Ca {
+        method who() { "C" }
+        method run($obj) {
+            sub probe() { self.who() }
+            my $a = probe();
+            my $junk = "$obj";        # stringify Other via .Str
+            my $b = probe();          # self must still be C
+            "$a$b";
+        }
+    }
+    is Ca.new.run(OtherS.new), "CC", 'string interpolation does not leak self';
+}
+
+# 2. Dynamic method call (`$obj."$name"()`) must not leak self.
+{
+    class OtherN { method name() { "n" } }
+    class Cb {
+        method who() { "C" }
+        method run($obj) {
+            sub probe() { self.who() }
+            my $a = probe();
+            my $meth = "name";
+            my $junk = $obj."$meth"();   # dynamic dispatch on Other
+            my $b = probe();             # self must still be C
+            "$a$b";
+        }
+    }
+    is Cb.new.run(OtherN.new), "CC", 'dynamic method call does not leak self';
+}
+
+# 3. Grammar action dispatch (Grammar.parse :actions) must not leak self.
+{
+    grammar G { token TOP { \w+ } }
+    class Acts { method TOP($/) { make ~$/ } }
+    class Cc {
+        method who() { "C" }
+        method run() {
+            sub probe() { self.who() }
+            my $a = probe();
+            G.parse("hello", :actions(Acts.new));
+            my $b = probe();             # self must still be C, not Acts
+            "$a$b";
+        }
+    }
+    is Cc.new.run(), "CC", 'grammar action dispatch does not leak self';
+}
+
+# 4. Combination: dotted-name + object stringification (Template::Mustache shape).
+{
+    class Obj { method Str() { "father" }; method label() { "L" } }
+    class Host {
+        method tag() { "T" }
+        method render(%ctx) {
+            sub emit($key) {
+                # read self, call a method on a context object, read self again
+                my $before = self.tag();
+                my $v = %ctx{$key};
+                my $s = "$v";              # stringify the object
+                my $after = self.tag();
+                "$before/$s/$after";
+            }
+            emit("o");
+        }
+    }
+    is Host.new.render({ o => Obj.new }), "T/father/T",
+        'self stable across object stringify in nested sub';
+}


### PR DESCRIPTION
## Summary

`self` inside a nested `sub` is resolved from the dynamic env (`GetSelfOrNoSelf` reads `env["self"]`), not captured lexically. Several method-dispatch paths bind `self` to a callee invocant for the duration of the call but **do not restore the caller's `self`** afterwards — so a later `self` read in an enclosing nested sub saw the wrong invocant.

Three leaking paths fixed:

1. **`try_compiled_method_or_interpret`** — used by string interpolation (`"$obj"` → `StringConcat`) and `~`/coercion. Runs a user method without the env-`self` save/restore that `call_method_with_values` performs. Wrapped to snapshot/restore `self`.
2. **dynamic method call `$obj."$name"()`** on a variable receiver (`exec_call_method_dynamic_mut_op` → `vm_call_method_mut_with_values`) — snapshot/restore added around the dispatch.
3. **grammar action dispatch** (`Grammar.parse(:actions)`) — action methods run with `self` = the actions object; the caller's `self` is now restored after the parse.

## Motivation

Template::Mustache `t/10-objects` (PLAN.md §H web-blog stack): rendering `{{object}}` where the context holds a user object threw `No such method 'log' for invocant of type 'TestObj'`, because `self` in the deeply-nested `format`/`get`/`visit` subs had leaked first to the grammar actions object and then to the rendered object. With these fixes that test passes.

## Known follow-up

The underlying fragility — nested subs read `self` dynamically from env rather than capturing it lexically — remains. The proper general fix is lexical `self` capture; these three cover the common dispatch paths that bite real modules.

## Test

- New `t/self-in-nested-sub-coherence.t` (4 cases: interpolation, dynamic call, grammar action, combined) — passes on both `raku` and mutsu.
- `make test` green (990 files / 9644 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)