### PR TITLE
fix(interp): a string-interpolation block's outer-variable side effects persist

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -46,6 +46,9 @@ impl Compiler {
                 custom_traits,
                 ..
             } => {
+                // Record this inline declaration (`(my $x = ...)`, `(state $a)`)
+                // for an enclosing scope-isolating do-block.
+                self.record_block_decl(name);
                 let is_dynamic = *ast_is_dynamic || self.var_is_dynamic(name);
                 // my $x = expr in expression context -> declare, assign, return value
                 if *is_state {

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -181,6 +181,8 @@ impl Compiler {
                         ..
                     } => {
                         // my $x = expr in block-final position: declare and return value
+                        // Record for an enclosing scope-isolating do-block.
+                        self.record_block_decl(name);
                         let is_dynamic = *ast_is_dynamic || self.var_is_dynamic(name);
                         let name_idx = self.code.add_constant(Value::Str(name.clone().into()));
                         self.code.emit(OpCode::SetVarDynamic {

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -42,6 +42,7 @@ impl Compiler {
                 body_end: 0,
                 label: label.clone(),
                 scope_isolate: false,
+                isolate_decls_idx: u32::MAX,
             });
             let saved = self.push_dynamic_scope_lexical();
             self.compile_phaser_block_scope(body, true);
@@ -53,6 +54,7 @@ impl Compiler {
             body_end: 0,
             label: label.clone(),
             scope_isolate: false,
+            isolate_decls_idx: u32::MAX,
         });
         self.compile_block_inline(body);
         self.code.patch_body_end(idx);
@@ -63,8 +65,30 @@ impl Compiler {
             body_end: 0,
             label: label.clone(),
             scope_isolate: true,
+            isolate_decls_idx: u32::MAX,
         });
+        // Record every `my`/`state` declaration compiled in the body (including
+        // ones nested in expressions like `(state $a)++` and ones shadowing an
+        // outer same-name) so the scope-isolating exit reverts exactly those
+        // while letting OUTER-variable mutations persist. A nested closure
+        // compiles in a fresh `Compiler`, so it never contributes here.
+        self.block_decl_tracker.push(Vec::new());
         self.compile_block_inline(body);
+        let mut decls = self.block_decl_tracker.pop().unwrap_or_default();
+        // Hashes are intentionally NOT isolated: a `my %h` (e.g.
+        // `:into(my %h := :{})`) must survive into the enclosing scope.
+        decls.retain(|n| !n.starts_with('%') && !n.starts_with('&'));
+        if !decls.is_empty() {
+            let decls_idx = self.code.add_constant(Value::array(
+                decls.into_iter().map(Value::str).collect::<Vec<_>>(),
+            ));
+            if let OpCode::DoBlockExpr {
+                isolate_decls_idx, ..
+            } = &mut self.code.ops[idx]
+            {
+                *isolate_decls_idx = decls_idx;
+            }
+        }
         self.code.patch_body_end(idx);
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -44,6 +44,14 @@ pub(crate) struct Compiler {
     /// prefix at compile time, since the runtime does not get a
     /// PackageScope opcode for unit declarations.
     pub(crate) in_unit_package: bool,
+    /// When `Some`, every `my`/`state` variable declaration compiled while the
+    /// stack-top frame is active is recorded here. A scope-isolating do-block
+    /// expression (e.g. a string-interpolation `{...}`) uses this to learn the
+    /// names it declares — including ones nested in expressions (`(state $a)++`)
+    /// or shadowing an outer same-name — so its isolating exit reverts exactly
+    /// those while letting OUTER-variable mutations persist. A nested closure
+    /// compiles in a fresh `Compiler` (own scope) so it never pollutes this.
+    pub(crate) block_decl_tracker: Vec<Vec<String>>,
     /// The kind of package (`module`/`package`/`grammar`) whose body is
     /// currently being compiled, or `None` in the mainline. Used to raise
     /// X::Attribute::Package when a `has` attribute is declared in a
@@ -149,6 +157,7 @@ impl Compiler {
             compiled_functions: HashMap::new(),
             current_package: "GLOBAL".to_string(),
             in_unit_package: false,
+            block_decl_tracker: Vec::new(),
             current_package_kind: None,
             enclosing_package: None,
             tmp_counter: 0,
@@ -264,6 +273,15 @@ impl Compiler {
             return format!("{sigil}{}::{}", self.current_package, &name[1..]);
         }
         format!("{}::{}", self.current_package, name)
+    }
+
+    /// Record a `my`/`state` declaration name for the innermost active
+    /// scope-isolation tracker (see `block_decl_tracker`). No-op when no
+    /// scope-isolating do-block is being compiled.
+    pub(crate) fn record_block_decl(&mut self, name: &str) {
+        if let Some(top) = self.block_decl_tracker.last_mut() {
+            top.push(name.to_string());
+        }
     }
 
     fn alloc_local(&mut self, name: &str) -> u32 {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -672,6 +672,10 @@ impl Compiler {
                 custom_traits,
                 where_constraint,
             } => {
+                // Record this declaration for an enclosing scope-isolating
+                // do-block (string-interpolation `{...}`) so it can revert
+                // exactly its own block-local declarations on exit.
+                self.record_block_decl(name);
                 // An inline `where` constraint on a scalar/sigilless variable
                 // (e.g. `my $x where * > 0`, `my Int $n where { $_ %% 2 }`,
                 // `my $v where &predicate`) is desugared into an anonymous subset

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -600,6 +600,12 @@ pub(crate) enum OpCode {
         body_end: u32,
         label: Option<String>,
         scope_isolate: bool,
+        /// Constant-pool index of a `Value::Array` of the scalar/array variable
+        /// names the block declares with `my`/`state` (sigil-keyed as stored in
+        /// env). On a `scope_isolate` exit those names revert to their pre-block
+        /// values (block-local declarations don't leak), while mutations of OUTER
+        /// variables persist. `u32::MAX` when there are none / not isolated.
+        isolate_decls_idx: u32,
     },
     OnceExpr {
         key_idx: u32,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3496,12 +3496,14 @@ impl Interpreter {
                 body_end,
                 label,
                 scope_isolate,
+                isolate_decls_idx,
             } => {
                 self.exec_do_block_expr_op(
                     code,
                     *body_end,
                     label,
                     *scope_isolate,
+                    *isolate_decls_idx,
                     ip,
                     compiled_fns,
                 )?;

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -67,12 +67,14 @@ impl Interpreter {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn exec_do_block_expr_op(
         &mut self,
         code: &CompiledCode,
         body_end: u32,
         label: &Option<String>,
         scope_isolate: bool,
+        isolate_decls_idx: u32,
         ip: &mut usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
@@ -133,25 +135,63 @@ impl Interpreter {
         // Restore scope if scope_isolate is true
         if let Some((saved_env, saved_locals)) = saved_env {
             let block_result = self.stack.pop().unwrap_or(Value::Nil);
-            // Preserve hash variables declared or re-declared inside the
-            // block so that inline `my %h` declarations (e.g. in
-            // `:into(my %h := :{})`) remain visible in the outer scope.
-            // Only hash variables are preserved to avoid side effects
-            // on other container types.
+            // Scope-isolating exit. The block isolates its OWN scalar/array `my`/
+            // `state` declarations (reverted to the pre-block value so they don't
+            // leak), but a mutation of an OUTER variable must persist —
+            // `"{ $x = 1 }"` / `"{ foo() }"` where `foo` writes an outer/`our`
+            // var. New hashes still leak (the `:into(my %h := :{})` idiom).
+            //   - declared scalar/array name (isolate set) -> revert (skip).
+            //   - other plain user var that changed            -> keep (outer mutation).
+            //   - new hash                                      -> keep (`:into`).
+            //   - internal `__mutsu_*` / specials / dynamics    -> revert.
+            // Isolate-set keyed by BARE name (sigil stripped) so it matches an env
+            // key regardless of whether that scalar/array is stored with or
+            // without its sigil (e.g. a `state $a` whose env mirror would
+            // otherwise be re-carried and pollute the next evaluation's init).
+            let strip_sigil = |n: &str| -> String {
+                n.strip_prefix(['$', '@', '%', '&'])
+                    .unwrap_or(n)
+                    .to_string()
+            };
+            let isolate_set: std::collections::HashSet<String> = if isolate_decls_idx != u32::MAX {
+                if let Value::Array(items, ..) = &code.constants[isolate_decls_idx as usize] {
+                    items
+                        .iter()
+                        .filter_map(|v| match v {
+                            Value::Str(s) => Some(strip_sigil(s.as_ref())),
+                            _ => None,
+                        })
+                        .collect()
+                } else {
+                    std::collections::HashSet::new()
+                }
+            } else {
+                std::collections::HashSet::new()
+            };
+            let is_plain_user_var = |name: &str| -> bool {
+                if name.starts_with("__") {
+                    return false;
+                }
+                let body = name.strip_prefix(['$', '@', '%', '&']).unwrap_or(name);
+                if body.starts_with(['*', '!', '.', '?']) || body == "_" {
+                    return false;
+                }
+                body.chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+            };
             let current_env = self.env().clone();
             let mut new_vars: Vec<(Symbol, Value)> = Vec::new();
             for (name, value) in current_env.iter() {
-                if !name.starts_with("%") || name.starts_with("%*") {
+                let nm = name.resolve();
+                if isolate_set.contains(&strip_sigil(&nm)) {
                     continue;
                 }
-                let is_new_or_changed = match saved_env.get_sym(*name) {
-                    None => true,
-                    Some(saved_val) => match (value, saved_val) {
-                        (Value::Hash(a), Value::Hash(b)) => !std::sync::Arc::ptr_eq(a, b),
-                        _ => std::mem::discriminant(value) != std::mem::discriminant(saved_val),
-                    },
+                let keep = match saved_env.get_sym(*name) {
+                    None => nm.starts_with('%') && !nm.starts_with("%*"),
+                    Some(saved_val) => is_plain_user_var(&nm) && value != saved_val,
                 };
-                if is_new_or_changed {
+                if keep {
                     new_vars.push((*name, value.clone()));
                 }
             }

--- a/t/interp-block-outer-writeback.t
+++ b/t/interp-block-outer-writeback.t
@@ -1,0 +1,53 @@
+use Test;
+
+# A string-interpolation block `"{ ... }"` may mutate an OUTER (or `our`)
+# variable, and that side effect must persist — while the block still isolates
+# its OWN `my`/`state` declarations (they don't leak, even when shadowing an
+# outer same-name or nested in an expression). Regression:
+# integration/advent2012-day10.t, and the scope-isolating do-block writeback.
+
+plan 9;
+
+# outer scalar mutated directly inside the interp block -> persists
+{
+    my $p = "init";
+    my $s = "[{ $p = "hi"; "X" }]";
+    is $s, "[X]", "interp block value";
+    is $p, "hi", "outer scalar mutation inside interp block persists";
+}
+
+# outer `our` mutated via a sub called from the interp block -> persists
+{
+    our $Prompt;
+    sub ask($t) { $Prompt = $t; "Q" }
+    my $s = "{ ask 'name?' }";
+    is $s, "Q", "interp sub-call value";
+    is $Prompt, "name?", "our var written by sub in interp block persists";
+}
+
+# inner `my` shadowing an outer same-name is isolated
+{
+    my $n = 1;
+    is "$n {my $n = 2} $n", "1 2 1", "inner my shadow does not leak";
+}
+
+# inner `my` does not leak at all
+{
+    my $r = "{ my $z = 9; $z }";
+    is $r, "9", "inner my block value";
+    nok (try { $z }).defined, "inner my does not leak to outer scope";
+}
+
+# `state` declared inside an interp block in nested loops is per-instance
+{
+    my @arr;
+    for ^2 { for ^2 { @arr.push("{ (state $a)++ }") } }
+    is @arr.join(","), "0,0,0,0", "state var in interp block uses block scope";
+}
+
+# `:into(my %h)` hash declaration still survives (must NOT be isolated)
+{
+    my @data = <a b a c b a>;
+    my %h := @data.classify({ $_ }, :into(my %dest));
+    is %dest.keys.sort.join(","), "a,b,c", ":into(my %h) hash still leaks out";
+}


### PR DESCRIPTION
A `"{ ... }"` interpolation block compiles to a scope-isolating do-block expression whose exit restored the whole saved env (re-adding only new/changed hashes), so a mutation of an **OUTER** (or `our`) variable inside the block was silently discarded:

```raku
my $p = "init";
"{ $p = "hi" }";
say $p;          # was: init ;  now: hi
```

## Fix
The isolating exit now reverts ONLY the block's own `my`/`state` declarations (so they don't leak) while letting outer-variable mutations persist. The crux is knowing exactly which names the block declares: the compiler records every `my`/`state` declaration compiled within the block (`block_decl_tracker`), which captures decls nested in expressions (`(state $a)++`) and ones **shadowing** an outer same-name — cases an AST scan or env-diff cannot reliably distinguish from an outer mutation. Hash declarations stay un-isolated so the `:into(my %h := :{})` idiom keeps leaking its hash.

## Verified
- `"$n {my $n=2} $n"` → `1 2 1` (inner shadow isolated)
- `state`-in-interp / `:into(my %h)` behaviour preserved
- Greens `integration/advent2012-day10.t` test 9
- `make test` + **701 whitelisted roast files** regression-clean (this is a high-blast-radius scope area)
- Test: `t/interp-block-outer-writeback.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)