### PR TITLE
feat(pack): implement pack/unpack + recognize `use experimental :pack`

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1344,3 +1344,22 @@ string` で die していた。
   この corner を踏むテストは存在しない。正しい解（Option A: Blob 専用 itemization マーカー）はスカラ代入経路全般に触れるため
   深く、本スライスでは見送り。
 - `t/blob-for-iteration.t`（11 件）。whitelist の Buf/Blob roast 10 ファイルは全て引き続きパス。
+
+## 2026-06-22 (session 11): `pack` / `unpack`（experimental）— `use experimental :pack` 認識 + バイナリシリアライズ
+
+`use experimental :pack` を no-op pragma として認識し、`pack` / `unpack` を一般 builtin として実装。バイナリプロトコル
+（クッキー・セッション・ネットワークバイトオーダー）を扱う weblog コードに有用。`src/builtins/pack.rs`。
+
+- **テンプレート**（raku-doc `Blob.unpack` のサブセット。Perl より小さい）: `A`/`a`/`Z`（文字列）、`C`（1 バイト整数）、
+  `H`（hex 文字列）、`S`/`v`（リトルエンディアン u16）、`n`（ビッグエンディアン u16）、`L`/`V`（リトルエンディアン u32）、
+  `N`（ビッグエンディアン u32）、`x`（null バイト）。
+- **Rakudo quirk を再現**: 数値レターの count は `pack` では実質無視され（`pack("C3",65,66,67)` は 1 バイト `65` のみ、
+  `pack("S2",a,b)` は `a` のみ）、各数値ユニットは 1 アイテムを消費。反復はレター反復（`"S" x $n`）で表現。`unpack` では
+  count は意味を持つ（`"C*"` は残り全バイト抽出）。`unpack` は結果 1 要素のときベア値（`Int`）に collapse（raku 一致）。
+- **配線**: `experimental` を compiler の no-op pragma リストに追加。`pack`/`unpack` を `BUILTIN_FUNCTION_NAMES` と
+  `native_function_variadic` に追加（arity 非依存ルーティング＝`chrs` と同方式）。`pack` は末尾アイテムを flatten
+  （`pack 'S' x N, $list` が単一 List 引数を個別要素として見えるよう）。`unpack` の sub 形式は Blob（Instance）引数を取るため
+  `try_native_function` の Instance ゲートを通す例外に追加。メソッド形式 `.unpack` は `methods_dispatch_match.rs` に追加。
+- **テスト**: `t/pack-unpack.t`（24 件、全て raku でも PASS）。副産物として MIME::Base64 の `binary-and-long-line.rakutest`
+  が 0→7/11 に改善（残り 4 は `blob16`/`blob8` 型付き Blob 宣言 + UTF-16 encode/decode 待ち＝別機能）。roast 影響なし
+  （`pack` を使う roast テストは存在しない）。

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -294,6 +294,10 @@ pub(crate) fn native_function(
     if name == "chrs" {
         return native_function_variadic(name, args);
     }
+    // pack/unpack take a template plus a variable item list; route every arity.
+    if name == "pack" || name == "unpack" {
+        return native_function_variadic(name, args);
+    }
     if name == "zip" {
         if args
             .iter()
@@ -1609,6 +1613,25 @@ fn is_extrema_named_pair(v: &Value) -> bool {
 
 fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, RuntimeError>> {
     match name {
+        "pack" => {
+            // pack(Str $template, *@items) — flatten the trailing items so
+            // `pack 'S' x $n, $list` (one List arg) sees individual elements.
+            let template = args.first().map(Value::to_string_value).unwrap_or_default();
+            let mut items = Vec::new();
+            for a in args.iter().skip(1) {
+                flat_val(a, &mut items, true);
+            }
+            Some(crate::builtins::pack::pack(&template, &items))
+        }
+        "unpack" => {
+            // unpack(Blob $blob, Str $template)
+            let bytes = args
+                .first()
+                .map(crate::runtime::Interpreter::extract_buf_bytes)
+                .unwrap_or_default();
+            let template = args.get(1).map(Value::to_string_value).unwrap_or_default();
+            Some(crate::builtins::pack::unpack(&bytes, &template))
+        }
         "min" => {
             if args.is_empty() {
                 return Some(Ok(Value::Nil));

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -11,6 +11,7 @@ mod functions;
 pub(crate) mod iterator_construct;
 pub(crate) mod methods_0arg;
 mod methods_narg;
+pub(crate) mod pack;
 pub(crate) mod parse_base;
 pub(crate) mod primality;
 pub(crate) mod quanthash_coerce;

--- a/src/builtins/pack.rs
+++ b/src/builtins/pack.rs
@@ -1,0 +1,250 @@
+//! `pack` / `unpack` (experimental, `use experimental :pack`).
+//!
+//! Raku's pack template is a smaller, and quirkier, set than Perl's. The
+//! letters mutsu supports mirror the table in `raku-doc` (Blob `unpack`):
+//!
+//! | Letter | Meaning                                                |
+//! |--------|--------------------------------------------------------|
+//! | A a Z  | string — each byte is one codepoint (pack: field bytes)|
+//! | C      | one element as an 8-bit integer                        |
+//! | H      | hex string                                             |
+//! | S v    | two bytes, little-endian unsigned                      |
+//! | n      | two bytes, big-endian ("network") unsigned             |
+//! | L V    | four bytes, little-endian unsigned                     |
+//! | N      | four bytes, big-endian ("network") unsigned            |
+//! | x      | a null byte (pack) / drop a byte (unpack)              |
+//!
+//! Rakudo treats a numeric letter's count as a no-op for `pack` (e.g.
+//! `pack("C3", 65, 66, 67)` packs a single byte `65`, and `pack("S2", a, b)`
+//! packs only `a`); each numeric unit consumes exactly one item. Repetition is
+//! expressed by repeating the letter (`"S" x $n`). mutsu matches that. For
+//! `unpack` the count is meaningful (`"C*"` extracts every remaining byte).
+
+use crate::value::{RuntimeError, Value};
+
+/// A single parsed template unit: a letter plus an optional count.
+struct Unit {
+    letter: char,
+    /// `Some(n)` for a fixed count, `None` for `*`, absent quantifier defaults
+    /// to `Some(1)`.
+    count: Option<usize>,
+}
+
+/// Parse a pack/unpack template string into units. Whitespace between units is
+/// ignored; a quantifier is `*` or a positive integer.
+fn parse_template(template: &str) -> Result<Vec<Unit>, RuntimeError> {
+    let mut units = Vec::new();
+    let mut chars = template.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        if !c.is_ascii_alphabetic() {
+            return Err(RuntimeError::new(format!(
+                "Unrecognised pack template character: '{c}'"
+            )));
+        }
+        let letter = c;
+        chars.next();
+        // Skip whitespace between the letter and its quantifier.
+        while matches!(chars.peek(), Some(d) if d.is_whitespace()) {
+            chars.next();
+        }
+        let count = match chars.peek() {
+            Some('*') => {
+                chars.next();
+                None
+            }
+            Some(d) if d.is_ascii_digit() => {
+                let mut n = 0usize;
+                while let Some(d) = chars.peek() {
+                    if let Some(digit) = d.to_digit(10) {
+                        n = n.saturating_mul(10).saturating_add(digit as usize);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                Some(n)
+            }
+            _ => Some(1),
+        };
+        units.push(Unit { letter, count });
+    }
+    Ok(units)
+}
+
+fn item_to_u64(v: &Value) -> u64 {
+    crate::runtime::to_int(v) as u64
+}
+
+/// `pack(Str $template, *@items) --> Buf`
+pub(crate) fn pack(template: &str, items: &[Value]) -> Result<Value, RuntimeError> {
+    let units = parse_template(template)?;
+    let mut out: Vec<u8> = Vec::new();
+    let mut it = items.iter();
+
+    for unit in &units {
+        match unit.letter {
+            // String letters: one item, laid out as `count` bytes (pad/truncate).
+            'A' | 'a' | 'Z' => {
+                let s = it.next().map(Value::to_string_value).unwrap_or_default();
+                let bytes = s.into_bytes();
+                let pad = if unit.letter == 'A' { b' ' } else { 0u8 };
+                match unit.count {
+                    None => out.extend_from_slice(&bytes),
+                    Some(width) => {
+                        for i in 0..width {
+                            out.push(bytes.get(i).copied().unwrap_or(pad));
+                        }
+                    }
+                }
+            }
+            // Hex string: one item; `count` hex digits (`*` = all of them).
+            'H' => {
+                let s = it.next().map(Value::to_string_value).unwrap_or_default();
+                let digits: Vec<u8> = s
+                    .chars()
+                    .filter_map(|c| c.to_digit(16).map(|d| d as u8))
+                    .collect();
+                let take = unit.count.unwrap_or(digits.len()).min(digits.len());
+                let mut i = 0;
+                while i < take {
+                    let hi = digits[i];
+                    let lo = if i + 1 < take { digits[i + 1] } else { 0 };
+                    out.push((hi << 4) | lo);
+                    i += 2;
+                }
+            }
+            // Null bytes (pack); consumes no item.
+            'x' => {
+                out.resize(out.len() + unit.count.unwrap_or(1), 0);
+            }
+            // Numeric letters: one item each, count is a no-op (Rakudo quirk).
+            'C' | 'c' => {
+                let n = it.next().map_or(0, item_to_u64);
+                out.push(n as u8);
+            }
+            'S' | 'v' => {
+                let n = it.next().map_or(0, item_to_u64) as u16;
+                out.extend_from_slice(&n.to_le_bytes());
+            }
+            'n' => {
+                let n = it.next().map_or(0, item_to_u64) as u16;
+                out.extend_from_slice(&n.to_be_bytes());
+            }
+            'L' | 'V' => {
+                let n = it.next().map_or(0, item_to_u64) as u32;
+                out.extend_from_slice(&n.to_le_bytes());
+            }
+            'N' => {
+                let n = it.next().map_or(0, item_to_u64) as u32;
+                out.extend_from_slice(&n.to_be_bytes());
+            }
+            other => {
+                return Err(RuntimeError::new(format!(
+                    "Unsupported pack template character: '{other}'"
+                )));
+            }
+        }
+    }
+
+    Ok(crate::builtins::buf_write_num::make_buf_value("Buf", out))
+}
+
+/// `unpack(Blob $blob, Str $template) --> List`
+pub(crate) fn unpack(bytes: &[u8], template: &str) -> Result<Value, RuntimeError> {
+    let units = parse_template(template)?;
+    let mut out: Vec<Value> = Vec::new();
+    let mut pos = 0usize;
+
+    for unit in &units {
+        match unit.letter {
+            // String: `count` bytes mapped to codepoints, joined into one Str.
+            'A' | 'a' | 'Z' => {
+                let take = match unit.count {
+                    None => bytes.len().saturating_sub(pos),
+                    Some(n) => n.min(bytes.len().saturating_sub(pos)),
+                };
+                let mut s = String::new();
+                for _ in 0..take {
+                    s.push(bytes[pos] as char);
+                    pos += 1;
+                }
+                if unit.letter == 'Z' {
+                    s.truncate(s.find('\0').unwrap_or(s.len()));
+                }
+                out.push(Value::str(s));
+            }
+            // Hex string of `count` nibbles (`*` = all remaining bytes).
+            'H' => {
+                let take_bytes = match unit.count {
+                    None => bytes.len().saturating_sub(pos),
+                    Some(n) => n.div_ceil(2).min(bytes.len().saturating_sub(pos)),
+                };
+                let mut s = String::new();
+                for _ in 0..take_bytes {
+                    s.push_str(&format!("{:02x}", bytes[pos]));
+                    pos += 1;
+                }
+                if let Some(n) = unit.count {
+                    s.truncate(n.min(s.len()));
+                }
+                out.push(Value::str(s));
+            }
+            'x' => {
+                pos = (pos + unit.count.unwrap_or(1)).min(bytes.len());
+            }
+            // Numeric: count IS meaningful for unpack (`*` = rest of the blob).
+            'C' | 'c' => unpack_ints(&mut out, bytes, &mut pos, unit.count, 1, false),
+            'S' | 'v' => unpack_ints(&mut out, bytes, &mut pos, unit.count, 2, false),
+            'n' => unpack_ints(&mut out, bytes, &mut pos, unit.count, 2, true),
+            'L' | 'V' => unpack_ints(&mut out, bytes, &mut pos, unit.count, 4, false),
+            'N' => unpack_ints(&mut out, bytes, &mut pos, unit.count, 4, true),
+            other => {
+                return Err(RuntimeError::new(format!(
+                    "Unsupported unpack template character: '{other}'"
+                )));
+            }
+        }
+    }
+
+    // Raku's unpack collapses a single extracted value to the bare element
+    // (`Blob.new(0x34,0x12).unpack("S")` is an `Int`, not a one-element list).
+    if out.len() == 1 {
+        return Ok(out.into_iter().next().unwrap());
+    }
+    Ok(Value::array(out))
+}
+
+/// Extract integers of `width` bytes from `bytes` at `pos`. `count == None`
+/// (`*`) consumes the rest of the blob; `Some(n)` extracts up to `n` elements.
+fn unpack_ints(
+    out: &mut Vec<Value>,
+    bytes: &[u8],
+    pos: &mut usize,
+    count: Option<usize>,
+    width: usize,
+    big_endian: bool,
+) {
+    let mut remaining = match count {
+        None => usize::MAX,
+        Some(n) => n,
+    };
+    while remaining > 0 && *pos + width <= bytes.len() {
+        let mut val: u64 = 0;
+        if big_endian {
+            for i in 0..width {
+                val = (val << 8) | bytes[*pos + i] as u64;
+            }
+        } else {
+            for i in 0..width {
+                val |= (bytes[*pos + i] as u64) << (8 * i);
+            }
+        }
+        out.push(Value::Int(val as i64));
+        *pos += width;
+        remaining -= 1;
+    }
+}

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2614,7 +2614,11 @@ impl Compiler {
                     || module == "nqp"
                     || module == "soft"
                     || module == "oo"
-                    || module == "class" => {}
+                    || module == "class"
+                    // `use experimental :pack/:cached/:macros/...` enables
+                    // experimental features that mutsu provides unconditionally
+                    // (e.g. pack/unpack), so the pragma is a compile-time no-op.
+                    || module == "experimental" => {}
             Stmt::Use { module, .. } if module == "MONKEY-TYPING" || module == "MONKEY" => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
                 self.code.emit(OpCode::UseModule {

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -110,6 +110,8 @@ pub(crate) const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     "sprintf",
     "zprintf",
     "printf",
+    "pack",
+    "unpack",
     "uniname",
     "uninames",
     "uniprop",

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -95,6 +95,12 @@ impl Interpreter {
                 Some(self.dispatch_encode(&target, &args))
             }
             "decode" => self.dispatch_decode(&target, &args),
+            "unpack" if matches!(&target, Value::Instance { .. }) => {
+                // $blob.unpack($template) — experimental, mirrors the sub form.
+                let bytes = Self::extract_buf_bytes(&target);
+                let template = args.first().map(Value::to_string_value).unwrap_or_default();
+                Some(crate::builtins::pack::unpack(&bytes, &template))
+            }
             "subbuf" => self.dispatch_subbuf(&target, &args),
             "polymod" => Some(self.method_polymod(&target, &args)),
             "VAR" if args.is_empty() => {

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -333,7 +333,9 @@ impl Interpreter {
             // other native function bails out on Instance args (they may need
             // method dispatch) and falls through to the interpreter.
             let name = name_sym.resolve();
-            if !matches!(name.as_str(), "any" | "all" | "one" | "none") {
+            // `unpack(Blob, Str)` takes a Blob (Instance) argument and is
+            // handled natively; everything else bails out on Instance args.
+            if !matches!(name.as_str(), "any" | "all" | "one" | "none" | "unpack") {
                 return None;
             }
         }

--- a/t/pack-unpack.t
+++ b/t/pack-unpack.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+use experimental :pack;
+
+# pack / unpack (experimental). Raku's template set is smaller than Perl's:
+# A a Z (string), C (byte), H (hex), S v (LE u16), n (BE u16), L V (LE u32),
+# N (BE u32), x (null byte). Numeric letters consume one item each; repetition
+# is expressed by repeating the letter ("S" x $n).
+
+plan 24;
+
+# --- pack: integers ---
+is pack("C", 65).list, (65), 'pack C — single byte';
+is pack("CCC", 1, 2, 3).list, (1, 2, 3), 'pack CCC — three bytes';
+is pack("S", 0x1234).list, (0x34, 0x12), 'pack S — little-endian u16';
+is pack("v", 0x1234).list, (0x34, 0x12), 'pack v — little-endian u16 (alias)';
+is pack("n", 0x1234).list, (0x12, 0x34), 'pack n — big-endian u16';
+is pack("L", 0x01020304).list, (4, 3, 2, 1), 'pack L — little-endian u32';
+is pack("V", 0x01020304).list, (4, 3, 2, 1), 'pack V — little-endian u32 (alias)';
+is pack("N", 0x01020304).list, (1, 2, 3, 4), 'pack N — big-endian u32';
+
+# --- pack: numeric count is a no-op (Rakudo quirk); repeat the letter ---
+is pack("C3", 65, 66, 67).list, (65,), 'pack C3 — count ignored, one byte';
+is pack("SS", 0x1234, 0x5678).list, (0x34, 0x12, 0x78, 0x56), 'pack SS — two units';
+
+# --- pack: strings ---
+is pack("A3", "Hi").list, (72, 105, 32), 'pack A3 — space-padded to width';
+is pack("A*", "ABC").list, (65, 66, 67), 'pack A* — full string';
+is pack("a3", "Hi").list, (72, 105, 0), 'pack a3 — null-padded to width';
+is pack("H*", "deadbeef").list, (0xde, 0xad, 0xbe, 0xef), 'pack H* — hex string';
+
+# --- pack: null bytes ---
+is pack("x3").list, (0, 0, 0), 'pack x3 — null bytes';
+is pack("Cx2C", 1, 2).list, (1, 0, 0, 2), 'pack with embedded null bytes';
+
+# --- pack: the MIME::Base64 encoder pattern ---
+{
+    my @vals = (0x1234, 0x5678, 0x9abc);
+    is pack("S" x @vals.elems, @vals).list, (0x34, 0x12, 0x78, 0x56, 0xbc, 0x9a),
+        'pack "S" x N over a list (MIME pattern)';
+}
+
+# --- unpack: integers ---
+is Blob.new(1, 2, 3, 4).unpack("C*").join(','), '1,2,3,4', 'unpack C* — all bytes';
+is Blob.new(0x34, 0x12).unpack("S"), 4660, 'unpack S — collapses single value to Int';
+is Blob.new(0x34, 0x12).unpack("S").^name, 'Int', 'unpack single value is an Int, not a List';
+is Blob.new(0, 1, 0, 2).unpack("nn").join(','), '1,2', 'unpack nn — two big-endian u16';
+is Blob.new(1, 2, 3, 4).unpack("N"), 0x01020304, 'unpack N — big-endian u32';
+
+# --- unpack: strings ---
+is Blob.new(72, 105).unpack("A*"), 'Hi', 'unpack A* — bytes to string';
+
+# --- round trip ---
+is Blob.new(pack("N", 0xdeadbeef).list).unpack("N"), 0xdeadbeef, 'pack/unpack N round trip';


### PR DESCRIPTION
## What

Recognize `use experimental :pack` as a no-op pragma and implement **`pack`/`unpack`** as general builtins (`src/builtins/pack.rs`). Useful for binary protocols (cookies, sessions, network byte order) in weblog code.

## Template letters

Mirrors raku-doc's `Blob.unpack` subset (smaller than Perl's):

| Letter | Meaning |
|--------|---------|
| A a Z  | string (each byte ↔ codepoint) |
| C      | 8-bit integer |
| H      | hex string |
| S v    | little-endian u16 |
| n      | big-endian ("network") u16 |
| L V    | little-endian u32 |
| N      | big-endian ("network") u32 |
| x      | null byte (pack) / drop byte (unpack) |

## Rakudo quirk, faithfully reproduced

A numeric letter's count is a no-op for `pack` (`pack("C3", 65,66,67)` packs a single byte `65`; `pack("S2", a, b)` packs only `a`); each numeric unit consumes one item, and repetition is expressed by repeating the letter (`"S" x $n`). For `unpack` the count IS meaningful (`"C*"` extracts the rest), and a single extracted value collapses to a bare `Int` (matching raku).

## Wiring

- `experimental` added to the compiler's no-op pragma list.
- `pack`/`unpack` added to `BUILTIN_FUNCTION_NAMES` and routed through `native_function_variadic` regardless of arity (like `chrs`).
- `pack` flattens trailing items so `pack 'S' x N, $list` (one List arg) sees individual elements.
- `unpack`'s sub form takes a Blob (Instance) arg → allowed through the `try_native_function` Instance gate; the `.unpack` method form is added in `methods_dispatch_match.rs`.

## Tests

- `t/pack-unpack.t` (24 assertions), all verified to pass under `raku` too.
- Side effect: MIME::Base64's `binary-and-long-line` test improves **0 → 7/11** (the remaining 4 need `blob16`/`blob8` typed Blobs + UTF-16 encode/decode — a separate feature).
- No roast impact (no roast test uses pack); `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)