### PR TITLE
fix(thread): large user-code stack for Thread.start / scheduler / hyper-race workers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -200,13 +200,16 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
 すべて NativeCall 非依存**（pure Raku）で、原理的に動作可能。各ブロッカーは独立した一般機能の欠落。
 ハーネス＝`tmp/webstack/`（gitignored）。
 
-- [ ] **HTTP::Server::Tiny スタック（全て pure Raku, NativeCall なし）— 想像以上に近い。**
-      本体は `use`＋`.new`＋非同期サーバが TCP listen/accept まで実際に動く。`:bin` Supply→`Buf[uint8]`（#TBD）と
-      HTTP::Parser 14/14（#3420/#3422/#3423）は landed（news 参照）。リクエスト/レスポンス往復を阻む**残ブロッカー**:
-  - **`whenever $conn.Supply(...)` の内側で `done`/`last`** を呼ぶと制御シグナルが react ハンドラに捕捉されず
-    「Unhandled exception in code scheduled on thread」（空メッセージ）でプロセス終了（bin/非 bin 共通・`.tap` 回避なら OK）。
-    real-TCP Supply の tap コールバックが worker thread 上で走り react の control-flow フレームから切れているため。
-    HTTP::Server::Tiny のリクエストループが `done` を使うなら要修正。
+- **✅ HTTP::Server::Tiny が end-to-end で動作（2026-06-28・全て pure Raku, NativeCall なし）**:
+      **未改変の upstream モジュールが mutsu で `use`＋`.new`＋`.run` し、実 TCP で HTTP 応答を配信**（GET=`hello`、
+      POST+body+`start{}` Promise 返却アプリ=content-length パス／TempFile・IO::Blob 経由で正しく往復）。
+      真因＝`Thread.start`（`socket_thread.rs`）だけが素の `std::thread::spawn`（OS デフォルト ~2-8 MiB スタック）を使い、
+      `start{}`/Promise/Supply worker が使う 256 MiB の `spawn_user_thread` から漏れていた。非同期サーバの react ループが
+      BUILD で VM を再入する深いネストで 8 MiB を超過しオーバーフロー（gdb で 83 フレーム＝小スタックと確定）。修正で
+      `Thread.start`／`$*SCHEDULER.cue`／hyper-race の全 user-code spawn を `spawn_user_thread` に統一。担保＝`t/thread-deep-stack.t`。
+  - **残（深掘り時）**: keep-alive 連続リクエスト・chunked request body・`whenever $conn.Supply(...)` 内の `done`/`last`
+    制御シグナル（real-TCP Supply の tap コールバックが worker thread 上で走り react の control-flow フレームから切れる）。
+    upstream のデフォルト構成（max-keepalive-reqs=1・HTTP/1.0）では発火しないため、基本配信はブロックされない。
   - **✅ HTTP::Status v0.0.5 全テスト PASS（68 subtests・#3832）**: 当初診断「`method sink` が呼ばれず空」は誤り。
     実際の 2 ブロッカーは①配列ホール追跡がスコープを越えなかった（autoviv ギャップの `Package("Any")` を実 `Any` と
     区別する `__mutsu_initialized_index::name` env side table がフレーム scope で、外側配列をメソッド/クロージャから
@@ -279,7 +282,7 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
 | 起動時間 vs raku | **0.04x** | 0.04x |
 | tree-walk フォールバック（メソッド/関数） | **~1% / ~18.6%（大半 carrier）** | 0%（carrier 除く） |
 | 動作モジュール数 | **5（Mustache, File::Temp, File::Directory::Tree, HTTP::Parser, MIME::Base64〔own test PASS〕）** | 5+（ウェブブログスタック） |
-| Template::Mustache / HTTP::Server::Tiny | **Mustache ✅** / Tiny ❌ | ✅ |
+| Template::Mustache / HTTP::Server::Tiny | **Mustache ✅** / **Tiny ✅（end-to-end 配信・2026-06-28）** | ✅ |
 
 ---
 

--- a/news/2026-06.md
+++ b/news/2026-06.md
@@ -12,6 +12,22 @@ CI（`make test` + 包括的 `make roast`）が全マージをゲートするの
 
 ## ハイライト
 
+### ★ HTTP::Server::Tiny が end-to-end で動作 — `Thread.start` worker のスタックサイズ修正（2026-06-28）
+
+PLAN.md §H の HTTP::Server::Tiny（pure Raku 非同期 HTTP サーバ）を mutsu でロード＋実 TCP で実行調査したところ、
+リクエスト処理中に worker thread が **スタックオーバーフロー**（"has overflowed its stack" でプロセス abort）。
+gdb backtrace で原因を特定：オーバーフロー時のスタックは**わずか 83 フレーム**＝無限再帰ではなく、worker thread の
+**スタックが小さすぎた**。`Thread.start`（`socket_thread.rs`）だけが素の `std::thread::spawn`（OS デフォルト ~2-8 MiB）を
+使っており、`start {}` / Promise / Supply worker が使う 256 MiB の `spawn_user_thread`（`USER_THREAD_STACK_SIZE`）から
+漏れていた。非同期サーバの react ループがオブジェクトを構築し、その BUILD が VM を再入する深いネストで 8 MiB を超過していた。
+
+修正：ユーザコードを実行する全 worker spawn を `spawn_user_thread` に統一。① `Thread.start`（直接の原因）
+② `$*SCHEDULER.cue` の scheduled callback（`scheduler.rs`）③ hyper/race の batch thread（`vm_hyper_race_parallel.rs`・
+戻り値を持つため `spawn_user_thread` を `JoinHandle<T>` ジェネリックに一般化）。結果、**未改変の upstream
+HTTP::Server::Tiny が mutsu の `IO::Socket::INET` クライアントに実 HTTP 応答を配信**（GET = `hello`、POST + body +
+`start{}` Promise 返却アプリ = `method=POST len=8` を content-length パス／TempFile・IO::Blob 経由で正しく往復）。
+リグレッション＝`t/thread-deep-stack.t`（`Thread.start` worker 上の深い再帰）。
+
 ### ★ §7-8 巨大ファイル分割 sweep — 500 行規約違反の最悪オフェンダーを一掃（2026-06-28）
 
 ANALYSIS §6/§8 の「500 行規約の大幅違反」に対し、500 行超のファイルを **cohesive サブモジュールへ純粋移設** で分割するキャンペーンを実施。確立した 2 つの流儀に従う：

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -10,9 +10,10 @@ pub(crate) const USER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
 
 /// Spawn a worker thread with a large stack for running user code, so deep VM
 /// recursion does not overflow the default thread stack.
-pub(crate) fn spawn_user_thread<F>(f: F) -> std::thread::JoinHandle<()>
+pub(crate) fn spawn_user_thread<F, T>(f: F) -> std::thread::JoinHandle<T>
 where
-    F: FnOnce() + Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
 {
     std::thread::Builder::new()
         .stack_size(USER_THREAD_STACK_SIZE)

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -385,7 +385,12 @@ impl Interpreter {
         // Enable immediate stdout so thread output goes directly to stdout
         thread_interp.set_immediate_stdout(true);
         let mutsu_tid = thread_id as i64;
-        let handle = std::thread::spawn(move || {
+        // Use the large user-code stack (matches `start {}` / Promise / Supply
+        // worker threads): `Thread.start` runs arbitrary user code, and the
+        // default ~2-8 MiB thread stack overflows on deep VM nesting (e.g. an
+        // async server whose react loop constructs objects whose BUILD re-enters
+        // the VM -- HTTP::Server::Tiny). See `USER_THREAD_STACK_SIZE`.
+        let handle = crate::runtime::builtins_system::spawn_user_thread(move || {
             // Set the mutsu thread ID for $*THREAD.id consistency
             super::set_current_mutsu_thread_id(mutsu_tid);
             match thread_interp.call_sub_value(block, vec![], false) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -160,7 +160,7 @@ mod builtins_operators_infix;
 mod builtins_operators_repeat;
 pub(crate) mod builtins_reduce;
 mod builtins_string;
-mod builtins_system;
+pub(crate) mod builtins_system;
 mod builtins_system_async;
 mod builtins_system_proc;
 mod builtins_system_require;

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -232,7 +232,10 @@ impl Interpreter {
                     self.scheduler_run_sync(params)?;
                 } else {
                     let mut thread_interp = self.clone_for_thread();
-                    std::thread::spawn(move || {
+                    // Large user-code stack: the scheduled callback runs user VM
+                    // code, which overflows the default thread stack on deep
+                    // nesting. See `USER_THREAD_STACK_SIZE`.
+                    crate::runtime::builtins_system::spawn_user_thread(move || {
                         thread_interp.scheduler_run_async(params);
                     });
                 }

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -46,51 +46,55 @@ impl Interpreter {
             let thread_interp = self.clone_for_thread();
             let block_clone = block.clone();
             let is_map_flag = is_map;
-            handles.push(std::thread::spawn(move || {
-                // CP-3 collapse: the cloned per-thread Interpreter *is* the Interpreter.
-                let mut vm = thread_interp;
-                let mut results = Vec::with_capacity(batch.len());
-                let mut error: Option<RuntimeError> = None;
-                for item in &batch {
-                    if error.is_some() {
-                        break;
-                    }
-                    // Route the per-item user-code call through the same
-                    // panic->X::AdHoc boundary that `start{}`/Promise workers use
-                    // (`guard_worker_panic`). Without it, a Rust panic raised by
-                    // user code in this batch thread only surfaces as a generic
-                    // "Thread panicked in hyper/race" at `join()` and leaks the raw
-                    // Rust panic message to stderr; the guard converts it into a
-                    // catchable X::AdHoc and suppresses the default backtrace dump,
-                    // making worker panic handling uniform across all spawn sites.
-                    let call_result = crate::vm::guard_worker_panic(|| {
-                        vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None)
-                    });
-                    match call_result {
-                        Ok(val) => {
-                            if is_map_flag {
-                                if let Value::Slip(ref s) = val {
-                                    results.extend(s.iter().cloned());
-                                } else {
-                                    results.push(val);
+            // Large user-code stack: hyper/race batch threads run user VM code,
+            // which overflows the default thread stack on deep nesting.
+            handles.push(crate::runtime::builtins_system::spawn_user_thread(
+                move || {
+                    // CP-3 collapse: the cloned per-thread Interpreter *is* the Interpreter.
+                    let mut vm = thread_interp;
+                    let mut results = Vec::with_capacity(batch.len());
+                    let mut error: Option<RuntimeError> = None;
+                    for item in &batch {
+                        if error.is_some() {
+                            break;
+                        }
+                        // Route the per-item user-code call through the same
+                        // panic->X::AdHoc boundary that `start{}`/Promise workers use
+                        // (`guard_worker_panic`). Without it, a Rust panic raised by
+                        // user code in this batch thread only surfaces as a generic
+                        // "Thread panicked in hyper/race" at `join()` and leaks the raw
+                        // Rust panic message to stderr; the guard converts it into a
+                        // catchable X::AdHoc and suppresses the default backtrace dump,
+                        // making worker panic handling uniform across all spawn sites.
+                        let call_result = crate::vm::guard_worker_panic(|| {
+                            vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None)
+                        });
+                        match call_result {
+                            Ok(val) => {
+                                if is_map_flag {
+                                    if let Value::Slip(ref s) = val {
+                                        results.extend(s.iter().cloned());
+                                    } else {
+                                        results.push(val);
+                                    }
+                                } else if val.truthy() {
+                                    results.push(item.clone());
                                 }
-                            } else if val.truthy() {
-                                results.push(item.clone());
+                            }
+                            Err(e) => {
+                                error = Some(e);
                             }
                         }
-                        Err(e) => {
-                            error = Some(e);
-                        }
                     }
-                }
-                let output = vm.take_output();
-                let stderr = vm.take_stderr_output();
-                let final_result = match error {
-                    Some(e) => Err(e),
-                    None => Ok(results),
-                };
-                (vm, final_result, output, stderr)
-            }));
+                    let output = vm.take_output();
+                    let stderr = vm.take_stderr_output();
+                    let final_result = match error {
+                        Some(e) => Err(e),
+                        None => Ok(results),
+                    };
+                    (vm, final_result, output, stderr)
+                },
+            ));
         }
         let mut all_results = Vec::with_capacity(items.len());
         let mut first_error: Option<RuntimeError> = None;

--- a/t/thread-deep-stack.t
+++ b/t/thread-deep-stack.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# Regression: threads spawned by `Thread.start` must use the same large
+# user-code stack as `start {}` / Promise / Supply worker threads. Previously
+# `Thread.start` used the OS default (~2-8 MiB) stack, so deep VM nesting on the
+# worker thread overflowed and aborted the whole process ("has overflowed its
+# stack"). This surfaced when running an async web server (HTTP::Server::Tiny)
+# whose react loop constructs objects whose BUILD re-enters the VM.
+#
+# Here we force deep recursion on a `Thread.start` worker; depth ~600 frames overflow
+# a default thread stack but fits comfortably in the 256 MiB user-code stack.
+
+plan 2;
+
+sub deep(Int $n) {
+    return 0 if $n <= 0;
+    return 1 + deep($n - 1);
+}
+
+# Baseline: deep recursion works on the main thread.
+is deep(600), 600, 'deep recursion on main thread';
+
+# The regression: the same work on a Thread.start worker must not overflow.
+my $result;
+my $thr = Thread.start({
+    $result = deep(600);
+});
+$thr.finish;
+is $result, 600, 'deep recursion on a Thread.start worker thread';


### PR DESCRIPTION
## What

`Thread.start` spawned its worker with a raw `std::thread::spawn`, so the worker ran user VM code on the OS default (~2-8 MiB) thread stack instead of the 256 MiB `spawn_user_thread` stack that `start {}` / Promise / Supply workers already use. Deep VM nesting on the worker overflowed and aborted the whole process (`has overflowed its stack`).

## How it surfaced

While investigating **HTTP::Server::Tiny** (PLAN.md §H), the unmodified upstream module loaded, `.new`'d, and listened — but every request crashed the process. A gdb backtrace at the overflow showed only **83 frames**: not infinite recursion, just a too-small stack. The async server's `react` loop constructs objects whose `BUILD` re-enters the VM, and that legitimate nesting exceeded 8 MiB.

## Fix

Route every user-code-running spawn through `spawn_user_thread`:
- **`Thread.start`** (`socket_thread.rs`) — the direct cause.
- **`$*SCHEDULER.cue`** scheduled callbacks (`scheduler.rs`).
- **hyper/race** batch threads (`vm_hyper_race_parallel.rs`); generalized `spawn_user_thread` to `JoinHandle<T>` since those closures return a value.

## Result

The **unmodified upstream HTTP::Server::Tiny now serves real HTTP end-to-end** through mutsu's `IO::Socket::INET` client:
- `GET /` → `hello`
- `POST /submit` + body + a `start{}`-returning app → round-trips via the content-length / TempFile / IO::Blob path (`method=POST len=8`).

## Tests

- `t/thread-deep-stack.t` — deep recursion on a `Thread.start` worker (overflows a default stack, fits the 256 MiB user-code stack).
- Full `make test` (cargo 470 + `t/` 1282 files / 12720 tests) PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4