### PR TITLE
feat(nativecall): Pointer type + `is rw` out-parameters (sqlite3 open/exec/close)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -201,9 +201,15 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     `'sqlite3'`）に対応。soname フォールバック（`libfoo.so`→`.so.0/.1/.2`）で runtime-only システムでもロード。
     実証: `abs`/`strlen`/`pow`/`sqrt`/`sqlite3_libversion()`→"3.45.1" が動作。担保＝`t/nativecall-mvp.t`。
     実装＝`src/runtime/nativecall.rs`（`native` feature 下、wasm はスタブ）。`use NativeCall` は no-op 認識。
-  - **残（DBDish::SQLite に必要）**: ① `Pointer[T]` の out-param（`sqlite3_open` が `**ppDb` を返す）/ ②
-    `CArray[uint8]`・`CArray[Str]` / ③ `is repr('CStruct')` 構造体 / ④ callback（`sqlite3_exec` の行コールバック）。
-    ②③④は段階実装。①が最優先（接続ハンドルの取得）。
+  - **✅ Pointer + out-param（#TBD）**: 組み込み `Pointer` 型（`.new`/`.Int`/`.Bool`/`.gist`・prelude 注入）＋
+    `Pointer is rw` out-parameter（C が `void**` に書き戻す）。**ライブラリは process-lifetime でキャッシュ**
+    （呼び出しごとの dlclose が libsqlite3 をアンロードしハンドルを無効化する問題を解消）。変数引数の
+    varref Capture / Scalar / ContainerRef を marshalling 前に unwrap（リテラルしか無かった MVP で潜在した
+    「変数を渡すと 0 になる」バグも修正）。**実証: `sqlite3_open`/`exec`(CREATE/INSERT)/`errmsg`/`close` の
+    完全往復が動作**（`:memory:` DB に表作成・挿入・エラー取得）。担保＝`t/nativecall-pointer.t`（posix_memalign）。
+  - **残（DBDish::SQLite に必要）**: ① Pointer **return**（`malloc`/`sqlite3_*` が `void*` を返す→ Pointer 化）/
+    ② `CArray[uint8]`・`CArray[Str]` / ③ `is repr('CStruct')` 構造体 / ④ callback（`sqlite3_exec` 行 cb）
+    または `sqlite3_prepare_v2`/`step`/`column_*`（prepared statement・out-pointer + text 取得）。
   - **DBIish/DBDish**: 上記 NativeCall 拡張が揃えば原理的に動く（ドライバは `sqlite3_*` C API）。
 - [ ] **DB アクセス（NativeCall が揃うまでの代替）— sqlite3 CLI ラッパ（pure Raku）。**
   - **代替**: `run`/`qqx` で `sqlite3`（`/usr/bin/sqlite3` 3.45.1）を呼ぶ薄い pure-Raku ラッパ。`sqlite3 -json` で

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -55,6 +55,17 @@ impl CType {
     }
 }
 
+/// One native parameter: its C type plus whether it was declared `is rw`.
+/// An `is rw` `Pointer` is an *out-parameter*: C receives a `void**` and writes
+/// the resulting pointer back into the caller's `Pointer` object.
+// Fields are read only in the `libffi` build (the wasm stub ignores them).
+#[cfg_attr(not(feature = "libffi"), allow(dead_code))]
+#[derive(Debug, Clone, Copy)]
+pub struct ParamSpec {
+    pub ct: CType,
+    pub is_rw: bool,
+}
+
 /// The resolved descriptor for one `is native` sub: which library/symbol to
 /// call and the C signature to marshal against.
 // In a non-`libffi` build (wasm) the fields are only written, never read (the
@@ -67,7 +78,7 @@ pub struct NativeCallSpec {
     pub library: Option<String>,
     /// C symbol name — from `is symbol('...')` if present, else the sub name.
     pub symbol: String,
-    pub params: Vec<CType>,
+    pub params: Vec<ParamSpec>,
     pub ret: CType,
 }
 
@@ -105,6 +116,49 @@ fn resolve_library_candidates(library: &Option<String>) -> Vec<String> {
     ]
 }
 
+/// Process-lifetime cache of dlopen'd libraries, keyed by the candidate name
+/// that successfully loaded. **Loading must persist across calls**: a `Library`
+/// dropped at the end of a call `dlclose`s it, and for a library that was not
+/// already resident (e.g. `libsqlite3`) that unloads it — invalidating every
+/// pointer the program obtained from it (a `sqlite3*` handle becomes a
+/// dangling pointer, so the next call segfaults). Leaking the handle to
+/// `'static` keeps each library mapped for the program's lifetime, matching
+/// Rakudo's NativeCall (which never unloads).
+#[cfg(feature = "libffi")]
+fn load_library_cached(
+    candidates: &[String],
+) -> Result<(&'static libloading::Library, &'static str), RuntimeError> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<HashMap<String, &'static libloading::Library>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = cache.lock().unwrap();
+
+    let mut last_err = String::new();
+    for cand in candidates {
+        if let Some(lib) = guard.get(cand) {
+            // Leak the key string too so the returned name is `'static`.
+            let name: &'static str = Box::leak(cand.clone().into_boxed_str());
+            return Ok((lib, name));
+        }
+        // SAFETY: dlopen of a user-named shared library is inherently unsafe (we
+        // trust the declared signature). This is the documented NativeCall
+        // contract. The handle is leaked to `'static` (never dlclosed).
+        match unsafe { libloading::Library::new(cand) } {
+            Ok(l) => {
+                let leaked: &'static libloading::Library = Box::leak(Box::new(l));
+                guard.insert(cand.clone(), leaked);
+                let name: &'static str = Box::leak(cand.clone().into_boxed_str());
+                return Ok((leaked, name));
+            }
+            Err(e) => last_err = format!("{cand}: {e}"),
+        }
+    }
+    Err(RuntimeError::new(format!(
+        "NativeCall: cannot load library {candidates:?}: {last_err}"
+    )))
+}
+
 #[cfg(feature = "libffi")]
 pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, RuntimeError> {
     use libffi::middle::{Arg, Cif, CodePtr, Type};
@@ -119,26 +173,7 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     }
 
     let candidates = resolve_library_candidates(&spec.library);
-    // SAFETY: dlopen of a user-named shared library is inherently unsafe (we
-    // trust the declared signature). This is the documented NativeCall contract.
-    // Try each candidate soname; keep the last error for the diagnostic.
-    let mut loaded = None;
-    let mut last_err = String::new();
-    for cand in &candidates {
-        match unsafe { libloading::Library::new(cand) } {
-            Ok(l) => {
-                loaded = Some((l, cand.clone()));
-                break;
-            }
-            Err(e) => last_err = format!("{cand}: {e}"),
-        }
-    }
-    let (lib, lib_name) = loaded.ok_or_else(|| {
-        RuntimeError::new(format!(
-            "NativeCall: cannot load library {:?}: {last_err}",
-            candidates
-        ))
-    })?;
+    let (lib, lib_name) = load_library_cached(&candidates)?;
     let func_ptr: *const std::ffi::c_void = unsafe {
         let sym: libloading::Symbol<*const std::ffi::c_void> =
             lib.get(spec.symbol.as_bytes()).map_err(|e| {
@@ -157,14 +192,26 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     let mut ffi_args: Vec<Arg> = Vec::with_capacity(args.len());
     let mut arg_types: Vec<Type> = Vec::with_capacity(args.len());
 
-    for (i, (ct, v)) in spec.params.iter().zip(args.iter()).enumerate() {
-        let (ty, owner) = marshal_arg(*ct, v).map_err(|msg| {
-            RuntimeError::new(format!(
-                "NativeCall: argument {} to '{}': {msg}",
-                i + 1,
-                spec.symbol
-            ))
-        })?;
+    // Arg indices whose `is rw Pointer` out-slot must be written back into the
+    // caller's Pointer object after the call.
+    let mut writebacks: Vec<usize> = Vec::new();
+
+    for (i, (ps, v)) in spec.params.iter().zip(args.iter()).enumerate() {
+        let (ty, owner) = if ps.is_rw && ps.ct == CType::Pointer {
+            // `Pointer is rw`: pass `void**` — a pointer to a slot holding the
+            // current address; C writes the new pointer into the slot.
+            let slot = Box::new(pointer_address(v));
+            writebacks.push(i);
+            (Type::pointer(), ArgOwner::new_out_ptr(slot))
+        } else {
+            marshal_arg(ps.ct, v).map_err(|msg| {
+                RuntimeError::new(format!(
+                    "NativeCall: argument {} to '{}': {msg}",
+                    i + 1,
+                    spec.symbol
+                ))
+            })?
+        };
         arg_types.push(ty);
         owners.push(owner);
     }
@@ -206,7 +253,66 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
             }
         }
     };
+
+    // Write `is rw Pointer` out-slots back into the caller's Pointer objects.
+    // The `Value::Instance` shares its attribute cell with the caller's
+    // variable, so the new address becomes visible there.
+    for idx in writebacks {
+        if let ArgOwner::OutPtr { slot, .. } = &owners[idx] {
+            write_pointer_address(&args[idx], **slot);
+        }
+    }
+
     Ok(result)
+}
+
+/// Read the C address carried by a NativeCall argument: a `Pointer` object's
+/// `address` attribute, a bare integer, or 0 for Nil / anything else. Unwraps a
+/// `Scalar` / `ContainerRef` container first (a `$`-variable argument arrives
+/// wrapped).
+#[cfg(feature = "libffi")]
+fn pointer_address(v: &Value) -> usize {
+    match v {
+        Value::Int(i) => *i as usize,
+        Value::Instance { attributes, .. } => match attributes.as_map().get("address") {
+            Some(Value::Int(i)) => *i as usize,
+            _ => 0,
+        },
+        Value::Scalar(inner) => pointer_address(inner),
+        Value::ContainerRef(cell) => cell.lock().ok().map(|g| pointer_address(&g)).unwrap_or(0),
+        // An `is rw` argument arrives as a varref Capture carrying the bound
+        // variable's current value.
+        Value::Capture { named, .. } => match named.get("__mutsu_varref_value") {
+            Some(inner) => pointer_address(inner),
+            None => 0,
+        },
+        _ => 0,
+    }
+}
+
+/// Write a resolved C address back into a `Pointer` object's `address`
+/// attribute (in place, through the shared attribute cell). Unwraps a `Scalar`
+/// / `ContainerRef` container so a `$`-variable out-argument updates the
+/// caller's object.
+#[cfg(feature = "libffi")]
+fn write_pointer_address(v: &Value, addr: usize) {
+    match v {
+        Value::Instance { attributes, .. } => {
+            attributes.insert("address".to_string(), Value::Int(addr as i64));
+        }
+        Value::Scalar(inner) => write_pointer_address(inner, addr),
+        Value::ContainerRef(cell) => {
+            if let Ok(g) = cell.lock() {
+                write_pointer_address(&g, addr);
+            }
+        }
+        Value::Capture { named, .. } => {
+            if let Some(inner) = named.get("__mutsu_varref_value") {
+                write_pointer_address(inner, addr);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Backing storage for one marshalled argument; keeps owned data alive for the
@@ -231,10 +337,25 @@ enum ArgOwner {
         #[allow(dead_code)] std::ffi::CString,
         *const std::ffi::c_char,
     ),
+    /// An `is rw Pointer` out-parameter (`void**`): `slot` holds the address
+    /// (C writes the new pointer here), `slot_ptr` is the `void**` value handed
+    /// to libffi (the address of `slot`).
+    OutPtr {
+        slot: Box<usize>,
+        slot_ptr: *mut std::ffi::c_void,
+    },
 }
 
 #[cfg(feature = "libffi")]
 impl ArgOwner {
+    /// Build an out-pointer owner. `slot_ptr` points at the heap-allocated
+    /// `slot`; the `Box` keeps that allocation stable across the move into the
+    /// `owners` vector, so the pointer remains valid for the call.
+    fn new_out_ptr(mut slot: Box<usize>) -> ArgOwner {
+        let slot_ptr: *mut std::ffi::c_void = (slot.as_mut() as *mut usize).cast();
+        ArgOwner::OutPtr { slot, slot_ptr }
+    }
+
     fn as_arg(&self) -> libffi::middle::Arg {
         use libffi::middle::arg;
         match self {
@@ -250,13 +371,34 @@ impl ArgOwner {
             ArgOwner::F64(v) => arg(v),
             ArgOwner::Ptr(p) => arg(p),
             ArgOwner::CStr(_, p) => arg(p),
+            ArgOwner::OutPtr { slot_ptr, .. } => arg(slot_ptr),
         }
     }
 }
 
+/// Unwrap a native-call argument to its underlying scalar value: a `$`-variable
+/// argument arrives wrapped in a `Scalar` / `ContainerRef`, or — when bound to a
+/// parameter — in an `is rw`-style varref `Capture`. Without this, `to_int` /
+/// `to_string_value` on the wrapper yields garbage (a `Capture` coerces to 0),
+/// so a `Pointer`/int held in a variable would be passed as 0.
 #[cfg(feature = "libffi")]
-fn marshal_arg(ct: CType, v: &Value) -> Result<(libffi::middle::Type, ArgOwner), String> {
+fn resolve_arg(v: &Value) -> Value {
+    match v {
+        Value::Scalar(inner) => resolve_arg(inner),
+        Value::ContainerRef(cell) => cell.lock().map(|g| resolve_arg(&g)).unwrap_or(Value::Nil),
+        Value::Capture { named, .. } => match named.get("__mutsu_varref_value") {
+            Some(inner) => resolve_arg(inner),
+            None => v.clone(),
+        },
+        other => other.clone(),
+    }
+}
+
+#[cfg(feature = "libffi")]
+fn marshal_arg(ct: CType, raw: &Value) -> Result<(libffi::middle::Type, ArgOwner), String> {
     use libffi::middle::Type;
+    let resolved = resolve_arg(raw);
+    let v = &resolved;
     let int = || crate::runtime::to_int(v);
     let num = || crate::runtime::utils::to_float_value(v).unwrap_or(0.0);
     Ok(match ct {
@@ -271,7 +413,8 @@ fn marshal_arg(ct: CType, v: &Value) -> Result<(libffi::middle::Type, ArgOwner),
         CType::F32 => (Type::f32(), ArgOwner::F32(num() as f32)),
         CType::F64 => (Type::f64(), ArgOwner::F64(num())),
         CType::Pointer => {
-            let addr = crate::runtime::to_int(v) as usize as *const std::ffi::c_void;
+            // A by-value `Pointer` passes its current address as `void*`.
+            let addr = pointer_address(v) as *const std::ffi::c_void;
             (Type::pointer(), ArgOwner::Ptr(addr))
         }
         CType::Str => {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -20,6 +20,26 @@ role Rational[::NuT = Int, ::DeT = Int] does Real {
 }
 "#;
 
+/// Builtin `Pointer` type for NativeCall. Stored as a plain class with a single
+/// `address` attribute; the NativeCall marshalling layer reads/writes that
+/// attribute in place (an `is rw Pointer` out-parameter writes the resolved C
+/// address back here). The `.gist`/`.Str` form mirrors Rakudo's
+/// `NativeCall::Types::Pointer<...>` rendering.
+const NATIVECALL_POINTER_PRELUDE: &str = r#"
+class Pointer {
+    has $.address = 0;
+    method Int(--> Int) { $!address }
+    method Numeric(--> Int) { $!address }
+    method Bool(--> Bool) { $!address != 0 }
+    method gist(--> Str) {
+        $!address == 0
+            ?? 'NativeCall::Types::Pointer<NULL>'
+            !! sprintf('NativeCall::Types::Pointer<0x%x>', $!address)
+    }
+    method Str(--> Str) { self.gist }
+}
+"#;
+
 impl Interpreter {
     /// Prepend builtin prelude role definitions to `stmts` when the source
     /// references them. Currently this provides the parametric `Rational` role
@@ -35,6 +55,31 @@ impl Interpreter {
         static RATIONAL_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
         let prelude = RATIONAL_STMTS.get_or_init(|| {
             crate::parse_dispatch::parse_source(RATIONAL_ROLE_PRELUDE)
+                .map(|(s, _)| s)
+                .unwrap_or_default()
+        });
+        if prelude.is_empty() {
+            return;
+        }
+        let mut combined = prelude.clone();
+        combined.append(stmts);
+        *stmts = combined;
+    }
+
+    /// Prepend the builtin NativeCall `Pointer` class when a program that uses
+    /// NativeCall references `Pointer` without declaring its own. Parsed once
+    /// and cached, like [`inject_prelude_roles`].
+    fn inject_nativecall_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+        if !source.contains("NativeCall")
+            || !source.contains("Pointer")
+            || source.contains("class Pointer")
+        {
+            return;
+        }
+        use std::sync::OnceLock;
+        static POINTER_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let prelude = POINTER_STMTS.get_or_init(|| {
+            crate::parse_dispatch::parse_source(NATIVECALL_POINTER_PRELUDE)
                 .map(|(s, _)| s)
                 .unwrap_or_default()
         });
@@ -802,6 +847,7 @@ impl Interpreter {
         // role) when the program references them. These are registered through the
         // normal RoleDecl/VM path by prepending their statements to the body.
         Self::inject_prelude_roles(&preprocessed, &mut stmts);
+        Self::inject_nativecall_prelude(&preprocessed, &mut stmts);
         let (_pre_ph, enter_ph, success_ph, failure_ph, _post_ph, body_main) =
             self.split_block_phasers(&stmts);
         // Register END phasers eagerly (before VM execution) so they run

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -633,7 +633,7 @@ impl Interpreter {
         return_type: Option<&String>,
         custom_traits: &[(String, Option<crate::ast::Expr>)],
     ) -> Result<(), RuntimeError> {
-        use crate::runtime::nativecall::{CType, NativeCallSpec};
+        use crate::runtime::nativecall::{CType, NativeCallSpec, ParamSpec};
 
         // Evaluate a trait's argument expression to a String, if present.
         let mut eval_trait_str = |trait_name: &str| -> Result<Option<String>, RuntimeError> {
@@ -665,7 +665,8 @@ impl Interpreter {
             let Some(ct) = CType::from_type_name(tc) else {
                 return Ok(());
             };
-            params.push(ct);
+            let is_rw = pd.traits.iter().any(|t| t == "rw");
+            params.push(ParamSpec { ct, is_rw });
         }
 
         let ret = match return_type {

--- a/t/nativecall-pointer.t
+++ b/t/nativecall-pointer.t
@@ -1,0 +1,54 @@
+use Test;
+
+# NativeCall `Pointer` type + `is rw` out-parameter.
+#
+# A `Pointer` carries a C address; an `is rw Pointer` argument is an
+# *out-parameter*: C receives a `void**` and writes the resulting pointer back
+# into the caller's `Pointer` object. We exercise this with libc's
+# `posix_memalign` (an out-pointer allocator, guaranteed present) so the test
+# does not depend on any optional library.
+
+use NativeCall;
+
+plan 11;
+
+# --- the Pointer type itself (no FFI) ---
+{
+    my $p = Pointer.new;
+    is $p.Int, 0, 'fresh Pointer.Int is 0';
+    is $p.Numeric, 0, 'fresh Pointer.Numeric is 0';
+    nok $p.Bool, 'fresh Pointer is falsy (NULL)';
+    is $p.gist, 'NativeCall::Types::Pointer<NULL>', 'NULL Pointer gist';
+}
+
+sub posix_memalign(Pointer $p is rw, int64 $align, int64 $size)
+    returns int32 is native('c') { * }
+sub free(int64 $p) is native('c') { * }
+sub memset(int64 $p, int32 $c, int64 $n) returns int64 is native('c') { * }
+
+# --- is rw Pointer out-parameter writes a real address back ---
+{
+    my $p = Pointer.new;
+    my $rc = posix_memalign($p, 16, 256);
+    is $rc, 0, 'posix_memalign succeeds';
+    ok $p.Int > 0, 'out-parameter wrote a non-NULL address into the Pointer';
+    ok $p.Bool, 'Pointer is now truthy';
+    ok $p.Int %% 16, 'returned block honours the 16-byte alignment';
+
+    # The address is a usable heap block: writing to it must not crash.
+    memset($p.Int, 0, 256);
+    pass 'memset through the returned pointer works';
+
+    free($p.Int);
+    pass 'free of the returned pointer works';
+}
+
+# --- a by-value Pointer passes its current address ---
+{
+    my $p = Pointer.new;
+    posix_memalign($p, 8, 64);
+    my $addr = $p.Int;
+    # Re-wrap the same address and confirm round-trip parity via .Int.
+    free($p.Int);
+    is $p.Int, $addr, 'Pointer.Int is stable across reads';
+}


### PR DESCRIPTION
## Summary

Builds on the NativeCall MVP (#3516) to make **real database access** work end-to-end. mutsu can now open a SQLite database, create tables, insert rows, read error messages, and close — all through `is native(...)` subs.

```raku
use NativeCall;
sub sqlite3_open(Str, Pointer is rw) returns int32 is native('sqlite3') {*}
sub sqlite3_exec(Pointer, Str, Pointer, Pointer, Pointer) returns int32 is native('sqlite3') {*}
sub sqlite3_close(Pointer) returns int32 is native('sqlite3') {*}

my $db = Pointer.new;
sqlite3_open(":memory:", $db);                       # rc 0, $db now holds the handle
sqlite3_exec($db, "CREATE TABLE t (id, name)", Pointer, Pointer, Pointer);  # 0
sqlite3_exec($db, "INSERT INTO t VALUES (1,'hi')",  Pointer, Pointer, Pointer);  # 0
sqlite3_close($db);                                  # 0
```

## What's new

- **`Pointer` type** — `.new`, `.Int`, `.Numeric`, `.Bool`, `.gist`/`.Str` (rendered as Rakudo's `NativeCall::Types::Pointer<...>`). Injected as a prelude class when a NativeCall program references `Pointer`.
- **`Pointer is rw` out-parameters** — C receives a `void**` and writes the resulting pointer back into the caller's `Pointer` (the value propagates via the varref-Capture the VM passes for a by-reference arg + the shared attribute cell). This is exactly `sqlite3_open(name, **ppDb)`.
- **Process-lifetime library cache** — previously every call `dlopen`/`dlclose`d the library. For a not-already-resident library (libsqlite3) the `dlclose` *unloaded* it and invalidated every pointer obtained from it, so the next call segfaulted. Libraries are now leaked to `'static` and reused, matching Rakudo.

## Fix (latent in the MVP)

Marshalling now unwraps a `$`-variable argument (varref `Capture` / `Scalar` / `ContainerRef`) before coercion. Without this an int or `Pointer` held in a **variable** coerced to `0` — the MVP tests only used literals, so it slipped through. `malloc()`'s pointer now survives being passed to `free()`/`memset()`.

## Verified

End-to-end against real libsqlite3 (open/create/insert/errmsg/close all `SQLITE_OK`; a bad statement reports `no such table: ...`). Also `posix_memalign` + `free` (out-pointer round-trip).

## Test

`t/nativecall-pointer.t` (11 cases) uses libc's `posix_memalign` — guaranteed present, no optional dep. `make test` / `cargo clippy -- -D warnings` / wasm32 build all clean.

## Next (PLAN.md §H)

Pointer *return*, `CArray`, `CStruct`, then callbacks or `sqlite3_prepare_v2`/`step`/`column_*` → DBDish::SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)