### PR TITLE
fix(enum): wrap instead of panicking on i64 auto-increment overflow

### DIFF
--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1123,7 +1123,11 @@ impl Interpreter {
             };
             match &val {
                 EnumValue::Int(i) => {
-                    next_int_value = i + 1;
+                    // Wrap instead of panicking when an enum's running counter
+                    // passes i64::MAX (e.g. `enum E (A => 2**63-1, ...)`). The
+                    // auto-increment past MAX is degenerate, but it must not abort
+                    // the interpreter.
+                    next_int_value = i.wrapping_add(1);
                 }
                 EnumValue::Str(_) | EnumValue::Generic(_) => {}
             }

--- a/t/enum-int-overflow.t
+++ b/t/enum-int-overflow.t
@@ -1,0 +1,11 @@
+use Test;
+
+plan 2;
+
+# An enum whose explicit Int value reaches i64::MAX must not abort the
+# interpreter when the running auto-increment counter passes MAX.
+# (Regression: panicked with "attempt to add with overflow". Reaching these
+#  assertions at all proves the declaration did not abort.)
+enum BigE (Top => 9223372036854775807, Other => 0);
+is Top.value, 9223372036854775807, 'explicit max enum value preserved';
+is Other.value, 0, 'following explicit value after max counter is fine';


### PR DESCRIPTION
Declaring an enum whose explicit Int value reaches `i64::MAX` aborted the interpreter with a Rust panic `attempt to add with overflow`:

```raku
enum E (Top => 9223372036854775807, Other => 0);   # panicked at registration_sub.rs:1126
```

The running auto-increment counter did `i + 1` past `MAX`. Use `wrapping_add` so the degenerate past-MAX counter wraps rather than panicking; explicit values are unaffected.

Found while bringing up the Cro stack (a truncated CBOR::Simple constant table hit it).

### Test
`t/enum-int-overflow.t`