### PR TITLE
fix(types): a core type name is never shadowed by an env alias in type matching

### DIFF
--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -519,7 +519,15 @@ impl Interpreter {
                 _ => {}
             }
         }
-        if let Some(Value::Package(bound)) = self.env.get(constraint).cloned()
+        // A type-name constraint may be an env-bound alias (e.g. `::T`, an
+        // imported short name) -> follow it. BUT never let such an alias shadow a
+        // core builtin type: declaring a user class like `Foo::Any` registers an
+        // unqualified `Any` env binding, and following it here would make
+        // `42 ~~ Any` (and untyped-param binding, which checks `Any`) resolve to
+        // the user `Foo::Any` and wrongly fail. Core type names always mean the
+        // core type in type matching.
+        if !crate::runtime::utils::is_known_type_constraint(constraint)
+            && let Some(Value::Package(bound)) = self.env.get(constraint).cloned()
             && bound != *constraint
         {
             return self.type_matches_value(&bound.resolve(), value);

--- a/t/core-type-not-shadowed-in-typematch.t
+++ b/t/core-type-not-shadowed-in-typematch.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# Regression: declaring a user class whose final name component collides with a
+# core type (e.g. `Foo::Any`) and using it as a method parameter type registered
+# an unqualified `Any` env binding. Type matching followed that alias, so
+# `42 ~~ Any` — and untyped-parameter binding, which checks `Any` — wrongly
+# resolved to the user `Foo::Any` and failed ("expected Any but got Str").
+# Surfaced loading zef (Zef::Distribution::DependencySpecification::Any).
+
+plan 8;
+
+class Foo::Any {
+    has @.specs;
+}
+class User {
+    multi method m(Foo::Any $s) { 'any' }
+    multi method m($s)          { 'other' }
+}
+
+# Core `Any` must still match ordinary values and reject nothing it shouldn't.
+ok 42 ~~ Any,    '42 ~~ Any holds after a Foo::Any class+method param exists';
+ok 'x' ~~ Any,   'Str ~~ Any holds';
+ok Nil ~~ Any,   'Nil ~~ Any holds';
+ok 3.14 ~~ Any,  'Rat ~~ Any holds';
+
+# Untyped parameter binding (implicit Any) accepts a Str.
+{
+    sub takes-any($p) { "got:$p" }
+    is takes-any('hello'), 'got:hello', 'untyped param binds a Str (implicit Any)';
+}
+
+# The user class still works as its own type.
+{
+    my $a = Foo::Any.new;
+    ok $a ~~ Foo::Any, 'Foo::Any instance matches Foo::Any';
+    is User.new.m($a), 'any', 'multi dispatch picks the Foo::Any candidate';
+}
+
+# A genuine user type alias (non-core name) is still followed.
+{
+    constant MyInt = Int;
+    ok 7 ~~ MyInt, 'user type alias constant still resolves in type matching';
+}


### PR DESCRIPTION
## What

Declaring a user class whose final name component collides with a core type (e.g. `Foo::Any`) and using it as a **method parameter type** registers an unqualified `Any` env binding. `type_matches_value` followed that alias for the constraint name, so:

```raku
class Foo::Any { }
class User { multi method m(Foo::Any $s) {…}; multi method m($s) {…} }
say 42 ~~ Any;   # was: False !!
```

…and untyped-parameter binding (implicit `Any`) wrongly failed with *"expected Any but got Str"*.

## Fix

Skip the env-alias redirect when the constraint is a known builtin type name (`is_known_type_constraint`): core type names always mean the core type in type matching. Genuine user aliases (`constant MyType = Int`, `::T` captures) are non-core names and still resolve.

## Surfaced by

Loading zef: `Zef::Distribution::DependencySpecification::Any` made `Zef::Config::parse-file($path)` reject its `Str` argument inside `package Zef::CLI`. With this fix the CLI gets past config parsing (next blocker is package-qualified `@*ARGS` resolution — separate).

## Tests

`t/core-type-not-shadowed-in-typematch.t` (8). 115 type/smartmatch/subset/multi prove files (1169 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4