### PR TITLE
fix(subscript): zen slice with a subscript adverb (@a[]:k) works

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -2280,6 +2280,23 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     rest = after;
                     continue;
                 }
+                // `@a[]:k` / `:v` / `:kv` / `:p` (and `:delete`): a zen slice
+                // carrying a subscript adverb returns all keys/values just like
+                // the whatever slice `@a[*]:adverb`, so model the empty subscript
+                // as a Whatever index and let the adverb block below build the
+                // `__mutsu_subscript_adverb` call. Without this the `[]` would be
+                // dropped and the adverb mis-parsed as a colonpair argument.
+                if parse_subscript_adverb_with_expr(r_adv).is_some()
+                    || parse_delete_adverb(r_adv).is_some()
+                {
+                    expr = Expr::Index {
+                        target: Box::new(expr),
+                        index: Box::new(Expr::Whatever),
+                        is_positional: true,
+                    };
+                    rest = after;
+                    continue;
+                }
                 rest = after;
                 continue;
             }

--- a/t/zen-slice-adverbs.t
+++ b/t/zen-slice-adverbs.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 12;
+
+# A zen slice (empty subscript `@a[]`) carrying a subscript adverb behaves like
+# the whatever slice `@a[*]:adverb`: it yields all keys/values/pairs. Previously
+# `@a[]:k` dropped the `[]` and mis-parsed `:k` as a colonpair argument.
+
+my @a = <a b c d>;
+
+is-deeply (@a[]:k),  (0, 1, 2, 3),                          'zen slice :k → all keys';
+is-deeply (@a[]:v),  ("a", "b", "c", "d"),                  'zen slice :v → all values';
+is-deeply (@a[]:kv), (0, "a", 1, "b", 2, "c", 3, "d"),      'zen slice :kv';
+is-deeply (@a[]:p),  (0 => "a", 1 => "b", 2 => "c", 3 => "d"), 'zen slice :p';
+is-deeply (@a[]:!k), (0, 1, 2, 3),                          'zen slice :!k';
+is-deeply (@a[]:!v), ("a", "b", "c", "d"),                  'zen slice :!v';
+
+# Conditional adverb argument.
+is-deeply (@a[]:k(True)),  (0, 1, 2, 3),               'zen slice :k(True)';
+is-deeply (@a[]:v(True)),  ("a", "b", "c", "d"),       'zen slice :v(True)';
+
+# A bare zen slice (no adverb) is still the identity on the list.
+is-deeply @a[], @a,                                          'bare zen slice is identity';
+
+# Matches the whatever slice exactly.
+is-deeply (@a[]:k),  (@a[*]:k),  'zen :k matches whatever :k';
+is-deeply (@a[]:v),  (@a[*]:v),  'zen :v matches whatever :v';
+is-deeply (@a[]:kv), (@a[*]:kv), 'zen :kv matches whatever :kv';


### PR DESCRIPTION
## Summary

`@a[]:k` / `:v` / `:kv` / `:p` (and `:delete`) on a **zen slice** (empty subscript) silently dropped the `[]` and left the adverb to be mis-parsed as a colonpair argument. In `is @a[]:k, (0,1,2,3), "..."` that meant `:k` became a named argument to `is`, which aborted the whole test file mid-run.

A zen slice carrying a subscript adverb returns all keys/values/pairs exactly like the whatever slice `@a[*]:adverb`, so this models the empty subscript as a `Whatever` index and lets the existing adverb block build the `__mutsu_subscript_adverb` call. Bare `@a[]` (no adverb) is unchanged (identity on the list).

## Result

On `roast/S32-array/adverbs.t` this removes a fatal mid-file abort — the file now runs all **606** tests instead of stopping at 283 — and fixes the zen-slice value adverbs (~130 more subtests pass). The file is still far from whitelisted (a separate for-loop multi-param binding bug remains), but this is a clean, self-contained correctness fix.

## Tests

- New `t/zen-slice-adverbs.t` (12 assertions).
- `make test` PASS (12428 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)