### PR TITLE
feat(socket): IO::Socket::Async .Supply(:bin) emits Buf[uint8], not Str

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -186,9 +186,14 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
 - [ ] **HTTP::Server::Tiny スタック（全て pure Raku, NativeCall なし）— 想像以上に近い。**
       本体は `use`＋`.new`＋非同期サーバが TCP listen/accept まで実際に動く。リクエスト/レスポンス往復を阻む
       独立した4バグ:
-  - **HTTP::Server::Tiny v0.0.2**: 最有力ブロッカー＝`IO::Socket::Async.Supply(:bin)` が `Buf[uint8]` でなく
-    `Str` を emit（`:bin` adverb 無視）→ ハンドラが `parse-http-request(Str)` で型エラー死。**ここが live server が
-    死ぬ正確な地点＝単独最大インパクト。**
+  - [x] **HTTP::Server::Tiny v0.0.2 — `IO::Socket::Async.Supply(:bin)` が `Buf[uint8]` を emit するよう修正（#TBD,
+    2026-06-22）。** real-TCP Supply パス（`async_socket_supply_real_tcp`）が `:bin` adverb を無視して常に `Str` を
+    emit していた（reader thread が `from_utf8_lossy`）→ `:bin` を受け取り `Self::make_buf`（`Buf[uint8]`）を emit。
+    in-memory パスの bin Buf 構築も `Self::make_buf` に統一（従来は素の `Buf`）。テスト `t/io-socket-async-bin.t`。
+  - **残（別の既存バグ・live server 続行に必要）**: `whenever $conn.Supply(...)` の **内側**で `done`/`last` を呼ぶと
+    制御シグナルが react のハンドラに捕捉されず「Unhandled exception in code scheduled on thread」（空メッセージ）で
+    プロセス終了する（bin/非 bin 共通・`.tap` 回避なら OK）。real-TCP Supply の tap コールバックが worker thread 上で
+    走り、react の control-flow フレームから切れているため。HTTP::Server::Tiny のリクエストループが `done` を使うなら要修正。
   - **HTTP::Parser v0.0.2**: `token SP { "\x20" }`（regex slang 内の**括弧なし** `"\xNN"`）がデコードされず
     grammar 全体が失敗（`\x[20]`/`\x[0d]` 等の括弧付きや非 regex の `"\x20"` は OK）。easy/medium。
   - **IO::Blob v0.0.1**: `class IO::Blob is IO::Handle` の user override（`.get`/`.lines` 等）が builtin native
@@ -224,8 +229,8 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
 - [ ] バイナリ配布: mise GitHub バックエンドのインストール検証 / GitHub Releases 自動化。
 
 **次の高インパクト順（推奨）:** ✅① `use`/`unit module` の `:ver<>:auth<>` adverb（File::Temp 完動・#3399）→
-✅② native `to-json`/`from-json`（JSON 全般・#TBD。mustache 91/92 は別の `:=`-hash-itemization バグ待ち）→
-③ `IO::Socket::Async.Supply(:bin)`→Buf
+✅② native `to-json`/`from-json`（JSON 全般・#3402。mustache 91/92 は別の `:=`-hash-itemization バグ待ち）→
+✅③ `IO::Socket::Async.Supply(:bin)`→`Buf[uint8]`（#TBD。live server には別途 `whenever Supply`内 `done` teardown 修正が要）
 （HTTP server 本体が死ぬ地点）→ ④ coercion-type パラメータ `T()` → ⑤ builtin 型サブクラスの user メソッド
 override 解決（IO::Blob）。①②④⑤ はいずれも単一モジュールを超える一般機能。
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1213,7 +1213,7 @@ overlay へ publish。`interpolate_regex_scalars` は `$*` twigil 解決時に e
 **結果**: `t/warn-cross-frame-control-resume.t`（7 ケース・rakudo 検証）。#3372 回帰ガード全緑（control/warn/catch/top-level/
 indent/quietly/gather）。make test 9819 全パス。これで PLAN.md §H の Template::Mustache が完了。
 
-## 2026-06-22: native `to-json` / `from-json`（JSON::Fast / JSON::Tiny 互換, #TBD）
+## 2026-06-22: native `to-json` / `from-json`（JSON::Fast / JSON::Tiny 互換, #3402）
 
 **JSON シリアライズ/デシリアライズをネイティブ実装した。** 外部 `JSON::Fast` 0.19 は `use nqp;` ＋ ~50 個の nqp op
 （`list_i` / `findnotcclass` / `strfromcodes` / native int 等）に依存し mutsu ではロード不可（実装は数週・高リスク）。
@@ -1236,3 +1236,23 @@ indent/quietly/gather）。make test 9819 全パス。これで PLAN.md §H の 
 「Type Array does not support associative indexing」で死ぬ。`my %h; %h{"k"} := @arr; %h.head.value.head` で JSON 抜きに
 再現する一般バグ（`:=` 束縛した hash 値が `.head.value`（Pair.value）経由で itemized に見え、`.elems`=1・`.head`＝配列自体に
 なる。container-identity 系・高 blast-radius）。JSON 機能自体は完動。
+
+## 2026-06-22: IO::Socket::Async `.Supply(:bin)` が `Buf[uint8]` を emit（#TBD）
+
+**PLAN.md §H ③。** HTTP::Server::Tiny の live server が死ぬ正確な地点を修正した。real-TCP 接続の `.Supply(:bin)`
+（`src/runtime/native_methods/socket_async_conn.rs` の `async_socket_supply_real_tcp`）が `:bin` adverb を完全に無視し、
+reader thread で常に `String::from_utf8_lossy` した `Str` を emit していた。これだとハンドラの `parse-http-request(Blob)`
+が型エラーで死ぬ。
+
+- **修正**: `async_socket_supply_real_tcp` が args を受け取り `is_bin` を判定、reader thread で bin 時は
+  `Self::make_buf`（`Buf[uint8]` インスタンス）を、非 bin 時は従来通り `Str` を emit。
+- **一般化**: in-memory パスの bin Buf 構築（`decode_pending_bytes_to_supply` / `deliver_bytes_to_peer_supplies`）も
+  素の `Buf` から `Self::make_buf`（`Buf[uint8]`）へ統一。raku は bin Supply で `Buf[uint8]` を emit するため `.^name` も一致。
+- **テスト**: `t/io-socket-async-bin.t`（3 ケース — real TCP で `ABC` を送り `Buf[uint8]` / バイト `(65,66,67)` を確認）。
+  whitelisted `roast/S32-io/IO-Socket-Async.t`（in-memory・40 件）は回帰なし。
+
+**残（別の既存バグ・live server 続行に必要）**: `whenever $conn.Supply(...)` の内側で `done`/`last` を呼ぶと、制御シグナルが
+react のハンドラに捕捉されず "Unhandled exception in code scheduled on thread"（空メッセージ＝制御 RuntimeError）で
+`std::process::exit(1)`（`encoding.rs:353`）。real-TCP Supply の tap コールバックが worker thread 上で走り react の
+control-flow フレームから切れているのが原因（bin/非 bin 共通、`.tap` 直叩きなら回避可）。HTTP::Server::Tiny の
+リクエストループが `done` を使うなら次に要修正。

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -57,7 +57,7 @@ impl Interpreter {
                 self.async_socket_close_in_memory(conn_id)?;
                 Ok(Value::Nil)
             }
-            "Supply" if is_real_tcp => self.async_socket_supply_real_tcp(conn_id),
+            "Supply" if is_real_tcp => self.async_socket_supply_real_tcp(conn_id, &args),
             "Supply" => self.async_socket_supply_in_memory(conn_id, &args, attributes),
             "write" | "print" if is_real_tcp => {
                 self.async_socket_write_real_tcp(conn_id, method, &args)
@@ -110,8 +110,13 @@ impl Interpreter {
     fn async_socket_supply_real_tcp(
         &mut self,
         conn_id: Option<u64>,
+        args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
+        // `.Supply(:bin)` must emit `Buf[uint8]` chunks (raw bytes), not decoded
+        // `Str`. This is the exact point HTTP::Server::Tiny's handler needs: it
+        // feeds the emitted value to `parse-http-request`, which expects a Blob.
+        let is_bin = Self::named_bool(args, "bin");
         let supply_id = next_supply_id();
         let (tx, rx) = mpsc::channel::<SupplyEvent>();
         if let Ok(mut map) = supply_channel_map().lock() {
@@ -131,8 +136,12 @@ impl Interpreter {
                                 break;
                             }
                             Ok(n) => {
-                                let data = String::from_utf8_lossy(&buf[..n]).to_string();
-                                if tx.send(SupplyEvent::Emit(Value::str(data))).is_err() {
+                                let value = if is_bin {
+                                    Self::make_buf(buf[..n].to_vec())
+                                } else {
+                                    Value::str(String::from_utf8_lossy(&buf[..n]).to_string())
+                                };
+                                if tx.send(SupplyEvent::Emit(value)).is_err() {
                                     break;
                                 }
                             }
@@ -221,17 +230,7 @@ impl Interpreter {
         initial_values: &mut Vec<Value>,
     ) {
         if is_bin {
-            let mut battrs = HashMap::new();
-            battrs.insert(
-                "bytes".to_string(),
-                Value::array(
-                    pending_bytes
-                        .iter()
-                        .map(|b| Value::Int(*b as i64))
-                        .collect(),
-                ),
-            );
-            initial_values.push(Value::make_instance(Symbol::intern("Buf"), battrs));
+            initial_values.push(Self::make_buf(pending_bytes.to_vec()));
         } else if let Some(supply) = get_async_supply(supply_id) {
             let decoded = if supply.encoding.eq_ignore_ascii_case("utf-8") {
                 String::from_utf8_lossy(pending_bytes).to_string()
@@ -386,12 +385,7 @@ impl Interpreter {
         for sid in supply_ids {
             if let Some(supply) = get_async_supply(*sid) {
                 if supply.is_bin {
-                    let mut battrs = HashMap::new();
-                    battrs.insert(
-                        "bytes".to_string(),
-                        Value::array(bytes.iter().map(|b| Value::Int(*b as i64)).collect()),
-                    );
-                    let buf = Value::make_instance(Symbol::intern("Buf"), battrs);
+                    let buf = Self::make_buf(bytes.to_vec());
                     let _ = self.async_supplier_emit_value(*sid, buf);
                 } else {
                     let mut pending = supply.byte_buffer.clone();

--- a/t/io-socket-async-bin.t
+++ b/t/io-socket-async-bin.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 3;
+
+# IO::Socket::Async connection .Supply(:bin) must emit Buf[uint8], not Str.
+# This is the exact point HTTP::Server::Tiny's handler dies: it feeds the
+# emitted value to parse-http-request, which expects a Blob, and a Str
+# triggers a type error.
+#
+# Capture via .tap (not `done` inside the Supply whenever) to isolate the
+# bin-vs-Str behaviour from the separate react/done teardown path.
+{
+    my $port = 19995;
+    my $got-type = '';
+    my $got-bytes;
+
+    my $server = start {
+        react {
+            whenever IO::Socket::Async.listen("127.0.0.1", $port) -> $conn {
+                $conn.Supply(:bin).tap(-> $data {
+                    $got-type = $data.^name;
+                    $got-bytes = $data;
+                });
+            }
+            whenever Promise.in(1.5) { done }
+        }
+    };
+
+    sleep 0.5;
+
+    my $client = IO::Socket::INET.new(host => '127.0.0.1', port => $port);
+    $client.print("ABC");
+    $client.close;
+
+    await $server;
+
+    ok $got-bytes ~~ Blob, "Supply(:bin) emits a Blob/Buf, not a Str";
+    is $got-type, 'Buf[uint8]', "emitted value .^name is Buf[uint8]";
+    is $got-bytes.list, (65, 66, 67), "bytes are the raw uint8 values of 'ABC'";
+}


### PR DESCRIPTION
## What

`IO::Socket::Async` connection `.Supply(:bin)` now emits `Buf[uint8]` chunks instead of `Str`. This is PLAN.md §H item ③ — the exact point HTTP::Server::Tiny's live server dies.

## Why

The real-TCP Supply path (`async_socket_supply_real_tcp`) ignored the `:bin` adverb entirely: its reader thread always emitted a `Str` via `String::from_utf8_lossy`. HTTP::Server::Tiny feeds the emitted value to `parse-http-request`, whose signature expects a `Blob` — so a `Str` is a type error and the request loop dies. (The in-memory Supply path already honored `:bin`; only the real-TCP path was wrong.)

## How

- `async_socket_supply_real_tcp` now receives the call args, computes `is_bin = Self::named_bool(args, "bin")`, and emits `Self::make_buf(...)` (a `Buf[uint8]` instance) when bin, keeping the `Str` path for text mode.
- Unify the in-memory bin Buf construction (`decode_pending_bytes_to_supply`, `deliver_bytes_to_peer_supplies`) onto `Self::make_buf` too — they previously built a bare `Buf`, but raku emits `Buf[uint8]`, so `.^name` now matches as well.

## Tests

- `t/io-socket-async-bin.t` — opens a real TCP connection, sends `"ABC"`, and asserts the `:bin` Supply emits a `Buf[uint8]` with bytes `(65, 66, 67)`. Verified byte-identical to raku.
- Whitelisted `roast/S32-io/IO-Socket-Async.t` (in-memory path, 40 tests) still passes — no regression from the `Buf[uint8]` unification.

## Remaining (independent, blocks the full live server)

A separate pre-existing bug remains: calling `done`/`last` **inside** a `whenever $conn.Supply(...)` block throws an uncaught control signal ("Unhandled exception in code scheduled on thread", empty message → `std::process::exit(1)`), because the real-TCP Supply tap callback runs on a worker thread detached from react's control-flow frame. It affects bin and text Supplies equally (`.tap` directly avoids it). Recorded in PLAN.md §H / news/2026-06.md for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)