### PR TITLE
fix(package): named subs in a package block capture the block's `my` lexicals

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1170,6 +1170,17 @@ pub struct Interpreter {
     /// by `SetGlobal` so they survive block-scope restoration (which only
     /// preserves env keys that existed before the block).
     our_vars: HashMap<String, Value>,
+    /// Package-block `my` lexicals, keyed by package name then env var name.
+    /// A named sub defined in a `package Foo { my $x = ...; sub f { $x } }` block
+    /// closes over `$x`, but mutsu's registry subs have no per-sub closure env and
+    /// resolve free vars from the call-time env; the block scope is dropped on exit
+    /// (`exec_package_scope_op`) so a by-name/exported call (`Foo::f`, an exported
+    /// `MAIN`) can no longer see `$x`. After the block runs, its `my` lexicals are
+    /// recorded here keyed by the package, and a `GetGlobal` miss falls back to
+    /// `package_lexicals[current_package]`. This fires ONLY inside that package's
+    /// subs (where `current_package == Foo`), so it does not leak the lexical to
+    /// bare references after the block (which run under `GLOBAL`).
+    pub(crate) package_lexicals: HashMap<String, HashMap<String, Value>>,
     state_vars: HashMap<String, Value>,
     /// Per-closure-instance captured-variable state, keyed by
     /// (closure instance id, captured variable Symbol). This is the hot

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1945,6 +1945,7 @@ impl Interpreter {
             strict_mode: false,
             fatal_mode: false,
             our_vars: HashMap::new(),
+            package_lexicals: HashMap::new(),
             state_vars: HashMap::new(),
             closure_captured_state: HashMap::new(),
             once_values: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -201,6 +201,7 @@ impl Interpreter {
             strict_mode: self.strict_mode,
             fatal_mode: self.fatal_mode,
             our_vars: HashMap::new(),
+            package_lexicals: self.package_lexicals.clone(),
             state_vars: HashMap::new(),
             // Mirror state_vars: a thread clone starts with no persisted
             // closure captured state (falls back to the captured-env initial

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -315,6 +315,27 @@ impl Interpreter {
                             .cloned()
                             .or_else(|| self.get_env_with_main_alias(&candidate))
                     })
+                    .or_else(|| {
+                        // Package-block `my` lexical fallback: a named sub defined in
+                        // a `package Foo { my $x = ...; sub f { $x } }` block closes
+                        // over `$x`, but the block scope is dropped on exit and named
+                        // registry subs have no per-sub closure env. When `f` runs
+                        // by-name `current_package` is `Foo`, so resolve the miss via
+                        // the per-package store recorded by `exec_package_scope_op`.
+                        // Gated on `current_package` so it never leaks to bare refs
+                        // after the block (those run under `GLOBAL`).
+                        if name.contains("::") {
+                            return None;
+                        }
+                        let cur = self.current_package().to_string();
+                        if cur.is_empty() || cur == "GLOBAL" {
+                            return None;
+                        }
+                        self.package_lexicals
+                            .get(&cur)
+                            .and_then(|m| m.get(name))
+                            .cloned()
+                    })
                     // Anonymous state variable (`$`): fall back to persisted
                     // state so the value survives across closure calls.
                     .or_else(|| self.anon_state_value(name))

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -258,11 +258,26 @@ impl Interpreter {
         let saved = self.current_package().to_string();
         let saved_env = self.env().clone();
         let saved_locals = self.locals.clone();
-        self.set_current_package(name);
+        self.set_current_package(name.clone());
         self.run_range(code, *ip + 1, body_end, compiled_fns)?;
         self.set_current_package(saved);
         let current_env = self.env().clone();
         let mut restored_env = saved_env.clone();
+        // The block's own `my` lexicals (new env keys, not package-qualified or
+        // internal) are dropped from the outer scope below (lexical scoping), but
+        // a named sub defined in this `package Foo {...}` block closes over them and
+        // is called by-name AFTER the block exits. Record them keyed by the package
+        // so a `GetGlobal` miss inside Foo's subs can fall back to them. Stored
+        // post-body, so the values reflect the block's assignments (e.g. zef's
+        // `package Zef::CLI { my $CONFIG = preprocess-args-config-mutate(...); ... }`).
+        for (k, v) in current_env.iter() {
+            if !saved_env.contains_key_sym(*k) && !k.contains_str("::") && !k.starts_with("__") {
+                self.package_lexicals
+                    .entry(name.clone())
+                    .or_default()
+                    .insert(k.resolve(), v.clone());
+            }
+        }
         for (k, v) in current_env.iter() {
             if saved_env.contains_key_sym(*k) || k.contains_str("::") {
                 restored_env.insert_sym(*k, v.clone());

--- a/t/package-block-lexical-capture.t
+++ b/t/package-block-lexical-capture.t
@@ -1,0 +1,46 @@
+use Test;
+
+# A named sub defined inside a `package`/`module` BLOCK closes over the block's
+# `my` lexicals. mutsu's registry subs have no per-sub closure env and resolve
+# free vars from the call-time env, and the block scope is dropped on exit, so a
+# by-name call (`Foo::f`) used to see the lexical as undefined. The package's
+# `my` lexicals are now recorded per-package and a variable miss inside that
+# package's subs falls back to them — without leaking to bare references after
+# the block (which run under GLOBAL).
+#
+# Surfaced by zef: `package Zef::CLI { my $CONFIG = ...; sub MAIN { ... $CONFIG } }`.
+
+plan 5;
+
+# The lexical does NOT leak to a bare reference after the block (raku scopes it):
+# evaluating such code dies. (Checked via is_run so the parse-time failure is
+# observed as a non-zero exit rather than aborting this file.)
+is_run 'package P3 { my $z = 1 }; say $z;', { status => { $_ != 0 }, err => /'not declared'/ },
+    "package-block my-lexical does not leak after the block";
+
+# Core case: by-name call to a package-block sub sees the block lexical.
+{
+    package P1 { my $X = "captured"; our sub show() { $X } }
+    is P1::show(), "captured", "package-block sub sees the block my-lexical";
+}
+
+# module block too.
+{
+    module M1 { my $Y = 42; our sub get() { $Y } }
+    is M1::get(), 42, "module-block sub sees the block my-lexical";
+}
+
+# The lexical does NOT leak to a bare reference after the block (raku scopes it).
+{
+    package P2 { my $secret = 99; our sub reveal() { $secret } }
+    is P2::reveal(), 99, "in-package access works";
+}
+
+# A value computed at block mainline (not a literal) is visible to the sub.
+{
+    package P4 {
+        my $derived = (1, 2, 3).map(* * 2).sum;
+        our sub total() { $derived }
+    }
+    is P4::total(), 12, "computed block lexical visible to by-name sub";
+}


### PR DESCRIPTION
## What

A named sub inside a `package Foo { my $x = ...; sub f { $x } }` (or `module`) **block** closes over the block's `my` lexicals in Raku. But mutsu's registry subs have no per-sub closure env (they resolve free vars from the call-time env), and `exec_package_scope_op` drops the block's lexicals on exit. So a by-name / exported call after the block saw the lexical as the undefined type object:

```raku
package P { my $X = "v"; our sub show() { say $X } }; P::show()
# mutsu was: (Any)   raku/now: v
```

## Fix

Record each package block's `my` lexicals in a per-package store (`package_lexicals`) **after** the block body runs (so values reflect the block's assignments), and fall back to `package_lexicals[current_package]` on a `GetGlobal` miss. The fallback fires **only inside that package's subs** (runtime `current_package == Foo`), so the lexical does **not** leak to a bare reference after the block — that runs under `GLOBAL` and still errors as in Raku (verified: `package P { my $z=1 }; say $z` → "not declared").

## Why it matters (zef north-star)

`package Zef::CLI { my $CONFIG = preprocess-args-config-mutate(@*ARGS); proto MAIN(|) is export {*}; multi MAIN('info',...) { ... $CONFIG } }` — `$CONFIG` read as `Any` inside the exported MAIN candidates, so `Zef::Fetch.new(:backends(|$CONFIG<Fetch>))` got a one-element `[Any]` backend list and `self!try-load(Any)` failed to bind its `Hash` param ("No such private method 'try-load'"). **`zef info`/`locate` now get past that blocker** (they reach the next, separate `CompUnit::Repository::FileSystem.resolve` gap).

## Tests

- `t/package-block-lexical-capture.t` (new, 5 subtests): package/module-block sub sees the lexical, computed value visible, no leak after the block.
- `make test` green (12908 `t/` tests, Result: PASS; cargo tests pass; no non-TODO failures).

## Known residual (follow-up, documented)

`zef list` still fails: its MAIN candidate is OTF-compiled and reads `$CONFIG` via a **local slot** rather than `GetGlobal`, which this `GetGlobal`-miss fallback does not yet cover. A complete fix would also seed the local slot (or give registry subs a real closure env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)