### PR TITLE
fix(array): push/pop/shift/unshift through a shared backing array mutate in place

### DIFF
--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2924,13 +2924,29 @@ impl Interpreter {
                     // Check element type constraints from container metadata
                     self.check_array_value_element_types(&target, &normalized_args)?;
                     if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key) {
-                        let items = Arc::make_mut(arc_items);
-                        if method == "append" {
-                            items.extend(flatten_append_args(normalized_args));
+                        let kind = *kind;
+                        let vals = if method == "append" {
+                            flatten_append_args(normalized_args)
                         } else {
-                            items.extend(normalized_args);
+                            normalized_args
+                        };
+                        if Arc::strong_count(arc_items) > 1 {
+                            // Shared backing array: mutate the interior in place so
+                            // every alias observes the push. `Arc::make_mut` would
+                            // detach a private copy and lose the write for those
+                            // aliases — the bug behind `$t.push` inside a `for`/`when`
+                            // body where `$t` is a by-ref param: entering the block
+                            // flushes a shared clone of `$t` into env, and a
+                            // make_mut here would write only that env copy, leaving
+                            // the caller's binding stale. SAFETY: same contract as
+                            // `array_push_in_place` — no live borrow into the items,
+                            // and we do not re-enter the VM while the borrow is held.
+                            let data = unsafe { crate::value::arc_contents_mut(arc_items) };
+                            data.items.extend(vals);
+                        } else {
+                            Arc::make_mut(arc_items).extend(vals);
                         }
-                        return Ok(Value::Array(Arc::clone(arc_items), *kind));
+                        return Ok(Value::Array(Arc::clone(arc_items), kind));
                     }
                     // Interior mutation: if the target Array has shared references
                     // (Arc refcount > 1), mutate in-place so all references see the
@@ -2975,7 +2991,13 @@ impl Interpreter {
                         return Err(RuntimeError::cannot_lazy("pop"));
                     }
                     if let Some(Value::Array(arc_items, _)) = self.env.get_mut(&key) {
-                        let items = Arc::make_mut(arc_items);
+                        // Shared backing array: in-place interior mutation (see `push`).
+                        let items = if Arc::strong_count(arc_items) > 1 {
+                            // SAFETY: same contract as `array_push_in_place`.
+                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                        } else {
+                            Arc::make_mut(arc_items)
+                        };
                         let out = if items.is_empty() {
                             make_empty_array_failure_what("pop", &empty_what)
                         } else {
@@ -3001,11 +3023,20 @@ impl Interpreter {
                 "unshift" => {
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key) {
-                        let items = Arc::make_mut(arc_items);
+                        let kind = *kind;
+                        // Shared backing array: mutate the interior in place so
+                        // every alias (a by-ref param, a captured-outer slot)
+                        // observes the change. See the `push` branch above.
+                        let items = if Arc::strong_count(arc_items) > 1 {
+                            // SAFETY: same contract as `array_push_in_place`.
+                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                        } else {
+                            Arc::make_mut(arc_items)
+                        };
                         for (i, arg) in normalized_args.iter().enumerate() {
                             items.insert(i, arg.clone());
                         }
-                        return Ok(Value::Array(Arc::clone(arc_items), *kind));
+                        return Ok(Value::Array(Arc::clone(arc_items), kind));
                     }
                     let mut items = match &target {
                         Value::Array(v, ..) => v.to_vec(),
@@ -3022,11 +3053,18 @@ impl Interpreter {
                 "prepend" => {
                     let flat_values = flatten_append_args(args);
                     if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key) {
-                        let items = Arc::make_mut(arc_items);
+                        let kind = *kind;
+                        // Shared backing array: in-place interior mutation (see `push`).
+                        let items = if Arc::strong_count(arc_items) > 1 {
+                            // SAFETY: same contract as `array_push_in_place`.
+                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                        } else {
+                            Arc::make_mut(arc_items)
+                        };
                         for (i, arg) in flat_values.iter().enumerate() {
                             items.insert(i, arg.clone());
                         }
-                        return Ok(Value::Array(Arc::clone(arc_items), *kind));
+                        return Ok(Value::Array(Arc::clone(arc_items), kind));
                     }
                     let items = match &target {
                         Value::Array(v, ..) => v.to_vec(),
@@ -3052,7 +3090,13 @@ impl Interpreter {
                         )));
                     }
                     if let Some(Value::Array(arc_items, _)) = self.env.get_mut(&key) {
-                        let items = Arc::make_mut(arc_items);
+                        // Shared backing array: in-place interior mutation (see `push`).
+                        let items = if Arc::strong_count(arc_items) > 1 {
+                            // SAFETY: same contract as `array_push_in_place`.
+                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                        } else {
+                            Arc::make_mut(arc_items)
+                        };
                         let out = if items.is_empty() {
                             make_empty_array_failure_what("shift", &empty_what)
                         } else {

--- a/t/array-push-byref-coherence.t
+++ b/t/array-push-byref-coherence.t
@@ -1,0 +1,115 @@
+use Test;
+
+# A `$`-scalar variable holding a real array, passed by reference to a sub and
+# mutated via `.push`/`.append`/`.unshift` *inside a `for`/`when` block body*,
+# must write through the shared array so the caller's binding observes it.
+#
+# Regression: entering a `for`/`when` body flushes a shared clone of the by-ref
+# param into env; the slow-path push used `Arc::make_mut` on that env copy, which
+# detached a private copy and lost the write for the caller (and any other alias).
+# Element assignment (`$t[0] = ...`) already mutated the shared interior in place,
+# so only `.push`-family methods were affected.  (Template::Mustache's `push-to`
+# helper hit this: `sub push-to ($t, $_) { when .defined { $t.push: $_ } }`.)
+
+plan 16;
+
+# --- baseline: by-ref push without a block already worked ---
+sub push-plain($t, $x) { $t.push: $x }
+my $a = [5];
+push-plain($a, 9);
+is-deeply $a, [5, 9], 'by-ref push in a plain sub body';
+
+# --- the regression: push inside a for-body ---
+sub push-for($t, $x) { for 1 { $t.push: $x } }
+my $b = [5];
+push-for($b, 9);
+is-deeply $b, [5, 9], 'by-ref push inside a for-block body';
+
+# --- push inside a when-body (statement-level when, topic = the param) ---
+sub push-when($t, $_) { when .defined { $t.push: $_ } }
+my $c = [];
+push-when($c, 'one');
+push-when($c, Any);     # undefined -> no branch -> no push
+push-when($c, 'two');
+is-deeply $c, ['one', 'two'], 'by-ref push inside a when-block body, twice';
+
+# --- append / unshift inside a for-body ---
+sub append-for($t, @xs) { for 1 { $t.append: @xs } }
+my $d = [1];
+append-for($d, [2, 3]);
+is-deeply $d, [1, 2, 3], 'by-ref append inside a for-block body';
+
+sub unshift-for($t, $x) { for 1 { $t.unshift: $x } }
+my $e = [2];
+unshift-for($e, 1);
+is-deeply $e, [1, 2], 'by-ref unshift inside a for-block body';
+
+# --- element-assign and push interleaved in the same for-body both survive ---
+sub mix($t) { for 1 { $t[1] = 7; $t.push: 99 } }
+my $f = [5];
+mix($f);
+is-deeply $f, [5, 7, 99], 'element-assign and push in one for-body both persist';
+
+# --- given/when also propagates ---
+sub push-given($t, $x) { given $x { when .defined { $t.push: $_ } } }
+my $g = [1];
+push-given($g, 2);
+is-deeply $g, [1, 2], 'by-ref push inside a given/when body';
+
+# --- nested block (for inside if) ---
+sub push-nested($t, $x) { if $x { for 1 { $t.push: $x } } }
+my $h = [1];
+push-nested($h, 2);
+is-deeply $h, [1, 2], 'by-ref push inside a for nested in an if';
+
+# --- multiple pushes accumulate across separate for-body sub calls ---
+sub acc($t, $x) { for 1 { $t.push: $x } }
+my $i = [];
+acc($i, 'a');
+acc($i, 'b');
+acc($i, 'c');
+is-deeply $i, ['a', 'b', 'c'], 'repeated by-ref push-in-for accumulates';
+
+# --- a `$`-scalar array directly captured by a for-body at top level ---
+my $j = [];
+for 1, 2, 3 { $j.push: $_ }
+is-deeply $j, [1, 2, 3], 'top-level for-body push on a $-scalar array';
+
+# --- the `when`-fallthrough helper shape from Template::Mustache ---
+my $froms = [];
+sub push-to ($target, $_) {
+    when Positional { $target.push: |$_ }
+    when .defined   { $target.push:  $_ }
+}
+push-to $froms, Any;          # no branch
+push-to $froms, 'views';      # .defined branch
+push-to $froms, ['a', 'b'];   # Positional branch -> flattened push
+is-deeply $froms, ['views', 'a', 'b'], 'Template::Mustache push-to helper shape';
+
+# --- @-array param still works (unaffected by the fix) ---
+sub push-array-for(@t, $x) { for 1 { @t.push: $x } }
+my @k;
+push-array-for(@k, 'v');
+is-deeply @k, ['v'], '@-array by-ref push inside a for-body (unchanged)';
+
+# --- value semantics: a fresh local array is NOT shared with the caller ---
+sub copies($t) { my @local = $t; for 1 { @local.push: 99 }; @local }
+my $m = [1];
+my @res = copies($m);
+is-deeply $m, [1], 'pushing a copied-out local does not mutate the caller array';
+
+# --- push on a non-shared scalar array (single owner) still works ---
+my $n = [1];
+for 1 { $n.push: 2 }
+is-deeply $n, [1, 2], 'push on a singly-owned scalar array in a for-body';
+
+# --- pop / shift inside a for-body also mutate the shared array ---
+sub pop-for($t) { for 1 { $t.pop } }
+my $o = [1, 2, 3];
+pop-for($o);
+is-deeply $o, [1, 2], 'by-ref pop inside a for-block body';
+
+sub shift-for($t) { for 1 { $t.shift } }
+my $p = [1, 2, 3];
+shift-for($p);
+is-deeply $p, [2, 3], 'by-ref shift inside a for-block body';


### PR DESCRIPTION
## Summary

A `\$`-scalar variable holding a real array, passed **by reference** to a sub and mutated via `.push`/`.append`/`.unshift`/`.prepend`/`.pop`/`.shift` **inside a `for`/`when` block body**, lost the write for the caller's binding.

```raku
sub push-for($t, $x) { for 1 { $t.push: $x } }
my $b = [5];
push-for($b, 9);
say $b;   # was [5]   -> now [5, 9]  (raku: [5, 9])
```

## Root cause

Entering a `for`/`when` body flushes a shared clone of the by-ref param into `env`. The interpreter slow path then took the `self.env.get_mut(&key)` branch and used `Arc::make_mut`, which — when the backing `Arc<ArrayData>` is shared (refcount > 1) — detaches a **private copy** and writes only that env copy, leaving the caller's binding (and every other alias) stale.

Element assignment (`\$t[0] = ...`) already mutated the shared interior in place, so only the `.push`-family mutators diverged.

## Fix

In the env-backed mutator branches, when the backing Arc is shared, mutate the interior **in place** via `arc_contents_mut` (the same aliased-mutation path `array_push_in_place` already uses for the target-backed branch) instead of `Arc::make_mut`. This makes the env-backed and target-backed branches consistent. Singly-owned arrays still use `Arc::make_mut`.

## Impact

Unblocks **file/partial template loading in Template::Mustache** (whose `push-to` helper is `sub push-to ($t, $_) { when .defined { $t.push: $_ } }`):
- `t/02-file.rakutest`: 2 → 6 passing
- `t/03-cascade.rakutest`: 0 → 3 passing

## Test

`t/array-push-byref-coherence.t` — 16 cases, spec-validated against `raku`. `make test` green (9660 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)