### PR TITLE
fix(construct): bless passes its named args to BUILD / TWEAK

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -337,7 +337,7 @@ impl Interpreter {
                     &role_name,
                     method_def,
                     attributes.clone(),
-                    Vec::new(),
+                    args.clone(),
                     Some(Value::make_instance(class_name, attributes.clone())),
                 )?;
                 attributes = updated;
@@ -362,16 +362,17 @@ impl Interpreter {
                     mro_class,
                     attributes.clone(),
                     "BUILD",
-                    Vec::new(),
+                    args.clone(),
                     Some(Value::make_instance(class_name, attributes.clone())),
                 )?;
                 attributes = updated;
             }
         }
-        // `self.bless(...)` runs BUILD/TWEAK with no extra args (the named
-        // attributes were already folded into `attributes` above); preserve
-        // that by passing an empty TWEAK arg list.
-        let attributes = self.run_tweak_phase(class_name, attributes, &[])?;
+        // `bless` passes its named arguments through to BUILD and TWEAK (as
+        // `BUILDALL` does), so a `submethod BUILD(:$!attr!)` with a required named
+        // parameter binds -- the args are also pre-folded into `attributes` above
+        // for the common no-explicit-BUILD case.
+        let attributes = self.run_tweak_phase(class_name, attributes, &args)?;
         Ok(Value::make_instance(class_name, attributes))
     }
 

--- a/t/bless-passes-args-to-build.t
+++ b/t/bless-passes-args-to-build.t
@@ -1,0 +1,78 @@
+use Test;
+
+plan 8;
+
+# `bless` must pass its named arguments through to BUILD / TWEAK (as BUILDALL
+# does), so a `submethod BUILD(:$!attr!)` with a *required* named parameter
+# binds. Previously bless ran BUILD with no args (relying only on folding named
+# args into the attribute map), so a required named BUILD param threw
+# "Required named parameter not passed". This blocked DBIish, whose
+# DBDish::StatementHandle.new does `::?CLASS.bless(|%args)` into a
+# `submethod BUILD(:$!parent!, ...)`.
+
+# Direct bless with a literal named arg.
+{
+    class A {
+        has $.parent;
+        submethod BUILD(:$!parent!) { }
+    }
+    is A.bless(:parent('P')).parent, 'P', 'bless(:parent(...)) binds required BUILD param';
+}
+
+# Direct bless with a hash splat.
+{
+    class B {
+        has $.parent;
+        has $.statement;
+        submethod BUILD(:$!parent!, :$!statement) { }
+    }
+    my %args = parent => 'P', statement => 'S';
+    my $b = B.bless(|%args);
+    is $b.parent, 'P', 'bless(|%args) binds required param';
+    is $b.statement, 'S', 'bless(|%args) binds optional attributive param';
+}
+
+# A custom `new(*%args) { ::?CLASS.bless(|%args) }` over a role (the DBIish
+# DBDish::StatementHandle shape).
+{
+    role R {
+        has $.parent;
+        method new(*%args) { ::?CLASS.bless(|%args) }
+    }
+    class C does R {
+        has $.statement;
+        submethod BUILD(:$!parent!, :$!statement, :$rows) { }
+    }
+    my $c = C.new(:statement('S'), :parent('P'));
+    is $c.parent, 'P', 'custom new + bless: required param binds';
+    is $c.statement, 'S', 'custom new + bless: optional param binds';
+}
+
+# bless still runs TWEAK with the named args.
+{
+    my $seen;
+    class D {
+        has $.x;
+        submethod TWEAK(:$x) { $seen = $x }
+    }
+    D.bless(:x(42));
+    is $seen, 42, 'bless passes named args to TWEAK';
+}
+
+# A missing required BUILD param still throws.
+{
+    class E {
+        has $.parent;
+        submethod BUILD(:$!parent!) { }
+    }
+    dies-ok { E.bless() }, 'missing required BUILD param still dies';
+}
+
+# The normal new path is unchanged.
+{
+    class F {
+        has $.parent;
+        submethod BUILD(:$!parent!) { }
+    }
+    is F.new(:parent('P')).parent, 'P', 'new(:parent(...)) still works';
+}


### PR DESCRIPTION
bless ran BUILD and TWEAK submethods with **no arguments**, relying only on folding its named args into the attribute map. A `submethod BUILD(:$!attr!)` with a *required* named parameter then threw *"Required named parameter not passed"*, because the param was never offered the arg.

The `new` path already passes the args to BUILD; bless now matches it (as `BUILDALL` does), threading the bless named args through both the role-composed and class-own BUILD calls and into the TWEAK phase.

## Impact
This blocked **DBIish**: `DBDish::StatementHandle.new` does `::?CLASS.bless(|%args)` into a `submethod BUILD(:$!parent!, ...)`. DBIish (TestMock driver) now runs a full **connect / prepare / execute / fetch / dispose** cycle end-to-end.

New regression test `t/bless-passes-args-to-build.t` (8 assertions). Verified `roast/S12-class/*` and `roast/S14-roles/*` (incl. whitelisted `parameterized-mixin.t`) still pass under `MUTSU_FUDGE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)