### PR TITLE
feat(json): Rakudo::Internals::JSON.from-json / .to-json

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -389,6 +389,11 @@ impl Interpreter {
             }
             return self.call_method_with_values(*inner, method, args);
         }
+        // `Rakudo::Internals::JSON.from-json` / `.to-json`: a core Rakudo class
+        // routed to the native JSON implementation (used by OpenSSL, JSON::JWT).
+        if let Some(result) = self.try_rakudo_internals_json_method(&target, method, &args) {
+            return result;
+        }
         // `proto method` body dispatch (see try_proto_method_body).
         if let Some(result) = self.try_proto_method_body(&target, method, &args) {
             return result;

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -33,6 +33,35 @@ impl Interpreter {
             _ => None,
         }
     }
+
+    /// Dispatch `Rakudo::Internals::JSON.from-json` / `.to-json`. Unlike the
+    /// module-provided `to-json`/`from-json` subs, this is a core Rakudo class
+    /// always available (used by e.g. OpenSSL's `%?RESOURCES` loading and
+    /// JSON::JWT), so it is not gated on a JSON module being loaded. Returns
+    /// `Some` when the invocant is the `Rakudo::Internals::JSON` type object and
+    /// the method is one of the two JSON routines.
+    pub(crate) fn try_rakudo_internals_json_method(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !matches!(method, "to-json" | "from-json") {
+            return None;
+        }
+        let Value::Package(name) = target else {
+            return None;
+        };
+        if name.resolve() != "Rakudo::Internals::JSON" {
+            return None;
+        }
+        let (clean_args, _) = self.sanitize_call_args(args);
+        Some(match method {
+            "to-json" => native_to_json(&clean_args),
+            "from-json" => native_from_json(&clean_args),
+            _ => unreachable!(),
+        })
+    }
 }
 
 fn native_to_json(args: &[Value]) -> Result<Value, RuntimeError> {

--- a/t/rakudo-internals-json.t
+++ b/t/rakudo-internals-json.t
@@ -1,0 +1,8 @@
+use Test;
+plan 4;
+my $d = Rakudo::Internals::JSON.from-json(q/{"a":1,"b":[2,3],"c":"x"}/);
+is $d<a>, 1, "from-json scalar";
+is $d<b>[1], 3, "from-json nested array";
+is $d<c>, "x", "from-json string";
+my $j = Rakudo::Internals::JSON.to-json({n => 5});
+like $j, /\"n\"/, "to-json emits key";


### PR DESCRIPTION
`Rakudo::Internals::JSON` is a core Rakudo class (always available, not module-provided) that several ecosystem modules call directly:

- **OpenSSL** loads `%?RESOURCES<libraries.json>` via `Rakudo::Internals::JSON.from-json`
- **JSON::JWT** uses it for token payloads

mutsu had no such class, so the call died with:
```
No such method 'from-json' for invocant of type 'Rakudo::Internals::JSON'
```

This routes `.from-json` / `.to-json` on the `Rakudo::Internals::JSON` type object to the existing native JSON implementation (`runtime/json.rs`). Unlike the module-provided `to-json`/`from-json` subs, it is **not** gated on a JSON module being loaded, since the class is part of the Rakudo core.

Found while bringing up the **Cro** module stack.

### Test
`t/rakudo-internals-json.t`