### PR TITLE
feat(vm): dispatch builtin infix:<op> operator-functions natively (§D state ownership)

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -790,6 +790,15 @@
   pin `t/atomic-ops-native-dispatch.t`(20)。**★教訓: method-fallback だけでなく function-fallback survey も §D の宝庫。`__mutsu_*` 内部マーカー（atomic/cas/hyper-prefix）は「pure でない（`&mut self`）」ため
   `try_native_function`→`native_function`(pure) を素通りし generic `call_function` fallback に全部落ちていた。`try_native_function` 冒頭に `&mut self` builtin への直接 dispatch arm を足せば、巨大 stress 系の
   fallback を一掃できる（state 所有は既に VM 側＝挙動不変の経路短絡）。**
+- **2026-06-25 (§D 状態所有 = builtin operator-as-function `infix:<op>(...)` の VM ネイティブ dispatch)**: atomic 後の function-fallback 集計で `infix:<op>` 族＝**44 演算子で計 ~5400 fallback**
+  （`&infix:<+>`・`[+]`/`[*]` reduce・`>>+>>` hyper・`reduce &infix:<…>` が lower する routine 形）。builtin operator は native Rust の `call_infix_routine`（`&mut self`・hyper/assignment-metaop/set-op/
+  全 binary op を dispatch）が impl だが、到達経路が `call_function_fallback` の infix arm 経由（tree-walk fallback 記録）だけだった。**修正**＝`dispatch_func_call_inner`（直接 Call 経路）と
+  `call_function_compiled_first`（hyper/reduce/string-regex 経路）の両方で、**全 user 演算子解決（compiled_fns / 非proto multi fork / `user_function_matches_call` / OTF）を試した後・terminal fallback の直前**に
+  `infix:<op>` を捕捉して `call_infix_routine(op,args)` を直接呼ぶ（U+2212 minus は `-` に正規化・arg_sources と `maybe_fetch_rw_proxy` は terminal else と同一処理＝byte-identical）。**user-override 厳守**＝
+  user `sub/multi infix:<…>` は上位ブランチで解決されるので native arm に到達せず（pin で `infix:<plus>`=103・`multi infix:<%%%>`=custom を検証）。**実測 直接 infix 呼び 100%→0**（user multi は正しく fallback 維持）。
+  全 t/(11765)・whitelist operator/metaops/junction 79 ファイル回帰ゼロ・20 infix 形 byte-identical to raku。pin `t/infix-function-native-dispatch.t`(22)。**★`call_infix_routine` を `pub(crate)` に拡大。
+  ★教訓: 直接 Call は `dispatch_func_call_inner`・hyper/reduce 等は `call_function_compiled_first` と fallback 記録サイトが 2 系統あるので、両方に同じ arm を置く要がある。user-override 系演算子の native 化は
+  「全 user 解決ブランチの後・fallback 記録の前」に挿入するのが鍵（先頭に置くと user 演算子を shadow する）。`<`/`>` を含む演算子名（`infix:«<»`）は別パーサ問題で CALL-ME エラー＝pin から除外。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -802,7 +802,7 @@ impl Interpreter {
         ))
     }
 
-    pub(super) fn call_infix_routine(
+    pub(crate) fn call_infix_routine(
         &mut self,
         op: &str,
         args: &[Value],

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -68,6 +68,23 @@ impl Interpreter {
         if let Some(result) = self.try_native_test_function(name, &args) {
             return result;
         }
+        // Builtin operator-as-function `infix:<op>(...)` (e.g. `&infix:<+>`, the
+        // routine `[+]`/hyper/`reduce` lower to). Any user-defined operator was
+        // already resolved above (compiled_fns / OTF), so reaching here means the
+        // builtin operator — dispatch it straight to the native `call_infix_routine`
+        // handler instead of recording a tree-walk fallback. This mirrors
+        // `call_function_fallback`'s infix arm exactly (the big `call_function` match
+        // has no infix arm, so both reach the same `call_infix_routine` on the same
+        // `self`); `sanitize_call_args` only strips the Test callsite marker, which
+        // operator routines never carry, so the result is byte-identical. §D state
+        // ownership: the operator handlers are native Rust on the VM's own state.
+        if let Some(op) = name
+            .strip_prefix("infix:<")
+            .and_then(|s| s.strip_suffix('>'))
+        {
+            let normalized = if op == "\u{2212}" { "-" } else { op };
+            return self.call_infix_routine(normalized, &args);
+        }
         // CARRIER (EVAL/pseudo-package) vs TODO: compile to bytecode (else branch =
         // true tree-walk function fallback). See ledger §2/§C.
         if Self::is_interpreter_carrier_function(name) {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1157,6 +1157,27 @@ impl Interpreter {
                     // caller env (scoped_child) and the captured-env merge is
                     // or_insert (parent-chain aware), so it never shadows them.
                     self.vm_call_on_value(callable, args, Some(compiled_fns))
+                } else if let Some(op) = name
+                    .strip_prefix("infix:<")
+                    .and_then(|s| s.strip_suffix('>'))
+                {
+                    // Builtin operator-as-function `infix:<op>(...)` (what `&infix:<+>`,
+                    // `[+]`, hyper and `reduce` lower to). Every user-defined operator
+                    // path (compiled_fns / multi / user_function_matches / OTF) was
+                    // tried above, so reaching here means the builtin operator —
+                    // dispatch it straight to the native `call_infix_routine` handler
+                    // instead of recording a tree-walk fallback. This mirrors
+                    // `call_function_fallback`'s infix arm exactly (the big
+                    // `call_function` match has no infix arm, so both reach the same
+                    // `call_infix_routine` on the same `self`), with the same
+                    // arg-sources + rw-proxy handling => byte-identical. §D state
+                    // ownership: the operator handlers are native Rust on VM state.
+                    let normalized = if op == "\u{2212}" { "-" } else { op };
+                    self.set_pending_call_arg_sources(arg_sources);
+                    let result = self.call_infix_routine(normalized, &args);
+                    self.set_pending_call_arg_sources(None);
+                    let result = result?;
+                    loan_env!(self, maybe_fetch_rw_proxy(result, true))
                 } else {
                     // Sync Interpreter locals to env before spawning threads so closures capture them
                     if name == "start" {

--- a/t/infix-function-native-dispatch.t
+++ b/t/infix-function-native-dispatch.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Pin for the ledger §D slice that dispatches builtin operator-as-function calls
+# `infix:<op>(...)` (what &infix:<+>, [+], hyper and reduce lower to) straight to the
+# native call_infix_routine handler instead of recording a tree-walk function
+# fallback. User-defined operators are resolved before this point, so they still win.
+
+plan 22;
+
+# --- arithmetic infix routines -------------------------------------------------
+is infix:<+>(3, 4), 7, 'infix:<+>';
+is infix:<->(10, 3), 7, 'infix:<->';
+is infix:<*>(6, 7), 42, 'infix:<*>';
+is infix:<%>(17, 5), 2, 'infix:<%>';
+is infix:<**>(2, 10), 1024, 'infix:<**>';
+is infix:<min>(5, 2), 2, 'infix:<min>';
+is infix:<max>(5, 2), 5, 'infix:<max>';
+is infix:<gcd>(12, 18), 6, 'infix:<gcd>';
+is infix:<lcm>(4, 6), 12, 'infix:<lcm>';
+
+# --- comparison / relational ---------------------------------------------------
+is infix:<==>(3, 3), True, 'infix:<==>';
+is infix:<lt>(2, 5), True, 'infix:<lt>';
+is infix:<eq>("a", "a"), True, 'infix:<eq>';
+is infix:<ne>(1, 2), True, 'infix:<ne>';
+
+# --- string -------------------------------------------------------------------
+is infix:<~>("foo", "bar"), "foobar", 'infix:<~>';
+is infix:<x>("ab", 3), "ababab", 'infix:<x>';
+
+# --- through reduce / hyper (lower to the infix routine) -----------------------
+is ([+] 1, 2, 3, 4), 10, 'reduce [+]';
+is ([*] 1, 2, 3, 4, 5), 120, 'reduce [*]';
+is reduce(&infix:<+>, 10, 20, 30), 60, 'reduce(&infix:<+>, …)';
+is-deeply ((1, 2, 3) >>+>> 10), (11, 12, 13), 'hyper >>+>>';
+
+# --- minus-sign normalisation (U+2212) -----------------------------------------
+is infix:<−>(10, 4), 6, 'infix:<−> (unicode minus) normalises to -';
+
+# --- user-defined operator still takes precedence ------------------------------
+sub infix:<plus>($a, $b) { $a + $b + 100 }
+is infix:<plus>(1, 2), 103, 'user-defined infix:<plus> wins over native dispatch';
+multi infix:<%%%>(Int $a, Int $b) { "custom-$a-$b" }
+is infix:<%%%>(3, 4), "custom-3-4", 'user-defined multi operator wins';


### PR DESCRIPTION
## Summary

§D state-ownership slice continuing the atomic drain. Surveying function-fallback showed the `infix:<op>` family spanning **44 operators for ~5400 fallbacks** — the routine form that `&infix:<+>`, `[+]`/`[*]` reduce, `>>+>>` hyper and `reduce(&infix:<…>)` lower to.

The builtin operator impl is the native Rust `call_infix_routine` (`&mut self`; handles hyper / assignment-metaop / set-op / every binary op), but the only path reaching it was `call_function_fallback`'s infix arm — i.e. the recorded tree-walk fallback.

## Change

Catch `infix:<op>` in **both** fallback dispatch sites — `dispatch_func_call_inner` (direct Call) and `call_function_compiled_first` (hyper/reduce/string-regex paths) — **after** all user-operator resolution (compiled_fns / non-proto multi fork / `user_function_matches` / OTF) and immediately **before** the terminal fallback record, calling `call_infix_routine` directly. U+2212 minus normalises to `-`; `arg_sources` and `maybe_fetch_rw_proxy` match the terminal else exactly ⇒ byte-identical.

## User-override preserved

A user `sub`/`multi infix:<…>` resolves in an earlier branch and never reaches the native arm — the pin verifies `infix:<plus>` ⇒ 103 and `multi infix:<%%%>` ⇒ custom.

## Verification

- Direct infix calls drop 100%→0 fallbacks (user multi still falls back correctly).
- All `t/` (11765) pass, 79 whitelisted operator/metaops/junction files regression-free, 20 infix forms byte-identical to `raku`.
- `call_infix_routine` widened to `pub(crate)`. pin `t/infix-function-native-dispatch.t` (22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)