### PR TITLE
feat(single-store): EVAL carrier scalar-reassignment writeback to container slots (env_dirty substrate S18)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -81,12 +81,16 @@
     `call_how_method_recording_writeback`（HOW 呼び出し前後 env scalar スナップショット差分→`pending_caller_var_writeback`）
     経由に置換 → smartmatch op 末尾の `apply_pending_caller_var_writeback` が drain・primitives 消化）。**counter が
     read-modify-write なので文跨ぎで消える**のが厄介。S16 同様 ungated（custom-HOW dispatch 限定スコープ）。
-    **★writeback 候補は枯渇**（S16 proto-multi・S17 custom-HOW）。**残 3 は全て別軸**: ①lazy-lists（**laziness 別軸・
-    writeback でない**・L 系 lazy 化が前提）②throttle（timing・flaky 系・決定的 pin 不可）③terminator（auto-curly array
-    composer・**parser・writeback でない**）。**次セッション**: 残 3 が env_dirty 削除をブロックしないことを確認 → §2-E 着手。
+    **S18（#TBD・3→2）= EVAL carrier の scalar 再代入 writeback を container slot にも適用**（`my $z=[]; EVAL q'$z=1'`
+    の writeback が `writeback_carrier_writes`〔vm_env_helpers.rs〕で「古い slot 値が scalar か」判定だったため Array slot を
+    スキップ→上書き拒否→blanket reconcile 頼み。適格判定を**新 env 値が scalar か**＋slot が `:=` bind cell でないことに変更）。
+    **★terminator は「parser/auto-curly」誤分類で実体は EVAL writeback だった**（normal=z=1・double-OFF だけ z=[]）。一般的修正。
+    **★writeback 候補は枯渇**（S16 proto-multi・S17 custom-HOW・S18 EVAL container-slot scalar）。**残 2 は両方 writeback で
+    ない別軸**: ①lazy-lists（**laziness 別軸**・L 系 lazy 化が前提）②throttle（timing・flaky 系・決定的 pin 不可）。
+    **次セッション**: 残 2 が env_dirty 削除をブロックしないことを確認 → §2-E 着手。
 - **✅ env↔locals 純 writeback コヒーレンス（blanket ON 下）は完了**（slice 1〜1.20・#3400）。lazy-lists.t laziness も
   解消（#3403）。OFF roast survey（blanket OFF）の決定的サーフェスは IO-Socket-Async.t flaky のみ。
-- **∴ 次 = roast double-OFF 残 3（別軸＝laziness/timing/parser）が env_dirty 削除をブロックしないか確認 → `env_dirty` 物理削除（§2-E）**:
+- **∴ 次 = roast double-OFF 残 2（別軸＝laziness/timing）が env_dirty 削除をブロックしないか確認 → `env_dirty` 物理削除（§2-E）**:
   `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/
   `saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
 

--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -919,22 +919,36 @@ re-flush し increment が文跨ぎで消える（double-OFF で find=4→1・ch
 `$obj~~T;$obj~~U;` の default 潜在バグも直す）。pin=`t/custom-how-type-check-writeback-coherence.t`（6・ON/OFF 両 PASS）。
 **残 roast double-OFF 3**: lazy-lists（laziness 別軸）／throttle（timing・flaky 系）／terminator（auto-curly composer・parser）。
 
-### 10.19 ハンドオフ — roast double-OFF 残 3（S17 後・2026-06-22）
+### 10.22 slice S18（2026-06-22）— EVAL carrier の scalar 再代入 writeback を container slot にも適用（roast 3→2）
 
-S4〜S17（15 slice）で **roast double-OFF surface 25 → 3**。全 whitelist（1285）の double-OFF sweep
-（`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release）で確定した残 3（**全て writeback でない別軸**・新規回帰ゼロ）:
+`my $z = []; EVAL q'$z = do { 1 } + 2;'; is $z, 1` = EVAL carrier が captured-outer caller scalar `$z` を **container を
+保持していた slot に** scalar 再代入する。**真因＝`writeback_carrier_writes`（vm_env_helpers.rs）の reconcile 適格判定が
+「古い slot 値が scalar か」だった**: `my $z = []`（slot=Array）→ EVAL の `$z = 1`（env=Int）writeback 時、slot の現在値が
+Array なので scalar 分岐をスキップ → container 保護分岐（COW `:=` cell hazard 回避で上書き拒否）→ blanket reconcile
+（double-OFF で no-op）頼みになり slot が stale Array のまま。**この case は誤って「parser（auto-curly）」と分類されていたが
+実体は EVAL carrier scalar writeback**（normal は z=1・auto-curly parse は正常・double-OFF だけ z=[]）。**修正**: 適格判定を
+**新しい env 値が scalar か**に変更（`is_writeback_safe_scalar(&env_val)` ＋ slot が `:=` bind cell＝`ContainerRef`/`HashSlotRef`
+でないこと）。scalar 新値は container COW-copy hazard を持たないので、slot が以前 container を持っていても安全に上書き可。
+`my @e = …; EVAL q'@e = 7,8'`（container→container）は新値が container なので従来の保護分岐のまま＝非該当。`:=` bind cell
+（`t/element-bind-cell.t`・`S03-binding/nested.t`・`arrays.t`）両モード PASS で回帰なし。pin=`t/eval-carrier-scalar-writeback-coherence.t`
+（6・ON/OFF 両 PASS）。**この修正は一般的**（任意の `EVAL q'$x = scalar'` で container を持っていた slot を救う）。
+**残 roast double-OFF 2**: lazy-lists（laziness 別軸）／throttle（timing・flaky 系）。
+
+### 10.19 ハンドオフ — roast double-OFF 残 2（S18 後・2026-06-22）
+
+S4〜S18（16 slice）で **roast double-OFF surface 25 → 2**。全 whitelist（1285）の double-OFF sweep
+（`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release）で確定した残 2（**両方 writeback でない別軸**・新規回帰ゼロ）:
 
 | file | サブテスト | 種別 | 次の一手 |
 |---|---|---|---|
 | `S02-types/lazy-lists.t` | 14,16 | **別軸（laziness）** | `grep is lazy`/`map is lazy`。writeback でなく lazy 化の問題（L 系）。env_dirty とは独立。 |
 | `S17-supply/throttle.t` | 3,4 | **別軸（timing）** | `.5〜.8 秒差`のタイミングアサート。flaky 系。env_dirty と無関係の可能性大。 |
-| `S04-statements/terminator.t` | 12 | **別軸（parser）** | `auto-curly applies inside array composer`。parser の問題で writeback でない。 |
 
-**∴ writeback 候補は枯渇**（S16 proto-multi・S17 custom-HOW で消化）。**残 3 は全て別軸**（laziness/timing/parser）で、
-env_dirty 物理削除の前提から外せるか精査が必要: ①lazy-lists＝`grep/map is lazy`（L 系・別途 lazy 化が前提・writeback では
-解けない）②throttle＝timing flaky（決定的 pin 不可・env_dirty と無関係の可能性大）③terminator＝parser（auto-curly・別軸）。
-**次セッション**: これら 3 が env_dirty 削除をブロックしないことを確認（lazy-lists の double-OFF fail が writeback でなく純粋に
-laziness 由来か、throttle が flaky か、terminator が parser-only か）→ ブロックしなければ §7.4 / PLAN §2-E（`env_dirty` 物理削除：
+**∴ writeback 候補は枯渇**（S16 proto-multi・S17 custom-HOW・S18 EVAL container-slot scalar writeback で消化）。**残 2 は
+両方 writeback でない別軸**（laziness/timing）。**★terminator は parser 誤分類で実体は EVAL writeback だった（S18 で消化）＝
+ハンドオフの「別軸」分類は要再検証の教訓**。**次セッション**: 残 2 が env_dirty 削除をブロックしないことを確認（lazy-lists の
+double-OFF fail が writeback でなく純粋に laziness 由来か、throttle が flaky か・両方とも writeback-snapshot 機構では拾えない）
+→ ブロックしなければ §7.4 / PLAN §2-E（`env_dirty` 物理削除：
 `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/`saved_env_dirty`
 削除 → `cell_boxing_active()` gate 撤去）に着手できる。診断ファイル＝`tmp/roast-double-off-final-fails.txt`。
 **★S16/S17 の共通教訓**: slow path（`run_instance_method_resolved`）経由の dispatch（proto-multi 候補・custom HOW メソッド）は

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -645,7 +645,25 @@ impl Interpreter {
             // A plain scalar is safe to copy from env: it carries no live `:=`
             // cell, so overwriting the slot cannot clobber shared state. This is
             // the common EVAL case (`$x = scalar`).
-            if Self::is_writeback_safe_scalar(&self.locals[i]) {
+            //
+            // The eligibility is on the *new env value*, not the old slot value:
+            // when the carrier reassigned the variable to a plain scalar (the env
+            // now holds e.g. `Int(1)`), writing it through is safe regardless of
+            // what the slot held before — there is no container COW-copy hazard in
+            // a scalar value. This covers `my $a = []; EVAL q'$a = 1'` (slot held
+            // an Array, env now holds a scalar), which the old "slot is a scalar"
+            // test missed, leaving it to the blanket reconcile (a no-op under
+            // double-OFF, so `$a` stayed the stale Array). The only excluded slots
+            // are live `:=` binding cells (ContainerRef/HashSlotRef), where the
+            // slot must keep routing through the bound cell.
+            let new_is_scalar = Self::is_writeback_safe_scalar(&env_val);
+            let slot_is_bind_cell = matches!(
+                &self.locals[i],
+                Value::ContainerRef(_) | Value::HashSlotRef { .. }
+            );
+            if Self::is_writeback_safe_scalar(&self.locals[i])
+                || (new_is_scalar && !slot_is_bind_cell)
+            {
                 self.locals[i] = env_val;
                 continue;
             }

--- a/t/eval-carrier-scalar-writeback-coherence.t
+++ b/t/eval-carrier-scalar-writeback-coherence.t
@@ -1,0 +1,51 @@
+use Test;
+
+# env<->locals coherence (env_dirty substrate, docs/captured-outer-cell-sharing.md
+# §10): an `EVAL` carrier that reassigns a captured-outer caller variable to a
+# plain scalar (`EVAL q'$x = 1'`) writes the new value into env, and the carrier
+# writeback reconciles it into the caller's local slot. The reconcile eligibility
+# is on the *new env value* (a plain scalar carries no `:=` cell), so it must fire
+# even when the slot previously held a container (`my $x = []; EVAL q'$x = 1'`) —
+# the old "slot is a scalar" test missed that, leaving it to the blanket reconcile
+# (a no-op under double-OFF). Each subtest must hold with blanket reconcile ON
+# (default) AND OFF (`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`).
+
+plan 6;
+
+{
+    my $a = [];
+    EVAL q'$a = 1';
+    is $a, 1, 'EVAL scalar assignment overwrites a container slot';
+}
+{
+    my $b = [];
+    EVAL q'$b = do { 5 }';
+    is $b, 5, 'EVAL do-block scalar assignment overwrites a container slot';
+}
+{
+    my $c = {};
+    EVAL q'$c = 7 + 2';
+    is $c, 9, 'EVAL scalar assignment overwrites a hash-valued slot';
+}
+{
+    # The auto-curly terminator case from roast/S04-statements/terminator.t.
+    my $z = [];
+    EVAL q'
+        $z = do { 1 }
+                + 2;
+    ';
+    is $z, 1, 'auto-curly applies inside array composer (EVAL writeback)';
+}
+{
+    # A scalar slot reassigned to a scalar must still work (regression guard).
+    my $d = 0;
+    EVAL q'$d = 42';
+    is $d, 42, 'EVAL scalar->scalar assignment still reconciles';
+}
+{
+    # A container slot reassigned to a *container* must NOT be clobbered
+    # incorrectly: the value still propagates and round-trips.
+    my @e = 1, 2, 3;
+    EVAL q'@e = 7, 8';
+    is @e.join(','), '7,8', 'EVAL container reassignment still reconciles';
+}


### PR DESCRIPTION
## Summary

env_dirty substrate slice **S18** — roast double-OFF surface **3 → 2**.

`my $z = []; EVAL q'$z = do { 1 } + 2;'; is $z, 1` — an EVAL carrier reassigns a captured-outer caller scalar `$z` whose slot previously held a container. The carrier writeback (`writeback_carrier_writes`) gated its reconcile eligibility on the *old slot value* being a scalar: with the slot holding `[]` (Array), the scalar branch was skipped and the container-protection branch refused to overwrite (to avoid clobbering a live `:=` cell from a COW-detached env copy), leaving it to the blanket reconcile — a no-op under double-OFF, so `$z` stayed the stale Array.

### Misclassification note

This case was previously logged as a **parser / auto-curly** failure. The auto-curly parse is in fact correct (normal mode yields `z=1`); the double-OFF failure is purely the EVAL carrier scalar writeback not refreshing the caller slot. (`terminator.t` test 12.)

## Fix

Gate the reconcile eligibility on the **new env value** being a writeback-safe scalar (plus the slot not being a `:=` bind cell — `ContainerRef`/`HashSlotRef`). A scalar new value carries no container COW-copy hazard, so it is safe to write through even when the slot previously held a container. A container→container reassignment (`my @e = ...; EVAL q'@e = 7,8'`) keeps the existing protection branch (new value is a container).

## Tests

- `roast/S04-statements/terminator.t` now passes under `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` (double-OFF) as well as default.
- `:=` bind-cell tests (`t/element-bind-cell.t`, `roast/S03-binding/nested.t`, `arrays.t`) pass in both modes — no regression.
- pin `t/eval-carrier-scalar-writeback-coherence.t` (6 subtests) passes with blanket reconcile ON and OFF.

This is a general improvement: any `EVAL q'$x = <scalar>'` that overwrites a container-holding slot benefits.

The remaining 2 double-OFF surfaces are both non-writeback axes: `lazy-lists.t` (a genuine laziness issue — `grep`/`map` on a `.lazy` gather is eagerly forced when the blanket reconcile is off; needs a laziness fix, not writeback) and `throttle.t` (timing-sensitive / flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)