### PR TITLE
fix(unicode): `.tc` titlecases the Latin DŽ digraph + title forms correctly

### DIFF
--- a/src/builtins/unicode.rs
+++ b/src/builtins/unicode.rs
@@ -4,10 +4,12 @@
 /// - digraph ligatures: special titlecase forms
 pub(crate) fn unicode_titlecase_first(ch: char) -> String {
     match ch {
-        // Latin digraph titlecase pairs
-        '\u{01C9}' | '\u{01C7}' => "\u{01C8}".to_string(), // Lj
-        '\u{01CC}' | '\u{01CA}' => "\u{01CB}".to_string(), // Nj
-        '\u{01F3}' | '\u{01F1}' => "\u{01F2}".to_string(), // Dz
+        // Latin digraph titlecase triples (lower | upper | title) → title form.
+        // The title form titlecases to ITSELF, not to the full uppercase digraph.
+        '\u{01C6}' | '\u{01C4}' | '\u{01C5}' => "\u{01C5}".to_string(), // Dž
+        '\u{01C9}' | '\u{01C7}' | '\u{01C8}' => "\u{01C8}".to_string(), // Lj
+        '\u{01CC}' | '\u{01CA}' | '\u{01CB}' => "\u{01CB}".to_string(), // Nj
+        '\u{01F3}' | '\u{01F1}' | '\u{01F2}' => "\u{01F2}".to_string(), // Dz
         // Sharp S: titlecase is "Ss", not "SS"
         '\u{00DF}' => "Ss".to_string(),
         // Latin ligature titlecase mappings

--- a/t/titlecase-digraph.t
+++ b/t/titlecase-digraph.t
@@ -1,0 +1,36 @@
+use Test;
+
+# `.tc` (Unicode titlecase) of the Latin digraph letters must use the
+# Titlecase_Mapping, not full uppercase. For the DŽ/LJ/NJ/DZ digraphs the
+# lowercase, uppercase AND titlecase code points all titlecase to the *title*
+# form (e.g. `ǆ`/`Ǆ`/`ǅ` → `ǅ`), not to the uppercase digraph (`Ǆ`).
+
+plan 16;
+
+# DŽ digraph (U+01C4 Ǆ, U+01C5 ǅ, U+01C6 ǆ) — this row was missing entirely.
+is "ǆ".tc, "ǅ", 'lowercase dž titlecases to ǅ';
+is "Ǆ".tc, "ǅ", 'uppercase DŽ titlecases to ǅ';
+is "ǅ".tc, "ǅ", 'title ǅ titlecases to itself';
+
+# LJ digraph
+is "ǉ".tc, "ǈ", 'lowercase lj titlecases to ǈ';
+is "Ǉ".tc, "ǈ", 'uppercase LJ titlecases to ǈ';
+is "ǈ".tc, "ǈ", 'title ǈ titlecases to itself';
+
+# NJ digraph
+is "ǌ".tc, "ǋ", 'lowercase nj titlecases to ǋ';
+is "Ǌ".tc, "ǋ", 'uppercase NJ titlecases to ǋ';
+is "ǋ".tc, "ǋ", 'title ǋ titlecases to itself';
+
+# DZ digraph
+is "ǳ".tc, "ǲ", 'lowercase dz titlecases to ǲ';
+is "Ǳ".tc, "ǲ", 'uppercase DZ titlecases to ǲ';
+is "ǲ".tc, "ǲ", 'title ǲ titlecases to itself';
+
+# Titlecase_Mapping uniprop agrees.
+is "ǆ".uniprop("Titlecase_Mapping"), "ǅ", 'Titlecase_Mapping uniprop for ǆ';
+
+# Ordinary titlecasing is unaffected.
+is "hello world".tc, "Hello world", 'plain word titlecase unaffected';
+is "ßdf".tc, "Ssdf", 'sharp-s titlecase (Ss) unaffected';
+is "ﬁle".tc, "File", 'ligature titlecase unaffected';


### PR DESCRIPTION
## Summary

`unicode_titlecase_first` mapped the LJ/NJ/DZ digraph letters to their `Titlecase_Mapping` but:

1. was **missing the DŽ digraph** (U+01C4 `Ǆ` / U+01C5 `ǅ` / U+01C6 `ǆ`) entirely, so `"ǆ".tc` fell through to full uppercase `Ǆ` instead of the title form `ǅ`; and
2. omitted the **title code points themselves** (`ǅ`/`ǈ`/`ǋ`/`ǲ`), so `"ǅ".tc` uppercased to `Ǆ` rather than staying `ǅ`.

For these digraphs the lowercase, uppercase and title forms all titlecase to the title form.

```
"ǆ".tc   # was Ǆ → now ǅ
"Ǆ".tc   # was Ǆ → now ǅ
"ǅ".tc   # was Ǆ → now ǅ   (and likewise LJ/NJ/DZ)
```

## Fix

Add the DŽ row and include the title code point in all four digraph rows of `unicode_titlecase_first` (`src/builtins/unicode.rs`).

## Tests

- `t/titlecase-digraph.t` (16 assertions: all 3 forms of each of the 4 digraphs + `Titlecase_Mapping` uniprop + no-regression for plain/`ß`/ligature titlecasing).
- Found via a mutsu-vs-rakudo Unicode diff batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)