### PR TITLE
fix(reduce): `[R op]` reverses the whole fold; single-element reduce numifies

### DIFF
--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -1758,7 +1758,7 @@ impl Interpreter {
         } else {
             (false, op_no_scan)
         };
-        let base_op = if base_op == "∘" {
+        let mut base_op = if base_op == "∘" {
             "o".to_string()
         } else {
             base_op
@@ -1809,6 +1809,21 @@ impl Interpreter {
                 }
                 other => vec![other],
             };
+        }
+        // The `R` (reverse) metaop on a reduction reverses the entire fold:
+        // `[R op] @list` == `[op] @list.reverse` (and likewise for the scan form
+        // `[\R op]`). Reversing the operand list and stripping the `R` yields the
+        // correct result for non-commutative / non-associative ops (`-`, `/`),
+        // where the per-step operand swap done by `eval_reduction_operator_values`
+        // would instead compute `[op]` right-folded (e.g. `[R/] 100,10,2` is
+        // `2/10/100` = 0.002, not `100/(10/2)` = 20).
+        while let Some(inner) = base_op.strip_prefix('R') {
+            if !inner.is_empty() && Self::is_builtin_reduction_op(inner) {
+                list.reverse();
+                base_op = inner.to_string();
+            } else {
+                break;
+            }
         }
         if base_op == "," {
             if scan {
@@ -2133,11 +2148,16 @@ impl Interpreter {
                             "base-10 number must begin with valid digits or '.'",
                         ));
                     }
-                    let identity = runtime::reduction_identity(&base_op);
                     // Coerce Instance values via Numeric()/Bridge() so that
                     // user-defined numeric types work (e.g. `[*] CustomNumify.new`).
                     let elem = self.coerce_numeric_bridge_value(list[0].clone())?;
-                    let v = self.reduction_step_with_args(&base_op, None, vec![identity, elem])?;
+                    // A single-element reduction returns the element *numified*,
+                    // NOT `op(identity, element)`. The latter is only correct for
+                    // the commutative `+`/`*` (where `0 + x == x`); for `-`/`/`/
+                    // `**`/`%` it would wrongly compute `0 - 5`, `1 / 5`, etc.
+                    // Numify via the additive identity so `[+] "2"` is Int 2,
+                    // `[-] 5` is 5, and `[/] 5` is 5 (matching Rakudo).
+                    let v = self.reduction_step_with_args("+", None, vec![Value::Int(0), elem])?;
                     let result = if negate { Value::Bool(!v.truthy()) } else { v };
                     self.stack.push(result);
                     return Ok(());

--- a/t/reduce-reverse-metaop.t
+++ b/t/reduce-reverse-metaop.t
@@ -1,0 +1,39 @@
+use Test;
+
+# The `R` (reverse) metaop on a reduction reverses the entire fold:
+# `[R op] @list` == `[op] @list.reverse`. Previously mutsu swapped operands
+# per-step, which is wrong for non-commutative / non-associative ops:
+# `[R/] 100,10,2` gave `100/(10/2)` = 20 instead of `2/10/100` = 0.002.
+#
+# Also covers the single-element reduce bug exposed by the R fix: `[op] $x`
+# returns the (numified) element for ANY op, not `op(identity, $x)`.
+
+plan 18;
+
+# [R op] == [op] reversed.
+is ([R-] 1, 2, 3, 4), -2, '[R-] reverses the fold (4-3-2-1)';
+is ([R/] 100, 10, 2), 0.002, '[R/] reverses the fold (2/10/100)';
+is ([R-] 10, 1), -9, '[R-] two elements';
+is ([R~] 1, 2, 3), '321', '[R~] reverses concatenation';
+is-deeply ([R,] 1, 2, 3), (3, 2, 1), '[R,] reverses the list';
+is ([R**] 2, 3, 4), 262144, '[R**] reverses then right-folds (4**(3**2))';
+
+# Scan form [\R op] also reverses first.
+is-deeply ([\R-] 1, 2, 3, 4), (4, 1, -1, -2), '[\R-] scan over reversed list';
+is-deeply ([\R/] 100, 10, 2), (2, 0.2, 0.002), '[\R/] scan over reversed list';
+
+# Commutative ops are unaffected by the reversal.
+is ([Rmin] 3, 1, 2), 1, '[Rmin] (commutative)';
+is ([R+] 1, 2, 3), 6, '[R+] (commutative)';
+
+# Single-element reduce returns the element itself (numified), not op(id, x).
+is ([-] 5), 5, '[-] single element is the element';
+is ([/] 5), 5, '[/] single element is the element';
+is ([**] 5), 5, '[**] single element is the element';
+is ([%] 5), 5, '[%] single element is the element';
+is ([R-] 5), 5, '[R-] single element is the element';
+
+# Single-element reduce still numifies (and validates) the element.
+is ([+] "2").WHAT.gist, '(Int)', '[+] "2" numifies to Int';
+is ([-] "5"), 5, '[-] "5" numifies to 5 (not -5)';
+dies-ok { [+] "hello" }, '[+] on a non-numeric string still dies';


### PR DESCRIPTION
## Two related reduction bugs

### 1. `[R op]` (reverse metaop) reduced wrong for non-commutative ops

| code | mutsu (before) | raku |
|------|----------------|------|
| `[R/] 100,10,2` | `20` | `0.002` |
| `[R-] 1,2,3,4` | `2` | `-2` |
| `[\R-] 1,2,3,4` | `(1 1 2 2)` | `(4 1 -1 -2)` |

mutsu swapped operands **per-step** via `eval_reduction_operator_values`, which for non-commutative/non-associative ops (`-`, `/`) gives a right-fold, not the reverse. In Raku `[R op] @list` == `[op] @list.reverse` (the scan form `[\R op]` likewise). Fixed in `exec_reduction_op`: reverse the operand list and strip the `R` so the base op folds normally.

### 2. Single-element reduce was `op(identity, x)` not the element

`[-] 5` gave `-5` (`0 - 5`) and `[/] 5` gave `0`. Raku returns the element itself, numified, for **any** op (`[-] 5` → 5, `[+] "2"` → Int 2). Numify via the additive identity instead of applying the operator. This bug was masked for `[R-]` by the per-step path; fixing #1 exposed it, so both are fixed here.

## Verification

Matches raku for `[R-]`/`[R/]`/`[R~]`/`[R,]`/`[R**]`/`[Rmin]`, scan `[\R-]`/`[\R/]`, and single-element `[-]`/`[/]`/`[**]`/`[%]`/`[+]"2"` (+ `[+]"hello"` still dies). New test `t/reduce-reverse-metaop.t` (18 cases). `cargo test` (468) green. Local sweep of **82** whitelisted S03-metaops/operators/sequence tests: 0 regressions (`reduce.t`/`reverse.t`/`cross.t` pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)