### PR TITLE
docs(roast): analyze the S09 shaped native-array early-abort blocker

### DIFF
--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -45,11 +45,39 @@
     Native num `array[num]` Range slice-assign (`@arr[^3] = ...`) now expands
     the range so values distribute per element.
 - [ ] roast/S09-typed-arrays/native-shape1-int.t
-  - Partial (101+ run, was 49). Shaped native `:exists` is now range-based,
-    `:delete` throws X::Delete, OOB-in-range reads return the element default,
-    and mutating map works. Tests 2/5 (`Positional[int]`) are `#?rakudo todo`.
-    Remaining failures: grep/first :p/:kv, .pairup/.antipairs, .pick/.roll,
-    .raku formatting, type-checked push/assign exceptions.
+  - Partial. Shaped native `:exists` is now range-based, `:delete` throws
+    X::Delete, OOB-in-range reads return the element default, and mutating map
+    works. `flat` now splices native shaped arrays (PR #3725). Tests 2/5
+    (`Positional[int]`) are `#?rakudo todo`.
+  - **EARLY ABORT (blocks ~1000 of 1110: only ~101 run).** The per-type `for
+    flat @int,@uint -> $T` loop aborts in iteration 1 at the "List-assign …
+    surrounded by literals" block (~line 158): `my @untyped = @native` makes
+    `@untyped` *hold* a shaped value, then `@untyped = flat 0,@native,11` is
+    wrongly re-clamped to that held shape (5) by the re-shape-on-reassign logic
+    in `vm_var_assign_ops.rs` (~line 6659, `shaped_array_shape(&self.locals[idx])`
+    && !assigned_has_own_shape → clamp), so `@untyped[10]` is out of range and
+    aborts the whole loop.
+  - **Fix attempts (all reverted — this is genuinely entangled):**
+    1. Gate the re-shape on the `__mutsu_shaped_array_dims::@x` env key alone:
+       clears the abort (1042→320) but regresses `my @s[3]; @s = 1,2,3` — the key
+       is recorded ONLY for `:=` binds (my_decl_assign.rs ~676), not for `my @s[3]`
+       declarations, so a declared shape with a *list* assignment loses its shape.
+    2. Also record `__mutsu_shaped_array_dims` at the `my @s[3]` decl sites (wrap
+       the VarDecl in a SyntheticBlock with the record call) THEN gate: STILL
+       regresses `my @s[3]; @s = 1,2,3` → `(*)` and made S09 worse (320→360). The
+       SyntheticBlock wrapping perturbs the decl, and the recorded shape isn't
+       seen by the later list-assign's SetLocal as expected.
+    3. Runtime de-shape on assign (convert a shaped RHS to plain when target not
+       declared-shaped): breaks `my @a[5]` itself — `my @a[5]` and `my @u=@native`
+       are indistinguishable at the SetLocal (both: shaped value, no dims key,
+       fresh slot, is_vardecl=true, is_bind=false).
+    The root need: a RELIABLE declared-vs-value-shaped distinction that survives
+    to the later list-assign. The dims-key mechanism is the intended signal but is
+    set inconsistently and read at a SetLocal that can't see the just-declared
+    shape. Needs careful, tested work across the decl paths + the re-shape site;
+    `flat`-of-native (PR #3725) is the only clean shaped-array win so far.
+  - Remaining (post-abort) failures: grep/first :p/:kv, .pairup/.antipairs,
+    .pick/.roll, .raku formatting, type-checked push/assign exceptions, slices.
 - [ ] roast/S09-typed-arrays/native-shape1-num.t
   - Partial (101+ run, was 49). Same shaped-array improvements as shape1-int.
 - [ ] roast/S09-typed-arrays/native-shape1-str.t


### PR DESCRIPTION
Documents the early-abort blocker in `S09-typed-arrays/native-shape1-*.t` (only ~101 of 1110 run) and the three reverted fix attempts, so the next session can resume without re-deriving. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)