### PR TITLE
fix(parser): parse `does Qualified::Role` trait on role/class declarations

### DIFF
--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -499,6 +499,18 @@ fn consume_raw_braced_body(input: &str) -> PResult<'_, Vec<Stmt>> {
 fn parse_token_like_name(input: &str) -> PResult<'_, String> {
     let (mut rest, mut name) = ident(input)?;
     loop {
+        // `::`-qualified name segments (e.g. `does DBDish::ErrorHandling`).
+        // Handle these before the single-`:` adverb logic so a qualified role
+        // name parses as one token rather than failing on the second segment.
+        if rest.starts_with("::") && !rest[2..].starts_with('(') {
+            if let Ok((r, seg)) = ident(&rest[2..]) {
+                name.push_str("::");
+                name.push_str(&seg);
+                rest = r;
+                continue;
+            }
+            break;
+        }
         if !rest.starts_with(':') {
             break;
         }

--- a/t/does-qualified-role-name.t
+++ b/t/does-qualified-role-name.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 4;
+
+# `does Qualified::Role::Name` as a trait on a `unit role` / `unit class`
+# declaration must parse as a single DoesDecl. Previously the qualified name
+# tripped the token-name parser at the `::`, so `does DBDish::ErrorHandling`
+# was split into two bare-word statements and the role was never composed --
+# its attributes (e.g. `$.parent`) never reached the consuming class. This
+# blocked DBIish (DBDish::ErrorHandling -> DBDish::StatementHandle -> driver
+# StatementHandle classes).
+
+role My::Base { has $.parent is required; }
+role My::Mid does My::Base { has $.mid; }
+class My::Leaf does My::Mid {
+    has $.leaf;
+    submethod BUILD(:$!parent!, :$!mid, :$!leaf) { }
+}
+
+my @names = My::Leaf.^attributes.map(*.name);
+ok '$!parent' (elem) @names, 'transitively-composed $!parent reaches the class';
+ok '$!mid'    (elem) @names, 'directly-composed $!mid reaches the class';
+
+my $obj = My::Leaf.new(parent => 'P', mid => 'M', leaf => 'L');
+is $obj.parent, 'P', 'attribute from a qualified-name role is usable';
+is $obj.mid, 'M', 'attribute from the qualified mid role is usable';


### PR DESCRIPTION
A `does Qualified::Role::Name` trait on a `unit role` / `unit class` declaration was split into two bare-word statements instead of a single `DoesDecl`, because `parse_token_like_name` (used by `does_decl`) stopped at the first `::` — it only handled single-`:` adverbs (`:sym<...>`). The role was then never composed, so its attributes never reached the consuming class.

## Impact
This blocked **DBIish**: `DBDish::ErrorHandling` declares `$.parent is required`, composed transitively through `DBDish::StatementHandle` into every driver`s StatementHandle class. The dropped composition surfaced as:

```
Attribute $!parent not declared in class DBDish::TestMock::StatementHandle
```

## Fix
`parse_token_like_name` now consumes `::`-qualified name segments before the adverb logic, so `does DBDish::ErrorHandling` parses as one `DoesDecl`.

New regression test `t/does-qualified-role-name.t` (4 assertions) covering transitive attribute composition through qualified-name roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)