### PR TITLE
fix(WHICH): ObjAt gists as the bare WHICH, raku as the constructor form

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -753,6 +753,21 @@ pub fn raku_value(v: &Value) -> String {
         Value::Set(..) | Value::Bag(..) | Value::Mix(..) => {
             setbagmix_raku(v).unwrap_or_else(|| v.to_string_value())
         }
+        // An ObjAt / ValueObjAt (from `.WHICH`) renders its `.raku` as the
+        // constructor form `ValueObjAt.new("Int|42")`; only `.gist` / `.Str`
+        // show the bare WHICH string (`Int|42`, via `to_string_value`).
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name == "ObjAt" || class_name == "ValueObjAt" => {
+            let which = attributes
+                .as_map()
+                .get("WHICH")
+                .map(|v| v.to_string_value())
+                .unwrap_or_default();
+            format!("{}.new(\"{}\")", class_name.resolve(), which)
+        }
         Value::Mixin(inner, mixins) => {
             // An allomorphic value (IntStr/RatStr/NumStr/ComplexStr) renders as
             // `TypeStr.new(<numeric>, "<original string>")` — e.g. `<42>.raku`

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -754,6 +754,12 @@ impl Interpreter {
                         .get("WHICH")
                         .map(|v| v.to_string_value())
                         .unwrap_or_default();
+                    // `.gist` (like `.Str`) shows the bare WHICH (`Int|42`);
+                    // only `.raku`/`.perl` show the `ValueObjAt.new("Int|42")`
+                    // constructor form.
+                    if method == "gist" {
+                        return Ok(Value::str(which));
+                    }
                     return Ok(Value::str(format!(
                         "{}.new(\"{}\")",
                         class_name.resolve(),

--- a/t/objat-gist-raku.t
+++ b/t/objat-gist-raku.t
@@ -1,0 +1,27 @@
+use Test;
+
+# An ObjAt / ValueObjAt (the result of `.WHICH`) gists (and stringifies) as the
+# bare WHICH string `Int|42`; only `.raku` / `.perl` show the constructor form
+# `ValueObjAt.new("Int|42")`. Previously mutsu had these swapped: `.gist` showed
+# the constructor form and the nested `.raku` showed the bare WHICH.
+
+plan 10;
+
+is 42.WHICH.Str, 'Int|42', '.WHICH.Str is the bare WHICH';
+is 42.WHICH.gist, 'Int|42', '.WHICH.gist is the bare WHICH';
+is 42.WHICH.raku, 'ValueObjAt.new("Int|42")', '.WHICH.raku is the constructor form';
+
+# say uses .gist.
+my $w = 42.WHICH;
+is "$w", 'Int|42', '.WHICH interpolates as the bare WHICH';
+
+is "abc".WHICH.gist, 'Str|abc', 'Str .WHICH.gist';
+is "abc".WHICH.raku, 'ValueObjAt.new("Str|abc")', 'Str .WHICH.raku';
+
+# Nested in containers: gist shows WHICH, raku shows constructor form.
+is [42.WHICH].gist, '[Int|42]', 'nested .gist shows the WHICH';
+is [42.WHICH].raku, '[ValueObjAt.new("Int|42")]', 'nested .raku shows the constructor';
+is { a => 1.WHICH }.raku, '{:a(ValueObjAt.new("Int|1"))}', 'hash-value .raku';
+
+# .WHICH equality still works.
+ok "x".WHICH eq "x".WHICH, '.WHICH values compare equal';


### PR DESCRIPTION
## Problem

| code | mutsu (before) | raku |
|------|----------------|------|
| `say 42.WHICH` | `ValueObjAt.new("Int|42")` | `Int\|42` |
| `42.WHICH.gist` | `ValueObjAt.new("Int|42")` | `Int\|42` |
| `[42.WHICH].raku` | `[Int\|42]` | `[ValueObjAt.new("Int|42")]` |

The `.gist`/`say` form and the nested `.raku` form were **swapped**.

## Fix

In Rakudo an ObjAt / ValueObjAt gists (and stringifies) as the bare WHICH (`Int|42`); only `.raku`/`.perl` show `ValueObjAt.new("Int|42")`. Fixed three rendering sites consistently:
- the `.gist` method path (`methods_instance_ops.rs`) returns the WHICH for `gist`, the constructor form only for `raku`/`perl`;
- `raku_value` (`raku_repr.rs`) gained an ObjAt arm returning the constructor form (it previously fell through to `to_string_value` → bare WHICH);
- the `.Str` path was already correct.

## Verification

Matches raku for `.Str`/`.gist`/`.raku`, interpolation, Str/Int WHICH, and ObjAt nested in arrays/hashes. New test `t/objat-gist-raku.t` (10 cases). `cargo test` (468) green. Local sweep of **141** whitelisted render/introspection tests: 0 regressions; `roast/S02-types/WHICH.t` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)