### PR TITLE
perf(dispatch): return Arc<FunctionDef> from hot single-result resolvers (§7 slice 3)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -95,9 +95,15 @@ CP-3 collapse で VM と Interpreter の二重構造は消えた。
     プログラムで顕著に軽くなる (200-sub のマイクロベンチで ~28%)。registry は**不変・共有可能な定義**を
     保持する設計になった (in-place 変異サイトは皆無＝`make_mut` 不要)。dispatch 側の戻り値型は
     `FunctionDef` のまま (resolution 境界で `(**arc).clone()`)。
-  - **残 (次スライス)**: 導出済み `Arc<FunctionDef>` をキャッシュし再 install 時に再利用 (真の
-    「derive once」)。dispatch resolution が `Arc<FunctionDef>` を直接返すよう貫通させると
-    resolution ごとの body deep-clone も消せる (より広い波及・別スライス)。
+  - **dispatch resolution への Arc 貫通 (slice 3)**: ホットな単一結果リゾルバ
+    (`resolve_function`/`resolve_function_with_types`/`_with_arity`/`_with_alias`/
+    `choose_best_matching_candidate`) の戻り値を `Option<Arc<FunctionDef>>` 化。**呼び出し毎の
+    resolution が body を deep-clone していたのを Arc bump に**。caller は Deref 経由で読み、所有 FunctionDef
+    が要る数箇所のみ明示 clone。multi 候補列挙 (`resolve_all_*`) と proto/redispatch
+    (`MultiDispatchEntry`) はレアパスなので境界で `FunctionDef` に変換し、core struct への波及を回避。
+  - **残 (次スライス)**: 導出済み `Arc<FunctionDef>` を fingerprint キーでキャッシュし再 install 時に
+    再利用 (真の「derive once」)。`MultiDispatchEntry` も `Arc<FunctionDef>` 化すると redispatch の
+    候補 clone も消える (core struct 波及・別スライス)。
 - **メソッド dispatch の resolver オーバーヘッド**: multi/submethod や `samewith`/`nextsame` は
   `run_instance_method` (resolve + frame setup) を**入口として**通る (本体は compiled)。`MUTSU_VM_STATS` の
   `resolver-path method dispatches` カウンタはこの dispatch 入口数を測る (tree-walk 実行ではない)。
@@ -305,7 +311,7 @@ env 変異は「別スレッドからの並行 env アクセスが UB」、alias
 | 4 | 制御フローを `RuntimeError` から `enum Control` へ分離は **完了** (§2.2・#3701/#3706 ほか)。残: `RuntimeError` 本体の縮小・Box 化で `result_large_err` 23 箇所を撤去 (高 churn・別 PR 群) | 設計 | 中 |
 | 5 | `.^methods`/`.can` の型別リスト: 確認済みドリフトは是正 (Str/Int/List・§4.1)。完全な実ディスパッチ表からの導出は arity-dispatch 非列挙のため別軸 | ドリフト解消 | 中 |
 | 6 | 陳腐化した `unsafe` SAFETY コメント是正は **完了** (§2.1)。残: 配列・ハッシュ要素の `ContainerRef` 化で生ポインタ unsoundness を撤廃 (高ブラスト・別 PR) | 健全性 (UB) | 中 |
-| 7 | 宣言登録の bytecode 化: sub 登録の冪等化 (**slice 1**・`SubRegisterOutcome`+fingerprint) と registry の `Arc<FunctionDef>` 化 (**slice 2**・snapshot を O(n) 共有に) 着手済 (§1.1)。残: 導出済み `Arc<FunctionDef>` キャッシュ再利用 (真の derive-once) + resolution への Arc 貫通。method dispatch の resolution caching (multi は #3684 着手) | 設計 + 性能 | 中 |
+| 7 | 宣言登録の bytecode 化: sub 登録の冪等化 (**slice 1**・`SubRegisterOutcome`+fingerprint) と registry Arc 化 (**slice 2**・snapshot 共有) + dispatch resolution への Arc 貫通 (**slice 3**・resolution 毎の body clone を Arc bump に) 着手済 (§1.1)。残: 導出済み `Arc<FunctionDef>` キャッシュ再利用 (真の derive-once) + `MultiDispatchEntry` の Arc 化。method dispatch の resolution caching (multi は #3684 着手) | 設計 + 性能 | 中 |
 | 8 | 一時ファイルを `tmp/` へ (root の `bom-test-*`) / 巨大ファイル分割 (500 行規約) | 衛生 | 低〜中 |
 
 ### Interpreter 除去という長期目標について — **達成 (2026-06)**

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -510,7 +510,7 @@ impl Interpreter {
             Value::Sub(data) => (data.params.clone(), data.param_defs.clone()),
             Value::Routine { name, .. } => {
                 if let Some(def) = self.resolve_function(&name.resolve()) {
-                    return (def.params, def.param_defs);
+                    return (def.params.clone(), def.param_defs.clone());
                 }
                 if let Some(arity) = Self::inferred_operator_arity(&name.resolve()) {
                     let params = (0..arity).map(|i| format!("arg{}", i)).collect();
@@ -1197,24 +1197,27 @@ impl Interpreter {
         // When pseudo-packages are present (e.g. OUR::, GLOBAL::), also check
         // our_scoped_functions for subs defined in EVAL that don't leak into
         // the regular functions map.
-        let def = self.resolve_function(lookup_name).or_else(|| {
-            if has_packages {
-                let fq = format!("{}::{}", self.current_package(), lookup_name);
-                self.registry()
-                    .our_scoped_functions
-                    .get(&Symbol::intern(&fq))
-                    .cloned()
-                    .or_else(|| {
-                        let global_fq = format!("GLOBAL::{}", lookup_name);
-                        self.registry()
-                            .our_scoped_functions
-                            .get(&Symbol::intern(&global_fq))
-                            .cloned()
-                    })
-            } else {
-                None
-            }
-        });
+        let def = self
+            .resolve_function(lookup_name)
+            .map(|a| (*a).clone())
+            .or_else(|| {
+                if has_packages {
+                    let fq = format!("{}::{}", self.current_package(), lookup_name);
+                    self.registry()
+                        .our_scoped_functions
+                        .get(&Symbol::intern(&fq))
+                        .cloned()
+                        .or_else(|| {
+                            let global_fq = format!("GLOBAL::{}", lookup_name);
+                            self.registry()
+                                .our_scoped_functions
+                                .get(&Symbol::intern(&global_fq))
+                                .cloned()
+                        })
+                } else {
+                    None
+                }
+            });
         let is_multi = if def.is_none() && !self.has_proto(lookup_name) {
             // Check if there are multi-dispatch variants (stored with arity/type suffixes)
             let prefix_local = format!("{}::{}/", self.current_package(), lookup_name);

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -108,7 +108,7 @@ impl Interpreter {
         &self,
         name: &str,
         args: &[Value],
-        defs: &[FunctionDef],
+        defs: &[Arc<FunctionDef>],
     ) -> RuntimeError {
         let arg_types = args
             .iter()
@@ -149,8 +149,8 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: &[Value],
-        candidates: Vec<(String, FunctionDef)>,
-    ) -> Option<FunctionDef> {
+        candidates: Vec<(String, Arc<FunctionDef>)>,
+    ) -> Option<Arc<FunctionDef>> {
         let mut matches = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for (_, def) in candidates {
@@ -205,7 +205,7 @@ impl Interpreter {
                     .then(a.1.1.cmp(&b.1.1))
                     .then(b.1.2.cmp(&a.1.2))
             });
-            let sorted_matches: Vec<FunctionDef> =
+            let sorted_matches: Vec<Arc<FunctionDef>> =
                 ranked.iter().map(|(i, _)| matches[*i].clone()).collect();
             matches = sorted_matches;
         }
@@ -214,7 +214,7 @@ impl Interpreter {
         let best_shape = self.candidate_dispatch_shape(&matches[0]);
         let best_distance = self.candidate_type_distance(args, &matches[0]);
         let best_req_named = Self::candidate_required_named_count(&matches[0]);
-        let tied: Vec<FunctionDef> = matches
+        let tied: Vec<Arc<FunctionDef>> = matches
             .iter()
             .filter(|def| {
                 self.candidate_specificity_rank(def) == best_rank
@@ -240,7 +240,7 @@ impl Interpreter {
         {
             // `is default` trait tie-breaking: if exactly one tied candidate
             // has `is_default`, prefer it over the others.
-            let default_candidates: Vec<&FunctionDef> =
+            let default_candidates: Vec<&Arc<FunctionDef>> =
                 tied.iter().filter(|def| def.is_default).collect();
             if default_candidates.len() == 1 {
                 return Some(default_candidates[0].clone());
@@ -598,7 +598,7 @@ impl Interpreter {
         }
     }
 
-    fn sort_candidates_by_specificity(&self, candidates: &mut [(String, FunctionDef)]) {
+    fn sort_candidates_by_specificity(&self, candidates: &mut [(String, Arc<FunctionDef>)]) {
         candidates.sort_by(|a, b| {
             let a_rank = self.candidate_specificity_rank(&a.1);
             let b_rank = self.candidate_specificity_rank(&b.1);
@@ -610,7 +610,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         arg_values: &[Value],
-    ) -> Option<FunctionDef> {
+    ) -> Option<Arc<FunctionDef>> {
         self.clear_pending_dispatch_error();
         if let Some(def) = self.resolve_function_with_types(name, arg_values) {
             return Some(def);
@@ -633,22 +633,22 @@ impl Interpreter {
         &self,
         name: &str,
         arity: usize,
-    ) -> Option<FunctionDef> {
+    ) -> Option<Arc<FunctionDef>> {
         if name.contains("::") {
             let multi_key = format!("{}/{}", name, arity);
             if let Some(def) = self.registry().functions.get(&Symbol::intern(&multi_key)) {
-                return Some((**def).clone());
+                return Some(def.clone());
             }
             return self
                 .registry()
                 .functions
                 .get(&Symbol::intern(name))
-                .map(|d| (**d).clone());
+                .cloned();
         }
         // Try multi-dispatch with arity first
         let multi_local = format!("{}::{}/{}", self.current_package(), name, arity);
         if let Some(def) = self.registry().functions.get(&Symbol::intern(&multi_local)) {
-            return Some((**def).clone());
+            return Some(def.clone());
         }
         let multi_global = format!("GLOBAL::{}/{}", name, arity);
         if let Some(def) = self
@@ -656,7 +656,7 @@ impl Interpreter {
             .functions
             .get(&Symbol::intern(&multi_global))
         {
-            return Some((**def).clone());
+            return Some(def.clone());
         }
         // Fall back to regular lookup
         self.resolve_function(name)
@@ -666,7 +666,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         arg_values: &[Value],
-    ) -> Option<FunctionDef> {
+    ) -> Option<Arc<FunctionDef>> {
         // Arity counts only positional args, excluding named args (Pair values)
         let arity = arg_values
             .iter()
@@ -677,7 +677,7 @@ impl Interpreter {
                 .registry()
                 .functions
                 .get(&Symbol::intern(name))
-                .map(|d| (**d).clone())
+                .cloned()
             {
                 // Block access to my-scoped (non-our) package items from outside
                 // their declaring package.
@@ -696,7 +696,7 @@ impl Interpreter {
             let untyped_key = format!("{}/{}", name, arity);
             let untyped_key_sym = Symbol::intern(&untyped_key);
             let untyped_m_prefix = format!("{}__m", untyped_key);
-            let mut candidates: Vec<(String, FunctionDef)> = self
+            let mut candidates: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
@@ -706,7 +706,7 @@ impl Interpreter {
                         || **key == untyped_key_sym
                         || ks.starts_with(&untyped_m_prefix)
                 })
-                .map(|(key, def)| (key.resolve(), (**def).clone()))
+                .map(|(key, def)| (key.resolve(), def.clone()))
                 .collect();
             self.sort_candidates_by_specificity(&mut candidates);
             if let Some(def) = self.choose_best_matching_candidate(name, arg_values, candidates) {
@@ -718,7 +718,7 @@ impl Interpreter {
             // not found by the arity-keyed lookup above, so collect them
             // separately (across all arities under `name/`) and dispatch on them.
             let subsig_prefix = format!("{}/", name);
-            let mut subsig_candidates: Vec<(String, FunctionDef)> = self
+            let mut subsig_candidates: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
@@ -726,7 +726,7 @@ impl Interpreter {
                     key.resolve().starts_with(&subsig_prefix)
                         && def.param_defs.iter().any(|p| p.is_capture_subsignature())
                 })
-                .map(|(key, def)| (key.resolve(), (**def).clone()))
+                .map(|(key, def)| (key.resolve(), def.clone()))
                 .collect();
             if !subsig_candidates.is_empty() {
                 self.sort_candidates_by_specificity(&mut subsig_candidates);
@@ -740,7 +740,7 @@ impl Interpreter {
                 .registry()
                 .functions
                 .get(&Symbol::intern(name))
-                .map(|d| (**d).clone())
+                .cloned()
             {
                 if !self.is_my_scoped_package_item(name) {
                     return Some(def);
@@ -776,7 +776,7 @@ impl Interpreter {
                         .registry()
                         .functions
                         .get(&Symbol::intern(&qualified))
-                        .map(|d| (**d).clone())
+                        .cloned()
                     {
                         return Some(def);
                     }
@@ -784,7 +784,7 @@ impl Interpreter {
                     let q_untyped_key = format!("{qualified}/{}", arity);
                     let q_untyped_key_sym = Symbol::intern(&q_untyped_key);
                     let q_untyped_m_prefix = format!("{}__m", q_untyped_key);
-                    let mut q_candidates: Vec<(String, FunctionDef)> = self
+                    let mut q_candidates: Vec<(String, Arc<FunctionDef>)> = self
                         .registry()
                         .functions
                         .iter()
@@ -794,7 +794,7 @@ impl Interpreter {
                                 || **key == q_untyped_key_sym
                                 || ks.starts_with(&q_untyped_m_prefix)
                         })
-                        .map(|(key, def)| (key.resolve(), (**def).clone()))
+                        .map(|(key, def)| (key.resolve(), def.clone()))
                         .collect();
                     self.sort_candidates_by_specificity(&mut q_candidates);
                     if let Some(def) =
@@ -811,7 +811,7 @@ impl Interpreter {
             .registry()
             .functions
             .get(&Symbol::intern(&exact_local))
-            .map(|d| (**d).clone())
+            .cloned()
         {
             return Some(def);
         }
@@ -820,7 +820,7 @@ impl Interpreter {
             .registry()
             .functions
             .get(&Symbol::intern(&exact_global))
-            .map(|d| (**d).clone())
+            .cloned()
         {
             return Some(def);
         }
@@ -831,7 +831,7 @@ impl Interpreter {
             format!("GLOBAL::{}/{}", name, arity),
         ];
         let mut found_multi_candidates = false;
-        let mut candidates: Vec<(String, FunctionDef)> = self
+        let mut candidates: Vec<(String, Arc<FunctionDef>)> = self
             .registry()
             .functions
             .iter()
@@ -839,17 +839,17 @@ impl Interpreter {
                 let ks = key.resolve();
                 ks.starts_with(&prefix_local) || ks.starts_with(&prefix_global)
             })
-            .map(|(key, def)| (key.resolve(), (**def).clone()))
+            .map(|(key, def)| (key.resolve(), def.clone()))
             .collect();
         for key in &generic_keys {
             let key_sym = Symbol::intern(key);
             let m_prefix = format!("{}__m", key);
-            let more: Vec<(String, FunctionDef)> = self
+            let more: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
-                .map(|(k, def)| (k.resolve(), (**def).clone()))
+                .map(|(k, def)| (k.resolve(), def.clone()))
                 .collect();
             if !more.is_empty() {
                 found_multi_candidates = true;
@@ -866,7 +866,7 @@ impl Interpreter {
             format!("{}::{}/", self.current_package(), name),
             format!("GLOBAL::{}/", name),
         ];
-        let mut optional_candidates: Vec<(String, FunctionDef)> = self
+        let mut optional_candidates: Vec<(String, Arc<FunctionDef>)> = self
             .registry()
             .functions
             .iter()
@@ -880,7 +880,7 @@ impl Interpreter {
                         .iter()
                         .any(|p| !p.named && (p.optional_marker || p.default.is_some()))
             })
-            .map(|(k, def)| (k.resolve(), (**def).clone()))
+            .map(|(k, def)| (k.resolve(), def.clone()))
             .collect();
         if !optional_candidates.is_empty() {
             found_multi_candidates = true;
@@ -906,7 +906,7 @@ impl Interpreter {
             format!("{}::{}/", self.current_package(), name),
             format!("GLOBAL::{}/", name),
         ];
-        let mut slurpy_candidates: Vec<(String, FunctionDef)> = self
+        let mut slurpy_candidates: Vec<(String, Arc<FunctionDef>)> = self
             .registry()
             .functions
             .iter()
@@ -918,7 +918,7 @@ impl Interpreter {
                         .iter()
                         .any(|p| p.slurpy || p.is_capture_subsignature())
             })
-            .map(|(k, def)| (k.resolve(), (**def).clone()))
+            .map(|(k, def)| (k.resolve(), def.clone()))
             .collect();
         if !slurpy_candidates.is_empty() {
             found_multi_candidates = true;
@@ -934,7 +934,7 @@ impl Interpreter {
             format!("{}::{name}/", self.current_package()),
             format!("GLOBAL::{name}/"),
         ];
-        let mut any_arity_candidates: Vec<(String, FunctionDef)> = self
+        let mut any_arity_candidates: Vec<(String, Arc<FunctionDef>)> = self
             .registry()
             .functions
             .iter()
@@ -944,7 +944,7 @@ impl Interpreter {
                     .iter()
                     .any(|prefix| ks.starts_with(prefix))
             })
-            .map(|(k, def)| (k.resolve(), (**def).clone()))
+            .map(|(k, def)| (k.resolve(), def.clone()))
             .collect();
         if !any_arity_candidates.is_empty() {
             found_multi_candidates = true;
@@ -1002,12 +1002,12 @@ impl Interpreter {
         for key in &generic_keys {
             let key_sym = Symbol::intern(key);
             let m_prefix = format!("{}__m", key);
-            let mut candidates: Vec<(String, FunctionDef)> = self
+            let mut candidates: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
-                .map(|(k, def)| (k.resolve(), (**def).clone()))
+                .map(|(k, def)| (k.resolve(), def.clone()))
                 .collect();
             candidates.sort_by(|a, b| {
                 let a_has_subsig = a.1.param_defs.iter().any(|p| p.sub_signature.is_some());
@@ -1025,7 +1025,7 @@ impl Interpreter {
                         crate::ast::function_body_fingerprint(&m.params, &m.param_defs, &m.body)
                             == fp
                     }) {
-                        all_matches.push(def);
+                        all_matches.push((*def).clone());
                     }
                 }
             }
@@ -1036,7 +1036,7 @@ impl Interpreter {
             format!("{}::{}/", self.current_package(), name),
             format!("GLOBAL::{}/", name),
         ];
-        let mut slurpy_candidates: Vec<(String, FunctionDef)> = self
+        let mut slurpy_candidates: Vec<(String, Arc<FunctionDef>)> = self
             .registry()
             .functions
             .iter()
@@ -1048,7 +1048,7 @@ impl Interpreter {
                         .iter()
                         .any(|p| p.slurpy || p.is_capture_subsignature())
             })
-            .map(|(k, def)| (k.resolve(), (**def).clone()))
+            .map(|(k, def)| (k.resolve(), def.clone()))
             .collect();
         slurpy_candidates.sort_by(|a, b| a.0.cmp(&b.0));
         for (_, def) in slurpy_candidates {
@@ -1058,7 +1058,7 @@ impl Interpreter {
                 if !all_matches.iter().any(|m: &FunctionDef| {
                     crate::ast::function_body_fingerprint(&m.params, &m.param_defs, &m.body) == fp
                 }) {
-                    all_matches.push(def);
+                    all_matches.push((*def).clone());
                 }
             }
         }
@@ -1070,19 +1070,19 @@ impl Interpreter {
     /// arity or type matching.  Used to build the full candidate list for
     /// callwith(), which may re-dispatch with different arguments.
     pub(crate) fn resolve_all_multi_candidates(&self, name: &str) -> Vec<FunctionDef> {
-        let mut all: Vec<(String, FunctionDef)> = Vec::new();
+        let mut all: Vec<(String, Arc<FunctionDef>)> = Vec::new();
         let prefixes = [
             format!("{}::{}/", self.current_package(), name),
             format!("GLOBAL::{}/", name),
         ];
         let mut seen_fps = Vec::new();
         for prefix in &prefixes {
-            let candidates: Vec<(String, FunctionDef)> = self
+            let candidates: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| k.resolve().starts_with(prefix.as_str()))
-                .map(|(k, def)| (k.resolve(), (**def).clone()))
+                .map(|(k, def)| (k.resolve(), def.clone()))
                 .collect();
             for (key, def) in candidates {
                 let fp =
@@ -1106,7 +1106,7 @@ impl Interpreter {
         // S12-methods/defer-next.t `nextsame + multi + where`). Mirrors the
         // deterministic winner resolution PR-4 added to `push_multi_dispatch_frame`.
         self.sort_candidates_by_specificity(&mut all);
-        all.into_iter().map(|(_, def)| def).collect()
+        all.into_iter().map(|(_, def)| (*def).clone()).collect()
     }
 
     pub(super) fn eval_token_call_values(
@@ -1692,7 +1692,7 @@ impl Interpreter {
             format!("GLOBAL::{}/{}", name, arity),
         ];
         // Collect all candidates (typed + generic) like resolve_function_with_types
-        let mut candidates: Vec<(String, FunctionDef)> = self
+        let mut candidates: Vec<(String, Arc<FunctionDef>)> = self
             .registry()
             .functions
             .iter()
@@ -1700,17 +1700,17 @@ impl Interpreter {
                 let ks = key.resolve();
                 ks.starts_with(&prefix_local) || ks.starts_with(&prefix_global)
             })
-            .map(|(key, def)| (key.resolve(), (**def).clone()))
+            .map(|(key, def)| (key.resolve(), def.clone()))
             .collect();
         for key in &generic_keys {
             let key_sym = Symbol::intern(key);
             let m_prefix = format!("{}__m", key);
-            let more: Vec<(String, FunctionDef)> = self
+            let more: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
                 .filter(|(k, _)| **k == key_sym || k.resolve().starts_with(&m_prefix))
-                .map(|(k, def)| (k.resolve(), (**def).clone()))
+                .map(|(k, def)| (k.resolve(), def.clone()))
                 .collect();
             candidates.extend(more);
         }
@@ -1741,7 +1741,7 @@ impl Interpreter {
                 }
                 continue;
             }
-            remaining.push(cand.clone());
+            remaining.push((**cand).clone());
         }
         remaining
     }
@@ -1761,7 +1761,7 @@ impl Interpreter {
             let untyped_key = format!("{}/{}", name, arity);
             let untyped_key_sym = Symbol::intern(&untyped_key);
             let untyped_m_prefix = format!("{}__m", untyped_key);
-            let mut candidates: Vec<(String, FunctionDef)> = self
+            let mut candidates: Vec<(String, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
@@ -1771,7 +1771,7 @@ impl Interpreter {
                         || **key == untyped_key_sym
                         || ks.starts_with(&untyped_m_prefix)
                 })
-                .map(|(key, def)| (key.resolve(), (**def).clone()))
+                .map(|(key, def)| (key.resolve(), def.clone()))
                 .collect();
             candidates.sort_by(|a, b| {
                 let a_has_where = a.1.param_defs.iter().any(|p| p.where_constraint.is_some());
@@ -1779,11 +1779,12 @@ impl Interpreter {
                 b_has_where.cmp(&a_has_where).then(a.0.cmp(&b.0))
             });
             if let Some(def) = self.choose_best_matching_candidate(name, arg_values, candidates) {
-                return Some(def);
+                return Some((*def).clone());
             }
             return None;
         }
         self.resolve_function_with_types(name, arg_values)
+            .map(|a| (*a).clone())
     }
 
     /// Collect formatted signature lines from multi dispatch candidates.

--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -205,7 +205,7 @@ impl Interpreter {
         if candidates.is_empty()
             && let Some(def) = self.resolve_function("MAIN")
         {
-            candidates.push(def);
+            candidates.push((*def).clone());
         }
         candidates
             .sort_by(|a, b| Self::candidate_specificity(b).cmp(&Self::candidate_specificity(a)));

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -34,14 +34,14 @@ impl Interpreter {
             )
     }
 
-    pub(super) fn resolve_function(&self, name: &str) -> Option<FunctionDef> {
+    pub(super) fn resolve_function(&self, name: &str) -> Option<Arc<FunctionDef>> {
         if name.contains("::") {
             // Try direct lookup first
             if let Some(def) = self
                 .registry()
                 .functions
                 .get(&Symbol::intern(name))
-                .map(|d| (**d).clone())
+                .cloned()
             {
                 return Some(def);
             }
@@ -63,7 +63,7 @@ impl Interpreter {
                         .registry()
                         .functions
                         .get(&Symbol::intern(&qualified))
-                        .map(|d| (**d).clone())
+                        .cloned()
                     {
                         return Some(def);
                     }
@@ -75,12 +75,12 @@ impl Interpreter {
         self.registry()
             .functions
             .get(&Symbol::intern(&local))
-            .map(|d| (**d).clone())
+            .cloned()
             .or_else(|| {
                 self.registry()
                     .functions
                     .get(&Symbol::intern(&format!("GLOBAL::{}", name)))
-                    .map(|d| (**d).clone())
+                    .cloned()
             })
     }
 

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -523,6 +523,7 @@ impl Interpreter {
     ) -> Option<Vec<crate::ast::ParamDef>> {
         // Replace junction args with non-junction placeholder values for type resolution
         let resolved_args: Vec<Value> = args.iter().map(Self::unwrap_junction_deep).collect();
-        loan_env!(self, resolve_function_with_types(name, &resolved_args)).map(|def| def.param_defs)
+        loan_env!(self, resolve_function_with_types(name, &resolved_args))
+            .map(|def| def.param_defs.clone())
     }
 }


### PR DESCRIPTION
## What

ANALYSIS §7 row 7 slice 3, building on the Arc-registry slice 2 (#3721).

`resolve_function` / `resolve_function_with_types` / `_with_arity` / `_with_alias` (and the shared `choose_best_matching_candidate`) cloned the whole matched `FunctionDef` — including its `Vec<Stmt>` body — on **every** function/multi call resolution.

## How

Now that the registry holds `Arc<FunctionDef>` (slice 2), these hot single-result resolvers return `Option<Arc<FunctionDef>>`, turning the per-resolution body deep-copy into an Arc refcount bump.

- Callers read the result through `Deref` (auto-coercion to `&FunctionDef`); the few that need an owned `FunctionDef` (e.g. returning `def.param_defs`, pushing onto the `FunctionDef`-typed MAIN-candidate list) clone explicitly.
- The rarer multi-candidate enumerators (`resolve_all_matching_candidates` / `resolve_all_multi_candidates`) and the proto/redispatch path (which stores candidates in the `FunctionDef`-typed `MultiDispatchEntry`) convert back to `FunctionDef` at their boundary, so this slice does **not** ripple into that core struct.

## Why (architecture)

After slice 2 the registry holds shareable immutable definitions; slice 3 lets the hot resolution path actually *share* them instead of deep-copying a routine body per call. Scoped to the hot single-result path to keep the blast radius contained (multi-enumeration and redispatch are rare paths).

## Tests

- `make test`: PASS (Files=1256, Tests=12510).
- `cargo clippy -D warnings`: clean.
- Targeted roast: `S06-multi/{lexical-multis,proto,type-based}`, `S06-routine-modifiers/scoped-named-subs`, `S11-modules/export`, `S06-other/main-usage`, `S12-construction/roles-6e`, `S06-currying/positional` — all PASS.

Follow-ups (ANALYSIS): cache the derived `Arc<FunctionDef>` for a true derive-once re-install; Arc-ify `MultiDispatchEntry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)