### PR TITLE
feat(single-store): precise closure/method nested-capture writeback (env_dirty substrate S3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -45,23 +45,21 @@
 - ✅ **reverse pull（`sync_locals_from_env`）撤去済み（#3354, 2026-06-21）**。第27〜40セッションの write-through
   グラインド（約30 PR・roast OFF 依存 16/16 を precise 化）で「reverse pull なしで全 t/+roast green」を達成し、
   危険な同期処理を削除。**二重ストアの correctness hazard は解消。**
-- 🔴 **残る `env_dirty` の物理削除はブロック中**。`env_dirty` はもはや correctness 機構ではなく、
-  precise reconcile（`reconcile_locals_from_env_at_site`）のゲート＝安価な perf 最適化に降格している。
-  だが完全削除には壁がある:
-  - **multi-frame accumulation の壁（2026-06-21 実証）**: `via(); via()`（A→B→外側変数書込を2回）の累積は
-    env_dirty-gated の blanket reconcile が支える唯一の機構。precise な単フレーム drain では届かず、source を
-    親へ持ち越す retention 方式も drain 順序に脆弱で**置換不可**（実験で確認・revert 済）。
-  - **根本**: 置き場が2つある限り「env を名前書きした→slot が stale かも」という目印は何らかの形で必要。
-    `env_dirty` を真に消すには **env を locals の派生ビュー化＝単一ストア化**が要り、それは
-    **env↔locals が同一コンテナ cell を共有する**こと（前提①）が前提。
-- **✅ env↔locals 純 writeback コヒーレンスは完了**（slice 1〜1.20・#3400 まで）。OFF roast survey の純 writeback
-  サーフェスは枯渇。
-- **✅ lazy-lists.t laziness バグも解消（2026-06-22）**: `.kv`/`.pairs`/`.antipairs` を lazy index-pipe 化（lazy ソース
-  上で eager force しない）。`S02-types/lazy-lists.t` 24-26 が OFF でも PASS。OFF roast survey の決定的サーフェスは
-  **IO-Socket-Async.t の reactive 並行 flaky のみ**（決定的 pin 不可）。
-- **∴ `env_dirty` 物理削除（§2-E）が射程に入った。** `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/
-  `ensure_locals_synced`/`saved_env_dirty` 削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
-  IO-Socket-Async の flaky はこの空洞化で実挙動を確認する。
+- 🟡 **`env_dirty` 物理削除は substrate グラインド進行中**（2026-06-22 着手）。実証で判明: `env_dirty` は
+  ①blanket reconcile のゲート（boxing 下で無効＝除去可）と②**精密 reconcile（`reconcile_locals_from_env_at_site`・
+  carrier/Proxy STORE/let-temp/closure 等のサイト）の perf ゲート（boxing 下でも load-bearing）**の2役。完全削除には
+  精密 reconcile も不要化＝精密 reconcile 依存 surface を一つずつ precise writeback / cell 共有へ畳む必要がある。
+  - **計測ハーネス `MUTSU_NO_PRECISE_RECONCILE`**（#3406）: `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`
+    （double-OFF）＝boxing のみ＝env_dirty 削除後の到達状態。残 fail = 未変換 by-name writer。0（flaky 除く）で削除可能。
+  - **double-OFF surface: 16 → 10**（2026-06-22・3 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
+    S2 let/temp restore（#3408）／S3 closure-method nested-capture writeback（#3409）。設計＝
+    [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md) §10。
+  - **残 10**: carrier（eval-carrier の regex `:let`／single-store-slice-c-prime）＋並行/制御（supply/react/junction
+    autothread/resumable-control/concurrent-cell＝**cross-thread cell・最難・最後**）＋done-paren（react done()）。
+- **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
+  解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
+- **∴ 次 = double-OFF surface 残 10 を畳む（carrier → 並行）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
+  `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化）。**
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -674,11 +674,23 @@ blanket reconcile は fallback として残置（harness 下 no-op）＝default 
 shared Arc 経由で slot が見えるので非該当。pin=`t/let-temp.t` + `t/let-temp-restore-writeback-coherence.t`
 （double-OFF で PASS 化）。make test 9904。
 
-### 10.5 残 13・次スライス候補
+### 10.5 slice S3（2026-06-22）— closure/method nested-capture writeback を precise 化（13→10）
 
-`closure-nested-writeback`（1-2）/ `note-gist-and-dynamic-handle` / `wrap-closure-capture` = **method/closure の
-nested capture writeback**（nested gist/method が捕捉した outer を変異・直接 free var でなく env-scan writeback 経路で
-拾う必要＝retain-on-miss 記録だけでは不足）。`eval-carrier-precise-writeback` / `single-store-slice-c-prime` =
-carrier。`junction-invocant-autothread` / `resumable-control-signal-indirect-call` /
-`concurrent-cell-writeback-coherence` / supply・react 系（4）= 並行/制御（cross-thread cell・最難・最後）。
-`done-paren-stmt-modifier` = react done()。全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。
+`cap({ note "" but role { method gist { $seen = 1 } } })`（note-gist）/ `capture-out` の `$output`
+（closure-nested-writeback）/ `&f.wrap(-> { $seen = True; callsame })`（wrap-closure-capture）= nested な
+gist/method/wrapper closure が捕捉した outer lexical を変異するが、その lexical は当該 closure の**直接 free var で
+ない**（nested 内で捕捉）ため §closure-dispatch の free_var 記録（811行）が拾えない。**修正**: ①closure-dispatch の
+env-scan writeback ループ（`vm_closure_dispatch.rs`）で、書き戻す caller-visible var の値が変化した場合
+`pending_caller_var_writeback`（retain-on-miss）に記録（`cell_boxing_active()` ガード＝default build の hot closure 経路
+には不可。blanket reconcile が担う）。②wrap dispatch（`vm_call_func_ops.rs:518`・`vm_call_exec_ops.rs:56`）で
+`apply_pending_rw_writeback` を追加（wrapper の記録を drain）。blanket reconcile は fallback として残置。
+pin=`t/note-gist-and-dynamic-handle.t` + `t/closure-nested-writeback.t` + `t/wrap-closure-capture.t`（double-OFF で
+PASS 化）。make test 9904。
+
+### 10.6 残 10・次スライス候補
+
+`eval-carrier-precise-writeback` / `single-store-slice-c-prime` = carrier。`junction-invocant-autothread` /
+`resumable-control-signal-indirect-call` / `concurrent-cell-writeback-coherence` / supply・react 系（4：
+`react-do-whenever-tap-coherence`/`react-whenever-last-next`/`supply-on-demand-closing`/`supply-sync-infinite-emit`）
+= 並行/制御（cross-thread cell・最難・最後）。`done-paren-stmt-modifier` = react done()。全消化後 → §7.4
+（精密 reconcile + env_dirty 物理削除）。

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -59,6 +59,11 @@ impl Interpreter {
         {
             let result = self.vm_call_sub_value(sub_val, args, false)?;
             self.stack.push(result);
+            // A wrapper closure (`&f.wrap(-> { $seen = True; callsame })`) may mutate
+            // a captured-outer lexical; the closure dispatch recorded it precisely
+            // (`pending_*_writeback`). Drain it so the caller's slot refreshes without
+            // the blanket env→locals pull (env_dirty-removal substrate).
+            self.apply_pending_rw_writeback(code);
             self.env_dirty = true;
             return Ok(());
         }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -521,9 +521,12 @@ impl Interpreter {
         {
             let result = self.vm_call_sub_value(sub_val, args, false)?;
             // Slice F (multi-frame coherence): a wrapper closure (`&f.wrap(-> {
-            // $seen = True; callsame })`) mutates a captured caller lexical by
-            // name. This branch blanket-marks `env_dirty`, so reconcile the
-            // caller's slots from env too — the reverse pull would have, in ON.
+            // $seen = True; callsame })`) mutates a captured caller lexical by name.
+            // The closure dispatch recorded it precisely (`pending_*_writeback`);
+            // drain it so the caller's slot refreshes without the blanket env→locals
+            // pull (env_dirty-removal substrate). The blanket reconcile stays as the
+            // fallback (no-op under the substrate harness).
+            self.apply_pending_rw_writeback(code);
             self.reconcile_locals_from_env_at_site(code);
             self.stack.push(result);
             self.env_dirty = true;

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -768,6 +768,19 @@ impl Interpreter {
                 cc.locals_sym.iter().copied().collect();
             let underscore_sym = Symbol::intern("_");
             let at_underscore_sym = Symbol::intern("@_");
+            // Caller lexicals this scan writes back with a *changed* value. They are
+            // recorded (after the loop, to avoid borrowing `self` while iterating
+            // `self.env()`) on the retain-on-miss writeback list so the call site
+            // refreshes the owner's local slot precisely — covers a nested
+            // gist/method/closure that mutated an outer lexical which is NOT a direct
+            // free var of THIS closure (`cap({ note … $seen = 1 })`), so the
+            // free_var recording below misses it (env_dirty-removal substrate).
+            // Only when cell-boxing is the coherence mechanism (boxing build /
+            // substrate harness): the default build's blanket reconcile already
+            // refreshes these slots, so skip the per-call collection to keep the hot
+            // closure path (`.map`, `.grep`) free of extra work.
+            let record_writeback = self.cell_boxing_active();
+            let mut caller_writeback: Vec<Symbol> = Vec::new();
             for (k, v) in self.env().iter() {
                 if *k != underscore_sym
                     && *k != at_underscore_sym
@@ -787,8 +800,20 @@ impl Interpreter {
                     if captured_names.contains(k) && !restored_env.contains_key_sym(*k) {
                         continue;
                     }
+                    // A genuine caller lexical whose value changed across the call:
+                    // queue its slot for a precise refresh.
+                    if record_writeback
+                        && restored_env.contains_key_sym(*k)
+                        && restored_env.get_sym(*k) != Some(v)
+                        && !k.starts_with("__mutsu")
+                    {
+                        caller_writeback.push(*k);
+                    }
                     restored_env.insert_sym(*k, v.clone());
                 }
+            }
+            for k in caller_writeback {
+                self.record_caller_var_writeback(&k.resolve());
             }
             // Slice F (env<->locals coherence): a closure that mutated a captured
             // outer variable (`@a.map({ $sum += $_ })`, `$blk()` closing over a


### PR DESCRIPTION
## Context

Third slice of the **env_dirty physical-removal substrate grind** (after #3406 bound-Proxy STORE and #3408 let/temp). Driven by the `MUTSU_NO_PRECISE_RECONCILE` harness — each surface still failing under "double-OFF" is a by-name writer not yet folded into precise writeback.

## Problem

A nested gist/method/wrapper closure that mutates an outer lexical which is **not a direct free var** of that closure (it is captured *inside* the nested callee) was invisible to the closure-dispatch free-var recording, so under the harness the mutation never reached the owner's slot:

- `cap({ note "" but role { method gist { $seen = 1 } } })` — `note-gist-and-dynamic-handle`
- the `$output` capture in a `$*OUT.print` method — `closure-nested-writeback`
- `&f.wrap(-> { $seen = True; callsame })` — `wrap-closure-capture`

## Fix

1. In the closure-dispatch **env-scan writeback** loop, record each caller-visible var whose value changed across the call on the retain-on-miss `pending_caller_var_writeback` list (collected during the loop, recorded after, to avoid borrowing `self` while iterating `self.env()`). **Gated on `cell_boxing_active()`** so the default build's hot closure path (`.map`/`.grep`) pays nothing — the blanket reconcile carries it there.
2. At the **wrap-chain dispatch** sites (`vm_call_func_ops`, `vm_call_exec_ops`) drain the recorded writes with `apply_pending_rw_writeback`.

The blanket reconcile stays as the fallback (no-op under the harness) → default build byte-identical.

## Tests

- `t/note-gist-and-dynamic-handle.t`, `t/closure-nested-writeback.t`, `t/wrap-closure-capture.t` now pass under **double-OFF**.
- double-OFF surface **13 → 10**.
- `make test` **9904 PASS** (default and double-OFF); clippy clean.

Design: `docs/captured-outer-cell-sharing.md` §10.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)