### PR TITLE
fix(types/parser): Hash is-a Map; ternary as a hash-literal element

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -1896,8 +1896,16 @@ fn parse_hash_literal_body(input: &str) -> PResult<'_, Expr> {
                         // Odd element becomes a pending key
                         pending_key = Some(hash_key_from_expr(elems[i].clone())?);
                     }
-                } else {
+                } else if matches!(other, Expr::Literal(_) | Expr::BareWord(_)) {
                     pending_key = Some(hash_key_from_expr(other)?);
+                } else {
+                    // A complex expression that is neither a `=>` pair nor a
+                    // simple key (e.g. a ternary `$x ?? :$x !! ()` used as a
+                    // hash element) is a BARE element: raku flattens it into the
+                    // initializer (warning about odd counts only at runtime).
+                    // Route it through the hash() builder via spread_args instead
+                    // of failing with "expected hash key".
+                    spread_args.push(other);
                 }
             }
         }

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -247,6 +247,13 @@ impl Interpreter {
         {
             return true;
         }
+        // Map: a Hash IS-A Map in Raku's type hierarchy (Hash subclasses Map), so
+        // a Hash value satisfies a `Map` / `Map:D` constraint. Only Hash (and Map
+        // itself, matched by the exact-name check above) — NOT Pair/Set/Bag/Mix,
+        // which do Associative but are not Map subtypes.
+        if constraint == "Map" && matches!(value_type, "Hash") {
+            return true;
+        }
         // Buf/Blob type hierarchy:
         // Blob is the immutable base; Buf extends Blob (mutable)
         // utf8 is a subtype of Blob

--- a/t/map-subtype-and-hash-ternary.t
+++ b/t/map-subtype-and-hash-ternary.t
@@ -1,0 +1,32 @@
+use Test;
+
+# Two general fixes surfaced while loading the Humming-Bird web framework's
+# request/response core (Humming-Bird::Glue).
+
+plan 9;
+
+# 1. Hash IS-A Map in raku's type hierarchy, so a Hash satisfies Map / Map:D.
+my %h = a => 1;
+ok %h ~~ Map, 'a Hash smartmatches Map';
+ok %h ~~ Map:D, 'a defined Hash smartmatches Map:D';
+lives-ok { my sub f(--> Map:D) { my %x = b => 2; %x }; f() },
+    'returning a Hash satisfies a `--> Map:D` constraint';
+my sub g(Map:D $m) { $m<a> }
+is g(%h), 1, 'a Hash binds to a Map:D parameter';
+
+# ...but Pair/Set/Bag are NOT Map subtypes (they only do Associative).
+nok (a => 1) ~~ Map, 'a Pair is not a Map';
+nok set(1, 2) ~~ Map, 'a Set is not a Map';
+
+# 2. A ternary (and other complex expression) as a comma-separated element in a
+#    `{ }` hash literal parses (raku flattens it into the initializer).
+my $f = 'file.txt';
+my %headers = ct => 'text';
+my %part = {
+    :%headers,
+    $f ?? :$f !! (),
+    body => 'B',
+};
+is %part<f>, 'file.txt', 'ternary element yielding a colonpair lands in the hash';
+is %part<body>, 'B', 'pairs around the ternary element are preserved';
+is %part<headers><ct>, 'text', 'colonpair-shorthand element is preserved';


### PR DESCRIPTION
## Summary

Two general fixes surfaced while loading the **Humming-Bird** web framework's request/response core (`Humming-Bird::Glue`):

1. **Hash IS-A Map** (`src/runtime/types/type_matching_static.rs`). In raku, `Hash` subclasses `Map`, so a Hash value satisfies a `Map` / `Map:D` constraint. mutsu only matched `Associative`, so `%h ~~ Map` was `False` and `sub f(--> Map:D) { my %h; %h }` wrongly threw a return-type error. Adds the `Map` rule for `Hash` only — NOT `Pair`/`Set`/`Bag`/`Mix`, which do `Associative` but are not `Map` subtypes (verified against rakudo).

2. **A ternary (or other complex expression) as a comma-separated element in a `{ }` hash literal** now parses (`src/parser/primary/misc.rs`). `{ k => 1, $f ?? :$f !! () }` failed with "expected hash key" because the hash-element parser only accepted a pair or a simple key. A bare non-key expression is now routed through the `hash()` builder as a flattened element — matching raku (which parses it and only warns about odd element counts at runtime). Humming-Bird builds multipart parts as `{ :%headers, $filename ?? :$filename !! (), body => ... }`.

## Test

`t/map-subtype-and-hash-ternary.t` (9 assertions). `make test` passes.

## Context

Part of getting an **existing, maintained** Raku web framework to load on mutsu (Humming-Bird 4.0.0). With these two fixes `Humming-Bird::Glue` parses. Remaining blockers are larger subsystem features (not one-off bugs): `%?RESOURCES` distribution-resource files (needed by `MIME::Types`), and the async `IO::Socket::Async` + `react`/`whenever` server backend that every modern Raku framework uses. These two fixes are general and help real-world Raku module compatibility broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)