### PR TITLE
feat(control): cross-frame resumable warn via inline resume_safe CONTROL handler

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -163,14 +163,11 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 
 目標: **mutsu でウェブブログシステムが構築できる**。現状 **0% 稼働**。
 
-- [~] **Template::Mustache** — 基本＋セクション＋partial＋cascade＋**継承（#3380）**＋readme Roster（#3381）まで動作。
-      2026-06-21 session-3 で #3377（cross-frame warn resume）/#3378（given/when 末尾 if 値）/#3380（do-if `-> $v`
-      バインド→12-inheritence 全パス）/#3381（`^^` を subrule 内で行頭誤認しない→50-readme Roster）をマージ。
-      **次ターゲット = ② デリミタ `{{=<% %>=}}`**（`$*LEFT/$*RIGHT` 動的変数の finalizer 再代入が次マッチに伝播しない＝
-      grammar action を reduce 時に実行し dyn-var 書き込みを overlay 経由で後続マッチへ。詳細メモリ
-      `plan-delimiter-incremental-actions`）。他の残: 06-logging（CONTROL `.resume` の真の cross-frame 継続）、
-      50-readme #4（grammar パース性能・無限ループでなく遅い）、`handles` 委譲経由 proto method（stderr のみ・非致命）。
-      詳細＝メモリ `project-template-mustache-status` / `session-handoff-2026-06-21-mustache`。ハーネス＝`tmp/mustache/`。
+- [x] **Template::Mustache — 完動（#3395, 2026-06-21）。** 全テストがパス（外部 `JSON::Fast` 依存の
+      91/92-specs を除く＝mutsu のバグではない）。最後のブロッカー 06-logging（深いフレームで投げた `warn` を
+      unit の `CONTROL { default { …; .resume } }` で受けて深部を継続）を #3395 で解決＝resume_safe な CONTROL を
+      raise 地点でインライン実行。詳細＝メモリ `project-template-mustache-status`、news/2026-06.md。
+      残（非致命・別軸）: 50-readme #4 grammar パース性能（遅いが正しい）、`handles` 委譲経由 proto method（stderr のみ）。
 - [ ] **HTTP::Server::Tiny** の依存（HTTP::Parser / IO::Blob / HTTP::Status）→ 本体。
 - [ ] DB アクセス — pure Raku 簡易実装 or qqx ベースの SQLite wrapper（NativeCall 不可）。
 - [ ] File::Temp / MIME::Base64 (pure Raku) / File::Directory::Tree。
@@ -205,7 +202,7 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 | 起動時間 vs raku | **0.04x** | 0.04x |
 | tree-walk フォールバック（メソッド/関数） | **~1% / ~18.6%（大半 carrier）** | 0%（carrier 除く） |
 | 動作モジュール数 | 0 | 5+（ウェブブログスタック） |
-| Template::Mustache / HTTP::Server::Tiny | ❌ | ✅ |
+| Template::Mustache / HTTP::Server::Tiny | **Mustache ✅** / Tiny ❌ | ✅ |
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1163,3 +1163,29 @@ overlay へ publish。`interpolate_regex_scalars` は `$*` twigil 解決時に e
 **結果**: Template::Mustache **01-basic 8/10 → 10/10**（delimiter change + `{{=delim=}}` substitution）, **13-pragmas** 全パス。
 回帰なし（全91 whitelisted S05 + S03/S32-str + make test 9763）。pin: `t/grammar-reduce-time-dynvar.t`。
 残る Mustache ブロッカー＝06-logging（unit-level `CONTROL{default{.resume}}` のクロスフレーム継続、最深）, grammar マッチ perf。
+
+## 2026-06-21: Template::Mustache 完動 — クロスフレーム再開可能 warn（06-logging, #3395）
+
+**Mustache の最後のブロッカー 06-logging を解決し、Template::Mustache が完全動作した。** 外部 `JSON::Fast` に依存する
+91/92-specs を除く全テストがパス（06-logging 3/3, 01-basic 10/10, 02-file 8/8, 03-cascade 5/5, 11-iterable 6/6,
+12-inheritence, 13-pragmas, 50-readme 4/4 ほか）。
+
+**問題**: 深いフレーム（render→…→`&warn.()`）で投げた `warn` を unit レベルの `CONTROL { default { …; .resume } }` で
+受けると、mutsu は warn シグナルを Rust の `Err` として CONTROL フレームまで巻き戻していた。途中の深いフレームが破棄されるため、
+単一の `resume_ip`（フレーム相対 IP 1つ）では巻き戻された深部に再入できず、warn 以降の計算が静かに失われていた（render が中断）。
+
+**解決＝resume_safe な CONTROL を raise 地点でインライン実行**:
+1. **コンパイル時**: CONTROL ブロックが「無条件 `.resume`（`when`/`succeed` 脱出なし）」かを AST から判定し
+   `OpCode::TryCatch{resume_safe}` に焼き込む（ランタイムは AST を見られない。`control_block_is_resume_safe`）。
+2. **ランタイム**: `control_handlers: Vec<ControlHandlerEntry>` を Interpreter に追加し `control_handler_depth` と完全同期
+   （`exec_try_catch_op_inner` の両 push/pop 地点）。resume_safe なエントリは自前の `Arc<CompiledCode>` + 範囲 + 関数表を保持
+   （clone コストは稀な CONTROL 進入時のみ）。
+3. **`builtin_warn`（depth>0）**: 最内ハンドラが resume_safe なら raise 地点でインライン実行（`try_resume_safe_control_inline`）し
+   `Ok(Nil)` を返す → 深部がそのまま再開。**鍵**: ハンドラのバイトコードは設置フレームのローカルスロットを参照するが、
+   現在の `self.locals` は深部フレームのもの。そこで env（クロスフレーム可視ストア、env キー＝`code.locals` 名）から
+   ハンドラのローカルを再構成して実行し、変化したスロットだけ env へ書き戻して `env_dirty` を立てる
+   → 設置フレームが呼び出し復帰時に `reconcile_locals_from_env_at_site` で取り込む（`$out ~=` が render 後まで残る）。
+   resume_safe でない `when CX::Warn { }` は従来の巻き戻し経路を維持（暗黙の `succeed` がブロック境界へ脱出する＝#3372 のキラー）。
+
+**結果**: `t/warn-cross-frame-control-resume.t`（7 ケース・rakudo 検証）。#3372 回帰ガード全緑（control/warn/catch/top-level/
+indent/quietly/gather）。make test 9819 全パス。これで PLAN.md §H の Template::Mustache が完了。

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -311,12 +311,17 @@ impl Compiler {
             }
         }
         let has_explicit_catch = catch_stmts.is_some();
+        let resume_safe = control_stmts
+            .as_deref()
+            .map(Self::control_block_is_resume_safe)
+            .unwrap_or(false);
         // Emit TryCatch placeholder.
         let try_idx = self.code.emit(OpCode::TryCatch {
             catch_start: 0,
             control_start: 0,
             body_end: 0,
             explicit_catch: has_explicit_catch,
+            resume_safe,
         });
         // Compile main body (last Stmt::Expr/Call leaves value on stack)
         let mut main_leaves_value = false;
@@ -508,5 +513,48 @@ impl Compiler {
             self.code.patch_jump(j);
         }
         self.pop_dynamic_scope_lexical(saved);
+    }
+
+    /// Classify a CONTROL block as "resume-safe": it always `.resume`s and
+    /// never `succeed`s/`when`-exits, so a `warn` caught by it can be handled
+    /// *inline* at the deep raise site (see `Interpreter::builtin_warn`) without
+    /// unwinding the Rust call stack — the mechanism behind cross-frame
+    /// resumable warns. Conservative: anything it does not recognise → false
+    /// (falls back to the existing unwinding path).
+    fn control_block_is_resume_safe(stmts: &[Stmt]) -> bool {
+        let meaningful: Vec<&Stmt> = stmts
+            .iter()
+            .filter(|s| !matches!(s, Stmt::SetLine(_)))
+            .collect();
+        if meaningful.is_empty() {
+            return false;
+        }
+        // A single `default { ... }` delegates to its body — the common
+        // `CONTROL { default { ...; .resume } }` shape.
+        if meaningful.len() == 1
+            && let Stmt::Default(body) = meaningful[0]
+        {
+            return Self::control_block_is_resume_safe(body);
+        }
+        // Any `when` arm or `succeed` escapes the block via a control signal
+        // (it does NOT resume) — the #3372 killer case. Reject.
+        if meaningful.iter().any(|s| Self::stmt_exits_control_block(s)) {
+            return false;
+        }
+        // The tail statement must be a `.resume` method call.
+        matches!(meaningful.last(), Some(Stmt::Expr(e)) if Self::expr_is_resume_call(e))
+    }
+
+    fn expr_is_resume_call(e: &Expr) -> bool {
+        matches!(e, Expr::MethodCall { name, .. } if name.resolve() == "resume")
+    }
+
+    fn stmt_exits_control_block(s: &Stmt) -> bool {
+        match s {
+            Stmt::When { .. } => true,
+            Stmt::Call { name, .. } => name.resolve() == "succeed",
+            Stmt::Expr(Expr::Call { name, .. }) => name.resolve() == "succeed",
+            _ => false,
+        }
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1039,6 +1039,13 @@ pub(crate) enum OpCode {
         /// True when CATCH { } is explicitly present — unhandled exceptions
         /// (no `when`/`default` match) must be re-thrown.
         explicit_catch: bool,
+        /// True when this block's CONTROL handler unconditionally `.resume`s
+        /// (e.g. `CONTROL { default { ...; .resume } }`) with no `when`/`succeed`
+        /// exit. Such a handler can be run *inline* at a deep `warn` raise site
+        /// (see `builtin_warn`) without unwinding the Rust call stack, which is
+        /// what enables cross-frame resumable warns. Computed at compile time
+        /// from the CONTROL block AST (the runtime cannot see the AST).
+        resume_safe: bool,
     },
 
     // -- Error handling --

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -318,7 +318,127 @@ impl Interpreter {
             }
             return Ok(Value::Nil);
         }
+        // A CONTROL handler is active somewhere up the dynamic call stack. If the
+        // *innermost* one unconditionally `.resume`s (`resume_safe`), run it
+        // INLINE here, at the raise site, then return `Ok(Nil)` so the deep
+        // computation continues exactly where the `warn` was raised. Returning an
+        // `Err` instead would unwind the Rust call stack to the CONTROL block's
+        // frame, destroying every frame between here and there — so the rest of
+        // the deep computation (the code after the `warn`) would be lost. This is
+        // the cross-frame resumable-warn mechanism. A non-resume-safe handler
+        // (e.g. `when CX::Warn { }`, which `succeed`s/exits the block) must take
+        // the unwinding path so the `succeed` has a block boundary to unwind to.
+        if let Some(result) = self.try_resume_safe_control_inline(&message) {
+            return result;
+        }
         Err(RuntimeError::warn_signal(message))
+    }
+
+    /// If the innermost active CONTROL handler is `resume_safe`, run it inline
+    /// against the current (deep) environment and return the value the suspended
+    /// `warn` should evaluate to (`Nil` for a bare `.resume`). Returns `None`
+    /// when there is no inline-eligible handler, so the caller falls back to the
+    /// unwinding path. See `builtin_warn` for why this is necessary.
+    fn try_resume_safe_control_inline(
+        &mut self,
+        message: &str,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let top = self.control_handlers.last()?;
+        if !top.resume_safe {
+            return None;
+        }
+        let handler = top.handler.as_ref()?;
+        // Clone what we need so we can take `&mut self` while running.
+        let code = handler.code.clone();
+        let control_begin = handler.control_begin;
+        let end = handler.end;
+        let fns = handler.compiled_fns.clone();
+
+        // Present the warning to the handler as a `CX::Warn` topic in `$_`,
+        // mirroring the unwinding path in `exec_try_catch_op_inner`.
+        let warn_signal = RuntimeError::warn_signal(message.to_string());
+        let topic = Self::control_signal_topic_value(&warn_signal);
+        let saved_topic = self.env().get("_").cloned();
+        if let Some(t) = topic {
+            self.env_mut().insert("_".to_string(), t);
+        }
+        let saved_when = self.when_matched();
+        self.set_when_matched(false);
+
+        // The handler's bytecode (`code`) belongs to the CONTROL-installing
+        // frame and addresses *that* frame's local slots, but right now
+        // `self.locals` is the deep frame's (the `warn` raise site). Reconstruct
+        // the installing frame's locals from `env` — the cross-frame-visible
+        // store, where `code.locals[i]` names slot `i` (this mirrors
+        // `reconcile_locals_from_env_at_site`). After running, flush any slot the
+        // handler mutated back to `env` and mark `env_dirty`, so the installing
+        // frame reconciles its slots from `env` when the deep call chain returns
+        // (the same path a normal cross-frame by-name write takes). This is what
+        // makes the handler's `$out ~= .Str` survive to after `render()`.
+        let handler_locals: Vec<Value> = code
+            .locals
+            .iter()
+            .map(|name| {
+                self.env().get(name).cloned().unwrap_or_else(|| {
+                    name.strip_prefix('$')
+                        .or_else(|| name.strip_prefix('@'))
+                        .or_else(|| name.strip_prefix('%'))
+                        .or_else(|| name.strip_prefix('&'))
+                        .and_then(|bare| self.env().get(bare).cloned())
+                        .unwrap_or(Value::Nil)
+                })
+            })
+            .collect();
+        let seeded = handler_locals.clone();
+        let saved_locals = std::mem::replace(&mut self.locals, handler_locals);
+
+        // The handler runs in the deep frame's stack; isolate its operand-stack
+        // effects so the suspended computation's stack is left untouched.
+        let saved_stack = self.stack.len();
+        let result = self.run_range(&code, control_begin, end, &fns);
+        self.stack.truncate(saved_stack);
+
+        // Flush slots the handler changed back to env so the installing frame
+        // (and any intervening by-name reader, e.g. `render`'s own `$out ~=`)
+        // observes them. Only changed slots are written, to keep blast radius
+        // minimal.
+        let handler_locals = std::mem::replace(&mut self.locals, saved_locals);
+        for (i, name) in code.locals.iter().enumerate() {
+            if name.is_empty() {
+                continue;
+            }
+            if handler_locals[i] != seeded[i] {
+                self.env_mut()
+                    .insert(name.clone(), handler_locals[i].clone());
+            }
+        }
+        self.env_dirty = true;
+
+        self.set_when_matched(saved_when);
+        if let Some(v) = saved_topic {
+            self.env_mut().insert("_".to_string(), v);
+        } else {
+            self.env_mut().remove("_");
+        }
+
+        match result {
+            // Handler fell through (no explicit `.resume`) — for a resume_safe
+            // handler this is equivalent to resuming with Nil.
+            Ok(()) => Some(Ok(Value::Nil)),
+            // `.resume` — the warn resumes; a bare `.resume` yields Nil.
+            Err(ce) if ce.is_resume => Some(Ok(Value::Nil)),
+            // The handler re-threw the warn (`warn`/`.rethrow` of CX::Warn):
+            // act like the default handler — print and resume.
+            Err(ce) if ce.is_warn => {
+                if !self.warning_suppressed() {
+                    self.write_warn_to_stderr(&ce.message);
+                }
+                Some(Ok(Value::Nil))
+            }
+            // Anything else (shouldn't happen for a resume_safe handler) →
+            // propagate so it is not silently swallowed.
+            Err(ce) => Some(Err(ce)),
+        }
     }
 
     pub(super) fn make_stub_exception(message: String) -> Value {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1204,6 +1204,12 @@ pub struct Interpreter {
     pub(crate) quanthash_bind_params: Vec<String>,
     pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,
     pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
+    /// Active CONTROL handlers on the dynamic call stack (one per executing
+    /// `CONTROL { }` block). Kept in lock-step with `control_handler_depth` so
+    /// a `warn` raised deep inside a protected body can find the innermost
+    /// handler via `.last()` and, if it is `resume_safe`, run it inline at the
+    /// raise site (cross-frame resumable warn). See `vm::ControlHandlerEntry`.
+    pub(crate) control_handlers: Vec<crate::vm::ControlHandlerEntry>,
     pub(crate) env_dirty: bool,
     /// Address of the `CompiledCode` of the bytecode frame currently executing
     /// in `exec_one` (set at the top of every dispatch). Used by the lazy-force
@@ -3413,6 +3419,7 @@ impl Interpreter {
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
+            control_handlers: Vec::new(),
             env_dirty: false,
             current_code: 0,
             carrier_writes: None,
@@ -5989,6 +5996,7 @@ impl Interpreter {
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
+            control_handlers: Vec::new(),
             env_dirty: false,
             current_code: 0,
             carrier_writes: None,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -170,6 +170,31 @@ fn cmp_values(left: &Value, right: &Value) -> std::cmp::Ordering {
 }
 
 /// Saved state for a compiled function/closure/method call frame.
+/// A CONTROL handler active on the dynamic (Rust) call stack. Pushed when a
+/// block with a `CONTROL { }` phaser begins executing its protected body and
+/// popped when that body finishes. `control_handlers.len()` is kept equal to
+/// `control_handler_depth` so the innermost handler is always `.last()`.
+pub(crate) struct ControlHandlerEntry {
+    /// Whether this handler unconditionally `.resume`s (see `OpCode::TryCatch`
+    /// `resume_safe`). When false, `handler` is `None` and a deep warn falls
+    /// back to the unwinding path.
+    pub resume_safe: bool,
+    /// Present only for `resume_safe` handlers: the bytecode + range + function
+    /// table needed to run the handler INLINE at a deep `warn` raise site.
+    pub handler: Option<ControlHandlerCode>,
+}
+
+/// Self-contained bytecode for running a `resume_safe` CONTROL handler inline.
+/// The `code` is an owned `Arc` clone of the installing frame's `CompiledCode`
+/// (intra-range jump targets stay valid because indices are preserved); the
+/// `compiled_fns` clone lets the handler body call user subs visible at install.
+pub(crate) struct ControlHandlerCode {
+    pub code: std::sync::Arc<CompiledCode>,
+    pub control_begin: usize,
+    pub end: usize,
+    pub compiled_fns: HashMap<String, CompiledFunction>,
+}
+
 pub(crate) struct VmCallFrame {
     pub saved_env: Env,
     pub saved_locals: Vec<Value>,
@@ -964,7 +989,7 @@ impl Interpreter {
         }
     }
 
-    fn run_range(
+    pub(crate) fn run_range(
         &mut self,
         code: &CompiledCode,
         start: usize,
@@ -3816,6 +3841,7 @@ impl Interpreter {
                 control_start,
                 body_end,
                 explicit_catch,
+                resume_safe,
             } => {
                 self.exec_try_catch_op(
                     code,
@@ -3823,6 +3849,7 @@ impl Interpreter {
                     *control_start,
                     *body_end,
                     *explicit_catch,
+                    *resume_safe,
                     ip,
                     compiled_fns,
                 )?;

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -54,7 +54,7 @@ impl Interpreter {
         }
     }
 
-    fn control_signal_topic_value(signal: &RuntimeError) -> Option<Value> {
+    pub(crate) fn control_signal_topic_value(signal: &RuntimeError) -> Option<Value> {
         // User-defined classes doing X::Control carry their original
         // exception instance. Surface it directly so CONTROL blocks see the
         // real type rather than a generic CX::Done wrapper.
@@ -3053,6 +3053,7 @@ impl Interpreter {
         control_start: u32,
         body_end: u32,
         explicit_catch: bool,
+        resume_safe: bool,
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
@@ -3065,6 +3066,7 @@ impl Interpreter {
             control_start,
             body_end,
             explicit_catch,
+            resume_safe,
             ip,
             compiled_fns,
         );
@@ -3086,6 +3088,7 @@ impl Interpreter {
         control_start: u32,
         body_end: u32,
         explicit_catch: bool,
+        resume_safe: bool,
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
@@ -3098,6 +3101,29 @@ impl Interpreter {
         let has_control = control_begin < end;
         if has_control {
             self.control_handler_depth += 1;
+            // Register this CONTROL handler so a `warn` raised deep inside the
+            // protected body (on the Rust call stack, several frames down) can
+            // find it. A `resume_safe` handler carries its own bytecode +
+            // function table so `builtin_warn` can run it INLINE at the raise
+            // site and resume the deep computation, instead of unwinding the
+            // Rust stack (which would lose every frame between the warn and
+            // here). The depth invariant `control_handlers.len() ==
+            // control_handler_depth` is preserved so the innermost handler is
+            // always `control_handlers.last()`.
+            let handler = if resume_safe {
+                Some(crate::vm::ControlHandlerCode {
+                    code: std::sync::Arc::new(code.clone()),
+                    control_begin,
+                    end,
+                    compiled_fns: compiled_fns.clone(),
+                })
+            } else {
+                None
+            };
+            self.control_handlers.push(crate::vm::ControlHandlerEntry {
+                resume_safe,
+                handler,
+            });
         }
         // Guard the protected body with a panic->X:: boundary so an internal
         // Rust panic (overflow/OOB/unwrap) raised anywhere inside it becomes a
@@ -3105,6 +3131,7 @@ impl Interpreter {
         let body_result = self.run_range_guarded(code, body_start, catch_begin, compiled_fns);
         if has_control {
             self.control_handler_depth -= 1;
+            self.control_handlers.pop();
         }
         match body_result {
             Ok(()) => {
@@ -3266,11 +3293,26 @@ impl Interpreter {
                             }
                             if has_control {
                                 self.control_handler_depth += 1;
+                                let handler = if resume_safe {
+                                    Some(crate::vm::ControlHandlerCode {
+                                        code: std::sync::Arc::new(code.clone()),
+                                        control_begin,
+                                        end,
+                                        compiled_fns: compiled_fns.clone(),
+                                    })
+                                } else {
+                                    None
+                                };
+                                self.control_handlers.push(crate::vm::ControlHandlerEntry {
+                                    resume_safe,
+                                    handler,
+                                });
                             }
                             let body_result =
                                 self.run_range(code, resume_point, catch_begin, compiled_fns);
                             if has_control {
                                 self.control_handler_depth -= 1;
+                                self.control_handlers.pop();
                             }
                             match body_result {
                                 Ok(()) => {

--- a/t/warn-cross-frame-control-resume.t
+++ b/t/warn-cross-frame-control-resume.t
@@ -1,0 +1,70 @@
+use Test;
+
+# A `warn` raised deep inside a sub/method call chain, caught by a unit-level
+# `CONTROL { default { ...; .resume } }` handler, must run that handler at the
+# raise site and *resume* the deep computation — the code after the `warn`
+# (several Rust frames down) still runs and its value flows back out. Previously
+# mutsu unwound the Rust call stack to the CONTROL frame, destroying every frame
+# between the warn and the handler, so the rest of the deep computation was lost
+# (the Template::Mustache 06-logging blocker). The handler is "resume-safe" (it
+# unconditionally `.resume`s with no `when`/`succeed` exit), so it is run inline
+# at the raise site rather than via the unwinding path.
+
+plan 7;
+
+# --- canonical deep cross-frame resume ---
+{
+    my $out = '';
+    sub deep { warn "deep warn"; "after-warn" }
+    sub render { my $r = deep(); $out ~= "[render-continued:$r]"; }
+    CONTROL { default { $out ~= "<caught:{.message.lines[0]}>"; .resume; } }
+    render();
+    is $out, '<caught:deep warn>[render-continued:after-warn]',
+        'deep warn caught by unit CONTROL{default{.resume}} resumes; deep frame continues';
+}
+
+# --- handler sees the CX::Warn message ---
+{
+    my @seen;
+    sub w-deep { warn "w1"; warn "w2"; "done" }
+    CONTROL { default { @seen.push(.message.lines[0]); .resume } }
+    my $r = w-deep();
+    is $r, 'done', 'multiple deep warns all resume; routine returns its value';
+    is @seen, ['w1', 'w2'], 'CONTROL handler observed each warn message in order';
+}
+
+# --- warn through a method chain ---
+{
+    my $log = '';
+    class C {
+        method deep() { warn "method warn"; 42 }
+        method top()  { self.deep() + 1 }
+    }
+    CONTROL { default { $log ~= .message.lines[0]; .resume } }
+    is C.new.top(), 43, 'warn deep in a method chain resumes; value flows out';
+    is $log, 'method warn', 'method-chain warn reached the CONTROL handler';
+}
+
+# --- indirect &warn.() deep in the chain (the Template::Mustache logger shape) ---
+{
+    my $caught = '';
+    sub inner { my $w = &warn; $w.("indirect deep"); "inner-ok" }
+    sub mid   { "[" ~ inner() ~ "]" }
+    CONTROL { default { $caught = .message.lines[0]; .resume } }
+    is mid(), '[inner-ok]', 'indirect &warn.() deep resumes; caller value preserved';
+}
+
+# --- a `when CX::Warn { }` handler still SUCCEEDS (exits), it does NOT resume ---
+# This guards the #3372 killer: a non-resume-safe handler must take the unwinding
+# path so the implicit `succeed` has a block boundary to exit to.
+{
+    my $after = 'not-run';
+    my $r = do {
+        warn "exit me";
+        $after = 'ran';
+        'body-value';
+        CONTROL { when CX::Warn { 'handled' } }
+    };
+    is $after, 'not-run',
+        'when CX::Warn succeeds (exits the block); code after the warn does NOT run';
+}


### PR DESCRIPTION
## Summary

Implements **cross-frame resumable `warn`** — the last Template::Mustache blocker (`06-logging`).

A `warn` raised several frames deep in a sub/method call chain, caught by a unit-level `CONTROL { default { ...; .resume } }`, previously unwound the Rust call stack to the CONTROL frame, destroying every frame between the raise site and the handler. The handler's `.resume` then had nothing to resume into (a single frame-relative `resume_ip` cannot re-enter unwound deep frames), so the rest of the deep computation was silently lost.

## Approach

- **Compile time:** classify a CONTROL block as `resume_safe` — it unconditionally `.resume`s with no `when`/`succeed` exit — and bake the flag into `OpCode::TryCatch` (the runtime can't see the AST).
- **Runtime:** track active CONTROL handlers in a `control_handlers` stack kept in lock-step with `control_handler_depth`. A `resume_safe` entry carries an owned `Arc<CompiledCode>` + range + function table.
- **`builtin_warn` (depth>0):** if the innermost handler is `resume_safe`, run it **inline at the raise site** — reconstruct the installing frame's local slots from `env` (the cross-frame-visible store), run the handler, flush mutated slots back to `env` + mark `env_dirty` so the installing frame reconciles on return — then return `Ok(Nil)` so the deep computation resumes exactly where the warn was raised. No Rust-stack unwinding.
- A non-`resume_safe` handler (e.g. `when CX::Warn { }`, which `succeed`s/exits the block) keeps the existing unwinding path so the implicit `succeed` has a block boundary to unwind to — the #3372 killer case, now guarded by a test.

## Results

- **Template::Mustache** now passes every test except `91/92-specs` (external `JSON::Fast` dep): `06-logging` 3/3, `01-basic` 10/10, `02-file` 8/8, `50-readme` 4/4, `11-iterable` 6/6, `12-inheritence`, `13-pragmas`, etc.
- `#3372` regression guard suite all green (`control.t`, `warn.t`, `catch.t`, `top-level.t`, `indent.t`, `quietly.t`, `gather.t`).
- `make test` PASS (9819 tests, 0 failed). clippy/fmt clean.
- Pin: `t/warn-cross-frame-control-resume.t` (7 cases, spec-validated against rakudo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)