### PR TITLE
feat(single-store): precise junction invocant autothread per-eigenstate writeback (env_dirty substrate S5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -51,15 +51,15 @@
   精密 reconcile も不要化＝精密 reconcile 依存 surface を一つずつ precise writeback / cell 共有へ畳む必要がある。
   - **計測ハーネス `MUTSU_NO_PRECISE_RECONCILE`**（#3406）: `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`
     （double-OFF）＝boxing のみ＝env_dirty 削除後の到達状態。残 fail = 未変換 by-name writer。0（flaky 除く）で削除可能。
-  - **double-OFF surface: 16 → 8**（2026-06-22・4 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
+  - **double-OFF surface: 16 → 7**（2026-06-22・5 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
     S2 let/temp restore（#3408）／S3 closure-method nested-capture writeback（#3409）／S4 regex embedded `{ }`/`:let`
-    cross-frame caller writeback（carrier 2 面消化）。設計＝
+    cross-frame caller writeback（#3412・carrier 2 面消化）／S5 junction invocant autothread per-eigenstate writeback。設計＝
     [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md) §10。
-  - **残 8**: 並行/制御のみ（supply/react/junction autothread/resumable-control/concurrent-cell＝**cross-thread cell・
-    最難・最後**）＋done-paren（react done()）。junction-invocant-autothread は単一スレッド＝最も着手しやすい候補。
+  - **残 7**: 並行/制御のみ（supply/react/resumable-control/concurrent-cell＝**cross-thread cell・最難・最後**）＋
+    done-paren（react done()）＋resumable-control-signal-indirect-call。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = double-OFF surface 残 8 を畳む（並行/制御）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
+- **∴ 次 = double-OFF surface 残 7 を畳む（並行/制御）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化）。**
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -704,10 +704,25 @@ carrier と EVAL carrier の双方）。`cell_boxing_active()` ガード＝defau
 担う＝バイト不変。pin=`t/single-store-slice-c-prime.t`（test 7）+ `t/eval-carrier-precise-writeback.t`（test 12）
 （double-OFF で PASS 化）。
 
-### 10.7 残 8・次スライス候補
+### 10.7 slice S5（2026-06-22）— junction invocant autothread の per-eigenstate writeback を precise 化（8→7）
 
-残はすべて **並行/制御**（cross-thread cell・最難・最後）: `junction-invocant-autothread-writeback-coherence`（junction
-autothread・**単一スレッド**＝最も着手しやすい候補）/ `resumable-control-signal-indirect-call`（control signal）/
-`done-paren-stmt-modifier`（react done()）/ `concurrent-cell-writeback-coherence` / supply・react 系 4
-（`react-do-whenever-tap-coherence`/`react-whenever-last-next`/`supply-on-demand-closing`/`supply-sync-infinite-emit`）。
-全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。
+`my Mu $x = JB1.new | JB1.new | JB2.new; $x.a`（`method a { $cnt1++ }` / JB2 は `$cnt2++`）= invocant junction を
+ユーザーメソッドで autothread し、各 eigenstate が captured-outer / `our` 変数を変異する。各 eigenstate の dispatch は
+その by-name write を `pending_rw_writeback_sources` に記録するが、**次の eigenstate の dispatch がそのバッファを
+上書き**するため、post-loop drain に残るのは**最後の eigenstate のソースだけ**。EARLIER eigenstate のみが書いた変数
+（最後が `$cnt2` を書く間に `$cnt1` を書いた）は失われ owning slot が stale（double-OFF で `$cnt1=1`・期待 2）。同じ変数を
+全 eigenstate が書く場合は最後のソースで足りるので動いていた（露出は「異なる変数を異なる eigenstate が書く」場合のみ）。
+**修正**: junction loop の各 eigenstate 呼び出し後に `pending_rw_writeback_sources` ＋ `pending_caller_var_writeback` を
+drain して retain-on-miss の `pending_caller_var_writeback` に accumulate（`record_caller_var_writeback`・dedup）。
+loop 後の 1 回の `apply_pending_caller_var_writeback` が env（既に全 eigenstate の累積値を保持）から owning caller slot を
+精密に書く。CallMethod（非mut）/ CallMethodMut（mut）両 junction path に対称適用（`$cnt++` は mut path 経由）。
+`cell_boxing_active()` ガード＝default build は従来どおり blanket `reconcile_locals_from_env_at_site` の pull＝バイト不変。
+pin=`t/junction-invocant-autothread-writeback-coherence.t`（6・double-OFF で PASS 化）。回帰元
+`roast/S03-junctions/autothreading.t` 107/107 PASS。
+
+### 10.8 残 7・次スライス候補
+
+残はすべて **並行/制御**（cross-thread cell・最難・最後）: `resumable-control-signal-indirect-call`（control signal・
+単一スレッド寄り＝次の候補）/ `done-paren-stmt-modifier`（react done()）/ `concurrent-cell-writeback-coherence` /
+supply・react 系 4（`react-do-whenever-tap-coherence`/`react-whenever-last-next`/`supply-on-demand-closing`/
+`supply-sync-infinite-emit`）。全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -587,6 +587,20 @@ impl Interpreter {
         {
             let kind = kind.clone();
             let mut results = Vec::new();
+            // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
+            // accumulate EVERY eigenstate's by-name caller write. Each eigenstate's
+            // method dispatch records its captured-outer / `our` write into
+            // `pending_rw_writeback_sources`, but the NEXT eigenstate's dispatch
+            // overwrites that buffer, so only the last eigenstate's source survived
+            // to the post-loop drain — a var written only by an EARLIER eigenstate
+            // (`$cnt1` while the last writes `$cnt2`) was lost (double-OFF). Drain
+            // each eigenstate's sources into the retain-on-miss
+            // `pending_caller_var_writeback` so all of them persist; the post-loop
+            // drain then writes every owning caller slot precisely from env (which
+            // already holds the accumulated value), replacing the blanket
+            // `reconcile_locals_from_env_at_site` pull. Armed only under boxing; the
+            // default build keeps the blanket pull (byte-identical).
+            let armed = self.cell_boxing_active();
             for v in values.iter() {
                 let r = if let Some(threaded) =
                     self.maybe_autothread_method_args(v, &method, &args)?
@@ -598,6 +612,16 @@ impl Interpreter {
                     self.try_compiled_method_or_interpret(v.clone(), &method, args.clone())?
                 };
                 results.push(r);
+                if armed {
+                    let pending: Vec<String> = self
+                        .pending_rw_writeback_sources
+                        .drain(..)
+                        .chain(self.pending_caller_var_writeback.drain(..))
+                        .collect();
+                    for name in pending {
+                        self.record_caller_var_writeback(&name);
+                    }
+                }
             }
             let junction_result = Value::Junction {
                 kind,
@@ -616,6 +640,9 @@ impl Interpreter {
             // pull disabled reconcile the caller's slots from env once here; env
             // already holds every eigenstate's accumulated value. Byte-identical
             // with the reverse pull enabled (gated on the env_dirty just set).
+            if armed {
+                self.apply_pending_caller_var_writeback(code);
+            }
             self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -451,6 +451,10 @@ impl Interpreter {
         {
             let kind = kind.clone();
             let mut results = Vec::new();
+            // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
+            // accumulate EVERY eigenstate's by-name caller write (see the matching
+            // CallMethodMut junction path for the full rationale).
+            let armed = self.cell_boxing_active();
             for v in values.iter() {
                 let r = if let Some(threaded) =
                     self.maybe_autothread_method_args(v, method, &args)?
@@ -462,6 +466,16 @@ impl Interpreter {
                     self.try_compiled_method_or_interpret(v.clone(), method, args.clone())?
                 };
                 results.push(r);
+                if armed {
+                    let pending: Vec<String> = self
+                        .pending_rw_writeback_sources
+                        .drain(..)
+                        .chain(self.pending_caller_var_writeback.drain(..))
+                        .collect();
+                    for name in pending {
+                        self.record_caller_var_writeback(&name);
+                    }
+                }
             }
             let junction_result = Value::Junction {
                 kind,
@@ -476,6 +490,9 @@ impl Interpreter {
             // slots; this path returns before the normal post-dispatch reconcile,
             // so reconcile the caller's local slots from env here (env already
             // holds every eigenstate's value). Byte-identical with reverse-sync on.
+            if armed {
+                self.apply_pending_caller_var_writeback(code);
+            }
             self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }


### PR DESCRIPTION
## Summary

env_dirty 物理削除 substrate グラインドの slice S5。double-OFF surface **8 → 7**。

Auto-threading a user method over an invocant junction — `my Mu \$x = JB1.new | JB1.new | JB2.new; \$x.a` with `method a { \$cnt1++ }` (and JB2 writing `\$cnt2`) — mutates a captured-outer / `our` variable in each eigenstate.

Each eigenstate's method dispatch records its by-name caller write into `pending_rw_writeback_sources`, but the **next** eigenstate's dispatch overwrites that buffer, so only the **last** eigenstate's source survived to the post-loop drain. A variable written only by an *earlier* eigenstate (`\$cnt1` while the last writes `\$cnt2`) was lost once the blanket/precise reconcile is gone (double-OFF: `\$cnt1=1`, expected `2`). The all-eigenstates-write-the-same-var case worked because the last source sufficed — the gap only showed when different eigenstates wrote different vars.

## Fix

In both junction paths (`CallMethod` + `CallMethodMut`), after each eigenstate call drain `pending_rw_writeback_sources` + `pending_caller_var_writeback` into the retain-on-miss `pending_caller_var_writeback` (accumulating, dedup). One post-loop `apply_pending_caller_var_writeback` then writes every owning caller slot precisely from env (which already holds the accumulated value), replacing the blanket `reconcile_locals_from_env_at_site` pull.

Gated by `cell_boxing_active()`: the default build keeps the blanket pull (byte-identical).

## Test

- pin: `t/junction-invocant-autothread-writeback-coherence.t` (6 subtests) — PASS in default **and** double-OFF.
- `roast/S03-junctions/autothreading.t` 107/107, `misc.t` 155, `boolean-context.t` 74 PASS.
- `make test` 9904 PASS, clippy/fmt clean.

double-OFF 残 7 はすべて並行/制御クラスタ。設計 = `docs/captured-outer-cell-sharing.md` §10.7。

🤖 Generated with [Claude Code](https://claude.com/claude-code)