### PR TITLE
fix(packages): GLOBAL:: is the root namespace for package declarations

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -215,6 +215,14 @@ impl Compiler {
     }
 
     pub(crate) fn qualify_package_name(&self, name: &str) -> String {
+        // `GLOBAL` is the implicit root namespace: `package GLOBAL::X::Y` declares
+        // `X::Y` absolutely, regardless of the enclosing package. Strip the leading
+        // `GLOBAL::` and do NOT prepend the current package (otherwise a nested
+        // `package GLOBAL::X::DBIish` inside `unit class DBIish` would wrongly
+        // become `DBIish::X::DBIish`).
+        if let Some(absolute) = name.strip_prefix("GLOBAL::") {
+            return absolute.to_string();
+        }
         if self.current_package == "GLOBAL" || self.current_package.contains("::&") {
             name.to_string()
         } else {

--- a/t/global-package-prefix.t
+++ b/t/global-package-prefix.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 5;
+
+# `GLOBAL` is the implicit root namespace, so `package GLOBAL::X::Y { ... }`
+# declares `X::Y` absolutely -- a class inside it is named `X::Y::Class`, not
+# `GLOBAL::X::Y::Class`. This is how DBIish declares its exception types
+# (`package GLOBAL::X::DBIish { class DriverNotFound is Exception {...} }`
+# *inside* `unit class DBIish`), then refers to them as `X::DBIish::DriverNotFound`.
+
+package GLOBAL::X::Demo {
+    class Oops is Exception {
+        has $.detail;
+        method message { "oops: $.detail" }
+    }
+}
+
+my $e = X::Demo::Oops.new(:detail('boom'));
+is $e.detail, 'boom', 'class in GLOBAL:: package is reachable by its absolute name';
+is $e.message, 'oops: boom', 'its methods work';
+ok $e ~~ Exception, 'it is an Exception';
+
+# The fully-qualified GLOBAL:: name still resolves to the same type.
+ok GLOBAL::X::Demo::Oops === X::Demo::Oops,
+    'GLOBAL::-prefixed and bare absolute names are the same type';
+
+# A GLOBAL:: package nested inside another package still resolves absolutely
+# (not relative to the enclosing package).
+class Outer {
+    package GLOBAL::X::Nested {
+        class Inner { method who { 'inner' } }
+    }
+}
+is X::Nested::Inner.new.who, 'inner',
+    'GLOBAL:: package inside a class is absolute, not Outer::X::Nested';


### PR DESCRIPTION
`package GLOBAL::X::Y { ... }` declares `X::Y` absolutely: `GLOBAL` is the implicit root, so the leading `GLOBAL::` must be stripped and the name must **not** be re-qualified by the enclosing package. mutsu kept the prefix, registering a class inside as `GLOBAL::X::Y::Class`, so the user-facing name `X::Y::Class` was unknown (`.new` threw `X::Method::NotFound`).

## Impact
This blocked **DBIish**, which declares its exception types as `package GLOBAL::X::DBIish { class DriverNotFound is Exception {...} }` *inside* `unit class DBIish`, then refers to them as `X::DBIish::DriverNotFound`. Without the fix that nested form even mis-qualified to `DBIish::X::DBIish::...`.

## Fix
`qualify_package_name` returns a `GLOBAL::`-prefixed name as the stripped absolute name (no enclosing-package prefix).

New regression test `t/global-package-prefix.t` (5 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)