### PR TITLE
feat(state-ownership): native-ize QuantHash/Map/Hash coercion of Cool scalars (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -420,6 +420,23 @@
   `.resolve`（実 FS canonicalize）は `None` で `native_io_path` 維持。新 string を返し受け手非変異＝writeback 不要・behavior-invariant。
   実測: `$p.absolute`/`.relative` の fallback → 0。pin `t/native-io-path-cwd.t`(14, `$*CWD`/instance cwd/explicit base/変数受け手/
   round-trip・raku/mutsu 双方 PASS)。io-path.t の既存 fail 2（`.SPEC`/`.CWD`）は不変。S16-io/S32-io/tmpdir/cwd whitelist 全緑。
+- **2026-06-23 (§D = QuantHash / Map / Hash coercion を plain `Cool` scalar 受け手でも VM ネイティブ化)**: coercion ドレインの
+  残差掃除。method-fallback の広がり再計測（全 whitelist・distinct ファイル数）で **`Set`/`Bag`/`Mix`/`SetHash`/`BagHash`/
+  `MixHash` が各 8-11 file でまだ fallback** していたのを確認し受け手を特定＝`"a".Set`/`42.Set`/`"blue".Set` 等の **plain
+  scalar 受け手**（list-like aggregate でないため VM gate の `list_like` チェックで除外され interpreter に落ちていた）。
+  interpreter は scalar `.Set` を `dispatch_to_set_with_what`＝**`to_set` そのもの**（Set/Bag/Mix arm に Package 特別扱いすら無く
+  scalar を `other =>` catch-all で単一要素化）で処理する＝native gate を広げても **完全に同一実装で behavior-invariant**。
+  `try_native_quanthash_coerce`/`try_native_map_hash_coerce` 共通の `list_like` 判定を新ヘルパー
+  `coerce_receiver_native_eligible` に集約し、list-like aggregate に **Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool** を追加
+  （非mut + mut 両 catch-all が共有）。`.Map`/`.Hash` の scalar（`42.Hash`）は同じ `to_hash`/`to_map` で `X::Hash::Store::OddNumber`
+  ＝raku/interpreter と一致（odd number）。**Instance（`__baggy_data__`/Match captures/user coercion）/ Package（型オブジェクト・
+  `.Map`/`.Hash` は型オブジェクト返し）/ Nil / Junction（autothread）は `None` で interpreter 維持**＝挙動不変。新しい
+  Set/Bag/Mix/Map/Hash 値を返し受け手を変異しない＝writeback 不要。実測: set.t/bag.t/mix.t の Set/Bag/Mix fallback
+  11/10/10 → 2/2/2（残 2 は `__baggy_data__` Instance / 型オブジェクト＝設計通り fall through）。pin
+  `t/native-scalar-quanthash-coerce.t`(39, literal/変数受け手 × Set/Bag/Mix/SetHash/BagHash/MixHash/Map/Hash・raku/mutsu
+  双方 PASS)。set.t 248/248・mix.t 244/244・categorize 28/28・hash.t 緑。（bag.t 252 "Foo instance union"・classify.t 40
+  "junction classify" は BLOCKERS.md 記載の pre-existing〔いずれも非whitelist〕で本変更と無関係。`(a=>1).Map` の odd-number
+  は Pair 受け手〔元から native gate 内〕の別 pre-existing バグで本スライス対象外。）
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -529,20 +529,23 @@ impl Interpreter {
             return result;
         }
         // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/
-        // `.MixHash` over a list-like receiver (ledger §1: native receiver dispatch
-        // -> Interpreter-native). Pure element-folding shared with the interpreter
-        // via `builtins::quanthash_coerce`. `.MixHash` embeds its type metadata
-        // directly in the `Value::Mix` Arc (not an interpreter-owned side table —
-        // container metadata has travelled in the value since #2952), so it is a
-        // pure value op like the others. Instance/Package receivers fall through.
+        // `.MixHash` over a list-like aggregate or a plain Cool scalar (ledger §D:
+        // native receiver dispatch -> Interpreter-native). Pure element-folding
+        // shared with the interpreter via `builtins::quanthash_coerce`. `.MixHash`
+        // embeds its type metadata directly in the `Value::Mix` Arc (not an
+        // interpreter-owned side table — container metadata has travelled in the
+        // value since #2952), so it is a pure value op like the others. A scalar
+        // (`42.Set`) becomes a single-element collection. Instance/Package/Junction
+        // receivers fall through.
         if args.is_empty()
             && let Some(result) = Self::try_native_quanthash_coerce(&target, method)
         {
             return result;
         }
-        // Native `.Map` / `.Hash` coercion over a list-like / Hash / QuantHash
-        // receiver (pure value op; the `Map` declared-type is embedded in the
-        // Hash Arc). Instance/Package fall through.
+        // Native `.Map` / `.Hash` coercion over a list-like aggregate or a plain
+        // Cool scalar (pure value op; the `Map` declared-type is embedded in the
+        // Hash Arc). A scalar (`42.Hash`) raises the same odd-number error as the
+        // interpreter. Instance/Package/Junction fall through.
         if args.is_empty()
             && let Some(result) = Self::try_native_map_hash_coerce(&target, method)
         {
@@ -1127,32 +1130,23 @@ impl Interpreter {
         }
     }
 
-    /// Interpreter-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`
-    /// over a list-like receiver (List/Array/Seq/Slip/Hash/Set/Bag/Mix/Pair/Range).
-    /// Delegates the element folding to the single authoritative pure
-    /// implementation in `builtins::quanthash_coerce`, the same one the
-    /// interpreter's `dispatch_method_by_name_2` uses, so the result is
-    /// behavior-invariant. The `*Hash` variants flip the mutable flag exactly as
-    /// the interpreter does.
+    /// Whether `target` is a receiver for which the pure `.Set`/`.Bag`/`.Mix`/
+    /// `.Map`/`.Hash`-family coercions can run natively in the VM. Two groups go
+    /// native:
+    ///   * list-like / QuantHash aggregates (List/Array/Seq/Slip/Hash/Set/Bag/Mix/
+    ///     Pair/Range) — they flatten their elements; and
+    ///   * plain `Cool` scalars (Str / Int / BigInt / Num / Rat / FatRat / Complex /
+    ///     Bool) — each becomes a single-element collection via the coercion's
+    ///     catch-all arm. The interpreter routes these exact scalars straight to the
+    ///     same shared `builtins` impl with no special-casing (`Str.Set` →
+    ///     `to_set` `other =>` arm = `Set(blue)`), so going native is behavior-invariant.
     ///
-    /// Returns `None` (fall through to the interpreter) for `.MixHash` (it
-    /// registers container type metadata — interpreter-owned state) and for
-    /// non-list-like receivers (`Instance`/`Package`/scalars), leaving those rarer
-    /// cases — `__baggy_data__` instances, type objects, user coercion — to the
-    /// interpreter.
-    fn try_native_quanthash_coerce(
-        target: &Value,
-        method: &str,
-    ) -> Option<Result<Value, RuntimeError>> {
-        if !matches!(
-            method,
-            "Set" | "SetHash" | "Bag" | "BagHash" | "Mix" | "MixHash"
-        ) {
-            return None;
-        }
-        // Only list-like / QuantHash receivers go native; everything else
-        // (Instance/Package/scalars) keeps the interpreter's richer handling.
-        let list_like = matches!(
+    /// `Instance` (`__baggy_data__` / Match captures / user coercion), `Package`
+    /// (type objects — `.Map`/`.Hash` return the type object, handled by the
+    /// interpreter), `Nil`, and `Junction` (autothread) receivers return `false`
+    /// and fall through to the interpreter's richer handling.
+    fn coerce_receiver_native_eligible(target: &Value) -> bool {
+        matches!(
             target,
             Value::Array(..)
                 | Value::Seq(_)
@@ -1163,8 +1157,42 @@ impl Interpreter {
                 | Value::Mix(..)
                 | Value::Pair(..)
                 | Value::ValuePair(..)
-        ) || target.is_range();
-        if !list_like {
+                | Value::Str(_)
+                | Value::Int(_)
+                | Value::BigInt(_)
+                | Value::Num(_)
+                | Value::Rat(..)
+                | Value::FatRat(..)
+                | Value::Complex(..)
+                | Value::Bool(_)
+        ) || target.is_range()
+    }
+
+    /// Interpreter-native QuantHash coercion for `.Set`/`.Bag`/`.Mix`/`.SetHash`/
+    /// `.BagHash`/`.MixHash` over a list-like aggregate or a plain `Cool` scalar
+    /// (see [`coerce_receiver_native_eligible`](Self::coerce_receiver_native_eligible)).
+    /// Delegates the element folding to the single authoritative pure
+    /// implementation in `builtins::quanthash_coerce`, the same one the
+    /// interpreter's `dispatch_method_by_name_2` uses, so the result is
+    /// behavior-invariant. The `*Hash` variants flip the mutable flag exactly as
+    /// the interpreter does. `.MixHash` embeds its type metadata directly in the
+    /// `Value::Mix` Arc (container metadata has travelled in the value since #2952),
+    /// so it is a pure value op like the others.
+    ///
+    /// Returns `None` (fall through to the interpreter) for `Instance`/`Package`/
+    /// `Nil`/`Junction` receivers, leaving those rarer cases — `__baggy_data__`
+    /// instances, type objects, user coercion, autothread — to the interpreter.
+    fn try_native_quanthash_coerce(
+        target: &Value,
+        method: &str,
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(
+            method,
+            "Set" | "SetHash" | "Bag" | "BagHash" | "Mix" | "MixHash"
+        ) {
+            return None;
+        }
+        if !Self::coerce_receiver_native_eligible(target) {
             return None;
         }
         let target = target.clone();
@@ -1190,14 +1218,17 @@ impl Interpreter {
         Some(result)
     }
 
-    /// Interpreter-native `.Map` / `.Hash` coercion over a list-like / Hash /
-    /// QuantHash receiver, sharing the single `builtins::map_hash_coerce` impl
-    /// the interpreter also uses. `.Map` decontainerizes and embeds the `Map`
-    /// declared-type *in* the `Value::Hash` Arc (container metadata travels in
-    /// the value since #2952 — no interpreter-owned side table), so both are
-    /// pure value ops. Instance (Match / `__baggy_data__`) and Package (type
-    /// object) receivers fall through to the interpreter's richer handling.
-    /// Lowercase `.hash` is intentionally not handled here.
+    /// Interpreter-native `.Map` / `.Hash` coercion over a list-like aggregate or
+    /// a plain `Cool` scalar (see
+    /// [`coerce_receiver_native_eligible`](Self::coerce_receiver_native_eligible)),
+    /// sharing the single `builtins::map_hash_coerce` impl the interpreter also
+    /// uses. `.Map` decontainerizes and embeds the `Map` declared-type *in* the
+    /// `Value::Hash` Arc (container metadata travels in the value since #2952 — no
+    /// interpreter-owned side table), so both are pure value ops. A scalar (`42.Hash`)
+    /// raises `X::Hash::Store::OddNumber` via the same `to_hash`, identical to the
+    /// interpreter. Instance (Match / `__baggy_data__`) and Package (type object,
+    /// where `.Map`/`.Hash` returns the type object) receivers fall through to the
+    /// interpreter's richer handling. Lowercase `.hash` is intentionally not handled here.
     fn try_native_map_hash_coerce(
         target: &Value,
         method: &str,
@@ -1205,19 +1236,7 @@ impl Interpreter {
         if !matches!(method, "Map" | "Hash") {
             return None;
         }
-        let list_like = matches!(
-            target,
-            Value::Array(..)
-                | Value::Seq(_)
-                | Value::Slip(_)
-                | Value::Hash(_)
-                | Value::Set(..)
-                | Value::Bag(..)
-                | Value::Mix(..)
-                | Value::Pair(..)
-                | Value::ValuePair(..)
-        ) || target.is_range();
-        if !list_like {
+        if !Self::coerce_receiver_native_eligible(target) {
             return None;
         }
         let target = target.clone();
@@ -1981,8 +2000,9 @@ impl Interpreter {
             return result;
         }
         // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/
-        // `.MixHash` over a list-like receiver. Variable receivers (`@a.Set`,
-        // `%h.MixHash`) compile to CallMethodMut and so land on this mut path; the
+        // `.MixHash` over a list-like aggregate or plain Cool scalar. Variable
+        // receivers (`@a.Set`, `$s.Bag`) compile to CallMethodMut and so land on this
+        // mut path; the
         // coercion produces a *new* Set/Bag/Mix value and never mutates the
         // receiver variable, so there is no writeback — identical to the non-mut
         // path's native dispatch. Instance/Package receivers fall through.

--- a/t/native-scalar-quanthash-coerce.t
+++ b/t/native-scalar-quanthash-coerce.t
@@ -1,0 +1,80 @@
+use Test;
+
+# Pin for the VM-native QuantHash / Map / Hash coercion of *plain Cool scalar*
+# receivers (ledger §D). `"a".Set` / `42.Bag` / `$s.Mix` etc. used to fall back to
+# the interpreter because the native gate only accepted list-like aggregates; the
+# scalar now folds to a single-element collection via the same shared
+# `builtins::quanthash_coerce` / `builtins::map_hash_coerce` impl the interpreter
+# uses, so the result is byte-identical. Both literal receivers (non-mut path) and
+# variable receivers (`$s.Set` -> CallMethodMut, mut path) are exercised.
+
+plan 39;
+
+sub showset($s) { $s.keys.sort.join(' ') }
+
+# --- .Set on scalars (literal = non-mut path) ---
+isa-ok "blue".Set, Set, 'Str.Set is a Set';
+is showset("blue".Set), 'blue', 'Str.Set has the string element';
+isa-ok 42.Set, Set, 'Int.Set is a Set';
+is showset(42.Set), '42', 'Int.Set has the int element';
+isa-ok (1/2).Set, Set, 'Rat.Set is a Set';
+is showset((1/2).Set), '0.5', 'Rat.Set has the rat element';
+isa-ok True.Set, Set, 'Bool.Set is a Set';
+
+# Int keys keep their type (set membership by value, not just string)
+ok 42.Set{42}, 'Int.Set membership tests true for the Int key';
+nok 42.Set{43}, 'Int.Set membership tests false for a different key';
+
+# --- .Bag / .Mix on scalars ---
+isa-ok "a".Bag, Bag, 'Str.Bag is a Bag';
+is "a".Bag<a>, 1, 'Str.Bag has weight 1';
+isa-ok 7.Bag, Bag, 'Int.Bag is a Bag';
+is 7.Bag{7}, 1, 'Int.Bag has weight 1 for the Int key';
+isa-ok 3.Mix, Mix, 'Int.Mix is a Mix';
+is 3.Mix{3}, 1, 'Int.Mix has weight 1';
+isa-ok "z".Mix, Mix, 'Str.Mix is a Mix';
+
+# --- *Hash variants are mutable ---
+isa-ok "a".SetHash, SetHash, 'Str.SetHash is a SetHash';
+isa-ok "a".BagHash, BagHash, 'Str.BagHash is a BagHash';
+isa-ok "a".MixHash, MixHash, 'Str.MixHash is a MixHash';
+my $sh = "a".SetHash;
+$sh{"b"} = True;
+is showset($sh), 'a b', 'SetHash from a scalar is mutable';
+
+# --- variable receivers (mut path / CallMethodMut) ---
+my $s = "cat";
+isa-ok $s.Set, Set, 'variable Str.Set is a Set';
+is showset($s.Set), 'cat', 'variable Str.Set has the string element';
+my $n = 99;
+is showset($n.Bag), '99', 'variable Int.Bag has the int element';
+my $r = 2/4;
+is showset($r.Mix), '0.5', 'variable Rat.Mix has the rat element';
+my $b = False;
+isa-ok $b.SetHash, SetHash, 'variable Bool.SetHash is a SetHash';
+
+# Receiver is not mutated by the coercion (no writeback)
+my $orig = "keep";
+$orig.Set;
+is $orig, 'keep', 'coercion does not mutate the scalar receiver';
+
+# --- .Map / .Hash on scalars ---
+# A single Pair-less scalar is an odd number of elements -> dies, same as raku.
+dies-ok { "a".Hash }, 'Str.Hash on a lone scalar dies (odd number)';
+dies-ok { 42.Hash }, 'Int.Hash on a lone scalar dies (odd number)';
+dies-ok { "a".Map }, 'Str.Map on a lone scalar dies (odd number)';
+my $k = "lonely";
+dies-ok { $k.Hash }, 'variable Str.Hash on a lone scalar dies (odd number)';
+
+# --- aggregate receivers still behave (unchanged path) ---
+isa-ok <a b c a>.Set, Set, 'list .Set still a Set';
+is showset(<a b c a>.Set), 'a b c', 'list .Set dedups';
+is showset([1, 2, 2, 3].Bag), '1 2 3', 'array .Bag keys';
+isa-ok (1, 2, 3).Mix, Mix, 'list .Mix still a Mix';
+my %h = a => 2, b => 0;
+is showset(%h.Set), 'a', 'hash .Set keeps truthy-weight keys';
+my @a = <x y x>;
+is showset(@a.Bag), 'x y', 'array variable .Bag keys';
+is %h.Hash<a>, 2, 'hash .Hash round-trips';
+isa-ok (a => 1, b => 2).Map, Map, 'list-of-Pairs .Map is a Map';
+is (a => 1, b => 2).Map<b>, 2, 'list-of-Pairs .Map round-trips a value';


### PR DESCRIPTION
## Summary

`"a".Set` / `42.Bag` / `\$s.Mix` and the `.Map`/`.Hash` family still fell back to the interpreter for **plain Cool scalar** receivers (Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool). The VM native coercion gate only accepted list-like aggregates, so a scalar bounced to the interpreter and showed up in the method-fallback histogram across 8–11 whitelist files each (Set/Bag/Mix/SetHash/BagHash/MixHash).

The interpreter routes a scalar `.Set` straight to `dispatch_to_set_with_what`, which **is** `builtins::quanthash_coerce::to_set` itself (no Package special-casing; a scalar folds to a single-element collection via the `other =>` catch-all arm). Widening the native gate to admit those scalars therefore uses the identical shared impl and is **behavior-invariant**. A scalar `.Map`/`.Hash` (`42.Hash`) raises the same `X::Hash::Store::OddNumber` via the same `to_hash`/`to_map`.

## Changes

- Consolidate the duplicated `list_like` receiver check in `try_native_quanthash_coerce` and `try_native_map_hash_coerce` into a single `coerce_receiver_native_eligible` helper shared by both the non-mut and mut catch-all paths, and add plain `Cool` scalars to it.
- Instance (`__baggy_data__` / Match captures / user coercion), Package (type objects), Nil, and Junction (autothread) receivers still return `None` and fall through to the interpreter.

## Verification

- Measured: `set.t`/`bag.t`/`mix.t` Set/Bag/Mix fallback **11/10/10 → 2/2/2** (residual 2 = `__baggy_data__` Instances + type objects, fall through by design).
- pin `t/native-scalar-quanthash-coerce.t` (39 subtests, literal + variable receivers across Set/Bag/Mix/SetHash/BagHash/MixHash/Map/Hash; raku + mutsu both pass).
- set.t 248/248, mix.t 244/244, categorize 28/28, hash.t green. `bag.t` 252 (Foo instance union) and `classify.t` 40 (junction classify) are pre-existing, non-whitelist failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)