### PR TITLE
fix(class): ::?CLASS in attribute defaults; .^ver returns Mu when unversioned

### DIFF
--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -355,9 +355,15 @@ impl Interpreter {
                 if invocant_name == "Grammar" {
                     return Ok(Self::version_from_value(Value::str_from("6.e")));
                 }
-                Err(RuntimeError::new(
-                    "X::Method::NotFound: Unknown method value dispatch (fallback disabled): ver",
-                ))
+                // A type with no declared version: `.^ver` is `Mu` (an undefined
+                // type object), not an error -- matching Rakudo. Reached e.g. when
+                // the `:ver(...)` adverb is an expression mutsu does not evaluate at
+                // registration (`unit class C:ver($?DISTRIBUTION.meta<ver>)`), or a
+                // plain unversioned class. (`has $.V = ::?CLASS.^ver` then sets V to
+                // Mu rather than throwing X::Method::NotFound.)
+                // TODO: evaluate expression-form `:ver(...)` adverbs at class
+                // registration and store the result in type_metadata.
+                Ok(Value::Package(crate::symbol::Symbol::intern("Mu")))
             }
             "auth" if args.len() == 1 => {
                 let invocant_name = match &args[0] {

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -355,15 +355,22 @@ impl Interpreter {
                 if invocant_name == "Grammar" {
                     return Ok(Self::version_from_value(Value::str_from("6.e")));
                 }
-                // A type with no declared version: `.^ver` is `Mu` (an undefined
+                // A *class* with no declared version: `.^ver` is `Mu` (an undefined
                 // type object), not an error -- matching Rakudo. Reached e.g. when
                 // the `:ver(...)` adverb is an expression mutsu does not evaluate at
                 // registration (`unit class C:ver($?DISTRIBUTION.meta<ver>)`), or a
                 // plain unversioned class. (`has $.V = ::?CLASS.^ver` then sets V to
                 // Mu rather than throwing X::Method::NotFound.)
+                // A bare `package` uses PackageHOW, which has no `.^ver` at all, so
+                // `P.^ver` must still throw X::Method::NotFound ("absent by design").
                 // TODO: evaluate expression-form `:ver(...)` adverbs at class
                 // registration and store the result in type_metadata.
-                Ok(Value::Package(crate::symbol::Symbol::intern("Mu")))
+                if self.registry().classes.contains_key(&name) {
+                    return Ok(Value::Package(crate::symbol::Symbol::intern("Mu")));
+                }
+                Err(RuntimeError::new(
+                    "X::Method::NotFound: Unknown method value dispatch (fallback disabled): ver",
+                ))
             }
             "auth" if args.len() == 1 => {
                 let invocant_name = match &args[0] {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -466,6 +466,14 @@ impl Interpreter {
                     let temp_self = Value::make_instance(class_name, attrs.clone());
                     let old_self = self.env.get("self").cloned();
                     let old_anon = self.env.get("__ANON_STATE__").cloned();
+                    // `::?CLASS` in a default (e.g. `has $.v = ::?CLASS.^ver`)
+                    // resolves through `?CLASS`; bind it to the class being built
+                    // (it is otherwise unset here, leaving `::?CLASS` as `Any`).
+                    let old_class = self.env.get("?CLASS").cloned();
+                    self.env.insert(
+                        "?CLASS".to_string(),
+                        Value::Package(crate::symbol::Symbol::intern(cn_resolved)),
+                    );
                     self.env.insert("self".to_string(), temp_self.clone());
                     self.env.insert("__ANON_STATE__".to_string(), temp_self);
                     let mut saved_attr_env: Vec<(String, Option<Value>)> = Vec::new();
@@ -514,6 +522,14 @@ impl Interpreter {
                         }
                         None => {
                             self.env.remove("__ANON_STATE__");
+                        }
+                    }
+                    match old_class {
+                        Some(v) => {
+                            self.env.insert("?CLASS".to_string(), v);
+                        }
+                        None => {
+                            self.env.remove("?CLASS");
                         }
                     }
                     let val = match result {
@@ -3709,6 +3725,12 @@ impl Interpreter {
                             let temp_self = Value::make_instance(*class_name, attrs.clone());
                             let old_self = self.env.get("self").cloned();
                             self.env.insert("self".to_string(), temp_self);
+                            // `::?CLASS` in a default (e.g. `has $.Version =
+                            // ::?CLASS.^ver` composed from a role) resolves through
+                            // `?CLASS`; bind it to the class being built.
+                            let old_class = self.env.get("?CLASS").cloned();
+                            self.env
+                                .insert("?CLASS".to_string(), Value::Package(*class_name));
                             // Set !attr_name and .attr_name in env so that $!a / $.a
                             // references in default expressions resolve to already-
                             // initialized attributes (e.g. `has $.c = $!a + $!b`).
@@ -3740,6 +3762,11 @@ impl Interpreter {
                                 self.env.insert("self".to_string(), old);
                             } else {
                                 self.env.remove("self");
+                            }
+                            if let Some(old) = old_class {
+                                self.env.insert("?CLASS".to_string(), old);
+                            } else {
+                                self.env.remove("?CLASS");
                             }
                             let val = result?;
                             Self::coerce_attr_value_by_sigil(val, sigil)

--- a/t/class-version-meta-and-default.t
+++ b/t/class-version-meta-and-default.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 8;
+
+# `.^ver` on a type with no declared version is `Mu` (an undefined type object),
+# not an error. Rakudo returns Mu; mutsu previously threw X::Method::NotFound.
+{
+    class Unversioned { }
+    nok Unversioned.^ver.defined, '.^ver of an unversioned class is undefined';
+    ok Unversioned.^ver === Mu, '.^ver of an unversioned class is Mu';
+}
+
+# A literal `:ver<...>` is still returned as a Version.
+{
+    class Versioned:ver<1.2.3>:auth<me> { }
+    is Versioned.^ver, v1.2.3, '.^ver returns the literal version';
+    is Versioned.^auth, 'me', '.^auth returns the literal auth';
+}
+
+# `::?CLASS` resolves to the class inside an attribute default (it was `Any`).
+{
+    class WithName {
+        has $.n = ::?CLASS.^name;
+    }
+    is WithName.new.n, 'WithName', '::?CLASS.^name in an attribute default';
+}
+
+# `::?CLASS.^ver` in an attribute default works for a literal version...
+{
+    class WithVer:ver<3.4.5> {
+        has $.v = ::?CLASS.^ver;
+    }
+    is WithVer.new.v, v3.4.5, '::?CLASS.^ver in an attribute default (literal version)';
+}
+
+# ...and through a role-composed attribute default (the DBIish shape:
+# DBDish::Driver has `$.Version = ::?CLASS.^ver`, composed into each driver).
+{
+    role Driver { has $.Version = ::?CLASS.^ver; }
+    class Driver1:ver<9.9.9> does Driver { }
+    is Driver1.new.Version, v9.9.9,
+        '::?CLASS.^ver in a role-composed attribute default';
+    # An unversioned consumer gets Mu, not an error.
+    class Driver2 does Driver { }
+    ok Driver2.new.Version === Mu,
+        'role-composed ::?CLASS.^ver is Mu for an unversioned class';
+}

--- a/t/class-version-meta-and-default.t
+++ b/t/class-version-meta-and-default.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 9;
 
 # `.^ver` on a type with no declared version is `Mu` (an undefined type object),
 # not an error. Rakudo returns Mu; mutsu previously threw X::Method::NotFound.
@@ -44,4 +44,12 @@ plan 8;
     class Driver2 does Driver { }
     ok Driver2.new.Version === Mu,
         'role-composed ::?CLASS.^ver is Mu for an unversioned class';
+}
+
+# A bare `package` has no `.^ver` at all (PackageHOW): it must still throw,
+# even though an unversioned *class* returns Mu.
+{
+    my package P:ver<1.2.3> { };
+    throws-like { P.^ver }, X::Method::NotFound,
+        '.^ver on a package is absent (not Mu)';
 }


### PR DESCRIPTION
Two related class-construction / metaclass fixes surfaced by **DBIish** (every driver class is `unit class ...:ver($?DISTRIBUTION.meta<ver>) does DBDish::Driver`, and `DBDish::Driver` has `has $.Version = ::?CLASS.^ver`):

1. **`::?CLASS` in attribute defaults.** Both attribute-default eval paths (the native build loop and the role-binding interpreter path) bound `self` but not `?CLASS`, so `::?CLASS` read as `Any` — `has $.n = ::?CLASS.^name` returned `"Any"` and `::?CLASS.^ver` threw. They now bind/restore `?CLASS` around the eval.

2. **`.^ver` on an unversioned type returns `Mu`** (an undefined type object) instead of throwing `X::Method::NotFound`, matching Rakudo. Reached for a plain unversioned class and when the `:ver(...)` adverb is an expression mutsu does not evaluate at registration (left as a `TODO`).

DBIish now loads, connects, and returns a Connection. New regression test `t/class-version-meta-and-default.t` (8 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)