### PR TITLE
fix(parser): three constructs blocking popular ecosystem modules

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1038,6 +1038,29 @@ fn parse_dot_assign<'a>(input: &'a str, expr: Expr) -> PResult<'a, Expr> {
         };
         return Ok((r_final, result));
     }
+    // `.= &sub` / `.= $meth` — mutating method-call-via-sub or dynamic method
+    // name (`$x .= &f` means `$x = $x.&f`). The name is a sigiled expression.
+    if r.starts_with('&') || r.starts_with('$') || r.starts_with('@') || r.starts_with('%') {
+        let (r_name, name_expr) = crate::parser::primary::primary(r)?;
+        let (r_after, _) = ws(r_name)?;
+        let (r_final, args) = if r_after.starts_with('(') {
+            let (r2, _) = parse_char(r_after, '(')?;
+            let (r2, _) = ws(r2)?;
+            let (r2, a) = parse_call_arg_list(r2)?;
+            let (r2, _) = ws(r2)?;
+            let (r2, _) = parse_char(r2, ')')?;
+            (r2, a)
+        } else {
+            (r_name, vec![])
+        };
+        let result = wrap_dot_assign(expr, |target| Expr::DynamicMethodCall {
+            target: Box::new(target),
+            name_expr: Box::new(name_expr.clone()),
+            args: args.clone(),
+            modifier: None,
+        });
+        return Ok((r_final, result));
+    }
     // Parse regular method name
     let (r, method_name) = crate::parser::primary::var::parse_ident_with_hyphens(r)?;
     let r_before_ws = r;

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -503,7 +503,14 @@ fn parse_token_like_name(input: &str) -> PResult<'_, String> {
             break;
         }
         let r = &rest[1..];
-        let (r, part) = take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?;
+        // `:sym<value>` has an identifier part; `:<value>` (shorthand for
+        // `:sym<value>`) has the colon immediately followed by `<...>` with no
+        // part name. Allow an empty part in that case.
+        let (r, part) = if r.starts_with('<') || r.starts_with("<<") || r.starts_with('\u{ab}') {
+            (r, "")
+        } else {
+            take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?
+        };
         name.push(':');
         name.push_str(part);
         let mut r2 = r;

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -2154,9 +2154,16 @@ fn parse_param_list_with_return_inner(input: &str) -> PResult<'_, (Vec<ParamDef>
         rest = r;
     }
     if let Some((r, _invocant_type)) = parse_implicit_invocant_marker(rest) {
+        let (r, _) = ws(r)?;
         rest = r;
         if rest.starts_with(')') {
             return Ok((rest, (params, return_type)));
+        }
+        // A typed invocant may be followed directly by the return constraint:
+        // `method m(Foo:D: --> Str)` has no positional params after the invocant.
+        if let Some(stripped) = rest.strip_prefix("-->") {
+            let (r, rt) = parse_return_type_annotation(stripped)?;
+            return Ok((r, (params, Some(rt))));
         }
         let (r, mut p) = parse_single_param(rest)?;
         p.multi_invocant = multi_invocant;

--- a/t/parser-lib-blockers.t
+++ b/t/parser-lib-blockers.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 7;
+
+# Three parser bugs that block popular ecosystem modules (URI, HTTP::Tiny,
+# YAMLish), each reduced to a minimal construct.
+
+# 1. Typed invocant followed directly by a return constraint (URI).
+class IB { method m(IB:D: --> Str) { "ok" } }
+is IB.new.m, "ok", 'typed invocant + return constraint in method signature';
+
+class IB2 { multi method n(IB2:D: --> Int) { 7 } }
+is IB2.new.n, 7, 'multi method typed invocant + return constraint';
+
+# 2. `.=` update assignment whose RHS is a sub reference (`$x .= &f`) — HTTP::Tiny.
+sub dbl($x) { $x * 2 }
+my $v = 21;
+$v .= &dbl;
+is $v, 42, '.= with a &sub reference (method-call-via-sub update)';
+
+my $w = 10;
+sub addn($x, $n) { $x + $n }
+$w .= &addn(5);
+is $w, 15, '.= &sub(args) passes extra arguments';
+
+# 3. Grammar named-variant declarator `:<name>` (YAMLish).
+grammar G {
+    rule TOP { <element> }
+    proto token element {*}
+    token element:<null> { 'null' }
+    token element:<true> { 'true' }
+}
+ok G.^name eq 'G', 'grammar with token NAME:<variant> declarators parses';
+
+# The `:sym<...>` long form still works.
+grammar G2 {
+    proto token op {*}
+    token op:sym<plus> { '+' }
+}
+ok G2.^name eq 'G2', 'token NAME:sym<variant> still parses';
+
+# Plain token still works.
+grammar G3 { token word { \w+ } }
+ok G3.parse('hello', :rule<word>), 'plain token still parses and matches';


### PR DESCRIPTION
From a load survey of the installed module set (49 dists: 30 OK, 11 parse errors, 4 runtime). Three parser bugs blocked **URI**, **HTTP::Tiny**, and **YAMLish**:

1. **Typed invocant + return constraint**: `method m(Foo:D: --> Str) { }`. After the invocant marker the signature parser tried to read a positional param and choked on `-->`; now it recognizes the return constraint. *(URI)*

2. **`.=` with a sub-reference RHS**: `$x .= &f` means `$x = $x.&f`. `parse_dot_assign` only accepted a method name; now a sigiled name expression (`&f` / `$meth`, optional args) builds a `.&`-style dynamic method call. *(HTTP::Tiny)*

3. **Grammar named-variant shorthand** `token foo:<bar> { }` (a `:sym<bar>` with no identifier part). `parse_token_like_name` required an identifier after `:`; now an empty part before `<...>` / `<<>>` / `«»` is allowed. *(YAMLish)*

Each module advances past its first parse error (they have further, unrelated blockers — this is part of an ongoing "make popular libraries load" effort).

### Test
`t/parser-lib-blockers.t` (verified against `raku`). `make test` green (11557).