### PR TITLE
fix(parser): -> ($a, $b) is one destructuring param, not two

### DIFF
--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -1219,7 +1219,14 @@ pub(super) fn arrow_lambda(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
-    // Sub-signature destructuring: -> (:key($var), :value($var2)) { body }
+    // Sub-signature destructuring: -> ($a, $b) { body }.
+    // In Raku, `-> ($a, $b)` is ONE parameter that binds a single list/Capture
+    // argument and unpacks it — NOT two separate parameters (`-> $a, $b`). So a
+    // multi-element parenthesized signature must become a single destructuring
+    // `__subsig__` param (matching `sub f(($a,$b))`), so `.map(-> ($k,$v){...})`
+    // destructures each list element instead of chunking the list 2-at-a-time.
+    // A single-element paren (`-> ($a)`) keeps the existing behavior of a lone
+    // param (mirrors the capture sub-sig `len == 1` special case in sub_param.rs).
     if r.starts_with('(') {
         let (r, _) = parse_char(r, '(')?;
         let (r, _) = ws(r)?;
@@ -1234,12 +1241,19 @@ pub(super) fn arrow_lambda(input: &str) -> PResult<'_, Expr> {
         if is_rw_block {
             inject_rw_trait(&mut sub_params);
         }
-        let params: Vec<String> = sub_params.iter().map(|p| p.name.clone()).collect();
+        let param_defs = if sub_params.len() > 1 {
+            let mut p = super::super::stmt::sub_param::make_param("__subsig__".to_string());
+            p.sub_signature = Some(sub_params);
+            vec![p]
+        } else {
+            sub_params
+        };
+        let params: Vec<String> = param_defs.iter().map(|p| p.name.clone()).collect();
         return Ok((
             r,
             Expr::AnonSubParams {
                 params,
-                param_defs: sub_params,
+                param_defs,
                 return_type,
                 body,
                 is_rw: false,

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -7,7 +7,7 @@ pub(super) mod modifier;
 pub(super) mod simple;
 mod simple_expr_stmt;
 mod sub;
-mod sub_param;
+pub(crate) mod sub_param;
 
 use super::memo::{MemoEntry, MemoStats, ParseMemo};
 use super::parse_result::{PError, PResult, parse_char, update_best_error};

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -65,7 +65,7 @@ pub(super) fn mark_params_as_invocant(params: &mut [ParamDef]) {
 }
 
 /// Helper to construct a default ParamDef with only required fields.
-fn make_param(name: String) -> ParamDef {
+pub(crate) fn make_param(name: String) -> ParamDef {
     ParamDef {
         name,
         default: None,

--- a/t/pointy-block-destructure.t
+++ b/t/pointy-block-destructure.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# A parenthesized pointy-block signature `-> ($a, $b)` is ONE parameter that
+# binds a single list/Capture argument and unpacks it (destructuring), NOT two
+# separate parameters (`-> $a, $b`). This distinction matters for `.map`:
+#   .map(-> ($k, $v) {...})  destructures each list element
+#   .map(-> $a, $b {...})    chunks the list two-at-a-time
+
+plan 9;
+
+# .map with a destructuring block: each element is a 2-list, unpacked.
+{
+    my @pairs = (1, 'a'), (2, 'b'), (3, 'c');
+    my @out = @pairs.map(-> ($n, $v) { "$n=$v" });
+    is @out.join(','), '1=a,2=b,3=c', '.map(-> ($a,$b)) destructures each element';
+}
+
+# .map with two plain params chunks two-at-a-time (unchanged behavior).
+{
+    my @out = (1, 2, 3, 4).map(-> $a, $b { "$a$b" });
+    is @out.join(','), '12,34', '.map(-> $a, $b) chunks two-at-a-time';
+}
+
+# The real Humming-Bird cookie-decode shape: split then destructuring map.
+{
+    my @r = "sid=abc123".split(/\s/, 2, :skip-empty)
+                        .map(*.split('=', 2, :skip-empty))
+                        .map(-> ($name, $value) { "$name|$value" })
+                        .flat;
+    is @r.join(','), 'sid|abc123', 'split + destructuring map (cookie-decode shape)';
+}
+
+# for over a list-of-lists with a destructuring pointy param.
+{
+    my @log;
+    for ((1, 2), (3, 4)) -> ($k, $v) { @log.push("$k:$v") }
+    is @log.join(','), '1:2,3:4', 'for over list-of-lists destructures -> ($k,$v)';
+}
+
+# for two-at-a-time (no parens) keeps chunking semantics.
+{
+    my @log;
+    for (1, 2, 3, 4) -> $a, $b { @log.push("$a-$b") }
+    is @log.join(','), '1-2,3-4', 'for -> $a, $b chunks two-at-a-time';
+}
+
+# A destructuring block bound directly, called with one list argument.
+{
+    my $b = -> ($a, $c) { "$a/$c" };
+    is $b((10, 20)), '10/20', 'pointy destructuring block called with one list arg';
+}
+
+# A single-element paren stays a lone parameter (no destructuring change).
+{
+    my $b = -> ($x) { $x * 2 };
+    is $b(21), 42, '-> ($x) is a single ordinary parameter';
+}
+
+# Nested data: list of 3-tuples.
+{
+    my @rows = ('a', 1, True), ('b', 2, False);
+    my @out = @rows.map(-> ($name, $num, $flag) { "$name$num$flag" });
+    is @out.join(','), 'a1True,b2False', 'destructuring map with 3 elements';
+}
+
+# rw pointy destructuring still parses and binds.
+{
+    my @pairs = (1, 2), (3, 4);
+    my @sums = @pairs.map(-> ($a, $b) { $a + $b });
+    is @sums.join(','), '3,7', 'destructuring map computing over elements';
+}


### PR DESCRIPTION
## What

In Raku a parenthesized pointy-block signature `-> ($a, $b)` is **one** parameter that binds a single list/Capture argument and unpacks it (destructuring) — it is **not** two separate parameters (`-> $a, $b`). The parser was stripping the parens and flattening the inner list into the block's parameter list, so `-> ($a, $b)` behaved like `-> $a, $b`.

This broke `.map(-> ($k, $v) {...})` — instead of destructuring each list element it chunked the list two-at-a-time, throwing `Not enough elements for map block arity`:

```raku
(("a",1),("b",2)).map(-> ($k, $v) { "$k=$v" })
# Rakudo:        (a=1 b=2)
# mutsu before:  Not enough elements for map block arity
# mutsu after:   (a=1 b=2)
```

## Why it matters

Found while exercising the **Humming-Bird** web framework. Its request cookie decoder is:

```raku
$cookie-string.split(/\s/, 2, :skip-empty)
              .map(*.split('=', 2, :skip-empty))
              .map(-> ($name, $value) { $name => Cookie.new(:$name, :$value) })
```

so `$request.cookie(...)` always errored — request cookies could not be read.

## Change

In `arrow_lambda`, when the parenthesized signature has more than one parameter, wrap it in a single `__subsig__` destructuring param (matching the existing `sub f(($a,$b))` representation), so `.map` / function-call binding destructures each element via the `requires_full_binding` path. A single-element paren (`-> ($x)`) keeps lone-parameter behavior (mirrors the capture sub-signature `len == 1` special case). Genuine two-param blocks (`-> $a, $b`) still chunk two-at-a-time, matching Rakudo.

## Tests

`t/pointy-block-destructure.t` (9 assertions). `make test` green (11486). `roast/S06-signature/*` unaffected (unpack-array, unpack-object, closure-parameters, arity, positional, named-parameters, tree-node-parameters, multidimensional all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)