### PR TITLE
fix(roles): qualified call resolves to consumed parameterized concretization

### DIFF
--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -127,6 +127,50 @@ impl Interpreter {
                 }
             }
         }
+        // When the qualifier names a parametric role base that the receiver
+        // consumed under exactly ONE concretization (`class C1 does R1[Int]`),
+        // resolve the method from THAT concretization's role definition rather
+        // than the by-name `roles` map. Two same-named roles (a parameterized
+        // `R1[::T]` and an unparameterized `R1`) collide in `roles`, so the map
+        // holds only the last-declared one and `resolve_method_with_owner` below
+        // can pick the wrong (unparameterized) variant — leaving the type
+        // parameter `T` unbound. Running the resolved method with the receiver
+        // class as `receiver_class_name` binds the consumed `T` (`=Int`) from the
+        // class's role-param bindings. The >1-concretization (ambiguous) case is
+        // rejected above.
+        if self.registry().roles.contains_key(qualifier) {
+            let concs = self.role_concretizations_at_nearest(&inst_cn_str, qualifier);
+            if concs.len() == 1 {
+                let conc = concs.into_iter().next().unwrap();
+                if conc.contains('[')
+                    && let Ok(Some((role_def, _tparams, _tvals))) =
+                        self.resolve_role_candidate(&conc)
+                    && let Some(overloads) = role_def.methods.get(actual_method).cloned()
+                {
+                    for def in overloads {
+                        if !def.is_private && self.method_args_match(&args, &def.param_defs) {
+                            let attrs_map = attributes.to_map();
+                            let inst_cn = inst_cn_str.to_string();
+                            let (result, updated) = match self
+                                .run_resolved_method_compiled_or_treewalk(
+                                    &inst_cn,
+                                    qualifier,
+                                    actual_method,
+                                    def,
+                                    attrs_map,
+                                    args,
+                                    Some(target.clone()),
+                                ) {
+                                Ok(v) => v,
+                                Err(e) => return Some(Err(e)),
+                            };
+                            attributes.commit_attrs(updated);
+                            return Some(Ok(result));
+                        }
+                    }
+                }
+            }
+        }
         // Try running the actual method on the qualifier class
         if let Some((_owner, method_def)) =
             self.resolve_method_with_owner(qualifier, actual_method, &args)

--- a/t/qualified-parameterized-role.t
+++ b/t/qualified-parameterized-role.t
@@ -1,0 +1,48 @@
+use Test;
+
+# A qualified call `self.Role::method` to a parameterized role must resolve to
+# the concretization the receiver consumed (binding its type parameter), even
+# when a same-named *unparameterized* role also exists (the two collide in the
+# by-name role registry).
+
+plan 4;
+
+{
+    my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ "/" ~ ($b ~~ Nil ?? "NIL" !! $b.^name) }
+    my role R1[::T] { method of-type { ts($?ROLE, T) } }
+    my role R1     { method of-type { ts($?ROLE) } }
+    my class C1 does R1[Int] {
+        method of-type { ("C1", self.R1::of-type) }
+    }
+    is-deeply C1.new.of-type, ("C1", "R1/Int"),
+        'qualified call resolves to the consumed parameterized concretization (T bound)';
+}
+
+{
+    # Different concretization over the same roles.
+    my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ "/" ~ ($b ~~ Nil ?? "NIL" !! $b.^name) }
+    my role R1[::T] { method of-type { ts($?ROLE, T) } }
+    my role R1     { method of-type { ts($?ROLE) } }
+    my class C2 does R1[Str] {
+        method of-type { ("C2", self.R1::of-type) }
+    }
+    is-deeply C2.new.of-type, ("C2", "R1/Str"),
+        'qualified call binds a different consumed type parameter';
+}
+
+{
+    # No unparameterized sibling: still works (regression guard for the common case).
+    my role R1[::T] { method of-type { "T=" ~ T.^name } }
+    my class C3 does R1[Int] {
+        method of-type { "C3 | " ~ self.R1::of-type }
+    }
+    is C3.new.of-type, "C3 | T=Int",
+        'single parameterized role + override + qualified call';
+}
+
+{
+    # A method NOT overridden by the class is still reachable via the qualifier.
+    my role R1[::T] { method who { "R1[" ~ T.^name ~ "]" } }
+    my class C4 does R1[Int] { }
+    is C4.new.who, "R1[Int]", 'unoverridden role method binds T';
+}


### PR DESCRIPTION
## Summary

First landable increment of the parameterized-role campaign (toward `S12-methods/qualified.t` subtest 6).

`self.Role::method` on an instance whose class consumed a parameterized role under exactly one concretization (`class C1 does R1[Int]`) now resolves the method from **that concretization's role definition** (binding its type parameter `T`=`Int`), instead of the by-name `roles` registry.

### The bug

Two same-named roles — a parameterized `R1[::T]` and an unparameterized `R1` — collide in the by-name `roles` map (only the last-declared survives there). So `resolve_method_with_owner("R1", …)` could pick the wrong **unparameterized** variant and leave `T` unbound:

```raku
my role R1[::T] { method of-type { ts($?ROLE, T) } }
my role R1     { method of-type { ts($?ROLE) } }
my class C1 does R1[Int] { method of-type { ("C1", self.R1::of-type) } }
say C1.new.of-type;   # was (C1 R1/NIL), now (C1 R1/Int)
```

### Fix

In `dispatch_qualified_instance_method`, when the qualifier is a role the receiver consumed under exactly one concretization, resolve via `role_concretizations_at_nearest` (already used for the ambiguity check) + `resolve_role_candidate`, and run with the receiver class as `receiver_class_name` so `T` binds from the class's role-param bindings. Guarded to the single-concretization parametric case; the ambiguous (>1) case is still rejected, and non-parametric / single-role dispatch is unchanged.

### Tests
- `t/qualified-parameterized-role.t` (4 cases): consumed concretization binds T, different T, single-role override, unoverridden role method.
- No regression across whitelisted S14-roles / S12-methods / S12-subset / S14-traits tests.

Remaining for subtest 6 (next increments): role-to-role `::T` forwarding (`R2[::T] does R1[::T]`), `$?ROLE`/`$?CLASS` parameterized names, multi-concretization slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)