### PR TITLE
feat(single-store): precise user .defined writeback for andthen/orelse/notandthen (env_dirty substrate S8)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -57,11 +57,14 @@
     writeback（#3414）／S6 resumable CONTROL handler writeback（#3416）／S7 react/whenever captured-outer writeback
     （**1 修正で 5 surface 一掃**＋do-whenever tap bind）。設計＝
     [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md) §10。
-  - **全 double-OFF pin（16）＋ broad supply/react/concurrency/promise/start t/ が両モード PASS＝t/ サーフェス 0**。
-    残既知 OFF 依存は IO-Socket-Async.t の flaky のみ。
+  - **t/ サーフェス 0**（全 double-OFF pin 16 ＋ broad supply/react/concurrency/promise/start t/ が両モード PASS）。
+    **⚠ だが全 roast whitelist（1285）の double-OFF sweep は 25 file の隠れサーフェスを露呈**（t/ pin は不完全＝
+    第45「OFF roast survey こそ authoritative」と同型）。診断＝`tmp/roast-double-off-fails.txt`。env_dirty 削除は roast
+    25→0 が前提。**S8（#TBD・roast 25→22）= user `.defined`（andthen/orelse/notandthen）writeback**（CallDefined snapshot・
+    1 修正 3 file）。残 22 = S14 roles 5／S02 types set系 3／S02 names 2／その他（docs §10.10 にカテゴリ表）。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = `env_dirty` 物理削除（§2-E）に着手可能**: 全 t/ + roast の double-OFF sweep で隠れ surface 0 を確認 →
+- **∴ 次 = roast double-OFF 22→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
   `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -749,10 +749,35 @@ callback は `vm_call_map_block` 経由で by-name に env を書くが per-writ
 `t/react-do-whenever-tap-coherence.t`（2）他（全 6・double-OFF で PASS 化）。broad supply/react/concurrency/promise/start
 t/ も両モード PASS。
 
-### 10.10 ✅ double-OFF surface 0 到達 → env_dirty 物理削除へ
+### 10.10 t/ surface 0 到達・**roast double-OFF sweep が 25 file の隠れサーフェスを露呈**（authoritative）
 
 S1〜S7 で **t/ pin（16）＋ broad supply/react/concurrency/promise/start クラスタが両モード（default / double-OFF）で全
-PASS**＝精密 reconcile に依存する t/ サーフェスは枯渇。残既知 OFF 依存は `IO-Socket-Async.t` の flaky のみ。**次の本丸 =
-§7.4 / PLAN §2-E（`env_dirty` 物理削除）**: ①全 t/ + roast の double-OFF sweep で隠れ surface 0 を最終確認 →
+PASS**＝t/ で観測できる精密 reconcile 依存サーフェスは枯渇。**だが全 roast whitelist（1285）の double-OFF sweep
+（`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release）を初めて実走したところ 25 file が決定的 fail
+＝t/ pin は不完全だった**（第45 で「OFF roast survey こそ authoritative」と判明したのと同型の教訓）。env_dirty 物理削除は
+この roast サーフェスを全消化してから。診断は `tmp/roast-double-off.log` / `tmp/roast-double-off-fails.txt`。
+
+**roast double-OFF 25 file（S8 着手前・カテゴリ別）**:
+- **S03 演算子（andthen/orelse/notandthen）**＝user `method defined { $calls++ }` の captured-outer write。
+  → **✅ S10.11 で解決**（CallDefined snapshot writeback・1 修正 3 file）。
+- **S14 roles（anonymous/mixin-6e/parameterized-mixin/rw/submethods-6e・5）**＝role mixin/`rw` accessor の writeback
+  （anonymous/parameterized-mixin は abort=Bad plan）。
+- **S02 types（baghash/mixhash/set・3）**＝Set/Bag/Mix 演算の captured write。
+- **S02 names（our/symbolic-deref・2）**＝`our`/symbolic deref の by-name writeback。
+- **その他**: S02-types/lazy-lists・S04 gather（abort）・S04 terminator・S04 pointy-rw・S06 lvalue-subroutines・
+  S06 named-parameters・S12 coercion-methods・S12 primitives・S12 defer-next・S17 cas-loop・S17 throttle・S32 kv。
+
+**∴ env_dirty 物理削除（§7.4 / PLAN §2-E）は roast double-OFF 0 が前提**: ①roast 25→0 を slice で消化 →
 ②`blanket_reconcile_if_dirty` / `reconcile_locals_from_env_at_site` を空洞化 → ③`env_dirty` / `ensure_locals_synced` /
 `saved_env_dirty` を削除 → ④`cell_boxing_active()` gate を撤去して boxing を恒久 ON（＝単一ストアの派生ビュー化）。
+
+### 10.11 slice S8（2026-06-22）— user `.defined`（andthen/orelse/notandthen）writeback を precise 化（roast 25→22）
+
+`my $calls=0; my class Foo { method defined { $calls++; True } }; Foo andthen meow $_` = `andthen`/`orelse`/`notandthen`
+は LHS の definedness を `OpCode::CallDefined` で判定し、user `method defined` があれば dispatch する（vm.rs:2831）。その
+user method が captured-outer `$calls` を by-name env 書きするが、`CallDefined` の post-call `reconcile_locals_from_env_at_site`
+（double-OFF で no-op）でしか slot に届かず stale（double-OFF で `$calls=0`・期待 1）。`run_instance_method` 経由なので
+per-write 記録なし→**user-method 呼び出し前後で caller-frame slot-backing env 値をスナップショット**し変化した slot だけ
+精密書き戻し（react S7 と同手法）。`cell_boxing_active()` ガード＝default は blanket reconcile が担う＝バイト不変。
+**1 修正で 3 roast file（S03 andthen/orelse/notandthen）消化**。pin=roast/S03-operators/{andthen,orelse,notandthen}.t
+（double-OFF で PASS 化）。

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2839,6 +2839,31 @@ impl Interpreter {
                 let has_user_defined = class_name
                     .as_ref()
                     .is_some_and(|cn| self.has_user_method(&cn.resolve(), "defined"));
+                // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
+                // a user `.defined` mutates a captured-outer lexical by name in env
+                // via the interpreter slow path (`run_instance_method`), which
+                // records nothing this site can drain. Snapshot the caller frame's
+                // slot-backing env values before the call so only the changed slots
+                // are written through after — the precise form of the blanket
+                // reconcile below. Armed only under boxing; the default build keeps
+                // the unconditional pull.
+                let armed = has_user_defined && self.cell_boxing_active();
+                let pre_env: Vec<Option<Value>> = if armed {
+                    code.locals
+                        .iter()
+                        .map(|n| {
+                            self.env().get(n).cloned().or_else(|| {
+                                n.strip_prefix('$')
+                                    .or_else(|| n.strip_prefix('@'))
+                                    .or_else(|| n.strip_prefix('%'))
+                                    .or_else(|| n.strip_prefix('&'))
+                                    .and_then(|b| self.env().get(b).cloned())
+                            })
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
                 let defined = if has_user_defined {
                     // Call user method directly, bypassing native method dispatch
                     let cn = class_name.unwrap();
@@ -2865,6 +2890,27 @@ impl Interpreter {
                 // defined { $calls++ }`). Reconcile the caller's slots so the
                 // write is visible without the reverse `sync_locals_from_env`
                 // pull (only on the user-method path; the native check is pure).
+                if armed {
+                    for (i, name) in code.locals.iter().enumerate() {
+                        if name.starts_with('!')
+                            || matches!(self.locals[i], Value::HashSlotRef { .. })
+                        {
+                            continue;
+                        }
+                        let cur = self.env().get(name).cloned().or_else(|| {
+                            name.strip_prefix('$')
+                                .or_else(|| name.strip_prefix('@'))
+                                .or_else(|| name.strip_prefix('%'))
+                                .or_else(|| name.strip_prefix('&'))
+                                .and_then(|b| self.env().get(b).cloned())
+                        });
+                        if let Some(cur) = cur
+                            && pre_env.get(i).map(|p| p.as_ref()) != Some(Some(&cur))
+                        {
+                            self.locals[i] = cur;
+                        }
+                    }
+                }
                 if has_user_defined {
                     self.reconcile_locals_from_env_at_site(code);
                 }


### PR DESCRIPTION
## Summary

env_dirty substrate slice S8。roast double-OFF surface **25 → 22**（1 修正で 3 roast file 消化）。

`andthen`/`orelse`/`notandthen` test the LHS definedness via `OpCode::CallDefined`, which dispatches a user `method defined` when one exists. A user `method defined { \$calls++ }` mutates a captured-outer lexical by name in env via the interpreter slow path (`run_instance_method`), which records nothing the CallDefined site can drain — so the caller's `\$calls` slot was reconciled only by the post-call `reconcile_locals_from_env_at_site`, a no-op once env_dirty is removed (double-OFF: `\$calls=0`, expected 1).

## Fix

Snapshot the caller frame's slot-backing env values before the user-method call and, after it, write through only the slots whose env value **changed** — the precise form of the blanket reconcile (mirrors the react S7 snapshot). One fix clears three roast files (`S03-operators/{andthen,orelse,notandthen}`).

Gated by `cell_boxing_active()`: the default build keeps the blanket reconcile (byte-identical).

## ⚠ Authoritative roast double-OFF survey

This PR also records an important finding: a **full roast whitelist (1285) sweep** under `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` reveals **25 roast files** with hidden precise-reconcile-dependent surfaces — the t/ pins (which reached 0) were **incomplete**. env_dirty physical removal is gated on clearing all of them. S8 takes roast 25 → 22. Categorized map in `docs/captured-outer-cell-sharing.md` §10.10 (S14 roles 5 / S02 set-types 3 / S02 names 2 / misc).

## Test

- pins: `roast/S03-operators/{andthen,orelse,notandthen}.t` PASS in default **and** double-OFF.
- `make test` running; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)