### PR TITLE
docs(roast): refine io-handle nested-with topic-clobber analysis

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -469,6 +469,17 @@
       the `with` body breaks `if { given { } }` value propagation — a separate
       pre-existing bug where a trailing `given` in an `if`/`with`-value position
       returns Nil; fix that first, then re-isolate the topic source).
+      Minimal repro (session 44): the failing shape is
+      `with $nl-out { with $file.open(:w, :$nl-out) { .say: |in } }` with `$nl-out`
+      a (readonly) sub param — after the INNER `with`, the OUTER topic var
+      `$nl-out` reads as the inner topic (the IO::Handle). RULED OUT: NOT the
+      `container_ref_var` writeback path — clearing it for an expression topic
+      (`given $fh.open(...)`, source_name=None) via a new `ClearContainerRef` op did
+      NOT fix it (reverted). The clobber happens WHILE the inner `with` runs (before
+      the outer given's writeback), so the next suspect is `env["_"]` /
+      `topic_source_var` aliasing: the outer `given $x` makes `$_` track `$x`, and
+      the inner given's `env["_"] = <handle>` (`exec_given_op` line ~40) leaks to
+      `$x`. Investigate `exec_given_op` topic save/restore under nesting.
       23 `.print-nl`, 29 `.WRITE`, 30 `.EOF/.WRITE` all need a user-subclassable
       IO::Handle with polymorphic READ/WRITE/EOF. Substantial feature.)
 - [x] roast/S32-io/io-path-cygwin.t


### PR DESCRIPTION
Refines the S32-io/io-handle.t (.say method, test 22) blocker note with a session-44 minimal reproducer and rules out the `container_ref_var` writeback path (a `ClearContainerRef` op for expression topics did not fix it; reverted). Points the next investigation at `exec_given_op` env["_"]/topic_source_var aliasing under nested `with`/`given`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)