### PR TITLE
fix(parser): sequence operator in a subscript seeds from the whole comma list

### DIFF
--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -665,7 +665,26 @@ fn parse_bracket_indices_inner(input: &str) -> PResult<'_, ParsedBracketIndex> {
                 continue;
             }
             let (r3, next) = expression(r3)?;
-            current_dim.push(next);
+            // `@a[0, 2 ... *]` — the sequence operator's seed is the WHOLE
+            // preceding comma list, not just its immediate left operand
+            // (raku parses this as `(0, 2) ... *`). When a comma item turns out
+            // to be a sequence, fold the items gathered so far into its seed.
+            if let Expr::Binary {
+                left,
+                op: op @ (TokenKind::DotDotDot | TokenKind::DotDotDotCaret),
+                right,
+            } = next
+            {
+                let mut seed = std::mem::take(&mut current_dim);
+                seed.push(*left);
+                current_dim = vec![Expr::Binary {
+                    left: Box::new(Expr::ArrayLiteral(seed)),
+                    op,
+                    right,
+                }];
+            } else {
+                current_dim.push(next);
+            }
             r = r3;
             continue;
         }

--- a/t/subscript-sequence-seed.t
+++ b/t/subscript-sequence-seed.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 8;
+
+# The sequence operator inside a subscript takes the WHOLE preceding comma list
+# as its seed: `@a[0, 2 ... *]` is `@a[(0,2)...*]`, indices 0,2,4,…, not
+# `@a[0, (2...*)]`.
+my @array = 3, 7, 9, 11;
+
+is-deeply @array[0, 2 ... *], (3, 9),  'even-index infinite slice seeds from (0,2)';
+is-deeply @array[1, 3 ... *], (7, 11), 'odd-index infinite slice seeds from (1,3)';
+is-deeply @array[0 ... *],    (3, 7, 9, 11), 'single-seed infinite slice';
+is-deeply @array[0, 1 ... *], (3, 7, 9, 11), 'consecutive infinite slice';
+
+# Finite sequence subscripts seed the same way.
+is-deeply @array[0, 2 ... 4], (3, 9, Any), 'finite even sequence seeds from (0,2)';
+
+# A plain comma slice (no sequence operator) is unaffected.
+is-deeply @array[0, 1, 2], (3, 7, 9), 'plain comma slice still a slice';
+is-deeply @array[0 .. 2],  (3, 7, 9), 'range slice still works';
+
+# Three-element seed.
+is-deeply @array[0, 1, 2 ... *], (3, 7, 9, 11), 'three-element seed';


### PR DESCRIPTION
## Summary

`@a[0, 2 ... *]` must parse as `@a[(0, 2) ... *]` (indices 0, 2, 4, …), matching
raku — not `@a[0, (2 ... *)]`. The bracket-index parser collected comma-separated
items individually, so the sequence operator (`...` / `...^`) only saw its
immediate left operand (`2`) as the seed instead of the whole preceding list
`(0, 2)`. The fix folds the items gathered so far into the sequence seed when a
comma item turns out to be a sequence.

Before: `my @a = 3,7,9,11; @a[0,2...*]` → `(3, Any)`
After:  `(3, 9)` (raku-correct: indices 0, 2; 4+ are out of range and truncated)

This is a real correctness fix in the lazy-sequence area. Note `S09-subscript/slice.t`
itself is not whitelist-eligible (raku aborts it at test 22 on a 6.e construct),
but this fixes two of its concrete failures plus the general behavior.

## Testing

- New `t/subscript-sequence-seed.t` (8 assertions)
- 93 subscript/slice/array/list whitelisted tests: pass
- Broad sweep of 608 whitelisted files (S02/S03/S04/S09/S32): no regressions
  (only the CWD-dependent CJK-encode tests + stale-temp `spurt.t` flaky)
- `make test`: cargo 470/470, t/ pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY