### PR TITLE
fix(temporal): render Date/DateTime .raku as the numeric-argument constructor

### DIFF
--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -103,8 +103,8 @@ pub fn date_method_0arg(
             Some(Ok(Value::make_instance(Symbol::intern("Instant"), attrs)))
         }
         "raku" | "perl" => Some(Ok(Value::str(format!(
-            "Date.new(\"{}\")",
-            format_date(year, month, day)
+            "Date.new({},{},{})",
+            year, month, day
         )))),
         "WHICH" => {
             let which = format!("Date|{}", days);
@@ -240,8 +240,23 @@ pub fn datetime_method_0arg(
             year, month, day, hour, minute, second, timezone,
         ))),
         "raku" | "perl" => {
-            let s = format_datetime(year, month, day, hour, minute, second, timezone);
-            Some(Ok(Value::str(format!("DateTime.new(\"{}\")", s))))
+            // Raku renders DateTime.raku as the numeric-argument constructor:
+            // `DateTime.new(2020,3,5,13,45,30)`, a fractional second as a decimal
+            // (`...,30.5)`), and a non-UTC offset as a trailing `:timezone(N)`.
+            let sec_str = if second == second.floor() {
+                format!("{}", second as i64)
+            } else {
+                format!("{}", second)
+            };
+            let mut s = format!(
+                "DateTime.new({},{},{},{},{},{}",
+                year, month, day, hour, minute, sec_str
+            );
+            if timezone != 0 {
+                s.push_str(&format!(",:timezone({})", timezone));
+            }
+            s.push(')');
+            Some(Ok(Value::str(s)))
         }
         "WHICH" => {
             let posix = datetime_to_posix(year, month, day, hour, minute, second, timezone);

--- a/t/date-datetime-raku.t
+++ b/t/date-datetime-raku.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Date.raku / DateTime.raku render the numeric-argument constructor form
+# (`Date.new(2020,3,5)`, `DateTime.new(2020,3,5,13,45,30)`), which round-trips
+# through .EVAL — not the ISO-string form. `.Str` / `.gist` keep the ISO form.
+
+plan 14;
+
+is Date.new(2020, 1, 1).raku,    'Date.new(2020,1,1)',   'Date.raku numeric form';
+is Date.new(2020, 12, 5).raku,   'Date.new(2020,12,5)',  'Date.raku two-digit fields';
+is Date.new(2020, 1, 1).perl,    'Date.new(2020,1,1)',   'Date.perl matches .raku';
+# .raku built from a string constructor still renders numeric
+is Date.new("2020-03-05").raku,  'Date.new(2020,3,5)',   'Date.raku from string ctor is numeric';
+# .Str / .gist keep ISO form
+is Date.new(2020, 3, 5).Str,     '2020-03-05',           'Date.Str keeps ISO form';
+is Date.new(2020, 3, 5).gist,    '2020-03-05',           'Date.gist keeps ISO form';
+
+is DateTime.new(2020, 3, 5, 13, 45, 30).raku,
+    'DateTime.new(2020,3,5,13,45,30)',                   'DateTime.raku numeric form';
+is DateTime.new(2020, 3, 5, 13, 45, 30.5).raku,
+    'DateTime.new(2020,3,5,13,45,30.5)',                 'DateTime.raku fractional second';
+is DateTime.new(2020, 3, 5, 13, 45, 30, :timezone(3600)).raku,
+    'DateTime.new(2020,3,5,13,45,30,:timezone(3600))',   'DateTime.raku with timezone';
+is DateTime.new(2020, 1, 1, 0, 0, 0).raku,
+    'DateTime.new(2020,1,1,0,0,0)',                      'DateTime.raku midnight';
+is DateTime.new(2020, 3, 5, 13, 45, 30).Str,
+    '2020-03-05T13:45:30Z',                              'DateTime.Str keeps ISO form';
+
+# round-trips through .EVAL
+my $d = Date.new(2020, 7, 14);
+ok $d.raku.EVAL eqv $d, 'Date.raku.EVAL round-trips';
+my $dt = DateTime.new(2020, 7, 14, 9, 8, 7);
+ok $dt.raku.EVAL eqv $dt, 'DateTime.raku.EVAL round-trips';
+my $dtz = DateTime.new(2020, 7, 14, 9, 8, 7, :timezone(3600));
+ok $dtz.raku.EVAL eqv $dtz, 'DateTime.raku.EVAL with timezone round-trips';


### PR DESCRIPTION
## Summary

`Date.raku` / `DateTime.raku` rendered the ISO-**string** constructor form, which diverges from raku and (unlike raku) is the form `.EVAL` round-trips through only by luck:

| expression | before | raku |
|---|---|---|
| `Date.new(2020,3,5).raku` | `Date.new("2020-03-05")` | `Date.new(2020,3,5)` |
| `DateTime.new(2020,3,5,13,45,30).raku` | `DateTime.new("2020-03-05T13:45:30Z")` | `DateTime.new(2020,3,5,13,45,30)` |
| `DateTime.new(...,30.5).raku` | `...T13:45:30.500000Z"` | `DateTime.new(2020,3,5,13,45,30.5)` |
| `DateTime.new(...,:timezone(3600)).raku` | `...+01:00"` | `DateTime.new(2020,3,5,13,45,30,:timezone(3600))` |

Both now render the numeric-argument constructor: a fractional second as a decimal, a non-UTC offset as a trailing `:timezone(N)`. `.Str`/`.gist` keep the ISO form (unchanged).

## Testing

- New `t/date-datetime-raku.t` (14 assertions, incl. `.raku.EVAL` round-trips), all matching `raku`.
- Whitelisted `roast/S32-temporal/{Date,DateTime,DateTime-Instant-Duration}.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)