### PR TITLE
fix(raku): escape control characters in Str.raku like Rakudo

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -411,19 +411,7 @@ pub(super) fn dispatch(
         Value::Str(s) => {
             if method == "raku" || method == "perl" {
                 // .raku wraps strings in quotes and escapes special chars
-                let escaped = s
-                    .replace('\\', "\\\\")
-                    .replace('"', "\\\"")
-                    .replace('$', "\\$")
-                    .replace('@', "\\@")
-                    .replace('%', "\\%")
-                    .replace('&', "\\&")
-                    .replace('{', "\\{")
-                    .replace('\n', "\\n")
-                    .replace('\t', "\\t")
-                    .replace('\r', "\\r")
-                    .replace('\0', "\\0");
-                Some(Ok(Value::str(format!("\"{}\"", escaped))))
+                Some(Ok(Value::str(super::raku_repr::escape_raku_str(s))))
             } else {
                 Some(Ok(Value::Str(s.clone())))
             }

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -4,6 +4,36 @@ use std::sync::Arc;
 
 use super::range_endpoint_display;
 
+/// Escape a string the way Rakudo's `Str.raku` does: wrap in double quotes,
+/// backslash the sigil/interpolation metacharacters, map the named control
+/// escapes (`\0 \b \t \n \r`), and render every other control character
+/// (Unicode category Cc: U+0000-U+001F, U+007F-U+009F) as `\x[HEX]` with
+/// upper-case, no-leading-zero hex. Non-control characters pass through as-is.
+pub(crate) fn escape_raku_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '$' => out.push_str("\\$"),
+            '@' => out.push_str("\\@"),
+            '%' => out.push_str("\\%"),
+            '&' => out.push_str("\\&"),
+            '{' => out.push_str("\\{"),
+            '\0' => out.push_str("\\0"),
+            '\u{8}' => out.push_str("\\b"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            c if c.is_control() => out.push_str(&format!("\\x[{:X}]", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// Format a BigRat with a terminating decimal as an exact decimal string.
 /// Assumes denominator is a power of 2 and 5 (verified by caller).
 fn format_bigrat_decimal_exact(n: &num_bigint::BigInt, d: &num_bigint::BigInt) -> String {
@@ -413,17 +443,7 @@ pub fn raku_value(v: &Value) -> String {
             let inner = items.iter().map(raku_value).collect::<Vec<_>>().join(", ");
             format!("slip({})", inner)
         }
-        Value::Str(s) => {
-            let escaped = s
-                .replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('$', "\\$")
-                .replace('@', "\\@")
-                .replace('%', "\\%")
-                .replace('&', "\\&")
-                .replace('{', "\\{");
-            format!("\"{}\"", escaped)
-        }
+        Value::Str(s) => escape_raku_str(s),
         Value::Int(i) => i.to_string(),
         Value::Rat(n, d) => {
             if *d == 0 {

--- a/t/raku-string-escape.t
+++ b/t/raku-string-escape.t
@@ -1,0 +1,33 @@
+use Test;
+
+# Str.raku escapes control characters like Rakudo: named escapes for
+# \0 \b \t \n \r, and \x[HEX] (upper-case, no leading zero) for every other
+# Unicode Cc control char. This must apply both to a bare string and to a
+# string nested inside a list/Seq (which used to leave control chars raw).
+plan 16;
+
+# Named control escapes.
+is 0.chr.raku,  '"\0"',  'NUL escapes to \0';
+is 8.chr.raku,  '"\b"',  'BS escapes to \b';
+is 9.chr.raku,  '"\t"',  'TAB escapes to \t';
+is 10.chr.raku, '"\n"',  'LF escapes to \n';
+is 13.chr.raku, '"\r"',  'CR escapes to \r';
+
+# Other control chars use \x[HEX], upper-case, no leading zero.
+is 27.chr.raku,   '"\x[1B]"', 'ESC escapes to \x[1B]';
+is 12.chr.raku,   '"\x[C]"',  'FF escapes to \x[C]';
+is 1.chr.raku,    '"\x[1]"',  'SOH escapes to \x[1]';
+is 127.chr.raku,  '"\x[7F]"', 'DEL escapes to \x[7F]';
+is 0x85.chr.raku, '"\x[85]"', 'NEL (C1) escapes to \x[85]';
+
+# Nested in a Seq/List: the tab must be escaped, not left raw.
+is "a\tb".comb.raku, '("a", "\t", "b").Seq', 'tab inside a Seq is escaped';
+is ("x\ny",).raku,   '("x\ny",)',            'newline inside a list is escaped';
+
+# Sigil / interpolation metacharacters are still escaped.
+is 'a@b'.raku, '"a\@b"', '@ is escaped';
+is 'a%b'.raku, '"a\%b"', '% is escaped';
+is 'a&b'.raku, '"a\&b"', '& is escaped';
+
+# Non-control high characters pass through unchanged.
+is "café".raku, '"café"', 'non-control chars pass through';


### PR DESCRIPTION
## Summary

`Str.raku` left most control characters raw. A tab inside a list rendered as a
literal tab, and ESC/BS/etc were never escaped:

```
$ raku  -e 'say "a\tb".comb.raku'   # ("a", "\t", "b").Seq
$ mutsu -e 'say "a\tb".comb.raku'   # ("a", <TAB>, "b").Seq   (before)

$ raku  -e 'say 27.chr.raku'        # "\x[1B]"
$ mutsu -e 'say 27.chr.raku'        # "<ESC>"                 (before)
```

There were two divergent copies of the escaping logic: the direct `Str.raku`
path escaped `\n\t\r\0` but not `\b`/`\x[..]`, while the collection path
(`raku_value`, used for strings nested in a list/Seq) escaped **no** control
characters at all.

## Fix

Unify both on a single `escape_raku_str` helper that matches Rakudo:

- named escapes for `\0 \b \t \n \r`
- `\x[HEX]` (upper-case, no leading zero) for every other Unicode Cc control
  char (U+0000–U+001F, U+007F–U+009F)
- sigil / interpolation metacharacters (`\ " $ @ % & {`) escaped as before
- non-control characters (incl. high Unicode, NBSP, BOM) pass through unchanged

Verified against Rakudo across the full C0/C1/DEL range and the sigil set.

## Test

- `t/raku-string-escape.t` — 16 cases.
- Swept the whitelisted S02/S03/S05/S32 roast tests that call `.raku`/`.perl`
  (160 files, run the CI way with `cd roast`) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)