### PR TITLE
feat(test): throws-like forces a bare gather final statement (sink context)

### DIFF
--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -147,7 +147,23 @@ impl Interpreter {
                     match run_result {
                         Ok(_) => {
                             if let Some(last_val) = nested.last_value.take() {
-                                Self::sink_failure_to_error(last_val)
+                                // throws-like runs its code in SINK context (Raku
+                                // sinks the result), so a deferred bare `gather`
+                                // as the final statement must be forced — its body
+                                // runs and any throw (e.g. `return` outside a
+                                // routine) surfaces as the exception under test.
+                                // Force only coroutine-backed (gather) lazy lists
+                                // so a pure lazy sequence/range is never driven.
+                                // A force error IS the thrown exception: surface it
+                                // as the eval result so the type matcher sees it.
+                                if let Value::LazyList(ref ll) = last_val
+                                    && ll.coroutine.is_some()
+                                    && let Err(e) = nested.force_lazy_list_vm(ll)
+                                {
+                                    Err(e)
+                                } else {
+                                    Self::sink_failure_to_error(last_val)
+                                }
                             } else {
                                 Ok(Value::Nil)
                             }
@@ -500,7 +516,23 @@ impl Interpreter {
                     match run_result {
                         Ok(_) => {
                             if let Some(last_val) = nested.last_value.take() {
-                                Self::sink_failure_to_error(last_val)
+                                // throws-like runs its code in SINK context (Raku
+                                // sinks the result), so a deferred bare `gather`
+                                // as the final statement must be forced — its body
+                                // runs and any throw (e.g. `return` outside a
+                                // routine) surfaces as the exception under test.
+                                // Force only coroutine-backed (gather) lazy lists
+                                // so a pure lazy sequence/range is never driven.
+                                // A force error IS the thrown exception: surface it
+                                // as the eval result so the type matcher sees it.
+                                if let Value::LazyList(ref ll) = last_val
+                                    && ll.coroutine.is_some()
+                                    && let Err(e) = nested.force_lazy_list_vm(ll)
+                                {
+                                    Err(e)
+                                } else {
+                                    Self::sink_failure_to_error(last_val)
+                                }
                             } else {
                                 Ok(Value::Nil)
                             }

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -411,7 +411,7 @@ impl Interpreter {
 
     /// Force a LazyList by running its compiled bytecode in the Interpreter.
     /// Falls back to interpreter if no compiled code is available.
-    pub(super) fn force_lazy_list_vm(
+    pub(crate) fn force_lazy_list_vm(
         &mut self,
         list: &LazyList,
     ) -> Result<Vec<Value>, RuntimeError> {

--- a/t/throws-like-gather-sink.t
+++ b/t/throws-like-gather-sink.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 4;
+
+# throws-like runs its code in sink context (Raku sinks the result). A bare
+# `gather {...}` as the final statement is therefore forced — its body runs and
+# a `return` outside any routine surfaces as X::ControlFlow::Return.
+# See roast/S32-exceptions/misc.t (old-issue-tracker for `gather { return }`).
+throws-like 'gather { return 1 }', X::ControlFlow::Return,
+    'bare gather with `return` as final statement throws X::ControlFlow::Return';
+
+# A plain `return;` and a `return` inside a for-loop body likewise throw.
+throws-like 'return;', X::ControlFlow::Return,
+    'bare return at mainline throws X::ControlFlow::Return';
+throws-like 'for ^5 { return; }', X::ControlFlow::Return,
+    'return inside a for loop throws X::ControlFlow::Return';
+
+# A gather with no escaping control flow must NOT be treated as throwing.
+{
+    lives-ok { my $s = gather { take 1; take 2 } },
+        'gather without escaping control flow lives';
+}


### PR DESCRIPTION
## Summary

`throws-like` runs its code in **sink context** (Raku sinks the result). A bare `gather {...}` as the final statement is deferred (its `LazyList` is left as the block's implicit value, not sunk), so the gather body never ran and a `return` outside any routine was silently swallowed:

```raku
throws-like 'gather { return 1 }', X::ControlFlow::Return;   # before: saw no exception
```

## Change
After running the code, if the last value is a **coroutine-backed (gather)** lazy list, force it so its body runs and any escaping control flow / throw surfaces as the exception under test. A force error becomes the eval result so the type matcher compares it (rather than aborting throws-like).

Gated on `coroutine.is_some()` so a pure lazy sequence/range (no side effects) is never driven — no infinite-force hang (verified `throws-like '1..Inf', ...` does not hang).

## Result
Makes roast `S32-exceptions/misc.t` `gather { return }` (X::ControlFlow::Return) pass; misc.t failures down 1 (30 → 29). `S04-statements/gather.t` and `return.t` still pass.

## Test
- New `t/throws-like-gather-sink.t` (4 assertions): bare-gather `return`, bare `return;`, `return` in a for-loop, and a no-control-flow gather that must live.
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)