### PR TITLE
docs: record §D(b) Str-method native-dispatch drains

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -726,6 +726,13 @@
   全 t/(11572)・S32-str/starts-with.t・ends-with.t・文字列 roast 70・1/5 roast サンプル 257 回帰ゼロ。**★教訓: named-arg 対応で slow path に置かれた純メソッドは、
   named-arg が arity を増やして別 path に行くので「無印 1-arg ケースだけ」を native gate（受け手型で限定）すれば安全に drain できる。`substr-eq`(87・位置解決 Whatever/負数/Failure で複雑)
   は次スライス候補。**
+- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `.substr-eq($needle, Int $pos)` の VM ネイティブ化)**: starts-with と同パターンの 2 スライス目。`.substr-eq` は
+  named-arg（`:i`/`:m`）と Whatever/負数/範囲外の位置解決（Failure 生成）対応のため slow path（`dispatch_substr_eq`）に在った。**plain 2 引数形＋非負 in-bounds Int 位置＋Str
+  受け手**は純 substring 比較なので `native_method_2arg` に arm 追加。それ以外は全てフォールスルー: Whatever/非Int 位置（`arg2` が `Int` でない）→ interpreter 解決／負数・範囲外 →
+  interpreter Failure／named-arg 形（Pair 追加で arity 3）→ 2-arg native path 不到達／user 定義 `.substr-eq` は native 前に解決＝非shadow。1 引数形（位置 0 デフォルト）は稀でフォールスルー維持。
+  pin `t/substr-eq-native.t`(16)。全 t/(11566)・S32-str/substr-eq.t・indices.t・index.t 回帰ゼロ。**★残る clean な string drain は枯渇**: `comb` 単純形は既に native（survey の 93 は
+  regex/named-arg 形）、`trans`(65) は range（spec 文字列内 `a..z`）/list-pair/regex で複雑、`Int`/`Num`/`Str.new` は ctor 完了済み領域。残カテゴリ＝iterator protocol 群（lazy・別軸）/
+  MOP carrier（反射・撲滅対象外）/concurrency（tap/emit・別軸）で、いずれも §D(b) の純 drain でなく別 substrate 前提。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,27 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### §D(b) tree-walk dispatch chain 削除 — 純 Str メソッドの VM ネイティブ化（`.starts-with`/`.ends-with`/`.substr-eq`）
+
+§D(b)（tree-walk method dispatch チェーンの構造的削除）に着手。method-fallback の名前別実測で、撲滅対象外（MOP 反射 `name`/`WHAT`/
+`WHY`/`can`）・別軸（concurrency `tap`/`stdout`、lazy iterator protocol `push-*`/`pull-one`）を除いた**最大の removable バウンス**が
+`starts-with`(513) と判明。原因は共通パターン: **named-arg 対応のため slow path に置かれた純メソッドが、無印形まで interpreter に
+バウンス**していた。
+
+- **`.starts-with`/`.ends-with`（#3580）**: case-/mark-insensitive 形（`:i`/`:ignorecase`/`:m`/`:ignoremark`）対応で
+  `dispatch_prefix_suffix_check` に在ったが、無印 `.starts-with($needle)` は純 prefix/suffix 判定。`native_method_1arg` に
+  Str-receiver gated arm 追加。named-arg 形は 2 引数（positional + Pair）なので 1-arg native path に到達せず自然にフォールスルー。
+- **`.substr-eq($needle, Int $pos)`（#3581）**: 同パターン。plain 2 引数形＋非負 in-bounds Int 位置＋Str 受け手を `native_method_2arg`
+  に追加。Whatever/負数/範囲外位置（Failure 生成）と named-arg 形（arity 3）はフォールスルー維持。
+
+両者とも **user 定義メソッドは VM が native 前に解決＝非shadow**（既存 `contains` arm と同保証）、フォールスルーケースは byte-identical。
+pin=`t/starts-ends-with-native.t`(22)/`t/substr-eq-native.t`(16)。全 t/・S32-str 系・roast サンプル回帰ゼロ。
+
+**★教訓**: named-arg 対応で slow path に置かれた純メソッドは、named-arg が arity を増やして別 dispatch path に行くので、
+**「無印ケースだけ」を受け手型で gate すれば安全に drain できる**。**残る clean な string drain は枯渇**（`comb` 単純形は既に native /
+`trans` は range・list-pair・regex で複雑 / scalar `.new` は ctor 完了済み）。残カテゴリ（iterator protocol=lazy・MOP=反射・
+concurrency）はいずれも別 substrate 前提＝§D(b) の純 drain ではない。
+
 ### `use` の `ORIGINAL_SOURCE` clobber バグ修正＋露出した phaser ブロック値バグ群の一般修正（§D）
 
 PLAN.md §2-D で「分離済み別軸（要別作業）」として残していた **`use` の `ORIGINAL_SOURCE` clobber バグ**を修正し、それが


### PR DESCRIPTION
Adds the ledger entry for the `.substr-eq` native arm (#3581) and a consolidated news highlight for the §D(b) tree-walk dispatch-chain drains (`.starts-with`/`.ends-with` #3580 + `.substr-eq` #3581). Notes the clean Str catch-all drains are now exhausted; remaining fallback categories (lazy iterator protocol, MOP reflection, concurrency) each depend on a separate substrate.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)