### PR TITLE
feat(multi-dispatch): OTF-compile default-param proto candidates (§D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -165,15 +165,16 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     where 除外を維持。実測 where-multi 3 種で fallback 77.8%→0%。pin=`t/multi-where-otf-dispatch.t`(20)。
     **★同 PR で nextsame/callsame 候補順序バグも修正**: `resolve_all_multi_candidates` が HashMap 順だったため、複数候補が同一引数に
     マッチ（重複 where + generic fallback）すると nextsame が広い候補を先に拾い狭い候補を脱落させた（hash-seed flake で defer-next.t を CI が捕捉）。specificity 順ソートで決定化。
-  - [x] **default param 値を持つ候補の OTF 化（genuine multi 候補のみ）= 完了（#TBD）→ [news/2026-06.md](news/2026-06.md)**。
+  - [x] **default param 値を持つ multi/proto 候補の OTF 化 = 完了（#3559 genuine-multi / #TBD proto 候補）→ [news/2026-06.md](news/2026-06.md)**。
     `def_is_otf_compilable` から `default.is_none()` を**全撤去**する単純版（PR #3546 close）は builtin-shadow パスで Test::Util
     `our sub run(Str, Str = '')` を OTF compile し name-keyed `otf_call_cache` を汚染→subtest 文脈で後続コア `run` を mis-bind
-    （release roast で env.t/system.t/cur-current-distribution.t 回帰）。**安全実装＝genuine multi 候補サイト（非proto multi fork・
-    `has_multi_candidates_cached(name)` ブランチ内）のみ default を許可**。そこは `compile_and_call_function_def` が name-cache しない
-    （`!has_multi_candidates_cached` ガードが false）ので汚染ハザードが構造的に起きない。新 `def_is_otf_compilable_multi_candidate`
-    （code_signature のみ除外）を line 1064 に適用。単一/builtin-shadow パスは `def_is_otf_compilable`（default 除外）維持。
-    回帰した env.t/system.t/cur-current-distribution.t + subtest/Test::Util 系ローカル全 PASS。pin=`t/multi-default-otf-dispatch.t`(11)。
-    **残**: proto 候補 / builtin-shadow 単一 / 非builtin 単一の default-OTF（name-cache 汚染リスクで除外維持）。
+    （release roast で env.t/system.t/cur-current-distribution.t 回帰）。**安全実装＝genuine multi/proto 候補サイトのみ default を許可**:
+    非proto multi fork（`has_multi_candidates_cached` ブランチ・#3559）＋ trivial/non-trivial proto 候補（`vm_resolve_trivial_proto_candidate`
+    ・`vm_call_proto_dispatch`・#TBD）。これらは `compile_and_call_function_def` の caching profile が default 有無で不変（非default 候補が
+    既に安全に OTF されている）＝汚染ハザードが構造的に起きない。新 `def_is_otf_compilable_multi_candidate`（code_signature のみ除外）を適用。
+    単一/builtin-shadow/非builtin 単一パスは `def_is_otf_compilable`（default 除外）維持。回帰した env.t/system.t/cur-current-distribution.t
+    + subtest/Test::Util 系ローカル全 PASS。pin=`t/multi-default-otf-dispatch.t`(14・proto default 含む)。
+    **残**: builtin-shadow 単一 / 非builtin 単一の default-OTF（name-cache 汚染リスクで除外維持）。
   - [x] **非trivial proto body の VM 化 = 完了（#3550 ①body compiled / #3552 ②候補 OTF）→ [news/2026-06.md](news/2026-06.md)**。
     `proto foo($x){ say "x"; {*} }` の body＋`{*}` 候補ディスパッチを両方 compiled 実行（`vm_try_run_nontrivial_proto_body`
     ＋`vm_call_proto_dispatch`）。実測 `t/proto-nontrivial-body-vm.t` で interpreter_fallbacks 50.1%→0.5%。
@@ -197,7 +198,7 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     callback / `&name` 渡し / outer 変数を閉包する callback まで byte-identical（pin=`t/multi-amp-param-otf-dispatch.t`(8)）。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ・`@a[1..*]` 再帰の immutable-List bug は §F）/
     `code_signature`〔`&cb:(Int)`〕param を持つ候補の OTF 化（依然除外・別軸で `&cb:(Int)` vs `&cb` の resolution ambiguity も要）/
-    default-param OTF の **proto 候補 / 単一候補** 版（name-cache 汚染リスクで除外維持）/ nextsame+rw チェーン（上記）。
+    default-param OTF の **単一候補（builtin-shadow / 非builtin）** 版（name-cache 汚染リスクで除外維持）/ nextsame+rw チェーン（上記）。
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -100,7 +100,14 @@ builtin-shadow / 非builtin-single / proto 候補の各パスは `def_is_otf_com
 literal default / earlier-param 参照 default / outer-lexical closure default / default-multi 再帰 / narrower 候補優先
 すべて raku 一致。★以前回帰した **env.t / system.t / cur-current-distribution.t** + subtest/Test::Util 系をローカルで再確認し
 全 PASS（builtin-shadow hazard を回避できている証左）。pin=`t/multi-default-otf-dispatch.t`(11)。
-**残**: proto 候補 / 単一候補 の default-OTF（name-cache 汚染リスクで除外維持）。
+
+**フォローアップ＝proto 候補にも拡張（同セッション）**: trivial proto（`vm_resolve_trivial_proto_candidate`）と non-trivial
+proto（`vm_call_proto_dispatch`）の候補ゲートも `def_is_otf_compilable_multi_candidate` に切り替え。proto 候補は **genuine multi
+候補**で、`compile_and_call_function_def` の caching profile が default 有無で不変（非default proto 候補が既に安全に OTF
+されている）＝default 拡張も同じ安全性。`proto pp(|){*}` + `multi pp(Int $x, Int $y=10){…}` の `pp(5)`/`pp(5,20)`/`pp("hi")`
+が fallback ゼロで raku 一致。hazard 領域（env.t/system.t/cur-current-distribution.t）+ proto/subtest pin 再確認で全 PASS。
+pin 拡張=`t/multi-default-otf-dispatch.t`(14)。
+**残**: 単一候補（builtin-shadow / 非builtin）の default-OTF（name-cache 汚染リスクで除外維持）。
 
 ### ネストクラスを属性型に使えるよう修正 → Template::Mustache 復活（PLAN §H）
 

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1231,7 +1231,13 @@ impl Interpreter {
         if def.empty_sig && !args.is_empty() {
             return None;
         }
-        if !Self::def_is_otf_compilable(&def) || Self::function_body_declares_state(&def.body) {
+        // A trivial-proto candidate is a genuine multi candidate (same caching
+        // profile in `compile_and_call_function_def` regardless of defaults), so a
+        // default param is safe to OTF here — see
+        // `def_is_otf_compilable_multi_candidate`.
+        if !Self::def_is_otf_compilable_multi_candidate(&def)
+            || Self::function_body_declares_state(&def.body)
+        {
             return None;
         }
         Some(def)
@@ -1370,7 +1376,13 @@ impl Interpreter {
         }
         if let Some(def) = self.resolve_proto_candidate_with_types(&proto_name, &args)
             && (!def.empty_sig || args.is_empty())
-            && Self::def_is_otf_compilable(&def)
+            // A proto candidate is a genuine multi candidate: its caching profile
+            // in `compile_and_call_function_def` is identical with or without a
+            // default param (caching keys on `has_multi_candidates_cached`, not on
+            // defaults), so default-bearing candidates are as safe to OTF here as
+            // the non-default ones already are. Permit defaults (see
+            // `def_is_otf_compilable_multi_candidate`).
+            && Self::def_is_otf_compilable_multi_candidate(&def)
             && !Self::function_body_declares_state(&def.body)
         {
             // pending_call_arg_sources is still set (resolution only reads it);

--- a/t/multi-default-otf-dispatch.t
+++ b/t/multi-default-otf-dispatch.t
@@ -10,7 +10,7 @@ use Test;
 # multi-cached), so that hazard cannot fire. Single / builtin-shadow candidates
 # keep the default exclusion.
 
-plan 11;
+plan 14;
 
 # literal default
 {
@@ -51,4 +51,14 @@ plan 11;
     multi gg(Int $x) { "second:$x" }
     is gg(3), "second:3", 'exact-arity candidate preferred over default-bearing one';
     is gg(3, 0), "first:3", 'default-bearing candidate selected for 2-arg call';
+}
+
+# proto-dispatched default-multi candidate (trivial proto)
+{
+    proto pp(|) {*}
+    multi pp(Int $x, Int $y = 10) { $x + $y }
+    multi pp(Str $s) { $s }
+    is pp(5), 15, 'proto default applied when omitted';
+    is pp(5, 20), 25, 'proto explicit value overrides default';
+    is pp("hi"), "hi", 'proto other candidate still selected';
 }


### PR DESCRIPTION
## Summary

Extends #3559 (default-param OTF for genuine multi candidates) to **proto-dispatched
candidates**. A proto candidate with a default parameter value
(`proto pp(|) {*}` / `multi pp(Int \$x, Int \$y = 10) { ... }`) still fell back to
the interpreter because both proto candidate gates used `def_is_otf_compilable`,
which excludes defaults.

## Fix

A proto candidate is a genuine multi candidate: its caching profile in
`compile_and_call_function_def` is identical with or without a default param
(caching keys on `has_multi_candidates_cached`, not on defaults), so a
default-bearing proto candidate is exactly as safe to OTF as the non-default ones
already are.

Switch both gates to `def_is_otf_compilable_multi_candidate`:
- `vm_resolve_trivial_proto_candidate` (trivial / bodyless proto)
- `vm_call_proto_dispatch` (non-trivial proto body `{*}`)

Single / builtin-shadow / non-builtin single paths keep `def_is_otf_compilable`
(default still excluded — the genuine name-cache-pollution surface).

## Verification

`proto pp(|) {*}` + `multi pp(Int \$x, Int \$y = 10)` dispatches `pp(5)` /
`pp(5, 20)` / `pp("hi")` with no fallback, matching raku. The previously-regressing
`env.t` / `system.t` / `cur-current-distribution.t` and the proto / subtest pins
all pass locally.

- pin `t/multi-default-otf-dispatch.t` (14, proto default cases added)
- `make test` green locally (Files=1130, Tests=11352, Result: PASS).

## Remaining

default-OTF for single candidates (builtin-shadow / non-builtin) stays excluded —
that is the genuine name-cache-pollution surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)