### PR TITLE
fix: four bugs blocking real web-app request handling (Humming-Bird)

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1957,7 +1957,19 @@ impl Compiler {
                         target,
                         index,
                         is_positional,
-                    } => Self::container_var_name(target).map(|c| (c, index, *is_positional)),
+                    } => Self::container_var_name(target)
+                        // The element-source writeback optimization looks the
+                        // container up by name in the locals store. An instance
+                        // attribute (`%!h`, `@!a`, twigil `!`/`.`) lives in the
+                        // instance attribute store, not in locals, so the lookup
+                        // would read an empty container and bind `$_` to Nil.
+                        // Fall through to evaluating the element value directly
+                        // (read-only, but correct) for attribute containers.
+                        .filter(|c| {
+                            let after_sigil = c.strip_prefix(['$', '@', '%']).unwrap_or(c);
+                            !after_sigil.starts_with(['!', '.'])
+                        })
+                        .map(|c| (c, index, *is_positional)),
                     _ => None,
                 };
                 let topic_readonly;

--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -205,6 +205,9 @@ pub(super) fn scalar_var(input: &str) -> PResult<'_, Expr> {
             let after_gt = &after_lt[end + 1..];
             return Ok((after_gt, Expr::CaptureVar(name.to_string())));
         }
+        // `$<>` is the zen slice of the match variable: sugar for `$/<>`.
+        // Return `$/` and leave the `<>` for postfix zen-angle parsing.
+        return Ok((input, Expr::Var("/".to_string())));
     }
     // Handle $=finish and other Pod variables ($=pod, $=data, etc.)
     if let Some(after_eq) = input.strip_prefix('=') {

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1436,12 +1436,7 @@ impl Interpreter {
             // `self`, so a following `$!attr = ...` would see a type-object self
             // and wrongly die "Cannot look up attributes in a ... type object".
             // `?CLASS`/`?ROLE`/`__ANON_STATE__` are likewise per-method context.
-            if k == "_"
-                || k == "self"
-                || k == "?CLASS"
-                || k == "?ROLE"
-                || k == "__ANON_STATE__"
-            {
+            if k == "_" || k == "self" || k == "?CLASS" || k == "?ROLE" || k == "__ANON_STATE__" {
                 continue;
             }
             if saved_env.contains_key_sym(*k) {

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1428,8 +1428,20 @@ impl Interpreter {
         }
         let mut merged_env = saved_env.clone();
         for (k, v) in self.env.iter() {
-            // $_ is method-local; don't bleed the method's $_ back to the caller
-            if k == "_" {
+            // These keys are method-local execution context, not outer lexicals:
+            // bleeding them back to the caller corrupts the caller's own context.
+            // `self` is the worst offender — a callee invoked on a *type object*
+            // (e.g. `CALL-ME` on `T:U:`) sets the method's `self` to that type
+            // object; merging it back would overwrite the caller's instance
+            // `self`, so a following `$!attr = ...` would see a type-object self
+            // and wrongly die "Cannot look up attributes in a ... type object".
+            // `?CLASS`/`?ROLE`/`__ANON_STATE__` are likewise per-method context.
+            if k == "_"
+                || k == "self"
+                || k == "?CLASS"
+                || k == "?ROLE"
+                || k == "__ANON_STATE__"
+            {
                 continue;
             }
             if saved_env.contains_key_sym(*k) {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -965,6 +965,45 @@ impl Interpreter {
                     result
                 }
             }
+            // Buf/Blob slice by a Range: `$buf[0..7]` / `$buf[2..^5]`. The bytes
+            // live in the instance's `bytes` array; a single-Int index is served
+            // by `AT-POS` above, but a Range index has no AT-POS arm and would
+            // otherwise fall through to Nil. Return the list of bytes in range
+            // (Raku yields a List of the byte values).
+            (
+                Value::Instance {
+                    ref class_name,
+                    ref attributes,
+                    ..
+                },
+                idx @ (Value::Range(..)
+                | Value::RangeExcl(..)
+                | Value::RangeExclStart(..)
+                | Value::RangeExclBoth(..)),
+            ) if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
+                if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
+                    let len = bytes.len() as i64;
+                    let (start, end_incl) = match idx {
+                        Value::Range(a, b) => (a, if Self::range_end_is_unbounded(b) { len - 1 } else { b }),
+                        Value::RangeExcl(a, b) => (a, if Self::range_end_is_unbounded(b) { len - 1 } else { b - 1 }),
+                        Value::RangeExclStart(a, b) => (a + 1, if Self::range_end_is_unbounded(b) { len - 1 } else { b }),
+                        Value::RangeExclBoth(a, b) => (a + 1, if Self::range_end_is_unbounded(b) { len - 1 } else { b - 1 }),
+                        _ => unreachable!(),
+                    };
+                    let start = start.max(0);
+                    let mut slice = Vec::new();
+                    let mut i = start;
+                    while i <= end_incl {
+                        if i >= 0 && i < len {
+                            slice.push(bytes[i as usize].clone());
+                        }
+                        i += 1;
+                    }
+                    Value::array(slice)
+                } else {
+                    Value::Nil
+                }
+            }
             (instance @ Value::Instance { .. }, Value::Array(keys, ..)) => {
                 let mut results = Vec::with_capacity(keys.len());
                 for k in keys.iter().cloned() {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -984,10 +984,38 @@ impl Interpreter {
                 if let Some(Value::Array(bytes, ..)) = attributes.as_map().get("bytes") {
                     let len = bytes.len() as i64;
                     let (start, end_incl) = match idx {
-                        Value::Range(a, b) => (a, if Self::range_end_is_unbounded(b) { len - 1 } else { b }),
-                        Value::RangeExcl(a, b) => (a, if Self::range_end_is_unbounded(b) { len - 1 } else { b - 1 }),
-                        Value::RangeExclStart(a, b) => (a + 1, if Self::range_end_is_unbounded(b) { len - 1 } else { b }),
-                        Value::RangeExclBoth(a, b) => (a + 1, if Self::range_end_is_unbounded(b) { len - 1 } else { b - 1 }),
+                        Value::Range(a, b) => (
+                            a,
+                            if Self::range_end_is_unbounded(b) {
+                                len - 1
+                            } else {
+                                b
+                            },
+                        ),
+                        Value::RangeExcl(a, b) => (
+                            a,
+                            if Self::range_end_is_unbounded(b) {
+                                len - 1
+                            } else {
+                                b - 1
+                            },
+                        ),
+                        Value::RangeExclStart(a, b) => (
+                            a + 1,
+                            if Self::range_end_is_unbounded(b) {
+                                len - 1
+                            } else {
+                                b
+                            },
+                        ),
+                        Value::RangeExclBoth(a, b) => (
+                            a + 1,
+                            if Self::range_end_is_unbounded(b) {
+                                len - 1
+                            } else {
+                                b - 1
+                            },
+                        ),
                         _ => unreachable!(),
                     };
                     let start = start.max(0);

--- a/t/buf-range-slice.t
+++ b/t/buf-range-slice.t
@@ -1,0 +1,27 @@
+use Test;
+
+# `$buf[$a..$b]` (slicing a Buf/Blob by a Range) returned Nil: a single-Int
+# index was served by AT-POS but a Range index had no match arm and fell
+# through. Raku yields the list of byte values in range. This blocked
+# Humming-Bird's Request.decode body extraction
+# (`Buf.new: $payload[$idx..($payload.bytes-1)].Slip`).
+
+plan 8;
+
+my $b = Buf.new("buy milk".encode);   # 98 117 121 32 109 105 108 107
+
+is $b[0..7].elems, 8,                    'inclusive range slice length';
+is $b[0..7].join(','), '98,117,121,32,109,105,108,107', 'inclusive range bytes';
+is $b[2..^5].join(','), '121,32,109',    'exclusive-end range slice';
+is $b[2^..5].join(','), '32,109,105',    'exclusive-start range slice';
+
+my $i = 0; my $j = 7;
+is $b[$i..$j].elems, 8,                  'range with variable endpoints';
+
+# round-trip through Buf.new + .Slip (the decode idiom)
+my $copy = Buf.new: $b[0..($b.bytes - 1)].Slip;
+is $copy.bytes, 8,                       'sliced bytes rebuild a Buf';
+is $copy.decode, 'buy milk',             'rebuilt Buf decodes to original';
+
+# single-index still works
+is $b[1], 117,                           'single-Int index still works';

--- a/t/given-without-attribute-element.t
+++ b/t/given-without-attribute-element.t
@@ -1,0 +1,52 @@
+use Test;
+
+# `given %!h{$k}` / `with`/`without %!h{$k}` (and their statement-modifier
+# forms) used an element-source writeback optimization that looked the
+# container up by NAME in the locals store. An instance attribute (`%!h`,
+# `@!a`) lives in the instance attribute store, not in locals, so the lookup
+# read an empty container and bound `$_` to Nil — breaking the very common
+# `return Nil without %!params{$k}` accessor idiom (Humming-Bird's
+# Request.param / Request.query).
+
+plan 8;
+
+class R {
+    has %.h;
+    has @.a;
+    method setup { %!h<name> = 'world'; @!a[0] = 'first'; }
+    method via-given-hash       { given %!h<name> { return $_ } }
+    method via-without-hash($k) { return 'MISSING' without %!h{$k}; %!h{$k} }
+    method via-with-hash($k)    { my $r = 'NONE'; $r = 'got:' ~ %!h{$k} with %!h{$k}; $r }
+    method via-given-array      { given @!a[0] { return $_ } }
+}
+
+my $r = R.new;
+$r.setup;
+
+is $r.via-given-hash,        'world', 'given on attr hash element (cross-method)';
+is $r.via-without-hash('name'), 'world', 'without stmt-mod sees defined attr element';
+is $r.via-without-hash('nope'), 'MISSING', 'without stmt-mod fires on undefined element';
+is $r.via-with-hash('name'),  'got:world', 'with stmt-mod sees defined attr element';
+is $r.via-given-array,        'first', 'given on attr array element';
+
+# block forms also correct
+class S {
+    has %.p;
+    method check($k) {
+        %!p{$k} = 'X';
+        my $out;
+        without %!p{$k} { $out = 'undef' }
+        with %!p{$k}    { $out = 'def' }
+        $out;
+    }
+}
+is S.new.check('a'), 'def', 'with block on attr element when defined';
+
+# plain lexical hash element still works (unchanged behavior)
+my %lex = :y(1);
+my $z = 'NO';
+$z = 'YES' with %lex<y>;
+is $z, 'YES', 'with on lexical hash element';
+my $w = 'NO';
+$w = 'RAN' without %lex<missing>;
+is $w, 'RAN', 'without on missing lexical hash element';

--- a/t/method-call-self-writeback.t
+++ b/t/method-call-self-writeback.t
@@ -1,0 +1,49 @@
+use Test;
+
+# When a method invoked on a *type object* (e.g. a `CALL-ME` with a `T:U:`
+# invocant) referenced a captured-outer lexical, the slow-path method
+# dispatch merged its execution-context `self` (the type object) back into the
+# caller's environment, overwriting the caller's instance `self`. A following
+# private-attribute assignment `$!attr = ...` then saw a type-object `self`
+# and wrongly died "Cannot look up attributes in a <T> type object".
+
+plan 4;
+
+my @registry;
+
+class Status {
+    has Int $.code;
+    method CALL-ME(Status:U: Int $n) { @registry[$n] }   # refs captured @registry
+}
+@registry[201] = Status.new(code => 201);
+@registry[200] = Status.new(code => 200);
+
+class Response {
+    has $.status;
+    method set-status(Int $n) {
+        $!status = Status($n);       # CALL-ME on type object, assigned to attr
+        self;
+    }
+}
+
+my $r = Response.new;
+$r.set-status(201);
+is $r.status.code, 201, 'attr assigned from CALL-ME-on-type-object survives';
+$r.set-status(200);
+is $r.status.code, 200, 'reassignment also works';
+
+# self stays the instance across the type-object call
+class C {
+    has $.x;
+    method go(Int $n) {
+        $!x = Status($n);
+        self.defined;            # self must still be the instance
+    }
+}
+is C.new.go(200), True, 'self is still the instance after type-object method call';
+
+# ordinary (non-CALL-ME) type-object method referencing captured outer is fine too
+my $base = 100;
+class T { method calc(Int $n) { $base + $n } }
+class D { has $.v; method run(Int $n) { $!v = T.calc($n); $!v } }
+is D.new.run(5), 105, 'ordinary type-object method with captured outer';

--- a/t/zen-slice-match-var.t
+++ b/t/zen-slice-match-var.t
@@ -1,0 +1,26 @@
+use Test;
+
+# `$<>` is the zen slice of the match variable `$/` (sugar for `$/<>`). It
+# used to parse as a bare anonymous `$` variable followed by a `<>` zen-angle
+# postfix, binding to an undefined anonymous state var instead of `$/`. After a
+# `:g` global match `$/` is a list of Match objects, and `$<>` must expose them.
+
+plan 6;
+
+"a1b2c3" ~~ m:g/\w\d/;
+is $<>.elems, 3, '$<> after :g match has all matches';
+is $<>>>.Str.join(','), 'a1,b2,c3', '$<> yields each match';
+is $/.elems, 3, '$/ also has 3 (sanity)';
+
+# query-string style parse (the Humming-Bird Request.decode pattern)
+my $path = '/search?q=raku&x=1';
+my %query;
+if $path ~~ m:g/\w+"="(<-[&]>+)/ {
+    %query = Map.new($<>.map({ .split('=', 2, :skip-empty) }).flat);
+}
+is %query<q>, 'raku', 'query param q parsed via $<>';
+is %query<x>, '1',    'query param x parsed via $<>';
+
+# single match: $<> exposes the one match
+"hello" ~~ /(\w+)/;
+is $<>.Str, 'hello', '$<> on a non-:g match exposes the whole match';


### PR DESCRIPTION
Exercising the off-the-shelf **Humming-Bird** framework's path-param / query / POST-body / accessor features surfaced four independent, general interpreter bugs. Each is fixed with a focused, general change and a regression test.

## 1. `$<>` zen slice of the match variable
`$<>` is sugar for `$/<>`. It parsed as a bare anonymous `$` variable followed by a `<>` zen-angle postfix, binding to an undefined anon state var instead of `$/`. After a `:g` match `$/` is a list of Match objects — Request.decode's query-string parser relies on `$<>` to read them.

## 2. `given`/`with`/`without` on an instance-attribute element
The element-source writeback optimization for `given %h{k}` / `@a[i]` looked the container up by **name** in the locals store. An instance attribute (`%!h`, `@!a`) lives in the attribute store, so the topic bound to **Nil**. Attribute-element topics now evaluate the value directly (read-only, correct). This unblocks the extremely common `return Nil without %!params{$k}` accessor idiom (Request.param / Request.query).

## 3. method-call `self` clobber across a type-object call
The slow-path env merge-back copied the **callee's** execution-context `self` back into the caller whenever the key also existed in the caller env. A `CALL-ME` invoked on a type object (`T:U:`) that referenced a captured-outer lexical then left the caller's `self` as a type object, so a following `$!attr = ...` died *"Cannot look up attributes in a … type object"*. Exclude `self`/`?CLASS`/`?ROLE`/`__ANON_STATE__` from merge-back. Unblocks `$!status = HTTP::Status($code)`.

## 4. Buf/Blob slice by a Range
`$buf[$a..$b]` had no match arm (only single-Int via AT-POS and WhateverCode) and fell through to **Nil**. Added a Range/RangeExcl slice arm yielding the byte list. Unblocks Request.decode body extraction (`Buf.new: $payload[$idx..($payload.bytes-1)].Slip`).

## Verification
- `make test` passes (11406 tests).
- Server-less Humming-Bird dispatch now serves path params, query params, POST raw body, and POST urlencoded forms correctly.
- New regression tests: `t/zen-slice-match-var.t`, `t/given-without-attribute-element.t`, `t/method-call-self-writeback.t`, `t/buf-range-slice.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)