### PR TITLE
docs(plan): record chained-Z Seq-ness bug + stale chained-cross-zip.t

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,7 +129,13 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
       (2) `m:g//` を `my @m` 代入後 `@m.gist` が `(…)` を返す（receiver の List-kind dual-store）。S05-capture/array-alias.t（30/37）。
 - [ ] 未実装演算子: `ff`/`fff`（flipflop 8 variants）/ `==>`・`<==`（feed precedence: `==>` が `=` より強く結合する差）/
       `~<`・`~>`（string bitwise shift・優先度低）。
-- [ ] メタ演算子: generalized negation meta（`!op`）/ hyper assignment（`@a >>+=>> 1`）。
+- [ ] メタ演算子: generalized negation meta（`!op`）/ hyper assignment（`@a >>+=>> 1`）/
+      **chained Z の Seq-ness バグ**: `(1 Z 2 Z 3)`（3-operand）が List を返す（raku=Seq）。2/4-operand は Seq で
+      **3-operand だけ** List＝binary-nested `Z` の型依存ラッピング非対称（`Seq Z scalar`→List だが `List Z scalar`→Seq）。
+      #3471（X/Z は Seq）の chained reduction への伝播漏れ。`t/chained-cross-zip.t` の期待値も #3471 以前のままで stale
+      （tests 1-2/19-20 が X chain の正しい `.Seq` 出力に対し旧 List 期待で fail＝t/ 非致命で隠れている）。修正時は
+      chained Z を n-ary Seq 化 + 全 `.raku` 期待値を raku 一致（`.Seq` 付き）へ更新する。`src/vm/vm_string_regex_ops.rs` の
+      binary Z パス（~2155）。
 - [ ] Phasers: rvalue caching（INIT/CHECK/BEGIN as rvalues）/ PRE/POST（contract programming）。
 - [ ] Signatures: type-check enforcement（X::TypeCheck）/ native int/uint overflow・bounds / 単一 sub の複数シグネチャ。
 - [ ] OOP: namespaced construction（`A::B.new`）/ `augment class` / parameterized role mixin。


### PR DESCRIPTION
While measuring catch-all fallbacks for the §D state-ownership work, I found a real metaops bug worth tracking.

## Bug: chained `Z` loses Seq-ness at 3 operands

`(1 Z 2 Z 3)` returns a **List**, but raku returns a **Seq**. The asymmetry is specific to 3 operands — 2- and 4-operand chained `Z` both correctly return Seq:

| expr | mutsu | raku |
|---|---|---|
| `(1 Z 2)` | Seq | Seq |
| `(1 Z 2 Z 3)` | **List** | Seq |
| `(1 Z 2 Z 3 Z 4)` | Seq | Seq |
| `(1 X 2 X 3)` | Seq | Seq |

The AST is binary-nested (`MetaOp Z` inside `MetaOp Z`), so the binary `Z` path's type-dependent result wrapping mishandles the 3-operand nesting — a leftover from #3471 (which made X/Z return Seq but didn't fully propagate to chained reductions).

## Stale test

`t/chained-cross-zip.t` expectations are stale (written pre-#3471): tests 1-2 / 19-20 assert the old List `.raku` rendering and now fail against the correct `.Seq` output. This is hidden because the `t/` suite is non-fatal in CI.

This PR only **records** the finding in PLAN.md §3-F (metaops backlog). The actual fix (n-ary-ize chained Z + update all `.raku` expectations to match raku) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)