### PR TITLE
fix(class/role/regex): six raku-module-compat fixes surfaced by Bailador

### DIFF
--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -75,6 +75,20 @@ pub(super) fn keyword<'a>(kw: &str, input: &'a str) -> Option<&'a str> {
     }
 }
 
+/// True when `input` begins a `unit class`/`unit role`/`unit grammar`
+/// declaration (the semicolon, rest-of-unit form), whose following statements
+/// must be captured as the type's body. `unit module`/`unit package` are
+/// deliberately excluded — their package context is set compiler-side instead.
+fn starts_unit_class_role_grammar(input: &str) -> bool {
+    let Some(r) = keyword("unit", input) else {
+        return false;
+    };
+    let Ok((r, _)) = ws1(r) else {
+        return false;
+    };
+    keyword("class", r).is_some() || keyword("role", r).is_some() || keyword("grammar", r).is_some()
+}
+
 /// Parse an identifier (alphanumeric, _, -).
 /// Hyphen is only allowed when followed by an alphabetic char (not a digit).
 fn ident(input: &str) -> PResult<'_, String> {
@@ -636,6 +650,22 @@ fn stmt_list_with_mode(
                     .to_string(),
                 Some(r.len()),
             ));
+        }
+        // `unit class`/`unit role`/`unit grammar` (semicolon form): the rest of
+        // the compilation unit is the body of the declared type — capture it
+        // like `unit sub MAIN`. Without this, a top-level `has`/`method` after
+        // `unit class Foo;` is seen as outside any package and rejected with
+        // X::Attribute::NoPackage. (`unit module`/`unit package` are excluded:
+        // the compiler keeps their package context for the rest of the scope.)
+        if allow_mainline_capture && starts_unit_class_role_grammar(r) {
+            let (after_decl, mut decl) = class::unit_module_stmt(r)?;
+            let (tail_rest, tail_stmts) = stmt_list_with_mode(after_decl, false, emit_setline)?;
+            match &mut decl {
+                Stmt::ClassDecl { body, .. } | Stmt::RoleDecl { body, .. } => *body = tail_stmts,
+                _ => {}
+            }
+            stmts.push(decl);
+            return Ok((tail_rest, stmts));
         }
         // Emit source line info for deprecation tracking and error reporting.
         let line = crate::parser::primary::current_line_number(r);

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -171,10 +171,17 @@ impl Interpreter {
                         continue;
                     }
                     checked.push(sig);
-                    // Find all methods with matching signature
+                    // Find all methods with matching signature. Identify each
+                    // candidate by its ORIGINAL defining role (diamond detection,
+                    // mirroring the non-multi path above): a multi method composed
+                    // transitively via several roles (`role R { multi method m }`,
+                    // `role S does R`, `class C does S`) traces back to the same
+                    // original role through every path and so is NOT a conflict.
+                    // Using `role_origin` (the immediate composition source) instead
+                    // would wrongly see it as `(S, R)` and demand resolution.
                     let mut roles_for_sig: Vec<String> = Vec::new();
                     let mut class_resolves = def_a.role_origin.is_none();
-                    if let Some(r) = &def_a.role_origin
+                    if let Some(r) = def_a.original_role.as_ref().or(def_a.role_origin.as_ref())
                         && !roles_for_sig.contains(r)
                     {
                         roles_for_sig.push(r.clone());
@@ -184,7 +191,8 @@ impl Interpreter {
                             if def_b.role_origin.is_none() {
                                 class_resolves = true;
                             }
-                            if let Some(r) = &def_b.role_origin
+                            if let Some(r) =
+                                def_b.original_role.as_ref().or(def_b.role_origin.as_ref())
                                 && !roles_for_sig.contains(r)
                             {
                                 roles_for_sig.push(r.clone());

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -4043,8 +4043,11 @@ impl Interpreter {
                             }
                             continue;
                         }
-                        if ch == '\'' {
-                            // Single-quoted string — skip until closing quote
+                        if ch == '\'' && angle_depth == 0 {
+                            // Single-quoted string — skip until closing quote.
+                            // Inside a `<...>` assertion / char class (angle_depth>0)
+                            // a quote is a literal member (e.g. `<-['"]>`), not a
+                            // string delimiter, so it must not swallow the group.
                             group_pattern.push(ch);
                             for sq in chars.by_ref() {
                                 group_pattern.push(sq);
@@ -4054,8 +4057,12 @@ impl Interpreter {
                             }
                             continue;
                         }
-                        if ch == '"' {
-                            // Double-quoted string — skip until closing quote
+                        if ch == '"' && angle_depth == 0 {
+                            // Double-quoted string — skip until closing quote.
+                            // Inside a `<...>` assertion / char class (angle_depth>0)
+                            // a `"` is a literal member (e.g. `<-["]>`), not a string
+                            // delimiter — without this guard it swallowed the closing
+                            // `)` and produced a spurious "Unmatched ( in regex".
                             group_pattern.push(ch);
                             for dq in chars.by_ref() {
                                 group_pattern.push(dq);

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -163,7 +163,15 @@ impl Interpreter {
             let mut stubs = Vec::new();
             let mut concrete = Vec::new();
             for def in all_defs {
-                if Self::is_stub_method_def(&def) {
+                // Only a stub that came FROM A COMPOSED ROLE is a required method
+                // the class must implement. A stub declared directly in the class
+                // body (`class A { method foo {...} }`, role_origin == None) is an
+                // abstract method: the class definition succeeds and the stub stays
+                // a callable method that dies ("Stub code executed") only if invoked
+                // — it must NOT raise X::Role::Composition::Unimplemented. So keep
+                // class-direct stubs as concrete; only role-origin stubs are
+                // requirements.
+                if Self::is_stub_method_def(&def) && def.role_origin.is_some() {
                     stubs.push(def);
                 } else {
                     concrete.push(def);

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2895,7 +2895,12 @@ impl Interpreter {
         let mut role_def = RoleDef {
             attributes: Vec::new(),
             methods: HashMap::new(),
-            is_stub_role: false,
+            // A yada-body forward declaration (`role Foo { ... }`) is a stub role:
+            // mark it so the real definition that follows replaces it instead of
+            // being treated as a second, conflicting role of the same name (which
+            // made transitively-composed methods like `add_route` look like a
+            // cross-role X::Role::Composition::Conflict).
+            is_stub_role: is_stub_body,
             is_hidden: false,
             is_rw: role_is_rw,
             captured_env: None,

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -442,6 +442,15 @@ impl Interpreter {
         if self.has_class(base) {
             return true;
         }
+        // Check user-defined roles (including forward-declared stub roles, e.g.
+        // `role Foo { ... }`). A role name is a valid type for a parameter /
+        // attribute constraint just like a class — without this, the classic
+        // mutual-reference pattern (`role Foo {...}` then `role Bar { method
+        // m(Foo $x) {...} }` then `role Foo does Bar {...}`) fails with
+        // "Invalid typename 'Foo'".
+        if self.has_role(base) {
+            return true;
+        }
         // Check if it starts with uppercase (heuristic for type names)
         // This handles cases like user-defined enum types that may not be registered as classes
         false

--- a/t/lib/UCPoint.rakumod
+++ b/t/lib/UCPoint.rakumod
@@ -1,0 +1,4 @@
+unit class UCPoint;
+has Int $.x = 10;
+has Int $.y = 20;
+method s() { $.x + $.y }

--- a/t/lib/URPort.rakumod
+++ b/t/lib/URPort.rakumod
@@ -1,0 +1,4 @@
+unit role URPort;
+has Int:D $.port = 8080;
+has Str:D $.host = '0.0.0.0';
+method show() { "$.host:$.port" }

--- a/t/unit-class-role-and-composition.t
+++ b/t/unit-class-role-and-composition.t
@@ -1,0 +1,46 @@
+use Test;
+use lib 't/lib';
+use UCPoint;
+use URPort;
+
+# Six general class/role/regex fixes surfaced while loading the Bailador web
+# framework. Each was a divergence from real raku.
+
+plan 10;
+
+# 1. `unit class` with top-level `has`/`method` (rest of the unit is the body).
+is UCPoint.new(x => 10, y => 20).s, 30, 'unit class with top-level has + method works';
+
+# 1b. `unit role` with top-level `has`, consumed by a class.
+my $c2 = (class :: does URPort {}).new(port => 9000);
+is $c2.show, '0.0.0.0:9000', 'unit role with top-level has, consumed by a class';
+
+# 2. A yada-stub method in a CLASS is an abstract stub (NOT a role requirement):
+#    the class defines fine; subclasses override; calling the stub dies.
+lives-ok { EVAL 'class A { method handle($m) { ... } }; True' },
+    'class with a yada-stub method defines without X::Role::Composition error';
+is (EVAL 'class A2 { method h($m){...} }; class B2 is A2 { method h($m){"B:$m"} }; B2.new.h("x")'),
+    'B:x', 'subclass overrides the class stub method';
+dies-ok { EVAL 'class A3 { method h { ... } }; A3.new.h' },
+    'calling an unoverridden class stub dies (Stub code executed)';
+
+# 2b. A required method from a ROLE is still enforced.
+dies-ok { EVAL 'role R4 { method need {...} }; class C4 does R4 {}; True' },
+    'role required method is still enforced (X::Role::Composition::Unimplemented)';
+
+# 3. A double-quote inside a negated char class `<-["]>` inside a capture group.
+ok (q{name="abc"} ~~ / 'name="' ( <-["]>+ ) '"' /) && ~$0 eq 'abc',
+    'a `"` inside <-[...]> within a capture group parses (no spurious "Unmatched (")';
+
+# 4. A forward-declared role used as a parameter type before its full
+#    definition (the mutual-reference pattern).
+my $r4 = EVAL 'role Fwd { ... }; role Use { method add(Fwd $f){ "added" } }; role Fwd does Use { method tag(){"fwd"} }; class K does Fwd {}; K.new.add(K.new)';
+is $r4, 'added', 'forward-declared role works as a parameter type';
+
+# 6. A multi method composed transitively via several roles is not a conflict.
+lives-ok { EVAL 'role Routing { multi method add_route($r) { "added" } }; role Route does Routing {}; class Simple does Route {}; True' },
+    'transitively-composed multi method is not a false X::Role::Composition::Conflict';
+
+# 6b. ...even with a forward-declared stub role in the chain (Bailador shape).
+lives-ok { EVAL 'role Rt { ... }; role Rting { multi method add_route(Rt $r) { "a" } }; role Rt does Rting {}; class Smpl does Rt {}; True' },
+    'forward-stub + transitive multi method does not conflict';


### PR DESCRIPTION
## Summary

Working toward running an off-the-shelf Raku web framework — **Bailador** (the canonical Sinatra-style one) — on mutsu, its modules surfaced **six general divergences from real raku**. Each is fixed here; together they let Bailador's `Route` / `Route::*` / `Request` / `Multipart` / `Template` modules load on mutsu.

| # | Fix | File |
|---|-----|------|
| 1 | `unit class`/`unit role`/`unit grammar` + top-level `has`/`method` — capture the rest of the unit as the body (was empty → `has` rejected with X::Attribute::NoPackage) | `parser/stmt/mod.rs` |
| 2 | A yada-stub method in a **class** is an abstract stub (defines fine, dies only if called), not a role requirement — only stubs from a composed **role** are requirements | `runtime/registration.rs` |
| 3 | `<-["]>` (a `"`/`'` inside a negated char class) inside a capture group wrongly raised "Unmatched ( in regex" — the group scanner treated the quote as a string delimiter | `runtime/regex_parse.rs` |
| 4 | A forward-declared role/class used as a param/attribute type before its full definition failed with "Invalid typename" — `is_resolvable_type` now accepts roles | `runtime/types/type_registry.rs` |
| 5 | `is_stub_role` was hardcoded `false` so a yada forward-declared role was not marked a stub | `runtime/registration_class.rs` |
| 6 | A multi method composed transitively via several roles was a false X::Role::Composition::Conflict — the multi path now dedupes by `original_role` like the non-multi path | `runtime/class.rs` |

## Test

`t/unit-class-role-and-composition.t` (10 assertions) + `t/lib/UCPoint.rakumod` + `t/lib/URPort.rakumod` pin all six. `make test` passes.

## Note

This is interpreter-fix progress toward an existing framework; Bailador does not fully load yet (its `App`/`Sessions`/`Context` still need work, and a couple of its deps — grondilu `Digest`, the `URI` dist providing `URI::Escape` — aren't present as source in this environment). These six fixes are general and help real-world Raku module compatibility broadly, not just Bailador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)