### PR TITLE
fix(topic): isolate nested with/given topic-source from outer scope

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -457,26 +457,29 @@
 - [ ] roast/S32-io/empty.txt
 - [x] roast/S32-io/indir.t
 - [ ] roast/S32-io/io-cathandle.t
-- [ ] roast/S32-io/io-handle.t (26/30 subtests pass; test 24 fixed (strict ASCII
-      decode). Remaining 4:
-      22 `.say method` — needs nested-`with`/`given` topic-source isolation so
-      `given $x { with 42 {} }` does not clobber `$x` (the obvious Given-wrap of
-      the `with` body breaks `if { given { } }` value propagation — a separate
-      pre-existing bug where a trailing `given` in an `if`/`with`-value position
-      returns Nil; fix that first, then re-isolate the topic source).
-      Minimal repro (session 44): the failing shape is
-      `with $nl-out { with $file.open(:w, :$nl-out) { .say: |in } }` with `$nl-out`
-      a (readonly) sub param — after the INNER `with`, the OUTER topic var
-      `$nl-out` reads as the inner topic (the IO::Handle). RULED OUT: NOT the
-      `container_ref_var` writeback path — clearing it for an expression topic
-      (`given $fh.open(...)`, source_name=None) via a new `ClearContainerRef` op did
-      NOT fix it (reverted). The clobber happens WHILE the inner `with` runs (before
-      the outer given's writeback), so the next suspect is `env["_"]` /
-      `topic_source_var` aliasing: the outer `given $x` makes `$_` track `$x`, and
-      the inner given's `env["_"] = <handle>` (`exec_given_op` line ~40) leaks to
-      `$x`. Investigate `exec_given_op` topic save/restore under nesting.
-      23 `.print-nl`, 29 `.WRITE`, 30 `.EOF/.WRITE` all need a user-subclassable
-      IO::Handle with polymorphic READ/WRITE/EOF. Substantial feature.)
+- [ ] roast/S32-io/io-handle.t (27/30 subtests pass; tests 22, 24 fixed.
+      Remaining 3:
+      22 `.say method` — FIXED: nested-`with`/`given` topic-source isolation.
+      Root cause was `topic_source_var` aliasing: `given $x` (or `with $x`,
+      which desugars to `given $x`) sets `topic_source_var = $x` so that
+      `$_ = ...` in the body writes back to `$x`. An inner `with LITERAL`
+      desugars to `$_ = (literal · __mutsu_topic_ro__)` and an inner
+      `with RVALUE` desugars to `$_ = $tmp`; BOTH ran in the outer scope and
+      propagated the inner topic back to `$x` through that alias. Fix is two
+      parts: (a) suppress the `topic_source_var` writeback when the assigned
+      value carries the `__mutsu_topic_ro__` marker (literal inner topic),
+      (b) route a non-lvalue, non-literal `with` (no pointy param) through
+      `given $tmp` so `$_` and `topic_source_var` are properly saved/restored
+      around the inner body instead of leaking into the enclosing scope.
+      Regression test: t/nested-with-topic-isolation.t.
+      23 `.print-nl` — needs `IO::Handle.open` to mutate the receiver in place:
+      `with IO::Handle.new(:path($f)) { .open: :w; .print-nl }` calls `.open`
+      on `$_`; mutsu's `.open` returns a fresh opened-handle Instance but does
+      NOT write the handle id back into the receiver `$_`, so the subsequent
+      `.print-nl` sees an unopened handle ("Expected IO::Handle"). Needs
+      method-call self-writeback of the opened handle id into the receiver.
+      29 `.WRITE`, 30 `.EOF/.WRITE` need a user-subclassable IO::Handle with
+      polymorphic READ/WRITE/EOF dispatch. Substantial feature.)
 - [x] roast/S32-io/io-path-cygwin.t
 - [ ] roast/S32-io/io-path-extension.t
 - [ ] roast/S32-io/io-path-subclasses.t

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -81,6 +81,15 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
         })
         .unwrap_or(false);
     let use_given_alias = cond_is_lvalue && (param_name.is_none() || pointy_routes_through_given);
+    // A non-lvalue, non-literal topic (`with foo()`) with no pointy parameter is
+    // run under `given $tmp` (the once-evaluated condition value), so `$_` is
+    // properly scoped: it is saved/restored around the body and the enclosing
+    // `given`/`with`'s topic-source writeback is suspended for the inner body.
+    // Without this, the flat `$_ = $tmp` topicalization runs in the outer scope
+    // and leaks back into the outer topic source — e.g. nested
+    // `with $x { with foo() { } }` clobbered `$x` with `foo()`'s value.
+    let is_literal_topic = matches!(&cond_expr, Expr::Literal(_));
+    let route_through_given_tmp = !cond_is_lvalue && !is_literal_topic && param_name.is_none();
     // Topicalize `$_` for the body. For a literal, wrap it in a Mixin marked
     // read-only so in-place mutation of `$_` throws X::Assignment::RO. Otherwise
     // reuse the `$tmp` holding the (once-evaluated) condition value.
@@ -230,6 +239,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
         with_body = vec![Stmt::Given {
             topic: cond_expr.clone(),
             body: given_body,
+        }];
+    } else if route_through_given_tmp {
+        with_body = vec![Stmt::Given {
+            topic: tmp_var.clone(),
+            body,
         }];
     } else {
         with_body.extend(body);

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -200,4 +200,15 @@ impl Interpreter {
     pub(crate) fn set_topic_source_var(&mut self, name: Option<String>) {
         self.topic_source_var = name;
     }
+
+    /// A `with LITERAL { ... }` block desugars to `$_ = (literal marked
+    /// __mutsu_topic_ro__)`, which *establishes a fresh topic scope* rather than
+    /// mutating an outer `given`/`with`'s aliased topic. When such an assignment
+    /// runs inside an enclosing `given $x` (whose `topic_source_var` is `$x`), the
+    /// topic-source writeback must be suppressed — otherwise the inner literal
+    /// topic leaks back into the outer source variable (e.g. nested
+    /// `with $x { with 12345 { } }` would clobber `$x` with `12345`).
+    pub(super) fn is_topic_ro_assignment(val: &Value) -> bool {
+        matches!(val, Value::Mixin(_, ov) if ov.contains_key("__mutsu_topic_ro__"))
+    }
 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1154,6 +1154,7 @@ impl Interpreter {
                     });
                 }
                 if name == "_"
+                    && !Self::is_topic_ro_assignment(&val)
                     && let Some(ref source_var) = self.topic_source_var
                     && !source_var.starts_with('@')
                     && !source_var.starts_with('%')

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1291,6 +1291,7 @@ impl Interpreter {
             self.env_mut().insert(format!(".{}", attr), val.clone());
         }
         if name == "_"
+            && !Self::is_topic_ro_assignment(&val)
             && let Some(ref source_var) = self.topic_source_var
             && !source_var.starts_with('@')
             && !source_var.starts_with('%')

--- a/t/nested-with-topic-isolation.t
+++ b/t/nested-with-topic-isolation.t
@@ -1,0 +1,78 @@
+use Test;
+
+# A nested `with`/`given` must not let the inner block's topic leak back into
+# the outer block's topic-source variable. Regression for the `given $x { with
+# EXPR {} }` clobber (roast S32-io/io-handle.t `.say method`): the inner `with`
+# topicalized `$_` to EXPR's value, which was wrongly written back to `$x`
+# through the outer `given`'s topic-source alias.
+
+plan 9;
+
+# Literal inner topic.
+{
+    my $x = "foos";
+    with $x {
+        with 12345 { }
+        is $x, "foos", 'literal inner with does not clobber outer my var';
+    }
+}
+
+# Non-literal (rvalue) inner topic.
+{
+    my $x = "outer";
+    sub inner-val { "INNER" }
+    with $x {
+        with inner-val() { }
+        is $x, "outer", 'rvalue inner with does not clobber outer my var';
+    }
+}
+
+# Outer topic is a (read-only) sub parameter, exactly like the roast shape.
+{
+    sub check (Str :$nl-out) {
+        with $nl-out {
+            with 999 { }
+            is $nl-out, "set", 'inner with does not clobber outer sub param (literal)';
+            with "other".uc { }
+            is $nl-out, "set", 'inner with does not clobber outer sub param (rvalue)';
+        }
+    }
+    check(:nl-out("set"));
+}
+
+# given (not with) outer scope.
+{
+    my $g = 3;
+    given $g {
+        with 100 { }
+        is $g, 3, 'inner with does not clobber outer given var';
+    }
+}
+
+# Inner topic restored, outer `$_ = ...` still writes back to the source.
+{
+    my $v = "start";
+    given $v {
+        with 7 { }
+        $_ = "changed";
+    }
+    is $v, "changed", 'outer given $_ writeback still works after inner with';
+}
+
+# `do with` value propagation is unaffected by the inner-topic routing.
+{
+    sub f { 42 }
+    is (do with f() { $_ + 1 }), 43, 'do with rvalue returns block value';
+    is (do with f() { $_ * 2 }), 84, 'do with rvalue returns last expr';
+}
+
+# Deeply nested with does not leak across two levels.
+{
+    my $a = "A";
+    with $a {
+        with "B" {
+            with "C" { }
+        }
+        is $a, "A", 'triple-nested with leaves outermost var intact';
+    }
+}


### PR DESCRIPTION
## Summary

A nested `with`/`given` leaked the inner block's topic into the **outer** block's topic-source variable.

In `given $x { with EXPR { } }`, the outer `given $x` (and `with $x`, which desugars to it) sets `topic_source_var` to `$x` so a `$_ = ...` in the body writes back to `$x`. The inner `with` desugars to a flat `$_ = ...` topicalization that ran in the *outer* scope, so it propagated the inner topic back into `$x`:

- `with LITERAL` → `$_ = (literal · __mutsu_topic_ro__)`
- `with RVALUE` → `$_ = $tmp`

Both wrote through the outer alias, clobbering `$x` with the inner value. Minimal repro:

```raku
my $x = "foos";
with $x { with 12345 { } }
say $x;   # was 12345, now "foos" (matches raku)
```

## Fix

1. Suppress the `topic_source_var` writeback when the assigned value carries the `__mutsu_topic_ro__` marker (literal-inner-topic case).
2. Route a non-lvalue, non-literal `with` (no pointy param) through `given $tmp` so `$_` and `topic_source_var` are properly saved/restored around the inner body instead of leaking into the enclosing scope.

## Result

Fixes roast `S32-io/io-handle.t` `.say method` (subtest 22 → now passing; io-handle.t 26→27/30). The remaining io-handle failures (23, 29, 30) need deeper IO::Handle features (`.open` receiver self-mutation; user-subclassable READ/WRITE/EOF) and are documented in `TODO_roast/S32.md`.

Adds `t/nested-with-topic-isolation.t` (9 assertions). `make test` passes; `do with` value propagation verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY