### PR TITLE
feat(multi-dispatch): {*} rw-redispatch for proto methods (§D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -178,22 +178,22 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     `proto foo($x){ say "x"; {*} }` の body＋`{*}` 候補ディスパッチを両方 compiled 実行（`vm_try_run_nontrivial_proto_body`
     ＋`vm_call_proto_dispatch`）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%。
     pin=`t/proto-nontrivial-body-vm.t`(13)/`t/proto-candidate-otf-dispatch.t`(7)。
-  - [x] **`{*}` を proto の現在パラメータで再ディスパッチ（scalar rw/raw proto sub）= 完了（#TBD）→ [news/2026-06.md](news/2026-06.md)**。
+  - [x] **`{*}` を proto の現在パラメータで再ディスパッチ（scalar rw/raw・proto sub #3556 / proto method #TBD）= 完了 → [news/2026-06.md](news/2026-06.md)**。
     `proto pr($x is rw){ $x=99; {*} }`/`multi pr(Int $x is rw){ $x=$x+1 }` で `pr($v)`（$v=10）が raku=**100** に対し mutsu=**99**
     （候補が body 変異済 `$x`=99 を見ず・候補の rw write が消える）だった。**★前回「§C varref container と絡む（重い）」と分類したが
-    arg_sources 機構で解決可と判明（terminator 同型の誤分類）**。修正＝`vm_call_proto_dispatch` に `proto_rw_redispatch_args`:
-    proto が scalar rw/raw positional param を持つ simple-positional sig のとき、`{*}` 時点の **proto param 現在値を live body locals
-    （`code.locals` slot・scalar rw param は mid-body slot-only で env 未 flush）から読んで rebuild**＋**arg_sources=proto param 名**を
-    resolution 前に `set_pending_call_arg_sources`。候補の `is rw` は plain 値でも arg_sources で writability チェックを通り
-    （`args_matching.rs:211` `has_arg_source`）、候補の writeback が proto frame env `$x` に着地→`__PROTO_DISPATCH__` call-site の
-    `apply_pending_rw_writeback` が proto body locals に書き戻し→proto exit の `apply_rw_bindings_to_env` が caller `$v` へ伝播。
-    pin=`t/proto-rw-redispatch-coherence.t`(9・proto param 名≠候補名/二項目 rw/is raw/非rw proto 不変 含む)。
-    **残ギャップ（別軸・本 PR 範囲外）**: ①**proto method** の rw redispatch（method_ctx は interpreter `call_proto_dispatch` に落ち
-    pre-existing で壊れる・要 interpreter path 同型修正）②**nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ
-    渡る際の rw write は multi_dispatch_stack 別機構で消える・C ケース 40→41 改善も 1041 には未達）。
+    arg_sources 機構で解決可と判明（terminator 同型の誤分類）**。修正＝`proto_rw_redispatch_args`（proto param_defs を取る）:
+    proto が scalar rw/raw fixed-positional param を持つとき（`%_`/`@_` catch-all は除外）、`{*}` 時点の **proto param 現在値**を
+    rebuild（VM sub=live body locals〔scalar rw param は mid-body slot-only で env 未 flush〕／interpreter method=env）＋
+    **arg_sources=proto param 名**を resolution 前に `set_pending_call_arg_sources`。候補の `is rw` は plain 値でも arg_sources で
+    writability チェックを通り（`args_matching.rs:211` `has_arg_source`）、候補の writeback が proto frame に着地→call-site の
+    writeback drain→proto exit の `apply_rw_bindings_to_env` が caller へ伝播。VM sub=`vm_call_proto_dispatch`（#3556）／
+    interpreter proto method=`call_proto_dispatch` の method_ctx 分岐（#TBD・`lookup_proto_method` で proto def 解決）。
+    pin=`t/proto-rw-redispatch-coherence.t`(9・sub) / `t/proto-method-rw-redispatch.t`(5・method)。
+    **残ギャップ（別軸）**: **nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は
+    `multi_dispatch_stack` 別機構で消える・2 候補ケース 40→41 改善も raku=1041 未達）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/
     `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）/
-    proto **method** rw redispatch（interpreter path）/ nextsame+rw チェーン（上記 ①②）。
+    nextsame+rw チェーン（上記）。
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -60,10 +60,17 @@ main と完全一致（回帰ゼロ）。**残る別軸**＝`is rw` proto-param 
 gate は scalar rw/raw param を持つ proto のみ（非 rw proto は完全不変）。pin=`t/proto-rw-redispatch-coherence.t`(9)
 ＝proto param 名≠候補名（位置別名）/ 非先頭 positional rw / `is raw` / body 非変異 / 候補非変異 / 非 rw proto 不変。
 
-**残ギャップ（別軸・本スライス範囲外）**: ①**proto method** の rw redispatch（`method_ctx` は interpreter
-`call_proto_dispatch` に落ち pre-existing で壊れている・interpreter path 同型修正が要）②**nextsame+rw チェーン**
-（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は `multi_dispatch_stack` 別機構で消える・
-2 候補ケースが 40→41 改善も raku=1041 には未達）。
+**フォローアップ＝proto method にも拡張（同セッション）**: 当初「残ギャップ①」とした **proto method** の rw redispatch も
+同機構で解決。proto method は `method_ctx` 経由で interpreter `call_proto_dispatch` に落ちるが、そこでも引数自体が
+失われて `Cannot resolve caller m(C:D: )`（候補の `is rw` が plain 値を writable arg として拒否）になっていた。
+`proto_rw_redispatch_args` を **proto の param_defs を直接取る**形に一般化し、VM sub path（`resolve_proto_function`）と
+interpreter proto method path（`lookup_proto_method` で invocant class から proto def 解決）の両方から呼べるように。
+proto method は常に暗黙の `%_`（named catch-all）を持つので、fixed-positional param（`%_`/`@_`/slurpy/named を除外）で
+arity 判定する点が proto sub との差。interpreter method path は param を env に bind するので現在値は env から読む（`code=None`）。
+pin=`t/proto-method-rw-redispatch.t`(5)。
+
+**残ギャップ（別軸）**: **nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は
+`multi_dispatch_stack` 別機構で消える・2 候補ケースが 40→41 改善も raku=1041 には未達）。
 
 ### ネストクラスを属性型に使えるよう修正 → Template::Mustache 復活（PLAN §H）
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1544,7 +1544,29 @@ impl Interpreter {
         // candidate on the invocant. The one-shot `proto_method_skip` flag makes
         // the re-entry bypass proto interception so it reaches the real candidate.
         if let Some(ctx) = method_ctx {
+            // `{*}` rw-redispatch for a proto *method* (ledger §D): like the proto
+            // *sub* path (`vm_call_proto_dispatch`), Rakudo redispatches with the
+            // proto's CURRENT (body-mutated) parameter, and a candidate's `is rw`
+            // param needs a writable argument. The interpreter binds method params
+            // by name into env, so the current value lives in env (`code = None`).
+            // Rebuild the rw args + arg_sources so the candidate matches and its
+            // writeback chains back through the proto method param to the caller.
+            let invocant_class = match &ctx.invocant {
+                Value::Instance { class_name, .. } => Some(class_name.resolve()),
+                _ => None,
+            };
+            let (args, rw_sources) = match invocant_class
+                .and_then(|cn| self.lookup_proto_method(&cn, &proto_name))
+                .and_then(|(_, proto)| {
+                    self.proto_rw_redispatch_args(&proto.param_defs, &args, None)
+                }) {
+                Some((rebuilt, sources)) => (rebuilt, Some(sources)),
+                None => (args, None),
+            };
             self.proto_method_skip = Some(proto_name.clone());
+            if rw_sources.is_some() {
+                self.set_pending_call_arg_sources(rw_sources);
+            }
             return self.call_method_with_values(ctx.invocant, &proto_name, args);
         }
         self.clear_pending_dispatch_error();

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1347,11 +1347,13 @@ impl Interpreter {
         // arg_sources naming the proto params, so the candidate's writeback lands
         // in the proto frame and the proto's own rw binding propagates it to the
         // caller at proto exit. `None` => unchanged (the common non-rw case).
-        let (args, rw_arg_sources) =
-            match self.proto_rw_redispatch_args(&proto_name, &args, Some(code)) {
-                Some((rebuilt, sources)) => (rebuilt, Some(sources)),
-                None => (args, None),
-            };
+        let (args, rw_arg_sources) = match self
+            .resolve_proto_function(&proto_name)
+            .and_then(|proto| self.proto_rw_redispatch_args(&proto.param_defs, &args, Some(code)))
+        {
+            Some((rebuilt, sources)) => (rebuilt, Some(sources)),
+            None => (args, None),
+        };
         // For rw redispatch the rebuilt args are plain values; a candidate's
         // `is rw` param requires a *writable* argument, which the multi-dispatch
         // writability check satisfies from `pending_call_arg_sources` (a named
@@ -1399,21 +1401,30 @@ impl Interpreter {
     /// signature.
     pub(crate) fn proto_rw_redispatch_args(
         &self,
-        proto_name: &str,
+        proto_param_defs: &[crate::ast::ParamDef],
         orig_args: &[Value],
         code: Option<&CompiledCode>,
     ) -> Option<(Vec<Value>, Vec<Option<String>>)> {
-        let proto = self.resolve_proto_function(proto_name)?;
-        let positional: Vec<&crate::ast::ParamDef> = proto
-            .param_defs
+        // The fixed positional params: drop the invocant and the variadic /
+        // named catch-alls (a `proto method` always carries an implicit `%_`),
+        // so a simple positional signature still qualifies. We only rebuild when
+        // these fixed params exactly consume the call's positional args.
+        let positional: Vec<&crate::ast::ParamDef> = proto_param_defs
             .iter()
-            .filter(|pd| !pd.is_invocant)
-            .collect();
-        // Only a simple all-positional signature with arity matching the call.
-        if positional.len() != orig_args.len()
-            || positional.iter().any(|pd| {
-                pd.named || pd.slurpy || pd.double_slurpy || pd.onearg || pd.sub_signature.is_some()
+            .filter(|pd| {
+                !pd.is_invocant
+                    && !pd.named
+                    && !pd.slurpy
+                    && !pd.double_slurpy
+                    && !pd.onearg
+                    && pd.sub_signature.is_none()
+                    && pd.name != "%_"
+                    && pd.name != "@_"
             })
+            .collect();
+        // All args must be positional, and the fixed positional params must
+        // exactly consume them (no slurpy mopping up extras).
+        if positional.len() != orig_args.len()
             || orig_args.iter().any(|a| {
                 matches!(
                     crate::runtime::types::unwrap_varref_value(a.clone()),

--- a/t/proto-method-rw-redispatch.t
+++ b/t/proto-method-rw-redispatch.t
@@ -1,0 +1,60 @@
+use Test;
+
+# `{*}` rw-redispatch for a proto *method* (ledger §D, multi-dispatch): like the
+# proto *sub* case (t/proto-rw-redispatch-coherence.t), Rakudo redispatches `{*}`
+# using the proto's CURRENT (body-mutated) parameter, and a candidate's `is rw`
+# write must chain back through the proto method parameter to the caller.
+# Regression pin: previously the redispatch passed the entry-time value with no
+# arg_source, so the candidate's `is rw` param rejected it
+# ("Cannot resolve caller m(C:D: )") and the body mutation was lost.
+
+plan 5;
+
+# 1. proto method body mutates rw param, candidate adds to it
+{
+    class C1 {
+        proto method m($x is rw) { $x = 30; {*} }
+        multi method m(Int $x is rw) { $x = $x + 3 }
+    }
+    my $v = 1; C1.new.m($v);
+    is $v, 33, 'proto method body mutation visible to candidate; candidate write propagates';
+}
+
+# 2. proto method param name differs from candidate (positional alias)
+{
+    class C2 {
+        proto method m($a is rw) { $a = 10; {*} }
+        multi method m(Int $b is rw) { $b = $b * 5 }
+    }
+    my $v = 2; C2.new.m($v);
+    is $v, 50, 'redispatch aliases by position, not by name';
+}
+
+# 3. no body mutation; candidate mutates from caller value
+{
+    class C3 {
+        proto method m($x is rw) { {*} }
+        multi method m(Int $x is rw) { $x = $x + 9 }
+    }
+    my $v = 4; C3.new.m($v);
+    is $v, 13, 'candidate rw write propagates without body mutation';
+}
+
+# 4. non-rw proto method still returns the candidate value
+{
+    class C4 {
+        proto method m($x) { {*} }
+        multi method m(Int $x) { $x * 10 }
+    }
+    is C4.new.m(5), 50, 'non-rw proto method dispatches to candidate';
+}
+
+# 5. is raw proto method param
+{
+    class C5 {
+        proto method m($x is raw) { $x = 7; {*} }
+        multi method m(Int $x is raw) { $x = $x + 1 }
+    }
+    my $v = 1; C5.new.m($v);
+    is $v, 8, 'is raw proto method param chains like is rw';
+}


### PR DESCRIPTION
## Summary

Generalizes the proto-sub `{*}` rw-redispatch fix (#3556) to proto **methods**.

`class C { proto method m(\$x is rw) { \$x = 30; {*} }; multi method m(Int \$x is rw) { \$x = \$x + 3 } }`
called as `C.new.m(\$v)` (\$v=1) errored with `Cannot resolve caller m(C:D: )` in
mutsu but gives **33** in Rakudo. The proto-method `{*}` redispatch (interpreter
`call_proto_dispatch`, `method_ctx` path) passed the entry-time value with no
`arg_source`, so the candidate's `is rw` param rejected the plain value (and the
body mutation `\$x=30` was lost).

## Fix

`proto_rw_redispatch_args` now takes the proto's `param_defs` directly, so both
dispatch paths share it:

- VM proto-sub path (`vm_call_proto_dispatch`) resolves the proto via
  `resolve_proto_function`;
- interpreter proto-method path resolves it via `lookup_proto_method` on the
  invocant's class.

A proto method always carries an implicit `%_` (named catch-all), so the helper
now keys arity on the **fixed** positional params (excluding `%_`/`@_`/slurpy/
named) instead of rejecting any non-simple signature. The interpreter binds
method params by name into env, so the current value is read from env
(`code = None`); the VM reads the live body local slot. The candidate's `is rw`
then matches via the named `arg_source` and its writeback chains back through the
proto method parameter to the caller — exactly like the sub case.

## Remaining gap (separate axis)

`nextsame`+rw chaining through the `multi_dispatch_stack` (the next candidate is a
separate dispatch path).

## Tests

- pin `t/proto-method-rw-redispatch.t` (5): body mutation visible to candidate,
  proto-param-name ≠ candidate-name (positional alias), no-body-mutation, non-rw
  proto method, `is raw`.
- `make test` green locally (Files=1128, Tests=11330, Result: PASS); proto/multi
  pins all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)