### PR TITLE
fix(vm): don't propagate $_/$//$! back to caller on routine return

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5528,6 +5528,17 @@ impl Interpreter {
         if let Some(popped) = self.caller_env_stack.pop() {
             for (key, value) in &popped {
                 key.with_str(|key_str| {
+                    // `$_`, `$/`, `$!` report as dynamic for `.VAR.dynamic` /
+                    // CALLER:: purposes, but they are *not* propagated back to the
+                    // caller on return: each routine gets its own topic/match/error
+                    // and the caller's value is restored from `saved_env`. Writing
+                    // the callee frame's stale copy back here clobbers the caller's
+                    // live `$_` (e.g. a `block.($_)` call inside a `for` loop would
+                    // revert the loop topic to the previous iteration's value).
+                    let bare = Self::normalize_var_meta_name(key_str);
+                    if matches!(bare, "_" | "/" | "!") {
+                        return;
+                    }
                     if self.is_var_dynamic(key_str) && restored_env.get_sym(*key) != Some(value) {
                         restored_env.insert_sym(*key, value.clone());
                     }

--- a/t/block-call-topic-restore.t
+++ b/t/block-call-topic-restore.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 4;
+
+# Calling a block that references `$_` must not clobber the caller's own `$_`.
+# The block gets its own topic (its argument); on return the caller's `$_` is
+# restored from its saved frame, NOT overwritten by the callee's stale topic.
+# Regression: `$_`/`$/`/`$!` report as dynamic for `.VAR.dynamic`, but they must
+# not be propagated back to the caller on return (a `for` loop's topic would
+# otherwise revert to the previous iteration's value after each block call).
+
+{
+    my $code = { $_ + 100 };
+    my @seen;
+    for 1..4 {
+        my $r = $code.($_);
+        @seen.push: $_;          # caller's $_ must still be the loop value
+    }
+    is-deeply @seen, [1, 2, 3, 4], 'caller $_ survives block.($_) inside a for loop';
+}
+
+{
+    # The block result itself is correct (it sees its own argument as $_).
+    my $code = { $_ * 10 };
+    my @out;
+    for 1..3 { @out.push: $code.($_); @out.push: $_; }
+    is-deeply @out, [10, 1, 20, 2, 30, 3], 'block topic and caller topic both correct';
+}
+
+{
+    # Smart-match flip-flop with `$_` comparisons relies on the same restore.
+    sub test_ff($c, @a) {
+        my $ret = '';
+        for @a { $ret ~= $c.($_) ?? $_ !! 'x'; }
+        $ret;
+    }
+    is test_ff({ $_ == 3 ff $_ == 5 }, 1..7), 'xx345xx', 'ff over $_ comparisons';
+}
+
+{
+    # Nested block calls also restore the topic at each level.
+    my $inner = { $_ ~ '!' };
+    my $outer = { $inner.($_) ~ $_ };
+    my @r;
+    for <a b c> { @r.push: $outer.($_); @r.push: $_; }
+    is-deeply @r, ['a!a', 'a', 'b!b', 'b', 'c!c', 'c'], 'nested block calls keep caller $_';
+}


### PR DESCRIPTION
Skip `$_`/`$/`/`$!` in the caller-env write-back loop. These report as dynamic (for `.VAR.dynamic` / CALLER:: since #3785) but are lexically scoped per routine — each call gets its own topic/match/error and the caller's value is restored from `saved_env`. `pop_caller_env_with_writeback` treated every dynamic var as write-back-to-caller, so a callee's stale `$_` clobbered the caller's live topic.

A `block.($_)` call inside a `for` loop reverted the loop topic to the previous iteration's value, making `$_ == 3 ff $_ == 5` off by one (`xx234xx` vs `xx345xx`). Fixes the long-failing t/flip-flop.t precedence subtests (added in #3169, hidden because t/ is non-fatal).

Tests: t/flip-flop.t 13/13 (was 8/13); new t/block-call-topic-restore.t (4); make test PASS; whitelisted caller/dynamic tests green; `$_.VAR.dynamic` still True.

🤖 Generated with [Claude Code](https://claude.com/claude-code)