### PR TITLE
fix(zip): zip() / chained Z over 3+ operands returns a Seq, not a List

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1728,7 +1728,9 @@ fn native_function_variadic(name: &str, args: &[Value]) -> Option<Result<Value, 
                     crate::value::LazyList::new_cached(result),
                 ))))
             } else {
-                Some(Ok(Value::array(result)))
+                // `zip` returns a Seq (so `.^name` is Seq, `.raku` shows `.Seq`),
+                // matching Rakudo and the `Z` metaop n-ary path.
+                Some(Ok(Value::Seq(std::sync::Arc::new(result))))
             }
         }
         "flat" => {

--- a/t/chained-cross-zip.t
+++ b/t/chained-cross-zip.t
@@ -6,8 +6,8 @@ use Test;
 plan 22;
 
 # --- Cross (X) chained: flat tuples ---
-is (1 X 2 X 3).raku, '((1, 2, 3),)', 'scalar X chain builds one 3-tuple';
-is (1 X 2 X 3 X 4).raku, '((1, 2, 3, 4),)', 'scalar X chain builds one 4-tuple';
+is (1 X 2 X 3).raku, '((1, 2, 3),).Seq', 'scalar X chain builds one 3-tuple';
+is (1 X 2 X 3 X 4).raku, '((1, 2, 3, 4),).Seq', 'scalar X chain builds one 4-tuple';
 is ((1,2) X (3,4) X (5,6)).elems, 8, 'X of three 2-lists has 8 combos';
 is ((1,2) X (3,4) X (5,6))[0].raku, '(1, 3, 5)', 'first X combo is a flat triple';
 is ((1,2) X (3,4) X (5,6))[7].raku, '(2, 4, 6)', 'last X combo is a flat triple';
@@ -18,7 +18,7 @@ is (<a b> X~ <c d> X~ <e f>).List, <ace acf ade adf bce bcf bde bdf>, 'X~ chain 
 is ((1..2) X* (1..2) X* (1..2)).List, (1, 2, 2, 4, 2, 4, 4, 8), 'X* chain multiplies across all operands';
 
 # --- Zip (Z) chained: flat tuples ---
-is (1 Z 2 Z 3).raku, '((1, 2, 3),)', 'scalar Z chain builds one 3-tuple';
+is (1 Z 2 Z 3).raku, '((1, 2, 3),).Seq', 'scalar Z chain builds one 3-tuple';
 is ((1,2) Z (3,4) Z (5,6)).elems, 2, 'Z of three 2-lists has 2 tuples';
 is ((1,2) Z (3,4) Z (5,6))[0].raku, '(1, 3, 5)', 'first Z tuple is a flat triple';
 is ((1,2) Z (3,4) Z (5,6))[1].raku, '(2, 4, 6)', 'second Z tuple is a flat triple';
@@ -36,8 +36,8 @@ is (1..3 Z 4..6 Z 7..9).List, ((1,4,7), (2,5,8), (3,6,9)), 'Z chain over ranges'
 is ((1..2) X (1..2) X (1..2)).elems, 8, 'X chain over ranges has 8 combos';
 
 # --- 2-operand cases unchanged ---
-is (1 X 2).raku, '((1, 2),)', '2-operand X still builds a pair';
-is (1 Z 2).raku, '((1, 2),)', '2-operand Z still builds a pair';
+is (1 X 2).raku, '((1, 2),).Seq', '2-operand X still builds a pair';
+is (1 Z 2).raku, '((1, 2),).Seq', '2-operand Z still builds a pair';
 
 # --- Empty operand short-circuits the whole cross ---
 is ((1,2) X () X (3,4)).elems, 0, 'X chain with an empty operand is empty';


### PR DESCRIPTION
## Summary

`(1 Z 2 Z 3)` parses to a `zip(1, 2, 3)` call (the chained-`Z` normalization), which routed through the native `zip` builtin. That path returned a **`List`** (`Value::array`), so:

```
(1 Z 2 Z 3).WHAT   # was List, raku says Seq
(1 Z 2 Z 3).raku   # was ((1, 2, 3),)  — missing the .Seq suffix
```

This diverged from Rakudo **and** from mutsu's own 2-operand `Z` metaop and n-ary `Z` paths, both of which already return a `Seq` (since #3471). The empty-zip case also already returned `Seq`.

## Fix

Make the non-lazy `zip` result a `Seq`. Now `zip(...)` is always a `Seq`, matching Rakudo:

```
(1 Z 2 Z 3).WHAT   # Seq
(1 Z 2 Z 3).raku   # ((1, 2, 3),).Seq
zip((1,2),(3,4)).raku  # ((1, 3), (2, 4)).Seq
```

## Tests

- Updates `t/chained-cross-zip.t`, whose `.raku` expectations predated the X/Z→Seq change (#3471) and were passing for the wrong reason (mutsu wrongly returned a List that matched the stale expectation).
- `make test` green; `S03-metaops/cross.t` and `zip.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)