### PR TITLE
feat(dispatch): proto-new no-match is X::Multi::NoMatch; constant init wraps in X::Comp::BeginTime

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -813,6 +813,18 @@ impl Compiler {
                 // var was marked readonly purely as a bind signal).
                 let is_bound_container_vardecl =
                     self.bind_vardecl && (name.starts_with('@') || name.starts_with('%'));
+                // A `constant` initializer is evaluated at BEGIN (compile) time,
+                // so an uncaught exception while evaluating it surfaces as
+                // X::Comp::BeginTime (with the original exception nested). Wrap
+                // the RHS evaluation in a CheckPhaser scope so the top-level run
+                // loop re-wraps any throw. Placed AFTER the X::Redeclaration /
+                // X::ParametricConstant early-returns above so those compile-time
+                // errors are not themselves wrapped.
+                let constant_init_phaser_start = if is_constant_decl {
+                    Some(self.code.emit(OpCode::CheckPhaserStart { end_ip: 0 }))
+                } else {
+                    None
+                };
                 if is_our_redecl_nil {
                     let qualified = self.qualify_variable_name(name);
                     let idx = self.code.add_constant(Value::str(qualified));
@@ -862,6 +874,14 @@ impl Compiler {
                         expr
                     };
                     self.compile_assignment_rhs_for_target(name, rhs_expr);
+                }
+                if let Some(start_idx) = constant_init_phaser_start {
+                    self.code.emit(OpCode::CheckPhaserEnd);
+                    let end_ip = self.code.ops.len() as u32;
+                    if let OpCode::CheckPhaserStart { end_ip: ref mut e } = self.code.ops[start_idx]
+                    {
+                        *e = end_ip;
+                    }
                 }
                 // `constant @x = ...` should store a List, not an Array.
                 // Coerce the value on the stack before storing.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -3492,6 +3492,23 @@ impl Interpreter {
                             if !e.is_multi_no_match() {
                                 return Err(e);
                             }
+                            // An explicit `proto method new` OVERRIDES the inherited
+                            // Mu.new proto, so it owns dispatch entirely: a no-match
+                            // must surface as X::Multi::NoMatch rather than falling
+                            // back to the default constructor (which would wrongly
+                            // give X::Constructor::Positional).
+                            let cn = class_name.resolve();
+                            if self.lookup_proto_method(&cn, "new").is_some() {
+                                if e.exception.as_deref().is_some_and(|ex| {
+                                    matches!(ex, Value::Instance { class_name, .. }
+                                        if class_name.resolve() == "X::Multi::NoMatch")
+                                }) {
+                                    return Err(e);
+                                }
+                                return Err(super::methods_signature::make_multi_no_match_error(
+                                    "new",
+                                ));
+                            }
                             // Mu.new only accepts named arguments. If the call
                             // had positional args and no multi candidate matched,
                             // die like Raku does.

--- a/t/proto-new-no-match.t
+++ b/t/proto-new-no-match.t
@@ -1,0 +1,54 @@
+use Test;
+
+plan 7;
+
+# An explicit `proto method new` overrides the inherited Mu.new proto, so it
+# owns dispatch entirely. A call that matches no candidate must surface as
+# X::Multi::NoMatch rather than falling back to the default constructor (which
+# would wrongly give X::Constructor::Positional).
+throws-like 'class Polar {
+    proto method new(|) { * }
+    multi method new(Real \mag, Real \theta) { }
+}
+Polar.new(0e0)', X::Multi::NoMatch,
+    'proto+multi new with no matching candidate throws X::Multi::NoMatch';
+
+# A matching candidate still dispatches normally.
+{
+    my class P {
+        proto method new(|) { * }
+        multi method new(Int \a, Int \b) { self.bless }
+    }
+    my $p = P.new(1, 2);
+    ok $p.defined, 'matching proto+multi new candidate still constructs';
+}
+
+# Without an explicit proto, an unmatched `multi method new` falls back to the
+# inherited default constructor (Mu.new), which rejects positional args.
+throws-like 'class Q {
+    multi method new(Real \mag, Real \theta) { }
+}
+Q.new(0e0)', X::Constructor::Positional,
+    'no-proto multi new still falls back to default constructor';
+
+# A `constant` initializer is evaluated at BEGIN time, so an uncaught exception
+# while evaluating it surfaces as X::Comp::BeginTime with the original nested.
+throws-like 'class Polar {
+    proto method new(|) { * }
+    multi method new(Real \mag, Real \theta) { }
+}
+constant j = Polar.new(0e0)', X::Comp::BeginTime, exception => X::Multi::NoMatch,
+    'constant init exception wraps in X::Comp::BeginTime (nested X::Multi::NoMatch)';
+
+throws-like 'constant boom = die "kaboom"', X::Comp::BeginTime,
+    'constant init die wraps in X::Comp::BeginTime';
+
+# A successful constant initializer is unaffected.
+{
+    constant FORTY_TWO = 6 * 7;
+    is FORTY_TWO, 42, 'normal constant initializer still works';
+}
+{
+    constant @list = 1, 2, 3;
+    is @list.elems, 3, 'constant list initializer still works';
+}


### PR DESCRIPTION
## Summary

Two related deep-feature fixes that together make roast `S32-exceptions/misc.t` test 218 pass.

### 1. Explicit `proto method new` owns `.new` dispatch
An explicit `proto method new` overrides the inherited `Mu.new` proto, so it owns `.new` dispatch entirely. Previously a `.new` call matching no candidate fell back to the default constructor and gave `X::Constructor::Positional`; it now correctly surfaces `X::Multi::NoMatch`.

Classes with only `multi method new` (no explicit proto) still fall back to `Mu.new` — unchanged, and matches Raku (the inherited default proto is still a candidate there).

```raku
class Polar {
    proto method new(|) { * }
    multi method new(Real \mag, Real \theta) { }
}
Polar.new(0e0);   # before: X::Constructor::Positional ; now: X::Multi::NoMatch
```

### 2. `constant` initializer evaluated at BEGIN time → X::Comp::BeginTime
A `constant` initializer is evaluated at BEGIN (compile) time, so an uncaught exception while evaluating it surfaces as `X::Comp::BeginTime` with the original exception nested. The constant RHS evaluation is now wrapped in a `CheckPhaser` scope (reusing the same mechanism as #3657), placed *after* the compile-time `X::Redeclaration` / `X::ParametricConstant` early-returns so those are not themselves wrapped.

```raku
constant boom = die "kaboom";   # X::Comp::BeginTime (matches rakudo)
```

Together: roast misc.t test 218 (`constant j = Polar.new(0e0)` → `X::Comp::BeginTime` / nested `X::Multi::NoMatch`) now passes. misc.t 36 → 35 failures.

## Test
- New `t/proto-new-no-match.t` (7 assertions): proto no-match, matching dispatch still works, no-proto fallback preserved, constant-init BeginTime wrapping, normal constant initializers unaffected.
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)