### PR TITLE
feat(runtime): register the built-in `Distribution` interface role

### DIFF
--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1855,6 +1855,56 @@ impl Interpreter {
                             },
                         );
                     }
+                    // `Distribution` built-in interface role. Real Rakudo defines
+                    // it with required stub methods `meta` and `content`; user
+                    // distribution classes (e.g. `Zef::Distribution does
+                    // Distribution`) supply the implementations. Registering the
+                    // role lets such classes compose and lets `~~ Distribution`
+                    // recognize them.
+                    {
+                        let stub_body = vec![Stmt::Expr(Expr::Call {
+                            name: Symbol::intern("__mutsu_stub_die"),
+                            args: vec![],
+                        })];
+                        let stub_method = |body: Vec<Stmt>| MethodDef {
+                            params: Vec::new(),
+                            param_defs: Vec::new(),
+                            body: std::sync::Arc::new(body),
+                            is_rw: false,
+                            is_private: false,
+                            is_multi: false,
+                            is_my: false,
+                            role_origin: None,
+                            original_role: None,
+                            return_type: None,
+                            compiled_code: None,
+                            delegation: None,
+                            is_default: false,
+                            deprecated_message: None,
+                            is_submethod: false,
+                        };
+                        let mut methods = HashMap::new();
+                        for name in ["meta", "content"] {
+                            methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
+                        }
+                        roles.insert(
+                            "Distribution".to_string(),
+                            RoleDef {
+                                attributes: Vec::new(),
+                                methods,
+                                is_stub_role: false,
+                                is_hidden: false,
+                                is_rw: false,
+                                captured_env: None,
+                                wildcard_handles: Vec::new(),
+                                role_id: 0,
+                                attribute_conflicts: Vec::new(),
+                                own_attribute_names: std::collections::HashSet::new(),
+                                deferred_body_stmts: Vec::new(),
+                                deferred_custom_traits: Vec::new(),
+                            },
+                        );
+                    }
                     roles
                 };
                 Arc::new(RwLock::new(registry))

--- a/t/builtin-distribution-role.t
+++ b/t/builtin-distribution-role.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# `Distribution` is a built-in Raku interface role (required stub methods `meta`
+# and `content`). User distribution classes compose it and supply the
+# implementations -- e.g. `Zef::Distribution does Distribution`. mutsu previously
+# rejected `does Distribution` with X::InvalidType because the role was unknown.
+
+plan 5;
+
+class MyDist does Distribution {
+    has %.metadata;
+    method meta { %!metadata }
+    method content($address) { "content-of-$address" }
+}
+
+my $d = MyDist.new(metadata => { name => 'Foo', ver => '1.0' });
+
+ok $d ~~ Distribution, 'an instance doing Distribution smartmatches the role';
+ok MyDist ~~ Distribution, 'the class type-conforms to Distribution';
+is $d.meta<name>, 'Foo', 'overridden meta method works';
+is $d.content('lib/Foo.rakumod'), 'content-of-lib/Foo.rakumod', 'overridden content method works';
+
+# A plain class that does NOT do the role is not a Distribution.
+class NotADist { }
+nok NotADist.new ~~ Distribution, 'an unrelated class does not smartmatch Distribution';


### PR DESCRIPTION
## What

`Distribution` is a core Raku interface role (required stub methods `meta` and `content`); distribution classes compose it and supply the implementations — e.g. `Zef::Distribution does Distribution`. mutsu had no such role, so `does Distribution` failed with `X::InvalidType: Invalid typename 'Distribution'`.

## Fix

Register `Distribution` in the role registry (next to the existing `CompUnit::Repository` / `X::Control` built-in roles) with `meta`/`content` stub methods. Classes can now compose it and `~~ Distribution` recognizes them.

## Result

Unblocks loading the **core Zef stack**: `Zef::Distribution`, `Zef::Distribution::Local`, `Zef::Client`, `Zef::Install`, and `Zef::Repository::Ecosystems` now load in mutsu. (Combined with the parser fixes in #3843/#3845/#3848/#3849, every Zef module now parses.) The remaining `Zef::CLI` blocker is a separate `my sub` forward-reference-in-`package`-block scoping bug.

## Tests

`t/builtin-distribution-role.t` (5): role composition, `~~ Distribution` for instance and type, overridden `meta`/`content`, and that an unrelated class does not smartmatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4