### PR TITLE
feat(state-ownership): native-ize IO::Path.open — VM allocates io_handles (ledger §D ③)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -480,6 +480,21 @@
   recursive・非空 rmdir Failure・chmod mode・raku/mutsu 双方 PASS)。S16-io/S32-io/spurt/dir whitelist 全緑。（`.unlink` of missing
   は mutsu=False/raku=True の別 pre-existing 差〔移動前 interpreter も `Err(NotFound)=>Bool(false)`〕で本スライス対象外＝pin 非対象。）
   **残る IO native = `comb`（&mut）と `open`（`io_handles` 確保）＝③ の `io_handles` 所有 capstone。**
+- **2026-06-23 (§D ③ capstone = `IO::Path.open` を VM ネイティブ化＝VM が `io_handles` を直接確保)**: ③（state 所有）の
+  **象徴的マイルストーン**。`open` は IO::Path FS メソッドの中で唯一 **`io_handles` テーブルを変異**する（`open_file_handle`→
+  `insert_handle_state` で handle id 確保＝`&mut self`）。台帳が当初「native-method（IO 系）は ③ がブロック」としていた根拠が
+  まさにこれ＝`io_handles` が interpreter 所有 state だから、だった。だが #2760-2772 以降 `io_handles` は **`Arc<RwLock>` 共有
+  フィールドで VM が所有**＝unified struct の `self` から `open_file_handle` を直接呼べる。新 `&mut self` ゲート `try_io_path_open`
+  を抽出（`resolve_io_path_buf`(&self)/`parse_io_flags_values`(&self) は owned 値を返すので後続 `&mut self` `open_file_handle` と
+  借用衝突なし）し、`native_io_path` は fs_mutate 委譲の直後で委譲＝**1 操作 = 1 実装**（open arm を match から削除）。VM の
+  **非mut/mut 両 dispatch 関数はどちらも `&mut self`** なので（`try_compiled_method_or_interpret_inner`/
+  `try_compiled_method_mut_or_interpret`）、`"x".IO.open`（非mut）も `$p.open`（mut）も native 化。`:r`/`:w`/`:a`/`:rw`/`:bin`/
+  `:enc`/`:create`/`:exclusive` 全 flag と Failure-on-error 整形を保持＝behavior-invariant（同一 `open_file_handle`）。実測:
+  `$p.open` の fallback → 0。**∴ open→read/write→close の全ライフサイクルが catch-all バウンス無しで VM ネイティブに走る**
+  （handle メソッド get/lines/print/say/close/tell/eof/seek/flush 等は既に native）。pin `t/native-io-path-open.t`(20, literal +
+  変数受け手〔mut path〕× :r/:w/:a/:exclusive/:bin・missing/directory Failure・opened state・raku/mutsu 双方 PASS)。S16-io/S32-io/
+  open whitelist 全緑（io-handle.t `.say` 既存 fail は main でも fail＝非whitelist・本変更と無関係）。**残る IO native = `comb`
+  （regex/closure dispatch が `&mut self`）と 2-path op（copy/rename/move/symlink/link）のみ＝③ の IO native はほぼ完遂。**
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -1092,6 +1092,77 @@ impl Interpreter {
         }
     }
 
+    /// Open a file handle for an `IO::Path` (`open`): allocate an `io_handles`
+    /// entry and return the `IO::Handle`. This is the one IO::Path FS method that
+    /// mutates VM-owned `io_handles` state (`&mut self`) — but the VM *owns* that
+    /// table (a shared `Arc<RwLock>`), so it dispatches `open` natively (ledger §D
+    /// ③) via the single shared `open_file_handle` the interpreter also uses, with
+    /// the same `:r`/`:w`/`:a`/`:rw`/`:bin`/`:enc`/`:create`/`:exclusive` flag
+    /// handling and the same Failure-on-error shaping. Path resolution
+    /// (`resolve_io_path_buf`) and flag parsing (`parse_io_flags_values`) are
+    /// `&self` reads returning owned values, so there is no borrow conflict with
+    /// the subsequent `&mut self` `open_file_handle`. Returns `None` for any other
+    /// method.
+    pub(crate) fn try_io_path_open(
+        &mut self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "open" {
+            return None;
+        }
+        let p = attributes
+            .get("path")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let path_buf = self.resolve_io_path_buf(attributes, &p);
+        let (
+            read,
+            write,
+            append,
+            bin,
+            line_chomp,
+            line_separators,
+            out_buffer_capacity,
+            nl_out,
+            enc,
+            create,
+            exclusive,
+        ) = self.parse_io_flags_values(args);
+        Some(
+            match self.open_file_handle(
+                &path_buf,
+                read,
+                write,
+                append,
+                bin,
+                line_chomp,
+                line_separators,
+                out_buffer_capacity,
+                nl_out,
+                enc,
+                create,
+                exclusive,
+            ) {
+                Ok(handle) => Ok(handle),
+                // Like the `open` sub, `IO::Path.open` returns a Failure (wrapping
+                // the exception) on error rather than throwing.
+                Err(err) => {
+                    let class_name = err
+                        .exception
+                        .as_deref()
+                        .and_then(|ex| match ex {
+                            Value::Instance { class_name, .. } => Some(class_name.to_string()),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| "X::AdHoc".to_string());
+                    Ok(io_exception_failure(&class_name, err.message))
+                }
+            },
+        )
+    }
+
     pub(super) fn native_io_path(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -1128,6 +1199,12 @@ impl Interpreter {
         // `chmod`) — one-shot syscall, no `io_handles`, shared with the VM's
         // native dispatch via `try_io_path_fs_mutate`.
         if let Some(result) = self.try_io_path_fs_mutate(attributes, class_name, method, &args) {
+            return result;
+        }
+        // `open` allocates an `io_handles` entry and returns an `IO::Handle`. The
+        // VM owns `io_handles`, so it dispatches `open` natively via the shared
+        // `try_io_path_open` (ledger §D ③).
+        if let Some(result) = self.try_io_path_open(attributes, method, &args) {
             return result;
         }
         // The concrete class of the receiver (`IO::Path` or a SPEC-variant
@@ -1304,50 +1381,8 @@ impl Interpreter {
             }
             // `slurp` (whole-file content read) is handled above by the shared
             // `try_io_path_content_read`, which the VM also dispatches natively.
-            "open" => {
-                let (
-                    read,
-                    write,
-                    append,
-                    bin,
-                    line_chomp,
-                    line_separators,
-                    out_buffer_capacity,
-                    nl_out,
-                    enc,
-                    create,
-                    exclusive,
-                ) = self.parse_io_flags_values(&args);
-                match self.open_file_handle(
-                    &path_buf,
-                    read,
-                    write,
-                    append,
-                    bin,
-                    line_chomp,
-                    line_separators,
-                    out_buffer_capacity,
-                    nl_out,
-                    enc,
-                    create,
-                    exclusive,
-                ) {
-                    Ok(handle) => Ok(handle),
-                    // Like the `open` sub, `IO::Path.open` returns a Failure
-                    // (wrapping the exception) on error rather than throwing.
-                    Err(err) => {
-                        let class_name = err
-                            .exception
-                            .as_deref()
-                            .and_then(|ex| match ex {
-                                Value::Instance { class_name, .. } => Some(class_name.to_string()),
-                                _ => None,
-                            })
-                            .unwrap_or_else(|| "X::AdHoc".to_string());
-                        Ok(io_exception_failure(&class_name, err.message))
-                    }
-                }
-            }
+            // `open` (allocates an `io_handles` entry) is handled above by the
+            // shared `try_io_path_open`, which the VM also dispatches natively.
             "copy" => {
                 let dest = args
                     .first()

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -246,6 +246,15 @@ impl Interpreter {
             {
                 return result;
             }
+            // Interpreter-native `open`: allocate an `io_handles` entry and return
+            // the `IO::Handle`. The VM owns `io_handles`, so this is a native
+            // dispatch (ledger §D ③). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) = self.try_io_path_open(&attributes.as_map(), method, &args)
+            {
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
@@ -1803,6 +1812,15 @@ impl Interpreter {
                 && let Value::Instance { attributes, .. } = &target
                 && let Some(result) =
                     self.try_io_path_fs_mutate(&attributes.as_map(), &class, method, &args)
+            {
+                return result;
+            }
+            // Interpreter-native `open`: allocate an `io_handles` entry and return
+            // the `IO::Handle`. The VM owns `io_handles`, so this is a native
+            // dispatch (ledger §D ③). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) = self.try_io_path_open(&attributes.as_map(), method, &args)
             {
                 return result;
             }

--- a/t/native-io-path-open.t
+++ b/t/native-io-path-open.t
@@ -1,0 +1,95 @@
+use Test;
+
+# Pin for VM-native `IO::Path.open` (ledger §D ③ — the io_handles capstone).
+# `.open` is the one IO::Path filesystem method that allocates an `io_handles`
+# entry (`&mut self`). The VM *owns* `io_handles` (a shared Arc<RwLock>), so it
+# dispatches `.open` natively via `try_io_path_open` — the single shared
+# `open_file_handle` impl the interpreter also uses. Once open is native, the
+# whole open -> read/write -> close lifecycle runs without the catch-all bounce.
+# Both literal (`"x".IO.open`, non-mut path) and variable (`$p.open` ->
+# CallMethodMut, mut path) receivers are exercised.
+
+plan 20;
+
+my $dir = "tmp/native-io-open-$*PID";
+mkdir $dir;
+my $r = "$dir/read.txt";
+spurt $r, "L1\nL2\nL3\n";
+
+# --- read mode (default / :r) ---
+my $fh = $r.IO.open;
+ok $fh ~~ IO::Handle,      '.open returns an IO::Handle';
+is $fh.lines.elems, 3,     '.open then .lines reads all lines';
+$fh.close;
+
+my $fh2 = $r.IO.open(:r);
+is $fh2.get, 'L1',         '.open(:r).get reads the first line';
+is $fh2.get, 'L2',         '.open(:r).get advances to the next line';
+$fh2.close;
+
+# slurp through a handle
+my $fh3 = $r.IO.open;
+is $fh3.slurp, "L1\nL2\nL3\n", '.open then .slurp reads the whole file';
+$fh3.close;
+
+# --- write mode (:w) truncates ---
+my $w = "$dir/write.txt";
+my $wfh = $w.IO.open(:w);
+ok $wfh ~~ IO::Handle,     '.open(:w) returns a handle';
+$wfh.print("hello\n");
+$wfh.print("world\n");
+$wfh.close;
+is $w.IO.slurp, "hello\nworld\n", '.open(:w) + .print wrote the content';
+
+# re-open :w truncates
+my $wfh2 = $w.IO.open(:w);
+$wfh2.say("fresh");
+$wfh2.close;
+is $w.IO.slurp, "fresh\n",  '.open(:w) truncates on re-open';
+
+# --- append mode (:a) ---
+my $afh = $w.IO.open(:a);
+$afh.say("appended");
+$afh.close;
+is $w.IO.slurp, "fresh\nappended\n", '.open(:a) appends';
+
+# --- exclusive mode (:x via :exclusive) fails on an existing file ---
+my $x = "$dir/excl.txt";
+my $xfh = $x.IO.open(:w, :exclusive);
+ok $xfh ~~ IO::Handle,     '.open(:exclusive) succeeds when the file is new';
+$xfh.close;
+my $xfail = $x.IO.open(:w, :exclusive);
+nok $xfail.defined,        '.open(:exclusive) on an existing file is an undefined Failure';
+
+# --- error cases return a Failure (not a thrown exception) ---
+nok "$dir/missing.txt".IO.open(:r).defined,
+    '.open(:r) on a missing file is an undefined Failure';
+nok $dir.IO.open.defined,
+    '.open on a directory is an undefined Failure';
+
+# --- bin mode yields a binary handle ---
+my $b = "$dir/bin.dat";
+spurt $b, Buf.new(0x41, 0x42, 0x43);
+my $bfh = $b.IO.open(:bin);
+my $buf = $bfh.read(3);
+ok $buf ~~ Blob,           '.open(:bin).read returns a Blob';
+is $buf.elems, 3,          '.open(:bin).read got 3 bytes';
+is $buf[0], 0x41,          '.open(:bin).read first byte';
+$bfh.close;
+
+# --- variable receiver: mut path (CallMethodMut) ---
+my $p = $r.IO;
+my $vfh = $p.open;
+is $vfh.lines.elems, 3,    'variable receiver .open + .lines';
+$vfh.close;
+
+# .opened reflects handle state
+my $ofh = $r.IO.open;
+ok $ofh.opened,            '.opened is True for an open handle';
+$ofh.close;
+nok $ofh.opened,           '.opened is False after .close';
+
+# cleanup
+unlink $r; unlink $w; unlink $x; unlink $b;
+rmdir $dir;
+ok True, 'cleanup ran';


### PR DESCRIPTION
## Summary

The **§D ③ capstone**. `.open` is the one IO::Path filesystem method that mutates the `io_handles` table (`open_file_handle` → `insert_handle_state` allocates a handle id, `&mut self`). This is exactly why the ledger originally marked native IO methods "③-blocked" — `io_handles` was interpreter-owned state. But since #2760-2772 `io_handles` is a shared `Arc<RwLock>` field the VM owns, so the unified struct can call `open_file_handle` directly.

## Changes

- Extract a `&mut self` gate `try_io_path_open`. `resolve_io_path_buf` and `parse_io_flags_values` are `&self` reads returning owned values, so there is no borrow conflict with the subsequent `&mut self` `open_file_handle`.
- `native_io_path` delegates right after the fs-mutate delegation; the open arm is removed from its match (1 op = 1 impl).
- Both VM dispatch functions are `&mut self` (`try_compiled_method_or_interpret_inner` / `try_compiled_method_mut_or_interpret`), so both `"x".IO.open` (non-mut) and `$p.open` (mut) go native.
- All `:r`/`:w`/`:a`/`:rw`/`:bin`/`:enc`/`:create`/`:exclusive` flags and the Failure-on-error shaping are preserved — behavior-invariant (same `open_file_handle`).

With open native, the whole **open → read/write → close lifecycle runs without the catch-all bounce** (the handle methods get/lines/print/say/close/tell/eof/seek/flush are already native).

## Verification

- Measured: `$p.open` method fallback **→ 0**.
- pin `t/native-io-path-open.t` (20 subtests: literal + variable receivers across `:r`/`:w`/`:a`/`:exclusive`/`:bin`, missing/directory Failures, opened state; raku + mutsu both pass).
- S16-io / S32-io / open whitelist green. io-handle.t `.say` failure is pre-existing (fails on main too) and non-whitelist.

## Remaining IO native work

Only `comb` (regex/closure dispatch, `&mut self`) and the two-path ops (copy/rename/move/symlink/link) remain — the §D ③ IO native methods are essentially complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)