### PR TITLE
feat(vm): Mixin-self attribute writeback in compiled methods + unconditional on-demand compile (§B #3658)

### DIFF
--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -340,6 +340,26 @@ frame boundary), now confirmed for the method-coercion redispatch path too.
      on-demand compile (`compile_method_def_in_place`, kept ready) becomes safe, THEN
      `run_instance_method_resolved`'s non-delegation tree-walk is dead and can be deleted (keeping
      only the delegation-forwarding branch, extracted to its own small function).
+  9. **Mixin-self attribute writeback fix + on-demand compile ENABLED — DONE (#TBD).** The
+     "multi-point" fix turned out small: a single `self_instance_attrs(val)` helper
+     (vm_var_assign_ops.rs) recursively unwraps a `Value::Mixin(inner, _)` `self` to the inner
+     instance's shared `Arc<RwLock>` cell, used in (a) scalar `read_self_attr_cell` /
+     `write_self_attr_cell` (in-method `$.n++` / `$!x`) and (b) the helper's `final_attrs` exit
+     commit (`inv_for_cell.and_then(Self::self_instance_attrs)` → `cell.to_map()`). The array
+     `@.items` push already reached the inner cell; it only needed the same `final_attrs` commit
+     to capture it. With that, the in-place on-demand compile is now **UNCONDITIONAL** in the
+     helper (`compile_method_def_in_place` on any body-ful, non-delegation, uncompiled candidate),
+     so runtime-`does` mixin / late-added methods run compiled. `make test` 12271 green;
+     `t/mixin-compiled-attr-writeback.t`(9, scalar+array+hash+multi-`.*`) green; broad OOP roast
+     sweep (S12-*/S14-*) = 110 pass / 6 pre-existing fail (all fail identically with on-demand
+     OFF — confirmed via a `MUTSU_NO_ONDEMAND` toggle, NOT regressions). **Pre-existing
+     limitations left (both tree-walk + compiled, unchanged):** role-ADDED `$.x` attributes (live
+     in the Mixin `overrides`, not the inner cell → read `Nil`), `self.^name` on a mixin (`Plain`
+     not `Plain+{Named}`), and the `.map`-attribute-vs-builtin-`.map` accessor shadowing.
+     **Next: the tree-walk `run_instance_method_resolved` non-delegation body is now (near-)dead**
+     — re-run `MUTSU_PROBE_TREEWALK` to confirm only body-less / delegation candidates remain,
+     then delete the tree-walk method-execution arm and extract the delegation-forwarding branch
+     to its own function.
   **★Separate pre-existing gap (NOT a regression, orthogonal):** hyper dispatch `@objs».meth`
   of a method writing a captured-outer *lexical* (`method touch { $seen++ }`) does not
   propagate the write — the hyper internal temp-target redispatch has no op-level drain of

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -989,49 +989,46 @@ impl Interpreter {
     }
 
     /// Compile all uncompiled method bodies in a method map.
+    /// Compile a single method/submethod body to bytecode in place if it has a
+    /// non-empty body and is not already compiled. Shared by the bulk registration
+    /// pass and the on-demand compile in `run_resolved_method_compiled_or_treewalk`.
+    pub(crate) fn compile_method_def_in_place(def: &mut super::MethodDef, package_name: &str) {
+        if def.compiled_code.is_some() || def.body.is_empty() {
+            return;
+        }
+        let mut compiler = crate::compiler::Compiler::new();
+        let method_package = def
+            .original_role
+            .as_deref()
+            .or(def.role_origin.as_deref())
+            .unwrap_or(package_name);
+        compiler.set_current_package(method_package.to_string());
+        // A method always carries an implicit `*%_` / `*@_` slurpy, so `%_` / `@_`
+        // are valid lexicals throughout the body (including a nested signature-less
+        // `do {}` block). Mark the method context so the do-block placeholder check
+        // permits them.
+        compiler.lexically_in_method = true;
+        let mut method_params = vec![
+            "self".to_string(),
+            "__ANON_STATE__".to_string(),
+            "?CLASS".to_string(),
+            "?ROLE".to_string(),
+        ];
+        method_params.extend(def.params.iter().cloned());
+        let mut cc =
+            compiler.compile_routine_closure_body(&method_params, &def.param_defs, &def.body);
+        cc.compute_may_capture_outer_vars();
+        cc.compute_needs_env_sync();
+        def.compiled_code = Some(std::sync::Arc::new(cc));
+    }
+
     fn compile_methods_for_map(
         methods: &mut HashMap<String, Vec<super::MethodDef>>,
         package_name: &str,
     ) {
-        let mut to_compile = Vec::new();
-        for (method_name, overloads) in methods.iter() {
-            for (idx, def) in overloads.iter().enumerate() {
-                if def.compiled_code.is_none() && !def.body.is_empty() {
-                    let mut compiler = crate::compiler::Compiler::new();
-                    let method_package = def
-                        .original_role
-                        .as_deref()
-                        .or(def.role_origin.as_deref())
-                        .unwrap_or(package_name);
-                    compiler.set_current_package(method_package.to_string());
-                    // A method always carries an implicit `*%_` / `*@_` slurpy, so
-                    // `%_` / `@_` are valid lexicals throughout the body (including a
-                    // nested signature-less `do {}` block). Mark the method context so
-                    // the do-block placeholder check permits them.
-                    compiler.lexically_in_method = true;
-                    let mut method_params = vec![
-                        "self".to_string(),
-                        "__ANON_STATE__".to_string(),
-                        "?CLASS".to_string(),
-                        "?ROLE".to_string(),
-                    ];
-                    method_params.extend(def.params.iter().cloned());
-                    let mut cc = compiler.compile_routine_closure_body(
-                        &method_params,
-                        &def.param_defs,
-                        &def.body,
-                    );
-                    cc.compute_may_capture_outer_vars();
-                    cc.compute_needs_env_sync();
-                    to_compile.push((method_name.clone(), idx, std::sync::Arc::new(cc)));
-                }
-            }
-        }
-        for (method_name, idx, arc_cc) in to_compile {
-            if let Some(overloads) = methods.get_mut(&method_name)
-                && let Some(def) = overloads.get_mut(idx)
-            {
-                def.compiled_code = Some(arc_cc);
+        for overloads in methods.values_mut() {
+            for def in overloads.iter_mut() {
+                Self::compile_method_def_in_place(def, package_name);
             }
         }
     }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1004,6 +1004,23 @@ impl Interpreter {
         // A delegation forwarder is synthesized with `compiled_code = None`, and an
         // uncompiled method likewise has none, so both fall through to the tree-walk
         // `run_instance_method_resolved` (the remaining reason it still exists).
+        // On-demand compile (§B, #3658): a resolved candidate reached before its
+        // owner's registration compile pass — or one added at runtime (a role method
+        // punned via `does`, a custom-HOW method) — can still have no `compiled_code`.
+        // Compile this exact candidate's body IN PLACE (not via re-resolution, which
+        // would mis-pick an override for a qualified `$obj.Class::meth` call) so it
+        // runs compiled instead of tree-walked. Only a genuinely body-less method
+        // (stub / delegation forwarder) then stays on the tree-walk path. The
+        // compiled-execution Mixin/instance attribute writeback is handled by
+        // `self_instance_attrs` (unwraps a `Value::Mixin` self to the inner cell) in
+        // the attr ops and the `final_attrs` commit below.
+        let mut method_def = method_def;
+        if method_def.compiled_code.is_none()
+            && method_def.delegation.is_none()
+            && !method_def.body.is_empty()
+        {
+            Self::compile_method_def_in_place(&mut method_def, owner_class);
+        }
         let writeback_safe_compiled =
             method_def.compiled_code.is_some() && method_def.delegation.is_none();
         if !writeback_safe_compiled {
@@ -1054,11 +1071,14 @@ impl Interpreter {
                     err.is_fail = true;
                     return Err(err);
                 }
+                // Read the committed attribute map from the live cell of `self`,
+                // unwrapping a `Value::Mixin` invocant to its inner instance (so a
+                // runtime-`does` mixin method's attribute mutations are captured, not
+                // the stale pre-call `updated` map). `adjusted` keeps the `:=`-recovered
+                // snapshot.
                 let final_attrs = if adjusted {
                     updated
-                } else if let Some(Value::Instance {
-                    attributes: cell, ..
-                }) = &inv_for_cell
+                } else if let Some(cell) = inv_for_cell.as_ref().and_then(Self::self_instance_attrs)
                 {
                     cell.to_map()
                 } else {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -5382,15 +5382,27 @@ impl Interpreter {
         }
     }
 
+    /// The inner instance's shared attribute cell for a `self` value, unwrapping a
+    /// `Value::Mixin` (runtime `$obj does Role`) to the wrapped instance. The
+    /// Mixin's inner value is held in a shared `Arc`, and the instance's own cell is
+    /// an `Arc<RwLock>` — so a write through this reference persists back to the
+    /// caller's Mixin (it shares the same inner instance). Returns `None` for a
+    /// type object / non-instance.
+    pub(crate) fn self_instance_attrs(val: &Value) -> Option<&crate::value::InstanceAttrs> {
+        match val {
+            Value::Instance { attributes, .. } => Some(attributes),
+            Value::Mixin(inner, _) => Self::self_instance_attrs(inner),
+            _ => None,
+        }
+    }
+
     /// Read a scalar attribute straight from `self`'s shared cell. `Some` only
-    /// when `name` is a scalar attr-twigil, `self` is a concrete instance, and
-    /// the attribute exists in the cell.
+    /// when `name` is a scalar attr-twigil, `self` is a concrete instance (or a
+    /// Mixin wrapping one), and the attribute exists in the cell.
     pub(super) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
         let twigil = self.canonical_attr_twigil(name)?;
         let self_val = self.get_env_with_main_alias("self")?;
-        let Value::Instance { attributes, .. } = &self_val else {
-            return None;
-        };
+        let attributes = Self::self_instance_attrs(&self_val)?;
         let key = self.resolve_attr_cell_key(&twigil, attributes)?;
         attributes.as_map().get(&key).cloned()
     }
@@ -5454,7 +5466,10 @@ impl Interpreter {
         let Some(self_val) = self.get_env_with_main_alias("self") else {
             return;
         };
-        let Value::Instance { attributes, .. } = &self_val else {
+        // Unwrap a `Value::Mixin` self to the inner instance's shared cell so a
+        // runtime-`does` mixin method's `$.attr`/`$!attr` write persists (the cell
+        // is an `Arc<RwLock>` shared with the caller's Mixin).
+        let Some(attributes) = Self::self_instance_attrs(&self_val) else {
             return;
         };
         if let Some(key) = self.resolve_attr_cell_key(name, attributes) {

--- a/t/mixin-compiled-attr-writeback.t
+++ b/t/mixin-compiled-attr-writeback.t
@@ -1,0 +1,67 @@
+use Test;
+
+# §B (#3658): a runtime `$obj does Role` mixin role method now runs as compiled
+# bytecode (on-demand compile in run_resolved_method_compiled_or_treewalk), and
+# its attribute mutations persist. The compiled attribute path unwraps a
+# Value::Mixin self to the inner instance's shared cell (self_instance_attrs) for
+# both the in-method read/write and the exit commit (final_attrs). Previously the
+# mixin method tree-walked; forcing it compiled used to lose the writeback.
+
+plan 9;
+
+# Scalar rw attribute incremented by a mixin role method.
+role Ctr { method bump { $.n++ } }
+class BoxN { has $.n is rw }
+my $b = BoxN.new(n => 5);
+$b does Ctr;
+$b.bump;
+is $b.n, 6, 'mixin role method scalar increment persists (compiled)';
+$b.bump; $b.bump;
+is $b.n, 8, 'mixin role method scalar increment accumulates across calls';
+
+# Array attribute pushed by a mixin role method.
+role Adder { method add($x) { push @.items, $x } }
+class BoxA { has @.items }
+my $a = BoxA.new;
+$a does Adder;
+$a.add(1); $a.add(2); $a.add(3);
+is $a.items, [1, 2, 3], 'mixin role method array push accumulates (compiled)';
+
+# Hash attribute populated by a mixin role method. (Attribute named `data`, not
+# `map`, to avoid the unrelated `.map`-accessor-vs-builtin-`.map` shadowing.)
+role Setter { method put($k, $v) { %.data{$k} = $v } }
+class BoxH { has %.data }
+my $h = BoxH.new;
+$h does Setter;
+$h.put('a', 1); $h.put('b', 2);
+is $h.data<a>, 1, 'mixin role method hash store persists key a (compiled)';
+is $h.data<b>, 2, 'mixin role method hash store persists key b (compiled)';
+
+# Multi method dispatch on mixed-in roles, each mutating an array attribute.
+role R5 {
+    multi method rt()       { push @.order, 'empty' }
+    multi method rt(Str $a) { push @.order, 'Str'   }
+}
+role R6 { multi method rt(Numeric $a) { push @.order, 'Numeric' } }
+class C { has @.order }
+my C $c1 .= new();
+$c1 does (R5, R6);
+$c1.*rt;
+is $c1.order, <empty>, 'multi mixin .* dispatch, empty signature (compiled)';
+my C $c2 .= new();
+$c2 does (R5, R6);
+$c2.*rt('hi');
+is $c2.order, <Str>, 'multi mixin .* dispatch, Str signature (compiled)';
+my C $c3 .= new();
+$c3 does (R5, R6);
+$c3.*rt(42);
+is $c3.order, <Numeric>, 'multi mixin .* dispatch, Numeric signature (compiled)';
+
+# `self` inside a compiled mixin method is the live receiver: a role method that
+# calls another method through self (and reads a class attribute via that method)
+# works — the mutation routes to the inner instance's cell.
+role Greeter { method greet { "Hi, {self.who}" } }
+class Person { has $.name; method who { $!name } }
+my $p = Person.new(name => 'Ann');
+$p does Greeter;
+is $p.greet, 'Hi, Ann', 'self inside a compiled mixin method dispatches back to a class method';


### PR DESCRIPTION
## Summary

Two coupled changes that let a runtime `\$obj does Role` mixin role method (and any late-added / not-yet-compiled candidate) run as **compiled bytecode** with correct attribute writeback — the last regression that blocked the on-demand compile (the `t/multi-method-roles.t` revert from the prior session).

### 1. Mixin-self attribute writeback

New `self_instance_attrs(val)` recursively unwraps a `Value::Mixin(inner, _)` self to the inner instance's shared `Arc<RwLock>` attribute cell. Used in:
- scalar `read_self_attr_cell` / `write_self_attr_cell` (so `\$.n++` / `\$!x` take effect in-method), and
- the helper's `final_attrs` exit commit (`inv_for_cell.and_then(self_instance_attrs)` → `cell.to_map()`, so the mutation is committed back instead of the stale pre-call map).

The array `@.items` push already reached the inner cell; it only needed the same commit to be captured.

### 2. On-demand compile is now UNCONDITIONAL

In `run_resolved_method_compiled_or_treewalk`, any body-ful, non-delegation candidate with no `compiled_code` is compiled **in place** (`compile_method_def_in_place`, extracted from `compile_methods_for_map`) rather than tree-walked. Compiling the owned candidate avoids the re-resolution hazard that would mis-pick an override for a qualified `\$obj.Class::meth` call.

After this, the only candidates that still reach the tree-walk `run_instance_method_resolved` are **body-less stubs and delegation forwarders** — the non-delegation tree-walk method-execution arm is now (near-)dead, ready to delete next.

## Pre-existing limitations left unchanged

Verified identical with on-demand OFF (via a `MUTSU_NO_ONDEMAND` toggle): role-ADDED `\$.x` attributes (live in the Mixin overrides, not the inner cell → `Nil`), `self.^name` on a mixin (`Plain` not `Plain+{Named}`), and `.map`-accessor-vs-builtin shadowing.

## Verification (fresh release build)

- `make test` → 12271 green.
- New pin `t/mixin-compiled-attr-writeback.t`(9: scalar + array + hash + multi-`.*`).
- `t/multi-method-roles.t` (the prior on-demand revert driver) now green.
- Broad OOP roast sweep `S12-*`/`S14-*` = **110 pass / 6 pre-existing fail** (all 6 fail identically with on-demand OFF — not regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)