### PR TITLE
feat(vm): construction submethods (BUILD/TWEAK) run compiled (§B Slice 3)

### DIFF
--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -948,16 +948,17 @@ impl Interpreter {
         //    records those in `pending_rw_writeback_sources` for a surrounding *call op*
         //    to drain, but an interpreter-context caller (BUILDALL, coercion/render
         //    redispatch, `samewith`) has none (render-method captured-write coherence);
-        //  - it is not a submethod — `submethod BUILD`/`TWEAK` run through the
-        //    construction machinery with its own writeback + `fail`-to-Failure handling.
+        //  - it is not a delegation forwarder (synthesized, `compiled_code = None`).
         // A pure body (the common multi-method / accessor / `samewith` case, e.g.
-        // S12-methods/defer-next.t method `m` x10000) records nothing, so it is safe.
+        // S12-methods/defer-next.t method `m` x10000, and §B Slice 3 `submethod
+        // BUILD`/`TWEAK` construction) records nothing, so it is safe. Submethods are
+        // included (Slice 3): the construction call sites' `fail`-to-Failure handling
+        // is preserved by re-raising an unhandled-Failure submethod result below.
         let writeback_safe_compiled = method_def
             .compiled_code
             .as_ref()
             .is_some_and(|cc| cc.free_var_writes.is_empty())
-            && method_def.delegation.is_none()
-            && !method_def.is_submethod;
+            && method_def.delegation.is_none();
         let result = if writeback_safe_compiled {
             let cc = method_def.compiled_code.clone().unwrap();
             let inv_for_cell = invocant.clone();
@@ -982,25 +983,41 @@ impl Interpreter {
                 &empty_fns,
             );
             self.pending_rw_writeback_sources = saved_pending;
-            call_result.map(|(v, updated, adjusted)| {
-                // `run_instance_method`'s contract is `(result, attrs-to-commit)`;
-                // the caller commits the returned map. `call_compiled_method` only
-                // marks `adjusted` on a `:=` recovery — otherwise the shared cell
-                // already holds the in-place mutations, so return those (the
-                // caller's commit becomes a no-op) rather than the stale baseline
-                // snapshot, which would clobber them.
-                let final_attrs = if adjusted {
-                    updated
-                } else if let Some(Value::Instance {
-                    attributes: cell, ..
-                }) = &inv_for_cell
-                {
-                    cell.to_map()
-                } else {
-                    updated
-                };
-                (v, final_attrs)
-            })
+            match call_result {
+                Ok((v, updated, adjusted)) => {
+                    // §B Slice 3: a `submethod BUILD`/`TWEAK` that `fail`ed comes back
+                    // as an unhandled Failure *value* (`call_compiled_method` converts
+                    // `fail` to a value), but the construction call sites
+                    // (BUILDALL / `run_build_phase`) drive their `fail`-to-Failure
+                    // behaviour off `Err(is_fail)`. Re-raise it so that handling is
+                    // unchanged. A non-submethod keeps a Failure as a legitimate return.
+                    if method_def.is_submethod
+                        && let Some(mut err) = self.failure_to_runtime_error_if_unhandled(&v)
+                    {
+                        err.is_fail = true;
+                        Err(err)
+                    } else {
+                        // `run_instance_method`'s contract is `(result, attrs-to-commit)`;
+                        // the caller commits the returned map. `call_compiled_method` only
+                        // marks `adjusted` on a `:=` recovery — otherwise the shared cell
+                        // already holds the in-place mutations, so return those (the
+                        // caller's commit becomes a no-op) rather than the stale baseline
+                        // snapshot, which would clobber them.
+                        let final_attrs = if adjusted {
+                            updated
+                        } else if let Some(Value::Instance {
+                            attributes: cell, ..
+                        }) = &inv_for_cell
+                        {
+                            cell.to_map()
+                        } else {
+                            updated
+                        };
+                        Ok((v, final_attrs))
+                    }
+                }
+                Err(e) => Err(e),
+            }
         } else {
             self.run_instance_method_resolved(
                 receiver_class_name,

--- a/t/construction-submethod-compiled.t
+++ b/t/construction-submethod-compiled.t
@@ -1,0 +1,45 @@
+use Test;
+plan 9;
+
+# §B Slice 3: BUILD/TWEAK submethods run as compiled bytecode.
+{
+    class P1 { has $.a; has $.b; submethod BUILD(:$x = 1) { $!a = $x; $!b = $x * 2 } }
+    is P1.new(x => 5).a, 5, 'BUILD binds named arg';
+    is P1.new(x => 5).b, 10, 'BUILD derives another attribute';
+    is P1.new.a, 1, 'BUILD parameter default';
+}
+
+# TWEAK runs after BUILD/default init.
+{
+    class P2 { has $.n = 10; submethod TWEAK { $!n = $!n + 5 } }
+    is P2.new.n, 15, 'TWEAK adjusts an attribute';
+}
+
+# fail inside BUILD yields a Failure, not a thrown error.
+{
+    class F { has $.x; submethod BUILD(:$x) { fail "bad" if $x < 0; $!x = $x } }
+    ok (try F.new(x => 5)).defined, 'BUILD succeeds for valid value';
+    my $r = F.new(x => -1);
+    ok $r ~~ Failure, 'fail inside BUILD returns a Failure';
+}
+
+# Inherited BUILD chain runs each class's BUILD (base-first).
+{
+    class Base3 { has @.order is rw; submethod BUILD { self.order.push("base") } }
+    class Sub3 is Base3 { submethod BUILD { self.order.push("sub") } }
+    is Sub3.new.order.join(","), "base,sub", 'BUILD runs base-first across inheritance';
+}
+
+# A captured-outer write in BUILD still works (kept on the tree-walk path).
+{
+    my $count = 0;
+    class C4 { submethod BUILD { $count++ } }
+    C4.new; C4.new;
+    is $count, 2, 'BUILD captured-outer write propagates';
+}
+
+# Attribute not touched by BUILD keeps its default.
+{
+    class DK { has $.a; has $.b = "kept"; submethod BUILD(:$a) { $!a = $a } }
+    is DK.new(a => 1).b, "kept", 'untouched attribute keeps default';
+}


### PR DESCRIPTION
## Summary

`submethod BUILD`/`TWEAK` reached through `run_instance_method` (the class-BUILD
sites in BUILDALL / `run_build_phase` / the TWEAK phase) were held on the tree-walk
`run_instance_method_resolved` recompile-each-call path by the Slice 2 `!is_submethod`
gate. Drops that gate so writeback-safe submethods run via the cached VM-native
`call_compiled_method` (~1.4× faster on a 50k-construction loop).

## The `fail`-to-Failure gap

Construction call sites drive `fail`-inside-BUILD → Failure off `Err(is_fail)`, but
`call_compiled_method` converts `fail` to an unhandled Failure *value*. So, scoped to
submethods, an unhandled-Failure result is re-raised as `Err(is_fail)` here, leaving
every construction site's fail handling unchanged. A non-submethod keeps a Failure as
a legitimate return value.

The writeback-safety guards still hold: a BUILD writing a captured-outer (`$outer++`)
has non-empty `free_var_writes` and stays on the env-merging tree-walk path
(sibling-writeback / #3620); `pending_rw_writeback_sources` is saved/restored around
the call; attributes commit from the live cell unless `:=`-adjusted.

The role-submethod sites that call `run_instance_method_resolved` directly
(`methods_dispatch_new.rs:335/445/545`) are a separate lower-traffic follow-up.

## Tests

`t/construction-submethod-compiled.t` (9 cases, raku-validated). 179 `t/` files
(1717 subtests) + 50 whitelisted S12-construction/class/role roast tests (749 subtests)
pass; native-build-construct fail tests and build-sibling-writeback-coherence green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)