### PR TITLE
fix(parser): hash literal %(...) may be directly brace-subscripted

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2551,6 +2551,12 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     | Expr::Literal(_)
                     | Expr::DoStmt(_)
                     | Expr::Grouped(_)
+                    // A hash literal `%(...)` is a term and may be directly
+                    // subscripted: `%(a=>1,b=>2){"a"}` is `1`. (Angle subscript
+                    // `%(...)<a>` already works because that handler is
+                    // unguarded.) Whitespace before `{` still parses as a block,
+                    // since this check requires `{` at the start of `rest`.
+                    | Expr::Hash(_)
             )
             // An inline `my`/`our`/`state` declaration must not be hash-
             // subscripted: the declaration parser consumes the whitespace after

--- a/t/hash-literal-brace-subscript.t
+++ b/t/hash-literal-brace-subscript.t
@@ -1,0 +1,22 @@
+# A hash literal `%(...)` is a term and may be directly subscripted with curly
+# braces: `%(a=>1,b=>2){"a"}` is `1`. Previously only the angle-bracket
+# postcircumfix `%(...)<a>` worked; the `{...}` postcircumfix was mis-parsed as a
+# separate block statement. Whitespace before `{` still parses as a block.
+use Test;
+
+plan 8;
+
+is %(a => 1, b => 2){"a"}, 1, 'hash literal brace subscript (a)';
+is %(a => 1, b => 2){"b"}, 2, 'hash literal brace subscript (b)';
+is %(a => 1, b => 2)<a>, 1, 'angle subscript still works';
+
+my $k = "b";
+is %(a => 1, b => 2){$k}, 2, 'hash literal brace subscript with variable key';
+
+is-deeply %(a => 1, b => 2){"a", "b"}, (1, 2), 'hash literal brace slice';
+
+ok %(a => 1, b => 2){"a"}:exists, 'brace subscript :exists (present)';
+nok %(a => 1, b => 2){"z"}:exists, 'brace subscript :exists (absent)';
+
+# Nested: subscript result chained further.
+is %(a => %(x => 9)){"a"}{"x"}, 9, 'chained brace subscript on nested hash literal';


### PR DESCRIPTION
## Problem

A hash literal `%(...)` could not be subscripted with curly braces:

```raku
say %(a=>1,b=>2){"a"};   # raku: 1
                         # mutsu: parsed {"a"} as a SEPARATE block,
                         #        printed the whole hash + a sink-context warning
```

The angle-bracket postcircumfix `%(...)<a>` already worked (its handler is unguarded), but the curly-brace subscript handler restricted its target to a fixed list of `Expr` variants that omitted `Expr::Hash`, so `{...}` after a hash literal fell through to the block parser.

## Fix

Add `Expr::Hash(_)` to the brace-subscript guard list. The handler only fires when `{` is at the start of the remaining input, so whitespace before `{` still parses as a block — matching raku, which treats `%(...) {...}` as a block in infix position.

This also makes `for %(...){...}` (no space) match raku: both now read the `{...}` as a hash subscript and report a missing loop block.

```raku
say %(a=>1,b=>2){"a"};        # 1
say %(a=>1,b=>2){"a","b"};    # (1 2)
say %(a=>1,b=>2){"a"}:exists; # True
say %(a=>%(x=>9)){"a"}{"x"};  # 9
```

## Tests

- New `t/hash-literal-brace-subscript.t` (8 cases).
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)