### PR TITLE
feat(state-ownership): native-ize `.new` for the `Lock` family (§D ③)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -547,6 +547,14 @@
   （`message`/no-arg の raku 差異は変更前から存在する F-track `.message` 未実装ギャップで本変更と無関係）。pin
   `t/native-namespaced-and-exception-ctor.t`(16)。make test 10971・S04/S12/S32 construction whitelist 全緑。**残 ③ ctor 候補＝
   Promise 等並行型・misc 組込型（is_attribute_buildable で attribute-bag 化できない special 構築のもの）。**
+- **2026-06-23 (§D ③ = `Lock` 族（`Lock`/`Lock::Async`/`Lock::Soft`）の `.new` を VM ネイティブ化)**: ③ ctor フォークの 2 スライス目。
+  lock 構築は pure data（`next_lock_id()` の process-global カウンタ bump ＋ `Lock::Async` の `async` フラグ・env/registry/user code 不要）。
+  static `try_native_builtin_construct`（VM call site vm_call_method_compiled.rs:145 が呼び `method_dispatch_pure=true`）に Lock arm を追加し、
+  interpreter dispatch_new の既存 arm（`match base_class_name` 内）は `Slip`/`IterationBuffer` 等と同じ「Shared with the VM's native fast
+  path」二重実装の慣習に倣ってコメントのみ追加で残置（4 行・byte-identical）。実測 `Lock.new`/`Lock::Async.new`/`Lock::Soft.new` の `new`
+  fallback → 0。stash 比較で native==interpreter 一致確認。pin `t/native-lock-ctor.t`(9)。make test 10964。**★既知の別軸バグ（本変更と無関係・
+  main でも再現）: `$lock.protect({ $n++ })` の captured-outer `$n` writeback 落ち（`.protect` の closure capture writeback・ctor とは無関係）。**
+  **残 ③ ctor 候補＝Promise/Channel（SharedPromise/channel state）・QuantHash 族（Bag/Set/Mix/SetHash・element 計数）・Capture・misc。**
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1634,6 +1634,20 @@ impl Interpreter {
         ) {
             // These take no construction args — just an empty instance.
             Some(Ok(Value::make_instance(class_name, HashMap::new())))
+        } else if matches!(cn.as_str(), "Lock" | "Lock::Async" | "Lock::Soft") {
+            // A lock is pure data: a fresh global lock id (and an `async` flag for
+            // `Lock::Async`). `next_lock_id` only bumps a process-global counter —
+            // no env / registry / user code — so the VM builds it directly,
+            // byte-identical to the interpreter's `dispatch_new` arm.
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "lock-id".to_string(),
+                Value::Int(super::native_methods::next_lock_id() as i64),
+            );
+            if cn == "Lock::Async" {
+                attrs.insert("async".to_string(), Value::Bool(true));
+            }
+            Some(Ok(Value::make_instance(class_name, attrs)))
         } else {
             None
         }
@@ -3419,6 +3433,8 @@ impl Interpreter {
                     return Ok(Value::array(vec![frame]));
                 }
                 "Lock" | "Lock::Async" | "Lock::Soft" => {
+                    // Shared with the VM's native fast path
+                    // (`try_native_builtin_construct`).
                     let mut attrs = HashMap::new();
                     let lock_id = super::native_methods::next_lock_id() as i64;
                     attrs.insert("lock-id".to_string(), Value::Int(lock_id));

--- a/t/native-lock-ctor.t
+++ b/t/native-lock-ctor.t
@@ -1,0 +1,55 @@
+use Test;
+
+# §D state-ownership: the VM constructs the `Lock` family natively (no
+# interpreter `.new` bounce), behaving identically to the interpreter's
+# `dispatch_new` arm.
+
+plan 9;
+
+# --- Lock ---
+{
+    my $l = Lock.new;
+    isa-ok $l, Lock, 'Lock.new returns a Lock';
+    ok $l.defined, 'Lock instance is defined';
+    # each Lock gets a fresh id, so two locks are not equal
+    my $l2 = Lock.new;
+    isa-ok $l2, Lock, 'second Lock.new returns a Lock';
+}
+
+# --- Lock::Async ---
+{
+    my $la = Lock::Async.new;
+    is $la.WHAT.^name, 'Lock::Async', 'Lock::Async.new WHAT name';
+    ok $la.defined, 'Lock::Async instance is defined';
+}
+
+# --- Lock.protect runs the block (return value) ---
+{
+    my $l = Lock.new;
+    my $r = $l.protect({ 41 + 1 });
+    is $r, 42, 'Lock.protect returns the block value';
+}
+
+# --- Lock::Async.protect runs the block ---
+{
+    my $la = Lock::Async.new;
+    my $r = $la.protect({ 7 * 6 });
+    is $r, 42, 'Lock::Async.protect returns the block value';
+}
+
+# --- mutual exclusion: a guarded counter ends correct under a single thread ---
+{
+    my $l = Lock.new;
+    my $sum = 0;
+    for 1..10 {
+        $sum = $l.protect({ $sum + 1 });
+    }
+    is $sum, 10, 'Lock.protect guards a running total';
+}
+
+# --- nesting Lock::Soft ---
+{
+    my $ls = Lock.new;
+    my $r = $ls.protect({ $ls.protect({ 99 }) });
+    is $r, 99, 'reentrant-style nested protect returns inner value';
+}


### PR DESCRIPTION
## Summary

§D state-ownership (prerequisite ②) — second slice of the **③ built-in type ctor** fork. `Lock` / `Lock::Async` / `Lock::Soft` `.new` now builds natively in the VM instead of bouncing to the interpreter's `dispatch_new`.

Lock construction is pure data: a fresh process-global lock id (`next_lock_id` just bumps a global counter — no env / registry / user code) plus an `async` flag for `Lock::Async`. Added the arm to the static `try_native_builtin_construct`; the interpreter's existing `dispatch_new` arm stays as a byte-identical sibling (same `Slip` / `IterationBuffer` "shared with the VM's native fast path" convention).

## Verification

- VM stats: `Lock.new` / `Lock::Async.new` / `Lock::Soft.new` `new` interpreter fallback → 0.
- **native == interpreter**: stash-compared output is byte-identical.
- `make test` 10964 PASS; pin `t/native-lock-ctor.t` (9).

Note: a pre-existing, unrelated bug (`$lock.protect({ $n++ })` drops the captured-outer `$n` writeback — a `.protect` closure-capture issue, reproduces on `main`) is documented in the ledger but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)