### PR TITLE
fix(class): `:D` smiley on an array/hash attribute does not require an initializer

### DIFF
--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -734,9 +734,17 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         type_smiley
     };
 
-    // Enforce type smiley constraints at parse time
+    // Enforce type smiley constraints at parse time. A `:D` smiley on an array
+    // (`@`) or hash (`%`) attribute constrains the ELEMENTS, not the container —
+    // the container itself defaults to an empty (defined) Array/Hash, so it needs
+    // no initializer. Only scalar-like attributes (`$`, `&`) must be initialized.
     let effective_smiley = type_smiley.as_deref().unwrap_or("_");
-    if effective_smiley == "D" && !has_explicit_default && is_required.is_none() {
+    if effective_smiley == "D"
+        && sigil != b'@'
+        && sigil != b'%'
+        && !has_explicit_default
+        && is_required.is_none()
+    {
         // :D attribute without a default or `is required` → X::Syntax::Variable::MissingInitializer
         let twigil = if is_public { "." } else { "!" };
         let tc_display = if let Some(ref tc) = type_constraint {

--- a/t/typed-defined-collection-attr.t
+++ b/t/typed-defined-collection-attr.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A `:D` type smiley on an array (`@`) or hash (`%`) attribute constrains the
+# ELEMENTS, not the container. The container defaults to an empty (defined)
+# Array/Hash and needs no initializer. mutsu used to demand an initializer
+# ("Variable '@!rules' of type 'Callable:D' must be initialized"), which broke
+# e.g. Path::Finder's `has Callable:D @!rules`.
+
+plan 5;
+
+class A {
+    has Callable:D @!rules;
+    method n { @!rules.elems }
+}
+is A.new.n, 0, ':D array attribute defaults to an empty array (no initializer needed)';
+
+class B {
+    has Int:D %!seen;
+    method n { %!seen.elems }
+}
+is B.new.n, 0, ':D hash attribute defaults to an empty hash';
+
+class C {
+    has Str:D @.tags;
+    method add($x) { @!tags.push: $x }
+    method all { @.tags.join(',') }
+}
+my $c = C.new;
+$c.add('x');
+$c.add('y');
+is $c.all, 'x,y', 'public :D array attribute is usable and pushable';
+
+# Elements still honour the :D constraint when assigned.
+class D {
+    has Int:D @.nums;
+}
+lives-ok { D.new(nums => [1, 2, 3]) }, ':D array accepts defined elements';
+
+# A scalar :D attribute with no default/`is required` must STILL error.
+dies-ok { EVAL 'class S1 { has Int:D $!x }; S1.new' },
+    'scalar :D attribute without initializer still errors';


### PR DESCRIPTION
A `:D` type smiley on an array (`@`) or hash (`%`) attribute constrains the **elements**, not the container. The container defaults to an empty (defined) Array/Hash and needs no initializer. mutsu's parse-time `X::Syntax::Variable::MissingInitializer` check fired for every `:D` attribute regardless of sigil, so `has Callable:D @!rules` (Path::Finder) was rejected with `Variable '@!rules' of type 'Callable:D' must be initialized`.

The check is now restricted to non-collection sigils (`$`, `&`); `@`/`%` attributes are exempt, matching Rakudo. Scalar `:D` attributes still require a default / `is required`.

Unblocks the first parse error in `Path::Finder`.

## Tests
New `t/typed-defined-collection-attr.t` (5 cases, incl. the scalar case that must still error). `make test` passes (Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)