### PR TITLE
feat(single-store): cross-frame cell boxing for EVAL carrier captured-outer writes (Sub-slice 1b slice 1.7)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -244,14 +244,33 @@ reconcile 非依存に。**この3つは cell 化ではなく precise-writeback 
 pin（既存）=`t/{lazy-reify-captured-outer,gather-lazy,subst-closure-writeback}.t`（ON/OFF 両 PASS）。make test 9672 /
 make roast 1285 回帰なし。
 
+### 7.1c ✅ スライス1.7（DONE・第42セッション）= EVAL carrier の multi-frame cell 共有
+
+carrier cluster の **multi-frame** 部（`eval-carrier-precise` subtest 3/5・`require-expression` subtest 3）＝
+**descendant frame から ancestor lexical を書く EVAL carrier**（`sub set_x(){ EVAL '$x = 5' }; set_x()`）。
+EVAL 文字列内の write は **静的 `free_var_writes` 解析が見えず**、owner の decl-site で cell 化できない。precise
+single-frame writeback も**不可**＝値が callee の env restore で失われ、drain は restore 後の stale env を読む（実証済）。
+∴ **EVAL 実行時に cross-frame cell 化**: `box_carrier_free_var_writes`（vm_env_helpers.rs）が EVAL'd code の
+`free_var_writes` の captured-outer scalar を、live `env` + 全 `call_frames.saved_env` で同一 `ContainerRef` cell 化
+→ EVAL の by-name write が cell を通り、owner frame の env restore 後も cell が 5 を保持。**ガード**:
+①`cell_boxing_active()` gated（default は no-op・byte-identical）②`__mutsu_in_eval` 限定（supply/whenever/gather body も
+eval_block_value 経由だが Track C 並行 cell が別管理＝触れない）③sigilless alias（`__mutsu_sigilless_alias::x`）は
+skip（`\x`→`$a` の alias chain を cell が detach するため）④type/where 制約 skip（`Mu` 除く）。
+呼び出し＝`eval_block_value`（resolution.rs・compile 後・run 前）。pin（既存）=`t/{eval-carrier-precise-writeback,
+require-expression}.t`（ON/OFF 両 PASS）。make test 9679 / make roast 1285 回帰なし。OFF survey 20→18。
+**注意**: 当初 `__mutsu_in_eval` 無し（broad）版は supply/whenever 14 file を OFF-clean 化したが
+`concurrent-cell-writeback` subtest4 / `sigilless-params` subtest3 を**回帰**＝並行 cell 機構との衝突。EVAL 限定で解消。
+
 ### 7.2 後続スライス（その先）
 
-- **carrier cluster の multi-frame 残**（`eval-carrier-precise` subtest 3/5・`require-expression` subtest 3）:
-  **descendant frame から ancestor lexical を書く EVAL/require carrier**＝§1 の multi-frame accumulation 壁そのもの。
-  precise single-frame drain では届かず（記録が中間フレームで discard される）、**cell 共有が要る本丸**。
+- **nested-method capture**（`methods-instance` subtest 3 = `method foo { my $a; method bar { $tracker = $a } }`）:
+  EVAL でない multi-frame captured-write（nested method 宣言が enclosing method の lexical 捕捉）。別機構の調査要。
+- **top-level captured-outer scalar**（`cross-metaops` subtest 2 = `my Mu $t; Nil Xorelse ($t = $_,)`）: env 常駐の
+  top-level scalar を metaop thunk が捕捉。`box_captured_lexicals` は local slot を box する＝env 常駐は対象外。
+- **top-level container（`attribute-trait-mod` 5 fail）**: `my @noted-names` を trait_mod dispatch 経由で変異（env 常駐）。
 - **container `@`/`%` の明示 cell 化**（必要なら）: 現状 Arc 共有で動くが、`box_captured_lexicals` の `@`/`%` skip を
   escape-aware に緩和する場合は **outer container の decont 消費面の網羅監査**が前提（§8）。
-- **並行 cluster**: cross-thread cell（最難・最後）。
+- **並行 cluster**（supply/whenever/react/promise/proc-async/scheduler ~13）: cross-thread cell（最難・最後）。
 
 ### 7.3 ★各スライスの必須手順（slice 1 の教訓）
 

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1772,6 +1772,11 @@ impl Interpreter {
             .map(|(k, v)| (*k, v.clone()))
             .collect();
         let (code, compiled_fns) = self.compile_block_value(body);
+        // Multi-frame coherence (env_dirty-deletion path): box any captured-outer
+        // scalar this carrier body writes into a shared cell across env + saved
+        // frames, so the by-name write survives the owner frame's env restore.
+        // No-op in the default build (gated on cell_boxing_active).
+        self.box_carrier_free_var_writes(&code);
         self.block_scope_depth += 1;
         let result = self.run_compiled_block(&code, &compiled_fns);
         let trailing_sub_value = match body.last() {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -692,6 +692,94 @@ impl Interpreter {
         blanket_reconcile_disabled()
     }
 
+    /// Box each captured-outer scalar that a carrier body (`EVAL`, an embedded
+    /// regex `{...}` block) WRITES into a `ContainerRef` cell shared across the
+    /// live `env` and every saved call frame's `saved_env`, so the carrier's
+    /// by-name write reaches the owner frame even after the owner's env is
+    /// restored on return (the multi-frame accumulation wall — a captured-outer
+    /// write hidden inside an `EVAL` string is invisible to the static
+    /// `free_var_writes` analysis at the owner's decl site, so it cannot be boxed
+    /// there; box it here at carrier-run time instead).
+    ///
+    /// Gated on `cell_boxing_active()` (the `MUTSU_NO_BLANKET_RECONCILE` toggle):
+    /// in the default build the blanket reconcile carries this, so boxing stays
+    /// off and behaviour is byte-identical (see `box_decl_local_cell`).
+    pub(crate) fn box_carrier_free_var_writes(&mut self, code: &CompiledCode) {
+        if !self.cell_boxing_active() || code.free_var_writes.is_empty() {
+            return;
+        }
+        // Restrict to the EVAL carrier (`__mutsu_in_eval`). The other
+        // eval_block_value users — supply/whenever/gather bodies — have their own
+        // concurrent-cell coherence (Track C, the hardest/last cluster); boxing
+        // their captured vars here conflicts with that machinery, so leave them be.
+        if self.env().get("__mutsu_in_eval").is_none() {
+            return;
+        }
+        let names: Vec<String> = code.free_var_writes.iter().map(|s| s.resolve()).collect();
+        for name in names {
+            if name == "_" || name == "$_" || name == "@_" || name == "%_" {
+                continue;
+            }
+            // Scalars only (containers share via Arc already); never hide a
+            // type object / sub / instance behind a cell.
+            if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
+                continue;
+            }
+            // A sigilless alias (`sub swap(\x,\y){ y=x }`) is NOT a captured-outer
+            // lexical: `x` resolves through `__mutsu_sigilless_alias::x` to the
+            // caller's `$a`, and writes propagate via that chain (#3318). Boxing
+            // `x` into a cell detaches it from `$a` — skip it.
+            if self
+                .env()
+                .get(&format!("__mutsu_sigilless_alias::{}", name))
+                .is_some()
+            {
+                continue;
+            }
+            let cur = match self.env().get(&name) {
+                Some(v) => v.clone(),
+                None => continue,
+            };
+            if cur.is_container_ref() {
+                continue;
+            }
+            if matches!(
+                cur,
+                Value::Package(_)
+                    | Value::Array(..)
+                    | Value::Hash(..)
+                    | Value::Sub(..)
+                    | Value::Instance { .. }
+                    | Value::Proxy { .. }
+            ) {
+                continue;
+            }
+            // A genuine type/`where` constraint must keep flowing through the
+            // assignment chokepoint (write-through bypasses the re-check); `Mu`
+            // is universal so it is safe to box (mirrors slice 1.5).
+            let mut tc = loan_env!(self, var_type_constraint(&name));
+            if tc.is_none() {
+                tc = loan_env!(self, var_type_constraint(name.trim_start_matches('$')));
+            }
+            if matches!(tc.as_deref(), Some(t) if t != "Mu") {
+                continue;
+            }
+            let container = cur.into_container_ref();
+            self.set_env_with_main_alias(&name, container.clone());
+            if let Some(idx) = code.locals.iter().rposition(|n| n == &name) {
+                self.locals[idx] = container.clone();
+            }
+            for frame in self.call_frames.iter_mut().rev() {
+                if frame.saved_env.contains_key(&name) {
+                    frame.saved_env.insert(name.clone(), container.clone());
+                }
+            }
+            if self.shared_vars_active {
+                loan_env!(self, set_shared_var(&name, container.clone()));
+            }
+        }
+    }
+
     pub(super) fn find_local_slot(&self, code: &CompiledCode, name: &str) -> Option<usize> {
         code.locals.iter().position(|n| n == name)
     }


### PR DESCRIPTION
## Summary

The **multi-frame captured-outer wall** — the last load-bearing role of `env_dirty` (per `docs/captured-outer-cell-sharing.md` §1). User-selected direction (multi-frame cell sharing本丸).

A write hidden inside an EVAL string —

```raku
my $x = 0;
sub set_x() { EVAL '$x = 5' }
set_x();
is $x, 5;     # raku=5; was 0 with the blanket reconcile disabled
```

— is **invisible to the static `free_var_writes` analysis** at the owner's decl site, so `$x` is never boxed. And **precise single-frame writeback cannot reach it either**: the value is written into the callee's env and lost when the callee's env is restored on return, so the call-site drain reads a stale env (verified empirically).

### Fix

Box it **at EVAL run time**: `box_carrier_free_var_writes` wraps each captured-outer scalar the EVAL'd code writes into **one `ContainerRef` cell shared across the live env and every saved call frame's `saved_env`**. The EVAL's by-name write goes through the cell, and the owner frame still holds the same cell after its env is restored on return.

### Guards (default build stays byte-identical; other mechanisms untouched)

- `cell_boxing_active()` gated — no-op unless `MUTSU_NO_BLANKET_RECONCILE`.
- `__mutsu_in_eval` only — supply/whenever/gather bodies also run via `eval_block_value` but have their own Track C concurrent-cell coherence; boxing their captured vars conflicts with it (a broad first cut regressed `concurrent-cell-writeback` / `sigilless-params`). Restricting to the EVAL carrier resolves both.
- skip sigilless aliases (`__mutsu_sigilless_alias::x`) — `\x` → `$a` propagates via the alias chain; a cell would detach it.
- skip genuine type/`where` constraints (`Mu` allowed, as in slice 1.5).

## Verification

- pins (existing): `t/eval-carrier-precise-writeback.t`, `t/require-expression.t` — pass both ON and with `MUTSU_NO_BLANKET_RECONCILE=1`.
- OFF survey (blanket reconcile disabled): 20 → 18 files (eval-carrier + require-expression resolved, no new failures).
- `make test`: 9679 — no regressions. `make roast`: 1285 / 208304 — no regressions.

### Remaining (deferred)

`methods-instance` (nested-method capture, not EVAL), `cross-metaops` / `attribute-trait-mod` (top-level env-resident captured vars/containers), and the concurrency cluster (~13, cross-thread cell — hardest/last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)