### PR TITLE
fix(parser): allow a trait / where clause on a type-only parameter

### DIFF
--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -996,13 +996,23 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             || r2.starts_with(']')
             || r2.starts_with('{')
             || r2.starts_with("-->")
+            // A type-only parameter may still carry traits / a where clause:
+            // `Pointer is rw` (a NativeCall out-parameter), `Int where * > 0`.
+            || keyword("is", r2).is_some()
+            || keyword("where", r2).is_some()
         {
             // True/False in signature position are literal Bool values, not type names.
             // In Raku, `sub f(True)` means "type Bool, smartmatched against True".
             // Smartmatch against True always succeeds, so the literal check is just
             // a Bool type constraint. Smartmatch against False always fails, so
             // sub f(False) would reject all calls (equivalent to an impossible constraint).
-            if tc == "True" || tc == "False" {
+            if (tc == "True" || tc == "False")
+                && (r2.starts_with(')')
+                    || r2.starts_with(',')
+                    || r2.starts_with(']')
+                    || r2.starts_with('{')
+                    || r2.starts_with("-->"))
+            {
                 super::super::add_parse_warning(format!(
                     "Potential difficulties:\n    Literal values in signatures are smartmatched against and smartmatch with `{}` will always {}. Use the `where` clause instead.",
                     tc,
@@ -1020,7 +1030,28 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             p.type_constraint = Some(tc);
             p.named = named;
             p.slurpy = slurpy;
-            return Ok((r2, p));
+            // Optional traits (`is rw`, `is copy`, …) and a `where` clause on the
+            // anonymous parameter.
+            let mut param_traits = Vec::new();
+            let (mut r3, _) = ws(r2)?;
+            while let Some(r) = keyword("is", r3) {
+                let (r, _) = ws1(r)?;
+                let (r, trait_name) = ident(r)?;
+                validate_param_trait(&trait_name, &param_traits, r)?;
+                param_traits.push(trait_name);
+                let (r, _) = ws(r)?;
+                r3 = r;
+            }
+            p.traits = param_traits;
+            let (r3, where_constraint) = if let Some(r) = keyword("where", r3) {
+                let (r, _) = ws1(r)?;
+                let (r, constraint) = parse_where_constraint_expr(r)?;
+                (r, Some(Box::new(constraint)))
+            } else {
+                (r3, None)
+            };
+            p.where_constraint = where_constraint;
+            return Ok((r3, p));
         } else {
             // Check for multiple prefix type constraints (e.g. `Int Str $x`)
             if let Some((r3, _second_tc)) = parse_type_constraint_expr(r2) {

--- a/t/anon-param-trait.t
+++ b/t/anon-param-trait.t
@@ -1,0 +1,58 @@
+use Test;
+
+# A type-only (anonymous) parameter may still carry a trait (`is rw`, `is copy`)
+# or a `where` clause — previously mutsu's signature parser only accepted a
+# trailing `)`, `,`, `]`, `{`, `-->` after the type and choked on `is`/`where`.
+# This shape is common in NativeCall signatures, e.g. `(Str, Pointer is rw)`.
+
+plan 9;
+
+# --- parses, and `is rw` is enforced like Rakudo (writable arg required) ---
+{
+    sub f(Str, Int is rw) returns Int { 42 }
+    my $n = 1;
+    is f("x", $n), 42, 'anon `is rw` param accepts a writable variable';
+    dies-ok { f("x", 1) }, 'anon `is rw` param rejects a literal (X::Parameter::RW)';
+}
+
+# --- multiple anon params, mixed traits ---
+{
+    sub g(Int is rw, Str is copy) { 'ok' }
+    my $i = 1;
+    is g($i, "a"), 'ok', 'two anon params with traits parse and run';
+}
+
+# --- anon param with a where clause ---
+{
+    sub h(Int where * > 0) { 'pos' }
+    is h(5), 'pos', 'anon param with a where clause parses';
+    dies-ok { h(-1) }, 'the where clause on the anon param is enforced';
+}
+
+# --- mixed: named param after an anon-with-trait ---
+{
+    sub k(Int is rw, Str $name) { $name }
+    my $i = 1;
+    is k($i, "bob"), 'bob', 'named param follows an anon-with-trait param';
+}
+
+# --- a bare type-only param (no trait) still works (no regression) ---
+{
+    sub m(Int) { 'typed' }
+    is m(7), 'typed', 'plain type-only param still parses';
+}
+
+# --- `is rw` on a *named* param is unaffected ---
+{
+    sub n($x is rw) { $x = 99 }
+    my $v = 1;
+    n($v);
+    is $v, 99, 'is rw on a named param still writes back';
+}
+
+# --- anon param trait coexists with an arrow return type ---
+{
+    sub p(Int is rw --> Int) { 3 }
+    my $i = 1;
+    is p($i), 3, 'anon-with-trait coexists with an arrow return type';
+}


### PR DESCRIPTION
## Summary

A type-only (anonymous) parameter couldn't carry a trait or a `where` clause. After reading the type, the signature parser only accepted a trailing `)`, `,`, `]`, `{`, or `-->`, and treated anything else — including `is` / `where` — as a *second* prefix type constraint. So these failed to parse with "expected statement":

```raku
sub f(Str, Int is rw) { ... }   # ← before: parse error
sub g(Int where * > 0) { ... }  # ← before: parse error
```

This is exactly the shape NativeCall signatures use:

```raku
sub sqlite3_open(Str, Pointer is rw) returns int32 is native('sqlite3') { * }
```

so without it an out-parameter had to be written with a throwaway variable name. Now an anonymous parameter accepts `is <trait>` (rw, copy, …) and a `where` clause, matching Rakudo.

`is rw` is still enforced at call time exactly like Rakudo: a **literal** argument dies with `X::Parameter::RW`, a **writable variable** is accepted (verified against `raku`).

## Test

`t/anon-param-trait.t` (9 cases) — covers anon `is rw` (accept variable / reject literal), mixed traits, `where`, a named param following an anon-with-trait, the arrow-return combination, and regression cases (plain type-only, named `is rw`).

`make test` / `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)