### PR TITLE
fix(interp): .= on nested/declaration targets, string-block method names, scalar parameterized types

### DIFF
--- a/src/parser/expr/postfix/call_method.rs
+++ b/src/parser/expr/postfix/call_method.rs
@@ -213,9 +213,14 @@ pub(crate) fn parse_quoted_method_name(input: &str) -> Option<(&str, QuotedMetho
         return Some((rest, QuotedMethodName::Static(content.to_string())));
     }
     if input.starts_with('"') {
-        // Double-quoted: may have interpolation
+        // Double-quoted: may have interpolation. A `{ … }` interpolation block can
+        // itself contain `"`-delimited string literals (`."{$c++; "new"}"`), so the
+        // closing quote of the method name is only the `"` seen at brace-depth 0
+        // and outside any inner string literal.
         let start = 1;
         let mut escaped = false;
+        let mut brace_depth = 0i32;
+        let mut in_inner_str = false;
         let mut end = None;
         for (i, c) in input[start..].char_indices() {
             if escaped {
@@ -226,9 +231,23 @@ pub(crate) fn parse_quoted_method_name(input: &str) -> Option<(&str, QuotedMetho
                 escaped = true;
                 continue;
             }
-            if c == '"' {
-                end = Some(i);
-                break;
+            if in_inner_str {
+                // Inside a `"…"` literal nested in a `{ … }` block: only its own
+                // closing quote matters; braces here are string content.
+                if c == '"' {
+                    in_inner_str = false;
+                }
+                continue;
+            }
+            match c {
+                '{' => brace_depth += 1,
+                '}' => brace_depth = (brace_depth - 1).max(0),
+                '"' if brace_depth == 0 => {
+                    end = Some(i);
+                    break;
+                }
+                '"' => in_inner_str = true,
+                _ => {}
             }
         }
         let end = end?;

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -13,6 +13,20 @@ pub(crate) fn atomic_var_name(expr: &Expr) -> Option<String> {
     }
 }
 
+/// The writeback variable name (`AssignExpr`-convention: `x` / `@a` / `%h`) for an
+/// expression whose value is a simple-variable lvalue, or `None` otherwise. Used to
+/// route an outer `.=` through a `do { … }`-block target back to its lvalue.
+fn lvalue_assign_name(e: &Expr) -> Option<String> {
+    match e {
+        Expr::Grouped(inner) => lvalue_assign_name(inner),
+        Expr::AssignExpr { name, .. } => Some(name.clone()),
+        Expr::Var(n) => Some(n.clone()),
+        Expr::ArrayVar(n) => Some(format!("@{}", n)),
+        Expr::HashVar(n) => Some(format!("%{}", n)),
+        _ => None,
+    }
+}
+
 /// Wrap a `.=` method call result in the appropriate assignment expression.
 /// For simple variables, generates `AssignExpr { name, expr }`.
 /// For index expressions, generates an `IndexAssign` wrapped in a `DoBlock`.
@@ -83,6 +97,71 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
         // ($var = expr).=method => evaluate the assignment, then $var = $var.method
         Expr::AssignExpr { name, .. } => {
             let assign_name = name.clone();
+            let var_expr = if let Some(rest) = assign_name.strip_prefix('@') {
+                Expr::ArrayVar(rest.to_string())
+            } else if let Some(rest) = assign_name.strip_prefix('%') {
+                Expr::HashVar(rest.to_string())
+            } else {
+                Expr::Var(assign_name.clone())
+            };
+            let method_result = method_call_fn(var_expr);
+            Expr::DoBlock {
+                body: vec![
+                    Stmt::Expr(target),
+                    Stmt::Expr(Expr::AssignExpr {
+                        name: assign_name,
+                        expr: Box::new(method_result),
+                        is_bind: false,
+                    }),
+                ],
+                label: None,
+            }
+        }
+        // An inline declaration target (`(my Int $x .= new).= new: 42`) parses to
+        // `DoStmt(VarDecl)`. Run the declaration (which declares and initializes the
+        // variable), then assign the method result back to the just-declared
+        // variable so the outer `.=` writes through, mirroring the AssignExpr case.
+        Expr::DoStmt(stmt) if matches!(stmt.as_ref(), Stmt::VarDecl { .. }) => {
+            let decl_name = match stmt.as_ref() {
+                Stmt::VarDecl { name, .. } => name.clone(),
+                _ => unreachable!(),
+            };
+            let var_expr = if let Some(rest) = decl_name.strip_prefix('@') {
+                Expr::ArrayVar(rest.to_string())
+            } else if let Some(rest) = decl_name.strip_prefix('%') {
+                Expr::HashVar(rest.to_string())
+            } else {
+                Expr::Var(decl_name.clone())
+            };
+            let method_result = method_call_fn(var_expr);
+            Expr::DoBlock {
+                body: vec![
+                    Stmt::Expr(target),
+                    Stmt::Expr(Expr::AssignExpr {
+                        name: decl_name,
+                        expr: Box::new(method_result),
+                        is_bind: false,
+                    }),
+                ],
+                label: None,
+            }
+        }
+        // A `do { … }` block whose value is an lvalue (`do { …; ($x .= new) }.= new`)
+        // writes the outer `.=` result back to that lvalue. Run the block once (its
+        // side effects included), then assign `$x = $x.method`.
+        Expr::DoBlock { body, .. }
+            if body
+                .last()
+                .and_then(|s| match s {
+                    Stmt::Expr(e) => lvalue_assign_name(e),
+                    _ => None,
+                })
+                .is_some() =>
+        {
+            let assign_name = match body.last() {
+                Some(Stmt::Expr(e)) => lvalue_assign_name(e).unwrap(),
+                _ => unreachable!(),
+            };
             let var_expr = if let Some(rest) = assign_name.strip_prefix('@') {
                 Expr::ArrayVar(rest.to_string())
             } else if let Some(rest) = assign_name.strip_prefix('%') {

--- a/src/parser/primary/string/interp_content.rs
+++ b/src/parser/primary/string/interp_content.rs
@@ -55,8 +55,7 @@ pub(crate) fn interpolate_string_content_with_modes(
         if interpolate_closures
             && rest.starts_with('{')
             && let Some((after, inner)) = parse_braced_interpolation(rest)
-            && let Ok((remaining, expr)) = expression(inner.trim())
-            && remaining.trim().is_empty()
+            && let Some(expr) = parse_braced_closure_body(inner.trim())
         {
             if !current.is_empty() {
                 parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
@@ -75,6 +74,32 @@ pub(crate) fn interpolate_string_content_with_modes(
     }
 
     finalize_interpolation(parts, current)
+}
+
+/// Parse the body of a `{ … }` string-interpolation block. A block may hold a
+/// full statement list (`{$c++; "new"}`), not just a single expression — mirror
+/// the `$( … )` interpolation path: try a statement list first (so multi-statement
+/// blocks and statement-modifiers work), then fall back to a single expression.
+fn parse_braced_closure_body(inner: &str) -> Option<Expr> {
+    if let Ok((leftover, stmts)) = crate::parser::stmt::stmt_list_pub(inner)
+        && leftover.trim().is_empty()
+        && !stmts.is_empty()
+    {
+        return Some(if stmts.len() == 1 {
+            Expr::DoStmt(Box::new(stmts.into_iter().next().unwrap()))
+        } else {
+            Expr::DoBlock {
+                body: stmts,
+                label: None,
+            }
+        });
+    }
+    if let Ok((leftover, expr)) = expression(inner)
+        && leftover.trim().is_empty()
+    {
+        return Some(expr);
+    }
+    None
 }
 
 pub(crate) fn parse_braced_interpolation(input: &str) -> Option<(&str, &str)> {

--- a/src/vm/vm_misc_typecheck.rs
+++ b/src/vm/vm_misc_typecheck.rs
@@ -81,6 +81,12 @@ impl Interpreter {
         };
         if let Value::Array(..) = &value
             && !is_container_constraint
+            // Element-level matching is for `@`-sigil typed arrays (`my Int @a`),
+            // whose constraint is the ELEMENT type. A `$`-scalar holding an array
+            // (`my Array[Numeric] $x = …`, `my Array[Numeric] constant c .= new`)
+            // matches the WHOLE value against the (parameterized) type, not its
+            // elements — fall through to the whole-value type check below.
+            && !var_name.is_some_and(|n| n.starts_with('$'))
         {
             if !self.array_elements_match_constraint(constraint, &value) {
                 return Err(self.typed_array_element_error(

--- a/t/dot-assign-nested-and-parameterized.t
+++ b/t/dot-assign-nested-and-parameterized.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 7;
+
+# `.=` with a string-interpolated method name whose `{ … }` block is a full
+# statement list (not just one expression).
+{
+    my $c = 0;
+    (my Int $x .= new).="{$c++; "new"}"(42);
+    is-deeply $x, 42, '.= on an inline-declared var with a string-block method name';
+    is-deeply $c, 1, 'method-name block ran exactly once';
+}
+
+# Same, but the outer `.=` target is a `do { … }` block whose value is an lvalue.
+{
+    my $c = 0;
+    my $b = 0;
+    my Int $x;
+    do { $b++; ($x .= new) }.="{$c++; "new"}"(42);
+    is-deeply $x, 42, '.= through a do-block lvalue target';
+    is-deeply "$b $c", '1 1', 'do-block and method-name block each ran once';
+}
+
+# A `$`-scalar with a parameterized container type matches the WHOLE value, not
+# its elements (element matching is only for `@`-sigil typed arrays).
+{
+    my Array[Numeric] $x = Array[Numeric].new(1, 2, 3);
+    is-deeply $x, Array[Numeric].new(1, 2, 3), 'scalar parameterized-array type matches whole value';
+
+    my Array[Numeric] constant foo .= new: 1, 2, 3;
+    is-deeply foo, Array[Numeric].new(1, 2, 3), 'parameterized-array constant via .=new';
+}
+
+# Regression guard: `@`-sigil element typing still rejects bad elements.
+{
+    dies-ok { my Int @a = 1, "x", 3 }, 'typed array still element-checks';
+}


### PR DESCRIPTION
Advances `roast/S03-operators/inplace.t` (4 → 2 failing) via four related fixes.

## Fixes

1. **Quoted method name scanner** (`.="…"`): track `{ … }` brace depth and nested string literals so the closing quote of `."{$c++; "new"}"` is found correctly instead of stopping at the inner `"`.

2. **String `{ … }` interpolation block**: parse a full statement list first (mirroring the `$( … )` path), so a multi-statement block method name (`{$c++; "new"}`) is evaluated as code rather than partially var-substituted.

3. **`wrap_dot_assign`**: handle an inline-declaration target (`(my Int $x .= new).= new`, i.e. `DoStmt(VarDecl)`) and a `do { … }`-block target whose value is an lvalue — writing the outer `.=` result back to that variable (mirrors the existing `AssignExpr` case).

4. **Scalar type check**: a `$`-scalar with a parameterized container type (`my Array[Numeric] $x = …`, `my Array[Numeric] constant c .= new`) matches the WHOLE value against the type, not element-wise. Element matching stays for `@`-sigil typed arrays only (this also fixes the latent `my Int $x = [1,2,3]` mis-accept).

## Impact

- `inplace.t`: tests 37 and 38 now pass; only 32 and 36 remain (both `.=` topic-writeback through given/with `@`-topic and andthen/orelse chains — deferred as a deeper topic-aliasing fix).
- New test: `t/dot-assign-nested-and-parameterized.t` (7 cases incl. regression guard).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)