### PR TITLE
feat(state-ownership): native-ize `.MixHash` coercion (ledger §1)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -36,7 +36,7 @@
 | `vm_data_ops.rs` non-simple push | 非Array/非ContainerRef な ArrayPush ターゲット（cold） | LOW | **probe で cold 確認 (2026-06-14)**: ArrayPush opcode は単一引数 push かつ *local* array 限定で emit。closure-captured / multi-arg push は CallMethodMut へ流れ **#3060 で native 化済**（下記）。残る ArrayPush 非Array 分岐は whitelist で発火例ゼロ＝cold |
 | ~~`vm_call_method_mut_ops.rs` CallMethodMut push~~ | ~~closure-captured / multi-arg `@a.push`~~ | — | **✅消化 (#3060)**: `try_native_array_mut` に `push` arm を追加。`@a.push(x)` は単一引数 local のみ ArrayPush opcode、それ以外（captured / multi-arg）は CallMethodMut で来るのを VM ネイティブ化。typed/shaped/lazy/shared/constrained は interpreter 維持 |
 | ~~`vm_smart_match.rs` key-method~~ | ~~smartmatch のキーメソッド抽出~~ | — | **✅消化 (PR2)**: 統一 compiled-first へ |
-| ~~`vm_call_method_compiled.rs` QuantHash coercion~~ | ~~`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`（list-like 受け手）~~ | — | **✅消化 (③ PR-8)**: `try_native_quanthash_coerce` で VM ネイティブ。pure 折り畳みは `builtins/quanthash_coerce` に一本化。`.MixHash`（型メタ登録）/ Instance/Package 受け手は interpreter 維持 |
+| ~~`vm_call_method_compiled.rs` QuantHash coercion~~ | ~~`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`（list-like 受け手）~~ | — | **✅消化 (③ PR-8 + MixHash slice)**: `try_native_quanthash_coerce` で VM ネイティブ。pure 折り畳みは `builtins/quanthash_coerce` に一本化。**`.MixHash` も追加**（旧除外理由「型メタ登録＝interpreter 所有 state」は #2952 のコンテナ値埋め込み化で stale＝`Value::Mix` の Arc にメタ埋め込みで pure value op・新 `to_mixhash`）。Instance/Package 受け手のみ interpreter 維持 |
 | `vm_call_helpers.rs` hyper temp | temp-bind した item への hyper メソッド | MEDIUM | 第一級コンテナ Phase 2 |
 | ~~`vm_register_ops.rs` react loop~~ | ~~`run_react_event_loop[_drain]` / `run_whenever_with_value`~~ | — | **✅消化 (Stage 1+2, #3010/#3027/#3029/#3031/#3038/#3039)**: 駆動ループの **4 箇所二重化**（react/await-promise/tap×2）を単一エンジンへ統合（tap×2→1 #3010、react↔await-promise を `SupplyDrivePolicy { React, Promise }` + `drive_react_subscriptions` へ #3027）。**Stage 2 = ループ所有権の逆転完了**: `run_react_event_loop`/`drive_react_subscriptions`/`run_react_consumer`/`replay_static_supply` を `impl Interpreter`→`impl VM`（新 `vm/vm_react_loop.rs`）へ移設 #3038、whenever body/LAST/CLOSE callback を `call_sub_value`(tree-walk)→`VM::call_react_callback`（`vm_call_map_block` でトピック束縛しつつコンパイル済みバイトコード実行）へ #3039。await/Promise 経路は薄い `Interpreter::drive_react_subscriptions` ブリッジ（mem::take/VM/restore）で到達。**Stage 3 follow-up = supply `QUIT` handler も VM ネイティブ化**: VM 駆動ループ内の 2 箇所（`vm_react_loop.rs` の React/Channel quit 経路）が `self.interpreter.call_supply_quit_handler`（tree-walk `call_sub_value`）へ戻っていたのを、`VM::call_supply_quit_handler`（`call_react_callback` 経由でコンパイル済みバイトコード実行）へ差し替え。**これで駆動ループのどのコールバックも tree-walk へ戻らない**。`Interpreter::call_supply_quit_handler` は Interpreter 単独の on-demand/tap supply 経路（`native_supplier_methods`/`native_supply_mut_methods`）からのみ使用（それ自体が別系の tree-walk runtime で、ここは対象外）。`supply_emit_buffer` は Interpreter field のまま（`self.interpreter.` 経由で VM から到達でき、global 化は不要）。 |
 
@@ -338,6 +338,21 @@
   **`op`=1418（Routine 値 lexical &-var `&infix:<(|)>` 束縛、今回の Sub/WeakSub 限定 fix の除外分）** / iterator push-* protocol
   （Track B）/ coercion（builtins 降ろし）。残る ctor 難ケース: required-after-BUILD / 未設定 class-typed + BUILD / `is built`/
   MOP set_build / BUILDALL / custom new / CUnion。
+- **2026-06-23 (§1 = `.MixHash` coercion の VM ネイティブ化)**: §D（状態所有）の実測駆動スライス。`MUTSU_VM_STATS` で
+  catch-all の支配カテゴリを計測したところ、PR-8 が **明示的に除外**していた `.MixHash`（QuantHash coercion の唯一の
+  残り）が最頻だった。PR-8 の除外理由は「`.MixHash` は container type metadata を登録＝interpreter 所有 state」だったが、
+  **これは #2952〜2985 のコンテナ値メタ埋め込み化で stale**＝`.MixHash` が生む `Value::Mix` の型メタ（`value_type=Real`/
+  `declared_type=MixHash`）は **interpreter 副テーブルでなく Mix の `Arc<MixData>` に埋め込まれる**（`tag_container_metadata`
+  の `embed_type_info!` 経路。副テーブル `register_container_type_metadata` を踏むのは Instance 等の `other =>` 枝のみ）。
+  ∴ `.MixHash` は env/state を一切触らない pure value op で、`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash` と同型に native 化可能。
+  新 pure fn `builtins::quanthash_coerce::to_mixhash`（`to_mix(_, "MixHash")` → mutable flip + メタ埋め込み）を VM の
+  `try_native_quanthash_coerce` に追加（method match に `"MixHash"` 追加）。**dedup**: interpreter の `dispatch_method_by_name_2`
+  の `Mix|MixHash` 分岐を `to_mixhash` 委譲へ（`tag_container_metadata` 直書きを撤去）＝**1 操作 = 1 実装**。受け手ゲートは
+  既存 5 兄弟と同一（list-like のみ native、Instance/Package は interpreter 維持）。変数受け手（`%h.MixHash`）は
+  `CallMethodMut` ルーティングで mut パスに行き 6 兄弟全て一律 fallback＝**既存挙動と完全 parity**（将来 mut パスへ
+  まとめて降ろす別スライス候補）。挙動不変（native==interpreter＝同一 `to_mixhash`）。pin `t/native-mixhash-coerce.t`(22,
+  raku/mutsu 双方 PASS・Str 要素で `.WHICH` キー差を回避)。mix.t 244/244・set.t・categorize 緑。
+  （bag.t 625 "Foo instance union" は BLOCKERS.md 記載の pre-existing で本変更と無関係。）
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -691,3 +691,25 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
         Ok(Value::mix_with_original_keys(weights, original_keys))
     }
 }
+
+/// Coerce `target` to a mutable `MixHash`. This is `.Mix` plus the mutable flag
+/// and the embedded `MixHash` type metadata (`value_type = Real`,
+/// `declared_type = MixHash`). The metadata lives *in* the `Value::Mix` Arc (not
+/// in any interpreter-owned side table — container type metadata has been
+/// embedded in the value since #2952), so this is a pure value operation with no
+/// interpreter state, mirroring the interpreter's `dispatch_to_mix_with_what` +
+/// `tag_container_metadata` path exactly. Single authoritative impl shared by the
+/// VM native dispatch and the interpreter fallback.
+pub(crate) fn to_mixhash(target: Value) -> Result<Value, RuntimeError> {
+    let coerced = to_mix(target, "MixHash")?;
+    let Value::Mix(mut arc, _) = coerced else {
+        // `to_mix` always returns a `Value::Mix` for the receivers we coerce; if
+        // that ever changes, hand the value back unmodified rather than panic.
+        return Ok(coerced);
+    };
+    let data = std::sync::Arc::make_mut(&mut arc);
+    data.value_type = Some("Real".to_string());
+    data.key_type = None;
+    data.declared_type = Some("MixHash".to_string());
+    Ok(Value::Mix(arc, true))
+}

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -93,29 +93,12 @@ impl Interpreter {
                 }
                 None
             }
-            "Mix" | "MixHash" if args.is_empty() => {
-                let result = match self.dispatch_to_mix_with_what(target, method) {
-                    Ok(r) => r,
-                    Err(e) => return Some(Err(e)),
-                };
-                if method == "MixHash" {
-                    // Ensure mutable flag is set for MixHash
-                    let result = if let Value::Mix(items, _) = result {
-                        Value::Mix(items, true)
-                    } else {
-                        result
-                    };
-                    let result = self.tag_container_metadata(
-                        result,
-                        ContainerTypeInfo {
-                            value_type: "Real".to_string(),
-                            key_type: None,
-                            declared_type: Some("MixHash".to_string()),
-                        },
-                    );
-                    return Some(Ok(result));
-                }
-                Some(Ok(result))
+            "Mix" if args.is_empty() => Some(self.dispatch_to_mix_with_what(target, method)),
+            "MixHash" if args.is_empty() => {
+                // `.MixHash` is `.Mix` plus the mutable flag and embedded `MixHash`
+                // type metadata; the metadata lives in the `Value::Mix` Arc, so the
+                // whole coercion is a pure value op shared with the VM native path.
+                Some(crate::builtins::quanthash_coerce::to_mixhash(target))
             }
             "Setty" | "Baggy" | "Mixy" if args.is_empty() => {
                 self.dispatch_setty_baggy_mixy(&target, method)

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -506,11 +506,13 @@ impl Interpreter {
         if let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
-        // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
-        // over a list-like receiver (ledger §1: native receiver dispatch ->
-        // Interpreter-native). Pure element-folding shared with the interpreter via
-        // `builtins::quanthash_coerce`. `.MixHash` falls through (it registers
-        // container type metadata, which is interpreter-owned state).
+        // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/
+        // `.MixHash` over a list-like receiver (ledger §1: native receiver dispatch
+        // -> Interpreter-native). Pure element-folding shared with the interpreter
+        // via `builtins::quanthash_coerce`. `.MixHash` embeds its type metadata
+        // directly in the `Value::Mix` Arc (not an interpreter-owned side table —
+        // container metadata has travelled in the value since #2952), so it is a
+        // pure value op like the others. Instance/Package receivers fall through.
         if args.is_empty()
             && let Some(result) = Self::try_native_quanthash_coerce(&target, method)
         {
@@ -1097,7 +1099,10 @@ impl Interpreter {
         target: &Value,
         method: &str,
     ) -> Option<Result<Value, RuntimeError>> {
-        if !matches!(method, "Set" | "SetHash" | "Bag" | "BagHash" | "Mix") {
+        if !matches!(
+            method,
+            "Set" | "SetHash" | "Bag" | "BagHash" | "Mix" | "MixHash"
+        ) {
             return None;
         }
         // Only list-like / QuantHash receivers go native; everything else
@@ -1134,6 +1139,7 @@ impl Interpreter {
                 })
             }
             "Mix" => crate::builtins::quanthash_coerce::to_mix(target, "Mix"),
+            "MixHash" => crate::builtins::quanthash_coerce::to_mixhash(target),
             _ => unreachable!(),
         };
         Some(result)

--- a/t/native-mixhash-coerce.t
+++ b/t/native-mixhash-coerce.t
@@ -1,0 +1,53 @@
+use Test;
+
+# `.MixHash` coercion native dispatch (VM-native, shared impl with the
+# interpreter via `builtins::quanthash_coerce::to_mixhash`). Each literal /
+# expression receiver goes through the native path; behavior must match the
+# interpreter fallback exactly (same value the `.Mix` folding produces, plus the
+# mutable flag and embedded `MixHash` type metadata).
+#
+# Uses Str elements so the angle-bracket subscript (`<a>` = Str "a") looks up the
+# same key the element folds to, matching raku's `.WHICH`-keyed semantics.
+
+plan 22;
+
+# --- type identity --------------------------------------------------------
+my $a = <a a b c>.MixHash;
+isa-ok $a, MixHash, 'List.MixHash is a MixHash';
+is $a.^name, 'MixHash', '.^name is MixHash';
+ok $a ~~ MixHash, 'smartmatches MixHash';
+ok $a ~~ Mixy, 'MixHash does Mixy';
+
+# --- weights / total ------------------------------------------------------
+is $a<a>, 2, 'duplicate element has weight 2';
+is $a<b>, 1, 'single element has weight 1';
+is $a<c>, 1, 'single element has weight 1 (c)';
+is $a.total, 4, 'total weight is 4';
+ok $a.so, 'a non-empty MixHash is truthy';
+
+# --- mutability (MixHash is the mutable QuantHash) ------------------------
+my $m = <x y>.MixHash;
+$m<z> = 5;
+is $m<z>, 5, 'MixHash element is assignable';
+is $m.elems, 3, 'assignment grows the MixHash';
+$m<x> = 0;
+is $m.elems, 2, 'setting weight to 0 removes the element';
+
+# --- from various receiver shapes ----------------------------------------
+is (a => 1.5, b => 2).Mix.MixHash.^name, 'MixHash', 'Mix.MixHash';
+is <a b b>.Bag.MixHash.^name,             'MixHash', 'Bag.MixHash';
+is <x y x>.Set.MixHash.^name,             'MixHash', 'Set.MixHash';
+is ('a', 'b', 'c').MixHash.^name,         'MixHash', 'List.MixHash';
+is (a => 1).MixHash.^name,                'MixHash', 'Pair.MixHash';
+my %h = a => 1, b => 2;
+is %h.MixHash.^name, 'MixHash', 'Hash.MixHash (variable receiver)';
+
+# --- empty ----------------------------------------------------------------
+my $e = ().MixHash;
+is $e.^name, 'MixHash', 'empty List.MixHash is a MixHash';
+nok $e.so, 'an empty MixHash is falsy';
+
+# --- Mix (immutable) is unaffected ---------------------------------------
+my $im = <a a b>.Mix;
+is $im.^name, 'Mix', '.Mix is still immutable Mix';
+is $im<a>, 2, 'Mix weights unchanged';


### PR DESCRIPTION
## What

`.MixHash` was the one QuantHash coercion still falling through the catch-all to the tree-walking interpreter. This native-izes it, advancing PLAN.md **§D (state ownership)**.

## Why the old exclusion was stale

PR-8 excluded `.MixHash` on the premise that it *"registers container type metadata, which is interpreter-owned state"*. That premise went **stale** with #2952's container-value metadata embedding: the `Value::Mix` that `.MixHash` produces now carries its type metadata (`value_type=Real`, `declared_type=MixHash`) **in** the `Arc<MixData>`, not in the interpreter's pointer-keyed side table. The side table (`register_container_type_metadata`) is only touched by the `other =>` branch (Instance receivers, etc.), which `.MixHash` never hits for the list-like receivers we coerce.

So `.MixHash` is a **pure value op** like its five siblings (`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`).

## How

- New pure fn `builtins::quanthash_coerce::to_mixhash` — `to_mix(_, "MixHash")` then mutable flip + embedded MixHash metadata. **Single authoritative impl** shared by the VM native path and the interpreter (1 operation = 1 impl).
- VM: add `"MixHash"` to `try_native_quanthash_coerce`.
- Dedup: the interpreter's `dispatch_method_by_name_2` `Mix|MixHash` branch now delegates to `to_mixhash` (drops the inline `tag_container_metadata` write).
- Receiver gate unchanged from the five siblings (list-like → native; Instance/Package → interpreter). Variable receivers (`%h.MixHash`) route through `CallMethodMut` and fall back exactly like the five siblings — **full parity, behavior-invariant**.

## Tests

- pin `t/native-mixhash-coerce.t` (22 subtests, passes on **both raku and mutsu**; uses Str elements to avoid the pre-existing string-vs-`.WHICH` key difference).
- mix.t 244/244, set.t, categorize green. (bag.t 625 "Foo instance union" is the documented pre-existing fail, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)