### PR TITLE
fix(subscript): trailing dimension on a flat List indexes scalar leaves as 1-element lists

### DIFF
--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -112,6 +112,15 @@ impl Interpreter {
         if dims.is_empty() {
             return Ok(target.clone());
         }
+        // A non-positional value behaves as a single-element list when
+        // subscripted in a further dimension: in `(10,20,30)[1,2;0]` each
+        // selected scalar is indexed by the trailing `0`, and `20[0]` is `20`
+        // (raku treats a scalar as a 1-element list under subscript). Without
+        // this, deeper dimensions on scalar leaves would all collapse to Nil.
+        if !matches!(target, Value::Array(..) | Value::Hash(..)) {
+            let single = Value::array(vec![target.clone()]);
+            return self.multi_dim_index_read(&single, dims);
+        }
         let dim = &dims[0];
         let rest = &dims[1..];
 

--- a/t/multidim-slice-scalar-leaf.t
+++ b/t/multidim-slice-scalar-leaf.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 10;
+
+# A trailing dimension applied to a flat List indexes each selected scalar
+# as a 1-element list: `20[0]` is 20, so `(10,20,30)[1,2;0]` is `(20 30)`.
+is-deeply (10,20,30)[1,2;0], (20, 30), 'flat List slice with scalar-leaf 0 dimension';
+is (10,20,30)[1;0], 20, 'single index with scalar-leaf 0 dimension';
+is (10,20,30)[0;0], 10, 'first element with scalar-leaf 0 dimension';
+is-deeply (10,20,30)[*;0], (10, 20, 30), 'Whatever first dim with scalar-leaf 0';
+is-deeply (10,20,30)[1;*], (20,), 'Whatever leaf dimension on a scalar';
+is-deeply (10,20,30)[1,2;0;0], (20, 30), 'two trailing scalar-leaf dimensions';
+
+# Arrays behave identically.
+my @a = 10, 20, 30;
+is-deeply @a[1,2;0], (20, 30), 'flat Array slice with scalar-leaf 0 dimension';
+
+# Nested arrays were already correct; keep them passing.
+is-deeply ((1,2),(3,4))[0,1;1], (2, 4), 'nested AoA slice still works';
+
+# A bare scalar under a positional subscript is a 1-element list.
+is 20[0], 20, 'scalar literal indexed by 0 is itself';
+is "hi"[0], "hi", 'string literal indexed by 0 is itself';


### PR DESCRIPTION
## Problem

A multidim slice with a trailing dimension applied to a flat List collapsed scalar leaves to `Nil`:

```raku
say (10,20,30)[1,2;0];   # raku: (20 30)   mutsu: (Nil Nil)
say (10,20,30)[1;0];     # raku: 20        mutsu: Nil
```

`multi_dim_index_read` only descended into `Value::Array` targets, so once the first dimension selected a scalar (`20`), the trailing `0` dimension had no Array to index and returned `Nil`.

## Fix

Raku treats a non-positional value as a 1-element list under subscript (`20[0]` is `20`, `20[*]` is `(20)`). Before descending into a dimension, wrap a non-`Array`/non-`Hash` target in a single-element list. Scalar leaves then index themselves at position 0 (and `Nil` past it), matching raku for `;0`/`;*` trailing dimensions. Nested-array slices are unaffected.

```raku
say (10,20,30)[1,2;0];   # (20 30)
say (10,20,30)[*;0];     # (10 20 30)
say (10,20,30)[1;*];     # (20)
say ((1,2),(3,4))[0,1;1];# (2 4)  (unchanged)
```

## Tests

- New `t/multidim-slice-scalar-leaf.t` (10 cases).
- `make test` PASS; whitelisted subscript/typed-array roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)