### PR TITLE
fix(map): native array .map returns a Seq, not a List

### DIFF
--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -211,12 +211,10 @@ impl Interpreter {
             self.set_env_with_main_alias(&name, new_array);
         }
 
-        // On a real array, mutsu's `.map` yields a List-kind array (matching the
-        // interpreter's return shape).
-        Some(Ok(Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(result)),
-            ArrayKind::List,
-        )))
+        // `.map` returns a Seq (matching Rakudo and the interpreter's
+        // `dispatch_map_method`). The rw writeback above is independent of this
+        // return value, so `@a.map({ $_++ })` still mutates `@a`.
+        Some(Ok(Value::Seq(std::sync::Arc::new(result))))
     }
 }
 

--- a/t/array-map-seq.t
+++ b/t/array-map-seq.t
@@ -1,0 +1,25 @@
+use Test;
+
+# `.map` on a concrete array returns a Seq (matches Rakudo), even when the
+# block is a plain closure that takes the native fast path. The rw writeback of
+# a topic-mutating block still updates the source array.
+plan 8;
+
+is [1, 2, 3].map(* + 1).^name, 'Seq', 'map with WhateverCode is a Seq';
+is [1, 2, 3].map({ $_ * 2 }).^name, 'Seq', 'map with a block is a Seq';
+is [1, 2, 3].map(-> $x { $x + 1 }).^name, 'Seq', 'map with a pointy block is a Seq';
+
+is [1, 2, 3].map({ $_ * 2 }).raku, '(2, 4, 6).Seq', 'map.raku renders as a Seq';
+
+my @a = 1, 2, 3;
+is @a.map(* + 10).^name, 'Seq', 'map on a named array is a Seq';
+
+# Multi-arity block still returns a Seq.
+is [1, 2, 3, 4].map(-> $a, $b { $a + $b }).raku, '(3, 7).Seq', 'multi-arity map is a Seq';
+
+# rw writeback: a topic-mutating block still updates the source array, and the
+# returned value is still a Seq.
+my @b = 1, 2, 3;
+my $r = @b.map({ $_++ });
+is $r.^name, 'Seq', 'topic-mutating map returns a Seq';
+is @b.raku, '[2, 3, 4]', 'topic-mutating map still writes back to the array';


### PR DESCRIPTION
## Summary

`.map` on a concrete array with a plain-closure block took the native fast path
(`try_native_array_map`), which returned a `List`-kind array. The interpreter's
`dispatch_map_method` and Rakudo both return a `Seq`:

```
$ raku  -e 'say [1,2,3].map(*+1).^name'   # Seq
$ mutsu -e 'say [1,2,3].map(*+1).^name'   # List   (before)

$ raku  -e 'say [1,2,3].map({$_*2}).raku' # (2, 4, 6).Seq
$ mutsu -e 'say [1,2,3].map({$_*2}).raku' # (2, 4, 6)
```

The divergence only showed for block / `WhateverCode` callbacks; a named-sub
callback like `&sqrt` already fell back to the interpreter and returned a Seq.

## Fix

Return `Value::Seq` from the native path. The rw writeback of a topic-mutating
block (`@a.map({ $_++ })`) is independent of the return value, so it still
updates the source array (verified against Rakudo).

`.grep` is intentionally left returning a List: on a real array it preserves
the rw-view binding (`@a.grep(*>2)>>++` writes back to `@a`), which is a
separate substrate concern (PLAN.md §C).

## Test

- `t/array-map-seq.t` — 8 cases (WhateverCode / block / pointy / multi-arity /
  named array / `.raku` / rw-writeback still mutates).
- Swept all 130 whitelisted roast tests that call `.map` (run the CI way) — no
  regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)