### PR TITLE
fix(vm): resume a warn raised deep in a callee under an outer CONTROL handler

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -896,6 +896,20 @@ pub struct Interpreter {
     /// EVAL) can observe handlers installed by the outer VM and propagate
     /// warn/control signals appropriately.
     pub(crate) control_handler_depth: u32,
+    /// Active CONTROL handler bodies, innermost last. Each entry is
+    /// `(code_ptr, control_begin, control_end, frame_depth)` where `code_ptr` is a
+    /// raw `*const CompiledCode` (kept as `usize` to stay `Send`) of the block
+    /// that installed the handler, and `frame_depth` is `call_frames.len()` at
+    /// install time. Pushed/popped in lockstep with `control_handler_depth`
+    /// (`exec_try_catch_op_inner`). Lets a resumable `warn` raised *deep* in a
+    /// callee be handled in that callee's still-live frame — running the handler
+    /// inline (with the installing frame's locals temporarily swapped in, found at
+    /// `call_frames[frame_depth].saved_locals`) and resuming via the callee
+    /// frame's own `resume_ip` — instead of unwinding to the installing block,
+    /// whose frame-relative `resume_ip` would point into the wrong code. SAFETY:
+    /// the installing block's `CompiledCode` is an ancestor frame on the live Rust
+    /// call stack while any entry is live, so the pointer never dangles.
+    pub(crate) control_handlers: Vec<(usize, usize, usize, usize)>,
     test_assertion_line_stack: Vec<i64>,
     block_stack: Vec<Value>,
     doc_comments: HashMap<String, DocComment>,
@@ -3106,6 +3120,7 @@ impl Interpreter {
             pending_call_arg_sources: None,
             test_pending_callsite_line: None,
             control_handler_depth: 0,
+            control_handlers: Vec::new(),
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),
             doc_comments: HashMap::new(),
@@ -5831,6 +5846,7 @@ impl Interpreter {
             pending_call_arg_sources: None,
             test_pending_callsite_line: None,
             control_handler_depth: 0,
+            control_handlers: Vec::new(),
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),
             doc_comments: HashMap::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -437,16 +437,6 @@ impl Interpreter {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn && self.control_handler_depth == 0 {
-                    if !self.warning_suppressed() {
-                        self.write_warn_to_stderr(&e.message);
-                    }
-                    if let Some(v) = e.return_value {
-                        self.stack.push(v);
-                    }
-                    ip += 1;
-                    continue;
-                }
                 self.sync_state_locals(code);
                 self.pop_once_scope();
                 // An uncaught CX::Return signal that escapes the top-level
@@ -671,16 +661,6 @@ impl Interpreter {
                     && let Some(target_ip) = self.find_label_target(code, label)
                 {
                     ip = target_ip;
-                    continue;
-                }
-                if e.is_warn && self.control_handler_depth == 0 {
-                    if !self.warning_suppressed() {
-                        self.write_warn_to_stderr(&e.message);
-                    }
-                    if let Some(v) = e.return_value {
-                        self.stack.push(v);
-                    }
-                    ip += 1;
                     continue;
                 }
                 self.sync_state_locals(code);
@@ -982,25 +962,8 @@ impl Interpreter {
                     ip = target_ip;
                     continue;
                 }
-                // Handle warn signals inline when no CONTROL handler is active.
-                if e.is_warn && self.control_handler_depth == 0 {
-                    if !self.warning_suppressed() {
-                        self.write_warn_to_stderr(&e.message);
-                    }
-                    if let Some(v) = e.return_value {
-                        self.stack.push(v);
-                    }
-                    // If a resume point was recorded for the original warn
-                    // site (e.g., when a CONTROL block rethrew the CX::Warn),
-                    // resume there so execution continues after the warn
-                    // rather than past whatever op propagated the signal.
-                    if let Some(resume_point) = self.resume_ip.take() {
-                        ip = resume_point;
-                    } else {
-                        ip += 1;
-                    }
-                    continue;
-                }
+                // Warns are handled at the per-op `exec_one` chokepoint, so a warn
+                // never reaches this loop's error arm; propagate anything else.
                 return Err(e);
             }
             if self.is_halted() {
@@ -1106,7 +1069,30 @@ impl Interpreter {
         }
     }
 
+    /// Execute the op at `*ip`. Wraps `exec_one_dispatch` so a resumable `warn`
+    /// raised by the op (directly, or by a builtin/closure it calls) is handled
+    /// inline in THIS frame — running the innermost installed `CONTROL` handler,
+    /// or printing — and execution resumes via this op's frame-correct resume
+    /// point. Handling at the single per-op chokepoint means every exec loop
+    /// (run loop, run_range, named-sub, method, closure, …) gets correct
+    /// cross-frame warn resumption without per-loop wiring. See
+    /// `handle_warn_inline`.
     fn exec_one(
+        &mut self,
+        code: &CompiledCode,
+        ip: &mut usize,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<(), RuntimeError> {
+        match self.exec_one_dispatch(code, ip, compiled_fns) {
+            Err(e) if e.is_warn => {
+                *ip = self.handle_warn_inline(&e, *ip + 1, compiled_fns)?;
+                Ok(())
+            }
+            other => other,
+        }
+    }
+
+    fn exec_one_dispatch(
         &mut self,
         code: &CompiledCode,
         ip: &mut usize,

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -54,6 +54,93 @@ impl Interpreter {
         }
     }
 
+    /// Handle a resumable `warn` (or any resumable control signal carrying a
+    /// CONTROL topic) *inline* in the current frame, running the innermost
+    /// installed CONTROL handler body if one is present, or printing to stderr if
+    /// not. Returns `Ok(Some(resume_ip))` when execution should continue (set
+    /// `ip = resume_ip`), or `Err` if the handler raised a non-resume error
+    /// (propagate). Always returns `Some` for a warn — a warn is always resumable.
+    ///
+    /// This is the key to resuming a warn raised *deep* in a callee: the warn is
+    /// caught and handled at the deepest frame's exec loop (where the raising op
+    /// recorded a frame-correct `resume_ip`), instead of unwinding to the block
+    /// that installed the handler — whose frame-relative `resume_ip` would point
+    /// into the wrong `CompiledCode`. The handler body reads/writes outer lexicals
+    /// by name through the (dynamic) env, so running it from the callee frame is
+    /// observationally identical to running it at the installing block.
+    pub(super) fn handle_warn_inline(
+        &mut self,
+        e: &RuntimeError,
+        fallback_ip: usize,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<usize, RuntimeError> {
+        // Run the innermost handler, if any (popped while running so a warn
+        // re-raised inside the handler is handled by an outer handler / printed,
+        // never re-entrant).
+        if let Some((code_ptr, cb, ce, frame_depth)) = self.control_handlers.last().copied() {
+            // SAFETY: see the `control_handlers` field doc — the installing block
+            // is an ancestor frame on the live Rust call stack.
+            let handler_code: &CompiledCode = unsafe { &*(code_ptr as *const CompiledCode) };
+            let saved_topic = self.env().get("_").cloned();
+            if let Some(topic) = Self::control_signal_topic_value(e) {
+                self.env_mut().insert("_".to_string(), topic);
+            }
+            let saved_stack = self.stack.len();
+            // The handler body's bytecode references the *installing* frame's
+            // local slots, not this (deeper) callee frame's. Temporarily swap the
+            // installing frame's saved locals into `self.locals` so slot accesses
+            // hit the right storage and the handler's mutations land where the
+            // installing frame will see them after this callee returns. (When the
+            // warn is in the installing frame itself, `frame_depth ==
+            // call_frames.len()` and no swap is needed.)
+            let swap_locals = frame_depth < self.call_frames.len();
+            if swap_locals {
+                std::mem::swap(&mut self.locals, &mut self.call_frames[frame_depth].saved_locals);
+            }
+            self.control_handlers.pop();
+            let dec = self.control_handler_depth > 0;
+            if dec {
+                self.control_handler_depth -= 1;
+            }
+            let handler_result = self.run_range(handler_code, cb, ce, compiled_fns);
+            if dec {
+                self.control_handler_depth += 1;
+            }
+            self.control_handlers.push((code_ptr, cb, ce, frame_depth));
+            if swap_locals {
+                std::mem::swap(&mut self.locals, &mut self.call_frames[frame_depth].saved_locals);
+            }
+            self.stack.truncate(saved_stack);
+            match saved_topic {
+                Some(v) => {
+                    self.env_mut().insert("_".to_string(), v);
+                }
+                None => {
+                    self.env_mut().remove("_");
+                }
+            }
+            match handler_result {
+                Ok(()) => {}
+                Err(ref c) if c.is_resume || c.is_succeed => {}
+                Err(c) if c.is_warn => {
+                    if !self.warning_suppressed() {
+                        self.write_warn_to_stderr(&c.message);
+                    }
+                }
+                Err(c) => return Err(c),
+            }
+        } else if !self.warning_suppressed() {
+            self.write_warn_to_stderr(&e.message);
+        }
+        // A resumable warn raised mid-expression (e.g. a Nil coercion) carries the
+        // value the suspended call should evaluate to; the stack already holds the
+        // surrounding operands, so push it so the call site sees a result.
+        if let Some(rv) = e.return_value.clone() {
+            self.stack.push(rv);
+        }
+        Ok(self.resume_ip.take().unwrap_or(fallback_ip))
+    }
+
     fn control_signal_topic_value(signal: &RuntimeError) -> Option<Value> {
         // User-defined classes doing X::Control carry their original
         // exception instance. Surface it directly so CONTROL blocks see the
@@ -3098,6 +3185,12 @@ impl Interpreter {
         let has_control = control_begin < end;
         if has_control {
             self.control_handler_depth += 1;
+            self.control_handlers.push((
+                code as *const CompiledCode as usize,
+                control_begin,
+                end,
+                self.call_frames.len(),
+            ));
         }
         // Guard the protected body with a panic->X:: boundary so an internal
         // Rust panic (overflow/OOB/unwrap) raised anywhere inside it becomes a
@@ -3105,6 +3198,7 @@ impl Interpreter {
         let body_result = self.run_range_guarded(code, body_start, catch_begin, compiled_fns);
         if has_control {
             self.control_handler_depth -= 1;
+            self.control_handlers.pop();
         }
         match body_result {
             Ok(()) => {
@@ -3266,11 +3360,18 @@ impl Interpreter {
                             }
                             if has_control {
                                 self.control_handler_depth += 1;
+                                self.control_handlers.push((
+                                    code as *const CompiledCode as usize,
+                                    control_begin,
+                                    end,
+                                    self.call_frames.len(),
+                                ));
                             }
                             let body_result =
                                 self.run_range(code, resume_point, catch_begin, compiled_fns);
                             if has_control {
                                 self.control_handler_depth -= 1;
+                                self.control_handlers.pop();
                             }
                             match body_result {
                                 Ok(()) => {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -95,7 +95,10 @@ impl Interpreter {
             // call_frames.len()` and no swap is needed.)
             let swap_locals = frame_depth < self.call_frames.len();
             if swap_locals {
-                std::mem::swap(&mut self.locals, &mut self.call_frames[frame_depth].saved_locals);
+                std::mem::swap(
+                    &mut self.locals,
+                    &mut self.call_frames[frame_depth].saved_locals,
+                );
             }
             self.control_handlers.pop();
             let dec = self.control_handler_depth > 0;
@@ -108,7 +111,10 @@ impl Interpreter {
             }
             self.control_handlers.push((code_ptr, cb, ce, frame_depth));
             if swap_locals {
-                std::mem::swap(&mut self.locals, &mut self.call_frames[frame_depth].saved_locals);
+                std::mem::swap(
+                    &mut self.locals,
+                    &mut self.call_frames[frame_depth].saved_locals,
+                );
             }
             self.stack.truncate(saved_stack);
             match saved_topic {

--- a/t/warn-deep-resume-under-control.t
+++ b/t/warn-deep-resume-under-control.t
@@ -1,0 +1,49 @@
+use Test;
+
+# A resumable `warn` raised *deep* inside a chain of nested calls must let an
+# enclosing `CONTROL {}` `.resume` so the deep call CONTINUES. Previously the
+# warn unwound to the installing block, whose frame-relative resume point pointed
+# into the wrong code, crashing with "No such method 'CALL-ME'..." or silently
+# truncating. The handler now runs inline in the warn's still-live frame.
+# (Template::Mustache logs warnings this way: render -> ... -> &warn.().)
+
+plan 6;
+
+# --- warn one level deep, resumed; caller continues to a 2nd warn ---
+{
+    my @seen;
+    CONTROL { default { @seen.push(.message); .resume; } }
+    sub emit { warn "a"; warn "b"; "done" }
+    my $r = emit();
+    is @seen.join(','), 'a,b', 'both warns from a called sub are caught';
+    is $r, 'done', 'the called sub runs to completion after resuming';
+}
+
+# --- warn two levels deep ---
+{
+    my @seen;
+    CONTROL { default { @seen.push(.message); .resume; } }
+    sub inner { warn "deep"; 42 }
+    sub outer { my $x = inner(); $x + 1 }
+    my $r = outer();
+    is @seen.join(','), 'deep', 'a warn two calls deep is caught';
+    is $r, 43, 'both frames continue after the deep warn resumes';
+}
+
+# --- warn via an indirect &warn.() deep in a sub ---
+{
+    my @seen;
+    CONTROL { default { @seen.push(.message); .resume; } }
+    sub logit($w, $msg) { $w.($msg) }
+    my $w = &warn;
+    logit($w, "x");
+    logit($w, "y");
+    is @seen.join(','), 'x,y', 'indirect &warn.() deep in a sub resumes';
+}
+
+# --- a deep warn with NO CONTROL just prints and the call still completes ---
+{
+    sub noisy { warn "ignored"; "ok" }
+    # No CONTROL here: the warn prints to stderr (not captured) but must not crash.
+    is noisy(), 'ok', 'an uncaught deep warn does not abort the calling sub';
+}


### PR DESCRIPTION
## Summary

A resumable `warn` raised **deep** in a chain of calls (e.g. `render → format → get → Logger.log → &warn.()`) could not be resumed by an enclosing `CONTROL {}`: the signal unwound to the installing block, whose frame-relative `resume_ip` pointed into the **callee's** `CompiledCode`, so resuming executed garbage and crashed (`No such method 'CALL-ME' for invocant of type 'Any'`) or silently truncated the computation.

```raku
my @seen;
CONTROL { default { @seen.push(.message); .resume } }
sub inner { warn "deep"; 42 }
sub outer { inner() + 1 }
outer();         # was: crash/abort   now: @seen=["deep"], outer() == 43
```

## Fix

Handle a resumable warn **inline at the per-op chokepoint** (`exec_one`, which every exec loop already routes through), in the deepest still-live frame where the op recorded a frame-correct `resume_ip`:

- New `Interpreter::control_handlers` stack mirrors `control_handler_depth`; each entry records the installing block's `CompiledCode` pointer, its CONTROL body range, and `call_frames.len()` at install time.
- `handle_warn_inline` runs the innermost handler body (or prints, when none) and returns the resume ip. Crucially it temporarily **swaps the installing frame's locals** (`call_frames[frame_depth].saved_locals`) into `self.locals` so the handler's bytecode addresses the right local slots and its mutations land where the installing frame sees them after the callee returns. Outer lexicals reached by name go through the (dynamic, shared) env and need no swap.
- `exec_one` now wraps `exec_one_dispatch`: a warn from the op is handled inline here, so every exec loop (run loop, `run_range`, named-sub, method, closure, …) gets correct cross-frame resumption with no per-loop wiring.

**SAFETY:** the installing block's `CompiledCode` is an ancestor frame on the live Rust call stack while its `control_handlers` entry exists, so the raw pointer never dangles.

## Impact

- **Template::Mustache** `render(:log-level<Warn>)` no longer crashes on a missing field (`06-logging` 0 → 2 of 3); stops the cross-frame-warn crash in `12-inheritence`/`13-pragmas`/`50-readme` (they now fail cleanly on their *own* remaining features instead of aborting).

## Test

`t/warn-deep-resume-under-control.t` — 6 cases (warn 1/2 levels deep, indirect `&warn.()`, uncaught deep warn), spec-validated against `raku`. `make test` green (9702 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)