### PR TITLE
docs(roast): record misc.t undeclared-symbol campaign + remaining blockers

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -127,6 +127,29 @@
 - [ ] roast/S32-exceptions/misc.t
   - 129/180 pass (plan 182). This is a very broad compile-time-error/exception file
     covering ~40 distinct features.
+  - **2026-06-26 compile-time undeclared-symbol campaign (5 PRs):** enum paren bare
+    terms `enum E (Cat,Dog)`→X::Undeclared::Symbols (#3641); `is export(WTF)` bare
+    tag→X::Undeclared::Symbols (#3642); `enum E (X=>1); class X{}`→X::Redeclaration
+    via enum-value namespace registration (#3643); `our sub` across sibling blocks
+    →X::Redeclaration (#3644); `use Mod BareWord`→X::Undeclared::Symbols (#3647).
+    Infra added: `find_undeclared_name_in_expr` recurses `ArrayLiteral`;
+    `find_undeclared_name_in_stmt` scans `EnumDecl`/`Use`; `find_our_routine_redeclaration`.
+  - **Remaining clusters, all involved (no whitelist payoff until ~all land):**
+    - sink-warning **source-format** preservation (5: `:foo(42)` must warn `:foo(42)`
+      not `foo => 42`; `0xFF`/big-int/`1.2e0` must warn the source literal, not the
+      evaluated value) — needs literal source spans threaded to the warning.
+    - **X::Comp::Group** wrapping (5: `for 1,2,3,{}`, `sub infix:<>(){}`, `5.`,
+      `CATCH{when..}`, `$*foo=1;say`) — mutsu throws untyped `PError::fatal`; raku
+      wraps compile sorrows/panics in a Group hierarchy mutsu does not model.
+    - **X::Comp::BeginTime** (3) + `BEGIN { ohnoes() }` forward call — needs BEGIN run
+      at its textual position so later subs are not yet visible.
+    - custom-operator **X::Comp::FailGoal** (2: `⟨5;` unterminated custom circumfix/
+      postcircumfix) — array `[1,2` + smart-quote `„foo` FailGoal already pass.
+    - 1-test parser checks: `my $x :a` (X::Syntax::Adverb, `:a` parses as a separate
+      stmt — needs adjacency detection), `my Int (Str $x)` (ConflictingTypes),
+      `sub foo(C of Int)` no-body NotParametric ordering, `gather{return}`
+      (X::ControlFlow::Return swallowed by the gather coroutine), CALLER::<$x>
+      non-dynamic enforcement, X::TooLateForREPR, etc.
   - Done (PR #3345): X::Bind binding into an immutable subscript target (tests 148,
     151, 152: `(1,2)[0] := 3`, `10[0] := 1`, `"Hi"[0] := 1` — parser-level check in
     `simple_expr_stmt` on the `Index :=` path); X::InvalidType for `hides`-ing an


### PR DESCRIPTION
Documents the 5 compile-time undeclared-symbol / redeclaration PRs (#3641/#3642/#3643/#3644/#3647) and the remaining misc.t clusters (all involved). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)