### PR TITLE
feat(state-ownership): native-ize `.new` for Promise/Channel/Supplier (§D ③)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -555,6 +555,16 @@
   fallback → 0。stash 比較で native==interpreter 一致確認。pin `t/native-lock-ctor.t`(9)。make test 10964。**★既知の別軸バグ（本変更と無関係・
   main でも再現）: `$lock.protect({ $n++ })` の captured-outer `$n` writeback 落ち（`.protect` の closure capture writeback・ctor とは無関係）。**
   **残 ③ ctor 候補＝Promise/Channel（SharedPromise/channel state）・QuantHash 族（Bag/Set/Mix/SetHash・element 計数）・Capture・misc。**
+- **2026-06-23 (§D ③ = `Promise`/`Channel`/`Supplier`/`Supplier::Preserving` の `.new` を VM ネイティブ化)**: ③ ctor フォークの 3 スライス目
+  ＝simple concurrency primitive。`Promise.new`=`Value::Promise(SharedPromise::new())`（空の planned promise・pure shared state）、
+  `Channel.new`=`Value::Channel(SharedChannel::new())`（空 channel）、`Supplier`/`Supplier::Preserving`=`{emitted:[], done:False,
+  supplier_id:next_supplier_id()}`（emission log ＋ process-global id）＝いずれも env/registry/user code 不要。static
+  `try_native_builtin_construct` に 3 arm 追加、interpreter dispatch_new の既存 arm はコメントのみ残置（byte-identical 二重実装の慣習）。
+  実測 4 種とも `new` fallback → 0。`$p.keep(42)`/`$c.send.list`/`$s.Supply.tap` 機能 raku 一致。pin `t/native-concurrency-ctor.t`(10)。
+  make test 10984。**★既知の別軸ギャップ（本変更と無関係）: `Supplier::Preserving` の tap 前 emit の late-tap replay 未実装（mutsu は
+  buffer/replay しない・construction とは無関係）。** **残 ③ ctor 候補＝QuantHash 族（Bag/Set/Mix/SetHash・element 計数＝`&mut self` type
+  check 要・static 不可）・Capture・Proxy（FETCH/STORE closure）・misc。** **★perf 注意=`SharedPromise::new()` 等の `pub(crate)` ctor を
+  VM static path から直接呼ぶ＝interpreter 委譲より 1 ホップ短い。**
 - **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
   到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
   `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1648,6 +1648,26 @@ impl Interpreter {
                 attrs.insert("async".to_string(), Value::Bool(true));
             }
             Some(Ok(Value::make_instance(class_name, attrs)))
+        } else if cn == "Promise" {
+            // A bare `Promise.new` is an empty planned promise — pure shared
+            // state, no env / registry / user code. Shared with the interpreter's
+            // `dispatch_new` arm.
+            Some(Ok(Value::Promise(crate::value::SharedPromise::new())))
+        } else if cn == "Channel" {
+            // Likewise an empty channel.
+            Some(Ok(Value::Channel(crate::value::SharedChannel::new())))
+        } else if matches!(cn.as_str(), "Supplier" | "Supplier::Preserving") {
+            // A supplier is pure data: an empty emission log, a not-done flag, and
+            // a fresh process-global supplier id. Shared with the interpreter's
+            // `dispatch_new` arm.
+            let mut attrs = HashMap::new();
+            attrs.insert("emitted".to_string(), Value::array(Vec::new()));
+            attrs.insert("done".to_string(), Value::Bool(false));
+            attrs.insert(
+                "supplier_id".to_string(),
+                Value::Int(super::native_methods::next_supplier_id() as i64),
+            );
+            Some(Ok(Value::make_instance(class_name, attrs)))
         } else {
             None
         }
@@ -2695,9 +2715,13 @@ impl Interpreter {
                     return self.dispatch_socket_inet_new(&args);
                 }
                 "Promise" => {
+                    // Shared with the VM's native fast path
+                    // (`try_native_builtin_construct`).
                     return Ok(Value::Promise(SharedPromise::new()));
                 }
                 "Channel" => {
+                    // Shared with the VM's native fast path
+                    // (`try_native_builtin_construct`).
                     return Ok(Value::Channel(SharedChannel::new()));
                 }
                 "Stash" => {
@@ -2709,6 +2733,8 @@ impl Interpreter {
                 }
                 "Supply" => return Ok(self.make_supply_instance()),
                 "Supplier" | "Supplier::Preserving" => {
+                    // Shared with the VM's native fast path
+                    // (`try_native_builtin_construct`).
                     let mut attrs = HashMap::new();
                     attrs.insert("emitted".to_string(), Value::array(Vec::new()));
                     attrs.insert("done".to_string(), Value::Bool(false));

--- a/t/native-concurrency-ctor.t
+++ b/t/native-concurrency-ctor.t
@@ -1,0 +1,55 @@
+use Test;
+
+# §D state-ownership: the VM constructs the simple concurrency primitives
+# (`Promise`, `Channel`, `Supplier`, `Supplier::Preserving`) natively (no
+# interpreter `.new` bounce), behaving identically to the interpreter's
+# `dispatch_new` arms.
+
+plan 10;
+
+# --- Promise ---
+{
+    my $p = Promise.new;
+    isa-ok $p, Promise, 'Promise.new returns a Promise';
+    $p.keep(42);
+    is $p.result, 42, 'kept Promise yields its result';
+    ok $p.status ~~ /Kept/, 'kept Promise status is Kept';
+}
+
+# --- Channel ---
+{
+    my $c = Channel.new;
+    isa-ok $c, Channel, 'Channel.new returns a Channel';
+    $c.send(7);
+    $c.send(8);
+    $c.close;
+    is $c.list, (7, 8), 'Channel delivers sent values in order';
+}
+
+# --- Supplier ---
+{
+    my $s = Supplier.new;
+    isa-ok $s, Supplier, 'Supplier.new returns a Supplier';
+    my @got;
+    $s.Supply.tap(-> $v { @got.push($v) });
+    $s.emit(1);
+    $s.emit(2);
+    is @got, [1, 2], 'Supplier emits to a tapped Supply';
+}
+
+# --- Supplier::Preserving (construction + post-tap emission) ---
+{
+    my $s = Supplier::Preserving.new;
+    isa-ok $s, Supplier::Preserving, 'Supplier::Preserving.new returns the type';
+    my @got;
+    $s.Supply.tap(-> $v { @got.push($v) });
+    $s.emit("a");
+    is @got, ["a"], 'Supplier::Preserving emits to a tapped Supply';
+}
+
+# --- a fresh Promise is not equal to another (distinct shared state) ---
+{
+    my $p1 = Promise.new;
+    my $p2 = Promise.new;
+    ok $p1 !=== $p2, 'two Promise.new are distinct';
+}


### PR DESCRIPTION
## Summary

§D state-ownership (prerequisite ②) — third slice of the **③ built-in type ctor** fork: simple concurrency primitives.

- `Promise.new` → `Value::Promise(SharedPromise::new())` (empty planned promise)
- `Channel.new` → `Value::Channel(SharedChannel::new())` (empty channel)
- `Supplier` / `Supplier::Preserving` → `{emitted: [], done: False, supplier_id: next_supplier_id()}`

All are pure shared/global-counter state with no env / registry / user code, so the VM builds them directly via `try_native_builtin_construct` instead of bouncing `.new` to the interpreter's `dispatch_new`. The interpreter's existing arms stay as byte-identical siblings.

## Verification

- VM stats: all four `new` interpreter fallback → 0.
- Behavior matches raku (keep/result, send/list, Supply/tap).
- `make test` 10984 PASS; pin `t/native-concurrency-ctor.t` (10).

Note: `Supplier::Preserving` late-tap replay (emit-before-tap buffering) is an unrelated pre-existing gap, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)