### PR TITLE
fix(capture): Signature/Version/Failure .Capture throw X::Cannot::Capture

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -743,6 +743,18 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             );
             Ok(Value::capture(vec![], named))
         }
+        // Version.Capture throws X::Cannot::Capture
+        Value::Version { .. } => Err(cannot_capture("Version")),
+        // Signature/Failure .Capture throw X::Cannot::Capture (both the type
+        // object and an instance).
+        Value::Instance { class_name, .. }
+            if matches!(class_name.resolve().as_str(), "Signature" | "Failure") =>
+        {
+            Err(cannot_capture(&class_name.resolve()))
+        }
+        Value::Package(name) if matches!(name.resolve().as_str(), "Signature" | "Failure") => {
+            Err(cannot_capture(&name.resolve()))
+        }
         // Pair.Capture → \(:key($pair.key), :value($pair.value))
         Value::Pair(k, v) => {
             let mut named = HashMap::new();


### PR DESCRIPTION
## Summary

Per `roast/S02-types/capture.t` subtest *"types whose .Capture throws"*, `.Capture` on:
- a **Signature** (`:(...)`),
- a **Version** (`v42`),
- a **Failure** (both the `Failure` type object and a *handled* instance)

must throw `X::Cannot::Capture`. mutsu previously fell through to the default arm of `value_to_capture` and wrapped the value as a single positional (`\(42)`, `\(Failure)`, …).

Added explicit throwing arms for `Value::Version`, and for `Signature`/`Failure` as both `Value::Instance` and `Value::Package` (type object).

An **unhandled** Failure is unaffected: accessing its `.Capture` throws the underlying exception (e.g. `X::Meows`) before reaching this coercion — which the subtest's "unhandled" case requires (verified against `raku`).

## Not covered

`Whatever` / `WhateverCode` (`((*)).Capture`) still don't throw — these need currying-suppression of a doubly-parenthesized `*` (`(*).Capture` curries to a WhateverCode, but `((*)).Capture` evaluates immediately and throws), a separate parser concern.

## Tests

`roast/S02-types/version.t`, `S06-signature/introspection.t`, and `S04-exception-handlers/catch.t` remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY