### PR TITLE
fix(method): bind the implicit *%_ slurpy on the fast dispatch path

### DIFF
--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -1688,6 +1688,34 @@ impl Interpreter {
         Ok(rw_bindings)
     }
 
+    /// Compute the implicit `*%_` slurpy of a method: a Hash of the named
+    /// arguments not consumed by an explicit named parameter (an empty Hash when
+    /// there are none). Every method exposes `%_` so its body can reference it --
+    /// e.g. forwarding `|%_` -- without declaring it, and so `%_` reads as an
+    /// empty Hash rather than `Any` (which would otherwise splat as a stray
+    /// positional). A method that declares its own hash slurpy (`*%foo`)
+    /// replaces `*%_`; callers skip this then.
+    pub(crate) fn implicit_method_named_slurpy(param_defs: &[ParamDef], args: &[Value]) -> Value {
+        let mut implicit_named = std::collections::HashMap::new();
+        for arg in args.iter() {
+            if let Value::Pair(key, val) = unwrap_varref_value(arg.clone()) {
+                if key.is_empty() {
+                    continue;
+                }
+                let consumed = param_defs.iter().any(|pd| {
+                    (pd.named && pd.name == key)
+                        || pd.name == format!(":{}", key)
+                        || (pd.named
+                            && (pd.name == format!("@{}", key) || pd.name == format!("%{}", key)))
+                });
+                if !consumed {
+                    implicit_named.insert(key.to_string(), *val);
+                }
+            }
+        }
+        Value::hash(implicit_named)
+    }
+
     /// Check shape constraint for array parameters in signatures.
     fn check_shape_constraint(
         &mut self,

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1094,6 +1094,30 @@ impl Interpreter {
             }
         }
 
+        // Bind the method's implicit `*%_` slurpy (a Hash of the leftover named
+        // args, empty when none). The compiler adds a `*%_` param to every method;
+        // the slow `bind_function_args_values` path fills it, but this fast path
+        // binds positionals by index and skips slurpy params, leaving `%_` as
+        // `Any` -- so `|%_` would splat a stray positional. Compute it here and let
+        // the locals-init loop fill the `%_` slot.
+        let implicit_named_slurpy: Option<Value> = if method_def
+            .param_defs
+            .iter()
+            .any(|pd| pd.slurpy && pd.name == "%_")
+        {
+            Some(Self::implicit_method_named_slurpy(&method_def.param_defs, &args))
+        } else {
+            None
+        };
+
+        // Bind the implicit `*%_` into env so a `%_` read finds it there first
+        // (its method local is stored sigiled as "%_", which the bare-name local
+        // lookup -- it strips the sigil and searches "_" -- can't resolve, falling
+        // back to the topic `$_`).
+        if let Some(slurpy) = &implicit_named_slurpy {
+            self.env_mut().insert("%_".to_string(), slurpy.clone());
+        }
+
         // Raku: routine parameters are read-only by default (`method m($x) { $x = 5 }`
         // dies). The slow path does this in `bind_function_args_values`; the fast
         // path binds params directly, so mark `$` scalar params read-only here.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1105,7 +1105,10 @@ impl Interpreter {
             .iter()
             .any(|pd| pd.slurpy && pd.name == "%_")
         {
-            Some(Self::implicit_method_named_slurpy(&method_def.param_defs, &args))
+            Some(Self::implicit_method_named_slurpy(
+                &method_def.param_defs,
+                &args,
+            ))
         } else {
             None
         };

--- a/t/method-implicit-named-slurpy.t
+++ b/t/method-implicit-named-slurpy.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 7;
+
+# Every method exposes an implicit `*%_` slurpy: a Hash of the named arguments
+# not bound to an explicit named parameter, and an *empty* Hash when none were
+# passed. Previously, when a method was called with only positionals (and so hit
+# the fast dispatch path), `%_` read as `Any` instead of `{}`, so forwarding
+# `|%_` splatted a stray positional and constructors failed with
+# "only takes named arguments". This blocked DBIish (DBIish.install-driver
+# forwards `|%_` from a method called with a single positional).
+
+class C { has $.parent; has $.x; }
+
+class Maker {
+    method build($driver) {
+        # %_ here is empty (no named args), so |%_ adds nothing.
+        return C.new(:parent($driver), |%_);
+    }
+    method build-with-named($driver) {
+        return C.new(:parent($driver), |%_);
+    }
+}
+
+my $m = Maker.new;
+
+is $m.build('P').parent, 'P', '|%_ with empty %_ forwards nothing (positional-only call)';
+
+my $c = $m.build-with-named('P', x => 42);
+is $c.parent, 'P', 'explicit named arg still binds';
+is $c.x, 42, 'extra named arg forwarded through |%_';
+
+# Direct %_ inspection
+class Inspect {
+    method m($pos) { %_ }
+}
+is Inspect.new.m('a').elems, 0, '%_ is an empty Hash for a positional-only call';
+is Inspect.new.m('a', foo => 1).elems, 1, '%_ holds one leftover named arg';
+ok Inspect.new.m('a') ~~ Hash, '%_ is a Hash, not Any';
+is Inspect.new.m('a', foo => 1, bar => 2)<bar>, 2, '%_ keys are accessible';


### PR DESCRIPTION
Every method exposes an implicit `*%_` slurpy — a Hash of the named arguments not bound to an explicit named parameter, **empty when none**. The compiler adds a `*%_` param to each method and the slow `bind_function_args_values` path fills it, but the fast method-dispatch path binds positionals by index and skipped the slurpy.

So a method called with only positionals read `%_` as `Any` (actually the topic `$_` — the sigiled `%_` local is unreachable via the bare-name local lookup, which strips the sigil and searches `"_"`). Forwarding `|%_` then splatted a stray positional, e.g. failing object construction with *"only takes named arguments"*.

## Fix
The fast path now computes the leftover-named Hash for a method carrying a `*%_` param and inserts it into env under `"%_"`, where a `%_` read resolves it first.

## Impact
This blocked **DBIish**: `DBIish.install-driver` builds the driver with `|%_` inside a method called with a single positional driver name.

New regression test `t/method-implicit-named-slurpy.t` (7 assertions). Verified `roast/S06-signature/sub-ref.t` (whitelisted) still passes under `MUTSU_FUDGE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)