### PR TITLE
fix(caller): CALLER::<$x> resolves caller-frame lexical; non-dynamic throws X::Caller::NotDynamic

### DIFF
--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -348,6 +348,28 @@ impl Compiler {
         let saved_terminal = self.bind_terminal;
         self.bind_terminal = false; // inner `target` indices are intermediate
 
+        // Special case: CALLER::<$x> stash-subscript access resolves a caller-frame
+        // lexical, exactly like the `$CALLER::x` symbolic form. Route both to the
+        // same GetCallerVar opcode so the dynamic-ness check (X::Caller::NotDynamic)
+        // and frame walk are shared. Supports nested CALLER::CALLER::<$x> too.
+        if let Expr::PseudoStash(stash) = target
+            && let Some((rest, depth)) = Self::parse_caller_prefix(stash)
+            && rest.is_empty()
+            && let Expr::Literal(Value::Str(key)) = index
+        {
+            let bare: String = match key.chars().next() {
+                Some('$' | '@' | '%' | '&') => key.chars().skip(1).collect(),
+                _ => key.as_ref().clone(),
+            };
+            let name_idx = self.code.add_constant(Value::str(bare));
+            self.code.emit(OpCode::GetCallerVar {
+                name_idx,
+                depth: depth as u32,
+            });
+            self.bind_terminal = saved_terminal;
+            return;
+        }
+
         // Special case: %*ENV<key> compiles to GetEnvIndex
         if let Expr::HashVar(name) = target {
             if name == "*ENV" {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5536,9 +5536,7 @@ impl Interpreter {
         if let Some(val) = env.get(name) {
             // Check that the variable is declared `is dynamic`
             if !self.is_var_dynamic(name) {
-                return Err(RuntimeError::new(format!(
-                    "Cannot access '${name}' through CALLER, because it is not declared as dynamic"
-                )));
+                return Err(crate::runtime::utils::caller_not_dynamic_error(name));
             }
             Ok(val.clone())
         } else {
@@ -5562,9 +5560,7 @@ impl Interpreter {
             )));
         }
         if !self.is_var_dynamic(name) {
-            return Err(RuntimeError::new(format!(
-                "Cannot access '${name}' through CALLER, because it is not declared as dynamic"
-            )));
+            return Err(crate::runtime::utils::caller_not_dynamic_error(name));
         }
         let idx = stack_len - depth;
         self.caller_env_stack[idx].insert(name.to_string(), value.clone());

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -3831,6 +3831,21 @@ pub(crate) fn dynamic_not_found_error(display_name: &str) -> RuntimeError {
     RuntimeError::typed("X::Dynamic::NotFound", attrs)
 }
 
+/// Build a structured X::Caller::NotDynamic RuntimeError.
+/// Thrown when accessing a caller-frame lexical through `CALLER::` (either the
+/// `$CALLER::x` symbolic form or the `CALLER::<$x>` stash-subscript form) when
+/// that variable is not declared `is dynamic`. `name` is the bare variable name
+/// without sigil; the reported `symbol` re-adds the `$` sigil.
+pub(crate) fn caller_not_dynamic_error(name: &str) -> RuntimeError {
+    let symbol = format!("${name}");
+    let msg =
+        format!("Cannot access '{symbol}' through CALLER, because it is not declared as dynamic");
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("symbol".to_string(), Value::str(symbol));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
+    RuntimeError::typed("X::Caller::NotDynamic", attrs)
+}
+
 /// Build a structured X::TypeCheck::Assignment RuntimeError.
 /// This creates a proper exception object that `throws-like` can match.
 pub(crate) fn type_check_assignment_typed_error(

--- a/t/caller-not-dynamic.t
+++ b/t/caller-not-dynamic.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 5;
+
+# CALLER::<$x> stash-subscript form resolves a caller-frame lexical, exactly
+# like the $CALLER::x symbolic form. Accessing a non-dynamic variable through
+# CALLER throws X::Caller::NotDynamic.
+
+# Non-dynamic variable: both forms throw X::Caller::NotDynamic.
+throws-like 'sub f() { CALLER::<$x> }; my $x; f',
+    X::Caller::NotDynamic, symbol => '$x',
+    'CALLER::<$x> on a non-dynamic var throws X::Caller::NotDynamic';
+
+throws-like 'sub f() { $CALLER::x }; my $x; f',
+    X::Caller::NotDynamic, symbol => '$x',
+    '$CALLER::x on a non-dynamic var throws X::Caller::NotDynamic';
+
+# Dynamic variable: the subscript form resolves the caller's value.
+sub get-bar() { CALLER::<$*bar> }
+{
+    my $*bar = 93;
+    is get-bar(), 93, 'CALLER::<$*bar> resolves a dynamic caller var';
+}
+
+# The symbol field reflects the accessed variable name.
+throws-like 'sub g() { CALLER::<$abc> }; my $abc; g',
+    X::Caller::NotDynamic, symbol => '$abc',
+    'symbol field reflects the accessed variable name';
+
+# Nested CALLER::CALLER::<$*v> walks two frames for a dynamic var.
+sub inner() { CALLER::CALLER::<$*v> }
+sub outer() { inner() }
+{
+    my $*v = 'deep';
+    is outer(), 'deep', 'CALLER::CALLER::<$*v> walks two caller frames';
+}


### PR DESCRIPTION
## Summary

The `CALLER::<$x>` stash-subscript form previously returned `Nil` for **every** access — it routed through `package_stash_value("CALLER")`, which never consulted the caller frame. Even `CALLER::<$*dyn>` for a live dynamic variable produced `Nil`.

This routes the subscript form (and nested `CALLER::CALLER::<$x>`) through the same `GetCallerVar` opcode the `$CALLER::x` symbolic form already uses, sharing the caller-frame walk and the dynamic-ness check.

Accessing a non-dynamic caller lexical through `CALLER` now throws a typed `X::Caller::NotDynamic` (with a `symbol` attribute) instead of a generic RuntimeError, matching rakudo. Both `get_caller_var` and `set_caller_var` use the new `caller_not_dynamic_error` helper.

## Effect

- `roast/S32-exceptions/misc.t` test 7 (`throws-like … X::Caller::NotDynamic`) now passes.
- `roast/S02-names/pseudo-6e.t` `CALLER::<$*bar> works` (test 135) now passes (was returning `Nil`).
- New `t/caller-not-dynamic.t` (5 subtests), all passing.

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY