### PR TITLE
fix(parser): enum trait argument + `trait_mod:<of>(...)` call syntax

### DIFF
--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1653,7 +1653,7 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
 
     // Handle special expression keywords before qualified name resolution
     match name.as_str() {
-        "infix" | "prefix" | "postfix" | "circumfix" | "postcircumfix" => {
+        "infix" | "prefix" | "postfix" | "circumfix" | "postcircumfix" | "trait_mod" => {
             // `infix:(...)` adverbs the operator declarator with a signature
             // literal, which is illegal -> X::Syntax::Adverb ("You can't adverb
             // :(...)"). Operator names use `:<...>`/`:sym<...>`, never `:(...)`.

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -253,6 +253,11 @@ pub(super) fn parse_enum_decl_body_with_type(
         if trait_name == "export" {
             is_export = true;
         }
+        // Consume an optional parenthesized trait argument, e.g.
+        // `is export(:traits)` — without this, the variant parser mistakes the
+        // `(:traits)` for the enum's `(...)` body and the real `<values>` list
+        // after it is left dangling.
+        let r = super::super::super::helpers::skip_balanced_parens(r);
         let (r, _) = ws(r)?;
         rest = r;
     }

--- a/t/enum-trait-arg-and-trait-mod-call.t
+++ b/t/enum-trait-arg-and-trait-mod-call.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Two parser fixes:
+#  1. A trait with a parenthesized argument between an enum name and its value
+#     list (`enum E is export(:traits) <a b c>`) must be consumed, otherwise the
+#     `(:traits)` is mistaken for the enum's `(...)` body and the `<values>` are
+#     dropped.
+#  2. A call to a sub whose name carries a `:<...>` adverbial part in a category
+#     other than infix/prefix/postfix — notably `trait_mod:<of>(...)` — parses
+#     as a function call.
+
+plan 6;
+
+our enum Precedence is export(:traits) <Skip Depth Name Stat>;
+is Skip.value,  0, 'enum with is export(:traits) keeps its first value';
+is Stat.value,  3, 'enum with is export(:traits) keeps later values';
+is Depth.Int,   1, 'enum value coerces to its ordinal';
+
+enum Plain is rw <Red Green Blue>;
+is Green.value, 1, 'enum with a no-arg trait still works';
+
+# trait_mod:<...> call syntax (definition already worked; the *call* did not).
+sub trait_mod:<of>($routine, $type) { "of:$type" }
+is trait_mod:<of>('r', 'MyType'), 'of:MyType', 'trait_mod:<of>(...) parses and dispatches as a call';
+
+# The operator-name call forms keep working.
+is infix:<+>(2, 3), 5, 'infix:<+>(...) still works';


### PR DESCRIPTION
Two parser fixes uncovered loading `Path::Finder`:

1. **enum trait argument** — `our enum Precedence is export(:traits) <Skip Depth Name>` dropped its values. The `is export` trait loop consumed `export` but left `(:traits)`, which the variant parser then mistook for the enum's `(...)` body, leaving the real `<values>` dangling as a stray quote-word list. The trait loop now skips a balanced parenthesized trait argument.

2. **`trait_mod:<of>(...)` call** — a call to a sub whose name carries a `:<...>` adverbial part was only recognized for the operator categories (infix/prefix/postfix/...). Adding `trait_mod` lets `trait_mod:<of>(...)` parse as a function call. (Defining `sub trait_mod:<is>` already worked; *calling* `trait_mod:<of>` did not.)

Together these advance `Path::Finder` past its first two parse blockers (after #3612's `:D`-collection-attr fix).

## Tests
New `t/enum-trait-arg-and-trait-mod-call.t` (6 cases). `make test` passes (Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)