### PR TITLE
feat(example): Tubu — a synchronous Sinatra/P6W web framework + integration test

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -202,6 +202,13 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
 目標: **mutsu でウェブブログシステムが構築できる**。**Template::Mustache 完動（#3395）**。
 HTTP スタック/JSON/DB/ユーティリティは下記調査の通り NativeCall 非依存で動作可能、各々独立した一般機能の欠落待ち。
 
+**✅ Tubu — 同期 Sinatra/P6W ウェブフレームワーク完動（2026-06-24）**: `t/lib/Tubu*`（pure Raku・`get`/`post`/path
+param/query/form param/cookie/before フック/json/html/redirect/静的ファイル/同期 `IO::Socket::INET` runner）。CI-safe
+統合テスト＝`t/tubu-web-framework.t`。実ソケットで curl 応答も実証。現実的ブログ（Tubu + DBDishLite/SQLite + Mustache +
+JSON + cookie）が end-to-end で動作（`tmp/webframe/blog.raku`）。HTTP::Server::Tiny は完全非同期（`react`/`whenever
+IO::Socket::Async`）で `whenever … done` 並行ギャップ待ち＝同期 INET パスが本命。surfaced bugs: readonly-param
+フレーム間漏れ（#3539 修正）/ imported-sub shadows builtin（#3538 テスト）/ stored Regex `<$var>` lexical capture 喪失（未修正・別軸）。
+
 **✅ 完動／native 化したモジュール（詳細は news/2026-06.md ＋ memory）**: Template::Mustache（#3395）/ JSON `to-json`・
 `from-json` native（#3402）/ File::Temp 0.0.12（#3399）/ File::Directory::Tree 0.2 / HTTP::Parser 14/14（#3420/#3422/#3423）/
 MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user override 修正・own test 一部残）。これらに付随した一般機能

--- a/t/lib/Tubu.rakumod
+++ b/t/lib/Tubu.rakumod
@@ -1,0 +1,122 @@
+use Tubu::Request;
+use Tubu::Response;
+
+unit module Tubu;
+
+# ---- Route table (module singleton) ----
+my class Route {
+    has Str $.method;
+    has Str $.pattern;        # regex source string for the path
+    has @.param-names;
+    has &.handler;
+}
+
+my @routes;
+
+# Compile a Sinatra-style path ('/post/:id') into a regex SOURCE string plus
+# capture names. (Kept as a string, not a Regex object, because the matcher is
+# built fresh at dispatch time with the pattern lexically in scope.)
+sub compile-path(Str $path) {
+    my @names;
+    my $pat = $path.subst(/':' (\w+)/, -> $m { @names.push(~$m[0]); '(<-[/]>+)' }, :g);
+    return $pat, @names;
+}
+
+sub add-route(Str $method, Str $path, &handler) {
+    my ($pat, @names) = compile-path($path);
+    @routes.push(Route.new(method => $method, pattern => $pat, param-names => @names, handler => &handler));
+}
+
+# ---- Exported route declarators (Sinatra/Bailador style: `get '/' => sub {...}`) ----
+sub get(Pair $r)    is export { add-route('GET', $r.key, $r.value) }
+sub post(Pair $r)   is export { add-route('POST', $r.key, $r.value) }
+sub put(Pair $r)    is export { add-route('PUT', $r.key, $r.value) }
+sub del(Pair $r)    is export { add-route('DELETE', $r.key, $r.value) }
+
+# ---- Current request accessor ----
+sub request() is export {
+    return $*TUBU-REQUEST;
+}
+
+# ---- before-hooks (middleware): run before each dispatched request ----
+my @before-hooks;
+sub before(&hook) is export { @before-hooks.push(&hook) }
+
+# ---- Response helpers (Sinatra-style) ----
+sub json($data) is export {
+    my $body = $data ~~ Str ?? $data !! $data.Str;
+    return Tubu::Response.new(
+        status => 200,
+        headers => ['Content-Type' => 'application/json'],
+        body => $body,
+    );
+}
+
+sub redirect(Str $location, Int $code = 302) is export {
+    return Tubu::Response.new.redirect($location, $code);
+}
+
+sub html(Str $body) is export {
+    my $r = Tubu::Response.new(body => $body);
+    $r.header('Content-Type', 'text/html; charset=utf-8');
+    return $r;
+}
+
+# ---- Normalize a handler return value into a Tubu::Response ----
+sub to-response($result) {
+    return $result if $result ~~ Tubu::Response;
+    my $r = Tubu::Response.new;
+    if $result ~~ Positional && $result.elems == 3 {
+        # already a P6W-ish triple
+        $r.status = $result[0];
+        for @($result[1]) -> $h { $r.headers.push($h) }
+        $r.body = $result[2] ~~ Positional ?? $result[2].join !! $result[2].Str;
+    } else {
+        $r.body = $result.Str;
+        $r.header('Content-Type', 'text/html; charset=utf-8');
+    }
+    return $r;
+}
+
+# ---- Dispatch one request (P6W env -> Response) ----
+sub dispatch(%env) is export {
+    my $req = Tubu::Request.new(%env);
+    my $method = $req.method;
+    my $path = $req.path;
+
+    for @routes -> $route {
+        next unless $route.method eq $method;
+        my $pat = $route.pattern;
+        if $path ~~ / ^ <$pat> $ / {
+            my %caps;
+            my @names = $route.param-names;
+            for ^@names.elems -> $i {
+                %caps{@names[$i]} = ~$/[$i];
+            }
+            $req.captures = %caps;
+            my $*TUBU-REQUEST = $req;
+            for @before-hooks -> &hook { hook($req) }
+            my &h = $route.handler;
+            my $result;
+            if &h.signature.params.elems > 0 {
+                $result = &h(|@names.map({ %caps{$_} }));
+            } else {
+                $result = &h();
+            }
+            return to-response($result);
+        }
+    }
+    # no route matched
+    my $r = Tubu::Response.new(status => 404);
+    $r.header('Content-Type', 'text/plain');
+    $r.body = 'Not Found';
+    return $r;
+}
+
+# ---- Produce a P6W app closure ----
+sub to-app() is export {
+    return sub (%env) {
+        my $resp = dispatch(%env);
+        return $resp.finalize;
+    };
+}

--- a/t/lib/Tubu/Request.rakumod
+++ b/t/lib/Tubu/Request.rakumod
@@ -1,0 +1,72 @@
+unit class Tubu::Request;
+
+# Wraps a P6W-style %env hash into a convenient request object.
+has %.env;
+has %.captures;   # path captures from the matched route (:id -> value)
+
+method new(%env) {
+    self.bless(env => %env);
+}
+
+method method() { %.env<REQUEST_METHOD> // 'GET' }
+method path()   { %.env<PATH_INFO> // '/' }
+method query-string() { %.env<QUERY_STRING> // '' }
+
+method header(Str $name) {
+    my $key = 'HTTP_' ~ $name.uc.subst('-', '_', :g);
+    return %.env{$key};
+}
+
+sub url-decode(Str $s) {
+    my $t = $s.subst('+', ' ', :g);
+    $t .= subst(/'%' (<[0..9A..Fa..f]> ** 2)/, -> $m { chr(:16(~$m[0])) }, :g);
+    return $t;
+}
+
+sub parse-pairs(Str $s) {
+    my %h;
+    return %h unless $s;
+    for $s.split('&') -> $pair {
+        next unless $pair;
+        my ($k, $v) = $pair.split('=', 2);
+        %h{url-decode($k)} = url-decode($v // '');
+    }
+    return %h;
+}
+
+method query() {
+    return parse-pairs(self.query-string);
+}
+
+method body() {
+    return %.env<p6w.input.body> // '';
+}
+
+method body-params() {
+    return parse-pairs(self.body);
+}
+
+# merged query + body params
+method params() {
+    my %p = self.query;
+    for self.body-params.kv -> $k, $v {
+        %p{$k} = $v;
+    }
+    return %p;
+}
+
+method param(Str $name) {
+    return self.params{$name};
+}
+
+method cookies() {
+    my %c;
+    my $raw = self.header('Cookie') // '';
+    return %c unless $raw;
+    for $raw.split(/\s* ';' \s*/) -> $pair {
+        next unless $pair;
+        my ($k, $v) = $pair.split('=', 2);
+        %c{$k.trim} = $v // '';
+    }
+    return %c;
+}

--- a/t/lib/Tubu/Response.rakumod
+++ b/t/lib/Tubu/Response.rakumod
@@ -1,0 +1,41 @@
+unit class Tubu::Response;
+
+has Int $.status is rw = 200;
+has @.headers;        # array of Pair (name => value)
+has $.body is rw = '';
+
+method new(:$status = 200, :@headers, :$body = '') {
+    self.bless(:$status, :@headers, :$body);
+}
+
+method header(Str $name, Str $value) {
+    @.headers.push($name => $value);
+    return self;
+}
+
+method content-type(Str $ct) {
+    self.header('Content-Type', $ct);
+}
+
+method cookie(Str $name, Str $value, *%opts) {
+    my $c = "$name=$value";
+    $c ~= "; Path=" ~ %opts<path> if %opts<path>:exists;
+    $c ~= "; Max-Age=" ~ %opts<max-age> if %opts<max-age>:exists;
+    $c ~= "; HttpOnly" if %opts<httponly>;
+    @.headers.push('Set-Cookie' => $c);
+    return self;
+}
+
+method redirect(Str $location, Int $code = 302) {
+    $.status = $code;
+    @.headers.push('Location' => $location);
+    $.body = '';
+    return self;
+}
+
+# Produce the P6W triple: (status, headers, body-list)
+method finalize() {
+    my $b = $.body;
+    my @body-list = $b ~~ Blob ?? ($b,) !! ($b.Str,);
+    return $.status, @.headers, @body-list;
+}

--- a/t/lib/Tubu/Server.rakumod
+++ b/t/lib/Tubu/Server.rakumod
@@ -1,0 +1,98 @@
+unit class Tubu::Server;
+
+# A minimal *synchronous* HTTP/1.0 server that drives a P6W app
+# (sub (%env) { return $status, @headers, @body }). One request per connection.
+
+has Str $.host = '127.0.0.1';
+has Int $.port = 8080;
+
+# Parse a raw HTTP request (headers + optional body) into a P6W-style %env.
+sub parse-request(Str $raw) {
+    my %env;
+    my ($head, $body) = $raw.split("\r\n\r\n", 2);
+    $body //= '';
+    my @lines = $head.split("\r\n");
+    my $request-line = @lines.shift // '';
+    my ($method, $target, $proto) = $request-line.split(' ');
+    $method //= 'GET';
+    $target //= '/';
+    my ($path, $query) = $target.split('?', 2);
+    %env<REQUEST_METHOD>  = $method;
+    %env<PATH_INFO>       = $path;
+    %env<QUERY_STRING>    = $query // '';
+    %env<SERVER_PROTOCOL> = $proto // 'HTTP/1.0';
+    for @lines -> $line {
+        next unless $line;
+        my ($k, $v) = $line.split(':', 2);
+        next unless $v.defined;
+        my $key = 'HTTP_' ~ $k.trim.uc.subst('-', '_', :g);
+        %env{$key} = $v.trim;
+    }
+    %env<CONTENT_LENGTH> = %env<HTTP_CONTENT_LENGTH> if %env<HTTP_CONTENT_LENGTH>:exists;
+    %env<p6w.input.body> = $body;
+    return %env;
+}
+
+my %CONTENT-TYPES =
+    'html' => 'text/html; charset=utf-8',
+    'css'  => 'text/css',
+    'js'   => 'application/javascript',
+    'json' => 'application/json',
+    'txt'  => 'text/plain; charset=utf-8',
+    'png'  => 'image/png',
+    'svg'  => 'image/svg+xml';
+
+#| Serve a file from disk: returns a P6W triple. 404 if missing.
+our sub static-file(Str $path) is export {
+    return (404, ['Content-Type' => 'text/plain'], ('Not Found',)) unless $path.IO.e;
+    my $ext = $path.IO.extension;
+    my $ct = %CONTENT-TYPES{$ext} // 'application/octet-stream';
+    my $content = $path.IO.slurp;
+    return (200, ['Content-Type' => $ct], ($content,));
+}
+
+my %STATUS-TEXT =
+    200 => 'OK', 201 => 'Created', 204 => 'No Content',
+    301 => 'Moved Permanently', 302 => 'Found', 304 => 'Not Modified',
+    400 => 'Bad Request', 401 => 'Unauthorized', 403 => 'Forbidden',
+    404 => 'Not Found', 405 => 'Method Not Allowed', 500 => 'Internal Server Error';
+
+# Build a raw HTTP response string from a P6W triple.
+sub build-response($status, $headers, $body) {
+    my $text = %STATUS-TEXT{$status} // 'OK';
+    my $body-str = $body ~~ Positional ?? $body.join !! $body.Str;
+    my %seen;
+    my $out = "HTTP/1.0 $status $text\r\n";
+    for @($headers) -> $h {
+        $out ~= "{$h.key}: {$h.value}\r\n";
+        %seen{$h.key.lc} = True;
+    }
+    $out ~= "Content-Length: {$body-str.encode.bytes}\r\n" unless %seen<content-length>;
+    $out ~= "Connection: close\r\n";
+    $out ~= "\r\n";
+    $out ~= $body-str;
+    return $out;
+}
+
+# Public: turn a raw request into a raw response by running the app. This is the
+# pure, network-free core (used for testing without binding a socket).
+method handle-raw(&app, Str $raw) {
+    my %env = parse-request($raw);
+    my ($status, $headers, $body) = app(%env);
+    return build-response($status, $headers, $body);
+}
+
+# Public: bind a socket and serve requests synchronously until interrupted.
+method run(&app) {
+    my $listen = IO::Socket::INET.new(
+        :localhost($.host), :localport($.port), :listen,
+    );
+    say "Tubu listening on http://$.host:$.port/";
+    loop {
+        my $conn = $listen.accept;
+        my $raw = $conn.recv;
+        my $resp = self.handle-raw(&app, $raw);
+        $conn.print($resp);
+        $conn.close;
+    }
+}

--- a/t/tubu-web-framework.t
+++ b/t/tubu-web-framework.t
@@ -1,0 +1,77 @@
+use Test;
+use lib 't/lib';
+use Tubu;
+use Tubu::Server;
+
+# Tubu is a minimal *synchronous*, P6W-compatible, Sinatra-style web framework
+# written in pure Raku (t/lib/Tubu*). This exercises its core end-to-end WITHOUT
+# binding a socket (the network-free `handle-raw` path) so it is deterministic
+# in CI. It demonstrates that mutsu can run a real web framework: routing, path
+# params, query/form params, cookies, before-hooks, JSON/HTML/redirect helpers,
+# 404, and a from-scratch HTTP request parser + response builder.
+#
+# Depends on:
+#  - imported route declarators (`get`/`post`) shadowing same-named core
+#    builtins (`get` is the IO line-reader) — see t/imported-sub-shadows-builtin.t
+#  - a caller's readonly param not poisoning a callee's same-named `my` var
+#    (the request parser does `my ($head,$body)=...`) — see t/readonly-param-shadow.t
+
+plan 18;
+
+get '/' => sub { 'home' };
+get '/hello/:name' => sub ($name) { "hi $name" };
+get '/search' => sub { 'q=' ~ (request.param('q') // '') };
+post '/submit' => sub { 'posted ' ~ (request.param('msg') // '') };
+get '/j' => sub { json('{"ok":1}') };
+get '/r' => sub { redirect('/') };
+get '/cookie' => sub {
+    my $n = (request.cookies<n> // '0').Int + 1;
+    my $resp = html("n=$n");
+    $resp.cookie('n', $n.Str, :path</>);
+    $resp;
+};
+
+my @hooks;
+before sub ($req) { @hooks.push($req.path) };
+
+my &app = to-app();
+my $srv = Tubu::Server.new;
+
+sub req($method, $path, :$query = '', :$body = '', :$cookie = '') {
+    my $c = $cookie ?? "Cookie: $cookie\r\n" !! '';
+    my $target = $query ?? "$path?$query" !! $path;
+    my $raw = "$method $target HTTP/1.0\r\nHost: x\r\n{$c}\r\n$body";
+    return $srv.handle-raw(&app, $raw);
+}
+
+my $home = req('GET', '/');
+ok $home.contains('200 OK'), 'GET / -> 200';
+ok $home.contains('home'), 'GET / body';
+
+ok req('GET', '/hello/world').contains('hi world'), 'path param captured';
+ok req('GET', '/search', query => 'q=raku').contains('q=raku'), 'query param parsed';
+ok req('POST', '/submit', body => 'msg=hi+there').contains('posted hi there'),
+    'form body param parsed + url-decoded';
+
+my $j = req('GET', '/j');
+ok $j.contains('application/json'), 'json helper sets content-type';
+ok $j.contains('"ok":1'), 'json helper body';
+
+my $r = req('GET', '/r');
+ok $r.contains('302 Found'), 'redirect status';
+ok $r.contains('Location: /'), 'redirect Location header';
+
+ok req('GET', '/nope').contains('404 Not Found'), 'unmatched route -> 404';
+
+my $c1 = req('GET', '/cookie');
+ok $c1.contains('Set-Cookie: n=1'), 'cookie set to 1 on first visit';
+ok $c1.contains('n=1'), 'cookie body shows n=1';
+my $c2 = req('GET', '/cookie', cookie => 'n=4');
+ok $c2.contains('Set-Cookie: n=5'), 'cookie incremented to 5';
+ok $c2.contains('n=5'), 'cookie body shows n=5';
+
+ok $home.contains('Content-Length: 4'), 'Content-Length computed for "home"';
+
+ok @hooks.elems >= 5, 'before-hook fired for each dispatched request';
+is @hooks[0], '/', 'first hook saw /';
+is @hooks[1], '/hello/world', 'second hook saw /hello/world';


### PR DESCRIPTION
## Summary

Adds **Tubu**, a minimal synchronous, P6W-compatible, Sinatra-style web framework written in pure Raku (`t/lib/Tubu*`), demonstrating that mutsu can run a real web framework end-to-end:

- routing with path params — `get '/post/:id' => sub ($id) {...}`
- query-string and url-encoded form-body params, cookies
- `before` hooks (middleware), `json` / `html` / `redirect` response helpers
- a from-scratch HTTP request parser + response builder
- static file serving and a synchronous `IO::Socket::INET` runner

## What it proves

`t/tubu-web-framework.t` (18 assertions) drives the whole stack through the network-free `handle-raw` path, so it is deterministic in CI. Beyond CI:

- the real `IO::Socket::INET` runner served `curl` over a bound socket;
- a realistic **blog** (Tubu + DBDishLite/SQLite via NativeCall + Template::Mustache + a JSON API + cookie sessions) runs end-to-end (kept as a demo under `tmp/`, since it needs libsqlite3 + the Mustache module, neither available in CI).

Chosen over HTTP::Server::Tiny, which is fully async (`react` / `whenever IO::Socket::Async` / `Supply.tap`) and blocked by the `whenever … done` concurrency gap — the synchronous `IO::Socket::INET` path is the proven one.

## Dependencies (landed)

The framework relies on two interpreter fixes landed just before it:
- imported `get`/`post` declarators shadowing the same-named core builtins — #3538
- a caller's readonly param not poisoning a callee's same-named `my` var — #3539 (hit by the request parser's `my ($head,$body)=...`)

A third bug it surfaced (a stored `Regex` interpolating `<$var>` loses the lexical capture when matched later) is worked around by storing the path pattern as a string; it is left for a dedicated fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)