### PR TITLE
fix(types): out-of-scope `my` class/role no longer resolves as a type

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -156,6 +156,21 @@
 - [ ] roast/S32-exceptions/misc.t
   - 153/180 pass (plan 182; 27 fail, 2 not-run). This is a very broad
     compile-time-error/exception file covering ~40 distinct features.
+  - **2026-06-28: test 49 done (X::Parameter::BadType)** — a `my`-scoped
+    class/role/enum whose enclosing block has exited was still resolvable as a
+    *type* (only the bare-word path consulted `suppressed_names`). An earlier
+    test's `{ my class A is Any {...} }` block leaked `A` into the cloned
+    registry, so the later `sub foo(A $a)` saw `A` as a valid type and never
+    reached the BadType branch. `has_type` / `is_resolvable_type` /
+    `is_declared_package` now return false for a suppressed bare name (FQ names
+    and later re-declarations are unaffected). General fix: out-of-scope
+    `my`-types no longer resolve. t/lexical-type-scope-suppression.t.
+  - test 48 (X::Syntax::Variable::BadType) still fails: the same nested eval
+    re-declares `my package A {}` while a *leaked* `my class A` remains in the
+    cloned `registry().classes`. Un-suppressing on the package re-declaration
+    would re-expose the stale class to `has_type`; properly removing the leaked
+    class on block exit is risky (escaped instances rely on name-based registry
+    lookup). Deferred — needs scope-qualified class storage or registry removal.
   - **2026-06-27 (PR #3710): test 167 done** — a bare *type-only* parameter
     naming an undeclared type (`sub x(RT123926Floo)`) is now
     X::Parameter::InvalidType (attr `typename`). `validate_param_type_constraints`

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -11,6 +11,15 @@ impl Interpreter {
     /// of a generic "not declared" error. A `class`/`role`/`enum`/`subset` is a
     /// real type and is NOT recorded here (it goes through the class registry).
     pub(crate) fn is_declared_package(&self, name: &str) -> bool {
+        // A `my`-scoped package/class whose enclosing block has exited is in
+        // `suppressed_names`: out of lexical scope it is no longer a declared
+        // package under its bare short name (a later re-declaration un-suppresses
+        // it). Without this, `{ my class A {} }; my A $x` would report the
+        // in-scope "insufficiently type-like" BadType instead of raku's
+        // "Type 'A' is not declared".
+        if !name.contains("::") && self.is_name_suppressed(name) {
+            return false;
+        }
         self.chain_declared_packages.contains(name)
             || matches!(self.env.get(name), Some(Value::Package(_)))
     }

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -254,6 +254,14 @@ impl Interpreter {
 
     /// Check if a type name is known (either a class, role, or enum).
     pub(crate) fn has_type(&self, name: &str) -> bool {
+        // A `my`-scoped class/role/enum whose enclosing block has exited is moved
+        // into `suppressed_names`: once out of lexical scope it is no longer a
+        // visible type under its bare short name (raku: "Type 'A' is not declared"
+        // after the block). Fully-qualified names (`Foo::Bar`) are never suppressed
+        // through this mechanism, and a later re-declaration un-suppresses the name.
+        if !name.contains("::") && self.is_name_suppressed(name) {
+            return false;
+        }
         if self.has_type_direct(name) {
             return true;
         }
@@ -380,6 +388,12 @@ impl Interpreter {
         } else {
             base
         };
+        // A `my`-scoped user type whose enclosing block has exited is suppressed
+        // and no longer resolvable under its bare short name (built-in types are
+        // never suppressed, so this never hides a core type). Mirrors `has_type`.
+        if !base.contains("::") && self.is_name_suppressed(base) {
+            return false;
+        }
         // Check built-in types
         if matches!(
             base,

--- a/t/lexical-type-scope-suppression.t
+++ b/t/lexical-type-scope-suppression.t
@@ -1,0 +1,25 @@
+use Test;
+
+# A `my`-scoped class is lexically scoped to its enclosing block. Once the
+# block exits, the name is no longer a visible *type* (not just no longer a
+# bare term). Previously only the bare-word path honoured the suppression, so
+# an out-of-scope `my class` still resolved as a type constraint.
+
+plan 3;
+
+# After the block, `A` is undeclared as a type, not silently accepted.
+# (Previously the out-of-scope `my class` still resolved as a type and the
+# `my A $x` declaration was accepted with no error.)
+throws-like '{ my class A is Any { } }; my A $x;', X::Comp,
+    'out-of-scope my class is not a type for a variable declaration';
+
+# A freshly-declared package used as a type is still BadType (the suppression
+# fix must not mask the in-scope "insufficiently type-like" diagnostic).
+throws-like 'my package P { }; sub g(P $x) { }', X::Parameter::BadType,
+    'in-scope package used as parameter type is BadType';
+
+# A class that is still in scope resolves normally.
+{
+    my class InScope { method tag { 'ok' } }
+    is InScope.new.tag, 'ok', 'in-scope my class resolves and works';
+}


### PR DESCRIPTION
## What

A `my`-scoped class/role/enum is lexically scoped to its enclosing block. On block exit mutsu moves the name into `suppressed_names`, but only the **bare-word** resolution path consulted that set — the **type**-resolution path (`has_type` / `is_resolvable_type` / `is_declared_package`) did not.

So an out-of-scope `my class A` still resolved as a valid type constraint:

```raku
{ my class A is Any { } }; my A $x;   # mutsu: silently accepted
                                       # raku:  "Type 'A' is not declared"
```

## Why it matters (roast)

This surfaced as a cross-eval state leak in `S32-exceptions/misc.t`: an earlier test's `{ my class A is Any {...} }` block leaked `A` into the registry that a later `throws-like` clones, so `sub foo(A $a)` saw `A` as a type and never reached the `X::Parameter::BadType` branch. **Fixes test 49.**

## Fix

Make `has_type` / `is_resolvable_type` / `is_declared_package` return `false` for a suppressed **bare** name. Fully-qualified names are never suppressed through this mechanism, a later re-declaration un-suppresses the name, and built-in types are never suppressed — so no core type is ever hidden. In-scope nested-class access still works via the existing `resolve_suppressed_type` path.

## Tests

- `t/lexical-type-scope-suppression.t` (new): out-of-scope `my class` is not a type; in-scope package is still `X::Parameter::BadType`; in-scope `my class` still resolves.
- `make test` green (477 unit + `t/` suite, no regressions).

## Not fixed (documented in `TODO_roast/S32.md`)

test 48 still fails: a leaked `my class A` co-exists with a re-declared `my package A` in the same nested eval; removing leaked classes from the registry risks escaped instances (name-based dispatch). Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)