### PR TITLE
fix(polymod): return a Seq, not a List (matches Rakudo)

### DIFF
--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -238,7 +238,7 @@ impl Interpreter {
         if !stopped {
             result.push(f64_to_val(n));
         }
-        Ok(Value::array(result))
+        Ok(Value::Seq(std::sync::Arc::new(result)))
     }
 
     pub(in crate::runtime) fn dispatch_tree(

--- a/t/polymod-seq.t
+++ b/t/polymod-seq.t
@@ -1,0 +1,18 @@
+use Test;
+
+# polymod returns a Seq, not a List (matches Rakudo).
+plan 8;
+
+is 10.polymod(3, 3).^name, 'Seq', 'polymod with args returns Seq';
+is 10.polymod(5).^name, 'Seq', 'polymod single arg returns Seq';
+is 10.polymod.^name, 'Seq', 'polymod no arg returns Seq';
+
+is 10.polymod(3, 3).raku, '(1, 0, 1).Seq', 'polymod raku render is a Seq';
+is 120.polymod(10, 10, 10).raku, '(0, 2, 1, 0).Seq', 'polymod multi-divisor render';
+is 10.polymod(5).raku, '(0, 2).Seq', 'polymod single-divisor render';
+
+# The values themselves are still correct.
+is 1000.polymod(10, 10, 10).List, (0, 0, 0, 1), 'polymod values are correct';
+
+my @d = 2, 2, 2, 2;
+is 1000.polymod(@d).List, (0, 0, 0, 1, 62), 'polymod with array divisors';


### PR DESCRIPTION
## Summary

`$n.polymod(...)` returns a `Seq` in Rakudo, but mutsu returned a `List`.

```
$ raku -e 'say 10.polymod(3,3).^name'   # Seq
$ mutsu -e 'say 10.polymod(3,3).^name'  # List  (before this PR)
```

This made `.^name` report `List` and `.raku` render `(1, 0, 1)` instead of
`(1, 0, 1).Seq`. Fixed by wrapping the result in `Value::Seq`.

## Test

- `t/polymod-seq.t` — checks `.^name`/`.raku` are `Seq`-shaped and that the
  decomposed values remain correct.
- `roast/S32-num/polymod.t` (already whitelisted) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)