### PR TITLE
feat(state-ownership): native-ize IO::Path `.absolute`/`.relative` (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -411,6 +411,21 @@
   （`("a"|"b").IO` は Junction を返し parity 確認）。新 IO::Path を返し受け手を変異しない＝writeback 不要。実測:
   `$s.IO`/`42.IO` の fallback → 0。pin `t/native-io-coercion.t`(18, literal/変数/numeric/型オブジェクト identity/null-byte
   dies/Junction autothread/`$*CWD` 継承・raku/mutsu 双方 PASS)。S16-io/S32-io/tmpdir/cwd whitelist 全緑。
+- **2026-06-23 (§D = `IO::Path.absolute`/`.relative` の VM ネイティブ化)**: IO::Path lexical スライスの cwd 依存 follow-up。
+  `.absolute`/`.relative` は path 文字列に **cwd**（`$*CWD`/instance `cwd` 属性/プロセス cwd）を組み合わせて文字列を導出するが、
+  cwd は `&self` の `resolve_path`/`get_cwd_path`/`apply_chroot` 経由で読み、これらは **純 lexical（FS stat なし）**＝`.IO` 同様
+  VM が env/cwd を所有するので native dispatch 可。新 `&self` メソッド `try_io_path_cwd_method`（win32/cygwin/posix の base 引数・
+  `$*CWD` fallback 全分岐を保持）へ抽出し、`native_io_path` は `try_io_path_lexical` の直後で委譲＝**1 操作 = 1 実装**（`absolute`/
+  `relative` arm を削除）。VM は IO::Path lexical dispatch の隣（`is_native_method` バウンス直前・非mut/mut 両 path）で呼ぶ。
+  `.resolve`（実 FS canonicalize）は `None` で `native_io_path` 維持。新 string を返し受け手非変異＝writeback 不要・behavior-invariant。
+  実測: `$p.absolute`/`.relative` の fallback → 0。pin `t/native-io-path-cwd.t`(14, `$*CWD`/instance cwd/explicit base/変数受け手/
+  round-trip・raku/mutsu 双方 PASS)。io-path.t の既存 fail 2（`.SPEC`/`.CWD`）は不変。S16-io/S32-io/tmpdir/cwd whitelist 全緑。
+- **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
+  到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
+  `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`
+  でゲートされず arm 1499 より前で interpreter 特殊処理されるため、`to_string_value()` で native 化すると壊れる（say.t/buf.t/
+  attributes.t で回帰確認）。`has_user_method`/`has_public_accessor`/built-in 型除外を足しても landmine が次々顕在化＝列挙不能で
+  安全に分離できないため見送り。clean な §D coercion 成果は IO::Path family（lexical/`.IO`/absolute-relative）で確定。
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -464,6 +464,135 @@ impl Interpreter {
         Some(result)
     }
 
+    /// `.absolute` / `.relative` on an `IO::Path`: like [`try_io_path_lexical`],
+    /// these derive a string from the path, but additionally depend on the
+    /// **cwd** (`$*CWD` / the instance `cwd` attribute / the process cwd) — read
+    /// through `&self` (`resolve_path`/`get_cwd_path`/`apply_chroot`), which are
+    /// purely lexical (no filesystem access). The VM owns env/cwd, so this is a
+    /// native dispatch; the single shared impl that `native_io_path` delegates to.
+    /// Returns `None` for any other method (`.resolve` canonicalizes against the
+    /// real filesystem and stays in `native_io_path`).
+    pub(crate) fn try_io_path_cwd_method(
+        &self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(method, "absolute" | "relative") {
+            return None;
+        }
+        let p = attributes
+            .get("path")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let instance_cwd = attributes.get("cwd").map(|v| v.to_string_value());
+        let path_buf = if Path::new(&p).is_absolute() {
+            self.resolve_path(&p)
+        } else if let Some(cwd) = &instance_cwd {
+            self.apply_chroot(PathBuf::from(cwd).join(Path::new(&p)))
+        } else {
+            self.resolve_path(&p)
+        };
+        let cwd_path = self.get_cwd_path();
+        let original = Path::new(&p);
+        Some(match method {
+            "absolute" => {
+                if Self::is_win32_spec(attributes) {
+                    let base = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .or_else(|| instance_cwd.clone())
+                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                    let abs = if Self::io_path_is_absolute_win32(&p) {
+                        p.clone()
+                    } else {
+                        let sep = '\\';
+                        if base.ends_with('\\') || base.ends_with('/') {
+                            format!("{}{}", base, p)
+                        } else {
+                            format!("{}{}{}", base, sep, p)
+                        }
+                    };
+                    let cleaned = Self::canonpath_win32(&abs, false);
+                    Ok(Value::str(cleaned))
+                } else if Self::is_cygwin_spec(attributes) {
+                    let base = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .or_else(|| instance_cwd.clone())
+                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                    let pn = p.replace('\\', "/");
+                    let abs = if Self::io_path_is_absolute_win32(&pn) {
+                        pn
+                    } else {
+                        let bn = base.replace('\\', "/");
+                        if bn.ends_with('/') {
+                            format!("{}{}", bn, pn)
+                        } else {
+                            format!("{}/{}", bn, pn)
+                        }
+                    };
+                    Ok(Value::str(Self::canonpath_cygwin(&abs, false)))
+                } else {
+                    let base = args.first().map(|v| v.to_string_value());
+                    if let Some(base) = base {
+                        if original.is_absolute() {
+                            Ok(Value::str(p.clone()))
+                        } else {
+                            let joined = PathBuf::from(&base).join(&p);
+                            Ok(Value::str(Self::stringify_path(&joined)))
+                        }
+                    } else {
+                        let absolute = Self::stringify_path(&path_buf);
+                        Ok(Value::str(absolute))
+                    }
+                }
+            }
+            "relative" => {
+                if Self::is_win32_spec(attributes) {
+                    let base = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .or_else(|| instance_cwd.clone())
+                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                    let norm_p = p.replace('/', "\\");
+                    let norm_base = base.replace('/', "\\");
+                    let rel = norm_p
+                        .strip_prefix(&norm_base)
+                        .and_then(|r| r.strip_prefix('\\'))
+                        .unwrap_or(&norm_p);
+                    Ok(Value::str(rel.to_string()))
+                } else if Self::is_cygwin_spec(attributes) {
+                    let base = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .or_else(|| instance_cwd.clone())
+                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
+                    let norm_p = p.replace('\\', "/");
+                    let norm_base = base.replace('\\', "/");
+                    let rel = norm_p
+                        .strip_prefix(&norm_base)
+                        .and_then(|r| r.strip_prefix('/'))
+                        .unwrap_or(&norm_p);
+                    Ok(Value::str(rel.to_string()))
+                } else {
+                    let rel_base_arg = args.first().map(|v| v.to_string_value());
+                    let rel_base = rel_base_arg
+                        .as_ref()
+                        .map(PathBuf::from)
+                        .or_else(|| instance_cwd.as_ref().map(PathBuf::from))
+                        .unwrap_or_else(|| cwd_path.clone());
+                    let rel = path_buf
+                        .strip_prefix(&rel_base)
+                        .map(Self::stringify_path)
+                        .unwrap_or_else(|_| Self::stringify_path(&path_buf));
+                    Ok(Value::str(rel))
+                }
+            }
+            _ => unreachable!(),
+        })
+    }
+
     pub(super) fn native_io_path(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -476,6 +605,12 @@ impl Interpreter {
         // the bytecode VM dispatches natively). Only the filesystem / cwd-relative
         // forms below need `&self`.
         if let Some(result) = Self::try_io_path_lexical(class_name, attributes, method, &args) {
+            return result;
+        }
+        // `.absolute` / `.relative` derive a string from the path + cwd (lexical,
+        // no filesystem) — handled by the shared `try_io_path_cwd_method` the VM
+        // also dispatches natively.
+        if let Some(result) = self.try_io_path_cwd_method(attributes, method, &args) {
             return result;
         }
         // The concrete class of the receiver (`IO::Path` or a SPEC-variant
@@ -612,102 +747,6 @@ impl Interpreter {
                     }
                 }
                 Ok(child)
-            }
-            "absolute" => {
-                if Self::is_win32_spec(attributes) {
-                    let base = args
-                        .first()
-                        .map(|v| v.to_string_value())
-                        .or_else(|| instance_cwd.clone())
-                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
-                    let abs = if Self::io_path_is_absolute_win32(&p) {
-                        p.clone()
-                    } else {
-                        let sep = '\\';
-                        if base.ends_with('\\') || base.ends_with('/') {
-                            format!("{}{}", base, p)
-                        } else {
-                            format!("{}{}{}", base, sep, p)
-                        }
-                    };
-                    // Canonicalize the result
-                    let cleaned = Self::canonpath_win32(&abs, false);
-                    Ok(Value::str(cleaned))
-                } else if Self::is_cygwin_spec(attributes) {
-                    let base = args
-                        .first()
-                        .map(|v| v.to_string_value())
-                        .or_else(|| instance_cwd.clone())
-                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
-                    let pn = p.replace('\\', "/");
-                    let abs = if Self::io_path_is_absolute_win32(&pn) {
-                        pn
-                    } else {
-                        let bn = base.replace('\\', "/");
-                        if bn.ends_with('/') {
-                            format!("{}{}", bn, pn)
-                        } else {
-                            format!("{}/{}", bn, pn)
-                        }
-                    };
-                    Ok(Value::str(Self::canonpath_cygwin(&abs, false)))
-                } else {
-                    let base = args.first().map(|v| v.to_string_value());
-                    if let Some(base) = base {
-                        if original.is_absolute() {
-                            Ok(Value::str(p.clone()))
-                        } else {
-                            let joined = PathBuf::from(&base).join(&p);
-                            Ok(Value::str(Self::stringify_path(&joined)))
-                        }
-                    } else {
-                        let absolute = Self::stringify_path(&path_buf);
-                        Ok(Value::str(absolute))
-                    }
-                }
-            }
-            "relative" => {
-                if Self::is_win32_spec(attributes) {
-                    let base = args
-                        .first()
-                        .map(|v| v.to_string_value())
-                        .or_else(|| instance_cwd.clone())
-                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
-                    // Normalize separators for comparison
-                    let norm_p = p.replace('/', "\\");
-                    let norm_base = base.replace('/', "\\");
-                    let rel = norm_p
-                        .strip_prefix(&norm_base)
-                        .and_then(|r| r.strip_prefix('\\'))
-                        .unwrap_or(&norm_p);
-                    Ok(Value::str(rel.to_string()))
-                } else if Self::is_cygwin_spec(attributes) {
-                    let base = args
-                        .first()
-                        .map(|v| v.to_string_value())
-                        .or_else(|| instance_cwd.clone())
-                        .unwrap_or_else(|| Self::stringify_path(&cwd_path));
-                    // Normalize separators for comparison (Cygwin uses forward slashes).
-                    let norm_p = p.replace('\\', "/");
-                    let norm_base = base.replace('\\', "/");
-                    let rel = norm_p
-                        .strip_prefix(&norm_base)
-                        .and_then(|r| r.strip_prefix('/'))
-                        .unwrap_or(&norm_p);
-                    Ok(Value::str(rel.to_string()))
-                } else {
-                    let rel_base_arg = args.first().map(|v| v.to_string_value());
-                    let rel_base = rel_base_arg
-                        .as_ref()
-                        .map(PathBuf::from)
-                        .or_else(|| instance_cwd.as_ref().map(PathBuf::from))
-                        .unwrap_or_else(|| cwd_path.clone());
-                    let rel = path_buf
-                        .strip_prefix(&rel_base)
-                        .map(Self::stringify_path)
-                        .unwrap_or_else(|_| Self::stringify_path(&path_buf));
-                    Ok(Value::str(rel))
-                }
             }
             "resolve" => {
                 let completely = Self::named_bool(&args, "completely");

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -207,6 +207,15 @@ impl Interpreter {
             {
                 return result;
             }
+            // Interpreter-native `.absolute` / `.relative` (path + cwd, lexical — no
+            // filesystem; the VM owns env/cwd). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    self.try_io_path_cwd_method(&attributes.as_map(), method, &args)
+            {
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
@@ -1706,6 +1715,15 @@ impl Interpreter {
                 && let Value::Instance { attributes, .. } = &target
                 && let Some(result) =
                     Self::try_io_path_lexical(&class, &attributes.as_map(), method, &args)
+            {
+                return result;
+            }
+            // Interpreter-native `.absolute` / `.relative` (path + cwd, lexical — no
+            // filesystem; the VM owns env/cwd). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    self.try_io_path_cwd_method(&attributes.as_map(), method, &args)
             {
                 return result;
             }

--- a/t/native-io-path-cwd.t
+++ b/t/native-io-path-cwd.t
@@ -1,0 +1,45 @@
+use Test;
+
+# `.absolute` / `.relative` on an IO::Path derive a string from the path and the
+# cwd ($*CWD / the instance cwd / the process cwd). The cwd is read through
+# `&self` helpers (resolve_path/get_cwd_path/apply_chroot) that are purely
+# lexical (no filesystem access), so the bytecode VM dispatches them natively,
+# sharing the single impl the interpreter's `native_io_path` also uses.
+
+plan 14;
+
+{
+    my $*CWD = "/base/dir".IO;
+
+    # --- .absolute ---
+    is "rel/x".IO.absolute,        "/base/dir/rel/x", "absolute of relative uses \$*CWD";
+    is "/abs/y".IO.absolute,       "/abs/y",          "absolute of already-absolute is itself";
+    is "rel/x".IO.absolute("/o"),  "/o/rel/x",        "absolute with an explicit base";
+    is "/abs/y".IO.absolute("/o"), "/abs/y",          "absolute base ignored when already absolute";
+
+    # --- .relative ---
+    is "/base/dir/sub/f".IO.relative,          "sub/f", "relative strips \$*CWD prefix";
+    is "/base/dir/sub/f".IO.relative("/base"), "dir/sub/f", "relative with an explicit base";
+    is "/elsewhere/g".IO.relative,             "/elsewhere/g", "relative of a non-descendant is unchanged";
+
+    # --- variable receiver (mut dispatch path) ---
+    my $p = "data/file".IO;
+    is $p.absolute,            "/base/dir/data/file", "absolute (variable receiver)";
+    is $p.relative("/base"),   "dir/data/file",       "relative (variable receiver)";
+    is $p.Str,                 "data/file",           "receiver not mutated by absolute/relative";
+
+    # --- chaining ---
+    is "a/b/c".IO.parent.absolute, "/base/dir/a/b", "parent then absolute";
+}
+
+# --- the instance's own cwd attribute wins over the process cwd ---
+my $rooted = IO::Path.new("rel", :CWD("/inst"));
+is $rooted.absolute, "/inst/rel", "instance cwd attribute drives absolute";
+
+# --- absolute/relative round-trip ---
+{
+    my $*CWD = "/home/u".IO;
+    my $abs = "proj/main".IO.absolute;
+    is $abs, "/home/u/proj/main",                "round-trip: absolute";
+    is $abs.IO.relative, "proj/main",            "round-trip: relative recovers the path";
+}


### PR DESCRIPTION
## Summary

Cwd-dependent follow-up to #3490 (IO::Path lexical methods) and #3492 (`.IO`
coercion). `.absolute` / `.relative` derive a string from the path **plus the
cwd** (`$*CWD` / the instance `cwd` attribute / the process cwd).

The cwd is read through the `&self` helpers `resolve_path` / `get_cwd_path` /
`apply_chroot`, which are **purely lexical (no filesystem access)** — so, exactly
like `.IO`, the VM owns env/cwd and can dispatch these natively.

## What changed

- Extract the two arms into a new `&self` method `try_io_path_cwd_method`
  (preserving the win32 / cygwin / posix branches, the explicit-base argument,
  and the `$*CWD` fallback).
- `native_io_path` delegates to it right after `try_io_path_lexical` and the
  `absolute`/`relative` arms are removed (**1 operation = 1 implementation**).
- The VM calls it next to the IO::Path lexical dispatch in **both** the non-mut
  and mut paths, gated to the built-in IO::Path family.
- `.resolve` (canonicalizes against the real filesystem) returns `None` and stays
  in `native_io_path`.

The methods return a new string and never mutate the receiver — no writeback,
**behavior-invariant**.

## Verification

- `$p.absolute` / `$p.relative` fallbacks drain to **0**; values match raku.
- io-path.t's pre-existing `.SPEC`/`.CWD` failures unchanged;
  S16-io/S32-io/tmpdir/cwd whitelist green; `make test` PASS (10646).
- pin: `t/native-io-path-cwd.t` (14 subtests — `$*CWD` / instance cwd / explicit
  base / variable receiver / round-trip, raku/mutsu parity).

### Also recorded in the ledger
A note documenting why the broader generic `Instance.Str`/`.Stringy` coercion was
**not** native-ized: VM-catch-all Instance `.Str` is not cleanly the
`to_string_value()` case — `Buf.Str` throws `X::Buf::AsStr`, `Attribute.Str` is
the name, and a `has $.Str` public accessor returns the attribute. These are
special-cased before the interpreter's default arm and aren't gated by
`is_native_method`, so a generic native path regresses them (caught locally in
say.t/buf.t/attributes.t).

🤖 Generated with [Claude Code](https://claude.com/claude-code)