### PR TITLE
feat(vm): dispatch atomic var/element RMW ops natively (§D state ownership)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -778,6 +778,18 @@
   proper-harness PASS・9 Match-invocant 形 byte-identical to raku（position・unicode CI 含む）・whitelist 回帰ゼロ。pin `t/str-search-match-invocant-native.t`(18)。**★教訓: 「別軸」と分類した
   defer も、bypass 順序（`is_native_method` テーブルに対象クラスが無ければ通過）と既存の coercion（helper が `to_string_value` で text 取得）を精査すると 1 述語の gate 緩和に圧縮できることがある。
   4 連続 string-search slice で `S32-str/{contains,starts-with,ends-with,substr-eq}.t` の method-fallback はほぼ枯渇（各 ≤14＝bare Match 形のみ）。**
+- **2026-06-25 (§D 状態所有 = atomic var/element RMW（`__mutsu_atomic_*`/`__mutsu_cas_*`）の VM ネイティブ dispatch)**: method-fallback の clean drain 枯渇後、**function-fallback** を全 whitelist 集計したところ
+  `__mutsu_atomic_add_var`(640001)/`__mutsu_atomic_post_inc_var`(320038)/`pre_inc`/`post_dec`/`pre_dec`(各 320001)/`__mutsu_cas_var`(282337)/`cas_hash_elem`(30000)/`cas_array_elem`(29420)＝
+  **計 ~250 万 fallback で function-fallback 全体を圧倒的に支配**（concurrency stress＝`⚛`-operators 駆動）。これは §D「状態所有」の直撃カテゴリ＝atomic op は VM 共有の `shared_vars`（`RwLock`）store と
+  per-attribute cell-CAS state（Phase 3）への RMW。既存 `builtin_atomic_*`/`builtin_cas_*` impl が既にその state を所有・操作しているが、**到達経路が generic な `call_function`（`vm_call_function`→`loan_env_for`→
+  ~数百 arm の名前 match）fallback だけ**だった（`try_native_function` は pure な `native_function` のみ呼ぶため `&mut self` の atomic op は素通り）。**修正**＝新 `try_native_atomic_function(name,args)`（`builtins_atomic.rs`・
+  `builtins.rs` の atomic arm 群を 1:1 ミラー・`cas_*` は `args.to_vec()`）を `try_native_function` 冒頭（Instance-arg bail より前＝`cas($x,$old,$obj)` の Instance 値も dispatch 可）で
+  `name.starts_with("__mutsu_atomic_"|"__mutsu_cas_")` 時に呼ぶ。`loan_env_for` は CP-3 collapse 後 `f(self)` の薄い passthrough＝env は両経路で同一 `self.env`・builtin は同一＝byte-identical。
+  **実測 atomic-ops.t/atomic.t の function-fallback：atomic markers が完全消滅**（cas.t stress=95003 opcodes 中 fallback 61＝残は `start`/`await`〔concurrency 別軸〕＋user-facing `cas`）。
+  全 t/(11725)・S17-lowlevel/{cas,cas-loop,cas-loop-int,atomic,atomic-ops}.t 全 PASS（atomic.t 34/34・atomic-ops.t 28/28＝debug は `for ^20000` stress で遅いが完走）・20 atomic 形 byte-identical to raku。
+  pin `t/atomic-ops-native-dispatch.t`(20)。**★教訓: method-fallback だけでなく function-fallback survey も §D の宝庫。`__mutsu_*` 内部マーカー（atomic/cas/hyper-prefix）は「pure でない（`&mut self`）」ため
+  `try_native_function`→`native_function`(pure) を素通りし generic `call_function` fallback に全部落ちていた。`try_native_function` 冒頭に `&mut self` builtin への直接 dispatch arm を足せば、巨大 stress 系の
+  fallback を一掃できる（state 所有は既に VM 側＝挙動不変の経路短絡）。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -6,6 +6,39 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub(super) static ATOMIC_VAR_KEY_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 impl Interpreter {
+    /// VM-native dispatch for the atomic var/element RMW markers (`__mutsu_atomic_*`
+    /// / `__mutsu_cas_*`) the parser emits for the `⚛`-operators (`⚛=`/`⚛+=`/`⚛++`/
+    /// `--⚛`/`cas`). These reached the interpreter only through the generic
+    /// `call_function` name-match fallback; the `builtin_atomic_*` / `builtin_cas_*`
+    /// impls already own the VM-shared `shared_vars` store and the per-attribute
+    /// cell-CAS state, so the VM dispatches them directly here without the
+    /// `call_function` round-trip (§D state ownership — byte-identical, the
+    /// `call_function` arms call these exact impls on the same `self`). Returns
+    /// `None` for every other name so the caller falls through to the rest of native
+    /// dispatch.
+    pub(crate) fn try_native_atomic_function(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let r = match name {
+            "__mutsu_atomic_fetch_var" => self.builtin_atomic_fetch_var(args),
+            "__mutsu_atomic_store_var" => self.builtin_atomic_store_var(args),
+            "__mutsu_atomic_add_var" => self.builtin_atomic_add_var(args),
+            "__mutsu_atomic_fetch_add_var" => self.builtin_atomic_fetch_add_var(args),
+            "__mutsu_atomic_post_inc_var" => self.builtin_atomic_post_inc_var(args),
+            "__mutsu_atomic_pre_inc_var" => self.builtin_atomic_pre_inc_var(args),
+            "__mutsu_atomic_post_dec_var" => self.builtin_atomic_post_dec_var(args),
+            "__mutsu_atomic_pre_dec_var" => self.builtin_atomic_pre_dec_var(args),
+            "__mutsu_cas_var" => self.builtin_cas_var(args.to_vec()),
+            "__mutsu_cas_array_elem" => self.builtin_cas_array_elem(args.to_vec()),
+            "__mutsu_cas_array_multidim" => self.builtin_cas_array_multidim(args.to_vec()),
+            "__mutsu_cas_hash_elem" => self.builtin_cas_hash_elem(args.to_vec()),
+            _ => return None,
+        };
+        Some(r)
+    }
+
     pub(super) fn canonical_atomic_var_name(
         &self,
         raw_name: &str,

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -371,6 +371,19 @@ impl Interpreter {
         name_sym: crate::symbol::Symbol,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
+        // Atomic var/element RMW markers (`__mutsu_atomic_*` / `__mutsu_cas_*`) for the
+        // `⚛`-operators. Dispatch them here directly so they don't fall through to the
+        // generic `call_function` name-match (§D state ownership). Checked before the
+        // Instance-arg bail below because a cas/store value may legitimately be an
+        // Instance (e.g. `cas($x, $old, $obj)`).
+        {
+            let name = name_sym.resolve();
+            if (name.starts_with("__mutsu_atomic_") || name.starts_with("__mutsu_cas_"))
+                && let Some(result) = self.try_native_atomic_function(name.as_str(), args)
+            {
+                return Some(result);
+            }
+        }
         if args.iter().any(|arg| matches!(arg, Value::Instance { .. })) {
             // Junction constructors wrap their arguments verbatim regardless of
             // type, so an Instance argument is safe to handle natively; every

--- a/t/atomic-ops-native-dispatch.t
+++ b/t/atomic-ops-native-dispatch.t
@@ -1,0 +1,51 @@
+use Test;
+
+# Pin for the ledger §D slice that dispatches the atomic var/element RMW markers
+# (__mutsu_atomic_* / __mutsu_cas_*, emitted for the ⚛-operators and cas()) directly
+# in the VM's native function fast path, instead of falling through to the generic
+# call_function name-match. Behavior is byte-identical (same builtin_atomic_* impls,
+# same shared_vars / cell-CAS state); this pins the correctness of every form.
+
+plan 20;
+
+# --- atomic increment / decrement (pre/post) -----------------------------------
+my atomicint $a = 0;
+$a⚛++;
+is $a, 1, 'post-increment ⚛++';
+is $a⚛++, 1, 'post-increment returns old value';
+is $a, 2, 'post-increment advanced';
+is ++⚛$a, 3, 'pre-increment ++⚛ returns new value';
+is $a⚛--, 3, 'post-decrement returns old value';
+is --⚛$a, 1, 'pre-decrement --⚛ returns new value';
+
+# --- atomic add / fetch-add ----------------------------------------------------
+$a ⚛+= 10;
+is $a, 11, 'atomic add-assign ⚛+=';
+is atomic-fetch-add($a, 4), 11, 'atomic-fetch-add returns old';
+is $a, 15, 'atomic-fetch-add advanced';
+is atomic-add-fetch($a, 5), 20, 'atomic-add-fetch returns new';
+
+# --- atomic fetch / store ------------------------------------------------------
+is atomic-fetch($a), 20, 'atomic-fetch reads current';
+atomic-assign($a, 100);
+is $a, 100, 'atomic-assign stores';
+
+# --- cas on a scalar (3-arg and code form) -------------------------------------
+my atomicint $b = 10;
+is cas($b, 10, 99), 10, 'cas 3-arg returns old (success)';
+is $b, 99, 'cas 3-arg swapped';
+is cas($b, 10, 7), 99, 'cas 3-arg returns current (failed compare)';
+is $b, 99, 'cas 3-arg left unchanged on failed compare';
+my atomicint $c = 5;
+cas($c, -> $old { $old * 2 });
+is $c, 10, 'cas code form computes new from old';
+
+# --- cas on an array element ---------------------------------------------------
+my int @arr = 1, 2, 3;
+is cas(@arr[1], 2, 20), 2, 'cas on array element returns old';
+is @arr[1], 20, 'cas on array element swapped';
+
+# --- cas on a hash element -----------------------------------------------------
+my %h = a => 1;
+cas(%h<a>, 1, 42);
+is %h<a>, 42, 'cas on hash element swapped';


### PR DESCRIPTION
## Summary

§D **state ownership** slice. After the method-fallback clean drains were exhausted, surveying *function*-fallback across the whole whitelist showed the atomic markers dominating overwhelmingly:

| marker | fallbacks |
|---|---|
| `__mutsu_atomic_add_var` | 640001 |
| `__mutsu_atomic_post_inc_var` | 320038 |
| `pre_inc` / `post_dec` / `pre_dec` | 320001 each |
| `__mutsu_cas_var` | 282337 |
| `cas_hash_elem` / `cas_array_elem` | 30000 / 29420 |

~2.5M fallbacks total, driven by `⚛`-operator concurrency stress tests. This is squarely a §D state-ownership category: atomic ops RMW the VM-shared `shared_vars` store and the Phase-3 per-attribute cell-CAS state.

The `builtin_atomic_*` / `builtin_cas_*` impls already own that state, but the only path reaching them was the generic `call_function` name-match fallback — `try_native_function` calls the pure `native_function`, which can't host these `&mut self` ops.

## Change

- Add `try_native_atomic_function` (mirrors the `call_function` atomic arms 1:1; `cas_*` take `args.to_vec()`).
- Call it at the top of `try_native_function` — **before** the Instance-arg bail, so a `cas` value that is an Instance still dispatches.
- `loan_env_for` is a thin `f(self)` passthrough post-CP-3, so env is the same `self.env` on both paths and the builtins are identical ⇒ byte-identical.

## Verification

- Atomic markers fully drained from function-fallback (cas.t stress: 95003 opcodes, 61 fallbacks left = `start`/`await` concurrency + user-facing `cas`).
- All `t/` (11725) pass; `S17-lowlevel/{cas,cas-loop,cas-loop-int,atomic,atomic-ops}.t` pass (atomic.t 34/34, atomic-ops.t 28/28 — debug-slow `^20000` stress but complete).
- 20 atomic forms byte-identical to `raku`. pin `t/atomic-ops-native-dispatch.t` (20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)