### PR TITLE
fix(range): coerce an allomorph Range endpoint to its numeric value

### DIFF
--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -558,6 +558,14 @@ impl Interpreter {
             | Value::Set(..)
             | Value::Bag(..)
             | Value::Mix(..) => runtime::coerce_to_numeric(value),
+            // An allomorph (IntStr/RatStr/NumStr/…) as a Range endpoint coerces
+            // to its numeric value, so `0..<5>` is `0..5` (not a degenerate
+            // single-element range over the un-numified Mixin).
+            Value::Mixin(ref inner, ref mixins)
+                if crate::value::types::allomorph_type_name(inner, mixins).is_some() =>
+            {
+                runtime::coerce_to_numeric(value)
+            }
             // Seq is NOT scalarized here — it must be caught by check_range_invalid_arg
             Value::Seq(..) => value,
             other => other,

--- a/t/allomorph-range-endpoint.t
+++ b/t/allomorph-range-endpoint.t
@@ -1,0 +1,25 @@
+use Test;
+
+# An allomorph (IntStr/RatStr/NumStr) used as a Range endpoint coerces to its
+# numeric value, so `0..<5>` is the range `0..5`, not a degenerate one-element
+# range over the un-numified Mixin.
+
+plan 10;
+
+is (0..<5>).elems,   6,           'IntStr as exclusive-of-nothing end endpoint';
+is (0..^<5>).elems,  5,           'IntStr as excluded end endpoint';
+is (<5>..10).elems,  6,           'IntStr as start endpoint';
+is (<2>..<5>).list,  (2, 3, 4, 5), 'IntStr on both ends';
+is (<5e0>..10).elems, 6,          'NumStr endpoint coerces numerically';
+is (<3.0>..6).elems, 4,           'RatStr endpoint coerces numerically';
+
+# the range actually iterates to the right values
+is (<1>..<3>).join(','), '1,2,3', 'allomorph range iterates correctly';
+
+# subscripting with an allomorph range
+my @a = 'a'..'j';
+is @a[0..^<3>].join, 'abc',       'allomorph range as a subscript';
+
+# plain numeric ranges are unaffected
+is (1..3).elems, 3,               'plain Int range unchanged';
+is (0..^5).elems, 5,              'plain excluded range unchanged';


### PR DESCRIPTION
## Summary

`scalarize_range_endpoint` coerced `Scalar`/`Array`/`Hash`/`Set`/`Bag`/`Mix` endpoints to numeric but left a `Value::Mixin` (an allomorph like `<5>`/`<5e0>`) untouched. A range built on such an endpoint became a degenerate one-element range over the un-numified Mixin:

| expression | before | raku |
|---|---|---|
| `(0..<5>).elems` | `1` | `6` |
| `(0..^<5>).elems` | `1` | `5` |
| `(<5>..10).elems` | `1` | `6` |

Allomorph endpoints now coerce to their inner numeric value (gated on `allomorph_type_name`, so a general `but`-mixin is unaffected). Plain numeric ranges are unchanged.

This is a latent bug surfaced while working on allomorph `.raku` rendering (`<5>.raku` → `IntStr.new(5, "5")`); the round-trip in `roast/S16-filehandles/argfiles.t` (`.lines: <5>.raku`) exercises exactly this path.

## Testing

- New `t/allomorph-range-endpoint.t` (10 assertions), all matching `raku`.
- Local `make roast` green (only the documented-flaky `S17-lowlevel/thread.t` timed out under load; passes on release retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)