### PR TITLE
feat(signature): return constraint followed by `;` is X::Syntax::Malformed

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -2104,7 +2104,12 @@ pub(super) fn parse_return_type_annotation(input: &str) -> PResult<'_, String> {
                 brace_depth -= 1;
                 idx += 1;
             }
-            b',' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => break,
+            // A `,` or `;` at signature-depth ends the return constraint. Since a
+            // `-->` return constraint must be the LAST element of the signature,
+            // anything after the break is a stray parameter — the caller then
+            // fails with a malformed-signature error (return constraints only
+            // allowed at the end), matching Raku's X::Syntax::Malformed.
+            b',' | b';' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => break,
             _ => idx += 1,
         }
     }

--- a/t/return-constraint-malformed.t
+++ b/t/return-constraint-malformed.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 10;
+
+# A `-->` return constraint must be the LAST element of a signature. Anything
+# after it (whether comma- or semicolon-separated) is a stray parameter and
+# must throw X::Syntax::Malformed (return constraints only allowed at the end).
+# See roast/S32-exceptions/misc.t (old-issue-tracker #4968).
+sub bad($code) { throws-like $code, X::Syntax::Malformed, :what(/return/) }
+bad 'sub foo (--> Bool Int $x, Int $y) { True }';
+bad 'sub foo (--> Bool Int $x; Int $y) { True }';
+bad 'sub foo (--> Bool Int $x, Int $y)';
+bad 'sub foo (--> Bool Int $x; Int $y)';
+bad 'sub foo (--> Bool, Int $x, Int $y)';
+bad 'sub foo (--> Bool; Int $x; Int $y)';
+bad 'sub foo ($x, --> Bool, Int $y)';
+bad 'sub foo ($x; --> Bool; Int $y)';
+
+# Legal signatures with a trailing return constraint, and multidimensional
+# signatures using `;`, must remain unaffected.
+{
+    sub good(--> Int) { 42 }
+    is good(), 42, 'trailing --> return constraint still works';
+}
+{
+    sub multidim(@a; @b) { @a.elems + @b.elems }
+    is multidim([1, 2], [3, 4, 5]), 5, 'multidimensional `;` signature still works';
+}


### PR DESCRIPTION
## Summary

A `-->` return constraint must be the LAST element of a signature. The return-type scanner already stopped at a depth-0 `,` (so `sub foo (--> Bool, Int \$x)` correctly failed), but it slurped a `;` into the return type, so:

```raku
sub foo (--> Bool Int $x; Int $y) { True }   # before: silently accepted
```

was wrongly accepted. Now a depth-0 `;` also terminates the return constraint, and the trailing stray parameter fails as a malformed signature — `X::Syntax::Malformed` ("return constraints only allowed at the end of the signature"), matching Raku.

## Not affected
- Multidimensional `;` signatures: `sub f(@a; @b) { ... }` (the `;` break only applies while scanning a `-->` return type).
- Normal trailing return constraints: `sub g(--> Int) { 42 }`, `sub h() returns Str { ... }`.

## Result
Fixes the last failing subtest of the misc.t #4968 block (`roast/S32-exceptions/misc.t`); misc.t 35 → 34 failures. `S06-signature/multidimensional.t` and `S06-signature/types.t` still pass.

## Test
- New `t/return-constraint-malformed.t` (10 assertions): all 8 malformed variants throw `X::Syntax::Malformed`, plus the two legal-use regressions.
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)