### PR TITLE
fix(subscript): resolve WhateverCode adverb index + typed missing-element default

### DIFF
--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -789,6 +789,19 @@ impl Interpreter {
             ref r if r.is_range() => crate::runtime::utils::value_to_list(r),
             other => vec![other],
         };
+        // Resolve WhateverCode indices (e.g. `@a[*-1]:k`) by applying them to the
+        // target's length, exactly as the plain-value subscript path does.
+        if indices.iter().any(|i| matches!(i, Value::Sub(..))) {
+            let target_len = match &target {
+                Value::Array(items, ..) => items.len() as i64,
+                _ => 0,
+            };
+            for idx in indices.iter_mut() {
+                if matches!(idx, Value::Sub(..)) {
+                    *idx = self.call_sub_value(idx.clone(), vec![Value::Int(target_len)], false)?;
+                }
+            }
+        }
         if matches!(indices.first(), Some(Value::Whatever))
             || matches!(indices.first(), Some(Value::Num(f)) if f.is_infinite() && *f > 0.0)
         {
@@ -815,13 +828,26 @@ impl Interpreter {
                         Value::Hash(map) => Some(map),
                         _ => None,
                     });
-                // Get container default value (from `is default(...)` trait)
-                let container_default = var_name
-                    .as_ref()
-                    .and_then(|name| self.var_default(name).cloned());
-                let type_constraint_default = var_name
-                    .as_ref()
-                    .and_then(|name| self.var_type_constraint(name))
+                // The missing-element default comes from the array's *element
+                // type*. Read it from the container value itself (embedded
+                // metadata / `is default`) FIRST so it survives rebinding — e.g.
+                // `for $@s, Str -> @a { @a[11]:!v }` where the loop variable has
+                // no type constraint but the bound array still carries `.of=Str`.
+                // Fall back to the declared variable's default/type, then Any.
+                let container_default = self.container_default(&target).cloned().or_else(|| {
+                    var_name
+                        .as_ref()
+                        .and_then(|name| self.var_default(name).cloned())
+                });
+                let type_constraint_default = self
+                    .container_type_metadata(&target)
+                    .map(|info| info.value_type)
+                    .filter(|t| !t.is_empty())
+                    .or_else(|| {
+                        var_name
+                            .as_ref()
+                            .and_then(|name| self.var_type_constraint(name))
+                    })
                     .map(|t| Value::Package(Symbol::intern(&t)));
                 let missing_value = container_default
                     .or(type_constraint_default)

--- a/t/subscript-adverb-whatever-missing.t
+++ b/t/subscript-adverb-whatever-missing.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 12;
+
+my @a = <a b c d>;
+
+# A WhateverCode subscript (`*-1`) carrying an adverb resolves the index against
+# the array, exactly like the plain-value subscript `@a[*-1]`.
+is-deeply (@a[*-1]:k),  3,            'WhateverCode index :k → resolved index';
+is-deeply (@a[*-1]:v),  "d",          'WhateverCode index :v → element';
+is-deeply (@a[*-1]:kv), (3, "d"),     'WhateverCode index :kv';
+is-deeply (@a[*-1]:p),  (3 => "d"),   'WhateverCode index :p';
+is-deeply (@a[*-2]:k),  2,            'WhateverCode *-2 :k';
+is-deeply (@a[*-1, *-2]:k), (3, 2),   'WhateverCode slice :k';
+
+# Missing-element keep_missing default reads the array's element type from the
+# container value (survives binding), not just the variable's declared type.
+my Str @s = <a b c d>;
+is-deeply (@s[11]:!v),  Str,          'typed-array missing :!v → element type';
+is-deeply (@s[11]:!kv), (11, Str),    'typed-array missing :!kv';
+is-deeply (@s[11]:!p),  (11 => Str),  'typed-array missing :!p';
+
+# An untyped array's missing default is Any.
+is-deeply (@a[11]:!v),  Any,          'untyped-array missing :!v → Any';
+
+# The same holds when the typed array is the bound loop variable.
+for $@s, Str -> @b, $T {
+    is-deeply (@b[11]:!v), Str,       'bound typed-array missing :!v → element type';
+    is $T, Str,                       'loop type param bound';
+}


### PR DESCRIPTION
## Summary

Two subscript-adverb correctness fixes in `__mutsu_subscript_adverb`:

1. **WhateverCode index + adverb.** `@a[*-1]:k` left the index unresolved, so `:k`/`:v`/`:kv`/`:p` returned empty. Resolve a `Sub` (WhateverCode) index by applying it to the target's length, mirroring the plain-value subscript path (`@a[*-1]` already worked). `@a[*-1]:k` → `3`, `:v` → `"d"`, etc.

2. **Typed missing-element default.** `@a[11]:!v` on a typed array read only the *variable's* declared type, so a bound typed array whose type lives on the container value (`for $@s, Str -> @a { @a[11]:!v }`, where `@a.of` = Str) defaulted to `Any`. Read the element type from the container value first (via `container_type_metadata`), mirroring the Hash branch, so it survives binding.

## Result

On `roast/S32-array/adverbs.t`, the WhateverCode fix takes the file from 88 → 56 failing subtests (on top of the merged #3713 / #3716). The typed-missing fix is correct (proven by t/) but doesn't move adverbs.t further yet — the file's `@s` is built via a `\a` raw param (`gen my Str @s`) which currently loses the element type (`@s.of` = Mu, a separate upstream bug); the fix will apply once that lands.

## Tests

- New `t/subscript-adverb-whatever-missing.t` (12 assertions).
- `make test` PASS (12485 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)