### PR TITLE
fix(vm): merge (not restore) pending_rw_writeback_sources around compiled candidate dispatch (§B)

### DIFF
--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1018,7 +1018,21 @@ impl Interpreter {
             invocant,
             &empty_fns,
         );
-        self.pending_rw_writeback_sources = saved_pending;
+        // MERGE the saved sibling writes (e.g. a sibling BUILD's captured-outer
+        // write queued for the outer `.new` caller to drain, #3620) with the
+        // body's OWN captured-outer writes that `call_compiled_method` recorded
+        // on exit — rather than RESTORING `saved_pending`, which would discard
+        // the body's writes (so a method's `$outer++` would be lost). With the
+        // `free_var_writes.is_empty()` writeback-safety gate above on, the body
+        // records nothing, so this is inert; it becomes correct once the gate is
+        // relaxed for captured-outer-writing bodies.
+        let mut merged = saved_pending;
+        for src in std::mem::take(&mut self.pending_rw_writeback_sources) {
+            if !merged.contains(&src) {
+                merged.push(src);
+            }
+        }
+        self.pending_rw_writeback_sources = merged;
         match call_result {
             Ok((v, updated, adjusted)) => {
                 if method_def.is_submethod


### PR DESCRIPTION
## Summary

Step 1 of the `run_instance_method_resolved` deletion sequence scoped in `docs/treewalk-method-removal-plan.md` §3a / #3658.

`run_resolved_method_compiled_or_treewalk` saved `pending_rw_writeback_sources` before `call_compiled_method` (to preserve a sibling BUILD write past the entry `clear()`, #3620) and **restored** it after — which discards the body's OWN captured-outer writes that `call_compiled_method` records on exit. Once the `free_var_writes.is_empty()` writeback-safety gate is relaxed (a later step), a method's `$outer++` would be lost.

Fix = **MERGE** (saved ++ body-recorded, deduped) instead of restore. With the gate still on, the body records nothing, so this change is **inert** today — but correct once the gate is relaxed for captured-outer-writing bodies.

## Sequence (per #3658)

1. **This PR** — land the merge fix (gate on → inert but correct).
2. Fix `free_var_writes` attribute-accessor mis-classification + hyper-rw `$.count++` commit.
3. Relax the gate.
4. Sound resolution cache (multi dispatch depends on arg types + where/value clauses).
5. Delete `run_instance_method_resolved`.

## Verification

Fresh release build:
- `make test` → 12165 tests green.
- Pins: `build-sibling-writeback-coherence`, `render/coercion-method-captured-writeback`, `multi-method-compiled-dispatch`, `construction-submethod-compiled`, `role-submethod-destroy-compiled`, `method-redispatch-compiled`, `nextsame-rw-redispatch` all pass.
- Roast: `S12-methods/{defer-next,multi}`, `S12-construction/BUILD`, `S14-roles/basic` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)