### PR TITLE
fix(for): iterate the live array so in-loop pushes are picked up

### DIFF
--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -241,6 +241,7 @@ impl Compiler {
             multi_param_names: Vec::new(),
             loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
             values_mode: Self::for_iterable_is_values_alias(iterable),
+            single_array_source: Self::for_single_array_source(iterable),
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -718,6 +718,16 @@ impl Compiler {
 
     /// Extract per-element variable names when the iterable is a list of
     /// scalar variables (e.g. `($a, $b, $c)`). Returns an empty vec otherwise.
+    /// The bare array variable name for a `for @a` loop (iterable is a single
+    /// plain `@`-variable), used for live-array iteration. `None` for anything
+    /// else (a transform, a literal list, a scalar, an index expression, …).
+    fn for_single_array_source(iterable: &Expr) -> Option<String> {
+        match iterable {
+            Expr::ArrayVar(name) => Some(name.clone()),
+            _ => None,
+        }
+    }
+
     fn for_iterable_var_names(iterable: &Expr) -> Vec<String> {
         if let Expr::ArrayLiteral(items) = iterable {
             let names: Vec<String> = items

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1582,6 +1582,7 @@ impl Compiler {
                         .collect(),
                     loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
                     values_mode: Self::for_iterable_is_values_alias(iterable),
+                    single_array_source: Self::for_single_array_source(iterable),
                 });
                 // Register sigilless for-params (`-> \v`, `-> \k, \v`) as
                 // sigilless locals while compiling the body so postfix/prefix

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -848,6 +848,13 @@ pub(crate) enum OpCode {
         /// type. Distinguished from bare `for %h` (Pairs, no value writeback) and
         /// `.keys` (read-only).
         values_mode: bool,
+        /// The bare source array variable name for `for @a` (without sigil), when
+        /// the iterable is a single plain array variable. Enables live-array
+        /// iteration: if the loop body pushes onto `@a`, the loop keeps yielding
+        /// the newly-appended tail (raku semantics). `None` for any non-trivial
+        /// iterable. Separate from `source_var_names` (a per-index scalar-list
+        /// writeback mechanism that must NOT be populated for a `@`-source).
+        single_array_source: Option<String>,
     },
     /// Restore the single named for-loop param's prior binding, deferred until
     /// after the loop's LAST/post phasers have run (which must still see the

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -28,6 +28,9 @@ pub(super) struct ForLoopSpec {
     /// container's value, so a `$_ = ...` topic writeback updates the source
     /// (plain Hash or mutable MixHash/BagHash) by key order.
     pub(super) values_mode: bool,
+    /// Bare source array name for `for @a` (live-array iteration). See the
+    /// `OpCode::ForLoop` field of the same name.
+    pub(super) single_array_source: Option<String>,
 }
 
 pub(super) struct WhileLoopSpec {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2928,6 +2928,7 @@ impl Interpreter {
                 multi_param_names,
                 loop_var_wraps_element,
                 values_mode,
+                single_array_source,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -2948,6 +2949,7 @@ impl Interpreter {
                     multi_param_names: multi_param_names.clone(),
                     loop_var_wraps_element: *loop_var_wraps_element,
                     values_mode: *values_mode,
+                    single_array_source: single_array_source.clone(),
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -12,7 +12,12 @@ impl Interpreter {
         loop_end: usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
         resume_index: usize,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<bool, RuntimeError> {
+        // `true`  = the loop ran every item to completion;
+        // `false` = it exited early via `last` or `return` (the live-array
+        // continuation in `exec_for_loop_op` must NOT pick up newly-pushed tail
+        // elements after an early exit).
+        let mut completed_all = true;
         let param_name = spec
             .param_idx
             .map(|idx| match &code.constants[idx as usize] {
@@ -449,6 +454,7 @@ impl Interpreter {
                                 self.stack.push(v);
                             }
                         }
+                        completed_all = false;
                         break 'for_loop;
                     }
                     Err(e) if e.is_last() && Self::label_matches(&e.label, &spec.label) => {
@@ -482,6 +488,7 @@ impl Interpreter {
                             &param_name,
                             idx,
                         );
+                        completed_all = false;
                         break 'for_loop;
                     }
                     Err(e) if e.is_next() && Self::label_matches(&e.label, &spec.label) => {
@@ -681,6 +688,6 @@ impl Interpreter {
             }
             self.stack.push(Value::array(coll));
         }
-        Ok(())
+        Ok(completed_all)
     }
 }

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -38,7 +38,7 @@ impl Interpreter {
                     return Ok(());
                 }
                 crate::value::ForLoopResumeState::List { items, next_index } => {
-                    self.exec_for_loop_body(
+                    let _ = self.exec_for_loop_body(
                         code,
                         spec,
                         &items,
@@ -217,10 +217,63 @@ impl Interpreter {
                 .unwrap_or_else(|_| Err(RuntimeError::new("thread panicked in race/hyper for")))
             });
             *ip = loop_end;
-            return result;
+            return result.map(|_| ());
         }
 
-        self.exec_for_loop_body(code, spec, &items, body_start, loop_end, compiled_fns, 0)?;
+        // Live-array iteration (RT113026): `for @a -> $n { @a.push: ... }` must
+        // iterate the *live* array — raku keeps yielding elements pushed during the
+        // loop. mutsu materialized `items` once via `value_to_list`, so it stopped
+        // at the original length. After each pass, if the single plain source array
+        // grew AND the loop ran to completion (no `last`/`return`), pick up the new
+        // tail (`resume_index = old_len`) and continue. Gated narrowly so only a
+        // bare `for @array` (no multi-arity / kv / values / pairs / non-array
+        // source) takes this path; everything else runs exactly as before.
+        let live_src: Option<&String> = spec.single_array_source.as_ref().filter(|_| {
+            spec.arity <= 1
+                && !spec.kv_mode
+                && !spec.values_mode
+                && !spec.loop_var_wraps_element
+                // A collecting loop (`my @r = (for @a {...})`) pushes its result
+                // array at the END of each `exec_for_loop_body` pass, so a
+                // continuation would emit one collected array per pass — keep
+                // those on the single-pass path (live-array growth in a collect
+                // context is not exercised by roast and needs cross-pass accum.).
+                && !spec.collect
+                && matches!(iterable, Value::Array(..))
+        });
+        let mut all_items = items;
+        let mut resume = 0usize;
+        loop {
+            let completed = self.exec_for_loop_body(
+                code,
+                spec,
+                &all_items,
+                body_start,
+                loop_end,
+                compiled_fns,
+                resume,
+            )?;
+            let Some(name) = live_src else { break };
+            if !completed {
+                break;
+            }
+            // Re-read the live source array. In the single-store model `@a` is
+            // authoritative in its local slot (the env copy can be stale), so try
+            // the local slot first (bare and `@`-sigiled names), then env.
+            let live = self
+                .find_local_slot(code, name)
+                .or_else(|| self.find_local_slot(code, &format!("@{name}")))
+                .map(|s| self.locals[s].clone())
+                .or_else(|| self.env().get(name).cloned());
+            let grown = match live {
+                Some(Value::Array(arc, _)) if arc.len() > all_items.len() => {
+                    arc.as_slice().to_vec()
+                }
+                _ => break,
+            };
+            resume = all_items.len();
+            all_items = grown;
+        }
         *ip = loop_end;
         Ok(())
     }

--- a/t/for-live-array-iteration.t
+++ b/t/for-live-array-iteration.t
@@ -1,0 +1,66 @@
+use Test;
+
+# `for @a { @a.push(...) }` iterates the LIVE array: elements appended to the
+# source during the loop are picked up and iterated, matching Rakudo. mutsu used
+# to materialise the iteration list once and stop at the original length.
+# (roast/S04-statements/for.t tests 82/83, RT113026.)
+
+plan 8;
+
+# The canonical RT113026 case.
+{
+    my @a = 1 .. 10;
+    my $iter = 0;
+    for @a -> $n {
+        $iter++;
+        @a.push: $n if $iter % 2;
+    }
+    is $iter, 20, 'iterating over an expanding list runs for every appended item';
+    is-deeply @a, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 3, 5, 7, 9, 1, 5, 9, 5, 5],
+        'the array expanded in the for loop is fully expanded';
+}
+
+# Topic form (`$_`) also iterates the live array.
+{
+    my @b = 1, 2;
+    my $count = 0;
+    for @b {
+        $count++;
+        @b.push(0) if $count < 4;   # bounded so it terminates
+    }
+    is $count, 5, 'topic for over an expanding array picks up appended items';
+}
+
+# `last` stops the whole loop even though the array is still growing.
+{
+    my @c = 1, 2, 3;
+    my $c = 0;
+    for @c -> $n {
+        $c++;
+        @c.push(99);
+        last if $c >= 3;
+    }
+    is $c, 3, 'last stops the expanding loop';
+    is @c.elems, 6, 'last leaves the array with only the in-loop pushes';
+}
+
+# `return` from inside the loop exits without continuing into appended items.
+{
+    sub f { my @d = 1, 2, 3; for @d -> $n { @d.push(9); return $n if $n == 2 } }
+    is f(), 2, 'return from an expanding for loop exits immediately';
+}
+
+# A non-growing plain `for @a` is unaffected.
+{
+    my @e = 1, 2, 3;
+    my $sum = 0;
+    $sum += $_ for @e;
+    is $sum, 6, 'a non-growing for loop iterates exactly once per element';
+}
+
+# Iterating a literal list (not a single array var) is unaffected.
+{
+    my $n = 0;
+    for (1, 2, 3) { $n++ }
+    is $n, 3, 'for over a literal list is not treated as a live array';
+}


### PR DESCRIPTION
## What

`for @a -> $n { @a.push: ... }` must iterate the **live** array — Rakudo keeps yielding elements appended to the source during the loop. mutsu materialized the iteration list once via `value_to_list`, so it stopped at the original length:

```raku
my @a = 1..10; my $iter = 0;
for @a -> $n { $iter++; @a.push: $n if $iter %% 2 }
say $iter;   # mutsu: 10   raku: 20
```

(roast/S04-statements/for.t tests 82/83, RT113026.)

## How

- **Dispatch-level continuation** (`vm_for_loop_dispatch.rs`): after each `exec_for_loop_body` pass, if the single plain source array grew **and** the loop ran to completion, pick up the new tail (`resume_index = old_len`) and run again.
- **Early-exit signal**: `exec_for_loop_body` now returns `bool` (false on a `last`/`return` break). An early exit stops the continuation, so a `last` does **not** wrongly resume into newly-pushed elements (verified: `last` stops, no infinite loop).
- **Source name**: a new `single_array_source` field on the `ForLoop` opcode/spec, set only when the iterable is a bare `@`-variable. Kept **separate** from `source_var_names` (a per-index scalar-list writeback mechanism that would corrupt a `@`-source). The live array is re-read from its **local slot** (authoritative in the single-store model; the env copy can be stale).
- **Narrow gate**: arity 1, not kv/values/pairs/**collect**, iterable is `Value::Array`. Every other loop runs exactly as before.

## Tests

- `t/for-live-array-iteration.t` (8 subtests): expanding loop, topic form, `last`/`return` early-exit, non-growing + literal-list regression guards.
- `make test` (12949) **PASS** and `make roast` **PASS** (no regressions).
- **for.t: 102/111 → 104/111** (82/83 now pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)