### PR TITLE
fix(vars): $_, $/, $! report as dynamic (.VAR.dynamic)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1274,6 +1274,7 @@ roast/integration/advent2012-day16.t
 roast/integration/advent2012-day20.t
 roast/integration/advent2012-day24.t
 roast/integration/advent2013-day07.t
+roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t
 roast/integration/code-blocks-as-sub-args.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5471,10 +5471,14 @@ impl Interpreter {
     }
 
     pub(crate) fn is_var_dynamic(&self, name: &str) -> bool {
-        self.var_dynamic_flags
-            .get(Self::normalize_var_meta_name(name))
-            .copied()
-            .unwrap_or(false)
+        let bare = Self::normalize_var_meta_name(name);
+        // The implicit special variables `$_`, `$/`, `$!` are dynamic by nature
+        // (no `*` twigil, but `.VAR.dynamic` is True and they are visible through
+        // CALLER::), so report them as dynamic even without an explicit flag.
+        if matches!(bare, "_" | "/" | "!") {
+            return true;
+        }
+        self.var_dynamic_flags.get(bare).copied().unwrap_or(false)
     }
 
     pub(crate) fn push_caller_env(&mut self) {

--- a/t/special-vars-dynamic.t
+++ b/t/special-vars-dynamic.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 5;
+
+# The implicit special variables `$_`, `$/`, `$!` are dynamic by nature
+# (no `*` twigil, but `.VAR.dynamic` is True), unlike ordinary lexicals.
+
+ok  $/.VAR.dynamic, '$/ is dynamic';
+ok  $_.VAR.dynamic, '$_ is dynamic';
+
+# An explicit `*`-twigil dynamic is still dynamic.
+{
+    my $*d = 1;
+    ok $*d.VAR.dynamic, 'explicit $*d is dynamic';
+}
+
+# An ordinary lexical is NOT dynamic.
+{
+    my $x = 1;
+    nok $x.VAR.dynamic, 'ordinary lexical $x is not dynamic';
+}
+
+# A non-dynamic lexical accessed through CALLER still throws (regression guard
+# for the X::Caller::NotDynamic path, which also consults is_var_dynamic).
+throws-like 'sub f() { CALLER::<$y> }; my $y; f',
+    X::Caller::NotDynamic,
+    'non-special lexical through CALLER still throws NotDynamic';


### PR DESCRIPTION
## Summary

The implicit special variables `$_`, `$/`, `$!` are dynamic by nature (no `*` twigil, but `.VAR.dynamic` is True and they are reachable through `CALLER::`). `is_var_dynamic` only consulted the explicit dynamic-scope flag map, so `$/.VAR.dynamic` returned `False` instead of `True`.

Treat those three bare names as always-dynamic in `is_var_dynamic`. Ordinary lexicals stay non-dynamic, so the `X::Caller::NotDynamic` path (which also consults `is_var_dynamic`) is unaffected for non-special names.

## Effect

- Whitelists `roast/integration/advent2013-day20.t` (22/22).
- Adds `t/special-vars-dynamic.t` (5 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S02-names/caller.t`, `dynamic-scope.t`, `is_dynamic.t`, `S02-magicals/dollar_bang.t` pass; `t/caller-not-dynamic.t` (from #3767) still passes
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY