### PR TITLE
fix(types): scalar parameter type constraints are env-scoped (no caller leak)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4774,6 +4774,40 @@ impl Interpreter {
         }
     }
 
+    /// Register the type constraint of a *bound routine parameter*. For scalar
+    /// parameters the constraint is written ONLY to the `env`-keyed
+    /// `__mutsu_type::name` metadata (which is scoped — dropped when the callee's
+    /// env is restored) and NOT to the global, name-keyed `var_type_constraints`
+    /// map. This is what stops a typed parameter (`Str:D $x`) from leaking its
+    /// constraint onto a same-named lexical in the *caller* (`my $x = f(...)`,
+    /// where `f`'s parameter is also `$x`): the global map would otherwise retain
+    /// the entry after the callee returns, and the env-first/`var_type_constraints`-
+    /// fallback read would surface it. `my`-declared and `subset` constraints
+    /// still go through `set_var_type_constraint` (both stores), so the global-map
+    /// fallback remains available where the env entry isn't visible (e.g. an
+    /// `EVAL`'d re-assignment to a `subset`-typed lexical). Container parameters
+    /// (`@a`/`%h`) keep the full behaviour — their element/key-type metadata is
+    /// consulted via the global map / container metadata for element checks.
+    pub(crate) fn bind_param_type_constraint(&mut self, name: &str, constraint: Option<String>) {
+        if name.starts_with('@') || name.starts_with('%') {
+            self.set_var_type_constraint(name, constraint);
+            return;
+        }
+        let meta_key = format!("__mutsu_type::{}", name);
+        match constraint {
+            Some(c) => {
+                let info = Self::parse_container_constraint(name, &c);
+                if info.value_type == "atomicint" || c.contains("atomicint") {
+                    self.atomic_var_seen = true;
+                }
+                self.env.insert(meta_key, Value::str(info.value_type));
+            }
+            None => {
+                self.env.remove(&meta_key);
+            }
+        }
+    }
+
     pub(crate) fn var_type_constraint(&self, name: &str) -> Option<String> {
         let key = name;
         let meta_key = format!("__mutsu_type::{}", key);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4803,7 +4803,18 @@ impl Interpreter {
                 self.env.insert(meta_key, Value::str(info.value_type));
             }
             None => {
+                // An untyped scalar parameter shadows any same-named lexical: it
+                // has NO constraint in the callee's scope. Clear both the env
+                // metadata AND a possibly-stale `var_type_constraints` entry left
+                // by an earlier `my Type $x` declaration whose block has exited
+                // (the global map is not block-scoped). Without this, reading the
+                // (Nil-defaulted) parameter would surface the stale constraint via
+                // the global-map fallback and return the type object instead of
+                // Nil — roast S02-types/nil.t f4. An enclosing typed lexical that
+                // is still in scope keeps its own env metadata, so its enforcement
+                // (read env-first) survives the callee's return.
                 self.env.remove(&meta_key);
+                self.var_type_constraints.remove(name);
             }
         }
     }

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -466,7 +466,7 @@ impl Interpreter {
                         format!("@{}", pd.name)
                     };
                     self.bind_param_value(&key, slurpy_value.clone());
-                    self.set_var_type_constraint(&key, pd.type_constraint.clone());
+                    self.bind_param_type_constraint(&key, pd.type_constraint.clone());
                 }
                 if let Some(sub_params) = &pd.sub_signature {
                     bind_sub_signature_from_value(self, sub_params, &slurpy_value)?;
@@ -504,7 +504,7 @@ impl Interpreter {
                     let capture_value = Value::capture(positional, named);
                     if !pd.name.is_empty() {
                         self.bind_param_value(&pd.name, capture_value.clone());
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
                     if let Some(sub_params) = &pd.sub_signature {
                         bind_sub_signature_from_value(self, sub_params, &capture_value)?;
@@ -523,7 +523,7 @@ impl Interpreter {
                     }
                     if !pd.name.is_empty() {
                         self.bind_param_value(&pd.name, Value::hash(hash_items));
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
                 } else if pd.double_slurpy {
                     // **@ (non-flattening slurpy): keep each argument as-is, skip Pairs
@@ -542,7 +542,7 @@ impl Interpreter {
                             format!("@{}", pd.name)
                         };
                         self.bind_param_value(&key, Value::real_array(items));
-                        self.set_var_type_constraint(&key, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&key, pd.type_constraint.clone());
                     }
                 } else if !pd.name.starts_with('@') {
                     // *$x -- slurpy scalar: captures what would otherwise be the
@@ -565,7 +565,7 @@ impl Interpreter {
                     }
                     if !pd.name.is_empty() {
                         self.bind_param_value(&pd.name, value.clone());
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
                 } else {
                     let mut items = Vec::new();
@@ -638,7 +638,7 @@ impl Interpreter {
                             format!("@{}", pd.name)
                         };
                         self.bind_param_value(&key, slurpy_value.clone());
-                        self.set_var_type_constraint(&key, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&key, pd.type_constraint.clone());
                     }
                     // Check where constraint for slurpy params
                     if let Some(where_expr) = &pd.where_constraint {
@@ -761,7 +761,7 @@ impl Interpreter {
                             rw_bindings.push((pd.name.clone(), source_name));
                         }
                         self.bind_param_value(&pd.name, bound_value);
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                         if let Some(sub_params) = &pd.sub_signature {
                             bind_named_rename_sub_signature(self, sub_params, &val)?;
                         }
@@ -785,7 +785,10 @@ impl Interpreter {
                                 && key == inner_key
                             {
                                 self.bind_param_value(&pd.name, *inner_val.clone());
-                                self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                                self.bind_param_type_constraint(
+                                    &pd.name,
+                                    pd.type_constraint.clone(),
+                                );
                                 bind_named_rename_sub_signature(self, sub_params, &inner_val)?;
                                 found = true;
                                 break;
@@ -892,11 +895,11 @@ impl Interpreter {
                         self.bind_type_capture(captured_name, &value);
                         if !pd.name.is_empty() {
                             self.bind_param_value(&pd.name, value.clone());
-                            self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                            self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                         }
                     } else if !pd.name.is_empty() {
                         self.bind_param_value(&pd.name, value.clone());
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
                     // For renamed named params like :foo($y) = $x, also bind the
                     // sub-signature variable ($y) to the default value.
@@ -918,7 +921,7 @@ impl Interpreter {
                     if !self.env.contains_key(&pd.name) {
                         let value = Self::missing_optional_param_value(pd);
                         self.bind_param_value(&pd.name, value);
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
                 }
             } else if pd.name == "__subsig__"
@@ -1491,7 +1494,10 @@ impl Interpreter {
                                 }
                             }
                             self.bind_param_value(&pd.name, Value::hash(map));
-                            self.set_var_type_constraint(&pd.name, bound_type_constraint.clone());
+                            self.bind_param_type_constraint(
+                                &pd.name,
+                                bound_type_constraint.clone(),
+                            );
                             if let Some(sub_params) = &pd.sub_signature {
                                 let target = self.env.get(&pd.name).cloned().unwrap_or(Value::Nil);
                                 bind_sub_signature_from_value(self, sub_params, &target)?;
@@ -1522,7 +1528,7 @@ impl Interpreter {
                             rw_bindings.push((pd.name.clone(), source_name.clone()));
                         }
                         self.bind_param_value(&pd.name, value);
-                        self.set_var_type_constraint(&pd.name, bound_type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, bound_type_constraint.clone());
                     }
                     if let Some(sub_params) = &pd.sub_signature {
                         let target = self
@@ -1544,7 +1550,7 @@ impl Interpreter {
                         self.bind_type_capture(captured_name, &value);
                     } else if !pd.name.is_empty() {
                         self.bind_param_value(&pd.name, value);
-                        self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
                     if let Some(sub_params) = &pd.sub_signature {
                         let target = self.env.get(&pd.name).cloned().unwrap_or(Value::Nil);
@@ -1576,7 +1582,7 @@ impl Interpreter {
                 } else if !pd.name.is_empty() {
                     // Optional parameters use typed empties/type objects when omitted.
                     self.bind_param_value(&pd.name, Self::missing_optional_param_value(pd));
-                    self.set_var_type_constraint(&pd.name, pd.type_constraint.clone());
+                    self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                 }
             }
         }

--- a/t/create-slots-resources-buf-strict-escape.t
+++ b/t/create-slots-resources-buf-strict-escape.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 15;
+plan 19;
 
 # --- 1. CREATE allocates attribute slots so `$!attr = ...` in a private
 #        builder (`self.CREATE!SET-SELF`) persists. ---
@@ -85,4 +85,35 @@ plan 15;
     without %h<missing> { $seen ~= "-skipped" }
     with %h<missing> { $seen ~= "!" }
     is $seen, "with:1-skipped", "with/without under strict (internal temps exempt)";
+}
+
+# --- A typed routine parameter must not leak its constraint onto a same-named
+#     lexical in the caller (scalar param constraints are env-scoped, not stored
+#     in the global var_type_constraints map). ---
+{
+    enum Color <Red Green Blue>;
+    sub to-color(Str:D $name --> Color:D) {
+        given $name.lc { when 'red' { Red }; default { Blue } }
+    }
+    sub from-sub {
+        my $name = to-color('red');   # caller's `my $name` shares the param name
+        $name
+    }
+    is from-sub(), Red, "typed param does not leak onto same-named caller lexical (sub)";
+
+    class Parser {
+        method parse {
+            my $name = to-color('blue');   # same collision from inside a method body
+            $name
+        }
+    }
+    is Parser.new.parse, Blue, "typed param does not leak onto same-named caller lexical (method)";
+
+    # The parameter's own type constraint is still enforced (env-scoped).
+    sub needs-int(Int $x is copy) { $x = "oops"; $x }
+    dies-ok { needs-int(1) }, "scalar param type constraint is still enforced inside the callee";
+
+    # `my Type $x` (not a param) still type-checks via the global-map fallback.
+    my Int $n = 5;
+    dies-ok { $n = "x" }, "a real typed lexical still type-checks";
 }


### PR DESCRIPTION
## Summary

`var_type_constraints` is a global, bare-name-keyed map. A typed routine parameter (`Str:D $x`) wrote its constraint there, and the entry **survived the callee's return**, so a same-named lexical in the *caller* saw the leaked constraint:

```raku
sub http-method-of-str(Str:D $method --> HTTPMethod:D) { ... }
my $method = http-method-of-str($raw);   # caller's `my $method` shares the param name
# → X::TypeCheck::Assignment: expected Str:D but got Int  (the enum return value)
```

This blocked Humming-Bird's `Request.decode` (and is a general correctness bug for any caller lexical sharing a name with a typed callee parameter).

## Fix

New `bind_param_type_constraint`: scalar parameter constraints go **only** into the scoped `env`-keyed `__mutsu_type::name` metadata (dropped when the callee's env is restored), not the global map. So they cannot leak, while the parameter's own constraint is still enforced inside the callee (the assignment check reads env first).

`my`-declared and `subset` constraints still use `set_var_type_constraint` (both stores) — the global-map fallback is **required** for an `EVAL`'d re-assignment to a `subset`-typed lexical whose env metadata isn't visible in the EVAL scope (`roast/S02-types/subset-6e.t`). Container parameters (`@a`/`%h`) keep full behaviour for element/key-type checks.

## Test

- `make test` passes (11269+ tests, no regressions).
- New subtests in `t/create-slots-resources-buf-strict-escape.t` cover the leak (sub + method callers), continued in-callee enforcement, and the unaffected `my Type $x` path.
- Whitelisted type/signature/class roast tests verified locally (58/58, incl. `subset-6e.t`, `S02-types/native.t`, `S06-signature/types.t`).

Follow-up to #3549; with this, Humming-Bird `Request.decode` parses requests end to end. (Remaining for full serving: driving detached `start { react { … } }` blocks across threads.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)