### PR TITLE
fix(operators): numeric ops coerce a list operand to its element count

### DIFF
--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -1619,6 +1619,14 @@ impl Interpreter {
         &mut self,
         value: Value,
     ) -> Result<Value, RuntimeError> {
+        // A pure positional list (List/Array/Seq) in numeric context coerces to
+        // its element count: `(1,2,3) <=> (1,2,4)` is `3 <=> 3` (Same) and
+        // `(1,2,3) == (1,2,4)` is `3 == 3` (True), NOT an element-wise compare
+        // (that is `cmp`). This must run before the Instance check below so the
+        // numeric comparison ops (`== != < > <= >= <=>`) see the elem count.
+        if let Some(items) = value.as_list_items() {
+            return Ok(Value::Int(items.len() as i64));
+        }
         if !matches!(value, Value::Instance { .. }) {
             return Ok(value);
         }

--- a/t/list-numeric-comparison.t
+++ b/t/list-numeric-comparison.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A pure positional list (List/Array/Seq) in numeric context coerces to its
+# element count, so the numeric comparison operators compare elem counts, NOT
+# element-wise (that is `cmp`). Previously `<=>` compared lists element-wise and
+# `==` compared two same-typed lists structurally.
+
+plan 14;
+
+# <=> compares element counts.
+is (1, 2, 3) <=> (1, 2, 4), Same, '<=> on equal-length lists is Same';
+is [1, 2, 3] <=> [4, 5], More, '<=> on Arrays compares elems (3 vs 2)';
+is <a b c> <=> <d e>, More, '<=> on string lists compares elems';
+is (1, 2, 3) <=> (1, 2, 4, 5), Less, '<=> shorter list is Less';
+
+# == / != compare element counts.
+ok (1, 2, 3) == (1, 2, 4), '== on equal-length lists is True';
+nok (1, 2, 3) == (1, 2), '== on different-length lists is False';
+ok (1, 2, 3) != (1, 2), '!= on different-length lists is True';
+
+# Relational operators (already worked) stay correct.
+ok (1, 2, 3) < (4, 5, 6, 7), '< compares elems (3 < 4)';
+ok (1, 2, 3) <= (1, 2, 4), '<= on equal-length lists';
+ok (1, 2, 3) >= (4, 5, 6), '>= on equal-length lists';
+
+# Arithmetic in numeric context (already worked) stays correct.
+is (1, 2, 3) + (4, 5), 5, '+ adds elem counts';
+is (1, 2, 3) * 2, 6, '* multiplies elem count';
+
+# Scalar numerics are unaffected.
+is 5 <=> 2, More, 'scalar <=> still works';
+is 1.5 <=> 2.5, Less, 'rational <=> still works';


### PR DESCRIPTION
## Problem

| code | mutsu (before) | raku |
|------|----------------|------|
| `(1,2,3) <=> (1,2,4)` | `Less` | `Same` |
| `[1,2,3] <=> [4,5]` | `Less` | `More` |
| `(1,2,3) == (1,2,4)` | `False` | `True` |

In Raku a pure positional list in **numeric** context coerces to its element count, so `<=>` and `==` compare elem counts (`3 <=> 3`, `3 == 3`) — element-wise comparison is `cmp`'s job, not `<=>`'s.

## Root cause

The relational/arithmetic ops (`+ - * < > <= >=`) already worked because they numify each operand downstream via `to_float_value` (which returns the elem count for a list). Only two ops bypassed that:
- `<=>` fell through to the element-wise `spaceship_ordering`;
- `==`/`!=` compared two same-typed lists with structural `l == r`.

## Fix

Coerce at the single authoritative point: `coerce_infix_operand_numeric` now coerces a pure positional list (List/Array/Seq, via `as_list_items()`) to `Int(elems)` before the Instance check, so every numeric infix operator sees the element count consistently.

## Verification

Matches raku for `<=>`, `==`, `!=`, `<`, `<=`, `>=`, `+`, `*` on lists/arrays/string-lists; scalar numerics unaffected. New test `t/list-numeric-comparison.t` (14 cases). `cargo test` (468) green. Local sweep of **169** whitelisted S03-operators/S02-types/S32-num/S03-sequence/S29-context tests: 0 regressions; `spaceship.t`/`comparison.t`/`relational.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)