### PR TITLE
docs(roast): update S32-array/adverbs.t status (550/606)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -1,30 +1,35 @@
 # S32 - arrays, basics, containers, exceptions, hash, io, list, num, scalar, str, temporal
 
 - [ ] roast/S32-array/adverbs.t
-  - 262/606 pass (was: aborted at 283 of 606). Huge subscript-adverb surface
+  - 550/606 pass (was: aborted at 283 of 606). Huge subscript-adverb surface
     (`:k`/`:v`/`:kv`/`:p`/`:exists`/`:delete` with `:!`/`(cond)` variants over
     single elem / slice / whatever `[*]` / zen `[]`, ×2 for `@n`(Any) and
     `@s`(Str)).
-  - **2026-06-27 (PR #3713): zen slice with a subscript adverb now works.**
-    `@a[]:k` etc. dropped the `[]` and mis-parsed `:k` as a colonpair arg, so
-    `is @a[]:k, ...` aborted the whole file mid-run. Now modelled as a Whatever
-    index (`@a[*]:adverb`); the file runs all 606 tests and the zen value
-    adverbs pass. t/zen-slice-adverbs.t.
-  - **DOMINANT remaining blocker — for-loop multi-param itemized-array binding
-    (container identity).** The file iterates `for $@n, Any, $@s, Str -> @a, $T`.
-    A multi-param `@`-sigil for-loop param bound from an itemized array (`$@n`)
-    is mis-bound: `@a` becomes a 1-element array `[$@n]` (elems=1) instead of the
-    de-itemized array (elems=4), so every value-needing test (`:v`/`:kv`/`:p`/
-    bare value) yields Nil while key-only `:k` (which just echoes the index)
-    passes. Repro: `for $@n, Any -> @a, $T { say @a.elems }` → 1 (raku: 4).
-    Root: `build_for_bind_stmts` (src/compiler/mod.rs) emits `@a = $_[i]`
-    (assign, which wraps an itemized array). Changing it to `:=` (bind) does NOT
-    fix it — the chunk element `$_[0]` is an *immutable* List in that context, so
-    a fresh `my @b := $_[0]` inside the loop throws "Cannot modify an immutable
-    List". This is the deep for-loop param container-identity area; needs the
-    chunk element to bind as a mutable, de-itemized array. Deferred.
-  - Other clusters after that lands: multi-element slice adverbs, and the
-    X::Adverb error `:what` strings ("whatever slice" / "zen slice" / nogo).
+  - **2026-06-27 — four fixes landed (132 → 550):**
+    - PR #3713: zen slice with a subscript adverb (`@a[]:k`) — the `[]` was
+      dropped and `:k` mis-parsed as a colonpair, aborting the file mid-run; now
+      modelled as a Whatever index. t/zen-slice-adverbs.t.
+    - PR #3716: for-loop multi-param `@`-sigil binding de-itemizes the chunk
+      element (`@a = $_[i].list` instead of plain assign, which wrapped an
+      itemized array as `[$@n]`). t/for-multiparam-array-bind.t.
+    - PR #3717: WhateverCode adverb index (`@a[*-1]:k` resolves `*-1` against the
+      target) + typed missing-element default read from the container value.
+      t/subscript-adverb-whatever-missing.t.
+  - **DOMINANT remaining blocker (≈ all 56) — for-loop multi-param binding is a
+    COPY, not a true ALIAS.** Raku binds `@a` to the *source* `@n` (`@a.VAR.name`
+    = `"@n"`, element type + identity preserved); mutsu's `.list` coercion makes
+    `@a` a fresh copy (`@a.VAR.name` = `"@a"`, `.of`/identity diverge). So the
+    remaining failures are:
+      * X::Adverb `:source(@a.name)` (14) — `.name` is the copy's name, not `@n`.
+      * typed missing-element (~16) — `gen my Str @s` yields `@a.of` = Mu: a
+        typed array declared INLINE as a call argument (`gen my Str @s`) is not
+        tagged with element-type metadata on the container value (separate
+        VarDecl-as-argument bug), and the `.list` copy can't recover it.
+      * "container respected" `:exists`/`:delete`/assign (4) — needs the alias.
+    The real fix is a true alias bind of the multi-param `@`-element, which is
+    blocked by chunk-element immutability: `value_to_list(($@n, Any))` yields an
+    immutable List for `$@n`, so `my @b := $_[0]` inside the loop throws "Cannot
+    modify an immutable List". Deep for-loop container-identity work; deferred.
 - [x] roast/S32-array/bool.t
 - [ ] roast/S32-array/create.t
 - [ ] roast/S32-array/delete-adverb-native.t


### PR DESCRIPTION
Four fixes landed this session take `roast/S32-array/adverbs.t` from aborting at 283 to **550/606 passing**: zen-slice adverb (#3713), for-loop multi-param de-itemize (#3716), WhateverCode adverb index + typed missing-element default (#3717).

Records the dominant remaining blocker: the for-loop multi-param `@`-binding is a `.list` **copy**, not a true alias to the source `@n`, so the remaining ~56 failures (X::Adverb `:source(@a.name)`, typed missing-element default, container-respected) all need a true alias bind — which is blocked by chunk-element immutability (`value_to_list(($@n, Any))` yields an immutable List). Deep for-loop container-identity work; deferred.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)