### PR TITLE
docs(roast): record S32-array/splice.t int8+ for-loop binding contamination

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -79,6 +79,20 @@
   - Note: the explicit `my @a := @int; @a = …` form (vs the for-loop binding)
     still drops the type — it takes a different store path and is not covered by
     this fix.
+  - **Known residual (int8/int16/int32/int64 rows, ~150 tests): for-loop binding
+    env-coherence contamination.** Only the `array[int]` row was actually fixed.
+    The fix reads the slot's *current* type via `get_env_with_main_alias("@a")`,
+    but in `for @testing -> @a, $T { @a = … }` over a list that mixes element
+    types (`…, $@int, array[int], $@int8, array[int8], …`), the env read for `@a`
+    returns the **previous iteration's** value: the int8 iteration sees the stale
+    `array[int]` and `@a.WHAT` becomes `array[int]` (wrong) instead of
+    `array[int8]`. (The `int` row is first after the untyped `Any`/`Array` rows,
+    so it reads its own current binding and passes.) Reproduces with
+    `my int @i; my int8 @j; my @t = $@i, array[int], $@j, array[int8]; for @t -> @a,$T { @a=1..5; say splice(@a,0).WHAT }` → `array[int] array[int]` (raku:
+    `array[int] array[int8]`). Root cause is the for-loop `@`-binding not keeping
+    `env["@a"]` coherent with the freshly-bound container each iteration — a
+    deeper binding-coherence fix than the SetGlobal type-preservation; fixing it
+    would unlock the int8/16/32/64 rows AND remove the cross-type contamination.
 - [ ] roast/S32-array/unshift.t
   - 8/76 pass (1, 19, 22-23, and a few others). `@arr.unshift(val)` method works but doesn't return correct count. Sub form `unshift(@arr, val)` broken. Most element verification fails. Difficulty: Medium-High (unshift return value and sub form)
 - [ ] roast/S32-basics/pairup.t


### PR DESCRIPTION
Follow-up documentation to #3885.

The native-typed-array splice fix (#3885) only addressed the `array[int]` row. The `int8`/`int16`/`int32`/`int64` rows (~150 tests) still fail due to a deeper for-loop `@`-binding coherence issue:

- `for @testing -> @a, $T` de-itemizes the chunk element via `.list` (`compiler/mod.rs`), which **drops** the source array's element type.
- The SetGlobal type-preservation (from #3885) then reads `@a`'s **stale** (previous-iteration) type via `get_env_with_main_alias`.
- With a list mixing element types (`…, $@int, array[int], $@int8, array[int8]`), the int8 iteration wrongly sees `array[int]`.

Repro:
```raku
my int @i; my int8 @j;
my @t = $@i, array[int], $@j, array[int8];
for @t -> @a, $T { @a = 1..5; say splice(@a, 0).WHAT }
# mutsu: array[int] array[int]   raku: array[int] array[int8]
```

Records the root cause as the next slice: a **type-preserving de-itemization** in the for-loop `@`-binding would unlock the int8/16/32/64 rows and remove the cross-type contamination. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)