### PR TITLE
fix(raku): trailing comma for a single Iterable element in an array's .raku

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -153,9 +153,43 @@ pub(crate) fn is_adverbial_pair_key(s: &str) -> bool {
     true
 }
 
-fn raku_array_wrap_counted(inner: &str, kind: ArrayKind, count: usize) -> String {
+/// Whether a single element warrants a trailing comma when it is the sole
+/// element of a real (`@`-sigil) array's `.raku`: `[1..5,]`, `[(1, 2),]`,
+/// `[{:x(1)},]`. Raku adds the comma when the element is itself an Iterable
+/// whose bare `.raku` literal would otherwise flatten/merge into the array
+/// (Range, List/Array, Seq, Hash/Map). Pair, Set/Bag/Mix (rendered as
+/// constructor calls), scalars, and type objects do NOT get a comma.
+fn element_needs_trailing_comma(v: &Value) -> bool {
+    match v {
+        Value::ContainerRef(cell) => {
+            let inner = cell.lock().unwrap().clone();
+            element_needs_trailing_comma(&inner)
+        }
+        Value::Range(..)
+        | Value::RangeExcl(..)
+        | Value::RangeExclStart(..)
+        | Value::RangeExclBoth(..)
+        | Value::GenericRange { .. }
+        | Value::Array(..)
+        | Value::Seq(..)
+        | Value::Hash(_) => true,
+        _ => false,
+    }
+}
+
+fn raku_array_wrap_counted(
+    inner: &str,
+    kind: ArrayKind,
+    count: usize,
+    single_listy: bool,
+) -> String {
+    // A real array with a single Iterable element renders with a trailing comma
+    // so the round-trip does not flatten it: `[1..5,]`, `$[(1, 2),]`.
+    let array_comma = if count == 1 && single_listy { "," } else { "" };
     match kind {
-        ArrayKind::Array | ArrayKind::Shaped | ArrayKind::Lazy => format!("[{}]", inner),
+        ArrayKind::Array | ArrayKind::Shaped | ArrayKind::Lazy => {
+            format!("[{}{}]", inner, array_comma)
+        }
         ArrayKind::List => {
             if count == 1 {
                 format!("({},)", inner)
@@ -163,7 +197,7 @@ fn raku_array_wrap_counted(inner: &str, kind: ArrayKind, count: usize) -> String
                 format!("({})", inner)
             }
         }
-        ArrayKind::ItemArray => format!("$[{}]", inner),
+        ArrayKind::ItemArray => format!("$[{}{}]", inner, array_comma),
         ArrayKind::ItemList => {
             if inner.is_empty() {
                 "$( )".to_string()
@@ -178,7 +212,7 @@ fn raku_array_wrap_counted(inner: &str, kind: ArrayKind, count: usize) -> String
 
 fn raku_array_wrap(inner: &str, kind: ArrayKind) -> String {
     // Fallback without count (used for self-referencing snapshot rendering)
-    raku_array_wrap_counted(inner, kind, 2) // count=2 to avoid trailing comma
+    raku_array_wrap_counted(inner, kind, 2, false) // count=2 to avoid trailing comma
 }
 
 /// Render a value for `.raku` but strip itemization (Scalar container).
@@ -300,7 +334,13 @@ fn raku_value_array(items: &[Value], kind: ArrayKind, v: &Value) -> String {
         .collect();
     let count = rendered.len();
     let inner = rendered.join(", ");
-    raku_array_wrap_counted(&inner, kind, count)
+    // For a real (`@`-sigil) array, a single Iterable element needs a trailing
+    // comma (`[1..5,]`); a self-referential marker element does not.
+    let single_listy = count == 1
+        && kind.is_real_array()
+        && !is_self_array_ref_marker(&items[0])
+        && element_needs_trailing_comma(&items[0]);
+    raku_array_wrap_counted(&inner, kind, count, single_listy)
 }
 
 pub fn raku_value(v: &Value) -> String {

--- a/t/array-single-listy-raku-comma.t
+++ b/t/array-single-listy-raku-comma.t
@@ -1,0 +1,38 @@
+use Test;
+
+# A real (`@`-sigil) array whose `.raku` has a single element that is itself an
+# Iterable (Range, List/Array, Seq, Hash/Map) renders with a trailing comma so
+# the round-trip does not flatten it: `[1..5,]`, `[(1, 2),]`, `[{:x(1)},]`.
+# Pair, Set/Bag (constructor-call forms), scalars, and type objects do NOT.
+
+plan 18;
+
+# --- single Iterable element => trailing comma -----------------------------
+
+{ my @a = 1..5,;            is @a.raku, '[1..5,]',            'single Range'; }
+{ my @a = $(1, 2),;         is @a.raku, '[(1, 2),]',          'single itemized List'; }
+{ my @a = $[1, 2],;         is @a.raku, '[[1, 2],]',          'single itemized Array'; }
+{ my @a = %(x => 1),;       is @a.raku, '[{:x(1)},]',         'single Hash'; }
+{ my @a = (1..5).Seq,;      is @a.raku, '[(1, 2, 3, 4, 5).Seq,]', 'single Seq'; }
+is [[1, 2, 3],].raku,       '[[1, 2, 3],]',                   'array literal: single Array';
+{ my @a = [1, 2, 3],;       is @a.raku, '[[1, 2, 3],]',       'single Array element'; }
+
+# --- single non-Iterable element => NO trailing comma ----------------------
+
+{ my @a = 42,;              is @a.raku, '[42]',               'single Int: no comma'; }
+{ my @a = "s",;             is @a.raku, '["s"]',              'single Str: no comma'; }
+{ my @a = (1 => 2),;        is @a.raku, '[1 => 2]',           'single Pair: no comma'; }
+{ my @a = Any,;             is @a.raku, '[Any]',              'single type object: no comma'; }
+
+# --- itemized array ($[...]) follows the same rule -------------------------
+
+is $[$(1, 2)].raku,         '$[(1, 2),]',                     'item-array: single listy';
+is $[42].raku,              '$[42]',                          'item-array: single scalar';
+
+# --- regressions guard: unchanged cases ------------------------------------
+
+is [].raku,                 '[]',                             'empty array';
+is [1, 2, 3].raku,          '[1, 2, 3]',                      'multi scalar';
+is [[1, 2], [3, 4]].raku,   '[[1, 2], [3, 4]]',               'multi array';
+is (1, 2, 3).raku,          '(1, 2, 3)',                      'multi-element list';
+is (1..5,).raku,            '(1..5,)',                        'single-element list keeps comma';


### PR DESCRIPTION
## Summary

A real (`@`-sigil) array whose `.raku` has exactly one element that is itself an Iterable rendered without the disambiguating trailing comma:

```raku
my @a = 1..5,;       say @a.raku;   # was [1..5]    → [1..5,]
my @a = $(1, 2),;    say @a.raku;   # was [(1, 2)]  → [(1, 2),]
my @a = %(x => 1),;  say @a.raku;   # was [{:x(1)}] → [{:x(1)},]
```

Raku adds the comma when the sole element is an Iterable whose bare `.raku` literal would otherwise flatten/merge into the array — **Range, List/Array, Seq, Hash/Map**. **Pair, Set/Bag/Mix** (rendered as constructor calls), **scalars**, and **type objects** keep getting no comma. Single-element *list* (`(x,)`) rendering was already correct; this extends the same disambiguation to real arrays and itemized arrays (`$[(1, 2),]`) via a new `element_needs_trailing_comma` helper threaded into `raku_array_wrap_counted`.

## Verification

- `make test` PASS (Files=1048, Tests=10179).
- Sampled array/list-rendering roast files (`S02-types/array.t`, `S32-list/{squish,categorize,grep}.t`) — no regressions.
- Regression guards in the test cover empty/multi-element arrays and lists.

## Test

`t/array-single-listy-raku-comma.t` — 18 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)