### PR TITLE
[codex] gitignore: ignore .codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ _tmp-io-colon-invocant-*
 
 target-local/
 .claude/worktrees/
+.codex
+.codex/
 
 # prove --state=save state file (CI roast failure-summary re-run; ephemeral)
 .prove


### PR DESCRIPTION
## Summary

Ignore the local `.codex` path in the repository.

## Why

`.codex` is a local Codex workspace artifact and should not keep showing up as an untracked path during normal development.

## Change

- add `.codex`
- add `.codex/`

to `.gitignore`, so both file and directory forms are ignored.

## Validation

- `git status --short` no longer shows `.codex` as untracked after updating `.gitignore`.