### PR TITLE
fix(default): surface Hash/Array value-carried is default through .default, .VAR.default, :delete and ++/--

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -164,6 +164,11 @@ pub(super) fn dispatch(
         }
         "default" => {
             let result = match target {
+                // A value-carried `is default(...)` (embedded in HashData/
+                // ArrayData) takes priority over the type default, so it survives
+                // raw-parameter binding and list construction.
+                Value::Array(a, _) if a.default.is_some() => a.default.as_deref().cloned().unwrap(),
+                Value::Hash(h) if h.default.is_some() => h.default.as_deref().cloned().unwrap(),
                 Value::Array(..) | Value::Hash(..) => Value::Package(Symbol::intern("Any")),
                 Value::Set(..) => Value::Bool(false),
                 Value::Bag(..) | Value::Mix(..) => Value::Int(0),

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -72,6 +72,26 @@ impl Compiler {
                     self.compile_expr(expr);
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::SetGlobal(name_idx));
+                    // Apply an `is default(...)` trait BEFORE reading the value back,
+                    // so the container's embedded default travels with the value
+                    // returned by this expression (`(my % is default(42))`). The
+                    // statement-position VarDecl applies traits via `ApplyVarTrait`;
+                    // the expression path must do the same or the default is lost.
+                    if let Some(trait_arg) = custom_traits
+                        .iter()
+                        .find_map(|(t, a)| if t == "default" { Some(a) } else { None })
+                    {
+                        if let Some(arg) = trait_arg {
+                            self.compile_expr(arg);
+                        }
+                        let trait_name_idx =
+                            self.code.add_constant(Value::str("default".to_string()));
+                        self.code.emit(OpCode::ApplyVarTrait {
+                            name_idx,
+                            trait_name_idx,
+                            has_arg: trait_arg.is_some(),
+                        });
+                    }
                     // Read back the coerced value (SetGlobal coerces list->hash for %)
                     let name_idx2 = self.code.add_constant(Value::str(name.clone()));
                     if name.starts_with('@') {

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -276,7 +276,23 @@ impl Interpreter {
         None
     }
 
+    /// The value-carried `is default(...)` of a Hash/Array, if any. Embedded in
+    /// `HashData`/`ArrayData` so it travels with the value through copy-on-write,
+    /// raw-parameter binding, and list construction — unlike the name-keyed
+    /// `var_defaults` table, which only resolves for a value still held under its
+    /// original variable name.
+    pub(crate) fn value_carried_default(target: &Value) -> Option<Value> {
+        match target {
+            Value::Hash(h) => h.default.as_deref().cloned(),
+            Value::Array(a, _) => a.default.as_deref().cloned(),
+            _ => None,
+        }
+    }
+
     pub(super) fn dispatch_default(target: &Value) -> Option<Result<Value, RuntimeError>> {
+        if let Some(def) = Self::value_carried_default(target) {
+            return Some(Ok(def));
+        }
         if matches!(target, Value::Array(..)) {
             return Some(Ok(Value::Package(Symbol::intern("Any"))));
         }

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -2008,8 +2008,13 @@ impl Interpreter {
                 Value::Bool(self.is_var_dynamic(target_var)),
             );
             // Add .default: explicit `is default(...)` value, or type object
-            // for typed variables, or (Any) for untyped.
-            let default_val = if let Some(def) = self.var_default(target_var) {
+            // for typed variables, or (Any) for untyped. Prefer the value-carried
+            // default (HashData/ArrayData) so it survives raw-parameter binding
+            // and list construction, where the name-keyed `var_defaults` lookup
+            // (the variable's original name) no longer resolves.
+            let default_val = if let Some(def) = Self::value_carried_default(&target) {
+                def
+            } else if let Some(def) = self.var_default(target_var) {
                 def.clone()
             } else if let Some(tc) = self.var_type_constraint(target_var) {
                 Value::Package(Symbol::intern(&tc))

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -988,8 +988,14 @@ impl Interpreter {
             self.set_var_default(&name, default_value.clone());
             // For array/hash variables, also register the container default
             // so that element access on missing indices returns the default.
+            // Fall back to the env value when the variable is not a local slot:
+            // an anonymous `(my % is default(...))` in expression position is
+            // stored via SetGlobal, not a local, so the embedded default would
+            // otherwise be skipped and lost when the value flows out.
             if (name.starts_with('@') || name.starts_with('%'))
-                && let Some(container) = self.locals_get_by_name(code, &name)
+                && let Some(container) = self
+                    .locals_get_by_name(code, &name)
+                    .or_else(|| self.get_env_with_main_alias(&name))
             {
                 let container = self.tag_container_default(container, default_value.clone());
                 self.locals_set_by_name(code, &name, container.clone());

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -2191,7 +2191,10 @@ impl Interpreter {
                 _ => Value::Nil,
             };
             let effective = Self::normalize_incdec_source(match current {
-                Value::Nil => Value::Int(0),
+                Value::Nil => Self::value_carried_default(&inner)
+                    .or_else(|| self.var_default(&name).cloned())
+                    .filter(|d| !matches!(d, Value::Nil))
+                    .unwrap_or(Value::Int(0)),
                 other => other,
             });
             let new_val = if increment {
@@ -2254,14 +2257,16 @@ impl Interpreter {
             Value::Nil => {
                 // Check if the container has an `is default(...)` value;
                 // e.g. `my @a is default(42); @a[0]++` should increment 42.
-                if let Some(def) = self.var_default(&name) {
-                    if matches!(def, Value::Nil) {
-                        Value::Int(0)
-                    } else {
-                        def.clone()
-                    }
-                } else {
-                    Value::Int(0)
+                // Prefer the value-carried default (HashData/ArrayData) so it
+                // works when the container arrived via a parameter (whose name
+                // is not in the name-keyed `var_defaults` table).
+                let def = container
+                    .as_ref()
+                    .and_then(Self::value_carried_default)
+                    .or_else(|| self.var_default(&name).cloned());
+                match def {
+                    Some(d) if !matches!(d, Value::Nil) => d,
+                    _ => Value::Int(0),
                 }
             }
             other => other.clone(),

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -128,15 +128,20 @@ impl Interpreter {
                 if hash_arc.has_type_meta() {
                     return None;
                 }
+                // A `:delete` of an absent key yields the hash's `is default(...)`
+                // value (Raku semantics), not Nil. Capture it before the env
+                // borrow is released for the mutating remove below.
+                let container_default = hash_arc.default.as_deref().cloned();
                 let key = idx.to_string_value();
                 if let Some(slot) = local_slot {
                     self.locals[slot] = Value::Nil;
                 }
                 let removed = if let Some(Value::Hash(hash)) = self.env_mut().get_mut(var_name) {
-                    Arc::make_mut(hash).remove(&key).unwrap_or(Value::Nil)
+                    Arc::make_mut(hash).remove(&key)
                 } else {
-                    Value::Nil
+                    None
                 };
+                let removed = removed.or(container_default).unwrap_or(Value::Nil);
                 if let Some(slot) = local_slot
                     && let Some(env_val) = self.env().get(var_name).cloned()
                 {
@@ -271,13 +276,14 @@ impl Interpreter {
         // for this variable: Arc pointers can be reused across
         // allocations, so a stale pointer-keyed entry from a freed
         // same-named container must not leak into the new container.
-        let saved_default = if self.var_default(&var_name).is_some() {
-            self.env()
-                .get(&var_name)
-                .and_then(|v| self.container_default(v).cloned())
-        } else {
-            None
-        };
+        // Prefer the value-carried default (HashData/ArrayData) so `:delete` of
+        // an absent key yields the default even when the container arrived via a
+        // parameter (whose name is not in the name-keyed `var_defaults` table).
+        let saved_default = self
+            .env()
+            .get(&var_name)
+            .and_then(|v| self.container_default(v).cloned())
+            .or_else(|| self.var_default(&var_name).cloned());
         // Resolve WhateverCode indices (e.g. *-1) for array targets
         let idx = if let Some(container) = self.env().get(&var_name).cloned() {
             self.resolve_delete_index_for_array(idx, &container)


### PR DESCRIPTION
## Summary

`is default(...)` is embedded in `HashData`/`ArrayData` so it travels with the value through copy-on-write, raw-parameter binding and list construction — but several read paths still consulted only the **name-keyed** `var_defaults` side table, which resolves only for a value still held under its original variable name. Through a parameter or a list element the name is gone, so the default was silently lost.

Six read paths now prefer the value-carried default (new shared helper `Interpreter::value_carried_default`):

| Path | Before | After |
|------|--------|-------|
| `%h.default` | `(Any)` | the embedded default |
| `%a.VAR.default` (via `is raw` param) | `(Any)` | the default |
| `%h<absent>:delete` | `Nil` | the default (fast + slow path) |
| `%h<absent>++` / `@a[i]++` (via param) | seeds 0 → `1` | seeds default → `43` |
| `(my % is default(N))` as an expression | default dropped | default carried |

The anonymous `(my % is default(N))` case: the `DoStmt` VarDecl expression path never applied the `default` trait, and the trait handler only tagged *local-slot* containers — the anon hash is stored via `SetGlobal`, so it now also falls back to the env value.

## Tests
- `S02-names/is_default.t`: **5 failing subtests → 2**. "Hashes" greened. Remaining: "Hash Attributes" (typed-key object-hash attribute defaults) and "Generics" (parametric-role `is default(T)` type-parameter substitution) — separate, more specialized features, so the file is not whitelisted here.
- `make test`: cargo + `t/` 12326 green
- No regressions in `S03-operators/autoincrement.t`, `S02-types/{baghash,mixhash,hash}.t`, `S09-typed-arrays/hashes.t`, `S32-hash/delete-adverb.t` (the `++`/`--` and `:delete` paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)