### PR TITLE
fix(role): allow lexically-scoped `my role` inside a role body

### DIFF
--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -194,7 +194,14 @@ pub(super) fn try_keyword_dispatch(
     }
     // my role Name[...] { ... }
     if keyword("role", rest).is_some() {
-        return role_decl(rest).map(Some);
+        let (r, mut stmt) = role_decl(rest)?;
+        // A `my role` is lexically scoped (private to its declaring scope). Mark it
+        // so the role-body forbidden-declaration check allows it inside another role,
+        // mirroring how `my class` is permitted inside a role.
+        if !is_our && let Stmt::RoleDecl { custom_traits, .. } = &mut stmt {
+            custom_traits.push(("__my_scoped".to_string(), None));
+        }
+        return Ok(Some((r, stmt)));
     }
     // my module Name { ... }
     if keyword("module", rest).is_some() {

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -2801,6 +2801,14 @@ impl Interpreter {
                 Stmt::ClassDecl { .. } => None,
                 Stmt::SubsetDecl { .. } => Some("subset"),
                 Stmt::EnumDecl { .. } => Some("enum"),
+                // A `my role` is lexically scoped and private to the role body, which
+                // is allowed (like `my class`); only an implicitly our-scoped `role` is
+                // forbidden.
+                Stmt::RoleDecl { custom_traits, .. }
+                    if custom_traits.iter().any(|(t, _)| t == "__my_scoped") =>
+                {
+                    None
+                }
                 Stmt::RoleDecl { .. } => Some("role"),
                 Stmt::VarDecl {
                     is_our: true,

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1684,6 +1684,10 @@ impl Interpreter {
             if has_trait_mod && (!custom_traits.is_empty() || !role_deferred.is_empty()) {
                 let type_obj = Value::Package(Symbol::intern(&qualified_name));
                 for (trait_name, trait_arg) in custom_traits {
+                    // Skip internal markers (e.g. `__my_scoped`); they are not real `is` traits.
+                    if trait_name.starts_with("__") {
+                        continue;
+                    }
                     let trait_value = if let Some(arg_expr) = trait_arg {
                         self.vm_eval_block_value(&[Stmt::Expr(arg_expr.clone())])?
                     } else {

--- a/t/my-role-in-role.t
+++ b/t/my-role-in-role.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 5;
+
+# A `my role` (lexically scoped) declared inside a role body is allowed,
+# mirroring how `my class` is permitted inside a role. Previously mutsu
+# rejected it with X::Declaration::OurScopeInRole, which blocked DBIish
+# (DBDish::StatementHandle declares `my role IntTrue` inside a unit role).
+role Outer {
+    my role IntTrue { method Bool { self.defined } }
+    method wrap($x) { $x but IntTrue }
+}
+class C does Outer {}
+
+my $v = C.new.wrap(42);
+ok $v.Bool, 'mixed-in my role method works';
+is $v + 0, 42, 'underlying value preserved through mixin';
+isa-ok $v, Int, 'value still an Int';
+
+# An implicitly our-scoped `role` inside a role is still forbidden.
+throws-like 'role A { role B { } }', X::Declaration::OurScopeInRole,
+    'implicit our-scoped role inside a role is forbidden';
+
+# An explicit `our role` inside a role is still forbidden.
+throws-like 'role A { our role B { } }', X::Declaration::OurScopeInRole,
+    'explicit our-scoped role inside a role is forbidden';


### PR DESCRIPTION
A `my role` declared inside a role body is lexically scoped and private to that scope, so it is allowed in Raku — just like a `my class`. mutsu rejected any role declaration nested in a role with `X::Declaration::OurScopeInRole`, which blocked **DBIish** from loading: `DBDish::StatementHandle` is a `unit role` that declares `my role IntTrue { method Bool {...} }` in its body.

## Fix
- Parser tags a `my role` with an internal `__my_scoped` custom-trait marker (mirroring `__our_scoped` for `my sub`).
- The role-body forbidden-declaration check skips `__my_scoped` roles (like it already does for `my class`).
- The role `trait_mod:<is>` dispatch ignores all `__`-prefixed internal markers so they are never treated as real `is` traits.
- Implicit and explicit `our role` inside a role are still forbidden.

## Result
DBIish now loads end-to-end (`use DBIish` succeeds). New regression test `t/my-role-in-role.t` (5 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)