### PR TITLE
feat(temporal): Str.Date / Str.DateTime coercion methods

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -42,6 +42,30 @@ pub(super) fn dispatch(
                 .collect();
             Some(Some(Ok(Value::Seq(Arc::new(lines)))))
         }
+        // `Str.Date` / `Str.DateTime` coerce an ISO-formatted string to a
+        // Date / DateTime (documented on Str). Str-only — `Int.Date` etc. are
+        // method-not-found in raku. Invalid/out-of-range strings surface the
+        // same X::Temporal::InvalidFormat / X::OutOfRange the constructors throw.
+        "Date" if matches!(target, Value::Str(_)) => {
+            let s = target.to_string_value();
+            Some(Some(
+                super::temporal::parse_date_string(&s)
+                    .map(|(y, m, d)| super::temporal::make_date(y, m, d)),
+            ))
+        }
+        "DateTime" if matches!(target, Value::Str(_)) => {
+            let s = target.to_string_value();
+            // A bare `yyyy-mm-dd` (no time component) becomes midnight UTC.
+            let result = if s.contains(['T', 't']) {
+                super::temporal::parse_datetime_string(&s).map(|(y, mo, d, h, mi, se, tz)| {
+                    super::temporal::make_datetime(y, mo, d, h, mi, se, tz)
+                })
+            } else {
+                super::temporal::parse_date_string(&s)
+                    .map(|(y, m, d)| super::temporal::make_datetime(y, m, d, 0, 0, 0.0, 0))
+            };
+            Some(Some(result))
+        }
         "trim" => Some(Some(Ok(Value::str(
             target.to_string_value().trim().to_string(),
         )))),

--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -320,7 +320,7 @@ pub fn parse_date_string(s: &str) -> Result<(i64, i64, i64), RuntimeError> {
         temporal_invalid_format_error(
             s,
             "Date",
-            format!("Invalid Date string '{}'; use yyyy-mm-dd", s),
+            format!("Invalid Date string '{}'; use yyyy-mm-dd instead", s),
         )
     };
 

--- a/t/str-date-coercion.t
+++ b/t/str-date-coercion.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Str.Date / Str.DateTime coerce an ISO-formatted string to a Date / DateTime
+# (documented Str methods). Str-only — other Cool types do not get them.
+
+plan 18;
+
+# --- Str.Date ---
+is "2015-11-24".Date,            "2015-11-24", 'Str.Date stringifies as the date';
+isa-ok "2015-11-24".Date,        Date,         'Str.Date returns a Date';
+is "2015-11-24".Date.year,       2015,         'Str.Date.year';
+is "2015-11-24".Date.month,      11,           'Str.Date.month';
+is "2015-11-24".Date.day,        24,           'Str.Date.day';
+is "2015-11-24".Date.day-of-week, 2,           'Str.Date.day-of-week';
+is "-0044-03-15".Date.year,      -44,          'Str.Date with negative (BCE) year';
+
+# --- Str.DateTime ---
+is "2015-12-24T12:23:00Z".DateTime, "2015-12-24T12:23:00Z", 'Str.DateTime full ISO';
+isa-ok "2015-12-24T12:23:00Z".DateTime, DateTime,           'Str.DateTime returns a DateTime';
+is "2012-02-29T12:34:56Z".DateTime.hour,   12, 'Str.DateTime.hour';
+is "2012-02-29T12:34:56Z".DateTime.minute, 34, 'Str.DateTime.minute';
+# A bare date (no time component) becomes midnight UTC.
+is "2015-11-24".DateTime, "2015-11-24T00:00:00Z", 'Str.DateTime from bare date is midnight';
+is "2015-11-24".DateTime.hour, 0, 'bare-date DateTime hour is 0';
+
+# --- round-trip and Cool function-call forms ---
+is "2015-11-24".DateTime.Date, "2015-11-24", 'DateTime.Date round-trips';
+is Date("2015-11-24").year,    2015,         'Date(Str) function form';
+is DateTime("2012-02-29T12:34:56Z").hour, 12, 'DateTime(Str) function form';
+
+# --- error handling ---
+throws-like { "abc".Date }, X::Temporal::InvalidFormat,
+    'malformed Str.Date throws InvalidFormat';
+throws-like { "garbage".DateTime }, X::Temporal::InvalidFormat,
+    'malformed Str.DateTime throws InvalidFormat';


### PR DESCRIPTION
## Summary

`Str.Date` and `Str.DateTime` are documented Str methods
([Str.rakudoc](raku-doc/doc/Type/Str.rakudoc), available since Rakudo 2020.05)
that coerce an ISO-formatted string to a `Date` / `DateTime`. mutsu was missing
them and threw `No such method 'Date' for invocant of type 'Str'`.

## Change

Add them as **Str-only** 0-arg methods in `dispatch_core_str.rs`, reusing the
existing `parse_date_string` / `parse_datetime_string` + `make_date` /
`make_datetime` constructors:

- `"2015-11-24".Date` → `Date` (signed/BCE years supported).
- `"2015-12-24T12:23:00Z".DateTime` → full ISO `DateTime`.
- `"2015-11-24".DateTime` → bare date becomes **midnight UTC**, matching rakudo.
- Malformed input → `X::Temporal::InvalidFormat`; `Int.Date` etc. stay
  method-not-found (Str-guarded), as in rakudo.

Also aligns the `InvalidFormat` message with rakudo (`...use yyyy-mm-dd
instead`), shared with the `Date.new(Str)` path.

All probed cases match rakudo byte-for-byte, including the `Date(Str)` /
`DateTime(Str)` function-call forms (already worked).

## Tests

`t/str-date-coercion.t` (18 assertions). `make test` passes; the whitelisted
S32-temporal suite (`Date.t`, `DateTime.t`, `DateTime-Instant-Duration.t`,
`calendar.t`) still passes.

Note: out-of-range dates currently throw `X::AdHoc` rather than rakudo's
`X::OutOfRange` — a pre-existing limitation in the shared `validate_date` path,
left for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)