### PR TITLE
fix(params,regex): writable params shadow caller readonly; alias captures dual-name

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1276,6 +1276,7 @@ roast/integration/advent2012-day16.t
 roast/integration/advent2012-day20.t
 roast/integration/advent2012-day24.t
 roast/integration/advent2013-day02.t
+roast/integration/advent2013-day06.t
 roast/integration/advent2013-day07.t
 roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -544,6 +544,16 @@ impl Interpreter {
                     subcap.sym = sym_key.cloned();
                 }
                 new_caps.code_blocks.extend(subcap.code_blocks.clone());
+                // A non-suppressing alias `<name=subrule>` (NOT `<name=.subrule>` /
+                // `<name=&subrule>`) installs the capture under BOTH the alias name
+                // AND the subrule's own name, matching Rakudo (e.g. `<x=num>` yields
+                // `$<x>` and `$<num>`; repeated `<num>`/`<offset=count>` aggregate
+                // into a list under the rule name). Snapshot the subcap/text before
+                // the alias push consumes them so we can also store under the original.
+                let also_under_original = spec.capture_name.is_some()
+                    && !spec.alias_replaces_original
+                    && capture_name != spec.lookup_name;
+                let original_subcap = also_under_original.then(|| subcap.clone());
                 new_caps
                     .named_subcaps
                     .entry(capture_name.to_string())
@@ -553,7 +563,7 @@ impl Interpreter {
                     .named
                     .entry(capture_name.to_string())
                     .or_default()
-                    .push(captured);
+                    .push(captured.clone());
                 if spec.capture_name.is_some() && capture_name != spec.lookup_name {
                     new_caps
                         .capture_alias_map
@@ -563,6 +573,18 @@ impl Interpreter {
                     {
                         last.action_name = Some(spec.lookup_name.clone());
                     }
+                }
+                if let Some(orig_subcap) = original_subcap {
+                    new_caps
+                        .named_subcaps
+                        .entry(spec.lookup_name.clone())
+                        .or_default()
+                        .push(orig_subcap);
+                    new_caps
+                        .named
+                        .entry(spec.lookup_name.clone())
+                        .or_default()
+                        .push(captured);
                 }
             } else if !inner_caps.named.is_empty() || !inner_caps.named_subcaps.is_empty() {
                 // Silent subrule (`<.foo>`) that contains nested captures. The

--- a/src/runtime/types/binding.rs
+++ b/src/runtime/types/binding.rs
@@ -1679,10 +1679,18 @@ impl Interpreter {
             // array/hash params through. (`@!attr`/`%.attr` twigil params are
             // attribute binds, already skipped above.)
             let is_container_param = pd.name.starts_with('@') || pd.name.starts_with('%');
-            if !is_container_param
-                && (!has_mutable_trait || raw_nonlvalue_params.contains(&pd.name))
-            {
-                self.readonly_vars.insert(pd.name.clone());
+            if !is_container_param {
+                if !has_mutable_trait || raw_nonlvalue_params.contains(&pd.name) {
+                    self.readonly_vars.insert(pd.name.clone());
+                } else {
+                    // Writable `is copy`/`is rw`/`is raw` scalar param: the
+                    // readonly set is keyed by bare name and shared across frames,
+                    // so a caller's same-named readonly param (e.g. an outer `$d`)
+                    // would otherwise leak in and make this writable param appear
+                    // readonly. Drop the mark; the surrounding call path restores
+                    // the caller's readonly state via `restore_readonly_vars`.
+                    self.readonly_vars.remove(&pd.name);
+                }
             }
         }
         Ok(rw_bindings)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -264,6 +264,11 @@ pub(crate) struct VmCallFrame {
     /// without cloning the whole set). Removed on `pop_call_frame`. Empty for the
     /// slow path, which restores the full set via `saved_readonly` instead.
     pub readonly_added: Vec<String>,
+    /// Read-only var names this frame *removed* from `readonly_vars` because a
+    /// writable (`is copy`/`is rw`/`is raw`) param shadows a caller's same-named
+    /// read-only variable. Re-added on `pop_call_frame` to restore the caller's
+    /// state. Light-frame method path counterpart to `readonly_added`.
+    pub readonly_removed: Vec<String>,
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
 }
 

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -182,6 +182,14 @@ impl Interpreter {
                     .any(|t| t == "rw" || t == "copy" || t == "raw");
                 if !has_mutable_trait {
                     self.mark_readonly(&pd.name);
+                } else {
+                    // `is copy`/`is rw`/`is raw` params are writable. The readonly
+                    // set is keyed by bare name and shared across frames, so a
+                    // caller's same-named readonly param (e.g. an outer `$d`) would
+                    // otherwise leak in and make this writable param appear readonly.
+                    // Unmark it; `restore_readonly_vars` reinstates the caller's
+                    // state after the call.
+                    self.unmark_readonly(&pd.name);
                 }
             }
         }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -26,6 +26,7 @@ impl Interpreter {
             saved_env: self.env().clone(),
             saved_readonly: Some(self.save_readonly_vars()),
             readonly_added: Vec::new(),
+            readonly_removed: Vec::new(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
@@ -42,6 +43,7 @@ impl Interpreter {
             saved_env: self.env().clone(),
             saved_readonly: None,
             readonly_added: Vec::new(),
+            readonly_removed: Vec::new(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
@@ -63,10 +65,14 @@ impl Interpreter {
         if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
             // Slow path: restore the whole snapshot (covers any `:=` marking).
             self.restore_readonly_vars(readonly);
-        } else if !frame.readonly_added.is_empty() {
-            // Light-frame method path: drop only the param names this frame added.
+        } else {
+            // Light-frame method path: drop only the param names this frame added
+            // and restore any caller names this frame's writable params shadowed.
             for name in &frame.readonly_added {
                 self.unmark_readonly(name);
+            }
+            for name in &frame.readonly_removed {
+                self.mark_readonly(name);
             }
         }
         frame

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -968,6 +968,16 @@ impl Interpreter {
                 .iter()
                 .any(|t| t == "rw" || t == "copy" || t == "raw")
             {
+                // A writable param must shadow a caller's same-named read-only
+                // variable (the readonly set is keyed by bare name, shared across
+                // frames). Drop the mark and record it so `pop_call_frame`
+                // restores the caller's state.
+                if self.readonly_vars().contains(pd.name.as_str()) {
+                    self.unmark_readonly(&pd.name);
+                    if let Some(frame) = self.call_frames.last_mut() {
+                        frame.readonly_removed.push(pd.name.clone());
+                    }
+                }
                 continue;
             }
             if self.readonly_vars().contains(pd.name.as_str()) {

--- a/t/copy-param-shadows-caller-readonly.t
+++ b/t/copy-param-shadows-caller-readonly.t
@@ -1,0 +1,53 @@
+use Test;
+
+# An `is copy` (or `is rw`) parameter must be writable even when an outer
+# routine in the call chain has a readonly parameter of the *same* name. The
+# readonly set is keyed by bare name and shared across frames, so without
+# shadowing the caller's readonly mark leaks in and the inner copy param wrongly
+# appears readonly. Regression: integration/advent2013-day06.t.
+
+plan 6;
+
+# sub -> sub, both named $d
+sub inner($d is copy) { $d++; $d }
+sub outer($d) { inner($d) }
+is outer(5), 6, 'is copy sub param writable despite same-named readonly caller param';
+
+# method -> method, both named $d (the day06 shape)
+class C {
+    method based-on($d is copy) {
+        $d++ until $d >= 10;
+        $d;
+    }
+    method top($d) {
+        self.based-on($d);
+    }
+}
+is C.new.top(3), 10, 'is copy method param writable despite same-named readonly caller param';
+
+# is rw target with same-named readonly caller param
+sub bump($x is rw) { $x += 100 }
+sub via($x) { my $y = $x; bump($y); $y }
+is via(1), 101, 'is rw param works with same-named readonly caller param';
+
+# caller's readonly param stays readonly after the inner call returns
+sub checks($d) {
+    inner($d);          # inner's copy param transiently unmarks "d"
+    $d = 99;            # must still be readonly here
+}
+dies-ok { checks(7) }, "caller's readonly param remains readonly after inner copy-param call";
+
+# nested loop mutation (until) on a copy param, day06 idiom
+class D {
+    has $.step = 7;
+    method walk(Int $d is copy where { $_ > 0 }) {
+        ++$d until $d %% $.step;
+        $d;
+    }
+    method run(Int $d) { self.walk($d) }
+}
+is D.new.run(3), 7, 'is copy + where method param mutated in until loop';
+
+# the original value at the caller is unaffected by the copy
+sub keep($v) { inner($v); $v }
+is keep(42), 42, 'copy param mutation does not write back to caller value';

--- a/t/regex-named-alias-dual-capture.t
+++ b/t/regex-named-alias-dual-capture.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A non-suppressing named-subrule alias `<name=rule>` installs the capture under
+# BOTH the alias name AND the subrule's own name (Rakudo behaviour). The dot/amp
+# forms (`<name=.rule>` / `<name=&rule>`) suppress the rule-name capture.
+# Repeated captures under the same rule name aggregate into a list.
+# Regression: roast/integration/advent2013-day06.t (`<offset=count>` + `<count>`).
+
+plan 8;
+
+grammar G {
+    token TOP { <x=num> }
+    token num { \d+ }
+}
+my $m = G.parse('5');
+ok $m<x>.defined,    '<x=num> creates the alias capture $<x>';
+ok $m<num>.defined,  '<x=num> ALSO creates the rule-name capture $<num>';
+is ~$m<x>,   '5', 'alias capture value';
+is ~$m<num>, '5', 'rule-name capture value';
+
+# dot-alias suppresses the rule-name capture
+grammar D {
+    token TOP { <x=.num> }
+    token num { \d+ }
+}
+my $d = D.parse('7');
+ok $d<x>.defined,     '<x=.num> creates $<x>';
+nok $d<num>.defined,  '<x=.num> does NOT create $<num>';
+
+# direct + aliased reference to the same rule aggregate under the rule name
+grammar L {
+    token TOP { <count> '-' <offset=count> }
+    token count { \d+ }
+}
+my $l = L.parse('3-2');
+is $l<count>.elems, 2, 'direct + aliased rule references aggregate into a list';
+is ~$l<offset>, '2', 'alias capture is the second reference';


### PR DESCRIPTION
Two independent correctness fixes that together green `roast/integration/advent2013-day06.t` (+1 whitelist).

## 1. Writable params must shadow a caller's same-named readonly param

`is copy` / `is rw` / `is raw` scalar params were appearing readonly when an outer routine in the call chain had a readonly param of the **same name**. The readonly set is keyed by bare name and shared across frames, so the caller's mark leaked in:

```raku
class C {
    method based-on($d is copy) { $d++ until $d >= 10; $d }
    method top($d) { self.based-on($d) }   # both params named $d
}
say C.new.top(3);   # was: Cannot resolve caller postfix:<++>(d) ... ; now: 10
```

Fixed all three param-binding paths:
- `bind_function_args_values` (sub / slow method path) — drop the mark.
- `call_compiled_function_typed` — unmark instead of leaving it.
- `mark_fast_method_params_readonly` (light method path) — unmark and record on the call frame's new `readonly_removed` list so `pop_call_frame` re-marks it, restoring the caller's state.

## 2. `<name=rule>` aliases capture under both names

A non-suppressing named-subrule alias now installs the capture under **both** the alias name and the subrule's own name, matching Rakudo:

```raku
grammar G { token TOP { <x=num> }; token num { \d+ } }
G.parse('5');   # now yields BOTH $<x> and $<num>
```

Repeated references (`<count>` + `<offset=count>`) aggregate into a list under the rule name — exactly what day06's `+$m<count>[0]` relies on. The dot/amp forms (`<name=.rule>` / `<name=&rule>`) still suppress the rule-name capture.

## Tests
- `t/copy-param-shadows-caller-readonly.t`
- `t/regex-named-alias-dual-capture.t`
- `make test` green; whitelisted S05/S06 + a method-heavy S12/S14/S03/S04 sample regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)