### PR TITLE
feat(single-store): precise symbolic-deref store carrier writeback (env_dirty substrate S9)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -60,11 +60,13 @@
   - **t/ サーフェス 0**（全 double-OFF pin 16 ＋ broad supply/react/concurrency/promise/start t/ が両モード PASS）。
     **⚠ だが全 roast whitelist（1285）の double-OFF sweep は 25 file の隠れサーフェスを露呈**（t/ pin は不完全＝
     第45「OFF roast survey こそ authoritative」と同型）。診断＝`tmp/roast-double-off-fails.txt`。env_dirty 削除は roast
-    25→0 が前提。**S8（#TBD・roast 25→22）= user `.defined`（andthen/orelse/notandthen）writeback**（CallDefined snapshot・
-    1 修正 3 file）。残 22 = S14 roles 5／S02 types set系 3／S02 names 2／その他（docs §10.10 にカテゴリ表）。
+    25→0 が前提。**S8（#3418・roast 25→22）= user `.defined`（andthen/orelse/notandthen）writeback**（CallDefined snapshot・
+    1 修正 3 file）。**S9（#TBD・roast 22→21）= symbolic-deref store（`$::()=`/`::('$x')=`）の carrier writeback**
+    （`note_caller_env_write` ログ・scalar・`:=` hazard なし）。残 21 = S14 roles 5／S02 types set系 3（lives-ok container
+    carrier・`:=` hazard）／S02 names our.t 1（EVAL+class+`$GLOBAL::`）／その他（docs §10.10 にカテゴリ表）。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = roast double-OFF 22→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
+- **∴ 次 = roast double-OFF 21→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
   `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -781,3 +781,15 @@ per-write 記録なし→**user-method 呼び出し前後で caller-frame slot-b
 精密書き戻し（react S7 と同手法）。`cell_boxing_active()` ガード＝default は blanket reconcile が担う＝バイト不変。
 **1 修正で 3 roast file（S03 andthen/orelse/notandthen）消化**。pin=roast/S03-operators/{andthen,orelse,notandthen}.t
 （double-OFF で PASS 化）。
+
+### 10.12 slice S9（2026-06-22）— symbolic-deref store の carrier writeback を precise 化（roast 22→21）
+
+`my $a_var=42; my $b_var="a_var"; lives-ok { $::($b_var) = 23 }; is $a_var, 23` = `$::($name) = v`（symbolic deref store・
+`exec_symbolic_deref_store_op`）と `::('$x') = v`（indirect type lookup store・`exec_indirect_type_lookup_store_op`）は
+ターゲット lexical を by-name で env 書きし `update_local_if_exists` で**現フレームの** slot だけ更新する。`lives-ok { }`
+carrier 内ではターゲット slot は carrier-caller のフレームにあり、carrier writeback（`writeback_carrier_writes`）経由で
+しか届かないが、両 store op は**carrier_writes にログしていなかった**ため OFF で reconcile されず stale（bare block では
+動くが lives-ok 内だけ失敗）。**修正**: 両 store op の env insert 後に `note_caller_env_write(&store_name)` を呼び
+carrier_writes へログ＋env_dirty（regex `:let`・`s///` writeback と同パターン）。スカラなので `:=` cell hazard なし。
+default build はバイト不変（scalar reconcile は blanket の subset）。pin=roast/S02-names/symbolic-deref.t（double-OFF で
+PASS 化）。**残 roast double-OFF 21**（our.t は EVAL+class+`$GLOBAL::`++ の別機構で未消化）。

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1246,6 +1246,15 @@ impl Interpreter {
         };
         self.env_mut().insert(store_name.clone(), value.clone());
         self.update_local_if_exists(code, &store_name, &value);
+        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a
+        // symbolic-deref store (`$::($name) = v`) writes the target lexical by name
+        // straight into env. `update_local_if_exists` refreshes the slot only when
+        // it lives in *this* frame; inside a carrier (`lives-ok { $::($n) = v }`)
+        // the owning slot is the carrier-caller's, reached only via the carrier
+        // writeback. Log the name so `writeback_carrier_writes` reconciles it (and
+        // set env_dirty) — without this the write is lost once the blanket
+        // reconcile is removed (mirrors the regex `:let` path).
+        self.note_caller_env_write(&store_name);
         self.stack.push(value);
     }
 
@@ -1263,6 +1272,9 @@ impl Interpreter {
         };
         self.env_mut().insert(store_name.clone(), value.clone());
         self.update_local_if_exists(code, &store_name, &value);
+        // env_dirty substrate: same as exec_symbolic_deref_store_op — `::('$x') = v`
+        // writes the target lexical by name, so log it for the carrier writeback.
+        self.note_caller_env_write(&store_name);
         self.stack.push(value);
     }
 


### PR DESCRIPTION
## Summary

env_dirty substrate slice S9。roast double-OFF surface **22 → 21**。

`\$::(\$name) = v` (symbolic deref store) and `::('\$x') = v` (indirect type lookup store) write the target lexical by name into env and refresh only **this** frame's slot via `update_local_if_exists`. Inside a carrier (`lives-ok { \$::(\$n) = v }`) the owning slot is the carrier-caller's frame, reached only via the carrier writeback — but neither store op logged the name into `carrier_writes`, so `writeback_carrier_writes` never reconciled it and the slot stayed stale once the blanket reconcile is removed (a bare block worked; only the lives-ok form failed).

## Fix

Call `note_caller_env_write(&store_name)` after the env insert in both store ops (mirrors the regex `:let` / `s///` writeback paths). Scalar-only, so no `:=` cell hazard. Default build byte-identical (the scalar reconcile is a subset of the blanket pull).

## Test

- pin: `roast/S02-names/symbolic-deref.t` PASS in default **and** double-OFF.
- `make test` running; clippy/fmt clean.

残 roast double-OFF 21（our.t は EVAL+class+`\$GLOBAL::`++ の別機構）。設計 = `docs/captured-outer-cell-sharing.md` §10.12。

🤖 Generated with [Claude Code](https://claude.com/claude-code)