### PR TITLE
fix(lazy): .List/.Array preserve laziness; eqv throws X::Cannot::Lazy on both-lazy (eqv.t)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -212,6 +212,7 @@ roast/S03-operators/context.t
 roast/S03-operators/custom.t
 roast/S03-operators/div.t
 roast/S03-operators/equality.t
+roast/S03-operators/eqv.t
 roast/S03-operators/flip-flop.t
 roast/S03-operators/gcd.t
 roast/S03-operators/identity.t

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -492,6 +492,20 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         Some(Ok(Value::array(items.to_vec())))
                     }
                 }
+                // A genuinely-lazy list stays lazy through `.Array`/`.list`:
+                // tag it with the target context so `.WHAT` reports `Array`/`List`
+                // without materializing the (possibly infinite) generator.
+                Value::LazyList(ll) if ll.is_genuinely_lazy() => {
+                    if want_array {
+                        Some(Ok(Value::LazyList(std::sync::Arc::new(
+                            ll.with_array_context(),
+                        ))))
+                    } else {
+                        Some(Ok(Value::LazyList(std::sync::Arc::new(
+                            ll.with_list_context(),
+                        ))))
+                    }
+                }
                 Value::Channel(_) => None, // fall through to runtime for drain
                 Value::Hash(map) => {
                     let pairs: Vec<Value> = map

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -43,9 +43,10 @@ impl Interpreter {
             | Value::GenericRange { .. } => "Range",
             Value::Array(_, kind) if kind.is_real_array() => "Array",
             Value::Array(_, _) => "List",
-            // A lazy list assigned into an `@` array reports `Array`; a bare Seq
-            // (scalar-held) reports `Seq`.
+            // A lazy list assigned into an `@` array reports `Array`; one coerced
+            // via `.List` reports `List`; a bare Seq (scalar-held) reports `Seq`.
             Value::LazyList(ll) if ll.in_array_context() => "Array",
+            Value::LazyList(ll) if ll.in_list_context() => "List",
             Value::LazyList(_) => "Seq",
             Value::Hash(_) => "Hash",
             Value::Rat(_, _) => "Rat",

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -102,6 +102,15 @@ impl Interpreter {
                 ));
             }
         }
+        // A genuinely-lazy list (`(1…∞).List`) must STAY lazy: materializing it
+        // would lose the infinite tail (and `.elems`/`eqv` must still throw
+        // X::Cannot::Lazy). Tag it as `.List`-coerced so `.WHAT` reports `List`
+        // while the generator is untouched.
+        if let Value::LazyList(ll) = &target
+            && ll.is_genuinely_lazy()
+        {
+            return Ok(Value::LazyList(std::sync::Arc::new(ll.with_list_context())));
+        }
         let items = Self::value_to_list(&target);
         Ok(Value::Array(
             std::sync::Arc::new(crate::value::ArrayData::new(items)),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -2046,6 +2046,27 @@ impl LazyList {
         cloned
     }
 
+    pub(crate) const LIST_CONTEXT_MARKER: &'static str = "__mutsu_lazylist_list_context";
+
+    /// Whether this lazy list was coerced via `.List` (so `.WHAT` is `List`,
+    /// not the default `Seq`). Mutually exclusive with array context in practice.
+    pub(crate) fn in_list_context(&self) -> bool {
+        matches!(
+            self.env.get(Self::LIST_CONTEXT_MARKER),
+            Some(Value::Bool(true))
+        )
+    }
+
+    /// Return a clone of this list tagged as a `.List`-coerced list. Preserves
+    /// laziness (the generator is untouched) while making `.WHAT` report `List`.
+    pub(crate) fn with_list_context(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned
+            .env
+            .insert(Self::LIST_CONTEXT_MARKER.to_string(), Value::Bool(true));
+        cloned
+    }
+
     /// Create a pre-cached lazy list (no body to evaluate).
     pub(crate) fn new_cached(items: Vec<Value>) -> Self {
         Self {

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -483,9 +483,40 @@ impl Interpreter {
         Ok(())
     }
 
+    /// The `.WHAT`-flavoured type tag of a *genuinely lazy* iterable (one that
+    /// `eqv` cannot compare without iterating forever), or `None` when the value
+    /// is not lazy. The tag follows `.WHAT`: a bare lazy `Seq` is `Seq`, a
+    /// `.List`-coerced one is `List`, a `.Array`/`@`-coerced one is `Array`.
+    fn lazy_eqv_type(v: &Value) -> Option<&'static str> {
+        match v {
+            Value::LazyList(ll) if ll.is_genuinely_lazy() => Some(if ll.in_array_context() {
+                "Array"
+            } else if ll.in_list_context() {
+                "List"
+            } else {
+                "Seq"
+            }),
+            Value::Array(_, kind) if kind.is_lazy() => Some("Array"),
+            _ => None,
+        }
+    }
+
     pub(super) fn exec_eqv_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        // `eqv` on two lazy iterables of the SAME type cannot be answered without
+        // iterating them, so it throws X::Cannot::Lazy (action `eqv`). Two lazy
+        // iterables of DIFFERENT type are trivially not-eqv (no iteration needed),
+        // and a single lazy operand falls through to the normal element compare,
+        // which short-circuits on the length/laziness mismatch.
+        match (Self::lazy_eqv_type(&left), Self::lazy_eqv_type(&right)) {
+            (Some(a), Some(b)) if a == b => return Err(RuntimeError::cannot_lazy("eqv")),
+            (Some(_), Some(_)) => {
+                self.stack.push(Value::Bool(false));
+                return Ok(());
+            }
+            _ => {}
+        }
         let result =
             self.eval_binary_with_junctions(left, right, |_, l, r| Ok(Value::Bool(l.eqv(&r))))?;
         self.stack.push(result);

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -303,7 +303,7 @@ impl Interpreter {
     pub(crate) fn lazy_pipe_preserving_coercion(method: &str) -> bool {
         matches!(
             method,
-            "Seq" | "List" | "list" | "cache" | "values" | "lazy"
+            "Seq" | "List" | "list" | "Array" | "cache" | "values" | "lazy"
         )
     }
 

--- a/t/eqv-lazy.t
+++ b/t/eqv-lazy.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 16;
+
+# `.List` / `.Array` on a genuinely-lazy sequence preserve laziness (they must
+# NOT materialize the infinite tail) and report the coerced `.WHAT`.
+{
+    ok (1…∞).is-lazy,        'infinite Seq is lazy';
+    ok (1…∞).List.is-lazy,   '.List of a lazy Seq stays lazy';
+    ok (1…∞).Array.is-lazy,  '.Array of a lazy Seq stays lazy';
+    is (1…∞).WHAT.^name,       'Seq',   'lazy Seq .WHAT is Seq';
+    is (1…∞).List.WHAT.^name,  'List',  'lazy .List .WHAT is List';
+    is (1…∞).Array.WHAT.^name, 'Array', 'lazy .Array .WHAT is Array';
+    is-deeply (1…∞).List.head(3).List,  (1, 2, 3), 'lazy .List still iterates';
+    is-deeply (1…∞).Array.head(3).List, (1, 2, 3), 'lazy .Array still iterates';
+}
+
+# A finite sequence coerces eagerly (not lazy).
+{
+    nok (1…3).List.is-lazy,  'finite .List is eager';
+    nok (1…3).Array.is-lazy, 'finite .Array is eager';
+}
+
+# `eqv` on two lazy iterables of the SAME type throws X::Cannot::Lazy; of
+# different types (or with only one lazy operand) it lives.
+{
+    throws-like { (1…∞)       eqv (1…∞)       }, X::Cannot::Lazy, :action<eqv>,
+        'both lazy Seqs throw';
+    throws-like { (1…∞).List  eqv (1…∞).List  }, X::Cannot::Lazy, :action<eqv>,
+        'both lazy Lists throw';
+    throws-like { (1…∞).Array eqv (1…∞).Array }, X::Cannot::Lazy, :action<eqv>,
+        'both lazy Arrays throw';
+    lives-ok { (1…∞) eqv (1…∞).List }, 'both lazy but different type lives';
+    lives-ok { (1…∞) eqv (1, 3)     }, 'only one lazy lives';
+    lives-ok { (1…∞).List eqv (1…3).List }, 'one lazy List lives';
+}


### PR DESCRIPTION
## Summary

Greens `S03-operators/eqv.t` (whitelisted) — the first concrete step into the
true-lazy-array lever (BLOCKERS §3.2) — by making lazy-sequence coercion and
`eqv` match Rakudo.

1. **`.List` / `.Array` / `.list` on a genuinely-lazy sequence stay lazy.**
   Previously `.List` materialized the cache (losing the infinite tail) and
   `.Array` threw `Cannot .Array a lazy list`. Now they preserve the generator
   and report the coerced `.WHAT`: a `.List`-coerced lazy list is `List`,
   `.Array`-coerced is `Array`, a bare lazy Seq is `Seq`. Tracked with a new
   `LIST_CONTEXT_MARKER` env tag on `LazyList`, mirroring the existing
   array-context marker. `.head`/`[^n]` still iterate; `.elems` still throws.

2. **`eqv` on two lazy iterables of the SAME type throws `X::Cannot::Lazy`**
   (`:action<eqv>`) — comparing them would iterate forever. Different lazy types
   are trivially not-eqv (no iteration); a single lazy operand falls through to
   the normal element compare, which short-circuits.

`.Array` is added to `lazy_pipe_preserving_coercion` so the VM no longer
force-materializes it.

## Testing

- `S03-operators/eqv.t`: **64/64** (whitelisted)
- 88 lazy/seq/list whitelisted tests: pass
- Broad sweep of 691 whitelisted files (S02/S03/S04/S06/S29/S32): no regressions
  (the only non-passes are the CWD-dependent CJK-encoding tests and the known
  stale-temp-file `spurt.t` flaky, both unrelated)
- `make test`: cargo 470/470, t/ pass
- New `t/eqv-lazy.t` (16 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY