### PR TITLE
fix(decl): tag element-type for a typed @-array declared in expr position

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -94,14 +94,20 @@ impl Compiler {
                     }
                     // Tag the container's element-type metadata so `.of` survives
                     // (and the missing-element default is the element type) when a
-                    // typed *array* is declared in EXPRESSION position
+                    // *named* typed array is declared in EXPRESSION position
                     // (`my $x = (my Str @c)`, `gen my Str @s`). The statement-
                     // position VarDecl emits the same `SetVarType`; without it the
-                    // expr path left `@c.of` = Mu. Restricted to boxed-element
-                    // `@`-arrays: native element types (`int`/`num`/`str`) change
-                    // the array storage (would panic in the expr-path auto-vivify),
-                    // and `%`-hash tagging here perturbs `Associative[T]` binding.
+                    // expr path left `@c.of` = Mu. Restrictions:
+                    //   - `@`-arrays only (`%`-hash tagging perturbs `Associative[T]`
+                    //     binding);
+                    //   - boxed element types only (native `int`/`num`/`str` change
+                    //     the array storage and would panic in the auto-vivify here);
+                    //   - NOT anonymous `my Int @` — leaving an anonymous typed
+                    //     array untagged in an argument keeps `Positional[T]`
+                    //     type-capture binding working (a pre-existing limitation
+                    //     where a parameterized Array[T] is rejected by `Positional[T]`).
                     if name.starts_with('@')
+                        && !name.contains("__ANON_ARRAY__")
                         && let Some(tc) = type_constraint
                         && !crate::runtime::native_types::is_native_array_element_type(tc)
                     {

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -92,6 +92,22 @@ impl Compiler {
                             has_arg: trait_arg.is_some(),
                         });
                     }
+                    // Tag the container's element-type metadata so `.of` survives
+                    // (and the missing-element default is the element type) when a
+                    // typed *array* is declared in EXPRESSION position
+                    // (`my $x = (my Str @c)`, `gen my Str @s`). The statement-
+                    // position VarDecl emits the same `SetVarType`; without it the
+                    // expr path left `@c.of` = Mu. Restricted to boxed-element
+                    // `@`-arrays: native element types (`int`/`num`/`str`) change
+                    // the array storage (would panic in the expr-path auto-vivify),
+                    // and `%`-hash tagging here perturbs `Associative[T]` binding.
+                    if name.starts_with('@')
+                        && let Some(tc) = type_constraint
+                        && !crate::runtime::native_types::is_native_array_element_type(tc)
+                    {
+                        let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    }
                     // Read back the coerced value (SetGlobal coerces list->hash for %)
                     let name_idx2 = self.code.add_constant(Value::str(name.clone()));
                     if name.starts_with('@') {

--- a/t/typed-container-decl-in-expr.t
+++ b/t/typed-container-decl-in-expr.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 5;
+
+# A typed @-array declared in EXPRESSION position (assignment RHS, call
+# argument) must tag its element-type metadata, so `.of` survives — the same as
+# a statement-position declaration. Previously these reported `.of` = Mu.
+
+my $x = (my Str @c);
+is @c.of, Str, 'typed @-array declared in assignment RHS keeps .of';
+
+sub id(\a) { a }
+id(my Str @d);
+is @d.of, Str, 'typed @-array passed as a call argument keeps .of';
+
+# Element-type drives the missing-element subscript-adverb default.
+is-deeply (@c[5]:!v), Str, 'missing-element :!v uses the element type';
+
+# A raw-param mutator (the roast `gen` idiom) preserves the type.
+sub gen(\a) { a[0] = 'x' }
+gen my Str @e;
+is @e.of, Str, 'typed @-array inline-declared as arg to a raw-param sub keeps .of';
+
+# Statement-position still works (regression guard).
+my Str @f;
+is @f.of, Str, 'statement-position typed @-array keeps .of';


### PR DESCRIPTION
## Summary

A typed `@`-array declared in **expression position** — assignment RHS or a call argument (`my $x = (my Str @c)`, `gen my Str @s`) — did not tag its element-type metadata, so `@c.of` was `Mu` instead of `Str`. The statement-position `VarDecl` emits `SetVarType`; the `compile_expr_do_stmt` container path applied only the `is default` trait. Now it emits `SetVarType` too.

Restricted to boxed-element `@`-arrays:
- native element types (`int`/`num`/`str`) change the array storage and would panic in the expr-path auto-vivify;
- tagging a `%`-hash here perturbs `Associative[T]` binding (caught by `t/assuming-type-capture.t`).

## Result

The roast `gen my Str @s` idiom now yields `@s.of` = Str, so the typed missing-element subscript-adverb default (`@s[11]:!v` → Str) is correct in the `for $@s, Str -> @a, $T` loop. On `roast/S32-array/adverbs.t`, combined with #3719: **576/606 passing** (was 550).

## Tests

- New `t/typed-container-decl-in-expr.t` (5 assertions).
- `make test` PASS (12510 tests); `t/assuming-type-capture.t` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)