### PR TITLE
feat(coerce): SetHash/BagHash/MixHash coercion functions

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -340,7 +340,21 @@
 - [ ] roast/S02-types/resolved-in-setting.t
   - 2/4 pass (tests 1-2). Test 3 fails. Runtime error: `Unknown method: m` — method dispatch issue
 - [ ] roast/S02-types/sethash.t
-  - 0/? pass. Parse error at line 15
+  - 279/284 pass (was aborting at 224). The abort was `SetHash(42)`/`BagHash(...)`/
+    `MixHash(...)` coercion *functions* being unimplemented ("Unknown function:
+    SetHash") — added the three `*Hash` arms in `call_function` (share the
+    immutable `builtin_set`/`bag`/`mix` builders, then flip the mutability flag via
+    `with_set_mutability`). Remaining 5 failures are deeper, separate blockers:
+    - tests 231-233 "retains object, not container": `$obj{$i}=42; $i++` then
+      `.keys` must be `(1001,)` — element-assign container identity (§D first-class
+      container).
+    - test 229 "cloned SetHash gets its own elements storage": clone must deep-copy
+      element storage so post-clone mutation doesn't leak (container identity).
+    - test 227 ".antipairs produces correct result": Pair literal `Bool::True => "a"`
+      stores the key as the *string* `"Bool::True"`, not a typed Bool — `Value::Pair`
+      keys are `String`, so a typed (enum/Bool) pair key can't round-trip. is-deeply
+      against an antipairs Seq (typed-Bool key) then mismatches. Deep Pair-key
+      representation limitation.
 - [ ] roast/S02-types/set-iterator.t
   - 0/? pass. Parse error at line 11
 - [x] roast/S02-types/set.t

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -574,6 +574,17 @@ impl Interpreter {
             "Set" if !args.is_empty() => self.builtin_set(&args),
             "Bag" if !args.is_empty() => self.builtin_bag(&args),
             "Mix" if !args.is_empty() => self.builtin_mix(&args),
+            // The mutable `*Hash` coercion functions share the immutable
+            // builders, then flip the mutability flag on the result.
+            "SetHash" if !args.is_empty() => self
+                .builtin_set(&args)
+                .map(|v| crate::runtime::utils::with_set_mutability(v, true)),
+            "BagHash" if !args.is_empty() => self
+                .builtin_bag(&args)
+                .map(|v| crate::runtime::utils::with_set_mutability(v, true)),
+            "MixHash" if !args.is_empty() => self
+                .builtin_mix(&args)
+                .map(|v| crate::runtime::utils::with_set_mutability(v, true)),
             "set" => self.builtin_set(&args),
             "bag" => self.builtin_bag(&args),
             "mix" => self.builtin_mix(&args),

--- a/t/sethash-baghash-mixhash-coerce-fn.t
+++ b/t/sethash-baghash-mixhash-coerce-fn.t
@@ -1,0 +1,44 @@
+use Test;
+
+# The mutable QuantHash coercion *functions* SetHash(...) / BagHash(...) /
+# MixHash(...) (as opposed to the .SetHash/.BagHash/.MixHash methods or the
+# immutable Set/Bag/Mix functions). These previously died with
+# "Unknown function: SetHash".
+
+plan 16;
+
+# Basic coercion produces the mutable variant.
+isa-ok SetHash(<a b c>), SetHash, 'SetHash(...) returns a SetHash';
+isa-ok BagHash(<a b c>), BagHash, 'BagHash(...) returns a BagHash';
+isa-ok MixHash(<a b c>), MixHash, 'MixHash(...) returns a MixHash';
+
+# Element membership / weights match the immutable counterparts.
+is SetHash(<a a b>).elems, 2, 'SetHash dedups elements';
+is BagHash(<a a b>){'a'}, 2, 'BagHash counts occurrences';
+is MixHash(<a a b>){'a'}, 2, 'MixHash sums weights';
+
+# A single scalar arg coerces, then .Hash round-trips the object.
+is SetHash(42).Hash.keys[0], 42, 'SetHash(42).Hash.keys[0] is the original Int';
+isa-ok SetHash(42).Hash.keys[0], Int, 'SetHash(42).Hash key retains Int type';
+
+# The result is mutable (unlike Set/Bag/Mix).
+my $sh = SetHash(<a b>);
+$sh<c> = True;
+ok $sh<c>, 'SetHash(...) result is mutable (can add a key)';
+is $sh.elems, 3, 'SetHash gained the new element';
+
+my $bh = BagHash(<a a>);
+$bh<a>++;
+is $bh<a>, 3, 'BagHash(...) result is mutable (can bump a weight)';
+
+my $mh = MixHash(<a>);
+$mh<b> = 2.5;
+is $mh<b>, 2.5, 'MixHash(...) result is mutable (can set a weight)';
+
+# No-arg form stays a type object (does not become an empty container).
+ok SetHash ~~ SetHash, 'bare SetHash is still the type object';
+ok BagHash ~~ BagHash, 'bare BagHash is still the type object';
+ok MixHash ~~ MixHash, 'bare MixHash is still the type object';
+
+# Coercing from a Hash decomposes pairs (same as Set/Bag/Mix).
+is SetHash({:a, :b}).elems, 2, 'SetHash(Hash) decomposes truthy pairs';


### PR DESCRIPTION
## Summary

`SetHash(42)` / `BagHash(<a a b>)` / `MixHash(...)` used as coercion **functions** (distinct from the `.SetHash`/`.BagHash`/`.MixHash` methods, or the immutable `Set`/`Bag`/`Mix` functions) previously died with `Unknown function: SetHash`.

This adds the three `*Hash` arms in `call_function`. They share the existing immutable `builtin_set`/`builtin_bag`/`builtin_mix` builders, then flip the mutability flag on the result via `with_set_mutability` so the coercion yields the *mutable* QuantHash variant. The no-arg form still falls through to the type object (so bare `SetHash` stays a type object).

## Roast impact

Unblocks `roast/S02-types/sethash.t`, which was **aborting at test 224** on `SetHash(42).Hash`. It now runs all 284 tests, **279 pass**. The remaining 5 failures are separate, deeper blockers (documented in `TODO_roast/S02.md`):

- element-assign container identity (`$obj{$i}=42; $i++` then `.keys`)
- clone element-storage isolation
- typed `Pair` key representation (`Value::Pair` keys are `String`, so a typed Bool/enum pair key can't round-trip)

## Tests

- New `t/sethash-baghash-mixhash-coerce-fn.t` (16 assertions): type, membership/weights, mutability, `.Hash` round-trip, no-arg type object, Hash decomposition.
- `cargo test` green (470), local set/bag/mix suites green, no regression in `S02-types/{set,bag,mix,baghash,mixhash}.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)