### PR TITLE
docs(vm): §D(b) tree-walk method-removal design + measurement counter

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -1,0 +1,140 @@
+# §D(b) — tree-walk method-dispatch removal plan
+
+**Status: design / measurement substrate (2026-06-26).**
+Goal of §D(b) (PLAN.md §2-D): structurally remove the tree-walking dispatch chain so
+the bytecode VM is the *only* execution engine for user code. This memo scopes that
+work from measurement, not speculation.
+
+## 1. What "tree-walk dispatch chain" actually means
+
+The Explore mapping of the method-dispatch chain (VM opcode → catch-all → interpreter
+slow path) established a key fact: **the only genuine AST tree-walking of *user code*
+is `run_instance_method` / `run_instance_method_resolved` in `src/runtime/class.rs`**
+(they end at `run_block(&method_def.body)`, class.rs:1300). Everything else in the
+chain — `dispatch_method_by_name_1/2/3`, `dispatch_new_and_constructors`,
+`dispatch_instance_and_fallback`, the `dispatch_*` family, every `call_native_*` — is
+**native Rust** that merely *routes* by name/arity. Those stay; only the user-body
+tree-walk is the removal target.
+
+So §D(b) reduces to: **make every user method body reach `dispatch_compiled_method`
+(compiled bytecode), so `run_instance_method[_resolved]` is never entered, then delete
+it** (and the now-unreachable `dispatch_instance_and_fallback` user-method arm).
+
+## 2. How `run_instance_method` is still reached today
+
+The catch-all (`vm_call_method_compiled.rs::try_compiled_method_or_interpret_inner`)
+already resolves + compiles user methods well: it tries the fast method cache, the
+monomorphic/`method_resolve_cache`, and `populate_uncompiled_method` (compile-on-demand
+for methods added after the registration compile pass). A synthetic
+`multi method` / plain `method` / proto test produces **zero** tree-walk events — they
+all dispatch as compiled bytecode.
+
+Tree-walk is still entered via:
+
+1. **`dispatch_instance_and_fallback` (methods_instance_ops.rs:867)** — `if
+   self.has_user_method(class, method) { run_instance_method(...) }`. Reached when the
+   catch-all's compiled dispatch did **not** fire (resolver returned `None`, or the
+   resolved def had no `compiled_code` and `populate_uncompiled_method` failed), and the
+   slow path's simpler name-based `has_user_method` still finds the method.
+2. **Internal `call_method_with_values(...)` redispatch** that bypasses the compiled
+   catch-all entirely. Examples in the slow path itself: the numeric bridge
+   (`.Numeric`/`.Bridge`/`.log`, methods_instance_ops.rs:853-864), instance render in
+   `say`/`print`/`gist`, `.COERCE`. Any internal `self.call_method_with_values(user_obj,
+   "...")` lands straight in the tree-walk slow path.
+3. **Private-method slow path** (methods_instance_ops.rs:106, direct
+   `run_instance_method_resolved`) when the compiled private fast path (vm_call_method_
+   compiled.rs:387) did not fire.
+4. **Construction submethods** `BUILD`/`TWEAK` run during `.new`.
+
+## 3. Measurement (MUTSU_VM_STATS `tree-walk method bodies` counter, full whitelist)
+
+A new counter `record_tree_walk_method` (vm_stats.rs) fires at `run_instance_method`
+entry. Across the full roast whitelist (1285 files), **only ~81 files** produce any
+tree-walk method body execution; **total ≈ 10983 events**, distributed:
+
+| method (name)                        | events | category |
+|--------------------------------------|--------|----------|
+| `m`                                  | 10005  | **`samewith` method redispatch — driver: `S12-methods/defer-next.t`** |
+| `Bridge` / `Numeric` / `Int` / `Num` / `Rat` / `COERCE` | ~405 | numeric-bridge + coerce redispatch (cat 2) |
+| `Str` / `gist`                       | ~59    | render redispatch / landmine (cat 2) |
+| `abs` / `succ` / `doit` / `foo` / `mul` / `test_method` / `prime` / `hi` / `cool` / … | ~250 | misc user methods (cat 1) |
+| `BUILD` / `TWEAK` / `new`            | ~60    | construction submethods (cat 4) |
+| `pull-one` / `skip-one` / `count-only` | ~34  | user-defined Iterator protocol (lever B/Phase2 adjacent) |
+| `find_method` / `accepts_type` / `CALL-ME` / `name` | ~21 | custom HOW / Metamodel (cat 1, MOP-ish) |
+| `FALLBACK`                           | ~10    | `method FALLBACK` (missing-method handler) |
+| `print`                              | ~65    | user `print` method redispatch |
+
+**Conclusion: `run_instance_method` is already nearly vestigial.** 91% of all tree-walk
+is a single method name `m`; excluding it, the residual is ~978 events across diverse,
+mostly-niche categories.
+
+### 3a. The `m` driver — `samewith` method redispatch (the deep 91%)
+
+`S12-methods/defer-next.t` accounts for ~10003 of the 10005 `m` events, from one
+construct amplified by a loop:
+
+```raku
+multi method m(Int $x) { samewith $x.Str }
+multi method m(Str)    { }
+multi method call()    { self.m(42) }
+C.call for ^10000      # 10000 iterations × (m(Int) + samewith → m(Str))
+```
+
+The test **passes** — this is correct-but-tree-walked, not a bug. The `samewith`
+redispatch (and `nextsame`/`callsame`/`nextwith`) of a `multi method` runs through the
+interpreter's **`method_dispatch_stack`** machinery (`dispatch.rs` ~1631-1670,
+`builtins_dispatch_next.rs`), which tree-walks each candidate body via
+`run_instance_method`. This is **exactly the blocker PLAN.md §2-D already flagged**
+("nextsame+rw チェーン … method 経路 … 単一スライス不可・§C の env↔locals/VM-frame cell
+共有を redispatch 境界へ広げる substrate 作業（要設計）", PLAN.md:193-209). So 91% of
+tree-walk *volume* is this one deep substrate; it is the **capstone**, not the first
+slice.
+
+## 4. Slice plan (tractable-first, not volume-first)
+
+The high-volume `m` case is the *deepest* (method redispatch substrate). Drain the
+tractable categories first; they share the same structural lever.
+
+- **Structural lever (the core fix):** make `call_method_with_values` (the slow-path
+  entry, `runtime/methods.rs:310`) try the **compiled** method path for a user method on
+  an Instance *before* descending to `dispatch_instance_and_fallback` →
+  `run_instance_method`. Today every *internal* redispatch (coercion `.Bridge`/
+  `.Numeric`, render `.gist`/`.Str`, `.COERCE`, and any `self.call_method_with_values(
+  user_obj, …)`) bypasses the compiled catch-all and tree-walks. Routing user-method
+  calls here through `resolve_method_with_owner_invocant` + `dispatch_compiled_method`
+  (the same machinery `try_compiled_method_or_interpret` uses) drains cat 1/2/4 at once.
+  Risk: `call_method_with_values` has many callers with slow-path expectations — gate to
+  the safe case (Instance receiver, resolves to a compilable single/non-redispatch user
+  method) and keep `run_instance_method` as the fallback for everything else.
+
+- **Slice 1 — coerce/render redispatch (Bridge/Numeric/Int/Num/Rat/COERCE/Str/gist,
+  ~460, the largest *tractable* bucket).** Apply the structural lever, scoped to the
+  numeric-bridge + render/coerce redispatch sites. Validates the lever on the
+  next-biggest category with bounded blast radius.
+- **Slice 2 — generalize the lever** to all user-method calls in
+  `call_method_with_values` (cat 1 misc user methods abs/succ/foo/…, and the
+  catch-all-miss path feeding `dispatch_instance_and_fallback:867`).
+- **Slice 3 — construction submethods (BUILD/TWEAK/new, ~60).** Run `.new`'s BUILD/TWEAK
+  as compiled bytecode.
+- **Slice 4 (capstone) — `samewith`/`nextsame`/`callsame` method redispatch (the `m`
+  91%).** Compile the `method_dispatch_stack` candidate dispatch. Coordinate with the
+  PLAN nextsame+rw substrate (rw-param slot coherence across the redispatch boundary).
+  This is the deep one; do it last, after the volume from Slices 1-3 confirms the
+  approach and after the function-side multi-redispatch lessons.
+- **Out of scope (stay / separate axis):** user `Iterator` `pull-one`/`skip-one`/
+  `count-only` (lever B / Phase 2), custom-HOW Metamodel methods (`find_method`/
+  `accepts_type`/`name` — MOP reflection), `method FALLBACK` (missing-method semantics).
+  These gate the *final deletion* of `run_instance_method`, but draining Slices 1-4
+  removes >99% of tree-walk volume and all the high-traffic categories.
+
+## 5. Risks / open questions
+
+- Whether `populate_uncompiled_method` fails for some body constructs (closures over
+  caller env, `nextsame`/`callsame` in a method, `where`-constrained candidates) — if
+  so those need the compiled binding path extended (mirrors the function-side multi OTF
+  work, ledger §D multi-dispatch).
+- The internal-redispatch sites (cat 2) must preserve the caller `self`/env exactly
+  (the catch-all's `try_compiled_method_or_interpret` save/restore of `self`).
+- byte-identical is the bar: each slice keeps `run_instance_method` as the fallback for
+  whatever it does not yet route, so a missed case degrades to today's behavior, not a
+  regression.

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -738,6 +738,7 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        crate::vm::vm_stats::record_tree_walk_method(method_name);
         let inv_value = if let Some(inv) = &invocant {
             inv.clone()
         } else if attributes.is_empty() {

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -50,6 +50,16 @@ fn function_carrier_by_name() -> &'static Mutex<HashMap<String, u64>> {
     static BY_NAME: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
     BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
 }
+
+/// Per-name histogram of method calls that reached *genuine AST tree-walking* of a
+/// user-defined method body (`run_instance_method` / `run_instance_method_resolved`),
+/// as opposed to native handlers reached via the catch-all (which `record_method_fallback`
+/// over-counts). This is the authoritative measure for the §D(b) tree-walk removal:
+/// only these calls keep `run_instance_method` alive.
+fn tree_walk_method_by_name() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_NAME: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
+}
 // Dual-store (locals <-> env) sync cost. See docs/vm-dual-store.md.
 static CLONE_ENV: AtomicU64 = AtomicU64::new(0);
 static ENV_DEEP_COPY: AtomicU64 = AtomicU64::new(0);
@@ -69,6 +79,17 @@ pub(crate) fn enabled() -> bool {
 pub(crate) fn record_method_dispatch() {
     if enabled() {
         METHOD_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record that a method call reached genuine AST tree-walking of a user method body
+/// (`run_instance_method[_resolved]`). The authoritative §D(b) removal target.
+#[inline]
+pub(crate) fn record_tree_walk_method(name: &str) {
+    if enabled()
+        && let Ok(mut map) = tree_walk_method_by_name().lock()
+    {
+        *map.entry(name.to_string()).or_insert(0) += 1;
     }
 }
 
@@ -220,6 +241,24 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] method-fallback by name (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    if let Ok(map) = tree_walk_method_by_name().lock()
+        && !map.is_empty()
+    {
+        let total: u64 = map.values().sum();
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] tree-walk method bodies total={} by name (top {}): {}",
+            total,
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary

Start of the §D(b) "tree-walk dispatch chain removal" substrate (PLAN §2-D), driven by **measurement, not speculation** — per the user's direction to scope the work with a design memo first.

## What this adds

1. **A measurement counter** `record_tree_walk_method` (vm_stats.rs) at `run_instance_method` entry (class.rs) — the authoritative count of genuine AST tree-walking of *user method bodies*. (`record_method_fallback` over-counts: it also fires for native handlers reached via the catch-all.) Off by default; a single cached-bool load on the hot path.
2. **The design memo** `docs/treewalk-method-removal-plan.md`.

## Key finding (full-whitelist survey)

- Only **~81 of 1285** files tree-walk any user method body; total **≈ 10983 events** — `run_instance_method` is already nearly vestigial.
- **91% (`m`=10005) is ONE construct**: `samewith` multi-method redispatch in `S12-methods/defer-next.t` (`multi method m(Int){ samewith $x.Str } … C.call for ^10000`). The test **passes** — correct-but-tree-walked. This is exactly the deep blocker PLAN §2-D already flagged (method `method_dispatch_stack` redispatch / nextsame+rw) → the **capstone**, not the first slice.
- The **tractable residual (~978)**: coerce/render redispatch (Bridge/Numeric/Int/COERCE/Str/gist ~460), construction submethods (BUILD/TWEAK ~60), misc user methods, plus out-of-scope Iterator / custom-HOW / FALLBACK.

## Proposed plan

The memo proposes the **core structural lever** — route user-method calls in `call_method_with_values` through the compiled method path before the tree-walk slow path — and a **tractable-first** slice plan (coerce/render → generalize → construction → samewith capstone).

No behavior change (counter is off by default). All `t/` (11847) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)