### PR TITLE
refactor(single-store): physically remove env_dirty dual-store dead code

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -49,8 +49,10 @@
   恒久 `true` にフリップし、**cell-boxing を唯一のコヒーレンス機構**にした（env→locals reconcile を retire）。
   根拠＝double-OFF survey（roast whitelist 1285・proper harness）＋ フル `make test`（`t/` 10135）が両方この状態で 0 失敗。
   これで goal「env↔locals コンテナ cell 共有」を**デフォルト挙動として実現**。
-  - 🟡 **残＝`env_dirty` / `reconcile_locals_from_env_at_site` / `ensure_locals_synced` / `saved_env_dirty` の物理削除**
-    （344 uses・dead code 化済み＝挙動不変の機械的クリーンアップ）。reconcile は no-op 化済みなので段階的に削除可。
+  - ✅ **物理削除 完了（2026-06-23）**: `env_dirty`（342 uses）/ `saved_env_dirty`（21）/ `reconcile_locals_from_env_at_site`（33）
+    / `blanket_reconcile_if_dirty` / `ensure_locals_synced` / `cell_boxing_active()`（恒久 true ゲート 24）/
+    `blanket_reconcile_disabled` / `precise_reconcile_disabled` を全て物理削除（挙動不変・604 行削除）。
+    cell-boxing ＋ precise writeback が唯一のコヒーレンス機構。make test + clippy green。
 - 🟡 **`env_dirty` 物理削除の substrate グラインドは完了**（2026-06-22）。`env_dirty` は
   ①blanket reconcile のゲート（boxing 下で無効＝除去可）と②**精密 reconcile（`reconcile_locals_from_env_at_site`・
   carrier/Proxy STORE/let-temp/closure 等のサイト）の perf ゲート（boxing 下でも load-bearing）**の2役だった。
@@ -109,8 +111,9 @@
 - **★★ roast double-OFF 決定的サーフェス = 0 到達（S4〜S21）＝`env_dirty` 物理削除の前提達成**。残る非決定的のみ＝
   full-consumption-through-pipe gather tail writeback（lazy pipe 経由 grep の内側 force が誤フレームに drop-on-miss・roast 非該当）
   ＋IO-Socket-Async.t flaky。
-- **∴ 次 = `env_dirty` 物理削除（§2-E）着手可能**: `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 →
-  `env_dirty`/`ensure_locals_synced`/`saved_env_dirty` 物理削除 → `cell_boxing_active()` gate 撤去で boxing 恒久 ON 化。
+- **✅ `env_dirty` 物理削除 完了（2026-06-23）**: `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site`/
+  `ensure_locals_synced` 関数と全 call site・`env_dirty`/`saved_env_dirty` フィールド・`cell_boxing_active()` ゲートを削除。
+  残る `env_dirty` 言及はコメントの履歴 breadcrumb のみ（挙動非依存）。§2-E 完了。
   着手前に念のため authoritative double-OFF survey（`MUTSU_BIN=… prove -e scripts/run-roast-test.sh` で全 whitelist）を再実走し 0 を再確認。
 
 ### B. tree-walking interpreter 撤去 — **struct 統合は完了・残フォークは状態所有待ち**
@@ -156,8 +159,8 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
         化し lazy ソースを eager force しないように修正。`my @res = one.kv` が gather body（`$was-lazy=0`）を走らせず、OFF で
         も PASS。値は eager 版とバイト一致（pairs=`i=>elem` / antipairs=`elem=>i` / kv=`i,elem` flat）。無限ソース上でも lazy。
       - IO-Socket-Async.t 5,7 = reactive 並行 flaky（決定的 pin 不可・env_dirty 削除の `blanket_reconcile_if_dirty` 空洞化で実挙動確認）。
-- [ ] **★次の本丸 = `env_dirty` 物理削除（§2-E・→ §1-A 解禁）**: OFF survey の決定的サーフェスが枯渇したので、
-      `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/`ensure_locals_synced`/`saved_env_dirty` 削除に着手できる。
+- ✅ **`env_dirty` 物理削除 完了（2026-06-23・§2-E）**: `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site`/
+      `ensure_locals_synced` 関数と全 call site・`env_dirty`/`saved_env_dirty` フィールド・`cell_boxing_active()` ゲートを削除（604 行減）。
 - [ ] follow-up（pre-existing・小）: `$x = @arr` 共有の method param 版（`method m($n){ $n.push }`）・`is copy` $-param。
       設計＝[docs/scalar-array-sharing.md](docs/scalar-array-sharing.md) §5。
 
@@ -173,9 +176,9 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 
 ### E. 単一ストア化の総仕上げ（C 完了後）
 
-- [ ] **`env_dirty` / `ensure_locals_synced` / `saved_env_dirty` 削除**（§1-A）。**前提 = §C Sub-slice 1b で
-      env↔locals がコンテナ cell 共有し乖離しなくなること。** ここで `pairs`/`slip` carrier-drop も安全化し、
-      `locals` が単一権威・`env` は派生ビューになる。`ensure_locals_synced` は既に1行（`env_dirty=false`）へ縮退済。
+- ✅ **`env_dirty` / `ensure_locals_synced` / `saved_env_dirty` 削除 完了（2026-06-23）**。cell-boxing ＋ precise
+      writeback が唯一のコヒーレンス機構。`locals` が単一権威・`env` は派生ビュー。残課題は §C（コンテナ cell 共有の
+      `pairs`/`slip` carrier-drop 安全化）だが、env_dirty 削除自体は完了。
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,26 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### `env_dirty` dual-store 機構の物理削除 — cell-boxing が唯一のコヒーレンス機構に（2026-06-23）
+
+#3450 で cell-boxing を恒久コヒーレンス機構にした（`blanket_reconcile_disabled()`/`precise_reconcile_disabled()`
+を恒久 `true` にフリップ）後の機械的フォローアップ。tree-walk 時代から残っていた env→locals reconcile の
+**dead code を物理削除**した（挙動不変・約 604 行削除）:
+
+- 関数: `reconcile_locals_from_env_at_site`（精密 reconcile・早期 return で no-op 化済）/ `blanket_reconcile_if_dirty`
+  （blanket reconcile・常に false ゲート）/ `ensure_locals_synced`（`env_dirty=false` のみ）/ `blanket_reconcile_disabled`
+  / `precise_reconcile_disabled` / `cell_boxing_active`（恒久 `true` を返すゲート）。
+- フィールド: `Interpreter::env_dirty`（342 uses・大半は `= true`/`= false` の no-op マーク）/ `VmCallFrame::saved_env_dirty`
+  （call frame save/restore の 21 uses）。
+- 全 call site（reconcile 呼び出し 33・cell_boxing ゲート 24・ensure_locals_synced 10 他）を削除し、`cell_boxing_active()`
+  ゲートで分岐していた precise writeback（`.defined`/Proxy STORE/does-but mixin/react-whenever/junction autothread/
+  CONTROL handler 他）を全て無条件化（default build = boxing ON と byte-identical）。
+
+これで `locals` が単一権威・`env` は派生ビューとなり、PLAN §1-A/§2-E の「単一ストア化 物理削除」が完了。
+コヒーレンスは cell-boxing（captured-outer write を共有 `ContainerRef` cell に畳む）＋ precise writeback
+（`pending_rw_writeback_sources`/`pending_caller_var_writeback` の call-site drain）の 2 機構のみが担う。
+make test（`t/` 10135）+ clippy `-D warnings` green。
+
 ### web ブログスタック第2弾: File::Temp 完動 — `use`/`unit module` の `:ver<>:auth<>` adverb（PR #3399, 2026-06-22）
 
 Template::Mustache（#3395）に続く2つ目の web ブログスタックモジュール **File::Temp 0.0.12**（+ 依存の

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -2139,9 +2139,7 @@ impl Interpreter {
         // captured-outer boxing (docs/captured-outer-cell-sharing.md). Gated on the
         // same toggle as the boxing it supports, so the default build is
         // byte-identical to before.
-        if self.cell_boxing_active()
-            && let Some(Value::ContainerRef(arc)) = self.env.get(&name).cloned()
-        {
+        if let Some(Value::ContainerRef(arc)) = self.env.get(&name).cloned() {
             arc.lock().unwrap().clone_from(&restored);
             return;
         }

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -516,17 +516,13 @@ impl Interpreter {
                     // site (`apply_pending_rw_writeback`).
                     let cas_pre_env: Option<
                         std::collections::HashMap<crate::symbol::Symbol, Value>,
-                    > = if self.cell_boxing_active() {
-                        Some(
-                            self.env
-                                .iter()
-                                .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
-                                .map(|(k, v)| (*k, v.clone()))
-                                .collect(),
-                        )
-                    } else {
-                        None
-                    };
+                    > = Some(
+                        self.env
+                            .iter()
+                            .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
+                            .map(|(k, v)| (*k, v.clone()))
+                            .collect(),
+                    );
                     let result = self.call_sub_value(code.clone(), call_args, bind_dollar_topic)?;
                     if let Some(cas_pre_env) = cas_pre_env {
                         let changed: Vec<String> = self

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -403,7 +403,6 @@ impl Interpreter {
         // observes them. Only changed slots are written, to keep blast radius
         // minimal.
         let handler_locals = std::mem::replace(&mut self.locals, saved_locals);
-        let armed = self.cell_boxing_active();
         for (i, name) in code.locals.iter().enumerate() {
             if name.is_empty() {
                 continue;
@@ -411,25 +410,17 @@ impl Interpreter {
             if handler_locals[i] != seeded[i] {
                 self.env_mut()
                     .insert(name.clone(), handler_locals[i].clone());
-                // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
-                // the handler body mutated the installing frame's lexical `name`
-                // by writing `env` here, but the frame's local SLOT is reached only
-                // by the blanket/precise `reconcile_locals_from_env_at_site` at the
-                // warn-call site — a no-op once env_dirty is removed (double-OFF: a
-                // *resumed* indirect `warn` left the caller's `$out` slot stale even
-                // though env held the handler's write). Record the name for the
-                // non-gated precise drain (`apply_pending_rw_writeback`) that every
-                // call site already runs: drop-on-miss for the same frame, plus
-                // retain-on-miss so a deeper raise site carries it up to the
-                // installing frame. Armed only under boxing; the default build's
-                // blanket reconcile covers it (byte-identical).
-                if armed {
-                    self.pending_rw_writeback_sources.push(name.clone());
-                    self.record_caller_var_writeback(name);
-                }
+                // The handler body mutated the installing frame's lexical `name`
+                // by writing `env` here (double-OFF: a *resumed* indirect `warn`
+                // left the caller's `$out` slot stale even though env held the
+                // handler's write). Record the name for the precise drain
+                // (`apply_pending_rw_writeback`) that every call site runs:
+                // drop-on-miss for the same frame, plus retain-on-miss so a deeper
+                // raise site carries it up to the installing frame.
+                self.pending_rw_writeback_sources.push(name.clone());
+                self.record_caller_var_writeback(name);
             }
         }
-        self.env_dirty = true;
 
         self.set_when_matched(saved_when);
         if let Some(v) = saved_topic {

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -88,26 +88,17 @@ impl Interpreter {
                 "X::Assignment::RO: target is not assignable",
             ));
         };
-        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a user
-        // `Proxy` STORE (`STORE => method ($v) { $realvar = $v }` from an lvalue
-        // sub) mutates a captured-outer caller lexical by name. The slot is the
-        // assign-caller's, reached only via the blanket reconcile at the assign
-        // site — a no-op once env_dirty is removed. Snapshot the env scalars before
-        // STORE so the names it changed can be recorded for the retain-on-miss
-        // caller-var writeback, which the assign call site drains. Armed only under
-        // boxing; the default build's blanket reconcile covers it (byte-identical).
-        let pre_env: Option<std::collections::HashMap<crate::symbol::Symbol, Value>> =
-            if self.cell_boxing_active() {
-                Some(
-                    self.env
-                        .iter()
-                        .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
-                        .map(|(k, v)| (*k, v.clone()))
-                        .collect(),
-                )
-            } else {
-                None
-            };
+        // A user `Proxy` STORE (`STORE => method ($v) { $realvar = $v }` from an
+        // lvalue sub) mutates a captured-outer caller lexical by name. Snapshot the
+        // env scalars before STORE so the names it changed can be recorded for the
+        // retain-on-miss caller-var writeback, which the assign call site drains.
+        let pre_env: Option<std::collections::HashMap<crate::symbol::Symbol, Value>> = Some(
+            self.env
+                .iter()
+                .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
+                .map(|(k, v)| (*k, v.clone()))
+                .collect(),
+        );
         let store_result =
             self.call_sub_value(*storer.clone(), vec![proxy.clone(), value.clone()], true);
         if let Err(err) = store_result {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1218,7 +1218,6 @@ pub struct Interpreter {
     /// handler via `.last()` and, if it is `resume_safe`, run it inline at the
     /// raise site (cross-frame resumable warn). See `vm::ControlHandlerEntry`.
     pub(crate) control_handlers: Vec<crate::vm::ControlHandlerEntry>,
-    pub(crate) env_dirty: bool,
     /// Address of the `CompiledCode` of the bytecode frame currently executing
     /// in `exec_one` (set at the top of every dispatch). Used by the lazy-force
     /// machinery to reconcile the *caller's* local slots from env after a reify
@@ -1233,8 +1232,8 @@ pub struct Interpreter {
     /// When `Some`, a *carrier* (EVAL / interpreter fallback) is running and
     /// every by-name env write through `set_env_with_main_alias` logs its name
     /// here. On carrier return, exactly these names are written back into the
-    /// caller's slots (`writeback_carrier_writes`), replacing the blanket
-    /// `env_dirty` pull for that carrier. See docs/vm-single-store.md Slice B.
+    /// caller's slots (`writeback_carrier_writes`). See docs/vm-single-store.md
+    /// Slice B.
     pub(crate) carrier_writes: Option<std::collections::HashSet<String>>,
     pub(crate) method_dispatch_pure: bool,
     pub(crate) resume_ip: Option<usize>,
@@ -3428,7 +3427,6 @@ impl Interpreter {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             control_handlers: Vec::new(),
-            env_dirty: false,
             current_code: 0,
             carrier_writes: None,
             method_dispatch_pure: false,
@@ -6024,7 +6022,6 @@ impl Interpreter {
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
             control_handlers: Vec::new(),
-            env_dirty: false,
             current_code: 0,
             carrier_writes: None,
             method_dispatch_pure: false,

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -806,17 +806,13 @@ impl Interpreter {
                     // before the clause runs and record the names it changes into the
                     // retain-on-miss caller-var writeback, drained at the call site.
                     let pre_env: Option<std::collections::HashMap<crate::symbol::Symbol, Value>> =
-                        if self.cell_boxing_active() {
-                            Some(
-                                self.env
-                                    .iter()
-                                    .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
-                                    .map(|(k, v)| (*k, v.clone()))
-                                    .collect(),
-                            )
-                        } else {
-                            None
-                        };
+                        Some(
+                            self.env
+                                .iter()
+                                .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
+                                .map(|(k, v)| (*k, v.clone()))
+                                .collect(),
+                        );
                     let ok = match where_expr.as_ref() {
                         Expr::AnonSub { body, .. } => self
                             .eval_block_value(body)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -207,7 +207,6 @@ pub(crate) struct VmCallFrame {
     /// without cloning the whole set). Removed on `pop_call_frame`. Empty for the
     /// slow path, which restores the full set via `saved_readonly` instead.
     pub readonly_added: Vec<String>,
-    pub saved_env_dirty: bool,
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }
 
@@ -653,7 +652,6 @@ impl Interpreter {
         // the outer execution next reads a local. (The ping-pong achieved this
         // implicitly: the inner Interpreter's env flowed back through the interpreter and
         // the caller re-synced from it.)
-        self.env_dirty = true;
 
         result
     }
@@ -2762,7 +2760,6 @@ impl Interpreter {
                 let left = self.stack.pop().unwrap();
                 let out = loan_env!(self, eval_sequence_values(left, right, *exclude_end))?;
                 self.stack.push(out);
-                self.env_dirty = true;
                 *ip += 1;
             }
 
@@ -2839,15 +2836,12 @@ impl Interpreter {
                 let has_user_defined = class_name
                     .as_ref()
                     .is_some_and(|cn| self.has_user_method(&cn.resolve(), "defined"));
-                // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
-                // a user `.defined` mutates a captured-outer lexical by name in env
+                // A user `.defined` mutates a captured-outer lexical by name in env
                 // via the interpreter slow path (`run_instance_method`), which
                 // records nothing this site can drain. Snapshot the caller frame's
                 // slot-backing env values before the call so only the changed slots
-                // are written through after — the precise form of the blanket
-                // reconcile below. Armed only under boxing; the default build keeps
-                // the unconditional pull.
-                let armed = has_user_defined && self.cell_boxing_active();
+                // are written through after.
+                let armed = has_user_defined;
                 let pre_env: Vec<Option<Value>> = if armed {
                     code.locals
                         .iter()
@@ -2910,9 +2904,6 @@ impl Interpreter {
                             self.locals[i] = cur;
                         }
                     }
-                }
-                if has_user_defined {
-                    self.reconcile_locals_from_env_at_site(code);
                 }
                 self.stack.push(defined);
                 *ip += 1;
@@ -3057,7 +3048,6 @@ impl Interpreter {
                 if let Some(Value::LazyList(list)) = self.stack.pop() {
                     // Sink context must realize lazy gathers for side effects.
                     self.force_lazy_list_vm(&list)?;
-                    self.env_dirty = true;
                 }
                 *ip += 1;
             }
@@ -3077,14 +3067,12 @@ impl Interpreter {
                     match &val {
                         Value::LazyList(list) => {
                             self.force_lazy_list_vm(list)?;
-                            self.env_dirty = true;
                         }
                         Value::LazyIoLines { handle, words, .. } => {
                             // Sinking a lazy IO lines iterator must drain the
                             // underlying handle so that side effects (read
                             // position, .eof) are observable.
                             loan_env!(self, force_lazy_io_lines(handle, *words))?;
-                            self.env_dirty = true;
                         }
                         _ => {
                             // Sinking an unhandled Failure always throws (Raku behavior)
@@ -3202,31 +3190,23 @@ impl Interpreter {
 
             // -- I/O --
             OpCode::Say(n) => {
-                self.ensure_locals_synced(code);
                 self.sync_env_from_locals(code);
                 self.exec_say_op(*n)?;
-                self.env_dirty = true;
                 *ip += 1;
             }
             OpCode::Put(n) => {
-                self.ensure_locals_synced(code);
                 self.sync_env_from_locals(code);
                 self.exec_put_op(*n)?;
-                self.env_dirty = true;
                 *ip += 1;
             }
             OpCode::Print(n) => {
-                self.ensure_locals_synced(code);
                 self.sync_env_from_locals(code);
                 self.exec_print_op(*n)?;
-                self.env_dirty = true;
                 *ip += 1;
             }
             OpCode::Note(n) => {
-                self.ensure_locals_synced(code);
                 self.sync_env_from_locals(code);
                 self.exec_note_op(*n)?;
-                self.env_dirty = true;
                 *ip += 1;
             }
 
@@ -4146,7 +4126,6 @@ impl Interpreter {
                 self.env_mut().insert(name.clone(), pkg_val.clone());
                 self.chain_declared_packages.insert(name.clone());
                 self.update_local_if_exists(code, &name, &pkg_val);
-                self.env_dirty = true;
                 *ip += 1;
             }
             OpCode::RegisterPackageMy { name_idx } => {
@@ -4163,7 +4142,6 @@ impl Interpreter {
                 if let Some(set) = self.block_declared_vars.last_mut() {
                     set.insert(name);
                 }
-                self.env_dirty = true;
                 *ip += 1;
             }
             OpCode::RegisterPackageStub { name_idx } => {
@@ -4573,7 +4551,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::GetLocalRaw(idx) => {
-                self.exec_get_local_raw_op(code, *idx);
+                self.exec_get_local_raw_op(*idx);
                 *ip += 1;
             }
             OpCode::SetLocal(idx) => {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -94,7 +94,6 @@ impl Interpreter {
         };
         self.env_mut()
             .insert(lookup_key.to_string(), Value::Array(Arc::new(items), kind));
-        self.env_dirty = true;
         Ok(Some(result.items))
     }
 
@@ -1002,18 +1001,11 @@ impl Interpreter {
     pub(super) fn exec_but_mixin_op(&mut self, code: &CompiledCode) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): `$obj but R`
-        // runs role R's `submethod TWEAK`/`BUILD` via the interpreter, which can
-        // mutate a captured-outer caller lexical by name (`my $invoked; role R {
-        // submethod TWEAK { $invoked = True } }`). Snapshot the overwritable slots
-        // for the precise diff that reconciles them under boxing (the reconcile
-        // below is the toggle-gated pull).
-        let armed = self.cell_boxing_active();
-        let pre_env = if armed {
-            self.snapshot_carrier_overwritable_env(code)
-        } else {
-            Vec::new()
-        };
+        // `$obj but R` runs role R's `submethod TWEAK`/`BUILD` via the interpreter,
+        // which can mutate a captured-outer caller lexical by name (`my $invoked;
+        // role R { submethod TWEAK { $invoked = True } }`). Snapshot the
+        // overwritable slots for the precise diff that reconciles them.
+        let pre_env = self.snapshot_carrier_overwritable_env(code);
         // `but` composing a role or another type into a type-object invocant is
         // illegal (no instance); mixing a concrete value (`Method but True`) is
         // allowed, so this only guards the role / type-object-RHS branches.
@@ -1042,15 +1034,9 @@ impl Interpreter {
                 return Err(Self::does_type_object_error("but", tn));
             }
             let composed = composed?;
-            // Stage 3: `$obj but R` runs role R's `submethod TWEAK`/`BUILD` via the
-            // interpreter (`eval_does_values`), which can mutate a captured-outer
-            // caller lexical by name (`my $invoked; role R { submethod TWEAK {
-            // $invoked = True } }`). Reconcile the caller's slots from env so the
-            // write is visible without the reverse `sync_locals_from_env` pull.
-            if armed {
-                self.carrier_writeback_changed_aggregates(code, &pre_env);
-            }
-            self.reconcile_locals_from_env_at_site(code);
+            // Reconcile the caller's slots from env so a captured-outer write made
+            // by the role's `submethod TWEAK`/`BUILD` is visible.
+            self.carrier_writeback_changed_aggregates(code, &pre_env);
             self.stack.push(composed);
             return Ok(());
         }
@@ -1279,23 +1265,13 @@ impl Interpreter {
         // Sync Interpreter locals to interpreter env so BUILD submethods can access
         // and modify closure variables from the enclosing scope.
         self.sync_env_from_locals(code);
-        // env_dirty substrate: snapshot for the precise BUILD/TWEAK captured-outer
-        // writeback (see exec_does_var_op).
-        let armed = self.cell_boxing_active();
-        let pre_env = if armed {
-            self.snapshot_carrier_overwritable_env(code)
-        } else {
-            Vec::new()
-        };
+        // Snapshot for the precise BUILD/TWEAK captured-outer writeback (see
+        // exec_does_var_op).
+        let pre_env = self.snapshot_carrier_overwritable_env(code);
         let result = self.vm_does_values(left, right)?;
-        // Sync back: BUILD submethods may have modified closure variables.
-        // Stage 3: use the toggle-independent reconcile so the BUILD submethod's
-        // captured-outer writes reach the caller's slots even with the reverse
-        // `sync_locals_from_env` pull disabled (byte-identical under ON).
-        if armed {
-            self.carrier_writeback_changed_aggregates(code, &pre_env);
-        }
-        self.reconcile_locals_from_env_at_site(code);
+        // Sync back: BUILD submethods may have modified closure variables, so the
+        // captured-outer writes reach the caller's slots.
+        self.carrier_writeback_changed_aggregates(code, &pre_env);
         // Capture Mixin value for trait_mod writeback (same as DoesVar path)
         if matches!(&result, Value::Mixin(..)) && self.trait_mod_writeback_key.is_some() {
             self.trait_mod_writeback_value = Some(result.clone());
@@ -1314,24 +1290,13 @@ impl Interpreter {
         // Sync Interpreter locals to interpreter env so BUILD submethods can access
         // and modify closure variables from the enclosing scope.
         self.sync_env_from_locals(code);
-        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a
-        // `submethod BUILD`/`TWEAK` run by the mixin can mutate a captured-outer
+        // A `submethod BUILD`/`TWEAK` run by the mixin can mutate a captured-outer
         // caller lexical (`my $n=0; role R { submethod TWEAK { $n++ } }; $x does R`).
-        // The reconcile below is the toggle-gated pull; snapshot the overwritable
-        // slots so the precise diff reconciles them under boxing too.
-        let armed = self.cell_boxing_active();
-        let pre_env = if armed {
-            self.snapshot_carrier_overwritable_env(code)
-        } else {
-            Vec::new()
-        };
+        // Snapshot the overwritable slots so the precise diff reconciles them.
+        let pre_env = self.snapshot_carrier_overwritable_env(code);
         let updated = self.vm_does_values(left, right)?;
         // Sync back: BUILD submethods may have modified closure variables.
-        // Stage 3: toggle-independent reconcile (see exec_does_op).
-        if armed {
-            self.carrier_writeback_changed_aggregates(code, &pre_env);
-        }
-        self.reconcile_locals_from_env_at_site(code);
+        self.carrier_writeback_changed_aggregates(code, &pre_env);
         let name = Self::const_str(code, name_idx).to_string();
         self.env_mut().insert(name.clone(), updated.clone());
         self.update_local_if_exists(code, &name, &updated);

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -461,7 +461,6 @@ impl Interpreter {
             }
 
             // Mark env as dirty so subsequent reads see updated values
-            self.env_dirty = true;
 
             // Refresh the target from the environment to pick up attribute mutations
             if let Some((ref cn, id)) = target_identity

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -509,8 +509,6 @@ impl Interpreter {
         };
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack_depth = self.stack.len();
-        let saved_env_dirty = self.env_dirty;
-        self.env_dirty = false;
 
         // Raku: routines get their own $_ initialized to (Any).
         let saved_topic = if cf.code.is_routine {
@@ -608,7 +606,6 @@ impl Interpreter {
 
         // Restore state
         self.locals = saved_locals;
-        self.env_dirty = saved_env_dirty;
 
         // Restore env: if env was mutated, merge non-local changes back.
         // When has_locals is false, saved_env is None and no restore is needed
@@ -624,7 +621,6 @@ impl Interpreter {
                     cf.code.locals.iter().map(|s| s.as_str()).collect()
                 };
             let scoped = std::mem::replace(self.env_mut(), caller_env);
-            let mut changed = false;
             for (k, v) in scoped.overlay_iter() {
                 // The callee's private topic / arg array / routine-id must not
                 // leak to the caller (the caller env already holds its own).
@@ -633,13 +629,7 @@ impl Interpreter {
                 }
                 if !k.with_str(|s| local_names.contains(s)) {
                     self.env_mut().insert_sym(*k, v.clone());
-                    changed = true;
                 }
-            }
-            // Mark env dirty so the caller re-syncs locals when a captured outer
-            // variable was modified (e.g. $a++ where $a is from the caller scope).
-            if changed {
-                self.env_dirty = true;
             }
         } else if let Some(saved_env) = saved_env {
             if saved_env.ptr_eq(self.env()) {
@@ -663,7 +653,6 @@ impl Interpreter {
                 // Mark env as dirty so caller re-syncs its locals from env.
                 // This is needed when captured outer variables were modified
                 // by the function (e.g. $a++ where $a is from the caller's scope).
-                self.env_dirty = true;
             }
         } else {
             // Slice 6.3 step 2: the no-merge case — a 0-local function (no overlay,
@@ -674,9 +663,7 @@ impl Interpreter {
             // no assign / increment / nested call / registration) cannot dirty a
             // caller slot — the dispatch's routine `_` is restored above — so it
             // needs no pull. Only a body that can write env forces the re-sync.
-            if cf.code.has_env_writes {
-                self.env_dirty = true;
-            }
+            if cf.code.has_env_writes {}
         }
 
         // Restore caller's $_ after routine call. In the scoped path the caller
@@ -1079,8 +1066,6 @@ impl Interpreter {
         }
 
         let saved_locals = std::mem::take(&mut self.locals);
-        let saved_env_dirty = self.env_dirty;
-        self.env_dirty = false;
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / local env writes land in a
@@ -1122,7 +1107,6 @@ impl Interpreter {
                     self.restore_readonly_vars(saved_readonly);
                     self.set_env(caller_env);
                     self.locals = saved_locals;
-                    self.env_dirty = saved_env_dirty;
                     {
                         let param_name = &cf.param_defs[param_idx].name;
                         let got = runtime::value_type_name(&val);
@@ -1207,7 +1191,6 @@ impl Interpreter {
         self.stack.truncate(saved_stack_depth);
 
         self.locals = saved_locals;
-        self.env_dirty = saved_env_dirty;
         self.restore_readonly_vars(saved_readonly);
 
         // Restore the caller env and merge the overlay (the callee's own writes)
@@ -1238,7 +1221,6 @@ impl Interpreter {
                 }
                 if !k.with_str(|s| local_names.contains(s)) {
                     self.env_mut().insert_sym(*k, v.clone());
-                    self.env_dirty = true;
                 }
             }
         }
@@ -1340,8 +1322,6 @@ impl Interpreter {
         self.record_cf_deprecation(cf);
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
-        let saved_env_dirty = self.env_dirty;
-        self.env_dirty = false;
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / alias / @_ env writes below
@@ -1445,7 +1425,6 @@ impl Interpreter {
                 } else if pd.required {
                     self.set_env(caller_env);
                     self.locals = saved_locals;
-                    self.env_dirty = saved_env_dirty;
                     // Missing required named parameter is a runtime X::AdHoc in
                     // Raku (see binding.rs); carry the typed exception so it does
                     // not fall back to the bare "Exception" default.
@@ -1472,7 +1451,6 @@ impl Interpreter {
                 } else if pd.required {
                     self.set_env(caller_env);
                     self.locals = saved_locals;
-                    self.env_dirty = saved_env_dirty;
                     return Err(RuntimeError::new(format!(
                         "Too few positionals passed; expected {} arguments but got {}",
                         cf.param_defs.iter().filter(|p| !p.named).count(),
@@ -1619,7 +1597,6 @@ impl Interpreter {
 
         // Restore locals
         self.locals = saved_locals;
-        self.env_dirty = saved_env_dirty;
 
         // Restore readonly vars
         self.restore_readonly_vars(saved_readonly);
@@ -1648,7 +1625,6 @@ impl Interpreter {
                 }
                 if !k.with_str(|s| local_names.contains(s)) {
                     self.env_mut().insert_sym(*k, v.clone());
-                    self.env_dirty = true;
                 }
             }
         }
@@ -1691,7 +1667,6 @@ impl Interpreter {
         // own nested-call dirtiness is about the callee env (subsumed by the merge
         // below), so it is reset before the body and recomputed from what the
         // merge actually wrote back to the caller env.
-        let saved_env_dirty = self.env_dirty;
         // Slice F: the rw-writeback list is drained by the call-site op right
         // after each dispatch returns, so it must hold *only* this call's
         // sources on return. Clear any leftover from a sibling whose call site
@@ -1887,7 +1862,6 @@ impl Interpreter {
         // Body-internal env_dirty (from nested calls) concerns the callee env,
         // which the return merge reconciles; reset so the post-merge value
         // reflects only what was actually written back to the caller.
-        self.env_dirty = false;
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -2049,7 +2023,6 @@ impl Interpreter {
         // `is rw` param writeback can alias a caller local slot; dynamic-var
         // writeback (pop_caller_env_with_writeback) targets `$*x` names that have
         // no compiled slot, so it never obliges a pull.
-        let mut changed = false;
         // Fast path: if the env wasn't mutated during the call (Arc still shared),
         // we can skip the expensive env merge and just restore directly.
         if restored_env.ptr_eq(self.env()) {
@@ -2061,11 +2034,6 @@ impl Interpreter {
                 self,
                 apply_rw_bindings_to_env(&rw_bindings, &mut restored_env)
             );
-            // An `is rw` param writeback aliases the caller's argument container,
-            // which may be a caller local slot -> force a re-sync.
-            if !rw_bindings.is_empty() {
-                changed = true;
-            }
             let rw_sources: std::collections::HashSet<String> = rw_bindings
                 .iter()
                 .map(|(_, source)| source.clone())
@@ -2115,22 +2083,11 @@ impl Interpreter {
                     && !k.with_str(|s| local_names.contains(s))
                     && !k.with_str(|s| rw_sources.contains(s))
                 {
-                    // Only a genuine value change (vs what the caller already had)
-                    // can leave a caller local slot stale.
-                    if restored_env.get_sym(*k) != Some(v) {
-                        changed = true;
-                    }
                     restored_env.insert_sym(*k, v.clone());
                 }
             }
             *self.env_mut() = restored_env;
         }
-        // A raw/Proxy return aliases a caller container in a way the value merge
-        // above does not see; keep the conservative mark for those.
-        if cf.is_raw {
-            changed = true;
-        }
-        self.env_dirty = saved_env_dirty || changed;
 
         // Slice F (env<->locals coherence): record the captured-outer variables
         // this body writes so the call-site op writes their new env values

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -64,7 +64,6 @@ impl Interpreter {
             // (`pending_*_writeback`). Drain it so the caller's slot refreshes without
             // the blanket env→locals pull (env_dirty-removal substrate).
             self.apply_pending_rw_writeback(code);
-            self.env_dirty = true;
             return Ok(());
         }
         if let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args) {
@@ -89,50 +88,20 @@ impl Interpreter {
             // Carrier may write the caller env by name (e.g. EVAL'd lexicals).
             // Slice B logs those writes (`begin_carrier`) and reconciles them into
             // the caller's slots on return (`writeback_carrier_writes`), so the
-            // reverse sync is precise. For a fully-reconciled EVAL we then drop the
-            // blanket `env_dirty` net (see below); other carriers keep it. See
-            // docs/vm-single-store.md.
-            let pre_dirty = self.env_dirty;
+            // reverse sync is precise. See docs/vm-single-store.md.
             let carrier_saved = self.begin_carrier();
             let exec_result = loan_env!(self, exec_call_values(&name, args));
             self.set_pending_call_arg_sources(None);
             let written = self.end_carrier(carrier_saved);
             exec_result?;
-            let fully = self.writeback_carrier_writes(code, &written);
             // This bareword carrier (EVAL and other interpreter-only routines)
             // writes caller lexicals through `set_env_with_main_alias` (EVAL's
             // SetGlobal) or — for an embedded regex `{ }`/`:my`/`:let` block —
-            // directly into env, which now also logs into the carrier set
-            // (regex_eval.rs, Slice C' / open-question #2). The writeback above
-            // reconciled every scalar it wrote into a current-frame slot; a
-            // diverged container leaves `fully` false (cell-aware, #3227) and
-            // ancestor lexicals have no current-frame slot (read straight from
-            // env). When the writeback was fully precise we drop the blanket
-            // env_dirty net that the nested run (`with_nested_registers`) sets
-            // unconditionally, eliminating the spurious per-carrier barrier pull
-            // (docs/vm-single-store.md Slice C': 1001 -> ~1 pulls on an
-            // EVAL-in-a-hot-loop). Restoring the *pre-carrier* dirty (not a blind
-            // clear) preserves a dirty the caller already owed. Validated by the
-            // full roast whitelist (byte-identical to the EVAL-only baseline) plus
-            // the regex/`:let`/`s///` t/ pins. (The `pairs`/`slip` carriers below
-            // keep their blanket — their interpreter builtins write through
-            // unlogged paths; see there.)
-            if fully {
-                self.env_dirty = pre_dirty;
-            } else {
-                self.env_dirty = true;
-                // Stage 3: the carrier writeback was not fully precise — an
-                // interpreter routine wrote a caller lexical by name through a
-                // path the carrier set does not log (e.g. an `is rw` for-loop
-                // alias mutated inside a `lives-ok { }` block, or a role/mixin
-                // composition). Reconcile the caller's slots from env here, at
-                // the call site, since the reverse `sync_locals_from_env` pull is
-                // no longer there to do it at the next sync point. Byte-identical
-                // to that pull under reverse-sync ON (same per-slot skips); only
-                // runs on the imprecise carrier path, never for a fully-reconciled
-                // EVAL (which restores `pre_dirty` above).
-                self.reconcile_locals_from_env_at_site(code);
-            }
+            // directly into env, which logs into the carrier set (regex_eval.rs,
+            // Slice C' / open-question #2). This writeback reconciles every scalar
+            // it wrote into a current-frame slot; cell-boxing keeps any diverged
+            // container / ancestor lexical coherent.
+            self.writeback_carrier_writes(code, &written);
         }
         Ok(())
     }
@@ -178,39 +147,19 @@ impl Interpreter {
         // builtins are not name-trackable and dropping the net corrupts cell
         // coherence (the CP-2 wall; t/element-bind-cell.t). See docs/vm-single-store.md.
         //
-        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a block
-        // Test function (`lives-ok { $b<a> = 42 }` / `lives-ok { $a does Role }`)
-        // mutates a captured-outer caller lexical through env, which
-        // `writeback_carrier_writes` leaves to the (now-removable) blanket pull.
-        // Snapshot the caller frame's slot-backing env values for the overwritable
-        // slots before the carrier, then write through only the slots whose env
-        // value changed. Plain Array/Hash and binding-cell slots are excluded (see
-        // `slot_carrier_overwritable`). Armed only under boxing; the default build
-        // keeps the blanket pull (byte-identical).
-        let armed = self.cell_boxing_active();
-        let pre_env: Vec<Option<Value>> = if armed {
-            self.snapshot_carrier_overwritable_env(code)
-        } else {
-            Vec::new()
-        };
+        // A block Test function (`lives-ok { $b<a> = 42 }` / `lives-ok { $a does
+        // Role }`) mutates a captured-outer caller lexical through env. Snapshot
+        // the caller frame's slot-backing env values for the overwritable slots
+        // before the carrier, then write through only the slots whose env value
+        // changed. Plain Array/Hash and binding-cell slots are excluded (see
+        // `slot_carrier_overwritable`).
+        let pre_env: Vec<Option<Value>> = self.snapshot_carrier_overwritable_env(code);
         let carrier_saved = self.begin_carrier();
         let exec_result = loan_env!(self, exec_call_pairs_values(&name, args));
         let written = self.end_carrier(carrier_saved);
         exec_result?;
         self.writeback_carrier_writes(code, &written);
-        if armed {
-            self.carrier_writeback_changed_aggregates(code, &pre_env);
-        }
-        self.env_dirty = true;
-        // Stage 3: a block-taking Test function (`lives-ok { ... }`,
-        // `throws-like`, ...) routes here (its `__mutsu_test_callsite_line`
-        // named arg makes it a pairs call) and runs its block through the
-        // interpreter, which can mutate a caller lexical by name through a path
-        // the carrier set does not log (an `is rw` for-loop alias inside the
-        // block). Reconcile the caller's slots from env at the call site, since
-        // the reverse `sync_locals_from_env` pull is gone. Byte-identical to that
-        // pull under reverse-sync ON (same per-slot HashSlotRef/`!attr` skips).
-        self.reconcile_locals_from_env_at_site(code);
+        self.carrier_writeback_changed_aggregates(code, &pre_env);
         Ok(())
     }
 
@@ -274,7 +223,6 @@ impl Interpreter {
         let written = self.end_carrier(carrier_saved);
         exec_result?;
         self.writeback_carrier_writes(code, &written);
-        self.env_dirty = true;
         Ok(())
     }
 }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -510,7 +510,6 @@ impl Interpreter {
             // env values through to this caller's local slots so they stay coherent
             // without the reverse `sync_locals_from_env` pull.
             self.apply_pending_rw_writeback(code);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -527,9 +526,7 @@ impl Interpreter {
             // pull (env_dirty-removal substrate). The blanket reconcile stays as the
             // fallback (no-op under the substrate harness).
             self.apply_pending_rw_writeback(code);
-            self.reconcile_locals_from_env_at_site(code);
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -545,12 +542,7 @@ impl Interpreter {
         // interpreter terminal.
         if let Some(callable) = lexical_override {
             let result = self.vm_call_on_value(callable, args, Some(compiled_fns))?;
-            // Slice F (multi-frame coherence): the dispatched lexical callable may
-            // mutate a caller lexical by name; this branch blanket-marks
-            // `env_dirty`, so reconcile the caller's slots from env too.
-            self.reconcile_locals_from_env_at_site(code);
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
         // Slice F (env<->locals coherence, docs/env-locals-coherence.md): the
@@ -598,14 +590,6 @@ impl Interpreter {
         // Slice F: write any `is rw` parameter writeback through to the caller's
         // local slot (see `apply_pending_rw_writeback`).
         self.apply_pending_rw_writeback(code);
-        // Slice F: a function call that dirtied env may have mutated a caller's
-        // captured-outer lexical by name — a native builtin running a thunk
-        // (X/Z-metaop thunks), a `multi sub` candidate body (`$reached = True`),
-        // an interpreter fallback, ... Reconcile the caller's slots from env so
-        // the write is visible without the reverse pull. Gated on `env_dirty`,
-        // exactly when the barrier would have pulled, so ON behavior is
-        // unchanged; a pure compiled call (env not dirtied) pays nothing.
-        self.blanket_reconcile_if_dirty(code);
         self.stack.push(result);
         // env_dirty is now managed inside dispatch_func_call_inner: the
         // interpreter / native fallback branches set it (they mutate env by
@@ -675,7 +659,6 @@ impl Interpreter {
             {
                 let result = self.vm_call_on_value(callable, args, Some(compiled_fns))?;
                 self.stack.push(result);
-                self.env_dirty = true;
                 return Ok(());
             }
         }
@@ -712,7 +695,6 @@ impl Interpreter {
                 let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
                 self.stack.push(result);
             }
-            self.env_dirty = true;
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             self.stack.push(native_result?);
         } else if let Some(callable) = self.lexical_amp_var_callable(Some(code), &name) {
@@ -723,7 +705,6 @@ impl Interpreter {
             // lexical_amp_var_callable excludes builtin / package-sub names.
             let result = self.vm_call_on_value(callable, args, Some(compiled_fns))?;
             self.stack.push(result);
-            self.env_dirty = true;
         } else {
             // Sync Interpreter locals to env before spawning threads so closures capture them
             if name == "start" {
@@ -732,7 +713,6 @@ impl Interpreter {
             let result = self.call_function_compiled_first(&name, args, compiled_fns)?;
             let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
             self.stack.push(result);
-            self.env_dirty = true;
         }
         Ok(())
     }
@@ -795,18 +775,7 @@ impl Interpreter {
         let result = result?;
         let result = loan_env!(self, maybe_fetch_rw_proxy(result, sub_is_rw))?;
         self.apply_pending_rw_writeback(code);
-        // Slice F (multi-frame coherence): a closure value invoked here
-        // (`$code()`/`$blk()`) — or a nested method/closure it calls — can mutate
-        // one of this caller frame's lexicals by name (e.g. a `$*OUT.print` whose
-        // method closes over the caller's `$output`). Reconcile the caller's slots
-        // from env so the write is visible at the next GetLocal without the reverse
-        // `sync_locals_from_env` pull. This path unconditionally marks `env_dirty`
-        // below (it cannot track the dispatched closure's writes precisely), so the
-        // reconcile is unconditional too — matching the blanket dirtiness the
-        // reverse pull would have acted on in the ON path.
-        self.reconcile_locals_from_env_at_site(code);
         self.stack.push(result);
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -889,13 +858,7 @@ impl Interpreter {
         };
         let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
         self.apply_pending_rw_writeback(code);
-        // Slice F (multi-frame coherence): see `exec_call_on_value_op`. A code var
-        // invoked by name (`&foo()` / `$blk()`) — or a callee it forwards to — may
-        // mutate a caller lexical by name; reconcile the caller's slots from env
-        // (this path also blanket-marks `env_dirty` below, so reconcile too).
-        self.reconcile_locals_from_env_at_site(code);
         self.stack.push(result);
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -912,7 +875,6 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         if let Some(callable) = call_me_override {
             let result = self.try_compiled_method_or_interpret(callable, "CALL-ME", args);
-            self.env_dirty = true;
             let result = result?;
             loan_env!(self, maybe_fetch_rw_proxy(result, true))
         } else {
@@ -1016,7 +978,6 @@ impl Interpreter {
                 // paths above instead rely on their own scoped-overlay merge to
                 // signal env_dirty only when a captured-outer write happened, so
                 // a pure compiled call no longer forces a per-call locals pull.
-                self.env_dirty = true;
                 if self.has_multi_candidates_cached(name) && !self.has_proto(name) {
                     // User-defined multi candidates take priority over builtins.
                     // Resolve the winning candidate Interpreter-side via the same resolver

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -1279,7 +1279,6 @@ impl Interpreter {
             // Write through the shared cell in place: every alias of this
             // iterator instance (caller var, locals) sees the advance directly.
             attributes.insert("index".to_string(), Value::Int(index as i64));
-            self.env_dirty = true;
         }
         Some(Ok(ret))
     }
@@ -1871,11 +1870,9 @@ impl Interpreter {
         // Save/swap stack and locals for the block
         let mut saved_locals = std::mem::take(&mut self.locals);
         let saved_stack = std::mem::take(&mut self.stack);
-        let saved_env_dirty = self.env_dirty;
 
         // Initialize locals for the block
         self.locals = vec![Value::Nil; block_cc.locals.len()];
-        self.env_dirty = false;
         if captured_env.is_some() {
             for (slot, name) in captured_bindings.iter() {
                 if (name.starts_with('@') || name.starts_with('%'))
@@ -1941,7 +1938,6 @@ impl Interpreter {
         // Restore outer state
         self.locals = saved_locals;
         self.stack = saved_stack;
-        self.env_dirty = saved_env_dirty;
 
         match exec_err {
             Some(e) => Err(e),
@@ -2017,7 +2013,6 @@ impl Interpreter {
                     self.env_mut().insert_sym(*k, v.clone());
                 }
             }
-            self.env_dirty = true;
         }
         if pushed_dispatch {
             self.pop_method_dispatch();

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -45,7 +45,6 @@ impl Interpreter {
             Some("+") => {
                 let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
                 self.stack.push(Value::array(vals));
-                self.env_dirty = true;
                 return Ok(());
             }
             Some("*") => {
@@ -56,7 +55,6 @@ impl Interpreter {
                     }
                     Err(e) => return Err(e),
                 }
-                self.env_dirty = true;
                 return Ok(());
             }
             _ => {}
@@ -132,7 +130,6 @@ impl Interpreter {
                     Value::RaceSeq(arc)
                 };
                 self.stack.push(result);
-                self.env_dirty = true;
                 return Ok(());
             }
             // HyperSeq/RaceSeq: delegate methods
@@ -145,24 +142,20 @@ impl Interpreter {
                 match method.as_str() {
                     "hyper" => {
                         self.stack.push(Value::HyperSeq(items_arc));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     "race" => {
                         self.stack.push(Value::RaceSeq(items_arc));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     "is-lazy" => {
                         self.stack.push(Value::Bool(false));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     "^name" => {
                         self.stack.push(Value::str(
                             if is_hyper { "HyperSeq" } else { "RaceSeq" }.to_string(),
                         ));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     "WHAT" => {
@@ -171,12 +164,10 @@ impl Interpreter {
                         } else {
                             "RaceSeq"
                         })));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     "defined" => {
                         self.stack.push(Value::Bool(true));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     "map" | "grep" => {
@@ -199,7 +190,6 @@ impl Interpreter {
                             Value::RaceSeq(Arc::new(result_items))
                         };
                         self.stack.push(wrapped);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     _ => {
@@ -216,7 +206,6 @@ impl Interpreter {
                             self.try_compiled_method_or_interpret(array_target, &method, args)
                         };
                         self.stack.push(call_result?);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                 }
@@ -239,7 +228,6 @@ impl Interpreter {
                 self.stack.push(call_result?);
             }
         }
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -279,7 +267,6 @@ impl Interpreter {
             Some("+") => {
                 let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
                 self.stack.push(Value::array(vals));
-                self.env_dirty = true;
                 return Ok(());
             }
             Some("*") => {
@@ -290,7 +277,6 @@ impl Interpreter {
                     }
                     Err(e) => return Err(e),
                 }
-                self.env_dirty = true;
                 return Ok(());
             }
             _ => {}
@@ -321,7 +307,6 @@ impl Interpreter {
         }
         let call_result = call_result?;
         self.stack.push(call_result);
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -405,7 +390,6 @@ impl Interpreter {
             let items = self.force_lazy_list_vm(ll)?;
             let reified = Value::real_array(items);
             self.env_mut().insert(target_name.clone(), reified.clone());
-            self.env_dirty = true;
             reified
         } else {
             target
@@ -542,7 +526,6 @@ impl Interpreter {
                 let t = self.eval_truthy(&target);
                 self.stack
                     .push(Value::Bool(if method == "not" { !t } else { t }));
-                self.env_dirty = true;
                 return Ok(());
             }
         }
@@ -604,10 +587,7 @@ impl Interpreter {
             // each eigenstate's sources into the retain-on-miss
             // `pending_caller_var_writeback` so all of them persist; the post-loop
             // drain then writes every owning caller slot precisely from env (which
-            // already holds the accumulated value), replacing the blanket
-            // `reconcile_locals_from_env_at_site` pull. Armed only under boxing; the
-            // default build keeps the blanket pull (byte-identical).
-            let armed = self.cell_boxing_active();
+            // already holds the accumulated value).
             for v in values.iter() {
                 let r = if let Some(threaded) =
                     self.maybe_autothread_method_args(v, &method, &args)?
@@ -619,15 +599,13 @@ impl Interpreter {
                     self.try_compiled_method_or_interpret(v.clone(), &method, args.clone())?
                 };
                 results.push(r);
-                if armed {
-                    let pending: Vec<String> = self
-                        .pending_rw_writeback_sources
-                        .drain(..)
-                        .chain(self.pending_caller_var_writeback.drain(..))
-                        .collect();
-                    for name in pending {
-                        self.record_caller_var_writeback(&name);
-                    }
+                let pending: Vec<String> = self
+                    .pending_rw_writeback_sources
+                    .drain(..)
+                    .chain(self.pending_caller_var_writeback.drain(..))
+                    .collect();
+                for name in pending {
+                    self.record_caller_var_writeback(&name);
                 }
             }
             let junction_result = Value::Junction {
@@ -635,7 +613,6 @@ impl Interpreter {
                 values: Arc::new(results),
             };
             self.stack.push(junction_result);
-            self.env_dirty = true;
             // Slice F (env<->locals coherence): an invocant junction that threads
             // a *user* method mutating a captured outer / `our` variable (e.g.
             // `$junc.a` with `method a { $cnt++ }`) accumulates each eigenstate's
@@ -643,21 +620,16 @@ impl Interpreter {
             // carries the *last* eigenstate's source — so a different variable
             // written by an earlier eigenstate (`$cnt1` vs the last `$cnt2`) never
             // reaches the caller's local slot. This junction path returns before
-            // the normal post-dispatch reconcile, so with the reverse env->locals
-            // pull disabled reconcile the caller's slots from env once here; env
-            // already holds every eigenstate's accumulated value. Byte-identical
-            // with the reverse pull enabled (gated on the env_dirty just set).
-            if armed {
-                self.apply_pending_caller_var_writeback(code);
-            }
-            self.reconcile_locals_from_env_at_site(code);
+            // the normal post-dispatch reconcile, so drain the accumulated
+            // per-eigenstate writebacks into the caller's slots here; env already
+            // holds every eigenstate's accumulated value.
+            self.apply_pending_caller_var_writeback(code);
             return Ok(());
         }
 
         // Junction auto-threading for method arguments (mut variant)
         if let Some(result) = self.maybe_autothread_method_args(&target, &method, &args)? {
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -671,7 +643,6 @@ impl Interpreter {
                 let stash = self.build_pseudo_stash(code, &pkg_name.resolve());
                 self.stack.push(stash);
             }
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -704,7 +675,6 @@ impl Interpreter {
             };
             let _ = crate::runtime::native_methods::release_lock(&lock, me);
             self.stack.push(result?);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -738,7 +708,6 @@ impl Interpreter {
                 let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.clone());
                 let result = self.shared_array_extend(&target_name, norm, method == "unshift");
                 self.stack.push(result);
-                self.env_dirty = true;
                 return Ok(());
             }
             let result = loan_env!(
@@ -747,7 +716,6 @@ impl Interpreter {
             )
             .unwrap_or_else(|| loan_env!(self, push_to_shared_var(&target_name, args, &target)));
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -872,7 +840,6 @@ impl Interpreter {
                 self.action_made = Some(value.clone());
             }
             self.stack.push(value);
-            self.env_dirty = true;
             return Ok(());
         }
         // `$s.subst-mutate(pattern, replacement, ...)` substitutes in place (like
@@ -912,7 +879,6 @@ impl Interpreter {
                 .insert(target_name.to_string(), new_str.clone());
             self.locals_set_by_name(code, &target_name, new_str);
             self.stack.push(ret);
-            self.env_dirty = true;
             return Ok(());
         }
         // .hyper/.race with named arguments in mut path
@@ -979,7 +945,6 @@ impl Interpreter {
                 Value::RaceSeq(arc)
             };
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
         // HyperSeq/RaceSeq delegation in mut path
@@ -1007,7 +972,6 @@ impl Interpreter {
                         _ => unreachable!(),
                     };
                     self.stack.push(result);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 "map" | "grep" => {
@@ -1040,7 +1004,6 @@ impl Interpreter {
                         Value::RaceSeq(std::sync::Arc::new(result_items))
                     };
                     self.stack.push(wrapped);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 _ => {
@@ -1068,7 +1031,6 @@ impl Interpreter {
                     let key = args[0].to_string_value();
                     let result = self.resolve_hash_entry(map, &key);
                     self.stack.push(result);
-                    self.env_dirty = true;
                     return Ok(());
                 }
             }
@@ -1096,7 +1058,6 @@ impl Interpreter {
                         let new_hash = self.tag_container_metadata(new_hash, meta);
                         self.env_mut().insert(target_name.to_string(), new_hash);
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Set(_, false) => {
@@ -1113,7 +1074,6 @@ impl Interpreter {
                         let new_val = Value::set_hash(new_set);
                         self.env_mut().insert(target_name.to_string(), new_val);
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Bag(_, false) => {
@@ -1130,7 +1090,6 @@ impl Interpreter {
                         let new_val = Value::bag_hash_big(new_counts);
                         self.env_mut().insert(target_name.to_string(), new_val);
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Mix(_, false) => {
@@ -1147,7 +1106,6 @@ impl Interpreter {
                         let new_val = Value::mix_hash(new_weights);
                         self.env_mut().insert(target_name.to_string(), new_val);
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Nil | Value::Package(_) => {
@@ -1156,7 +1114,6 @@ impl Interpreter {
                         self.env_mut()
                             .insert(target_name.to_string(), Value::Hash(Value::hash_arc(hash)));
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     _ => {}
@@ -1191,7 +1148,6 @@ impl Interpreter {
                         let new_hash = self.tag_container_metadata(new_hash, meta);
                         self.env_mut().insert(target_name.to_string(), new_hash);
                         self.stack.push(old_value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Set(_, false) => {
@@ -1204,7 +1160,6 @@ impl Interpreter {
                         let new_val = Value::set_hash(new_set);
                         self.env_mut().insert(target_name.to_string(), new_val);
                         self.stack.push(Value::Bool(existed));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Bag(_, false) => {
@@ -1217,7 +1172,6 @@ impl Interpreter {
                         let new_val = Value::bag_hash_big(new_counts);
                         self.env_mut().insert(target_name.to_string(), new_val);
                         self.stack.push(Value::from_bigint(old_count));
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Mix(_, false) => {
@@ -1231,12 +1185,10 @@ impl Interpreter {
                         self.env_mut().insert(target_name.to_string(), new_val);
                         let result = crate::value::mix_weight_to_value(old_weight);
                         self.stack.push(result);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Nil | Value::Package(_) => {
                         self.stack.push(Value::Nil);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     _ => {}
@@ -1289,7 +1241,6 @@ impl Interpreter {
                             self.update_local_if_exists(code, &source_name, &cell_val);
                         }
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Nil | Value::Package(_) => {
@@ -1324,7 +1275,6 @@ impl Interpreter {
                             self.update_local_if_exists(code, &source_name, &cell_val);
                         }
                         self.stack.push(value);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     Value::Set(_, mutable) => {
@@ -1357,7 +1307,6 @@ impl Interpreter {
             let empty_array = Value::real_array(vec![]);
             self.env_mut()
                 .insert(target_name.to_string(), empty_array.clone());
-            self.env_dirty = true;
             empty_array
         } else {
             target
@@ -1369,7 +1318,6 @@ impl Interpreter {
                 let vals =
                     self.call_method_all_with_fallback(&target, &method, &args, skip_native)?;
                 self.stack.push(Value::array(vals));
-                self.env_dirty = true;
             }
             Some("*") => {
                 match self.call_method_all_with_fallback(&target, &method, &args, skip_native) {
@@ -1379,7 +1327,6 @@ impl Interpreter {
                     }
                     Err(e) => return Err(e),
                 }
-                self.env_dirty = true;
             }
             _ => {
                 // Native fast path for mutating list methods on a plain, untyped
@@ -1394,7 +1341,6 @@ impl Interpreter {
                         self.try_native_array_mut(&target_name, &target, &method, &args)
                 {
                     self.stack.push(result?);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Symmetric bound-cell fast path for hash mutators (`%h.push` /
@@ -1408,7 +1354,6 @@ impl Interpreter {
                         self.try_native_hash_mut_bound(&target_name, &method, &args)
                 {
                     self.stack.push(result?);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Native fast path for the simple (non-erroring) forms of `splice`
@@ -1419,7 +1364,6 @@ impl Interpreter {
                         self.try_native_array_splice(&target_name, &target, &method, &args)
                 {
                     self.stack.push(result?);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Native fast path for mutating Buf write methods on a mutable Buf
@@ -1429,7 +1373,6 @@ impl Interpreter {
                         self.try_native_buf_mut(&target_name, &target, &method, &args)
                 {
                     self.stack.push(result?);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Native fast path for the Iterator protocol on a self-contained
@@ -1440,7 +1383,6 @@ impl Interpreter {
                     && let Some(result) = self.try_native_iterator(&target, &method, &args)
                 {
                     self.stack.push(result?);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Array-subclass instance delegation (mut path): when the Instance's
@@ -1512,7 +1454,6 @@ impl Interpreter {
                                 storage,
                             );
                             self.stack.push(result);
-                            self.env_dirty = true;
                             return Ok(());
                         }
                         // Perform the operation on the backing array
@@ -1547,7 +1488,6 @@ impl Interpreter {
                             storage,
                         );
                         self.stack.push(result);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                 }
@@ -1594,39 +1534,20 @@ impl Interpreter {
                 } else {
                     self.try_compiled_method_mut_or_interpret(&target_name, target, &method, args)
                 };
-                // Slice 6.3: mark env dirty only when the dispatch was not a
-                // proven-pure compiled method call.
-                let mark_dirty = !self.method_dispatch_pure;
                 match modifier {
                     Some("?") => match call_result {
                         Ok(val) => {
                             self.stack.push(val);
-                            if mark_dirty {
-                                self.env_dirty = true;
-                            }
                         }
                         Err(e) if Self::is_method_not_found_error(&e) => {
                             self.stack.push(Value::Nil);
-                            if mark_dirty {
-                                self.env_dirty = true;
-                            }
                         }
                         Err(e) => return Err(e),
                     },
                     _ => {
                         self.stack.push(call_result?);
-                        if mark_dirty {
-                            self.env_dirty = true;
-                        }
                     }
                 }
-                // Slice F: reconcile the caller's local slots from env after a
-                // method that dirtied env (a `submethod BUILD`/`TWEAK` during
-                // `.new`, a `.map`/`.grep`/`.sort` block, a `.gist`/`.Str`
-                // closure run by `say`/`note`, ...). Gated on `env_dirty`,
-                // exactly when the barrier would have pulled. See the CallMethod
-                // twin and `reconcile_locals_from_env_at_site`.
-                self.blanket_reconcile_if_dirty(code);
             }
         }
         Ok(())
@@ -1898,7 +1819,6 @@ impl Interpreter {
         };
         self.env_mut()
             .insert(target_name.to_string(), updated_instance);
-        self.env_dirty = true;
     }
 
     /// Interpreter-native `splice` on a plain, untyped `@`-array bound to `target_name`

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -379,7 +379,6 @@ impl Interpreter {
             && let Some(result) = self.autoviv_typed_array_push(&type_name.resolve(), &args)?
         {
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
         // .emit on any value: push to supply emit buffer if inside a supply
@@ -430,7 +429,6 @@ impl Interpreter {
                 let t = self.eval_truthy(&target);
                 self.stack
                     .push(Value::Bool(if method == "not" { !t } else { t }));
-                self.env_dirty = true;
                 return Ok(());
             }
         }
@@ -459,10 +457,8 @@ impl Interpreter {
         {
             let kind = kind.clone();
             let mut results = Vec::new();
-            // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
-            // accumulate EVERY eigenstate's by-name caller write (see the matching
+            // Accumulate EVERY eigenstate's by-name caller write (see the matching
             // CallMethodMut junction path for the full rationale).
-            let armed = self.cell_boxing_active();
             for v in values.iter() {
                 let r = if let Some(threaded) =
                     self.maybe_autothread_method_args(v, method, &args)?
@@ -474,15 +470,13 @@ impl Interpreter {
                     self.try_compiled_method_or_interpret(v.clone(), method, args.clone())?
                 };
                 results.push(r);
-                if armed {
-                    let pending: Vec<String> = self
-                        .pending_rw_writeback_sources
-                        .drain(..)
-                        .chain(self.pending_caller_var_writeback.drain(..))
-                        .collect();
-                    for name in pending {
-                        self.record_caller_var_writeback(&name);
-                    }
+                let pending: Vec<String> = self
+                    .pending_rw_writeback_sources
+                    .drain(..)
+                    .chain(self.pending_caller_var_writeback.drain(..))
+                    .collect();
+                for name in pending {
+                    self.record_caller_var_writeback(&name);
                 }
             }
             let junction_result = Value::Junction {
@@ -490,18 +484,13 @@ impl Interpreter {
                 values: Arc::new(results),
             };
             self.stack.push(junction_result);
-            self.env_dirty = true;
             // Slice F (env<->locals coherence): see the matching CallMethodMut
             // junction path. An invocant junction threading a user method that
             // mutates a captured-outer / `our` variable accumulates into env, but
             // only the last eigenstate's pending writeback reaches the caller's
-            // slots; this path returns before the normal post-dispatch reconcile,
-            // so reconcile the caller's local slots from env here (env already
-            // holds every eigenstate's value). Byte-identical with reverse-sync on.
-            if armed {
-                self.apply_pending_caller_var_writeback(code);
-            }
-            self.reconcile_locals_from_env_at_site(code);
+            // slots; drain the accumulated writeback into the caller's local slots
+            // (env already holds every eigenstate's value).
+            self.apply_pending_caller_var_writeback(code);
             return Ok(());
         }
 
@@ -509,7 +498,6 @@ impl Interpreter {
         // If any method arg is a Junction, auto-thread over it.
         if let Some(result) = self.maybe_autothread_method_args(&target, method, &args)? {
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -555,7 +543,6 @@ impl Interpreter {
             };
             let _ = crate::runtime::native_methods::release_lock(&lock, me);
             self.stack.push(result?);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -926,7 +913,6 @@ impl Interpreter {
                             Value::RaceSeq(Arc::new(result))
                         };
                         self.stack.push(wrapped);
-                        self.env_dirty = true;
                         return Ok(());
                     }
                     // Large list: fall through to array-based dispatch
@@ -958,7 +944,6 @@ impl Interpreter {
             let topic = self.env().get("_").cloned().unwrap_or(Value::Nil);
             let matched = self.vm_smart_match(&topic, &target);
             self.stack.push(Value::Bool(matched));
-            self.env_dirty = true;
             return Ok(());
         }
         // .WHO on pseudo-package Package values: build the stash in the Interpreter
@@ -971,7 +956,6 @@ impl Interpreter {
                 let stash = self.build_pseudo_stash(code, &pkg_name.resolve());
                 self.stack.push(stash);
             }
-            self.env_dirty = true;
             return Ok(());
         }
         // `.print(arg)` / `.say(arg)` / `.put(arg)` / `.note(arg)` on a Failure
@@ -1042,7 +1026,6 @@ impl Interpreter {
                 let vals =
                     self.call_method_all_with_fallback(&target, method, &args, skip_native)?;
                 self.stack.push(Value::array(vals));
-                self.env_dirty = true;
             }
             Some("*") => {
                 match self.call_method_all_with_fallback(&target, method, &args, skip_native) {
@@ -1052,7 +1035,6 @@ impl Interpreter {
                     }
                     Err(e) => return Err(e),
                 }
-                self.env_dirty = true;
             }
             _ => {
                 // Array-subclass instance delegation: when the Instance's class
@@ -1089,7 +1071,6 @@ impl Interpreter {
                             self.try_compiled_method_or_interpret(storage, method, args.clone());
                         if let Ok(val) = result {
                             self.stack.push(val);
-                            self.env_dirty = true;
                             return Ok(());
                         }
                         // Fall through to normal dispatch if delegation failed
@@ -1138,7 +1119,6 @@ impl Interpreter {
                                 _ => args,
                             };
                             self.stack.push(Value::real_array(arr));
-                            self.env_dirty = true;
                             return Ok(());
                         }
                         "defined" | "Bool" | "so" | "not" | "gist" | "Str" | "raku" | "perl"
@@ -1216,7 +1196,6 @@ impl Interpreter {
                         _ => args,
                     };
                     self.stack.push(Value::real_array(arr));
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // If we have a pending Proxy subclass attribute reference and this
@@ -1231,7 +1210,6 @@ impl Interpreter {
                     let result =
                         self.proxy_subclass_array_mutate(&attrs_ref, &attr_name, method, &args)?;
                     self.stack.push(result);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Fast path for shift/pop on array values in the non-mutating
@@ -1338,23 +1316,17 @@ impl Interpreter {
                     Some("?") => match call_result {
                         Ok(val) => {
                             self.stack.push(val);
-                            if mark_dirty {
-                                self.env_dirty = true;
-                            }
+                            if mark_dirty {}
                         }
                         Err(e) if Self::is_method_not_found_error(&e) => {
                             self.stack.push(Value::Nil);
-                            if mark_dirty {
-                                self.env_dirty = true;
-                            }
+                            if mark_dirty {}
                         }
                         Err(e) => return Err(e),
                     },
                     _ => {
                         self.stack.push(call_result?);
-                        if mark_dirty {
-                            self.env_dirty = true;
-                        }
+                        if mark_dirty {}
                     }
                 }
                 // Slice F: reconcile the caller's local slots from env after a

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -741,12 +741,18 @@ impl Interpreter {
             .param_defs
             .iter()
             .any(|pd| pd.sigilless || pd.traits.iter().any(|t| t == "rw" || t == "raw"));
+        // `cc.has_env_writes` catches a body that writes a captured-outer lexical
+        // by name (a `SetGlobal`/`AssignExpr` to a var that is captured but not
+        // tracked in `free_var_syms`, e.g. an anonymous role-method `gist` doing
+        // `$seen = 1`) — `free_changed` misses it, so without this the writeback
+        // is silently dropped. A read-only leaf block (the common map/grep body)
+        // has no env-write opcode and still skips the scan.
         let needs_caller_writeback = free_changed
-            || self.env_dirty
             || has_captured_local
             || has_writable_params
             || !rw_bindings.is_empty()
-            || cc.has_calls;
+            || cc.has_calls
+            || cc.has_env_writes;
         // Whether any closure-writeback metadata key (sigilless readonly/alias,
         // state-var, predictive-seq) may exist in any env. The common program
         // creates none, so this stays false and the per-call metadata scans
@@ -774,12 +780,7 @@ impl Interpreter {
             // refreshes the owner's local slot precisely — covers a nested
             // gist/method/closure that mutated an outer lexical which is NOT a direct
             // free var of THIS closure (`cap({ note … $seen = 1 })`), so the
-            // free_var recording below misses it (env_dirty-removal substrate).
-            // Only when cell-boxing is the coherence mechanism (boxing build /
-            // substrate harness): the default build's blanket reconcile already
-            // refreshes these slots, so skip the per-call collection to keep the hot
-            // closure path (`.map`, `.grep`) free of extra work.
-            let record_writeback = self.cell_boxing_active();
+            // free_var recording below misses it.
             let mut caller_writeback: Vec<Symbol> = Vec::new();
             for (k, v) in self.env().iter() {
                 if *k != underscore_sym
@@ -802,8 +803,7 @@ impl Interpreter {
                     }
                     // A genuine caller lexical whose value changed across the call:
                     // queue its slot for a precise refresh.
-                    if record_writeback
-                        && restored_env.contains_key_sym(*k)
+                    if restored_env.contains_key_sym(*k)
                         && restored_env.get_sym(*k) != Some(v)
                         && !k.starts_with("__mutsu")
                     {

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1245,7 +1245,6 @@ impl Interpreter {
         // was removed in Stage 3 (the interpreter-bridge writes it covered, e.g.
         // EVAL modifying a `$GLOBAL::` variable, are now reconciled by precise
         // write-throughs at their own sites).
-        self.env_dirty = false;
         self.sync_regex_interpolation_env_from_locals(code);
         let saved_in_smartmatch_rhs = self.in_smartmatch_rhs;
         self.in_smartmatch_rhs = true;
@@ -1388,21 +1387,16 @@ impl Interpreter {
             // (`apply_pending_caller_var_writeback`). This is what keeps the slot
             // coherent once the blanket/precise reconcile is gone (double-OFF). Only
             // armed under boxing; the default build's blanket reconcile covers it.
-            if self.cell_boxing_active() {
-                for name in &written {
-                    let is_match_name = name == "/"
-                        || (!name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()));
-                    if is_match_name || self.find_local_slot(code, name).is_some() {
-                        continue;
-                    }
-                    self.record_caller_var_writeback(name);
+            for name in &written {
+                let is_match_name =
+                    name == "/" || (!name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()));
+                if is_match_name || self.find_local_slot(code, name).is_some() {
+                    continue;
                 }
+                self.record_caller_var_writeback(name);
             }
         }
         self.pending_local_updates.clear();
-        if !pure {
-            self.env_dirty = true;
-        }
         // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a custom
         // HOW `type_check`/`accepts_type`/`find_method` invoked by this smartmatch
         // (`$obj ~~ $custom-type`) may mutate a captured-outer caller scalar (e.g.

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -573,7 +573,6 @@ impl Interpreter {
                 items.len()
             )));
         }
-        self.env_dirty = true;
         let body_start = *ip + 1;
         let loop_end = spec.body_end as usize;
 
@@ -1239,7 +1238,6 @@ impl Interpreter {
                 self,
                 overwrite_array_items_by_identity_for_vm(&source, source_items, source_kind,)
             );
-            self.env_dirty = true;
         }
         // Unmark readonly topic after loop completion
         if topic_readonly {
@@ -1389,7 +1387,6 @@ impl Interpreter {
         // them per-iteration (owned_captures). Balanced by pop on every exit.
         self.push_loop_local_scope();
 
-        self.env_dirty = true;
         // When resuming a gather coroutine, start from the saved position.
         let mut i = if let Some(crate::value::ForLoopResumeState::IntRange { current, .. }) =
             self.gather_for_loop_resume.take()
@@ -1642,8 +1639,6 @@ impl Interpreter {
         let saved_topic_source = self.topic_source_var.take();
         let was_topic_readonly = self.readonly_vars().contains("_");
 
-        self.env_dirty = true;
-
         if !spec.is_rw {
             if let Some(ref name) = param_name {
                 if !name.starts_with('@') && !name.starts_with('%') {
@@ -1828,7 +1823,6 @@ impl Interpreter {
             None
         };
 
-        self.env_dirty = true;
         let mut line_index: i64 = 0;
 
         'for_loop: loop {
@@ -2886,7 +2880,6 @@ impl Interpreter {
             self.env_mut().remove("_");
         }
         self.stack.push(last);
-        self.env_dirty = true;
         *ip = end;
         Ok(())
     }
@@ -3389,14 +3382,10 @@ impl Interpreter {
             Err(e) => {
                 // Exception — restore let saves
                 loan_env!(self, restore_let_saves(let_mark));
-                self.env_dirty = true;
                 // The restore wrote the saved values back into `env` only and
                 // recorded each restored name precisely (`restore_let_value`); drain
-                // it so this frame's slots refresh without the blanket env→locals
-                // pull (env_dirty-removal substrate). The blanket reconcile stays as
-                // the fallback (no-op under the substrate harness).
+                // it so this frame's slots refresh.
                 self.apply_pending_rw_writeback(code);
-                self.reconcile_locals_from_env_at_site(code);
                 if catch_begin >= control_begin {
                     return Err(e);
                 }

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -512,12 +512,10 @@ impl Interpreter {
                 };
                 let result = self.shared_array_extend(target_name, items, false);
                 self.stack.push(result);
-                self.env_dirty = true;
                 return Ok(());
             }
             let result = loan_env!(self, call_method_with_values(target, "push", vec![val]))?;
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
         // TODO: compile to bytecode — shaped-array push, blocked-by: shaped
@@ -531,7 +529,6 @@ impl Interpreter {
             let target = self.env().get(target_name).cloned().unwrap_or(Value::Nil);
             let result = loan_env!(self, call_method_with_values(target, "push", vec![val]))?;
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
         let mut val = self.stack.pop().unwrap_or(Value::Nil);
@@ -605,7 +602,6 @@ impl Interpreter {
                     let result = Value::Array(arr.clone(), kind);
                     drop(guard);
                     self.stack.push(result);
-                    self.env_dirty = true;
                     return Ok(());
                 }
                 // Non-array inner (e.g. Hash): generic clone-and-write-back.
@@ -614,12 +610,10 @@ impl Interpreter {
                 let result = loan_env!(self, call_method_with_values(inner, "push", vec![val]))?;
                 *cell.lock().unwrap() = result.clone();
                 self.stack.push(result);
-                self.env_dirty = true;
                 return Ok(());
             }
             let result = loan_env!(self, call_method_with_values(target, "push", vec![val]))?;
             self.stack.push(result);
-            self.env_dirty = true;
             return Ok(());
         }
 

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1,46 +1,6 @@
 use super::*;
 
-/// Whether the `env_dirty`-gated "blanket reconcile" barrier is disabled.
-///
-/// **Now permanently `true`.** Coherence rests on cell-boxing alone: every
-/// captured-outer write is folded into a shared `ContainerRef` cell (or a precise
-/// write-back), so the env→locals pull is no longer needed. This was a diagnostic
-/// toggle (`MUTSU_NO_BLANKET_RECONCILE`) during the substrate grind; the whole
-/// roast whitelist + the `t/` suite pass with it forced on (double-OFF survey =
-/// 0), so the blanket reconcile is retired. The `env_dirty` flag and the reconcile
-/// machinery it gates are now dead and removed incrementally.
-/// See docs/captured-outer-cell-sharing.md §7.4 / §10.
-#[inline]
-pub(crate) fn blanket_reconcile_disabled() -> bool {
-    true
-}
-
-/// Whether the *precise* env→locals reconcile (`reconcile_locals_from_env_at_site`,
-/// run at carrier/call sites) is disabled.
-///
-/// **Now permanently `true`** — see [`blanket_reconcile_disabled`]. With both
-/// reconciles retired, coherence rests on cell-boxing ALONE (the end state the
-/// substrate grind targeted). Every former by-name writer has been folded into a
-/// shared cell or a precise write-back, validated by the double-OFF survey
-/// (roast 1285 + `t/` all green).
-#[inline]
-pub(crate) fn precise_reconcile_disabled() -> bool {
-    true
-}
-
 impl Interpreter {
-    /// Clear the env-dirty flag at a barrier where the caller does not need a
-    /// reconcile. The blanket reverse `sync_locals_from_env` pull this used to
-    /// perform was removed in Stage 3 (docs/env-locals-coherence.md §7): every
-    /// by-name caller-lexical env write is now reconciled by a precise
-    /// write-through (`pending_rw_writeback_sources` /
-    /// `reconcile_locals_from_env_at_site` / carrier logging) at the sites that
-    /// need it. This barrier therefore only clears the flag — preserving the
-    /// no-op-pull behavior the default (reverse-sync-off) build already shipped.
-    pub(super) fn ensure_locals_synced(&mut self, _code: &CompiledCode) {
-        self.env_dirty = false;
-    }
-
     /// Collapse the interpreter's env to a flat (`parent=None`) env if it is
     /// currently a scoped overlay. No-op (O(1)) for a flat env. Used at every
     /// boundary that would otherwise let a transient scoped env survive into code
@@ -53,8 +13,8 @@ impl Interpreter {
         }
     }
 
-    /// Save the current env, locals, stack depth, readonly vars, and env_dirty flag
-    /// into a new call frame. Resets env_dirty to false for the new frame.
+    /// Save the current env, locals, stack depth, and readonly vars into a new
+    /// call frame.
     pub(super) fn push_call_frame(&mut self) {
         crate::vm::vm_stats::record_clone_env();
         // Save the caller env by an O(1) clone (an Arc bump, even when scoped):
@@ -68,10 +28,8 @@ impl Interpreter {
             readonly_added: Vec::new(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
-            saved_env_dirty: self.env_dirty,
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
         };
-        self.env_dirty = false;
         self.call_frames.push(frame);
     }
 
@@ -85,14 +43,12 @@ impl Interpreter {
             readonly_added: Vec::new(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_stack_depth: self.stack.len(),
-            saved_env_dirty: self.env_dirty,
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
         };
-        self.env_dirty = false;
         self.call_frames.push(frame);
     }
 
-    /// Pop the most recent call frame and restore locals, readonly vars, and env_dirty flag.
+    /// Pop the most recent call frame and restore locals and readonly vars.
     /// Returns the frame so callers can access `saved_env` for site-specific merge logic.
     pub(super) fn pop_call_frame(&mut self) -> VmCallFrame {
         let mut frame = self
@@ -110,7 +66,6 @@ impl Interpreter {
                 self.unmark_readonly(name);
             }
         }
-        self.env_dirty = frame.saved_env_dirty;
         frame
     }
 
@@ -336,64 +291,20 @@ impl Interpreter {
         }
     }
 
-    /// Precise env→locals reconcile at a call/construction site where an
-    /// interpreter bridge wrote a caller lexical by name. This is the surviving
-    /// mechanism that keeps the slot store coherent now that the blanket reverse
-    /// pull is gone (Stage 3, docs/env-locals-coherence.md §7). The canonical case
-    /// is an interpreter-dispatched construction (`.new`/`.bless` running a
-    /// `submethod BUILD`/`TWEAK` via `run_build_phase`) whose body mutates a
-    /// captured-outer lexical (`my $n; submethod BUILD { $n++ }`): unlike a
-    /// compiled method (whose `merge_method_env` records
-    /// `pending_rw_writeback_sources`), the interpreter build path never reaches
-    /// that machinery, so the caller's slot must be reconciled here at the call
-    /// site. The per-slot skips (HashSlotRef binding cells / `!attr` locals) match
-    /// the precise write-through family exactly. Gated by the caller on
-    /// `env_dirty` at the hot sites, so a pure call pays nothing.
-    pub(super) fn reconcile_locals_from_env_at_site(&mut self, code: &CompiledCode) {
-        if precise_reconcile_disabled() {
-            // Measurement harness (see `precise_reconcile_disabled`): with the
-            // precise reconcile off, only surfaces already folded into shared
-            // cells stay coherent. Used to drive the env_dirty-removal substrate
-            // grind toward the boxing-only end state.
-            return;
-        }
-        for (i, name) in code.locals.iter().enumerate() {
-            if matches!(self.locals[i], Value::HashSlotRef { .. }) {
-                continue;
-            }
-            if name.starts_with('!') {
-                continue;
-            }
-            if let Some(val) = self.env().get(name).cloned() {
-                self.locals[i] = val;
-            } else if let Some(bare) = name
-                .strip_prefix('$')
-                .or_else(|| name.strip_prefix('@'))
-                .or_else(|| name.strip_prefix('%'))
-                .or_else(|| name.strip_prefix('&'))
-                && let Some(val) = self.env().get(bare).cloned()
-            {
-                self.locals[i] = val;
-            }
-        }
-    }
-
     /// Record a by-name caller-lexical env write that did NOT flow through
     /// `set_env_with_main_alias` (the single by-name writer that auto-logs). Some
     /// ops mutate a caller lexical with a direct `env_mut().insert` — e.g. the
     /// `$x ~~ s///` writeback to its LHS variable. For the reverse sync to stay
     /// precise *and* complete (Slice C', open-question #2), every such write must
-    /// (a) log into the active carrier set so the carrier-return
+    /// log into the active carrier set so the carrier-return
     /// `writeback_carrier_writes` reconciles the caller slot — without this, an
     /// EVAL/carrier that dropped its blanket net (a fully-reconciled bareword
-    /// carrier, #3227/#3231) would silently lose the write — and (b) set
-    /// `env_dirty` so a non-carrier reader still pulls it. Call this right after
+    /// carrier, #3227/#3231) would silently lose the write. Call this right after
     /// the direct insert, for each caller-visible name written.
     pub(crate) fn note_caller_env_write(&mut self, name: &str) {
         if let Some(set) = self.carrier_writes.as_mut() {
             set.insert(name.to_string());
         }
-        self.env_dirty = true;
     }
 
     /// Begin a carrier region: start logging by-name env writes. Returns the
@@ -829,35 +740,6 @@ impl Interpreter {
     /// call (e.g. `fib`) never trips it and pays nothing.
     pub(super) fn drain_and_reconcile_after_cached_call(&mut self, code: &CompiledCode) {
         self.apply_pending_rw_writeback(code);
-        self.blanket_reconcile_if_dirty(code);
-    }
-
-    /// Multi-frame captured-outer accumulation barrier: when a nested callee wrote
-    /// a caller lexical *by name* (env_dirty), pull the env values back into the
-    /// caller's slots at the call site. This is the LAST load-bearing role of
-    /// `env_dirty` — the "blanket reconcile" that
-    /// docs/captured-outer-cell-sharing.md is incrementally replacing with shared
-    /// `ContainerRef` cells (a captured-outer lexical migrated to a shared cell no
-    /// longer needs this pull, because both the slot and the env hold the same
-    /// Arc). Once that surface is empty the whole mechanism (this method +
-    /// `env_dirty`) is deleted. Gated on `env_dirty` so a pure call (e.g. `fib`)
-    /// pays nothing; the `MUTSU_NO_BLANKET_RECONCILE` diagnostic disables it so the
-    /// remaining not-yet-cell-shared surface can be measured (see §5 of the doc).
-    #[inline]
-    pub(super) fn blanket_reconcile_if_dirty(&mut self, code: &CompiledCode) {
-        if self.env_dirty && !blanket_reconcile_disabled() {
-            self.reconcile_locals_from_env_at_site(code);
-        }
-    }
-
-    /// Whether captured-outer cell boxing is the active coherence mechanism (the
-    /// complement of the blanket reconcile — exactly one is on). Method wrapper
-    /// over `blanket_reconcile_disabled()` so callers outside the `vm` module
-    /// (e.g. `let`/`temp` restore in `runtime/`) can reach it. See
-    /// `box_decl_local_cell` and docs/captured-outer-cell-sharing.md.
-    #[inline]
-    pub(crate) fn cell_boxing_active(&self) -> bool {
-        blanket_reconcile_disabled()
     }
 
     /// Box each captured-outer scalar that a carrier body (`EVAL`, an embedded
@@ -869,11 +751,10 @@ impl Interpreter {
     /// `free_var_writes` analysis at the owner's decl site, so it cannot be boxed
     /// there; box it here at carrier-run time instead).
     ///
-    /// Gated on `cell_boxing_active()` (the `MUTSU_NO_BLANKET_RECONCILE` toggle):
-    /// in the default build the blanket reconcile carries this, so boxing stays
-    /// off and behaviour is byte-identical (see `box_decl_local_cell`).
+    /// Cell boxing is the permanent coherence mechanism (the env→locals reconcile
+    /// is retired), so this always boxes when there are free-var writes.
     pub(crate) fn box_carrier_free_var_writes(&mut self, code: &CompiledCode) {
-        if !self.cell_boxing_active() || code.free_var_writes.is_empty() {
+        if code.free_var_writes.is_empty() {
             return;
         }
         // Restrict to the EVAL carrier (`__mutsu_in_eval`). The other

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -335,7 +335,6 @@ impl Interpreter {
             let items = self.force_lazy_list_vm_n(&ll, MAX_ARRAY_EXPAND)?;
             self.env_mut()
                 .insert(name.to_string(), Value::real_array(items));
-            self.env_dirty = true;
         }
         Ok(())
     }
@@ -482,7 +481,6 @@ impl Interpreter {
         let saved_env = self.clone_env();
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack = std::mem::take(&mut self.stack);
-        let saved_env_dirty = self.env_dirty;
 
         // Set up the lazy list's environment as a scoped overlay's parent: the
         // gather body reads its captured lexicals through to `list.env` and its
@@ -503,7 +501,6 @@ impl Interpreter {
                 self.locals[i] = val.clone();
             }
         }
-        self.env_dirty = false;
         self.stack = Vec::new();
 
         // Run the compiled code using the lazy list's own compiled_fns.
@@ -592,24 +589,9 @@ impl Interpreter {
         // docs/captured-outer-cell-sharing.md is retiring).
         self.record_eager_block_free_var_writeback(cc.as_ref(), &[]);
 
-        // Check whether the merged env actually changed any outer-scope variables.
-        let env_actually_changed = {
-            let merged = self.env();
-            saved_env.iter().any(|(k, old_val)| {
-                merged
-                    .get_sym(*k)
-                    .is_some_and(|new_val| new_val.to_string_value() != old_val.to_string_value())
-            })
-        };
-
         // Restore Interpreter state
         self.locals = saved_locals;
         self.stack = saved_stack;
-        self.env_dirty = if env_actually_changed {
-            true
-        } else {
-            saved_env_dirty
-        };
 
         // Check for errors
         run_result?;
@@ -666,7 +648,7 @@ impl Interpreter {
         if caller_code == 0 {
             return;
         }
-        if self.env_dirty || !self.pending_rw_writeback_sources.is_empty() {
+        if !self.pending_rw_writeback_sources.is_empty() {
             // SAFETY: `caller_code` is the address of the `CompiledCode` of the
             // bytecode frame that invoked this force. That frame is an ancestor
             // on the call stack (the op handler driving the force) and is alive
@@ -674,7 +656,6 @@ impl Interpreter {
             // valid here.
             let code = unsafe { &*(caller_code as *const CompiledCode) };
             self.apply_pending_rw_writeback(code);
-            self.blanket_reconcile_if_dirty(code);
         }
     }
 
@@ -737,7 +718,6 @@ impl Interpreter {
         let saved_env = self.clone_env();
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack = std::mem::take(&mut self.stack);
-        let saved_env_dirty = self.env_dirty;
 
         // Determine starting IP and locals from coroutine state or fresh start
         let mut ip;
@@ -783,8 +763,6 @@ impl Interpreter {
             self.stack = Vec::new();
             has_prior_state = false;
         }
-
-        self.env_dirty = false;
 
         // Push gather items collector with the take limit
         let saved_gather_len = self.gather_items_len();
@@ -908,23 +886,9 @@ impl Interpreter {
         // `force_lazy_list_vm_inner`.
         self.record_eager_block_free_var_writeback(cc.as_ref(), &[]);
 
-        let env_actually_changed = {
-            let merged = self.env();
-            saved_env.iter().any(|(k, old_val)| {
-                merged
-                    .get_sym(*k)
-                    .is_some_and(|new_val| new_val.to_string_value() != old_val.to_string_value())
-            })
-        };
-
         // Restore Interpreter state
         self.locals = saved_locals;
         self.stack = saved_stack;
-        self.env_dirty = if env_actually_changed {
-            true
-        } else {
-            saved_env_dirty
-        };
 
         run_result?;
 

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -22,7 +22,6 @@ impl Interpreter {
         }
         self.set_env_with_main_alias(var, new_val.clone());
         self.locals_set_by_name(code, var, new_val);
-        self.env_dirty = true;
     }
 
     /// `$b>>++` / `$b>>--` on a Bag/Mix/Set: apply the postfix op to each weight,
@@ -519,7 +518,6 @@ impl Interpreter {
                     )
                 );
             }
-            self.env_dirty = true;
         }
         // Hash target: write any in-place per-value mutation back to the
         // original variable (e.g. `%h>>++` increments the stored values). The
@@ -543,7 +541,6 @@ impl Interpreter {
             } else {
                 self.overwrite_hash_bindings_by_identity(existing, new_hash);
             }
-            self.env_dirty = true;
         }
         // Preserve the container type of the target for QuantHash types.
         // The items list was produced by value_to_list, which yields Pairs
@@ -878,7 +875,6 @@ impl Interpreter {
                 self,
                 overwrite_array_items_by_identity_for_vm(existing, items.clone(), *kind,)
             );
-            self.env_dirty = true;
         }
         // Preserve the container type of the target for QuantHash types
         match &target {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3387,7 +3387,7 @@ impl Interpreter {
         // is in `restore_let_value`. Gated on the same toggle as the boxing it
         // supports, so the default build is byte-identical to before.
         let old_val = match old_val {
-            Value::ContainerRef(arc) if self.cell_boxing_active() => arc.lock().unwrap().clone(),
+            Value::ContainerRef(arc) => arc.lock().unwrap().clone(),
             v => v,
         };
         // For temp, deep-copy Array/Hash so the snapshot is independent of
@@ -3438,21 +3438,15 @@ impl Interpreter {
                 let topic = self.env().get("_").cloned().unwrap_or(Value::Nil);
                 let success = Self::is_let_success(&topic);
                 loan_env!(self, resolve_let_saves_on_success(mark, success));
-                self.env_dirty = true;
                 // `let`/`temp` restore writes the saved value back into `env` only;
                 // the matching local slot still holds the in-block value. The restore
                 // recorded each restored name precisely (`restore_let_value`); drain
-                // it so the frame's slots refresh without the blanket env→locals pull
-                // (env_dirty-removal substrate). The blanket reconcile stays as the
-                // fallback (no-op under the substrate harness).
+                // it so the frame's slots refresh.
                 self.apply_pending_rw_writeback(code);
-                self.reconcile_locals_from_env_at_site(code);
             }
             Err(e) => {
                 loan_env!(self, restore_let_saves(mark));
-                self.env_dirty = true;
                 self.apply_pending_rw_writeback(code);
-                self.reconcile_locals_from_env_at_site(code);
                 return Err(e);
             }
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -751,7 +751,6 @@ impl Interpreter {
         // cell mutation of a local that env does not yet reflect -- see the
         // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
         // flag-deferred barrier pull, which runs once env is fresh, is correct.)
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -789,7 +788,6 @@ impl Interpreter {
         // cell mutation of a local that env does not yet reflect -- see the
         // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
         // flag-deferred barrier pull, which runs once env is fresh, is correct.)
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -810,7 +808,6 @@ impl Interpreter {
         // cell mutation of a local that env does not yet reflect -- see the
         // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
         // flag-deferred barrier pull, which runs once env is fresh, is correct.)
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -831,7 +828,6 @@ impl Interpreter {
         // cell mutation of a local that env does not yet reflect -- see the
         // cyclic-`:=`-bind regression in t/element-bind-cell.t. Only the
         // flag-deferred barrier pull, which runs once env is fresh, is correct.)
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -949,7 +945,6 @@ impl Interpreter {
                     self.set_env_with_main_alias(&name, default_value);
                 }
             }
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -1032,7 +1027,6 @@ impl Interpreter {
                 let name_str = name.to_string();
                 self.locals_set_by_name(code, &name_str, buf.clone());
                 self.set_env_with_main_alias(&name_str, buf);
-                self.env_dirty = true;
                 return Ok(());
             }
         }
@@ -1059,7 +1053,6 @@ impl Interpreter {
             }
             // Mark the variable read-only to prevent mutation
             self.mark_readonly(&name_str);
-            self.env_dirty = true;
             return Ok(());
         }
 
@@ -1204,7 +1197,6 @@ impl Interpreter {
                 self.set_env_with_main_alias(&name_str, instance.clone());
                 // Set type constraint so future assignments are coerced correctly
                 self.vm_set_var_type_constraint(&name_str, Some(trait_name.clone()));
-                self.env_dirty = true;
                 return Ok(());
             }
         }
@@ -1219,7 +1211,6 @@ impl Interpreter {
                 }
                 let name_str = name.to_string();
                 self.vm_set_var_type_constraint(&name_str, Some(et));
-                self.env_dirty = true;
                 return Ok(());
             }
         }
@@ -1257,7 +1248,6 @@ impl Interpreter {
         )?;
         let named_arg = Value::Pair(trait_name, Box::new(trait_value));
         self.vm_call_function("trait_mod:<is>", vec![var_obj, named_arg])?;
-        self.env_dirty = true;
         Ok(())
     }
 
@@ -1287,7 +1277,6 @@ impl Interpreter {
             if name.resolve().is_empty() {
                 self.stack.push(result);
             }
-            self.env_dirty = true;
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterEnum expects EnumDecl"))
@@ -1465,7 +1454,6 @@ impl Interpreter {
             // outer `code`.
             self.apply_pending_rw_writeback(code);
 
-            self.env_dirty = true;
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterClass expects ClassDecl"))
@@ -1590,7 +1578,6 @@ impl Interpreter {
                     });
                 }
             }
-            self.env_dirty = true;
             // Execute deferred non-declaration body statements now that the role
             // name is fully available in the environment.  This lets code like
             // `role R { method foo {}; R.foo }` work.
@@ -1675,7 +1662,6 @@ impl Interpreter {
                     };
                 self.register_exported_var(export_pkg, export_short, export_tags.clone());
             }
-            self.env_dirty = true;
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterSubset expects SubsetDecl"))
@@ -1697,7 +1683,6 @@ impl Interpreter {
         let run_result = self.run_range(code, body_start, end, compiled_fns);
         self.stack.truncate(saved_depth);
         self.finish_subtest(ctx, &label, run_result)?;
-        self.env_dirty = true;
         *ip = end;
         Ok(())
     }
@@ -1718,7 +1703,6 @@ impl Interpreter {
         // attribute mutations written into the shared cell after bind-stdin), then
         // flush all locals to env so captured vars are visible/mutable from the
         // whenever callbacks.
-        self.ensure_locals_synced(code);
         self.sync_env_from_locals(code);
 
         // Enter react mode: whenever blocks will register subscriptions
@@ -1734,31 +1718,23 @@ impl Interpreter {
         // whenever / LAST / QUIT / CLOSE callback as compiled bytecode
         // (Stage 2 #3038/#3039; QUIT handlers Interpreter-native in the Stage 3 follow-up).
         // No drive-loop callback routes back through the tree-walk interpreter.
-        // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): the
-        // `whenever` callbacks mutate captured-outer lexicals by name in env, with
-        // no per-write record this site can drain. Snapshot the caller frame's
+        // The `whenever` callbacks mutate captured-outer lexicals by name in env,
+        // with no per-write record this site can drain. Snapshot the caller frame's
         // slot-backing env values right before the event loop so that, after it,
-        // only the slots whose env value actually changed are written through —
-        // the precise form of the blanket reconcile below, which is the by-name
-        // writer the react loop *is*. Armed only under boxing; the default build
-        // keeps the unconditional `reconcile_locals_from_env_at_site` pull.
-        let armed = self.cell_boxing_active();
-        let pre_env: Vec<Option<Value>> = if armed {
-            code.locals
-                .iter()
-                .map(|n| {
-                    self.env().get(n).cloned().or_else(|| {
-                        n.strip_prefix('$')
-                            .or_else(|| n.strip_prefix('@'))
-                            .or_else(|| n.strip_prefix('%'))
-                            .or_else(|| n.strip_prefix('&'))
-                            .and_then(|b| self.env().get(b).cloned())
-                    })
+        // only the slots whose env value actually changed are written through.
+        let pre_env: Vec<Option<Value>> = code
+            .locals
+            .iter()
+            .map(|n| {
+                self.env().get(n).cloned().or_else(|| {
+                    n.strip_prefix('$')
+                        .or_else(|| n.strip_prefix('@'))
+                        .or_else(|| n.strip_prefix('%'))
+                        .or_else(|| n.strip_prefix('&'))
+                        .and_then(|b| self.env().get(b).cloned())
                 })
-                .collect()
-        } else {
-            Vec::new()
-        };
+            })
+            .collect();
         let event_result = if body_done {
             // Drain any queued subscriptions so they don't leak
             self.run_react_event_loop_drain();
@@ -1770,32 +1746,25 @@ impl Interpreter {
         // compiled bytecode on *this* VM (synchronous `from-list` emit) and
         // mutated captured-outer caller lexicals (`my $i; whenever ... { $i++ }`)
         // straight into `env` by name. Reconcile the caller's local slots from
-        // env unconditionally (not gated by the reverse-sync campaign toggle), so
-        // the slot stays coherent without relying on the speculative reverse
-        // `sync_locals_from_env` pull. Under reverse-sync ON this is byte-identical
-        // to the barrier pull it replaces (same HashSlotRef / `!attr` per-slot
-        // skips); under OFF it is what keeps `$i` correct.
-        if armed {
-            for (i, name) in code.locals.iter().enumerate() {
-                if name.starts_with('!') || matches!(self.locals[i], Value::HashSlotRef { .. }) {
-                    continue;
-                }
-                let cur = self.env().get(name).cloned().or_else(|| {
-                    name.strip_prefix('$')
-                        .or_else(|| name.strip_prefix('@'))
-                        .or_else(|| name.strip_prefix('%'))
-                        .or_else(|| name.strip_prefix('&'))
-                        .and_then(|b| self.env().get(b).cloned())
-                });
-                if let Some(cur) = cur
-                    && pre_env.get(i).map(|p| p.as_ref()) != Some(Some(&cur))
-                {
-                    self.locals[i] = cur;
-                }
+        // env so the slot stays coherent (same HashSlotRef / `!attr` per-slot
+        // skips); this is what keeps `$i` correct.
+        for (i, name) in code.locals.iter().enumerate() {
+            if name.starts_with('!') || matches!(self.locals[i], Value::HashSlotRef { .. }) {
+                continue;
+            }
+            let cur = self.env().get(name).cloned().or_else(|| {
+                name.strip_prefix('$')
+                    .or_else(|| name.strip_prefix('@'))
+                    .or_else(|| name.strip_prefix('%'))
+                    .or_else(|| name.strip_prefix('&'))
+                    .and_then(|b| self.env().get(b).cloned())
+            });
+            if let Some(cur) = cur
+                && pre_env.get(i).map(|p| p.as_ref()) != Some(Some(&cur))
+            {
+                self.locals[i] = cur;
             }
         }
-        self.reconcile_locals_from_env_at_site(code);
-        self.env_dirty = true;
 
         *ip = end;
         if let Err(err) = run_result
@@ -1828,7 +1797,6 @@ impl Interpreter {
                 self,
                 run_whenever_with_value(supply_val, target_var, &param, body)
             )?;
-            self.env_dirty = true;
             // Slice F (env<->locals coherence): a `my $tap = do whenever $sup {…}`
             // binds the tap handle by writing `env[target_var]` directly (see
             // `run_whenever_with_value`), but never updates the caller's local
@@ -1843,15 +1811,13 @@ impl Interpreter {
             // bound name is known exactly (`target_var`), so write just that slot
             // through from env — the precise form of the blanket reconcile below.
             // Armed only under boxing; the default build keeps the blanket pull.
-            if self.cell_boxing_active()
-                && let Some(name) = target_var
+            if let Some(name) = target_var
                 && let Some(slot) = self.find_local_slot(code, name)
                 && !matches!(self.locals[slot], Value::HashSlotRef { .. })
                 && let Some(val) = self.env().get(name).cloned()
             {
                 self.locals[slot] = val;
             }
-            self.reconcile_locals_from_env_at_site(code);
             Ok(())
         } else {
             Err(RuntimeError::new("WheneverScope expects Block body"))

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5078,7 +5078,6 @@ impl Interpreter {
                     let cell_val = Value::ContainerRef(cell.clone());
                     self.set_env_with_main_alias(src, cell_val.clone());
                     self.update_local_if_exists(code, src, &cell_val);
-                    self.env_dirty = true;
                 }
                 self.stack.push(val);
             }
@@ -5115,7 +5114,6 @@ impl Interpreter {
                         let cell_val = Value::ContainerRef(cell.clone());
                         self.set_env_with_main_alias(src, cell_val.clone());
                         self.update_local_if_exists(code, src, &cell_val);
-                        self.env_dirty = true;
                     }
                 }
                 self.stack.push(val);
@@ -5576,8 +5574,7 @@ impl Interpreter {
 
     /// Like `exec_get_local_op` but does NOT resolve DeferredHashAccess/HashSlotRef.
     /// Pushes the raw local value, preserving container references for `=:=` checks.
-    pub(super) fn exec_get_local_raw_op(&mut self, code: &CompiledCode, idx: u32) {
-        self.ensure_locals_synced(code);
+    pub(super) fn exec_get_local_raw_op(&mut self, idx: u32) {
         let idx = idx as usize;
         let val = self.locals[idx].clone();
         self.stack.push(val);
@@ -5588,7 +5585,6 @@ impl Interpreter {
         code: &CompiledCode,
         idx: u32,
     ) -> Result<(), RuntimeError> {
-        self.ensure_locals_synced(code);
         let idx = idx as usize;
         // Check if this variable has a binding alias (e.g. from $CALLER::foo := $other_var)
         let name = code.locals.get(idx).cloned().unwrap_or_default();
@@ -5859,9 +5855,7 @@ impl Interpreter {
         // closures are boxed precisely at their creation op, so reusing that set
         // here would over-box unrelated same-named locals (same-named `my` locals
         // share one slot) and break e.g. `let`-restore in a sibling block.
-        let box_decl = self.cell_boxing_active()
-            && self.vardecl_context
-            && !code.needs_cell_named_sub.is_empty();
+        let box_decl = self.vardecl_context && !code.needs_cell_named_sub.is_empty();
         let r = self.exec_set_local_op_inner(code, idx);
         // Phase 3 Stage 2: write-through scalar attribute writes to the cell.
         if r.is_ok() {
@@ -6026,12 +6020,8 @@ impl Interpreter {
                 // closure. For the substr-rw/subbuf-rw/undefine Proxies the STORE
                 // records the referent on the retain-on-miss writeback list
                 // (`record_caller_var_writeback`); `apply_pending_rw_writeback` drains
-                // it precisely (works under the no-precise-reconcile substrate harness
-                // — env_dirty-removal step). The blanket reconcile remains as the
-                // fallback for arbitrary user `Proxy` STOREs that write other lexicals
-                // (no-op under the harness); byte-identical in the default build.
+                // it precisely.
                 self.apply_pending_rw_writeback(code);
-                self.reconcile_locals_from_env_at_site(code);
                 return Ok(());
             }
             // First write through a missing-key `:=` bind (a local holding a
@@ -7253,11 +7243,8 @@ impl Interpreter {
             // A Proxy STORE wrote the referent caller lexical by name. For
             // substr-rw/subbuf-rw/undefine the STORE recorded the referent precisely
             // (`record_caller_var_writeback`); drain it here so the slot refreshes
-            // without the blanket pull (env_dirty-removal substrate; see the other
-            // Proxy-STORE assign site). The blanket reconcile stays as the fallback
-            // for arbitrary user `Proxy` STOREs (no-op under the substrate harness).
+            // (see the other Proxy-STORE assign site).
             self.apply_pending_rw_writeback(code);
-            self.reconcile_locals_from_env_at_site(code);
             return Ok(());
         }
 
@@ -7526,7 +7513,6 @@ impl Interpreter {
             return;
         }
 
-        self.ensure_locals_synced(code);
         // MY:: pseudo-stash: collect all variable names from current scope.
         let mut entries: HashMap<String, Value> = HashMap::new();
         for (i, var_name) in code.locals.iter().enumerate() {
@@ -7572,7 +7558,6 @@ impl Interpreter {
             return loan_env!(self, package_stash_value(name));
         }
         // MY / LEXICAL: collect locals + env
-        self.ensure_locals_synced(code);
         let mut entries: HashMap<String, Value> = HashMap::new();
         for (i, var_name) in code.locals.iter().enumerate() {
             let val = self.locals[i].clone();

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -131,13 +131,11 @@ impl Interpreter {
                 // CARRIER: pseudo-package names (SETTING::, OUTER::, CALLER::) need
                 // the interpreter's reflective scope resolution. See ledger §C.
                 // For regular qualified names, try compiled dispatch first.
-                let result = if self.is_interpreter_handled_function(name) {
+                if self.is_interpreter_handled_function(name) {
                     self.vm_call_function(name, Vec::new())?
                 } else {
                     self.call_function_compiled_first(name, Vec::new(), compiled_fns)?
-                };
-                self.env_dirty = true;
-                result
+                }
             } else if !name.starts_with('$') && !name.starts_with('@') && !name.starts_with('%') {
                 v.clone()
             } else {
@@ -152,9 +150,7 @@ impl Interpreter {
                 // precisely via its return merge; no blanket mark needed.
                 self.call_compiled_function_named(cf, Vec::new(), compiled_fns, &pkg, name)?
             } else {
-                let result = self.compile_and_call_function_def(&def, Vec::new(), compiled_fns)?;
-                self.env_dirty = true;
-                result
+                self.compile_and_call_function_def(&def, Vec::new(), compiled_fns)?
             }
         } else if self.has_type(name)
             || Self::is_builtin_type(name)
@@ -167,16 +163,12 @@ impl Interpreter {
                 Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
             )
         {
-            let result = self.vm_call_on_value(callable, Vec::new(), Some(compiled_fns))?;
-            self.env_dirty = true;
-            result
+            self.vm_call_on_value(callable, Vec::new(), Some(compiled_fns))?
         } else if let Some(sub_id) = self.wrap_sub_id_for_name(name)
             && !self.is_wrap_dispatching(sub_id)
             && let Some(sub_val) = self.get_wrapped_sub(name)
         {
-            let result = self.vm_call_on_value(sub_val, Vec::new(), Some(compiled_fns))?;
-            self.env_dirty = true;
-            result
+            self.vm_call_on_value(sub_val, Vec::new(), Some(compiled_fns))?
         } else if Interpreter::is_test_function_name(name)
             && self.test_mode_active()
             // Only try test function dispatch for hyphenated names (e.g.
@@ -186,9 +178,7 @@ impl Interpreter {
             && name.contains('-')
         {
             // CARRIER: Test-framework function dispatch (test-mode state). See ledger §C.
-            let result = self.vm_call_function(name, Vec::new())?;
-            self.env_dirty = true;
-            result
+            self.vm_call_function(name, Vec::new())?
         } else if self.has_function(name)
             || Interpreter::is_implicit_zero_arg_builtin(name)
             || self.has_multi_function(name)
@@ -206,9 +196,7 @@ impl Interpreter {
                 // compiled-first function dispatch (ledger §2): this adds OTF
                 // compilation of simple user subs; the interpreter remains only as
                 // the terminal fallback inside call_function_compiled_first.
-                let result = self.call_function_compiled_first(name, Vec::new(), compiled_fns)?;
-                self.env_dirty = true;
-                result
+                self.call_function_compiled_first(name, Vec::new(), compiled_fns)?
             }
         } else if name == "callsame"
             || name == "nextsame"
@@ -218,9 +206,7 @@ impl Interpreter {
             || name == "lastcall"
         {
             // CARRIER: call-chain introspection (interpreter MOP dispatch stack). See ledger §C.
-            let result = self.vm_call_function(name, Vec::new())?;
-            self.env_dirty = true;
-            result
+            self.vm_call_function(name, Vec::new())?
         } else if name.starts_with("Metamodel::") {
             // Meta-object protocol type objects
             Value::Package(Symbol::intern(name))
@@ -243,9 +229,7 @@ impl Interpreter {
                 // Route the package-qualified term fork through the Interpreter's unified
                 // compiled-first function dispatch (ledger §2): interpreter remains
                 // only as the terminal fallback.
-                let result = self.call_function_compiled_first(name, Vec::new(), compiled_fns)?;
-                self.env_dirty = true;
-                result
+                self.call_function_compiled_first(name, Vec::new(), compiled_fns)?
             } else if let Some((pkg_prefix, last_seg)) = name.rsplit_once("::")
                 && !last_seg.is_empty()
                 && last_seg.starts_with(|c: char| c.is_ascii_lowercase())


### PR DESCRIPTION
## What

After #3450 made cell-boxing the permanent coherence mechanism (both env→locals reconciles retired), the `env_dirty` machinery became dead. This PR physically removes it (~770 lines deleted, +206 −772).

### Removed
- **Functions**: `reconcile_locals_from_env_at_site` (early-return no-op), `blanket_reconcile_if_dirty` (always-false gate), `ensure_locals_synced` (`env_dirty=false` only), `blanket_reconcile_disabled` / `precise_reconcile_disabled` / `cell_boxing_active` (constant `true` gates).
- **Fields**: `Interpreter::env_dirty` (342 uses, mostly no-op `=true`/`=false` marks) and `VmCallFrame::saved_env_dirty`.
- **All call sites** + the `cell_boxing_active()` gates (now unconditional — byte-identical to the default boxing-on build).

Coherence now rests solely on **cell-boxing** (captured-outer writes folded into a shared `ContainerRef` cell) plus **precise write-backs** (`pending_rw_writeback_sources` drop-on-miss / `pending_caller_var_writeback` retain-on-miss, drained at call sites). `locals` is the single authority; `env` is a derived view. Completes PLAN §1-A / §2-E.

## Gotcha (one `env_dirty` read was load-bearing, not dead)

`vm_closure_dispatch`'s `needs_caller_writeback` ORed `self.env_dirty` to force the caller-writeback env-scan when a closure body wrote a captured-outer lexical **by name** that free-var analysis missed — e.g. an anonymous role-method `gist` doing `$seen = 1`, where the capture flows through `data.env` and never lands in `free_var_syms`. The double-OFF survey (which only disabled the *reconciles*) never exercised this trigger.

Replaced with the compile-time `cc.has_env_writes` flag (covers `SetGlobal` / `AssignExpr` / inc-dec but **not** plain `SetLocal`, so read-only `map`/`grep` leaf blocks still skip the scan). `cc.has_calls || cc.has_env_writes` covers everything `env_dirty` did. Regression caught locally by `t/note-gist-and-dynamic-handle.t`.

## Testing
- `make test` — 10135 tests, all pass.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)