### PR TITLE
fix(parser): unit-class `also is Parent` extracts into the parent list

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1282,6 +1282,7 @@ roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t
 roast/integration/code-blocks-as-sub-args.t
+roast/integration/diamond.t
 roast/integration/eval-and-threads.t
 roast/integration/failure-and-callsame.t
 roast/integration/lexical-array-in-inner-block.t

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -245,9 +245,53 @@ pub(crate) fn stmt_list_with_mode(
         // the compiler keeps their package context for the rest of the scope.)
         if allow_mainline_capture && starts_unit_class_role_grammar(r) {
             let (after_decl, mut decl) = class::unit_module_stmt(r)?;
-            let (tail_rest, tail_stmts) = stmt_list_with_mode(after_decl, false, emit_setline)?;
+            let (tail_rest, mut tail_stmts) = stmt_list_with_mode(after_decl, false, emit_setline)?;
             match &mut decl {
-                Stmt::ClassDecl { body, .. } | Stmt::RoleDecl { body, .. } => *body = tail_stmts,
+                Stmt::ClassDecl {
+                    body,
+                    parents,
+                    class_is_rw,
+                    ..
+                } => {
+                    // A `class Foo { ... }` block extracts `also is Parent` and
+                    // `also is rw` from its body into the parents list / rw flag
+                    // at parse time. The `unit class Foo;` form gathers trailing
+                    // statements here, so apply the same extraction — otherwise an
+                    // `also is Parent` (a bare `is(also, Parent)` infix expression)
+                    // would execute as a runtime "two terms in a row".
+                    tail_stmts.retain(|stmt| {
+                        if class::stmt_is_also_is_rw(stmt) {
+                            *class_is_rw = true;
+                            false
+                        } else if let Some(parent_name) = class::stmt_also_is_parent(stmt) {
+                            parents.push(parent_name);
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    // `use` is compile-time in Raku, so a `unit class Foo; use Bar;
+                    // also is Bar;` must load Bar before Foo's parents resolve. The
+                    // unit-class body runs at class-registration time (after parents
+                    // are resolved), so hoist any `use`/`need`/`import` statements
+                    // out of the body to before the declaration. They stay in the
+                    // same compilation-unit scope, so imported symbols remain
+                    // visible. (Diamond inheritance: roast/integration/diamond.t.)
+                    if !parents.is_empty() {
+                        let mut hoisted: Vec<Stmt> = Vec::new();
+                        tail_stmts.retain(|stmt| {
+                            if matches!(stmt, Stmt::Use { .. }) {
+                                hoisted.push(stmt.clone());
+                                false
+                            } else {
+                                true
+                            }
+                        });
+                        stmts.extend(hoisted);
+                    }
+                    *body = tail_stmts;
+                }
+                Stmt::RoleDecl { body, .. } => *body = tail_stmts,
                 _ => {}
             }
             stmts.push(decl);

--- a/t/unit-class-also-is.t
+++ b/t/unit-class-also-is.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `also is Parent` / `also is rw` inside a `unit class Foo;` must be extracted
+# into the class's parent list / rw flag, exactly as a `class Foo { ... }` block
+# does. Previously the unit-class form left `also is Parent` as a bare
+# `is(also, Parent)` infix expression in the body, which executed as a runtime
+# "two terms in a row". Regression: roast/integration/diamond.t.
+
+plan 8;
+
+# unit class via EVAL (a fresh compilation unit) exercises the file-scope
+# `unit class Foo; also is Parent;` path directly.
+class Base { method greet { "hi" } }
+my $derived = EVAL q:to/CODE/;
+    unit class Derived;
+    also is Base;
+    method extra { "x" }
+    CODE
+is $derived.^name, "Derived", "unit class with also-is registers";
+is $derived.new.greet, "hi", "unit class also is Parent inherits the parent method";
+is $derived.new.extra, "x", "unit class own method works alongside also is";
+
+# A diamond unit class declared at file scope is exercised by the diamond roast
+# test; here we also verify the block-equivalent behaviours.
+class Animal { method sound { "..." } }
+class Dog is Animal { method sound { "woof" } }
+is Dog.new.sound, "woof", "ordinary is-inheritance still works";
+
+# also is rw in a class block
+class Point { also is rw; has $.x; }
+my $p = Point.new(x => 1);
+lives-ok { $p.x = 5 }, "also is rw makes accessors writable";
+is $p.x, 5, "also is rw accessor assignment took effect";
+
+# also is Parent in a class block resolves the parent into the MRO
+class C1 { method m { "c1" } }
+class C2 { also is C1; }
+is C2.new.m, "c1", "also is Parent (block form) inherits the method";
+ok C2.^mro.map(*.^name).grep("C1"), "C1 is in C2's MRO via also is";


### PR DESCRIPTION
A `class Foo { ... }` block extracts `also is Parent` and `also is rw` statements from its body into the class's parent list / `rw` flag at parse time. The `unit class Foo;` form gathers trailing statements as the class body via a separate code path (stmtlist mainline capture) that never applied this extraction, so `also is Parent` stayed in the body as a bare `is(also, Parent)` infix expression and executed as a runtime `Confused. Two terms in a row`:

```raku
unit class X;
also is Cool;        # was: Runtime error: Two terms in a row
method bar { 42 }
say X.new.bar;       # now: 42
```

## Fix
- Apply the same `also is` / `also is rw` extraction when capturing a unit-class body.
- `use` is compile-time in Raku, but a unit-class body runs at class-registration time (after parents resolve). So `unit class A; use B; also is B;` failed to resolve `B`. When the unit class has extracted parents, hoist `use` statements out of the body to before the declaration (they stay in the same compunit scope, so imports remain visible). This greens diamond inheritance across precompiled modules.

## Result
- Whitelists `roast/integration/diamond.t` (diamond inheritance A is B,C; B,C is D, across modules + precompilation invalidation).
- Test: `t/unit-class-also-is.t`; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)