### PR TITLE
fix(class): private `method !foo` does not collide with public `method foo`

### DIFF
--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1908,20 +1908,32 @@ impl Interpreter {
                         } else {
                             // Check for duplicate non-multi method definition.
                             // Only error if the existing method was defined in
-                            // this class (not composed from a role).
+                            // this class (not composed from a role) AND shares the
+                            // same privacy: a private `method !foo` and a public
+                            // `method foo` live in separate namespaces and do not
+                            // collide (they are stored together but dispatch filters
+                            // on `is_private`).
+                            let new_is_private = def.is_private;
                             if let Some(existing) = class_def.methods.get(&resolved_method_name) {
-                                let all_from_role =
-                                    existing.iter().all(|m| m.role_origin.is_some());
-                                if !all_from_role {
+                                let conflicts = existing.iter().any(|m| {
+                                    m.role_origin.is_none() && m.is_private == new_is_private
+                                });
+                                if conflicts {
                                     return Err(RuntimeError::new(format!(
                                         "Package '{}' already has a method '{}' (did you mean to declare a multi method?)",
                                         name, resolved_method_name
                                     )));
                                 }
                             }
-                            class_def
+                            // A non-multi method replaces prior same-privacy
+                            // candidates but must preserve methods of the OTHER
+                            // privacy stored under the same name.
+                            let entry = class_def
                                 .methods
-                                .insert(resolved_method_name.clone(), vec![def]);
+                                .entry(resolved_method_name.clone())
+                                .or_default();
+                            entry.retain(|m| m.is_private != new_is_private);
+                            entry.push(def);
                         }
                     }
                     // A method declared `is export` is recorded as an export of

--- a/t/private-public-method-namespace.t
+++ b/t/private-public-method-namespace.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A private method `method !foo` and a public method `method foo` live in
+# separate namespaces and must not collide. mutsu stored both under the bare
+# name `foo` and the duplicate-method check ignored privacy, so declaring a
+# private `!request` alongside a public (multi) `request` raised
+# "Package '...' already has a method 'request'".
+
+plan 5;
+
+class A {
+    method request(Str $m) { 'pub:' ~ self!request($m) }
+    method !request(Str $m) { "priv:$m" }
+}
+is A.new.request('GET'), 'pub:priv:GET',
+    'public and private method of the same name coexist and both dispatch';
+
+# Public multi + private of the same name (the HTTP::Tiny shape).
+class B {
+    proto method request(|c) { {*} }
+    multi method request(Int $x) { 'int:' ~ self!request($x) }
+    multi method request(Str $x) { 'str:' ~ self!request($x) }
+    method !request($x) { "p($x)" }
+}
+is B.new.request(5),   'int:p(5)', 'private + public multi (Int candidate) works';
+is B.new.request('z'), 'str:p(z)', 'private + public multi (Str candidate) works';
+
+# A genuine duplicate public non-multi must still error.
+dies-ok { EVAL 'class C { method m {1}; method m {2} }' },
+    'two public non-multi methods of the same name still error';
+
+# Two private non-multi methods of the same name must still error.
+dies-ok { EVAL 'class D { method !m {1}; method !m {2} }' },
+    'two private non-multi methods of the same name still error';


### PR DESCRIPTION
A private method and a public method of the same name live in **separate namespaces**. mutsu stored both under the bare name in `class_def.methods` (with an `is_private` flag that dispatch already filters on), but the duplicate-method registration check ignored privacy — so a class declaring a private `method !request` alongside a public `multi method request` died with `Package '...' already has a method 'request'`.

The non-multi duplicate check now only conflicts with an existing same-name, **same-privacy**, non-role method; and a non-multi method is appended to the name's candidate list (replacing only same-privacy candidates) instead of overwriting it, so public and private methods of the same name coexist and both dispatch.

Unblocks loading `HTTP::Tiny`, which pairs a public `multi method request` with a private `method !request`. With this plus the redeclaration (#3605) and `&& not` (#3607) fixes, `HTTP::Tiny.new` loads and constructs.

## Tests
New `t/private-public-method-namespace.t` (5 cases, incl. two genuine duplicates that must still error). `make test` passes (Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)