### PR TITLE
feat(enum): bare paren-term enum body is X::Undeclared::Symbols

### DIFF
--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -194,7 +194,13 @@ fn parse_static_enum_variants(input: &str) -> PResult<'_, Vec<(String, Option<Ex
 fn parse_enum_variant_entry(input: &str) -> PResult<'_, (String, Option<Expr>)> {
     let (rest, expr) = expression(input)?;
     match expr {
-        Expr::BareWord(name) => Ok((rest, (name, None))),
+        // A *bare identifier* inside the parenthesised `(...)` enum body is a
+        // term reference, not an autoquoted key (only the `<...>` word-list form
+        // autoquotes). If it is not a declared symbol it is X::Undeclared — so
+        // reject it here and let the dynamic-expression fallback re-parse the
+        // body as a value expression, which the undeclared-names check scans.
+        // (Pairs like `A => 1` keep their bare LHS as an autoquoted key below.)
+        Expr::BareWord(_) => Err(PError::expected("enum value (use <...> to autoquote keys)")),
         Expr::Literal(Value::Str(name)) => Ok((rest, (name.to_string(), None))),
         Expr::Binary {
             left,

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -1002,6 +1002,15 @@ impl Interpreter {
             Stmt::When { cond, .. } => {
                 self.find_undeclared_name_in_expr(cond, local_classes, declared)
             }
+            // `enum E (Foo, Bar)` with bare *terms* in the parenthesised body
+            // (parsed as a single `__DYNAMIC__` value expression) references
+            // undeclared symbols — `<Foo Bar>` is the autoquoting form. Scan the
+            // value expressions for undeclared barewords.
+            Stmt::EnumDecl { variants, .. } => variants.iter().find_map(|(_, vexpr)| {
+                vexpr
+                    .as_ref()
+                    .and_then(|e| self.find_undeclared_name_in_expr(e, local_classes, declared))
+            }),
             _ => None,
         }
     }
@@ -1148,6 +1157,11 @@ impl Interpreter {
                 }
                 None
             }
+            // A list/array literal (e.g. the parenthesised `(Foo, Bar)` body of an
+            // enum) — scan each element for an undeclared bareword term.
+            Expr::ArrayLiteral(items) => items
+                .iter()
+                .find_map(|e| self.find_undeclared_name_in_expr(e, local_classes, declared)),
             _ => None,
         }
     }

--- a/t/enum-paren-bareword-undeclared.t
+++ b/t/enum-paren-bareword-undeclared.t
@@ -1,0 +1,28 @@
+use Test;
+
+# `enum E (Foo, Bar)` with *bare identifiers* in the parenthesised body is an
+# undeclared-symbol error (only the `<...>` word-list form autoquotes keys).
+# Pairs (`Foo => 1`) and the `<...>` form stay valid.
+
+plan 7;
+
+throws-like 'enum Animal (Cat, Dog)', X::Undeclared::Symbols,
+    'enum with bare paren terms is X::Undeclared::Symbols';
+throws-like 'enum Color (red, green, blue)', X::Undeclared::Symbols,
+    'enum with several bare paren terms';
+
+# The autoquoting word-list form is fine.
+lives-ok { EVAL 'enum E1 <Cat Dog>' }, 'enum <...> word list lives';
+
+# Pair entries (bare LHS is an autoquoted key) are fine.
+lives-ok { EVAL 'enum E2 (A => 1, B => 2)' }, 'enum (A => 1, ...) pairs live';
+
+# Runtime sanity: the valid forms produce working enums.
+my @r = do {
+    enum Suit <Hearts Spades>;
+    enum Rank (Low => 1, High => 13);
+    (Hearts.value, Spades.value, Low.value, High.value)
+};
+is @r[0], 0, 'word-list enum value 0';
+is @r[1], 1, 'word-list enum value 1';
+is @r[3], 13, 'pair enum value';


### PR DESCRIPTION
## Summary

`enum Animal (Cat, Dog)` — bare **identifiers** inside the parenthesised enum body are term references, not autoquoted keys (only the `<...>` word-list form autoquotes). When undeclared they are `X::Undeclared::Symbols`, matching rakudo (`Undeclared names`). mutsu silently accepted them as enum keys.

## Fix

- **Parser:** `parse_enum_variant_entry` now rejects a bare `BareWord`, so the parenthesised body re-parses via the existing dynamic-expression fallback into a single `__DYNAMIC__` value expression (an `ArrayLiteral` of the bare terms). Pairs (`A => 1`, whose LHS is already an autoquoted `Str`) and the `<...>` word-list form are unaffected.
- **Check:** `find_undeclared_name_in_stmt` now scans `EnumDecl` value expressions, and `find_undeclared_name_in_expr` recurses into `ArrayLiteral`, so the bare undeclared terms surface as `X::Undeclared::Symbols` at EVAL/compile time.

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `enum Animal (Cat, Dog)` subtest) — part of the compile-time undeclared-symbol campaign.

## Tests

New `t/enum-paren-bareword-undeclared.t` (7): bare paren terms throw; `<...>` and pair forms still live and produce working enums. Full `t/` suite green (1206 files, 12085 tests), `cargo test` green (470), `S12-enums/basic.t` + all local enum suites unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)