### PR TITLE
fix(array): .splice on a scalar variable holding an array writes back in place

### DIFF
--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2330,7 +2330,21 @@ impl Interpreter {
             return self.buf_mutate_method(target_var, target, method, args);
         }
 
-        if target_var.starts_with('@') {
+        // `.splice` on a *scalar* variable holding a real array
+        // (`my $n = [1,2,3]; $n.splice(1,1)`) writes back through the same array
+        // path as `@a.splice`. The plain scalar array-mutator fast path covers
+        // push/pop/shift/unshift/append/prepend but not splice, so those reached
+        // here only via an `@`-sigiled name; route a scalar-held splice through
+        // the `@` block too. (`env.insert(key, …)` below keys on the bare
+        // `target_var`, so a scalar name is written back correctly; the metadata
+        // lookups return `None` for an untyped scalar, which is a no-op.) This
+        // also fixes `is Array`-instance splice, which delegates through a
+        // scalar-named (`__mutsu_array_tmp`) temp binding.
+        let scalar_holds_real_array = !target_var.starts_with('@')
+            && !target_var.starts_with('%')
+            && !target_var.starts_with('&')
+            && matches!(&target, Value::Array(_, crate::value::ArrayKind::Array));
+        if target_var.starts_with('@') || (method == "splice" && scalar_holds_real_array) {
             // Check for shaped (multidimensional) arrays - these don't support
             // mutating operations like push/pop/shift/unshift/splice/append/prepend
             if matches!(

--- a/t/scalar-held-array-splice.t
+++ b/t/scalar-held-array-splice.t
@@ -1,0 +1,50 @@
+use Test;
+
+# `.splice` on a scalar variable holding a real array (`my $n = [...]`) must
+# mutate it in place, like `@a.splice`. The plain scalar array-mutator fast path
+# covers push/pop/shift/unshift/append/prepend but not splice, so a scalar-held
+# splice previously left the array unchanged. This also covers `is Array`
+# instances, whose splice delegates through a scalar-named temp binding.
+
+plan 8;
+
+# scalar holding an array
+{
+    my $n = [1, 2, 3, 4, 5];
+    my @removed = $n.splice(1, 2);
+    is $n.join(","), "1,4,5", 'scalar-held splice removes in place';
+    is @removed.join(","), "2,3", 'splice returns the removed elements';
+}
+
+# splice with a replacement list
+{
+    my $n = [1, 2, 3, 4];
+    my @removed = $n.splice(1, 2, (8, 9));
+    is $n.join(","), "1,8,9,4", 'scalar-held splice inserts the replacement';
+    is @removed.join(","), "2,3", 'splice returns removed when replacing';
+}
+
+# is-Array instance splice
+{
+    class S is Array {}
+    my $s = S.new;
+    $s.push(1, 2, 3, 4, 5);
+    $s.splice(1, 2);
+    is $s.Array.join(","), "1,4,5", 'is-Array instance splice mutates the instance';
+}
+
+# @-sigiled splice still works (no regression)
+{
+    my @a = 1, 2, 3, 4, 5;
+    my @removed = @a.splice(1, 2);
+    is @a.join(","), "1,4,5", '@-array splice still works';
+    is @removed.join(","), "2,3", '@-array splice returns removed';
+}
+
+# a scalar bound to an array via := splices through the shared container
+{
+    my @a = 1, 2, 3, 4;
+    my $r := @a;
+    $r.splice(1, 1);
+    is @a.join(","), "1,3,4", 'splice through a := bound scalar writes to the source';
+}


### PR DESCRIPTION
## Summary

`my \$n = [1,2,3,4,5]; \$n.splice(1,2)` left `\$n` unchanged. The array-mutation
write-back block in `call_method_mut_with_values` was gated on the variable name
starting with `@`, and the plain scalar array-mutator fast path covers
push/pop/shift/unshift/append/prepend but **not** splice — so a scalar-held splice
reached neither path and never mutated.

## Fix

Route a `.splice` on a scalar-like variable holding a real array
(`ArrayKind::Array`) through the same `@`-array splice block. `env.insert(key, …)`
keys on the bare variable name, so a scalar name is written back correctly, and
the type-metadata lookups return `None` for an untyped scalar (a no-op).

This also fixes **`is Array`-instance splice**, which delegates through a
scalar-named (`__mutsu_array_tmp`) temp binding.

## Verification

Against Rakudo: scalar-held splice, splice with a replacement list + the removed
return value, is-Array instance splice, and (no regression) `@`-array splice and
splice through a `:=`-bound scalar.

- pin `t/scalar-held-array-splice.t` (8)
- `make test` green locally (Files=1137, Tests=11413, Result: PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)