### PR TITLE
feat(vm): dispatch plain .starts-with / .ends-with natively (ledger §D(b))

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -717,6 +717,15 @@
   do-block=stack の 2 モード）。pin `t/enter-phaser-rvalue.t`(18)。全 t/(11502)・S04-phasers whitelist(17)・`use Test::Util` whitelist 270 本・roast 1/3
   サンプル 428 本いずれも回帰ゼロ。**★教訓: phaser ブロックの値は ENTER section とは別フェーズで実体化が要る（専用スタックで body 末尾に橋渡し）。do-block は
   値をスタックで返す（`DoBlockExpr` が pop）が statement 文脈は topic 経由＝同じヘルパーをモードで分岐。**
+- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `.starts-with`/`.ends-with`〔無印形〕の VM ネイティブ化)**: method-fallback の名前別実測で
+  `starts-with`(513) が catch-all バウンス上位（`name`/`WHAT`/`WHY`/`can`=MOP 反射・撲滅対象外、`tap`/`stdout`=concurrency 別軸、iterator protocol 群=lazy 別軸を除く）。
+  原因＝`starts-with`/`ends-with` は named-arg（`:i`/`:ignorecase`/`:m`/`:ignoremark`）対応のため slow path（`dispatch_prefix_suffix_check`）に置かれ、**named arg を持たない
+  `.starts-with($needle)` 一般形まで interpreter にバウンス**していた。`(false,false)` ケースは純 prefix/suffix 判定なので `native_method_1arg`（methods_narg.rs）に
+  Str-receiver gated arm を追加。named-arg 形は **2 引数（positional + Pair）なので 1-arg native path に到達せず**自然に slow path へフォールスルー＝byte-identical。
+  user 定義 `.starts-with` は VM が native 前に解決するため非shadow（既存 `contains` arm と同保証）。実測 `$s.starts-with` fallback 2→0。pin `t/starts-ends-with-native.t`(22)。
+  全 t/(11572)・S32-str/starts-with.t・ends-with.t・文字列 roast 70・1/5 roast サンプル 257 回帰ゼロ。**★教訓: named-arg 対応で slow path に置かれた純メソッドは、
+  named-arg が arity を増やして別 path に行くので「無印 1-arg ケースだけ」を native gate（受け手型で限定）すれば安全に drain できる。`substr-eq`(87・位置解決 Whatever/負数/Failure で複雑)
+  は次スライス候補。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -937,8 +937,28 @@ pub(crate) fn native_method_1arg(
             let s = target.to_string_value();
             Some(Ok(contains_value_recursive(&s, arg)))
         }
-        // starts-with and ends-with are handled in runtime/methods.rs
-        // to support named args (:i, :ignorecase, :m, :ignoremark)
+        // starts-with / ends-with: the plain `.starts-with($needle)` form (a
+        // single positional argument) is a pure prefix/suffix check on a Str
+        // receiver, so handle it natively here. The case-/mark-insensitive forms
+        // (`:i`/`:ignorecase`/`:m`/`:ignoremark`) carry a second (Pair) argument
+        // and so never reach this 1-arg path — they keep falling through to the
+        // interpreter's `dispatch_prefix_suffix_check` (runtime/methods_string.rs).
+        "starts-with" | "ends-with" if matches!(target, Value::Str(_)) => {
+            if let Value::Package(type_name) = arg {
+                return Some(Err(RuntimeError::new(format!(
+                    "Cannot resolve caller {}({}:U)",
+                    method, type_name
+                ))));
+            }
+            let text = target.to_string_value();
+            let needle = arg.to_string_value();
+            let ok = if method == "starts-with" {
+                text.starts_with(needle.as_str())
+            } else {
+                text.ends_with(needle.as_str())
+            };
+            Some(Ok(Value::Bool(ok)))
+        }
         "samemark" => {
             let target_str = target.to_string_value();
             let source_str = arg.to_string_value();

--- a/t/starts-ends-with-native.t
+++ b/t/starts-ends-with-native.t
@@ -1,0 +1,49 @@
+use Test;
+
+# The plain `.starts-with($needle)` / `.ends-with($needle)` form (a single
+# positional argument on a Str receiver) is dispatched natively by the VM
+# instead of falling back to the tree-walking interpreter. The case-/mark-
+# insensitive named-arg forms keep falling through, so they must still work too.
+
+plan 22;
+
+# Basic prefix/suffix on a string variable and a literal.
+my $s = "hello world";
+ok $s.starts-with("hello"), 'variable receiver starts-with prefix';
+ok $s.ends-with("world"),   'variable receiver ends-with suffix';
+ok "hello".starts-with("he"), 'literal receiver starts-with prefix';
+ok "hello".ends-with("lo"),   'literal receiver ends-with suffix';
+
+nok $s.starts-with("world"), 'starts-with non-prefix is False';
+nok $s.ends-with("hello"),   'ends-with non-suffix is False';
+
+# Empty needle / empty string edge cases.
+ok "abc".starts-with(""), 'starts-with empty needle is True';
+ok "abc".ends-with(""),   'ends-with empty needle is True';
+ok "".starts-with(""),    'empty string starts-with empty is True';
+nok "abc".starts-with("abcd"), 'longer needle is False';
+
+# Unicode.
+ok "café".ends-with("fé"),   'ends-with multibyte suffix';
+ok "café".starts-with("caf"), 'starts-with multibyte prefix';
+
+# Non-string (Cool) receiver: coerced to Str (falls through to interpreter).
+ok 42.starts-with("4"),  'Int receiver coerces and starts-with';
+ok 42.ends-with("2"),    'Int receiver coerces and ends-with';
+
+# Case-insensitive / mark-insensitive named-arg forms still work.
+ok "Hello".starts-with("hello", :i), 'starts-with :i case-insensitive';
+ok "WORLD".ends-with("rld", :i),     'ends-with :i case-insensitive';
+ok "café".ends-with("cafe", :m),     'ends-with :m mark-insensitive';
+nok "Hello".starts-with("hello"),    'starts-with without :i is case-sensitive';
+
+# Needle coercion from a non-Str positional.
+ok "42abc".starts-with(42), 'numeric needle coerces to Str';
+
+# A user-defined .starts-with method is not shadowed by the native arm.
+class D { method starts-with($x) { "user:$x" } }
+is D.new.starts-with("z"), "user:z", 'user-defined starts-with takes precedence';
+
+# Chained on the result of another method.
+ok "  trim me  ".trim.starts-with("trim"), 'starts-with after .trim';
+ok "ABCDEF".lc.ends-with("def"), 'ends-with after .lc';


### PR DESCRIPTION
## Summary

First slice of §D(b) (tree-walk dispatch-chain removal). A method-fallback-by-name survey showed `starts-with=513` as the top *removable* catch-all bounce — after excluding MOP reflection (`name`/`WHAT`/`WHY`/`can`), concurrency (`tap`/`stdout`), and the lazy iterator protocol, which are all blocked on other axes.

`.starts-with`/`.ends-with` were routed through the interpreter's `dispatch_prefix_suffix_check` because that path handles the case-/mark-insensitive named-arg forms (`:i`/`:ignorecase`/`:m`/`:ignoremark`). That left the **common no-named-arg form** bouncing too.

The no-named-arg case is a pure prefix/suffix check, so this adds a `Str`-receiver-gated arm to `native_method_1arg`. The named-arg forms carry a second (`Pair`) argument, so they never reach the 1-arg native path and keep falling through to the interpreter — byte-identical. A user-defined `.starts-with` is resolved before native dispatch (same guarantee as the existing `contains` arm), so it is not shadowed.

## Testing

- pin `t/starts-ends-with-native.t` (22)
- All `t/` (1155 files, 11572 tests) pass
- `S32-str/starts-with.t`, `S32-str/ends-with.t`, the string-roast subset (70), and a 1/5 roast whitelist sample (257) — no regressions
- Verified `.starts-with($n)` now dispatches with 0 fallbacks; `:i`/`:m`, Cool receivers, and user methods all still correct vs Rakudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)