### PR TITLE
feat(single-store): nested-method captured-outer scalar writeback (Sub-slice 1b slice 1.10)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -1,10 +1,11 @@
 # Captured-outer lexical cell 共有 — 実装プラン（Sub-slice 1b+ / env_dirty 削除への substrate）
 
-> **Status:** SLICE 1〜1.9 DONE（〜2026-06-21・第41〜43セッション）。§6 第1スライス（named-sub 捕捉
-> scalar decl-site cell 化）＋§7.1〜7.1e（metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／
-> **captured-outer container `@`/`%` cell 化＝§7.1d**／**`X`-cross metaop thunk scalar writeback＝§7.1e**）を実装。
-> 各 pin が **blanket reconcile ON/OFF 両方で PASS**。OFF survey は 16 file（うち並行 ~13）。
-> 次＝§7.2（nested-method capture／parametric-role-of-type／並行 cluster）。
+> **Status:** SLICE 1〜1.10 DONE（〜2026-06-21・第41〜44セッション）。§6 第1スライス（named-sub 捕捉
+> scalar decl-site cell 化）＋§7.1〜7.1f（metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／
+> **captured-outer container `@`/`%` cell 化＝§7.1d**／**`X`-cross metaop thunk scalar writeback＝§7.1e**／
+> **nested-method capture＝§7.1f**）を実装。
+> 各 pin が **blanket reconcile ON/OFF 両方で PASS**。OFF survey は 15 file（うち並行 ~13）。
+> 次＝§7.2（parametric-role-of-type＝instance-attr 別機構／並行 cluster）。
 > 関連: [docs/env-locals-coherence.md](env-locals-coherence.md)（§7.3 = env_dirty 削除の壁）/
 > [docs/container-identity.md](container-identity.md)（cell インフラ）/ PLAN.md §1-A・§2-C・§2-E。
 >
@@ -300,10 +301,31 @@ drain。**非gated（ON/OFF 両対応・reconcile と idempotent）**。pin=`t/c
 **注意（範囲外の別バグ）**: ①`(1,2,3) Xandthen (...)` の list 反復 count（raku=3・mutsu=2）は cross_shortcircuit ループの
 別バグ（ON でも fail・captured-write 無関係）。②`$x + 1`（`$x=11` 後）が 2 を返すパーサ quirk も別件。両方とも本スライス対象外。
 
-### 7.2 後続スライス（その先）
+### 7.1f ✅ スライス1.10（DONE・第44セッション）= nested-method capture（`methods-instance` subtest 3）
 
-- **nested-method capture**（`methods-instance` subtest 3 = `method foo { my $a; method bar { $tracker = $a } }`）:
-  EVAL でない multi-frame captured-write（nested method 宣言が enclosing method の lexical 捕捉）。別機構の調査要。
+`method foo { my $a = 42; method bar { $tracker = $a } }` の **method body 内で宣言された method** `bar` を
+`.foo` 後に `.bar` で呼ぶケース。`bar` の captured-outer write（`$tracker`）が OFF で caller slot に届かず stale。
+**真因＝dispatch path**: nested-declared method は foo 実行時に RegisterSub で **captured env 付き `&bar` sub** として登録され、
+`$d.bar` は compiled method merge path（`call_compiled_method` / `merge_method_env`）でも closure dispatch
+（`call_compiled_closure_with_topic`）でもなく、slow path `call_method_with_values` → **`call_sub_value(merge_all=true)`**
+（tree-walk）を通る。`call_sub_value` は captured-outer scalar write を `merged`（caller env）へ正しくマージするが、
+**caller の local slot を refresh しない**＝blanket reconcile ON 時のみ slot が env から pull される。
+（class-level method の `$Foo++` は compiled path = #3322 の `merge_method_env` `changed_caller_locals` 記録で OFF も成立済。
+gap は nested-declared method の interpreter dispatch path だけ）。
+
+- **修正（precise-writeback・非gated）**: ①`call_sub_value`（resolution.rs）の merge ループで、body-entry snapshot
+  （`body_entry_env`）から **変化した captured-outer scalar**（Bool/Int/Num/Str/Rat・caller env に存在）を収集し
+  `pending_rw_writeback_sources` に push（merge_all / non-merge_all 両 branch・既存の precise scalar-changed 条件と同型）。
+  ②CallMethod op（vm_call_method_ops.rs）の call-site tail を `blanket_reconcile_if_dirty(code)` →
+  `drain_and_reconcile_after_cached_call(code)`（= `apply_pending_rw_writeback` + blanket）に変更。**この op は従来
+  pending を drain しておらず**（`merge_method_env` のコメント「CallMethod op が slot へ書き戻す」が示す意図に実装が
+  追いついていなかった＝latent gap も同時に解消）。ON では blanket が superset なので byte-identical、OFF では
+  precise drain のみが効く。
+- pin=`t/nested-method-captured-writeback-coherence.t`（9・given/topic・explicit invocant・RMW 累積・+=・string・
+  enclosing lexical read＋outer write・複数 outer・後続式コヒーレンス・intervening call・ON/OFF 両 PASS）。
+  make test 9727 / make roast 回帰なし。OFF survey 16→15（並行 ~13 残）。
+
+### 7.2 後続スライス（その先）
 - **`parametric-role-of-type`**（OFF で決定的 abort・ran 11/14・test 12）: ON で PASS。**captured-outer ではなく
   インスタンス属性コヒーレンス**＝`my role TreeNode[::T] does Positional { has TreeNode[T] @!children handles
   <AT-POS ASSIGN-POS BIND-POS>; has T $.data is rw }` で `$tree[0] = TreeNode.new`（ASSIGN-POS handles 経由で `@!children`

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1518,12 +1518,37 @@ impl Interpreter {
             let rw_map_topic = self.env.get("__mutsu_rw_map_topic__").cloned();
             let mut merged = saved_env;
             self.pop_caller_env_with_writeback(&mut merged);
+            // Slice 1b (captured-outer cell sharing): a nested-declared method/sub
+            // dispatched through `call_sub_value` (`$d.bar` where `method bar { … }`
+            // was declared in `foo`'s body) runs its body via the interpreter and
+            // merges a captured-outer scalar write back into `merged` (the caller
+            // env) below. But the caller's matching *local slot* is not refreshed
+            // from env unless the blanket reconcile is on. Record each captured-outer
+            // scalar this body actually *changed* (vs its body-entry snapshot) so the
+            // call site (`apply_pending_rw_writeback`) writes the merged value straight
+            // through to the caller's slot, dropping the dependency on the reverse
+            // `sync_locals_from_env` pull. Mirrors `merge_method_env`'s
+            // `changed_caller_locals` for the compiled method path.
+            let mut captured_outer_writes: Vec<String> = Vec::new();
             if merge_all {
                 for (k, v) in self.env.iter() {
                     if k != "_"
                         && k != "@_"
                         && (merged.contains_key_sym(*k) || k.starts_with("__mutsu_var_meta::"))
                     {
+                        if merged.contains_key_sym(*k)
+                            && matches!(
+                                v,
+                                Value::Bool(_)
+                                    | Value::Int(_)
+                                    | Value::Num(_)
+                                    | Value::Str(_)
+                                    | Value::Rat(_, _)
+                            )
+                            && body_entry_env.get_sym(*k) != Some(v)
+                        {
+                            captured_outer_writes.push(k.resolve().to_string());
+                        }
                         merged.insert_sym(*k, v.clone());
                     }
                 }
@@ -1559,10 +1584,15 @@ impl Interpreter {
                         // a mutation, and must not clobber the caller's live value.
                         && body_entry_env.get_sym(*k) != Some(v)
                     {
+                        captured_outer_writes.push(k.resolve().to_string());
                         merged.insert_sym(*k, v.clone());
                     }
                 }
             }
+            // Record the captured-outer scalar writes for precise caller-slot
+            // write-back (drained by the call-site `apply_pending_rw_writeback`).
+            self.pending_rw_writeback_sources
+                .extend(captured_outer_writes);
             self.merge_sigilless_alias_writes(&mut merged, &self.env);
             // Apply rw bindings after merge so they take precedence
             self.apply_rw_bindings_to_env(&rw_bindings, &mut merged);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1316,7 +1316,13 @@ impl Interpreter {
                 // the barrier would have pulled — so this is byte-identical to the
                 // barrier under reverse-sync ON; a pure method call (env not
                 // dirtied) pays nothing.
-                self.blanket_reconcile_if_dirty(code);
+                //
+                // Slice 1b: a nested-declared method dispatched through the
+                // interpreter (`call_sub_value`) records the captured-outer scalars
+                // it changed in `pending_rw_writeback_sources`; drain them straight
+                // to the caller's local slots (precise, reverse-sync-independent)
+                // before the env_dirty-gated blanket reconcile.
+                self.drain_and_reconcile_after_cached_call(code);
                 // Wrap map/grep results back into HyperSeq/RaceSeq
                 if let Some(is_hyper) = hyper_race_wrap
                     && let Some(result) = self.stack.pop()

--- a/t/nested-method-captured-writeback-coherence.t
+++ b/t/nested-method-captured-writeback-coherence.t
@@ -1,0 +1,147 @@
+use Test;
+
+# Slice 1b (env<->locals coherence): a `method` declared inside another method's
+# body captures an outer lexical and writes it when later called. The nested method
+# is dispatched through the interpreter `call_sub_value` path (not the compiled
+# method merge path), so its captured-outer write must reconcile the caller's local
+# slot via the precise `pending_rw_writeback_sources` drain — independent of the
+# blanket reverse-sync pull. Each subtest must hold both with the blanket reconcile
+# ON (default) and OFF (`MUTSU_NO_BLANKET_RECONCILE=1`).
+
+plan 9;
+
+# 1. Basic captured-outer scalar write via a nested method.
+{
+    my $tracker;
+    class A1 {
+        method foo {
+            my $a = 42;
+            method bar { $tracker = $a }
+        }
+    }
+    given A1.new {
+        .foo;
+        .bar;
+    }
+    is $tracker, 42, 'nested method writes captured outer lexical (via given/topic)';
+}
+
+# 2. Explicit invocant call form.
+{
+    my $tracker;
+    class A2 {
+        method foo {
+            method bar { $tracker = 77 }
+        }
+    }
+    my $o = A2.new;
+    $o.foo;
+    $o.bar;
+    is $tracker, 77, 'nested method writes captured outer (explicit invocant)';
+}
+
+# 3. Read-modify-write accumulation across repeated calls.
+{
+    my $count = 0;
+    class A3 {
+        method install {
+            method tick { $count++ }
+        }
+    }
+    my $o = A3.new;
+    $o.install;
+    $o.tick;
+    $o.tick;
+    $o.tick;
+    is $count, 3, 'nested method RMW accumulates across calls';
+}
+
+# 4. += compound assignment to captured outer.
+{
+    my $sum = 10;
+    class A4 {
+        method setup {
+            method add5 { $sum += 5 }
+        }
+    }
+    my $o = A4.new;
+    $o.setup;
+    $o.add5;
+    $o.add5;
+    is $sum, 20, 'nested method += accumulates';
+}
+
+# 5. Captured outer string write.
+{
+    my $name = 'init';
+    class A5 {
+        method setup {
+            method rename { $name = 'changed' }
+        }
+    }
+    my $o = A5.new;
+    $o.setup;
+    $o.rename;
+    is $name, 'changed', 'nested method writes captured outer string';
+}
+
+# 6. Both: nested method reads an enclosing-method lexical and writes an outer one.
+{
+    my $out;
+    class A6 {
+        method foo {
+            my $secret = 99;
+            method reveal { $out = $secret }
+        }
+    }
+    my $o = A6.new;
+    $o.foo;
+    $o.reveal;
+    is $out, 99, 'nested method reads enclosing lexical, writes outer';
+}
+
+# 7. Multiple captured-outer scalars written in one nested method.
+{
+    my $x = 0;
+    my $y = 0;
+    class A7 {
+        method setup {
+            method bump { $x = 1; $y = 2 }
+        }
+    }
+    my $o = A7.new;
+    $o.setup;
+    $o.bump;
+    is "$x,$y", '1,2', 'nested method writes multiple captured outers';
+}
+
+# 8. Coherent in a later expression in the same scope.
+{
+    my $v;
+    class A8 {
+        method setup {
+            method go { $v = 5 }
+        }
+    }
+    my $o = A8.new;
+    $o.setup;
+    $o.go;
+    my $doubled = $v * 2;
+    is $doubled, 10, 'caller slot coherent in a later expression';
+}
+
+# 9. Captured outer survives an intervening unrelated method call.
+{
+    my $tracker;
+    class A9 {
+        method setup {
+            method mark { $tracker = 'marked' }
+        }
+        method noop { 1 }
+    }
+    my $o = A9.new;
+    $o.setup;
+    $o.mark;
+    $o.noop;
+    is $tracker, 'marked', 'captured-outer write survives an intervening call';
+}


### PR DESCRIPTION
## Summary

A `method` declared inside another method's body captures an outer lexical and writes it when later called:

```raku
my $tracker;
class A {
    method foo {
        my $a = 42;
        method bar { $tracker = $a }   # nested-declared method
    }
}
given A.new { .foo; .bar }
is $tracker, 42;   # was Nil under MUTSU_NO_BLANKET_RECONCILE=1
```

This is the §7.2 **nested-method capture** surface (the `methods-instance` subtest 3) on the path to removing `env_dirty` (single-store unification).

## Root cause

The dispatch path. A nested-declared method is registered at runtime (when `foo` runs) as a **captured-env `&bar` sub**, so `$d.bar` is dispatched neither through the compiled method merge path (`merge_method_env`, which already records captured-outer writes since #3322) nor the closure dispatch, but through the slow path `call_method_with_values` → **`call_sub_value(merge_all=true)`**. That path merges the captured-outer scalar write into the caller env correctly but never refreshes the caller's **local slot**; only the blanket reverse-sync pull did.

## Fix (precise write-back, ungated)

- **`call_sub_value`** (`resolution.rs`): collect each captured-outer scalar it actually *changed* (vs its body-entry snapshot) in both merge branches and push them to `pending_rw_writeback_sources` — mirroring `merge_method_env`'s `changed_caller_locals`.
- **CallMethod op** (`vm_call_method_ops.rs`): drain them via `drain_and_reconcile_after_cached_call` (`apply_pending_rw_writeback` + the env_dirty-gated blanket reconcile) instead of the blanket reconcile alone. This op previously never drained `pending_rw_writeback_sources`, so this also closes the latent gap the `merge_method_env` comment already assumed closed.

With the blanket reconcile ON (default/CI) the dispatch is impure → `env_dirty`, so the blanket reconcile is a superset and behaviour is **byte-identical**; OFF, the precise drain alone carries the write.

## Tests

- New pin `t/nested-method-captured-writeback-coherence.t` (9 subtests: given/topic, explicit invocant, RMW accumulation, `+=`, string, enclosing-lexical-read + outer-write, multiple outers, later-expression coherence, intervening call) — **ON/OFF both PASS**.
- `make test` 9727 PASS, `make roast` 1285 PASS — no regressions.
- OFF survey 16 → 15 (remaining ~13 are the concurrency cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)