### PR TITLE
feat(single-store): X-cross metaop thunk captured-outer scalar writeback (Sub-slice 1b slice 1.9)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -1,9 +1,10 @@
 # Captured-outer lexical cell 共有 — 実装プラン（Sub-slice 1b+ / env_dirty 削除への substrate）
 
-> **Status:** SLICE 1〜1.8 DONE（〜2026-06-21・第41〜43セッション）。§6 第1スライス（named-sub 捕捉
-> scalar decl-site cell 化）＋§7.1〜7.1d（metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／
-> **captured-outer container `@`/`%` cell 化＝§7.1d**）を実装。各 pin が **blanket reconcile ON/OFF 両方で PASS**。
-> OFF survey は 17 file（うち並行 ~13）。次＝§7.2（cross-metaops scalar metaop-thunk／nested-method capture）。
+> **Status:** SLICE 1〜1.9 DONE（〜2026-06-21・第41〜43セッション）。§6 第1スライス（named-sub 捕捉
+> scalar decl-site cell 化）＋§7.1〜7.1e（metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／
+> **captured-outer container `@`/`%` cell 化＝§7.1d**／**`X`-cross metaop thunk scalar writeback＝§7.1e**）を実装。
+> 各 pin が **blanket reconcile ON/OFF 両方で PASS**。OFF survey は 16 file（うち並行 ~13）。
+> 次＝§7.2（nested-method capture／parametric-role-of-type／並行 cluster）。
 > 関連: [docs/env-locals-coherence.md](env-locals-coherence.md)（§7.3 = env_dirty 削除の壁）/
 > [docs/container-identity.md](container-identity.md)（cell インフラ）/ PLAN.md §1-A・§2-C・§2-E。
 >
@@ -286,13 +287,23 @@ slot-restore も同一 cell を保つ。
 - pin=`t/captured-outer-container-cell-sharing.t`（9・trait_mod push/hash-elem・named-sub accumulation・ON/OFF 両 PASS）。
   OFF survey 17 file（attribute-trait-mod の 5 fail 解消）。
 
+### 7.1e ✅ スライス1.9（DONE・第43セッション）= `X`-cross metaop thunk の captured-outer scalar write（`cross-metaops` subtest 2）
+
+`Nil Xorelse ($t = $_,)`（`X` cross meta over short-circuit op）は右辺を `__mutsu_cross_shortcircuit("orelse", Nil,
+AnonSub{$t=$_})` の **immediately-invoked thunk** にコンパイルする。call arg として渡される closure は escape 解析が
+non-escaping 扱い→`box_captured_lexicals` が box しない→thunk の captured-outer write（`$t`）が OFF で caller slot に
+届かない。**cell 化でなく precise-writeback で解決**（slice 1.6 の lazy-map/gather/subst と同型）: `builtin_cross_shortcircuit`
+が thunk 実行後（`thunk_ran` 時のみ）に thunk の `compiled_code.free_var_writes` を `record_eager_block_free_var_writeback`
+で `pending_rw_writeback_sources` に積む→`__mutsu_cross_shortcircuit` の call-site が既存 `apply_pending_rw_writeback` で
+drain。**非gated（ON/OFF 両対応・reconcile と idempotent）**。pin=`t/cross-metaop-thunk-captured-writeback-coherence.t`
+（6・Xorelse/Xandthen/Xor・ON/OFF 両 PASS）。make test 回帰なし。OFF survey 17→16。
+**注意（範囲外の別バグ）**: ①`(1,2,3) Xandthen (...)` の list 反復 count（raku=3・mutsu=2）は cross_shortcircuit ループの
+別バグ（ON でも fail・captured-write 無関係）。②`$x + 1`（`$x=11` 後）が 2 を返すパーサ quirk も別件。両方とも本スライス対象外。
+
 ### 7.2 後続スライス（その先）
 
 - **nested-method capture**（`methods-instance` subtest 3 = `method foo { my $a; method bar { $tracker = $a } }`）:
   EVAL でない multi-frame captured-write（nested method 宣言が enclosing method の lexical 捕捉）。別機構の調査要。
-- **top-level captured-outer scalar**（`cross-metaops` subtest 2 = `my Mu $t; Nil Xorelse ($t = $_,)`）: env 常駐の
-  top-level scalar を metaop thunk（immediately-invoked＝escape 解析が見ない）が捕捉。`box_captured_lexicals` は escaping
-  closure の local slot を box するので未到達。precise-writeback（Xorelse の metaop call-site で drain）か box 化のいずれか。
 - **`parametric-role-of-type`**（OFF で決定的 abort・ran 11/14）: ON で PASS。captured-outer の別サーフェス（要調査）。
 - **container `@`/`%` の named-sub 以外の cell 化**（必要なら）: closure 捕捉 container は現状 Arc 共有で動く。`box_captured_lexicals`
   の `@`/`%` skip を緩和する場合は §8 の decont 監査が前提（broad boxing は ~12 file 回帰を実証済＝precise 限定必須）。

--- a/src/runtime/builtins_feed.rs
+++ b/src/runtime/builtins_feed.rs
@@ -171,6 +171,7 @@ impl Interpreter {
         };
         let thunk = args[2].clone();
         let mut out = Vec::new();
+        let mut thunk_ran = false;
         for left in left_values {
             let needs_rhs = match op.as_str() {
                 "and" | "&&" => left.truthy(),
@@ -183,6 +184,7 @@ impl Interpreter {
                 out.push(left);
                 continue;
             }
+            thunk_ran = true;
             let rhs_value = if op == "andthen" || op == "orelse" {
                 let saved_topic = self.env.get("_").cloned();
                 self.env.insert("_".to_string(), left.clone());
@@ -203,6 +205,19 @@ impl Interpreter {
             for rhs in rhs_values {
                 out.push(rhs);
             }
+        }
+        // The thunk (`X` short-circuit RHS, e.g. `Nil Xorelse ($t = $_,)`) is an
+        // immediately-invoked closure, so escape analysis never boxes the outer
+        // lexicals it captures-and-writes. Record its captured-outer writes so the
+        // enclosing `__mutsu_cross_shortcircuit` call site drains them back into
+        // the caller's locals (mirrors the lazy-map / gather / subst carriers,
+        // slice 1.6) — without this they are lost once the blanket reconcile is
+        // removed (docs/captured-outer-cell-sharing.md §7.2).
+        if thunk_ran
+            && let Value::Sub(ref data) = thunk
+            && let Some(code) = data.compiled_code.clone()
+        {
+            self.record_eager_block_free_var_writeback(&code, &data.params);
         }
         Ok(Value::array(out))
     }

--- a/t/cross-metaop-thunk-captured-writeback-coherence.t
+++ b/t/cross-metaop-thunk-captured-writeback-coherence.t
@@ -1,0 +1,50 @@
+use Test;
+
+# An `X` cross meta-operator over a short-circuit op (`Xorelse` / `Xandthen` /
+# `Xand` / `Xor`) compiles its right operand to an immediately-invoked thunk
+# (`__mutsu_cross_shortcircuit`). Escape analysis never boxes the outer lexicals
+# that thunk captures-and-writes, so without recording the thunk's captured-outer
+# writes at the call site they are lost once the blanket reconcile is removed
+# (`MUTSU_NO_BLANKET_RECONCILE=1`). Verify the captured write is coherent under
+# BOTH builds.
+
+plan 6;
+
+{
+    my Mu $topic is default(Nil) = 0;
+    Nil Xorelse ($topic = $_,);
+    ok $topic === Nil, 'Xorelse thunk writes captured outer Mu scalar (Nil topic)';
+}
+
+{
+    my $seen = 0;
+    Nil Xorelse ($seen = 42,);
+    is $seen, 42, 'Xorelse thunk write reaches caller slot';
+}
+
+{
+    my $seen = 0;
+    1 Xandthen ($seen = 7,);
+    is $seen, 7, 'Xandthen thunk write reaches caller slot';
+}
+
+{
+    # Captured-outer write through the thunk then re-read after another call
+    # (`ok`'s env save/restore would clobber a stale slot without the writeback).
+    my $stored = 0;
+    Nil Xorelse ($stored = 11,);
+    my $probe = "force a call";   # intervening statement
+    is $stored, 11, 'captured-outer thunk write survives a later read';
+}
+
+{
+    my $hit = 0;
+    0 Xor ($hit = 99,);
+    is $hit, 99, 'Xor thunk write reaches caller slot when left is falsy';
+}
+
+{
+    my $untouched = 5;
+    1 Xor ($untouched = 99,);
+    is $untouched, 5, 'Xor thunk does not run when left is truthy (no spurious write)';
+}


### PR DESCRIPTION
## Summary

Continues the env↔locals captured-outer coherence substrate (the §2-C / §2-E prerequisite for `env_dirty` removal). An `X` cross meta-operator over a short-circuit op evaluates its right operand as an immediately-invoked thunk; the thunk's captured-outer write was lost under the cell-boxing build.

```raku
my Mu $t;
Nil Xorelse ($t = $_,);   # $t should become Nil
```

`Nil Xorelse (...)` compiles to `__mutsu_cross_shortcircuit("orelse", Nil, AnonSub{$t = $_})`. A closure passed as a **call argument** is non-escaping, so escape analysis never boxes `$t`, and its write was lost under `MUTSU_NO_BLANKET_RECONCILE=1` (`t/cross-metaops-regressions.t` subtest 2).

## Fix

Precise writeback (same mechanism as the lazy-map / gather / subst carriers, **not** cell boxing): `builtin_cross_shortcircuit` records the thunk's `compiled_code.free_var_writes` into `pending_rw_writeback_sources` after running it (guarded by `thunk_ran`), so the enclosing `__mutsu_cross_shortcircuit` call site drains them into the caller's locals via the existing `apply_pending_rw_writeback`. Unconditional — works under both builds, idempotent with the blanket reconcile.

## Result

- OFF survey **17 → 16**.
- pin `t/cross-metaop-thunk-captured-writeback-coherence.t` (6, Xorelse/Xandthen/Xor) passes under **both** toggle states.
- `make test` **9711 PASS**, no regressions.

Design: `docs/captured-outer-cell-sharing.md` §7.1e.

### Out of scope (separate pre-existing bugs — fail under the default build too)
- `(1, 2, 3) Xandthen (...)` list-iteration count (raku=3, mutsu=2) — a cross_shortcircuit loop bug, unrelated to captured writes.
- a `$x + 1` parser quirk after a prior write.

Both noted in §7.1e for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)