### PR TITLE
feat(subst): :sigspace implies :samemark (greens subst.t, whitelisted)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -70,11 +70,8 @@ without colliding, pick from the **top**:
 
 ### Regex engine (`runtime/regex*.rs`)
 
-- **S05-substitution/subst.t** — **Medium**. The remaining failures are
-  regex-internal: `X::Syntax::Regex::NullRegex` (empty `s///`), `:samecase`/
-  `:samemark` application in `.subst`, non-constant `:i`. Sequence these AFTER any
-  open regex PR. (NOT whitelistable as a whole — rakudo itself fails tests 157,
-  170.) See S05.md.
+- **S05-substitution/subst.t** — **DONE (whitelisted).** All 191 pass. Last fix:
+  `:sigspace` implies `:samemark` (test 102). See S05.md.
 - **S05-match/capturing-contexts.t** — **Medium (multi-feature)**. 56/64. 8
   *disparate* failures: binding `$/` (`my $/ := 42`), index-stable positional slots
   so `(y)?`→Nil and `(z)*`→empty-list coexist, `%%` separator backtracking vs an

--- a/TODO_roast/S05.md
+++ b/TODO_roast/S05.md
@@ -247,13 +247,9 @@
       Not whitelisted; would require implementing removed language semantics.
 - [ ] roast/S05-substitution/67222.t
 - [ ] roast/S05-substitution/match.t
-- [ ] roast/S05-substitution/subst.t
-  - 190/191 pass (only 102 fails). **Whitelistable in principle**: although
-    reference rakudo on this box fails tests 157 (`:i(1) is OK`) and 170
-    (`s[]="" when $_ is not set`), **mutsu passes both** (157 outright; 170 is
-    `#?rakudo todo`, so a mutsu failure there would not fail the file anyway). The
-    only remaining mutsu failure is 102, the `:ss`+`:m` Rakudo mark-transfer quirk
-    (WON'T FIX, see below). Remaining/historical failures:
+- [x] roast/S05-substitution/subst.t
+  - WHITELISTED. All 191 tests pass (test 170 is `#?rakudo todo`, so a mutsu
+    failure there does not fail the file). Remaining/historical failures:
   - ABORT FIXED (1): the file previously aborted mid-run at the `s[...] OP= ...`
     block (`given 'a 2 3' -> $_ is copy { s[\d] += 5 }`). `given LITERAL -> $_ is
     copy` marked `$_` read-only (the `$_ = $_` copy-head desugar then died on the
@@ -277,16 +273,15 @@
     duplicated `else if` blocks in `apply_substitutions` /
     `apply_substitutions_with_captures` / `apply_substitutions_dynamic` by routing
     them all through the single chokepoint.
-  - 102 (WON'T FIX — Rakudo quirk): `ss:i:m` (samespace + ignorecase +
-    *ignoremark*, **not** samemark) expects combining marks to *transfer* from the
-    matched text to the replacement (`ḇ`→`x̱`, `Ć`→`ý`). Re-verified 2026-06-16:
-    plain `s:i:m/ÅbCd/wxyz/` on "aḇĆd" gives `"wxyz"` (marks dropped) in rakudo,
-    but **adding `:ss` revives them** (`"w\nx̱\tý z"`). `:samespace` logically
-    governs only whitespace, so its effect on mark transfer is a Rakudo-specific
-    interaction artifact. Replicating it would require special-case logic keyed on
-    the `:ss`+`:m` combination — a hack, which the project rules forbid. Effectively
-    blocks a clean subst.t whitelist (187 is now FIXED; 102 is the only remaining
-    mutsu failure, and reference rakudo additionally fails 157/170).
+  - 102 (FIXED): `ss:i:m` expects combining marks to *transfer* from the matched
+    text to the replacement (`ḇ`→`x̱`, `Ć`→`ý`). The earlier note dismissed this as
+    a `:ss`+`:m` quirk, but probing rakudo shows the rule is general and clean:
+    **`:sigspace` implies `:samemark`** (so `:s`, `:ss`/`:samespace`, and the
+    `ss///` operator all copy marks even without an explicit `:mm`). Verified:
+    `s:s/ḇ/x/` → `"x̱"` while plain `s/ḇ/x/` → `"x"`, and `:sigspace` does NOT imply
+    `:samecase` (`s:s:i/b/x/` on "B" → `"x"`). Implemented by folding
+    `samemark |= sigspace` in `apply_subst_case_transforms`
+    (`src/vm/vm_string_regex_ops.rs`) and widening `SubstCaseTransforms::any()`.
   - 146-152 (FIXED): `.subst` `:samecase`/`:samemark` adverbs, including with `:g`
     and block replacement (152 fixed via the closure-writeback fix below).
   - 156 (FIXED): `s:i($i)/.../` now throws `X::Value::Dynamic` (non-constant

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -444,6 +444,7 @@ roast/S05-modifier/samemark.t
 roast/S05-modifier/sigspace.t
 roast/S05-substitution/67222.t
 roast/S05-substitution/match.t
+roast/S05-substitution/subst.t
 roast/S05-syntactic-categories/new-symbols.t
 roast/S05-transliteration/79778.t
 roast/S05-transliteration/trans-TR-operator.t

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -14,7 +14,9 @@ pub(super) struct SubstCaseTransforms {
 
 impl SubstCaseTransforms {
     fn any(&self) -> bool {
-        self.samecase || self.samemark || self.samespace
+        // `:sigspace`/`:samespace` imply `:samemark` (see
+        // `apply_subst_case_transforms`), so a bare `:s` still needs the transform.
+        self.samecase || self.samemark || self.samespace || self.sigspace
     }
 
     fn apply(&self, replacement: &str, matched: &str) -> String {

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -87,6 +87,11 @@ pub(crate) fn apply_subst_case_transforms(
     sigspace: bool,
     samespace: bool,
 ) -> String {
+    // In Raku, `:sigspace` (and therefore `:samespace`, which implies `:sigspace`,
+    // and the `ss///` operator) also implies `:samemark`: the matched text's
+    // combining marks are copied onto the replacement. `:samecase` is NOT implied
+    // by sigspace, so only fold samemark in here.
+    let samemark = samemark || sigspace;
     // `:samecase` and `:samemark` are independent transforms and can be combined
     // (e.g. `s:ii:mm///`). Apply case first, then transfer marks onto the
     // case-adjusted text. Using `else if` here would silently drop samemark

--- a/t/samecase-samemark.t
+++ b/t/samecase-samemark.t
@@ -5,7 +5,7 @@ use Test;
 # `if samecase {} else if samemark {}` chain, silently dropping samemark whenever
 # samecase was also present (roast S05-substitution/subst.t tests 100, 104).
 
-plan 6;
+plan 9;
 
 {
     my $a = "Ä";
@@ -43,4 +43,26 @@ plan 6;
     # The .subst method shares the same chokepoint.
     is "Ä".subst(/:i:m a/, "x", :samecase, :samemark), "Ẍ",
         '.subst with :samecase and :samemark applies both';
+}
+
+# In Raku, `:sigspace` (and therefore `:samespace` / the `ss///` operator) also
+# implies `:samemark` — the matched text's combining marks are copied onto the
+# replacement even without an explicit `:mm` (roast S05-substitution/subst.t #102).
+{
+    $_ = "ḇ";
+    s:s/ḇ/x/;
+    is $_, "x̱", ':s (sigspace) implies samemark on a literal mark match';
+}
+
+{
+    $_ = "a\nḇ\tĆ d";
+    ss:i:m/Å b C d/w x y z/;
+    is $_, "w\nx̱\tý z", 'ss:i:m preserves whitespace and copies marks';
+}
+
+{
+    # sigspace does NOT imply samecase.
+    $_ = "B";
+    s:s:i/b/x/;
+    is $_, "x", ':s (sigspace) does not imply samecase';
 }


### PR DESCRIPTION
## Summary

In Raku, `:sigspace` — and therefore `:samespace` (which implies `:sigspace`) and the `ss///` operator — also implies `:samemark`: combining marks from the matched text are copied onto the replacement even without an explicit `:mm`. `:samecase` is **not** implied by sigspace.

This was the last remaining failure (test 102) in `roast/S05-substitution/subst.t`. The previous TODO note dismissed it as a `:ss`+`:m` "Rakudo quirk requiring a hack" — but probing reference rakudo shows the rule is general and clean.

## Verification (against reference rakudo)

- `s:s/ḇ/x/` → `"x̱"`  (plain `s/ḇ/x/` → `"x"`)
- `ss:i:m/Å b C d/w x y z/` on `"a\nḇ\tĆ d"` → `"w\nx̱\tý z"`
- `s:s:i/b/x/` on `"B"` → `"x"` (sigspace does not imply samecase)

## Implementation

Folded `samemark |= sigspace` into the single chokepoint `apply_subst_case_transforms` (`src/vm/vm_string_regex_ops.rs`), so all `s///`/`ss///` opcode paths inherit it, and widened `SubstCaseTransforms::any()` (`src/runtime/methods_string.rs`) so the `.subst` method path also applies the transform for a bare `:s`.

## Result

`roast/S05-substitution/subst.t` now passes 191/191 → added to `roast-whitelist.txt`. New regression cases in `t/samecase-samemark.t`. TODO_roast notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)