### PR TITLE
fix(parser): a symbolic prefix may stack on another prefix (`+!$x`)

### DIFF
--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -410,6 +410,10 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
             || crate::builtins::unicode::unicode_rat_value(c).is_some()
             || crate::builtins::unicode::unicode_numeric_int_value(c).is_some()
     };
+    // A symbolic prefix (`+`, `-`, `~`) may be followed by ANOTHER prefix
+    // operator: `+!$x` is `+(!$x)`, `-?$x` is `-(?$x)`. Without this the leading
+    // `+`/`-`/`~` falls through to numeric-literal parsing and fails on the `!`.
+    let starts_another_prefix = |s: &str| parse_prefix_unary_op(s.trim_start()).is_some();
     if input.starts_with('!')
         && !input.starts_with("!!")
         && !input.starts_with("!~~")
@@ -430,6 +434,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         && !input.starts_with("->")
         && (starts_hyper_prefix_marker(&input[1..])
             || starts_user_prefix_op(&input[1..])
+            || starts_another_prefix(&input[1..])
             || (matches!(next_non_ws(&input[1..]), Some(c) if unary_term_start(c) || c == '.' || c == '\u{221E}')))
     // topic call / ∞
     {
@@ -443,6 +448,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
         && !input.starts_with("++")
         && (starts_hyper_prefix_marker(&input[1..])
             || starts_user_prefix_op(&input[1..])
+            || starts_another_prefix(&input[1..])
             || matches!(next_non_ws(&input[1..]), Some(c) if unary_term_start(c) || c == '.' || c == '\u{221E}'))
     {
         Some((PrefixUnaryOp::Positive, 1))
@@ -451,6 +457,7 @@ pub(super) fn parse_prefix_unary_op(input: &str) -> Option<(PrefixUnaryOp, usize
     } else if input.starts_with('~')
         && !input.starts_with("~~")
         && (starts_hyper_prefix_marker(&input[1..])
+            || starts_another_prefix(&input[1..])
             || matches!(next_non_ws(&input[1..]), Some(c) if unary_term_start(c) || c == '.'))
     {
         Some((PrefixUnaryOp::Stringify, 1))

--- a/t/stacked-prefix-operators.t
+++ b/t/stacked-prefix-operators.t
@@ -1,0 +1,24 @@
+use Test;
+
+# A symbolic prefix operator (`+`, `-`, `~`) may be applied to the result of
+# ANOTHER prefix operator: `+!$x` is `+(!$x)`. mutsu used to fall through to
+# numeric-literal parsing after the leading `+`/`-`/`~` and fail on the `!`.
+# (Path::Finder: `return Prune(+!$value)`.)
+
+plan 8;
+
+my $zero = 0;
+my $five = 5;
+
+is (+!$zero),     1,     '+!0 numifies the negation (True -> 1)';
+is (+!$five),     0,     '+!5 numifies the negation (False -> 0)';
+is (+!$zero + 1), 2,     '+!$x participates in further arithmetic';
+is (-!$five),     0,     '-!5 negates the numified negation';
+is (-!$zero),     -1,    '-!0 is -1';
+is (~!$zero),     'True', '~!0 stringifies the negation';
+is (?!$five),     False, '?!5 booleanizes the negation (?(!5) = ?False = False)';
+
+# Coercion call wrapping a stacked prefix (the exact Path::Finder shape).
+enum Prune <PruneInclusive PruneExclusive>;
+sub negate(Prune $v) { return Prune(+!$v) }
+is negate(PruneInclusive), PruneExclusive, 'Prune(+!$v) coerces the stacked-prefix result';


### PR DESCRIPTION
`+`, `-`, and `~` as prefix operators only accepted a *term* as their operand, so `+!$x` (which is `+(!$x)`) fell through to numeric-literal parsing and failed on the `!`. They now also accept a following prefix operator, so `+!$x`, `-!$x`, `~!$x` (and deeper stacks) parse as in Rakudo.

Unblocks Path::Finder's `return Prune(+!$value)`.

## Tests
New `t/stacked-prefix-operators.t` (8 cases, cross-checked against Rakudo). `make test` passes (Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)