### PR TITLE
fix(coerce): X::Str::Numeric carries the `⏏` marker for .Int/.UInt/.Num/.Numeric

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -22,15 +22,18 @@ fn str_numeric_exception_attrs(s: &str) -> std::collections::HashMap<String, Val
     ex_attrs.insert("source".to_string(), Value::str(s.to_string()));
     ex_attrs.insert("reason".to_string(), Value::str(reason.clone()));
     ex_attrs.insert("pos".to_string(), Value::Int(pos as i64));
+    let source_indicator = crate::runtime::str_numeric::build_source_indicator(s, pos);
     ex_attrs.insert(
         "source-indicator".to_string(),
-        Value::str(crate::runtime::str_numeric::build_source_indicator(s, pos)),
+        Value::str(source_indicator.clone()),
     );
+    // Include the `⏏` position marker, matching Rakudo:
+    // `Cannot convert string to number: trailing characters after number
+    //  in '5⏏ foo' (indicated by ⏏)`.
     ex_attrs.insert(
         "message".to_string(),
         Value::str(format!(
-            "Cannot convert string to number: {} in '{}'",
-            reason, s
+            "Cannot convert string to number: {reason} {source_indicator}"
         )),
     );
     ex_attrs
@@ -522,34 +525,10 @@ pub(super) fn dispatch(
                     if let Some(v) = parse_raku_int_from_str(s) {
                         Some(v)
                     } else {
-                        // Return Failure for invalid string
-                        let mut ex_attrs = std::collections::HashMap::new();
-                        ex_attrs.insert("source".to_string(), Value::str(s.to_string()));
-                        ex_attrs.insert(
-                            "reason".to_string(),
-                            Value::str(
-                                "base-10 number must begin with valid digits or '.'".to_string(),
-                            ),
-                        );
-                        ex_attrs.insert("pos".to_string(), Value::Int(0));
-                        ex_attrs.insert(
-                            "message".to_string(),
-                            Value::str(format!(
-                                "Cannot convert string to number: base-10 number must begin with valid digits or '.' in '{}'",
-                                s
-                            )),
-                        );
-                        let ex = Value::make_instance(
-                            crate::symbol::Symbol::intern("X::Str::Numeric"),
-                            ex_attrs,
-                        );
-                        let mut failure_attrs = std::collections::HashMap::new();
-                        failure_attrs.insert("exception".to_string(), ex);
-                        failure_attrs.insert("handled".to_string(), Value::Bool(false));
-                        return Some(Some(Ok(Value::make_instance(
-                            crate::symbol::Symbol::intern("Failure"),
-                            failure_attrs,
-                        ))));
+                        // Invalid string: same X::Str::Numeric Failure (with the `⏏`
+                        // position marker) as `.Int`, rather than a hand-rolled
+                        // message that hard-codes the wrong reason and drops the marker.
+                        return Some(Some(Ok(str_numeric_failure(s))));
                     }
                 }
                 _ => None,
@@ -696,10 +675,9 @@ pub(super) fn dispatch(
                     } else if let Ok(f) = s.trim().parse::<f64>() {
                         Value::Num(f)
                     } else {
-                        return Some(Some(Err(RuntimeError::new(format!(
-                            "X::Str::Numeric: Cannot convert string '{}' to a number",
-                            s
-                        )))));
+                        // Same X::Str::Numeric Failure (typed, with the `⏏` marker)
+                        // as `.Int`/`.Numeric`.
+                        return Some(Some(Ok(str_numeric_failure(s))));
                     }
                 }
                 Value::Array(items, ..) => Value::Int(items.len() as i64),
@@ -758,10 +736,9 @@ pub(super) fn dispatch(
                     if let Some(v) = crate::runtime::str_numeric::parse_raku_str_to_numeric(s) {
                         v
                     } else {
-                        return Some(Some(Err(RuntimeError::new(format!(
-                            "X::Str::Numeric: Cannot convert string '{}' to a number",
-                            s
-                        )))));
+                        // Same X::Str::Numeric Failure (typed, with the `⏏` marker)
+                        // as `.Int`.
+                        return Some(Some(Ok(str_numeric_failure(s))));
                     }
                 }
                 Value::Bool(b) => Value::Int(if *b { 1 } else { 0 }),

--- a/t/str-numeric-marker.t
+++ b/t/str-numeric-marker.t
@@ -1,0 +1,39 @@
+use Test;
+
+# X::Str::Numeric from a string→number coercion should carry the `⏏` position
+# marker, matching Rakudo:
+#   Cannot convert string to number: trailing characters after number
+#   in '123⏏abc' (indicated by ⏏)
+# `.Int` produced the marker but `.UInt`/`.Num`/`.Numeric` used hand-rolled
+# messages that dropped it (and `.UInt` even reported the wrong reason).
+
+plan 8;
+
+my $marker = "\c[EJECT SYMBOL]";  # ⏏
+my $expected = "Cannot convert string to number: trailing characters after number "
+             ~ "in '123{$marker}abc' (indicated by {$marker})";
+
+{
+    my $msg; { "123abc".Int.sink;     CATCH { default { $msg = .message } } }
+    is $msg, $expected, '.Int message has the ⏏ marker';
+}
+{
+    my $msg; { "123abc".UInt.sink;    CATCH { default { $msg = .message } } }
+    is $msg, $expected, '.UInt message has the ⏏ marker';
+}
+{
+    my $msg; { "123abc".Num.sink;     CATCH { default { $msg = .message } } }
+    is $msg, $expected, '.Num message has the ⏏ marker';
+}
+{
+    my $msg; { "123abc".Numeric.sink; CATCH { default { $msg = .message } } }
+    is $msg, $expected, '.Numeric message has the ⏏ marker';
+}
+
+# The exception is a real X::Str::Numeric (not a hand-rolled AdHoc).
+throws-like { "123abc".Int.sink },     X::Str::Numeric, '.Int throws X::Str::Numeric';
+throws-like { "123abc".Numeric.sink }, X::Str::Numeric, '.Numeric throws X::Str::Numeric';
+
+# Valid strings still coerce.
+is "1_000".Int, 1000, 'valid string still coerces with .Int';
+is "3.14".Num, 3.14e0, 'valid string still coerces with .Num';


### PR DESCRIPTION
## Summary

A failed string→number coercion should report the offending position with the `⏏` (EJECT SYMBOL) marker, matching Rakudo:

```
Cannot convert string to number: trailing characters after number in '123⏏abc' (indicated by ⏏)
```

Only `.Int` did this. `.UInt`, `.Num` and `.Numeric` hand-rolled their own message:
- they dropped the `⏏` marker,
- `.UInt` reported the **wrong reason** ("base-10 number must begin with valid digits" instead of "trailing characters after number"),
- `.Num`/`.Numeric` threw a string-tagged `RuntimeError` (`"X::Str::Numeric: …"`) rather than a real typed `X::Str::Numeric` Failure.

## Fix

Route all of them through the shared `str_numeric_failure(s)`, which already builds the correctly-positioned marker message (via `build_source_indicator`) as a typed `X::Str::Numeric` Failure.

```
"123abc".Int      # already correct
"123abc".UInt     # was: wrong reason, no marker  → now matches .Int
"123abc".Num      # was: string RuntimeError       → now typed Failure + marker
"123abc".Numeric  # was: string RuntimeError       → now typed Failure + marker
```

## Tests

- `t/str-numeric-marker.t` (8 assertions: marker message for all four methods, `throws-like X::Str::Numeric`, and that valid strings still coerce).
- `make test` cargo suite passes (470); valid-coercion + marker spot-checks match rakudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)