### PR TITLE
feat(state-ownership): native-ize Seq.new (ledger §D ③ ctor)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -133,15 +133,17 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
   - **`Failure.new($exception?)`（#TBD）= 完了**＝残 `new` fallback の最大カウント（2593）。VM 所有 state のみ読む pure data assembly（明示 exception /
     `$!` env / `X::AdHoc` default＋非例外値の `X::AdHoc` wrap・MRO 読み `mro_readonly`）。`dispatch_new_and_constructors` の arm を `build_native_failure_value`
     に丸ごと抽出し VM/interpreter 両方が呼ぶ＝true single impl。単一ストア化後 `self.env`（＝`$!`）は VM/interpreter 同一＝byte-identical。
+  - **`Seq.new($iterator?)`（#3533）= 完了**。前回「iterator carrier＝別軸（impure）」と保守分類していたが carrier state 自体が VM 所有
+    （`predictive_seq_iters` フィールド＋env 内部キー＋Seq Arc キーのグローバル deferred-iter 表）＝構築は eager pull せず VM 所有 state への登録のみ。
+    `dispatch_new` の Seq arm を `try_native_seq_construct` に丸ごと抽出し VM/interpreter 両方が呼ぶ＝true single impl・byte-identical。
   - **次の clean な ctor スライス（2 件・2026-06-24 実測訂正）**: 台帳が「state 依存」と分類していた 2 件は実は tractable。
     - **`Proc::Async.new`（最も簡単・次セッション最初）**＝完全 pure data（プロセス spawn は `.start`・ctor は引数パース＋`next_supply_id()` 〔free fn〕
       ＋`SharedPromise::new()`＋Supply 属性構築のみ・`&self` 依存ゼロ）。`build_native_proc_async_value` static helper を `try_native_builtin_construct` に
       `Promise`/`Channel` と同型で wire。
     - **`IO::Socket::INET.new`（medium・次）**＝`dispatch_socket_inet_new`（`&mut self`・実 bind/connect＋`insert_handle_state`）は **io_handles 依存だが
       `IO::Path.open`（#3507 native 化済）と同型**（io_handles は VM 所有）。`try_native_socket_inet_construct` で両 catch-all から既存 helper へ委譲。
-  - **真に構造ブロック（上記 2 件 land 後に ctor-fork 完了）**: `CallFrame.new`〔call-stack carrier〕・`Seq.new(iterator)`〔predictive iterator carrier・
-    `predictive_seq_iters` field ＋ env 書き込みで impure〕・error-only（HyperWhatever/Whatever/Instant）。これら以後は §D の本丸＝(b) tree-walk dispatch-chain
-    削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
+  - **真に構造ブロック（上記 2 件 land 後に ctor-fork 完了）**: `CallFrame.new`〔call-stack carrier〕・error-only（HyperWhatever/Whatever/Instant）。
+    これら以後は §D の本丸＝(b) tree-walk dispatch-chain 削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で
     撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -644,8 +644,18 @@
   ① **`Proc::Async.new`＝実は完全 pure data**（プロセス spawn は `.start`・ctor は引数パース＋`next_supply_id()` free fn＋`SharedPromise::new()`＋
   Supply 属性構築のみ・`&self` 依存ゼロ）＝`build_native_proc_async_value` static helper を `try_native_builtin_construct` に wire（Promise/Channel と同型・最易）。
   ② **`IO::Socket::INET.new`＝io_handles 依存だが `IO::Path.open`（#3507）と同型**（`dispatch_socket_inet_new` が `insert_handle_state` で VM 所有 io_handle 確保）
-  ＝`try_native_socket_inet_construct` で既存 helper へ委譲。**真に構造ブロック（②まで land 後に ctor-fork 完了）**: `CallFrame`〔call stack carrier〕・`Seq.new`
-  〔predictive iterator carrier＝`predictive_seq_iters` field＋env 書き込みで impure〕＝別軸。**∴ ctor-fork 残=Proc::Async（pure）＋IO::Socket::INET（io_handles）の 2 件のみ。**
+  ＝`try_native_socket_inet_construct` で既存 helper へ委譲。**真に構造ブロック（②まで land 後に ctor-fork 完了）**: `CallFrame`〔call stack carrier〕＝別軸。
+  （`Seq.new` は #3533 で native 化済＝下記。）**∴ ctor-fork 残=Proc::Async（pure）＋IO::Socket::INET（io_handles）の 2 件のみ。**
+- **2026-06-24 (§D ③ = `Seq.new($iterator?)` を VM ネイティブ化, #3533)**: 前エントリで「iterator carrier＝別軸（impure）」と保守的に分類していた `Seq.new` を再評価し
+  native 化。**carrier state 自体が VM 所有**（`predictive_seq_iters` フィールド ＋ env の `__mutsu_predictive_seq_iter::` 内部キー ＋ Seq の Arc を
+  キーにしたグローバル deferred-iter 副表）＝単一ストア化後 `self` は VM/interpreter 同一なので native gate から同じ書き込みができる。**構築は eager pull
+  しない**（PredictiveIterator は carrier に stash、materialized `items`/`stuff` instance は要素コピー、その他 iterator は deferred 登録、no-arg は
+  pre-consumed Seq）＝iterator 消費は後の consumption 時で構築とは別＝FS/process/user code 不要。`dispatch_new` の Seq arm（~46 行）を新 `&mut self`
+  helper `try_native_seq_construct` に**丸ごと抽出**（interpreter arm は delegation）。VM は非mut/mut 両 catch dispatch（Failure ctor arm の直後・
+  `class_name=="Seq"` gate・`method_dispatch_pure=true`）から呼ぶ＝**1 操作 = 1 実装**・byte-identical。user subclass（`class S is Seq`）は class_name が
+  自名に解決され gate に掛からず interpreter 維持。pin `t/native-seq-ctor.t`(11・raku/mutsu 双方 PASS。`.raku` の `$(...)` itemization 差は pre-existing・
+  無関係)。S32-list/seq.t(50)/skip.t/tail.t/rotor.t・S07-iterators/range-iterator.t(103) 全緑。**残 `new` fallback＝Proc::Async（pure・次）/
+  IO::Socket::INET（io_handles・次）/CallFrame〔call stack carrier・別軸〕。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1695,6 +1695,62 @@ impl Interpreter {
     /// `dispatch_new_and_constructors` arm calls the same helper, so the native
     /// path is byte-identical (the VM and interpreter are one struct, so `self.env`
     /// — and thus `$!` — is identical at the call site).
+    /// VM-native construction for `Seq.new($iterator?)`. Construction reads and
+    /// writes only VM-owned state: a `PredictiveIterator` argument is stashed in
+    /// the `predictive_seq_iters` carrier table (plus an `__mutsu_*` env side
+    /// table so the association survives sub/block returns), a materialized
+    /// `items`/`stuff` instance is copied eagerly, any other iterator is
+    /// registered as a deferred (lazy) iterator keyed off the new Seq's own Arc,
+    /// and the no-arg form yields a pre-consumed Seq. No FS / process / user
+    /// code — pulling from the iterator happens later, on consumption. The
+    /// interpreter's `dispatch_new` arm delegates here, so the native VM fast
+    /// path is byte-identical (one struct, one `self`).
+    pub(crate) fn try_native_seq_construct(&mut self, args: &[Value]) -> Value {
+        // Seq.new(iterator)
+        if let Some(iterator) = args.first() {
+            if matches!(iterator, Value::Instance { .. })
+                && self.type_matches_value("PredictiveIterator", iterator)
+            {
+                let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+                if let Value::Seq(items) = &seq {
+                    let seq_id = std::sync::Arc::as_ptr(items) as usize;
+                    // Store off the scoped env so the association
+                    // survives sub/block returns (see field docs).
+                    self.predictive_seq_iters.insert(seq_id, iterator.clone());
+                    self.env.insert(
+                        format!("__mutsu_predictive_seq_iter::{seq_id}"),
+                        iterator.clone(),
+                    );
+                }
+                return seq;
+            }
+            if let Value::Instance { attributes, .. } = iterator {
+                let map = attributes.as_map();
+                if let Some(Value::Array(items, ..)) = map.get("items").or_else(|| map.get("stuff"))
+                {
+                    return Value::Seq(std::sync::Arc::new(items.to_vec()));
+                }
+            }
+            // Register deferred iterator: don't pull eagerly.
+            // Raku's Seq.new(iterator) creates a lazy Seq; pulling
+            // happens only when the Seq is actually consumed/iterated.
+            let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+            if let Value::Seq(items) = &seq {
+                crate::value::seq_register_deferred_iter(items, iterator.clone());
+            }
+            return seq;
+        }
+        // Seq.new() with no args creates a pre-consumed Seq.
+        // This matches Raku: Seq.new() has no iterator, so it's
+        // immediately consumed. This is what .raku returns for
+        // consumed Seqs ("Seq.new()") so the EVAL roundtrip works.
+        let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
+        if let Value::Seq(items) = &seq {
+            let _ = crate::value::seq_consume(items);
+        }
+        seq
+    }
+
     pub(crate) fn build_native_failure_value(&self, args: &[Value]) -> Value {
         let default_exception = || {
             let mut attrs = HashMap::new();
@@ -2587,50 +2643,11 @@ impl Interpreter {
                     return Ok(Self::build_native_uni_value(&args));
                 }
                 "Seq" => {
-                    // Seq.new(iterator) — pull all items from the iterator
-                    if let Some(iterator) = args.first() {
-                        if matches!(iterator, Value::Instance { .. })
-                            && self.type_matches_value("PredictiveIterator", iterator)
-                        {
-                            let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
-                            if let Value::Seq(items) = &seq {
-                                let seq_id = std::sync::Arc::as_ptr(items) as usize;
-                                // Store off the scoped env so the association
-                                // survives sub/block returns (see field docs).
-                                self.predictive_seq_iters.insert(seq_id, iterator.clone());
-                                self.env.insert(
-                                    format!("__mutsu_predictive_seq_iter::{seq_id}"),
-                                    iterator.clone(),
-                                );
-                            }
-                            return Ok(seq);
-                        }
-                        if let Value::Instance { attributes, .. } = iterator {
-                            let map = attributes.as_map();
-                            if let Some(Value::Array(items, ..)) =
-                                map.get("items").or_else(|| map.get("stuff"))
-                            {
-                                return Ok(Value::Seq(std::sync::Arc::new(items.to_vec())));
-                            }
-                        }
-                        // Register deferred iterator: don't pull eagerly.
-                        // Raku's Seq.new(iterator) creates a lazy Seq; pulling
-                        // happens only when the Seq is actually consumed/iterated.
-                        let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
-                        if let Value::Seq(items) = &seq {
-                            crate::value::seq_register_deferred_iter(items, iterator.clone());
-                        }
-                        return Ok(seq);
-                    }
-                    // Seq.new() with no args creates a pre-consumed Seq.
-                    // This matches Raku: Seq.new() has no iterator, so it's
-                    // immediately consumed. This is what .raku returns for
-                    // consumed Seqs ("Seq.new()") so the EVAL roundtrip works.
-                    let seq = Value::Seq(std::sync::Arc::new(Vec::new()));
-                    if let Value::Seq(items) = &seq {
-                        let _ = crate::value::seq_consume(items);
-                    }
-                    return Ok(seq);
+                    // Shared single implementation with the VM's native fast path
+                    // (`try_native_seq_construct`). Reads/writes only VM-owned state
+                    // (the `predictive_seq_iters` carrier table + the deferred-iter
+                    // side table keyed off the Seq's own Arc).
+                    return Ok(self.try_native_seq_construct(&args));
                 }
                 "Version" => {
                     let arg = args.first().cloned().unwrap_or(Value::Nil);

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -213,6 +213,19 @@ impl Interpreter {
             self.method_dispatch_pure = true;
             return Ok(self.build_native_failure_value(&args));
         }
+        // Native Seq construction: `Seq.new($iterator?)` — registers the
+        // iterator into the VM-owned predictive/deferred carrier tables (no
+        // eager pull, no FS / process / user code). Built via the single
+        // `try_native_seq_construct` impl the interpreter's `dispatch_new` arm
+        // also delegates to. (A user subclass `class S is Seq` resolves to its
+        // own class name and is left to the interpreter.)
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && class_name.resolve() == "Seq"
+        {
+            self.method_dispatch_pure = true;
+            return Ok(self.try_native_seq_construct(&args));
+        }
         // Native built-in *class* method (a pure type-object method other than
         // `.new`, e.g. `Instant.from-posix`) — built directly instead of routing
         // through the interpreter's class-method dispatch.
@@ -1845,6 +1858,14 @@ impl Interpreter {
         {
             self.method_dispatch_pure = true;
             return Ok(self.build_native_failure_value(&args));
+        }
+        // Native Seq construction (mut path twin of the above).
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && class_name.resolve() == "Seq"
+        {
+            self.method_dispatch_pure = true;
+            return Ok(self.try_native_seq_construct(&args));
         }
         // Native built-in class method (mut path twin of the above).
         if let Value::Package(class_name) = &target

--- a/t/native-seq-ctor.t
+++ b/t/native-seq-ctor.t
@@ -1,0 +1,49 @@
+use Test;
+
+# Pin for the VM-native `Seq.new` fast path (ledger §D ③ ctor). The VM gate in
+# `vm_call_method_compiled.rs` and the interpreter's `dispatch_new` arm both call
+# the single `try_native_seq_construct` helper, so the native and slow paths must
+# stay byte-identical. Construction reads/writes only VM-owned carrier state.
+
+plan 11;
+
+# Seq.new(iterator) over a materialized list — eager copy of items.
+my $s1 = Seq.new((1, 2, 3).iterator);
+is $s1.List, (1, 2, 3), 'Seq.new(list iterator) yields the items';
+
+# A second, independent Seq.new is not aliased to the first.
+my $s2 = Seq.new((4, 5).iterator);
+is $s2.elems, 2, 'independent Seq.new has its own items';
+is $s1.elems, 3, 'first Seq is unaffected by the second';
+
+# Deferred / lazy iterator: only consumed on demand.
+my $s3 = Seq.new((10, 20, 30).iterator);
+is $s3.List, (10, 20, 30), 'deferred Seq pulls its items on consumption';
+
+# No-arg Seq.new() is a pre-consumed Seq.
+my $s4 = Seq.new;
+is $s4.raku, 'Seq.new()', 'argless Seq.new is pre-consumed';
+dies-ok { $s4.List }, 'consuming an already-consumed Seq dies';
+
+# A gather block produces a Seq that round-trips through .List.
+my $g = gather { take $_ * $_ for 1..4 };
+is $g.List, (1, 4, 9, 16), 'gather Seq materializes correctly';
+
+# Seq.new is also reachable via a non-Package variable receiver (mut path).
+my $cls = Seq;
+my $s5 = $cls.new((7, 8, 9).iterator);
+is $s5.List, (7, 8, 9), 'Seq.new via variable receiver (mut path)';
+
+# Map over a Seq still works (the Seq value is a normal lazy sequence).
+my $s6 = Seq.new((1, 2, 3).iterator);
+is $s6.map(* + 1).List, (2, 3, 4), 'map over a native-constructed Seq';
+
+# Empty iterator yields an empty Seq.
+my $s7 = Seq.new(().iterator);
+is $s7.elems, 0, 'Seq.new(empty iterator) is empty';
+
+# A user subclass of Seq is left to the interpreter (not intercepted).
+my $sub = (1, 2, 3).Seq;
+is $sub.List, (1, 2, 3), '.Seq coercion still works alongside Seq.new';
+
+done-testing;


### PR DESCRIPTION
## Summary

`Seq.new($iterator?)` was the last `new` fallback receiver the §D ③ ctor ledger had grouped under "iterator carrier — different axis". On re-evaluation the carrier state it touches is **VM-owned**, so it native-izes with the same "extract one impl, both call it" pattern as the QuantHash/aggregate/IO::Path/Failure slices.

- The construction reads/writes only VM-owned state: the `predictive_seq_iters` field, an `__mutsu_predictive_seq_iter::` internal env key, and the global deferred-iter side table keyed off the new Seq's own `Arc`.
- It never pulls eagerly — a `PredictiveIterator` is stashed, a materialized `items`/`stuff` instance is copied, any other iterator is registered as a deferred (lazy) iterator, and the no-arg form yields a pre-consumed `Seq`. Pulling happens later, on consumption, so there is no FS / process / user code at construction time.
- The ~46-line Seq arm of `dispatch_new` is extracted into a single `try_native_seq_construct(&mut self)` helper. The interpreter arm delegates to it; the VM gate (both non-mut and mut catch dispatch, right after the Failure ctor arm) calls the same impl — byte-identical.
- A user subclass `class S is Seq` resolves to its own class name and is left to the interpreter.

This removes another catch-all bounce, advancing §D state-ownership (前提②).

## Test
- New pin `t/native-seq-ctor.t` (11 subtests, raku/mutsu parity).
- `S32-list/seq.t` (50) / `skip.t` / `tail.t` / `rotor.t` / `S07-iterators/range-iterator.t` (103) green.
- `make test` PASS (Files=1111, Tests=11161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)