### PR TITLE
fix(parser): dynamic :$delete on multi-dim subscript reads through normal path

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2934,19 +2934,26 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 if let Expr::MultiDimIndex {
                     target: mdt,
                     dimensions: dims,
-                } = expr
+                } = expr.clone()
                 {
-                    // For MultiDimIndex, pass var_name + adverb info + indices
+                    // `:$delete` is the `delete` adverb with a runtime-decided
+                    // flag. Mirror the literal `:delete($cond)` lowering: a
+                    // Ternary whose else-branch is the *original* MultiDimIndex
+                    // read (so the value path resolves the variable through the
+                    // normal opcode, seeing local slots / sub-writeback — unlike
+                    // the by-name `self.env.get` the builtin used, which missed an
+                    // outer hash assigned inside a sub).
                     let var_name = multidim_target_var_name(&mdt);
-                    let mut args = vec![
-                        Expr::Literal(Value::str(var_name)),
-                        Expr::Literal(Value::str(adverb_var.to_string())),
-                        Expr::Var(adverb_var.to_string()),
-                    ];
-                    args.extend(dims);
-                    expr = Expr::Call {
-                        name: Symbol::intern("__mutsu_multidim_dynamic_adverb"),
-                        args,
+                    let mut del_args = vec![Expr::Literal(Value::str(var_name))];
+                    del_args.extend(dims);
+                    let delete_expr = Expr::Call {
+                        name: Symbol::intern("__mutsu_multidim_delete"),
+                        args: del_args,
+                    };
+                    expr = Expr::Ternary {
+                        cond: Box::new(Expr::Var(adverb_var.to_string())),
+                        then_expr: Box::new(delete_expr),
+                        else_expr: Box::new(expr),
                     };
                 } else if matches!(&expr, Expr::Call { name, .. }
                     if name == "__mutsu_multidim_subscript_adverb"

--- a/t/multidim-dynamic-delete-adverb.t
+++ b/t/multidim-dynamic-delete-adverb.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `%h{a;b;c}:$delete` (a multi-dim subscript with a *dynamic* :delete adverb —
+# a runtime boolean rather than a literal) must read through the normal
+# subscript path when the flag is false. Previously it routed through a builtin
+# that resolved the container by name via `self.env.get`, which missed an outer
+# hash assigned inside a sub (returning Nil instead of the value).
+
+plan 5;
+
+# Hash assigned indirectly via a sub (the failure mode).
+my %hash;
+sub set-up(--> Nil) { %hash = a => { b => { c => 42 } } }
+set-up;
+
+my $no = False;
+my $r1 = %hash{"a";"b";"c"}:$no;
+is $r1, 42, 'dynamic :delete(False) reads the value (sub-assigned hash)';
+
+# In a for loop with bound keys (the roast multislice shape).
+for "a", "b", "c", 42 -> $a, $b, $c, $result {
+    my $rr = %hash{$a;$b;$c}:$no;
+    is $rr, 42, 'dynamic :delete(False) reads with for-bound keys';
+    last;
+}
+
+# Direct (non-sub) assignment.
+my %h;
+%h{"x";"y"} = 99;
+my $f = False;
+my $r2 = %h{"x";"y"}:$f;
+is $r2, 99, 'dynamic :delete(False) direct hash read';
+ok %h{"x";"y"}:exists, 'key still present after :delete(False)';
+
+# Array multi-dim dynamic adverb reads too.
+my @a = [[1, 2], [3, 4]];
+my $g = False;
+my $r3 = @a[1;0]:$g;
+is $r3, 3, 'dynamic :delete(False) on an array multi-dim subscript';


### PR DESCRIPTION
## Summary

`%h{a;b;c}:\$delete` — a multi-dim subscript with a **dynamic** delete adverb (a runtime boolean, not a literal `:delete(0/1)`) — lowered to a `__mutsu_multidim_dynamic_adverb` builtin that resolved the container **by name** via `self.env.get(var_name)`. That by-name lookup missed an outer hash assigned inside a sub (a captured-outer write the normal subscript opcode sees, but the raw env map does not), so the read path returned `Nil` instead of the value:

```raku
my %hash;
sub set-up(--> Nil) { %hash = a => { b => { c => 42 } } }
set-up;
my $no = False;
say %hash{"a";"b";"c"}:$no;   # raku: 42   mutsu (before): Nil
```

## Fix

Lower the dynamic case exactly like the literal `:delete($cond)` case already is: a `Ternary` whose **else-branch is the original `MultiDimIndex` read**. The value path now resolves the variable through the normal subscript opcode (seeing local slots / sub-writeback); only the actual delete (cond true) still goes through `__mutsu_multidim_delete`, identical to the literal lowering.

## Roast impact

Advances `roast/S32-hash/multislice-6e.t` **144 → 153**. (The file still needs the remaining multi-dim adverb suite — `:exists`/`:kv`/`:p`/`:k` — to whitelist.)

## Tests

New `t/multidim-dynamic-delete-adverb.t` (5): sub-assigned & direct hashes, for-bound keys, array multi-dim subscript. Full `t/` suite green (1202 files, 12050 tests), `cargo test` green (470), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)