### PR TITLE
feat(dispatch): .new on a builtin instance delegates to its type constructor

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -2418,6 +2418,26 @@ impl Interpreter {
             err.exception = Some(Box::new(ex));
             return Err(err);
         }
+        // Calling `.new(...)` on a concrete builtin scalar / Pair instance delegates
+        // to that type's constructor (raku: `$pair.new(:key<k>, :value<v>)`,
+        // `42.new` => Int.new => 0, `"x".new` => Str.new => ""). Placed after the
+        // enum-name `Str` check above so a Str holding an enum type name still
+        // throws X::Constructor::BadType rather than delegating to Str.new.
+        {
+            let type_pkg = match &target {
+                Value::Pair(..) | Value::ValuePair(..) => Some("Pair"),
+                Value::Int(_) | Value::BigInt(_) => Some("Int"),
+                Value::Num(_) => Some("Num"),
+                Value::Rat(..) => Some("Rat"),
+                Value::FatRat(..) => Some("FatRat"),
+                Value::Complex(..) => Some("Complex"),
+                Value::Str(_) => Some("Str"),
+                _ => None,
+            };
+            if let Some(type_name) = type_pkg {
+                return self.dispatch_new(Value::Package(Symbol::intern(type_name)), args);
+            }
+        }
         if let Value::ParametricRole {
             base_name,
             type_args,

--- a/t/new-on-instance.t
+++ b/t/new-on-instance.t
@@ -1,0 +1,30 @@
+use Test;
+
+# Calling `.new(...)` on a *concrete instance* of a builtin type delegates to
+# that type's constructor, exactly as raku does (e.g. inside the `.=` metaop
+# `($p = ...).=new :key<k> :value<v>` — roast S03-operators/inplace.t).
+
+plan 9;
+
+# Pair instance .new builds a fresh Pair from key/value named args.
+my $p = Pair.new(:key<a>, :value<b>);
+is-deeply $p.new(:key<foo>, :value<bar>), (:foo<bar>).Pair,
+    'Pair instance .new(:key, :value) builds a new Pair';
+
+# Numeric / Str instances delegate to their type's default constructor.
+is-deeply 42.new,    0,   'Int instance .new => 0';
+is-deeply (4.2).new, 0.0, 'Rat instance .new => 0.0';
+is-deeply (4e0).new, 0e0, 'Num instance .new => 0e0';
+is-deeply "s".new,   "",  'Str instance .new => ""';
+
+# The `.=` metaop on a parenthesised assignment target works end-to-end.
+my $q;
+($q = $p.antipair.antipair).=new :key<foo> :value<bar>;
+is-deeply $q, (:foo<bar>).Pair, '(.= new) with fake-infix adverbs on paren-assign target';
+
+# A bigint instance still delegates to Int.
+is-deeply (10 ** 30).new, 0, 'BigInt instance .new => 0';
+
+# Delegation does not disturb type-object construction.
+is-deeply Pair.new(:key<x>, :value<y>), (:x<y>).Pair, 'Pair type .new still works';
+is-deeply Int.new, 0, 'Int type .new still works';


### PR DESCRIPTION
## Summary

Calling `.new(...)` on a concrete builtin scalar / `Pair` instance now delegates to that type's constructor, matching raku:

```raku
my $p = Pair.new(:key<a>, :value<b>);
$p.new(:key<foo>, :value<bar>)   # :foo("bar")
42.new                            # 0   (Int.new)
"s".new                           # ""  (Str.new)
```

Previously these fell through to the generic instance-method slow path and errored with `X::Method::NotFound ... new`.

## Motivation

This unblocks the `.=` metaop applied to a parenthesised assignment target with fake-infix adverb args:

```raku
($p2 = $p.self.antipair.antipair).=new :key<foo> :value<bar>;
```

`roast/S03-operators/inplace.t` subtest 33 (`.= works with fake-infix adverb named args`) now passes (file goes from 5 → 4 failing subtests; the remaining failures are unrelated `notandthen`/`.=` chaining features).

## Implementation

Added a delegation arm in `dispatch_new` (`src/runtime/methods_object.rs`) mapping concrete `Pair`/`ValuePair`/`Int`/`BigInt`/`Num`/`Rat`/`FatRat`/`Complex`/`Str` instances to their type `Package` constructor. It is placed **after** the enum-name `Str` check so a `Str` holding an enum type name still throws `X::Constructor::BadType` rather than delegating to `Str.new`.

## Tests

- New `t/new-on-instance.t` (9 assertions).
- `make test` passes (12265 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)