### PR TITLE
feat(vm): remaining resolved-candidate method sites run compiled via shared helper (§B)

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -103,9 +103,10 @@ impl Interpreter {
                             caller_class.as_deref().unwrap_or("GLOBAL"),
                         ));
                     }
-                    let (result, updated) = self.run_instance_method_resolved(
+                    let (result, updated) = self.run_resolved_method_compiled_or_treewalk(
                         &class_name.resolve(),
                         &resolved_owner,
+                        pm_name,
                         method_def,
                         attributes.to_map(),
                         args,
@@ -1187,9 +1188,10 @@ impl Interpreter {
                         ));
                     }
                     let attrs = HashMap::new();
-                    let (result, _updated) = self.run_instance_method_resolved(
+                    let (result, _updated) = self.run_resolved_method_compiled_or_treewalk(
                         &name.resolve(),
                         &resolved_owner,
+                        pm_name,
                         method_def,
                         attrs,
                         args,

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -3968,9 +3968,10 @@ impl Interpreter {
                         if !class_is_6e && class_has_own_build && role_lang_rev == "c" {
                             continue;
                         }
-                        let (_v, updated) = self.run_instance_method_resolved(
+                        let (_v, updated) = self.run_resolved_method_compiled_or_treewalk(
                             &class_name.resolve(),
                             &role_name,
+                            "BUILD",
                             method_def,
                             attrs.clone(),
                             args.clone(),
@@ -4097,9 +4098,10 @@ impl Interpreter {
                         if !class_is_6e && class_has_own_tweak && role_lang_rev == "c" {
                             continue;
                         }
-                        let (_v, updated) = self.run_instance_method_resolved(
+                        let (_v, updated) = self.run_resolved_method_compiled_or_treewalk(
                             &class_name.resolve(),
                             &role_name,
+                            "TWEAK",
                             method_def,
                             attrs.clone(),
                             args.clone(),

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -1121,9 +1121,10 @@ impl Interpreter {
                             caller_class.as_deref().unwrap_or("GLOBAL"),
                         ));
                     }
-                    let (result, updated) = self.run_instance_method_resolved(
+                    let (result, updated) = self.run_resolved_method_compiled_or_treewalk(
                         &class_name.resolve(),
                         &resolved_owner,
+                        pm_name,
                         method_def,
                         attributes.to_map(),
                         args,
@@ -1156,9 +1157,10 @@ impl Interpreter {
                         attrs.clone(),
                         *target_id,
                     );
-                    let (result, updated) = self.run_instance_method_resolved(
+                    let (result, updated) = self.run_resolved_method_compiled_or_treewalk(
                         &class_name.resolve(),
                         &resolved_owner,
+                        method,
                         method_def,
                         attrs,
                         args.clone(),

--- a/t/private-method-compiled-dispatch.t
+++ b/t/private-method-compiled-dispatch.t
@@ -1,0 +1,42 @@
+use Test;
+plan 5;
+
+# §B: private method (`$obj!m`) dispatch now uses the shared compiled-or-treewalk
+# helper (was run_instance_method_resolved directly).
+{
+    class C1 {
+        has $.v;
+        method !secret { "s:" ~ $!v }
+        method reveal { self!secret }
+    }
+    is C1.new(v => 7).reveal, "s:7", 'private method dispatched (compiled helper)';
+}
+
+# Private method that mutates an attribute.
+{
+    class C2 {
+        has $.n is rw = 0;
+        method !bump { $!n = $!n + 5 }
+        method go { self!bump; self!bump; $!n }
+    }
+    is C2.new.go, 10, 'private method attribute mutation persists';
+}
+
+# Private method with arguments.
+{
+    class C3 { method !add($a, $b) { $a + $b }; method run { self!add(3, 4) } }
+    is C3.new.run, 7, 'private method with args';
+}
+
+# `.*` method walk dispatches each MRO level's method.
+{
+    class A4 { method m { 1 } }
+    class B4 is A4 { method m { 2 } }
+    is B4.new.*m.sort.join(","), "1,2", '.* walks all MRO methods';
+}
+
+# Public method still works alongside privates.
+{
+    class C5 { has $.x = 9; method !p { $!x }; method pub { self!p + 1 } }
+    is C5.new.pub, 10, 'public+private mix';
+}


### PR DESCRIPTION
## Summary

Routes the remaining direct `run_instance_method_resolved` call sites through the
shared `run_resolved_method_compiled_or_treewalk` helper (#3651), so they run as
compiled bytecode when writeback-safe instead of recompiling the body each call:

- a **second construction path**'s role BUILD/TWEAK submethods (`methods_object.rs`,
  the custom-constructor BUILDALL) — missed by the `methods_dispatch_new` conversion;
- private method dispatch `$obj!m` (`methods_instance_ops.rs`, `methods_signature.rs`);
- the `.*` per-MRO-level method walk (`methods_signature.rs`).

All are drop-in (the helper shares `run_instance_method_resolved`'s
`(result, attrs-to-commit)` contract). The writeback-safety gate keeps captured-outer
and delegation cases on the tree-walk path; the submethod fail-re-raise preserves
construction fail-to-Failure.

The `does`/`but` mixin role-method site (`methods_mixin_dispatch.rs`) is left as a
follow-up — it save/restores role params in `env` around the call and needs separate
care.

## Tests

`t/private-method-compiled-dispatch.t` (5 cases, raku-validated). 179 `t/` files
(1703 subtests) + 60 whitelisted S12/S14 roast tests (1095 subtests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)