### PR TITLE
vm: reference-capture (cell) for read-only scalar upvalues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,19 @@ CI (`make test` + the extensive `make roast` spec suite) gates every merge, and 
 
 The goal is essential architectural improvement, not the appearance of progress through small safe diffs.
 
+### What "gain" and "risk" actually mean (read before weighing any change)
+
+When deciding whether a change is worth it, use these definitions — NOT a vague sense of "effort vs payoff", and NOT micro-perf:
+
+- **Gain (利得)** = moving toward the *correct architecture*: a maintainable, fast interpreter with **no flaky tests** and **better Raku compatibility**. A change that removes a band-aid/fallback, unifies a dual mechanism, or makes a subsystem sound is a gain even if its immediate speedup is modest.
+- **Risk (リスク)** = making the codebase *worse*: introducing **flaky tests**, **reducing Raku compatibility**, **lowering maintainability**, or adding **ad-hoc / band-aid changes**.
+- **A temporary CI/roast failure is NOT a risk.** roast detects it deterministically and you fix it forward. Do not down-weight an architecturally-correct change because it will "break tests for a while" — that is the safety net working, not a cost.
+
+Consequences for design choices:
+
+- Prefer **sound mechanisms that cannot go flaky** over clever optimizations that are correct only under an *incomplete* static analysis. Example: capturing a closure's mutable lexical as a **shared cell** always tracks later mutations, so it never flakes; snapshotting it **by value** is only correct if you can prove the variable is never mutated — and mutsu's compile-time mutation analysis is incomplete (it does not see writes from separately-registered role/class methods, nor rw-arg sinks like `cas`), so a missed case turns into a *flaky* failure (see the `S12-construction/roles-6e.t` regression). The by-value route is therefore the **risky** one and the cell route is the **gain**, even though by-value reads are faster.
+- A known-hard prerequisite (e.g. making `ContainerRef` deref universal, §2.1 / Track B) is itself a **gain** to pursue, not a reason to stop — surfacing its gaps as deterministic roast failures and fixing them *is* the architectural progress.
+
 ## Known flaky tests
 
 Some tests are genuinely non-deterministic (concurrency/timing/CI-load sensitive) and fail intermittently. When a `make roast` / `make test` failure is **only** in the list below and your change is unrelated (e.g. an operator/parser fix), treat it as flaky: re-run the single file a few times before assuming a regression. Do **not** remove it from the whitelist.


### PR DESCRIPTION
## Summary

Makes a closure read its **creator's** lexical binding (not a caller's same-name variable) by reference-capturing read-only scalar upvalues into shared cells — the sound, flaky-free model. Builds on #3715.

## Problem

Phase 1 (#3715) only fast-pathed a read-only scalar upvalue when it was *already* a `ContainerRef` cell; otherwise it read the variable live from env. So a returned closure read whatever same-name variable existed at the call site instead of its creator's binding — `sub ma($x){ -> {$x} }` called where the caller has its own `$x` returned the caller's value (an env-capture bug mutsu shared with the pre-upvalue behavior).

## Fix

`box_upvalue_scalars` boxes the creating frame's **own read-only upvalue scalars** into shared cells at capture time, so `capture_upvalues` captures the cell and the closure reads its creator's binding by index.

Reference capture (a cell) is the **sound** choice: a cell always tracks later mutations, so it can never go flaky. A by-value snapshot is only correct under a complete mutation analysis mutsu does **not** have (it misses writes from separately-registered role/class methods and rw-arg sinks like `cas`) — which is exactly what made `S12-construction/roles-6e.t` flaky when by-value was tried. Only plain-value scalars are boxed; reference/type-object values keep the existing #2749 skip (a type object must not be hidden behind a `ContainerRef`).

## Behavior

- `make-adder($x)` now ignores a caller `$x` — matches Rakudo (Raku compat ↑).
- No flakiness: `roles-6e.t` stable across repeated runs.
- All other closure semantics preserved (container-capture, counter state, loop closures sharing an outer lexical).

## Also

Records the project's working definition of **gain vs risk** in CLAUDE.md (correct architecture / no flaky tests / Raku compat = gain; flakiness / reduced compat / ad-hoc band-aids = risk; a *temporary* roast failure is not a risk — roast catches it).

## Testing

- `t/closure-upvalue.t` (9 subtests, incl. the same-name case)
- `make test` green; `roles-6e.t` stable; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)