### PR TITLE
fix(compiler): do not package-qualify a twigil variable inside a package block

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -261,6 +261,15 @@ impl Compiler {
             && matches!(sigil, '$' | '@' | '%' | '&')
             && name.len() > 1
         {
+            // A twigil immediately after the sigil marks a non-package variable:
+            // dynamic (`@*ARGS`, `$*OUT`), compile-time (`$?FILE`), attribute
+            // (`$!x`, `$.y`), etc. These must NOT be package-qualified (e.g. an
+            // `@*ARGS = ...` inside `package Zef::CLI` must stay `@*ARGS`, not
+            // become `@Zef::CLI::*ARGS`). Mirrors the sigilless twigil check above.
+            let twigil = name[1..].chars().next();
+            if matches!(twigil, Some('_' | '/' | '!' | '?' | '*' | '.' | '=')) {
+                return name.to_string();
+            }
             return format!("{sigil}{}::{}", self.current_package, &name[1..]);
         }
         format!("{}::{}", self.current_package, name)

--- a/t/dynamic-var-not-package-qualified.t
+++ b/t/dynamic-var-not-package-qualified.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# Regression: assigning to a twigil variable inside a non-unit `package`/`module`
+# block wrongly package-qualified its name. For `@*ARGS` the compiler checked the
+# sigil (`@`) for a twigil instead of the char after it (`*`), so `@*ARGS = …`
+# became `@Zef::CLI::*ARGS` -> "Dynamic variable @Zef::CLI::*ARGS not found".
+# Surfaced loading Zef::CLI: `@*ARGS = eager gather …` inside `package Zef::CLI`.
+
+plan 7;
+
+# Dynamic array/scalar assignment inside a package keeps the bare dynamic name.
+{
+    my @*DYN = 1, 2, 3;
+    package P { @*DYN = 7, 8 }
+    is @*DYN.elems, 2, '@*DYN = … inside a package writes the dynamic var, not @P::*DYN';
+}
+
+{
+    my $*FLAG = 0;
+    package Q { $*FLAG = 42 }
+    is $*FLAG, 42, '$*FLAG = … inside a package writes the dynamic var';
+}
+
+# Reading a process dynamic inside a package still works.
+package R {
+    our $pid-ok = $*PID > 0;
+}
+ok $R::pid-ok, 'reading $*PID inside a package works';
+
+# Ordinary `our` package variables ARE still package-qualified (not broken).
+package S { our $shared = 10 }
+is $S::shared, 10, 'our package var is still qualified and externally visible';
+
+# A `module` block behaves the same.
+module M {
+    our sub bump { $*X = 99 }
+}
+{
+    my $*X = 1;
+    M::bump();
+    is $*X, 99, 'dynamic write from a module sub reaches the caller dynamic';
+}
+
+# Attribute twigils inside a class are unaffected.
+class C {
+    has $.x = 5;
+    method bump { $!x = 6; $!x }
+}
+is C.new.bump, 6, 'attribute twigil $!x works inside a class method';
+is C.new.x, 5, 'attribute accessor works';


### PR DESCRIPTION
## What

`qualify_variable_name` checked the **first** character for a non-package twigil, but for a sigiled variable the twigil is the **second** character. So a dynamic variable like `@*ARGS` (sigil `@`, twigil `*`) **assigned** inside a non-unit `package`/`module` block was qualified to `@Pkg::*ARGS`:

```raku
package P { @*ARGS = (1, 2) }   # was: "Dynamic variable @P::*ARGS not found"
```

## Fix

After the sigil, skip qualification when the next char is a twigil (`* ? ! . = _ /`), mirroring the existing sigilless twigil check. Dynamic (`@*ARGS`, `$*OUT`), compile-time (`$?FILE`), and attribute (`$!x`, `$.y`) variables stay unqualified; ordinary `our` package vars are still qualified.

## Surfaced by

Loading `Zef::CLI`: `@*ARGS = eager gather …` inside `package Zef::CLI`. **With this fix the entire Zef::CLI module loads** (the whole zef stack now compiles and loads in mutsu).

## Tests

`t/dynamic-var-not-package-qualified.t` (7): dynamic array/scalar assignment in package & module, `$*PID` read, `our` var still qualified, module-sub dynamic write reaches caller, attribute twigils unaffected. 28 dynamic/package/twigil/module prove files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENnfFiuQFqDygeE1BXy7N4