### PR TITLE
feat(state-ownership): native-ize Failure.new (ledger §D ③ ctor)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -127,12 +127,15 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
   - **allomorph〔`IntStr`/`NumStr`/`RatStr`/`ComplexStr`〕＋`ObjAt`/`ValueObjAt` の `.new`（#3528）= 完了**。`dispatch_new` ではなく
     `dispatch_new_and_constructors`（slow-path）側に在った pure-static ctor。`new` fallback receiver の再計測で最頻（RatStr 892 等）と判明。
     static `build_native_allomorph_value`/`build_native_objat_value` を `try_native_builtin_construct` と interpreter 両方が呼ぶ＝true single impl。
-  - **`IO::Path` family〔`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`〕の `.new`（#TBD）= 完了**＝IO::Path native 化の ctor capstone。
+  - **`IO::Path` family〔`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`〕の `.new`（#3529）= 完了**＝IO::Path native 化の ctor capstone。
     pure path-string assembly（registry 読みのみ・FS/cwd/env 不要）。`dispatch_new` の IO::Path arm（~117 行）を `build_io_path_instance` に丸ごと抽出、
     VM ゲート `try_native_io_path_construct` は `is_io_path_lexical_class`（built-in family のみ）に絞って非mut/mut 両 call site から呼ぶ＝true single impl。
-  - **clean な built-in ctor 候補は枯渇。** 残る `new` fallback receiver は state/FS/process 依存（IO::Socket::INET・Proc::Async・Failure〔`$!` 読み〕・
-    Distribution/CompUnit::Repository・Backtrace・Seq〔predictive iterator carrier〕・CallFrame〔call stack〕）か error-only（HyperWhatever/
-    Whatever/Instant）＝別軸 or 構造ブロッカー前提。
+  - **`Failure.new($exception?)`（#TBD）= 完了**＝残 `new` fallback の最大カウント（2593）。VM 所有 state のみ読む pure data assembly（明示 exception /
+    `$!` env / `X::AdHoc` default＋非例外値の `X::AdHoc` wrap・MRO 読み `mro_readonly`）。`dispatch_new_and_constructors` の arm を `build_native_failure_value`
+    に丸ごと抽出し VM/interpreter 両方が呼ぶ＝true single impl。単一ストア化後 `self.env`（＝`$!`）は VM/interpreter 同一＝byte-identical。
+  - **pure-value / VM-owned-state な built-in ctor 候補は枯渇。** 残る `new` fallback receiver は state/process/socket 依存（IO::Socket::INET・Proc::Async・
+    Distribution/CompUnit::Repository・Backtrace・Seq〔predictive iterator carrier〕・CallFrame〔call stack〕）か error-only（HyperWhatever/Whatever/Instant）
+    ＝別軸 or 構造ブロッカー前提。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で
     撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -632,6 +632,16 @@
   positional/triple/instance-arg/Win32-Unix-Cygwin subclass/CWD/empty-null dies・raku/mutsu 双方 PASS)。S32-io/S16-io/tmpdir/cwd/S11-compunit whitelist
   全緑（io-path.t 34/35 の `.SPEC`/`.CWD` attribute 既存 fail は main でも同一＝非whitelist・本変更と無関係）。**残 `new` fallback＝Proc::Async/Failure
   〔`$!` env〕/IO::Socket::INET/CallFrame/Seq＝state 依存 or 別軸。**
+- **2026-06-24 (§D ③ = `Failure.new($exception?)` を VM ネイティブ化)**: 残 `new` fallback の**最大カウント**（プローブ実測 2593・`fail`/明示構築駆動）。
+  `Failure.new` は **VM 所有 state のみ読む pure data assembly**＝明示 exception 引数（無ければ `$!` を env から、それも無ければ `X::AdHoc("Failed")`
+  デフォルト）を、既に `Exception`/`X::`/`CX::`（MRO 読み `mro_readonly`）でなければ `X::AdHoc` に wrap して `{exception, handled:false}` instance を作るだけ。
+  `&self` 依存は **env 読み（`$!`）＋ registry 読み（`mro_readonly`）**＝VM 所有（単一ストア化後 `self.env` は VM/interpreter で同一）＝FS/process/socket/
+  user code 不要。`dispatch_new_and_constructors` の Failure arm（~52 行）を新 `&self` helper `build_native_failure_value` に**丸ごと抽出**（interpreter arm は
+  delegation）。VM は非mut/mut 両 catch dispatch（IO::Path ctor arm の直後・`class_name=="Failure"` gate・`method_dispatch_pure=true`）から呼ぶ＝**1 操作 =
+  1 実装**・byte-identical。実測 `Failure.new`（明示/string-wrap/`$!`/argless 全パス）の `new` fallback → 0。pin `t/native-failure-ctor.t`(11・raku/mutsu
+  双方 PASS。`X::AdHoc` は `:payload` で構築＝`.message` が payload を読む pre-existing detail を回避)。S04-exceptions/S04-statement-modifiers/
+  S05-capture/named/S06-advanced whitelist 全緑。**残 `new` fallback＝Proc::Async〔process〕/IO::Socket::INET〔socket〕/CallFrame〔call stack〕/
+  Seq〔iterator carrier〕＝いずれも state 依存（process/socket/stack/iterator carrier）で別軸。pure-value/VM-owned-state ctor ドレインは枯渇。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -59,57 +59,9 @@ impl Interpreter {
                 Some(Self::build_native_allomorph_value(&type_name, &args))
             }
             "new" if matches!(target, Value::Package(name) if name == "Failure") => {
-                let default_exception = || {
-                    let mut attrs = std::collections::HashMap::new();
-                    attrs.insert("message".to_string(), Value::str("Failed".to_string()));
-                    // `Failure.new` with no explicit exception defaults to
-                    // X::AdHoc in Raku, not the abstract base Exception.
-                    Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
-                };
-                let raw_exception = args
-                    .first()
-                    .cloned()
-                    .filter(|v| !matches!(v, Value::Nil))
-                    .or_else(|| {
-                        self.env
-                            .get("!")
-                            .cloned()
-                            .filter(|v| !matches!(v, Value::Nil))
-                    })
-                    .unwrap_or_else(default_exception);
-                // Wrap non-Exception values in X::AdHoc (Raku behavior)
-                let exception = if let Value::Instance { class_name, .. } = &raw_exception {
-                    let cn = class_name.resolve();
-                    if cn == "Exception"
-                        || cn.starts_with("X::")
-                        || cn.starts_with("CX::")
-                        || self.mro_readonly(&cn).iter().any(|p| {
-                            p == "Exception" || p.starts_with("X::") || p.starts_with("CX::")
-                        })
-                    {
-                        raw_exception
-                    } else {
-                        let mut attrs = std::collections::HashMap::new();
-                        attrs.insert("payload".to_string(), raw_exception.clone());
-                        attrs.insert(
-                            "message".to_string(),
-                            Value::str(raw_exception.to_string_value()),
-                        );
-                        Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
-                    }
-                } else {
-                    let mut attrs = std::collections::HashMap::new();
-                    attrs.insert("payload".to_string(), raw_exception.clone());
-                    attrs.insert(
-                        "message".to_string(),
-                        Value::str(raw_exception.to_string_value()),
-                    );
-                    Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
-                };
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("exception".to_string(), exception);
-                attrs.insert("handled".to_string(), Value::Bool(false));
-                Some(Ok(Value::make_instance(Symbol::intern("Failure"), attrs)))
+                // Pure data assembly (reads `$!` / MRO) — shared with the VM's
+                // `try_native_failure_construct`.
+                Some(Ok(self.build_native_failure_value(&args)))
             }
             "handled" if matches!(target, Value::Instance { class_name, .. } if class_name == "Failure") =>
             {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1687,6 +1687,63 @@ impl Interpreter {
         }
     }
 
+    /// VM-native construction for `Failure.new($exception?)` — pure data assembly
+    /// reading only VM-owned state: the explicit exception argument (or `$!` from
+    /// env when omitted, or the `X::AdHoc("Failed")` default), wrapped into an
+    /// `X::AdHoc` if it is not already an `Exception`/`X::`/`CX::` (checked via the
+    /// MRO read `mro_readonly`). No FS / process / user code. The interpreter's
+    /// `dispatch_new_and_constructors` arm calls the same helper, so the native
+    /// path is byte-identical (the VM and interpreter are one struct, so `self.env`
+    /// — and thus `$!` — is identical at the call site).
+    pub(crate) fn build_native_failure_value(&self, args: &[Value]) -> Value {
+        let default_exception = || {
+            let mut attrs = HashMap::new();
+            // `Failure.new` with no explicit exception defaults to X::AdHoc in
+            // Raku, not the abstract base Exception.
+            attrs.insert("message".to_string(), Value::str("Failed".to_string()));
+            Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
+        };
+        let raw_exception = args
+            .first()
+            .cloned()
+            .filter(|v| !matches!(v, Value::Nil))
+            .or_else(|| {
+                self.env
+                    .get("!")
+                    .cloned()
+                    .filter(|v| !matches!(v, Value::Nil))
+            })
+            .unwrap_or_else(default_exception);
+        // Wrap non-Exception values in X::AdHoc (Raku behavior).
+        let wrap_adhoc = |raw: Value| {
+            let mut attrs = HashMap::new();
+            attrs.insert("payload".to_string(), raw.clone());
+            attrs.insert("message".to_string(), Value::str(raw.to_string_value()));
+            Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
+        };
+        let exception = if let Value::Instance { class_name, .. } = &raw_exception {
+            let cn = class_name.resolve();
+            if cn == "Exception"
+                || cn.starts_with("X::")
+                || cn.starts_with("CX::")
+                || self
+                    .mro_readonly(&cn)
+                    .iter()
+                    .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"))
+            {
+                raw_exception
+            } else {
+                wrap_adhoc(raw_exception)
+            }
+        } else {
+            wrap_adhoc(raw_exception)
+        };
+        let mut attrs = HashMap::new();
+        attrs.insert("exception".to_string(), exception);
+        attrs.insert("handled".to_string(), Value::Bool(false));
+        Value::make_instance(Symbol::intern("Failure"), attrs)
+    }
+
     /// VM-native gate for `IO::Path` family `.new(...)`. Returns `Some` only for
     /// the built-in `IO::Path` classes (`IO::Path`, `IO::Path::Unix`/`::Win32`/
     /// `::Cygwin`/`::QNX`), which never carry a user `new`; user subclasses fall

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -201,6 +201,18 @@ impl Interpreter {
             self.method_dispatch_pure = true;
             return result;
         }
+        // Native Failure construction: `Failure.new($exception?)` — pure data
+        // assembly reading only VM-owned state (`$!` from env, the exception's MRO
+        // from the registry), no FS / process / user code. Built via the single
+        // `build_native_failure_value` impl the interpreter's
+        // `dispatch_new_and_constructors` arm also delegates to.
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && class_name.resolve() == "Failure"
+        {
+            self.method_dispatch_pure = true;
+            return Ok(self.build_native_failure_value(&args));
+        }
         // Native built-in *class* method (a pure type-object method other than
         // `.new`, e.g. `Instant.from-posix`) — built directly instead of routing
         // through the interpreter's class-method dispatch.
@@ -1825,6 +1837,14 @@ impl Interpreter {
         {
             self.method_dispatch_pure = true;
             return result;
+        }
+        // Native Failure construction (mut path twin of the above).
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && class_name.resolve() == "Failure"
+        {
+            self.method_dispatch_pure = true;
+            return Ok(self.build_native_failure_value(&args));
         }
         // Native built-in class method (mut path twin of the above).
         if let Value::Package(class_name) = &target

--- a/t/native-failure-ctor.t
+++ b/t/native-failure-ctor.t
@@ -1,0 +1,41 @@
+use Test;
+
+# Pin for the §D ③ ctor-fork slice native-izing `Failure.new($exception?)` in the
+# VM. The construction is pure data assembly reading only VM-owned state: the
+# explicit exception argument (or `$!` from env when omitted, or the
+# `X::AdHoc("Failed")` default), wrapped into an `X::AdHoc` if it is not already an
+# Exception (checked via the MRO read `mro_readonly`). No FS / process / user
+# code. The VM builds it directly via `build_native_failure_value` — the single
+# impl the interpreter's `dispatch_new_and_constructors` arm also delegates to.
+#
+# (`X::AdHoc` is built with `:payload`, not `:message` — `.message` reads the
+# payload, a pre-existing X::AdHoc detail unrelated to construction.)
+
+plan 11;
+
+# --- explicit exception argument is kept as-is ------------------------------
+my $f1 = Failure.new(X::AdHoc.new(payload => "boom"));
+isa-ok $f1, Failure, 'Failure.new(exception) yields a Failure';
+is $f1.exception.message, "boom", 'explicit exception preserved';
+is $f1.handled, False, 'fresh Failure is unhandled';
+isa-ok $f1.exception, X::AdHoc, 'X:: subtype kept (not re-wrapped)';
+
+# --- a non-Exception value is wrapped into X::AdHoc -------------------------
+my $f2 = Failure.new("oops");
+isa-ok $f2, Failure, 'Failure.new(Str) yields a Failure';
+is $f2.exception.message, "oops", 'string wrapped as X::AdHoc message';
+isa-ok $f2.exception, X::AdHoc, 'non-Exception wrapped into X::AdHoc';
+
+# --- no argument defaults to X::AdHoc("Failed") -----------------------------
+my $f3 = Failure.new;
+isa-ok $f3, Failure, 'argless Failure.new yields a Failure';
+is $f3.exception.message, "Failed", 'argless default message is "Failed"';
+
+# --- `.handled` round-trips -------------------------------------------------
+my $f4 = Failure.new("h");
+$f4.handled = True;
+is $f4.handled, True, '.handled can be set';
+
+# mark the sample Failures handled so they do not warn at sink
+$f1.so; $f2.so; $f3.so;
+ok True, 'all sample Failures marked handled';


### PR DESCRIPTION
## Summary

Continues the §D ③ ctor-fork (state ownership). `Failure.new($exception?)` was
the **highest-count** remaining `new` method-fallback receiver (probe: 2593
across the whitelist, `fail`/explicit-construction driven).

It is pure data assembly reading only VM-owned state:
- the explicit exception argument, or
- `$!` from env when omitted, or
- the `X::AdHoc("Failed")` default,

wrapped into an `X::AdHoc` unless it is already an `Exception`/`X::`/`CX::`
(checked via the MRO read `mro_readonly`). Its `&self` deps are an env read
(`$!`) and a registry read (`mro_readonly`), both VM-owned — after single-store,
`self.env` (and thus `$!`) is identical in the VM and interpreter. No FS,
process, socket, or user code.

## Implementation

Extract the `dispatch_new_and_constructors` Failure arm (~52 lines) wholesale
into a `&self` helper `build_native_failure_value` (the interpreter arm now
delegates). The VM calls it from both the non-mut and mut catch-all dispatch
(right after the IO::Path ctor arm, gated on `class_name == "Failure"`,
`method_dispatch_pure=true`) = **one op, one impl**, byte-identical.

## Verification

- Measured: `Failure.new` (explicit / string-wrap / `$!` / argless paths) `new`
  fallback → 0.
- Pin `t/native-failure-ctor.t` (11, raku/mutsu both pass; `X::AdHoc` is built
  with `:payload` to sidestep the pre-existing `.message`-reads-payload detail).
- Whitelist green: S04-exceptions, S04-statement-modifiers, S05-capture/named,
  S06-advanced.
- `cargo test` 468/0, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)