### PR TITLE
feat(vm): dispatch pure list/coercion builtin functions natively (§D(b))

### DIFF
--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -809,6 +809,13 @@
   14 IO 形 byte-identical to raku。pin `t/io-function-native-dispatch.t`(14)。**★教訓: user-definable な builtin 名（IO/operator）の native 化は `try_native_function`（早すぎ）でなく、両 dispatch 経路の
   「user 解決後・fallback record 前」に置く。`__mutsu_*` 内部マーカー（atomic）だけが `try_native_function` 先頭に置ける（user 定義不可ゆえ）。残 function-fallback＝concurrency（await/start・start は
   `sync_env_from_locals` 要で別軸・flaky）/ MOP（samewith）/ heterogeneous 内部マーカー（feed/assign-lvalue・context-sensitive）＝clean homogeneous drain は枯渇。**
+- **2026-06-25 (§D(b) = 純 list/coercion builtin *関数* 形〔`val`/`list`/`slip`/`hash`〕の VM ネイティブ dispatch)**: IO 関数形と同パターンの follow-up。`val`(pure free-fn)/`list`/`slip`/`hash`(`&self`)は
+  collection constructor で、`call_function` fallback 経由のままだった（survey: slip 3824〔S07-hyperrace stress〕/val 1555/list 720/hash 336・計 ~6400）。新 `try_native_collection_function(name,args)`
+  （`builtins_collection.rs`・`call_function` arm を 1:1 ミラー）を **IO/infix と同じ user-override 安全位置**（`dispatch_func_call_inner` の IO arm の後・infix arm の前／`call_function_compiled_first` の IO arm の後）で呼ぶ。
+  pure/`&self` で rw param 無し＝byte-identical。**実測 builtin val/list/slip/hash 呼び 0 fallback**・user `sub list` は正しく shadow（pin 検証）。全 t/(11834)・whitelist S02/S07-slip/S32-list 132 ファイル回帰ゼロ・
+  raku byte-identical。pin `t/collection-function-native-dispatch.t`(14)。**★pin で判明した別軸（mutsu 既存挙動・本変更と無関係）: `list((1,2),3)` を mutsu の `builtin_list` は flatten するが raku は `((1,2),3)`（非flatten）/
+  block-scoped `sub list` が mutsu では outer に leak（raku は block-scope）＝両方 pin から除外。★function-fallback の clean drain（state-owning: atomic/IO ＋ pure dispatch: infix/collection）は実質枯渇。残＝concurrency
+  （await/start/Supply/tap・Promise/scheduler state・flaky）/ MOP（samewith・反射）/ user-class 構築（new/bless・構造 substrate 要設計）。**
 
 ### 重要な現状認識（2026-06-08, PR-3 時点）
 **「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -264,6 +264,28 @@ impl Interpreter {
         }
     }
 
+    /// VM-native dispatch for the pure list/coercion builtin *functions*
+    /// (`val`/`list`/`slip`/`hash`) — collection constructors that reached the
+    /// interpreter only via the generic `call_function` name-match fallback. They are
+    /// pure / `&self` (no tree-walk, no mutable interpreter state beyond reading
+    /// `self`), so the VM dispatches them straight to the existing `builtin_*` impls.
+    /// Mirrors the `call_function` arms 1:1 — same args, same `self` => byte-identical.
+    /// Dispatched after all user-sub resolution (so a user `sub list` still wins).
+    pub(crate) fn try_native_collection_function(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let r = match name {
+            "val" => Ok(builtin_val(args)),
+            "list" => self.builtin_list(args),
+            "slip" | "Slip" => self.builtin_slip(args),
+            "hash" => self.builtin_hash(args),
+            _ => return None,
+        };
+        Some(r)
+    }
+
     pub(super) fn builtin_hash(&self, args: &[Value]) -> Result<Value, RuntimeError> {
         let mut flat_values = Vec::new();
         for arg in args {

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -93,6 +93,12 @@ impl Interpreter {
         if let Some(result) = self.try_native_io_function(name, &args) {
             return result;
         }
+        // Pure list/coercion builtin function (`val`/`list`/`slip`/`hash`): user subs
+        // resolved above, so dispatch the builtin natively instead of a tree-walk
+        // fallback (§D(b) dispatch chain). Byte-identical to call_function's arms.
+        if let Some(result) = self.try_native_collection_function(name, &args) {
+            return result;
+        }
         // CARRIER (EVAL/pseudo-package) vs TODO: compile to bytecode (else branch =
         // true tree-walk function fallback). See ledger §2/§C.
         if Self::is_interpreter_carrier_function(name) {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1169,6 +1169,13 @@ impl Interpreter {
                     // byte-identical.
                     let result = result?;
                     loan_env!(self, maybe_fetch_rw_proxy(result, true))
+                } else if let Some(result) = self.try_native_collection_function(name, &args) {
+                    // Pure list/coercion builtin function (`val`/`list`/`slip`/`hash`).
+                    // User subs resolved above, so this is the builtin — dispatch
+                    // natively instead of the tree-walk fallback (§D(b) dispatch
+                    // chain). Same builtin_* impls as call_function => byte-identical.
+                    let result = result?;
+                    loan_env!(self, maybe_fetch_rw_proxy(result, true))
                 } else if let Some(op) = name
                     .strip_prefix("infix:<")
                     .and_then(|s| s.strip_suffix('>'))

--- a/t/collection-function-native-dispatch.t
+++ b/t/collection-function-native-dispatch.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Pin for the ledger §D(b) slice that dispatches the pure list/coercion builtin
+# *functions* (val / list / slip / hash) straight to their native builtin_* impls
+# instead of recording a tree-walk function fallback. User subs resolve first, so a
+# (block-scoped) user `sub list` still wins.
+
+plan 14;
+
+# val() — allomorph coercion
+is val("42").^name, 'IntStr', 'val("42") is IntStr';
+is val("42"), 42, 'val("42") numifies to 42';
+is val("3.14").^name, 'RatStr', 'val("3.14") is RatStr';
+is val("abc").^name, 'Str', 'val("abc") stays Str';
+is val("0x1F").^name, 'IntStr', 'val("0x1F") is IntStr';
+
+# list()
+is-deeply list(1, 2, 3), (1, 2, 3), 'list(1,2,3)';
+is list(1, 2, 3).^name, 'List', 'list returns a List';
+is list().elems, 0, 'list() is empty';
+
+# hash()
+is hash(a => 1, b => 2)<a>, 1, 'hash from pairs';
+is hash("x", 10, "y", 20)<y>, 20, 'hash from flat k/v list';
+is hash().elems, 0, 'hash() is empty';
+
+# slip()
+is slip(2, 3).^name, 'Slip', 'slip returns a Slip';
+{
+    my @a = 1, slip(2, 3), 4;
+    is-deeply @a, [1, 2, 3, 4], 'slip flattens into surrounding list';
+}
+
+# user-defined sub wins over native dispatch
+{
+    sub list(|c) { "USER-list" }
+    is list(9, 9), "USER-list", 'user sub list shadows builtin';
+}


### PR DESCRIPTION
## Summary

Follow-up to the IO function-form drain, same pattern. The pure list/coercion builtin functions `val` (pure free-fn) / `list` / `slip` / `hash` (`&self`) are collection constructors that still reached the interpreter only via the generic `call_function` fallback (survey: slip 3824 from S07-hyperrace stress, val 1555, list 720, hash 336 — ~6400 total).

## Change

New `try_native_collection_function` (builtins_collection.rs, mirroring the `call_function` arms 1:1) dispatched at the **user-override-safe point** — like the IO/infix slices — in `dispatch_func_call_inner` (after the IO arm, before the infix arm) and `call_function_compiled_first` (after the IO arm). They are pure / `&self` with no rw params ⇒ byte-identical.

## Verification

- Builtin `val`/`list`/`slip`/`hash` calls drop to **0 fallbacks**; a user `sub list` still wins (pin-verified).
- All `t/` (11834) pass, 132 whitelisted S02/S07-slip/S32-list files regression-free, byte-identical to `raku`.
- pin `t/collection-function-native-dispatch.t` (14).

Two pre-existing mutsu/raku diffs unrelated to this change were found and excluded from the pin: mutsu's `builtin_list` flattens `list((1,2),3)` (raku keeps `((1,2),3)`), and a block-scoped `sub list` leaks to the outer scope in mutsu (raku block-scopes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)