### PR TITLE
fix(scope): lexical `my sub` must not leak out of its declaring scope (lexical-subs.t)

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -2159,6 +2159,19 @@ impl Interpreter {
                 registry.functions.insert(key, def);
             }
         }
+        drop(registry);
+        // The routine registry just changed: a lexical (`my sub`) registered
+        // inside the block was removed. Invalidate the name-keyed resolution
+        // caches so a subsequent call to that name re-resolves against the
+        // restored registry rather than returning the now-out-of-scope
+        // CompiledFunction the first in-block call cached (the compiled-function
+        // map is program-global and still contains the lexical sub's body).
+        self.fn_resolve_gen += 1;
+        self.method_resolve_cache.clear();
+        self.last_method_resolve = None;
+        self.fast_method_cache.clear();
+        self.multi_resolve_cache.clear();
+        self.multi_type_cacheable.clear();
     }
 
     pub(crate) fn push_block_scope_depth(&mut self) {


### PR DESCRIPTION
## Summary

A `my sub` is lexically scoped to its declaring block / routine body, but mutsu kept it callable after that scope exited — calling the name outside the scope returned the sub's value instead of throwing `X::Undeclared::Symbols`. This greens **`S06-advanced/lexical-subs.t`** (was 11/13) and adds it to the whitelist.

The file failed two subtests, each from an independent leak with its own substrate root cause:

### 1. Block-scoped `my sub` — stale resolution cache
`BlockScope` already snapshots/restores the routine registry on exit, but it never invalidated the name-keyed resolution caches. The first in-block call cached `name → CompiledFunction`; because the compiled-function map is program-global it still held the lexical sub's body, so the stale `fn_resolve_cache` hit kept resolving after the registry itself was restored. `restore_routine_registry_impl` now bumps `fn_resolve_gen` and clears the method/multi caches (mirroring `register_sub_decl`).

### 2. Routine-body `my sub` — never unregistered on return
A `my sub` declared *directly* in a function body (not inside a nested `{ }` block, which `BlockScope` already handles) was never removed when the call returned. Added a compile-time `CompiledFunction::declares_inner_routines` flag (true when the body emits a top-level `RegisterSub`/`RegisterSubset`) and snapshot/restore the routine registry around the fast and named call paths **only when set**. The narrow gate (vs the broader `has_inner_subs`, which also covers closures/callbacks that never touch the registry) keeps the per-call snapshot off the hot path for ordinary functions.

## Correctness (verified against `raku`)
- Returned closures: `sub make { my sub inner {42}; &inner }` → `make()()` == 42
- `our sub` inside a routine still persists (package-scoped)
- Inner-sub recursion (`fac` with an inner `step`) == 120
- Outer same-name sub reappears once the inner `my sub` block exits

## Tests
- `make test`: cargo 470 passed + `t/` 12313 tests green
- `roast/S06-advanced/lexical-subs.t`: 13/13, added to whitelist

🤖 Generated with [Claude Code](https://claude.com/claude-code)