### PR TITLE
feat(single-store): relax Mu universal type-skip for captured-outer cell boxing (Sub-slice 1b slice 1.5)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -211,14 +211,16 @@ scalar accumulation は boxing で解決済（pin 2 本が toggle 下 PASS）の
 
 > 地図は `tmp/blanket-reconcile-surface.txt`（揮発）にも出力。再計測コマンドは上記。
 
-### 7.1 ★次スライス推奨 = `metaop-thunk` の typed-scalar（`Mu` universal 緩和）
+### 7.1 ✅ スライス1.5（DONE・第42セッション）= `metaop-thunk` の typed-scalar（`Mu` universal 緩和）
 
 `metaop-thunk-captured-outer`(4 fail) は `my Mu $s; 1 Zand ($s++,)` 系＝**thunk（closure）に捕捉される
 typed scalar**。untyped `my $s` は toggle 下 PASS（`box_captured_lexicals` が box）だが、`Mu` 制約付きは
 §6.3/§8 の「type/where 制約 skip」で box されず fail。**`Mu` は universal type（全値マッチ）なので write-through が
-制約再チェックを迂回しても無害**＝`box_captured_lexicals`（vm_register_ops.rs:349）と `box_decl_local_cell`
-（vm_var_assign_ops.rs）の type-skip を `Mu` のみ緩和すれば解ける小スライス。**注意**: `Any` は Junction を弾く
-ので universal でない＝緩和は `Mu` のみ。closure 駆動なので `box_captured_lexicals` 側の緩和が主。
+制約再チェックを迂回しても無害**＝`box_captured_lexicals`（vm_register_ops.rs:343-353）の type-skip を
+`tc != "Mu"` のときのみ発火するよう緩和。subtest 4/6/8/9（`Zand`/`Zor`/`Z&&`/`Z||` with `my Mu $s`）が
+toggle 下でも PASS に。pin=`t/metaop-thunk-captured-outer-coherence.t`（12・ON/OFF 両 PASS）。make test 9656 /
+make roast 1285 回帰なし。**注意**: `Any` は Junction を弾くので universal でない＝緩和は `Mu` のみ。closure 駆動
+なので `box_captured_lexicals` 側の緩和のみで足り、`box_decl_local_cell`（named-sub path）は今回不要だった。
 
 ### 7.2 後続スライス（その先）
 

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -346,9 +346,15 @@ impl Interpreter {
                     // boxing it (inline `where` desugars to an anonymous subset, so
                     // var_type_constraint catches block/whatever/`&pred` forms).
                     // Applied to (B) only — the loop path (A) is left unchanged.
-                    if loan_env!(self, var_type_constraint(s)).is_some()
-                        || loan_env!(self, var_type_constraint(s.trim_start_matches('$'))).is_some()
-                    {
+                    // EXCEPTION: `Mu` is the universal type — every value satisfies
+                    // it, so the ContainerRef write-through bypasses no real check.
+                    // Box `my Mu $s` so captured-outer thunks (metaop `Xxx`/`Zand`)
+                    // share its cell and stay coherent without the blanket reconcile.
+                    let mut tc = loan_env!(self, var_type_constraint(s));
+                    if tc.is_none() {
+                        tc = loan_env!(self, var_type_constraint(s.trim_start_matches('$')));
+                    }
+                    if matches!(tc.as_deref(), Some(t) if t != "Mu") {
                         return None;
                     }
                 }


### PR DESCRIPTION
## Summary

Next slice toward `env_dirty` deletion (Sub-slice 1b, captured-outer cell sharing).

`box_captured_lexicals` skipped boxing any type-constrained scalar so each mutation re-checks the constraint through the assignment chokepoint (a `ContainerRef` write-through would bypass it). But `Mu` is the **universal type** — every value satisfies it, so a write-through bypasses no real check.

This PR relaxes the skip to `tc != "Mu"`, letting `my Mu $s` captured-outer scalars share a cell.

## Why

Metaop thunks whose operand mutates a `my Mu $s` caller lexical — `(($s++,),) Xxx 9`, `1 Zand ($s++,)`, `1 Z&& ($s++,)`, `0 Z|| ($s++,)` — relied on the blanket reverse reconcile to carry the env-by-name write back into the caller's local slot. With the slice-1 cell boxing they were the remaining OFF-survey failures because the `Mu` type constraint forced the boxing to be skipped.

Genuine constraints (`Int` / subset / inline `where`) still skip boxing so each mutation re-checks them.

## Verification

- pin: `t/metaop-thunk-captured-outer-coherence.t` (12; subtests 4/6/8/9 failed with `MUTSU_NO_BLANKET_RECONCILE=1` before this change) — now PASS both ON and OFF.
- `make test`: 9656 — no regressions.
- `make roast`: 1285 files / 208304 tests — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)