### PR TITLE
fix(vm): multi-dimensional hash subscript read %h{a;b;c}

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -298,6 +298,14 @@
   - 13/27 pass (1-2, 12-20, 22, 24). Good `.kv` support on hashes. Failures: sub form `kv(%hash)` (3-4), `Pair.kv` (5-7), constant hash refs (8-11), rw aliases in kv (21, 23, 25). Only 25 tests reached. Difficulty: Medium
 - [ ] roast/S32-hash/map.t
 - [ ] roast/S32-hash/multislice-6e.t
+  - The multi-dim hash subscript *read* `%h{a;b;c}` (rvalue) was fixed (PR: was
+    returning Nil — `multi_dim_index_read` only handled arrays; added
+    `multi_dim_hash_read` for single key / key-slice / `*`, with missing-key→Any
+    per 6.e). 144 subtests pass now. CANNOT whitelist: blocked on (1) the `&&`
+    vs `?? !!` precedence trap in the test's expected-value expression
+    (`!$exists && !$delete ?? Any !! $result`; see memory
+    `and-ternary-precedence-trap`), and (2) the full multidim adverb suite on
+    hash subscripts (`:delete`/`:exists`/`:kv`/`:p`/`:k`).
 - [ ] roast/S32-hash/pairs.t
   - 17/26 pass (1-2, 4-10, 12-18, 20). Good `.pairs` support on hashes. Failures: element count (3, 11), rw aliases (19, 21), `:p` adverb form (22-26). Difficulty: Medium
 - [ ] roast/S32-hash/perl.t

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -124,6 +124,12 @@ impl Interpreter {
         let dim = &dims[0];
         let rest = &dims[1..];
 
+        // Hash targets index by key (string), recursing into the nested value
+        // for the remaining dimensions: `%h{"a";"b";"c"}`.
+        if let Value::Hash(map, ..) = target {
+            return self.multi_dim_hash_read(map, dim, rest);
+        }
+
         match dim {
             Value::Whatever => {
                 // Iterate all elements at this level
@@ -215,6 +221,75 @@ impl Interpreter {
                     }
                 }
             }
+        }
+    }
+
+    /// Read from a hash using one multi-dim dimension, recursing for the rest.
+    /// The dimension may be a single key (scalar), a list of keys (slice), or
+    /// `*` (all values). A missing key reads as `Nil`.
+    fn multi_dim_hash_read(
+        &mut self,
+        map: &std::collections::HashMap<String, Value>,
+        dim: &Value,
+        rest: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        // Look up one key and recurse into the nested value for `rest`.
+        // A missing key reads as the `Any` type object (raku hash semantics),
+        // and short-circuits any remaining dimensions.
+        let read_key =
+            |this: &mut Self, key: &str, rest: &[Value]| -> Result<Value, RuntimeError> {
+                match map.get(key) {
+                    Some(v) => {
+                        // Decontainerize a Scalar-wrapped nested value before recursing.
+                        let inner = match v {
+                            Value::Scalar(b) => (**b).clone(),
+                            other => other.clone(),
+                        };
+                        this.multi_dim_index_read(&inner, rest)
+                    }
+                    None => Ok(Value::Package(crate::symbol::Symbol::intern("Any"))),
+                }
+            };
+
+        match dim {
+            // `*` — all values at this level.
+            Value::Whatever => {
+                let has_more_multi = rest
+                    .iter()
+                    .any(|v| matches!(v, Value::Whatever | Value::Array(..)));
+                let mut out = Vec::with_capacity(map.len());
+                for v in map.values() {
+                    let inner = match v {
+                        Value::Scalar(b) => (**b).clone(),
+                        other => other.clone(),
+                    };
+                    let result = self.multi_dim_index_read(&inner, rest)?;
+                    if has_more_multi && let Value::Array(items, ..) = &result {
+                        out.extend(items.iter().cloned());
+                    } else {
+                        out.push(result);
+                    }
+                }
+                Ok(Value::array(out))
+            }
+            // A list of keys — slice.
+            Value::Array(keys, ..) => {
+                let has_more_multi = rest
+                    .iter()
+                    .any(|v| matches!(v, Value::Whatever | Value::Array(..)));
+                let mut out = Vec::with_capacity(keys.len());
+                for key in keys.iter() {
+                    let result = read_key(self, &key.to_string_value(), rest)?;
+                    if has_more_multi && let Value::Array(items, ..) = &result {
+                        out.extend(items.iter().cloned());
+                    } else {
+                        out.push(result);
+                    }
+                }
+                Ok(Value::array(out))
+            }
+            // A single key.
+            _ => read_key(self, &dim.to_string_value(), rest),
         }
     }
 

--- a/t/multidim-hash-read.t
+++ b/t/multidim-hash-read.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Reading a multi-dimensional hash subscript `%h{a;b;c}` (the rvalue side).
+# Assignment already worked, but the read previously returned Nil because the
+# MultiDimIndex read path only handled arrays. Matches raku 6.e semantics: an
+# all-scalar-keys read yields the scalar leaf, a missing key reads as `Any`.
+
+plan 12;
+
+my %h;
+%h{"a";"b";"c"} = 42;
+%h{"a";"b";"d"} = 7;
+
+is %h{"a";"b";"c"}, 42, 'nested 3-level scalar read';
+is %h{"a";"b";"d"}, 7, 'sibling nested key read';
+
+# Reading a partial path returns the nested hash.
+is-deeply %h{"a";"b"}.keys.sort, ("c", "d").Seq, 'partial path returns nested hash';
+
+# Missing keys read as the Any type object (not Nil).
+ok %h{"a";"b";"x"} === Any, 'missing leaf key reads as Any';
+ok %h{"a";"x";"c"} === Any, 'missing mid key reads as Any';
+ok %h{"x";"y";"z"} === Any, 'missing top key reads as Any';
+
+# Slices: a list of keys at the final dimension.
+is-deeply %h{"a";"b";("c","d")}, (42, 7), 'final-dimension key slice';
+is-deeply %h{"a";"b";("c","x")}, (42, Any), 'slice with a missing key fills Any';
+
+# `*` reads all values at a level.
+is-deeply %h{"a";"b";*}.sort, (7, 42), 'whatever reads all values at a level';
+
+# Single-level still behaves.
+my %flat = a => 1, b => 2, c => 3;
+is %flat{"b"}, 2, 'single-dimension scalar read unaffected';
+is-deeply %flat{"a","c"}, (1, 3), 'single-dimension slice unaffected';
+
+# Deeper nesting.
+my %deep;
+%deep{"p";"q";"r";"s"} = "leaf";
+is %deep{"p";"q";"r";"s"}, "leaf", '4-level nested read';


### PR DESCRIPTION
## Summary

Reading a multi-dimensional hash subscript (`%h{\"a\";\"b\";\"c\"}`) returned `Nil`. The `MultiDimIndex` read path (`multi_dim_index_read`) only handled arrays, so a `Hash` target fell through to the `_ => Nil` arm at every level. Assignment already worked — `%h{a;b;c} = 42` built the nested structure correctly — but the value could never be read back through the same syntax.

This adds a `multi_dim_hash_read` helper that indexes a `Hash` by key and recurses into the nested value for the remaining dimensions. It supports the three dimension shapes:

- a single key
- a list of keys (slice)
- `*` (all values at that level)

It decontainerizes `Scalar`-wrapped nested values before recursing, and a **missing key reads as the `Any` type object** (short-circuiting remaining dimensions), matching raku 6.e semantics.

## Verification

Checked against raku 6.e for: scalar reads, partial-path reads (returns the nested hash), missing-key (`Any`, shallow and deep), final-dimension key slices (including mixed present/missing → `(42, Any)`), `*` all-values, and 4-level nesting. New `t/multidim-hash-read.t` (12 assertions).

## Roast impact

Advances `roast/S32-hash/multislice-6e.t` (the previously all-`Nil` reads now return correct values). The file still **cannot** whitelist — it is gated on the `&&` vs `?? !!` precedence trap (used in the test's expected-value expression) plus the full multidim adverb suite (`:delete`/`:exists`/`:kv`/`:p`/`:k`), which are separate, deeper blockers.

No regression: `S32-array/adverbs.t` unchanged, local multidim/semicolon suites green, `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)