### PR TITLE
perf(registration): hold grammar token_defs candidates as Arc<FunctionDef> (§7 slice 7)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1490,7 +1490,7 @@ pub(crate) struct SubtestContext {
 pub(crate) type RoutineRegistrySnapshot = (
     HashMap<Symbol, Arc<FunctionDef>>,
     HashMap<Symbol, Arc<FunctionDef>>,
-    HashMap<Symbol, Vec<FunctionDef>>,
+    HashMap<Symbol, Vec<Arc<FunctionDef>>>,
     HashSet<String>,
     HashSet<String>,
     HashSet<Symbol>,

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -3,7 +3,7 @@ use super::regex_helpers::NamedRegexLookupSpec;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    pub(super) fn resolve_token_defs_in_pkg(&self, name: &str, pkg: &str) -> Vec<FunctionDef> {
+    pub(super) fn resolve_token_defs_in_pkg(&self, name: &str, pkg: &str) -> Vec<Arc<FunctionDef>> {
         let mut out = Vec::new();
         if name.contains("::") {
             if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(name)) {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -119,8 +119,11 @@ pub(crate) struct Registry {
     pub(crate) our_scoped_functions: HashMap<Symbol, FunctionDef>,
     /// `proto sub` markers (multi proto stubs): name -> proto `FunctionDef`.
     pub(crate) proto_functions: HashMap<Symbol, std::sync::Arc<FunctionDef>>,
-    /// Grammar token/rule definitions: name -> [overloads].
-    pub(crate) token_defs: HashMap<Symbol, Vec<FunctionDef>>,
+    /// Grammar token/rule definitions: name -> [overloads]. Each overload is
+    /// held behind `Arc` so the whole-map snapshot/restore clones (and the
+    /// per-resolution candidate merges) are O(n) refcount bumps rather than
+    /// deep clones of the token bodies.
+    pub(crate) token_defs: HashMap<Symbol, Vec<std::sync::Arc<FunctionDef>>>,
     /// `proto sub` declaration markers (existence set).
     pub(crate) proto_subs: HashSet<String>,
     /// `proto token`/`proto rule` declaration markers (existence set).

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -86,6 +86,7 @@ impl Interpreter {
 
     pub(super) fn insert_token_def(&mut self, name: &str, def: FunctionDef, multi: bool) {
         let key = Symbol::intern(&format!("{}::{}", self.current_package(), name));
+        let def = std::sync::Arc::new(def);
         if multi {
             self.registry_mut()
                 .token_defs
@@ -102,7 +103,7 @@ impl Interpreter {
         &self,
         scope: &str,
         name: &str,
-        defs: &mut Vec<FunctionDef>,
+        defs: &mut Vec<std::sync::Arc<FunctionDef>>,
     ) {
         let exact_key = format!("{scope}::{name}");
         if let Some(exact) = self.registry().token_defs.get(&Symbol::intern(&exact_key)) {
@@ -153,7 +154,10 @@ impl Interpreter {
         result
     }
 
-    pub(crate) fn resolve_token_defs(&self, name: &str) -> Option<Vec<FunctionDef>> {
+    pub(crate) fn resolve_token_defs(
+        &self,
+        name: &str,
+    ) -> Option<Vec<std::sync::Arc<FunctionDef>>> {
         if name.contains("::") {
             let mut defs = Vec::new();
             if let Some(exact) = self.registry().token_defs.get(&Symbol::intern(name)) {


### PR DESCRIPTION
## Summary

§7 slice 7 — the capstone of the registration/dispatch derive-once campaign.
After this, **no `FunctionDef` is deep-cloned in the routine-registry snapshot**.

The grammar token/rule registry (`Registry::token_defs`) stored each overload as
a plain `FunctionDef`, whose `body: Vec<Stmt>` is deep-cloned on every clone. So:

- `snapshot_routine_registry` (entered whenever a routine declaring inner
  routines runs, to scope `my sub`s) deep-cloned every token body,
- the save/restore clones in subtest / fails-like / regex EVAL / regex-match
  setup did the same, and
- `resolve_token_defs` / `collect_token_defs_for_scope` /
  `resolve_token_defs_in_pkg` rebuilt a merged candidate `Vec` on **every token
  resolution during grammar parsing**, deep-cloning each candidate's body.

Change `token_defs` to `HashMap<Symbol, Vec<Arc<FunctionDef>>>`, completing the
registry-Arc story begun in §7 slices 2/6 (#3721 functions, #3735 proto). The
resolve helpers thread `Vec<Arc<FunctionDef>>`; their consumers read fields
through `Deref` (and `Symbol`/`bool` via `Copy`), so the per-resolution candidate
merges and the whole-map clones become O(n) refcount bumps. `insert_token_def`
wraps the derived `FunctionDef` in `Arc::new`. `token_defs` has no in-place value
mutation (no `get_mut`/`values_mut`), so shared-Arc storage is safe.

## Test
- `make test`: 12542 tests PASS.
- Grammar: all 16 `t/grammar-*.t`, all `roast/S05-grammar/*.t` PASS.
- `cargo clippy -- -D warnings` + `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)