### PR TITLE
docs(roast): record misc.t triage and test 167 completion

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -125,8 +125,28 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 129/180 pass (plan 182). This is a very broad compile-time-error/exception file
-    covering ~40 distinct features.
+  - 153/180 pass (plan 182; 27 fail, 2 not-run). This is a very broad
+    compile-time-error/exception file covering ~40 distinct features.
+  - **2026-06-27 (PR #3710): test 167 done** — a bare *type-only* parameter
+    naming an undeclared type (`sub x(RT123926Floo)`) is now
+    X::Parameter::InvalidType (attr `typename`). `validate_param_type_constraints`
+    previously skipped every `__`-prefixed synthetic param, including
+    `__type_only__`; now only genuine literal-value params (`__literal__`) are
+    skipped. Enum value names declared in the same unit are collected so they are
+    valid value-params AND offered as did-you-mean suggestions; built-in enum
+    values (`LittleEndian`, `Less`, ... in the global base) and value-terms
+    (`Inf`/`NaN`/`True`/`False`/`Empty`) are recognised so they are not rejected.
+    t/param-invalid-type-suggestions.t.
+  - **Triage 2026-06-27 — remaining 27 are all deep / fuzzy / rakudo-todo; no
+    clean single-test win left.** Best coherent clusters if revisited:
+    X::Comp::Group (5: compiler must group multiple compile sorrows/panics) and
+    sink-warning source-format (5: needs literal source text threaded through the
+    AST — 600+ `Expr::Literal` sites). Others: class-registry-leak BadType (48/49
+    — `my package A` from an earlier EVAL leaks into the global type namespace),
+    custom `⟨ ⟩` circumfix FailGoal (21/22), bare-`ord.method` X::Obsolete (37 —
+    needs 0-ary-term vs argful-listop distinction), `&[unknownop]` (27 — parse-time
+    operator-table check), backtrace frame count (157/161), parametric-role
+    metamodel (166), rakudo-todo (149/150).
   - **2026-06-26 compile-time undeclared-symbol campaign (5 PRs):** enum paren bare
     terms `enum E (Cat,Dog)`→X::Undeclared::Symbols (#3641); `is export(WTF)` bare
     tag→X::Undeclared::Symbols (#3642); `enum E (X=>1); class X{}`→X::Redeclaration
@@ -164,8 +184,8 @@
     102 (`.map: * xx 2` — Whatever-currying treats `* xx 2` as callable; blocked on
     the whatever.t track), 105 (`my $x :a` → X::Syntax::Adverb, undetected),
     107 (`$bar:D` smiley on an untyped param → X::Parameter::InvalidType typename
-    'D', silently accepted), 167 (undeclared bareword param type with enum-value
-    suggestions). t/typed-exceptions-misc.t.
+    'D', silently accepted). t/typed-exceptions-misc.t.
+    (167 done — PR #3710, see the 2026-06-27 note above.)
   - Done: "Useless use of X in sink context" warnings (tests 111-120,
     122-138 — the bulk of the 111-142 cluster). New parser post-pass
     `parser::sink_warn` walks the mainline (all-sink) statement list, recursing


### PR DESCRIPTION
Updates the `S32-exceptions/misc.t` ledger in `TODO_roast/S32.md`:

- **test 167 done** (PR #3710): bare type-only parameter type-name validation with enum-value did-you-mean suggestions.
- **2026-06-27 triage** of the remaining 27 failures: all deep / fuzzy / rakudo-todo, no clean single-test win left. Best coherent clusters if revisited are X::Comp::Group (5) and sink-warning source-format (5, needs literal source text through the AST).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)