### PR TITLE
feat(json): native to-json / from-json (JSON::Fast / JSON::Tiny compatible)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -202,11 +202,16 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
     mutsu の `run`/`qqx`（`:out`/`:err`/`exitcode`）は raku とバイト一致で動作確認済。`sqlite3 -json` で行を JSON 出力可。
     工数 ~1-2日。値エスケープ/1クエリ1プロセスは要注意。
   - **フォールバック**: flat-file `.raku`＋`EVALFILE`（mutsu で round-trip 確認済）は今日すぐ動く MVP。
-- [ ] **JSON — JSON::Fast はロード不可（NQP 依存）。builtin or shim を推奨。**
-      JSON::Fast 0.19 は `use nqp;`＋**~50 個の nqp op**（`list_i`/`findnotcclass`/`strfromcodes`/native int 等）に
-      依存。mutsu は nqp op を 2 個（`atkey`/`atpos`）しか実装しておらず、`use JSON::Fast` 時点で `Unknown function:
-      list_i` で死。全 op 実装は数週・高リスク。**代替＝mutsu に builtin `to-json`/`from-json` を実装**（or `nqp::`
-      非依存の小さな pure-Raku JSON shim）。Template::Mustache 91/92-specs も即解禁。
+- [x] **JSON — `to-json`/`from-json` をネイティブ実装（#TBD, 2026-06-22）。** JSON::Fast 0.19 は `use nqp;`＋~50 個の
+      nqp op 依存でロード不可のため、`use JSON::Fast` / `use JSON::Tiny` を組み込みモジュールとして認識し（`Test` と同方式・
+      `loaded_modules` ゲート）、`to-json`/`from-json` を Rust ネイティブ実装（`src/runtime/json.rs`、ディスパッチは
+      `src/vm/vm_native_json.rs`）。raku JSON::Fast とバイト一致（pretty 2-space / `:!pretty` / `:sorted-keys` / `:spacing`、
+      Rat→`.0`・Num→`e0`、null→`Any`、decimal→Rat・exp→Num、surrogate escape）。テスト `t/json.t`（34 件）。
+  - **残ブロッカー（JSON とは独立）: Template::Mustache 91/92-specs。** ハーネス TestUtil の `%specs{ .basename } := %data<tests>`
+    後に `%specs.head.value.head<template>` が「Type Array does not support associative indexing」で死ぬ。原因＝`:=` で hash 要素に
+    束縛した Array が `.head.value`（Pair.value）経由で **itemized** に見え（`.elems`=1、`.head`＝配列自体）、`<template>` 添字で失敗。
+    `my %h; %h{"k"} := @arr; %h.head.value.head` で JSON 抜きに再現する一般バグ（container-identity 系、`pair-value-container-three-facets`
+    と同族・高 blast-radius）。JSON 機能自体は完動。
 - [ ] **ユーティリティ:**
   - [x] **File::Temp 0.0.12 — 完動（#3399, 2026-06-22）。** `tempfile`/`tempdir` 実ファイル生成・
     write→read・END cleanup・`File::Directory::Tree` 依存ロードまで raku 一致。ブロッカーだった
@@ -219,7 +224,8 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
 - [ ] バイナリ配布: mise GitHub バックエンドのインストール検証 / GitHub Releases 自動化。
 
 **次の高インパクト順（推奨）:** ✅① `use`/`unit module` の `:ver<>:auth<>` adverb（File::Temp 完動・#3399）→
-② builtin `to-json`/`from-json`（JSON 全般＋mustache specs）→ ③ `IO::Socket::Async.Supply(:bin)`→Buf
+✅② native `to-json`/`from-json`（JSON 全般・#TBD。mustache 91/92 は別の `:=`-hash-itemization バグ待ち）→
+③ `IO::Socket::Async.Supply(:bin)`→Buf
 （HTTP server 本体が死ぬ地点）→ ④ coercion-type パラメータ `T()` → ⑤ builtin 型サブクラスの user メソッド
 override 解決（IO::Blob）。①②④⑤ はいずれも単一モジュールを超える一般機能。
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1212,3 +1212,27 @@ overlay へ publish。`interpolate_regex_scalars` は `$*` twigil 解決時に e
 
 **結果**: `t/warn-cross-frame-control-resume.t`（7 ケース・rakudo 検証）。#3372 回帰ガード全緑（control/warn/catch/top-level/
 indent/quietly/gather）。make test 9819 全パス。これで PLAN.md §H の Template::Mustache が完了。
+
+## 2026-06-22: native `to-json` / `from-json`（JSON::Fast / JSON::Tiny 互換, #TBD）
+
+**JSON シリアライズ/デシリアライズをネイティブ実装した。** 外部 `JSON::Fast` 0.19 は `use nqp;` ＋ ~50 個の nqp op
+（`list_i` / `findnotcclass` / `strfromcodes` / native int 等）に依存し mutsu ではロード不可（実装は数週・高リスク）。
+代替として `to-json` / `from-json` を Rust ネイティブで実装し、`Test` と同じ方式でモジュールにゲートした。
+
+- **モジュール認識**: `use JSON::Fast` / `use JSON::Tiny` を組み込みモジュールとして認識（`src/runtime/mod.rs` の
+  pragma 分岐に追加、`loaded_modules` に記録）。パーサ側は `register_module_exports`（`src/parser/stmt/simple.rs`）で
+  `to-json` / `from-json` をハードコード export（ソースファイルが無いため scan 不可）。
+- **ネイティブ実装**: `src/runtime/json.rs`（encode/decode 本体）＋ `src/vm/vm_native_json.rs`（`try_native_json_function`
+  ディスパッチ、`json_module_loaded()` ゲート）。`Test` の `try_native_test_function` と同型 — ユーザ定義 `sub to-json`
+  があればそちらが優先（ユーザ解決が先に走る）。`vm_call_func_ops.rs` の Test ディスパッチ直後に挿入。
+- **raku JSON::Fast とバイト一致**: pretty（2-space 既定）/ `:!pretty`（コンパクト）/ `:sorted-keys` / `:spacing(n)`、
+  空 `{ }`・`[ ]` の改行、Rat は整数なら `.0` 付与、Num は指数なし時 `e0` 付与、NaN/Inf→`null`、型オブジェクト→`null`、
+  文字列 escape（`\n`/`\r`/`\t`・制御文字 `\u00xx`・BMP 超はサロゲートペア）。decode は `true`/`false`→Bool、`null`→`Any`
+  型オブジェクト、整数→Int、小数→Rat、指数→Num、配列→可変 Array（`real_array`）。
+- **テスト**: `t/json.t`（34 ケース — スカラ/エスケープ/構造/pretty・sorted・compact/ラウンドトリップ）。
+
+**残ブロッカー（JSON とは独立）**: Template::Mustache 91/92-specs は依然失敗。ハーネス TestUtil が
+`%specs{ .basename } := %data<tests>` で hash 要素に Array を `:=` 束縛した後、`%specs.head.value.head<template>` が
+「Type Array does not support associative indexing」で死ぬ。`my %h; %h{"k"} := @arr; %h.head.value.head` で JSON 抜きに
+再現する一般バグ（`:=` 束縛した hash 値が `.head.value`（Pair.value）経由で itemized に見え、`.elems`=1・`.head`＝配列自体に
+なる。container-identity 系・高 blast-radius）。JSON 機能自体は完動。

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -1031,6 +1031,17 @@ pub(in crate::parser) fn register_module_exports(module: &str) {
                 associativity: None,
             })
             .collect()
+    } else if module == "JSON::Fast" || module == "JSON::Tiny" {
+        // Native modules: `to-json`/`from-json` are implemented in Rust
+        // (runtime/json.rs), so there is no source file to scan for exports.
+        ["to-json", "from-json"]
+            .iter()
+            .map(|s| InlineModuleExport {
+                name: (*s).to_string(),
+                precedence: None,
+                associativity: None,
+            })
+            .collect()
     } else {
         // Check for infinite recursion
         let already_loading = LOADING_MODULES.with(|m| m.borrow().contains(module));

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -1,0 +1,489 @@
+//! Native `to-json` / `from-json` (JSON::Fast / JSON::Tiny compatible).
+//!
+//! These are NOT Raku core builtins — they are provided by the `JSON::Fast` /
+//! `JSON::Tiny` modules. The real `JSON::Fast` depends on ~50 `nqp::` ops mutsu
+//! does not implement, so mutsu ships native Rust implementations gated behind
+//! `use JSON::Fast` / `use JSON::Tiny`, mirroring how the `Test` functions are
+//! gated on `use Test` (see `vm_native_test.rs`).
+//!
+//! Encoding follows JSON::Fast 0.19 semantics: `:pretty` defaults to True with a
+//! 2-space indent, type objects / undefined values render as `null`, `Rat`s gain
+//! a trailing `.0` when integral, and `Num`s gain a trailing `e0` when they carry
+//! no exponent. Decoding maps `true`/`false` to `Bool`, `null` to the `Any` type
+//! object, integers to `Int`, decimals to `Rat`, and exponential forms to `Num`.
+
+use crate::value::{Value, make_rat};
+use std::collections::HashMap;
+
+/// Options controlling `to-json` rendering. Mirrors the JSON::Fast named params.
+pub(crate) struct ToJsonOpts {
+    pub pretty: bool,
+    pub sorted_keys: bool,
+    pub spacing: usize,
+}
+
+impl Default for ToJsonOpts {
+    fn default() -> Self {
+        ToJsonOpts {
+            pretty: true,
+            sorted_keys: false,
+            spacing: 2,
+        }
+    }
+}
+
+/// Serialize a `Value` to a JSON string.
+pub(crate) fn to_json(val: &Value, opts: &ToJsonOpts) -> String {
+    let mut out = String::new();
+    jsonify(val, opts, 0, &mut out);
+    out
+}
+
+fn indent(out: &mut String, opts: &ToJsonOpts, level: usize) {
+    if opts.pretty {
+        for _ in 0..(level * opts.spacing) {
+            out.push(' ');
+        }
+    }
+}
+
+fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
+    match val {
+        Value::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        Value::Int(_) | Value::BigInt(_) => out.push_str(&val.to_string_value()),
+        Value::Rat(..) | Value::FatRat(..) | Value::BigRat(..) => {
+            // JSON::Fast: emit the Rat string, appending ".0" when it has no
+            // decimal point so the value reads back as a Rat, not an Int.
+            let s = val.to_string_value();
+            out.push_str(&s);
+            if !s.contains('.') {
+                out.push_str(".0");
+            }
+        }
+        Value::Num(f) => {
+            if f.is_nan() || f.is_infinite() {
+                // JSON has no NaN/Inf; JSON::Fast emits `null` unless the dynamic
+                // var $*JSON_NAN_INF_SUPPORT is set (which mutsu does not model).
+                out.push_str("null");
+            } else {
+                let s = val.to_string_value();
+                out.push_str(&s);
+                if !s.contains('e') && !s.contains('E') {
+                    out.push_str("e0");
+                }
+            }
+        }
+        Value::Str(s) => {
+            out.push('"');
+            escape_str(s, out);
+            out.push('"');
+        }
+        Value::Scalar(inner) => jsonify(inner, opts, level, out),
+        Value::Mixin(inner, _) => jsonify(inner, opts, level, out),
+        Value::Array(arr, _) => jsonify_seq(&arr.items, opts, level, out),
+        Value::Seq(items) | Value::Slip(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+            jsonify_seq(items, opts, level, out)
+        }
+        Value::Hash(h) => {
+            let entries: Vec<(&String, &Value)> = h.map.iter().collect();
+            jsonify_object(entries, opts, level, out);
+        }
+        Value::Pair(k, v) => {
+            jsonify_object(vec![(k, v.as_ref())], opts, level, out);
+        }
+        Value::ValuePair(k, v) => {
+            let key = k.to_string_value();
+            jsonify_object(vec![(&key, v.as_ref())], opts, level, out);
+        }
+        // Type objects / undefined values render as JSON null.
+        Value::Nil | Value::Package(_) | Value::Whatever | Value::HyperWhatever => {
+            out.push_str("null");
+        }
+        // Anything else: fall back to a quoted stringification. Raku would die on
+        // an unjsonifiable object; being lenient keeps web/template use working.
+        other => {
+            out.push('"');
+            escape_str(&other.to_string_value(), out);
+            out.push('"');
+        }
+    }
+}
+
+fn jsonify_seq(items: &[Value], opts: &ToJsonOpts, level: usize, out: &mut String) {
+    if items.is_empty() {
+        // JSON::Fast prints an empty array as "[\n]" in pretty mode.
+        if opts.pretty {
+            out.push_str("[\n");
+            indent(out, opts, level);
+            out.push(']');
+        } else {
+            out.push_str("[]");
+        }
+        return;
+    }
+    out.push('[');
+    if opts.pretty {
+        out.push('\n');
+    }
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+            if opts.pretty {
+                out.push('\n');
+            }
+        }
+        indent(out, opts, level + 1);
+        jsonify(item, opts, level + 1, out);
+    }
+    if opts.pretty {
+        out.push('\n');
+        indent(out, opts, level);
+    }
+    out.push(']');
+}
+
+fn jsonify_object(
+    entries: Vec<(&String, &Value)>,
+    opts: &ToJsonOpts,
+    level: usize,
+    out: &mut String,
+) {
+    if entries.is_empty() {
+        if opts.pretty {
+            out.push_str("{\n");
+            indent(out, opts, level);
+            out.push('}');
+        } else {
+            out.push_str("{}");
+        }
+        return;
+    }
+    let mut entries = entries;
+    if opts.sorted_keys {
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+    }
+    out.push('{');
+    if opts.pretty {
+        out.push('\n');
+    }
+    for (i, (k, v)) in entries.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+            if opts.pretty {
+                out.push('\n');
+            }
+        }
+        indent(out, opts, level + 1);
+        out.push('"');
+        escape_str(k, out);
+        out.push_str("\":");
+        if opts.pretty {
+            out.push(' ');
+        }
+        jsonify(v, opts, level + 1, out);
+    }
+    if opts.pretty {
+        out.push('\n');
+        indent(out, opts, level);
+    }
+    out.push('}');
+}
+
+/// Escape a string per JSON::Fast's `str-escape`: `\n`/`\r`/`\t` and `"`/`\\`
+/// get short escapes, other control chars (< 0x20) become `\u00xx`, code points
+/// above the BMP become surrogate pairs, everything else passes through literally.
+fn escape_str(s: &str, out: &mut String) {
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c if (c as u32) >= 0x10000 => {
+                let cp = c as u32 - 0x10000;
+                let hi = 0xD800 + (cp >> 10);
+                let lo = 0xDC00 + (cp & 0x3FF);
+                out.push_str(&format!("\\u{:04x}\\u{:04x}", hi, lo));
+            }
+            c => out.push(c),
+        }
+    }
+}
+
+/// Parse a JSON string into a `Value`. Returns an error message on malformed input.
+pub(crate) fn from_json(text: &str) -> Result<Value, String> {
+    let mut p = Parser {
+        bytes: text.as_bytes(),
+        chars: text,
+        pos: 0,
+    };
+    p.skip_ws();
+    let value = p.parse_value()?;
+    p.skip_ws();
+    if p.pos != p.bytes.len() {
+        return Err("JSON Input contained additional text after the document".to_string());
+    }
+    Ok(value)
+}
+
+struct Parser<'a> {
+    bytes: &'a [u8],
+    chars: &'a str,
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn skip_ws(&mut self) {
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b' ' | b'\t' | b'\n' | b'\r' => self.pos += 1,
+                _ => break,
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn parse_value(&mut self) -> Result<Value, String> {
+        self.skip_ws();
+        match self.peek() {
+            Some(b'{') => self.parse_object(),
+            Some(b'[') => self.parse_array(),
+            Some(b'"') => Ok(Value::str(self.parse_string()?)),
+            Some(b't') => self.parse_literal("true", Value::Bool(true)),
+            Some(b'f') => self.parse_literal("false", Value::Bool(false)),
+            Some(b'n') => {
+                self.parse_literal("null", Value::Package(crate::symbol::Symbol::intern("Any")))
+            }
+            Some(c) if c == b'-' || c.is_ascii_digit() => self.parse_number(),
+            Some(c) => Err(format!("Unexpected character in JSON: {}", c as char)),
+            None => Err("Unexpected end of JSON".to_string()),
+        }
+    }
+
+    fn parse_literal(&mut self, word: &str, val: Value) -> Result<Value, String> {
+        if self.chars[self.pos..].starts_with(word) {
+            self.pos += word.len();
+            Ok(val)
+        } else {
+            Err(format!("Invalid JSON literal, expected '{word}'"))
+        }
+    }
+
+    fn parse_object(&mut self) -> Result<Value, String> {
+        self.pos += 1; // consume '{'
+        let mut map = HashMap::new();
+        self.skip_ws();
+        if self.peek() == Some(b'}') {
+            self.pos += 1;
+            return Ok(Value::Hash(Value::hash_arc(map)));
+        }
+        loop {
+            self.skip_ws();
+            if self.peek() != Some(b'"') {
+                return Err("Expected string key in JSON object".to_string());
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            if self.peek() != Some(b':') {
+                return Err("Expected ':' in JSON object".to_string());
+            }
+            self.pos += 1;
+            let val = self.parse_value()?;
+            map.insert(key, val);
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => {
+                    self.pos += 1;
+                }
+                Some(b'}') => {
+                    self.pos += 1;
+                    return Ok(Value::Hash(Value::hash_arc(map)));
+                }
+                _ => return Err("Expected ',' or '}' in JSON object".to_string()),
+            }
+        }
+    }
+
+    fn parse_array(&mut self) -> Result<Value, String> {
+        self.pos += 1; // consume '['
+        let mut items = Vec::new();
+        self.skip_ws();
+        if self.peek() == Some(b']') {
+            self.pos += 1;
+            return Ok(Value::real_array(items));
+        }
+        loop {
+            let val = self.parse_value()?;
+            items.push(val);
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => {
+                    self.pos += 1;
+                }
+                Some(b']') => {
+                    self.pos += 1;
+                    return Ok(Value::real_array(items));
+                }
+                _ => return Err("Expected ',' or ']' in JSON array".to_string()),
+            }
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, String> {
+        self.pos += 1; // consume opening '"'
+        let mut result = String::new();
+        while self.pos < self.bytes.len() {
+            let c = self.bytes[self.pos];
+            match c {
+                b'"' => {
+                    self.pos += 1;
+                    return Ok(result);
+                }
+                b'\\' => {
+                    self.pos += 1;
+                    let esc = self.peek().ok_or("Unterminated escape in JSON string")?;
+                    match esc {
+                        b'"' => result.push('"'),
+                        b'\\' => result.push('\\'),
+                        b'/' => result.push('/'),
+                        b'b' => result.push('\u{0008}'),
+                        b'f' => result.push('\u{000c}'),
+                        b'n' => result.push('\n'),
+                        b'r' => result.push('\r'),
+                        b't' => result.push('\t'),
+                        b'u' => {
+                            let cp = self.parse_unicode_escape()?;
+                            // Handle surrogate pairs.
+                            if (0xD800..=0xDBFF).contains(&cp) {
+                                if self.chars[self.pos..].starts_with("\\u") {
+                                    self.pos += 2;
+                                    let lo = self.parse_unicode_escape()?;
+                                    let combined = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                                    if let Some(ch) = char::from_u32(combined) {
+                                        result.push(ch);
+                                    }
+                                } else if let Some(ch) = char::from_u32(cp) {
+                                    result.push(ch);
+                                }
+                                continue;
+                            } else if let Some(ch) = char::from_u32(cp) {
+                                result.push(ch);
+                            }
+                            continue;
+                        }
+                        other => {
+                            result.push('\\');
+                            result.push(other as char);
+                        }
+                    }
+                    self.pos += 1;
+                }
+                _ => {
+                    // Copy the full UTF-8 character.
+                    let ch_str = &self.chars[self.pos..];
+                    let ch = ch_str
+                        .chars()
+                        .next()
+                        .ok_or("Invalid UTF-8 in JSON string")?;
+                    result.push(ch);
+                    self.pos += ch.len_utf8();
+                }
+            }
+        }
+        Err("Unterminated JSON string".to_string())
+    }
+
+    /// Parse exactly 4 hex digits (the `\u` already consumed) and advance past them.
+    fn parse_unicode_escape(&mut self) -> Result<u32, String> {
+        self.pos += 1; // consume 'u'
+        if self.pos + 4 > self.bytes.len() {
+            return Err("Truncated \\u escape in JSON string".to_string());
+        }
+        let hex = &self.chars[self.pos..self.pos + 4];
+        let cp = u32::from_str_radix(hex, 16)
+            .map_err(|_| "Invalid \\u escape in JSON string".to_string())?;
+        self.pos += 4;
+        Ok(cp)
+    }
+
+    fn parse_number(&mut self) -> Result<Value, String> {
+        let start = self.pos;
+        if self.peek() == Some(b'-') {
+            self.pos += 1;
+        }
+        while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+            self.pos += 1;
+        }
+        let mut is_rat = false;
+        let mut is_num = false;
+        if self.peek() == Some(b'.') {
+            is_rat = true;
+            self.pos += 1;
+            while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+                self.pos += 1;
+            }
+        }
+        if matches!(self.peek(), Some(b'e') | Some(b'E')) {
+            is_num = true;
+            self.pos += 1;
+            if matches!(self.peek(), Some(b'+') | Some(b'-')) {
+                self.pos += 1;
+            }
+            while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+                self.pos += 1;
+            }
+        }
+        let num_str = &self.chars[start..self.pos];
+        if is_num {
+            // Exponential form -> Num.
+            num_str
+                .parse::<f64>()
+                .map(Value::Num)
+                .map_err(|_| format!("Invalid JSON number: {num_str}"))
+        } else if is_rat {
+            Ok(decimal_to_rat(num_str))
+        } else {
+            // Plain integer -> Int (fall back to Num if it overflows i64).
+            match num_str.parse::<i64>() {
+                Ok(i) => Ok(Value::Int(i)),
+                Err(_) => num_str
+                    .parse::<f64>()
+                    .map(Value::Num)
+                    .map_err(|_| format!("Invalid JSON number: {num_str}")),
+            }
+        }
+    }
+}
+
+/// Convert a decimal literal (e.g. "2.5", "-0.75") into a reduced `Rat`.
+fn decimal_to_rat(s: &str) -> Value {
+    let negative = s.starts_with('-');
+    let abs = s.trim_start_matches('-');
+    if let Some((int_part, frac_part)) = abs.split_once('.') {
+        let frac_digits = frac_part.len() as u32;
+        if let Some(denom) = 10i64.checked_pow(frac_digits) {
+            let int_val = int_part.parse::<i64>().unwrap_or(0);
+            let frac_val = if frac_part.is_empty() {
+                0
+            } else {
+                frac_part.parse::<i64>().unwrap_or(0)
+            };
+            if let Some(scaled) = int_val.checked_mul(denom) {
+                let mut numer = scaled + frac_val;
+                if negative {
+                    numer = -numer;
+                }
+                return make_rat(numer, denom);
+            }
+        }
+    }
+    // Fallback for overflow / unexpected shape.
+    Value::Num(s.parse::<f64>().unwrap_or(0.0))
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -151,6 +151,7 @@ mod eval_check;
 mod handle;
 mod io;
 mod io_handles;
+pub(crate) mod json;
 mod lock_reentry;
 mod main_args;
 mod metamodel;
@@ -3862,6 +3863,12 @@ impl Interpreter {
                     | "fatal"
                     | "oo"
                     | "class"
+                    // JSON::Fast / JSON::Tiny: the real distributions depend on
+                    // ~50 nqp ops mutsu does not implement. Recognize them as
+                    // built-in modules and provide native `to-json`/`from-json`
+                    // (see runtime/json.rs, dispatched in vm_native_json.rs).
+                    | "JSON::Fast"
+                    | "JSON::Tiny"
             ) {
             // Track MONKEY-TYPING pragma
             if module == "MONKEY-TYPING" || module == "MONKEY" {

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -143,6 +143,12 @@ impl Interpreter {
             || self.loaded_modules.iter().any(|m| m.starts_with("Test::"))
     }
 
+    /// True once `use JSON::Fast` / `use JSON::Tiny` has been seen, gating the
+    /// native `to-json` / `from-json` dispatch (see `vm_native_json.rs`).
+    pub(crate) fn json_module_loaded(&self) -> bool {
+        self.loaded_modules.contains("JSON::Fast") || self.loaded_modules.contains("JSON::Tiny")
+    }
+
     /// Check if a name matches a known test function (Test or Test::Util).
     /// Used by the bare word resolver to dispatch zero-arg test function calls.
     pub(crate) fn is_test_function_name(name: &str) -> bool {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -146,6 +146,7 @@ pub(crate) mod vm_misc_ops;
 mod vm_native_dispatch;
 mod vm_native_extrema;
 mod vm_native_first;
+mod vm_native_json;
 mod vm_native_map;
 mod vm_native_sort;
 mod vm_native_subst;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1101,6 +1101,10 @@ impl Interpreter {
                 } else if let Some(result) = self.try_native_test_function(name, &args) {
                     // Dispatch Test functions straight to their typed handler (lever A).
                     result
+                } else if let Some(result) = self.try_native_json_function(name, &args) {
+                    // Dispatch JSON::Fast / JSON::Tiny `to-json` / `from-json`
+                    // to the native implementation (runtime/json.rs).
+                    result
                 } else if let Some(callable) = self.lexical_amp_var_callable(Some(code), name) {
                     // Pure lexical `&name` callable (a `&code` parameter or
                     // `my &f = ...` with no same-named package sub): dispatch

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -1,0 +1,75 @@
+//! VM-side dispatch for the `JSON::Fast` / `JSON::Tiny` `to-json` / `from-json`
+//! routines.
+//!
+//! These are not Raku core builtins — they are provided by the JSON modules.
+//! The real `JSON::Fast` depends on ~50 `nqp::` ops mutsu lacks, so mutsu ships
+//! native Rust implementations (`runtime/json.rs`) gated behind `use JSON::Fast`
+//! / `use JSON::Tiny`, mirroring the native `Test` dispatch in `vm_native_test`.
+
+use super::*;
+use crate::runtime::json::{self, ToJsonOpts};
+use crate::value::Value;
+
+impl Interpreter {
+    /// Dispatch `to-json` / `from-json` straight to the native JSON
+    /// implementation when a JSON module is loaded. Returns `Some(result)` when
+    /// handled, `None` to let the caller fall through unchanged (so a
+    /// user-defined `sub to-json { … }` still wins, since user resolution runs
+    /// before this).
+    pub(super) fn try_native_json_function(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(name, "to-json" | "from-json") || !self.json_module_loaded() {
+            return None;
+        }
+        // Strip the synthetic `__test_callsite_line` trailer (and any other
+        // call-site bookkeeping) the same way the Test path does.
+        let (clean_args, _callsite_line) = self.sanitize_call_args(args);
+        match name {
+            "to-json" => Some(native_to_json(&clean_args)),
+            "from-json" => Some(native_from_json(&clean_args)),
+            _ => None,
+        }
+    }
+}
+
+fn native_to_json(args: &[Value]) -> Result<Value, RuntimeError> {
+    let mut opts = ToJsonOpts::default();
+    let mut subject: Option<&Value> = None;
+    for arg in args {
+        match arg {
+            Value::Pair(name, val) => apply_to_json_named(&mut opts, name, val),
+            Value::ValuePair(key, val) => {
+                apply_to_json_named(&mut opts, &key.to_string_value(), val)
+            }
+            other if subject.is_none() => subject = Some(other),
+            _ => {}
+        }
+    }
+    let subject = subject.unwrap_or(&Value::Nil);
+    Ok(Value::str(json::to_json(subject, &opts)))
+}
+
+fn apply_to_json_named(opts: &mut ToJsonOpts, name: &str, val: &Value) {
+    match name {
+        "pretty" => opts.pretty = val.truthy(),
+        "sorted-keys" => opts.sorted_keys = val.truthy(),
+        "spacing" => {
+            if let Value::Int(n) = val {
+                opts.spacing = (*n).max(0) as usize;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn native_from_json(args: &[Value]) -> Result<Value, RuntimeError> {
+    let text = args
+        .iter()
+        .find(|a| !matches!(a, Value::Pair(..) | Value::ValuePair(..)))
+        .map(|v| v.to_string_value())
+        .unwrap_or_default();
+    json::from_json(&text).map_err(RuntimeError::new)
+}

--- a/t/json.t
+++ b/t/json.t
@@ -1,0 +1,58 @@
+use Test;
+use JSON::Fast;
+
+plan 34;
+
+# --- from-json: scalars ---
+is from-json("42"), 42, 'from-json integer';
+is from-json("42").^name, 'Int', 'from-json integer is Int';
+is from-json("-7"), -7, 'from-json negative integer';
+is from-json("2.5"), 2.5, 'from-json decimal';
+is from-json("2.5").^name, 'Rat', 'from-json decimal is Rat';
+is from-json("1e2").^name, 'Num', 'from-json exponent is Num';
+is from-json('"hello"'), 'hello', 'from-json string';
+is from-json("true"), True, 'from-json true';
+is from-json("false"), False, 'from-json false';
+is from-json("null").^name, 'Any', 'from-json null is Any';
+
+# --- from-json: escapes ---
+is from-json('"a\nb"'), "a\nb", 'from-json newline escape';
+is from-json('"tab\there"'), "tab\there", 'from-json tab escape';
+is from-json('"quote\"x"'), 'quote"x', 'from-json quote escape';
+is from-json('"A"'), 'A', 'from-json unicode escape';
+
+# --- from-json: structures ---
+my $arr = from-json("[1, 2, 3]");
+is $arr.^name, 'Array', 'from-json array is Array';
+is $arr.elems, 3, 'from-json array elems';
+is $arr[1], 2, 'from-json array element';
+
+my $obj = from-json('{"a": 1, "b": "two", "c": [true, null]}');
+is $obj.^name, 'Hash', 'from-json object is Hash';
+is $obj<a>, 1, 'from-json object int value';
+is $obj<b>, 'two', 'from-json object str value';
+is $obj<c>[0], True, 'from-json nested array bool';
+
+# --- to-json: scalars ---
+is to-json(42), '42', 'to-json integer';
+is to-json("str"), '"str"', 'to-json string';
+is to-json(True), 'true', 'to-json True';
+is to-json(False), 'false', 'to-json False';
+is to-json(Any), 'null', 'to-json type object is null';
+is to-json(3/4), '0.75', 'to-json Rat';
+is to-json(2/1), '2.0', 'to-json integral Rat gets .0';
+
+# --- to-json: escapes ---
+is to-json("a\nb"), '"a\nb"', 'to-json escapes newline';
+is to-json('say "hi"'), '"say \"hi\""', 'to-json escapes quotes';
+
+# --- to-json: non-pretty / sorted ---
+is to-json({b => 1, a => 2}, :!pretty, :sorted-keys), '{"a":2,"b":1}', 'to-json compact sorted';
+is to-json([1, 2, 3], :!pretty), '[1,2,3]', 'to-json compact array';
+
+# --- roundtrip ---
+my $data = {name => "alice", tags => ["x", "y"], n => 3};
+is-deeply from-json(to-json($data)), $data, 'roundtrip preserves data';
+
+# --- empty ---
+is to-json({}, :!pretty), '{}', 'to-json empty hash compact';


### PR DESCRIPTION
## What

Implement `to-json` / `from-json` natively in Rust, exposed via `use JSON::Fast` / `use JSON::Tiny`.

The real `JSON::Fast` 0.19 depends on ~50 `nqp::` ops mutsu does not implement (`list_i`, `findnotcclass`, `strfromcodes`, native int, …), so `use JSON::Fast` cannot load at all. Rather than implement the whole nqp surface (weeks of work, high risk), mutsu now recognizes `JSON::Fast` / `JSON::Tiny` as built-in modules and ships native implementations of their two routines — the same pattern already used for the `Test` functions (native Rust, gated on `use`, user-defined subs still win because user resolution runs first).

## How

- **`src/runtime/json.rs`** — encoder/decoder. Byte-identical to raku `JSON::Fast`:
  - `:pretty` (2-space default) / `:!pretty` (compact) / `:sorted-keys` / `:spacing(n)`
  - empty `{ }` / `[ ]` newline form, `Rat` gets trailing `.0` when integral, `Num` gets trailing `e0` when it has no exponent, `NaN`/`Inf` and type objects render as `null`
  - string escaping: `\n`/`\r`/`\t`, control chars `\u00xx`, code points above the BMP as surrogate pairs
  - decode: `true`/`false` → `Bool`, `null` → `Any` type object, integer → `Int`, decimal → `Rat`, exponent → `Num`, array → mutable `Array`
- **`src/vm/vm_native_json.rs`** — `try_native_json_function` dispatch (mirrors `try_native_test_function`); parses `:pretty`/`:sorted-keys`/`:spacing` named args; gated on `json_module_loaded()`.
- **`src/runtime/mod.rs`** — recognize `JSON::Fast` / `JSON::Tiny` as built-in modules.
- **`src/parser/stmt/simple.rs`** — register `to-json` / `from-json` as known exports.
- **`src/vm/vm_call_func_ops.rs`** — dispatch JSON functions right after the Test branch.

## Tests

`t/json.t` — 34 cases (scalars, escapes, structures, pretty/sorted/compact, roundtrip). Output verified byte-identical to `raku -e 'use JSON::Fast; …'`.

## Remaining (independent of JSON)

`Template::Mustache` 91/92-specs are still blocked, but **not** by JSON — by an independent `:=`-bound-hash-value itemization bug: `my %h; %h{"k"} := @arr; %h.head.value.head` sees the bound array as itemized (`.elems` == 1, `.head` == the whole array), so the harness's `%specs.head.value.head<template>` dies with "Type Array does not support associative indexing". Recorded in `PLAN.md` §H / `news/2026-06.md` (container-identity family, high blast-radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)