### PR TITLE
feat(vm): route qualified-call / .* walk / proto dispatch through the compiled method runner (§B #3658)

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -289,13 +289,25 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
      the closure dispatch, which already did). This is a general correctness fix — it also
      fixed the same bug for DIRECT calls through the catch-all. pin=
      `t/method-closure-env-write-merge.t`(7).
-  5. **`free_var_writes` gate filter REMOVED — DONE (#TBD).** With #3670 in place the gate's
+  5. **`free_var_writes` gate filter REMOVED — DONE (#3672).** With #3670 in place the gate's
      dynamic/special-twigil exception is no longer needed: `run_resolved_method_compiled_or_treewalk`
      now runs ANY candidate with `compiled_code.is_some() && delegation.is_none()` compiled,
      regardless of free-var writes. `grammar-reduce-time-dynvar.t` passes compiled; `make test`
-     (12240) green. `run_instance_method_resolved` is now reached ONLY for `compiled_code = None`
-     candidates — delegation forwarders and any method that failed to compile.
-  6. **Resolution caching is unsound naively.** Multi dispatch depends on arg *types* AND
+     (12240) green.
+  6. **Direct-caller routing through the helper — DONE (#TBD).** A `MUTSU_PROBE_TREEWALK`
+     instrumentation pass at the non-delegation entry of `run_instance_method_resolved` revealed
+     that **compiled** candidates were still tree-walked when reached via callers that bypass the
+     helper: qualified method calls (`$obj.Class::meth`, `dispatch_qualified_instance_method` /
+     `dispatch_qualified_mixin_method` ×4), the `.*` / `.+` method walk (`methods_walk.rs`), and
+     proto `{*}` dispatch (`dispatch.rs`). All six now call
+     `run_resolved_method_compiled_or_treewalk` (drop-in: same contract, plus the method-name
+     arg), so a compiled candidate runs compiled there too. (`builtins_dispatch_next` already
+     dispatches compiled when `compiled_code.is_some()`, so it was left as-is.) pin=
+     `t/qualified-walk-compiled-dispatch.t`(9). After this, `run_instance_method_resolved` is
+     reached ONLY for `compiled_code = None` candidates — delegation forwarders and the residual
+     uncompiled methods (anonymous role methods, custom-HOW submethods, etc. — the probe's
+     `compiled=false` rows).
+  7. **Resolution caching is unsound naively.** Multi dispatch depends on arg *types* AND
      `where`/value clauses, so a `(class, method, arg-type)` cache is wrong for where/literal
      candidates — any cache must exclude those (or key on more).
   **★Separate pre-existing gap (NOT a regression, orthogonal):** hyper dispatch `@objs».meth`

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1455,9 +1455,10 @@ impl Interpreter {
                 invocant: invocant.clone(),
             }),
         ));
-        let result = self.run_instance_method_resolved(
+        let result = self.run_resolved_method_compiled_or_treewalk(
             receiver_class,
             owner_class,
+            method_name,
             method_def,
             attributes,
             args,

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -167,9 +167,10 @@ impl Interpreter {
                 {
                     let attrs_map = attributes.to_map();
                     let inst_cn = inst_cn_str.to_string();
-                    let (result, updated) = match self.run_instance_method_resolved(
+                    let (result, updated) = match self.run_resolved_method_compiled_or_treewalk(
                         &inst_cn,
                         qualifier,
+                        actual_method,
                         def,
                         attrs_map,
                         args,
@@ -200,9 +201,10 @@ impl Interpreter {
                 if !def.is_private && self.method_args_match(&args, &def.param_defs) {
                     let attrs_map = attributes.to_map();
                     let inst_cn = inst_cn_str.to_string();
-                    let (result, updated) = match self.run_instance_method_resolved(
+                    let (result, updated) = match self.run_resolved_method_compiled_or_treewalk(
                         &inst_cn,
                         qualifier,
+                        actual_method,
                         def.clone(),
                         attrs_map,
                         args,
@@ -353,9 +355,10 @@ impl Interpreter {
                     saved.push((name.clone(), self.env.get(name).cloned()));
                     self.env.insert(name.clone(), value.clone());
                 }
-                let res = self.run_instance_method_resolved(
+                let res = self.run_resolved_method_compiled_or_treewalk(
                     qualifier,
                     qualifier,
+                    actual_method,
                     def,
                     role_attrs,
                     args,
@@ -413,9 +416,10 @@ impl Interpreter {
                 } else {
                     HashMap::new()
                 };
-                let res = self.run_instance_method_resolved(
+                let res = self.run_resolved_method_compiled_or_treewalk(
                     &inst_cn_str,
                     qualifier,
+                    actual_method,
                     def,
                     attrs_map,
                     args,

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -311,9 +311,10 @@ impl Interpreter {
             else {
                 continue;
             };
-            let call = self.run_instance_method_resolved(
+            let call = self.run_resolved_method_compiled_or_treewalk(
                 &receiver_class,
                 &owner,
+                &method_name,
                 method_def,
                 attributes_map.clone(),
                 args.clone(),

--- a/t/qualified-walk-compiled-dispatch.t
+++ b/t/qualified-walk-compiled-dispatch.t
@@ -1,0 +1,61 @@
+use Test;
+
+# §B (#3658): qualified method calls ($obj.Class::meth), the .* / .+ method walk,
+# and proto-method dispatch now route resolved candidates through the compiled
+# bytecode runner (run_resolved_method_compiled_or_treewalk) instead of always
+# tree-walking run_instance_method_resolved. These exercise such dispatch over
+# methods that read/mutate attributes and captured-outer state.
+
+plan 9;
+
+# Qualified method call resolving to a role method that reads an attribute.
+role Speaker { method greet { "hi from {self.name}" } }
+class Person does Speaker { has $.name }
+my $p = Person.new(name => 'Ann');
+is $p.Speaker::greet, 'hi from Ann', 'qualified role-method call reads attribute (compiled)';
+
+# Qualified call to a parent-class method that mutates an rw attribute.
+class Base { has $.n is rw; method base-bump { $.n++ } }
+class Derived is Base { method base-bump { $.n += 100 } }
+my $d = Derived.new(n => 1);
+$d.Base::base-bump;
+is $d.n, 2, 'qualified parent-class method mutates the rw attribute (compiled)';
+
+# A qualified call whose body writes a captured-outer lexical.
+my $log = '';
+role Logger { method record { $log ~= 'r' } }
+class Worker does Logger { }
+my $w = Worker.new;
+$w.Logger::record;
+$w.Logger::record;
+is $log, 'rr', 'qualified role-method captured-outer write propagates (compiled)';
+
+# .* method walk across the MRO calling every matching method.
+my @seen;
+class A1 { method tag { @seen.push('A1') } }
+class B1 is A1 { method tag { @seen.push('B1') } }
+my $b = B1.new;
+my @r = $b.*tag;
+is @seen.join(','), 'B1,A1', '.* walk invokes each MRO method (compiled, captured-outer write)';
+is @r.elems, 2, '.* walk returns one result per matching method';
+
+# .+ walk (at least one) similarly.
+@seen = ();
+$b.+tag;
+is @seen.join(','), 'B1,A1', '.+ walk invokes each MRO method (compiled)';
+
+# Qualified method call that increments a private attribute.
+class Acct { has $!bal = 0; method Acct::deposit { $!bal += 5 }; method bal { $!bal } }
+my $a = Acct.new;
+$a.Acct::deposit; $a.Acct::deposit;
+is $a.bal, 10, 'qualified call mutating a private attribute persists (compiled)';
+
+# proto method dispatch still routes correctly.
+class Calc {
+    proto method op(|) {*}
+    multi method op(Int $x) { $x * 2 }
+    multi method op(Str $s) { $s ~ $s }
+}
+my $c = Calc.new;
+is $c.op(21), 42, 'proto/multi-method Int candidate (compiled dispatch)';
+is $c.op('ab'), 'abab', 'proto/multi-method Str candidate (compiled dispatch)';


### PR DESCRIPTION
## Summary

A `MUTSU_PROBE_TREEWALK` instrumentation pass at the non-delegation entry of `run_instance_method_resolved` revealed that **compiled** candidates were still being tree-walked when reached via callers that bypass the `run_resolved_method_compiled_or_treewalk` helper:
- qualified method calls (`\$obj.Class::meth`) — `dispatch_qualified_instance_method` and `dispatch_qualified_mixin_method` (4 sites),
- the `.*` / `.+` method walk (`methods_walk.rs`),
- proto `{*}` dispatch (`dispatch.rs`).

All six now call `run_resolved_method_compiled_or_treewalk` (a drop-in: same `(result, attrs)` contract, plus the method-name argument), so a resolved candidate with compiled bytecode runs compiled at those sites too instead of recompiling its body each call. `builtins_dispatch_next` already dispatches compiled when `compiled_code.is_some()`, so it was left as-is.

After this, `run_instance_method_resolved` is reached only for `compiled_code = None` candidates — delegation forwarders (handled by its delegation branch) and the residual uncompiled methods (anonymous role methods, custom-HOW submethods). Compiling those is the last step before deleting the tree-walk body.

## Verification (fresh release build)

- `make test` → 12242 green.
- Pins: `qualified-walk-compiled-dispatch`(9, new, raku-validated), `grammar-reduce-time-dynvar`, `parallel-dispatch-regression`, `nextsame-rw-redispatch`, `compiled-method-attr-incdec`.
- Roast: `S12-methods/{defer-next,multi,private}`, `S14-roles/{basic,composition}`, `S12-attributes/instance`, `S05-grammar/protoregex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)