### PR TITLE
feat(parser): two statement modifiers is X::Syntax::Confused

### DIFF
--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -75,14 +75,27 @@ fn rewrite_placeholder_block_modifier_stmt(stmt: Stmt, cond: &Expr) -> Stmt {
 }
 
 pub(super) fn is_stmt_modifier_keyword(input: &str) -> bool {
-    for kw in &[
+    leading_modifier_keyword(input).is_some()
+}
+
+/// The statement-modifier keyword at the start of `input`, if any.
+fn leading_modifier_keyword(input: &str) -> Option<&'static str> {
+    [
         "if", "unless", "for", "while", "until", "given", "when", "with", "without",
-    ] {
-        if keyword(kw, input).is_some() {
-            return true;
-        }
-    }
-    false
+    ]
+    .into_iter()
+    .find(|kw| keyword(kw, input).is_some())
+}
+
+/// Whether a second statement modifier `next` is legal after a first `first`.
+/// Raku only allows a *conditional* modifier (`if`/`unless`/`with`/`without`)
+/// followed by a *loop* modifier (`for`/`while`/`until`/`given`), e.g.
+/// `EXPR if COND for LIST`. Everything else (two conditionals, two loops, a loop
+/// then a conditional) is X::Syntax::Confused.
+fn second_modifier_allowed(first: &str, next: &str) -> bool {
+    let first_is_cond = matches!(first, "if" | "unless" | "with" | "without");
+    let next_is_loop = matches!(next, "for" | "while" | "until" | "given");
+    first_is_cond && next_is_loop
 }
 
 /// Check if an expression ends with a block body (e.g., `try { ... }`,
@@ -137,6 +150,8 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
     }
     let mut current_stmt = stmt;
     let mut rest = rest;
+    // The keywords of the modifiers parsed so far, in order.
+    let mut parsed_kinds: Vec<&str> = Vec::new();
 
     loop {
         // If there's a semicolon, the statement is terminated — no more modifiers
@@ -149,9 +164,36 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
             return Ok((rest, current_stmt));
         }
 
+        // A second modifier is only legal as `conditional THEN loop`
+        // (`EXPR if COND for LIST`). Any other chain — two conditionals, two
+        // loops, a loop then a conditional, or a third modifier — needs a `;`
+        // and so is X::Syntax::Confused ("Missing semicolon").
+        if let Some(next_kw) = leading_modifier_keyword(rest)
+            && let Some(&first) = parsed_kinds.first()
+            && (parsed_kinds.len() >= 2 || !second_modifier_allowed(first, next_kw))
+        {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "message".to_string(),
+                crate::value::Value::str("Missing semicolon".to_string()),
+            );
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Confused"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(
+                "Missing semicolon".to_string(),
+                Box::new(ex),
+            ));
+        }
+
+        let kw = leading_modifier_keyword(rest);
         match parse_single_modifier(rest, current_stmt.clone())? {
             Some((r, modified)) => {
                 current_stmt = modified;
+                if let Some(k) = kw {
+                    parsed_kinds.push(k);
+                }
                 let (r, _) = ws(r)?;
                 rest = r;
             }

--- a/t/double-statement-modifier-confused.t
+++ b/t/double-statement-modifier-confused.t
@@ -1,0 +1,25 @@
+use Test;
+
+# Raku allows at most one statement modifier, except a *conditional* modifier
+# (if/unless/with/without) immediately followed by a *loop* modifier
+# (for/while/until/given) — `EXPR if COND for LIST`. Any other chain needs a `;`
+# and is X::Syntax::Confused ("Missing semicolon").
+
+plan 9;
+
+throws-like 'say 1 if 2 if 3 { say 3 }', X::Syntax::Confused,
+    'two conditional modifiers';
+throws-like 'say 1 if 2 if 3', X::Syntax::Confused,
+    'two conditional modifiers (no block)';
+throws-like 'say 1 for 1..2 for 3..4', X::Syntax::Confused,
+    'two loop modifiers';
+throws-like 'say 1 for 3..4 if 2', X::Syntax::Confused,
+    'loop then conditional';
+
+# The one legal chain plus all single modifiers.
+is-deeply (($_ * $_ if $_ %% 2 for 0..5)).list, (0, 4, 16),
+    'conditional then loop chain (EXPR if COND for LIST)';
+lives-ok { EVAL 'say 1 if 2' }, 'single if lives';
+lives-ok { EVAL 'say $_ for 1..3' }, 'single for lives';
+lives-ok { EVAL 'say 1 unless 0' }, 'single unless lives';
+lives-ok { EVAL 'say 1 if 2 for 3..4' }, 'if then for lives';


### PR DESCRIPTION
## Summary

`say 1 if 2 if 3` (and `... if 3 { say 3 }`) chains two statement modifiers, which rakudo rejects with "Missing semicolon" (`X::Syntax::Confused`). mutsu's modifier loop accepted any number of modifiers.

## Fix

Raku allows at most one modifier, with one exception: a **conditional** modifier (`if`/`unless`/`with`/`without`) immediately followed by a **loop** modifier (`for`/`while`/`until`/`given`) — `EXPR if COND for LIST`. `parse_statement_modifier` now tracks the modifier keywords parsed and rejects any other chain (two conditionals, two loops, loop-then-conditional, or a third modifier) as `X::Syntax::Confused`. The single legal `conditional then loop` chain, every single modifier, and `;`-separated statements are unaffected (the `parse_chained_inline_modifiers_in_paren_expr` unit test still passes).

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the double-modifier subtest) — part of the deep compile-time-error campaign.

## Tests

New `t/double-statement-modifier-confused.t` (9, incl. the legal `if COND for LIST` chain). Full `t/` suite green (1220 files, 12160 tests), `cargo test` green (470), `S04-statement-modifiers/*` + `S04-statements/*` unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)