### PR TITLE
feat(single-store): precise lives-ok container carrier Set/Bag/Mix writeback (env_dirty substrate S11)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -62,12 +62,14 @@
     第45「OFF roast survey こそ authoritative」と同型）。診断＝`tmp/roast-double-off-fails.txt`。env_dirty 削除は roast
     25→0 が前提。**S8（#3418・25→22）= user `.defined`（andthen/orelse/notandthen）**（CallDefined snapshot・1 修正 3 file）。
     **S9（#3419・22→21）= symbolic-deref store（`$::()=`/`::('$x')=`）**（`note_caller_env_write` ログ・scalar）。
-    **S10（#TBD・21→20）= user Proxy STORE（lvalue sub）**（`assign_proxy_lvalue` の env scalar スナップショット差分）。
-    残 20 = S14 roles 5／S02 types set系 3（lives-ok container carrier・`:=` hazard）／S02 names our.t 1（EVAL+class+
-    `$GLOBAL::`）／Pair rw aliasing（kv/pointy-rw 2）／その他（docs §10.10 にカテゴリ表）。
+    **S10（#3421・21→20）= user Proxy STORE（lvalue sub）**（`assign_proxy_lvalue` の env scalar スナップショット差分）。
+    **S11（#TBD・20→17）= lives-ok container carrier の Set/Bag/Mix writeback**（`exec_call_pairs_op` の COW aggregate
+    スナップショット差分・Array/Hash と Instance は除外）。残 17 = S14 roles 5（うち rw.t = Instance rw-accessor の
+    shared-cell・snapshot 不可・別手法要）／S02 names our.t 1（EVAL+class+`$GLOBAL::`）／Pair rw aliasing（kv/pointy-rw 2）／
+    その他（docs §10.10 にカテゴリ表）。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = roast double-OFF 20→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
+- **∴ 次 = roast double-OFF 17→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
   `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -805,3 +805,16 @@ blanket reconcile（double-OFF で no-op）でしか届かず stale（double-OFF
 （`is_writeback_safe_scalar` フィルタ）なので container/`:=` cell hazard なし。`cell_boxing_active()` ガード＝default は
 blanket reconcile が担う＝バイト不変。pin=roast/S06-routine-modifiers/lvalue-subroutines.t（double-OFF で PASS 化）。
 **残 roast double-OFF 20**。
+
+### 10.14 slice S11（2026-06-22）— lives-ok container carrier の Set/Bag/Mix writeback を precise 化（roast 20→17）
+
+`my $b=(…).BagHash; lives-ok { $b<a> = 42 }; is $b<a>, 42` = block Test fn（`lives-ok`/`dies-ok`＝`exec_call_pairs_op`
+carrier）が captured-outer の Set/Bag/Mix を env 経由で変異するが、`writeback_carrier_writes` は container slot を保護的に
+スキップ（barrier 任せ）するため double-OFF で stale。**修正**: carrier 実行**前後で env をスナップショット**し、変化した
+slot を write-through。**対象を COW aggregate（scalar + Set/Bag/Mix）に限定**＝`Value::Set/Bag/Mix(Arc<…Data>)` は
+in-place 変異で `make_mut` が COW し新 Arc へ detach する（pre snapshot は旧 Arc を保持）ので差分検出が確実。**Array/Hash
+除外**（env が COW-detach コピーで interior `:=` element cell を破壊する hazard）。**★Instance も除外**＝attributes が
+`Arc<RwLock>` の **shared cell** で in-place 変異するため snapshot が cell を共有し pre==post で差分検出**不可**（Instance
+rw-accessor は別スライス＝S14-roles/rw.t に残置）。`cell_boxing_active()` ガード＝default はバイト不変。
+回帰確認: element-bind-cell/S03-binding nested・arrays/set・mix 全 PASS（`:=` hazard なし）。pin=roast/S02-types/{baghash,
+mixhash,set}.t（double-OFF で PASS 化）。**残 roast double-OFF 17**（rw.t Instance rw-accessor 含む）。

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -177,11 +177,33 @@ impl Interpreter {
         // Keeps the blanket: deep `:=` bind-cell mutations through interpreter
         // builtins are not name-trackable and dropping the net corrupts cell
         // coherence (the CP-2 wall; t/element-bind-cell.t). See docs/vm-single-store.md.
+        //
+        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a block
+        // Test function (`lives-ok { $b<a> = 42 }`) mutates a captured-outer
+        // Set/Bag/Mix through env, which `writeback_carrier_writes` leaves to the
+        // (now-removable) blanket pull. Snapshot the caller frame's slot-backing env
+        // values for the COW aggregate types (scalars + Set/Bag/Mix) before the
+        // carrier, then write through only the slots whose env value changed. Plain
+        // Array/Hash and Instance slots are deliberately excluded (see
+        // `is_carrier_writeback_aggregate`). Armed only under boxing; the default
+        // build keeps the blanket pull (byte-identical).
+        let armed = self.cell_boxing_active();
+        let pre_env: Vec<Option<Value>> = if armed {
+            code.locals
+                .iter()
+                .map(|n| self.carrier_snapshot_env_value(n))
+                .collect()
+        } else {
+            Vec::new()
+        };
         let carrier_saved = self.begin_carrier();
         let exec_result = loan_env!(self, exec_call_pairs_values(&name, args));
         let written = self.end_carrier(carrier_saved);
         exec_result?;
         self.writeback_carrier_writes(code, &written);
+        if armed {
+            self.carrier_writeback_changed_aggregates(code, &pre_env);
+        }
         self.env_dirty = true;
         // Stage 3: a block-taking Test function (`lives-ok { ... }`,
         // `throws-like`, ...) routes here (its `__mutsu_test_callsite_line`

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -422,6 +422,68 @@ impl Interpreter {
         written
     }
 
+    /// Snapshot the env value backing local `name` for the carrier aggregate
+    /// writeback (`carrier_writeback_changed_aggregates`). Returns the value only
+    /// for the *cell-free aggregate* types it reconciles (scalar / Set / Bag /
+    /// Mix / Instance); anything else (plain Array/Hash, binding cells) snapshots
+    /// as `None` so the post-carrier diff never overwrites it. Resolves the
+    /// sigil-stripped fallback key the same way the blanket reconcile does.
+    pub(super) fn carrier_snapshot_env_value(&self, name: &str) -> Option<Value> {
+        let v = self.env().get(name).cloned().or_else(|| {
+            name.strip_prefix('$')
+                .or_else(|| name.strip_prefix('@'))
+                .or_else(|| name.strip_prefix('%'))
+                .or_else(|| name.strip_prefix('&'))
+                .and_then(|b| self.env().get(b).cloned())
+        })?;
+        if Self::is_carrier_writeback_aggregate(&v) {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Whether `v` is a cell-free aggregate the carrier writeback may overwrite a
+    /// slot with: a writeback-safe scalar, or a Set/Bag/Mix. Those use COW
+    /// `Arc<…Data>` storage, so a carrier's in-place mutation detaches a fresh Arc
+    /// (the pre-carrier snapshot still holds the old one) and the post-carrier diff
+    /// reliably detects the change. Plain Array/Hash are excluded (env may hold a
+    /// COW-detached copy that would clobber a live interior `:=` element cell), and
+    /// so is `Instance`: its attributes live in a *shared* `Arc<RwLock>` cell that
+    /// mutates in place, so the snapshot shares the cell and the diff can never see
+    /// the change — the Instance rw-accessor surface needs its own slice.
+    pub(super) fn is_carrier_writeback_aggregate(v: &Value) -> bool {
+        Self::is_writeback_safe_scalar(v)
+            || matches!(v, Value::Set(..) | Value::Bag(..) | Value::Mix(..))
+    }
+
+    /// Post-carrier (`lives-ok { … }` / block Test fn) precise writeback for
+    /// cell-free aggregate caller lexicals: for each local whose env value is now
+    /// a different aggregate than `pre_env[i]`, write it through to the slot. The
+    /// double-OFF replacement for the blanket reconcile, restricted to the types
+    /// that carry no live `:=` cell. Skips `!attr` and live binding-cell slots.
+    pub(super) fn carrier_writeback_changed_aggregates(
+        &mut self,
+        code: &CompiledCode,
+        pre_env: &[Option<Value>],
+    ) {
+        for (i, name) in code.locals.iter().enumerate() {
+            if name.starts_with('!')
+                || matches!(
+                    self.locals[i],
+                    Value::HashSlotRef { .. } | Value::ContainerRef(_)
+                )
+            {
+                continue;
+            }
+            let cur = self.carrier_snapshot_env_value(name);
+            let Some(cur) = cur else { continue };
+            if pre_env.get(i).map(|p| p.as_ref()) != Some(Some(&cur)) {
+                self.locals[i] = cur;
+            }
+        }
+    }
+
     /// A local value that is safe to overwrite from env during a carrier
     /// writeback: an immutable, cell-free scalar. A container (Array/Hash/...),
     /// an Instance, or a binding cell/ref may hold *live* `:=` cells whose


### PR DESCRIPTION
## Summary

env_dirty substrate slice S11。roast double-OFF surface **20 → 17**（1 修正で set-types 3 file 消化）。

A block Test function (`lives-ok { \$b<a> = 42 }` / `dies-ok`, the `exec_call_pairs_op` carrier) mutates a captured-outer Set/Bag/Mix through env. `writeback_carrier_writes` conservatively skips container slots (leaving them to the blanket pull), so the slot stayed stale once env_dirty is removed (double-OFF: `\$b<a>` read the original count, not the assigned value).

## Fix

Snapshot the caller frame's slot-backing env values before the carrier and, after it, write through only the slots whose env value **changed** — restricted to the COW aggregate types (scalars + Set/Bag/Mix). `Value::Set/Bag/Mix(Arc<…Data>)` use copy-on-write storage, so an in-place carrier mutation detaches a fresh Arc (the pre-carrier snapshot still holds the old one) and the diff reliably detects the change.

**Deliberately excluded:**
- **Array/Hash** — env may hold a COW-detached copy that would clobber a live interior `:=` element cell.
- **Instance** — its attributes live in a *shared* `Arc<RwLock>` cell that mutates in place, so the snapshot shares the cell and the diff can never see the change. The Instance rw-accessor surface (`S14-roles/rw.t`) needs its own slice.

Gated by `cell_boxing_active()`: the default build keeps the blanket pull (byte-identical; verified inert in default).

## Test

- pins: `roast/S02-types/{baghash,mixhash,set}.t` PASS in default **and** double-OFF.
- regression: `S03-binding/{nested,arrays}.t` + `t/element-bind-cell.t` stay green in double-OFF (no `:=` hazard).
- `make test` 9963 PASS, clippy/fmt clean.

残 roast double-OFF 17。設計 = `docs/captured-outer-cell-sharing.md` §10.14。

🤖 Generated with [Claude Code](https://claude.com/claude-code)