### PR TITLE
fix(signature): renamed named param `:key($key)` is not a self-redeclaration

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -1795,8 +1795,14 @@ fn check_duplicate_params(params: &[ParamDef]) -> Result<(), PError> {
             }
         }
 
-        // Collect the variable name for this param
-        all_var_names.push(display_name);
+        // Collect the variable name for this param. For a *renamed* named param
+        // (`:key($key)`), the outer `p.name` ("key") is only the external
+        // argument key — the bound variable is the inner sub-signature param
+        // (`$key`), collected below. Counting both made `:key($key)` look like a
+        // self-redeclaration of `$key`.
+        if !(p.named && p.sub_signature.is_some()) {
+            all_var_names.push(display_name);
+        }
 
         // For named params with sub-signature (renamed params like :foo($x)),
         // also collect the inner variable names

--- a/t/named-param-rename-redeclaration.t
+++ b/t/named-param-rename-redeclaration.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A renamed named parameter `:key($key)` binds the *inner* variable `$key`;
+# the outer `key` is only the external argument name. mutsu used to count both
+# the outer name (as `$key`) and the inner variable, falsely reporting
+# X::Redeclaration of `$key`.
+
+plan 7;
+
+sub one(:key($key)) { $key }
+is one(key => 5), 5, ':key($key) single renamed named param binds the inner var';
+
+sub two(:key($key), :value($value)) { "$key=$value" }
+is two(key => 'a', value => 'b'), 'a=b', 'two renamed named params do not clash';
+
+# Inside pointy-block signatures across separate loops (the HTTP::Tiny pattern).
+my %form = a => 1, b => 2;
+my @out1;
+for %form.sort -> ( :$key, :$value ) { @out1.push: "$key:$value" }
+is @out1.sort.join(','), 'a:1,b:2', 'shorthand :$key destructuring works';
+
+my @out2;
+for %form.sort -> ( :key($key), :value($v) ) { @out2.push: "$key:$v" }
+is @out2.sort.join(','), 'a:1,b:2', 'renamed destructuring in a separate loop works';
+
+# Mixing shorthand and renamed forms across separate scopes is fine.
+sub three(:$key) { $key }
+is three(key => 9), 9, 'shorthand :$key in another sub does not clash with renamed form';
+
+# A genuine clash must still be reported.
+dies-ok { EVAL 'sub bad(:key($x), $x) { }' },
+    'real duplicate ($x renamed + $x positional) still errors';
+dies-ok { EVAL 'sub bad2(:key($x), :other($x)) { }' },
+    'two renamed params binding the same $x still error';


### PR DESCRIPTION
A renamed named parameter `:key($key)` binds the inner variable `$key`; the outer `key` is only the external argument name. The duplicate-parameter check counted **both** the outer param (reconstructed as `$key` from the external name) **and** the inner sub-signature variable `$key`, so a single `:key($key)` — or a `-> ( :key($k), … )` destructuring — falsely raised `X::Redeclaration: Redeclaration of symbol '$key'`.

For a named param carrying a sub-signature, the outer name is an external key, not a bound variable, so it is no longer added to the variable-collision set. Genuine clashes (`:key($x), $x` and `:key($x), :other($x)`) are still caught via the sub-signature variables.

Unblocks loading `HTTP::Tiny`, which uses `-> ( :$key, :$value )` and `-> ( :key($key), :value($v) )` in adjacent loops.

## Tests
New `t/named-param-rename-redeclaration.t` (7 cases, incl. two that must still die). `make test` passes (Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)