### PR TITLE
feat(state-ownership): native-ize IO::Path single-path FS mutations (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -466,6 +466,20 @@
   slurp/lines/words・`:bin` Blob・utf-8 decode・limit・`:!chomp`・missing-path dies・raku/mutsu 双方 PASS)。S16-io/S32-io/slurp/
   lines whitelist 全緑（io-path.t `.SPEC`/`.CWD` 既存 fail は非whitelist・不変）。**残る IO native = `comb`（&mut）と handle 確保
   open/spurt＝③ の `io_handles` 所有本丸。**
+- **2026-06-23 (§D = `IO::Path` の単一パス FS 変異 `spurt`/`mkdir`/`rmdir`/`unlink`/`chmod` を VM ネイティブ化)**: content-read
+  スライスの **write 系 follow-up**（spurt 広がり 18 file）。これら 5 op は FS を**変異**するが `io_handles` を一切確保しない＝
+  path を VM 所有 cwd へ解決後 **一回限りの syscall**（`fs::write`/`create_dir_all`/`remove_dir`/`remove_file`/`set_permissions`）
+  を呼ぶだけ（`spurt` は open→write→即 drop でハンドルを残さない）。encoding lookup（`encode_with_encoding`＝VM 所有 registry
+  読み）は `&self`。新 `&self` ゲート `try_io_path_fs_mutate`（`Option` 返し）＋ fallible 本体 `io_path_fs_mutate`（`?` 用に分離・
+  `mkdir` は `class_name` で IO::Path を round-trip 返し）へ抽出。`native_io_path` は content 委譲の直後で委譲＝**1 操作 = 1 実装**
+  （5 arm を match から削除）。VM は content dispatch の隣（非mut/mut 両 path）で呼ぶ。**2-path op（`copy`/`rename`/`move`/`symlink`/
+  `link`・宛先 path 解決が必要）と handle-opening `open`（`io_handles` 確保＝`&mut self`）は `None` で `native_io_path` 維持**＝次の
+  ③ io_handles 本丸 capstone。新しい Bool/IO::Path/Failure を返し受け手非変異＝writeback 不要・behavior-invariant（同一 syscall +
+  `:append`/`:createonly`/`:enc`+BOM/Buf 全分岐保持）。実測: `$p.{spurt,mkdir,rmdir,unlink,chmod}` の fallback → 0。pin
+  `t/native-io-path-fs-mutate.t`(22, literal + 変数受け手〔mut path〕× 5 op・`:append`/`:createonly` Failure・Buf spurt・mkdir
+  recursive・非空 rmdir Failure・chmod mode・raku/mutsu 双方 PASS)。S16-io/S32-io/spurt/dir whitelist 全緑。（`.unlink` of missing
+  は mutsu=False/raku=True の別 pre-existing 差〔移動前 interpreter も `Err(NotFound)=>Bool(false)`〕で本スライス対象外＝pin 非対象。）
+  **残る IO native = `comb`（&mut）と `open`（`io_handles` 確保）＝③ の `io_handles` 所有 capstone。**
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -890,6 +890,208 @@ impl Interpreter {
         }
     }
 
+    /// Single-path filesystem *mutations* on an `IO::Path`
+    /// (`spurt`/`mkdir`/`rmdir`/`unlink`/`chmod`): resolve the path against the
+    /// VM-owned cwd, then perform a one-shot syscall (`fs::write`/`create_dir_all`/
+    /// `remove_dir`/`remove_file`/`set_permissions`). They allocate **no
+    /// `io_handles`** — `spurt` opens, writes, and immediately drops its file
+    /// handle. Encoding lookup (`encode_with_encoding`, reading the VM-owned
+    /// encoding registry) is a `&self` read, so the VM dispatches these natively
+    /// (ledger §D): the single impl `native_io_path` also delegates to. Two-path
+    /// ops (`copy`/`rename`/`move`/`symlink`/`link`, which resolve a destination)
+    /// and handle-opening `open` return `None` and stay in `native_io_path`.
+    pub(crate) fn try_io_path_fs_mutate(
+        &self,
+        attributes: &HashMap<String, Value>,
+        class_name: &str,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(method, "spurt" | "mkdir" | "rmdir" | "unlink" | "chmod") {
+            return None;
+        }
+        Some(self.io_path_fs_mutate(attributes, class_name, method, args))
+    }
+
+    /// The fallible body of [`try_io_path_fs_mutate`] (the gate returns `Option`
+    /// so it cannot use `?`). Behavior-invariant with the arms `native_io_path`
+    /// previously held.
+    fn io_path_fs_mutate(
+        &self,
+        attributes: &HashMap<String, Value>,
+        class_name: &str,
+        method: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let p = attributes
+            .get("path")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let path_buf = self.resolve_io_path_buf(attributes, &p);
+        match method {
+            "spurt" => {
+                let content_value = args
+                    .first()
+                    .cloned()
+                    .unwrap_or(Value::Str(String::new().into()));
+                let mut append = false;
+                let mut createonly = false;
+                let mut enc: Option<String> = None;
+                for arg in args.iter().skip(1) {
+                    if let Value::Pair(key, val) = arg {
+                        match key.as_str() {
+                            "append" => append = val.truthy(),
+                            "createonly" => createonly = val.truthy(),
+                            "enc" => enc = Some(val.to_string_value()),
+                            _ => {}
+                        }
+                    }
+                }
+                if createonly && path_buf.exists() {
+                    return Ok(io_exception_failure(
+                        "X::IO::Spurt",
+                        format!("Failed to spurt '{}': file already exists", p),
+                    ));
+                }
+                let is_buf = crate::runtime::Interpreter::is_buf_value(&content_value);
+                let write_result = if is_buf {
+                    let bytes = crate::runtime::Interpreter::extract_buf_bytes(&content_value);
+                    if append {
+                        use std::io::Write;
+                        fs::OpenOptions::new()
+                            .append(true)
+                            .create(true)
+                            .open(&path_buf)
+                            .and_then(|mut file| file.write_all(&bytes))
+                    } else {
+                        fs::write(&path_buf, &bytes)
+                    }
+                } else {
+                    let content = content_value.to_string_value();
+                    let bytes = if let Some(ref enc_name) = enc {
+                        match self.encode_with_encoding(&content, enc_name) {
+                            Ok(mut b) => {
+                                // For utf16 (auto-endian), prepend BOM
+                                let enc_lower = enc_name.to_lowercase();
+                                if enc_lower == "utf-16" || enc_lower == "utf16" {
+                                    let bom: &[u8] = if cfg!(target_endian = "little") {
+                                        &[0xFF, 0xFE]
+                                    } else {
+                                        &[0xFE, 0xFF]
+                                    };
+                                    let mut with_bom = Vec::with_capacity(bom.len() + b.len());
+                                    with_bom.extend_from_slice(bom);
+                                    with_bom.append(&mut b);
+                                    with_bom
+                                } else {
+                                    b
+                                }
+                            }
+                            Err(e) => {
+                                return Ok(io_exception_failure("X::IO::Spurt", e.message));
+                            }
+                        }
+                    } else {
+                        content.into_bytes()
+                    };
+                    if append {
+                        use std::io::Write;
+                        fs::OpenOptions::new()
+                            .append(true)
+                            .create(true)
+                            .open(&path_buf)
+                            .and_then(|mut file| file.write_all(&bytes))
+                    } else {
+                        fs::write(&path_buf, &bytes)
+                    }
+                };
+                match write_result {
+                    Ok(()) => Ok(Value::Bool(true)),
+                    Err(err) => Ok(io_exception_failure(
+                        "X::IO::Spurt",
+                        format!("Failed to spurt '{}': {}", p, err),
+                    )),
+                }
+            }
+            "mkdir" => match fs::create_dir_all(&path_buf) {
+                Ok(()) => Ok(Value::make_instance(
+                    Symbol::intern(class_name),
+                    attributes.clone(),
+                )),
+                Err(err) => {
+                    let msg = format!(
+                        "Failed to create directory '{}' with mode '0o777': Failed to mkdir: {}",
+                        p, err
+                    );
+                    let mut ex_attrs = HashMap::new();
+                    ex_attrs.insert("message".to_string(), Value::str_from(&msg));
+                    ex_attrs.insert("path".to_string(), Value::str_from(&p));
+                    let ex = Value::make_instance(Symbol::intern("X::IO::Mkdir"), ex_attrs);
+                    let mut failure_attrs = HashMap::new();
+                    failure_attrs.insert("exception".to_string(), ex);
+                    Ok(Value::make_instance(
+                        Symbol::intern("Failure"),
+                        failure_attrs,
+                    ))
+                }
+            },
+            "rmdir" => match fs::remove_dir(&path_buf) {
+                Ok(()) => Ok(Value::Bool(true)),
+                Err(err) => {
+                    let msg = format!("Failed to remove the directory '{}': {}", p, err);
+                    let mut ex_attrs = HashMap::new();
+                    ex_attrs.insert("message".to_string(), Value::str_from(&msg));
+                    ex_attrs.insert("path".to_string(), Value::str_from(&p));
+                    let ex = Value::make_instance(Symbol::intern("X::IO::Rmdir"), ex_attrs);
+                    let mut failure_attrs = HashMap::new();
+                    failure_attrs.insert("exception".to_string(), ex);
+                    Ok(Value::make_instance(
+                        Symbol::intern("Failure"),
+                        failure_attrs,
+                    ))
+                }
+            },
+            "unlink" => match fs::remove_file(&path_buf) {
+                Ok(()) => Ok(Value::Bool(true)),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Value::Bool(false)),
+                Err(err) => Err(RuntimeError::new(format!(
+                    "Failed to unlink '{}': {}",
+                    p, err
+                ))),
+            },
+            "chmod" => {
+                let mode_value = args
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| RuntimeError::new("chmod requires mode"))?;
+                let mode_int = match mode_value {
+                    Value::Int(i) => i as u32,
+                    Value::Str(s) => u32::from_str_radix(&s, 8).unwrap_or(0),
+                    other => {
+                        return Err(RuntimeError::new(format!(
+                            "Invalid mode: {}",
+                            other.to_string_value()
+                        )));
+                    }
+                };
+                #[cfg(unix)]
+                {
+                    let perms = PermissionsExt::from_mode(mode_int);
+                    fs::set_permissions(&path_buf, perms).map_err(|err| {
+                        RuntimeError::new(format!("Failed to chmod '{}': {}", p, err))
+                    })?;
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = mode_int;
+                    return Err(RuntimeError::new("chmod not supported on this platform"));
+                }
+                Ok(Value::Bool(true))
+            }
+            _ => unreachable!("io_path_fs_mutate called with non-mutation method"),
+        }
+    }
+
     pub(super) fn native_io_path(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -920,6 +1122,12 @@ impl Interpreter {
         // split/decode the bytes; no `io_handles`, shared with the VM's native
         // dispatch via `try_io_path_content_read`.
         if let Some(result) = self.try_io_path_content_read(attributes, method, &args) {
+            return result;
+        }
+        // Single-path filesystem mutations (`spurt`/`mkdir`/`rmdir`/`unlink`/
+        // `chmod`) — one-shot syscall, no `io_handles`, shared with the VM's
+        // native dispatch via `try_io_path_fs_mutate`.
+        if let Some(result) = self.try_io_path_fs_mutate(attributes, class_name, method, &args) {
             return result;
         }
         // The concrete class of the receiver (`IO::Path` or a SPEC-variant
@@ -1220,70 +1428,9 @@ impl Interpreter {
                 })?;
                 Ok(Value::Bool(true))
             }
-            "chmod" => {
-                let mode_value = args
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| RuntimeError::new("chmod requires mode"))?;
-                let mode_int = match mode_value {
-                    Value::Int(i) => i as u32,
-                    Value::Str(s) => u32::from_str_radix(&s, 8).unwrap_or(0),
-                    other => {
-                        return Err(RuntimeError::new(format!(
-                            "Invalid mode: {}",
-                            other.to_string_value()
-                        )));
-                    }
-                };
-                #[cfg(unix)]
-                {
-                    let perms = PermissionsExt::from_mode(mode_int);
-                    fs::set_permissions(&path_buf, perms).map_err(|err| {
-                        RuntimeError::new(format!("Failed to chmod '{}': {}", p, err))
-                    })?;
-                }
-                #[cfg(not(unix))]
-                {
-                    let _ = mode_int;
-                    return Err(RuntimeError::new("chmod not supported on this platform"));
-                }
-                Ok(Value::Bool(true))
-            }
-            "mkdir" => match fs::create_dir_all(&path_buf) {
-                Ok(()) => Ok(Value::make_instance(io_path_class, attributes.clone())),
-                Err(err) => {
-                    let msg = format!(
-                        "Failed to create directory '{}' with mode '0o777': Failed to mkdir: {}",
-                        p, err
-                    );
-                    let mut ex_attrs = HashMap::new();
-                    ex_attrs.insert("message".to_string(), Value::str_from(&msg));
-                    ex_attrs.insert("path".to_string(), Value::str_from(&p));
-                    let ex = Value::make_instance(Symbol::intern("X::IO::Mkdir"), ex_attrs);
-                    let mut failure_attrs = HashMap::new();
-                    failure_attrs.insert("exception".to_string(), ex);
-                    Ok(Value::make_instance(
-                        Symbol::intern("Failure"),
-                        failure_attrs,
-                    ))
-                }
-            },
-            "rmdir" => match fs::remove_dir(&path_buf) {
-                Ok(()) => Ok(Value::Bool(true)),
-                Err(err) => {
-                    let msg = format!("Failed to remove the directory '{}': {}", p, err);
-                    let mut ex_attrs = HashMap::new();
-                    ex_attrs.insert("message".to_string(), Value::str_from(&msg));
-                    ex_attrs.insert("path".to_string(), Value::str_from(&p));
-                    let ex = Value::make_instance(Symbol::intern("X::IO::Rmdir"), ex_attrs);
-                    let mut failure_attrs = HashMap::new();
-                    failure_attrs.insert("exception".to_string(), ex);
-                    Ok(Value::make_instance(
-                        Symbol::intern("Failure"),
-                        failure_attrs,
-                    ))
-                }
-            },
+            // `chmod`/`mkdir`/`rmdir` (single-path FS mutations) are handled above
+            // by the shared `try_io_path_fs_mutate`, which the VM also dispatches
+            // natively.
             "dir" => {
                 let mut entries = Vec::new();
                 let requested = PathBuf::from(&p);
@@ -1319,98 +1466,8 @@ impl Interpreter {
                 }
                 Ok(Value::array(entries))
             }
-            "spurt" => {
-                let content_value = args
-                    .first()
-                    .cloned()
-                    .unwrap_or(Value::Str(String::new().into()));
-                let mut append = false;
-                let mut createonly = false;
-                let mut enc: Option<String> = None;
-                for arg in args.iter().skip(1) {
-                    if let Value::Pair(key, val) = arg {
-                        match key.as_str() {
-                            "append" => append = val.truthy(),
-                            "createonly" => createonly = val.truthy(),
-                            "enc" => enc = Some(val.to_string_value()),
-                            _ => {}
-                        }
-                    }
-                }
-                if createonly && path_buf.exists() {
-                    return Ok(io_exception_failure(
-                        "X::IO::Spurt",
-                        format!("Failed to spurt '{}': file already exists", p),
-                    ));
-                }
-                let is_buf = crate::runtime::Interpreter::is_buf_value(&content_value);
-                let write_result = if is_buf {
-                    let bytes = crate::runtime::Interpreter::extract_buf_bytes(&content_value);
-                    if append {
-                        use std::io::Write;
-                        fs::OpenOptions::new()
-                            .append(true)
-                            .create(true)
-                            .open(&path_buf)
-                            .and_then(|mut file| file.write_all(&bytes))
-                    } else {
-                        fs::write(&path_buf, &bytes)
-                    }
-                } else {
-                    let content = content_value.to_string_value();
-                    let bytes = if let Some(ref enc_name) = enc {
-                        match self.encode_with_encoding(&content, enc_name) {
-                            Ok(mut b) => {
-                                // For utf16 (auto-endian), prepend BOM
-                                let enc_lower = enc_name.to_lowercase();
-                                if enc_lower == "utf-16" || enc_lower == "utf16" {
-                                    let bom: &[u8] = if cfg!(target_endian = "little") {
-                                        &[0xFF, 0xFE]
-                                    } else {
-                                        &[0xFE, 0xFF]
-                                    };
-                                    let mut with_bom = Vec::with_capacity(bom.len() + b.len());
-                                    with_bom.extend_from_slice(bom);
-                                    with_bom.append(&mut b);
-                                    with_bom
-                                } else {
-                                    b
-                                }
-                            }
-                            Err(e) => {
-                                return Ok(io_exception_failure("X::IO::Spurt", e.message));
-                            }
-                        }
-                    } else {
-                        content.into_bytes()
-                    };
-                    if append {
-                        use std::io::Write;
-                        fs::OpenOptions::new()
-                            .append(true)
-                            .create(true)
-                            .open(&path_buf)
-                            .and_then(|mut file| file.write_all(&bytes))
-                    } else {
-                        fs::write(&path_buf, &bytes)
-                    }
-                };
-                match write_result {
-                    Ok(()) => Ok(Value::Bool(true)),
-                    Err(err) => Ok(io_exception_failure(
-                        "X::IO::Spurt",
-                        format!("Failed to spurt '{}': {}", p, err),
-                    )),
-                }
-            }
-            "unlink" => match fs::remove_file(&path_buf) {
-                Ok(()) => Ok(Value::Bool(true)),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Value::Bool(false)),
-                Err(err) => Err(RuntimeError::new(format!(
-                    "Failed to unlink '{}': {}",
-                    p, err
-                ))),
-            },
+            // `spurt`/`unlink` (single-path FS mutations) are handled above by the
+            // shared `try_io_path_fs_mutate`, which the VM also dispatches natively.
             "symlink" => {
                 // IO::Path.symlink($name, :$absolute = True)
                 // Creates a symlink named $name pointing to self (the target).

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -236,6 +236,16 @@ impl Interpreter {
             {
                 return result;
             }
+            // Interpreter-native single-path filesystem mutations (`spurt`/`mkdir`/
+            // `rmdir`/`unlink`/`chmod`): one-shot syscall, no `io_handles` (ledger
+            // §D). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    self.try_io_path_fs_mutate(&attributes.as_map(), &class, method, &args)
+            {
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
@@ -1783,6 +1793,16 @@ impl Interpreter {
                 && let Value::Instance { attributes, .. } = &target
                 && let Some(result) =
                     self.try_io_path_content_read(&attributes.as_map(), method, &args)
+            {
+                return result;
+            }
+            // Interpreter-native single-path filesystem mutations (`spurt`/`mkdir`/
+            // `rmdir`/`unlink`/`chmod`): one-shot syscall, no `io_handles` (ledger
+            // §D). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) =
+                    self.try_io_path_fs_mutate(&attributes.as_map(), &class, method, &args)
             {
                 return result;
             }

--- a/t/native-io-path-fs-mutate.t
+++ b/t/native-io-path-fs-mutate.t
@@ -1,0 +1,79 @@
+use Test;
+
+# Pin for VM-native single-path `IO::Path` filesystem mutations (ledger §D):
+# `.spurt` / `.mkdir` / `.rmdir` / `.unlink` / `.chmod`. Each resolves the path
+# against the VM-owned cwd and performs a one-shot syscall, allocating no
+# io_handles (`.spurt` opens, writes, and immediately drops its file handle), so
+# the VM dispatches them natively via `try_io_path_fs_mutate` — the single impl
+# `native_io_path` also delegates to. Both literal (`"x".IO.spurt(...)`, non-mut
+# path) and variable (`$p.spurt(...)` -> CallMethodMut, mut path) receivers are
+# exercised. Two-path ops (copy/rename/move/symlink/link) and handle-opening
+# `open` stay in the interpreter and are intentionally not covered here.
+
+plan 22;
+
+my $dir = "tmp/native-io-mutate-$*PID";
+mkdir $dir;
+
+# --- .spurt (write) + round-trip via .slurp ---
+my $f = "$dir/out.txt";
+is $f.IO.spurt("hello\n"), True, '.spurt returns True';
+is $f.IO.slurp, "hello\n",        '.spurt wrote the content';
+
+# .spurt(:append)
+$f.IO.spurt("more\n", :append);
+is $f.IO.slurp, "hello\nmore\n",  '.spurt(:append) appends';
+
+# .spurt(:createonly) on an existing file fails (Failure, not exception)
+nok $f.IO.spurt("nope", :createonly).defined,
+    '.spurt(:createonly) on an existing file is an undefined Failure';
+is $f.IO.slurp, "hello\nmore\n",  '.spurt(:createonly) did not overwrite';
+
+# .spurt a Buf writes raw bytes
+my $bf = "$dir/bytes.bin";
+$bf.IO.spurt(Buf.new(0x41, 0x42, 0x43));
+is $bf.IO.slurp, "ABC",           '.spurt of a Buf writes the raw bytes';
+
+# --- .mkdir creates a directory (recursively) and returns an IO::Path ---
+my $sub = "$dir/a/b/c";
+my $made = $sub.IO.mkdir;
+ok $made ~~ IO::Path,             '.mkdir returns an IO::Path';
+ok $sub.IO.d,                     '.mkdir created the directory tree';
+
+# --- .rmdir removes an empty directory ---
+my $empty = "$dir/empty";
+mkdir $empty;
+ok $empty.IO.d,                   'directory exists before rmdir';
+is $empty.IO.rmdir, True,         '.rmdir returns True';
+nok $empty.IO.e,                  '.rmdir removed the directory';
+
+# .rmdir on a non-empty directory fails (Failure)
+nok $sub.IO.parent.parent.rmdir.defined,
+    '.rmdir on a non-empty directory is an undefined Failure';
+
+# --- .unlink removes an existing file ---
+my $u = "$dir/del.txt";
+$u.IO.spurt("x");
+ok $u.IO.e,                       'file exists before unlink';
+is $u.IO.unlink, True,            '.unlink returns True for an existing file';
+nok $u.IO.e,                      '.unlink removed the file';
+
+# --- .chmod sets permission bits ---
+my $c = "$dir/perm.txt";
+$c.IO.spurt("p");
+is $c.IO.chmod(0o644), True,      '.chmod returns True';
+is $c.IO.mode, "0644",            '.chmod set the mode';
+$c.IO.chmod(0o600);
+is $c.IO.mode, "0600",            '.chmod can change the mode again';
+
+# --- variable receivers (mut path / CallMethodMut) ---
+my $vp = "$dir/var.txt".IO;
+is $vp.spurt("vv\n"), True,       'variable receiver .spurt';
+is $vp.slurp, "vv\n",             'variable receiver round-trip';
+my $vd = "$dir/vardir".IO;
+$vd.mkdir;
+ok $vd.d,                         'variable receiver .mkdir';
+
+# cleanup (best-effort)
+$c.IO.unlink; $bf.IO.unlink; $f.IO.unlink; $vp.IO.unlink;
+ok True, 'cleanup ran';


### PR DESCRIPTION
## Summary

Write-side follow-up to #3501 (IO::Path content reads). The single-path mutation methods `.spurt`/`.mkdir`/`.rmdir`/`.unlink`/`.chmod` mutate the filesystem but allocate **no `io_handles`**: they resolve the path against the VM-owned cwd and call a one-shot syscall (`fs::write`/`create_dir_all`/`remove_dir`/`remove_file`/`set_permissions`). `.spurt` opens, writes, and immediately drops its file handle. Encoding lookup (`encode_with_encoding`, reading the VM-owned registry) is `&self`.

## Changes

- Extract a `&self` gate `try_io_path_fs_mutate` (returns `Option`) + its fallible body `io_path_fs_mutate` (split out so it can use `?`; `mkdir` takes `class_name` to round-trip the IO::Path subclass).
- `native_io_path` delegates right after the content-read delegation; the five arms are removed from its match (1 op = 1 impl). The VM calls the helper next to the content-read dispatch on both the non-mut and mut paths.
- Two-path ops (`copy`/`rename`/`move`/`symlink`/`link`) and handle-opening `open` (`io_handles`, `&mut self`) still return `None` and stay in `native_io_path` — the remaining §D ③ io_handles capstone.

Methods return a fresh `Bool`/`IO::Path`/`Failure` and never mutate the receiver → no writeback. Behavior is identical (same syscall + all `:append`/`:createonly`/`:enc`+BOM/Buf branches preserved).

## Verification

- Measured: `$p.{spurt,mkdir,rmdir,unlink,chmod}` method fallback **→ 0**.
- pin `t/native-io-path-fs-mutate.t` (22 subtests: literal + variable receivers across the five ops, `:append`/`:createonly` Failures, Buf spurt, recursive mkdir, non-empty rmdir Failure, chmod mode; raku + mutsu both pass).
- S16-io / S32-io / spurt / dir whitelist green.
- `.unlink` of a missing path (mutsu `False` vs raku `True`) is a pre-existing difference, out of scope and not pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)