### PR TITLE
fix(.gist/.raku): a WhateverCode renders as WhateverCode.new

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -5,6 +5,20 @@ use crate::value::{RuntimeError, Value};
 use super::raku_repr::raku_value;
 use super::{format_temporal_num, gist_array_wrap, range_gist_string};
 
+/// Leaf-value gist for a list/array element: a WhateverCode (`*+1`) gists as
+/// `WhateverCode.new`; everything else uses its string value.
+fn leaf_gist(v: &Value) -> String {
+    if let Value::Sub(data) = v
+        && matches!(
+            data.env.get("__mutsu_callable_type"),
+            Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+        )
+    {
+        return "WhateverCode.new".to_string();
+    }
+    v.to_string_value()
+}
+
 /// A collection whose gist embeds an element's gist must defer to the runtime
 /// slow path when any element may carry a user-defined `method gist` (an
 /// instance, custom type, or type object). The pure fast path here cannot
@@ -493,7 +507,7 @@ pub(super) fn dispatch(
                             .unwrap_or_else(|| v.to_string_value())
                     }
                     other if other.is_range() => range_gist_string(other),
-                    other => other.to_string_value(),
+                    other => leaf_gist(other),
                 }
             }
             // Shaped arrays: format with newlines between rows
@@ -568,7 +582,7 @@ pub(super) fn dispatch(
                             .unwrap_or_else(|| v.to_string_value())
                     }
                     other if other.is_range() => range_gist_string(other),
-                    other => other.to_string_value(),
+                    other => leaf_gist(other),
                 }
             }
             let inner = items.iter().map(gist_item).collect::<Vec<_>>().join(" ");
@@ -584,6 +598,17 @@ pub(super) fn dispatch(
             }
         }
         Value::Junction { .. } if method == "raku" || method == "perl" => None,
+        // A WhateverCode (`*+1`, `*.abs`) renders as `WhateverCode.new` for
+        // `.gist`/`.raku`/`.perl`, not the generic closure form.
+        Value::Sub(data)
+            if (method == "raku" || method == "perl" || method == "gist")
+                && matches!(
+                    data.env.get("__mutsu_callable_type"),
+                    Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+                ) =>
+        {
+            Some(Ok(Value::str_from("WhateverCode.new")))
+        }
         // Sub/Routine/WeakSub: delegate to interpreter for proper raku/gist/Str
         Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } => None,
         Value::Pair(k, v) => {

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -805,6 +805,16 @@ pub fn raku_value(v: &Value) -> String {
                 raku_value(inner)
             }
         }
+        // A WhateverCode (`*+1`) renders as `WhateverCode.new`, including when it
+        // appears as an element of an array/list being `.raku`-rendered.
+        Value::Sub(data)
+            if matches!(
+                data.env.get("__mutsu_callable_type"),
+                Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+            ) =>
+        {
+            "WhateverCode.new".to_string()
+        }
         other => other.to_string_value(),
     }
 }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1132,6 +1132,16 @@ pub(crate) fn gist_value(value: &Value) -> String {
                 gist_value(inner)
             }
         }
+        // A WhateverCode (`*+1`, `*.abs`) gists as `WhateverCode.new`, not the
+        // empty string its bare closure stringification would yield.
+        Value::Sub(data)
+            if matches!(
+                data.env.get("__mutsu_callable_type"),
+                Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+            ) =>
+        {
+            "WhateverCode.new".to_string()
+        }
         _ => value.to_string_value(),
     }
 }

--- a/t/whatevercode-gist-raku.t
+++ b/t/whatevercode-gist-raku.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 11;
+
+# A WhateverCode (`*+1`, `*.abs`) renders as `WhateverCode.new` for
+# .gist / .raku / .perl, and via say (which gists), not as a generic
+# closure form or an empty string.
+my $c = * + 1;
+is $c.raku, 'WhateverCode.new', 'WhateverCode .raku';
+is $c.perl, 'WhateverCode.new', 'WhateverCode .perl';
+is $c.gist, 'WhateverCode.new', 'WhateverCode .gist';
+
+my $d = *.abs;
+is $d.raku, 'WhateverCode.new', 'method-call WhateverCode .raku';
+
+# In a list / array .raku and .gist, each WhateverCode element renders too.
+is (* + 1, * - 1).raku, '(WhateverCode.new, WhateverCode.new)',
+    'WhateverCode elements in a list .raku';
+my @a = * + 1, * - 1;
+is @a.raku, '[WhateverCode.new, WhateverCode.new]', 'WhateverCode elements in an array .raku';
+is @a.gist, '[WhateverCode.new WhateverCode.new]', 'WhateverCode elements in an array .gist';
+
+# As a pair / hash value.
+is (a => * + 1).raku, ':a(WhateverCode.new)', 'WhateverCode as a pair value .raku';
+
+# The WhateverCode still works as a callable (the rendering change is cosmetic).
+is $c(5), 6, 'WhateverCode is still callable after rendering';
+is (* + 1)(10), 11, 'inline WhateverCode call works';
+
+# A regular block is NOT a WhateverCode and must not render as one.
+my $b = { $_ + 1 };
+isnt $b.raku, 'WhateverCode.new', 'a plain block does not render as WhateverCode';


### PR DESCRIPTION
## Summary

`.gist`, `.raku`, `.perl` and `say` on a **WhateverCode** (`*+1`, `*.abs`) produced the generic closure form or an empty string instead of `WhateverCode.new`:

```
$ mutsu -e 'my $c = *+1; say $c'
                             # empty (before)
WhateverCode.new             # after (matches raku)

$ mutsu -e 'say (*+1).raku'
                             # empty (before)
WhateverCode.new             # after
```

Rakudo renders any WhateverCode as `WhateverCode.new`.

## Fix

A WhateverCode can reach four distinct rendering paths; all four now special-case it:

| Path | File |
|------|------|
| `.gist`/`.raku`/`.perl` method fast path | `dispatch_core_repr.rs` |
| `say` / implicit-gist | `runtime::utils::gist_value` |
| list/array element `.raku` | `raku_repr::raku_value` |
| list/array element `.gist` | shared `leaf_gist` helper |

A WhateverCode is identified by its `Value::Sub` carrying `__mutsu_callable_type == "WhateverCode"`, so a plain block (`{ $_ + 1 }`) is unaffected. The change is purely cosmetic — the WhateverCode is still callable.

## Tests

New `t/whatevercode-gist-raku.t` (11 cases: scalar/list/array/pair rendering, still-callable, and a negative case for plain blocks). `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)