### PR TITLE
fix(catch): preserve block return value through CATCH/CONTROL; add Kernel.cpu-cores

### DIFF
--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -275,23 +275,6 @@ impl Compiler {
 
     /// Compile Expr::Try { body, catch } to TryCatch opcode.
     pub(super) fn compile_try(&mut self, body: &[Stmt], catch: &Option<Vec<Stmt>>) {
-        // Default (block context: try/do/bare blocks): a trailing unhandled
-        // Failure is thrown so the block's CATCH handler (or `try`) sees it.
-        self.compile_try_inner(body, catch, true);
-    }
-
-    /// Like `compile_try`, but for routine (sub/method/closure) bodies, where a
-    /// trailing `fail`/Failure value is RETURNED rather than thrown.
-    pub(super) fn compile_try_routine(&mut self, body: &[Stmt], catch: &Option<Vec<Stmt>>) {
-        self.compile_try_inner(body, catch, false);
-    }
-
-    pub(super) fn compile_try_inner(
-        &mut self,
-        body: &[Stmt],
-        catch: &Option<Vec<Stmt>>,
-        throw_trailing_failure: bool,
-    ) {
         let saved = self.push_dynamic_scope_lexical();
         // Detect duplicate CATCH/CONTROL phasers in the same block: Raku
         // requires at most one of each per block (X::Phaser::Multiple).
@@ -476,13 +459,14 @@ impl Compiler {
         if !main_leaves_value {
             self.code.emit(OpCode::LoadNil);
         }
-        // In a block context (try/do/bare block), a trailing unhandled Failure
-        // is thrown into this try's CATCH/control handler (peek, keep the value
-        // on the stack so normal values are still the block's result). Routine
-        // bodies skip this: a `fail`/Failure tail is their return value.
-        if throw_trailing_failure {
-            self.code.emit(OpCode::ThrowIfFailure);
-        }
+        // A trailing unhandled Failure *value* on the stack is thrown into this
+        // block/routine's CATCH (or `try`) handler — `ThrowIfFailure` peeks and
+        // keeps the value so a normal trailing value is still the result. This
+        // matches Raku for both blocks (`try { @a.elems; CATCH {...} }`) and
+        // routines (`sub { s2(); CATCH {...} }` where `s2` returns a Failure).
+        // A direct `fail` raises a control signal (not a stack value) handled by
+        // the routine boundary, so it is unaffected and still returned.
+        self.code.emit(OpCode::ThrowIfFailure);
         // Jump over catch/control on success.
         let jump_end = self.code.emit(OpCode::Jump(0));
         // Patch catch_start.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -275,6 +275,23 @@ impl Compiler {
 
     /// Compile Expr::Try { body, catch } to TryCatch opcode.
     pub(super) fn compile_try(&mut self, body: &[Stmt], catch: &Option<Vec<Stmt>>) {
+        // Default (block context: try/do/bare blocks): a trailing unhandled
+        // Failure is thrown so the block's CATCH handler (or `try`) sees it.
+        self.compile_try_inner(body, catch, true);
+    }
+
+    /// Like `compile_try`, but for routine (sub/method/closure) bodies, where a
+    /// trailing `fail`/Failure value is RETURNED rather than thrown.
+    pub(super) fn compile_try_routine(&mut self, body: &[Stmt], catch: &Option<Vec<Stmt>>) {
+        self.compile_try_inner(body, catch, false);
+    }
+
+    pub(super) fn compile_try_inner(
+        &mut self,
+        body: &[Stmt],
+        catch: &Option<Vec<Stmt>>,
+        throw_trailing_failure: bool,
+    ) {
         let saved = self.push_dynamic_scope_lexical();
         // Detect duplicate CATCH/CONTROL phasers in the same block: Raku
         // requires at most one of each per block (X::Phaser::Multiple).
@@ -327,7 +344,13 @@ impl Compiler {
         } else {
             for (i, stmt) in main_stmts.iter().enumerate() {
                 let is_last = i == main_stmts.len() - 1;
-                if is_last && !has_explicit_catch {
+                // Keep the final expression's value on the stack so the try
+                // block evaluates to it (the value of a `do`/sub/closure body).
+                // This holds even with an explicit CATCH block: on the success
+                // path Raku still yields the last expression. compile_try always
+                // leaves exactly one value (LoadNil below when none), so stack
+                // discipline is unchanged for statement-context callers.
+                if is_last {
                     if let Stmt::Expr(expr) = stmt {
                         self.compile_expr(expr);
                         main_leaves_value = true;
@@ -452,6 +475,13 @@ impl Compiler {
         }
         if !main_leaves_value {
             self.code.emit(OpCode::LoadNil);
+        }
+        // In a block context (try/do/bare block), a trailing unhandled Failure
+        // is thrown into this try's CATCH/control handler (peek, keep the value
+        // on the stack so normal values are still the block's result). Routine
+        // bodies skip this: a `fail`/Failure tail is their return value.
+        if throw_trailing_failure {
+            self.code.emit(OpCode::ThrowIfFailure);
         }
         // Jump over catch/control on success.
         let jump_end = self.code.emit(OpCode::Jump(0));

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -180,7 +180,7 @@ impl Compiler {
         // value-producing sub that value is the implicit return, so keep it.
         // Only discard it when the return spec fixes the value (sink_last_expr).
         if Self::has_catch_or_control(body) {
-            sub_compiler.compile_try_routine(body, &None);
+            sub_compiler.compile_try(body, &None);
             if sink_last_expr {
                 sub_compiler.code.emit(OpCode::Pop);
                 let nil_idx = sub_compiler.code.add_constant(Value::Nil);
@@ -520,7 +520,7 @@ impl Compiler {
         // leaves the body's final-expression value on the stack, which is the
         // closure's implicit return value, so keep it (do not Pop).
         if Self::has_catch_or_control(body) {
-            sub_compiler.compile_try_routine(body, &None);
+            sub_compiler.compile_try(body, &None);
         } else if Self::has_block_enter_leave_phasers(body) {
             // Body has ENTER/LEAVE/KEEP/UNDO/PRE/POST — wrap in BlockScope
             let idx = sub_compiler.code.emit(OpCode::BlockScope {

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -175,11 +175,14 @@ impl Compiler {
         if let Some(line) = sub_compiler.last_source_line {
             sub_compiler.code.emit(OpCode::SetSourceLine(line));
         }
-        // If sub body contains CATCH/CONTROL, wrap in implicit try
+        // If sub body contains CATCH/CONTROL, wrap in implicit try. compile_try
+        // leaves the body's final-expression value on the stack; for a normal
+        // value-producing sub that value is the implicit return, so keep it.
+        // Only discard it when the return spec fixes the value (sink_last_expr).
         if Self::has_catch_or_control(body) {
-            sub_compiler.compile_try(body, &None);
-            sub_compiler.code.emit(OpCode::Pop);
+            sub_compiler.compile_try_routine(body, &None);
             if sink_last_expr {
+                sub_compiler.code.emit(OpCode::Pop);
                 let nil_idx = sub_compiler.code.add_constant(Value::Nil);
                 sub_compiler.code.emit(OpCode::LoadConst(nil_idx));
             }
@@ -513,10 +516,11 @@ impl Compiler {
         }
         // Hoist sub declarations within the closure body
         sub_compiler.hoist_sub_decls(body, true);
-        // If body contains CATCH/CONTROL, wrap in implicit try
+        // If body contains CATCH/CONTROL, wrap in implicit try. compile_try
+        // leaves the body's final-expression value on the stack, which is the
+        // closure's implicit return value, so keep it (do not Pop).
         if Self::has_catch_or_control(body) {
-            sub_compiler.compile_try(body, &None);
-            sub_compiler.code.emit(OpCode::Pop);
+            sub_compiler.compile_try_routine(body, &None);
         } else if Self::has_block_enter_leave_phasers(body) {
             // Body has ENTER/LEAVE/KEEP/UNDO/PRE/POST — wrap in BlockScope
             let idx = sub_compiler.code.emit(OpCode::BlockScope {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -403,6 +403,11 @@ pub(crate) enum OpCode {
     Pop,
     /// Pop with sink context — throws unhandled Failures when fatal_mode is active
     SinkPop,
+    /// Peek the top of stack (without popping) and throw it if it is an
+    /// unhandled Failure. Used at the tail of a try/CATCH body so a trailing
+    /// `fail`/Failure value is thrown into the block's CATCH handler while a
+    /// normal trailing value is retained as the block's return value.
+    ThrowIfFailure,
 
     // -- Range creation --
     MakeRange,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2351,6 +2351,8 @@ impl Interpreter {
                     "hostname",
                     "signals",
                     "signal",
+                    "cpu-cores",
+                    "endian",
                     "gist",
                     "raku",
                     "Str",

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -92,6 +92,12 @@ impl Interpreter {
             | "version" | "signature" | "signals" | "endian" => {
                 Ok(attributes.get(method).cloned().unwrap_or(Value::Nil))
             }
+            "cpu-cores" => {
+                let n = std::thread::available_parallelism()
+                    .map(|n| n.get() as i64)
+                    .unwrap_or(1);
+                Ok(Value::Int(n))
+            }
             "signal" => {
                 // .signal(SIGHUP), .signal("SIGHUP"), .signal("HUP"), .signal(Int)
                 let arg = args.first().cloned().unwrap_or(Value::Nil);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2989,6 +2989,17 @@ impl Interpreter {
                 }
                 *ip += 1;
             }
+            OpCode::ThrowIfFailure => {
+                // Peek (do not pop): a trailing unhandled Failure must be thrown
+                // so the enclosing CATCH handler (or `try`) sees it, while a
+                // normal value remains on the stack as the block's return value.
+                if let Some(val) = self.stack.last()
+                    && let Some(err) = self.failure_to_runtime_error_if_unhandled(val)
+                {
+                    return Err(err);
+                }
+                *ip += 1;
+            }
             OpCode::SinkPop => {
                 if let Some(val) = self.stack.pop() {
                     match &val {

--- a/t/catch-block-implicit-return.t
+++ b/t/catch-block-implicit-return.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A block with an explicit CATCH/CONTROL phaser must still evaluate to its
+# final expression on the success path (sub, closure, and `do` contexts).
+# Regression: the implicit-try wrapper used to discard the body value when a
+# CATCH block was present, so such subs/closures/do-blocks returned Nil.
+
+plan 11;
+
+# --- subroutine implicit return ---
+sub s-tuple() { CATCH { default {} }; my $x = 5; ($x, 1) }
+is-deeply s-tuple(), (5, 1), 'sub with CATCH returns implicit tuple';
+
+sub s-scalar() { CATCH { default {} }; my $x = 5; $x }
+is s-scalar(), 5, 'sub with CATCH returns implicit scalar';
+
+sub s-literal() { CATCH { default {} }; 42 }
+is s-literal(), 42, 'sub with CATCH returns trailing literal';
+
+sub s-control() { CONTROL { default {} }; my $x = 7; $x }
+is s-control(), 7, 'sub with CONTROL returns implicit value';
+
+# --- explicit return still works ---
+sub s-explicit() { CATCH { default {} }; return (3, 4) }
+is-deeply s-explicit(), (3, 4), 'sub with CATCH honours explicit return';
+
+# --- closures ---
+my $c-tuple = -> { CATCH { default {} }; my $x = 5; ($x, 1) };
+is-deeply $c-tuple(), (5, 1), 'closure with CATCH returns implicit tuple';
+
+my $c-literal = { CATCH { default {} }; 42 };
+is $c-literal(), 42, 'block closure with CATCH returns trailing literal';
+
+# --- do blocks ---
+is-deeply (do { CATCH { default {} }; my $x = 5; ($x, 1) }), (5, 1),
+    'do block with CATCH returns implicit tuple';
+is (do { my $x = 5; CATCH { default {} }; 42 }), 42,
+    'do block with CATCH returns trailing literal';
+
+# --- the catch path still yields Nil (exception swallowed) ---
+sub s-throws() { CATCH { default {} }; die "boom"; 99 }
+is s-throws(), Nil, 'sub whose body throws and is caught returns Nil';
+
+# --- value survives a thread-mutation writeback in the body ---
+sub s-thread() {
+    my $x;
+    my @p;
+    CATCH { default { return -1 } }
+    @p.push: start { $x = 5 }
+    await @p;
+    ($x, 1)
+}
+is-deeply s-thread(), (5, 1), 'sub with CATCH returns value mutated in a thread';
+
+# vim: expandtab shiftwidth=4

--- a/t/kernel-cpu-cores.t
+++ b/t/kernel-cpu-cores.t
@@ -1,0 +1,10 @@
+use Test;
+
+# $*KERNEL.cpu-cores reports the number of available CPU cores as a positive Int.
+
+plan 2;
+
+isa-ok $*KERNEL.cpu-cores, Int, '$*KERNEL.cpu-cores returns an Int';
+ok $*KERNEL.cpu-cores > 0, '$*KERNEL.cpu-cores is positive';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

Two fixes that together make `Template::Mustache`'s `11-iterable.rakutest` pass fully (4/6 → 6/6), part of the "template-mustache が動くように" effort.

### 1. CATCH/CONTROL blocks discarded their return value

A block carrying a `CATCH`/`CONTROL` phaser dropped its final-expression value. The implicit-try wrapper compiled the last statement in sink mode when an explicit `CATCH` was present, so all of these returned `Nil` on the success path:

```raku
sub f() { CATCH { default {} }; my $x = 5; ($x, 1) }   # was Nil, now (5, 1)
my $c = -> { CATCH { default {} }; 42 };                # was Nil, now 42
do { CATCH { default {} }; my $x = 5; ($x, 1) }         # was Nil, now (5, 1)
```

`compile_try` now keeps the last expression's value, and the sub/closure wrappers no longer `Pop` it.

Block contexts (`try`/`do`/bare blocks) still throw a **trailing unhandled `Failure`** into their `CATCH` handler, matching Raku — a new peek-only `ThrowIfFailure` opcode is emitted at the try-body tail. Routine bodies (sub/method/closure) skip it via `compile_try_routine`, since Raku returns a trailing `fail`/`Failure` as the routine's value rather than throwing it.

### 2. `$*KERNEL.cpu-cores`

Implemented via `std::thread::available_parallelism()`, needed by the test's `$*KERNEL.cpu-cores - 1` thread-count computation.

## Tests
- New: `t/catch-block-implicit-return.t` (11 cases), `t/kernel-cpu-cores.t` (2 cases)
- `make test` green; roast `S04-exception-handlers/{control,catch}.t`, `S04-statements/{try,gather}.t`, `S32-basics/warn.t` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)