### PR TITLE
perf(dispatch): hold multi-dispatch candidates as Arc<FunctionDef> (§7 slice 5)

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -905,7 +905,7 @@ impl Interpreter {
         if let Some(err) = saved_err {
             self.set_pending_dispatch_error(err);
         }
-        let remaining: Vec<super::FunctionDef> = all_candidates
+        let remaining: Vec<std::sync::Arc<super::FunctionDef>> = all_candidates
             .into_iter()
             .filter(|c| {
                 let fp = crate::ast::function_body_fingerprint(&c.params, &c.param_defs, &c.body);

--- a/src/runtime/builtins_operators.rs
+++ b/src/runtime/builtins_operators.rs
@@ -393,7 +393,7 @@ impl Interpreter {
             let all_candidates = self.resolve_all_multi_candidates(name);
             let def_fp =
                 crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
-            let remaining: Vec<FunctionDef> = all_candidates
+            let remaining: Vec<std::sync::Arc<FunctionDef>> = all_candidates
                 .into_iter()
                 .filter(|c| {
                     crate::ast::function_body_fingerprint(&c.params, &c.param_defs, &c.body)

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1069,7 +1069,7 @@ impl Interpreter {
     /// Collect ALL multi dispatch candidates for a function name, regardless of
     /// arity or type matching.  Used to build the full candidate list for
     /// callwith(), which may re-dispatch with different arguments.
-    pub(crate) fn resolve_all_multi_candidates(&self, name: &str) -> Vec<FunctionDef> {
+    pub(crate) fn resolve_all_multi_candidates(&self, name: &str) -> Vec<Arc<FunctionDef>> {
         let mut all: Vec<(String, Arc<FunctionDef>)> = Vec::new();
         let prefixes = [
             format!("{}::{}/", self.current_package(), name),
@@ -1106,7 +1106,7 @@ impl Interpreter {
         // S12-methods/defer-next.t `nextsame + multi + where`). Mirrors the
         // deterministic winner resolution PR-4 added to `push_multi_dispatch_frame`.
         self.sort_candidates_by_specificity(&mut all);
-        all.into_iter().map(|(_, def)| (*def).clone()).collect()
+        all.into_iter().map(|(_, def)| def).collect()
     }
 
     pub(super) fn eval_token_call_values(
@@ -1680,7 +1680,7 @@ impl Interpreter {
         name: &str,
         args: &[Value],
         current_def: &FunctionDef,
-    ) -> Vec<FunctionDef> {
+    ) -> Vec<Arc<FunctionDef>> {
         let arity = args
             .iter()
             .filter(|v| !matches!(v, Value::Pair(..)))
@@ -1741,7 +1741,7 @@ impl Interpreter {
                 }
                 continue;
             }
-            remaining.push((**cand).clone());
+            remaining.push(cand.clone());
         }
         remaining
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -408,7 +408,12 @@ pub(crate) struct ProtoMethodCtx {
 /// One entry of `multi_dispatch_stack`: (function_name, remaining_candidates,
 /// original_args, first_candidate_rw_params). See the field doc on
 /// `Interpreter::multi_dispatch_stack`.
-type MultiDispatchEntry = (String, Vec<FunctionDef>, Vec<Value>, Vec<(usize, String)>);
+type MultiDispatchEntry = (
+    String,
+    Vec<Arc<FunctionDef>>,
+    Vec<Value>,
+    Vec<(usize, String)>,
+);
 
 #[derive(Debug, Clone)]
 struct MethodDispatchFrame {


### PR DESCRIPTION
## Summary

§7 slice 5 of the registration/dispatch derive-once campaign. The multi-dispatch
stack used to store each entry's candidate list as `Vec<FunctionDef>`, so every
redispatch step (`callsame`/`nextsame`/`callwith`/`nextwith`/`nextcallee`) and
every proto/multi frame setup **deep-cloned the full function bodies** of the
remaining candidates.

This changes `MultiDispatchEntry`'s candidate vector to `Vec<Arc<FunctionDef>>`:

- `resolve_all_multi_candidates` and `resolve_remaining_proto_candidates` already
  held `Arc<FunctionDef>` from the registry internally and only deep-cloned at the
  return boundary — they now return the Arc directly.
- Consumers in `builtins_dispatch_next.rs` read candidate fields through
  `Deref`/`Copy` and clone owned fields (params/body) exactly as before. Per-step
  body deep-clone becomes a refcount bump; behavior is byte-identical.

Follows slice 2 (#3721 registry Arc), slice 3 (#3724 resolution Arc), slice 4
(#3730 derive-once cache). This eliminates the remaining redispatch-path body
clones noted as "残" in those slices.

## Test
- `make test`: 12542 tests PASS.
- Dispatch roast: `S12-methods/{defer-next,defer-call,lastcall}.t`,
  `S06-multi/{proto,redispatch}.t` all PASS (including the hash-seed-flaky
  `nextsame + multi + where` case).
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)