### PR TITLE
refactor(error): migrate 5 more control signals into enum Control (§7-4 slice 2)

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -905,7 +905,7 @@ impl Interpreter {
                         let result = self.call_sub_value(first, Vec::new(), true);
                         self.pop_warn_suppression();
                         match result {
-                            Err(e) if e.is_warn => Ok(Value::Nil),
+                            Err(e) if e.is_warn() => Ok(Value::Nil),
                             other => other,
                         }
                     }

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2289,7 +2289,7 @@ impl Interpreter {
                 for item in items.iter() {
                     match self.duckmap_element(block, item) {
                         Ok(v) => result.push(v),
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) if e.is_last => break,
                         Err(e) => return Err(e),
                     }
@@ -2305,7 +2305,7 @@ impl Interpreter {
                 for item in items.iter() {
                     match self.duckmap_element(block, item) {
                         Ok(v) => result.push(v),
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) if e.is_last => break,
                         Err(e) => return Err(e),
                     }
@@ -2319,7 +2319,7 @@ impl Interpreter {
                         Ok(mapped) => {
                             result.insert(k.clone(), mapped);
                         }
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) if e.is_last => break,
                         Err(e) => return Err(e),
                     }
@@ -2399,14 +2399,14 @@ impl Interpreter {
                                 }
                                 result.push(v);
                             }
-                            Err(e) if e.is_next => continue,
+                            Err(e) if e.is_next() => continue,
                             Err(e) => return Err(e),
                         }
                         continue;
                     }
                     match self.deepmap_iterate_inner(block, item, child_itemize) {
                         Ok(v) => result.push(v),
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2440,7 +2440,7 @@ impl Interpreter {
                 for item in items.iter() {
                     match self.deepmap_iterate_inner(block, item, true) {
                         Ok(v) => result.push(v),
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2478,7 +2478,7 @@ impl Interpreter {
                                 }
                                 result.insert(k.clone(), val);
                             }
-                            Err(e) if e.is_next => continue,
+                            Err(e) if e.is_next() => continue,
                             Err(e) => return Err(e),
                         }
                         continue;
@@ -2492,7 +2492,7 @@ impl Interpreter {
                         Ok(val) => {
                             result.insert(k.clone(), val);
                         }
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2518,7 +2518,7 @@ impl Interpreter {
                 for item in items.iter() {
                     match self.call_sub_value(block.clone(), vec![item.clone()], false) {
                         Ok(v) => result.push(v),
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2529,7 +2529,7 @@ impl Interpreter {
                 for item in items.iter() {
                     match self.call_sub_value(block.clone(), vec![item.clone()], false) {
                         Ok(v) => result.push(v),
-                        Err(e) if e.is_next => continue,
+                        Err(e) if e.is_next() => continue,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2545,7 +2545,7 @@ impl Interpreter {
         // Try to call the block with this value
         match self.call_sub_value(block.clone(), vec![value.clone()], false) {
             Ok(result) => Ok(result),
-            Err(e) if e.is_next || e.is_last || e.is_redo() => {
+            Err(e) if e.is_next() || e.is_last || e.is_redo() => {
                 // Propagate loop control signals (next, last, redo)
                 Err(e)
             }

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -434,10 +434,10 @@ impl Interpreter {
             // handler this is equivalent to resuming with Nil.
             Ok(()) => Some(Ok(Value::Nil)),
             // `.resume` — the warn resumes; a bare `.resume` yields Nil.
-            Err(ce) if ce.is_resume => Some(Ok(Value::Nil)),
+            Err(ce) if ce.is_resume() => Some(Ok(Value::Nil)),
             // The handler re-threw the warn (`warn`/`.rethrow` of CX::Warn):
             // act like the default handler — print and resume.
-            Err(ce) if ce.is_warn => {
+            Err(ce) if ce.is_warn() => {
                 if !self.warning_suppressed() {
                     self.write_warn_to_stderr(&ce.message);
                 }

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -523,7 +523,7 @@ impl Interpreter {
         args: &[Value],
     ) -> RuntimeError {
         // Don't enhance errors that are already enhanced or are control flow
-        if err.is_return() || err.is_last || err.is_next || func_name.is_empty() {
+        if err.is_return() || err.is_last || err.is_next() || func_name.is_empty() {
             return err;
         }
         // Build call profile: func_name(Type1, Type2, ...)

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -619,7 +619,7 @@ impl Interpreter {
                 // signal so the default handler writes to stderr and
                 // execution continues.
                 if cn == "CX::Warn" {
-                    err.is_warn = true;
+                    err.control = Some(crate::value::Control::Warn);
                 }
                 err.exception = Some(Box::new(target.clone()));
                 return Err(err);

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -398,7 +398,7 @@ impl Interpreter {
                                         break 'redo_item;
                                     }
                                     Err(e) if e.is_redo() => continue 'redo_item,
-                                    Err(e) if e.is_next => break 'redo_item,
+                                    Err(e) if e.is_next() => break 'redo_item,
                                     Err(e) if e.is_last => {
                                         return grep_adverb.transform_result(
                                             Value::array(result),

--- a/src/runtime/methods_seq_dispatch.rs
+++ b/src/runtime/methods_seq_dispatch.rs
@@ -87,7 +87,7 @@ impl Interpreter {
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo() && label_matches(&e.label) => continue 'body_redo,
-                    Err(e) if e.is_next && label_matches(&e.label) => break 'body_redo,
+                    Err(e) if e.is_next() && label_matches(&e.label) => break 'body_redo,
                     Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,
                     Err(e) => return Err(e),
                 }
@@ -96,7 +96,7 @@ impl Interpreter {
             if let Some(step) = step_callable.clone() {
                 match self.call_sub_value(step, vec![], true) {
                     Ok(_) => {}
-                    Err(e) if e.is_next && label_matches(&e.label) => continue 'from_loop,
+                    Err(e) if e.is_next() && label_matches(&e.label) => continue 'from_loop,
                     Err(e) if e.is_redo() && label_matches(&e.label) => continue 'from_loop,
                     Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,
                     Err(e) => return Err(e),

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -161,7 +161,7 @@ impl Interpreter {
         match result {
             Ok(_) if matched => QuitOutcome::Handled,
             Ok(_) => QuitOutcome::Unhandled,
-            Err(err) if err.is_react_done || err.is_succeed => QuitOutcome::Handled,
+            Err(err) if err.is_react_done() || err.is_succeed() => QuitOutcome::Handled,
             Err(_) => QuitOutcome::Unhandled,
         }
     }

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -491,7 +491,7 @@ impl Interpreter {
                         // how `(1..Inf).Supply.tap({ ...; done if ... })` terminates).
                         match self.call_sub_value(tap_cb.clone(), vec![v.clone()], true) {
                             Ok(_) => {}
-                            Err(err) if err.is_react_done || err.is_last => break,
+                            Err(err) if err.is_react_done() || err.is_last => break,
                             Err(err) => return Err(err),
                         }
                     }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -2227,7 +2227,7 @@ impl Interpreter {
                                 v => result.push(v),
                             }
                         }
-                        Err(e) if e.is_next => {}
+                        Err(e) if e.is_next() => {}
                         Err(e) if e.is_last => break,
                         Err(mut e) => {
                             // A `return` inside the map block targets the routine
@@ -2465,7 +2465,7 @@ impl Interpreter {
                                 v => result.push(v),
                             }
                         }
-                        Err(e) if e.is_next => {
+                        Err(e) if e.is_next() => {
                             if arity == 1
                                 && let Some(mutated) = vm.env().get(topic_key).cloned()
                             {
@@ -2661,7 +2661,7 @@ impl Interpreter {
                                 break 'body_redo;
                             }
                             Err(e) if e.is_redo() => continue 'body_redo,
-                            Err(e) if e.is_next => break 'body_redo,
+                            Err(e) if e.is_next() => break 'body_redo,
                             Err(e) if e.is_last => {
                                 stop = true;
                                 break 'body_redo;

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -118,7 +118,7 @@ impl Interpreter {
         }
         let cb = self.supply_stream_consumers[idx].consumer_cb.clone();
         match self.call_sub_value(cb, vec![value.clone()], true) {
-            Err(e) if e.is_react_done => {
+            Err(e) if e.is_react_done() => {
                 self.supply_stream_consumers[idx].done = true;
                 for close_cb in
                     crate::runtime::native_methods::take_supplier_close_callbacks(supplier_id)

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -81,7 +81,7 @@ impl Interpreter {
             self.run_on_demand_body(on_demand_cb, Some(emitter_supplier_id));
 
         if let Err(err) = cb_result
-            && !err.is_react_done
+            && !err.is_react_done()
         {
             promise.break_with(
                 err.exception
@@ -291,10 +291,10 @@ impl Interpreter {
             };
             for item in items {
                 if let Err(err) = run_capture(self, callback.clone(), vec![item], last_value) {
-                    if err.is_react_done || err.is_last {
+                    if err.is_react_done() || err.is_last {
                         break 'replay;
                     }
-                    if err.is_next || err.is_redo() {
+                    if err.is_next() || err.is_redo() {
                         continue;
                     }
                     // A `die` quits the supply: route to the QUIT phaser.

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -54,6 +54,16 @@ pub enum Control {
     Emit,
     /// `redo` — re-run the current loop iteration.
     Redo,
+    /// `next` — skip to the next loop iteration.
+    Next,
+    /// `succeed` — leave the enclosing `when`/`given` successfully.
+    Succeed,
+    /// A resumable control signal (e.g. a resumed `warn`/CONTROL handler).
+    Resume,
+    /// `done` for a `react`/`supply` (consumed by the react runtime).
+    ReactDone,
+    /// `warn` — emit a warning (resumable); message in `RuntimeError::message`.
+    Warn,
 }
 
 #[derive(Debug)]
@@ -65,21 +75,17 @@ pub struct RuntimeError {
     pub hint: Option<String>,
     pub return_value: Option<Value>,
     /// The control-flow signal this error carries, if any (see `Control`).
-    /// Replaces the former `is_return`/`is_goto`/`is_proceed`/`is_take`/
-    /// `is_emit`/`is_redo` bools; read via the `is_*()` accessor methods.
+    /// Replaces the former `is_*` bools for the migrated signals; read via the
+    /// `is_*()` accessor methods. The remaining `is_*: bool` fields below carry
+    /// signals not yet migrated to the enum (later slices).
     pub control: Option<Control>,
     pub is_last: bool,
-    pub is_next: bool,
-    pub is_succeed: bool,
     pub is_fail: bool,
     /// When true, the Failure produced from this fail error should be marked as handled.
     /// Set when UNDO phasers run in response to the fail.
     pub fail_handled: bool,
-    pub is_warn: bool,
     pub is_done: bool,
     pub is_leave: bool,
-    pub is_resume: bool,
-    pub is_react_done: bool,
     pub label: Option<String>,
     pub leave_callable_id: Option<u64>,
     pub leave_routine: Option<String>,
@@ -117,15 +123,10 @@ impl RuntimeError {
             return_value: None,
             control: None,
             is_last: false,
-            is_next: false,
-            is_succeed: false,
             is_fail: false,
             fail_handled: false,
-            is_warn: false,
             is_done: false,
             is_leave: false,
-            is_resume: false,
-            is_react_done: false,
             label: None,
             leave_callable_id: None,
             leave_routine: None,
@@ -159,6 +160,26 @@ impl RuntimeError {
     /// `redo` control signal (re-run the current loop iteration).
     pub(crate) fn is_redo(&self) -> bool {
         self.control == Some(Control::Redo)
+    }
+    /// `next` control signal (skip to the next loop iteration).
+    pub(crate) fn is_next(&self) -> bool {
+        self.control == Some(Control::Next)
+    }
+    /// `succeed` control signal (leave the enclosing `when`/`given`).
+    pub(crate) fn is_succeed(&self) -> bool {
+        self.control == Some(Control::Succeed)
+    }
+    /// Resumable control signal (resumed `warn`/CONTROL handler).
+    pub(crate) fn is_resume(&self) -> bool {
+        self.control == Some(Control::Resume)
+    }
+    /// `done` control signal for a `react`/`supply`.
+    pub(crate) fn is_react_done(&self) -> bool {
+        self.control == Some(Control::ReactDone)
+    }
+    /// `warn` control signal (resumable warning).
+    pub(crate) fn is_warn(&self) -> bool {
+        self.control == Some(Control::Warn)
     }
 
     /// Check if this error represents an X::CompUnit::UnsatisfiedDependency error.
@@ -228,15 +249,10 @@ impl RuntimeError {
             return_value: None,
             control: None,
             is_last: false,
-            is_next: false,
-            is_succeed: false,
             is_fail: false,
             fail_handled: false,
-            is_warn: false,
             is_done: false,
             is_leave: false,
-            is_resume: false,
-            is_react_done: false,
             label: None,
             leave_callable_id: None,
             leave_routine: None,
@@ -258,7 +274,7 @@ impl RuntimeError {
     pub(crate) fn next_signal() -> Self {
         Self {
             message: "X::ControlFlow".to_string(),
-            is_next: true,
+            control: Some(Control::Next),
             ..Self::new("")
         }
     }
@@ -289,7 +305,7 @@ impl RuntimeError {
 
     pub(crate) fn succeed_signal() -> Self {
         Self {
-            is_succeed: true,
+            control: Some(Control::Succeed),
             ..Self::new("")
         }
     }
@@ -301,14 +317,14 @@ impl RuntimeError {
     /// surfaces to user code.
     pub(crate) fn supply_terminate_signal() -> Self {
         Self {
-            is_react_done: true,
+            control: Some(Control::ReactDone),
             ..Self::new("")
         }
     }
 
     pub(crate) fn resume_signal() -> Self {
         Self {
-            is_resume: true,
+            control: Some(Control::Resume),
             ..Self::new("")
         }
     }
@@ -331,7 +347,7 @@ impl RuntimeError {
         );
         let xcf = Self::typed("X::ControlFlow", attrs);
         Self {
-            is_react_done: true,
+            control: Some(Control::ReactDone),
             exception: xcf.exception,
             ..Self::new("")
         }
@@ -349,7 +365,7 @@ impl RuntimeError {
     pub(crate) fn warn_signal(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            is_warn: true,
+            control: Some(Control::Warn),
             ..Self::new("")
         }
     }
@@ -405,7 +421,7 @@ impl RuntimeError {
     pub(crate) fn warn_signal_with_resume(message: impl Into<String>, resume_value: Value) -> Self {
         Self {
             message: message.into(),
-            is_warn: true,
+            control: Some(Control::Warn),
             return_value: Some(resume_value),
             ..Self::new("")
         }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -484,7 +484,7 @@ pub(crate) fn current_time_secs_f64() -> f64 {
 pub(crate) use display::is_internal_anon_type_name;
 pub use display::{format_complex, tclc_str, wordcase_str};
 pub(crate) use error::expected_type_object;
-pub use error::{RuntimeError, RuntimeErrorCode};
+pub use error::{Control, RuntimeError, RuntimeErrorCode};
 // SubData is re-exported so callers can destructure Value::Sub(data)
 
 static INSTANCE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -462,7 +462,7 @@ impl Interpreter {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn && self.control_handler_depth == 0 {
+                if e.is_warn() && self.control_handler_depth == 0 {
                     if !self.warning_suppressed() {
                         self.write_warn_to_stderr(&e.message);
                     }
@@ -695,7 +695,7 @@ impl Interpreter {
                     ip = target_ip;
                     continue;
                 }
-                if e.is_warn && self.control_handler_depth == 0 {
+                if e.is_warn() && self.control_handler_depth == 0 {
                     if !self.warning_suppressed() {
                         self.write_warn_to_stderr(&e.message);
                     }
@@ -1005,7 +1005,7 @@ impl Interpreter {
                     continue;
                 }
                 // Handle warn signals inline when no CONTROL handler is active.
-                if e.is_warn && self.control_handler_depth == 0 {
+                if e.is_warn() && self.control_handler_depth == 0 {
                     if !self.warning_suppressed() {
                         self.write_warn_to_stderr(&e.message);
                     }
@@ -3351,7 +3351,7 @@ impl Interpreter {
                         // Record a resume point so a call that raises a
                         // control signal (e.g. `warn`) can be resumed after
                         // the call site by `.resume` in a CONTROL block.
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3398,7 +3398,7 @@ impl Interpreter {
                         // method call is itself a `.resume`/`.rethrow` that
                         // re-raises a control signal, the original resume
                         // point (e.g. after `warn`) must be preserved.
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3419,7 +3419,7 @@ impl Interpreter {
                         // Record a resume point so a method that raises a
                         // control signal (e.g. a resumable `warn`) can be
                         // resumed after the call site by `.resume`.
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3443,7 +3443,7 @@ impl Interpreter {
                 ) {
                     Ok(()) => {}
                     Err(e) => {
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3482,7 +3482,7 @@ impl Interpreter {
                 ) {
                     Ok(()) => {}
                     Err(e) => {
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3519,7 +3519,7 @@ impl Interpreter {
                 match self.exec_call_on_value_op(code, *arity, *arg_sources_idx, compiled_fns) {
                     Ok(()) => {}
                     Err(e) => {
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3541,7 +3541,7 @@ impl Interpreter {
                 ) {
                     Ok(()) => {}
                     Err(e) => {
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -3563,7 +3563,7 @@ impl Interpreter {
                 ) {
                     Ok(()) => {}
                     Err(e) => {
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -4315,7 +4315,7 @@ impl Interpreter {
                         // A per-element method may raise a resumable warn (the
                         // hyper op re-raises it carrying the full result); record
                         // the resume point so `.resume` continues after the call.
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);
@@ -4330,7 +4330,7 @@ impl Interpreter {
                 match self.exec_hyper_method_call_dynamic_op(code, *arity, *modifier_idx) {
                     Ok(()) => {}
                     Err(e) => {
-                        if !e.is_resume && self.resume_ip.is_none() {
+                        if !e.is_resume() && self.resume_ip.is_none() {
                             self.resume_ip = Some(*ip + 1);
                         }
                         return Err(e);

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -514,7 +514,7 @@ impl Interpreter {
                     result = Err(e);
                     break;
                 }
-                Err(e) if e.is_succeed => {
+                Err(e) if e.is_succeed() => {
                     // `when`/`default` succeed signals are caught at the
                     // enclosing block boundary (sub, method, or pointy block).
                     let ret_val = e.return_value.unwrap_or(Value::Nil);

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -95,21 +95,21 @@ impl Interpreter {
         }
         let class_name = if signal.is_last {
             Some("CX::Last")
-        } else if signal.is_next {
+        } else if signal.is_next() {
             Some("CX::Next")
         } else if signal.is_redo() {
             Some("CX::Redo")
         } else if signal.is_proceed() {
             Some("CX::Proceed")
-        } else if signal.is_succeed {
+        } else if signal.is_succeed() {
             Some("CX::Succeed")
-        } else if signal.is_warn {
+        } else if signal.is_warn() {
             Some("CX::Warn")
         } else if signal.is_take() {
             Some("CX::Take")
         } else if signal.is_emit() {
             Some("CX::Emit")
-        } else if signal.is_done || signal.is_react_done {
+        } else if signal.is_done || signal.is_react_done() {
             Some("CX::Done")
         } else if signal.is_return() {
             Some("CX::Return")
@@ -124,7 +124,7 @@ impl Interpreter {
         // text without the location, so strip the appended suffix.
         let message_text = if signal.message.is_empty() {
             class_name.to_string()
-        } else if signal.is_warn {
+        } else if signal.is_warn() {
             signal
                 .message
                 .split_once("\n  in block ")
@@ -289,7 +289,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_succeed => {
+                    Err(e) if e.is_succeed() => {
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
                                 self.env_mut().insert("_".to_string(), v);
@@ -327,7 +327,7 @@ impl Interpreter {
                     Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
                         break 'while_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
                                 self.env_mut().insert("_".to_string(), v);
@@ -947,7 +947,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_succeed => {
+                    Err(e) if e.is_succeed() => {
                         if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
@@ -1073,7 +1073,7 @@ impl Interpreter {
                         );
                         break 'for_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
                         if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
@@ -1380,7 +1380,7 @@ impl Interpreter {
                         );
                         break 'body_redo;
                     }
-                    Err(e) if e.is_succeed => {
+                    Err(e) if e.is_succeed() => {
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
@@ -1410,7 +1410,7 @@ impl Interpreter {
                     Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
                         break 'for_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
                         break 'body_redo;
                     }
                     Err(e)
@@ -1608,7 +1608,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_succeed => {
+                    Err(e) if e.is_succeed() => {
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
@@ -1634,7 +1634,7 @@ impl Interpreter {
                     Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
                         break 'for_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
                         break 'body_redo;
                     }
                     Err(e)
@@ -1830,7 +1830,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_succeed => {
+                    Err(e) if e.is_succeed() => {
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
@@ -1848,7 +1848,7 @@ impl Interpreter {
                     Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
                         break 'for_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
                         break 'body_redo;
                     }
                     Err(e) => {
@@ -2546,7 +2546,7 @@ impl Interpreter {
                         }
                         break 'body_redo;
                     }
-                    Err(e) if e.is_succeed => {
+                    Err(e) if e.is_succeed() => {
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
@@ -2570,7 +2570,7 @@ impl Interpreter {
                     Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
                         break 'c_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
                         break 'body_redo;
                     }
                     Err(e)
@@ -2718,7 +2718,7 @@ impl Interpreter {
         let mut inner_ip = body_start;
         while inner_ip < end {
             if let Err(e) = self.exec_one(code, &mut inner_ip, compiled_fns) {
-                if e.is_succeed {
+                if e.is_succeed() {
                     self.stack.truncate(stack_base);
                     if let Some(v) = e.return_value {
                         self.stack.push(v);
@@ -2771,7 +2771,7 @@ impl Interpreter {
                 }
                 self.stack.truncate(stack_base);
             }
-            Err(e) if e.is_succeed => {
+            Err(e) if e.is_succeed() => {
                 if let Some(v) = e.return_value {
                     last = v;
                 }
@@ -2864,7 +2864,7 @@ impl Interpreter {
                 Err(e) if e.is_proceed() => {
                     did_proceed = true;
                 }
-                Err(e) if e.is_succeed => {
+                Err(e) if e.is_succeed() => {
                     loan_env!(self, set_when_matched(true));
                     return Err(e);
                 }
@@ -2901,7 +2901,7 @@ impl Interpreter {
         let end = body_end as usize;
         match self.run_range(code, body_start, end, compiled_fns) {
             Ok(()) => {}
-            Err(e) if e.is_succeed => {
+            Err(e) if e.is_succeed() => {
                 loan_env!(self, set_when_matched(true));
                 return Err(e);
             }
@@ -2974,7 +2974,7 @@ impl Interpreter {
                     Err(e) if e.is_last && Self::label_matches(&e.label, label) => {
                         break 'repeat_loop;
                     }
-                    Err(e) if e.is_next && Self::label_matches(&e.label, label) => {
+                    Err(e) if e.is_next() && Self::label_matches(&e.label, label) => {
                         break 'body_redo;
                     }
                     Err(e) => {
@@ -3120,7 +3120,7 @@ impl Interpreter {
                             self.stack.truncate(saved_depth);
                             self.stack.push(Value::Nil);
                         }
-                        Err(control_err) if control_err.is_succeed => {
+                        Err(control_err) if control_err.is_succeed() => {
                             self.stack.truncate(saved_depth);
                             self.stack.push(Value::Nil);
                         }
@@ -3140,8 +3140,8 @@ impl Interpreter {
             }
             Err(e)
                 if e.return_value.is_some()
-                    && !e.is_succeed
-                    && !e.is_warn
+                    && !e.is_succeed()
+                    && !e.is_warn()
                     && !e.is_take()
                     && !e.is_emit() =>
             {
@@ -3152,15 +3152,15 @@ impl Interpreter {
             // block must propagate up — `try` alone does not catch them.
             Err(e)
                 if (e.is_last
-                    || e.is_next
+                    || e.is_next()
                     || e.is_redo()
                     || e.is_proceed()
-                    || e.is_succeed
-                    || e.is_warn
+                    || e.is_succeed()
+                    || e.is_warn()
                     || e.is_take()
                     || e.is_emit()
                     || e.is_done
-                    || e.is_react_done)
+                    || e.is_react_done())
                     && control_begin >= end =>
             {
                 self.discard_let_saves(let_mark);
@@ -3168,15 +3168,15 @@ impl Interpreter {
             }
             Err(e)
                 if (e.is_last
-                    || e.is_next
+                    || e.is_next()
                     || e.is_redo()
                     || e.is_proceed()
-                    || e.is_succeed
-                    || e.is_warn
+                    || e.is_succeed()
+                    || e.is_warn()
                     || e.is_take()
                     || e.is_emit()
                     || e.is_done
-                    || e.is_react_done)
+                    || e.is_react_done())
                     && control_begin < end =>
             {
                 self.discard_let_saves(let_mark);
@@ -3192,16 +3192,16 @@ impl Interpreter {
                     let control_result = self.run_range(code, control_begin, end, compiled_fns);
                     let next_resume = match control_result {
                         Ok(()) => None,
-                        Err(ref ce) if ce.is_succeed => None,
+                        Err(ref ce) if ce.is_succeed() => None,
                         // Re-throwing a CX::Warn from CONTROL acts like the
                         // default warn handler: print to stderr and resume.
-                        Err(ce) if ce.is_warn => {
+                        Err(ce) if ce.is_warn() => {
                             if !self.warning_suppressed() {
                                 self.write_warn_to_stderr(&ce.message);
                             }
                             self.resume_ip.take()
                         }
-                        Err(ce) if ce.is_resume => {
+                        Err(ce) if ce.is_resume() => {
                             let _ = ce;
                             self.resume_ip.take()
                         }
@@ -3233,7 +3233,7 @@ impl Interpreter {
                             // other control signals (take/emit/done) also carry a
                             // `return_value` for their own machinery, which must NOT
                             // land on the Interpreter operand stack here.
-                            if pending_err.is_warn
+                            if pending_err.is_warn()
                                 && let Some(rv) = pending_err.return_value.take()
                             {
                                 self.stack.push(rv);
@@ -3268,15 +3268,15 @@ impl Interpreter {
                                 }
                                 Err(new_err)
                                     if new_err.is_last
-                                        || new_err.is_next
+                                        || new_err.is_next()
                                         || new_err.is_redo()
                                         || new_err.is_proceed()
-                                        || new_err.is_succeed
-                                        || new_err.is_warn
+                                        || new_err.is_succeed()
+                                        || new_err.is_warn()
                                         || new_err.is_take()
                                         || new_err.is_emit()
                                         || new_err.is_done
-                                        || new_err.is_react_done =>
+                                        || new_err.is_react_done() =>
                                 {
                                     pending_err = new_err;
                                     continue;
@@ -3336,7 +3336,7 @@ impl Interpreter {
                     match self.run_range(code, catch_begin, control_begin, compiled_fns) {
                         Ok(()) => self.when_matched(),
                         // succeed from `when` inside CATCH means exception was handled
-                        Err(catch_err) if catch_err.is_succeed => {
+                        Err(catch_err) if catch_err.is_succeed() => {
                             // Truncate values left by default body, then push Nil
                             // (Raku: try { die; CATCH { default { "caught" } } } returns Nil)
                             self.stack.truncate(catch_stack_base);
@@ -3344,7 +3344,7 @@ impl Interpreter {
                             true
                         }
                         // .resume called inside CATCH: resume execution after the die
-                        Err(catch_err) if catch_err.is_resume => {
+                        Err(catch_err) if catch_err.is_resume() => {
                             self.stack.truncate(catch_stack_base);
                             loan_env!(self, set_when_matched(saved_when));
                             if let Some(v) = saved_topic {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -512,7 +512,7 @@ impl Interpreter {
         while ip < cc.ops.len() {
             match self.exec_one(&cc, &mut ip, run_fns) {
                 Ok(()) => {}
-                Err(e) if e.is_warn => {
+                Err(e) if e.is_warn() => {
                     if !self.warning_suppressed() {
                         self.write_warn_to_stderr(&e.message);
                     }
@@ -835,7 +835,7 @@ impl Interpreter {
         while ip < cc.ops.len() {
             match self.exec_one(&cc, &mut ip, run_fns) {
                 Ok(()) => {}
-                Err(e) if e.is_warn => {
+                Err(e) if e.is_warn() => {
                     if !self.warning_suppressed() {
                         self.write_warn_to_stderr(&e.message);
                     }
@@ -1061,7 +1061,7 @@ impl Interpreter {
                             return Ok(c[..n].to_vec());
                         }
                         // `next`: skip the current element and continue.
-                        Err(e) if e.is_next => Vec::new(),
+                        Err(e) if e.is_next() => Vec::new(),
                         Err(e) => return Err(e),
                     };
                     {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -473,7 +473,7 @@ impl Interpreter {
                                     // Resumable warn from a per-element native
                                     // method: use its carried resume value and
                                     // remember the warn to re-raise after the loop.
-                                    Err(e) if collect_warns && e.is_warn => {
+                                    Err(e) if collect_warns && e.is_warn() => {
                                         let rv = e.return_value.clone().unwrap_or(Value::Nil);
                                         if pending_warn.is_none() {
                                             pending_warn = Some(e);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -3197,14 +3197,14 @@ impl Interpreter {
             return false;
         }
         !(err.is_last
-            || err.is_next
+            || err.is_next()
             || err.is_redo()
             || err.is_goto()
             || err.is_proceed()
-            || err.is_succeed
+            || err.is_succeed()
             || err.is_leave
-            || err.is_resume
-            || err.is_react_done)
+            || err.is_resume()
+            || err.is_react_done())
     }
 
     fn should_run_success_queue(
@@ -3287,7 +3287,7 @@ impl Interpreter {
                     self.stack.truncate(stack_base);
                     continue;
                 }
-                Err(e) if e.is_next && has_label && Self::label_matches(&e.label, &label) => {
+                Err(e) if e.is_next() && has_label && Self::label_matches(&e.label, &label) => {
                     self.stack.truncate(stack_base);
                     self.stack.push(Value::Slip(std::sync::Arc::new(vec![])));
                     break Ok(());

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -65,7 +65,7 @@ impl Interpreter {
                 loan_env!(self, set_when_matched(saved_when));
                 Ok(())
             }
-            Err(err) if err.is_succeed => {
+            Err(err) if err.is_succeed() => {
                 loan_env!(self, set_when_matched(saved_when));
                 Ok(())
             }
@@ -103,12 +103,12 @@ impl Interpreter {
     ) -> Result<bool, RuntimeError> {
         match self.call_react_callback(&sub.callback.clone(), vec![value.clone()]) {
             Ok(_) => Ok(false),
-            Err(e) if e.is_react_done => Ok(true),
-            Err(e) if e.is_next => Ok(false),
+            Err(e) if e.is_react_done() => Ok(true),
+            Err(e) if e.is_next() => Ok(false),
             Err(e) if e.is_last => {
                 for cb in sub.last_callbacks.clone() {
                     match self.call_react_callback(&cb, vec![value.clone()]) {
-                        Err(le) if le.is_react_done => {
+                        Err(le) if le.is_react_done() => {
                             sub.done = true;
                             return Ok(true);
                         }
@@ -250,7 +250,7 @@ impl Interpreter {
                                 .map(|c| c.done)
                                 .unwrap_or(false);
                             if let Err(od_err) = od_res
-                                && !od_err.is_react_done
+                                && !od_err.is_react_done()
                             {
                                 self.supply_stream_consumers.truncate(stream_idx);
                                 return Err(crate::runtime::Interpreter::wrap_react_died(od_err));
@@ -267,7 +267,7 @@ impl Interpreter {
                                     .unwrap_or_default();
                                 for last_cb in &last_cbs {
                                     match self.call_react_callback(&last_cb.clone(), Vec::new()) {
-                                        Err(e) if e.is_react_done => return Ok(()),
+                                        Err(e) if e.is_react_done() => return Ok(()),
                                         _ => {}
                                     }
                                 }
@@ -354,7 +354,7 @@ impl Interpreter {
                             .unwrap_or_default();
                         for last_cb in &last_cbs {
                             match self.call_react_callback(&last_cb.clone(), Vec::new()) {
-                                Err(e) if e.is_react_done => return Ok(()),
+                                Err(e) if e.is_react_done() => return Ok(()),
                                 _ => {}
                             }
                         }
@@ -454,7 +454,7 @@ impl Interpreter {
                 {
                     for callback in &sub.last_callbacks {
                         match self.call_react_callback(&callback.clone(), Vec::new()) {
-                            Err(e) if e.is_react_done => break 'react_loop,
+                            Err(e) if e.is_react_done() => break 'react_loop,
                             other => {
                                 other?;
                             }
@@ -569,7 +569,7 @@ impl Interpreter {
                                 &sub.callback.clone(),
                                 vec![Value::str(remaining)],
                             ) {
-                                Err(e) if e.is_react_done => break 'react_loop,
+                                Err(e) if e.is_react_done() => break 'react_loop,
                                 other => {
                                     other?;
                                 }
@@ -619,12 +619,12 @@ impl Interpreter {
                                 // supply: keep the promise with the last emitted
                                 // value immediately rather than spinning to the
                                 // deadline.
-                                if err.is_react_done || err.is_last {
+                                if err.is_react_done() || err.is_last {
                                     promise.keep(last_value.clone(), String::new(), String::new());
                                     return Ok(());
                                 }
                                 // `next`/`redo` are loop control, not completion.
-                                if !err.is_next && !err.is_redo() {
+                                if !err.is_next() && !err.is_redo() {
                                     // A `die` quits the supply: break with the cause.
                                     let cause = err
                                         .exception
@@ -668,7 +668,7 @@ impl Interpreter {
                                     &sub.callback.clone(),
                                     vec![Value::str(remaining)],
                                 ) {
-                                    Err(e) if e.is_react_done => break 'react_loop,
+                                    Err(e) if e.is_react_done() => break 'react_loop,
                                     other => {
                                         other?;
                                     }
@@ -874,7 +874,7 @@ impl Interpreter {
             .map(|c| c.done)
             .unwrap_or(false);
         if let Err(e) = res
-            && !e.is_react_done
+            && !e.is_react_done()
         {
             self.supply_stream_consumers.truncate(idx);
             return Err(crate::runtime::Interpreter::wrap_react_died(e));
@@ -904,7 +904,7 @@ impl Interpreter {
                     // A plain value buffered by the body (no active stream route):
                     // deliver it to the consumer directly.
                     match self.call_react_callback(&consumer_cb.clone(), vec![v]) {
-                        Err(e) if e.is_react_done => {
+                        Err(e) if e.is_react_done() => {
                             reached = true;
                             break;
                         }
@@ -919,7 +919,7 @@ impl Interpreter {
         if !reached {
             for cb in last_callbacks {
                 match self.call_react_callback(&cb.clone(), Vec::new()) {
-                    Err(e) if e.is_react_done => {
+                    Err(e) if e.is_react_done() => {
                         reached = true;
                         break;
                     }
@@ -943,8 +943,8 @@ impl Interpreter {
             for v in values.iter() {
                 match self.call_react_callback(&callback.clone(), vec![v.clone()]) {
                     Ok(_) => {}
-                    Err(e) if e.is_react_done => return Ok(true),
-                    Err(e) if e.is_next => continue,
+                    Err(e) if e.is_react_done() => return Ok(true),
+                    Err(e) if e.is_next() => continue,
                     Err(e) if e.is_last => {
                         last_topic = Some(v.clone());
                         break;
@@ -959,7 +959,7 @@ impl Interpreter {
                 None => Vec::new(),
             };
             match self.call_react_callback(&cb.clone(), args) {
-                Err(e) if e.is_react_done => return Ok(true),
+                Err(e) if e.is_react_done() => return Ok(true),
                 other => {
                     other?;
                 }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -1821,7 +1821,7 @@ impl Interpreter {
 
         // If `done;` was called in the react body, skip the event loop —
         // the body already signaled that no further events should be processed.
-        let body_done = matches!(&run_result, Err(e) if e.is_react_done);
+        let body_done = matches!(&run_result, Err(e) if e.is_react_done());
         // The react/supply drive loop runs Interpreter-side and dispatches every
         // whenever / LAST / QUIT / CLOSE callback as compiled bytecode
         // (Stage 2 #3038/#3039; QUIT handlers Interpreter-native in the Stage 3 follow-up).
@@ -1876,12 +1876,12 @@ impl Interpreter {
 
         *ip = end;
         if let Err(err) = run_result
-            && !err.is_react_done
+            && !err.is_react_done()
         {
             return Err(err);
         }
         if let Err(err) = event_result
-            && !err.is_react_done
+            && !err.is_react_done()
         {
             // Wrap in X::React::Died if not already wrapped
             return Err(crate::runtime::Interpreter::wrap_react_died_if_needed(err));


### PR DESCRIPTION
Slice 2 of the §7-4 control-flow / RuntimeError separation (slice 1 = #3701).

Migrates mutation-free, mutually-exclusive control signals off their is_*: bool fields into enum Control: Next, Succeed, Resume, ReactDone, Warn.

- enum Control gains the 5 variants; bool fields removed; builders set control: Some(Control::X); ~116 read sites use is_*() accessors; one err.is_warn=true mutation becomes err.control=Some(Control::Warn). Control re-exported from crate::value.
- Remaining bool fields (later slices, have post-construction mutations): is_last, is_fail/fail_handled, is_done, is_leave.

Behavior-preserving: control-flow smoke + roast (S04 return/given/last/loop/while, phasers/in-loop) + t/ suites pass. make test (release) PASS; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)