### PR TITLE
fix(sprintf): %f rounds half-away-from-zero on exact value, like Rakudo

### DIFF
--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -336,14 +336,11 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             }
             'f' | 'F' => {
                 let p = prec_num.unwrap_or(6);
-                // Use exact rational formatting for Rat/FatRat with high precision
-                if p > 17 {
-                    if let Some(rendered) = format_rat_fixed(arg, p, plus_sign, space_flag) {
-                        rendered
-                    } else {
-                        let f = float_val();
-                        format_float_fixed(f, p, plus_sign, space_flag)
-                    }
+                // Use exact rational formatting (round-half-away-from-zero, like
+                // Rakudo) for all numeric args; fall back to float only for
+                // non-numeric arguments.
+                if let Some(rendered) = format_rat_fixed(arg, p, plus_sign, space_flag) {
+                    rendered
                 } else {
                     let f = float_val();
                     format_float_fixed(f, p, plus_sign, space_flag)

--- a/src/runtime/sprintf_helpers.rs
+++ b/src/runtime/sprintf_helpers.rs
@@ -13,8 +13,35 @@ pub(super) fn format_float_fixed(f: f64, p: usize, plus_sign: bool, space_flag: 
     }
 }
 
-/// Format a Rat/FatRat value for %f with exact precision (avoids f64 rounding).
-/// Returns None if the argument is not a rational type.
+/// Convert a finite f64 to an exact rational (numer/denom) via its shortest
+/// round-trippable decimal representation. Rust's `{}` formatting never uses
+/// scientific notation for f64, so the string is always positional.
+fn f64_to_rational(f: f64) -> (BigInt, BigInt) {
+    let s = format!("{f}");
+    let (is_neg, digits) = match s.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, s.as_str()),
+    };
+    let (int_part, frac_part) = match digits.split_once('.') {
+        Some((i, fr)) => (i, fr),
+        None => (digits, ""),
+    };
+    let combined = format!("{int_part}{frac_part}");
+    let mut numer = combined
+        .parse::<BigInt>()
+        .unwrap_or_else(|_| BigInt::from(0));
+    if is_neg {
+        numer = -numer;
+    }
+    let denom = num_traits::pow::pow(BigInt::from(10), frac_part.len());
+    (numer, denom)
+}
+
+/// Format a numeric value for %f with exact precision (avoids f64 half-to-even
+/// rounding). Uses round-half-away-from-zero like Rakudo. For Num arguments the
+/// f64 is first converted to its exact shortest-decimal rational so that e.g.
+/// `sprintf("%.2f", 1.005e0)` yields `1.01`, matching Rakudo.
+/// Returns None if the argument is not numeric.
 pub(super) fn format_rat_fixed(
     arg: Option<&Value>,
     p: usize,
@@ -27,9 +54,18 @@ pub(super) fn format_rat_fixed(
         Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
             ((**n).clone(), (**d).clone())
         }
+        Some(Value::Int(i)) => (BigInt::from(*i), BigInt::from(1)),
+        Some(Value::Num(f)) if f.is_finite() => f64_to_rational(*f),
+        Some(Value::Str(s)) => match s.trim().parse::<f64>() {
+            Ok(f) if f.is_finite() => f64_to_rational(f),
+            _ => return None,
+        },
         _ => return None,
     };
-    let is_neg = numer < BigInt::from(0);
+    // Detect a negatively-signed zero (e.g. -0.0e0) so its sign is preserved.
+    let neg_zero = matches!(arg, Some(Value::Num(f)) if f.is_sign_negative())
+        || matches!(arg, Some(Value::Str(s)) if s.trim().starts_with('-'));
+    let is_neg = numer < BigInt::from(0) || (numer == BigInt::from(0) && neg_zero);
     let prefix = sign_prefix(is_neg, plus_sign, space_flag);
     let abs_numer = if is_neg { -&numer } else { numer };
     // Compute integer and fractional parts using BigInt arithmetic

--- a/t/sprintf-round-half-up.t
+++ b/t/sprintf-round-half-up.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Rakudo rounds %f half-away-from-zero (not half-to-even), and uses the exact
+# value of Rat literals / the shortest-decimal value of Num, so the results are
+# stable regardless of f64 representation quirks.
+
+plan 22;
+
+# Half-away-from-zero on exactly-representable halves (Rat literals)
+is sprintf("%.0f", 0.5),  "1", "0.5 rounds up";
+is sprintf("%.0f", 1.5),  "2", "1.5 rounds up";
+is sprintf("%.0f", 2.5),  "3", "2.5 rounds up (not banker's 2)";
+is sprintf("%.0f", 3.5),  "4", "3.5 rounds up";
+is sprintf("%.0f", 4.5),  "5", "4.5 rounds up (not banker's 4)";
+
+# Negative halves round away from zero
+is sprintf("%.0f", -0.5), "-1", "-0.5 rounds away from zero";
+is sprintf("%.0f", -2.5), "-3", "-2.5 rounds away from zero";
+
+# Below/above the half do not flip
+is sprintf("%.0f", 0.25), "0", "0.25 rounds down";
+is sprintf("%.0f", 0.35), "0", "0.35 rounds down";
+
+# Rat literals are exact: 2.675 == 2675/1000, so it rounds to 2.68
+is sprintf("%.2f", 2.675), "2.68", "exact Rat 2.675 -> 2.68";
+is sprintf("%.2f", 0.125), "0.13", "exact 0.125 -> 0.13";
+is sprintf("%.2f", 1.005), "1.01", "exact Rat 1.005 -> 1.01";
+
+# Num (float) arguments use shortest-decimal value, same results
+is sprintf("%.0f", 2.5e0),   "3",    "Num 2.5e0 -> 3";
+is sprintf("%.2f", 1.005e0), "1.01", "Num 1.005e0 -> 1.01";
+is sprintf("%.2f", 0.125e0), "0.13", "Num 0.125e0 -> 0.13";
+
+# Sign preservation
+is sprintf("%.2f", -0.0e0), "-0.00", "negative zero keeps its sign";
+is sprintf("%.2f", 0.0e0),  "0.00",  "positive zero has no sign";
+
+# Integers and flags still work
+is sprintf("%.2f", 100),    "100.00", "Int argument";
+is sprintf("%+.2f", 3.14),  "+3.14",  "plus flag";
+is sprintf("%08.2f", 3.14), "00003.14", "zero-pad width";
+
+# String numeric arguments
+is sprintf("%.2f", "3.14159"), "3.14", "string numeric argument";
+is sprintf("%.0f", "2.5"),     "3",    "string half rounds up";
+
+done-testing;


### PR DESCRIPTION
## Problem

mutsu's `%f`/`%F` sprintf formatting routed all but ultra-high precision (`p > 17`) through Rust's `{:.*}` formatter, which rounds **half-to-even** (banker's rounding) on the f64 value. Rakudo instead:

1. Rounds **half-away-from-zero**, and
2. Uses the **exact value** of the argument — a `Rat` literal keeps its exact rational value, and a `Num` is taken at its shortest-decimal representation.

So the outputs diverged:

| expression | Rakudo | mutsu (before) |
|---|---|---|
| `sprintf("%.0f", 2.5)` | `3` | `2` |
| `sprintf("%.0f", 0.5)` | `1` | `0` |
| `sprintf("%.0f", 4.5)` | `5` | `4` |
| `sprintf("%.2f", 1.005)` | `1.01` | `1.00` |
| `sprintf("%.2f", 2.675)` | `2.68` | `2.67` |

## Fix

Route every numeric `%f` argument through the existing exact-rational formatter `format_rat_fixed` (which already rounds half-away-from-zero via BigInt arithmetic), extending it to `Int`/`Num`/`Str`:

- `Int` → `n/1`
- `Num` → converted to its exact shortest-decimal rational (Rust's `{}` Display never uses scientific notation for f64, so the string is always positional)
- `Str` → parsed as f64 then same as `Num`

Negative-zero sign is preserved (`sprintf("%.2f", -0.0e0)` → `-0.00`). Non-numeric args still fall back to the float path.

## Tests

- New `t/sprintf-round-half-up.t` (22 assertions).
- Whitelisted `roast/6.d/S32-str/sprintf-f.t` (2282 tests) and `sprintf.t` (174) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)