### PR TITLE
fix(dispatch): Sub/Block binding failure is X::TypeCheck::Binding, not X::TypeCheck::Argument

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1272,6 +1272,7 @@ roast/integration/advent2012-day24.t
 roast/integration/advent2013-day07.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t
+roast/integration/code-blocks-as-sub-args.t
 roast/integration/eval-and-threads.t
 roast/integration/failure-and-callsame.t
 roast/integration/lexical-array-in-inner-block.t

--- a/scripts/near-pass-scan.sh
+++ b/scripts/near-pass-scan.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Scan non-whitelisted roast tests and record per-file (plan, failed) counts so
+# near-pass files (1-2 failing subtests) can be prioritized for whitelisting.
+# Output: tmp/near-pass.tsv  columns: failed<TAB>plan<TAB>ran<TAB>file
+# Sorted by failed ascending (most-nearly-passing first).
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+MUTSU=./target/release/mutsu
+export MUTSU_FUDGE=1
+TIMEOUT=15
+OUT=tmp/near-pass.tsv
+> "$OUT"
+
+# All roast .t files NOT already whitelisted.
+mapfile -t ALL < <(find roast -name '*.t' -type f | sort)
+mapfile -t WL < <(sort roast-whitelist.txt)
+
+declare -A IS_WL
+for w in "${WL[@]}"; do IS_WL["$w"]=1; done
+
+count=0
+for f in "${ALL[@]}"; do
+  [ -n "${IS_WL[$f]:-}" ] && continue
+  count=$((count+1))
+  EXIT_CODE=0
+  OUTPUT=$(timeout "$TIMEOUT" "$MUTSU" "$f" 2>/dev/null | tr -d '\0') || EXIT_CODE=$?
+  [ "$EXIT_CODE" -eq 124 ] && continue   # timeout: skip
+  PLAN=$(echo "$OUTPUT" | grep -oE '^1\.\.[0-9]+' | head -1 | sed 's/1\.\.//')
+  PLAN=$(echo "$PLAN" | grep -oE '^[0-9]+$' || true)
+  [ -z "$PLAN" ] && continue             # no plan: skip (parse/error)
+  OK=$(echo "$OUTPUT" | grep -cE '^ok [0-9]' || true)
+  NOK=$(echo "$OUTPUT" | grep -E '^not ok [0-9]' | grep -cvE '# TODO' || true)
+  RAN=$((OK + NOK))
+  # Treat plan-not-reached as additional missing tests.
+  MISSING=$((PLAN - RAN))
+  [ "$MISSING" -lt 0 ] && MISSING=0
+  TOTAL_BAD=$((NOK + MISSING))
+  [ "$TOTAL_BAD" -eq 0 ] && continue      # fully passing (would already be whitelistable)
+  printf '%d\t%d\t%d\t%s\n' "$TOTAL_BAD" "$PLAN" "$RAN" "$f" >> "$OUT"
+done
+
+sort -n -k1,1 "$OUT" -o "$OUT"
+echo "Scanned $count non-whitelisted files. Near-pass candidates (failed<=3):"
+awk -F'\t' '$1<=3' "$OUT"

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -515,6 +515,64 @@ impl Interpreter {
         format!("({})", sig_parts.join(", "))
     }
 
+    /// Extract the expected type name from a binding type-check error message.
+    /// Handles both message shapes mutsu emits:
+    ///   "... expected Sub, got Block"
+    ///   "... expected Int but got Str"
+    fn extract_expected_type(message: &str) -> Option<String> {
+        let after = message.rsplit_once("expected ")?.1;
+        let end = after
+            .find([',', ';'])
+            .or_else(|| after.find(" but "))
+            .unwrap_or(after.len());
+        let ty = after[..end].trim();
+        if ty.is_empty() {
+            None
+        } else {
+            Some(ty.to_string())
+        }
+    }
+
+    /// True for the simple built-in types whose binding failure raku surfaces as
+    /// a compile-time X::TypeCheck::Argument (rather than a runtime
+    /// X::TypeCheck::Binding::Parameter). Notably excludes `Sub`/`Block` and other
+    /// `Callable` refinements, which are only checked at run time.
+    fn is_simple_argument_type(ty: &str) -> bool {
+        matches!(
+            ty,
+            "Int"
+                | "Str"
+                | "Bool"
+                | "Num"
+                | "Rat"
+                | "Complex"
+                | "Real"
+                | "Numeric"
+                | "Cool"
+                | "Any"
+                | "Mu"
+                | "IO"
+                | "Regex"
+                | "Callable"
+                | "Positional"
+                | "Associative"
+                | "Range"
+                | "Match"
+                | "Pair"
+                | "List"
+                | "Array"
+                | "Hash"
+                | "Set"
+                | "Bag"
+                | "Mix"
+                | "Junction"
+                | "Seq"
+                | "Supply"
+                | "Promise"
+                | "Channel"
+        )
+    }
+
     /// Enhance a binding error with function name, call profile, and signature info.
     pub(crate) fn enhance_binding_error(
         err: RuntimeError,
@@ -574,43 +632,28 @@ impl Interpreter {
                         || pd.name.starts_with('%')
                         || pd.name.starts_with('&'))
             })
-            && param_defs.iter().any(|pd| {
-                pd.type_constraint.as_ref().is_some_and(|tc| {
-                    matches!(
-                        tc.as_str(),
-                        "Int"
-                            | "Str"
-                            | "Bool"
-                            | "Num"
-                            | "Rat"
-                            | "Complex"
-                            | "Real"
-                            | "Numeric"
-                            | "Cool"
-                            | "Any"
-                            | "Mu"
-                            | "IO"
-                            | "Regex"
-                            | "Callable"
-                            | "Positional"
-                            | "Associative"
-                            | "Range"
-                            | "Match"
-                            | "Pair"
-                            | "List"
-                            | "Array"
-                            | "Hash"
-                            | "Set"
-                            | "Bag"
-                            | "Mix"
-                            | "Junction"
-                            | "Seq"
-                            | "Supply"
-                            | "Promise"
-                            | "Channel"
-                    )
-                })
-            });
+            // Gate on the *failing* parameter's expected type (parsed from the
+            // error message), NOT on whether any param happens to be simple. A
+            // call like `foo(Sub $c, Str $a); foo(-> {}, "a")` fails on the `Sub`
+            // param; the presence of a simple `Str` param must not reclassify it
+            // as a compile-time X::TypeCheck::Argument. raku throws a runtime
+            // X::TypeCheck::Binding::Parameter when the expected type is one (like
+            // Sub/Block) it cannot rule out statically.
+            && Self::extract_expected_type(&err.message)
+                .as_deref()
+                .is_some_and(|expected| {
+                    // The expected type must be a simple built-in AND must appear
+                    // as a *declared* constraint on some parameter. A type-capture
+                    // call (`sub f(::T, T $a); f.assuming(Int)`) reports the
+                    // resolved `Int` in its message while the declared constraint
+                    // is still `T`, so it must NOT be reclassified to a
+                    // compile-time X::TypeCheck::Argument — it stays a runtime
+                    // X::TypeCheck::Binding::Parameter.
+                    Self::is_simple_argument_type(expected)
+                        && param_defs
+                            .iter()
+                            .any(|pd| pd.type_constraint.as_deref() == Some(expected))
+                });
         if (is_arity_error || is_type_only_mismatch)
             && (err.exception.is_none() || is_binding_param_exception)
         {

--- a/t/typecheck-binding-vs-argument.t
+++ b/t/typecheck-binding-vs-argument.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 6;
+
+# A binding type-check failure on a parameter whose expected type cannot be
+# ruled out statically (e.g. Sub vs Block) is a runtime
+# X::TypeCheck::Binding::Parameter (which ISA X::TypeCheck::Binding) — NOT a
+# compile-time X::TypeCheck::Argument. The presence of a *different*, simply-typed
+# parameter (Str) in the same signature must not reclassify the failure.
+
+sub takes-sub (Sub $code, Str $a, Str $b) { $a.WHAT }
+
+throws-like { takes-sub(-> { die "x" }, "a", "b") },
+    X::TypeCheck::Binding,
+    'pointy block bound to Sub param throws X::TypeCheck::Binding';
+
+lives-ok { takes-sub(sub { die "x" }, "a", "b") },
+    'anonymous sub satisfies Sub param';
+
+# With an optional trailing param the classification is unchanged.
+sub takes-sub2 (Sub $code, Str $a, Str $b?) { $a.WHAT }
+
+throws-like { takes-sub2(-> { die "x" }, "a") },
+    X::TypeCheck::Binding,
+    'pointy block bound to Sub param (optional last) throws X::TypeCheck::Binding';
+
+# A simply-typed parameter bound to a literal of the wrong type is the
+# compile-time-detectable case and stays X::TypeCheck::Argument.
+throws-like 'sub f(Int $x) { }; f("hi")',
+    X::TypeCheck::Argument,
+    'Int param bound to Str literal throws X::TypeCheck::Argument';
+
+throws-like 'sub f(Str) { }; f(42)',
+    X::TypeCheck::Argument,
+    'type-only Str param bound to Int literal throws X::TypeCheck::Argument';
+
+# The runtime Sub-vs-Block failure also reports the right concrete subtype.
+my $ex;
+{
+    takes-sub(-> { 1 }, "a", "b");
+    CATCH { default { $ex = $_ } }
+}
+isa-ok $ex, X::TypeCheck::Binding::Parameter,
+    'concrete exception is X::TypeCheck::Binding::Parameter';


### PR DESCRIPTION
## Summary

`enhance_binding_error` reclassified a **runtime** parameter type-check failure into a **compile-time** `X::TypeCheck::Argument` whenever *any* parameter in the signature had a simple built-in type — even when the parameter that actually failed did not.

So `sub f(Sub $c, Str $a); f(-> {}, "a")` (a pointy `Block` bound to a `Sub` param) wrongly surfaced as `X::TypeCheck::Argument` because of the sibling `Str` param, instead of the runtime `X::TypeCheck::Binding::Parameter` that raku throws.

## Fix

Gate the reclassification on the **failing** parameter: the expected type parsed from the error message must (a) be a simple built-in **and** (b) appear as a *declared* constraint on some parameter.

- `foo(Int $x); foo("hi")` and type-only `foo(Str); foo(42)` → still compile-time `X::TypeCheck::Argument` ✓
- `Sub`/`Block` mismatch → runtime `X::TypeCheck::Binding::Parameter` (ISA `X::TypeCheck::Binding`) ✓
- type-capture `sub f(::T, T $a); f.assuming(Int)` (message reports resolved `Int`, but declares `T`) → stays `X::TypeCheck::Binding::Parameter` ✓ (this guard prevents a regression in `t/assuming-type-capture.t`)

## Effect

- Whitelists `roast/integration/code-blocks-as-sub-args.t` (4/4).
- Adds `scripts/near-pass-scan.sh` (lists non-whitelisted roast files by failing-subtest count, to find near-pass candidates).
- Adds `t/typecheck-binding-vs-argument.t` regression test.

## Testing

- `make test` green (cargo 470 passed; t/ no failures; `assuming-type-capture.t` back to 5/5)
- all `S06-multi/*` pass; `S06-signature/types.t`, `arity.t` pass
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY