### PR TITLE
feat(state-ownership): implement Capture.new (ledger §D ③)

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1749,6 +1749,24 @@ impl Interpreter {
                 Value::Int(super::native_methods::next_supplier_id() as i64),
             );
             Some(Ok(Value::make_instance(class_name, attrs)))
+        } else if cn == "Capture" {
+            // The default `Capture.new` produces an *empty* Capture: named args
+            // are dropped (Capture has no buildable public attributes — `bless`
+            // ignores them) and positional args are rejected (`Mu.new` is
+            // named-only). A *populated* Capture is built with the `\(...)`
+            // literal, not `.new`. A named arg reaches here as `Value::Pair`;
+            // anything else (a literal, a positional `"a" => 1` `ValuePair`) is
+            // positional and dies, exactly as raku does.
+            if args.iter().any(|a| !matches!(a, Value::Pair(..))) {
+                Some(Err(RuntimeError::new(
+                    "Default constructor for 'Capture' only takes named arguments",
+                )))
+            } else {
+                Some(Ok(Value::Capture {
+                    positional: Box::new(Vec::new()),
+                    named: Box::new(HashMap::new()),
+                }))
+            }
         } else if cn == "FakeScheduler" {
             Some(Ok(Self::build_native_fakescheduler_value()))
         } else if cn == "Proxy" {

--- a/t/native-capture-ctor.t
+++ b/t/native-capture-ctor.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Pin for the §D ③ ctor fork: `Capture.new`. Previously mutsu errored with
+# "Unknown method ... new on Capture" — `Capture` had no constructor at all.
+#
+# raku semantics (verified): the default `Capture.new` produces an *empty*
+# Capture. Named arguments are silently dropped (Capture has no buildable public
+# attributes, so `bless` ignores them) and positional arguments are rejected
+# ("Default constructor for 'Capture' only takes named arguments"), exactly as
+# `Mu.new` (named-only) does. A *populated* Capture is built with `\(...)`.
+#
+# This is pure data assembly, so the VM builds it directly via
+# `try_native_builtin_construct` (no env / registry / user code).
+
+plan 9;
+
+# Empty capture
+my $c = Capture.new;
+isa-ok $c, Capture, 'Capture.new yields a Capture';
+is $c.elems, 0, 'Capture.new is empty';
+is $c.list.elems, 0, 'Capture.new has no positional';
+is $c.hash.elems, 0, 'Capture.new has no named';
+
+# Named arguments are dropped (NOT stored as named captures)
+my $n = Capture.new(:a(3), :b(4));
+is $n.elems, 0, 'named args to Capture.new are dropped';
+is $n<a>, Nil, 'a dropped named arg is not accessible';
+
+# Positional arguments are rejected
+dies-ok { Capture.new(1, 2) }, 'positional args to Capture.new die';
+dies-ok { Capture.new("a" => 1) }, 'a positional Pair to Capture.new dies';
+
+# A populated Capture is built with the `\(...)` literal (unchanged)
+my $cap = \(1, 2, :a(3));
+is $cap.list.elems, 2, '\\(...) still builds a populated Capture';


### PR DESCRIPTION
## Summary
§D ③ ctor fork: `Capture` had no constructor at all — `Capture.new` errored with "Unknown method ... new on Capture". This implements the default constructor.

raku semantics (verified): the default `Capture.new` yields an **empty** Capture. Named arguments are silently dropped (Capture has no buildable public attributes) and positional arguments are rejected ("Default constructor for 'Capture' only takes named arguments"), exactly as the named-only `Mu.new`. A *populated* Capture is still built with `\(...)`.

Pure data assembly → lives in `try_native_builtin_construct`; the VM builds it directly, no interpreter bounce.

### Known unchanged gap (not a regression)
`.new` on a *Capture instance* (`\(1).new`) still errors, like `.new` on the other built-in value variants — the broader "instance `.new` delegation for non-Instance built-in values" gap, out of scope here.

## Test
- pin `t/native-capture-ctor.t` (9) — passes under **both** mutsu and raku.

> Note: stacked on #3523 (FakeScheduler/Proxy/Match ctor); will rebase once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)