### PR TITLE
fix(sink-warn): warn on pure prefix ops; name bare anonymous $ correctly

### DIFF
--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -307,6 +307,10 @@ fn describe_useless(expr: &Expr) -> Option<String> {
         // user-written bare scalar. A real bare `@a` parses to `ArrayVar("a")`,
         // so this never suppresses a genuine sink warning; it only stops the
         // spurious "Useless use of $@a in sink context" on `my @a := @b`.
+        // A bare anonymous `$` (the unnamed state scalar) parses to a synthetic
+        // `__ANON_STATE_<id>__` name. Raku reports it as "unnamed $ variable",
+        // not by its internal name.
+        Expr::Var(n) if n.starts_with("__ANON_STATE_") => Some("unnamed $ variable".to_string()),
         Expr::Var(n) if n.starts_with(['$', '@', '%', '&']) => None,
         Expr::Var(n) => Some(format!("${}", n)),
         Expr::ArrayVar(n) => Some(format!("@{}", n)),
@@ -319,6 +323,14 @@ fn describe_useless(expr: &Expr) -> Option<String> {
             // effects), e.g. `1 + 2` but not `$x + foo()`.
             describe_useless(left)?;
             describe_useless(right)?;
+            let rendered = render_source(expr)?;
+            Some(format!("\"{}\" in expression \"{}\"", sym, rendered))
+        }
+        Expr::Unary { op, expr: inner } => {
+            let sym = pure_prefix_symbol(op)?;
+            // Only flag when the operand itself is useless (no side effects),
+            // e.g. `-5` / `?5` / `-$x` but not `-foo()`.
+            describe_useless(inner)?;
             let rendered = render_source(expr)?;
             Some(format!("\"{}\" in expression \"{}\"", sym, rendered))
         }
@@ -360,6 +372,10 @@ fn render_source(expr: &Expr) -> Option<String> {
         Expr::ArrayVar(n) => Some(format!("@{}", n)),
         Expr::HashVar(n) => Some(format!("%{}", n)),
         Expr::BareWord(s) => Some(s.clone()),
+        Expr::Unary { op, expr: inner } => {
+            let sym = pure_prefix_symbol(op)?;
+            Some(format!("{}{}", sym, render_source(inner)?))
+        }
         Expr::Binary { left, op, right } => {
             let sym = pure_op_symbol(op)?;
             let l = render_source(left)?;
@@ -393,6 +409,19 @@ fn pure_op_symbol(op: &TokenKind) -> Option<&'static str> {
         TokenKind::Gte => ">=",
         TokenKind::LtEqGt => "<=>",
         TokenKind::FatArrow => "=>",
+        _ => return None,
+    })
+}
+
+/// Pure prefix operators that produce a value with no side effect. Operators
+/// not listed here are treated as potentially effectful and never flagged.
+fn pure_prefix_symbol(op: &TokenKind) -> Option<&'static str> {
+    Some(match op {
+        TokenKind::Plus => "+",
+        TokenKind::Minus => "-",
+        TokenKind::Tilde => "~",
+        TokenKind::Bang => "!",
+        TokenKind::Question => "?",
         _ => return None,
     })
 }

--- a/t/sink-warning.t
+++ b/t/sink-warning.t
@@ -2,7 +2,7 @@ use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 
-plan 19;
+plan 25;
 
 # A pure value evaluated in sink (void) context warns.
 is_run 'say "hi"; 42', { :0status, :out("hi\n"), :err(/"Useless use" .* 42/) },
@@ -55,3 +55,21 @@ is_run 'sub f { my @x = gather 43 }; f()', { :0status, :err(/"Useless use" .* 43
     'gather body inside a sub warns';
 is_run 'my @x = gather { take 1 }; say @x.elems', { :0status, :out("1\n"), :err('') },
     'gather body with only a take does not warn';
+
+# A bare anonymous `$` is reported as "unnamed $ variable", not its internal name.
+is_run '$; my $b;', { :0status, :err(/"Useless use of unnamed " '$' " variable"/) },
+    'bare anonymous $ in sink warns as unnamed variable';
+
+# Pure prefix operators on useless operands warn, naming the operator.
+is_run '-5', { :0status, :err(/"Useless use" .* '"-"' .* '-5'/) },
+    'prefix minus on constant in sink warns';
+is_run '!5', { :0status, :err(/"Useless use" .* '"!"' .* '!5'/) },
+    'prefix bang on constant in sink warns';
+is_run '?5', { :0status, :err(/"Useless use" .* '"?"' .* '?5'/) },
+    'prefix question on constant in sink warns';
+is_run 'my $x = 1; -$x', { :0status, :err(/"Useless use" .* '"-"' .* '-$x'/) },
+    'prefix minus on variable in sink warns';
+
+# A prefix operator on a side-effecting operand never warns.
+is_run 'sub f { 5 }; -f()', { :0status, :err('') },
+    'prefix minus on sub call does not warn';


### PR DESCRIPTION
## Summary

Two sink-context "Useless use of … in sink context" fidelity fixes, matching Rakudo.

### 1. Pure prefix operators now warn
`-`, `+`, `~`, `!`, `?` applied to a side-effect-free operand now emit a warning, e.g.:

```
$ mutsu -e '-5'
Useless use of "-" in expression "-5" in sink context (line 1)
```

Previously mutsu emitted **no** warning for any prefix-operator expression. A prefix op on an effectful operand (`-foo()`) still correctly does not warn (the operand must itself be useless).

### 2. Bare anonymous `$` named correctly
A bare anonymous `$` (the unnamed state scalar) is now reported as `unnamed $ variable` instead of its synthetic internal name (`$__ANON_STATE_0__`).

## Test impact

- Fixes `roast/S32-exceptions/misc.t` test *"unnamed var in sink context warns"*.
- Improves the special-Nums coverage there (`-Inf` now warns as `"-" in expression "-Inf"`).
- New cases added to `t/sink-warning.t` (19 → 25).

All match `raku` reference output. `make test` passes; whitelisted sink-related roast tests (`S32-list/{repeated,squish,unique}`, `S04-statements/while`, `S32-array/pop`, `S05-metasyntax/regex`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)