### PR TITLE
[codex] vm: capture closure lexicals as upvalues

### DIFF
--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -2,6 +2,16 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Compiler {
+    fn method_args_escape(target: &Expr, name: &Symbol) -> bool {
+        matches!(
+            (target, name.resolve().as_str()),
+            (
+                Expr::Literal(Value::Package(pkg)),
+                "from-loop" | "from_loop"
+            ) if *pkg == Symbol::intern("Seq")
+        )
+    }
+
     /// Compile method call on indexed target: .VAR on @a[0] / %h<k>
     pub(super) fn compile_expr_method_var_on_index(&mut self, target: &Expr) {
         if let Expr::Index {
@@ -100,8 +110,9 @@ impl Compiler {
         self.compile_expr(target);
         let arity = args.len() as u32;
         let arg_sources_idx = self.add_arg_sources_constant(args);
+        let escaping_args = Self::method_args_escape(target, name);
         for arg in args {
-            self.compile_method_arg(arg);
+            self.compile_method_arg_with_escape(arg, escaping_args);
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
@@ -313,8 +324,9 @@ impl Compiler {
         self.compile_expr(target);
         let arity = args.len() as u32;
         let arg_sources_idx = self.add_arg_sources_constant(args);
+        let escaping_args = Self::method_args_escape(target, name);
         for arg in args {
-            self.compile_method_arg(arg);
+            self.compile_method_arg_with_escape(arg, escaping_args);
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -100,10 +100,16 @@ impl Compiler {
     /// Compile a method call argument. Named args (AssignExpr) are
     /// compiled as Pair values so they survive VM execution.
     pub(super) fn compile_method_arg(&mut self, arg: &Expr) {
+        self.compile_method_arg_with_escape(arg, false);
+    }
+
+    /// Like `compile_method_arg` but lets the caller mark the argument as
+    /// escaping when the callee retains the closure beyond the immediate call.
+    pub(super) fn compile_method_arg_with_escape(&mut self, arg: &Expr, escaping: bool) {
         // A method argument is passed to the callee, not stored in the caller
         // frame, so a closure argument is conservatively NON-escaping (same
         // #2746 guard as compile_call_arg).
-        self.with_escape(false, |s| {
+        self.with_escape(escaping, |s| {
             s.with_suppress_pair_capture(true, |s| {
                 if let Expr::AssignExpr { name, expr, .. } = arg {
                     // `foo(arg = 1)` in method-call argument position is treated as a

--- a/src/env.rs
+++ b/src/env.rs
@@ -483,7 +483,8 @@ impl Env {
             None => global_base()
                 .map(|b| {
                     b.iter()
-                        .filter_map(|(k, v)| keep(*k, v).then(|| (*k, v.clone())))
+                        .filter(|(k, v)| keep(**k, v))
+                        .map(|(k, v)| (*k, v.clone()))
                         .collect()
                 })
                 .unwrap_or_default(),

--- a/src/env.rs
+++ b/src/env.rs
@@ -472,6 +472,37 @@ impl Env {
         out
     }
 
+    /// Full symbol-keyed snapshot filtered during collection, without first
+    /// materializing every reachable entry into an intermediate flat env.
+    pub(crate) fn filtered_symbol_map<F>(&self, keep: &mut F) -> HashMap<Symbol, Value>
+    where
+        F: FnMut(Symbol, &Value) -> bool,
+    {
+        let mut out: HashMap<Symbol, Value> = match &self.parent {
+            Some(parent) => parent.filtered_symbol_map(keep),
+            None => global_base()
+                .map(|b| {
+                    b.iter()
+                        .filter_map(|(k, v)| keep(*k, v).then(|| (*k, v.clone())))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+        if let Some(tomb) = &self.tombstones {
+            for k in tomb {
+                out.remove(k);
+            }
+        }
+        for (k, v) in self.inner.iter() {
+            if keep(*k, v) {
+                out.insert(*k, v.clone());
+            } else {
+                out.remove(k);
+            }
+        }
+        out
+    }
+
     pub fn len(&self) -> usize {
         self.inner.len()
     }

--- a/src/runtime/methods_classhow.rs
+++ b/src/runtime/methods_classhow.rs
@@ -2317,6 +2317,8 @@ impl Interpreter {
                     source_line: None,
                     source_file: None,
                     owned_captures: Vec::new(),
+                    captured_upvalues: Vec::new(),
+                    captured_upvalues_from_local: Vec::new(),
                 };
                 meta.insert(
                     "build".to_string(),

--- a/src/runtime/methods_seq_dispatch.rs
+++ b/src/runtime/methods_seq_dispatch.rs
@@ -1,6 +1,38 @@
 use super::*;
 
 impl Interpreter {
+    fn sync_from_loop_closure_state(&mut self, source: &Value, siblings: &[Value]) {
+        let Value::Sub(source_data) = source else {
+            return;
+        };
+        let Some(source_cc) = source_data.compiled_code.as_deref() else {
+            return;
+        };
+        for sym in &source_cc.free_var_syms {
+            let Some(val) = self
+                .get_closure_captured_state(source_data.id, *sym)
+                .cloned()
+                .or_else(|| source_data.captured_upvalue(source_cc, *sym).cloned())
+            else {
+                continue;
+            };
+            for sibling in siblings {
+                let Value::Sub(sibling_data) = sibling else {
+                    continue;
+                };
+                if sibling_data.id == source_data.id {
+                    continue;
+                }
+                let Some(sibling_cc) = sibling_data.compiled_code.as_deref() else {
+                    continue;
+                };
+                if sibling_cc.free_var_syms.contains(sym) {
+                    self.set_closure_captured_state(sibling_data.id, *sym, val.clone());
+                }
+            }
+        }
+    }
+
     /// Dispatch Seq.from-loop / Seq.from_loop
     pub(super) fn dispatch_seq_from_loop(
         &mut self,
@@ -43,6 +75,11 @@ impl Interpreter {
         };
         let cond_callable = positional.get(1).cloned();
         let step_callable = positional.get(2).cloned();
+        let sibling_closures: Vec<Value> = positional
+            .iter()
+            .filter(|value| matches!(value, Value::Sub(_)))
+            .cloned()
+            .collect();
 
         // If there's no condition and no step, this is a lazy infinite Seq.
         // Return a lazy list backed by a from-loop iterator.
@@ -72,6 +109,7 @@ impl Interpreter {
                 && let Some(cond) = cond_callable.clone()
             {
                 let cond_value = self.call_sub_value(cond, vec![], true)?;
+                self.sync_from_loop_closure_state(&positional[1], &sibling_closures);
                 if !cond_value.truthy() {
                     break;
                 }
@@ -81,6 +119,7 @@ impl Interpreter {
             'body_redo: loop {
                 match self.call_sub_value(body_callable.clone(), vec![], true) {
                     Ok(value) => {
+                        self.sync_from_loop_closure_state(&body_callable, &sibling_closures);
                         if !matches!(value, Value::Nil) {
                             items.push(value);
                         }
@@ -95,7 +134,9 @@ impl Interpreter {
 
             if let Some(step) = step_callable.clone() {
                 match self.call_sub_value(step, vec![], true) {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        self.sync_from_loop_closure_state(&positional[2], &sibling_closures);
+                    }
                     Err(e) if e.is_next() && label_matches(&e.label) => continue 'from_loop,
                     Err(e) if e.is_redo() && label_matches(&e.label) => continue 'from_loop,
                     Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -73,6 +73,8 @@ impl Interpreter {
                 source_line: None,
                 source_file: None,
                 owned_captures: Vec::new(),
+                captured_upvalues: Vec::new(),
+                captured_upvalues_from_local: Vec::new(),
             };
             // Store the routine name so call_sub_value can dispatch
             sub_data.env.insert(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -7007,6 +7007,8 @@ mod tests {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            captured_upvalues: Vec::new(),
+            captured_upvalues_from_local: Vec::new(),
         });
 
         let mut interp = Interpreter::new();

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1351,11 +1351,9 @@ impl Interpreter {
             if let Some(cc) = data.compiled_code.as_deref() {
                 for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
                     let Some(val) = maybe_val else { continue };
-                    if matches!(val, Value::ContainerRef(_)) {
-                        new_env.insert_sym(*sym, val.clone());
-                    } else if !merge_all
-                        || !(matches!(new_env.get_sym(*sym), Some(Value::Array(..)))
-                            && matches!(val, Value::Array(..)))
+                    if !(merge_all
+                        && matches!(new_env.get_sym(*sym), Some(Value::Array(..)))
+                        && matches!(val, Value::Array(..)))
                     {
                         new_env.insert_sym(*sym, val.clone());
                     }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1586,7 +1586,8 @@ impl Interpreter {
                         .compiled_code
                         .as_deref()
                         .is_some_and(|cc| data.captured_upvalue_from_local(cc, *k));
-                    if k == "_" || k == "@_" || plain_upvalue || subsig_names.contains(&k.resolve()) {
+                    if k == "_" || k == "@_" || plain_upvalue || subsig_names.contains(&k.resolve())
+                    {
                         continue;
                     }
                     if matches!(v, Value::Array(..)) {

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1348,6 +1348,19 @@ impl Interpreter {
                 }
                 new_env.insert_sym(*k, v.clone());
             }
+            if let Some(cc) = data.compiled_code.as_deref() {
+                for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
+                    let Some(val) = maybe_val else { continue };
+                    if matches!(val, Value::ContainerRef(_)) {
+                        new_env.insert_sym(*sym, val.clone());
+                    } else if !merge_all
+                        || !(matches!(new_env.get_sym(*sym), Some(Value::Array(..)))
+                            && matches!(val, Value::Array(..)))
+                    {
+                        new_env.insert_sym(*sym, val.clone());
+                    }
+                }
+            }
             self.env = new_env.clone();
             // Check for empty signature: a pointy block `-> { }` or sub with no
             // params that doesn't use @_/%_ must reject positional arguments.
@@ -1418,6 +1431,8 @@ impl Interpreter {
                 source_line: data.source_line,
                 source_file: data.source_file.clone(),
                 owned_captures: data.owned_captures.clone(),
+                captured_upvalues: data.captured_upvalues.clone(),
+                captured_upvalues_from_local: data.captured_upvalues_from_local.clone(),
             });
             new_env.insert(
                 "&?BLOCK".to_string(),
@@ -1532,8 +1547,13 @@ impl Interpreter {
             let mut captured_outer_writes: Vec<String> = Vec::new();
             if merge_all {
                 for (k, v) in self.env.iter() {
+                    let plain_upvalue = data
+                        .compiled_code
+                        .as_deref()
+                        .is_some_and(|cc| data.captured_upvalue_from_local(cc, *k));
                     if k != "_"
                         && k != "@_"
+                        && !plain_upvalue
                         && (merged.contains_key_sym(*k) || k.starts_with("__mutsu_var_meta::"))
                     {
                         if merged.contains_key_sym(*k)
@@ -1562,7 +1582,11 @@ impl Interpreter {
                     Self::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
                 }
                 for (k, v) in self.env.iter() {
-                    if k == "_" || k == "@_" || subsig_names.contains(&k.resolve()) {
+                    let plain_upvalue = data
+                        .compiled_code
+                        .as_deref()
+                        .is_some_and(|cc| data.captured_upvalue_from_local(cc, *k));
+                    if k == "_" || k == "@_" || plain_upvalue || subsig_names.contains(&k.resolve()) {
                         continue;
                     }
                     if matches!(v, Value::Array(..)) {
@@ -1920,7 +1944,7 @@ impl Interpreter {
                 .locals
                 .iter()
                 .enumerate()
-                .filter(|(_, name)| data.env.contains_key(name))
+                .filter(|(_, name)| data.captures_name(data.compiled_code.as_deref(), name))
                 .map(|(idx, name)| (idx, name.clone()))
                 .collect();
             let mut assigned_slots = std::collections::HashSet::new();
@@ -1961,7 +1985,9 @@ impl Interpreter {
                 let Some(crate::value::Value::Str(name)) = compiled.constants.get(idx) else {
                     continue;
                 };
-                if data.env.contains_key(name.as_str()) && !captured_names.contains(name) {
+                if data.captures_name(data.compiled_code.as_deref(), name.as_str())
+                    && !captured_names.contains(name)
+                {
                     captured_names.push(name.to_string());
                 }
             }
@@ -2173,6 +2199,14 @@ impl Interpreter {
             for (k, v) in &data.env {
                 if !self.env.contains_key_sym(*k) {
                     self.env.insert_sym(*k, v.clone());
+                }
+            }
+            if let Some(cc) = data.compiled_code.as_deref() {
+                for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
+                    let Some(val) = maybe_val else { continue };
+                    if !self.env.contains_key_sym(*sym) {
+                        self.env.insert_sym(*sym, val.clone());
+                    }
                 }
             }
 
@@ -2407,6 +2441,14 @@ impl Interpreter {
                     self.env.insert_sym(*k, v.clone());
                 }
             }
+            if let Some(cc) = data.compiled_code.as_deref() {
+                for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
+                    let Some(val) = maybe_val else { continue };
+                    if !self.env.contains_key_sym(*sym) {
+                        self.env.insert_sym(*sym, val.clone());
+                    }
+                }
+            }
 
             // CP-3 collapse: run the rw map loop with fresh execution registers
             // (replaces the `mem::take(self)` + `VM::new` sub-VM). The closure
@@ -2587,6 +2629,12 @@ impl Interpreter {
             // Pre-insert closure env
             for (k, v) in &data.env {
                 self.env.insert_sym(*k, v.clone());
+            }
+            if let Some(cc) = data.compiled_code.as_deref() {
+                for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
+                    let Some(val) = maybe_val else { continue };
+                    self.env.insert_sym(*sym, val.clone());
+                }
             }
 
             // CP-3 collapse: run the grep loop with fresh execution registers

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -21,6 +21,30 @@ impl Interpreter {
     pub(crate) const LAZY_GATHER_TAKE_LIMIT_SIGNAL: &str =
         "__mutsu_lazy_gather_take_limit_reached__";
 
+    pub(crate) fn closure_upvalue_value(
+        &self,
+        data: &crate::value::SubData,
+        sym: Symbol,
+        captured: Option<&Value>,
+    ) -> Option<Value> {
+        self.get_closure_captured_state(data.id, sym)
+            .cloned()
+            .or_else(|| captured.cloned())
+    }
+
+    pub(crate) fn persist_closure_upvalue_state(
+        &mut self,
+        data: &crate::value::SubData,
+        code: Option<&crate::opcode::CompiledCode>,
+    ) {
+        let Some(code) = code else { return };
+        for sym in &code.free_var_syms {
+            if let Some(val) = self.env.get_sym(*sym).cloned() {
+                self.set_closure_captured_state(data.id, *sym, val);
+            }
+        }
+    }
+
     fn is_stub_method_body(body: &[Stmt]) -> bool {
         let filtered: Vec<_> = body
             .iter()
@@ -1350,13 +1374,11 @@ impl Interpreter {
             }
             if let Some(cc) = data.compiled_code.as_deref() {
                 for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
-                    let Some(val) = maybe_val else { continue };
-                    if !(merge_all
-                        && matches!(new_env.get_sym(*sym), Some(Value::Array(..)))
-                        && matches!(val, Value::Array(..)))
-                    {
-                        new_env.insert_sym(*sym, val.clone());
-                    }
+                    let Some(val) = self.closure_upvalue_value(&data, *sym, maybe_val.as_ref())
+                    else {
+                        continue;
+                    };
+                    new_env.insert_sym(*sym, val);
                 }
             }
             self.env = new_env.clone();
@@ -1527,6 +1549,7 @@ impl Interpreter {
                 self.closure_env_overrides
                     .insert(data.id, persisted_closure_env);
             }
+            self.persist_closure_upvalue_state(&data, data.compiled_code.as_deref());
             // Preserve map rw topic writeback across env restoration
             let rw_map_topic = self.env.get("__mutsu_rw_map_topic__").cloned();
             let mut merged = saved_env;
@@ -1545,13 +1568,15 @@ impl Interpreter {
             let mut captured_outer_writes: Vec<String> = Vec::new();
             if merge_all {
                 for (k, v) in self.env.iter() {
-                    let plain_upvalue = data
+                    let creator_local_upvalue = data
                         .compiled_code
                         .as_deref()
                         .is_some_and(|cc| data.captured_upvalue_from_local(cc, *k));
+                    let unrelated_caller_binding =
+                        creator_local_upvalue && merged.get_sym(*k) != body_entry_env.get_sym(*k);
                     if k != "_"
                         && k != "@_"
-                        && !plain_upvalue
+                        && !unrelated_caller_binding
                         && (merged.contains_key_sym(*k) || k.starts_with("__mutsu_var_meta::"))
                     {
                         if merged.contains_key_sym(*k)
@@ -1580,11 +1605,16 @@ impl Interpreter {
                     Self::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
                 }
                 for (k, v) in self.env.iter() {
-                    let plain_upvalue = data
+                    let creator_local_upvalue = data
                         .compiled_code
                         .as_deref()
                         .is_some_and(|cc| data.captured_upvalue_from_local(cc, *k));
-                    if k == "_" || k == "@_" || plain_upvalue || subsig_names.contains(&k.resolve())
+                    let unrelated_caller_binding =
+                        creator_local_upvalue && merged.get_sym(*k) != body_entry_env.get_sym(*k);
+                    if k == "_"
+                        || k == "@_"
+                        || unrelated_caller_binding
+                        || subsig_names.contains(&k.resolve())
                     {
                         continue;
                     }

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -221,6 +221,22 @@ impl Interpreter {
                             self.env.insert_sym(*k, v.clone());
                         }
                     }
+                    let closure_code = data
+                        .compiled_code
+                        .as_deref()
+                        .or_else(|| precompiled.map(|(code, _)| code));
+                    if let Some(cc) = closure_code {
+                        for (sym, maybe_val) in
+                            cc.free_var_syms.iter().zip(data.captured_upvalues.iter())
+                        {
+                            let Some(val) =
+                                self.closure_upvalue_value(data, *sym, maybe_val.as_ref())
+                            else {
+                                continue;
+                            };
+                            self.env.insert_sym(*sym, val);
+                        }
+                    }
 
                     // Bind parameters
                     for (i, param) in data.params.iter().enumerate() {
@@ -268,6 +284,9 @@ impl Interpreter {
                     // then restore the caller env. This runs on every exit path —
                     // including `last` — so `{ ++$sunk; last }` still records its
                     // side effect even though the body signals termination.
+                    if let Some(cc) = closure_code {
+                        self.persist_closure_upvalue_state(data, Some(cc));
+                    }
                     let mut restored = saved;
                     for (k, before) in &pre {
                         if let Some(after) = self.env.get_sym(*k)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1012,11 +1012,7 @@ pub struct SubData {
 }
 
 impl SubData {
-    pub(crate) fn captured_upvalue(
-        &self,
-        code: &CompiledCode,
-        sym: Symbol,
-    ) -> Option<&Value> {
+    pub(crate) fn captured_upvalue(&self, code: &CompiledCode, sym: Symbol) -> Option<&Value> {
         code.free_var_syms
             .iter()
             .position(|candidate| *candidate == sym)
@@ -1025,8 +1021,7 @@ impl SubData {
     }
 
     pub(crate) fn captures_symbol(&self, code: Option<&CompiledCode>, sym: Symbol) -> bool {
-        self.env.contains_key_sym(sym)
-            || code.is_some_and(|cc| cc.free_var_syms.contains(&sym))
+        self.env.contains_key_sym(sym) || code.is_some_and(|cc| cc.free_var_syms.contains(&sym))
     }
 
     pub(crate) fn captures_name(&self, code: Option<&CompiledCode>, name: &str) -> bool {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1000,6 +1000,47 @@ pub struct SubData {
     /// the shared lexical name — Raku's per-iteration closure capture. Empty for
     /// non-loop closures and named subs.
     pub(crate) owned_captures: Vec<Symbol>,
+    /// Captured free-variable values aligned with `compiled_code.free_var_syms`.
+    /// For compiled closures this is the primary capture store for lexical
+    /// upvalues; `env` keeps only non-free/system names and metadata.
+    pub(crate) captured_upvalues: Vec<Option<Value>>,
+    /// Parallel to `captured_upvalues`: true when the corresponding plain lexical
+    /// was read from the creating frame's own local slot rather than an ancestor
+    /// env entry. Such upvalues are private to the closure instance unless they
+    /// were explicitly boxed into a shared `ContainerRef`.
+    pub(crate) captured_upvalues_from_local: Vec<bool>,
+}
+
+impl SubData {
+    pub(crate) fn captured_upvalue(
+        &self,
+        code: &CompiledCode,
+        sym: Symbol,
+    ) -> Option<&Value> {
+        code.free_var_syms
+            .iter()
+            .position(|candidate| *candidate == sym)
+            .and_then(|idx| self.captured_upvalues.get(idx))
+            .and_then(|val| val.as_ref())
+    }
+
+    pub(crate) fn captures_symbol(&self, code: Option<&CompiledCode>, sym: Symbol) -> bool {
+        self.env.contains_key_sym(sym)
+            || code.is_some_and(|cc| cc.free_var_syms.contains(&sym))
+    }
+
+    pub(crate) fn captures_name(&self, code: Option<&CompiledCode>, name: &str) -> bool {
+        self.captures_symbol(code, Symbol::intern(name))
+    }
+
+    pub(crate) fn captured_upvalue_from_local(&self, code: &CompiledCode, sym: Symbol) -> bool {
+        code.free_var_syms
+            .iter()
+            .position(|candidate| *candidate == sym)
+            .and_then(|idx| self.captured_upvalues_from_local.get(idx))
+            .copied()
+            .unwrap_or(false)
+    }
 }
 
 fn gcd(mut a: i64, mut b: i64) -> i64 {
@@ -3641,6 +3682,8 @@ impl Value {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            captured_upvalues: Vec::new(),
+            captured_upvalues_from_local: Vec::new(),
         }))
     }
 
@@ -3675,6 +3718,8 @@ impl Value {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            captured_upvalues: Vec::new(),
+            captured_upvalues_from_local: Vec::new(),
         }))
     }
 

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -777,12 +777,12 @@ impl Interpreter {
                 .iter()
                 .map(|(_, source)| Symbol::intern(source))
                 .collect();
-            let captured_names: std::collections::HashSet<Symbol> =
-                data.env
-                    .keys()
-                    .copied()
-                    .chain(cc.free_var_syms.iter().copied())
-                    .collect();
+            let captured_names: std::collections::HashSet<Symbol> = data
+                .env
+                .keys()
+                .copied()
+                .chain(cc.free_var_syms.iter().copied())
+                .collect();
             // Write back captured-variable changes, but NOT the closure's own
             // parameters/locals (which live in cc.locals).  Without this filter,
             // recursive &?BLOCK calls clobber the outer frame's $n, etc.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -237,6 +237,14 @@ impl Interpreter {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
             }
         }
+        for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
+            let Some(val) = maybe_val else { continue };
+            if matches!(val, Value::ContainerRef(_)) {
+                self.env_mut().insert_sym(*sym, val.clone());
+            } else {
+                self.env_mut().insert_sym(*sym, val.clone());
+            }
+        }
         // Per-iteration loop captures (Raku fresh-binding semantics): these free
         // variables were declared in an enclosing loop body when this closure was
         // created, so each iteration's closure froze a distinct value in its
@@ -248,7 +256,11 @@ impl Interpreter {
         // per-instance-state override below so a mutating loop closure's
         // accumulated state still wins on later calls. See PLAN.md lever C.
         for sym in &data.owned_captures {
-            if let Some(val) = data.env.get_sym(*sym).cloned() {
+            if let Some(val) = data
+                .captured_upvalue(cc, *sym)
+                .or_else(|| data.env.get_sym(*sym))
+                .cloned()
+            {
                 self.env_mut().insert_sym(*sym, val);
             }
         }
@@ -302,6 +314,8 @@ impl Interpreter {
             source_line: data.source_line,
             source_file: data.source_file.clone(),
             owned_captures: data.owned_captures.clone(),
+            captured_upvalues: data.captured_upvalues.clone(),
+            captured_upvalues_from_local: data.captured_upvalues_from_local.clone(),
         });
         self.env_mut().insert(
             "&?BLOCK".to_string(),
@@ -480,7 +494,7 @@ impl Interpreter {
         let has_captured_local = cc
             .locals
             .iter()
-            .any(|n| !n.is_empty() && data.env.contains_key(n));
+            .any(|n| !n.is_empty() && data.captures_name(Some(cc), n));
 
         let let_mark = self.let_saves_len();
         let mut ip = 0;
@@ -639,7 +653,7 @@ impl Interpreter {
         // per call for the common read-only closure (which has no captured
         // locals to flush at all).
         for (i, local_name) in cc.locals.iter().enumerate() {
-            if !local_name.is_empty() && data.env.contains_key(local_name) {
+            if !local_name.is_empty() && data.captures_name(Some(cc), local_name) {
                 {
                     let __v = self.locals[i].clone();
                     self.env_mut().insert(local_name.clone(), __v);
@@ -764,7 +778,11 @@ impl Interpreter {
                 .map(|(_, source)| Symbol::intern(source))
                 .collect();
             let captured_names: std::collections::HashSet<Symbol> =
-                data.env.keys().copied().collect();
+                data.env
+                    .keys()
+                    .copied()
+                    .chain(cc.free_var_syms.iter().copied())
+                    .collect();
             // Write back captured-variable changes, but NOT the closure's own
             // parameters/locals (which live in cc.locals).  Without this filter,
             // recursive &?BLOCK calls clobber the outer frame's $n, etc.
@@ -783,8 +801,10 @@ impl Interpreter {
             // free_var recording below misses it.
             let mut caller_writeback: Vec<Symbol> = Vec::new();
             for (k, v) in self.env().iter() {
+                let plain_upvalue = data.captured_upvalue_from_local(cc, *k);
                 if *k != underscore_sym
                     && *k != at_underscore_sym
+                    && !plain_upvalue
                     && !rw_sources.contains(k)
                     && !param_names.contains(k)
                     && (restored_env.contains_key_sym(*k)
@@ -827,8 +847,10 @@ impl Interpreter {
             // no-op in the drain; a captured-only var is filtered out).
             if free_changed {
                 for (k, old) in cc.free_var_syms.iter().zip(free_at_entry.iter()) {
+                    let plain_upvalue = data.captured_upvalue_from_local(cc, *k);
                     if *k != underscore_sym
                         && *k != at_underscore_sym
+                        && !plain_upvalue
                         && !param_names.contains(k)
                         && restored_env.contains_key_sym(*k)
                         && self.env().get_sym(*k) != old.as_ref()
@@ -901,7 +923,13 @@ impl Interpreter {
         // Only update keys matching the closure's captured variable names to
         // avoid overwriting unrelated captured lexicals in other END phasers.
         if self.end_phaser_count() > 0 && !data.env.is_empty() {
-            let captured_strs: Vec<String> = data.env.keys().map(|s| s.resolve()).collect();
+            let captured_strs: Vec<String> = data
+                .env
+                .keys()
+                .copied()
+                .chain(cc.free_var_syms.iter().copied())
+                .map(|s| s.resolve())
+                .collect();
             let captured_names: std::collections::HashSet<&str> =
                 captured_strs.iter().map(|s| s.as_str()).collect();
             // Flatten: END phasers run at program exit with this captured env;

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -239,11 +239,7 @@ impl Interpreter {
         }
         for (sym, maybe_val) in cc.free_var_syms.iter().zip(data.captured_upvalues.iter()) {
             let Some(val) = maybe_val else { continue };
-            if matches!(val, Value::ContainerRef(_)) {
-                self.env_mut().insert_sym(*sym, val.clone());
-            } else {
-                self.env_mut().insert_sym(*sym, val.clone());
-            }
+            self.env_mut().insert_sym(*sym, val.clone());
         }
         // Per-iteration loop captures (Raku fresh-binding semantics): these free
         // variables were declared in an enclosing loop body when this closure was

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -82,6 +82,8 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let (captured_upvalues, captured_upvalues_from_local) =
+                self.capture_closure_upvalues(code, &compiled_code);
             let cc_source_line = compiled_code
                 .as_ref()
                 .and_then(|cc| cc.source_line)
@@ -108,6 +110,8 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_upvalues,
+                captured_upvalues_from_local,
             }));
             self.stack.push(val);
             Ok(())
@@ -137,6 +141,8 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let (captured_upvalues, captured_upvalues_from_local) =
+                self.capture_closure_upvalues(code, &compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
             let mut env = self.capture_closure_env(code, &compiled_code);
             if let Some(rt) = return_type {
@@ -172,6 +178,8 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_upvalues,
+                captured_upvalues_from_local,
             }));
             self.stack.push(val);
             Ok(())
@@ -239,9 +247,39 @@ impl Interpreter {
     /// `env_dirty` path and, for captured-and-mutated locals, the shared
     /// `ContainerRef` cell that `box_captured_lexicals` installs in both the slot
     /// and `env`.
-    fn capture_closure_env(
+    fn capture_closure_upvalues(
         &self,
         code: &CompiledCode,
+        cc: &Option<std::sync::Arc<CompiledCode>>,
+    ) -> (Vec<Option<Value>>, Vec<bool>) {
+        let Some(cc) = cc else {
+            return (Vec::new(), Vec::new());
+        };
+        cc.free_var_syms.iter().fold(
+            (Vec::with_capacity(cc.free_var_syms.len()), Vec::with_capacity(cc.free_var_syms.len())),
+            |(mut values, mut from_local), sym| {
+                if !sym.with_str(crate::env::is_plain_user_lexical) {
+                    values.push(None);
+                    from_local.push(false);
+                    return (values, from_local);
+                }
+                if let Some(slot) = sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+                    && let Some(val) = self.locals.get(slot)
+                {
+                    values.push(Some(val.clone()));
+                    from_local.push(true);
+                    return (values, from_local);
+                }
+                values.push(Some(self.env().get_sym(*sym).cloned().unwrap_or(Value::Nil)));
+                from_local.push(false);
+                (values, from_local)
+            },
+        )
+    }
+
+    fn capture_closure_env(
+        &self,
+        _code: &CompiledCode,
         cc: &Option<std::sync::Arc<CompiledCode>>,
     ) -> Env {
         let Some(cc) = cc else {
@@ -251,27 +289,12 @@ impl Interpreter {
             return self.clone_env();
         }
         let free: std::collections::HashSet<Symbol> = cc.free_var_syms.iter().copied().collect();
-        // Flatten once (same as `clone_env`), then keep only the upvalue set,
-        // shadow-meta, and system names. The base tier (GLOBAL_BASE) is never in
-        // the overlay and stays reachable through the flat env's tail lookup.
-        let flat = self.clone_env();
-        let mut map: std::collections::HashMap<Symbol, Value> = std::collections::HashMap::new();
-        for (k, v) in flat.iter() {
-            let keep = free.contains(k) || k.with_str(|s| !crate::env::is_plain_user_lexical(s));
-            if keep {
-                map.insert(*k, v.clone());
-            }
-        }
-        // Upvalue read: override this frame's own free-var slots with the live
-        // local value. Authoritative even after the closure-driven env flush is
-        // gone (a slot-only local is no longer mirrored into `env`).
-        for sym in &cc.free_var_syms {
-            if let Some(slot) = sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
-                && let Some(val) = self.locals.get(slot)
-            {
-                map.insert(*sym, val.clone());
-            }
-        }
+        // Keep only non-free names here: system/meta names still flow through
+        // env, while lexical free vars live in `captured_upvalues`.
+        let mut keep = |k: Symbol, _v: &Value| {
+            !free.contains(&k) || !k.with_str(crate::env::is_plain_user_lexical)
+        };
+        let map = self.env().filtered_symbol_map(&mut keep);
         crate::env::Env::from_symbol_map(map)
     }
 
@@ -421,6 +444,8 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let (captured_upvalues, captured_upvalues_from_local) =
+                self.capture_closure_upvalues(code, &compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
             let mut env = self.capture_closure_env(code, &compiled_code);
             if let Some(rt) = return_type {
@@ -456,6 +481,8 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_upvalues,
+                captured_upvalues_from_local,
             }));
             self.stack.push(val);
             Ok(())
@@ -475,6 +502,8 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let (captured_upvalues, captured_upvalues_from_local) =
+                self.capture_closure_upvalues(code, &compiled_code);
             let cc_source_line = compiled_code
                 .as_ref()
                 .and_then(|cc| cc.source_line)
@@ -500,6 +529,8 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_upvalues,
+                captured_upvalues_from_local,
             }));
             self.stack.push(val);
             Ok(())

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -256,7 +256,10 @@ impl Interpreter {
             return (Vec::new(), Vec::new());
         };
         cc.free_var_syms.iter().fold(
-            (Vec::with_capacity(cc.free_var_syms.len()), Vec::with_capacity(cc.free_var_syms.len())),
+            (
+                Vec::with_capacity(cc.free_var_syms.len()),
+                Vec::with_capacity(cc.free_var_syms.len()),
+            ),
             |(mut values, mut from_local), sym| {
                 if !sym.with_str(crate::env::is_plain_user_lexical) {
                     values.push(None);
@@ -270,7 +273,9 @@ impl Interpreter {
                     from_local.push(true);
                     return (values, from_local);
                 }
-                values.push(Some(self.env().get_sym(*sym).cloned().unwrap_or(Value::Nil)));
+                values.push(Some(
+                    self.env().get_sym(*sym).cloned().unwrap_or(Value::Nil),
+                ));
                 from_local.push(false);
                 (values, from_local)
             },

--- a/t/closure-upvalue-capture.t
+++ b/t/closure-upvalue-capture.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 4;
+
+sub make-adder($x) {
+    -> $y { $x + $y }
+}
+
+my $add = make-adder(10);
+my $x = 999;
+is $add(5), 15, 'closure reads captured lexical, not caller same-name lexical';
+
+sub make-counter() {
+    my $n = 0;
+    -> { $n++ }
+}
+
+my $next = make-counter();
+my $n = 100;
+is $next(), 0, 'first call sees captured counter state';
+is $next(), 1, 'captured counter state persists across calls';
+is $n, 100, 'caller lexical with same name is untouched';

--- a/t/seq-from-loop-upvalue.t
+++ b/t/seq-from-loop-upvalue.t
@@ -1,0 +1,12 @@
+use Test;
+
+plan 3;
+
+my @values = 1..100;
+my $seq = Seq.from-loop({ @values.shift }, { state $count = 0; $count++ < 10 });
+is-deeply $seq, (1..10).Seq, 'from-loop body and condition retain closure-private capture state';
+
+my $count = 0;
+$seq = Seq.from-loop({ ++$ }, { $count < 10 }, { $count++ });
+is-deeply $seq, (1..10).Seq, 'from-loop step closure updates captured lexical across iterations';
+is $count, 10, 'from-loop step writes persist to the captured lexical';


### PR DESCRIPTION
## Summary

Switch compiled closure capture away from treating plain lexical free variables as part of the closure env snapshot.

This PR:

- stores compiled closure lexical captures in `SubData` upvalue vectors aligned with `free_var_syms`
- keeps dynamic/special/meta names in `Env`, but avoids flattening the full lexical env just to capture plain free vars
- teaches closure dispatch and interpreter-side block execution to re-inject upvalues when running compiled closures
- preserves writeback for ancestor lexicals and dynamic vars, while preventing creator-local upvalues from leaking into caller same-name lexicals
- adds a regression test for same-name caller lexicals vs captured closure state

## Why

`PLAN.md` §G Lever 1 calls out closure capture as a method-call bottleneck because closure creation deep-clones env state. The existing model also conflated creator-local lexical captures with general env writeback, which made same-name caller lexicals vulnerable to stale closure state.

This change moves plain lexical captures toward indexed upvalues and narrows the env snapshot to the names that still need env semantics.

## Impact

- reduces closure-capture dependence on full env flattening for plain lexical free vars
- makes compiled closures read their captured lexical state from dedicated upvalue storage
- keeps existing captured-outer lexical and dynamic-var propagation behavior intact

## Validation

- `cargo build --quiet`
- `prove -v -e './target/debug/mutsu' t/closure.t t/closure-upvalue-capture.t t/method-closure-env-write-merge.t`

## Notes

`cargo test --quiet` still hits existing sandbox/read-only-filesystem test failures unrelated to this change.