### PR TITLE
fix(interp): preserve element type when reassigning a bound typed array

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -1,7 +1,8 @@
 # S32 - arrays, basics, containers, exceptions, hash, io, list, num, scalar, str, temporal
 
-- [ ] roast/S32-array/adverbs.t
-  - 550/606 pass (was: aborted at 283 of 606). Huge subscript-adverb surface
+- [x] roast/S32-array/adverbs.t — **DONE, 606/606, whitelisted.** (BLOCKERS.md
+    §1.2 is stale; this file fully passes.)
+  - 606/606 pass (was: aborted at 283 of 606). Huge subscript-adverb surface
     (`:k`/`:v`/`:kv`/`:p`/`:exists`/`:delete` with `:!`/`(cond)` variants over
     single elem / slice / whatever `[*]` / zen `[]`, ×2 for `@n`(Any) and
     `@s`(Str)).
@@ -43,6 +44,15 @@
 - [ ] roast/S32-array/keys_values.t
 - [ ] roast/S32-array/kv.t
 - [ ] roast/S32-array/multislice-6e.t
+  - **2026-06-28 triage**: the bulk of failures need TRUE first-class element
+    containers. The test's `assignable-ok(\target, …)` binds a multislice
+    (`@a[i;j;k]`) as a raw `\target` and then *checks the array's state inside the
+    sub*; mutsu's index-arg binding only writes back AFTER the call returns
+    (post-call writeback), so the in-sub read sees the unmodified array. This is
+    the same limitation as single-dim `@a[1]` bound as `\target` — it is Track B
+    (array/hash element `ContainerRef` cells, ADR-0001 layer 3a, fused with GC).
+    Do NOT attempt a post-call-writeback workaround: it corrupts state ordering
+    against the test's `set-up-array` resets and aborts the file early.
 - [ ] roast/S32-array/pairs.t
 - [ ] roast/S32-array/perl.t
   - 8/9 pass. Test 8 (circular array-within-circular-hash .raku.EVAL roundtrip) blocked on array container sharing semantics: in Raku, assigning `%h<c> = @b` shares the underlying container so later `@b = ...` is visible via `%h<c>`, but mutsu copies on assignment. Fixing requires deeper container-model work.
@@ -54,6 +64,21 @@
 - [ ] roast/S32-array/shift.t
   - 11/33 pass (1, 11-12, 21-27, 33). Similar to pop: sub form `shift(@arr)` broken, method form has issues. Post-exhaustion returns undefined/Failure correctly. Difficulty: Medium
 - [ ] roast/S32-array/splice.t
+  - 171/381 pass (was ~136). **2026-06-28**: the native-typed-array cluster
+    (`array[int]`/`array[int8]`/…, ~35 tests) was failing because a list
+    assignment to a *bound* / for-loop-bound array (`for @typed-arrays -> @a { @a
+    = … }`) dropped the element type — `@a.WHAT` became plain `Array`, so the
+    `is ret.WHAT, $T.WHAT` type checks failed. Fixed in the `SetGlobal` store
+    path: when the target name has no *declared* element type but the container
+    already in the slot is element-typed (`array[int]`), the assignment now
+    preserves that type (writes INTO the container) instead of replacing it with
+    an untyped `Array`. t/typed-array-alias-reassign.t. Remaining failures are
+    other clusters: "Array push/replace self" (self-referential splice) and the
+    `:delete`/binding-lvalue patterns shared with multislice-6e (need true
+    first-class element containers — Track B / ADR-0001).
+  - Note: the explicit `my @a := @int; @a = …` form (vs the for-loop binding)
+    still drops the type — it takes a different store path and is not covered by
+    this fix.
 - [ ] roast/S32-array/unshift.t
   - 8/76 pass (1, 19, 22-23, and a few others). `@arr.unshift(val)` method works but doesn't return correct count. Sub form `unshift(@arr, val)` broken. Most element verification fails. Difficulty: Medium-High (unshift return value and sub form)
 - [ ] roast/S32-basics/pairup.t

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -874,6 +874,33 @@ impl Interpreter {
                         || loan_env!(self, var_hash_key_constraint(&name)).is_some())
                 {
                     val = self.coerce_typed_container_assignment(&name, val, false)?;
+                } else if name.starts_with('@')
+                    && name.len() > 1
+                    && !name.contains("__")
+                    && loan_env!(self, var_type_constraint(&name)).is_none()
+                {
+                    // `@a = list` where `@a` has no *declared* element type but is
+                    // an alias / for-loop binding of an element-typed array
+                    // (`array[int]`): the assignment writes INTO that container, so
+                    // preserve its declared element type rather than replacing it
+                    // with an untyped `Array`. Internal/anonymous names
+                    // (`@__ANON_ARRAY__`, `@__mutsu_*`) are excluded: they are
+                    // fresh per use and must not inherit a stale slot's type.
+                    let old_info = match self.get_env_with_main_alias(&name) {
+                        Some(Value::Array(old, _))
+                            if old.value_type.is_some() || old.declared_type.is_some() =>
+                        {
+                            Some(crate::runtime::ContainerTypeInfo {
+                                value_type: old.value_type.clone().unwrap_or_default(),
+                                key_type: None,
+                                declared_type: old.declared_type.clone(),
+                            })
+                        }
+                        _ => None,
+                    };
+                    if let Some(info) = old_info {
+                        val = self.tag_container_metadata(val, info);
+                    }
                 }
                 if let Some(constraint) = loan_env!(self, var_type_constraint(&name))
                     && !name.starts_with('%')

--- a/t/typed-array-alias-reassign.t
+++ b/t/typed-array-alias-reassign.t
@@ -1,0 +1,46 @@
+use Test;
+
+# A list-assignment to an array binding that has no *declared* element type of
+# its own, but currently holds an element-typed container (`array[int]`), writes
+# INTO that container and preserves its element type, rather than replacing it
+# with an untyped `Array`. Previously the assignment dropped the element type.
+
+plan 6;
+
+# for-loop binding over typed arrays (the S32-array/splice.t pattern).
+{
+    my int @int = 1, 2, 3;
+    my @testing = $@int, array[int];
+    for @testing -> @a, $T {
+        @a = 5, 6, 7, 8;
+        is @a.WHAT.^name, 'array[int]',
+            'for-loop bound typed array keeps element type after reassignment';
+        is $T.^name, 'array[int]', 'expected type object name';
+    }
+}
+
+# splice return/remainder of a for-bound native int array stays typed.
+{
+    my int @int = 1 .. 10;
+    my @testing = $@int, array[int];
+    for @testing -> @a, $T {
+        @a = 1 .. 10;
+        my $ret = splice(@a, 0, 2);
+        is $ret.WHAT.^name, 'array[int]', 'splice return keeps element type';
+        is @a.WHAT.^name, 'array[int]', 'remainder keeps element type';
+    }
+}
+
+# A plain untyped array reassignment must NOT gain a spurious type.
+{
+    my @plain = 1, 2, 3;
+    @plain = 4, 5, 6;
+    is @plain.WHAT.^name, 'Array', 'untyped array stays untyped after reassignment';
+}
+
+# A directly-declared typed array still keeps its type (unchanged behavior).
+{
+    my int @d = 1, 2, 3;
+    @d = 9, 8, 7;
+    is @d.WHAT.^name, 'array[int]', 'directly-declared typed array keeps type';
+}


### PR DESCRIPTION
## What

A list assignment to an array binding with no *declared* element type of its own, but currently holding an element-typed container (`array[int]`), dropped the element type — `@a.WHAT` became plain `Array`:

```raku
my int @int = 1..10;
my @testing = $@int, array[int];
for @testing -> @a, $T {
    @a = 1..10;
    say @a.WHAT.^name;   # was: Array   now: array[int]
}
```

This broke the `for @typed-arrays -> @a { @a = ... }` pattern in `roast/S32-array/splice.t`, where `is ret.WHAT, $T.WHAT` type checks failed.

## How

The `SetGlobal` store path applied an element type only when the variable name carried a *declared* constraint (`my int @a`). A for-loop binding has no declared constraint, so the new untyped list replaced the typed container. Now, when there is no declared constraint **but the container already in the slot is element-typed**, the assignment preserves that type (writing INTO the container) instead of replacing it with an untyped `Array`. A genuinely untyped array reassignment is unaffected.

## Impact

- Fixes ~35 native-typed-array tests in `roast/S32-array/splice.t` (now 171/381).
- New test: `t/typed-array-alias-reassign.t` (6 cases, incl. negative cases).
- `make test` passes; whitelisted S09-typed-arrays / S32-array/adverbs tests unaffected.

## Triage notes (TODO_roast/S32.md)

- `S32-array/adverbs.t` already **fully passes** (BLOCKERS.md §1.2 is stale).
- `S32-array/multislice-6e.t`'s assignment-via-binding (`assignable-ok(\target, …)` checking array state *inside* the sub) needs true first-class element containers (Track B / ADR-0001), not a post-call writeback.
- The explicit `my @a := @int` form takes a different store path and is not covered by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)