### PR TITLE
feat(multi-dispatch): VM-ize non-trivial proto bodies (ledger §D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -174,12 +174,25 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     stateful 文脈で後続コア `run` を mis-bind（subtest ブロックが `1..0`/`1..1` で早期終了）＝PR-2 の builtin-shadow hazard の default-param 版。
     **安全実装の方向**：builtin-shadow 単一候補パスは default-param を OTF しない（fallback 維持）まま、genuine multi 候補と非builtin 単一だけ許す
     ——narrow 化の安全確認には full roast 走が要る。fallback payoff 85.7%。impl + pin（`t/multi-default-otf-dispatch.t` 16）は branch `multi-dispatch-default-otf` に保存。
-  - [ ] **非trivial proto body の VM 化（次の本丸・設計メモ）**: `proto foo($x) { say "x"; {*} }` の body が `eval_block_value`
-    （tree-walk）で走る（実測 100% fallback）。VM 化の3要素＝①proto body（`rewrite_proto_dispatch_stmts` で `{*}`→
-    `__PROTO_DISPATCH__` call 済み）を `compile_and_call_function_def` 相当で compiled 実行 ②`__PROTO_DISPATCH__`（現 `builtins.rs:386`
-    →`call_proto_dispatch`・interpreter）を VM ネイティブ化し winner を OTF 実行 ③`proto_dispatch_stack`（`{*}` の args/method_ctx を保持）の
-    push/pop を VM 経路でも維持。難所＝proto body 内 `{*}` が compiled bytecode から `call_proto_dispatch` を呼ぶ際の env/routine_stack/
-    proto_dispatch_stack 整合と、候補側の rw-binding writeback。`vm_resolve_trivial_proto_candidate`（trivial 専用）を非trivial に拡張する形。
+  - [x] **非trivial proto body の VM 化（①proto body compiled = 完了・#TBD）**: `proto foo($x) { say "x"; {*} }` の body は
+    かつて `eval_block_value`（tree-walk・実測 100% fallback）で走っていた。①proto body（`rewrite_proto_dispatch_stmts` で `{*}`→
+    `__PROTO_DISPATCH__` call 済み）を `otf_compile_function_def`＋`call_compiled_function_named` で compiled 実行する
+    `vm_try_run_nontrivial_proto_body` を `dispatch_func_call_inner` の proto fork（trivial 解決の次）に追加。proto body は
+    dispatcher でありcandidateでないので multi-dispatch frame は push せず（`compile_and_call_function_def` は使わない）、
+    `proto_dispatch_stack` を push/pop（`push_proto_dispatch_frame`/`pop_proto_dispatch_frame` accessor 経由・args=ORIGINAL
+    proto args で interpreter `call_proto_function` と一致）するだけ。proto sig gate（`method_args_match`）＋`def_is_otf_compilable`
+    ＋非`state` を gate に、非適格 proto（class/role/start body・default/where/code-param sig）は None→interpreter fallback 維持。
+    `{*}`（compiled body 内の `__PROTO_DISPATCH__()`）は依然 interpreter `call_proto_dispatch`（builtins.rs:386 経由）に届くので
+    候補は tree-walk のまま＝②③は follow-up。実測 proto 名（p1-p4/fib/nm…）が fallback-by-name から消え `__PROTO_DISPATCH__` のみ残る。
+    pin=`t/proto-nontrivial-body-vm.t`(13)。env.t/system.t/cur-current-distribution.t＋S06-multi proto/syntax/lexical-multis ローカル全 PASS。
+    **★既知の別軸バグ（main でも同一・本スライスで不変）**: `is rw` proto param の writeback は非trivial proto body を越えて伝播しない
+    （`inc1($v)` が 10 のまま・interpreter path でも同じ）／複数 `{*}` を rvalue で使う body（`my $a={*}`）は Nil。候補側 rw-binding
+    writeback の真の修正は②③（候補 OTF 実行）と同時が筋。
+  - [ ] **②③候補 OTF 実行（follow-up・次の本丸）**: ②`__PROTO_DISPATCH__`（現 `builtins.rs:386`→`call_proto_dispatch`・interpreter）を
+    VM ネイティブ化（`dispatch_func_call_inner` 冒頭で `name=="__PROTO_DISPATCH__"` を intercept→`vm_call_proto_dispatch(compiled_fns)`）し
+    winner を `compile_and_call_function_def` で OTF 実行 ③その際の env/routine_stack/proto_dispatch_stack 整合と候補側 rw-binding writeback。
+    非OTF候補/no-match/ambiguity/proto-method（method_ctx）は interpreter `call_proto_dispatch` に委譲。builtin-shadow hazard は候補名が
+    proto名（multi 持ち）→`otf_call_cache` insert skip されるので非該当の見込み。
     **★default-OTF の教訓**: multi-dispatch 変更は make test + 局所 whitelist で緑でも release roast で broad 回帰しうる（[[project_multi_dispatch_otf_default_deferred]]）。
     実装時は env.t/system.t/cur-current-distribution.t（subprocess+Test::Util+subtest）を必ずローカル再現確認し、full roast を CI に委ねる。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -918,6 +918,18 @@ impl Interpreter {
         self.multi_dispatch_stack.pop();
     }
 
+    /// Push a proto-sub dispatch frame so a compiled proto body's `{*}`
+    /// (`__PROTO_DISPATCH__`) can read the original proto args when it
+    /// redispatches to the winning multi candidate (ledger §D).
+    pub(crate) fn push_proto_dispatch_frame(&mut self, name: String, args: Vec<Value>) {
+        self.proto_dispatch_stack.push((name, args, None));
+    }
+
+    /// Pop the proto-sub dispatch frame pushed by `push_proto_dispatch_frame`.
+    pub(crate) fn pop_proto_dispatch_frame(&mut self) {
+        self.proto_dispatch_stack.pop();
+    }
+
     /// Push a samewith context for a multi sub dispatch.
     pub(crate) fn push_samewith_context(&mut self, name: &str, invocant: Option<Value>) {
         self.samewith_context_stack

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1717,7 +1717,7 @@ impl Interpreter {
         remaining
     }
 
-    fn rewrite_proto_dispatch_stmts(body: &[Stmt]) -> Vec<Stmt> {
+    pub(crate) fn rewrite_proto_dispatch_stmts(body: &[Stmt]) -> Vec<Stmt> {
         body.iter().map(Self::rewrite_proto_dispatch_stmt).collect()
     }
 

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -81,6 +81,73 @@ impl Interpreter {
     /// Compile a FunctionDef on-the-fly to bytecode and execute via the Interpreter.
     /// This avoids the interpreter's tree-walking execution path.
     #[allow(dead_code)]
+    /// Compile a `FunctionDef` on-the-fly to a `CompiledFunction`, caching by the
+    /// body fingerprint (+ package, which scopes compile-time pseudo-variables
+    /// like `$?PACKAGE`). Caching is essential to preserve state-variable identity
+    /// across calls. Shared by `compile_and_call_function_def` and the non-trivial
+    /// proto-body runner (ledger §D, multi-dispatch VM-ization), so both go through
+    /// the same compile/cache path.
+    pub(super) fn otf_compile_function_def(
+        &mut self,
+        def: &crate::ast::FunctionDef,
+    ) -> CompiledFunction {
+        let pkg = def.package.resolve();
+        let fingerprint =
+            crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+        let cache_key = {
+            let mut hasher = std::hash::DefaultHasher::new();
+            std::hash::Hash::hash(&fingerprint, &mut hasher);
+            std::hash::Hash::hash(&pkg, &mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        };
+        if let Some(cached) = self.otf_compile_cache.get(&cache_key) {
+            return cached.clone();
+        }
+        let cc = {
+            let mut compiler = crate::compiler::Compiler::new();
+            if !pkg.is_empty() && pkg != "GLOBAL" {
+                compiler.set_current_package(pkg.to_string());
+            }
+            // Resolve $?DISTRIBUTION from the function's defining package
+            compiler.current_distribution = self
+                .package_distributions
+                .get(&pkg)
+                .cloned()
+                .or_else(|| self.current_distribution.clone());
+            compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
+        };
+        let deprecated_info = def.deprecated_message.as_ref().map(|msg| {
+            let kind = if def.is_method { "Method" } else { "Sub" };
+            (
+                kind.to_string(),
+                def.name.resolve(),
+                def.package.resolve(),
+                msg.clone(),
+            )
+        });
+        let mut cf = CompiledFunction {
+            code: cc,
+            params: def.params.clone(),
+            param_defs: def.param_defs.clone(),
+            return_type: def.return_type.clone(),
+            fingerprint,
+            empty_sig: def.empty_sig,
+            is_rw: def.is_rw,
+            is_raw: def.is_raw,
+            param_local_slots: None,
+            has_inner_subs: false,
+            named_param_slots: None,
+            deprecated_info,
+            declared_locals: None,
+        };
+        cf.precompute_param_local_slots();
+        cf.precompute_named_param_slots();
+        cf.detect_inner_subs();
+        cf.compute_declared_locals();
+        self.otf_compile_cache.insert(cache_key, cf.clone());
+        cf
+    }
+
     pub(super) fn compile_and_call_function_def(
         &mut self,
         def: &crate::ast::FunctionDef,
@@ -98,66 +165,7 @@ impl Interpreter {
         let name = def.name.resolve();
         let pkg = def.package.resolve();
 
-        let fingerprint =
-            crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
-
-        // Use cached compilation if available, otherwise compile on-the-fly.
-        // Caching is essential to preserve state variable identity across calls.
-        // The cache key includes the package name because compile-time
-        // pseudo-variables like $?PACKAGE depend on the compilation context.
-        let cache_key = {
-            let mut hasher = std::hash::DefaultHasher::new();
-            std::hash::Hash::hash(&fingerprint, &mut hasher);
-            std::hash::Hash::hash(&pkg, &mut hasher);
-            std::hash::Hasher::finish(&hasher)
-        };
-        let cf = if let Some(cached) = self.otf_compile_cache.get(&cache_key) {
-            cached.clone()
-        } else {
-            let cc = {
-                let mut compiler = crate::compiler::Compiler::new();
-                if !pkg.is_empty() && pkg != "GLOBAL" {
-                    compiler.set_current_package(pkg.to_string());
-                }
-                // Resolve $?DISTRIBUTION from the function's defining package
-                compiler.current_distribution = self
-                    .package_distributions
-                    .get(&pkg)
-                    .cloned()
-                    .or_else(|| self.current_distribution.clone());
-                compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
-            };
-            let deprecated_info = def.deprecated_message.as_ref().map(|msg| {
-                let kind = if def.is_method { "Method" } else { "Sub" };
-                (
-                    kind.to_string(),
-                    def.name.resolve(),
-                    def.package.resolve(),
-                    msg.clone(),
-                )
-            });
-            let mut cf = CompiledFunction {
-                code: cc,
-                params: def.params.clone(),
-                param_defs: def.param_defs.clone(),
-                return_type: def.return_type.clone(),
-                fingerprint,
-                empty_sig: def.empty_sig,
-                is_rw: def.is_rw,
-                is_raw: def.is_raw,
-                param_local_slots: None,
-                has_inner_subs: false,
-                named_param_slots: None,
-                deprecated_info,
-                declared_locals: None,
-            };
-            cf.precompute_param_local_slots();
-            cf.precompute_named_param_slots();
-            cf.detect_inner_subs();
-            cf.compute_declared_locals();
-            self.otf_compile_cache.insert(cache_key, cf.clone());
-            cf
-        };
+        let cf = self.otf_compile_function_def(def);
 
         // Cache by name for fast lookup in exec_call_func_op — but never for a
         // multi name. The name-keyed cache is type-blind, so caching one multi

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1016,6 +1016,17 @@ impl Interpreter {
                     // candidate still work because compile_and_call_function_def pushes
                     // the same multi-dispatch + samewith frames the interpreter would.
                     self.compile_and_call_function_def(&def, args, compiled_fns)
+                } else if self.has_proto(name)
+                    && let Some(result) =
+                        self.vm_try_run_nontrivial_proto_body(name, args.clone(), compiled_fns)
+                {
+                    // VM-native non-trivial proto body (ledger §D): a proto with a
+                    // real body (`proto foo($x) { say "x"; {*} }`) runs that body as
+                    // compiled bytecode instead of tree-walking it. The `{*}` inside
+                    // still redispatches to the winning multi candidate through the
+                    // existing proto-dispatch handler. Non-OTF-eligible protos return
+                    // None and fall through to the interpreter unchanged.
+                    result
                 } else if self.has_multi_candidates_cached(name) && !self.has_proto(name) {
                     // User-defined multi candidates take priority over builtins.
                     // Resolve the winning candidate Interpreter-side via the same resolver
@@ -1212,6 +1223,78 @@ impl Interpreter {
             return None;
         }
         Some(def)
+    }
+
+    /// Run a *non-trivial-body* proto (`proto foo($x) { say "x"; {*} }`) as
+    /// compiled bytecode instead of tree-walking its body through the interpreter
+    /// (ledger §D, multi-dispatch VM-ization). The proto body is rewritten so each
+    /// `{*}` becomes a `__PROTO_DISPATCH__()` call, then compiled and run like any
+    /// routine: its `{*}` redispatch still resolves and runs the winning multi
+    /// candidate through the existing proto-dispatch handler (reached from the
+    /// compiled body's `__PROTO_DISPATCH__` call), so behaviour — including the
+    /// candidate's `nextsame`/`callsame` — is byte-identical to the interpreter.
+    ///
+    /// Returns `None` (leaving the interpreter fallback in place) whenever the
+    /// bypass would not be safe / byte-identical:
+    /// - the name is interpreter-handled, or has no proto / a *trivial* body
+    ///   (handled by `vm_resolve_trivial_proto_candidate` instead);
+    /// - the args do not satisfy the proto's own signature (the interpreter then
+    ///   raises the proper `X::TypeCheck::Argument`);
+    /// - the proto's signature or (rewritten) body is not OTF-compilable, or the
+    ///   body declares `state` (whose shared-cell identity the fingerprint cache
+    ///   cannot preserve).
+    pub(super) fn vm_try_run_nontrivial_proto_body(
+        &mut self,
+        name: &str,
+        args: Vec<Value>,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        use crate::ast::{Expr, Stmt};
+        if self.is_interpreter_handled_function(name) {
+            return None;
+        }
+        let proto = self.resolve_proto_function(name)?;
+        // Only handle *non-trivial* bodies here; the trivial (bodyless / `{*}`-only)
+        // case is the trivial resolver's job. A bodyless proto (`def.body.empty`)
+        // dispatches implicitly and must not be compiled here.
+        let significant: Vec<&Stmt> = proto
+            .body
+            .iter()
+            .filter(|s| !matches!(s, Stmt::SetLine(_)))
+            .collect();
+        let trivial = significant.is_empty()
+            || (significant.len() == 1 && matches!(significant[0], Stmt::Expr(Expr::Whatever)));
+        if trivial {
+            return None;
+        }
+        // The proto's OWN signature is a gate (same as the trivial path): bypassing
+        // to compiled code must still reject args the proto signature forbids.
+        if !proto.param_defs.is_empty() && !self.method_args_match(&args, &proto.param_defs) {
+            return None;
+        }
+        // Rewrite `{*}` -> `__PROTO_DISPATCH__()` and require the resulting body +
+        // the proto's own signature to be OTF-compilable. `state` in the proto body
+        // would break the body-fingerprint state cache, so exclude it too.
+        let rewritten = crate::runtime::Interpreter::rewrite_proto_dispatch_stmts(&proto.body);
+        let mut proto_def = proto.clone();
+        proto_def.body = rewritten;
+        if !Self::def_is_otf_compilable(&proto_def)
+            || Self::function_body_declares_state(&proto_def.body)
+        {
+            return None;
+        }
+        // Compile the proto body and run it like a routine. `{*}` redispatch reads
+        // the args from `proto_dispatch_stack` (the ORIGINAL proto args, matching
+        // the interpreter's `call_proto_function`), so push that before the body
+        // runs and pop after. No multi-dispatch frame is pushed for the proto body
+        // itself — it is the dispatcher, not a candidate; the candidate's own
+        // `nextsame` frame is set up by the proto-dispatch handler when `{*}` runs.
+        let cf = self.otf_compile_function_def(&proto_def);
+        let pkg = proto_def.package.resolve();
+        self.push_proto_dispatch_frame(name.to_string(), args.clone());
+        let result = self.call_compiled_function_named(&cf, args, compiled_fns, &pkg, name);
+        self.pop_proto_dispatch_frame();
+        Some(result)
     }
 
     pub(super) fn def_is_otf_compilable(def: &crate::ast::FunctionDef) -> bool {

--- a/t/proto-nontrivial-body-vm.t
+++ b/t/proto-nontrivial-body-vm.t
@@ -1,0 +1,67 @@
+# Non-trivial proto bodies run as compiled bytecode (ledger §D, multi-dispatch
+# VM-ization): a `proto foo($x) { ...; {*} }` with a real body around `{*}` is
+# compiled and run like any routine, with `{*}` still redispatching to the
+# winning multi candidate. These assertions verify the bypass is byte-identical
+# to the interpreter fallback.
+use Test;
+plan 13;
+
+# basic non-trivial body wraps the dispatched candidate result
+proto p1($x) { my $pre = "[$x]"; my $r = {*}; "$pre$r" }
+multi p1(Int $x) { "int" }
+multi p1(Str $x) { "str" }
+is p1(5), "[5]int", "non-trivial body wraps int candidate";
+is p1("a"), "[a]str", "non-trivial body wraps str candidate";
+
+# capture-param proto `(|)`
+proto p2(|) { "<" ~ {*} ~ ">" }
+multi p2(Int) { "i" }
+multi p2(Str) { "s" }
+is p2(1), "<i>", "capture-param proto body";
+
+# where-constrained candidates dispatched through a non-trivial body
+proto p3($x) { "w:" ~ {*} }
+multi p3($x where * > 10) { "big" }
+multi p3($x) { "small" }
+is p3(20), "w:big", "where candidate via non-trivial body";
+is p3(2), "w:small", "fallback candidate via non-trivial body";
+
+# callsame from the candidate dispatched under a non-trivial body
+proto p4($x) { "pre " ~ {*} }
+multi p4(Int $x) { "narrow+" ~ callsame() }
+multi p4($x) { "wide" }
+is p4(7), "pre narrow+wide", "callsame from candidate under non-trivial body";
+
+# recursion through a non-trivial proto body
+proto fib($n) { {*} }
+multi fib(0) { 0 }
+multi fib(1) { 1 }
+multi fib(Int $n) { fib($n - 1) + fib($n - 2) }
+is fib(10), 55, "recursion through non-trivial proto body";
+
+# named args through the proto body
+proto nm(:$a, :$b) { "n:" ~ {*} }
+multi nm(:$a!, :$b!) { "$a-$b" }
+is nm(a => 1, b => 2), "n:1-2", "named args through proto body";
+
+# explicit return from the candidate
+proto rr($x) { "ignored-prefix"; {*} }
+multi rr(Int $x) { return "early"; "unreached" }
+is rr(1), "early", "explicit return from candidate";
+
+# proto signature gate still rejects wrong types / accepts right ones
+proto pg(Int $x) { "g:" ~ {*} }
+multi pg($x) { "ok" }
+dies-ok { pg("string") }, "proto signature gate rejects Str";
+is pg(3), "g:ok", "proto signature gate passes Int";
+
+# proto body computes on the param before dispatching
+proto cc($x) { my $y = $x * 2; "y=$y;" ~ {*} }
+multi cc(Int $x) { "got" }
+is cc(4), "y=8;got", "proto body computes on param before dispatch";
+
+# side-effecting statement in the body runs before dispatch
+my @log;
+proto se($x) { @log.push("pre"); my $r = {*}; @log.push("post"); $r }
+multi se(Int $x) { @log.push("cand"); "v" }
+is se(1) ~ "|" ~ @log.join(","), "v|pre,cand,post", "body statements run around dispatch in order";


### PR DESCRIPTION
## Summary

A `proto foo(\$x) { say \"x\"; {*} }` with a real body around `{*}` used to run its **whole body through the tree-walking interpreter** (measured 100% fallback). This PR compiles the proto body to bytecode and runs it like any routine, with `{*}` still redispatching to the winning multi candidate through the existing proto-dispatch handler.

This is **slice ①** of the §D non-trivial-proto-body VM-ization design (PLAN.md §D). The candidate dispatched by `{*}` still runs through the interpreter's `call_proto_dispatch` — VM-native `__PROTO_DISPATCH__` + OTF candidate execution are the **②③ follow-up**.

## How

- **`vm_try_run_nontrivial_proto_body`** — wired into `dispatch_func_call_inner`'s proto fork right after trivial-proto resolution. Rewrites each `{*}` → `__PROTO_DISPATCH__()`, gates on the proto signature (`method_args_match`) + `def_is_otf_compilable` + no-`state`, compiles, and runs via `call_compiled_function_named`.
- **`otf_compile_function_def`** — extracted from `compile_and_call_function_def` so the proto-body runner and the existing OTF path share one compile/cache route.
- The proto body is the **dispatcher, not a candidate**, so no multi-dispatch frame is pushed for it — only `proto_dispatch_stack` (new `push_proto_dispatch_frame`/`pop_proto_dispatch_frame` accessors), carrying the **original** proto args to match the interpreter's `call_proto_function`.
- Non-eligible protos (class/role/start bodies, default/where/code-param signatures) return `None` and **fall through to the interpreter unchanged**.

## Verification

- pin: `t/proto-nontrivial-body-vm.t` (13 subtests) — all pass, byte-identical to `raku`.
- `MUTSU_VM_STATS` confirms proto names (p1–p4/fib/nm/…) drop out of fallback-by-name; only `__PROTO_DISPATCH__` (candidate dispatch, the ②③ follow-up) remains.
- `make test` green (cargo 470 passed; prove all successful).
- Multi-dispatch-hazard tests flagged in PLAN pass locally: `roast/S02-magicals/env.t`, `roast/S29-os/system.t`, `roast/S11-repository/cur-current-distribution.t`, plus `S06-multi/{proto,syntax,lexical-multis}.t`.

## Known (pre-existing, unchanged)

`is rw` proto-param writeback across a non-trivial proto body, and multiple-`{*}`-as-rvalue bodies, fail identically on `main`; they are out of scope for slice ① and are the right place for the ②③ candidate-OTF work to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)