### PR TITLE
Complete HTTP::Parser: silent-subrule grammar actions + Blob .first iteration

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -1595,6 +1595,35 @@ impl Interpreter {
         }
     }
 
+    /// If `v` is a Buf/Blob, return its element bytes as a list of Int values.
+    /// Raku iterates a Blob as its bytes, so list methods (`map`/`grep`/`first`)
+    /// must expand it rather than treating the whole Blob as a single element.
+    /// (Note: list-*assignment* keeps a Blob as one element — `my @a = $buf` —
+    /// so this is used only by the iterating methods, not `value_to_list`.)
+    pub(in crate::runtime) fn buf_as_byte_items(v: &Value) -> Option<Vec<Value>> {
+        if let Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } = v
+        {
+            let cn = class_name.resolve();
+            let is_blob = cn == "Buf"
+                || cn == "Blob"
+                || cn == "utf8"
+                || cn == "utf16"
+                || cn == "utf32"
+                || cn.starts_with("Buf[")
+                || cn.starts_with("Blob[")
+                || cn.starts_with("buf")
+                || cn.starts_with("blob");
+            if is_blob && let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
+                return Some(bytes.iter().cloned().collect());
+            }
+        }
+        None
+    }
+
     pub(super) fn builtin_first(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         // Separate named args (Pairs) from positional args
         let mut positional = Vec::new();

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -94,7 +94,10 @@ impl Interpreter {
             return self.dispatch_supply_first(&(attributes).as_map(), func, has_end);
         }
 
-        let items = crate::runtime::utils::value_to_list(&target);
+        // A Blob/Buf iterates as its element bytes (unlike list assignment, which
+        // keeps it as a single element), so `.first` scans the bytes.
+        let items = Self::buf_as_byte_items(&target)
+            .unwrap_or_else(|| crate::runtime::utils::value_to_list(&target));
         if let Some((idx, value)) = self.find_first_match_over_items(func, &items, has_end)? {
             return Ok(super::super::builtins_collection::format_first_result(
                 idx, value, has_k, has_kv, has_p,

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -377,6 +377,46 @@ impl Interpreter {
         None
     }
 
+    /// Dispatch the silent-action captures reachable from a match's attribute
+    /// map: this level's own `silent_caps` (hidden `<.foo>` subrule matches that
+    /// carry nested captures), then — descending through positional `( )` groups
+    /// — each group's `silent_caps`. Only `silent_caps` are fired, never a group's
+    /// named children: those are already dispatched by the named-children walk in
+    /// `invoke_grammar_actions`, so re-firing them would double-dispatch (see
+    /// t/grammar-reduce-time-dynvar.t). Captures are dispatched in source order.
+    fn dispatch_silent_action_caps(
+        &mut self,
+        attrs: &crate::value::AttrReadGuard<'_>,
+        actions: &mut Value,
+    ) -> Result<(), RuntimeError> {
+        if let Some(Value::Array(silent_arr, _)) = attrs.get("silent_caps") {
+            let mut items: Vec<Value> = silent_arr.iter().cloned().collect();
+            items.sort_by_key(|m| {
+                if let Value::Instance { attributes, .. } = m
+                    && let Some(Value::Int(from)) = attributes.as_map().get("from")
+                {
+                    *from
+                } else {
+                    0
+                }
+            });
+            for item in items {
+                let dispatch_name = Self::get_action_name(&item).unwrap_or_default();
+                self.invoke_grammar_actions(item, actions, &dispatch_name)?;
+            }
+        }
+        let positionals: Vec<Value> = match attrs.get("list") {
+            Some(Value::Array(pos_arr, _)) => pos_arr.iter().cloned().collect(),
+            _ => Vec::new(),
+        };
+        for p in &positionals {
+            if let Value::Instance { attributes, .. } = p {
+                self.dispatch_silent_action_caps(&attributes.as_map(), actions)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Walk the match tree bottom-up and invoke action methods on the actions object.
     pub(crate) fn invoke_grammar_actions(
         &mut self,
@@ -436,35 +476,18 @@ impl Interpreter {
             updated_attrs.insert("named".to_string(), Value::hash(updated_named));
         }
 
-        // Recurse into positional captures (numbered `( )` groups). A `( )` group
-        // is an anonymous capture boundary: named rules matched inside it (e.g.
-        // `( <.request-line> )` whose request-line contains `<method>`/`<path>`)
-        // are stored under the group's own Match, not flattened up to this rule,
-        // so the named-children walk above never reaches them. Recurse into each
-        // positional child so their nested actions still fire. The anonymous group
-        // itself has no action method (dispatch falls through as method-not-found
-        // and is silently skipped); only its descendants' actions run.
-        if let Some(Value::Array(pos_arr, pos_meta)) = attributes.as_map().get("list") {
-            let mut updated_pos = Vec::with_capacity(pos_arr.len());
-            for item in pos_arr.iter() {
-                // Only Match instances carry nested captures worth recursing into;
-                // pass anything else through untouched.
-                if matches!(item, Value::Instance { .. }) {
-                    let updated_item =
-                        self.invoke_grammar_actions(item.clone(), actions, "__anon_capture_group")?;
-                    updated_pos.push(updated_item);
-                } else {
-                    updated_pos.push(item.clone());
-                }
-            }
-            updated_attrs.insert(
-                "list".to_string(),
-                Value::Array(
-                    Arc::new(crate::value::ArrayData::new(updated_pos)),
-                    *pos_meta,
-                ),
-            );
-        }
+        // Dispatch actions for silent-action captures: hidden `<.foo>` subrule
+        // matches that carry nested captures. The subrule is absent from `.hash`,
+        // but Rakudo fires its action method (and its descendants') at reduce time
+        // regardless of capture — so recurse into each (bottom-up, in source order)
+        // to dispatch them. Each subcap's `action_name` names the method to call.
+        // This also descends through positional `( )` groups, since a silent
+        // subrule matched inside a group has its marker stored on the GROUP's
+        // match. Only `silent_caps` are dispatched — never the groups' named
+        // children (the named-children walk above already handles those; firing
+        // them again double-dispatches, see t/grammar-reduce-time-dynvar.t).
+        // Results are not stored back: silent captures are never read by user code.
+        self.dispatch_silent_action_caps(&attributes.as_map(), actions)?;
 
         // Rebuild match_obj with updated children
         let match_obj = Value::make_instance(class_name, (updated_attrs.clone()).to_map());

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -608,6 +608,13 @@ pub(crate) struct CodeBlockContext {
 /// A single entry in a quantified capture list: (matched_text, from, to, subcaptures).
 pub(crate) type QuantifiedCaptureEntry = (String, usize, usize, Option<RegexCaptures>);
 
+/// Prefix marking a `named_subcaps` entry as a *silent action capture*: the
+/// match of a silent subrule (`<.foo>`) that is hidden from `.hash` but whose
+/// grammar action method (and its descendants') must still fire. The prefix is a
+/// control character that can never appear in a real capture name, so marker
+/// entries never collide with user captures and are trivially filtered.
+pub(crate) const SILENT_ACTION_MARKER_PREFIX: &str = "\u{1}silent\u{1}";
+
 #[derive(Clone, Default)]
 pub(crate) struct RegexCaptures {
     pub(crate) named: HashMap<String, Vec<String>>,

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -551,22 +551,49 @@ impl Interpreter {
                         last.action_name = Some(spec.lookup_name.clone());
                     }
                 }
+            } else if !inner_caps.named.is_empty() || !inner_caps.named_subcaps.is_empty() {
+                // Silent subrule (`<.foo>`) that contains nested captures. The
+                // subrule is hidden from `.hash`, but its OWN action method must
+                // still fire (Rakudo dispatches actions at reduce time regardless
+                // of capture), and its nested rules' actions must fire too — with
+                // their `.made` set on the SAME nodes the parent action reads
+                // (`method header-field { ...$/<field-name>.made... }`). Store the
+                // whole subrule match under a HIDDEN MARKER key in `named_subcaps`
+                // (the prefix can never be a real capture name). The Match builder
+                // routes marker entries into a `silent_caps` attribute instead of
+                // `.hash`; the grammar action walk recurses into them. This replaces
+                // the older "flatten direct children into the parent" hack, which
+                // lost the rule's own action and over-exposed children in `.hash`.
+                let inner_len = end - pos;
+                let cs = (pos + inner_caps.capture_start.unwrap_or(0)).clamp(pos, end);
+                let ce = (pos + inner_caps.capture_end.unwrap_or(inner_len)).clamp(cs, end);
+                let captured: String = chars[cs..ce].iter().collect();
+                let mut subcap = inner_caps;
+                subcap.matched = captured;
+                subcap.from = cs;
+                subcap.to = ce;
+                if subcap.sym.is_none() && sym_key.is_some() {
+                    subcap.sym = sym_key.cloned();
+                }
+                subcap.action_name = Some(spec.lookup_name.clone());
+                new_caps.code_blocks.extend(subcap.code_blocks.clone());
+                let marker = format!(
+                    "{}{}",
+                    crate::runtime::SILENT_ACTION_MARKER_PREFIX,
+                    spec.lookup_name
+                );
+                new_caps
+                    .named_subcaps
+                    .entry(marker)
+                    .or_default()
+                    .push(subcap);
             } else {
-                // Silent subrule (`<.foo>`) — the subrule itself is not captured,
-                // but mutsu propagates its *direct* named captures up to the parent
-                // so grammar action methods (driven by the capture tree) still fire
-                // for them. Merge both the flat `named` text AND the structured
-                // `named_subcaps` (each carrying its own nested captures); dropping
-                // the latter would strip a propagated capture's grandchildren —
-                // e.g. `<.request-line>` containing `<request-target>` which in turn
-                // contains `<path>` would lose `path`, so its action never runs.
+                // Childless silent subrule (`<.ws>`, `<.CRLF>`, `<.sym>`, ...): no
+                // nested captures and (in practice) no action of interest, so keep
+                // the cheap path — just carry its code blocks up. Routing these
+                // through the marker channel would store a subcap for every `<.ws>`
+                // in a parse for no benefit.
                 let mut inner_caps = inner_caps;
-                for (k, v) in inner_caps.named.drain() {
-                    new_caps.named.entry(k).or_default().extend(v);
-                }
-                for (k, v) in inner_caps.named_subcaps.drain() {
-                    new_caps.named_subcaps.entry(k).or_default().extend(v);
-                }
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
             }
             out.push((end, new_caps));

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -3992,12 +3992,31 @@ impl Value {
                     .entry(qname.clone())
                     .or_insert_with(|| Value::real_array(Vec::new()));
             }
+            // Silent-action captures: hidden `<.foo>` subrule matches (stored under
+            // a marker key in `named_subcaps`) that carry nested captures. They are
+            // absent from `named`/`.hash`, but their action methods must fire, so
+            // build them into a `silent_caps` array for the grammar action walk.
+            // Each subcap's `action_name` carries the rule name to dispatch on.
+            let mut silent_caps_vals: Vec<Value> = Vec::new();
+            for (key, scs) in &caps.named_subcaps {
+                if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
+                    for sc in scs {
+                        silent_caps_vals.push(make_subcap_match(sc, orig));
+                    }
+                }
+            }
             let mut attrs = HashMap::new();
             attrs.insert("str".to_string(), Value::str(caps.matched.clone()));
             attrs.insert("from".to_string(), Value::Int(caps.from as i64));
             attrs.insert("to".to_string(), Value::Int(caps.to as i64));
             attrs.insert("list".to_string(), Value::array(pos_vals));
             attrs.insert("named".to_string(), Value::hash(sub_named));
+            if !silent_caps_vals.is_empty() {
+                attrs.insert(
+                    "silent_caps".to_string(),
+                    Value::real_array(silent_caps_vals),
+                );
+            }
             if let Some(o) = orig {
                 attrs.insert("orig".to_string(), Value::str(o.to_string()));
             }
@@ -4094,6 +4113,24 @@ impl Value {
                 .or_insert_with(|| Value::real_array(Vec::new()));
         }
         attrs.insert("named".to_string(), Value::hash(named_caps_map));
+        // Silent-action captures: hidden `<.foo>` subrule matches carrying nested
+        // captures (see make_subcap_match). Build them into a `silent_caps` array
+        // so the grammar action walk fires their (and descendants') actions; they
+        // are deliberately absent from `named`/`.hash`.
+        let mut silent_caps_vals: Vec<Value> = Vec::new();
+        for (key, scs) in named_subcaps {
+            if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
+                for sc in scs {
+                    silent_caps_vals.push(make_subcap_match(sc, orig));
+                }
+            }
+        }
+        if !silent_caps_vals.is_empty() {
+            attrs.insert(
+                "silent_caps".to_string(),
+                Value::real_array(silent_caps_vals),
+            );
+        }
         Value::make_instance(Symbol::intern("Match"), attrs)
     }
 

--- a/t/grammar-silent-rule-action.t
+++ b/t/grammar-silent-rule-action.t
@@ -1,0 +1,60 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A silent subrule `<.foo>` is hidden from `.hash`, but its OWN action method
+# must still fire (Rakudo dispatches actions at reduce time regardless of
+# capture), as must its descendants' — matching `raku`.
+
+grammar G {
+    token TOP { <.foo> }
+    token foo { <bar> }
+    token bar { \w+ }
+}
+class A {
+    has @.log;
+    method foo($/) { @!log.push('foo:' ~ ~$/); }
+    method bar($/) { @!log.push('bar:' ~ ~$/); }
+}
+{
+    my $a = A.new;
+    G.parse('hello', :actions($a));
+    is $a.log, ['bar:hello', 'foo:hello'],
+        "a silent subrule's own action fires (and its child's), bottom-up";
+}
+
+# The silent subrule and its children stay hidden from `.hash`.
+{
+    my $m = G.parse('hello');
+    nok $m<foo>.defined, 'silent <.foo> is absent from .hash';
+    nok $m<bar>.defined, "silent subrule's children are absent from .hash";
+}
+
+# A `( )` group containing silent subrules still fires their actions, and a
+# repeated silent subrule fires its action once per match.
+grammar H {
+    token TOP { ( [ <.item> ]+ ) }
+    token item { <name> ',' }
+    token name { \w+ }
+}
+class HA {
+    has @.names;
+    method item($/) { @!names.push('item:' ~ $/<name>); }
+    method name($/)  { @!names.push('name:' ~ ~$/); }
+}
+{
+    my $a = HA.new;
+    H.parse('a,b,c,', :actions($a));
+    is $a.names.grep(* ~~ /^name/), ['name:a', 'name:b', 'name:c'],
+        'name action fires once per repeated silent <.item>';
+    is $a.names.grep(* ~~ /^item/).elems, 3,
+        "repeated silent subrule's own action fires once per match";
+}
+
+# `.first` on a Blob iterates its element bytes (unlike list assignment, which
+# keeps a Blob as a single element).
+{
+    my $buf = "AB\x[C8]".encode('latin1');
+    is $buf.first(* > 127, :k), 2, '.first(:k) scans a Blob as its bytes';
+}


### PR DESCRIPTION
Makes the **HTTP::Parser** web-stack module fully pass (14/14), via two independent fixes (one commit each).

## 1. Grammar: fire a silent subrule's own action

A silent subrule `<.foo>` is hidden from `.hash`, but Rakudo still fires its action method (and its descendants') at reduce time. mutsu's post-match action walk couldn't — `<.foo>` isn't in the capture tree. The prior workaround flattened a silent rule's direct named children up to the parent (firing *their* actions) but lost the rule's **own** action and over-exposed children in `.hash`. The positional-group recursion from #3422 also **double-dispatched** for grammars with `( )` text captures next to named subrules (`t/grammar-reduce-time-dynvar.t` produced `c,c,c`).

Replaced both with a proper **silent-action channel**:
- A silent subrule carrying nested captures is stored under a hidden marker key in `named_subcaps` (never in `named` → absent from `.hash`). Childless silent rules (`<.ws>`/`<.CRLF>`) keep the cheap path.
- The Match builder routes marker entries into a `silent_caps` attribute.
- The action walk dispatches `silent_caps` (this level's, then descending through positional `( )` groups), firing the silent rule's own action + descendants' with correct `.made` propagation, in source order. Only `silent_caps` fire through groups — never their named children — so the #3422 double-dispatch is gone.

Fixes the `t/grammar-reduce-time-dynvar.t` regression #3422 introduced (t/ is non-fatal in CI, so it slipped through). New `t/grammar-silent-rule-action.t`. Known pre-existing gap: a *named* rule directly in a `( )` group (`( <foo> )`) still doesn't fire its action (deeper match-tree leak).

## 2. Buf: `.first` iterates a Blob's bytes

`$blob.first(matcher)` must scan the Blob's element bytes (Rakudo calls `.iterator` on the invocant). mutsu used `value_to_list`, which correctly keeps a Blob whole for list *assignment* (`my @a = $buf` → `[Buf]`), so `.first` saw one opaque element → Nil. Added `buf_as_byte_items`, used in the `.first` method dispatch. The `first` *sub* form is unchanged (treats a Blob arg as one value, matching Rakudo).

## Validation

- HTTP::Parser: 14/14 (was failing both test files).
- `make test`: PASS (9963 tests); `t/grammar-reduce-time-dynvar.t` now green.
- 94 whitelisted S05-grammar / S05-metasyntax / match / subst roast tests: 0 failures.
- Every new test asserts output verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)