### PR TITLE
fix(capture): Blob/Buf/utf8 .Capture unpacks bytes into positionals

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -686,6 +686,30 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
         Value::Capture { .. } => Ok(target.clone()),
         // Match.Capture returns self
         Value::Instance { class_name, .. } if class_name.resolve() == "Match" => Ok(target.clone()),
+        // Blob/Buf/utf8/utf16 .Capture behaves like List.Capture: each byte
+        // becomes a positional argument (no nameds).
+        Value::Instance {
+            class_name,
+            attributes,
+            ..
+        } if {
+            let cn = class_name.resolve();
+            cn == "Buf"
+                || cn == "Blob"
+                || cn == "utf8"
+                || cn == "utf16"
+                || cn.starts_with("Buf[")
+                || cn.starts_with("Blob[")
+                || cn.starts_with("buf")
+                || cn.starts_with("blob")
+        } =>
+        {
+            let positional = match attributes.as_map().get("bytes") {
+                Some(Value::Array(items, ..)) => items.iter().cloned().collect(),
+                _ => vec![],
+            };
+            Ok(Value::capture(positional, HashMap::new()))
+        }
         // Pair.Capture → \(:key($pair.key), :value($pair.value))
         Value::Pair(k, v) => {
             let mut named = HashMap::new();


### PR DESCRIPTION
## Summary

`Blob.new(1,2,42).Capture` (and `Buf`/`utf8`/`utf16`) now behaves like `List.Capture`: each byte becomes a positional argument, so `Blob.new(1,2,42).Capture eqv \(1,2,42)`. Previously these fell through to the default arm in `value_to_capture` and wrapped the whole Blob as a single positional (`\(Blob:0x<...>)`).

The byte list is read from the instance's `bytes` attribute — the same representation the existing `.List` coercion uses for these types.

## Result

Advances `roast/S02-types/capture.t` subtest *"types whose .Capture behaves like List.Capture"* (Blob/Buf/utf8 cases). `roast/S03-buf/{read,write}-int.t` and `read-num.t` remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY