### PR TITLE
refactor(error): introduce enum Control, migrate 6 control signals (§7-4 slice 1)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2545,7 +2545,7 @@ impl Interpreter {
         // Try to call the block with this value
         match self.call_sub_value(block.clone(), vec![value.clone()], false) {
             Ok(result) => Ok(result),
-            Err(e) if e.is_next || e.is_last || e.is_redo => {
+            Err(e) if e.is_next || e.is_last || e.is_redo() => {
                 // Propagate loop control signals (next, last, redo)
                 Err(e)
             }

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -523,7 +523,7 @@ impl Interpreter {
         args: &[Value],
     ) -> RuntimeError {
         // Don't enhance errors that are already enhanced or are control flow
-        if err.is_return || err.is_last || err.is_next || func_name.is_empty() {
+        if err.is_return() || err.is_last || err.is_next || func_name.is_empty() {
             return err;
         }
         // Build call profile: func_name(Type1, Type2, ...)

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -397,7 +397,7 @@ impl Interpreter {
                                         }
                                         break 'redo_item;
                                     }
-                                    Err(e) if e.is_redo => continue 'redo_item,
+                                    Err(e) if e.is_redo() => continue 'redo_item,
                                     Err(e) if e.is_next => break 'redo_item,
                                     Err(e) if e.is_last => {
                                         return grep_adverb.transform_result(

--- a/src/runtime/methods_seq_dispatch.rs
+++ b/src/runtime/methods_seq_dispatch.rs
@@ -86,7 +86,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && label_matches(&e.label) => continue 'body_redo,
+                    Err(e) if e.is_redo() && label_matches(&e.label) => continue 'body_redo,
                     Err(e) if e.is_next && label_matches(&e.label) => break 'body_redo,
                     Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,
                     Err(e) => return Err(e),
@@ -97,7 +97,7 @@ impl Interpreter {
                 match self.call_sub_value(step, vec![], true) {
                     Ok(_) => {}
                     Err(e) if e.is_next && label_matches(&e.label) => continue 'from_loop,
-                    Err(e) if e.is_redo && label_matches(&e.label) => continue 'from_loop,
+                    Err(e) if e.is_redo() && label_matches(&e.label) => continue 'from_loop,
                     Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,
                     Err(e) => return Err(e),
                 }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -2236,7 +2236,7 @@ impl Interpreter {
                             // closure env) so propagation/out-of-dynamic-scope
                             // detection works when the map is forced lazily after
                             // the enclosing routine has exited.
-                            if e.is_return
+                            if e.is_return()
                                 && e.return_target_callable_id.is_none()
                                 && let Some(Value::Int(id)) = data.env.get("__mutsu_callable_id")
                             {
@@ -2660,7 +2660,7 @@ impl Interpreter {
                                 }
                                 break 'body_redo;
                             }
-                            Err(e) if e.is_redo => continue 'body_redo,
+                            Err(e) if e.is_redo() => continue 'body_redo,
                             Err(e) if e.is_next => break 'body_redo,
                             Err(e) if e.is_last => {
                                 stop = true;

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -294,7 +294,7 @@ impl Interpreter {
                     if err.is_react_done || err.is_last {
                         break 'replay;
                     }
-                    if err.is_next || err.is_redo {
+                    if err.is_next || err.is_redo() {
                         continue;
                     }
                     // A `die` quits the supply: route to the QUIT phaser.

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -31,6 +31,31 @@ impl RuntimeErrorCode {
     }
 }
 
+/// A non-error control-flow signal carried by an `Err(RuntimeError)`.
+///
+/// Raku implements `return`/`last`/`next`/`take`/`emit`/... as control
+/// exceptions that unwind the Rust call stack via `Result::Err`. Historically
+/// each was a separate `bool` on `RuntimeError`; they are mutually exclusive (an
+/// error carries at most one control signal), so they are being consolidated
+/// into this single enum (ANALYSIS §2.2 / §7-4). Migration is incremental — only
+/// the variants below have moved off their `bool` fields so far; the rest remain
+/// `is_*: bool` on `RuntimeError` until later slices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Control {
+    /// `return` — non-local return carrying `return_value`.
+    Return,
+    /// `goto` (`is_goto`) — labelled jump; the label is in `RuntimeError::label`.
+    Goto,
+    /// `proceed` — fall through to the next `when` in a `given`.
+    Proceed,
+    /// `take` — yield a value to the enclosing `gather` (`return_value`).
+    Take,
+    /// `emit` — emit a value to the enclosing `supply`/`react` (`return_value`).
+    Emit,
+    /// `redo` — re-run the current loop iteration.
+    Redo,
+}
+
 #[derive(Debug)]
 pub struct RuntimeError {
     pub message: String,
@@ -39,20 +64,18 @@ pub struct RuntimeError {
     pub column: Option<usize>,
     pub hint: Option<String>,
     pub return_value: Option<Value>,
-    pub is_return: bool,
+    /// The control-flow signal this error carries, if any (see `Control`).
+    /// Replaces the former `is_return`/`is_goto`/`is_proceed`/`is_take`/
+    /// `is_emit`/`is_redo` bools; read via the `is_*()` accessor methods.
+    pub control: Option<Control>,
     pub is_last: bool,
     pub is_next: bool,
-    pub is_redo: bool,
-    pub is_goto: bool,
-    pub is_proceed: bool,
     pub is_succeed: bool,
     pub is_fail: bool,
     /// When true, the Failure produced from this fail error should be marked as handled.
     /// Set when UNDO phasers run in response to the fail.
     pub fail_handled: bool,
     pub is_warn: bool,
-    pub is_take: bool,
-    pub is_emit: bool,
     pub is_done: bool,
     pub is_leave: bool,
     pub is_resume: bool,
@@ -92,18 +115,13 @@ impl RuntimeError {
             column: None,
             hint: None,
             return_value: None,
-            is_return: false,
+            control: None,
             is_last: false,
             is_next: false,
-            is_redo: false,
-            is_goto: false,
-            is_proceed: false,
             is_succeed: false,
             is_fail: false,
             fail_handled: false,
             is_warn: false,
-            is_take: false,
-            is_emit: false,
             is_done: false,
             is_leave: false,
             is_resume: false,
@@ -116,6 +134,31 @@ impl RuntimeError {
             exception: None,
             backtrace: None,
         }
+    }
+
+    /// `return` control signal (non-local return carrying `return_value`).
+    pub(crate) fn is_return(&self) -> bool {
+        self.control == Some(Control::Return)
+    }
+    /// `goto` control signal (labelled jump; label in `self.label`).
+    pub(crate) fn is_goto(&self) -> bool {
+        self.control == Some(Control::Goto)
+    }
+    /// `proceed` control signal (fall through to the next `when`).
+    pub(crate) fn is_proceed(&self) -> bool {
+        self.control == Some(Control::Proceed)
+    }
+    /// `take` control signal (yield to the enclosing `gather`).
+    pub(crate) fn is_take(&self) -> bool {
+        self.control == Some(Control::Take)
+    }
+    /// `emit` control signal (emit to the enclosing `supply`/`react`).
+    pub(crate) fn is_emit(&self) -> bool {
+        self.control == Some(Control::Emit)
+    }
+    /// `redo` control signal (re-run the current loop iteration).
+    pub(crate) fn is_redo(&self) -> bool {
+        self.control == Some(Control::Redo)
     }
 
     /// Check if this error represents an X::CompUnit::UnsatisfiedDependency error.
@@ -183,18 +226,13 @@ impl RuntimeError {
             column: Some(column),
             hint: None,
             return_value: None,
-            is_return: false,
+            control: None,
             is_last: false,
             is_next: false,
-            is_redo: false,
-            is_goto: false,
-            is_proceed: false,
             is_succeed: false,
             is_fail: false,
             fail_handled: false,
             is_warn: false,
-            is_take: false,
-            is_emit: false,
             is_done: false,
             is_leave: false,
             is_resume: false,
@@ -228,7 +266,7 @@ impl RuntimeError {
     pub(crate) fn redo_signal() -> Self {
         Self {
             message: "X::ControlFlow".to_string(),
-            is_redo: true,
+            control: Some(Control::Redo),
             ..Self::new("")
         }
     }
@@ -236,7 +274,7 @@ impl RuntimeError {
     pub(crate) fn goto_signal(label: String) -> Self {
         Self {
             message: "X::ControlFlow".to_string(),
-            is_goto: true,
+            control: Some(Control::Goto),
             label: Some(label),
             ..Self::new("")
         }
@@ -244,7 +282,7 @@ impl RuntimeError {
 
     pub(crate) fn proceed_signal() -> Self {
         Self {
-            is_proceed: true,
+            control: Some(Control::Proceed),
             ..Self::new("")
         }
     }
@@ -303,7 +341,7 @@ impl RuntimeError {
         Self {
             message: "CX::Return".to_string(),
             return_value: Some(value),
-            is_return: true,
+            control: Some(Control::Return),
             ..Self::new("")
         }
     }
@@ -330,7 +368,7 @@ impl RuntimeError {
         let xcf = Self::typed("X::ControlFlow", attrs);
         Self {
             message: "CX::Take".to_string(),
-            is_take: true,
+            control: Some(Control::Take),
             return_value: Some(value),
             exception: xcf.exception,
             ..Self::new("")
@@ -356,7 +394,7 @@ impl RuntimeError {
         let xcf = Self::typed("X::ControlFlow", attrs);
         Self {
             message: "CX::Emit".to_string(),
-            is_emit: true,
+            control: Some(Control::Emit),
             return_value: Some(value),
             exception: xcf.exception,
             ..Self::new("")

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -455,7 +455,7 @@ impl Interpreter {
         let mut ip = 0;
         while ip < code.ops.len() {
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
-                if e.is_goto
+                if e.is_goto()
                     && let Some(label) = e.label.as_deref()
                     && let Some(target_ip) = self.find_label_target(code, label)
                 {
@@ -482,7 +482,7 @@ impl Interpreter {
                 // stack contains no routine — otherwise the return is meant
                 // for an enclosing routine that will catch it via its own
                 // call-frame handling further up the stack.
-                if e.is_return && self.routine_stack().is_empty() {
+                if e.is_return() && self.routine_stack().is_empty() {
                     let inner_err = RuntimeError::controlflow_return(true);
                     if self.check_phaser_depth > 0 {
                         return Err(Self::wrap_in_begin_time(inner_err));
@@ -688,7 +688,7 @@ impl Interpreter {
         let mut ip = 0;
         while ip < code.ops.len() {
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
-                if e.is_goto
+                if e.is_goto()
                     && let Some(label) = e.label.as_deref()
                     && let Some(target_ip) = self.find_label_target(code, label)
                 {
@@ -996,7 +996,7 @@ impl Interpreter {
         let mut ip = start;
         while ip < end {
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
-                if e.is_goto
+                if e.is_goto()
                     && let Some(label) = e.label.as_deref()
                     && let Some(target_ip) = self.find_label_target(code, label)
                     && (start..end).contains(&target_ip)

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -97,21 +97,21 @@ impl Interpreter {
             Some("CX::Last")
         } else if signal.is_next {
             Some("CX::Next")
-        } else if signal.is_redo {
+        } else if signal.is_redo() {
             Some("CX::Redo")
-        } else if signal.is_proceed {
+        } else if signal.is_proceed() {
             Some("CX::Proceed")
         } else if signal.is_succeed {
             Some("CX::Succeed")
         } else if signal.is_warn {
             Some("CX::Warn")
-        } else if signal.is_take {
+        } else if signal.is_take() {
             Some("CX::Take")
-        } else if signal.is_emit {
+        } else if signal.is_emit() {
             Some("CX::Emit")
         } else if signal.is_done || signal.is_react_done {
             Some("CX::Done")
-        } else if signal.is_return {
+        } else if signal.is_return() {
             Some("CX::Return")
         } else {
             None
@@ -299,7 +299,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
                                 self.env_mut().insert("_".to_string(), v);
@@ -980,7 +980,7 @@ impl Interpreter {
                         );
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
                             self.env_mut().insert("_".to_string(), item.clone());
                         }
@@ -1383,7 +1383,7 @@ impl Interpreter {
                     Err(e) if e.is_succeed => {
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
                             self.env_mut().insert("_".to_string(), item.clone());
                         }
@@ -1611,7 +1611,7 @@ impl Interpreter {
                     Err(e) if e.is_succeed => {
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
                             self.env_mut().insert("_".to_string(), item.clone());
                         }
@@ -1833,7 +1833,7 @@ impl Interpreter {
                     Err(e) if e.is_succeed => {
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
                             self.env_mut().insert("_".to_string(), item.clone());
                         }
@@ -2549,7 +2549,7 @@ impl Interpreter {
                     Err(e) if e.is_succeed => {
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         continue 'body_redo;
                     }
                     Err(e)
@@ -2861,7 +2861,7 @@ impl Interpreter {
             let mut did_proceed = false;
             match self.run_range(code, body_start, end, compiled_fns) {
                 Ok(()) => {}
-                Err(e) if e.is_proceed => {
+                Err(e) if e.is_proceed() => {
                     did_proceed = true;
                 }
                 Err(e) if e.is_succeed => {
@@ -2957,7 +2957,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_redo && Self::label_matches(&e.label, label) => {
+                    Err(e) if e.is_redo() && Self::label_matches(&e.label, label) => {
                         continue 'body_redo;
                     }
                     Err(e)
@@ -3105,7 +3105,7 @@ impl Interpreter {
                 *ip = end;
                 Ok(())
             }
-            Err(e) if e.is_return => {
+            Err(e) if e.is_return() => {
                 self.discard_let_saves(let_mark);
                 if control_begin < end {
                     self.stack.truncate(saved_depth);
@@ -3142,8 +3142,8 @@ impl Interpreter {
                 if e.return_value.is_some()
                     && !e.is_succeed
                     && !e.is_warn
-                    && !e.is_take
-                    && !e.is_emit =>
+                    && !e.is_take()
+                    && !e.is_emit() =>
             {
                 self.discard_let_saves(let_mark);
                 Err(e)
@@ -3153,12 +3153,12 @@ impl Interpreter {
             Err(e)
                 if (e.is_last
                     || e.is_next
-                    || e.is_redo
-                    || e.is_proceed
+                    || e.is_redo()
+                    || e.is_proceed()
                     || e.is_succeed
                     || e.is_warn
-                    || e.is_take
-                    || e.is_emit
+                    || e.is_take()
+                    || e.is_emit()
                     || e.is_done
                     || e.is_react_done)
                     && control_begin >= end =>
@@ -3169,12 +3169,12 @@ impl Interpreter {
             Err(e)
                 if (e.is_last
                     || e.is_next
-                    || e.is_redo
-                    || e.is_proceed
+                    || e.is_redo()
+                    || e.is_proceed()
                     || e.is_succeed
                     || e.is_warn
-                    || e.is_take
-                    || e.is_emit
+                    || e.is_take()
+                    || e.is_emit()
                     || e.is_done
                     || e.is_react_done)
                     && control_begin < end =>
@@ -3269,12 +3269,12 @@ impl Interpreter {
                                 Err(new_err)
                                     if new_err.is_last
                                         || new_err.is_next
-                                        || new_err.is_redo
-                                        || new_err.is_proceed
+                                        || new_err.is_redo()
+                                        || new_err.is_proceed()
                                         || new_err.is_succeed
                                         || new_err.is_warn
-                                        || new_err.is_take
-                                        || new_err.is_emit
+                                        || new_err.is_take()
+                                        || new_err.is_emit()
                                         || new_err.is_done
                                         || new_err.is_react_done =>
                                 {

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3198,9 +3198,9 @@ impl Interpreter {
         }
         !(err.is_last
             || err.is_next
-            || err.is_redo
-            || err.is_goto
-            || err.is_proceed
+            || err.is_redo()
+            || err.is_goto()
+            || err.is_proceed()
             || err.is_succeed
             || err.is_leave
             || err.is_resume
@@ -3283,7 +3283,7 @@ impl Interpreter {
         let result = loop {
             match self.run_range(code, body_start, end, compiled_fns) {
                 Ok(()) => break Ok(()),
-                Err(e) if e.is_redo && has_label && Self::label_matches(&e.label, &label) => {
+                Err(e) if e.is_redo() && has_label && Self::label_matches(&e.label, &label) => {
                     self.stack.truncate(stack_base);
                     continue;
                 }

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -624,7 +624,7 @@ impl Interpreter {
                                     return Ok(());
                                 }
                                 // `next`/`redo` are loop control, not completion.
-                                if !err.is_next && !err.is_redo {
+                                if !err.is_next && !err.is_redo() {
                                     // A `die` quits the supply: break with the cause.
                                     let cause = err
                                         .exception


### PR DESCRIPTION
## Summary

First incremental slice of **ANALYSIS §7-4 / §2.2** — separating control flow from `RuntimeError`.

`RuntimeError` carries control-flow as ~15 separate `bool` fields (`is_return`, `is_last`, `is_take`, …), mixing control flow with real errors and bloating the struct (the reason for the scattered `#[allow(clippy::result_large_err)]`). These signals are **mutually exclusive** (an error carries at most one), so they consolidate into a single `enum Control` field.

This PR establishes the `enum Control` + `control: Option<Control>` field and migrates the **6 simplest, mutation-free signals** off their bool fields:

`Return`, `Goto`, `Proceed`, `Take`, `Emit`, `Redo`

- Builders set `control: Some(Control::X)`.
- Reads (~45 sites) go through new `is_*()` accessor methods.
- The remaining signals (`last`/`next`/`succeed`/`fail`/`done`/`leave`/`resume`/`react_done`/`warn`) stay as bool fields and migrate in later slices (this is a multi-PR campaign).

## Why incremental

The signals with post-construction mutations (`is_fail`, `is_done`, the `is_leave`/`is_last` clear-pair) need per-site care and are deferred to keep each slice small and CI-green.

## Verification

Behavior-preserving. Control-flow smoke tests (return, gather/take, given/when/proceed, loop/redo, react/emit) and the control-flow `t/` suite pass unchanged. `make test` (release) PASS; cargo test 470/0; clippy/fmt clean.

No new `t/` test (pure internal refactor, no behavior change; verified by the existing control-flow suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)