### PR TITLE
feat(parser): top-level ; sections a list/array literal into sub-lists

### DIFF
--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -234,26 +234,44 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
     };
     let (input, _) = parse_char(input, sep)?;
     let (input, _) = ws(input)?;
+    // A top-level `;` inside `(...)` separates the list into "sections", one per
+    // semicolon-group: `(1,2;3,4)` is `((1,2),(3,4))`, not the flat `(1,2,3,4)`.
+    // `items` accumulates the CURRENT section; completed sections move into
+    // `sections`. With no semicolon present, the result is the usual flat list.
+    let mut sections: Vec<Vec<Expr>> = Vec::new();
     let mut items = vec![first];
-    if let Some(result) = try_inline_modifier(input, finalize_paren_list(items.clone())) {
+    let mut saw_semicolon = false;
+    if sep == ';' {
+        saw_semicolon = true;
+        sections.push(std::mem::take(&mut items));
+    }
+    if !saw_semicolon
+        && let Some(result) = try_inline_modifier(input, finalize_paren_list(items.clone()))
+    {
         let (rest, modified_expr) = result?;
         let (rest, _) = ws(rest)?;
         let (rest, _) = parse_char(rest, ')')?;
         return Ok((rest, modified_expr));
     }
-    // Handle trailing comma before close paren
+    // Handle trailing comma/semicolon before close paren
     if let Ok((input, _)) = parse_char(input, ')') {
-        return Ok((input, finalize_paren_list(items)));
+        return Ok((
+            input,
+            finalize_paren_sections(sections, items, saw_semicolon),
+        ));
     }
     let (mut input_rest, second) = expression_no_sequence(input)?;
     items.push(second);
     loop {
         let (input, _) = ws(input_rest)?;
         if let Ok((input, _)) = parse_char(input, ')') {
-            return Ok((input, finalize_paren_list(items)));
+            return Ok((
+                input,
+                finalize_paren_sections(sections, items, saw_semicolon),
+            ));
         }
-        // Check for sequence operator before comma
-        if let Some(seq) = try_parse_sequence_in_paren(input, &items) {
+        // Check for sequence operator before comma (not inside a semicolon list)
+        if !saw_semicolon && let Some(seq) = try_parse_sequence_in_paren(input, &items) {
             return seq;
         }
         let sep = if input.starts_with(',') {
@@ -265,18 +283,60 @@ pub(super) fn paren_expr(input: &str) -> PResult<'_, Expr> {
         };
         let (input, _) = parse_char(input, sep)?;
         let (input, _) = ws(input)?;
-        if let Some(result) = try_inline_modifier(input, finalize_paren_list(items.clone())) {
+        if sep == ';' {
+            saw_semicolon = true;
+            sections.push(std::mem::take(&mut items));
+        }
+        if !saw_semicolon
+            && let Some(result) = try_inline_modifier(input, finalize_paren_list(items.clone()))
+        {
             let (rest, modified_expr) = result?;
             let (rest, _) = ws(rest)?;
             let (rest, _) = parse_char(rest, ')')?;
             return Ok((rest, modified_expr));
         }
         if let Ok((input, _)) = parse_char(input, ')') {
-            return Ok((input, finalize_paren_list(items)));
+            return Ok((
+                input,
+                finalize_paren_sections(sections, items, saw_semicolon),
+            ));
         }
         let (input, next) = expression_no_sequence(input)?;
         items.push(next);
         input_rest = input;
+    }
+}
+
+/// Combine semicolon-separated sections of a parenthesized list. With no
+/// semicolon seen the list is flat (`finalize_paren_list`). Otherwise each
+/// non-empty section becomes one element: a multi-item section is a sub-list,
+/// a single-item section is the bare item. A single overall section (e.g. a
+/// trailing `;`: `(1,2,3;)`) is NOT wrapped, matching Raku.
+fn finalize_paren_sections(
+    mut sections: Vec<Vec<Expr>>,
+    current: Vec<Expr>,
+    saw_semicolon: bool,
+) -> Expr {
+    if !saw_semicolon {
+        return finalize_paren_list(current);
+    }
+    if !current.is_empty() {
+        sections.push(current);
+    }
+    match sections.len() {
+        0 => Expr::ArrayLiteral(Vec::new()),
+        1 => build_paren_section(sections.into_iter().next().unwrap()),
+        _ => Expr::ArrayLiteral(sections.into_iter().map(build_paren_section).collect()),
+    }
+}
+
+/// Render one semicolon-section: a single item stays bare; multiple items form
+/// a sub-list (via `finalize_paren_list`, so meta-ops etc. still lift).
+fn build_paren_section(items: Vec<Expr>) -> Expr {
+    if items.len() == 1 {
+        items.into_iter().next().unwrap()
+    } else {
+        finalize_paren_list(items)
     }
 }
 
@@ -976,6 +1036,11 @@ pub(super) fn array_literal(input: &str) -> PResult<'_, Expr> {
     if let Ok((input, _)) = parse_char(input, ']') {
         return Ok((input, Expr::BracketArray(items, false)));
     }
+    // A top-level `;` sections an array composer just like a parenthesized list:
+    // `[1,2;3,4]` is `[(1,2),(3,4)]`. `items` is the current section; completed
+    // sections move into `sections`.
+    let mut sections: Vec<Vec<Expr>> = Vec::new();
+    let mut saw_semicolon = false;
     let (mut rest, first) = expression(input)?;
     items.push(first);
     loop {
@@ -983,7 +1048,10 @@ pub(super) fn array_literal(input: &str) -> PResult<'_, Expr> {
         if let Ok((r, _)) = parse_char(r, ',') {
             let (r, _) = ws(r)?;
             if let Ok((r, _)) = parse_char(r, ']') {
-                return Ok((r, Expr::BracketArray(merge_sequence_seeds(items), true)));
+                return Ok((
+                    r,
+                    finalize_array_sections(sections, items, saw_semicolon, true),
+                ));
             }
             // After a separator we need another element or a closing `]`.
             // Hitting unparseable/end-of-input here means the array composer
@@ -991,10 +1059,28 @@ pub(super) fn array_literal(input: &str) -> PResult<'_, Expr> {
             let (r, next) = expression(r).map_err(|_| array_fail_goal())?;
             items.push(next);
             rest = r;
+        } else if r.starts_with(';') && !r.starts_with(";;") {
+            // Semicolon section separator.
+            let (r, _) = parse_char(r, ';')?;
+            let (r, _) = ws(r)?;
+            saw_semicolon = true;
+            sections.push(std::mem::take(&mut items));
+            if let Ok((r, _)) = parse_char(r, ']') {
+                return Ok((
+                    r,
+                    finalize_array_sections(sections, items, saw_semicolon, false),
+                ));
+            }
+            let (r, next) = expression(r).map_err(|_| array_fail_goal())?;
+            items.push(next);
+            rest = r;
         } else {
             let (r, _) = ws(r)?;
             if let Ok((r, _)) = parse_char(r, ']') {
-                return Ok((r, Expr::BracketArray(merge_sequence_seeds(items), false)));
+                return Ok((
+                    r,
+                    finalize_array_sections(sections, items, saw_semicolon, false),
+                ));
             }
             // Neither a separator nor the closing bracket: if another term
             // follows, this is "Two terms in a row" (X::Syntax::Confused),
@@ -1005,8 +1091,45 @@ pub(super) fn array_literal(input: &str) -> PResult<'_, Expr> {
             // We have parsed a valid array composer but cannot find the
             // closing `]` (e.g. `[1,2` at end of input): X::Comp::FailGoal.
             let (r, _) = parse_char(r, ']').map_err(|_| array_fail_goal())?;
-            return Ok((r, Expr::BracketArray(merge_sequence_seeds(items), false)));
+            return Ok((
+                r,
+                finalize_array_sections(sections, items, saw_semicolon, false),
+            ));
         }
+    }
+}
+
+/// Combine semicolon-separated sections of an array composer. With no semicolon
+/// the array is flat. Otherwise each non-empty section becomes one element: a
+/// multi-item section is a sub-list, a single-item section is the bare item. A
+/// single overall section (e.g. a trailing `;`: `[1,2,3;]`) stays flat.
+fn finalize_array_sections(
+    mut sections: Vec<Vec<Expr>>,
+    current: Vec<Expr>,
+    saw_semicolon: bool,
+    trailing_comma: bool,
+) -> Expr {
+    if !saw_semicolon {
+        return Expr::BracketArray(merge_sequence_seeds(current), trailing_comma);
+    }
+    if !current.is_empty() {
+        sections.push(current);
+    }
+    if sections.len() <= 1 {
+        let flat = sections.into_iter().next().unwrap_or_default();
+        return Expr::BracketArray(merge_sequence_seeds(flat), false);
+    }
+    let elems = sections.into_iter().map(build_array_section).collect();
+    Expr::BracketArray(elems, false)
+}
+
+/// Render one array section: a single item stays bare; multiple items form a
+/// sub-list (`ArrayLiteral`, so they render as `(a, b)`).
+fn build_array_section(items: Vec<Expr>) -> Expr {
+    if items.len() == 1 {
+        items.into_iter().next().unwrap()
+    } else {
+        Expr::ArrayLiteral(merge_sequence_seeds(items))
     }
 }
 

--- a/t/semicolon-list-literal.t
+++ b/t/semicolon-list-literal.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 22;
+
+# A top-level `;` inside `(...)` or `[...]` sections the list: each
+# semicolon-group becomes one element — a multi-item group is a sub-list, a
+# single-item group is the bare item. A single overall section is not wrapped.
+
+# --- Parenthesized lists ---
+is-deeply (1,2;3,4), ((1,2),(3,4)), 'paren: two multi-item sections';
+is (1,2;3,4).elems, 2, 'paren: section count';
+is-deeply (1,2;3,4;5,6), ((1,2),(3,4),(5,6)), 'paren: three sections';
+is-deeply (1,2;3), ((1,2),3), 'paren: mixed multi/single section';
+is-deeply (1;2,3), (1,(2,3)), 'paren: single then multi';
+is-deeply (1;2;3), (1,2,3), 'paren: all single-item sections flatten';
+is-deeply (1,2,3;), (1,2,3), 'paren: trailing semicolon, one section stays flat';
+is (1;), 1, 'paren: single item with trailing semicolon is bare';
+is-deeply (1,2;), (1,2), 'paren: one multi-item section with trailing semicolon';
+is-deeply (1..2;3..4), (1..2,3..4), 'paren: single-element Range sections';
+is (1,2;3,4).raku, '((1, 2), (3, 4))', 'paren: .raku nests';
+is-deeply (1,2;3,4)[1], (3,4), 'paren: subscript selects a section';
+is (1,2;3,4)[1][0], 3, 'paren: nested subscript';
+
+# Assignment preserves the nesting.
+my @a = (1,2;3,4);
+is @a.elems, 2, 'assigned array has 2 rows';
+is @a[1].sum, 7, 'second row sums correctly';
+
+# --- Array composers ---
+is-deeply [1,2;3,4], [(1,2),(3,4)], 'array: two multi-item sections';
+is [1,2;3,4].elems, 2, 'array: section count';
+is-deeply [1;2;3], [1,2,3], 'array: all single-item sections flatten';
+is-deeply [1,2,3;], [1,2,3], 'array: trailing semicolon stays flat';
+is-deeply [1,2;3], [(1,2),3], 'array: mixed sections';
+is-deeply [1;], [1], 'array: single item trailing semicolon is a 1-elem array';
+is [1,2;3,4].raku, '[(1, 2), (3, 4)]', 'array: .raku nests';


### PR DESCRIPTION
## Problem

A top-level `;` inside `(...)` or `[...]` was treated as a synonym for `,`, flattening every semicolon group:

```raku
say (1,2;3,4);        # raku: ((1 2) (3 4))   mutsu: (1 2 3 4)
say (1,2;3,4).elems;  # raku: 2               mutsu: 4
say [1,2;3,4];        # raku: [(1 2) (3 4)]   mutsu: parse error
```

## Fix

Both the parenthesized-list parser (`paren_expr`) and the array-composer parser (`array_literal`) now track the current section's items separately from completed sections. With no top-level `;` the result is the usual flat list. Otherwise each non-empty semicolon group becomes one element: a multi-item group is a sub-list, a single-item group is the bare item — matching Rakudo:

```raku
(1,2;3,4)    # ((1, 2), (3, 4))     (1;2;3)    # (1, 2, 3)
(1,2;3)      # ((1, 2), 3)          (1,2,3;)   # (1, 2, 3)
(1;)         # 1                    [1,2;3,4]  # [(1, 2), (3, 4)]
```

A single overall section (e.g. from a trailing `;`) is not wrapped. Sequence operators / inline statement modifiers are unchanged (they only apply when no top-level `;` is present).

## Scope notes

- Element itemization on retrieval (`@a[0].raku` → `$(...)`) is a separate, pre-existing behavior and is untouched — it also affects `((1,2),(3,4))[0].raku`.
- `for (1,2;3,4)` still hits C-style-`for` detection (separate, pre-existing); not addressed here.

## Tests

- New `t/semicolon-list-literal.t` (22 cases, paren + array).
- `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)