### PR TITLE
docs: record captured-outer cell-sharing progress (slices 1.8/1.9) + remaining surface

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -88,13 +88,15 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 - [ ] **Phase 2 Stage 2 slice 5（最終 SlotRef キル）**: 残る `HashSlotRef`/`DeferredHashAccess` 生成サイト
       （junction-bind / `is raw` reduce lvalue-read の autoviv）を cell 化し、variant を削除。
 - [ ] **grep-rw-view 撤去**: 最後の ptr-keyed グローバル。matched 要素を cell 昇格し view registry を全廃。
-- [ ] **★env↔locals cell 共有 — captured-outer cell 化（A の律速・最重要）**: nested callee（closure **だけでなく**
+- [~] **★env↔locals cell 共有 — captured-outer cell 化（A の律速・最重要）**: nested callee（closure **だけでなく**
       named sub）に捕捉＋変異される lexical を、owner の local slot と env エントリの両方で**同一 `ContainerRef` cell**
-      にする（escape-aware・裸ローカルは従来の Arc 共有で perf 崖回避）。**実装プラン確定済＝
-      [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md)**（配管は全て既存・`:=` bind が
-      precedent・欠落は「検出＋ボックス化」だけ）。**第1スライス＝named-sub 捕捉 scalar（`$acc` の multi-frame 壁）**、
-      スライス2＝捕捉 container `@`/`%`。`:=` bind container/scalar 共有は既に done。
-      **これが入ると env↔locals が乖離しなくなり、§1-A の単一ストア化（env_dirty 削除）が解禁される。**
+      にする（escape-aware・裸ローカルは従来の Arc 共有で perf 崖回避）。台帳＝
+      [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md)。**slice 1〜1.9 landed**（named-sub 捕捉
+      scalar／metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／**captured-outer container `@`/`%` cell 化**／
+      **X-cross metaop thunk scalar writeback**）。OFF survey 16 file まで縮小。**残り**：①並行 cluster ~13（cross-thread
+      cell・最難・最後）②instance-attr コヒーレンス（`parametric-role-of-type`＝Phase 3 cell 領域・別機構）③multi-frame
+      nested-method capture（`methods-instance`）。`:=` bind container/scalar 共有・closure captured scalar は既に done。
+      **これが完了すると env↔locals が乖離しなくなり、§1-A の単一ストア化（env_dirty 削除）が解禁される。**
 - [ ] follow-up（pre-existing・小）: `$x = @arr` 共有の method param 版（`method m($n){ $n.push }`）・`is copy` $-param。
       設計＝[docs/scalar-array-sharing.md](docs/scalar-array-sharing.md) §5。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -304,7 +304,12 @@ drain。**非gated（ON/OFF 両対応・reconcile と idempotent）**。pin=`t/c
 
 - **nested-method capture**（`methods-instance` subtest 3 = `method foo { my $a; method bar { $tracker = $a } }`）:
   EVAL でない multi-frame captured-write（nested method 宣言が enclosing method の lexical 捕捉）。別機構の調査要。
-- **`parametric-role-of-type`**（OFF で決定的 abort・ran 11/14）: ON で PASS。captured-outer の別サーフェス（要調査）。
+- **`parametric-role-of-type`**（OFF で決定的 abort・ran 11/14・test 12）: ON で PASS。**captured-outer ではなく
+  インスタンス属性コヒーレンス**＝`my role TreeNode[::T] does Positional { has TreeNode[T] @!children handles
+  <AT-POS ASSIGN-POS BIND-POS>; has T $.data is rw }` で `$tree[0] = TreeNode.new`（ASSIGN-POS handles 経由で `@!children`
+  へ書込）後に `$tree[0]`（AT-POS）が **non-instance** を返し `$tree[0].data = 1` が `X::Assignment::RO` で abort。
+  typed array インスタンス属性の in-place mutation が OFF で persist しない＝Phase 3 instance-attr cell の別サーフェス
+  （`mirror_attr_local_to_cell`／`read_self_attr_cell` 周辺）。captured-outer cell 共有とは独立機構＝別スライス。
 - **container `@`/`%` の named-sub 以外の cell 化**（必要なら）: closure 捕捉 container は現状 Arc 共有で動く。`box_captured_lexicals`
   の `@`/`%` skip を緩和する場合は §8 の decont 監査が前提（broad boxing は ~12 file 回帰を実証済＝precise 限定必須）。
 - **並行 cluster**（supply/whenever/react/promise/proc-async/scheduler ~13）: cross-thread cell（最難・最後）。


### PR DESCRIPTION
Docs-only follow-up to #3371 (captured-outer container `@`/`%` cell sharing) and #3374 (X-cross metaop thunk scalar writeback).

- **`docs/captured-outer-cell-sharing.md`**: status header + §7.1d/§7.1e for the two landed slices, and characterize the remaining `parametric-role-of-type` OFF abort as an **instance-attribute (Phase 3 cell) coherence** issue — distinct from captured-outer cell sharing (a typed `@!children` ASSIGN-POS write does not persist under `MUTSU_NO_BLANKET_RECONCILE=1`, so `$tree[0]` reads a non-instance and `$tree[0].data = …` aborts with `X::Assignment::RO`).
- **`PLAN.md` §2-C**: mark the substrate in-progress (slices 1–1.9 done, OFF survey down to 16 files) and enumerate the remaining surface: concurrent cluster ~13 (cross-thread cell, hardest/last), instance-attr coherence, multi-frame nested-method capture.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)