### PR TITLE
fix(arrays): persist mutating .map over shaped arrays

### DIFF
--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1343,16 +1343,23 @@ impl Interpreter {
             && target_var.starts_with('@')
             && !matches!(&target, Value::LazyList(ll) if ll.is_infinite_spec())
         {
-            let mut items = if crate::runtime::utils::is_shaped_array(&target) {
+            let is_shaped = crate::runtime::utils::is_shaped_array(&target);
+            let mut items = if is_shaped {
                 crate::runtime::utils::shaped_array_leaves(&target)
             } else {
                 Self::value_to_list(&target)
             };
             let result = self.eval_map_over_items_rw(args.first().cloned(), &mut items)?;
-            // Write mutated elements back to the source array (skip for shaped arrays
-            // since map shouldn't mutate the shaped structure)
-            if !crate::runtime::utils::is_shaped_array(&target) {
-                let key = target_var.to_string();
+            // Write mutated elements back to the source array. `.map(* *= 2)`
+            // rw-binds `$_` to each element, so element mutations persist (Raku
+            // semantics). A shaped array keeps its shape/structure — only the leaf
+            // values change — so rebuild it from the mutated leaves instead of
+            // flattening it into an ordinary list.
+            let key = target_var.to_string();
+            if is_shaped {
+                let rebuilt = crate::runtime::utils::replace_shaped_leaves(&target, &items);
+                self.env.insert(key, rebuilt);
+            } else {
                 self.env.insert(key, Value::real_array(items));
             }
             return Ok(result);

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1357,7 +1357,16 @@ impl Interpreter {
             // flattening it into an ordinary list.
             let key = target_var.to_string();
             if is_shaped {
-                let rebuilt = crate::runtime::utils::replace_shaped_leaves(&target, &items);
+                let mut rebuilt = crate::runtime::utils::replace_shaped_leaves(&target, &items);
+                // The element-type metadata (`array[int]`) is embedded in
+                // ArrayData; `replace_shaped_leaves` rebuilds it, so re-tag the
+                // result to keep `.WHAT`/`.raku` (and shaped-only behaviours like
+                // `:delete` dying) correct after the map. Runs even for a
+                // non-mutating map (`@a.map(* + 2)`), which still round-trips the
+                // array through this writeback.
+                if let Some(info) = self.container_type_metadata(&target) {
+                    rebuilt = self.tag_container_metadata(rebuilt, info);
+                }
                 self.env.insert(key, rebuilt);
             } else {
                 self.env.insert(key, Value::real_array(items));

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -156,6 +156,35 @@ fn collect_indexed_leaves(value: &Value, indices: &mut Vec<i64>, out: &mut Vec<(
     }
 }
 
+/// Rebuild a shaped array, replacing its leaf values (in depth-first order) with
+/// `new_leaves`, while preserving the nested structure, shape metadata, and array
+/// kind. Used to write `.map`/mutation results back into a shaped array without
+/// flattening it into an ordinary list. `new_leaves` must have exactly as many
+/// elements as the array has leaves; extras are ignored, shortfalls keep the
+/// original leaf.
+pub(crate) fn replace_shaped_leaves(original: &Value, new_leaves: &[Value]) -> Value {
+    let mut iter = new_leaves.iter();
+    rebuild_with_leaves(original, &mut iter)
+}
+
+fn rebuild_with_leaves<'a, I: Iterator<Item = &'a Value>>(value: &Value, iter: &mut I) -> Value {
+    if let Value::Array(items, kind) = value {
+        let new_items: Vec<Value> = if items.iter().any(|v| matches!(v, Value::Array(..))) {
+            items.iter().map(|c| rebuild_with_leaves(c, iter)).collect()
+        } else {
+            items
+                .iter()
+                .map(|orig| iter.next().cloned().unwrap_or_else(|| orig.clone()))
+                .collect()
+        };
+        let mut data = crate::value::ArrayData::new(new_items);
+        data.shape = items.shape.clone();
+        Value::Array(Arc::new(data), *kind)
+    } else {
+        iter.next().cloned().unwrap_or_else(|| value.clone())
+    }
+}
+
 pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::Package(name), Value::Int(0)) | (Value::Int(0), Value::Package(name))

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -679,6 +679,16 @@ impl Interpreter {
         let new_val = self.maybe_wrap_native_int(name, new_val);
         self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
+        // Track topic mutations for the rw-map writeback (`@a.map({ $_ += 1 })`).
+        // A compound assign / inc-dec to `$_` lands here via the fused
+        // `AtomicCompoundVar` path; the plain-assign path (`AssignExpr`) records
+        // this already, so without it `+=`/`~=`/`++` mutations inside a map block
+        // are silently dropped on the source array (only `*=`/`/=`, whose LHS
+        // desugars through a `defined`-ternary and so skips fusion, worked).
+        if name == "_" {
+            self.env_mut()
+                .insert("__mutsu_rw_map_topic__".to_string(), new_val.clone());
+        }
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
         // Slice F: an inc/dec (`$*foo++`) of a caller-declared dynamic variable

--- a/t/shaped-array-map-mutation.t
+++ b/t/shaped-array-map-mutation.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `.map(* OP= ...)` / `.map({ $_ OP= ... })` rw-binds `$_` to each element, so
+# element mutations must persist to the source array (Raku semantics). For a
+# shaped array the shape/structure is preserved — only leaf values change.
+# Two bugs fixed:
+#  1. The shaped-array map writeback was skipped entirely.
+#  2. Fused compound assigns (`+=`/`~=`/etc., via AtomicCompoundVar) did not
+#     record the `$_` mutation for the rw-map writeback, so only `*=`/`/=`
+#     (whose LHS desugars through a `defined`-ternary, skipping fusion) worked.
+
+plan 12;
+
+# native int shaped, compound *= (ternary-LHS form)
+my int @i[4] = 10, 15, 12, 16;
+@i.map(* *= 2);
+is @i.join(","), "20,30,24,32", "int shaped: map(* *= 2) persists";
+
+# native int shaped, += (fused form — the previously-broken path)
+my int @j[3] = 1, 2, 3;
+@j.map({ $_ += 10 });
+is @j.join(","), "11,12,13", "int shaped: map(\$_ += 10) persists";
+
+# native int shaped, plain assign to $_
+my int @k[3] = 1, 2, 3;
+@k.map({ $_ = $_ * 100 });
+is @k.join(","), "100,200,300", "int shaped: map(\$_ = ...) persists";
+
+# native str shaped, ~= (fused concat-assign)
+my str @s[3] = "a", "b", "c";
+@s.map({ $_ ~= "x" });
+is @s.join(","), "ax,bx,cx", "str shaped: map(\$_ ~= ...) persists";
+
+# shape and element type are preserved
+is @i.shape, (4,), "int shaped: shape preserved after map";
+ok @i ~~ Array, "int shaped: still an array after map";
+
+# a non-mutating map must NOT change the source
+my int @n[3] = 1, 2, 3;
+my @r = @n.map({ $_ + 100 });
+is @n.join(","), "1,2,3", "non-mutating map leaves shaped source unchanged";
+is @r.join(","), "101,102,103", "non-mutating map returns mapped values";
+
+# multi-dim shaped: map over leaves, structure preserved
+my @m[2;2] = (1, 2), (3, 4);
+@m.map({ $_ += 1 });
+is @m[0;0], 2, "multidim shaped: leaf (0,0) mutated";
+is @m[1;1], 5, "multidim shaped: leaf (1,1) mutated";
+is @m.shape, (2, 2), "multidim shaped: shape preserved";
+
+# ordinary (non-shaped) array still works
+my @o = 1, 2, 3;
+@o.map({ $_ += 1 });
+is @o.join(","), "2,3,4", "non-shaped array: compound-assign map persists";


### PR DESCRIPTION
`@arr.map(* OP= ...)` / `.map({ \$_ OP= ... })` rw-binds `\$_` to each element, so element mutations must persist to the source array. Two bugs prevented this for **shaped** arrays (`my int @a[4]`, `array[T].new(:shape(...))`):

```raku
my int @a[4] = 10, 15, 12, 16;
@a.map(* *= 2);    # @a was unchanged; now [20 30 24 32]

my str @s[3] = "a", "b", "c";
@s.map({ $_ ~= "x" });   # @s was unchanged; now [ax bx cx]
```

## Fixes
1. The shaped-array map writeback was **skipped entirely** (an old comment claimed "map shouldn't mutate the shaped structure"). A shaped array keeps its shape — only the leaf values change — so rebuild it from the mutated leaves via the new `replace_shaped_leaves` helper instead of flattening into an ordinary list.
2. Fused compound assigns (`+=`/`~=`/…, compiled to `AtomicCompoundVar`) didn't record the `$_` mutation in the rw-map topic tracker, so the writeback dropped them. Only `*=`/`/=` worked, because their LHS desugars through a `defined`-ternary that skips fusion and routes through the plain-assign path (which already records the mutation). Now `store_named_scalar_rmw_result` records it too for name `_`.

## Impact
- `S09-typed-arrays/native-shape1-{int,num,str}.t`: **33 → 7** failing subtests each (remaining: shaped slice / `:delete` / `.raku` / clear-reinit — separate features, follow-up).
- Non-mutating maps still leave the source unchanged; multidim shaped arrays preserve structure.
- Test: `t/shaped-array-map-mutation.t`; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)