### PR TITLE
fix: [&sub] single-bracket is an array literal, not a reduction

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -238,6 +238,25 @@ pub(super) fn reduction_op(input: &str) -> PResult<'_, Expr> {
         "∘" => "o".to_string(),
         other => other.to_string(),
     };
+    // A `&callable` reduction operator requires the double-bracket form
+    // `[[&foo]]` (the inner `[&foo]` is itself the bracketed infix). A single
+    // `[&foo]` is an array literal containing the sub, NOT a reduction — in
+    // Raku `[&foo]` alone is a term (array literal), `2 [&foo] 3` is an infix,
+    // and only `[[&foo]] @a` is the reduction. Both forms flatten to op
+    // `&foo`, so distinguish by whether the raw inner was itself bracketed.
+    let meta = |c: char| c == 'R' || c == 'Z' || c == 'X' || c == '\\';
+    let is_callable_amp = |s: &str| {
+        s.strip_prefix('&')
+            .and_then(|rest| rest.chars().next())
+            .is_some_and(|c| c.is_alphabetic() || c == '_')
+    };
+    if is_callable_amp(op.trim_start_matches(meta))
+        && !inner.trim_start().trim_start_matches(meta).starts_with('[')
+    {
+        return Err(PError::expected(
+            "callable reduction requires double-bracket form [[&op]]",
+        ));
+    }
     // Only accept known operators (after flattening) to avoid confusion with array literals.
     if !is_valid_reduction_op(&op) {
         return Err(PError::expected("known reduction operator"));

--- a/t/callable-bracket-array-literal.t
+++ b/t/callable-bracket-array-literal.t
@@ -1,0 +1,42 @@
+use Test;
+
+# `[&foo]` (single bracket) is an array literal containing the sub `&foo`,
+# NOT a reduction. The reduction parser used to flatten both `[&foo]` and
+# `[[&foo]]` to op "&foo" and treat the single-bracket form as a reduction
+# (which returned Nil), so passing `[&mw]` as a positional argument bound to
+# an `@`-sigil parameter failed with a type-check error. In Raku:
+#   * `[&foo]`        -> array literal (a term)
+#   * `2 [&foo] 3`    -> `&foo` used as an infix operator
+#   * `[[&foo]] @a`   -> reduction with `&foo` as the operator
+
+plan 12;
+
+sub dbl($x) { $x * 2 }
+sub add($a, $b) { $a + $b }
+sub cat($a, $b) { $a ~ $b }
+
+# --- single-bracket callable is an array literal ---------------------------
+
+is [&dbl].elems,        1,    '[&dbl] is a one-element array';
+is [&dbl][0].(21),      42,   '[&dbl][0] is the sub itself';
+is [&dbl, &add].elems,  2,    'multi-element callable array literal';
+
+# passing `[&mw]` as a positional arg to an @-sigil parameter (the bug)
+sub takes-array(Str:D $s, @mw = List.new) { "$s:{ @mw.elems }" }
+is takes-array('a', [&dbl]),        'a:1', 'single-callable array binds to @param';
+is takes-array('a', [&dbl, &add]),  'a:2', 'two-callable array binds to @param';
+is takes-array('a'),                'a:0', 'default empty array still works';
+
+# combined with a &callback parameter (the Humming-Bird get/post shape)
+sub route(Str:D $path, &cb, @mw = List.new) { "{ &cb($path) }/{ @mw.elems }" }
+is route('/', -> $p { $p.uc }, [&dbl]), '//1', 'route(&cb, [&mw]) binds correctly';
+
+# --- reduction and infix forms still work ----------------------------------
+
+is ([[&add]] 1, 2, 3, 4),  10,    '[[&add]] reduces with a sub operator';
+is ([[&cat]] <a b c>),     'abc', '[[&cat]] reduces strings';
+is (2 [&add] 3),           5,     '[&add] as an infix operator';
+is (2 [&add] 3 [&add] 4),  9,     'chained [&add] infix';
+
+# symbolic reductions unaffected
+is ([+] 1, 2, 3),          6,     '[+] symbolic reduction still works';


### PR DESCRIPTION
## Problem

In Raku, `[&foo]` (single bracket) is an **array literal** containing the sub `&foo`. The reduction-with-a-sub form requires **double** brackets `[[&foo]]`, and `2 [&foo] 3` uses `&foo` as an **infix** operator.

mutsu's reduction parser flattened both `[&foo]` and `[[&foo]]` to op `&foo` and accepted the single-bracket form as a reduction (which returned `Nil`). As a result, passing `[&mw]` as a positional argument bound to an `@`-sigil parameter failed:

```
sub foo(Str:D $path, @mw = List.new) { ... }
foo('/', [&bar]);
# Type check failed in binding to parameter '@mw'; expected Positional but got Any (Nil)
```

This blocked the off-the-shelf **Humming-Bird** web framework's `get/post(path, &callback, [&middleware])` call shape.

## Fix

Reject the single-bracket callable form in `reduction_op`, distinguishing a callable `&foo` (`&` + identifier) from the `&&` logical-and operator, so it falls through to array-literal parsing. `[[&foo]]` reductions, `2 [&foo] 3` infixes, and symbolic reductions (`[+]`, `[&&]`) are unaffected.

## Tests

- New `t/callable-bracket-array-literal.t` (12 assertions).
- Verified no regression across the reduction/metaop suite and `roast/S13-overloading/metaoperators.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)