### PR TITLE
fix(seq): geometric Int sequence promotes to BigInt instead of overflow panic

### DIFF
--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -372,11 +372,47 @@ impl Interpreter {
                 }
                 crate::value::SequenceSpec::GeometricRat { num, den } => {
                     if let Value::Int(n) = last {
-                        let result = n * num;
-                        if result % den == 0 {
-                            Value::Int(result / den)
+                        // `n * num` can overflow i64 for a growing geometric
+                        // sequence (`1, 2, 4 ... *`). Raku's Int is arbitrary
+                        // precision, so promote to BigInt on overflow instead of
+                        // panicking.
+                        match n.checked_mul(*num) {
+                            Some(result) if result % den == 0 => Value::Int(result / den),
+                            Some(result) => match result.checked_mul(*num) {
+                                Some(rn) => Value::Rat(rn, *den),
+                                None => {
+                                    use num_bigint::BigInt;
+                                    crate::value::make_big_rat_arith(
+                                        BigInt::from(result) * BigInt::from(*num),
+                                        BigInt::from(*den),
+                                    )
+                                }
+                            },
+                            None => {
+                                use num_bigint::BigInt;
+                                let prod = BigInt::from(n) * BigInt::from(*num);
+                                let bden = BigInt::from(*den);
+                                if (&prod % &bden) == BigInt::from(0) {
+                                    crate::value::Value::from_bigint(prod / bden)
+                                } else {
+                                    crate::value::make_big_rat_arith(
+                                        prod * BigInt::from(*num),
+                                        bden,
+                                    )
+                                }
+                            }
+                        }
+                    } else if let Value::BigInt(n) = last {
+                        // Continue an already-promoted geometric sequence in exact
+                        // BigInt arithmetic (raku keeps `1, 2, 4 ... *` exact past
+                        // i64), rather than dropping to lossy f64.
+                        use num_bigint::BigInt;
+                        let prod = n.as_ref().clone() * BigInt::from(*num);
+                        let bden = BigInt::from(*den);
+                        if (&prod % &bden) == BigInt::from(0) {
+                            crate::value::Value::from_bigint(prod / bden)
                         } else {
-                            Value::Rat(result * num, *den)
+                            crate::value::make_big_rat_arith(prod * BigInt::from(*num), bden)
                         }
                     } else {
                         let n = last.to_f64();

--- a/t/geometric-sequence-bigint-overflow.t
+++ b/t/geometric-sequence-bigint-overflow.t
@@ -1,0 +1,22 @@
+use Test;
+
+# A growing integer geometric sequence (`1, 2, 4 ... *`) must not overflow i64
+# and panic — Raku's Int is arbitrary precision, so values past 2**62 promote to
+# BigInt and stay exact. Regression: a "multiply with overflow" panic in the
+# lazy sequence generator (integration/advent2010-day04.t).
+
+plan 6;
+
+my @p = 1, 2, 4 ... *;
+is @p[^10].join(" "), "1 2 4 8 16 32 64 128 256 512", "small powers of two exact";
+is @p[63], 9223372036854775808, "2**63 (just past i64::MAX) is exact";
+is @p[69], 590295810358705651712, "2**69 stays exact BigInt";
+ok @p[100] > @p[99], "deep geometric index does not panic and grows";
+
+# ratio 3 geometric also stays exact
+my @t = 1, 3, 9 ... *;
+is @t[40], 3**40, "powers of three exact past i64";
+
+# arithmetic int sequence unaffected
+my @a = 2, 4 ... *;
+is @a[10], 22, "arithmetic sequence still correct";


### PR DESCRIPTION
A growing integer geometric sequence (`1, 2, 4 ... *`) computed each next term as a raw i64 `n * num`, **panicking** with "attempt to multiply with overflow" once the value passed 2\*\*62 (`vm_helpers_junction.rs`).

Raku's `Int` is arbitrary precision, so:
- use `checked_mul` and promote to `BigInt` on overflow;
- continue an already-promoted sequence in exact `BigInt` arithmetic (a `Value::BigInt` term previously dropped to lossy `f64`).

```raku
(1, 2, 4 ... *)[69]   # was: panic;  now: 590295810358705651712 (exact)
```

Removes the panic from `integration/advent2010-day04.t` (which has a separate arithmetic-Rat-step issue, so the file isn't whitelisted here). Test: `t/geometric-sequence-bigint-overflow.t`; seq/num whitelisted roast regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)