### PR TITLE
feat(nativecall): minimal C FFI for `is native(...)` subs (MVP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
+name = "libffi"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +427,8 @@ dependencies = [
  "icu_collator",
  "icu_collator_data",
  "libc",
+ "libffi",
+ "libloading",
  "num-bigint",
  "num-integer",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["native"]
-native = ["rustyline", "libc", "pcre2"]
+native = ["rustyline", "libc", "pcre2", "libloading", "libffi"]
 wasm = ["wasm-bindgen", "console_error_panic_hook"]
+# NativeCall (C FFI) support — gated under `native`; wasm builds cannot do FFI.
+libloading = ["dep:libloading"]
+libffi = ["dep:libffi"]
 
 [dependencies]
 regex = "1.12.3"
@@ -34,6 +37,8 @@ serde_json = "1"
 bincode = "1"
 icu_collator = "2.1"
 icu_collator_data = "2.1"
+libloading = { version = "0.8", optional = true }
+libffi = { version = "3", optional = true }
 
 [profile.release]
 debug = true

--- a/PLAN.md
+++ b/PLAN.md
@@ -178,12 +178,20 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     HTTP::Server::Tiny のリクエストループが `done` を使うなら要修正。
   - **HTTP::Status v0.0.5**: user `method sink` がシンクコンテキストで呼ばれず status table が空。
     ⚠️ 注意: 過去に sink 修正は sink.t を回帰させた（メモリ `sink-context-blocked-container-identity` 参照）。
-- [ ] **DB アクセス — sqlite3 CLI ラッパ（pure Raku）が現実解。**
-  - **DBIish/DBDish**: NativeCall 依存 → **ブロック**（ドライバは `sqlite3_*` C API）。API shape のみ再利用可。
-  - **推奨**: `run`/`qqx` で `sqlite3`（`/usr/bin/sqlite3` 3.45.1, インストール済）を呼ぶ薄い pure-Raku ラッパ。
-    mutsu の `run`/`qqx`（`:out`/`:err`/`exitcode`）は raku とバイト一致で動作確認済。`sqlite3 -json` で行を JSON 出力可。
-    工数 ~1-2日。値エスケープ/1クエリ1プロセスは要注意。
-  - **フォールバック**: flat-file `.raku`＋`EVALFILE`（mutsu で round-trip 確認済）は今日すぐ動く MVP。
+- [ ] **NativeCall（C FFI）— MVP landed、DBDish への正攻法。**
+  - **✅ MVP（#TBD）**: `is native(...)` の sub を `dlopen`+`libffi` で実 C 呼び出し。スカラ整数/浮動小数・
+    `Str`→`char*`・`Pointer`・戻り値 `char*`→`Str`・`is symbol(...)`・非デフォルトライブラリ（`is native('m')`/
+    `'sqlite3'`）に対応。soname フォールバック（`libfoo.so`→`.so.0/.1/.2`）で runtime-only システムでもロード。
+    実証: `abs`/`strlen`/`pow`/`sqrt`/`sqlite3_libversion()`→"3.45.1" が動作。担保＝`t/nativecall-mvp.t`。
+    実装＝`src/runtime/nativecall.rs`（`native` feature 下、wasm はスタブ）。`use NativeCall` は no-op 認識。
+  - **残（DBDish::SQLite に必要）**: ① `Pointer[T]` の out-param（`sqlite3_open` が `**ppDb` を返す）/ ②
+    `CArray[uint8]`・`CArray[Str]` / ③ `is repr('CStruct')` 構造体 / ④ callback（`sqlite3_exec` の行コールバック）。
+    ②③④は段階実装。①が最優先（接続ハンドルの取得）。
+  - **DBIish/DBDish**: 上記 NativeCall 拡張が揃えば原理的に動く（ドライバは `sqlite3_*` C API）。
+- [ ] **DB アクセス（NativeCall が揃うまでの代替）— sqlite3 CLI ラッパ（pure Raku）。**
+  - **代替**: `run`/`qqx` で `sqlite3`（`/usr/bin/sqlite3` 3.45.1）を呼ぶ薄い pure-Raku ラッパ。`sqlite3 -json` で
+    行を JSON 出力可。値エスケープ/1クエリ1プロセスは要注意。NativeCall 完成までの繋ぎ。
+  - **フォールバック**: flat-file `.raku`＋`EVALFILE`（mutsu で round-trip 確認済）。
 - **JSON は native 実装済み**（`to-json`/`from-json`・#3402・news 参照）。Template::Mustache 91/92-specs の残（別軸・
   本タスク外）= 実 spec の rendering ギャップ（delimiter 永続化／inheritable partials／lambda）＋ 最初の spec のみ
   `+$spec.value`=0 になる subtest/Seq-consumption 系バグ（itemization とは独立）。

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -177,6 +177,19 @@ impl Interpreter {
     }
 
     /// Peek at the callsite line from args without consuming or sanitizing them.
+    /// True for the synthetic callsite-line marker the compiler appends to some
+    /// call argument lists (for deprecation / test diagnostics). NativeCall (and
+    /// any raw-args consumer) must drop it before treating the list as real args.
+    pub(crate) fn is_callsite_line_marker(arg: &Value) -> bool {
+        match arg {
+            Value::Pair(key, _) => key == TEST_CALLSITE_LINE_KEY,
+            Value::ValuePair(key, _) => {
+                matches!(key.as_ref(), Value::Str(name) if name.as_str() == TEST_CALLSITE_LINE_KEY)
+            }
+            _ => false,
+        }
+    }
+
     pub(crate) fn peek_callsite_line(args: &[Value]) -> Option<i64> {
         for arg in args {
             match arg {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -198,6 +198,7 @@ mod native_supply_dispatch;
 mod native_supply_methods;
 mod native_supply_mut_methods;
 pub(crate) mod native_types;
+pub(crate) mod nativecall;
 mod ops;
 mod output_sink;
 pub(crate) mod phasers;
@@ -873,6 +874,10 @@ pub struct Interpreter {
     /// `std::process::exit()`.  Used by in-process `is_run` so that
     /// the nested interpreter does not kill the parent process.
     pub(crate) nested_mode: bool,
+    /// NativeCall (`is native`) sub descriptors, keyed by sub name. Populated at
+    /// declaration; a call to a name present here is routed through C FFI
+    /// instead of running the (`{ * }`) Raku body.
+    pub(crate) native_call_specs: HashMap<String, nativecall::NativeCallSpec>,
     operator_assoc: HashMap<String, String>,
     /// Operator sub names (infix:<..>, prefix:<..>, etc.) that have been
     /// imported into the current lexical scope via `use Module`. Used to
@@ -3109,6 +3114,7 @@ impl Interpreter {
             halted: false,
             exit_code: 0,
             nested_mode: false,
+            native_call_specs: HashMap::new(),
             operator_assoc: HashMap::new(),
             imported_operator_names: HashSet::new(),
             lib_paths: Vec::new(),
@@ -3862,6 +3868,10 @@ impl Interpreter {
                     | "fatal"
                     | "oo"
                     | "class"
+                    // NativeCall: the `is native(...)` trait machinery is built
+                    // into the VM (see runtime/nativecall.rs); `use NativeCall`
+                    // only needs to be a recognized no-op.
+                    | "NativeCall"
                     // JSON::Fast / JSON::Tiny: the real distributions depend on
                     // ~50 nqp ops mutsu does not implement. Recognize them as
                     // built-in modules and provide native `to-json`/`from-json`
@@ -5864,6 +5874,7 @@ impl Interpreter {
             halted: false,
             exit_code: 0,
             nested_mode: self.nested_mode,
+            native_call_specs: self.native_call_specs.clone(),
             operator_assoc: self.operator_assoc.clone(),
             imported_operator_names: self.imported_operator_names.clone(),
             lib_paths: self.lib_paths.clone(),

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -1,0 +1,314 @@
+//! Minimal NativeCall (C FFI) support.
+//!
+//! A sub declared with the `is native(...)` trait and a `{ * }` body is not run
+//! as Raku code; instead, at call time we `dlopen` the named shared library,
+//! `dlsym` the symbol, build a libffi CIF from the declared parameter / return
+//! types, marshal the Raku argument `Value`s into C values, perform the call,
+//! and marshal the C return value back into a `Value`.
+//!
+//! This is the MVP: scalar C types (signed/unsigned 8/16/32/64-bit integers,
+//! 32/64-bit floats), `Str` passed as a NUL-terminated `char*`, and an opaque
+//! `Pointer`. Aggregates (`CStruct`/`CArray`/`CUnion`), callbacks, and typed
+//! pointers are follow-up work.
+
+use crate::value::{RuntimeError, Value};
+
+/// A C type a native parameter or return value can take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CType {
+    Void,
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    F32,
+    F64,
+    /// `Str` marshalled as a NUL-terminated `char*` (input only in the MVP).
+    Str,
+    /// Opaque `Pointer` / `Pointer[T]` — carried as an integer address.
+    Pointer,
+}
+
+impl CType {
+    /// Map a Raku type-constraint name (from a signature) to a C type.
+    /// Returns `None` for an unrecognized / unsupported type name.
+    pub fn from_type_name(name: &str) -> Option<CType> {
+        Some(match name {
+            "int8" => CType::I8,
+            "int16" => CType::I16,
+            "int32" => CType::I32,
+            "int64" | "long" | "longlong" | "int" | "Int" => CType::I64,
+            "uint8" | "byte" => CType::U8,
+            "uint16" => CType::U16,
+            "uint32" => CType::U32,
+            "uint64" | "ulong" | "ulonglong" | "uint" | "size_t" => CType::U64,
+            "num32" => CType::F32,
+            "num64" | "num" | "Num" => CType::F64,
+            "Str" => CType::Str,
+            "Pointer" | "OpaquePointer" => CType::Pointer,
+            _ => return None,
+        })
+    }
+}
+
+/// The resolved descriptor for one `is native` sub: which library/symbol to
+/// call and the C signature to marshal against.
+// In a non-`libffi` build (wasm) the fields are only written, never read (the
+// `call_native` stub just errors), so suppress the dead-code lint there.
+#[cfg_attr(not(feature = "libffi"), allow(dead_code))]
+#[derive(Debug, Clone)]
+pub struct NativeCallSpec {
+    /// Library path/name as written in `is native(...)`. `None` means the trait
+    /// had no argument (look the symbol up in the C library / main program).
+    pub library: Option<String>,
+    /// C symbol name — from `is symbol('...')` if present, else the sub name.
+    pub symbol: String,
+    pub params: Vec<CType>,
+    pub ret: CType,
+}
+
+/// Candidate OS library file names for a `is native(<arg>)` argument, applying
+/// Raku's convention of supplying the platform prefix/suffix when only a bare
+/// stem is given. Several candidates are returned because the unversioned dev
+/// symlink (`libfoo.so`) is often a linker script or absent on a runtime-only
+/// system, while the versioned runtime object (`libfoo.so.N`) is present.
+#[cfg(feature = "libffi")]
+fn resolve_library_candidates(library: &Option<String>) -> Vec<String> {
+    let stem = match library {
+        // No argument, or the conventional "c" alias → the C runtime.
+        None => return vec!["libc.so.6".to_string()],
+        Some(name) if name == "c" => return vec!["libc.so.6".to_string()],
+        Some(name) if name == "m" => {
+            // libm is merged into glibc; prefer the versioned objects.
+            return vec![
+                "libm.so.6".to_string(),
+                "libc.so.6".to_string(),
+                "libm.so".to_string(),
+            ];
+        }
+        Some(name) => name,
+    };
+    // An explicit path or already-decorated name is used verbatim.
+    if stem.contains('/') || stem.contains(".so") || stem.contains(".dylib") {
+        return vec![stem.clone()];
+    }
+    // A bare stem like "sqlite3" → try the dev symlink and common runtime sonames.
+    vec![
+        format!("lib{stem}.so"),
+        format!("lib{stem}.so.0"),
+        format!("lib{stem}.so.1"),
+        format!("lib{stem}.so.2"),
+    ]
+}
+
+#[cfg(feature = "libffi")]
+pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, RuntimeError> {
+    use libffi::middle::{Arg, Cif, CodePtr, Type};
+
+    if args.len() != spec.params.len() {
+        return Err(RuntimeError::new(format!(
+            "NativeCall: '{}' expects {} argument(s), got {}",
+            spec.symbol,
+            spec.params.len(),
+            args.len()
+        )));
+    }
+
+    let candidates = resolve_library_candidates(&spec.library);
+    // SAFETY: dlopen of a user-named shared library is inherently unsafe (we
+    // trust the declared signature). This is the documented NativeCall contract.
+    // Try each candidate soname; keep the last error for the diagnostic.
+    let mut loaded = None;
+    let mut last_err = String::new();
+    for cand in &candidates {
+        match unsafe { libloading::Library::new(cand) } {
+            Ok(l) => {
+                loaded = Some((l, cand.clone()));
+                break;
+            }
+            Err(e) => last_err = format!("{cand}: {e}"),
+        }
+    }
+    let (lib, lib_name) = loaded.ok_or_else(|| {
+        RuntimeError::new(format!(
+            "NativeCall: cannot load library {:?}: {last_err}",
+            candidates
+        ))
+    })?;
+    let func_ptr: *const std::ffi::c_void = unsafe {
+        let sym: libloading::Symbol<*const std::ffi::c_void> =
+            lib.get(spec.symbol.as_bytes()).map_err(|e| {
+                RuntimeError::new(format!(
+                    "NativeCall: symbol '{}' not found in '{lib_name}': {e}",
+                    spec.symbol
+                ))
+            })?;
+        // The symbol's address IS the function entry point.
+        *sym.into_raw()
+    };
+
+    // Owners that must outlive the libffi call (boxed scalars and CStrings the
+    // Arg pointers reference).
+    let mut owners: Vec<ArgOwner> = Vec::with_capacity(args.len());
+    let mut ffi_args: Vec<Arg> = Vec::with_capacity(args.len());
+    let mut arg_types: Vec<Type> = Vec::with_capacity(args.len());
+
+    for (i, (ct, v)) in spec.params.iter().zip(args.iter()).enumerate() {
+        let (ty, owner) = marshal_arg(*ct, v).map_err(|msg| {
+            RuntimeError::new(format!(
+                "NativeCall: argument {} to '{}': {msg}",
+                i + 1,
+                spec.symbol
+            ))
+        })?;
+        arg_types.push(ty);
+        owners.push(owner);
+    }
+    // Build the Arg pointers after all owners are in place (stable addresses).
+    for owner in &owners {
+        ffi_args.push(owner.as_arg());
+    }
+
+    let cif = Cif::new(arg_types, ret_ffi_type(spec.ret));
+    let code = CodePtr(func_ptr as *mut _);
+
+    // SAFETY: the CIF matches the declared signature; arg pointers outlive the
+    // call via `owners`.
+    let result = unsafe {
+        match spec.ret {
+            CType::Void => {
+                cif.call::<()>(code, &ffi_args);
+                Value::Nil
+            }
+            CType::I8 => Value::Int(cif.call::<i8>(code, &ffi_args) as i64),
+            CType::I16 => Value::Int(cif.call::<i16>(code, &ffi_args) as i64),
+            CType::I32 => Value::Int(cif.call::<i32>(code, &ffi_args) as i64),
+            CType::I64 => Value::Int(cif.call::<i64>(code, &ffi_args)),
+            CType::U8 => Value::Int(cif.call::<u8>(code, &ffi_args) as i64),
+            CType::U16 => Value::Int(cif.call::<u16>(code, &ffi_args) as i64),
+            CType::U32 => Value::Int(cif.call::<u32>(code, &ffi_args) as i64),
+            CType::U64 => Value::Int(cif.call::<u64>(code, &ffi_args) as i64),
+            CType::F32 => Value::Num(cif.call::<f32>(code, &ffi_args) as f64),
+            CType::F64 => Value::Num(cif.call::<f64>(code, &ffi_args)),
+            CType::Pointer => Value::Int(cif.call::<usize>(code, &ffi_args) as i64),
+            CType::Str => {
+                let ptr = cif.call::<*const std::ffi::c_char>(code, &ffi_args);
+                if ptr.is_null() {
+                    Value::Nil
+                } else {
+                    let cstr = std::ffi::CStr::from_ptr(ptr);
+                    Value::str(cstr.to_string_lossy().into_owned())
+                }
+            }
+        }
+    };
+    Ok(result)
+}
+
+/// Backing storage for one marshalled argument; keeps owned data alive for the
+/// duration of the libffi call.
+#[cfg(feature = "libffi")]
+enum ArgOwner {
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+    Ptr(*const std::ffi::c_void),
+    /// A C string (kept alive only to back the pointer) plus the `char*` handed
+    /// to libffi. The `CString` field is never read directly — it is an RAII
+    /// keep-alive for the buffer the pointer references.
+    CStr(
+        #[allow(dead_code)] std::ffi::CString,
+        *const std::ffi::c_char,
+    ),
+}
+
+#[cfg(feature = "libffi")]
+impl ArgOwner {
+    fn as_arg(&self) -> libffi::middle::Arg {
+        use libffi::middle::arg;
+        match self {
+            ArgOwner::I8(v) => arg(v),
+            ArgOwner::I16(v) => arg(v),
+            ArgOwner::I32(v) => arg(v),
+            ArgOwner::I64(v) => arg(v),
+            ArgOwner::U8(v) => arg(v),
+            ArgOwner::U16(v) => arg(v),
+            ArgOwner::U32(v) => arg(v),
+            ArgOwner::U64(v) => arg(v),
+            ArgOwner::F32(v) => arg(v),
+            ArgOwner::F64(v) => arg(v),
+            ArgOwner::Ptr(p) => arg(p),
+            ArgOwner::CStr(_, p) => arg(p),
+        }
+    }
+}
+
+#[cfg(feature = "libffi")]
+fn marshal_arg(ct: CType, v: &Value) -> Result<(libffi::middle::Type, ArgOwner), String> {
+    use libffi::middle::Type;
+    let int = || crate::runtime::to_int(v);
+    let num = || crate::runtime::utils::to_float_value(v).unwrap_or(0.0);
+    Ok(match ct {
+        CType::I8 => (Type::i8(), ArgOwner::I8(int() as i8)),
+        CType::I16 => (Type::i16(), ArgOwner::I16(int() as i16)),
+        CType::I32 => (Type::i32(), ArgOwner::I32(int() as i32)),
+        CType::I64 => (Type::i64(), ArgOwner::I64(int())),
+        CType::U8 => (Type::u8(), ArgOwner::U8(int() as u8)),
+        CType::U16 => (Type::u16(), ArgOwner::U16(int() as u16)),
+        CType::U32 => (Type::u32(), ArgOwner::U32(int() as u32)),
+        CType::U64 => (Type::u64(), ArgOwner::U64(int() as u64)),
+        CType::F32 => (Type::f32(), ArgOwner::F32(num() as f32)),
+        CType::F64 => (Type::f64(), ArgOwner::F64(num())),
+        CType::Pointer => {
+            let addr = crate::runtime::to_int(v) as usize as *const std::ffi::c_void;
+            (Type::pointer(), ArgOwner::Ptr(addr))
+        }
+        CType::Str => {
+            let s = v.to_string_value();
+            let cstr = std::ffi::CString::new(s)
+                .map_err(|_| "Str argument contains an embedded NUL byte".to_string())?;
+            let ptr = cstr.as_ptr();
+            (Type::pointer(), ArgOwner::CStr(cstr, ptr))
+        }
+        CType::Void => return Err("a parameter cannot have type void".to_string()),
+    })
+}
+
+#[cfg(feature = "libffi")]
+fn ret_ffi_type(ct: CType) -> libffi::middle::Type {
+    use libffi::middle::Type;
+    match ct {
+        CType::Void => Type::void(),
+        CType::I8 => Type::i8(),
+        CType::I16 => Type::i16(),
+        CType::I32 => Type::i32(),
+        CType::I64 => Type::i64(),
+        CType::U8 => Type::u8(),
+        CType::U16 => Type::u16(),
+        CType::U32 => Type::u32(),
+        CType::U64 => Type::u64(),
+        CType::F32 => Type::f32(),
+        CType::F64 => Type::f64(),
+        CType::Str | CType::Pointer => Type::pointer(),
+    }
+}
+
+/// Stub used when the `libffi` feature is disabled (e.g. wasm builds).
+#[cfg(not(feature = "libffi"))]
+pub fn call_native(spec: &NativeCallSpec, _args: &[Value]) -> Result<Value, RuntimeError> {
+    Err(RuntimeError::new(format!(
+        "NativeCall is not available in this build (cannot call '{}')",
+        spec.symbol
+    )))
+}

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -116,6 +116,28 @@ impl Interpreter {
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_function_dispatch();
+        // NativeCall: a sub declared `is native(...)` is dispatched through C
+        // FFI rather than running its (`{ * }`) Raku body. The registry is
+        // empty in the overwhelmingly common case, so this guard is free.
+        if !self.native_call_specs.is_empty() {
+            let name_str = Self::const_str(code, name_idx);
+            if let Some(spec) = self.native_call_specs.get(name_str).cloned() {
+                let arity_usize = arity as usize;
+                if self.stack.len() < arity_usize {
+                    return Err(RuntimeError::new(format!(
+                        "NativeCall: '{}' called with too few arguments on the stack",
+                        spec.symbol
+                    )));
+                }
+                let start = self.stack.len() - arity_usize;
+                let mut args: Vec<Value> = self.stack.drain(start..).collect();
+                // Drop the synthetic callsite-line marker the compiler may append.
+                args.retain(|a| !Self::is_callsite_line_marker(a));
+                let result = crate::runtime::nativecall::call_native(&spec, &args)?;
+                self.stack.push(result);
+                return Ok(());
+            }
+        }
         // If this name is used as a `&`-sigil parameter anywhere, a lexical
         // `&name` binding in the current frame may shadow a same-named package
         // sub. The name-keyed light-call caches cannot represent that, so bypass

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -556,6 +556,16 @@ impl Interpreter {
                     custom_traits,
                 )
             })?;
+            // If this sub carries the `is native(...)` trait, record its C-FFI
+            // descriptor so calls route through NativeCall instead of the body.
+            if custom_traits.iter().any(|(t, _)| t == "native") {
+                self.register_native_call_sub(
+                    &resolved_name,
+                    param_defs,
+                    return_type.as_ref(),
+                    custom_traits,
+                )?;
+            }
             self.fn_resolve_gen += 1;
             self.method_resolve_cache.clear();
             self.last_method_resolve = None;
@@ -610,6 +620,72 @@ impl Interpreter {
         } else {
             Err(RuntimeError::new("RegisterSub expects SubDecl"))
         }
+    }
+
+    /// Build and store the NativeCall descriptor for an `is native(...)` sub.
+    /// The library name comes from the `native` trait argument, the C symbol
+    /// from an optional `is symbol('...')` trait (defaulting to the sub name),
+    /// and the C signature from the parameter / return type constraints.
+    fn register_native_call_sub(
+        &mut self,
+        name: &str,
+        param_defs: &[crate::ast::ParamDef],
+        return_type: Option<&String>,
+        custom_traits: &[(String, Option<crate::ast::Expr>)],
+    ) -> Result<(), RuntimeError> {
+        use crate::runtime::nativecall::{CType, NativeCallSpec};
+
+        // Evaluate a trait's argument expression to a String, if present.
+        let mut eval_trait_str = |trait_name: &str| -> Result<Option<String>, RuntimeError> {
+            for (t, arg) in custom_traits {
+                if t == trait_name {
+                    return Ok(match arg {
+                        Some(expr) => Some(
+                            self.vm_eval_block_value(&[Stmt::Expr(expr.clone())])?
+                                .to_string_value(),
+                        ),
+                        None => None,
+                    });
+                }
+            }
+            Ok(None)
+        };
+
+        let library = eval_trait_str("native")?;
+        let symbol = eval_trait_str("symbol")?.unwrap_or_else(|| name.to_string());
+
+        // Map each parameter's type constraint to a C type. An unmapped /
+        // missing type means we cannot marshal it — skip native registration so
+        // the failure surfaces clearly rather than mis-calling.
+        let mut params = Vec::with_capacity(param_defs.len());
+        for pd in param_defs {
+            let Some(tc) = pd.type_constraint.as_deref() else {
+                return Ok(());
+            };
+            let Some(ct) = CType::from_type_name(tc) else {
+                return Ok(());
+            };
+            params.push(ct);
+        }
+
+        let ret = match return_type {
+            None => CType::Void,
+            Some(rt) => match CType::from_type_name(rt) {
+                Some(ct) => ct,
+                None => return Ok(()),
+            },
+        };
+
+        self.native_call_specs.insert(
+            name.to_string(),
+            NativeCallSpec {
+                library,
+                symbol,
+                params,
+                ret,
+            },
+        );
+        Ok(())
     }
 
     pub(super) fn exec_register_token_op(

--- a/t/nativecall-mvp.t
+++ b/t/nativecall-mvp.t
@@ -1,0 +1,28 @@
+use Test;
+
+# Minimal NativeCall (C FFI) MVP: a sub declared `is native(...)` with a `{ * }`
+# body is dispatched through C FFI (dlopen + libffi) instead of running Raku
+# code. Exercises scalar int / num marshalling, Str -> char*, the `is symbol`
+# override, and a non-default library ("m").
+
+use NativeCall;
+
+plan 7;
+
+sub c_abs(int32 $n) returns int32 is native('c') is symbol('abs') { * }
+sub c_strlen(Str $s) returns int64 is native('c') is symbol('strlen') { * }
+sub c_toupper(int32 $c) returns int32 is native('c') is symbol('toupper') { * }
+sub c_getpid() returns int32 is native('c') is symbol('getpid') { * }
+sub c_pow(num64 $base, num64 $exp) returns num64 is native('m') is symbol('pow') { * }
+sub c_sqrt(num64 $x) returns num64 is native('m') is symbol('sqrt') { * }
+
+is c_abs(-5),       5,   'int32 -> int32 (abs)';
+is c_strlen('hello'), 5, 'Str -> char* -> int64 (strlen)';
+is c_toupper(97),   65,  'int32 -> int32 (toupper of "a" is "A")';
+ok c_getpid() > 0,       'no-arg int32 return (getpid is positive)';
+is c_pow(2e0, 10e0), 1024e0, 'two num64 args -> num64 (pow), non-c library';
+is c_sqrt(16e0),    4e0,  'num64 -> num64 (sqrt)';
+
+# A bad symbol surfaces as a clear runtime error, not a crash.
+sub c_nope() returns int32 is native('c') is symbol('this_symbol_does_not_exist_xyz') { * }
+dies-ok { c_nope() }, 'calling a missing symbol dies cleanly';


### PR DESCRIPTION
## Summary

Makes the `is native(...)` trait **actually call C functions** instead of being a no-op. This is the foundation for `DBDish::SQLite` and other C-binding modules — the honest path to real DB access for the web-blog stack (vs. the sqlite3-CLI-wrapper workaround).

At call time the VM `dlopen`s the named shared library (`libloading`), `dlsym`s the symbol, builds a libffi CIF from the declared signature, marshals the Raku argument `Value`s into C values, calls, and marshals the C return back into a `Value`.

## Supported (MVP)

- scalar C ints (`int8/16/32/64`, `uint8/16/32/64`) and floats (`num32/num64`)
- `Str` → NUL-terminated `char*`; `char*` return → `Str`
- opaque `Pointer` (integer address)
- `is symbol('...')` override (defaults to the sub name)
- non-default libraries: `is native('m')`, `is native('sqlite3')`, …
- soname fallback (`libfoo.so` → `.so.0/.1/.2`) so a runtime-only system (where `libc.so`/`libm.so` are linker scripts or absent) still loads the versioned object

## Verified end-to-end

Against real `libc` / `libm` / `libsqlite3`:

```
abs(-5) = 5
strlen("hello") = 5
toupper(97) = 65
pow(2,10) = 1024
sqrt(16) = 4
sqlite3_libversion() = "3.45.1"
```

## Implementation

- `src/runtime/nativecall.rs` — gated under the `native` feature (`libffi` + `libloading`); the wasm build gets a stub that errors cleanly (verified `wasm32-unknown-unknown` compiles).
- `is native` detected at sub registration (`register_native_call_sub`); descriptor stored in `Interpreter::native_call_specs`.
- `exec_call_func_op` routes a matching name through FFI (and strips the synthetic callsite-line marker). Subs whose types don't map are left as ordinary `{ * }` subs (graceful degradation).
- `use NativeCall` recognized as a built-in no-op.

## Next (PLAN.md §H)

out-`Pointer[T]` (e.g. `sqlite3_open`'s `**ppDb`), `CArray`, `is repr('CStruct')`, callbacks → then DBDish::SQLite.

## Test

`t/nativecall-mvp.t` (7 cases). `make test` passes; `cargo clippy -- -D warnings` clean; wasm32 build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)