### PR TITLE
docs(plan): reflect §D(b) tree-walk-removal measurement + writeback-coherence blocker

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -147,11 +147,19 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
   - **∴ pure-value / VM-owned-state な built-in ctor は全て native 化済＝③ ctor フォーク完了**。残 `new` fallback receiver は `CallFrame.new`
     〔call-stack carrier〕・error-only（HyperWhatever/Whatever/Instant）のみ＝別軸 or 構造ブロック。次は §D の本丸＝(b) tree-walk dispatch-chain
     削除 substrate or multi-dispatch VM 化（下記の唯一の `[ ]`）。
-  - **(b) tree-walk dispatch chain 削除の substrate**: IO/coercion が native 化した今、`dispatch_method_by_name_*` チェーンと
-    catch-all バウンス（`vm_call_method_compiled.rs` 末尾）の構造的削除。残る到達カテゴリ＝MOP carrier（WHAT/name/can/HOW・反射で
-    撲滅対象外）/ landmine（Instance.Str/.Stringy/.raku/.gist・列挙不能で見送り済）/ block-exec slow path（map/grep・lever B/Phase 2）/
-    concurrency（Supply/tap・別軸）/ typed-array mutator（typed/shaped/shared・Phase 2/lever B）。**純粋に削れる残りは少なく、各々別軸の
-    前提が要る**＝substrate 着手は要設計。
+  - **(b) tree-walk dispatch chain 削除の substrate** — **着手済み・計測で精密化（2026-06-26、設計＝[docs/treewalk-method-removal-plan.md](docs/treewalk-method-removal-plan.md)）**:
+    `dispatch_method_by_name_*` 等は全て native Rust（残す）。**唯一の真のユーザーコード tree-walk は `run_instance_method[_resolved]`**
+    （class.rs・`run_block(method_def.body)`）。新計測カウンタ（`MUTSU_VM_STATS` の `tree-walk method bodies`・#3606）で全1285 whitelist を測ると
+    **tree-walk するのは 81 ファイルのみ・総 10983 イベント＝`run_instance_method` はほぼ vestigial**。**91%（`m`=10005）は1構文**＝
+    `S12-methods/defer-next.t` の `samewith` multi-method redispatch（`for ^10000` で増幅）＝PLAN 既出の深い blocker（method `method_dispatch_stack`
+    redispatch・nextsame+rw）＝capstone。残 ~978 が tractable（coerce/render redispatch ~460・construction BUILD/TWEAK ~60・各種）。
+    **★Slice 1（compiled dispatch へ routing）試行→revert で判明（#3609）: `dispatch_compiled_method` は属性 commit/Proxy は同等だが、
+    internal-redispatch context で呼ぶと method body の captured-outer/closure-env writeback を caller lexical に伝播しない**
+    （`method Numeric{$calls++}` の `$calls++` が消える・junction-invocant eigenstate writeback・grammar reduce-time dynvar も同様）。
+    **★narrow: explicit `$obj.method` は catch-all 経由で writeback 保持・redispatch context のみ喪失** → 修正は「redispatch 呼び出し点で
+    compiled method の closure env を正しいスコープに root する」（`call_compiled_closure` の `scoped_child` 機構）。**∴ 真の §D(b) substrate ＝
+    captured-outer/closure-env writeback coherence（`docs/captured-outer-cell-sharing.md` 機構）を compiled-method redispatch 境界へ拡張する**
+    （関数側 nextsame+rw と同根）＝要設計の deep 多スライス work。MOP carrier / landmine(.Str/.gist) / block-exec(map/grep) / concurrency / typed-array は別軸（撲滅対象外 or 別前提）。
 - [ ] **multi-dispatch の VM 化**（着手済・proto sub の trivial-body 経路は #3541 で landed）:
   - [x] **proto sub dispatch（trivial body）= 完了（#3541）**。`proto foo {*}` / bodyless proto を VM call site で直接ディスパッチ
     （`vm_resolve_trivial_proto_candidate` が VM 所有レジストリで winner 候補を解決→`compile_and_call_function_def` で compiled 実行）。


### PR DESCRIPTION
Updates PLAN §2-D (b) with this session's §D(b) findings (full memo: `docs/treewalk-method-removal-plan.md`):

- **`run_instance_method` is nearly vestigial** — only 81/1285 whitelist files tree-walk any user method body (new `MUTSU_VM_STATS` counter, #3606); total ~10983 events.
- **91% (`m`=10005) is one construct**: the `samewith` multi-method redispatch in `S12-methods/defer-next.t` (× `for ^10000`) = the deep nextsame+rw capstone PLAN already flagged.
- **The structural lever is blocked on writeback coherence** (#3609): routing a resolved user method through `dispatch_compiled_method` instead of `run_instance_method` loses captured-outer/closure-env writeback in the internal-redispatch context (`method Numeric { $calls++ }` loses the write; junction-invocant + grammar-dynvar also break). Explicit calls preserve it → the fix is rooting the compiled method's closure env at the redispatch boundary (the `call_compiled_closure` `scoped_child` mechanism). The real substrate = extend captured-outer-cell-sharing to the compiled-method redispatch boundary (same root as the function-side nextsame+rw blocker).

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)