### PR TITLE
fix(types): bare and pointy blocks are `Block`, not `Sub`

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -228,7 +228,12 @@ impl Compiler {
         } else {
             vec![param.to_string()]
         };
-        let compiled = self.compile_closure_body(&params, &[], body);
+        let mut compiled = self.compile_closure_body(&params, &[], body);
+        // A pointy block (`-> $x {...}`) is a `Block`, not a `Sub`. A WhateverCode
+        // (`*+1`, also an `Expr::Lambda`) is tagged separately via callable_type.
+        if !is_whatever_code {
+            compiled.is_pointy_block = true;
+        }
         let esc = self.escaping_position;
         let cc_idx = self.code.add_closure_code(compiled, esc);
         let idx = self.code.add_stmt(Stmt::SubDecl {

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -74,10 +74,16 @@ impl Interpreter {
             }
             Value::Routine { is_regex: true, .. } => "Regex",
             Value::Routine { .. } => "Sub",
+            // Keep in sync with `runtime::utils::value_type_name`: a bare/pointy
+            // block (`{...}`, `-> {...}`) is a `Block`, not a `Sub`. `.WHAT`/`.^name`
+            // previously reported `Sub` for these even though smartmatch already
+            // treated them as `Block` (via `value_type_name`).
             Value::Sub(data) => match data.env.get("__mutsu_callable_type") {
                 Some(Value::Str(kind)) if kind.as_str() == "Method" => "Method",
                 Some(Value::Str(kind)) if kind.as_str() == "Submethod" => "Submethod",
                 Some(Value::Str(kind)) if kind.as_str() == "WhateverCode" => "WhateverCode",
+                Some(Value::Str(kind)) if kind.as_str() == "Block" => "Block",
+                _ if data.is_bare_block => "Block",
                 _ => "Sub",
             },
             Value::WeakSub(_) => "Sub",

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -806,8 +806,18 @@ impl Interpreter {
                     } else {
                         let (use_positional, use_named) = Self::auto_signature_uses(&data.body);
                         let mut defs = Vec::new();
-                        // Bare blocks have an implicit $_ parameter with default from outer scope
-                        if data.is_bare_block && !use_positional {
+                        // A *bare* block `{ ... }` has an implicit `$_` parameter
+                        // (default from the outer topic). A pointy block `-> { ... }`
+                        // is also a `Block` (`is_bare_block` is set for the `.WHAT`),
+                        // but its signature is explicit — an empty `-> {}` takes no
+                        // arguments, so it must NOT gain the implicit `$_` (which
+                        // would render its signature as `($$_?)` and break
+                        // `.raku`/`.gist` round-tripping).
+                        let is_pointy = data
+                            .compiled_code
+                            .as_ref()
+                            .is_some_and(|cc| cc.is_pointy_block);
+                        if data.is_bare_block && !is_pointy && !use_positional {
                             defs.push(ParamDef {
                                 name: "$_".to_string(),
                                 default: Some(Expr::Var("$_".to_string())),

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -166,7 +166,10 @@ impl Interpreter {
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
                 empty_sig: params.is_empty() && param_defs.is_empty(),
-                is_bare_block: false,
+                // A pointy block (`-> $x {...}`) is a `Block`, not a `Sub`. Named
+                // anonymous subs (`sub {...}`) have `is_pointy_block == false` and
+                // stay `Sub`. (`WhateverCode` already overrides via callable_type.)
+                is_bare_block: compiled_code.as_ref().is_some_and(|cc| cc.is_pointy_block),
                 owned_captures,
                 compiled_code,
                 deprecated_message: None,
@@ -450,7 +453,10 @@ impl Interpreter {
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
                 empty_sig: params.is_empty() && param_defs.is_empty(),
-                is_bare_block: false,
+                // A pointy block (`-> $x {...}`) is a `Block`, not a `Sub` — mark it
+                // so `.WHAT`/`.^name`/smartmatch report `Block`. Named anonymous subs
+                // (`sub {...}`) have `is_pointy_block == false` and stay `Sub`.
+                is_bare_block: compiled_code.as_ref().is_some_and(|cc| cc.is_pointy_block),
                 owned_captures,
                 compiled_code,
                 deprecated_message: None,

--- a/t/block-vs-sub-what.t
+++ b/t/block-vs-sub-what.t
@@ -1,0 +1,23 @@
+use Test;
+
+# A bare block `{...}` and a pointy block `-> ... {...}` are `Block`s, not `Sub`s.
+# Only `sub {...}` / `sub name {...}` are `Sub`s. mutsu already smartmatched bare
+# blocks as Block, but `.WHAT`/`.^name` reported `Sub`, and pointy blocks were
+# mis-typed as `Sub` everywhere (so `-> $x {…} ~~ Sub` was wrongly True).
+
+plan 12;
+
+is {42}.WHAT.^name,          'Block', 'bare block {…} is a Block';
+is {$_ + 1}.WHAT.^name,      'Block', 'bare block with implicit $_ is a Block';
+is (-> {42}).WHAT.^name,     'Block', 'pointy block -> {…} is a Block';
+is (-> $x {$x}).WHAT.^name,  'Block', 'pointy block with a param is a Block';
+is (-> $x, $y {$x}).WHAT.^name, 'Block', 'pointy block with multiple params is a Block';
+is (sub {42}).WHAT.^name,    'Sub',   'anonymous sub {…} is a Sub';
+is (sub f {42}).WHAT.^name,  'Sub',   'named sub is a Sub';
+
+# Smartmatch type relationships (Block is NOT a Sub/Routine; Sub IS-A Block).
+ok  (-> $x {$x}) ~~ Block,  'pointy block ~~ Block';
+nok (-> $x {$x}) ~~ Sub,    'pointy block is NOT a Sub';
+nok (-> $x {$x}) ~~ Routine,'pointy block is NOT a Routine';
+ok  (sub {42})   ~~ Block,  'a Sub IS-A Block (Routine subclasses Block)';
+ok  {42}         ~~ Code,   'a block is Code';


### PR DESCRIPTION
## Summary

`{...}` and `-> ... {...}` are `Block`s in Raku; only `sub {...}` / `sub name {...}` are `Sub`s. mutsu already smartmatched a bare block as `Block`, but two paths disagreed with the canonical `runtime::utils::value_type_name`:

1. `dispatch_what` (`.WHAT` / `.^name` / `.gist`) ignored `SubData::is_bare_block`, so `{...}.WHAT.^name` reported `Sub`.
2. Pointy blocks (`-> $x {...}`) were never flagged as blocks at all — their `is_bare_block` was hard-coded `false`, so even smartmatch wrongly reported `-> $x {…} ~~ Sub` as **True**.

## Fix

- `dispatch_what` now honours `is_bare_block` (and a `"Block"` callable_type), matching `value_type_name`.
- The compiler tags single/zero-param pointy `Expr::Lambda`s (`!is_whatever_code`) with `is_pointy_block`.
- The `MakeLambda` / `MakeAnonSubParams` VM ops derive `is_bare_block` from `is_pointy_block`.

Named `sub {...}` keeps `is_pointy_block == false` → stays `Sub`; WhateverCode is unaffected (tagged separately via callable_type).

```
{42}.WHAT.^name           # was Sub  → Block
(-> $x {$x}).WHAT.^name   # was Sub  → Block
(-> $x {$x}) ~~ Sub       # was True → False
(sub {42}).WHAT.^name     # Sub  (unchanged)
```

## Tests

- `t/block-vs-sub-what.t` (12 assertions covering bare/pointy/sub and the Block/Sub/Routine/Code smartmatch relationships).
- `make test` cargo suite passes (470); broad block-usage spot-checks (map/grep/for/invocation/`return` transparency) match rakudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)