### PR TITLE
feat: Humming-Bird web framework serves end-to-end on mutsu (4 fixes)

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -627,7 +627,7 @@ impl Compiler {
                     // sink expr -- evaluate, discard, push Nil
                     // SinkPop throws unhandled Failures
                     self.compile_expr(&args[0]);
-                    self.code.emit(OpCode::SinkPop);
+                    self.code.emit(OpCode::SinkPop(false));
                     self.code.emit(OpCode::LoadNil);
                 }
             }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -412,11 +412,30 @@ impl Compiler {
         Some(vec![decl, for_stmt, writeback])
     }
 
+    /// Whether a bare statement expression yields a syntactically fresh rvalue
+    /// (a method call / `Foo.new`) whose value may invoke a user-defined `sink`
+    /// method in sink context. Bare variables (`$x;`) and function-call returns
+    /// (`frob();`, possibly `is rw` → container) are excluded: Raku keeps those
+    /// container-wrapped and does not auto-sink them, and mutsu decontainerizes
+    /// before `SinkPop` so the two cases are indistinguishable at runtime.
+    fn stmt_value_may_user_sink(expr: &Expr) -> bool {
+        match expr {
+            Expr::MethodCall { .. } => true,
+            Expr::DoStmt(inner) => match inner.as_ref() {
+                // `do { ... }` carries the value of its last statement.
+                Stmt::Expr(e) => Self::stmt_value_may_user_sink(e),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
     pub(super) fn compile_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::Expr(expr) => {
                 self.compile_condition_expr(expr);
-                self.code.emit(OpCode::SinkPop);
+                self.code
+                    .emit(OpCode::SinkPop(Self::stmt_value_may_user_sink(expr)));
             }
             Stmt::Block(stmts) => {
                 // Check for placeholder conflicts in blocks
@@ -657,7 +676,7 @@ impl Compiler {
                     {
                         // Emit a Nil instead of the Var to avoid forcing.
                         self.code.emit(OpCode::LoadNil);
-                        self.code.emit(OpCode::SinkPop);
+                        self.code.emit(OpCode::SinkPop(false));
                         continue;
                     }
                     self.compile_stmt(s);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -401,8 +401,13 @@ pub(crate) enum OpCode {
     // -- Stack manipulation --
     Dup,
     Pop,
-    /// Pop with sink context — throws unhandled Failures when fatal_mode is active
-    SinkPop,
+    /// Pop with sink context — throws unhandled Failures when fatal_mode is active.
+    /// The bool is `true` when the sunk value is a syntactically fresh rvalue
+    /// (e.g. a method call / `Foo.new`) that may invoke a user-defined `sink`
+    /// method; `false` for bare variables / function-call returns whose values
+    /// are (or may be) container-wrapped and must not auto-sink (Raku does not
+    /// sink container-wrapped values).
+    SinkPop(bool),
     /// Peek the top of stack (without popping) and throw it if it is an
     /// unhandled Failure. Used at the tail of a try/CATCH body so a trailing
     /// `fail`/Failure value is thrown into the block's CATCH handler while a

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1122,7 +1122,7 @@ fn is_unspace_before_postfix(input: &str) -> bool {
 
 /// Parse expression listop arguments: comma-separated full expressions.
 /// Stops at statement modifiers, semicolons, and closing brackets.
-fn parse_expr_listop_args(input: &str, name: String) -> PResult<'_, Expr> {
+pub(in crate::parser) fn parse_expr_listop_args(input: &str, name: String) -> PResult<'_, Expr> {
     if name == "make" {
         // Use expression_no_sequence so that `make X => Y` parses the entire
         // Pair as the argument (fat-arrow has lower precedence than or_expr).

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -607,6 +607,16 @@ pub(super) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
         ));
     }
 
+    // `foo: args` where `foo` is a declared subroutine is a colon-listop call,
+    // not a label (Raku: `trim: "x"` calls `trim("x")`, while `LOOP: for ...`
+    // is a label). The loop/block label forms are handled above; only the
+    // generic `IDENT: <expr>` case is ambiguous, and a declared-sub name
+    // resolves it to a call. Parse the colon-listop argument list directly.
+    if crate::parser::stmt::simple::is_user_declared_sub(&label) {
+        let (r, call) = crate::parser::primary::ident::parse_expr_listop_args(rest, label.clone())?;
+        return Ok((r, Stmt::Expr(call)));
+    }
+
     // Generic labeled statement: LABEL: <statement>
     let (r, stmt) = statement(rest)?;
     Ok((

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -1859,12 +1859,27 @@ impl Interpreter {
                 return Ok(Value::make_instance(*class_name, attrs));
             }
         }
-        // Buf/Blob push/append/unshift/prepend on non-variable targets: validate args
+        // Buf/Blob push/append/unshift/prepend on non-variable (rvalue) targets,
+        // e.g. `Buf.new($s.encode).append: $body`. There is no container to
+        // write back to, so perform the mutation on a copy and return the new
+        // Buf. (The named-variable path goes through `buf_mutate_method`, which
+        // additionally writes the result back into the variable.)
         if matches!(method, "push" | "append" | "unshift" | "prepend")
-            && let Value::Instance { class_name, .. } = &target
+            && let Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } = &target
         {
             let cn = class_name.resolve();
             if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                // Blob is immutable.
+                if crate::runtime::utils::is_blob_like_class(&cn) {
+                    return Err(RuntimeError::new(format!(
+                        "Cannot modify immutable {} with {}",
+                        cn, method
+                    )));
+                }
                 // Check for string args => X::TypeCheck
                 for a in &args {
                     if matches!(a, Value::Str(_)) {
@@ -1883,6 +1898,25 @@ impl Interpreter {
                         return Err(err);
                     }
                 }
+                let mut bytes =
+                    if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
+                        items.to_vec()
+                    } else {
+                        Vec::new()
+                    };
+                let new_items = Self::flatten_buf_args(args);
+                match method {
+                    "append" | "push" => bytes.extend(new_items),
+                    "prepend" | "unshift" => {
+                        let mut combined = new_items;
+                        combined.extend(bytes);
+                        bytes = combined;
+                    }
+                    _ => unreachable!(),
+                }
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("bytes".to_string(), Value::array(bytes));
+                return Ok(Value::make_instance(*class_name, attrs));
             }
         }
         // Buf/Blob pop/shift on non-variable targets (e.g. Buf.new.pop throws X::Cannot::Empty)

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -969,7 +969,20 @@ impl Interpreter {
             {
                 return Ok(coerced);
             }
-            if !matches!(method, "Numeric" | "Real" | "Bridge")
+            // When the object has its OWN `Str` method, stringification must not
+            // be delegated through the numeric bridge: `.Stringy` (and `.Str`)
+            // should use that custom stringification, not the numeric value
+            // (e.g. HTTP::Status: `method Numeric { $!code }; method Str
+            // { $!title }` → `~$status` / `"$status"` is the title, not the
+            // code). A class that `does Real` with no custom `Str` keeps
+            // bridging `.Str`/`.gist` to its number (e.g. `class P does Real
+            // { method Bridge { $!n.Num } }` → `P.new(n=>7).gist` is "7").
+            let has_user_str = matches!(target, Value::Instance { class_name, .. }
+                if self.has_user_method(&class_name.resolve(), "Str"));
+            let is_numeric_coercion = matches!(method, "Numeric" | "Real" | "Bridge");
+            let is_own_stringify = has_user_str && matches!(method, "Str" | "Stringy");
+            if !is_numeric_coercion
+                && !is_own_stringify
                 && let Ok(coerced) = self
                     .call_method_with_values(target.clone(), "Numeric", vec![])
                     .or_else(|_| self.call_method_with_values(target.clone(), "Bridge", vec![]))

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -4342,7 +4342,7 @@ impl Interpreter {
 
     /// Recursively flatten arguments for Buf mutate methods.
     /// Handles nested arrays, Seq, Slip, and Buf/Blob instances.
-    fn flatten_buf_args(args: Vec<Value>) -> Vec<Value> {
+    pub(in crate::runtime) fn flatten_buf_args(args: Vec<Value>) -> Vec<Value> {
         let mut result = Vec::new();
         for a in args {
             match &a {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3083,8 +3083,92 @@ impl Interpreter {
                 }
                 *ip += 1;
             }
-            OpCode::SinkPop => {
+            OpCode::SinkPop(user_sink) => {
+                let user_sink = *user_sink;
                 if let Some(val) = self.stack.pop() {
+                    // A bare statement value whose class defines its own `sink`
+                    // method invokes it in sink context (Raku semantics:
+                    // `class C { method sink {...} }; C.new;` runs the sink).
+                    // Gated on:
+                    //  - `user_sink` (compile-time): the value is a fresh rvalue
+                    //    (method call / term), not a bare variable or function
+                    //    return that Raku keeps container-wrapped (mutsu decont's
+                    //    those before SinkPop, losing the distinction);
+                    //  - a user-defined `sink` method, so built-in / container
+                    //    sink behavior is untouched;
+                    //  - the class has no `STORE` method (a STORE class is itself
+                    //    a container — Raku sinks the container, not the inner;
+                    //    sink.t "we don't sink the result of thing().=method").
+                    // TODO: a normal (non-`is rw`) sub returning a fresh instance
+                    // should also sink it; that needs first-class container
+                    // identity to tell an `is rw` (container) return from a plain
+                    // one. Until then function-call returns are conservatively
+                    // not auto-sunk.
+                    let sink_class = if !user_sink {
+                        None
+                    } else if let Value::Instance { class_name, .. } = &val {
+                        let cn = class_name.resolve();
+                        if self.has_user_method(&cn, "sink") && !self.has_user_method(&cn, "STORE")
+                        {
+                            Some(cn)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some(cn) = sink_class {
+                        let attrs = match &val {
+                            Value::Instance { attributes, .. } => attributes.to_map(),
+                            _ => std::collections::HashMap::new(),
+                        };
+                        // `sink` can mutate a captured-outer caller lexical by
+                        // name (`my @reg; method sink { @reg.push(...) }`) via
+                        // the slow path, which records nothing this site drains.
+                        // Snapshot slot-backing env before, reconcile after
+                        // (same dance as CallDefined).
+                        let pre_env: Vec<Option<Value>> = code
+                            .locals
+                            .iter()
+                            .map(|n| {
+                                self.env().get(n).cloned().or_else(|| {
+                                    n.strip_prefix('$')
+                                        .or_else(|| n.strip_prefix('@'))
+                                        .or_else(|| n.strip_prefix('%'))
+                                        .or_else(|| n.strip_prefix('&'))
+                                        .and_then(|b| self.env().get(b).cloned())
+                                })
+                            })
+                            .collect();
+                        let _ = self.vm_run_instance_method(
+                            &cn,
+                            attrs,
+                            "sink",
+                            Vec::new(),
+                            Some(val.clone()),
+                        );
+                        for (i, name) in code.locals.iter().enumerate() {
+                            if name.starts_with('!')
+                                || matches!(self.locals[i], Value::HashEntryRef { .. })
+                            {
+                                continue;
+                            }
+                            let cur = self.env().get(name).cloned().or_else(|| {
+                                name.strip_prefix('$')
+                                    .or_else(|| name.strip_prefix('@'))
+                                    .or_else(|| name.strip_prefix('%'))
+                                    .or_else(|| name.strip_prefix('&'))
+                                    .and_then(|b| self.env().get(b).cloned())
+                            });
+                            if let Some(cur) = cur
+                                && pre_env.get(i).map(|p| p.as_ref()) != Some(Some(&cur))
+                            {
+                                self.locals[i] = cur;
+                            }
+                        }
+                        *ip += 1;
+                        return Ok(());
+                    }
                     match &val {
                         Value::LazyList(list) => {
                             self.force_lazy_list_vm(list)?;

--- a/t/buf-rvalue-append.t
+++ b/t/buf-rvalue-append.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 8;
+
+# .append / .push / .prepend / .unshift on an rvalue Buf (no container to
+# write back to) must perform the operation and return the new Buf.
+{
+    my $r = Buf.new(1, 2).append(3, 4);
+    is-deeply $r.list.Array, [1, 2, 3, 4], 'Buf rvalue .append(ints)';
+}
+{
+    my $body = Buf.new(65, 66);
+    my $r = Buf.new("X".encode).append: $body;
+    is-deeply $r.list.Array, [88, 65, 66], 'Buf rvalue .append: chained colon form';
+}
+{
+    my $r = Buf.new(3, 4).prepend(1, 2);
+    is-deeply $r.list.Array, [1, 2, 3, 4], 'Buf rvalue .prepend';
+}
+{
+    my $r = Buf.new(3, 4).unshift(1, 2);
+    is-deeply $r.list.Array, [1, 2, 3, 4], 'Buf rvalue .unshift';
+}
+{
+    my $r = Buf.new(1).push(2);
+    is-deeply $r.list.Array, [1, 2], 'Buf rvalue .push';
+}
+
+# Appending a Blob/Buf argument flattens its bytes.
+{
+    my $r = Buf.new(1, 2).append(Buf.new(3, 4));
+    is-deeply $r.list.Array, [1, 2, 3, 4], 'Buf rvalue .append(Buf)';
+}
+
+# The named-variable path still mutates in place.
+{
+    my $b = Buf.new(1, 2);
+    $b.append(3);
+    is-deeply $b.list.Array, [1, 2, 3], 'named Buf .append mutates in place';
+}
+
+# Blob (immutable) rvalue append throws.
+{
+    dies-ok { Blob.new(1, 2).append(3) }, 'Blob rvalue .append throws (immutable)';
+}

--- a/t/colon-listop-call.t
+++ b/t/colon-listop-call.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 7;
+
+# `foo: args` at statement position, where `foo` is a declared subroutine,
+# is a colon-listop call (Raku), not a label. This is the form used as the
+# sole statement of a routine body, so it is observable via the return value.
+sub trim($x) { $x ~ "!" }
+sub wrap1() { trim: "hi" }
+is wrap1(), "hi!", 'colon-listop call as sub body statement';
+
+sub add2($a, $b) { $a + $b }
+sub wrap2() { add2: 3, 4 }
+is wrap2(), 7, 'colon-listop call with multiple args';
+
+# A chained method-call argument after the colon.
+sub upper($s) { $s.uc }
+sub wrap3() { upper: "abc".substr(0, 2) }
+is wrap3(), "AB", 'colon-listop with a method-chain argument';
+
+# The side effect of a colon-listop call statement runs.
+my @log;
+sub record($x) { @log.push($x) }
+sub run-it() { record: 99 }
+run-it();
+is-deeply @log, [99], 'colon-listop call statement runs its effect';
+
+# Labels on loops still work (undeclared name → label).
+my @seen;
+OUTER: for 1..2 -> $i {
+    for 1..2 -> $j {
+        @seen.push("$i$j");
+        next OUTER if $j == 1;
+    }
+}
+is-deeply @seen, ['11', '21'], 'loop label still works (next LABEL)';
+
+# A label on a bare block still works when the name is not a sub.
+my $ran = 0;
+NOPE: { $ran = 42; }
+is $ran, 42, 'label on a bare block still runs';
+
+# An undeclared name with colon + statement is a label, not a call.
+lives-ok { MYLABEL: my $x = 5; $x }, 'label before a my-declaration parses';

--- a/t/sink-method-context.t
+++ b/t/sink-method-context.t
@@ -1,0 +1,69 @@
+use Test;
+
+plan 6;
+
+# A bare statement whose value is a fresh instance of a class with a
+# user-defined `sink` method invokes that method in sink context.
+{
+    my @reg;
+    class C {
+        has $.n;
+        method sink { @reg.push($!n) }
+    }
+    C.new(n => 1);
+    C.new(n => 2);
+    is-deeply @reg, [1, 2], 'bare Foo.new statements invoke user method sink';
+}
+
+# Sinking happens for a method call returning a fresh instance too.
+{
+    my $sunk = 0;
+    class D {
+        method self-ish { self }
+        method sink { $sunk++ }
+    }
+    D.new.self-ish;
+    is $sunk, 1, 'method-call chain ending in a fresh instance is sunk';
+}
+
+# A value bound into a Scalar container is NOT sunk (Raku container semantics).
+{
+    my $sunk = False;
+    my ($a) = class { method sink { $sunk = True } }.new;
+    is $sunk, False, 'my ($a) = ... does not trigger sinking';
+    # silence "used once" sink of $a
+    $a.defined;
+}
+
+# A function-call return is not auto-sunk (it may be an `is rw` container).
+{
+    my $sunk = False;
+    my sub wrap() is rw {
+        my $var = class { method sink { $sunk = True } }.new;
+        $var;
+    }
+    wrap();
+    is $sunk, False, 'function-call return is not auto-sunk';
+}
+
+# A class that is itself a container (defines STORE) is not sunk.
+{
+    my $sunk = False;
+    (class {
+        method STORE(*@args) {}
+        method foo() { self }
+        method sink() { $sunk = True }
+    }.new).=foo;
+    is $sunk, False, 'STORE-container .=method result is not sunk';
+}
+
+# sink runs as a statement, also from within a module-like block scope.
+{
+    my @log;
+    {
+        class E { has $.v; method sink { @log.push: $!v } }
+        E.new(v => 'x');
+        E.new(v => 'y');
+    }
+    is-deeply @log, ['x', 'y'], 'bare statements inside a block scope are sunk';
+}

--- a/t/stringy-numeric-object.t
+++ b/t/stringy-numeric-object.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 7;
+
+# An object with both a Numeric and a Str method stringifies via Str, not
+# via its numeric value (string interpolation, ~, .Stringy).
+class S {
+    has $.code;
+    has $.title;
+    method Int     { $!code }
+    method Numeric { $!code }
+    method Str     { $!title }
+    method gist    { $!title }
+}
+my $s = S.new(code => 200, title => 'OK');
+is ~$s,         'OK', '~obj uses Str, not Numeric';
+is "$s",        'OK', 'string interpolation uses Str';
+is $s.Stringy,  'OK', '.Stringy delegates to user Str';
+is $s.Str,      'OK', '.Str returns the title';
+is +$s,         200,  '+obj still uses Numeric';
+
+# A class that does Real with no custom Str still bridges .gist/.Str to the
+# number (the numeric bridge is preserved when there is no user Str).
+class P does Real {
+    has $.n;
+    method Bridge { $!n.Num }
+}
+my $p = P.new(n => 7);
+is $p.gist, '7', 'does-Real object gist bridges to number (no user Str)';
+ok ($p + 5) == 12, 'does-Real object still bridges arithmetic';


### PR DESCRIPTION
## Summary

The off-the-shelf, maintained **Humming-Bird 4.0.0** Raku web framework now serves real HTTP end-to-end on mutsu: it accepts a real TCP connection, decodes the request, routes it, runs the handler, encodes the `Response`, and writes a well-formed reply to `curl`.

```
$ curl -i http://127.0.0.1:18080/
HTTP/1.1 200 OK
Content-Length: 42
Date: ...
X-Server: Humming-Bird (Raku)
content-type: text/html

<h1>Hello from Humming-Bird on mutsu!</h1>
```

Four independent, general-purpose fixes were needed (each with its own bug, none specific to Humming-Bird):

1. **Sink-context user `method sink`** — a bare statement whose value is a fresh rvalue (a method call / `Foo.new`) invokes a user-defined `sink` in sink context. `SinkPop` carries a compile-time bool marking "fresh rvalue", so container-bearing forms (bare variables, function returns, `STORE` containers) are not auto-sunk. Unblocks `HTTP::Status` (its `@codes` table is built by module-top `HTTP::Status.new: ...` statements). Keeps `S04-statements/sink.t` 10/10 and additionally fixes `S04-statements/for.t` test 102.

2. **Colon-listop call parse** — `foo: args` at statement position, where `foo` is a declared sub, is `foo(args)` (Raku), not a label. Was silently parsed as a `Stmt::Label` returning `Nil`. Unblocks `now-rfc2822` (`trim-utc-for-gmt: DateTime.now(...).utc.Str`).

3. **Buf rvalue mutating methods** — `.append`/`.push`/`.prepend`/`.unshift` on an rvalue `Buf` (`Buf.new($s.encode).append: $body`) now perform the op on a copy and return the new `Buf`, instead of raising "No such method 'append'". `Blob` (immutable) still throws.

4. **Stringification not delegated through the numeric bridge** — an object with its own `Str` method (`HTTP::Status`: `method Numeric { $!code }; method Str { $!title }`) stringifies via `Str` in `~`/interpolation/`.Stringy`, so the status line is `200 OK`, not `200 200`. A `does Real` object with no custom `Str` still bridges `.Str`/`.gist` to its number.

## Tests

New: `t/sink-method-context.t`, `t/colon-listop-call.t`, `t/buf-rvalue-append.t`, `t/stringy-numeric-object.t`.

Local: `cargo test` 470/0, `cargo clippy -D warnings` clean, `cargo fmt` clean, `prove t/` only previously-failing `t/native-instant-duration-render.t` test 13 (now also fixed). Full `make roast` delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)