### PR TITLE
fix(match): a Match in a collection renders as Match.new under .raku

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -776,6 +776,17 @@ pub fn raku_value(v: &Value) -> String {
         // An ObjAt / ValueObjAt (from `.WHICH`) renders its `.raku` as the
         // constructor form `ValueObjAt.new("Int|42")`; only `.gist` / `.Str`
         // show the bare WHICH string (`Int|42`, via `to_string_value`).
+        // A Match object embedded in a collection renders via its full
+        // `Match.new(...)` form, the same as a direct `$/.raku`. Without this,
+        // `$/.list.raku` / `$/.caps.raku` / an array holding a Match stringified
+        // the Match to its matched text instead.
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name == "Match" => {
+            super::match_helpers::match_raku_repr(&attributes.as_map())
+        }
         Value::Instance {
             class_name,
             attributes,

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -784,9 +784,7 @@ pub fn raku_value(v: &Value) -> String {
             class_name,
             attributes,
             ..
-        } if class_name == "Match" => {
-            super::match_helpers::match_raku_repr(&attributes.as_map())
-        }
+        } if class_name == "Match" => super::match_helpers::match_raku_repr(&attributes.as_map()),
         Value::Instance {
             class_name,
             attributes,

--- a/t/match-raku-in-collection.t
+++ b/t/match-raku-in-collection.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 6;
+
+# A Match object embedded in a collection renders via its full `Match.new(...)`
+# form under `.raku`, the same as a direct `$/.raku`. Previously a Match inside
+# a List/Array/Pair stringified to its matched text instead.
+
+"hello" ~~ /(.)(.)/;
+
+is $/.list.raku,
+   '(Match.new(:orig("hello"), :from(0), :pos(1)), Match.new(:orig("hello"), :from(1), :pos(2)))',
+   '$/.list.raku renders each Match in full';
+
+is $/.caps.raku,
+   '(0 => Match.new(:orig("hello"), :from(0), :pos(1)), 1 => Match.new(:orig("hello"), :from(1), :pos(2)))',
+   '$/.caps.raku renders Pair values as Match.new';
+
+my @m = "hello" ~~ /(.)(.)/;
+is @m.raku,
+   '[Match.new(:orig("hello"), :from(0), :pos(2), :list((Match.new(:orig("hello"), :from(0), :pos(1)), Match.new(:orig("hello"), :from(1), :pos(2)))))]',
+   'an Array holding a Match renders it in full';
+
+# A direct Match .raku is unchanged.
+is $0.raku, 'Match.new(:orig("hello"), :from(0), :pos(1))', 'direct $0.raku unchanged';
+
+# Round-trips: the collection .raku output EVALs back to Match objects.
+my @r = $/.list.raku.EVAL;
+is @r.elems, 2, 'collection Match .raku round-trips (count)';
+is @r[0].^name, 'Match', 'round-tripped elements are Match objects';


### PR DESCRIPTION
## Problem

A `Match` object embedded in a collection lost its `.raku` representation:

```raku
"hello" ~~ /(.)(.)/;
say $/.list.raku;   # raku: (Match.new(...), Match.new(...))   mutsu: (h, e)
say $/.caps.raku;   # raku: (0 => Match.new(...), ...)         mutsu: (0 => h, 1 => e)
my @m = "hello" ~~ /(.)(.)/;
say @m.raku;        # raku: [Match.new(... :list((...)))]      mutsu: [he]
```

A direct `$0.raku` / `$/.raku` already rendered correctly.

## Cause

A Match is a `Value::Instance` with `class_name == "Match"`. The direct `.raku` method dispatch produced the full form via `match_raku_repr`, but the collection-element renderer `raku_value` only special-cased `ObjAt`/`ValueObjAt` instances and fell through to `to_string_value()` for a Match.

## Fix

Add a `Match` arm to `raku_value` that delegates to the same `match_raku_repr`, so nested Match objects render identically wherever they appear (List, Array, Pair value).

## Tests

- New `t/match-raku-in-collection.t` (6 cases, including EVAL round-trip).
- `make test` PASS; S05 match/capture roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)