### PR TITLE
feat(vm): multi-method dispatch executes compiled, not recompile-each-call (§B)

### DIFF
--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -932,14 +932,85 @@ impl Interpreter {
             let cl = self.test_pending_callsite_line;
             self.check_deprecation_for_method_with_line(method_name, &owner_class, msg, cl);
         }
-        let result = self.run_instance_method_resolved(
-            receiver_class_name,
-            &owner_class,
-            method_def,
-            attributes,
-            args,
-            invocant,
-        );
+        // §B: run the resolved (non-wrapped) candidate as compiled bytecode via the
+        // VM-native `call_compiled_method` instead of the tree-walk
+        // `run_instance_method_resolved` recompile-each-call path. The MRO frame is
+        // already pushed above, so the candidate's own `nextsame`/`callsame`
+        // continues this chain. This is the hot path for multi-method dispatch and
+        // `samewith` re-dispatch reached through `call_method_with_values`
+        // (roast S12-methods/defer-next.t: method `m` x10000). Delegation forwarders
+        // (synthesized, `compiled_code = None`) and any other uncompiled method keep
+        // the interpreter path.
+        // Only take the compiled path when it is writeback-safe; otherwise keep the
+        // tree-walk `run_instance_method_resolved`, which merges captured-outer
+        // caller writes back through the shared `env`:
+        //  - the body writes no captured-outer (free) variables — `call_compiled_method`
+        //    records those in `pending_rw_writeback_sources` for a surrounding *call op*
+        //    to drain, but an interpreter-context caller (BUILDALL, coercion/render
+        //    redispatch, `samewith`) has none (render-method captured-write coherence);
+        //  - it is not a submethod — `submethod BUILD`/`TWEAK` run through the
+        //    construction machinery with its own writeback + `fail`-to-Failure handling.
+        // A pure body (the common multi-method / accessor / `samewith` case, e.g.
+        // S12-methods/defer-next.t method `m` x10000) records nothing, so it is safe.
+        let writeback_safe_compiled = method_def
+            .compiled_code
+            .as_ref()
+            .is_some_and(|cc| cc.free_var_writes.is_empty())
+            && method_def.delegation.is_none()
+            && !method_def.is_submethod;
+        let result = if writeback_safe_compiled {
+            let cc = method_def.compiled_code.clone().unwrap();
+            let inv_for_cell = invocant.clone();
+            let empty_fns: HashMap<String, crate::opcode::CompiledFunction> = HashMap::new();
+            // `call_compiled_method` clears `pending_rw_writeback_sources` on entry;
+            // a writeback-safe (free-var-write-free) body records none of its own, so
+            // save and restore the list around the call to preserve any sibling write
+            // already queued for an outer frame to drain (the #3620 BUILDALL case:
+            // a nested `.new` here must not drop a parent `submethod BUILD { $o++ }`
+            // write). Without this the hot path would have to fall back whenever the
+            // list is non-empty, losing the speedup.
+            let saved_pending = std::mem::take(&mut self.pending_rw_writeback_sources);
+            let call_result = self.call_compiled_method(
+                receiver_class_name,
+                &owner_class,
+                method_name,
+                &method_def,
+                &cc,
+                attributes,
+                args,
+                invocant,
+                &empty_fns,
+            );
+            self.pending_rw_writeback_sources = saved_pending;
+            call_result.map(|(v, updated, adjusted)| {
+                // `run_instance_method`'s contract is `(result, attrs-to-commit)`;
+                // the caller commits the returned map. `call_compiled_method` only
+                // marks `adjusted` on a `:=` recovery — otherwise the shared cell
+                // already holds the in-place mutations, so return those (the
+                // caller's commit becomes a no-op) rather than the stale baseline
+                // snapshot, which would clobber them.
+                let final_attrs = if adjusted {
+                    updated
+                } else if let Some(Value::Instance {
+                    attributes: cell, ..
+                }) = &inv_for_cell
+                {
+                    cell.to_map()
+                } else {
+                    updated
+                };
+                (v, final_attrs)
+            })
+        } else {
+            self.run_instance_method_resolved(
+                receiver_class_name,
+                &owner_class,
+                method_def,
+                attributes,
+                args,
+                invocant,
+            )
+        };
         self.samewith_context_stack.pop();
         if pushed_dispatch {
             self.method_dispatch_stack.pop();

--- a/t/multi-method-compiled-dispatch.t
+++ b/t/multi-method-compiled-dispatch.t
@@ -1,0 +1,53 @@
+use Test;
+plan 6;
+
+# Multi-method dispatch + samewith re-dispatch run as compiled bytecode (§B):
+# `call_method_with_values` -> run_instance_method now executes the resolved
+# candidate via call_compiled_method instead of recompile-each-call tree-walk.
+{
+    class C1 {
+        has $.log is rw;
+        multi method m(Int $x) { self.log ~= "int;"; samewith $x.Str }
+        multi method m(Str $x) { self.log ~= "str:$x;" }
+    }
+    my $o = C1.new(log => "");
+    $o.m(42);
+    is $o.log, "int;str:42;", 'multi-method samewith re-dispatch chains correctly';
+}
+
+# Repeated multi-method dispatch in a loop (the defer-next hot-path shape).
+{
+    class C2 {
+        multi method m(Int $x) { samewith $x.Str }
+        multi method m(Str) { 7 }
+        multi method call() { self.m(1) }
+    }
+    my $sum = 0;
+    $sum += C2.new.call for ^200;
+    is $sum, 1400, 'repeated multi-method/samewith loop accumulates correctly';
+}
+
+# Multi-method dispatched by argument type.
+{
+    class C3 {
+        multi method describe(Int) { "int" }
+        multi method describe(Str) { "str" }
+        multi method describe($)   { "other" }
+    }
+    my $o = C3.new;
+    is $o.describe(5), "int", 'multi-method Int candidate';
+    is $o.describe("x"), "str", 'multi-method Str candidate';
+    is $o.describe(3.14), "other", 'multi-method fallback candidate';
+}
+
+# Attribute mutation across a samewith chain is preserved.
+{
+    class C4 {
+        has @.calls is rw;
+        multi method step(Int $n) { @!calls.push("i$n"); samewith "s$n" }
+        multi method step(Str $s) { @!calls.push($s) }
+    }
+    my $o = C4.new(calls => []);
+    $o.step(9);
+    is $o.calls.join(","), "i9,s9", 'attribute mutation across samewith preserved';
+}


### PR DESCRIPTION
## Summary

`run_instance_method` — reached for multi-method dispatch and `samewith`
re-dispatch through `call_method_with_values` (e.g. roast `S12-methods/defer-next.t`
method `m` ×10000) — ran the resolved candidate through `run_instance_method_resolved`,
which `run_block`-**compiles the body on every call**. This executes it via the cached
VM-native `call_compiled_method` instead, eliminating per-call recompilation
(~2.3× faster on a 50k-iteration multi-method+`samewith` loop). The MRO frame is
already pushed above this point, so the candidate's own `nextsame`/`callsame`
continues the chain.

## Writeback-safety guards (keep the tree-walk path)

The tree-walk path merges captured-outer caller writes via the shared `env`; the
compiled path differs there, so it is gated to writeback-safe candidates:
- body writes no captured-outer (free) vars (else queued for a call op an
  interpreter caller lacks — render-method coherence);
- not a submethod (`BUILD`/`TWEAK` construction machinery);
- not a delegation forwarder (`compiled_code = None`).

The pending-writeback list is saved/restored around the call (`call_compiled_method`
clears it on entry) so a sibling `submethod BUILD { $outer++ }` write survives a
nested `.new` (#3620). The returned attrs are the live cell unless `:=`-adjusted, so
an in-place `self.attr ~= ...` is not clobbered.

## Tests

`t/multi-method-compiled-dispatch.t` (6 cases, raku-validated). 216 `t/` files
(2123 subtests) + 70 whitelisted S12/S14/S06 roast tests (1196 subtests) pass; the
4 captured-outer/BUILD tests an unguarded version regressed are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)