### PR TITLE
fix(mixin): Bool-but-Bool stringifies from the effective .Bool

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1257,6 +1257,7 @@ roast/integration/advent2010-day06.t
 roast/integration/advent2010-day08.t
 roast/integration/advent2010-day10.t
 roast/integration/advent2010-day12.t
+roast/integration/advent2010-day19.t
 roast/integration/advent2010-day21.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -413,6 +413,27 @@ pub(crate) fn native_method_0arg(
         {
             return Some(Ok(str_val.clone()));
         }
+        // A Bool with a mixed-in Bool override (`True but False`) renders its
+        // Str/gist/raku from the *effective* boolean — `Bool.Str` is
+        // `self ?? 'True' !! 'False'`, so it follows `.Bool`, not the base bool.
+        if matches!(inner.as_ref(), Value::Bool(_))
+            && mixins.get("Str").is_none()
+            && let Some(Value::Bool(b)) = mixins.get("Bool")
+        {
+            match method {
+                "Str" | "~" | "gist" => {
+                    return Some(Ok(Value::str(
+                        if *b { "True" } else { "False" }.to_string(),
+                    )));
+                }
+                "raku" | "perl" => {
+                    return Some(Ok(Value::str(
+                        if *b { "Bool::True" } else { "Bool::False" }.to_string(),
+                    )));
+                }
+                _ => {}
+            }
+        }
         // An allomorph (IntStr/NumStr/…) gists as its preserved source string,
         // not the inner numeric's gist: `<1e3>.gist` → `1e3` (not `1000`). Only
         // allomorphs; a general `but`-mixin gists via its inner value (below).

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -956,6 +956,12 @@ impl Value {
             Value::Mixin(inner, mixins) => {
                 if let Some(str_val) = mixins.get("Str") {
                     str_val.to_string_value()
+                } else if let (Value::Bool(_), Some(Value::Bool(b))) =
+                    (inner.as_ref(), mixins.get("Bool"))
+                {
+                    // `True but False`: Bool stringifies from the effective
+                    // boolean (`self ?? 'True' !! 'False'`), so follow `.Bool`.
+                    if *b { "True" } else { "False" }.to_string()
                 } else {
                     inner.to_string_value()
                 }

--- a/t/bool-but-bool-stringify.t
+++ b/t/bool-but-bool-stringify.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 10;
+
+# `Bool but Bool` (`True but False`) mixes in a Bool override. `Bool.Str` is
+# `self ?? 'True' !! 'False'`, so Str/gist follow the *effective* `.Bool`, not
+# the underlying base bool. `.raku` renders as `Bool::True` / `Bool::False`.
+
+my $tf = True but False;
+is ?$tf, False, 'True but False is falsy';
+is ~$tf, 'False', 'True but False stringifies as False (~)';
+is $tf.Str, 'False', 'True but False .Str is False';
+is $tf.gist, 'False', 'True but False .gist is False';
+is $tf.raku, 'Bool::False', 'True but False .raku is Bool::False';
+
+my $ft = False but True;
+is ?$ft, True, 'False but True is truthy';
+is ~$ft, 'True', 'False but True stringifies as True';
+is $ft.gist, 'True', 'False but True .gist is True';
+
+# An explicit Str mixin still wins over the Bool-derived string.
+my $custom = True but False but role { method Str { 'custom' } };
+is $custom.Str, 'custom', 'explicit Str mixin overrides Bool-derived string';
+
+# A non-Bool `but` mixin is unaffected (delegates to inner / Str mixin).
+is (1 but "x").Str, 'x', 'non-Bool but-mixin unaffected';


### PR DESCRIPTION
## Problem

`True but False` mixes a Bool override into a Bool. `Bool.Str` is `self ?? 'True' !! 'False'`, so Str/gist must follow the **effective** `.Bool`, not the underlying base bool. mutsu delegated Str to the inner value, so `~(True but False)` gave `'True'` instead of `'False'`.

## Fix

Handle a Bool inner with a mixed-in `Bool` (and no explicit `Str` mixin) in both the `.Str`/`.gist`/`.raku` method path and `to_string_value` (used by prefix `~` / string interpolation):

- `(True but False).Str / .gist` → `'False'`
- `(True but False).raku` → `'Bool::False'`

An explicit `Str` mixin still wins; non-Bool `but`-mixins and allomorphs (IntStr/NumStr/…) are unaffected.

## Tests

- Whitelists `roast/integration/advent2010-day19.t` (6/6).
- New `t/bool-but-bool-stringify.t` (10 subtests).
- `allomorphic.t` unaffected (still its pre-existing `.ACCEPTS` 1-fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)