### PR TITLE
feat(vm): dispatch string-search methods on a Match receiver natively (§D(b))

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -769,6 +769,15 @@
   3 ファイル proper-harness PASS・10 named 形 byte-identical to raku（unicode CI・Str position 含む）・whitelist 回帰ゼロ。pin `t/starts-ends-substr-eq-named-native.t`(21)。**★教訓:
   raku 参照実装は `"abc".ends-with("", :i)` で "Iteration past end of grapheme iterator" を投げる（空 needle+ci のバグ）が mutsu は正しく True を返す＝pin から該当形を除外（mutsu の方が正しい）。
   ★string-method の `:m`/`:ignoremark` は `strip_marks`（NFD→combining-mark filter）で別処理だが、これらの roast テストは backend≠moar ゲートで `:m` 形を skip するので native 化不要・defer で十分。**
+- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = string-search 4 メソッドの Match invocant の VM ネイティブ化)**: 前 3 slice（contains/starts-with・ends-with・substr-eq）で
+  「Match invocant は別軸（Match→Str coercion・instance-bypass 相互作用）」と deferred していたが、精査で **低リスクな gate 緩和のみで解決可**と判明。①`is_native_method("Match", …)` は
+  **エントリ無し→false**＝Match.contains 等は instance-bypass block を通過し variadic helper（arity dispatch 直前）に到達する ②各 helper は既に `text = target.to_string_value()` で text を取得
+  ＝Match なら matched substring（`Cool.Str` と同一）。∴ 受け手 gate を `Value::Str(_)` のみ → 新述語 `is_str_or_match_receiver`（Str or `Instance{class_name=="Match"}`）に緩和するだけで
+  4 メソッド全形の Match invocant を drain。**失敗 match は `Any`/`Nil`（Match instance でない）→ gate 不通過→interpreter が "No such method" を raise**（byte-identical）。**実測 contains.t 140→6・
+  starts-with.t 42→8・ends-with.t 42→8・substr-eq.t 48→14**（残＝bare Match 形〔markings 無し・1-/2-arg arm が Str-gate〕＋テスト自身の `.match`/`$*PERL.compiler`）。全 t/(11710)・4 ファイル
+  proper-harness PASS・9 Match-invocant 形 byte-identical to raku（position・unicode CI 含む）・whitelist 回帰ゼロ。pin `t/str-search-match-invocant-native.t`(18)。**★教訓: 「別軸」と分類した
+  defer も、bypass 順序（`is_native_method` テーブルに対象クラスが無ければ通過）と既存の coercion（helper が `to_string_value` で text 取得）を精査すると 1 述語の gate 緩和に圧縮できることがある。
+  4 連続 string-search slice で `S32-str/{contains,starts-with,ends-with,substr-eq}.t` の method-fallback はほぼ枯渇（各 ≤14＝bare Match 形のみ）。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/builtins/methods_narg.rs
+++ b/src/builtins/methods_narg.rs
@@ -482,7 +482,7 @@ pub(crate) fn native_contains_with_options(
     target: &Value,
     args: &[Value],
 ) -> Option<Result<Value, RuntimeError>> {
-    if !matches!(target, Value::Str(_)) {
+    if !is_str_or_match_receiver(target) {
         return None;
     }
     let mut positional: Vec<&Value> = Vec::new();
@@ -529,6 +529,17 @@ pub(crate) fn native_contains_with_options(
     Some(Ok(result))
 }
 
+/// The string-search methods (`contains` / `starts-with` / `ends-with` / `substr-eq`)
+/// accept a `Str` receiver or a (successful) `Match`. A Match coerces to its matched
+/// substring via `to_string_value()` exactly as `Cool.Str` would, so the same native
+/// search applies — the `text = target.to_string_value()` in each helper yields the
+/// matched substring. A failed match is `Any`/`Nil` (not a Match instance) and so is
+/// not accepted here; the interpreter raises its "No such method" for that.
+fn is_str_or_match_receiver(target: &Value) -> bool {
+    matches!(target, Value::Str(_))
+        || matches!(target, Value::Instance { class_name, .. } if class_name == "Match")
+}
+
 /// Separate `(needle, …)`-style positional args from the `:i`/`:ignorecase`/
 /// `:m`/`:ignoremark` named markings shared by `contains` / `starts-with` /
 /// `ends-with` / `substr-eq`. Returns `None` if an *unexpected* named arg is
@@ -567,7 +578,7 @@ pub(crate) fn native_prefix_suffix_with_options(
     args: &[Value],
     is_prefix: bool,
 ) -> Option<Result<Value, RuntimeError>> {
-    if !matches!(target, Value::Str(_)) {
+    if !is_str_or_match_receiver(target) {
         return None;
     }
     let (positional, ignore_case, ignore_mark) = split_string_match_args(args)?;
@@ -610,7 +621,7 @@ pub(crate) fn native_substr_eq_with_options(
     target: &Value,
     args: &[Value],
 ) -> Option<Result<Value, RuntimeError>> {
-    if !matches!(target, Value::Str(_)) {
+    if !is_str_or_match_receiver(target) {
         return None;
     }
     let (positional, ignore_case, ignore_mark) = split_string_match_args(args)?;

--- a/t/str-search-match-invocant-native.t
+++ b/t/str-search-match-invocant-native.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Pin for the ledger §D(b) slice that extends the native string-search fast paths
+# (contains / starts-with / ends-with / substr-eq, including the :i named forms) to a
+# Match receiver. A (successful) Match coerces to its matched substring via .Str, so
+# the same native search applies; the receiver gate was widened from Str-only to
+# Str-or-Match. The interpreter still owns failed matches (Any/Nil) and :m/ignoremark.
+
+plan 18;
+
+my $m = "FooBar123".match(/<:alpha>+/);   # matches "FooBar"
+is ~$m, 'FooBar', 'sanity: Match stringifies to matched substring';
+
+# contains
+is $m.contains("ooB"), True, 'Match.contains present';
+is $m.contains("xyz"), False, 'Match.contains absent';
+is $m.contains("oob", :i), True, 'Match.contains :i present';
+is $m.contains("oob"), False, 'Match.contains case-sensitive';
+is $m.contains("bar", 3, :i), True, 'Match.contains position + :i';
+is $m.contains("123"), False, 'Match.contains excludes unmatched tail';
+
+# starts-with / ends-with
+is $m.starts-with("Foo"), True, 'Match.starts-with present';
+is $m.starts-with("foo", :i), True, 'Match.starts-with :i';
+is $m.starts-with("foo"), False, 'Match.starts-with case-sensitive';
+is $m.ends-with("Bar"), True, 'Match.ends-with present';
+is $m.ends-with("BAR", :i), True, 'Match.ends-with :i';
+is $m.ends-with("123"), False, 'Match.ends-with excludes unmatched tail';
+
+# substr-eq
+is $m.substr-eq("Bar", 3), True, 'Match.substr-eq position';
+is $m.substr-eq("BAR", 3, :i), True, 'Match.substr-eq position + :i';
+is $m.substr-eq("Bar", 0), False, 'Match.substr-eq position mismatch';
+
+# unicode case-insensitive over a Match
+my $u = "café".match(/\w+/);
+is $u.contains("FÉ", :i), True, 'Match.contains :i unicode';
+is $u.starts-with("CA", :i), True, 'Match.starts-with :i unicode';


### PR DESCRIPTION
## Summary

§D(b) tree-walk dispatch-chain drain — the capstone of the four-slice string-search series. The previous three slices drained the Str-receiver forms of `contains` / `starts-with` / `ends-with` / `substr-eq` (including the `:i` named forms) but deferred the **Match invocants** as a "separate axis" (Match→Str coercion + instance-bypass interaction).

On closer inspection that defer collapses to a low-risk gate relaxation:

1. `is_native_method("Match", …)` has no entry → `false`, so `Match.contains` et al. pass the instance-bypass block and reach the variadic helpers (placed just before the arity dispatch).
2. Each helper already takes `text = target.to_string_value()`, which for a Match yields its matched substring (identical to `Cool.Str`).

## Change

Widen the receiver gate from `Value::Str(_)` to a new predicate `is_str_or_match_receiver` (Str or `Instance{class_name == "Match"}`), draining the Match invocants for all four methods at once. A failed match is `Any`/`Nil` (not a Match instance), so it doesn't pass the gate and the interpreter still raises its "No such method".

## Verification

- `contains.t` 140→6, `starts-with.t` 42→8, `ends-with.t` 42→8, `substr-eq.t` 48→14 (remaining = bare Match forms on the Str-gated 1-/2-arg arms + the tests' own `.match` / `$*PERL.compiler`).
- All `t/` (11710) pass, four files green via the proper harness, 9 Match-invocant forms byte-identical to `raku` (position + unicode CI), whitelist regression-free.
- pin `t/str-search-match-invocant-native.t` (18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)