### PR TITLE
fix(dispatch): is-Array instances delegate the full list-method set to storage

### DIFF
--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -24,6 +24,15 @@ by-value 委譲が正しい。fallback は `grep`（結果が source への rw v
 mutating メソッド（`splice`/`ASSIGN-POS`/…）のみに縮小（first-class element-cell write-back が要る部分＝lever B）。
 出力は main と byte-identical（既存の interpreter fallback と一致）。pin=`t/native-array-backed-instance-methods.t`(13)。
 
+**フォローアップ＝is-Array list メソッドの correctness 修正（whitelist 拡張）**: 上記調査中に、`is Array` インスタンスの
+mut-path 委譲ゲート（`vm_call_method_mut_ops.rs` の `is_array_method` whitelist）が **多数の list メソッドを欠いて**おり、
+`$s.minmax`/`.min`/`.max`/`.sum`/`.kv`/`.pairs`/`.keys`/`.values`/`.reduce`/`.classify`/`.combinations`/`.permutations`/
+`.all`/`.any` 等が storage に委譲されず **インスタンス自身を1要素リスト扱い**して誤結果（`S.new` / `Nil` / "No such method"）
+を返していた（変数受け手は CallMethodMut＝mut-path を通るため・非mut-path は blanket 委譲で正しかった）。whitelist に
+numeric reduction（min/max/minmax/sum/reduce/produce）/ index views（kv/pairs/antipairs/keys/values）/ grouping・
+combinatorics（classify/categorize/combinations/permutations/rotor/batch）/ selection（pick/roll）/ junction
+（all/any/none/one）を追加し、全て raku 一致に回復。pin 拡張=`t/native-array-backed-instance-methods.t`(28)。
+
 ### 非trivial proto body の VM 化（§D multi-dispatch・#3550 / #3552）
 
 `proto foo($x) { say "x"; {*} }` のような **本体を持つ proto** はこれまで proto body 全体を

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1427,6 +1427,34 @@ impl Interpreter {
                             | "EXISTS-POS"
                             | "DELETE-POS"
                             | "BIND-POS"
+                            // Numeric reductions / list folds over the elements.
+                            | "min"
+                            | "max"
+                            | "minmax"
+                            | "sum"
+                            | "reduce"
+                            | "produce"
+                            // Index/element views.
+                            | "kv"
+                            | "pairs"
+                            | "antipairs"
+                            | "keys"
+                            | "values"
+                            // Grouping and combinatorics.
+                            | "classify"
+                            | "categorize"
+                            | "combinations"
+                            | "permutations"
+                            | "rotor"
+                            | "batch"
+                            // Element selection (non-mutating).
+                            | "pick"
+                            | "roll"
+                            // Junction constructors over the elements.
+                            | "all"
+                            | "any"
+                            | "none"
+                            | "one"
                     );
                     if is_array_method
                         && !self.has_user_method(&cn, &method)

--- a/t/native-array-backed-instance-methods.t
+++ b/t/native-array-backed-instance-methods.t
@@ -9,7 +9,7 @@ use Test;
 # dispatch matches the previous interpreter fallback), and that mutating methods
 # (push/pop) still work.
 
-plan 13;
+plan 28;
 
 class S is Array {}
 my $s = S.new;
@@ -34,3 +34,22 @@ is $s.elems, 4, 'pop mutates the instance';
 
 # the sort result must not have mutated the source order
 is $s.join(","), "3,1,2,4", 'non-mutating methods leave the instance untouched';
+
+# list-operation methods (previously missing from the is-Array delegation list,
+# so they wrongly treated the instance as a single element) now operate on the
+# backing storage, matching Rakudo.
+is $s.min, 1, 'min over is-Array elements';
+is $s.max, 4, 'max over is-Array elements';
+is $s.minmax.gist, "1..4", 'minmax over is-Array elements';
+is $s.sum, 10, 'sum over is-Array elements';
+is $s.reduce(* + *), 10, 'reduce over is-Array elements';
+is $s.keys.join(","), "0,1,2,3", 'keys (indices) of is-Array';
+is $s.values.join(","), "3,1,2,4", 'values of is-Array';
+is $s.kv.join(","), "0,3,1,1,2,2,3,4", 'kv of is-Array';
+is $s.pairs.map(*.value).join(","), "3,1,2,4", 'pairs of is-Array';
+is $s.antipairs.map(*.key).join(","), "3,1,2,4", 'antipairs of is-Array';
+is $s.classify({ $_ %% 2 })<True>.join(","), "2,4", 'classify over is-Array';
+is $s.rotor(2).map(*.join("")).join(","), "31,24", 'rotor over is-Array';
+is $s.combinations(4).elems, 1, 'combinations over is-Array';
+is $s.permutations.elems, 24, 'permutations over is-Array';
+is $s.all.so, True, 'all junction over is-Array';


### PR DESCRIPTION
## Summary

An `is Array` subclass instance (`class S is Array {}`) delegates list methods to
its backing `__mutsu_array_storage`. The mut-dispatch path (`\$s.minmax` on a
*variable* compiles to `CallMethodMut`) gated delegation on a hardcoded
`is_array_method` whitelist that was missing many common List/Array methods.

So `\$s.minmax` / `.min` / `.max` / `.sum` / `.kv` / `.pairs` / `.keys` /
`.values` / `.reduce` / `.classify` / `.combinations` / `.permutations` /
`.all` / `.any` (and more) were **not delegated** — they treated the instance as a
single-element list and returned wrong results (`S.new` / `Nil` / "No such
method"). The non-mut path already blanket-delegates, so a sink-context call
worked; only the mut path (the common variable-receiver case) was affected.

## Fix

Add the missing methods to the whitelist:
- numeric reductions: `min`/`max`/`minmax`/`sum`/`reduce`/`produce`
- index views: `kv`/`pairs`/`antipairs`/`keys`/`values`
- grouping & combinatorics: `classify`/`categorize`/`combinations`/`permutations`/`rotor`/`batch`
- selection: `pick`/`roll`
- junction constructors: `all`/`any`/`none`/`one`

All now operate on the backing storage and match Rakudo.

## Tests

- pin `t/native-array-backed-instance-methods.t` expanded to 28
- `make test` green locally (Files=1136, Tests=11420, Result: PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)