### PR TITLE
fix(concurrency): retain-on-miss cross-thread shared-var writeback (destruction.t 3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -54,8 +54,11 @@
   - **根本**: 置き場が2つある限り「env を名前書きした→slot が stale かも」という目印は何らかの形で必要。
     `env_dirty` を真に消すには **env を locals の派生ビュー化＝単一ストア化**が要り、それは
     **env↔locals が同一コンテナ cell を共有する**こと（前提①）が前提。
-- **∴ 次の一手 = 前提① の env↔locals コンテナ cell 共有（下記 §C Sub-slice 1b）。** これが入って初めて
-  `env_dirty` 削除が射程に入る。それまで env_dirty は perf ゲートとして正当に残す。
+- **✅ env↔locals 純 writeback コヒーレンスは完了**（slice 1〜1.20・#3400 まで）。OFF roast survey の純 writeback
+  サーフェスは枯渇。**残る OFF 依存は別軸＝lazy-lists.t の laziness バグ**（`.kv`/`.pairs`/`.antipairs` の eager force・
+  下記 §C 参照）。
+- **∴ 次の一手 = lazy-lists 真 lazy 化（§C 末尾 ＋ §3-F の L 系）。** これを消化すれば OFF survey が実質クリアし、
+  `env_dirty` 削除（§2-E）が射程に入る。それまで env_dirty は perf ゲートとして正当に残す。
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**
 
@@ -88,15 +91,20 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 - [ ] **Phase 2 Stage 2 slice 5（最終 SlotRef キル）**: 残る `HashSlotRef`/`DeferredHashAccess` 生成サイト
       （junction-bind / `is raw` reduce lvalue-read の autoviv）を cell 化し、variant を削除。
 - [ ] **grep-rw-view 撤去**: 最後の ptr-keyed グローバル。matched 要素を cell 昇格し view registry を全廃。
-- [~] **★env↔locals cell 共有 — captured-outer cell 化（A の律速・最重要）**: nested callee（closure **だけでなく**
-      named sub）に捕捉＋変異される lexical を、owner の local slot と env エントリの両方で**同一 `ContainerRef` cell**
-      にする（escape-aware・裸ローカルは従来の Arc 共有で perf 崖回避）。台帳＝
-      [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md)。**slice 1〜1.9 landed**（named-sub 捕捉
-      scalar／metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／**captured-outer container `@`/`%` cell 化**／
-      **X-cross metaop thunk scalar writeback**）。OFF survey 16 file まで縮小。**残り**：①並行 cluster ~13（cross-thread
-      cell・最難・最後）②instance-attr コヒーレンス（`parametric-role-of-type`＝Phase 3 cell 領域・別機構）③multi-frame
-      nested-method capture（`methods-instance`）。`:=` bind container/scalar 共有・closure captured scalar は既に done。
-      **これが完了すると env↔locals が乖離しなくなり、§1-A の単一ストア化（env_dirty 削除）が解禁される。**
+- [x] **★env↔locals cell 共有 — captured-outer cell 化／純 writeback コヒーレンス（A の律速・完了）**: nested callee
+      （closure・named sub）／carrier／cross-thread に捕捉＋変異される lexical の writeback コヒーレンスを precise 化。台帳＝
+      [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md)。**slice 1〜1.20 landed**（named-sub 捕捉
+      scalar／metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／container `@`/`%` cell 化／X-cross thunk／
+      nested-method capture／cross-thread shared-var／object 添字代入 invocant／substr-rw・undefine lvalue／zip-topic・LAST
+      phaser／proto `state %`／caller-frame write／param default self-scoping／**cross-thread DESTROY writeback（#3400）**）。
+      **OFF roast survey の純 writeback サーフェスは枯渇**（残は別軸＝下記）。`:=` bind・closure captured scalar も done。
+      **★残る OFF 依存は純 writeback でない別軸 2 のみ**:
+      - **lazy-lists.t 24-26 = laziness バグの露出**（`.kv`/`.pairs`/`.antipairs` が gather を eager force・ON は write-loss
+        で偶然 raku 一致、OFF が正しく伝播して露出）。**修正＝`.kv`/`.pairs`/`.antipairs` の真 lazy 化**（§3-F の L 系と合流・
+        precise-writeback では解けない）。**これが env_dirty 削除の最後の前提。**
+      - IO-Socket-Async.t 5,7 = reactive 並行 flaky（決定的 pin 不可・env_dirty 削除の `blanket_reconcile_if_dirty` 空洞化で実挙動確認）。
+- [ ] **★次の本丸 = lazy-lists 真 lazy 化（→ §1-A 解禁）**: 上記 lazy-lists.t を消化すれば OFF survey が実質クリアし、
+      §2-E（`env_dirty`/`ensure_locals_synced`/`saved_env_dirty` 物理削除）が射程に入る。L 系（§3-F の L2b 系）と合流。
 - [ ] follow-up（pre-existing・小）: `$x = @arr` 共有の method param 版（`method m($n){ $n.push }`）・`is copy` $-param。
       設計＝[docs/scalar-array-sharing.md](docs/scalar-array-sharing.md) §5。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -431,7 +431,7 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
 | ~~S06-multi/proto.t~~ | 21 | caching proto `state %` writeback | ✅ slice 1.17 |
 | ~~S06-multi/subsignature.t~~ | 54 | caching proto `state %` writeback | ✅ slice 1.17 |
 | ~~S06-signature/code.t~~ | 8 | `&`-param default self-scoping | ✅ slice 1.19 |
-| S12-construction/destruction.t | 3 | cross-thread worker-DESTROY captured-write の parent-slot 未 refresh（§7.2c） | 🔴 cross-thread writeback 記録拡張 |
+| ~~S12-construction/destruction.t~~ | 3 | cross-thread worker-DESTROY captured-write（retain-on-miss sync） | ✅ slice 1.20 |
 | ~~S32-list/map.t~~ | 62 | `.map` block LAST phaser writeback | ✅ slice 1.15 |
 | ~~S32-scalar/undef.t~~ | 85 | undefine() lvalue slot writeback | ✅ slice 1.16 |
 | S32-io/IO-Socket-Async.t | 5, 7 | reactive 並行（flaky 疑い） | |
@@ -477,22 +477,30 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
   pre-bind**（self-reference が outer ではなく未定義パラメータに解決＝Raku の「param はその default 内で scope に入る」規則）。
   earlier param（`$b = $a`）は前 iter で bind 済なので影響なし、別名 outer（`$z = $y`）も影響なし。pin=
   `t/param-default-self-scoping.t`（7・ON/OFF 両 PASS）。make test 9819。
-- **残り 1（純 writeback でない＝別軸・第47で真因を cell-detachment と特定）**:
-  - **destruction.t 3**: `submethod DESTROY { $in_destructor++ }` の captured write が `await start { loop {…} }` の
-    後で top-level slot に届かない。**第47セッションで最小再現＋真因を確定**（下記 §7.2c）。当初の「GC タイミング依存」も
-    「cell-detachment」も**誤り**＝真因は **cross-thread**（`start` が別スレッド・worker で DESTROY 発火）。env は親へ伝播し
-    親 slot も await call-site で到達可能だが、**ワーカーが書いた captured scalar を親の pending writeback に記録する一点が欠落**
-    （loop+複数 var 時に shared_vars dirty から落ちる）。**cell substrate 不要・cross-thread writeback 記録の拡張で解ける見込み**（§7.2c）。
+- ~~**destruction.t 3**~~ ✅ **slice 1.20 で消化（第48セッション・retain-on-miss cross-thread sync）**。`submethod DESTROY {
+  $a++ }` の worker-thread captured write が top-level slot に届かない。真因＝§7.2c の「cell-detachment」は**誤診断**（#3398
+  で訂正済・真因は cross-thread writeback の **drop-on-miss** リスト誤用）。実測トレースで確定: worker が `$a` を 1 に書き
+  `shared_vars_dirty` にマーク → `await` の `sync_shared_vars_to_env`（mod.rs:6420）が `["a","@order"]` を pending に push し
+  `env["a"]=1` → しかしその後 `await` 内の `run_pending_instance_destroys()`（builtins_system.rs:1796）が **DESTROY を
+  `locals=[]` で dispatch** し、その tail の `apply_pending_rw_writeback`（drop-on-miss）が pending を**消費して捨てる** →
+  top-level frame（`locals=["a","@order","b0"]`・"a" slot 所有）が drain する頃には `sources=[]`。**修正**＝`sync_shared_vars_to_env`
+  の push 先を **drop-on-miss の `pending_rw_writeback_sources` → retain-on-miss の `pending_caller_var_writeback`** に変更
+  （cross-thread synced var の owning slot は数フレーム上＝caller-var と同形の retain-on-miss が正しい）。slice 1.18 の
+  caller-frame writeback と同じリストを再利用＝中間 DESTROY frame は slot 無しで retain、top-level が drain して slot refresh。
+  pin=`t/destroy-cross-thread-writeback-coherence.t`（5・ON/OFF 両 PASS）。
   - ＋別軸: lazy-lists.t 24-26（laziness バグ・L 系）／IO-Socket-Async.t 5,7（flaky）。
 
-**残 1（destruction.t GC＝純 writeback でない別軸）＋別軸 2（lazy-lists laziness・IO-Socket-Async flaky）
-全消化後に §7.4（env_dirty 削除）が射程**。純 writeback コヒーレンスのサーフェスは slice 1.18 で枯渇、
-露出バグ（code.t scoping）は slice 1.19 で消化。
+**残＝別軸 2（lazy-lists laziness・IO-Socket-Async flaky）のみ。純 writeback コヒーレンスのサーフェスは枯渇
+（slice 1.18 で純 writeback、1.19 で露出バグ、1.20 で cross-thread DESTROY writeback）。
+§7.4（env_dirty 削除）は lazy-lists の真 lazy 化（L 系・別軸）後に射程。**
 
-### 7.2c 🔴 destruction.t 3 — cross-thread（worker DESTROY）captured-write の parent-slot 未 refresh（第47セッション・真因確定・未解決）
+### 7.2c ✅ destruction.t 3 — cross-thread（worker DESTROY）captured-write（第47調査・第48解決＝slice 1.20）
 
-> **訂正（第47後半）**: 当初この節は「cell-detachment」と記したが**誤診断だった**。計測で `$a` は **cell-box されていない**
-> （`box_decl_local_cell`/`box_captured_lexicals` の probe が一切発火せず）。真因は **cross-thread**（`start` が別スレッド）。
+**★解決済（slice 1.20・第48セッション）。** 真因は cross-thread writeback の **drop-on-miss リスト誤用**（§7.2a の slice 1.20
+行を参照）。修正＝`sync_shared_vars_to_env` の push 先を `pending_rw_writeback_sources`（drop-on-miss）→
+`pending_caller_var_writeback`（retain-on-miss）に変更。なお第47前半の「cell-detachment」診断は#3398 で誤りと訂正済
+（計測で `$a` は cell-box されておらず、`box_decl_local_cell`/`box_captured_lexicals` の probe が一切発火しない）＝
+真因は cross-thread。以下は当時の調査記録（歴史参考）。
 
 **最小再現（決定的・`MUTSU_NO_BLANKET_RECONCILE=1` で確実 fail）**:
 ```raku

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -596,8 +596,19 @@ env を stale slot で clobber→state 永続化が空 hash 保存。修正＝fa
 
 ## 9. 着手手順（次セッション用クイックスタート）
 
-1. このプラン §6.1 案A の配線可否を調査（`compute_free_vars` から named sub の `CompiledCode` 到達可能か）。
-2. `t/captured-outer-cell-sharing.t` を先に書く（multi-frame `$acc` accumulation 他・raku 期待値で固定）。
-3. 検出＋ボックス化を実装（§6.1-6.2）。
-4. §6.4 で検証（blanket 外して pin が通る → 戻して make test）。
-5. PR（feature branch・auto-merge）。CI 後、§7 スライス2へ。
+**★純 writeback コヒーレンスは slice 1.20（#3400）で完了＝OFF roast survey の純 writeback サーフェスは枯渇。**
+captured-outer cell 共有のグラインドはここで終わり。次の本丸は**別軸の laziness バグ**で、これが env_dirty 削除（§7.4）の
+最後の前提。
+
+**次セッションの本丸 = `S02-types/lazy-lists.t` 24-26 の真 lazy 化（§7.2a triage 参照・§3-F の L 系と合流）**:
+- 症状: OFF で subtests 24-26 が決定的 fail（`MUTSU_FUDGE=1 MUTSU_NO_BLANKET_RECONCILE=1 prove -e target/debug/mutsu
+  roast/S02-types/lazy-lists.t` → Failed 24-26）。ON は write-loss で偶然 raku 一致。
+- 真因: `make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy` を `.kv`/`.pairs`/`.antipairs` が **eager に force** して
+  `$was-lazy = 0` を走らせる（mutsu の `.kv`/`.pairs`/`.antipairs` が非 lazy）。**writeback ではなく laziness バグ**＝
+  precise-writeback では解けない。
+- 修正方針: `.kv`/`.pairs`/`.antipairs` を真に lazy 化（lazy Seq/gather を eager 消費しない）。`docs/lazy-arrays.md` の
+  L 系（L2b 等）と設計を合流させる。raku で `(gather { ... }).lazy.kv` が lazy のままなことを確認してから着手。
+- これが入れば OFF survey が実質クリア（残は IO-Socket-Async.t の flaky のみ＝決定的 pin 不可）→ §7.4 が射程。
+
+**その後 = §7.4（env_dirty 物理削除）**: `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/`ensure_locals_synced`/
+`saved_env_dirty` 削除 → `cell_boxing_active()` gate を外して boxing 恒久 ON 化。IO-Socket-Async の flaky はこの空洞化で実挙動確認。

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -6477,8 +6477,19 @@ impl Interpreter {
         // unless the blanket reconcile is on. Record each synced caller-visible
         // name so the await/`.result` call site drains it straight to the caller's
         // slot (`apply_pending_rw_writeback`), dropping the reverse-sync dependency.
+        //
+        // The synced var's owning slot may live an *unknown number of frames up*:
+        // `await` runs `run_pending_instance_destroys()` (DESTROY dispatch, empty
+        // `locals`) between the shared-var sync and returning to the top-level
+        // frame that owns the slot. A drop-on-miss list (`pending_rw_writeback_sources`)
+        // would be consumed and discarded by those intervening DESTROY frames
+        // before reaching the owner. Use the retain-on-miss list
+        // (`pending_caller_var_writeback`) instead, which carries the source up the
+        // frame chain until the frame whose `code` actually has the slot drains it.
         for (key, val) in updates {
-            self.pending_rw_writeback_sources.push(key.clone());
+            if !self.pending_caller_var_writeback.contains(&key) {
+                self.pending_caller_var_writeback.push(key.clone());
+            }
             self.env.insert(key, val);
         }
     }

--- a/t/destroy-cross-thread-writeback-coherence.t
+++ b/t/destroy-cross-thread-writeback-coherence.t
@@ -1,0 +1,61 @@
+# Slice 1b (env<->locals cross-frame cell coherence): a `submethod DESTROY`
+# fires on a *worker* thread (a `start` block spawns a cloned interpreter), and
+# writes a captured-outer lexical owned by a top-level local slot. The worker's
+# write propagates to the parent env via the shared-var sync, but the parent's
+# matching local *slot* lives several frames up (the `await` runs
+# `run_pending_instance_destroys()` with empty `locals` in between). A drop-on-miss
+# writeback list would be consumed and discarded by those intervening frames before
+# reaching the owner. The retain-on-miss caller-var list carries it up to the
+# owning frame. This pin reproduces the destruction.t failure that only manifested
+# with blanket reconcile OFF (MUTSU_NO_BLANKET_RECONCILE=1).
+use Test;
+plan 5;
+
+# 1. Minimal repro from docs/captured-outer-cell-sharing.md §7.2c: a scalar
+#    DESTROY write inside `await start { loop {...} }` with conditional creation.
+{
+    my $a = 0;
+    my @order;
+    class Foo1 { submethod DESTROY { $a++ } }
+    class Bar1 { submethod DESTROY { push @order, "x" } }
+    my $b0 = Bar1.new; $b0 = Nil;
+    await start {
+        loop {
+            $*VM.request-garbage-collection;
+            my $foo = Foo1.new;
+            my $bar = Bar1.new unless +@order;
+            last if $a && @order;
+        }
+    };
+    ok $a >= 1, "DESTROY scalar write from worker thread reaches top-level slot ($a)";
+}
+
+# 2. A simple cross-thread captured scalar write through `await start { ... }`.
+{
+    my $x = 10;
+    await start { $x = 42 };
+    is $x, 42, "cross-thread scalar write reaches caller slot";
+}
+
+# 3. A worker that writes a captured scalar inside a loop, awaited.
+{
+    my $sum = 0;
+    await start {
+        for 1..5 { $sum += $_ }
+    };
+    is $sum, 15, "cross-thread accumulation in worker loop reaches caller slot";
+}
+
+# 4. Two captured vars (scalar + array) written from the worker.
+{
+    my $count = 0;
+    my @log;
+    await start {
+        for 1..3 {
+            $count++;
+            push @log, $count;
+        }
+    };
+    is $count, 3, "worker scalar write coherent with caller slot";
+    is @log.join(","), "1,2,3", "worker array write coherent with caller slot";
+}


### PR DESCRIPTION
## Summary

Resolves the last pure-writeback OFF-survey surface (`destruction.t` subtest 3) blocking `env_dirty` removal — the env↔locals cross-frame cell coherence substrate (PLAN §2-C Sub-slice 1b).

A `submethod DESTROY` fires on a **worker thread** (a `start` block spawns a cloned interpreter). When it writes a captured-outer lexical owned by a top-level local slot, the worker's write propagates to the parent env via `sync_shared_vars_to_env`, but under `MUTSU_NO_BLANKET_RECONCILE=1` the parent's matching local *slot* was left stale → `a=0` instead of `a=1`.

## Root cause (measured via trace)

The synced var's owning slot lives several frames up. `await` runs `run_pending_instance_destroys()` (DESTROY dispatch with empty `locals`) **between** the shared-var sync and returning to the top-level frame that owns the slot. The **drop-on-miss** list `pending_rw_writeback_sources` was consumed and discarded by those intervening slot-less DESTROY frames before reaching the owner, so the top-level drain saw an empty source list.

This corrects the earlier "cell-detachment" misdiagnosis (docs §7.2c).

## Fix

Push synced cross-thread names onto the **retain-on-miss** list `pending_caller_var_writeback` (the same list slice 1.18 uses for caller-frame writes) instead of the drop-on-miss `pending_rw_writeback_sources`. Retain-on-miss carries the source up the frame chain until the frame whose `code` actually owns the slot drains it; intervening slot-less frames retain rather than discard. No-op under the default build (blanket reconcile makes it redundant = byte-identical).

## Verification

- `roast/S12-construction/destruction.t`: PASS both ON and OFF (`MUTSU_NO_BLANKET_RECONCILE=1`).
- New pin `t/destroy-cross-thread-writeback-coherence.t` (5 tests): PASS both ON and OFF.
- Existing concurrency pins (`cross-thread-shared-var-writeback-coherence`, `nested-method-captured-writeback-coherence`, `caller-frame-write-slot-coherence`): no regression ON/OFF.
- `make test`: PASS (9831 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)