### PR TITLE
feat(state-ownership): native-ize `.new` for `::`-namespaced classes & built-in exception types (§D ③)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -533,6 +533,20 @@
   **clean な pure-value native-method ドレインも枯渇**（残カテゴリ＝③ 組込型 ctor〔Buf.new 等〕/ MOP carrier〔WHAT/name/can〕/
   landmine〔Instance.Str/.Stringy/.raku/.gist〕/ block-exec slow path〔map/grep〕/ concurrency〔Supply/tap〕/ typed-array mutator・
   いずれも別軸 or 構造的ブロッカー前提）。次の §D は ③ 組込型 ctor か tree-walk dispatch chain 削除の substrate（要設計・大）。
+- **2026-06-23 (§D ③ = `::`-namespaced クラス／組込例外型の `.new` を VM ネイティブ化)**: ③ 組込型 ctor フォークの初スライス。
+  `is_native_default_constructible` の `cn_resolved.contains("::")` ガードが **全ての `::` namespaced クラス**（ユーザ `A::B`／
+  組込例外型 `X::AdHoc`・`X::TypeCheck::Binding` …）を native 構築から除外していた＝唯一のブロッカー。`[`（parametric）ガードは維持し
+  `::` ガードを削除。さらに組込例外型は registry に `attributes: Vec::new()`（宣言属性ゼロ・named args は `is_attribute_buildable` の
+  未宣言名 `true` フォールバックで attribute-bag 化）で登録されるため `has_attribute` が false → 末尾返却で除外されていた。MRO に
+  `Exception` を含むなら native 可（`build_native_default_instance` は同じ `is_attribute_buildable` で named args を格納＝interpreter と
+  byte-identical）として `has_attribute || is_exception` に変更。**VM call site（vm_call_method_compiled.rs:127）に
+  `materialize_exception_message_in_result` を追加**＝interpreter slow path（methods.rs:3369 が `dispatch_new` 後に呼ぶ）と等価に、
+  user `message` メソッドを構築時に1回走らせ `message` 属性へキャッシュ（built-in 例外・非例外は no-op）。user `message` を走らせる場合は
+  `method_dispatch_pure=false`（caller slot reconcile 保全）。`materialize_…` の可視性を `pub(super)`→`pub(crate)`。実測: `X::AdHoc.new`/
+  `X::TypeCheck::Binding.new`/`A::B.new`/`P::Q::R.new` の `new` fallback → 0。stash 比較で native==interpreter 出力完全一致を確認
+  （`message`/no-arg の raku 差異は変更前から存在する F-track `.message` 未実装ギャップで本変更と無関係）。pin
+  `t/native-namespaced-and-exception-ctor.t`(16)。make test 10971・S04/S12/S32 construction whitelist 全緑。**残 ③ ctor 候補＝
+  Promise 等並行型・misc 組込型（is_attribute_buildable で attribute-bag 化できない special 構築のもの）。**
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -48,9 +48,19 @@ impl Interpreter {
     /// data: assign (sigil-coerced) named args to attributes and evaluate
     /// attribute defaults.
     pub(crate) fn is_native_default_constructible(&self, cn_resolved: &str) -> bool {
-        if cn_resolved.contains('[') || cn_resolved.contains("::") {
+        // A parametric type name (`Hash[Int,Str]`, `array[int]`) needs the
+        // interpreter's parametric construction machinery — keep it out.
+        if cn_resolved.contains('[') {
             return false;
         }
+        // A `::`-namespaced name is allowed: built-in exception types
+        // (`X::AdHoc`, `X::TypeCheck::Binding`) and user `A::B` classes are pure
+        // attribute-bag data assembly just like a non-namespaced class, so they
+        // pass through the same eligibility checks below. (§D state-ownership: the
+        // VM constructs them natively instead of bouncing to `dispatch_new`.) The
+        // exception-`message` materialization that the interpreter applies after
+        // `dispatch_new` is reproduced at the native call sites via
+        // `materialize_exception_message_in_result`, so behavior stays identical.
         if !self.registry().classes.contains_key(cn_resolved) {
             return false;
         }
@@ -81,7 +91,18 @@ impl Interpreter {
         // `apply_attribute_does_role_mixins` helper (same approximation as the
         // full constructor), as a post-assembly phase.
         let mut has_attribute = false;
+        // A built-in exception type (`X::AdHoc`, `X::TypeCheck::Binding`, ...) is
+        // registered with NO declared attributes — its named constructor args
+        // (`payload`, `got`, `expected`, ...) are stored as a generic attribute
+        // bag via `is_attribute_buildable`'s undeclared-name `true` fallback, which
+        // `build_native_default_instance` already honours identically to the
+        // interpreter. So such a class is native-constructible even though
+        // `has_attribute` stays false; track that here.
+        let mut is_exception = false;
         for cls in self.mro_readonly(cn_resolved) {
+            if cls == "Exception" {
+                is_exception = true;
+            }
             if cls == "Any" || cls == "Mu" || cls == "Cool" {
                 continue;
             }
@@ -196,7 +217,7 @@ impl Interpreter {
             }
             has_attribute |= !class_def.attributes.is_empty();
         }
-        has_attribute
+        has_attribute || is_exception
     }
 
     /// A type constraint the native default constructor can enforce with a plain
@@ -1674,7 +1695,7 @@ impl Interpreter {
     /// as a method and have no `message` attribute, so built-in and
     /// attribute-message exceptions are unaffected. Errors in the message method
     /// are swallowed (the exception is still returned un-materialized).
-    pub(super) fn materialize_exception_message_in_result(
+    pub(crate) fn materialize_exception_message_in_result(
         &mut self,
         result: Result<Value, RuntimeError>,
     ) -> Result<Value, RuntimeError> {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -128,14 +128,26 @@ impl Interpreter {
             && let Value::Package(class_name) = &target
             && let Some(result) = loan_env!(self, try_native_default_construct(*class_name, &args))
         {
+            // An exception type with a user-defined `message` method needs that
+            // method run once at construction and cached into the `message`
+            // attribute, exactly as the interpreter's `dispatch_new` caller does
+            // (`materialize_exception_message_in_result`). For built-in exceptions
+            // and non-exceptions this is a no-op (no user `message` method).
+            let cn = class_name.resolve();
+            let result = self.materialize_exception_message_in_result(result);
             // Native construction of an attribute-only class is pure data assembly
             // (named args + defaults; writes nothing to the caller env, Slice 6.3).
             // BUT if the class has a `submethod BUILD`/`TWEAK`, the native path runs
             // that phase, whose body can mutate a captured-outer caller lexical
             // (`my $n; submethod TWEAK { $n++ }`) — so that construction is NOT
             // env-pure: leave the dispatch impure so the call site reconciles the
-            // caller's slot (Slice F, `reconcile_locals_from_env_at_site`).
-            self.method_dispatch_pure = !self.mro_has_build_or_tweak(&class_name.resolve());
+            // caller's slot (Slice F, `reconcile_locals_from_env_at_site`). A
+            // user `message` method materialized above can likewise run user code,
+            // so treat that as impure too.
+            let runs_message =
+                (cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::"))
+                    && self.has_user_method(&cn, "message");
+            self.method_dispatch_pure = !self.mro_has_build_or_tweak(&cn) && !runs_message;
             return result;
         }
         // Native built-in construction: `Buf`/`Blob` (byte overlay), `utf8`/

--- a/t/native-namespaced-and-exception-ctor.t
+++ b/t/native-namespaced-and-exception-ctor.t
@@ -1,0 +1,62 @@
+use Test;
+
+# §D state-ownership: the VM constructs `::`-namespaced classes and built-in
+# exception types natively (no interpreter `.new` bounce), behaving identically
+# to the interpreter's generic constructor.
+
+plan 16;
+
+# --- user `A::B` namespaced class (declared attributes) ---
+{
+    class A::B { has $.x; has Int $.y = 5; }
+    my $o = A::B.new(x => 10);
+    is $o.x, 10, 'namespaced class: provided attr';
+    is $o.y, 5, 'namespaced class: default attr';
+    is $o.^name, 'A::B', 'namespaced class: name';
+}
+
+# --- deeper namespace ---
+{
+    class P::Q::R { has $.v = 42; }
+    is P::Q::R.new.v, 42, 'three-level namespace default';
+    is P::Q::R.new(v => 1).v, 1, 'three-level namespace provided';
+}
+
+# --- built-in exception type: attribute-bag construction ---
+{
+    my $e = X::AdHoc.new(payload => "boom");
+    is $e.payload, "boom", 'X::AdHoc payload stored';
+    is $e.message, "boom", 'X::AdHoc message from payload';
+    is $e.^name, 'X::AdHoc', 'X::AdHoc name';
+    ok $e ~~ X::AdHoc, 'X::AdHoc isa X::AdHoc';
+    ok $e ~~ Exception, 'X::AdHoc isa Exception';
+}
+
+# --- nested built-in exception type ---
+{
+    my $t = X::TypeCheck::Binding.new(got => 1, expected => Str);
+    is $t.^name, 'X::TypeCheck::Binding', 'nested exception name';
+    ok $t ~~ X::TypeCheck, 'nested exception isa parent';
+    is $t.got, 1, 'nested exception got attr';
+}
+
+# --- user exception with a `message` method (materialize at construction) ---
+{
+    my class X::My::Boom is Exception {
+        has $.detail;
+        method message { "boom: " ~ $.detail }
+    }
+    my $e = X::My::Boom.new(detail => "kaboom");
+    is $e.message, "boom: kaboom", 'user exception message method materialized';
+    is $e.detail, "kaboom", 'user exception attr';
+}
+
+# --- throwing a natively-constructed exception still works ---
+{
+    my $caught;
+    {
+        CATCH { default { $caught = .message } }
+        die X::AdHoc.new(payload => "thrown");
+    }
+    is $caught, "thrown", 'natively-constructed exception throws & catches';
+}


### PR DESCRIPTION
## Summary

§D state-ownership (prerequisite ②) — first slice of the **③ built-in type ctor** fork laid out in the last handoff. The VM now constructs `::`-namespaced classes and built-in exception types natively instead of bouncing every `.new` to the interpreter's generic `dispatch_new`.

- `is_native_default_constructible`: drop the `contains("::")` guard (keep the `[`-parametric guard). Namespaced user `A::B` classes now pass the same eligibility checks as non-namespaced ones.
- Built-in exception types (`X::AdHoc`, `X::TypeCheck::Binding`, ...) register with **zero declared attributes**; their named ctor args become a generic attribute bag via `is_attribute_buildable`'s undeclared-name `true` fallback, which `build_native_default_instance` already honours identically to the interpreter. Allow them through the final eligibility return (`has_attribute || is_exception`, keyed on `Exception` in the MRO).
- Reproduce the interpreter's post-`dispatch_new` `materialize_exception_message_in_result` at the VM native call site, so an exception with a user `message` method still caches its computed message at construction. Marked impure when that user code runs. No-op for built-in exceptions / non-exceptions.

## Verification

- **native == interpreter**: stash-compared output is byte-identical. The `message`/no-arg raku divergences are pre-existing F-track `.message` gaps, unrelated to this change.
- VM stats: `X::AdHoc.new` / `X::TypeCheck::Binding.new` / `A::B.new` / `P::Q::R.new` `new` interpreter fallback → 0.
- `make test` 10971 PASS; pin `t/native-namespaced-and-exception-ctor.t` (16); S04/S12/S32 construction whitelist spot-checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)