### PR TITLE
fix(vm): multidim index assign writes through shared ContainerRef cell

### DIFF
--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -372,6 +372,33 @@ impl Interpreter {
             .cloned()
             .and_then(|v| self.container_type_metadata(&v));
 
+        // If the variable is bound to a shared container cell — e.g. it was
+        // assigned by a sub/closure that captured the outer variable, leaving a
+        // `ContainerRef` in both env and locals — mutate THROUGH the cell. The
+        // cell is shared, so the write is visible everywhere; mutating the env
+        // snapshot (the path below) would only touch a copy and silently drop the
+        // write. This mirrors the simple-index assignment's ContainerRef handling.
+        let container_cell = match self.env().get(&var_name) {
+            Some(Value::ContainerRef(cell)) => Some(cell.clone()),
+            _ => self
+                .locals_get_by_name(code, &var_name)
+                .and_then(|v| match v {
+                    Value::ContainerRef(cell) => Some(cell),
+                    _ => None,
+                }),
+        };
+        if let Some(cell) = container_cell {
+            let mut inner = cell.lock().unwrap();
+            if is_shaped {
+                Self::assign_array_multidim(&mut inner, &dims, value.clone())?;
+            } else {
+                Self::multi_dim_assign(&mut inner, &dims, value.clone())?;
+            }
+            drop(inner);
+            self.stack.push(value);
+            return Ok(());
+        }
+
         // Get mutable reference to the target variable
         if let Some(container) = self.env_mut().get_mut(&var_name) {
             if is_shaped {

--- a/t/multidim-assign-shared-container.t
+++ b/t/multidim-assign-shared-container.t
@@ -1,0 +1,66 @@
+use Test;
+
+# Regression: a multi-dimensional index assignment (`@a[i;j] = v`, `%h{a;b} = v`)
+# must write back even when the container was assigned by a sub/closure that
+# captured the outer variable. Such an assignment leaves the variable bound to a
+# shared `ContainerRef` cell; the multidim-assign path used to mutate only the
+# env snapshot and silently drop the write, so the outer variable kept its old
+# value. (Simple single-index assignment already handled the shared cell.)
+
+plan 8;
+
+{
+    my @a;
+    sub set_twod(--> Nil) { @a = [[1, 2], [3, 4]]; }
+    set_twod;
+    @a[0;1] = 999;
+    is-deeply @a, [[1, 999], [3, 4]], 'multidim assign persists after sub-assigned 2D array';
+}
+
+{
+    my @a;
+    sub set_threed(--> Nil) { @a = [[[42, 666, [314]],],]; }
+    set_threed;
+    @a[0;0;0] = 999;
+    is-deeply @a, [[[999, 666, [314]],],], 'multidim assign persists after sub-assigned 3D array';
+}
+
+{
+    # The whole assignment still evaluates to the assigned value.
+    my @a;
+    sub setup(--> Nil) { @a = [[1, 2], [3, 4]]; }
+    setup;
+    my $r = (@a[1;0] = 77);
+    is $r, 77, 'multidim assign expression returns the assigned value';
+    is-deeply @a, [[1, 2], [77, 4]], 'value landed at the right place';
+}
+
+{
+    # Hash multidim assignment through a sub-assigned hash.
+    my %h;
+    sub seth(--> Nil) { %h = (a => {b => 1}); }
+    seth;
+    %h{"a";"b"} = 99;
+    is %h<a><b>, 99, 'hash multidim assign persists after sub-assigned hash';
+}
+
+{
+    # Closure (block) capture, not just a named sub.
+    my @a;
+    my $init = -> { @a = [[10, 20], [30, 40]]; };
+    $init();
+    @a[1;1] = 5;
+    is-deeply @a, [[10, 20], [30, 5]], 'multidim assign persists after closure-assigned array';
+}
+
+# Plain (non-captured) declarations must keep working unchanged.
+{
+    my @a = [[1, 2], [3, 4]];
+    @a[0;0] = 8;
+    is-deeply @a, [[8, 2], [3, 4]], 'multidim assign on a directly-declared array still works';
+}
+{
+    my @a = [1, 2, 3];
+    @a[1] = 9;
+    is-deeply @a, [1, 9, 3], 'simple index assign unaffected';
+}


### PR DESCRIPTION
## Summary

`@a[i;j] = v` / `%h{a;b} = v` silently dropped the write when the variable had been assigned by a sub or closure that captured the outer variable.

Such an assignment leaves the variable bound to a shared `ContainerRef` (Mutex) cell in both env and locals. The multidim-assign handler only did `env_mut().get_mut(name)` + `multi_dim_assign`, which on a `ContainerRef` target falls through `ensure_array_size`/`ensure_hash` and replaces the cell with a fresh container instead of mutating the shared one — so a later read through the cell returned the pre-assignment value. (The simple single-index assignment path already handled the shared cell.)

## Fix

Detect the `ContainerRef` (in env or the local slot) and mutate **through** the locked cell. The cell is shared, so the write is visible everywhere and no env/local snapshot sync is needed.

## Repro

```raku
my @a;
sub setup(--> Nil) { @a = [[1,2],[3,4]]; }
setup;
@a[0;1] = 999;   # was lost; @a stayed [[1,2],[3,4]]
say @a;          # now [[1 999] [3 4]] (matches raku)
```

Found while investigating `roast/S32-array/multislice-6e.t` (this was the test-3 root cause; the file has further unrelated bugs).

## Tests

- `t/multidim-assign-shared-container.t` (8 assertions: 2D/3D sub-assigned arrays, closure-assigned, hash multidim, return value, plus no-regression for directly-declared arrays and simple index assign).
- `make test` passes locally (cargo 470).

🤖 Generated with [Claude Code](https://claude.com/claude-code)