### PR TITLE
feat(single-store): precise captured-outer writeback for lazy-map/gather/subst carriers (Sub-slice 1b slice 1.6)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -222,9 +222,33 @@ toggle 下でも PASS に。pin=`t/metaop-thunk-captured-outer-coherence.t`（12
 make roast 1285 回帰なし。**注意**: `Any` は Junction を弾くので universal でない＝緩和は `Mu` のみ。closure 駆動
 なので `box_captured_lexicals` 側の緩和のみで足り、`box_decl_local_cell`（named-sub path）は今回不要だった。
 
+### 7.1b ✅ スライス1.6（DONE・第42セッション）= carrier cluster の single-frame 部（lazy map / gather / subst）
+
+carrier cluster のうち **single-frame**（書く callee が caller と同一フレーム or 直接呼ばれた callee）の3機構を
+precise writeback 化（`pending_rw_writeback_sources` に積み、既存の call-site/force-site drain が処理）＝blanket
+reconcile 非依存に。**この3つは cell 化ではなく precise-writeback で解けた**（map/grep が既に使う #3335/#3307 の機構を
+横展開）:
+
+- **lazy map（`@a.map({$c++}).eager`）**: `try_native_array_map` の `classify_body` が `$c++`/`$c--`（topic 以外の
+  **plain named** scalar inc/dec）を過剰に escape（`None`）扱いし slow path へ落とし、slow path は captured write を
+  記録しなかった。`Expr::Var(_) => Some(false)`（topic を変異しないので simple）に緩和＝native loop が処理し
+  `$c=$c+1` 同様に free-var write を記録（vm_native_map.rs:303）。indexed `@a[$i]++`/attr `$o.x++` は引き続き fall back。
+- **gather（`gather { ...; $c++; take $_ }`）**: forcing 時の `reconcile_caller_after_lazy_force` が gather body を
+  `blanket_reconcile_if_dirty`（OFF 無効）でしか reconcile していなかった。両 force inner（`force_lazy_list_vm_inner` /
+  `_n_inner`）の env-merge 直後に gather body の `free_var_writes` を `record_eager_block_free_var_writeback` で記録
+  （vm_helpers.rs）＝force-site の既存 `apply_pending_rw_writeback` が precise drain。
+- **subst（`.subst(/../, { $n++ })`）**: `eval_subst_replacement_cased` は捕捉 lexical write を env へ伝播するが
+  pending に積まず blanket 依存だった。伝播箇所で名前を `pending_rw_writeback_sources` に push（methods_string.rs）＝
+  `.subst` call-site が drain。
+
+pin（既存）=`t/{lazy-reify-captured-outer,gather-lazy,subst-closure-writeback}.t`（ON/OFF 両 PASS）。make test 9672 /
+make roast 1285 回帰なし。
+
 ### 7.2 後続スライス（その先）
 
-- **carrier cluster**（subst-closure / eval-carrier / lazy-reify）: 捕捉 outer scalar を carrier 経路でも cell 化。
+- **carrier cluster の multi-frame 残**（`eval-carrier-precise` subtest 3/5・`require-expression` subtest 3）:
+  **descendant frame から ancestor lexical を書く EVAL/require carrier**＝§1 の multi-frame accumulation 壁そのもの。
+  precise single-frame drain では届かず（記録が中間フレームで discard される）、**cell 共有が要る本丸**。
 - **container `@`/`%` の明示 cell 化**（必要なら）: 現状 Arc 共有で動くが、`box_captured_lexicals` の `@`/`%` skip を
   escape-aware に緩和する場合は **outer container の decont 消費面の網羅監査**が前提（§8）。
 - **並行 cluster**: cross-thread cell（最難・最後）。

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -1082,6 +1082,13 @@ impl Interpreter {
             }
             if let Some(v) = self.env.get_sym(k) {
                 saved.insert_sym(k, v.clone());
+                // Precise (env_dirty-independent) writeback: record the captured
+                // lexical so the `.subst` call site drains it into the caller's
+                // local slot via `apply_pending_rw_writeback`, like a map/grep
+                // callback. Without this the write reached env but the caller's
+                // slot relied on the blanket reconcile (being retired — see
+                // docs/captured-outer-cell-sharing.md).
+                self.pending_rw_writeback_sources.push(name);
             }
         }
         self.env = saved;

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1978,7 +1978,7 @@ impl Interpreter {
     /// lexical lands in `env` but is never recorded for write-through. Replay the
     /// block's compile-time `free_var_writes` here. Topic/param names are
     /// loop-local (restored by the caller) and excluded.
-    fn record_eager_block_free_var_writeback(
+    pub(crate) fn record_eager_block_free_var_writeback(
         &mut self,
         code: &crate::opcode::CompiledCode,
         params: &[String],

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -584,6 +584,13 @@ impl Interpreter {
             }
         }
         *self.env_mut() = merged_env;
+        // Precise (env_dirty-independent) writeback: record the gather body's
+        // captured-outer writes so `apply_pending_rw_writeback` (called from
+        // `reconcile_caller_after_lazy_force`) drains them into the caller's local
+        // slots, exactly like a `map`/`grep` callback. Without this the gather
+        // case relied solely on the blanket `env_dirty` reconcile (the surface
+        // docs/captured-outer-cell-sharing.md is retiring).
+        self.record_eager_block_free_var_writeback(cc.as_ref(), &[]);
 
         // Check whether the merged env actually changed any outer-scope variables.
         let env_actually_changed = {
@@ -896,6 +903,10 @@ impl Interpreter {
             }
         }
         *self.env_mut() = merged_env;
+        // Precise (env_dirty-independent) writeback of the gather body's
+        // captured-outer writes — see the matching comment in
+        // `force_lazy_list_vm_inner`.
+        self.record_eager_block_free_var_writeback(cc.as_ref(), &[]);
 
         let env_actually_changed = {
             let merged = self.env();

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -302,10 +302,17 @@ fn classify_expr(expr: &Expr) -> Option<bool> {
         Expr::ControlFlow { .. } => None,
         Expr::Unary { op, expr } | Expr::PostfixOp { op, expr } => {
             if matches!(op, TokenKind::PlusPlus | TokenKind::MinusMinus) {
-                // `$_++` / `$_--` mutate the topic; an increment of any other
-                // variable cannot be reproduced by the clone-based loop.
+                // `$_++` / `$_--` mutate the topic. A `++`/`--` of a plain
+                // *named* scalar (`$c++`, a captured-outer or block-local var)
+                // does NOT touch the topic and is reproduced by the native loop
+                // exactly like `$c = $c + 1` (its free-var write is recorded and
+                // drained at the call site, #3307) — so classify it as a simple,
+                // non-topic-mutating body. Any other `++`/`--` target (an indexed
+                // element `@a[$i]++`, an attribute `$o.x++`, a deref) is not a
+                // plain name write and stays an escape (fall back).
                 match expr.as_ref() {
                     Expr::Var(n) if n == "_" => Some(true),
+                    Expr::Var(_) => Some(false),
                     _ => None,
                 }
             } else {


### PR DESCRIPTION
## Summary

Continues the captured-outer cell-sharing campaign (path to `env_dirty` deletion). Resolves the **single-frame** part of the carrier cluster (user-selected next direction).

Three carrier mechanisms relied on the `env_dirty` blanket reconcile to carry a captured-outer write back into the caller's local slot. This PR makes all three **precise** — they record into `pending_rw_writeback_sources`, drained by the existing call-/force-site `apply_pending_rw_writeback` — so they no longer depend on the blanket reconcile (which `docs/captured-outer-cell-sharing.md` is retiring).

### Fixes

- **lazy map** (`@a.map({ $c++ }).eager`): `try_native_array_map`'s `classify_body` over-conservatively treated `$c++`/`$c--` of a plain *named* (non-topic) scalar as an escape, falling to a slow path that did not record the captured write. A `++`/`--` of a named var does not touch the topic `$_` and is reproduced by the native loop exactly like `$c = $c + 1` (whose free-var write **is** recorded). Classify it as simple; indexed (`@a[$i]++`) / attribute (`$o.x++`) targets still fall back.
- **gather** (`gather { ...; $c++; take $_ }`): the lazy-force reconcile only ran the gather body's env-merge through `blanket_reconcile_if_dirty`. Record the gather body's `free_var_writes` after the merge in both force inner paths so the force site's `apply_pending_rw_writeback` drains them precisely.
- **subst** (`.subst(/.../, { $n++ })`): `eval_subst_replacement_cased` propagated the block's captured writes to env but not to pending; push the propagated names so the `.subst` call site drains them.

All three are byte-identical with the blanket reconcile ON (it writes the same env value into the same slot).

### Out of scope (the deeper wall)

The remaining carrier failures — `eval-carrier-precise` (ancestor / two-deep EVAL) and `require-expression` (BEGIN/EVAL) — are the **multi-frame accumulation wall**: a descendant frame writes an ancestor lexical, and precise single-frame drain can't reach it (the record is discarded one frame too deep). That needs cell sharing, not precise writeback.

## Verification

- pins (existing): `t/lazy-reify-captured-outer-coherence.t`, `t/gather-lazy.t`, `t/subst-closure-writeback.t` — now PASS both ON and with `MUTSU_NO_BLANKET_RECONCILE=1`.
- `make test`: 9672 — no regressions.
- `make roast`: 1285 files / 208304 tests — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)