### PR TITLE
feat(vm): does/but mixin role-method dispatch runs compiled (§B — completes method-execution migration)

### DIFF
--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -120,9 +120,10 @@ impl Interpreter {
                         method_attrs.insert(attr.to_string(), value.clone());
                     }
                 }
-                let method_result = self.run_instance_method_resolved(
+                let method_result = self.run_resolved_method_compiled_or_treewalk(
                     &role_name,
                     &role_name,
+                    lookup_name,
                     def,
                     method_attrs,
                     args,

--- a/t/mixin-method-compiled.t
+++ b/t/mixin-method-compiled.t
@@ -1,0 +1,26 @@
+use Test;
+plan 3;
+
+# §B: a role method reached via a `does`/`but` mixin now runs through the shared
+# compiled-or-treewalk helper (was run_instance_method_resolved directly).
+{
+    role Greet { method hi { "hi" } }
+    my $x = 42 but Greet;
+    is $x.hi, "hi", 'mixed-in role method runs (compiled helper)';
+}
+
+# Role method that reads the object's value.
+{
+    role Describe { method describe { "val=" ~ self.Int } }
+    my $n = 7 but Describe;
+    is $n.describe, "val=7", 'mixed-in role method reads invocant';
+}
+
+# `does` mixin with a role method that reads an attribute.
+{
+    class Box { has $.v }
+    role Tag { method tagged { "tag:" ~ self.v } }
+    my $b = Box.new(v => 3);
+    $b does Tag;
+    is $b.tagged, "tag:3", 'does-mixin role method reads attribute';
+}


### PR DESCRIPTION
## Summary

Routes the **last remaining** direct `run_instance_method_resolved` call site — a
role method reached through a `does`/`but` mixin — through the shared
`run_resolved_method_compiled_or_treewalk` helper, so it runs as compiled bytecode
when writeback-safe. Drop-in: the role-parameter env bindings set before the call
stay visible (the compiled frame roots at the live env), the writeback-safety gate
keeps captured-outer writes on the tree-walk path, and the surrounding param
save/restore + attribute commit are unchanged.

## Milestone

This **completes the §B method-execution-compiled migration**: every resolved-candidate
method/submethod dispatch — general, multi-method, `samewith`/`nextsame`/`callsame`
redispatch, construction BUILD/TWEAK (both paths), DESTROY, private methods, `.*` walk,
and now mixin role methods — runs as cached compiled bytecode instead of recompiling
the body each call. The only interpreter-bound method execution left is the synthesized
`proto` body (`compiled_code = None`).

## Tests

`t/mixin-method-compiled.t` (3 cases, raku-validated). 37 does/but/role `t/` files
(264 subtests) + 50 whitelisted S14-roles/S12 roast tests (777 subtests) pass.
(A pre-existing parameterized-role-via-mixin method-lookup gap is unchanged and out
of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)