### PR TITLE
fix(parser): trailing comma in a parenthesized list-assignment RHS

### DIFF
--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -1959,7 +1959,7 @@ pub(in crate::parser) fn parse_comma_or_expr(input: &str) -> PResult<'_, Expr> {
     if r.starts_with(',') && !r.starts_with(",,") {
         let (r, _) = parse_char(r, ',')?;
         let (r, _) = ws(r)?;
-        if r.starts_with(';') || r.is_empty() || r.starts_with('}') {
+        if r.starts_with(';') || r.is_empty() || r.starts_with('}') || r.starts_with(')') {
             return Ok((r, Expr::ArrayLiteral(vec![first])));
         }
         let mut items = vec![first];
@@ -1973,7 +1973,7 @@ pub(in crate::parser) fn parse_comma_or_expr(input: &str) -> PResult<'_, Expr> {
             }
             let (r2, _) = parse_char(r2, ',')?;
             let (r2, _) = ws(r2)?;
-            if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') {
+            if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')') {
                 let items = merge_sequence_seeds(lift_meta_ops_in_list(items));
                 return Ok((r2, finalize_list(items)));
             }

--- a/t/paren-trailing-comma.t
+++ b/t/paren-trailing-comma.t
@@ -1,0 +1,22 @@
+use Test;
+
+# Trailing comma inside parentheses after a list assignment used to be a parse
+# error (the list-assignment RHS comma-list parser did not treat ')' as a valid
+# trailing-comma terminator).
+
+plan 8;
+
+is (my @a = 1, 2, 3,).raku, '[1, 2, 3]', 'array list-assign with trailing comma in parens';
+is (my @b = 1,).raku, '[1]', 'single-element array list-assign with trailing comma in parens';
+is (my @c = 1, 2, 3).raku, '[1, 2, 3]', 'array list-assign without trailing comma still works';
+is (my %h = a => 1, b => 2,).raku, '{:a(1), :b(2)}', 'hash list-assign with trailing comma in parens';
+
+# Scalar item assignment: the comma is a separate list element, not absorbed.
+is (my $x = 5,).raku, '(5,)', 'scalar item-assign keeps trailing comma as list';
+is (my $y = 42, 1).raku, '(42, 1)', 'scalar item-assign comma list in parens';
+
+# Bare parenthesized list with trailing comma (already worked, guard against regression).
+is (1, 2, 3,).raku, '(1, 2, 3)', 'bare parenthesized list with trailing comma';
+
+my @d = 1, 2, 3,;
+is @d.raku, '[1, 2, 3]', 'statement-level list-assign with trailing comma';


### PR DESCRIPTION
## Problem

`(my @a = 1, 2, 3,)` was a parse error:

```
say (my @a = 1,2,3,).raku
===SORRY!=== Error while compiling -e
expected statement: ...
```

raku gives `[1, 2, 3]`.

## Root cause

The list-assignment RHS comma-list parsers in `src/parser/stmt/assign.rs`
(`parse_comma_or_expr` and `parse_assign_expr_or_comma`) only treated `;`,
end-of-input, and `}` as valid trailing-comma terminators. A trailing comma
directly before `)` made them try to parse another list element and fail on
the `)`.

Statement context (`my @a = 1,2,3,;`) and bare parenthesized lists
(`(1,2,3,)`) already worked because their parsers (`parse_assignment_rhs_mode`,
the paren-list parser in `primary/container.rs`) already include `)` as a
terminator. This change adds `)` to the comma-list terminator checks so the
list-assignment RHS path is consistent.

## Verification

All match `raku`:

| code | result |
|------|--------|
| `(my @a = 1,2,3,).raku` | `[1, 2, 3]` |
| `(my @a = 1,).raku` | `[1]` |
| `(my %h = a=>1, b=>2,).raku` | `{:a(1), :b(2)}` |
| `(my $x = 5,).raku` | `(5,)` |
| `(my $y = 42, 1).raku` | `(42, 1)` |

New regression test: `t/paren-trailing-comma.t` (8 cases). `cargo test`
(468) green. No roast regressions (assign.t/array.t partial-fail counts
identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)