### PR TITLE
feat(class): X::TooLateForREPR when a stub upgrade introduces a repr

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -287,6 +287,10 @@ impl Interpreter {
         // so that `augment class C { class Nested {} }` can detect redeclaring a
         // nested type that the original `class C { class Nested {} }` declared.
         let mut class_nested: HashMap<String, HashSet<String>> = HashMap::new();
+        // The `repr` of each class at its first declaration. A later declaration
+        // (e.g. upgrading a `{ ... }` stub) may not introduce a different repr —
+        // that is X::TooLateForREPR ("must be set at initial declaration").
+        let mut seen_class_repr: HashMap<String, Option<String>> = HashMap::new();
         let collect_nested = |body: &[Stmt]| -> HashSet<String> {
             body.iter()
                 .filter_map(|s| match s {
@@ -432,12 +436,34 @@ impl Interpreter {
                     name,
                     body,
                     is_lexical,
+                    repr,
                     ..
                 } => {
                     if let Some(err) = dup_scoped_method(body) {
                         return Err(err);
                     }
                     let name = name.resolve().to_string();
+                    // X::TooLateForREPR: the repr must be fixed at the initial
+                    // declaration. If an earlier declaration of this class had a
+                    // different (typically absent) repr, a later one cannot set it.
+                    match seen_class_repr.get(&name) {
+                        Some(prev) if repr.is_some() && prev != repr => {
+                            let mut attrs = std::collections::HashMap::new();
+                            attrs.insert("type".to_string(), Value::str(name.clone()));
+                            attrs.insert(
+                                "message".to_string(),
+                                Value::str(format!(
+                                    "Cannot change REPR of {} now (must be set at initial declaration)",
+                                    name
+                                )),
+                            );
+                            return Err(RuntimeError::typed("X::TooLateForREPR", attrs));
+                        }
+                        Some(_) => {}
+                        None => {
+                            seen_class_repr.insert(name.clone(), repr.clone());
+                        }
+                    }
                     class_nested
                         .entry(name.clone())
                         .or_default()

--- a/t/class-too-late-for-repr.t
+++ b/t/class-too-late-for-repr.t
@@ -1,0 +1,21 @@
+use Test;
+
+# A class's repr must be fixed at its initial declaration. Upgrading a `{ ... }`
+# stub (or any earlier declaration) with a new `is repr(...)` is X::TooLateForREPR.
+
+plan 4;
+
+throws-like 'my class A { ... }; my class A is repr("Uninstantiable") { }',
+    X::TooLateForREPR, 'adding a repr when upgrading a stub';
+
+# Valid: repr set at the initial declaration.
+lives-ok { EVAL 'my class B is repr("P6opaque") { }' },
+    'repr at the initial declaration lives';
+
+# Valid: a stub upgraded without introducing a repr.
+lives-ok { EVAL 'my class C { ... }; my class C { method m { 1 } }' },
+    'stub upgrade without a repr lives';
+
+# Valid: the same repr repeated is not a change.
+lives-ok { EVAL 'my class D is repr("P6opaque") { ... }; my class D is repr("P6opaque") { }' },
+    'same repr on stub and upgrade lives';


### PR DESCRIPTION
## Summary

A class's repr must be fixed at its initial declaration. `my class A { ... }; my class A is repr("Uninstantiable") { }` upgrades a stub and introduces a repr the stub did not have — rakudo raises `X::TooLateForREPR` (`Cannot change REPR of A now`). mutsu silently accepted it.

## Fix

`check_eval_class_redeclarations` now records each class's repr at its first declaration (`seen_class_repr`) and rejects a later declaration that sets a different (typically previously-absent) repr. Setting the repr at the initial declaration, upgrading a stub without a repr, and repeating the same repr are all unaffected.

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the X::TooLateForREPR subtest) — part of the deep compile-time-error campaign.

## Tests

New `t/class-too-late-for-repr.t` (4). Full `t/` suite green (1216 files, 12142 tests), `cargo test` green (470), `S12-class/*` unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)