### PR TITLE
feat(state-ownership): native-ize Cool scalar `.IO` coercion (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -400,6 +400,17 @@
   （残るのは `Str.IO` coercion〔別操作・Str 受け手〕と `IO::Path::*.new`〔③ ctor〕）。pin `t/native-io-path-lexical.t`(40,
   literal `.IO` + 変数受け手〔mut path〕+ Win32 subclass round-trip・raku/mutsu 双方 PASS)。io-path.t の既存 fail 2
   （`.SPEC`/`.CWD` attribute）は main でも fail＝本変更と無関係。S16-io/S32-io/tmpdir/cwd/dir whitelist 全緑。
+- **2026-06-23 (§D = Cool scalar `.IO` coercion の VM ネイティブ化)**: IO::Path lexical スライス（上）の follow-up。
+  実測広がりで次点だった `.IO`(14 file・`"path".IO`/`$s.IO`/`42.IO`)＝Str/numeric を IO::Path へ coerce する fallback を
+  ドレイン。`.IO` は `dispatch_method_by_name` の arm（`make_io_path_instance(target.to_string_value())`＋null-byte check、
+  IO::Path 型オブジェクトは identity）で **`&self`＝`$*SPEC`/`$*CWD` を env から読む**＝pure ではないが VM は env を所有する
+  ので native 読み可。VM の非mut/mut 両 catch-all（iterator construct の後・最終 fallback 直前）に `try_native_io_coercion`
+  を追加し、**Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool 受け手 + IO::Path(-subclass) 型オブジェクト identity** を native 化、
+  **同じ `make_io_path_instance` を呼ぶ**＝1 操作 = 1 実装（interpreter dispatch は無改修・同 fn 共有）。Instance（user `.IO`/
+  IO::Path/IO::Handle）/ 非IO Package / aggregate / **Junction（autothread）** は `None` で interpreter 維持＝behavior-invariant
+  （`("a"|"b").IO` は Junction を返し parity 確認）。新 IO::Path を返し受け手を変異しない＝writeback 不要。実測:
+  `$s.IO`/`42.IO` の fallback → 0。pin `t/native-io-coercion.t`(18, literal/変数/numeric/型オブジェクト identity/null-byte
+  dies/Junction autothread/`$*CWD` 継承・raku/mutsu 双方 PASS)。S16-io/S32-io/tmpdir/cwd whitelist 全緑。
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -558,6 +558,12 @@ impl Interpreter {
         {
             return Ok(result);
         }
+        // Native `.IO` coercion over a Cool scalar (`"path".IO`, `42.IO`) — builds
+        // an IO::Path via the shared `make_io_path_instance` (ledger §D). Instance /
+        // non-IO Package / aggregate receivers fall through.
+        if let Some(result) = self.try_native_io_coercion(&target, method, &args) {
+            return result;
+        }
         // TODO: compile to bytecode — native/Buf/Failure method fork (ledger §1).
         // User-defined Instance methods now always run as bytecode (compiled at
         // registration, or on demand above via `populate_uncompiled_method`), so
@@ -1211,6 +1217,58 @@ impl Interpreter {
             "Hash" => crate::builtins::map_hash_coerce::to_hash(target, true),
             _ => unreachable!(),
         })
+    }
+
+    /// Interpreter-native `.IO` coercion over a `Cool` scalar receiver
+    /// (`"path".IO`, `42.IO`): constructs an `IO::Path` from the receiver's string
+    /// value via the single shared `make_io_path_instance` (which inherits `$*SPEC`
+    /// / `$*CWD` from env — a normal native env read, identical to the
+    /// interpreter's `dispatch_method_by_name` `.IO` arm). An `IO::Path`(-subclass)
+    /// *type object* (`Value::Package`) returns itself (`IO::Path === IO::Path.IO`).
+    ///
+    /// Returns `None` (fall through to the interpreter) for `Instance` receivers
+    /// (which may have a user `.IO` or be IO::Path/IO::Handle), non-IO `Package`
+    /// type objects, and aggregate / `Junction` receivers (which autothread or
+    /// have their own semantics) — only plain stringifiable scalars go native.
+    fn try_native_io_coercion(
+        &self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "IO" || !args.is_empty() {
+            return None;
+        }
+        match target {
+            // `.IO` on an IO::Path (sub)class type object returns the type object
+            // itself, so `IO::Path::Unix === IO::Path::Unix.IO`.
+            Value::Package(name) => {
+                let n = name.resolve();
+                if n == "IO::Path" || n.starts_with("IO::Path::") {
+                    Some(Ok(target.clone()))
+                } else {
+                    None
+                }
+            }
+            // Plain stringifiable scalars coerce their string value to an IO::Path.
+            Value::Str(_)
+            | Value::Int(_)
+            | Value::BigInt(_)
+            | Value::Num(_)
+            | Value::Rat(..)
+            | Value::FatRat(..)
+            | Value::Complex(..)
+            | Value::Bool(_) => {
+                let s = target.to_string_value();
+                if s.contains('\0') {
+                    return Some(Err(RuntimeError::new(
+                        "X::IO::Null: Found null byte in pathname",
+                    )));
+                }
+                Some(Ok(self.make_io_path_instance(&s)))
+            }
+            _ => None,
+        }
     }
 
     /// Interpreter-native `.iterator` construction, mirroring
@@ -1929,6 +1987,12 @@ impl Interpreter {
             && let Some(result) = crate::builtins::seq_coerce::to_seq_structural(&target)
         {
             return Ok(result);
+        }
+        // Native `.IO` coercion over a Cool scalar for variable receivers
+        // (`$s.IO`) — builds a *new* IO::Path and never mutates the receiver, so no
+        // writeback. Instance / non-IO Package / aggregate receivers fall through.
+        if let Some(result) = self.try_native_io_coercion(&target, method, &args) {
+            return result;
         }
         // TODO: compile to bytecode — native/Buf/Failure method fork, mut (ledger §1).
         // User-defined methods run as bytecode (compiled at registration or on

--- a/t/native-io-coercion.t
+++ b/t/native-io-coercion.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `.IO` coercion over a Cool scalar (`"path".IO`, `42.IO`) is dispatched natively
+# by the bytecode VM, constructing an IO::Path via the single shared
+# `make_io_path_instance` the interpreter also uses (so `$*SPEC`/`$*CWD` are
+# honored identically). An IO::Path(-subclass) *type object* returns itself.
+# Instance / non-IO Package / aggregate / Junction receivers fall through to the
+# interpreter (autothreading etc.), so behavior is unchanged.
+
+plan 18;
+
+# --- Str receiver (literal = non-mut path, variable = mut path) ---
+is "abc".IO.Str,        "abc",      "Str literal .IO";
+is "abc".IO.^name,      "IO::Path", ".IO produces an IO::Path";
+my $s = "/a/b/c";
+is $s.IO.Str,           "/a/b/c",   "Str variable .IO (mut path)";
+is $s.IO.parent.Str,    "/a/b",     ".IO chains into path methods";
+is $s, "/a/b/c",                    "receiver string is not mutated";
+
+# --- numeric Cool receivers stringify first ---
+is 42.IO.Str,           "42",       "Int .IO";
+is 3.14.IO.Str,         "3.14",     "Rat .IO";
+is True.IO.Str,         "True",     "Bool .IO";
+
+# --- IO::Path type object returns itself (identity) ---
+ok IO::Path.IO === IO::Path,                "IO::Path.IO is identity";
+ok IO::Path::Unix.IO === IO::Path::Unix,    "IO::Path::Unix.IO is identity";
+
+# --- an IO::Path instance round-trips (handled by the lexical native path) ---
+is "/x/y".IO.IO.Str,    "/x/y",     "IO::Path instance .IO preserves path";
+
+# --- null byte in the path string fails ---
+dies-ok { "a\0b".IO },                      ".IO with a null byte dies";
+
+# --- Junction receiver autothreads (falls through to the interpreter) ---
+my $j = ("a"|"b").IO;
+is $j.WHAT.^name,       "Junction", "Junction .IO autothreads to a Junction";
+ok so($j.basename eq "a" | "b"),            "autothreaded IO::Path basenames";
+
+# --- $*CWD is inherited by a relative .IO (shared make_io_path_instance) ---
+{
+    my $*CWD = "/base".IO;
+    is "rel".IO.CWD, "/base", "relative .IO inherits \$*CWD";
+}
+
+# --- a list/array .IO is not intercepted (interpreter coerces the list) ---
+my @a = "x", "y";
+ok @a.IO ~~ IO::Path,                       "Array .IO still yields an IO::Path";
+
+# --- chained from a numeric ---
+is 100.IO.sibling("s").Str, "s",            "numeric .IO chains into path methods";
+
+# --- gist round-trip ---
+is "/foo".IO.gist, '"/foo".IO',             ".IO then gist";


### PR DESCRIPTION
## Summary

Follow-up to #3490 (IO::Path lexical methods). The next-broadest measured
method-fallback (by distinct-file count) is `.IO` — the Str/numeric → IO::Path
coercion — appearing in 14 whitelist files (`"path".IO`, `$s.IO`, `42.IO`).

## What changed

`.IO` constructs an IO::Path via `make_io_path_instance(target.to_string_value())`
(null-byte check; an IO::Path-subclass *type object* returns itself). That helper
is `&self` because it inherits `$*SPEC`/`$*CWD` from env — a normal native env
read (not tree-walk), and the VM owns env, so it can call it directly.

`try_native_io_coercion` is added to **both** the non-mut and mut VM catch-alls
(after iterator construction, just before the final interpreter fallback). It
handles **Str / Int / BigInt / Num / Rat / FatRat / Complex / Bool** receivers
plus the **IO::Path type-object identity**, calling the same
`make_io_path_instance` the interpreter's `dispatch_method_by_name` `.IO` arm
uses (**1 operation = 1 implementation**; the interpreter dispatch is untouched).

Instance (user `.IO` / IO::Path / IO::Handle), non-IO Package, aggregate, and
**Junction (autothreading)** receivers return `None` and fall through →
**behavior-invariant** (`("a"|"b").IO` still yields a Junction). The coercion
returns a new IO::Path and never mutates the receiver — no writeback on the mut
path.

## Verification

- `$s.IO` / `42.IO` fallbacks drain to **0**.
- S16-io / S32-io / tmpdir / cwd whitelist all green; `make test` PASS (10608).
- pin: `t/native-io-coercion.t` (18 subtests — literal/variable/numeric
  receivers, type-object identity, null-byte dies, Junction autothread, `$*CWD`
  inheritance, raku/mutsu parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)