### PR TITLE
fix(lines): lines("...") function form returns a Seq, not a List

### DIFF
--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -1141,8 +1141,10 @@ impl Interpreter {
             if let Some(n) = limit {
                 lines.truncate(n);
             }
-            let values = lines.into_iter().map(Value::str).collect();
-            return Ok(Value::array(values));
+            let values: Vec<Value> = lines.into_iter().map(Value::str).collect();
+            // `lines` returns a Seq (so `.^name` is Seq), matching Rakudo and
+            // the `Str.lines` method form.
+            return Ok(Value::Seq(std::sync::Arc::new(values)));
         }
 
         let handle = args


### PR DESCRIPTION
## Summary

The string-argument form `lines("a\nb")` returned a **`List`** (`Value::array`), so `.WHAT` was `List` — diverging from Rakudo (where `lines` is always a `Seq`) and from mutsu's own `Str.lines` method form, which already returns a `Seq`. Sibling of the zip/cross Seq fixes (#3479/#3480).

```
lines("a\nb").WHAT   # was List, raku says Seq
lines("a\nb").raku   # now ("a", "b").Seq
```

## Tests

- `make test` green; `S32-str/lines.t` and `S16-io/lines.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)