### PR TITLE
feat(single-store): precise regex embedded {}/:let cross-frame caller writeback (env_dirty substrate S4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -51,14 +51,15 @@
   精密 reconcile も不要化＝精密 reconcile 依存 surface を一つずつ precise writeback / cell 共有へ畳む必要がある。
   - **計測ハーネス `MUTSU_NO_PRECISE_RECONCILE`**（#3406）: `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`
     （double-OFF）＝boxing のみ＝env_dirty 削除後の到達状態。残 fail = 未変換 by-name writer。0（flaky 除く）で削除可能。
-  - **double-OFF surface: 16 → 10**（2026-06-22・3 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
-    S2 let/temp restore（#3408）／S3 closure-method nested-capture writeback（#3409）。設計＝
+  - **double-OFF surface: 16 → 8**（2026-06-22・4 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
+    S2 let/temp restore（#3408）／S3 closure-method nested-capture writeback（#3409）／S4 regex embedded `{ }`/`:let`
+    cross-frame caller writeback（carrier 2 面消化）。設計＝
     [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md) §10。
-  - **残 10**: carrier（eval-carrier の regex `:let`／single-store-slice-c-prime）＋並行/制御（supply/react/junction
-    autothread/resumable-control/concurrent-cell＝**cross-thread cell・最難・最後**）＋done-paren（react done()）。
+  - **残 8**: 並行/制御のみ（supply/react/junction autothread/resumable-control/concurrent-cell＝**cross-thread cell・
+    最難・最後**）＋done-paren（react done()）。junction-invocant-autothread は単一スレッド＝最も着手しやすい候補。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = double-OFF surface 残 10 を畳む（carrier → 並行）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
+- **∴ 次 = double-OFF surface 残 8 を畳む（並行/制御）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化）。**
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -687,10 +687,27 @@ env-scan writeback ループ（`vm_closure_dispatch.rs`）で、書き戻す cal
 pin=`t/note-gist-and-dynamic-handle.t` + `t/closure-nested-writeback.t` + `t/wrap-closure-capture.t`（double-OFF で
 PASS 化）。make test 9904。
 
-### 10.6 残 10・次スライス候補
+### 10.6 slice S4（2026-06-22）— regex embedded `{ }` / `:let` の cross-frame caller writeback を precise 化（10→8）
 
-`eval-carrier-precise-writeback` / `single-store-slice-c-prime` = carrier。`junction-invocant-autothread` /
-`resumable-control-signal-indirect-call` / `concurrent-cell-writeback-coherence` / supply・react 系（4：
-`react-do-whenever-tap-coherence`/`react-whenever-last-next`/`supply-on-demand-closing`/`supply-sync-infinite-emit`）
-= 並行/制御（cross-thread cell・最難・最後）。`done-paren-stmt-modifier` = react done()。全消化後 → §7.4
-（精密 reconcile + env_dirty 物理削除）。
+`sub do-match($txt) { $txt ~~ / (\d+) { $tracked = +$0 } / }`（single-store-slice-c-prime test 7）/
+EVAL 内 `my regex la { :let $a = 5; … }`（eval-carrier-precise-writeback test 12）= regex の埋め込み `{ }` /
+`:let` ブロックが、当該マッチが走るフレーム（`do-match` の本体・EVAL'd code）の slot では**ない** caller lexical
+（sub の呼び出し元／EVAL の呼び出し元の `$tracked`/`$a`）を `env` へ by-name 書きする。`writeback_match_locals`
+（マッチサイト `vm_comparison_ops.rs`）は**現フレームの slot しか書かない**ため、owning slot は1つ以上上のフレームに
+あり stale のまま残る（double-OFF で `$tracked=-1`/`$a=1`）。EVAL の cell-boxing（slice 1.7）は `$x=5` 型の
+`SetGlobal` 書き込みは cell 経由で拾うが、`:let` は `restore_env_entries` の直接 env insert で cell リンクを断つ
+ため拾えない。**修正**: マッチサイトで `writeback_match_locals` の後、埋め込み write 名（`pending_local_updates`）の
+うち match-special（`$/`/`$0`…）でも現フレーム slot でもないものを retain-on-miss の
+`pending_caller_var_writeback`（`record_caller_var_writeback`）に記録。owning フレームへ戻る call site の
+`apply_pending_caller_var_writeback` が drain する（slice 1.18/S1-S3 と同型）。**1 修正で 2 surface 消化**（sub
+carrier と EVAL carrier の双方）。`cell_boxing_active()` ガード＝default build は従来どおり blanket/精密 reconcile が
+担う＝バイト不変。pin=`t/single-store-slice-c-prime.t`（test 7）+ `t/eval-carrier-precise-writeback.t`（test 12）
+（double-OFF で PASS 化）。
+
+### 10.7 残 8・次スライス候補
+
+残はすべて **並行/制御**（cross-thread cell・最難・最後）: `junction-invocant-autothread-writeback-coherence`（junction
+autothread・**単一スレッド**＝最も着手しやすい候補）/ `resumable-control-signal-indirect-call`（control signal）/
+`done-paren-stmt-modifier`（react done()）/ `concurrent-cell-writeback-coherence` / supply・react 系 4
+（`react-do-whenever-tap-coherence`/`react-whenever-last-next`/`supply-on-demand-closing`/`supply-sync-infinite-emit`）。
+全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1378,6 +1378,26 @@ impl Interpreter {
                 .map(|(n, _)| n.clone())
                 .collect();
             self.writeback_match_locals(code, &written);
+            // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): an
+            // embedded `{ }` / `:my` / `:let` block writes a caller lexical that is
+            // NOT a slot of *this* frame — e.g. a regex run inside `sub do-match { … }`
+            // mutates a lexical captured from the sub's caller. `writeback_match_locals`
+            // only reaches this frame's slots, and the owning slot lives one or more
+            // frames up, so record those names for the retain-on-miss caller-var
+            // writeback; the call site that returns to the owning frame drains them
+            // (`apply_pending_caller_var_writeback`). This is what keeps the slot
+            // coherent once the blanket/precise reconcile is gone (double-OFF). Only
+            // armed under boxing; the default build's blanket reconcile covers it.
+            if self.cell_boxing_active() {
+                for name in &written {
+                    let is_match_name = name == "/"
+                        || (!name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()));
+                    if is_match_name || self.find_local_slot(code, name).is_some() {
+                        continue;
+                    }
+                    self.record_caller_var_writeback(name);
+                }
+            }
         }
         self.pending_local_updates.clear();
         if !pure {


### PR DESCRIPTION
## Summary

env_dirty 物理削除 substrate グラインドの slice S4。double-OFF surface **10 → 8**。

A regex embedded `{ }` / `:my` / `:let` block can write a caller lexical that is **not** a slot of the frame the match runs in:

- `sub do-match($txt) { $txt ~~ / (\d+) { \$tracked = +\$0 } / }` — the embedded code mutates `\$tracked`, captured from the sub's caller.
- EVAL `my regex la { :let \$a = 5; … }` — `:let` writes the EVAL caller's `\$a` (and bypasses the cell-boxing the SetGlobal path uses, since `:let` does a direct env insert via `restore_env_entries`).

`writeback_match_locals` only reaches the **current frame's** slots, so the owning slot (one or more frames up) stays stale once the blanket/precise reconcile is gone (double-OFF: `\$tracked=-1` / `\$a=1`).

## Fix

At the regex match site (`vm_comparison_ops.rs`), after `writeback_match_locals`, record each embedded-write name (`pending_local_updates`) that is neither a match-special (`\$/`/`\$0`…) nor a current-frame slot into the **retain-on-miss** `pending_caller_var_writeback`. The call site that returns to the owning frame drains it (`apply_pending_caller_var_writeback`) — same machinery as slices 1.18 / S1–S3. **One fix clears two carrier surfaces** (sub carrier + EVAL carrier).

Gated by `cell_boxing_active()`: the default build's blanket/precise reconcile covers it unchanged (byte-identical).

## Test

- pin: `t/single-store-slice-c-prime.t` (test 7) + `t/eval-carrier-precise-writeback.t` (test 12) — both PASS in default **and** double-OFF (`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`).
- `make test` 9904 PASS, clippy/fmt clean.

double-OFF 残 8 はすべて並行/制御クラスタ（cross-thread cell・最難・最後）。設計 = `docs/captured-outer-cell-sharing.md` §10.6。

🤖 Generated with [Claude Code](https://claude.com/claude-code)