### PR TITLE
fix(types): resolve short-name import alias for `my ImportedClass:D` constraints

### DIFF
--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -254,6 +254,30 @@ impl Interpreter {
 
     /// Check if a type name is known (either a class, role, or enum).
     pub(crate) fn has_type(&self, name: &str) -> bool {
+        if self.has_type_direct(name) {
+            return true;
+        }
+        // A short-name import alias (`use Foo; my Bar:D $x` where `Bar` is
+        // `Foo::Bar`) is recorded in `env` as a `Value::Package` pointing at the
+        // fully-qualified class. Resolve that alias so the short name counts as a
+        // type — otherwise `my Bar:D $x` is wrongly rejected as a bare package
+        // ("insufficiently type-like") inside a method OTF-compiled in the
+        // importing module's scope. Humming-Bird's `Route.CALL-ME` does
+        // `my Response:D $res = ...` with `Response` imported from
+        // `Humming-Bird::Glue`.
+        if let Some(Value::Package(target)) = self.env.get(name) {
+            let resolved = target.resolve();
+            if resolved != name && self.has_type_direct(&resolved) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// `has_type` without short-name alias resolution — checks the type
+    /// registries directly (classes/roles/enums/subsets, including parametric
+    /// base names).
+    fn has_type_direct(&self, name: &str) -> bool {
         self.registry().classes.contains_key(name)
             || self.registry().roles.contains_key(name)
             || self.registry().enum_types.contains_key(name)

--- a/t/imported-class-definite-type.t
+++ b/t/imported-class-definite-type.t
@@ -1,0 +1,49 @@
+use v6;
+use lib $?FILE.IO.parent.add('lib');
+use Test;
+use ImportedDefiniteType;
+
+plan 6;
+
+# An imported class used as a `:D`-smiley type constraint on a `my` variable
+# must be recognized as a type (it is registered under its qualified name
+# `ImportedDefiniteType::Widget` while the importing scope refers to it by the
+# short alias `Widget`). Regression: this threw
+# X::Syntax::Variable::BadType "Package 'Widget:D' is insufficiently type-like".
+{
+    my Widget:D $w = Widget.new(size => 3);
+    is $w.area, 9, 'my ImportedClass:D in main scope';
+}
+
+# The short name is an alias to the qualified class.
+is Widget.^name, 'ImportedDefiniteType::Widget', 'imported class keeps its qualified name';
+
+# The same `my ImportedClass:D` inside a method that is dispatched (and thus
+# compiled) lazily — the Humming-Bird Route.CALL-ME shape.
+class Holder {
+    has &.cb is required;
+    method CALL-ME($given?) {
+        my Widget:D $w = $given // Widget.new(size => 4);
+        &!cb($w);
+    }
+}
+{
+    my $h = Holder.new(cb => -> $w { $w.area });
+    is $h(), 16, 'my ImportedClass:D inside a CALL-ME method';
+    is $h(Widget.new(size => 5)), 25, 'CALL-ME with an explicit instance';
+}
+
+# `:D` enforcement still applies (a type object is rejected).
+{
+    my $threw = False;
+    { my Widget:D $w = Widget; CATCH { default { $threw = True } } }
+    ok $threw, ':D smiley still rejects a type object for an imported class';
+}
+
+# A genuinely-unknown type is still rejected.
+{
+    my $threw = False;
+    { ::('NoSuchType123'); my $x; CATCH { default { $threw = True } } }
+    # (the ::() lookup itself throws for an undeclared type)
+    ok $threw, 'unknown type name still errors';
+}

--- a/t/lib/ImportedDefiniteType.rakumod
+++ b/t/lib/ImportedDefiniteType.rakumod
@@ -1,0 +1,10 @@
+use v6;
+unit module ImportedDefiniteType;
+
+# A class declared inside a module: its `.^name` is qualified
+# (`ImportedDefiniteType::Widget`), and the importing scope sees it under the
+# short alias `Widget`.
+class Widget is export {
+    has Int $.size = 0;
+    method area { $!size * $!size }
+}


### PR DESCRIPTION
## Summary

A class declared inside a module has a qualified `.^name` (e.g. `Foo::Bar`) and is registered in the type registry under that qualified name. The importing scope refers to it by the short alias `Bar`, recorded in `env` as a `Value::Package` pointing at the qualified class.

`has_type("Bar")` only checked the registries directly, so it returned **false** for the short alias while `is_declared_package("Bar")` returned **true** — making `my Bar:D $x = ...` wrongly throw:

```
X::Syntax::Variable::BadType: Package 'Bar:D' is insufficiently type-like to qualify a variable. Did you mean 'class'?
```

This blocked **Humming-Bird**'s `Route.CALL-ME`, which does `my Response:D $res = ...` with `Response` imported from `Humming-Bird::Glue`. The method is compiled lazily on first dispatch, in the importing module's scope, so only the short alias is visible.

## Fix

`has_type` now falls back to resolving a short-name `env` `Value::Package` alias to its qualified target and re-checking the registries.

## Test

`make test` passes (no regressions). New `t/imported-class-definite-type.t` (+ `t/lib/ImportedDefiniteType.rakumod`): the `:D` constraint works in main scope and inside a lazily-compiled `CALL-ME` method, `:D` still rejects a type object, and unknown type names still error. Whitelisted type/signature/class/role roast tests verified locally (133/0).

Follow-up to #3549 / #3551. With this, Humming-Bird's request handler runs end to end (the remaining serving gap is unrelated: user-defined `method sink` is not invoked on a bare statement in sink context, which HTTP::Status relies on to build its status table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)