### PR TITLE
fix(regex): decode bracketless \xHH in a double-quoted regex string literal

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -197,8 +197,11 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
     制御シグナルが react のハンドラに捕捉されず「Unhandled exception in code scheduled on thread」（空メッセージ）で
     プロセス終了する（bin/非 bin 共通・`.tap` 回避なら OK）。real-TCP Supply の tap コールバックが worker thread 上で
     走り、react の control-flow フレームから切れているため。HTTP::Server::Tiny のリクエストループが `done` を使うなら要修正。
-  - **HTTP::Parser v0.0.2**: `token SP { "\x20" }`（regex slang 内の**括弧なし** `"\xNN"`）がデコードされず
-    grammar 全体が失敗（`\x[20]`/`\x[0d]` 等の括弧付きや非 regex の `"\x20"` は OK）。easy/medium。
+  - [x] **HTTP::Parser v0.0.2 — regex slang 内の括弧なし `"\xNN"` デコードを修正（#TBD, 2026-06-22）。**
+    double-quote regex 文字列の `\x` ハンドラが `\x[HH]`（括弧付き）のみ処理し、`"\x20"` を "x20" に落としていた
+    （`token SP { "\x20" }` で grammar 全体が失敗）→ クォート外と同じく括弧なし連続 hex 桁を読むように。テスト
+    `t/regex-dq-hex-escape.t`。**これで HTTP::Parser の grammar がロード・パース実行できるようになった**（10 件中 2 件
+    PASS）。残る 8 失敗は別軸の独立バグ（Buf/byte 列処理・`.subst`・encode 往復）で、`\x20` とは無関係。
   - **IO::Blob v0.0.1**: `class IO::Blob is IO::Handle` の user override（`.get`/`.lines` 等）が builtin native
     IO::Handle メソッドに shadow され `Expected IO::Handle` で死。MRO/dispatch バグ（builtin 型のサブクラスの
     user メソッドが native を優先すべき）。medium・汎用性高。

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3100,7 +3100,8 @@ impl Interpreter {
                                     }
                                 }
                                 Some('x') => {
-                                    // \x[HEX] inside double-quoted regex string
+                                    // \x[HEX] or bracketless \xHH inside a double-quoted
+                                    // regex string (e.g. `token SP { "\x20" }`).
                                     if chars.peek() == Some(&'[') {
                                         chars.next(); // skip '['
                                         let mut hex = String::new();
@@ -3113,6 +3114,16 @@ impl Interpreter {
                                             chars.next();
                                         }
                                         if let Ok(cp) = u32::from_str_radix(hex.trim(), 16)
+                                            && let Some(ch) = char::from_u32(cp)
+                                        {
+                                            literal.push(ch);
+                                        }
+                                    } else if chars.peek().is_some_and(|c| c.is_ascii_hexdigit()) {
+                                        let mut hex = String::new();
+                                        while chars.peek().is_some_and(|c| c.is_ascii_hexdigit()) {
+                                            hex.push(chars.next().unwrap());
+                                        }
+                                        if let Ok(cp) = u32::from_str_radix(&hex, 16)
                                             && let Some(ch) = char::from_u32(cp)
                                         {
                                             literal.push(ch);

--- a/t/regex-dq-hex-escape.t
+++ b/t/regex-dq-hex-escape.t
@@ -1,0 +1,22 @@
+use Test;
+
+# Bracketless \xHH (and \x[HH]) hex escapes inside a double-quoted string
+# literal in regex slang. Regression for HTTP::Parser, whose grammar uses
+# `token SP { "\x20" }` / `token HTAB { "\x09" }`.
+
+plan 8;
+
+ok ("a b" ~~ / "\x20" /),       'bracketless \x20 matches a space';
+ok ("a\tb" ~~ / "\x09" /),      'bracketless \x09 matches a tab';
+ok ("a\rb" ~~ / "\x0d" /),      'bracketless \x0d matches CR';
+ok ("a  b" ~~ / "\x20\x20" /),  'two bracketless escapes in one string';
+ok ("a b" ~~ / "\x[20]" /),     'bracketed \x[20] still matches';
+ok ("xAy" ~~ / "\x41" /),       'bracketless \x41 matches A';
+
+# The decoded character is exactly the codepoint (no stray "x"/digits left).
+my $m = ("a b c" ~~ / (. "\x20" .) /);
+is ~$m, 'a b', 'capture around \x20 spans exactly one space';
+
+# In a grammar token used directly (no subrule indirection).
+grammar G { token TOP { \w "\x20" \w } }
+ok G.parse("a b"), 'grammar token with bracketless \x20 parses';


### PR DESCRIPTION
In regex slang, a double-quoted literal like `"\x20"` decoded only the bracketed `\x[HH]` form; the bracketless `\xHH` form fell through to a catch-all that dropped the backslash, so `"\x20"` became the text "x20". This made HTTP::Parser's grammar fail to load entirely — its `token SP { "\x20" }` / `token HTAB { "\x09" }` never matched.

## Fix
Read a run of hex digits after a bracketless `\x` inside a double-quoted regex string (mirroring the existing unquoted-regex `\x` handler). Bracketed `\x[HH]` is unchanged.

With this, HTTP::Parser's grammar loads and parses (2/10 of its tests pass; the remaining failures are unrelated Buf/byte-handling bugs, not the `\x20` decode).

## Tests
- `t/regex-dq-hex-escape.t` (8 cases): bracketless `\x20`/`\x09`/`\x0d`/`\x41`, two escapes in one string, bracketed `\x[20]` still works, capture spanning, grammar token. Byte-identical to raku.
- `make test`: 9912 PASS. Whitelisted S05 regex roast unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)