### PR TITLE
fix(io): IO::Handle.open mutates the receiver in place

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -457,8 +457,8 @@
 - [ ] roast/S32-io/empty.txt
 - [x] roast/S32-io/indir.t
 - [ ] roast/S32-io/io-cathandle.t
-- [ ] roast/S32-io/io-handle.t (27/30 subtests pass; tests 22, 24 fixed.
-      Remaining 3:
+- [ ] roast/S32-io/io-handle.t (28/30 subtests pass; tests 22, 23, 24 fixed.
+      Remaining 2:
       22 `.say method` — FIXED: nested-`with`/`given` topic-source isolation.
       Root cause was `topic_source_var` aliasing: `given $x` (or `with $x`,
       which desugars to `given $x`) sets `topic_source_var = $x` so that
@@ -472,12 +472,15 @@
       `given $tmp` so `$_` and `topic_source_var` are properly saved/restored
       around the inner body instead of leaking into the enclosing scope.
       Regression test: t/nested-with-topic-isolation.t.
-      23 `.print-nl` — needs `IO::Handle.open` to mutate the receiver in place:
-      `with IO::Handle.new(:path($f)) { .open: :w; .print-nl }` calls `.open`
-      on `$_`; mutsu's `.open` returns a fresh opened-handle Instance but does
-      NOT write the handle id back into the receiver `$_`, so the subsequent
-      `.print-nl` sees an unopened handle ("Expected IO::Handle"). Needs
-      method-call self-writeback of the opened handle id into the receiver.
+      23 `.print-nl` — FIXED: `IO::Handle.open` now mutates the receiver in
+      place. In Raku `$fh.open(...)` opens the handle and returns self, so a
+      later `$fh.print-nl` (or the `with` topic `.print-nl`) sees the opened
+      handle. mutsu builds a fresh opened-handle instance; the new
+      `native_io_handle_mut` (dispatched from `call_native_instance_method_mut`)
+      returns the opened handle's attributes as the `updated` map so the existing
+      `write_back_sharing` mechanism replaces the receiver's attributes. On open
+      error a Failure is returned and the receiver is left unopened.
+      Regression test: t/io-handle-open-mutates-receiver.t.
       29 `.WRITE`, 30 `.EOF/.WRITE` need a user-subclassable IO::Handle with
       polymorphic READ/WRITE/EOF dispatch. Substantial feature.)
 - [x] roast/S32-io/io-path-cygwin.t

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -1,6 +1,45 @@
 use super::*;
 
 impl Interpreter {
+    /// Mutable dispatch for `IO::Handle` methods that mutate the receiver in
+    /// place. Currently only `.open`: in Raku `$fh.open(...)` opens the handle
+    /// *and returns self*, so a later `$fh.print`/`$fh.print-nl` operates on the
+    /// now-opened handle. mutsu's `.open` builds a fresh opened-handle instance
+    /// (the handle id lives in the handle table); to match Raku, the receiver's
+    /// attributes must be replaced with the opened handle's so the caller's
+    /// binding (`$fh`, or the `with` topic `$_`) reflects the open. The returned
+    /// `updated` map is written back to the receiver by the caller
+    /// (`write_back_sharing`). Any other method falls back to the immutable path
+    /// via the sentinel "No native mutable method" error.
+    pub(crate) fn native_io_handle_mut(
+        &mut self,
+        attributes: HashMap<String, Value>,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        if method == "open" {
+            let result = self.native_io_handle(&attributes, "open", args)?;
+            // A successful open returns an `IO::Handle` instance carrying the new
+            // handle id; an error returns a `Failure`. Only mutate the receiver on
+            // success — on failure the handle stays unopened (as in Raku).
+            if let Value::Instance {
+                class_name,
+                attributes: new_attrs,
+                ..
+            } = &result
+                && class_name == "IO::Handle"
+            {
+                let updated = new_attrs.as_map().clone();
+                return Ok((result, updated));
+            }
+            return Ok((result, attributes));
+        }
+        Err(RuntimeError::new(format!(
+            "No native mutable method '{}' on 'IO::Handle'",
+            method
+        )))
+    }
+
     pub(crate) fn native_io_handle(
         &mut self,
         target: &HashMap<String, Value>,

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -289,6 +289,7 @@ impl Interpreter {
             })
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
+            "IO::Handle" => self.native_io_handle_mut(attributes, method, args),
             "Proc" => self.native_proc_mut(attributes, method, args),
             "Promise" => self.native_promise_mut(attributes, method, args),
             "Channel" => self.native_channel_mut(attributes, method, args),

--- a/t/io-handle-open-mutates-receiver.t
+++ b/t/io-handle-open-mutates-receiver.t
@@ -1,0 +1,69 @@
+use Test;
+
+# In Raku `$fh.open(...)` opens the handle *and returns self*, so a subsequent
+# method call on the same binding operates on the now-opened handle. mutsu's
+# `.open` builds a fresh opened-handle instance (the OS handle lives in the
+# handle table); the receiver binding must be updated to reflect the open.
+# Regression for roast S32-io/io-handle.t `.print-nl` (subtest 23).
+
+plan 6;
+
+my $dir = $*TMPDIR.add("mutsu-open-mutate-{$*PID}");
+$dir.mkdir;
+LEAVE { try $dir.&{ .dir».unlink; .rmdir } }
+
+# Variable receiver: .open then .print on the same variable.
+{
+    my $path = $dir.add("a.txt");
+    my $fh = IO::Handle.new(:path($path));
+    $fh.open(:w);
+    $fh.print("hello");
+    $fh.close;
+    is $path.slurp, "hello", '.open mutates a variable receiver (.print works after)';
+}
+
+# .nl-out passed to .open is honored by .print-nl.
+{
+    my $path = $dir.add("b.txt");
+    my $fh = IO::Handle.new(:path($path));
+    $fh.open(:w, :nl-out<bar>);
+    $fh.print-nl;
+    $fh.close;
+    is $path.slurp, "bar", '.open(:nl-out) honored by .print-nl on the receiver';
+}
+
+# Re-open (write then append) on the same variable.
+{
+    my $path = $dir.add("c.txt");
+    my $fh = IO::Handle.new(:path($path));
+    $fh.open(:w, :nl-out<bar>);  $fh.print-nl;  $fh.close;
+    $fh.open(:a);  $fh.nl-out = 'ber';  $fh.print-nl;  $fh.close;
+    is $path.slurp, "barber", 're-open (append) on the same receiver';
+}
+
+# Topic receiver inside `with` (the exact roast shape).
+{
+    my $path = $dir.add("d.txt");
+    with IO::Handle.new(:path($path)) {
+        .open: :w, :nl-out<bar>;  .print-nl;  .close;
+    }
+    is $path.slurp, "bar", '.open mutates the `with` topic receiver';
+}
+
+# Temp (non-variable) receiver still works: result is the opened handle.
+{
+    my $path = $dir.add("e.txt");
+    my $fh = IO::Handle.new(:path($path)).open(:w);
+    $fh.print("temp");
+    $fh.close;
+    is $path.slurp, "temp", '.open on a temp receiver returns the opened handle';
+}
+
+# Opening a missing file for read returns a Failure and leaves the binding
+# usable (does not corrupt the receiver into something un-droppable).
+{
+    my $path = $dir.add("missing.txt");
+    my $fh = IO::Handle.new(:path($path));
+    my $r = $fh.open(:r);
+    ok $r ~~ Failure, '.open of a missing file for read returns a Failure';
+}


### PR DESCRIPTION
## Summary

In Raku `\$fh.open(...)` opens the handle and **returns self**, so a later `\$fh.print` / `\$fh.print-nl` (or the `with` topic `.print-nl`) operates on the now-opened handle.

mutsu's `.open` builds a fresh opened-handle instance (the OS handle lives in the handle table) but never wrote the new handle id back into the receiver binding, so a subsequent method on the same variable saw an unopened handle and failed with `Expected IO::Handle`:

```raku
my $fh = IO::Handle.new(:path($path));
$fh.open(:w);
$fh.print("hello");   # was: "Expected IO::Handle"; now writes "hello"
$fh.close;
```

## Fix

Add `native_io_handle_mut`, dispatched from `call_native_instance_method_mut` for an `IO::Handle` receiver. For `.open` it computes the opened handle and returns its attributes as the `updated` map, so the existing `write_back_sharing` mechanism replaces the receiver's attributes with the opened handle's. On an open error a `Failure` is returned and the receiver is left unopened (matching Raku). All other methods fall through to the immutable path via the `No native mutable method` sentinel, so behavior is unchanged for them.

## Result

Fixes roast `S32-io/io-handle.t` `.print-nl` (subtest 23); io-handle.t now 27→28/30. The remaining 2 (`.WRITE`, `.EOF/.WRITE`) need a user-subclassable IO::Handle with polymorphic READ/WRITE/EOF — documented in `TODO_roast/S32.md`.

Adds `t/io-handle-open-mutates-receiver.t` (6 assertions). `cargo test` (477) passes; io roast suite (io-path/io-special/say/print/open/slurp/spurt) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY