### PR TITLE
fix(regex): `^^` line-anchor respects original text position inside subrules

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
 use unicode_segmentation::UnicodeSegmentation;
@@ -9,6 +9,26 @@ thread_local! {
     /// Collects plain (non-assertion) code blocks that should be executed eagerly
     /// during regex matching, even if the overall match fails. Used by `comb` etc.
     pub(crate) static EAGER_CODE_BLOCKS: RefCell<Option<Vec<CodeBlockContext>>> = const { RefCell::new(None) };
+    /// The character immediately preceding the start of the text currently being
+    /// matched. A subrule (`<foo>`) is matched against a *slice* `chars[pos..]`
+    /// in a fresh sub-interpreter, so position 0 of that slice is not necessarily
+    /// the start of a line in the original text. Look-behind anchors (`^^`, `^`)
+    /// consult this to decide whether slice-position 0 is a real line/string
+    /// start: `None` means it truly is the start of the parse text, `Some(c)`
+    /// means `c` was the char just before the slice. Saved/restored around each
+    /// subrule dispatch so nesting threads correctly.
+    pub(crate) static REGEX_PRECEDING_CHAR: Cell<Option<char>> = const { Cell::new(None) };
+}
+
+/// Restores `REGEX_PRECEDING_CHAR` to a saved value when dropped, so a subrule
+/// dispatch can publish the slice's preceding char for the duration of the match
+/// and have it restored on every exit path (including early returns).
+pub(crate) struct RegexPrecedingCharGuard(pub(crate) Option<char>);
+
+impl Drop for RegexPrecedingCharGuard {
+    fn drop(&mut self) {
+        REGEX_PRECEDING_CHAR.with(|c| c.set(self.0));
+    }
 }
 
 /// Strip combining marks from a character, returning just the base character(s).

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -319,6 +319,19 @@ impl Interpreter {
             let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
             if !candidates.is_empty() {
                 let tail: Vec<char> = chars[pos..].to_vec();
+                // The subrule candidates match `tail` (a slice from `pos`) at
+                // position 0, so publish the char before the slice for look-behind
+                // anchors (`^^`). At `pos == 0` inherit the current value (this
+                // slice may itself be a nested subrule's tail). Restored on every
+                // exit path by the guard.
+                let saved_prev = super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get());
+                let slice_prev = if pos > 0 {
+                    Some(chars[pos - 1])
+                } else {
+                    saved_prev
+                };
+                super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.set(slice_prev));
+                let _restore_prev = super::regex_helpers::RegexPrecedingCharGuard(saved_prev);
 
                 // Left-recursion detection using (name, remaining_chars_count) as key.
                 // remaining = chars.len() - pos = tail.len().

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -244,12 +244,23 @@ impl Interpreter {
                 };
             }
             RegexAtom::StartOfLine => {
-                if pos == 0 {
+                // The char immediately before `pos`. At slice-position 0 this is
+                // not necessarily the start of the original parse text: a subrule
+                // is matched against `chars[pos..]` in a sub-interpreter, so
+                // consult `REGEX_PRECEDING_CHAR` (the char before this slice). It
+                // is `None` only at the true start of the parse text.
+                let prev = if pos > 0 {
+                    Some(chars[pos - 1])
+                } else {
+                    super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get())
+                };
+                let Some(prev) = prev else {
+                    // True start of the parse text — a line start.
                     return Some(pos);
-                }
+                };
                 // After \n: match unless at end-of-string (trailing newline)
                 // or \n was part of \r\n (match after complete \r\n, not between \r and \n)
-                if chars[pos - 1] == '\n' {
+                if prev == '\n' {
                     // Don't match at end-of-string after trailing \n
                     if pos == chars.len() {
                         return None;
@@ -257,7 +268,7 @@ impl Interpreter {
                     return Some(pos);
                 }
                 // After \r not followed by \n: standalone \r is a line ending
-                if chars[pos - 1] == '\r' {
+                if prev == '\r' {
                     // \r followed by \n is NOT a standalone line ending;
                     // don't match between \r and \n
                     if pos < chars.len() && chars[pos] == '\n' {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -387,6 +387,19 @@ impl Interpreter {
             let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
             if !candidates.is_empty() {
                 let tail: Vec<char> = chars[pos..].to_vec();
+                // The subrule matches `tail` (a slice starting at `pos`) in a fresh
+                // sub-interpreter, where slice-position 0 is not the original text
+                // start. Publish the char before the slice so look-behind anchors
+                // (`^^`) in the subrule see the real context. At `pos == 0` inherit
+                // the current value (this slice may itself be a nested subrule).
+                let saved_prev = super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get());
+                let slice_prev = if pos > 0 {
+                    Some(chars[pos - 1])
+                } else {
+                    saved_prev
+                };
+                super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.set(slice_prev));
+                let _restore_prev = super::regex_helpers::RegexPrecedingCharGuard(saved_prev);
                 let mut best: Option<(usize, RegexCaptures)> = None;
                 let mut best_sym: Option<String> = None;
                 for (sub_pat, sub_pkg, sym_key) in candidates {

--- a/t/caret-line-anchor-in-subrule.t
+++ b/t/caret-line-anchor-in-subrule.t
@@ -1,0 +1,74 @@
+use Test;
+
+# The `^^` (start-of-line) anchor must respect the position in the *original*
+# parse text, not the start of the slice a subrule is matched against. A subrule
+# (`<foo>`) is matched against `chars[pos..]` in a sub-interpreter; previously
+# `^^` at the subrule's entry always succeeded (slice position 0 looked like a
+# line start) even when the subrule was entered mid-line. That made a
+# non-standalone tag wrongly match a standalone line rule and swallow the
+# newline that ended the previous content line (seen in Template::Mustache's
+# `hunk`/`linetag` grammar — section iterations ran together on one line).
+
+plan 6;
+
+# `^^` at a subrule called mid-line (preceded by a non-newline) must FAIL.
+grammar MidLine {
+    token TOP { 'H' <close> }
+    token close { ^^ 'X' }
+}
+nok MidLine.parse('HX').defined,
+    '^^ in a subrule entered mid-line does not match';
+
+# `^^` at a subrule called right after a newline must MATCH.
+grammar AfterNl {
+    token TOP { 'a' \n <close> }
+    token close { ^^ 'X' }
+}
+ok AfterNl.parse("a\nX").defined,
+    '^^ in a subrule entered after a newline matches';
+
+# `^^` in a subrule at the true start of the parse text still matches.
+grammar AtStart {
+    token TOP { <s> 'rest' }
+    token s { ^^ 'go' }
+}
+ok AtStart.parse('gorest').defined,
+    '^^ in a subrule at the true text start matches';
+
+# The motivating case (mirrors Template::Mustache's grammar): a standalone
+# line-tag rule (`^^ ... <tag> ... \n`) must not consume the newline ending the
+# *previous*, non-standalone content line.
+grammar Hunks {
+    regex TOP { ^ <hunk>* (.*) $ }
+    regex hunk { (.*?) [ <linetag> | <tag> ] }
+    token linetag { ^^ (\h*) <tag> \h* [\n | $] }
+    token tag { '{' <( <[\w/]>+ )> '}' }
+}
+class Collect {
+    method tag($/)     { make ~$/ }
+    method linetag($/) { make 'LINE:' ~ $<tag>.made }
+    method hunk($/) {
+        my @x;
+        @x.push('T<' ~ ~$0 ~ '>') if ~$0;
+        for $<linetag tag>.grep(*.defined)>>.made -> $m { @x.push($m) }
+        make @x.Slip;
+    }
+    method TOP($/) { make $<hunk>>>.made.flat.join('|') ~ '|tail<' ~ ~$0 ~ '>' }
+}
+
+# '{/x}' is NOT standalone (preceded by 'H'), so the newline before the
+# standalone '{/end}' survives as its own text hunk.
+my $nl = "\n";
+is Hunks.parse("a\{x}H\{/x}\n\{/end}body", :actions(Collect)).made,
+    "T<a>|x|T<H>|/x|T<$nl>|/end|tail<body>",
+    'a non-standalone close tag leaves the trailing newline for the next hunk';
+
+# Regression guard: without the nested mid-line tag the result is unchanged.
+is Hunks.parse("a\{x}\n\{/end}body", :actions(Collect)).made,
+    "T<a>|x|T<$nl>|/end|tail<body>",
+    'trailing newline preserved (no nested tag) — unchanged';
+
+# A standalone tag on its own line still consumes its whole line (newline gone).
+is Hunks.parse("\{open}\nbody", :actions(Collect)).made,
+    'LINE:open|tail<body>',
+    'a standalone tag consumes its own line including the newline';


### PR DESCRIPTION
## Problem

A subrule (`<foo>`) is matched against a **slice** `chars[pos..]` in a fresh sub-interpreter, so position 0 of that slice is not necessarily the start of a line in the original parse text. `^^` (StartOfLine) only checked `pos == 0 || chars[pos-1] == '\n'`, so at slice-position 0 it **always matched** — a subrule entered mid-line saw a spurious line start.

Minimal repro:

```raku
grammar G { token TOP { 'H' <close> };  token close { ^^ 'X' } }
say G.parse('HX').defined;   # rakudo: False    mutsu (before): True
```

In a grammar like Template::Mustache's `token linetag { ^^ (\h*) <tag> \h* [\n|$] }`, a non-standalone close tag (`...H{/x}`) entered mid-line wrongly matched `linetag`, and its `[\n|$]` swallowed the newline ending the content line — so section iterations ran together on one line.

## Fix

A thread-local `REGEX_PRECEDING_CHAR` is published at each subrule dispatch (the char immediately before the slice; inherited when the slice itself starts at position 0 of a parent slice) and restored on every exit path by a drop guard. `StartOfLine` consults it at `pos == 0`: `None` ⇒ true start of the parse text (a line start); `Some(c)` ⇒ apply the normal after-`\n`/`\r` logic against `c`.

## Impact

Fixes **Template::Mustache 50-readme #3 (Roster)** — a `{{#people}}` section with a nested inline `{{#emcee}}` now renders one guest per line, matching rakudo.

## Tests

- New pin `t/caret-line-anchor-in-subrule.t` (6 cases, spec-validated against rakudo).
- `make test` green (9757); S05 grammar/capture/metasyntax/mass roast green.

Known follow-up: `^` (start-of-string) has the same slice-relative issue via a different path (a pattern-level `anchor_start` flag, not a StartOfLine atom); left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)