### PR TITLE
feat(nativecall): &trait_mod:<>, Rakudo::Internals.IS-WIN, is encoded(...) param trait

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -242,8 +242,19 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
     `connect`→`Connection`・`.execute`→行ハッシュ配列・`.close`）が実 SQLite で CREATE/INSERT/ORDER BY/WHERE SELECT を
     往復（担保＝`t/dbdish-lite.t`）。= ウェブブログの DB 層が再利用可能モジュールとして揃った。これを暴いた precomp
     キャッシュ staleness バグ（注入後 AST をキャッシュするが version stamp が dev ビルド間で不変）は exe-mtime stamp で修正済。
-  - **DBIish/DBDish（off-the-shelf）**: 実配布版はまだ 3 機能待ち（regex "Unmatched (" parse / `Rakudo::Internals.REGISTER-DYNAMIC` /
-    `is encoded(...)` NativeCall param trait）。手書き互換層は上記の通り動く。
+  - **DBIish/DBDish（off-the-shelf）調査（2026-06-28・DBIish 0.6.8）**: zef で取得し mutsu でロード試行。スタック全体
+    （`DBDish`/`Connection`/`StatementHandle`/`SQLite`/`SQLite::Native`/`ErrorHandling`）はパース可能。3 件の一般修正で
+    **`NativeLibs` と `DBDish::SQLite::Native` がロード可能に**（#TBD）: ① `&trait_mod:<is>`（拡張識別子 `&`-参照に
+    `trait_mod` カテゴリ追加）② `Rakudo::Internals.IS-WIN`/`.IS-MACOS`（host target から解決）③ `is encoded('utf8')`
+    param trait（許可＋括弧引数消費・`skip_optional_trait_arg`）。担保＝`t/nativecall-module-compat.t`。
+    **🧱 残る壁（アーキテクチャ非互換）**: `DBDish::SQLite` は `NativeHelpers::Blob` → **`MoarVM::Guts::REPRs`** に依存し、
+    これが MoarVM の**内部メモリ表現を直接エミュレート**（`nativesizeof`〔未実装〕・`Pointer.WHERE` ポインタ演算で
+    VMArray/CStruct のオフセットを実メモリ走査・`constant Offset = do{…}` を load 時に eager 実行）。mutsu は MoarVM では
+    ないためこの層は原理的に動かせない（BLOB 列の `blob-from-pointer` 専用で、int/text CRUD には本来不要）。
+    **= off-the-shelf DBDish::SQLite の完動は MoarVM REPR エミュレーション待ち＝事実上の壁**。実用 SQLite は手書き
+    `DBDishLite` + NativeCall MVP が正道。副次的に発見した一般パースバグ（別軸・未修正）: `constant NAME is export =
+    <cond> ?? <Type> !! <Type>` が then 枝 bareword/型で失敗（非 export は `constant` を関数呼び出しに誤フォールバックして
+    黙って誤パース）＝文レベル `expression` の ternary then 枝 greediness。
 - **JSON は native 実装済み**（`to-json`/`from-json`・#3402・news 参照）。Template::Mustache 91/92-specs の残（別軸・
   本タスク外）= 実 spec の rendering ギャップ（delimiter 永続化／inheritable partials／lambda）＋ 最初の spec のみ
   `+$spec.value`=0 になる subtest/Seq-consumption 系バグ（itemization とは独立）。

--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -401,6 +401,7 @@ pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
                 || n.starts_with("term:<")
                 || n.starts_with("circumfix:<")
                 || n.starts_with("postcircumfix:<")
+                || n.starts_with("trait_mod:<")
         )
     {
         return Ok((op_rest, Expr::CodeVar(op_name)));
@@ -412,7 +413,7 @@ pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
     if twigil.is_empty()
         && matches!(
             name,
-            "infix" | "prefix" | "postfix" | "term" | "circumfix" | "postcircumfix"
+            "infix" | "prefix" | "postfix" | "term" | "circumfix" | "postcircumfix" | "trait_mod"
         )
         && let Some((r, full_name)) = parse_operator_code_ref_suffix(name, rest)
     {

--- a/src/parser/stmt/sub/param_validate.rs
+++ b/src/parser/stmt/sub/param_validate.rs
@@ -1,7 +1,50 @@
 use super::*;
 
 /// Known valid parameter traits for `is <trait>` in signatures.
-const VALID_PARAM_TRAITS: &[&str] = &["rw", "readonly", "copy", "required", "raw"];
+/// `encoded` is a NativeCall string-marshalling trait (`Str $s is encoded('utf8')`)
+/// that carries a parenthesized argument; see `skip_optional_trait_arg`.
+const VALID_PARAM_TRAITS: &[&str] = &["rw", "readonly", "copy", "required", "raw", "encoded"];
+
+/// After a parameter trait name, skip an optional parenthesized argument such as
+/// the `('utf8')` in `is encoded('utf8')`. Balances nested parens and ignores
+/// parens inside single/double-quoted string literals. Leading whitespace before
+/// the `(` is permitted. Returns the input unchanged when no `(` follows.
+pub(crate) fn skip_optional_trait_arg(input: &str) -> &str {
+    let trimmed = input.trim_start();
+    if !trimmed.starts_with('(') {
+        return input;
+    }
+    let bytes = trimmed.as_bytes();
+    let mut depth = 0u32;
+    let mut quote: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match quote {
+            Some(q) => {
+                if c == b'\\' {
+                    i += 1; // skip escaped char
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                b'\'' | b'"' => quote = Some(c),
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &trimmed[i + 1..];
+                    }
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    // Unbalanced: leave the input as-is so the normal parser reports the error.
+    input
+}
 
 /// Public wrapper for `validate_param_trait` used by control.rs.
 pub(crate) fn validate_param_trait_pub<'a>(
@@ -31,7 +74,8 @@ pub(crate) fn validate_param_trait<'a>(
             trait_name
         ));
     }
-    Ok((input, ()))
+    // Consume an optional parenthesized trait argument, e.g. `is encoded('utf8')`.
+    Ok((skip_optional_trait_arg(input), ()))
 }
 
 pub(crate) fn static_default_type(expr: &Expr) -> Option<String> {

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -116,7 +116,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         while let Some(r2) = super::super::keyword("is", r) {
             let (r2, _) = ws1(r2)?;
             let (r2, trait_name) = super::super::ident(r2)?;
-            super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
+            let (r2, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
             param_traits.push(trait_name);
             let (r2, _) = ws(r2)?;
             r = r2;
@@ -160,7 +160,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             while let Some(rt) = super::super::keyword("is", r) {
                 let (rt, _) = ws1(rt)?;
                 let (rt, trait_name) = super::super::ident(rt)?;
-                super::super::sub::validate_param_trait(&trait_name, &param_traits, rt)?;
+                let (rt, _) =
+                    super::super::sub::validate_param_trait(&trait_name, &param_traits, rt)?;
                 param_traits.push(trait_name);
                 let (rt, _) = ws(rt)?;
                 r = rt;
@@ -405,7 +406,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                 while let Some(r) = super::super::keyword("is", rest) {
                     let (r, _) = ws1(r)?;
                     let (r, trait_name) = super::super::ident(r)?;
-                    super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
+                    let (r, _) =
+                        super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
                     param_traits.push(trait_name);
                     let (r, _) = ws(r)?;
                     rest = r;
@@ -494,7 +496,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             while let Some(r) = super::super::keyword("is", r3) {
                 let (r, _) = ws1(r)?;
                 let (r, trait_name) = super::super::ident(r)?;
-                super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
+                let (r, _) =
+                    super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
                 param_traits.push(trait_name);
                 let (r, _) = ws(r)?;
                 r3 = r;
@@ -618,7 +621,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         while let Some(rt) = super::super::keyword("is", r) {
             let (rt, _) = ws1(rt)?;
             let (rt, trait_name) = super::super::ident(rt)?;
-            super::super::sub::validate_param_trait(&trait_name, &sigilless_traits, rt)?;
+            let (rt, _) =
+                super::super::sub::validate_param_trait(&trait_name, &sigilless_traits, rt)?;
             sigilless_traits.push(trait_name);
             let (rt, _) = ws(rt)?;
             r = rt;
@@ -707,7 +711,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                     while let Some(r) = super::super::keyword("is", rest) {
                         let (r, _) = ws1(r)?;
                         let (r, trait_name) = super::super::ident(r)?;
-                        super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
+                        let (r, _) =
+                            super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
                         param_traits.push(trait_name);
                         let (r, _) = ws(r)?;
                         rest = r;
@@ -749,7 +754,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                 while let Some(r) = super::super::keyword("is", rest) {
                     let (r, _) = ws1(r)?;
                     let (r, trait_name) = super::super::ident(r)?;
-                    super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
+                    let (r, _) =
+                        super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
                     param_traits.push(trait_name);
                     let (r, _) = ws(r)?;
                     rest = r;
@@ -795,7 +801,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             while let Some(r) = super::super::keyword("is", rest) {
                 let (r, _) = ws1(r)?;
                 let (r, trait_name) = super::super::ident(r)?;
-                super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
+                let (r, _) =
+                    super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
                 param_traits.push(trait_name);
                 let (r, _) = ws(r)?;
                 rest = r;
@@ -878,7 +885,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         while let Some(r2) = super::super::keyword("is", r) {
             let (r2, _) = ws1(r2)?;
             let (r2, trait_name) = super::super::ident(r2)?;
-            super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
+            let (r2, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
             param_traits.push(trait_name);
             let (r2, _) = ws(r2)?;
             r = r2;
@@ -1001,7 +1008,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         while let Some(r2) = super::super::keyword("is", r) {
             let (r2, _) = ws1(r2)?;
             let (r2, trait_name) = super::super::ident(r2)?;
-            super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
+            let (r2, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
             param_traits.push(trait_name);
             let (r2, _) = ws(r2)?;
             r = r2;
@@ -1051,7 +1058,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         while let Some(r2) = super::super::keyword("is", r) {
             let (r2, _) = ws1(r2)?;
             let (r2, trait_name) = super::super::ident(r2)?;
-            super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
+            let (r2, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r2)?;
             param_traits.push(trait_name);
             let (r2, _) = ws(r2)?;
             r = r2;
@@ -1133,7 +1140,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
     while let Some(r) = super::super::keyword("is", rest) {
         let (r, _) = ws1(r)?;
         let (r, trait_name) = super::super::ident(r)?;
-        super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
+        let (r, _) = super::super::sub::validate_param_trait(&trait_name, &param_traits, r)?;
         param_traits.push(trait_name);
         let (r, _) = ws(r)?;
         rest = r;

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -98,6 +98,19 @@ impl Interpreter {
         if let Some(result) = self.try_rakudo_internals_json_method(&target, method, &args) {
             return result;
         }
+        // `Rakudo::Internals.IS-WIN` / `.IS-MACOS`: platform predicates used by
+        // low-level native modules (e.g. NativeLibs picks the library name by
+        // `Rakudo::Internals.IS-WIN()`). Resolved from the host build target.
+        if matches!(&target, Value::Package(name) if name.resolve() == "Rakudo::Internals")
+            && matches!(method, "IS-WIN" | "IS-MACOS")
+        {
+            let val = match method {
+                "IS-WIN" => cfg!(target_os = "windows"),
+                "IS-MACOS" => cfg!(target_os = "macos"),
+                _ => unreachable!(),
+            };
+            return Ok(Value::Bool(val));
+        }
         // `Rakudo::Internals.REGISTER-DYNAMIC: '$*name', { ... }` installs a
         // default for a process dynamic variable by running the initializer
         // block (which typically does `PROCESS::<$name> = ...`). Real Rakudo runs

--- a/t/nativecall-module-compat.t
+++ b/t/nativecall-module-compat.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# General improvements surfaced while loading the real NativeCall-based module
+# stack (NativeLibs / DBDish::SQLite::Native). Each is an independent Raku
+# feature, not a DBDish-specific hack.
+
+plan 7;
+
+# 1. `&trait_mod:<is>` — referencing the `is` trait-modifier routine by its
+#    extended categorical name (NativeLibs' EXPORT introspects it). Previously
+#    only infix/prefix/postfix/term/circumfix categories parsed; `trait_mod`
+#    raised a parse error. The fix is parse-level, so the reference just has to
+#    compile and evaluate without throwing.
+{
+    lives-ok { my $code = &trait_mod:<is>; $code }, '&trait_mod:<is> parses and is referenceable';
+}
+
+# 2. Rakudo::Internals.IS-WIN / .IS-MACOS platform predicates (used by NativeLibs
+#    to choose a library name). They must return Bool values.
+{
+    my $win = Rakudo::Internals.IS-WIN;
+    isa-ok $win, Bool, 'Rakudo::Internals.IS-WIN returns a Bool';
+    my $mac = Rakudo::Internals.IS-MACOS;
+    isa-ok $mac, Bool, 'Rakudo::Internals.IS-MACOS returns a Bool';
+    # Not both true on any real platform.
+    nok ($win && $mac), 'IS-WIN and IS-MACOS are not both true';
+}
+
+# 3. `is encoded('utf8')` parameter trait (NativeCall string marshalling). The
+#    trait name and its parenthesized argument must parse, and the value must
+#    pass through unchanged.
+{
+    sub take-str(Str $s is encoded('utf8')) { $s.uc }
+    is take-str('hello'), 'HELLO', 'is encoded(...) param trait accepted; value passes through';
+}
+
+# A return-type'd native-style signature with an encoded param also parses.
+{
+    sub two(Str $a is encoded('utf8'), Int $n --> Str) { $a x $n }
+    is two('ab', 3), 'ababab', 'encoded param alongside other params and return type';
+}
+
+# Anonymous (type-only) param with the encoded trait parses too.
+{
+    sub anon(Str $ is encoded('utf8')) { 'ok' }
+    is anon('x'), 'ok', 'encoded trait on a named-but-unused param parses';
+}


### PR DESCRIPTION
## What

Three independent Raku features surfaced while loading the real NativeCall-based module stack (NativeLibs, DBDish::SQLite::Native) in mutsu. Each is a general improvement, not a module-specific hack.

1. **`&trait_mod:<is>`** — extend the `&`-sigil categorical operator-reference parser to accept the `trait_mod` category (it already handled `infix`/`prefix`/`postfix`/`term`/`circumfix`/`postcircumfix`). NativeLibs' `sub EXPORT` introspects `&trait_mod:<is>.candidates`. Parse-level support: the reference now compiles and evaluates instead of raising a parse error.

2. **`Rakudo::Internals.IS-WIN` / `.IS-MACOS`** — platform predicates resolved from the host build target (`cfg!(target_os = ...)`), added next to the existing `REGISTER-DYNAMIC` handler. NativeLibs picks a library name via `Rakudo::Internals.IS-WIN()`.

3. **`is encoded('utf8')` parameter trait** — accept `encoded` as a valid parameter trait (NativeCall string marshalling) and consume its optional parenthesized argument. `validate_param_trait` now returns the advanced input via a shared `skip_optional_trait_arg` helper (balances nested parens, ignores quoted parens), and every signature trait-parse site threads that position through.

## Result

With these, the unmodified upstream **`NativeLibs` and `DBDish::SQLite::Native` now load** in mutsu.

Full upstream `DBDish::SQLite` remains blocked further down the stack by `NativeHelpers::Blob` → `MoarVM::Guts::REPRs`, which emulates MoarVM's internal memory layout (`nativesizeof`, `Pointer.WHERE` pointer arithmetic, CStruct offset scanning) — architecturally incompatible with mutsu. The hand-written `DBDishLite` + NativeCall MVP remains the viable SQLite path. See PLAN.md §H for the full investigation.

## Tests

- `t/nativecall-module-compat.t` (7 subtests).
- cargo unit tests 474 pass; targeted param/trait/constant/nativecall prove suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4