### PR TITLE
feat(sprintf): %s dispatches a user-defined .Str method (§B render redispatch)

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -173,9 +173,18 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
   coercion sites + `say`/`note`) use it; only the genuine lazy-force reify keeps the
   drop-on-miss `reconcile_caller_after_lazy_force` (its pending entries are always its own
   callee's).
-  **Remaining same-shape sites (deferred, lower traffic):** `sprintf`/`.fmt` `%s`
-  formatting drops the `.Str` writeback too (it also calls `.Str` a surprising number of
-  times — a separate count quirk that complicates a clean pin); and `value ~~ $instance`
+  **`sprintf` `%s` user-`.Str` dispatch — DONE (#TBD).** `sprintf("%s", $obj)` rendered the
+  object's `.gist` (`S()`) instead of dispatching a user-defined `.Str` (Rakudo → the
+  `.Str` result). `builtin_sprintf` is now `&mut self` and pre-stringifies each `%s`-directive
+  Instance/Package arg (located via the new `sprintf_str_arg_indices` directive walk) by
+  calling its user `.Str` (`.Str` only — Rakudo `%s` does NOT use `.Stringy`; verified the
+  gist falls through). The captured-outer writeback drains through the surrounding `sprintf`
+  call op's existing `apply_pending_rw_writeback`, so no manual drain is needed (the runtime
+  builtin records the write; the VM call op consumes it). mutsu calls `.Str` once per use;
+  Rakudo's double-call-per-sprintf quirk is not reproduced (pin asserts the value + that the
+  write propagates, not the exact count). pin=`t/sprintf-user-str-dispatch.t`(8, raku-validated).
+  **Remaining same-shape sites (deferred, lower traffic):** `.fmt` `%s`
+  formatting drops the `.Str` writeback too; and `value ~~ $instance`
   / `$instance ~~ (key => …)` do not even *dispatch* the user `ACCEPTS`/key method today
   (`smart_match` bottoms out at `(_, Instance) => false`), so they are a missing-dispatch
   bug, not a writeback one — out of scope for this slice.

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -10,7 +10,7 @@ impl Interpreter {
     // method, the single source of truth in methods_0arg/dispatch_core_unicode).
     // flip / lc / uc / tc / trim / chars removed (Slice 6.3 dedup) — same.
     pub(super) fn builtin_sprintf(
-        &self,
+        &mut self,
         args: &[Value],
         z_mode: bool,
     ) -> Result<Value, RuntimeError> {
@@ -21,22 +21,47 @@ impl Interpreter {
         // Flatten array arguments (Raku: sprintf("%d", [42]) treats array elements as args)
         let rest = &args[1..];
         let flattened: Vec<Value>;
-        let actual_args = if rest.len() == 1 {
+        let mut actual_args: Vec<Value> = if rest.len() == 1 {
             if let Value::Array(items, ..) = &rest[0] {
                 flattened = items.as_ref().clone().items;
-                &flattened
+                flattened
             } else {
-                rest
+                rest.to_vec()
             }
         } else {
-            rest
+            rest.to_vec()
         };
         super::sprintf::validate_sprintf_directives(&fmt, actual_args.len())?;
-        super::sprintf::validate_sprintf_arg_types(&fmt, actual_args)?;
+        super::sprintf::validate_sprintf_arg_types(&fmt, &actual_args)?;
+        // A `%s` directive stringifies via `.Str` (Raku uses `.Str` only — not
+        // `.Stringy`); the pure formatter only knows `to_string_value`/`.gist`,
+        // so dispatch a user-defined `Str` method on Instance/Package args first
+        // and substitute the result. Any captured-outer write the method makes is
+        // recorded for the surrounding `sprintf` call op's
+        // `apply_pending_rw_writeback` to drain into the caller's slot (same as
+        // every other user-method call).
+        for idx in super::sprintf::sprintf_str_arg_indices(&fmt) {
+            let Some(arg) = actual_args.get(idx) else {
+                continue;
+            };
+            let class_name = match arg {
+                Value::Instance { class_name, .. } => Some(class_name.resolve().to_string()),
+                Value::Package(name) => Some(name.resolve().to_string()),
+                _ => None,
+            };
+            let Some(cn) = class_name else { continue };
+            if !self.has_user_method(&cn, "Str") {
+                continue;
+            }
+            let arg_clone = actual_args[idx].clone();
+            if let Ok(v) = self.call_method_with_values(arg_clone, "Str", vec![]) {
+                actual_args[idx] = Value::str(v.to_string_value());
+            }
+        }
         let rendered = if z_mode {
-            super::sprintf::format_zprintf_args(&fmt, actual_args)
+            super::sprintf::format_zprintf_args(&fmt, &actual_args)
         } else {
-            super::sprintf::format_sprintf_args(&fmt, actual_args)
+            super::sprintf::format_sprintf_args(&fmt, &actual_args)
         };
         Ok(Value::str(rendered))
     }

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -6,8 +6,8 @@ use super::sprintf_helpers::{
     format_rat_fixed, normalize_sci_exponent, sign_prefix,
 };
 pub(crate) use super::sprintf_validate::{
-    directives_count_message, sprintf_directive_count, validate_sprintf_arg_types,
-    validate_sprintf_directives,
+    directives_count_message, sprintf_directive_count, sprintf_str_arg_indices,
+    validate_sprintf_arg_types, validate_sprintf_directives,
 };
 
 pub(crate) fn format_sprintf(fmt: &str, arg: Option<&Value>) -> String {

--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -387,3 +387,90 @@ pub(crate) fn validate_sprintf_arg_types(fmt: &str, args: &[Value]) -> Result<()
     }
     Ok(())
 }
+
+/// Collect the argument indices consumed by `%s` (string) directives, so the
+/// caller can dispatch a user-defined `.Str`/`.Stringy` method on Instance args
+/// before the pure formatter (which only knows `to_string_value`/`.gist`) runs.
+/// Mirrors `validate_sprintf_arg_types`' directive walk (flags/width/precision/
+/// `*`/positional `N$`), returning the effective arg index for each `s` spec.
+pub(crate) fn sprintf_str_arg_indices(fmt: &str) -> Vec<usize> {
+    let bytes = fmt.as_bytes();
+    let len = bytes.len();
+    let mut pos = 0usize;
+    let mut arg_index = 0usize;
+    let mut out = Vec::new();
+    while pos < len {
+        if bytes[pos] != b'%' {
+            pos += 1;
+            continue;
+        }
+        pos += 1;
+        if pos < len && bytes[pos] == b'%' {
+            pos += 1;
+            continue;
+        }
+        let mut positional_arg: Option<usize> = None;
+        {
+            let start = pos;
+            while pos < len && bytes[pos].is_ascii_digit() {
+                pos += 1;
+            }
+            if pos > start && pos < len && bytes[pos] == b'$' {
+                let n: usize = fmt[start..pos].parse().unwrap_or(1);
+                positional_arg = Some(n - 1);
+                pos += 1;
+            } else {
+                pos = start;
+            }
+        }
+        // Skip flags
+        while pos < len {
+            let b = bytes[pos];
+            if b == b'-' || b == b'+' || b == b' ' || b == b'#' || b == b'0' {
+                pos += 1;
+            } else {
+                break;
+            }
+        }
+        // Skip width (a `*` consumes an arg)
+        if pos < len && bytes[pos] == b'*' {
+            pos += 1;
+            if positional_arg.is_none() {
+                arg_index += 1;
+            }
+        } else {
+            while pos < len && bytes[pos].is_ascii_digit() {
+                pos += 1;
+            }
+        }
+        // Skip precision (a `.*` consumes an arg)
+        if pos < len && bytes[pos] == b'.' {
+            pos += 1;
+            if pos < len && bytes[pos] == b'*' {
+                pos += 1;
+                if positional_arg.is_none() {
+                    arg_index += 1;
+                }
+            } else {
+                while pos < len && bytes[pos].is_ascii_digit() {
+                    pos += 1;
+                }
+            }
+        }
+        let spec = if pos < len {
+            let s = fmt[pos..].chars().next().unwrap();
+            pos += s.len_utf8();
+            s
+        } else {
+            '?'
+        };
+        let effective_index = positional_arg.unwrap_or(arg_index);
+        if spec == 's' {
+            out.push(effective_index);
+        }
+        if positional_arg.is_none() {
+            arg_index += 1;
+        }
+    }
+    out
+}

--- a/t/sprintf-user-str-dispatch.t
+++ b/t/sprintf-user-str-dispatch.t
@@ -1,0 +1,50 @@
+use Test;
+plan 8;
+
+# sprintf %s dispatches a user-defined .Str method (was rendering the .gist).
+{
+    class S1 { method Str { "CUSTOM" } }
+    is sprintf("%s", S1.new), "CUSTOM", '%s dispatches user .Str';
+}
+
+# %s with width/flags still routes through user .Str.
+{
+    class S2 { method Str { "ab" } }
+    is sprintf("%5s", S2.new), "   ab", '%s with width uses user .Str';
+    is sprintf("%-5s|", S2.new), "ab   |", '%s left-justified uses user .Str';
+}
+
+# When a class defines BOTH, %s uses .Str (not .Stringy).
+{
+    class GB { method Str { "viaStr" }; method Stringy { "viaStringy" } }
+    is sprintf("%s", GB.new), "viaStr", '%s uses .Str, not .Stringy';
+}
+
+# Multiple %s args each dispatch.
+{
+    class A { method Str { "A" } }
+    class B { method Str { "B" } }
+    is sprintf("%s-%s", A.new, B.new), "A-B", 'multiple %s args dispatch';
+}
+
+# Positional %s ($) dispatches.
+{
+    class P { method Str { "P" } }
+    is sprintf('%1$s%1$s', P.new), "PP", 'positional %s dispatches';
+}
+
+# The captured-outer write inside .Str propagates back to the caller's slot
+# (writeback coherence — the surrounding sprintf op drains it).
+{
+    my $calls = 0;
+    class C { method Str { $calls++; "x" } }
+    my $c = C.new;
+    sprintf("%s", $c);
+    sprintf("%s", $c);
+    ok $calls >= 2, 'user .Str captured-outer write propagates across sprintf calls';
+}
+
+# %d is unaffected by the %s coercion (only %s args are pre-stringified).
+{
+    is sprintf("%d", 42), "42", '%d numeric formatting unaffected';
+}


### PR DESCRIPTION
## Summary

`sprintf("%s", \$obj)` rendered the object's `.gist` (e.g. `S()`) instead of
dispatching a user-defined `.Str` method — diverging from Rakudo. `put`/`print`/
interpolation already dispatch user `.Str` (treewalk-removal Slice 1b); `sprintf`
was the deferred same-shape site.

```raku
class S { method Str { "CUSTOM" } }
say sprintf("%s", S.new);   # was: S()   now: CUSTOM   (raku: CUSTOM)
```

## Changes

- New `sprintf_str_arg_indices` walks the format's directives (flags / width /
  precision / `*` / positional `N$`) and returns the arg indices consumed by `%s`.
- `builtin_sprintf` is now `&mut self`: for each `%s` Instance/Package arg whose
  class defines a user `Str` method, it calls `.Str` and substitutes the result
  before the pure formatter runs. **`.Str` only** — Rakudo `%s` does not use
  `.Stringy` (verified: a `.Stringy`-only object renders its gist).
- The captured-outer write a user `.Str` makes drains through the surrounding
  `sprintf` call op's existing `apply_pending_rw_writeback`.

`native_sprintf` already routes Instance args to the interpreter path, so the fast
path is unchanged. `%d`/other directives are untouched.

## Tests

`t/sprintf-user-str-dispatch.t` (8 cases, validated against raku). Existing
sprintf/printf/fmt suite (`format-class`, `native-sprintf`, `sprintf-c-flags`,
`str-sprintf-method`, …) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)