### PR TITLE
fix(compiler): $!attr outside a method raises X::Syntax::NoSelf

### DIFF
--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -509,6 +509,18 @@ impl Compiler {
         if let Some(attr_name) = name.strip_prefix('!')
             && !attr_name.is_empty()
         {
+            // `$!attr` requires `self`. In a method body `self` is a direct
+            // local, so the bound attribute slot is read directly. Otherwise
+            // (mainline, a plain `sub`, or a bare class-body statement) there is
+            // no `self`: validate it at runtime via `GetSelfOrNoSelf`, which
+            // raises X::Syntax::NoSelf when absent — matching `$.attr`. When a
+            // `self` *is* reachable (a closure nested in a method) the validated
+            // value is discarded and the attribute slot is read as before.
+            if !self.local_map.contains_key("self") {
+                let name_idx = self.code.add_constant(Value::str(format!("${}", name)));
+                self.code.emit(OpCode::GetSelfOrNoSelf(name_idx));
+                self.code.emit(OpCode::Pop);
+            }
             let slot = self.alloc_local(name);
             self.code.emit(OpCode::GetLocal(slot));
             return;


### PR DESCRIPTION
## Summary

`$!attr` (the private-attribute twigil) requires `self`. mutsu compiled it to an unconditional `GetLocal`, so when used where no `self` is available — the mainline, a plain `sub`, or a bare class-body statement — it silently read an empty slot (a sink-context "useless use" warning at most) instead of raising the compile/EVAL-time error Raku produces. `$.attr` already raised `X::Syntax::NoSelf` via `GetSelfOrNoSelf`; this brings `$!attr` in line.

```raku
try EVAL '$!a';  say $! ~~ Exception;  # was False, now True (X::Syntax::NoSelf)
```

## How
When `self` is a direct local (method body) the bound attribute slot is read as before. Otherwise the access is guarded by `GetSelfOrNoSelf`, which raises `X::Syntax::NoSelf` when no `self` is reachable and is a no-op (validated value discarded) when one is — e.g. a closure nested inside a method, where `$!attr` still reads correctly.

## Verified against raku
- `method get { $!x + $.y }` → unchanged
- `method viaClosure { my $c = { $!x * 2 }; $c() }` → unchanged
- `EVAL '$!a'` now throws `X::Syntax::NoSelf`

Greens `S12-attributes/class.t` test 14 (2 failing → 1; the remaining failure, "cannot declare attribute inside a runtime EVAL", is a separate class-composition-timing feature, so the file is not whitelisted here).

## Tests
- `make test`: cargo 470 + `t/` 12313 green
- No regressions in `S12-attributes/*`, `S12-class/attributes.t`, `S12-construction/construction.t`, `S14-roles/instantiation.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)