### PR TITLE
docs(roast): correct S32-str stale entries and refine the 2 Unicode blockers

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -147,16 +147,50 @@
 
 ### 1.6 Unicode / RakuAST / Collation
 
+**前提（2026-06-27 調査）**: mutsu の Unicode 対応は実質完成。
+S15 全 81 ファイル、および tractable な S32-str Unicode 機能
+（fc/flip/comb/tc/tclc/uc/capitalize/samecase/samemark/uniparse/utf8-c8 …）は
+すべて whitelist 済み。未 whitelist の Unicode テストは下記 2 件のみで、
+どちらも大規模サブシステム待ち。新規に着手して通せる tractable な Unicode
+テストは残っていない。
+
 - `S32-str/CollationTest_NON_IGNORABLE-3.t`
   - **難度**: Hard
+  - **根本原因**:
+    1369 中 2 失敗（test 1161, 1171）。ICU4X が BMP センチネル noncharacter を
+    特別扱いする（U+FFFE = primary-ignorable、U+FFFF = max-sentinel）一方、
+    UCA-17/MoarVM は全 noncharacter に codepoint 由来 implicit weight
+    （AAAA=0xFBC0+(cp>>15)）を付与するため。mutsu は符号位置を正しく保持して
+    おり、差異は ICU4X collator 内部のみ。
+  - **依存方針の調査結果**:
+    - `icu_collator`（icu4x）は **完全 pure Rust・C 依存なし**。ICU4C（C ライブラリ）
+      とは別物で、データも Rust crate に同梱（`cargo tree` で確認）。
+      よって「外部 C 依存を減らす」観点では現状すでに問題なし。
+    - 代替（すべて pure Rust）: **feruca**（from-scratch UCA、Unicode16/CLDR46、
+      icu4x より小依存・2-4倍速、spec 準拠なので noncharacter バグは直る見込み／
+      要実測）、collate（成熟度低）、rust_icu（ICU4C bindings = **C 依存が増える**、却下）。
+    - 自前実装の規模 ≒ feruca を作り直す（DUCET データ + contraction/expansion +
+      implicit weight 派生 + sort key 構築、数千行 + 生成データ）。pure Rust の
+      feruca が既にある以上、自前実装の妥当性は低い。
+    - feruca 採用時の **要検証リスク**: 現状の `coll` は icu4x で 3 強度比較して
+      `$*COLLATION` の 4 レベル個別 reverse/disable を合成している。feruca の公開
+      API は `collate()` 一本で per-strength / sort key を露出しないため、
+      `coll` + 非デフォルト `$*COLLATION` の再現が難しい可能性がある。
   - **評価**:
-    2 ケースだけだが、実装は重い。
-    低 ROI という旧評価はそのままでよい。
+    実バグだが正しい修正には DUCET ベースの collation 入れ替え（feruca 移行 or
+    自前実装）が必要で、2 ケースのために大仕事。noncharacter は交換用途では
+    非妥当文字で実害も薄い。低 ROI のため defer。着手するなら feruca を throwaway
+    で実測（noncharacter 修正可否 + coll/$*COLLATION 維持可否）してから判断する。
 - `S32-str/format.t`
   - **難度**: Hard
+  - **現状**: 49 中 26 到達・全 pass。`Format`/`.fmt` は完全実装済みで、
+    test 30-49 相当（List/Seq/Set/Bag/Mix/Map への `.fmt`）も単体では動く。
   - **評価**:
-    本質的には `Formatter.AST` と `RakuAST` 不在の問題。
-    `Format` クラス本体の表面的な修正だけでは whitelist にならない。
+    test 27-29 が `Formatter::Syntax.parse`→Match、`Formatter.CODE`→Callable、
+    `Formatter.AST`→`RakuAST::Node` を要求し、ここで runtime error 中断するため
+    以降が到達不能。本質は **RakuAST サブシステム不在**。参照 raku 本体すら
+    `Format`（6.e）未対応。RakuAST::Node を偽装するのは stub（禁止）なので、
+    RakuAST 本実装なしには whitelist 不可。
 
 ---
 

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -597,22 +597,33 @@
 - [x] roast/S32-str/CollationTest_NON_IGNORABLE-1.t
 - [x] roast/S32-str/CollationTest_NON_IGNORABLE-2.t
 - [ ] roast/S32-str/CollationTest_NON_IGNORABLE-3.t
-      2 of 1369 fail: noncharacters U+FFF0/U+FFFE and U+FFFF/U+1FFFE. ICU4X
-      treats the noncharacters as primary-ignorable, so the comparison falls
-      through to the trailing codepoint; UCA-17/MoarVM assign implicit primary
-      weights by codepoint. Needs custom implicit-weight handling.
-- [ ] roast/S32-str/comb.t
-  - 8/88 pass (tests 1-6, 20-21). Crashes with "Division by zero" after test 22. Failures: grapheme precomposed/non-precomposed (7-8), comb with regex limit (9-14), regex word matching (15-19), comb list (22). Most failures need `.comb(Regex, limit)` with proper limit handling. Difficulty: Medium
+      2 of 1369 fail (tests 1161, 1171). Both are noncharacter-vs-noncharacter
+      primary comparisons that ICU4X resolves differently from UCA-17/MoarVM:
+        * test 1161 (0xFFF0,0x62) <=> (0xFFFE,0x21): ICU4X treats U+FFFE as
+          primary-IGNORABLE (`Uni.new(0xFFFE).Str unicmp "a"` is Less in mutsu,
+          More in raku), so the comparison falls through to the trailing ASCII
+          codepoint instead of ordering by the noncharacter's implicit weight.
+        * test 1171 (0xFFFF,0x62) <=> (0x1FFFE,0x21): ICU4X gives U+FFFF a
+          MAX-sentinel primary weight, so FFFF sorts AFTER 1FFFE; UCA-17/MoarVM
+          assign implicit weights by codepoint, so FFFF < 1FFFE.
+      Root cause is ICU4X's special handling of the BMP sentinel noncharacters
+      (U+FFFE ignorable, U+FFFF max), which diverges from the UCA implicit-weight
+      rule (AAAA=0xFBC0+(cp>>15)) that MoarVM applies to all noncharacters.
+      mutsu preserves the codepoints correctly; the divergence is purely inside
+      ICU4X's collator. Fixing requires computing UCA implicit weights for
+      noncharacters ourselves and interleaving them with ICU's DUCET weights for
+      assigned characters -- heavy, brittle, and risks regressing the 1367
+      passing cases. Genuinely low-ROI; defer until/unless collation is rebuilt
+      off a self-owned DUCET table. (Difficulty: Hard)
+- [x] roast/S32-str/comb.t (88/88; `.comb(Regex, limit)` + grapheme comb, whitelisted)
 - [ ] roast/S32-str/contains.t
   - Backend resolution now works (`$*RAKU.compiler.backend`) and `.contains` dispatch exists, but test still aborts after first assertion with uncaught `X::OutOfRange` in later cases.
 - [ ] roast/S32-str/encode.t
   - 3/41 pass (2, 4, 7). Basic `.encode` works for ASCII/UTF-8. Failures: return type is not Blob (1), Buf length (3, 5-6), indexing encoded bytes (8-9), cp1252 encoding (10-11). Only 12 tests reached. Difficulty: Medium-High (Buf/Blob types needed)
 - [ ] roast/S32-str/ends-with.t
   - 0/3 pass. `Cool.ends-with` with wrong args hangs (test 1). Other tests use complex test framework syntax. Difficulty: Medium
-- [ ] roast/S32-str/fc.t
-  - 0/12 pass. `.fc` (foldcase) method not implemented. All tests fail. Difficulty: Medium (need Unicode case folding implementation)
-- [ ] roast/S32-str/flip.t
-  - 10/13 pass (1-5, 7-8, 11-13). Failures: test 6 unknown, grapheme precomposed (9), grapheme without precomposed (10). Difficulty: Low (grapheme cluster awareness needed)
+- [x] roast/S32-str/fc.t (12/12; `.fc` foldcase implemented and whitelisted)
+- [x] roast/S32-str/flip.t (13/13; grapheme-aware flip, whitelisted)
 - [ ] roast/S32-str/format.t
   - 26/49 reachable tests pass (was 0). The `Format` class (6.e) is now
     implemented: `Format.new`, `~~ Format`, `.arity`/`.count`, `.Callable`


### PR DESCRIPTION
## Summary

Triage of the Unicode-related roast blockers (`BLOCKERS.md` §1.6/§5.2). Documentation accuracy only — no code change.

`mutsu`'s Unicode support is essentially complete: all 81 S15 tests and all tractable S32-str Unicode features (fc/flip/comb/tc/tclc/uc/capitalize/samecase/samemark/uniparse/utf8-c8/…) pass and are whitelisted. Only two Unicode roast tests remain unwhitelisted, and both are genuinely deep.

### Stale entries fixed

`TODO_roast/S32.md` had ~44 S32-str entries marked `[ ]` that are actually whitelisted and passing. This PR fixes the Unicode-relevant ones:

- `fc.t` — 12/12 (`.fc` foldcase)
- `flip.t` — 13/13 (grapheme-aware)
- `comb.t` — 88/88 (`.comb(Regex, limit)` + grapheme)

### Blocker root-causes refined

- **`CollationTest_NON_IGNORABLE-3.t`** — 2/1369 fail (tests 1161, 1171). ICU4X special-cases the BMP sentinel noncharacters (U+FFFE as primary-ignorable, U+FFFF as a max-sentinel), diverging from the UCA-17/MoarVM rule that gives every noncharacter a codepoint-derived implicit weight (`AAAA=0xFBC0+(cp>>15)`). `mutsu` preserves the codepoints correctly; the divergence is inside ICU4X's collator. A proper fix needs a self-owned UCA implicit-weight computation interleaved with ICU's DUCET weights — heavy, brittle, low-ROI.
- **`format.t`** — `Format`/`.fmt` are fully implemented (tests 1-26 + the 23 `.fmt` tests pass standalone); blocked only at tests 27-29 which require `RakuAST::Node` (`Formatter::Syntax`/`Formatter.CODE`/`Formatter.AST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)