### PR TITLE
feat(multi-dispatch): OTF-compile multi candidates with a &callback param (§D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -191,9 +191,13 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     pin=`t/proto-rw-redispatch-coherence.t`(9・sub) / `t/proto-method-rw-redispatch.t`(5・method)。
     **残ギャップ（別軸）**: **nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は
     `multi_dispatch_stack` 別機構で消える・2 候補ケース 40→41 改善も raku=1041 未達）。
+  - [x] **`&`-code param を持つ候補の OTF 化 = 完了（#TBD）→ [news/2026-06.md](news/2026-06.md)**。`def_is_otf_compilable` の
+    `!pd.name.starts_with('&')` ガードを撤去（`code_signature`〔`&cb:(Int)`〕と default 値の除外は維持）。`multi f(&cb){…}` 候補が
+    bare multi / proto 経由とも compiled 実行され interpreter fallback を解消（proto `&cb` 経由 25%→0%）。block literal / 引数付き
+    callback / `&name` 渡し / outer 変数を閉包する callback まで byte-identical（pin=`t/multi-amp-param-otf-dispatch.t`(8)）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ）/
-    `code_signature`・`&`-code param を持つ候補の OTF 化（依然除外）/ default-param OTF（上記 DEFERRED・builtin-shadow gate 要）/
-    nextsame+rw チェーン（上記）。
+    `code_signature`〔`&cb:(Int)`〕param を持つ候補の OTF 化（依然除外・別軸で `&cb:(Int)` vs `&cb` の resolution ambiguity も要）/
+    default-param OTF（上記 DEFERRED・builtin-shadow gate 要）/ nextsame+rw チェーン（上記）。
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -72,6 +72,17 @@ pin=`t/proto-method-rw-redispatch.t`(5)。
 **残ギャップ（別軸）**: **nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は
 `multi_dispatch_stack` 別機構で消える・2 候補ケースが 40→41 改善も raku=1041 には未達）。
 
+### `&`-code param を持つ multi 候補の OTF 化（§D multi-dispatch・fallback 解消）
+
+`multi f(&cb) { cb() + 1 }` のような **`&callback` パラメータを持つ multi 候補** は `def_is_otf_compilable` の
+`!pd.name.starts_with('&')` ガードで interpreter fallback に落ちていた（proto `&cb` 経由で実測 25% fallback）。
+このガードを撤去（`code_signature`〔`&cb:(Int)`〕と default 値の除外は維持）し、compiled 実行に。block literal /
+引数付き callback / `&name` 渡し / outer 変数を閉包する callback まで byte-identical（全ケース raku 一致）。
+bare multi・proto-dispatched 両経路で fallback 0%。pin=`t/multi-amp-param-otf-dispatch.t`(8)。
+
+★調査中に判明した無関係な落とし穴: `m` で始まる sub 名（`mc`/`mm`）に `{...}` を続けると `m:c//`/`m:m//`（match adverb +
+`{}` デリミタ）に誤パースされる（slang 衝突）。テスト命名で `m`-prefix を避ければよい（本 PR とは無関係の既存パーサ挙動）。
+
 ### ネストクラスを属性型に使えるよう修正 → Template::Mustache 復活（PLAN §H）
 
 属性の型にネストクラスを使うと構築時に解決失敗していたバグを修正:

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1488,10 +1488,18 @@ impl Interpreter {
         // (for single candidates), and merges the `&name` Sub's captured env so
         // a `where` referencing closure variables resolves them — byte-identical
         // to the interpreter fallback (ledger §D, multi-dispatch VM-ization).
+        //
+        // A `&callback` parameter is also NOT excluded: it binds and is invoked
+        // (`cb()`, `cb($x)`) exactly like any compiled local, including blocks,
+        // `&name`-passed subs, and closures over outer lexicals. Only a `&cb` with
+        // an explicit code signature (`&cb:(Int)`, `code_signature`) and a param
+        // with a default value stay excluded (the former still has a separate
+        // resolution-ambiguity gap; the latter is the deferred default-OTF case).
         !Self::function_body_needs_interpreter(&def.body)
-            && def.param_defs.iter().all(|pd| {
-                pd.default.is_none() && pd.code_signature.is_none() && !pd.name.starts_with('&')
-            })
+            && def
+                .param_defs
+                .iter()
+                .all(|pd| pd.default.is_none() && pd.code_signature.is_none())
     }
 
     /// Check if a function body contains constructs that require

--- a/t/multi-amp-param-otf-dispatch.t
+++ b/t/multi-amp-param-otf-dispatch.t
@@ -1,0 +1,50 @@
+use Test;
+
+# Multi candidates with a `&callback` parameter are now OTF-compiled (run as
+# compiled bytecode) instead of forced through the interpreter fallback (ledger
+# §D, multi-dispatch VM-ization). `def_is_otf_compilable` previously excluded any
+# param whose name starts with `&`; that exclusion is removed (params with a
+# *code signature* `&cb:(...)` or a default value remain excluded). This is a
+# fallback-elimination change: behavior is byte-identical, dispatch just no
+# longer bounces through the tree-walk interpreter.
+
+plan 8;
+
+# bare multi with a callback candidate (block literal is Callable)
+{
+    multi bb(&cb) { cb() + 1 }
+    multi bb(Int $x) { $x }
+    is bb({ 41 }), 42, 'bare multi &cb candidate runs the block';
+    is bb(7), 7, 'bare multi Int candidate still selected';
+}
+
+# callback called with arguments
+{
+    multi nn(&fn, Int $n) { fn($n) * 2 }
+    multi nn(Int $n) { $n }
+    is nn(-> $x { $x + 100 }, 5), 210, 'callback invoked with an argument';
+    is nn(9), 9, 'non-callback candidate still selected';
+}
+
+# a named sub passed by &name
+{
+    sub helper($x) { $x * 3 }
+    multi pp(&f) { f(4) }
+    is pp(&helper), 12, 'named sub passed by &name and invoked';
+}
+
+# callback closing over an outer variable
+{
+    my $base = 1000;
+    multi cc(&g) { g() + $base }
+    is cc({ 5 }), 1005, 'callback closes over outer lexical';
+}
+
+# proto-dispatched callback candidate
+{
+    proto pr(|) {*}
+    multi pr(&cb) { "cb:" ~ cb() }
+    multi pr(Int $x) { "int:$x" }
+    is pr({ 41 }), 'cb:41', 'proto-dispatched &cb candidate';
+    is pr(7), 'int:7', 'proto-dispatched Int candidate';
+}


### PR DESCRIPTION
## Summary

`def_is_otf_compilable` excluded any candidate with a parameter whose name starts
with `&`, forcing `multi f(&cb) { cb() + 1 }` candidates through the interpreter
fallback (measured **25%** function-call fallback for a proto-dispatched `&cb`
candidate). A `&callback` param binds and is invoked exactly like any compiled
local, so the exclusion is unnecessary.

## Fix

Remove the `!pd.name.starts_with('&')` guard. Params with an explicit code
signature (`&cb:(...)`) and params with a default value stay excluded (the former
has a separate resolution-ambiguity gap; the latter is the deferred default-OTF
case). `&cb` candidates now run as compiled bytecode in both bare-multi and
proto-dispatched paths — byte-identical, just no interpreter bounce.

Verified against Rakudo for: block literals, callbacks invoked with arguments,
named subs passed by `&name`, and callbacks closing over outer lexicals.

## Tests

- pin `t/multi-amp-param-otf-dispatch.t` (8)
- `make test` green locally (Files=1129, Tests=11338, Result: PASS); proto/multi
  pins all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)