### PR TITLE
fix(xx): re-evaluate mutating-method LHS each repetition

### DIFF
--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -327,6 +327,13 @@ impl Compiler {
         }
     }
 
+    /// Whether the left operand of `xx` must be re-evaluated on each repetition.
+    /// Raku's `LHS xx N` evaluates `LHS` afresh N times. mutsu re-evaluates a
+    /// known set of non-deterministic / side-effecting calls (so `rand xx 3`
+    /// yields three values and `@a.push(0) xx 2` pushes twice); plain values and
+    /// pure calls are replicated once. (A fully general re-evaluation is blocked
+    /// by the thunk-result capture path discarding a value-returning user sub's
+    /// result in sink context — tracked separately.)
     pub(super) fn xx_lhs_needs_reeval(expr: &Expr) -> bool {
         matches!(
             expr,
@@ -340,6 +347,13 @@ impl Compiler {
                     || name == "take"
                     || name == "shift"
                     || name == "pop"
+                    // Mutating methods whose side effect must happen each
+                    // repetition (e.g. `@tree.push(0) xx 2` builds two slots).
+                    || name == "push"
+                    || name == "append"
+                    || name == "unshift"
+                    || name == "prepend"
+                    || name == "splice"
                     || name == "readchars"
                     || name == "receive"
                     || name == "getc"

--- a/t/xx-reevaluates-lhs.t
+++ b/t/xx-reevaluates-lhs.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 8;
+
+# Raku's `LHS xx N` re-evaluates a side-effecting / non-deterministic LHS on each
+# of the N repetitions. mutsu re-runs a known set of such calls; plain values are
+# replicated.
+
+# Mutating method runs on each repetition (regression: HTTP::HPACK builds a
+# Huffman tree with `@tree.push(0) xx 2`).
+my @push;
+@push.push(0) xx 3;
+is @push.elems, 3, '.push(0) xx 3 pushes three times';
+
+my @app;
+@app.append(1, 2) xx 2;
+is @app.elems, 4, '.append xx 2 appends twice';
+
+my @un;
+@un.unshift(9) xx 2;
+is @un.elems, 2, '.unshift xx 2 runs twice';
+
+# rand is re-evaluated, so the values vary (not all identical).
+my @r = (^1000).pick xx 20;
+ok @r.unique.elems > 1, '.pick xx N re-evaluated (values vary)';
+
+# Plain literal is replicated.
+is-deeply (42 xx 3).List, (42, 42, 42).List, 'literal replicated';
+
+# Variable read is replicated.
+my $v = 7;
+is-deeply ($v xx 3).List, (7, 7, 7).List, 'variable read replicated';
+
+# A block literal is replicated as a value (NOT executed).
+my $side = 0;
+my @blocks = { $side++ } xx 3;
+is $side, 0, 'block literal not executed by xx';
+
+# Zero count produces an empty list.
+my @z;
+is (@z.push(1) xx 0).elems, 0, 'xx 0 produces empty list';


### PR DESCRIPTION
`@a.push(0) xx 2` must run the push **twice** — Raku re-evaluates the left operand of `xx` on each repetition. mutsu only re-evaluated a whitelist of non-deterministic calls (`rand`/`pick`/`roll`/...), so a mutating-method LHS ran once:

```raku
my @t;
@t.push(0) xx 2;
say @t.elems;   # was 1; now 2
```

This broke **HTTP::HPACK**'s Huffman-tree construction (`@tree.push(0) xx 2`), which then died with `Effective index out of range. Is: -1`.

Add the in-place array mutators (`push`/`append`/`unshift`/`prepend`/`splice`) to the re-evaluation set so their side effect happens on every repetition.

(A fully general re-evaluation of any value-returning user sub is still blocked by the thunk-result capture discarding a sink-context return — left for a separate fix and noted in the code.)

Unblocks loading **HTTP::HPACK** (a Cro::HTTP / HTTP/2 dependency).

### Test
`t/xx-reevaluates-lhs.t` (verified against `raku`). `make test` green (11548).