### PR TITLE
fix(warn): resume cross-frame warn inline when no CONTROL handler is active

### DIFF
--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -302,6 +302,22 @@ impl Interpreter {
             })
             .unwrap_or(1);
         message.push_str(&format!("\n  in block <unit> at {} line {}", file, line));
+        // When no CONTROL handler is active (`control_handler_depth == 0`), this
+        // warn's only possible fate is the default handler: print to stderr and
+        // resume. Handle it inline here, at the raise site, rather than returning
+        // an `Err` that unwinds the Rust call stack. Unwinding loses every frame
+        // between here and the top-level loop, so a `warn` raised deep inside a
+        // method/sub chain (e.g. `render -> log -> &warn.()`) would abandon the
+        // whole computation instead of resuming it (cross-frame warn). Because
+        // `control_handler_depth == 0` guarantees there is no `CONTROL`/`when
+        // CX::Warn` block on the stack, there is no `succeed`/unwind target to
+        // honour, so resolving the warn locally is complete and correct here.
+        if self.control_handler_depth == 0 {
+            if !self.warning_suppressed() {
+                self.write_warn_to_stderr(&message);
+            }
+            return Ok(Value::Nil);
+        }
         Err(RuntimeError::warn_signal(message))
     }
 

--- a/t/warn-cross-frame-resume.t
+++ b/t/warn-cross-frame-resume.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A `warn` raised deep inside a sub/method call chain, with NO CONTROL handler
+# installed, must print to stderr and *resume* — the suspended computation
+# continues and its value flows back out. Previously mutsu unwound the Rust call
+# stack on the warn signal, abandoning every frame between the warn and the
+# top-level loop (cross-frame warn), so the deep result was lost.
+
+plan 6;
+
+# Direct `warn` two frames deep.
+sub inner-direct() { warn "deep direct"; return "inner-result"; }
+sub outer-direct() { my $x = inner-direct(); return "outer[$x]"; }
+is outer-direct(), "outer[inner-result]",
+    'direct warn deep in call chain resumes; caller value preserved';
+
+# Indirect `&warn.(...)` two frames deep (the Template::Mustache logger shape).
+sub inner-indirect() { my $w = &warn; $w.("deep indirect"); return "inner-ok"; }
+sub outer-indirect() { return "outer[" ~ inner-indirect() ~ "]"; }
+is outer-indirect(), "outer[inner-ok]",
+    'indirect &warn.() deep in call chain resumes; caller value preserved';
+
+# warn inside a method call chain resumes too.
+class C {
+    method deep() { warn "method warn"; return 42; }
+    method top()  { return self.deep() + 1; }
+}
+is C.new.top(), 43, 'warn inside a method chain resumes and the value flows out';
+
+# warn mid-expression resumes; the rest of the expression still evaluates.
+sub w-mid() { return 1 + (warn("mid") // 0) + 2; }
+is w-mid(), 3, 'warn mid-expression resumes (value is Nil) and expression completes';
+
+# A loop body that warns keeps iterating (one warn per element, all resume).
+my @collected;
+for 1..3 -> $n { warn "warn $n"; @collected.push: $n * 10; }
+is @collected, [10, 20, 30], 'warn in a loop body resumes every iteration';
+
+# `quietly` suppresses the warning output but execution still resumes.
+sub quiet-deep() { quietly { warn "hushed"; }; return "after-quiet"; }
+is quiet-deep(), "after-quiet", 'warn under quietly resumes without aborting';


### PR DESCRIPTION
## Problem

A `warn` raised deep in a sub/method call chain, with **no CONTROL handler** installed, must print to stderr and *resume* — Raku's default warn behaviour — so the suspended computation continues and its value flows back out.

mutsu instead lost the deep computation:

```raku
sub inner() { warn "deep"; return "inner-result"; }
sub outer() { return "outer[" ~ inner() ~ "]"; }
say outer();   # raku: outer[inner-result]   mutsu (before): outer[]  (or a panic)
```

`builtin_warn` always returned `Err(warn_signal)`. With no CONTROL block on the stack, that Err unwound the Rust call stack to the top-level loop, where `vm.rs` printed the warning and did `ip += 1` — "resuming" only at top-level statement granularity. Every frame between the `warn` and the top (the whole `outer(inner())` chain) was abandoned.

## Fix

When `control_handler_depth == 0` (no CONTROL block is active ⟺ the warn's only possible fate is the default handler, so there is no `succeed`/unwind target to honour), handle the warn **inline at the raise site** in `builtin_warn`: print to stderr and `return Ok(Nil)` instead of unwinding. This resolves the warn locally without losing intervening frames.

When a CONTROL handler **is** active (`depth > 0`), the original unwind-to-handler path is unchanged, so `CONTROL { when CX::Warn {...} }` and its `succeed` semantics keep working.

## Impact

Unblocks Template::Mustache **13-pragmas #1/#2** (keep-unused-variables; was a crash) and **50-readme**'s warn-on-missing-field crash. The remaining `06-logging` case installs a unit-level `CONTROL { default { .resume } }` (`depth > 0`) and needs true cross-frame continuation — out of scope here.

## Tests

- New pin `t/warn-cross-frame-resume.t` (6 cases: direct / indirect `&warn.()` / method chain / mid-expression / loop body / `quietly`).
- No regression: `S32-basics/warn.t`, `S04-exception-handlers/control.t`+`catch.t`+`top-level.t`, `S32-str/indent.t`, `S04-statements/quietly.t`+`gather.t`, `S04-exceptions/*` all green; `make test` (9724 tests) PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)