### PR TITLE
fix(array): embed autoviv-hole tracking in ArrayData; user Str in eq/is (HTTP::Status)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -207,8 +207,12 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     「Unhandled exception in code scheduled on thread」（空メッセージ）でプロセス終了（bin/非 bin 共通・`.tap` 回避なら OK）。
     real-TCP Supply の tap コールバックが worker thread 上で走り react の control-flow フレームから切れているため。
     HTTP::Server::Tiny のリクエストループが `done` を使うなら要修正。
-  - **HTTP::Status v0.0.5**: user `method sink` がシンクコンテキストで呼ばれず status table が空。
-    ⚠️ 注意: 過去に sink 修正は sink.t を回帰させた（メモリ `sink-context-blocked-container-identity` 参照）。
+  - **✅ HTTP::Status v0.0.5 全テスト PASS（68 subtests・#3832）**: 当初診断「`method sink` が呼ばれず空」は誤り。
+    実際の 2 ブロッカーは①配列ホール追跡がスコープを越えなかった（autoviv ギャップの `Package("Any")` を実 `Any` と
+    区別する `__mutsu_initialized_index::name` env side table がフレーム scope で、外側配列をメソッド/クロージャから
+    埋めると喪失→`:exists`/`:k`/`:p`/`.keys` がギャップを存在扱い）。`ArrayData::initialized` 埋め込みセット化で値と共に
+    COW 伝播（`default`/`shape` と同パターン）。②`eq`/`is` がユーザ `Str` メソッドを使わず `.gist` 文字列化していた→
+    infix `~` と同じ user-stringifier coercion を流用。`:exists` がホール追跡を一切参照しなかった既存バグも併せて修正。
 - [ ] **NativeCall（C FFI）— MVP landed、DBDish への正攻法。**
   - **✅ MVP（#TBD）**: `is native(...)` の sub を `dlopen`+`libffi` で実 C 呼び出し。スカラ整数/浮動小数・
     `Str`→`char*`・`Pointer`・戻り値 `char*`→`Str`・`is symbol(...)`・非デフォルトライブラリ（`is native('m')`/

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -269,13 +269,11 @@ impl Interpreter {
         let mut rows: Vec<(Value, Value, bool)> = Vec::with_capacity(indices.len());
         match &target {
             Value::Array(items, ..) => {
-                let bound_map = var_name
-                    .as_ref()
-                    .and_then(|name| self.env.get(&format!("__mutsu_initialized_index::{name}")))
-                    .and_then(|v| match v {
-                        Value::Hash(map) => Some(map),
-                        _ => None,
-                    });
+                // The set of explicitly element-assigned indices travels with
+                // the array value (embedded `ArrayData::initialized`), so a slot
+                // holding a `Package("Any")` hole is distinguished from a real
+                // `Any` value even after the array crosses scopes/closures.
+                let bound_map = items.initialized.as_ref();
                 // The missing-element default comes from the array's *element
                 // type*. Read it from the container value itself (embedded
                 // metadata / `is default`) FIRST so it survives rebinding — e.g.
@@ -312,12 +310,9 @@ impl Interpreter {
                         continue;
                     }
                     let ui = i as usize;
-                    let exists = if let Some(map) = bound_map {
-                        if map.contains_key(&i.to_string()) {
-                            true
-                        } else {
-                            !matches!(&items[ui], Value::Package(name) if name == "Any")
-                        }
+                    let exists = if let Some(set) = bound_map {
+                        set.contains(&ui)
+                            || !matches!(&items[ui], Value::Package(name) if name == "Any")
                     } else {
                         true
                     };

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -113,6 +113,25 @@ impl Interpreter {
             Value::LazyIoLines { handle, words, .. } => {
                 Ok(self.force_lazy_io_lines(handle, *words)?.to_string_value())
             }
+            // `is $got, $expected` compares via Raku's `eq` (Str coercion), so an
+            // object whose class defines a user `Stringy`/`Str` must be compared
+            // by that string value rather than its `.gist`.
+            Value::Instance { class_name, .. } | Value::Package(class_name) => {
+                let cn = class_name.resolve().to_string();
+                let method = if self.has_user_method(&cn, "Stringy") {
+                    Some("Stringy")
+                } else if self.has_user_method(&cn, "Str") {
+                    Some("Str")
+                } else {
+                    None
+                };
+                match method {
+                    Some(m) => Ok(self
+                        .call_method_with_values(value.clone(), m, vec![])?
+                        .to_string_value()),
+                    None => Ok(value.to_string_value()),
+                }
+            }
             _ => Ok(value.to_string_value()),
         }
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -876,6 +876,18 @@ pub struct ArrayData {
     /// `Arc::as_ptr`-keyed `ShapedArrayIds` side table) so the shape travels
     /// with the container through copy-on-write.
     pub shape: Option<Vec<usize>>,
+    /// Indices that were explicitly element-assigned (`@a[i] = …`), as opposed
+    /// to autovivification gaps. `None` means the array was bulk/literal-
+    /// constructed, so every in-range index exists (the historical
+    /// "no side table → all exist" fallback). `Some(set)` means element-wise
+    /// assignment has occurred: an in-range slot exists iff it is in the set OR
+    /// its value is not a `Package("Any")` hole. Embedded (not an env-name-keyed
+    /// side table) so it travels with the value across scopes, closures, and
+    /// method calls — the former `__mutsu_initialized_index::name` table was
+    /// scoped to the assigning frame and lost on scope exit, so an outer array
+    /// filled from inside a method/closure (e.g. HTTP::Status's `method sink`
+    /// populating `@codes`) reported every gap as existing.
+    pub initialized: Option<std::collections::HashSet<usize>>,
 }
 
 /// Value stored in an enum variant: an integer, a string, or an arbitrary Value.

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -157,6 +157,7 @@ impl ArrayData {
             declared_type: None,
             default: None,
             shape: None,
+            initialized: None,
         }
     }
 

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -112,6 +112,17 @@ impl Value {
     pub fn real_array(items: Vec<Value>) -> Self {
         Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::Array)
     }
+    /// Create a true Array value with a single explicitly-assigned index
+    /// recorded in the embedded `initialized` set (used when autovivifying a
+    /// missing variable via `@a[i] = …`, so the autovivification gaps below `i`
+    /// are recognized as holes by `:exists`/`:k`/`:p`).
+    pub fn real_array_initialized_at(items: Vec<Value>, idx: usize) -> Self {
+        let mut data = ArrayData::new(items);
+        let mut set = std::collections::HashSet::new();
+        set.insert(idx);
+        data.initialized = Some(set);
+        Value::Array(Arc::new(data), ArrayKind::Array)
+    }
     /// Create a shaped (multidimensional) Array value.
     pub fn shaped_array(items: Vec<Value>) -> Self {
         Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::Shaped)
@@ -131,6 +142,7 @@ impl Value {
             declared_type: like.declared_type.clone(),
             default: like.default.clone(),
             shape: like.shape.clone(),
+            initialized: like.initialized.clone(),
         })
     }
     /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -133,19 +133,21 @@ impl Interpreter {
         // an internal redispatch with no surrounding CallMethod op, so drain any
         // captured-outer writeback into the caller's slot (Slice 1b render pattern).
         let caller_code = self.current_code;
-        let left = self.concat_coerce_operand(left)?;
-        let right = self.concat_coerce_operand(right)?;
+        let left = self.coerce_stringy_operand(left)?;
+        let right = self.coerce_stringy_operand(right)?;
         self.reconcile_caller_after_internal_dispatch(caller_code);
         let result = Self::concat_values(left, right);
         self.stack.push(result);
         Ok(())
     }
 
-    /// Coerce a concat operand whose class defines a user `Stringy`/`Str` to its
-    /// string value (Raku infix `~` uses `.Stringy`, falling back to `.Str`). Plain
-    /// values and instances without a user stringifier pass through unchanged (the
-    /// pure `concat_values` handles those, including built-in `.gist`/`.Str`).
-    fn concat_coerce_operand(&mut self, v: Value) -> Result<Value, RuntimeError> {
+    /// Coerce an operand whose class defines a user `Stringy`/`Str` to its
+    /// string value (Raku infix `~` uses `.Stringy`, falling back to `.Str`;
+    /// the string comparators `eq`/`lt`/… use `.Str`). Plain values and
+    /// instances without a user stringifier pass through unchanged (the pure
+    /// `concat_values` / `to_str_context` handle those, including built-in
+    /// `.gist`/`.Str`). Shared by infix `~` and the string-comparison ops.
+    pub(super) fn coerce_stringy_operand(&mut self, v: Value) -> Result<Value, RuntimeError> {
         let cn = match &v {
             Value::Instance { class_name, .. } => class_name.resolve().to_string(),
             Value::Package(name) => name.resolve().to_string(),

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -6,9 +6,28 @@ use super::vm_comparison_ops::{
 use super::*;
 
 impl Interpreter {
+    /// Coerce both operands of a string comparator (`eq`/`ne`/`lt`/`gt`/`le`/
+    /// `ge`) through a user-defined `Str`/`Stringy` method when present, so an
+    /// instance compares by its string value (Raku's `infix:<eq>` is `.Str`
+    /// coercion). Junctions and plain values pass through unchanged, preserving
+    /// autothreading. This is an internal redispatch with no surrounding
+    /// CallMethod op, so drain any captured-outer writeback into the caller.
+    fn coerce_str_compare_operands(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<(Value, Value), RuntimeError> {
+        let caller_code = self.current_code;
+        let left = self.coerce_stringy_operand(left)?;
+        let right = self.coerce_stringy_operand(right)?;
+        self.reconcile_caller_after_internal_dispatch(caller_code);
+        Ok((left, right))
+    }
+
     pub(super) fn exec_str_eq_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let (left, right) = self.coerce_str_compare_operands(left, right)?;
         let result = self.eval_binary_with_junctions(left, right, |_, l, r| {
             if Self::is_buf_value(&l) && Self::is_buf_value(&r) {
                 Ok(Value::Bool(
@@ -25,6 +44,7 @@ impl Interpreter {
     pub(super) fn exec_str_ne_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let (left, right) = self.coerce_str_compare_operands(left, right)?;
         // ne is a negation meta-operator shortcut for !eq.
         // It first evaluates eq (which autothreads through junctions),
         // then negates the boolean-collapsed result, always returning Bool.
@@ -50,6 +70,7 @@ impl Interpreter {
     pub(super) fn exec_str_lt_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let (left, right) = self.coerce_str_compare_operands(left, right)?;
         let result = self.eval_binary_with_junctions(left, right, |_, l, r| {
             if Self::is_buf_value(&l) && Self::is_buf_value(&r) {
                 Ok(Value::Bool(
@@ -66,6 +87,7 @@ impl Interpreter {
     pub(super) fn exec_str_gt_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let (left, right) = self.coerce_str_compare_operands(left, right)?;
         let result = self.eval_binary_with_junctions(left, right, |_, l, r| {
             if Self::is_buf_value(&l) && Self::is_buf_value(&r) {
                 Ok(Value::Bool(
@@ -82,6 +104,7 @@ impl Interpreter {
     pub(super) fn exec_str_le_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let (left, right) = self.coerce_str_compare_operands(left, right)?;
         let result = self.eval_binary_with_junctions(left, right, |_, l, r| {
             if Self::is_buf_value(&l) && Self::is_buf_value(&r) {
                 Ok(Value::Bool(
@@ -98,6 +121,7 @@ impl Interpreter {
     pub(super) fn exec_str_ge_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let (left, right) = self.coerce_str_compare_operands(left, right)?;
         let result = self.eval_binary_with_junctions(left, right, |_, l, r| {
             if Self::is_buf_value(&l) && Self::is_buf_value(&r) {
                 Ok(Value::Bool(

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1223,7 +1223,7 @@ impl Interpreter {
                             {
                                 let mut arr = vec![Value::Package(Symbol::intern("Any")); i + 1];
                                 arr[i] = val.clone();
-                                *container = Value::real_array(arr);
+                                *container = Value::real_array_initialized_at(arr, i);
                             } else {
                                 let mut hash = std::collections::HashMap::new();
                                 hash.insert(key.clone(), val.clone());
@@ -1246,7 +1246,7 @@ impl Interpreter {
                         let mut arr = vec![Value::Package(Symbol::intern("Any")); i + 1];
                         arr[i] = val.clone();
                         self.env_mut()
-                            .insert(var_name.clone(), Value::real_array(arr));
+                            .insert(var_name.clone(), Value::real_array_initialized_at(arr, i));
                     } else {
                         let mut hash = std::collections::HashMap::new();
                         hash.insert(key.clone(), val.clone());

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -40,19 +40,6 @@ impl Interpreter {
     /// assigned slots are tracked via `__mutsu_initialized_index::` metadata
     /// and are NOT trimmed.
     fn trim_trailing_array_holes(&mut self, var_name: &str) {
-        let init_key = format!("__mutsu_initialized_index::{}", var_name);
-        // Clone the initialized set to avoid borrow conflicts
-        let initialized: std::collections::HashSet<String> = self
-            .env()
-            .get(&init_key)
-            .and_then(|v| {
-                if let Value::Hash(map) = v {
-                    Some(map.keys().cloned().collect())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_default();
         // Get the type constraint for typed arrays (e.g. "Int" for `my Int @a`)
         let type_constraint = loan_env!(self, var_type_constraint(var_name)).unwrap_or_default();
         let env = self.env_mut();
@@ -63,21 +50,26 @@ impl Interpreter {
             return;
         };
         let arr = Arc::make_mut(items);
+        // The explicitly-assigned indices travel with the array (embedded set).
+        let initialized = arr.initialized.clone().unwrap_or_default();
         while let Some(last) = arr.last() {
-            let idx_str = (arr.len() - 1).to_string();
+            let idx = arr.len() - 1;
             let is_hole = match last {
                 Value::Nil => true,
-                Value::Package(name) if name == "Any" => !initialized.contains(&idx_str),
+                Value::Package(name) if name == "Any" => !initialized.contains(&idx),
                 // For typed arrays (e.g. `my Int @a`), the type object is also a hole
                 Value::Package(name)
                     if !type_constraint.is_empty() && name == type_constraint.as_str() =>
                 {
-                    !initialized.contains(&idx_str)
+                    !initialized.contains(&idx)
                 }
                 _ => false,
             };
             if is_hole {
                 arr.pop();
+                if let Some(s) = arr.initialized.as_mut() {
+                    s.remove(&idx);
+                }
             } else {
                 break;
             }

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -562,11 +562,36 @@ impl Interpreter {
             return Ok(());
         }
 
-        let (items, is_shaped): (&[Value], bool) = match &target {
-            Value::Array(items, kind) => {
-                (items.as_slice(), *kind == crate::value::ArrayKind::Shaped)
+        let (items, is_shaped, arr_initialized): (
+            &[Value],
+            bool,
+            Option<&std::collections::HashSet<usize>>,
+        ) = match &target {
+            Value::Array(items, kind) => (
+                items.as_slice(),
+                *kind == crate::value::ArrayKind::Shaped,
+                items.initialized.as_ref(),
+            ),
+            _ => (&[] as &[Value], false, None),
+        };
+        // An in-range slot exists unless it is a `Value::Nil` (deleted) or an
+        // autovivification gap (`Package("Any")` not in the embedded
+        // `initialized` set). Mirrors the `:k`/`:p` predicate in
+        // builtins_multidim_subscript so `:exists` agrees with them.
+        let slot_present_at = |i: i64| -> bool {
+            if is_shaped {
+                return i >= 0 && (i as usize) < items.len();
             }
-            _ => (&[] as &[Value], false),
+            if i < 0 {
+                return false;
+            }
+            match items.get(i as usize) {
+                None | Some(Value::Nil) => false,
+                Some(Value::Package(name)) if name == "Any" => {
+                    arr_initialized.is_none_or(|s| s.contains(&(i as usize)))
+                }
+                Some(_) => true,
+            }
         };
 
         let is_multi = indices.len() != 1 || is_zen;
@@ -576,14 +601,7 @@ impl Interpreter {
             let i = indices[0];
             // Shaped arrays are fixed-size: any in-range index exists,
             // regardless of whether the slot holds the (default) Nil value.
-            let slot_present = if is_shaped {
-                i >= 0 && (i as usize) < items.len()
-            } else {
-                i >= 0
-                    && items
-                        .get(i as usize)
-                        .is_some_and(|v| !matches!(v, Value::Nil))
-            };
+            let slot_present = slot_present_at(i);
             let is_deleted = array_var_name
                 .as_deref()
                 .is_some_and(|n| self.is_deleted_index(n, i));
@@ -622,14 +640,7 @@ impl Interpreter {
         let pairs: Vec<(i64, bool)> = indices
             .iter()
             .map(|&i| {
-                let slot_present = if is_shaped {
-                    i >= 0 && (i as usize) < items.len()
-                } else {
-                    i >= 0
-                        && items
-                            .get(i as usize)
-                            .is_some_and(|v| !matches!(v, Value::Nil))
-                };
+                let slot_present = slot_present_at(i);
                 let is_deleted = array_var_name
                     .as_deref()
                     .is_some_and(|n| self.is_deleted_index(n, i));

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -670,14 +670,32 @@ impl Interpreter {
                 Arc::make_mut(map).remove(&encoded);
             }
         }
-        let key = format!("__mutsu_initialized_index::{}", var_name);
-        if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
-            Arc::make_mut(map).insert(encoded, Value::Bool(true));
+        // Record the assigned index in the array's *embedded* `initialized`
+        // set so it travels with the value across scopes/closures/method calls
+        // (the former env-name-keyed side table was scoped to the assigning
+        // frame and lost on scope exit). Only array indices (plain integers)
+        // are tracked — hash existence is determined by key presence.
+        let Ok(idx) = encoded.parse::<usize>() else {
             return;
+        };
+        // Mutate the array in place when it is shared by-ref through a scalar
+        // ($) container, mirroring the assignment path's `use_inplace` choice
+        // (vm_var_assign_index_named). Using `Arc::make_mut` here would clone a
+        // shared array and sever the by-ref alias, so a subsequent `.push` on
+        // the original would be lost (t/array-push-byref-coherence).
+        let use_inplace = !var_name.starts_with('@');
+        if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name) {
+            let data: &mut crate::value::ArrayData = if use_inplace && Arc::strong_count(items) > 1 {
+                // SAFETY: aliased in-place mutation of a shared array; same
+                // contract as the assignment site's `arc_contents_mut` use.
+                unsafe { crate::value::arc_contents_mut(items) }
+            } else {
+                Arc::make_mut(items)
+            };
+            data.initialized
+                .get_or_insert_with(std::collections::HashSet::new)
+                .insert(idx);
         }
-        let mut map = std::collections::HashMap::new();
-        map.insert(encoded, Value::Bool(true));
-        self.env_mut().insert(key, Value::hash(map));
     }
 
     /// Mark the given indices as deleted. `:exists` on an array consults
@@ -761,12 +779,49 @@ impl Interpreter {
     /// `trim_trailing_array_holes` so that deleted slots are recognized
     /// as holes and can be trimmed.
     pub(super) fn unmark_initialized_indices(&mut self, var_name: &str, idx: &Value) {
-        let key = format!("__mutsu_initialized_index::{}", var_name);
-        let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) else {
+        // Collect the integer indices addressed by `idx` (scalar, slice, or
+        // range) and drop them from the array's embedded `initialized` set so
+        // the deleted slots are recognized as holes and can be trimmed.
+        let mut to_remove: Vec<usize> = Vec::new();
+        Self::collect_usize_indices(idx, &mut to_remove);
+        if to_remove.is_empty() {
             return;
-        };
-        let m = Arc::make_mut(map);
-        Self::unmark_index_entries(m, idx);
+        }
+        if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name)
+            && let Some(set) = Arc::make_mut(items).initialized.as_mut()
+        {
+            for i in to_remove {
+                set.remove(&i);
+            }
+        }
+    }
+
+    /// Flatten a subscript index `Value` (scalar / array slice / range) into the
+    /// list of non-negative integer array indices it addresses.
+    fn collect_usize_indices(idx: &Value, out: &mut Vec<usize>) {
+        match idx {
+            Value::Array(items, ..) => {
+                for item in items.iter() {
+                    Self::collect_usize_indices(item, out);
+                }
+            }
+            Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => {
+                for item in &crate::runtime::utils::value_to_list(idx) {
+                    Self::collect_usize_indices(item, out);
+                }
+            }
+            Value::Int(i) if *i >= 0 => out.push(*i as usize),
+            Value::Num(f) if *f >= 0.0 => out.push(*f as usize),
+            _ => {
+                if let Ok(i) = idx.to_string_value().parse::<usize>() {
+                    out.push(i);
+                }
+            }
+        }
     }
 
     fn unmark_index_entries(map: &mut std::collections::HashMap<String, Value>, idx: &Value) {

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -685,7 +685,8 @@ impl Interpreter {
         // the original would be lost (t/array-push-byref-coherence).
         let use_inplace = !var_name.starts_with('@');
         if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name) {
-            let data: &mut crate::value::ArrayData = if use_inplace && Arc::strong_count(items) > 1 {
+            let data: &mut crate::value::ArrayData = if use_inplace && Arc::strong_count(items) > 1
+            {
                 // SAFETY: aliased in-place mutation of a shared array; same
                 // contract as the assignment site's `arc_contents_mut` use.
                 unsafe { crate::value::arc_contents_mut(items) }

--- a/t/array-hole-tracking-cross-scope.t
+++ b/t/array-hole-tracking-cross-scope.t
@@ -1,0 +1,80 @@
+use Test;
+
+# Autovivification gaps (holes) must be distinguished from existing elements by
+# :exists / :k / :p / .keys, and this hole-tracking must travel with the array
+# value across scope boundaries (closures, subs, methods). Previously the
+# tracking lived in an env-name-keyed side table that was scoped to the
+# assigning frame and lost on scope exit, so an outer array filled from inside a
+# method/closure reported every gap as existing (HTTP::Status `method sink`).
+
+plan 15;
+
+# --- baseline: top-level sparse fill ---
+{
+    my @a;
+    @a[100] = 'x';
+    @a[200] = 'y';
+    is-deeply @a[]:k, (100, 200), 'top-level sparse :k skips holes';
+    is @a[50]:exists, False, 'top-level hole :exists is False';
+    is @a[100]:exists, True, 'top-level filled :exists is True';
+}
+
+# --- fill inside a sub, read at top scope ---
+{
+    my @a;
+    sub fill() { @a[100] = 'x'; @a[200] = 'y' }
+    fill();
+    is-deeply @a[]:k, (100, 200), 'sub-filled array :k skips holes (cross-scope)';
+    is @a.elems, 201, 'sub-filled array elems counts up to last index';
+}
+
+# --- fill inside a method, read at top scope ---
+{
+    my @codes;
+    class Filler {
+        has $.code;
+        method sink() { @codes[$!code] = self }
+    }
+    Filler.new(code => 10);
+    Filler.new(code => 20);
+    Filler.new(code => 30);
+    42;  # sink the previous statements
+    is-deeply @codes[]:k, (10, 20, 30), 'method-sink-filled array :k skips holes';
+    is @codes[15]:exists, False, 'method-filled hole :exists is False';
+    is-deeply (@codes[]:p).head, (10 => @codes[10]), 'method-filled :p head is first real pair';
+}
+
+# --- explicit Any assignment counts as existing ---
+{
+    my @a;
+    @a[3] = Any;
+    is @a[3]:exists, True, 'explicitly-assigned Any :exists is True';
+    is-deeply @a[]:k, (3,), 'explicitly-assigned Any appears in :k';
+}
+
+# --- literal-constructed array with an Any element: all exist ---
+{
+    my @a = (1, Any, 3);
+    is-deeply @a[]:k, (0, 1, 2), 'literal Any element still exists';
+    is @a.elems, 3, 'literal array elems';
+}
+
+# --- delete creates a hole that :k skips ---
+{
+    my @a;
+    @a[5] = 10;
+    @a[2] = 20;
+    @a[2]:delete;
+    is-deeply @a[]:k, (5,), 'deleted index removed from :k';
+}
+
+# --- user .Str method drives eq / is comparison ---
+{
+    class Titled {
+        has $.title;
+        method Str() { $!title }
+    }
+    my $t = Titled.new(title => 'OK');
+    ok $t eq 'OK', 'eq uses user Str method';
+    is $t, 'OK', 'is() compares via user Str method';
+}


### PR DESCRIPTION
## Summary

Makes the **HTTP::Status v0.0.5** test suite pass (68 subtests across `t/01-basic`, `t/02-is-tests`, `t/03-associative`). HTTP::Status builds its status table by *sinking* bare `HTTP::Status.new` statements — a user `method sink` runs `@codes[$!code] = self` on a file-scoped `@codes`. Two independent bugs blocked it (see PLAN.md §H "HTTP::Status v0.0.5").

## Bug 1 — array hole tracking lost across scopes

Autovivification gaps are stored as `Package("Any")` slots, distinguished from a *real* `Any` value by the `__mutsu_initialized_index::name` **env side table**. That table was keyed by variable name and scoped to the assigning frame, so an outer array filled from inside a sub/method/closure lost it on return — `:exists`/`:k`/`:p`/`.keys` then reported every gap as existing (keys count 600 vs raku's 93).

**Fix:** move the tracking into an embedded `ArrayData::initialized` set — the same migration already done for `default`/`shape`/`value_type` (the doc-comment on those fields explicitly notes the pointer-keyed side table broke on Arc rebuild). It now travels with the value through copy-on-write across scopes/closures/methods. `mark_initialized_index` mutates the array in place when it is shared by-ref through a `$` container (mirroring the assignment path's `use_inplace` choice) so it never clones-and-severs a shared alias. This also fixes `:exists` on autoviv holes, which never consulted the tracking set at all (pre-existing bug, now consistent with `:k`/`:p`).

## Bug 2 — `eq`/`is` ignored user `Str` method

The string comparators (`eq`/`ne`/`lt`/`gt`/`le`/`ge`) and Test's `is` stringified instances via `.gist`/`to_str_context` instead of a user-defined `Str`/`Stringy` method, so `is HTTP::Status(100), 'Continue'` failed. They now reuse the same user-stringifier coercion as infix `~`.

## Testing

- All 68 HTTP::Status subtests pass.
- New regression test `t/array-hole-tracking-cross-scope.t` (15 subtests) covering sub/method/closure fills, explicit-`Any` assignment, literal-`Any` elements, delete-holes, and `eq`/`is` user-Str.
- `make test`: **Result: PASS** (1281 files, 12718 tests), no regressions. Verified the by-ref coherence case (`t/array-push-byref-coherence.t`) and whitelisted `S32-array/exists-adverb.t` / `delete-adverb.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)