### PR TITLE
fix(parser): `$@(...)` and `$%(...)` itemized list/hash contextualizers

### DIFF
--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -708,6 +708,36 @@ pub(super) fn itemized_paren_expr(input: &str) -> PResult<'_, Expr> {
     ))
 }
 
+/// Parse an item-context coercion applied to a list/hash contextualizer:
+/// `$@(...)` and `$%(...)`.
+///
+/// In Raku these are the itemizing forms of the list/hash contextualizers:
+/// the inner `@(...)` / `%(...)` builds a List / Hash, and the leading `$`
+/// itemizes it (wraps it in a Scalar container). We lower `$@(expr)` to
+/// `@(expr).item` and `$%(expr)` to `%(expr).item`.
+pub(super) fn itemized_context_paren_expr(input: &str) -> PResult<'_, Expr> {
+    let Some(rest) = input.strip_prefix('$') else {
+        return Err(PError::expected("itemized context paren expression"));
+    };
+    let (rest, inner) = if rest.starts_with("@(") {
+        list_context_paren_expr(rest)?
+    } else if rest.starts_with("%(") {
+        hash_context_paren_expr(rest)?
+    } else {
+        return Err(PError::expected("itemized context paren expression"));
+    };
+    Ok((
+        rest,
+        Expr::MethodCall {
+            target: Box::new(inner),
+            name: Symbol::intern("item"),
+            args: vec![],
+            modifier: None,
+            quoted: false,
+        },
+    ))
+}
+
 /// Parse list-context parenthesized expression: `@(...)`.
 ///
 /// In Raku, `@(expr)` coerces the expression into list context.

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -196,6 +196,7 @@ pub(super) fn primary(input: &str) -> PResult<'_, Expr> {
         try_primary!(regex::version_lit(input));
         try_primary!(ident::keyword_literal(input));
         try_primary!(regex::topic_method_call(input));
+        try_primary!(container::itemized_context_paren_expr(input));
         try_primary!(container::itemized_paren_expr(input));
         try_primary!(container::itemized_bracket_expr(input));
         try_primary!(container::itemized_brace_expr(input));

--- a/t/itemized-context-paren.t
+++ b/t/itemized-context-paren.t
@@ -1,0 +1,29 @@
+use Test;
+
+# `$@(...)` and `$%(...)` are the itemizing forms of the list/hash
+# contextualizers: the inner `@(...)` / `%(...)` builds a List / Hash, and the
+# leading `$` itemizes it (wraps it in a Scalar container). Previously mutsu
+# mis-parsed `$%(...)` as a modulo on an anonymous state variable.
+
+plan 12;
+
+is $%(x => 1).raku, '${:x(1)}', '$%(...) single pair itemized hash';
+is $%(a => 1, b => 2).raku, '${:a(1), :b(2)}', '$%(...) multi pair itemized hash';
+is $%().raku, '${}', '$%() empty itemized hash';
+is $%(x => 1).WHAT.gist, '(Hash)', '$%(...) is a Hash';
+
+is $@(1, 2, 3).raku, '$(1, 2, 3)', '$@(...) itemized list';
+is $@().raku, '$( )', '$@() empty itemized list';
+is $@(1, 2, 3).WHAT.gist, '(List)', '$@(...) is a List';
+
+# Assigning to a scalar keeps the itemized value.
+my $h = $%(k => 42);
+is $h.raku, '${:k(42)}', '$%(...) assigned to scalar';
+is $h<k>, 42, 'itemized hash is indexable';
+
+my $l = $@(10, 20);
+is $l.raku, '$(10, 20)', '$@(...) assigned to scalar';
+is $l[1], 20, 'itemized list is indexable';
+
+# Plain contextualizers still work (guard against regression).
+is %(x => 1).raku, '{:x(1)}', '%(...) plain hash contextualizer still works';


### PR DESCRIPTION
## Problem

`$%(x => 1)` was mis-parsed as a modulo on an anonymous state variable, raising a runtime error; `$@(1,2,3)` silently produced `Nil`:

```
$ mutsu -e 'say $%(x=>1).raku'
Runtime error: Cannot convert string to number: ... in ':x(1)'
$ mutsu -e 'say $@(1,2,3).raku'
Nil
```

raku gives `${:x(1)}` and `$(1, 2, 3)` respectively.

## Fix

`$@(...)` and `$%(...)` are the **itemizing** forms of the list/hash contextualizers: the inner `@(...)` / `%(...)` builds a List / Hash, and the leading `$` itemizes it (wraps it in a Scalar container). Raku lowers `$@(expr)` → `@(expr).item` and `$%(expr)` → `%(expr).item`.

Added `itemized_context_paren_expr` (in `primary/container.rs`) that strips the leading `$`, dispatches `@(...)`/`%(...)` to the existing `list_context_paren_expr` / `hash_context_paren_expr`, and wraps in `.item`. Registered in the primary dispatch before `itemized_paren_expr` (which only matches `$(`).

## Verification

All match `raku`:

| code | result |
|------|--------|
| `$%(x=>1).raku` | `${:x(1)}` |
| `$%(a=>1,b=>2).raku` | `${:a(1), :b(2)}` |
| `$%().raku` | `${}` |
| `$@(1,2,3).raku` | `$(1, 2, 3)` |
| `$%(x=>1).WHAT` | `(Hash)` |
| `$@(1,2,3).WHAT` | `(List)` |

New test `t/itemized-context-paren.t` (12 cases). `cargo test` (468) green. No roast regression (`capture.t` partial-fail count identical to main; its abort at test 34 is an unrelated pre-existing block-comparator failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)