### PR TITLE
feat: support URI module — grammar inheritance, Lock.protect writeback, $._port

### DIFF
--- a/src/parser/primary/var.rs
+++ b/src/parser/primary/var.rs
@@ -312,7 +312,9 @@ pub(super) fn scalar_var(input: &str) -> PResult<'_, Expr> {
         || input.starts_with('?')
         || input.starts_with('!')
         || input.starts_with('^')
-        || (input.starts_with('.') && input.len() > 1 && input.as_bytes()[1].is_ascii_alphabetic())
+        || (input.starts_with('.')
+            && input.len() > 1
+            && (input.as_bytes()[1].is_ascii_alphabetic() || input.as_bytes()[1] == b'_'))
         || (input.starts_with('~') && input.len() > 1 && input.as_bytes()[1].is_ascii_alphabetic())
     {
         (&input[1..], &input[..1])

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -1713,6 +1713,9 @@ pub(super) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws1(rest)?;
     let (rest, name) = qualified_ident(rest)?;
     check_pseudo_package_in_decl(&name)?;
+    // Consume optional type adverbs (`:ver<...>`, etc.) on the grammar name
+    // before the `is`/`does` parent clauses (e.g. `grammar Foo:ver<1> is Bar`).
+    let (rest, _traits) = parse_declarator_traits(rest)?;
     let (rest, _) = ws(rest)?;
     let mut r = rest;
     let mut parents = Vec::new();
@@ -1992,6 +1995,11 @@ pub(super) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws1(r)?;
         let (r, name) = qualified_ident(r)?;
         check_pseudo_package_in_decl(&name)?;
+        // Consume optional type adverbs (`:ver<...>`, `:auth<...>`, `:api<...>`)
+        // on the grammar name before the `is`/`does` parent clauses, e.g.
+        // `unit grammar Foo:ver<0.3.8> is Bar;`. Without this, the adverb blocks
+        // the `is Bar` parent from being parsed (parent silently dropped).
+        let (r, _traits) = parse_declarator_traits(r)?;
         let (r, _) = ws(r)?;
         let mut r = r;
         let mut parents = Vec::new();

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -86,10 +86,30 @@ pub(super) fn is_stmt_modifier_keyword(input: &str) -> bool {
 }
 
 /// Check if an expression ends with a block body (e.g., `try { ... }`,
-/// `do { ... }`, `gather { ... }`). Such expressions should not have
-/// statement modifiers attached across a newline.
+/// `do { ... }`, `gather { ... }`, or a call whose final argument is a bare
+/// block such as `$lock.protect: { ... }` / `@a.map: { ... }`). Such
+/// expressions should not have statement modifiers attached across a newline:
+/// in Raku a statement ending in a `}` block at end of line is self-terminating.
 fn expr_ends_with_block(expr: &Expr) -> bool {
-    matches!(expr, Expr::Try { .. } | Expr::Gather(_))
+    match expr {
+        Expr::Try { .. } | Expr::Gather(_) => true,
+        Expr::MethodCall { args, .. }
+        | Expr::HyperMethodCall { args, .. }
+        | Expr::DynamicMethodCall { args, .. }
+        | Expr::Call { args, .. } => {
+            matches!(args.last(), Some(Expr::AnonSub { is_block: true, .. }))
+        }
+        _ => false,
+    }
+}
+
+/// After a statement-modifier keyword's condition, a `{` block (or `-> ... {`
+/// pointy header) means this is actually a full control statement (`if COND
+/// { ... }`), not a postfix modifier — modifiers never take a block. Mirrors
+/// the guard the `for`/`with` modifiers already apply to their own headers.
+fn block_follows_modifier_condition(r: &str) -> bool {
+    let r = r.trim_start();
+    r.starts_with('{') || r.starts_with("->")
 }
 
 /// Parse statement modifier (postfix if/unless/for/while/until/given/when).
@@ -155,6 +175,13 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
+        // A `{` block after the condition means this is a full `if COND { ... }`
+        // control statement, not a postfix modifier (modifiers take no block).
+        // This arises after a block-final statement on the previous line whose
+        // trailing newline was consumed (`$lock.protect: { ... }` then `if ...`).
+        if block_follows_modifier_condition(r) {
+            return Ok(None);
+        }
         check_two_terms_across_lines(r)?;
         let then_stmt = rewrite_placeholder_block_modifier_stmt(stmt, &cond);
         return Ok(Some((
@@ -177,6 +204,9 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
+        if block_follows_modifier_condition(r) {
+            return Ok(None);
+        }
         check_two_terms_across_lines(r)?;
         let then_stmt = rewrite_placeholder_block_modifier_stmt(stmt, &cond);
         return Ok(Some((
@@ -293,6 +323,9 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
+        if block_follows_modifier_condition(r) {
+            return Ok(None);
+        }
         return Ok(Some((
             r,
             Stmt::While {
@@ -312,6 +345,9 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
+        if block_follows_modifier_condition(r) {
+            return Ok(None);
+        }
         return Ok(Some((
             r,
             Stmt::While {
@@ -334,6 +370,9 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             remaining_len: err.remaining_len.or(Some(r.len())),
             exception: None,
         })?;
+        if block_follows_modifier_condition(r) {
+            return Ok(None);
+        }
         let given_stmt = rewrite_placeholder_block_modifier_stmt(stmt, &topic);
         return Ok(Some((
             r,

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -2105,6 +2105,19 @@ impl Interpreter {
                 });
             }
         }
+        // Grammars inherit parse/subparse/parsefile from the built-in Grammar
+        // type. These are dispatched natively (no ClassDef.methods entry), so the
+        // MRO walk above misses them — probe the grammar-ness of the target.
+        if results.is_empty()
+            && matches!(method_name, "parse" | "subparse" | "parsefile")
+            && self.package_looks_like_grammar(&class_name)
+        {
+            results.push(Value::Routine {
+                package: Symbol::intern(&class_name),
+                name: Symbol::intern(method_name),
+                is_regex: false,
+            });
+        }
         // Built-in exception instances (X::...) expose their attributes as
         // accessor methods (e.g. X::Undeclared.suggestions, .symbol). The HOW
         // metamodel has no user class def for these, so probe the instance's own

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -2383,6 +2383,23 @@ impl Interpreter {
             }
         }
 
+        // The block runs inline in the current env, so a free variable it
+        // assigns (`$x = 99` where `$x` is a captured outer lexical) is written
+        // via SetGlobal straight into env — never as a block-local, so the
+        // writeback_bindings loop below (which only handles block-locals) misses
+        // it. Reconcile the *outer frame's* local slot for each such free-var
+        // write from env, so the caller sees the mutation (e.g. a value assigned
+        // inside `$lock.protect: { ... }`).
+        for sym in &block_cc.free_var_writes {
+            sym.with_str(|name| {
+                if let Some(outer_slot) = outer_local_slots.get(name)
+                    && let Some(val) = self.env().get(name).cloned()
+                    && let Some(target) = saved_locals.get_mut(*outer_slot)
+                {
+                    *target = val;
+                }
+            });
+        }
         // Sync locals back to env
         if let Some(captured) = captured_env {
             for (slot, name) in writeback_bindings.iter() {

--- a/t/block-final-stmt-modifier.t
+++ b/t/block-final-stmt-modifier.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A statement modifier (if/unless/while/until/given) never takes a block.
+# `if COND { ... }` after a block-final statement on the previous line is a
+# full control statement, not a postfix modifier attached to the prior line.
+
+plan 5;
+
+# Same-line modifier still works (ends in `;`, not a block).
+my @a = 1, 2, 3;
+my $n = 0;
+@a.map: { $n += $_ } if True;
+is $n, 6, 'same-line block-call + postfix if still attaches';
+
+{
+    my @log;
+    my $cond = False;
+    do { @log.push('body') }
+    if $cond { @log.push('if-branch') }
+    is @log.join(','), 'body', 'do-block then if-statement parse as two statements';
+}
+
+{
+    my $x = 5;
+    my $hit = 0;
+    do { $x = 10 }
+    unless $x > 100 { $hit = 1 }
+    is $hit, 1, 'unless after a block-final statement is its own statement';
+}
+
+{
+    my $lock = Lock.new;
+    my $count = 0;
+    $lock.protect: { $count = 1 }
+    until $count >= 3 { $count++ }
+    is $count, 3, 'until-statement after block-final statement is separate';
+}
+
+{
+    my $out = '';
+    my @a = 'a';
+    @a.map: { $out = $_ }
+    given 3 { $out ~= "-$_" }
+    is $out, 'a-3', 'given-statement after block-final statement is separate';
+}

--- a/t/dollar-dot-underscore-accessor.t
+++ b/t/dollar-dot-underscore-accessor.t
@@ -1,0 +1,25 @@
+use Test;
+
+# `$.method` / `$!attr` accessor with a name starting with an underscore.
+# Previously the `$.` twigil parser only accepted alphabetic first characters,
+# so `$._port` failed to parse.
+
+plan 4;
+
+class C {
+    has $._port = 9;
+    method _port { 5 }
+    method via-dot { $._port }
+    method via-attr { $!_port }
+    multi method port(C:D: --> Int) { $._port // 99 }
+}
+
+is C.new.via-dot, 5, '$._port calls the _port method';
+is C.new.via-attr, 9, '$!_port reads the _port attribute';
+is C.new.port, 5, '$._port works in a multi method with return type';
+
+class D {
+    method _x { 42 }
+    method go { $._x }
+}
+is D.new.go, 42, 'underscore-leading accessor name in a plain method';

--- a/t/grammar-can-and-ver-parent.t
+++ b/t/grammar-can-and-ver-parent.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Two grammar fixes:
+#  1. `.can('parse')` reports the inherited Grammar parse methods.
+#  2. A type adverb (`:ver<...>`) on a grammar name no longer eats the
+#     following `is Parent` clause, so grammar inheritance composes.
+
+plan 6;
+
+grammar G { token TOP { \d+ } }
+ok so G.can('parse'),     'grammar.can("parse") is true';
+ok so G.can('subparse'),  'grammar.can("subparse") is true';
+ok so G.can('parsefile'), 'grammar.can("parsefile") is true';
+
+grammar Base:ver<1.0> {
+    token ipv4 { \d+ '.' \d+ '.' \d+ '.' \d+ }
+}
+grammar Child:ver<1.0> is Base {
+    token TOP  { <host> }
+    token host { <ipv4> | \w+ }
+}
+
+ok Child.^mro.map(*.^name).grep('Base'), 'versioned grammar inherits its parent (MRO has Base)';
+
+my $m = Child.parse('1.2.3.4');
+ok $m.defined, 'child grammar matches via inherited subrule';
+is ~$m<host>, '1.2.3.4', 'inherited subrule captured the host';

--- a/t/lock-protect-writeback.t
+++ b/t/lock-protect-writeback.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A captured outer lexical assigned inside `Lock.protect: { ... }` must be
+# visible to the caller after the protected block returns. The block runs
+# inline in the current env, so the free-var write lands in env and must be
+# reconciled back into the caller's local slot.
+
+plan 4;
+
+{
+    my $lock = Lock.new;
+    my $x = 1;
+    $lock.protect: { $x = 42; };
+    is $x, 42, 'plain assignment inside protect writes back';
+}
+
+{
+    my $lock = Lock.new;
+    my $x = 1;
+    $lock.protect: { $x = $x + 100; };
+    is $x, 101, 'read-modify-write inside protect writes back';
+}
+
+sub in-sub() {
+    my $lock = Lock.new;
+    my $x = 5;
+    $lock.protect: { $x = 7; };
+    $x;
+}
+is in-sub(), 7, 'protect writeback works inside a sub';
+
+{
+    # No semicolon after the protect block, followed by `if` on the next line:
+    # the `if` must be a separate statement, not a postfix modifier.
+    my $lock = Lock.new;
+    my $x = 1;
+    $lock.protect: {
+        $x = 9;
+    }
+    if (! $x) { $x = -1 }
+    is $x, 9, 'block-final protect statement self-terminates before if';
+}


### PR DESCRIPTION
Five general-purpose fixes uncovered while making the off-the-shelf `URI` distribution load and parse. With these, `URI.new('http://...')` gets through grammar construction, inheritance composition, and into the RFC grammar match (next blocker is the `<+unreserved +sub-delims>` enumerated character class, a separate feature).

## Fixes

1. **parser: `$._port` accessor** — `$.`/`$!` accessor names may start with an underscore. The `$.` twigil branch only accepted an alphabetic first char.

2. **runtime: `Grammar.can('parse')`** — `.can` now reports the inherited native `parse`/`subparse`/`parsefile`. These dispatch natively (no ClassDef method entry) so the `.^can` MRO walk missed them.

3. **vm: `Lock.protect` writeback** — a captured outer lexical assigned inside `$lock.protect: { ... }` is reconciled back into the caller's local slot. The block runs inline in the current env; its free-var write landed in env but never reached the caller's local.

4. **parser: statement-modifier block guard** — `if/unless/while/until/given` reject a `{` block after their condition (`if COND { ... }` is a control statement, not a postfix modifier). Arises after a block-final statement whose trailing newline was consumed. Mirrors the guard `for`/`with`/`without` already apply.

5. **parser: grammar `:ver` + `is Parent`** — a type adverb on a grammar name no longer eats the `is Parent` clause, so `grammar Foo:ver<1> is Bar` composes Bar into the MRO.

## Tests

New `t/` files: `dollar-dot-underscore-accessor.t`, `grammar-can-and-ver-parent.t`, `lock-protect-writeback.t`, `block-final-stmt-modifier.t`. `make test` passes (11764 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)