### PR TITLE
feat(single-store): broaden lives-ok carrier writeback to slot-overwritable (env_dirty substrate S12) — roast double-OFF 17→11

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -63,13 +63,15 @@
     25→0 が前提。**S8（#3418・25→22）= user `.defined`（andthen/orelse/notandthen）**（CallDefined snapshot・1 修正 3 file）。
     **S9（#3419・22→21）= symbolic-deref store（`$::()=`/`::('$x')=`）**（`note_caller_env_write` ログ・scalar）。
     **S10（#3421・21→20）= user Proxy STORE（lvalue sub）**（`assign_proxy_lvalue` の env scalar スナップショット差分）。
-    **S11（#TBD・20→17）= lives-ok container carrier の Set/Bag/Mix writeback**（`exec_call_pairs_op` の COW aggregate
-    スナップショット差分・Array/Hash と Instance は除外）。残 17 = S14 roles 5（うち rw.t = Instance rw-accessor の
-    shared-cell・snapshot 不可・別手法要）／S02 names our.t 1（EVAL+class+`$GLOBAL::`）／Pair rw aliasing（kv/pointy-rw 2）／
-    その他（docs §10.10 にカテゴリ表）。
+    **S11（#3426・20→17）= lives-ok container carrier の Set/Bag/Mix writeback**（`exec_call_pairs_op` のスナップショット差分）。
+    **S12（#TBD・17→11）= 同 writeback の eligibility を slot-overwritable に拡張**（「上書きされる slot の現在値型」で判定＝
+    `slot_carrier_overwritable`・`HashSlotRef`/`ContainerRef`/plain Array/Hash のみ除外）。**さらに 6 file 消化**（our／
+    pointy-rw／gather／coercion-methods／rw／kv）。残 11 = S14 `does`-mixin 4（anonymous/mixin-6e/parameterized-mixin/
+    submethods-6e＝block-scoped 再代入が outer env に届かない別機構）／lazy-lists／terminator／named-parameters／primitives／
+    defer-next／cas-loop／throttle。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = roast double-OFF 17→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
+- **∴ 次 = roast double-OFF 11→0 を slice で消化 → `env_dirty` 物理削除（§2-E）**:
   `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -818,3 +818,18 @@ in-place 変異で `make_mut` が COW し新 Arc へ detach する（pre snapsho
 rw-accessor は別スライス＝S14-roles/rw.t に残置）。`cell_boxing_active()` ガード＝default はバイト不変。
 回帰確認: element-bind-cell/S03-binding nested・arrays/set・mix 全 PASS（`:=` hazard なし）。pin=roast/S02-types/{baghash,
 mixhash,set}.t（double-OFF で PASS 化）。**残 roast double-OFF 17**（rw.t Instance rw-accessor 含む）。
+
+### 10.15 slice S12（2026-06-22）— lives-ok carrier writeback の eligibility を slot-overwritable に拡張（roast 17→11）
+
+S11（§10.14）は carrier writeback を **COW aggregate（scalar + Set/Bag/Mix）に限定**したが、これは「新しい env 値の型」で
+判定していたため取りこぼしが多かった。S12 は eligibility を **「上書きされる slot の*現在値*の型」**（`slot_carrier_overwritable`）
+へ転換: 除外は `HashSlotRef`/`ContainerRef`（`:=` binding cell）と plain `Array`/`Hash`（env COW-detach コピーが interior
+`:=` element cell を破壊する hazard）の**2 種のみ**で、それ以外（scalar/Set/Bag/Mix/Mixin/Instance/…）はすべて write-through
+対象。これで `lives-ok { $a does Role[42] }`（Int(0) slot → Mixin・型変化）/ `lives-ok { $obj.r1++ }`（Instance rw-accessor・
+diverged Instance）/ Pair `.kv`/`.values` rw aliasing / `$GLOBAL::`++ も拾える。Instance の in-place attribute 変異は
+shared `Arc<RwLock>` cell で pre==post になり diff 不発火＝無害（genuine な値/型変化のみ write-through）。**全 roast double-OFF
+sweep で 17→11（新規回帰ゼロ・残 11 全て pre-existing）＝S11 比でさらに 6 file 消化**（S02-names/our・S04 pointy-rw・S04
+gather・S12 coercion-methods・S14 rw・S32 kv）。`cell_boxing_active()` ガード＝default はバイト不変。回帰確認: S03-binding
+nested/arrays・element-bind-cell 全 PASS。**残 roast double-OFF 11**: S14 `does`-mixin block-scoped 再代入 4（anonymous/
+mixin-6e/parameterized-mixin/submethods-6e＝block 内 `$a does R` 再代入が outer env に届かない・次スライス）／lazy-lists／
+terminator／named-parameters／primitives／defer-next／cas-loop／throttle。

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -179,20 +179,17 @@ impl Interpreter {
         // coherence (the CP-2 wall; t/element-bind-cell.t). See docs/vm-single-store.md.
         //
         // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a block
-        // Test function (`lives-ok { $b<a> = 42 }`) mutates a captured-outer
-        // Set/Bag/Mix through env, which `writeback_carrier_writes` leaves to the
-        // (now-removable) blanket pull. Snapshot the caller frame's slot-backing env
-        // values for the COW aggregate types (scalars + Set/Bag/Mix) before the
-        // carrier, then write through only the slots whose env value changed. Plain
-        // Array/Hash and Instance slots are deliberately excluded (see
-        // `is_carrier_writeback_aggregate`). Armed only under boxing; the default
-        // build keeps the blanket pull (byte-identical).
+        // Test function (`lives-ok { $b<a> = 42 }` / `lives-ok { $a does Role }`)
+        // mutates a captured-outer caller lexical through env, which
+        // `writeback_carrier_writes` leaves to the (now-removable) blanket pull.
+        // Snapshot the caller frame's slot-backing env values for the overwritable
+        // slots before the carrier, then write through only the slots whose env
+        // value changed. Plain Array/Hash and binding-cell slots are excluded (see
+        // `slot_carrier_overwritable`). Armed only under boxing; the default build
+        // keeps the blanket pull (byte-identical).
         let armed = self.cell_boxing_active();
         let pre_env: Vec<Option<Value>> = if armed {
-            code.locals
-                .iter()
-                .map(|n| self.carrier_snapshot_env_value(n))
-                .collect()
+            self.snapshot_carrier_overwritable_env(code)
         } else {
             Vec::new()
         };

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -422,62 +422,71 @@ impl Interpreter {
         written
     }
 
-    /// Snapshot the env value backing local `name` for the carrier aggregate
-    /// writeback (`carrier_writeback_changed_aggregates`). Returns the value only
-    /// for the *cell-free aggregate* types it reconciles (scalar / Set / Bag /
-    /// Mix / Instance); anything else (plain Array/Hash, binding cells) snapshots
-    /// as `None` so the post-carrier diff never overwrites it. Resolves the
-    /// sigil-stripped fallback key the same way the blanket reconcile does.
-    pub(super) fn carrier_snapshot_env_value(&self, name: &str) -> Option<Value> {
-        let v = self.env().get(name).cloned().or_else(|| {
+    /// Resolve the env value backing local `name` (with the sigil-stripped
+    /// fallback the blanket reconcile uses). Raw — no type filter.
+    fn carrier_env_value(&self, name: &str) -> Option<Value> {
+        self.env().get(name).cloned().or_else(|| {
             name.strip_prefix('$')
                 .or_else(|| name.strip_prefix('@'))
                 .or_else(|| name.strip_prefix('%'))
                 .or_else(|| name.strip_prefix('&'))
                 .and_then(|b| self.env().get(b).cloned())
-        })?;
-        if Self::is_carrier_writeback_aggregate(&v) {
-            Some(v)
-        } else {
-            None
-        }
+        })
     }
 
-    /// Whether `v` is a cell-free aggregate the carrier writeback may overwrite a
-    /// slot with: a writeback-safe scalar, or a Set/Bag/Mix. Those use COW
-    /// `Arc<…Data>` storage, so a carrier's in-place mutation detaches a fresh Arc
-    /// (the pre-carrier snapshot still holds the old one) and the post-carrier diff
-    /// reliably detects the change. Plain Array/Hash are excluded (env may hold a
-    /// COW-detached copy that would clobber a live interior `:=` element cell), and
-    /// so is `Instance`: its attributes live in a *shared* `Arc<RwLock>` cell that
-    /// mutates in place, so the snapshot shares the cell and the diff can never see
-    /// the change — the Instance rw-accessor surface needs its own slice.
-    pub(super) fn is_carrier_writeback_aggregate(v: &Value) -> bool {
-        Self::is_writeback_safe_scalar(v)
-            || matches!(v, Value::Set(..) | Value::Bag(..) | Value::Mix(..))
+    /// Whether the carrier writeback may overwrite a slot *currently* holding `v`.
+    /// Eligibility is keyed on what the slot WOULD LOSE, not on the incoming value
+    /// (so an `Int` slot that a carrier turns into a `Mixin` via `does` is fine).
+    /// Excludes the binding cells (`HashSlotRef`/`ContainerRef`) and a plain
+    /// `Array`/`Hash` slot — env may hold a COW-detached copy whose write would
+    /// clobber a live interior `:=` element cell. Scalars, Set/Bag/Mix, Mixin,
+    /// Instance and the rest are safe targets (the whole slot value is replaced).
+    /// (Note: an Instance mutated *in place* through its shared `Arc<RwLock>`
+    /// attribute cell snapshots equal pre/post, so the diff never fires for it —
+    /// only a genuine value/type change writes through.)
+    fn slot_carrier_overwritable(v: &Value) -> bool {
+        !matches!(
+            v,
+            Value::HashSlotRef { .. } | Value::ContainerRef(_) | Value::Array(..) | Value::Hash(..)
+        )
     }
 
-    /// Post-carrier (`lives-ok { … }` / block Test fn) precise writeback for
-    /// cell-free aggregate caller lexicals: for each local whose env value is now
-    /// a different aggregate than `pre_env[i]`, write it through to the slot. The
-    /// double-OFF replacement for the blanket reconcile, restricted to the types
-    /// that carry no live `:=` cell. Skips `!attr` and live binding-cell slots.
+    /// Snapshot the slot-backing env values before a `lives-ok`/`dies-ok` carrier
+    /// runs, for the locals whose slot is overwritable. `None` entries (cell /
+    /// Array / Hash slots, or absent env keys) are never written back.
+    pub(super) fn snapshot_carrier_overwritable_env(
+        &self,
+        code: &CompiledCode,
+    ) -> Vec<Option<Value>> {
+        code.locals
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                if name.starts_with('!') || !Self::slot_carrier_overwritable(&self.locals[i]) {
+                    None
+                } else {
+                    self.carrier_env_value(name)
+                }
+            })
+            .collect()
+    }
+
+    /// Post-carrier (`lives-ok { … }` / block Test fn) precise writeback: for each
+    /// overwritable slot whose env value changed during the carrier, write the new
+    /// env value through to the slot. The double-OFF replacement for the blanket
+    /// reconcile, restricted to slots that carry no live `:=` cell.
     pub(super) fn carrier_writeback_changed_aggregates(
         &mut self,
         code: &CompiledCode,
         pre_env: &[Option<Value>],
     ) {
         for (i, name) in code.locals.iter().enumerate() {
-            if name.starts_with('!')
-                || matches!(
-                    self.locals[i],
-                    Value::HashSlotRef { .. } | Value::ContainerRef(_)
-                )
-            {
+            if name.starts_with('!') || !Self::slot_carrier_overwritable(&self.locals[i]) {
                 continue;
             }
-            let cur = self.carrier_snapshot_env_value(name);
-            let Some(cur) = cur else { continue };
+            let Some(cur) = self.carrier_env_value(name) else {
+                continue;
+            };
             if pre_env.get(i).map(|p| p.as_ref()) != Some(Some(&cur)) {
                 self.locals[i] = cur;
             }


### PR DESCRIPTION
## Summary

env_dirty substrate slice S12（S11 #3426 の拡張）。**roast double-OFF surface 17 → 11**（S11 比でさらに 6 file 消化・新規回帰ゼロ）。

S11 restricted the lives-ok/dies-ok carrier slot writeback to COW aggregates (scalar + Set/Bag/Mix), keyed on the *incoming* env value's type. That missed many shapes. S12 keys eligibility on the **slot's current value** instead (`slot_carrier_overwritable`): only `HashSlotRef`/`ContainerRef` (`:=` binding cells) and plain `Array`/`Hash` slots (env may hold a COW-detached copy that would clobber a live interior `:=` element cell) are excluded; everything else (scalar/Set/Bag/Mix/Mixin/Instance/…) is a whole-value write-through target.

This now reconciles:
- `lives-ok { \$a does Role[42] }` (Int slot → Mixin, a type change)
- `lives-ok { \$obj.r1++ }` (Instance rw-accessor, a diverged Instance)
- Pair `.kv`/`.values` rw aliasing
- `\$GLOBAL::`++ inside a carrier

An Instance mutated in place through its shared `Arc<RwLock>` attribute cell snapshots equal pre/post, so the diff fires only on a genuine value/type change (harmless no-op otherwise).

Gated by `cell_boxing_active()`: the default build keeps the blanket pull (byte-identical; the snapshot/diff never runs in default).

## Validation

- **Full roast whitelist double-OFF sweep: 17 → 11** (no new failures; the 11 remaining are all pre-existing). Six more files clear vs S11: `S02-names/our`, `S04-blocks-and-statements/pointy-rw`, `S04-statements/gather`, `S12-coercion/coercion-methods`, `S14-roles/rw`, `S32-hash/kv`.
- Regression: `S03-binding/{nested,arrays}` + `t/element-bind-cell` stay green in double-OFF.
- `make test` running; clippy/fmt clean.

残 roast double-OFF 11（S14 `does`-mixin block-scoped 再代入 4 + lazy-lists/terminator/named-parameters/primitives/defer-next/cas-loop/throttle）。設計 = `docs/captured-outer-cell-sharing.md` §10.15。

🤖 Generated with [Claude Code](https://claude.com/claude-code)