### PR TITLE
fix(hash): decontainerize element cells when iterating a hash as pairs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -215,11 +215,14 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
       `loaded_modules` ゲート）、`to-json`/`from-json` を Rust ネイティブ実装（`src/runtime/json.rs`、ディスパッチは
       `src/vm/vm_native_json.rs`）。raku JSON::Fast とバイト一致（pretty 2-space / `:!pretty` / `:sorted-keys` / `:spacing`、
       Rat→`.0`・Num→`e0`、null→`Any`、decimal→Rat・exp→Num、surrogate escape）。テスト `t/json.t`（34 件）。
-  - **残ブロッカー（JSON とは独立）: Template::Mustache 91/92-specs。** ハーネス TestUtil の `%specs{ .basename } := %data<tests>`
-    後に `%specs.head.value.head<template>` が「Type Array does not support associative indexing」で死ぬ。原因＝`:=` で hash 要素に
-    束縛した Array が `.head.value`（Pair.value）経由で **itemized** に見え（`.elems`=1、`.head`＝配列自体）、`<template>` 添字で失敗。
-    `my %h; %h{"k"} := @arr; %h.head.value.head` で JSON 抜きに再現する一般バグ（container-identity 系、`pair-value-container-three-facets`
-    と同族・高 blast-radius）。JSON 機能自体は完動。
+  - [x] **hash 要素 cell の pair-value デコンテナ化（#TBD, 2026-06-22）。** `%specs{ .basename } := %data<tests>` 後の
+    `%specs.head.value.head<template>` が「Type Array does not support associative indexing」で死んでいた原因を修正。
+    hash 要素は `ContainerRef` cell で格納されるが、hash を pairs として反復（`.pairs`/`.head`/`.kv`/`.antipairs`/`.sort`）する
+    際に cell を Pair 値へそのまま入れていた（`%h<k>` 読み・`.values` は deref していたのに不整合）→ `+`/`.elems` が cell を
+    単一スカラ扱い。`typed_pair`（hash→pair の中心）＋ `.pairs`/`.kv`/`.antipairs` で `deref_container()` 適用。テスト
+    `t/bind-hash-value-pairs.t`（14 件）。**これで 91/92-specs のハーネスが実際の spec を走るようになった。**
+  - **91/92-specs の残（別軸・本タスク外）**: 実 spec の rendering ギャップ（delimiter 永続化／inheritable partials／lambda）と、
+    最初の spec のみ `+$spec.value`=0 になる subtest/Seq-consumption 系バグ。いずれも itemization とは独立。
 - [ ] **ユーティリティ:**
   - [x] **File::Temp 0.0.12 — 完動（#3399, 2026-06-22）。** `tempfile`/`tempdir` 実ファイル生成・
     write→read・END cleanup・`File::Directory::Tree` 依存ロードまで raku 一致。ブロッカーだった

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1256,3 +1256,25 @@ react のハンドラに捕捉されず "Unhandled exception in code scheduled o
 `std::process::exit(1)`（`encoding.rs:353`）。real-TCP Supply の tap コールバックが worker thread 上で走り react の
 control-flow フレームから切れているのが原因（bin/非 bin 共通、`.tap` 直叩きなら回避可）。HTTP::Server::Tiny の
 リクエストループが `done` を使うなら次に要修正。
+
+## 2026-06-22: hash 要素 cell の pair-value デコンテナ化（#TBD）
+
+**hash を pairs として反復したときに要素 cell が漏れていたバグを修正した。** Template::Mustache 91/92-specs の
+ハーネス（`%specs{ .basename } := %data<tests>` → `%specs.head.value.head<template>`）が
+「Type Array does not support associative indexing」で死んでいた根本原因。
+
+- **原因**: hash 要素は `ContainerRef` cell で格納される（第一級コンテナ Phase 2）。`%h<k>` 読みと `.values` は
+  cell を deref していたが、hash を pairs として反復する経路（`.pairs`/`.head`/`.kv`/`.antipairs`/`.sort`）は cell を
+  そのまま Pair 値へ入れていた。すると `+`/`.elems` が cell を単一スカラ扱いし（`.elems`=1、`.head`＝配列自体）、
+  `.value.head<template>` 添字が失敗する。`my %h; %h{"k"} := @arr; %h.head.value.head` で JSON/Mustache 抜きに再現
+  （`=` 代入でも同様）。
+- **修正**: hash→pair 構築の中心 `HashData::typed_pair`（value_to_list / sort 等 10 箇所が利用）で値を
+  `deref_container()`。加えて独自に Pair を組む `.pairs`/`.kv`/`.antipairs`（collection.rs）でも適用。スカラ値は
+  `deref_container` が no-op なので無影響。
+- **テスト**: `t/bind-hash-value-pairs.t`（14 件 — `:=`/`=`/`.pairs`/`.head`/`.kv`/`.antipairs`/`.sort`、スカラ値の不変）。
+  raku とバイト一致。whitelisted hash/pair roast（S02-types/hash・pair、pairs、nested_pairs、S03-binding/hashes、
+  baghash/mixhash、lazy-lists、S32-list/sort）は回帰なし。
+
+**効果**: Template::Mustache 91/92-specs のハーネスが crash せず**実際の spec を走るようになった**（delimiters 11/14 等）。
+残る spec 失敗（delimiter 永続化／inheritable partials／lambda、および最初の spec のみ `+$spec.value`=0 になる
+subtest/Seq-consumption バグ）は itemization とは独立の別軸。

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -486,7 +486,8 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         } else {
                             kv.push(Value::hash_key_decode(k));
                         }
-                        kv.push(v.clone());
+                        // Decontainerize element cells (see t/bind-hash-value-pairs.t).
+                        kv.push(v.deref_container());
                     }
                     Some(Ok(Value::Seq(Arc::new(kv))))
                 }
@@ -563,18 +564,20 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             match target {
                 Value::Hash(items) => {
                     let has_orig = crate::runtime::utils::hash_uses_typed_keys(target);
+                    // Decontainerize element cells so the pair value matches a
+                    // `%h<k>` read / `.values` (see t/bind-hash-value-pairs.t).
                     let pairs: Vec<Value> = if has_orig {
                         items
                             .iter()
                             .map(|(k, v)| {
                                 let typed_k = crate::runtime::utils::hash_typed_key(target, k);
-                                Value::ValuePair(Box::new(typed_k), Box::new(v.clone()))
+                                Value::ValuePair(Box::new(typed_k), Box::new(v.deref_container()))
                             })
                             .collect()
                     } else {
                         items
                             .iter()
-                            .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
+                            .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.deref_container())))
                             .collect()
                     };
                     Some(Ok(Value::Seq(Arc::new(pairs))))
@@ -663,9 +666,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         .iter()
                         .map(|(k, v)| {
                             let orig_key = crate::runtime::utils::hash_typed_key(target, k);
-                            match v {
+                            // Decontainerize element cells (see t/bind-hash-value-pairs.t).
+                            match v.deref_container() {
                                 Value::Str(s) => Value::Pair(s.to_string(), Box::new(orig_key)),
-                                _ => Value::ValuePair(Box::new(v.clone()), Box::new(orig_key)),
+                                dv => Value::ValuePair(Box::new(dv), Box::new(orig_key)),
                             }
                         })
                         .collect();

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -2012,6 +2012,8 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
         // An itemized hash (`item %h` / `$(%h)`) is a single list element and does
         // NOT flatten to its pairs (mirrors the itemized-Array arm above).
         Value::Hash(items) if items.itemized => vec![val.clone()],
+        // `typed_pair` decontainerizes element cells so the pair value matches a
+        // `%h<k>` read / `.values` (see t/bind-hash-value-pairs.t).
         Value::Hash(items) => items
             .iter()
             .map(|(k, v)| items.typed_pair(k, v.clone()))

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1357,7 +1357,14 @@ impl HashData {
     /// hashes. Plain string keys yield `Value::Pair`; non-string typed keys
     /// (object hashes) yield `Value::ValuePair`. Behaviour-neutral for plain
     /// hashes (returns `Value::Pair(str_key, value)` as before).
+    /// Build a `Pair` for a hash entry `(str_key, value)`, honoring object-hash
+    /// typed keys. The value is decontainerized: a hash element is stored as a
+    /// `ContainerRef` cell, but the pair must carry the inner value (matching a
+    /// `%h<k>` read and `.values`) — otherwise iterating a hash as pairs leaks
+    /// the cell and `+`/`.elems` on the pair value misbehave (the cell counts as
+    /// a single scalar item). See t/bind-hash-value-pairs.t.
     pub fn typed_pair(&self, str_key: &str, value: Value) -> Value {
+        let value = value.deref_container();
         match self.typed_key(str_key) {
             Value::Str(s) => Value::Pair((*s).clone(), Box::new(value)),
             other => Value::ValuePair(Box::new(other), Box::new(value)),

--- a/t/bind-hash-value-pairs.t
+++ b/t/bind-hash-value-pairs.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 14;
+
+# A hash element holds its value in a container cell. Iterating the hash as
+# pairs (.pairs / .head / .kv / .antipairs / .sort) must yield the inner value
+# (matching a `%h<k>` read and `.values`), not the cell — otherwise `.elems` /
+# `+` on the pair value see the cell as a single scalar item.
+# Regression: Template::Mustache 91/92-specs harness does
+# `%specs{$name} := @tests; for %specs.sort(*.key) -> $s { plan +$s.value }`.
+
+my @arr = {a => 1}, {a => 2}, {a => 3};
+
+# --- := bind into a hash slot ---
+{
+    my %h; %h{"k"} := @arr;
+    is %h<k>.elems, 3, ':= bound — direct subscript read';
+    is %h.values.head.elems, 3, ':= bound — .values';
+    is %h.pairs.head.value.elems, 3, ':= bound — .pairs value';
+    is %h.head.value.elems, 3, ':= bound — .head value';
+    is %h.head.value.head<a>, 1, ':= bound — .head.value.head indexes the inner hash';
+    is (+%h.sort(*.key).head.value), 3, ':= bound — .sort value numifies to elems';
+}
+
+# --- = assign into a hash slot ---
+{
+    my %h; %h{"k"} = @arr;
+    is %h<k>.elems, 3, '= assigned — direct subscript read';
+    is %h.pairs.head.value.elems, 3, '= assigned — .pairs value';
+    is %h.sort(*.key).head.value.elems, 3, '= assigned — .sort value';
+}
+
+# --- .kv yields the inner value too ---
+{
+    my %h; %h{"k"} := @arr;
+    my @seen;
+    for %h.kv -> $key, $val { @seen.push: $val.elems }
+    is @seen, (3,), '.kv value elems';
+}
+
+# --- plain scalar values are unaffected ---
+{
+    my %h = a => 10, b => 20;
+    is %h.sort(*.key).map(*.value).List, (10, 20), 'scalar values sort/pairs unchanged';
+    is %h.pairs.sort(*.key).head.value, 10, 'scalar pair value';
+}
+
+# --- antipairs over a hash with an array value ---
+{
+    my %h; %h{"k"} := @arr;
+    my $ap = %h.antipairs.head;        # value (array) becomes the key
+    is $ap.key.elems, 3, '.antipairs — array value-as-key keeps its elems';
+    is $ap.value, 'k', '.antipairs — original key becomes value';
+}


### PR DESCRIPTION
## What

A hash element holding an array/object value was leaking its container cell into the value of pairs produced by `.pairs` / `.head` / `.kv` / `.antipairs` / `.sort`. This fixes that — the pair value now matches a `%h<k>` read and `.values`.

## Why

Hash elements are stored as `ContainerRef` cells (first-class containers, Phase 2). Reading `%h<k>` and `.values` already deref the cell, but the hash-as-pairs paths put the raw cell into the Pair value. Downstream `+` / `.elems` on that value then treat the cell as a single scalar item (`.elems` == 1, `.head` == the whole array), so:

```raku
my %h; %h{"k"} := @arr;
%h.head.value.head;     # "Type Array does not support associative indexing"
%h.pairs.head.value.elems;  # 1  (should be @arr.elems)
```

(Also reproduces with `=` assignment, and via `.sort(*.key)`.)

This is exactly what the **Template::Mustache 91/92-specs** harness hits: `%specs{$name} := @tests; for %specs.sort(*.key) -> $s { plan +$s.value; ... }`.

## How

Deref the value at the central hash→pair builder `HashData::typed_pair` (used by `value_to_list`, `sort`, and ~10 other callers), plus the explicit `.pairs` / `.kv` / `.antipairs` builders in `builtins/methods_0arg/collection.rs`. Scalar values are unaffected — `deref_container` is a no-op for non-`ContainerRef`.

## Tests

- `t/bind-hash-value-pairs.t` — 14 cases (`:=` / `=`, `.pairs` / `.head` / `.kv` / `.antipairs` / `.sort`, scalar-value invariance). Byte-identical to raku.
- Whitelisted hash/pair roast (`S02-types/hash`, `pair`, `pairs`, `nested_pairs`, `S03-binding/hashes`, `baghash`, `mixhash`, `lazy-lists`, `S32-list/sort`) unchanged.
- `make test`: 9904 tests, Result: PASS.

## Effect

The Template::Mustache 91/92-specs harness now runs the real spec subtests instead of crashing on the first `%specs.head.value.head<template>`. The remaining 91/92 spec failures are independent (actual rendering gaps — delimiter persistence, inheritable partials, lambdas — and a first-spec-only `+$spec.value`==0 subtest/Seq-consumption bug), not the itemization issue. Recorded in PLAN.md / news.

🤖 Generated with [Claude Code](https://claude.com/claude-code)