### PR TITLE
fix(parser): bare Perl 5 unary functions (ord/chr/lc/uc/abs) are X::Obsolete

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1530,6 +1530,20 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 
+    // Perl 5 unary functions used bare (no argument). `ord`/`chr`/`lc`/`uc`/`abs`
+    // defaulted to `$_` in Perl 5 but require an explicit argument/invocant in
+    // Raku, so a bare use — end of statement or immediately a `.method` (i.e. no
+    // argument follows) — is X::Obsolete, matching Rakudo's "Unsupported use of
+    // bare ..." (e.g. `ord.Cool`). A real call (`ord $x` / `ord('A')`) parses as
+    // a listop/call before reaching this fallback, so it is unaffected.
+    if is_terminator_or_dot && matches!(name.as_str(), "ord" | "chr" | "lc" | "uc" | "abs") {
+        return Err(PError::fatal(format!(
+            "X::Obsolete: Unsupported use of bare \"{name}\".  In Raku please use: \
+             .{name} if you meant to call it as a method on $_, or use an explicit \
+             invocant or argument."
+        )));
+    }
+
     // Method-like: .new, .elems etc. is handled at expression level
     Ok((rest, Expr::BareWord(name)))
 }

--- a/t/bare-perl5-unary-obsolete.t
+++ b/t/bare-perl5-unary-obsolete.t
@@ -1,0 +1,23 @@
+use Test;
+
+# Perl 5 unary functions (`ord`/`chr`/`lc`/`uc`/`abs`) defaulted to `$_` in
+# Perl 5 but require an explicit argument/invocant in Raku. A bare use with no
+# argument is X::Obsolete (Rakudo: «Unsupported use of bare "ord"...»).
+# Regression: S32-exceptions/misc.t ("adequate error message when calling bare
+# ord"). A real call or method form must still work.
+
+plan 13;
+
+for <ord chr lc uc abs> -> $fn {
+    throws-like $fn ~ '.Cool', X::Obsolete, "bare $fn (followed by .method) is X::Obsolete";
+}
+
+# real calls / listops / method forms are unaffected
+is ord('A'), 65, 'ord with parens works';
+is lc('HI'), 'hi', 'lc with parens works';
+is (uc 'hi'), 'HI', 'uc as listop works';
+is abs(-5), 5, 'abs with parens works';
+is (chr 66), 'B', 'chr as listop works';
+is "A".ord, 65, '.ord method works';
+is "HI".lc, 'hi', '.lc method works';
+is (-5).abs, 5, '.abs method works';


### PR DESCRIPTION
`ord`/`chr`/`lc`/`uc`/`abs` defaulted to `$_` in Perl 5 but require an explicit argument/invocant in Raku. A bare use with no argument — end of statement or immediately followed by a `.method` (e.g. `ord.Cool`) — must throw **X::Obsolete** ("Unsupported use of bare ..."), matching Rakudo, instead of being silently treated as a bareword string.

```raku
ord.Cool;   # was: No such method 'Cool' for Str ;  now: X::Obsolete
```

A real call (`ord $x` / `ord('A')`) or method form (`$x.ord`) parses before this fallback and is unaffected.

Fixes `S32-exceptions/misc.t` "adequate error message when calling bare ord". Test: `t/bare-perl5-unary-obsolete.t`; `make test` + str/numeric whitelisted roast regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)