### PR TITLE
fix(exception): Str/gist delegate to a user `message` method, not just the attribute

### DIFF
--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -416,6 +416,13 @@ impl Interpreter {
             self.stack.push(v);
             return Ok(());
         }
+        // `Exception.Str`/`.gist` delegate to a user `message` *method* (e.g. from a
+        // parameterized role). `$e.Str` on a variable compiles to CallMethodMut, so
+        // the mut path needs the same interception as CallMethod.
+        if let Some(out) = self.try_exception_str_via_user_message(&target, &method, &args)? {
+            self.stack.push(out);
+            return Ok(());
+        }
         // gist/Str/raku/perl of a genuinely-lazy list renders raku's placeholder
         // (`[...]` in `@` array context, `(...)` for a bare Seq, `...` for Str)
         // rather than forcing the (possibly infinite) sequence. Must run before

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -159,6 +159,59 @@ impl Interpreter {
         }
     }
 
+    /// `Exception.Str`/`.gist` delegate to `self.message` (raku semantics). When a
+    /// user exception supplies `message` as a *method* (e.g. composed from a
+    /// parameterized role `role X[Str $e] { method message {...} }`) rather than an
+    /// attribute, the native exception Str/gist fast path would otherwise read the
+    /// (absent) `message` attribute and render "X::Foo with no message". Route
+    /// through the user method instead. `.message` already dispatches to the user
+    /// method, so it is unaffected. Returns `Ok(None)` when this case does not
+    /// apply (the caller continues with normal dispatch). Shared by the CallMethod
+    /// and CallMethodMut paths (`$e.Str` on a variable compiles to CallMethodMut).
+    pub(super) fn try_exception_str_via_user_message(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Result<Option<Value>, RuntimeError> {
+        if !matches!(method, "Str" | "gist") || !args.is_empty() {
+            return Ok(None);
+        }
+        let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target
+        else {
+            return Ok(None);
+        };
+        let cn = class_name.resolve();
+        if !(cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::"))
+            || attributes.as_map().contains_key("message")
+            || !self.has_user_method(&cn, "message")
+            || self.has_user_method(&cn, method)
+        {
+            return Ok(None);
+        }
+        let msg = self.vm_call_method_with_values(target.clone(), "message", vec![])?;
+        let out = if method == "gist" {
+            let bt = attributes
+                .as_map()
+                .get("backtrace")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            let m = msg.to_string_value();
+            if bt.is_empty() {
+                Value::str(m)
+            } else {
+                Value::str(format!("{m}\n{bt}"))
+            }
+        } else {
+            Value::str(msg.to_string_value())
+        };
+        Ok(Some(out))
+    }
+
     /// `fail`/`die`/`throw`/`rethrow`/`resume` require a concrete (instance)
     /// invocant. Calling one on an Exception *type object* (e.g. `X::NYI.throw`)
     /// is `X::Parameter::InvalidConcreteness`, not "no such method". Shared by the
@@ -245,6 +298,13 @@ impl Interpreter {
         if let Some(result) = self.try_proto_method_body(&target, method, &args) {
             let v = result?;
             self.stack.push(v);
+            return Ok(());
+        }
+        // `Exception.Str`/`.gist` delegate to `self.message` (raku semantics) when
+        // `message` is a user *method* rather than an attribute. See
+        // `try_exception_str_via_user_message`.
+        if let Some(out) = self.try_exception_str_via_user_message(&target, method, &args)? {
+            self.stack.push(out);
             return Ok(());
         }
         // .return method: triggers a return from the enclosing sub with the invocant

--- a/t/exception-str-via-user-message.t
+++ b/t/exception-str-via-user-message.t
@@ -1,0 +1,37 @@
+use Test;
+
+# `Exception.Str`/`.gist` delegate to `self.message` (raku semantics). When a user
+# exception supplies `message` as a *method* — e.g. composed from a parameterized
+# role `role X[Str $e] is Exception { method message {...} }` — rather than as an
+# attribute, the native exception Str/gist fast path used to read the (absent)
+# `message` attribute and render "X::Foo with no message". It must call the user
+# method instead. (Template::Mustache defines all its exceptions this way.)
+
+plan 5;
+
+role X[Str:D $err] is Exception {
+    has $.str;
+    method message { "$err <$!str>" }
+}
+class X::FieldNotFound does X['Field not found'] { }
+
+my $e = X::FieldNotFound.new(:str('missing'));
+
+is $e.message, 'Field not found <missing>', '.message dispatches to the user method';
+is $e.Str,     'Field not found <missing>', '.Str delegates to the user message method';
+is $e.gist,    'Field not found <missing>', '.gist delegates to the user message method (no backtrace)';
+
+# Caught (thrown) form: CATCH sees the same message.
+my $caught;
+{
+    X::FieldNotFound.new(:str('boom')).throw;
+    CATCH { default { $caught = .Str } }
+}
+is $caught, 'Field not found <boom>', 'a thrown user exception stringifies via its message method';
+
+# A plain attribute-based message still works (no regression).
+class X::Plain is Exception {
+    has $.message;
+}
+is X::Plain.new(message => 'plain msg').Str, 'plain msg',
+    'attribute-based message still works';


### PR DESCRIPTION
## Summary

`Exception.Str`/`.gist` should delegate to `self.message` (raku semantics). When a user exception supplies `message` as a **method** — e.g. composed from a parameterized role `role X[Str \$e] is Exception { method message {...} }` rather than as an attribute — the native exception Str/gist fast path read the (absent) `message` attribute and rendered `"X::Foo with no message"`.

`.message` itself already dispatched to the user method, so only `Str`/`gist` were wrong:

```raku
role X[Str:D $err] is Exception { has $.str; method message { "$err <$!str>" } }
class X::FieldNotFound does X['Field not found'] { }
my $e = X::FieldNotFound.new(:str('missing'));
$e.message;   # "Field not found <missing>"  (already worked)
$e.Str;       # was "X::FieldNotFound with no message"  ->  now "Field not found <missing>"
```

## Fix

A shared `try_exception_str_via_user_message` interception in **both** the CallMethod and CallMethodMut dispatch paths (`$e.Str` on a variable compiles to CallMethodMut) — when the invocant is an exception with a user `message` method, no `message` attribute, and no user-defined `Str`/`gist`, call `.message` and use its result (gist appends the backtrace when present).

This is the exception shape every Template::Mustache exception uses (`class X::FieldNotFound does X['Field not found']`).

## Test

`t/exception-str-via-user-message.t` — 5 cases (`.message`/`.Str`/`.gist`, thrown+CATCH, attribute-message regression), spec-validated against `raku`. `make test` green.

## Note

Internal stringification via `join` / `sprintf "%s"` / `~` / interpolation still goes through the interpreter-less `to_string_value` and is **not** yet covered — that needs message materialization at construction (follow-up). So this fixes explicit `.Str`/`.gist` but not yet the Template::Mustache `log` path (which uses `sprintf "%s", \$e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)