### PR TITLE
refactor(registration): idempotent sub re-registration via compile-time fingerprint (§7 slice 1)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -83,6 +83,14 @@ CP-3 collapse で VM と Interpreter の二重構造は消えた。
 - **宣言登録** (`class`/`role`/`enum`/`sub`/`method` の `register_*_decl`) は依然 tree-walk で実行
   (`Register*` opcode → `register_sub_decl` / `register_class_decl`)。クラスシステム・MRO・role 合成は
   未コンパイル。ただしこれは**宣言の登録**であって本体実行ではない。
+  - **sub 登録の冪等化 (slice 1)**: `RegisterSub` は enclosing frame が走るたびに再実行される
+    (hot routine 内の `my sub` 等) が、宣言が識別不変なら再実行は no-op であるべき。各宣言に
+    コンパイル時 fingerprint (`CompiledCode.sub_fingerprints`) を持たせ、`register_sub_decl` が
+    `SubRegisterOutcome::{Installed, Unchanged}` を返すことで、**識別不変な再登録を `FunctionDef`
+    再導出なしに O(1) で検出し、resolution cache を乱さない**よう型で明示した。
+  - **残 (次スライス)**: ①導出済み `Arc<FunctionDef>` をキャッシュし再 install 時に再利用 (真の
+    「derive once」)。②`my sub` を持つルーチン呼び出しの `snapshot_routine_registry` が registry 全体を
+    deep-clone している → registry を `Arc<FunctionDef>` 化して snapshot を O(1) 共有にする。
 - **メソッド dispatch の resolver オーバーヘッド**: multi/submethod や `samewith`/`nextsame` は
   `run_instance_method` (resolve + frame setup) を**入口として**通る (本体は compiled)。`MUTSU_VM_STATS` の
   `resolver-path method dispatches` カウンタはこの dispatch 入口数を測る (tree-walk 実行ではない)。
@@ -173,14 +181,21 @@ env 変異は「別スレッドからの並行 env アクセスが UB」、alias
 **配列/ハッシュ要素を first-class `ContainerRef` セル化 (Track B) して interior mutability に置換する**ことで
 初めて解消する (高ブラスト半径・別 PR)。
 
-### 2.2 `RuntimeError` god-struct が制御フローをエラーチャネルで運ぶ
+### 2.2 `RuntimeError` god-struct が制御フローをエラーチャネルで運ぶ — **bool→enum 分離は完了、残るは縮小・Box 化**
 
-`RuntimeError` (`value/error.rs`) は本来のエラー情報に加え、
-`is_return/is_last/is_next/is_redo/is_goto/is_proceed/is_succeed/is_fail/is_take/is_emit/...`
-**制御フロー bool を 18 個超**同居させる。`return`/`last`/`next`/`take`/`emit` を `Result::Err` で実装しており、
-エラーと制御が型レベルで混線。構造体肥大のため `#[allow(clippy::result_large_err)]` が **23 箇所**に散在。
-**改善**: `enum Control { Return, Last, Next, Take(Value), Emit(Value), ... }` を分離し
-`RuntimeError` を純エラーに縮小・Box 化。
+`RuntimeError` (`value/error.rs`) は `return`/`last`/`next`/`take`/`emit`/... を `Result::Err` で
+実装しており、エラーと制御が同じチャネルを流れる。かつては
+`is_return/is_last/.../is_emit` の**制御フロー bool が 18 個超**同居していたが、§7-4 キャンペーン
+(#3701 slice 1 / #3706 slice 2 / slice 3) で**単一の `enum Control` (`value/error.rs`) へ統合済み**。
+いまは `control: Option<Control>` 1 フィールドが排他的な制御シグナルを保持し、各 `is_*()` は
+そこから派生する。残る独立 bool は `fail_handled` (Fail の修飾) と `is_leave`
+(Last と同時成立しうるので enum に畳めない) の 2 つだけで、これらは意図的に分離している。
+
+**残課題**: `RuntimeError` 本体はまだ ~270 バイトと巨大で、`#[allow(clippy::result_large_err)]` が
+**23 箇所**に残る。縮小には (a) cold な routing フィールド
+(`leave_*`/`return_target_callable_id`/`container_name`/`backtrace`/`hint`/parse 用 `code`/`line`/`column`)
+を `Box` した補助構造体へ退避するか、(b) `Result<T, Box<RuntimeError>>` 化する必要がある。
+いずれも構築サイト ~1700・`Result` シグネチャ ~1280 に波及する高 churn 作業で、別 PR 群として実施する。
 
 ---
 
@@ -280,10 +295,10 @@ env 変異は「別スレッドからの並行 env アクセスが UB」、alias
 | 1 | アロケーション abort ガードは **完了** (配列 autoviv・文字列リピート・shaped 宣言・`Buf.allocate`/`reallocate`・§5)。残: Supply worker panic の QUIT 伝播 | 堅牢性 (任意) | 低 |
 | 2 | クロージャに upvalue を導入し env 経由捕捉を撤廃 (PLAN §G Lever 1) | 性能 | 中 |
 | 3 | ローカルスロットにレキシカルスコープを導入 (シャドウ衝突解消) | 正しさ + 設計 | 中 |
-| 4 | 制御フローを `RuntimeError` から `enum Control` へ分離 | 設計 | 中 |
+| 4 | 制御フローを `RuntimeError` から `enum Control` へ分離は **完了** (§2.2・#3701/#3706 ほか)。残: `RuntimeError` 本体の縮小・Box 化で `result_large_err` 23 箇所を撤去 (高 churn・別 PR 群) | 設計 | 中 |
 | 5 | `.^methods`/`.can` の型別リスト: 確認済みドリフトは是正 (Str/Int/List・§4.1)。完全な実ディスパッチ表からの導出は arity-dispatch 非列挙のため別軸 | ドリフト解消 | 中 |
 | 6 | 陳腐化した `unsafe` SAFETY コメント是正は **完了** (§2.1)。残: 配列・ハッシュ要素の `ContainerRef` 化で生ポインタ unsoundness を撤廃 (高ブラスト・別 PR) | 健全性 (UB) | 中 |
-| 7 | 宣言登録の bytecode 化 / method dispatch の resolution caching (multi は #3684 着手) | 設計 + 性能 | 中 |
+| 7 | 宣言登録の bytecode 化: sub 登録の冪等化は **slice 1 着手** (§1.1・`SubRegisterOutcome`+コンパイル時 fingerprint)。残: 導出済み `Arc<FunctionDef>` キャッシュ再利用 + registry の `Arc<FunctionDef>` 化 (snapshot 共有)。method dispatch の resolution caching (multi は #3684 着手) | 設計 + 性能 | 中 |
 | 8 | 一時ファイルを `tmp/` へ (root の `bom-test-*`) / 巨大ファイル分割 (500 行規約) | 衛生 | 低〜中 |
 
 ### Interpreter 除去という長期目標について — **達成 (2026-06)**

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -105,6 +105,33 @@ pub(crate) fn function_body_fingerprint(
     hasher.finish()
 }
 
+/// Identity fingerprint of a sub *declaration* for idempotent re-registration.
+///
+/// Two executions of the same `RegisterSub` site install structurally identical
+/// declarations; this fingerprint lets the registrar recognize that in O(1) and
+/// skip re-deriving the `FunctionDef`. It extends `function_body_fingerprint`
+/// with the return type and the flags that distinguish otherwise same-bodied
+/// declarations (`multi`/`is rw`/`is raw`), so a genuine change is never mistaken
+/// for a no-op. The name and package are *not* hashed: they are the registry key
+/// the fingerprint is compared under, so they are already known to match.
+pub(crate) fn sub_registration_fingerprint(
+    params: &[String],
+    param_defs: &[ParamDef],
+    body: &[Stmt],
+    return_type: Option<&String>,
+    multi: bool,
+    is_rw: bool,
+    is_raw: bool,
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    function_body_fingerprint(params, param_defs, body).hash(&mut hasher);
+    return_type.hash(&mut hasher);
+    multi.hash(&mut hasher);
+    is_rw.hash(&mut hasher);
+    is_raw.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) enum PhaserKind {
     Begin,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1396,6 +1396,14 @@ pub(crate) struct CompiledCode {
     /// snapshots the whole env instead of just the free vars. Set during
     /// `compute_needs_env_sync`.
     pub(crate) captures_env_by_name: bool,
+    /// Compile-time identity fingerprint for each `Stmt::SubDecl` in `stmt_pool`,
+    /// keyed by its pool index. A `RegisterSub(idx)` opcode re-executes whenever
+    /// its enclosing frame runs (e.g. a `my sub` inside a hot routine), but the
+    /// declaration it installs is constant. The fingerprint lets the registrar
+    /// recognize an idempotent re-registration in O(1) — without re-deriving the
+    /// `FunctionDef` from the AST — and skip perturbing the resolution caches.
+    /// Computed once here at compile time (see `add_stmt`).
+    pub(crate) sub_fingerprints: std::collections::HashMap<u32, u64>,
 }
 
 impl CompiledCode {
@@ -1428,6 +1436,7 @@ impl CompiledCode {
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
             captures_env_by_name: false,
+            sub_fingerprints: std::collections::HashMap::new(),
         }
     }
 
@@ -2204,6 +2213,33 @@ impl CompiledCode {
 
     pub(crate) fn add_stmt(&mut self, stmt: Stmt) -> u32 {
         let idx = self.stmt_pool.len() as u32;
+        // Record a declaration fingerprint for SubDecls so a re-executed
+        // `RegisterSub(idx)` (e.g. a `my sub` inside a hot routine) can be
+        // recognized as an idempotent no-op without re-deriving the FunctionDef.
+        if let Stmt::SubDecl {
+            params,
+            param_defs,
+            body,
+            return_type,
+            multi,
+            is_rw,
+            is_raw,
+            name_expr,
+            ..
+        } = &stmt
+            && name_expr.is_none()
+        {
+            let fp = crate::ast::sub_registration_fingerprint(
+                params,
+                param_defs,
+                body,
+                return_type.as_ref(),
+                *multi,
+                *is_rw,
+                *is_raw,
+            );
+            self.sub_fingerprints.insert(idx, fp);
+        }
         self.stmt_pool.push(stmt);
         idx
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -209,7 +209,7 @@ pub(crate) mod regex;
 pub(crate) mod regex_parse;
 mod registration;
 mod registration_class;
-mod registration_sub;
+pub(crate) mod registration_sub;
 mod registry;
 pub(crate) mod resolution;
 mod run;
@@ -1328,6 +1328,14 @@ pub struct Interpreter {
     /// `lexical_override` check resolves the correct callable). Populated at sub
     /// registration; checked cheaply (guarded by `is_empty()`) on each call.
     pub(crate) amp_param_shadowed_names: std::collections::HashSet<Symbol>,
+    /// Fingerprint of the sub declaration currently installed under each
+    /// `package::name` (single, non-multi) routine key. A re-executed
+    /// `RegisterSub` whose compile-time fingerprint matches the installed one is
+    /// an idempotent no-op (see [`crate::ast::sub_registration_fingerprint`]),
+    /// so the registrar can return early without re-deriving the FunctionDef and
+    /// without invalidating the resolution caches. Entries are best-effort: a
+    /// miss simply takes the full registration path.
+    pub(crate) registered_fn_fingerprints: HashMap<Symbol, u64>,
     pub(crate) method_resolve_cache: HashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
     #[allow(clippy::type_complexity)]
     pub(crate) last_method_resolve: Option<(Symbol, Symbol, String, Arc<MethodDef>)>,
@@ -3503,6 +3511,7 @@ impl Interpreter {
             pos_light_call_cache: HashMap::new(),
             pos_light_call_cache_gen: 0,
             amp_param_shadowed_names: std::collections::HashSet::new(),
+            registered_fn_fingerprints: HashMap::new(),
             method_resolve_cache: HashMap::new(),
             last_method_resolve: None,
             fast_method_cache: HashMap::new(),
@@ -6172,6 +6181,7 @@ impl Interpreter {
             pos_light_call_cache: HashMap::new(),
             pos_light_call_cache_gen: 0,
             amp_param_shadowed_names: std::collections::HashSet::new(),
+            registered_fn_fingerprints: HashMap::new(),
             method_resolve_cache: HashMap::new(),
             last_method_resolve: None,
             fast_method_cache: HashMap::new(),

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -392,6 +392,35 @@ impl Interpreter {
         )
     }
 
+    /// Whether registering a sub named `name` would raise `X::Redeclaration`
+    /// because a conflicting `&name` (e.g. an earlier `my &name`) is already
+    /// bound in the lexical env. Mirrors the env-`&name` check in
+    /// `register_sub_decl_fp`; the idempotent fast path consults it so it never
+    /// short-circuits past a redeclaration error (the registry can hold an
+    /// identical entry from a hoisted pass while a `my &name` declared afterward
+    /// must still make the textual `sub name` a redeclaration).
+    fn sub_decl_would_redeclare(&self, name: &str, is_lexical_hoist: bool) -> bool {
+        let code_var_key = format!("&{}", name);
+        let Some(existing) = self.env.get(&code_var_key) else {
+            return false;
+        };
+        if matches!(existing, Value::Mixin(..)) {
+            return false;
+        }
+        let allow_lexical_shadow = (self.block_scope_depth > 0 || is_lexical_hoist)
+            && !matches!(self.env.get("__mutsu_in_eval"), Some(Value::Bool(true)))
+            && !matches!(
+                self.env.get("__mutsu_eval_wrapped_decls"),
+                Some(Value::Bool(true))
+            );
+        if allow_lexical_shadow {
+            return false;
+        }
+        let is_in_eval = matches!(self.env.get("__mutsu_in_eval"), Some(Value::Bool(true)));
+        let shadows_outer_eval_name = is_in_eval && is_outer_amp_name(&code_var_key);
+        !shadows_outer_eval_name
+    }
+
     /// `register_sub_decl` with an optional compile-time declaration fingerprint
     /// (`site_fingerprint`) enabling the idempotent-reregistration fast path. The
     /// `register_sub_decl` wrapper passes `None` for call sites (EVAL, the
@@ -432,6 +461,7 @@ impl Interpreter {
             && !multi
             && !is_method_value_decl
             && !custom_traits.iter().any(|(t, _)| !t.starts_with("__"))
+            && !self.sub_decl_would_redeclare(name, is_lexical_hoist)
         {
             let fq = format!("{}::{}", self.current_package(), name);
             let fq_sym = Symbol::intern(&fq);

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -3,6 +3,20 @@ use crate::symbol::Symbol;
 use std::cell::RefCell;
 use std::collections::HashSet;
 
+/// Outcome of a `register_sub_decl` call, distinguishing a genuine
+/// (re-)installation from an idempotent no-op re-registration of an already
+/// present, structurally identical declaration. The VM uses this to decide
+/// whether the resolution caches must be invalidated: an `Unchanged` outcome
+/// means the registry is exactly as it was, so the caches stay valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubRegisterOutcome {
+    /// The declaration was (re-)derived and installed; resolution state changed.
+    Installed,
+    /// An identical declaration was already installed under this key; nothing
+    /// was derived or installed beyond refreshing the routine's callable id.
+    Unchanged,
+}
+
 thread_local! {
     /// Stack (for nested EVALs) of the `&name` code-variable keys that already
     /// existed in the enclosing scope when an `EVAL` began. A sub declared inside
@@ -360,13 +374,79 @@ impl Interpreter {
         is_test_assertion: bool,
         supersede: bool,
         custom_traits: &[(String, Option<crate::ast::Expr>)],
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<SubRegisterOutcome, RuntimeError> {
+        self.register_sub_decl_fp(
+            name,
+            params,
+            param_defs,
+            return_type,
+            associativity,
+            body,
+            multi,
+            is_rw,
+            is_raw,
+            is_test_assertion,
+            supersede,
+            custom_traits,
+            None,
+        )
+    }
+
+    /// `register_sub_decl` with an optional compile-time declaration fingerprint
+    /// (`site_fingerprint`) enabling the idempotent-reregistration fast path. The
+    /// `register_sub_decl` wrapper passes `None` for call sites (EVAL, the
+    /// interpreter run path) where the fast path does not apply.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn register_sub_decl_fp(
+        &mut self,
+        name: &str,
+        params: &[String],
+        param_defs: &[ParamDef],
+        return_type: Option<&String>,
+        associativity: Option<&String>,
+        body: &[Stmt],
+        multi: bool,
+        is_rw: bool,
+        is_raw: bool,
+        is_test_assertion: bool,
+        supersede: bool,
+        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        site_fingerprint: Option<u64>,
+    ) -> Result<SubRegisterOutcome, RuntimeError> {
         let is_method_value_decl = custom_traits
             .iter()
             .any(|(t, _)| t == "__mutsu_method_decl");
         let allow_redeclare = supersede || is_method_value_decl;
         let is_our_scoped = custom_traits.iter().any(|(t, _)| t == "__our_scoped");
         let is_lexical_hoist = custom_traits.iter().any(|(t, _)| t == "__lexical_hoist");
+        // Idempotent re-registration fast path. A `RegisterSub` re-executes every
+        // time its enclosing frame runs (e.g. a `my sub` inside a hot routine),
+        // but the declaration it installs is constant. When a structurally
+        // identical single (non-multi) sub with no user-visible traits is already
+        // installed under this key, there is nothing to re-derive: refresh the
+        // routine's callable id and return `Unchanged` so the caller leaves the
+        // resolution caches intact. The `contains_key` guard keeps this correct
+        // across block-scope restoration (a `my sub` removed when its scope exits
+        // misses here and takes the full path).
+        if let Some(site_fp) = site_fingerprint
+            && !multi
+            && !is_method_value_decl
+            && !custom_traits.iter().any(|(t, _)| !t.starts_with("__"))
+        {
+            let fq = format!("{}::{}", self.current_package(), name);
+            let fq_sym = Symbol::intern(&fq);
+            if self.registered_fn_fingerprints.get(&fq_sym) == Some(&site_fp)
+                && self.registry().functions.contains_key(&fq_sym)
+            {
+                let callable_key =
+                    format!("__mutsu_callable_id::{}::{}", self.current_package(), name);
+                self.env.insert(
+                    callable_key,
+                    Value::Int(crate::value::next_instance_id() as i64),
+                );
+                return Ok(SubRegisterOutcome::Unchanged);
+            }
+        }
         Self::validate_callable_param_return_redeclaration(param_defs)?;
         if let Some(spec) = return_type
             && self.is_definite_return_spec(spec)
@@ -521,7 +601,7 @@ impl Interpreter {
                     callable_key,
                     Value::Int(crate::value::next_instance_id() as i64),
                 );
-                return Ok(());
+                return Ok(SubRegisterOutcome::Unchanged);
             }
             // When re-registering a hoisted sub with custom traits, skip redeclaration
             // checks but don't return early — fall through to apply trait_mod:<is>.
@@ -539,7 +619,7 @@ impl Interpreter {
                         callable_key,
                         Value::Int(crate::value::next_instance_id() as i64),
                     );
-                    return Ok(());
+                    return Ok(SubRegisterOutcome::Unchanged);
                 }
             }
         }
@@ -626,9 +706,19 @@ impl Interpreter {
             }
         } else {
             let fq = format!("{}::{}", self.current_package(), name);
-            self.registry_mut()
-                .functions
-                .insert(Symbol::intern(&fq), def);
+            let fq_sym = Symbol::intern(&fq);
+            self.registry_mut().functions.insert(fq_sym, def);
+            // Record this declaration's fingerprint so a later re-execution of the
+            // same `RegisterSub` site is recognized as an idempotent no-op. Reuse
+            // the compile-time `site_fingerprint` rather than recomputing it here:
+            // the recomputation would `Debug`-format the body on every install,
+            // which (for a `my sub` whose lexical scope is snapshot/restored each
+            // enclosing call) is exactly the per-call cost this is meant to avoid.
+            if let Some(fp) = site_fingerprint {
+                self.registered_fn_fingerprints.insert(fq_sym, fp);
+            } else {
+                self.registered_fn_fingerprints.remove(&fq_sym);
+            }
         }
         // If this is an our-scoped sub, also store it in the persistent our_scoped_functions
         // so it survives block scope restoration.
@@ -740,7 +830,7 @@ impl Interpreter {
                 }
             }
         }
-        Ok(())
+        Ok(SubRegisterOutcome::Installed)
     }
 
     /// Resolve a name to a type object (Package value) if the name refers to a known class or role.

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -540,8 +540,12 @@ impl Interpreter {
             } else {
                 name.resolve()
             };
-            self.loan_env_for(|i| {
-                i.register_sub_decl(
+            // Compile-time declaration fingerprint for this site (absent for a
+            // runtime-resolved `name_expr` sub), enabling the idempotent
+            // re-registration fast path inside `register_sub_decl_fp`.
+            let site_fp = code.sub_fingerprints.get(&idx).copied();
+            let outcome = self.loan_env_for(|i| {
+                i.register_sub_decl_fp(
                     &resolved_name,
                     params,
                     param_defs,
@@ -554,65 +558,77 @@ impl Interpreter {
                     *is_test_assertion,
                     *supersede,
                     custom_traits,
+                    site_fp,
                 )
             })?;
-            // If this sub carries the `is native(...)` trait, record its C-FFI
-            // descriptor so calls route through NativeCall instead of the body.
-            if custom_traits.iter().any(|(t, _)| t == "native") {
-                self.register_native_call_sub(
-                    &resolved_name,
-                    param_defs,
-                    return_type.as_ref(),
-                    custom_traits,
-                )?;
-            }
-            self.fn_resolve_gen += 1;
-            self.method_resolve_cache.clear();
-            self.last_method_resolve = None;
-            self.fast_method_cache.clear();
-            self.multi_resolve_cache.clear();
-            self.multi_type_cacheable.clear();
-            // Record `&`-sigil parameter names so calls to a same-named routine
-            // inside this sub bypass the name-keyed light-call caches (the param
-            // can shadow a package sub of the same name).
-            for pd in param_defs {
-                if let Some(bare) = pd.name.strip_prefix('&')
-                    && !bare.is_empty()
-                {
-                    // Records both plain names (`foo`) and operator categories
-                    // (`infix:<@@>`); both can shadow a same-named package routine.
-                    self.amp_param_shadowed_names.insert(Symbol::intern(bare));
-                }
-            }
-            if *is_export && !self.suppress_exports {
-                let pkg = self.current_package().to_string();
-                self.register_exported_sub(pkg.clone(), resolved_name.clone(), export_tags.clone());
-                // If a custom `is` trait mixed a role into this routine, the
-                // resulting Mixin lives in the lexical env as `&name` but would
-                // be dropped when the module scope exits. Capture it so `import`
-                // can restore the trait-modified value.
-                let code_var_key = format!("&{}", resolved_name);
-                if let Some(val @ Value::Mixin(..)) = self.env().get(&code_var_key) {
-                    self.record_exported_sub_value(pkg, resolved_name.clone(), val.clone());
-                }
-            }
-            for (alt_params, alt_param_defs) in signature_alternates {
-                self.loan_env_for(|i| {
-                    i.register_sub_decl(
+            // An idempotent re-registration of an already-installed identical sub
+            // leaves the registry untouched, so none of the install bookkeeping
+            // below (cache invalidation, `&`-param shadow tracking, export, native
+            // descriptor, signature alternates) needs to re-run — they were all
+            // done by the first installation and persist.
+            if outcome == crate::runtime::registration_sub::SubRegisterOutcome::Installed {
+                // If this sub carries the `is native(...)` trait, record its C-FFI
+                // descriptor so calls route through NativeCall instead of the body.
+                if custom_traits.iter().any(|(t, _)| t == "native") {
+                    self.register_native_call_sub(
                         &resolved_name,
-                        alt_params,
-                        alt_param_defs,
+                        param_defs,
                         return_type.as_ref(),
-                        associativity.as_ref(),
-                        body,
-                        *multi,
-                        *is_rw,
-                        *is_raw,
-                        *is_test_assertion,
-                        *supersede,
                         custom_traits,
-                    )
-                })?;
+                    )?;
+                }
+                self.fn_resolve_gen += 1;
+                self.method_resolve_cache.clear();
+                self.last_method_resolve = None;
+                self.fast_method_cache.clear();
+                self.multi_resolve_cache.clear();
+                self.multi_type_cacheable.clear();
+                // Record `&`-sigil parameter names so calls to a same-named routine
+                // inside this sub bypass the name-keyed light-call caches (the param
+                // can shadow a package sub of the same name).
+                for pd in param_defs {
+                    if let Some(bare) = pd.name.strip_prefix('&')
+                        && !bare.is_empty()
+                    {
+                        // Records both plain names (`foo`) and operator categories
+                        // (`infix:<@@>`); both can shadow a same-named package routine.
+                        self.amp_param_shadowed_names.insert(Symbol::intern(bare));
+                    }
+                }
+                if *is_export && !self.suppress_exports {
+                    let pkg = self.current_package().to_string();
+                    self.register_exported_sub(
+                        pkg.clone(),
+                        resolved_name.clone(),
+                        export_tags.clone(),
+                    );
+                    // If a custom `is` trait mixed a role into this routine, the
+                    // resulting Mixin lives in the lexical env as `&name` but would
+                    // be dropped when the module scope exits. Capture it so `import`
+                    // can restore the trait-modified value.
+                    let code_var_key = format!("&{}", resolved_name);
+                    if let Some(val @ Value::Mixin(..)) = self.env().get(&code_var_key) {
+                        self.record_exported_sub_value(pkg, resolved_name.clone(), val.clone());
+                    }
+                }
+                for (alt_params, alt_param_defs) in signature_alternates {
+                    self.loan_env_for(|i| {
+                        i.register_sub_decl(
+                            &resolved_name,
+                            alt_params,
+                            alt_param_defs,
+                            return_type.as_ref(),
+                            associativity.as_ref(),
+                            body,
+                            *multi,
+                            *is_rw,
+                            *is_raw,
+                            *is_test_assertion,
+                            *supersede,
+                            custom_traits,
+                        )
+                    })?;
+                }
             }
             // Note: we intentionally do NOT push the Sub onto the stack or
             // store it in env here. The interpreter's trailing_sub_value

--- a/t/nested-sub-reregistration.t
+++ b/t/nested-sub-reregistration.t
@@ -1,0 +1,65 @@
+use Test;
+
+# A `my sub` declared inside a routine re-executes its RegisterSub opcode on
+# every call to the enclosing routine. The registrar recognizes the structurally
+# identical re-registration as an idempotent no-op (compile-time fingerprint),
+# which must not change the observable behaviour: each invocation still sees a
+# fresh lexical scope, captures the right outer values, and the inner sub stays
+# lexically scoped.
+
+plan 12;
+
+# Captured outer value is per-call, not frozen at first registration.
+sub outer($n) {
+    my sub helper() { $n * 2 }
+    helper();
+}
+is outer(5), 10, 'nested sub captures per-call $n (first call)';
+is outer(7), 14, 'nested sub captures per-call $n (second call)';
+is outer(5), 10, 're-registration is idempotent, captures still correct';
+
+# Loop body: each iteration's nested sub captures that iteration's value.
+my @r;
+for 1..3 -> $i {
+    my sub h() { $i }
+    @r.push(h());
+}
+is @r.join(','), '1,2,3', 'loop-local nested sub captures per-iteration value';
+
+# Recursion through a nested sub across repeated enclosing calls.
+sub fact-outer($n) {
+    my sub fact($x) { $x <= 1 ?? 1 !! $x * fact($x - 1) }
+    fact($n);
+}
+is fact-outer(5), 120, 'recursive nested sub works (first call)';
+is fact-outer(6), 720, 'recursive nested sub works (repeated call)';
+
+# Mutual recursion relies on the hoisted registration being visible before the
+# textual position of the second sub.
+sub mutual($n) {
+    my sub is-even($x) { $x == 0 ?? True  !! is-odd($x - 1) }
+    my sub is-odd($x)  { $x == 0 ?? False !! is-even($x - 1) }
+    is-even($n);
+}
+ok mutual(4),  'mutually recursive nested subs (even)';
+nok mutual(7), 'mutually recursive nested subs (odd)';
+
+# The inner sub must remain lexically scoped — not leak to the outer scope.
+sub scoped() {
+    my sub secret() { 42 }
+    secret();
+}
+is scoped(), 42, 'nested sub is callable inside its scope';
+my $leaked = try { secret() };
+nok $leaked.defined, 'nested sub does not leak out of its scope';
+
+# A re-registered nested sub returning a closure: the returned closures from
+# different calls capture different scopes.
+sub make-adder($base) {
+    my sub adder($x) { $base + $x }
+    &adder;
+}
+my $add10 = make-adder(10);
+my $add100 = make-adder(100);
+is $add10(5), 15, 'closure from first registration keeps its scope';
+is $add100(5), 105, 'closure from later registration has its own scope';


### PR DESCRIPTION
## What

ANALYSIS §7 row 7 (「宣言登録の bytecode 化」) slice 1, plus recording §7-4 (enum Control) as complete.

A `RegisterSub` opcode re-executes every time its enclosing frame runs — a `my sub` inside a hot routine re-registers on **every call**. The registrar previously re-derived the `FunctionDef` from the AST (auto-signature detection, `Debug`-format body comparison) and bumped `fn_resolve_gen` + cleared all five resolution caches on every such re-execution, even when the declaration was structurally identical to the one already installed.

This makes the **"re-registration of an unchanged declaration is a no-op"** property explicit in the architecture rather than rediscovering it per call.

## How

- Each `Stmt::SubDecl` carries a compile-time identity fingerprint (`CompiledCode.sub_fingerprints`, computed once in `add_stmt` via the new `ast::sub_registration_fingerprint`).
- `register_sub_decl` now returns `SubRegisterOutcome::{Installed, Unchanged}`. An `Unchanged` outcome means the registry is exactly as it was, so `exec_register_sub_op` leaves the resolution caches (and `&`-param shadow tracking, export, signature alternates) intact instead of re-running them.
- The idempotent fast path recognizes a structurally identical, still-present single sub in O(1) via the fingerprint side-map (`registered_fn_fingerprints`), **without re-deriving the FunctionDef**. The `contains_key` guard keeps it correct across block-scope restoration (a `my sub` removed when its scope exits misses and takes the full path).

## Why this shape (architecture, not micro-opt)

The goal is the **derive-once / idempotent-install** principle expressed in the type system. `SubRegisterOutcome` and the compile-time declaration identity are the foundation for the documented next slices:

1. Cache the derived `Arc<FunctionDef>` so even a re-install (after lexical-scope snapshot/restore removes the entry) reuses it rather than re-deriving.
2. Make the routine registry hold `Arc<FunctionDef>` so `snapshot_routine_registry` (deep-cloned per call for `my sub` scoping) becomes an O(1) Arc share.

## Tests

- New `t/nested-sub-reregistration.t` (12 subtests): per-call capture, loop-local capture, recursion, mutual recursion, lexical scoping (no leak), and per-registration closure scopes — all confirmed against `raku`.
- `make test`: PASS (Files=1247, Tests=12416; cargo `470 passed; 0 failed`).
- Spot-checked roast: `S06-multi/lexical-multis.t`, `S06-routine-modifiers/scoped-named-subs.t`, `S11-modules/export.t`, `S11-modules/import-multi.t`, `S06-other/main-usage.t` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)