### PR TITLE
fix(coerce): empty/whitespace string coerces to 0 for .Int/.Num/.UInt

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -465,7 +465,11 @@ pub(super) fn dispatch(
                     Value::Int((n.as_ref() / d.as_ref()).to_i64().unwrap_or(i64::MAX))
                 }
                 Value::Str(s) => {
-                    if let Some(v) = parse_raku_int_from_str(s) {
+                    if s.trim().is_empty() {
+                        // An empty or whitespace-only string coerces to 0, like
+                        // `"".Numeric` (a defined-but-empty string, no warning).
+                        Value::Int(0)
+                    } else if let Some(v) = parse_raku_int_from_str(s) {
                         v
                     } else {
                         // Return a Failure (lazy exception) instead of throwing
@@ -525,6 +529,7 @@ pub(super) fn dispatch(
                 Value::Num(f) if f.is_finite() => Some(Value::Int(f.trunc() as i64)),
                 Value::Rat(n, d) if *d != 0 => Some(Value::Int(*n / *d)),
                 Value::Bool(b) => Some(Value::Int(if *b { 1 } else { 0 })),
+                Value::Str(s) if s.trim().is_empty() => Some(Value::Int(0)),
                 Value::Str(s) => {
                     if let Some(v) = parse_raku_int_from_str(s) {
                         Some(v)
@@ -626,14 +631,20 @@ pub(super) fn dispatch(
                 }
                 Value::Str(s) => {
                     let trimmed = s.trim();
-                    // Normalize U+2212 MINUS SIGN to ASCII hyphen-minus
-                    let normalized = trimmed.replace('\u{2212}', "-");
-                    if let Ok(f) = normalized.parse::<f64>() {
-                        Value::Num(f)
+                    if trimmed.is_empty() {
+                        // An empty or whitespace-only string coerces to 0, like
+                        // `"".Numeric`.
+                        Value::Num(0.0)
                     } else {
-                        // An invalid string yields a lazy X::Str::Numeric Failure,
-                        // mirroring `.Int` (not an eager X::AdHoc RuntimeError).
-                        return Some(Some(Ok(str_numeric_failure(s))));
+                        // Normalize U+2212 MINUS SIGN to ASCII hyphen-minus
+                        let normalized = trimmed.replace('\u{2212}', "-");
+                        if let Ok(f) = normalized.parse::<f64>() {
+                            Value::Num(f)
+                        } else {
+                            // An invalid string yields a lazy X::Str::Numeric Failure,
+                            // mirroring `.Int` (not an eager X::AdHoc RuntimeError).
+                            return Some(Some(Ok(str_numeric_failure(s))));
+                        }
                     }
                 }
                 Value::Bool(b) => Value::Num(if *b { 1.0 } else { 0.0 }),

--- a/t/empty-str-numeric-coerce.t
+++ b/t/empty-str-numeric-coerce.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 14;
+
+# An empty or whitespace-only string coerces to 0 for .Int / .Num / .UInt,
+# consistent with .Numeric (the string is defined-but-empty, so no failure).
+is "".Int, 0, 'empty string .Int is 0';
+is "   ".Int, 0, 'whitespace-only string .Int is 0';
+is "\t\n".Int, 0, 'tab/newline string .Int is 0';
+is "".Int.WHAT.raku, 'Int', 'empty string .Int is an Int';
+
+is "".Num, 0, 'empty string .Num is 0';
+is "  ".Num, 0, 'whitespace-only string .Num is 0';
+is "".Num.WHAT.raku, 'Num', 'empty string .Num is a Num';
+
+is "".UInt, 0, 'empty string .UInt is 0';
+is "  ".UInt, 0, 'whitespace-only string .UInt is 0';
+
+# Consistency with .Numeric and prefix + (which already returned 0).
+is "".Numeric, 0, 'empty string .Numeric is 0';
+is (+""), 0, 'prefix + on empty string is 0';
+
+# Genuinely non-numeric strings still fail (a Failure, not silently 0).
+ok "abc".Int ~~ Failure, 'non-numeric .Int still produces a Failure';
+is "5".Int, 5, 'a valid numeric string still coerces';
+is "3.14".Num, 3.14e0, 'a valid float string still coerces';


### PR DESCRIPTION
## Summary

`"".Int`, `"".Num` and `"".UInt` (and whitespace-only strings) threw an `X::Str::Numeric` Failure, while `"".Numeric` and prefix `+""` already returned `0`. Per Rakudo, a *defined-but-empty* string numifies to `0` with no warning, so all numeric coercions should agree:

```
"".Int    # 0  (was: Failure)
"  ".Num  # 0  (was: Failure)
"".UInt   # 0  (was: Failure)
```

Genuinely non-numeric strings (`"abc".Int`) still produce a Failure — only the empty/whitespace case is now `0`.

## Tests

New `t/empty-str-numeric-coerce.t` (14 cases incl. type checks, the still-failing `"abc".Int`, and consistency with `.Numeric`/prefix `+`). `S32-num/int` passes; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)