### PR TITLE
feat(signature): native array[Int] (boxed element) is X::Comp::BeginTime

### DIFF
--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -136,6 +136,27 @@ impl Interpreter {
             let Some(tc) = pd.type_constraint.as_deref() else {
                 continue;
             };
+            // A native `array[T]` may only be parameterized with a *native*
+            // element type (`int`/`uint`/`num`/`str`, …). A boxed type such as
+            // `array[Int]` cannot back a native array, so rakudo fails the
+            // parameterization at compile time (X::Comp::BeginTime). The boxed
+            // `Array[Int]` (capital A) is fine and not matched here.
+            if let Some(inner) = tc.strip_prefix("array[").and_then(|r| r.strip_suffix(']')) {
+                let inner = inner.trim();
+                if !inner.is_empty()
+                    && !crate::runtime::native_types::is_native_array_element_type(inner)
+                {
+                    let mut attrs = std::collections::HashMap::new();
+                    attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!(
+                            "An exception occurred while parameterizing array\nException details: Can only parameterize array with a native type, not {}",
+                            inner
+                        )),
+                    );
+                    return Err(RuntimeError::typed("X::Comp::BeginTime", attrs));
+                }
+            }
             // A parameterized form `Base[...]` (also how `Base of T` is stored,
             // including the type-only `(Base of T)` param named `__type_only__`)
             // on a non-parametric type (a plain class or a package/module) is

--- a/t/native-array-boxed-type-param.t
+++ b/t/native-array-boxed-type-param.t
@@ -1,0 +1,21 @@
+use Test;
+
+# A native `array[T]` may only be parameterized with a *native* element type
+# (int/uint/num/str/...). A boxed type (`array[Int]`) cannot back a native array,
+# so the parameterization fails at compile time (X::Comp::BeginTime). The boxed
+# `Array[Int]` (capital A) is unaffected.
+
+plan 6;
+
+throws-like 'sub x(array[Int]) { }', X::Comp::BeginTime,
+    'array[Int] (boxed) param is X::Comp::BeginTime';
+throws-like 'sub x(array[Str] @a) { }', X::Comp::BeginTime,
+    'array[Str] (boxed) param is X::Comp::BeginTime';
+
+# Native element types parameterize fine.
+lives-ok { EVAL 'sub a(array[int] @x) { }' }, 'array[int] native param lives';
+lives-ok { EVAL 'sub b(array[num] @x) { }' }, 'array[num] native param lives';
+lives-ok { EVAL 'sub c(array[str] @x) { }' }, 'array[str] native param lives';
+
+# Boxed Array (capital A) with a boxed element is valid.
+lives-ok { EVAL 'sub d(Array[Int] @x) { }' }, 'Array[Int] (boxed) param lives';


### PR DESCRIPTION
## Summary

A native `array[T]` may only be parameterized with a native element type (`int`/`uint`/`num`/`str`/...). A boxed type such as `array[Int]` cannot back a native array, so rakudo fails the parameterization at compile time (`X::Comp::BeginTime`). mutsu silently accepted it. The boxed `Array[Int]` (capital A) is a normal parameterized array and is unaffected.

## Fix

`validate_param_type_constraints` now rejects a parameter type `array[<non-native>]` (via the existing `is_native_array_element_type`) with `X::Comp::BeginTime`.

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `sub x(array[Int])` subtest) — part of the deep compile-time-error campaign.

## Tests

New `t/native-array-boxed-type-param.t` (6). Full `t/` suite green (1222 files, 12174 tests), `cargo test` green (470), `S09-typed-arrays/{native-int,arrays}.t` + `S02-types/array.t` unaffected (native `array[int]`/`[num]`/`[str]` and boxed `Array[Int]` all live), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)