### PR TITLE
feat(redeclaration): our sub across sibling blocks is X::Redeclaration

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -227,10 +227,54 @@ impl Interpreter {
         }
     }
 
+    /// Walk bare blocks collecting `our sub` names (package-scoped): two
+    /// `our sub foo` declarations install the same package symbol, so a duplicate
+    /// across sibling blocks (or block vs mainline) is X::Redeclaration. `my sub`
+    /// is lexical and does not conflict across blocks, so it is ignored here.
+    fn find_our_routine_redeclaration(
+        stmts: &[Stmt],
+        seen: &mut HashSet<String>,
+    ) -> Option<RuntimeError> {
+        for stmt in stmts {
+            match stmt {
+                Stmt::SubDecl {
+                    name,
+                    multi: false,
+                    custom_traits,
+                    ..
+                } if custom_traits.iter().any(|(t, _)| t == "__our_scoped") => {
+                    let n = name.resolve().to_string();
+                    if !n.is_empty() && !seen.insert(n.clone()) {
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("symbol".to_string(), Value::str(n.clone()));
+                        attrs.insert("what".to_string(), Value::str("routine".to_string()));
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!("Redeclaration of routine '{}'", n)),
+                        );
+                        return Some(RuntimeError::typed("X::Redeclaration", attrs));
+                    }
+                }
+                Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
+                    if let Some(e) = Self::find_our_routine_redeclaration(body, seen) {
+                        return Some(e);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
     pub(crate) fn check_eval_class_redeclarations(
         &self,
         stmts: &[Stmt],
     ) -> Result<(), RuntimeError> {
+        // `our sub` is package-scoped: a duplicate across sibling blocks is
+        // X::Redeclaration even though each block is its own lexical scope.
+        if let Some(e) = Self::find_our_routine_redeclaration(stmts, &mut HashSet::new()) {
+            return Err(e);
+        }
         // Type-like declarations (class/role/subset/enum) share one symbol
         // namespace; a non-stub declaration cannot be redeclared by another
         // type declaration of the same name (regardless of kind).

--- a/t/our-sub-sibling-block-redeclaration.t
+++ b/t/our-sub-sibling-block-redeclaration.t
@@ -1,0 +1,21 @@
+use Test;
+
+# `our sub` is package-scoped: two `our sub foo` declarations install the same
+# package symbol, so a duplicate across sibling blocks (or block vs mainline) is
+# X::Redeclaration. `my sub` is lexical and does NOT conflict across blocks.
+
+plan 4;
+
+throws-like '{ our sub foo { say "OMG" } }; { our sub foo { say "WTF" } };',
+    X::Redeclaration, 'our sub in sibling blocks is X::Redeclaration';
+
+# `my sub` in separate blocks is lexical — no conflict.
+lives-ok { EVAL '{ my sub foo { 1 } }; { my sub foo { 2 } }' },
+    'my sub in sibling blocks lives (lexical)';
+
+# A single our sub is fine.
+lives-ok { EVAL '{ our sub foo { 42 } }' }, 'single our sub lives';
+
+# Different names do not conflict.
+lives-ok { EVAL '{ our sub foo { 1 } }; { our sub bar { 2 } }' },
+    'different our sub names live';


### PR DESCRIPTION
## Summary

`{ our sub foo {...} }; { our sub foo {...} }` — `our sub` is package-scoped, so two declarations install the same package symbol and the second is an `X::Redeclaration`, even though each block is its own lexical scope. mutsu's redeclaration check only scanned top-level routines, so block-nested `our sub` duplicates went undetected.

## Fix

Add `find_our_routine_redeclaration`, which walks bare blocks (`Block`/`SyntheticBlock`) collecting `our sub` names (detected via the `__our_scoped` custom trait the parser attaches) and flags a duplicate. `my sub` is lexical and intentionally ignored (no cross-block conflict).

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `our sub foo` sibling-block subtest) — part of the compile-time symbol-checking campaign.

## Tests

New `t/our-sub-sibling-block-redeclaration.t` (4). Full `t/` suite green (1208 files, 12100 tests), `cargo test` green (470). `S04-declarations/our.t` (0 fail) and all redeclaration local suites unaffected; `S10-packages/basic.t` unchanged (18 fail), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)