### PR TITLE
feat(parser): `no Module BareWord` (undeclared) is X::Undeclared::Symbols

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -623,6 +623,9 @@ pub(crate) enum Stmt {
     /// `no Module ...;` — disable pragma/module effects for current lexical scope.
     No {
         module: String,
+        /// Positional argument (e.g. `no Module BareWord`), if any. Mirrors
+        /// `Use { arg }`; used for undeclared-symbol detection.
+        arg: Option<Expr>,
     },
     /// `need Module;` — load module without importing exports
     Need {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2649,7 +2649,7 @@ impl Compiler {
                 };
                 self.code.emit(OpCode::ImportModule { name_idx, tags_idx });
             }
-            Stmt::No { module } => {
+            Stmt::No { module, .. } => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
                 self.code.emit(OpCode::NoModule(name_idx));
             }

--- a/src/parser/stmt/decl/use_decl.rs
+++ b/src/parser/stmt/decl/use_decl.rs
@@ -409,6 +409,5 @@ pub(in crate::parser::stmt) fn no_stmt(input: &str) -> PResult<'_, Stmt> {
 
     let (rest, _) = ws(rest)?;
     let (rest, _) = opt_char(rest, ';');
-    let _ = arg;
-    Ok((rest, Stmt::No { module }))
+    Ok((rest, Stmt::No { module, arg }))
 }

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -956,7 +956,7 @@ mod tests {
         let (rest, stmts) = program("no strict;").unwrap();
         assert_eq!(rest, "");
         assert_eq!(stmts.len(), 1);
-        assert!(matches!(&stmts[0], Stmt::No { module } if module == "strict"));
+        assert!(matches!(&stmts[0], Stmt::No { module, .. } if module == "strict"));
     }
 
     #[test]

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -1204,7 +1204,7 @@ impl Interpreter {
             // argument is a term reference, not an import symbol (those are
             // strings / `<...>` / `:tags`). An undeclared one is
             // X::Undeclared::Symbols (rakudo: "Undeclared name: ...").
-            Stmt::Use { arg: Some(arg), .. } => {
+            Stmt::Use { arg: Some(arg), .. } | Stmt::No { arg: Some(arg), .. } => {
                 self.find_undeclared_name_in_expr(arg, local_classes, declared)
             }
             _ => None,

--- a/t/no-pragma-undeclared-arg.t
+++ b/t/no-pragma-undeclared-arg.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 4;
+
+# A bare identifier as a positional argument to `use`/`no` is a term
+# reference, not an import symbol (those are strings / `<...>` / `:tags`).
+# An undeclared one is X::Undeclared::Symbols, for both `use` and `no`.
+# See roast/S32-exceptions/misc.t (old-issue-tracker #3649).
+throws-like 'use DoesNotMatter Undeclared;', X::Undeclared::Symbols,
+    'use Module BareWord (undeclared) throws X::Undeclared::Symbols';
+throws-like 'no DoesNotMatter Undeclared;', X::Undeclared::Symbols,
+    'no Module BareWord (undeclared) throws X::Undeclared::Symbols';
+
+# Legal `no` pragmas without a bareword argument must remain unaffected.
+{
+    my $out = EVAL 'no strict; $undeclared_ok = 42; $undeclared_ok';
+    is $out, 42, 'no strict still works (no false undeclared positive)';
+}
+{
+    lives-ok { EVAL 'no worries; 1' }, 'no worries pragma still works';
+}


### PR DESCRIPTION
## Summary

A bare identifier as a positional argument to `use`/`no` is a term reference, not an import symbol (those are strings / `<...>` / `:tags`). #3647 added this detection for `use`, but the `no` statement discarded its parsed argument (`Stmt::No` had no `arg` field), so:

```raku
no DoesNotMatter Undeclared;   # before: silently accepted ; now: X::Undeclared::Symbols
```

was silently accepted.

## Change
- Add an `arg: Option<Expr>` field to `Stmt::No` (mirroring `Stmt::Use`); the parser already parsed the argument but threw it away.
- Scan it in `find_undeclared_name_in_stmt` (shared arm with `Stmt::Use`).

The scan runs only in the EVAL/throws-like compile-time pre-check, so normal `no` pragmas (`no strict`, `no worries`, …) are unaffected at runtime.

## Result
Makes roast `S32-exceptions/misc.t` #3649 `no` subtest (test 51) pass.

## Test
- New `t/no-pragma-undeclared-arg.t` (4 assertions): `use`/`no` undeclared bareword both throw, plus `no strict` / `no worries` regressions.
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)