### PR TITLE
fix(parser): combined dynamic adverb :exists:$delete / :kv:$delete read path

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -298,14 +298,19 @@
   - 13/27 pass (1-2, 12-20, 22, 24). Good `.kv` support on hashes. Failures: sub form `kv(%hash)` (3-4), `Pair.kv` (5-7), constant hash refs (8-11), rw aliases in kv (21, 23, 25). Only 25 tests reached. Difficulty: Medium
 - [ ] roast/S32-hash/map.t
 - [ ] roast/S32-hash/multislice-6e.t
-  - The multi-dim hash subscript *read* `%h{a;b;c}` (rvalue) was fixed (PR: was
-    returning Nil — `multi_dim_index_read` only handled arrays; added
-    `multi_dim_hash_read` for single key / key-slice / `*`, with missing-key→Any
-    per 6.e). 144 subtests pass now. CANNOT whitelist: blocked on (1) the `&&`
-    vs `?? !!` precedence trap in the test's expected-value expression
-    (`!$exists && !$delete ?? Any !! $result`; see memory
-    `and-ternary-precedence-trap`), and (2) the full multidim adverb suite on
-    hash subscripts (`:delete`/`:exists`/`:kv`/`:p`/`:k`).
+  - Progression: 144 (multi-dim hash *read* `%h{a;b;c}` fixed — was Nil) -> 153
+    (`&&`-vs-`?? !!` precedence #3631 + bare dynamic `:$delete` read #3635) -> 174
+    (combined dynamic adverb `:exists:$delete`/`:kv:$delete`/... *read* path). The
+    dynamic-adverb fixes lower `:$delete` to a Ternary whose else-branch keeps the
+    original subscript/Exists expr (resolves the container via the normal opcode,
+    seeing a sub-writeback) instead of the by-name `self.env.get` builtin.
+  - Remaining (CANNOT whitelist yet):
+    - test 2 "check assignability with 999": `(%h{a;b;c} = v)` as an lvalue that
+      returns the assigned value -- container identity (§D).
+    - tests 11+ the `:delete`(True) MUTATION path: `__mutsu_multidim_delete` /
+      `_dyn` mutate the variable by name via `self.env.get_mut`, which still
+      misses a sub-assigned outer hash (captured-outer *write* coherence, §C/§D
+      substrate). The Ternary read-fix can't help -- delete must mutate by name.
 - [ ] roast/S32-hash/pairs.t
   - 17/26 pass (1-2, 4-10, 12-18, 20). Good `.pairs` support on hashes. Failures: element count (3, 11), rw aliases (19, 21), `:p` adverb form (22-26). Difficulty: Medium
 - [ ] roast/S32-hash/perl.t

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2959,14 +2959,19 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     if name == "__mutsu_multidim_subscript_adverb"
                     || name == "__mutsu_multidim_exists_adverb")
                 {
-                    // Wrap adverb calls: inject delete flag into the call
-                    // by converting to a combined handler
+                    // Wrap adverb calls: inject delete flag into the call by
+                    // converting to a combined handler. Like the bare `:$delete`
+                    // case, lower to a Ternary so the no-delete branch keeps the
+                    // *original* static-adverb call (which passes the evaluated
+                    // target expression and so resolves the container normally);
+                    // only the delete branch falls back to the by-name `_dyn`
+                    // builtin (it must mutate the variable).
+                    let original_expr = expr.clone();
                     if let Expr::Call {
                         name: inner_name,
                         mut args,
                     } = expr
                     {
-                        // Insert dynamic delete flag after adverb name
                         // Original args: [target_expr, adverb_name, dim0, dim1, ...]
                         // New args: [var_name_str, adverb_name, delete_var, dim0, dim1, ...]
                         let target = args.remove(0);
@@ -2984,9 +2989,14 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         } else {
                             "__mutsu_multidim_exists_adverb_dyn"
                         };
-                        expr = Expr::Call {
+                        let delete_expr = Expr::Call {
                             name: Symbol::intern(fn_name),
                             args: new_args,
+                        };
+                        expr = Expr::Ternary {
+                            cond: Box::new(Expr::Var(adverb_var.to_string())),
+                            then_expr: Box::new(delete_expr),
+                            else_expr: Box::new(original_expr),
                         };
                     } else {
                         unreachable!()
@@ -2998,12 +3008,16 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     ..
                 } = &expr
                 {
-                    // :$delete on Exists { target: MultiDimIndex }
+                    // :$delete on Exists { target: MultiDimIndex }. Lower to a
+                    // Ternary so the no-delete branch keeps the original `Exists`
+                    // expr (which resolves the container via the normal opcode);
+                    // only the delete branch uses the by-name `_dyn` builtin.
                     if let Expr::MultiDimIndex {
                         target: mdt,
                         dimensions: dims,
                     } = target.as_ref()
                     {
+                        let original_expr = expr.clone();
                         let var_name = multidim_target_var_name(mdt);
                         let adverb_str = match exists_adv {
                             ExistsAdverb::Kv => "kv",
@@ -3021,9 +3035,14 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             Expr::Literal(Value::str(adverb_str.to_string())),
                         ];
                         new_args.extend(dims);
-                        expr = Expr::Call {
+                        let delete_expr = Expr::Call {
                             name: Symbol::intern("__mutsu_multidim_exists_adverb_dyn"),
                             args: new_args,
+                        };
+                        expr = Expr::Ternary {
+                            cond: Box::new(Expr::Var(adverb_var.to_string())),
+                            then_expr: Box::new(delete_expr),
+                            else_expr: Box::new(original_expr),
                         };
                     } else {
                         expr = Expr::Call {

--- a/t/multidim-dynamic-delete-adverb.t
+++ b/t/multidim-dynamic-delete-adverb.t
@@ -6,7 +6,7 @@ use Test;
 # that resolved the container by name via `self.env.get`, which missed an outer
 # hash assigned inside a sub (returning Nil instead of the value).
 
-plan 5;
+plan 8;
 
 # Hash assigned indirectly via a sub (the failure mode).
 my %hash;
@@ -16,6 +16,14 @@ set-up;
 my $no = False;
 my $r1 = %hash{"a";"b";"c"}:$no;
 is $r1, 42, 'dynamic :delete(False) reads the value (sub-assigned hash)';
+
+# Combined static adverb + dynamic :delete(False) on a sub-assigned hash.
+my $e = %hash{"a";"b";"c"}:exists:$no;
+ok $e, 'dynamic :exists:delete(False) reads (sub-assigned hash)';
+my $kv = %hash{"a";"b";"c"}:kv:$no;
+is-deeply $kv, (("a", "b", "c"), 42), 'dynamic :kv:delete(False) reads (sub-assigned hash)';
+my $vv = %hash{"a";"b";"c"}:v:$no;
+is $vv, 42, 'dynamic :v:delete(False) reads (sub-assigned hash)';
 
 # In a for loop with bound keys (the roast multislice shape).
 for "a", "b", "c", 42 -> $a, $b, $c, $result {


### PR DESCRIPTION
## Summary

Follow-up to #3635 (bare `:\$delete`). The **combined** multi-dim adverbs — `%h{a;b;c}:exists:\$delete`, `:kv:\$delete`, `:p:\$delete`, and `:k`/`:v` + `:\$delete` — lowered straight to the `__mutsu_multidim_subscript_adverb_dyn` / `__mutsu_multidim_exists_adverb_dyn` builtins, which resolve the container **by name** via `self.env.get`. So they returned `Nil`/wrong for an outer hash assigned inside a sub (the captured-outer read the normal subscript opcode sees but the raw env map does not).

Lower both combined cases to a `Ternary`, exactly like the bare `:\$delete` case: the no-delete (else) branch keeps the **original** static-adverb call / `Exists` expr, which passes the *evaluated* target and resolves the container normally; only the delete (cond true) branch falls back to the by-name `_dyn` builtin (it must mutate the variable).

## Roast impact

Advances `roast/S32-hash/multislice-6e.t` **153 → 174**.

The remaining failures are the `:delete`(True) **mutation** path (by-name write coherence — captured-outer write, §C/§D substrate) and assignability (`(%h{a;b;c} = v)` lvalue, container identity), documented in `TODO_roast/S32.md`.

## Tests

New combined-read assertions in `t/multidim-dynamic-delete-adverb.t` (8 total). Full `t/` suite green (1202 files, 12050 tests), `cargo test` green (470), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)