### PR TITLE
fix(sprintf): match rakudo's X::Str::Sprintf::Directives::Count message

### DIFF
--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -104,21 +104,7 @@ impl Interpreter {
         attrs.insert("args-have".to_string(), Value::Int(args_have as i64));
         attrs.insert("args-used".to_string(), Value::Int(args_used as i64));
         attrs.insert("format".to_string(), Value::str(fmt.to_string()));
-        let message = format!(
-            "Your printf-style directives specify {} argument{}, but {} {} supplied",
-            args_used,
-            if args_used == 1 { "" } else { "s" },
-            if args_have < 1 {
-                "no".to_string()
-            } else {
-                args_have.to_string()
-            },
-            if args_have == 1 {
-                "argument was"
-            } else {
-                "arguments were"
-            },
-        );
+        let message = super::sprintf::directives_count_message(fmt, args_used, args_have);
         attrs.insert("message".to_string(), Value::str(message.clone()));
         let mut err = RuntimeError::new(message);
         err.exception = Some(Box::new(Value::make_instance(

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -6,7 +6,8 @@ use super::sprintf_helpers::{
     format_rat_fixed, normalize_sci_exponent, sign_prefix,
 };
 pub(crate) use super::sprintf_validate::{
-    sprintf_directive_count, validate_sprintf_arg_types, validate_sprintf_directives,
+    directives_count_message, sprintf_directive_count, validate_sprintf_arg_types,
+    validate_sprintf_directives,
 };
 
 pub(crate) fn format_sprintf(fmt: &str, arg: Option<&Value>) -> String {

--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -1,6 +1,35 @@
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 
+/// Build rakudo's `X::Str::Sprintf::Directives::Count` message: the directive
+/// count (`args_used`) is pluralized simply, the supplied count (`args_have`)
+/// renders `0` as "no argument was" / `1` as "1 argument was" / `n` as
+/// "n arguments were", the format is echoed after a newline, and the
+/// interpolated-`$` hint is appended when fewer arguments were supplied than
+/// directives expect.
+pub(crate) fn directives_count_message(fmt: &str, args_used: usize, args_have: usize) -> String {
+    let (have_count, have_unit, have_verb) = match args_have {
+        0 => ("no".to_string(), "argument", "was"),
+        1 => ("1".to_string(), "argument", "was"),
+        n => (n.to_string(), "arguments", "were"),
+    };
+    let hint = if args_have < args_used {
+        "  Are you using an interpolated '$'?"
+    } else {
+        ""
+    };
+    format!(
+        "Your printf-style directives specify {} argument{}, but {} {} {}\nsupplied to format '{}'.{}",
+        args_used,
+        if args_used == 1 { "" } else { "s" },
+        have_count,
+        have_unit,
+        have_verb,
+        fmt,
+        hint,
+    )
+}
+
 /// Count the number of arguments a sprintf-style format string consumes.
 /// This is the number of directives (excluding `%%`), counting `*` width/precision
 /// as additional sequential args, and using the highest positional index when
@@ -236,26 +265,12 @@ pub(crate) fn validate_sprintf_directives(fmt: &str, arg_count: usize) -> Result
         sequential_args
     };
     if expected_args != arg_count {
+        let message = directives_count_message(fmt, expected_args, arg_count);
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("args-have".to_string(), Value::Int(arg_count as i64));
         attrs.insert("args-used".to_string(), Value::Int(expected_args as i64));
-        attrs.insert(
-            "message".to_string(),
-            Value::str(format!(
-                "Your printf-style directives specify {} arguments, but {} argument{} {} supplied",
-                expected_args,
-                arg_count,
-                if arg_count == 1 { "" } else { "s" },
-                if arg_count == 1 { "was" } else { "were" },
-            )),
-        );
-        let mut err = RuntimeError::new(format!(
-            "Your printf-style directives specify {} arguments, but {} argument{} {} supplied",
-            expected_args,
-            arg_count,
-            if arg_count == 1 { "" } else { "s" },
-            if arg_count == 1 { "was" } else { "were" },
-        ));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let mut err = RuntimeError::new(message);
         err.exception = Some(Box::new(Value::make_instance(
             Symbol::intern("X::Str::Sprintf::Directives::Count"),
             attrs,

--- a/t/sprintf-directive-count.t
+++ b/t/sprintf-directive-count.t
@@ -1,0 +1,48 @@
+use Test;
+
+# X::Str::Sprintf::Directives::Count message faithfulness: rakudo pluralizes
+# BOTH the directive count and the supplied count independently, renders 0
+# supplied args as "no argument was", echoes the format after a newline, and
+# appends the interpolated-'$' hint when fewer args were supplied than needed.
+
+plan 12;
+
+throws-like 'sprintf("%s", 1, 2, 3)', X::Str::Sprintf::Directives::Count,
+    'too many args',
+    args-used => 1, args-have => 3,
+    message => /'specify 1 argument, but 3 arguments were' \n 'supplied to format'/;
+
+throws-like 'sprintf("%s %s %s", 1)', X::Str::Sprintf::Directives::Count,
+    'too few args carries the interpolated-$ hint',
+    args-used => 3, args-have => 1,
+    message => /'specify 3 arguments, but 1 argument was' \n 'supplied' .* "interpolated '\$'"/;
+
+throws-like 'sprintf("%s")', X::Str::Sprintf::Directives::Count,
+    'zero args renders "no argument was"',
+    args-used => 1, args-have => 0,
+    message => /'but no argument was'/;
+
+throws-like 'sprintf("abc", 1, 2)', X::Str::Sprintf::Directives::Count,
+    'zero directives still pluralizes "0 arguments"',
+    args-used => 0, args-have => 2,
+    message => /'specify 0 arguments,'/;
+
+# The format string is echoed verbatim.
+throws-like 'sprintf("<%d|%d>", 5)', X::Str::Sprintf::Directives::Count,
+    'format is echoed in the message',
+    message => /"format '<\%d|\%d>'."/;
+
+# No hint when extra args are supplied (have > used).
+{
+    my $e;
+    try { sprintf("%s", 1, 2); CATCH { default { $e = $_ } } }
+    nok $e.message.contains("interpolated"), 'no hint when too many args';
+    ok  $e.message.contains("\n"),           'message wraps before "supplied"';
+}
+
+# Plain integers still format fine (no false positive).
+is sprintf("%d-%d", 1, 2), '1-2', 'matching arity formats normally';
+is sprintf("%s", "ok"),    'ok',  'single directive single arg';
+is sprintf("%%"),          '%',   'literal percent needs no args';
+is sprintf("%d %d %d", 1, 2, 3), '1 2 3', 'three directives three args';
+is sprintf("no directives here"), 'no directives here', 'no directives no args';


### PR DESCRIPTION
## Summary

The `X::Str::Sprintf::Directives::Count` message (arity mismatch in `sprintf`)
diverged from rakudo:

| case | before | rakudo / after |
|------|--------|----------------|
| `sprintf("%s", 1,2,3)` | `specify 1 arguments, but 3 arguments were supplied` | `specify 1 argument, but 3 arguments were`⏎`supplied to format '%s'.` |
| `sprintf("%s")` | `specify 1 argument, but 0 arguments were supplied` | `specify 1 argument, but no argument was`⏎`supplied to format '%s'.  Are you using an interpolated '$'?` |

Three fixes:
1. Pluralize the **directive** count independently (`1 argument`, not `1 arguments`).
2. Render 0 supplied arguments as **"no argument was"** (not "0 arguments were").
3. Echo the format after a newline and append the **interpolated-`$` hint**
   when fewer arguments were supplied than the directives expect.

## Change

A shared `directives_count_message(fmt, args_used, args_have)` helper in
`runtime/sprintf_validate.rs` reproduces rakudo's exact wording. Both the
`sprintf` validation path and the `.fmt`/`Format` arity path now route through
it, so they stay consistent.

## Tests

`t/sprintf-directive-count.t` (12 assertions) covers too-many / too-few / zero
args, the zero-directive case, the format echo, and the hint condition. All
six probed cases match rakudo's `.message` byte-for-byte. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)