### PR TITLE
perf(dispatch): skip per-call body-fingerprint work on the method hot path

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -93,15 +93,31 @@ pub(crate) struct FunctionDef {
     pub(crate) deprecated_message: Option<String>,
 }
 
+/// A `fmt::Write` sink that streams formatted bytes straight into a `Hasher`,
+/// so `write!(.., "{:?}", x)` hashes the Debug rendering without ever
+/// allocating an intermediate `String`. `function_body_fingerprint` runs on the
+/// per-dispatch hot path (candidate identity in multi/method dispatch), so the
+/// three `format!` allocations it used to do showed up as a large share of the
+/// allocator traffic in method-call / class benchmarks.
+struct HashWrite<'a, H: Hasher>(&'a mut H);
+
+impl<H: Hasher> std::fmt::Write for HashWrite<'_, H> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.0.write(s.as_bytes());
+        Ok(())
+    }
+}
+
 pub(crate) fn function_body_fingerprint(
     params: &[String],
     param_defs: &[ParamDef],
     body: &[Stmt],
 ) -> u64 {
+    use std::fmt::Write as _;
     let mut hasher = DefaultHasher::new();
-    format!("{:?}", params).hash(&mut hasher);
-    format!("{:?}", param_defs).hash(&mut hasher);
-    format!("{:?}", body).hash(&mut hasher);
+    let mut sink = HashWrite(&mut hasher);
+    // Separators keep distinct fields from colliding when their renderings abut.
+    let _ = write!(sink, "{params:?}\x00{param_defs:?}\x00{body:?}");
     hasher.finish()
 }
 

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -279,6 +279,15 @@ impl Interpreter {
         self.samewith_context_stack
             .push((method_name.to_string(), Some(invocant.clone())));
         let all_candidates = self.resolve_all_methods_with_owner(receiver_class, method_name, args);
+        // Fast path: with zero or one candidate there is nothing to defer to, so no
+        // dispatch frame is ever pushed (the single candidate is the chosen one and
+        // gets skipped, leaving `remaining` empty). Returning early here avoids the
+        // per-call `function_body_fingerprint` work below — which Debug-traverses the
+        // whole method body AST to derive a candidate identity — for the overwhelmingly
+        // common single-method case. Mirrors `push_multi_dispatch_frame`'s `<= 1` guard.
+        if all_candidates.len() <= 1 {
+            return false;
+        }
         // Identify the chosen candidate and skip exactly that one
         let chosen = self.resolve_method_with_owner(receiver_class, method_name, args);
         let chosen_fp = chosen.as_ref().map(|(_, def)| {

--- a/t/single-candidate-dispatch-fast-path.t
+++ b/t/single-candidate-dispatch-fast-path.t
@@ -1,0 +1,59 @@
+use Test;
+
+# Guards the single-candidate fast path in push_method_dispatch_frame: when a
+# method has zero or one candidate there is no other candidate to defer to, so
+# the dispatch frame is skipped (and the per-call body-fingerprint work avoided).
+# These cases must keep behaving exactly as before that short-circuit.
+
+plan 7;
+
+# 1. A plain single method still dispatches and returns its value.
+class P1 {
+    has $.x;
+    method twice { $!x * 2 }
+}
+is P1.new(x => 21).twice, 42, 'single-candidate method returns correctly';
+
+# 2. samewith re-dispatches the same single method with new args.
+class Fact {
+    method f($n) { $n <= 1 ?? 1 !! $n * samewith($n - 1) }
+}
+is Fact.f(5), 120, 'samewith works with a single candidate';
+
+# 3. nextsame across an inheritance chain (multiple candidates) still chains.
+class Base {
+    method greet { 'base' }
+}
+class Derived is Base {
+    method greet { 'derived+' ~ callsame() }
+}
+is Derived.greet, 'derived+base', 'callsame chains to parent candidate';
+
+# 4. nextsame with a parent candidate forwards control.
+class A2 {
+    method m { 'A' }
+}
+class B2 is A2 {
+    method m { nextsame }
+}
+is B2.new.m, 'A', 'nextsame defers to the inherited candidate';
+
+# 5. A single method calling callsame with no further candidate returns Nil.
+class Lonely {
+    method only { callsame() }
+}
+nok Lonely.only.defined, 'callsame with no next candidate yields an undefined value';
+
+# 6. Accessor methods (single candidate) keep working in a tight loop.
+class Pt { has $.v }
+my $sum = 0;
+$sum += Pt.new(v => $_).v for ^100;
+is $sum, 4950, 'single-candidate accessor dispatch in a loop';
+
+# 7. multi-candidate method dispatch by arity still selects correctly.
+class Multi {
+    multi method g(Int $n) { "int:$n" }
+    multi method g(Str $s) { "str:$s" }
+}
+is Multi.new.g(7) ~ '|' ~ Multi.new.g('hi'), 'int:7|str:hi',
+    'multi-method dispatch unaffected';


### PR DESCRIPTION
## Summary

`push_method_dispatch_frame` runs on **every method call** to build the nextsame/callsame deferral frame. To identify the chosen candidate it called `function_body_fingerprint` for the chosen def and for every candidate — and that function `format!("{:?}", body)`-rendered the **entire method body AST** into a `String` and hashed it: three heap allocations plus a full AST `Debug` traversal *per method call*.

Profiling `method-call` / `bench-class` (release) showed this as a large share of both allocator traffic and CPU — `<mutsu::ast::Expr as core::fmt::Debug>::fmt`, `DebugStruct::field`, `format_inner`, and `malloc`/`free` all traced back to `function_body_fingerprint`.

### Fixes

1. **Single-candidate fast path** (`accessors_state.rs`): when a method has ≤1 candidate there is nothing to defer to, so no frame is ever pushed (the lone candidate is the chosen one and gets skipped, leaving `remaining` empty). Return early *before* any fingerprinting. This mirrors `push_multi_dispatch_frame`'s existing `<= 1` guard and is **behavior-preserving** — the old code already returned `false` here, just after doing the work. Covers the overwhelmingly common single-method dispatch.

2. **Allocation-free `function_body_fingerprint`** (`ast.rs`): stream the `Debug` rendering straight into the hasher via a `fmt::Write` adapter instead of building three intermediate `String`s, for the genuine multi-candidate paths that still fingerprint and for construction-time computation.

### Results

- `method-call` benchmark **0.44s → 0.32s (~27% faster)**.
- The AST `Expr` `Debug` formatting and `function_body_fingerprint` disappear from the `method-call` profile entirely (new top costs are `Symbol::intern` and `Value` drop — future work).
- `make test` passes (12761 tests). Deferral roast tests `S12-methods/defer-call.t` and `defer-next.t` still pass.
- New regression test `t/single-candidate-dispatch-fast-path.t` guards single-candidate dispatch, `samewith`, `callsame`/`nextsame` chaining, and multi-method arity dispatch.

> Note: this is part of re-grounding the Phase A perf work — the previously-planned "Lever 1 (eliminate env deep clone)" target is already solved (`MUTSU_VM_STATS` shows `env_deep_copies ≈ 0` per run after the single-store campaign), so the real method-call bottleneck is elsewhere. This PR removes the first one found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)