### PR TITLE
feat(state-ownership): native-ize `.Seq` coercion (structural receivers)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -373,6 +373,15 @@
   Instance（Match の named captures / `__baggy_data__`）/ Package（型オブジェクト）/ lowercase `.hash` は interpreter 維持。
   挙動不変（`to_map` は embed して identity 保持＝`Map.Map === Map`、odd-count は `X::Hash::Store::OddNumber`）。pin
   `t/native-map-hash-coerce.t`(21, raku/mutsu 双方 PASS)。mix.t 244/244・set.t・hash.t・categorize・classify-list 緑。
+- **2026-06-23 (§1 = `.Seq` coercion の structural 分岐を VM ネイティブ化)**: coercion drainage の締め。`.Seq` は
+  `dispatch_seq_coercion`（`&mut self`）だが **structural 分岐（Seq/Array/Slip/Range/bare scalar）は pure**、
+  Supply（on-demand callback 駆動）/ LazyList（lazy bridge force）/ Instance（Buf/Blob byte 読み・generic wrap）のみ
+  carrier/state 依存。pure 分岐を新 `src/builtins/seq_coerce.rs::to_seq_structural(target) -> Option<Value>` へ抽出
+  （Supply/LazyList/**全 Instance** は `None` で interpreter へ）。interpreter の `dispatch_seq_coercion` は冒頭で委譲、
+  VM は非mut + mut 両 catch-all で `method == "Seq"` 時に呼ぶ＝**1 操作 = 1 実装**。gather/lazy の `.Seq` は引き続き
+  interpreter carrier で正しく drain。pin `t/native-seq-coerce.t`(16, raku/mutsu 双方 PASS)。S32-list/seq.t・S17-supply/Seq.t・
+  integration/sequence.t 緑。**これで pure-coercion fallback カテゴリ（Set/Bag/Mix/MixHash/Map/Hash/List/Array/Slip/Seq）は
+  実測ドレイン完了**＝残る coercion fallback は `.Setty`/`.Baggy`/`.Mixy`（型オブジェクト返し・niche）のみ。
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod parse_base;
 pub(crate) mod primality;
 pub(crate) mod quanthash_coerce;
 pub(crate) mod rng;
+pub(crate) mod seq_coerce;
 pub(crate) mod split;
 pub(crate) mod str_increment;
 pub(crate) mod substr;

--- a/src/builtins/seq_coerce.rs
+++ b/src/builtins/seq_coerce.rs
@@ -1,0 +1,37 @@
+// Pure `.Seq` coercion over structural receivers (Seq/Array/Slip/Range and bare
+// scalars). These carry no interpreter state: they wrap the receiver's elements
+// in a `Value::Seq`. Single authoritative impl shared by the bytecode VM
+// (native dispatch) and the interpreter's `dispatch_seq_coercion`.
+//
+// Receivers whose `.Seq` needs interpreter state / a carrier — a `Supply`
+// (drains its on-demand callback / value buffer), a `LazyList` (forced through
+// the lazy bridge), or a `Buf`/`Blob` Instance (reads the `bytes` attribute) —
+// return `None` here and are handled by the interpreter.
+//
+// Spec: https://docs.raku.org/routine/Seq
+
+use crate::runtime::utils::value_to_list;
+use crate::value::Value;
+use std::sync::Arc;
+
+/// Coerce a structural receiver to a `Seq`, or `None` to fall through to the
+/// interpreter (Supply / LazyList / any Instance — including Buf/Blob and
+/// generic objects, which the interpreter wraps after its special-cases).
+pub(crate) fn to_seq_structural(target: &Value) -> Option<Value> {
+    match target {
+        Value::Seq(_) => Some(target.clone()),
+        Value::Array(items, ..) => Some(Value::Seq(Arc::new(items.to_vec()))),
+        Value::Slip(items) => Some(Value::Seq(items.clone())),
+        Value::Range(..)
+        | Value::RangeExcl(..)
+        | Value::RangeExclStart(..)
+        | Value::RangeExclBoth(..)
+        | Value::GenericRange { .. } => Some(Value::Seq(Arc::new(value_to_list(target)))),
+        // Supply (carrier), LazyList (lazy bridge), and any Instance (Buf/Blob
+        // byte read, or the generic 1-element wrap) are left to the interpreter.
+        Value::LazyList(_) | Value::Instance { .. } => None,
+        // A bare scalar becomes a one-element Seq (matches the interpreter's
+        // `other => Seq([other])` tail).
+        other => Some(Value::Seq(Arc::new(vec![other.clone()]))),
+    }
+}

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -4,6 +4,12 @@ use crate::symbol::Symbol;
 impl Interpreter {
     /// Dispatch .Seq coercion method
     pub(super) fn dispatch_seq_coercion(&mut self, target: Value) -> Result<Value, RuntimeError> {
+        // Structural receivers (Seq/Array/Slip/Range/bare scalar) share the pure
+        // impl with the VM native path; Supply/LazyList/Instance need state and
+        // are handled below.
+        if let Some(seq) = crate::builtins::seq_coerce::to_seq_structural(&target) {
+            return Ok(seq);
+        }
         Ok(match target {
             Value::Seq(_) => target,
             Value::Array(items, ..) => Value::Seq(std::sync::Arc::new(items.to_vec())),

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -526,6 +526,15 @@ impl Interpreter {
         {
             return result;
         }
+        // Native `.Seq` coercion over a structural receiver (Seq/Array/Slip/
+        // Range/bare scalar). Supply/LazyList/Instance need state and fall
+        // through to the interpreter.
+        if args.is_empty()
+            && method == "Seq"
+            && let Some(result) = crate::builtins::seq_coerce::to_seq_structural(&target)
+        {
+            return Ok(result);
+        }
         // Native `.iterator` construction over a plain receiver (Range/Set/Bag/
         // Mix/List/Array/...): builds the `Iterator` instance via the single
         // `builtins::iterator_construct` impl the interpreter also uses. `Seq`
@@ -1887,6 +1896,14 @@ impl Interpreter {
             && let Some(result) = Self::try_native_map_hash_coerce(&target, method)
         {
             return result;
+        }
+        // Native `.Seq` coercion for variable receivers (`@a.Seq`) — structural
+        // receivers only, same pure value op as the non-mut path.
+        if args.is_empty()
+            && method == "Seq"
+            && let Some(result) = crate::builtins::seq_coerce::to_seq_structural(&target)
+        {
+            return Ok(result);
         }
         // TODO: compile to bytecode — native/Buf/Failure method fork, mut (ledger §1).
         // User-defined methods run as bytecode (compiled at registration or on

--- a/t/native-seq-coerce.t
+++ b/t/native-seq-coerce.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `.Seq` coercion native dispatch (VM-native, shared impl with the interpreter
+# via `builtins::seq_coerce::to_seq_structural`). Structural receivers
+# (Seq/Array/Slip/Range/bare scalar) go native; Supply/LazyList/Instance keep
+# the interpreter's state-touching handling. Behavior must match raku.
+
+plan 16;
+
+# --- structural receivers (native) ----------------------------------------
+is (1, 2, 3).Seq.^name, 'Seq', 'List.Seq is a Seq';
+isa-ok [1, 2, 3].Seq, Seq, 'Array.Seq is a Seq';
+is [1, 2, 3].Seq.elems, 3, 'Array.Seq elems';
+is (1..5).Seq.elems, 5, 'Range.Seq elems';
+is (1..^5).Seq.elems, 4, 'exclusive Range.Seq elems';
+is <a b c>.Seq.join(','), 'a,b,c', 'word-list.Seq contents';
+is (1, 2, 3).Seq.Seq.elems, 3, 'Seq.Seq is idempotent';
+
+# --- bare scalar wraps into a one-element Seq -----------------------------
+is 'x'.Seq.elems, 1, 'Str.Seq is one element';
+is 42.Seq.elems, 1, 'Int.Seq is one element';
+is 42.Seq.[0], 42, 'Int.Seq element value';
+
+# --- Slip flattens (interpreter and native agree) -------------------------
+is (slip(1, 2), 3).Seq.elems, 3, 'Slip in list.Seq flattens';
+
+# --- variable receiver (mut path) -----------------------------------------
+my @a = 10, 20, 30;
+is @a.Seq.^name, 'Seq', '@a.Seq is a Seq (variable receiver)';
+is @a.Seq.list.join(','), '10,20,30', '@a.Seq contents';
+is @a.elems, 3, 'receiver array unchanged';
+
+# --- gather/lazy still works via the interpreter carrier ------------------
+my $g = (gather { take 1; take 2; take 3 }).Seq;
+is $g.elems, 3, 'gather.Seq drains via interpreter (carrier)';
+
+# --- empty ----------------------------------------------------------------
+is ().Seq.elems, 0, 'empty list .Seq is empty';


### PR DESCRIPTION
## What

Completes the pure-coercion drainage (after #3481/#3484/#3486). `.Seq` lives in `dispatch_seq_coercion` (`&mut self`), but its **structural branches** (Seq/Array/Slip/Range/bare scalar) are pure value ops — only Supply (drives its on-demand callback), LazyList (forced through the lazy bridge) and Instance receivers (Buf/Blob byte read, or the generic 1-element wrap) touch interpreter state / a carrier.

## How

- New pure `src/builtins/seq_coerce.rs::to_seq_structural(target) -> Option<Value>`, returning `None` for Supply / LazyList / any Instance so the interpreter keeps handling those. **Single authoritative impl** shared by the VM native path and `dispatch_seq_coercion`.
- Interpreter `dispatch_seq_coercion` delegates the structural part up front, then handles the state-touching receivers.
- VM: native `.Seq` dispatch in both the non-mut and mut catch-alls (`@a.Seq` variable receiver goes via CallMethodMut).

## Tests

gather/lazy `.Seq` still drains correctly via the interpreter carrier.
- pin `t/native-seq-coerce.t` (16, passes on **both raku and mutsu**).
- S32-list/seq.t, S17-supply/Seq.t, integration/sequence.t green.

With this, the pure-coercion fallback category (Set/Bag/Mix/MixHash/Map/Hash/List/Array/Slip/Seq) is empirically drained; only `.Setty`/`.Baggy`/`.Mixy` (niche type-object returns) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)