### PR TITLE
feat(phaser): errors in a BEGIN phaser wrap in X::Comp::BeginTime

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2240,10 +2240,22 @@ impl Compiler {
                 self.compile_check_phaser(body);
             }
             Stmt::Phaser {
-                kind: PhaserKind::Begin | PhaserKind::Init | PhaserKind::Enter,
+                kind: PhaserKind::Begin,
                 body,
             } => {
-                // BEGIN/INIT are extracted and run at compile time.
+                // BEGIN runs at compile time; an error thrown inside it is wrapped
+                // in X::Comp::BeginTime (same mechanism as CHECK — the
+                // CheckPhaserStart/End opcodes raise the `check_phaser_depth`
+                // counter, and a throw at depth > 0 is wrapped). The opcodes don't
+                // touch the stack, so the body's value/side-effects are preserved.
+                self.compile_check_phaser(body);
+            }
+            Stmt::Phaser {
+                kind: PhaserKind::Init | PhaserKind::Enter,
+                body,
+            } => {
+                // INIT runs at run start, ENTER on block entry — neither is a
+                // compile-time phaser, so their errors are NOT X::Comp::BeginTime.
                 // ENTER at top-level scope compiles inline (in sub/method/closure
                 // bodies it is handled by BlockScope and filtered out before
                 // reaching this match arm).

--- a/t/begin-phaser-begintime.t
+++ b/t/begin-phaser-begintime.t
@@ -1,0 +1,23 @@
+use Test;
+
+# An error thrown inside a BEGIN phaser is wrapped in X::Comp::BeginTime (BEGIN
+# runs at compile time). The original exception is carried as `.exception`.
+
+plan 5;
+
+throws-like 'BEGIN { die "oh noes!" }', X::Comp::BeginTime,
+    exception => sub ($e) { $e.message eq 'oh noes!' },
+    'die in BEGIN is X::Comp::BeginTime with the original exception';
+
+throws-like 'BEGIN { my $x = 1 / 0; $x.Int }', X::Comp::BeginTime,
+    'a numeric failure in BEGIN wraps too';
+
+# Normal BEGIN behaviour is preserved: side effects run, and a BEGIN value is usable.
+my $log = '';
+EVAL 'BEGIN { $*OUT.print: "" }';  # smoke: BEGIN parses/runs
+is (BEGIN { 21 * 2 }), 42, 'BEGIN as an rvalue yields its value';
+lives-ok { EVAL 'BEGIN { 1 + 1 }' }, 'a non-throwing BEGIN lives';
+
+# INIT (runtime phaser) errors are NOT wrapped as BeginTime.
+throws-like 'INIT { die "later" }', X::AdHoc,
+    'die in INIT is a plain runtime error, not BeginTime';


### PR DESCRIPTION
## Summary

`BEGIN { die "oh noes!" }` runs at compile time, so an error thrown inside it is wrapped in `X::Comp::BeginTime` (carrying the original as `.exception`), matching rakudo. mutsu compiled BEGIN inline without the wrapping, so a die surfaced as a plain `X::AdHoc`.

## Fix

Compile a BEGIN body via `compile_check_phaser` (the same path CHECK uses): the `CheckPhaserStart`/`CheckPhaserEnd` opcodes raise the `check_phaser_depth` counter, and a throw at depth > 0 is wrapped via `wrap_in_begin_time`. The opcodes don't touch the value stack, so the body's value (BEGIN as an rvalue) and side effects are preserved. INIT/ENTER (runtime phasers) are split into their own arm and stay inline — their errors are deliberately NOT BeginTime.

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `BEGIN { die }` X::Comp::BeginTime subtest; the constant-init and `array[Int]` BeginTime cases are separate compile-time paths). Part of the deep compile-time-error campaign.

## Tests

New `t/begin-phaser-begintime.t` (5, incl. the `.exception` matcher and the INIT-is-not-BeginTime contrast). Full `t/` suite green (1217 files, 12147 tests), `cargo test` green (470), `S04-phasers/{begin,check,multiple,in-eval}.t` unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)