### PR TITLE
fix(subst): evaluate `s{}=EXPR` / `S{}=EXPR` replacement in the right scope

### DIFF
--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -237,13 +237,12 @@
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
 - [ ] roast/S05-substitution/subst.t
-  - 189/191 pass. **Whitelistable in principle**: although reference rakudo on
-    this box fails tests 157 (`:i(1) is OK`) and 170 (`s[]="" when $_ is not set`),
-    **mutsu passes both** (157 outright; 170 is `#?rakudo todo`, so a mutsu failure
-    there would not fail the file anyway). So fixing the remaining mutsu failures
-    (102, 187) does reach a clean mutsu pass and the file can be
-    whitelisted. Remaining mutsu failures span several distinct (mostly
-    regex-internal) features:
+  - 190/191 pass (only 102 fails). **Whitelistable in principle**: although
+    reference rakudo on this box fails tests 157 (`:i(1) is OK`) and 170
+    (`s[]="" when $_ is not set`), **mutsu passes both** (157 outright; 170 is
+    `#?rakudo todo`, so a mutsu failure there would not fail the file anyway). The
+    only remaining mutsu failure is 102, the `:ss`+`:m` Rakudo mark-transfer quirk
+    (WON'T FIX, see below). Remaining/historical failures:
   - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
     block (`given 'a 2 3' -> $_ is copy { s[\d] += 5 }`). `given LITERAL -> $_ is
     copy` marked `$_` read-only (the `$_ = $_` copy-head desugar then died on the
@@ -275,7 +274,8 @@
     governs only whitespace, so its effect on mark transfer is a Rakudo-specific
     interaction artifact. Replicating it would require special-case logic keyed on
     the `:ss`+`:m` combination — a hack, which the project rules forbid. Effectively
-    blocks a clean subst.t whitelist (the only other gap, 187, is real but rare).
+    blocks a clean subst.t whitelist (187 is now FIXED; 102 is the only remaining
+    mutsu failure, and reference rakudo additionally fails 157/170).
   - 146-152 (FIXED): `.subst` `:samecase`/`:samemark` adverbs, including with `:g`
     and block replacement (152 fixed via the closure-writeback fix below).
   - 156 (FIXED): `s:i($i)/.../` now throws `X::Value::Dynamic` (non-constant
@@ -328,13 +328,24 @@
     Any (the `$_`-reset in `call_compiled_closure_with_topic` is skipped when the
     `param_defs` carry placeholder names — a bare placeholder block is a block, not
     a routine). Local: t/placeholder-block-topic.t.
-  - 187: `S{5}=$^a` (the `S{...}=EXPR` assignment form) desugars to
-    `.subst(/5/, { $^a })` — the replacement EXPR is wrapped in an auto-generated
-    closure, so the user's `$^a` lands *inside* that closure and is not hoisted to
-    the enclosing block. Indistinguishable at the AST level from an explicit
-    `.subst(/5/, { $^a })` closure replacement (where `$^a` genuinely belongs to
-    the replacement closure). Fixing requires the parser to mark the `S{}=`-desugared
-    replacement closure so its placeholders bubble up to the surrounding block.
+  - 187 (FIXED): the `S{...}=EXPR` non-destructive assignment form used to desugar
+    to `.subst(/pat/, { EXPR })` — wrapping the replacement in an auto-generated
+    `AnonSub` closure, which (a) rebound `$_` to the match (so `$_.chars` saw the
+    1-char match, not the original topic) and (b) captured the user's `$^a`
+    *inside* that closure instead of hoisting it to the enclosing block. The
+    destructive `s{...}=EXPR` path already avoided this by compiling to a
+    `Subst` node with the raw replacement source wrapped in a `{...}` block string
+    (evaluated per match by the interpolator with `$/`/`$0` bound, `$_` kept, and
+    placeholders bubbling up). The non-destructive path now mirrors it, building a
+    `NonDestructiveSubst` node the same way. Also fixed a deeper root cause shared
+    by *both* paths: `parse_subst_replacement_expr` parsed only the first *primary*
+    of the replacement, so a compound replacement like `"<" ~ $/ ~ ">"` left
+    `~ $/ ~ ">"` dangling to be (mis)parsed as an outer binary expression and
+    silently dropped (`S{P}="<" ~ $/ ~ ">"` gave `abc<defXYZ>` instead of
+    `abc<XYZ>def`). It now parses the full `expression` and only takes the literal
+    shortcut when the whole replacement is a single `Literal`. Local test:
+    t/subst-assign-expr-replacement.t. (subst.t still can't whitelist: 102 is the
+    Rakudo `:ss`+`:m` quirk above, and reference rakudo itself fails 157/170.)
   - Fixed in this pass: `:g`/`:x`/multi-`:nth` now return a List of Match in `$/`
     (single `:nth(N)` stays a Match even with `:g`); `s:g[...] = expr` with
     captures/`$/`/`$0` on the RHS evaluated per match; multi-value `:nth(a,b)`

--- a/src/parser/primary/regex.rs
+++ b/src/parser/primary/regex.rs
@@ -474,7 +474,14 @@ fn has_unescaped_statement_boundary(input: &str) -> bool {
 
 fn parse_subst_replacement_expr(input: &str) -> PResult<'_, String> {
     let (input, _) = ws(input)?;
-    let (rest, expr) = super::primary(input)?;
+    // Parse the FULL replacement expression (not just the first primary): the
+    // literal shortcut is only valid when the entire replacement is a single
+    // literal. Using `primary` here would stop after the first term, so a
+    // compound replacement like `"<" ~ $/ ~ ">"` would leave `~ $/ ~ ">"` in the
+    // stream to be (mis)parsed as an outer binary expression, silently dropping
+    // it from the substitution. Requiring `expression` to yield a bare `Literal`
+    // routes any compound replacement to the closure/block path instead.
+    let (rest, expr) = expression(input)?;
     let replacement = match expr {
         Expr::Literal(value) => value.to_string_value(),
         _ => {
@@ -1719,16 +1726,49 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                                 },
                             ));
                         }
-                        // Expression-based replacement (e.g. S[(o)] = $0.uc)
+                        // Expression-based replacement (e.g. S[(o)] = $0.uc).
                         let (after_eq_ws, _) = ws(after_eq)?;
-                        let (rest, replacement) = expression(after_eq_ws)?;
+                        let (rest, replacement_expr) = expression(after_eq_ws)?;
+                        // Perl5 substitutions keep the legacy `.subst` closure
+                        // lowering, which binds Perl5 captures (`$1`, `$0`, ...)
+                        // per match; the generic interpolator cannot reproduce it.
+                        if adverbs.perl5 {
+                            return Ok((
+                                rest,
+                                build_non_destructive_subst_expr(
+                                    pattern.to_string(),
+                                    replacement_expr,
+                                    &adverbs,
+                                )?,
+                            ));
+                        }
+                        // Capture the raw replacement source and wrap it in a
+                        // `{...}` block so the NonDestructiveSubst interpolator
+                        // evaluates it once per match with `$/`, `$0`, ... bound to
+                        // that match. Crucially this does NOT rebind `$_` (it stays
+                        // the surrounding topic) nor steal the enclosing block's
+                        // placeholder parameters (`$^a`) -- both of which the
+                        // AnonSub `.subst` lowering would incorrectly do. Mirrors
+                        // the destructive `s[pattern] = expr` path above.
+                        let consumed = after_eq_ws.len() - rest.len();
+                        let raw_replacement = after_eq_ws[..consumed].trim().to_string();
+                        let pattern = apply_inline_match_adverbs(pattern.to_string(), &adverbs);
+                        validate_regex_pattern_or_perror(&pattern)?;
+                        let replacement = format!("{{{raw_replacement}}}");
                         return Ok((
                             rest,
-                            build_non_destructive_subst_expr(
-                                pattern.to_string(),
+                            Expr::NonDestructiveSubst {
+                                pattern,
                                 replacement,
-                                &adverbs,
-                            )?,
+                                samecase: adverbs.samecase,
+                                sigspace: adverbs.sigspace,
+                                samemark: adverbs.samemark,
+                                samespace: adverbs.samespace,
+                                global: adverbs.global,
+                                nth: adverbs.nth.clone(),
+                                x: adverbs.repeat,
+                                perl5: adverbs.perl5,
+                            },
                         ));
                     }
                 }

--- a/t/subst-assign-expr-replacement.t
+++ b/t/subst-assign-expr-replacement.t
@@ -1,0 +1,88 @@
+use Test;
+
+# Substitution with an assignment-syntax replacement (`s{pat}=EXPR` /
+# `S{pat}=EXPR`) where EXPR is a compound expression or references the topic
+# `$_`, the match `$/`, captures `$0`, or an enclosing placeholder `$^a`.
+#
+# Previously the replacement parser grabbed only the first primary term, so a
+# compound replacement like `"<" ~ $/ ~ ">"` left `~ $/ ~ ">"` dangling to be
+# (mis)parsed as an outer binary expression -- silently dropped from the
+# substitution. And the expression path wrapped the replacement in an AnonSub
+# closure that rebound `$_` to the match and captured `$^a` itself instead of
+# letting it belong to the enclosing block.
+
+plan 14;
+
+# --- non-destructive S{pat}=EXPR -----------------------------------------
+
+{
+    $_ = "abcXYZdef";
+    is (S{<[A..Z]>+} = "<" ~ $/ ~ ">"), "abc<XYZ>def", 'S{}: compound repl with $/';
+}
+{
+    $_ = "abcXYZdef";
+    is (S{<[A..Z]>+} = "[" ~ $/.lc ~ "]"), "abc[xyz]def", 'S{}: $/.lc in compound repl';
+}
+{
+    $_ = "12345";
+    is (S{5} = $_.chars), "12345", 'S{}: $_ is the original topic, not the match';
+}
+{
+    $_ = "a1b2c3";
+    is (S:g{(\d)} = $0 + 10), "a11b12c13", 'S{}:g per-match capture arithmetic';
+}
+{
+    $_ = "12345";
+    is-deeply ([3,4].map: { S{5} = $^a }), ('12343', '12344'),
+        'S{}: placeholder belongs to the enclosing block';
+}
+{
+    my $c = 0;
+    $_ = "xxx";
+    is (S:g{x} = $c++), "012", 'S{}:g per-match side effect runs each match';
+}
+{
+    $_ = "12345";
+    is (S{5} = "X"), "1234X", 'S{}: plain literal replacement still works';
+}
+
+# --- destructive s{pat}=EXPR ---------------------------------------------
+
+{
+    $_ = "abcXYZdef";
+    s{<[A..Z]>+} = "<" ~ $/ ~ ">";
+    is $_, "abc<XYZ>def", 's{}: compound repl with $/';
+}
+{
+    $_ = "12345";
+    s{5} = $_.chars;
+    is $_, "12345", 's{}: $_ is the original topic';
+}
+{
+    $_ = "a1b2c3";
+    s:g{(\d)} = $0 + 10;
+    is $_, "a11b12c13", 's{}:g per-match capture arithmetic';
+}
+{
+    my $c = 0;
+    $_ = "xxx";
+    s:g{x} = $c++;
+    is $_, "012", 's{}:g per-match side effect';
+}
+{
+    is-deeply ([3,4].map: { my $x = "12345"; $x ~~ s{5} = $^a; $x }),
+        ('12343', '12344'), 's{}: placeholder belongs to enclosing block';
+}
+{
+    $_ = "12345";
+    s{5} = "X";
+    is $_, "1234X", 's{}: plain literal replacement still works';
+}
+
+# --- slash-delimited forms unaffected ------------------------------------
+
+{
+    $_ = "abcXYZdef";
+    is (S/<[A..Z]>+/{ "[" ~ $/.lc ~ "]" }/), "abc[xyz]def",
+        'S/.../{...}/ block replacement still works';
+}


### PR DESCRIPTION
## Summary

Fixes how the assignment-syntax substitution replacement (`s{pat}=EXPR` / `S{pat}=EXPR`) is parsed and scoped. Two related bugs:

1. **Partial replacement consumption (both forms).** `parse_subst_replacement_expr` parsed only the first *primary* of the replacement, so a compound replacement like `"<" ~ $/ ~ ">"` left `~ $/ ~ ">"` dangling to be (mis)parsed as an outer binary expression and silently dropped:
   - `S{P}="<" ~ $/ ~ ">"` → `abc<defXYZ>` (was) vs `abc<XYZ>def` (raku) ✅ now fixed
   - It now parses the full `expression` and only takes the literal shortcut when the whole replacement is a single `Literal`.

2. **Wrong scope in the non-destructive `S{}=EXPR` path.** It wrapped the replacement in an auto-generated `AnonSub` closure (`.subst(/pat/, { EXPR })`), which rebound `$_` to the match and captured the user's `$^a` inside that closure instead of hoisting it to the enclosing block:
   - `S{5}=$_.chars` → `$_` was the 1-char match, not the original topic ✅
   - `[3,4].map: { S{5}=$^a }` → `$^a` belongs to the map block ✅
   - It now mirrors the already-correct destructive path: raw source wrapped in a `{...}` block string → `NonDestructiveSubst`, evaluated per match by the interpolator (`$/`/`$0` bound, `$_` kept, placeholders bubble up, per-match side effects preserved). Perl5 substitutions keep the legacy `.subst` lowering.

## Roast impact

Fixes **S05-substitution/subst.t test 187** (placeholder parameter in substitution assignment). The file still can't be whitelisted: test 102 is the Rakudo `:ss`+`:m` mark-transfer quirk (WON'T FIX, documented in `TODO_roast/S05.md`), and reference rakudo itself fails tests 157/170.

## Test

`t/subst-assign-expr-replacement.t` — 14 cases covering both destructive/non-destructive forms with `$/`, `$0`, `$_`, placeholders, per-match side effects, and plain literals.

`make test` passes (Files=1046, Tests=10149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)