### PR TITLE
fix(X::Str::Numeric): populate .source-indicator with pos-aware split

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -8,54 +8,42 @@ use std::sync::Arc;
 
 use super::parse_raku_int_from_str;
 
-/// Build a lazy `Failure` wrapping an `X::Str::Numeric` exception for a string
-/// that cannot be numified — the shape raku's `.Int`/`.Num` produce on a bad
-/// string (the exception only fires when the Failure is sunk/used).
-/// Escape control characters the way Raku renders them inside an
-/// `X::Str::Numeric.source-indicator` (backspace → `\b`, tab → `\t`, …),
-/// leaving printable characters untouched.
-fn escape_for_source_indicator(s: &str) -> String {
-    let mut out = String::new();
-    for c in s.chars() {
-        match c {
-            '\u{8}' => out.push_str("\\b"),
-            '\t' => out.push_str("\\t"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\u{c}' => out.push_str("\\f"),
-            '\0' => out.push_str("\\0"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\x[{:X}]", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out
-}
-
-pub(crate) fn str_numeric_failure(s: &str) -> Value {
+/// Build the `X::Str::Numeric` attribute map for a string that cannot be
+/// numified, deriving `pos`/`reason` from the same analyzer the numeric
+/// operators use (so `"5 foo"` reports `trailing characters after number` at
+/// pos 1, not a blanket "must begin with valid digits" at pos 0), and the
+/// matching `source-indicator`.
+fn str_numeric_exception_attrs(s: &str) -> std::collections::HashMap<String, Value> {
+    let (pos, reason) = crate::runtime::str_numeric::str_numeric_failure(s).unwrap_or((
+        0,
+        "base-10 number must begin with valid digits or '.'".to_string(),
+    ));
     let mut ex_attrs = std::collections::HashMap::new();
     ex_attrs.insert("source".to_string(), Value::str(s.to_string()));
-    ex_attrs.insert(
-        "reason".to_string(),
-        Value::str("base-10 number must begin with valid digits or '.'".to_string()),
-    );
-    ex_attrs.insert("pos".to_string(), Value::Int(0));
-    // The visual indicator marks where numification failed with `⏏` (U+23CF).
-    // The bad string follows the marker (pos 0), with control characters escaped.
+    ex_attrs.insert("reason".to_string(), Value::str(reason.clone()));
+    ex_attrs.insert("pos".to_string(), Value::Int(pos as i64));
     ex_attrs.insert(
         "source-indicator".to_string(),
-        Value::str(format!(
-            "in '\u{23CF}{}' (indicated by \u{23CF})",
-            escape_for_source_indicator(s)
-        )),
+        Value::str(crate::runtime::str_numeric::build_source_indicator(s, pos)),
     );
     ex_attrs.insert(
         "message".to_string(),
         Value::str(format!(
-            "Cannot convert string to number: base-10 number must begin with valid digits or '.' in '{}'",
-            s
+            "Cannot convert string to number: {} in '{}'",
+            reason, s
         )),
     );
-    let ex = Value::make_instance(Symbol::intern("X::Str::Numeric"), ex_attrs);
+    ex_attrs
+}
+
+/// Build a lazy `Failure` wrapping an `X::Str::Numeric` exception for a string
+/// that cannot be numified — the shape raku's `.Int`/`.Num` produce on a bad
+/// string (the exception only fires when the Failure is sunk/used).
+pub(crate) fn str_numeric_failure(s: &str) -> Value {
+    let ex = Value::make_instance(
+        Symbol::intern("X::Str::Numeric"),
+        str_numeric_exception_attrs(s),
+    );
     let mut failure_attrs = std::collections::HashMap::new();
     failure_attrs.insert("exception".to_string(), ex);
     failure_attrs.insert("handled".to_string(), Value::Bool(false));
@@ -472,34 +460,8 @@ pub(super) fn dispatch(
                     } else if let Some(v) = parse_raku_int_from_str(s) {
                         v
                     } else {
-                        // Return a Failure (lazy exception) instead of throwing
-                        let mut ex_attrs = std::collections::HashMap::new();
-                        ex_attrs.insert("source".to_string(), Value::str(s.to_string()));
-                        ex_attrs.insert(
-                            "reason".to_string(),
-                            Value::str(
-                                "base-10 number must begin with valid digits or '.'".to_string(),
-                            ),
-                        );
-                        ex_attrs.insert("pos".to_string(), Value::Int(0));
-                        ex_attrs.insert(
-                            "message".to_string(),
-                            Value::str(format!(
-                                "Cannot convert string to number: base-10 number must begin with valid digits or '.' in '{}'",
-                                s
-                            )),
-                        );
-                        let ex = Value::make_instance(
-                            crate::symbol::Symbol::intern("X::Str::Numeric"),
-                            ex_attrs,
-                        );
-                        let mut failure_attrs = std::collections::HashMap::new();
-                        failure_attrs.insert("exception".to_string(), ex);
-                        failure_attrs.insert("handled".to_string(), Value::Bool(false));
-                        return Some(Some(Ok(Value::make_instance(
-                            crate::symbol::Symbol::intern("Failure"),
-                            failure_attrs,
-                        ))));
+                        // Return a Failure (lazy exception) instead of throwing.
+                        return Some(Some(Ok(str_numeric_failure(s))));
                     }
                 }
                 Value::Bool(b) => Value::Int(if *b { 1 } else { 0 }),

--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -82,6 +82,40 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
 /// `pos` is the 0-based character index at which parsing stopped and `reason`
 /// is the human-readable explanation. Returns `None` when the string actually
 /// IS a valid number (so callers can treat `None` as "no error").
+/// Escape control characters the way Raku renders them inside an
+/// `X::Str::Numeric.source-indicator` (backspace -> `\b`, tab -> `\t`, ...),
+/// leaving printable characters untouched.
+pub(crate) fn escape_for_source_indicator(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        match c {
+            '\u{8}' => out.push_str("\\b"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{c}' => out.push_str("\\f"),
+            '\0' => out.push_str("\\0"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\x[{:X}]", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Build the `source-indicator` string Raku attaches to an `X::Str::Numeric`:
+/// the source split at character position `pos` with a `U+23CF` marker showing
+/// where numification stopped, control characters escaped. For example
+/// `("5 foo", 1)` yields `in '5<EJECT> foo' (indicated by <EJECT>)`.
+pub(crate) fn build_source_indicator(source: &str, pos: usize) -> String {
+    let good: String = source.chars().take(pos).collect();
+    let bad: String = source.chars().skip(pos).collect();
+    format!(
+        "in '{}\u{23CF}{}' (indicated by \u{23CF})",
+        escape_for_source_indicator(&good),
+        escape_for_source_indicator(&bad)
+    )
+}
+
 pub(crate) fn str_numeric_failure(s: &str) -> Option<(usize, String)> {
     if parse_raku_str_to_numeric(s).is_some() {
         return None;

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3205,6 +3205,12 @@ pub(crate) fn str_numeric_error(source: &str, pos: usize, reason: &str) -> Runti
     attrs.insert("pos".to_string(), Value::Int(pos as i64));
     attrs.insert("reason".to_string(), Value::str(reason.to_string()));
     attrs.insert("target-name".to_string(), Value::str("Numeric".to_string()));
+    attrs.insert(
+        "source-indicator".to_string(),
+        Value::str(crate::runtime::str_numeric::build_source_indicator(
+            source, pos,
+        )),
+    );
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     let ex = Value::make_instance(crate::symbol::Symbol::intern("X::Str::Numeric"), attrs);
     let mut err = RuntimeError::new(&msg);

--- a/t/str-numeric-error.t
+++ b/t/str-numeric-error.t
@@ -4,15 +4,17 @@ use Test;
 # carrying source / pos / reason, instead of silently coercing to 0.
 # (Numeric comparison is intentionally left lenient — see infix_is_strictly_numeric.)
 
-plan 8;
+plan 14;
 
 throws-like 'use fatal; my $x = "5 foo" + 8;', X::Str::Numeric,
     'trailing characters after a number',
-    source => '5 foo', pos => 1, reason => /:i trailing/;
+    source => '5 foo', pos => 1, reason => /:i trailing/,
+    source-indicator => /'5' .* ' foo'/;
 
 throws-like 'use fatal; my $x = "foo" + 1;', X::Str::Numeric,
     'no leading number',
-    source => 'foo', pos => 0, reason => /:i begin/;
+    source => 'foo', pos => 0, reason => /:i begin/,
+    source-indicator => /'foo'/;
 
 throws-like 'use fatal; my $x = "5 foo" * 2;', X::Str::Numeric,
     'multiplication also coerces strictly';
@@ -25,3 +27,21 @@ is "5" + 8, 13, 'plain integer string';
 is "5.5" + 1, 6.5, 'decimal string';
 is "  10  " + 2, 12, 'surrounding whitespace is fine';
 is "1_000" + 1, 1001, 'underscores in number';
+
+# The lazy `.Int`/`.Num` Failure path carries the same pos/reason/indicator as
+# the eager arithmetic path (it must not blanket every bad string to pos 0).
+{
+    my $n = "12abc".Int;
+    isa-ok $n, Failure, '"12abc".Int is a Failure';
+    try { $n.sink }   # vivify the exception so $! is populated
+    is $!.pos, 2, '.Int reports trailing-character position';
+    like $!.reason, /:i trailing/, '.Int trailing reason';
+    like $!.source-indicator, /'12' .* 'abc'/, '.Int source-indicator splits at pos';
+}
+
+{
+    my $n = "abc".Int;
+    try { $n.sink }
+    is $!.pos, 0, '.Int must-begin position';
+    like $!.source-indicator, /'abc'/, '.Int must-begin source-indicator';
+}


### PR DESCRIPTION
## Summary

`X::Str::Numeric.source-indicator` returned `Nil` on the arithmetic path
(infix `+` / numeric comparison), and the `.Int`/`.Num`/prefix-`+` **Failure**
path hardcoded `pos => 0` with a blanket *"must begin with valid digits"*
reason. As a result `"5 foo".Int` mislabeled a trailing-character failure as a
leading one and rendered the `⏏` marker before the whole string (`⏏5 foo`)
instead of after the parsed prefix (`5⏏ foo`).

## Change

- Add two reusable helpers in `runtime/str_numeric.rs`:
  `escape_for_source_indicator` and `build_source_indicator(source, pos)`.
- Route every `X::Str::Numeric` builder through the existing
  `str_numeric_failure` analyzer to derive the correct `(pos, reason)`, so the
  eager (throw) path and the lazy (Failure) path agree.
- The infix path (`runtime/utils.rs`) now also carries `source-indicator`.

Before/after for `"5 foo"`:

| path | before | after |
|------|--------|-------|
| infix `+`  | `source-indicator = Nil` | `in '5⏏ foo' (indicated by ⏏)` |
| `.Int`     | `in '⏏5 foo' …` (pos 0) | `in '5⏏ foo' …` (pos 1) |

## Tests

- Fixes the `.source-indicator matches /'\b'/` subtest in
  `roast/S32-exceptions/misc.t` (test 274).
- Extends `t/str-numeric-error.t` (8 → 14 tests) covering pos/reason/indicator
  on both the eager and lazy `.Int` paths.
- `make test` passes; no regression in `misc2.t`, `numeric.t`, `int.t`,
  `list.t`, `radix.t`, `parse-base.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)