### PR TITLE
docs(PLAN/news §D): record non-trivial proto body VM-ization (#3550/#3552)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -178,12 +178,15 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     `proto foo($x){ say "x"; {*} }` の body＋`{*}` 候補ディスパッチを両方 compiled 実行（`vm_try_run_nontrivial_proto_body`
     ＋`vm_call_proto_dispatch`）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%。
     pin=`t/proto-nontrivial-body-vm.t`(13)/`t/proto-candidate-otf-dispatch.t`(7)。
-  - [ ] **`is rw` proto-param writeback を非trivial proto body 越しに伝播（次スライス・別軸）**: `proto inc($x is rw){ {*} }`/
-    `multi inc(Int $x is rw){$x++}` で `inc($v)` が **10**（11 が正・main/①/② 全て同一・interpreter path でも壊れている）。
-    真因＝`proto_dispatch_stack` の args が proto の **original 値**で caller のコンテナ（別名）を運ばない→候補が `$x is rw` を
-    rebind しても caller `$v` に届かない。trivial proto は body を bypass し元の呼び出し args（コンテナ）で候補を直呼びするので動く。
-    修正は proto_dispatch_stack に caller コンテナ（or arg_sources）を運ぶ設計が要る。複数 `{*}` rvalue（`my $a={*}`）の Nil も
-    同系（rewrite が statement 位置のみ対応）。
+  - [ ] **`{*}` を proto の現在パラメータで再ディスパッチ（次スライス・別軸・semantic fix）**: `proto pr($x is rw){ $x=99; {*} }`/
+    `multi pr(Int $x is rw){ $x=$x+1 }` で `pr($v)`（$v=10）が raku=**100**（候補は body が変異した `$x`=99 を見て 100 を書き $v に伝播）
+    に対し mutsu=**99**（候補の書き込みが失われる）。真因＝raku の `{*}` は proto の**現在の（body で変異済・別名保持の）パラメータ**で
+    再ディスパッチするが、mutsu は `proto_dispatch_stack` に保存した**入口時の original args（値）**を候補に渡す→候補は caller `$v` の
+    コンテナへの別名を得られず rw write が消える。修正＝`vm_call_proto_dispatch`（と interpreter `call_proto_dispatch`）が proto の
+    param 名から現フレームの**現在のコンテナ値**を読んで候補へ渡す（`proto_dispatch_stack` に param 名 or 現在 binding を持たせる）。
+    これは VM 化でなく `{*}` 再ディスパッチ意味論の修正で、`is rw` writeback（`inc($v)`→10）も同時に直る。trivial proto は body を
+    bypass し元の呼び出し args（コンテナ）で候補を直呼びするので元から動く。複数 `{*}` rvalue（`my $a={*}`）の Nil は別系
+    （rewrite が statement 位置のみ対応）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/
     `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）。
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -174,28 +174,16 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     stateful 文脈で後続コア `run` を mis-bind（subtest ブロックが `1..0`/`1..1` で早期終了）＝PR-2 の builtin-shadow hazard の default-param 版。
     **安全実装の方向**：builtin-shadow 単一候補パスは default-param を OTF しない（fallback 維持）まま、genuine multi 候補と非builtin 単一だけ許す
     ——narrow 化の安全確認には full roast 走が要る。fallback payoff 85.7%。impl + pin（`t/multi-default-otf-dispatch.t` 16）は branch `multi-dispatch-default-otf` に保存。
-  - [x] **非trivial proto body の VM 化（①proto body compiled = 完了・#TBD）**: `proto foo($x) { say "x"; {*} }` の body は
-    かつて `eval_block_value`（tree-walk・実測 100% fallback）で走っていた。①proto body（`rewrite_proto_dispatch_stmts` で `{*}`→
-    `__PROTO_DISPATCH__` call 済み）を `otf_compile_function_def`＋`call_compiled_function_named` で compiled 実行する
-    `vm_try_run_nontrivial_proto_body` を `dispatch_func_call_inner` の proto fork（trivial 解決の次）に追加。proto body は
-    dispatcher でありcandidateでないので multi-dispatch frame は push せず（`compile_and_call_function_def` は使わない）、
-    `proto_dispatch_stack` を push/pop（`push_proto_dispatch_frame`/`pop_proto_dispatch_frame` accessor 経由・args=ORIGINAL
-    proto args で interpreter `call_proto_function` と一致）するだけ。proto sig gate（`method_args_match`）＋`def_is_otf_compilable`
-    ＋非`state` を gate に、非適格 proto（class/role/start body・default/where/code-param sig）は None→interpreter fallback 維持。
-    `{*}`（compiled body 内の `__PROTO_DISPATCH__()`）は依然 interpreter `call_proto_dispatch`（builtins.rs:386 経由）に届くので
-    候補は tree-walk のまま＝②③は follow-up。実測 proto 名（p1-p4/fib/nm…）が fallback-by-name から消え `__PROTO_DISPATCH__` のみ残る。
-    pin=`t/proto-nontrivial-body-vm.t`(13)。env.t/system.t/cur-current-distribution.t＋S06-multi proto/syntax/lexical-multis ローカル全 PASS。
-    **★既知の別軸バグ（main でも同一・本スライスで不変）**: `is rw` proto param の writeback は非trivial proto body を越えて伝播しない
-    （`inc1($v)` が 10 のまま・interpreter path でも同じ）／複数 `{*}` を rvalue で使う body（`my $a={*}`）は Nil。これは
-    proto_dispatch_stack args が rw コンテナを運ばない深い別軸（interpreter/VM 共通）で ②③ でも不変。
-  - [x] **②③候補 OTF 実行 = 完了（#TBD）**: ②`__PROTO_DISPATCH__`（旧 `builtins.rs:386`→`call_proto_dispatch`・interpreter）を
-    VM ネイティブ化（`dispatch_func_call_inner` 冒頭で `name=="__PROTO_DISPATCH__"` を intercept→`vm_call_proto_dispatch(compiled_fns)`）し
-    winner を `compile_and_call_function_def` で OTF 実行（trivial-proto fork と同一経路）。proto-method（method_ctx）/no-match/
-    ambiguity/empty-sig-with-args/非OTF/state は interpreter `call_proto_dispatch` に委譲（X::Multi::NoMatch/Ambiguous の生成と
-    proto_method_skip 整合は interpreter 所有のまま）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%
-    （`__PROTO_DISPATCH__` 188→0・残 callsame carrier と dies-ok エラー経路のみ）。builtin-shadow hazard 非該当（候補名=proto名で
-    `has_multi_candidates_cached`→`otf_call_cache` insert skip）。pin=`t/proto-candidate-otf-dispatch.t`(7・nextsame/samewith/callsame
-    chain＋nested proto)。env.t/system.t/cur-current-distribution.t＋S06-multi＋proto-含む roast 24 本 = 失敗数 main と完全一致（回帰ゼロ）。
+  - [x] **非trivial proto body の VM 化 = 完了（#3550 ①body compiled / #3552 ②候補 OTF）→ [news/2026-06.md](news/2026-06.md)**。
+    `proto foo($x){ say "x"; {*} }` の body＋`{*}` 候補ディスパッチを両方 compiled 実行（`vm_try_run_nontrivial_proto_body`
+    ＋`vm_call_proto_dispatch`）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%。
+    pin=`t/proto-nontrivial-body-vm.t`(13)/`t/proto-candidate-otf-dispatch.t`(7)。
+  - [ ] **`is rw` proto-param writeback を非trivial proto body 越しに伝播（次スライス・別軸）**: `proto inc($x is rw){ {*} }`/
+    `multi inc(Int $x is rw){$x++}` で `inc($v)` が **10**（11 が正・main/①/② 全て同一・interpreter path でも壊れている）。
+    真因＝`proto_dispatch_stack` の args が proto の **original 値**で caller のコンテナ（別名）を運ばない→候補が `$x is rw` を
+    rebind しても caller `$v` に届かない。trivial proto は body を bypass し元の呼び出し args（コンテナ）で候補を直呼びするので動く。
+    修正は proto_dispatch_stack に caller コンテナ（or arg_sources）を運ぶ設計が要る。複数 `{*}` rvalue（`my $a={*}`）の Nil も
+    同系（rewrite が statement 位置のみ対応）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/
     `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）。
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,31 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### 非trivial proto body の VM 化（§D multi-dispatch・#3550 / #3552）
+
+`proto foo($x) { say "x"; {*} }` のような **本体を持つ proto** はこれまで proto body 全体を
+tree-walking interpreter（`eval_block_value`）で実行していた（実測 100% fallback）。2 スライスで VM 化:
+
+- **① proto body の compiled 実行（#3550）**: `vm_try_run_nontrivial_proto_body` を `dispatch_func_call_inner`
+  の proto fork（trivial 解決の次）に追加。`{*}`→`__PROTO_DISPATCH__()` rewrite した body を
+  `otf_compile_function_def`（`compile_and_call_function_def` から抽出した共通ヘルパー）＋
+  `call_compiled_function_named` で compiled 実行。proto body は dispatcher であり candidate ではないので
+  multi-dispatch frame は push せず、`proto_dispatch_stack` のみ push/pop（新 accessor・args=ORIGINAL proto
+  args で interpreter `call_proto_function` と一致）。gate=proto sig + `def_is_otf_compilable` + 非`state`。
+  非適格 proto（class/role/start body・default/where/code-param sig）は interpreter fallback 維持。
+- **② 候補ディスパッチの VM 化（#3552）**: `dispatch_func_call_inner` 冒頭で `__PROTO_DISPATCH__` を intercept→
+  `vm_call_proto_dispatch` で winner（`resolve_proto_candidate_with_types`）を `compile_and_call_function_def`
+  で OTF 実行（trivial fork と同一経路）。候補本体＋`nextsame`/`callsame`/`samewith` 再ディスパッチが VM-native に。
+  proto-method（method_ctx）/no-match/ambiguity/empty-sig-with-args/非OTF/state は interpreter
+  `call_proto_dispatch`（`pub(crate)` 化）に委譲（X::Multi::NoMatch/Ambiguous 生成と proto_method_skip は interpreter 所有）。
+  builtin-shadow hazard 非該当（候補名=proto名 multi 持ち→`otf_call_cache` insert skip）。
+
+実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks **50.1%→0.5%**（`__PROTO_DISPATCH__` 188→0）。
+pin=`t/proto-nontrivial-body-vm.t`(13) / `t/proto-candidate-otf-dispatch.t`(7)。proto-含む roast 24 本の失敗数が
+main と完全一致（回帰ゼロ）。**残る別軸**＝`is rw` proto-param writeback（`inc($v)`→10・main/①/② 全て同一）は
+`proto_dispatch_stack` args が caller のコンテナ（別名）でなく proto の original 値を運ぶため伝播しない深い問題
+（interpreter path でも同様に壊れている・trivial proto は body を bypass し元 args 直呼びなので動く）。
+
 ### ネストクラスを属性型に使えるよう修正 → Template::Mustache 復活（PLAN §H）
 
 属性の型にネストクラスを使うと構築時に解決失敗していたバグを修正:


### PR DESCRIPTION
Doc-only follow-up to #3550 / #3552.

- Moves the two completed non-trivial-proto-body VM-ization slices out of `PLAN.md` into `news/2026-06.md` (PLAN holds future work only, per the planning convention).
- Condenses §D to a one-line completed reference with the real PR numbers (was `#TBD`).
- Promotes the remaining `is rw`-through-non-trivial-proto-body writeback gap to the next open slice, with the root cause (the proto-dispatch frame carries the proto's original arg *values*, not the caller's containers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)