### PR TITLE
feat(roles): role-to-role ::T forwarding + per-concretization qualified dispatch

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -152,12 +152,31 @@
     into the consumer as an independent candidate (registration_class.rs).
   - Remaining failure:
     - "parameterizations and inheritance" (subtest 6): stacks several distinct features.
-      `my class CR2 does R1[Set]` inside a role is now accepted (was rejected as our-scoped),
-      but the subtest still needs: (a) role-to-role type-parameter forwarding in role
-      application (`role R2[::T] does R1[::T]` -> "cannot use ::T in role application");
-      (b) `$?ROLE`/`$?CLASS` returning parameterized type names (e.g. `R1[Int]`, `R2[Num]`);
-      (c) relaxed qualified calls returning multiple slipped concretizations
-      (`self.R2::of-type` yielding `R2`, `R1[Bool]`, ...). Substantial parameterized-role work.
+      **Progress (session 43, PRs #3878 + #3879):**
+      - (a) role-to-role `::T` forwarding (`role R2[::T] does R1[::T]`) no longer errors
+        at declaration — DONE.
+      - same-named-role qualified dispatch (`self.R1::of-type` with both `R1[::T]` and
+        `R1` defined) now resolves to the consumed concretization with `T` bound — DONE
+        (`role_concretizations_at_nearest` + `class_direct_composed_roles` +
+        per-concretization binding + context-relative resolution from inside a
+        forwarding role). The first stanza of subtest 6 (`C1.new.of-type` ->
+        `(C1 R1[Int] R2[Num] R1[Num])`) now works in isolation.
+      **Still failing — the full subtest aborts in `C2`/`CR2`/`C3` setup:**
+      - **(NEXT) same-named-role group at the `role_parents` level.** With BOTH an
+        unparameterized `role R2 does R1[Bool]` and a parameterized
+        `role R2[::T] does R1[::T]`, `role_parents["R2"]` MERGES both variants'
+        parents = `["R1[Bool]", "R1[::T]"]`. So when `class C2 is C1 does R2` (the
+        UNPARAMETERIZED R2) resolves `self.R1::*`, `role_concretizations_at_nearest`
+        descends into `R2` and sees two R1 concretizations -> spurious
+        "Ambiguous concretization lookup for R1". The per-variant parents ARE stored
+        (each `RoleCandidateDef.parents`), so the fix is to make the BFS in
+        `role_concretizations_at_nearest` (methods_qualified.rs) follow the CONSUMED
+        variant's parents (resolve the queued role to its matching candidate by arity)
+        instead of the merged `role_parents`. The BFS currently pushes bare base names
+        and loses the variant — it must carry concretizations.
+      - (b) `$?ROLE`/`$?CLASS` returning parameterized type names (e.g. `R1[Int]`).
+      - `$?CLASS` inside a role-private nested class (`my class CR2 does R1[Set]` ->
+        `CR2-of-type`), and inheritance via `callsame` (the `C2`/`C3` cases).
     - **Minimal root-cause reproducer for the qualified-dispatch facet (session 43):**
       ```
       my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ "/" ~ ($b ~~ Nil ?? "NIL" !! $b.^name) }

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -143,24 +143,58 @@ impl Interpreter {
             if concs.len() == 1 {
                 let conc = concs.into_iter().next().unwrap();
                 if conc.contains('[')
-                    && let Ok(Some((role_def, _tparams, _tvals))) =
-                        self.resolve_role_candidate(&conc)
+                    && let Ok(Some((role_def, tparams, tvals))) = self.resolve_role_candidate(&conc)
                     && let Some(overloads) = role_def.methods.get(actual_method).cloned()
                 {
                     for def in overloads {
                         if !def.is_private && self.method_args_match(&args, &def.param_defs) {
                             let attrs_map = attributes.to_map();
                             let inst_cn = inst_cn_str.to_string();
-                            let (result, updated) = match self
-                                .run_resolved_method_compiled_or_treewalk(
-                                    &inst_cn,
-                                    qualifier,
-                                    actual_method,
-                                    def,
-                                    attrs_map,
-                                    args,
-                                    Some(target.clone()),
-                                ) {
+                            // Bind THIS concretization's type parameters (`T`=`Int`)
+                            // under the qualifier role name for the duration of the
+                            // call. The method body reads `T` from the role-param
+                            // bindings; the consuming class's own bindings
+                            // (`class_role_param_bindings[C1]`) are keyed by bare
+                            // param name and collide when several roles share the
+                            // name `T`, so we must use the resolved per-concretization
+                            // values instead. The run path prefers the owner's
+                            // bindings (`else if` over the receiver's), so setting
+                            // them under `qualifier` overrides the collided class
+                            // bindings. Save/restore to avoid leaking.
+                            let saved = self
+                                .registry()
+                                .class_role_param_bindings
+                                .get(qualifier)
+                                .cloned();
+                            {
+                                let bindings: std::collections::HashMap<String, Value> =
+                                    tparams.iter().cloned().zip(tvals.iter().cloned()).collect();
+                                self.registry_mut()
+                                    .class_role_param_bindings
+                                    .insert(qualifier.to_string(), bindings);
+                            }
+                            let run = self.run_resolved_method_compiled_or_treewalk(
+                                &inst_cn,
+                                qualifier,
+                                actual_method,
+                                def,
+                                attrs_map,
+                                args,
+                                Some(target.clone()),
+                            );
+                            match saved {
+                                Some(b) => {
+                                    self.registry_mut()
+                                        .class_role_param_bindings
+                                        .insert(qualifier.to_string(), b);
+                                }
+                                None => {
+                                    self.registry_mut()
+                                        .class_role_param_bindings
+                                        .remove(qualifier);
+                                }
+                            }
+                            let (result, updated) = match run {
                                 Ok(v) => v,
                                 Err(e) => return Some(Err(e)),
                             };
@@ -280,10 +314,15 @@ impl Interpreter {
         base_role: &str,
     ) -> std::collections::BTreeSet<String> {
         use std::collections::{BTreeSet, VecDeque};
-        // The consumer's directly-composed roles: classes use class_composed_roles,
-        // roles use role_parents (which records `does`-composed sub-roles).
+        // The consumer's directly-composed roles: classes use their DIRECT
+        // `does` list (NOT the transitive `class_composed_roles` closure, which
+        // would surface a concretization reached only via another role and make a
+        // directly-declared one falsely ambiguous); roles use role_parents (which
+        // records `does`-composed sub-roles, already direct).
         let direct_roles = |node: &str| -> Vec<String> {
-            if let Some(roles) = self.registry().class_composed_roles.get(node) {
+            if let Some(roles) = self.registry().class_direct_composed_roles.get(node) {
+                roles.clone()
+            } else if let Some(roles) = self.registry().class_composed_roles.get(node) {
                 roles.clone()
             } else if let Some(parents) = self.registry().role_parents.get(node) {
                 parents.clone()

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -181,10 +181,11 @@ impl Interpreter {
                     }
                 })
             };
-            if let Some(conc) = conc {
-                if conc.contains('[')
-                    && let Ok(Some((role_def, tparams, tvals))) = self.resolve_role_candidate(&conc)
-                    && let Some(overloads) = role_def.methods.get(actual_method).cloned()
+            if let Some(conc) = conc
+                && conc.contains('[')
+                && let Ok(Some((role_def, tparams, tvals))) = self.resolve_role_candidate(&conc)
+                && let Some(overloads) = role_def.methods.get(actual_method).cloned()
+            {
                 {
                     for def in overloads {
                         if !def.is_private && self.method_args_match(&args, &def.param_defs) {

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -139,9 +139,49 @@ impl Interpreter {
         // class's role-param bindings. The >1-concretization (ambiguous) case is
         // rejected above.
         if self.registry().roles.contains_key(qualifier) {
-            let concs = self.role_concretizations_at_nearest(&inst_cn_str, qualifier);
-            if concs.len() == 1 {
-                let conc = concs.into_iter().next().unwrap();
+            // Pick the concretization of the qualifier role to dispatch to.
+            // (1) Context-relative: when executing INSIDE a role method whose role
+            //     FORWARDS the qualifier (`role R2[::T] does R1[::T]`), resolve
+            //     relative to that role's forwarded parent with its current type
+            //     binding — so `self.R1::of-type` called within `R2[Num]`'s method
+            //     sees `R1[Num]`, not the receiver class's own `R1[Int]`.
+            // (2) Otherwise: the receiver's single directly-declared concretization.
+            let conc: Option<String> = {
+                let mut ctx = None;
+                if let Some(cur_role) = self.method_class_stack_top()
+                    && cur_role != qualifier
+                    && self.registry().roles.contains_key(&cur_role)
+                    && let Some(parents) = self.registry().role_parents.get(&cur_role).cloned()
+                    && let Some(parent_spec) = parents.iter().find(|p| {
+                        p.split_once('[').map(|(b, _)| b).unwrap_or(p.as_str()) == qualifier
+                    })
+                    && let Some(bindings) = self
+                        .registry()
+                        .class_role_param_bindings
+                        .get(&cur_role)
+                        .cloned()
+                {
+                    let mut spec = parent_spec.clone();
+                    for (param, val) in &bindings {
+                        spec = spec.replace(
+                            &format!("::{param}"),
+                            &super::registration_class::type_value_name(val),
+                        );
+                    }
+                    if spec.contains('[') && !spec.contains("::") {
+                        ctx = Some(spec);
+                    }
+                }
+                ctx.or_else(|| {
+                    let concs = self.role_concretizations_at_nearest(&inst_cn_str, qualifier);
+                    if concs.len() == 1 {
+                        concs.into_iter().next()
+                    } else {
+                        None
+                    }
+                })
+            };
+            if let Some(conc) = conc {
                 if conc.contains('[')
                     && let Ok(Some((role_def, tparams, tvals))) = self.resolve_role_candidate(&conc)
                     && let Some(overloads) = role_def.methods.get(actual_method).cloned()

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -390,6 +390,11 @@ impl Interpreter {
         }
         // Compose roles listed in the parents (from "does Role" or "is Role" in class header)
         let mut composed_roles_list = Vec::new();
+        // The DIRECTLY-declared role parents (one per class-header `does`/`is`
+        // role), captured before any transitive sub-role concretizations are
+        // flattened into `composed_roles_list`. Used for qualified-call
+        // concretization resolution (see `class_direct_composed_roles`).
+        let mut direct_composed_roles: Vec<String> = Vec::new();
         let mut punned_roles = Vec::new();
         let mut hidden_punned_role_bases: HashSet<String> = HashSet::new();
         let mut class_role_param_bindings: HashMap<String, Value> = HashMap::new();
@@ -424,6 +429,7 @@ impl Interpreter {
                     }
                 }
                 composed_roles_list.push(resolved_parent_name.clone());
+                direct_composed_roles.push(resolved_parent_name.clone());
                 // Look up the role's language revision for submethod composition rules.
                 let role_lang_rev = self
                     .type_metadata
@@ -797,6 +803,9 @@ impl Interpreter {
             self.registry_mut()
                 .class_composed_roles
                 .insert(name.to_string(), composed_roles_list.clone());
+            self.registry_mut()
+                .class_direct_composed_roles
+                .insert(name.to_string(), direct_composed_roles.clone());
             // Propagate `hides` from composed roles (and sub-roles) to the class
             {
                 let mut role_stack: Vec<String> = composed_roles_list

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -537,48 +537,55 @@ impl Interpreter {
                     // Use resolve_role_candidate to properly handle named
                     // arguments and default values in parameterized role
                     // composition.
-                    let type_subs: Vec<(String, String)> =
-                        if let Some((_, resolved_param_names, resolved_values)) =
+                    // `does R1[::T]` inside a parameterized role forwards this
+                    // role's type parameter into the parent role. The concrete
+                    // value of `::T` is not known until THIS role is itself
+                    // concretized, so don't resolve the parent now (that errors
+                    // with "cannot use ::T in role application"); record the
+                    // forwarding binding (parent-param -> `::T`) via the
+                    // role_type_params branch below and defer real composition to
+                    // class-application time.
+                    let forwards_type_param = role_name_str.contains("::");
+                    let type_subs: Vec<(String, String)> = if !forwards_type_param
+                        && let Some((_, resolved_param_names, resolved_values)) =
                             self.resolve_role_candidate(&role_name_str)?
+                    {
+                        // Store the resolved param bindings so they are
+                        // available when the child role is punned to a class
+                        // and methods referencing role params are dispatched.
                         {
-                            // Store the resolved param bindings so they are
-                            // available when the child role is punned to a class
-                            // and methods referencing role params are dispatched.
-                            {
-                                let mut registry = self.registry_mut();
-                                let bindings = registry
-                                    .class_role_param_bindings
-                                    .entry(name.to_string())
-                                    .or_default();
-                                for (p, v) in
-                                    resolved_param_names.iter().zip(resolved_values.iter())
-                                {
-                                    bindings.insert(p.clone(), v.clone());
-                                }
+                            let mut registry = self.registry_mut();
+                            let bindings = registry
+                                .class_role_param_bindings
+                                .entry(name.to_string())
+                                .or_default();
+                            for (p, v) in resolved_param_names.iter().zip(resolved_values.iter()) {
+                                bindings.insert(p.clone(), v.clone());
                             }
-                            resolved_param_names
+                        }
+                        resolved_param_names
+                            .iter()
+                            .zip(resolved_values.iter())
+                            .map(|(p, v)| (p.clone(), type_value_name(v)))
+                            .collect()
+                    } else if let Some(parent_type_params) =
+                        self.registry().role_type_params.get(base_role_name)
+                    {
+                        if let Some(bracket_start) = role_name_str.find('[') {
+                            let args_str =
+                                &role_name_str[bracket_start + 1..role_name_str.len() - 1];
+                            let type_args = parse_role_type_args(args_str);
+                            parent_type_params
                                 .iter()
-                                .zip(resolved_values.iter())
-                                .map(|(p, v)| (p.clone(), type_value_name(v)))
+                                .zip(type_args.iter())
+                                .map(|(p, a)| (p.clone(), a.clone()))
                                 .collect()
-                        } else if let Some(parent_type_params) =
-                            self.registry().role_type_params.get(base_role_name)
-                        {
-                            if let Some(bracket_start) = role_name_str.find('[') {
-                                let args_str =
-                                    &role_name_str[bracket_start + 1..role_name_str.len() - 1];
-                                let type_args = parse_role_type_args(args_str);
-                                parent_type_params
-                                    .iter()
-                                    .zip(type_args.iter())
-                                    .map(|(p, a)| (p.clone(), a.clone()))
-                                    .collect()
-                            } else {
-                                Vec::new()
-                            }
                         } else {
                             Vec::new()
-                        };
+                        }
+                    } else {
+                        Vec::new()
+                    };
                     for attr in &role.attributes {
                         if role_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
                             // Already present. Only a real conflict if both

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -69,8 +69,18 @@ pub(crate) struct Registry {
     pub(crate) class_trusts: HashMap<String, HashSet<String>>,
     /// Per-class metaclass (`HOW`) value override.
     pub(crate) class_how_values: HashMap<String, Value>,
-    /// Roles composed into each class: class -> [role names].
+    /// Roles composed into each class: class -> [role names]. This is the
+    /// FLATTENED set (includes roles reached transitively through a composed
+    /// role's own `does`), used for `~~`/role-membership checks.
     pub(crate) class_composed_roles: HashMap<String, Vec<String>>,
+    /// Roles DIRECTLY declared on each class's `does` list (NOT the transitive
+    /// closure): class -> [role names]. Qualified `self.Role::method` resolution
+    /// of a parametric role uses this so a concretization reached only
+    /// transitively (e.g. `R1[Num]` pulled in via `does R2[Num]` where
+    /// `R2[::T] does R1[::T]`) does not make a directly-declared `R1[Int]`
+    /// ambiguous (Raku resolves a qualified role call against the immediate
+    /// roles of the consumer).
+    pub(crate) class_direct_composed_roles: HashMap<String, Vec<String>>,
     /// Roles implicitly composed by enums: enum -> [role names].
     pub(crate) class_enum_roles: HashMap<String, Vec<String>>,
     /// Subs declared inside a class body: class -> (sub name -> value).

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -249,6 +249,8 @@ impl Interpreter {
         let hidden_classes_snapshot = self.registry().hidden_classes.clone();
         let hidden_defer_parents_snapshot = self.registry().hidden_defer_parents.clone();
         let class_composed_roles_snapshot = self.registry().class_composed_roles.clone();
+        let class_direct_composed_roles_snapshot =
+            self.registry().class_direct_composed_roles.clone();
         let class_role_param_bindings_snapshot = self.registry().class_role_param_bindings.clone();
         let env_snapshot = self.env.clone();
         let saved_topic = self.env.get("_").cloned();
@@ -363,6 +365,8 @@ impl Interpreter {
         let current_hidden_classes = self.registry().hidden_classes.clone();
         let current_hidden_defer_parents = self.registry().hidden_defer_parents.clone();
         let current_class_composed_roles = self.registry().class_composed_roles.clone();
+        let current_class_direct_composed_roles =
+            self.registry().class_direct_composed_roles.clone();
         let current_class_role_param_bindings = self.registry().class_role_param_bindings.clone();
         let current_env = self.env.clone();
         let current_type_keys: std::collections::HashSet<String> = self
@@ -387,6 +391,7 @@ impl Interpreter {
         self.registry_mut().hidden_classes = hidden_classes_snapshot;
         self.registry_mut().hidden_defer_parents = hidden_defer_parents_snapshot;
         self.registry_mut().class_composed_roles = class_composed_roles_snapshot;
+        self.registry_mut().class_direct_composed_roles = class_direct_composed_roles_snapshot;
         self.registry_mut().class_role_param_bindings = class_role_param_bindings_snapshot;
         self.registry_mut().roles.extend(current_roles);
         // Don't extend user_declared_roles: roles declared in EVAL are EVAL-scoped
@@ -411,6 +416,9 @@ impl Interpreter {
         self.registry_mut()
             .class_composed_roles
             .extend(current_class_composed_roles);
+        self.registry_mut()
+            .class_direct_composed_roles
+            .extend(current_class_direct_composed_roles);
         self.registry_mut()
             .class_role_param_bindings
             .extend(current_class_role_param_bindings);

--- a/t/qualified-role-multi-concretization.t
+++ b/t/qualified-role-multi-concretization.t
@@ -1,0 +1,50 @@
+use Test;
+
+# Qualified `self.Role::method` resolution when a class composes several
+# parameterized roles, including role-to-role type-parameter forwarding
+# (`role R2[::T] does R1[::T]`). A concretization the class declares DIRECTLY
+# (`does R1[Int]`) must resolve to that direct concretization and bind its own
+# type parameter — a same-base concretization reached only transitively (via
+# `does R2[Num]`) must not make the direct one ambiguous, and the per-role type
+# parameters must not collide. Distinct role names per case avoid the global
+# role-registry name collision between independent lexical roles.
+
+plan 4;
+
+my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ ($b ~~ Nil ?? "" !! "[" ~ $b.^name ~ "]") }
+
+{
+    my role P1[::T] { method of-type { ts($?ROLE, T) } }
+    my role P2[::T] does P1[::T] { method p2 { "P2" } }
+    my class CP does P1[Int] does P2[Num] {
+        method via-p1 { self.P1::of-type }
+    }
+    is CP.new.via-p1, "P1[Int]",
+        'directly-declared concretization wins over a transitive same-base one';
+}
+
+{
+    my role Q1[::T] { method t-name { T.^name } }
+    my role Q2[::T] does Q1[::T] { }
+    my class CQ does Q2[Str] { }
+    is CQ.new.t-name, "Str", 'role-to-role ::T forwarding composes the parent role';
+}
+
+{
+    my role A1[::T] { method a-type { ts($?ROLE, T) } }
+    my role B1[::T] { method b-type { ts($?ROLE, T) } }
+    my class CAB does A1[Int] does B1[Str] {
+        method both { (self.A1::a-type, self.B1::b-type) }
+    }
+    is-deeply CAB.new.both, ("A1[Int]", "B1[Str]"),
+        'distinct roles bind distinct type parameters without collision';
+}
+
+{
+    my role S1[::T] { method of-type { ts($?ROLE, T) } }
+    my role S2[::T] does S1[::T] { }
+    my class CS does S1[Str] does S2[Int] {
+        method via-s1 { self.S1::of-type }
+    }
+    is CS.new.via-s1, "S1[Str]", 'direct concretization resolves with its own type';
+}

--- a/t/qualified-role-multi-concretization.t
+++ b/t/qualified-role-multi-concretization.t
@@ -9,7 +9,7 @@ use Test;
 # parameters must not collide. Distinct role names per case avoid the global
 # role-registry name collision between independent lexical roles.
 
-plan 4;
+plan 5;
 
 my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ ($b ~~ Nil ?? "" !! "[" ~ $b.^name ~ "]") }
 
@@ -47,4 +47,17 @@ my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ ($b ~~ Nil ?? "" !! "[" ~ $b.^name ~ "
         method via-s1 { self.S1::of-type }
     }
     is CS.new.via-s1, "S1[Str]", 'direct concretization resolves with its own type';
+}
+
+{
+    # Context-relative resolution: `self.W1::of-type` called from INSIDE a
+    # forwarding role's method must see that role's forwarded concretization
+    # (W2[Num] forwards W1[Num]), not the receiver class's own direct W1[Int].
+    my role W1[::T] { method of-type { ts($?ROLE, T) } }
+    my role W2[::T] does W1[::T] { method from-r2 { self.W1::of-type } }
+    my class CW does W1[Int] does W2[Num] {
+        method outer { (self.W1::of-type, self.W2::from-r2) }
+    }
+    is-deeply CW.new.outer, ("W1[Int]", "W1[Num]"),
+        'qualified call resolves relative to the executing role context';
 }


### PR DESCRIPTION
## Summary

Second increment of the parameterized-role campaign (toward `S12-methods/qualified.t` subtest 6). Three coordinated pieces:

1. **`does R1[::T]` no longer errors at role declaration.** Forwarding a role's type parameter into a parent role (`role R2[::T] does R1[::T]`) previously raised "cannot use ::T in role application". The parent's concretization is now deferred (the `::T` value is unknown until the declaring role is itself concretized).

2. **`Registry::class_direct_composed_roles`** records a class's *directly-declared* `does` roles, separate from the flattened `class_composed_roles` (which also includes transitively-reached roles). Qualified-call concretization resolution uses the direct list, so `R1[Num]` reached only via `does R2[Num]` no longer makes a directly-declared `R1[Int]` falsely ambiguous (matches Raku: a qualified role call resolves against the consumer's immediate roles).

3. **Per-concretization type binding.** Qualified `self.Role::method` binds the resolved concretization's own type parameters (via `resolve_role_candidate`), instead of the consuming class's `class_role_param_bindings` — those are keyed by bare param name and collide when several composed roles share `T`.

Result: `self.R1::of-type` on `class C does R1[Int] does R2[Num]` (with `role R2[::T] does R1[::T]`) yields `R1[Int]` with `T` bound.

### Tests
- `t/qualified-role-multi-concretization.t` (4 cases): direct-vs-transitive concretization, `::T` forwarding, no `T` collision across roles.
- No regression across whitelisted S14-roles / S14-traits / S12-methods / S12-subset / S12-class / S02-types.

### Remaining for subtest 6 (next increments)
Context-relative qualified resolution from *inside* a role method (`self.R1::of-type` within `R2[Num]`'s method should see `R1[Num]`), `$?CLASS` in a role-private class, inheritance cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)