### PR TITLE
feat(vm): positional subscript coerces a user object index via .Int

### DIFF
--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -320,6 +320,26 @@ impl Interpreter {
             self.stack.push(index);
             return self.exec_index_op_with_positional(is_positional);
         }
+        // A user object used as a positional subscript coerces via its `.Int`
+        // method (`@a[$obj]` where `$obj` defines `method Int`, Raku subscript
+        // protocol). Gate on an array-like target so an associative `%h{...}`
+        // key Instance is left alone, and on the class actually defining a user
+        // `Int` method so built-in instances (Match, Failure, …) fall through to
+        // their own handling. Slice F: this op-level redispatch has no surrounding
+        // CallMethod op, so drain the captured-outer writeback (`my $i; method Int
+        // { $i++; ... }`) into the caller's slot via `current_code` +
+        // `reconcile_caller_after_internal_dispatch` (retain-on-miss).
+        if let Value::Instance { class_name, .. } = &index
+            && matches!(&target, Value::Array(..) | Value::Seq(_) | Value::Slip(_))
+            && self.has_user_method(&class_name.resolve().to_string(), "Int")
+        {
+            let caller_code = self.current_code;
+            let coerced = self.try_compiled_method_or_interpret(index.clone(), "Int", vec![]);
+            self.reconcile_caller_after_internal_dispatch(caller_code);
+            if let Ok(v) = coerced {
+                index = v;
+            }
+        }
         // If target is a Failure, propagate it (// will catch it as undefined)
         if matches!(&target, Value::Instance { class_name, .. } if class_name == "Failure") {
             self.stack.push(target);

--- a/t/index-instance-int-coercion.t
+++ b/t/index-instance-int-coercion.t
@@ -1,0 +1,58 @@
+use Test;
+
+# Raku subscript protocol: a positional subscript coerces the index via its
+# `.Int` method. `@a[$obj]` where `$obj` defines `method Int` was returning Nil
+# (mutsu did not coerce the Instance index at all). The fix also drains the
+# coercion method's captured-outer writeback into the caller's slot (§D(b)
+# Slice F, retain-on-miss), mirroring the coercion/render redispatch fixes.
+
+plan 7;
+
+# --- basic Int-coerced index ---
+{
+    my @a = 10, 20, 30;
+    class CI { method Int { 1 } }
+    is @a[CI.new], 20, '@a[$obj] coerces index via .Int';
+}
+
+# --- Int method captured-outer writeback propagates ---
+{
+    my $calls = 0;
+    my @a = 10, 20, 30;
+    class CW { method Int { $calls++; 2 } }
+    my $w = CW.new;
+    my $x = @a[$w];
+    my $y = @a[$w];
+    is $x, 30, 'indexed value correct';
+    is $calls, 2, '.Int captured-outer write propagates (subscript)';
+}
+
+# --- Int coercion on a list literal / word list ---
+{
+    my @a = <a b c d>;
+    class CN { method Int { 3 } }
+    is @a[CN.new], 'd', 'Int coercion picks the right element';
+}
+
+# --- associative subscript is NOT affected (string key stays a key) ---
+{
+    my %h = alpha => 'A', beta => 'B';
+    is %h<alpha>, 'A', 'hash key lookup unaffected by index coercion';
+}
+
+# --- plain integer index still works (no regression) ---
+{
+    my @a = 100, 200, 300;
+    is @a[2], 300, 'plain integer subscript unchanged';
+}
+
+# --- Int-coerced subscript inside a sibling BUILD keeps parent BUILD write
+#     (regression guard: relies on the BUILDALL retain-on-miss fix, #3620) ---
+{
+    my $pc = 0;
+    class IdxI { method Int { 0 } }
+    class IdxP { submethod BUILD { $pc++ } }
+    class IdxC is IdxP { submethod BUILD { my @a = 7, 8; my $x = @a[IdxI.new] } }
+    IdxC.new;
+    is $pc, 1, 'index coercion inside child BUILD keeps parent BUILD write';
+}


### PR DESCRIPTION
## Summary

`@a[\$obj]` where `\$obj` defines `method Int` now coerces the index via that method (Raku subscript protocol), instead of returning Nil:

```raku
class CI { method Int { 1 } }
my @a = 10, 20, 30;
say @a[CI.new];   # 20  (was: Nil)
```

Gated on an array-like target (an associative `%h{...}` key Instance is untouched) and on the class actually defining a user `Int` method (built-in instances like Match/Failure keep their own handling).

The `.Int` coercion is an op-level redispatch with no surrounding CallMethod op, so its captured-outer writeback (`my \$i; method Int { \$i++; ... }`) is drained into the caller's slot via `current_code` + `reconcile_caller_after_internal_dispatch` (retain-on-miss), matching #3615/#3617.

Now that the BUILDALL sibling-writeback clobber is fixed (#3620), a `.Int`-coerced subscript inside a sibling `submethod BUILD` no longer drops the other BUILD's captured write — the pin guards that shape.

## Tests

- New pin `t/index-instance-int-coercion.t` (7): basic coercion, writeback propagation, word-list, hash-key non-interference, plain-index non-regression, sibling-BUILD guard.
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)