### PR TITLE
fix(cross): cross() returns a Seq, not a List

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2138,7 +2138,7 @@ impl Interpreter {
         }
 
         if lists.is_empty() {
-            return Ok(Value::array(vec![]));
+            return Ok(Value::Seq(std::sync::Arc::new(vec![])));
         }
 
         // Compute Cartesian product iteratively
@@ -2155,18 +2155,20 @@ impl Interpreter {
             result = new_result;
         }
 
-        // Apply `with` function or create tuples
+        // Apply `with` function or create tuples. `cross` returns a Seq (so
+        // `.^name` is Seq, `.raku` shows `.Seq`), matching Rakudo and the `X`
+        // metaop.
         if let Some(func) = with_func {
             let mut final_result = Vec::new();
             for combo in result {
                 let val = self.call_sub_value(func.clone(), combo, false)?;
                 final_result.push(val);
             }
-            Ok(Value::array(final_result))
+            Ok(Value::Seq(std::sync::Arc::new(final_result)))
         } else {
             // Return as list of lists (tuples)
             let tuples: Vec<Value> = result.into_iter().map(Value::array).collect();
-            Ok(Value::array(tuples))
+            Ok(Value::Seq(std::sync::Arc::new(tuples)))
         }
     }
 


### PR DESCRIPTION
## Summary

`cross((1,2),(3,4))` returned a **`List`** (`Value::array`), so `.WHAT` was `List` and `.raku` lacked the `.Seq` suffix — diverging from Rakudo (where `cross(...)` is always a `Seq`) and from the `X` metaop, which already returns a `Seq`. Sibling of the `zip` fix (#3479).

```
cross((1,2),(3,4)).WHAT   # was List, raku says Seq
cross((1,2),(3,4)).raku   # was ((1, 3), ...), now ((1, 3), (1, 4), (2, 3), (2, 4)).Seq
```

## Fix

All three result paths (empty, `:with`-combined, plain tuples) now return a `Seq`, matching Rakudo.

## Tests

- `make test` green; `S03-metaops/cross.t` and `S32-list/cross.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)