### PR TITLE
feat(phaser): BEGIN calling a later-declared sub is X::Undeclared::Symbols

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -98,6 +98,7 @@ impl Interpreter {
                 self.check_eval_undeclared_type_args(&stmts)?;
                 self.check_eval_undeclared_vars(&stmts)?;
                 self.check_eval_undeclared_names(&stmts)?;
+                self.check_eval_begin_forward_calls(&stmts)?;
                 self.check_eval_param_type_constraints(&stmts)?;
                 // When EVAL is called inside a class body, MethodDecl statements
                 // should be added to the enclosing class rather than lowered to subs.
@@ -997,6 +998,108 @@ impl Interpreter {
     /// Walks the AST looking for BareWord expressions that start with uppercase
     /// and aren't known types, classes, or packages. This mirrors Raku's
     /// compile-time check for undeclared symbols.
+    /// A `BEGIN { ... }` block runs at compile time, so it can only see routines
+    /// declared *before* it. Calling a sub that is declared *later* in the same
+    /// unit (`BEGIN { ohnoes() }; sub ohnoes() {}`) is X::Undeclared::Symbols at
+    /// BEGIN time, even though the sub exists by the end of the unit.
+    pub(crate) fn check_eval_begin_forward_calls(
+        &self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        // All sub names declared at this level (forward + backward).
+        let mut all_subs: HashSet<String> = HashSet::new();
+        for s in stmts {
+            if let Stmt::SubDecl { name, .. } = s {
+                all_subs.insert(name.resolve());
+            }
+        }
+        if all_subs.is_empty() {
+            return Ok(());
+        }
+        let mut declared_before: HashSet<String> = HashSet::new();
+        for s in stmts {
+            match s {
+                Stmt::SubDecl { name, .. } => {
+                    declared_before.insert(name.resolve());
+                }
+                Stmt::Phaser {
+                    kind: PhaserKind::Begin,
+                    body,
+                } => {
+                    let mut calls: HashSet<String> = HashSet::new();
+                    Self::collect_call_names_in_stmts(body, &mut calls);
+                    // A call to a sub declared only *after* this BEGIN.
+                    if let Some(fwd) = calls
+                        .iter()
+                        .find(|c| all_subs.contains(*c) && !declared_before.contains(*c))
+                    {
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("symbol".to_string(), Value::str(fwd.clone()));
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!("Undeclared routine:\n    {} used at line 1", fwd)),
+                        );
+                        return Err(RuntimeError::typed("X::Undeclared::Symbols", attrs));
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Collect the names of bare function calls (`foo(...)`) appearing anywhere
+    /// in `stmts`, recursing into nested expressions and block bodies.
+    fn collect_call_names_in_stmts(stmts: &[Stmt], out: &mut HashSet<String>) {
+        for s in stmts {
+            match s {
+                Stmt::Expr(e) => Self::collect_call_names_in_expr(e, out),
+                Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+                    Self::collect_call_names_in_expr(expr, out)
+                }
+                Stmt::Say(es) | Stmt::Print(es) | Stmt::Put(es) | Stmt::Note(es) => {
+                    for e in es {
+                        Self::collect_call_names_in_expr(e, out);
+                    }
+                }
+                Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
+                    Self::collect_call_names_in_stmts(body, out)
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_call_names_in_expr(expr: &Expr, out: &mut HashSet<String>) {
+        match expr {
+            Expr::Call { name, args } => {
+                out.insert(name.resolve());
+                for a in args {
+                    Self::collect_call_names_in_expr(a, out);
+                }
+            }
+            Expr::Binary { left, right, .. } => {
+                Self::collect_call_names_in_expr(left, out);
+                Self::collect_call_names_in_expr(right, out);
+            }
+            Expr::Unary { expr, .. } | Expr::Grouped(expr) => {
+                Self::collect_call_names_in_expr(expr, out)
+            }
+            Expr::MethodCall { target, args, .. } => {
+                Self::collect_call_names_in_expr(target, out);
+                for a in args {
+                    Self::collect_call_names_in_expr(a, out);
+                }
+            }
+            Expr::StringInterpolation(parts) => {
+                for p in parts {
+                    Self::collect_call_names_in_expr(p, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
     pub(crate) fn check_eval_undeclared_names(&self, stmts: &[Stmt]) -> Result<(), RuntimeError> {
         // Collect class/role names and locally-declared variables/subs from
         // this EVAL code. Both are valid references so they should not be

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -100,6 +100,7 @@ impl Interpreter {
                                 .and_then(|()| nested.check_eval_undeclared_type_args(&stmts))
                                 .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
                                 .and_then(|()| nested.check_eval_undeclared_names(&stmts))
+                                .and_then(|()| nested.check_eval_begin_forward_calls(&stmts))
                         }
                         Err(mut e) => {
                             // A compile-time exception raised while parsing the
@@ -467,7 +468,8 @@ impl Interpreter {
                             .and_then(|()| nested.check_eval_undeclared_trusts(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_type_args(&stmts))
                             .and_then(|()| nested.check_eval_undeclared_vars(&stmts))
-                            .and_then(|()| nested.check_eval_undeclared_names(&stmts)),
+                            .and_then(|()| nested.check_eval_undeclared_names(&stmts))
+                            .and_then(|()| nested.check_eval_begin_forward_calls(&stmts)),
                         Err(mut e) => {
                             // A compile-time exception raised while parsing the
                             // EVAL'd code reports the EVAL pseudo-file and the

--- a/t/begin-forward-call-undeclared.t
+++ b/t/begin-forward-call-undeclared.t
@@ -1,0 +1,20 @@
+use Test;
+
+# A BEGIN block runs at compile time, so it can only see routines declared
+# *before* it. Calling a sub declared *later* in the same unit is
+# X::Undeclared::Symbols at BEGIN time, even though the sub exists by unit end.
+
+plan 5;
+
+throws-like 'BEGIN { ohnoes() }; sub ohnoes() { }', X::Undeclared::Symbols,
+    'BEGIN calling a sub declared later is X::Undeclared::Symbols';
+throws-like 'BEGIN { my $x = laterfn() + 1 }; sub laterfn() { 2 }', X::Undeclared::Symbols,
+    'forward call nested in an expression is detected';
+
+# Valid: BEGIN calling an earlier-declared sub, or a builtin.
+lives-ok { EVAL 'sub okfn() { 42 }; BEGIN { okfn() }' },
+    'BEGIN calling an earlier-declared sub lives';
+lives-ok { EVAL 'BEGIN { my $x = 1 + 1 }' },
+    'BEGIN with no user calls lives';
+lives-ok { EVAL 'BEGIN { say "hi" }' },
+    'BEGIN calling a builtin lives';


### PR DESCRIPTION
## Summary

A BEGIN block runs at compile time, so it can only see routines declared **before** it. `BEGIN { ohnoes() }; sub ohnoes() {}` calls a sub declared later in the same unit — rakudo reports `X::Undeclared::Symbols` at BEGIN time. mutsu runs BEGIN at its textual position with the whole unit already registered, so the forward call silently succeeded.

## Fix

Add `check_eval_begin_forward_calls` to the EVAL/throws-like pre-check chain: it walks the top-level statements in order, tracking which subs have been declared so far, and flags a BEGIN body whose calls (collected recursively) name a sub that is declared only **later**. Builtins and earlier-declared subs are not flagged (only names in this unit's later sub-declaration set are).

## Roast impact

Advances `roast/S32-exceptions/misc.t` (the `BEGIN { ohnoes() }` subtest) — part of the deep compile-time-error campaign.

## Tests

New `t/begin-forward-call-undeclared.t` (5). Full `t/` suite green (1222 files, 12174 tests), `cargo test` green (470), `S04-phasers/{begin,in-eval,multiple}.t` + `S11-modules/lexical.t` unaffected, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)