### PR TITLE
fix(vm): drain captured-outer writeback at internal coercion redispatch (§D(b) Slice 1a)

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -139,13 +139,29 @@ does. Until that lands, `run_instance_method` stays. This mirrors the function-s
 `nextsame+rw` blocker (PLAN §2-D): same root cause (writeback across a redispatch
 frame boundary), now confirmed for the method-coercion redispatch path too.
 
-- **Slice 1 (revised) — env/writeback-coherence at the compiled-redispatch boundary.**
-  Make `dispatch_compiled_method` (or its `call_compiled_method` core), when invoked as
-  an internal redispatch, root the callee frame at the live caller env (`scoped_child` +
-  parent-chain-aware merge, as `call_compiled_closure` already does for lexical `&name`
-  callables) and record captured-outer writebacks. Validate against the three reverted
-  tests (junction-invocant / grammar-dynvar / `$calls++` coercion) BEFORE re-enabling the
-  routing. THEN the coerce/render routing (original Slice 1) becomes safe.
+- **Slice 1a (revised) — DONE (#TBD): coercion-redispatch writeback coherence.**
+  The reverted Slice 1's premise (that `dispatch_compiled_method` fails to *link* the
+  callee frame to the caller env) was **wrong about the mechanism**. The captured-outer
+  write *does* reach the caller env: `call_compiled_method`'s `merge_method_env`
+  propagates it and records the changed caller-visible names into
+  `pending_rw_writeback_sources` (vm_method_dispatch.rs:682). The break is purely that an
+  **internal coercion redispatch has no surrounding CallMethod op to drain that list**
+  into the caller's local *slot*, so the slot stays stale (env is correct, slot is not —
+  the dual-store gap). Fix = drain at each op-level coercion redispatch site using the
+  existing `current_code` + `reconcile_caller_after_lazy_force` machinery (the same
+  pattern `say`/`note` already use for a `.gist` closure). Sites covered:
+  `exec_num_coerce_op` (`+$obj`), `exec_str_coerce_op` (`~$obj`, `.Stringy`/`.Str`),
+  `coerce_numeric_bridge_value` (infix arith + numeric comparison coercion), and
+  `eval_truthy` (`if $obj`/`?$obj` Bool). The three reverted tests (junction-invocant /
+  grammar-dynvar / `$calls++` coercion) all pass — no closure-env rooting was needed.
+  pin=`t/coercion-method-captured-writeback.t`(10).
+- **Slice 1b (next) — generalize the drain to the remaining `call_method_with_values`
+  internal redispatches** (the numeric bridge `.Bridge`/`.Int`/`.Real`, `.COERCE`,
+  render `.gist`/`.Str` reached via paths other than `say`/`note`), each at its own
+  op-handler boundary with `current_code` + `reconcile_caller_after_lazy_force`. THEN the
+  coerce/render *routing* (original Slice 1: route tree-walked `dispatch_instance_and_
+  fallback` user methods through `dispatch_compiled_method`) becomes safe, because the
+  drain point exists.
 - **Slice 2 — generalize the lever** to all user-method calls in
   `call_method_with_values` (cat 1 misc user methods abs/succ/foo/…, and the
   catch-all-miss path feeding `dispatch_instance_and_fallback:867`).

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -190,7 +190,20 @@ impl Interpreter {
         &mut self,
         value: Value,
     ) -> Result<Value, RuntimeError> {
-        loan_env!(self, coerce_infix_operand_numeric(value))
+        // Slice F (compiled-method redispatch coherence): a user `Numeric`/`Bridge`
+        // method run by this internal coercion can mutate a captured-outer caller
+        // lexical (`my $c; method Numeric { $c++; ... }`). `call_compiled_method`
+        // records that write into `pending_rw_writeback_sources`, but — unlike an
+        // explicit `$obj.Numeric` call op — this internal redispatch has no
+        // surrounding op to drain it, so the caller's local slot stays stale.
+        // Capture the caller frame's code before the dispatch (which clobbers
+        // `current_code`) and reconcile after, mirroring `say`/`note`'s `.gist`
+        // closure handling. No-op when the coercion ran no user method (pending
+        // list stays empty).
+        let caller_code = self.current_code;
+        let r = loan_env!(self, coerce_infix_operand_numeric(value));
+        self.reconcile_caller_after_lazy_force(caller_code);
+        r
     }
 
     pub(super) fn coerce_numeric_bridge_pair(
@@ -226,21 +239,28 @@ impl Interpreter {
         match val {
             Value::Package(name) => {
                 let class_name = name.resolve().to_string();
-                if loan_env!(self, resolve_method_with_owner(&class_name, "Bool", &[])).is_some()
-                    && let Ok(result) =
-                        self.try_compiled_method_or_interpret(val.clone(), "Bool", vec![])
-                {
-                    return result.truthy();
+                if loan_env!(self, resolve_method_with_owner(&class_name, "Bool", &[])).is_some() {
+                    // Slice F: a user `Bool` method run by this internal coercion
+                    // can mutate a captured-outer caller lexical; drain its
+                    // writeback to the caller's slot (see coerce_numeric_bridge_value).
+                    let caller_code = self.current_code;
+                    let result = self.try_compiled_method_or_interpret(val.clone(), "Bool", vec![]);
+                    self.reconcile_caller_after_lazy_force(caller_code);
+                    if let Ok(result) = result {
+                        return result.truthy();
+                    }
                 }
                 val.truthy()
             }
             Value::Instance { class_name, .. } => {
                 let cn = class_name.resolve().to_string();
-                if loan_env!(self, resolve_method_with_owner(&cn, "Bool", &[])).is_some()
-                    && let Ok(result) =
-                        self.try_compiled_method_or_interpret(val.clone(), "Bool", vec![])
-                {
-                    return result.truthy();
+                if loan_env!(self, resolve_method_with_owner(&cn, "Bool", &[])).is_some() {
+                    let caller_code = self.current_code;
+                    let result = self.try_compiled_method_or_interpret(val.clone(), "Bool", vec![]);
+                    self.reconcile_caller_after_lazy_force(caller_code);
+                    if let Ok(result) = result {
+                        return result.truthy();
+                    }
                 }
                 val.truthy()
             }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -759,12 +759,19 @@ impl Interpreter {
             ));
         }
         // If the value is an Instance, try calling the Numeric method
-        if let Value::Instance { .. } = &val
-            && let Ok(result) =
-                self.try_compiled_method_or_interpret(val.clone(), "Numeric", vec![])
-        {
-            self.stack.push(result);
-            return Ok(());
+        if let Value::Instance { .. } = &val {
+            // Slice F: a user `Numeric` method can mutate a captured-outer caller
+            // lexical (`my $c; method Numeric { $c++; ... }`); this op-level
+            // redispatch has no surrounding CallMethod op to drain the writeback,
+            // so capture the caller frame's code and reconcile after (see
+            // coerce_numeric_bridge_value).
+            let caller_code = self.current_code;
+            let result = self.try_compiled_method_or_interpret(val.clone(), "Numeric", vec![]);
+            self.reconcile_caller_after_lazy_force(caller_code);
+            if let Ok(result) = result {
+                self.stack.push(result);
+                return Ok(());
+            }
         }
         // Force a lazy IO words/lines iterator so numeric coercion counts its
         // elements (e.g. `+$fh.words` / `+$fh.lines`) rather than yielding 0.
@@ -854,13 +861,20 @@ impl Interpreter {
         }
         // If the value is an Instance, try calling the Stringy method, then Str
         if let Value::Instance { .. } = &val {
-            if let Ok(result) =
-                self.try_compiled_method_or_interpret(val.clone(), "Stringy", vec![])
-            {
+            // Slice F: a user `Stringy`/`Str` method can mutate a captured-outer
+            // caller lexical; reconcile its writeback to the caller's slot (see
+            // coerce_numeric_bridge_value).
+            let caller_code = self.current_code;
+            let stringy = self.try_compiled_method_or_interpret(val.clone(), "Stringy", vec![]);
+            self.reconcile_caller_after_lazy_force(caller_code);
+            if let Ok(result) = stringy {
                 self.stack.push(result);
                 return Ok(());
             }
-            if let Ok(result) = self.try_compiled_method_or_interpret(val.clone(), "Str", vec![]) {
+            let caller_code = self.current_code;
+            let str_r = self.try_compiled_method_or_interpret(val.clone(), "Str", vec![]);
+            self.reconcile_caller_after_lazy_force(caller_code);
+            if let Ok(result) = str_r {
                 self.stack.push(result);
                 return Ok(());
             }

--- a/t/coercion-method-captured-writeback.t
+++ b/t/coercion-method-captured-writeback.t
@@ -1,0 +1,73 @@
+use Test;
+
+# §D(b) substrate: a user coercion method (Numeric/Str/Bool) run by an internal
+# op-level redispatch (`+$obj`, `~$obj`, `?$obj`/`if $obj`, comparison coercion)
+# can mutate a captured-outer caller lexical. Unlike an explicit `$obj.Numeric`
+# call, that internal redispatch has no surrounding CallMethod op to drain the
+# captured-outer writeback into the caller's local slot. These regressed to
+# losing the write (counter stuck at 0).
+
+plan 10;
+
+# --- Numeric coercion via prefix:<+> ---
+{
+    my $calls = 0;
+    class CNum { has $.x = 5; method Numeric { $calls++; $!x } }
+    my $c = CNum.new;
+    my $a = +$c;
+    my $b = +$c;
+    is $a, 5, 'prefix:<+> returns Numeric result';
+    is $calls, 2, 'Numeric method captured-outer write propagates (prefix:<+>)';
+}
+
+# --- Numeric coercion via a numeric comparison operator ---
+{
+    my $calls = 0;
+    class CCmp { method Numeric { $calls++; 7 } }
+    my $c = CCmp.new;
+    my $r = ($c == 7);
+    ok $r, 'numeric == coercion uses Numeric';
+    is $calls, 1, 'Numeric write propagates through comparison coercion';
+}
+
+# --- Str coercion via prefix:<~> ---
+{
+    my $calls = 0;
+    class CStr { method Str { $calls++; "hi" } }
+    my $c = CStr.new;
+    my $s = ~$c;
+    my $t = ~$c;
+    is $s, "hi", 'prefix:<~> returns Str result';
+    is $calls, 2, 'Str method captured-outer write propagates (prefix:<~>)';
+}
+
+# --- Bool coercion via `if` / prefix:<?> ---
+{
+    my $calls = 0;
+    class CBool { method Bool { $calls++; True } }
+    my $c = CBool.new;
+    if $c { }
+    my $x = ?$c;
+    is $calls, 2, 'Bool method captured-outer write propagates (if / prefix:<?>)';
+}
+
+# --- accumulation across many calls (slot must stay coherent) ---
+{
+    my $n = 0;
+    class CAcc { method Numeric { $n++; 1 } }
+    my $c = CAcc.new;
+    my $sum = 0;
+    $sum += +$c for ^5;
+    is $n, 5, 'accumulating Numeric write coherent across loop';
+    is $sum, 5, 'returned value correct each iteration';
+}
+
+# --- explicit call still works (no regression) ---
+{
+    my $calls = 0;
+    class CExp { method bump { $calls++ } }
+    my $c = CExp.new;
+    $c.bump;
+    $c.bump;
+    is $calls, 2, 'explicit method call writeback unchanged';
+}


### PR DESCRIPTION
## Summary

A user coercion method (`Numeric`/`Str`/`Stringy`/`Bool`) run by an **internal op-level redispatch** — `+\$obj`, `~\$obj`, `?\$obj`/`if \$obj`, and infix arith / numeric comparison coercion — could mutate a captured-outer caller lexical and silently lose the write:

```raku
my $calls = 0;
class C { method Numeric { $calls++; 5 } }
my $c = C.new;
+$c; +$c;
say $calls;   # raku: 2   mutsu (before): 0
```

## Root cause

The captured-outer write already reaches the caller **env**: `call_compiled_method`'s `merge_method_env` propagates it and records the changed caller-visible names into `pending_rw_writeback_sources`. The break was that an internal coercion redispatch has **no surrounding `CallMethod` op** to drain that list into the caller's local **slot**, so the slot stayed stale (env correct, slot stale — the dual-store gap). An explicit `\$obj.Numeric` works precisely because its op tail runs `drain_and_reconcile_after_cached_call`.

## Fix

Drain at each op-level coercion redispatch site using the existing `current_code` + `reconcile_caller_after_lazy_force` machinery (the same pattern `say`/`note` already use to reconcile a `.gist`/`.Str` closure's captured write). Sites: `exec_num_coerce_op`, `exec_str_coerce_op`, `coerce_numeric_bridge_value`, `eval_truthy`.

This extends the captured-outer / closure-env writeback coherence to the compiled-method **coercion-redispatch boundary** (PLAN §D(b) substrate). Notably, no closure-env rooting was needed — the design doc's earlier `dispatch_compiled_method` premise was wrong about the mechanism; the three previously-reverted blocker tests (junction-invocant / grammar-dynvar / `\$calls++` coercion) all pass.

## Tests

- New pin `t/coercion-method-captured-writeback.t` (10): Numeric/Str/Bool via prefix ops, comparison coercion, loop accumulation, explicit-call non-regression.
- `make test` PASS (11898 tests).
- S13-overloading roast suite PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)