### PR TITLE
fix(vm): compiled-method $.attr++ persists to the shared cell; attr twigils are not free-var writes (§B)

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -245,35 +245,38 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
   effort, NOT a single slice.** Removing the helper's `free_var_writes.is_empty()` gate (so
   captured-outer-writing bodies also run compiled) was prototyped behind an env flag and
   traced:
-  1. **Save/restore-discards-body-writes (FIX FOUND).** The helper takes `pending_rw_writeback_sources`
-     before the call and restores it after — to preserve a sibling BUILD write (#3620) past
-     `call_compiled_method`'s entry `clear()`. But `call_compiled_method` *records the body's
-     own captured-outer writes* into that list on exit, which the restore then discards →
-     the method's `$outer++` is lost. **Fix = MERGE (saved ++ body-recorded), not restore.**
-     With that merge + gate off, `build-sibling-writeback-coherence`,
-     `render-method-captured-writeback`, `native-build-construct`, and
-     `coercion-method-captured-writeback` all pass.
-  2. **Hyper-rw attribute (STILL FAILS — separate, DEEPER blocker).** `@objs».inc` where
-     `method inc { $.count++ }` — `parallel-dispatch-regression.t` test 1. `$.count` is
-     mis-classified into `free_var_writes` as `.count` (confirmed via dump). **Tried the
-     narrowest safe relaxation** (2026-06-26): gate on `free_var_writes.all(|n| n starts
-     with '.'/'!')` (attribute-accessors only) + filter `.`/`!` names out of the merged
-     pending list (so they're not propagated as caller-var). Build/render/native-build/
-     coercion + the merge cases pass, **but `@objs».inc` STILL gives `1,2,3` not `2,3,4`** —
-     when `inc` runs compiled via the helper, the **hyper dispatch path does not commit the
-     compiled method's attribute mutation back to the array element** (the tree-walk
-     `run_instance_method_resolved` path did). So the blocker is NOT just `free_var_writes`
-     classification or pending propagation — it is the **hyper (and likely junction-
-     autothread) dispatch's attribute-writeback contract** assuming the tree-walk executor.
-     This must be fixed in the hyper/autothread op's commit-of-`updated`-attrs before any
-     attribute-mutating method may run compiled there. **Reverted — do NOT relax the gate
-     until the hyper/autothread attribute commit is unified.**
+  1. **Save/restore-discards-body-writes — DONE (#3664).** The helper took
+     `pending_rw_writeback_sources` before the call and *restored* it after — to preserve a
+     sibling BUILD write (#3620) past `call_compiled_method`'s entry `clear()`. But
+     `call_compiled_method` *records the body's own captured-outer writes* into that list on
+     exit, which the restore then discarded → the method's `$outer++` would be lost once the
+     gate is relaxed. **Fix = MERGE (saved ++ body-recorded, deduped), not restore.** With the
+     gate still on the body records nothing, so it is inert but correct.
+  2. **`free_var_writes` attribute-accessor mis-classification + hyper-rw commit — DONE
+     (#TBD).** Two coupled fixes: (a) `compute_free_vars` now treats an attribute-twigil name
+     (`.count`/`!x`/`@.`/`@!`/`%.`/`%!`) as a `self` attribute, NOT a captured-outer free-var
+     write (new `is_attribute_accessor_name`) — so `method inc { $.count++ }` has empty
+     `free_var_writes` and dispatches compiled. Dynamic (`$*x`) and special twigils stay in
+     `free_var_writes` deliberately (they still need the writeback gate — reduce-time
+     dynamic-var scoping in grammar actions, `t/grammar-reduce-time-dynvar.t`). (b) The earlier
+     investigation (#3661) suspected the *hyper dispatch's attribute-writeback contract* was a
+     deeper blocker (compiled `inc` left `@objs».inc` at `1,2,3`). The real cause was narrower:
+     the compiled path's `$.count++` landed only in `env` — the public `.count` accessor name
+     has no local slot (unlike `$!count`), so the cell-mirror in the inc/dec ops never fired,
+     and the increment never reached `self`'s shared cell at all. The hyper path's
+     commit-of-`updated` was fine; it reads the shared Arc cell, which simply was never
+     written. New `try_slotless_attr_incdec` read-modify-writes the shared cell directly for a
+     slotless scalar attribute twigil, wired into all four inc/dec inner ops — so the mutation
+     reaches the cell and the hyper/direct/junction commits all observe it. pins=
+     `t/compiled-method-attr-incdec.t`(13), `t/parallel-dispatch-regression.t`. (Non-rw
+     `$.attr++` mutating is a pre-existing gap — `$.attr = N` on a non-rw attr already mutates
+     in mutsu; enforcing attribute readonly is a separate axis, out of scope.)
   3. **Resolution caching is unsound naively.** Multi dispatch depends on arg *types* AND
      `where`/value clauses, so a `(class, method, arg-type)` cache is wrong for where/literal
      candidates — any cache must exclude those (or key on more).
-  Sequence for a fresh session: land the merge fix (gate still on → inert but correct), then
-  fix the `free_var_writes` attribute-accessor mis-classification + hyper-rw commit, then
-  relax the gate, then (separately) the sound resolution cache, then delete
+  Remaining sequence: relax the `free_var_writes.is_empty()` gate in
+  `run_resolved_method_compiled_or_treewalk` (the merge from step 1 makes captured-outer
+  writes survive), then (separately) the sound resolution cache, then delete
   `run_instance_method_resolved`.
   **★Pre-existing blocker — BUILDALL sibling writeback clobber — FIXED (#3620).** A
   *nested method dispatch inside one BUILD clobbered a sibling BUILD's captured-outer

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1458,25 +1458,7 @@ impl CompiledCode {
                     continue;
                 }
                 // Skip known method-specific/internal names
-                if name == "self"
-                    || name == "__ANON_STATE__"
-                    || name == "?CLASS"
-                    || name == "?ROLE"
-                    || name == "_"
-                    || name == "!"
-                    || name == "/"
-                    || name == "__mutsu_callable_id"
-                    || name.starts_with('!')
-                    || name.starts_with('.')
-                    || name.starts_with("@!")
-                    || name.starts_with("@.")
-                    || name.starts_with("%!")
-                    || name.starts_with("%.")
-                    || name.starts_with("__mutsu_")
-                    || name.starts_with('*')
-                    || name.starts_with("?")
-                    || name.starts_with('^')
-                {
+                if Self::is_non_lexical_name(name) {
                     continue;
                 }
                 self.may_capture_outer_vars = true;
@@ -1634,6 +1616,52 @@ impl CompiledCode {
     /// `captured_mutated_locals`. NOTE: declaration (`SetLocal` after
     /// `MarkVarDeclContext`) and own-local reassignment (`AssignExprLocal`) are
     /// slot-based and handled separately by the caller.
+    /// A name that is NOT a lexical free variable: an attribute accessor
+    /// (`$.x` → `.x`, `$!x` → `!x`, `@.x`/`@!x`/`%.x`/`%!x`), `self`, a special
+    /// twigil var (`$*foo`, `$?FILE`, `$^a`), or a compiler-internal temporary.
+    /// Such names resolve via `self`/dynamic scope/internals, never the
+    /// enclosing lexical env, so they must be excluded from the free-var
+    /// read/write classification (otherwise e.g. `method inc { $.count++ }`
+    /// mis-records `.count` as a captured-outer write and the redispatch
+    /// writeback corrupts the rw attribute update — #3658).
+    pub(crate) fn is_non_lexical_name(name: &str) -> bool {
+        name == "self"
+            || name == "__ANON_STATE__"
+            || name == "?CLASS"
+            || name == "?ROLE"
+            || name == "_"
+            || name == "!"
+            || name == "/"
+            || name == "__mutsu_callable_id"
+            || name.starts_with('!')
+            || name.starts_with('.')
+            || name.starts_with("@!")
+            || name.starts_with("@.")
+            || name.starts_with("%!")
+            || name.starts_with("%.")
+            || name.starts_with("__mutsu_")
+            || name.starts_with('*')
+            || name.starts_with('?')
+            || name.starts_with('^')
+    }
+
+    /// A name that names an instance attribute via its twigil (`$!x` → `!x`,
+    /// `$.x` → `.x`, and the `@!`/`@.`/`%!`/`%.` array/hash forms). These resolve
+    /// through `self`, never the enclosing lexical env, so a *write* to one is an
+    /// attribute mutation — NOT a captured-outer free-var write. Narrower than
+    /// `is_non_lexical_name`: it deliberately does NOT cover dynamic (`$*x`) or
+    /// special (`$?x`/`$^x`) vars, which must stay in `free_var_writes` to keep
+    /// the redispatch writeback gate (#3658).
+    fn is_attribute_accessor_name(name: &str) -> bool {
+        name == "self"
+            || name.starts_with('!')
+            || name.starts_with('.')
+            || name.starts_with("@!")
+            || name.starts_with("@.")
+            || name.starts_with("%!")
+            || name.starts_with("%.")
+    }
+
     fn op_name_write_const_idx(op: &OpCode) -> Option<u32> {
         match op {
             OpCode::SetGlobal(idx)
@@ -1733,7 +1761,16 @@ impl CompiledCode {
             {
                 if own.contains(name.as_str()) {
                     self_mutated.insert(Symbol::intern(name));
-                } else {
+                } else if !Self::is_attribute_accessor_name(name) {
+                    // Attribute accessors (`$.count++` → name `.count`, `$!x`, the
+                    // `@.`/`@!`/`%.`/`%!` forms) resolve via `self`, NOT the
+                    // enclosing lexical env, so they must not count as free-var
+                    // writes — else the redispatch writeback mis-propagates the
+                    // attribute name as a caller var (#3658). Dynamic vars (`$*x`)
+                    // and special twigils stay in `free_var_writes` deliberately:
+                    // they still need the writeback gate (reduce-time dynamic-var
+                    // scoping in grammar actions, t/grammar-reduce-time-dynvar.t),
+                    // so they are NOT excluded here.
                     free_writes.insert(Symbol::intern(name));
                 }
             }

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -937,6 +937,9 @@ impl Interpreter {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
+        if let Some(r) = self.try_slotless_attr_incdec(code, name, true, true) {
+            return r;
+        }
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })
@@ -1035,6 +1038,9 @@ impl Interpreter {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
+        if let Some(r) = self.try_slotless_attr_incdec(code, name, false, true) {
+            return r;
+        }
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)
             && !matches!(self.locals[slot], Value::Proxy { .. })

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1851,6 +1851,45 @@ impl Interpreter {
         r
     }
 
+    /// Read-modify-write a scalar attribute that has NO local slot — the public
+    /// accessor twigil form `$.count++` / `--$.count`. The private `$!count` form
+    /// binds a local slot and is handled by the slot + cell-mirror path; the public
+    /// form compiles to a raw name op (`.count`) with no slot, so without this the
+    /// increment lands only in `env` and never reaches `self`'s shared attribute
+    /// cell — losing the rw-attribute update under compiled dispatch (the hyper-rw
+    /// `@objs».inc` of `method inc { $.count++ }`, #3658). Returns `Some(result)`
+    /// when it handled a slotless scalar attribute, `None` otherwise (the caller
+    /// continues its normal env path). `is_pre` selects whether the NEW (pre) or
+    /// OLD (post) value is pushed onto the stack.
+    pub(super) fn try_slotless_attr_incdec(
+        &mut self,
+        code: &CompiledCode,
+        name: &str,
+        is_increment: bool,
+        is_pre: bool,
+    ) -> Option<Result<(), RuntimeError>> {
+        if Self::attr_twigil_base(name).is_none() || self.find_local_slot(code, name).is_some() {
+            return None;
+        }
+        let cur = self.read_self_attr_cell(name)?;
+        let result = (|| {
+            self.check_readonly_for_increment(name)?;
+            let val = self.normalize_incdec_source_with_type(name, cur);
+            let new_val = if is_increment {
+                self.increment_value_smart(&val)?
+            } else {
+                self.decrement_value_smart(&val)?
+            };
+            self.check_incdec_type_constraint(name, &new_val)?;
+            self.write_self_attr_cell(name, new_val.clone());
+            // Keep env coherent for a later same-frame read of the accessor name.
+            self.set_env_with_main_alias(name, new_val.clone());
+            self.stack.push(if is_pre { new_val } else { val });
+            Ok(())
+        })();
+        Some(result)
+    }
+
     fn exec_post_increment_op_inner(
         &mut self,
         code: &CompiledCode,
@@ -1867,6 +1906,9 @@ impl Interpreter {
             loan_env!(self, set_caller_var(&bare_name, depth, new_val))?;
             self.stack.push(val);
             return Ok(());
+        }
+        if let Some(r) = self.try_slotless_attr_incdec(code, name, true, false) {
+            return r;
         }
         self.check_readonly_for_increment(name)?;
         if name.starts_with('!')
@@ -1953,6 +1995,9 @@ impl Interpreter {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
+        if let Some(r) = self.try_slotless_attr_incdec(code, name, false, false) {
+            return r;
+        }
         self.check_readonly_for_increment(name)?;
         if name.starts_with('!')
             && let Some(slot) = self.find_local_slot(code, name)

--- a/t/compiled-method-attr-incdec.t
+++ b/t/compiled-method-attr-incdec.t
@@ -1,0 +1,60 @@
+use Test;
+
+# §B (#3658): a public rw attribute mutated by ++/--/pre-inc/dec inside a method
+# body (`$.count++`) must persist to the instance even when the method runs as
+# compiled bytecode (the writeback-safety gate now treats `.count` as an
+# attribute, not a captured-outer free var, so the method dispatches compiled).
+# Regression: it previously silently dropped the mutation (returned the old
+# value) under compiled dispatch, breaking the hyper-rw `@objs».inc` form.
+
+plan 13;
+
+class Counter {
+    has $.count is rw;
+    method inc  { $.count++ }
+    method dec  { $.count-- }
+    method preinc { ++$.count }
+    method predec { --$.count }
+}
+
+# Direct dispatch — post-increment returns OLD value, persists the new one.
+my $c = Counter.new(count => 5);
+is $c.inc, 5, 'post-increment returns the old value';
+is $c.count, 6, 'post-increment persisted to the instance';
+
+is $c.dec, 6, 'post-decrement returns the old value';
+is $c.count, 5, 'post-decrement persisted to the instance';
+
+# Pre-increment / pre-decrement return the NEW value.
+is $c.preinc, 6, 'pre-increment returns the new value';
+is $c.count, 6, 'pre-increment persisted to the instance';
+
+is $c.predec, 5, 'pre-decrement returns the new value';
+is $c.count, 5, 'pre-decrement persisted to the instance';
+
+# Hyper dispatch (`@objs».inc`) updates each object's rw public attribute.
+my @objs = (1..3).map({ Counter.new(count => $_) });
+@objs».inc;
+is @objs.map({ .count }).join(","), "2,3,4",
+    'hyper post-increment updates rw public attributes';
+
+@objs».dec;
+is @objs.map({ .count }).join(","), "1,2,3",
+    'hyper post-decrement updates rw public attributes';
+
+# Multiple increments accumulate across calls (cell, not a per-call snapshot).
+my $d = Counter.new(count => 0);
+$d.inc for ^4;
+is $d.count, 4, 'repeated increments accumulate on the shared cell';
+
+# String increment semantics still apply to the attribute.
+class Tag { has $.id is rw; method bump { $.id++ } }
+my $t = Tag.new(id => 'aa');
+$t.bump;
+is $t.id, 'ab', 'string magic increment works on a public attribute';
+
+# Private-attribute increment (the always-mutable storage form) still works.
+class Priv { has $!n; method bump { $!n++ }; method get { $!n } }
+my $p = Priv.new;
+$p.bump; $p.bump;
+is $p.get, 2, 'private attribute increment still persists';


### PR DESCRIPTION
## Summary

Step 2 of the `run_instance_method_resolved` deletion sequence (`docs/treewalk-method-removal-plan.md` / #3658). Two coupled fixes that let an rw public-attribute increment run as compiled bytecode:

1. **`free_var_writes` classification.** `compute_free_vars` now treats an attribute-twigil name (`.count`, `!x`, and the `@.`/`@!`/`%.`/`%!` forms) as a `self` attribute, **not** a captured-outer free-var write (new `is_attribute_accessor_name`). So `method inc { $.count++ }` has empty `free_var_writes` and dispatches compiled instead of tree-walked. Dynamic (`$*x`) and special (`$?x`/`$^x`) twigils stay in `free_var_writes` deliberately — they still need the redispatch writeback gate (reduce-time dynamic-var scoping in grammar actions, `t/grammar-reduce-time-dynvar.t`).

2. **Slotless attribute inc/dec.** The public `$.count++` accessor name compiles to a raw `.count` name op with **no local slot** (unlike `$!count`, which binds a slot and mirrors to `self`'s cell). Under compiled dispatch the increment landed only in `env` and never reached `self`'s shared attribute cell, so the rw-attribute update was lost (`@objs».inc` of `method inc { $.count++ }` returned `1,2,3` instead of `2,3,4`). New `try_slotless_attr_incdec` read-modify-writes the shared cell directly for a slotless scalar attribute twigil, wired into all four inc/dec inner ops. The hyper/direct/junction commits read the shared `Arc` cell, so once it is written they all observe the mutation — the earlier suspicion (#3661) that the hyper writeback contract was the deeper blocker was wrong; the cell simply was never written.

Non-rw `$.attr++` now mutates (consistent with `$.attr = N`, which already mutates a non-rw attr in mutsu); enforcing attribute readonly is a separate, pre-existing gap, out of scope here.

## Remaining sequence (#3658)

3. Relax the `free_var_writes.is_empty()` gate in `run_resolved_method_compiled_or_treewalk` (the #3664 merge makes captured-outer writes survive).
4. Sound resolution cache.
5. Delete `run_instance_method_resolved`.

## Verification (fresh release build)

- `make test` → 12165 green.
- Pins: `compiled-method-attr-incdec`(13, new), `parallel-dispatch-regression`, `grammar-reduce-time-dynvar`, `hyper-autoincr-writeback`, `hyper-assign`, `hyper-func-op-writeback`, `multi-method-compiled-dispatch`, `construction-submethod-compiled`, `method-redispatch-compiled`, `nextsame-rw-redispatch`, `coercion/render-method-captured-writeback`.
- Roast: `S12-methods/{defer-next,multi}`, `S12-construction/BUILD`, `S12-attributes/{instance,mutators}`, `S14-roles/basic`, `S03-operators/hyper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)