### PR TITLE
fix(subscript): an itemized list/Range subscript is a single index, not a slice

### DIFF
--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -3087,6 +3087,21 @@ impl Interpreter {
         let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
         let has_declared_shape = self.env().contains_key(&declared_shape_key);
         let idx = self.stack.pop().unwrap_or(Value::Nil);
+        // An *itemized* list/Range subscript (`@a[$(7,8,9)] = …`) is a SINGLE
+        // index (its `.Int`, the element count), not a slice — itemization makes
+        // it one item. An itemized list reaches here as `ArrayKind::ItemList` (or
+        // a `Scalar`-wrapped list/Range). A bare `@a[7,8,9] = …` stays a slice.
+        let idx = match &idx {
+            Value::Array(items, crate::value::ArrayKind::ItemList) => {
+                Value::Int(items.len() as i64)
+            }
+            Value::Scalar(inner)
+                if inner.is_range() || matches!(inner.as_ref(), Value::Array(..)) =>
+            {
+                Value::Int(crate::runtime::utils::value_to_list(inner).len() as i64)
+            }
+            _ => idx,
+        };
         let index_target = self.env().get(&var_name).cloned();
         let idx = self.resolve_whatever_index_for_target(idx, index_target.as_ref());
         // Normalize Seq/Slip/Range index to Array for uniform handling in assignment.

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -195,6 +195,19 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let var_name = Self::const_str(code, name_idx).to_string();
         let idx = self.stack.pop().unwrap_or(Value::Nil);
+        // An *itemized* list subscript (`@a[$(7,8,9)]:delete`) is a SINGLE index
+        // (its `.Int`, the element count), not a slice.
+        let idx = match &idx {
+            Value::Array(items, crate::value::ArrayKind::ItemList) => {
+                Value::Int(items.len() as i64)
+            }
+            Value::Scalar(inner)
+                if inner.is_range() || matches!(inner.as_ref(), Value::Array(..)) =>
+            {
+                Value::Int(crate::runtime::utils::value_to_list(inner).len() as i64)
+            }
+            _ => idx,
+        };
         // Fast path for simple hash delete
         if let Some(result) = self.try_fast_hash_delete(code, &var_name, &idx) {
             self.stack.push(result?);

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -54,7 +54,20 @@ impl Interpreter {
             let idxs: Vec<i64> = (0..len as i64).collect();
             (target, idxs)
         } else {
-            let idx = self.stack.pop().unwrap_or(Value::Nil);
+            let mut idx = self.stack.pop().unwrap_or(Value::Nil);
+            // An *itemized* list subscript (`@a[$(7,8,9)]:exists`) is a SINGLE
+            // index (its `.Int`, the element count), not a slice.
+            match &idx {
+                Value::Array(items, crate::value::ArrayKind::ItemList) => {
+                    idx = Value::Int(items.len() as i64);
+                }
+                Value::Scalar(inner)
+                    if inner.is_range() || matches!(inner.as_ref(), Value::Array(..)) =>
+                {
+                    idx = Value::Int(crate::runtime::utils::value_to_list(inner).len() as i64);
+                }
+                _ => {}
+            }
             let target = self.stack.pop().unwrap_or(Value::Nil);
             Self::throw_if_failure(&target)?;
             if let Some(map) = match &target {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -263,14 +263,17 @@ impl Interpreter {
         is_positional: bool,
     ) -> Result<(), RuntimeError> {
         let mut index = self.stack.pop().unwrap();
-        // An *itemized* Range used as a subscript (`@a[my $ = ^2]`) is a single
-        // numeric index, not a slice: the contained Range numifies to its element
-        // count. (A bare Range index `@a[^2]` is still a slice.)
+        // An *itemized* list/Range used as a subscript (`@a[$(7,8,9)]`,
+        // `@a[my $ = ^2]`) is a SINGLE index, not a slice: itemization makes it
+        // one item, which numifies to its element count (`$(7,8,9).Int == 3`).
+        // (A bare `@a[7,8,9]` / `@a[^2]` is still a slice.)
         if let Value::Scalar(inner) = &index
-            && inner.is_range()
+            && (inner.is_range() || matches!(inner.as_ref(), Value::Array(..)))
         {
             let n = crate::runtime::utils::value_to_list(inner).len() as i64;
             index = Value::Int(n);
+        } else if let Value::Array(items, crate::value::ArrayKind::ItemList) = &index {
+            index = Value::Int(items.len() as i64);
         }
         let mut target = self.stack.pop().unwrap();
         if let Value::Junction { kind, values } = &target {

--- a/t/itemized-list-subscript.t
+++ b/t/itemized-list-subscript.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 9;
+
+# An *itemized* list/Range subscript is a SINGLE index (its `.Int`, the element
+# count) — container identity makes it one item — not a multi-element slice.
+# `@a[$(7,8,9)]` is `@a[3]`, while `@a[7,8,9]` / `@a[(7,8,9)]` stay slices.
+
+{
+    my @a;
+    @a[$(7,8,9)] = 101;
+    is @a.elems, 4,                  'itemized list subscript assigns a single element';
+    is @a[$(7,8,9)], 101,            'itemized list subscript reads a single element';
+    ok  (@a[$(7,8,9)]:exists),       'itemized list subscript :exists is single';
+    @a[$(7,8,9)]:delete;
+    nok (@a[$(7,8,9)]:exists),       'itemized list subscript :delete removes the single element';
+}
+
+# A bare list / parenthesized list subscript is still a slice.
+{
+    my @a = ^10;
+    is-deeply @a[7, 8, 9],   (7, 8, 9), 'bare list subscript stays a slice';
+    is-deeply @a[(7, 8, 9)], (7, 8, 9), 'parenthesized list subscript stays a slice';
+    is @a[$(7, 8, 9)], 3,              'itemized list subscript is the element count index';
+}
+
+# An itemized Range subscript is also a single index.
+{
+    my @a = ^10;
+    is @a[$( ^3 )], 3,    'itemized Range subscript is a single index';
+    is-deeply @a[^3], (0, 1, 2), 'bare Range subscript stays a slice';
+}


### PR DESCRIPTION
`@a[$(7,8,9)]` is `@a[3]` — the itemized list numifies to its element count, a **single** element, not a 3-element slice — because itemization makes it one item. mutsu was slicing it (indices 7,8,9). A bare `@a[7,8,9]` / `@a[(7,8,9)]` stays a slice; only the itemized `$(…)` form collapses.

The itemized index arrives as `ArrayKind::ItemList` (assign/exists/delete) or a `Scalar`-wrapped list/Range (read). Now handled as a single `.Int` index across all four subscript paths: read, assign, `:exists`, `:delete`.

## Result

Fixes the "container respected" cluster of `roast/S32-array/adverbs.t` (assign / access / `:exists` / `:delete`): **14 → 10 failing** subtests. New `t/itemized-list-subscript.t` (9 assertions); `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)