### PR TITLE
feat(state-ownership): native-ize QuantHash coercion on the mut path

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -353,6 +353,15 @@
   まとめて降ろす別スライス候補）。挙動不変（native==interpreter＝同一 `to_mixhash`）。pin `t/native-mixhash-coerce.t`(22,
   raku/mutsu 双方 PASS・Str 要素で `.WHICH` キー差を回避)。mix.t 244/244・set.t・categorize 緑。
   （bag.t 625 "Foo instance union" は BLOCKERS.md 記載の pre-existing で本変更と無関係。）
+- **2026-06-23 (§1 = QuantHash coercion を mut パスでも VM ネイティブ化)**: 上記 MixHash slice の follow-up。**変数受け手**
+  （`@a.Set`/`%h.MixHash`）は `CallMethodMut` にコンパイルされ非mut パスの `try_native_quanthash_coerce` を踏まず、
+  6 兄弟（`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`）が一律 mut catch-all で interpreter fallback していた
+  （MixHash slice の「parity」注記参照）。`vm_call_method_compiled.rs` の **mut catch-all**（`try_compiled_method_mut_or_interpret`
+  末尾・`try_native_first` の後）に同じ `Self::try_native_quanthash_coerce` を追加。coercion は**新しい** Set/Bag/Mix 値を返し
+  受け手変数を変異させない（writeback 不要）ので非mut パスと完全同型＝挙動不変。Instance/Package 受け手は fall through。
+  実測: `@a.{Set,Bag,Mix,SetHash,BagHash,MixHash}` の fallback 6→0（残 `^name` は MOP）。pin
+  `t/native-quanthash-coerce-mut-path.t`(19, raku/mutsu 双方 PASS)。mix.t 244/244・set.t・categorize 緑。
+  （bag.t 252 / classify.t 40〔junction classify・非whitelist〕は stash 確認で main でも fail＝pre-existing・本変更と無関係。）
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -1824,6 +1824,17 @@ impl Interpreter {
         if let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
+        // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/
+        // `.MixHash` over a list-like receiver. Variable receivers (`@a.Set`,
+        // `%h.MixHash`) compile to CallMethodMut and so land on this mut path; the
+        // coercion produces a *new* Set/Bag/Mix value and never mutates the
+        // receiver variable, so there is no writeback — identical to the non-mut
+        // path's native dispatch. Instance/Package receivers fall through.
+        if args.is_empty()
+            && let Some(result) = Self::try_native_quanthash_coerce(&target, method)
+        {
+            return result;
+        }
         // TODO: compile to bytecode — native/Buf/Failure method fork, mut (ledger §1).
         // User-defined methods run as bytecode (compiled at registration or on
         // demand above); what remains is native receiver dispatch blocked on

--- a/t/native-quanthash-coerce-mut-path.t
+++ b/t/native-quanthash-coerce-mut-path.t
@@ -1,0 +1,48 @@
+use Test;
+
+# QuantHash coercion on a *variable* receiver (`@a.Set`, `%h.MixHash`, ...).
+# Variable receivers compile to CallMethodMut, so these land on the VM's mut
+# dispatch path, which previously fell back to the interpreter for all six
+# coercions. They are now native there too (the coercion returns a new value and
+# never mutates the receiver variable). Behavior must match the interpreter.
+
+plan 19;
+
+my @a = <a a b c>;
+
+# --- all six coercions go native and keep their type identity --------------
+is @a.Set.^name,     'Set',     '@a.Set';
+is @a.Bag.^name,     'Bag',     '@a.Bag';
+is @a.Mix.^name,     'Mix',     '@a.Mix';
+is @a.SetHash.^name, 'SetHash', '@a.SetHash';
+is @a.BagHash.^name, 'BagHash', '@a.BagHash';
+is @a.MixHash.^name, 'MixHash', '@a.MixHash';
+
+# --- weights / membership (Str elements => keys match subscripts) ----------
+is @a.Bag<a>, 2, 'Bag weight from variable receiver';
+is @a.Bag<b>, 1, 'Bag weight 1';
+ok @a.Set<a>,    'Set membership true';
+nok @a.Set<z>,   'Set non-membership';
+is @a.MixHash<a>, 2, 'MixHash weight from variable receiver';
+
+# --- hash receiver ---------------------------------------------------------
+my %h = x => 1, y => 2;
+is %h.Set.^name,     'Set',     '%h.Set';
+is %h.MixHash.^name, 'MixHash', '%h.MixHash';
+is %h.Bag<x>, 1, '%h.Bag weight';
+
+# --- mutability of the hashy variants -------------------------------------
+my $sh = @a.SetHash;
+$sh<d> = True;
+ok $sh<d>, 'SetHash from variable receiver is mutable';
+my $mh = @a.MixHash;
+$mh<e> = 4;
+is $mh<e>, 4, 'MixHash from variable receiver is mutable';
+
+# --- the receiver variable itself is unchanged (coercion is non-mutating) --
+is @a.elems, 4, 'receiver array unchanged after coercion';
+is @a.join(","), 'a,a,b,c', 'receiver array contents unchanged';
+
+# --- typed (non-Str) elements keep original key values --------------------
+my @nums = 1, 1, 2;
+is @nums.Bag{1}, 2, 'Bag of Int elements keyed by value';


### PR DESCRIPTION
## What

Follow-up to the `.MixHash` native slice (#3481). **Variable receivers** (`@a.Set`, `%h.MixHash`) compile to `CallMethodMut` and so land on the VM mut dispatch path, which lacked the QuantHash coercion fast-path — so all six coercions (`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`) fell back to the tree-walking interpreter for variable receivers (the "parity" note in #3481).

## How

Add the same `Self::try_native_quanthash_coerce` to the mut catch-all in `vm_call_method_compiled.rs` (after `try_native_first`). The coercion returns a **new** Set/Bag/Mix value and **never mutates** the receiver variable, so there is no writeback — identical to the non-mut path, behavior-invariant. Instance/Package receivers fall through.

## Tests

- Measured: `@a.{Set,Bag,Mix,SetHash,BagHash,MixHash}` fallback **6 → 0** (only `.^name` MOP remains).
- pin `t/native-quanthash-coerce-mut-path.t` (19, passes on **both raku and mutsu**).
- mix.t 244/244, set.t, categorize green.
- bag.t 252 / classify.t 40 (junction classify, non-whitelisted) are **pre-existing** — confirmed via `git stash` that they fail on main too. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)