### PR TITLE
feat(exception): .fail method on Exception instances

### DIFF
--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -571,7 +571,7 @@ impl Interpreter {
         // .resume / .throw / .rethrow on instances of user-defined Exception
         // subclasses (the builtin fast path only handles Exception/X::*/CX::*/
         // Failure by name).
-        if matches!(method, "resume" | "throw" | "rethrow")
+        if matches!(method, "resume" | "throw" | "rethrow" | "fail")
             && args.is_empty()
             && let Value::Instance {
                 class_name,
@@ -590,6 +590,12 @@ impl Interpreter {
             if is_exception || does_x_control {
                 if method == "resume" {
                     return Err(crate::value::RuntimeError::resume_signal());
+                }
+                // `$exc.fail` is `fail $exc`: return a Failure carrying the
+                // exception (which throws only when sunk/used unhandled), not an
+                // immediate throw like `.throw`.
+                if method == "fail" {
+                    return self.builtin_fail(std::slice::from_ref(&target));
                 }
                 // throw / rethrow: build a RuntimeError carrying this exception.
                 let msg = attributes

--- a/t/exception-fail-method.t
+++ b/t/exception-fail-method.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 6;
+
+# `$exception.fail` is `fail $exception`: it returns a Failure carrying the
+# exception (which throws only when the Failure is sunk/used unhandled), rather
+# than throwing immediately like `.throw`. mutsu previously had no `.fail`
+# method on Exception instances ("No such method 'fail'"). This is used by
+# DBIish: `X::DBIish::DriverNotFound.new(...).fail`.
+
+class MyErr is Exception {
+    has $.msg;
+    method message { $.msg }
+}
+
+# .fail inside a sub, caught by CATCH.
+{
+    my $caught;
+    sub boom() { MyErr.new(:msg('bang')).fail }
+    {
+        boom();
+        CATCH { default { $caught = .message } }
+    }
+    is $caught, 'bang', '.fail throws the exception when sunk';
+}
+
+# .fail returns a Failure (not an immediate throw).
+{
+    sub mk() { return MyErr.new(:msg('x')).fail }
+    my $f = mk();
+    nok $f.defined, '.fail returns an undefined Failure';
+    ok $f.WHAT === Failure, '.fail returns a Failure';
+}
+
+# A user X::-namespaced exception works too.
+{
+    my $caught;
+    {
+        X::AdHoc.new(:payload('adhoc!')).fail;
+        CATCH { default { $caught = .message } }
+    }
+    is $caught, 'adhoc!', '.fail on an X:: exception';
+}
+
+# .fail on a type object is still a concreteness error, not "no such method".
+throws-like 'MyErr.fail', Exception, '.fail on a type object dies (concreteness)';
+
+# .throw still throws immediately.
+{
+    my $caught;
+    {
+        MyErr.new(:msg('thrown')).throw;
+        CATCH { default { $caught = .message } }
+    }
+    is $caught, 'thrown', '.throw still works';
+}


### PR DESCRIPTION
`$exception.fail` is `fail $exception`: it returns a Failure carrying the exception (which throws only when the Failure is sunk or used unhandled), rather than throwing immediately like `.throw`. mutsu had no `.fail` method on Exception instances, so `$exc.fail` died with *"No such method .fail"*.

## Fix
The instance `throw`/`resume`/`rethrow` handler now also accepts `fail`, routing it through `builtin_fail` (the same path as the `fail` routine). `.fail` on a *type object* remains an `X::Parameter::InvalidConcreteness` error.

## Impact
Used by **DBIish**: `X::DBIish::DriverNotFound.new(...).fail`.

New regression test `t/exception-fail-method.t` (6 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)