### PR TITLE
feat(use): bare word import arg is X::Undeclared::Symbols

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -1011,6 +1011,13 @@ impl Interpreter {
                     .as_ref()
                     .and_then(|e| self.find_undeclared_name_in_expr(e, local_classes, declared))
             }),
+            // `use Module BareWord` — a bare identifier as a positional import
+            // argument is a term reference, not an import symbol (those are
+            // strings / `<...>` / `:tags`). An undeclared one is
+            // X::Undeclared::Symbols (rakudo: "Undeclared name: ...").
+            Stmt::Use { arg: Some(arg), .. } => {
+                self.find_undeclared_name_in_expr(arg, local_classes, declared)
+            }
             _ => None,
         }
     }

--- a/t/use-bareword-import-undeclared.t
+++ b/t/use-bareword-import-undeclared.t
@@ -1,0 +1,15 @@
+use Test;
+
+# A bare identifier as a positional import argument (`use Module Bar`) is a term
+# reference, not an import symbol (those are strings / `<...>` / `:tags`). An
+# undeclared one is X::Undeclared::Symbols, matching rakudo
+# ("Undeclared name: Undeclared").
+
+plan 3;
+
+throws-like 'use DoesNotMatter Undeclared;', X::Undeclared::Symbols,
+    'bare import arg is X::Undeclared::Symbols';
+
+# Valid use forms still parse / load.
+lives-ok { EVAL 'use lib "lib"' }, 'use lib "string" lives';
+lives-ok { EVAL 'use Test' }, 'plain use Test lives';


### PR DESCRIPTION
## Summary

`use DoesNotMatter Undeclared;` — a bare identifier as a positional import argument is a term reference, not an import symbol (those are strings / `<...>` / `:tags`). An undeclared one is `X::Undeclared::Symbols` (rakudo: `Undeclared name: Undeclared`), reported at compile time before the module load. mutsu fell through to a module-not-found error.

## Fix

`find_undeclared_name_in_stmt` now scans a `Stmt::Use` positional `arg` for an undeclared bareword. String / `<...>` / `:tag` import forms (whose `arg` is not a bareword) are unaffected. (The `no Module ...` form discards its arg in the AST, so only `use` is covered here.)

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `use DoesNotMatter Undeclared` subtest) — part of the compile-time undeclared-symbol campaign.

## Tests

New `t/use-bareword-import-undeclared.t` (3). Full `t/` suite green (1209 files, 12104 tests), `cargo test` green (470), `S11-modules/{lexical,import,export,need}.t` and all module local suites unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)