### PR TITLE
fix(placeholder): allow %_ / @_ inside a do {} block within a method

### DIFF
--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -4,9 +4,11 @@ impl Compiler {
     pub(super) fn compile_do_block_expr(&mut self, body: &[Stmt], label: &Option<String>) {
         // A `do {}` block does not take a signature, so a placeholder variable
         // used directly inside it cannot be captured -> X::Placeholder::Block.
+        // Exception: inside a method, the legacy argument variables `%_` / `@_`
+        // refer to the method's implicit `*%_` / `*@_` slurpy and are valid here.
         if let Some(ph) = crate::ast::collect_unattached_placeholders(body)
             .into_iter()
-            .next()
+            .find(|ph| !(self.lexically_in_method && (ph == "%_" || ph == "@_")))
         {
             let err = Self::placeholder_scope_error("block", &ph);
             let idx = self.code.add_constant(err);

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -100,6 +100,10 @@ impl Compiler {
         let mut sub_compiler = Compiler::new();
         sub_compiler.is_routine = true;
         sub_compiler.lexically_in_routine = true;
+        // A method body carries the synthetic `?CLASS` parameter injected by the
+        // MethodDecl lowering. Methods always provide an implicit `*%_` / `*@_`
+        // slurpy, so `%_` / `@_` are valid lexicals anywhere in the body.
+        sub_compiler.lexically_in_method = params.iter().any(|p| p == "?CLASS");
         // Propagate last_source_line so the sub body knows which line
         // the sub was defined at (for backtraces).
         sub_compiler.last_source_line = self.last_source_line;
@@ -532,6 +536,11 @@ impl Compiler {
         // already is, or the parent itself is a routine.
         sub_compiler.lexically_in_routine =
             is_routine || self.is_routine || self.lexically_in_routine;
+        // `%_` / `@_` from an enclosing method stay visible inside nested
+        // closures (e.g. a `do {}` block inside a `.protect: { ... }` block),
+        // so carry the method context down. A nested *named sub* is not a method
+        // and gets a fresh compiler via compile_sub_body, so it correctly resets.
+        sub_compiler.lexically_in_method = self.lexically_in_method;
         // Propagate last_source_line so closures inside blocks that
         // lack their own SetLine can still inherit the line from the
         // enclosing statement.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -65,6 +65,13 @@ pub(crate) struct Compiler {
     /// Used to decide whether `return` in a non-routine block should perform
     /// a non-local return (via CX::Return) or throw X::ControlFlow::Return.
     pub(crate) lexically_in_routine: bool,
+    /// Whether the enclosing routine is a `method` (or submethod). A method
+    /// always carries an implicit `*%_` / `*@_` slurpy, so the legacy argument
+    /// variables `%_` / `@_` are valid lexicals throughout its body — including
+    /// inside a nested `do {}` block that does not itself take a signature. A
+    /// plain `sub` has no such implicit slurpy, so `%_` there only works as a
+    /// per-block placeholder and may not appear in a nested signature-less block.
+    pub(crate) lexically_in_method: bool,
     /// When true, the current VarDecl is from a `:=` bind declaration.
     bind_vardecl: bool,
     /// When true, Index expressions should emit IndexAutovivify instead of
@@ -150,6 +157,7 @@ impl Compiler {
             accessed_dynamic_vars: std::collections::HashSet::new(),
             is_routine: false,
             lexically_in_routine: false,
+            lexically_in_method: false,
             bind_vardecl: false,
             scalar_bind_autovivify: false,
             bind_terminal: false,

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -989,6 +989,11 @@ impl Interpreter {
                         .or(def.role_origin.as_deref())
                         .unwrap_or(package_name);
                     compiler.set_current_package(method_package.to_string());
+                    // A method always carries an implicit `*%_` / `*@_` slurpy, so
+                    // `%_` / `@_` are valid lexicals throughout the body (including a
+                    // nested signature-less `do {}` block). Mark the method context so
+                    // the do-block placeholder check permits them.
+                    compiler.lexically_in_method = true;
                     let mut method_params = vec![
                         "self".to_string(),
                         "__ANON_STATE__".to_string(),

--- a/t/placeholder-named-in-method-do.t
+++ b/t/placeholder-named-in-method-do.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 7;
+
+# A method always carries an implicit `*%_` / `*@_` slurpy, so the legacy
+# argument variables `%_` / `@_` are valid lexicals anywhere in the method
+# body -- including inside a nested signature-less `do {}` block. This blocked
+# DBIish, whose DBIish.install-driver uses `|%_` inside a `do {}` block nested
+# in a `.protect: { ... }` block.
+
+# %_ directly inside a do {} block in a method
+{
+    class A { method m { my $r = do { %_ }; $r } }
+    is A.m(a => 1, b => 2).elems, 2, '%_ in do {} inside method resolves named args';
+}
+
+# @_ directly inside a do {} block in a method
+{
+    class B { method m { my $r = do { @_ }; $r.elems } }
+    is B.m(1, 2, 3), 3, '@_ in do {} inside method resolves positional args';
+}
+
+# %_ in a do {} nested inside a bare block (the DBIish .protect: shape)
+{
+    class C {
+        method install {
+            my $lock = Lock.new;
+            $lock.protect: {
+                my $d = do { self.make(|%_) };
+                $d;
+            }
+        }
+        method make(*%a) { %a.elems }
+    }
+    is C.new.install(x => 1, y => 2, z => 3), 3,
+        '%_ in do {} inside a nested block in a method';
+}
+
+# %_ used directly in a method (no do block) still works
+{
+    class D { method m { %_.elems } }
+    is D.m(a => 1), 1, '%_ directly in method body';
+}
+
+# A plain sub still rejects %_ inside a nested do {} block (no implicit slurpy)
+throws-like 'sub f { do { %_ } }; f(a => 1)', X::Placeholder::Block,
+    '%_ in do {} inside a sub is still forbidden';
+
+# %_ at the mainline is still an error
+throws-like 'my $x = do { %_ }', X::Placeholder,
+    '%_ in a mainline do {} is still forbidden';
+
+# %_ directly in a sub body still works (auto-signature)
+{
+    sub g { %_.elems }
+    is g(a => 1, b => 2), 2, '%_ directly in a sub body works';
+}


### PR DESCRIPTION
A method always carries an implicit `*%_` / `*@_` slurpy, so the legacy argument variables `%_` / `@_` are valid lexicals throughout the method body — including inside a nested signature-less `do {}` block. mutsu rejected them with `X::Placeholder::Block`, which blocked **DBIish**: `DBIish.install-driver` builds the driver with `|%_` inside a `do {}` block nested in a `.protect: { ... }` block.

## Fix
Track a `lexically_in_method` flag on the compiler:
- set for method bodies via both the package-method lowering and the class/role method-compile path,
- propagated into nested closures.

The do-block placeholder check now skips `%_` / `@_` when lexically inside a method.

## Preserved behavior (matches Rakudo)
- A plain `sub` still rejects `%_` in a nested `do {}` block (no implicit slurpy).
- Mainline `%_` still errors.
- `%_` directly in a sub/method body still works.

New regression test `t/placeholder-named-in-method-do.t` (7 assertions). Combined with #3586 (`my role` in a role), DBIish loads end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)