### PR TITLE
feat(vm): dispatch Buf .write-int*/.write-uint*/.write-num* natively (ledger §D(b))

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -733,6 +733,21 @@
   pin `t/substr-eq-native.t`(16)。全 t/(11566)・S32-str/substr-eq.t・indices.t・index.t 回帰ゼロ。**★残る clean な string drain は枯渇**: `comb` 単純形は既に native（survey の 93 は
   regex/named-arg 形）、`trans`(65) は range（spec 文字列内 `a..z`）/list-pair/regex で複雑、`Int`/`Num`/`Str.new` は ctor 完了済み領域。残カテゴリ＝iterator protocol 群（lazy・別軸）/
   MOP carrier（反射・撲滅対象外）/concurrency（tap/emit・別軸）で、いずれも §D(b) の純 drain でなく別 substrate 前提。**
+- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `Buf.write-int*`/`.write-uint*`/`.write-num*` 族の VM ネイティブ化)**: method-fallback 再計測（全1285 whitelist
+  集計）で string drain 枯渇後の **最頻 clean-drain カテゴリ**が判明＝`write-int8/16/32/64/128`(各 3852) ＋ `write-uint*`(各 2220) ＋ `write-num32/64`(各 492)＝計 ~3 万 fallback。
+  発生源は **S03-buf/write-int.t / write-num.t**（`existing."$write"($off,$val[,$endian])` の `\sigilless` instance 形と `buf8."$write"(...)` の type-object 形＝両方 `"$write"`
+  **動的メソッド名**）。既存 native 化は **mut-bound `$`-var の static 名**（`try_native_buf_mut`・CallMethodMut）のみで、(1) type-object 形（`Value::Package` 受け手＝fresh buf 返し）
+  (2) `\sigilless`/`BareWord` instance 形（non-mut 動的 op `exec_call_method_dynamic_op`→`try_native_method` 経由・writeback 先 var 無し）(3) `$`-var 動的名（mut 動的 op
+  `exec_call_method_dynamic_mut_op`＝native fast path を一切試さず直接 `vm_call_method_mut_with_values`）の 3 経路が全て interpreter にバウンスしていた。**修正**＝新 pure helper
+  `buf_write_int::try_native_buf_write(target, method, args)` が type-object（fresh `make_buf_value`）と instance（shared cell へ `write_back_sharing`→`commit_attrs` で in-place commit
+  →全 binding が観測）の両形を 1 impl で扱う（byte transform は既存共有 `apply_write_int`/`apply_write_num`）。これを **`try_native_method` 冒頭**に wire（arity-keyed `native_method_*arg` は
+  3 引数〔offset,value,endian〕を dispatch 不可なので専用分岐が必須）→ 経路(1)(2) を drain。経路(3) は `exec_call_method_dynamic_mut_op` で generic fork 前に `try_native_buf_mut` を呼んで drain。
+  **フォールスルー維持**＝`Blob`/`blob8`（type-object はメソッド無し・instance は immutable で interpreter が "Cannot modify immutable Blob" を raise・現挙動 byte-identical）/非Int offset
+  （Whatever 位置解決）/負数・範囲外（`apply_write_int` が Err→`dies-ok` 維持）/arity≠2,3。**実測 write-int.t fallback 20240→0・write-num.t 656→0**（両 method-call fallback 完全消滅）。
+  全 t/(11615 PASS)・S03-buf 全緑・roast 108 サンプル回帰ゼロ。pin `t/buf-write-native.t`(27・type-object/scalar/sigilless 動的名/round-trip/error 全形)。**★教訓: 動的メソッド名
+  （`."$name"()`）には 2 つの専用 opcode（`CallMethodDynamic`〔BareWord/literal target〕/`CallMethodDynamicMut`〔`$`/`@`/`%`-var target〕）があり、後者は native fast path を一切試さない
+  ＝static 名で native 化済のメソッドも動的名だと全バウンス。動的名で呼ばれる native メソッド族を drain するには両 dynamic op に fast-path 呼び出しを足す要あり。instance mutator の non-mut
+  動的形は writeback 先 var が無くても shared attribute cell（`commit_attrs`）への in-place commit で `\sigilless`-bound に伝播する（env insert 不要）。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/buf_write_int.rs
+++ b/src/builtins/buf_write_int.rs
@@ -5,7 +5,9 @@
 //   method write-uint8(Buf:D: $offset, uint8 $value, $endian = NativeEndian --> Buf:D)
 //   (similarly for write-int8, write-uint16, ..., write-int128)
 
-use crate::value::{RuntimeError, Value};
+use crate::symbol::Symbol;
+use crate::value::{InstanceAttrs, RuntimeError, Value};
+use std::sync::Arc;
 
 /// Returns Some((byte_size, is_signed)) if the method is a write-int/uint method.
 pub(crate) fn write_int_info(method: &str) -> Option<(usize, bool)> {
@@ -122,4 +124,134 @@ pub(crate) fn apply_write_int(
     }
 
     Ok(())
+}
+
+/// The shared attribute cell of a Buf *instance* receiver, captured so a write can be
+/// committed straight back into it (propagating to every binding sharing the same buf).
+struct BufWriteCell<'a> {
+    attributes: &'a Arc<InstanceAttrs>,
+    class_sym: Symbol,
+    id: u64,
+}
+
+/// Non-mut native dispatch for the Buf write methods (`write-int*` / `write-uint*` /
+/// `write-num*`), covering both forms:
+/// - **type object** (`buf8.write-int32($off, $val, [$endian])`): builds a *fresh*
+///   buf, applies the write, returns it — a pure value transform, no interpreter state.
+/// - **instance** (`$b.write-int32(...)` reached without a mut binding, e.g. a
+///   `\sigilless`-bound buf or `(buf8.new).write-...`): applies the write to a copy of
+///   the current bytes and commits them straight into the receiver's *shared* attribute
+///   cell (`write_back_sharing` → `commit_attrs`), so every binding observing the same
+///   buf sees the mutation. Returns the updated value (which the method call yields).
+///
+/// Mirrors the interpreter's non-mut branches in `runtime/methods.rs` exactly: the byte
+/// transforms are the shared pure `apply_write_int` / `apply_write_num` impls.
+///
+/// Returns `None` (fall through to the interpreter) for:
+/// - non write-int/uint/num methods,
+/// - non Buf/Blob receivers,
+/// - `Blob`/`blob8` (type object has no such method in raku; instance is immutable —
+///   the interpreter raises "Cannot modify immutable Blob"). Current behavior preserved.
+/// - bad arity (not 2 or 3 args) and non-numeric offsets — the interpreter raises those
+///   errors / resolves Whatever positions.
+pub(crate) fn try_native_buf_write(
+    target: &Value,
+    method: &str,
+    args: &[Value],
+) -> Option<Result<Value, RuntimeError>> {
+    let is_num = crate::builtins::buf_write_num::write_num_size(method).is_some();
+    let is_int = write_int_info(method).is_some();
+    if !(is_num || is_int) {
+        return None;
+    }
+    // Resolve the receiver into class name, current bytes, and (for instances) the
+    // shared attribute cell to commit back into.
+    let cn: String;
+    let mut bytes: Vec<u8> = Vec::new();
+    let inst: Option<BufWriteCell>;
+    match target {
+        Value::Package(name) => {
+            cn = name.resolve();
+            if !crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                return None;
+            }
+            inst = None;
+        }
+        Value::Instance {
+            class_name,
+            attributes,
+            id,
+        } => {
+            cn = class_name.resolve();
+            if !crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                return None;
+            }
+            if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes") {
+                bytes.reserve(items.len());
+                for it in items.iter() {
+                    bytes.push(match it {
+                        Value::Int(i) => (*i).clamp(0, 255) as u8,
+                        Value::Num(f) => (*f as i64).clamp(0, 255) as u8,
+                        _ => 0,
+                    });
+                }
+            }
+            inst = Some(BufWriteCell {
+                attributes,
+                class_sym: *class_name,
+                id: *id,
+            });
+        }
+        _ => return None,
+    }
+    // Blob has no write methods (type object) and is immutable (instance) — let the
+    // interpreter own those semantics so current behavior is byte-identical.
+    if cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob") {
+        return None;
+    }
+    if args.len() < 2 || args.len() > 3 {
+        return None;
+    }
+    let offset_i64 = match &args[0] {
+        Value::Int(i) => *i,
+        Value::Num(f) => *f as i64,
+        _ => return None,
+    };
+    let endian_val = if args.len() == 3 {
+        crate::builtins::buf_write_num::decode_endian(&args[2])
+    } else {
+        0
+    };
+    let res = if is_num {
+        crate::builtins::buf_write_num::apply_write_num(
+            &mut bytes, method, offset_i64, &args[1], endian_val,
+        )
+    } else {
+        apply_write_int(&mut bytes, method, offset_i64, &args[1], endian_val)
+    };
+    if let Err(e) = res {
+        return Some(Err(e));
+    }
+    match inst {
+        Some(cell) => {
+            let mut updated_map = cell.attributes.to_map();
+            updated_map.insert(
+                "bytes".to_string(),
+                Value::array(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()),
+            );
+            Some(Ok(Value::write_back_sharing(
+                cell.attributes,
+                cell.class_sym,
+                updated_map,
+                cell.id,
+            )))
+        }
+        None => {
+            let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
+            Some(Ok(crate::builtins::buf_write_num::make_buf_value(
+                &normalized,
+                bytes,
+            )))
+        }
+    }
 }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -295,6 +295,15 @@ impl Interpreter {
             call_args.push(target);
             call_args.extend(args);
             self.vm_call_on_value(name_val, call_args, None)
+        } else if modifier.is_none()
+            && let Some(result) = self.try_native_buf_mut(&target_name, &target, &method, &args)
+        {
+            // Native fast path for mutating Buf write methods (`write-int*`/`write-uint*`/
+            // `write-num*`/`write-bits`) reached via a *dynamic* method name
+            // (`$buf."$write"(...)`) on a mutable Buf instance — mirror the static
+            // CallMethodMut path (ledger §D(b)). Type-object / non-Buf receivers and
+            // bad arity fall through to the generic fork unchanged.
+            result
         } else {
             // TODO: compile to bytecode — generic mut method fork (ledger §1).
             self.vm_call_method_mut_with_values(&target_name, target, &method, args)

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -78,6 +78,17 @@ impl Interpreter {
         if method_sym == "squish" || method_sym == "tail" {
             return None;
         }
+        // Buf write methods (`write-int*`/`write-uint*`/`write-num*`) on a type object
+        // (`buf8.write-int32($off, $val, [$endian])` → fresh buf) or a non-mut-bound
+        // instance (`\sigilless`/`(buf8.new).write-...` → mutate the shared cell). Pure
+        // value / VM-owned shared-cell mutation, no interpreter state. Handle natively
+        // (2-or-3-arg form, which the arity-keyed native_method_*arg dispatch below
+        // cannot cover for 3 args). Blob and bad arity fall through to the interpreter.
+        if let Some(result) =
+            crate::builtins::buf_write_int::try_native_buf_write(target, &method_name, args)
+        {
+            return Some(result);
+        }
         // Mixin role method bypass
         if self.mixin_role_has_method(target, &method_name) {
             return None;

--- a/t/buf-write-native.t
+++ b/t/buf-write-native.t
@@ -1,0 +1,71 @@
+use Test;
+
+# Pin for the ledger §D(b) slice that drains the Buf write-int/uint/num method
+# family to VM-native dispatch in both the type-object form (`buf8.write-int32(...)`
+# returns a fresh buf) and the instance form reached via a dynamic method name or a
+# `\sigilless`/`:=` binding (mutate the shared cell, return the same buf). Previously
+# these fell through to the interpreter slow path on every call.
+
+plan 27;
+
+# --- type-object form: fresh buf -----------------------------------------------
+is buf8.write-int8(0, 0x2A).gist, 'Buf[uint8]:0x<2A>', 'type-object write-int8';
+is buf8.write-int16(0, 0x1234).gist, 'Buf[uint8]:0x<34 12>', 'type-object write-int16 LE default';
+is buf8.write-int16(0, 0x1234, BigEndian).gist, 'Buf[uint8]:0x<12 34>', 'type-object write-int16 BigEndian';
+is buf8.write-int32(0, 7).elems, 4, 'type-object write-int32 size';
+is buf8.write-int64(0, 1).elems, 8, 'type-object write-int64 size';
+is buf8.write-int128(0, 1).elems, 16, 'type-object write-int128 size';
+is buf8.write-uint8(0, 255).gist, 'Buf[uint8]:0x<FF>', 'type-object write-uint8';
+is buf8.write-uint16(2, 0xABCD, BigEndian).gist, 'Buf[uint8]:0x<00 00 AB CD>', 'type-object write-uint16 offset+BE';
+is buf8.write-num32(0, 1e0).elems, 4, 'type-object write-num32 size';
+is buf8.write-num64(0, 1e0).elems, 8, 'type-object write-num64 size';
+
+# offset extends the buffer
+is buf8.write-int8(3, 9).gist, 'Buf[uint8]:0x<00 00 00 09>', 'type-object offset extends';
+
+# --- scalar (=) instance: mutate-and-writeback ---------------------------------
+my $b = buf8.new(0 xx 8);
+my $r = $b.write-uint16(0, 0x1234);
+is $b.gist, 'Buf[uint8]:0x<34 12 00 00 00 00 00 00>', 'scalar write mutates in place';
+is $r.gist, $b.gist, 'scalar write returns the (mutated) buf value';
+is $b.elems, 8, 'scalar write does not change size when in-bounds';
+
+# --- sigilless (:=) instance via dynamic method name ---------------------------
+my \e := buf8.new(0 xx 8);
+for <write-int8 write-uint8> -> $w {
+    e."$w"(2, 0x63);
+    is e.gist, 'Buf[uint8]:0x<00 00 63 00 00 00 00 00>', "sigilless dynamic $w mutates shared cell";
+}
+my \g := buf8.new(0 xx 8);
+my $write = 'write-int32';
+my $ret := g."$write"(0, 0x04030201, LittleEndian);
+is g.gist, 'Buf[uint8]:0x<01 02 03 04 00 00 00 00>', 'sigilless dynamic write-int32 LE';
+ok $ret =:= g, 'sigilless dynamic write returns the same buf';
+
+# --- scalar instance via dynamic method name -----------------------------------
+my $sb = buf8.new(0 xx 4);
+my $sw = 'write-uint8';
+$sb."$sw"(1, 0xEE);
+is $sb.gist, 'Buf[uint8]:0x<00 EE 00 00>', 'scalar dynamic write mutates in place';
+
+# --- type-object via dynamic method name ---------------------------------------
+my $tw = 'write-int16';
+is buf8."$tw"(0, 0x0102, BigEndian).gist, 'Buf[uint8]:0x<01 02>', 'type-object dynamic write-int16 BE';
+
+# --- error semantics preserved (fall through to interpreter) -------------------
+dies-ok { buf8.write-int8(-1, 42) }, 'type-object negative offset dies';
+dies-ok { buf8.new."$sw"(-1, 42) }, 'instance dynamic negative offset dies';
+dies-ok { blob8.new(1, 2, 3).write-int8(0, 9) }, 'blob instance is immutable';
+
+# --- round-trip read back ------------------------------------------------------
+my $rt = buf8.new(0 xx 16);
+$rt.write-int32(4, 0xDEADBEEF, BigEndian);
+is $rt.read-uint32(4, BigEndian), 0xDEADBEEF, 'write then read-uint32 round-trips';
+$rt.write-int64(8, 42, LittleEndian);
+is $rt.read-int64(8, LittleEndian), 42, 'write then read-int64 round-trips';
+
+# negative signed value
+my $sv = buf8.new(0 xx 4);
+$sv.write-int8(0, -1);
+is $sv.read-int8(0), -1, 'signed -1 round-trips';
+is $sv.read-uint8(0), 255, 'as unsigned reads 255';


### PR DESCRIPTION
## Summary

§D(b) tree-walk dispatch-chain drain. Re-measuring `MUTSU_VM_STATS` method-fallback-by-name across the whole whitelist showed the **Buf write-int/uint/num method family** as the top clean-drain category once the string drains were exhausted (~30k fallbacks, all from `S03-buf/write-int.t` and `write-num.t`).

The existing native path (`try_native_buf_mut`, `CallMethodMut`) only covered the **static-name, mut-bound `$`-var** form. Three paths still bounced to the interpreter:

1. **type-object form** `buf8.write-int32($off,$val,[$endian])` (returns a fresh buf),
2. **`\sigilless`/`BareWord` instance** form via the non-mut dynamic op (`exec_call_method_dynamic_op` → `try_native_method`),
3. **`$`-var dynamic-name** form (`exec_call_method_dynamic_mut_op` tried no native fast path at all).

Both real tests use the dynamic method name `."$write"(...)` for *everything*, so all forms bounced.

## Change

- New pure helper `buf_write_int::try_native_buf_write(target, method, args)` handles **both** forms in one impl:
  - type-object → fresh `make_buf_value`,
  - instance → commit straight into the receiver's **shared attribute cell** (`write_back_sharing` → `commit_attrs`), so every binding observing the same buf sees the mutation (no env writeback needed even for the non-mut path).
- Wired into `try_native_method` (covers paths 1+2; the arity-keyed `native_method_*arg` dispatch can't reach the 3-arg endian form).
- `try_native_buf_mut` is now also called in the mut dynamic op before its generic fork (path 3).
- Byte transforms remain the shared `apply_write_int` / `apply_write_num` impls.

## Byte-identical fall-throughs

`Blob`/`blob8` (no write method on the type object; immutable instance → interpreter raises "Cannot modify immutable Blob"), non-Int offsets (Whatever resolution), out-of-range/negative offsets (`dies-ok`), and bad arity all fall through to the interpreter unchanged.

## Verification

- `write-int.t` method fallbacks **20240 → 0**, `write-num.t` **656 → 0**.
- All `t/` (11615) pass, `S03-buf` green, 108-file roast sample regression-free.
- pin `t/buf-write-native.t` (27): type-object / scalar / sigilless dynamic-name / round-trip / error forms, byte-identical to `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)