### PR TITLE
fix(subscript): lazy subscript adverb auto-truncates out-of-range indices

### DIFF
--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -782,11 +782,23 @@ impl Interpreter {
             keep_missing
         };
 
+        // A lazy subscript (`@a[lazy 11..12]`, materialized to a Seq/LazyList)
+        // auto-truncates at the array end: out-of-range indices are dropped rather
+        // than reported as missing. An eager Range keeps missing elements.
+        let mut truncate_oob = false;
         let mut indices = match index {
             Value::Array(items, ..) => items.to_vec(),
             // A Range subscript on a hash is a multi-key slice (`%h{"b".."c"}:kv`),
             // so expand it to its element keys.
             ref r if r.is_range() => crate::runtime::utils::value_to_list(r),
+            Value::Seq(ref items) => {
+                truncate_oob = true;
+                items.to_vec()
+            }
+            Value::LazyList(ref ll) => {
+                truncate_oob = true;
+                self.force_lazy_list_vm(ll)?
+            }
             other => vec![other],
         };
         // Resolve WhateverCode indices (e.g. `@a[*-1]:k`) by applying them to the
@@ -815,6 +827,18 @@ impl Interpreter {
                     .collect::<Vec<_>>(),
                 _ => Vec::new(),
             };
+        }
+        // Lazy-subscript truncation: keep only in-range indices of the array.
+        if truncate_oob && let Value::Array(items, ..) = &target {
+            let len = items.len() as i64;
+            indices.retain(|idx| match idx {
+                Value::Int(i) => *i >= 0 && *i < len,
+                Value::Num(f) => *f >= 0.0 && (*f as i64) < len,
+                _ => idx
+                    .to_string_value()
+                    .parse::<i64>()
+                    .is_ok_and(|i| i >= 0 && i < len),
+            });
         }
         let is_multi = indices.len() != 1;
 

--- a/t/subscript-adverb-lazy-truncate.t
+++ b/t/subscript-adverb-lazy-truncate.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 8;
+
+# A lazy subscript (`@a[lazy 11..12]`) auto-truncates at the array end: indices
+# past the end are dropped, not reported as missing — so every adverb yields an
+# empty result. An eager out-of-range Range keeps the missing elements.
+
+my Str @a = <a b c d>;
+
+is-deeply  @a[lazy 11..12],      (),   'lazy out-of-range value → empty';
+is-deeply (@a[lazy 11..12]:k),   (),   'lazy out-of-range :k → empty';
+is-deeply (@a[lazy 11..12]:!k),  (),   'lazy out-of-range :!k → empty (truncated, not missing)';
+is-deeply (@a[lazy 11..12]:v),   (),   'lazy out-of-range :v → empty';
+is-deeply (@a[lazy 11..12]:!v),  (),   'lazy out-of-range :!v → empty';
+is-deeply (@a[lazy 11..12]:kv),  (),   'lazy out-of-range :kv → empty';
+
+# A lazy range that is partly in range keeps only the in-range part.
+is-deeply (@a[lazy 2..10]:k),    (2, 3),       'lazy partial range :k keeps in-range indices';
+is-deeply (@a[lazy 2..10]:v),    ("c", "d"),   'lazy partial range :v keeps in-range values';


### PR DESCRIPTION
## Summary

A lazy subscript (`@a[lazy 11..12]`, materialized to a Seq/LazyList index) must auto-truncate at the array end: indices past the end are dropped, not reported as missing, so every adverb (`:k`/`:v`/`:kv`/`:p`, with `:!`/`(cond)`) yields an empty result. `__mutsu_subscript_adverb` did not recognize a Seq/LazyList index — it fell through to the scalar arm and parsed the whole Seq to a single `-1` index, producing bogus `(-1, …)` rows.

Now a Seq/LazyList index is expanded to its element list and (because such an index is lazy) out-of-range indices are dropped; an eager `Range` still keeps its missing elements.

## Result

On `roast/S32-array/adverbs.t`: 30 → **14 failing** (592/606). New `t/subscript-adverb-lazy-truncate.t` (8 assertions, incl. a partly-in-range case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)