### PR TITLE
docs(roast): record S32-array/adverbs.t status (zen fix + for-loop blocker)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -1,6 +1,30 @@
 # S32 - arrays, basics, containers, exceptions, hash, io, list, num, scalar, str, temporal
 
 - [ ] roast/S32-array/adverbs.t
+  - 262/606 pass (was: aborted at 283 of 606). Huge subscript-adverb surface
+    (`:k`/`:v`/`:kv`/`:p`/`:exists`/`:delete` with `:!`/`(cond)` variants over
+    single elem / slice / whatever `[*]` / zen `[]`, ×2 for `@n`(Any) and
+    `@s`(Str)).
+  - **2026-06-27 (PR #3713): zen slice with a subscript adverb now works.**
+    `@a[]:k` etc. dropped the `[]` and mis-parsed `:k` as a colonpair arg, so
+    `is @a[]:k, ...` aborted the whole file mid-run. Now modelled as a Whatever
+    index (`@a[*]:adverb`); the file runs all 606 tests and the zen value
+    adverbs pass. t/zen-slice-adverbs.t.
+  - **DOMINANT remaining blocker — for-loop multi-param itemized-array binding
+    (container identity).** The file iterates `for $@n, Any, $@s, Str -> @a, $T`.
+    A multi-param `@`-sigil for-loop param bound from an itemized array (`$@n`)
+    is mis-bound: `@a` becomes a 1-element array `[$@n]` (elems=1) instead of the
+    de-itemized array (elems=4), so every value-needing test (`:v`/`:kv`/`:p`/
+    bare value) yields Nil while key-only `:k` (which just echoes the index)
+    passes. Repro: `for $@n, Any -> @a, $T { say @a.elems }` → 1 (raku: 4).
+    Root: `build_for_bind_stmts` (src/compiler/mod.rs) emits `@a = $_[i]`
+    (assign, which wraps an itemized array). Changing it to `:=` (bind) does NOT
+    fix it — the chunk element `$_[0]` is an *immutable* List in that context, so
+    a fresh `my @b := $_[0]` inside the loop throws "Cannot modify an immutable
+    List". This is the deep for-loop param container-identity area; needs the
+    chunk element to bind as a mutable, de-itemized array. Deferred.
+  - Other clusters after that lands: multi-element slice adverbs, and the
+    X::Adverb error `:what` strings ("whatever slice" / "zen slice" / nogo).
 - [x] roast/S32-array/bool.t
 - [ ] roast/S32-array/create.t
 - [ ] roast/S32-array/delete-adverb-native.t


### PR DESCRIPTION
After PR #3713 (zen slice with a subscript adverb), `roast/S32-array/adverbs.t` runs all 606 tests (262 pass, up from aborting at 283).

Documents the dominant remaining blocker: a **for-loop multi-param `@`-sigil binding from an itemized array** (`for $@n, Any -> @a, $T`) mis-binds `@a` as a 1-element array `[$@n]` (elems=1) instead of the de-itemized array (elems=4), so every value-needing adverb test yields `Nil` while key-only `:k` passes. A `:=` bind does not fix it — the chunk element is an immutable List in that context. This is the deep for-loop container-identity area; deferred.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)