### PR TITLE
fix(multidim): :delete out of a shaped array's bounds dies

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -4,6 +4,7 @@ roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S14-roles/submethods.t
 roast/6.d/S02-literals/version.t
 roast/6.d/S05-capture/match-object.t
+roast/6.d/S09-multidim/indexing.t
 roast/6.d/S32-num/atanh.t
 roast/6.d/S32-num/log.t
 roast/6.d/S32-num/sign.t

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -378,12 +378,50 @@ impl Interpreter {
         let raw_indices = args[1..].to_vec();
         let target_val = self.env.get(&var_name).cloned().unwrap_or(Value::Nil);
         let indices = self.resolve_multidim_indices(&target_val, &raw_indices)?;
+        // A shaped array (`my @a[2;2]`) has fixed dimensions; an out-of-range
+        // index in any dimension is an error (raku throws X::AdHoc), not a
+        // silent no-op that yields Any.
+        Self::check_shaped_index_bounds(&target_val, &indices)?;
         let Some(target) = self.env.get_mut(&var_name) else {
             return Ok(Value::Nil);
         };
         let result = multidim_delete(target, &indices);
         self.writeback_multidim_var_to_local(&var_name);
         Ok(result)
+    }
+
+    /// Validate multidim indices against a shaped array's fixed dimensions.
+    /// Returns an X::AdHoc error (matching raku) for the first out-of-range
+    /// dimension. A no-op for non-shaped arrays / hashes, and for `Whatever` or
+    /// multi-index (list/range) subscripts which select within bounds.
+    fn check_shaped_index_bounds(target: &Value, indices: &[Value]) -> Result<(), RuntimeError> {
+        let Value::Array(data, ArrayKind::Shaped) = target else {
+            return Ok(());
+        };
+        let Some(shape) = data.shape.as_ref() else {
+            return Ok(());
+        };
+        for (dim, idx) in indices.iter().enumerate() {
+            let Some(&size) = shape.get(dim) else { break };
+            // Only plain integer indices are bounds-checked here; Whatever and
+            // list/range selectors stay within the dimension by construction.
+            let n = match idx {
+                Value::Int(n) => *n,
+                _ => continue,
+            };
+            let size = size as i64;
+            // Negative indices count from the end; raku rejects those past -size.
+            let resolved = if n < 0 { n + size } else { n };
+            if resolved < 0 || resolved >= size {
+                return Err(RuntimeError::new(format!(
+                    "Index {} for dimension {} out of range (must be 0..{})",
+                    n,
+                    dim + 1,
+                    size - 1
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// After a multidim `:delete` mutates the env copy of `@a`/`%h` in place,

--- a/t/multidim-shaped-delete-bounds.t
+++ b/t/multidim-shaped-delete-bounds.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 7;
+
+# A shaped array (`my @a[2;2]`) has fixed dimensions. An out-of-range index in
+# any dimension is an error (raku throws), not a silent no-op yielding Any.
+
+my @arr[2;2] = <a b>, <c d>;
+
+dies-ok { @arr[2;0]:delete }, 'delete out of range in dimension 1 dies';
+dies-ok { @arr[0;2]:delete }, 'delete out of range in dimension 2 dies';
+dies-ok { @arr[5;5]:delete }, 'delete far out of range dies';
+dies-ok { @arr[-3;0]:delete }, 'delete with too-negative index dies';
+
+# In-range deletes still work and return the old value.
+is @arr[0;0]:delete, 'a', 'in-range delete returns old value';
+is @arr[1;1]:delete, 'd', 'second in-range delete returns old value';
+
+# A negative index within range counts from the end and is allowed.
+my @b[3] = <x y z>;
+is @b[*-1]:delete, 'z', 'negative-in-range delete works';


### PR DESCRIPTION
## Summary

`@arr[2;0]:delete` on a shaped array (`my @arr[2;2]`) silently returned `Any` instead of dying. A shaped array has fixed dimensions, so an out-of-range index in any dimension is an error — raku throws `Index N for dimension D out of range (must be 0..M)`.

`builtin_multidim_delete` now validates each integer index against the shaped array's `shape` before mutating, throwing for the first out-of-range dimension.

- Negative-in-range indices (`@a[*-1]`) and `Whatever` / list / range selectors are unaffected.
- Non-shaped arrays and hashes keep their previous lenient behavior.

## Effect

- Whitelists `roast/6.d/S09-multidim/indexing.t` (2/2).
- Adds `t/multidim-shaped-delete-bounds.t` regression test.

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S09-multidim/*`, `multi_dimensional_array.t`, `mixed_multi_dimensional.t` pass; native-shape1-* unchanged (their pre-existing failures are unrelated, BLOCKERS §1.4)
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY