### PR TITLE
feat(dispatch): bodyless `proto method new` routes through the proto runner

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -3473,6 +3473,39 @@ impl Interpreter {
                     );
                     return Ok(Value::make_instance(*class_name, attrs));
                 }
+                // An explicit `proto method new` owns dispatch. When there are
+                // no multi candidates it is registered only as a proto (so
+                // `has_user_method` is false), yet `.new` must still run the
+                // proto body: `proto method new() { 42 }` returns 42, while a
+                // pure forwarder `proto method new($) {*}` with no candidates
+                // surfaces X::Multi::NoMatch. Route through the proto runner
+                // instead of falling back to the default constructor.
+                if !self.has_user_method(class_key, "new")
+                    && let Some((owner, proto)) =
+                        self.lookup_proto_method(&class_name.resolve(), "new")
+                {
+                    // A pure `{*}` forwarder proto with no multi candidates can
+                    // never dispatch, so running it would recurse forever via
+                    // `__PROTO_DISPATCH__` re-entering `.new`. Short-circuit to
+                    // X::Multi::NoMatch. A proto with a real body (no `{*}`)
+                    // runs normally and returns its value.
+                    if proto
+                        .body
+                        .iter()
+                        .any(|s| matches!(s, Stmt::Expr(Expr::Whatever)))
+                    {
+                        return Err(super::methods_signature::make_multi_no_match_error("new"));
+                    }
+                    let cn = class_name.resolve();
+                    return self.run_proto_method(
+                        target.clone(),
+                        &cn,
+                        &owner,
+                        "new",
+                        args.clone(),
+                        proto,
+                    );
+                }
                 // Check for user-defined .new method first
                 if self.has_user_method(class_key, "new") {
                     let empty_attrs = HashMap::new();

--- a/t/proto-new-no-match.t
+++ b/t/proto-new-no-match.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 7;
+plan 9;
 
 # An explicit `proto method new` overrides the inherited Mu.new proto, so it
 # owns dispatch entirely. A call that matches no candidate must surface as
@@ -51,4 +51,19 @@ throws-like 'constant boom = die "kaboom"', X::Comp::BeginTime,
 {
     constant @list = 1, 2, 3;
     is @list.elems, 3, 'constant list initializer still works';
+}
+
+# A bodyless `proto method new` (pure `{*}` forwarder) with NO multi candidates
+# can never dispatch, so any call surfaces X::Multi::NoMatch (not the default
+# constructor's X::Constructor::Positional, and not a stack overflow).
+{
+    my class A is Any { proto method new($) {*} }
+    throws-like { A.new(now) }, X::Multi::NoMatch,
+        'bodyless proto new with no candidates throws X::Multi::NoMatch';
+}
+
+# A `proto method new` with a real body (no `{*}`) runs the body.
+{
+    my class B { proto method new() { 42 } }
+    is B.new, 42, 'proto new with a real body runs the body';
 }


### PR DESCRIPTION
## Summary

#3665 made a `proto+multi method new` no-match throw `X::Multi::NoMatch`, but only when there was at least one multi candidate (so `has_user_method` was true). A class whose only `new` is a bodyless proto registers just the proto, not a regular method, so `.new` fell back to the default constructor and wrongly gave `X::Constructor::Positional`:

```raku
my class A is Any { proto method new($) {*} }
A.new(now);   # before: X::Constructor::Positional ; now: X::Multi::NoMatch
```

## Change
Route such a `.new` through the proto runner:
- a pure `{*}` forwarder with no candidates can never dispatch (running it would recurse forever via `__PROTO_DISPATCH__` re-entering `.new`), so short-circuit to `X::Multi::NoMatch`;
- a proto with a real body (no `{*}`, e.g. `proto method new() { 42 }`) runs the body and returns its value (`A.new` → `42`), matching Raku.

## Result
Makes roast `S32-exceptions/misc.t` #3142 (`A.new(now)` → `X::Multi::NoMatch`) pass; misc.t failures down 2. `S12-construction/new.t` and `S12-methods/multi.t` still pass.

## Test
- `t/proto-new-no-match.t` extended (now 9 assertions): bodyless-proto no-match, and real-body proto runs.
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)