### PR TITLE
fix(test): throws-like string code writes caller lexicals back

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -113,9 +113,11 @@
     throws `Too few positionals passed; expected N arguments but got M` mid-loop
     (test 49), and `-> $a, $b = 7` applies defaults via an `_.elems > i ?? _[i] !!
     default` bind (test 52). Test 97 (`$_ ~~ s///` backref writeback) FIXED via
-    #3170 (smartmatch topic-restore clobbered the in-place substitution). Remaining 11:
-    throws-like string-EVAL scope isolation (50, blocked on EVAL lexical scope =
-    my-6e.t), label-less `last` Nil-vs-() (65, `#TODO Rakudo`), expanding-list live
+    #3170 (smartmatch topic-restore clobbered the in-place substitution). Remaining 10
+    (was 11): test 50 (throws-like string-EVAL scope writeback) FIXED — `throws-like`
+    now writes a caller lexical's post-run value back from the nested EVAL interpreter
+    (excluding names the EVAL re-declares with `my`/`state`), so partial work before a
+    throw is visible. label-less `last` Nil-vs-() (65, `#TODO Rakudo`), expanding-list live
     iteration (82/83, blocked: `Value::Array` is COW Arc, push detaches the loop's
     held snapshot — first-class container), is-rw slurpy `*@v is raw` write-through
     (90-92, container identity), for-loop decontainerize (100, container identity),

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -51,14 +51,27 @@ impl Interpreter {
                 nested.lexical_class_scopes = self.lexical_class_scopes.clone();
                 nested.var_dynamic_flags = self.var_dynamic_flags.clone();
                 nested.restore_var_type_constraints(self.snapshot_var_type_constraints());
+                // Copy the caller's lexicals into the nested interpreter so the
+                // EVAL'd code sees them, and remember which names were copied so
+                // their post-run values can be written back. Raku EVALs the string
+                // in the *caller's* lexical scope, so a mutation the code makes
+                // before throwing (e.g. `$str ~= ...` in a loop that later dies)
+                // must be visible to the caller afterwards.
+                let mut shared_var_names: Vec<Symbol> = Vec::new();
                 for (k, v) in &self.env {
                     if k.contains_str("::") {
                         continue;
                     }
                     nested.env.insert_sym(*k, v.clone());
+                    shared_var_names.push(*k);
                 }
                 // Pre-check for undeclared names (compile-time errors in Raku).
                 // Parse the code and check for undeclared type names before running.
+                // Also collect the names the code re-declares with `my`/`state` at
+                // the top level: those must NOT be written back to the caller (an
+                // EVAL `my $x` is a fresh lexical that does not touch the caller's
+                // same-named variable).
+                let mut eval_declared_names: Vec<Symbol> = Vec::new();
                 let pre_check_result = {
                     let op_names = nested.collect_operator_sub_names();
                     let op_assoc = nested.collect_operator_assoc_map();
@@ -69,13 +82,25 @@ impl Interpreter {
                         &op_assoc,
                         &imported_names,
                     ) {
-                        Ok((stmts, _)) => nested
-                            .check_eval_mainline_placeholders(&stmts)
-                            .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
-                            .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
-                            .and_then(|()| nested.check_eval_undeclared_type_args(&stmts))
-                            .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
-                            .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
+                        Ok((stmts, _)) => {
+                            for stmt in &stmts {
+                                if let crate::ast::Stmt::VarDecl {
+                                    name,
+                                    is_our: false,
+                                    ..
+                                } = stmt
+                                {
+                                    eval_declared_names.push(Symbol::intern(name));
+                                }
+                            }
+                            nested
+                                .check_eval_mainline_placeholders(&stmts)
+                                .and_then(|()| nested.check_eval_class_redeclarations(&stmts))
+                                .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
+                                .and_then(|()| nested.check_eval_undeclared_type_args(&stmts))
+                                .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
+                                .and_then(|()| nested.check_eval_undeclared_names(&stmts))
+                        }
                         Err(mut e) => {
                             // A compile-time exception raised while parsing the
                             // EVAL'd code reports the EVAL pseudo-file and the
@@ -103,6 +128,19 @@ impl Interpreter {
                     Err(e)
                 } else {
                     let run_result = nested.run(code).map(|_| Value::Nil);
+                    // Write back mutations the code made to the caller's lexicals
+                    // (e.g. `$str`), whether or not it threw — Raku runs the code
+                    // in the caller's scope, so partial work before a throw is
+                    // visible afterwards. Only names that were shared in are
+                    // written back; new lexicals declared inside the EVAL are not.
+                    for name in &shared_var_names {
+                        if eval_declared_names.contains(name) {
+                            continue;
+                        }
+                        if let Some(new_val) = nested.env.get_sym(*name).cloned() {
+                            self.env.insert_sym(*name, new_val);
+                        }
+                    }
                     // If execution succeeded, check if the last evaluated value was
                     // a Failure (which would throw in sink context in Raku).
                     match run_result {

--- a/t/throws-like-outer-var-writeback.t
+++ b/t/throws-like-outer-var-writeback.t
@@ -1,0 +1,25 @@
+use Test;
+
+# `throws-like 'CODE', ...` runs the string CODE in the caller's lexical scope
+# (Raku EVALs it there). Mutations the code makes to a caller variable before it
+# throws must be visible afterwards — but a fresh `my` inside the code must NOT
+# leak back to a same-named caller variable.
+
+plan 6;
+
+# A loop that builds a string for the complete groups, then dies on the last
+# incomplete one. The partial work must survive.
+my $str = '';
+throws-like 'for 1..5 ->  $x, $y { $str ~= "$x$y" }', Exception,
+    'partial loop work runs before the throw';
+is $str, "1234", 'caller $str saw the writeback from the thrown code';
+
+# A plain assignment (no `my`) before a die writes back.
+my $acc = 0;
+throws-like 'for 1..3 { $acc += $_ }; die "boom"', Exception, 'dies after accumulating';
+is $acc, 6, 'caller $acc accumulated via writeback';
+
+# A `my` inside the code shadows: the caller variable is untouched.
+my $shadowed = 10;
+throws-like 'my $shadowed = 999; die "x"', Exception, 'dies with a shadowing my';
+is $shadowed, 10, 'a fresh my inside throws-like does not clobber the caller';


### PR DESCRIPTION
## Summary

`throws-like 'CODE', ...` runs the string CODE in a nested `Interpreter` with the caller's lexicals copied in, but never copied mutations back. Raku EVALs the string in the **caller's** lexical scope, so work the code does before it throws must be visible afterwards:

```raku
my $str = '';
throws-like 'for 1..5 ->  $x, $y { $str ~= "$x$y" }', Exception, '...';
is $str, "1234", 'partial loop work runs before the throw';  # mutsu (before): $str empty
```

## Fix

After the nested run, write each shared caller lexical's post-run value back — whether or not the code threw — **except** names the EVAL'd code re-declares at the top level with `my`/`state`. A fresh `my $x` inside the code is a new lexical that must not clobber the caller's same-named variable; the declared names are collected from the pre-check parse already performed.

## Verification

- Greens `roast/S04-statements/for.t` test 50 (now 10/111 failing, was 11)
- New `t/throws-like-outer-var-writeback.t` (6): writeback of a mutated outer var, plain accumulation before a die, and the shadowing case (a `my` inside the code leaves the caller untouched) — all matching raku
- Full `t/` suite green (1204 files, 12063 tests), `cargo test` green (470), clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)