### PR TITLE
fix(coerce): flatten an itemized list of pairs in .hash / %(...)

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -361,7 +361,16 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Some(Ok(Value::hash(std::collections::HashMap::new())))
             }
             _ => {
-                let items = crate::runtime::utils::value_to_list(target);
+                // Iterate an Array/Seq/Slip's own elements as the hash
+                // initializer, even when the value is itemized (`$(:a, :b).hash`):
+                // `value_to_list` would treat an itemized list as one opaque
+                // element and wrongly raise "Odd number of elements". This mirrors
+                // the `my %h = $list` assignment path.
+                let items = match target {
+                    Value::Array(items, _) => items.iter().cloned().collect(),
+                    Value::Seq(items) | Value::Slip(items) => items.iter().cloned().collect(),
+                    _ => crate::runtime::utils::value_to_list(target),
+                };
                 Some(crate::runtime::utils::build_hash_from_items(items))
             }
         },

--- a/t/itemized-list-hash-coerce.t
+++ b/t/itemized-list-hash-coerce.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 6;
+
+# `.hash` / `%(...)` on an itemized list of pairs must flatten the pairs into a
+# Hash, not treat the itemized list as a single opaque element (which wrongly
+# raised X::Hash::Store::OddNumber). This blocked DBIish, whose connect path
+# does `|%($*DBI-DEFS<ConnDefaults>)` where ConnDefaults is an itemized list of
+# colon-pairs.
+
+my $cd = $(:RaiseError, :!PrintError, :AutoCommit);
+
+is $cd.WHAT.^name, 'List', 'source is an itemized List';
+
+my %h = $cd.hash;
+is %h<RaiseError>, True,  '.hash flattens :RaiseError';
+is %h<PrintError>, False, '.hash flattens :!PrintError';
+is %h<AutoCommit>, True,  '.hash flattens :AutoCommit';
+
+# %(...) coercion form
+my %g = %($cd);
+is %g.elems, 3, '%($itemized-list) builds a 3-key hash';
+
+# A plain (non-itemized) list of pairs still works
+my %f = (:a, :b).hash;
+is %f.elems, 2, '.hash on a flat pair list still works';


### PR DESCRIPTION
`.hash` (and the `%(...)` coercion form, which compiles to `.hash`) on an itemized list — `$(:a, :b, :c).hash` — treated the list as a single opaque element and raised `X::Hash::Store::OddNumber` instead of flattening its pairs into a Hash.

The `_ =>` arm of the `.hash` dispatch used `value_to_list`, which keeps an itemized list as one item. It now iterates an Array/Seq/Slip`s own elements directly, matching the already-correct `my %h = $list` assignment path.

## Impact
This blocked **DBIish**: its connect path does `|%($*DBI-DEFS<ConnDefaults>)`, where `ConnDefaults` is an itemized list of colon-pairs (`$(:RaiseError, :!PrintError, :AutoCommit)`).

New regression test `t/itemized-list-hash-coerce.t` (6 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)