### PR TITLE
feat(signature): trailing `:D`/`:U`/`:_` smiley on a parameter is X::Parameter::InvalidType

### DIFF
--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -1725,6 +1725,18 @@ fn reject_attr_params_in_sub(params: &[ParamDef]) -> Result<(), PError> {
     Ok(())
 }
 
+/// Build an `X::Parameter::InvalidType` for a `:D`/`:U`/`:_` smiley that trails
+/// a parameter after whitespace (`$x :D`) instead of attaching to a type
+/// (`Int:D $x`). Raku reports the smiley letter as a bogus typename.
+fn invalid_param_smiley_error(smiley: &str) -> PError {
+    let msg = format!("Invalid typename '{}' in parameter declaration.", smiley);
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    attrs.insert("typename".to_string(), Value::str(smiley.to_string()));
+    let ex = Value::make_instance(Symbol::intern("X::Parameter::InvalidType"), attrs);
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 fn reject_invocant_in_sub(params: &[ParamDef]) -> Result<(), PError> {
     if params
         .iter()
@@ -1950,6 +1962,19 @@ fn parse_param_list_inner(input: &str) -> PResult<'_, Vec<ParamDef>> {
             params.push(p);
             rest = r;
             continue;
+        }
+        // A `:D`/`:U`/`:_` definedness smiley must attach to a TYPE
+        // (`Int:D $x`), never trail a parameter after whitespace (`$x :D` or
+        // `Int $x :D`). Such a trailing smiley is X::Parameter::InvalidType
+        // ("Invalid typename '<X>'"), not an invocant `:` marker — catch it
+        // before the invocant handling below would mis-read the `:`.
+        if (r.starts_with(":D") || r.starts_with(":U") || r.starts_with(":_"))
+            && r[2..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        {
+            return Err(invalid_param_smiley_error(&r[1..2]));
         }
         // Handle invocant marker ':'
         if let Some(r) = r.strip_prefix(':') {
@@ -2229,6 +2254,19 @@ fn parse_param_list_with_return_inner(input: &str) -> PResult<'_, (Vec<ParamDef>
             params.push(p);
             rest = r;
             continue;
+        }
+        // A `:D`/`:U`/`:_` definedness smiley must attach to a TYPE
+        // (`Int:D $x`), never trail a parameter after whitespace (`$x :D` or
+        // `Int $x :D`). Such a trailing smiley is X::Parameter::InvalidType
+        // ("Invalid typename '<X>'"), not an invocant `:` marker — catch it
+        // before the invocant handling below would mis-read the `:`.
+        if (r.starts_with(":D") || r.starts_with(":U") || r.starts_with(":_"))
+            && r[2..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        {
+            return Err(invalid_param_smiley_error(&r[1..2]));
         }
         if let Some(r) = r.strip_prefix(':') {
             // Mark all params parsed so far as invocant

--- a/t/param-smiley-invalid-type.t
+++ b/t/param-smiley-invalid-type.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 7;
+
+# A `:D`/`:U`/`:_` definedness smiley must attach to a TYPE (`Int:D $x`), never
+# trail a parameter after whitespace. A trailing smiley is X::Parameter::InvalidType
+# ("Invalid typename '<X>'"), not an invocant `:` marker.
+# See roast/S32-exceptions/misc.t (old-issue-tracker #3092).
+throws-like 'sub foo ($bar :D) { 1 }', X::Parameter::InvalidType,
+    'untyped param + trailing :D smiley is X::Parameter::InvalidType';
+throws-like 'sub foo (Int $bar :D) { 1 }', X::Parameter::InvalidType,
+    'typed param + trailing :D smiley is X::Parameter::InvalidType';
+throws-like 'sub foo ($bar :U) { 1 }', X::Parameter::InvalidType,
+    'trailing :U smiley is X::Parameter::InvalidType';
+
+# A proper type-attached smiley still works.
+{
+    sub g(Int:D $x) { $x * 2 }
+    is g(5), 10, 'Int:D $x type-attached smiley works';
+}
+
+# An invocant `:` marker (method) is unaffected.
+{
+    my class C { method m($self: $x) { $x + 1 } }
+    is C.new.m(4), 5, 'method invocant `$self:` marker still parses';
+}
+
+# Plain and multi-param signatures are unaffected.
+{
+    sub h($a, $b) { $a + $b }
+    is h(2, 3), 5, 'plain multi-param signature still works';
+}
+{
+    sub n(:$x) { $x }
+    is n(x => 9), 9, 'named parameter `:$x` still works';
+}


### PR DESCRIPTION
## Summary

A definedness smiley must attach to a TYPE (`Int:D $x`), never trail a parameter after whitespace. mutsu mis-read the `:` in `$bar :D` as an invocant marker, so:

```raku
sub foo ($bar :D) { 1 }     # before: X::Syntax::Signature::InvocantNotAllowed
                            # now:    X::Parameter::InvalidType ("Invalid typename 'D'")
```

## Change
In both signature param-list loops (`parse_param_list_inner` and `parse_param_list_with_return_inner`), detect a `:D`/`:U`/`:_` token (smiley followed by a word boundary) *before* the invocant `:` handling and raise `X::Parameter::InvalidType` naming the smiley letter as the bogus typename.

## Not affected
- Real invocant markers: `method m($self: $x)` (colon then whitespace/`)`/param).
- Type-attached smileys: `Int:D $x`.
- Named params: `:$x`.

## Result
Makes roast `S32-exceptions/misc.t` #3092 (`sub foo ($bar :D)`) pass; misc.t failures down 1. `S06-signature/{errors,multi-invocant,named-parameters,introspection,arity,types,...}.t` all still pass.

## Test
- New `t/param-smiley-invalid-type.t` (7 assertions).
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)