### PR TITLE
fix(vm): record a resume point for control signals from CallOnValue/CallOnCodeVar

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3325,7 +3325,20 @@ impl Interpreter {
                 arity,
                 arg_sources_idx,
             } => {
-                self.exec_call_on_value_op(code, *arity, *arg_sources_idx, compiled_fns)?;
+                // Set a resume point before propagating a control signal so an
+                // enclosing `CONTROL {}` can `.resume` after this call — e.g.
+                // `my $w = &warn; $w.("x")` raises a resumable `warn` signal from
+                // inside the dispatched callable, exactly like a direct `warn`
+                // (which the `ExecCall` arm below already handles).
+                match self.exec_call_on_value_op(code, *arity, *arg_sources_idx, compiled_fns) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::CallOnCodeVar {
@@ -3333,13 +3346,21 @@ impl Interpreter {
                 arity,
                 arg_sources_idx,
             } => {
-                self.exec_call_on_code_var_op(
+                match self.exec_call_on_code_var_op(
                     code,
                     *name_idx,
                     *arity,
                     *arg_sources_idx,
                     compiled_fns,
-                )?;
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if !e.is_resume && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
                 *ip += 1;
             }
             OpCode::ExecCall {

--- a/t/resumable-control-signal-indirect-call.t
+++ b/t/resumable-control-signal-indirect-call.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A resumable control signal (e.g. `warn`) raised from inside a callable invoked
+# *indirectly* — `$code.(...)` / `&warn.(...)` — must let an enclosing `CONTROL {}`
+# `.resume` after the call, exactly like a direct `warn`. The `CallOnValue` /
+# `CallOnCodeVar` opcodes did not record a resume point before propagating the
+# signal (unlike the direct-call `ExecCall` path), so `.resume` had nowhere to go
+# and the program silently terminated. (Template::Mustache logs warnings through
+# `$!routines{$level} = &warn; $_.(...)`, hitting exactly this path.)
+
+plan 5;
+
+# --- direct warn under CONTROL (already worked) ---
+{
+    my $out = '';
+    CONTROL { default { $out ~= "[{.message}]"; .resume; } }
+    warn "direct";
+    is $out, '[direct]', 'direct warn is caught and resumed';
+    pass 'execution continues after a direct warn';
+}
+
+# --- indirect warn via a &warn reference ---
+{
+    my $out = '';
+    CONTROL { default { $out ~= "[{.message}]"; .resume; } }
+    my $w = &warn;
+    $w.("indirect");
+    is $out, '[indirect]', 'indirect warn via &warn.() is caught and resumed';
+    pass 'execution continues after an indirect warn';
+}
+
+# --- two indirect warns both resume (accumulation) ---
+{
+    my @seen;
+    CONTROL { default { @seen.push(.message); .resume; } }
+    my $w = &warn;
+    $w.("one");
+    $w.("two");
+    is @seen.join(','), 'one,two', 'consecutive indirect warns each resume';
+}


### PR DESCRIPTION
## Summary

A resumable control signal (notably `warn`) raised from a callable invoked **indirectly** — `$code.(...)` / `&warn.(...)` — left an enclosing `CONTROL {}` with nowhere to `.resume`, so the program **silently terminated**:

```raku
my $out = '';
CONTROL { default { $out ~= .message; .resume } }
my $w = &warn;
$w.("hi");          # was: program ends here, $out never checked
say $out;           # now: "hi", execution continues
```

The direct-call path (`ExecCall`) records `resume_ip = ip + 1` before propagating such a signal, but the `CallOnValue` and `CallOnCodeVar` opcodes propagated the error with `?` and never set a resume point.

## Fix

Both opcodes now mirror `ExecCall` — on error, set `resume_ip = Some(ip + 1)` (when not already a resume and none is pending) before returning, so `.resume` continues after the indirect call exactly like after a direct `warn`.

This is the shape Template::Mustache's logger uses (`$!routines{$level} = &warn; $_.(...)`).

## Test

`t/resumable-control-signal-indirect-call.t` — 5 cases (direct vs `&warn.()`, consecutive indirect warns), spec-validated against `raku`. `make test` green (9691 tests).

## Note

A warn raised *deeper* inside a user sub invoked indirectly (`my $code = sub { warn "x" }; $code.()`) needs the resume to re-enter that sub's frame, which a single frame-relative `resume_ip` cannot express — that cross-frame continuation case is left for follow-up. This fixes the direct-callable (`&warn`) case the module hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)