### PR TITLE
feat(state-ownership): native-ize Proc::Async.new (ledger §D ③ ctor)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -136,13 +136,14 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
   - **`Seq.new($iterator?)`（#3533）= 完了**。前回「iterator carrier＝別軸（impure）」と保守分類していたが carrier state 自体が VM 所有
     （`predictive_seq_iters` フィールド＋env 内部キー＋Seq Arc キーのグローバル deferred-iter 表）＝構築は eager pull せず VM 所有 state への登録のみ。
     `dispatch_new` の Seq arm を `try_native_seq_construct` に丸ごと抽出し VM/interpreter 両方が呼ぶ＝true single impl・byte-identical。
-  - **次の clean な ctor スライス（2 件・2026-06-24 実測訂正）**: 台帳が「state 依存」と分類していた 2 件は実は tractable。
-    - **`Proc::Async.new`（最も簡単・次セッション最初）**＝完全 pure data（プロセス spawn は `.start`・ctor は引数パース＋`next_supply_id()` 〔free fn〕
-      ＋`SharedPromise::new()`＋Supply 属性構築のみ・`&self` 依存ゼロ）。`build_native_proc_async_value` static helper を `try_native_builtin_construct` に
-      `Promise`/`Channel` と同型で wire。
-    - **`IO::Socket::INET.new`（medium・次）**＝`dispatch_socket_inet_new`（`&mut self`・実 bind/connect＋`insert_handle_state`）は **io_handles 依存だが
-      `IO::Path.open`（#3507 native 化済）と同型**（io_handles は VM 所有）。`try_native_socket_inet_construct` で両 catch-all から既存 helper へ委譲。
-  - **真に構造ブロック（上記 2 件 land 後に ctor-fork 完了）**: `CallFrame.new`〔call-stack carrier〕・error-only（HyperWhatever/Whatever/Instant）。
+  - **`Proc::Async.new(@cmd, :w, :enc)`（#3535）= 完了**。台帳が「state 依存」と分類していたが ctor は完全 pure data（実プロセス spawn は `.start`・
+    ctor は引数パース＋3 本の process-global supply id〔`next_supply_id` free fn〕＋空の stdout/stderr/merged `Supply` 構築のみ・`&self` 依存ゼロ）。
+    `dispatch_new` の arm を static `build_native_proc_async_value` に丸ごと抽出し、VM は `try_native_builtin_construct` に arm を `Promise`/`Channel` と
+    同型で wire＝true single impl・byte-identical。
+  - **次の clean な ctor スライス（残 1 件）**: **`IO::Socket::INET.new`（medium）**＝`dispatch_socket_inet_new`（`&mut self`・実 bind/connect＋
+    `insert_handle_state`）は **io_handles 依存だが `IO::Path.open`（#3507 native 化済）と同型**（io_handles は VM 所有）。`try_native_socket_inet_construct`
+    で両 catch-all から既存 helper へ委譲。
+  - **真に構造ブロック（上記 1 件 land 後に ctor-fork 完了）**: `CallFrame.new`〔call-stack carrier〕・error-only（HyperWhatever/Whatever/Instant）。
     これら以後は §D の本丸＝(b) tree-walk dispatch-chain 削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -656,6 +656,14 @@
   自名に解決され gate に掛からず interpreter 維持。pin `t/native-seq-ctor.t`(11・raku/mutsu 双方 PASS。`.raku` の `$(...)` itemization 差は pre-existing・
   無関係)。S32-list/seq.t(50)/skip.t/tail.t/rotor.t・S07-iterators/range-iterator.t(103) 全緑。**残 `new` fallback＝Proc::Async（pure・次）/
   IO::Socket::INET（io_handles・次）/CallFrame〔call stack carrier・別軸〕。**
+- **2026-06-24 (§D ③ = `Proc::Async.new(@cmd, :w, :enc)` を VM ネイティブ化, #3535)**: 前々エントリで「state 依存」と保守分類していた
+  `Proc::Async.new` を再評価し native 化。**ctor は完全 pure data**＝引数パース（positional command ＋ `:w`/`:enc` flag）＋3 本の
+  process-global supply id（`next_supply_id`＝bare global counter）＋空の stdout/stderr/merged `Supply` instance 構築のみ。**実プロセス spawn は
+  `.start` 側**＝ctor 時は env/registry/io_handles/user code を一切触らない（`&self` 依存ゼロ）。`dispatch_new` の Proc::Async arm（~66 行）を新 static
+  helper `build_native_proc_async_value(class_name, args)` に**丸ごと抽出**（interpreter arm は delegation）し、VM は既存の `try_native_builtin_construct`
+  に `cn=="Proc::Async"` arm を `Promise`/`Channel`/`Supplier` と同型で wire＝**1 操作 = 1 実装**・byte-identical。pin `t/native-proc-async-ctor.t`(8・
+  raku/mutsu 双方 PASS。実 echo/cat round-trip ＋ exit code ＋ `:w` stdin 込み)。t/proc-async.t(23)・roast/S17-procasync/basic.t(47)/print.t(16) 全緑。
+  **残 `new` fallback＝IO::Socket::INET（io_handles・次・`IO::Path.open` と同型）/CallFrame〔call stack carrier・別軸〕。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1982,6 +1982,79 @@ impl Interpreter {
     /// of these, else `None` so the caller falls through to the generic
     /// constructor. The interpreter's `dispatch_new` arms call the same per-type
     /// helpers, so the native path is byte-identical.
+    /// VM-native construction for `Proc::Async.new(@cmd, :w, :enc)`. Pure data
+    /// assembly: parse the positional command + `:w`/`:enc` flags, allocate three
+    /// fresh process-global supply ids (`next_supply_id`, a bare global counter),
+    /// and build empty stdout/stderr/merged `Supply` instances plus the
+    /// not-yet-started `Proc::Async` instance. No `&self` — the process is only
+    /// spawned later, by `.start`. The interpreter's `dispatch_new` arm delegates
+    /// here so the native VM fast path is byte-identical.
+    pub(crate) fn build_native_proc_async_value(class_name: Symbol, args: &[Value]) -> Value {
+        let mut positional = Vec::new();
+        let mut w_flag = false;
+        let mut enc = Value::str_from("utf-8");
+        for arg in args {
+            match arg {
+                Value::Pair(key, value) if key == "w" => {
+                    w_flag = value.truthy();
+                }
+                Value::Pair(key, _value) if key == "out" => {}
+                Value::Pair(key, value) if key == "enc" => {
+                    enc = Value::str(value.to_string_value());
+                }
+                _ => positional.push(arg.clone()),
+            }
+        }
+        let stdout_id = super::native_methods::next_supply_id();
+        let stderr_id = super::native_methods::next_supply_id();
+        let supply_id = super::native_methods::next_supply_id();
+        let stdout_descriptor = SharedPromise::new();
+        let stderr_descriptor = SharedPromise::new();
+        let mut stdout_supply_attrs = HashMap::new();
+        stdout_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
+        stdout_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+        stdout_supply_attrs.insert("supply_id".to_string(), Value::Int(stdout_id as i64));
+        stdout_supply_attrs.insert("enc".to_string(), enc.clone());
+        stdout_supply_attrs.insert(
+            "native_descriptor_promise".to_string(),
+            Value::Promise(stdout_descriptor),
+        );
+        let mut stderr_supply_attrs = HashMap::new();
+        stderr_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
+        stderr_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+        stderr_supply_attrs.insert("supply_id".to_string(), Value::Int(stderr_id as i64));
+        stderr_supply_attrs.insert("enc".to_string(), enc.clone());
+        stderr_supply_attrs.insert(
+            "native_descriptor_promise".to_string(),
+            Value::Promise(stderr_descriptor),
+        );
+        let mut merged_supply_attrs = HashMap::new();
+        merged_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
+        merged_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+        merged_supply_attrs.insert("supply_id".to_string(), Value::Int(supply_id as i64));
+
+        let mut attrs = HashMap::new();
+        attrs.insert("cmd".to_string(), Value::array(positional));
+        attrs.insert("started".to_string(), Value::Bool(false));
+        attrs.insert("enc".to_string(), enc);
+        attrs.insert(
+            "stdout".to_string(),
+            Value::make_instance(Symbol::intern("Supply"), stdout_supply_attrs),
+        );
+        attrs.insert(
+            "stderr".to_string(),
+            Value::make_instance(Symbol::intern("Supply"), stderr_supply_attrs),
+        );
+        attrs.insert(
+            "supply".to_string(),
+            Value::make_instance(Symbol::intern("Supply"), merged_supply_attrs),
+        );
+        if w_flag {
+            attrs.insert("w".to_string(), Value::Bool(true));
+        }
+        Value::make_instance(class_name, attrs)
+    }
+
     pub(crate) fn try_native_builtin_construct(
         class_name: Symbol,
         args: &[Value],
@@ -2086,6 +2159,12 @@ impl Interpreter {
                 Value::Int(super::native_methods::next_supplier_id() as i64),
             );
             Some(Ok(Value::make_instance(class_name, attrs)))
+        } else if cn == "Proc::Async" {
+            // `Proc::Async.new(@cmd, :w, :enc)` is pure data: arg parsing +
+            // process-global supply ids + empty Supply attributes. The process is
+            // only spawned later by `.start`. Shared with the interpreter's
+            // `dispatch_new` arm via the single `build_native_proc_async_value`.
+            Some(Ok(Self::build_native_proc_async_value(class_name, args)))
         } else if cn == "Capture" {
             // The default `Capture.new` produces an *empty* Capture: named args
             // are dropped (Capture has no buildable public attributes — `bless`
@@ -2921,72 +3000,11 @@ impl Interpreter {
                     return Ok(repo);
                 }
                 "Proc::Async" => {
-                    let mut positional = Vec::new();
-                    let mut w_flag = false;
-                    let mut enc = Value::str_from("utf-8");
-                    for arg in &args {
-                        match arg {
-                            Value::Pair(key, value) if key == "w" => {
-                                w_flag = value.truthy();
-                            }
-                            Value::Pair(key, _value) if key == "out" => {}
-                            Value::Pair(key, value) if key == "enc" => {
-                                enc = Value::str(value.to_string_value());
-                            }
-                            _ => positional.push(arg.clone()),
-                        }
-                    }
-                    let stdout_id = super::native_methods::next_supply_id();
-                    let stderr_id = super::native_methods::next_supply_id();
-                    let supply_id = super::native_methods::next_supply_id();
-                    let stdout_descriptor = SharedPromise::new();
-                    let stderr_descriptor = SharedPromise::new();
-                    let mut stdout_supply_attrs = HashMap::new();
-                    stdout_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
-                    stdout_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
-                    stdout_supply_attrs
-                        .insert("supply_id".to_string(), Value::Int(stdout_id as i64));
-                    stdout_supply_attrs.insert("enc".to_string(), enc.clone());
-                    stdout_supply_attrs.insert(
-                        "native_descriptor_promise".to_string(),
-                        Value::Promise(stdout_descriptor),
-                    );
-                    let mut stderr_supply_attrs = HashMap::new();
-                    stderr_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
-                    stderr_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
-                    stderr_supply_attrs
-                        .insert("supply_id".to_string(), Value::Int(stderr_id as i64));
-                    stderr_supply_attrs.insert("enc".to_string(), enc.clone());
-                    stderr_supply_attrs.insert(
-                        "native_descriptor_promise".to_string(),
-                        Value::Promise(stderr_descriptor),
-                    );
-                    let mut merged_supply_attrs = HashMap::new();
-                    merged_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
-                    merged_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
-                    merged_supply_attrs
-                        .insert("supply_id".to_string(), Value::Int(supply_id as i64));
-
-                    let mut attrs = HashMap::new();
-                    attrs.insert("cmd".to_string(), Value::array(positional));
-                    attrs.insert("started".to_string(), Value::Bool(false));
-                    attrs.insert("enc".to_string(), enc);
-                    attrs.insert(
-                        "stdout".to_string(),
-                        Value::make_instance(Symbol::intern("Supply"), stdout_supply_attrs),
-                    );
-                    attrs.insert(
-                        "stderr".to_string(),
-                        Value::make_instance(Symbol::intern("Supply"), stderr_supply_attrs),
-                    );
-                    attrs.insert(
-                        "supply".to_string(),
-                        Value::make_instance(Symbol::intern("Supply"), merged_supply_attrs),
-                    );
-                    if w_flag {
-                        attrs.insert("w".to_string(), Value::Bool(true));
-                    }
-                    return Ok(Value::make_instance(*class_name, attrs));
+                    // Shared single implementation with the VM's native fast
+                    // path (`try_native_builtin_construct`). Pure data assembly:
+                    // arg parsing + process-global supply ids + empty Supply
+                    // attributes. The process is only spawned later by `.start`.
+                    return Ok(Self::build_native_proc_async_value(*class_name, &args));
                 }
                 "utf8" | "utf16" => {
                     // Shared with the VM's native fast path (pure code-unit build).

--- a/t/native-proc-async-ctor.t
+++ b/t/native-proc-async-ctor.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Pin for the VM-native `Proc::Async.new` fast path (ledger §D ③ ctor). The VM
+# gate (`try_native_builtin_construct`) and the interpreter's `dispatch_new` arm
+# both call the single static `build_native_proc_async_value` helper, so the
+# native and slow paths must stay byte-identical. Construction is pure data —
+# the process is only spawned later, by `.start`.
+
+plan 8;
+
+# Basic construction yields a Proc::Async.
+my $p = Proc::Async.new('echo', 'hello', 'world');
+isa-ok $p, Proc::Async, 'Proc::Async.new builds a Proc::Async';
+
+# stdout/stderr are tappable Supplies before start.
+my @out;
+$p.stdout.tap(-> $line { @out.push($line) });
+ok @out == 0, 'no output before start';
+
+# Running the process feeds the tapped stdout.
+my $proc = await $p.start;
+is @out.join.chomp, 'hello world', 'echo output is captured';
+is $proc.exitcode, 0, 'successful exit code';
+
+# A second, independent Proc::Async is not aliased to the first.
+my $p2 = Proc::Async.new('echo', 'second');
+my @out2;
+$p2.stdout.tap(-> $l { @out2.push($l) });
+await $p2.start;
+is @out2.join.chomp, 'second', 'independent Proc::Async runs separately';
+is @out.join.chomp, 'hello world', 'first Proc::Async output is unaffected';
+
+# `:w` construction allows writing to the child stdin.
+my $cat = Proc::Async.new(:w, 'cat');
+my @cout;
+$cat.stdout.tap(-> $l { @cout.push($l) });
+my $pr = $cat.start;
+await $cat.write('piped-input'.encode);
+$cat.close-stdin;
+await $pr;
+is @cout.join.chomp, 'piped-input', ':w Proc::Async round-trips stdin to stdout';
+
+# A non-zero exit is reported.
+my $false = Proc::Async.new('false');
+$false.stdout.tap(-> $l { });
+my $fp = await $false.start;
+isnt $fp.exitcode, 0, 'non-zero exit code is reported';


### PR DESCRIPTION
## Summary

`Proc::Async.new` was one of the two `new` fallback receivers the §D ③ ctor ledger flagged for re-evaluation (a sibling correction note in #3531 established it is tractable). The constructor is in fact **pure data** — the real process is spawned only later, by `.start`.

- `.new(@cmd, :w, :enc)` parses the positional command + `:w`/`:enc` flags, allocates three fresh process-global supply ids (`next_supply_id`, a bare global counter), and builds empty stdout/stderr/merged `Supply` instances plus the not-yet-started `Proc::Async` instance. No `&self` — no env / registry / io_handles / user code at construction time.
- The ~66-line Proc::Async arm of `dispatch_new` is extracted into a single static `build_native_proc_async_value(class_name, args)` helper. The interpreter arm delegates to it; the VM's `try_native_builtin_construct` gains a `cn == "Proc::Async"` arm wired the same way as `Promise` / `Channel` / `Supplier` — byte-identical.

This removes another `new` catch-all bounce, advancing §D state-ownership (前提②). After this lands, the only remaining clean ctor slice is `IO::Socket::INET.new` (io_handles, same shape as the already-native `IO::Path.open`).

## Test
- New pin `t/native-proc-async-ctor.t` (8 subtests, raku/mutsu parity: real echo/cat round-trip, exit codes, `:w` stdin).
- `t/proc-async.t` (23) / `roast/S17-procasync/basic.t` (47) / `print.t` (16) green.
- `make test` PASS (Files=1113, Tests=11175; cargo test 470 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)