### PR TITLE
fix(interp): a my-package declaration shadows an out-of-scope same-named class

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -154,7 +154,7 @@
     on a `Failure` invocant fails dispatch into X::Multi::NoMatch rather than
     re-throwing the Failure's own exception. Deferred — broad IO blast radius.
 - [ ] roast/S32-exceptions/misc.t
-  - 153/180 pass (plan 182; 27 fail, 2 not-run). This is a very broad
+  - 155/180 pass (plan 182; 25 fail, 2 not-run). This is a very broad
     compile-time-error/exception file covering ~40 distinct features.
   - **2026-06-28: test 49 done (X::Parameter::BadType)** — a `my`-scoped
     class/role/enum whose enclosing block has exited was still resolvable as a
@@ -165,12 +165,18 @@
     `is_declared_package` now return false for a suppressed bare name (FQ names
     and later re-declarations are unaffected). General fix: out-of-scope
     `my`-types no longer resolve. t/lexical-type-scope-suppression.t.
-  - test 48 (X::Syntax::Variable::BadType) still fails: the same nested eval
-    re-declares `my package A {}` while a *leaked* `my class A` remains in the
-    cloned `registry().classes`. Un-suppressing on the package re-declaration
-    would re-expose the stale class to `has_type`; properly removing the leaked
-    class on block exit is risky (escaped instances rely on name-based registry
-    lookup). Deferred — needs scope-qualified class storage or registry removal.
+  - **2026-06-28: test 48 done (X::Syntax::Variable::BadType)** — a `my package A`
+    declaration now *shadows* a same-named class whose lexical scope already exited
+    (the name is in `suppressed_names`). `RegisterPackage`/`RegisterPackageMy` call
+    `shadow_suppressed_type_with_package`, which removes the stale out-of-scope
+    `class`/`role`/`enum`/`subset` from the registry and un-suppresses the bare
+    name, so the package becomes the active `A`: `{ my class A {} }; my package A {};
+    my A $x` now resolves `A` to the package and reports BadType instead of seeing
+    the dead class via `has_type`. Only out-of-scope (suppressed) types are removed,
+    so an in-scope same-named redeclaration is unaffected. t/lexical-type-scope-suppression.t.
+    (The parameter-type variant `{ ... }; my package A {}; sub h(A $x)` still leaks
+    because sub decls are hoisted and validated before `my package A` runs — a
+    separate hoisting-order issue, not the registry-leak one.)
   - **2026-06-27 (PR #3710): test 167 done** — a bare *type-only* parameter
     naming an undeclared type (`sub x(RT123926Floo)`) is now
     X::Parameter::InvalidType (attr `typename`). `validate_param_type_constraints`

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -140,6 +140,25 @@ impl Interpreter {
         }
     }
 
+    /// A `package`/`module` declaration with a bare `name` shadows any same-named
+    /// `class`/`role`/`enum` whose lexical scope has already exited (i.e. the name
+    /// is in `suppressed_names`). Without this, a stale out-of-scope `class A` left
+    /// in the registry keeps `has_type("A")` true, so a later `my package A {}; my A $x`
+    /// resolves `A` to the dead class and never reports X::Syntax::Variable::BadType.
+    /// Remove the stale type and un-suppress the name so the package becomes the
+    /// active `A`. Only out-of-scope (suppressed) types are removed — an in-scope
+    /// same-named class is a genuine redeclaration handled elsewhere.
+    pub(crate) fn shadow_suppressed_type_with_package(&mut self, name: &str) {
+        if name.contains("::") || !self.suppressed_names.contains(name) {
+            return;
+        }
+        self.registry_mut().classes.remove(name);
+        self.registry_mut().roles.remove(name);
+        self.registry_mut().enum_types.remove(name);
+        self.registry_mut().subsets.remove(name);
+        self.suppressed_names.remove(name);
+    }
+
     /// Mark a fully-qualified name as `my`-scoped within its parent package.
     /// Items in this set are excluded from the parent package's stash.
     pub(crate) fn mark_my_scoped_package_item(&mut self, fq_name: String) {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3228,6 +3228,7 @@ impl Interpreter {
             }
             OpCode::RegisterPackage { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
+                self.shadow_suppressed_type_with_package(&name);
                 let pkg_val = Value::Package(Symbol::intern(&name));
                 self.env_mut().insert(name.clone(), pkg_val.clone());
                 self.chain_declared_packages.insert(name.clone());
@@ -3236,6 +3237,7 @@ impl Interpreter {
             }
             OpCode::RegisterPackageMy { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
+                self.shadow_suppressed_type_with_package(&name);
                 let pkg_val = Value::Package(Symbol::intern(&name));
                 self.env_mut().insert(name.clone(), pkg_val.clone());
                 self.chain_declared_packages.insert(name.clone());

--- a/t/lexical-type-scope-suppression.t
+++ b/t/lexical-type-scope-suppression.t
@@ -5,7 +5,7 @@ use Test;
 # bare term). Previously only the bare-word path honoured the suppression, so
 # an out-of-scope `my class` still resolved as a type constraint.
 
-plan 3;
+plan 4;
 
 # After the block, `A` is undeclared as a type, not silently accepted.
 # (Previously the out-of-scope `my class` still resolved as a type and the
@@ -17,6 +17,14 @@ throws-like '{ my class A is Any { } }; my A $x;', X::Comp,
 # fix must not mask the in-scope "insufficiently type-like" diagnostic).
 throws-like 'my package P { }; sub g(P $x) { }', X::Parameter::BadType,
     'in-scope package used as parameter type is BadType';
+
+# A `my package A` declaration shadows a same-named class whose lexical scope
+# has already exited: the package becomes the active `A`, so `my A $x` reports
+# X::Syntax::Variable::BadType (package is insufficiently type-like) rather than
+# resolving to the dead, out-of-scope class.
+throws-like '{ my class A is Any { } }; my package A { }; my A $x;',
+    X::Syntax::Variable::BadType,
+    'my package shadows an out-of-scope same-named class (variable type)';
 
 # A class that is still in scope resolves normally.
 {


### PR DESCRIPTION
## What

A `my package A {}` declaration now shadows a same-named class whose lexical scope has already exited. Previously a stale, out-of-scope `class A` left in the registry kept `has_type("A")` true, so:

```raku
{ my class A is Any { } }   # block exits → A is suppressed (out of scope)
my package A { };           # declares package A
my A $x;                    # should be X::Syntax::Variable::BadType
```

resolved `A` to the dead class and reported nothing (or "Type not declared"), instead of `X::Syntax::Variable::BadType` (package is insufficiently type-like).

## How

`RegisterPackage`/`RegisterPackageMy` now call a new `shadow_suppressed_type_with_package`, which:
- removes the stale **out-of-scope** (suppressed) `class`/`role`/`enum`/`subset` from the registry, and
- un-suppresses the bare name,

so the package becomes the active `A`. Only out-of-scope (suppressed) types are removed — an in-scope same-named redeclaration is unaffected (it remains a genuine redeclaration handled elsewhere).

## Impact

- Unblocks test 48 (`X::Syntax::Variable::BadType`) in `roast/S32-exceptions/misc.t` → now **155/180**.
- Test: `t/lexical-type-scope-suppression.t` (+1 case, 4 total).
- `make test` passes; whitelisted S10/S11/S12/S14 package/class/role tests unaffected.

The parameter-type variant (`{ ... }; my package A {}; sub h(A $x)`) still leaks because sub decls are hoisted and validated before `my package A` runs — a separate hoisting-order issue, documented in `TODO_roast/S32.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)