### PR TITLE
fix(parser): multi-line enum lists and where-then-default signatures

### DIFF
--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -100,6 +100,58 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
     result
 }
 
+/// Like [`expression`] but does NOT consume a trailing simple/compound
+/// assignment. Used for signature `where` constraints so that a following `=`
+/// introduces the parameter default instead of being parsed as an assignment to
+/// the constraint expression. Applies the same fat-arrow and WhateverCode
+/// wrapping as [`expression`].
+pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> {
+    let (rest, mut expr) = precedence::ternary_no_assign(input)?;
+    let (r, _) = ws(rest)?;
+    if r.starts_with("=>") && !r.starts_with("==>") {
+        let r = &r[2..];
+        let (r, _) = ws(r)?;
+        let (r, value) = parse_fat_arrow_value(r)?;
+        let consumed = &input[..input.len() - rest.len()];
+        let is_bareword = matches!(&expr, Expr::BareWord(_));
+        let left = match expr {
+            Expr::BareWord(ref name) if !consumed.trim_start().starts_with('(') => {
+                Expr::Literal(Value::str(name.clone()))
+            }
+            _ => expr,
+        };
+        let pair = Expr::Binary {
+            left: Box::new(left),
+            op: TokenKind::FatArrow,
+            right: Box::new(value),
+        };
+        let result = if is_bareword {
+            pair
+        } else {
+            Expr::PositionalPair(Box::new(pair))
+        };
+        return Ok((r, result));
+    }
+    expr = wrap_composition_operands(expr);
+    if should_wrap_whatevercode(&expr) {
+        expr = match expr {
+            Expr::CallOn { target, args }
+                if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
+            {
+                Expr::CallOn {
+                    target: Box::new(wrap_whatevercode(&target)),
+                    args,
+                }
+            }
+            ref e if try_wrap_whatevercode_call_chain(e).is_some() => {
+                try_wrap_whatevercode_call_chain(&expr).unwrap()
+            }
+            other => wrap_whatevercode(&other),
+        };
+    }
+    Ok((rest, expr))
+}
+
 pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr> {
     // Same as expression but skip memo and don't include sequence
     let (rest, mut expr) = precedence::ternary_mode(input, operators::ExprMode::NoSequence)?;

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -245,6 +245,23 @@ fn call_arg_ternary_expr(input: &str) -> PResult<'_, Expr> {
     ))
 }
 
+/// Parse a ternary-level expression that does NOT consume a trailing simple or
+/// compound assignment (`=`, `+=`, ...). Used for signature `where` constraints,
+/// where a following `=` introduces the parameter default rather than an
+/// assignment to the constraint expression. `ternary_mode` cannot be reused here
+/// because its no-`??` fallback (`or_expr_mode`) includes assignment, which would
+/// swallow the default value (e.g. `$x where Int = 9`).
+pub(super) fn ternary_no_assign(input: &str) -> PResult<'_, Expr> {
+    let (rest, cond) = or_expr_no_assign_mode(input, ExprMode::Full)?;
+    let (rest_ws, _) = ws(rest)?;
+    if rest_ws.starts_with("??") {
+        // A conditional constraint: the full ternary parser is safe because a
+        // top-level `=` only appears after the complete `?? !!` expression.
+        return ternary_mode(input, ExprMode::Full);
+    }
+    Ok((rest, cond))
+}
+
 pub(super) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (rest, cond) = or_expr_no_assign_mode(input, mode)?;
     let (rest_ws, _) = ws(rest)?;

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -42,13 +42,15 @@ fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
         let mut variants = Vec::new();
         let mut r = r;
         loop {
-            let (r2, _) = take_while_opt(r, |c: char| c == ' ' || c == '\t');
+            let (r2, _) =
+                take_while_opt(r, |c: char| c == ' ' || c == '\t' || c == '\n' || c == '\r');
             if let Some(r2) = r2.strip_prefix('>') {
                 r = r2;
                 break;
             }
-            let (r2, word) =
-                take_while1(r2, |c: char| c != '>' && c != ' ' && c != '\t' && c != '\n')?;
+            let (r2, word) = take_while1(r2, |c: char| {
+                c != '>' && c != ' ' && c != '\t' && c != '\n' && c != '\r'
+            })?;
             variants.push((word.to_string(), None));
             r = r2;
         }
@@ -263,13 +265,15 @@ pub(super) fn parse_enum_decl_body_with_type(
         let mut variants = Vec::new();
         let mut r = r;
         loop {
-            let (r2, _) = take_while_opt(r, |c: char| c == ' ' || c == '\t');
+            let (r2, _) =
+                take_while_opt(r, |c: char| c == ' ' || c == '\t' || c == '\n' || c == '\r');
             if let Some(r2) = r2.strip_prefix('>') {
                 r = r2;
                 break;
             }
-            let (r2, word) =
-                take_while1(r2, |c: char| c != '>' && c != ' ' && c != '\t' && c != '\n')?;
+            let (r2, word) = take_while1(r2, |c: char| {
+                c != '>' && c != ' ' && c != '\t' && c != '\n' && c != '\r'
+            })?;
             variants.push((word.to_string(), None));
             r = r2;
         }

--- a/src/parser/stmt/sub_param.rs
+++ b/src/parser/stmt/sub_param.rs
@@ -296,7 +296,10 @@ fn parse_where_constraint_expr(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
-    expression(input)
+    // Parse the constraint without consuming a trailing `=` default value: in a
+    // signature `$x where <constraint> = <default>`, the `=` introduces the
+    // parameter default, not an assignment to the constraint expression.
+    crate::parser::expr::expression_no_assign(input)
 }
 
 fn malformed_double_closure_error() -> PError {

--- a/t/enum-multiline-wordlist.t
+++ b/t/enum-multiline-wordlist.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 6;
+
+# Multi-line `<...>` word-quote enum variant lists (newlines between words).
+my enum Dir <
+    North East
+    South West
+>;
+is North.value, 0, 'first variant on continued line';
+is West.value,  3, 'last variant after newline';
+
+# Anonymous enum spanning lines.
+enum <
+    Red
+    Green Blue
+>;
+is Red.value,   0, 'anon enum first variant';
+is Blue.value,  2, 'anon enum variant after newline';
+
+# The single-line form must still work.
+my enum Flag <a b c>;
+is a.value, 0, 'single-line enum still works';
+is c.value, 2, 'single-line enum last variant';

--- a/t/where-constraint-default.t
+++ b/t/where-constraint-default.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 9;
+
+# A `where` constraint must not swallow the following `=` default value.
+sub a($x where * > 0 = 9) { $x }
+is a(),  9, 'where + default: default applies when arg omitted';
+is a(5), 5, 'where + default: passed arg used';
+
+# Type constraint as the where target, followed by a default.
+sub b($x where Int = 7) { $x }
+is b(),  7, 'where Int + default applies';
+is b(3), 3, 'where Int + passed arg used';
+
+# Named parameter with type, where, default, then a `-->` return constraint.
+sub c(Str:D :$pad where *.chars <= 1 = '=' --> Str) { $pad }
+is c(), '=', 'named typed where + default + return constraint';
+
+# Multi-line signature: where + default, comma, newline, then `-->`.
+sub d(
+    $blob,
+    :$pad where *.chars <= 1 = '=',
+--> Int) {
+    $pad.chars
+}
+is d(1), 1, 'multi-line where + default + comma + return constraint';
+
+# The where constraint still rejects invalid values.
+sub e($x where * > 0 = 9) { $x }
+dies-ok { e(-1) }, 'where still rejects out-of-range value';
+lives-ok { e(2) }, 'where accepts valid value';
+
+# Block form of where with a following default still works.
+sub f($x where { $_ %% 2 } = 4) { $x }
+is f(), 4, 'block where + default';


### PR DESCRIPTION
Two parser fixes uncovered while bringing up the **Cro** module stack.

### 1. Multi-line `<...>` enum variant lists
The single-angle word-quote branch of the enum parser only skipped spaces/tabs
between variants, so an enum whose words span multiple lines failed:

```raku
my enum GENERAL_NAME_TYPE <
    GEN_OTHERNAME GEN_EMAIL GEN_DNS
    GEN_URI GEN_IPADD GEN_RID
>;
```

(from OpenSSL / `IO::Socket::Async::SSL`). Newlines are now skipped between words.

### 2. `where` constraint swallowing the parameter default
A signature `$x where <constraint> = <default>` must treat the `=` as the
parameter default. The constraint was parsed with the full `expression` parser,
whose no-`??` fallback includes assignment, so `$x where Int = 9` parsed as
`where (Int = 9)` with **no** default — and `($x where * > 0 = 9, --> T)` failed
to parse outright. Added a no-assignment expression entry
(`expression_no_assign` / `ternary_no_assign`) used for `where` constraints.

```raku
sub a($x where * > 0 = 9) { $x }   # a() == 9, a(5) == 5
```

This unblocks loading `Base64` and OpenSSL's enum tables.

### Tests
- `t/enum-multiline-wordlist.t`
- `t/where-constraint-default.t`