### PR TITLE
feat(roles): whitelist S12-methods/qualified.t (parameterized-role campaign complete)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -680,6 +680,7 @@ roast/S12-methods/method-vs-sub.t
 roast/S12-methods/multi.t
 roast/S12-methods/parallel-dispatch.t
 roast/S12-methods/private.t
+roast/S12-methods/qualified.t
 roast/S12-methods/submethods.t
 roast/S12-methods/syntax.t
 roast/S12-methods/topic.t

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -519,8 +519,23 @@ impl Interpreter {
                     for (param_name, param_value) in &role_param_values {
                         self.bind_type_capture(param_name, param_value);
                     }
+                    // Run a nested TYPE declaration (`my class CR2`) in the role
+                    // body with the ROLE as the current package so it is named
+                    // `R2::CR2`, not the composing class. Only type declarations get
+                    // the role package — a lexical `sub`/`my $x` keeps the outer
+                    // package so a bare reference from a role method still resolves.
+                    let saved_body_pkg = self.current_package().to_string();
                     for stmt in &role.deferred_body_stmts {
-                        self.run_block_raw(std::slice::from_ref(stmt))?;
+                        let is_type_decl =
+                            matches!(stmt, Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. });
+                        if is_type_decl {
+                            self.set_current_package(base_role_name.to_string());
+                        }
+                        let r = self.run_block_raw(std::slice::from_ref(stmt));
+                        if is_type_decl {
+                            self.set_current_package(saved_body_pkg.clone());
+                        }
+                        r?;
                     }
                     // Remove type capture markers (but keep the variables
                     // created by the deferred stmts for method closures)

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -500,7 +500,26 @@ impl Interpreter {
                             .push(role_name_str);
                         continue;
                     }
-                    let role = match self.registry().roles.get(base_role_name).cloned() {
+                    // For a CONCRETE parametric parent (`does R1[Bool]`), resolve the
+                    // specific concretization's RoleDef by arity rather than the
+                    // by-name `roles` map — with a same-named role group (a
+                    // parameterized `R1[::T]` AND an unparameterized `R1`) the map
+                    // holds only the last-declared variant, so composing by bare name
+                    // would pull the wrong one and drop the parametric role's methods.
+                    // Skip when the application forwards a type param (`R1[::T]`),
+                    // which `resolve_role_candidate` rejects.
+                    let concretized_parent =
+                        if role_name_str.contains('[') && !role_name_str.contains("::") {
+                            self.resolve_role_candidate(&role_name_str)
+                                .ok()
+                                .flatten()
+                                .map(|(rd, _, _)| rd)
+                        } else {
+                            None
+                        };
+                    let role = match concretized_parent
+                        .or_else(|| self.registry().roles.get(base_role_name).cloned())
+                    {
                         Some(r) => r,
                         None => {
                             // If trait_mod:<is> is defined and this is a lowercase name,

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -350,8 +350,25 @@ impl Interpreter {
                     .get_role_def(&qualified_name)
                     .map(|r| r.deferred_body_stmts.clone())
                     .unwrap_or_default();
+                // Run a nested TYPE declaration (`my class CR2` / `my role`) in the
+                // role body with the ROLE as the current package, so it is named
+                // `R2::CR2` (qualified by its lexical role) and `$?CLASS.^name`
+                // reports the full name. Only type declarations get the role
+                // package — a lexical `sub`/`my $x` in the role body must keep the
+                // outer package so a bare `&a` reference from a role method still
+                // resolves (else it would register as `Role::a` and vanish).
+                let saved_role_body_pkg = self.current_package().to_string();
                 for stmt in &deferred {
-                    self.vm_run_block_raw(std::slice::from_ref(stmt))?;
+                    let is_type_decl =
+                        matches!(stmt, Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. });
+                    if is_type_decl {
+                        self.set_current_package(qualified_name.clone());
+                    }
+                    let r = self.vm_run_block_raw(std::slice::from_ref(stmt));
+                    if is_type_decl {
+                        self.set_current_package(saved_role_body_pkg.clone());
+                    }
+                    r?;
                 }
                 // Slice F: write the deferred body's outer-lexical mutations
                 // through to this caller frame's local slots (vm_run_block_raw

--- a/t/role-samename-composition-and-nested-class.t
+++ b/t/role-samename-composition-and-nested-class.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 4;
+
+# (1) Composition-time same-name role group: when both a parameterized `R1[::T]`
+# and an unparameterized `R1` exist, a role/class composing the CONCRETE
+# `R1[Bool]` must compose the parameterized variant's methods (not the
+# unparameterized sibling, which the by-name `roles` map would return).
+{
+    my role CR1[::T] { method greet { "param" } }
+    my role CR1     { method other { "plain" } }
+    my role CR2 does CR1[Bool] { }
+    my class CC does CR2 { }
+    is CC.new.greet, "param",
+        'composing a concrete parametric parent uses the parameterized variant';
+}
+
+# (2) Same, composed directly by the class.
+{
+    my role DR1[::T] { method tag { "T=" ~ T.^name } }
+    my role DR1     { method misc { 0 } }
+    my class DC does DR1[Int] { }
+    is DC.new.tag, "T=Int",
+        'class composing a concrete parametric role binds its type parameter';
+}
+
+# (3) Role-private nested class is named `Role::Class` (qualified by its lexical
+# role), so `$?CLASS.^name` / `::?CLASS.^name` inside it reports the full name.
+{
+    my role NR {
+        my class NCls { method who { ::?CLASS.^name } }
+        method make { NCls.new.who }
+    }
+    my class NC does NR { }
+    is NC.new.make, "NR::NCls",
+        'nested class in a role is named Role::Class';
+}
+
+# (4) The two together (the qualified.t subtest-6 shape, distilled).
+{
+    my sub ts(Mu \a, Mu $b = Nil) { a.^name ~ ($b ~~ Nil ?? "" !! "[" ~ $b.^name ~ "]") }
+    my role FR1[::T] { method of-type { ts($?ROLE, T) } }
+    my role FR1     { method of-type { ts($?ROLE) } }
+    my role FR2 does FR1[Bool] {
+        my class FCR2 does FR1[Set] {
+            method of-type { (ts($?CLASS), |self.FR1::of-type) }
+        }
+        method cr2 { FCR2.new.of-type }
+    }
+    my class FC does FR2 { }
+    is-deeply FC.new.cr2, ("FR2::FCR2", "FR1[Set]"),
+        'role-private class dispatches its own qualified role calls with $?CLASS named';
+}


### PR DESCRIPTION
## Summary

**Completes the parameterized-role qualified-dispatch campaign** — `S12-methods/qualified.t` now passes fully (all 7 subtests) and is whitelisted. Two fixes close subtest 6's last two stanzas (after #3878 / #3879 / #3886 landed the qualified-dispatch machinery):

1. **Composition-time same-name role group.** When a role/class composes a concrete parametric parent (`role R2 does R1[Bool]`, `class C does R1[Int]`) and a same-named role group exists (`role R1[::T]` **and** an unparameterized `role R1`), the parent's `RoleDef` was fetched from the by-name `roles` map — which keeps only the last-declared variant — so the parametric role's methods were dropped (`C.method` → X::Method::NotFound). `register_role_decl` now resolves a concrete parametric parent via `resolve_role_candidate` (by arity). This is the registration-time analog of the dispatch-time fix in #3886.

2. **Role-private nested class naming.** A `my class CR2` in a role body is now named `Role::CR2` (qualified by its lexical role), so `$?CLASS.^name` / `::?CLASS.^name` inside it reports the full name. The role body runs (at both role declaration and composition) with the role as the current package.

### Tests
- `t/role-samename-composition-and-nested-class.t` (4 cases).
- `roast/S12-methods/qualified.t` added to the whitelist (sorted).
- No regression across whitelisted S10-* / S11-* / S12-* / S14-* / S02-types / S26-* / S32-exceptions, or `cargo test` (477 passed).

### Campaign recap
`#3878` (consumed-concretization dispatch) → `#3879` (`::T` forwarding, `class_direct_composed_roles`, per-concretization binding, context-relative) → `#3886` (variant-aware + owner-relative + MRO BFS) → **this PR** (composition-time same-name group + role-private class naming). Whitelist +1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)