### PR TITLE
feat(grammar): reduce-time $* dyn-var actions for mid-parse delimiter change

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1143,3 +1143,23 @@ env_dirty-gated blanket reconcile が支える唯一の機構で、source を親
 VM が真に所有（tree-walking 撤去の律速）。tree-walk フォールバックは記録 16 サイト（メソッド ~1%／関数 ~18.6%・大半 carrier）で
 「easy/medium な個別撲滅は枯渇・残は構造的」（`docs/vm-interpreter-fallback-ledger.md`）、`runtime/` ~11万行の ~40% が ③ 完了後に
 削除可。完了済み大型キャンペーンの詳細を PLAN.md から本 news へ移動。
+
+## 2026-06-21: Template::Mustache デリミタ変更 `{{=<% %>=}}` — reduce-time の `$*` 動的変数アクション (#3390)
+
+**Mustache の最後級ブロッカー「マッチ途中のデリミタ変更」を実装。** `{{=<% %>=}}` はタグの finalizer が
+`($*LEFT,$*RIGHT)=@delim` を書き換え、以降のタグを新デリミタでマッチさせる。mutsu はアクションを post-parse 実行
+していたため書き込みが live match に効かなかった。正規表現マッチエンジンは `&self` で env を mid-match 変更できないため、
+**parse スコープのスレッドローカル overlay**（`REGEX_DYNVAR_OVERLAY`）を導入: `<subrule>*`/`+` の各イテレーション確定後に
+そのアクションを scratch interp（actions オブジェクトは**ディープコピー**して self 変更を隔離）で走らせ、変化した `$*` 変数を
+overlay へ publish。`interpolate_regex_scalars` は `$*` twigil 解決時に env より先に overlay を参照する。**SEEN ゲート**
+（最初の `$*` 補間で立つ）により、動的変数に依存しない通常グラマーはゼロコスト。
+
+3つの落とし穴: ①`token`（ratchet）の `<x>*` は高速経路を通り hook が刺さらない＝`regex` のみ一般経路（mustache TOP/hunk は
+`regex`）②候補選択パスが overlay を汚染し本マッチが汚染状態で開始→`dynvar_overlay_reset_scan()` を parse driver の本マッチ
+直前に挿入（regex エントリ内に置くとサブルールマッチ毎にリセットして scan 内状態を破壊する）③独立した既存バグ: 補間スカラーは
+リテラルマッチすべきだが `escape_regex_scalar_literal` が `%`/`&` を未エスケープ→`%>` デリミタが直前 `\h*` と結合し
+`\h* % ...`（セパレータ量化子）と誤解釈。`%`/`&` をエスケープ集合に追加（複数文字 `<% %>` デリミタ単独でもブロッカーだった）。
+
+**結果**: Template::Mustache **01-basic 8/10 → 10/10**（delimiter change + `{{=delim=}}` substitution）, **13-pragmas** 全パス。
+回帰なし（全91 whitelisted S05 + S03/S32-str + make test 9763）。pin: `t/grammar-reduce-time-dynvar.t`。
+残る Mustache ブロッカー＝06-logging（unit-level `CONTROL{default{.resume}}` のクロスフレーム継続、最深）, grammar マッチ perf。

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -151,6 +151,15 @@ impl Interpreter {
         // parses stay balanced.
         let saved_grammar_actions =
             std::mem::replace(&mut self.current_grammar_actions, actions_obj.clone());
+        // Activate the reduce-time dyn-var overlay for action-driven parses so an
+        // action that writes a `$*` dynamic var mid-parse (e.g. a delimiter
+        // finalizer) affects subsequent subrule matching. No-op overlay cost
+        // until a pattern actually interpolates a `$*` var (see the SEEN gate in
+        // `interpolate_regex_scalars`). Dropped at scope end, restoring any outer
+        // parse's overlay.
+        let _dynvar_overlay_guard = actions_obj
+            .is_some()
+            .then(super::regex::regex_helpers::RegexDynvarOverlayGuard::activate);
         let result = (|| -> Result<Value, RuntimeError> {
             let pattern = match self.eval_token_call_values(&start_rule, &rule_args) {
                 Ok(Some(pattern)) => pattern,
@@ -182,6 +191,11 @@ impl Interpreter {
                 let _ = self.bind_function_args_values(&def.param_defs, &def.params, &rule_args);
             }
 
+            // Candidate selection above (`eval_token_call_values`) may have run a
+            // preliminary match that evolved the reduce-time dyn-var overlay
+            // (e.g. fired a delimiter finalizer). Reset it so the real match
+            // begins from the initial dynamic-var state in `self.env`.
+            super::regex::regex_helpers::dynvar_overlay_reset_scan();
             let captures = if method == "parse" || method == "parsefile" {
                 self.regex_match_with_captures_full_from_start(&pattern, &text)
             } else {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -201,7 +201,7 @@ mod ops;
 mod output_sink;
 pub(crate) mod phasers;
 mod react_died;
-mod regex;
+pub(crate) mod regex;
 pub(crate) mod regex_parse;
 mod registration;
 mod registration_class;

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -1,6 +1,6 @@
 mod regex_casefold;
 mod regex_eval;
-mod regex_helpers;
+pub(crate) mod regex_helpers;
 mod regex_interpolate;
 mod regex_match_atom;
 mod regex_match_atom_simple;

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -264,6 +264,117 @@ impl Interpreter {
         out
     }
 
+    /// Reduce-time grammar action hook for a `<subrule>` quantifier iteration.
+    /// Called from the quantifier loop after each iteration commits. When the
+    /// live parse is action-driven AND its matching already depends on a `$*`
+    /// dynamic var (the SEEN gate), run THIS iteration's subrule action so any
+    /// dyn-var write it performs (e.g. Template::Mustache's delimiter finalizer
+    /// `($*LEFT,$*RIGHT)=@delim`) is published to the overlay and thus visible to
+    /// the next iteration's pattern interpolation. No-op for ordinary grammars.
+    pub(super) fn maybe_run_reduce_time_dynvar_action(
+        &self,
+        token: &RegexToken,
+        new_caps: &RegexCaptures,
+    ) {
+        if !super::regex_helpers::dynvar_overlay_active() || !super::regex_helpers::dynvar_seen() {
+            return;
+        }
+        let Some(actions) = self.current_grammar_actions.clone() else {
+            return;
+        };
+        let rule_name = match &token.atom {
+            RegexAtom::Named(n) => n.trim().to_string(),
+            _ => return,
+        };
+        // The sub-capture this iteration stored under (explicit `$<alias>=` wins).
+        let cap_name = token
+            .named_capture
+            .clone()
+            .unwrap_or_else(|| rule_name.clone());
+        let Some(sub) = new_caps
+            .named_subcaps
+            .get(&cap_name)
+            .and_then(|v| v.last())
+            .cloned()
+        else {
+            return;
+        };
+        self.run_reduce_time_action(&sub, &rule_name, actions);
+    }
+
+    /// Run a single subrule's grammar action in a scratch interpreter and publish
+    /// any `$*` dynamic-var writes it makes into the reduce-time overlay. The
+    /// scratch is seeded with the overlay's current values so the action sees the
+    /// latest dynamic state; only vars whose value actually changes are published.
+    fn run_reduce_time_action(&self, sub: &RegexCaptures, rule_name: &str, actions: Value) {
+        // Run on an INDEPENDENT deep copy of the actions object so any `self`
+        // attribute the action mutates does not leak into the real actions
+        // object — the authoritative post-parse action pass will run again and is
+        // the one whose `make`/`self` effects count. The reduce-time pass exists
+        // ONLY to extract `$*` dynamic-var writes (which flow through the scratch
+        // env into the overlay, not through actions state). `InstanceAttrs::clone`
+        // is a deep, fresh-cell copy.
+        let mut actions = match &actions {
+            Value::Instance {
+                class_name,
+                attributes,
+                id,
+            } => Value::Instance {
+                class_name: *class_name,
+                attributes: Arc::new((**attributes).clone()),
+                id: *id,
+            },
+            other => other.clone(),
+        };
+        let match_obj = Value::make_match_object_full_q(
+            sub.matched.clone(),
+            sub.from as i64,
+            sub.to as i64,
+            &sub.positional,
+            &sub.named,
+            &sub.named_subcaps,
+            &sub.positional_subcaps,
+            &sub.positional_quantified,
+            &sub.positional_nil,
+            None,
+            &sub.named_quantified,
+        );
+        let mut scratch = Interpreter {
+            env: self.env.clone(),
+            current_package: Arc::new(RwLock::new(self.current_package())),
+            ..Default::default()
+        };
+        self.copy_full_registry_into(&mut scratch);
+        // Seed the scratch's `$*` vars from the overlay (latest delimiters etc.).
+        for (k, v) in super::regex_helpers::dynvar_overlay_snapshot() {
+            scratch.env.insert(k, v);
+        }
+        // Baseline of `$*` vars visible to the action, to diff after it runs.
+        let baseline: HashMap<String, Value> = scratch
+            .env
+            .iter()
+            .filter(|(k, _)| k.starts_with("*"))
+            .map(|(k, v)| (k.with_str(|s| s.to_string()), v.clone()))
+            .collect();
+        let _ = scratch.invoke_grammar_actions(match_obj, &mut actions, rule_name);
+        // Publish changed `$*` vars into the overlay for subsequent matching.
+        let changed: Vec<(String, Value)> = scratch
+            .env
+            .iter()
+            .filter(|(k, _)| k.starts_with("*"))
+            .filter_map(|(k, v)| {
+                let name = k.with_str(|s| s.to_string());
+                match baseline.get(&name) {
+                    Some(old) if old == v => None,
+                    _ => Some((name, v.clone())),
+                }
+            })
+            .collect();
+        for (name, val) in changed {
+            super::regex_helpers::dynvar_overlay_put(&name, val);
+        }
+    }
+
     /// Create an X::Syntax::Regex::QuantifierValue exception with the given flag attribute set to True.
     pub(super) fn make_quantifier_value_error(flag: &str, message: &str) -> RuntimeError {
         let mut attrs = std::collections::HashMap::new();

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use unicode_normalization::UnicodeNormalization;
 use unicode_normalization::char::is_combining_mark;
 use unicode_segmentation::UnicodeSegmentation;
@@ -18,6 +19,105 @@ thread_local! {
     /// means `c` was the char just before the slice. Saved/restored around each
     /// subrule dispatch so nesting threads correctly.
     pub(crate) static REGEX_PRECEDING_CHAR: Cell<Option<char>> = const { Cell::new(None) };
+    /// Parse-scoped overlay of `$*` dynamic-variable values written by grammar
+    /// action methods that run at *reduce time* (during matching). The regex
+    /// match engine is `&self`, so an action's dyn-var write (e.g.
+    /// Template::Mustache's delimiter finalizer `($*LEFT,$*RIGHT)=@delim`) cannot
+    /// mutate `self.env` mid-match. Instead the reduce-time action runs in a
+    /// scratch interpreter and its changed `$*` vars are published here;
+    /// `interpolate_regex_scalars` consults this overlay BEFORE `self.env` so
+    /// subsequent subrule matches re-interpolate their patterns with the new
+    /// values. `Some` only while a grammar-actions parse is live (the common
+    /// non-grammar case stays `None` for zero lookup cost). Keyed by the env name
+    /// form (sigil-less, twigil-kept: `$*LEFT` -> `"*LEFT"`).
+    pub(crate) static REGEX_DYNVAR_OVERLAY: RefCell<Option<HashMap<String, Value>>> = const { RefCell::new(None) };
+    /// Set true once `interpolate_regex_scalars` resolves a `$*` dynamic var
+    /// while a grammar-actions parse is live — i.e. the grammar's matching
+    /// actually depends on a dynamic variable. The reduce-time action hook only
+    /// fires when this is true, so ordinary (non-dyn-var) grammars pay nothing.
+    pub(crate) static REGEX_GRAMMAR_DYNVAR_SEEN: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Look up a `$*` dynamic var in the reduce-time overlay (see
+/// `REGEX_DYNVAR_OVERLAY`). `name` is the env form without sigil (e.g. `*LEFT`).
+/// Returns `None` when the overlay is inactive or has no entry for the name.
+pub(crate) fn dynvar_overlay_get(name: &str) -> Option<Value> {
+    REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow().as_ref().and_then(|m| m.get(name).cloned()))
+}
+
+/// True while a grammar-actions parse has an active dyn-var overlay.
+pub(crate) fn dynvar_overlay_active() -> bool {
+    REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow().is_some())
+}
+
+/// Record that the live grammar parse interpolated a `$*` dynamic var, enabling
+/// the reduce-time action hook for the rest of the parse.
+pub(crate) fn dynvar_mark_seen() {
+    REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.set(true));
+}
+
+/// Whether any `$*` dynamic var has been interpolated during the live parse.
+pub(crate) fn dynvar_seen() -> bool {
+    REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.get())
+}
+
+/// Reset the overlay to empty (and clear the SEEN flag) at the start of a fresh
+/// top-level grammar scan. A scan evolves the overlay left-to-right; a NEW scan
+/// of the whole input (e.g. the candidate-selection pass vs the real match, or a
+/// re-`parse`) must begin with the initial dynamic-var state from `self.env`,
+/// not the values a previous scan left behind. No-op when the overlay is
+/// inactive (non-grammar matching).
+pub(crate) fn dynvar_overlay_reset_scan() {
+    REGEX_DYNVAR_OVERLAY.with(|slot| {
+        let mut b = slot.borrow_mut();
+        if b.is_some() {
+            *b = Some(HashMap::new());
+        }
+    });
+    REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.set(false));
+}
+
+/// Clone the current overlay contents (empty when inactive). Used to seed a
+/// reduce-time action's scratch interpreter with the latest dyn-var values.
+pub(crate) fn dynvar_overlay_snapshot() -> HashMap<String, Value> {
+    REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow().clone().unwrap_or_default())
+}
+
+/// Publish a changed `$*` dynamic var into the overlay so subsequent subrule
+/// pattern interpolation sees it. `name` is the env form (e.g. `*LEFT`).
+pub(crate) fn dynvar_overlay_put(name: &str, value: Value) {
+    REGEX_DYNVAR_OVERLAY.with(|slot| {
+        if let Some(m) = slot.borrow_mut().as_mut() {
+            m.insert(name.to_string(), value);
+        }
+    });
+}
+
+/// RAII guard that activates the reduce-time dyn-var overlay for the duration of
+/// a grammar-actions parse and restores the previous state (overlay + seen flag)
+/// on drop, so nested/re-entrant `Grammar.parse` calls stay balanced.
+pub(crate) struct RegexDynvarOverlayGuard {
+    prev_overlay: Option<HashMap<String, Value>>,
+    prev_seen: bool,
+}
+
+impl RegexDynvarOverlayGuard {
+    pub(crate) fn activate() -> Self {
+        let prev_overlay =
+            REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow_mut().replace(HashMap::new()));
+        let prev_seen = REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.replace(false));
+        RegexDynvarOverlayGuard {
+            prev_overlay,
+            prev_seen,
+        }
+    }
+}
+
+impl Drop for RegexDynvarOverlayGuard {
+    fn drop(&mut self) {
+        REGEX_DYNVAR_OVERLAY.with(|slot| *slot.borrow_mut() = self.prev_overlay.take());
+        REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.set(self.prev_seen));
+    }
 }
 
 /// Restores `REGEX_PRECEDING_CHAR` to a saved value when dropped, so a subrule

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -924,6 +924,15 @@ impl Interpreter {
                                     iter_pos_base,
                                     apply_named_capture(token, current, next, pos_base, new_caps),
                                 );
+                                // Reduce-time grammar action: when a `<subrule>`
+                                // quantifier iteration commits inside an
+                                // action-driven parse whose matching depends on a
+                                // `$*` dynamic var, run this iteration's subrule
+                                // action now so any dyn-var write (e.g. a delimiter
+                                // finalizer) is visible to the next iteration's
+                                // pattern interpolation. Gated on the SEEN flag so
+                                // plain grammars pay nothing.
+                                self.maybe_run_reduce_time_dynvar_action(token, &new_caps);
                                 current_caps = new_caps.clone();
                                 positions.push((next, new_caps));
                                 current = next;
@@ -1155,6 +1164,15 @@ impl Interpreter {
                                     iter_pos_base,
                                     apply_named_capture(token, current, next, pos_base, new_caps),
                                 );
+                                // Reduce-time grammar action: when a `<subrule>`
+                                // quantifier iteration commits inside an
+                                // action-driven parse whose matching depends on a
+                                // `$*` dynamic var, run this iteration's subrule
+                                // action now so any dyn-var write (e.g. a delimiter
+                                // finalizer) is visible to the next iteration's
+                                // pattern interpolation. Gated on the SEEN flag so
+                                // plain grammars pay nothing.
+                                self.maybe_run_reduce_time_dynvar_action(token, &new_caps);
                                 current_caps = new_caps.clone();
                                 positions.push((next, new_caps));
                                 current = next;

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -5041,10 +5041,19 @@ impl Interpreter {
                         continue;
                     }
                     let name: String = chars[name_start..j].iter().collect();
-                    let value = self
-                        .env
-                        .get(&name)
-                        .cloned()
+                    // Reduce-time dyn-var overlay: a `$*` var written by a grammar
+                    // action mid-parse takes precedence over `self.env` so the next
+                    // subrule matches with the updated value (see REGEX_DYNVAR_OVERLAY).
+                    let overlay_value = if name.starts_with('*')
+                        && super::regex::regex_helpers::dynvar_overlay_active()
+                    {
+                        super::regex::regex_helpers::dynvar_mark_seen();
+                        super::regex::regex_helpers::dynvar_overlay_get(&name)
+                    } else {
+                        None
+                    };
+                    let value = overlay_value
+                        .or_else(|| self.env.get(&name).cloned())
                         .or_else(|| self.env.get(&format!("${name}")).cloned())
                         .unwrap_or(Value::Nil);
                     let value = value.into_deref();
@@ -5320,6 +5329,13 @@ impl Interpreter {
                         | ':'
                         | '#'
                         | '\''
+                        // `%` (and `%%`) is the separator-quantifier infix and `&`
+                        // is the conjunction infix; an interpolated scalar matches
+                        // *literally* (raku does not re-parse it as regex source),
+                        // so e.g. a `%>` delimiter after `\h*` must not bind as a
+                        // `\h* % ...` separator. Escape them to force literal match.
+                        | '%'
+                        | '&'
                 )
             {
                 out.push('\\');

--- a/t/grammar-reduce-time-dynvar.t
+++ b/t/grammar-reduce-time-dynvar.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Reduce-time grammar actions: a `$*` dynamic variable written by an action that
+# runs while a `<subrule>*` quantifier is still matching must affect the matching
+# of subsequent iterations. This models Template::Mustache's `{{=<% %>=}}`
+# delimiter change, where a tag finalizer reassigns `($*LEFT,$*RIGHT)`.
+
+plan 6;
+
+grammar G {
+    regex TOP { <chunk>* (.*) }
+    regex chunk { (\w+?) [ <delim> | <var> ] }
+    token delim { $*L '=' (\w+) '=' $*R }
+    token var { $*L (\w+) $*R }
+}
+class A {
+    has @.vars;
+    method chunk($/) { ($<delim>//$<var>).?made }
+    method var($/)   { @!vars.push(~$0) }
+    method delim($/) { my $f = { $*L = '<'; $*R = '>'; }; $f() }
+}
+
+my $a = A.new;
+my $*L = '{';
+my $*R = '}';
+my $m = G.parse('a{=x=}b<c>', :actions($a));
+ok $m.defined, 'parse succeeded across a mid-parse delimiter change';
+is $m<chunk>.elems, 2, 'both chunks matched (delimiter change took effect)';
+is ~$m<chunk>[0], 'a{=x=}', 'first chunk used the original delimiters';
+is ~$m<chunk>[1], 'b<c>', 'second chunk used the new delimiters';
+is $a.vars.join(','), 'c', 'var action saw the chunk matched under new delimiters';
+
+# An interpolated scalar matches literally even when it ends/starts with the
+# separator-quantifier infix `%`, which must not bind to a preceding `\h*`.
+my $*LEFT = '<%';
+my $*RIGHT = '%>';
+ok ('<% bar %>' ~~ / $*LEFT \h* (\w+) \h* $*RIGHT /).defined,
+    'multi-char delimiter containing % interpolates as a literal match';


### PR DESCRIPTION
## Summary

Implements **reduce-time grammar actions for `$*` dynamic-variable writes**, so a `<subrule>*`/`+` iteration's action that reassigns a dynamic variable affects the matching of subsequent iterations. This is the long-standing Template::Mustache `{{=<% %>=}}` **delimiter-change** blocker (PART 2 of the incremental grammar-actions work).

In Template::Mustache, a tag finalizer reassigns `($*LEFT,$*RIGHT)` from inside `method hunk`; the regex tokens reference `$*LEFT`/`$*RIGHT`, so subsequent tags must match with the new delimiters. mutsu runs actions post-parse, so the write never affected the live match.

## Mechanism

The regex match engine is `&self`, so an action's dyn-var write cannot mutate `self.env` mid-match. Instead:

- **Overlay** (`REGEX_DYNVAR_OVERLAY`, thread-local): parse-scoped map of `$*` values written at reduce time. `interpolate_regex_scalars` consults it before `self.env` for `$*`-twigil names. A **SEEN gate** (set on the first `$*` interpolation during a grammar-actions parse) means non-dyn-var grammars pay nothing.
- **Reduce hook**: after each `<subrule>` quantifier iteration commits, its action runs in a scratch interpreter on a **deep-copied** actions object (so `self`-mutations don't leak — the authoritative post-parse pass is the one whose `make`/`self` effects count). Changed `$*` vars are published to the overlay.
- **Scan reset**: the overlay is reset between the candidate-selection pass and the real match so a previous scan's evolved delimiters don't leak into a fresh scan.

## Independent fix

Escape `%` and `&` in `escape_regex_scalar_literal`: an interpolated scalar matches *literally*, so a `%>` delimiter after `\h*` must not bind as a `\h* % ...` separator-quantifier. Pre-existing bug that also blocked the multi-char `<% %>` delimiters.

## Results

- **Template::Mustache 01-basic: 8/10 → 10/10** (delimiter change + `{{=delim=}}` substitution).
- **Template::Mustache 13-pragmas**: full pass.
- No regression across all 91 whitelisted S05 (grammar/regex) tests, S03/S32-str, and `make test` (9763 tests).

Pin: `t/grammar-reduce-time-dynvar.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)