### PR TITLE
fix(io): coerce a numeric/allomorph .lines/.words limit argument

### DIFF
--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -3,6 +3,24 @@ use crate::symbol::Symbol;
 use num_traits::ToPrimitive;
 use std::path::Component;
 
+/// Coerce a positional limit argument (the `$limit` of `.lines`/`.words`/`.get`
+/// reads) to a row count. Accepts any non-negative numeric, including an
+/// allomorph (`<3>`, `<3e0>`, `<3+0i>`) by unwrapping the `Mixin` to its inner
+/// numeric. Returns `None` for non-numeric args, `*`/`Whatever`, and `+Inf`
+/// (all meaning "no limit").
+fn numeric_limit_arg(arg: &Value) -> Option<usize> {
+    match arg {
+        Value::Int(i) => Some((*i).max(0) as usize),
+        Value::BigInt(bi) => Some(bi.to_usize().unwrap_or(usize::MAX)),
+        Value::Num(f) if f.is_infinite() => None,
+        Value::Num(f) if *f >= 0.0 => Some(*f as usize),
+        Value::Rat(n, d) if *d != 0 => Some(((*n as f64 / *d as f64) as i64).max(0) as usize),
+        Value::Complex(re, im) if *im == 0.0 && *re >= 0.0 => Some(*re as usize),
+        Value::Mixin(inner, _) => numeric_limit_arg(inner),
+        _ => None,
+    }
+}
+
 fn io_exception(class_name: &str, message: String) -> RuntimeError {
     let mut err = RuntimeError::new(message);
     err.exception = Some(Box::new(Value::make_instance(
@@ -766,15 +784,8 @@ impl Interpreter {
                 let (_, _, _, _, chomp, nl_in, _, _, _, _, _) = self.parse_io_flags_values(&args);
                 let mut parts = Self::split_content_by_separators(&content, &nl_in, chomp);
 
-                // Check for a positional limit argument
-                let limit = args.iter().find_map(|arg| match arg {
-                    Value::Int(i) => Some((*i).max(0) as usize),
-                    Value::BigInt(bi) => {
-                        use num_traits::ToPrimitive;
-                        Some(bi.to_usize().unwrap_or(usize::MAX))
-                    }
-                    _ => None,
-                });
+                // Check for a positional limit argument (any numeric, incl. allomorphs)
+                let limit = args.iter().find_map(numeric_limit_arg);
                 if let Some(n) = limit {
                     parts.truncate(n);
                 }
@@ -788,15 +799,8 @@ impl Interpreter {
                     .split_whitespace()
                     .map(|token| Value::str(token.to_string()))
                     .collect();
-                // Check for a positional limit argument
-                let limit = args.iter().find_map(|arg| match arg {
-                    Value::Int(i) => Some((*i).max(0) as usize),
-                    Value::BigInt(bi) => {
-                        use num_traits::ToPrimitive;
-                        Some(bi.to_usize().unwrap_or(usize::MAX))
-                    }
-                    _ => None,
-                });
+                // Check for a positional limit argument (any numeric, incl. allomorphs)
+                let limit = args.iter().find_map(numeric_limit_arg);
                 if let Some(n) = limit {
                     parts.truncate(n);
                 }
@@ -2518,23 +2522,13 @@ impl Interpreter {
                         Value::Pair(k, v) if k == "close" => {
                             close_after = v.truthy();
                         }
-                        Value::Pair(..) => {}
-                        Value::Int(i) => limit = Some((*i).max(0) as usize),
-                        Value::BigInt(bi) => {
-                            use num_traits::ToPrimitive;
-                            limit = Some(bi.to_usize().unwrap_or(usize::MAX));
+                        // Any numeric (incl. allomorphs) is a row limit; named
+                        // args and Whatever/+Inf mean "no limit".
+                        _ => {
+                            if let Some(n) = numeric_limit_arg(arg) {
+                                limit = Some(n);
+                            }
                         }
-                        Value::Whatever => {}
-                        Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {}
-                        Value::Num(f) if *f >= 0.0 => limit = Some(*f as usize),
-                        Value::Rat(n, d) if *d == 0 && *n > 0 => {}
-                        Value::Rat(n, d) if *d != 0 => {
-                            limit = Some(((*n as f64 / *d as f64) as i64).max(0) as usize);
-                        }
-                        Value::Complex(re, im) if *im == 0.0 && *re >= 0.0 => {
-                            limit = Some(*re as usize);
-                        }
-                        _ => {}
                     }
                 }
                 if limit.is_some() {
@@ -2571,16 +2565,13 @@ impl Interpreter {
                         Value::Pair(k, v) if k == "close" => {
                             close_after = v.truthy();
                         }
-                        Value::Pair(..) => {}
-                        Value::Int(i) => limit = Some((*i).max(0) as usize),
-                        Value::BigInt(bi) => {
-                            use num_traits::ToPrimitive;
-                            limit = Some(bi.to_usize().unwrap_or(usize::MAX));
+                        // Any numeric (incl. allomorphs) is a word limit; named
+                        // args and Whatever/+Inf mean "no limit".
+                        _ => {
+                            if let Some(n) = numeric_limit_arg(arg) {
+                                limit = Some(n);
+                            }
                         }
-                        Value::Whatever => {}
-                        Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {}
-                        Value::Num(f) if *f >= 0.0 => limit = Some(*f as usize),
-                        _ => {}
                     }
                 }
                 if limit.is_none() {

--- a/t/lines-words-allomorph-limit.t
+++ b/t/lines-words-allomorph-limit.t
@@ -1,0 +1,37 @@
+use Test;
+
+# `.lines($limit)` / `.words($limit)` accept any Numeric as the limit, including
+# allomorphs (`<3>`, `<3e0>`, `<3+0i>`) — they coerce to a row count rather than
+# being silently ignored (which used to read the whole file).
+
+plan 12;
+
+my $file = $*TMPDIR.add("mutsu-lines-{$*PID}.txt");
+$file.spurt("one\ntwo\nthree\nfour\nfive\n");
+
+# plain numerics
+is $file.lines(3).elems,    3, 'Int limit';
+is $file.lines(3e0).elems,  3, 'Num limit';
+is $file.lines(3/1).elems,  3, 'Rat limit';
+
+# allomorphs
+is $file.lines(<3>).elems,    3, 'IntStr limit';
+is $file.lines(<3e0>).elems,  3, 'NumStr limit';
+is $file.lines(<3/1>).elems,  3, 'RatStr (eval) limit';
+is $file.lines(<3+0i>).elems, 3, 'ComplexStr limit (zero imaginary)';
+
+# no limit reads everything
+is $file.lines.elems, 5, 'no limit reads all lines';
+
+# .words with allomorph limit
+my $wfile = $*TMPDIR.add("mutsu-words-{$*PID}.txt");
+$wfile.spurt("a b c d e f");
+is $wfile.words(<2>).elems, 2, 'IntStr words limit';
+is $wfile.words(4).elems,   4, 'Int words limit';
+is $wfile.words.elems,      6, 'no limit reads all words';
+
+# limit larger than available is fine
+is $file.lines(<100>).elems, 5, 'limit beyond EOF returns all';
+
+$file.unlink;
+$wfile.unlink;


### PR DESCRIPTION
## Summary

`.lines($limit)` / `.words($limit)` recognised only a plain `Int`/`BigInt` positional limit in the file-path forms, so an allomorph or other numeric limit was silently dropped and the whole file was read:

| expression | before | raku |
|---|---|---|
| `"f".IO.lines(<3>).elems` | `5` | `3` |
| `"f".IO.lines(<3e0>).elems` | `5` | `3` |
| `"f".IO.lines(<3+0i>).elems` | `5` | `3` |
| `"f".IO.lines(3/1).elems` (file form) | `5` | `3` |

A new shared `numeric_limit_arg` helper coerces any non-negative numeric — including an allomorph `Mixin` (unwrapped to its inner numeric) — to a row count (`None` for non-numeric / `*` / `+Inf`). All four `.lines`/`.words` limit sites (file-path and handle forms) now route through it, so they accept the same numeric range consistently.

This is an independent latent bug (reproduces on `main`), and is also a prerequisite for rendering allomorph `.raku` as `IntStr.new(...)`, since `roast/S16-filehandles/argfiles.t` round-trips a `<5>` limit through `.lines: <5>.raku`.

## Testing

- New `t/lines-words-allomorph-limit.t` (12 assertions), all matching `raku`.
- `roast/S16-filehandles/argfiles.t` and `roast/S16-io/lines.t` pass; `S32-io/io-handle.t` unchanged (same pre-existing failures on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)