### PR TITLE
fix(interp): type-preserving de-itemization for for-loop @-array binding

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -64,35 +64,30 @@
 - [ ] roast/S32-array/shift.t
   - 11/33 pass (1, 11-12, 21-27, 33). Similar to pop: sub form `shift(@arr)` broken, method form has issues. Post-exhaustion returns undefined/Failure correctly. Difficulty: Medium
 - [ ] roast/S32-array/splice.t
-  - 171/381 pass (was ~136). **2026-06-28**: the native-typed-array cluster
-    (`array[int]`/`array[int8]`/…, ~35 tests) was failing because a list
-    assignment to a *bound* / for-loop-bound array (`for @typed-arrays -> @a { @a
-    = … }`) dropped the element type — `@a.WHAT` became plain `Array`, so the
-    `is ret.WHAT, $T.WHAT` type checks failed. Fixed in the `SetGlobal` store
-    path: when the target name has no *declared* element type but the container
-    already in the slot is element-typed (`array[int]`), the assignment now
-    preserves that type (writes INTO the container) instead of replacing it with
-    an untyped `Array`. t/typed-array-alias-reassign.t. Remaining failures are
-    other clusters: "Array push/replace self" (self-referential splice) and the
-    `:delete`/binding-lvalue patterns shared with multislice-6e (need true
-    first-class element containers — Track B / ADR-0001).
+  - 346/381 pass (was ~136). **2026-06-28**, two fixes:
+    - (#3885) `SetGlobal` store path: a list assignment to a name with no
+      *declared* element type that currently holds an element-typed container
+      preserves the element type (writes INTO the container) instead of replacing
+      it with an untyped `Array`. Guarded to only fire when the RHS is itself
+      untyped — when the RHS already carries a type (e.g. a `DeitemizeForBind`
+      chunk element), that type wins, avoiding cross-type for-loop contamination.
+      t/typed-array-alias-reassign.t.
+    - for-loop `@`-binding type-preserving de-itemization: `for @typed-arrays ->
+      @a` previously bound `@a` via `element.list`, which collapses `array[int8]`
+      to an untyped `Array`. New `Expr::DeitemizeForBind` / `OpCode::DeitemizeForBind`
+      strips only the itemization wrap (`ItemArray → Array`) while keeping the
+      element type, falling back to `.list` for non-array values (preserving the
+      PR #3716 `[$@n]` flattening). This unblocked the int8/int16/int32/int64
+      rows (~175 tests). t/for-bind-typed-array-deitemize.t.
+  - Remaining 35 failures are ALL the "push/replace self" cases (`splice(@a, …,
+    @a)`): the `@a` captured in the splice args must be a container reference
+    reflecting the in-place mutation — true first-class element containers
+    (Track B / ADR-0001), not fixable standalone.
   - Note: the explicit `my @a := @int; @a = …` form (vs the for-loop binding)
     still drops the type — it takes a different store path and is not covered by
-    this fix.
-  - **Known residual (int8/int16/int32/int64 rows, ~150 tests): for-loop binding
-    env-coherence contamination.** Only the `array[int]` row was actually fixed.
-    The fix reads the slot's *current* type via `get_env_with_main_alias("@a")`,
-    but in `for @testing -> @a, $T { @a = … }` over a list that mixes element
-    types (`…, $@int, array[int], $@int8, array[int8], …`), the env read for `@a`
-    returns the **previous iteration's** value: the int8 iteration sees the stale
-    `array[int]` and `@a.WHAT` becomes `array[int]` (wrong) instead of
-    `array[int8]`. (The `int` row is first after the untyped `Any`/`Array` rows,
-    so it reads its own current binding and passes.) Reproduces with
-    `my int @i; my int8 @j; my @t = $@i, array[int], $@j, array[int8]; for @t -> @a,$T { @a=1..5; say splice(@a,0).WHAT }` → `array[int] array[int]` (raku:
-    `array[int] array[int8]`). Root cause is the for-loop `@`-binding not keeping
-    `env["@a"]` coherent with the freshly-bound container each iteration — a
-    deeper binding-coherence fix than the SetGlobal type-preservation; fixing it
-    would unlock the int8/16/32/64 rows AND remove the cross-type contamination.
+    these fixes. (The earlier "int8/16/32/64 env-coherence contamination"
+    residual noted in #3888 is now resolved by the `DeitemizeForBind` +
+    RHS-untyped-guard fixes above.)
 - [ ] roast/S32-array/unshift.t
   - 8/76 pass (1, 19, 22-23, and a few others). `@arr.unshift(val)` method works but doesn't return correct count. Sub form `unshift(@arr, val)` broken. Most element verification fails. Difficulty: Medium-High (unshift return value and sub form)
 - [ ] roast/S32-basics/pairup.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -387,6 +387,11 @@ pub(crate) enum Expr {
     /// Item context coercion: `$%hash` or `$@array` — wraps value in Scalar container
     /// so it won't be flattened in list context.
     Itemize(Box<Expr>),
+    /// De-itemize the chunk element of a `for … -> @a` binding. Like `.list`
+    /// (flattens a one-element itemized-array wrap into its elements), but
+    /// preserves the source array's element type so `@a` keeps `array[int]`
+    /// instead of collapsing to an untyped `Array`.
+    DeitemizeForBind(Box<Expr>),
     Reduction {
         op: String,
         expr: Box<Expr>,
@@ -1571,9 +1576,10 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             collect_ph_expr(expr, out);
             collect_ph_expr(value, out);
         }
-        Expr::Reduction { expr, .. } | Expr::Eager(expr) | Expr::Itemize(expr) => {
-            collect_ph_expr(expr, out)
-        }
+        Expr::Reduction { expr, .. }
+        | Expr::Eager(expr)
+        | Expr::Itemize(expr)
+        | Expr::DeitemizeForBind(expr) => collect_ph_expr(expr, out),
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }
         | Expr::MetaOp { left, right, .. } => {
@@ -1865,9 +1871,10 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
                 collect_ph_stmt_shallow(s, out);
             }
         }
-        Expr::Reduction { expr, .. } | Expr::Eager(expr) | Expr::Itemize(expr) => {
-            collect_ph_expr_shallow(expr, out)
-        }
+        Expr::Reduction { expr, .. }
+        | Expr::Eager(expr)
+        | Expr::Itemize(expr)
+        | Expr::DeitemizeForBind(expr) => collect_ph_expr_shallow(expr, out),
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }
         | Expr::MetaOp { left, right, .. } => {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -606,6 +606,10 @@ impl Compiler {
                 self.compile_expr(inner);
                 self.code.emit(OpCode::Itemize);
             }
+            Expr::DeitemizeForBind(inner) => {
+                self.compile_expr(inner);
+                self.code.emit(OpCode::DeitemizeForBind);
+            }
             Expr::PositionalPair(inner) => {
                 self.compile_expr(inner);
                 self.code.emit(OpCode::ContainerizePair);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -646,18 +646,14 @@ impl Compiler {
             // An `@`-sigil multi-param de-itemizes the chunk element: Raku binds
             // `@a` to the element's *list* (`for $@n, Any -> @a, $T` → `@a` IS the
             // 4-element array), whereas a plain assignment would wrap an itemized
-            // array as a one-element array (`[$@n]`, elems=1). Coerce via `.list`
-            // so the de-itemized elements flow into the fresh container. (A scalar
-            // param keeps plain assignment + later MarkReadonly; `%`-sigil is left
-            // as plain assignment — `.hash` mis-coerces an itemized hash.)
+            // array as a one-element array (`[$@n]`, elems=1). `DeitemizeForBind`
+            // de-itemizes like `.list` but preserves the source array's element
+            // type, so a typed chunk element (`array[int]`) keeps its type instead
+            // of collapsing to an untyped `Array`. (A scalar param keeps plain
+            // assignment + later MarkReadonly; `%`-sigil is left as plain
+            // assignment — `.hash` mis-coerces an itemized hash.)
             let value_expr = if actual_name.starts_with('@') {
-                Expr::MethodCall {
-                    target: Box::new(value_expr),
-                    name: Symbol::intern("list"),
-                    args: Vec::new(),
-                    modifier: None,
-                    quoted: false,
-                }
+                Expr::DeitemizeForBind(Box::new(value_expr))
             } else {
                 value_expr
             };

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -176,6 +176,10 @@ pub(crate) enum OpCode {
     /// item in list context. Emitted when `$` variable values are used inside
     /// `ArrayLiteral` or assigned to `@`/`%` targets.
     Itemize,
+    /// De-itemize a `for … -> @a` chunk element while preserving the source
+    /// array's element type (see `Expr::DeitemizeForBind`). Falls back to plain
+    /// list flattening for non-array values.
+    DeitemizeForBind,
     /// Like `Itemize`, but skips itemization when the named scalar variable is
     /// bound (`:=`) to a Positional value. A bound scalar is NOT a Scalar
     /// container, so `@a = $bound` must flatten (matching Raku). The argument is

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -899,6 +899,7 @@ impl Interpreter {
                     && name.len() > 1
                     && !name.contains("__")
                     && loan_env!(self, var_type_constraint(&name)).is_none()
+                    && matches!(&val, Value::Array(d, _) if d.value_type.is_none() && d.declared_type.is_none())
                 {
                     // `@a = list` where `@a` has no *declared* element type but is
                     // an alias / for-loop binding of an element-typed array
@@ -906,7 +907,11 @@ impl Interpreter {
                     // preserve its declared element type rather than replacing it
                     // with an untyped `Array`. Internal/anonymous names
                     // (`@__ANON_ARRAY__`, `@__mutsu_*`) are excluded: they are
-                    // fresh per use and must not inherit a stale slot's type.
+                    // fresh per use and must not inherit a stale slot's type. The
+                    // guard `val` is itself untyped is essential: when the RHS
+                    // already carries a type (e.g. a `DeitemizeForBind` chunk
+                    // element), that type wins — reading a possibly-stale slot here
+                    // would clobber it (the cross-type for-loop contamination).
                     let old_info = match self.get_env_with_main_alias(&name) {
                         Some(Value::Array(old, _))
                             if old.value_type.is_some() || old.declared_type.is_some() =>
@@ -1327,6 +1332,12 @@ impl Interpreter {
             OpCode::Itemize => {
                 let val = self.stack.pop().unwrap_or(Value::Nil);
                 self.stack.push(Self::itemize_value(val));
+                *ip += 1;
+            }
+            OpCode::DeitemizeForBind => {
+                let val = self.stack.pop().unwrap_or(Value::Nil);
+                let deitemized = self.deitemize_for_bind(val)?;
+                self.stack.push(deitemized);
                 *ip += 1;
             }
             OpCode::ItemizeVar(name_idx) => {

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -611,4 +611,18 @@ impl Interpreter {
             other => other,
         }
     }
+
+    /// De-itemize a `for … -> @a` chunk element while preserving its element
+    /// type. An element-typed array (`array[int]`) keeps its type — only the
+    /// itemization/scalar wrap is stripped, which is exactly the de-itemization
+    /// the binding needs. Every other value flattens via the existing `.list`
+    /// semantics (preserving prior behavior exactly).
+    pub(crate) fn deitemize_for_bind(&mut self, val: Value) -> Result<Value, RuntimeError> {
+        if let Value::Array(data, kind) = &val
+            && (data.value_type.is_some() || data.declared_type.is_some())
+        {
+            return Ok(Value::Array(data.clone(), kind.decontainerize()));
+        }
+        self.call_method_with_values(val, "list", vec![])
+    }
 }

--- a/t/for-bind-typed-array-deitemize.t
+++ b/t/for-bind-typed-array-deitemize.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A `for … -> @a` binding de-itemizes the chunk element. When that element is an
+# element-typed array (`array[int]`), the binding must preserve the element type
+# rather than collapsing it to an untyped `Array` (which `.list` does). This also
+# guards against cross-type contamination when the iterated list mixes element
+# types: each iteration's `@a` must reflect its own element's type, not a stale
+# previous-iteration type.
+
+plan 7;
+
+# Single typed array, bound and inspected.
+{
+    my int8 @j = 1, 2, 3;
+    for ($@j,) -> @a {
+        is @a.WHAT.^name, 'array[int8]', 'for-bound typed array keeps element type';
+    }
+}
+
+# Mixed element types in the iterated list: no cross-iteration contamination.
+{
+    my int @i;
+    my int8 @j;
+    my @t = $@i, array[int], $@j, array[int8];
+    my @seen;
+    for @t -> @a, $T {
+        @seen.push: @a.WHAT.^name ~ '=' ~ $T.^name;
+    }
+    is @seen[0], 'array[int]=array[int]',   'int row binds array[int]';
+    is @seen[1], 'array[int8]=array[int8]', 'int8 row binds array[int8] (no contamination)';
+}
+
+# Reassignment inside the loop body keeps the bound element type.
+{
+    my int @i;
+    my int8 @j;
+    my @t = $@i, array[int], $@j, array[int8];
+    my @kinds;
+    for @t -> @a, $T {
+        @a = 1, 2, 3;
+        @kinds.push: @a.WHAT.^name;
+    }
+    is @kinds[0], 'array[int]',  'int row reassignment keeps array[int]';
+    is @kinds[1], 'array[int8]', 'int8 row reassignment keeps array[int8]';
+}
+
+# De-itemization still flattens (the PR #3716 `[$@n]` regression must not return).
+{
+    my @n = 1, 2, 3, 4;
+    for ($@n, Any) -> @a, $b {
+        is @a.elems, 4, 'itemized array flattens to its elements, not [$@n]';
+    }
+}
+
+# A plain (untyped) array element still binds as an untyped Array.
+{
+    for ([1, 2, 3],) -> @a {
+        is @a.WHAT.^name, 'Array', 'untyped array element binds as untyped Array';
+    }
+}


### PR DESCRIPTION
## What

`for @typed-arrays -> @a { … }` bound `@a` via `element.list`, which collapses an element-typed chunk (`array[int8]`) to an untyped `Array`:

```raku
my int @i; my int8 @j;
my @t = $@i, array[int], $@j, array[int8];
for @t -> @a, $T { @a = 1..5; say splice(@a, 0).WHAT }
# before: array[int] array[int]   now: array[int] array[int8]   (raku: array[int] array[int8])
```

This broke the `int8`/`int16`/`int32`/`int64` rows of `roast/S32-array/splice.t` (the `is ret.WHAT, $T.WHAT` type checks).

## How

- **New `Expr::DeitemizeForBind` / `OpCode::DeitemizeForBind`**: de-itemizes a for-loop chunk element while preserving its element type — it strips only the itemization wrap (`ItemArray → Array`) on an element-typed array, and falls back to `.list` for everything else (so the PR #3716 `[$@n]` flattening for untyped / multi-element chunks is unchanged). The for-loop `@`-binding emits this instead of a `.list` method call.

- **Guard the #3885 SetGlobal element-type-preservation** to only fire when the RHS is itself untyped. When the RHS already carries a type (the `DeitemizeForBind` chunk element), that type wins; reading the possibly-stale slot would otherwise clobber it — the cross-type contamination where the int8 iteration saw the int iteration's `array[int]`.

## Impact

- `roast/S32-array/splice.t`: **171 → 346/381**. The remaining 35 are all "push/replace self" (`splice(@a, …, @a)`) cases needing true first-class element containers (Track B / ADR-0001).
- New test: `t/for-bind-typed-array-deitemize.t` (7 cases incl. contamination + flattening guards).
- `make test` green; `S09-typed-arrays/*`, `S32-array/adverbs`, `S04-statements/for` unaffected (no new regressions).

Touches the for-loop hot path — relying on CI + roast as the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)