### PR TITLE
fix(exception): materialize a user `message` method into the message attribute at construction

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3336,7 +3336,7 @@ impl Interpreter {
             "new" | "bless" | "Mu::new" | "handled" | "new-from-pairs"
         ) && let Some(result) = self.dispatch_new_and_constructors(&target, method, args.clone())
         {
-            return result;
+            return self.materialize_exception_message_in_result(result);
         }
 
         // Enum dispatch

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1663,6 +1663,57 @@ impl Interpreter {
         }
     }
 
+    /// Materialize a user `message` *method* into the `message` attribute of a
+    /// freshly-constructed exception. raku computes `Exception.message` lazily,
+    /// but mutsu's interpreter-less stringification (`join`, `sprintf "%s"`, `~`,
+    /// interpolation -> `to_string_value`) cannot dispatch a user method, so such
+    /// an exception would stringify as "X::Foo with no message" outside an
+    /// explicit `.Str`/`.gist` call. Running the (conventionally pure) message
+    /// method once at construction and caching the result keeps every
+    /// stringification path coherent. Scoped to exceptions that define `message`
+    /// as a method and have no `message` attribute, so built-in and
+    /// attribute-message exceptions are unaffected. Errors in the message method
+    /// are swallowed (the exception is still returned un-materialized).
+    pub(super) fn materialize_exception_message_in_result(
+        &mut self,
+        result: Result<Value, RuntimeError>,
+    ) -> Result<Value, RuntimeError> {
+        let Ok(Value::Instance {
+            class_name,
+            attributes,
+            id,
+        }) = result
+        else {
+            return result;
+        };
+        let cn = class_name.resolve();
+        let is_exc = cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::");
+        if !is_exc
+            || attributes.as_map().contains_key("message")
+            || !self.has_user_method(&cn, "message")
+        {
+            return Ok(Value::Instance {
+                class_name,
+                attributes,
+                id,
+            });
+        }
+        let instance = Value::Instance {
+            class_name,
+            attributes: attributes.clone(),
+            id,
+        };
+        if let Ok(msg) = self.call_method_with_values(instance.clone(), "message", vec![]) {
+            let msg_str = msg.to_string_value();
+            if !msg_str.is_empty() {
+                let mut attrs = attributes.as_map().clone();
+                attrs.insert("message".to_string(), Value::str(msg_str));
+                return Ok(Value::make_instance(class_name, attrs));
+            }
+        }
+        Ok(instance)
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,

--- a/t/exception-message-materialize.t
+++ b/t/exception-message-materialize.t
@@ -1,0 +1,33 @@
+use Test;
+
+# An exception whose `message` is a user *method* (e.g. composed from a
+# parameterized role) must stringify to that message through EVERY stringification
+# path, not just an explicit `.Str`/`.gist` call. mutsu's `join`/`sprintf "%s"`/
+# `~`/interpolation go through the interpreter-less `to_string_value`, which cannot
+# dispatch a user method — so the message is materialized into the `message`
+# attribute once at construction. (Template::Mustache logs exceptions via
+# `sprintf "%s", $e` and `@msgs.join`.)
+
+plan 7;
+
+role X[Str:D $err] is Exception {
+    has $.str;
+    method message { "$err <$!str>" }
+}
+class X::FieldNotFound does X['Field not found'] { }
+
+my $e = X::FieldNotFound.new(:str('f1'));
+my $expect = 'Field not found <f1>';
+
+is $e.Str,                $expect, '.Str';
+is ('' ~ $e),             $expect, 'concatenation (~)';
+is "$e",                  $expect, 'string interpolation';
+is ($e,).join,            $expect, '.join';
+is sprintf('%s', $e),     $expect, 'sprintf %s';
+is $e.message,            $expect, '.message (user method, unchanged)';
+
+# A plain built-in-style exception with no user message method is unaffected:
+# constructing it does not crash and it still reports its attribute message.
+class X::Plain is Exception { has $.message; }
+is sprintf('%s', X::Plain.new(message => 'plain')), 'plain',
+    'attribute-message exception still stringifies normally';


### PR DESCRIPTION
## Summary

Follow-up to #3367 (`Str`/`gist` → user `message` method). A user exception whose `message` is a **method** (e.g. composed from a parameterized role) stringified correctly only via an explicit `.Str`/`.gist` call. Internal stringification — `join`, `sprintf "%s"`, `~`, interpolation — goes through the interpreter-less `to_string_value`, which cannot dispatch a user method, so those paths rendered `"X::Foo with no message"`.

```raku
role X[Str:D $err] is Exception { has $.str; method message { "$err <$!str>" } }
class X::FieldNotFound does X['Field not found'] { }
my $e = X::FieldNotFound.new(:str('f1'));
sprintf('%s', $e);   # was "X::FieldNotFound with no message"  ->  now "Field not found <f1>"
($e,).join;          # likewise
"$e";                # likewise
```

## Fix

At the constructor chokepoint (`call_method_with_values`'s `dispatch_new_and_constructors` arm), run the user `message` method once on the freshly-built exception and cache the result in the `message` attribute. Then every stringification path (which reads the attribute) is coherent.

Scoped to exceptions (`Exception`/`X::*`/`CX::*`) that define `message` as a method and have **no** `message` attribute, so built-in and attribute-message exceptions are untouched; message-method errors are swallowed (the exception is returned un-materialized). raku computes `.message` lazily, but the eager cache is behavior-equivalent for the conventional (pure) message method.

## Test

`t/exception-message-materialize.t` — 7 cases (`.Str`/`~`/interpolation/`join`/`sprintf`/`.message` + attribute-message regression), spec-validated against `raku`. `make test` green (9684 tests).

## Context

This is the exception shape every Template::Mustache exception uses. It fixes the exception **stringification** in the module's `log` path (`sprintf "%s", \$e` / `@msgs.join`). (06-logging additionally needs a separate fix for invoking `&warn` via a Callable reference under `CONTROL` — tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)