### PR TITLE
feat(enum): register the built-in SeekType enum

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -208,8 +208,10 @@ HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCa
     MRO 上に自前メソッドを持つときは native を取らないように。`has_user_method` は `is_native_method` が真のときのみ評価される
     （short-circuit）ので hot-path コストは最小。`get`/`lines`/`getc`/`word`/`words`/constructor が動作、**Text::CSV を
     IO::Blob から読む `t/020-text-csv.t` が PASS**。テスト `t/builtin-subclass-method-override.t`（8 件）。
-    残（別軸）: `seek`/`read`/`write`/`slurp-rest`/`Supply` は `SeekType` enum（`SeekFromBeginning` 等）が未登録 enum で
-    bareword Str 扱いされ `SeekType:D` デフォルト型チェックに失敗する独立バグ待ち。
+    ✅ `SeekType` enum も登録済み（#TBD, 2026-06-22）: `SeekFromBeginning`/`SeekFromCurrent`/`SeekFromEnd` を組み込み enum 化
+    （`init_seek_type_enum`）し `SeekType:D` デフォルト型チェックが通るように。単独の `$io.seek(n); $io.read(n)` は raku 一致。
+    残（別軸・本タスク外）: 010_basic の `subtest {}` 内 `read`/`print`/`say`/`write`/`slurp-rest`/`close`/`nl`/`Supply` が
+    なお fail（フルファイル内のみ・分離では PASS）。Buf `is` 比較／`.data is rw` 書き戻し／nl-out／Supply など複数の独立バグ。
   - **HTTP::Status v0.0.5**: user `method sink` がシンクコンテキストで呼ばれず status table が空。
     ⚠️ 注意: 過去に sink 修正は sink.t を回帰させた（メモリ `sink-context-blocked-container-identity` 参照）。
 - [ ] **DB アクセス — sqlite3 CLI ラッパ（pure Raku）が現実解。**

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3476,6 +3476,7 @@ impl Interpreter {
         interpreter.init_endian_enum(&mut enum_base);
         interpreter.init_protocol_family_enum(&mut enum_base);
         interpreter.init_signal_enum(&mut enum_base);
+        interpreter.init_seek_type_enum(&mut enum_base);
         // Hoist the immutable process-constant magic/dynamic vars out of every
         // per-frame env overlay into the shared base tier (docs/vm-dual-store.md
         // 4c "natural extension"). These are set once at interpreter start and

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -83,6 +83,35 @@ impl Interpreter {
         }
     }
 
+    pub(in crate::runtime) fn init_seek_type_enum(&mut self, base: &mut HashMap<Symbol, Value>) {
+        // The `SeekType` enum used by IO::Handle.seek (and user IO classes that
+        // subclass it, e.g. IO::Blob): SeekFromBeginning(0)/SeekFromCurrent(1)/
+        // SeekFromEnd(2). Registering it as a real enum makes `SeekType:D`
+        // parameter/default type checks pass and the values smartmatch SeekType.
+        let variants = vec![
+            ("SeekFromBeginning".to_string(), EnumValue::Int(0)),
+            ("SeekFromCurrent".to_string(), EnumValue::Int(1)),
+            ("SeekFromEnd".to_string(), EnumValue::Int(2)),
+        ];
+        self.registry_mut()
+            .enum_types
+            .insert("SeekType".to_string(), variants.clone());
+        base.insert(Symbol::intern("SeekType"), Value::str_from("SeekType"));
+        for (index, (key, val)) in variants.iter().enumerate() {
+            let enum_val = Value::Enum {
+                enum_type: Symbol::intern("SeekType"),
+                key: Symbol::intern(key),
+                value: val.clone(),
+                index,
+            };
+            base.insert(
+                Symbol::intern(&format!("SeekType::{}", key)),
+                enum_val.clone(),
+            );
+            base.insert(Symbol::intern(key), enum_val);
+        }
+    }
+
     pub(in crate::runtime) fn init_signal_enum(&mut self, base: &mut HashMap<Symbol, Value>) {
         // Use libc constants on Unix, standard POSIX numbers on other platforms
         let variants = vec![

--- a/t/seektype-enum.t
+++ b/t/seektype-enum.t
@@ -1,0 +1,36 @@
+use Test;
+
+# The built-in SeekType enum (used by IO::Handle.seek and user IO classes that
+# subclass it, e.g. IO::Blob). Regression: its values were bare Str, so a
+# `SeekType:D $whence = SeekFromBeginning` default failed its type check.
+
+plan 12;
+
+is SeekFromBeginning.Int, 0, 'SeekFromBeginning is 0';
+is SeekFromCurrent.Int,   1, 'SeekFromCurrent is 1';
+is SeekFromEnd.Int,       2, 'SeekFromEnd is 2';
+
+ok SeekFromBeginning ~~ SeekType, 'SeekFromBeginning smartmatches SeekType';
+ok SeekFromCurrent   ~~ SeekType, 'SeekFromCurrent smartmatches SeekType';
+ok SeekFromEnd       ~~ SeekType, 'SeekFromEnd smartmatches SeekType';
+
+# Qualified names resolve to the same values.
+is SeekType::SeekFromEnd.Int, 2, 'qualified SeekType::SeekFromEnd works';
+
+# A SeekType:D parameter accepts the enum value, including as a default.
+sub whence(SeekType:D $w = SeekFromBeginning) { $w.Int }
+is whence(),            0, 'SeekType:D default value passes its type check';
+is whence(SeekFromEnd), 2, 'SeekType:D parameter accepts an explicit value';
+
+# Native IO::Handle.seek accepts the enum values.
+my $p = "tmp/seektype-enum-test.txt".IO;
+$p.spurt("0123456789");
+my $fh = $p.open;
+$fh.seek(3, SeekFromBeginning);
+is $fh.read(2).decode, '34', 'seek SeekFromBeginning + read';
+$fh.seek(2, SeekFromCurrent);
+is $fh.read(1).decode, '7', 'seek SeekFromCurrent + read';
+$fh.seek(-1, SeekFromEnd);
+is $fh.read(1).decode, '9', 'seek SeekFromEnd + read';
+$fh.close;
+$p.unlink;


### PR DESCRIPTION
SeekType's values (SeekFromBeginning=0, SeekFromCurrent=1, SeekFromEnd=2) were unregistered barewords resolving to plain Str, so a `SeekType:D $whence = SeekFromBeginning` default value (used by `IO::Handle.seek` and user IO classes that subclass it, e.g. IO::Blob) failed its type check with `X::Parameter::Default::TypeCheck` ("got Str").

## Fix
Register SeekType as a real built-in enum (`init_seek_type_enum`, same shape as Order/Endian/Signal): the bare and qualified names resolve to typed `Enum` values, `SeekType:D` checks pass, and the values smartmatch SeekType. Native `IO::Handle.seek` already accepted the values; it now also works via the enum form.

## Tests
- `t/seektype-enum.t` (12 cases): enum `.Int` values, smartmatch, qualified names, `SeekType:D` parameter + default, native file seek with all three values. Byte-identical to raku.
- `make test`: 9926 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)