### PR TITLE
feat(smartmatch): $x ~~ $obj dispatches a user-defined ACCEPTS method

### DIFF
--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -46,6 +46,24 @@ impl Interpreter {
         match (left, right) {
             // Whatever on RHS always matches (ACCEPTS returns True for any value)
             (_, Value::Whatever) => true,
+            // `$x ~~ $obj` where $obj's class defines a user `ACCEPTS` method
+            // dispatches `$obj.ACCEPTS($x)` — the core smartmatch protocol.
+            // Built-in types (IO::Path / Signature / Buf / Date…) carry native
+            // ACCEPTS semantics in the specific arms below and report no *user*
+            // method here, so they are unaffected. Junction LHS is excluded so
+            // junction autothreading (the arm below) still wins.
+            (_, Value::Instance { class_name, .. })
+                if !matches!(left, Value::Junction { .. })
+                    && self.has_user_method(&class_name.resolve(), "ACCEPTS") =>
+            {
+                match self.call_method_with_values(right.clone(), "ACCEPTS", vec![left.clone()]) {
+                    Ok(v) => v.truthy(),
+                    Err(e) => {
+                        self.set_pending_dispatch_error(e);
+                        false
+                    }
+                }
+            }
             (
                 Value::Instance {
                     class_name: left_class,

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -578,6 +578,24 @@ impl Interpreter {
     /// Perform a smart match, trying pure value matching first, falling back to
     /// the interpreter for complex cases (regex, callable, type checks, etc.).
     pub(super) fn vm_smart_match(&mut self, left: &Value, right: &Value) -> bool {
+        // `$x ~~ $obj` where $obj's class defines a user `ACCEPTS` dispatches
+        // `$obj.ACCEPTS($x)` — the core smartmatch protocol. Check this BEFORE
+        // `pure_smart_match`, whose generic Instance~~Instance arm would otherwise
+        // short-circuit to an identity check and never reach the dispatch. Junction
+        // LHS is excluded so junction autothreading still applies. Mirrors the
+        // interpreter `smart_match` arm (the grep/given paths reach that one).
+        if let Value::Instance { class_name, .. } = right
+            && !matches!(left, Value::Junction { .. })
+            && self.has_user_method(&class_name.resolve(), "ACCEPTS")
+        {
+            match self.call_method_with_values(right.clone(), "ACCEPTS", vec![left.clone()]) {
+                Ok(v) => return v.truthy(),
+                Err(e) => {
+                    self.set_pending_dispatch_error(e);
+                    return false;
+                }
+            }
+        }
         // Try pure matching first
         if let Some(result) = pure_smart_match(left, right) {
             return result;

--- a/t/smartmatch-user-accepts.t
+++ b/t/smartmatch-user-accepts.t
@@ -1,0 +1,48 @@
+use Test;
+plan 12;
+
+# `$x ~~ $obj` dispatches a user-defined ACCEPTS method (the smartmatch protocol).
+{
+    class Even { method ACCEPTS($x) { $x %% 2 } }
+    my $e = Even.new;
+    ok  (4 ~~ $e), 'value ~~ obj uses user ACCEPTS (true)';
+    nok (5 ~~ $e), 'value ~~ obj uses user ACCEPTS (false)';
+    nok (4 !~~ $e), '!~~ negates user ACCEPTS';
+    ok  (5 !~~ $e), '!~~ negates user ACCEPTS (true)';
+    is  ((1..6).grep($e)).Str, '2 4 6', 'grep uses user ACCEPTS';
+}
+
+# given/when dispatches user ACCEPTS.
+{
+    class Big { method ACCEPTS($x) { $x > 100 } }
+    my $b = Big.new;
+    my $r = do given 50 {
+        when $b { "big" }
+        default { "small" }
+    };
+    is $r, "small", 'given/when uses user ACCEPTS';
+}
+
+# Instance ~~ Instance dispatches RHS.ACCEPTS(LHS), not identity.
+{
+    class Tag { has $.t; method ACCEPTS($x) { $x.t eq $.t } }
+    ok  (Tag.new(t=>"a") ~~ Tag.new(t=>"a")), 'Instance~~Instance uses ACCEPTS (match)';
+    nok (Tag.new(t=>"a") ~~ Tag.new(t=>"b")), 'Instance~~Instance uses ACCEPTS (no match)';
+}
+
+# A class WITHOUT ACCEPTS keeps identity / type semantics.
+{
+    class Plain { }
+    my $p = Plain.new;
+    ok ($p ~~ $p),    'no-ACCEPTS class: identity holds';
+    ok ($p ~~ Plain), 'no-ACCEPTS class: type match holds';
+    nok ($p ~~ Plain.new), 'no-ACCEPTS class: distinct instances differ';
+}
+
+# ACCEPTS receives the LHS value as its argument.
+{
+    class Recorder { has @.seen is rw; method ACCEPTS($x) { @!seen.push($x); True } }
+    my $r = Recorder.new;
+    1 ~~ $r;
+    ok (1 ~~ $r), 'ACCEPTS receives the LHS argument';
+}


### PR DESCRIPTION
## Summary

`value ~~ \$instance` (and `\$instance ~~ \$instance`) never dispatched a
user-defined `ACCEPTS` method — smartmatch bottomed out at an identity check, so
`7 ~~ Even.new` returned `False` where Rakudo calls `Even.new.ACCEPTS(7)`.

```raku
class Even { method ACCEPTS($x) { $x %% 2 } }
say 4 ~~ Even.new;   # was: False   now: True   (raku: True)
say (1..6).grep(Even.new);   # was: ()   now: (2 4 6)
```

This is the core smartmatch protocol: `$x ~~ $y` calls `$y.ACCEPTS($x)`.

## Changes

- `vm_smart_match`: before `pure_smart_match` (whose generic Instance~~Instance arm
  short-circuits to identity), dispatch `$obj.ACCEPTS($x)` when the RHS class
  defines a user `ACCEPTS`.
- interpreter `smart_match`: same guarded arm near the top of the match, for the
  paths that reach it directly (`grep`, `given`/`when`).

Junction LHS is excluded so junction autothreading still wins. Built-in types
(IO::Path / Signature / Buf / Date…) have native ACCEPTS semantics in their own
arms and report no *user* method, so they are unaffected; a class without
`ACCEPTS` keeps identity / type-object semantics.

## Tests

`t/smartmatch-user-accepts.t` (12 cases, validated against raku). Existing
smartmatch / given-when / match / react suite (33 files, 298 subtests) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)