### PR TITLE
perf(dispatch): cache single-candidate methods to skip per-call MRO walk

### DIFF
--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -180,6 +180,7 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
     }
 
     pub(crate) fn push_block_scope_depth(&mut self) {

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -268,6 +268,62 @@ impl Interpreter {
     /// Set up a method dispatch frame for nextsame/callsame support.
     /// Returns true if a frame was pushed (caller must call pop_method_dispatch).
     /// Also pushes a samewith context unconditionally for samewith() support.
+    /// True if `(class, method)` has >= 2 *structural* dispatch candidates across
+    /// the MRO — i.e. enough overloads that `push_method_dispatch_frame` might build
+    /// a deferral (`nextsame`/`callsame`) frame. Counts the same defs
+    /// `resolve_all_methods_with_owner` iterates (non-private; submethods only at
+    /// the receiver level) but BEFORE arg-matching and without cloning, so the
+    /// result depends only on the registry shape and is memoized in
+    /// `dispatch_multi_candidate`. A `false` answer lets the caller skip the full
+    /// per-call resolve: arg-matching only reduces the count, so <=1 structural
+    /// candidate can never yield >=2 matched candidates (no frame is ever pushed).
+    pub(crate) fn has_multiple_dispatch_candidates(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+    ) -> bool {
+        let class_sym = crate::symbol::Symbol::intern(class_name);
+        let method_sym = crate::symbol::Symbol::intern(method_name);
+        if let Some(&c) = self.dispatch_multi_candidate.get(&(class_sym, method_sym)) {
+            return c;
+        }
+        let mro = self.class_mro(class_name);
+        let mut count = 0usize;
+        'outer: for cn in &mro {
+            let is_ancestor = cn != class_name;
+            let registry = self.registry();
+            let overloads = registry
+                .classes
+                .get(cn.as_str())
+                .and_then(|c| c.methods.get(method_name))
+                .or_else(|| {
+                    registry
+                        .roles
+                        .get(cn.as_str())
+                        .and_then(|r| r.methods.get(method_name))
+                });
+            if let Some(overloads) = overloads {
+                for def in overloads {
+                    if def.is_private {
+                        continue;
+                    }
+                    // Submethods are NOT inherited (mirrors resolve_all_methods_with_owner).
+                    if def.is_my && is_ancestor {
+                        continue;
+                    }
+                    count += 1;
+                    if count >= 2 {
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        let multi = count >= 2;
+        self.dispatch_multi_candidate
+            .insert((class_sym, method_sym), multi);
+        multi
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -278,6 +334,15 @@ impl Interpreter {
         // Always push samewith context so samewith() can find the method name/invocant
         self.samewith_context_stack
             .push((method_name.to_string(), Some(invocant.clone())));
+        // Fast path: a name with at most one *structural* dispatch candidate across
+        // the MRO can never produce a deferral frame (arg-matching only reduces the
+        // candidate count), so skip the per-call `resolve_all_methods_with_owner`
+        // MRO walk + MethodDef clones. The structural shape depends only on
+        // (class, method), so it is memoized in `dispatch_multi_candidate` and
+        // invalidated with the other method caches on any registry change.
+        if !self.has_multiple_dispatch_candidates(receiver_class, method_name) {
+            return false;
+        }
         let all_candidates = self.resolve_all_methods_with_owner(receiver_class, method_name, args);
         // Fast path: with zero or one candidate there is nothing to defer to, so no
         // dispatch frame is ever pushed (the single candidate is the chosen one and

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1493,6 +1493,15 @@ pub struct Interpreter {
     /// (i.e. cacheable in `multi_resolve_cache`). Computed once by scanning the MRO
     /// candidates for value-dependent constraints.
     pub(crate) multi_type_cacheable: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
+    /// Memoized `(class, method) -> does this name have >= 2 structural dispatch
+    /// candidates across the MRO` (counting overloads BEFORE arg-matching).
+    /// `false` means the name resolves to at most one candidate, so
+    /// `push_method_dispatch_frame` can skip the per-call `resolve_all_methods_with_owner`
+    /// MRO walk + MethodDef clones entirely (a single/zero candidate never produces
+    /// a deferral frame regardless of args — arg-matching only reduces the count).
+    /// Structural (registry-shape) only, so it is sound to key on `(class, method)`
+    /// and is cleared with the other method caches on any registry change.
+    pub(crate) dispatch_multi_candidate: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
     pub(crate) block_declared_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2054,6 +2054,7 @@ impl Interpreter {
             fast_method_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -322,6 +322,7 @@ impl Interpreter {
             fast_method_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -29,6 +29,7 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
@@ -64,6 +65,7 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
         // Slice F: write imported symbols through to the caller's local slots
         // (import_module recorded their names); keeps an imported `constant c`
         // coherent without the reverse pull. This op holds the outer `code`.
@@ -90,6 +92,7 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
@@ -112,6 +115,7 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -193,6 +193,7 @@ impl Interpreter {
                 self.fast_method_cache.clear();
                 self.multi_resolve_cache.clear();
                 self.multi_type_cacheable.clear();
+                self.dispatch_multi_candidate.clear();
                 // Record `&`-sigil parameter names so calls to a same-named routine
                 // inside this sub bypass the name-keyed light-call caches (the param
                 // can shadow a package sub of the same name).

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -51,6 +51,7 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::ClassDecl {
             name,


### PR DESCRIPTION
## What

`push_method_dispatch_frame` ran `resolve_all_methods_with_owner` on **every method call** — an MRO walk that looks up each ancestor in the (String-keyed) registry, arg-matches every overload, and clones the matched `MethodDef`s into a `Vec` — only to early-return when the candidate count is `<= 1` (the overwhelmingly common single-method case, which never produces a `nextsame`/`callsame` deferral frame).

Memoize, per `(class, method)` interned-`Symbol` pair, whether the name has **>= 2 structural dispatch candidates** across the MRO (counting the same defs the resolver iterates — non-private, submethods only at the receiver level — but **before** arg-matching and without cloning). When the cached answer is "<= 1 candidate", `push_method_dispatch_frame` returns immediately, skipping the full resolve.

## Soundness

- Arg-matching only **reduces** the candidate count, so a name with <= 1 structural candidate can never yield >= 2 matched candidates → no deferral frame is ever pushed regardless of args.
- The structural shape depends only on the registry, so the cache is keyed on `(class, method)` and **cleared with the other method caches at every registry-mutation site** (`method_resolve_cache.clear()` siblings).
- Names with >= 2 structural candidates fall through to the unchanged arg-dependent resolve.

Cache is an `FxHashMap` (consistent with the dispatch caches in #3867).

## Measured (instructions retired, `perf stat`, single P-core pinned — deterministic, load-independent)

| benchmark | baseline (post-#3867) | branch | reduction |
|---|---|---|---|
| method-call (300k iters) | 73.9B | 70.0B | **-5.2%** |
| bench-class | 4.170B | 4.022B | **-3.5%** |

Cumulative with #3867 from pre-campaign main: method-call **-12.2%**, bench-class **-7.6%**.

## Validation

- `make test`: PASS (Files=1304, Tests=12884)
- deferral unit tests: `nextsame-rw-redispatch` / `method-redispatch-compiled` / `single-candidate-dispatch-fast-path` / `samewith` / `wrap` / `proto-vm-dispatch` / `multi-otf-dispatch` / `proto-nontrivial-body-vm` all PASS
- 30 whitelisted S12/S14/multi/inheritance roast tests PASS
- full `make roast` delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)