### PR TITLE
feat(vm): dispatch .substr-eq($needle, Int $pos) natively (ledger §D(b))

### DIFF
--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -2798,6 +2798,40 @@ pub(crate) fn native_method_2arg(
         return None;
     }
 
+    // `.substr-eq($needle, $pos)` with a plain non-negative Int position is a
+    // pure substring comparison on a Str receiver. Whatever / negative /
+    // out-of-range positions and the case-/mark-insensitive named-arg forms
+    // (`:i`/`:m`, which arrive as an extra Pair argument) keep the interpreter's
+    // position resolution + Failure semantics (runtime/methods_string.rs).
+    if method == "substr-eq"
+        && let Value::Str(_) = &target
+    {
+        if let Value::Package(type_name) = arg1 {
+            return Some(Err(RuntimeError::new(format!(
+                "Cannot resolve caller substr-eq({}:U)",
+                type_name
+            ))));
+        }
+        let Value::Int(pos) = arg2.descalarize() else {
+            return None;
+        };
+        if *pos < 0 {
+            return None;
+        }
+        let text = target.to_string_value();
+        let len = text.chars().count() as i64;
+        if *pos > len {
+            return None;
+        }
+        let needle = arg1.to_string_value();
+        let substr: String = text
+            .chars()
+            .skip(*pos as usize)
+            .take(needle.chars().count())
+            .collect();
+        return Some(Ok(Value::Bool(substr == needle)));
+    }
+
     if method == "split" {
         if let Value::Instance { class_name, .. } = target
             && (class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe")

--- a/t/substr-eq-native.t
+++ b/t/substr-eq-native.t
@@ -1,0 +1,40 @@
+use Test;
+
+# The `.substr-eq($needle, $pos)` form with a plain non-negative Int position on
+# a Str receiver is dispatched natively by the VM. Whatever / out-of-range /
+# negative positions and the case-/mark-insensitive named-arg forms keep falling
+# through to the interpreter.
+
+plan 16;
+
+ok  "hello".substr-eq("ell", 1),   'matching substring at position';
+nok "hello".substr-eq("ell", 2),   'non-matching substring at position';
+ok  "hello".substr-eq("hello", 0), 'full match at position 0';
+ok  "hello".substr-eq("lo", 3),    'match at tail position';
+nok "hello".substr-eq("xx", 1),    'no match';
+ok  "hello".substr-eq("", 2),      'empty needle matches anywhere in range';
+ok  "hello".substr-eq("o", 4),     'single char at last position';
+
+# Position equal to length with empty needle is in range.
+ok  "abc".substr-eq("", 3),        'empty needle at position == length';
+
+# Unicode.
+ok  "café au lait".substr-eq("au", 5), 'multibyte substring match';
+ok  "café".substr-eq("fé", 2),         'multibyte tail match';
+
+# Numeric needle coerces to Str.
+ok  "a42b".substr-eq(42, 1),       'numeric needle coerces';
+
+# Case-insensitive named-arg form (falls through to the interpreter).
+ok  "hello".substr-eq("ELL", 1, :i), 'substr-eq :i case-insensitive';
+nok "hello".substr-eq("ELL", 1),     'substr-eq without :i is case-sensitive';
+
+# Position from a Whatever (falls through; interpreter resolves it).
+ok  "hello".substr-eq("lo", *-2),  'substr-eq with Whatever position';
+
+# A user-defined .substr-eq method is not shadowed by the native arm.
+class S { method substr-eq($a, $b) { "user:$a:$b" } }
+is S.new.substr-eq("x", 1), "user:x:1", 'user-defined substr-eq takes precedence';
+
+# Chained on a method result.
+ok "  hello  ".trim.substr-eq("ell", 1), 'substr-eq after .trim';


### PR DESCRIPTION
## Summary

Second slice of §D(b) (tree-walk dispatch-chain removal), following the `.starts-with`/`.ends-with` native drain pattern. `.substr-eq` was routed through the interpreter (`dispatch_substr_eq`) because that path handles the case-/mark-insensitive named-arg forms (`:i`/`:m`) and Whatever / negative / out-of-range position resolution (which produce a Failure).

The plain `.substr-eq($needle, $pos)` form with a **non-negative, in-bounds Int** position on a `Str` receiver is a pure substring comparison, so this adds a native arm to `native_method_2arg`. Everything else falls through unchanged:
- Whatever / non-Int position → interpreter resolution
- negative / out-of-range position → interpreter Failure semantics
- named-arg forms (`:i`/`:m`) carry an extra `Pair` (arity 3) → never reach the 2-arg native path
- user-defined `.substr-eq` is resolved before native dispatch (not shadowed)

The rarer 1-arg form (`.substr-eq($needle)`, position 0) keeps falling through.

## Testing

- pin `t/substr-eq-native.t` (16)
- All `t/` (1155 files, 11566 tests) pass
- `S32-str/substr-eq.t`, `indices.t`, `index.t` pass
- Verified the native path is byte-identical to the interpreter for the in-bounds Int case; every fall-through case (Whatever, out-of-range, `:i`, user method) unchanged vs Rakudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)