### PR TITLE
fix(capture): Complex/Rat/FatRat .Capture expose attributes as nameds

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -710,6 +710,39 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             };
             Ok(Value::capture(positional, HashMap::new()))
         }
+        // Numeric types follow Mu.Capture: public attributes become nameds.
+        // Complex → \(:re, :im)
+        Value::Complex(r, i) => {
+            let mut named = HashMap::new();
+            named.insert("re".to_string(), Value::Num(*r));
+            named.insert("im".to_string(), Value::Num(*i));
+            Ok(Value::capture(vec![], named))
+        }
+        // Rat/FatRat/BigRat → \(:numerator, :denominator)
+        Value::Rat(n, d) => {
+            let mut named = HashMap::new();
+            named.insert("numerator".to_string(), Value::Int(*n));
+            named.insert("denominator".to_string(), Value::Int(*d));
+            Ok(Value::capture(vec![], named))
+        }
+        Value::FatRat(n, d) => {
+            let mut named = HashMap::new();
+            named.insert("numerator".to_string(), Value::Int(*n));
+            named.insert("denominator".to_string(), Value::Int(*d));
+            Ok(Value::capture(vec![], named))
+        }
+        Value::BigRat(n, d) => {
+            let mut named = HashMap::new();
+            named.insert(
+                "numerator".to_string(),
+                Value::BigInt(std::sync::Arc::new((**n).clone())),
+            );
+            named.insert(
+                "denominator".to_string(),
+                Value::BigInt(std::sync::Arc::new((**d).clone())),
+            );
+            Ok(Value::capture(vec![], named))
+        }
         // Pair.Capture → \(:key($pair.key), :value($pair.value))
         Value::Pair(k, v) => {
             let mut named = HashMap::new();


### PR DESCRIPTION
## Summary

Numeric types follow `Mu.Capture`: public attributes become named arguments. mutsu previously wrapped them as a single positional (`\(<42+1i>)`, `\(0.5)`).

- `Complex.Capture` → `\(:re, :im)`
- `Rat`/`FatRat`/`BigRat.Capture` → `\(:numerator, :denominator)`

Matches Rakudo:
- `(42+1i).Capture` → `\(:im(1e0), :re(42e0))`
- `(1/2).Capture` → `\(:denominator(2), :numerator(1))`

Advances `roast/S02-types/capture.t` subtest *"types whose .Capture behaves like Mu.Capture"* (Complex/Rat/FatRat cases).

## Tests

`roast/S32-num/complex.t`, `S32-num/rat.t`, `S32-num/fatrat.t` remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY