### PR TITLE
fix(dd): dump a user instance as its .raku (F.new(...)), not F()

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -1400,3 +1400,11 @@ string` で die していた。
   修正（roast が authoritative spec）。`.Str` は別経路で範囲外のため不変。
 - **テスト**: `t/instance-gist.t`（10 件、全て raku でも PASS）。型オブジェクト gist・カスタム gist 優先・Real ブリッジ
   gist・ネスト・`.=` round-trip をカバー。`make test` PASS（t/ 回帰ゼロ）。
+
+## 2026-06-22 (session 11): `dd` のユーザインスタンスを `.raku` 形式でダンプ
+
+`dd F.new(:x(3))` が型オブジェクト形式 `F()` ではなく raku 通りの `F.new(x => 3)` をダンプするように修正。`dd` は
+静的 `raku_value` を使っていたが、これはクラスレジストリにアクセスできず公開属性を集められなかった（→ `F()`）。
+`builtin_dd` がインスタンスに対しては interpreter の `.raku` メソッドをディスパッチするよう変更（`&mut self` なので可能）。
+非インスタンス値は従来通り静的レンダラ。ネストインスタンスも再帰的に正しくダンプ。`t/dd-instance.t`（5 件、is_run で
+stderr 検証、全て raku でも PASS）。

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -309,7 +309,17 @@ impl Interpreter {
         let arg_sources = self.pending_call_arg_sources.clone().unwrap_or_default();
         for (i, val) in args.iter().enumerate() {
             let source_name = arg_sources.get(i).and_then(|entry| entry.as_deref());
-            let repr = Self::dd_format(val, source_name);
+            // A user-class instance's `.raku` needs the class registry to collect
+            // its public attributes, which the static `raku_value` cannot reach
+            // (it would render `F()`); dispatch the instance method instead.
+            let value_repr = if matches!(val, Value::Instance { .. }) {
+                self.call_method_with_values(val.clone(), "raku", vec![])
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|_| crate::builtins::methods_0arg::raku_repr::raku_value(val))
+            } else {
+                crate::builtins::methods_0arg::raku_repr::raku_value(val)
+            };
+            let repr = Self::dd_format_with_repr(val, source_name, value_repr);
             self.emit_stderr(&format!("{}\n", repr));
         }
         Ok(args.first().cloned().unwrap_or(Value::Nil))
@@ -321,8 +331,12 @@ impl Interpreter {
     /// is a plain variable (e.g. `dd %h`), Raku prefixes it with the runtime
     /// type and the variable name: `Hash %h = {:a(1)}`. Literals and complex
     /// expressions render as just the value.
-    fn dd_format(val: &Value, source_name: Option<&str>) -> String {
-        let value_repr = crate::builtins::methods_0arg::raku_repr::raku_value(val);
+    /// Format a `dd` line from a precomputed value representation. The caller
+    /// supplies the value repr — an interpreter-dispatched `.raku` for a
+    /// user-class instance (whose attribute list needs the class registry), or
+    /// the static `raku_value` otherwise. When the argument is a plain variable
+    /// (`dd %h`), Raku prefixes it with the runtime type and name.
+    fn dd_format_with_repr(val: &Value, source_name: Option<&str>, value_repr: String) -> String {
         match source_name {
             Some(name) if Self::dd_is_plain_var(name) => {
                 let ty = crate::runtime::utils::value_type_name(val);

--- a/t/dd-instance.t
+++ b/t/dd-instance.t
@@ -1,0 +1,26 @@
+use lib 'roast/packages/Test-Helpers/lib';
+use Test;
+use Test::Util;
+
+# `dd` of a user-class instance dumps its `.raku` representation
+# (`F.new(x => 3)`), not the type-object form `F()`. The value part needs the
+# class registry to collect public attributes, so `dd` dispatches the instance
+# `.raku` method rather than the static raku renderer.
+
+plan 5;
+
+is_run 'class F { has $.x }; dd F.new(:x(3))',
+    { :err("F.new(x => 3)\n"), :out(""), :status(0) },
+    'dd of an instance dumps ClassName.new(attr => value)';
+
+is_run 'class F { has $.a; has $.b }; dd F.new(:a(1), :b(2))',
+    { :err("F.new(a => 1, b => 2)\n"), :status(0) },
+    'dd of a multi-attribute instance';
+
+is_run 'class Inner { has $.x }; class Outer { has $.i }; dd Outer.new(:i(Inner.new(:x(7))))',
+    { :err("Outer.new(i => Inner.new(x => 7))\n"), :status(0) },
+    'dd renders nested instances recursively';
+
+# non-instance values are unaffected
+is_run 'dd [1, 2, 3]', { :err("[1, 2, 3]\n"), :status(0) }, 'dd of an array is unchanged';
+is_run 'dd 42', { :err("42\n"), :status(0) }, 'dd of an Int is unchanged';


### PR DESCRIPTION
## What

`dd F.new(:x(3))` now dumps `F.new(x => 3)` (matching raku) instead of the type-object form `F()`.

## Why

`dd` rendered its value with the static `raku_value`, which cannot reach the class registry to collect a user instance's public attributes — so an instance fell back to `F()`. `builtin_dd` now dispatches the instance `.raku` method for `Value::Instance` arguments (it already has `&mut self`); non-instance values keep the static renderer. Nested instances dump recursively.

This complements #3436 (which fixed the same `F()`-vs-`F.new(...)` issue for `.gist` / `say`).

## Tests

- `t/dd-instance.t` (5 assertions, stderr verified via `is_run`, all pass under `raku` too): instance, multi-attribute, nested, plus array/Int unaffected.
- `make test` PASS (no t/ regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)