### PR TITLE
perf(dispatch): serve mro_readonly from the cached C3 MRO instead of re-walking

### DIFF
--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -123,6 +123,24 @@ impl Interpreter {
 
     /// Walk MRO (read-only) collecting ancestor names.
     pub(crate) fn mro_readonly(&self, class_name: &str) -> Vec<String> {
+        // Fast path: when the registry already holds the precomputed C3 MRO it
+        // *is* the full ancestor list in order (its first element is the class
+        // itself). The BFS below would only re-derive exactly that — and worse,
+        // it calls `class_parents_readonly` per node, each of which clones the
+        // whole `class_def.mro`, so the walk is O(N^2) string clones for an
+        // N-deep hierarchy. `mro_readonly` runs on hot paths (constructor
+        // BUILD/TWEAK/smiley probes, dispatch), so return the cached MRO with a
+        // single clone instead. Equivalence: the BFS seeds `result` with
+        // `[class_name]`, the first pop expands `class_parents_readonly(class_name)
+        // == class_def.mro`, and every later node is already visited, so the
+        // result is exactly `class_def.mro`.
+        if let Some(class_def) = self.registry().classes.get(class_name)
+            && !class_def.mro.is_empty()
+        {
+            return class_def.mro.clone();
+        }
+        // Fallback: built-in/unregistered classes, or a registered class whose
+        // MRO has not been computed yet (parents-only walk).
         let mut result = vec![class_name.to_string()];
         let mut visited = std::collections::HashSet::new();
         visited.insert(class_name.to_string());

--- a/t/deep-mro-dispatch.t
+++ b/t/deep-mro-dispatch.t
@@ -1,0 +1,39 @@
+use Test;
+
+# Guards mro_readonly's cached-MRO fast path: for a class whose registry MRO is
+# populated, mro_readonly returns class_def.mro directly instead of re-deriving
+# it via a BFS. This must stay equivalent for deep hierarchies — method
+# resolution, inherited-method order, and constructor BUILD/TWEAK probing (which
+# all walk mro_readonly) must behave exactly as the BFS did.
+
+plan 6;
+
+# 4-level linear hierarchy.
+class L0 { method tag { 'L0' } method only0 { 'o0' } }
+class L1 is L0 { method tag { 'L1' } }
+class L2 is L1 { }
+class L3 is L2 { method tag { 'L3' } method only3 { 'o3' } }
+
+# 1. Most-derived override wins through a deep chain.
+is L3.new.tag, 'L3', 'most-derived override resolves through 4 levels';
+
+# 2. A method inherited from the top is found through the whole chain.
+is L3.new.only0, 'o0', 'top-level inherited method resolves through deep MRO';
+
+# 3. A mid-level instance resolves to the nearest ancestor definition.
+is L2.new.tag, 'L1', 'mid-level instance resolves to nearest ancestor (L1, skipping L2 gap)';
+
+# 4. .^mro reflects the full linearization order.
+is L3.^mro.map(*.^name).head(4).join(','), 'L3,L2,L1,L0',
+    '.^mro order is the full C3 linearization';
+
+# 5. Constructor BUILD runs through the MRO (BUILD probing uses mro_readonly).
+my $built = '';
+class B0 { submethod BUILD { $built ~= '0' } }
+class B1 is B0 { submethod BUILD { $built ~= '1' } }
+class B2 is B1 { submethod BUILD { $built ~= '2' } }
+B2.new;
+is $built, '012', 'BUILD submethods run for every class in the MRO';
+
+# 6. isa across the deep chain.
+ok L3.new ~~ L0, 'deep-chain instance smartmatches its top ancestor type';


### PR DESCRIPTION
## Summary

`mro_readonly` rebuilt the ancestor list with a BFS on **every call**: a fresh `HashSet` + queue, and — because `class_parents_readonly` already returns the whole `class_def.mro` when present — it re-cloned the full MRO `Vec` at every node, i.e. **O(N²) string clones** for an N-deep hierarchy.

It runs on hot paths: the constructor probes `BUILD` / `TWEAK` / `:D|:U` smiley via `mro_readonly` (**3× per `.new`**), and dispatch/resolution walk it too. This was a major source of the `_int_free`/allocation traffic in the method-call / class profiles.

### Fix

When the registry already holds the precomputed C3 MRO (`class_def.mro` non-empty), that `Vec` **is** the full ancestor list in order (its first element is the class itself), so return it with a single clone.

**Equivalence with the BFS** (why this is safe): the BFS seeds `result = [class_name]`, the first pop expands `class_parents_readonly(class_name) == class_def.mro`, and every later node is already visited — so the result is exactly `class_def.mro`. The BFS fallback is kept for built-in/unregistered classes and registered classes whose MRO has not been computed yet.

### Results (release, machine-quiet, best-of-7)

| benchmark | before | after |
|---|---|---|
| method-call | 0.31s | **0.24s** |
| bench-class | 0.66s | **0.54s** |

Cumulative with #3853 / #3857 this campaign: **method-call 0.44→0.24s (~45%)**, **bench-class 0.80→0.54s (~33%)**. `mro_readonly` and its allocation traffic drop out of the method-call profile.

- `make test` passes (12847 tests); S12/S14 class/role roast tests pass.
- New test `t/deep-mro-dispatch.t` guards deep-hierarchy resolution, `.^mro` order, `BUILD` ordering, and isa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)