### PR TITLE
fix(for-loop): multi-param @-sigil binding de-itemizes the chunk element

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -616,6 +616,24 @@ impl Compiler {
                 },
                 None => element_expr,
             };
+            // An `@`-sigil multi-param de-itemizes the chunk element: Raku binds
+            // `@a` to the element's *list* (`for $@n, Any -> @a, $T` → `@a` IS the
+            // 4-element array), whereas a plain assignment would wrap an itemized
+            // array as a one-element array (`[$@n]`, elems=1). Coerce via `.list`
+            // so the de-itemized elements flow into the fresh container. (A scalar
+            // param keeps plain assignment + later MarkReadonly; `%`-sigil is left
+            // as plain assignment — `.hash` mis-coerces an itemized hash.)
+            let value_expr = if actual_name.starts_with('@') {
+                Expr::MethodCall {
+                    target: Box::new(value_expr),
+                    name: Symbol::intern("list"),
+                    args: Vec::new(),
+                    modifier: None,
+                    quoted: false,
+                }
+            } else {
+                value_expr
+            };
             let stmt = bind_stmt(actual_name.clone(), value_expr);
             if actual_name == "_" {
                 deferred_topic = Some(stmt);

--- a/t/for-multiparam-array-bind.t
+++ b/t/for-multiparam-array-bind.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 7;
+
+# A multi-param `@`-sigil for-loop parameter de-itemizes the chunk element,
+# just like Raku binds it: `for $@n, Any -> @a, $T` makes `@a` the underlying
+# array (elems=4), not a one-element array wrapping the itemized value (elems=1).
+
+my @n = <a b c d>;
+
+for $@n, Any -> @a, $T {
+    is @a.elems, 4,                 'multi-param @a de-itemizes (elems)';
+    is @a[1], "b",                  'multi-param @a single index';
+    is-deeply @a[1, 2], ("b", "c"), 'multi-param @a slice index';
+    is $T, Any,                     'second param bound';
+}
+
+# Two array params, each de-itemized.
+my @x = <a b>;
+my @y = <c d>;
+for $@x, $@y -> @a, @b {
+    is-deeply (@a[0], @b[1]), ("a", "d"), 'two @-params both de-itemize';
+}
+
+# Single-param binding still works (regression guard).
+for $@n -> @a {
+    is @a.elems, 4,                 'single-param @a de-itemizes';
+}
+
+# Plain flat iteration with two scalar params is unaffected.
+my @pairs = 1, 2, 3, 4;
+my @seen;
+for @pairs -> $p, $q { @seen.push: "$p-$q" }
+is-deeply @seen, ["1-2", "3-4"],    'two scalar params chunk correctly';


### PR DESCRIPTION
## Summary

A multi-param `@`-sigil for-loop parameter bound from an itemized array was mis-bound: `for $@n, Any -> @a, $T` made `@a` a one-element array wrapping the itemized value (`[$@n]`, elems=1) instead of the de-itemized 4-element array, so indexing `@a` (single or slice) yielded `Nil`.

The single-param path already de-itemizes (the VM binds it directly via `param_idx`); only the multi-param path — which emits `@a = $_[i]` bind statements in `build_for_bind_stmts` — was affected, because list assignment treats an itemized array as a single item and wraps it.

Fix: coerce the chunk element through `.list` for `@`-sigil multi-params so the de-itemized elements flow into the fresh container, matching Raku's bind. Scalar params keep plain assignment (+ `MarkReadonly`); `%`-sigil params already de-itemize correctly under plain hash assignment and are left unchanged.

## Result

On `roast/S32-array/adverbs.t` this fixes the dominant blocker — every value-needing adverb test over the `for $@n, Any, $@s, Str -> @a, $T` loop. Combined with the zen-slice adverb fix (#3713, already merged), `adverbs.t` goes from aborting at 283/606 to **518/606 passing (88 failing)**.

## Tests

- New `t/for-multiparam-array-bind.t` (7 assertions).
- `make test` PASS (12445 tests); `S04-statements/for.t` unchanged (9/111, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)