### PR TITLE
feat(multi-dispatch): nextsame/callsame chain rw writes through redispatch (§D capstone)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -198,23 +198,20 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     writeback drain→proto exit の `apply_rw_bindings_to_env` が caller へ伝播。VM sub=`vm_call_proto_dispatch`（#3556）／
     interpreter proto method=`call_proto_dispatch` の method_ctx 分岐（#TBD・`lookup_proto_method` で proto def 解決）。
     pin=`t/proto-rw-redispatch-coherence.t`(9・sub) / `t/proto-method-rw-redispatch.t`(5・method)。
-    **残ギャップ（別軸・深い substrate ブロック・2026-06-25 精査）**: **nextsame+rw チェーン**。
-    `multi pr(Int $x is rw){$x=$x+1; nextsame} multi pr($x is rw){$x=$x+1000}` で `pr($v)`（$v=10）が raku=**1011**
-    に対し mutsu=**11**（次候補の rw write が消える）。精査で判明した真の blocker は **VM↔interpreter の rw-param スロット
-    コヒーレンス**で、3 経路すべてに跨る:
-    - **function VM/OTF 経路**: バレ multi は OTF コンパイルされ VM で走る。`nextsame`（control-flow builtin）は
-      interpreter `dispatch_next_candidate` の `multi_dispatch_stack` 経路に落ち、次候補を `call_function_def`（interpreter）で
-      呼ぶが、(1) 次候補に渡す現在値が **VM ローカルスロット**（$x=11）でなく stale env（$x=10）/ (2) 次候補の rw writeback は
-      env に書くが、**最初の候補の `call_compiled_function_named` 末尾（vm_call_dispatch.rs:2006-2016）が rw-param ローカル
-      スロット（11）を env に flush し直して上書き**するので消える。修正には①次候補に現在スロット値を渡す②次候補の結果を
-      **最初の候補の VM スロット**へ書き戻す（env だけでは flush に潰される）の両方が要る＝§C cell coherence と同根。
-    - **function interpreter 経路**: `multi_dispatch_stack` 経路。`dispatch_next_candidate` に arg_sources 再設定＋現在 rw 値
-      再読みを追加すれば部分的に解けるが、現状すべて OTF 化されるため到達せず単体検証困難。
-    - **method 経路**: `multi method` は `method_dispatch_stack` 経路（dispatch.rs:131-217）で、次候補の rw param に
-      arg_sources が無く **`X::Parameter::RW` で die**（raku は成功）。別機構の修正が要る。
-    試行（4-tuple に現候補 param_defs を追加し interpreter 経路で再読み＋arg_sources 設定）は VM スロット潰し（②）に阻まれ
-    headline repro を直せず revert 済。**結論=単一スライス不可・§C の env↔locals/VM-frame cell 共有を redispatch 境界へ広げる
-    substrate 作業**（要設計）。repro=`tmp/nextsame_rw.raku`（function）/`tmp/nextsame_rw2.raku`（method・die）。
+    **nextsame+rw チェーン = 完了（#TBD・§D(b) capstone）**。
+    `multi pr(Int $x is rw){$x=$x+1; nextsame} multi pr($x is rw){$x=$x+1000}` で `pr($v)`（$v=10）が function/method とも
+    raku=**1011** に一致（method は以前 `X::Parameter::RW` で die）。callsame 継続（最初の候補が再開して chained 値を読む→**1016**）・
+    3 候補チェーン（→**1106**）も raku 一致。pin=`t/nextsame-rw-redispatch.t`(11・raku 検証済)。実装:
+    `multi_dispatch_stack` の 4 要素目に **最初の（勝者・compiled）候補の scalar rw param**を `Vec<(positional_index, param_name)>`
+    （`MultiDispatchEntry`/`rw_scalar_positional_params`）で保持（param 名は VM スロット位置の特定に必要・チェーン中 FIXED）。
+    `MethodDispatchFrame` も同 `rw_params` フィールド。`dispatch_next_candidate` で redispatch 前に各 rw param の**現在値**を
+    `env[first_param]`（body 変異済の live 値=11）から読み `call_args[pos]` を再構築（function は varref source 維持・method は
+    varref 無しなので `set_pending_call_arg_sources` で source 命名）。redispatch 後にチェーン最終値を **最初の候補の VM ローカル
+    スロット**（`self.current_code` 経由）AND `env[first_param]` へ書き戻す→exit flush がスロットを読むので clobber 回避、callsame
+    継続は env で名前読み。**鍵=「flush を抑止」でなく「flush が読むスロットを chained 値に更新」**＝callsame 継続・N 段チェーンと
+    自然に合成。旧 4-tuple 試行は env のみ書き compiled exit flush が読むスロットを更新しなかったため失敗。`!rw_params.is_empty()`
+    ガードで非 rw nextsame/callsame/callwith は byte-identical。対象外（不変）: `nextwith`/`callwith`+rw（override 引数・raku 自身が
+    literal→rw を拒否）。
   - [x] **`&`-code param を持つ候補の OTF 化 = 完了（#TBD）→ [news/2026-06.md](news/2026-06.md)**。`def_is_otf_compilable` の
     `!pd.name.starts_with('&')` ガードを撤去（`code_signature`〔`&cb:(Int)`〕と default 値の除外は維持）。`multi f(&cb){…}` 候補が
     bare multi / proto 経由とも compiled 実行され interpreter fallback を解消（proto `&cb` 経由 25%→0%）。block literal / 引数付き
@@ -245,7 +242,7 @@ HoH 深い共有が全て raku 一致（pin=`t/container-identity-phase2-complet
     pin=`t/enter-phaser-rvalue.t`(18)。
   - [ ] **残**: bare multi の残フォールバック（`@_` slurpy recursive sub 等は別カテゴリ・`@a[1..*]` 再帰の immutable-List bug は §F）/
     `code_signature`〔`&cb:(Int)`〕param を持つ候補の OTF 化（依然除外・別軸で `&cb:(Int)` vs `&cb` の resolution ambiguity も要）/
-    default-param OTF の **builtin-shadow 単一候補**（name-cache 汚染リスクで除外維持・PR #3546）/ nextsame+rw チェーン（上記）/
+    default-param OTF の **builtin-shadow 単一候補**（name-cache 汚染リスクで除外維持・PR #3546）/
     モジュール sub OTF の残 interpreter 結合構文（state/EVAL/CATCH/sigilless/rw/raw/code-sig/sub-sig/戻り型 coercion）＝保守ゲートで除外中・compiled_fns 拡充が本筋。
 
 ---

--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -218,32 +218,37 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
   PLAN nextsame+rw substrate (rw-param slot coherence across the redispatch boundary).
   This is the deep one; do it last, after the volume from Slices 1-3 confirms the
   approach and after the function-side multi-redispatch lessons.
-  **★Scoped implementation path (2026-06-26, after Slices 1a/1b/3 landed).** Current
-  state: function `multi pr(Int $x is rw){$x=$x+1;nextsame} multi pr($x is rw){$x=$x+1000}`
-  with `pr($v)` ($v=10) → mutsu **11**, raku **1011** (next candidate's rw write lost);
-  the *method* form **dies** `X::Parameter::RW`. Root mechanism in
-  `dispatch_next_candidate` (builtins_dispatch_next.rs:218-251, function path): the next
-  candidate is invoked `call_function_def(&next_def, &call_args)` where `call_args` is the
-  **value snapshot** stored in `multi_dispatch_stack` (`(name, Vec<FunctionDef>,
-  Vec<Value>)`, mod.rs:1140) — so (a) it sees the STALE original value (10, not the first
-  candidate's mutated 11), and (b) it has no arg *source*, so its `is rw` writeback has
-  nowhere to land. **Lever = the `arg_sources` mechanism that already solved proto `{*}`
-  rw-redispatch (#3556):** `set_pending_call_arg_sources(Some(vec![Some("v")]))` before
-  the next-candidate call lets the candidate's `is rw` param bind writable to `$v`
-  (`args_matching.rs` `has_arg_source`), and its writeback chains to the caller. The
-  concrete multi-part change: (1) extend `multi_dispatch_stack`'s tuple to carry the
-  original arg *sources* (`Vec<Option<String>>`) alongside the values — touches
-  `push_multi_dispatch_frame` (accessors.rs:878) and the 3 stack-write sites; (2) in
-  `dispatch_next_candidate`, rebuild `call_args` from the *current* rw-param values (read
-  the live slot/env, not the stale snapshot) and `set_pending_call_arg_sources` from the
-  stored sources before `call_function_def`; (3) ensure the first (VM/OTF) candidate's
-  `call_compiled_function_named` exit flush does not overwrite the rw-param slot with its
-  own value after the nested candidate wrote it (the VM-frame↔interpreter-frame slot
-  coherence — §C cell sharing across the redispatch boundary). The *method* path
-  (method_dispatch_stack, lines 130-217) additionally needs the next candidate's `is rw`
-  param to receive an arg_source so it stops dying with `X::Parameter::RW`. A prior 4-tuple
-  attempt was reverted on (3); the retain-on-miss + arg_sources machinery now in place
-  (Slices 1a/1b/#3620) is the substrate this builds on.
+  **★DONE — nextsame+rw redispatch (2026-06-26, #TBD).** Both the function path
+  (`pr($v)` → **1011**) and the method path (no longer dies `X::Parameter::RW`, → **1011**)
+  now chain the rw write through the redispatch, including `callsame` continuations
+  (first candidate resumes and reads the chained value, → **1016**) and 3+ candidate
+  chains (→ **1106**). pin=`t/nextsame-rw-redispatch.t`(11, validated against raku).
+  **How it landed** (close to the scoped plan, with two refinements found while building):
+  (1) `multi_dispatch_stack`'s tuple gained a 4th element — NOT the raw arg sources, but
+  the FIRST (winning, compiled) candidate's scalar rw params as `Vec<(positional_index,
+  param_name)>` (`MultiDispatchEntry`, `rw_scalar_positional_params`). The first
+  candidate's param name (not the caller source) is what locates its VM slot for the
+  writeback, so it is what must be stored; it stays FIXED across the chain (always the
+  first candidate's slots). `MethodDispatchFrame` gained the same `rw_params` field.
+  (2) In `dispatch_next_candidate`, before the redispatch: read each rw param's CURRENT
+  value from `env[first_param]` (the body-mutated live value, e.g. 11), rebuild
+  `call_args[pos]` with it (keeping the varref source for the function path; the method
+  path has none, so `set_pending_call_arg_sources` names the source). (3) AFTER the
+  redispatch: the chain's final value is in env; write it back into the first candidate's
+  VM local slot via `self.current_code` (the live ancestor compiled frame) AND into
+  `env[first_param]` — the slot so the exit flush reads the chained value (not the
+  candidate's own pre-nextsame value, the §C clobber), the env so a `callsame` body that
+  resumes after the redispatch reads the chained value by name. The function path routes
+  the next candidate's writeback through the caller source (varref name); the method path
+  routes it through the first candidate's param name (`source = first_param`), because
+  method args carry no varref. **Refinements vs the plan:** the stored element is the
+  first candidate's *param name* (for slot location), not the caller arg source; and the
+  fix is NOT "prevent the exit flush from clobbering" but "update the slot the flush reads
+  to the chained value", which composes cleanly with `callsame` continuations and N-level
+  chains. The prior reverted 4-tuple attempt failed because it wrote env only; the slot is
+  what the compiled exit flush reads. Guarded entirely behind `!rw_params.is_empty()` so
+  non-rw `nextsame`/`callsame`/`callwith` are byte-identical. Out of scope (unchanged):
+  `nextwith`/`callwith`+rw (override args; raku itself rejects a literal into an rw param).
 - **Out of scope (stay / separate axis):** user `Iterator` `pull-one`/`skip-one`/
   `count-only` (lever B / Phase 2), custom-HOW Metamodel methods (`find_method`/
   `accepts_type`/`name` — MOP reflection), `method FALLBACK` (missing-method semantics).

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -800,11 +800,18 @@ impl Interpreter {
         }
         let pushed = !remaining.is_empty();
         if pushed {
+            let rw_params = chosen
+                .as_ref()
+                .map(|(_, def)| {
+                    super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs)
+                })
+                .unwrap_or_default();
             self.method_dispatch_stack.push(super::MethodDispatchFrame {
                 receiver_class: receiver_class.to_string(),
                 invocant,
                 args: args.to_vec(),
                 remaining,
+                rw_params,
             });
         }
         pushed
@@ -907,8 +914,16 @@ impl Interpreter {
             .collect();
         let pushed = !remaining.is_empty();
         if pushed {
+            // Capture the FIRST (winning) candidate's scalar rw params so a
+            // nextsame+rw redispatch can chain the rw value through it (§D).
+            let rw_params = self
+                .resolve_function_with_alias(name, args)
+                .map(|def| {
+                    super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs)
+                })
+                .unwrap_or_default();
             self.multi_dispatch_stack
-                .push((name.to_string(), remaining, args.to_vec()));
+                .push((name.to_string(), remaining, args.to_vec(), rw_params));
         }
         pushed
     }

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -1,6 +1,42 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// Extract `(positional_arg_index, sigil-less_param_name)` for each scalar
+/// `is rw`/`is raw` positional parameter of a multi candidate's signature.
+/// Used by the nextsame/callsame+rw redispatch chain (§D capstone) to locate the
+/// FIRST (winning, compiled) candidate's rw params: their CURRENT value is
+/// forwarded to the next candidate, and the chain's final value is written back
+/// into the first candidate's VM local slot so its exit flush propagates it
+/// rather than clobbering it with its own pre-nextsame value.
+pub(super) fn rw_scalar_positional_params(
+    param_defs: &[crate::ast::ParamDef],
+) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    for pd in param_defs {
+        if pd.is_invocant || pd.named {
+            continue;
+        }
+        let is_scalar = pd.name != "_"
+            && pd
+                .name
+                .as_bytes()
+                .first()
+                .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_');
+        let is_rw = pd.traits.iter().any(|t| t == "rw" || t == "raw");
+        if is_scalar && is_rw && !pd.slurpy && !pd.double_slurpy && !pd.onearg {
+            out.push((pos, pd.name.clone()));
+        }
+        // Slurpy params consume the remaining positionals; positional indexing
+        // past one is ambiguous, but rw scalars always precede a slurpy, so the
+        // indices collected above stay correct.
+        if !pd.slurpy && !pd.double_slurpy {
+            pos += 1;
+        }
+    }
+    out
+}
+
 impl Interpreter {
     pub(super) fn no_dispatcher_error(func_name: &str) -> RuntimeError {
         let mut attrs = HashMap::new();
@@ -130,7 +166,8 @@ impl Interpreter {
         // Try method dispatch stack
         if !self.method_dispatch_stack.is_empty() {
             let frame_idx = self.method_dispatch_stack.len() - 1;
-            let (receiver_class, invocant, call_args, owner_class, method_def) = {
+            let is_override = override_args.is_some();
+            let (receiver_class, invocant, mut call_args, owner_class, method_def, rw_params) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
                 let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {
                     if tail_call {
@@ -142,6 +179,7 @@ impl Interpreter {
                     return Ok(Value::Nil);
                 };
                 frame.remaining.remove(0);
+                let rw_params = frame.rw_params.clone();
                 let call_args = if let Some(new_args) = override_args {
                     // Update the frame's args so subsequent callsame uses the new args
                     frame.args = new_args.clone();
@@ -164,44 +202,94 @@ impl Interpreter {
                     call_args,
                     owner_class,
                     method_def,
+                    rw_params,
                 )
             };
-            let (result, updated_invocant) = match &invocant {
+            // nextsame/callsame+rw chaining for methods (§D capstone): the stored
+            // method args are plain values (no varref), so without an arg source the
+            // next candidate's `is rw` param dies with X::Parameter::RW. Forward the
+            // first candidate's CURRENT rw value and name the FIRST candidate's param
+            // as the source, so the next candidate writes back into it (env-only, all
+            // method candidates run via the interpreter) and the first candidate's own
+            // exit writeback then propagates the chained result to the caller.
+            let mut rw_sources: Vec<Option<String>> = Vec::new();
+            let mut have_rw_source = false;
+            if !rw_params.is_empty() && !is_override {
+                rw_sources = vec![None; call_args.len()];
+                for (pos, first_param) in &rw_params {
+                    if *pos >= call_args.len() {
+                        continue;
+                    }
+                    if let Some(cur) = self.env.get(first_param).cloned() {
+                        call_args[*pos] = crate::runtime::types::unwrap_varref_value(cur);
+                    }
+                    rw_sources[*pos] = Some(first_param.clone());
+                    have_rw_source = true;
+                }
+            }
+            if have_rw_source {
+                self.set_pending_call_arg_sources(Some(rw_sources));
+            }
+            // The first method candidate runs as compiled bytecode (VM slots), so
+            // its exit flush reads its rw-param slot. Capture its frame code now to
+            // write the chain's final value into that slot after the redispatch.
+            let caller_code = self.current_code;
+            let dispatch_result = match &invocant {
                 Value::Instance {
                     class_name,
                     attributes,
                     id: target_id,
-                } => {
-                    let (result, updated) = self.run_instance_method_resolved(
+                } => self
+                    .run_instance_method_resolved(
                         &receiver_class,
                         &owner_class,
                         method_def,
                         attributes.to_map(),
                         call_args,
                         Some(invocant.clone()),
-                    )?;
-                    (
-                        result,
-                        Some(Value::write_back_sharing(
-                            attributes,
-                            *class_name,
-                            updated,
-                            *target_id,
-                        )),
                     )
-                }
-                _ => {
-                    let (result, _) = self.run_instance_method_resolved(
+                    .map(|(result, updated)| {
+                        (
+                            result,
+                            Some(Value::write_back_sharing(
+                                attributes,
+                                *class_name,
+                                updated,
+                                *target_id,
+                            )),
+                        )
+                    }),
+                _ => self
+                    .run_instance_method_resolved(
                         &receiver_class,
                         &owner_class,
                         method_def,
                         HashMap::new(),
                         call_args,
                         Some(invocant.clone()),
-                    )?;
-                    (result, None)
-                }
+                    )
+                    .map(|(result, _)| (result, None)),
             };
+            if have_rw_source {
+                self.set_pending_call_arg_sources(None);
+            }
+            let (result, updated_invocant) = dispatch_result?;
+            // Write the chain's final value (now in env under each first-candidate
+            // param name) back into the first (compiled) candidate's VM local slot
+            // so its exit flush propagates it instead of its own pre-nextsame value.
+            if caller_code != 0 && have_rw_source {
+                // SAFETY: caller_code is the address of the CompiledCode of the
+                // first (compiled) method candidate, the live ancestor frame
+                // currently executing this nextsame/callsame.
+                let code = unsafe { &*(caller_code as *const crate::opcode::CompiledCode) };
+                for (_pos, first_param) in &rw_params {
+                    if let Some(slot) = code.locals.iter().position(|n| n == first_param)
+                        && let Some(val) = self.env.get(first_param).cloned()
+                    {
+                        self.locals[slot] = val;
+                    }
+                }
+            }
             if let Some(new_invocant) = updated_invocant
                 && let Some(frame) = self.method_dispatch_stack.get_mut(frame_idx)
             {
@@ -216,8 +304,49 @@ impl Interpreter {
             return Ok(result);
         }
         // Try multi dispatch stack
-        if let Some((_name, candidates, orig_args)) = self.multi_dispatch_stack.last().cloned() {
-            let call_args = override_args.unwrap_or(orig_args);
+        if let Some((_name, candidates, orig_args, rw_params)) =
+            self.multi_dispatch_stack.last().cloned()
+        {
+            let is_override = override_args.is_some();
+            let mut call_args = override_args.unwrap_or(orig_args);
+            // nextsame/callsame+rw chaining (§D capstone): forward each scalar rw
+            // param's CURRENT value (it was mutated by the first candidate's body
+            // before it called nextsame) to the next candidate, and record the
+            // caller source + first candidate slot so the chain's final value is
+            // written back into the first (compiled) candidate's VM local slot —
+            // its exit flush reads that slot, so without this the first
+            // candidate's own pre-nextsame value clobbers the chained result.
+            let caller_code = self.current_code;
+            let mut rw_writebacks: Vec<(String, String)> = Vec::new();
+            let mut rw_sources: Vec<Option<String>> = Vec::new();
+            let mut have_rw_source = false;
+            if !rw_params.is_empty() && !is_override {
+                rw_sources = vec![None; call_args.len()];
+                for (pos, first_param) in &rw_params {
+                    let Some(arg) = call_args.get(*pos).cloned() else {
+                        continue;
+                    };
+                    let caller_source =
+                        crate::runtime::types::indexed_varref_from_value(&arg).map(|(n, _, _)| n);
+                    // The first candidate's live (body-mutated) param value.
+                    if let Some(cur) = self.env.get(first_param).cloned() {
+                        call_args[*pos] =
+                            match crate::runtime::types::indexed_varref_from_value(&arg) {
+                                Some((name, _, index)) => {
+                                    crate::runtime::types::make_varref_value(name, cur, index)
+                                }
+                                None => cur,
+                            };
+                    }
+                    if let Some(src) = caller_source {
+                        if *pos < rw_sources.len() {
+                            rw_sources[*pos] = Some(src.clone());
+                        }
+                        rw_writebacks.push((src, first_param.clone()));
+                        have_rw_source = true;
+                    }
+                }
+            }
             // Find the first candidate whose signature matches the (possibly new) args.
             let mut matched_idx = None;
             for (i, cand) in candidates.iter().enumerate() {
@@ -239,8 +368,43 @@ impl Interpreter {
             let next_def = candidates[idx].clone();
             let remaining = candidates[idx + 1..].to_vec();
             let stack_len = self.multi_dispatch_stack.len();
-            self.multi_dispatch_stack[stack_len - 1] = (_name, remaining, call_args.clone());
-            let result = self.call_function_def(&next_def, &call_args)?;
+            // Keep rw_params fixed: it always identifies the FIRST candidate's
+            // slots, even as the chain advances through later candidates.
+            self.multi_dispatch_stack[stack_len - 1] =
+                (_name, remaining, call_args.clone(), rw_params.clone());
+            if have_rw_source {
+                self.set_pending_call_arg_sources(Some(rw_sources));
+            }
+            let result = self.call_function_def(&next_def, &call_args);
+            if have_rw_source {
+                self.set_pending_call_arg_sources(None);
+            }
+            let result = result?;
+            // Write the chain's final value (now in env under each caller source)
+            // back into the first candidate's VM local slot so its exit flush
+            // propagates it instead of its own pre-nextsame value.
+            if !rw_writebacks.is_empty() {
+                // SAFETY: caller_code is the address of the CompiledCode of the
+                // first (compiled) candidate, which is the live ancestor frame
+                // currently executing this nextsame/callsame.
+                let code = (caller_code != 0)
+                    .then(|| unsafe { &*(caller_code as *const crate::opcode::CompiledCode) });
+                for (caller_source, first_param) in &rw_writebacks {
+                    let Some(val) = self.env.get(caller_source).cloned() else {
+                        continue;
+                    };
+                    // Update the first candidate's param both as a VM local slot
+                    // (its exit flush reads the slot) and in env (a callsame body
+                    // that resumes after the redispatch may read the param by
+                    // name), so the chain's final value survives both routes.
+                    if let Some(code) = code
+                        && let Some(slot) = code.locals.iter().position(|n| n == first_param)
+                    {
+                        self.locals[slot] = val.clone();
+                    }
+                    self.env.insert(first_param.clone(), val);
+                }
+            }
             if tail_call {
                 return Err(RuntimeError {
                     return_value: Some(result),
@@ -302,7 +466,9 @@ impl Interpreter {
         // Check method dispatch stack
         // (not yet implemented for methods — return Nil)
         // Check multi dispatch stack
-        let Some((_name, candidates, orig_args)) = self.multi_dispatch_stack.last().cloned() else {
+        let Some((_name, candidates, orig_args, rw_params)) =
+            self.multi_dispatch_stack.last().cloned()
+        else {
             return Ok(Value::Nil);
         };
         // Find the first candidate that matches the original arguments,
@@ -323,7 +489,7 @@ impl Interpreter {
         // Remove this candidate and all before it from the remaining list
         let remaining = candidates[idx + 1..].to_vec();
         let stack_len = self.multi_dispatch_stack.len();
-        self.multi_dispatch_stack[stack_len - 1] = (_name, remaining, orig_args);
+        self.multi_dispatch_stack[stack_len - 1] = (_name, remaining, orig_args, rw_params);
         // Return as a callable Sub value
         Ok(Value::make_sub(
             next_def.package,

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -402,8 +402,14 @@ impl Interpreter {
                 .collect();
             let pushed_dispatch = !remaining.is_empty();
             if pushed_dispatch {
-                self.multi_dispatch_stack
-                    .push((name.to_string(), remaining, args.to_vec()));
+                let rw_params =
+                    super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs);
+                self.multi_dispatch_stack.push((
+                    name.to_string(),
+                    remaining,
+                    args.to_vec(),
+                    rw_params,
+                ));
             }
             self.samewith_context_stack.push((name.to_string(), None));
             if def.empty_sig && !args.is_empty() {

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -848,11 +848,15 @@ impl Interpreter {
             self.samewith_context_stack
                 .push((method_name.to_string(), Some(invocant_for_dispatch.clone())));
             if pushed_dispatch {
+                let rw_params = super::builtins_dispatch_next::rw_scalar_positional_params(
+                    &method_def.param_defs,
+                );
                 self.method_dispatch_stack.push(MethodDispatchFrame {
                     receiver_class: receiver_class_name.to_string(),
                     invocant: invocant_for_dispatch,
                     args: args.clone(),
                     remaining,
+                    rw_params,
                 });
             }
             let mut orig_env = crate::env::Env::new();
@@ -913,11 +917,14 @@ impl Interpreter {
         self.samewith_context_stack
             .push((method_name.to_string(), Some(invocant_for_dispatch.clone())));
         if pushed_dispatch {
+            let rw_params =
+                super::builtins_dispatch_next::rw_scalar_positional_params(&method_def.param_defs);
             self.method_dispatch_stack.push(MethodDispatchFrame {
                 receiver_class: receiver_class_name.to_string(),
                 invocant: invocant_for_dispatch,
                 args: args.clone(),
                 remaining,
+                rw_params,
             });
         }
         // Check for `is DEPRECATED` trait on the method

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1635,8 +1635,14 @@ impl Interpreter {
         let remaining = self.resolve_remaining_proto_candidates(&proto_name, &args, &def);
         let pushed_dispatch = !remaining.is_empty();
         if pushed_dispatch {
-            self.multi_dispatch_stack
-                .push((proto_name.clone(), remaining, args.clone()));
+            let rw_params =
+                super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs);
+            self.multi_dispatch_stack.push((
+                proto_name.clone(),
+                remaining,
+                args.clone(),
+                rw_params,
+            ));
         }
         self.samewith_context_stack.push((proto_name.clone(), None));
         self.routine_stack.push(RoutineFrame {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -405,12 +405,22 @@ pub(crate) struct ProtoMethodCtx {
     pub(crate) invocant: Value,
 }
 
+/// One entry of `multi_dispatch_stack`: (function_name, remaining_candidates,
+/// original_args, first_candidate_rw_params). See the field doc on
+/// `Interpreter::multi_dispatch_stack`.
+type MultiDispatchEntry = (String, Vec<FunctionDef>, Vec<Value>, Vec<(usize, String)>);
+
 #[derive(Debug, Clone)]
 struct MethodDispatchFrame {
     receiver_class: String,
     invocant: Value,
     args: Vec<Value>,
     remaining: Vec<(String, MethodDef)>,
+    /// The FIRST (winning) candidate's scalar `is rw`/`is raw` positional params
+    /// as (positional_arg_index, sigil-less_param_name). Stays fixed across the
+    /// MRO chain so a `nextsame`+rw redispatch can forward the rw param's current
+    /// value and route the next candidate's writeback through it (§D capstone).
+    rw_params: Vec<(usize, String)>,
 }
 
 /// Frame for navigating through wrapper chain during callsame/callwith.
@@ -1136,8 +1146,15 @@ pub struct Interpreter {
     /// Set when reading a Proxy subclass attribute; consumed by subsequent .push/.pop etc.
     pub(crate) pending_proxy_subclass_attr: Option<(crate::value::ProxySubclassAttrs, String)>,
     /// Stack of remaining multi dispatch candidates for callsame/nextsame/nextcallee.
-    /// Each entry is (function_name, remaining_candidates, original_args).
-    multi_dispatch_stack: Vec<(String, Vec<FunctionDef>, Vec<Value>)>,
+    /// Each entry is (function_name, remaining_candidates, original_args,
+    /// first_candidate_rw_params). The 4th element lists the FIRST (winning,
+    /// compiled) candidate's scalar `is rw`/`is raw` positional params as
+    /// (positional_arg_index, sigil-less_param_name); it stays fixed across the
+    /// redispatch chain so a `nextsame`+rw redispatch can (a) pass the rw param's
+    /// CURRENT value to the next candidate and (b) write the chain's final value
+    /// back into the first candidate's VM local slot, instead of the first
+    /// candidate's exit flush clobbering it with its own stale value (§D capstone).
+    multi_dispatch_stack: Vec<MultiDispatchEntry>,
     method_dispatch_stack: Vec<MethodDispatchFrame>,
     /// Stack of samewith dispatch contexts.
     /// Each entry is (function_or_method_name, optional_invocant).

--- a/t/nextsame-rw-redispatch.t
+++ b/t/nextsame-rw-redispatch.t
@@ -1,0 +1,104 @@
+use Test;
+plan 11;
+
+# Function: nextsame chains rw write through to the next candidate (§D capstone).
+{
+    multi pr(Int $x is rw) { $x = $x + 1; nextsame }
+    multi pr($x is rw)     { $x = $x + 1000 }
+    my $v = 10;
+    pr($v);
+    is $v, 1011, 'function nextsame+rw chains both candidate writes';
+}
+
+# Function: callsame returns, then the first candidate continues and sees the
+# chained value in its rw param.
+{
+    multi pr(Int $x is rw) { $x = $x + 1; callsame; $x = $x + 5 }
+    multi pr($x is rw)     { $x = $x + 1000 }
+    my $v = 10;
+    pr($v);
+    is $v, 1016, 'function callsame+rw continuation sees chained value';
+}
+
+# Function: three candidates chain through nextsame.
+{
+    multi tri(Int $x is rw where * < 100)   { $x = $x + 1;   nextsame }
+    multi tri(Int $x is rw where * < 10000) { $x = $x + 100; nextsame }
+    multi tri($x is rw)                     { $x = $x + 1000 }
+    my $v = 5;
+    tri($v);
+    is $v, 1106, 'function three-candidate nextsame+rw chain';
+}
+
+# Method: nextsame chains rw write (used to die X::Parameter::RW).
+{
+    class C {
+        multi method pr(Int $x is rw) { $x = $x + 1; nextsame }
+        multi method pr($x is rw)     { $x = $x + 1000 }
+    }
+    my $v = 10;
+    C.pr($v);
+    is $v, 1011, 'method nextsame+rw chains both candidate writes';
+}
+
+# Method: callsame continuation.
+{
+    class D {
+        multi method pr(Int $x is rw) { $x = $x + 1; callsame; $x = $x + 5 }
+        multi method pr($x is rw)     { $x = $x + 1000 }
+    }
+    my $v = 10;
+    D.pr($v);
+    is $v, 1016, 'method callsame+rw continuation sees chained value';
+}
+
+# Differently named rw params still chain (source routes through first param).
+{
+    multi nm(Int $a is rw) { $a = $a + 1; nextsame }
+    multi nm($b is rw)     { $b = $b + 1000 }
+    my $v = 10;
+    nm($v);
+    is $v, 1011, 'differently-named rw params chain';
+}
+
+# Non-rw nextsame is unaffected (no rw_params -> original behavior).
+{
+    multi gr(Int $x) { 'int:' ~ $x ~ ',' ~ nextsame }
+    multi gr($x)     { 'any:' ~ $x }
+    is gr(5), 'any:5', 'non-rw nextsame unchanged';
+}
+
+# callwith with new args still works (non-rw).
+{
+    multi cw(Int $x) { 'first ' ~ callwith(20) }
+    multi cw($x)     { "second:$x" }
+    is cw(3), 'first second:20', 'callwith with new args unchanged';
+}
+
+# Method non-rw nextsame unchanged.
+{
+    class M {
+        multi method foo(Int $x) { 'I' ~ $x ~ self.bar ~ nextsame }
+        multi method foo($x)     { 'A' ~ $x }
+        method bar { '-' }
+    }
+    is M.foo(7), 'A7', 'method non-rw nextsame unchanged';
+}
+
+# rw write without nextsame still propagates (single candidate path).
+{
+    multi solo(Int $x is rw) { $x = $x + 7 }
+    my $v = 3;
+    solo($v);
+    is $v, 10, 'single multi candidate rw write propagates';
+}
+
+# nextsame+rw where the first candidate also reads the value back post-callsame
+# into a returned expression.
+{
+    multi acc(Int $x is rw) { $x = $x * 2; my $r = callsame; $x = $x + $r }
+    multi acc($x is rw)     { $x = $x + 100; 7 }
+    my $v = 5;
+    acc($v);
+    is $v, 117, 'callsame return value usable alongside chained rw';
+}


### PR DESCRIPTION
## Summary

Implements the **§D(b) capstone**: `nextsame`/`callsame` now chain `is rw`
parameter writes through the multi-dispatch redispatch, for both function and
method paths.

- `multi pr(Int \$x is rw){\$x=\$x+1; nextsame} multi pr(\$x is rw){\$x=\$x+1000}`
  with `pr(\$v)` (`\$v=10`): **1011** (was 11) — function path.
- The method form: **1011** (was a `X::Parameter::RW` die).
- `callsame` continuation (first candidate resumes and reads the chained value): **1016**.
- 3-candidate chain: **1106**.

All validated against Rakudo.

## Root cause

`dispatch_next_candidate` redispatched with the entry-time value snapshot and no
arg source, so the next candidate saw the stale value and its `is rw` writeback
had nowhere to land; the first (compiled) candidate's exit flush then overwrote
the caller variable with its own pre-nextsame value (the VM-frame↔interpreter-frame
slot clobber documented in PLAN §D / the ledger).

## Fix

- `multi_dispatch_stack` (now `MultiDispatchEntry`) and `MethodDispatchFrame`
  carry the FIRST (winning, compiled) candidate's scalar rw positional params as
  `(positional_index, param_name)` — the param name locates the VM local slot and
  stays fixed across the chain. Computed via the new `rw_scalar_positional_params`.
- Before redispatch: read each rw param's CURRENT (body-mutated) value from
  `env[first_param]` and rebuild the positional arg with it.
- After redispatch: write the chain's final value back into the first candidate's
  VM local slot (via `self.current_code`) **and** `env[first_param]`, so the exit
  flush reads the chained value (not the clobber) and a resuming `callsame` body
  reads it by name.

The earlier reverted 4-tuple attempt wrote env only; the compiled exit flush
reads the local slot, which this updates. Entirely guarded by
`!rw_params.is_empty()`, so non-rw `nextsame`/`callsame`/`callwith` are
byte-identical. `nextwith`/`callwith`+rw stay out of scope (Rakudo itself rejects
a literal bound to an rw param).

## Tests

`t/nextsame-rw-redispatch.t` (11 cases, validated against raku). Local: cargo
unit tests (470), 25 dispatch-related `t/` files, roast `S06-advanced/dispatching.t`
+ `callsame.t` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)