### PR TITLE
fix(smartmatch): list/array ~~ Numeric compares element count

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1256,6 +1256,7 @@ roast/integration/advent2009-day22.t
 roast/integration/advent2010-day06.t
 roast/integration/advent2010-day08.t
 roast/integration/advent2010-day10.t
+roast/integration/advent2010-day12.t
 roast/integration/advent2010-day21.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -181,6 +181,13 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         (Value::Int(a), Value::Str(b)) => Some(b.trim().parse::<f64>() == Ok(*a as f64)),
         (Value::Nil, Value::Str(s)) => Some(s.is_empty()),
 
+        // Array/List ~~ Numeric: a list smart-matched against a number compares
+        // numerically (`@a == $n`), and a list's numeric value is its element
+        // count — so `[1,2,3] ~~ 3` is True (3 elems), `~~ 2` is False.
+        (Value::Array(a, _), Value::Int(b)) => Some(a.items.len() as i64 == *b),
+        (Value::Array(a, _), Value::Num(b)) => Some(a.items.len() as f64 == *b),
+        (Value::Array(a, _), Value::Rat(n, d)) => Some(*d != 0 && a.items.len() as i64 * *d == *n),
+
         // IO::Path ~~ IO::Path: compare by cleanup.absolute
         (
             Value::Instance {

--- a/t/array-num-smartmatch.t
+++ b/t/array-num-smartmatch.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 10;
+
+# A list/array smart-matched against a number compares numerically (`@a == $n`),
+# and a list's numeric value is its element count.
+
+ok  [1, 2, 3]    ~~ 3,  '3-elem array ~~ 3 (elem count)';
+nok [1, 2, 3]    ~~ 2,  '3-elem array !~~ 2';
+ok  [1, 2, 3, 4] ~~ 4,  '4-elem array ~~ 4';
+ok  (1, 2, 3)    ~~ 3,  '3-elem list ~~ 3';
+ok  []           ~~ 0,  'empty array ~~ 0';
+ok  [1, 2, 3]    ~~ 3.0, 'array ~~ Num (3.0)';
+nok [1, 2, 3]    ~~ 3.5, 'array !~~ 3.5';
+
+# The whole-array-of-6 smart-match from the advent 2010 day 12 medley.
+ok  [1, 10, 1, 20, 1, 30] ~~ 6, '6-elem array ~~ 6';
+
+# Existing non-numeric smart-matches are unaffected.
+ok  [1, 2, 3] ~~ [1, 2, 3], 'array ~~ array still structural';
+ok  "6"       ~~ 6,         'string ~~ number still numifies';


### PR DESCRIPTION
## Summary

`[1,2,3] ~~ 3` was `False` — `pure_smart_match` had no `Array ~~ Numeric` arm, so an array LHS with a numeric RHS fell through to a non-numeric path.

In Raku a list smart-matched against a number compares numerically (`@a == $n`), and a list's numeric value is its element count, so `[1,2,3] ~~ 3` is `True` and `~~ 2` is `False`.

Adds `Array ~~ Int/Num/Rat` arms comparing `items.len()` to the number. Array-vs-array structural matches and string-vs-number numification are unaffected.

## Effect

- Whitelists `roast/integration/advent2010-day12.t` (13/13).
- Adds `t/array-num-smartmatch.t` (10 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- all `roast/S03-smartmatch/*` pass; `S03-junctions/misc.t` pass
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY