### PR TITLE
fix(smartmatch): $x ~~ (key => val) accepts ValuePair (S03 Pair smartmatch)

### DIFF
--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -898,11 +898,22 @@ impl Interpreter {
                 }
             }
             // Hash ~~ Pair: check that key exists in hash and value smartmatches
+            // Hash ~~ Pair: look up the pair's key and smartmatch the hash value
+            // against the pair value. `key => val` literals build a `ValuePair`,
+            // so accept both representations.
             (Value::Hash(map), Value::Pair(key, val)) => {
                 if let Some(hash_val) = map.get(key.as_str()) {
                     self.smart_match(hash_val, val)
                 } else {
                     // Key not in hash: compare against an undefined type object.
+                    self.smart_match(&Value::Package(Symbol::intern("Mu")), val)
+                }
+            }
+            (Value::Hash(map), Value::ValuePair(key, val)) => {
+                let key = key.to_string_value();
+                if let Some(hash_val) = map.get(&key) {
+                    self.smart_match(hash_val, val)
+                } else {
                     self.smart_match(&Value::Package(Symbol::intern("Mu")), val)
                 }
             }

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -620,6 +620,11 @@ impl Interpreter {
                     | Value::Seq(_)
                     | Value::Slip(_)
                     | Value::LazyList(_)
+                    // A Pair LHS has its own Pair-vs-Pair smartmatch (key AND value
+                    // equality), NOT method-key dispatch — `("a"=>"b") ~~ ("a"=>"b")`
+                    // must compare, not call method `a` on the left Pair.
+                    | Value::Pair(..)
+                    | Value::ValuePair(..)
             )
         {
             // Route the key-method call through the Interpreter's unified compiled-first

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -605,7 +605,14 @@ impl Interpreter {
         // to Bool, and compare with pair value coerced to Bool.
         // Per S03: ?."{X.key}" === ?X.value
         // Exclude types with their own Pair smartmatch semantics (Hash checks key+value).
-        if let Value::Pair(key, val) = right
+        // Both `Value::Pair` (string-keyed) and `Value::ValuePair` (`key => val`
+        // literals are built as ValuePair) reach here.
+        let pair_key_val = match right {
+            Value::Pair(key, val) => Some((key.clone(), val.as_ref().clone())),
+            Value::ValuePair(key, val) => Some((key.to_string_value(), val.as_ref().clone())),
+            _ => None,
+        };
+        if let Some((method_name, val)) = pair_key_val
             && !matches!(
                 left,
                 Value::Hash(_)
@@ -615,13 +622,12 @@ impl Interpreter {
                     | Value::LazyList(_)
             )
         {
-            let method_name = key.as_str();
             // Route the key-method call through the Interpreter's unified compiled-first
             // dispatch (ledger §1): user-defined methods run as compiled bytecode;
             // only native/reflective methods bottom out at the interpreter. `left`
             // is never an Array/Hash/Seq here (excluded above), so the native
             // array/list fast paths inside are inert.
-            match self.try_compiled_method_or_interpret(left.clone(), method_name, Vec::new()) {
+            match self.try_compiled_method_or_interpret(left.clone(), &method_name, Vec::new()) {
                 Ok(result) => {
                     return result.truthy() == val.truthy();
                 }

--- a/t/smartmatch-pair-method.t
+++ b/t/smartmatch-pair-method.t
@@ -1,5 +1,5 @@
 use Test;
-plan 9;
+plan 13;
 
 # `$x ~~ (key => val)` runs `$x.key` and compares booleans: ?($x.key) === ?val
 # (S03 Pair smartmatch). `key => val` literals build a ValuePair, which the
@@ -29,4 +29,18 @@ plan 9;
 {
     my %h = a => 1, b => 2;
     is (%h ~~ (a => 1)), True, 'Hash ~~ Pair checks key+value, not method';
+}
+
+# A Pair LHS uses Pair-vs-Pair equality (key AND value), NOT method-key dispatch
+# (regression: must not call method named by the RHS key on the left Pair).
+{
+    is (("a" => "b") ~~ ("a" => "b")), True,  'Pair ~~ Pair: equal key+value';
+    is (("a" => "b") ~~ ("a" => "c")), False, 'Pair ~~ Pair: differing value';
+    is (("a" => "b") ~~ ("x" => "b")), False, 'Pair ~~ Pair: differing key';
+}
+
+# A BagHash whose key is a Pair smartmatches that Pair (no method dispatch).
+{
+    my $b = BagHash.new( (a => "b") );
+    is ($b.keys[0] ~~ ("a" => "b")), True, 'BagHash Pair key ~~ Pair';
 }

--- a/t/smartmatch-pair-method.t
+++ b/t/smartmatch-pair-method.t
@@ -1,0 +1,32 @@
+use Test;
+plan 9;
+
+# `$x ~~ (key => val)` runs `$x.key` and compares booleans: ?($x.key) === ?val
+# (S03 Pair smartmatch). `key => val` literals build a ValuePair, which the
+# smartmatch Pair handler must accept (it previously only matched Value::Pair).
+{
+    is ("abc" ~~ (chars => 3)), True,  'Str ~~ (chars => 3): ?3 === ?3';
+    is ("abc" ~~ (chars => 0)), False, 'boolean semantics: ?3 === ?0 (False, 0 falsy)';
+    is ("" ~~ (chars => 5)),    False, 'empty: ?0 === ?5 is False';
+}
+
+# User object: method dispatched, boolean-compared.
+{
+    class C { has $.n; method positive { $.n > 0 } }
+    is (C.new(n=>5) ~~ (positive => True)),  True,  'obj ~~ (method => True) when method truthy';
+    is (C.new(n=>-1) ~~ (positive => True)), False, 'obj ~~ (method => True) when method falsy';
+    is (C.new(n=>-1) ~~ (positive => False)), True, 'obj ~~ (method => False) when method falsy';
+}
+
+# Numeric method returning a value, boolean-compared.
+{
+    class M { method size { 5 } }
+    is (M.new ~~ (size => 1)), True,  '?(size=5) === ?1 is True';
+    is (M.new ~~ (size => 0)), False, '?(size=5) === ?0 is False';
+}
+
+# A Hash LHS keeps its own Pair smartmatch (key+value), not method dispatch.
+{
+    my %h = a => 1, b => 2;
+    is (%h ~~ (a => 1)), True, 'Hash ~~ Pair checks key+value, not method';
+}


### PR DESCRIPTION
## Summary

`$x ~~ (key => val)` should run `$x.key` and boolean-compare (`?($x.key) === ?val`,
S03 Pair smartmatch), but `key => val` literals build a `Value::ValuePair` while the
smartmatch Pair handlers only matched `Value::Pair`.

```raku
say "abc" ~~ (chars => 3);   # was: False   now: True   (raku: True)
class C { method size { 5 } }
say C.new ~~ (size => 1);     # was: False   now: True   (raku: True)
my %h = a => 1;
say %h ~~ (a => 1);          # was: False   now: True   (raku: True)
```

## Changes

- `vm_smart_match` (the `~~` operator path): the "Any ~~ Pair" method-key handler now
  extracts `(method_name, val)` from both `Value::Pair` and `Value::ValuePair`.
- interpreter `smart_match`: added a `(Hash, ValuePair)` arm mirroring the existing
  `(Hash, Pair)` key+value check.

## Tests

`t/smartmatch-pair-method.t` (9 cases, validated against raku). Existing smartmatch /
given-when / match / hash suite (92 files, 1021 subtests) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)