### PR TITLE
feat(state-ownership): native-ize IO::Path family .new (ledger §D ③ ctor capstone)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -124,11 +124,14 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     populated は `\(...)`。残ギャップ＝Capture **instance** 受け手の `.new`（別軸の built-in value variant instance ctor 委譲）。
   - **`Array`/`List`/`Positional`/`array`/`Hash`/`Map` の `.new`（#3526）= 完了**。`&mut self`（shaped/typed/metadata）なので QuantHash 同様
     新モジュール `methods_aggregate_ctor.rs` に 2 arm（~310 行）丸ごと抽出＝true single impl。
-  - **allomorph〔`IntStr`/`NumStr`/`RatStr`/`ComplexStr`〕＋`ObjAt`/`ValueObjAt` の `.new`（#TBD）= 完了**。`dispatch_new` ではなく
+  - **allomorph〔`IntStr`/`NumStr`/`RatStr`/`ComplexStr`〕＋`ObjAt`/`ValueObjAt` の `.new`（#3528）= 完了**。`dispatch_new` ではなく
     `dispatch_new_and_constructors`（slow-path）側に在った pure-static ctor。`new` fallback receiver の再計測で最頻（RatStr 892 等）と判明。
     static `build_native_allomorph_value`/`build_native_objat_value` を `try_native_builtin_construct` と interpreter 両方が呼ぶ＝true single impl。
+  - **`IO::Path` family〔`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`〕の `.new`（#TBD）= 完了**＝IO::Path native 化の ctor capstone。
+    pure path-string assembly（registry 読みのみ・FS/cwd/env 不要）。`dispatch_new` の IO::Path arm（~117 行）を `build_io_path_instance` に丸ごと抽出、
+    VM ゲート `try_native_io_path_construct` は `is_io_path_lexical_class`（built-in family のみ）に絞って非mut/mut 両 call site から呼ぶ＝true single impl。
   - **clean な built-in ctor 候補は枯渇。** 残る `new` fallback receiver は state/FS/process 依存（IO::Socket::INET・Proc::Async・Failure〔`$!` 読み〕・
-    Distribution/CompUnit::Repository・Backtrace・Seq〔predictive iterator carrier〕・IO::Path family〔registry・候補〕）か error-only（HyperWhatever/
+    Distribution/CompUnit::Repository・Backtrace・Seq〔predictive iterator carrier〕・CallFrame〔call stack〕）か error-only（HyperWhatever/
     Whatever/Instant）＝別軸 or 構造ブロッカー前提。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -620,6 +620,18 @@
   whitelist 全緑。（allomorphic.t 107/113 の既存 fail は main でも同一＝`.ACCEPTS`/`.Numeric` の別軸ギャップで本変更と無関係。）**残 `new` fallback receiver
   ＝Proc::Async〔process〕/Failure〔`$!` env 読み〕/IO::Socket::INET〔socket〕/IO::Path family〔registry・別スライス候補〕/CallFrame〔call stack〕/
   Seq〔iterator carrier〕＝いずれも state 依存 or 別軸。**
+- **2026-06-24 (§D ③ = `IO::Path` family〔`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`〕の `.new` を VM ネイティブ化＝IO::Path ctor capstone)**:
+  IO::Path native 化テーマの締め＝メソッド族（stat/content-read/fs-mutate/open/2-path/comb・#3499〜3511）は 100% native 化済だが **ctor だけ
+  catch-all バウンス**していた（プローブ実測で `IO::Path::Win32`/`::Cygwin`/`::Unix`/`IO::Path` 計~112 occ）。`.new` は **pure path-string assembly**
+  ＝positional path / IO::Path instance（`path` 再利用）/ basename+dirname+volume の三つ組を SPEC 由来セパレータで join し、CWD/SPEC 属性を付与する
+  だけ。`&self` 依存は **registry 読み**（`class_mro`＝IO::Path-instance 引数判定）のみ＝VM 所有（phase ②）＝FS/cwd/env/user code 不要。`dispatch_new`
+  の IO::Path arm（~117 行）を新 `&mut self` helper `build_io_path_instance` に**丸ごと抽出**（interpreter arm は delegation・SPEC-variant subclass の
+  一回限り registry 登録も保持）。VM ゲート `try_native_io_path_construct` は **built-in IO::Path family のみ**（`is_io_path_lexical_class`＝lexical method
+  スライスと同一ゲート＝user subclass の custom new を侵さない）に絞り、非mut/mut 両 call site（aggregate ctor arm の直後・`method_dispatch_pure=true`）から
+  呼ぶ＝**1 操作 = 1 実装**・byte-identical。実測 `IO::Path.new`/`IO::Path::Win32.new` 等の `new` fallback → 0。pin `t/native-io-path-ctor.t`(19・
+  positional/triple/instance-arg/Win32-Unix-Cygwin subclass/CWD/empty-null dies・raku/mutsu 双方 PASS)。S32-io/S16-io/tmpdir/cwd/S11-compunit whitelist
+  全緑（io-path.t 34/35 の `.SPEC`/`.CWD` attribute 既存 fail は main でも同一＝非whitelist・本変更と無関係）。**残 `new` fallback＝Proc::Async/Failure
+  〔`$!` env〕/IO::Socket::INET/CallFrame/Seq＝state 依存 or 別軸。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1687,6 +1687,179 @@ impl Interpreter {
         }
     }
 
+    /// VM-native gate for `IO::Path` family `.new(...)`. Returns `Some` only for
+    /// the built-in `IO::Path` classes (`IO::Path`, `IO::Path::Unix`/`::Win32`/
+    /// `::Cygwin`/`::QNX`), which never carry a user `new`; user subclasses fall
+    /// through to the interpreter's `dispatch_new` (where the broader MRO-based
+    /// `is_io_path_like` gate applies). The construction is pure path-string
+    /// assembly via the shared `build_io_path_instance` impl the interpreter's
+    /// `dispatch_new` arm also calls, so the native path is byte-identical. The
+    /// SPEC-variant subclass is registered (parent `IO::Path`) so reflection on
+    /// the result matches the interpreter, which registers it on `.new`.
+    pub(crate) fn try_native_io_path_construct(
+        &mut self,
+        class_name: Symbol,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let cn_resolved = class_name.resolve();
+        if !Self::is_io_path_lexical_class(&cn_resolved) {
+            return None;
+        }
+        // SPEC-variant subclasses are registered (parent IO::Path) the first time
+        // they are constructed, mirroring the interpreter's `dispatch_new`.
+        if cn_resolved.starts_with("IO::Path::")
+            && !self.registry().classes.contains_key(cn_resolved.as_str())
+        {
+            self.registry_mut().classes.insert(
+                cn_resolved.to_string(),
+                ClassDef {
+                    parents: vec!["IO::Path".to_string()],
+                    attributes: Vec::new(),
+                    methods: HashMap::new(),
+                    native_methods: std::collections::HashSet::new(),
+                    mro: Vec::new(),
+                    attribute_types: HashMap::new(),
+                    attribute_smileys: HashMap::new(),
+                    attribute_built: HashMap::new(),
+                    wildcard_handles: Vec::new(),
+                    alias_attributes: HashSet::new(),
+                    class_level_attrs: HashMap::new(),
+                },
+            );
+        }
+        Some(self.build_io_path_instance(class_name, &cn_resolved, args))
+    }
+
+    /// Pure path-string assembly for an `IO::Path` family `.new(...)`: a
+    /// positional path (or an `IO::Path` instance whose `path` is reused), or a
+    /// `basename`/`dirname`/`volume` triple, joined with the SPEC-derived
+    /// separator, plus optional `CWD`/`SPEC` attributes. Reads only the registry
+    /// (`class_mro`, for the IO::Path-instance argument case) — no FS, no cwd, no
+    /// env, no user code. The single authoritative impl shared by the interpreter's
+    /// `dispatch_new` arm and the VM's `try_native_io_path_construct`.
+    pub(crate) fn build_io_path_instance(
+        &mut self,
+        class_name: Symbol,
+        cn_resolved: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let mut positional_path: Option<String> = None;
+        let mut basename_part: Option<String> = None;
+        let mut dirname_part: Option<String> = None;
+        let mut volume_part: Option<String> = None;
+        let mut cwd_attr: Option<String> = None;
+        let mut spec_attr: Option<Value> = None;
+        for arg in args {
+            match arg {
+                Value::Pair(key, value) if key == "CWD" => {
+                    cwd_attr = Some(value.to_string_value());
+                }
+                Value::Pair(key, value) if key == "SPEC" => {
+                    spec_attr = Some((**value).clone());
+                }
+                Value::Pair(key, value) if key == "basename" => {
+                    basename_part = Some(value.to_string_value());
+                }
+                Value::Pair(key, value) if key == "dirname" => {
+                    dirname_part = Some(value.to_string_value());
+                }
+                Value::Pair(key, value) if key == "volume" => {
+                    volume_part = Some(value.to_string_value());
+                }
+                Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if positional_path.is_none()
+                    && self
+                        .class_mro(&class_name.resolve())
+                        .iter()
+                        .any(|n| n == "IO::Path") =>
+                {
+                    positional_path = Some(
+                        attributes
+                            .as_map()
+                            .get("path")
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default(),
+                    );
+                    if cwd_attr.is_none() {
+                        cwd_attr = attributes.as_map().get("cwd").map(|v| v.to_string_value());
+                    }
+                }
+                Value::Pair(_, _) => {}
+                _ if positional_path.is_none() => {
+                    positional_path = Some(arg.to_string_value());
+                }
+                _ => {}
+            }
+        }
+        // Determine dir separator from SPEC (Win32 uses '\', others use '/')
+        let is_win32_spec = spec_attr
+            .as_ref()
+            .map(|s| {
+                let name = match s {
+                    Value::Package(n) => n.resolve().to_string(),
+                    Value::Instance { class_name, .. } => class_name.resolve().to_string(),
+                    _ => String::new(),
+                };
+                name == "IO::Spec::Win32" || name.ends_with("Win32")
+            })
+            .unwrap_or(false);
+        let dir_sep = if is_win32_spec { '\\' } else { '/' };
+        let path = if let Some(positional) = positional_path {
+            positional
+        } else if let Some(basename) = basename_part {
+            let mut built = match dirname_part {
+                Some(dirname) if !dirname.is_empty() => {
+                    if dirname.ends_with('/') || dirname.ends_with('\\') {
+                        format!("{dirname}{basename}")
+                    } else {
+                        format!("{dirname}{dir_sep}{basename}")
+                    }
+                }
+                _ => basename,
+            };
+            if let Some(volume) = volume_part
+                && !volume.is_empty()
+            {
+                if volume.ends_with('/') || volume.ends_with('\\') {
+                    built = format!("{volume}{built}");
+                } else {
+                    built = format!("{volume}{dir_sep}{built}");
+                }
+            }
+            built
+        } else {
+            String::new()
+        };
+        if path.is_empty() {
+            return Err(RuntimeError::new(
+                "Must specify a non-empty string as a path",
+            ));
+        }
+        if path.contains('\0') {
+            return Err(RuntimeError::new(
+                "X::IO::Null: Found null byte in pathname",
+            ));
+        }
+        let mut attrs = HashMap::new();
+        attrs.insert("path".to_string(), Value::str(path));
+        if let Some(cwd) = cwd_attr {
+            attrs.insert("cwd".to_string(), Value::str(cwd));
+        }
+        if cn_resolved.starts_with("IO::Path::") {
+            let spec_name = format!("IO::Spec::{}", cn_resolved.trim_start_matches("IO::Path::"));
+            attrs.insert(
+                "SPEC".to_string(),
+                Value::Package(Symbol::intern(&spec_name)),
+            );
+        } else if let Some(spec) = spec_attr {
+            attrs.insert("SPEC".to_string(), spec);
+        }
+        Ok(Value::make_instance(class_name, attrs))
+    }
+
     /// VM-native construction for a built-in type whose `.new(...)` is pure data
     /// assembly (no env / registry / user code): `Buf`/`Blob` (byte overlay),
     /// `utf8`/`utf16` (code units), `Uni` (codepoints), `Version`, `Duration`
@@ -2330,123 +2503,9 @@ impl Interpreter {
                     .iter()
                     .any(|name| name == "IO::Path");
             if is_io_path_like && !self.has_user_method(class_key, "new") {
-                let mut positional_path: Option<String> = None;
-                let mut basename_part: Option<String> = None;
-                let mut dirname_part: Option<String> = None;
-                let mut volume_part: Option<String> = None;
-                let mut cwd_attr: Option<String> = None;
-                let mut spec_attr: Option<Value> = None;
-                for arg in &args {
-                    match arg {
-                        Value::Pair(key, value) if key == "CWD" => {
-                            cwd_attr = Some(value.to_string_value());
-                        }
-                        Value::Pair(key, value) if key == "SPEC" => {
-                            spec_attr = Some((**value).clone());
-                        }
-                        Value::Pair(key, value) if key == "basename" => {
-                            basename_part = Some(value.to_string_value());
-                        }
-                        Value::Pair(key, value) if key == "dirname" => {
-                            dirname_part = Some(value.to_string_value());
-                        }
-                        Value::Pair(key, value) if key == "volume" => {
-                            volume_part = Some(value.to_string_value());
-                        }
-                        Value::Instance {
-                            class_name,
-                            attributes,
-                            ..
-                        } if positional_path.is_none()
-                            && self
-                                .class_mro(&class_name.resolve())
-                                .iter()
-                                .any(|n| n == "IO::Path") =>
-                        {
-                            positional_path = Some(
-                                attributes
-                                    .as_map()
-                                    .get("path")
-                                    .map(|v| v.to_string_value())
-                                    .unwrap_or_default(),
-                            );
-                            if cwd_attr.is_none() {
-                                cwd_attr =
-                                    attributes.as_map().get("cwd").map(|v| v.to_string_value());
-                            }
-                        }
-                        Value::Pair(_, _) => {}
-                        _ if positional_path.is_none() => {
-                            positional_path = Some(arg.to_string_value());
-                        }
-                        _ => {}
-                    }
-                }
-                // Determine dir separator from SPEC (Win32 uses '\', others use '/')
-                let is_win32_spec = spec_attr
-                    .as_ref()
-                    .map(|s| {
-                        let name = match s {
-                            Value::Package(n) => n.resolve().to_string(),
-                            Value::Instance { class_name, .. } => class_name.resolve().to_string(),
-                            _ => String::new(),
-                        };
-                        name == "IO::Spec::Win32" || name.ends_with("Win32")
-                    })
-                    .unwrap_or(false);
-                let dir_sep = if is_win32_spec { '\\' } else { '/' };
-                let path = if let Some(positional) = positional_path {
-                    positional
-                } else if let Some(basename) = basename_part {
-                    let mut built = match dirname_part {
-                        Some(dirname) if !dirname.is_empty() => {
-                            if dirname.ends_with('/') || dirname.ends_with('\\') {
-                                format!("{dirname}{basename}")
-                            } else {
-                                format!("{dirname}{dir_sep}{basename}")
-                            }
-                        }
-                        _ => basename,
-                    };
-                    if let Some(volume) = volume_part
-                        && !volume.is_empty()
-                    {
-                        if volume.ends_with('/') || volume.ends_with('\\') {
-                            built = format!("{volume}{built}");
-                        } else {
-                            built = format!("{volume}{dir_sep}{built}");
-                        }
-                    }
-                    built
-                } else {
-                    String::new()
-                };
-                if path.is_empty() {
-                    return Err(RuntimeError::new(
-                        "Must specify a non-empty string as a path",
-                    ));
-                }
-                if path.contains('\0') {
-                    return Err(RuntimeError::new(
-                        "X::IO::Null: Found null byte in pathname",
-                    ));
-                }
-                let mut attrs = HashMap::new();
-                attrs.insert("path".to_string(), Value::str(path));
-                if let Some(cwd) = cwd_attr {
-                    attrs.insert("cwd".to_string(), Value::str(cwd));
-                }
-                if cn_resolved.starts_with("IO::Path::") {
-                    let spec_name =
-                        format!("IO::Spec::{}", cn_resolved.trim_start_matches("IO::Path::"));
-                    attrs.insert(
-                        "SPEC".to_string(),
-                        Value::Package(Symbol::intern(&spec_name)),
-                    );
-                } else if let Some(spec) = spec_attr {
-                    attrs.insert("SPEC".to_string(), spec);
-                }
-                return Ok(Value::make_instance(*class_name, attrs));
+                // Pure path-string assembly (registry reads only) — shared with the
+                // VM's `try_native_io_path_construct`.
+                return self.build_io_path_instance(*class_name, &cn_resolved, &args);
             }
             match base_class_name {
                 "IterationBuffer" => {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -188,6 +188,19 @@ impl Interpreter {
             self.method_dispatch_pure = true;
             return result;
         }
+        // Native IO::Path family construction: `IO::Path`/`IO::Path::Unix`/`::Win32`/
+        // `::Cygwin`/`::QNX`.new(...) — pure path-string assembly (positional path
+        // or basename/dirname/volume/CWD/SPEC pairs), no FS / cwd / env / user code
+        // (registry reads + a one-time SPEC-subclass registration, which the VM
+        // owns). Built via the single `build_io_path_instance` impl the
+        // interpreter's `dispatch_new` arm also delegates to.
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && let Some(result) = self.try_native_io_path_construct(*class_name, &args)
+        {
+            self.method_dispatch_pure = true;
+            return result;
+        }
         // Native built-in *class* method (a pure type-object method other than
         // `.new`, e.g. `Instant.from-posix`) — built directly instead of routing
         // through the interpreter's class-method dispatch.
@@ -1801,6 +1814,14 @@ impl Interpreter {
             && let Value::Package(class_name) = &target
             && let Some(result) =
                 self.try_native_aggregate_construct_for_package(*class_name, &args)
+        {
+            self.method_dispatch_pure = true;
+            return result;
+        }
+        // Native IO::Path family construction (mut path twin of the above).
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && let Some(result) = self.try_native_io_path_construct(*class_name, &args)
         {
             self.method_dispatch_pure = true;
             return result;

--- a/t/native-io-path-ctor.t
+++ b/t/native-io-path-ctor.t
@@ -1,0 +1,57 @@
+use Test;
+
+# Pin for the §D ③ ctor-fork slice native-izing the `IO::Path` family `.new`
+# (`IO::Path`, `IO::Path::Unix`/`::Win32`/`::Cygwin`/`::QNX`) in the VM. The
+# construction is pure path-string assembly (a positional path / an IO::Path
+# instance whose `path` is reused / a basename+dirname+volume triple, plus
+# optional CWD/SPEC), reading only the registry — no FS, cwd, env, or user code.
+# The VM builds it directly via `try_native_io_path_construct` instead of
+# bouncing to the interpreter, using the single `build_io_path_instance` impl the
+# interpreter's `dispatch_new` arm also delegates to (byte-identical). This is the
+# constructor capstone of the IO::Path native-ization (all IO::Path methods were
+# already native).
+
+plan 19;
+
+# --- positional path --------------------------------------------------------
+my $p = IO::Path.new("foo/bar");
+isa-ok $p, IO::Path, 'IO::Path.new yields an IO::Path';
+is $p.Str, "foo/bar", 'positional path is stored verbatim';
+is $p.basename, "bar", 'basename derived from path';
+is $p.parent.Str, "foo", 'parent derived from path';
+
+# --- basename / dirname / volume triple ------------------------------------
+is IO::Path.new(:basename<file.txt>, :dirname</tmp>).Str, "/tmp/file.txt",
+    'basename + dirname joined with /';
+is IO::Path.new(:basename<x>).Str, "x", 'basename alone';
+
+# --- pure lexical methods compose on the native-constructed instance --------
+is IO::Path.new("base").add("child").Str, "base/child", '.add on native ctor';
+is IO::Path.new("a/b/c.txt").extension, "txt", '.extension on native ctor';
+
+# --- IO::Path instance argument reuses its path -----------------------------
+my $orig = IO::Path.new("orig/path");
+my $copy = IO::Path.new($orig);
+isa-ok $copy, IO::Path, 'IO::Path.new(IO::Path) yields an IO::Path';
+is $copy.Str, "orig/path", 'path reused from IO::Path argument';
+
+# --- SPEC-variant subclasses ------------------------------------------------
+my $w = IO::Path::Win32.new("a/b/c");
+isa-ok $w, IO::Path::Win32, 'IO::Path::Win32.new yields IO::Path::Win32';
+is $w.Str, "a/b/c", 'Win32 path stored';
+is $w.SPEC.gist, "(Win32)", 'Win32 subclass gets IO::Spec::Win32';
+
+my $u = IO::Path::Unix.new("x/y");
+isa-ok $u, IO::Path::Unix, 'IO::Path::Unix.new yields IO::Path::Unix';
+is $u.Str, "x/y", 'Unix path stored';
+
+my $cyg = IO::Path::Cygwin.new("p/q");
+isa-ok $cyg, IO::Path::Cygwin, 'IO::Path::Cygwin.new yields IO::Path::Cygwin';
+
+# --- CWD attribute ----------------------------------------------------------
+my $c = IO::Path.new("rel", :CWD</base/dir>);
+is $c.Str, "rel", 'CWD does not alter the stored path';
+
+# --- error cases ------------------------------------------------------------
+dies-ok { IO::Path.new("") }, 'empty path dies';
+dies-ok { IO::Path.new("a\0b") }, 'null byte in path dies';


### PR DESCRIPTION
## Summary

The constructor capstone of the IO::Path native-ization (§D ③ state ownership).
The IO::Path **method** family (stat / content-read / fs-mutate / open /
two-path / comb) is already 100% VM-native (#3499–#3511), but the **`.new`
constructor** still bounced to the interpreter's catch-all — a probe across the
full whitelist showed `IO::Path::Win32`/`::Cygwin`/`::Unix`/`IO::Path` ctor
traffic (~112 occurrences).

`.new` is **pure path-string assembly**:
- a positional path, or
- an `IO::Path` instance whose `path` is reused, or
- a `basename`+`dirname`+`volume` triple joined with the SPEC-derived separator,

plus optional `CWD`/`SPEC` attributes. Its only `&self` dependency is a registry
read (`class_mro`, for the IO::Path-instance argument case), which the VM owns
(phase ②): no FS, cwd, env, or user code.

## Implementation

- Extract the `dispatch_new` IO::Path arm (~117 lines) wholesale into a
  `&mut self` helper `build_io_path_instance` (the interpreter arm now delegates;
  the one-time SPEC-variant subclass registration is preserved).
- VM gate `try_native_io_path_construct` is restricted to the built-in IO::Path
  family via `is_io_path_lexical_class` (the same gate the lexical-method slice
  uses, so a user subclass's custom `new` stays authoritative), called from both
  the non-mut and mut catch-all dispatch right after the aggregate-ctor arm
  (`method_dispatch_pure=true`).

= **one op, one impl**, byte-identical.

## Verification

- Measured: `IO::Path.new` / `IO::Path::Win32.new` etc. `new` fallback → 0.
- Pin `t/native-io-path-ctor.t` (19, raku/mutsu both pass):
  positional / triple / instance-arg / Win32-Unix-Cygwin subclass / CWD /
  empty-and-null-byte dies.
- Whitelist green: S32-io, S16-io, tmpdir, cwd, S11-compunit.
- `cargo test` 468/0, clippy clean.
- `io-path.t` 34/35 (`.SPEC`/`.CWD` attribute) fails are identical on `main` =
  a separate axis, unrelated to construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)