### PR TITLE
fix(class): resolve a nested class used as an attribute type during construction

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,31 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### ネストクラスを属性型に使えるよう修正 → Template::Mustache 復活（PLAN §H）
+
+属性の型にネストクラスを使うと構築時に解決失敗していたバグを修正:
+
+```raku
+class Outer {
+    class Inner { }
+    has Inner $.x;   # Inner の型オブジェクトがデフォルト
+}
+Outer.new;           # 以前: "Undeclared name: Inner used at line 1"
+```
+
+- **真因**: `has Inner $.x`（明示デフォルトなし）のデフォルトは `Inner` 型オブジェクト（`BareWord("Inner")`）。
+  これは構築時に評価されるが、その時点では method-class / package コンテキストが無く、ネストクラス短縮名 `Inner` は
+  suppressed（クラス外で見えないよう登録）されているため `resolve_suppressed_type` が `Outer::Inner` を引けず失敗していた。
+  発火点は `build_native_default_instance`（`methods_object.rs`）の属性デフォルト評価で、`has_class_scoped_subs` が
+  false（class-scoped sub が無い）だと package すら切り替えていなかった。
+- **修正**: 構築中のクラスを `constructing_class` フィールドに記録し、属性デフォルト評価の間だけセット。
+  `resolve_suppressed_type` がこのコンテキストで `<Class>::Inner` を解決できるようにした。**スコープは壊さない**:
+  フィールドはデフォルト評価の間しか立たないので、クラス外の `Inner.new`（raku では Undeclared）は引き続き失敗する。
+  担保＝`t/nested-class-attribute-type.t`（8 ケース・否定ケース含む）。
+- **波及**: Template::Mustache の `Logger` クラスは内部に `class LoggersMap is Hash {...}` を持ち `has LoggersMap $.routines;`
+  で使う。このバグで `.render` が `Undeclared name: LoggersMap` で全滅していたのが解消し、**Mustache が再び動作**（`Hello World!`）。
+  ※ このバグは precomp キャッシュの staleness 修正（前項）で露出した（古い正しいキャッシュが Mustache の動作を隠していた）。
+
 ### precomp キャッシュ staleness 修正 ＋ 薄い DBDish::SQLite 互換層が動作（exe-mtime stamp）
 
 ウェブブログスタックの DB 層を「再利用可能な pure-Raku モジュール」として用意する作業中に、precomp キャッシュの

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -481,7 +481,14 @@ impl Interpreter {
                     if self.has_class_scoped_subs(cn_resolved) {
                         self.set_current_package(cn_resolved.to_string());
                     }
+                    // Mark the class under construction so a bare nested-class
+                    // type name in the default (e.g. `has Inner $.x` whose default
+                    // is the `Inner` type object) resolves to `<Class>::Inner`,
+                    // even though no method-class / package context is active here.
+                    let saved_constructing = self.constructing_class.take();
+                    self.constructing_class = Some(cn_resolved.to_string());
                     let result = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())]);
+                    self.constructing_class = saved_constructing;
                     self.set_current_package(saved_package);
                     for (key, old_val) in saved_attr_env {
                         match old_val {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -904,6 +904,10 @@ pub struct Interpreter {
     routine_stack: Vec<RoutineFrame>,
     callframe_stack: Vec<CallFrameEntry>,
     method_class_stack: Vec<String>,
+    /// The class whose instance is currently being constructed, set only while
+    /// evaluating typed-attribute default type objects so a suppressed nested
+    /// class name resolves within its owning class (see `resolve_suppressed_type`).
+    constructing_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
     test_pending_callsite_line: Option<i64>,
     /// Number of active CONTROL handlers in the current VM stack. Tracked
@@ -3129,6 +3133,7 @@ impl Interpreter {
             routine_stack: Vec::new(),
             callframe_stack: Vec::new(),
             method_class_stack: Vec::new(),
+            constructing_class: None,
             pending_call_arg_sources: None,
             test_pending_callsite_line: None,
             control_handler_depth: 0,
@@ -3723,6 +3728,19 @@ impl Interpreter {
         }
         // Check method class stack
         for class_name in self.method_class_stack.iter().rev() {
+            let qualified = format!("{}::{}", class_name, name);
+            if self.has_type(&qualified) {
+                return Some(qualified);
+            }
+        }
+        // The class currently being constructed. A typed attribute's default
+        // type object (`has Inner $.x` defaults to `BareWord("Inner")`) is
+        // evaluated during construction with no method-class / package context,
+        // yet the nested name must resolve within its owning class. This is set
+        // only for the duration of attribute-default evaluation, so it does not
+        // leak the suppressed name into outer lexical scopes (where raku keeps it
+        // undeclared).
+        if let Some(class_name) = &self.constructing_class {
             let qualified = format!("{}::{}", class_name, name);
             if self.has_type(&qualified) {
                 return Some(qualified);
@@ -5891,6 +5909,7 @@ impl Interpreter {
             routine_stack: Vec::new(),
             callframe_stack: Vec::new(),
             method_class_stack: Vec::new(),
+            constructing_class: None,
             pending_call_arg_sources: None,
             test_pending_callsite_line: None,
             control_handler_depth: 0,

--- a/t/nested-class-attribute-type.t
+++ b/t/nested-class-attribute-type.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A nested class used as the type of an attribute must resolve when the
+# enclosing class is constructed. `has Inner $.x` (no explicit default) defaults
+# to the `Inner` type object, which is evaluated during construction with no
+# active method-class / package context — so the suppressed short name `Inner`
+# must still resolve to `Outer::Inner` there. (Regression: this failed with
+# "Undeclared name: Inner".) But the short name must remain undeclared OUTSIDE
+# the class, matching Raku's lexical scoping for nested classes.
+
+plan 8;
+
+# 1-3: bare nested type as an uninitialized attribute (defaults to the type object).
+{
+    class Outer {
+        class Inner { }
+        has Inner $.x;
+    }
+    my $o = Outer.new;
+    ok $o.defined, 'constructed Outer with a nested-class-typed attribute';
+    is $o.^name, 'Outer', 'instance has the expected type';
+    is $o.x.^name, 'Outer::Inner', 'uninitialized attr defaults to the nested type object';
+}
+
+# 4-5: BUILD using the nested type as a parameter default.
+{
+    class Box {
+        class Item is Hash { }
+        has Item $.it;
+        submethod BUILD(Item :$!it = Item.new) { }
+    }
+    my $b = Box.new;
+    ok $b.it.defined, 'BUILD default constructed a nested-class instance';
+    is $b.it.^name, 'Box::Item', 'BUILD default has the nested type';
+}
+
+# 6-7: an explicitly-passed nested instance round-trips.
+{
+    class Reg {
+        class Entry { has $.v }
+        has Entry $.e;
+    }
+    my $entry = Reg::Entry.new(v => 42);
+    my $r = Reg.new(e => $entry);
+    is $r.e.^name, 'Reg::Entry', 'passed nested instance kept its type';
+    is $r.e.v, 42, 'passed nested instance kept its value';
+}
+
+# 8: the short name stays undeclared OUTSIDE its enclosing class (lexical scope).
+{
+    class Hidden {
+        class Secret { }
+    }
+    dies-ok { EVAL 'Secret.new' }, 'nested short name is undeclared outside the class';
+}


### PR DESCRIPTION
## Problem

A nested class used as the type of an attribute fails to resolve when the enclosing class is constructed:

```raku
class Outer {
    class Inner { }
    has Inner $.x;   # default is the Inner type object
}
Outer.new;           # before: "Undeclared name: Inner used at line 1"
```

`has Inner $.x` (no explicit default) defaults to the `Inner` type object (`BareWord("Inner")`), which is evaluated **during construction**. The nested class is registered under its qualified name `Outer::Inner` and its short name is *suppressed* so it stays undeclared outside the enclosing class. But at the default-evaluation site in `build_native_default_instance`, there is no active method-class / package context (the package is only switched when the class has class-scoped subs), so `resolve_suppressed_type("Inner")` could not find `Outer::Inner`.

## Fix

Record the class under construction in a new `constructing_class` field, set **only for the duration of attribute-default evaluation**, and consult it in `resolve_suppressed_type`. Because the field is live only during that evaluation, it does not leak the suppressed name into outer lexical scopes — `Inner.new` outside the class stays undeclared, matching Raku.

## Impact: Template::Mustache restored

Mustache's `Logger` class declares a nested `class LoggersMap is Hash {...}` and uses it as `has LoggersMap $.routines;`. `.render` had been dying with `Undeclared name: LoggersMap`; it now renders correctly (`Hello World!`). Combined with the DBDishLite SQLite layer, a real web-blog stack (DB + templating + HTTP) renders end to end.

(This bug was masked on dev machines by stale precompilation caches until the exe-mtime cache-stamp fix in #3532 exposed it.)

## Test

- `t/nested-class-attribute-type.t` — 8 cases including the out-of-scope negative case (a nested short name stays undeclared outside its class).
- `make test`: cargo 470/0, no prove regressions.
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)