### PR TITLE
test: imported sub shadows a same-named builtin (route declarators)

### DIFF
--- a/t/imported-sub-shadows-builtin.t
+++ b/t/imported-sub-shadows-builtin.t
@@ -1,0 +1,27 @@
+use Test;
+use lib 't/lib';
+use ShadowBuiltin;
+
+# An imported sub whose name collides with a core builtin (here `get`, the IO
+# line-reader, and `close`) must shadow the builtin in the importing scope when
+# called with matching arguments. This is what lets Sinatra/Bailador-style web
+# frameworks export `get`/`post`/`close` route declarators that override the
+# same-named core builtins.
+
+plan 5;
+
+# Parenthesized call dispatches to the imported sub, not the builtin `get`
+# (which would expect an IO::Handle and fail).
+is get("/a", sub { "x" }), "GET /a -> x", 'paren call hits imported get';
+
+# No-paren listop call also dispatches to the imported sub.
+is (get "/b", sub { "y" }), "GET /b -> y", 'listop call hits imported get';
+
+# `close` (also a builtin) resolves to the imported sub.
+is close("db"), "closed db", 'imported close shadows builtin close';
+
+# The imported handler block actually runs.
+is get("/c", sub { 1 + 1 }), "GET /c -> 2", 'imported get runs the handler block';
+
+# Unshadowed builtins keep working in the same scope.
+is "Hello".uc, "HELLO", 'unshadowed builtins still work';

--- a/t/lib/ShadowBuiltin.rakumod
+++ b/t/lib/ShadowBuiltin.rakumod
@@ -1,0 +1,7 @@
+unit module ShadowBuiltin;
+
+# These names collide with core builtins (`get` reads a line from an IO::Handle,
+# `close` closes a handle). An importing scope must see THESE subs, fully
+# shadowing the builtins.
+sub get(Str $path, &handler) is export { return "GET $path -> " ~ handler() }
+sub close(Str $what)         is export { return "closed $what" }


### PR DESCRIPTION
## Summary

A module that exports a sub whose name collides with a core builtin (e.g. `get` — the IO line-reader — or `close`) **shadows** that builtin in the importing scope when called with matching arguments. This is what lets Sinatra/Bailador-style web frameworks export `get`/`post`/`close` route declarators that override the same-named core builtins.

mutsu's existing matched-dispatch arm already handles this correctly. This PR adds **regression protection** for the capability, which underpins a synchronous Sinatra-style web framework built on top of the interpreter.

> An earlier revision of this branch also tried to make an *arity-mismatched* call to a shadowing sub raise a binding error instead of falling back to the builtin. That surfaced a deeper, separate issue — non-exported `our sub`s from `use`d modules are visible to dispatch (so Test::Util's `our sub run` would intercept a plain `run(...)`), regressing `S02-magicals/env.t` / `S29-os/system.t`. That gap needs lexical-visibility-aware dispatch and is left for a dedicated change; this PR is test-only.

## Test

`t/imported-sub-shadows-builtin.t` (5 assertions) + `t/lib/ShadowBuiltin.rakumod`: paren + listop calls hit the imported `get`, imported `close` shadows the builtin, the handler block runs, and unshadowed builtins keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)