### PR TITLE
fix(%%): is-divisible-by works for Rat/Num/BigInt, not only Int

### DIFF
--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1448,15 +1448,23 @@ impl Interpreter {
     }
 
     fn divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
+        Ok(Value::Bool(self.is_divisible(left, right)?))
+    }
+
+    /// `$a %% $b` is `$a % $b == 0`. Compute the modulo with the exact-rational
+    /// semantics of `arith_mod` (so Rat/Num/BigInt operands work, not just Int),
+    /// then test the remainder for zero. A zero divisor reports the dividend and
+    /// `infix:<%%>`, matching Rakudo.
+    fn is_divisible(&self, left: Value, right: Value) -> Result<bool, RuntimeError> {
         let (l, r) = runtime::coerce_numeric(left.clone(), right);
-        match (l, r) {
-            (Value::Int(_), Value::Int(0)) => Err(RuntimeError::numeric_divide_by_zero_full(
+        if !r.truthy() {
+            return Err(RuntimeError::numeric_divide_by_zero_full(
                 Some(left),
                 Some("infix:<%%>"),
-            )),
-            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a % b == 0)),
-            _ => Ok(Value::Bool(false)),
+            ));
         }
+        let remainder = crate::builtins::arith_mod(l, r)?;
+        Ok(!remainder.truthy())
     }
 
     pub(super) fn exec_not_divisible_by_op(&mut self) -> Result<(), RuntimeError> {
@@ -1476,14 +1484,6 @@ impl Interpreter {
     }
 
     fn not_divisible_by_values(&self, left: Value, right: Value) -> Result<Value, RuntimeError> {
-        let (l, r) = runtime::coerce_numeric(left.clone(), right);
-        match (l, r) {
-            (Value::Int(_), Value::Int(0)) => Err(RuntimeError::numeric_divide_by_zero_full(
-                Some(left),
-                Some("infix:<%%>"),
-            )),
-            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a % b != 0)),
-            _ => Ok(Value::Bool(true)),
-        }
+        Ok(Value::Bool(!self.is_divisible(left, right)?))
     }
 }

--- a/t/divisible-rational.t
+++ b/t/divisible-rational.t
@@ -1,0 +1,49 @@
+use Test;
+
+# infix:<%%> ("is divisible by") is defined as `$a % $b == 0` and must work for
+# Rat/Num/BigInt operands, not only Int. Previously mutsu returned False for any
+# non-Int operand.
+
+plan 24;
+
+# Rat operands
+ok   3.5 %% 0.5,  "3.5 %% 0.5 is True (7 times)";
+nok  3.6 %% 0.5,  "3.6 %% 0.5 is False";
+ok   1.0 %% 0.5,  "1.0 %% 0.5 is True";
+ok   0.5 %% 0.5,  "0.5 %% 0.5 is True";
+ok   0.3 %% 0.1,  "0.3 %% 0.1 is True";
+ok   10  %% 2.5,  "Int %% Rat works (10 %% 2.5)";
+ok   7   %% 0.5,  "7 %% 0.5 is True";
+
+# Negative operands (divisor-sign / floor semantics, same as %)
+ok  -6   %% 2,    "-6 %% 2 is True";
+ok   6   %% -2,   "6 %% -2 is True";
+ok  -6.5 %% 0.5,  "-6.5 %% 0.5 is True";
+ok  -3.5 %% 0.5,  "-3.5 %% 0.5 is True";
+
+# Plain Int still works
+ok   6 %% 2,  "6 %% 2 is True";
+nok  7 %% 2,  "7 %% 2 is False";
+
+# BigInt operands
+nok (2 ** 70)     %% 5, "2**70 %% 5 is False";
+ok  (2 ** 70 + 1) %% 5, "2**70+1 %% 5 is True";
+
+# String operands coerce numerically
+ok  "6" %% 2, '"6" %% 2 is True';
+
+# FatRat operands
+ok FatRat.new(7, 2) %% 0.5, "FatRat %% Rat works";
+
+# !%% (not divisible)
+nok  6.6 !%% 2.2, "6.6 !%% 2.2 is False (divisible)";
+ok   6.5 !%% 2.2, "6.5 !%% 2.2 is True (not divisible)";
+ok   7   !%% 2,   "7 !%% 2 is True";
+nok  6   !%% 2,   "6 !%% 2 is False";
+
+# Divide-by-zero throws, reporting infix:<%%>
+throws-like { 7   %% 0   }, X::Numeric::DivideByZero, "Int %% 0 throws";
+throws-like { 3.5 %% 0   }, X::Numeric::DivideByZero, "Rat %% 0 throws";
+throws-like { 7   %% 0.0 }, X::Numeric::DivideByZero, "Int %% 0.0 throws";
+
+done-testing;


### PR DESCRIPTION
## Problem

`infix:<%%>` ("is divisible by") is defined as `$a % $b == 0`, but mutsu's implementation only matched `(Int, Int)` and returned `False` for **every** other operand combination:

| expression | Rakudo | mutsu (before) |
|---|---|---|
| `3.5 %% 0.5` | `True` | `False` |
| `1.0 %% 0.5` | `True` | `False` |
| `10 %% 2.5` | `True` | `False` |
| `0.3 %% 0.1` | `True` | `False` |
| `7 %% 0.5` | `True` | `False` |

## Fix

Route the computation through `arith_mod`, which already implements exact-rational modulo (floor / divisor-sign semantics) for `Rat`/`Num`/`BigInt`/`FatRat`, then test the remainder for zero via `truthy()`. `!%%` negates the result.

A zero divisor is detected up front (before calling `arith_mod`) so it reports the dividend and `infix:<%%>`, matching Rakudo's `Attempt to divide N by zero using infix:<%%>`.

## Tests

- New `t/divisible-rational.t` (24 assertions: Rat/Num/BigInt/FatRat/String operands, negatives, `!%%`, divide-by-zero).
- `roast/S03-operators/is-divisible-by.t` (whitelisted) and `arith.t`, `div.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)