### PR TITLE
fix(parser): a Bool default conforms to an Int/Numeric/Real parameter

### DIFF
--- a/src/parser/stmt/sub/param_validate.rs
+++ b/src/parser/stmt/sub/param_validate.rs
@@ -168,9 +168,14 @@ pub(crate) fn default_type_matches_constraint(
         return Some(false);
     }
     match base {
-        "Int" | "UInt" | "Bool" | "Str" | "List" | "Array" | "Hash" | "Pair" | "Junction"
-        | "Complex" | "Signature" | "Capture" => Some(false),
-        "Numeric" | "Real" => Some(matches!(default_type, "Int" | "Num" | "Rat")),
+        // `Bool` enumerates to `Int` (`enum Bool does Int`), so a `Bool` default
+        // conforms to an `Int`/`Numeric`/`Real` (and `Cool`/`Any`/`Mu`, handled
+        // above) parameter -- e.g. `Int :$wrap = False` is valid (used by zef's
+        // CLI). It does NOT conform to `Num` or `Rat`.
+        "Int" => Some(default_type == "Bool"),
+        "UInt" | "Bool" | "Str" | "List" | "Array" | "Hash" | "Pair" | "Junction" | "Complex"
+        | "Signature" | "Capture" => Some(false),
+        "Numeric" | "Real" => Some(matches!(default_type, "Int" | "Num" | "Rat" | "Bool")),
         "Num" => Some(matches!(default_type, "Int" | "Num" | "Rat")),
         "Rat" => Some(matches!(default_type, "Int" | "Rat")),
         "Callable" | "Code" | "Block" => Some(default_type == "Callable"),

--- a/t/param-default-bool-conforms-int.t
+++ b/t/param-default-bool-conforms-int.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# Regression: a `Bool` default value conforms to an `Int`/`Numeric`/`Real`
+# parameter constraint, because `Bool` enumerates to `Int` (`enum Bool does Int`)
+# in raku. mutsu's compile-time default-type check wrongly rejected
+# `Int :$wrap = False` with X::Parameter::Default::TypeCheck.
+# Surfaced loading Zef::CLI:  multi sub MAIN('search', Int :$wrap = False, ...)
+
+plan 8;
+
+# The exact zef shape: Int-typed named param with a Bool default.
+{
+    sub f(Int :$wrap = False) { $wrap }
+    is f().^name, 'Bool', 'Int :$wrap = False defaults to the Bool value';
+    is f(wrap => 5), 5, 'passing an Int still binds as Int';
+}
+
+# Bool default also conforms to Numeric / Real.
+{
+    sub g(Numeric :$x = False) { $x }
+    is g().^name, 'Bool', 'Numeric :$x = False accepted';
+    sub h(Real :$x = False) { $x }
+    is h().^name, 'Bool', 'Real :$x = False accepted';
+}
+
+# True works the same way.
+{
+    sub t(Int :$on = True) { $on }
+    is t(), True, 'Int :$on = True accepted';
+}
+
+# Genuinely incompatible defaults are still rejected at compile time.
+{
+    dies-ok { EVAL 'sub f(Int :$x = "str") { }' },
+        'Str default for Int param still rejected';
+    dies-ok { EVAL 'sub f(Str :$x = 5) { }' },
+        'Int default for Str param still rejected';
+    dies-ok { EVAL 'sub f(Num :$x = False) { }' },
+        'Bool default for Num param rejected (Bool is not a Num)';
+}


### PR DESCRIPTION
## What

`enum Bool does Int` in raku, so a `Bool` default value type-conforms to an `Int` (and `Numeric`/`Real`) parameter constraint. mutsu's compile-time default-type check (`default_type_matches_constraint`) wrongly rejected `Int :$wrap = False` with `X::Parameter::Default::TypeCheck`, even though `False ~~ Int` is `True` at runtime.

## Fix

Accept a `Bool` default for `Int`/`Numeric`/`Real` constraints. `Num` and `Rat` still reject it (Bool is not a Num/Rat), and genuinely incompatible defaults (`Int :$x = "str"`, `Str :$x = 5`) remain compile-time errors — verified against raku:

| default | Int | Numeric | Real | Num | Rat |
|---|---|---|---|---|---|
| `False` | ✅ | ✅ | ✅ | ❌ | ❌ |

## Surfaced by

Loading `Zef::CLI`:
```raku
multi sub MAIN('search', Int :$wrap = False, ...)
```

With this, **every Zef module now parses**; the remaining blocker is the missing built-in `Distribution` role (a runtime concern).

## Tests

`t/param-default-bool-conforms-int.t` (8). Full `t/*param*`/`t/*signature*`/`t/*default*` suites (63 files) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4