### PR TITLE
docs(plan): record precise nextsame+rw blocker analysis (§D)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -190,8 +190,23 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     writeback drain→proto exit の `apply_rw_bindings_to_env` が caller へ伝播。VM sub=`vm_call_proto_dispatch`（#3556）／
     interpreter proto method=`call_proto_dispatch` の method_ctx 分岐（#TBD・`lookup_proto_method` で proto def 解決）。
     pin=`t/proto-rw-redispatch-coherence.t`(9・sub) / `t/proto-method-rw-redispatch.t`(5・method)。
-    **残ギャップ（別軸）**: **nextsame+rw チェーン**（first 候補の rw は伝播するが nextsame で次候補へ渡る rw write は
-    `multi_dispatch_stack` 別機構で消える・2 候補ケース 40→41 改善も raku=1041 未達）。
+    **残ギャップ（別軸・深い substrate ブロック・2026-06-25 精査）**: **nextsame+rw チェーン**。
+    `multi pr(Int $x is rw){$x=$x+1; nextsame} multi pr($x is rw){$x=$x+1000}` で `pr($v)`（$v=10）が raku=**1011**
+    に対し mutsu=**11**（次候補の rw write が消える）。精査で判明した真の blocker は **VM↔interpreter の rw-param スロット
+    コヒーレンス**で、3 経路すべてに跨る:
+    - **function VM/OTF 経路**: バレ multi は OTF コンパイルされ VM で走る。`nextsame`（control-flow builtin）は
+      interpreter `dispatch_next_candidate` の `multi_dispatch_stack` 経路に落ち、次候補を `call_function_def`（interpreter）で
+      呼ぶが、(1) 次候補に渡す現在値が **VM ローカルスロット**（$x=11）でなく stale env（$x=10）/ (2) 次候補の rw writeback は
+      env に書くが、**最初の候補の `call_compiled_function_named` 末尾（vm_call_dispatch.rs:2006-2016）が rw-param ローカル
+      スロット（11）を env に flush し直して上書き**するので消える。修正には①次候補に現在スロット値を渡す②次候補の結果を
+      **最初の候補の VM スロット**へ書き戻す（env だけでは flush に潰される）の両方が要る＝§C cell coherence と同根。
+    - **function interpreter 経路**: `multi_dispatch_stack` 経路。`dispatch_next_candidate` に arg_sources 再設定＋現在 rw 値
+      再読みを追加すれば部分的に解けるが、現状すべて OTF 化されるため到達せず単体検証困難。
+    - **method 経路**: `multi method` は `method_dispatch_stack` 経路（dispatch.rs:131-217）で、次候補の rw param に
+      arg_sources が無く **`X::Parameter::RW` で die**（raku は成功）。別機構の修正が要る。
+    試行（4-tuple に現候補 param_defs を追加し interpreter 経路で再読み＋arg_sources 設定）は VM スロット潰し（②）に阻まれ
+    headline repro を直せず revert 済。**結論=単一スライス不可・§C の env↔locals/VM-frame cell 共有を redispatch 境界へ広げる
+    substrate 作業**（要設計）。repro=`tmp/nextsame_rw.raku`（function）/`tmp/nextsame_rw2.raku`（method・die）。
   - [x] **`&`-code param を持つ候補の OTF 化 = 完了（#TBD）→ [news/2026-06.md](news/2026-06.md)**。`def_is_otf_compilable` の
     `!pd.name.starts_with('&')` ガードを撤去（`code_signature`〔`&cb:(Int)`〕と default 値の除外は維持）。`multi f(&cb){…}` 候補が
     bare multi / proto 経由とも compiled 実行され interpreter fallback を解消（proto `&cb` 経由 25%→0%）。block literal / 引数付き


### PR DESCRIPTION
Replaces the vague nextsame+rw residual note in PLAN §2-D with the concrete root cause found during investigation: the next candidate's `is rw` writeback must reach the executing candidate's **VM local slot**, which the interpreter redispatch cannot do — the candidate's `call_compiled_function_named` flush (vm_call_dispatch.rs:2006-2016) overwrites any env write with the stale slot value. Covers all three affected paths (function VM/OTF, function interpreter, method dispatch — the last dies with X::Parameter::RW). Concludes it is §C-style env↔locals / VM-frame cell coherence extended to the redispatch boundary, not a single slice.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)