### PR TITLE
fix(parser): superscript power in method-call syntax (`2.²`)

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1530,6 +1530,20 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 "X::Obsolete: Perl -> is dead. Please use '.' instead.".to_string(),
             ));
         }
+        // Superscript power in method-call syntax: `2.²` == `2²` == `2 ** 2`
+        // (also `.³`, `.⁻¹`, ...). Must run before the general `.method`
+        // dispatch below, which would otherwise treat `²` as a method name.
+        if let Some(after_dot) = rest.strip_prefix('.')
+            && let Some((exp, len)) = parse_superscript_exp(after_dot)
+        {
+            rest = &after_dot[len..];
+            expr = Expr::Binary {
+                left: Box::new(expr),
+                op: crate::token_kind::TokenKind::StarStar,
+                right: Box::new(Expr::Literal(Value::Int(exp))),
+            };
+            continue;
+        }
         // Method call: .method or .method(args) or .method: args
         // Also handles modifiers: .?method, .!method
         // Also handles: .^method (meta-method)

--- a/t/superscript-method-power.t
+++ b/t/superscript-method-power.t
@@ -1,0 +1,22 @@
+use Test;
+
+# Superscript powers can be written in method-call syntax (`2.²`), the same as
+# the adjacent form (`2²`). Both mean `2 ** 2`. Previously mutsu parsed `.²` as
+# a method call and died with "No such method '²'".
+
+plan 10;
+
+is 2.², 4, '2.² == 2 ** 2';
+is 2.³, 8, '2.³ == 2 ** 3';
+is 5.², 25, '5.² == 25';
+is 3.⁴, 81, '3.⁴ == 81';
+is 2.⁻¹, 0.5, '2.⁻¹ == 0.5 (negative exponent)';
+
+my $x = 3;
+is $x.², 9, 'method-superscript on a variable';
+is (1 + 1).², 4, 'method-superscript on a parenthesized expression';
+is 2².³, 64, 'chained adjacent + method superscripts ((2**2)**3)';
+
+# Adjacent form still works, and normal method calls are unaffected.
+is 2², 4, 'adjacent superscript still works';
+is 5.abs, 5, 'normal method call still works';


### PR DESCRIPTION
## Problem

```
$ mutsu -e 'say 2.²'
Runtime error: No such method '²' for invocant of type 'Int'
$ raku -e 'say 2.²'
4
```

Raku accepts both the adjacent form `2²` and the method-call form `2.²` (and `.³`, `.⁻¹`, ...), each meaning `2 ** 2`. mutsu parsed the superscript after `.` as a method name.

## Fix

Handle `.` + superscript-digits in `postfix_expr_loop` **before** the general `.method` dispatch, lowering it to the same `** <exp>` Binary as the adjacent form (reusing `parse_superscript_exp`, so signs and multi-digit exponents work).

## Verification

Matches raku for `2.²`/`2.³`/`5.²`/`3.⁴`/`2.⁻¹`, on variables and parenthesized expressions, and chained with the adjacent form (`2².³` → 64). Normal method calls and `..` ranges unaffected. New test `t/superscript-method-power.t` (10 cases). `cargo test` (468) green; 126-file whitelisted number/operator sweep: 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)