### PR TITLE
feat(signature): returns/of <undeclared> is X::InvalidType (vs --> X::Undeclared)

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -1540,6 +1540,12 @@ pub(super) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
             let (r, type_name) =
                 take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
             return_type = Some(type_name.to_string());
+            // Mark that the return type came from a `returns`/`of` trait (not a
+            // `-->` signature arrow): an undeclared one is X::InvalidType, while
+            // an undeclared `-->` type is X::Undeclared.
+            if !custom_traits.iter().any(|(t, _)| t == "__return_via_trait") {
+                custom_traits.push(("__return_via_trait".to_string(), None));
+            }
             input = r;
             continue;
         }
@@ -1553,6 +1559,9 @@ pub(super) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
                 Some(base) if !base.contains('[') => format!("{base}[{type_name}]"),
                 _ => type_name.to_string(),
             });
+            if !custom_traits.iter().any(|(t, _)| t == "__return_via_trait") {
+                custom_traits.push(("__return_via_trait".to_string(), None));
+            }
             input = r;
             continue;
         }

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -65,13 +65,16 @@ fn walk_validate_sub_param_types(
                 param_defs,
                 body,
                 return_type,
+                custom_traits,
                 ..
             } => {
                 interp.validate_param_type_constraints(param_defs, declared, packages, classes)?;
+                let via_trait = custom_traits.iter().any(|(t, _)| t == "__return_via_trait");
                 interp.validate_return_type_constraint(
                     return_type.as_deref(),
                     param_defs,
                     declared,
+                    via_trait,
                 )?;
                 walk_validate_sub_param_types(interp, body, declared, packages, classes)?;
             }

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -229,6 +229,7 @@ impl Interpreter {
         return_type: Option<&str>,
         param_defs: &[ParamDef],
         declared_types: &std::collections::HashSet<String>,
+        via_trait: bool,
     ) -> Result<(), RuntimeError> {
         let Some(rt) = return_type else {
             return Ok(());
@@ -264,13 +265,6 @@ impl Interpreter {
             return Ok(());
         }
         let suggestions = self.suggest_type_names(rt);
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("what".to_string(), Value::str("Type".to_string()));
-        attrs.insert("symbol".to_string(), Value::str(rt.to_string()));
-        attrs.insert(
-            "suggestions".to_string(),
-            Value::array(suggestions.iter().cloned().map(Value::str).collect()),
-        );
         let mut message = format!("Type '{}' is not declared", rt);
         if suggestions.len() == 1 {
             message.push_str(&format!(". Did you mean '{}'?", suggestions[0]));
@@ -281,8 +275,23 @@ impl Interpreter {
                 quoted.join(", ")
             ));
         }
+        let mut attrs = std::collections::HashMap::new();
         attrs.insert("message".to_string(), Value::str(message));
-        Err(RuntimeError::typed("X::Undeclared", attrs))
+        attrs.insert(
+            "suggestions".to_string(),
+            Value::array(suggestions.iter().cloned().map(Value::str).collect()),
+        );
+        // A `returns`/`of` trait naming an undeclared type is X::InvalidType
+        // (with `typename`); a `-->` signature arrow is X::Undeclared (with
+        // `what` => "Type", `symbol`).
+        if via_trait {
+            attrs.insert("typename".to_string(), Value::str(rt.to_string()));
+            Err(RuntimeError::typed("X::InvalidType", attrs))
+        } else {
+            attrs.insert("what".to_string(), Value::str("Type".to_string()));
+            attrs.insert("symbol".to_string(), Value::str(rt.to_string()));
+            Err(RuntimeError::typed("X::Undeclared", attrs))
+        }
     }
 
     fn validate_static_default_typechecks(

--- a/t/return-type-undeclared-invalidtype.t
+++ b/t/return-type-undeclared-invalidtype.t
@@ -1,0 +1,23 @@
+use Test;
+
+# An undeclared return type names a different exception depending on how it was
+# written: a `returns`/`of` TRAIT is X::InvalidType (with `.typename`), while a
+# `-->` signature ARROW is X::Undeclared (with `what => "Type"`).
+
+plan 7;
+
+throws-like 'sub foo() returns Bar { }', X::InvalidType, typename => 'Bar',
+    'returns <undeclared> is X::InvalidType';
+throws-like 'sub foo() of Baz { }', X::InvalidType, typename => 'Baz',
+    'of <undeclared> is X::InvalidType';
+throws-like 'sub foo(--> Quux) { }', X::Undeclared,
+    '--> <undeclared> is X::Undeclared';
+
+# Declared return types in every form still work.
+lives-ok { EVAL 'sub a() returns Int { 1 }' }, 'returns Int lives';
+lives-ok { EVAL 'sub b(--> Str) { "x" }' }, '--> Str lives';
+lives-ok { EVAL 'sub c() of Numeric { 1 }' }, 'of Numeric lives';
+
+# A return type naming a same-unit declared class is fine.
+lives-ok { EVAL 'my class MyType { }; sub d() returns MyType { MyType.new }' },
+    'returns <locally declared class> lives';


### PR DESCRIPTION
## Summary

An undeclared return type names a different exception by origin: a `returns`/`of` **trait** is `X::InvalidType` (with `.typename`), while a `-->` signature **arrow** is `X::Undeclared`. mutsu threw `X::Undeclared` for all three.

## Fix

The two share `return_type: Option<String>` in the AST with no origin info, so `parse_sub_traits` now tags a `returns`/`of` return type with a `__return_via_trait` custom trait. `validate_return_type_constraint` takes a `via_trait` flag (computed from that marker by the EVAL-check caller) and, on an undeclared type, raises `X::InvalidType` (`typename`) when via a trait, else `X::Undeclared` (`what`/`symbol`) for `-->`. Declared return types in every form are unaffected.

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `returns Bar` X::InvalidType subtest; `hides`/`does` undeclared already pass) — part of the deep compile-time-error campaign.

## Tests

New `t/return-type-undeclared-invalidtype.t` (7, incl. the `.typename` matcher and the `-->` contrast). Full `t/` suite green (1221 files, 12165 tests), `cargo test` green (470), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)