### PR TITLE
feat(lazy): lazy .pairs/.antipairs/.kv over a lazy list (no eager force)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -55,10 +55,13 @@
     `env_dirty` を真に消すには **env を locals の派生ビュー化＝単一ストア化**が要り、それは
     **env↔locals が同一コンテナ cell を共有する**こと（前提①）が前提。
 - **✅ env↔locals 純 writeback コヒーレンスは完了**（slice 1〜1.20・#3400 まで）。OFF roast survey の純 writeback
-  サーフェスは枯渇。**残る OFF 依存は別軸＝lazy-lists.t の laziness バグ**（`.kv`/`.pairs`/`.antipairs` の eager force・
-  下記 §C 参照）。
-- **∴ 次の一手 = lazy-lists 真 lazy 化（§C 末尾 ＋ §3-F の L 系）。** これを消化すれば OFF survey が実質クリアし、
-  `env_dirty` 削除（§2-E）が射程に入る。それまで env_dirty は perf ゲートとして正当に残す。
+  サーフェスは枯渇。
+- **✅ lazy-lists.t laziness バグも解消（2026-06-22）**: `.kv`/`.pairs`/`.antipairs` を lazy index-pipe 化（lazy ソース
+  上で eager force しない）。`S02-types/lazy-lists.t` 24-26 が OFF でも PASS。OFF roast survey の決定的サーフェスは
+  **IO-Socket-Async.t の reactive 並行 flaky のみ**（決定的 pin 不可）。
+- **∴ `env_dirty` 物理削除（§2-E）が射程に入った。** `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/
+  `ensure_locals_synced`/`saved_env_dirty` 削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
+  IO-Socket-Async の flaky はこの空洞化で実挙動を確認する。
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**
 
@@ -98,13 +101,13 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
       nested-method capture／cross-thread shared-var／object 添字代入 invocant／substr-rw・undefine lvalue／zip-topic・LAST
       phaser／proto `state %`／caller-frame write／param default self-scoping／**cross-thread DESTROY writeback（#3400）**）。
       **OFF roast survey の純 writeback サーフェスは枯渇**（残は別軸＝下記）。`:=` bind・closure captured scalar も done。
-      **★残る OFF 依存は純 writeback でない別軸 2 のみ**:
-      - **lazy-lists.t 24-26 = laziness バグの露出**（`.kv`/`.pairs`/`.antipairs` が gather を eager force・ON は write-loss
-        で偶然 raku 一致、OFF が正しく伝播して露出）。**修正＝`.kv`/`.pairs`/`.antipairs` の真 lazy 化**（§3-F の L 系と合流・
-        precise-writeback では解けない）。**これが env_dirty 削除の最後の前提。**
+      **★残る OFF 依存は IO-Socket-Async.t の flaky のみ**:
+      - **✅ lazy-lists.t 24-26 解消（2026-06-22）**: `.kv`/`.pairs`/`.antipairs` を lazy index-pipe（`MapGrepSpec.index_transform`）
+        化し lazy ソースを eager force しないように修正。`my @res = one.kv` が gather body（`$was-lazy=0`）を走らせず、OFF で
+        も PASS。値は eager 版とバイト一致（pairs=`i=>elem` / antipairs=`elem=>i` / kv=`i,elem` flat）。無限ソース上でも lazy。
       - IO-Socket-Async.t 5,7 = reactive 並行 flaky（決定的 pin 不可・env_dirty 削除の `blanket_reconcile_if_dirty` 空洞化で実挙動確認）。
-- [ ] **★次の本丸 = lazy-lists 真 lazy 化（→ §1-A 解禁）**: 上記 lazy-lists.t を消化すれば OFF survey が実質クリアし、
-      §2-E（`env_dirty`/`ensure_locals_synced`/`saved_env_dirty` 物理削除）が射程に入る。L 系（§3-F の L2b 系）と合流。
+- [ ] **★次の本丸 = `env_dirty` 物理削除（§2-E・→ §1-A 解禁）**: OFF survey の決定的サーフェスが枯渇したので、
+      `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/`ensure_locals_synced`/`saved_env_dirty` 削除に着手できる。
 - [ ] follow-up（pre-existing・小）: `$x = @arr` 共有の method param 版（`method m($n){ $n.push }`）・`is copy` $-param。
       設計＝[docs/scalar-array-sharing.md](docs/scalar-array-sharing.md) §5。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -6,9 +6,11 @@
 > object 添字代入 invocant slot／substr-rw・subbuf-rw／zip short-circuit／map LAST phaser／undefine() lvalue）
 > ＋slice 1.17（proto state-%cache）／1.18（caller-frame by-name write）／**1.19（param default self-scoping＝code.t 8）**
 > を実装。各 pin が **blanket reconcile ON/OFF 両方で PASS**。**OFF roast survey（authoritative・§7.2a）= 初回 13 → 残 1**。
-> **残 1（純 writeback でない）＝destruction.t 3（cross-thread worker-DESTROY の parent-slot 未 refresh・§7.2c に真因確定）**。
-> ＋別軸 2＝lazy-lists.t（laziness・L 系）／IO-Socket-Async.t（flaky）。
-> 次＝§7.2c（cross-thread writeback 記録の拡張＝slice 1.11 family・cell substrate 不要）or env_dirty 削除の最終段（§7.4・`blanket_reconcile_if_dirty` 空洞化）。
+> **destruction.t 3 = slice 1.20（#3400）で解決済**（cross-thread writeback の retain-on-miss・§7.2c）。
+> **lazy-lists.t 24-26 = 2026-06-22 で解決済**（`.kv`/`.pairs`/`.antipairs` を lazy index-pipe 化＝
+> `MapGrepSpec.index_transform`・lazy ソースを eager force しない）。**∴ OFF roast survey の決定的サーフェスは
+> IO-Socket-Async.t の reactive 並行 flaky のみ（決定的 pin 不可）に枯渇。**
+> 次＝env_dirty 削除の最終段（§7.4・`blanket_reconcile_if_dirty` 空洞化）。
 > 関連: [docs/env-locals-coherence.md](env-locals-coherence.md)（§7.3 = env_dirty 削除の壁）/
 > [docs/container-identity.md](container-identity.md)（cell インフラ）/ PLAN.md §1-A・§2-C・§2-E。
 >
@@ -596,19 +598,20 @@ env を stale slot で clobber→state 永続化が空 hash 保存。修正＝fa
 
 ## 9. 着手手順（次セッション用クイックスタート）
 
-**★純 writeback コヒーレンスは slice 1.20（#3400）で完了＝OFF roast survey の純 writeback サーフェスは枯渇。**
-captured-outer cell 共有のグラインドはここで終わり。次の本丸は**別軸の laziness バグ**で、これが env_dirty 削除（§7.4）の
-最後の前提。
+**★純 writeback コヒーレンスは slice 1.20（#3400）で完了。lazy-lists.t 24-26 の真 lazy 化も完了（2026-06-22）＝
+OFF roast survey の決定的サーフェスは IO-Socket-Async.t の flaky のみに枯渇。** これで env_dirty 削除（§7.4）の前提が
+すべて揃った。
 
-**次セッションの本丸 = `S02-types/lazy-lists.t` 24-26 の真 lazy 化（§7.2a triage 参照・§3-F の L 系と合流）**:
-- 症状: OFF で subtests 24-26 が決定的 fail（`MUTSU_FUDGE=1 MUTSU_NO_BLANKET_RECONCILE=1 prove -e target/debug/mutsu
-  roast/S02-types/lazy-lists.t` → Failed 24-26）。ON は write-loss で偶然 raku 一致。
+**lazy-lists.t 24-26 の解決（2026-06-22・完了）**:
 - 真因: `make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy` を `.kv`/`.pairs`/`.antipairs` が **eager に force** して
-  `$was-lazy = 0` を走らせる（mutsu の `.kv`/`.pairs`/`.antipairs` が非 lazy）。**writeback ではなく laziness バグ**＝
-  precise-writeback では解けない。
-- 修正方針: `.kv`/`.pairs`/`.antipairs` を真に lazy 化（lazy Seq/gather を eager 消費しない）。`docs/lazy-arrays.md` の
-  L 系（L2b 等）と設計を合流させる。raku で `(gather { ... }).lazy.kv` が lazy のままなことを確認してから着手。
-- これが入れば OFF survey が実質クリア（残は IO-Socket-Async.t の flaky のみ＝決定的 pin 不可）→ §7.4 が射程。
+  `$was-lazy = 0` を走らせていた。ON は write-loss で偶然 raku 一致、OFF が正しく伝播して露出（writeback でなく laziness バグ）。
+- 修正: `MapGrepSpec` に `index_transform: Option<IndexTransform>`（Pairs/AntiPairs/Kv）を追加し、`.kv`/`.pairs`/`.antipairs`
+  を **lazy index-pipe**（`LazyList::new_index_pipe`）化。genuinely-lazy ソース（`.lazy` gather・無限 spec）に対しては eager
+  force でなく lazy pipe を返す。`source_idx` を positional key に使い、pull は既存の `pull_source_element`（gather coroutine を
+  incremental 消費）を再利用。`force_lazy_pipe` が `index_transform` Some 時に func/grep を bypass して index 変換を emit。
+  3 dispatch 経路（CallMethodMut fast-path・CallMethod 非mut・runtime slow-path methods.rs）すべてに早期 dispatch を追加。
+  index-pipe は preserve marker を持つので `my @res = one.kv` が lazy 保持。値は eager 版とバイト一致。pin=
+  `t/lazy-pairs-kv-antipairs.t`（18・ON/OFF 両 PASS）。
 
-**その後 = §7.4（env_dirty 物理削除）**: `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/`ensure_locals_synced`/
+**次 = §7.4（env_dirty 物理削除）**: `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/`ensure_locals_synced`/
 `saved_env_dirty` 削除 → `cell_boxing_active()` gate を外して boxing 恒久 ON 化。IO-Socket-Async の flaky はこの空洞化で実挙動確認。

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -3135,6 +3135,24 @@ impl Interpreter {
                 ll.in_array_context(),
             )));
         }
+        // Lazy `.pairs`/`.antipairs`/`.kv` over a genuinely-lazy source: build a
+        // lazy index-pipe stage instead of forcing the source (mirrors the
+        // CallMethodMut fast-path so a chained `.pairs` stays lazy too).
+        if let Value::LazyList(ll) = &target
+            && ll.is_genuinely_lazy()
+            && args.is_empty()
+            && matches!(method, "kv" | "pairs" | "antipairs")
+        {
+            let transform = match method {
+                "pairs" => crate::value::IndexTransform::Pairs,
+                "antipairs" => crate::value::IndexTransform::AntiPairs,
+                _ => crate::value::IndexTransform::Kv,
+            };
+            return Ok(Value::LazyList(std::sync::Arc::new(
+                crate::value::LazyList::new_index_pipe(target.clone(), transform),
+            )));
+        }
+
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target
             && Self::should_force_lazy_list(method)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1801,6 +1801,23 @@ pub(crate) struct MapGrepSpec {
     pub(crate) source_idx: usize,
     /// `true` once `source` reported exhaustion (finite source ran out).
     pub(crate) done: bool,
+    /// When set, this stage ignores `func`/`is_grep` and emits an index-based
+    /// transform of each source element (`.pairs`/`.antipairs`/`.kv`), using
+    /// `source_idx` as the positional key. Lets these methods stay lazy over a
+    /// lazy source instead of materializing it.
+    pub(crate) index_transform: Option<IndexTransform>,
+}
+
+/// Index-based transform applied lazily to a positional source, used by
+/// `.pairs`/`.antipairs`/`.kv` over a lazy list so they don't force it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IndexTransform {
+    /// `.pairs`: element `i` → `Pair(i, elem)`.
+    Pairs,
+    /// `.antipairs`: element `i` → `Pair(elem, i)`.
+    AntiPairs,
+    /// `.kv`: element `i` → two flat outputs `i, elem`.
+    Kv,
 }
 
 /// Saved for-loop state for resuming a gather coroutine mid-iteration.
@@ -2106,6 +2123,45 @@ impl LazyList {
                 is_grep,
                 source_idx: 0,
                 done: false,
+                index_transform: None,
+            })),
+            closure_seq: None,
+        }
+    }
+
+    /// Create a lazy `.pairs`/`.antipairs`/`.kv` stage over `source`.
+    ///
+    /// Stays lazy (carries the gather + preserve markers so array assignment
+    /// keeps it lazy, matching Rakudo where these methods are `.is-lazy` over a
+    /// lazy list). Elements are produced on demand by pulling from `source` and
+    /// applying the index transform with the source position as the key.
+    pub(crate) fn new_index_pipe(source: Value, transform: IndexTransform) -> Self {
+        let mut env = crate::env::Env::new();
+        env.insert(
+            "__mutsu_lazylist_from_gather".to_string(),
+            Value::Bool(true),
+        );
+        env.insert(
+            "__mutsu_preserve_lazy_on_array_assign".to_string(),
+            Value::Bool(true),
+        );
+        Self {
+            body: Vec::new(),
+            env,
+            cache: Mutex::new(Some(Vec::new())),
+            compiled_code: None,
+            compiled_fns: None,
+            elems_count: None,
+            scan_spec: None,
+            sequence_spec: None,
+            coroutine: None,
+            lazy_pipe: Some(Mutex::new(MapGrepSpec {
+                source,
+                func: Value::Nil,
+                is_grep: false,
+                source_idx: 0,
+                done: false,
+                index_transform: Some(transform),
             })),
             closure_seq: None,
         }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -448,6 +448,26 @@ impl Interpreter {
             self.stack.push(result?);
             return Ok(());
         }
+        // Lazy `.pairs`/`.antipairs`/`.kv` over a genuinely-lazy source: build a
+        // lazy index-pipe stage instead of forcing the (possibly infinite)
+        // source. Matches Rakudo where these are `.is-lazy` over a lazy list.
+        if let Value::LazyList(ref ll) = target
+            && ll.needs_vm_lazy_dispatch()
+            && ll.is_genuinely_lazy()
+            && args.is_empty()
+            && matches!(method.as_str(), "kv" | "pairs" | "antipairs")
+        {
+            let transform = match method.as_str() {
+                "pairs" => crate::value::IndexTransform::Pairs,
+                "antipairs" => crate::value::IndexTransform::AntiPairs,
+                _ => crate::value::IndexTransform::Kv,
+            };
+            let pipe = Value::LazyList(std::sync::Arc::new(
+                crate::value::LazyList::new_index_pipe(target.clone(), transform),
+            ));
+            self.stack.push(pipe);
+            return Ok(());
+        }
         let target = if let Value::LazyList(ref ll) = target
             && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(&method)

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -685,6 +685,26 @@ impl Interpreter {
             self.stack.push(result?);
             return Ok(());
         }
+        // Lazy `.pairs`/`.antipairs`/`.kv` over a genuinely-lazy source: build a
+        // lazy index-pipe stage instead of forcing (mirrors the CallMethodMut
+        // fast-path so a chained `.pairs` stays lazy too).
+        if let Value::LazyList(ref ll) = target
+            && ll.needs_vm_lazy_dispatch()
+            && ll.is_genuinely_lazy()
+            && args.is_empty()
+            && matches!(method, "kv" | "pairs" | "antipairs")
+        {
+            let transform = match method {
+                "pairs" => crate::value::IndexTransform::Pairs,
+                "antipairs" => crate::value::IndexTransform::AntiPairs,
+                _ => crate::value::IndexTransform::Kv,
+            };
+            let pipe = Value::LazyList(std::sync::Arc::new(
+                crate::value::LazyList::new_index_pipe(target.clone(), transform),
+            ));
+            self.stack.push(pipe);
+            return Ok(());
+        }
         let target = if let Value::LazyList(ref ll) = target
             && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(method)

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -971,13 +971,14 @@ impl Interpreter {
 
             // Snapshot the stage so no pipe lock is held across the pull/apply
             // (which may recursively pull from a nested pipe source).
-            let (source, func, is_grep, source_idx) = {
+            let (source, func, is_grep, source_idx, index_transform) = {
                 let spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
                 (
                     spec.source.clone(),
                     spec.func.clone(),
                     spec.is_grep,
                     spec.source_idx,
+                    spec.index_transform,
                 )
             };
 
@@ -991,6 +992,27 @@ impl Interpreter {
                     let c = cache.as_ref().cloned().unwrap_or_default();
                     let n = needed.min(c.len());
                     return Ok(c[..n].to_vec());
+                }
+                Some(elem) if index_transform.is_some() => {
+                    // `.pairs`/`.antipairs`/`.kv` over a lazy source: emit the
+                    // index-based transform using the source position as the key,
+                    // bypassing the map/grep callback entirely.
+                    let idx = Value::Int(source_idx as i64);
+                    let produced: Vec<Value> = match index_transform.unwrap() {
+                        crate::value::IndexTransform::Pairs => {
+                            vec![Value::ValuePair(Box::new(idx), Box::new(elem))]
+                        }
+                        crate::value::IndexTransform::AntiPairs => {
+                            vec![Value::ValuePair(Box::new(elem), Box::new(idx))]
+                        }
+                        crate::value::IndexTransform::Kv => vec![idx, elem],
+                    };
+                    {
+                        let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
+                        spec.source_idx = source_idx + 1;
+                    }
+                    let mut cache = list.cache.lock().unwrap();
+                    cache.get_or_insert_with(Vec::new).extend(produced);
                 }
                 Some(elem) => {
                     // Apply the stage with Interpreter-native dispatch so the callback

--- a/t/lazy-pairs-kv-antipairs.t
+++ b/t/lazy-pairs-kv-antipairs.t
@@ -1,0 +1,68 @@
+use Test;
+
+# `.pairs`/`.antipairs`/`.kv` over a genuinely-lazy list must stay lazy
+# (not force the source). Regression pin for S02-types/lazy-lists.t 24-26.
+# Also verifies the produced values match the eager equivalents.
+
+plan 18;
+
+my $was-lazy;
+sub make-lazy-list($num) { gather { take $_ for 0 ..^ $num; $was-lazy = 0 }.lazy };
+
+# Laziness: assigning the whole transform to an @-array must not force the
+# gather body (which would run `$was-lazy = 0`).
+$was-lazy = 1;
+my \one = make-lazy-list(10);
+my @res-kv = one.kv;
+ok $was-lazy, 'kv over a lazy list is lazy';
+
+$was-lazy = 1;
+my \two = make-lazy-list(10);
+my @res-pairs = two.pairs;
+ok $was-lazy, 'pairs over a lazy list is lazy';
+
+$was-lazy = 1;
+my \three = make-lazy-list(10);
+my @res-anti = three.antipairs;
+ok $was-lazy, 'antipairs over a lazy list is lazy';
+
+# .is-lazy on the transform result is True (both bound and chained).
+my \four = make-lazy-list(4);
+my $p := four.pairs;
+ok $p.is-lazy, 'pairs result reports is-lazy True';
+ok make-lazy-list(4).kv.is-lazy, 'chained kv reports is-lazy True';
+ok make-lazy-list(4).antipairs.is-lazy, 'chained antipairs reports is-lazy True';
+
+# Values: a bounded prefix matches the eager transform.
+is make-lazy-list(4).pairs.head(3).List, (0 => 0, 1 => 1, 2 => 2),
+    'lazy pairs prefix values';
+is make-lazy-list(4).antipairs.head(3).List, (0 => 0, 1 => 1, 2 => 2),
+    'lazy antipairs prefix values';
+is make-lazy-list(4).kv.head(6).List, (0, 0, 1, 1, 2, 2),
+    'lazy kv prefix values';
+
+# Full eager realization matches the eager transform exactly.
+is make-lazy-list(4).pairs.eager, (0 => 0, 1 => 1, 2 => 2, 3 => 3),
+    'lazy pairs full values';
+is make-lazy-list(4).antipairs.eager, (0 => 0, 1 => 1, 2 => 2, 3 => 3),
+    'lazy antipairs full values';
+is make-lazy-list(4).kv.eager, (0, 0, 1, 1, 2, 2, 3, 3),
+    'lazy kv full values';
+
+# Over an infinite source: stays lazy, a bounded slice still terminates.
+is ((1 .. *).pairs[^3]).List, (0 => 1, 1 => 2, 2 => 3),
+    'pairs over infinite range, bounded slice';
+is ((1 .. *).antipairs[^3]).List, (1 => 0, 2 => 1, 3 => 2),
+    'antipairs over infinite range, bounded slice';
+is ((1 .. *).kv[^6]).List, (0, 1, 1, 2, 2, 3),
+    'kv over infinite range, bounded slice';
+
+# Non-lazy (eager) gather still materializes: .pairs is not lazy there.
+nok (gather { take $_ for ^3 }).pairs.is-lazy,
+    'pairs over a non-lazy gather is not lazy';
+my @e = (gather { take $_ for ^3 }).pairs;
+is @e.elems, 3, 'non-lazy gather pairs has all elements';
+
+# antipairs values where the element is a string (positional ValuePair form).
+is make-lazy-list(3).map({ "v$_" }).antipairs.eager, ("v0" => 0, "v1" => 1, "v2" => 2),
+    'antipairs keeps element as key for strings';


### PR DESCRIPTION
## Summary

`.kv`/`.pairs`/`.antipairs` materialized their receiver via `value_to_list`, **eagerly forcing** a genuinely-lazy gather/infinite source. For `make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy`, `my @res = one.kv` ran the gather body to completion — surfaced by `S02-types/lazy-lists.t` subtests **24-26** under `MUTSU_NO_BLANKET_RECONCILE=1` (the default build hid it via captured-write loss, so the tests passed by accident).

This was the **last deterministic OFF-survey blocker** before `env_dirty` physical removal (PLAN.md §2-C → §2-E). Raku keeps `.kv`/`.pairs`/`.antipairs` lazy over a lazy list (`.is-lazy` True).

## Fix

- Add `MapGrepSpec.index_transform: Option<IndexTransform>` (`Pairs`/`AntiPairs`/`Kv`) and `LazyList::new_index_pipe`.
- For a **genuinely-lazy** source (`.lazy` gather, infinite seq/closure), build a **lazy index-pipe** instead of forcing. `force_lazy_pipe` emits the index transform using `source_idx` as the positional key (bypassing the map/grep callback); elements pull incrementally via the existing `pull_source_element` (gather coroutine), so an infinite source stays bounded.
- The pipe carries the array-preserve marker, so `my @res = one.kv` keeps it lazy.
- Early dispatch added to all three method paths: `CallMethodMut` fast-path, `CallMethod` non-mut, and the runtime slow-path (`methods.rs`).

Values match the eager form byte-for-byte (`pairs` = `i=>elem`, `antipairs` = `elem=>i`, `kv` = flat `i, elem`); a **non-lazy gather still materializes** (`.is-lazy` False).

## Tests

- New pin `t/lazy-pairs-kv-antipairs.t` (18 subtests, **ON/OFF both PASS**).
- `S02-types/lazy-lists.t` now passes ON **and** OFF (was: OFF Failed 24-26).
- `make test` 9853 PASS; clippy clean. Related pairs/kv/iterator roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)