### PR TITLE
fix(unicode): uniname() of a too-high codepoint returns "<unassigned>"

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -5,6 +5,7 @@ roast/6.c/S14-roles/submethods.t
 roast/6.d/S02-literals/version.t
 roast/6.d/S05-capture/match-object.t
 roast/6.d/S09-multidim/indexing.t
+roast/6.d/S15-unicode-information/uniname.t
 roast/6.d/S32-num/atanh.t
 roast/6.d/S32-num/log.t
 roast/6.d/S32-num/sign.t

--- a/src/builtins/unicode.rs
+++ b/src/builtins/unicode.rs
@@ -489,14 +489,10 @@ pub(crate) fn uniname_from_int(codepoint: i64) -> Result<String, crate::value::R
     }
     let cp = codepoint as u64;
     if cp > 0x10FFFF {
-        let msg = format!("Unassigned codepoint: 0x{:X}", cp);
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
-        let ex =
-            crate::value::Value::make_instance(crate::symbol::Symbol::intern("X::AdHoc"), attrs);
-        let mut err = crate::value::RuntimeError::new(&msg);
-        err.exception = Some(Box::new(ex));
-        return Err(err);
+        // Codepoints beyond the Unicode maximum (U+10FFFF) have no name; Rakudo
+        // returns "<unassigned>" rather than erroring (mirrors the in-range
+        // unassigned "<reserved-XXXX>" / negative "<illegal>" sentinels).
+        return Ok("<unassigned>".to_string());
     }
     Ok(unicode_char_name_by_codepoint(cp as u32))
 }

--- a/t/uniname-out-of-range.t
+++ b/t/uniname-out-of-range.t
@@ -1,0 +1,14 @@
+use Test;
+
+# `uniname` for a codepoint beyond the Unicode maximum (U+10FFFF) has no name;
+# Rakudo returns "<unassigned>" rather than throwing. (In-range unassigned
+# codepoints return "<reserved-XXXX>" and negatives return "<illegal>".)
+# Regression: roast/6.d/S15-unicode-information/uniname.t.
+
+plan 5;
+
+is uniname(0x110000), '<unassigned>', 'just past max returns <unassigned>';
+is uniname(0x210000), '<unassigned>', 'far past max returns <unassigned>';
+is uniname(0x41), 'LATIN CAPITAL LETTER A', 'assigned codepoint still named';
+is uniname(0x378), '<reserved-0378>', 'in-range unassigned still <reserved-XXXX>';
+is uniname(-1), '<illegal>', 'negative codepoint still <illegal>';


### PR DESCRIPTION
`uniname` for a codepoint beyond the Unicode maximum (> U+10FFFF) threw `X::AdHoc` "Unassigned codepoint". Rakudo instead returns the sentinel `"<unassigned>"` (mirroring in-range unassigned `"<reserved-XXXX>"` and negative `"<illegal>"`):

```raku
say uniname(0x110000);   # was: error;  now: <unassigned>
```

Whitelists `roast/6.d/S15-unicode-information/uniname.t` (2/2). Test: `t/uniname-out-of-range.t`. S15 unicode whitelisted tests regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)