### PR TITLE
docs: record File::Temp completion (#3399), fix PLAN.md #TBD

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -200,7 +200,7 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
       list_i` で死。全 op 実装は数週・高リスク。**代替＝mutsu に builtin `to-json`/`from-json` を実装**（or `nqp::`
       非依存の小さな pure-Raku JSON shim）。Template::Mustache 91/92-specs も即解禁。
 - [ ] **ユーティリティ:**
-  - [x] **File::Temp 0.0.12 — 完動（#TBD, 2026-06-22）。** `tempfile`/`tempdir` 実ファイル生成・
+  - [x] **File::Temp 0.0.12 — 完動（#3399, 2026-06-22）。** `tempfile`/`tempdir` 実ファイル生成・
     write→read・END cleanup・`File::Directory::Tree` 依存ロードまで raku 一致。ブロッカーだった
     `use`/`unit module` の `:ver<>:auth<>` adverb（version/auth セレクタを import タグ扱いして `no such tag 'ver'`）を
     解消＝parser で dist セレクタとして消費・破棄。`unit module Foo:ver<>:auth<>` も対応。多数のモジュールに効く一般機能。
@@ -210,7 +210,7 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
     **coercion-type シグネチャパラメータ（`T()`/`T(U)`）の一般対応**が必要。medium・汎用性高。
 - [ ] バイナリ配布: mise GitHub バックエンドのインストール検証 / GitHub Releases 自動化。
 
-**次の高インパクト順（推奨）:** ✅① `use`/`unit module` の `:ver<>:auth<>` adverb（File::Temp 完動・#TBD）→
+**次の高インパクト順（推奨）:** ✅① `use`/`unit module` の `:ver<>:auth<>` adverb（File::Temp 完動・#3399）→
 ② builtin `to-json`/`from-json`（JSON 全般＋mustache specs）→ ③ `IO::Socket::Async.Supply(:bin)`→Buf
 （HTTP server 本体が死ぬ地点）→ ④ coercion-type パラメータ `T()` → ⑤ builtin 型サブクラスの user メソッド
 override 解決（IO::Blob）。①②④⑤ はいずれも単一モジュールを超える一般機能。

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,29 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### web ブログスタック第2弾: File::Temp 完動 — `use`/`unit module` の `:ver<>:auth<>` adverb（PR #3399, 2026-06-22）
+
+Template::Mustache（#3395）に続く2つ目の web ブログスタックモジュール **File::Temp 0.0.12**（+ 依存の
+**File::Directory::Tree 0.2**）が mutsu で raku とバイト一致で動くようになった（`tempfile`/`tempdir` の実ファイル生成・
+write→read・END クリーンアップ）。PLAN.md §H の推奨高インパクト項目①。
+
+唯一のブロッカーは `:ver<>`/`:auth<>`/`:api<>` adverb の扱いだった。これらは**配布物セレクタであって import タグではない**:
+- `use Foo:ver<...>:auth<...>` → parser が `ver`/`auth` を import タグ扱い → 実行時 `Error while importing from 'Foo':
+  no such tag 'ver' declared`。
+- `unit module Foo:ver<...>:auth<...>` → adverb が孤立したコロンペア式文として漏れ（`Useless use of "=>" ... in sink context`）。
+
+修正:
+- `src/parser/stmt/decl/use_decl.rs`: use の adverb 収集ループで `:ver|auth|api<...>` を検出し `<...>` を消費・破棄
+  （use_tags に積まない）。本物の未知タグ（`:nonesuch`）は引き続き `X::Import::NoSuchTag` で拒否。
+- `src/parser/stmt/class.rs` の `unit_module_stmt`: 名前の後で `parse_declarator_traits` を呼ぶ（`module Foo {}` ブロック
+  形式・クラス形式は既に対応済みだった）。
+
+テスト: `t/use-version-auth-adverb.t`（+ `t/lib/VersionedMod.rakumod`）。`make test` PASS、S11-modules roast 全 PASS。
+多数の配布物が `:ver<>:auth<>` 付きの `use` を持つため、単一モジュールを超える一般機能。
+
+※ dev の落とし穴: parser 変更後はモジュールロードに `~/.cache/mutsu/precomp/` の古い AST が使われる（dev 版は
+CARGO_PKG_VERSION が `0.1.0` 固定で無効化されない）。parser を触ったら `rm -rf ~/.cache/mutsu/precomp` してから検証する。
+
 ### CP-3 collapse: `struct VM` を `Interpreter` へ溶かし ping-pong を撤去（PR #3102）
 
 VM decoupling の最終ゴール本体。それまで `VM { interpreter: Interpreter, ... }` という 2 つの相互参照 struct が、


### PR DESCRIPTION
Doc-only follow-up to #3399.

- **news/2026-06.md**: add a highlight describing the `:ver<>:auth<>` adverb fix that made **File::Temp + File::Directory::Tree** load and run under mutsu (2nd web-blog-stack module after Mustache), including the precomp-cache dev gotcha.
- **PLAN.md §H**: correct the placeholder `#TBD` references to the actual PR number **#3399**.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)