### PR TITLE
fix(constant): compile a shadowing constant as a pure lexical binding

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -480,6 +480,16 @@ impl Compiler {
     ) -> CompiledCode {
         let mut sub_compiler = Compiler::new();
         sub_compiler.is_routine = is_routine;
+        // Make the names of all constants visible at this closure's definition
+        // point known to the child compiler, so a `constant X` inside the body
+        // that shadows an outer constant is recognised as shadowing (and thus
+        // kept purely lexical, not written back to the shared package store).
+        sub_compiler.outer_constant_names = self
+            .constant_vars_in_scope
+            .iter()
+            .chain(self.outer_constant_names.iter())
+            .cloned()
+            .collect();
         // A closure body is lexically inside a routine if either the parent
         // already is, or the parent itself is a routine.
         sub_compiler.lexically_in_routine =

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -88,6 +88,15 @@ pub(crate) struct Compiler {
     /// entry). Declaring the same constant twice in one block is an
     /// X::Redeclaration; a shadowing declaration in an inner block is allowed.
     constant_vars_current_scope: std::collections::HashSet<String>,
+    /// Names of constants declared in an *enclosing* compiler (i.e. visible at a
+    /// nested closure's definition point). Propagated into child closure
+    /// compilers (which otherwise start with empty constant state). Used ONLY to
+    /// detect that a `constant X` inside the closure *shadows* an outer constant
+    /// — a shadowing constant is purely lexical and must not clobber the outer
+    /// constant's shared package store. This set is deliberately NOT consulted
+    /// during bare-word resolution (that stays driven by `constant_vars_in_scope`
+    /// + `local_map`), so it cannot turn an outer-constant read into a GetLocal.
+    outer_constant_names: std::collections::HashSet<String>,
     /// Local names that are sigilless bindings (declared with `my \Foo = ...`
     /// or as a sigilless parameter).  BareWord resolution only uses GetLocal
     /// for names in this set; `$`-sigiled variables must not shadow type names.
@@ -147,6 +156,7 @@ impl Compiler {
             constant_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
             constant_vars_current_scope: std::collections::HashSet::new(),
+            outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -768,6 +768,17 @@ impl Compiler {
                 // Track constant declarations so the compiler can avoid itemizing
                 // them in `for` loops (constants have no Scalar container).
                 let is_constant_decl = custom_traits.iter().any(|(t, _)| t == "__constant");
+                // A `constant` that shadows an outer constant of the same name
+                // (in an enclosing block or closure) is a fresh lexical binding,
+                // not a reassignment of the outer package symbol. It must read
+                // from its own local slot only and must NOT clobber the outer
+                // constant's shared package store (`SetGlobalRaw`). Detect the
+                // shadow *before* inserting this decl into the in-scope set — a
+                // same-scope duplicate errors as X::Redeclaration below, so a hit
+                // here is always an outer shadow.
+                let shadows_outer_constant = is_constant_decl
+                    && (self.constant_vars_in_scope.contains(name.as_str())
+                        || self.outer_constant_names.contains(name.as_str()));
                 if is_constant_decl {
                     // X::Redeclaration on a duplicate same-scope `constant` is only
                     // fired when the *sigil* matches. mutsu's AST strips the `$`
@@ -1032,7 +1043,16 @@ impl Compiler {
                         self.code.emit(OpCode::MarkScalarBindContext);
                     }
                     self.code.emit(OpCode::SetLocal(slot));
-                    if *is_our {
+                    // A `constant` that shadows an outer constant of the same name
+                    // (in an enclosing block or closure) is a fresh lexical binding,
+                    // not a reassignment of the outer package symbol. Compile it as
+                    // a pure `my` lexical: it lives only in its own local slot and
+                    // never touches the shared package store (`our_locals` /
+                    // `SetGlobalRaw`). Writing the package store would clobber the
+                    // outer constant for sibling scopes, and the writeback merge for
+                    // an `our` var declared inside a closure leaks the shadowing
+                    // value back to the caller.
+                    if *is_our && !shadows_outer_constant {
                         let qualified = self.qualify_variable_name(name);
                         // Track this slot as `our`-scoped so BlockScope restoration
                         // can sync the local from its global after block exit.

--- a/t/constant-shadow.t
+++ b/t/constant-shadow.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+plan 7;
+
+# A `constant` is lexically scoped: a nested declaration of the same name is a
+# fresh binding that shadows the outer one only within its own scope, and must
+# not leak back to (or clobber) the outer constant.
+
+# Shadow inside a bare block.
+{
+    constant T = "outer";
+    {
+        constant T = "inner";
+        is T, "inner", "inner block sees its own shadowing constant";
+    }
+    is T, "outer", "outer scope keeps its constant after a shadowing block";
+}
+
+# Shadow inside a named sub; a sibling sub must still see the outer constant.
+{
+    constant U = "outer";
+    sub with-shadow() { constant U = "inner"; U }
+    sub no-shadow() { U }
+    is with-shadow(), "inner", "sub with a shadowing constant sees the shadow";
+    is no-shadow(), "outer", "sibling sub sees the outer constant, not the shadow";
+    is U, "outer", "outer scope unaffected by a sub-local shadowing constant";
+}
+
+# A constant declared at the top of a scope is visible to a sub defined later
+# (lexical visibility must survive the shadow fix).
+{
+    constant V = "visible";
+    sub reader() { V }
+    is reader(), "visible", "constant is visible inside a later-defined sub";
+}
+
+# A nested sub captures the *shadowing* constant of its enclosing block.
+{
+    constant W = "outer";
+    {
+        constant W = "inner";
+        sub deep() { W }
+        is deep(), "inner", "nested sub captures the enclosing shadowing constant";
+    }
+}


### PR DESCRIPTION
## Problem

A Raku `constant` is lexically scoped, but mutsu compiled *every* constant as an `our`-scoped package symbol, writing its value into the shared package store (`SetGlobalRaw`). When a nested block, sub, or closure declared a `constant` with the same name as an outer one, the inner declaration **clobbered the outer constant's package cell**, so the outer (and sibling) scopes read the shadowing value:

```raku
constant T = "outer";
{ constant T = "inner"; }
say T;   # was "inner", should be "outer"
```

This surfaced in the web-stack `IO::Blob` test suite, whose `subtest { constant TEXT = ... }` blocks redefine a same-named constant.

## Fix

Detect at compile time when a `constant` shadows an outer constant of the same name — via the enclosing compiler's `constant_vars_in_scope` (lexical blocks) or a new `outer_constant_names` set propagated into nested closure compilers — and compile the shadowing declaration as a **pure `my` lexical**: it lives only in its own local slot and never touches the package store. A non-shadowing constant is unchanged (still installed in the package so later subs/methods can see it).

## Tests

Adds `t/constant-shadow.t` (7 cases): block shadow, sub shadow, sibling-sub isolation, later-defined-sub visibility, and nested-sub capture of the shadowing constant. `make test` green; whitelisted `roast/S04-declarations/constant-6.d.t` still passes.

## Known limitation (out of scope)

A `my`/`constant` declared inside an **anonymous closure** that shadows a *captured* outer variable still leaks back to the caller via the env↔locals writeback merge (a general capture bug, not constant-specific — affects plain `my` too). That is the single-store / `env_dirty` substrate track; this PR only fixes the package-store clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)