### PR TITLE
docs(roast): qualified.t subtest-6 blocked on lexical role/class identity

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -176,7 +176,32 @@
         and loses the variant — it must carry concretizations.
       - (b) `$?ROLE`/`$?CLASS` returning parameterized type names (e.g. `R1[Int]`).
       - `$?CLASS` inside a role-private nested class (`my class CR2 does R1[Set]` ->
-        `CR2-of-type`), and inheritance via `callsame` (the `C2`/`C3` cases).
+        `CR2-of-type`).
+    - **HARD BLOCKER for the full file (session 43, attempted + reverted): lexical
+      role/class identity.** A variant-aware `role_concretizations_at_nearest`
+      (BFS carrying full concretizations; each role node resolves to its matching
+      `RoleCandidateDef` by arity and returns THAT candidate's type-substituted
+      parents instead of the merged by-name `role_parents`) PLUS resolving relative
+      to the executing method's owner (`method_class_stack` top, with MRO walk for
+      inherited roles) makes subtest 6's stanzas 1 (`C2.new.of-type` ->
+      `(C2 C1 R1[Int] R2[Num] R1[Num] R2 R1[Bool])`) and 4 (`C3.C1-R1-of-type` ->
+      `R1[Int]`) pass — BUT it REGRESSES subtest 7. Root cause: subtests 6 and 7
+      each declare DIFFERENT `my role R2` (6: `R2 does R1[Bool]`; 7:
+      `R2 does R1[Int] does R1[Bool]`) and different `my class C1`/`C2`, but mutsu
+      keys `role_candidates`/`roles`/`classes` GLOBALLY by bare name, so they
+      collide: subtest 7's `C2` (whose `R2` genuinely has two `R1`s -> should be
+      ambiguous) resolves against subtest 6's same-arity `R2` candidate (one `R1`)
+      and stops being ambiguous. The OLD merged `role_parents` made subtest 7
+      ambiguous only by ACCIDENT of that same cross-subtest pollution. Satisfying
+      both subtests requires real lexical role/class identity (same-name `my role`/
+      `my class` in distinct lexical scopes must be distinct declarations, not
+      collide in the global registries) — a major structural feature, its own
+      campaign. The per-variant change net-regressed qualified.t (Failed 1->2) and
+      was reverted; it is CI-safe (0 whitelisted-test regressions) but should not
+      land until lexical identity exists. Merged improvements that DO stand and
+      work in isolation: #3878 (consumed-concretization qualified dispatch) and
+      #3879 (`::T` forwarding, `class_direct_composed_roles`, per-concretization
+      binding, context-relative resolution).
     - **Minimal root-cause reproducer for the qualified-dispatch facet (session 43):**
       ```
       my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ "/" ~ ($b ~~ Nil ?? "NIL" !! $b.^name) }


### PR DESCRIPTION
## Summary

Records the hard blocker reached at the end of the parameterized-role qualified-dispatch campaign (after #3878 + #3879 landed).

A variant-aware `role_concretizations_at_nearest` (BFS carrying full concretizations; each role node resolves its matching `RoleCandidateDef` by arity and returns that candidate's type-substituted parents instead of the merged by-name `role_parents`) plus resolving relative to the executing method's owner (with an MRO walk for inherited roles) makes subtest 6's stanzas 1 & 4 pass:
- `C2.new.of-type` → `(C2 C1 R1[Int] R2[Num] R1[Num] R2 R1[Bool])`
- `C3.C1-R1-of-type` → `R1[Int]`

**But it regresses subtest 7.** Subtests 6 and 7 each declare a *different* `my role R2` and `my class C1`/`C2`, yet mutsu keys `role_candidates`/`roles`/`classes` globally by bare name, so they collide. Subtest 7's `C2` (whose `R2` genuinely has two `R1`s → should be ambiguous) resolves against subtest 6's same-arity `R2` candidate (one `R1`) and stops being ambiguous. The old merged `role_parents` made subtest 7 ambiguous only by accident of that same cross-subtest pollution.

Satisfying both requires real **lexical role/class identity** — a major structural feature (its own campaign). The per-variant change net-regressed qualified.t (Failed 1→2, though CI-safe with 0 whitelisted regressions) and was reverted.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)