### PR TITLE
feat(state-ownership): native-ize .new for allomorphs + ObjAt/ValueObjAt (ledger §D ③)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -124,8 +124,12 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     populated は `\(...)`。残ギャップ＝Capture **instance** 受け手の `.new`（別軸の built-in value variant instance ctor 委譲）。
   - **`Array`/`List`/`Positional`/`array`/`Hash`/`Map` の `.new`（#3526）= 完了**。`&mut self`（shaped/typed/metadata）なので QuantHash 同様
     新モジュール `methods_aggregate_ctor.rs` に 2 arm（~310 行）丸ごと抽出＝true single impl。
-  - **clean な built-in ctor 候補は枯渇。** 残る `dispatch_new` arm は state/FS/process 依存（IO::Socket::INET・Distribution/CompUnit::Repository・
-    Proc::Async・Backtrace・Seq〔predictive iterator carrier〕）か error-only（HyperWhatever/Whatever/Instant）＝別軸 or 構造ブロッカー前提。
+  - **allomorph〔`IntStr`/`NumStr`/`RatStr`/`ComplexStr`〕＋`ObjAt`/`ValueObjAt` の `.new`（#TBD）= 完了**。`dispatch_new` ではなく
+    `dispatch_new_and_constructors`（slow-path）側に在った pure-static ctor。`new` fallback receiver の再計測で最頻（RatStr 892 等）と判明。
+    static `build_native_allomorph_value`/`build_native_objat_value` を `try_native_builtin_construct` と interpreter 両方が呼ぶ＝true single impl。
+  - **clean な built-in ctor 候補は枯渇。** 残る `new` fallback receiver は state/FS/process 依存（IO::Socket::INET・Proc::Async・Failure〔`$!` 読み〕・
+    Distribution/CompUnit::Repository・Backtrace・Seq〔predictive iterator carrier〕・IO::Path family〔registry・候補〕）か error-only（HyperWhatever/
+    Whatever/Instant）＝別軸 or 構造ブロッカー前提。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で
     撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -606,6 +606,20 @@
   mutsu 固有挙動は roast S02-types/array.t・hash.t・S09-typed-arrays/* がカバー)。**★これで `dispatch_new` の built-in 型 ctor のうち native 化
   可能な clean 候補は枯渇。残る arm は state/FS/process 依存（IO::Socket::INET〔socket〕・Distribution/CompUnit::Repository〔FS〕・Proc::Async
   〔process〕・Backtrace〔call stack〕・Seq〔predictive iterator carrier〕）か error-only（HyperWhatever/Whatever/Instant）。**
+- **2026-06-24 (§D ③ = allomorph〔`IntStr`/`NumStr`/`RatStr`/`ComplexStr`〕＋`ObjAt`/`ValueObjAt` の `.new` を VM ネイティブ化)**: ③ ctor フォークの
+  再計測（全 whitelist の `new` fallback receiver を一時プローブで実測）で、aggregate 後も残る最頻 receiver が **`dispatch_new` ではなく
+  `dispatch_new_and_constructors`（slow-path method dispatch）に在る**ことが判明: `RatStr`(892)/`IntStr`(306)/`ComplexStr`(176)/`NumStr`(125)
+  ＝allomorph、`ObjAt`/`ValueObjAt`(計18)。これらは完全 **pure-static**（args→instance・`&self` 一切不要＝registry/env/FS も触らない）。
+  allomorph `.new(numeric, string)` は inner numeric（allomorphic `Mixin` 引数なら unwrap）を `Str` override 付き `Value::mixin` に、`ObjAt`/
+  `ValueObjAt` `.new(which)` は first positional の stringify を `WHICH` 属性に格納するだけ。**static `try_native_builtin_construct`（VM call site
+  vm_call_method_compiled.rs:160/1788 が呼び `method_dispatch_pure=true`）に 2 arm 追加**し、新 static helper `build_native_allomorph_value`/
+  `build_native_objat_value` を `dispatch_new_and_constructors`（インライン実装を撤去）と両方が呼ぶ＝**1 操作 = 1 実装**（FakeScheduler/Proxy/Match
+  と同パターン）。arity エラー文言は mutsu 固有（"requires two arguments" / "Too few positionals"＝raku と異なる pre-existing 差）を抽出時に保持＝
+  byte-identical。実測 `IntStr.new`/`RatStr.new`/`ObjAt.new` 等の `new` fallback → 0（val.t の `new` が histogram から消失）。pin
+  `t/native-allomorph-objat-ctor.t`(23・raku/mutsu 双方 PASS)。S32-str/val.t・S03-operators/set_union.t・S32-num/rounders.t・rat.t・S02-types/num.t
+  whitelist 全緑。（allomorphic.t 107/113 の既存 fail は main でも同一＝`.ACCEPTS`/`.Numeric` の別軸ギャップで本変更と無関係。）**残 `new` fallback receiver
+  ＝Proc::Async〔process〕/Failure〔`$!` env 読み〕/IO::Socket::INET〔socket〕/IO::Path family〔registry・別スライス候補〕/CallFrame〔call stack〕/
+  Seq〔iterator carrier〕＝いずれも state 依存 or 別軸。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -42,49 +42,21 @@ impl Interpreter {
             }
             "new" if matches!(target, Value::Package(name) if matches!(name.resolve().as_str(), "ObjAt" | "ValueObjAt")) =>
             {
-                let class_name = if let Value::Package(n) = target {
-                    n.resolve()
-                } else {
-                    unreachable!()
+                // Pure data assembly — shared with the VM's `try_native_builtin_construct`.
+                let class_name = match target {
+                    Value::Package(n) => *n,
+                    _ => unreachable!(),
                 };
-                // Find the first non-Pair positional argument (Pairs are named args)
-                let positional = args
-                    .iter()
-                    .find(|a| !matches!(a, Value::Pair(_, _) | Value::ValuePair(_, _)));
-                match positional {
-                    Some(val) => {
-                        let which_str = val.to_string_value();
-                        let mut attrs = std::collections::HashMap::new();
-                        attrs.insert("WHICH".to_string(), Value::str(which_str));
-                        Some(Ok(Value::make_instance(Symbol::intern(&class_name), attrs)))
-                    }
-                    None => Some(Err(RuntimeError::new(
-                        "Too few positionals passed; expected 2 arguments but got 1".to_string(),
-                    ))),
-                }
+                Some(Self::build_native_objat_value(class_name, &args))
             }
             "new" if matches!(target, Value::Package(name) if matches!(name.resolve().as_str(), "IntStr" | "NumStr" | "RatStr" | "ComplexStr")) =>
             {
-                let type_name = if let Value::Package(n) = target {
-                    n.resolve()
-                } else {
-                    unreachable!()
+                // Pure data assembly — shared with the VM's `try_native_builtin_construct`.
+                let type_name = match target {
+                    Value::Package(n) => n.resolve(),
+                    _ => unreachable!(),
                 };
-                if args.len() < 2 {
-                    return Some(Err(RuntimeError::new(format!(
-                        "{}.new requires two arguments (numeric, string)",
-                        type_name
-                    ))));
-                }
-                // Unwrap allomorphic (Mixin) arguments to get the inner numeric value
-                let numeric = match &args[0] {
-                    Value::Mixin(inner, _) => (**inner).clone(),
-                    other => other.clone(),
-                };
-                let string = args[1].to_string_value();
-                let mut mixins = std::collections::HashMap::new();
-                mixins.insert("Str".to_string(), Value::str(string));
-                Some(Ok(Value::mixin(numeric, mixins)))
+                Some(Self::build_native_allomorph_value(&type_name, &args))
             }
             "new" if matches!(target, Value::Package(name) if name == "Failure") => {
                 let default_exception = || {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1636,6 +1636,57 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Match"), attrs)
     }
 
+    /// VM-native construction for an allomorph type (`IntStr`/`NumStr`/`RatStr`/
+    /// `ComplexStr`) — `.new(numeric, string)` is pure data assembly: the inner
+    /// numeric value (unwrapped from an allomorphic `Mixin` argument) is mixed
+    /// with a `Str` override carrying the string form. No env / registry / user
+    /// code. The interpreter's `dispatch_new_and_constructors` arm calls the same
+    /// helper, so the native path is byte-identical.
+    pub(crate) fn build_native_allomorph_value(
+        type_name: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        if args.len() < 2 {
+            return Err(RuntimeError::new(format!(
+                "{}.new requires two arguments (numeric, string)",
+                type_name
+            )));
+        }
+        // Unwrap allomorphic (Mixin) arguments to get the inner numeric value.
+        let numeric = match &args[0] {
+            Value::Mixin(inner, _) => (**inner).clone(),
+            other => other.clone(),
+        };
+        let string = args[1].to_string_value();
+        let mut mixins = HashMap::new();
+        mixins.insert("Str".to_string(), Value::str(string));
+        Ok(Value::mixin(numeric, mixins))
+    }
+
+    /// VM-native construction for `ObjAt`/`ValueObjAt` — `.new(which)` is pure
+    /// data assembly: the first positional argument's stringification is stored
+    /// as the `WHICH` attribute. A missing positional is the same arity error the
+    /// interpreter raises. Shared with the interpreter's
+    /// `dispatch_new_and_constructors` arm so the native path is byte-identical.
+    pub(crate) fn build_native_objat_value(
+        class_name: Symbol,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let positional = args
+            .iter()
+            .find(|a| !matches!(a, Value::Pair(_, _) | Value::ValuePair(_, _)));
+        match positional {
+            Some(val) => {
+                let mut attrs = HashMap::new();
+                attrs.insert("WHICH".to_string(), Value::str(val.to_string_value()));
+                Ok(Value::make_instance(class_name, attrs))
+            }
+            None => Err(RuntimeError::new(
+                "Too few positionals passed; expected 2 arguments but got 1".to_string(),
+            )),
+        }
+    }
+
     /// VM-native construction for a built-in type whose `.new(...)` is pure data
     /// assembly (no env / registry / user code): `Buf`/`Blob` (byte overlay),
     /// `utf8`/`utf16` (code units), `Uni` (codepoints), `Version`, `Duration`
@@ -1773,6 +1824,15 @@ impl Interpreter {
             Some(Ok(Self::build_native_proxy_value(args)))
         } else if cn == "Match" {
             Some(Ok(Self::build_native_match_value(args)))
+        } else if matches!(cn.as_str(), "IntStr" | "NumStr" | "RatStr" | "ComplexStr") {
+            // Allomorph `.new(numeric, string)` is pure data assembly (a numeric
+            // value mixed with a `Str` override) — shared with the interpreter's
+            // `dispatch_new_and_constructors` arm.
+            Some(Self::build_native_allomorph_value(&cn, args))
+        } else if matches!(cn.as_str(), "ObjAt" | "ValueObjAt") {
+            // `ObjAt`/`ValueObjAt` `.new(which)` stores the stringified first
+            // positional as the `WHICH` attribute — pure data assembly.
+            Some(Self::build_native_objat_value(class_name, args))
         } else {
             None
         }

--- a/t/native-allomorph-objat-ctor.t
+++ b/t/native-allomorph-objat-ctor.t
@@ -1,0 +1,57 @@
+use Test;
+
+# Pin for the §D ③ ctor-fork slice native-izing the allomorph (`IntStr`/`NumStr`/
+# `RatStr`/`ComplexStr`) and `ObjAt`/`ValueObjAt` `.new` constructors in the VM.
+# These are pure data assembly (a numeric value mixed with a `Str` override, or a
+# stringified `WHICH`), so the VM builds them directly via
+# `try_native_builtin_construct` instead of bouncing to the interpreter. The
+# behaviour is byte-identical to the interpreter's `dispatch_new_and_constructors`
+# arm, which now delegates to the same `build_native_*` helpers.
+
+plan 23;
+
+# --- IntStr -----------------------------------------------------------------
+my $is = IntStr.new(42, "forty-two");
+isa-ok $is, IntStr, 'IntStr.new yields an IntStr';
+is $is.Int, 42, 'IntStr numeric part';
+is $is.Str, "forty-two", 'IntStr string part';
+ok $is ~~ Int, 'IntStr does Int';
+ok $is ~~ Str, 'IntStr does Str';
+
+# --- NumStr -----------------------------------------------------------------
+my $ns = NumStr.new(3.5e0, "three-and-a-half");
+isa-ok $ns, NumStr, 'NumStr.new yields a NumStr';
+is $ns.Num, 3.5e0, 'NumStr numeric part';
+is $ns.Str, "three-and-a-half", 'NumStr string part';
+
+# --- RatStr -----------------------------------------------------------------
+my $rs = RatStr.new(1/2, "half");
+isa-ok $rs, RatStr, 'RatStr.new yields a RatStr';
+is $rs.Rat, 0.5, 'RatStr numeric part';
+is $rs.Str, "half", 'RatStr string part';
+ok $rs ~~ Rat, 'RatStr does Rat';
+
+# --- ComplexStr -------------------------------------------------------------
+my $cs = ComplexStr.new(1+2i, "one plus two i");
+isa-ok $cs, ComplexStr, 'ComplexStr.new yields a ComplexStr';
+is $cs.Complex, 1+2i, 'ComplexStr numeric part';
+is $cs.Str, "one plus two i", 'ComplexStr string part';
+
+# --- numeric value unwrapped from an allomorph argument ---------------------
+my $nested = IntStr.new($is, "wrap");
+is $nested.Int, 42, 'allomorph numeric argument is unwrapped to its inner value';
+is $nested.Str, "wrap", 'allomorph string override is applied';
+
+# --- allomorphs participate in arithmetic / string context ------------------
+is $is + 8, 50, 'IntStr in numeric context';
+is $rs * 4, 2, 'RatStr in numeric context';
+is ~$is, "forty-two", 'IntStr stringifies to its Str part';
+
+# --- ObjAt / ValueObjAt -----------------------------------------------------
+my $o = ObjAt.new("some-which-value");
+isa-ok $o, ObjAt, 'ObjAt.new yields an ObjAt';
+my $vo = ValueObjAt.new("another-which");
+isa-ok $vo, ValueObjAt, 'ValueObjAt.new yields a ValueObjAt';
+
+# error: ObjAt.new with no positional argument dies
+dies-ok { ObjAt.new }, 'ObjAt.new with no positional dies';


### PR DESCRIPTION
## Summary

Continues the §D ③ ctor-fork (state ownership). Re-measuring the `new`
method-fallback receivers across the full whitelist (temporary probe) showed the
most frequent remaining ctor traffic lives in `dispatch_new_and_constructors`
(the slow-path method dispatch), **not** in `dispatch_new`:

- allomorphs: `RatStr`=892, `IntStr`=306, `ComplexStr`=176, `NumStr`=125
- `ObjAt`/`ValueObjAt`

These are **pure-static** constructors (args → instance; no `&self` — no
registry / env / FS / user code):

- allomorph `.new(numeric, string)` → inner numeric (unwrapped from an
  allomorphic `Mixin` arg) mixed with a `Str` override
- `ObjAt`/`ValueObjAt` `.new(which)` → stringified first positional stored as
  the `WHICH` attribute

## Implementation

Extract static helpers `build_native_allomorph_value` /
`build_native_objat_value`, called from **both**:
- `try_native_builtin_construct` (the VM's native ctor fast path, sets
  `method_dispatch_pure=true`)
- the interpreter's `dispatch_new_and_constructors` arm (inline impl removed)

= **one op, one impl**, byte-identical (FakeScheduler/Proxy/Match pattern,
#3523). The mutsu-specific arity error messages are preserved verbatim
(`"requires two arguments"` / `"Too few positionals"` — pre-existing diffs vs
raku, unchanged).

## Verification

- Measured: `IntStr.new`/`RatStr.new`/`ObjAt.new` `new` fallback → 0 (the `new`
  entry drops out of `val.t`'s fallback histogram).
- Pin `t/native-allomorph-objat-ctor.t` (23, raku/mutsu both pass).
- Whitelist green: `S32-str/val.t`, `S03-operators/set_union.t`,
  `S32-num/{rounders,rat}.t`, `S02-types/num.t`, `S02-types/built-in.t`.
- `cargo test` 468/0, clippy clean.
- `allomorphic.t` 107/113 pre-existing fails are identical on `main` (`.ACCEPTS`
  / `.Numeric` — a separate axis, unrelated to construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)