### PR TITLE
fix(parser): expression-level assignment & bind precedence (lvalue ternary, `:=`)

### DIFF
--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -136,6 +136,37 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
         }
     }
 
+    // Binding (`:=`) is an expression-level operator at item-assignment
+    // precedence (raku), so it must work unparenthesized after `return`, in a
+    // declarator RHS, etc. -- e.g. `return @!specs := @specs`. mutsu otherwise
+    // only handled `:=` at the statement level. Compile-time `::=` is left to
+    // its own statement-level handler. Only simple sigil-variable lvalues bind
+    // here; other lvalue shapes (bareword pseudo-packages like `OUTER`, call
+    // results, indexed elements) fall through to the statement-level handler,
+    // which validates them and throws X::Bind where appropriate.
+    if r.starts_with(":=") && !r.starts_with("::=") {
+        let after = &r[2..];
+        let (after, _) = ws(after)?;
+        if let Ok((r2, rhs)) = ternary_mode(after, mode) {
+            let bind_name = match unwrap_grouped_lvalue(expr.clone()) {
+                Expr::Var(name) => Some(name),
+                Expr::ArrayVar(name) => Some(format!("@{name}")),
+                Expr::HashVar(name) => Some(format!("%{name}")),
+                _ => None,
+            };
+            if let Some(name) = bind_name {
+                return Ok((
+                    r2,
+                    Expr::AssignExpr {
+                        name,
+                        expr: Box::new(rhs),
+                        is_bind: true,
+                    },
+                ));
+            }
+        }
+    }
+
     if !(r.starts_with('=') && !r.starts_with("==") && !r.starts_with("=>")) {
         return Ok((rest, expr));
     }

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -194,18 +194,25 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             parse_tag(input, "!!")?
         };
         let (input, _) = ws(input)?;
-        // Parse else-expr at ternary precedence (allows nested ternary)
+        // Parse the else-expr. In Full mode do NOT absorb a trailing assignment:
+        // `=` is LOOSER than the conditional `?? !!`, so `cond ?? t !! lhs = rhs`
+        // parses as `(cond ?? t !! lhs) = rhs` (an lvalue-ternary assignment),
+        // not as an assignment nested inside the else-branch. Parsing the
+        // else-branch no-assign leaves `= rhs` for the trailing handler below.
         let (input, else_expr) = if mode == ExprMode::Full {
-            ternary_mode(input, mode).map_err(|err| {
+            ternary_no_assign(input).map_err(|err| {
                 enrich_expected_error(err, "expected else-expression after '!!'", input.len())
             })?
         } else {
             ternary_mode(input, mode)?
         };
+        // A then-branch assignment is a genuine error (the `=` would sit between
+        // `??` and `!!`); raku rejects it too. In non-Full modes the else-branch
+        // may still have greedily taken an assignment, which is likewise too loose.
         if is_assignment_expr(&then_expr) || is_assignment_expr(&else_expr) {
             return Err(conditional_precedence_too_loose_error());
         }
-        if let Expr::Binary { left, op, right } = cond {
+        let ternary_expr = if let Expr::Binary { left, op, right } = cond {
             // The loose word-logicals (`and`/`andthen`/`notandthen`/`or`/`orelse`)
             // are LOOSER than the conditional `?? !!`, so when one was greedily
             // folded into the condition the ternary must re-associate to bind
@@ -222,36 +229,53 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
                     | TokenKind::OrWord
                     | TokenKind::OrElse
             ) {
-                return Ok((
-                    input,
-                    Expr::Binary {
-                        left,
-                        op,
-                        right: Box::new(Expr::Ternary {
-                            cond: right,
-                            then_expr: Box::new(then_expr),
-                            else_expr: Box::new(else_expr),
-                        }),
-                    },
-                ));
-            }
-            return Ok((
-                input,
+                Expr::Binary {
+                    left,
+                    op,
+                    right: Box::new(Expr::Ternary {
+                        cond: right,
+                        then_expr: Box::new(then_expr),
+                        else_expr: Box::new(else_expr),
+                    }),
+                }
+            } else {
                 Expr::Ternary {
                     cond: Box::new(Expr::Binary { left, op, right }),
                     then_expr: Box::new(then_expr),
                     else_expr: Box::new(else_expr),
-                },
-            ));
-        }
-        return Ok((
-            input,
+                }
+            }
+        } else {
             Expr::Ternary {
                 cond: Box::new(cond),
                 then_expr: Box::new(then_expr),
                 else_expr: Box::new(else_expr),
-            },
-        ));
+            }
+        };
+        // A trailing simple assignment binds the whole ternary as an lvalue:
+        // `cond ?? $a !! $b = rhs` is `(cond ?? $a !! $b) = rhs` (raku precedence).
+        if mode == ExprMode::Full {
+            let (after_ws, _) = ws(input)?;
+            if after_ws.starts_with('=')
+                && !after_ws.starts_with("==")
+                && !after_ws.starts_with("=>")
+                && !after_ws.starts_with("=:=")
+                && !after_ws.starts_with("=~=")
+            {
+                let (rhs_in, _) = ws(&after_ws[1..])?;
+                let (input2, rhs) = ternary_mode(rhs_in, mode).map_err(|err| {
+                    enrich_expected_error(err, "expected value after '='", rhs_in.len())
+                })?;
+                return Ok((
+                    input2,
+                    Expr::Call {
+                        name: Symbol::intern("__mutsu_assign_callable_lvalue"),
+                        args: vec![ternary_expr, Expr::ArrayLiteral(Vec::new()), rhs],
+                    },
+                ));
+            }
+        }
+        return Ok((input, ternary_expr));
     }
     // No ternary operator: fall back to regular OR-level parsing, which includes
     // assignment expressions.

--- a/t/bind-expression-level.t
+++ b/t/bind-expression-level.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# Regression: `:=` binding is an expression-level operator (item-assignment
+# precedence) in raku, so it must work unparenthesized after `return`, in a
+# declarator RHS, etc. mutsu previously only handled `:=` at the statement level,
+# so `return $x := 5` failed to parse ("expected statement").
+# Surfaced loading Zef::Distribution:
+#   return @!provides-specs := @provides-specs;
+
+plan 8;
+
+# `return EXPR := EXPR`
+{
+    my $x;
+    sub f { return $x := 5 }
+    is f(), 5, 'return $x := 5 returns the bound value';
+    is $x, 5, 'the binding took effect';
+}
+
+# `return @arr := @other` (array binding)
+{
+    my @x;
+    my @y = 1, 2, 3;
+    sub g { return @x := @y }
+    is g().elems, 3, 'return @x := @y binds and returns the array';
+}
+
+# Binding inside a declarator RHS.
+{
+    my $x;
+    my $y = $x := 5;
+    is $x, 5, 'declarator RHS: inner bind took effect';
+    is $y, 5, 'declarator RHS: outer var got the bound value';
+}
+
+# Hash binding via return.
+{
+    my %h;
+    my %src = a => 1, b => 2;
+    sub h { return %h := %src }
+    is h()<a>, 1, 'return %h := %src binds the hash';
+}
+
+# The bare statement form still works (was already supported).
+{
+    my @x;
+    @x := [10, 20];
+    is @x[1], 20, 'bare-statement := binding still works';
+}
+
+# Compile-time `::=` is NOT mis-consumed by the new `:=` path.
+{
+    constant pi-ish ::= 3;
+    is pi-ish, 3, '::= compile-time bind unaffected';
+}

--- a/t/ternary-lvalue-assign-reassoc.t
+++ b/t/ternary-lvalue-assign-reassoc.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# Regression: `cond ?? $a !! $b = rhs` must parse as `(cond ?? $a !! $b) = rhs`
+# because the assignment operator `=` is LOOSER than the conditional `?? !!`.
+# mutsu previously rejected it ("Assignment operators inside ?? !! are too
+# loose; parenthesize them") -- the else-branch greedily absorbed the
+# assignment instead of leaving it to bind around the whole ternary.
+# Surfaced loading Zef::Distribution:
+#   $!ver ~~ Version ?? $_ !! $!ver = Version.new($_ // 0)
+
+plan 7;
+
+{
+    my $a; my $b;
+    1 ?? $a !! $b = 5;
+    is $a, 5, 'true cond: lvalue ternary assigns to then-branch target';
+    ok !$b.defined, 'else-branch target untouched when cond true';
+}
+
+{
+    my $a; my $b;
+    0 ?? $a !! $b = 5;
+    is $b, 5, 'false cond: lvalue ternary assigns to else-branch target';
+    ok !$a.defined, 'then-branch target untouched when cond false';
+}
+
+# A `~~`-condition (Binary cond) is the exact Zef::Distribution shape.
+{
+    my $ver;
+    my $version = '1.2';
+    my $r = do {
+        with $ver // $version {
+            $ver ~~ Version ?? $_ !! $ver = Version.new($_ // 0)
+        }
+    };
+    is $r, v1.2, 'Zef::Distribution ver() pattern: smartmatch cond + else-assign';
+    is $ver, v1.2, 'else-branch attribute-like var was assigned the new Version';
+}
+
+# Parenthesized form keeps working (explicit lvalue ternary).
+{
+    my $a; my $b;
+    ($a ?? $a !! $b) = 7;
+    is $b, 7, 'explicit parenthesized lvalue ternary still works';
+}


### PR DESCRIPTION
Two related expression-level precedence fixes surfaced while loading **Zef** modules in mutsu. Both are general parser improvements, not zef-specific.

## 1. `cond ?? $a !! $b = rhs` → `(cond ?? $a !! $b) = rhs`

`=` is looser than the conditional `?? !!`, so an assignment trailing a ternary applies to the whole ternary as an lvalue. mutsu's else-branch parser greedily absorbed the assignment and rejected it (*"Assignment operators inside ?? !! are too loose; parenthesize them"*).

Fix (Full mode): parse the else-branch with the no-assign ternary so the trailing `= rhs` survives, then bind it around the complete ternary via the existing `__mutsu_assign_callable_lvalue` path. A then-branch assignment (the `=` between `??` and `!!`) is still a genuine error, matching raku.

Surfaced in `Zef::Distribution`:
```raku
$!ver ~~ Version ?? $_ !! $!ver = Version.new($_ // 0)
```

## 2. `:=` binding as an expression-level operator

`:=` binds at item-assignment precedence in raku, but mutsu only recognized it at the statement level — so `return $x := 5`, `my $y = $x := 5`, and `return @!specs := @specs` failed to parse.

Fix: handle `:=` in the item-assignment tier (`assign_not_expr_mode`), building `AssignExpr { is_bind: true }` for simple sigil-variable lvalues (`$`/`@`/`%`). Compile-time `::=` and non-variable lvalues (bareword pseudo-packages like `OUTER`/`MY`, call results, indexed elements) fall through to the statement-level handler, which still throws `X::Bind` where appropriate (kept `t/bind-invalid-lhs.t` green).

Surfaced in `Zef::Distribution`:
```raku
return @!provides-specs := @provides-specs;
```

With both, `Zef::Distribution` now parses (the remaining blocker is the missing built-in `Distribution` role, a runtime concern).

## Tests

`t/ternary-lvalue-assign-reassoc.t` (7) and `t/bind-expression-level.t` (8). Full `t/*bind*`/`t/*assign*`/`t/*ternary*` suites + 474 cargo unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4