### PR TITLE
feat(multi-dispatch): VM-dispatch trivial-body proto subs (ledger §D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -152,7 +152,13 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/
     concurrency（Supply/tap・別軸）/ typed-array mutator（typed/shaped/shared・Phase 2/lever B）。**純粋に削れる残りは少なく、各々別軸の
     前提が要る**＝substrate 着手は要設計。
-- [ ] **multi-dispatch の VM 化**: proto multi / where 制約評価を VM 側で（`vm_call_func_ops.rs:1051/1084`）。
+- [ ] **multi-dispatch の VM 化**（着手済・proto sub の trivial-body 経路は #3541 で landed）:
+  - [x] **proto sub dispatch（trivial body）= 完了（#3541）**。`proto foo {*}` / bodyless proto を VM call site で直接ディスパッチ
+    （`vm_resolve_trivial_proto_candidate` が VM 所有レジストリで winner 候補を解決→`compile_and_call_function_def` で compiled 実行）。
+    tree-walk な proto body＋`__PROTO_DISPATCH__` round-trip＋候補 body `run_block` を全てバイパス。proto sig は gate として検証
+    （`method_args_match`）。非trivial body / 非OTF候補 / where 候補は interpreter fallback 維持。実測 `proto factorial` で fallback 100%→0%。
+  - [ ] **残**: where 制約付き候補の OTF 化（候補側 `def_is_otf_compilable` が where を除外）/ 非trivial proto body の VM 化 /
+    bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）。`vm_call_func_ops.rs:1084` の where 緩和も候補。
 
 ---
 

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -48,6 +48,7 @@
 | ~~`vm_var_get_ops.rs` pkg-qualified~~ | ~~`Module::func` を term 位置で~~ | — | **✅消化 (PR3)**: 同上 |
 | `vm_call_func_ops.rs` builtin-shadow（slip + 通常 2 サイト） | ユーザ sub が同名 builtin を shadow | 部分消化 | **✅単一候補の compilable 分は ③ PR-2 で OTF compile 化**（proto/multi/複雑 sig は call_function_fallback 維持） |
 | `vm_call_func_ops.rs` multi-dispatch fork / final else | 非proto multi / `call_function` 末端 | 部分消化 | **✅非proto multi の unambiguous/OTF-compilable/非state 候補は ③ PR-4 で OTF compile 化**（ambiguity/where/state-alternate/proto/末端は fallback 維持） |
+| `vm_call_func_ops.rs` proto sub dispatch（trivial body） | `proto foo {*}` / bodyless proto の `{*}` ディスパッチ | 部分消化 | **✅消化 (#3541)**: VM call site で `vm_resolve_trivial_proto_candidate`→`compile_and_call_function_def`。tree-walk proto body＋`__PROTO_DISPATCH__`＋候補 `run_block` を全バイパス。proto sig は `method_args_match` で gate。非trivial body / 非OTF候補 / where候補は fallback 維持 |
 | `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` 末端（実測でほぼ枯渇＝下記 PR-6 注記） | HARD | ③（残=lexical-alias-to-builtin / `__mutsu_*` 内部 / 並行〔lever B〕/ no-match エラー生成） |
 | ~~`vm_dispatch_helpers.rs` Routine call_function~~ | ~~Routine 値の関数解決~~ | — | **✅消化 (③ PR-1)**: 3 サイトを統一 compiled-first へ（builtin 名 Routine は builtin 優先維持） |
 
@@ -674,6 +675,21 @@
   socket-accept-and-working-threads.t(15)/socket-fail-invalid-values.t(4)/socket-host-port-split.t(2) 全緑。**∴ ③ ctor フォーク完了**＝pure-value/
   VM-owned-state な built-in ctor は全て native 化済。**残 `new` fallback＝CallFrame〔call stack carrier〕・error-only（HyperWhatever/Whatever/Instant）＝
   別軸 or 構造ブロック。** 次は §D の本丸＝(b) tree-walk dispatch-chain 削除 substrate or multi-dispatch VM 化。
+- **2026-06-24 (§D multi-dispatch = proto sub dispatch（trivial body）の VM 化, #3541)**: ③ ctor 完了後の §D 次本丸＝multi-dispatch VM 化に着手。
+  実測（S06 sample・`MUTSU_VM_STATS`）で **bare multi は 0 fallback**（PR-4 で OTF 化済）だが **proto multi は 100% fallback**（2 層: proto sub 呼び出し自体
+  ＋内部 `__PROTO_DISPATCH__`、各候補 body は `call_proto_dispatch`→`run_block` で tree-walk）と判明。**trivial-body proto（`proto foo {*}` / bodyless）を
+  VM call site で直接ディスパッチ**: `dispatch_func_call_inner` の else ブロック先頭に proto fast-path を追加し、新ヘルパー `vm_resolve_trivial_proto_candidate`
+  が ① interpreter-handled 名を除外 ② proto def を `resolve_proto_function` で取得し body が trivial（`SetLine` marker 除外後に空 or `[Expr(Whatever)]`）か検証
+  ③ **proto 自身の sig を `method_args_match` で gate**（`proto f(Int) {*}` が Str を弾く・S06-multi/proto.t subtest 26 が捕捉した回帰を修正）④ `resolve_proto_candidate_with_types`
+  で winner 候補を解決（VM 所有レジストリ＝phase ②）⑤ OTF-compilable かつ非state なら返す。返れば `compile_and_call_function_def` で **候補 body を compiled 実行**
+  （tree-walk proto body＋`__PROTO_DISPATCH__` round-trip＋候補 `run_block` を全バイパス）。`nextsame`/`samewith`/`callwith` は同関数の `push_multi_dispatch_frame`＋
+  samewith context で動作（PR-4 で検証済の機構）。非trivial body / 非OTF候補 / where候補 / sig 不一致は `None` で従来の interpreter fallback 維持＝byte-identical。
+  可視性: `resolve_proto_candidate_with_types`/`resolve_proto_function`/`method_args_match` を `pub(crate)` に拡大。実測 `proto factorial` で fallback 100%→0%、
+  S06 sample の `__PROTO_DISPATCH__` 50→30（残 30 は where候補/非trivial body/非OTF候補で正しく fallback）。pin `t/proto-vm-dispatch.t`(12・raku/mutsu 双方 PASS=
+  recursion/型別候補/samewith/nextsame/proto-sig gate〔EVAL ラップ〕/非trivial body guard)。whitelisted S06 全 87 件＋roast/S06-multi/proto.t(27) 全緑、make test 11202。
+  **残 multi-dispatch fallback**: where 制約付き候補の OTF 化（候補側 `def_is_otf_compilable` が where 除外）/ 非trivial proto body の VM 化 / `@_` slurpy recursive
+  plain sub（別カテゴリ）。**★教訓: `{*}` proto body は登録時に `SetLine` marker が前置され body.len=2 になる＝trivial 判定は marker 除外が必須。proto 自身の sig は
+  候補 sig と独立の gate＝バイパス時は `method_args_match` で必ず検証（さもないと `proto f(Int)` の型検査が抜ける）。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1240,7 +1240,7 @@ impl Interpreter {
         None
     }
 
-    pub(super) fn resolve_proto_function(&self, name: &str) -> Option<FunctionDef> {
+    pub(crate) fn resolve_proto_function(&self, name: &str) -> Option<FunctionDef> {
         if name.contains("::") {
             return self
                 .registry()
@@ -1708,7 +1708,7 @@ impl Interpreter {
         body.iter().map(Self::rewrite_proto_dispatch_stmt).collect()
     }
 
-    fn resolve_proto_candidate_with_types(
+    pub(crate) fn resolve_proto_candidate_with_types(
         &mut self,
         name: &str,
         arg_values: &[Value],

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -535,11 +535,7 @@ impl Interpreter {
         result
     }
 
-    pub(in crate::runtime) fn method_args_match(
-        &mut self,
-        args: &[Value],
-        param_defs: &[ParamDef],
-    ) -> bool {
+    pub(crate) fn method_args_match(&mut self, args: &[Value], param_defs: &[ParamDef]) -> bool {
         let is_invocant_param =
             |p: &ParamDef| p.is_invocant || p.traits.iter().any(|t| t == "invocant");
         let all_invocant_only = param_defs.iter().all(is_invocant_param);

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1000,7 +1000,23 @@ impl Interpreter {
                 // paths above instead rely on their own scoped-overlay merge to
                 // signal env_dirty only when a captured-outer write happened, so
                 // a pure compiled call no longer forces a per-call locals pull.
-                if self.has_multi_candidates_cached(name) && !self.has_proto(name) {
+                if self.has_proto(name)
+                    && let Some(def) = self.vm_resolve_trivial_proto_candidate(name, &args)
+                {
+                    // VM-native proto dispatch (ledger §D, multi-dispatch VM-ization):
+                    // a trivial-body proto (`proto foo {*}` / bodyless) resolves its
+                    // winning multi candidate via the VM-owned registry (phase ②) and
+                    // runs it as compiled bytecode, bypassing the tree-walk proto body
+                    // + `__PROTO_DISPATCH__` round-trip and the candidate body's own
+                    // `run_block`. Non-trivial proto bodies, unresolved/ambiguous
+                    // candidates, and non-OTF-compilable candidates return None from
+                    // the resolver above and fall through to the interpreter, which
+                    // produces the proper dispatch result / X::Multi::NoMatch error.
+                    // `nextsame`/`callsame`/`callwith`/`samewith` from the selected
+                    // candidate still work because compile_and_call_function_def pushes
+                    // the same multi-dispatch + samewith frames the interpreter would.
+                    self.compile_and_call_function_def(&def, args, compiled_fns)
+                } else if self.has_multi_candidates_cached(name) && !self.has_proto(name) {
                     // User-defined multi candidates take priority over builtins.
                     // Resolve the winning candidate Interpreter-side via the same resolver
                     // call_function_fallback uses (③ PR-3, ledger §2). When the
@@ -1138,6 +1154,66 @@ impl Interpreter {
     /// interpreter): a plain body and no default/where/code-signature/`&`-code
     /// params. Shared by the non-shadow OTF branch and the builtin-shadow forks
     /// (③ PR-2) so the same compilability gate is applied consistently.
+    /// Resolve the winning multi candidate for a *trivial-body* proto so the VM
+    /// can run it as compiled bytecode instead of falling back to the tree-walk
+    /// proto body + `__PROTO_DISPATCH__` round-trip (ledger §D, multi-dispatch
+    /// VM-ization). Returns `None` — leaving the existing interpreter fallback in
+    /// place — whenever the bypass would not be byte-identical:
+    ///
+    /// - the name is interpreter-handled (e.g. a proto'd native Test routine);
+    /// - the proto has a *non-trivial* body (statements around `{*}`), which must
+    ///   still run;
+    /// - no candidate resolves, or resolution is ambiguous (the interpreter then
+    ///   raises the proper `X::Multi::NoMatch` / `X::Multi::Ambiguous`);
+    /// - the winning candidate is not OTF-compilable, or declares `state` (whose
+    ///   shared-cell identity the OTF body-fingerprint cache cannot preserve).
+    pub(super) fn vm_resolve_trivial_proto_candidate(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<crate::ast::FunctionDef> {
+        use crate::ast::{Expr, Stmt};
+        if self.is_interpreter_handled_function(name) {
+            return None;
+        }
+        let proto = self.resolve_proto_function(name)?;
+        // A trivial proto body is empty (bodyless proto) or exactly `{*}` — only
+        // then is bypassing the body safe. `{*}` parses to `Stmt::Expr(Whatever)`.
+        // The compiler prepends line-tracking `SetLine` markers (no runtime
+        // effect on dispatch), so ignore those when judging triviality.
+        let significant: Vec<&Stmt> = proto
+            .body
+            .iter()
+            .filter(|s| !matches!(s, Stmt::SetLine(_)))
+            .collect();
+        let trivial = significant.is_empty()
+            || (significant.len() == 1 && matches!(significant[0], Stmt::Expr(Expr::Whatever)));
+        if !trivial {
+            return None;
+        }
+        // The proto's OWN signature is a gate: `proto f(Int $x) {*}` rejects a
+        // `Str` arg even when a candidate (`multi f($)`) would accept it
+        // (S06-multi/proto.t: "proto signature is checked"). Bypassing the body
+        // would skip that check, so only proceed when the args satisfy the proto
+        // signature; otherwise fall back so the interpreter raises the proper
+        // X::TypeCheck::Argument. An empty proto signature accepts anything.
+        if !proto.param_defs.is_empty() && !self.method_args_match(args, &proto.param_defs) {
+            return None;
+        }
+        // Ambiguity is signalled by `None` + a pending dispatch error; clear any
+        // stale one first (mirrors the non-proto multi fork) so a prior call's
+        // ambiguity can't leak into this resolution.
+        let _ = self.take_pending_dispatch_error();
+        let def = self.resolve_proto_candidate_with_types(name, args)?;
+        if def.empty_sig && !args.is_empty() {
+            return None;
+        }
+        if !Self::def_is_otf_compilable(&def) || Self::function_body_declares_state(&def.body) {
+            return None;
+        }
+        Some(def)
+    }
+
     pub(super) fn def_is_otf_compilable(def: &crate::ast::FunctionDef) -> bool {
         !Self::function_body_needs_interpreter(&def.body)
             && def.param_defs.iter().all(|pd| {

--- a/t/proto-vm-dispatch.t
+++ b/t/proto-vm-dispatch.t
@@ -1,0 +1,57 @@
+use Test;
+
+# Pin for VM-native proto dispatch (ledger §D, multi-dispatch VM-ization). A
+# trivial-body proto (`proto foo {*}` / bodyless) now resolves its winning multi
+# candidate via the VM-owned registry and runs it as compiled bytecode, instead
+# of falling back to the tree-walk proto body + `__PROTO_DISPATCH__` round-trip.
+# These cases exercise the correctness-critical paths that must stay identical to
+# the interpreter fallback: recursion, redispatch (nextsame/samewith), the proto
+# signature gate, non-trivial proto bodies, and X::Multi::NoMatch.
+
+plan 12;
+
+# Basic proto multi dispatch + recursion through the proto.
+proto fact($) {*}
+multi fact(0) { 1 }
+multi fact(Int $n) { $n * fact($n - 1) }
+is fact(5), 120, 'recursive proto multi (fact)';
+is fact(0), 1, 'base case candidate';
+
+# Type-based candidate selection through a permissive proto.
+proto describe($) {*}
+multi describe(Int $) { 'int' }
+multi describe(Str $) { 'str' }
+multi describe(Any $) { 'any' }
+is describe(42), 'int', 'Int candidate selected';
+is describe('x'), 'str', 'Str candidate selected';
+is describe(3.5), 'any', 'fallback Any candidate selected';
+
+# samewith re-dispatches through the proto with new args.
+proto countdown($) {*}
+multi countdown(0) { 'done' }
+multi countdown(Int $n) { "$n " ~ samewith($n - 1) }
+is countdown(3), '3 2 1 done', 'samewith recursion';
+
+# nextsame walks to the next candidate (its value replaces the caller's).
+proto rank($) {*}
+multi rank(Int $n where * > 100) { "big" }
+multi rank(Int $) { "small" }
+is rank(5), 'small', 'where-narrowed candidate falls through to next';
+is rank(500), 'big', 'where-constrained candidate matches';
+
+# The proto's OWN signature is a gate: a constraining proto sig must reject args
+# even when a candidate would accept them (S06-multi/proto.t parity). Wrapped in
+# EVAL so the surrounding file compiles under Rakudo too (which rejects the bad
+# call at compile time, while mutsu rejects it at run time — both must fail).
+proto onlyint(Int $x) {*}
+multi onlyint($) { 'accepted' }
+is onlyint(7), 'accepted', 'arg satisfying proto sig dispatches';
+dies-ok { EVAL q{ proto oi(Int $x) {*}; multi oi($) { 'a' }; oi('str') } },
+    'proto signature rejects bad arg before dispatch';
+
+# A non-trivial proto body must still run (not be bypassed) — observable through
+# a guard that short-circuits the result before `{*}`.
+proto guarded(Int $n) { return 'neg' if $n < 0; {*} }
+multi guarded(Int $n) { "pos:$n" }
+is guarded(5), 'pos:5', 'non-trivial proto body dispatches when guard passes';
+is guarded(-5), 'neg', 'non-trivial proto body guard short-circuits dispatch';


### PR DESCRIPTION
## Summary

With the ③ ctor fork complete, this starts the §D **multi-dispatch VM-ization**. Measurement (S06 sample, `MUTSU_VM_STATS`) showed bare multis already dispatch with **0 fallback** (PR-4 OTF-compiles candidates), but **proto multis fall back 100%** — two tree-walk layers: the proto sub call itself, then the inner `__PROTO_DISPATCH__` whose `call_proto_dispatch` runs each candidate body through `run_block`.

This intercepts **trivial-body protos** (`proto foo {*}` / bodyless) at the VM call site. A new helper `vm_resolve_trivial_proto_candidate`:

- skips interpreter-handled names;
- fetches the proto def and requires a **trivial body** — empty, or exactly `{*}` after filtering the compiler's prepended `SetLine` markers;
- **gates on the proto's OWN signature** via `method_args_match`, so a constraining proto (`proto f(Int) {*}`) still rejects a bad arg even when a candidate would accept it (`S06-multi/proto.t` parity — the gate fixes a real regression the naive bypass introduced);
- resolves the winning candidate from the VM-owned registry (phase ②);
- requires it be OTF-compilable and non-`state`.

When all hold, the candidate runs via `compile_and_call_function_def` (compiled bytecode), bypassing the tree-walk proto body, the `__PROTO_DISPATCH__` round-trip, and the candidate's `run_block`. `nextsame`/`samewith`/`callwith` keep working through that helper's multi-dispatch + samewith frames (validated by PR-4). Non-trivial bodies, non-OTF / where-constrained candidates, and proto-sig mismatches return `None` and fall back unchanged — byte-identical.

Visibility: widen `resolve_proto_candidate_with_types` / `resolve_proto_function` / `method_args_match` to `pub(crate)`.

## Measured
- `proto factorial`: fallback **100% → 0%**.
- S06 sample `__PROTO_DISPATCH__`: **50 → 30** (the remaining 30 — where-constrained / non-trivial / non-OTF candidates — correctly fall back).

## Test
- New pin `t/proto-vm-dispatch.t` (12 subtests, raku/mutsu parity: recursion, type-based candidates, samewith, nextsame, proto-sig gate, non-trivial body guard).
- Whitelisted S06 all 87 green incl. `roast/S06-multi/proto.t` (27).
- `make test` PASS (Files=1116, Tests=11202).

## Follow-ups (remaining multi-dispatch fallback)
- where-constrained candidate OTF compilation (candidate-side `def_is_otf_compilable` excludes `where`).
- non-trivial proto body VM-ization.
- `@_` slurpy recursive plain subs (a separate fallback category).

🤖 Generated with [Claude Code](https://claude.com/claude-code)