### PR TITLE
fix(vm): compiled-method can_skip_merge must account for has_calls (closure/code-var env writes)

### DIFF
--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -1792,7 +1792,12 @@ impl Interpreter {
                     && !pd.named
             })
             .count();
-        let can_skip_merge = !cc.has_env_writes;
+        // Also gate on `cc.has_calls`: a body that invokes a CLOSURE
+        // (`$f()` — `CallOnValue`/`CallOnCodeVar`) or a CallDefined/ExecCallSlip can
+        // write a dynamic var / captured-outer lexical / global into this frame's
+        // env (those call ops are NOT in `has_env_writes`). Skipping the merge would
+        // drop that write — e.g. `method go { my $f = { $*x = 1 }; $f() }`. #3658.
+        let can_skip_merge = !cc.has_env_writes && !cc.has_calls;
         let has_defaults = method_def.param_defs.iter().any(|pd| {
             !pd.is_invocant && !pd.traits.iter().any(|t| t == "invocant") && pd.default.is_some()
         });

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -89,10 +89,20 @@ impl Interpreter {
         // mirroring how `has_aliasable_container_params` handles `@`/`%` params.
         let shares_scalar_container =
             self.method_shares_container_into_scalar_param(method_def, &args);
+        // `cc.has_calls` (not just `has_env_writes`): a body that calls a CLOSURE
+        // (`my $f = { $*x = 1 }; $f()` — `CallOnValue`/`CallOnCodeVar`) or any other
+        // call op NOT listed in `has_env_writes` (CallDefined/ExecCallSlip) can
+        // write a captured-outer lexical, dynamic var, or global into this frame's
+        // env. Skipping the merge would silently drop that write (e.g. a grammar
+        // action `method delim { my $f = { $*L = '<' }; $f() }` — the dynamic-var
+        // change is lost). The closure dispatch already gates on
+        // `has_calls || has_env_writes` (vm_closure_dispatch.rs); the method fast
+        // path dropped `has_calls`. #3658.
         let can_skip_merge = !has_rw_params
             && !has_aliasable_container_params
             && !shares_scalar_container
-            && !cc.has_env_writes;
+            && !cc.has_env_writes
+            && !cc.has_calls;
 
         // Fast path: bypass env entirely and populate locals directly from
         // source data. Avoids the ~12μs Arc::make_mut deep clone that the

--- a/t/method-closure-env-write-merge.t
+++ b/t/method-closure-env-write-merge.t
@@ -1,0 +1,54 @@
+use Test;
+
+# A method whose body INVOKES A CLOSURE that writes an outer-scope variable
+# (dynamic var, captured-outer lexical, or global) must merge that write back to
+# the caller. The compiled method fast path's can_skip_merge gated only on
+# has_env_writes, which omits the closure-invocation ops (CallOnValue/
+# CallOnCodeVar) and CallDefined/ExecCallSlip — so the write was silently dropped
+# (a method `{ my $f = { $*x = 1 }; $f() }` left $*x unchanged). The closure
+# dispatch already gated on has_calls || has_env_writes; the method path did not.
+
+plan 7;
+
+# Dynamic variable written by a nested closure inside a method.
+my $*DV = 'orig';
+class A { method go { my $f = { $*DV = 'changed' }; $f() } }
+A.new.go;
+is $*DV, 'changed', 'dynamic var written by a nested closure in a method propagates';
+
+# Captured-outer lexical written by a nested closure inside a method.
+my $lex = 0;
+class B { method bump { my $f = { $lex = 42 }; $f() } }
+B.new.bump;
+is $lex, 42, 'captured-outer lexical written by a nested closure in a method propagates';
+
+# Two dynamic vars written by a nested closure (the grammar delimiter shape).
+my $*L = '{';
+my $*R = '}';
+class C { method delim { my $f = { $*L = '<'; $*R = '>'; }; $f() } }
+C.new.delim;
+is "$*L$*R", '<>', 'both dynamic vars written by a nested closure propagate';
+
+# A direct dynamic-var write from a method still works (was never broken).
+my $*D2 = 'a';
+class D { method set { $*D2 = 'b' } }
+D.new.set;
+is $*D2, 'b', 'direct dynamic-var write from a method still propagates';
+
+# A method calling a named sub that writes a dynamic var via .() also merges.
+my $*VIA = 'x';
+sub writer { $*VIA = 'y' }
+class E { method run { my $w = &writer; $w() } }
+E.new.run;
+is $*VIA, 'y', 'dynamic var written through a code-var call in a method propagates';
+
+# Nested closure increment of a captured-outer counter accumulates across calls.
+my $count = 0;
+class F { method tick { my $f = { $count++ }; $f() } }
+my $f = F.new;
+$f.tick; $f.tick; $f.tick;
+is $count, 3, 'nested-closure captured-outer increment accumulates across method calls';
+
+# A pure method (no calls, no env writes) still skips the merge correctly.
+class G { has $.v; method read { $.v } }
+is G.new(v => 9).read, 9, 'a pure read-only method still returns correctly (merge-skip intact)';


### PR DESCRIPTION
## Summary

A method body that **invokes a closure** which writes an outer-scope variable — `method go { my \$f = { \$*x = 1 }; \$f() }` — silently dropped the write under compiled dispatch.

The fast-path `can_skip_merge` gated only on `cc.has_env_writes`, whose call-op set omits the closure-invocation ops (`CallOnValue` / `CallOnCodeVar`) and `CallDefined` / `ExecCallSlip`. With `can_skip_merge` true the method exit just restores the saved caller env, discarding any dynamic var / captured-outer lexical / global the called closure wrote.

Subs were unaffected — the closure dispatch already gates on `has_calls || has_env_writes`; only the **method** paths dropped `has_calls`.

## Fix

Both method `can_skip_merge` sites — the `call_compiled_method` full path and the `fast_method_cache` entry consumed by `dispatch_compiled_method` (the direct-call catch-all) — now also require `!cc.has_calls`, mirroring the closure dispatch. A pure read-only method (no calls, no env writes) still skips the merge.

This is a standalone correctness fix for a **pre-existing** bug (confirmed: fails identically on `origin/main`), independent of but on the path to the `run_instance_method_resolved` deletion (#3658): it makes nested-closure dynamic-var writes from methods work whether the method dispatches via the catch-all (direct call) or the resolved-candidate slow path — which unblocks removing the dynamic/special-twigil gate exception next.

## Verification (fresh release build)

- `make test` → 12236 green.
- Pins: `method-closure-env-write-merge`(7, new), `grammar-reduce-time-dynvar`, `captured-outer-method-compiled-gate`, `compiled-method-attr-incdec`, `parallel-dispatch-regression`, `nextsame-rw-redispatch`.
- Roast: `S05-grammar/{action-stubs,protoregex}`, `S05-metasyntax/repeat`, `S12-methods/defer-next`, `S12-construction/BUILD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)