### PR TITLE
docs(roast): sharpen qualified parameterized-role root-cause

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -189,6 +189,24 @@
       parameterized vs unparameterized) + `resolve_method_with_owner` (`role_bindings` is
       read from `class_name`=bare qualifier, so `T` is unbound). Substantial; entry point
       for the campaign.
+    - **Sharper finding (session 43, follow-up): the blocker is specifically the
+      TWO-same-named-roles case.** With only the parameterized role present
+      (`role R1[::T]` and no unparameterized `role R1`), `C1 does R1[Int]` with a
+      `method of-type` that OVERRIDES the role's, calling `self.R1::of-type`, ALREADY
+      WORKS on main — the role copy stays reachable and `T` binds (`C1-OWN | ROLE-T=Int`).
+      It only breaks when an unparameterized `role R1` ALSO exists: then `self.R1::of-type`
+      resolves to that unparameterized `R1`'s `of-type` (`ts($?ROLE)` -> "R1/NIL") instead
+      of the consumed `R1[Int]` concretization. So the missing piece is **same-name role
+      disambiguation in the qualified `R1::` lookup** (pick the concretization the receiver
+      consumed among same-base-name roles), NOT a general "class override drops the role
+      copy" problem (that theory was disproved — the single-role override case works).
+      Two reverted dead-ends this session: (1) remapping the qualifier to the
+      concretization name — methods register under the short name; (2) preferring the
+      class's composed copy in `dispatch_qualified_instance_method` + a `retain` change in
+      `registration_class_decl.rs` to keep role-composed copies — neither changed the
+      two-role outcome (the class only stores its OWN `of-type` overload; the role copy for
+      that name is not in `C1.methods` when two same-named roles coexist, so the registry
+      path picks the unparameterized `R1`).
 - [ ] roast/S12-methods/submethods.t
 - [ ] roast/S12-methods/syntax.t
   - 2/15 pass (tests 1, 15). Failures: method call with empty parens `obj.doit()` (2), `.doit ()` with space (3), unspace `obj.doit\ ()` (4), colon form `obj.doit: args` (5-9), block as arg (10-12), `$.a(args)` (13-14). Difficulty: Medium-High (method call syntax variants)


### PR DESCRIPTION
## Summary

Follow-up to #3874. Sharpens the `S12-methods/qualified.t` subtest-6 root-cause analysis:

- The blocker is specifically the **two-same-named-roles** case. A single `role R1[::T]` whose method a class overrides and calls via `self.R1::of-type` **already works on main** (`T` binds → `C1-OWN | ROLE-T=Int`).
- It only breaks when an unparameterized `role R1` **also** exists: `self.R1::of-type` then resolves to the unparameterized `R1` (`ts($?ROLE)` → "R1/NIL") instead of the consumed `R1[Int]` concretization.
- So the missing piece is **same-name role disambiguation in the qualified `R1::` lookup**, not a "class override drops the role copy" problem (that theory was disproved).
- Records two reverted dead-ends (qualifier→concretization remap; prefer-class-composed-copy + a `retain` change) so the next session doesn't repeat them.

Docs-only; no code or whitelist changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)