### PR TITLE
fix(interp): native shaped typed arrays (whitelist +3)

### DIFF
--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -44,44 +44,30 @@
   - Partial. Same Positional/.of/OOB-default/mutating-map improvements apply.
     Native num `array[num]` Range slice-assign (`@arr[^3] = ...`) now expands
     the range so values distribute per element.
-- [ ] roast/S09-typed-arrays/native-shape1-int.t
-  - Partial. Shaped native `:exists` is now range-based, `:delete` throws
-    X::Delete, OOB-in-range reads return the element default, and mutating map
-    works. `flat` now splices native shaped arrays (PR #3725). Tests 2/5
-    (`Positional[int]`) are `#?rakudo todo`.
-  - **EARLY ABORT (blocks ~1000 of 1110: only ~101 run).** The per-type `for
-    flat @int,@uint -> $T` loop aborts in iteration 1 at the "List-assign …
-    surrounded by literals" block (~line 158): `my @untyped = @native` makes
-    `@untyped` *hold* a shaped value, then `@untyped = flat 0,@native,11` is
-    wrongly re-clamped to that held shape (5) by the re-shape-on-reassign logic
-    in `vm_var_assign_ops.rs` (~line 6659, `shaped_array_shape(&self.locals[idx])`
-    && !assigned_has_own_shape → clamp), so `@untyped[10]` is out of range and
-    aborts the whole loop.
-  - **Fix attempts (all reverted — this is genuinely entangled):**
-    1. Gate the re-shape on the `__mutsu_shaped_array_dims::@x` env key alone:
-       clears the abort (1042→320) but regresses `my @s[3]; @s = 1,2,3` — the key
-       is recorded ONLY for `:=` binds (my_decl_assign.rs ~676), not for `my @s[3]`
-       declarations, so a declared shape with a *list* assignment loses its shape.
-    2. Also record `__mutsu_shaped_array_dims` at the `my @s[3]` decl sites (wrap
-       the VarDecl in a SyntheticBlock with the record call) THEN gate: STILL
-       regresses `my @s[3]; @s = 1,2,3` → `(*)` and made S09 worse (320→360). The
-       SyntheticBlock wrapping perturbs the decl, and the recorded shape isn't
-       seen by the later list-assign's SetLocal as expected.
-    3. Runtime de-shape on assign (convert a shaped RHS to plain when target not
-       declared-shaped): breaks `my @a[5]` itself — `my @a[5]` and `my @u=@native`
-       are indistinguishable at the SetLocal (both: shaped value, no dims key,
-       fresh slot, is_vardecl=true, is_bind=false).
-    The root need: a RELIABLE declared-vs-value-shaped distinction that survives
-    to the later list-assign. The dims-key mechanism is the intended signal but is
-    set inconsistently and read at a SetLocal that can't see the just-declared
-    shape. Needs careful, tested work across the decl paths + the re-shape site;
-    `flat`-of-native (PR #3725) is the only clean shaped-array win so far.
-  - Remaining (post-abort) failures: grep/first :p/:kv, .pairup/.antipairs,
-    .pick/.roll, .raku formatting, type-checked push/assign exceptions, slices.
-- [ ] roast/S09-typed-arrays/native-shape1-num.t
-  - Partial (101+ run, was 49). Same shaped-array improvements as shape1-int.
-- [ ] roast/S09-typed-arrays/native-shape1-str.t
-  - Partial. Same shaped-array improvements; native str default is empty string.
+- [x] roast/S09-typed-arrays/native-shape1-int.t
+  - PASS (1110/1110). The early-abort and all residual failures are fixed.
+- [x] roast/S09-typed-arrays/native-shape1-num.t
+  - PASS (333/333).
+- [x] roast/S09-typed-arrays/native-shape1-str.t
+  - PASS (112/112).
+  - **Resolution.** The "declared-vs-value-shaped" distinction that the earlier
+    reverted attempts needed turned out to be unnecessary; the entanglement was
+    four separate bugs:
+    1. `my @untyped = @native` inherited the shaped value. Fix: in the `=`
+       (non-bind) array-assign path, when the LHS slot is unshaped and the RHS
+       is shaped, drop shaped-ness to a plain growable Array (Raku `=` copies
+       VALUES; `:=` still preserves the shape). This removes the early abort.
+    2. A flat 1-dim shaped array dropped its cached `ArrayData.shape` crossing
+       the `env_dirty` dual store, so a re-assignment shrank it. Fix:
+       `shaped_array_shape` recovers `[len]` for any flat `ArrayKind::Shaped`.
+    3. `@arr = (...)` used as an *expression* (`is (@arr = ()), ...`) compiles to
+       `AssignExprLocal`, which lacked the shaped-LHS reshape that the statement
+       `SetLocal` path had. Fix: add the same reshape (preferring whichever store
+       holds a shaped value, since locals/env can diverge).
+    4. The reshape padded with `Nil`; native arrays must pad with the element
+       type's default (`int`→0, `num`→0e0, `str`→""). Fix: pad via
+       `typed_container_default`. Also `@a[0,1]` on a *1-dim* shaped array is a
+       slice (only *multi*-dim shaped routes a comma-list to multidim access).
 - [ ] roast/S09-typed-arrays/native-str.t
   - Partial. Positional/.of improvements apply. Remaining: grep :p, pop/shift
     on empty native array dies with the right X:: type, .raku formatting.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -563,6 +563,9 @@ roast/S09-typed-arrays/hashes.t
 roast/S09-typed-arrays/native-decl.t
 roast/S09-typed-arrays/native-int.t
 roast/S09-typed-arrays/native-num.t
+roast/S09-typed-arrays/native-shape1-int.t
+roast/S09-typed-arrays/native-shape1-num.t
+roast/S09-typed-arrays/native-shape1-str.t
 roast/S09-typed-arrays/native-str.t
 roast/S09-typed-arrays/native.t
 roast/S10-packages/export.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1003,6 +1003,12 @@ impl Compiler {
                     // can allow overwriting immutable containers (e.g. Blob)
                     // when the local slot is reused across loop iterations.
                     self.code.emit(OpCode::MarkVarDeclContext);
+                    // A shaped declaration (`my @a[5] = ...`) keeps its declared
+                    // shape; mark it so SetLocal does not strip the shape the way
+                    // an unshaped value-copy (`my @u = @shaped`) does.
+                    if custom_traits.iter().any(|(t, _)| t == "__shaped_decl") {
+                        self.code.emit(OpCode::MarkShapedDeclContext);
+                    }
                     // For % variables with QuantHash `is` traits, skip hash coercion
                     // so the trait handler gets the raw array/list value.
                     let has_quant_hash_trait = name.starts_with('%')

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -141,6 +141,11 @@ pub(crate) enum OpCode {
     /// Mark that the next SetLocal is from a `my` VarDecl (allows overwriting
     /// immutable Blob containers when the local slot is reused in a loop).
     MarkVarDeclContext,
+    /// Mark that the next SetLocal declares a *shaped* (fixed-dimension) array
+    /// (`my @a[5]`, `my int @a[3;3] = ...`). The shape comes from the declaration
+    /// itself, so SetLocal must KEEP it (unlike `my @u = @shaped`, which copies
+    /// values and drops shaped-ness).
+    MarkShapedDeclContext,
     SetVarType {
         name_idx: u32,
         tc_idx: u32,

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -289,6 +289,9 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         {
             custom_traits.push(("__has_initializer".to_string(), None));
         }
+        if s.shape_dims.is_some() {
+            custom_traits.push(("__shaped_decl".to_string(), None));
+        }
         let mut feed = expr;
         {
             let slot = crate::parser::feed_leftmost_operand_mut(&mut feed);
@@ -319,6 +322,7 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         }
         return Ok((rest, stmt));
     }
+    let is_shaped_decl = s.shape_dims.is_some();
     let expr = if let Some(dims) = s.shape_dims {
         shaped_array_new_with_data_expr(dims, expr)
     } else {
@@ -330,6 +334,12 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         .any(|(name, _)| name == "__has_initializer")
     {
         custom_traits.push(("__has_initializer".to_string(), None));
+    }
+    // A shaped declaration (`my @a[5] = ...`) keeps its declared shape; mark it so
+    // SetLocal does not strip the shape the way a value-copy (`my @u = @shaped`)
+    // does.
+    if is_shaped_decl {
+        custom_traits.push(("__shaped_decl".to_string(), None));
     }
     let base_stmt = Stmt::VarDecl {
         name: s.name.clone(),
@@ -376,6 +386,9 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         .any(|(name, _)| name == "__has_initializer")
     {
         custom_traits.push(("__has_initializer".to_string(), None));
+    }
+    if is_shaped_decl {
+        custom_traits.push(("__shaped_decl".to_string(), None));
     }
     let stmt = Stmt::VarDecl {
         name: s.name.clone(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1417,6 +1417,10 @@ pub struct Interpreter {
     pub(crate) element_share_pending: bool,
     pub(crate) explicit_initializer_context: bool,
     pub(crate) vardecl_context: bool,
+    /// Set by `MarkShapedDeclContext` before a `SetLocal` whose `my @a[N]` /
+    /// `my @a[N;M] = ...` declaration is itself shaped — so the assignment KEEPS
+    /// the shape instead of dropping it as a value copy (`my @u = @shaped` does).
+    pub(crate) shaped_decl_context: bool,
     /// Slice F (env<->locals coherence): the caller-variable *source* names that
     /// the most recent compiled-function return wrote back via an `is rw` /
     /// `is raw` / aliased-container parameter (`apply_rw_bindings_to_env`). The

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2032,6 +2032,7 @@ impl Interpreter {
             element_share_pending: false,
             explicit_initializer_context: false,
             vardecl_context: false,
+            shaped_decl_context: false,
             pending_rw_writeback_sources: Vec::new(),
             pending_caller_var_writeback: Vec::new(),
             local_bind_pairs: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -300,6 +300,7 @@ impl Interpreter {
             element_share_pending: false,
             explicit_initializer_context: false,
             vardecl_context: false,
+            shaped_decl_context: false,
             pending_rw_writeback_sources: Vec::new(),
             pending_caller_var_writeback: Vec::new(),
             local_bind_pairs: Vec::new(),

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -72,6 +72,14 @@ pub(crate) fn shaped_array_shape(value: &Value) -> Option<Vec<usize>> {
     {
         return Some(cached_shape.clone());
     }
+    // A flat (1-dim) shaped array's shape is unambiguously `[len]`. Recover it
+    // even when the cached `ArrayData.shape` was dropped crossing a store
+    // boundary (the dual-store sync does not always carry it), so a re-assignment
+    // (`@arr = ...` after an earlier `@arr = ...`) still sees the array as shaped
+    // and refills to its fixed dimension instead of silently shrinking.
+    if items.iter().all(|v| !matches!(v, Value::Array(..))) {
+        return Some(vec![items.len()]);
+    }
     let inferred_shape = infer_shape_from_array(items.as_ref())?;
     if !shape_matches_structure(value, &inferred_shape) {
         return None;

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1389,6 +1389,10 @@ impl Interpreter {
                 self.vardecl_context = true;
                 *ip += 1;
             }
+            OpCode::MarkShapedDeclContext => {
+                self.shaped_decl_context = true;
+                *ip += 1;
+            }
 
             // -- String --
             OpCode::Concat => {

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -105,13 +105,28 @@ impl Interpreter {
             }
         } else if name.starts_with('@') {
             let mut assigned = runtime::coerce_to_array(raw_val);
-            // Check for shaped array on current value, and preserve on re-assignment
-            let current_val = code
+            // Check for shaped array on current value, and preserve on re-assignment.
+            // The local slot and the env copy of a variable can diverge (the
+            // `env_dirty` dual store): a method call between two assignments may
+            // flush an unshaped copy into one store while the other still holds
+            // the shaped array. A shaped array's shape is authoritative, so prefer
+            // whichever store currently presents a shaped value; otherwise fall
+            // back to the local slot (then env). Without this, an `@arr = (...)`
+            // used as an expression (`is (@arr = ()), ...`) reads the stale
+            // unshaped local and silently shrinks a fixed-dimension array.
+            let local_val = code
                 .locals
                 .iter()
                 .position(|n| n == &name)
-                .and_then(|idx| self.locals.get(idx).cloned())
-                .or_else(|| self.get_env_with_main_alias(&name));
+                .and_then(|idx| self.locals.get(idx).cloned());
+            let env_val = self.get_env_with_main_alias(&name);
+            let is_shaped = |v: &Value| crate::runtime::utils::shaped_array_shape(v).is_some();
+            let current_val = match (&local_val, &env_val) {
+                (Some(l), _) if is_shaped(l) => local_val.clone(),
+                (_, Some(e)) if is_shaped(e) => env_val.clone(),
+                (Some(_), _) => local_val.clone(),
+                _ => env_val.clone(),
+            };
             let current_shape = current_val
                 .as_ref()
                 .and_then(crate::runtime::utils::shaped_array_shape)

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -179,6 +179,47 @@ impl Interpreter {
                     )?;
                 }
             }
+            // Preserve a shaped (fixed-dimension) LHS across an expression-context
+            // reassignment (`is (@arr = ()), ...`), mirroring the statement-form
+            // `SetLocal` path: a fixed-dimension array refills to its dimension
+            // instead of shrinking. The local slot and the env copy can diverge
+            // (the `env_dirty` dual store), so consult whichever currently holds a
+            // shaped value.
+            let lhs_shape =
+                crate::runtime::utils::shaped_array_shape(&self.locals[idx]).or_else(|| {
+                    self.get_env_with_main_alias(name)
+                        .as_ref()
+                        .and_then(crate::runtime::utils::shaped_array_shape)
+                });
+            let assigned_has_own_shape = crate::runtime::utils::shaped_array_shape(&assigned)
+                .is_some()
+                || matches!(&assigned, Value::Array(_, crate::value::ArrayKind::Shaped));
+            if let Some(shape) = &lhs_shape
+                && shape.len() == 1
+                && !assigned_has_own_shape
+            {
+                let items = runtime::value_to_list(&assigned);
+                let item_count = items.len();
+                let mut shaped_items: Vec<Value> = items.into_iter().take(shape[0]).collect();
+                if item_count < shape[0] {
+                    // Pad with the element type's default (native arrays: int->0,
+                    // num->0e0, str->""), not Nil, so clearing a shaped num array
+                    // yields `0 0 0 0` rather than empty slots.
+                    let default = {
+                        let old = self.locals[idx].clone();
+                        self.typed_container_default(&old)
+                    };
+                    Self::autoviv_resize(&mut shaped_items, shape[0], default)?;
+                }
+                assigned = Value::Array(
+                    Arc::new(crate::value::ArrayData::new(shaped_items)),
+                    crate::value::ArrayKind::Shaped,
+                );
+                crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
+                if let Some(info) = self.container_type_metadata(&self.locals[idx]) {
+                    assigned = self.tag_container_metadata(assigned, info);
+                }
+            }
             assigned
         } else {
             Self::normalize_scalar_assignment_value(raw_val)

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -82,6 +82,7 @@ impl Interpreter {
         let is_constant = self.constant_context;
         let has_explicit_initializer = self.explicit_initializer_context;
         let is_vardecl = self.vardecl_context;
+        let is_shaped_decl = self.shaped_decl_context;
         let scalar_bind = self.scalar_bind_context;
         let array_share = self.array_share_context;
         self.bind_context = false;
@@ -91,6 +92,7 @@ impl Interpreter {
         self.array_share_context = false;
         self.explicit_initializer_context = false;
         self.vardecl_context = false;
+        self.shaped_decl_context = false;
         // Slice 2a/2b: `$scalar = @arr` / `$scalar = %hash` / chained `$r = $q`
         // promotes the source container to a shared `ContainerRef` cell (raku
         // reference semantics). Handled before the decont marker and fast/slow
@@ -711,6 +713,8 @@ impl Interpreter {
                     assigned = self.tag_container_metadata(assigned, info);
                 }
             } else if !is_bind
+                && !is_shaped_decl
+                && (has_explicit_initializer || !is_vardecl)
                 && lhs_shape.is_none()
                 && assigned_has_own_shape
                 && let Value::Array(items, _) = &assigned
@@ -721,6 +725,9 @@ impl Interpreter {
                 // Array (`.shape` is `(*)`), so a later `@u = ...` is not
                 // truncated to the original fixed dimension. Binding (`:=`)
                 // keeps the shaped value, so this is guarded on `!is_bind`.
+                // A *shaped declaration* (`my @a[5]`) has no RHS initializer —
+                // its shaped value comes from the `[5]` spec, not a source array —
+                // so `has_explicit_initializer || !is_vardecl` keeps that shape.
                 let items = if items.shape.is_some() {
                     let mut data = (**items).clone();
                     data.shape = None;

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -683,7 +683,8 @@ impl Interpreter {
             let assigned_has_own_shape = crate::runtime::utils::shaped_array_shape(&assigned)
                 .is_some()
                 || matches!(&assigned, Value::Array(_, crate::value::ArrayKind::Shaped));
-            if let Some(shape) = crate::runtime::utils::shaped_array_shape(&self.locals[idx])
+            let lhs_shape = crate::runtime::utils::shaped_array_shape(&self.locals[idx]);
+            if let Some(shape) = &lhs_shape
                 && shape.len() == 1
                 && !assigned_has_own_shape
             {
@@ -691,17 +692,43 @@ impl Interpreter {
                 let item_count = items.len();
                 let mut shaped_items: Vec<Value> = items.into_iter().take(shape[0]).collect();
                 if item_count < shape[0] {
-                    Self::autoviv_resize(&mut shaped_items, shape[0], Value::Nil)?;
+                    // Pad with the element type's default (native arrays: int->0,
+                    // num->0e0, str->""), not Nil, so clearing a shaped num array
+                    // yields `0 0 0 0` rather than empty slots.
+                    let default = {
+                        let old = self.locals[idx].clone();
+                        self.typed_container_default(&old)
+                    };
+                    Self::autoviv_resize(&mut shaped_items, shape[0], default)?;
                 }
                 assigned = Value::Array(
                     std::sync::Arc::new(crate::value::ArrayData::new(shaped_items)),
                     crate::value::ArrayKind::Shaped,
                 );
-                crate::runtime::utils::mark_shaped_array(&assigned, Some(&shape));
+                crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
                 // Preserve container type metadata
                 if let Some(info) = self.container_type_metadata(&self.locals[idx]) {
                     assigned = self.tag_container_metadata(assigned, info);
                 }
+            } else if !is_bind
+                && lhs_shape.is_none()
+                && assigned_has_own_shape
+                && let Value::Array(items, _) = &assigned
+            {
+                // The LHS is a plain (non-shaped) `@` array but the RHS is a
+                // shaped array. Raku `=` copies element VALUES and drops
+                // shaped-ness: `my @u = @shaped` yields a growable unshaped
+                // Array (`.shape` is `(*)`), so a later `@u = ...` is not
+                // truncated to the original fixed dimension. Binding (`:=`)
+                // keeps the shaped value, so this is guarded on `!is_bind`.
+                let items = if items.shape.is_some() {
+                    let mut data = (**items).clone();
+                    data.shape = None;
+                    std::sync::Arc::new(data)
+                } else {
+                    items.clone()
+                };
+                assigned = Value::Array(items, crate::value::ArrayKind::Array);
             }
             let class_name = match &self.locals[idx] {
                 Value::Instance { class_name, .. } => Some(*class_name),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -604,11 +604,14 @@ impl Interpreter {
                 }
             }
             (target @ Value::Array(..), Value::Array(indices, ..)) => {
-                // A comma-list index (`@a[0,1]`) is always a positional slice,
-                // EXCEPT on shaped arrays where it is multi-dimensional access
-                // (`@a[0;1]` uses MultiDimIndex, a separate opcode). A plain
-                // array-of-arrays is NOT shaped, so it slices.
-                let is_shaped = crate::runtime::utils::is_shaped_array(&target);
+                // A comma-list index (`@a[0,1]`) is a positional slice, EXCEPT on
+                // a MULTI-dimensional shaped array where it is partial-dimension
+                // access (`@a[0;1]` true multidim uses MultiDimIndex, a separate
+                // opcode). On a *1-dim* shaped array `@a[0,1]` is an ordinary
+                // slice (raku: `array[str].new(:shape(4),...)[0,2]` is `("m","a")`),
+                // and a plain array-of-arrays is not shaped at all — both slice.
+                let is_shaped =
+                    crate::runtime::utils::shaped_array_shape(&target).is_some_and(|s| s.len() > 1);
                 if !is_shaped {
                     // Positional slice: @a[0,1,2] returns (@a[0], @a[1], @a[2]).
                     // An array-valued subscript is ALWAYS a slice, so a single


### PR DESCRIPTION
## Summary

Fixes the **shaped native typed array** campaign (BLOCKERS §1.4). `array[T].new(:shape(N), ...)` fixed-dimension arrays had four entangled bugs that together blocked three roast files — `native-shape1-int.t` ran only **101 of 1110** tests before aborting.

All three now pass fully and are whitelisted:
- `native-shape1-int.t` — 1110/1110
- `native-shape1-num.t` — 333/333
- `native-shape1-str.t` — 112/112

## The four bugs

1. **`my @untyped = @native` inherited the shape** → a later `@untyped = flat 0, @native, 11` was re-clamped to the held dimension, and indexing past it aborted the whole per-type loop. Raku `=` copies element VALUES into a *growable unshaped* Array (`:=` binding preserves the shape). The `=` array-assign path now drops shaped-ness when the LHS slot is itself unshaped.

2. **A flat 1-dim shaped array lost its cached `ArrayData.shape`** crossing the `env_dirty` dual store, so re-assignment silently shrank it. `shaped_array_shape` now recovers the unambiguous `[len]` for any flat `ArrayKind::Shaped` array.

3. **`@arr = (...)` as an expression** (`is (@arr = ()), ...`) compiles to `AssignExprLocal`, which lacked the shaped-LHS reshape the statement-form `SetLocal` path had. Added it, preferring whichever store currently holds a shaped value (locals/env can diverge).

4. **The reshape padded with `Nil`**; native arrays must pad with the element type's default (`int`→0, `num`→0e0, `str`→""). Padding now uses `typed_container_default`. Also `@a[0,1]` on a *1-dim* shaped array is an ordinary slice — only *multi*-dim shaped routes a comma-list to partial-dimension access.

## Testing

- `native-shape1-{int,num,str}.t` pass fully and are added to `roast-whitelist.txt` (sorted).
- No regression in whitelisted array tests (`arrays`, `native-{int,num,str}`, `hashes`, `S32-array/adverbs`) or `cargo test` (477 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)