### PR TITLE
feat(state-ownership): native-ize pure-lexical IO::Path methods (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -382,6 +382,24 @@
   interpreter carrier で正しく drain。pin `t/native-seq-coerce.t`(16, raku/mutsu 双方 PASS)。S32-list/seq.t・S17-supply/Seq.t・
   integration/sequence.t 緑。**これで pure-coercion fallback カテゴリ（Set/Bag/Mix/MixHash/Map/Hash/List/Array/Slip/Seq）は
   実測ドレイン完了**＝残る coercion fallback は `.Setty`/`.Baggy`/`.Mixy`（型オブジェクト返し・niche）のみ。
+- **2026-06-23 (§D = 純 lexical `IO::Path` メソッドの VM ネイティブ化)**: coercion ドレイン後の実測駆動スライス。
+  `MUTSU_VM_STATS` の **広がり計測（distinct ファイル数）** で method-fallback の最大カテゴリが `parent`(66 file)/
+  `add`(65 file)＝temp-file/dir ヘルパー（`make-temp-dir`/`make-temp-file`）経由で 60+ ファイルに分散する **IO::Path の
+  パス操作メソッド**と判明（カウント最大の `AT-POS`=5816 は単一 `read-int.t` の Buf 受け手に集中＝広がり 7 file のみで不適）。
+  `IO::Path` の `native_io_path`（`&mut self`・FS/cwd 依存）のうち **パス文字列だけを操作する純 lexical メソッド**
+  （`parent`/`add`/`child`(非secure)/`sibling`/`basename`/`dirname`/`volume`/`cleanup`/`parts`/`extension`/`succ`/`pred`/
+  `starts-with`/`is-absolute`/`is-relative`/`Str`/`gist`/`IO`/`SPEC`）を新 associated fn `Interpreter::try_io_path_lexical`
+  （`&self` 不要＝FS/cwd/env を一切触らない・static `Self::io_path_*` ヘルパーのみ使用）へ抽出。**dedup**: `native_io_path`
+  は冒頭でこれに委譲し移動済み arm を削除＝**1 操作 = 1 実装**（`child`/`add` の join は共有ヘルパー `io_path_join_child`
+  に切り出し、`child :secure` の FS-resolve のみ `native_io_path` に残す）。VM は **非mut + mut 両方**の `is_native_method`
+  バウンス**直前**で `Self::is_io_path_lexical_class`（組込 `IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX` 限定）＋
+  `try_io_path_lexical` を呼ぶ（fallback 記録は `is_native_method` バウンス〔vm_call_method_compiled.rs:201/1652〕で起きていた
+  ため catch-all でなくここに配置）。coercion 同様 **新しい IO::Path/string/bool を返し受け手を変異しない**＝writeback 不要。
+  FS/cwd 依存（`e`/`f`/`slurp`/`spurt`/`absolute`/`relative`/`resolve`/`CWD`/`raku`）と numeric coercion・`child :secure` は
+  `None` で interpreter 維持＝behavior-invariant。実測: `$p.{parent,add,basename,dirname,sibling,…}` の fallback → 0
+  （残るのは `Str.IO` coercion〔別操作・Str 受け手〕と `IO::Path::*.new`〔③ ctor〕）。pin `t/native-io-path-lexical.t`(40,
+  literal `.IO` + 変数受け手〔mut path〕+ Win32 subclass round-trip・raku/mutsu 双方 PASS)。io-path.t の既存 fail 2
+  （`.SPEC`/`.CWD` attribute）は main でも fail＝本変更と無関係。S16-io/S32-io/tmpdir/cwd/dir whitelist 全緑。
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -158,6 +158,312 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
+    /// Join a `child`/`add` name onto a path lexically (no filesystem access),
+    /// honoring the receiver's SPEC (Win32 vs POSIX separators). Raises
+    /// `X::IO::Null` for an embedded null byte. Shared by `try_io_path_lexical`
+    /// (the pure fast path) and `native_io_path`'s `child :secure` arm so the
+    /// join is implemented once.
+    fn io_path_join_child(
+        attributes: &HashMap<String, Value>,
+        p: &str,
+        child_name: &str,
+    ) -> Result<String, RuntimeError> {
+        if child_name.contains('\0') || p.contains('\0') {
+            return Err(RuntimeError::new(
+                "X::IO::Null: Found null byte in pathname",
+            ));
+        }
+        let joined = if Self::is_win32_spec(attributes) {
+            if p == "." {
+                child_name.to_string()
+            } else if p.ends_with('\\') || p.ends_with('/') {
+                format!("{}{}", p, child_name)
+            } else {
+                format!("{}\\{}", p, child_name)
+            }
+        } else if p == "." {
+            child_name.to_string()
+        } else if p.ends_with('/') {
+            format!("{}{}", p, child_name)
+        } else {
+            Self::stringify_path(&Path::new(p).join(child_name))
+        };
+        Ok(joined)
+    }
+
+    /// Whether `class_name` is one of the built-in `IO::Path` family classes
+    /// (`IO::Path` plus the SPEC-variant subclasses) whose pure lexical methods
+    /// the VM may dispatch natively via [`try_io_path_lexical`](Self::try_io_path_lexical).
+    /// A user subclass that overrides a method is dispatched as compiled bytecode
+    /// before the catch-all is reached, so restricting the native fast path to the
+    /// built-in family keeps any user override authoritative.
+    pub(crate) fn is_io_path_lexical_class(class_name: &str) -> bool {
+        matches!(
+            class_name,
+            "IO::Path"
+                | "IO::Path::Unix"
+                | "IO::Path::Win32"
+                | "IO::Path::Cygwin"
+                | "IO::Path::QNX"
+        )
+    }
+
+    /// Pure, lexical `IO::Path` methods: those that derive a new path (or a
+    /// string/bool) purely from the receiver's `path`/`SPEC` *attributes* and the
+    /// arguments, with no filesystem access, no cwd resolution (`&self`), and no
+    /// env. This is the single authoritative implementation shared by the
+    /// bytecode VM's catch-all native dispatch (`try_compiled_method_*`) and the
+    /// interpreter's [`native_io_path`](Self::native_io_path), which delegates to
+    /// it (`1 operation = 1 implementation`).
+    ///
+    /// Returns `None` (fall through to `native_io_path`'s richer handling) for any
+    /// method that needs interpreter-owned state: filesystem stat/read/write
+    /// (`e`/`f`/`d`/`slurp`/`spurt`/`open`/`resolve`/…), cwd-relative forms
+    /// (`absolute`/`relative`/`CWD`/`raku`), numeric coercion that re-dispatches
+    /// through `self` (`Numeric`/`Int`/…), and `child :secure` (which resolves the
+    /// path against the filesystem). Path-deriving methods round-trip the concrete
+    /// receiver class (`IO::Path::Win32.parent` stays `IO::Path::Win32`).
+    pub(crate) fn try_io_path_lexical(
+        class_name: &str,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let io_path_class = Symbol::intern(class_name);
+        let p = attributes
+            .get("path")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let original = Path::new(&p);
+        let result = match method {
+            "Str" => Ok(Value::str(p.clone())),
+            "gist" => {
+                let shown = if Self::io_path_is_absolute_spec(attributes, &p, original) {
+                    if Self::is_win32_spec(attributes) {
+                        Self::canonpath_win32(&p, false)
+                    } else if Self::is_cygwin_spec(attributes) {
+                        Self::canonpath_cygwin(&p.replace('\\', "/"), false)
+                    } else {
+                        p.clone()
+                    }
+                } else {
+                    p.clone()
+                };
+                Ok(Value::str(format!("\"{}\".IO", shown.replace('"', "\\\""))))
+            }
+            "IO" => Ok(Value::make_instance(io_path_class, attributes.clone())),
+            "SPEC" => {
+                let spec_name = attributes
+                    .get("SPEC")
+                    .and_then(|s| match s {
+                        Value::Package(n) => Some(n.resolve().to_string()),
+                        Value::Instance { class_name, .. } => {
+                            Some(class_name.resolve().to_string())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| "IO::Spec::Unix".to_string());
+                Ok(Value::Package(Symbol::intern(&spec_name)))
+            }
+            "basename" => {
+                let (_, _, bname) = Self::io_path_parts_spec(&p, attributes);
+                Ok(Value::str(bname))
+            }
+            "dirname" => {
+                let (_, dname, _) = Self::io_path_parts_spec(&p, attributes);
+                Ok(Value::str(dname))
+            }
+            "volume" => {
+                let (volume, _, _) = Self::io_path_parts_spec(&p, attributes);
+                Ok(Value::str(volume))
+            }
+            "cleanup" => {
+                let normalized = if Self::is_win32_spec(attributes) {
+                    Self::cleanup_io_path_lexical_win32(&p)
+                } else {
+                    Self::cleanup_io_path_lexical(&p)
+                };
+                Ok(Self::clone_io_path_with_path(
+                    attributes,
+                    io_path_class,
+                    normalized,
+                ))
+            }
+            "parts" => {
+                let (volume, dirname, basename) = Self::io_path_parts_spec(&p, attributes);
+                let mut parts = HashMap::new();
+                parts.insert("volume".to_string(), Value::str(volume));
+                parts.insert("dirname".to_string(), Value::str(dirname));
+                parts.insert("basename".to_string(), Value::str(basename));
+                Ok(Value::hash(parts))
+            }
+            "parent" => {
+                let mut levels = 1i64;
+                if let Some(Value::Int(i)) = args.first() {
+                    if *i < 0 {
+                        return Some(Err(RuntimeError::new(
+                            "X::IO::ParentOutOfRange: Cannot go to a negative parent",
+                        )));
+                    }
+                    levels = *i;
+                }
+                if levels == 0 {
+                    return Some(Ok(Value::make_instance(io_path_class, attributes.clone())));
+                }
+                let sep = Self::io_path_sep(attributes);
+                let mut path = if Self::is_cygwin_spec(attributes) {
+                    p.replace('\\', "/")
+                } else {
+                    p.clone()
+                };
+                for _ in 0..levels {
+                    if path == "." {
+                        path = "..".to_string();
+                        continue;
+                    }
+                    if path == ".." {
+                        path = format!("..{}{}", sep, "..");
+                        continue;
+                    }
+                    let (volume, dirname, _basename) = Self::io_path_parts(&path);
+                    let full_vol_dir = format!("{}{}", volume, dirname);
+                    if dirname == "/" || dirname == "\\" {
+                        let new_path = format!("{}{}", volume, dirname);
+                        if new_path == path {
+                            break;
+                        }
+                        path = new_path;
+                    } else if dirname == "." && volume.is_empty() {
+                        path = ".".to_string();
+                    } else {
+                        path = full_vol_dir;
+                    }
+                }
+                let mut new_attrs = attributes.clone();
+                new_attrs.insert("path".to_string(), Value::str(path));
+                Ok(Value::make_instance(io_path_class, new_attrs))
+            }
+            "sibling" => {
+                let sibling_name = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let (volume, dirname, _) = Self::io_path_parts(&p);
+                let dir_with_volume = format!("{}{}", volume, dirname);
+                let sibling_path = if dir_with_volume == "/" || dir_with_volume == "\\" {
+                    format!("{}{}", dir_with_volume, sibling_name)
+                } else if dir_with_volume == "." {
+                    sibling_name
+                } else if dir_with_volume.ends_with('/') || dir_with_volume.ends_with('\\') {
+                    format!("{}{}", dir_with_volume, sibling_name)
+                } else {
+                    format!("{}/{}", dir_with_volume, sibling_name)
+                };
+                Ok(Self::clone_io_path_with_path(
+                    attributes,
+                    io_path_class,
+                    sibling_path,
+                ))
+            }
+            // `.add($name)` and `.child($name)` without `:secure` are pure lexical
+            // joins. `.child(:secure)` resolves against the filesystem and stays in
+            // `native_io_path`.
+            "add" | "child" => {
+                if method == "child" && Self::named_bool(args, "secure") {
+                    return None;
+                }
+                let child_name = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                match Self::io_path_join_child(attributes, &p, &child_name) {
+                    Ok(joined) => {
+                        let mut new_attrs = attributes.clone();
+                        new_attrs.insert("path".to_string(), Value::str(joined));
+                        Ok(Value::make_instance(io_path_class, new_attrs))
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            "extension" => (|| -> Result<Value, RuntimeError> {
+                let subst = Self::positional_value(args, 0).map(|v| v.to_string_value());
+                let parts_spec = Self::io_path_extension_parts_spec(args)?;
+                let selected_parts = parts_spec.select(Self::io_path_extension_part_count(&p));
+
+                if let Some(subst) = subst {
+                    let Some(parts_to_replace) = selected_parts else {
+                        return Ok(Value::make_instance(io_path_class, attributes.clone()));
+                    };
+                    let joiner = Self::named_value(args, "joiner")
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|| {
+                            if subst.is_empty() {
+                                "".to_string()
+                            } else {
+                                ".".to_string()
+                            }
+                        });
+                    let (dir_prefix, basename) = Self::split_path_for_extension(&p);
+                    let Some(base_without_ext) =
+                        Self::io_path_extension_strip_n_parts(basename, parts_to_replace)
+                    else {
+                        return Ok(Value::make_instance(io_path_class, attributes.clone()));
+                    };
+                    let mut new_basename = format!("{base_without_ext}{joiner}{subst}");
+                    if new_basename.is_empty() {
+                        new_basename = ".".to_string();
+                    }
+                    let mut new_attrs = attributes.clone();
+                    new_attrs.insert(
+                        "path".to_string(),
+                        Value::str(format!("{dir_prefix}{new_basename}")),
+                    );
+                    Ok(Value::make_instance(io_path_class, new_attrs))
+                } else {
+                    let Some(parts) = selected_parts else {
+                        return Ok(Value::str(String::new()));
+                    };
+                    Ok(Value::str(
+                        Self::io_path_extension_with_n_parts(&p, parts).unwrap_or_default(),
+                    ))
+                }
+            })(),
+            "starts-with" => {
+                let prefix = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                Ok(Value::Bool(p.starts_with(&prefix)))
+            }
+            "is-absolute" => Ok(Value::Bool(Self::io_path_is_absolute_spec(
+                attributes, &p, original,
+            ))),
+            "is-relative" => Ok(Value::Bool(!Self::io_path_is_absolute_spec(
+                attributes, &p, original,
+            ))),
+            "succ" => {
+                let (volume, dirname, basename) = Self::io_path_parts(&p);
+                let new_basename = crate::builtins::str_increment::string_succ(&basename);
+                let sep = Self::io_path_sep(attributes);
+                let new_path = Self::join_io_path_parts(&volume, &dirname, &new_basename, sep);
+                let mut new_attrs = attributes.clone();
+                new_attrs.insert("path".to_string(), Value::str(new_path));
+                Ok(Value::make_instance(io_path_class, new_attrs))
+            }
+            "pred" => {
+                let (volume, dirname, basename) = Self::io_path_parts(&p);
+                let new_basename = crate::builtins::str_increment::string_pred(&basename);
+                let sep = Self::io_path_sep(attributes);
+                let new_path = Self::join_io_path_parts(&volume, &dirname, &new_basename, sep);
+                let mut new_attrs = attributes.clone();
+                new_attrs.insert("path".to_string(), Value::str(new_path));
+                Ok(Value::make_instance(io_path_class, new_attrs))
+            }
+            _ => return None,
+        };
+        Some(result)
+    }
+
     pub(super) fn native_io_path(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -165,12 +471,18 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // Pure lexical path methods (`.parent`/`.add`/`.basename`/`.sibling`/…)
+        // are handled by the single shared `try_io_path_lexical` (the same impl
+        // the bytecode VM dispatches natively). Only the filesystem / cwd-relative
+        // forms below need `&self`.
+        if let Some(result) = Self::try_io_path_lexical(class_name, attributes, method, &args) {
+            return result;
+        }
         // The concrete class of the receiver (`IO::Path` or a SPEC-variant
         // subclass `IO::Path::Unix`/`::Win32`/`::Cygwin`/`::QNX`). Path-deriving
-        // methods (`.parent`, `.sibling`, `.child`, ...) must round-trip this
-        // class so e.g. `IO::Path::Win32.new("x").parent(0)` stays an
-        // `IO::Path::Win32` (Rakudo preserves the subclass; `is-deeply`/`eqv`
-        // compares it).
+        // methods (`.child :secure`, ...) must round-trip this class so e.g.
+        // `IO::Path::Win32.new("x").parent(0)` stays an `IO::Path::Win32`
+        // (Rakudo preserves the subclass; `is-deeply`/`eqv` compares it).
         let io_path_class = Symbol::intern(class_name);
         let p = attributes
             .get("path")
@@ -187,27 +499,6 @@ impl Interpreter {
         let cwd_path = self.get_cwd_path();
         let original = Path::new(&p);
         match method {
-            "Str" => Ok(Value::str(p.clone())),
-            "gist" => {
-                // IO::Path.gist returns `"<str>".IO`, where <str> is the
-                // absolute path (SPEC-normalized separators) when the path is
-                // absolute, else the path string verbatim. So an absolute Win32
-                // path gists with backslashes: `IO::Path::Win32.new('/foo')` →
-                // `"\foo".IO` (Cygwin normalizes to forward slashes).
-                let shown = if Self::io_path_is_absolute_spec(attributes, &p, original) {
-                    if Self::is_win32_spec(attributes) {
-                        Self::canonpath_win32(&p, false)
-                    } else if Self::is_cygwin_spec(attributes) {
-                        Self::canonpath_cygwin(&p.replace('\\', "/"), false)
-                    } else {
-                        p.clone()
-                    }
-                } else {
-                    p.clone()
-                };
-                // Only escape double quotes, not backslashes.
-                Ok(Value::str(format!("\"{}\".IO", shown.replace('"', "\\\""))))
-            }
             "raku" | "perl" => {
                 let escape = |s: &str| {
                     s.replace('\\', "\\\\")
@@ -239,36 +530,9 @@ impl Interpreter {
                     escape(&cwd)
                 )))
             }
-            "IO" => Ok(Value::make_instance(io_path_class, attributes.clone())),
             "CWD" => {
                 let cwd = instance_cwd.unwrap_or_else(|| Self::stringify_path(&cwd_path));
                 Ok(Value::str(cwd))
-            }
-            "SPEC" => {
-                // Return the IO::Spec type object backing this path. Normalize to
-                // a canonical `Value::Package` so that two paths sharing the same
-                // SPEC compare `eqv` regardless of whether the stored value was a
-                // `Package` (from `IO::Path::Unix.new`) or a type-object instance
-                // (from `$*SPEC`). Defaults to IO::Spec::Unix.
-                let spec_name = attributes
-                    .get("SPEC")
-                    .and_then(|s| match s {
-                        Value::Package(n) => Some(n.resolve().to_string()),
-                        Value::Instance { class_name, .. } => {
-                            Some(class_name.resolve().to_string())
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or_else(|| "IO::Spec::Unix".to_string());
-                Ok(Value::Package(Symbol::intern(&spec_name)))
-            }
-            "basename" => {
-                let (_, _, bname) = Self::io_path_parts_spec(&p, attributes);
-                Ok(Value::str(bname))
-            }
-            "dirname" => {
-                let (_, dname, _) = Self::io_path_parts_spec(&p, attributes);
-                Ok(Value::str(dname))
             }
             // IO::Path is Cool: `.Numeric`/`.Int`/`.Rat`/`.Num`/`.FatRat`/`.Real`
             // coerce the *basename* to a number, failing with an X::Str::Numeric
@@ -299,121 +563,15 @@ impl Interpreter {
                     Ok(self.fail_error_to_failure_value(&err))
                 }
             }
-            "cleanup" => {
-                let normalized = if Self::is_win32_spec(attributes) {
-                    Self::cleanup_io_path_lexical_win32(&p)
-                } else {
-                    Self::cleanup_io_path_lexical(&p)
-                };
-                Ok(Self::clone_io_path_with_path(
-                    attributes,
-                    io_path_class,
-                    normalized,
-                ))
-            }
-            "parts" => {
-                let (volume, dirname, basename) = Self::io_path_parts_spec(&p, attributes);
-                let mut parts = HashMap::new();
-                parts.insert("volume".to_string(), Value::str(volume));
-                parts.insert("dirname".to_string(), Value::str(dirname));
-                parts.insert("basename".to_string(), Value::str(basename));
-                Ok(Value::hash(parts))
-            }
-            "parent" => {
-                let mut levels = 1i64;
-                if let Some(Value::Int(i)) = args.first() {
-                    if *i < 0 {
-                        return Err(RuntimeError::new(
-                            "X::IO::ParentOutOfRange: Cannot go to a negative parent",
-                        ));
-                    }
-                    levels = *i;
-                }
-                if levels == 0 {
-                    return Ok(Value::make_instance(io_path_class, attributes.clone()));
-                }
-                let sep = Self::io_path_sep(attributes);
-                let mut path = if Self::is_cygwin_spec(attributes) {
-                    p.replace('\\', "/")
-                } else {
-                    p.clone()
-                };
-                for _ in 0..levels {
-                    if path == "." {
-                        path = "..".to_string();
-                        continue;
-                    }
-                    if path == ".." {
-                        path = format!("..{}{}", sep, "..");
-                        continue;
-                    }
-                    let (volume, dirname, _basename) = Self::io_path_parts(&path);
-                    let full_vol_dir = format!("{}{}", volume, dirname);
-                    if dirname == "/" || dirname == "\\" {
-                        let new_path = format!("{}{}", volume, dirname);
-                        if new_path == path {
-                            // Already at root, stop
-                            break;
-                        }
-                        path = new_path;
-                    } else if dirname == "." && volume.is_empty() {
-                        path = ".".to_string();
-                    } else {
-                        path = full_vol_dir;
-                    }
-                }
-                let mut new_attrs = attributes.clone();
-                new_attrs.insert("path".to_string(), Value::str(path));
-                Ok(Value::make_instance(io_path_class, new_attrs))
-            }
-            "sibling" => {
-                let sibling_name = args
-                    .first()
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_default();
-                // For sibling, get the dirname and join with the new name
-                let (volume, dirname, _) = Self::io_path_parts(&p);
-                let dir_with_volume = format!("{}{}", volume, dirname);
-                let sibling_path = if dir_with_volume == "/" || dir_with_volume == "\\" {
-                    format!("{}{}", dir_with_volume, sibling_name)
-                } else if dir_with_volume == "." {
-                    sibling_name
-                } else if dir_with_volume.ends_with('/') || dir_with_volume.ends_with('\\') {
-                    format!("{}{}", dir_with_volume, sibling_name)
-                } else {
-                    format!("{}/{}", dir_with_volume, sibling_name)
-                };
-                Ok(Self::clone_io_path_with_path(
-                    attributes,
-                    io_path_class,
-                    sibling_path,
-                ))
-            }
-            "child" | "add" => {
+            // `.child($name, :secure)` resolves the path against the filesystem.
+            // (Plain `.child`/`.add` are pure lexical joins handled by
+            // `try_io_path_lexical` before this match.)
+            "child" => {
                 let child_name = args
                     .first()
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
-                if child_name.contains('\0') || p.contains('\0') {
-                    return Err(RuntimeError::new(
-                        "X::IO::Null: Found null byte in pathname",
-                    ));
-                }
-                let joined = if Self::is_win32_spec(attributes) {
-                    if p == "." {
-                        child_name.clone()
-                    } else if p.ends_with('\\') || p.ends_with('/') {
-                        format!("{}{}", p, child_name)
-                    } else {
-                        format!("{}\\{}", p, child_name)
-                    }
-                } else if p == "." {
-                    child_name.clone()
-                } else if p.ends_with('/') {
-                    format!("{}{}", p, child_name)
-                } else {
-                    Self::stringify_path(&original.join(&child_name))
-                };
+                let joined = Self::io_path_join_child(attributes, &p, &child_name)?;
                 let mut new_attrs = attributes.clone();
                 new_attrs.insert("path".to_string(), Value::str(joined.clone()));
                 let child = Value::make_instance(io_path_class, new_attrs);
@@ -422,7 +580,7 @@ impl Interpreter {
                 // X::IO::Resolve when the parent or the child path cannot be
                 // completely resolved, and with X::IO::NotAChild when the
                 // resolved child escapes the parent directory.
-                if method == "child" && Self::named_bool(&args, "secure") {
+                if Self::named_bool(&args, "secure") {
                     let parent_abs = if original.is_absolute() {
                         path_buf.clone()
                     } else if let Some(cwd) = &instance_cwd {
@@ -454,50 +612,6 @@ impl Interpreter {
                     }
                 }
                 Ok(child)
-            }
-            "extension" => {
-                let subst = Self::positional_value(&args, 0).map(|v| v.to_string_value());
-                let parts_spec = Self::io_path_extension_parts_spec(&args)?;
-                let selected_parts = parts_spec.select(Self::io_path_extension_part_count(&p));
-
-                if let Some(subst) = subst {
-                    let Some(parts_to_replace) = selected_parts else {
-                        return Ok(Value::make_instance(io_path_class, attributes.clone()));
-                    };
-                    let joiner = Self::named_value(&args, "joiner")
-                        .map(|v| v.to_string_value())
-                        .unwrap_or_else(|| {
-                            if subst.is_empty() {
-                                "".to_string()
-                            } else {
-                                ".".to_string()
-                            }
-                        });
-                    let (dir_prefix, basename) = Self::split_path_for_extension(&p);
-                    let Some(base_without_ext) =
-                        Self::io_path_extension_strip_n_parts(basename, parts_to_replace)
-                    else {
-                        return Ok(Value::make_instance(io_path_class, attributes.clone()));
-                    };
-                    let mut new_basename = format!("{base_without_ext}{joiner}{subst}");
-                    // Raku: empty basename after replacement becomes "."
-                    if new_basename.is_empty() {
-                        new_basename = ".".to_string();
-                    }
-                    let mut new_attrs = attributes.clone();
-                    new_attrs.insert(
-                        "path".to_string(),
-                        Value::str(format!("{dir_prefix}{new_basename}")),
-                    );
-                    Ok(Value::make_instance(io_path_class, new_attrs))
-                } else {
-                    let Some(parts) = selected_parts else {
-                        return Ok(Value::str(String::new()));
-                    };
-                    Ok(Value::str(
-                        Self::io_path_extension_with_n_parts(&p, parts).unwrap_or_default(),
-                    ))
-                }
             }
             "absolute" => {
                 if Self::is_win32_spec(attributes) {
@@ -595,13 +709,6 @@ impl Interpreter {
                     Ok(Value::str(rel))
                 }
             }
-            "starts-with" => {
-                let prefix = args
-                    .first()
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_default();
-                Ok(Value::Bool(p.starts_with(&prefix)))
-            }
             "resolve" => {
                 let completely = Self::named_bool(&args, "completely");
                 let resolved = match Self::resolve_io_path(&path_buf, completely, &p) {
@@ -616,34 +723,6 @@ impl Interpreter {
                 new_attrs.insert("path".to_string(), Value::str(resolved));
                 let sep = Self::io_path_sep(attributes).to_string();
                 new_attrs.insert("cwd".to_string(), Value::str(sep));
-                Ok(Value::make_instance(io_path_class, new_attrs))
-            }
-            "volume" => {
-                let (volume, _, _) = Self::io_path_parts_spec(&p, attributes);
-                Ok(Value::str(volume))
-            }
-            "is-absolute" => Ok(Value::Bool(Self::io_path_is_absolute_spec(
-                attributes, &p, original,
-            ))),
-            "is-relative" => Ok(Value::Bool(!Self::io_path_is_absolute_spec(
-                attributes, &p, original,
-            ))),
-            "succ" => {
-                let (volume, dirname, basename) = Self::io_path_parts(&p);
-                let new_basename = crate::builtins::str_increment::string_succ(&basename);
-                let sep = Self::io_path_sep(attributes);
-                let new_path = Self::join_io_path_parts(&volume, &dirname, &new_basename, sep);
-                let mut new_attrs = attributes.clone();
-                new_attrs.insert("path".to_string(), Value::str(new_path));
-                Ok(Value::make_instance(io_path_class, new_attrs))
-            }
-            "pred" => {
-                let (volume, dirname, basename) = Self::io_path_parts(&p);
-                let new_basename = crate::builtins::str_increment::string_pred(&basename);
-                let sep = Self::io_path_sep(attributes);
-                let new_path = Self::join_io_path_parts(&volume, &dirname, &new_basename, sep);
-                let mut new_attrs = attributes.clone();
-                new_attrs.insert("path".to_string(), Value::str(new_path));
                 Ok(Value::make_instance(io_path_class, new_attrs))
             }
             "e" => Ok(Value::Bool(path_buf.exists())),

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -194,6 +194,19 @@ impl Interpreter {
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
                 return result;
             }
+            // Interpreter-native pure-lexical `IO::Path` methods (`.parent`/`.add`/
+            // `.basename`/`.sibling`/`.parts`/`.extension`/…): derive a new
+            // path/string/bool purely from the receiver's attributes, with no
+            // filesystem / cwd / env dependency (ledger §D). Single impl shared with
+            // the interpreter's `native_io_path`. Filesystem / cwd-relative forms and
+            // `child :secure` return `None` and fall through to the native fork below.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    Self::try_io_path_lexical(&class, &attributes.as_map(), method, &args)
+            {
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
@@ -1624,6 +1637,18 @@ impl Interpreter {
             // the handle's record reader (PR-D read side). ArgFiles/Stdin/non-UTF8
             // (which need @*ARGS / decode) fall through.
             if let Some(result) = self.try_native_io_handle_read(&target, method, &args) {
+                return result;
+            }
+            // Interpreter-native pure-lexical `IO::Path` methods for variable
+            // receivers (`$p.parent`, `$p.add(...)`): same pure value op as the
+            // non-mut path — produces a *new* IO::Path/string/bool and never mutates
+            // the receiver, so no writeback. Filesystem / cwd-relative forms and
+            // `child :secure` fall through to the native fork below.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    Self::try_io_path_lexical(&class, &attributes.as_map(), method, &args)
+            {
                 return result;
             }
             // A user-defined subclass of a builtin type may override an inherited

--- a/t/native-io-path-lexical.t
+++ b/t/native-io-path-lexical.t
@@ -1,0 +1,76 @@
+use Test;
+
+# Pure lexical IO::Path methods (`.parent`/`.add`/`.basename`/`.sibling`/
+# `.cleanup`/`.extension`/`.volume`/`.succ`/`.pred`/`.starts-with`/
+# `.is-absolute`/`.is-relative`/`.Str`/`.gist`/`.IO`) are dispatched natively by
+# the bytecode VM (no filesystem / cwd / env), sharing the single
+# `try_io_path_lexical` impl the interpreter's `native_io_path` delegates to.
+# These derive a new path/string/bool purely from the receiver's attributes, so
+# both a literal `.IO` receiver and a variable receiver (the mut dispatch path)
+# must agree with Rakudo.
+
+plan 40;
+
+# --- literal `.IO` receiver (non-mut dispatch path) ---
+is "/foo/bar/baz".IO.parent.Str,        "/foo/bar",     "parent (literal)";
+is "/foo/bar/baz".IO.parent(2).Str,     "/foo",         "parent(2)";
+is "/foo/bar/baz".IO.parent(0).Str,     "/foo/bar/baz", "parent(0) is identity";
+is "/foo/bar".IO.add("qux").Str,        "/foo/bar/qux", "add";
+is "/foo/bar".IO.child("c").Str,        "/foo/bar/c",   "child (non-secure)";
+is "/foo/bar/baz".IO.basename,          "baz",          "basename";
+is "/foo/bar/baz".IO.dirname,           "/foo/bar",     "dirname";
+is "/foo/bar/baz".IO.sibling("s").Str,  "/foo/bar/s",   "sibling";
+is "rel/path".IO.parent.Str,            "rel",          "parent of relative";
+
+# --- variable receiver (mut dispatch path) ---
+my $p = "/a/b/c.tar.gz".IO;
+is $p.parent.Str,         "/a/b",         "parent (var)";
+is $p.add("d").Str,       "/a/b/c.tar.gz/d", "add (var)";
+is $p.basename,           "c.tar.gz",     "basename (var)";
+is $p.dirname,            "/a/b",         "dirname (var)";
+is $p.sibling("e").Str,   "/a/b/e",       "sibling (var)";
+is $p.extension,          "gz",           "extension (var)";
+is $p.cleanup.Str,        "/a/b/c.tar.gz","cleanup (var)";
+ok $p.is-absolute,                        "is-absolute (var)";
+nok $p.is-relative,                       "is-relative (var)";
+ok $p.starts-with("/a"),                  "starts-with true";
+nok $p.starts-with("/z"),                 "starts-with false";
+
+# the variable is not mutated by these pure derivations
+is $p.Str, "/a/b/c.tar.gz", "receiver variable unchanged after derivations";
+
+# --- extension replacement / removal ---
+is "foo.tar.gz".IO.extension("tgz").Str, "foo.tar.tgz", "extension replace one part";
+is "foo.tar.gz".IO.extension("", :parts(0..*)).Str, "foo", "extension strip all";
+is "foo".IO.extension,    "",             "extension of extensionless is empty";
+
+# --- cleanup normalizes lexically (collapses `//` and `/./`, keeps `..`) ---
+is "/a/b//c".IO.cleanup.Str, "/a/b/c",    "cleanup collapses duplicate slashes";
+is "/a/./b".IO.cleanup.Str,  "/a/b",      "cleanup removes single-dot segments";
+
+# --- succ / pred on the basename ---
+is "abc".IO.succ.Str,     "abd",          "succ";
+is "abd".IO.pred.Str,     "abc",          "pred";
+is "/x/y/az".IO.succ.Str, "/x/y/ba",      "succ carries within basename only";
+
+# --- volume (empty on POSIX) ---
+is "/foo/bar".IO.volume,  "",             "volume empty on POSIX";
+
+# --- relative path predicates ---
+ok "a/b".IO.is-relative,                  "relative path is-relative";
+nok "a/b".IO.is-absolute,                 "relative path not is-absolute";
+
+# --- gist / Str / IO round-trip ---
+is "/foo".IO.Str,         "/foo",         "Str";
+is "/foo".IO.gist,        '"/foo".IO',    "gist of absolute path";
+ok "/foo".IO.IO ~~ IO::Path,              ".IO on an IO::Path is an IO::Path";
+is "/foo".IO.IO.Str,      "/foo",         ".IO preserves the path";
+
+# --- chained derivations stay pure ---
+is "/a/b/c".IO.parent.add("x").Str, "/a/b/x", "chained parent.add";
+is "/a/b/c".IO.sibling("d").basename, "d",    "chained sibling.basename";
+
+# --- subclass round-trips through path-deriving methods ---
+my $w = IO::Path::Win32.new("a\\b\\c");
+ok $w.parent ~~ IO::Path::Win32,          "Win32 parent stays Win32";
+is $w.parent.Str,         "a\\b",         "Win32 parent uses backslash sep";


### PR DESCRIPTION
## Summary

§D (state ownership) measured-driven slice. Drains the broadest tractable
method-fallback category: the **IO::Path path-deriving methods**.

Breadth measurement (`MUTSU_VM_STATS`, distinct-file count across the whitelist)
shows `.parent` (66 files) and `.add` (65 files) as the broadest fallbacks —
reached via the `make-temp-dir`/`make-temp-file` test helpers in 60+ files. (The
top-by-raw-count `AT-POS`=5816 is concentrated in a single Buf-heavy test, 7
files only, so it is a poor target.)

## What changed

Extract the **pure, lexical** IO::Path methods — those deriving a new
path/string/bool purely from the receiver's `path`/`SPEC` attributes, with no
filesystem / cwd / env dependency — into a single associated fn
`Interpreter::try_io_path_lexical`:

`parent`, `add`, `child` (non-secure), `sibling`, `basename`, `dirname`,
`volume`, `cleanup`, `parts`, `extension`, `succ`, `pred`, `starts-with`,
`is-absolute`, `is-relative`, `Str`, `gist`, `IO`, `SPEC`.

- **dedup (1 operation = 1 implementation):** `native_io_path` delegates to it
  (the moved arms are removed); the `child`/`add` join is factored into a shared
  `io_path_join_child`, leaving only `child :secure` (filesystem resolve) in
  `native_io_path`.
- **VM native dispatch:** both the non-mut and mut method paths call it just
  before the `is_native_method` interpreter bounce (where the fallback was being
  recorded), gated to the built-in `IO::Path` family
  (`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`). These derivations return a
  *new* value and never mutate the receiver, so there is no writeback.

Filesystem / cwd-relative forms (`e`/`f`/`slurp`/`spurt`/`absolute`/`relative`/
`resolve`/`CWD`/`raku`), numeric coercion, and `child :secure` fall through to
the interpreter → **behavior-invariant**.

## Verification

- `$p.{parent,add,basename,dirname,sibling,…}` fallbacks drain to **0** (the
  remaining IO fallbacks are `Str.IO` coercion — a different op — and
  `IO::Path::*.new` ctors, ③-blocked).
- `io-path.t`'s 2 pre-existing failures (`.SPEC`/`.CWD` attribute) fail on `main`
  too — unrelated.
- S16-io / S32-io / tmpdir / cwd / dir whitelist all green; `make test` PASS
  (10584 tests).
- pin: `t/native-io-path-lexical.t` (40 subtests — literal `.IO` + variable
  receiver/mut path + Win32 subclass round-trip, raku/mutsu parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)