### PR TITLE
fix(metaops): cross (X) and zip (Z) return a Seq, not a List

### DIFF
--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1059,7 +1059,7 @@ impl Interpreter {
                 let v = self.eval_block_value(&[Stmt::Expr(expr.clone())])?;
                 let raw_items: Vec<Value> = match &v {
                     Value::Array(items, _) => items.as_ref().clone().items,
-                    Value::Slip(items) => items.as_ref().clone(),
+                    Value::Seq(items) | Value::Slip(items) => items.as_ref().clone(),
                     Value::Hash(map) => map
                         .iter()
                         .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -2144,10 +2144,9 @@ impl Interpreter {
                     Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
                         results,
                     )))
-                } else if results.is_empty() {
-                    Value::Seq(std::sync::Arc::new(Vec::new()))
                 } else {
-                    Value::array(results)
+                    // `X` is a Seq (so `.^name` is Seq, `.raku` shows `.Seq`).
+                    Value::Seq(std::sync::Arc::new(results))
                 }
             }
             "Z" => {
@@ -2206,7 +2205,8 @@ impl Interpreter {
                         results,
                     )))
                 } else {
-                    Value::array(results)
+                    // `Z` is a Seq (so `.^name` is Seq, `.raku` shows `.Seq`).
+                    Value::Seq(std::sync::Arc::new(results))
                 }
             }
             "!" => {
@@ -2301,10 +2301,9 @@ impl Interpreter {
                     Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
                         results,
                     )))
-                } else if results.is_empty() {
-                    Value::Seq(std::sync::Arc::new(Vec::new()))
                 } else {
-                    Value::array(results)
+                    // `X` is a Seq (so `.^name` is Seq, `.raku` shows `.Seq`).
+                    Value::Seq(std::sync::Arc::new(results))
                 }
             }
             "Z" => {
@@ -2326,7 +2325,8 @@ impl Interpreter {
                         results,
                     )))
                 } else {
-                    Value::array(results)
+                    // `Z` is a Seq (so `.^name` is Seq, `.raku` shows `.Seq`).
+                    Value::Seq(std::sync::Arc::new(results))
                 }
             }
             _ => {

--- a/t/cross-zip-seq.t
+++ b/t/cross-zip-seq.t
@@ -1,0 +1,32 @@
+use Test;
+
+# The cross (X) and zip (Z) metaoperators return a Seq, not a List (matches
+# Rakudo). Their inner tuples remain plain Lists.
+plan 14;
+
+# Cross.
+is (^3 X ^2).^name, 'Seq', 'X returns a Seq';
+is (^3 X ^2).raku,
+    '((0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)).Seq',
+    'X.raku shows .Seq with List inner tuples';
+is (1, 2 X 3, 4).^name, 'Seq', 'X with comma operands is a Seq';
+is (^2 X ^2 X ^2).^name, 'Seq', 'n-ary X is a Seq';
+is (() X ()).^name, 'Seq', 'empty X is a Seq';
+is ((1, 2, 3) X (4, 5)).elems, 6, 'X cardinality is preserved';
+
+# Zip.
+is (1, 2 Z 3, 4).^name, 'Seq', 'Z returns a Seq';
+is (1, 2 Z 3, 4).raku, '((1, 3), (2, 4)).Seq', 'Z.raku shows .Seq';
+is (() Z ()).^name, 'Seq', 'empty Z is a Seq';
+is (1, 2, 3 Z+ 10, 20, 30).raku, '(11, 22, 33).Seq', 'Z+ reduction is a Seq';
+is (<a b> Z=> <1 2>).^name, 'Seq', 'Z=> is a Seq';
+
+# Assigning to an @-array still reifies as Array.
+my @r = ^3 X ^2;
+is @r.^name, 'Array', 'X assigned to @ becomes an Array';
+is @r.elems, 6, 'reified cross has all tuples';
+
+# A lazy operand still works.
+is (1 .. * Z "a" .. "c").raku,
+    '((1, "a"), (2, "b"), (3, "c")).Seq',
+    'Z with a lazy side truncates to the finite side';


### PR DESCRIPTION
## Summary

`X` and `Z` (and their reduction / `Z=>` forms) returned a `List`, so `.^name`
was `List` and `.raku` rendered without the trailing `.Seq`:

```
$ raku  -e 'say (^3 X ^2).^name'   # Seq
$ mutsu -e 'say (^3 X ^2).^name'   # List

$ raku  -e 'say (1,2 Z 3,4).raku'  # ((1, 3), (2, 4)).Seq
$ mutsu -e 'say (1,2 Z 3,4).raku'  # ((1, 3), (2, 4))
```

## Fix

The binary and n-ary X/Z paths wrapped their non-empty results in
`Value::array` (a List) while the empty case already returned a `Seq`. Wrap the
non-empty result in `Value::Seq` too, in all four sites
(`vm_string_regex_ops.rs`). The inner tuples (`(0, 0)`, ...) stay plain Lists,
matching Rakudo, and lazy-input results still produce a `LazyList`.

## Test

- `t/cross-zip-seq.t` — 14 cases (X/Z `.^name`/`.raku`, n-ary, empty,
  reduction, `Z=>`, lazy side, `@`-reification stays Array).
- Swept the whitelisted X/Z roast tests (cross.t, zip.t S03/S17/S32, infix.t)
  plus 107 S02/S03 files using X/Z — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)