### PR TITLE
fix(parser): reject `new TypeName` (C++ constructor syntax) with X::Obsolete

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1279,6 +1279,7 @@ roast/integration/failure-and-callsame.t
 roast/integration/lexical-array-in-inner-block.t
 roast/integration/lexicals-and-attributes.t
 roast/integration/method-calls-and-instantiation.t
+roast/integration/no-indirect-new.t
 roast/integration/packages.t
 roast/integration/pair-in-array.t
 roast/integration/passing-pair-class-to-sub.t

--- a/src/parser/primary/ident.rs
+++ b/src/parser/primary/ident.rs
@@ -1551,6 +1551,28 @@ pub(super) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     let (rest, name) = super::super::stmt::parse_raku_ident(input)?;
     let name = normalize_raku_identifier(name);
 
+    // C++ constructor syntax: `new TypeName` (indirect object notation) is
+    // unsupported in Raku — `Foo.new` must be used instead. Detect `new`
+    // followed by whitespace and an uppercase-initial bareword type name and
+    // reject with X::Obsolete (matching rakudo). Restricting to an uppercase
+    // initial keeps operator/keyword words (all lowercase: `new and`, `new if`)
+    // and `new(...)` / `newFoo` from triggering.
+    if name == "new" && rest.starts_with([' ', '\t']) {
+        let after = rest.trim_start_matches([' ', '\t']);
+        if after.chars().next().is_some_and(char::is_uppercase)
+            && let Ok((tail, _typename)) = super::super::stmt::parse_raku_ident(after)
+            // `new Foo: args` is the valid colon-invocant method call (== Foo.new(args));
+            // only the bare `new Foo` / `new Foo(...)` indirect form is C++ syntax.
+            && (!tail.starts_with(':') || tail.starts_with("::"))
+        {
+            return Err(PError::fatal(
+                "X::Obsolete: Unsupported use of C++ constructor syntax.  \
+                 In Raku please use: method call syntax."
+                    .to_string(),
+            ));
+        }
+    }
+
     // A statement-control keyword immediately followed by `(...) { ... }` (no
     // whitespace before the parens) is a `keyword()`-as-function mistake
     // (`if() {}`, `with() {}`). Raku rejects this with an X::Comp::Group whose

--- a/t/cpp-constructor-syntax.t
+++ b/t/cpp-constructor-syntax.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 8;
+
+# `new TypeName` (C++ / indirect constructor syntax) is unsupported in Raku;
+# it must be rejected with X::Obsolete. `TypeName.new` is the correct form.
+
+throws-like 'class A { has $.b }; new A',
+    X::Obsolete,
+    'bare `new A` is rejected as C++ constructor syntax';
+
+throws-like 'class A { has $.b }; new A( :b(1) )',
+    X::Obsolete,
+    '`new A(:b(1))` is rejected as C++ constructor syntax';
+
+throws-like 'class A {}; my $x = new A.new',
+    X::Obsolete,
+    '`new A.new` is rejected as C++ constructor syntax';
+
+throws-like 'new Int',
+    X::Obsolete,
+    '`new Int` on a built-in type is rejected';
+
+# The correct method-call forms must still work.
+{
+    class C { has $.v }
+    is C.new(v => 5).v, 5, '`C.new(...)` still works';
+    is C.new.defined, True, '`C.new` still works';
+}
+
+# `new` as an ordinary sub name (lowercase args / parens) is unaffected.
+{
+    sub new($x) { $x * 2 }
+    is new(21), 42, '`new(...)` as a sub call still works';
+}
+
+# `new` used as a hash pair key is unaffected.
+{
+    my %h = new => 7;
+    is %h<new>, 7, '`new => ...` pair key still works';
+}


### PR DESCRIPTION
## Summary

`new A` / `new A(...)` (indirect-object / C++ constructor notation) is unsupported in Raku — `A.new` must be used. mutsu silently parsed `new A` as two separate terms (`new` then bareword `A`), so the construct ran without error.

`identifier_or_call` now detects `new` followed by whitespace and an uppercase-initial bareword type name and rejects it with `X::Obsolete`, matching rakudo:
> Unsupported use of C++ constructor syntax.  In Raku please use: method call syntax.

## Scoping (avoids false positives)

- **Uppercase initial only** — all-lowercase operator/keyword words (`new and`, `new if`, `new x`) and `newFoo` / `new(...)` do not trigger.
- **Colon-invocant form excluded** — `new Foo: args` is the valid indirect method call (`== Foo.new(args)`), detected by a trailing single `:` after the type name, so it is not rejected.

Verified still-working: `A.new`, `A.new(...)`, `new(...)` as a sub call, `new => ...` pair key.

## Effect

- Whitelists `roast/integration/no-indirect-new.t` (2/2).
- Adds `t/cpp-constructor-syntax.t` (8 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S12-construction/new.t`, `S12-class/basic.t`, `instantiate.t` pass
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY