### PR TITLE
feat(nativecall): make the Pointer prelude available inside modules

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -212,6 +212,10 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     **`sqlite3_prepare_v2`/`step`/`column_int`/`column_text`/`finalize` による prepared-statement SELECT で実際の
     行データ（int+text）を読み取れる**（新規 Rust 不要・既存 marshalling で動作）。担保＝`t/nativecall-sqlite.t`
     （libsqlite3 不在なら graceful skip）。**= mutsu から実 SQLite DB の完全な CRUD 往復が可能。**
+  - **✅ モジュール配布 + 無名パラメータ（#TBD）**: NativeCall バインディングを **`use`-可能なモジュールとして配布可能**に
+    （`Pointer` prelude を module 解析パス `parse_module_source` でも注入）。さらに無名（型のみ）パラメータにトレイト/where
+    を許可（`sub f(Str, Pointer is rw)` がパース可能に・`src/parser/stmt/sub_param.rs`）。担保＝`t/nativecall-in-module.t`
+    / `t/anon-param-trait.t`。**= 薄い DBDish::SQLite 互換層を pure-Raku モジュールとして書ける状態。**
   - **残（より広いモジュール互換に）**: ① `CArray[uint8]`・`CArray[Str]` / ② `is repr('CStruct')` 構造体 /
     ③ callback（汎用 C コールバック）。DBDish::SQLite 自体は上記 prepared-statement API で原理的に駆動可能。
   - **DBIish/DBDish**: pure-Raku ドライバを上記 NativeCall sub 群で実装可能（次の有力タスク＝薄い DBDish::SQLite 互換層）。

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -1439,7 +1439,12 @@ impl Interpreter {
             err.message = format!("Failed to parse module '{}': {}", module, err.message);
             err
         })?;
-        let stmts = Self::merge_unit_class(stmts);
+        let mut stmts = Self::merge_unit_class(stmts);
+        // A module that uses NativeCall and references `Pointer` needs the
+        // builtin `Pointer` prelude class too — the main-program injection only
+        // sees the main source, so a NativeCall binding distributed as a module
+        // would otherwise hit an undeclared `Pointer`.
+        Self::inject_nativecall_prelude(&preprocessed, &mut stmts);
 
         // Save to precompilation cache when the module is eligible.
         if precomp_eligible {

--- a/t/lib/NCPointerMod.rakumod
+++ b/t/lib/NCPointerMod.rakumod
@@ -1,0 +1,20 @@
+use NativeCall;
+unit module NCPointerMod;
+
+# A NativeCall binding distributed as a *module* — it references the builtin
+# `Pointer` type, which must be available even though the program that `use`s
+# this module never mentions `Pointer` itself. Uses libc only (CI-safe).
+
+sub posix_memalign(Pointer $p is rw, int64 $align, int64 $size)
+    returns int32 is native('c') { * }
+sub free(Pointer $p) is native('c') { * }
+
+#| Allocate `$size` bytes aligned to `$align`; return the (non-NULL) Pointer.
+sub alloc-aligned(Int $align, Int $size) is export {
+    my $p = Pointer.new;
+    my $rc = posix_memalign($p, $align, $size);
+    die "posix_memalign failed: $rc" if $rc != 0;
+    $p;
+}
+
+sub release(Pointer $p) is export { free($p) }

--- a/t/nativecall-in-module.t
+++ b/t/nativecall-in-module.t
@@ -1,0 +1,16 @@
+use Test;
+use lib 't/lib';
+use NCPointerMod;
+
+# A NativeCall binding distributed as a module references the builtin `Pointer`
+# type. The main program below never mentions `Pointer`, so the `Pointer`
+# prelude must be injected for the *module* too — otherwise the module hits an
+# undeclared `Pointer` at runtime.
+
+plan 4;
+
+my $p = alloc-aligned(16, 256);
+isa-ok $p, Pointer, 'module returned a Pointer object';
+ok $p.Int > 0, 'the module allocated a non-NULL block (is rw out-parameter worked across the module boundary)';
+ok $p.Int %% 16, 'the block honours the requested alignment';
+lives-ok { release($p) }, 'the module can free the block';


### PR DESCRIPTION
## Summary

A NativeCall binding distributed as a `use`-able module references the builtin `Pointer` type, but the prelude that defines `Pointer` was only injected into the **main program's** source. So a program that `use`s such a module without itself mentioning `Pointer` hit an undeclared `Pointer` at runtime — blocking the natural way to ship a binding (e.g. a thin `DBDish::SQLite`-style wrapper).

This injects the `Pointer` prelude in `parse_module_source` too (same gate: the module source references NativeCall + Pointer and doesn't declare its own `Pointer`). A NativeCall binding now works as an ordinary module.

Verified: a module exposing `posix_memalign`/`free` via `Pointer` (and a `:memory:` sqlite wrapper) works from a program that never names `Pointer`. Double-injection (both main and module use `Pointer`) and the precompilation-cache path are both fine.

## Test

`t/nativecall-in-module.t` + `t/lib/NCPointerMod.rakumod` (libc-only, CI-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)