### PR TITLE
fix(failure): interpolating an unhandled Failure into a string throws

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1491,6 +1491,13 @@ impl Interpreter {
         let values: Vec<Value> = self.stack.drain(start..).collect();
         let mut result = String::new();
         for v in values {
+            // Interpolating an unhandled Failure into a string throws its underlying
+            // exception (Raku: a Failure is an "unthrown exception" that explodes on
+            // use as a value). Mirrors the prefix:<~> stringify path; without this,
+            // `"$f"` would silently render "Failure()" and hide real errors.
+            if let Some(err) = self.failure_to_runtime_error_if_unhandled(&v) {
+                return Err(err);
+            }
             // Buf/Blob instances with "bytes" attribute: call .Str which throws X::Buf::AsStr
             // Blob type objects (no "bytes" attr, e.g. $*DISTRO.signature) stringify to ""
             if let Value::Instance { attributes, .. } = &v

--- a/t/failure-string-interpolation.t
+++ b/t/failure-string-interpolation.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A Failure is an "unthrown exception" that explodes when used as a value.
+# Interpolating an unhandled Failure into a string must throw its underlying
+# exception (like prefix:<~> / .Str), not silently render "Failure()".
+
+plan 6;
+
+# Interpolating an unhandled Failure throws.
+{
+    my $q = "x";
+    my $f = $q<foo>;   # associative index on a Str -> a Failure
+    dies-ok({ my $s = "val=$f end" }, 'interpolating an unhandled Failure throws');
+}
+
+# The thrown exception carries the right message.
+{
+    my $q = "x";
+    my $f = $q<foo>;
+    throws-like({ my $s = "v=$f" }, Exception,
+                message => /'does not support associative indexing'/,
+                'interpolation throws the underlying exception message');
+}
+
+# Handling the Failure first (// ) means no throw, and the default is used.
+{
+    my $q = "x";
+    my $f = $q<foo>;
+    my $v = $f // 'DEFAULT';
+    is $v, 'DEFAULT', 'a // -handled Failure does not throw';
+    lives-ok({ my $s = "v=$v" }, 'interpolating the handled result does not throw');
+}
+
+# Smartmatch / .defined handle the Failure (no throw).
+{
+    my $q = "x";
+    my $f = $q<foo>;
+    ok ($f ~~ Failure), 'Failure smartmatches Failure (handles it)';
+    nok $f.defined, 'an (now handled) Failure is not defined';
+}


### PR DESCRIPTION
## What

A Failure is an "unthrown exception" that explodes when used as a value. The `prefix:<~>` stringify path already throws an unhandled Failure's underlying exception, but the `StringConcat` opcode used by string **interpolation** (`"...$f..."`) did not — it called `.Stringy`/`.Str` and silently rendered `"Failure()"`, hiding the real error.

This diverged from Rakudo:

```raku
my $q = "x"; my $f = $q<foo>;   # associative index on a Str -> a Failure
say "v=$f";
# Rakudo:  Type Str does not support associative indexing.
# mutsu (before): v=Failure()
# mutsu (after):  Type Str does not support associative indexing.
```

## Why this matters

The silent rendering masked a real authoring bug while exercising the Humming-Bird web framework. `"<p>query: $q</p>"` parses `$q</p>` as an associative subscript `$q<...>` (correct Raku behavior — `$var<...>` interpolates as a subscript). On a `Str` that yields a Failure, which mutsu quietly stringified to `"Failure()"` instead of erroring. This was previously misdiagnosed as a non-deterministic multi-dispatch thread race; it is in fact 100% deterministic and reproduces at the top level.

## Change

Add the unhandled-Failure check to `exec_string_concat_op`, mirroring the existing `prefix:<~>` path. Handled Failures (via `//`, `~~ Failure`, `.defined`, `.so`/`.not`) are unaffected.

## Tests

`t/failure-string-interpolation.t` (6 assertions). `make test` green (11477 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)