### PR TITLE
feat(vm): dispatch Str starts-with/ends-with/substr-eq :i named forms natively (§D(b))

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -759,6 +759,16 @@
   （unicode CI・Str position 含む）・roast contains 系サンプル回帰ゼロ。pin `t/contains-options-native.t`(22)。**★教訓: starts-with/substr-eq で「named-arg は deferred」としたが、
   named-arg 形こそが実テストの主トラフィックのことがある（contains.t は全形 markings 付き）。variadic helper（positional/named 分離→interpreter dispatch ミラー）を arity dispatch 前に
   wire すれば named-arg 形も drain できる。受け手が Str 以外（Match 等 coercion 要）の半分は別軸で残る。**
+- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `Str.starts-with`/`.ends-with`/`.substr-eq` の `:i` named-arg 形の VM ネイティブ化)**: contains slice で確立した
+  variadic-helper パターンを兄弟 string-method に横展開。`S32-str/{starts-with,ends-with,substr-eq}.t` も全形に markings named-arg を付ける（contains.t と同型）ため、無印
+  native 形（starts-with=1arg・substr-eq=2arg）が drain 済でも `:i` 付き形（Pair で arity 超過）は 100% interpreter にバウンスしていた。**修正**＝新ヘルパー `native_prefix_suffix_with_options`
+  （starts-with/ends-with）/ `native_substr_eq_with_options`（substr-eq）が共有 `split_string_match_args`（positional/named 分離・`i`/`ignorecase`=ci・`m`/`ignoremark`=mark・未知 named は
+  defer）で markings を解釈し、`dispatch_prefix_suffix_check`/`dispatch_substr_eq` を厳密ミラー。`try_native_method` の arity dispatch 直前（contains arm の隣）に wire。**フォールスルー維持**＝
+  非Str 受け手（**Match invocant**＝別軸）/Package needle/`:m`/`:ignoremark`（`strip_marks` decomposition は interpreter）/substr-eq の非Int-非Str position（Whatever resolution）・負数・範囲外
+  （X::OutOfRange Failure）/無印形（既存 1-/2-arg arm 維持）。**実測 starts-with.t 80→42・ends-with.t 80→42・substr-eq.t 86→48**（残＝Match invocant `:i` 形・別軸）。全 t/(11692)・
+  3 ファイル proper-harness PASS・10 named 形 byte-identical to raku（unicode CI・Str position 含む）・whitelist 回帰ゼロ。pin `t/starts-ends-substr-eq-named-native.t`(21)。**★教訓:
+  raku 参照実装は `"abc".ends-with("", :i)` で "Iteration past end of grapheme iterator" を投げる（空 needle+ci のバグ）が mutsu は正しく True を返す＝pin から該当形を除外（mutsu の方が正しい）。
+  ★string-method の `:m`/`:ignoremark` は `strip_marks`（NFD→combining-mark filter）で別処理だが、これらの roast テストは backend≠moar ゲートで `:m` 形を skip するので native 化不要・defer で十分。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -529,6 +529,128 @@ pub(crate) fn native_contains_with_options(
     Some(Ok(result))
 }
 
+/// Separate `(needle, …)`-style positional args from the `:i`/`:ignorecase`/
+/// `:m`/`:ignoremark` named markings shared by `contains` / `starts-with` /
+/// `ends-with` / `substr-eq`. Returns `None` if an *unexpected* named arg is
+/// present (the interpreter owns those semantics). `ignore_mark` being requested
+/// also returns `None` from the callers below — `strip_marks` decomposition is
+/// left to the interpreter so the native fast paths stay purely ASCII/`to_lowercase`.
+fn split_string_match_args(args: &[Value]) -> Option<(Vec<&Value>, bool, bool)> {
+    let mut positional: Vec<&Value> = Vec::new();
+    let mut ignore_case = false;
+    let mut ignore_mark = false;
+    for arg in args {
+        if let Value::Pair(key, value) = arg {
+            match key.as_str() {
+                "i" | "ignorecase" => ignore_case = value.truthy(),
+                "m" | "ignoremark" => ignore_mark = value.truthy(),
+                _ => return None,
+            }
+        } else {
+            positional.push(arg);
+        }
+    }
+    Some((positional, ignore_case, ignore_mark))
+}
+
+/// `.starts-with($needle, :i?)` / `.ends-with($needle, :i?)` on a `Str` receiver —
+/// the case-insensitive named forms. The plain `starts-with($needle)` form keeps its
+/// `native_method_1arg` arm; this handles only the forms that carry a marking Pair
+/// (which pushes them past the arity-keyed native dispatch). Mirrors
+/// `Interpreter::dispatch_prefix_suffix_check`.
+///
+/// Returns `None` (fall through) for: non-Str receivers, a Package needle,
+/// `:m`/`:ignoremark` (strip_marks → interpreter), unknown named args, and the bare
+/// single-needle form.
+pub(crate) fn native_prefix_suffix_with_options(
+    target: &Value,
+    args: &[Value],
+    is_prefix: bool,
+) -> Option<Result<Value, RuntimeError>> {
+    if !matches!(target, Value::Str(_)) {
+        return None;
+    }
+    let (positional, ignore_case, ignore_mark) = split_string_match_args(args)?;
+    if ignore_mark {
+        return None;
+    }
+    let needle_val: &Value = positional.first().copied()?;
+    // Bare single needle (no markings) stays on the 1-arg native arm.
+    if positional.len() == args.len() {
+        return None;
+    }
+    if let Value::Package(_) = needle_val {
+        return None;
+    }
+    let text = target.to_string_value();
+    let needle = needle_val.to_string_value();
+    let (t, n) = if ignore_case {
+        (text.to_lowercase(), needle.to_lowercase())
+    } else {
+        (text, needle)
+    };
+    let ok = if is_prefix {
+        t.starts_with(n.as_str())
+    } else {
+        t.ends_with(n.as_str())
+    };
+    Some(Ok(Value::Bool(ok)))
+}
+
+/// `.substr-eq($needle, $pos?, :i?)` on a `Str` receiver — the case-insensitive and/or
+/// named forms. The plain `substr-eq($needle, Int $pos)` form keeps its
+/// `native_method_2arg` arm; this handles the forms carrying a marking Pair (which push
+/// them past the arity-keyed dispatch). Mirrors `Interpreter::dispatch_substr_eq`.
+///
+/// Returns `None` (fall through) for: non-Str receivers, a Package needle,
+/// `:m`/`:ignoremark`, unknown named args, non-Int/Str positions (Whatever resolution),
+/// out-of-range / negative positions (X::OutOfRange Failure), and the bare forms
+/// already handled by the 1-/2-arg arms.
+pub(crate) fn native_substr_eq_with_options(
+    target: &Value,
+    args: &[Value],
+) -> Option<Result<Value, RuntimeError>> {
+    if !matches!(target, Value::Str(_)) {
+        return None;
+    }
+    let (positional, ignore_case, ignore_mark) = split_string_match_args(args)?;
+    if ignore_mark {
+        return None;
+    }
+    // Only the named forms reach here; the bare positional forms keep their
+    // existing 1-/2-arg native arms.
+    if positional.len() == args.len() {
+        return None;
+    }
+    let needle_val: &Value = positional.first().copied()?;
+    if let Value::Package(_) = needle_val {
+        return None;
+    }
+    let start = match positional.get(1).copied() {
+        Some(Value::Int(i)) => *i,
+        Some(Value::Str(s)) => s.parse::<i64>().ok()?,
+        Some(_) => return None,
+        None => 0,
+    };
+    let text = target.to_string_value();
+    let len = text.chars().count() as i64;
+    if start < 0 || start > len {
+        return None;
+    }
+    let needle = needle_val.to_string_value();
+    let substr: String = text
+        .chars()
+        .skip(start as usize)
+        .take(needle.chars().count())
+        .collect();
+    let eq = if ignore_case {
+        substr.to_lowercase() == needle.to_lowercase()
+    } else {
+        substr == needle
+    };
+    Some(Ok(Value::Bool(eq)))
+}
+
 fn sample_weighted_mix_key(items: &HashMap<String, f64>) -> Option<Value> {
     let mut total = 0.0;
     for weight in items.values() {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -94,6 +94,7 @@ pub(crate) use functions::{deitemize_flat_operand, flat_val};
 pub(crate) use methods_0arg::native_method_0arg;
 pub(crate) use methods_narg::{
     native_contains_with_options, native_method_1arg, native_method_2arg,
+    native_prefix_suffix_with_options, native_substr_eq_with_options,
 };
 pub(crate) use unicode::{samecase_string, samemark_string, unicode_titlecase_first};
 

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -224,6 +224,25 @@ impl Interpreter {
         {
             return Some(result);
         }
+        // `.starts-with`/`.ends-with`/`.substr-eq` with `:i`/`:ignorecase` markings
+        // (and, for substr-eq, a start position) carry a Pair / 3rd arg that pushes
+        // them past the arity-keyed dispatch below. Handle the case-insensitive forms
+        // natively (mirror dispatch_prefix_suffix_check / dispatch_substr_eq); the bare
+        // forms keep their 1-/2-arg arms, and `:m`/out-of-range fall through.
+        if matches!(method_name.as_str(), "starts-with" | "ends-with")
+            && let Some(result) = crate::builtins::native_prefix_suffix_with_options(
+                target,
+                args,
+                method_name == "starts-with",
+            )
+        {
+            return Some(result);
+        }
+        if method_name == "substr-eq"
+            && let Some(result) = crate::builtins::native_substr_eq_with_options(target, args)
+        {
+            return Some(result);
+        }
         let mut result = if args.len() == 2 {
             crate::builtins::native_method_2arg(target, method_sym, &args[0], &args[1])
         } else if args.len() == 1 {

--- a/t/starts-ends-substr-eq-named-native.t
+++ b/t/starts-ends-substr-eq-named-native.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Pin for the ledger §D(b) slice that drains the case-insensitive named forms of
+# Str.starts-with / .ends-with / .substr-eq to VM-native dispatch. The bare forms
+# (`starts-with($needle)`, `substr-eq($needle, Int $pos)`) were already native; the
+# `:i`/`:ignorecase` markings push them past the arity-keyed native dispatch (a Pair
+# arg), so they previously bounced to the interpreter. `:m`/`:ignoremark` (strip_marks)
+# and out-of-range positions stay on the interpreter.
+
+plan 21;
+
+# --- starts-with ---------------------------------------------------------------
+is "Hello".starts-with("HE", :i), True, 'starts-with :i present';
+is "Hello".starts-with("HE"), False, 'starts-with case-sensitive';
+is "Hello".starts-with("HE", :!i), False, 'starts-with :!i case-sensitive';
+is "Hello".starts-with("xx", :i), False, 'starts-with :i absent';
+is "café".starts-with("CAF", :i), True, 'starts-with :i unicode';
+is "Hello".starts-with("he", :ignorecase), True, 'starts-with :ignorecase';
+
+# --- ends-with -----------------------------------------------------------------
+is "Hello".ends-with("LO", :i), True, 'ends-with :i present';
+is "Hello".ends-with("LO"), False, 'ends-with case-sensitive';
+is "Hello".ends-with("xx", :i), False, 'ends-with :i absent';
+is "Hello".ends-with("lo", :ignorecase), True, 'ends-with :ignorecase';
+
+# --- substr-eq (named, with and without position) ------------------------------
+is "foobar".substr-eq("OOB", 1, :i), True, 'substr-eq pos + :i present';
+is "foobar".substr-eq("OOB", 1), False, 'substr-eq pos case-sensitive';
+is "foobar".substr-eq("OOB", 2, :i), False, 'substr-eq pos + :i mismatch';
+is "foobar".substr-eq("oob", "1"), True, 'substr-eq string position';
+is "foobar".substr-eq("BAR", 3, :ignorecase), True, 'substr-eq :ignorecase';
+is "foobar".substr-eq("FOO", 0, :i), True, 'substr-eq pos 0 + :i';
+is "foobar".substr-eq("foo", :i), True, 'substr-eq :i no explicit position';
+
+# --- error / fall-through cases preserved --------------------------------------
+{
+    my $r = "foo".substr-eq("o", -1, :i);
+    ok $r ~~ Failure, 'substr-eq negative position -> Failure';
+    $r.so;
+}
+
+# --- Match invocant still works (interpreter coercion path) ---------------------
+my $m = "Foobar".match(/\w+/);
+is $m.starts-with("foo", :i), True, 'Match invocant starts-with :i';
+is $m.ends-with("BAR", :i), True, 'Match invocant ends-with :i';
+is $m.substr-eq("oob", 1, :i), True, 'Match invocant substr-eq :i';


### PR DESCRIPTION
## Summary

§D(b) tree-walk dispatch-chain drain. Extends the variadic-helper pattern established for `Str.contains` (#3591) to its sibling string methods.

`S32-str/{starts-with,ends-with,substr-eq}.t` attach a markings named-arg (`:i`/`:ignorecase`/…) to **every** form they test. So even though the bare forms are already native (`starts-with` = 1-arg, `substr-eq` = 2-arg), the `:i` forms carry a `Pair` that pushes them past the arity-keyed native dispatch — they bounced to the interpreter on every call.

## Change

- New helpers `native_prefix_suffix_with_options` (starts-with/ends-with) and `native_substr_eq_with_options` (substr-eq), sharing `split_string_match_args` to parse the `i`/`ignorecase` (case-insensitive) and `m`/`ignoremark` markings.
- Mirror `dispatch_prefix_suffix_check` / `dispatch_substr_eq` exactly.
- Wired into `try_native_method` next to the contains arm.

## Byte-identical fall-throughs

Non-Str receivers (Match invocants — separate axis), `Package` needles, `:m`/`:ignoremark` (`strip_marks` decomposition → interpreter), substr-eq non-Int/Str positions (Whatever resolution) and out-of-range/negative positions (`X::OutOfRange` Failure), and the bare forms (kept on their 1-/2-arg arms).

## Verification

- `starts-with.t` 80→42, `ends-with.t` 80→42, `substr-eq.t` 86→48 (remaining = Match invocants).
- All `t/` (11692) pass, three files green via the proper harness, 10 named forms byte-identical to `raku` (incl. unicode case-insensitive and Str positions), whitelist regression-free.
- pin `t/starts-ends-substr-eq-named-native.t` (21).
- Note: `raku` itself throws `Iteration past end of grapheme iterator` on `"abc".ends-with("", :i)` (empty-needle + ci bug); mutsu correctly returns `True`, so that form is excluded from the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)