### PR TITLE
fix(exceptions): Exception instances stringify via .message; X::AdHoc.raku shows payload

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1267,6 +1267,7 @@ roast/integration/advent2011-day24.t
 roast/integration/advent2012-day02.t
 roast/integration/advent2012-day03.t
 roast/integration/advent2012-day06.t
+roast/integration/advent2012-day12.t
 roast/integration/advent2012-day16.t
 roast/integration/advent2012-day20.t
 roast/integration/advent2012-day24.t

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -703,22 +703,39 @@ impl Interpreter {
                     self.class_mro(&class_name.resolve()).contains(&target_name),
                 ));
             }
-            if (method == "gist" || method == "message")
-                && args.is_empty()
-                && (class_name.resolve().starts_with("X::")
-                    || class_name == "Exception"
-                    || class_name.resolve().ends_with("Exception"))
-            {
-                if let Some(msg) = attributes.as_map().get("message") {
-                    return Ok(Value::str(msg.to_string_value()));
-                }
-                if let Some(formatted) =
-                    crate::builtins::exception_message::format_exception_message(
-                        &class_name.resolve(),
-                        &(attributes).as_map(),
-                    )
-                {
-                    return Ok(Value::str(formatted));
+            // An Exception instance stringifies (.Str/.gist/~) and reports via its
+            // `.message` (raku: Exception.Str and .gist both return .message). Detect
+            // it via the MRO so a user `class E is Exception` (whose name is not
+            // `X::*`/`*Exception`) is covered too. A user-defined `gist`/`Str`/
+            // `message` already won dispatch above, so reaching here is the default.
+            if args.is_empty() && matches!(method, "gist" | "Str" | "Stringy" | "message") {
+                let cn = class_name.resolve();
+                let is_exception = cn == "Exception"
+                    || cn.starts_with("X::")
+                    || cn.starts_with("CX::")
+                    || cn.ends_with("Exception")
+                    || self
+                        .class_mro(&cn)
+                        .iter()
+                        .any(|p| p == "Exception" || p == "Failure");
+                if is_exception {
+                    // For .Str/.gist, prefer a user-defined `message` method (it may
+                    // interpolate attributes); `message` itself only reaches here when
+                    // no user method exists, so fall to the stored attr / formatted msg.
+                    if method != "message" && self.has_user_method(&cn, "message") {
+                        return self.call_method_with_values(target.clone(), "message", vec![]);
+                    }
+                    if let Some(msg) = attributes.as_map().get("message") {
+                        return Ok(Value::str(msg.to_string_value()));
+                    }
+                    if let Some(formatted) =
+                        crate::builtins::exception_message::format_exception_message(
+                            &cn,
+                            &(attributes).as_map(),
+                        )
+                    {
+                        return Ok(Value::str(formatted));
+                    }
                 }
             }
             // Default `.gist` of a user instance matches its `.raku` (raku:
@@ -765,6 +782,25 @@ impl Interpreter {
                         "{}.new(\"{}\")",
                         class_name.resolve(),
                         which
+                    )));
+                }
+                // X::AdHoc's raku-visible attribute is `payload` (mutsu stores the
+                // die string under `message`/`payload`); render it as
+                // `X::AdHoc.new(payload => "...")` rather than the bare `.new`.
+                if class_name.resolve() == "X::AdHoc"
+                    && (method == "raku" || method == "perl")
+                    && let attr_map = attributes.as_map()
+                    && let Some(payload) = attr_map
+                        .get("payload")
+                        .or_else(|| attr_map.get("message"))
+                        .cloned()
+                {
+                    let payload_raku = self
+                        .call_method_with_values(payload.clone(), "raku", vec![])
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|_| payload.to_string_value());
+                    return Ok(Value::str(format!(
+                        "X::AdHoc.new(payload => {payload_raku})"
                     )));
                 }
                 // Collect public attributes for .raku representation

--- a/t/exception-str-gist-message.t
+++ b/t/exception-str-gist-message.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 9;
+
+# An Exception instance stringifies (.Str / .gist / ~ / interpolation) via its
+# .message — including a user `class E is Exception` whose name is not X::* and
+# whose message() is a method that interpolates attributes.
+
+class X::HTTP is Exception {
+    has $.url;
+    has $.status;
+    method message() { "Error to $.url: $.status" }
+}
+
+my $e = X::HTTP.new(url => 'http://x', status => 404);
+is $e.message, 'Error to http://x: 404', '.message (user method) works';
+is $e.Str,     'Error to http://x: 404', '.Str returns .message';
+is $e.gist,    'Error to http://x: 404', '.gist returns .message';
+is ~$e,        'Error to http://x: 404', 'prefix ~ returns .message';
+is "$e",       'Error to http://x: 404', 'interpolation returns .message';
+
+# A non-X:: user exception class is detected via its MRO.
+class MyError is Exception { method message { 'boom' } }
+is "{MyError.new}", 'boom', 'non-X:: exception detected via MRO';
+
+# Built-in X::AdHoc (from `die "..."`) stringifies to its payload and renders
+# `.raku` with the payload.
+{
+    my $caught;
+    try { die "Neat error message" };
+    $caught = $!;
+    is "$caught", 'Neat error message', 'X::AdHoc interpolates its payload';
+    is $caught.raku, 'X::AdHoc.new(payload => "Neat error message")',
+        'X::AdHoc.raku shows payload';
+}
+
+# Typed built-in exception still stringifies (regression guard).
+{
+    try { "abc".substr(10) };
+    ok "$!".chars > 0, 'typed built-in exception still stringifies';
+}


### PR DESCRIPTION
## Summary

An Exception instance now reports its `.message` from `.Str`, `.gist`, `.Stringy`, prefix `~`, and string interpolation. Previously these yielded the type repr (`X::HTTP()` / `E.new`).

- Detection is via the **MRO**, so a user `class E is Exception` (whose name is neither `X::*` nor `*Exception`) is covered.
- A user-defined `message` method (which may interpolate attributes like `"$.url"`) is preferred over a stored `message` attribute.
- `X::AdHoc.raku` (from `die "..."`) now renders `X::AdHoc.new(payload => "...")` instead of the bare `X::AdHoc.new`, matching rakudo.

## Effect

- Whitelists `roast/integration/advent2012-day12.t` (5/5).
- Adds `t/exception-str-gist-message.t` (9 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S32-exceptions/misc.t` unchanged (26 fails, no regression); built-in `die` / typed exceptions still stringify
- unthrown user-exception `.gist` returns message (matches raku)
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY