### PR TITLE
fix(parser): `[TypeName]` is an array literal, not a reduction metaop

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -183,10 +183,17 @@ fn is_custom_reduction_op(op: &str) -> bool {
         // Also accept the symbol as a prefix of op (shouldn't happen for reduction, but be safe)
         let _ = symbol;
     }
+    // A bareword that is not a declared infix operator: accept it as a custom
+    // reduction op ONLY if it looks like an operator name (lowercase/`_`-initial).
+    // An uppercase-initial identifier is a type name or class (`[Any]`, `[Int]`,
+    // `[Exception]`), so `[Type]` must parse as an array literal, not a reduction
+    // (`[Any].raku` is `[Any]` array literal's `.raku`, NOT a reduction with op
+    // "Any"). User-declared uppercase infixes are already matched above by
+    // `match_user_declared_infix_symbol_op`.
     if !op
         .chars()
         .next()
-        .is_some_and(|c| c.is_alphabetic() || c == '_')
+        .is_some_and(|c| c.is_lowercase() || c == '_')
     {
         return false;
     }

--- a/t/array-literal-type-not-reduction.t
+++ b/t/array-literal-type-not-reduction.t
@@ -1,0 +1,40 @@
+use Test;
+
+# `[TypeName]` is an array literal containing a type object, NOT a reduction
+# metaop. The reduction parser used to accept any bareword as the operator, so
+# `[Any].raku` parsed as a reduction with op "Any" applied to `$_.raku` and
+# returned Nil. Uppercase-initial barewords (type/class names) must parse as
+# array literals; lowercase named infixes (`[min]`, `[max]`) and user-declared
+# infixes (even uppercase) still reduce.
+
+plan 14;
+
+# --- type objects in brackets are array literals ---------------------------
+
+is [Any].raku,        '[Any]',          '[Any] is an array literal';
+is [Int].raku,        '[Int]',          '[Int] is an array literal';
+is [Exception].raku,  '[Exception]',    '[Exception] is an array literal';
+is [Any].elems,       1,                '[Any] has one element';
+is [Int][0].^name,    'Int',            '[Int][0] is the Int type object';
+is-deeply [Str, Int, Num].map(*.^name).List, ('Str', 'Int', 'Num'),
+    'multi-type array literal';
+
+# --- standard reductions still work ----------------------------------------
+
+is ([+] 1, 2, 3),     6,   '[+] reduction';
+is ([*] 1..5),        120, '[*] reduction';
+is ([max] 4, 2, 8),   8,   '[max] reduction';
+is ([min] 4, 2, 8),   2,   '[min] reduction';
+is ([gcd] 12, 8),     4,   '[gcd] reduction';
+is ([~] 'a', 'b'),    'ab', '[~] reduction';
+
+# --- user-declared infix (uppercase) still reduces -------------------------
+
+{
+    sub infix:<Plus>($a, $b) { $a + $b }
+    is ([Plus] 1, 2, 3), 6, 'user-declared uppercase infix reduces';
+}
+
+# --- lowercase named reduction not in the core list still parses -----------
+
+is ([lcm] 4, 6), 12, '[lcm] reduction';


### PR DESCRIPTION
## Summary

The reduction-operator parser accepted **any** bareword as the operator name, so a single-element array literal containing a type object misparsed as a reduction:

```raku
say [Any].raku;   # parsed as [Any]-reduction of $_.raku  →  Nil   (should be [Any])
say [Int].raku;   # →  Nil   (should be [Int])
```

`[Any].raku` was lexed as `Reduction { op: "Any", expr: $_.raku }` instead of the array literal `[Any]`'s `.raku`.

Fix: restrict the bareword fallback in `is_custom_reduction_op` to **lowercase/`_`-initial** identifiers — operator names are conventionally lowercase; type/class names are Titlecase. Standard named reductions (`[min]`, `[max]`, `[gcd]`, `[lcm]`, …) and user-declared infixes — including uppercase ones like `infix:<Plus>`, matched earlier by `match_user_declared_infix_symbol_op` — are unaffected.

## Verification

- `[Any]`/`[Int]`/`[Exception]`/`[Str, Int, Num]` now render and behave like raku (incl. `[Any](1)` → "No such method 'CALL-ME'").
- `S03-metaops/{reduce,cross,infix,not,reverse}.t` and `S03-operators/reduce-le1arg.t` stay green.

## Test

`t/array-literal-type-not-reduction.t` — 14 cases (type-literal array forms + standard/user/lowercase reductions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)