### PR TITLE
docs(roast): allomorphic.t (118/119) + inplace.t (33/38) progress

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -24,19 +24,21 @@
 - [ ] roast/S02-literals/adverbs.t
   - 0/? pass. Parse error at line 7
 - [ ] roast/S02-literals/allomorphic.t
-  - 117/119 pass (runs the full plan, no parse error anymore). Two failing subtests, both
-    blocked on deep features:
-  - Test 107 (`.ACCEPTS` subtest): same-named lexical class redeclared in two `gather`
-    blocks; mutsu keys classes by name in one global map so the second clobbers the first.
-    Needs per-decl class identity (mirror `role_id`/`role_candidates`).
-  - Test 113 (`.Numeric on :U allomorphs ...` subtest): a re-execution/state bug — the
-    subtest plans 25 but mutsu runs 34. Inside `quietly{}` with warning-emitting
-    `:U`-coercion (`CustomNumeric.Numeric`), the `is-deeply` assertion is emitted twice
-    (one pass, one fail returning 0 instead of self.new's 42) and the following
-    `for @types {...}` loop iterates 9× instead of 5×. NOT reproducible in isolation
-    (`CustomNumeric.Numeric` returns 42 standalone; `for @types` iterates 5 standalone) —
-    only the subtest+quietly+warn-resume combination triggers it. Likely the same
-    CONTROL-resume-re-executes-statements class as #2888.
+  - **118/119 pass now** (was 117). Test 113 (`.Numeric on :U`) was FIXED by the
+    Mu.Numeric type-object coercion default (#3621) + scope-transparent `quietly`
+    (#3623): `Mu.Numeric` now warns+returns 0 instead of throwing, and `quietly`'s
+    warn-resume completes the guarded assignment inline. The plan-25-vs-ran-34
+    re-execution symptom was a downstream artifact of the `quietly`+warn-resume
+    interaction, now resolved.
+  - **ONLY test 107 (`.ACCEPTS` subtest) remains** — blocked on **per-decl class
+    identity** (Hard). The subtest declares `my class IntFoo {...}` (Numeric→3) in
+    the `@true` gather AND a different `my class IntFoo {...}` (Numeric→42) in the
+    `@false` gather. mutsu keys classes by name in one global registry map, so the
+    two same-named lexical classes collide (verified: both gathers' `IntFoo.new`
+    .Numeric return the SAME value). `IntStr.new(3,"3").ACCEPTS(IntFoo.new)` then
+    compares against the clobbered definition. Needs distinct identity per lexical
+    class declaration (mirror `role_id`/`role_candidates`). Same root as
+    S02-types/allomorphic-style same-name-lexical-class clobbers.
 - [ ] roast/S02-literals/array-interpolation.t
   - 5/12 pass (tests 1, 5, 7, 9, 11). Failures: `@array.[]` interpolation, `@array` without brackets not interpolating, embedded array ref stringification in double-quoted strings
 - [ ] roast/S02-literals/autoref.t

--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -171,7 +171,13 @@
   - 11/41 pass.
 - [x] roast/S03-operators/infixed-function.t
 - [ ] roast/S03-operators/inplace.t
-  - 14/38 pass.
+  - 33/38 pass (5 failing subtests: 32, 33, 34, 36, 37). Subtest 34's sigilless
+    `.= Numeric` inits were unblocked by the Mu.Numeric coercion default (#3621)
+    and scope-transparent `quietly` (#3623). Remaining failures are disparate `.=`
+    metaop edge cases: method-chain `.=` with fake-infix adverb args
+    (`($p2 = ...).=new :key<foo>`), `quietly`-warn cases in subtest 34's later
+    asserts, `.=` inside `andthen`/`orelse` (36), and `($o2 = ...).=meth` weird
+    cases (37). Each is a separate mini-feature in `.=` parsing/lowering.
 - [ ] roast/S03-operators/is-divisible-by.t
   - 7/16 pass.
 - [x] roast/S03-operators/lcm.t


### PR DESCRIPTION
Records the progress from this session's coercion/quietly fixes (#3621, #3623):

- **allomorphic.t**: 117 → 118/119. Test 113 (`.Numeric on :U`) fixed; only the per-decl class-identity `.ACCEPTS` subtest (test 107) remains (Hard).
- **inplace.t**: documented 14 → 33/38; the sigilless `.= Numeric` inits now work. Remaining 5 are disparate `.=` metaop edge cases.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)