### PR TITLE
fix(dispatch): .name on a type object hits its own attribute accessor (dies)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1273,6 +1273,7 @@ roast/integration/advent2012-day13.t
 roast/integration/advent2012-day16.t
 roast/integration/advent2012-day20.t
 roast/integration/advent2012-day24.t
+roast/integration/advent2013-day02.t
 roast/integration/advent2013-day07.t
 roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1489,6 +1489,17 @@ impl Interpreter {
                 Value::Routine { name, .. } => {
                     Ok(Value::str(format_operator_name(&name.resolve())))
                 }
+                // `.name` on a *type object* whose class declares its own public
+                // attribute `$.name` resolves to that accessor, and reading an
+                // instance attribute off a type object is an error (raku). Only
+                // divert when the class actually has a `name` attribute; otherwise
+                // keep the type-name introspection behaviour.
+                Value::Package(name) if self.has_public_accessor(&name.resolve(), "name") => {
+                    Err(RuntimeError::new(format!(
+                        "Cannot look up attributes in a {} type object. Did you forget a '.new'?",
+                        name.resolve()
+                    )))
+                }
                 Value::Package(name) => Ok(Value::str(name.resolve())),
                 Value::Str(name) => Ok(Value::Str(name.clone())),
                 Value::Sub(data) => Ok(Value::str(format_operator_name(&data.name.resolve()))),

--- a/t/name-accessor-type-object.t
+++ b/t/name-accessor-type-object.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 5;
+
+# `.name` on a TYPE OBJECT whose class declares its own public `$.name` attribute
+# resolves to that accessor; reading an instance attribute off a type object is an
+# error. An *instance* still reads the attribute normally.
+
+class Dog { has $.name }
+
+is Dog.new(name => 'Fido').name, 'Fido', '.name on an instance reads the attribute';
+dies-ok { Dog.name }, '.name on the type object dies (attribute lookup on type object)';
+throws-like 'class D { has $.name }; D.name', Exception,
+    '.name on a type object throws an Exception';
+
+# A class WITHOUT a `name` attribute is unaffected (keeps type-name behaviour).
+class Plain { }
+lives-ok { Plain.name }, '.name on a class without a name attribute does not die';
+
+# Routine .name is unaffected.
+sub greet() { }
+is &greet.name, 'greet', '&sub.name still returns the routine name';


### PR DESCRIPTION
## Summary

`Dog.name` (a type object) returned the class name via the builtin `.name` handler, **shadowing** the class's own `has $.name` accessor. In raku, reading an instance attribute off a type object is an error.

When a `Value::Package` (type object) is asked for `.name` and its class declares a public `name` attribute, throw `Cannot look up attributes in a <Class> type object` instead of returning the type name.

- Classes **without** a `name` attribute keep the type-name introspection behaviour.
- `Routine` / `Sub` / instance `.name` are unaffected.
- Blast radius is limited to classes that declare a `name` attribute.

## Effect

- Whitelists `roast/integration/advent2013-day02.t` (12/12).
- Adds `t/name-accessor-type-object.t` (5 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S12-class/attributes.t`, `S14-roles/basic.t`, `S12-introspection/methods.t`, `S12-attributes/instance.t` pass
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY