### PR TITLE
fix(regex): enumerated bracket+named char classes & cross-package grammar token resolution

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -1510,6 +1510,14 @@ impl Interpreter {
         *self.current_package.write().unwrap() = pkg;
     }
 
+    /// Interior-mutable variant for the `&self` regex matcher: the package is
+    /// stored behind a RwLock, so a temporary switch (e.g. into a cross-package
+    /// grammar subrule's defining package while parsing its body) does not need
+    /// `&mut self`.
+    pub(crate) fn set_current_package_shared(&self, pkg: String) {
+        *self.current_package.write().unwrap() = pkg;
+    }
+
     fn stash_symbol_key_from_env_tail(rest: &str) -> String {
         if rest.starts_with('$')
             || rest.starts_with('@')

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -388,7 +388,20 @@ impl Interpreter {
                         if sym_key.is_some() {
                             has_proto = true;
                         }
-                        if let Some(parsed) = self.parse_regex(sub_pat) {
+                        // Parse the candidate's body in its OWN package so that
+                        // nested unqualified token references (notably char-class
+                        // `<+name>` items) resolve against the grammar that
+                        // defines them, not the outer caller's package.
+                        let saved_pkg = self.current_package();
+                        let switch_pkg = saved_pkg.as_str() != sub_pkg.as_str();
+                        if switch_pkg {
+                            self.set_current_package_shared(sub_pkg.clone());
+                        }
+                        let parsed_opt = self.parse_regex(sub_pat);
+                        if switch_pkg {
+                            self.set_current_package_shared(saved_pkg);
+                        }
+                        if let Some(parsed) = parsed_opt {
                             let all_matches =
                                 self.regex_match_ends_from_caps_in_pkg(&parsed, &tail, 0, sub_pkg);
                             // all_matches: HIGHEST FIRST.

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -301,11 +301,16 @@ impl Interpreter {
             let mut best_sym: Option<String> = None;
             let mut best_prefix_match: usize = 0;
             for (sub_pat, sub_pkg, sym_key) in filtered {
+                // Switch into the subrule's defining package *before* parsing its
+                // pattern: a nested char-class token reference (e.g. the RFC URI
+                // grammar's `<+unenc-pchar>`) must resolve in the grammar's
+                // package, not the caller's (`URI::Query` invoking
+                // `<IETF::RFC_Grammar::URI::query>`).
+                let saved_pkg = self.current_package();
+                self.set_current_package(sub_pkg);
                 let prefix_match_len = self
                     .declarative_prefix_match_len(&sub_pat, text)
                     .unwrap_or(0);
-                let saved_pkg = self.current_package();
-                self.set_current_package(sub_pkg);
                 let mut caps = self.regex_match_with_captures(&sub_pat, text);
                 self.set_current_package(saved_pkg);
                 if let Some(mut caps) = caps.take() {

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -3568,6 +3568,17 @@ impl Interpreter {
                                     } else {
                                         continue;
                                     }
+                                } else if trimmed.starts_with('[')
+                                    && Self::bracket_class_has_combination_tail(trimmed)
+                                {
+                                    // A bracket class combined with named classes:
+                                    // `[a..z] +digit`, `[\-._~] +alpha +digit`. The
+                                    // leading bracket is an implicit positive item.
+                                    if let Some(atom) = self.parse_combined_class(trimmed, mode) {
+                                        atom
+                                    } else {
+                                        continue;
+                                    }
                                 } else if trimmed == "?" {
                                     // <?>  null assertion: matches zero-width at any position
                                     RegexAtom::ZeroWidth
@@ -6023,9 +6034,15 @@ impl Interpreter {
         let mut positive_items: Vec<ClassItem> = Vec::new();
         let mut negative_items: Vec<ClassItem> = Vec::new();
         let mut remaining = input.trim();
+        // A leading bracket class with no sign (`[a..z] +digit`) is an implicit
+        // positive first item: the `+`/`-` only separates the subsequent parts.
+        let mut implicit_first = remaining.starts_with('[');
         while !remaining.is_empty() {
             let adding;
-            if remaining.starts_with('+') {
+            if implicit_first {
+                adding = true;
+                implicit_first = false;
+            } else if remaining.starts_with('+') {
                 adding = true;
                 remaining = remaining[1..].trim_start();
             } else if remaining.starts_with('-') {
@@ -6124,6 +6141,21 @@ impl Interpreter {
                 negative: negative_items,
             })
         }
+    }
+
+    /// Whether a bracket-class string (`[a..z] +digit`) is followed by a
+    /// `+`/`-` named-class combination after its closing `]`. Used to route
+    /// `<[...] +name>` enumerated classes to `parse_combined_class`.
+    fn bracket_class_has_combination_tail(s: &str) -> bool {
+        let Some(after_open) = s.strip_prefix('[') else {
+            return false;
+        };
+        let bracket_end = Self::find_bracket_end(after_open);
+        if bracket_end >= after_open.len() {
+            return false; // unterminated bracket
+        }
+        let tail = after_open[bracket_end + 1..].trim_start();
+        tail.starts_with('+') || tail.starts_with('-')
     }
 
     /// Find the end of a named class part in a combined class expression.

--- a/t/regex-bracket-charclass-combine.t
+++ b/t/regex-bracket-charclass-combine.t
@@ -1,0 +1,33 @@
+use Test;
+
+# An enumerated character class may combine a leading bracket class with named
+# builtin classes: `<[a..z] +digit>`. Previously a bracket class followed by a
+# `+name`/`-name` part matched nothing (it fell through both the pure-bracket
+# and the pure-combined parsing branches).
+
+plan 10;
+
+ok "3" ~~ / ^ <[a..z] +digit> $ /, 'bracket + digit matches a digit';
+ok "a" ~~ / ^ <[a..z] +digit> $ /, 'bracket + digit matches a letter';
+nok "!" ~~ / ^ <[a..z] +digit> $ /, 'bracket + digit rejects punctuation';
+
+ok "_" ~~ / ^ <[\-._~] +alpha> $ /, 'bracket with escapes + alpha matches underscore-set member';
+ok "x" ~~ / ^ <[\-._~] +alpha> $ /, 'bracket with escapes + alpha matches a letter';
+
+# Subtraction tail.
+ok  "b" ~~ / ^ <[a..z] -[aeiou]> $ /, 'bracket minus bracket keeps a consonant';
+nok "a" ~~ / ^ <[a..z] -[aeiou]> $ /, 'bracket minus bracket removes a vowel';
+
+# Nested: a grammar token used as a char class that is itself a combined class.
+grammar G {
+    token TOP        { <reg-name> }
+    token reg-name   { <+unreserved +sub-delims>* }
+    token unreserved { <[\-._~] +uri-alphanum> }
+    token sub-delims { <[;!$&'()*+,=]> }
+    token uri-alphanum { <+alpha +digit> }
+}
+my $m = G.parse("ab-c.com");
+ok $m.defined, 'nested combined char-class grammar matches';
+is ~$m, 'ab-c.com', 'nested combined char-class captured whole host';
+
+ok G.parse("a1-b_2").defined, 'nested combined class accepts digits and unreserved marks';

--- a/t/regex-crosspkg-charclass-token.t
+++ b/t/regex-crosspkg-charclass-token.t
@@ -1,0 +1,27 @@
+use Test;
+
+# When a regex in one package invokes a *qualified* grammar subrule from another
+# package (`<Other::Grammar::tok>`), nested *unqualified* token references
+# inside that subrule's body — especially char-class `<+name>` items — must
+# resolve against the grammar's own package, not the caller's. Previously the
+# subrule body was parsed in the caller's package, so the nested name failed to
+# resolve ("No such method 'name' for invocant of type 'Match'").
+
+plan 3;
+
+grammar Lib::G {
+    token frag       { <+unenc +sub>+ }
+    token unenc      { <[:@] +alpha +digit> }
+    token sub        { <[;!$&]> }
+}
+
+# A different package matching the qualified subrule.
+class App::User {
+    method check(Str $s) {
+        so $s ~~ / ^ <Lib::G::frag> $ /;
+    }
+}
+
+ok App::User.check('abc'),  'cross-package qualified subrule resolves nested char-class token (letters)';
+ok App::User.check('a1:b'), 'cross-package nested char-class accepts digits and bracket members';
+nok App::User.check('a b'), 'cross-package nested char-class rejects a space';


### PR DESCRIPTION
Two general regex/grammar fixes uncovered while making the off-the-shelf `URI` distribution parse RFC URIs.

## 1. Enumerated char class combining a bracket with named classes

`<[a..z] +digit>` — a leading bracket class followed by `+name`/`-name`/`+[...]` — matched **nothing**: it fell through both the pure-bracket branch (needs the assertion to *end* with `]`) and the combined-class branch (needs a leading `+`/`-`). The leading bracket is now treated as an implicit positive item, and `<[...] +name>` is routed to `parse_combined_class`.

## 2. Cross-package grammar subrule token resolution

When a regex in one package invokes a qualified subrule from another (`<Other::Grammar::tok>`), the subrule body was parsed with `current_package` still pointing at the *caller*, so nested **unqualified** char-class `<+name>` items failed to resolve (`No such method 'name' for invocant of type 'Match'`). The matcher now parses each candidate's body in its own defining package. Adds `set_current_package_shared(&self, …)` (interior-mutable, the package is already behind a `RwLock`).

Together these let the RFC URI grammar's `token unreserved { <[\-._~] +uri-alphanum> }` (used inside `<+unreserved +sub-delims>`) and the cross-package `URI::Query` → `<IETF::RFC_Grammar::URI::query>` chain resolve. (Full `URI.new` still exercises the IPv6 grammar's heavy backtracking — a separate engine-performance matter.)

## Tests

New `t/` files: `regex-bracket-charclass-combine.t` (10), `regex-crosspkg-charclass-token.t` (3). `make test` passes (Files=1179, Tests=11819).

🤖 Generated with [Claude Code](https://claude.com/claude-code)