### PR TITLE
fix(vm): smartmatch env-sync must not clobber a readonly for/sub param

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -623,6 +623,16 @@ impl Interpreter {
             if !self.env().contains_key(name) {
                 continue;
             }
+            // Never clobber a name that is currently bound as a readonly param
+            // (a `for ... -> $x` / sub param). The compiler allocates one slot
+            // per *name* across the whole unit, so a sibling scope's `my $x`
+            // produces a `code.locals` entry that shares this name but whose
+            // slot is an uninitialised stale value here. The live binding lives
+            // in `env` (params are env-authoritative), so pushing the stale
+            // slot would overwrite the param with Nil. Skip it.
+            if self.is_readonly(name) {
+                continue;
+            }
             self.set_env_with_main_alias(name, self.locals[i].clone());
         }
     }


### PR DESCRIPTION
## Summary

A `~~` smartmatch flushes the frame's named locals into `env` (so a regex RHS can interpolate `$vars`) via `sync_regex_interpolation_env_from_locals`. The compiler allocates **one local slot per name** across the whole compilation unit, so a sibling scope's `my $x` produces a `code.locals` entry for `x` whose slot is an uninitialised (Nil) value in an unrelated frame.

When an earlier `for ... -> $x { ... ~~ ... }` binds `$x` as an env-authoritative readonly param (`param_local` was `None` because the slot was allocated *later* in source order), the sync pushed the stale Nil slot over `env["x"]`, so reads of `$x` after the smartmatch saw `Nil`.

### Minimal repro (before this fix)
```raku
for [9] -> $assigned {
    42 ~~ Int;            # smartmatch flushes locals → env
    say $assigned;        # printed Nil instead of 9
}
for 0 -> $z { my $assigned; }   # sibling `my` allocates the shared "assigned" slot
```

### Fix
Skip names currently bound as **readonly params** in that sync: their live value is in `env` (params are env-authoritative) and the same-named slot is a stale sibling-scope allocation. Regex interpolation is unaffected — the param's current value is already in env.

## Impact

`roast/S32-array/multislice-6e.t` previously **aborted at test 4** (planned 812). It now runs **788/812**; the remaining failures are unrelated multislice `:delete` / assignability semantics. `make test` (12542 tests) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY