### PR TITLE
docs: restructure PLAN.md/ANALYSIS.md around GC phasing (ADR-0001)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -4,7 +4,7 @@
 「設計上どこまで整理できていて、何がまだ負債として残っているか」をまとめたもの。
 バグ票の一覧ではなく、**アーキテクチャと健全性のレビュー**として読む想定。
 
-初版: 2026-06-03 / rev2: 2026-06-15 / rev3: 2026-06-17 / rev4: 2026-06-27 (単一ストア化 #3455・ユーザメソッド本体 tree-walk 撤去 §B #3680) / **rev5: 2026-06-27 (クロージャ upvalue Phase 1 #3715・Track B 着手前設計メモを §1.3/§2.1 に反映)**
+初版: 2026-06-03 / rev2: 2026-06-15 / rev3: 2026-06-17 / rev4: 2026-06-27 (単一ストア化 #3455・ユーザメソッド本体 tree-walk 撤去 §B #3680) / **rev5: 2026-06-27 (クロージャ upvalue Phase 1 #3715・Track B 着手前設計メモを §1.3/§2.1 に反映)** / **rev6: 2026-06-27 (GC 方針確定 ADR-0001＝cycle collector on Arc・Track B は GC 統合=層3a・§2.1/§7-6 に反映)**
 方法:
 - 調査エージェントによるサブシステム単位の精読
 - 主張ごとの実機再現確認
@@ -243,6 +243,12 @@ Track B は規模・難度ともに大きく、着手前に次を踏まえるこ
   場当たりに lock を足すと CLAUDE.md の「リスク」(flaky/ハング/ad-hoc) に直結する。設計を詰めてから着手。
 - これが §1.3 クロージャ upvalue Phase 2+ の前提でもある (read-only/per-iteration/cross-thread キャプチャの
   健全なセル化が解禁される)。
+- **方針決定 (ADR-0001, 2026-06-27)**: Track B は単独で着手せず **GC (cycle collector on Arc) と統合**して
+  実施する (ADR 層3a)。同じ `Arc<ArrayData>`/`Arc<HashData>` 群 (79 箇所) を Track B と GC が触るため、
+  `Arc → Gc<T>` 置換と要素セル化を 1 キャンペーンにまとめる (別々だと 79 箇所を 2 回触る)。再入デッドロックと
+  GC セーフポイントは同じ再入境界の問題として一緒に設計する。moving GC は Rust 所有+Arc と非互換ゆえ却下、
+  スカラ系は型フィルタで GC 対象外＝hot path コスト 0。Phase A 完了後に着手。詳細は
+  [docs/adr/0001-gc-strategy-and-phasing.md](docs/adr/0001-gc-strategy-and-phasing.md)。
 
 ### 2.2 `RuntimeError` god-struct が制御フローをエラーチャネルで運ぶ — **bool→enum 分離は完了、残るは縮小・Box 化**
 
@@ -360,7 +366,7 @@ Track B は規模・難度ともに大きく、着手前に次を踏まえるこ
 | 3 | ローカルスロットにレキシカルスコープを導入 (シャドウ衝突解消) | 正しさ + 設計 | 中 |
 | 4 | 制御フローを `RuntimeError` から `enum Control` へ分離は **完了** (§2.2・#3701/#3706 ほか)。残: `RuntimeError` 本体の縮小・Box 化で `result_large_err` 23 箇所を撤去 (高 churn・別 PR 群) | 設計 | 中 |
 | 5 | `.^methods`/`.can` の型別リスト: 確認済みドリフトは是正 (Str/Int/List・§4.1)。完全な実ディスパッチ表からの導出は arity-dispatch 非列挙のため別軸 | ドリフト解消 | 中 |
-| 6 | **Track B**: 陳腐化 `unsafe` コメント是正は完了。残: 配列・ハッシュ要素の `ContainerRef` 化で生ポインタ unsoundness を撤廃。**着手前設計メモを §2.1 に追記** (79 箇所・コア表現変更・再入デッドロック/perf の地雷・cross-thread 共有は `shared_vars`)。再入安全なロック/所有モデルの設計判断が要る研究レベル作業。#2 upvalue Phase 2+ の前提 | 健全性 (UB) + 性能 | 中〜大 |
+| 6 | **Track B**: 陳腐化 `unsafe` コメント是正は完了。残: 配列・ハッシュ要素の `ContainerRef` 化で生ポインタ unsoundness を撤廃。**GC と統合＝ADR-0001 層3a (`Arc → Gc<T>` 一斉置換・cycle collector on Arc)。単独着手しない・Phase A 完了後。** 着手前設計メモは §2.1 (79 箇所・コア表現変更・再入デッドロック/perf の地雷・cross-thread 共有は `shared_vars`)。#2 upvalue Phase 2+ の前提 | 健全性 (UB) + 性能 | 中〜大 |
 | 7 | 宣言登録の bytecode 化: sub 登録の冪等化 (**slice 1**・`SubRegisterOutcome`+fingerprint) と registry Arc 化 (**slice 2**・snapshot 共有) + dispatch resolution への Arc 貫通 (**slice 3**・resolution 毎の body clone を Arc bump に) 着手済 (§1.1)。残: 導出済み `Arc<FunctionDef>` キャッシュ再利用 (真の derive-once) + `MultiDispatchEntry` の Arc 化。method dispatch の resolution caching (multi は #3684 着手) | 設計 + 性能 | 中 |
 | 8 | 一時ファイルを `tmp/` へ (root の `bom-test-*`) / 巨大ファイル分割 (500 行規約) | 衛生 | 低〜中 |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,6 +21,25 @@
 起動が速い強みを活かし、まずは CLI ツールとスクリプト実行を主戦場にする。
 最終的には、**mutsu でウェブアプリやブログを組める程度のライブラリ互換性**を目指す。
 
+### フェーズ構成と次の大型ジャンプ（ADR-0001）
+
+性能と互換性で raku に追いついたその先、**GC と JIT が次の大型ジャンプ**になる。
+GC のないインタプリタは「欠陥品」とみなされ誰も使わない＝GC は table stakes。順序と方式は
+[docs/adr/0001-gc-strategy-and-phasing.md](docs/adr/0001-gc-strategy-and-phasing.md) で決定済み。要点:
+
+| フェーズ | 内容 | 本書の該当 |
+|---|---|---|
+| **A. 追いつく** | 互換性＋速度で raku に並ぶ（**いまここ**） | §F roast / §2 multi-dispatch / §H module / §G Lever 1・3 |
+| **A'. 地ならし** | root 集約で GC 実装を楽にする | レキシカルスコープ（ANALYSIS §1.4）/ upvalue index 化（ANALYSIS §1.3） |
+| **B. Value 表現リワーク＋GC** | Track B（要素 cell 化）＋ cycle collector を**統合**（ADR 層3a） | §G Lever 2 周辺 / §I Track B 依存項目 / §J |
+| **C. JIT** | 独自メリット | §G Lever 4 |
+
+- **GC は JIT の前**（JIT を GC 前提の上に載せる）。**GC は Phase A 完了後**に着手（当面は §J の将来扱い）。
+- **方式 = cycle collector on Arc（non-moving + refcount・レベル1 採用）**。スカラ系は型フィルタで GC 対象外
+  ＝数値/文字列 hot path はコスト 0。性能は GC でなく JIT で稼ぐ。
+- **Track B は GC と一体（層3a）。単独で先行着手しない。** NaN-boxing は JIT の地ならし（層3b）、
+  biased refcount は層3c。
+
 ### 🚫 標準ルール: 「1 操作 = 1 実装」を守る（ユーザー方針 2026-06-07）
 
 実行エンジンは単一の `Interpreter` 構造体（= bytecode VM）に統合済み。
@@ -133,10 +152,15 @@
 
 - [ ] **Lever 1: closure captures を indexed slot 化（高 payoff・設計済）**: closure 生成時の env deep clone を撤廃。
       コンパイル時に closure が read/write する変数を解析し `Vec<Value>` に格納。method-call <2x 狙い。
-- [ ] **Lever 2: NaN-boxing（高 payoff・設計済）**: `Value` 48→8 bytes（Int/Num/Bool/Nil を NaN payload に）。
-      int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。
+- [ ] **Lever 2: NaN-boxing（高 payoff・設計済）= ADR-0001 層3b（JIT の地ならし・GC 後）**: `Value` 48→8 bytes
+      （Int/Num/Bool/Nil を NaN payload に）。int-arith 2x・fib ~30% 狙い。8B 固定・タグ単純で JIT 生成が楽に
+      なる（型境界は GC の型フィルタと一致）。`value_size_guard` テストでサイズ監視中。
 - [ ] **Lever 3: threaded dispatch（中 payoff・ラフ）**: opcode の `match` を関数ポインタテーブルに。命令律速ベンチ 10–30%。
-- [ ] **Lever 4: JIT（Cranelift）/ Lever 5: 型制約チェックの tight-loop 省略**（ラフ・大）。
+- [ ] **Lever 4: JIT（Cranelift）= ADR-0001 層4（GC の後）/ Lever 5: 型制約チェックの tight-loop 省略**（ラフ・大）。
+      GC を cycle collector on Arc（non-moving + refcount）にする決定で、JIT は stack map/forwarding/write barrier
+      不要・`Arc` inc/dec を emit するだけになる。intループのネイティブ化で hot path は GC/refcost ゼロ（ADR-0001 §3-8）。
+- [ ] **Lever 6: biased reference counting = ADR-0001 層3c（GC 後の独立 perf）**: 所有スレッドからの refcount を
+      非 atomic 化。JIT が intループをネイティブ化すれば hot path から refcount が消えるため優先度は低め。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。
 - 目標: method-call <1.5x、bench-class <1.5x、bench-fib（型制約付き）<2x。
 
@@ -222,12 +246,16 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
 
 スカラ／state の `start` 間ライブ共有・hash/array 要素 atomic は landed（→ news）。残:
 
-- [ ] **`state @`/`%`・lexical aggregate の真共有**（Track B 要素 cell 基盤に依存）。
+- [ ] **`state @`/`%`・lexical aggregate の真共有**（Track B 要素 cell 基盤に依存。Track B は GC と統合＝
+      ADR-0001 層3a なので、この項目も実質 Phase B 待ち）。
 - [ ] Semaphore / nonblocking await / lock 競合（S17・hard・別軸）。
 - [ ] `unsafe` の single-thread 前提コメント是正（`Arc::as_ptr as *mut` を strong_count ガード前提に・最終的に要素も cell 化）。
 
 ### J. 構造リファクタ・将来（独立・中長期）
 
+- [ ] **★大型ジャンプ: GC（cycle collector on Arc）→ JIT**（ADR-0001・Phase B/C）。Phase A 完了後に着手。
+      **Track B（要素 cell 化）と GC は統合キャンペーン（層3a・`Arc → Gc<T>` 一斉置換）**。続いて NaN-boxing
+      （層3b・JIT 地ならし）→ JIT（層4）。未決は収集方式（同期/非同期）と A' 地ならしの範囲（ADR §4.2/§4.3）。
 - [ ] 制御フロー（`return`/`last`/`next`/`take`/`emit`）を `RuntimeError` god-struct から `enum Control` へ分離（ANALYSIS §2.4）。
 - [ ] `.^methods`/`.can` を実ディスパッチ表から導出 / roast fudge ロジック分離 / 500 行超ファイル分割。
 - [ ] エラーメッセージ品質向上 / エッジケースの panic・crash を 0 に。


### PR DESCRIPTION
## 概要

ADR-0001（GC 方針確定）を受けて、**PLAN.md / ANALYSIS.md 本体を GC 前提のフェーズ構成に再整理**する。GC の決定が perf レバーの中に埋もれず、ロードマップの骨格として見えるようにする。ドキュメントのみ。

## PLAN.md

- **方針の直後にフェーズ表を追加**: A(追いつく・いまここ) → A'(root 地ならし) → B(Value 表現リワーク+GC) → C(JIT)。GC は JIT の前・Phase A 後、方式は cycle collector on Arc（レベル1）、Track B は GC と一体・単独着手しない。
- **§G perf**: Lever 2(NaN-boxing) を「層3b・JIT 地ならし・GC 後」、Lever 4(JIT) を「層4・GC 後」とタグ付け。Lever 6(biased refcount・層3c) を追加。
- **§I**: `state @/%` 真共有は Track B 依存 → 実質 Phase B 待ちと明記。
- **§J**: 「★大型ジャンプ: GC → JIT」を将来項目として追加。

## ANALYSIS.md

- **§2.1 設計メモ**: Track B は単独着手せず GC と統合（層3a・`Arc→Gc<T>` 一斉置換）を追記。
- **§7 ロードマップ #6**: Track B 行に「GC 統合・単独着手しない・Phase A 後」を反映。
- rev6 を追記。

すべて [docs/adr/0001-gc-strategy-and-phasing.md](docs/adr/0001-gc-strategy-and-phasing.md) にリンク。

🤖 Generated with [Claude Code](https://claude.com/claude-code)