### PR TITLE
fix(subscript): zen slice X::Adverb reports .what = zen slice

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -312,7 +312,12 @@ fn try_parse_unknown_adverb(input: &str) -> Option<(&str, String)> {
 /// Determine "element access" vs "slice" from the target and index.
 /// Hash access is always "slice"; array single-element is "element access".
 fn determine_subscript_what(target: &Expr, index_expr: &Expr) -> String {
-    // A whatever slice (`@a[*]`, parsed as a Whatever index) reports
+    // A *zen* slice (`@a[]` / `%h{}`, modelled as a `Literal(Whatever)` index by
+    // the empty-subscript-with-adverb path) reports "zen slice".
+    if matches!(index_expr, Expr::Literal(Value::Whatever)) {
+        return "zen slice".to_string();
+    }
+    // A whatever slice (`@a[*]`, parsed as a bare Whatever index) reports
     // "whatever slice". A hash zen slice keeps the bracket-kind descriptor
     // (`{} slice`), which the runtime downgrades to plain "slice" on a nogo
     // conflict (see `builtin_subscript_adverb_error`).
@@ -2300,10 +2305,18 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 // dropped and the adverb mis-parsed as a colonpair argument.
                 if parse_subscript_adverb_with_expr(r_adv).is_some()
                     || parse_delete_adverb(r_adv).is_some()
+                    || try_parse_unknown_adverb(r_adv).is_some()
                 {
+                    // A zen slice carrying an adverb behaves like the whatever
+                    // slice for VALUES (all keys/values), so model the empty
+                    // subscript as a Whatever index. Use a `Literal(Whatever)`
+                    // (which evaluates to the same `Value::Whatever`) rather than
+                    // bare `Expr::Whatever` so the X::Adverb error path can tell a
+                    // *zen* slice (`@a[]` → ".what" = "zen slice") apart from a
+                    // *whatever* slice (`@a[*]` → "whatever slice").
                     expr = Expr::Index {
                         target: Box::new(expr),
-                        index: Box::new(Expr::Whatever),
+                        index: Box::new(Expr::Literal(Value::Whatever)),
                         is_positional: true,
                     };
                     rest = after;

--- a/t/zen-slice-adverb-what.t
+++ b/t/zen-slice-adverb-what.t
@@ -1,0 +1,19 @@
+use Test;
+use MONKEY-SEE-NO-EVAL;
+
+plan 6;
+
+# The X::Adverb raised by a zen slice (`@a[]`) carrying a conflicting or unknown
+# adverb reports `.what` = "zen slice", distinct from a whatever slice (`@a[*]`,
+# "whatever slice"). Both yield all elements for the value adverbs.
+
+my @a = <a b c d>;
+
+throws-like '@a[]:k:v',  X::Adverb, what => 'zen slice',      'zen slice conflict → zen slice';
+throws-like '@a[]:foo',  X::Adverb, what => 'zen slice',      'zen slice unknown adverb → zen slice';
+throws-like '@a[*]:k:v', X::Adverb, what => 'whatever slice', 'whatever slice conflict → whatever slice';
+
+# Value adverbs on a zen slice still yield all keys/values.
+is-deeply (@a[]:k), (0, 1, 2, 3),                 'zen slice :k yields all keys';
+is-deeply (@a[]:v), ("a", "b", "c", "d"),         'zen slice :v yields all values';
+is-deeply (@a[]:kv), (0,"a",1,"b",2,"c",3,"d"),   'zen slice :kv';


### PR DESCRIPTION
A zen slice (`@a[]`) carrying a conflicting (`:k:v`) or unknown (`:foo`) adverb reported `.what` = "whatever slice" (or nothing for the unknown case): the empty-subscript-with-adverb path modelled `@a[]` as a bare `Expr::Whatever` index, indistinguishable from a real whatever slice `@a[*]`.

Now the zen index is `Expr::Literal(Value::Whatever)` — it evaluates to the same `Value::Whatever` (so value adverbs still yield all keys/values), but `determine_subscript_what` tells it apart and reports `"zen slice"`. An unknown adverb (`@a[]:foo`) is also routed through this path so it raises `X::Adverb` instead of silently mis-parsing `:foo` as a colonpair.

## Result

`roast/S32-array/adverbs.t`: **10 → 6 failing** (600/606). The remaining 6 are the typed missing-element default, blocked on the declared-shape metadata work. New `t/zen-slice-adverb-what.t`; `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)