### PR TITLE
feat(sprintf): numeric directives dispatch user .Int / .Numeric

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -183,6 +183,12 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
   builtin records the write; the VM call op consumes it). mutsu calls `.Str` once per use;
   Rakudo's double-call-per-sprintf quirk is not reproduced (pin asserts the value + that the
   write propagates, not the exact count). pin=`t/sprintf-user-str-dispatch.t`(8, raku-validated).
+  **`sprintf` numeric directives — DONE (#TBD).** Generalized the same mechanism to numeric
+  directives: integer (`%d %i %u %b %o %x %X %c`) → user `.Int`, float (`%e %f %g`) →
+  user `.Numeric` (the `sprintf_str_arg_indices` helper became `sprintf_arg_specs`, returning
+  `(arg_index, spec)`). `%d` prefers `.Int` over `.Numeric` (Rakudo behavior). The coerced
+  numeric value (not a string) replaces the arg so the formatter renders it. pin=
+  `t/sprintf-numeric-coerce.t`(10, raku-validated).
   **Remaining same-shape sites (deferred, lower traffic):** `.fmt` `%s`
   formatting drops the `.Str` writeback too; and `value ~~ $instance`
   / `$instance ~~ (key => …)` do not even *dispatch* the user `ACCEPTS`/key method today

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -33,14 +33,16 @@ impl Interpreter {
         };
         super::sprintf::validate_sprintf_directives(&fmt, actual_args.len())?;
         super::sprintf::validate_sprintf_arg_types(&fmt, &actual_args)?;
-        // A `%s` directive stringifies via `.Str` (Raku uses `.Str` only — not
-        // `.Stringy`); the pure formatter only knows `to_string_value`/`.gist`,
-        // so dispatch a user-defined `Str` method on Instance/Package args first
-        // and substitute the result. Any captured-outer write the method makes is
-        // recorded for the surrounding `sprintf` call op's
-        // `apply_pending_rw_writeback` to drain into the caller's slot (same as
-        // every other user-method call).
-        for idx in super::sprintf::sprintf_str_arg_indices(&fmt) {
+        // The pure formatter only knows `to_string_value`/`.gist`/numeric unbox,
+        // so a directive whose arg is a user object must first dispatch the user's
+        // coercion method matching the directive: `%s` → `.Str` (Raku uses `.Str`
+        // only, not `.Stringy`); integer directives (`%d %i %u %b %o %x %X %c`) →
+        // `.Int`; float directives (`%e %f %g`) → `.Numeric`. The coerced value
+        // replaces the arg (a string for `%s`, the numeric value otherwise). Any
+        // captured-outer write the method makes is recorded for the surrounding
+        // `sprintf` call op's `apply_pending_rw_writeback` to drain into the
+        // caller's slot (same as every other user-method call).
+        for (idx, spec) in super::sprintf::sprintf_arg_specs(&fmt) {
             let Some(arg) = actual_args.get(idx) else {
                 continue;
             };
@@ -50,12 +52,22 @@ impl Interpreter {
                 _ => None,
             };
             let Some(cn) = class_name else { continue };
-            if !self.has_user_method(&cn, "Str") {
+            let method = match spec.to_ascii_lowercase() {
+                's' => "Str",
+                'd' | 'i' | 'u' | 'b' | 'o' | 'x' | 'c' => "Int",
+                'e' | 'f' | 'g' => "Numeric",
+                _ => continue,
+            };
+            if !self.has_user_method(&cn, method) {
                 continue;
             }
             let arg_clone = actual_args[idx].clone();
-            if let Ok(v) = self.call_method_with_values(arg_clone, "Str", vec![]) {
-                actual_args[idx] = Value::str(v.to_string_value());
+            if let Ok(v) = self.call_method_with_values(arg_clone, method, vec![]) {
+                actual_args[idx] = if method == "Str" {
+                    Value::str(v.to_string_value())
+                } else {
+                    v
+                };
             }
         }
         let rendered = if z_mode {

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -6,7 +6,7 @@ use super::sprintf_helpers::{
     format_rat_fixed, normalize_sci_exponent, sign_prefix,
 };
 pub(crate) use super::sprintf_validate::{
-    directives_count_message, sprintf_directive_count, sprintf_str_arg_indices,
+    directives_count_message, sprintf_arg_specs, sprintf_directive_count,
     validate_sprintf_arg_types, validate_sprintf_directives,
 };
 

--- a/src/runtime/sprintf_validate.rs
+++ b/src/runtime/sprintf_validate.rs
@@ -388,12 +388,14 @@ pub(crate) fn validate_sprintf_arg_types(fmt: &str, args: &[Value]) -> Result<()
     Ok(())
 }
 
-/// Collect the argument indices consumed by `%s` (string) directives, so the
-/// caller can dispatch a user-defined `.Str`/`.Stringy` method on Instance args
-/// before the pure formatter (which only knows `to_string_value`/`.gist`) runs.
-/// Mirrors `validate_sprintf_arg_types`' directive walk (flags/width/precision/
-/// `*`/positional `N$`), returning the effective arg index for each `s` spec.
-pub(crate) fn sprintf_str_arg_indices(fmt: &str) -> Vec<usize> {
+/// Collect `(arg_index, conversion_spec)` for each value-consuming directive, so
+/// the caller can dispatch a user-defined coercion method on Instance/Package args
+/// before the pure formatter (which only knows `to_string_value`/`.gist`/numeric
+/// unbox) runs: `%s` → `.Str`, integer directives → `.Int`, float directives →
+/// `.Numeric`. Mirrors `validate_sprintf_arg_types`' directive walk (flags/width/
+/// precision/`*`/positional `N$`); a `*` width/precision arg is counted (so the
+/// effective index stays aligned) but reported with spec `*` for the caller to skip.
+pub(crate) fn sprintf_arg_specs(fmt: &str) -> Vec<(usize, char)> {
     let bytes = fmt.as_bytes();
     let len = bytes.len();
     let mut pos = 0usize;
@@ -465,9 +467,7 @@ pub(crate) fn sprintf_str_arg_indices(fmt: &str) -> Vec<usize> {
             '?'
         };
         let effective_index = positional_arg.unwrap_or(arg_index);
-        if spec == 's' {
-            out.push(effective_index);
-        }
+        out.push((effective_index, spec));
         if positional_arg.is_none() {
             arg_index += 1;
         }

--- a/t/sprintf-numeric-coerce.t
+++ b/t/sprintf-numeric-coerce.t
@@ -1,0 +1,48 @@
+use Test;
+plan 10;
+
+# Integer directives dispatch a user .Int method.
+{
+    class N1 { method Int { 7 } }
+    is sprintf("%d", N1.new), "7", '%d dispatches user .Int';
+}
+{
+    class N2 { method Int { 255 } }
+    is sprintf("%x", N2.new), "ff", '%x dispatches user .Int';
+    is sprintf("%o", N2.new), "377", '%o dispatches user .Int';
+    is sprintf("%b", N2.new), "11111111", '%b dispatches user .Int';
+}
+
+# Float directives dispatch a user .Numeric method.
+{
+    class F { method Numeric { 3.5 } }
+    is sprintf("%.2f", F.new), "3.50", '%f dispatches user .Numeric';
+    is sprintf("%.1e", F.new), "3.5e+00", '%e dispatches user .Numeric';
+}
+
+# %d prefers .Int when both .Int and .Numeric exist.
+{
+    class B { method Int { 9 }; method Numeric { 3.5 } }
+    is sprintf("%d", B.new), "9", '%d uses .Int over .Numeric';
+}
+
+# Width/precision still apply after coercion.
+{
+    class N3 { method Int { 42 } }
+    is sprintf("%5d", N3.new), "   42", '%d width applies after coercion';
+}
+
+# Captured-outer write inside .Int propagates across sprintf calls.
+{
+    my $calls = 0;
+    class C { method Int { $calls++; 1 } }
+    my $c = C.new;
+    sprintf("%d", $c);
+    sprintf("%d", $c);
+    ok $calls >= 2, 'user .Int captured-outer write propagates';
+}
+
+# Plain numeric args are unaffected.
+{
+    is sprintf("%d/%.1f", 10, 2.5), "10/2.5", 'plain numeric args unaffected';
+}


### PR DESCRIPTION
## Summary

Follow-up to the `%s` → user-`.Str` fix (#3630): `sprintf` numeric directives also
never dispatched a user object's coercion method, rendering `0` instead of the
coerced value.

```raku
class N { method Int { 7 } }
say sprintf("%d", N.new);     # was: 0      now: 7      (raku: 7)
class F { method Numeric { 3.5 } }
say sprintf("%.2f", F.new);   # was: 0.00   now: 3.50   (raku: 3.50)
```

## Changes

- `sprintf_str_arg_indices` → `sprintf_arg_specs`, returning `(arg_index, spec)`
  for every value-consuming directive.
- `builtin_sprintf` dispatches the directive-matched user coercion: `%s` → `.Str`,
  integer directives (`%d %i %u %b %o %x %X %c`) → `.Int`, float directives
  (`%e %f %g`) → `.Numeric`. The coerced numeric value (not a string) replaces the
  arg so the pure formatter renders it. `%d` prefers `.Int` over `.Numeric`
  (Rakudo behavior).

The captured-outer write a coercion method makes drains through the surrounding
`sprintf` call op's `apply_pending_rw_writeback`. Plain numeric args and built-in
types are unaffected.

## Tests

`t/sprintf-numeric-coerce.t` (10 cases, validated against raku). Existing
sprintf/printf/fmt suite (12 files, 164 subtests) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)