### PR TITLE
fix(signature): parameter is in scope within its own default (self-shadow)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -429,7 +429,7 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
 | ~~S06-advanced/callframe.t~~ | 12 | caller-frame by-name write slot writeback | ✅ slice 1.18 |
 | ~~S06-multi/proto.t~~ | 21 | caching proto `state %` writeback | ✅ slice 1.17 |
 | ~~S06-multi/subsignature.t~~ | 54 | caching proto `state %` writeback | ✅ slice 1.17 |
-| S06-signature/code.t | 8 | `&`-param signature | |
+| ~~S06-signature/code.t~~ | 8 | `&`-param default self-scoping | ✅ slice 1.19 |
 | S12-construction/destruction.t | 3 | DESTROY phaser | |
 | ~~S32-list/map.t~~ | 62 | `.map` block LAST phaser writeback | ✅ slice 1.15 |
 | ~~S32-scalar/undef.t~~ | 85 | undefine() lvalue slot writeback | ✅ slice 1.16 |
@@ -467,13 +467,22 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
   と分離した理由＝caller-frame の slot は数フレーム上にあり、writer が return 前に**より深い**呼び出しをすると（`f(){ callframe(1).my.<$x>=v; g() }`）pending が g() の call-site で1フレーム早く消費される→**retain-on-miss**（slot が
   当該 code に無ければ破棄せず保持し、所有フレームまで運ぶ）。`is dynamic` でない caller lexical は従来通り die。
   pin=`t/caller-frame-write-slot-coherence.t`（5・ON/OFF 両 PASS）。make test 9799。
-- **残り 2（純 writeback でない＝別軸）**:
+- ~~**code.t 8（`&`-param）**~~ ✅ **slice 1.19 で消化（第47セッション・PR 別途）**。`sub foo(&foo = &foo){...}` の default
+  scoping バグ＝**writeback でなく露出バグ**（ON は carrier `lives-ok { foo }` で captured write が reconcile に落とされ偶然
+  PASS、OFF が正しく伝播して露出）。真因＝パラメータの default 式を評価する際に **そのパラメータ自身が scope に入っていない**
+  ため、`&foo`（default RHS）が外側の登録済み sub `foo` に解決されていた（raku は param `&foo` 自身＝undefined に解決）。
+  修正＝`bind_function_args_values` の両 default-eval サイト（binding.rs ~770 named / ~1500 positional）を新ヘルパー
+  `eval_param_default` に集約し、default 式評価の**直前にパラメータ名自身を undefined 型オブジェクト（or Nil）で env に
+  pre-bind**（self-reference が outer ではなく未定義パラメータに解決＝Raku の「param はその default 内で scope に入る」規則）。
+  earlier param（`$b = $a`）は前 iter で bind 済なので影響なし、別名 outer（`$z = $y`）も影響なし。pin=
+  `t/param-default-self-scoping.t`（7・ON/OFF 両 PASS）。make test 9819。
+- **残り 1（純 writeback でない＝別軸）**:
   - **destruction.t 3**: `submethod DESTROY { $x++ }` の GC 時 captured write（最小再現は GC タイミング依存で要工夫）。
-  - **code.t 8（`&`-param）**: `sub foo(&foo = &foo){...}` の default scoping バグ＝**writeback でなく露出バグ**（第46で確認・別軸）。
   - ＋別軸: lazy-lists.t 24-26（laziness バグ・L 系）／IO-Socket-Async.t 5,7（flaky）。
 
-**残 2（code.t scoping・destruction.t GC＝いずれも純 writeback でない別軸）＋別軸 2（lazy-lists laziness・IO-Socket-Async flaky）
-全消化後に §7.4（env_dirty 削除）が射程**。純 writeback コヒーレンスのサーフェスは slice 1.18 で枯渇。
+**残 1（destruction.t GC＝純 writeback でない別軸）＋別軸 2（lazy-lists laziness・IO-Socket-Async flaky）
+全消化後に §7.4（env_dirty 削除）が射程**。純 writeback コヒーレンスのサーフェスは slice 1.18 で枯渇、
+露出バグ（code.t scoping）は slice 1.19 で消化。
 
 ### 7.2b ✅ proto `{*}` redispatch ＋ `state` var coherence（proto.t 21 / subsignature.t 54）= slice 1.17 で解決
 **実際の真因は当初推測（`restore_env_preserving_existing` が state を巻き戻す）とは別だった。** plain `state %h` を持つ

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -48,6 +48,64 @@ impl Interpreter {
                 .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
     }
 
+    /// Evaluate a parameter's default expression under Raku's parameter
+    /// scoping: the parameter being bound is in scope (as its undefined type
+    /// object) *within its own default*, shadowing any outer symbol of the same
+    /// name. This is why `sub f(&foo = &foo)` defaults to the (undefined)
+    /// parameter — not the outer routine `foo` — and `$x = $x` is undefined.
+    /// Earlier parameters remain visible because they were bound in prior loop
+    /// iterations. The topic (`$_`/`_`) is saved/restored so the eval does not
+    /// leak it into the caller's scope.
+    fn eval_param_default(
+        &mut self,
+        pd: &ParamDef,
+        default_expr: &Expr,
+    ) -> Result<Value, RuntimeError> {
+        let saved_topic = self.env.get("_").cloned();
+        let saved_dollar_topic = self.env.get("$_").cloned();
+        // Shadow the parameter with its undefined type object (or Nil) so a
+        // self-reference in the default resolves to the parameter rather than
+        // an outer symbol of the same name.
+        let saved_self = if !pd.name.is_empty() {
+            let prev = self.env.get(&pd.name).cloned();
+            let shadow = pd
+                .type_constraint
+                .as_deref()
+                .filter(|c| !c.starts_with("::"))
+                .and_then(|c| self.resolve_type_object(c))
+                .unwrap_or(Value::Nil);
+            self.env.insert(pd.name.clone(), shadow);
+            Some(prev)
+        } else {
+            None
+        };
+        let value = self.eval_block_value(&[Stmt::Expr(default_expr.clone())]);
+        // Restore the parameter's prior env binding; the caller performs the
+        // real bind right after. On the error path this prevents the shadow
+        // from leaking.
+        if let Some(prev) = saved_self {
+            match prev {
+                Some(v) => {
+                    self.env.insert(pd.name.clone(), v);
+                }
+                None => {
+                    self.env.remove(&pd.name);
+                }
+            }
+        }
+        if let Some(t) = saved_topic {
+            self.env.insert("_".to_string(), t);
+        } else {
+            self.env.remove("_");
+        }
+        if let Some(t) = saved_dollar_topic {
+            self.env.insert("$_".to_string(), t);
+        } else {
+            self.env.remove("$_");
+        }
+        value
+    }
+
     fn parameter_binding_error(message: String) -> RuntimeError {
         let mut err = RuntimeError::new(message);
         let mut ex_attrs = std::collections::HashMap::new();
@@ -768,21 +826,7 @@ impl Interpreter {
                     }
                 }
                 if !found && let Some(default_expr) = &pd.default {
-                    // Save $_ so that evaluating the default expression does not
-                    // leak the topic into the caller's scope.
-                    let saved_topic = self.env.get("_").cloned();
-                    let saved_dollar_topic = self.env.get("$_").cloned();
-                    let value = self.eval_block_value(&[Stmt::Expr(default_expr.clone())])?;
-                    if let Some(t) = saved_topic {
-                        self.env.insert("_".to_string(), t);
-                    } else {
-                        self.env.remove("_");
-                    }
-                    if let Some(t) = saved_dollar_topic {
-                        self.env.insert("$_".to_string(), t);
-                    } else {
-                        self.env.remove("$_");
-                    }
+                    let value = self.eval_param_default(pd, default_expr)?;
                     let value = self.checked_default_param_value(pd, value)?;
                     let value = if pd
                         .type_constraint
@@ -1456,21 +1500,7 @@ impl Interpreter {
                     }
                     positional_idx += 1;
                 } else if let Some(default_expr) = &pd.default {
-                    // Save $_ so that evaluating the default expression does not
-                    // leak the topic into the caller's scope.
-                    let saved_topic = self.env.get("_").cloned();
-                    let saved_dollar_topic = self.env.get("$_").cloned();
-                    let value = self.eval_block_value(&[Stmt::Expr(default_expr.clone())])?;
-                    if let Some(t) = saved_topic {
-                        self.env.insert("_".to_string(), t);
-                    } else {
-                        self.env.remove("_");
-                    }
-                    if let Some(t) = saved_dollar_topic {
-                        self.env.insert("$_".to_string(), t);
-                    } else {
-                        self.env.remove("$_");
-                    }
+                    let value = self.eval_param_default(pd, default_expr)?;
                     let value = self.checked_default_param_value(pd, value)?;
                     if let Some(captured_name) = pd
                         .type_constraint

--- a/t/param-default-self-scoping.t
+++ b/t/param-default-self-scoping.t
@@ -1,0 +1,51 @@
+use Test;
+
+# A parameter is in scope (as its undefined type object) within its own
+# default expression, shadowing any outer symbol of the same name. See
+# roast S06-signature/code.t test 8 (RT #67932) and the general Raku rule.
+
+plan 7;
+
+# Self-reference: the inner `&foo` default refers to the (undefined)
+# parameter, not the outer routine `foo`.
+{
+    my $tracker;
+    sub foo(&foo = &foo) { $tracker = &foo }
+    foo;
+    nok $tracker.defined, 'inner &foo default is the undefined param, not outer sub';
+}
+
+# Scalar self-reference is undefined.
+{
+    my $x = 10;
+    sub f($x = $x) { $x }
+    nok f().defined, 'scalar $x = $x default is undefined (self-shadow)';
+}
+
+# Earlier parameters remain visible in later defaults.
+{
+    sub g($a = 5, $b = $a) { "$a $b" }
+    is g(), '5 5', 'earlier param visible in later default';
+    is g(2), '2 2', 'earlier param value flows to later default';
+}
+
+# An outer symbol of a *different* name is visible in a default.
+{
+    my $y = 99;
+    sub h($z = $y) { $z }
+    is h(), 99, 'outer symbol of different name visible in default';
+}
+
+# Named parameter self-reference also shadows.
+{
+    my $w = 7;
+    sub k(:$w = $w) { $w }
+    nok k().defined, 'named param :$w = $w default is undefined (self-shadow)';
+}
+
+# Passing an argument still binds normally (default not used).
+{
+    my $x = 10;
+    sub m($x = $x) { $x }
+    is m(42), 42, 'explicit argument binds, default skipped';
+}


### PR DESCRIPTION
## Summary

A Raku parameter is in scope (as its undefined type object) **within its own default expression**, shadowing any outer symbol of the same name. mutsu was instead resolving a self-reference in a default to an outer symbol:

```raku
sub foo(&foo = &foo) { ... }    # &foo default resolved to outer sub foo (WRONG)
my $x = 10; sub f($x = $x) {}   # $x default resolved to outer $x = 10 (WRONG)
```

Raku semantics (verified with `raku`):
- `$x = $x` → param shadows itself, default is the **undefined** parameter.
- `$a = 5, $b = $a` → earlier params **remain visible** (`5 5`).
- `my $y = 99; sub h($z = $y)` → outer symbol of a **different** name is visible (`99`).

## Fix

Collapse the two default-eval sites in `bind_function_args_values` (named ~770 / positional ~1500) into a new `eval_param_default` helper that pre-binds the parameter name to its undefined type object (or `Nil`) **before** evaluating the default, so a self-reference resolves to the parameter rather than an outer symbol. The real bind right after overwrites the shadow; the existing `$_`/`_` topic save/restore is preserved.

## Impact

Resolves roast `S06-signature/code.t` test 8 (RT #67932) — the last `MUTSU_NO_BLANKET_RECONCILE=1` **OFF exposure bug** (as opposed to a pure-writeback gap) on the path to `env_dirty` removal (Sub-slice 1b slice 1.19). ON had passed by accident: the `lives-ok { foo }` carrier dropped the captured write under blanket reconcile, while OFF correctly propagated it and exposed the scoping bug (doc §7.3 lesson #3).

pin: `t/param-default-self-scoping.t` (7 subtests, ON/OFF both PASS). `make test` 9819, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)