### PR TITLE
fix(sum): fold with + so result type promotes (Rat/allomorphs)

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -915,19 +915,13 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         }
                     }
                 }
-                let has_float = items
+                // Fold with `+` so the result type promotes like Raku's reduction
+                // (Int+Rat -> Rat, allomorphs unwrap to their numeric value, etc.).
+                let result = items
                     .iter()
-                    .any(|v| matches!(v, Value::Num(_) | Value::Rat(_, _) | Value::Str(_)));
-                if has_float {
-                    let total: f64 = items
-                        .iter()
-                        .map(|v| runtime::to_float_value(v).unwrap_or(0.0))
-                        .sum();
-                    Some(Ok(Value::Num(total)))
-                } else {
-                    let total: i64 = items.iter().map(runtime::to_int).sum();
-                    Some(Ok(Value::Int(total)))
-                }
+                    .cloned()
+                    .try_fold(Value::Int(0), crate::builtins::arith_add);
+                Some(result)
             }
             // Integer ranges: use Gauss formula for O(1) sum
             Value::Range(a, b) => {

--- a/t/sum-type-promotion.t
+++ b/t/sum-type-promotion.t
@@ -1,0 +1,30 @@
+use Test;
+
+# .sum folds with `+`, so the result type promotes like Raku's reduction
+# (Int+Rat -> Rat, allomorphs unwrap to their numeric value) instead of
+# always collapsing to Num / truncating to Int.
+plan 14;
+
+# Allomorphs (RatStr from <...>) must not be truncated to their Int part.
+is <1.5 2.5>.sum, 4, 'sum of RatStr allomorphs is exact';
+is <1.5 2.5>.sum.^name, 'Rat', 'sum of RatStr stays Rat';
+is <1 2 3>.sum, 6, 'sum of IntStr allomorphs';
+is <1 2 3>.sum.^name, 'Int', 'sum of IntStr stays Int';
+
+# Rat type is preserved.
+is (1.5, 2.5).sum.^name, 'Rat', 'Rat sum stays Rat';
+is (1, 2.5, 3).sum.^name, 'Rat', 'Int+Rat sum is Rat';
+is (1/3, 1/3, 1/3).sum, 1, 'Rat sum is exact';
+is (1/3, 1/3, 1/3).sum.^name, 'Rat', 'Rat sum name';
+
+# Num stays Num, Int stays Int.
+is (1.5e0, 2.5e0).sum.^name, 'Num', 'Num sum stays Num';
+is (1, 2.5e0).sum.^name, 'Num', 'Int+Num sum is Num';
+is (1, 2, 3).sum.^name, 'Int', 'Int sum stays Int';
+
+# Empty list sums to Int 0.
+is ().sum, 0, 'empty sum is 0';
+is ().sum.^name, 'Int', 'empty sum is Int';
+
+# BigInt promotion on overflow still works.
+is (2**63, 2**63).sum, 18446744073709551616, 'sum promotes to BigInt on overflow';


### PR DESCRIPTION
## Summary

`.sum` selected its result type with an ad-hoc `has_float` check that only
recognised bare `Num`/`Rat`/`Str` items. As a result:

```
$ raku  -e 'say <1.5 2.5>.sum'          # 4
$ mutsu -e 'say <1.5 2.5>.sum'          # 3   <- RatStr truncated to Int!

$ raku  -e 'say (1.5, 2.5).sum.^name'   # Rat
$ mutsu -e 'say (1.5, 2.5).sum.^name'   # Num
```

The `<1.5 2.5>` allomorphs (`RatStr`) were not detected as floats, so each
element was truncated via `to_int` (`1 + 2 = 3`) instead of summed
(`1.5 + 2.5 = 4`) — a real data-loss bug.

## Fix

Fold the items with `arith_add` from `Int(0)` instead of the bespoke type
selection. This reuses the normal `+` promotion rules:

- Int+Rat → Rat, Rat+Rat → Rat
- allomorphs (`RatStr`/`IntStr`/`NumStr`) unwrap to their numeric value
- BigInt promotion on overflow
- Num when any float is involved

The non-numeric-string `X::Str::Numeric` pre-check and the junction-threading
path are unchanged.

## Test

- `t/sum-type-promotion.t` — 14 cases (allomorphs, Rat/Int/Num promotion,
  empty list, BigInt overflow).
- Swept the 9 whitelisted roast tests that actually call `.sum` (S02 list /
  multi-dim, S03 junction/range, S09 native-int, S17 throttle, S29 deg-trans,
  S32 hyperslice) plus `S32-num/rat.t`, `S03-metaops/reduce.t` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)