### PR TITLE
fix(arrays): preserve element-type & shape of shaped arrays through mutation

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2489,19 +2489,55 @@ impl Interpreter {
             && info.value_type != "Any"
             && info.value_type != "Mu"
         {
-            let raku_str = crate::builtins::methods_0arg::raku_repr::raku_value(&target);
             let type_prefix = if let Some(ref dt) = info.declared_type {
                 dt.clone()
             } else {
                 format!("array[{}]", info.value_type)
             };
-            // Replace the "Array.new(" prefix with the typed prefix
-            let result = if let Some(rest) = raku_str.strip_prefix("Array.new(") {
-                format!("{}.new({}", type_prefix, rest)
+            // Rakudo renders a shaped array as
+            //   array[int].new(:shape(4,), [1, 2, 3, 4])           # 1-D
+            //   array[int].new(:shape(2, 2), [1, 2], [3, 4])       # 2-D
+            // i.e. `:shape(<dims>)` (a single dim gets a trailing comma, being a
+            // 1-element list), then the data: the whole bracket for 1-D, or each
+            // first-dimension slice as a separate positional arg for N-D.
+            fn render_data(v: &Value) -> String {
+                if let Value::Array(items, _) = v {
+                    let inner = items
+                        .iter()
+                        .map(render_data)
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("[{}]", inner)
+                } else {
+                    crate::builtins::methods_0arg::raku_repr::raku_value(v)
+                }
+            }
+            let shape = Self::infer_array_shape(&target).unwrap_or_default();
+            let shape_str = if shape.len() == 1 {
+                format!("{},", shape[0])
             } else {
-                raku_str
+                shape
+                    .iter()
+                    .map(|d| d.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             };
-            return Ok(Value::str(result));
+            let Value::Array(items, _) = &target else {
+                unreachable!()
+            };
+            let data = if shape.len() <= 1 {
+                render_data(&target)
+            } else {
+                items
+                    .iter()
+                    .map(render_data)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            return Ok(Value::str(format!(
+                "{}.new(:shape({}), {})",
+                type_prefix, shape_str, data
+            )));
         }
         // .raku/.perl on constrained regular Array (e.g. Array[Int])
         if matches!(method, "raku" | "perl")

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2502,11 +2502,7 @@ impl Interpreter {
             // first-dimension slice as a separate positional arg for N-D.
             fn render_data(v: &Value) -> String {
                 if let Value::Array(items, _) = v {
-                    let inner = items
-                        .iter()
-                        .map(render_data)
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                    let inner = items.iter().map(render_data).collect::<Vec<_>>().join(", ");
                     format!("[{}]", inner)
                 } else {
                     crate::builtins::methods_0arg::raku_repr::raku_value(v)
@@ -2528,11 +2524,7 @@ impl Interpreter {
             let data = if shape.len() <= 1 {
                 render_data(&target)
             } else {
-                items
-                    .iter()
-                    .map(render_data)
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                items.iter().map(render_data).collect::<Vec<_>>().join(", ")
             };
             return Ok(Value::str(format!(
                 "{}.new(:shape({}), {})",

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -214,12 +214,15 @@ impl Interpreter {
         if Self::loop_var_unchanged(&current_topic, &items[actual_idx]) {
             return;
         }
-        let mut updated = items.to_vec();
-        updated[actual_idx] = current_topic;
-        let updated_value = Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(updated)),
-            kind,
-        );
+        // Clone the original ArrayData (carrying its element-type / declared-type
+        // / shape / default metadata) and replace only the mutated element, so a
+        // mutating `for @a { $_++ }` over a native or shaped array preserves
+        // `array[int]` typing and the shape (`ArrayData::new` would drop them,
+        // turning `array[int]` into a bare `Array` and breaking later `.WHAT`,
+        // `.raku`, and shaped `:delete`-dies behaviour).
+        let mut new_data = (*items).clone();
+        new_data.items[actual_idx] = current_topic;
+        let updated_value = Value::Array(std::sync::Arc::new(new_data), kind);
         self.write_back_container_source(code, source, &raw_source, updated_value);
     }
 }

--- a/t/shaped-array-type-preservation.t
+++ b/t/shaped-array-type-preservation.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Shaped native arrays must keep their element-type (`array[int]`) and shape
+# metadata through mutating operations, and render `.raku` in Rakudo's
+# `array[T].new(:shape(...), ...)` form. Element-type metadata is embedded in
+# ArrayData; the for-loop / map writebacks used to rebuild the array with a
+# fresh ArrayData (dropping the metadata), turning `array[int]` into a bare
+# `Array` and breaking `.WHAT` / `.raku` / shaped `:delete`-dies behaviour.
+
+plan 9;
+
+# --- .raku format ---------------------------------------------------------
+my int @r1[4] = 1, 2, 3, 4;
+is @r1.raku, 'array[int].new(:shape(4,), [1, 2, 3, 4])', '1-D int .raku';
+
+my str @rs[2] = "x", "y";
+is @rs.raku, 'array[str].new(:shape(2,), ["x", "y"])', '1-D str .raku';
+
+my int @r2[2;2] = (1, 2), (3, 4);
+is @r2.raku, 'array[int].new(:shape(2, 2), [1, 2], [3, 4])', '2-D int .raku';
+
+# --- type/shape preserved through a mutating for loop ---------------------
+my int @f[4] = 10, 15, 12, 16;
+$_++ for @f;
+ok @f ~~ Array, 'for-loop: still an array';
+is @f.WHAT.^name, 'array[int]', 'for-loop preserves array[int] type';
+is @f.raku, 'array[int].new(:shape(4,), [11, 16, 13, 17])', 'for-loop preserves .raku form';
+# a shaped array still rejects :delete after a mutating for loop
+dies-ok { @f[0]:delete }, 'shaped array still dies on :delete after for-loop mutation';
+
+# --- type preserved through a mutating map --------------------------------
+my int @m[3] = 1, 2, 3;
+@m.map(* *= 2);
+is @m.WHAT.^name, 'array[int]', 'map preserves array[int] type';
+is @m.raku, 'array[int].new(:shape(3,), [2, 4, 6])', 'map preserves .raku form';


### PR DESCRIPTION
Follow-up to #3828. Native/shaped array element-type metadata (`array[int]`) and shape are embedded in `ArrayData`, but rebuild sites dropped them.

## Fixes
- **Mutating for-loop writeback** (`$_++ for @a`): rebuilt the source with a fresh `ArrayData::new`, turning `array[int]` into a bare `Array` and losing the shape. Now clones the original `ArrayData` (carrying type/shape/default metadata) and replaces only the mutated element. This cascaded: a no-longer-native array stopped dying on `:delete`, so this also restores shaped `:delete`-dies behaviour after a mutating loop.
- **`.raku` on shaped native arrays**: now renders Rakudo's form
  - `array[int].new(:shape(4,), [1, 2, 3, 4])` (1-D, trailing-comma shape)
  - `array[int].new(:shape(2, 2), [1, 2], [3, 4])` (N-D)

  Previously it omitted `:shape(...)` and emitted bare brackets for 1-D.

## Impact
- `S09-typed-arrays/native-shape1-{int,num,str}.t`: **7 → 6** failing subtests each (the for-loop type loss had cascaded into the `:delete` subtest).
- Remaining failures (slice `@arr[*-1,*-2]` WhateverStar; shaped clear/reinit through the `:=`-bound / expression-context assign paths; `flat`) are separate features.
- Test: `t/shaped-array-type-preservation.t`; `make test` green; array-heavy whitelisted roast regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)