### PR TITLE
feat(parser): my $x :a -> X::Syntax::Adverb; my Int(Str $x) -> ConflictingTypes

### DIFF
--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -75,6 +75,31 @@ pub(in crate::parser::stmt) fn parse_destructuring_decl(
                 || after_tc_ws.starts_with('&')
                 || after_tc_ws.starts_with('\\')
             {
+                // An outer declaration type (`my Int (...)`) and an inner element
+                // type (`Str $x`) that disagree are X::Syntax::Variable::ConflictingTypes.
+                if let Some(outer) = &type_constraint
+                    && outer != &tc
+                {
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert(
+                        "outer".to_string(),
+                        crate::value::Value::Package(crate::symbol::Symbol::intern(outer)),
+                    );
+                    attrs.insert(
+                        "inner".to_string(),
+                        crate::value::Value::Package(crate::symbol::Symbol::intern(&tc)),
+                    );
+                    let msg = format!(
+                        "X::Syntax::Variable::ConflictingTypes: Variable definition of type {} (from declaration) conflicts with type {} (from inner declaration)",
+                        outer, tc
+                    );
+                    attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+                    let exception = crate::value::Value::make_instance(
+                        crate::symbol::Symbol::intern("X::Syntax::Variable::ConflictingTypes"),
+                        attrs,
+                    );
+                    return Err(PError::fatal_with_exception(msg, Box::new(exception)));
+                }
                 per_var_type_constraint = Some(tc);
                 r = after_tc_ws;
             }

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -361,6 +361,32 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
         &mut hash_key_constraint,
     )?;
 
+    // A colonpair adverb directly on a declaration (`my $x :a`) is illegal —
+    // you can't adverb a variable. `:=` (bind) and `::` are not adverbs.
+    if let Some(after_colon) = rest.strip_prefix(':')
+        && !after_colon.starts_with('=')
+        && !after_colon.starts_with(':')
+        && after_colon
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphabetic() || c == '_' || c == '!')
+    {
+        let sigil = if is_array {
+            "@"
+        } else if is_hash {
+            "%"
+        } else if is_code {
+            "&"
+        } else {
+            "$"
+        };
+        return Err(illegal_my_var_error(
+            "X::Syntax::Adverb",
+            &format!("You can't adverb {}{}", sigil, name),
+            &[],
+        ));
+    }
+
     // Delegate to assignment/binding handler
     my_decl_assign_or_default(rest, state)
 }

--- a/t/var-decl-syntax-errors.t
+++ b/t/var-decl-syntax-errors.t
@@ -1,0 +1,23 @@
+use Test;
+
+# Two compile-time syntax errors on variable declarations:
+#  * `my $x :a` — you can't adverb a declaration (X::Syntax::Adverb).
+#  * `my Int (Str $x)` — an outer declaration type conflicting with an inner
+#    element type is X::Syntax::Variable::ConflictingTypes.
+
+plan 9;
+
+throws-like 'my $x :a', X::Syntax::Adverb, 'scalar decl + adverb';
+throws-like 'my @a :b', X::Syntax::Adverb, 'array decl + adverb';
+throws-like 'my %h :c', X::Syntax::Adverb, 'hash decl + adverb';
+
+throws-like 'my Int (Str $x);', X::Syntax::Variable::ConflictingTypes,
+    :outer(Int), :inner(Str), 'outer Int vs inner Str';
+throws-like 'my Numeric (Str $y);', X::Syntax::Variable::ConflictingTypes,
+    'outer Numeric vs inner Str';
+
+# Valid forms still parse / run.
+lives-ok { EVAL 'my $x := 5' }, 'bind (`:=`) is not an adverb';
+lives-ok { EVAL 'my Int:D $y = 3' }, 'definite smiley on the type lives';
+lives-ok { EVAL 'my (Int $a, Str $b) = (1, "x")' }, 'per-var types without an outer type live';
+lives-ok { EVAL 'my Int ($a, $b) = (1, 2)' }, 'outer type with untyped elements lives';


### PR DESCRIPTION
## Summary

Two compile-time syntax errors on variable declarations that mutsu silently accepted:

- **`my $x :a`** — a colonpair adverb directly on a declaration is illegal (`You can't adverb $x`, `X::Syntax::Adverb`). mutsu parsed the `:a` as a separate statement. `my_decl_inner` now rejects a trailing `:ident` adverb after the declaration (excluding `:=` bind and `::`).
- **`my Int (Str $x)`** — an outer declaration type that disagrees with an inner element type is `X::Syntax::Variable::ConflictingTypes` (with `outer => Int`, `inner => Str`). mutsu discarded the outer type. `parse_destructuring_decl` already has both the outer `type_constraint` and the inner `per_var_type_constraint` in hand, so it now compares them and throws on a mismatch.

Both checks preserve valid forms (`:=` bind, definite smiley `Int:D`, per-var types without an outer type, outer type with untyped elements).

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `my $x :a` and `my Int (Str $x)` subtests) — part of the deep compile-time-error campaign.

## Tests

New `t/var-decl-syntax-errors.t` (9, incl. the `.outer`/`.inner` matchers). Full `t/` suite green (1213 files, 12121 tests), `cargo test` green (470), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)