### PR TITLE
fix(builtins): slurpy builtins (&warn, &note, &say, …) report arity 0

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -516,8 +516,24 @@ impl Interpreter {
                     let params = (0..arity).map(|i| format!("arg{}", i)).collect();
                     return (params, Vec::new());
                 }
-                // Well-known 0-arity terms should report as having no parameters
-                if matches!(name.resolve().as_ref(), "rand" | "now" | "time") {
+                // Well-known 0-arity terms, and slurpy (`*@args`) builtins whose
+                // required-positional arity is 0, should report no parameters
+                // (raku: `&warn.arity == 0`). Mustache's logger keys on
+                // `&warn.?arity == 2`, so a spurious arity of 1 sent it down the
+                // wrong (2-arg) branch.
+                if matches!(
+                    name.resolve().as_ref(),
+                    "rand"
+                        | "now"
+                        | "time"
+                        | "warn"
+                        | "note"
+                        | "say"
+                        | "print"
+                        | "put"
+                        | "die"
+                        | "fail"
+                ) {
                     return (Vec::new(), Vec::new());
                 }
                 (vec!["arg0".to_string()], Vec::new())

--- a/t/slurpy-builtin-arity.t
+++ b/t/slurpy-builtin-arity.t
@@ -1,0 +1,23 @@
+use Test;
+
+# A `&name` reference to a slurpy (`*@args`) builtin reports arity 0, matching
+# raku — `&warn`, `&note`, `&say`, ... take no *required* positionals. mutsu
+# previously defaulted an unknown builtin Routine to one positional (arity 1),
+# which sent Template::Mustache's logger — keyed on `&warn.?arity == 2` via
+# `.?arity // 0 == 2` — down the wrong branch.
+
+plan 7;
+
+is &warn.arity,  0, '&warn.arity is 0';
+is &note.arity,  0, '&note.arity is 0';
+is &say.arity,   0, '&say.arity is 0';
+is &print.arity, 0, '&print.arity is 0';
+is &put.arity,   0, '&put.arity is 0';
+
+# `.?arity // 0 == 2` (the Mustache logger guard) must be false for &warn so it
+# takes the formatted-message branch, not the 2-arg one. (`==` binds tighter than
+# `//`, so this is `&warn.?arity // (0 == 2)` = `0 // False` = 0 = falsy.)
+nok (&warn.?arity // 0 == 2), 'the Mustache &warn.?arity guard is false';
+
+# A genuinely 1-ary builtin still reports its arity.
+is &chr.arity,   1, '&chr.arity is 1 (single required positional)';


### PR DESCRIPTION
## Summary

A `&name` reference to a builtin with no resolvable user definition fell through `callable_signature` to a default of **one** positional, so `&warn.arity` was `1` instead of raku's `0`.

Template::Mustache's logger keys on `&warn.?arity == 2` (written `.?arity // 0 == 2`; `==` binds tighter than `//`, so it is `arity // (0 == 2)` = `arity // False`): with arity `1` that is `1` (truthy) and the logger took the wrong 2-arg branch, mangling warning output; with the correct arity `0` it is `0` (falsy) and the formatted-message branch runs.

## Fix

Report the slurpy (`*@args`) output/control builtins — `warn`, `note`, `say`, `print`, `put`, `die`, `fail` — as 0-arity (no required positionals), alongside the existing `rand`/`now`/`time` terms.

## Test

`t/slurpy-builtin-arity.t` — 7 cases (`&warn`/`&note`/`&say`/`&print`/`&put` = 0, the Mustache `.?arity` guard, `&chr` = 1), spec-validated against `raku`. `make test` green (9702 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)