### PR TITLE
fix(Match.raku): close the :list(( ... )) paren for positional captures

### DIFF
--- a/src/builtins/methods_0arg/match_helpers.rs
+++ b/src/builtins/methods_0arg/match_helpers.rs
@@ -38,7 +38,9 @@ pub(super) fn match_raku_repr(attributes: &HashMap<String, Value>) -> String {
     {
         let items_raku: Vec<String> = items.iter().map(value_raku_repr).collect();
         let trailing = if items.len() == 1 { "," } else { "" };
-        parts.push(format!(":list(({}{})", items_raku.join(", "), trailing));
+        // `:list(( ... ))`: an outer paren for the `:list(...)` adverb plus an
+        // inner paren for the captured List literal — both must be closed.
+        parts.push(format!(":list(({}{}))", items_raku.join(", "), trailing));
     }
 
     // Named captures (:hash)

--- a/t/match-raku-list-parens.t
+++ b/t/match-raku-list-parens.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 6;
+
+# A Match with positional captures renders `.raku` with a balanced
+# `:list(( ... ))` — an outer paren for the adverb and an inner paren for
+# the captured List. The closing paren of the adverb must not be dropped.
+sub balanced($s) { $s.comb('(').elems == $s.comb(')').elems }
+
+"hello world" ~~ /(\w+) \s+ (\w+)/;
+my $two = $/.raku;
+ok balanced($two), 'two-capture Match .raku has balanced parens';
+is $two,
+   'Match.new(:orig("hello world"), :from(0), :pos(11), :list((Match.new(:orig("hello world"), :from(0), :pos(5)), Match.new(:orig("hello world"), :from(6), :pos(11)))))',
+   'two-capture Match .raku matches Rakudo';
+
+"ab" ~~ /(.)/;
+my $one = $/.raku;
+ok balanced($one), 'single-capture Match .raku has balanced parens';
+is $one,
+   'Match.new(:orig("ab"), :from(0), :pos(1), :list((Match.new(:orig("ab"), :from(0), :pos(1)),)))',
+   'single-capture Match .raku has the trailing comma and balanced parens';
+
+# .raku output must EVAL back to an equivalent Match.
+"xy" ~~ /(.)(.)/;
+my $m = $/.raku.EVAL;
+is $m.list.elems, 2, 'Match .raku round-trips via EVAL (positional count)';
+is ~$m, 'xy', 'round-tripped Match stringifies to the matched text';


### PR DESCRIPTION
## Summary

A `Match` with positional captures rendered `.raku` with an **unbalanced** paren — the closing paren of the `:list(...)` adverb was dropped:

```
$ mutsu -e '"hello world" ~~ /(\w+) \s+ (\w+)/; print $/.raku'
... :pos(11))))      # before — 14 "(" but only 13 ")"
... :pos(11)))))     # after  — balanced, matches raku
```

`:list((...))` needs two parens — an outer one for the `:list(...)` adverb and an inner one for the captured `List` literal — but the code only emitted one closer. The result was not valid Raku and would not round-trip through `EVAL`.

## Tests

New `t/match-raku-list-parens.t` (6 cases: two-capture, single-capture-with-trailing-comma, balanced-paren check, and an `EVAL` round-trip). The whitelisted `roast/S05-match/raku.t` still passes; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)