### PR TITLE
fix(parser): emit X::Syntax::Malformed::Elsif for `else if`

### DIFF
--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -201,6 +201,19 @@ fn lower_else_binding(source_binding: &str, else_clause: ElseClause) -> Vec<Stmt
     vec![Stmt::Expr(call_expr)]
 }
 
+/// `else if` is a C-ism; Raku spells it `elsif`. Raise the dedicated
+/// `X::Syntax::Malformed::Elsif` with Raku's exact diagnostic message.
+fn malformed_elsif_error() -> PError {
+    let msg = "In Raku, please use \"elsif' instead of \"else if\"".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+    let ex = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Syntax::Malformed::Elsif"),
+        attrs,
+    );
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 pub(crate) fn parse_elsif_chain(
     input: &str,
 ) -> PResult<'_, (Vec<IfChainClause>, Option<ElseClause>)> {
@@ -290,6 +303,12 @@ pub(crate) fn parse_elsif_chain(
 
     if let Some(r) = keyword("else", rest) {
         let (r, _) = ws(r)?;
+        // `else if ...` is the C-style spelling of `elsif`; Raku rejects it with a
+        // dedicated, helpful diagnostic (X::Syntax::Malformed::Elsif) rather than a
+        // generic "expected '{'" parse error.
+        if keyword("if", r).is_some() {
+            return Err(malformed_elsif_error());
+        }
         let (r, binding_params) = parse_if_binding_params(r)?;
         let (r, _) = ws(r)?;
         let (r, mut body) = block(r)?;

--- a/t/malformed-elsif.t
+++ b/t/malformed-elsif.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 6;
+
+# `else if` is a C-ism; Raku spells it `elsif` and rejects `else if` with a
+# dedicated X::Syntax::Malformed::Elsif diagnostic.
+throws-like
+    'if 10 > 5 { say "a" } else if 10 == 5 { say "b" } else { say "c" }',
+    X::Syntax::Malformed::Elsif,
+    'else if is rejected with X::Syntax::Malformed::Elsif';
+
+throws-like
+    'if 1 { } else if 2 { }',
+    X::Syntax::Malformed::Elsif,
+    message => /elsif/,
+    'diagnostic message mentions elsif';
+
+# `else if` after an elsif chain is still caught.
+throws-like
+    'if 0 { } elsif 0 { } else if 1 { }',
+    X::Syntax::Malformed::Elsif,
+    'else if after an elsif chain is rejected';
+
+# Legitimate spellings keep working.
+lives-ok
+    { EVAL 'my $x = 3; if $x == 1 { } elsif $x == 3 { } else { }' },
+    'if/elsif/else parses fine';
+
+is
+    (EVAL 'my $x = 3; if $x == 1 { "one" } elsif $x == 3 { "three" } else { "other" }'),
+    'three',
+    'elsif chain selects the right branch';
+
+# A bare identifier starting with "if" inside the else block is not mistaken
+# for `else if`.
+is
+    (EVAL 'my $ifx = 9; if 0 { 1 } else { $ifx }'),
+    9,
+    'an else block referencing an "if"-prefixed name is fine';


### PR DESCRIPTION
## What

`else if` is a C-ism; Raku spells it `elsif`. Previously mutsu rejected `else if` with a generic `expected '{'` parse error (surfaced as `X::AdHoc`), whereas Raku raises the dedicated `X::Syntax::Malformed::Elsif` with the helpful message:

```
In Raku, please use "elsif' instead of "else if"
```

(the asymmetric quoting is Raku's actual message, reproduced verbatim.)

## How

In the elsif-chain parser, when `else` is immediately followed by the `if` keyword, return a fatal parse error carrying a structured `X::Syntax::Malformed::Elsif` exception. The type was already present in the known-type table, so smartmatch (`$_ ~~ X::Syntax::Malformed::Elsif`) works.

This is unambiguous: `else` is otherwise always followed by `{` or a `-> $x {` binding, so there are no false positives (covered by a test for an `if`-prefixed identifier inside an `else` block).

## Impact

- Unblocks the `else if` case in `roast/S32-exceptions/misc.t`.
- New test: `t/malformed-elsif.t` (6 subtests).
- `make test` passes; if/unless/with roast tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)