### PR TITLE
fix(class): flatten a slip/Seq bound to an `@`-attribute into an Array

### DIFF
--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -297,6 +297,23 @@ impl Interpreter {
         // path is byte-identical. The gate already excluded `is Type` containers
         // and native/parametric element types, so only plain class elements reach
         // here. Done against the final `attrs` Arcs that move into the instance.
+        // A `|@x` slip (or a `Seq`) passed to an `@`-sigiled attribute
+        // (`:items(|@x)`) arrives as a `Slip`/`Seq`. Assigning a list to a `@`
+        // container flattens it (just like `my @a = |@x` yields an `Array`, not a
+        // `Slip`), so materialize it into a plain mutable `Array` here. Without
+        // this the attribute keeps a `Slip` whose `.^name` is `Slip`.
+        for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
+            if *sigil != '@' {
+                continue;
+            }
+            if let Some(Value::Slip(items) | Value::Seq(items)) = attrs.get(attr_name) {
+                let flattened = Value::Array(
+                    std::sync::Arc::new(crate::value::ArrayData::new((**items).clone())),
+                    crate::value::ArrayKind::Array,
+                );
+                attrs.insert(attr_name.clone(), flattened);
+            }
+        }
         for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
             if !matches!(sigil, '@' | '%') {
                 continue;

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1477,6 +1477,25 @@ impl Interpreter {
                         return Err(constructor_positional_error(&class_name.resolve()));
                     }
                 }
+                // A `|@x` slip (or a `Seq`) passed to an `@`-sigiled attribute
+                // (`:backends(|@x)`) arrives as a `Slip`/`Seq`. Assigning a list to a
+                // `@` container flattens it (just like `my @a = |@x` yields an
+                // `Array`, not a `Slip`), so materialize it into a plain mutable
+                // `Array` here. Without this the attribute keeps a `Slip` whose
+                // `.^name` is `Slip` and whose re-iteration differs from raku's `Array`.
+                for (attr_name, _is_public, _default, _is_rw, _is_required, sigil, _) in
+                    &class_attrs_info
+                {
+                    if *sigil == '@'
+                        && let Some(Value::Slip(items) | Value::Seq(items)) = attrs.get(attr_name)
+                    {
+                        let flattened = Value::Array(
+                            std::sync::Arc::new(crate::value::ArrayData::new((**items).clone())),
+                            ArrayKind::Array,
+                        );
+                        attrs.insert(attr_name.clone(), flattened);
+                    }
+                }
                 // For @-sigiled attributes with shaped array declarations,
                 // convert user-provided values to shaped arrays preserving shape.
                 for (attr_name, _is_public, default, _is_rw, _is_required, sigil, _) in

--- a/t/slip-to-array-attribute.t
+++ b/t/slip-to-array-attribute.t
@@ -1,0 +1,30 @@
+use Test;
+
+# A `|@x` slip (or a Seq) passed to an `@`-sigiled attribute is flattened into
+# the array container, exactly like `my @a = |@x` yields an Array (not a Slip).
+# Surfaced by zef: `Zef::Fetch.new(:backends(|%config<Fetch>))` left `@.backends`
+# as a one-shot Slip whose `.^name` was `Slip` instead of `Array`.
+
+plan 8;
+
+class Simple { has @.b }          # default constructor path
+class Complex { has @.b; submethod TWEAK {} }   # full dispatch_new path
+
+my @x = (1, 2, 3);
+
+is Simple.new(:b(|@x)).b.^name, 'Array', 'slip into @-attr is Array (default ctor)';
+is Simple.new(:b(|@x)).b.elems, 3, 'slip into @-attr keeps all elements';
+is-deeply Simple.new(:b(|@x)).b.List, (1, 2, 3), 'slip into @-attr has correct elements';
+
+is Complex.new(:b(|@x)).b.^name, 'Array', 'slip into @-attr is Array (dispatch_new)';
+
+# A Seq is likewise materialized into the array.
+is Simple.new(:b((1, 2).Seq)).b.^name, 'Array', 'Seq into @-attr is Array';
+
+# Re-iteration works (an Array, unlike a one-shot Slip, can be walked twice).
+my $c = Complex.new(:b(|@x));
+is $c.b.elems, 3, 'first read of @-attr';
+is $c.b.elems, 3, 'second read of @-attr (re-iterable)';
+
+# A plain array argument is unchanged.
+is Simple.new(:b([4, 5])).b.^name, 'Array', 'plain array @-attr stays Array';


### PR DESCRIPTION
## What

`:items(|@x)` passes a `Slip` as the named-arg value (and a `Seq` can reach an attribute the same way). Assigning a list to a `@`-sigiled container flattens it in Raku — `my @a = |@x` yields an `Array`, not a `Slip` — but the object-construction paths stored the slip/Seq verbatim:

```raku
class C { has @.b }
my @x = (1, 2, 3);
say C.new(:b(|@x)).b.^name;   # mutsu: Slip   raku: Array
```

## Fix

Materialize a `Slip`/`Seq` value for an `@`-attribute into a plain mutable `Array` in **both** constructor paths — the native default ctor (`methods_object_default_ctor.rs`) and the full `dispatch_new` (`methods_object_dispatch_new.rs`). Typed `@`-attributes (`has Int @.b`) still tag their element type after the flatten; plain-array and empty-default attributes are unchanged.

## Why it matters

Surfaced by the zef north-star: `Zef::Fetch.new(:backends(|%config<Fetch>))` left `@.backends` as a `Slip` whose `.^name` and re-iteration semantics diverge from raku's `Array`. (Note: this is a genuine general correctness fix; it is *not* the cause of the separate `zef list/locate` `try-load(Any)` blocker, which remains under investigation.)

## Tests

- `t/slip-to-array-attribute.t` (new, 8 subtests): slip/Seq into `@`-attr → Array, on both ctor paths, with re-iteration and plain-array regression checks.
- `make test` green (477 unit + 12902 `t/` tests, Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)