### PR TITLE
feat(vm): dispatch Str.contains named-arg/position forms natively (ledger §D(b))

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -748,6 +748,17 @@
   （`."$name"()`）には 2 つの専用 opcode（`CallMethodDynamic`〔BareWord/literal target〕/`CallMethodDynamicMut`〔`$`/`@`/`%`-var target〕）があり、後者は native fast path を一切試さない
   ＝static 名で native 化済のメソッドも動的名だと全バウンス。動的名で呼ばれる native メソッド族を drain するには両 dynamic op に fast-path 呼び出しを足す要あり。instance mutator の non-mut
   動的形は writeback 先 var が無くても shared attribute cell（`commit_attrs`）への in-place commit で `\sigilless`-bound に伝播する（env insert 不要）。**
+- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `Str.contains($needle, $pos?, :i/:m?)` の named-arg/position 形の VM ネイティブ化)**: starts-with/substr-eq で
+  「named-arg 形は slow path 維持」と保守的に deferred していた string-method 族の **named-arg 形を初めて native 化**。`S32-str/contains.t`(survey 278) は全テストが
+  `invocant.contains(|c)` で **markings named-arg（`:i`/`:ignorecase`/`:!i`…）を必ず付ける**ため、無印 1-arg native 形（`native_method_1arg`）にほぼ到達せず、Pair 付き 2-arg or
+  position+Pair の 3-arg で arity-keyed dispatch（`native_method_2arg` 止まり・3arg path 無し）を素通りして 100% interpreter にバウンスしていた。**修正**＝新 variadic helper
+  `native_contains_with_options(target, args)` が positional/named を分離し、needle=positional[0]・start=positional[1]（Int/Num/Str-parse）・`i`/`ignorecase`/`m`/`ignoremark`
+  を全て lowercase 比較に畳む（`Interpreter::dispatch_contains` を厳密ミラー）。`try_native_method` の arity dispatch 直前に wire。**フォールスルー維持**＝非Str 受け手（**Match invocant** は
+  別軸の Match→Str coercion・instance-bypass 相互作用で defer）/Package needle/BigInt position（overflow→X::OutOfRange は interpreter）/負数・範囲外 position（X::OutOfRange Failure）/
+  未知 named arg。junction needle は `contains_value_recursive[_ci]` で thread。**実測 contains.t fallback 272→140**（残 140＝Match invocant・別軸）。全 t/(11610)・contains 11 形 byte-identical
+  （unicode CI・Str position 含む）・roast contains 系サンプル回帰ゼロ。pin `t/contains-options-native.t`(22)。**★教訓: starts-with/substr-eq で「named-arg は deferred」としたが、
+  named-arg 形こそが実テストの主トラフィックのことがある（contains.t は全形 markings 付き）。variadic helper（positional/named 分離→interpreter dispatch ミラー）を arity dispatch 前に
+  wire すれば named-arg 形も drain できる。受け手が Str 以外（Match 等 coercion 要）の半分は別軸で残る。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -453,6 +453,82 @@ fn contains_value_recursive(hay: &str, needle: &Value) -> Value {
     }
 }
 
+fn contains_value_recursive_ci(hay_lc: &str, needle: &Value) -> Value {
+    match needle {
+        Value::Junction { kind, values } => {
+            let mapped = values
+                .iter()
+                .map(|v| contains_value_recursive_ci(hay_lc, v))
+                .collect::<Vec<_>>();
+            Value::junction(kind.clone(), mapped)
+        }
+        _ => Value::Bool(hay_lc.contains(&needle.to_string_value().to_lowercase())),
+    }
+}
+
+/// `.contains($needle, $pos?, :i/:ignorecase/:m/:ignoremark?)` on a `Str` receiver —
+/// the forms that carry a start position and/or the case-/mark-insensitive named
+/// markings. These never reach the arity-keyed `native_method_*arg` dispatch (a Pair
+/// or a 3rd arg pushes them past it), so they previously bounced to the interpreter.
+/// Mirrors `Interpreter::dispatch_contains` (runtime/methods_string.rs) exactly: named
+/// `i`/`ignorecase`/`m`/`ignoremark` all fold to a lowercase compare, and the start
+/// position is taken from the second positional (Int/Num/Str-parsed).
+///
+/// Returns `None` (fall through to the interpreter) for: non-Str receivers, a Package
+/// (type-object) needle, a `BigInt` position (overflow → X::OutOfRange handled by the
+/// interpreter), and out-of-range / negative positions (X::OutOfRange Failure). The
+/// plain single-needle form (`contains($needle)`) keeps its `native_method_1arg` arm.
+pub(crate) fn native_contains_with_options(
+    target: &Value,
+    args: &[Value],
+) -> Option<Result<Value, RuntimeError>> {
+    if !matches!(target, Value::Str(_)) {
+        return None;
+    }
+    let mut positional: Vec<&Value> = Vec::new();
+    let mut ignore_case = false;
+    for arg in args {
+        if let Value::Pair(key, value) = arg {
+            if matches!(key.as_str(), "i" | "ignorecase" | "m" | "ignoremark") {
+                ignore_case = value.truthy();
+            } else {
+                // An unexpected named arg: let the interpreter own the semantics.
+                return None;
+            }
+        } else {
+            positional.push(arg);
+        }
+    }
+    // Only the positioned / named forms are handled here; the bare single needle
+    // (`contains($needle)`) stays on the existing 1-arg native arm.
+    let needle: &Value = positional.first().copied()?;
+    if positional.len() == 1 && args.len() == 1 {
+        return None;
+    }
+    if let Value::Package(_) = needle {
+        return None;
+    }
+    let start = match positional.get(1).copied() {
+        Some(Value::Int(i)) => *i,
+        Some(Value::Num(f)) => *f as i64,
+        Some(Value::Str(s)) => s.parse::<i64>().ok()?,
+        Some(_) => return None,
+        None => 0,
+    };
+    let text = target.to_string_value();
+    let len = text.chars().count() as i64;
+    if start < 0 || start > len {
+        return None;
+    }
+    let hay: String = text.chars().skip(start as usize).collect();
+    let result = if ignore_case {
+        contains_value_recursive_ci(&hay.to_lowercase(), needle)
+    } else {
+        contains_value_recursive(&hay, needle)
+    };
+    Some(Ok(result))
+}
+
 fn sample_weighted_mix_key(items: &HashMap<String, f64>) -> Option<Value> {
     let mut total = 0.0;
     for weight in items.values() {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -92,7 +92,9 @@ pub(crate) use functions::join_flat;
 pub(crate) use functions::native_function;
 pub(crate) use functions::{deitemize_flat_operand, flat_val};
 pub(crate) use methods_0arg::native_method_0arg;
-pub(crate) use methods_narg::{native_method_1arg, native_method_2arg};
+pub(crate) use methods_narg::{
+    native_contains_with_options, native_method_1arg, native_method_2arg,
+};
 pub(crate) use unicode::{samecase_string, samemark_string, unicode_titlecase_first};
 
 /// Convert a floating-point number to a Rat using a continued fraction algorithm.

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -214,6 +214,16 @@ impl Interpreter {
         {
             return None;
         }
+        // `.contains($needle, $pos?, :i/:m?)` — the positioned / case-insensitive
+        // forms carry a Pair or a 3rd arg, so they never reach the arity-keyed
+        // native_method_*arg dispatch below. Handle them natively (pure Str search,
+        // mirrors Interpreter::dispatch_contains). The bare single-needle form keeps
+        // its native_method_1arg arm; out-of-range / BigInt positions fall through.
+        if method_name == "contains"
+            && let Some(result) = crate::builtins::native_contains_with_options(target, args)
+        {
+            return Some(result);
+        }
         let mut result = if args.len() == 2 {
             crate::builtins::native_method_2arg(target, method_sym, &args[0], &args[1])
         } else if args.len() == 1 {

--- a/t/contains-options-native.t
+++ b/t/contains-options-native.t
@@ -1,0 +1,54 @@
+use Test;
+
+# Pin for the ledger §D(b) slice that drains the positioned / case-insensitive forms
+# of Str.contains to VM-native dispatch. The bare `contains($needle)` form was already
+# native (native_method_1arg); the forms carrying a start position and/or the
+# `:i`/`:ignorecase`/`:m`/`:ignoremark` markings push past the arity-keyed native
+# dispatch (a Pair or a 3rd arg), so they previously bounced to the interpreter.
+
+plan 22;
+
+# bare needle (already native — sanity)
+is "hello".contains("ell"), True, 'bare needle present';
+is "hello".contains("xyz"), False, 'bare needle absent';
+
+# case-insensitive (named, no position)
+is "hello".contains("L", :i), True, ':i present';
+is "hello".contains("L"), False, 'case-sensitive absent';
+is "Foo".contains("foo", :ignorecase), True, ':ignorecase present';
+is "hello".contains("L", :!i), False, ':!i is case-sensitive';
+is "café".contains("É", :i), True, ':i over unicode';
+
+# start position (positional)
+is "hello".contains("l", 3), True, 'position hits';
+is "hello".contains("l", 4), False, 'position misses';
+is "hello".contains("h", 1), False, 'position skips earlier match';
+is "hello".contains("", 2), True, 'empty needle in-bounds';
+is "hello".contains("", 5), True, 'empty needle at len';
+is "hello".contains("l", "3"), True, 'string position coerces';
+
+# position + case-insensitive together
+is "hello".contains("L", 2, :i), True, 'position + :i present';
+is "hello".contains("L", 4, :i), False, 'position + :i past match';
+
+# junction needle (threaded; result is a Junction, collapse in boolean context)
+ok so "hello".contains(any("z", "ell")), 'any-junction needle';
+ok so "hello".contains(all("ell", "lo")), 'all-junction needle present';
+nok so "hello".contains(all("ell", "zz")), 'all-junction needle absent';
+
+# error semantics preserved (fall through to interpreter)
+{
+    my $r = "foo".contains("o", -42);
+    ok $r ~~ Failure, 'negative position returns a Failure';
+    $r.so; # defuse
+}
+{
+    my $r = "foo".contains("o", 99999999999999999999999999999);
+    ok $r ~~ Failure, 'huge BigInt position returns a Failure';
+    $r.so;
+}
+
+# Match invocant still works (interpreter coercion path)
+my $m = "foobara".match(/\w+/);
+is $m.contains("bar"), True, 'Match invocant contains present';
+is $m.contains("zzz"), False, 'Match invocant contains absent';


### PR DESCRIPTION
## Summary

§D(b) tree-walk dispatch-chain drain. The bare `contains($needle)` form was already native (`native_method_1arg`), but the forms carrying a **start position** and/or the **`:i`/`:ignorecase`/`:m`/`:ignoremark` markings** push past the arity-keyed `native_method_*arg` dispatch (a `Pair` arg, or a 3rd arg, and there is no `native_method_3arg`), so they bounced to the interpreter on every call.

`S32-str/contains.t` (survey: 278 fallbacks) attaches a markings named-arg to **every** form it tests (`invocant.contains(|c)` with `\(|capture, :i)` etc.), so almost nothing reached the 1-arg native arm.

`starts-with` / `substr-eq` previously deferred their named-arg forms as "slow-path only". This is the first string-method slice to drain the **named-arg** forms.

## Change

- New variadic helper `native_contains_with_options(target, args)` splits positional/named args and mirrors `Interpreter::dispatch_contains` exactly:
  - needle = `positional[0]`,
  - start = `positional[1]` (Int / Num / Str-parsed),
  - `i` / `ignorecase` / `m` / `ignoremark` all fold to a lowercase compare (same as the interpreter).
- Wired into `try_native_method` just before the arity-keyed dispatch.
- Junction needles are threaded via `contains_value_recursive[_ci]`.

## Byte-identical fall-throughs

Non-Str receivers (**Match** invocants need a `Match`→`Str` coercion — separate axis), `Package` needles, `BigInt` positions (overflow → `X::OutOfRange`), out-of-range / negative positions (`X::OutOfRange` Failure), and unknown named args all fall through to the interpreter unchanged.

## Verification

- `contains.t` fallbacks **272 → 140** (remaining 140 = Match invocants).
- All `t/` (11610) pass; 11 contains forms byte-identical to `raku` (incl. unicode case-insensitive and Str positions); contains roast sample regression-free.
- pin `t/contains-options-native.t` (22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)