### PR TITLE
fix(parser): `not`/`so` after `&&` binds with loose-unary precedence

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -1134,7 +1134,12 @@ fn and_and_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
         };
         let r = &r[len..];
         let (r, _) = ws(r)?;
-        let (r, right) = if mode == ExprMode::Full {
+        // `A && not B` / `A && so B`: loose unary `not`/`so` on the RHS of a
+        // tight operator binds LOOSELY (`A && (not (B ...))`), so delegate to the
+        // loose-unary parser instead of the tighter comparison operand.
+        let (r, right) = if is_loose_not_or_so_prefix(r) {
+            not_expr_mode(r, mode)?
+        } else if mode == ExprMode::Full {
             comparison_expr_mode(r, mode).map_err(|err| {
                 enrich_expected_error(err, "expected expression after '&&'", r.len())
             })?

--- a/t/and-not-loose-precedence.t
+++ b/t/and-not-loose-precedence.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `not`/`so` are loose-precedence unary operators. On the right of a tight `&&`
+# they bind loosely: `A && not B` is `A && (not B)`, and `A && not B && C` is
+# `A && not (B && C)`. mutsu used to treat `not` after `&&` as a bareword,
+# producing a parse error (`if A && not B { ... }`). `||` already handled this.
+
+plan 7;
+
+is (True  && not False), True,  'True && not False is True';
+is (True  && not True),  False, 'True && not True is False';
+is (False && not True),  False, 'False && not True short-circuits to False';
+
+# Loose binding: not grabs the rest of the && chain.
+is (True && not False && False), True, 'A && not B && C parses as A && not (B && C)';
+
+# Works as an `if` condition followed by a block (the HTTP::Tiny pattern).
+my $a = True;
+my $b = False;
+my $hit = 0;
+if $a && not $b { $hit = 1 }
+is $hit, 1, 'if A && not B { } parses and runs';
+
+# `so` (the positive loose unary) on the RHS of &&.
+is (True && so 5), True, 'True && so 5 is True';
+
+# A method call with colon args after `&& not` (mirrors HTTP::Tiny exactly).
+class H { method can-reuse($a, $b, $c) { False } }
+my $h = H.new;
+my $ok = 0;
+if $h && not $h.can-reuse: 1, 2, 3 { $ok = 1 }
+is $ok, 1, '&& not $obj.meth: a, b, c { } parses';


### PR DESCRIPTION
`not` and `so` are loose-precedence prefix operators. On the right of a tight `&&`, mutsu treated `not` as a bareword, so `A && not B` mis-parsed (`$a && not` then a stray `$b`) and `if A && not B { ... }` failed with `expected '{' or expression statement`.

`||` already delegated a loose `not`/`so` RHS to the loose-unary parser (`or_or_expr_mode`); this applies the same to `and_and_expr_mode`. Now `A && not B` parses as `A && (not B)` and `A && not B && C` as `A && not (B && C)`, matching Rakudo.

Unblocks `HTTP::Tiny` (`if $handle && not $handle.can-reuse: $scheme, $host, $port { ... }`).

## Tests
New `t/and-not-loose-precedence.t` (7 cases incl. the loose-binding chain and the HTTP::Tiny colon-call shape). `make test` passes (Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)