### PR TITLE
feat(nativecall): Pointer return + real SQLite SELECT round-trip

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -208,14 +208,13 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     varref Capture / Scalar / ContainerRef を marshalling 前に unwrap（リテラルしか無かった MVP で潜在した
     「変数を渡すと 0 になる」バグも修正）。**実証: `sqlite3_open`/`exec`(CREATE/INSERT)/`errmsg`/`close` の
     完全往復が動作**（`:memory:` DB に表作成・挿入・エラー取得）。担保＝`t/nativecall-pointer.t`（posix_memalign）。
-  - **残（DBDish::SQLite に必要）**: ① Pointer **return**（`malloc`/`sqlite3_*` が `void*` を返す→ Pointer 化）/
-    ② `CArray[uint8]`・`CArray[Str]` / ③ `is repr('CStruct')` 構造体 / ④ callback（`sqlite3_exec` 行 cb）
-    または `sqlite3_prepare_v2`/`step`/`column_*`（prepared statement・out-pointer + text 取得）。
-  - **DBIish/DBDish**: 上記 NativeCall 拡張が揃えば原理的に動く（ドライバは `sqlite3_*` C API）。
-- [ ] **DB アクセス（NativeCall が揃うまでの代替）— sqlite3 CLI ラッパ（pure Raku）。**
-  - **代替**: `run`/`qqx` で `sqlite3`（`/usr/bin/sqlite3` 3.45.1）を呼ぶ薄い pure-Raku ラッパ。`sqlite3 -json` で
-    行を JSON 出力可。値エスケープ/1クエリ1プロセスは要注意。NativeCall 完成までの繋ぎ。
-  - **フォールバック**: flat-file `.raku`＋`EVALFILE`（mutsu で round-trip 確認済）。
+  - **✅ Pointer return + 実 SELECT（#TBD）**: `returns Pointer` が実 `Pointer` オブジェクトを返す（`malloc`→Pointer→free）。
+    **`sqlite3_prepare_v2`/`step`/`column_int`/`column_text`/`finalize` による prepared-statement SELECT で実際の
+    行データ（int+text）を読み取れる**（新規 Rust 不要・既存 marshalling で動作）。担保＝`t/nativecall-sqlite.t`
+    （libsqlite3 不在なら graceful skip）。**= mutsu から実 SQLite DB の完全な CRUD 往復が可能。**
+  - **残（より広いモジュール互換に）**: ① `CArray[uint8]`・`CArray[Str]` / ② `is repr('CStruct')` 構造体 /
+    ③ callback（汎用 C コールバック）。DBDish::SQLite 自体は上記 prepared-statement API で原理的に駆動可能。
+  - **DBIish/DBDish**: pure-Raku ドライバを上記 NativeCall sub 群で実装可能（次の有力タスク＝薄い DBDish::SQLite 互換層）。
 - **JSON は native 実装済み**（`to-json`/`from-json`・#3402・news 参照）。Template::Mustache 91/92-specs の残（別軸・
   本タスク外）= 実 spec の rendering ギャップ（delimiter 永続化／inheritable partials／lambda）＋ 最初の spec のみ
   `+$spec.value`=0 になる subtest/Seq-consumption 系バグ（itemization とは独立）。

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -241,7 +241,7 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
             CType::U64 => Value::Int(cif.call::<u64>(code, &ffi_args) as i64),
             CType::F32 => Value::Num(cif.call::<f32>(code, &ffi_args) as f64),
             CType::F64 => Value::Num(cif.call::<f64>(code, &ffi_args)),
-            CType::Pointer => Value::Int(cif.call::<usize>(code, &ffi_args) as i64),
+            CType::Pointer => make_pointer_value(cif.call::<usize>(code, &ffi_args)),
             CType::Str => {
                 let ptr = cif.call::<*const std::ffi::c_char>(code, &ffi_args);
                 if ptr.is_null() {
@@ -264,6 +264,17 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     }
 
     Ok(result)
+}
+
+/// Build a `Pointer` object holding the given C address. Used to marshal a
+/// `void*` return value. The `Pointer` prelude class is registered whenever a
+/// program references `Pointer` (which a `returns Pointer` signature does), so
+/// method dispatch (`.Int`/`.gist`/…) on the result resolves.
+#[cfg(feature = "libffi")]
+fn make_pointer_value(addr: usize) -> Value {
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("address".to_string(), Value::Int(addr as i64));
+    Value::make_instance(crate::symbol::Symbol::intern("Pointer"), attrs)
 }
 
 /// Read the C address carried by a NativeCall argument: a `Pointer` object's

--- a/t/nativecall-pointer.t
+++ b/t/nativecall-pointer.t
@@ -10,7 +10,7 @@ use Test;
 
 use NativeCall;
 
-plan 11;
+plan 16;
 
 # --- the Pointer type itself (no FFI) ---
 {
@@ -51,4 +51,21 @@ sub memset(int64 $p, int32 $c, int64 $n) returns int64 is native('c') { * }
     # Re-wrap the same address and confirm round-trip parity via .Int.
     free($p.Int);
     is $p.Int, $addr, 'Pointer.Int is stable across reads';
+}
+
+# --- a `returns Pointer` function yields a real Pointer object ---
+{
+    sub malloc(int64 $size) returns Pointer is native('c') { * }
+    sub free_p(Pointer $p) is native('c') is symbol('free') { * }
+    sub memset_p(Pointer $p, int32 $c, int64 $n) returns Pointer is native('c') is symbol('memset') { * }
+
+    my $p = malloc(128);
+    is $p.^name, 'Pointer', 'malloc returns a Pointer object';
+    isa-ok $p, Pointer, 'the return value isa Pointer';
+    ok $p.Bool, 'malloc returned a non-NULL Pointer';
+    # The returned Pointer is usable as a by-value Pointer argument.
+    memset_p($p, 0, 128);
+    pass 'memset through a returned Pointer works';
+    free_p($p);
+    pass 'free of a returned Pointer works';
 }

--- a/t/nativecall-sqlite.t
+++ b/t/nativecall-sqlite.t
@@ -1,0 +1,73 @@
+use Test;
+
+# End-to-end NativeCall integration: drive a real SQLite database through its C
+# API — open, create a table, insert rows, run a prepared SELECT and read the
+# result rows, then finalize and close. This exercises the whole NativeCall
+# surface together: `is rw Pointer` out-parameters (open / prepare_v2), by-value
+# `Pointer` arguments, `int32` and `Str` (`char*`) returns, and the bare
+# `Pointer` type object passed as a NULL pointer.
+#
+# libsqlite3 is preinstalled on common Linux CI images, but it is not part of
+# the language core, so the whole file degrades to a single skip when the
+# library cannot be loaded — it never fails the suite on a host that lacks it.
+
+use NativeCall;
+
+sub sqlite3_libversion() returns Str is native('sqlite3') { * }
+sub sqlite3_open(Str $name, Pointer $db is rw) returns int32 is native('sqlite3') { * }
+sub sqlite3_close(Pointer $db) returns int32 is native('sqlite3') { * }
+sub sqlite3_exec(Pointer $db, Str $sql, Pointer $cb, Pointer $arg, Pointer $err)
+    returns int32 is native('sqlite3') { * }
+sub sqlite3_prepare_v2(Pointer $db, Str $sql, int32 $n, Pointer $stmt is rw, Pointer $tail)
+    returns int32 is native('sqlite3') { * }
+sub sqlite3_step(Pointer $stmt) returns int32 is native('sqlite3') { * }
+sub sqlite3_column_int(Pointer $stmt, int32 $col) returns int32 is native('sqlite3') { * }
+sub sqlite3_column_text(Pointer $stmt, int32 $col) returns Str is native('sqlite3') { * }
+sub sqlite3_finalize(Pointer $stmt) returns int32 is native('sqlite3') { * }
+sub sqlite3_errmsg(Pointer $db) returns Str is native('sqlite3') { * }
+
+# Probe whether libsqlite3 is loadable at all; skip the whole file if not.
+my $version = try sqlite3_libversion();
+without $version {
+    plan 1;
+    skip 'libsqlite3 not available on this host', 1;
+    done-testing;
+    exit 0;
+}
+
+plan 11;
+
+ok $version ~~ /^ \d+ '.' \d+ /, "sqlite3 libversion looks sane ($version)";
+
+constant SQLITE_OK  = 0;
+constant SQLITE_ROW = 100;
+
+my $db = Pointer.new;
+is sqlite3_open(':memory:', $db), SQLITE_OK, 'sqlite3_open(:memory:) returns OK';
+ok $db.Bool, 'open wrote a non-NULL db handle (is rw out-parameter)';
+
+is sqlite3_exec($db, 'CREATE TABLE t (id INTEGER, name TEXT)', Pointer, Pointer, Pointer),
+    SQLITE_OK, 'CREATE TABLE via sqlite3_exec';
+is sqlite3_exec($db, q{INSERT INTO t VALUES (1,'alice'),(2,'bob'),(3,'carol')}, Pointer, Pointer, Pointer),
+    SQLITE_OK, 'INSERT rows via sqlite3_exec';
+
+my $stmt = Pointer.new;
+is sqlite3_prepare_v2($db, 'SELECT id, name FROM t ORDER BY id', -1, $stmt, Pointer),
+    SQLITE_OK, 'prepare_v2 a SELECT (is rw stmt out-parameter)';
+ok $stmt.Bool, 'prepare_v2 wrote a non-NULL statement handle';
+
+my @rows;
+while sqlite3_step($stmt) == SQLITE_ROW {
+    @rows.push: sqlite3_column_int($stmt, 0) => sqlite3_column_text($stmt, 1);
+}
+is @rows.elems, 3, 'stepped over all three rows';
+is-deeply @rows, [1 => 'alice', 2 => 'bob', 3 => 'carol'],
+    'read back int + text columns for every row';
+
+# A bad statement: exec returns non-zero and errmsg reports it.
+isnt sqlite3_exec($db, 'SELECT * FROM nope', Pointer, Pointer, Pointer), SQLITE_OK,
+    'a bad statement returns a non-OK code';
+like sqlite3_errmsg($db), /'no such table'/, 'errmsg reports the failure';
+
+sqlite3_finalize($stmt);
+sqlite3_close($db);


### PR DESCRIPTION
## Summary

Two things land here, together completing real database access through NativeCall:

1. **`returns Pointer` yields a real `Pointer` object** (was a bare Int). A `void*`-returning C function like `malloc` now gives a value you can inspect (`.^name` → `Pointer`, `.gist`, `.Bool`) and pass straight back into another `Pointer` parameter (`free`/`memset`). Built in `call_native` via `Value::make_instance`.

2. **A full SQLite query round-trip works** — with no further Rust. The existing `is rw Pointer` out-parameters + `int32`/`Str` returns already cover `sqlite3_prepare_v2` / `step` / `column_int` / `column_text` / `finalize`, so mutsu runs a prepared SELECT and reads the **actual result rows**:

```
row: id=1 name=alice
row: id=2 name=bob
row: id=3 name=carol
```

That's a complete CRUD round-trip (open → CREATE → INSERT → prepared SELECT → read rows → close) against a real database from mutsu.

## Tests

- `t/nativecall-pointer.t` — adds a `returns Pointer` case (malloc → Pointer → memset/free), libc-only.
- `t/nativecall-sqlite.t` (**new**) — end-to-end integration: `:memory:` open, CREATE, INSERT, prepared SELECT reading 3 rows back (int + text), error reporting, finalize, close. **Degrades to a single skip when libsqlite3 can't be loaded** (verified `try` catches the load failure), so it never fails the suite on a host without the library.

`make test` / `cargo clippy -- -D warnings` / wasm32 build all clean.

## PLAN.md

Drops the now-moot "sqlite3 CLI wrapper" fallback — NativeCall covers real DB access directly. Next: `CArray` / `CStruct` / callbacks, and a thin DBDish::SQLite-compatible layer in pure Raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)