### PR TITLE
feat(state-ownership): native-ize IO::Socket::INET.new (ledger §D ③ ctor capstone)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -110,7 +110,8 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
       100% VM ネイティブ化済**（2026-06-23、#3499/#3501/#3503/#3504/#3507/#3511）。`.encode`/`.decode`（#3509）/ coercion 全族
       （scalar 受け手まで・#3497 他）も native。**clean な pure-value native-method ドレインは枯渇**＝残る catch-all バウンスは
       全て別軸 or 構造的ブロッカー前提（下記）。
-- [x] **(a) 組込型 ctor の native 化 — clean 候補は枯渇（2026-06-24・7 スライス landed）**: ③ ctor フォーク。
+- [x] **(a) 組込型 ctor の native 化 — ③ ctor フォーク完了（2026-06-24・10 スライス landed）**: pure-value / VM-owned-state な
+      built-in ctor は全て native 化済（IO::Socket::INET capstone #3536）。残 `new` fallback は CallFrame〔call stack〕・error-only のみ。
   - `::`-namespaced クラス＋組込例外型（`X::AdHoc`/`X::TypeCheck::Binding` …）の `.new`（#3514）= `is_native_default_constructible`
     の `::` ガード撤去＋`has_attribute || is_exception` 緩和＋VM call site で `materialize_exception_message_in_result`。
   - `Lock`/`Lock::Async`/`Lock::Soft`（#3515）/ `Promise`/`Channel`/`Supplier`/`Supplier::Preserving`（#3517）= static
@@ -140,11 +141,12 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     ctor は引数パース＋3 本の process-global supply id〔`next_supply_id` free fn〕＋空の stdout/stderr/merged `Supply` 構築のみ・`&self` 依存ゼロ）。
     `dispatch_new` の arm を static `build_native_proc_async_value` に丸ごと抽出し、VM は `try_native_builtin_construct` に arm を `Promise`/`Channel` と
     同型で wire＝true single impl・byte-identical。
-  - **次の clean な ctor スライス（残 1 件）**: **`IO::Socket::INET.new`（medium）**＝`dispatch_socket_inet_new`（`&mut self`・実 bind/connect＋
-    `insert_handle_state`）は **io_handles 依存だが `IO::Path.open`（#3507 native 化済）と同型**（io_handles は VM 所有）。`try_native_socket_inet_construct`
-    で両 catch-all から既存 helper へ委譲。
-  - **真に構造ブロック（上記 1 件 land 後に ctor-fork 完了）**: `CallFrame.new`〔call-stack carrier〕・error-only（HyperWhatever/Whatever/Instant）。
-    これら以後は §D の本丸＝(b) tree-walk dispatch-chain 削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
+  - **`IO::Socket::INET.new(...)`（#3536）= 完了＝③ ctor フォーク capstone**。実 bind/connect を行うが書き込み先は VM 所有 `io_handles`
+    （`insert_handle_state`＝native 化済 `IO::Path.open`〔#3507〕と同型）。既存 `&mut self` helper `dispatch_socket_inet_new` を `pub(crate)` に広げ、
+    VM の非mut/mut 両 catch dispatch から同じ helper を直接呼ぶ＝true single impl・byte-identical（新規コピー無し）。
+  - **∴ pure-value / VM-owned-state な built-in ctor は全て native 化済＝③ ctor フォーク完了**。残 `new` fallback receiver は `CallFrame.new`
+    〔call-stack carrier〕・error-only（HyperWhatever/Whatever/Instant）のみ＝別軸 or 構造ブロック。次は §D の本丸＝(b) tree-walk dispatch-chain
+    削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
   - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
     catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で
     撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -664,6 +664,16 @@
   に `cn=="Proc::Async"` arm を `Promise`/`Channel`/`Supplier` と同型で wire＝**1 操作 = 1 実装**・byte-identical。pin `t/native-proc-async-ctor.t`(8・
   raku/mutsu 双方 PASS。実 echo/cat round-trip ＋ exit code ＋ `:w` stdin 込み)。t/proc-async.t(23)・roast/S17-procasync/basic.t(47)/print.t(16) 全緑。
   **残 `new` fallback＝IO::Socket::INET（io_handles・次・`IO::Path.open` と同型）/CallFrame〔call stack carrier・別軸〕。**
+- **2026-06-24 (§D ③ = `IO::Socket::INET.new(...)` を VM ネイティブ化, #3536)**: ③ ctor フォークの clean ラスト。`IO::Socket::INET.new`（`:listen`
+  server / client 両モード）の ctor は実 bind/connect を行うが、**書き込み先は VM 所有の `io_handles`**（`insert_handle_state`＝既に native 化済の
+  `IO::Path.open`〔#3507〕と同型）＝env/registry/user code は触らない。既存の `&mut self` helper `dispatch_socket_inet_new`（interpreter の `dispatch_new`
+  arm が呼んでいた単一 impl）を `pub(in crate::runtime)`→`pub(crate)` に広げ、VM の非mut/mut 両 catch dispatch（Seq ctor arm の直後・
+  `class_name=="IO::Socket::INET"` gate・`method_dispatch_pure=true`）から**同じ helper を直接呼ぶ**＝**1 操作 = 1 実装**・byte-identical（新規コピー無し）。
+  user subclass は class_name が自名に解決され gate に掛からず interpreter 維持。pin `t/native-socket-inet-ctor.t`(7・raku/mutsu 双方 PASS。実 loopback
+  client/server round-trip ＋ invalid port/family dies ＋ 独立 listener)。t/socket.t(3)・roast/S32-io/IO-Socket-INET.t(32)/IO-Socket-INET-UNIX.t(8)/
+  socket-accept-and-working-threads.t(15)/socket-fail-invalid-values.t(4)/socket-host-port-split.t(2) 全緑。**∴ ③ ctor フォーク完了**＝pure-value/
+  VM-owned-state な built-in ctor は全て native 化済。**残 `new` fallback＝CallFrame〔call stack carrier〕・error-only（HyperWhatever/Whatever/Instant）＝
+  別軸 or 構造ブロック。** 次は §D の本丸＝(b) tree-walk dispatch-chain 削除 substrate or multi-dispatch VM 化。
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -2,7 +2,11 @@ use super::*;
 
 impl Interpreter {
     /// IO::Socket::INET.new — handles both :listen (server) and client modes.
-    pub(in crate::runtime) fn dispatch_socket_inet_new(
+    /// The real bind/connect writes only VM-owned `io_handles` state (via
+    /// `insert_handle_state`, the same shape as the already-native
+    /// `IO::Path.open`), so the VM's `.new` fast path calls this directly — one
+    /// implementation shared with the interpreter's `dispatch_new` arm.
+    pub(crate) fn dispatch_socket_inet_new(
         &mut self,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2800,6 +2800,9 @@ impl Interpreter {
                     return Ok(dt);
                 }
                 "IO::Socket::INET" => {
+                    // Shared single implementation with the VM's native fast
+                    // path. The real bind/connect writes only VM-owned
+                    // `io_handles` state (same shape as the native `IO::Path.open`).
                     return self.dispatch_socket_inet_new(&args);
                 }
                 "Promise" => {

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -226,6 +226,19 @@ impl Interpreter {
             self.method_dispatch_pure = true;
             return Ok(self.try_native_seq_construct(&args));
         }
+        // Native IO::Socket::INET construction: `IO::Socket::INET.new(...)` —
+        // the real bind/connect writes only VM-owned `io_handles` state (same
+        // shape as the native `IO::Path.open`). Built via the single
+        // `dispatch_socket_inet_new` impl the interpreter's `dispatch_new` arm
+        // also delegates to. (A user subclass resolves to its own class name and
+        // is left to the interpreter.)
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && class_name.resolve() == "IO::Socket::INET"
+        {
+            self.method_dispatch_pure = true;
+            return self.dispatch_socket_inet_new(&args);
+        }
         // Native built-in *class* method (a pure type-object method other than
         // `.new`, e.g. `Instant.from-posix`) — built directly instead of routing
         // through the interpreter's class-method dispatch.
@@ -1866,6 +1879,14 @@ impl Interpreter {
         {
             self.method_dispatch_pure = true;
             return Ok(self.try_native_seq_construct(&args));
+        }
+        // Native IO::Socket::INET construction (mut path twin of the above).
+        if method == "new"
+            && let Value::Package(class_name) = &target
+            && class_name.resolve() == "IO::Socket::INET"
+        {
+            self.method_dispatch_pure = true;
+            return self.dispatch_socket_inet_new(&args);
         }
         // Native built-in class method (mut path twin of the above).
         if let Value::Package(class_name) = &target

--- a/t/native-socket-inet-ctor.t
+++ b/t/native-socket-inet-ctor.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Pin for the VM-native `IO::Socket::INET.new` fast path (ledger §D ③ ctor). The
+# VM gate in `vm_call_method_compiled.rs` and the interpreter's `dispatch_new`
+# arm both call the single `dispatch_socket_inet_new` impl, so the native and
+# slow paths must stay byte-identical. The real bind/connect writes only
+# VM-owned `io_handles` state (same shape as the native `IO::Path.open`).
+
+plan 7;
+
+# A listening server socket on an ephemeral port.
+my $server = IO::Socket::INET.new(:listen, :localhost<127.0.0.1>, :localport(0));
+isa-ok $server, IO::Socket::INET, 'server socket constructs';
+
+# Invalid port is rejected at construction.
+dies-ok { IO::Socket::INET.new(:host<127.0.0.1>, :port(99999)) },
+    'out-of-range port dies';
+
+# Invalid family is rejected at construction.
+dies-ok { IO::Socket::INET.new(:host<127.0.0.1>, :port(80), :family(42)) },
+    'unsupported family dies';
+
+# A full client/server round-trip over the loopback interface.
+my $port-promise = Promise.new;
+my $listener = IO::Socket::INET.new(:listen, :localhost<127.0.0.1>, :localport(0));
+my $accepted = start {
+    my $conn = $listener.accept;
+    my $got = $conn.recv;
+    $conn.print("echo:$got");
+    $conn.close;
+    $listener.close;
+    $got;
+};
+
+# Connect a client and exchange a message.
+my $client = IO::Socket::INET.new(:host<127.0.0.1>, :port($listener.localport));
+isa-ok $client, IO::Socket::INET, 'client socket constructs';
+$client.print("hello");
+my $reply = $client.recv;
+is $reply, 'echo:hello', 'round-trip reply received';
+$client.close;
+is (await $accepted), 'hello', 'server received the client message';
+
+# A second independent socket pair is not aliased to the first.
+my $l2 = IO::Socket::INET.new(:listen, :localhost<127.0.0.1>, :localport(0));
+isnt $l2.localport, $listener.localport, 'independent listeners bind distinct ports';
+$l2.close;


### PR DESCRIPTION
## Summary

The last clean ctor of the §D ③ fork, completing it. `IO::Socket::INET.new` (both `:listen` server mode and client mode) does a real bind/connect, but the state it writes is **VM-owned**: it goes through `insert_handle_state` into `io_handles` — the exact shape as the already-native `IO::Path.open` (#3507). No env / registry / user code.

- Widen the existing `&mut self` helper `dispatch_socket_inet_new` (the single impl the interpreter's `dispatch_new` arm already called) from `pub(in crate::runtime)` to `pub(crate)`.
- Call it directly from the VM's non-mut and mut catch dispatch (right after the Seq ctor arm, `class_name == "IO::Socket::INET"`, `method_dispatch_pure = true`) — one operation, one implementation, byte-identical with **no new copy**.
- A user subclass resolves to its own class name and is left to the interpreter.

This **completes the ③ ctor fork**: every pure-value / VM-owned-state built-in ctor is now native. The remaining `new` fallback receivers are `CallFrame` (call-stack carrier) and the error-only `Whatever` family. Next up in §D is the (b) tree-walk dispatch-chain deletion substrate, or multi-dispatch VM-ization.

## Test
- New pin `t/native-socket-inet-ctor.t` (7 subtests, raku/mutsu parity: real loopback client/server round-trip, invalid port/family dies, independent listeners).
- `t/socket.t` (3) / roast S32-io `IO-Socket-INET.t` (32) / `IO-Socket-INET-UNIX.t` (8) / `socket-accept-and-working-threads.t` (15) / `socket-fail-invalid-values.t` (4) / `socket-host-port-split.t` (2) green.
- `make test` PASS (Files=1115, Tests=11190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)