### PR TITLE
fix(dispatch): user method overrides a builtin parent's native method

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -200,9 +200,15 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
     （`token SP { "\x20" }` で grammar 全体が失敗）→ クォート外と同じく括弧なし連続 hex 桁を読むように。テスト
     `t/regex-dq-hex-escape.t`。**これで HTTP::Parser の grammar がロード・パース実行できるようになった**（10 件中 2 件
     PASS）。残る 8 失敗は別軸の独立バグ（Buf/byte 列処理・`.subst`・encode 往復）で、`\x20` とは無関係。
-  - **IO::Blob v0.0.1**: `class IO::Blob is IO::Handle` の user override（`.get`/`.lines` 等）が builtin native
-    IO::Handle メソッドに shadow され `Expected IO::Handle` で死。MRO/dispatch バグ（builtin 型のサブクラスの
-    user メソッドが native を優先すべき）。medium・汎用性高。
+  - [x] **IO::Blob v0.0.1 — builtin 型サブクラスの user メソッド override を修正（#TBD, 2026-06-22）。**
+    `class IO::Blob is IO::Handle` の user override（`.get`/`.lines`/`.getc`/`.word`/`.words`）が、Instance dispatch の
+    `is_native_method` フォーク（`vm_call_method_compiled.rs` の &self/&mut 両経路）で継承元 native IO::Handle メソッドに
+    shadow され `Expected IO::Handle` で死んでいた。フォーク条件に `&& !has_user_method(class, method)` を追加し、クラスが
+    MRO 上に自前メソッドを持つときは native を取らないように。`has_user_method` は `is_native_method` が真のときのみ評価される
+    （short-circuit）ので hot-path コストは最小。`get`/`lines`/`getc`/`word`/`words`/constructor が動作、**Text::CSV を
+    IO::Blob から読む `t/020-text-csv.t` が PASS**。テスト `t/builtin-subclass-method-override.t`（8 件）。
+    残（別軸）: `seek`/`read`/`write`/`slurp-rest`/`Supply` は `SeekType` enum（`SeekFromBeginning` 等）が未登録 enum で
+    bareword Str 扱いされ `SeekType:D` デフォルト型チェックに失敗する独立バグ待ち。
   - **HTTP::Status v0.0.5**: user `method sink` がシンクコンテキストで呼ばれず status table が空。
     ⚠️ 注意: 過去に sink 修正は sink.t を回帰させた（メモリ `sink-context-blocked-container-identity` 参照）。
 - [ ] **DB アクセス — sqlite3 CLI ラッパ（pure Raku）が現実解。**

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -194,7 +194,11 @@ impl Interpreter {
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
                 return result;
             }
-            if self.is_native_method(&class, method) {
+            // A user-defined subclass of a builtin type may override an inherited
+            // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
+            // The user override must win, so do not take the native fork when the
+            // class (via its MRO) provides its own method of this name.
+            if self.is_native_method(&class, method) && !self.has_user_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return loan_env!(self, call_method_with_values(target, method, args));
@@ -1562,7 +1566,11 @@ impl Interpreter {
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
                 return result;
             }
-            if self.is_native_method(&class, method) {
+            // A user-defined subclass of a builtin type may override an inherited
+            // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
+            // The user override must win, so do not take the native fork when the
+            // class (via its MRO) provides its own method of this name.
+            if self.is_native_method(&class, method) && !self.has_user_method(&class, method) {
                 // TODO: compile to bytecode — Instance native-method fork, mut (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self.vm_call_method_mut_with_values(target_name, target, method, args);

--- a/t/builtin-subclass-method-override.t
+++ b/t/builtin-subclass-method-override.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A user-defined subclass of a builtin type may override an inherited native
+# method; the user override must win over the native handler. Regression for
+# IO::Blob (`class IO::Blob is IO::Handle` overriding .get/.lines/.getc/...),
+# which previously died with "Expected IO::Handle" because the native
+# IO::Handle.get shadowed the user method.
+
+plan 8;
+
+class MyHandle is IO::Handle {
+    has @.lines-data;
+    has $.idx = 0;
+    method get { @!lines-data[$!idx++] // Nil }
+    method eof { $!idx >= @!lines-data.elems }
+    method extra { "extra-method" }
+}
+
+my $h = MyHandle.new(lines-data => <a b c>);
+is $h.get, 'a', 'overridden .get returns the user value (not native)';
+is $h.get, 'b', 'overridden .get is stateful';
+nok $h.eof, 'overridden .eof works while data remains';
+$h.get;
+ok $h.eof, 'overridden .eof reports end';
+is $h.extra, 'extra-method', 'a user-only (non-native) method still dispatches';
+
+# The override must still resolve through a deeper MRO.
+class Base is IO::Handle { method get { "base" } }
+class Derived is Base { }
+is Derived.new.get, 'base', 'inherited user override (grandparent) wins over native';
+
+# A subclass that does NOT override keeps using the inherited native method
+# (here just confirm the class builds and a user method on it dispatches).
+class Plain is IO::Handle { method tag { "plain" } }
+is Plain.new.tag, 'plain', 'non-overriding subclass dispatches its own method';
+
+# Overriding a native method on a non-IO builtin parent works too.
+class MyStr is Str { method Str { "custom-str" } }
+is MyStr.new.Str, 'custom-str', 'override of a native method on a Str subclass wins';


### PR DESCRIPTION
A user-defined subclass of a builtin type (e.g. `class IO::Blob is IO::Handle { method get {...} }`) could not override an inherited native method: the Instance-dispatch `is_native_method` fork in `vm_call_method_compiled.rs` (both the `&self` and `&mut` paths) took the native `IO::Handle.get` handler, which then died with "Expected IO::Handle" because the instance has no real handle.

## Fix
Gate the native fork on `!has_user_method(class, method)`: when the class provides its own method anywhere in its MRO, the user override wins and dispatch falls through to it. `has_user_method` is only evaluated when `is_native_method` is already true (short-circuit), so the hot path is unaffected for ordinary user methods.

With this, IO::Blob's `get`/`lines`/`getc`/`word`/`words`/constructor work and its Text::CSV integration test (`t/020-text-csv.t`) passes. (Its seek/read/write tests remain blocked by an unrelated `SeekType`-enum default-value bug.)

## Tests
- `t/builtin-subclass-method-override.t` (8 cases): override wins over native, stateful override, user-only method, grandparent override through MRO, non-overriding subclass, Str subclass override. Byte-identical to raku.
- `make test`: 9926 PASS. Whitelisted S12/S13/S32-io roast unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)