### PR TITLE
feat(multi-dispatch): VM-native {*} proto candidate dispatch (ledger §D ②③)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -186,15 +186,16 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     候補は tree-walk のまま＝②③は follow-up。実測 proto 名（p1-p4/fib/nm…）が fallback-by-name から消え `__PROTO_DISPATCH__` のみ残る。
     pin=`t/proto-nontrivial-body-vm.t`(13)。env.t/system.t/cur-current-distribution.t＋S06-multi proto/syntax/lexical-multis ローカル全 PASS。
     **★既知の別軸バグ（main でも同一・本スライスで不変）**: `is rw` proto param の writeback は非trivial proto body を越えて伝播しない
-    （`inc1($v)` が 10 のまま・interpreter path でも同じ）／複数 `{*}` を rvalue で使う body（`my $a={*}`）は Nil。候補側 rw-binding
-    writeback の真の修正は②③（候補 OTF 実行）と同時が筋。
-  - [ ] **②③候補 OTF 実行（follow-up・次の本丸）**: ②`__PROTO_DISPATCH__`（現 `builtins.rs:386`→`call_proto_dispatch`・interpreter）を
+    （`inc1($v)` が 10 のまま・interpreter path でも同じ）／複数 `{*}` を rvalue で使う body（`my $a={*}`）は Nil。これは
+    proto_dispatch_stack args が rw コンテナを運ばない深い別軸（interpreter/VM 共通）で ②③ でも不変。
+  - [x] **②③候補 OTF 実行 = 完了（#TBD）**: ②`__PROTO_DISPATCH__`（旧 `builtins.rs:386`→`call_proto_dispatch`・interpreter）を
     VM ネイティブ化（`dispatch_func_call_inner` 冒頭で `name=="__PROTO_DISPATCH__"` を intercept→`vm_call_proto_dispatch(compiled_fns)`）し
-    winner を `compile_and_call_function_def` で OTF 実行 ③その際の env/routine_stack/proto_dispatch_stack 整合と候補側 rw-binding writeback。
-    非OTF候補/no-match/ambiguity/proto-method（method_ctx）は interpreter `call_proto_dispatch` に委譲。builtin-shadow hazard は候補名が
-    proto名（multi 持ち）→`otf_call_cache` insert skip されるので非該当の見込み。
-    **★default-OTF の教訓**: multi-dispatch 変更は make test + 局所 whitelist で緑でも release roast で broad 回帰しうる（[[project_multi_dispatch_otf_default_deferred]]）。
-    実装時は env.t/system.t/cur-current-distribution.t（subprocess+Test::Util+subtest）を必ずローカル再現確認し、full roast を CI に委ねる。
+    winner を `compile_and_call_function_def` で OTF 実行（trivial-proto fork と同一経路）。proto-method（method_ctx）/no-match/
+    ambiguity/empty-sig-with-args/非OTF/state は interpreter `call_proto_dispatch` に委譲（X::Multi::NoMatch/Ambiguous の生成と
+    proto_method_skip 整合は interpreter 所有のまま）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%
+    （`__PROTO_DISPATCH__` 188→0・残 callsame carrier と dies-ok エラー経路のみ）。builtin-shadow hazard 非該当（候補名=proto名で
+    `has_multi_candidates_cached`→`otf_call_cache` insert skip）。pin=`t/proto-candidate-otf-dispatch.t`(7・nextsame/samewith/callsame
+    chain＋nested proto)。env.t/system.t/cur-current-distribution.t＋S06-multi＋proto-含む roast 24 本 = 失敗数 main と完全一致（回帰ゼロ）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/
     `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）。
 

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -930,6 +930,15 @@ impl Interpreter {
         self.proto_dispatch_stack.pop();
     }
 
+    /// Clone of the current proto-dispatch frame `(name, args, method_ctx)`, read
+    /// by the VM-native `{*}` redispatch handler. `None` outside a proto body.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn proto_dispatch_last(
+        &self,
+    ) -> Option<(String, Vec<Value>, Option<super::ProtoMethodCtx>)> {
+        self.proto_dispatch_stack.last().cloned()
+    }
+
     /// Push a samewith context for a multi sub dispatch.
     pub(crate) fn push_samewith_context(&mut self, name: &str, invocant: Option<Value>) {
         self.samewith_context_stack

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1534,7 +1534,7 @@ impl Interpreter {
         Some(result)
     }
 
-    pub(super) fn call_proto_dispatch(&mut self) -> Result<Value, RuntimeError> {
+    pub(crate) fn call_proto_dispatch(&mut self) -> Result<Value, RuntimeError> {
         let (proto_name, args, method_ctx) = self
             .proto_dispatch_stack
             .last()

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -895,6 +895,13 @@ impl Interpreter {
         call_me_override: Option<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
+        if name == "__PROTO_DISPATCH__" {
+            // `{*}` inside a compiled proto body (ledger §D): the proto-dispatch
+            // marker rewritten by `rewrite_proto_dispatch_stmts`. Resolve and run
+            // the winning multi candidate VM-natively (compiled bytecode) instead
+            // of bouncing through interpreter `call_proto_dispatch` + `run_block`.
+            return self.vm_call_proto_dispatch(compiled_fns);
+        }
         if let Some(callable) = call_me_override {
             let result = self.try_compiled_method_or_interpret(callable, "CALL-ME", args);
             let result = result?;
@@ -1295,6 +1302,52 @@ impl Interpreter {
         let result = self.call_compiled_function_named(&cf, args, compiled_fns, &pkg, name);
         self.pop_proto_dispatch_frame();
         Some(result)
+    }
+
+    /// VM-native `{*}` redispatch (ledger §D, multi-dispatch VM-ization step ②③):
+    /// reached when a compiled proto body executes its rewritten `__PROTO_DISPATCH__()`
+    /// call. Resolves the winning multi candidate from the proto-dispatch frame's
+    /// original args and runs it as compiled bytecode via
+    /// `compile_and_call_function_def` — the same path the trivial-proto fork uses —
+    /// so the candidate body and its `nextsame`/`callsame`/`samewith` redispatch all
+    /// run VM-natively instead of tree-walking through interpreter `call_proto_dispatch`
+    /// + `run_block`. (The `is rw` writeback *through* a non-trivial proto body is a
+    /// separate pre-existing gap — the proto-dispatch frame carries the proto's
+    /// original args, not the caller's containers — and is unchanged here; it fails
+    /// identically on the interpreter path.)
+    ///
+    /// Falls back to the interpreter's `call_proto_dispatch` (which owns the full
+    /// `X::Multi::NoMatch` / `X::Multi::Ambiguous` reporting, `proto method`
+    /// invocant handling, and the tree-walk `run_block`) whenever a VM-native run
+    /// would not be byte-identical: a `proto method` `{*}` (invocant context), no
+    /// resolvable / ambiguous candidate, an empty-sig candidate called with args, or
+    /// a non-OTF-compilable / `state`-declaring candidate.
+    pub(super) fn vm_call_proto_dispatch(
+        &mut self,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<Value, RuntimeError> {
+        let Some((proto_name, args, method_ctx)) = self.proto_dispatch_last() else {
+            // `{*}` outside a proto — let the interpreter raise the proper error.
+            return self.loan_env_for(|i| i.call_proto_dispatch());
+        };
+        // `proto method` redispatch needs the invocant + one-shot `proto_method_skip`
+        // bookkeeping the interpreter owns; only proto *subs* run compiled here.
+        if method_ctx.is_some() {
+            return self.loan_env_for(|i| i.call_proto_dispatch());
+        }
+        // Clear any stale pending dispatch error (mirrors the trivial-proto fork)
+        // so a prior call's ambiguity can't leak into this resolution.
+        let _ = self.take_pending_dispatch_error();
+        if let Some(def) = self.resolve_proto_candidate_with_types(&proto_name, &args)
+            && (!def.empty_sig || args.is_empty())
+            && Self::def_is_otf_compilable(&def)
+            && !Self::function_body_declares_state(&def.body)
+        {
+            return self.compile_and_call_function_def(&def, args, compiled_fns);
+        }
+        // No candidate / ambiguous / empty-sig-with-args / non-OTF / state: the
+        // interpreter re-resolves and produces the exact error or tree-walk result.
+        self.loan_env_for(|i| i.call_proto_dispatch())
     }
 
     pub(super) fn def_is_otf_compilable(def: &crate::ast::FunctionDef) -> bool {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1310,11 +1310,11 @@ impl Interpreter {
     /// original args and runs it as compiled bytecode via
     /// `compile_and_call_function_def` — the same path the trivial-proto fork uses —
     /// so the candidate body and its `nextsame`/`callsame`/`samewith` redispatch all
-    /// run VM-natively instead of tree-walking through interpreter `call_proto_dispatch`
-    /// + `run_block`. (The `is rw` writeback *through* a non-trivial proto body is a
-    /// separate pre-existing gap — the proto-dispatch frame carries the proto's
-    /// original args, not the caller's containers — and is unchanged here; it fails
-    /// identically on the interpreter path.)
+    /// run VM-natively instead of tree-walking through interpreter
+    /// `call_proto_dispatch` and `run_block`. (The `is rw` writeback *through* a
+    /// non-trivial proto body is a separate pre-existing gap — the proto-dispatch
+    /// frame carries the proto's original args, not the caller's containers — and is
+    /// unchanged here; it fails identically on the interpreter path.)
     ///
     /// Falls back to the interpreter's `call_proto_dispatch` (which owns the full
     /// `X::Multi::NoMatch` / `X::Multi::Ambiguous` reporting, `proto method`

--- a/t/proto-candidate-otf-dispatch.t
+++ b/t/proto-candidate-otf-dispatch.t
@@ -1,0 +1,44 @@
+# VM-native `{*}` redispatch (ledger §D, multi-dispatch VM-ization ②③): a
+# compiled proto body`s `__PROTO_DISPATCH__()` resolves and runs the winning
+# multi candidate as compiled bytecode (`vm_call_proto_dispatch` ->
+# `compile_and_call_function_def`), so the candidate body, `nextsame`/`callsame`/
+# `samewith`, and nested proto calls all run VM-natively. Byte-identical to raku.
+use Test;
+plan 7;
+
+# nextsame as tail (replaces dispatch) under a non-trivial proto body
+proto a($x) { "A[" ~ {*} ~ "]" }
+multi a(Int $x) { nextsame }
+multi a($x)     { "any" }
+is a(3), "A[any]", "nextsame tail from candidate under non-trivial proto body";
+
+# samewith recursion via candidate
+proto c($n) { {*} }
+multi c(Int $n) { $n <= 0 ?? "end" !! "c" ~ samewith($n - 1) }
+is c(3), "cccend", "samewith recursion under proto";
+
+# callsame value used in candidate arithmetic (returns, composable)
+proto d($x) { ">" ~ {*} }
+multi d(Int $x where * > 100) { "huge-" ~ callsame() }
+multi d(Int $x) { "int-" ~ callsame() }
+multi d($x) { "any" }
+is d(200), ">huge-int-any", "callsame 3-level chain";
+is d(5),   ">int-any",      "callsame 2-level chain (huge skipped)";
+
+# nested proto calls (proto body calls another proto)
+proto outer($x) { "O(" ~ inner($x) ~ "|" ~ {*} ~ ")" }
+multi outer(Int $x) { "oi" }
+proto inner($x) { "I[" ~ {*} ~ "]" }
+multi inner(Int $x) { "ii" }
+is outer(1), "O(I[ii]|oi)", "nested proto calls";
+
+# proto body + candidate share arg correctly
+proto e($x) { my $r = {*}; "$x:$r" }
+multi e(Int $x) { $x * $x }
+is e(6), "6:36", "proto body and candidate share arg correctly";
+
+# callsame returning a value used in arithmetic
+proto f($x) { {*} }
+multi f(Int $x) { 1 + callsame() }
+multi f($x) { 10 }
+is f(5), 11, "callsame value used in candidate arithmetic";


### PR DESCRIPTION
## Summary

**Slice ②** of the §D non-trivial-proto-body VM-ization (slice ① = #3550). Previously a compiled proto body's `{*}` (rewritten to `__PROTO_DISPATCH__()`) bounced back to interpreter `call_proto_dispatch`, which resolved the winning multi candidate and ran its body via the tree-walking `run_block`.

Now `dispatch_func_call_inner` intercepts `__PROTO_DISPATCH__` and routes it to **`vm_call_proto_dispatch`**, which resolves the candidate from the proto-dispatch frame's args and runs it as **compiled bytecode** via `compile_and_call_function_def` — the same path the trivial-proto fork uses. The candidate body and its `nextsame`/`callsame`/`samewith` redispatch now run VM-natively.

## Delegation to the interpreter (byte-identical fallback)

`vm_call_proto_dispatch` delegates to interpreter `call_proto_dispatch` — which owns `X::Multi::NoMatch` / `X::Multi::Ambiguous` reporting, `proto method` invocant handling, and the tree-walk fallback — for: a `proto method` `{*}` (invocant context), no resolvable / ambiguous candidate, an empty-sig candidate called with args, and non-OTF-compilable / `state`-declaring candidates.

The **builtin-shadow OTF hazard** ([[project_multi_dispatch_otf_default_deferred]]) does not apply: the candidate name is the proto name, which has multi candidates cached, so `compile_and_call_function_def` skips the name-keyed `otf_call_cache` insert.

## Effect

On `t/proto-nontrivial-body-vm.t`, `MUTSU_VM_STATS` interpreter fallbacks drop **50.1% → 0.5%** (`__PROTO_DISPATCH__` 188 → 0; only a `callsame` carrier and the `dies-ok` error path remain).

## Verification

- pin: `t/proto-candidate-otf-dispatch.t` (7 — nextsame/samewith/callsame chains + nested proto calls, byte-identical to `raku`).
- `make test` green (cargo 470; prove all successful).
- `roast/S02-magicals/env.t`, `roast/S29-os/system.t`, `roast/S11-repository/cur-current-distribution.t` + `S06-multi/{proto,syntax,lexical-multis}.t` pass.
- 24 proto-containing roast files: failure counts **identical to main** (wrap 12, misc 48, weird 10, …) — zero regressions.

## Known (pre-existing, unchanged)

`is rw` writeback through a non-trivial proto body, and multiple-`{*}`-as-rvalue bodies, remain pre-existing gaps (fail identically on the interpreter path / main) — the proto-dispatch frame carries the proto's original args, not the caller's containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)