### PR TITLE
refactor(error): migrate last/fail/done into enum Control (§7-4 slice 3)

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -2290,7 +2290,7 @@ impl Interpreter {
                     match self.duckmap_element(block, item) {
                         Ok(v) => result.push(v),
                         Err(e) if e.is_next() => continue,
-                        Err(e) if e.is_last => break,
+                        Err(e) if e.is_last() => break,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2306,7 +2306,7 @@ impl Interpreter {
                     match self.duckmap_element(block, item) {
                         Ok(v) => result.push(v),
                         Err(e) if e.is_next() => continue,
-                        Err(e) if e.is_last => break,
+                        Err(e) if e.is_last() => break,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2320,7 +2320,7 @@ impl Interpreter {
                             result.insert(k.clone(), mapped);
                         }
                         Err(e) if e.is_next() => continue,
-                        Err(e) if e.is_last => break,
+                        Err(e) if e.is_last() => break,
                         Err(e) => return Err(e),
                     }
                 }
@@ -2545,7 +2545,7 @@ impl Interpreter {
         // Try to call the block with this value
         match self.call_sub_value(block.clone(), vec![value.clone()], false) {
             Ok(result) => Ok(result),
-            Err(e) if e.is_next() || e.is_last || e.is_redo() => {
+            Err(e) if e.is_next() || e.is_last() || e.is_redo() => {
                 // Propagate loop control signals (next, last, redo)
                 Err(e)
             }

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -31,7 +31,9 @@ impl Interpreter {
     ) -> RuntimeError {
         if matches!(value, Value::Nil) {
             let mut err = RuntimeError::new(default_message);
-            err.is_fail = is_fail;
+            if is_fail {
+                err.control = Some(crate::value::Control::Fail);
+            }
             return err;
         }
 
@@ -62,7 +64,9 @@ impl Interpreter {
         };
 
         let mut err = RuntimeError::new(&msg);
-        err.is_fail = is_fail;
+        if is_fail {
+            err.control = Some(crate::value::Control::Fail);
+        }
         if let Value::Instance { class_name, .. } = value {
             let cn = class_name.resolve();
             let is_exception = cn == "Exception"
@@ -144,7 +148,7 @@ impl Interpreter {
             return Err(self.runtime_error_from_die_value(&current, "Failed", true));
         }
         let mut err = RuntimeError::new("Failed");
-        err.is_fail = true;
+        err.control = Some(crate::value::Control::Fail);
         Err(err)
     }
 

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -548,7 +548,7 @@ impl Interpreter {
             }
             // Convert fail errors to Failure values (same as closure call path)
             if let Err(e) = &result
-                && e.is_fail
+                && e.is_fail()
             {
                 return Ok(self.fail_error_to_failure_value(e));
             }

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -523,7 +523,7 @@ impl Interpreter {
         args: &[Value],
     ) -> RuntimeError {
         // Don't enhance errors that are already enhanced or are control flow
-        if err.is_return() || err.is_last || err.is_next() || func_name.is_empty() {
+        if err.is_return() || err.is_last() || err.is_next() || func_name.is_empty() {
             return err;
         }
         // Build call profile: func_name(Type1, Type2, ...)

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -1064,7 +1064,7 @@ impl Interpreter {
                 if method_def.is_submethod
                     && let Some(mut err) = self.failure_to_runtime_error_if_unhandled(&v)
                 {
-                    err.is_fail = true;
+                    err.control = Some(crate::value::Control::Fail);
                     return Err(err);
                 }
                 // Read the committed attribute map from the live cell of `self`,

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -613,7 +613,7 @@ impl Interpreter {
                 // Classes doing X::Control throw as control exceptions so
                 // CONTROL blocks catch them instead of CATCH.
                 if does_x_control {
-                    err.is_done = true;
+                    err.control = Some(crate::value::Control::Done);
                 }
                 // Throwing/rethrowing a CX::Warn re-raises it as a warn
                 // signal so the default handler writes to stderr and

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -399,7 +399,7 @@ impl Interpreter {
                                     }
                                     Err(e) if e.is_redo() => continue 'redo_item,
                                     Err(e) if e.is_next() => break 'redo_item,
-                                    Err(e) if e.is_last => {
+                                    Err(e) if e.is_last() => {
                                         return grep_adverb.transform_result(
                                             Value::array(result),
                                             &result_indices,

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -577,7 +577,7 @@ impl Interpreter {
                     Ok((_v, updated)) => {
                         attributes = updated;
                     }
-                    Err(err) if err.is_fail => {
+                    Err(err) if err.is_fail() => {
                         // `fail` inside BUILD yields a Failure, not an error.
                         let ex = if let Some(exception) = err.exception {
                             *exception

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -4074,7 +4074,7 @@ impl Interpreter {
                             Ok((_v, updated)) => {
                                 attrs = updated;
                             }
-                            Err(err) if err.is_fail => {
+                            Err(err) if err.is_fail() => {
                                 // fail in BUILD: return a Failure wrapping the exception
                                 let ex = if let Some(exception) = err.exception {
                                     *exception

--- a/src/runtime/methods_seq_dispatch.rs
+++ b/src/runtime/methods_seq_dispatch.rs
@@ -88,7 +88,7 @@ impl Interpreter {
                     }
                     Err(e) if e.is_redo() && label_matches(&e.label) => continue 'body_redo,
                     Err(e) if e.is_next() && label_matches(&e.label) => break 'body_redo,
-                    Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,
+                    Err(e) if e.is_last() && label_matches(&e.label) => break 'from_loop,
                     Err(e) => return Err(e),
                 }
             }
@@ -98,7 +98,7 @@ impl Interpreter {
                     Ok(_) => {}
                     Err(e) if e.is_next() && label_matches(&e.label) => continue 'from_loop,
                     Err(e) if e.is_redo() && label_matches(&e.label) => continue 'from_loop,
-                    Err(e) if e.is_last && label_matches(&e.label) => break 'from_loop,
+                    Err(e) if e.is_last() && label_matches(&e.label) => break 'from_loop,
                     Err(e) => return Err(e),
                 }
             }

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -491,7 +491,7 @@ impl Interpreter {
                         // how `(1..Inf).Supply.tap({ ...; done if ... })` terminates).
                         match self.call_sub_value(tap_cb.clone(), vec![v.clone()], true) {
                             Ok(_) => {}
-                            Err(err) if err.is_react_done() || err.is_last => break,
+                            Err(err) if err.is_react_done() || err.is_last() => break,
                             Err(err) => return Err(err),
                         }
                     }

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1473,7 +1473,7 @@ impl Interpreter {
                     };
                     if matches_frame {
                         e.is_leave = false;
-                        e.is_last = false;
+                        e.control = None;
                         if e.return_value.is_none() {
                             e.return_value = Some(Value::Nil);
                         }
@@ -1603,7 +1603,7 @@ impl Interpreter {
             self.env = merged;
             self.restore_readonly_vars(saved_readonly);
             if let Err(e) = &result
-                && e.is_fail
+                && e.is_fail()
             {
                 return Ok(self.fail_error_to_failure_value(e));
             }
@@ -2228,7 +2228,7 @@ impl Interpreter {
                             }
                         }
                         Err(e) if e.is_next() => {}
-                        Err(e) if e.is_last => break,
+                        Err(e) if e.is_last() => break,
                         Err(mut e) => {
                             // A `return` inside the map block targets the routine
                             // that lexically encloses the block. Stamp the signal
@@ -2472,7 +2472,7 @@ impl Interpreter {
                                 list_items[i] = mutated;
                             }
                         }
-                        Err(e) if e.is_last => {
+                        Err(e) if e.is_last() => {
                             if arity == 1
                                 && let Some(mutated) = vm.env().get(topic_key).cloned()
                             {
@@ -2662,7 +2662,7 @@ impl Interpreter {
                             }
                             Err(e) if e.is_redo() => continue 'body_redo,
                             Err(e) if e.is_next() => break 'body_redo,
-                            Err(e) if e.is_last => {
+                            Err(e) if e.is_last() => {
                                 stop = true;
                                 break 'body_redo;
                             }

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -286,7 +286,7 @@ impl Interpreter {
                     match exec_result {
                         Ok(v) => v,
                         Err(e) if e.return_value.is_some() => e.return_value.unwrap(),
-                        Err(e) if e.is_last => return Ok(None),
+                        Err(e) if e.is_last() => return Ok(None),
                         Err(_e) if suppress_generator_error => return Ok(None),
                         Err(e) => return Err(e),
                     }

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -291,7 +291,7 @@ impl Interpreter {
             };
             for item in items {
                 if let Err(err) = run_capture(self, callback.clone(), vec![item], last_value) {
-                    if err.is_react_done() || err.is_last {
+                    if err.is_react_done() || err.is_last() {
                         break 'replay;
                     }
                     if err.is_next() || err.is_redo() {

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -64,6 +64,14 @@ pub enum Control {
     ReactDone,
     /// `warn` — emit a warning (resumable); message in `RuntimeError::message`.
     Warn,
+    /// `last` — break out of the enclosing loop. (A `LEAVE`/routine unwind also
+    /// sets the separate `is_leave` flag on top of this.)
+    Last,
+    /// `fail` — produce a Failure (see also `fail_handled`).
+    Fail,
+    /// A user `X::Control`-doing exception thrown as a control signal so CONTROL
+    /// blocks (not CATCH) handle it.
+    Done,
 }
 
 #[derive(Debug)]
@@ -79,12 +87,14 @@ pub struct RuntimeError {
     /// `is_*()` accessor methods. The remaining `is_*: bool` fields below carry
     /// signals not yet migrated to the enum (later slices).
     pub control: Option<Control>,
-    pub is_last: bool,
-    pub is_fail: bool,
-    /// When true, the Failure produced from this fail error should be marked as handled.
-    /// Set when UNDO phasers run in response to the fail.
+    /// When true, the Failure produced from a `Control::Fail` error should be
+    /// marked as handled. Set when UNDO phasers run in response to the fail.
+    /// (A modifier on `Control::Fail`, kept as a separate flag.)
     pub fail_handled: bool,
-    pub is_done: bool,
+    /// A `LEAVE`/routine unwind sets this *in addition to* `Control::Last` (it
+    /// breaks loops like `last` but also targets a routine frame via
+    /// `leave_callable_id`/`leave_routine`/`label`), so it cannot live in the
+    /// single-signal `control` enum and stays a separate flag.
     pub is_leave: bool,
     pub label: Option<String>,
     pub leave_callable_id: Option<u64>,
@@ -122,10 +132,7 @@ impl RuntimeError {
             hint: None,
             return_value: None,
             control: None,
-            is_last: false,
-            is_fail: false,
             fail_handled: false,
-            is_done: false,
             is_leave: false,
             label: None,
             leave_callable_id: None,
@@ -180,6 +187,18 @@ impl RuntimeError {
     /// `warn` control signal (resumable warning).
     pub(crate) fn is_warn(&self) -> bool {
         self.control == Some(Control::Warn)
+    }
+    /// `last` control signal (break out of the enclosing loop).
+    pub(crate) fn is_last(&self) -> bool {
+        self.control == Some(Control::Last)
+    }
+    /// `fail` control signal (produces a Failure).
+    pub(crate) fn is_fail(&self) -> bool {
+        self.control == Some(Control::Fail)
+    }
+    /// User `X::Control`-doing exception thrown as a control signal.
+    pub(crate) fn is_done(&self) -> bool {
+        self.control == Some(Control::Done)
     }
 
     /// Check if this error represents an X::CompUnit::UnsatisfiedDependency error.
@@ -248,10 +267,7 @@ impl RuntimeError {
             hint: None,
             return_value: None,
             control: None,
-            is_last: false,
-            is_fail: false,
             fail_handled: false,
-            is_done: false,
             is_leave: false,
             label: None,
             leave_callable_id: None,
@@ -266,7 +282,7 @@ impl RuntimeError {
     pub(crate) fn last_signal() -> Self {
         Self {
             message: "X::ControlFlow".to_string(),
-            is_last: true,
+            control: Some(Control::Last),
             ..Self::new("")
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -283,7 +283,9 @@ impl Interpreter {
             );
             let exception = Value::make_instance(Symbol::intern("X::AdHoc"), attrs);
             let mut err = RuntimeError::new(default_message);
-            err.is_fail = is_fail;
+            if is_fail {
+                err.control = Some(crate::value::Control::Fail);
+            }
             err.exception = Some(Box::new(exception));
             return err;
         }
@@ -314,7 +316,9 @@ impl Interpreter {
         };
 
         let mut err = RuntimeError::new(&message);
-        err.is_fail = is_fail;
+        if is_fail {
+            err.control = Some(crate::value::Control::Fail);
+        }
         if let Value::Instance { class_name, .. } = &value {
             let cn = class_name.resolve();
             let is_exception = cn == "Exception"

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -603,7 +603,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     fail_bypass = true;
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
@@ -1215,7 +1215,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     fail_bypass = true;
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
@@ -1620,7 +1620,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     fail_bypass = true;
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
@@ -1982,7 +1982,7 @@ impl Interpreter {
                     };
                     if matches_frame {
                         e.is_leave = false;
-                        e.is_last = false;
+                        e.control = None;
                         let ret_val = e.return_value.unwrap_or(Value::Nil);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
@@ -2013,7 +2013,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     // fail() — restore let saves and return a Failure value
                     fail_bypass = true;
                     let failure = self.fail_error_to_failure_value(&e);

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -501,7 +501,7 @@ impl Interpreter {
                     };
                     if matches_frame {
                         e.is_leave = false;
-                        e.is_last = false;
+                        e.control = None;
                         let ret_val = e.return_value.unwrap_or(Value::Nil);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
@@ -564,7 +564,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     fail_bypass = true;
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -88,12 +88,12 @@ impl Interpreter {
         // User-defined classes doing X::Control carry their original
         // exception instance. Surface it directly so CONTROL blocks see the
         // real type rather than a generic CX::Done wrapper.
-        if signal.is_done
+        if signal.is_done()
             && let Some(ex) = signal.exception.as_ref()
         {
             return Some((**ex).clone());
         }
-        let class_name = if signal.is_last {
+        let class_name = if signal.is_last() {
             Some("CX::Last")
         } else if signal.is_next() {
             Some("CX::Next")
@@ -109,7 +109,7 @@ impl Interpreter {
             Some("CX::Take")
         } else if signal.is_emit() {
             Some("CX::Emit")
-        } else if signal.is_done || signal.is_react_done() {
+        } else if signal.is_done() || signal.is_react_done() {
             Some("CX::Done")
         } else if signal.is_return() {
             Some("CX::Return")
@@ -324,7 +324,7 @@ impl Interpreter {
                         }
                         break 'while_loop;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
                         break 'while_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
@@ -1040,7 +1040,7 @@ impl Interpreter {
                         }
                         break 'for_loop;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
                         if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,
@@ -1407,7 +1407,7 @@ impl Interpreter {
                         }
                         break 'for_loop;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
                         break 'for_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
@@ -1631,7 +1631,7 @@ impl Interpreter {
                     {
                         break 'for_loop;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
                         break 'for_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
@@ -1845,7 +1845,7 @@ impl Interpreter {
                         }
                         continue 'body_redo;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
                         break 'for_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
@@ -2567,7 +2567,7 @@ impl Interpreter {
                         }
                         break 'c_loop;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, &spec.label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
                         break 'c_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
@@ -2971,7 +2971,7 @@ impl Interpreter {
                         }
                         break 'repeat_loop;
                     }
-                    Err(e) if e.is_last && Self::label_matches(&e.label, label) => {
+                    Err(e) if e.is_last() && Self::label_matches(&e.label, label) => {
                         break 'repeat_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, label) => {
@@ -3151,7 +3151,7 @@ impl Interpreter {
             // Control signals (warn, last, next, redo, etc.) without a CONTROL
             // block must propagate up — `try` alone does not catch them.
             Err(e)
-                if (e.is_last
+                if (e.is_last()
                     || e.is_next()
                     || e.is_redo()
                     || e.is_proceed()
@@ -3159,7 +3159,7 @@ impl Interpreter {
                     || e.is_warn()
                     || e.is_take()
                     || e.is_emit()
-                    || e.is_done
+                    || e.is_done()
                     || e.is_react_done())
                     && control_begin >= end =>
             {
@@ -3167,7 +3167,7 @@ impl Interpreter {
                 Err(e)
             }
             Err(e)
-                if (e.is_last
+                if (e.is_last()
                     || e.is_next()
                     || e.is_redo()
                     || e.is_proceed()
@@ -3175,7 +3175,7 @@ impl Interpreter {
                     || e.is_warn()
                     || e.is_take()
                     || e.is_emit()
-                    || e.is_done
+                    || e.is_done()
                     || e.is_react_done())
                     && control_begin < end =>
             {
@@ -3267,7 +3267,7 @@ impl Interpreter {
                                     return Ok(());
                                 }
                                 Err(new_err)
-                                    if new_err.is_last
+                                    if new_err.is_last()
                                         || new_err.is_next()
                                         || new_err.is_redo()
                                         || new_err.is_proceed()
@@ -3275,7 +3275,7 @@ impl Interpreter {
                                         || new_err.is_warn()
                                         || new_err.is_take()
                                         || new_err.is_emit()
-                                        || new_err.is_done
+                                        || new_err.is_done()
                                         || new_err.is_react_done() =>
                                 {
                                     pending_err = new_err;

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1050,7 +1050,7 @@ impl Interpreter {
                     };
                     let produced: Vec<Value> = match applied {
                         Ok(p) => p,
-                        Err(e) if e.is_last => {
+                        Err(e) if e.is_last() => {
                             // `last`: terminate the sequence, current element excluded.
                             let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();
                             spec.done = true;

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -546,7 +546,7 @@ impl Interpreter {
                     };
                     if matches_frame {
                         e.is_leave = false;
-                        e.is_last = false;
+                        e.control = None;
                         let ret_val = e.return_value.unwrap_or(Value::Nil);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
@@ -577,7 +577,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);
@@ -1271,7 +1271,7 @@ impl Interpreter {
                     };
                     if matches_frame {
                         e.is_leave = false;
-                        e.is_last = false;
+                        e.control = None;
                         let ret_val = e.return_value.unwrap_or(Value::Nil);
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
@@ -1300,7 +1300,7 @@ impl Interpreter {
                     result = Ok(());
                     break;
                 }
-                Err(e) if e.is_fail => {
+                Err(e) if e.is_fail() => {
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
                     self.stack.truncate(saved_stack_depth);

--- a/src/vm/vm_misc_ops.rs
+++ b/src/vm/vm_misc_ops.rs
@@ -2995,7 +2995,7 @@ impl Interpreter {
         if ran_undo
             && undo_start < post_start
             && let Err(ref mut e) = body_result
-            && e.is_fail
+            && e.is_fail()
         {
             e.fail_handled = true;
         }
@@ -3190,13 +3190,13 @@ impl Interpreter {
     }
 
     pub(crate) fn is_exceptional_block_exit(err: &RuntimeError) -> bool {
-        if err.is_fail {
+        if err.is_fail() {
             return true;
         }
         if err.return_value.is_some() {
             return false;
         }
-        !(err.is_last
+        !(err.is_last()
             || err.is_next()
             || err.is_redo()
             || err.is_goto()
@@ -3305,7 +3305,7 @@ impl Interpreter {
                     );
                     break Ok(());
                 }
-                Err(e) if e.is_last && has_label && Self::label_matches(&e.label, &label) => {
+                Err(e) if e.is_last() && has_label && Self::label_matches(&e.label, &label) => {
                     self.stack.truncate(stack_base);
                     self.stack.push(
                         e.return_value

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -105,7 +105,7 @@ impl Interpreter {
             Ok(_) => Ok(false),
             Err(e) if e.is_react_done() => Ok(true),
             Err(e) if e.is_next() => Ok(false),
-            Err(e) if e.is_last => {
+            Err(e) if e.is_last() => {
                 for cb in sub.last_callbacks.clone() {
                     match self.call_react_callback(&cb, vec![value.clone()]) {
                         Err(le) if le.is_react_done() => {
@@ -619,7 +619,7 @@ impl Interpreter {
                                 // supply: keep the promise with the last emitted
                                 // value immediately rather than spinning to the
                                 // deadline.
-                                if err.is_react_done() || err.is_last {
+                                if err.is_react_done() || err.is_last() {
                                     promise.keep(last_value.clone(), String::new(), String::new());
                                     return Ok(());
                                 }
@@ -945,7 +945,7 @@ impl Interpreter {
                     Ok(_) => {}
                     Err(e) if e.is_react_done() => return Ok(true),
                     Err(e) if e.is_next() => continue,
-                    Err(e) if e.is_last => {
+                    Err(e) if e.is_last() => {
                         last_topic = Some(v.clone());
                         break;
                     }


### PR DESCRIPTION
Slice 3 of the §7-4 control-flow / RuntimeError consolidation (slices 1-2 = #3701, #3706). Migrates the remaining mutually-exclusive control signals that carry post-construction mutations — Last, Fail, Done — off their is_*: bool fields into enum Control.

Mutation sites handled per-case:
- err.is_fail = is_fail / = true (vm.rs, builtins_control_flow.rs, class.rs) → if is_fail { err.control = Some(Control::Fail) } / = Some(Control::Fail).
- err.is_done = true (methods.rs) → err.control = Some(Control::Done).
- leave/last clear-pair e.is_leave = false; e.is_last = false (resolution, vm_closure_dispatch, vm_method_dispatch×2, vm_call_dispatch) → e.is_leave = false; e.control = None.

is_leave deliberately stays a separate bool: a LEAVE/routine unwind sets it in addition to Control::Last (breaks loops like last AND targets a routine frame), so it co-occurs with a control signal and cannot live in the single-signal enum. fail_handled likewise stays as a Fail modifier.

After this slice the only control state left as bools is is_leave (co-occurring) and fail_handled (modifier); every standalone signal is in enum Control.

Behavior-preserving: last/fail/LEAVE-return/grep-last/try-fail smoke tests + control-flow & exception roast (S04 return/last/loop/while, fail/fail-6e, phasers/in-loop) + t/ suites pass. make test (release) PASS; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)