### PR TITLE
perf(registration): derive each sub declaration once, reuse the Arc on re-install (§7 slice 4)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -101,9 +101,16 @@ CP-3 collapse で VM と Interpreter の二重構造は消えた。
     resolution が body を deep-clone していたのを Arc bump に**。caller は Deref 経由で読み、所有 FunctionDef
     が要る数箇所のみ明示 clone。multi 候補列挙 (`resolve_all_*`) と proto/redispatch
     (`MultiDispatchEntry`) はレアパスなので境界で `FunctionDef` に変換し、core struct への波及を回避。
-  - **残 (次スライス)**: 導出済み `Arc<FunctionDef>` を fingerprint キーでキャッシュし再 install 時に
-    再利用 (真の「derive once」)。`MultiDispatchEntry` も `Arc<FunctionDef>` 化すると redispatch の
-    候補 clone も消える (core struct 波及・別スライス)。
+  - **derive-once キャッシュ (slice 4)**: `my sub` はルーチン return 時に registry から外れ
+    (lexical scope の snapshot/restore)、次の呼び出しで再 install される。slice 1 の冪等パスは
+    「registry に残っている」場合専用なので、この**再 install は AST→`FunctionDef` を毎回再導出**して
+    いた (auto-sig scan・validation・body clone)。導出済み `Arc<FunctionDef>` を
+    `(fingerprint, package)` キーでキャッシュ (`prepared_fn_defs`) し、単純な単一 sub の再 install は
+    キャッシュした `Arc` を clone して streamlined install するだけにした (**真の derive-once**)。
+    package をキーに含めるので同 body の別 package sub が混ざらない。
+  - **残 (次スライス)**: `MultiDispatchEntry` の候補列 (`Vec<FunctionDef>`) を `Arc` 化すると
+    redispatch (`nextsame`/`callsame`) の候補 clone も消える。ただし `resolve_all_*` 候補列挙の
+    Arc 貫通 cascade を伴う (slice 3 で意図的に scope 外にした範囲・別スライス)。
 - **メソッド dispatch の resolver オーバーヘッド**: multi/submethod や `samewith`/`nextsame` は
   `run_instance_method` (resolve + frame setup) を**入口として**通る (本体は compiled)。`MUTSU_VM_STATS` の
   `resolver-path method dispatches` カウンタはこの dispatch 入口数を測る (tree-walk 実行ではない)。

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1342,6 +1342,18 @@ pub struct Interpreter {
     /// without invalidating the resolution caches. Entries are best-effort: a
     /// miss simply takes the full registration path.
     pub(crate) registered_fn_fingerprints: HashMap<Symbol, u64>,
+    /// Derive-once cache: a declaration is parsed into a `FunctionDef` exactly
+    /// once, then shared. Keyed by the routine's fully-qualified name
+    /// (`package::name`), the value is `(declaration fingerprint, Arc<FunctionDef>)`.
+    /// A `my sub` inside a routine is removed from the registry when the routine
+    /// returns (lexical-scope snapshot/restore) and re-installed on the next call;
+    /// without this cache that re-install would re-run the full AST→FunctionDef
+    /// derivation (auto-signature scan, validation, body clone) every call. With
+    /// it, the re-install is a cheap `Arc` clone of the already-derived definition.
+    /// The key is the FQ name (not the fingerprint) so two distinct subs that share
+    /// an identical body but differ in name never alias; the stored fingerprint is
+    /// re-checked on lookup so a redefined body at the same name re-derives.
+    pub(crate) prepared_fn_defs: HashMap<Symbol, (u64, Arc<FunctionDef>)>,
     pub(crate) method_resolve_cache: HashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
     #[allow(clippy::type_complexity)]
     pub(crate) last_method_resolve: Option<(Symbol, Symbol, String, Arc<MethodDef>)>,
@@ -3519,6 +3531,7 @@ impl Interpreter {
             pos_light_call_cache_gen: 0,
             amp_param_shadowed_names: std::collections::HashSet::new(),
             registered_fn_fingerprints: HashMap::new(),
+            prepared_fn_defs: HashMap::new(),
             method_resolve_cache: HashMap::new(),
             last_method_resolve: None,
             fast_method_cache: HashMap::new(),
@@ -6190,6 +6203,7 @@ impl Interpreter {
             pos_light_call_cache_gen: 0,
             amp_param_shadowed_names: std::collections::HashSet::new(),
             registered_fn_fingerprints: HashMap::new(),
+            prepared_fn_defs: HashMap::new(),
             method_resolve_cache: HashMap::new(),
             last_method_resolve: None,
             fast_method_cache: HashMap::new(),

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -494,6 +494,45 @@ impl Interpreter {
                 return Ok(SubRegisterOutcome::Unchanged);
             }
         }
+        // Derive-once re-install fast path. A `my sub` is removed from the registry
+        // when its routine returns (lexical-scope snapshot/restore) and re-installed
+        // on the next call. The registry no longer has it (so the idempotent path
+        // above missed), but we derived an identical `FunctionDef` on an earlier
+        // call — reuse that cached `Arc` instead of re-running the full AST→def
+        // derivation. Restricted to simple single subs (no multi/our/traits/assoc)
+        // so the streamlined install below covers every side effect the full path
+        // would apply for this shape.
+        if let Some(site_fp) = site_fingerprint
+            && !multi
+            && !is_method_value_decl
+            && !is_our_scoped
+            && associativity.is_none()
+            && !custom_traits.iter().any(|(t, _)| !t.starts_with("__"))
+            && !self.sub_decl_would_redeclare(name, is_lexical_hoist)
+        {
+            let pkg = self.current_package().to_string();
+            let fq = format!("{}::{}", pkg, name);
+            let fq_sym = Symbol::intern(&fq);
+            if !self.registry().functions.contains_key(&fq_sym)
+                && let Some(cached) = self
+                    .prepared_fn_defs
+                    .get(&fq_sym)
+                    .filter(|(fp, _)| *fp == site_fp)
+                    .map(|(_, arc)| arc.clone())
+            {
+                self.registry_mut().functions.insert(fq_sym, cached);
+                self.registered_fn_fingerprints.insert(fq_sym, site_fp);
+                if pkg != "GLOBAL" {
+                    self.mark_my_scoped_package_item(fq);
+                }
+                let callable_key = format!("__mutsu_callable_id::{}::{}", pkg, name);
+                self.env.insert(
+                    callable_key,
+                    Value::Int(crate::value::next_instance_id() as i64),
+                );
+                return Ok(SubRegisterOutcome::Installed);
+            }
+        }
         Self::validate_callable_param_return_redeclaration(param_defs)?;
         if let Some(spec) = return_type
             && self.is_definite_return_spec(spec)
@@ -752,11 +791,10 @@ impl Interpreter {
                     .or_insert(std::sync::Arc::new(def));
             }
         } else {
-            let fq = format!("{}::{}", self.current_package(), name);
+            let pkg = self.current_package().to_string();
+            let fq = format!("{}::{}", pkg, name);
             let fq_sym = Symbol::intern(&fq);
-            self.registry_mut()
-                .functions
-                .insert(fq_sym, std::sync::Arc::new(def));
+            let arc = std::sync::Arc::new(def);
             // Record this declaration's fingerprint so a later re-execution of the
             // same `RegisterSub` site is recognized as an idempotent no-op. Reuse
             // the compile-time `site_fingerprint` rather than recomputing it here:
@@ -765,9 +803,20 @@ impl Interpreter {
             // enclosing call) is exactly the per-call cost this is meant to avoid.
             if let Some(fp) = site_fingerprint {
                 self.registered_fn_fingerprints.insert(fq_sym, fp);
+                // Cache the derived definition so a later re-install of this exact
+                // simple single sub reuses the `Arc` instead of re-deriving it (the
+                // derive-once fast path above). Only cache the shapes that fast path
+                // accepts, so a cache hit always lands on the streamlined install.
+                if !is_our_scoped
+                    && associativity.is_none()
+                    && !custom_traits.iter().any(|(t, _)| !t.starts_with("__"))
+                {
+                    self.prepared_fn_defs.insert(fq_sym, (fp, arc.clone()));
+                }
             } else {
                 self.registered_fn_fingerprints.remove(&fq_sym);
             }
+            self.registry_mut().functions.insert(fq_sym, arc);
         }
         // If this is an our-scoped sub, also store it in the persistent our_scoped_functions
         // so it survives block scope restoration.


### PR DESCRIPTION
## What

ANALYSIS §7 row 7 slice 4 — completes the "derive once" thesis on top of the idempotent-registration (slice 1) and Arc-registry (slice 2) slices.

A `my sub` is removed from the routine registry when its enclosing routine returns (lexical-scope snapshot/restore) and re-installed on the next call. The idempotent fast path (slice 1) only covers the case where the entry is **still present**, so this re-install fell through to the full path and re-ran the whole AST→FunctionDef derivation **every call**: auto-signature scan, static validation, and a clone of the body `Vec<Stmt>`.

## How

Cache the derived definition. `register_sub_decl_fp` records the derived `Arc<FunctionDef>` in `prepared_fn_defs`, keyed by `(declaration fingerprint, package)`. A later re-install of a simple single sub whose registry entry is gone but whose fingerprint is cached reuses the cached `Arc` via a streamlined install (registry insert, fingerprint, my-scoped mark, callable id) — **no re-derivation**.

- The **package** is part of the key, so two same-bodied subs in different packages never alias.
- Caching and the fast path are both restricted to **simple single subs** (no multi / `our` / associativity / user traits), so a cache hit always lands on the streamlined install that reproduces exactly that shape's side effects; every other shape keeps the full path.
- Builds on the Arc-registry (slice 2): the cached value *is* what the registry stores, so the re-install is a refcount bump, not a body copy.

## Tests

- `cargo test`: 470 passed, 0 failed.
- New behavior verified: `t/nested-sub-reregistration.t` (per-call capture, recursion, mutual recursion, lexical scoping), per-iteration loop capture (`my sub f(){$i*10}` → 10,20,30 matching raku), `my &x; sub x{}` still throws X::Redeclaration.
- Targeted roast: `S06-multi/{lexical-multis,proto}`, `S06-routine-modifiers/scoped-named-subs`, `S11-modules/{export,import-multi}`, `S06-other/main-usage`, `S02-names/our` — all PASS.
- `cargo clippy -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)