### PR TITLE
fix(grammar): fire action methods for rules nested in ( ) groups and silent subrules

### DIFF
--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -436,6 +436,36 @@ impl Interpreter {
             updated_attrs.insert("named".to_string(), Value::hash(updated_named));
         }
 
+        // Recurse into positional captures (numbered `( )` groups). A `( )` group
+        // is an anonymous capture boundary: named rules matched inside it (e.g.
+        // `( <.request-line> )` whose request-line contains `<method>`/`<path>`)
+        // are stored under the group's own Match, not flattened up to this rule,
+        // so the named-children walk above never reaches them. Recurse into each
+        // positional child so their nested actions still fire. The anonymous group
+        // itself has no action method (dispatch falls through as method-not-found
+        // and is silently skipped); only its descendants' actions run.
+        if let Some(Value::Array(pos_arr, pos_meta)) = attributes.as_map().get("list") {
+            let mut updated_pos = Vec::with_capacity(pos_arr.len());
+            for item in pos_arr.iter() {
+                // Only Match instances carry nested captures worth recursing into;
+                // pass anything else through untouched.
+                if matches!(item, Value::Instance { .. }) {
+                    let updated_item =
+                        self.invoke_grammar_actions(item.clone(), actions, "__anon_capture_group")?;
+                    updated_pos.push(updated_item);
+                } else {
+                    updated_pos.push(item.clone());
+                }
+            }
+            updated_attrs.insert(
+                "list".to_string(),
+                Value::Array(
+                    Arc::new(crate::value::ArrayData::new(updated_pos)),
+                    *pos_meta,
+                ),
+            );
+        }
+
         // Rebuild match_obj with updated children
         let match_obj = Value::make_instance(class_name, (updated_attrs.clone()).to_map());
 

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -552,10 +552,20 @@ impl Interpreter {
                     }
                 }
             } else {
-                // Silent subrule — merge named captures only.
+                // Silent subrule (`<.foo>`) — the subrule itself is not captured,
+                // but mutsu propagates its *direct* named captures up to the parent
+                // so grammar action methods (driven by the capture tree) still fire
+                // for them. Merge both the flat `named` text AND the structured
+                // `named_subcaps` (each carrying its own nested captures); dropping
+                // the latter would strip a propagated capture's grandchildren —
+                // e.g. `<.request-line>` containing `<request-target>` which in turn
+                // contains `<path>` would lose `path`, so its action never runs.
                 let mut inner_caps = inner_caps;
                 for (k, v) in inner_caps.named.drain() {
                     new_caps.named.entry(k).or_default().extend(v);
+                }
+                for (k, v) in inner_caps.named_subcaps.drain() {
+                    new_caps.named_subcaps.entry(k).or_default().extend(v);
                 }
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
             }

--- a/t/grammar-nested-action-dispatch.t
+++ b/t/grammar-nested-action-dispatch.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+plan 4;
+
+# Grammar action methods must fire for named rules that are nested inside a
+# numbered capture group `( ... )`, and the propagated captures must keep their
+# own nested sub-captures so deeper action methods also fire.
+
+grammar G {
+    token TOP { ( <.request-line> ) .* }
+    token request-line { <method> <.SP> <request-target> }
+    token method { \w+ }
+    token request-target { <path> [ '?' <query> ]? }
+    token path  { <-[?#\ ]>* }
+    token query { <-[#\ ]>* }
+    token SP { ' ' }
+}
+
+class Actions {
+    has %.env;
+    method method($/)         { %!env<METHOD>      = ~$/; }
+    method request-target($/) { %!env<URI>         = ~$/; %!env<QUERY> //= ''; }
+    method path($/)           { %!env<PATH>        = ~$/; }
+    method query($/)          { %!env<QUERY>       = ~$/; }
+}
+
+# Actions for rules nested in a `( )` group fire (regression: a positional
+# capture group used to be a boundary the action walk never crossed).
+{
+    my $a = Actions.new;
+    G.parse("GET /foo HTTP", :actions($a));
+    is $a.env<METHOD>, 'GET', 'action for a rule inside a ( ) group fires (method)';
+    is $a.env<URI>, '/foo', 'captured subrule action fires (request-target)';
+    # request-target is captured AND nested under the non-captured request-line;
+    # its own nested <path> must survive so the path action fires too.
+    is $a.env<PATH>, '/foo', 'grandchild action survives propagation (path)';
+}
+
+# Action methods for rules nested (any depth) under a silent `<.subrule>` fire,
+# because the propagated captures keep their own nested sub-captures.
+{
+    grammar H {
+        token TOP { <.outer> }
+        token outer { <inner> }
+        token inner { <leaf> }
+        token leaf { \w+ }
+    }
+    class HActions {
+        has @.seen;
+        method leaf($/)  { @!seen.push('leaf:'  ~ ~$/); }
+        method inner($/) { @!seen.push('inner:' ~ ~$/); }
+    }
+    my $a = HActions.new;
+    H.parse("hello", :actions($a));
+    is $a.seen, ['leaf:hello', 'inner:hello'],
+        'deeply nested action methods fire through a silent subrule';
+}


### PR DESCRIPTION
## Problem

Grammar action dispatch in mutsu is a post-match walk over the capture tree. Two gaps left nested action methods unfired:

1. **Positional `( )` groups were a boundary.** The walk recursed only into *named* captures, never into positional capture groups. A named rule matched inside `( ... )` (e.g. `( <.request-line> )` whose request-line contains `<method>`/`<path>`) is stored under the group's `Match`, so its action never fired.

2. **Silent subrules dropped nested structure.** A silent subrule (`<.foo>`) propagates its direct named captures up to the parent so their actions still fire, but it merged only the flat `named` text and dropped the structured `named_subcaps`. A propagated capture therefore lost its own grandchildren — e.g. `<.request-line>` → `<request-target>` → `<path>` lost `path`, so the `path` action never ran.

## Fix

1. `invoke_grammar_actions` now also recurses into positional (`list`) captures. The anonymous group has no action method (dispatch falls through as method-not-found, silently skipped); only its descendants' actions run.
2. The silent-subrule merge now propagates `named_subcaps` alongside `named`, preserving each propagated capture's nested sub-captures.

Together these make action methods fire for arbitrarily nested rules, matching Rakudo.

## Verification

- Against the `HTTP::Parser` module test: **8 → 3** subtest failures. (The remaining 3 need a separate change so a *silent* rule's **own** action fires — reduce-time semantics mutsu's tree-walk can't yet express; tracked separately.)
- New `t/grammar-nested-action-dispatch.t` (4 cases), each verified to match `raku` output.
- All whitelisted `S05-grammar` / `S05-metasyntax` tests pass; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)