### PR TITLE
fix(divide-by-zero): descriptive uncaught message; int % reports dividend

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -1164,18 +1164,23 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
         });
     }
     {
+        // Integer `%` by zero reports the dividend and `using %`, like Rakudo
+        // (`Attempt to divide 7 by zero using %`).
+        let mod_div0 = |dividend: &Value| {
+            RuntimeError::numeric_divide_by_zero_full(Some(dividend.clone()), Some("%"))
+        };
         Ok(match (l, r) {
-            (Value::Int(_), Value::Int(0)) => {
-                return Err(RuntimeError::numeric_divide_by_zero());
+            (Value::Int(a), Value::Int(0)) => {
+                return Err(mod_div0(&Value::Int(a)));
             }
-            (Value::BigInt(_), Value::Int(0)) => {
-                return Err(RuntimeError::numeric_divide_by_zero());
+            (Value::BigInt(a), Value::Int(0)) => {
+                return Err(mod_div0(&Value::from_bigint((*a).clone())));
             }
-            (Value::Int(_), Value::BigInt(b)) if b.is_zero() => {
-                return Err(RuntimeError::numeric_divide_by_zero());
+            (Value::Int(a), Value::BigInt(b)) if b.is_zero() => {
+                return Err(mod_div0(&Value::Int(a)));
             }
-            (Value::BigInt(_), Value::BigInt(b)) if b.is_zero() => {
-                return Err(RuntimeError::numeric_divide_by_zero());
+            (Value::BigInt(a), Value::BigInt(b)) if b.is_zero() => {
+                return Err(mod_div0(&Value::from_bigint((*a).clone())));
             }
             (Value::Int(a), Value::Int(b)) => Value::Int(num_integer::Integer::mod_floor(&a, &b)),
             (Value::BigInt(a), Value::Int(b)) => {

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -435,7 +435,10 @@ impl RuntimeError {
             attrs.insert("numerator".to_string(), n);
         }
         let ex = Value::make_instance(Symbol::intern("X::Numeric::DivideByZero"), attrs);
-        let mut err = Self::new("X::Numeric::DivideByZero");
+        // Use the descriptive message (not the bare type name) so an uncaught
+        // divide-by-zero prints like Rakudo (`Attempt to divide 1 by zero
+        // using %`) instead of `X::Numeric::DivideByZero`.
+        let mut err = Self::new(&msg);
         err.exception = Some(Box::new(ex));
         err
     }

--- a/t/divide-by-zero-message.t
+++ b/t/divide-by-zero-message.t
@@ -1,0 +1,56 @@
+use Test;
+
+# An uncaught X::Numeric::DivideByZero prints its descriptive message (matching
+# Rakudo), and integer `%` by zero reports the dividend and `using %`.
+plan 8;
+
+# `.message` carries the full description, not the bare type name.
+{
+    my $msg;
+    { (7 % 0).sink; CATCH { default { $msg = .message } } }
+    is $msg, 'Attempt to divide 7 by zero using %', 'int % 0 message';
+}
+{
+    my $msg;
+    { (1 div 0).sink; CATCH { default { $msg = .message } } }
+    is $msg, 'Attempt to divide 1 by zero using div', 'int div 0 message';
+}
+
+# The exception type is correct.
+{
+    my $name;
+    { (5 % 0).sink; CATCH { default { $name = .^name } } }
+    is $name, 'X::Numeric::DivideByZero', '% by zero is X::Numeric::DivideByZero';
+}
+
+# Large (BigInt) dividend is rendered in the message.
+{
+    my $msg;
+    { ((2 ** 70) % 0).sink; CATCH { default { $msg = .message } } }
+    is $msg, 'Attempt to divide 1180591620717411303424 by zero using %',
+        'BigInt % 0 message';
+}
+
+# `%%` (is-divisible) by zero keeps its own operator name.
+{
+    my $msg;
+    { (7 %% 0).sink; CATCH { default { $msg = .message } } }
+    is $msg, 'Attempt to divide 7 by zero using infix:<%%>', '%% by zero message';
+}
+
+# Both operands negative / mixed signs still report the dividend.
+{
+    my $msg;
+    { (-8 % 0).sink; CATCH { default { $msg = .message } } }
+    is $msg, 'Attempt to divide -8 by zero using %', 'negative dividend % 0';
+}
+
+# div by zero still throws the right type.
+{
+    my $name;
+    { (9 div 0).sink; CATCH { default { $name = .^name } } }
+    is $name, 'X::Numeric::DivideByZero', 'div by zero type';
+}
+
+# A valid modulo still works (no false positive).
+is 7 % 3, 1, 'valid modulo still works';


### PR DESCRIPTION
## Summary

Two related `X::Numeric::DivideByZero` message gaps:

**1. Uncaught message was the bare type name.** `numeric_divide_by_zero_full`
set the `RuntimeError`'s own message to `"X::Numeric::DivideByZero"` instead of
the descriptive text it had just built:

```
$ raku  -e 'say 1 % 0'   # Attempt to divide 1 by zero using %
$ mutsu -e 'say 1 % 0'   # X::Numeric::DivideByZero   (before)
```

**2. Integer `%` by zero dropped the dividend and operator.** It called
`numeric_divide_by_zero()` with no arguments, so `.message` was just
`Attempt to divide by zero`. Now it passes the dividend and `using %`:

```
$ raku  -e 'my $x = 7 % 0; CATCH { default { say .message } }'   # Attempt to divide 7 by zero using %
$ mutsu -e 'my $x = 7 % 0; CATCH { default { say .message } }'   # Attempt to divide by zero  (before)
```

The BigInt dividend case is handled too. The Rat `%` path (Rakudo:
`...when calling .floor on Rational`) is intentionally left unchanged — a
separate, narrower message.

## Test

- `t/divide-by-zero-message.t` — 8 cases (also passes on Rakudo).
- Swept the 8 whitelisted roast tests mentioning divide-by-zero (S02/S03/S32) —
  no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)