### PR TITLE
fix(subscript): Array OOB is Any, array-valued subscript is a slice, type-object comparison coercion

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -988,6 +988,7 @@ roast/S29-context/sleep.t
 roast/S29-conversions/hash.t
 roast/S29-conversions/ord_and_chr.t
 roast/S29-os/system.t
+roast/S32-array/adverbs.t
 roast/S32-array/bool.t
 roast/S32-array/create.t
 roast/S32-array/delete-adverb-native.t

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -380,6 +380,10 @@ fn parse_destructuring_with_rhs(
             && dvar.name.starts_with('@')
             && !vars[i + 1..].iter().any(|v| !v.is_slurpy);
 
+        let effective_tc = dvar
+            .per_var_type_constraint
+            .clone()
+            .or_else(|| type_constraint.clone());
         let expr = if dvar.is_slurpy || is_implicit_slurpy {
             Expr::Index {
                 target: Box::new(Expr::ArrayVar(array_bare.clone())),
@@ -391,16 +395,26 @@ fn parse_destructuring_with_rhs(
                 is_positional: true,
             }
         } else {
-            Expr::Index {
+            let read = Expr::Index {
                 target: Box::new(Expr::ArrayVar(array_bare.clone())),
                 index: Box::new(Expr::Literal(Value::Int(i as i64))),
                 is_positional: true,
+            };
+            // A *typed* element whose RHS ran out of values gets the type's
+            // DEFAULT, not the `Any` an out-of-range Array read now yields
+            // (`my Str ($a) = ()` → `$a` is `Str`, not the un-assignable `Any`).
+            // Untyped vars keep the raw `Any`. The `// default` fallback fires
+            // only for an undefined (missing) read, so present values pass through.
+            if effective_tc.is_some() {
+                Expr::Binary {
+                    left: Box::new(read),
+                    op: TokenKind::SlashSlash,
+                    right: Box::new(native_type_default(&effective_tc)),
+                }
+            } else {
+                read
             }
         };
-        let effective_tc = dvar
-            .per_var_type_constraint
-            .clone()
-            .or_else(|| type_constraint.clone());
         let effective_where = dvar.where_constraint.clone().map(Box::new);
         stmts.push(Stmt::VarDecl {
             name: dvar.name.clone(),

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -202,6 +202,11 @@ impl Interpreter {
         // auto-truncates at the array end: out-of-range indices are dropped rather
         // than reported as missing. An eager Range keeps missing elements.
         let mut truncate_oob = false;
+        // A list-valued subscript (`@a[@b]`, `@a[(1,)]`, `@a[1..2]`, a Seq, ...)
+        // is ALWAYS a slice and yields a list result, even for a single index —
+        // `@a[@b]:!v` is `($T,)`, not the scalar `$T`. Only a bare scalar
+        // subscript (`@a[11]:!v`) returns a scalar.
+        let mut force_list = true;
         let mut indices = match index {
             Value::Array(items, ..) => items.to_vec(),
             // A Range subscript on a hash is a multi-key slice (`%h{"b".."c"}:kv`),
@@ -215,7 +220,10 @@ impl Interpreter {
                 truncate_oob = true;
                 self.force_lazy_list_vm(ll)?
             }
-            other => vec![other],
+            other => {
+                force_list = false;
+                vec![other]
+            }
         };
         // Resolve WhateverCode indices (e.g. `@a[*-1]:k`) by applying them to the
         // target's length, exactly as the plain-value subscript path does.
@@ -256,7 +264,7 @@ impl Interpreter {
                     .is_ok_and(|i| i >= 0 && i < len),
             });
         }
-        let is_multi = indices.len() != 1;
+        let is_multi = indices.len() != 1 || force_list;
 
         let mut rows: Vec<(Value, Value, bool)> = Vec::with_capacity(indices.len());
         match &target {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3511,14 +3511,11 @@ pub(crate) fn to_float_value(val: &Value) -> Option<f64> {
             .as_map()
             .get("__mutsu_int_value")
             .and_then(to_float_value),
-        // A numeric type object (e.g. `Rat`, `FatRat`, `Int`) numifies to 0 in
+        // A type object (e.g. `Any`, `Str`, `Rat`, a user class) numifies to 0 in
         // numeric context (Raku warns "Use of uninitialized value"). This makes
-        // `(Rat) == 0` true, matching Rakudo.
-        Value::Package(name) => match name.resolve().as_str() {
-            "Int" | "UInt" | "Rat" | "FatRat" | "Num" | "Rational" | "Complex" | "Numeric"
-            | "Real" | "IntStr" | "RatStr" | "NumStr" | "ComplexStr" => Some(0.0),
-            _ => None,
-        },
+        // `(Any) == 0` / `@a[oob] == 0` true, matching Rakudo. (`Mu` alone has no
+        // Numeric and dies in raku, but treating it as 0 is a harmless divergence.)
+        Value::Package(_) => Some(0.0),
         _ => None,
     }
 }

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -15,7 +15,7 @@ impl Interpreter {
                     Self::buf_cmp_bytes(&l, &r) == std::cmp::Ordering::Equal,
                 ))
             } else {
-                Ok(Value::Bool(l.to_string_value() == r.to_string_value()))
+                Ok(Value::Bool(l.to_str_context() == r.to_str_context()))
             }
         })?;
         self.stack.push(result);
@@ -34,7 +34,7 @@ impl Interpreter {
                     Self::buf_cmp_bytes(&l, &r) == std::cmp::Ordering::Equal,
                 ))
             } else {
-                Ok(Value::Bool(l.to_string_value() == r.to_string_value()))
+                Ok(Value::Bool(l.to_str_context() == r.to_str_context()))
             }
         })?;
         self.stack.push(Value::Bool(!eq_result.truthy()));
@@ -56,7 +56,7 @@ impl Interpreter {
                     Self::buf_cmp_bytes(&l, &r) == std::cmp::Ordering::Less,
                 ))
             } else {
-                Ok(Value::Bool(l.to_string_value() < r.to_string_value()))
+                Ok(Value::Bool(l.to_str_context() < r.to_str_context()))
             }
         })?;
         self.stack.push(result);
@@ -72,7 +72,7 @@ impl Interpreter {
                     Self::buf_cmp_bytes(&l, &r) == std::cmp::Ordering::Greater,
                 ))
             } else {
-                Ok(Value::Bool(l.to_string_value() > r.to_string_value()))
+                Ok(Value::Bool(l.to_str_context() > r.to_str_context()))
             }
         })?;
         self.stack.push(result);
@@ -88,7 +88,7 @@ impl Interpreter {
                     Self::buf_cmp_bytes(&l, &r) != std::cmp::Ordering::Greater,
                 ))
             } else {
-                Ok(Value::Bool(l.to_string_value() <= r.to_string_value()))
+                Ok(Value::Bool(l.to_str_context() <= r.to_str_context()))
             }
         })?;
         self.stack.push(result);
@@ -104,7 +104,7 @@ impl Interpreter {
                     Self::buf_cmp_bytes(&l, &r) != std::cmp::Ordering::Less,
                 ))
             } else {
-                Ok(Value::Bool(l.to_string_value() >= r.to_string_value()))
+                Ok(Value::Bool(l.to_str_context() >= r.to_str_context()))
             }
         })?;
         self.stack.push(result);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -609,8 +609,11 @@ impl Interpreter {
                 // (`@a[0;1]` uses MultiDimIndex, a separate opcode). A plain
                 // array-of-arrays is NOT shaped, so it slices.
                 let is_shaped = crate::runtime::utils::is_shaped_array(&target);
-                if !is_shaped && indices.len() > 1 {
-                    // Positional slice: @a[0,1,2] returns (@a[0], @a[1], @a[2])
+                if !is_shaped {
+                    // Positional slice: @a[0,1,2] returns (@a[0], @a[1], @a[2]).
+                    // An array-valued subscript is ALWAYS a slice, so a single
+                    // element (`@a[@b]`, `@a[(1,)]`) still yields a 1-list, not a
+                    // scalar (raku: `@a[(1,)]` is `(20,)`, not `20`).
                     let Value::Array(items, kind) = &target else {
                         unreachable!()
                     };

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -324,7 +324,13 @@ impl Interpreter {
                 return def;
             }
             Value::Package(Symbol::intern(&info.value_type))
-        } else if matches!(target, Value::Hash(_)) {
+        } else if matches!(target, Value::Hash(_))
+            || matches!(target, Value::Array(_, kind) if kind.is_real_array())
+        {
+            // An untyped Array/Hash defaults its missing elements to the `Any`
+            // type object (raku: `my @a; @a[5]` is `Any`), not `Nil`. A *List*
+            // (`(1,2,3)[11]`, `()[0]`) is out-of-range → `Nil`, so only a real
+            // `Array` (`[...]`/`my @a`) gets the `Any` default.
             Value::Package(Symbol::intern("Any"))
         } else {
             Value::Nil

--- a/t/array-oob-any.t
+++ b/t/array-oob-any.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 24;
+
+# An out-of-range read on a real Array yields the `Any` type object (not Nil),
+# while a List yields Nil.
+{
+    my @a = 1, 2, 3;
+    is @a[11].^name, 'Any', 'untyped Array OOB is Any';
+    is [1, 2, 3][11].^name, 'Any', 'Array literal OOB is Any';
+    is (1, 2, 3)[11].raku, 'Nil', 'List OOB is Nil';
+    is ().[0].raku, 'Nil', 'empty List OOB is Nil';
+
+    my Str @s = 'a', 'b';
+    is @s[11].^name, 'Str', 'typed Array OOB is the element type';
+}
+
+# A type object coerces to "" (Str context) and 0 (numeric context).
+{
+    ok Any eq '', 'Any eq ""';
+    ok Str eq '', 'Str eq ""';
+    ok Int == 0, 'Int == 0';
+    ok Any == 0, 'Any == 0';
+    my @foo;
+    ok @foo[0] eq '', 'Array OOB eq ""';
+    ok @foo[0] == 0, 'Array OOB == 0';
+    ok @foo[0] ne 'f', 'Array OOB ne "f"';
+}
+
+# An array-valued subscript is always a slice (a 1-element list, not a scalar).
+{
+    my @a = 10, 20, 30;
+    my @b = 1;
+    is-deeply @a[@b], (20,), '@a[@b] single-elem slice is a list';
+    is-deeply @a[(1,)], (20,), '@a[(1,)] is a list';
+    is-deeply @a[1,], (20,), '@a[1,] is a list';
+    is @a[1], 20, '@a[1] scalar subscript stays scalar';
+    is-deeply @a[@b]:!v, (20,), '@a[@b]:!v is a list';
+
+    my @B = 11;
+    is-deeply @a[@B], (Any,), 'missing array slice yields (Any,)';
+    is-deeply @a[@B]:!v, (Any,), 'missing array :!v yields (Any,)';
+}
+
+# List-destructuring assignment fills missing typed slots with the type default.
+{
+    my Str ($a) = ();
+    is $a.^name, 'Str', 'my Str ($a) = () gives the Str default';
+    my ($b) = ();
+    is $b.^name, 'Any', 'untyped destructure missing is Any';
+    my Int ($c) = ();
+    is $c.^name, 'Int', 'my Int ($c) = () gives the Int default';
+    my ($d, $e) = 5;
+    is $e.^name, 'Any', 'untyped short destructure missing is Any';
+    my Str ($f) = 'x';
+    is $f, 'x', 'present value passes through';
+}

--- a/t/junction-ops.t
+++ b/t/junction-ops.t
@@ -12,4 +12,4 @@ nok 1 ^ 1 == 1, 'junction ^ fails when more than one matches';
 ok 1^2 == 2, 'junction ^ parses without surrounding spaces';
 nok 1^1 == 1, 'junction ^ without spaces fails when more than one matches';
 
-ok (1 | 2).WHAT eq '(Junction)', 'junction operator constructs junction';
+ok (1 | 2).^name eq 'Junction', 'junction operator constructs junction';


### PR DESCRIPTION
## Summary

Fixes `S32-array/adverbs.t` (now 606/606, whitelisted) by aligning out-of-range
array reads and single-element array slices with Rakudo, plus the type-object
coercions that fall out of it.

Four coupled changes:

1. **Array OOB → `Any`.** An out-of-range read on a *real* Array yields the
   `Any` type object, not `Nil` (`my @a; @a[5]` is `Any`). A List
   (`(1,2,3)[11]`, `()[0]`) is still `Nil`, gated on `ArrayKind::is_real_array`.

2. **Array-valued subscript is always a slice.** `@a[@b]`, `@a[(1,)]`, `@a[1,]`
   yield a 1-list even for a single element, not a scalar — both in the plain
   index path and in `__mutsu_subscript_adverb` (`@a[@b]:!v` is `($T,)`).

3. **Type objects coerce in comparisons.** A type object stringifies to `""`
   (`Any eq ""` is True) and numifies to `0` (`Any == 0` is True), matching
   Rakudo. Previously a type object compared as its gist (`"(Any)"`), which is
   non-spec — this was a latent bug exposed by change 1.

4. **Typed list-destructure defaults.** A missing *typed* slot gets the type's
   default rather than the now-`Any` OOB read (`my Str ($a) = ()` → `Str`).
   Untyped slots keep `Any`.

The local `t/junction-ops.t` relied on the old gist-stringification of a type
object in `eq`; switched it to `.^name` (raku itself dies on `Junction eq Str`).

## Testing

- `S32-array/adverbs.t`: 600/606 → **606/606** (whitelisted)
- `S32-hash/adverbs.t`: 56 → 48 failures (no regression, improved)
- Broad local sweep of 610 + 281 whitelisted files: no regressions
- `make test`: cargo 470/470; the one `t/junction-ops.t` regression fixed
- New `t/array-oob-any.t` (24 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY