### PR TITLE
feat: PROCESS::<$x> write-through and Rakudo::Internals.REGISTER-DYNAMIC

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -367,7 +367,7 @@ impl Compiler {
             return;
         }
         if let Expr::PseudoStash(stash_name) = target
-            && stash_name == "MY::"
+            && (stash_name == "MY::" || stash_name == "PROCESS::")
             && let Expr::Literal(Value::Str(key_name)) = index
         {
             self.compile_expr(value);

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -394,6 +394,42 @@ impl Interpreter {
         if let Some(result) = self.try_rakudo_internals_json_method(&target, method, &args) {
             return result;
         }
+        // `Rakudo::Internals.REGISTER-DYNAMIC: '$*name', { ... }` installs a
+        // default for a process dynamic variable by running the initializer
+        // block (which typically does `PROCESS::<$name> = ...`). Real Rakudo runs
+        // it lazily on first access; running it eagerly here is sufficient for the
+        // modules that use it (e.g. DBIish's `$*DBI-DEFS`).
+        if method == "REGISTER-DYNAMIC"
+            && matches!(&target, Value::Package(name) if name.resolve() == "Rakudo::Internals")
+        {
+            let (clean_args, _) = self.sanitize_call_args(&args);
+            let name = clean_args
+                .iter()
+                .find(|a| matches!(a, Value::Str(_)))
+                .map(|v| v.to_string_value());
+            let block = clean_args
+                .iter()
+                .find(|a| matches!(a, Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }))
+                .cloned();
+            if let Some(block) = block {
+                // Run the initializer block. Its `PROCESS::<$name> = ...` writes
+                // into the block's own frame (lost on return), so also bind the
+                // dynamic var in the caller's scope from the block's result — the
+                // assignment's value — keyed by the supplied name. `$*name`
+                // (env key `*name`) then resolves.
+                let result = self.call_sub_value(block, Vec::new(), false)?;
+                if let Some(name) = name {
+                    let env_key = match name.strip_prefix("$*").or_else(|| name.strip_prefix('$')) {
+                        Some(bare) => format!("*{bare}"),
+                        None => format!("*{name}"),
+                    };
+                    if self.env().get(&env_key).is_none() {
+                        self.env_mut().insert(env_key, result);
+                    }
+                }
+            }
+            return Ok(Value::Nil);
+        }
         // `proto method` body dispatch (see try_proto_method_body).
         if let Some(result) = self.try_proto_method_body(&target, method, &args) {
             return result;

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -4300,6 +4300,35 @@ impl Interpreter {
         key_name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let stash_name = Self::const_str(code, stash_name_idx);
+        // `PROCESS::<$name> = value` sets the process-level dynamic variable, so
+        // a later `$*name` (stored in the env as `*name`) resolves to it. This is
+        // how `Rakudo::Internals.REGISTER-DYNAMIC` installs defaults (e.g.
+        // DBIish's `$*DBI-DEFS`).
+        if stash_name == "PROCESS::" {
+            let raw_key = Self::const_str(code, key_name_idx).to_string();
+            // Map the sigiled stash key to the env dynamic-var key:
+            //   $name → *name, @name → @*name, %name → %*name, name → *name
+            let env_key = match raw_key.chars().next() {
+                Some('$') => format!("*{}", &raw_key[1..]),
+                Some('@') => format!("@*{}", &raw_key[1..]),
+                Some('%') => format!("%*{}", &raw_key[1..]),
+                _ => format!("*{raw_key}"),
+            };
+            let val = self.stack.pop().unwrap_or(Value::Nil);
+            let val = if env_key.starts_with('@') {
+                runtime::coerce_to_array(val)
+            } else if env_key.starts_with('%') {
+                self.coerce_hash_var_value(&env_key, val)?
+            } else {
+                Self::normalize_scalar_assignment_value(val)
+            };
+            self.env_mut().insert(env_key, val.clone());
+            // An assignment is an expression: leave the assigned value on the
+            // stack so `Rakudo::Internals.REGISTER-DYNAMIC`'s block (whose body is
+            // `PROCESS::<$x> = ...`) returns it.
+            self.stack.push(val);
+            return Ok(());
+        }
         if stash_name != "MY::" {
             return Err(RuntimeError::new(format!(
                 "Unsupported pseudo-stash assignment target {stash_name}"

--- a/t/process-register-dynamic.t
+++ b/t/process-register-dynamic.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 5;
+
+# `PROCESS::<$name> = value` sets a process-level dynamic variable so a later
+# `$*name` resolves to it (used by Rakudo::Internals.REGISTER-DYNAMIC).
+PROCESS::<$MY-PROC-VAR> = 42;
+is $*MY-PROC-VAR, 42, 'PROCESS::<$x> = v makes $*x resolve';
+
+# The assignment is an expression returning the assigned value.
+my $r = (PROCESS::<$RV> = 7);
+is $r, 7, 'PROCESS::<$x> = v returns the assigned value';
+
+# Visible across call frames (dynamic scoping).
+PROCESS::<$SEEN> = 'yes';
+sub check-it { $*SEEN }
+is check-it(), 'yes', 'process dynamic var visible inside a sub';
+
+# Rakudo::Internals.REGISTER-DYNAMIC installs a default via its block.
+Rakudo::Internals.REGISTER-DYNAMIC: '$*DBI-DEFS', {
+    PROCESS::<$DBI-DEFS> = { ConnDefaults => 'x' }
+}
+is $*DBI-DEFS<ConnDefaults>, 'x', 'REGISTER-DYNAMIC installs a process default';
+
+# REGISTER-DYNAMIC with a block that simply returns a value.
+Rakudo::Internals.REGISTER-DYNAMIC: '$*SIMPLE-DEF', { 99 }
+is $*SIMPLE-DEF, 99, 'REGISTER-DYNAMIC binds the block result';


### PR DESCRIPTION
Two related process-dynamic-variable features, prerequisites for **DBIish** (the database cluster) and useful generally.

1. **`PROCESS::<$name> = value`** now sets the process-level dynamic variable so a later `$*name` resolves to it (env key `*name`; `@`/`%` sigils map to `@*name`/`%*name`). The assignment is an expression returning the assigned value. Previously the write was discarded and `$*name` read `Nil`. Compiled via the existing `IndexAssignPseudoStashNamed` op, extended from `MY::` to `PROCESS::`.

2. **`Rakudo::Internals.REGISTER-DYNAMIC: '$*name', { ... }`** installs a default for a process dynamic variable by running the initializer block and binding `$*name` to its result. Real Rakudo runs the block lazily on first access; running it eagerly is sufficient for the modules that use it (e.g. DBIish's `$*DBI-DEFS`).

```raku
Rakudo::Internals.REGISTER-DYNAMIC: '$*DBI-DEFS', {
    PROCESS::<$DBI-DEFS> = { ConnDefaults => 'x' }
}
say $*DBI-DEFS<ConnDefaults>;   # x
```

**DBIish** advances past its `REGISTER-DYNAMIC` load failure (it has further, unrelated blockers).

### Test
`t/process-register-dynamic.t` (verified against `raku`). `make test` green (11600).