### PR TITLE
feat(redeclaration): enum value vs same-named type is X::Redeclaration

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -417,7 +417,23 @@ impl Interpreter {
                     (name.resolve().to_string(), body_is_stub(body))
                 }
                 Stmt::SubsetDecl { name, .. } => (name.resolve().to_string(), false),
-                Stmt::EnumDecl { name, .. } => (name.resolve().to_string(), false),
+                Stmt::EnumDecl { name, variants, .. } => {
+                    // Enum value names share the type/term namespace, so a later
+                    // class/role/enum (or another value) of the same name is a
+                    // redeclaration. Register each value name as a non-stub
+                    // symbol. (`__DYNAMIC__` is the placeholder for an unresolved
+                    // parenthesised body, handled by the undeclared-names check.)
+                    for (vname, _) in variants {
+                        if vname.is_empty() || vname == "__DYNAMIC__" {
+                            continue;
+                        }
+                        if matches!(seen_types.get(vname), Some(false)) {
+                            return Err(type_redeclaration(vname));
+                        }
+                        seen_types.insert(vname.clone(), false);
+                    }
+                    (name.resolve().to_string(), false)
+                }
                 _ => continue,
             };
 

--- a/t/enum-value-class-redeclaration.t
+++ b/t/enum-value-class-redeclaration.t
@@ -1,0 +1,17 @@
+use Test;
+
+# An enum *value* name shares the type/term namespace, so declaring a class
+# (or another type) of the same name afterwards is an X::Redeclaration.
+
+plan 4;
+
+throws-like 'enum Error ( Metadata => -20); class Metadata { }', X::Redeclaration,
+    'class redeclaring an enum value is X::Redeclaration';
+throws-like 'enum E <Foo Bar>; class Foo { }', X::Redeclaration,
+    'class redeclaring a word-list enum value';
+throws-like 'enum A (X => 1); enum B (X => 2)', X::Redeclaration,
+    'two enums sharing a value name';
+
+# An unrelated class after an enum is fine.
+lives-ok { EVAL 'enum Color (Red => 1, Green => 2); class Shape { }' },
+    'enum + unrelated class lives';


### PR DESCRIPTION
## Summary

`enum Error (Metadata => -20); class Metadata { }` — an enum **value** name shares the type/term namespace, so a later class/role/enum (or another enum value) of the same name is an `X::Redeclaration`, matching rakudo. mutsu only registered the enum's NAME, not its value names, so the conflict went undetected.

## Fix

`check_eval_class_redeclarations` now registers each enum value name as a non-stub type symbol (skipping the `__DYNAMIC__` placeholder), so a subsequent same-named declaration — or another enum reusing the value name — throws `X::Redeclaration`.

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `enum Error (...); class Metadata` subtest) — part of the compile-time symbol-checking campaign.

## Tests

New `t/enum-value-class-redeclaration.t` (4). Full `t/` suite green (1208 files, 12100 tests), `cargo test` green (470), `S12-enums/basic.t` + all redeclaration / enum local suites unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)