### PR TITLE
feat(vm): remove free_var_writes gate filter — all compiled candidates run compiled (§B #3658 step 4)

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -279,20 +279,34 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
      **dynamic (`$*x`) / special (`$?x`/`$^x`)** twigils, whose reduce-time / dynamic-scope
      writeback through a compiled redispatch frame is not yet wired (the remaining blocker
      below). `make test` (12205) green; pin=`t/captured-outer-method-compiled-gate.t`(7).
-     **★Remaining for full relaxation (4): dynamic-var writeback through compiled redispatch.**
-     `method delim { $*L = '<' }` (grammar reduce-time action, `t/grammar-reduce-time-dynvar.t`)
-     — the only case that still needs tree-walk. Also note a SEPARATE pre-existing gap (NOT a
-     regression, fails identically on tree-walk): hyper dispatch `@objs».meth` of a method
-     writing a captured-outer lexical (`method touch { $seen++ }`) does not propagate the
-     write — the hyper internal temp-target redispatch has no op-level drain of
-     `pending_rw_writeback_sources` (the coercion/render Slice-1a/1b drain pattern, not yet
-     applied to the hyper/junction sites). That gap predates the gate work and is orthogonal.
-  4. **Resolution caching is unsound naively.** Multi dispatch depends on arg *types* AND
+  4. **`can_skip_merge` closure/code-var env-write fix — DONE (#3670).** The blocker for
+     dynamic-var writeback was NOT a missing redispatch drain — it was that the compiled
+     method fast-path `can_skip_merge` gated only on `cc.has_env_writes`, whose call-op set
+     omits the closure-invocation ops (`CallOnValue`/`CallOnCodeVar`) and `CallDefined`/
+     `ExecCallSlip`. A method invoking a closure that writes a dynamic var (`method delim { my
+     $f = { $*L = '<' }; $f() }`) had its env-write silently dropped on exit (saved env just
+     restored). Both method `can_skip_merge` sites now also require `!cc.has_calls` (mirroring
+     the closure dispatch, which already did). This is a general correctness fix — it also
+     fixed the same bug for DIRECT calls through the catch-all. pin=
+     `t/method-closure-env-write-merge.t`(7).
+  5. **`free_var_writes` gate filter REMOVED — DONE (#TBD).** With #3670 in place the gate's
+     dynamic/special-twigil exception is no longer needed: `run_resolved_method_compiled_or_treewalk`
+     now runs ANY candidate with `compiled_code.is_some() && delegation.is_none()` compiled,
+     regardless of free-var writes. `grammar-reduce-time-dynvar.t` passes compiled; `make test`
+     (12240) green. `run_instance_method_resolved` is now reached ONLY for `compiled_code = None`
+     candidates — delegation forwarders and any method that failed to compile.
+  6. **Resolution caching is unsound naively.** Multi dispatch depends on arg *types* AND
      `where`/value clauses, so a `(class, method, arg-type)` cache is wrong for where/literal
      candidates — any cache must exclude those (or key on more).
-  Remaining sequence: wire the dynamic-var writeback through the compiled redispatch frame
-  (then the gate's dynamic/special exception can drop too), then (separately) the sound
-  resolution cache, then delete `run_instance_method_resolved`.
+  **★Separate pre-existing gap (NOT a regression, orthogonal):** hyper dispatch `@objs».meth`
+  of a method writing a captured-outer *lexical* (`method touch { $seen++ }`) does not
+  propagate the write — the hyper internal temp-target redispatch has no op-level drain of
+  `pending_rw_writeback_sources` (the coercion/render Slice-1a/1b drain pattern, not yet applied
+  to the hyper/junction sites). Fails identically on tree-walk; predates this work.
+  Remaining sequence: handle the `compiled_code = None` candidates (compile delegation
+  forwarders / ensure every method compiles) so the tree-walk fallback is unreachable, then
+  delete `run_instance_method_resolved` (a sound resolution cache is an orthogonal perf win,
+  not a prerequisite for deletion).
   **★Pre-existing blocker — BUILDALL sibling writeback clobber — FIXED (#3620).** A
   *nested method dispatch inside one BUILD clobbered a sibling BUILD's captured-outer
   writeback*:

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -988,25 +988,24 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
-        // Writeback-safety gate (§B, #3658 step 3). A captured-outer *lexical*
-        // write (`method m { $outer++ }` closing over a `my $outer`) is now safe
-        // to run compiled: `call_compiled_method` records the change into
-        // `pending_rw_writeback_sources`, and the caller drain MERGES it (#3664)
-        // rather than discarding it. The ONLY free-var writes that still require
-        // the env-merging tree-walk are dynamic (`$*x`) and special (`$?x`/`$^x`)
-        // twigils — their reduce-time / dynamic-scope writeback through a compiled
-        // redispatch frame is not yet wired (t/grammar-reduce-time-dynvar.t: a
-        // grammar action `method delim { $*L = '<' }` whose write must affect the
-        // ongoing match). Attribute twigils (`.count`/`!x`/…) are not in
-        // `free_var_writes` at all (#3666, `is_attribute_accessor_name`). A
-        // delegation forwarder is synthesized (`compiled_code = None`) and keeps
-        // the interpreter path. The free-var names are sigil-stripped, twigil-kept
-        // (`$*L` → `*L`).
-        let writeback_safe_compiled = method_def.compiled_code.as_ref().is_some_and(|cc| {
-            cc.free_var_writes.iter().all(|s| {
-                s.with_str(|n| !n.starts_with('*') && !n.starts_with('?') && !n.starts_with('^'))
-            })
-        }) && method_def.delegation.is_none();
+        // Writeback-safety gate (§B, #3658 step 4 — free_var_writes filter REMOVED).
+        // Any resolved candidate that has compiled bytecode and is not a delegation
+        // forwarder now runs compiled, regardless of what free vars it writes:
+        //   - captured-outer *lexical* writes (`method m { $outer++ }`) propagate via
+        //     `call_compiled_method` queuing `pending_rw_writeback_sources` + the
+        //     caller drain MERGING it (#3664);
+        //   - dynamic (`$*x`) / captured-outer writes from a nested CLOSURE inside
+        //     the body (the grammar reduce-time action `method delim { my $f = { $*L =
+        //     '<' }; $f() }`) propagate now that the method fast-path `can_skip_merge`
+        //     also gates on `has_calls` (#3670) — so the closure's env write is merged
+        //     back instead of dropped;
+        //   - attribute twigils (`.count`/`!x`/…) are not in `free_var_writes` at all
+        //     (#3666).
+        // A delegation forwarder is synthesized with `compiled_code = None`, and an
+        // uncompiled method likewise has none, so both fall through to the tree-walk
+        // `run_instance_method_resolved` (the remaining reason it still exists).
+        let writeback_safe_compiled =
+            method_def.compiled_code.is_some() && method_def.delegation.is_none();
         if !writeback_safe_compiled {
             return self.run_instance_method_resolved(
                 receiver_class_name,


### PR DESCRIPTION
## Summary

`run_resolved_method_compiled_or_treewalk` no longer filters by `free_var_writes`: any resolved candidate with compiled bytecode that is not a delegation forwarder now runs as compiled bytecode, regardless of which free vars its body writes.

This is safe now that the prerequisites have landed:
- captured-outer lexical writes propagate via the **merged** `pending_rw_writeback` drain (#3664, step 1);
- dynamic-var / captured-outer writes from a **nested closure** inside the body (the grammar reduce-time action `method delim { my \$f = { \$*L='<' }; \$f() }`) propagate now that the method fast-path `can_skip_merge` also gates on `has_calls` (#3670) — the closure's env write is merged back instead of dropped;
- attribute twigils are not in `free_var_writes` at all (#3666).

`run_instance_method_resolved` is now reached **only** for candidates with `compiled_code = None` — delegation forwarders and any method that failed to compile. Compiling those (so the tree-walk fallback is unreachable) is the last step before deleting the helper.

## Verification (fresh release build)

- `make test` → 12240 green.
- Pins: `grammar-reduce-time-dynvar`, `method-closure-env-write-merge`, `captured-outer-method-compiled-gate`, `compiled-method-attr-incdec`, `parallel-dispatch-regression`, `nextsame-rw-redispatch`.
- Roast: `S05-grammar/{action-stubs,protoregex}`, `S12-methods/{defer-next,multi}`, `S12-construction/BUILD`, `S12-attributes/instance`, `S14-roles/basic`, `S03-junctions/autothreading`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)