### PR TITLE
feat(vm): method nextsame/callsame redispatch runs compiled, not tree-walk (§B)

### DIFF
--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -234,41 +234,103 @@ impl Interpreter {
             // its exit flush reads its rw-param slot. Capture its frame code now to
             // write the chain's final value into that slot after the redispatch.
             let caller_code = self.current_code;
+            // §B: run the next MRO candidate as compiled bytecode (`call_compiled_method`)
+            // when it has compiled code, instead of the tree-walk
+            // `run_instance_method_resolved` recompile-each-call path. Both leave the
+            // active `method_dispatch_stack` frame in place (neither pushes a new one),
+            // so a further `nextsame`/`callsame` inside the candidate continues this
+            // same MRO chain. Methods without compiled code (rare; added post-compile)
+            // keep the interpreter path.
+            let method_name_for_dispatch = self
+                .samewith_context_stack
+                .last()
+                .map(|(n, _)| n.clone())
+                .unwrap_or_default();
+            let empty_fns: HashMap<String, crate::opcode::CompiledFunction> = HashMap::new();
             let dispatch_result = match &invocant {
                 Value::Instance {
                     class_name,
                     attributes,
                     id: target_id,
-                } => self
-                    .run_instance_method_resolved(
-                        &receiver_class,
-                        &owner_class,
-                        method_def,
-                        attributes.to_map(),
-                        call_args,
-                        Some(invocant.clone()),
-                    )
-                    .map(|(result, updated)| {
-                        (
-                            result,
-                            Some(Value::write_back_sharing(
-                                attributes,
-                                *class_name,
-                                updated,
-                                *target_id,
-                            )),
+                } => {
+                    if let Some(cc) = method_def.compiled_code.clone() {
+                        self.call_compiled_method(
+                            &receiver_class,
+                            &owner_class,
+                            &method_name_for_dispatch,
+                            &method_def,
+                            &cc,
+                            attributes.to_map(),
+                            call_args,
+                            Some(invocant.clone()),
+                            &empty_fns,
                         )
-                    }),
-                _ => self
-                    .run_instance_method_resolved(
-                        &receiver_class,
-                        &owner_class,
-                        method_def,
-                        HashMap::new(),
-                        call_args,
-                        Some(invocant.clone()),
-                    )
-                    .map(|(result, _)| (result, None)),
+                        .map(|(result, updated, adjusted)| {
+                            // Commit only an `adjusted` (`:=`-recovered) snapshot, exactly
+                            // like `dispatch_compiled_method`: an unadjusted run already
+                            // mutated the shared attribute cell in place, so writing the
+                            // baseline snapshot back would clobber it (e.g. a parent
+                            // `callsame` candidate's `self.x ~= ...`).
+                            let new_inv = if adjusted {
+                                Value::write_back_sharing(
+                                    attributes,
+                                    *class_name,
+                                    updated,
+                                    *target_id,
+                                )
+                            } else {
+                                invocant.clone()
+                            };
+                            (result, Some(new_inv))
+                        })
+                    } else {
+                        self.run_instance_method_resolved(
+                            &receiver_class,
+                            &owner_class,
+                            method_def,
+                            attributes.to_map(),
+                            call_args,
+                            Some(invocant.clone()),
+                        )
+                        .map(|(result, updated)| {
+                            (
+                                result,
+                                Some(Value::write_back_sharing(
+                                    attributes,
+                                    *class_name,
+                                    updated,
+                                    *target_id,
+                                )),
+                            )
+                        })
+                    }
+                }
+                _ => {
+                    if let Some(cc) = method_def.compiled_code.clone() {
+                        self.call_compiled_method(
+                            &receiver_class,
+                            &owner_class,
+                            &method_name_for_dispatch,
+                            &method_def,
+                            &cc,
+                            HashMap::new(),
+                            call_args,
+                            Some(invocant.clone()),
+                            &empty_fns,
+                        )
+                        .map(|(result, _, _)| (result, None))
+                    } else {
+                        self.run_instance_method_resolved(
+                            &receiver_class,
+                            &owner_class,
+                            method_def,
+                            HashMap::new(),
+                            call_args,
+                            Some(invocant.clone()),
+                        )
+                        .map(|(result, _)| (result, None))
+                    }
+                }
             };
             if have_rw_source {
                 self.set_pending_call_arg_sources(None);

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -6,7 +6,7 @@ impl Interpreter {
     /// Call a compiled method body (MethodDef with compiled_code).
     /// Mirrors `Interpreter::run_instance_method_resolved` but executes bytecode.
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn call_compiled_method(
+    pub(crate) fn call_compiled_method(
         &mut self,
         receiver_class_name: &str,
         owner_class: &str,

--- a/t/method-redispatch-compiled.t
+++ b/t/method-redispatch-compiled.t
@@ -1,0 +1,62 @@
+use Test;
+plan 8;
+
+# Method MRO callsame/nextsame chains run the redispatched candidates as compiled
+# bytecode (§B). Verify the chain semantics are correct across inheritance.
+{
+    class A1 { method greet { "A" } }
+    class B1 is A1 { method greet { "B" ~ callsame() } }
+    class C1 is B1 { method greet { "C" ~ callsame() } }
+    is C1.new.greet, "CBA", 'callsame walks the MRO (compiled redispatch)';
+}
+
+# nextsame (tail) returns the next candidate's result.
+{
+    class P2 { method tag { "p" } }
+    class Q2 is P2 { method tag { nextsame } }
+    is Q2.new.tag, "p", 'nextsame defers to parent';
+}
+
+# callsame return value is usable in the caller candidate.
+{
+    class P3 { method n { 10 } }
+    class Q3 is P3 { method n { callsame() + 5 } }
+    is Q3.new.n, 15, 'callsame return value usable';
+}
+
+# MRO with callsame across 3 levels accumulates.
+{
+    class L1 { method v { 1 } }
+    class L2 is L1 { method v { callsame() + 10 } }
+    class L3 is L2 { method v { callsame() + 100 } }
+    is L3.new.v, 111, 'three-level callsame chain';
+}
+
+# Attribute mutation before callsame is visible to the parent (current self).
+{
+    class Base4 { has $.log is rw; method run { self.log ~= "base;" } }
+    class Sub4 is Base4 { method run { self.log ~= "sub;"; callsame } }
+    my $o = Sub4.new(log => "");
+    $o.run;
+    is $o.log, "sub;base;", 'attribute mutation visible across redispatch';
+}
+
+# nextsame with an argument-bearing method.
+{
+    class A5 { method f($x) { $x * 2 } }
+    class B5 is A5 { method f($x) { nextsame } }
+    is B5.new.f(7), 14, 'nextsame passes the same args';
+}
+
+# callwith re-dispatches with new args.
+{
+    class A6 { method g($x) { "got:$x" } }
+    class B6 is A6 { method g($x) { callwith($x + 1) } }
+    is B6.new.g(4), "got:5", 'callwith passes new args';
+}
+
+# Plain single-method call (no redispatch) still works.
+{
+    class S7 { method m { "ok" } }
+    is S7.new.m, "ok", 'plain method call unaffected';
+}


### PR DESCRIPTION
## Summary

The method MRO redispatch (`nextsame`/`callsame`/`callwith`/`nextwith` inside a
method) ran the next candidate through the interpreter's
`run_instance_method_resolved` (recompile-each-call, env-based slow path). This
runs it as compiled bytecode via the VM-native `call_compiled_method` when the
candidate has compiled code — matching how the *initial* method dispatch already
works. The §B 本丸: the method_dispatch_stack candidates were the remaining
tree-walk holdout for method MRO.

Methods without compiled code (rare; added after the registration compile pass)
keep the interpreter path. Both paths leave the active `method_dispatch_stack`
frame in place, so a further `nextsame`/`callsame` inside the redispatched
candidate continues the same MRO chain.

## Correctness

- `call_compiled_method` widened to `pub(crate)` for the runtime dispatch site.
- Like `dispatch_compiled_method`, the redispatch commits the returned attribute
  snapshot to the shared cell **only when `attrs_adjusted`** is true — an
  unadjusted run already mutated the cell in place, so committing the baseline
  snapshot would clobber a parent candidate's `self.attr ~= ...` (this is exercised
  by the attribute-mutation case in the pin; the first version of this PR regressed
  it before the `adjusted` guard was added).
- The §D `nextsame`+rw chaining (slot writeback via `current_code`) is preserved.

## Tests

`t/method-redispatch-compiled.t` (8 cases, validated against raku);
`t/nextsame-rw-redispatch.t` stays green. Broad local regression: 179 `t/` files
(1620 subtests) + 50 whitelisted S12/S06 roast tests (812 subtests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)