### PR TITLE
fix(vm): retain captured-outer writeback dropped by a nested call (BUILDALL coherence)

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -683,11 +683,21 @@ impl Interpreter {
         if !self.pending_rw_writeback_sources.is_empty() {
             let sources = std::mem::take(&mut self.pending_rw_writeback_sources);
             for source in sources {
-                if let Some(slot) = self.find_local_slot(code, &source)
-                    && !matches!(self.locals[slot], Value::HashEntryRef { .. })
-                    && let Some(val) = self.env().get(&source).cloned()
-                {
-                    self.locals[slot] = val;
+                if let Some(slot) = self.find_local_slot(code, &source) {
+                    if !matches!(self.locals[slot], Value::HashEntryRef { .. })
+                        && let Some(val) = self.env().get(&source).cloned()
+                    {
+                        self.locals[slot] = val;
+                    }
+                } else if !self.pending_caller_var_writeback.contains(&source) {
+                    // The owning slot is not in THIS frame. Don't drop the source:
+                    // it belongs to a frame further up the stack (e.g. a sibling
+                    // `submethod BUILD`'s `$counter++` queued for the outer `.new`
+                    // site, consumed here by a *nested* call inside another BUILD —
+                    // S12-construction/BUILD.t). Move it to the retain-on-miss
+                    // caller-var list so the owning frame's drain refreshes its slot
+                    // instead of leaving it stale.
+                    self.pending_caller_var_writeback.push(source);
                 }
             }
         }

--- a/t/build-sibling-writeback-coherence.t
+++ b/t/build-sibling-writeback-coherence.t
@@ -1,0 +1,62 @@
+use Test;
+
+# Pre-existing §D(b) construction blocker: a nested method dispatch inside one
+# BUILD submethod (`my $x = S.new`) consumed a *sibling* BUILD's captured-outer
+# writeback via the drop-on-miss method-call op-tail drain, leaving the caller's
+# slot stale (S12-construction/BUILD.t "Called Parent's BUILD method once").
+# Fixed by routing a drop-on-miss source to the retain-on-miss caller-var list so
+# the frame that owns the slot drains it.
+
+plan 6;
+
+# --- nested .new inside child BUILD must not drop parent BUILD's write ---
+{
+    my $pc = 0;
+    class S1 { }
+    class P1 { submethod BUILD { $pc++ } }
+    class C1 is P1 { submethod BUILD { my $x = S1.new } }
+    C1.new;
+    is $pc, 1, 'nested .new in child BUILD keeps parent BUILD write';
+}
+
+# --- nested method call (with user method) inside child BUILD ---
+{
+    my $pc = 0;
+    class S2 { method hi { 42 } }
+    class P2 { submethod BUILD { $pc++ } }
+    class C2 is P2 { submethod BUILD { my $x = S2.new.hi } }
+    C2.new;
+    is $pc, 1, 'nested user-method call in child BUILD keeps parent write';
+}
+
+# --- both BUILDs counted correctly with nested dispatch ---
+{
+    my $pc = 0;
+    my $cc = 0;
+    class S3 { }
+    class P3 { submethod BUILD { $pc++ } }
+    class C3 is P3 { submethod BUILD { $cc++; my $x = S3.new } }
+    C3.new;
+    is $pc, 1, 'parent counter == 1';
+    is $cc, 1, 'child counter == 1';
+}
+
+# --- coercion (nested dispatch) inside child BUILD ---
+{
+    my $pc = 0;
+    class N4 { method Numeric { 5 } }
+    class P4 { submethod BUILD { $pc++ } }
+    class C4 is P4 { submethod BUILD { my $x = +N4.new } }
+    C4.new;
+    is $pc, 1, 'nested coercion in child BUILD keeps parent write';
+}
+
+# --- ordinary method call writeback still works (no regression) ---
+{
+    my $calls = 0;
+    class E5 { method bump { $calls++ } }
+    my $e = E5.new;
+    $e.bump;
+    $e.bump;
+    is $calls, 2, 'ordinary method-call writeback unchanged';
+}


### PR DESCRIPTION
## Summary

Fixes the pre-existing construction blocker documented in #3618: a nested method dispatch inside one BUILD submethod consumed a **sibling** BUILD's captured-outer writeback and left the caller's slot stale.

```raku
my $pc = 0;
class P { submethod BUILD { $pc++ } }
class C is P { submethod BUILD { my $x = S.new } }   # any nested dispatch
C.new; say $pc;   # raku: 1, mutsu before: 0
```

## Root cause (confirmed by tracing)

`apply_pending_rw_writeback` — the method-call op-tail drain — is **drop-on-miss**. BUILDALL runs Parent.BUILD (records `$pc++` into `pending_rw_writeback_sources`, owned by the outer `.new` caller's frame), then Child.BUILD; a nested `S.new` inside Child.BUILD reaches this drain at a frame where `$pc` is **not** a slot (`find_local_slot == None`), so drop-on-miss discards it. The outer `.new` drain then finds nothing and the top-level slot stays stale. With an empty/non-dispatching Child.BUILD there is no intervening drain → it was already correct; only a nested dispatch triggered the loss.

## Fix

When `apply_pending_rw_writeback` finds a source whose slot is not in the current frame, **move it to the retain-on-miss `pending_caller_var_writeback` list** instead of dropping it, so the frame that owns the slot (the outer `.new` site) drains it. Mirrors `reconcile_caller_after_internal_dispatch` (#3617) but at the real method-call op tail. Ordinary single-frame method writeback is unchanged.

## Tests

- New pin `t/build-sibling-writeback-coherence.t` (6): nested `.new` / user-method / coercion inside child BUILD + ordinary-call non-regression.
- `roast/S12-construction/BUILD.t`, `construction.t` PASS; coercion/render pins PASS.
- `make test` green (full suite; this is a hot-path drain change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)