### PR TITLE
feat(single-store): zip short-circuit topicalizing thunk writeback (Sub-slice 1b slice 1.14)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -377,6 +377,16 @@ AT-POS が空 `@!c` を読む。
 - pin=`t/substr-rw-lvalue-writeback-coherence.t`（6・substr-rw/from-only/累積/bound proxy/subbuf-rw・ON/OFF 両 PASS）。
   make test 9754。`S32-str/substr-rw.t` 46/46・`S03-operators/buf.t` も ON/OFF PASS（OFF survey の **2 file** 消化）。
 
+### 7.1j ✅ スライス1.14（DONE・第45セッション）= zip short-circuit topicalizing thunk writeback（`zip.t` 68/71）
+`23 Zandthen ($side-effect = $_,)` の topicalize thunk write が OFF で lost（OFF=0・raku/ON=23）。`Zandthen`/`Zorelse`
+は `builtin_zip_shortcircuit_topic`（builtins_feed.rs:299）/`builtin_zip_shortcircuit` 経由で thunk を評価するが、
+`builtin_cross_shortcircuit`（slice 1.9・X-cross）と違い **captured-outer write を記録していなかった**＝即時起動 closure で
+escape 解析が box しない→blanket reconcile のみが運んでいた。修正＝両関数で thunk 実行後に
+`record_eager_block_free_var_writeback(&code, &params)` を呼び pending に push→`__mutsu_zip_shortcircuit*` call site の
+`apply_pending_rw_writeback` が drain（X-cross と同型）。ON は冪等 superset＝byte-identical。
+pin=`t/zip-shortcircuit-topic-writeback-coherence.t`（5・Zandthen/Zorelse topicalize＋increment・ON/OFF 両 PASS）。
+make test 9769。`S03-metaops/zip.t` ON/OFF PASS（OFF survey の **1 file** 消化）。
+
 ### 7.2 後続スライス（その先）
 - **delegated mutating method call の invocant writeback**（pre-existing・トグル非依存）: `$q.push(5)` が `handles` 経由で
   `@!c` に委譲されるとき、attr は変異するが method-call 後に caller の `$q` slot/instance が refresh されず累積が壊れる
@@ -393,14 +403,14 @@ AT-POS が空 `@!c` を読む。
 これまでの「決定的 OFF 依存 = 0 到達」は **t/ のみの `^not ok` survey** に基づく過小評価だった。`MUTSU_NO_BLANKET_RECONCILE=1
 make roast`（release・全 whitelist 1285）を実走したところ、**13 ファイルが OFF で決定的に fail**（全て pre-existing＝
 main baseline でも同じ subtest が OFF fail・本スライスの変更とは無関係＝debug 比較で確認）。これが env_dirty 物理削除
-（§7.4）を解禁するために潰すべき残サーフェス（初回 13 → slice 1.13 で **substr-rw.t / buf.t 消化済 → 残 11**）:
+（§7.4）を解禁するために潰すべき残サーフェス（初回 13 → slice 1.13 で substr-rw.t/buf.t、slice 1.14 で zip.t 消化 → **残 10**）:
 
 | file | failed subtests | 推定カテゴリ | 状態 |
 |------|-----------------|--------------|------|
 | ~~S32-str/substr-rw.t~~ | 1, 8-9, 16, 24-25, 33-38 | substr-rw lvalue slot writeback | ✅ slice 1.13 |
 | ~~S03-operators/buf.t~~ | 38 | subbuf-rw lvalue slot writeback | ✅ slice 1.13 |
 | S02-types/lazy-lists.t | 24-26 | lazy list captured-outer | |
-| S03-metaops/zip.t | 68, 71 | metaop thunk captured | |
+| ~~S03-metaops/zip.t~~ | 68, 71 | Z-cross topicalizing thunk writeback | ✅ slice 1.14 |
 | S02-names/caller.t | 9 | callframe/caller | |
 | S06-advanced/callframe.t | 12 | callframe | |
 | S06-multi/proto.t | 21 | multi-dispatch | |
@@ -411,10 +421,10 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
 | S32-scalar/undef.t | 85 | undef/Failure | |
 | S32-io/IO-Socket-Async.t | 5, 7 | reactive 並行（flaky 疑い） | |
 
-**次スライス候補**: lazy-lists/map（lazy captured-outer・slice 1.6 の lazy map 修正と同系）or zip metaop thunk
-（slice 1.5/1.9 と同系）が同型 precise-writeback で解ける見込み。手順＝
+**次スライス候補**: lazy-lists.t（24-26 `kv`/`pairs`/`antipairs` is lazy）or map.t（62 LAST phaser）or callframe/caller。
+lazy 系は slice 1.6 の lazy map 修正と同系の precise-writeback で解ける見込み。手順＝
 `MUTSU_NO_BLANKET_RECONCILE=1 target/release/mutsu roast/<file>` で最小再現→env 書込経路特定→
-`locals_set_by_name`/`pending_rw_writeback_sources` で precise 化。**残 11 全消化後に §7.4（env_dirty 削除）が射程。**
+`locals_set_by_name`/`pending_rw_writeback_sources` で precise 化。**残 10 全消化後に §7.4（env_dirty 削除）が射程。**
 
 ### 7.3 ★各スライスの必須手順（slice 1 の教訓）
 

--- a/src/runtime/builtins_feed.rs
+++ b/src/runtime/builtins_feed.rs
@@ -253,6 +253,7 @@ impl Interpreter {
         let right_thunks = crate::runtime::value_to_list(&args[2]);
         let len = left_values.len().min(right_thunks.len());
         let mut out = Vec::with_capacity(len);
+        let mut ran_thunks: Vec<Value> = Vec::new();
         for i in 0..len {
             let left = left_values[i].clone();
             let needs_rhs = match op.as_str() {
@@ -271,6 +272,7 @@ impl Interpreter {
             let rhs_value = if !matches!(entry, Value::Sub(_)) {
                 entry
             } else if op == "andthen" || op == "orelse" {
+                ran_thunks.push(entry.clone());
                 let saved_topic = self.env.get("_").cloned();
                 self.env.insert("_".to_string(), left.clone());
                 let result = self.eval_call_on_value(entry, Vec::new());
@@ -284,9 +286,20 @@ impl Interpreter {
                 }
                 result?
             } else {
+                ran_thunks.push(entry.clone());
                 self.eval_call_on_value(entry, Vec::new())?
             };
             out.push(rhs_value);
+        }
+        // Record each evaluated thunk's captured-outer writes so the call site
+        // drains them into the caller's locals (carrier; see the topic variant
+        // and slice 1.9 / docs §7.1i).
+        for thunk in ran_thunks {
+            if let Value::Sub(ref data) = thunk
+                && let Some(code) = data.compiled_code.clone()
+            {
+                self.record_eager_block_free_var_writeback(&code, &data.params);
+            }
         }
         Ok(Value::array(out))
     }
@@ -318,6 +331,7 @@ impl Interpreter {
         };
         let thunk = args[2].clone();
         let mut out = Vec::new();
+        let mut thunk_ran = false;
         for (i, left) in left_values.iter().enumerate() {
             let needs_rhs = match op.as_str() {
                 "andthen" => crate::runtime::types::value_is_defined(left),
@@ -328,6 +342,7 @@ impl Interpreter {
                 out.push(left.clone());
                 continue;
             }
+            thunk_ran = true;
             let saved_topic = self.env.get("_").cloned();
             self.env.insert("_".to_string(), left.clone());
             let result = self.eval_call_on_value(thunk.clone(), Vec::new());
@@ -343,6 +358,17 @@ impl Interpreter {
             // The thunk returns the whole right list; pick element i (zip is 1:1).
             let rhs_items = crate::runtime::value_to_list(&rhs_value);
             out.push(rhs_items.into_iter().nth(i).unwrap_or(Value::Nil));
+        }
+        // Record the topicalizing thunk's captured-outer writes (`$x = $_`) so the
+        // call site drains them into the caller's locals — same as the
+        // `__mutsu_cross_shortcircuit` carrier (slice 1.9). Without this the write
+        // is lost once the blanket reconcile is removed
+        // (docs/captured-outer-cell-sharing.md §7.1i).
+        if thunk_ran
+            && let Value::Sub(ref data) = thunk
+            && let Some(code) = data.compiled_code.clone()
+        {
+            self.record_eager_block_free_var_writeback(&code, &data.params);
         }
         Ok(Value::array(out))
     }

--- a/t/zip-shortcircuit-topic-writeback-coherence.t
+++ b/t/zip-shortcircuit-topic-writeback-coherence.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Coherence pin for the env<->locals single-store path
+# (MUTSU_NO_BLANKET_RECONCILE): the right-hand thunk of a zip short-circuit
+# metaop (`Zandthen`/`Zorelse`) that writes a captured-outer lexical
+# (`$x = $_`, `$x++`) must reach the caller's local slot, not only the env
+# entry that the (removed) blanket reconcile used to pull. Must pass
+# identically with and without the blanket reconcile.
+
+plan 5;
+
+{
+    my Mu $side-effect is default(Nil) = 0;
+    23 Zandthen ($side-effect = $_,);
+    is $side-effect, 23, "Zandthen topicalizing thunk write reaches the slot";
+}
+
+{
+    my Mu $side-effect is default(Nil) = 0;
+    1 Zandthen ($side-effect++,);
+    is $side-effect, 1, "Zandthen increment thunk reaches the slot";
+}
+
+{
+    my Mu $side-effect is default(Nil) = 0;
+    Nil Zandthen ($side-effect++,);
+    is $side-effect, 0, "Zandthen does not run the thunk for an undefined left";
+}
+
+{
+    my Mu $side-effect is default(Nil) = 0;
+    Nil Zorelse ($side-effect = $_,);
+    is $side-effect, Nil, "Zorelse topicalizing thunk write reaches the slot";
+}
+
+{
+    my Mu $side-effect is default(Nil) = 0;
+    Nil Zorelse ($side-effect++,);
+    is $side-effect, 1, "Zorelse increment thunk reaches the slot";
+}


### PR DESCRIPTION
## What

The right-hand thunk of `Zandthen`/`Zorelse` (and `Zand`/`Zor`) is an immediately-invoked closure, so escape analysis never boxes the outer lexicals it captures-and-writes. `builtin_zip_shortcircuit_topic` / `builtin_zip_shortcircuit` evaluated the thunk but, unlike `builtin_cross_shortcircuit` (slice 1.9, the `X`-cross variant), never recorded its captured-outer writes. Under `MUTSU_NO_BLANKET_RECONCILE` the write `\$x = \$_` was lost — only the blanket env reconcile carried it.

```raku
my Mu \$side-effect is default(Nil) = 0;
23 Zandthen (\$side-effect = \$_,);
say \$side-effect;   # ON/raku: 23   OFF before fix: 0
```

## Fix

After running the thunk(s), call `record_eager_block_free_var_writeback` to push the thunk's captured-outer writes onto `pending_rw_writeback_sources`; the enclosing `__mutsu_zip_shortcircuit*` call site's `apply_pending_rw_writeback` drains them into the caller's local slots — mirroring the X-cross carrier (slice 1.9). Under the default build this is the idempotent superset of the blanket reconcile = byte-identical.

## Verification

- `t/zip-shortcircuit-topic-writeback-coherence.t` (new pin, 5 subtests) — passes under both ON and `MUTSU_NO_BLANKET_RECONCILE=1`.
- `S03-metaops/zip.t` now passes under both modes (was failing tests 68, 71 under OFF).
- `make test`: PASS (9769).
- OFF roast survey surface: 11 → 10 (tracked in `docs/captured-outer-cell-sharing.md §7.2a`).

Follows #3382 (slice 1.12) and #3384 (slice 1.13) — same single-store coherence campaign toward `env_dirty` removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)