### PR TITLE
feat(concat): infix ~ dispatches user .Stringy / .Str

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2413,7 +2413,7 @@ impl Interpreter {
 
             // -- String --
             OpCode::Concat => {
-                self.exec_concat_op();
+                self.exec_concat_op()?;
                 *ip += 1;
             }
 

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -541,7 +541,7 @@ impl Interpreter {
         self.stack.push(out);
     }
 
-    pub(super) fn exec_concat_op(&mut self) {
+    pub(super) fn exec_concat_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
         // Thread over junctions — concat uses left-first threading
@@ -551,10 +551,41 @@ impl Interpreter {
         if matches!(left, Value::Junction { .. }) || matches!(right, Value::Junction { .. }) {
             let result = self.eval_concat_with_junctions(left, right);
             self.stack.push(result);
-            return;
+            return Ok(());
         }
+        // Infix `~` stringifies an operand via `.Stringy` (falling back to `.Str`),
+        // so an operand whose class defines a user `Stringy`/`Str` must dispatch it
+        // — the pure `concat_values` only knows `.gist` (rendering `Foo()`). This is
+        // an internal redispatch with no surrounding CallMethod op, so drain any
+        // captured-outer writeback into the caller's slot (Slice 1b render pattern).
+        let caller_code = self.current_code;
+        let left = self.concat_coerce_operand(left)?;
+        let right = self.concat_coerce_operand(right)?;
+        self.reconcile_caller_after_internal_dispatch(caller_code);
         let result = Self::concat_values(left, right);
         self.stack.push(result);
+        Ok(())
+    }
+
+    /// Coerce a concat operand whose class defines a user `Stringy`/`Str` to its
+    /// string value (Raku infix `~` uses `.Stringy`, falling back to `.Str`). Plain
+    /// values and instances without a user stringifier pass through unchanged (the
+    /// pure `concat_values` handles those, including built-in `.gist`/`.Str`).
+    fn concat_coerce_operand(&mut self, v: Value) -> Result<Value, RuntimeError> {
+        let cn = match &v {
+            Value::Instance { class_name, .. } => class_name.resolve().to_string(),
+            Value::Package(name) => name.resolve().to_string(),
+            _ => return Ok(v),
+        };
+        if self.has_user_method(&cn, "Stringy") {
+            let r = self.try_compiled_method_or_interpret(v, "Stringy", Vec::new())?;
+            return Ok(Value::str(r.to_string_value()));
+        }
+        if self.has_user_method(&cn, "Str") {
+            let r = self.try_compiled_method_or_interpret(v, "Str", Vec::new())?;
+            return Ok(Value::str(r.to_string_value()));
+        }
+        Ok(v)
     }
 
     fn eval_concat_with_junctions(&mut self, left: Value, right: Value) -> Value {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1762,7 +1762,7 @@ impl Interpreter {
             B::Div => self.exec_div_op()?,
             B::Mod => self.exec_mod_op()?,
             B::Pow => self.exec_pow_op()?,
-            B::Concat => self.exec_concat_op(),
+            B::Concat => self.exec_concat_op()?,
             B::BitAnd => self.exec_bit_and_op(),
             B::BitOr => self.exec_bit_or_op(),
             B::BitXor => self.exec_bit_xor_op(),

--- a/t/concat-user-stringy.t
+++ b/t/concat-user-stringy.t
@@ -1,0 +1,43 @@
+use Test;
+plan 8;
+
+# Infix ~ stringifies an operand via .Stringy (falling back to .Str).
+{
+    class S1 { method Str { "Z" } }
+    is (S1.new ~ "!"), "Z!", 'infix ~ dispatches user .Str (right operand literal)';
+    is ("[" ~ S1.new), "[Z", 'infix ~ dispatches user .Str (left operand literal)';
+}
+
+# .Stringy is preferred over .Str for infix ~ (Raku behavior).
+{
+    class S2 { method Str { "STR" }; method Stringy { "STRINGY" } }
+    is ("a" ~ S2.new ~ "b"), "aSTRINGYb", 'infix ~ prefers .Stringy over .Str';
+}
+
+# .Str is used when there is no .Stringy.
+{
+    class T { method Str { "T!" } }
+    is (T.new ~ T.new), "T!T!", 'both operands dispatch user .Str';
+}
+
+# Captured-outer write inside the stringifier propagates.
+{
+    my $calls = 0;
+    class C { method Str { $calls++; "x" } }
+    my $c = C.new;
+    my $a = $c ~ "";
+    my $b = $c ~ "";
+    ok $calls >= 2, 'user .Str captured-outer write propagates across ~';
+}
+
+# Plain values are unaffected.
+{
+    is ("a" ~ "b" ~ 3), "ab3", 'plain Str/Int concat unaffected';
+    is (1 ~ 2), "12", 'Int ~ Int unaffected';
+}
+
+# A class without a stringifier still renders its gist (unchanged).
+{
+    class P { }
+    ok (P.new ~ "").contains("P"), 'no-stringifier class renders gist';
+}


### PR DESCRIPTION
## Summary

`$obj ~ "x"` rendered the object's `.gist` (`Foo()`) instead of stringifying via the
user's coercion method. Raku infix `~` stringifies via `.Stringy`, falling back to
`.Str`.

```raku
class S { method Str { "Z" } }
say S.new ~ "!";   # was: S()!   now: Z!   (raku: Z!)
```

## Changes

- `exec_concat_op` coerces each Instance/Package operand whose class defines a user
  `Stringy`/`Str` (preferring `.Stringy`) before the pure `concat_values` runs;
  plain values and stringifier-less instances pass through unchanged (gist kept).
- The op now returns `Result` so a throwing stringifier propagates; both call sites
  already run in `Result` contexts.
- Captured-outer writes drain via the `current_code` +
  `reconcile_caller_after_internal_dispatch` render pattern (Slice 1b).

## Tests

`t/concat-user-stringy.t` (8 cases, validated against raku). Concat/string/interp
suite (52 files, 551 subtests) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)