### PR TITLE
feat(state-ownership): native-ize .encode / .decode (Str<->Buf) (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -506,6 +506,19 @@
   5 op・copy-onto-self/createonly Failure・symlink resolve・hard link・raku/mutsu 双方 PASS。stale ファイル混入を防ぐため毎回 dir を
   クリーンに再生成)。S16-io/S32-io/copy/rename whitelist 全緑。**∴ IO::Path FS メソッド族（stat/content-read/fs-mutate/open/2-path）が
   全て VM ネイティブ化完了＝§D ③ の IO native はほぼ完遂。残るは `comb`（regex/closure dispatch が `&mut self`・別軸）のみ。**
+- **2026-06-23 (§D = `.encode`/`.decode`（Str↔Buf 変換）を VM ネイティブ化)**: IO::Path 族の次の clean な native-method ドレイン
+  （広がり `encode`=16 file）。**明示エンコーディング形**（`"x".encode("utf-16")`/`$buf.decode("ascii")`）は `dispatch_method_by_name`
+  catch-all で interpreter にバウンスしていた（0-arg `.encode` は `methods_0arg` で既に native）。これらは VM 所有の `encoding_registry`
+  を読む（`find_encoding`/`encode_with_encoding`/`decode_with_encoding`＝全 `&self`）pure な Str↔Buf 変換で `io_handles` 不要。新
+  `pub(crate)` ヘルパー `try_native_encode_decode` を **`crate::runtime`（methods_io_dispatch.rs）側に**置き（`dispatch_encode`/
+  `dispatch_decode` が `pub(super)` なので同 crate::runtime から呼ぶ・IO::Path と同パターン）、VM の非mut/mut 両 catch-all（`try_native_io_coercion`
+  の直後・最終バウンス直前）から呼ぶ＝**1 操作 = 1 実装**。**保守的ゲート**: `.encode` は plain Cool scalar（Str/Int/BigInt/Num/Rat/
+  FatRat/Complex/Bool）のみ、`.decode` は `dispatch_decode` 自身が Buf/Blob Instance にゲート（それ以外 `None`）。user Instance（custom
+  `.encode`/`.decode` は compiled method で先に解決）・Supply（独自 chunk-encode・interpreter arm が除外）・Buf 受け手の `.encode` は
+  fall through＝behavior-invariant。新しい Buf/Str を返し受け手非変異＝writeback 不要。実測: `"x".encode("utf-16")`/`$buf.decode` の
+  fallback → 0。pin `t/native-encode-decode.t`(23, literal + 変数受け手〔mut path〕× encode utf-8/utf-16/ascii/latin-1・Int/Bool/Rat
+  encode・Buf/Blob decode・round-trip・raku/mutsu 双方 PASS。utf-16 `.elems`=16-bit ユニット数の注意込み)。encoding/buf/S32-str/encode
+  whitelist 全緑。
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -2,6 +2,49 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Interpreter-native `.encode` (a `Cool` scalar -> `Buf`) and `.decode`
+    /// (a `Buf`/`Blob` -> `Str`) for built-in receivers, sharing the single
+    /// `dispatch_encode` / `dispatch_decode` impl the interpreter's catch-all also
+    /// uses (ledger §D). Pure transformations: they stringify/encode or decode
+    /// bytes via the VM-owned encoding registry (`&self` reads) and allocate no
+    /// `io_handles`.
+    ///
+    /// `.encode` is gated to plain `Cool` scalars (Str / numeric / Bool); `.decode`
+    /// is gated by `dispatch_decode` itself to `Buf`/`Blob` instances (it returns
+    /// `None` for anything else). User Instances (a custom `.encode`/`.decode` is
+    /// resolved earlier as a compiled method), `Supply` (its own chunk-encode), and
+    /// `Buf` receivers for `.encode` fall through to the interpreter. The 0-arg
+    /// `.encode` is already native via `methods_0arg`; this drains the
+    /// explicit-encoding form (`.encode("utf-16")`). Behavior-invariant.
+    pub(crate) fn try_native_encode_decode(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        match method {
+            "encode"
+                if matches!(
+                    target,
+                    Value::Str(_)
+                        | Value::Int(_)
+                        | Value::BigInt(_)
+                        | Value::Num(_)
+                        | Value::Rat(..)
+                        | Value::FatRat(..)
+                        | Value::Complex(..)
+                        | Value::Bool(_)
+                ) =>
+            {
+                Some(self.dispatch_encode(target, args))
+            }
+            // `dispatch_decode` is internally gated to Buf/Blob instances and
+            // returns `None` for any other receiver, so it falls through cleanly.
+            "decode" => self.dispatch_decode(target, args),
+            _ => None,
+        }
+    }
+
     pub(super) fn dispatch_say(&mut self, target: &Value) -> Result<Value, RuntimeError> {
         let gist = self.render_gist_value(target);
         self.write_to_named_handle("$*OUT", &gist, true)?;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -625,6 +625,12 @@ impl Interpreter {
         if let Some(result) = self.try_native_io_coercion(&target, method, &args) {
             return result;
         }
+        // Native `.encode` (Cool scalar -> Buf) / `.decode` (Buf/Blob -> Str) —
+        // pure transformation via the VM-owned encoding registry, no `io_handles`
+        // (ledger §D). Single impl shared with the interpreter catch-all.
+        if let Some(result) = self.try_native_encode_decode(&target, method, &args) {
+            return result;
+        }
         // TODO: compile to bytecode — native/Buf/Failure method fork (ledger §1).
         // User-defined Instance methods now always run as bytecode (compiled at
         // registration, or on demand above via `populate_uncompiled_method`), so
@@ -2128,6 +2134,12 @@ impl Interpreter {
         // (`$s.IO`) — builds a *new* IO::Path and never mutates the receiver, so no
         // writeback. Instance / non-IO Package / aggregate receivers fall through.
         if let Some(result) = self.try_native_io_coercion(&target, method, &args) {
+            return result;
+        }
+        // Native `.encode` (Cool scalar -> Buf) / `.decode` (Buf/Blob -> Str) for
+        // variable receivers (`$s.encode("utf-16")`) — same pure transformation as
+        // the non-mut path; returns a *new* Buf/Str, no writeback.
+        if let Some(result) = self.try_native_encode_decode(&target, method, &args) {
             return result;
         }
         // TODO: compile to bytecode — native/Buf/Failure method fork, mut (ledger §1).

--- a/t/native-encode-decode.t
+++ b/t/native-encode-decode.t
@@ -1,0 +1,62 @@
+use Test;
+
+# Pin for VM-native `.encode` (Cool scalar -> Buf) and `.decode` (Buf/Blob -> Str)
+# (ledger §D). The explicit-encoding forms (`"x".encode("utf-16")`, `$buf.decode`)
+# used to bounce to the interpreter's `dispatch_method_by_name` catch-all; they are
+# pure transformations over the VM-owned encoding registry (no io_handles), so the
+# VM now dispatches them natively via `try_native_encode_decode` — the single shared
+# `dispatch_encode`/`dispatch_decode` impl. Both literal and variable receivers
+# (mut path) are exercised. The 0-arg `.encode` is already native via methods_0arg.
+
+plan 23;
+
+# --- .encode on a Str ---
+is "abc".encode("utf-8").elems, 3,        '.encode("utf-8") yields 3 bytes';
+is "abc".encode("utf-8")[0], 0x61,        '.encode first byte is "a"';
+ok "abc".encode("utf-8") ~~ Blob,         '.encode returns a Blob';
+is "héllo".encode("utf-8").elems, 6,      '.encode counts utf-8 bytes (é = 2)';
+
+# utf-16 .elems counts 16-bit units (one per BMP codepoint), not bytes
+is "xy".encode("utf-16").elems, 2,        '.encode("utf-16") counts 16-bit units';
+
+# ascii / latin-1 single-byte encodings
+is "abc".encode("ascii").elems, 3,        '.encode("ascii") is single-byte';
+is "abc".encode("latin-1").elems, 3,      '.encode("latin-1") is single-byte';
+
+# --- .encode on other Cool scalars ---
+is 42.encode("utf-8").decode, "42",       'Int.encode stringifies then encodes';
+is True.encode("utf-8").decode, "True",   'Bool.encode stringifies then encodes';
+is (1/2).encode("utf-8").decode, "0.5",   'Rat.encode stringifies then encodes';
+
+# --- .decode on a Buf/Blob ---
+is Buf.new(0x61, 0x62, 0x63).decode("utf-8"), "abc", '.decode("utf-8") of ASCII bytes';
+is Buf.new(0xc3, 0xa9).decode("utf-8"), "é",          '.decode("utf-8") of a 2-byte sequence';
+is Buf.new(0x41, 0x42).decode, "AB",                  '.decode defaults to utf-8';
+is Blob.new(0x68, 0x69).decode("ascii"), "hi",        '.decode("ascii") of a Blob';
+
+# round-trip
+is "round trip ☃".encode("utf-8").decode("utf-8"), "round trip ☃",
+   '.encode -> .decode round-trips through utf-8';
+is "wide ☃".encode("utf-16").decode("utf-16"), "wide ☃",
+   '.encode -> .decode round-trips through utf-16';
+
+# --- variable receivers (mut path / CallMethodMut) ---
+my $s = "data";
+is $s.encode("utf-8").elems, 4,           'variable Str.encode';
+ok $s.encode("utf-8") ~~ Blob,            'variable Str.encode is a Blob';
+my $b = Buf.new(0x6f, 0x6b);
+is $b.decode("utf-8"), "ok",              'variable Buf.decode';
+my $enc = "z";
+is $enc.encode("utf-16").elems, 1,        'variable Str.encode("utf-16") in 16-bit units';
+
+# receiver is not mutated by encode/decode (new value returned)
+my $orig = "keep";
+$orig.encode("utf-8");
+is $orig, "keep",                         '.encode does not mutate the receiver';
+my $bo = Buf.new(0x78);
+$bo.decode;
+is $bo.elems, 1,                          '.decode does not mutate the receiver';
+
+# --- decode on a non-Buf falls through (still works via interpreter) ---
+# (Str has no .decode; ensure we did not break the fall-through path.)
+ok "abc".encode.elems == 3,               '0-arg .encode still works (methods_0arg)';


### PR DESCRIPTION
## Summary

After the IO::Path FS family, the next clean native-method drainage. The explicit-encoding forms `"x".encode("utf-16")` / `$buf.decode("ascii")` bounced to the interpreter's `dispatch_method_by_name` catch-all (the 0-arg `.encode` is already native via methods_0arg). These are pure Str↔Buf transformations over the VM-owned `encoding_registry` (`find_encoding`/`encode_with_encoding`/`decode_with_encoding`, all `&self`) and allocate **no io_handles**.

## Changes

- Add a `pub(crate)` helper `try_native_encode_decode` in `crate::runtime` (methods_io_dispatch.rs, so it can call the `pub(super)` `dispatch_encode`/`dispatch_decode` — same pattern as the IO::Path helpers) and call it from the VM's non-mut and mut catch-alls right after `try_native_io_coercion` (1 op = 1 impl).
- **Conservative gating**: `.encode` is limited to plain Cool scalars (Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool); `.decode` is gated by `dispatch_decode` itself to Buf/Blob instances (returns None otherwise). User Instances (custom .encode/.decode resolved earlier as compiled methods), Supply (its own chunk-encode), and Buf receivers for `.encode` fall through — behavior-invariant.

The methods return a fresh Buf/Str and never mutate the receiver, so no writeback.

## Verification

- Measured: `"x".encode("utf-16")` / `$buf.decode` method fallback **→ 0**.
- pin `t/native-encode-decode.t` (23 subtests: literal + variable receivers across encode utf-8/utf-16/ascii/latin-1, Int/Bool/Rat encode, Buf/Blob decode, round-trips; raku + mutsu both pass).
- encoding / buf / S32-str / encode whitelist green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)