### PR TITLE
refactor(grep): remove grep-rw-view side channel; use first-class element cells

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -79,13 +79,18 @@ Stage 0〜2c 完了（Stage 3 = escape-aware cell 省略は perf 未正当化で
 
 - [ ] **Phase 2 Stage 2 slice 5（最終 SlotRef キル）**: 残る `HashSlotRef`/`DeferredHashAccess` 生成サイト
       （junction-bind / `is raw` reduce lvalue-read の autoviv）を cell 化し、variant を削除。
-- [ ] **grep-rw-view 撤去**: `for_grep_view`（Interpreter フィールド・vm.rs で save/restore）＋ `GrepView`（ArrayData 埋め込み
-      `grep_source`）＋ index ベース writeback（`overwrite_array_items_by_identity_for_vm`＝Arc-identity で source array を特定）
-      を、matched 要素の cell 昇格で全廃する。**★調査結果（2026-06-23）= これは「最終 SlotRef キル」と同じ Phase-2
-      配列要素 cell インフラに依存し、単独スライスではない**: cell 昇格すると `@a` の matched slot が `ContainerRef` を恒久保持
-      → `say @a`/`@a[i]`/copy/gist など**全 read パスが要素 cell を deref する必要**がある。write chokepoint（`assign_element_slot`・
-      value/mod.rs:3170）は存在するが read 側 deref は部分的（`:=`-bound 全体 cell には対応・要素 cell は未網羅）。
-      ∴ **着手順は「最終 SlotRef キル＝Phase-2 要素 cell の read-deref 網羅」が先**、その上で grep-rw-view を cell 化する。
+- [x] **grep-rw-view 撤去（完了・2026-06-23）**: `for_grep_view`（Interpreter フィールド・vm.rs save/restore）＋
+      `GrepView`／`grep_source`（ArrayData 埋め込み）＋ index ベース writeback を全廃。`.grep` は matched source slot を
+      共有 `ContainerRef` cell に昇格し、結果が同じ cell を参照する（`for @a.grep(...){ $_++ }` は通常の要素 cell write
+      パスで @a に書き戻る）。`>>++`/`>>--` は hyper ループで cell を通して in-place inc。pin=`t/grep-cell-read-deref.t`。
+      **read-deref 未網羅は実測で次の箇所のみ（いずれも `:=`-bound 要素 cell の既存バグでもあった）**:
+      (1) `compare_values`（.sort/min/max）(2) `collect_minmax_candidates`（.minmax）(3) hyper メソッドループ（`>>.method`
+      の invocant）(4) `.join` の Instance 判定 3 箇所（fast-narg／runtime／0-arg）(5) **メソッド dispatch の invocant**
+      （`.grep(...).head.method` 等で cell が単要素抽出されメソッド受信側になる）＝`exec_call_method_op` で `ContainerRef`
+      invocant を `.VAR` 以外 decont。**★教訓: 「全 read パスが deref 必要」という事前調査は過大評価。実際は ~30 op を実測して
+      上記のみ欠けていた（say/map/gist/raku/reduce/flat/splice/Bag/Set/first/squish/index 等は既存 chokepoint で deref 済）。
+      ★最重要の中心修正＝CallMethod invocant の decont（読み専用なので安全・CallMethodMut は `:=`-bound 容器変異を壊すので
+      decont 不可）。これ 1 つで `.head.method`/`.first.method` 系の class 全体が解ける。**
 - [x] **★env↔locals cell 共有 — captured-outer cell 化／純 writeback コヒーレンス（A の律速・完了）**: slice 1〜1.20
       ＋ S1〜S21 で nested callee／carrier／cross-thread の captured-mutated lexical を全て precise 化。台帳＝
       [docs/captured-outer-cell-sharing.md](docs/captured-outer-cell-sharing.md)、グラインド詳細＝news/2026-06.md ＋ MEMORY

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -269,8 +269,13 @@ pub(super) fn dispatch(
             }
             if let Some(items) = target.as_list_items() {
                 // If any item is an Instance, fall through to runtime
-                // so user-defined Str() methods can be called.
-                if items.iter().any(|v| matches!(v, Value::Instance { .. })) {
+                // so user-defined Str() methods can be called. A `ContainerRef`
+                // element (grep rw alias / `:=`-bound slot) is decontainerized
+                // first so a cell-wrapped Instance is also routed to runtime.
+                if items
+                    .iter()
+                    .any(|v| v.with_deref(|inner| matches!(inner, Value::Instance { .. })))
+                {
                     return Some(None);
                 }
                 let joined = items

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -1182,8 +1182,13 @@ pub(crate) fn native_method_1arg(
             }
             if let Some(items) = target.as_list_items() {
                 // If any item is an Instance, fall through to runtime
-                // so user-defined Str() methods can be called.
-                if items.iter().any(|v| matches!(v, Value::Instance { .. })) {
+                // so user-defined Str() methods can be called. A `ContainerRef`
+                // element (grep rw alias / `:=`-bound slot) is decontainerized
+                // first so a cell-wrapped Instance is also routed to runtime.
+                if items
+                    .iter()
+                    .any(|v| v.with_deref(|inner| matches!(inner, Value::Instance { .. })))
+                {
                     return None;
                 }
                 let sep = arg.to_string_value();

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -768,6 +768,10 @@ impl Interpreter {
         match value {
             // Unwrap Scalar containers
             Value::Scalar(inner) => Self::collect_minmax_candidates(inner, out),
+            // Unwrap first-class element containers (`:=`-bound / grep rw alias).
+            Value::ContainerRef(cell) => {
+                Self::collect_minmax_candidates(&cell.lock().unwrap().clone(), out)
+            }
             Value::Range(a, b)
             | Value::RangeExcl(a, b)
             | Value::RangeExclStart(a, b)

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -287,17 +287,14 @@ impl Interpreter {
             Value::Array(items, arr_kind) => {
                 let (filtered, mutated_items) =
                     self.eval_grep_over_items_with_mutated(args.first().cloned(), items.to_vec())?;
-                let updated_source = crate::value::Value::array_data_like(&items, mutated_items);
-                self.overwrite_array_bindings_by_identity(
-                    &items,
-                    Value::Array(updated_source.clone(), arr_kind),
-                );
+                // Determine which source positions matched (identity scan against
+                // the post-grep source), so the matched slots can be shared with
+                // the result as first-class element containers.
                 let mut indices = Vec::new();
                 if let Value::Array(filtered_items, ..) = &filtered {
                     let mut scan_from = 0usize;
-                    let source_items = updated_source.as_ref();
                     for needle in filtered_items.iter() {
-                        if let Some(rel) = source_items[scan_from..].iter().position(|candidate| {
+                        if let Some(rel) = mutated_items[scan_from..].iter().position(|candidate| {
                             crate::runtime::utils::values_identical(candidate, needle)
                         }) {
                             let absolute = scan_from + rel;
@@ -306,18 +303,38 @@ impl Interpreter {
                         }
                     }
                 }
-                // Embed the rw-view binding into the filtered ArrayData so it
-                // travels with the value through copy-on-write (no Arc-pointer
-                // side table). The `:k`/`:kv`/`:p` adverbs rebuild a fresh array
-                // in `transform_result`, which naturally drops the binding.
+                // Promote each matched source slot to a shared `ContainerRef`
+                // cell and reference the SAME cells from the grep result. A
+                // writeback loop (`for @a.grep(...) { $_++ }` / `@a.grep(...)>>++`)
+                // then mutates THROUGH the cell into @a's slot via the ordinary
+                // element-cell write path — no GrepView side channel needed. A
+                // later `=` assignment (`my @g = @a.grep(...)`) decontainerizes the
+                // cells, so the named copy owns its values and never writes back.
+                let mut promoted = mutated_items;
+                let mut shared_cells: Vec<Value> = Vec::with_capacity(indices.len());
+                for &i in &indices {
+                    let cell = match &promoted[i] {
+                        v @ Value::ContainerRef(_) => v.clone(),
+                        other => Value::ContainerRef(std::sync::Arc::new(std::sync::Mutex::new(
+                            other.clone(),
+                        ))),
+                    };
+                    promoted[i] = cell.clone();
+                    shared_cells.push(cell);
+                }
+                let updated_source = crate::value::Value::array_data_like(&items, promoted);
+                self.overwrite_array_bindings_by_identity(
+                    &items,
+                    Value::Array(updated_source, arr_kind),
+                );
+                // Build the result array from the shared cells (default `:v`
+                // adverb). The `:k`/`:kv`/`:p` adverbs rebuild a fresh array in
+                // `transform_result` from `indices`, which drops the aliasing (a
+                // keys/pairs copy owns its values).
                 let filtered = match filtered {
                     Value::Array(filtered_items, fkind) if !indices.is_empty() => {
                         let mut data = (*filtered_items).clone();
-                        data.grep_source = Some(Box::new(crate::value::GrepView {
-                            source: updated_source.clone(),
-                            indices: indices.clone(),
-                            source_kind: arr_kind,
-                        }));
+                        data.items = shared_cells;
                         Value::Array(std::sync::Arc::new(data), fkind)
                     }
                     other => other,

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -568,6 +568,9 @@ impl Interpreter {
         };
         let mut parts = Vec::with_capacity(items.len());
         for v in &items {
+            // Decontainerize a `ContainerRef` element (grep rw alias / `:=`-bound
+            // slot) so a cell-wrapped Instance still gets its user-defined `.Str`.
+            let v = v.deref_container();
             if matches!(v, Value::Instance { .. }) {
                 let s = match self.call_method_with_values(v.clone(), "Str", vec![]) {
                     Ok(s) => s,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1203,12 +1203,6 @@ pub struct Interpreter {
     pub(crate) container_ref_reversed: bool,
     pub(crate) topic_source_var: Option<String>,
     pub(crate) element_source: Option<(String, Value, bool)>,
-    #[allow(clippy::type_complexity)]
-    pub(crate) for_grep_view: Option<(
-        Arc<crate::value::ArrayData>,
-        Vec<usize>,
-        crate::value::ArrayKind,
-    )>,
     pub(crate) quanthash_bind_params: Vec<String>,
     pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,
     pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
@@ -3422,7 +3416,6 @@ impl Interpreter {
             container_ref_reversed: false,
             topic_source_var: None,
             element_source: None,
-            for_grep_view: None,
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),
@@ -6017,7 +6010,6 @@ impl Interpreter {
             container_ref_reversed: false,
             topic_source_var: None,
             element_source: None,
-            for_grep_view: None,
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),
             call_frames: Vec::new(),

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -36,6 +36,13 @@ impl Interpreter {
     }
 
     pub(crate) fn smart_match(&mut self, left: &Value, right: &Value) -> bool {
+        // A first-class element container on the LHS (`ContainerRef`, e.g. a
+        // `.grep(...).head` rw alias / `:=`-bound slot) is transparent to
+        // smartmatch — test the contained value (Raku container semantics).
+        if let Value::ContainerRef(cell) = left {
+            let inner = cell.lock().unwrap().clone();
+            return self.smart_match(&inner, right);
+        }
         match (left, right) {
             // Whatever on RHS always matches (ACCEPTS returns True for any value)
             (_, Value::Whatever) => true,

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3493,6 +3493,12 @@ pub(crate) fn compare_values(a: &Value, b: &Value) -> i32 {
         } as i32)
     }
 
+    // First-class element containers (`ContainerRef`, e.g. a `:=`-bound array
+    // slot or a `.grep` rw alias) compare by their inner value — `.sort`/min/max
+    // over a grepped/bound array must order the values, not the cells.
+    if matches!(a, Value::ContainerRef(_)) || matches!(b, Value::ContainerRef(_)) {
+        return compare_values(&a.deref_container(), &b.deref_container());
+    }
     match (a, b) {
         (Value::Version { parts: ap, .. }, Value::Version { parts: bp, .. }) => {
             version_cmp_parts(ap, bp) as i32

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1427,27 +1427,6 @@ pub struct ArrayData {
     /// `Arc::as_ptr`-keyed `ShapedArrayIds` side table) so the shape travels
     /// with the container through copy-on-write.
     pub shape: Option<Vec<usize>>,
-    /// rw aggregate-view binding for `for @a.grep(...) { $_++ }`. A grep result
-    /// over an array carries the source array and the matched source indices so
-    /// the for-loop can write modified topics back to the original slots.
-    /// Embedded (replacing the former `Arc::as_ptr`-keyed grep-view side table)
-    /// so the binding travels with the filtered value through copy-on-write and
-    /// can never be inherited by an unrelated array via pointer reuse. A `=`
-    /// assignment / any rebuild via `array_data_like` drops it (the named-array
-    /// copy owns its elements and must not leak writeback into the source).
-    pub grep_source: Option<Box<GrepView>>,
-}
-
-/// The source binding embedded in a grep result so `for @a.grep(...) { $_++ }`
-/// can mirror modified topics back to the original array's matched slots.
-#[derive(Debug, Clone)]
-pub struct GrepView {
-    /// The (post-grep) source array whose slots the filtered elements alias.
-    pub source: Arc<ArrayData>,
-    /// For each filtered element, its 0-based index in `source`.
-    pub indices: Vec<usize>,
-    /// The source array's kind (preserved through writeback).
-    pub source_kind: ArrayKind,
 }
 
 impl ArrayData {
@@ -1459,7 +1438,6 @@ impl ArrayData {
             declared_type: None,
             default: None,
             shape: None,
-            grep_source: None,
         }
     }
 
@@ -3057,8 +3035,6 @@ impl Value {
             declared_type: like.declared_type.clone(),
             default: like.default.clone(),
             shape: like.shape.clone(),
-            // A rebuilt array never inherits a stale grep rw-view binding.
-            grep_source: None,
         })
     }
     /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -560,7 +560,6 @@ impl Interpreter {
         let saved_topic_save_stack = std::mem::take(&mut self.topic_save_stack);
         let saved_topic_source_var = self.topic_source_var.take();
         let saved_element_source = self.element_source.take();
-        let saved_for_grep_view = self.for_grep_view.take();
         let saved_container_ref_var = self.container_ref_var.take();
         let saved_container_ref_reversed = self.container_ref_reversed;
         let saved_quanthash_bind_params = std::mem::take(&mut self.quanthash_bind_params);
@@ -616,7 +615,6 @@ impl Interpreter {
         self.topic_save_stack = saved_topic_save_stack;
         self.topic_source_var = saved_topic_source_var;
         self.element_source = saved_element_source;
-        self.for_grep_view = saved_for_grep_view;
         self.container_ref_var = saved_container_ref_var;
         self.container_ref_reversed = saved_container_ref_reversed;
         self.quanthash_bind_params = saved_quanthash_bind_params;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -294,6 +294,16 @@ impl Interpreter {
         } else {
             target
         };
+        // A method invocant that is a first-class element container
+        // (`ContainerRef`, e.g. a `.grep` rw alias / `:=`-bound slot extracted via
+        // `.head`/`.first`) is transparent to method dispatch — decontainerize it
+        // so the method runs on the inner value (Raku container semantics). `.VAR`
+        // is the one introspection method that wants the container itself.
+        let target = if matches!(&target, Value::ContainerRef(_)) && method != "VAR" {
+            target.deref_container()
+        } else {
+            target
+        };
         // `proto method` body dispatch (see try_proto_method_body).
         if let Some(result) = self.try_proto_method_body(&target, method, &args) {
             let v = result?;

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -439,18 +439,6 @@ impl Interpreter {
 
         let iterable = self.stack.pop().unwrap();
 
-        // rw aggregate view: `for @a.grep(...) { $_++ }` iterates over a grep
-        // result whose elements alias slots of the original array. If the
-        // iterable carries a registered grep-view binding, remember the source
-        // array + matched indices so the loop can write modified topics back.
-        self.for_grep_view = match &iterable {
-            Value::Array(items, _) => items
-                .grep_source
-                .as_deref()
-                .map(|gv| (gv.source.clone(), gv.indices.clone(), gv.source_kind)),
-            _ => None,
-        };
-
         // Handle lazy IO lines: iterate by pulling one line at a time
         // so that $fh.tell reflects the current read position.
         if let Value::LazyIoLines {
@@ -663,21 +651,6 @@ impl Interpreter {
         let saved_topic_source = self.topic_source_var.take();
         let saved_quanthash_bind = std::mem::take(&mut self.quanthash_bind_params);
         let container_binding = self.container_ref_var.take();
-        // rw aggregate view writeback (`for @a.grep(...) { $_++ }`): take the
-        // grep-view binding captured by exec_for_loop_op. When present and the
-        // loop writes back its topic / rw param, modified values are mirrored to
-        // the source array's matched slots after the loop (by Arc identity).
-        // Only applies when the iterable is a transient grep result flowing
-        // directly into the loop. If `container_binding` is set, the iterable is
-        // a named array variable (e.g. `my @g = @a.grep(...); for @g {...}`)
-        // whose `=` assignment decontainerized the rw aliases — the name-based
-        // writeback owns that array, so the grep view must not leak into @a.
-        let grep_view = if container_binding.is_none() {
-            self.for_grep_view.take()
-        } else {
-            self.for_grep_view = None;
-            None
-        };
         // A sigilless/`is rw` for-param aliases the source element, but an
         // *immutable* Mix/Set/Bag yields immutable weights — assigning to the
         // alias must throw X::Assignment::RO, and no writeback may run (it would
@@ -708,7 +681,6 @@ impl Interpreter {
                 Some(Value::Mix(_, true)) | Some(Value::Set(_, true)) | Some(Value::Bag(_, true))
             )
         });
-        let mut grep_view_writes: Vec<(usize, Value)> = Vec::new();
         let container_reversed = self.container_ref_reversed;
         self.container_ref_reversed = false;
         // Capture hash key order before the loop so writeback uses the
@@ -957,18 +929,6 @@ impl Interpreter {
                             &param_name,
                             idx,
                         );
-                        if let Some((_, ref indices, _)) = grep_view
-                            && arity == 1
-                            && (writes_back_topic || rw_writeback)
-                            && let Some(&src_idx) = indices.get(idx)
-                            && let Some(v) = self.grep_view_topic_value(
-                                writes_back_topic,
-                                rw_writeback,
-                                &param_name,
-                            )
-                        {
-                            grep_view_writes.push((src_idx, v));
-                        }
                         if let Some(ref mut coll) = collected {
                             let base = stack_base.unwrap();
                             if self.stack.len() > base {
@@ -1018,18 +978,6 @@ impl Interpreter {
                             &param_name,
                             idx,
                         );
-                        if let Some((_, ref indices, _)) = grep_view
-                            && arity == 1
-                            && (writes_back_topic || rw_writeback)
-                            && let Some(&src_idx) = indices.get(idx)
-                            && let Some(v) = self.grep_view_topic_value(
-                                writes_back_topic,
-                                rw_writeback,
-                                &param_name,
-                            )
-                        {
-                            grep_view_writes.push((src_idx, v));
-                        }
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
@@ -1221,23 +1169,6 @@ impl Interpreter {
             if self.is_halted() {
                 break;
             }
-        }
-        // rw aggregate-view writeback: mirror modified topics/params back to the
-        // source array's matched slots (by Arc identity, so the originating
-        // `@a` variable observes the mutation), e.g. `for @a.grep(...) { $_++ }`.
-        if let Some((source, _, source_kind)) = grep_view
-            && !grep_view_writes.is_empty()
-        {
-            let mut source_items = source.to_vec();
-            for (src_idx, val) in grep_view_writes {
-                if src_idx < source_items.len() {
-                    source_items[src_idx] = val;
-                }
-            }
-            loan_env!(
-                self,
-                overwrite_array_items_by_identity_for_vm(&source, source_items, source_kind,)
-            );
         }
         // Unmark readonly topic after loop completion
         if topic_readonly {
@@ -1966,24 +1897,6 @@ impl Interpreter {
             self.stack.push(Value::array(coll));
         }
         Ok(())
-    }
-
-    /// Read the loop's current writeback value (implicit `$_` or a single rw
-    /// param) for rw aggregate-view (grep) writeback.
-    fn grep_view_topic_value(
-        &self,
-        writes_back_topic: bool,
-        rw_writeback: bool,
-        param_name: &Option<String>,
-    ) -> Option<Value> {
-        if writes_back_topic {
-            self.env().get("_").cloned()
-        } else if rw_writeback {
-            let var = param_name.as_deref().unwrap_or("_");
-            self.env().get(var).cloned()
-        } else {
-            None
-        }
     }
 
     /// Write a mutated whole-container topic back to its source variable after a

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -219,6 +219,37 @@ impl Interpreter {
                 results.push(val);
                 continue;
             }
+            // Built-in postfix `++`/`--` on a shared `ContainerRef` element (e.g.
+            // `@a.grep(...)>>++`, whose matched elements alias @a's slots): mutate
+            // the inner value THROUGH the cell so the source array observes it, and
+            // return the pre-increment value (postfix semantics). The cell is left
+            // in place, so the source aliasing survives. A plain (non-cell) element
+            // falls through to the ordinary in-place method dispatch below.
+            if matches!(method.as_str(), "postfix:<++>" | "postfix:<-->")
+                && let Value::ContainerRef(cell) = item
+            {
+                let inner = cell.lock().unwrap().clone();
+                let new_val = if method == "postfix:<++>" {
+                    self.increment_value_smart(&inner)?
+                } else {
+                    self.decrement_value_smart(&inner)?
+                };
+                cell.lock().unwrap().clone_from(&new_val);
+                results.push(inner);
+                continue;
+            }
+            // A shared `ContainerRef` element (a `.grep` rw alias / `:=`-bound
+            // slot) flowing through a hyper method call (`@a.grep(...)>>.made`):
+            // dispatch on the inner value, then write any in-place mutation back
+            // THROUGH the cell so the source array observes it and the result
+            // array keeps its source aliasing.
+            let hyper_cell = if let Value::ContainerRef(cell) = item {
+                let cell = cell.clone();
+                *item = cell.lock().unwrap().clone();
+                Some(cell)
+            } else {
+                None
+            };
             let mut skip_native = method == "VAR"
                 || (quoted
                     && matches!(
@@ -468,6 +499,13 @@ impl Interpreter {
                     }
                 }
             }
+            // Re-wrap the element in its shared cell after writing any in-place
+            // mutation back through it, so `existing.items` keeps the source
+            // aliasing for the writeback below.
+            if let Some(cell) = hyper_cell {
+                cell.lock().unwrap().clone_from(item);
+                *item = Value::ContainerRef(cell);
+            }
         }
         if let Value::Array(existing, kind) = &target {
             if let Some(var) = target_var
@@ -500,22 +538,6 @@ impl Interpreter {
                 loan_env!(
                     self,
                     overwrite_array_items_by_identity_for_vm(existing, items.clone(), *kind,)
-                );
-            }
-            if let Some(gv) = existing.grep_source.as_deref() {
-                let mut source_items = gv.source.to_vec();
-                for (filtered_idx, source_idx) in gv.indices.iter().enumerate() {
-                    if filtered_idx < items.len() && *source_idx < source_items.len() {
-                        source_items[*source_idx] = items[filtered_idx].clone();
-                    }
-                }
-                loan_env!(
-                    self,
-                    overwrite_array_items_by_identity_for_vm(
-                        &gv.source,
-                        source_items,
-                        gv.source_kind,
-                    )
                 );
             }
         }

--- a/t/grep-cell-read-deref.t
+++ b/t/grep-cell-read-deref.t
@@ -1,0 +1,75 @@
+use Test;
+
+# A `.grep` over an array now returns first-class element containers
+# (`ContainerRef` cells aliasing the source slots) so a writeback loop mutates
+# the source. Every *read* path over such a result — and over any `:=`-bound
+# element cell — must decontainerize the cell before operating on it.
+
+plan 17;
+
+# .sort over a grep result orders the inner values, not the cells.
+{
+    my @a = 3, 1, 12, 2, 5;
+    is-deeply @a.grep(* > 1).sort, (2, 3, 5, 12), '.sort over grep cells orders values';
+    is-deeply @a.grep(* > 1).sort({ $^b <=> $^a }), (12, 5, 3, 2),
+        '.sort(block) over grep cells';
+}
+
+# .sort over a `:=`-bound element cell (pre-existing read-deref path).
+{
+    my $x = 10;
+    my @b = 1, 2, 3;
+    @b[1] := $x;
+    is-deeply @b.sort, (1, 3, 10), '.sort derefs a :=-bound element cell';
+}
+
+# .min / .max over grep cells.
+{
+    my @a = 5, 3, 8, 1, 9, 2, 7;
+    is @a.grep(* > 3).min, 5, '.min over grep cells';
+    is @a.grep(* > 3).max, 9, '.max over grep cells';
+}
+
+# .minmax over grep cells builds a value Range.
+{
+    my @x = 3, 1, 2;
+    is-deeply @x.grep(* >= 1).minmax, (1..3), '.minmax over grep cells';
+}
+
+# .minmax over a `:=`-bound element cell.
+{
+    my $y = 10;
+    my @b = 1, 2, 3;
+    @b[1] := $y;
+    is-deeply @b.minmax, (1..10), '.minmax derefs a :=-bound element cell';
+}
+
+# Other read paths over grep cells.
+{
+    my @a = 5, 3, 8, 1, 9, 2, 7;
+    is @a.grep(* > 3).sum, 29, '.sum over grep cells';
+    is @a.grep(* > 3).join(","), '5,8,9,7', '.join over grep cells';
+    is-deeply @a.grep(* > 3).reverse, (7, 9, 8, 5), '.reverse over grep cells';
+    is @a.grep(* > 3).first(* > 6), 8, '.first over grep cells';
+    is-deeply @a.grep(* > 3).map(* + 1), (6, 9, 10, 8), '.map over grep cells';
+    is @a.grep(* > 3)[2], 9, 'index into grep cells derefs';
+}
+
+# A read-only grep must not corrupt the source array.
+{
+    my @a = 1..6;
+    @a.grep(* %% 2);             # promotes slots to cells, no writeback
+    is-deeply @a, [1, 2, 3, 4, 5, 6], 'read-only grep leaves source intact';
+}
+
+# Stringifying a grep result whose cells wrap user Instances must call the
+# user `.Str` (not the cell's gist) — for both arg-form and no-arg `.join`.
+{
+    my class P { has $.n; method Str { "P<$.n>" } }
+    my @objs = P.new(n => 1), P.new(n => 2), P.new(n => 3);
+    is @objs.grep({ .n > 1 }).join(","), 'P<2>,P<3>', '.join(sep) over grep Instance cells';
+    is @objs.grep({ .n > 1 }).join, 'P<2>P<3>', '.join (no arg) over grep Instance cells';
+    # `.map(*.Str)` exercises method dispatch on each cell.
+    is-deeply @objs.grep({ .n > 1 }).map(*.Str), ('P<2>', 'P<3>'),
+        '.map(method) over grep Instance cells';
+}

--- a/t/grep-cell-read-deref.t
+++ b/t/grep-cell-read-deref.t
@@ -5,7 +5,7 @@ use Test;
 # the source. Every *read* path over such a result — and over any `:=`-bound
 # element cell — must decontainerize the cell before operating on it.
 
-plan 17;
+plan 19;
 
 # .sort over a grep result orders the inner values, not the cells.
 {
@@ -72,4 +72,13 @@ plan 17;
     # `.map(*.Str)` exercises method dispatch on each cell.
     is-deeply @objs.grep({ .n > 1 }).map(*.Str), ('P<2>', 'P<3>'),
         '.map(method) over grep Instance cells';
+    # A cell extracted via `.head` and method-dispatched (CallMethod invocant).
+    is @objs.grep({ .n > 1 }).head.n, 2, 'method call on a `.head`-extracted grep cell';
+}
+
+# Smartmatch over a `.head`-extracted grep cell decontainerizes the LHS
+# (e.g. `42.2.^roles.grep(Rational).head ~~ Rational`).
+{
+    my @nums = 1, 2.5, 3, 4.5;
+    ok @nums.grep(* > 2).head ~~ Rat, 'smartmatch over a grep cell tests the inner value';
 }


### PR DESCRIPTION
## Summary

`for @a.grep(...) { \$_++ }` / `@a.grep(...)>>++` previously wrote back to the source array through a bespoke index-based side channel — a `for_grep_view` Interpreter field, a `GrepView`/`grep_source` binding embedded in the filtered `ArrayData`, and `overwrite_array_items_by_identity_for_vm` writeback keyed by Arc identity. This was tree-walk-era special-case machinery (PLAN.md §C).

This PR removes it and uses **first-class element containers** instead: `.grep` over an array promotes each matched source slot to a shared `ContainerRef` cell and references the same cells from the result. A writeback loop then mutates *through* the cell into `@a`'s slot via the ordinary element-cell write path (the for-loop already writes through cells; `>>++`/`>>--` now increment the cell in place). A subsequent `=` assignment decontainerizes the cells, so a named copy (`my @g = @a.grep(...)`) never writes back.

## Read-deref coverage

Because the grep result now carries real element cells, every read path over it must decontainerize them. I audited ~30 operations; only these lacked deref (each was a pre-existing bug for `:=`-bound element cells too, now fixed):

- `compare_values` — `.sort` / `.min` / `.max`
- `collect_minmax_candidates` — `.minmax`
- the hyper method loop — `@a.grep(...)>>.method`
- `.join` Instance detection — narg fast path, runtime path, 0-arg path
- **method dispatch invocant** — `.grep(...).head.method`: decontainerize a `ContainerRef` invocant in `exec_call_method_op` (except `.VAR`). This is the central fix. `CallMethodMut` is intentionally **not** decont'd so `:=`-bound container mutation (`my @x := @src; @x.push`) still reaches the source.

## Result

Net **-90 lines** of VM/value machinery removed. Adds `t/grep-cell-read-deref.t`. Full `t/` suite passes; whitelisted roast sweep green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)