### PR TITLE
feat(state-ownership): native-ize IO::Path.comb — completes the FS family + fixes no-arg comb (ledger §D)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -519,6 +519,20 @@
   fallback → 0。pin `t/native-encode-decode.t`(23, literal + 変数受け手〔mut path〕× encode utf-8/utf-16/ascii/latin-1・Int/Bool/Rat
   encode・Buf/Blob decode・round-trip・raku/mutsu 双方 PASS。utf-16 `.elems`=16-bit ユニット数の注意込み)。encoding/buf/S32-str/encode
   whitelist 全緑。
+- **2026-06-23 (§D = `IO::Path.comb` を VM ネイティブ化＝IO::Path FS 族 100% 完結 ＋ no-arg comb バグ修正)**: IO::Path FS メソッド
+  族の**最後の 1 メソッド**。`comb` はファイル全体を読んで content を comb するが、matcher dispatch（`dispatch_comb_with_args`）は
+  regex/closure matcher が match エンジンを走らせるため `&mut self`＝ただし `io_handles` は触らない。新 `&mut self` ヘルパー
+  `try_io_path_comb`（read→`?` 用に `match` で error 整形）へ抽出し `native_io_path` は two-path 委譲の直後で委譲＝**1 操作 = 1 実装**
+  （comb arm を match から削除）。VM は two-path dispatch の隣（非mut/mut 両 path）で呼ぶ。**同時に pre-existing バグも修正**: 引数なし
+  `$path.IO.comb`（matcher 無し）が空 Seq を返していた（旧 arm が `dispatch_comb_with_args` の `None` を空にマップ）→ content を
+  grapheme 分割（`Str.comb` no-arg / Rakudo と一致）。`dispatch_comb_with_args` の `None`-no-arg セマンティクスは generic caller
+  （methods_dispatch_match.rs:187）と共有なので**修正は IO::Path comb helper にローカル**に留めた（None→grapheme）。実測:
+  `$p.comb`/`$p.comb(/re/)`/`$p.comb(N)` の fallback → 0。pin `t/native-io-path-comb.t`(17, literal + 変数受け手〔mut path〕× no-arg
+  grapheme・regex・Int chunk・Str fixed・limit・empty file・unicode・raku/mutsu 双方 PASS)。S16-io/S32-io/comb whitelist 全緑。
+  **★∴ IO::Path FS メソッド族（stat/content-read/fs-mutate/open/2-path/comb）が 100% VM ネイティブ化完了＝§D ③ の IO native 完遂。**
+  **clean な pure-value native-method ドレインも枯渇**（残カテゴリ＝③ 組込型 ctor〔Buf.new 等〕/ MOP carrier〔WHAT/name/can〕/
+  landmine〔Instance.Str/.Stringy/.raku/.gist〕/ block-exec slow path〔map/grep〕/ concurrency〔Supply/tap〕/ typed-array mutator・
+  いずれも別軸 or 構造的ブロッカー前提）。次の §D は ③ 組込型 ctor か tree-walk dispatch chain 削除の substrate（要設計・大）。
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 use num_traits::ToPrimitive;
 use std::path::Component;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Coerce a positional limit argument (the `$limit` of `.lines`/`.words`/`.get`
 /// reads) to a row count. Accepts any non-negative numeric, including an
@@ -1337,6 +1338,60 @@ impl Interpreter {
         }
     }
 
+    /// `IO::Path.comb`: read the whole file, then comb the content. The matcher
+    /// dispatch (`dispatch_comb_with_args`) is `&mut self` because a regex/closure
+    /// matcher runs the match engine — but it reads no `io_handles`, so the VM
+    /// dispatches `comb` natively (ledger §D): the single impl `native_io_path`
+    /// also delegates to. **Also fixes a pre-existing bug**: the no-matcher form
+    /// (`$path.IO.comb` with no positional) used to return an empty Seq here (the
+    /// old arm mapped `dispatch_comb_with_args`'s `None` to empty); it now splits
+    /// the content into graphemes, matching `Str.comb` and Rakudo. Returns `None`
+    /// for any other method.
+    pub(crate) fn try_io_path_comb(
+        &mut self,
+        attributes: &HashMap<String, Value>,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method != "comb" {
+            return None;
+        }
+        let p = attributes
+            .get("path")
+            .map(|v| v.to_string_value())
+            .unwrap_or_default();
+        let path_buf = self.resolve_io_path_buf(attributes, &p);
+        let content = match fs::read_to_string(&path_buf) {
+            Ok(c) => super::utils::strip_utf8_bom(c),
+            Err(err) => {
+                return Some(Err(RuntimeError::new(format!(
+                    "Failed to read '{}': {}",
+                    p, err
+                ))));
+            }
+        };
+        // Filter out :close (irrelevant for IO::Path) before delegating.
+        let comb_args: Vec<Value> = args
+            .iter()
+            .filter(|a| !matches!(a, Value::Pair(k, _) if k == "close"))
+            .cloned()
+            .collect();
+        Some(
+            match self.dispatch_comb_with_args(Value::str(content.clone()), &comb_args) {
+                Some(res) => res,
+                // No matcher: comb into graphemes (same as `Str.comb` with no
+                // args / Rakudo). The old arm wrongly returned an empty Seq.
+                None => {
+                    let parts: Vec<Value> = content
+                        .graphemes(true)
+                        .map(|g| Value::str(g.to_string()))
+                        .collect();
+                    Ok(Value::Seq(std::sync::Arc::new(parts)))
+                }
+            },
+        )
+    }
+
     pub(super) fn native_io_path(
         &mut self,
         attributes: &HashMap<String, Value>,
@@ -1385,6 +1440,12 @@ impl Interpreter {
         // paths against the VM-owned cwd, one-shot syscall, no `io_handles`, shared
         // with the VM's native dispatch via `try_io_path_two_path_op`.
         if let Some(result) = self.try_io_path_two_path_op(attributes, method, &args) {
+            return result;
+        }
+        // `comb` reads the whole file then combs the content (matcher dispatch is
+        // `&mut self` but touches no `io_handles`) — shared with the VM's native
+        // dispatch via `try_io_path_comb`.
+        if let Some(result) = self.try_io_path_comb(attributes, method, &args) {
             return result;
         }
         // The concrete class of the receiver (`IO::Path` or a SPEC-variant
@@ -1543,22 +1604,8 @@ impl Interpreter {
             // shared `try_io_path_fs_stat`, which the VM also dispatches natively.
             // `lines`/`words` (whole-file content reads) are handled above by the
             // shared `try_io_path_content_read`, which the VM also dispatches
-            // natively. `comb` stays here: its regex/closure dispatch needs `&mut`.
-            "comb" => {
-                let content = fs::read_to_string(&path_buf)
-                    .map_err(|err| RuntimeError::new(format!("Failed to read '{}': {}", p, err)))?;
-                let content = super::utils::strip_utf8_bom(content);
-                // Filter out :close (irrelevant for IO::Path) before delegating.
-                let comb_args: Vec<Value> = args
-                    .iter()
-                    .filter(|a| !matches!(a, Value::Pair(k, _) if k == "close"))
-                    .cloned()
-                    .collect();
-                match self.dispatch_comb_with_args(Value::str(content), &comb_args) {
-                    Some(res) => res,
-                    None => Ok(Value::Seq(std::sync::Arc::new(Vec::new()))),
-                }
-            }
+            // natively. `comb` is handled above by the shared `try_io_path_comb`,
+            // which the VM also dispatches natively.
             // `slurp` (whole-file content read) is handled above by the shared
             // `try_io_path_content_read`, which the VM also dispatches natively.
             // `open` (allocates an `io_handles` entry) is handled above by the

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -265,6 +265,14 @@ impl Interpreter {
             {
                 return result;
             }
+            // Interpreter-native `comb`: read the file then comb the content (no
+            // `io_handles`; ledger §D). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) = self.try_io_path_comb(&attributes.as_map(), method, &args)
+            {
+                return result;
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
@@ -1847,6 +1855,14 @@ impl Interpreter {
                 && let Value::Instance { attributes, .. } = &target
                 && let Some(result) =
                     self.try_io_path_two_path_op(&attributes.as_map(), method, &args)
+            {
+                return result;
+            }
+            // Interpreter-native `comb`: read the file then comb the content (no
+            // `io_handles`; ledger §D). Single impl shared with `native_io_path`.
+            if Self::is_io_path_lexical_class(&class)
+                && let Value::Instance { attributes, .. } = &target
+                && let Some(result) = self.try_io_path_comb(&attributes.as_map(), method, &args)
             {
                 return result;
             }

--- a/t/native-io-path-comb.t
+++ b/t/native-io-path-comb.t
@@ -1,0 +1,62 @@
+use Test;
+
+# Pin for VM-native `IO::Path.comb` (ledger §D) — the last IO::Path FS method, so
+# this completes the family (stat / content-read / fs-mutate / open / two-path /
+# comb all VM-native). `comb` reads the whole file then combs the content; the
+# matcher dispatch is `&mut self` (a regex/closure matcher runs the match engine)
+# but touches no io_handles, so the VM dispatches it natively via `try_io_path_comb`
+# — the single impl `native_io_path` also delegates to.
+#
+# This slice ALSO fixes a pre-existing bug: the no-matcher form (`$path.IO.comb`
+# with no positional argument) used to return an empty Seq; it now splits the file
+# content into graphemes, matching `Str.comb` and Rakudo.
+
+plan 17;
+
+my $dir = "tmp/native-io-comb-$*PID";
+$dir.IO.mkdir;
+.unlink for $dir.IO.dir;
+my $f = "$dir/data.txt";
+spurt $f, "abc123def456";
+my $u = "$dir/uni.txt";
+spurt $u, "héllo wörld";
+
+# --- no-matcher comb: graphemes (the bug fix) ---
+is $f.IO.comb.elems, 12,                    '.comb (no arg) combs into graphemes';
+is $f.IO.comb[0], 'a',                       '.comb (no arg) first grapheme';
+is $f.IO.comb.join, 'abc123def456',          '.comb (no arg) round-trips the content';
+is $u.IO.comb.elems, 11,                     '.comb (no arg) counts graphemes for unicode';
+isa-ok $f.IO.comb, Seq,                      '.comb returns a Seq';
+
+# --- regex matcher ---
+is $f.IO.comb(/\d+/).raku, ("123", "456").Seq.raku, '.comb(/regex/) extracts matches';
+is $f.IO.comb(/<[a..z]>+/).raku, ("abc", "def").Seq.raku, '.comb(/letters/) extracts runs';
+
+# --- Int chunk matcher ---
+is $f.IO.comb(3).raku, ("abc", "123", "def", "456").Seq.raku, '.comb(Int) chunks';
+is $f.IO.comb(4).elems, 3,                   '.comb(Int) chunk count';
+
+# --- Str fixed matcher ---
+is $f.IO.comb("e").raku, ("e",).Seq.raku, '.comb(Str) finds the fixed substring';
+
+# --- limit (second positional) ---
+is $f.IO.comb(/\d/, 2).raku, ("1", "2").Seq.raku, '.comb(/regex/, $limit) truncates';
+is $f.IO.comb(2, 2).raku, ("ab", "c1").Seq.raku, '.comb(Int, $limit) truncates';
+
+# --- variable receiver (mut path / CallMethodMut) ---
+my $p = $f.IO;
+is $p.comb.elems, 12,                        'variable receiver .comb (no arg)';
+is $p.comb(/\d+/).raku, ("123", "456").Seq.raku, 'variable receiver .comb(/regex/)';
+
+# receiver path is not mutated
+is $p.Str, $f, '.comb does not mutate the receiver path';
+
+# --- empty file: no-arg comb yields an empty Seq ---
+my $e = "$dir/empty.txt";
+spurt $e, "";
+is $e.IO.comb.elems, 0,                      '.comb of an empty file is empty';
+
+# cleanup
+.unlink for $dir.IO.dir;
+$dir.IO.rmdir;
+ok True, 'cleanup ran';


### PR DESCRIPTION
## Summary

The **last IO::Path filesystem method**, so this completes the family. `comb` reads the whole file then combs the content; the matcher dispatch (`dispatch_comb_with_args`) is `&mut self` because a regex/closure matcher runs the match engine, but it touches **no `io_handles`**, so the VM dispatches it natively.

## Changes

- Extract a `&mut self` helper `try_io_path_comb`. `native_io_path` delegates right after the two-path delegation; the comb arm is removed from its match (1 op = 1 impl). The VM calls the helper next to the two-path dispatch on both non-mut and mut paths.
- **Also fixes a pre-existing bug**: the no-matcher form (`$path.IO.comb` with no positional) returned an empty Seq (the old arm mapped `dispatch_comb_with_args`'s `None` to empty). It now splits the content into graphemes, matching `Str.comb` with no args and Rakudo. The `None`-for-no-arg semantics are shared with the generic caller, so the fix is kept local to the IO::Path comb helper.

With this slice the whole **IO::Path FS method family (stat / content-read / fs-mutate / open / two-path / comb) is VM-native** — §D ③'s IO native work is complete.

## Verification

- Measured: `$p.comb` / `$p.comb(/re/)` / `$p.comb(N)` method fallback **→ 0**.
- pin `t/native-io-path-comb.t` (17 subtests: literal + variable receivers across no-arg grapheme split, regex / Int-chunk / Str-fixed matchers, limit, empty file, unicode; raku + mutsu both pass).
- S16-io / S32-io / comb whitelist green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)