### PR TITLE
fix(parser): `($x, $y) .= method` applies the method to the whole list

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1264,6 +1264,7 @@ roast/integration/advent2011-day05.t
 roast/integration/advent2011-day16.t
 roast/integration/advent2011-day20.t
 roast/integration/advent2011-day22.t
+roast/integration/advent2011-day23.t
 roast/integration/advent2011-day24.t
 roast/integration/advent2012-day02.t
 roast/integration/advent2012-day03.t

--- a/src/parser/expr/postfix.rs
+++ b/src/parser/expr/postfix.rs
@@ -1029,6 +1029,17 @@ fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> E
                 label: None,
             }
         }
+        // A parenthesized list of lvalues (`($x, $y) .= reverse`) applies the
+        // method to the WHOLE list and assigns the result back element-wise
+        // (`($x, $y) = ($x, $y).reverse`), not per-element.
+        Expr::ArrayLiteral(_) => {
+            let lhs = target.clone();
+            let value = method_call_fn(target);
+            Expr::Call {
+                name: Symbol::intern("__mutsu_assign_callable_lvalue"),
+                args: vec![lhs, Expr::ArrayLiteral(Vec::new()), value],
+            }
+        }
         _ => method_call_fn(target),
     }
 }

--- a/t/list-dot-equals-method.t
+++ b/t/list-dot-equals-method.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 6;
+
+# `($x, $y) .= method` applies the method to the WHOLE parenthesized list and
+# assigns the result back across the lvalues (`($x, $y) = ($x, $y).method`),
+# not per-element.
+
+{
+    my ($x, $y) = 7, 35;
+    ($x, $y) .= reverse;
+    is-deeply [$x, $y], [35, 7], 'two-element list .= reverse';
+}
+
+{
+    my ($a, $b, $c) = 1, 2, 3;
+    ($a, $b, $c) .= reverse;
+    is-deeply [$a, $b, $c], [3, 2, 1], 'three-element list .= reverse';
+}
+
+{
+    my ($a, $b, $c) = 3, 1, 2;
+    ($a, $b, $c) .= sort;
+    is-deeply [$a, $b, $c], [1, 2, 3], 'list .= sort';
+}
+
+# Scalar `.=` is unaffected.
+{
+    my $s = 'abc';
+    $s .= flip;
+    is $s, 'cba', 'scalar .= flip still works';
+}
+
+# Array variable `.=` is unaffected.
+{
+    my @a = 3, 1, 2;
+    @a .= sort;
+    is-deeply @a, [1, 2, 3], 'array var .= sort still works';
+}
+
+# Element `.=` is unaffected.
+{
+    my @a = 'ab', 'cd';
+    @a[0] .= flip;
+    is-deeply @a, ['ba', 'cd'], 'array element .= flip still works';
+}


### PR DESCRIPTION
## Summary

`($x, $y) .= reverse` discarded its result. `wrap_dot_assign` had no arm for a parenthesized list lvalue (`Expr::ArrayLiteral`), so it fell through to a plain method call with no assign-back — leaving `$x`/`$y` unchanged (effectively per-element rather than whole-list).

Add an `ArrayLiteral` arm that lowers `($x, $y) .= m` to `($x, $y) = ($x, $y).m` (via `__mutsu_assign_callable_lvalue`), so the method runs on the **whole list** and the result is assigned back across the lvalues. Scalar / array-variable / element `.=` are unaffected.

## Effect

- Whitelists `roast/integration/advent2011-day23.t` (55/55).
- Adds `t/list-dot-equals-method.t` (6 subtests).

## Testing

- `make test` green (cargo 470 passed; t/ no failures)
- `S03-operators/inplace.t`, `assign.t`, `S02-types/array.t` unchanged vs main (same pre-existing fail counts; not whitelisted)
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY