### PR TITLE
fix(compiler): given/when/default block ending in `if` yields the if value

### DIFF
--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -2,6 +2,47 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Compiler {
+    /// Compile a `given`/`when`/`default` body's final statement in value
+    /// position, leaving its value on the stack (the value the block — and via
+    /// `succeed`, the enclosing `given` — evaluates to). Returns `false` when
+    /// `stmt` is not one of the value-producing forms handled here, so the
+    /// caller falls back to plain statement compilation.
+    ///
+    /// Without this, a `when`/`given` block whose final statement is an `if`
+    /// (or a bare block) compiled in statement mode discards its value, so
+    /// `given $t { if ... { "x" } }` wrongly evaluated to `Nil`. `Stmt::Expr`
+    /// in tail position already keeps its value (and tags a bare-variable topic
+    /// for container writeback), so that case is preserved here too.
+    pub(super) fn compile_when_tail_stmt(&mut self, stmt: &Stmt) -> bool {
+        match stmt {
+            Stmt::Expr(expr) => {
+                self.compile_expr(expr);
+                if let Expr::Var(name) = expr {
+                    let name_idx = self.code.add_constant(Value::str(name.clone()));
+                    self.code.emit(OpCode::TagContainerRef(name_idx));
+                }
+                true
+            }
+            Stmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                binding_var,
+            } if binding_var.is_none()
+                && Self::do_if_branch_supported(then_branch)
+                && Self::do_if_branch_supported(else_branch) =>
+            {
+                self.compile_do_if_expr(cond, then_branch, else_branch);
+                true
+            }
+            Stmt::Block(inner) | Stmt::SyntheticBlock(inner) => {
+                self.compile_block_inline(inner);
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Compile a block inline (for blocks without placeholders).
     pub(super) fn compile_block_inline(&mut self, stmts: &[Stmt]) {
         let saved = self.push_dynamic_scope_lexical();

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -430,6 +430,12 @@ impl Compiler {
                 // (it leaves the block value on the stack); only a non-final
                 // `given` is unsupported here.
                 Stmt::Given { .. } if i != last => return false,
+                // A loose `when`/`default` (a topicalizer that smartmatches `$_`
+                // and `succeed`s) is not expressible via the `do if` value path:
+                // its value flows out through the enclosing `when`/`given` via a
+                // control signal, not as a stack-top fallthrough. Branches that
+                // contain one must use ordinary statement compilation.
+                Stmt::When { .. } | Stmt::Default(_) => return false,
                 Stmt::If {
                     then_branch,
                     else_branch,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2008,13 +2008,7 @@ impl Compiler {
                     for (i, s) in body.iter().enumerate() {
                         let is_last = i == body.len() - 1;
                         if is_last {
-                            if let Stmt::Expr(expr) = s {
-                                self.compile_expr(expr);
-                                if let Expr::Var(name) = expr {
-                                    let name_idx = self.code.add_constant(Value::str(name.clone()));
-                                    self.code.emit(OpCode::TagContainerRef(name_idx));
-                                }
-                            } else {
+                            if !self.compile_when_tail_stmt(s) {
                                 self.compile_stmt(s);
                             }
                         } else {
@@ -2030,13 +2024,7 @@ impl Compiler {
                 for (i, s) in body.iter().enumerate() {
                     let is_last = i == body.len() - 1;
                     if is_last {
-                        if let Stmt::Expr(expr) = s {
-                            self.compile_expr(expr);
-                            if let Expr::Var(name) = expr {
-                                let name_idx = self.code.add_constant(Value::str(name.clone()));
-                                self.code.emit(OpCode::TagContainerRef(name_idx));
-                            }
-                        } else {
+                        if !self.compile_when_tail_stmt(s) {
                             self.compile_stmt(s);
                         }
                     } else {
@@ -2054,13 +2042,7 @@ impl Compiler {
                     for (i, s) in body.iter().enumerate() {
                         let is_last = i == body.len() - 1;
                         if is_last {
-                            if let Stmt::Expr(expr) = s {
-                                self.compile_expr(expr);
-                                if let Expr::Var(name) = expr {
-                                    let name_idx = self.code.add_constant(Value::str(name.clone()));
-                                    self.code.emit(OpCode::TagContainerRef(name_idx));
-                                }
-                            } else {
+                            if !self.compile_when_tail_stmt(s) {
                                 self.compile_stmt(s);
                             }
                         } else {

--- a/t/given-when-tail-if-value.t
+++ b/t/given-when-tail-if-value.t
@@ -1,0 +1,59 @@
+use Test;
+
+# The value of a `given`/`when`/`default` block whose final statement is an
+# `if`/`unless` (or a bare block) must be that statement's value — exactly like
+# a `do { if ... }` or a sub whose last statement is an `if`. Previously mutsu
+# only kept the value when the final statement was a plain expression; a trailing
+# `if` was compiled in statement mode, so its value was discarded and the block
+# evaluated to Nil.
+
+plan 9;
+
+# `given` whose body is a bare trailing if/else.
+sub given-if($t) {
+    given $t {
+        if $t eq 'x' { 'GIVEN-IF' } else { 'GIVEN-ELSE' }
+    }
+}
+is given-if('x'), 'GIVEN-IF',  'given body ending in if (then) yields the if value';
+is given-if('y'), 'GIVEN-ELSE', 'given body ending in if (else) yields the else value';
+
+# `when` block whose final statement is an if/else.
+sub when-if($t) {
+    given $t {
+        when 'a' { if True  { 'WHEN-A-IF' } else { 'WHEN-A-ELSE' } }
+        when 'b' { if False { 'WHEN-B-IF' } else { 'WHEN-B-ELSE' } }
+        default  { 'DEFAULT' }
+    }
+}
+is when-if('a'), 'WHEN-A-IF',   'when block ending in if (then-taken) yields its value';
+is when-if('b'), 'WHEN-B-ELSE', 'when block ending in if (else-taken) yields its value';
+is when-if('z'), 'DEFAULT',     'default branch still yields its value';
+
+# `when` block ending in a bare `if` with no else, condition false -> Nil.
+sub when-if-noelse($t) {
+    given $t {
+        when 'a' { if False { 'NEVER' } }
+        default  { 'DEF' }
+    }
+}
+is when-if-noelse('a'), Nil, 'when block ending in else-less if (false) yields Nil';
+
+# `default` block ending in an if.
+sub default-if($t) {
+    given $t {
+        when 'x' { 'X' }
+        default  { if $t eq 'q' { 'DEF-Q' } else { 'DEF-OTHER' } }
+    }
+}
+is default-if('q'), 'DEF-Q',     'default block ending in if (then) yields its value';
+is default-if('r'), 'DEF-OTHER', 'default block ending in if (else) yields its value';
+
+# `when` block ending in a nested bare block.
+sub when-block($t) {
+    given $t {
+        when 'a' { { 'NESTED-BLOCK' } }
+        default  { 'DEF' }
+    }
+}
+is when-block('a'), 'NESTED-BLOCK', 'when block ending in a bare block yields the block value';


### PR DESCRIPTION
## Problem

A `given`/`when`/`default` body whose final statement is an `if`/`unless` (or a bare block) was compiled in statement mode, so its value was discarded and the block evaluated to `Nil`:

```raku
sub f($t) { given $t { if $t eq 'x' { 'A' } else { 'B' } } }
say f('x');   # was Nil, should be 'A'
```

Only a final `Stmt::Expr` kept its value. A `do { if ... }` and a sub whose last statement is an `if` already yielded the branch value; this brings `given`/`when`/`default` tails in line with that.

## Fix

A new `compile_when_tail_stmt` helper compiles the final statement of a given/when/default body in value position — handling `Stmt::Expr` (as before, including the bare-variable topic writeback tag), a block-final `if`/`unless` (via `compile_do_if_expr`), and a bare nested block — used by all three body loops. It returns `false` for other forms so the caller falls back to plain statement compilation.

The `if` case is gated on `do_if_branch_supported`, extended to reject branches containing a loose `when`/`default`: such a branch's value escapes via a `succeed` control signal, not as a stack-top fallthrough, and `compile_do_if_expr` cannot express it (it also drops the per-branch `-> $_` binding). Without the gate, feeding a complex `when` if-chain (e.g. Template::Mustache's section renderer) through the value path leaked the enclosing `given` topic into the branch. Gating keeps those chains on the existing statement path, so this change is **purely additive** — no behavior changes for code that already worked.

## Tests

- New pin `t/given-when-tail-if-value.t` (9 cases: given/when/default tails ending in if with then/else/no-else, and nested bare block).
- `make test` green (9733 tests); `S04-statements/given.t`, `S04-statements/when.t`, `S04-statement-modifiers/given.t` roast green; Template::Mustache 11-iterable / 03-cascade unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)