### PR TITLE
fix(mixin): boolean context uses a runtime mixin's mixed-in .Bool method

### DIFF
--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -264,6 +264,19 @@ impl Interpreter {
                 }
                 val.truthy()
             }
+            // A runtime mixin (`42 but role { method Bool {...} }`) boolifies via
+            // the mixed-in `Bool` method, exactly like a class with a user `Bool`.
+            // Without this, `?$mixin` / `if $mixin` ignored the role's `Bool` and
+            // used the base value's truthiness.
+            Value::Mixin(..) if self.mixin_role_has_method(val, "Bool") => {
+                let caller_code = self.current_code;
+                let result = self.try_compiled_method_or_interpret(val.clone(), "Bool", vec![]);
+                self.reconcile_caller_after_internal_dispatch(caller_code);
+                match result {
+                    Ok(result) => result.truthy(),
+                    Err(_) => val.truthy(),
+                }
+            }
             Value::Regex(_)
             | Value::RegexWithAdverbs { .. }
             | Value::Routine { is_regex: true, .. } => {

--- a/t/mixin-bool-truthy.t
+++ b/t/mixin-bool-truthy.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 7;
+
+# A runtime mixin (`$x but role { method Bool {...} }`) must boolify via the
+# mixed-in `Bool` method in boolean context (`?`, `so`, `if`, `unless`), exactly
+# like a class with a user-defined `Bool` — not via the base value's truthiness.
+
+my $falsey = 42 but role { method Bool { False } };
+is        $falsey.Bool, False, '.Bool method returns the mixed-in value';
+nok       ?$falsey,             'prefix ? uses the mixed-in Bool';
+nok       so $falsey,          'so uses the mixed-in Bool';
+is (?$falsey ?? 'y' !! 'n'), 'n', 'ternary boolean context uses mixed-in Bool';
+{
+    my $hit = 'else';
+    if $falsey { $hit = 'then' }
+    is $hit, 'else', 'if uses the mixed-in Bool';
+}
+
+# A mixin with a truthy Bool stays true; the base value is unaffected.
+my $truthy = 0 but role { method Bool { True } };
+ok ?$truthy, 'prefix ? uses a True-returning mixed-in Bool over a falsey base';
+
+# A plain value with no mixed-in Bool keeps its ordinary truthiness.
+ok ?(42 but role { method Str { "x" } }), 'mixin without Bool keeps base truthiness';


### PR DESCRIPTION
## Summary

`?$mixin` / `if $mixin` / `so $mixin` — where `$mixin = 42 but role { method Bool {...} }` — ignored the mixed-in `Bool` and used the **base** value's truthiness, even though `$mixin.Bool` itself returned the right value.

`eval_truthy` handled a `Value::Instance` with a user `Bool` but had **no `Value::Mixin` arm**, so a mixin fell through to the base `truthy()`.

Add a `Value::Mixin` arm that, when a mixed-in role defines `Bool` (`mixin_role_has_method`), dispatches to it — mirroring the class-instance path. Mixins without a `Bool` role keep their base truthiness.

## Effect

- Fixes `?$mixin` / `if` / `unless` / `so` / ternary boolean context for role mixins.
- Advances `roast/integration/advent2010-day19.t` (2→1 fail). The remaining failure is a separate feature — `True but False` (mixing a *value*, not a role) must produce a real mixin whose `.Str`/`.Bool` come from the value — so this PR is a correctness fix without a whitelist gain yet.
- Adds `t/mixin-bool-truthy.t` (7 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S04-statements/if.t`, `S03-operators/value_equivalence.t`, `S14-roles/stubs.t` pass
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY