### PR TITLE
fix(str): `.ords` / `ords()` return a Seq (not a List)

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1089,7 +1089,8 @@ fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Value, Runtime
         "ords" => {
             let s = arg.to_string_value();
             let codes: Vec<Value> = s.chars().map(|ch| Value::Int(ch as u32 as i64)).collect();
-            Some(Ok(Value::array(codes)))
+            // `ords` returns a Seq (like `comb`), not a List.
+            Some(Ok(Value::Seq(std::sync::Arc::new(codes))))
         }
         "gist" => Some(Ok(Value::str(arg.to_string_value()))),
         _ => None,

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -87,7 +87,8 @@ pub(super) fn dispatch(
                 .chars()
                 .map(|c| Value::Int(c as u32 as i64))
                 .collect();
-            Some(Some(Ok(Value::array(ords))))
+            // `.ords` returns a Seq (like `.comb`), not a List.
+            Some(Some(Ok(Value::Seq(std::sync::Arc::new(ords)))))
         }
         "uniprop" => {
             match target {
@@ -263,6 +264,7 @@ pub(super) fn dispatch(
             };
             let items: Vec<i64> = match target {
                 Value::Array(items, ..) => items.iter().map(&val_to_i64).collect(),
+                Value::Seq(items) => items.iter().map(&val_to_i64).collect(),
                 Value::Range(a, b) => (*a..=*b).collect(),
                 Value::RangeExcl(a, b) => (*a..*b).collect(),
                 _ => vec![val_to_i64(target)],

--- a/t/ords-returns-seq.t
+++ b/t/ords-returns-seq.t
@@ -1,0 +1,26 @@
+use Test;
+
+# `.ords` / `ords()` return a Seq (like `.comb`/`comb()`), not a List, and the
+# Seq round-trips through `.chrs` (which must accept a Seq argument, not just a
+# List/Range).
+
+plan 12;
+
+is "abc".ords.WHAT.^name, 'Seq', '"abc".ords is a Seq';
+is ords("abc").WHAT.^name, 'Seq', 'ords("abc") is a Seq';
+
+is-deeply "abc".ords.List, (97, 98, 99), '.ords values';
+is-deeply ords("abc").List, (97, 98, 99), 'ords() values';
+
+is "abc".ords.raku, '(97, 98, 99).Seq', '.ords renders as a Seq';
+is "".ords.raku, '().Seq', 'empty .ords renders as a Seq';
+
+# Round-trips
+is "abc".ords.chrs, "abc", '.ords.chrs round-trips (method chrs accepts a Seq)';
+is chrs(ords("ABCDEFGHIJK")), "ABCDEFGHIJK", 'chrs(ords()) round-trips';
+
+# Common downstream usage keeps working
+is "abc".ords[1], 98, '.ords is indexable';
+is "abc".ords.sum, 294, '.ords.sum';
+is "abc".ords.elems, 3, '.ords.elems';
+is-deeply "abc".ords.map(*+1).List, (98, 99, 100), '.ords.map';


### PR DESCRIPTION
## Summary

`"abc".ords` and `ords("abc")` returned a **List**, but Raku specifies a **Seq** (same shape as `.comb`/`comb()`):

```raku
say "abc".ords.WHAT;   # mutsu: (List)  →  raku: (Seq)
say "abc".ords.raku;   # mutsu: (97, 98, 99)  →  raku: (97, 98, 99).Seq
```

Fix: wrap the codepoint vector in `Value::Seq` in the `.ords` method and the `ords()` builtin (the `Nil.ords` resume was already a Seq).

The `.chrs` **method** only flattened `Array`/`Range`, so a `Seq` argument fell into the scalar fallback and broke the `.ords.chrs` round-trip. Added a `Value::Seq` arm so it flattens like a List. (The `chrs()` builtin already flattens via `value_to_list`, so `chrs(ords(...))` was unaffected.)

## Verification

- `roast/S29-conversions/ord_and_chr.t` (whitelisted) stays green — test 245 (`'ABC...'.ords.chrs` round-trip) exercised the method `.chrs` path.
- Spot-checked other `.ords`-using roast files (`S32-str/words.t`, `S15-nfg/*`, `S03-operators/{bit,repeat}.t`, etc.) — no regressions.

## Test

`t/ords-returns-seq.t` — 12 cases (type, values, `.raku`, round-trips, indexing/sum/map downstream usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)