### PR TITLE
fix(setbagmix): bag/set/mix flatten a Seq argument into its elements

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1268,6 +1268,7 @@ roast/integration/advent2012-day02.t
 roast/integration/advent2012-day03.t
 roast/integration/advent2012-day06.t
 roast/integration/advent2012-day12.t
+roast/integration/advent2012-day13.t
 roast/integration/advent2012-day16.t
 roast/integration/advent2012-day20.t
 roast/integration/advent2012-day24.t

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -172,6 +172,13 @@ impl Interpreter {
                         insert_value(&pair, &mut elems, &mut original_keys, &mut has_typed_keys);
                     }
                 }
+                // A Seq (e.g. from `.map`/`.comb`) is a list of elements, not one
+                // opaque value — flatten it like a regular array.
+                Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                    for item in items.iter() {
+                        insert_value(item, &mut elems, &mut original_keys, &mut has_typed_keys);
+                    }
+                }
                 other => {
                     insert_value(other, &mut elems, &mut original_keys, &mut has_typed_keys);
                 }
@@ -242,6 +249,13 @@ impl Interpreter {
                 Value::Set(_, _) | Value::Bag(_, _) | Value::Mix(_, _) => {
                     add_item(&mut counts, &mut original_keys, &mut has_non_str_keys, arg);
                 }
+                // A Seq (e.g. from `.map`/`.comb`) is a list of elements, not one
+                // opaque value — flatten it like a regular array.
+                Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                    for item in items.iter() {
+                        add_item(&mut counts, &mut original_keys, &mut has_non_str_keys, item);
+                    }
+                }
                 other => {
                     add_item(
                         &mut counts,
@@ -300,6 +314,13 @@ impl Interpreter {
                     for (k, v) in map.iter() {
                         let pair = Value::Pair(k.clone(), Box::new(v.clone()));
                         insert_value(&pair, &mut weights, &mut original_keys, &mut has_typed_keys);
+                    }
+                }
+                // A Seq (e.g. from `.map`/`.comb`) is a list of elements, not one
+                // opaque value — flatten it like a regular array.
+                Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                    for item in items.iter() {
+                        insert_value(item, &mut weights, &mut original_keys, &mut has_typed_keys);
                     }
                 }
                 other => {

--- a/t/bag-set-mix-flatten-seq.t
+++ b/t/bag-set-mix-flatten-seq.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 9;
+
+# The `bag` / `set` / `mix` list builtins flatten a Seq argument (e.g. from
+# `.map` / `.comb`) into its individual elements, rather than counting the whole
+# Seq as one opaque key.
+
+is (set "abc".comb).keys.sort.join,        'abc',    'set flattens a .comb Seq';
+is (bag "aabbc".comb).{'a'},               2,        'bag counts elements of a .comb Seq';
+is (set (1, 2, 3).map(* + 1)).keys.sort.join(','), '2,3,4', 'set flattens a .map Seq';
+is (bag (1, 1, 2).map(* + 0)).{'1'},       2,        'bag counts elements of a .map Seq';
+is (mix <a b a>.map(*.uc)).{'A'},          2,        'mix flattens a .map Seq';
+
+# Set difference over Seq-built sets/bags yields individual keys (advent2012-day13).
+{
+    my $words1 = bag "aa bb cc dd".comb(/\w+/);
+    my $words2 = set "cc dd".comb(/\w+/);
+    is ($words1 (-) $words2).keys.sort.join(','), 'aa,bb',
+        'set difference over Seq-built quanthashes';
+}
+
+# Explicit flat lists are unaffected (regression guard).
+is (set <x y z>).keys.sort.join,           'xyz',    'set of a flat list still works';
+is (bag 1, 1, 2).{'1'},                    2,        'bag of a comma list still works';
+
+# A single non-list value stays a single key.
+is (set 'hello').keys.join,                'hello',  'set of one string is one key';


### PR DESCRIPTION
## Summary

`bag $seq` / `set $seq` / `mix $seq` (where `$seq` comes from `.map` / `.comb`, etc.) counted the whole `Seq` as one opaque key (`((a b c))`) instead of its individual elements. The list builtins flattened `Array` / `Hash` arguments but routed a `Seq` / `HyperSeq` / `RaceSeq` through the single-element fallback.

A Seq-flattening arm (mirroring the regular-array case) is added to `builtin_set`, `builtin_bag`, and `builtin_mix`. Explicit flat lists and single non-list values are unaffected.

## Effect

- Whitelists `roast/integration/advent2012-day13.t` (42/42).
- Adds `t/bag-set-mix-flatten-seq.t` (9 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S02-types/set.t`, `mix.t`, `S32-list/categorize.t` pass; `bag.t` unchanged (its 1 fail is the pre-existing rakudo#5190 Foo-union case, unrelated)
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY