### PR TITLE
perf(dispatch): OTF-compile a default-param single sub that shadows a builtin

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1571,12 +1571,20 @@ impl Interpreter {
         // resolved def already satisfies it and the compiled binding just binds the
         // callable — byte-identical to the interpreter. Any cross-candidate
         // ambiguity (`&c:(Int)` vs untyped `&c`) is a *resolution*-level gap that
-        // fires identically with or without OTF, so it is unaffected. Only a param
-        // with a default value stays excluded here (the name-cache-pollution /
-        // builtin-shadow hazard, PR #3546 — allowed at genuine multi sites via
-        // `def_is_otf_compilable_multi_candidate`).
+        // fires identically with or without OTF, so it is unaffected.
+        //
+        // A param with a default value is ALSO no longer excluded. It once was, to
+        // avoid the builtin-shadow name-cache hazard (PR #3546: Test::Util's
+        // `our sub run(Str, Str = '')` shadowing the `run` builtin — the OTF cache
+        // could pin the user sub so a later builtin `run` mis-bound). That hazard is
+        // now closed by the `otf_call_cache` scope-coherence fix: the cache is gated
+        // on `fn_resolve_gen`, which bumps when the shadowing scope changes (import
+        // pop / lexical scope exit), so the user `run` is evicted and a later builtin
+        // `run` (process spawn) re-resolves correctly. Verified: `{ sub run($c,$i='')
+        // {...}; run(...) }; run("echo", ..., :out)` binds the user sub inside the
+        // block and the builtin outside, matching raku. Within a single scope a name
+        // resolves to one routine, so no same-scope mis-bind is possible.
         !Self::function_body_needs_interpreter(&def.body)
-            && def.param_defs.iter().all(|pd| pd.default.is_none())
     }
 
     /// Like `def_is_otf_compilable`, but also permits a parameter with a default

--- a/t/default-param-builtin-shadow-otf.t
+++ b/t/default-param-builtin-shadow-otf.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A single user sub with a default parameter that SHADOWS a builtin is now
+# OTF-compiled (was excluded to avoid an otf_call_cache name-cache hazard, PR
+# #3546). The hazard is closed by the cache's `fn_resolve_gen` scope coherence:
+# when the shadowing scope exits the cache is evicted, so the builtin re-binds.
+# (PLAN §2-D.)
+
+plan 5;
+
+# User `run` (default param) shadowing the builtin `run`, then the builtin
+# `run` (process) outside the shadowing scope.
+{
+    my $inside;
+    {
+        sub run(Str $code, Str $input = '') { "user:$code/$input" }
+        $inside = run("a");
+    }
+    is $inside, "user:a/", "user run with default binds inside its scope";
+
+    my $proc = run("echo", "hello", :out);
+    is $proc.out.slurp(:close).chomp, "hello",
+        "builtin run (process) re-binds after the shadowing scope exits";
+}
+
+# A user sub shadowing a builtin, both calls in the same scope, default applied.
+{
+    sub run(Str $code, Str $tag = 'def') { "$code\[$tag]" }
+    is run("x"), "x[def]", "default applied to shadowing sub (no arg)";
+    is run("x", "y"), "x[y]", "explicit arg to shadowing sub";
+}
+
+# A non-shadowing single sub with a default still works (regression guard).
+{
+    sub greet(Str $who, Str $greeting = "Hi") { "$greeting, $who" }
+    is greet("Sam"), "Hi, Sam", "ordinary default-param sub";
+}


### PR DESCRIPTION
## What

A single user sub with a **default parameter** that **shadows a builtin** was excluded from on-the-fly (OTF) bytecode compilation (`def_is_otf_compilable`), so it fell back to the tree-walk interpreter on every call (PLAN §2-D, remaining multi-dispatch fallback).

## Why it's now safe

The exclusion guarded the PR #3546 name-cache hazard: Test::Util's `our sub run(Str, Str = '')` shadows the `run` builtin, and pinning the user sub in `otf_call_cache` could mis-bind a later builtin `run` (process spawn).

That hazard is **closed by the cache's scope coherence**: `otf_call_cache` is gated on `fn_resolve_gen`, which bumps when the shadowing scope changes (import pop / lexical scope exit), evicting the user sub so a later builtin call re-resolves correctly. Within a single scope a name resolves to one routine, so no same-scope mis-bind is possible.

Verified:
```raku
{ sub run($c, $i = '') { ... }; run("first"); }   # user sub
my $proc = run("echo", "hi", :out);               # builtin process run — re-binds
```
binds the user sub inside the block and the builtin process `run` outside, matching raku.

## Tests

- `t/default-param-builtin-shadow-otf.t` (new, 5 subtests): shadowing sub inside scope, builtin re-bind outside, same-scope default application, non-shadowing regression guard.
- `make test` green (12934 tests, Result: PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)