### PR TITLE
docs(news): record session 10 web-stack work (HTTP::Parser complete)

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1297,3 +1297,26 @@ raku 一致）。全 sub が `IO(Cool) $io` 強制型パラメータを使い、
   削除するため（debug ビルドで Raku 1 呼び出しが太いネイティブフレームを消費）。再帰深度 ~500→~1200。
 - **テスト**: `t/io-coercion-param.t`（14 件 — `IO` ロール / `IO(Cool)`・`IO()` の Str/IO::Path 両受理 / `my IO(Cool)` 宣言・
   再代入 / `.=parent` on `is copy` / 非 coercion `IO` param）。`make test` 9918 件 PASS、whitelisted S32-io/S06-signature 回帰なし。
+
+## 2026-06-22 (session 10): HTTP::Parser 完動 + grammar action / constant 修正
+
+**4 つ目（HTTP 系で最初）の動作モジュール HTTP::Parser を完動**（own test 14/14、raku 一致）。3 PR：
+
+- **#3420 `constant` レキシカルシャドウ**: あらゆる `constant` を `our`（package 格納）でコンパイルしていたため、
+  block/sub/closure 内で同名 `constant` を宣言すると外側の package セルを上書きし、外側スコープが内側の値を読んでいた。
+  シャドウする `constant` をコンパイル時に検出し（`constant_vars_in_scope` ＋ closure へ伝播する `outer_constant_names`）、
+  純粋な `my` レキシカルとしてコンパイル（local slot のみ、package 不変）。`t/constant-shadow.t`。
+- **#3422 grammar action の `( )` グループ / ネスト対応**: action walk が named キャプチャしか辿らず、numbered `( )`
+  グループ内のルール（`( <.request-line> )` 等）の action が発火しなかった。positional キャプチャへの再帰 ＋ silent
+  subrule 伝播時の `named_subcaps` 構造保持。`t/grammar-nested-action-dispatch.t`。
+- **#3423 silent subrule 自身の action 発火 + Blob `.first`**: silent subrule（`<.foo>`、`.hash` から不可視）自身の
+  action は Rakudo では reduce-time に発火するが、mutsu の post-match walk では辿れなかった。nested capture を持つ
+  silent subrule を `named_subcaps` の隠しマーカーキーに格納 → Match builder が `silent_caps` 属性を生成 → action walk が
+  `silent_caps`（当該レベル＋positional グループを降下）のみをディスパッチ（グループの named children は二重発火を避けて
+  発火しない）。これで `<.header-field>` action が CONTENT_TYPE/HTTP_USER_AGENT を埋める。併せて #3422 が混入させた
+  dynvar 二重ディスパッチ回帰（`t/grammar-reduce-time-dynvar.t` → `c,c,c`）も解消。Blob `.first` はバイト列として反復
+  （`value_to_list` は代入時に Blob を単一要素として保つため `.first` メソッド dispatch で個別対応；sub 形式は不変）。
+  `t/grammar-silent-rule-action.t`。`make test` 9963 件 PASS。
+- **既知ギャップ**: `( <foo> )`（`( )` グループ内の named ルール）の action は未発火（match-tree リーク、深い）。残り web-stack
+  モジュール（HTTP::Status=sink/container-identity、io-blob 残=closure-capture leak、MIME::Base64=`for $blob` itemization、
+  HTTP::Server::Tiny=concurrency）はいずれも Slice F／深い基盤待ち。


### PR DESCRIPTION
Records session 10 accomplishments in news/2026-06.md: HTTP::Parser fully working (14/14) plus the constant-shadow (#3420), grammar action-dispatch (#3422), and silent-subrule-action + Blob .first (#3423) fixes. Documents the remaining web-stack blockers (all Slice F / deep infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)