### PR TITLE
fix(coerce): type-object .Numeric/.Real default to Mu's 0 with a warning

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1535,13 +1535,18 @@ impl Interpreter {
                     _ => None,
                 };
                 if let Some(name) = num_name {
+                    // A bare type object (no user `.Numeric`/`.Real`, and not one of
+                    // the concrete numeric types handled on the fast path) inherits
+                    // Mu's coercion: warn "uninitialized ... in numeric context" and
+                    // return 0. Roles keep their existing silent 0 for back-compat.
                     if self.registry().roles.contains_key(&name) {
                         Ok(Value::Int(0))
                     } else {
-                        Err(RuntimeError::new(format!(
-                            "X::Method::NotFound: Unknown method value dispatch (fallback disabled): {}",
-                            method
-                        )))
+                        let msg = format!(
+                            "Use of uninitialized value of type {} in numeric context",
+                            name
+                        );
+                        Err(RuntimeError::warn_signal_with_resume(msg, Value::Int(0)))
                     }
                 } else {
                     Err(RuntimeError::new(format!(

--- a/t/type-object-numeric-coercion.t
+++ b/t/type-object-numeric-coercion.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 9;
+
+# A bare type object inherits Mu's `.Numeric`/`.Real`: it warns
+# "Use of uninitialized value of type T in numeric context" and returns 0,
+# rather than throwing X::Method::NotFound.
+
+is-deeply (quietly Mu.Numeric), 0, 'Mu.Numeric is 0';
+is-deeply (quietly Mu.Real), 0, 'Mu.Real is 0';
+
+my class Bare {}
+is-deeply (quietly Bare.Numeric), 0, 'user-class type object .Numeric is 0';
+is-deeply (quietly Bare.Real), 0, 'user-class type object .Real is 0';
+
+# The coercion warns about an uninitialized value in numeric context.
+warns-like { Mu.Numeric }, *.contains('uninitialized' & 'numeric'),
+    'Mu.Numeric warns about uninitialized value in numeric context';
+
+# Concrete numeric type objects still give their typed zero (fast path).
+is-deeply (quietly Int.Numeric), 0, 'Int.Numeric is 0';
+is-deeply (quietly Num.Numeric), 0e0, 'Num.Numeric is 0e0';
+is-deeply (quietly Rat.Numeric), 0.0, 'Rat.Numeric is 0.0';
+
+# A user-defined .Numeric still takes priority over the Mu default.
+my class HasNum { method Numeric { 99 } }
+is HasNum.Numeric, 99, 'user .Numeric method wins over the Mu default';


### PR DESCRIPTION
Calling `.Numeric`/`.Real` on a bare type object that has no user-defined
coercion (and is not one of the concrete numeric types handled on the fast path)
previously threw `X::Method::NotFound: Unknown method value dispatch`. Raku
inherits Mu's behavior: warn *"Use of uninitialized value of type T in numeric
context"* and return 0.

After this change, `Mu.Numeric`, `Mu.Real`, and a plain user class's
`Foo.Numeric`/`Foo.Real` match Rakudo (warn + 0) instead of erroring.

- The fast path still returns the typed zero for the concrete numeric types
  (`Num.Numeric` → `0e0`, `Rat` → `0.0`, `Complex` → `<0+0i>`).
- A user-defined `.Numeric` method still wins (dispatched before this fallback).
- Roles keep their existing silent `0`.

Surfaced by `my \x .= Numeric` (desugars to `Mu.Numeric`) in
`S03-operators/inplace.t` and `.Numeric on :U` in `S02-literals/allomorphic.t`.

## Tests
- New `t/type-object-numeric-coercion.t` (9 assertions).
- Local: `cargo test` 470 ✓, full `prove t/` ✓, whitelisted
  S02-types/S32-num/S02-literals ✓ (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)