### PR TITLE
docs(roast): record qualified parameterized-role dispatch root-cause

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -158,6 +158,37 @@
       (b) `$?ROLE`/`$?CLASS` returning parameterized type names (e.g. `R1[Int]`, `R2[Num]`);
       (c) relaxed qualified calls returning multiple slipped concretizations
       (`self.R2::of-type` yielding `R2`, `R1[Bool]`, ...). Substantial parameterized-role work.
+    - **Minimal root-cause reproducer for the qualified-dispatch facet (session 43):**
+      ```
+      my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ "/" ~ ($b ~~ Nil ?? "NIL" !! $b.^name) }
+      my role R1[::T] { method of-type { ts($?ROLE, T) } }
+      my role R1     { method of-type { ts($?ROLE) } }
+      my class C1 does R1[Int] { method of-type { ("C1", self.R1::of-type) } }
+      say C1.new.of-type;   # mutsu: (C1 R1/NIL)   raku: (C1 R1/Int)
+      ```
+      The qualified call `self.R1::of-type` (method name `"R1::of-type"`) resolves the
+      owner from the bare qualifier `R1` and, because BOTH a parameterized `R1[::T]` and
+      an unparameterized `R1` register their `of-type` under the name `R1`, it picks the
+      UNPARAMETERIZED `R1`'s method (`ts($?ROLE)` -> "R1/NIL") instead of the
+      concretization the receiver actually consumed (`R1[Int]`, whose `T` would bind to
+      `Int` -> "R1/Int"). It only misfires when both same-named roles coexist: drop the
+      unparameterized `R1`, or call via a differently-named method, and it is correct.
+      Confirmed via isolation: `C1.^roles».^name` is `(R1[Int])`, so mutsu DOES know the
+      consumed concretization (`role_concretizations_at_nearest("C1","R1")` -> {"R1[Int]"}).
+      **Attempted fix (reverted, session 43):** remapping the bare qualifier `R1` to the
+      concretization `R1[Int]` in `dispatch_qualified_instance_method` does NOT work —
+      `resolve_method_with_owner("R1[Int]", "of-type")` finds nothing because a
+      parameterized role's methods register under the SHORT name `R1`, not under the
+      concretization name. So the real fix is harder: among the same-named-`R1` method
+      overloads (both `R1[::T].of-type` and `R1.of-type`), the qualified resolution must
+      SELECT the one belonging to the concretization the receiver consumed (likely via
+      `role_origin`/a concretization tag on the `MethodDef`) AND bind its type parameter
+      `T` (the binding lives under the consuming class `C1` in `class_role_param_bindings`,
+      keyed `T`, not under `R1`). Touches `dispatch_qualified_instance_method` (the
+      `role_origin == qualifier` fallback already exists but doesn't disambiguate
+      parameterized vs unparameterized) + `resolve_method_with_owner` (`role_bindings` is
+      read from `class_name`=bare qualifier, so `T` is unbound). Substantial; entry point
+      for the campaign.
 - [ ] roast/S12-methods/submethods.t
 - [ ] roast/S12-methods/syntax.t
   - 2/15 pass (tests 1, 15). Failures: method call with empty parens `obj.doit()` (2), `.doit ()` with space (3), unspace `obj.doit\ ()` (4), colon form `obj.doit: args` (5-9), block as arg (10-12), `$.a(args)` (13-14). Difficulty: Medium-High (method call syntax variants)


### PR DESCRIPTION
## Summary

Records the precise root-cause + a minimal reproducer for the remaining failure in `S12-methods/qualified.t` subtest 6 ("parameterizations and inheritance"), per the CLAUDE.md rule to document deferral reasons in `TODO_roast/`.

### The bug (one facet of subtest 6)

```raku
my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ "/" ~ ($b ~~ Nil ?? "NIL" !! $b.^name) }
my role R1[::T] { method of-type { ts($?ROLE, T) } }
my role R1     { method of-type { ts($?ROLE) } }
my class C1 does R1[Int] { method of-type { ("C1", self.R1::of-type) } }
say C1.new.of-type;   # mutsu: (C1 R1/NIL)   raku: (C1 R1/Int)
```

`self.R1::of-type` resolves the owner from the bare qualifier `R1`. Because both a parameterized `R1[::T]` and an unparameterized `R1` register `of-type` under the short name `R1`, mutsu picks the unparameterized one (`T` unbound) instead of the concretization the receiver consumed (`R1[Int]`, `T`=Int). It only misfires when both same-named roles coexist.

### Attempted fix (reverted)

Remapping the bare qualifier `R1` → concretization `R1[Int]` fails: parameterized-role methods register under the **short** name `R1`, so `resolve_method_with_owner("R1[Int]", …)` finds nothing. The real fix must select, among the same-named-`R1` overloads, the one belonging to the consumed concretization (via `role_origin`/a concretization tag) **and** bind `T` (the binding lives under the consuming class in `class_role_param_bindings`). Documented as the campaign entry point — substantial parameterized-role work.

Docs-only; no code or whitelist changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)