### PR TITLE
feat(raku/gist): render allomorphs (IntStr/RatStr/NumStr) faithfully

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -413,6 +413,15 @@ pub(crate) fn native_method_0arg(
         {
             return Some(Ok(str_val.clone()));
         }
+        // An allomorph (IntStr/NumStr/…) gists as its preserved source string,
+        // not the inner numeric's gist: `<1e3>.gist` → `1e3` (not `1000`). Only
+        // allomorphs; a general `but`-mixin gists via its inner value (below).
+        if method == "gist"
+            && crate::value::types::allomorph_type_name(inner, mixins).is_some()
+            && let Some(str_val) = mixins.get("Str")
+        {
+            return Some(Ok(str_val.clone()));
+        }
         if method == "WHICH"
             && let Some(allo_name) = crate::value::types::allomorph_type_name(inner, mixins)
         {
@@ -449,6 +458,15 @@ pub(crate) fn native_method_0arg(
                 }
                 _ => {}
             }
+        }
+        // An allomorph (IntStr/RatStr/NumStr/ComplexStr) renders its `.raku` /
+        // `.perl` as `TypeStr.new(<numeric>, "<string>")`, NOT the bare inner
+        // value's `.raku`. (`.gist`/`.Str` keep the source-string form, handled
+        // above; a general `but`-mixin falls through to the inner delegation.)
+        if matches!(method, "raku" | "perl")
+            && crate::value::types::allomorph_type_name(inner, mixins).is_some()
+        {
+            return Some(Ok(Value::str(raku_repr::raku_value(target))));
         }
         // Check for mixin key matching the method name (e.g. "Array", "List", "Int", etc.)
         // This handles `True but [1, 2]` where `.Array` should return the mixed-in array.

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -713,6 +713,23 @@ pub fn raku_value(v: &Value) -> String {
         Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
             setbagmix_raku(v).unwrap_or_else(|| v.to_string_value())
         }
+        Value::Mixin(inner, mixins) => {
+            // An allomorphic value (IntStr/RatStr/NumStr/ComplexStr) renders as
+            // `TypeStr.new(<numeric>, "<original string>")` — e.g. `<42>.raku`
+            // → `IntStr.new(42, "42")`, `<1e3>.raku` → `NumStr.new(1000e0, "1e3")`
+            // (the string half preserves the source literal). The numeric half is
+            // the inner value's `.raku`. A non-allomorphic mixin falls back to its
+            // inner value's `.raku`.
+            if let Some(name) = crate::value::types::allomorph_type_name(inner, mixins) {
+                let str_repr = mixins
+                    .get("Str")
+                    .map(raku_value)
+                    .unwrap_or_else(|| "\"\"".to_string());
+                format!("{}.new({}, {})", name, raku_value(inner), str_repr)
+            } else {
+                raku_value(inner)
+            }
+        }
         other => other.to_string_value(),
     }
 }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1125,6 +1125,18 @@ pub(crate) fn gist_value(value: &Value) -> String {
         // `$(...)` itemized container: `.gist` never shows the itemization sigil,
         // so it gists exactly like its inner value (`${a=>1}.gist` → `{a => 1}`).
         Value::Scalar(inner) => gist_value(inner),
+        // An allomorph (IntStr/NumStr/…) gists as its preserved source string
+        // (`<1e3>.gist` → `1e3`, not the inner Num's `1000`); a general mixin
+        // gists via its inner value.
+        Value::Mixin(inner, mixins) => {
+            if crate::value::types::allomorph_type_name(inner, mixins).is_some()
+                && let Some(str_val) = mixins.get("Str")
+            {
+                str_val.to_string_value()
+            } else {
+                gist_value(inner)
+            }
+        }
         _ => value.to_string_value(),
     }
 }

--- a/t/allomorph-raku-gist.t
+++ b/t/allomorph-raku-gist.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Allomorphic values (IntStr / RatStr / NumStr) created by `<...>` carry both a
+# numeric value and the original source string. `.raku` / `.perl` render them as
+# `TypeStr.new(<numeric>, "<string>")`, while `.gist` / `.Str` / `say` use the
+# preserved source string.
+
+plan 18;
+
+# --- .raku / .perl show the allomorph constructor form ---
+is <42>.raku,    'IntStr.new(42, "42")',       'IntStr .raku';
+is <42>.perl,    'IntStr.new(42, "42")',       'IntStr .perl';
+is <-5>.raku,    'IntStr.new(-5, "-5")',       'negative IntStr .raku';
+is <0>.raku,     'IntStr.new(0, "0")',         'zero IntStr .raku';
+is <3.14>.raku,  'RatStr.new(3.14, "3.14")',   'RatStr .raku';
+is <1e3>.raku,   'NumStr.new(1000e0, "1e3")',  'NumStr .raku keeps source string';
+
+# --- .gist / .Str / say use the preserved source string, NOT the numeric ---
+is <1e3>.gist,   '1e3',  'NumStr .gist is the source string';
+is <1e3>.Str,    '1e3',  'NumStr .Str is the source string';
+is <42>.gist,    '42',   'IntStr .gist';
+is <3.14>.gist,  '3.14', 'RatStr .gist';
+
+# --- inside a list, each allomorph renders independently ---
+is <1 2 3>.raku, '(IntStr.new(1, "1"), IntStr.new(2, "2"), IntStr.new(3, "3"))',
+    'list of IntStr .raku';
+is (<1e3>,).gist, '(1e3)',  'NumStr in a list gists as source string';
+is [<1e3>].gist,  '[1e3]',  'NumStr in an array gists as source string';
+
+# --- the WHAT type is preserved ---
+is <42>.WHAT.raku,   'IntStr', 'IntStr WHAT';
+is <3.14>.WHAT.raku, 'RatStr', 'RatStr WHAT';
+is <1e3>.WHAT.raku,  'NumStr', 'NumStr WHAT';
+
+# --- allomorphs still behave numerically / stringily ---
+is <42> + 1,   43,    'IntStr numifies';
+is <42> ~ "x", '42x', 'IntStr stringifies';


### PR DESCRIPTION
## Summary

`<42>.raku` rendered the bare inner numeric (`42`) instead of the allomorph constructor. Raku renders an allomorph's `.raku`/`.perl` as the constructor that preserves both halves, and its `.gist`/`.Str`/`say` as the **source string**:

| expression | before | raku |
|---|---|---|
| `<42>.raku` | `42` | `IntStr.new(42, "42")` |
| `<3.14>.raku` | `3.14` | `RatStr.new(3.14, "3.14")` |
| `<1e3>.raku` | `1000e0` | `NumStr.new(1000e0, "1e3")` |
| `<1e3>.gist` / `say <1e3>` | `1000` | `1e3` |
| `<1 2 3>.raku` | `(1, 2, 3)` | `(IntStr.new(1, "1"), …)` |

## Changes

- `raku_value` (`methods_0arg/raku_repr.rs`): a `Value::Mixin` allomorph renders `TypeStr.new(num, "str")`; a non-allomorph mixin falls back to its inner value.
- `gist_value` (`runtime/utils.rs`) + the `.gist` and `.raku`/`.perl` Mixin handling in `methods_0arg/mod.rs`: allomorph `.gist`/`.Str` use the source string, `.raku`/`.perl` use the constructor form.

## Dependency

This is the capstone of a small series — it depends on the allomorph **numeric-coercion** fixes that landed first, so an allomorph flowing through a `.raku.EVAL` round-trip into a numeric-argument site still numifies:
- Range endpoints — #3444
- `.lines`/`.words` limits — #3447

`roast/S16-filehandles/argfiles.t` (which round-trips `.lines: <5>.raku`) stays green precisely because of those.

## Testing

- New `t/allomorph-raku-gist.t` (18 assertions), all matching `raku`.
- **Full local `make roast` is green** (broad rendering change — verified no whitelist regression). Non-whitelisted `allomorphic.t`/`eqv.t`/`perl.t` have identical failure counts to `main` (neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)