### PR TITLE
feat(state-ownership): native-ize IO::Path content reads slurp/lines/words (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -452,6 +452,20 @@
   `.changed` は mutsu=Int / raku=Instant の別 pre-existing 型差を避け `> 0`/`.defined` で検証)。S16-io/S32-io/slurp/spurt whitelist
   全緑（io-path.t の `.SPEC`/`.CWD` 既存 fail は非whitelist・不変）。**残る IO native = content 読み（slurp/lines）と handle 確保
   （open/spurt）＝③ の `io_handles` 所有を直接触る本丸。**
+- **2026-06-23 (§D = `IO::Path` の whole-file content 読み `slurp`/`lines`/`words` を VM ネイティブ化)**: FS stat-only スライス
+  （上）の content-read follow-up。`slurp`(広がり 26 file)/`lines`(13)/`words` は **ファイル全体を読む**が、`io_handles` を一切
+  確保せず emit もしない＝path を VM 所有 cwd へ解決後 `fs::read[_to_string]` し、bytes を split/decode するだけ。flag 解析
+  （`parse_io_flags_values`）と encoding lookup（`decode_with_encoding`＝VM 所有の `encoding_registry` を読む）は全て `&self`
+  read なので native dispatch 可。新 `&self` ゲート `try_io_path_content_read`（`Option` 返し）＋ fallible 本体 `io_path_content_read`
+  （`?` を使うため分離）へ抽出。path_buf 解決は 3 サイト目になったので `resolve_io_path_buf` ヘルパーに集約し `try_io_path_fs_stat`
+  も委譲化（dedup）。`native_io_path` は stat 委譲の直後で content 委譲＝**1 操作 = 1 実装**（slurp/lines/words arm を match から削除）。
+  VM は stat dispatch の隣（非mut/mut 両 path）で呼ぶ。**`comb`（regex/closure dispatch が `&mut self` 必要）/ `open`/`spurt`
+  （`io_handles` 確保・FS write）は `None` で `native_io_path` 維持**＝次スライス（③ io_handles 本丸）。新しい Str/Buf/Seq を返し
+  受け手非変異＝writeback 不要・behavior-invariant（同一 read + split/decode、`:bin`/limit/`:!chomp`/非utf-8 decode 全分岐保持）。
+  実測: `$p.{slurp,lines,words}` の fallback → 0。pin `t/native-io-path-content-read.t`(24, literal + 変数受け手〔mut path〕×
+  slurp/lines/words・`:bin` Blob・utf-8 decode・limit・`:!chomp`・missing-path dies・raku/mutsu 双方 PASS)。S16-io/S32-io/slurp/
+  lines whitelist 全緑（io-path.t `.SPEC`/`.CWD` 既存 fail は非whitelist・不変）。**残る IO native = `comb`（&mut）と handle 確保
+  open/spurt＝③ の `io_handles` 所有本丸。**
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -632,15 +632,24 @@ impl Interpreter {
             .get("path")
             .map(|v| v.to_string_value())
             .unwrap_or_default();
-        let instance_cwd = attributes.get("cwd").map(|v| v.to_string_value());
-        let path_buf = if Path::new(&p).is_absolute() {
-            self.resolve_path(&p)
-        } else if let Some(cwd) = &instance_cwd {
-            self.apply_chroot(PathBuf::from(cwd).join(Path::new(&p)))
-        } else {
-            self.resolve_path(&p)
-        };
+        let path_buf = self.resolve_io_path_buf(attributes, &p);
         Some(Self::io_path_stat_result(&path_buf, &p, method))
+    }
+
+    /// Resolve an `IO::Path`'s `path` attribute to an absolute filesystem
+    /// `PathBuf` against the VM-owned cwd (`$*CWD` / the instance `cwd` attribute /
+    /// the process cwd), applying any chroot. Purely lexical (no filesystem
+    /// access) — shared by the `&self` native IO::Path methods
+    /// (`try_io_path_fs_stat` / `try_io_path_content_read`) and `native_io_path`.
+    fn resolve_io_path_buf(&self, attributes: &HashMap<String, Value>, p: &str) -> PathBuf {
+        let instance_cwd = attributes.get("cwd").map(|v| v.to_string_value());
+        if Path::new(p).is_absolute() {
+            self.resolve_path(p)
+        } else if let Some(cwd) = &instance_cwd {
+            self.apply_chroot(PathBuf::from(cwd).join(Path::new(p)))
+        } else {
+            self.resolve_path(p)
+        }
     }
 
     /// Pure `stat`-based result for the [`try_io_path_fs_stat`] methods given an
@@ -782,6 +791,105 @@ impl Interpreter {
         }
     }
 
+    /// Filesystem *whole-file content reads* on an `IO::Path`
+    /// (`slurp`/`lines`/`words`): resolve the path against the VM-owned cwd, read
+    /// the entire file (`fs::read[_to_string]`), then split / decode the bytes.
+    /// These allocate **no `io_handles`** and emit nothing; flag parsing
+    /// (`parse_io_flags_values`) and encoding lookup (`decode_with_encoding`, which
+    /// reads the VM-owned encoding registry) are `&self` reads, so the VM
+    /// dispatches them natively (ledger §D) via the single impl `native_io_path`
+    /// also delegates to. `comb` (its regex/closure dispatch needs `&mut self`)
+    /// and `open`/`spurt` (io_handles / FS writes) return `None` and stay in
+    /// `native_io_path`. Behavior-invariant (same read + split/decode logic).
+    pub(crate) fn try_io_path_content_read(
+        &self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(method, "slurp" | "lines" | "words") {
+            return None;
+        }
+        Some(self.io_path_content_read(attributes, method, args))
+    }
+
+    /// The fallible body of [`try_io_path_content_read`] (the gate returns
+    /// `Option` so it cannot use `?`). Resolves the path then reads + splits /
+    /// decodes the whole file. Behavior-invariant with the arms `native_io_path`
+    /// previously held.
+    fn io_path_content_read(
+        &self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let p = attributes
+            .get("path")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let path_buf = self.resolve_io_path_buf(attributes, &p);
+        match method {
+            "slurp" => {
+                let (_, _, _, bin, _, _, _, _, enc, _, _) = self.parse_io_flags_values(args);
+                if bin {
+                    let bytes = fs::read(&path_buf).map_err(|err| {
+                        RuntimeError::new(format!("Failed to slurp '{}': {}", p, err))
+                    })?;
+                    let byte_vals: Vec<Value> = bytes
+                        .into_iter()
+                        .map(|b| Value::Int(i64::from(b)))
+                        .collect();
+                    let mut attrs = HashMap::new();
+                    attrs.insert("bytes".to_string(), Value::array(byte_vals));
+                    return Ok(Value::make_instance(Symbol::intern("Buf[uint8]"), attrs));
+                }
+                // A non-utf-8 encoding reads raw bytes and decodes; utf-8 reads
+                // the string directly (stripping a leading BOM).
+                let needs_non_utf8 = enc.as_ref().is_some_and(|e| {
+                    let lower = e.to_lowercase();
+                    lower != "utf-8" && lower != "utf8"
+                });
+                if needs_non_utf8 {
+                    let bytes = fs::read(&path_buf).map_err(|err| {
+                        RuntimeError::new(format!("Failed to slurp '{}': {}", p, err))
+                    })?;
+                    let decoded = self.decode_with_encoding(&bytes, enc.as_ref().unwrap())?;
+                    Ok(Value::str(decoded))
+                } else {
+                    let content = fs::read_to_string(&path_buf).map_err(|err| {
+                        RuntimeError::new(format!("Failed to slurp '{}': {}", p, err))
+                    })?;
+                    Ok(Value::str(super::utils::strip_utf8_bom(content)))
+                }
+            }
+            "lines" => {
+                let content = fs::read_to_string(&path_buf)
+                    .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
+                let content = super::utils::strip_utf8_bom(content);
+                let (_, _, _, _, chomp, nl_in, _, _, _, _, _) = self.parse_io_flags_values(args);
+                let mut parts = Self::split_content_by_separators(&content, &nl_in, chomp);
+                if let Some(n) = args.iter().find_map(numeric_limit_arg) {
+                    parts.truncate(n);
+                }
+                Ok(Value::Seq(std::sync::Arc::new(parts)))
+            }
+            "words" => {
+                let content = fs::read_to_string(&path_buf)
+                    .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
+                let content = super::utils::strip_utf8_bom(content);
+                let mut parts: Vec<Value> = content
+                    .split_whitespace()
+                    .map(|token| Value::str(token.to_string()))
+                    .collect();
+                if let Some(n) = args.iter().find_map(numeric_limit_arg) {
+                    parts.truncate(n);
+                }
+                Ok(Value::Seq(std::sync::Arc::new(parts)))
+            }
+            _ => unreachable!("io_path_content_read called with non-content method"),
+        }
+    }
+
     pub(super) fn native_io_path(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -806,6 +914,12 @@ impl Interpreter {
         // `modified`) — `stat` reads only, no `io_handles`, shared with the VM's
         // native dispatch via `try_io_path_fs_stat`.
         if let Some(result) = self.try_io_path_fs_stat(attributes, method) {
+            return result;
+        }
+        // Whole-file content reads (`slurp`/`lines`/`words`) — read the file,
+        // split/decode the bytes; no `io_handles`, shared with the VM's native
+        // dispatch via `try_io_path_content_read`.
+        if let Some(result) = self.try_io_path_content_read(attributes, method, &args) {
             return result;
         }
         // The concrete class of the receiver (`IO::Path` or a SPEC-variant
@@ -962,37 +1076,9 @@ impl Interpreter {
             // `e`/`f`/`d`/`l`/`r`/`w`/`x`/`rw`/`rwx`/`z`/`mode`/`s`/`created`/
             // `modified`/`accessed`/`changed` (stat-only) are handled above by the
             // shared `try_io_path_fs_stat`, which the VM also dispatches natively.
-            "lines" => {
-                let content = fs::read_to_string(&path_buf)
-                    .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
-                let content = super::utils::strip_utf8_bom(content);
-
-                // Parse nl-in / chomp named args
-                let (_, _, _, _, chomp, nl_in, _, _, _, _, _) = self.parse_io_flags_values(&args);
-                let mut parts = Self::split_content_by_separators(&content, &nl_in, chomp);
-
-                // Check for a positional limit argument (any numeric, incl. allomorphs)
-                let limit = args.iter().find_map(numeric_limit_arg);
-                if let Some(n) = limit {
-                    parts.truncate(n);
-                }
-                Ok(Value::Seq(std::sync::Arc::new(parts)))
-            }
-            "words" => {
-                let content = fs::read_to_string(&path_buf)
-                    .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
-                let content = super::utils::strip_utf8_bom(content);
-                let mut parts: Vec<Value> = content
-                    .split_whitespace()
-                    .map(|token| Value::str(token.to_string()))
-                    .collect();
-                // Check for a positional limit argument (any numeric, incl. allomorphs)
-                let limit = args.iter().find_map(numeric_limit_arg);
-                if let Some(n) = limit {
-                    parts.truncate(n);
-                }
-                Ok(Value::Seq(std::sync::Arc::new(parts)))
-            }
+            // `lines`/`words` (whole-file content reads) are handled above by the
+            // shared `try_io_path_content_read`, which the VM also dispatches
+            // natively. `comb` stays here: its regex/closure dispatch needs `&mut`.
             "comb" => {
                 let content = fs::read_to_string(&path_buf)
                     .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
@@ -1008,40 +1094,8 @@ impl Interpreter {
                     None => Ok(Value::Seq(std::sync::Arc::new(Vec::new()))),
                 }
             }
-            "slurp" => {
-                let (_, _, _, bin, _, _, _, _, enc, _, _) = self.parse_io_flags_values(&args);
-                if bin {
-                    let bytes = fs::read(&path_buf).map_err(|err| {
-                        RuntimeError::new(format!("Failed to slurp '{}': {}", p, err))
-                    })?;
-                    let byte_vals: Vec<Value> = bytes
-                        .into_iter()
-                        .map(|b| Value::Int(i64::from(b)))
-                        .collect();
-                    let mut attrs = HashMap::new();
-                    attrs.insert("bytes".to_string(), Value::array(byte_vals));
-                    return Ok(Value::make_instance(Symbol::intern("Buf[uint8]"), attrs));
-                }
-                // If an encoding is specified and it's not utf-8, read raw bytes
-                // and decode with the specified encoding
-                let needs_non_utf8 = enc.as_ref().is_some_and(|e| {
-                    let lower = e.to_lowercase();
-                    lower != "utf-8" && lower != "utf8"
-                });
-                if needs_non_utf8 {
-                    let bytes = fs::read(&path_buf).map_err(|err| {
-                        RuntimeError::new(format!("Failed to slurp '{}': {}", p, err))
-                    })?;
-                    let decoded = self.decode_with_encoding(&bytes, enc.as_ref().unwrap())?;
-                    Ok(Value::str(decoded))
-                } else {
-                    let content = fs::read_to_string(&path_buf).map_err(|err| {
-                        RuntimeError::new(format!("Failed to slurp '{}': {}", p, err))
-                    })?;
-                    let content = super::utils::strip_utf8_bom(content);
-                    Ok(Value::str(content))
-                }
-            }
+            // `slurp` (whole-file content read) is handled above by the shared
+            // `try_io_path_content_read`, which the VM also dispatches natively.
             "open" => {
                 let (
                     read,

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -226,6 +226,16 @@ impl Interpreter {
             {
                 return result;
             }
+            // Interpreter-native whole-file content reads (`slurp`/`lines`/`words`):
+            // read the file + split/decode; no `io_handles` (ledger §D). Single impl
+            // shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    self.try_io_path_content_read(&attributes.as_map(), method, &args)
+            {
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
@@ -1763,6 +1773,16 @@ impl Interpreter {
             if Self::is_io_path_lexical_class(&class)
                 && let Value::Instance { attributes, .. } = &target
                 && let Some(result) = self.try_io_path_fs_stat(&attributes.as_map(), method)
+            {
+                return result;
+            }
+            // Interpreter-native whole-file content reads (`slurp`/`lines`/`words`):
+            // read the file + split/decode; no `io_handles` (ledger §D). Single impl
+            // shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    self.try_io_path_content_read(&attributes.as_map(), method, &args)
             {
                 return result;
             }

--- a/t/native-io-path-content-read.t
+++ b/t/native-io-path-content-read.t
@@ -1,0 +1,75 @@
+use Test;
+
+# Pin for VM-native `IO::Path` whole-file content reads (ledger §D):
+# `.slurp` / `.lines` / `.words`. These read the entire file (`fs::read[_to_string]`)
+# and split / decode the bytes, allocating no io_handles and emitting nothing, so
+# the VM dispatches them natively via `try_io_path_content_read` — the single impl
+# `native_io_path` also delegates to. Both literal (`"x".IO.slurp`, non-mut path)
+# and variable (`$p.slurp` -> CallMethodMut, mut path) receivers are exercised.
+# `.comb` (regex dispatch, &mut) and `.open`/`.spurt` (io_handles) stay in the
+# interpreter and are intentionally not covered here.
+
+plan 24;
+
+my $dir = "tmp/native-io-content-$*PID";
+mkdir $dir;
+my $f  = "$dir/data.txt";
+spurt $f, "line1\nline2\nline3\n";
+my $w  = "$dir/words.txt";
+spurt $w, "foo bar  baz\nqux\n";
+my $u  = "$dir/utf8.txt";
+spurt $u, "héllo wörld\n";          # non-ASCII, utf-8
+
+# --- .slurp ---
+is $f.IO.slurp, "line1\nline2\nline3\n", '.slurp returns the whole file';
+is $u.IO.slurp, "héllo wörld\n",          '.slurp decodes utf-8';
+is $u.IO.slurp.chars, 12,                 '.slurp counts codepoints, not bytes';
+isa-ok $f.IO.slurp, Str,                  '.slurp is a Str';
+
+# .slurp(:bin) -> a Blob/Buf of bytes
+my $bytes = $f.IO.slurp(:bin);
+ok  $bytes ~~ Blob,        '.slurp(:bin) is a Blob';
+is  $bytes.elems, 18,      '.slurp(:bin) has the raw byte count';
+is  $bytes[0], 0x6c,       '.slurp(:bin) first byte is "l"';
+
+# --- .lines ---
+my @lines = $f.IO.lines;
+is @lines.elems, 3,        '.lines returns 3 lines';
+is @lines[0], 'line1',     '.lines chomps by default';
+is @lines[2], 'line3',     '.lines last element';
+isa-ok $f.IO.lines, Seq,   '.lines is a Seq';
+
+# .lines($limit)
+is $f.IO.lines(2).elems, 2, '.lines($n) truncates to n';
+
+# .lines(:!chomp) keeps the newline
+my @nl = $f.IO.lines(:!chomp);
+is @nl[0], "line1\n",      '.lines(:!chomp) keeps the trailing newline';
+
+# --- .words ---
+my @words = $w.IO.words;
+is @words.elems, 4,        '.words splits on whitespace (incl. newlines)';
+is @words[0], 'foo',       '.words first token';
+is @words[2], 'baz',       '.words collapses runs of whitespace';
+is @words[3], 'qux',       '.words crosses line boundaries';
+is $w.IO.words(2).elems, 2, '.words($n) truncates to n';
+
+# --- variable receivers (mut path / CallMethodMut) ---
+my $p = $f.IO;
+is $p.slurp, "line1\nline2\nline3\n", 'variable receiver .slurp';
+is $p.lines.elems, 3,                 'variable receiver .lines';
+my $pw = $w.IO;
+is $pw.words.elems, 4,                'variable receiver .words';
+
+# receiver path is not mutated by a read
+my $orig = $f.IO;
+$orig.slurp;
+is $orig.Str, $f, 'content read does not mutate the receiver path';
+
+# --- a missing file: slurp dies (not a silent empty string) ---
+my $missing = "$dir/nope.txt";
+dies-ok { $missing.IO.slurp }, '.slurp on a missing path dies';
+
+# cleanup
+unlink $f; unlink $w; unlink $u; rmdir $dir;
+ok True, 'cleanup ran';


### PR DESCRIPTION
## Summary

Follow-up to #3499 (IO::Path stat-only methods). `.slurp`/`.lines`/`.words` read the whole file but allocate **no `io_handles`** and emit nothing: they resolve the path against the VM-owned cwd, `fs::read[_to_string]` it, and split/decode the bytes. Flag parsing (`parse_io_flags_values`) and encoding lookup (`decode_with_encoding`, reading the VM-owned `encoding_registry`) are `&self` reads, so the VM dispatches them natively.

## Changes

- Extract a `&self` gate `try_io_path_content_read` (returns `Option`) + its fallible body `io_path_content_read` (split out so it can use `?`).
- Path resolution is now used in three places → consolidated into a `resolve_io_path_buf` helper that `try_io_path_fs_stat` also adopts (dedup).
- `native_io_path` delegates right after the stat delegation; the slurp/lines/words arms are removed from its match (1 op = 1 impl). The VM calls the helper next to the stat dispatch on both the non-mut and mut paths.
- `comb` (regex/closure dispatch needs `&mut self`) and `open`/`spurt` (allocate `io_handles` / write the FS) still return `None` and stay in `native_io_path` — the remaining §D ③ io_handles work.

Methods return a fresh `Str`/`Buf`/`Seq` and never mutate the receiver → no writeback. Behavior is identical (same read + split/decode; all `:bin`/limit/`:!chomp`/non-utf-8-decode branches preserved).

## Verification

- Measured: `$p.{slurp,lines,words}` method fallback **→ 0**.
- pin `t/native-io-path-content-read.t` (24 subtests: literal + variable receivers across slurp/lines/words, `:bin` Blob, utf-8 decode, limit, `:!chomp`, missing-path dies; raku + mutsu both pass).
- S16-io / S32-io / slurp / lines whitelist green. io-path.t `.SPEC`/`.CWD` failures are pre-existing and non-whitelist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)