### PR TITLE
perf(registration): hold proto_functions registry as Arc<FunctionDef> (§7 slice 6)

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1259,16 +1259,16 @@ impl Interpreter {
                 .registry()
                 .proto_functions
                 .get(&Symbol::intern(name))
-                .cloned();
+                .map(|def| (**def).clone());
         }
         let local = format!("{}::{}", self.current_package(), name);
         if let Some(def) = self.registry().proto_functions.get(&Symbol::intern(&local)) {
-            return Some(def.clone());
+            return Some((**def).clone());
         }
         self.registry()
             .proto_functions
             .get(&Symbol::intern(&format!("GLOBAL::{}", name)))
-            .cloned()
+            .map(|def| (**def).clone())
     }
 
     pub(super) fn call_proto_function(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1489,7 +1489,7 @@ pub(crate) struct SubtestContext {
 
 pub(crate) type RoutineRegistrySnapshot = (
     HashMap<Symbol, Arc<FunctionDef>>,
-    HashMap<Symbol, FunctionDef>,
+    HashMap<Symbol, Arc<FunctionDef>>,
     HashMap<Symbol, Vec<FunctionDef>>,
     HashSet<String>,
     HashSet<String>,
@@ -4474,7 +4474,7 @@ impl Interpreter {
                 self.registry_mut().functions.insert(k, v);
             }
 
-            let proto_entries: Vec<(Symbol, FunctionDef)> = self
+            let proto_entries: Vec<(Symbol, Arc<FunctionDef>)> = self
                 .registry()
                 .proto_functions
                 .iter()

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1009,7 +1009,7 @@ impl Interpreter {
         let fq = format!("{}::{}", self.current_package(), name);
         self.registry_mut().proto_functions.insert(
             Symbol::intern(&fq),
-            FunctionDef {
+            std::sync::Arc::new(FunctionDef {
                 package: Symbol::intern(&self.current_package()),
                 name: Symbol::intern(name),
                 params: params.to_vec(),
@@ -1023,7 +1023,7 @@ impl Interpreter {
                 return_type: None,
                 is_default: false,
                 deprecated_message: None,
-            },
+            }),
         );
         Ok(())
     }
@@ -1242,7 +1242,7 @@ impl Interpreter {
         self.registry_mut().proto_subs.insert(key.clone());
         self.registry_mut().proto_functions.insert(
             Symbol::intern(&key),
-            FunctionDef {
+            std::sync::Arc::new(FunctionDef {
                 package: Symbol::intern("GLOBAL"),
                 name: Symbol::intern(name),
                 params: params.to_vec(),
@@ -1256,7 +1256,7 @@ impl Interpreter {
                 return_type: None,
                 is_default: false,
                 deprecated_message: None,
-            },
+            }),
         );
         Ok(())
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -118,7 +118,7 @@ pub(crate) struct Registry {
     /// `our`-scoped subs that persist across block boundaries.
     pub(crate) our_scoped_functions: HashMap<Symbol, FunctionDef>,
     /// `proto sub` markers (multi proto stubs): name -> proto `FunctionDef`.
-    pub(crate) proto_functions: HashMap<Symbol, FunctionDef>,
+    pub(crate) proto_functions: HashMap<Symbol, std::sync::Arc<FunctionDef>>,
     /// Grammar token/rule definitions: name -> [overloads].
     pub(crate) token_defs: HashMap<Symbol, Vec<FunctionDef>>,
     /// `proto sub` declaration markers (existence set).


### PR DESCRIPTION
## Summary

§7 slice 6 of the registration/dispatch derive-once campaign. The proto-sub
registry (`Registry::proto_functions`) stored each entry as a plain `FunctionDef`,
whose `body: Vec<Stmt>` is deep-cloned on every clone. So:

- `snapshot_routine_registry` (invoked whenever a routine declaring inner
  routines is entered, to scope `my sub`s) deep-cloned **every proto body**, and
- the save/restore clones in subtest / throws-like / fails-like / regex EVAL
  setup did the same.

This changes `proto_functions` to `HashMap<Symbol, Arc<FunctionDef>>`, mirroring
the `functions` registry Arc-ification from §7 slice 2 (#3721):

- The full-map clones (snapshot, save/restore, nested-interpreter copy) become
  O(n) refcount bumps.
- `resolve_proto_function` converts the Arc back to an owned `FunctionDef` at the
  boundary (`(**def).clone()`), so its callers and the rest of the proto dispatch
  path are unchanged.
- The two registration insert sites wrap the derived `FunctionDef` in `Arc::new`.

This completes the registry-Arc story noted as "残" in slice 2
(`our_scoped/proto_functions は FunctionDef のまま`). `our_scoped_functions` is
not deep-cloned in the snapshot (only its keys are), so it stays plain.

## Test
- `make test`: 12542 tests PASS.
- Proto roast/`t/`: `S06-multi/proto.t` + all 8 `t/proto-*.t` PASS.
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)