### PR TITLE
docs(plan,ledger): correct next ctor slices — Proc::Async/IO::Socket::INET are tractable

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -133,9 +133,15 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
   - **`Failure.new($exception?)`（#TBD）= 完了**＝残 `new` fallback の最大カウント（2593）。VM 所有 state のみ読む pure data assembly（明示 exception /
     `$!` env / `X::AdHoc` default＋非例外値の `X::AdHoc` wrap・MRO 読み `mro_readonly`）。`dispatch_new_and_constructors` の arm を `build_native_failure_value`
     に丸ごと抽出し VM/interpreter 両方が呼ぶ＝true single impl。単一ストア化後 `self.env`（＝`$!`）は VM/interpreter 同一＝byte-identical。
-  - **pure-value / VM-owned-state な built-in ctor 候補は枯渇。** 残る `new` fallback receiver は state/process/socket 依存（IO::Socket::INET・Proc::Async・
-    Distribution/CompUnit::Repository・Backtrace・Seq〔predictive iterator carrier〕・CallFrame〔call stack〕）か error-only（HyperWhatever/Whatever/Instant）
-    ＝別軸 or 構造ブロッカー前提。
+  - **次の clean な ctor スライス（2 件・2026-06-24 実測訂正）**: 台帳が「state 依存」と分類していた 2 件は実は tractable。
+    - **`Proc::Async.new`（最も簡単・次セッション最初）**＝完全 pure data（プロセス spawn は `.start`・ctor は引数パース＋`next_supply_id()` 〔free fn〕
+      ＋`SharedPromise::new()`＋Supply 属性構築のみ・`&self` 依存ゼロ）。`build_native_proc_async_value` static helper を `try_native_builtin_construct` に
+      `Promise`/`Channel` と同型で wire。
+    - **`IO::Socket::INET.new`（medium・次）**＝`dispatch_socket_inet_new`（`&mut self`・実 bind/connect＋`insert_handle_state`）は **io_handles 依存だが
+      `IO::Path.open`（#3507 native 化済）と同型**（io_handles は VM 所有）。`try_native_socket_inet_construct` で両 catch-all から既存 helper へ委譲。
+  - **真に構造ブロック（上記 2 件 land 後に ctor-fork 完了）**: `CallFrame.new`〔call-stack carrier〕・`Seq.new(iterator)`〔predictive iterator carrier・
+    `predictive_seq_iters` field ＋ env 書き込みで impure〕・error-only（HyperWhatever/Whatever/Instant）。これら以後は §D の本丸＝(b) tree-walk dispatch-chain
+    削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で
     撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -640,8 +640,12 @@
   delegation）。VM は非mut/mut 両 catch dispatch（IO::Path ctor arm の直後・`class_name=="Failure"` gate・`method_dispatch_pure=true`）から呼ぶ＝**1 操作 =
   1 実装**・byte-identical。実測 `Failure.new`（明示/string-wrap/`$!`/argless 全パス）の `new` fallback → 0。pin `t/native-failure-ctor.t`(11・raku/mutsu
   双方 PASS。`X::AdHoc` は `:payload` で構築＝`.message` が payload を読む pre-existing detail を回避)。S04-exceptions/S04-statement-modifiers/
-  S05-capture/named/S06-advanced whitelist 全緑。**残 `new` fallback＝Proc::Async〔process〕/IO::Socket::INET〔socket〕/CallFrame〔call stack〕/
-  Seq〔iterator carrier〕＝いずれも state 依存（process/socket/stack/iterator carrier）で別軸。pure-value/VM-owned-state ctor ドレインは枯渇。**
+  S05-capture/named/S06-advanced whitelist 全緑。**残 `new` fallback の次スライス候補（2026-06-24 実測訂正・「state 依存」分類を訂正）**:
+  ① **`Proc::Async.new`＝実は完全 pure data**（プロセス spawn は `.start`・ctor は引数パース＋`next_supply_id()` free fn＋`SharedPromise::new()`＋
+  Supply 属性構築のみ・`&self` 依存ゼロ）＝`build_native_proc_async_value` static helper を `try_native_builtin_construct` に wire（Promise/Channel と同型・最易）。
+  ② **`IO::Socket::INET.new`＝io_handles 依存だが `IO::Path.open`（#3507）と同型**（`dispatch_socket_inet_new` が `insert_handle_state` で VM 所有 io_handle 確保）
+  ＝`try_native_socket_inet_construct` で既存 helper へ委譲。**真に構造ブロック（②まで land 後に ctor-fork 完了）**: `CallFrame`〔call stack carrier〕・`Seq.new`
+  〔predictive iterator carrier＝`predictive_seq_iters` field＋env 書き込みで impure〕＝別軸。**∴ ctor-fork 残=Proc::Async（pure）＋IO::Socket::INET（io_handles）の 2 件のみ。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは


### PR DESCRIPTION
## Summary

Doc-only handoff for the next session. Post-#3530 analysis of the remaining
`new` method-fallback receivers found the ledger's "state-dependent, not clean"
classification was too pessimistic for two of them:

- **`Proc::Async.new` is pure data assembly** — the process is spawned at
  `.start`, **not** `.new`. The ctor only parses args (`:w`/`:enc`/`:out`/cmd),
  allocates supply IDs via the free fn `next_supply_id()`, makes `SharedPromise`
  descriptors, and builds Supply-attr hashmaps. No `&self` deps → goes in the
  static `try_native_builtin_construct`, like `Promise`/`Channel`/`Supplier`.
  **Easiest next slice.**
- **`IO::Socket::INET.new`** allocates an io_handle via `insert_handle_state`
  (real bind/connect) but `io_handles` is VM-owned (`Arc<RwLock>`) — the same
  shape as `IO::Path.open`, which was native-ized (§D capstone #3507). Delegate
  to the existing `dispatch_socket_inet_new` helper. **Medium.**

Genuinely blocked (defer): `CallFrame.new` (call-stack carrier), `Seq.new`
(predictive iterator carrier — writes a VM field + env, impure).

No code changes; updates PLAN.md §D and the ledger so the next session can start
from an accurate map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)