### PR TITLE
fix(range): `.pick(N)` / `.pick(*)` on a Range returns a Seq

### DIFF
--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -3479,14 +3479,14 @@ fn range_pick_n_fast(target: &Value, arg: &Value) -> Option<Value> {
         };
 
         if count == 0 {
-            return Some(Value::array(Vec::new()));
+            return Some(Value::Seq(Arc::new(Vec::new())));
         }
 
         let items = generic_range_pick_n(gs, ge, excl_start, excl_end, count)?;
-        Some(Value::array(items))
+        Some(Value::Seq(Arc::new(items)))
     } else {
         if end < start {
-            return Some(Value::array(Vec::new()));
+            return Some(Value::Seq(Arc::new(Vec::new())));
         }
 
         if is_whatever {
@@ -3498,7 +3498,7 @@ fn range_pick_n_fast(target: &Value, arg: &Value) -> Option<Value> {
                 return None;
             }
             let items = range_pick_n_i64(start, end, range_size as usize);
-            return Some(Value::array(items));
+            return Some(Value::Seq(Arc::new(items)));
         }
 
         let count = match arg {
@@ -3510,10 +3510,10 @@ fn range_pick_n_fast(target: &Value, arg: &Value) -> Option<Value> {
         };
 
         if count == 0 {
-            return Some(Value::array(Vec::new()));
+            return Some(Value::Seq(Arc::new(Vec::new())));
         }
 
         let items = range_pick_n_i64(start, end, count);
-        Some(Value::array(items))
+        Some(Value::Seq(Arc::new(items)))
     }
 }

--- a/t/range-pick-n-seq.t
+++ b/t/range-pick-n-seq.t
@@ -1,0 +1,22 @@
+use Test;
+
+# `.pick(N)` / `.pick(*)` on a Range returns a Seq (like on a List/Array), not
+# a List. The integer-range fast path (`range_pick_n_fast`) used to return a
+# `Value::array`, diverging from `<a b c>.pick(*)` (already a Seq).
+
+plan 10;
+
+is (1..10).pick(3).WHAT.^name, 'Seq', '(1..10).pick(3) is a Seq';
+is (1..10).pick(*).WHAT.^name, 'Seq', '(1..10).pick(*) is a Seq';
+is (1..10).pick(Inf).WHAT.^name, 'Seq', '(1..10).pick(Inf) is a Seq';
+is (5..1).pick(*).WHAT.^name, 'Seq', 'empty range .pick(*) is a Seq';
+is (1..10).pick(0).WHAT.^name, 'Seq', '.pick(0) is a Seq';
+
+# Behaviour preserved
+is (1..10).pick(3).elems, 3, '.pick(3) returns 3 elements';
+is-deeply (1..5).pick(*).sort.List, (1, 2, 3, 4, 5), '.pick(*) is a full shuffle';
+is (1..5).pick(*).elems, 5, '.pick(*) returns all elements';
+is (5..1).pick(*).elems, 0, 'empty range .pick(*) is empty';
+
+# Large range fast path stays lazy/correct
+is (1..1000000000000).pick(2).elems, 2, '.pick(2) on a huge range';


### PR DESCRIPTION
## Summary

`.pick(N)` / `.pick(*)` on a **Range** returned a List, but Raku specifies a **Seq** — the same shape `.pick` already returned for List/Array/Set/Bag invocants:

```raku
say (1..10).pick(3).WHAT;   # mutsu: (List)  →  raku: (Seq)
say (1..10).pick(*).WHAT;   # mutsu: (List)  →  raku: (Seq)
say <a b c>.pick(*).WHAT;   # (Seq) — already correct
```

The integer-range fast path `range_pick_n_fast` short-circuited the generic (Seq-returning) `.pick(N)` code and built a `Value::array` in every branch. Wrap each result in `Value::Seq` instead — covering the i64 and BigInt/`GenericRange` paths, the empty-range / `count==0` / full-shuffle `pick(*)` / huge-range cases.

## Verification

- `roast/S32-list/pick.t` and `S32-list/roll.t` stay green.
- Behaviour preserved: element counts, full-shuffle coverage, large-range laziness.

## Test

`t/range-pick-n-seq.t` — 10 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)