### PR TITLE
fix(precomp): stamp cache with executable mtime to invalidate on rebuild

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -223,7 +223,12 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     / `t/anon-param-trait.t`。**= 薄い DBDish::SQLite 互換層を pure-Raku モジュールとして書ける状態。**
   - **残（より広いモジュール互換に）**: ① `CArray[uint8]`・`CArray[Str]` / ② `is repr('CStruct')` 構造体 /
     ③ callback（汎用 C コールバック）。DBDish::SQLite 自体は上記 prepared-statement API で原理的に駆動可能。
-  - **DBIish/DBDish**: pure-Raku ドライバを上記 NativeCall sub 群で実装可能（次の有力タスク＝薄い DBDish::SQLite 互換層）。
+  - **✅ 薄い DBDish::SQLite 互換層（pure-Raku モジュール）が動作**: `t/lib/DBDishLite.rakumod`（`use`-可能・
+    `connect`→`Connection`・`.execute`→行ハッシュ配列・`.close`）が実 SQLite で CREATE/INSERT/ORDER BY/WHERE SELECT を
+    往復（担保＝`t/dbdish-lite.t`）。= ウェブブログの DB 層が再利用可能モジュールとして揃った。これを暴いた precomp
+    キャッシュ staleness バグ（注入後 AST をキャッシュするが version stamp が dev ビルド間で不変）は exe-mtime stamp で修正済。
+  - **DBIish/DBDish（off-the-shelf）**: 実配布版はまだ 3 機能待ち（regex "Unmatched (" parse / `Rakudo::Internals.REGISTER-DYNAMIC` /
+    `is encoded(...)` NativeCall param trait）。手書き互換層は上記の通り動く。
 - **JSON は native 実装済み**（`to-json`/`from-json`・#3402・news 参照）。Template::Mustache 91/92-specs の残（別軸・
   本タスク外）= 実 spec の rendering ギャップ（delimiter 永続化／inheritable partials／lambda）＋ 最初の spec のみ
   `+$spec.value`=0 になる subtest/Seq-consumption 系バグ（itemization とは独立）。

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,25 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### precomp キャッシュ staleness 修正 ＋ 薄い DBDish::SQLite 互換層が動作（exe-mtime stamp）
+
+ウェブブログスタックの DB 層を「再利用可能な pure-Raku モジュール」として用意する作業中に、precomp キャッシュの
+**実バグ**を発見・修正した（PLAN §H）。
+
+- **症状**: NativeCall の SQLite バインディングをモジュール（`unit module DB`）として書くと、main で `Pointer` を一切
+  参照していないのに `Undeclared name: Pointer` で落ちる。同一内容を別名モジュールにすると動く。
+- **真因**: precomp キャッシュは **prelude 注入後の AST**（`inject_nativecall_prelude` で `Pointer` クラスを前置した後）を
+  保存するが、キャッシュ version stamp は `CARGO_PKG_VERSION`（dev ビルドでは固定の "0.1.0"）＋ enum 用 `CACHE_FORMAT_VERSION`
+  だけで、注入ロジックの変更を捕捉しない。#3527 で「モジュールにも Pointer prelude を注入」する修正が入る前にキャッシュされた
+  **prelude なし AST** が、ソース mtime/hash 一致のため有効と見なされ続けて再利用されていた。CLAUDE.md の
+  「⚠️ parser 変更後は precomp キャッシュを rm」はこの footgun の手動回避策だった。
+- **修正**: version stamp に**実行バイナリの mtime** を加える（`{crate}+cf{n}+exe{nanos}`）。注入・`merge_unit_class`・
+  roast directive 前処理など「ソースではなくバイナリに住む変換」が変わるたび、リビルドで自動的にキャッシュ無効化される。
+  手動 rm は不要に。担保＝`src/precomp.rs` の `version_stamp_includes_exe_mtime` / `cache_invalidated_on_version_mismatch`。
+- **成果物**: `t/lib/DBDishLite.rakumod`（`use`-可能・`connect`→`Connection`・`.execute`→行ハッシュ配列・`.close`）が
+  実 SQLite で CREATE/INSERT/ORDER BY/WHERE SELECT を往復。担保＝`t/dbdish-lite.t`（libsqlite3 不在なら graceful skip）。
+  = ウェブブログの DB 層が再利用可能な薄い DBDish 互換層として揃った。
+
 ### grep-rw-view 側道機構の撤去 — `.grep` を第一級要素 cell 化（#3466, 2026-06-23）
 
 `for @a.grep(...) { $_++ }` / `@a.grep(...)>>++` の source 書き戻しは、tree-walk 時代の専用側道で実装されていた:

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -14,7 +14,11 @@
 //!
 //! A cache entry is valid when ALL of the following match:
 //! - The source file modification time matches the stored mtime
-//! - The interpreter version matches the stored version stamp
+//! - The source content hash matches the stored hash
+//! - The interpreter version matches the stored version stamp. The stamp embeds
+//!   the running executable's mtime, so a rebuilt mutsu (with different parse /
+//!   prelude-injection / AST-lowering logic) never reuses an older build's cache
+//!   — the stored AST is post-transform, and those transforms live in the binary.
 //!
 //! ## Serialization
 //!
@@ -35,12 +39,36 @@ const CACHE_MAGIC: &[u8; 4] = b"MTSU";
 
 /// The interpreter version stamp embedded in cache files.
 /// Cache is invalidated whenever this changes.
-/// Includes both the crate version and a cache format version that should be
-/// bumped whenever the AST enum layout changes (adding/removing/reordering variants).
+/// Includes the crate version, a cache format version that should be bumped
+/// whenever the AST enum layout changes (adding/removing/reordering variants),
+/// and the running executable's modification time.
+///
+/// The executable mtime is essential: the cache stores the AST *after* compile-
+/// time transforms (`merge_unit_class`, the NativeCall `Pointer` / `Rational`
+/// prelude injection, roast-directive preprocessing). Those transforms live in
+/// the binary, not the source, so a rebuilt mutsu that changes any of them must
+/// not reuse a cache produced by an older build. The crate version is a fixed
+/// "0.1.0" across every dev build and CACHE_FORMAT_VERSION only tracks enum
+/// layout, so neither catches logic changes — which is why a stale post-injection
+/// AST could survive the prelude-injection fix and resurface as an undeclared
+/// `Pointer`. Stamping the exe mtime invalidates the cache on every rebuild,
+/// removing the need to manually `rm` the cache after parser/compiler changes.
 fn interpreter_version() -> String {
     // Bump CACHE_FORMAT_VERSION when Stmt/Expr/Value enum variants change
     const CACHE_FORMAT_VERSION: u32 = 6;
-    format!("{}+cf{}", env!("CARGO_PKG_VERSION"), CACHE_FORMAT_VERSION)
+    let exe_stamp = std::env::current_exe()
+        .and_then(fs::metadata)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "{}+cf{}+exe{}",
+        env!("CARGO_PKG_VERSION"),
+        CACHE_FORMAT_VERSION,
+        exe_stamp
+    )
 }
 
 /// Compute a deterministic hash of a canonical file path for use as cache filename.
@@ -279,6 +307,64 @@ mod tests {
 
         // Cache should now be invalid
         assert!(load_cached_ast(&source).is_none());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn version_stamp_includes_exe_mtime() {
+        // The version stamp must embed the running executable's mtime so a
+        // rebuilt binary invalidates caches that hold post-transform ASTs.
+        // The test runner is a real on-disk binary, so the stamp must resolve
+        // to a non-zero value (a "+exe0" fallback would silently disable the
+        // protection).
+        let v = interpreter_version();
+        assert!(
+            v.contains("+exe"),
+            "version stamp must carry exe component: {v}"
+        );
+        assert!(
+            !v.ends_with("+exe0"),
+            "exe mtime should resolve to a real timestamp, got: {v}"
+        );
+    }
+
+    #[test]
+    fn cache_invalidated_on_version_mismatch() {
+        // A cache whose stored version no longer matches the current
+        // interpreter_version() (as happens when the binary is rebuilt with
+        // different parse/injection logic) must be rejected even when the
+        // source file is byte-for-byte unchanged.
+        let stmts = vec![Stmt::Say(vec![Expr::Literal(Value::Int(7))])];
+
+        let dir = tempdir("version");
+        let source = dir.join("test3.rakumod");
+        {
+            let mut f = fs::File::create(&source).unwrap();
+            writeln!(f, "say 7;").unwrap();
+        }
+
+        // Write a cache entry by hand with a stale version stamp.
+        let canonical = source.canonicalize().unwrap();
+        let cdir = cache_dir().unwrap();
+        let cache_file = cdir.join(format!("{}.bin", path_hash(&canonical)));
+        let meta = CacheMetadata {
+            mtime_nanos: source_mtime_nanos(&source).unwrap(),
+            source_hash: source_content_hash(&source),
+            version: "0.0.0+cf0+exe0".to_string(),
+        };
+        let meta_bytes = bincode::serialize(&meta).unwrap();
+        let ast_bytes = bincode::serialize(&stmts).unwrap();
+        let mut data = Vec::new();
+        data.extend_from_slice(CACHE_MAGIC);
+        data.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());
+        data.extend_from_slice(&meta_bytes);
+        data.extend_from_slice(&ast_bytes);
+        fs::write(&cache_file, &data).unwrap();
+
+        // Stale version → cache must be rejected (and removed).
+        assert!(load_cached_ast(&source).is_none());
+        assert!(!cache_file.exists(), "stale cache file should be removed");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/t/dbdish-lite.t
+++ b/t/dbdish-lite.t
@@ -1,0 +1,44 @@
+use Test;
+use lib 't/lib';
+use DBDishLite;
+
+# Drive a real SQLite database through the DBDishLite *module* — the smallest
+# reusable database layer for the web-blog stack. The main program never
+# mentions NativeCall or `Pointer`; the module owns all of that. This is the
+# end-to-end path that a stale precompilation cache previously masked (the cache
+# served a pre-prelude-injection AST and the module hit an undeclared
+# `Pointer`); the cache is now keyed on the executable mtime so a rebuilt mutsu
+# never reuses a cache produced by older injection logic.
+#
+# libsqlite3 is not part of the language core, so degrade to a single skip when
+# the library cannot be loaded.
+
+unless sqlite-available() {
+    plan 1;
+    skip 'libsqlite3 not available on this host', 1;
+    done-testing;
+    exit 0;
+}
+
+plan 6;
+
+my $db = connect(':memory:');
+ok $db.defined, 'connect(:memory:) returned a connection';
+
+$db.execute('CREATE TABLE posts (id INTEGER, title TEXT, body TEXT)');
+$db.execute(q{INSERT INTO posts VALUES
+    (1, 'Hello', 'first post'),
+    (2, 'World', 'second post'),
+    (3, 'Raku',  'third post')});
+
+my @rows = $db.execute('SELECT id, title FROM posts ORDER BY id');
+is @rows.elems, 3, 'SELECT returned every row as a hash';
+is @rows[0]<title>, 'Hello', 'first row title column';
+is @rows[2]<id>, '3', 'third row id column';
+is-deeply @rows.map(*<title>).Array, ['Hello', 'World', 'Raku'],
+    'rows came back in ORDER BY order with named columns';
+
+my @filtered = $db.execute(q{SELECT title FROM posts WHERE id = 2});
+is @filtered[0]<title>, 'World', 'WHERE-filtered query via the module';
+
+$db.close;

--- a/t/lib/DBDishLite.rakumod
+++ b/t/lib/DBDishLite.rakumod
@@ -1,0 +1,64 @@
+use NativeCall;
+
+# A tiny DBDish::SQLite-shaped wrapper distributed as a reusable module. It is
+# the smallest "real" database layer for the web-blog stack: a `connect` that
+# returns a connection object whose `.execute` runs a statement and returns the
+# result rows as an array of hashes (column-name => value), plus `.close`.
+#
+# The whole point of shipping this as a module is that the main program need not
+# mention NativeCall or `Pointer` at all — the `Pointer` prelude is injected for
+# the module. (A stale precompilation cache used to mask this by serving an old
+# post-injection AST; the cache is now keyed on the executable mtime.)
+unit module DBDishLite;
+
+sub sqlite3_open(Str, Pointer is rw) returns int32 is native('sqlite3') { * }
+sub sqlite3_close(Pointer) returns int32 is native('sqlite3') { * }
+sub sqlite3_prepare_v2(Pointer, Str, int32, Pointer is rw, Pointer)
+    returns int32 is native('sqlite3') { * }
+sub sqlite3_step(Pointer) returns int32 is native('sqlite3') { * }
+sub sqlite3_column_count(Pointer) returns int32 is native('sqlite3') { * }
+sub sqlite3_column_text(Pointer, int32) returns Str is native('sqlite3') { * }
+sub sqlite3_column_name(Pointer, int32) returns Str is native('sqlite3') { * }
+sub sqlite3_finalize(Pointer) returns int32 is native('sqlite3') { * }
+sub sqlite3_errmsg(Pointer) returns Str is native('sqlite3') { * }
+sub sqlite3_libversion() returns Str is native('sqlite3') { * }
+
+constant SQLITE_OK  = 0;
+constant SQLITE_ROW = 100;
+
+#| True when libsqlite3 can be loaded on this host.
+sub sqlite-available() is export {
+    so (try sqlite3_libversion()).defined;
+}
+
+class Connection {
+    has Pointer $.handle;
+
+    #| Run a statement. For a SELECT, returns an array of row hashes
+    #| (column-name => text value). For a non-query, returns the empty list.
+    method execute(Str $sql) {
+        my $stmt = Pointer.new;
+        my $rc = sqlite3_prepare_v2($!handle, $sql, -1, $stmt, Pointer);
+        die "prepare failed: " ~ sqlite3_errmsg($!handle) if $rc != SQLITE_OK;
+        my @rows;
+        my $ncol = sqlite3_column_count($stmt);
+        while sqlite3_step($stmt) == SQLITE_ROW {
+            my %row;
+            for ^$ncol -> $i {
+                %row{ sqlite3_column_name($stmt, $i) } = sqlite3_column_text($stmt, $i);
+            }
+            @rows.push: %row;
+        }
+        sqlite3_finalize($stmt);
+        @rows;
+    }
+
+    method close() { sqlite3_close($!handle); }
+}
+
+#| Open a connection to the given SQLite database path (e.g. ':memory:').
+sub connect(Str $path) is export {
+    my $h = Pointer.new;
+    die "open failed" if sqlite3_open($path, $h) != SQLITE_OK;
+    Connection.new(handle => $h);
+}


### PR DESCRIPTION
## Problem

The module precompilation cache stores the AST **after** compile-time transforms (`merge_unit_class`, the NativeCall `Pointer` / `Rational` prelude injection, roast-directive preprocessing). Those transforms live in the binary, not the source — but the cache version stamp was only `CARGO_PKG_VERSION` (a fixed `"0.1.0"` across every dev build) plus an enum-layout `CACHE_FORMAT_VERSION`.

So when the injection logic changed (#3527 — inject the `Pointer` prelude into modules too), a previously cached **pre-injection** AST kept matching on mtime/hash and was reused, resurfacing as `Undeclared name: Pointer` for a NativeCall binding shipped as a module. This is exactly the footgun behind CLAUDE.md's "⚠️ rm precomp cache after parser changes" note.

### Repro (before this PR)
A `unit module DB` NativeCall binding whose `.rakumod` was cached by an older build fails with `Undeclared name: Pointer` even though the main program never mentions `Pointer`; the identical content under a different module name (no stale cache) works.

## Fix

Embed the running executable's mtime in the version stamp (`{crate}+cf{n}+exe{nanos}`). A rebuilt mutsu never reuses a cache produced by an older build, so the manual `rm` is no longer needed — any change to a binary-resident transform self-invalidates the cache on the next build.

- Unit tests: `version_stamp_includes_exe_mtime`, `cache_invalidated_on_version_mismatch`.

## Web-blog capstone

Adds `t/lib/DBDishLite.rakumod` — a `use`-able DBDish::SQLite-shaped wrapper (`connect` → `Connection`, `.execute` → array of row hashes, `.close`) — and `t/dbdish-lite.t` driving **real SQLite CRUD** (CREATE/INSERT/ORDER BY/WHERE SELECT) through the module. This is the end-to-end path the stale cache had been masking, and gives the web-blog stack a reusable thin DB layer. Degrades to a single skip when libsqlite3 is absent.

## Test

- `cargo test --lib precomp` — 4/4 pass
- `prove t/dbdish-lite.t t/nativecall-*.t t/anon-param-trait.t` — all pass
- `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)