### PR TITLE
refactor(vm): rename run_instance_method_resolved → forward_resolved_delegation; fix the misnamed tree-walk counter (§B #3658)

### DIFF
--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -207,8 +207,9 @@ impl Interpreter {
             };
             // §B: compile the next MRO candidate on-demand if it has no compiled code
             // (a runtime-added / not-yet-compiled body), so the dispatch below runs it
-            // compiled instead of via the tree-walk `run_instance_method_resolved`.
-            // Delegation forwarders keep their synthesized empty body uncompiled.
+            // compiled rather than tree-walked — the non-delegation tree-walk arm of
+            // `forward_resolved_delegation` was deleted (#3680). Delegation forwarders
+            // keep their synthesized empty body uncompiled.
             if method_def.compiled_code.is_none() && method_def.delegation.is_none() {
                 Self::compile_method_def_in_place(&mut method_def, &owner_class);
             }
@@ -242,11 +243,11 @@ impl Interpreter {
             // write the chain's final value into that slot after the redispatch.
             let caller_code = self.current_code;
             // §B: run the next MRO candidate as compiled bytecode (`call_compiled_method`)
-            // when it has compiled code, instead of the tree-walk
-            // `run_instance_method_resolved` recompile-each-call path. Both leave the
-            // active `method_dispatch_stack` frame in place (neither pushes a new one),
-            // so a further `nextsame`/`callsame` inside the candidate continues this
-            // same MRO chain. Methods without compiled code (rare; added post-compile)
+            // when it has compiled code (always, after the on-demand compile above,
+            // except a delegation forwarder). Both leave the active
+            // `method_dispatch_stack` frame in place (neither pushes a new one), so a
+            // further `nextsame`/`callsame` inside the candidate continues this same MRO
+            // chain. Methods without compiled code (a delegation forwarder)
             // keep the interpreter path.
             let method_name_for_dispatch = self
                 .samewith_context_stack
@@ -291,7 +292,7 @@ impl Interpreter {
                             (result, Some(new_inv))
                         })
                     } else {
-                        self.run_instance_method_resolved(
+                        self.forward_resolved_delegation(
                             &receiver_class,
                             &owner_class,
                             method_def,
@@ -327,7 +328,7 @@ impl Interpreter {
                         )
                         .map(|(result, _, _)| (result, None))
                     } else {
-                        self.run_instance_method_resolved(
+                        self.forward_resolved_delegation(
                             &receiver_class,
                             &owner_class,
                             method_def,

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -740,7 +740,7 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
-        crate::vm::vm_stats::record_tree_walk_method(method_name);
+        crate::vm::vm_stats::record_resolver_method_dispatch(method_name);
         let inv_value = if let Some(inv) = &invocant {
             inv.clone()
         } else if attributes.is_empty() {
@@ -1000,9 +1000,9 @@ impl Interpreter {
         //     back instead of dropped;
         //   - attribute twigils (`.count`/`!x`/…) are not in `free_var_writes` at all
         //     (#3666).
-        // A delegation forwarder is synthesized with `compiled_code = None`, and an
-        // uncompiled method likewise has none, so both fall through to the tree-walk
-        // `run_instance_method_resolved` (the remaining reason it still exists).
+        // A delegation forwarder is synthesized with `compiled_code = None`, so it
+        // falls through to `forward_resolved_delegation` (the remaining reason it
+        // still exists).
         // On-demand compile (§B, #3658): a resolved candidate reached before its
         // owner's registration compile pass — or one added at runtime (a role method
         // punned via `does`, a custom-HOW method) — can still have no `compiled_code`.
@@ -1020,7 +1020,7 @@ impl Interpreter {
         let writeback_safe_compiled =
             method_def.compiled_code.is_some() && method_def.delegation.is_none();
         if !writeback_safe_compiled {
-            return self.run_instance_method_resolved(
+            return self.forward_resolved_delegation(
                 receiver_class_name,
                 owner_class,
                 method_def,
@@ -1091,7 +1091,7 @@ impl Interpreter {
     /// has been deleted. Every non-delegation candidate is now compiled on-demand by
     /// its caller (`compile_method_def_in_place`) before reaching here, so this only
     /// handles delegation forwarders.)
-    pub(super) fn run_instance_method_resolved(
+    pub(super) fn forward_resolved_delegation(
         &mut self,
         receiver_class_name: &str,
         owner_class: &str,
@@ -1175,7 +1175,7 @@ impl Interpreter {
         // method reaching this point would be an internal invariant violation.
         let _ = (&owner_class, &attributes, &args, &invocant);
         Err(RuntimeError::new(format!(
-            "internal error: run_instance_method_resolved reached the deleted tree-walk arm for non-delegation method on '{}' (should have been compiled on-demand)",
+            "internal error: forward_resolved_delegation reached for a non-delegation method on '{}' (should have been compiled on-demand)",
             receiver_class_name
         )))
     }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -51,12 +51,13 @@ fn function_carrier_by_name() -> &'static Mutex<HashMap<String, u64>> {
     BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Per-name histogram of method calls that reached *genuine AST tree-walking* of a
-/// user-defined method body (`run_instance_method` / `run_instance_method_resolved`),
-/// as opposed to native handlers reached via the catch-all (which `record_method_fallback`
-/// over-counts). This is the authoritative measure for the §D(b) tree-walk removal:
-/// only these calls keep `run_instance_method` alive.
-fn tree_walk_method_by_name() -> &'static Mutex<HashMap<String, u64>> {
+/// Per-name histogram of method calls that entered the slow-path resolver dispatch
+/// `run_instance_method` (resolve candidate + frame setup + env clone). §B #3680
+/// deleted the tree-walk of the method body, so these now execute the body as
+/// COMPILED bytecode — this counter measures the residual *dispatch* overhead (the
+/// next target: VM-native multi/submethod resolution caching so a `CallMethod` op
+/// dispatches without entering `run_instance_method`), NOT tree-walk execution.
+fn resolver_method_by_name() -> &'static Mutex<HashMap<String, u64>> {
     static BY_NAME: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
     BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -82,12 +83,12 @@ pub(crate) fn record_method_dispatch() {
     }
 }
 
-/// Record that a method call reached genuine AST tree-walking of a user method body
-/// (`run_instance_method[_resolved]`). The authoritative §D(b) removal target.
+/// Record that a method call entered the slow-path resolver dispatch
+/// `run_instance_method` (resolve + setup; the body itself runs compiled since #3680).
 #[inline]
-pub(crate) fn record_tree_walk_method(name: &str) {
+pub(crate) fn record_resolver_method_dispatch(name: &str) {
     if enabled()
-        && let Ok(mut map) = tree_walk_method_by_name().lock()
+        && let Ok(mut map) = resolver_method_by_name().lock()
     {
         *map.entry(name.to_string()).or_insert(0) += 1;
     }
@@ -245,7 +246,7 @@ pub(crate) fn dump() {
             top.join(" ")
         );
     }
-    if let Ok(map) = tree_walk_method_by_name().lock()
+    if let Ok(map) = resolver_method_by_name().lock()
         && !map.is_empty()
     {
         let total: u64 = map.values().sum();
@@ -257,7 +258,7 @@ pub(crate) fn dump() {
             .map(|(name, count)| format!("{name}={count}"))
             .collect();
         eprintln!(
-            "[mutsu vm-stats] tree-walk method bodies total={} by name (top {}): {}",
+            "[mutsu vm-stats] resolver-path method dispatches total={} (resolve+setup; body runs compiled) by name (top {}): {}",
             total,
             top.len(),
             top.join(" ")


### PR DESCRIPTION
## Summary

Finalization of the §B / §2-D(b) tree-walk deletion (#3680).

- **Rename `run_instance_method_resolved` → `forward_resolved_delegation`.** Now that the non-delegation tree-walk arm is deleted, the helper only forwards `handles`-delegation, so the name now matches (definition + 3 call sites). No behavior change.
- **Fix the misnamed MUTSU_VM_STATS counter.** `record_tree_walk_method` fires at `run_instance_method` ENTRY (resolve + frame setup), but the body now runs as **compiled** bytecode since #3680 — so the `tree-walk method bodies` label was false (e.g. `defer-next.t` reported `m=10000` as tree-walk when it is compiled). Renamed → `record_resolver_method_dispatch`; summary line → `resolver-path method dispatches (resolve+setup; body runs compiled)`. This is the right metric for the next optimization: VM-native multi/submethod resolution caching so a `CallMethod` op dispatches without entering `run_instance_method`.

## Verification (fresh release build)

- `make test` → 12289 green.
- Roast: `S14-roles/composition`, `S12-attributes/delegation`, `S12-methods/{defer-next,multi}` pass.
- Delegation + mixin/arity/nextsame/method-redispatch pins green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)