### PR TITLE
fix(scope): clean up routine-body lexical my sub on return unless it escapes (greens lexical-subs.t)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -454,6 +454,7 @@ roast/S05-transliteration/with-closure.t
 roast/S06-advanced/callframe.t
 roast/S06-advanced/callsame.t
 roast/S06-advanced/dispatching.t
+roast/S06-advanced/lexical-subs.t
 roast/S06-advanced/recurse.t
 roast/S06-advanced/return.t
 roast/S06-advanced/stub.t

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -378,6 +378,7 @@ impl Compiler {
             is_raw,
             param_local_slots: None,
             has_inner_subs: false,
+            declares_inner_routines: false,
             named_param_slots: None,
             deprecated_info,
             declared_locals: None,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2231,6 +2231,14 @@ pub(crate) struct CompiledFunction {
     /// When true, parameters must be written to env (not just locals) so that
     /// nested functions can capture them via closure.
     pub(crate) has_inner_subs: bool,
+    /// True if the function body *directly* declares a lexical routine via a
+    /// top-level `RegisterSub` / `RegisterSubset` opcode (`my sub`, a bare
+    /// nested `sub`/`regex`/`token`/`rule`, or a `subset`). Such a routine is
+    /// lexically scoped to this body and — unless it escapes by being returned —
+    /// must be removed from the (program-global) routine registry when the call
+    /// returns. A `my sub` nested inside a `{ }` block within the body is not
+    /// counted here: `BlockScope` already restores the registry for it.
+    pub(crate) declares_inner_routines: bool,
     /// Pre-computed mapping for named parameters: (match_key, local_slot, sub_sig_slots).
     /// sub_sig_slots is a list of (inner_key, inner_slot) for sub_signature aliases.
     /// Used by the OTF named call fast path to avoid name-based lookup per call.
@@ -2340,6 +2348,14 @@ impl CompiledFunction {
                         | OpCode::ForLoop { .. }
                 )
             });
+        // A routine declared directly in this body (not inside a nested
+        // BlockScope, which restores the registry itself) is lexical to the
+        // body and must be unregistered on return unless it escapes.
+        self.declares_inner_routines = self
+            .code
+            .ops
+            .iter()
+            .any(|op| matches!(op, OpCode::RegisterSub(..) | OpCode::RegisterSubset(..)));
     }
 
     /// Compute the set of variable names declared locally in this function

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -167,6 +167,7 @@ impl Interpreter {
             is_raw: def.is_raw,
             param_local_slots: None,
             has_inner_subs: false,
+            declares_inner_routines: false,
             named_param_slots: None,
             deprecated_info,
             declared_locals: None,
@@ -514,6 +515,14 @@ impl Interpreter {
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
         self.record_cf_deprecation(cf);
+        // A routine declared directly in this body is lexical; snapshot the
+        // registry so it is removed on return unless it escaped (see
+        // `call_compiled_function_named` / `return_value_escapes_routine`).
+        let routine_snapshot = if cf.declares_inner_routines {
+            Some(self.snapshot_routine_registry())
+        } else {
+            None
+        };
         // Only save env when there are local variables to clean up.
         // When the function has no locals, the env save/restore is a
         // no-op (nothing to remove), but still causes an Arc clone that
@@ -745,7 +754,7 @@ impl Interpreter {
             });
         }
 
-        match result {
+        let final_result = match result {
             Ok(()) if fail_bypass => Ok(ret_val),
             Ok(()) => {
                 if let Some(v) = explicit_return {
@@ -755,7 +764,16 @@ impl Interpreter {
                 }
             }
             Err(e) => Err(e),
+        };
+        // Restore the routine registry (removing this body's lexical routines)
+        // unless an inner routine escaped via the return value.
+        if let Some(snapshot) = routine_snapshot {
+            match &final_result {
+                Ok(v) if Self::return_value_escapes_routine(v) => {}
+                _ => self.restore_routine_registry(snapshot),
+            }
         }
+        final_result
     }
 
     /// Check if a compiled function is eligible for the fast call path.
@@ -1692,7 +1710,52 @@ impl Interpreter {
         }
     }
 
+    /// A return value that may *be* (or carry) a routine declared inside the
+    /// callee body — i.e. a `my sub` that escaped by being returned. When the
+    /// body declares an inner routine and returns one of these, its registry
+    /// entry must survive the call so it stays callable by name (e.g. `my &bar
+    /// := producer()` then `bar(...)`). Any other return value means the inner
+    /// routine did not escape via the return slot and can be cleaned up.
+    fn return_value_escapes_routine(v: &Value) -> bool {
+        matches!(
+            v,
+            Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } | Value::Mixin(..)
+        )
+    }
+
     pub(super) fn call_compiled_function_named(
+        &mut self,
+        cf: &CompiledFunction,
+        args: Vec<Value>,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+        fn_package: &str,
+        fn_name: &str,
+    ) -> Result<Value, RuntimeError> {
+        // A routine declared directly in this body is lexical to the call.
+        // Snapshot the routine registry around the (multi-exit) body so the
+        // lexical routine is removed on return — UNLESS it escapes by being
+        // returned (then its registry entry must survive so it stays callable
+        // by name). The snapshot is cheap relative to the rare case it guards.
+        if !cf.declares_inner_routines {
+            return self.call_compiled_function_named_inner(
+                cf,
+                args,
+                compiled_fns,
+                fn_package,
+                fn_name,
+            );
+        }
+        let snapshot = self.snapshot_routine_registry();
+        let result =
+            self.call_compiled_function_named_inner(cf, args, compiled_fns, fn_package, fn_name);
+        match &result {
+            Ok(v) if Self::return_value_escapes_routine(v) => {}
+            _ => self.restore_routine_registry(snapshot),
+        }
+        result
+    }
+
+    fn call_compiled_function_named_inner(
         &mut self,
         cf: &CompiledFunction,
         args: Vec<Value>,


### PR DESCRIPTION
## Summary

A `my sub` (or bare nested `sub`/`regex`/`token`/`rule`) declared **directly** in a routine body is lexically scoped to that body, but mutsu kept it registered after the routine returned, so its name stayed callable from an outer scope (and an `EVAL` there could see it). #3686 fixed the block-scoped (`{ my sub … }`) case; this fixes the routine-body case, which the existing `BlockScope` snapshot/restore never covered.

```raku
sub f() { my sub g(){"g"}; g() }
f();                # "g"
EVAL 'g';           # was callable (leaked) — now X::Undeclared::Symbols
```

## Escape gate
The naive "snapshot at entry, restore at exit" removes the inner routine on every path — but an inner sub frequently **escapes** by being returned:

```raku
sub producer { my $a = 2; sub bar($x where $a) { $x } }
my &bar := producer(); bar(2);          # bar must survive

sub foo($a) { sub bar($n) { … &?ROUTINE($n-1) } }   # &?ROUTINE generator
my $r1 = foo('a'); $r1(4);              # bar must survive
```

So the restore is gated by `return_value_escapes_routine`: when the call returns a `Sub` / `Routine` / `WeakSub` / `Mixin`, the registry is left intact; otherwise the body's lexical routines are removed. Conservative — a sub escaping via a non-return path (binding into an outer container) still leaks, matching prior behaviour — but it covers the return-slot escape every real case uses.

Gated on a new compile-time `CompiledFunction::declares_inner_routines` (body emits a top-level `RegisterSub`/`RegisterSubset`), so ordinary functions pay nothing. Applied to the fast and named call paths (the positional/light paths exclude `has_inner_subs`, a superset, so never see such a body).

## Tests
- **Greens `S06-advanced/lexical-subs.t` (13/13)** — added to whitelist
- Verified unregressed: `6.c/S02-types/subset-6c.t`, `S02-types/subset-6e.t`, `S02-magicals/sub.t` (the `&?ROUTINE` generator an earlier un-gated attempt crashed), plus a full S06 / S04-declarations / S02-names / S10 / S11 whitelist sweep
- `make test`: cargo 470 + `t/` 12313 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)