### PR TITLE
fix(scope): a `my` declaration clears an inherited readonly-param flag

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5934,6 +5934,21 @@ impl Interpreter {
             // in a called sub).
             let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
             self.env_mut().remove(&readonly_key);
+            // Clear any readonly-parameter flag inherited from a caller/outer
+            // scope. `readonly_vars` is keyed by bare name and is NOT cleared on
+            // function entry, so a caller's readonly param (`sub f(Str $x){...}`)
+            // would otherwise make a callee's freshly-declared `my $x` readonly
+            // ("Cannot assign to a readonly variable (x)"). A plain `my $x = ...`
+            // always creates a new writable binding (a readonly trait, if any, is
+            // re-applied by the trait op that follows). EXCLUDE `:=` binds: a
+            // literal-bound scalar (`my $y := 5`) is genuinely readonly and that
+            // marking is set as part of the bind — unmarking it here would let a
+            // subsequent `$y = 6` slip through. Strip the sigil to match the bare
+            // key form used by check_readonly_for_modify.
+            if !is_bind && !scalar_bind {
+                let bare = name.trim_start_matches(['$', '@', '%', '&']);
+                self.unmark_readonly(bare);
+            }
             // Replace stale ContainerRef in env with Nil so a new `my $var`
             // doesn't inherit a binding from an earlier scope. Keep the key
             // so saved frame propagation can still find it.

--- a/t/readonly-param-shadow.t
+++ b/t/readonly-param-shadow.t
@@ -1,0 +1,59 @@
+use Test;
+
+# A caller's readonly parameter must NOT make a same-named `my` variable in a
+# CALLEE (or a later inner scope) read-only. `my $x` always introduces a fresh,
+# writable binding. Before the fix, a readonly param `$x` in an outer routine
+# leaked into a callee's `my $x`, raising "Cannot assign to a readonly variable".
+
+plan 7;
+
+# --- the core bug: readonly param leaks into a callee's `my` of the same name ---
+sub callee() {
+    my $body = 'init';
+    $body = 'changed';
+    return $body;
+}
+sub outer(Str $body) {        # readonly positional param named $body
+    return callee();
+}
+is outer("ro"), 'changed', 'callee my-var with caller readonly-param name is writable';
+
+# --- destructuring + //= (the shape that surfaced this in a web framework) ---
+sub parse(Str $s) {
+    my ($a, $body) = $s.split('|', 2);
+    $body //= 'DEF';
+    return "$a:$body";
+}
+sub wrapper(:$body = '') {     # readonly named param $body
+    return parse('x|y') ~ ' ' ~ parse('only');
+}
+is wrapper(), 'x:y only:DEF', 'destructure + //= works under a readonly-named param caller';
+
+# --- nested calls, same name three deep ---
+sub deep3() { my $x = 1; $x = $x + 1; $x }
+sub deep2(Int $x) { deep3() }
+sub deep1(Int $x) { deep2(99) }
+is deep1(7), 2, 'same-named readonly params three frames deep do not block inner my';
+
+# --- the readonly param itself is STILL readonly (no over-correction) ---
+sub ro-stays(Str $z) {
+    my $err;
+    { $z = 'nope'; CATCH { default { $err = .message } } }
+    return $err.defined;
+}
+ok ro-stays("x"), 'a readonly param remains readonly (assignment still throws)';
+
+# --- `is copy` param is writable as before ---
+sub with-copy(Str $w is copy) { $w = 'w2'; $w }
+is with-copy("w1"), 'w2', 'is copy param stays writable';
+
+# --- a plain my then reassign at top level still works ---
+my $top = 'a';
+$top = 'b';
+is $top, 'b', 'top-level my reassignment works';
+
+# --- a `:=` literal-bound scalar is STILL readonly (the unmark must skip binds) ---
+dies-ok {
+    my $bound := 5;
+    $bound = 6;
+}, 'a literal-bound (`:=`) scalar stays readonly even though it is a `my` decl';


### PR DESCRIPTION
## Summary

`readonly_vars` is a name-keyed set that is saved/restored at function-call boundaries but **not cleared on entry**, so a caller's readonly parameter leaks into a callee. When the callee freshly declares a same-named `my` variable, the inherited flag made it read-only:

```raku
sub callee()         { my $body = 'i'; $body = 'c'; $body }
sub outer(Str $body) { callee() }            # readonly param $body
outer("ro");   # was: "Cannot assign to a readonly variable (body)"; raku: works
```

## Fix

A plain `my $x = ...` always introduces a fresh, writable binding (a readonly trait, if present, is re-applied by the trait op that follows). Clear the inherited readonly flag in the `is_vardecl` block of `exec_set_local_op_inner`, mirroring the adjacent sigilless-readonly / var-default / deleted-index clears.

`:=` binds are **excluded** — a literal-bound scalar (`my $y := 5`) is genuinely readonly and that marking is part of the bind, so a subsequent `$y = 6` must still throw `X::Assignment::RO`. The parameter itself also stays readonly (a direct assignment to it, with no shadowing `my`, still throws).

## Test

`t/readonly-param-shadow.t` (7 assertions): callee/inner/3-deep `my` shadows are writable; destructure + `//=` works; the readonly param stays readonly; `is copy` stays writable; a `:=` literal-bound scalar stays readonly.

`make test` passes (regressions in `t/block-final-scalar-bind.t` / `t/exception-types.t` from an earlier revision are fixed by the `:=` exclusion).

Surfaced by a synchronous web framework whose request parser did `my ($head, $body) = ...; $body //= ''` under a caller passing a `:$body` named parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)