### PR TITLE
fix(range): Range.gist matches Range.raku (quote strings, Inf, ^N form)

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -731,94 +731,14 @@ fn range_endpoint_display(v: i64) -> String {
 
 /// Return the gist (compact display) representation of a Range value.
 fn range_gist_string(value: &Value) -> String {
-    match value {
-        Value::Range(a, b) => {
-            format!(
-                "{}..{}",
-                range_endpoint_display(*a),
-                range_endpoint_display(*b)
-            )
-        }
-        Value::RangeExcl(a, b) => {
-            if *a == 0 {
-                format!("^{}", range_endpoint_display(*b))
-            } else {
-                format!(
-                    "{}..^{}",
-                    range_endpoint_display(*a),
-                    range_endpoint_display(*b)
-                )
-            }
-        }
-        Value::RangeExclStart(a, b) => {
-            format!(
-                "{}^..{}",
-                range_endpoint_display(*a),
-                range_endpoint_display(*b)
-            )
-        }
-        Value::RangeExclBoth(a, b) => {
-            format!(
-                "{}^..^{}",
-                range_endpoint_display(*a),
-                range_endpoint_display(*b)
-            )
-        }
-        Value::GenericRange {
-            start,
-            end,
-            excl_start,
-            excl_end,
-        } => {
-            let start_sep = if *excl_start { "^.." } else { ".." };
-            let end_sep = if *excl_end { "^" } else { "" };
-            let endpoint_str = |v: &Value, is_end: bool| -> String {
-                match v {
-                    Value::Whatever | Value::HyperWhatever => {
-                        if is_end {
-                            "Inf".to_string()
-                        } else {
-                            "-Inf".to_string()
-                        }
-                    }
-                    Value::Rat(n, d) => {
-                        if *d == 0 {
-                            if *n == 0 {
-                                "NaN".to_string()
-                            } else if *n > 0 {
-                                "Inf".to_string()
-                            } else {
-                                "-Inf".to_string()
-                            }
-                        } else {
-                            let val = *n as f64 / *d as f64;
-                            if val.fract() == 0.0 {
-                                format!("{:.1}", val)
-                            } else {
-                                format!("{}", val)
-                            }
-                        }
-                    }
-                    _ => v.to_string_value(),
-                }
-            };
-            let start_str = endpoint_str(start.as_ref(), false);
-            let end_str = endpoint_str(end.as_ref(), true);
-            // Special case: 0..^N displays as ^N
-            if !*excl_start && *excl_end {
-                let is_zero = match start.as_ref() {
-                    Value::Int(0) => true,
-                    Value::Num(f) if *f == 0.0 => true,
-                    Value::Rat(0, _) => true,
-                    _ => false,
-                };
-                if is_zero {
-                    return format!("^{}", end_str);
-                }
-            }
-            format!("{}{}{}{}", start_str, start_sep, end_sep, end_str)
-        }
-        _ => value.to_string_value(),
+    // Range.gist is identical to Range.raku in Rakudo: numeric endpoints render
+    // plainly, string endpoints are quoted (`"a".."c"`), `i64::MAX`/Whatever
+    // endpoints render as `Inf`/`-Inf`, and `0..^N` uses the `^N` short form.
+    // Delegate to the raku renderer so both stay in sync.
+    if value.is_range() {
+        raku_repr::raku_value(value)
+    } else {
+        value.to_string_value()
     }
 }
 

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1098,21 +1098,16 @@ pub(crate) fn gist_value(value: &Value) -> String {
         }
         Value::Version { .. } => format!("v{}", value.to_string_value()),
         Value::Nil => "Nil".to_string(),
-        // Range gist shows the range notation, not the expanded elements
-        Value::Range(a, b) => format!("{}..{}", a, b),
-        Value::RangeExcl(a, b) => format!("{}..^{}", a, b),
-        Value::RangeExclStart(a, b) => format!("^{}..{}", a, b),
-        Value::RangeExclBoth(a, b) => format!("^{}..^{}", a, b),
-        Value::GenericRange {
-            start,
-            end,
-            excl_start,
-            excl_end,
-        } => {
-            let prefix = if *excl_start { "^" } else { "" };
-            let sep = if *excl_end { "..^" } else { ".." };
-            format!("{}{}{}{}", prefix, gist_value(start), sep, gist_value(end))
-        }
+        // Range.gist is identical to Range.raku in Rakudo: it shows the range
+        // notation (not the expanded elements), numeric endpoints render plainly,
+        // string endpoints are quoted (`"a".."c"`), `i64::MAX`/Whatever endpoints
+        // render as `Inf`/`-Inf`, and `0..^N` uses the `^N` short form. Delegate
+        // to the raku renderer so all of this stays in sync.
+        Value::Range(..)
+        | Value::RangeExcl(..)
+        | Value::RangeExclStart(..)
+        | Value::RangeExclBoth(..)
+        | Value::GenericRange { .. } => crate::builtins::methods_0arg::raku_repr::raku_value(value),
         // A Match nested inside a container (e.g. the values of `$/.caps` or a
         // `m:g//` result list) must still gist as `｢matched｣` plus its sub-
         // captures, matching `Match.gist`. The generic Instance fall-through

--- a/t/range-gist.t
+++ b/t/range-gist.t
@@ -1,0 +1,34 @@
+use Test;
+
+# Range.gist is identical to Range.raku in Rakudo: it shows the range notation,
+# numeric endpoints render plainly, string endpoints are quoted (`"a".."c"`),
+# i64::MAX / Whatever endpoints render as Inf, and `0..^N` uses the `^N` short
+# form. Previously mutsu's gist dropped the quotes on string endpoints, leaked
+# `9223372036854775807` for `1..*`, and expanded `^5` to `0..^5`.
+
+plan 13;
+
+# String ranges keep quotes in gist (both `.gist` and the implicit say-gist).
+is ("a" .. "c").gist, '"a".."c"', 'string Range .gist quotes endpoints';
+is ("a" ^.. "c").gist, '"a"^.."c"', 'excl-min string Range .gist';
+is ("a" .. "c", "x" .. "z").gist, '("a".."c" "x".."z")', 'list of string Ranges gist';
+
+# Numeric ranges render plainly.
+is (1 .. 3).gist, '1..3', 'int Range .gist';
+is (1 ..^ 4).gist, '1..^4', 'excl-end int Range .gist';
+is (1 ^.. 5).gist, '1^..5', 'excl-start int Range .gist';
+is (1 ^..^ 5).gist, '1^..^5', 'excl-both int Range .gist';
+is (1.5 .. 3.5).gist, '1.5..3.5', 'rational Range .gist';
+
+# Infinite / Whatever endpoints render as Inf, not i64::MAX.
+is (1 .. *).gist, '1..Inf', 'open-ended Range .gist renders Inf';
+
+# 0..^N short form.
+is (^5).gist, '^5', '^N short form in gist';
+
+# gist == raku for ranges.
+is ("a" .. "c").gist, ("a" .. "c").raku, 'Range gist matches raku (string)';
+is (1 .. *).gist, (1 .. *).raku, 'Range gist matches raku (open-ended)';
+
+# Range nested in a hash value gist keeps quotes.
+is %(r => ("a" .. "c")).gist, '{r => "a".."c"}', 'Range in hash value gist';


### PR DESCRIPTION
## Problem

mutsu's `Range.gist` diverged from Rakudo in three ways:

| code | mutsu (before) | raku |
|------|----------------|------|
| `("a".."c").gist` | `a..c` | `"a".."c"` |
| `(1..*).gist` | `1..9223372036854775807` | `1..Inf` |
| `(^5).gist` | `0..^5` | `^5` |

(The implicit `say $range` path was also affected.)

## Fix

In Rakudo, `Range.gist` is **identical** to `Range.raku` for every endpoint type (verified across int / rational / string / excl-start / excl-end / excl-both / open-ended / `^N`). Both the implicit say-gist path (`gist_value` in `runtime/utils.rs`) and the explicit `.gist`/`.Str` method path (`range_gist_string` in `builtins/methods_0arg/mod.rs`) now delegate range rendering to the existing, already-correct `raku_repr::raku_value`, so the two representations stay in sync and the duplicated (buggy) range-formatting logic is removed.

## Verification

All match raku, including ranges nested in lists (`("a".."c" "x".."z")`) and hash values (`{r => "a".."c"}`). New test `t/range-gist.t` (13 cases). `cargo test` (468) green. No roast regression — `S02-types/range.t` failure count identical to main; a local whitelisted sweep of range/gist/perl/coerce tests showed no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)