### PR TITLE
fix(capture): container identity for === + nested placeholder scoping

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -86,11 +86,15 @@ impl Compiler {
             self.code
                 .emit(OpCode::MakeAnonSubParams(idx, Some(cc_idx), false));
         } else {
-            // Use deep collection for conflict checking, shallow for params.
-            let deep_placeholders = crate::ast::collect_placeholders(body);
+            // Conflict checking, like params, uses the *shallow* collector: a
+            // placeholder belongs to its innermost enclosing block, so a
+            // placeholder nested in an inner closure must not be attributed to
+            // this block (which would falsely flag a redeclaration against this
+            // block's `my $a`).
+            let block_placeholders = crate::ast::collect_placeholders_shallow(body);
             // Immediate block calls (`{ ... }(...)`) are parsed as AnonSub.
             // Apply the same placeholder conflict checks as block/sub declarations.
-            if let Some(err_val) = self.check_placeholder_conflicts(&deep_placeholders, body, None)
+            if let Some(err_val) = self.check_placeholder_conflicts(&block_placeholders, body, None)
             {
                 let idx = self.code.add_constant(err_val);
                 self.code.emit(OpCode::LoadConst(idx));

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -463,8 +463,12 @@ impl Compiler {
                     .emit(OpCode::SinkPop(Self::stmt_value_may_user_sink(&feed)));
             }
             Stmt::Block(stmts) => {
-                // Check for placeholder conflicts in blocks
-                let placeholders = crate::ast::collect_placeholders(stmts);
+                // Check for placeholder conflicts in blocks. Use the *shallow*
+                // collector: a placeholder belongs to its innermost enclosing
+                // block, so placeholders nested inside an inner closure
+                // (`{ my $a; { $^a } }`) must NOT be attributed to this block
+                // and falsely flagged as redeclaring this block's `my $a`.
+                let placeholders = crate::ast::collect_placeholders_shallow(stmts);
                 if !placeholders.is_empty()
                     && let Some(err_val) =
                         self.check_placeholder_conflicts(&placeholders, stmts, None)

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -433,7 +433,46 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
         (Value::Junction { values: a_vals, .. }, Value::Junction { values: b_vals, .. }) => {
             std::sync::Arc::ptr_eq(a_vals, b_vals)
         }
+        // Capture identity is NOT structural: a Capture's `.WHICH` keeps the
+        // *container* identity of each captured element, so `\($a) === \($b)`
+        // is False even when `$a` and `$b` hold equal values, while
+        // `\(42) === \(42)` is True (both literal-value elements). This is
+        // unlike `eqv`, which deconts and compares structurally.
+        (
+            Value::Capture {
+                positional: ap,
+                named: an,
+            },
+            Value::Capture {
+                positional: bp,
+                named: bn,
+            },
+        ) => {
+            ap.len() == bp.len()
+                && an.len() == bn.len()
+                && ap
+                    .iter()
+                    .zip(bp.iter())
+                    .all(|(x, y)| capture_elem_identical(x, y))
+                && an
+                    .iter()
+                    .all(|(k, v)| bn.get(k).is_some_and(|bv| capture_elem_identical(v, bv)))
+        }
         _ => left.eqv(right),
+    }
+}
+
+/// Identity comparison for a single Capture element. Unlike a top-level
+/// `===` (which deconts a bound scalar to its value), a Capture retains the
+/// container identity of each element: two `ContainerRef` cells are identical
+/// only when they are the same `Arc` (i.e. bound to the same container), and a
+/// container can never be identical to a plain value. Non-container elements
+/// fall back to the normal value identity rules.
+fn capture_elem_identical(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::ContainerRef(x), Value::ContainerRef(y)) => std::sync::Arc::ptr_eq(x, y),
+        (Value::ContainerRef(_), _) | (_, Value::ContainerRef(_)) => false,
+        _ => values_identical(a, b),
     }
 }
 


### PR DESCRIPTION
## Summary

Two related fixes, both required to make `roast/S02-types/capture.t` reach and pass subtests #34-35 (`\($a) !=== \(42)`, and `\($a) === \($c)` when `$c := $a`).

### 1. Capture `===` is container-identity, not structural

`\($a)` captures the *container* of `$a`; `\(42)` captures a literal value. In Rakudo a Capture's `.WHICH` keeps each element's container identity, so:

- `\($a) === \($b)` is **False** even when `$a` and `$b` hold equal values
- `\(42) === \(42)` is **True**
- `\($a) === \($c)` (with `$c := $a`) is **True** (same container)

mutsu previously fell through to structural `eqv`, making `\($a) === \($b)` wrongly True. `values_identical` now has a `Capture` arm comparing each positional/named element via container identity (`Arc::ptr_eq` on `ContainerRef`; a container is never `===` a plain value). `eqv` is unchanged (still deconts, so `\($a) eqv \(42)` stays True).

### 2. Nested-closure placeholder scoping

A placeholder belongs to its **innermost** enclosing block. The placeholder-conflict checker used the *deep* collector, which descended into nested `AnonSubParams`/`Lambda` and attributed an inner block's `$^a` to the outer block — falsely raising `X::Redeclaration` against the outer `my $a` and aborting capture.t mid-file. Switched both conflict-check sites to the shallow collector. Direct same-block collisions (`{ my $a; say $^a }`) are still detected.

## Result

- `capture.t` now runs all **46** subtests (was aborting at 33). Remaining 4 failures (#36, #39-41) are unrelated feature gaps (non-Str-key Pairs in List, more `.Capture`-throws types, Blob/Buf `.Capture`) — separate follow-ups.
- `roast/S06-signature/sub-ref.t`, the placeholder roast suite, and `make test` (12542 tests) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY