### PR TITLE
docs: slim ANALYSIS.md, move completed work to news/2026-06.md

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -4,7 +4,7 @@
 「設計上どこまで整理できていて、何がまだ負債として残っているか」をまとめたもの。
 バグ票の一覧ではなく、**アーキテクチャと健全性のレビュー**として読む想定。
 
-初版: 2026-06-03 / rev2: 2026-06-15 / rev3: 2026-06-17 / rev4: 2026-06-27 (単一ストア化 #3455・ユーザメソッド本体 tree-walk 撤去 §B #3680) / **rev5: 2026-06-27 (クロージャ upvalue Phase 1 #3715・Track B 着手前設計メモを §1.3/§2.1 に反映)** / **rev6: 2026-06-27 (GC 方針確定 ADR-0001＝cycle collector on Arc・Track B は GC 統合=層3a・§2.1/§7-6 に反映)**
+初版: 2026-06-03 / rev2: 2026-06-15 / rev3: 2026-06-17 / rev4: 2026-06-27 (単一ストア化 #3455・ユーザメソッド本体 tree-walk 撤去 §B #3680) / **rev5: 2026-06-27 (クロージャ upvalue Phase 1 #3715・Track B 着手前設計メモを §1.3/§2.1 に反映)** / **rev6: 2026-06-27 (GC 方針確定 ADR-0001＝cycle collector on Arc・Track B は GC 統合=層3a・§2.1/§7-6 に反映)** / **rev7: 2026-06-28 (§7-8 巨大ファイル分割 sweep 完了・registry-Arc/単一ストア/bool→enum の完了詳細を news へ移動し §1.1/§6/§7 をスリム化)**
 方法:
 - 調査エージェントによるサブシステム単位の精読
 - 主張ごとの実機再現確認
@@ -83,43 +83,15 @@ CP-3 collapse で VM と Interpreter の二重構造は消えた。
 - **宣言登録** (`class`/`role`/`enum`/`sub`/`method` の `register_*_decl`) は依然 tree-walk で実行
   (`Register*` opcode → `register_sub_decl` / `register_class_decl`)。クラスシステム・MRO・role 合成は
   未コンパイル。ただしこれは**宣言の登録**であって本体実行ではない。
-  - **sub 登録の冪等化 (slice 1)**: `RegisterSub` は enclosing frame が走るたびに再実行される
-    (hot routine 内の `my sub` 等) が、宣言が識別不変なら再実行は no-op であるべき。各宣言に
-    コンパイル時 fingerprint (`CompiledCode.sub_fingerprints`) を持たせ、`register_sub_decl` が
-    `SubRegisterOutcome::{Installed, Unchanged}` を返すことで、**識別不変な再登録を `FunctionDef`
-    再導出なしに O(1) で検出し、resolution cache を乱さない**よう型で明示した。
-  - **registry の `Arc<FunctionDef>` 化 (slice 2)**: `my sub` を宣言するルーチンへ入るたびに
-    `snapshot_routine_registry` が `functions.clone()` で**プログラム中の全ルーチン body を deep-clone**
-    していた (lexical scope を巻き戻すため)。registry が `HashMap<Symbol, Arc<FunctionDef>>` を保持する
-    ことで、この snapshot は O(n) の refcount-bump になり、body の大きいルーチンを多数持つ現実的な
-    プログラムで顕著に軽くなる (200-sub のマイクロベンチで ~28%)。registry は**不変・共有可能な定義**を
-    保持する設計になった (in-place 変異サイトは皆無＝`make_mut` 不要)。dispatch 側の戻り値型は
-    `FunctionDef` のまま (resolution 境界で `(**arc).clone()`)。
-  - **dispatch resolution への Arc 貫通 (slice 3)**: ホットな単一結果リゾルバ
-    (`resolve_function`/`resolve_function_with_types`/`_with_arity`/`_with_alias`/
-    `choose_best_matching_candidate`) の戻り値を `Option<Arc<FunctionDef>>` 化。**呼び出し毎の
-    resolution が body を deep-clone していたのを Arc bump に**。caller は Deref 経由で読み、所有 FunctionDef
-    が要る数箇所のみ明示 clone。multi 候補列挙 (`resolve_all_*`) と proto/redispatch
-    (`MultiDispatchEntry`) はレアパスなので境界で `FunctionDef` に変換し、core struct への波及を回避。
-  - **derive-once キャッシュ (slice 4)**: `my sub` はルーチン return 時に registry から外れ
-    (lexical scope の snapshot/restore)、次の呼び出しで再 install される。slice 1 の冪等パスは
-    「registry に残っている」場合専用なので、この**再 install は AST→`FunctionDef` を毎回再導出**して
-    いた (auto-sig scan・validation・body clone)。導出済み `Arc<FunctionDef>` を
-    `(fingerprint, package)` キーでキャッシュ (`prepared_fn_defs`) し、単純な単一 sub の再 install は
-    キャッシュした `Arc` を clone して streamlined install するだけにした (**真の derive-once**)。
-    package をキーに含めるので同 body の別 package sub が混ざらない。
-  - **`MultiDispatchEntry` の Arc 化 (slice 5)**: redispatch スタックの候補列を
-    `Vec<Arc<FunctionDef>>` 化。`resolve_all_multi_candidates`/`resolve_remaining_proto_candidates`
-    は registry の `Arc` をそのまま返し、`nextsame`/`callsame`/`callwith`/`nextcallee` の
-    per-step 候補 clone が refcount-bump になった。
-  - **registry-Arc の完遂 (slice 6/7/8)**: registry に残っていた `FunctionDef` 直保持マップを
-    すべて `Arc<FunctionDef>` 化した — `proto_functions` (slice 6)、grammar `token_defs`
-    (`HashMap<Symbol, Vec<Arc<FunctionDef>>>`・slice 7)、`our_scoped_functions` (slice 8)。
-    これにより `snapshot_routine_registry` / `clone_for_thread` / EVAL コピー / block-scope
-    restore のいずれの registry クローンでも **`FunctionDef` body が deep-clone されなくなった**。
-    grammar token 解決 (`resolve_token_defs`) の候補 merge も Arc bump になり、`our` sub の
-    restore は `functions` と同一 `Arc` を共有する。**→ registry-Arc キャンペーン完了。** 残る
-    §1.1 課題はメソッド dispatch の resolution caching のみ (下記)。
+  - **sub 登録の冪等化 + registry-Arc キャンペーン完了** (slice 1-8・詳細は [news/2026-06.md](news/2026-06.md)):
+    `my sub` 宣言ルーチンへ入るたびに `snapshot_routine_registry` が registry クローンで**全ルーチン body を
+    deep-clone** していた問題を、registry の全定義マップ (`functions`/`proto_functions`/grammar `token_defs`/
+    `our_scoped_functions`) を `Arc<FunctionDef>` 化し、コンパイル時 fingerprint
+    (`CompiledCode.sub_fingerprints`) による再登録冪等化 (`SubRegisterOutcome::{Installed, Unchanged}`) と
+    `(fingerprint, package)` キーの derive-once キャッシュ (`prepared_fn_defs`) を加えて解消。dispatch
+    resolution と `MultiDispatchEntry` も `Arc` 貫通。**どの registry クローン (snapshot/`clone_for_thread`/
+    EVAL/block-scope restore) でも `FunctionDef` body が deep-clone されなくなった。** 残る §1.1 課題は
+    メソッド dispatch の resolution caching のみ (下記)。
 - **メソッド dispatch の resolver オーバーヘッド**: multi/submethod や `samewith`/`nextsame` は
   `run_instance_method` (resolve + frame setup) を**入口として**通る (本体は compiled)。`MUTSU_VM_STATS` の
   `resolver-path method dispatches` カウンタはこの dispatch 入口数を測る (tree-walk 実行ではない)。
@@ -356,9 +328,14 @@ Track B は規模・難度ともに大きく、着手前に次を踏まえるこ
   持つ場合は実 `BlockScope` を通すよう修正し、`bom-test-2-*` のリークは解消。pin=`t/tail-block-leave-phaser.t`。
   残: `t/bom-stripping.t` は自前で `LEAVE unlink` 済 (CWD だが掃除される)。別軸の未修正＝bare block での KEEP が
   raku では発火しないのに mutsu は発火する (tail/非-tail 共通・本修正と独立)。
-- **500 行規約の大幅違反**: `src/` に 500 行超 **164 ファイル**、1000 行超 **82 ファイル**。
-  最大は `vm/vm_var_assign_ops.rs` **7267**、`runtime/mod.rs` **6633**、`runtime/regex_parse.rs` **6193**、
-  `runtime/methods_object.rs` 5135、`runtime/io.rs` 4494。規約 (500 行上限) は形骸化。
+- **500 行規約違反 — §7-8 sweep で最悪オフェンダーを一掃**（詳細は [news/2026-06.md](news/2026-06.md)）:
+  500 行超のファイルを **cohesive サブモジュールへ純粋移設**（impl ブロック→兄弟ファイル / 自由関数→facade + サブディレクトリ）。
+  最大級だった `vm/vm_var_assign_ops.rs`（7267）・`runtime/mod.rs`・`runtime/methods_object.rs`・`runtime/io.rs`・
+  `runtime/methods.rs`・`runtime/regex_parse.rs` 等をすべて分割し、`vm.rs` module root は 4872→**286** 行に。
+  **`1000 行超` ファイルが 82→~40 件台へ激減**。`500 行超` の総数は微減（giant な単一 `match`/dispatch メソッド
+  —`exec_one`・`call_method_with_values`・`register_class_decl`・`native_method_1arg` 等—が関数境界で分割できず
+  residual 単独ファイルとして残るため）だが、これらは**意図的な indivisible 例外**。残: `ast.rs`・`registration_sub.rs`
+  等の未分割ファイルと、giant dispatch メソッドの構造的分割（logic refactor を伴うため別軸）。
 
 ---
 
@@ -377,7 +354,7 @@ Track B は規模・難度ともに大きく、着手前に次を踏まえるこ
 | 5 | `.^methods`/`.can` の型別リスト: 確認済みドリフトは是正 (Str/Int/List・§4.1)。完全な実ディスパッチ表からの導出は arity-dispatch 非列挙のため別軸 | ドリフト解消 | 中 |
 | 6 | **Track B**: 陳腐化 `unsafe` コメント是正は完了。残: 配列・ハッシュ要素の `ContainerRef` 化で生ポインタ unsoundness を撤廃。**GC と統合＝ADR-0001 層3a (`Arc → Gc<T>` 一斉置換・cycle collector on Arc)。単独着手しない・Phase A 完了後。** 着手前設計メモは §2.1 (79 箇所・コア表現変更・再入デッドロック/perf の地雷・cross-thread 共有は `shared_vars`)。#2 upvalue Phase 2+ の前提 | 健全性 (UB) + 性能 | 中〜大 |
 | 7 | 宣言登録の bytecode 化: 冪等化 (**slice 1**) + **registry-Arc キャンペーン完了** (slice 2 `functions` / slice 3 dispatch resolution / slice 4 derive-once キャッシュ / slice 5 `MultiDispatchEntry` / slice 6 `proto_functions` / slice 7 `token_defs` / slice 8 `our_scoped_functions`)。**registry のどのクローンでも `FunctionDef` body は deep-clone されない** (§1.1)。残: method dispatch の resolution caching (multi は #3684 着手・`fast_method_cache` 済・残るは multi arg-shape 依存解決) | 設計 + 性能 | 中 |
-| 8 | 一時ファイルを `tmp/` へ (root の `bom-test-*`) / 巨大ファイル分割 (500 行規約) | 衛生 | 低〜中 |
+| 8 | 巨大ファイル分割 (500 行規約): **§7-8 sweep で最悪オフェンダー一掃済み**（1000 行超 82→~40 件台・最大ファイル群を全分割・詳細は news）。残: `ast.rs`・`registration_sub.rs` 等の未分割ファイル / giant dispatch メソッドの構造的分割（別軸）。一時ファイルを `tmp/` へ (root の `bom-test-*`) | 衛生 | 低〜中 |
 
 ### Interpreter 除去という長期目標について — **達成 (2026-06)**
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,39 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### ★ §7-8 巨大ファイル分割 sweep — 500 行規約違反の最悪オフェンダーを一掃（2026-06-28）
+
+ANALYSIS §6/§8 の「500 行規約の大幅違反」に対し、500 行超のファイルを **cohesive サブモジュールへ純粋移設** で分割するキャンペーンを実施。確立した 2 つの流儀に従う：
+
+- **impl ブロックのファイル**（`impl Interpreter` 一枚岩）→ 同ディレクトリの**フラットな兄弟ファイル**へ分割し親 mod に `mod` 宣言を追加（`runtime/resolution.rs` #3792 が原型・visibility-only：兄弟から呼ぶ private `fn` を `pub(crate)` に昇格）。
+- **自由関数のファイル**（パーサ・builtins）→ **facade ファイル + サブディレクトリ**（`parser/primary/misc.rs` #3793 が原型・facade が `pub(crate) use submod::*` で全外部呼び出し元の経路を保存・本体の `super::` 参照は絶対 `crate::...` 経路へ書き換え）。
+
+いずれも **pure relocation**（関数/メソッドの multiset はバイト等価・挙動不変）。CI（`make test` + 包括的 `make roast`）が安全網。worktree 隔離エージェントを最大 4 並列で回し、`src/runtime/mod.rs` 等の共有 mod ファイルを編集する PR はアルファベット位置が異なれば git 3-way が自動マージ、衝突時は rebase で解消。
+
+主な分割（抜粋・各 PR）：
+
+- **VM**: `vm/vm_var_assign_ops.rs`（8009→10 ファイル）、`vm.rs` module root（4872→**286**・`exec_one` ~3665 行を `vm_exec_dispatch.rs` へ分離 + run loop / core helpers）、`vm/vm_call_method_compiled.rs`（2668→6）
+- **runtime**: `runtime/mod.rs` module root（7169 行・~5240 行の `impl Interpreter` を抽出）、`methods_object.rs`（4964→8）、`methods_mut.rs`（4595→6）、`io.rs`（4497→8）、`regex_parse.rs`（6482→5）、`methods.rs`（3493→facade + `call_method_with_values` ~3183 行の indivisible 単独ファイル）、`registration_class.rs`（3964→5）、`methods_classhow.rs`（2686→7）、`ops.rs`（1721→4）、`builtins_operators.rs`（1926→4）、`types/binding.rs`（1822→2）
+- **parser**: `expr/postfix.rs`（3803→facade + 5）、`primary/ident.rs`（3111→facade 14 行 + 7）、`primary/regex.rs`（2385→facade + 6）、`primary/container.rs`（1887→facade + 6・完全分解）、`stmt/simple_expr_stmt.rs`（2134→facade + 5）、`stmt/sub_param.rs`、`expr/precedence_meta_ops.rs`、`primary/var.rs`
+- **builtins**: `methods_narg.rs`（3787→facade + 10）、`functions.rs`（2103→facade + 11）、`arith.rs`（1528→facade + 6・完全分解）、`uniprop.rs`（1187→facade + 4・完全分解）
+
+**indivisible giant の扱い**: 単一の巨大 `match`/dispatch メソッド（`exec_one`・`call_method_with_values`・`materialize_exception_message_in_result`・`register_class_decl`・`native_method_1arg`・`compile_stmt` 等）は関数境界で分割できないため、各自を単独ファイルに隔離（500 行超を許容・コミットメッセージに明記）。これがパーサ/dispatch の本質。
+
+**成果**: `1000 行超` ファイルが **82→~40 件台** へ激減（最大ファイル `vm_var_assign_ops.rs` 7267 や `runtime/mod.rs`・`methods_object.rs`・`io.rs`・`methods.rs` 等の超巨大ファイルがすべて分割）。`500 行超` の総数は giant dispatch メソッドが residual 単独ファイルとして残るため微減に留まるが、**最悪オフェンダーの解消と凝集性向上**が主眼。`ast.rs`・`registration_sub.rs` 等の残りは後続。
+
+### ★ registry-Arc キャンペーン完了 — registry クローンで `FunctionDef` body が deep-clone されない（slice 1-8）
+
+`my sub` を宣言するルーチンへ入るたび `snapshot_routine_registry` が `functions.clone()` で**プログラム中の全ルーチン body を deep-clone** していた（lexical scope 巻き戻し用）。registry の全 `FunctionDef` 直保持マップを `Arc<FunctionDef>` 化することで、snapshot を O(n) refcount-bump にした：
+
+- **slice 1（冪等化）**: `RegisterSub` の再実行（hot routine 内 `my sub`）を、コンパイル時 fingerprint（`CompiledCode.sub_fingerprints`）で `SubRegisterOutcome::{Installed, Unchanged}` 判定し、識別不変な再登録を `FunctionDef` 再導出なしに O(1) 検出。
+- **slice 2（`functions` Arc 化）**: registry が `HashMap<Symbol, Arc<FunctionDef>>` を保持（200-sub マイクロベンチで ~28% 改善）。in-place 変異サイトは皆無＝`make_mut` 不要。
+- **slice 3（dispatch resolution への Arc 貫通）**: ホットな単一結果リゾルバの戻り値を `Option<Arc<FunctionDef>>` 化。呼び出し毎の resolution body deep-clone を Arc bump に。
+- **slice 4（derive-once キャッシュ）**: `my sub` の再 install で AST→`FunctionDef` を毎回再導出していたのを `(fingerprint, package)` キーの `prepared_fn_defs` でキャッシュ。
+- **slice 5（`MultiDispatchEntry` Arc 化）**: redispatch スタック候補列を `Vec<Arc<FunctionDef>>` 化。`nextsame`/`callsame`/`callwith` の per-step 候補 clone が refcount-bump に。
+- **slice 6/7/8**: 残る `proto_functions`（6）・grammar `token_defs`（7）・`our_scoped_functions`（8）を Arc 化。`snapshot_routine_registry` / `clone_for_thread` / EVAL コピー / block-scope restore のいずれの registry クローンでも `FunctionDef` body が deep-clone されなくなった。
+
+残る §1.1 課題はメソッド dispatch の resolution caching のみ（multi は #3684 で着手済み）。
+
 ### ★ §D(b) / §B 完了 — ユーザメソッド body の tree-walk 削除（`run_instance_method_resolved` 非-delegation arm 撤去・#3664〜#3680）
 
 6月末、**唯一の真のユーザーコード tree-walk だった `run_instance_method_resolved` の非-delegation arm（`run_block(method_def.body)`・~470行）を削除**し、


### PR DESCRIPTION
ANALYSIS.md is an architecture/health review of *remaining* debt, not a changelog. This slims it and records the completed work in news.

## news/2026-06.md (new entries)
- **§7-8 giant-file-split sweep**: the 500-line-rule cleanup. impl-block files → flat sibling files; free-function files → facade + subdir. Pure relocation (fn multiset byte-identical, no behavior change). `1000`-line-over files **82 → ~40s**; `vm.rs` module root **4872 → 286**; the very largest files (`vm_var_assign_ops.rs` 7267, `runtime/mod.rs`, `methods_object.rs`, `io.rs`, `methods.rs`, `regex_parse.rs`, …) all split. Indivisible giant `match`/dispatch methods isolated into their own files (accepted >500 exception).
- **registry-Arc campaign complete** (slices 1-8): registry maps → `Arc<FunctionDef>`, fingerprint-based idempotent re-registration, derive-once cache. No registry clone deep-clones `FunctionDef` bodies anymore.

## ANALYSIS.md (slimmed)
- §1.1: 8-slice registry-Arc detail → 1-bullet summary + news pointer (keep remaining method-dispatch resolution-caching item).
- §6 / §7 (row 8): replace stale 500-line-violation stats (cited now-split files) with the post-sweep state + news pointer.
- Header: rev7.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)