### PR TITLE
feat(single-store): precise let/temp restore writeback (env_dirty substrate S2)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -663,9 +663,22 @@ retain-on-miss が運ぶ（slice 1.18 と同型）。blanket reconcile は任意
 サイトに残置（double-OFF harness 下では no-op）＝default build はバイト不変。pin=既存
 `t/substr-rw-lvalue-writeback-coherence.t`（test 4・double-OFF で PASS 化）。make test 9890（default/double-OFF 両 PASS）。
 
-### 10.4 次スライス候補
+### 10.4 slice S2（2026-06-22）— `let`/`temp` restore を precise 化（15→13）
 
-残 15 のうち contained なもの: `note-gist-and-dynamic-handle`（test 3 のみ）/
-`done-paren-stmt-modifier`（react done() の precise writeback）。closure 系（`closure-nested-writeback` 1-2・
-`wrap-closure-capture`）は method/closure 捕捉の cell 化（sub-slice 1c）。並行系（supply/react）は cross-thread
-cell（最難・最後）。全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。
+`temp $x = 20` のブロック退出復元が `restore_let_value`（`accessors.rs`）の非cell path で `env.insert` のみ＝
+slot stale（double-OFF で `$x` が 20 のまま）。restore は復元名を正確に知っている。**修正**: 非cell path で復元名を
+`pending_rw_writeback_sources`（drop-on-miss・same-frame bare block 用）＋ `pending_caller_var_writeback`
+（retain-on-miss・nested callee の `temp` 用）に記録し、block-exit op 3 サイト（`vm_misc_ops.rs` success/err・
+`vm_control_ops.rs` err）で `reconcile_locals_from_env_at_site` の前に `apply_pending_rw_writeback` で精密 drain。
+blanket reconcile は fallback として残置（harness 下 no-op）＝default build 挙動不変。cell-boxed binding は従来どおり
+shared Arc 経由で slot が見えるので非該当。pin=`t/let-temp.t` + `t/let-temp-restore-writeback-coherence.t`
+（double-OFF で PASS 化）。make test 9904。
+
+### 10.5 残 13・次スライス候補
+
+`closure-nested-writeback`（1-2）/ `note-gist-and-dynamic-handle` / `wrap-closure-capture` = **method/closure の
+nested capture writeback**（nested gist/method が捕捉した outer を変異・直接 free var でなく env-scan writeback 経路で
+拾う必要＝retain-on-miss 記録だけでは不足）。`eval-carrier-precise-writeback` / `single-store-slice-c-prime` =
+carrier。`junction-invocant-autothread` / `resumable-control-signal-indirect-call` /
+`concurrent-cell-writeback-coherence` / supply・react 系（4）= 並行/制御（cross-thread cell・最難・最後）。
+`done-paren-stmt-modifier` = react done()。全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -2145,6 +2145,15 @@ impl Interpreter {
             arc.lock().unwrap().clone_from(&restored);
             return;
         }
+        // Non-cell restore writes the saved value into `env` by name only; record
+        // it so the block-exit op refreshes the owning local slot precisely
+        // (`apply_pending_rw_writeback`) instead of relying on the blanket
+        // env→locals pull (env_dirty-removal substrate). The owner is usually this
+        // same frame (a bare `{ temp $x = … }` block), but a `temp`/`let` inside a
+        // nested callee owns the slot a frame up — record on both the drop-on-miss
+        // and retain-on-miss lists so either reaches it.
+        self.pending_rw_writeback_sources.push(name.clone());
+        self.record_caller_var_writeback(&name);
         if let Value::Instance {
             attributes: saved_attrs,
             ..

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -3352,10 +3352,12 @@ impl Interpreter {
                 // Exception — restore let saves
                 loan_env!(self, restore_let_saves(let_mark));
                 self.env_dirty = true;
-                // The restore wrote the saved values back into `env` only;
-                // reconcile this frame's local slots so a later read sees the
-                // restored value without relying on reverse-sync (byte-identical
-                // to the env_dirty barrier pull in reverse-sync ON mode).
+                // The restore wrote the saved values back into `env` only and
+                // recorded each restored name precisely (`restore_let_value`); drain
+                // it so this frame's slots refresh without the blanket env→locals
+                // pull (env_dirty-removal substrate). The blanket reconcile stays as
+                // the fallback (no-op under the substrate harness).
+                self.apply_pending_rw_writeback(code);
                 self.reconcile_locals_from_env_at_site(code);
                 if catch_begin >= control_begin {
                     return Err(e);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3419,17 +3419,19 @@ impl Interpreter {
                 let success = Self::is_let_success(&topic);
                 loan_env!(self, resolve_let_saves_on_success(mark, success));
                 self.env_dirty = true;
-                // `let`/`temp` restore writes the saved value back into `env`
-                // only; the matching local slot still holds the in-block value.
-                // Without reverse-sync a later read through the locals store would
-                // see the un-restored value, so reconcile the frame's slots from
-                // env here (byte-identical to the reverse pull the env_dirty net
-                // would trigger in reverse-sync ON mode).
+                // `let`/`temp` restore writes the saved value back into `env` only;
+                // the matching local slot still holds the in-block value. The restore
+                // recorded each restored name precisely (`restore_let_value`); drain
+                // it so the frame's slots refresh without the blanket env→locals pull
+                // (env_dirty-removal substrate). The blanket reconcile stays as the
+                // fallback (no-op under the substrate harness).
+                self.apply_pending_rw_writeback(code);
                 self.reconcile_locals_from_env_at_site(code);
             }
             Err(e) => {
                 loan_env!(self, restore_let_saves(mark));
                 self.env_dirty = true;
+                self.apply_pending_rw_writeback(code);
                 self.reconcile_locals_from_env_at_site(code);
                 return Err(e);
             }


### PR DESCRIPTION
## Context

Second slice of the **env_dirty physical-removal substrate grind** (after #3406's bound-Proxy STORE slice). Driven by the `MUTSU_NO_PRECISE_RECONCILE` measurement harness: each surface still failing under "double-OFF" (`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`, i.e. cell-boxing alone) is a by-name writer not yet folded into precise writeback.

## Problem

`temp $x = 20` (and `let`) writes the restored value back into `env` by name on block exit but leaves the owning local **slot** stale, relying on the blanket env→locals pull. Under the substrate harness the restored value is not visible (`$x` stays `20` instead of restoring to `10`).

## Fix

`restore_let_value` knows exactly which names it restores. On the non-cell path (a cell-boxed binding already refreshes the slot through its shared Arc) record each restored name on **both**:
- `pending_rw_writeback_sources` (drop-on-miss) — same-frame bare `{ temp $x = … }` block;
- `pending_caller_var_writeback` (retain-on-miss) — a `temp` inside a nested callee owns the slot a frame up.

The three block-exit ops (`vm_misc_ops.rs` success/err, `vm_control_ops.rs` err) drain it precisely (`apply_pending_rw_writeback`) **before** the blanket `reconcile_locals_from_env_at_site`, which stays as the fallback (no-op under the harness) → default build byte-identical.

## Tests

- `t/let-temp.t` and `t/let-temp-restore-writeback-coherence.t` now pass under **double-OFF** (were the surface failures).
- double-OFF surface **15 → 13**.
- `make test` **9904 PASS** in both the default build and double-OFF; clippy clean.

Design: `docs/captured-outer-cell-sharing.md` §10.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)