### PR TITLE
feat(pragma): if pragma — conditional use Foo:if(EXPR)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -615,6 +615,10 @@ pub(crate) enum Stmt {
         /// Import tags specified as colonpairs (e.g. `:ALL`, `:others`).
         /// Empty means default import (:DEFAULT).
         tags: Vec<String>,
+        /// Condition from the `if` pragma's `:if(EXPR)` adverb
+        /// (`use Foo:if($cond)`): the module is loaded only when `EXPR` is true,
+        /// evaluated at runtime. `None` for an unconditional `use`.
+        condition: Option<Box<Expr>>,
     },
     /// `no Module ...;` — disable pragma/module effects for current lexical scope.
     No {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2575,7 +2575,19 @@ impl Compiler {
                 };
                 self.code.emit(OpCode::UseModule { name_idx, tags_idx });
             }
-            Stmt::Use { module, tags, .. } => {
+            // `use if;` — the bare `if` pragma module itself is a no-op; it only
+            // provides the `:if(...)` adverb handled below.
+            Stmt::Use {
+                module,
+                condition: None,
+                ..
+            } if module == "if" => {}
+            Stmt::Use {
+                module,
+                tags,
+                condition,
+                ..
+            } => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
                 let tags_idx = if tags.is_empty() {
                     None
@@ -2583,7 +2595,17 @@ impl Compiler {
                     let entries = tags.iter().cloned().map(Value::str).collect::<Vec<Value>>();
                     Some(self.code.add_constant(Value::array(entries)))
                 };
-                self.code.emit(OpCode::UseModule { name_idx, tags_idx });
+                // `use Foo:if(EXPR)` (the `if` pragma): load the module only when
+                // EXPR is true at runtime, evaluated here so platform-conditional
+                // imports (`use Foo:if($*DISTRO.is-win)`) pick the right branch.
+                if let Some(cond) = condition {
+                    self.compile_expr(cond);
+                    let skip = self.code.emit(OpCode::JumpIfFalse(0));
+                    self.code.emit(OpCode::UseModule { name_idx, tags_idx });
+                    self.code.patch_jump(skip);
+                } else {
+                    self.code.emit(OpCode::UseModule { name_idx, tags_idx });
+                }
             }
             Stmt::Import { module, tags } => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));

--- a/src/parser/stmt/decl/use_decl.rs
+++ b/src/parser/stmt/decl/use_decl.rs
@@ -29,6 +29,7 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
                 module: "v6".to_string(),
                 arg: Some(Expr::Literal(Value::str(version))),
                 tags: Vec::new(),
+                condition: None,
             },
         ));
     }
@@ -57,6 +58,7 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
                 module,
                 arg: Some(arg),
                 tags: Vec::new(),
+                condition: None,
             },
         ));
     }
@@ -64,12 +66,30 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
     // Collect adverbs/colonpairs on use (e.g. `use Foo :ALL`, `use Foo :tag1, :tag2`)
     let mut rest = rest;
     let mut use_tags: Vec<String> = Vec::new();
+    let mut condition: Option<Box<Expr>> = None;
     loop {
         if rest.starts_with(':') && !rest.starts_with("::") {
             let r = &rest[1..];
             // :!name
             let r = r.strip_prefix('!').unwrap_or(r);
             if let Ok((r, tag_name)) = ident(r) {
+                // The `if` pragma's `:if(EXPR)` adverb (`use Foo:if($cond)`) loads
+                // the module only when EXPR is true at runtime. It is NOT an import
+                // tag; capture the condition expression instead.
+                if tag_name == "if" && r.starts_with('(') {
+                    let inner = &r[1..];
+                    let (after_expr, cond) = expression(inner)?;
+                    let (after_expr, _) = ws(after_expr)?;
+                    let after = after_expr
+                        .strip_prefix(')')
+                        .ok_or_else(|| PError::expected("closing ')' in :if() adverb"))?;
+                    condition = Some(Box::new(cond));
+                    let (after, _) = ws(after)?;
+                    let after = after.strip_prefix(',').unwrap_or(after);
+                    let (after, _) = ws(after)?;
+                    rest = after;
+                    continue;
+                }
                 // Version/auth/api selectors (`:ver<...>`, `:auth<...>`, `:api<...>`)
                 // are NOT import tags — they refine which distribution to load.
                 // Consume their `<...>` value and discard, instead of treating the
@@ -130,6 +150,7 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
             module,
             arg,
             tags: use_tags,
+            condition,
         },
     ))
 }
@@ -271,6 +292,7 @@ fn parse_use_smiley_pragma<'a>(input: &'a str, pragma_name: &'a str) -> PResult<
             module: pragma_name.to_string(),
             arg: Some(Expr::Literal(Value::str(format!(":{}", smiley)))),
             tags: Vec::new(),
+            condition: None,
         },
     ))
 }

--- a/t/use-if-pragma.t
+++ b/t/use-if-pragma.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 4;
+
+# The `if` pragma: `use Foo:if(EXPR)` loads Foo only when EXPR is true at
+# runtime. `use if;` itself is a no-op that just enables the adverb.
+# (Crypt::Random uses this to pick a platform backend:
+#  `use Crypt::Random::Win:if($*DISTRO.is-win)`.)
+
+use if;
+pass "use if; is a no-op pragma";
+
+# False condition: the module is NOT loaded, even if it does not exist.
+use Totally::Nonexistent::Module:if(False);
+pass "use Mod:if(False) skips the load entirely";
+
+# True condition: the module IS loaded and its exports are available.
+my $cond = True;
+use List::Util:if(False);   # not loaded
+use Test:if($cond);         # already loaded; just exercises the true branch
+pass "use Mod:if(True) takes the load branch";
+
+# Negated platform-style condition (true on non-Windows).
+use Totally::Other::Missing:if($*DISTRO.is-win);
+pass "use Mod:if(\$*DISTRO.is-win) skips on non-Windows";


### PR DESCRIPTION
The `if` pragma loads a module only when a runtime condition holds:

```raku
use if;
use Crypt::Random::Win:if($*DISTRO.is-win);
use Crypt::Random::Nix:if(!$*DISTRO.is-win);
```

mutsu parsed the `:if(...)` adverb as an import tag, dying with `no such tag 'if' declared`. Now:

- `use if;` (the bare pragma module) is a no-op.
- `:if(EXPR)` is captured as a condition on the `use` (new `Stmt::Use.condition` field) rather than an import tag. The compiler evaluates EXPR at runtime and loads the module only when true — a false branch never even attempts to load a (possibly platform-specific, non-existent) module.

Unblocks `Crypt::Random` (a Cro::HTTP dependency) and other platform-backend-selecting modules.

### Test
`t/use-if-pragma.t`. `make test` green (11534 tests).