### PR TITLE
fix(quietly): statement-prefix quietly is scope-transparent

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -632,6 +632,29 @@ impl Compiler {
                 }
             }
         }
+        // quietly: suppress warnings raised while evaluating the expression, but
+        // run it INLINE in the current scope (so `quietly my $x = ...` leaks $x),
+        // unlike the `quietly(&block)` builtin which runs the block in its own
+        // frame. The guarded warn still resumes in place with its resume value.
+        else if name == "quietly" && args.len() == 1 {
+            match &args[0] {
+                Expr::AnonSub { body, .. } | Expr::AnonSubParams { body, .. } => {
+                    // `quietly { ... }` -- run the block body inline as a do-block.
+                    self.code.emit(OpCode::WarnSuppressPush);
+                    let do_block = Expr::DoBlock {
+                        body: body.clone(),
+                        label: None,
+                    };
+                    self.compile_expr(&do_block);
+                    self.code.emit(OpCode::WarnSuppressPop);
+                }
+                _ => {
+                    self.code.emit(OpCode::WarnSuppressPush);
+                    self.compile_expr(&args[0]);
+                    self.code.emit(OpCode::WarnSuppressPop);
+                }
+            }
+        }
         // Rewrite indir($path, { ... }) body into a callable block value so
         // call_function("indir", ...) can execute it after switching $*CWD.
         else if name == "indir" && args.len() >= 2 {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -408,6 +408,16 @@ pub(crate) enum OpCode {
     /// are (or may be) container-wrapped and must not auto-sink (Raku does not
     /// sink container-wrapped values).
     SinkPop(bool),
+    /// Statement-prefix `quietly`: push a warning-suppression frame so any
+    /// warning raised while evaluating the following expression is silenced
+    /// (the warn still resumes in place with its resume value, matching Raku's
+    /// CONTROL/CX::Warn `.resume`). Balanced by `WarnSuppressPop`. Unlike the
+    /// `quietly(&block)` builtin, this runs the guarded expression INLINE in the
+    /// current lexical scope, so `quietly my $x = ...` leaks `$x` to the
+    /// enclosing scope as Raku requires.
+    WarnSuppressPush,
+    /// Pop the warning-suppression frame pushed by `WarnSuppressPush`.
+    WarnSuppressPop,
     /// Peek the top of stack (without popping) and throw it if it is an
     /// unhandled Failure. Used at the tail of a try/CATCH body so a trailing
     /// `fail`/Failure value is thrown into the block's CATCH handler while a

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -2223,17 +2223,16 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         }
         "quietly" => {
             let (r, _) = ws(rest)?;
-            // quietly expr — defer evaluation so quietly can control warning behavior
+            // `quietly EXPR` — pass the raw expression so the compiler can run it
+            // INLINE in the current scope under a warning-suppression frame
+            // (so `quietly my $x = ...` leaks `$x`, matching Raku). A block form
+            // `quietly { ... }` arrives as an AnonSub and is handled there too.
             let (r, expr) = expression(r)?;
-            let wrapped = match expr {
-                Expr::AnonSub { .. } | Expr::AnonSubParams { .. } => expr,
-                other => make_anon_sub(vec![Stmt::Expr(other)]),
-            };
             return Ok((
                 r,
                 Expr::Call {
                     name: Symbol::intern(&name),
-                    args: vec![wrapped],
+                    args: vec![expr],
                 },
             ));
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3093,6 +3093,14 @@ impl Interpreter {
                 }
                 *ip += 1;
             }
+            OpCode::WarnSuppressPush => {
+                self.push_warn_suppression();
+                *ip += 1;
+            }
+            OpCode::WarnSuppressPop => {
+                self.pop_warn_suppression();
+                *ip += 1;
+            }
             OpCode::SinkPop(user_sink) => {
                 let user_sink = *user_sink;
                 if let Some(val) = self.stack.pop() {

--- a/t/quietly-scope-transparency.t
+++ b/t/quietly-scope-transparency.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 9;
+
+# Statement-prefix `quietly` is scope-transparent: a `my` declaration inside it
+# leaks to the enclosing scope (Raku semantics), unlike a block/sub.
+quietly my $a = 5;
+is $a, 5, 'quietly my $a = 5 leaks $a to the enclosing scope';
+
+quietly my @b = 1, 2, 3;
+is @b.elems, 3, 'quietly my @b = ... leaks @b';
+
+quietly my %h = :x(1), :y(2);
+is %h<x>, 1, 'quietly my %h = ... leaks %h';
+
+# A warning raised while evaluating the guarded expression is suppressed, and
+# the warn resumes in place so the assignment still completes with its value.
+quietly my $n = Mu.Numeric;
+is $n, 0, 'quietly suppresses the warn AND the assignment completes (Mu.Numeric)';
+
+quietly my \z .= Numeric;
+is z, 0, 'quietly my \z .= Numeric leaks z and resumes to 0';
+
+# The block form still works and suppresses warnings.
+my $ran = 0;
+quietly { warn "boom"; $ran = 1 };
+is $ran, 1, 'quietly { ... } runs the block with warnings suppressed';
+
+# A plain expression under quietly returns its value.
+is (quietly 41 + 1), 42, 'quietly EXPR returns the expression value';
+
+# quietly does not suppress non-warning output.
+{
+    my $x;
+    quietly $x = 7;
+    is $x, 7, 'quietly assignment to an outer var works';
+}
+
+# Nested quietly is fine.
+quietly { quietly my $deep = 99; is $deep, 99, 'nested quietly leaks inner decl' };


### PR DESCRIPTION
`quietly EXPR` was lowered to `quietly(-> { EXPR })`, wrapping the guarded code
in an anonymous sub. That gave it its own lexical scope, so a declaration inside
(`quietly my \$x = ...`) was trapped in the sub and invisible to the enclosing
scope. Raku's statement-prefix `quietly` is **scope-transparent** — the
declaration leaks out (`quietly my \$x = 5; say \$x` prints `5`).

## Fix

Lower `quietly EXPR` like `sink EXPR`: the parser passes the raw expression, and
the compiler runs it **inline** in the current scope between a new
`WarnSuppressPush`/`WarnSuppressPop` opcode pair. Because a guarded warning still
resumes *in place* (the run loop's resumable-warn handler pushes the resume value
and continues), `quietly my \$x = <warns-and-returns-0>` now both suppresses the
warning AND completes the assignment with the resumed value — matching Raku.

`quietly { ... }` block form is handled inline as a do-block.

## Impact

Combined with the merged Mu.Numeric coercion default (#3621), this advances:
- `S03-operators/inplace.t`: 6 → 5 failing subtests (`quietly my \v .= Numeric`).
- `S02-literals/allomorphic.t`: 2 → 1 failing subtest (`.Numeric on :U` block).

## Tests
- New `t/quietly-scope-transparency.t` (9 assertions).
- Local: `cargo test` 470 ✓, full `prove t/` ✓, whitelisted warn/quietly roast
  tests ✓ (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)