### PR TITLE
feat(multi-dispatch): {*} rw-redispatch chains candidate writes through proto param (§D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -178,21 +178,22 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     `proto foo($x){ say "x"; {*} }` の body＋`{*}` 候補ディスパッチを両方 compiled 実行（`vm_try_run_nontrivial_proto_body`
     ＋`vm_call_proto_dispatch`）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%。
     pin=`t/proto-nontrivial-body-vm.t`(13)/`t/proto-candidate-otf-dispatch.t`(7)。
-  - [ ] **`{*}` を proto の現在パラメータで再ディスパッチ（次スライス・別軸・semantic fix）**: `proto pr($x is rw){ $x=99; {*} }`/
-    `multi pr(Int $x is rw){ $x=$x+1 }` で `pr($v)`（$v=10）が raku=**100**（候補は body が変異した `$x`=99 を見て 100 を書き $v に伝播）
-    に対し mutsu=**99**（候補の書き込みが失われる）。真因＝raku の `{*}` は proto の**現在の（body で変異済・別名保持の）パラメータ**で
-    再ディスパッチするが、mutsu は `proto_dispatch_stack` に保存した**入口時の original args（値）**を候補に渡す→候補は caller `$v` の
-    コンテナへの別名を得られず rw write が消える。修正＝`vm_call_proto_dispatch`（と interpreter `call_proto_dispatch`）が proto の
-    param 名から現フレームの**現在のコンテナ値**を読んで候補へ渡す。trivial proto は body を bypass し元の呼び出し args（コンテナ）
-    で候補を直呼びするので元から動く。複数 `{*}` rvalue（`my $a={*}`）の Nil は別系（rewrite が statement 位置のみ対応）。
-    **★試行で判明（2026-06-24・破棄済）= 「env[param 名] の値を読むだけ」では不成立**: 候補の rw が効くには引数が **varref コンテナ**
-    （proto の `$x` slot への別名）である必要があり（`vm_call_dispatch.rs:925` `arg_is_container_value`/`plain_container_with_source`）、
-    `env().get("x")` の返すプレーン値では候補が proto `$x` を別名参照できない（`helper($x)` 伝播は arg_sources 経由の name-based
-    writeback でコンテナ別名ではない）。∴ 正しい修正は **proto 現在パラメータを varref コンテナとして構築 or arg_sources=proto param 名を
-    `set_pending_call_arg_sources` で候補へ渡し name-based writeback を proto frame env 経由で caller までチェーンさせる**＝§C
-    container-identity substrate と絡む（当初想定より重い）。VM（`vm_call_proto_dispatch`）/ interpreter（`call_proto_dispatch`）両 path 要修正。
+  - [x] **`{*}` を proto の現在パラメータで再ディスパッチ（scalar rw/raw proto sub）= 完了（#TBD）→ [news/2026-06.md](news/2026-06.md)**。
+    `proto pr($x is rw){ $x=99; {*} }`/`multi pr(Int $x is rw){ $x=$x+1 }` で `pr($v)`（$v=10）が raku=**100** に対し mutsu=**99**
+    （候補が body 変異済 `$x`=99 を見ず・候補の rw write が消える）だった。**★前回「§C varref container と絡む（重い）」と分類したが
+    arg_sources 機構で解決可と判明（terminator 同型の誤分類）**。修正＝`vm_call_proto_dispatch` に `proto_rw_redispatch_args`:
+    proto が scalar rw/raw positional param を持つ simple-positional sig のとき、`{*}` 時点の **proto param 現在値を live body locals
+    （`code.locals` slot・scalar rw param は mid-body slot-only で env 未 flush）から読んで rebuild**＋**arg_sources=proto param 名**を
+    resolution 前に `set_pending_call_arg_sources`。候補の `is rw` は plain 値でも arg_sources で writability チェックを通り
+    （`args_matching.rs:211` `has_arg_source`）、候補の writeback が proto frame env `$x` に着地→`__PROTO_DISPATCH__` call-site の
+    `apply_pending_rw_writeback` が proto body locals に書き戻し→proto exit の `apply_rw_bindings_to_env` が caller `$v` へ伝播。
+    pin=`t/proto-rw-redispatch-coherence.t`(9・proto param 名≠候補名/二項目 rw/is raw/非rw proto 不変 含む)。
+    **残ギャップ（別軸・本 PR 範囲外）**: ①**proto method** の rw redispatch（method_ctx は interpreter `call_proto_dispatch` に落ち
+    pre-existing で壊れる・要 interpreter path 同型修正）②**nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ
+    渡る際の rw write は multi_dispatch_stack 別機構で消える・C ケース 40→41 改善も 1041 には未達）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/
-    `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）。
+    `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）/
+    proto **method** rw redispatch（interpreter path）/ nextsame+rw チェーン（上記 ①②）。
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -37,6 +37,34 @@ main と完全一致（回帰ゼロ）。**残る別軸**＝`is rw` proto-param 
 `proto_dispatch_stack` args が caller のコンテナ（別名）でなく proto の original 値を運ぶため伝播しない深い問題
 （interpreter path でも同様に壊れている・trivial proto は body を bypass し元 args 直呼びなので動く）。
 
+### `{*}` rw-redispatch — 候補が body 変異済 proto param を見て書き戻す（§D multi-dispatch follow-up）
+
+上記「残る別軸」だった `is rw` proto-param writeback を解決。`proto pr($x is rw){ $x=99; {*} }` /
+`multi pr(Int $x is rw){ $x=$x+1 }` で `pr($v)`（$v=10）が raku=**100**（候補は body が変異した `$x`=99 を見て
+100 を書き $v に伝播）に対し mutsu=**99**（候補が body 変異を見ず・候補の rw write が消える）だった。
+
+**★当初「§C varref container substrate と絡む（当初想定より重い）」と分類していたが、誤分類だった**（terminator が
+「parser auto-curly」と誤分類され実体は EVAL writeback だったのと同型）。実体は arg_sources 機構で解決可能:
+
+- `vm_call_proto_dispatch` に `proto_rw_redispatch_args` ヘルパーを追加。proto が **scalar `is rw`/`is raw`
+  positional param** を持つ simple-positional sig のとき、`{*}` 時点の proto param の**現在値**を rebuild する。
+  scalar rw param は mid-body は **slot-only**（env 未 flush）なので、live body locals（`dispatch_func_call_inner`
+  が持つ proto body `code.locals` の slot）から読む。
+- 同時に **arg_sources = proto param 名** を resolution 前に `set_pending_call_arg_sources`。候補の `is rw` は
+  rebuild した plain 値でも arg_sources があれば multi-dispatch の writability チェックを通る
+  （`args_matching.rs:211` `has_arg_source`・named source は VarRef と同等）。
+- 結果、候補の rw writeback が **proto frame env の `$x`** に着地→`__PROTO_DISPATCH__` call-site の
+  `apply_pending_rw_writeback` が proto body locals に書き戻し→proto exit の `apply_rw_bindings_to_env` が
+  proto の rw binding（proto `$x`→caller `$v`）で `$v` まで伝播。チェーン: 候補 → proto param → caller。
+
+gate は scalar rw/raw param を持つ proto のみ（非 rw proto は完全不変）。pin=`t/proto-rw-redispatch-coherence.t`(9)
+＝proto param 名≠候補名（位置別名）/ 非先頭 positional rw / `is raw` / body 非変異 / 候補非変異 / 非 rw proto 不変。
+
+**残ギャップ（別軸・本スライス範囲外）**: ①**proto method** の rw redispatch（`method_ctx` は interpreter
+`call_proto_dispatch` に落ち pre-existing で壊れている・interpreter path 同型修正が要）②**nextsame+rw チェーン**
+（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は `multi_dispatch_stack` 別機構で消える・
+2 候補ケースが 40→41 改善も raku=1041 には未達）。
+
 ### ネストクラスを属性型に使えるよう修正 → Template::Mustache 復活（PLAN §H）
 
 属性の型にネストクラスを使うと構築時に解決失敗していたバグを修正:

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -900,7 +900,7 @@ impl Interpreter {
             // marker rewritten by `rewrite_proto_dispatch_stmts`. Resolve and run
             // the winning multi candidate VM-natively (compiled bytecode) instead
             // of bouncing through interpreter `call_proto_dispatch` + `run_block`.
-            return self.vm_call_proto_dispatch(compiled_fns);
+            return self.vm_call_proto_dispatch(code, compiled_fns);
         }
         if let Some(callable) = call_me_override {
             let result = self.try_compiled_method_or_interpret(callable, "CALL-ME", args);
@@ -1324,6 +1324,7 @@ impl Interpreter {
     /// a non-OTF-compilable / `state`-declaring candidate.
     pub(super) fn vm_call_proto_dispatch(
         &mut self,
+        code: &CompiledCode,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
         let Some((proto_name, args, method_ctx)) = self.proto_dispatch_last() else {
@@ -1338,16 +1339,131 @@ impl Interpreter {
         // Clear any stale pending dispatch error (mirrors the trivial-proto fork)
         // so a prior call's ambiguity can't leak into this resolution.
         let _ = self.take_pending_dispatch_error();
+        // `{*}` rw-redispatch (ledger §D): when the proto declares a scalar
+        // `is rw`/`is raw` parameter, Rakudo redispatches `{*}` using the proto's
+        // CURRENT (body-mutated) parameter, so a candidate's own rw write chains
+        // back through the proto parameter to the caller. Rebuild the args from
+        // the proto's current parameter values (live body locals) and pass
+        // arg_sources naming the proto params, so the candidate's writeback lands
+        // in the proto frame and the proto's own rw binding propagates it to the
+        // caller at proto exit. `None` => unchanged (the common non-rw case).
+        let (args, rw_arg_sources) =
+            match self.proto_rw_redispatch_args(&proto_name, &args, Some(code)) {
+                Some((rebuilt, sources)) => (rebuilt, Some(sources)),
+                None => (args, None),
+            };
+        // For rw redispatch the rebuilt args are plain values; a candidate's
+        // `is rw` param requires a *writable* argument, which the multi-dispatch
+        // writability check satisfies from `pending_call_arg_sources` (a named
+        // source is as good as a VarRef). Set it before resolving so the rw
+        // candidate matches, and clear it again on any interpreter fallthrough.
+        let had_rw_sources = rw_arg_sources.is_some();
+        if had_rw_sources {
+            self.set_pending_call_arg_sources(rw_arg_sources);
+        }
         if let Some(def) = self.resolve_proto_candidate_with_types(&proto_name, &args)
             && (!def.empty_sig || args.is_empty())
             && Self::def_is_otf_compilable(&def)
             && !Self::function_body_declares_state(&def.body)
         {
-            return self.compile_and_call_function_def(&def, args, compiled_fns);
+            // pending_call_arg_sources is still set (resolution only reads it);
+            // `compile_and_call_function_def`'s bind consumes it for the rw chain.
+            let result = self.compile_and_call_function_def(&def, args, compiled_fns);
+            if had_rw_sources {
+                self.set_pending_call_arg_sources(None);
+            }
+            return result;
         }
         // No candidate / ambiguous / empty-sig-with-args / non-OTF / state: the
         // interpreter re-resolves and produces the exact error or tree-walk result.
+        if had_rw_sources {
+            self.set_pending_call_arg_sources(None);
+        }
         self.loan_env_for(|i| i.call_proto_dispatch())
+    }
+
+    /// `{*}` rw-redispatch helper (ledger §D, multi-dispatch VM-ization): Rakudo
+    /// redispatches `{*}` using the proto's CURRENT parameter, so a candidate's
+    /// own `is rw` write chains back through the (possibly body-mutated) proto
+    /// parameter to the caller's container. mutsu instead passes the proto's
+    /// entry-time args, so a candidate's rw write either targets the caller
+    /// directly (colliding with the proto's own writeback) or is lost.
+    ///
+    /// When the proto declares a scalar `is rw`/`is raw` positional parameter and
+    /// its signature is a simple all-positional one, return rebuilt args (read
+    /// from the proto's current parameter values — the live body locals when
+    /// `code` is given, else env) and arg_sources naming the proto params, so the
+    /// candidate binds its rw param with `source = <proto param>` and its
+    /// writeback lands in the proto frame. Returns `None` (no rebuild, current
+    /// behavior) for protos without a scalar rw/raw param or with a non-simple
+    /// signature.
+    pub(crate) fn proto_rw_redispatch_args(
+        &self,
+        proto_name: &str,
+        orig_args: &[Value],
+        code: Option<&CompiledCode>,
+    ) -> Option<(Vec<Value>, Vec<Option<String>>)> {
+        let proto = self.resolve_proto_function(proto_name)?;
+        let positional: Vec<&crate::ast::ParamDef> = proto
+            .param_defs
+            .iter()
+            .filter(|pd| !pd.is_invocant)
+            .collect();
+        // Only a simple all-positional signature with arity matching the call.
+        if positional.len() != orig_args.len()
+            || positional.iter().any(|pd| {
+                pd.named || pd.slurpy || pd.double_slurpy || pd.onearg || pd.sub_signature.is_some()
+            })
+            || orig_args.iter().any(|a| {
+                matches!(
+                    crate::runtime::types::unwrap_varref_value(a.clone()),
+                    Value::Pair(..) | Value::ValuePair(..)
+                )
+            })
+        {
+            return None;
+        }
+        // A scalar param is stored sigil-less, so its name starts with an ASCII
+        // letter / `_` (not `@`/`%`/`&`). Require at least one scalar rw/raw param
+        // — the only case where the current value differs or a writeback link is
+        // needed; `@`/`%` rw params propagate in-place by name already.
+        let is_scalar_rw = |pd: &crate::ast::ParamDef| {
+            pd.traits.iter().any(|t| t == "rw" || t == "raw")
+                && pd.name != "_"
+                && pd
+                    .name
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+        };
+        if !positional.iter().any(|pd| is_scalar_rw(pd)) {
+            return None;
+        }
+        let mut new_args = Vec::with_capacity(positional.len());
+        let mut sources = Vec::with_capacity(positional.len());
+        for (pd, orig) in positional.iter().zip(orig_args.iter()) {
+            if is_scalar_rw(pd) {
+                // Rebuild from the proto's CURRENT parameter value: a scalar rw
+                // param is slot-only mid-body (not yet flushed to env), so read
+                // the live body local slot first, then env, then the entry-time
+                // arg as a last resort. arg_sources names the proto param so the
+                // candidate's writeback chains back through it.
+                let cur = code
+                    .and_then(|c| c.locals.iter().position(|n| n == &pd.name))
+                    .map(|slot| self.locals[slot].clone())
+                    .or_else(|| self.env().get(&pd.name).cloned())
+                    .unwrap_or_else(|| crate::runtime::types::unwrap_varref_value(orig.clone()));
+                new_args.push(crate::runtime::types::unwrap_varref_value(cur));
+                sources.push(Some(pd.name.clone()));
+            } else {
+                // Non-rw params keep their original argument (a VarRef / container
+                // carries the caller's aliasing for `@`/`%`/`is raw`-by-name
+                // params); rebuilding to a plain current value would sever it.
+                new_args.push(orig.clone());
+                sources.push(None);
+            }
+        }
+        Some((new_args, sources))
     }
 
     pub(super) fn def_is_otf_compilable(def: &crate::ast::FunctionDef) -> bool {

--- a/t/proto-rw-redispatch-coherence.t
+++ b/t/proto-rw-redispatch-coherence.t
@@ -1,0 +1,75 @@
+use Test;
+
+# `{*}` rw-redispatch (ledger §D, multi-dispatch VM-ization): Rakudo redispatches
+# `{*}` using the proto's CURRENT (body-mutated) parameter, so a candidate's own
+# `is rw` write chains back through the proto parameter to the caller's container.
+# Regression pin: previously mutsu passed the proto's entry-time args to the
+# candidate, so the body mutation was invisible to the candidate and the
+# candidate's rw write was lost.
+
+plan 9;
+
+# 1. proto body mutates rw param, candidate adds to it
+{
+    proto pr($x is rw) { $x = 99; {*} }
+    multi pr(Int $x is rw) { $x = $x + 1 }
+    my $v = 10; pr($v);
+    is $v, 100, 'proto body mutation visible to candidate, candidate write propagates';
+}
+
+# 2. proto param name differs from candidate param name (positional alias)
+{
+    proto pr($a is rw) { $a = 50; {*} }
+    multi pr(Int $b is rw) { $b = $b * 2 }
+    my $v = 5; pr($v);
+    is $v, 100, 'redispatch aliases by position, not by name';
+}
+
+# 3. no body mutation; candidate mutates from caller value
+{
+    proto pr($x is rw) { {*} }
+    multi pr(Int $x is rw) { $x = $x + 7 }
+    my $v = 3; pr($v);
+    is $v, 10, 'candidate rw write propagates without body mutation';
+}
+
+# 4. candidate does not mutate; proto body mutation still wins
+{
+    proto pr($x is rw) { $x = 77; {*} }
+    multi pr(Int $x is rw) { $x }
+    my $v = 1; pr($v);
+    is $v, 77, 'proto body mutation survives a non-mutating candidate';
+}
+
+# 5. two positional params, second is rw
+{
+    proto pr($a, $b is rw) { $b = $b + 100; {*} }
+    multi pr(Int $a, Int $b is rw) { $b = $b + $a }
+    my $v = 5; pr(3, $v);
+    is $v, 108, 'rw chains for a non-leading positional rw param';
+}
+
+# 6. is raw param
+{
+    proto pr($x is raw) { $x = 20; {*} }
+    multi pr(Int $x is raw) { $x = $x + 5 }
+    my $v = 1; pr($v);
+    is $v, 25, 'is raw param chains like is rw';
+}
+
+# 7. candidate computes via a temporary, then assigns
+{
+    proto pr($x is rw) { $x = 7; {*} }
+    multi pr(Int $x is rw) { my $t = $x * 2; $x = $t }
+    my $v = 1; pr($v);
+    is $v, 14, 'candidate write through a temporary still propagates';
+}
+
+# 8. non-rw proto is unchanged (no spurious writeback)
+{
+    proto nn($x) { {*} }
+    multi nn(Int $x) { $x + 1 }
+    my $v = 41;
+    is nn($v), 42, 'non-rw proto returns candidate value';
+    is $v, 41, 'non-rw proto does not mutate the caller variable';
+}


### PR DESCRIPTION
## Summary

`proto pr(\$x is rw) { \$x = 99; {*} }` / `multi pr(Int \$x is rw) { \$x = \$x + 1 }`
called as `pr(\$v)` (\$v=10) gave **99** in mutsu but **100** in Rakudo: the
candidate neither saw the proto body's mutation (`\$x`=99) nor propagated its own
`is rw` write back to the caller.

Rakudo redispatches `{*}` using the proto's **current** (body-mutated) parameter,
so a candidate's own `is rw` write chains back through the proto parameter to the
caller. mutsu instead passed the proto's entry-time args, so the body mutation was
invisible and the candidate's rw write collided with the proto's own writeback (or
was lost).

## Fix

`vm_call_proto_dispatch` now, for a proto with a scalar `is rw`/`is raw`
positional parameter:

1. rebuilds that arg from the proto's **current** value — read from the live body
   local slot (a scalar rw param is slot-only mid-body, not flushed to env);
2. sets `arg_sources` naming the proto param before resolution, so the candidate's
   `is rw` param matches against the named source even from a plain value (the
   multi-dispatch writability check accepts a named `arg_source` like a `VarRef`).

The candidate's writeback then lands in the proto frame; `apply_pending_rw_writeback`
at the `__PROTO_DISPATCH__` call site refreshes the proto body local, and the
proto's own rw binding propagates the final value to the caller at proto exit.
Chain: candidate → proto param → caller. Non-rw params keep their original
(aliasing) argument; non-rw protos are completely unchanged.

This was previously recorded (#3554) as needing the §C varref-container substrate;
it turned out tractable via the existing `arg_sources` name-based writeback
mechanism (a terminator-style misdiagnosis — see PLAN/news).

## Remaining gaps (separate axes, out of scope)

- proto **method** rw redispatch (the `method_ctx` path falls to the interpreter
  `call_proto_dispatch`, where it is pre-existing-broken);
- **nextsame+rw** chaining (the next candidate is reached via `multi_dispatch_stack`,
  a separate path; the 2-candidate case improves 40→41 but not to Rakudo's 1041).

## Tests

- pin `t/proto-rw-redispatch-coherence.t` (9): proto-param-name ≠ candidate-name
  (positional alias), non-leading positional rw, `is raw`, body-no-mutation,
  candidate-no-mutation, non-rw proto unchanged.
- `make test` green locally (Files=1126, Tests=11319, Result: PASS); all proto/multi
  pins pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)