### PR TITLE
fix(sprintf): match Rakudo's unsupported-directive error message

### DIFF
--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -172,9 +172,12 @@ pub(crate) fn validate_sprintf_directives(fmt: &str, arg_count: usize) -> Result
         if vector_flag {
             pos += 1;
         }
+        // Read the conversion char as a full UTF-8 scalar so `pos` always lands
+        // on a char boundary (the directive may be a non-ASCII char such as
+        // `%♥`, which must still slice cleanly into `.directive` / `.sequence`).
         let spec = if pos < len {
-            let s = bytes[pos] as char;
-            pos += 1;
+            let s = fmt[pos..].chars().next().unwrap();
+            pos += s.len_utf8();
             s
         } else {
             '?'
@@ -329,8 +332,8 @@ pub(crate) fn validate_sprintf_arg_types(fmt: &str, args: &[Value]) -> Result<()
             }
         }
         let spec = if pos < len {
-            let s = bytes[pos] as char;
-            pos += 1;
+            let s = fmt[pos..].chars().next().unwrap();
+            pos += s.len_utf8();
             s
         } else {
             '?'

--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -127,6 +127,11 @@ pub(crate) fn validate_sprintf_directives(fmt: &str, arg_count: usize) -> Result
                 pos = start; // reset
             }
         }
+        // Everything from here through the conversion char is the "directive"
+        // reported in X::Str::Sprintf::Directives::Unsupported (Raku includes
+        // flags / width / the vector flag in `.directive`, e.g. `%5vd` reports
+        // directive `5vd`).
+        let directive_start = pos;
         // Skip flags
         while pos < len {
             let b = bytes[pos];
@@ -161,6 +166,12 @@ pub(crate) fn validate_sprintf_directives(fmt: &str, arg_count: usize) -> Result
                 }
             }
         }
+        // Perl 5 vector flag (`%vd`, `%5vd`, ...) is not supported in Raku and
+        // makes the whole directive invalid regardless of the following spec.
+        let vector_flag = pos < len && (bytes[pos] == b'v' || bytes[pos] == b'V');
+        if vector_flag {
+            pos += 1;
+        }
         let spec = if pos < len {
             let s = bytes[pos] as char;
             pos += 1;
@@ -168,37 +179,39 @@ pub(crate) fn validate_sprintf_directives(fmt: &str, arg_count: usize) -> Result
         } else {
             '?'
         };
-        if !matches!(
-            spec,
-            's' | 'd'
-                | 'i'
-                | 'u'
-                | 'x'
-                | 'X'
-                | 'o'
-                | 'b'
-                | 'B'
-                | 'f'
-                | 'F'
-                | 'e'
-                | 'E'
-                | 'g'
-                | 'G'
-                | 'c'
-        ) {
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("directive".to_string(), Value::str(format!("%{}", spec)));
-            attrs.insert(
-                "message".to_string(),
-                Value::str(format!(
-                    "Directive {} is not valid in a sprintf format",
-                    spec
-                )),
+        if vector_flag
+            || !matches!(
+                spec,
+                's' | 'd'
+                    | 'i'
+                    | 'u'
+                    | 'x'
+                    | 'X'
+                    | 'o'
+                    | 'b'
+                    | 'B'
+                    | 'f'
+                    | 'F'
+                    | 'e'
+                    | 'E'
+                    | 'g'
+                    | 'G'
+                    | 'c'
+            )
+        {
+            // Raku reports `.directive` as everything after the `%` (flags,
+            // width, vector flag, conversion char) and `.sequence` as `%` + that.
+            let directive = &fmt[directive_start..pos];
+            let sequence = format!("%{}", directive);
+            let message = format!(
+                "Directive {} is not valid in sprintf format '{}'",
+                directive, sequence
             );
-            let mut err = RuntimeError::new(format!(
-                "Directive {} is not valid in a sprintf format",
-                spec
-            ));
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("directive".to_string(), Value::str(directive.to_string()));
+            attrs.insert("sequence".to_string(), Value::str(sequence));
+            attrs.insert("message".to_string(), Value::str(message.clone()));
+            let mut err = RuntimeError::new(message);
             err.exception = Some(Box::new(Value::make_instance(
                 Symbol::intern("X::Str::Sprintf::Directives::Unsupported"),
                 attrs,

--- a/t/sprintf-unsupported-directive.t
+++ b/t/sprintf-unsupported-directive.t
@@ -1,0 +1,23 @@
+use Test;
+
+# X::Str::Sprintf::Directives::Unsupported should report `.directive` as
+# everything after the `%` (flags, width, the Perl-5 vector flag, and the
+# conversion char) and `.sequence` as `%` + that, matching Rakudo. The message
+# is "Directive <directive> is not valid in sprintf format '<sequence>'".
+
+plan 15;
+
+sub check($fmt, $directive, $message) {
+    my $ex;
+    { sprintf($fmt, 1); CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::Str::Sprintf::Directives::Unsupported, "$fmt throws Unsupported";
+    is $ex.directive, $directive, "$fmt .directive is $directive";
+    is $ex.message, $message, "$fmt message";
+}
+
+check '%q', 'q', q{Directive q is not valid in sprintf format '%q'};
+check '%z', 'z', q{Directive z is not valid in sprintf format '%z'};
+# Perl 5 vector flag is unsupported in Raku and makes the whole directive bad.
+check '%vd', 'vd', q{Directive vd is not valid in sprintf format '%vd'};
+check '%5vd', '5vd', q{Directive 5vd is not valid in sprintf format '%5vd'};
+check '%v', 'v', q{Directive v is not valid in sprintf format '%v'};

--- a/t/sprintf-unsupported-directive.t
+++ b/t/sprintf-unsupported-directive.t
@@ -5,7 +5,7 @@ use Test;
 # conversion char) and `.sequence` as `%` + that, matching Rakudo. The message
 # is "Directive <directive> is not valid in sprintf format '<sequence>'".
 
-plan 15;
+plan 18;
 
 sub check($fmt, $directive, $message) {
     my $ex;
@@ -21,3 +21,5 @@ check '%z', 'z', q{Directive z is not valid in sprintf format '%z'};
 check '%vd', 'vd', q{Directive vd is not valid in sprintf format '%vd'};
 check '%5vd', '5vd', q{Directive 5vd is not valid in sprintf format '%5vd'};
 check '%v', 'v', q{Directive v is not valid in sprintf format '%v'};
+# A non-ASCII conversion char must slice cleanly into .directive / .sequence.
+check '%♥', '♥', q{Directive ♥ is not valid in sprintf format '%♥'};


### PR DESCRIPTION
## Problem

mutsu's `X::Str::Sprintf::Directives::Unsupported` diverged from Rakudo:

```
$ mutsu -e 'sprintf("%vd","1.2.3")'
Directive v is not valid in a sprintf format     # .directive = "%v"
$ raku  -e 'sprintf("%vd","1.2.3")'
Directive vd is not valid in sprintf format '%vd'  # .directive="vd", .sequence="%vd"
```

## Fix (`runtime/sprintf_validate.rs`)

- Record `directive_start` right after the `%` (and positional `N$`) so the reported `.directive` includes flags/width — Rakudo reports `%5vd` as directive `5vd`.
- Detect the Perl-5 **vector flag** (`v`/`V`): it is unsupported in Raku and makes the whole directive invalid regardless of the following conversion char, so `%vd`, `%5vd`, `%-vd`, and bare `%v` are now all reported with their full sequence.
- Emit `.directive`, `.sequence`, and a message `Directive <d> is not valid in sprintf format '<seq>'`, matching Rakudo.

## Verification

`.directive` / `.sequence` / `.message` all match raku for `%q %z %vd %vs %v %vx %5vd %-vd %n`. Valid directives (`%d %05.2f %x %-10s %b`) unaffected.

New test `t/sprintf-unsupported-directive.t` (15 cases). `cargo test` (468) green. Whitelisted `roast/6.d/S32-str/sprintf.t` still passes; no roast-count change (`S32-str/sprintf.t` failures identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)