### PR TITLE
feat(single-store): caller-frame by-name write slot writeback (Sub-slice 1b slice 1.18)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -417,7 +417,7 @@ pin=`t/undefine-lvalue-writeback-coherence.t`（3）。`S32-scalar/undef.t` ON/O
 これまでの「決定的 OFF 依存 = 0 到達」は **t/ のみの `^not ok` survey** に基づく過小評価だった。`MUTSU_NO_BLANKET_RECONCILE=1
 make roast`（release・全 whitelist 1285）を実走したところ、**13 ファイルが OFF で決定的に fail**（全て pre-existing＝
 main baseline でも同じ subtest が OFF fail・本スライスの変更とは無関係＝debug 比較で確認）。これが env_dirty 物理削除
-（§7.4）を解禁するために潰すべき残サーフェス（初回 13 → slice 1.13 で substr-rw.t/buf.t、slice 1.14 で zip.t、slice 1.15 で map.t、slice 1.16 で undef.t、slice 1.17 で proto.t/subsignature.t 消化 → **残 6**）:
+（§7.4）を解禁するために潰すべき残サーフェス（初回 13 → slice 1.13 で substr-rw.t/buf.t、slice 1.14 で zip.t、slice 1.15 で map.t、slice 1.16 で undef.t、slice 1.17 で proto.t/subsignature.t、slice 1.18 で caller.t/callframe.t 消化 → **残 4**）:
 
 | file | failed subtests | 推定カテゴリ | 状態 |
 |------|-----------------|--------------|------|
@@ -425,8 +425,8 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
 | ~~S03-operators/buf.t~~ | 38 | subbuf-rw lvalue slot writeback | ✅ slice 1.13 |
 | S02-types/lazy-lists.t | 24-26 | lazy list captured-outer | |
 | ~~S03-metaops/zip.t~~ | 68, 71 | Z-cross topicalizing thunk writeback | ✅ slice 1.14 |
-| S02-names/caller.t | 9 | callframe/caller | |
-| S06-advanced/callframe.t | 12 | callframe | |
+| ~~S02-names/caller.t~~ | 9 | caller-frame by-name write slot writeback | ✅ slice 1.18 |
+| ~~S06-advanced/callframe.t~~ | 12 | caller-frame by-name write slot writeback | ✅ slice 1.18 |
 | ~~S06-multi/proto.t~~ | 21 | caching proto `state %` writeback | ✅ slice 1.17 |
 | ~~S06-multi/subsignature.t~~ | 54 | caching proto `state %` writeback | ✅ slice 1.17 |
 | S06-signature/code.t | 8 | `&`-param signature | |
@@ -435,7 +435,7 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
 | ~~S32-scalar/undef.t~~ | 85 | undefine() lvalue slot writeback | ✅ slice 1.16 |
 | S32-io/IO-Socket-Async.t | 5, 7 | reactive 並行（flaky 疑い） | |
 
-**残 8 の triage（第45セッション・実測済）**:
+**triage（第45〜46セッション・実測済）**:
 - ~~**map.t 62**~~ ✅ **slice 1.15 で消化**（§7.1k）。`.map({ LAST $x=True })` の LAST phaser body は map body と**別に**
   コンパイル・実行される（`resolution.rs:2253`）ので、map body の `record_eager_block_free_var_writeback`（:2276）が
   phaser の write を拾わなかった。phaser 実行直後に `record_eager_block_free_var_writeback(&phaser_code, &[])` 追加で解決。
@@ -458,14 +458,22 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
   in-place push は元々 coherent で非該当。教訓: run_inner の state persist は `sync_state_locals`（env 優先・476）→
   `sync_env_from_locals`（480）順なので、reorder（env flush 先）は逆効果（stale local が fresh env を clobber）＝源流の
   divergence 修正が正解。pin=`t/proto-state-cache-writeback-coherence.t`（6・ON/OFF 両 PASS）。make test 9788。
-- **残り（全て第45セッションで ON=PASS/OFF=FAIL を実測＝純 writeback コヒーレンス・露出バグではない）**:
-  - **callframe.t 12**: `f()` が `callframe(1)` introspection 経由で caller の `$x is dynamic` を書く（callframe write-back）。
-  - **caller.t 9**: `$CALLER::` 経由の rw dynamic-var write。**callframe.t と同機構（caller-frame 名前書き）＝次の最有力。**
+- ~~**caller.t 9 ＋ callframe.t 12**~~ ✅ **slice 1.18 で消化（1 修正で 2 file・第46セッション）**。caller-frame の
+  lexical を名前書きする `$CALLER::x = v`（rw dynamic-var）／`callframe(d).my.<$x> = v` が OFF=stale（ON=書込成功）。
+  真因＝`set_caller_var`（mod.rs:5327）は `caller_env_stack[idx]` と現在 env に書き、`pop_caller_env_with_writeback`
+  （mod.rs:5277）が return 時に restored caller env へ dynamic var を伝播するが、**caller の local slot は未更新**＝OFF で
+  stale slot を読む。修正＝`set_caller_var` で書いた bare name を**新リスト `pending_caller_var_writeback`** に push し、
+  call-site の `apply_pending_rw_writeback` が `env[name]`→slot に drain。★`pending_rw_writeback_sources`（drop-on-miss）
+  と分離した理由＝caller-frame の slot は数フレーム上にあり、writer が return 前に**より深い**呼び出しをすると（`f(){ callframe(1).my.<$x>=v; g() }`）pending が g() の call-site で1フレーム早く消費される→**retain-on-miss**（slot が
+  当該 code に無ければ破棄せず保持し、所有フレームまで運ぶ）。`is dynamic` でない caller lexical は従来通り die。
+  pin=`t/caller-frame-write-slot-coherence.t`（5・ON/OFF 両 PASS）。make test 9799。
+- **残り 2（純 writeback でない＝別軸）**:
   - **destruction.t 3**: `submethod DESTROY { $x++ }` の GC 時 captured write（最小再現は GC タイミング依存で要工夫）。
-  - **code.t 8（`&`-param）**: ★doc 冒頭 Status の設計ノートは「cell boxing が `&foo=&foo` self-ref 型チェック欠落を露出」型と
-    示唆＝**writeback でなく露出バグの可能性・着手前に要確認**（最小再現 `sub foo(&foo = &foo){...}`・第46で確認＝scoping バグ・別軸）。
+  - **code.t 8（`&`-param）**: `sub foo(&foo = &foo){...}` の default scoping バグ＝**writeback でなく露出バグ**（第46で確認・別軸）。
+  - ＋別軸: lazy-lists.t 24-26（laziness バグ・L 系）／IO-Socket-Async.t 5,7（flaky）。
 
-**残 4（caller/callframe/code/destruction）＋別軸 2（lazy-lists laziness・IO-Socket-Async flaky）全消化後に §7.4（env_dirty 削除）が射程**。
+**残 2（code.t scoping・destruction.t GC＝いずれも純 writeback でない別軸）＋別軸 2（lazy-lists laziness・IO-Socket-Async flaky）
+全消化後に §7.4（env_dirty 削除）が射程**。純 writeback コヒーレンスのサーフェスは slice 1.18 で枯渇。
 
 ### 7.2b ✅ proto `{*}` redispatch ＋ `state` var coherence（proto.t 21 / subsignature.t 54）= slice 1.17 で解決
 **実際の真因は当初推測（`restore_env_preserving_existing` が state を巻き戻す）とは別だった。** plain `state %h` を持つ

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1259,6 +1259,15 @@ pub struct Interpreter {
     /// straight through to the caller's local slot, so the slot stays coherent
     /// without the reverse `sync_locals_from_env` pull.
     pub(crate) pending_rw_writeback_sources: Vec<String>,
+    /// Like `pending_rw_writeback_sources` but for writes that target a *caller
+    /// frame's* lexical by name (`callframe(d).my.<$x> = v` / `$CALLER::x = v`).
+    /// These differ in two ways: (1) the target slot lives several frames up, not
+    /// in the immediate caller, so a source unmatched at one call site must be
+    /// RETAINED (not dropped) until it reaches the frame that owns the slot — an
+    /// intervening *deeper* call (the writer making another call before returning)
+    /// must not consume it; (2) the value is read from env at drain time, same as
+    /// the rw list. Drained at the same call sites, with retain-on-miss semantics.
+    pub(crate) pending_caller_var_writeback: Vec<String>,
     pub(crate) local_bind_pairs: Vec<(usize, usize)>,
     pub(crate) otf_compile_cache: HashMap<u64, CompiledFunction>,
     pub(crate) state_scope_id: Option<u64>,
@@ -3419,6 +3428,7 @@ impl Interpreter {
             explicit_initializer_context: false,
             vardecl_context: false,
             pending_rw_writeback_sources: Vec::new(),
+            pending_caller_var_writeback: Vec::new(),
             local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),
             state_scope_id: None,
@@ -5347,6 +5357,19 @@ impl Interpreter {
         if self.env.contains_key(name) {
             self.env.insert(name.to_string(), value);
         }
+        // Single-store coherence: this write targets a *caller frame's* lexical by
+        // name (`callframe(d).my.<$x> = v` / `$CALLER::x = v`). `pop_caller_env_
+        // with_writeback` propagates it into the restored caller env on return, but
+        // the caller's local *slot* is not refreshed when blanket reconcile is off,
+        // so the caller reads the stale slot. Record the bare name so the call site
+        // drains `env[name]` into that slot. Uses the caller-var list (retain-on-
+        // miss) rather than the rw list, so an intervening deeper call the writer
+        // makes before returning does not consume it one frame too soon. No-op when
+        // no such slot exists; the default build's blanket reconcile makes it
+        // redundant = byte-identical.
+        if !self.pending_caller_var_writeback.iter().any(|n| n == name) {
+            self.pending_caller_var_writeback.push(name.to_string());
+        }
         Ok(())
     }
 
@@ -5981,6 +6004,7 @@ impl Interpreter {
             explicit_initializer_context: false,
             vardecl_context: false,
             pending_rw_writeback_sources: Vec::new(),
+            pending_caller_var_writeback: Vec::new(),
             local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),
             state_scope_id: None,

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -626,18 +626,46 @@ impl Interpreter {
     /// `drain_and_reconcile_after_cached_call` (and the slow call path) runs at
     /// each frame's call site.
     pub(super) fn apply_pending_rw_writeback(&mut self, code: &CompiledCode) {
-        if self.pending_rw_writeback_sources.is_empty() {
-            return;
-        }
-        let sources = std::mem::take(&mut self.pending_rw_writeback_sources);
-        for source in sources {
-            if let Some(slot) = self.find_local_slot(code, &source)
-                && !matches!(self.locals[slot], Value::HashSlotRef { .. })
-                && let Some(val) = self.env().get(&source).cloned()
-            {
-                self.locals[slot] = val;
+        if !self.pending_rw_writeback_sources.is_empty() {
+            let sources = std::mem::take(&mut self.pending_rw_writeback_sources);
+            for source in sources {
+                if let Some(slot) = self.find_local_slot(code, &source)
+                    && !matches!(self.locals[slot], Value::HashSlotRef { .. })
+                    && let Some(val) = self.env().get(&source).cloned()
+                {
+                    self.locals[slot] = val;
+                }
             }
         }
+        self.apply_pending_caller_var_writeback(code);
+    }
+
+    /// Drain caller-frame-targeted writes (`$CALLER::x = v` / `callframe(d).my.<$x>
+    /// = v`). Unlike `pending_rw_writeback_sources`, a source whose slot is NOT in
+    /// this frame's `code` is RETAINED rather than dropped, because the target slot
+    /// lives an unknown number of frames up: the writer may make an intervening
+    /// *deeper* call (whose code lacks the slot) before returning to the frame that
+    /// owns it, and that deeper call's drain must not consume the pending write.
+    /// Each matched source is removed so it is applied exactly once.
+    pub(super) fn apply_pending_caller_var_writeback(&mut self, code: &CompiledCode) {
+        if self.pending_caller_var_writeback.is_empty() {
+            return;
+        }
+        let sources = std::mem::take(&mut self.pending_caller_var_writeback);
+        let mut retained = Vec::new();
+        for source in sources {
+            if let Some(slot) = self.find_local_slot(code, &source) {
+                if !matches!(self.locals[slot], Value::HashSlotRef { .. })
+                    && let Some(val) = self.env().get(&source).cloned()
+                {
+                    self.locals[slot] = val;
+                }
+                // matched (slot exists in this frame) → applied, do not retain
+            } else {
+                retained.push(source);
+            }
+        }
+        self.pending_caller_var_writeback = retained;
     }
 
     /// Slice F (multi-frame coherence): drain after a *cached fast-call* dispatch

--- a/t/caller-frame-write-slot-coherence.t
+++ b/t/caller-frame-write-slot-coherence.t
@@ -1,0 +1,51 @@
+use Test;
+
+# Writing a caller frame's lexical by name — `$CALLER::x = v` or
+# `callframe(d).my.<$x> = v` — must refresh the caller's local *slot*, not just
+# its env entry, so the caller reads the new value (Sub-slice 1b).
+#
+# Root cause this pins: `set_caller_var` wrote the value into the caller env
+# (propagated on frame pop) but not the caller's local slot. With blanket
+# reconcile off (the single-store path) the caller read the stale slot. The fix
+# records the bare name on a retain-on-miss caller-var writeback list so the
+# call site drains env -> slot, surviving an intervening *deeper* call the
+# writer makes before returning. Verified ON and OFF (MUTSU_NO_BLANKET_RECONCILE).
+
+plan 5;
+
+# $CALLER:: read-modify-write of a dynamic var.
+{
+    my sub modify { $CALLER::foo++ }
+    my $foo is dynamic = 42;
+    modify();
+    is $foo, 43, '$CALLER::foo++ modifies the caller lexical';
+}
+
+# callframe(1).my.<$x> = v writes the caller's dynamic lexical.
+{
+    sub f1() { callframe(1).my.<$x> = 23 }
+    my $x is dynamic = 42;
+    f1();
+    is $x, 23, 'callframe(1).my.<$x> = v modifies the caller lexical';
+}
+
+# The write must survive an intervening *deeper* call made before the writer
+# returns (the pending writeback must not be consumed one frame too soon).
+{
+    sub deeper() { 99 }
+    sub f2() {
+        callframe(1).my.<$y> = 7;
+        deeper();           # intervening deeper call
+    }
+    my $y is dynamic = 0;
+    f2();
+    is $y, 7, 'caller-frame write survives an intervening deeper call';
+}
+
+# A non-dynamic caller lexical cannot be mutated this way (still dies).
+{
+    sub f3() { callframe(1).my.<$z> = 5 }
+    my $z = 100;
+    dies-ok { f3() }, 'cannot mutate a non-dynamic caller lexical';
+    is $z, 100, 'non-dynamic caller lexical unchanged';
+}


### PR DESCRIPTION
## Summary

Writing a caller frame's lexical by name — `$CALLER::x = v` (rw dynamic var) or `callframe(d).my.<$x> = v` — was lost on the single-store path (`MUTSU_NO_BLANKET_RECONCILE=1`): the caller read its stale local slot.

- `S06-advanced/callframe.t` subtest 12 (`$x successfully modified`)
- `S02-names/caller.t` subtest 9 (`$CALLER::` rw dynamic var)

## Root cause

`set_caller_var` writes the value into `caller_env_stack[idx]` and the current env, and `pop_caller_env_with_writeback` propagates dynamic-var changes into the restored caller env on return — but the caller's local **slot** is never refreshed. With blanket reconcile off, the caller reads the stale slot.

## Fix

Record the bare name written by `set_caller_var` so the call site drains `env[name]` into the caller's local slot. This uses a **new** list, `pending_caller_var_writeback`, kept separate from `pending_rw_writeback_sources` with **retain-on-miss** semantics:

- The target slot lives an unknown number of frames up, and the writer may make an intervening *deeper* call before returning (`sub f { callframe(1).my.<$x> = v; g() }`), whose call-site drain must NOT consume the pending write one frame too soon.
- A source whose slot is absent from the current frame's code is **retained** until it reaches the frame that owns it; a matched source is applied once and removed.
- `is dynamic`-less caller lexicals still die as before.

## Impact

One fix clears two roast files (both exercise caller-frame by-name writes). The default build's blanket reconcile already made the slot coherent, so the result is **byte-identical** there. OFF-survey writeback surface **6 → 4** (the remaining 4 are non-writeback: code.t `&`-param scoping, destruction.t GC timing, plus off-axis lazy-lists/IO-Socket-Async). The pure writeback-coherence surface is now exhausted.

## Testing

- Pin: `t/caller-frame-write-slot-coherence.t` (5, ON and OFF both pass)
- `roast/S06-advanced/callframe.t` and `roast/S02-names/caller.t` pass ON and OFF
- `make test`: 9799, Result PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)