### PR TITLE
feat(single-store): precise resumable CONTROL handler writeback (env_dirty substrate S6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -51,15 +51,15 @@
   精密 reconcile も不要化＝精密 reconcile 依存 surface を一つずつ precise writeback / cell 共有へ畳む必要がある。
   - **計測ハーネス `MUTSU_NO_PRECISE_RECONCILE`**（#3406）: `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`
     （double-OFF）＝boxing のみ＝env_dirty 削除後の到達状態。残 fail = 未変換 by-name writer。0（flaky 除く）で削除可能。
-  - **double-OFF surface: 16 → 7**（2026-06-22・5 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
+  - **double-OFF surface: 16 → 6**（2026-06-22・6 slice landed）: S1 bound-Proxy substr-rw/subbuf-rw/undefine（#3406）／
     S2 let/temp restore（#3408）／S3 closure-method nested-capture writeback（#3409）／S4 regex embedded `{ }`/`:let`
-    cross-frame caller writeback（#3412・carrier 2 面消化）／S5 junction invocant autothread per-eigenstate writeback。設計＝
+    cross-frame caller writeback（#3412・carrier 2 面消化）／S5 junction invocant autothread per-eigenstate writeback（#3414）／
+    S6 resumable CONTROL handler writeback（indirect `warn`）。設計＝
     [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md) §10。
-  - **残 7**: 並行/制御のみ（supply/react/resumable-control/concurrent-cell＝**cross-thread cell・最難・最後**）＋
-    done-paren（react done()）＋resumable-control-signal-indirect-call。
+  - **残 6**: 並行/react のみ（supply/react/concurrent-cell＝**cross-thread cell・最難・最後**）＋done-paren（react done()）。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = double-OFF surface 残 7 を畳む（並行/制御）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
+- **∴ 次 = double-OFF surface 残 6 を畳む（並行/react）→ §2-E（精密 reconcile + `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化）。**
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -720,9 +720,22 @@ loop 後の 1 回の `apply_pending_caller_var_writeback` が env（既に全 ei
 pin=`t/junction-invocant-autothread-writeback-coherence.t`（6・double-OFF で PASS 化）。回帰元
 `roast/S03-junctions/autothreading.t` 107/107 PASS。
 
-### 10.8 残 7・次スライス候補
+### 10.8 slice S6（2026-06-22）— resumable CONTROL handler writeback を precise 化（7→6）
 
-残はすべて **並行/制御**（cross-thread cell・最難・最後）: `resumable-control-signal-indirect-call`（control signal・
-単一スレッド寄り＝次の候補）/ `done-paren-stmt-modifier`（react done()）/ `concurrent-cell-writeback-coherence` /
-supply・react 系 4（`react-do-whenever-tap-coherence`/`react-whenever-last-next`/`supply-on-demand-closing`/
-`supply-sync-infinite-emit`）。全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。
+`my $out=''; CONTROL { default { $out ~= "[{.message}]"; .resume } }; my $w = &warn; $w.("indirect")` =
+indirect call（`$w.(...)`／`&warn.(...)`＝CallOnValue）から raise された resumable な `warn` を、enclosing CONTROL の
+`resume_safe` ハンドラがインライン実行する（`try_resume_safe_control_inline`・builtins_control_flow.rs）。ハンドラ本体は
+installing frame の lexical `$out` を変異するが、ハンドラは locals を env から再構成 → 実行 → **変化した slot を env に
+flush + env_dirty** するだけで、frame の local SLOT は warn-call サイトの blanket/精密 `reconcile_locals_from_env_at_site`
+でしか更新されない＝double-OFF で no-op。**direct `warn`（ExecCall）は通り**、indirect（CallOnValue）だけ落ちた
+（計測: indirect 後 `env["out"]=[indirect]` は生存・slot[0] が stale・read が slot を見て空）。**修正**: ハンドラの flush
+ループで変化した名前を `pending_rw_writeback_sources`（drop-on-miss・same-frame）＋ `pending_caller_var_writeback`
+（retain-on-miss・deeper raise site が installing frame まで運ぶ）に記録。両 call site（ExecCall/CallOnValue）が既に走らせる
+**非ゲートの `apply_pending_rw_writeback`** が env → slot を drain する。`cell_boxing_active()` ガード＝default build は従来
+どおり blanket reconcile が担う＝バイト不変。pin=`t/resumable-control-signal-indirect-call.t`（5・double-OFF で PASS 化）。
+
+### 10.9 残 6・次スライス候補
+
+残はすべて **並行/react**（cross-thread cell・最難・最後）: `done-paren-stmt-modifier`（react done()）/
+`concurrent-cell-writeback-coherence` / supply・react 系 4（`react-do-whenever-tap-coherence`/`react-whenever-last-next`/
+`supply-on-demand-closing`/`supply-sync-infinite-emit`）。全消化後 → §7.4（精密 reconcile + env_dirty 物理削除）。

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -403,6 +403,7 @@ impl Interpreter {
         // observes them. Only changed slots are written, to keep blast radius
         // minimal.
         let handler_locals = std::mem::replace(&mut self.locals, saved_locals);
+        let armed = self.cell_boxing_active();
         for (i, name) in code.locals.iter().enumerate() {
             if name.is_empty() {
                 continue;
@@ -410,6 +411,22 @@ impl Interpreter {
             if handler_locals[i] != seeded[i] {
                 self.env_mut()
                     .insert(name.clone(), handler_locals[i].clone());
+                // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
+                // the handler body mutated the installing frame's lexical `name`
+                // by writing `env` here, but the frame's local SLOT is reached only
+                // by the blanket/precise `reconcile_locals_from_env_at_site` at the
+                // warn-call site — a no-op once env_dirty is removed (double-OFF: a
+                // *resumed* indirect `warn` left the caller's `$out` slot stale even
+                // though env held the handler's write). Record the name for the
+                // non-gated precise drain (`apply_pending_rw_writeback`) that every
+                // call site already runs: drop-on-miss for the same frame, plus
+                // retain-on-miss so a deeper raise site carries it up to the
+                // installing frame. Armed only under boxing; the default build's
+                // blanket reconcile covers it (byte-identical).
+                if armed {
+                    self.pending_rw_writeback_sources.push(name.clone());
+                    self.record_caller_var_writeback(name);
+                }
             }
         }
         self.env_dirty = true;


### PR DESCRIPTION
## Summary

env_dirty 物理削除 substrate グラインドの slice S6。double-OFF surface **7 → 6**。

A resumable control signal (`warn`) raised from an **indirect** call (`\$w.("indirect")` / `&warn.(...)`, the `CallOnValue`/`CallOnCodeVar` opcodes) is caught by an enclosing `resume_safe` CONTROL handler that runs **inline** at the raise site (`try_resume_safe_control_inline`). The handler body mutates the installing frame's lexical (`\$out ~= .Str`), but it only flushed the changed slot to `env` + set `env_dirty`; the frame's local SLOT was reconciled solely by the blanket/precise `reconcile_locals_from_env_at_site` at the warn-call site — a no-op once env_dirty is removed.

So under double-OFF a *resumed* indirect `warn` left the caller's `\$out` slot stale even though env held the write. Direct `warn` (ExecCall) happened to work; the gap was indirect-only (measured: `env["out"]=[indirect]` survived but `slot[0]` was stale and the read consulted the slot).

## Fix

In the handler flush loop (`builtins_control_flow.rs`), record each changed name into `pending_rw_writeback_sources` (drop-on-miss, same frame) **and** `pending_caller_var_writeback` (retain-on-miss, so a deeper raise site carries it up to the installing frame). The non-gated `apply_pending_rw_writeback` that both call sites (ExecCall + CallOnValue) already run then drains env → slot.

Gated by `cell_boxing_active()`: the default build keeps the blanket reconcile (byte-identical).

## Test

- pin: `t/resumable-control-signal-indirect-call.t` (5 subtests) — PASS in default **and** double-OFF.
- `roast/S04-exception-handlers/control.t` PASS, `t/control.t` PASS.
- `make test` 9934 PASS, clippy/fmt clean.

double-OFF 残 6 はすべて並行/react クラスタ（cross-thread cell・最難・最後）。設計 = `docs/captured-outer-cell-sharing.md` §10.8。

🤖 Generated with [Claude Code](https://claude.com/claude-code)