### PR TITLE
fix(interp): chained .= writes back through the andthen/orelse/notandthen topic

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -171,13 +171,27 @@
   - 11/41 pass.
 - [x] roast/S03-operators/infixed-function.t
 - [ ] roast/S03-operators/inplace.t
-  - 33/38 pass (5 failing subtests: 32, 33, 34, 36, 37). Subtest 34's sigilless
-    `.= Numeric` inits were unblocked by the Mu.Numeric coercion default (#3621)
-    and scope-transparent `quietly` (#3623). Remaining failures are disparate `.=`
-    metaop edge cases: method-chain `.=` with fake-infix adverb args
-    (`($p2 = ...).=new :key<foo>`), `quietly`-warn cases in subtest 34's later
-    asserts, `.=` inside `andthen`/`orelse` (36), and `($o2 = ...).=meth` weird
-    cases (37). Each is a separate mini-feature in `.=` parsing/lowering.
+  - **2026-06-28: 36/38 pass (2 failing: 32, 36).** Landed:
+    - (#3894) string-block method names (`."{$c++; "new"}"`), inline-decl /
+      do-block `.=` targets (`(my Int $x .= new).= new`, `do {…}.= new`), and
+      scalar parameterized-container type checks (`my Array[Numeric] $x = …`).
+      Fixed tests 37, 38.
+    - chained `.=` topic writeback: `$var andthen/orelse/notandthen .=method`
+      retargets the implied-`$_` `.=` to the chain root variable (the topic
+      aliases it in Raku), recursing through nested chains. Handles test 36's
+      x1/x3 cases. t/chained-dotassign-writeback.t.
+  - **Remaining (32, 36):**
+    - Test 36 still fails on its x2/x4 cases: fake-infix adverbs on a `.=method`
+      inside an `andthen`/`orelse` *expression* chain — `.=self :42moews` (`.self`
+      rejects the named arg) and `.=new :42a :70b` (parses to a spurious CALL-ME
+      in expression context, though `my Meow $m .= new :42a :70b` in *declaration*
+      context works). Separate fake-infix-adverb lowering issue.
+    - Test 32: (a) `.=` on a class instance with a `STORE` method
+      (`(Foo.new).=foo` must invoke `STORE` and return the instance — Proxy-like
+      semantics), and (b) `with @a { .=uc }` — an `@`/`%` topic is read-only-for-
+      reassign in mutsu's `given`/`with`, so `$_ = $_.uc` throws; raku aliases the
+      topic writably. Both need topic/Proxy write-through (deeper than the chained
+      retarget above).
 - [ ] roast/S03-operators/is-divisible-by.t
   - 7/16 pass.
 - [x] roast/S03-operators/lcm.t

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -18,6 +18,97 @@ impl Compiler {
         )
     }
 
+    /// The chain's root lvalue variable name (`x` / `@a` / `%h`), if the leftmost
+    /// operand of an `andthen`/`orelse`/`notandthen` chain is a simple variable.
+    fn chain_root_lvalue_name(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Var(n) => Some(n.clone()),
+            Expr::ArrayVar(n) => Some(format!("@{}", n)),
+            Expr::HashVar(n) => Some(format!("%{}", n)),
+            Expr::Grouped(inner) => Self::chain_root_lvalue_name(inner),
+            Expr::Binary {
+                left,
+                op: TokenKind::AndThen | TokenKind::OrElse | TokenKind::NotAndThen,
+                ..
+            } => Self::chain_root_lvalue_name(left),
+            _ => None,
+        }
+    }
+
+    /// Replace the implied topic `$_` with `var` in a `.=`-method-call target so
+    /// the mutation writes through to the chain's root variable.
+    fn subst_topic_var(expr: &Expr, var: &str) -> Expr {
+        match expr {
+            Expr::Var(n) if n == "_" => Expr::Var(var.to_string()),
+            Expr::Grouped(inner) => Expr::Grouped(Box::new(Self::subst_topic_var(inner, var))),
+            Expr::MethodCall {
+                target,
+                name,
+                args,
+                modifier,
+                quoted,
+            } => Expr::MethodCall {
+                target: Box::new(Self::subst_topic_var(target, var)),
+                name: *name,
+                args: args.clone(),
+                modifier: *modifier,
+                quoted: *quoted,
+            },
+            Expr::DynamicMethodCall {
+                target,
+                name_expr,
+                args,
+                modifier,
+            } => Expr::DynamicMethodCall {
+                target: Box::new(Self::subst_topic_var(target, var)),
+                name_expr: name_expr.clone(),
+                args: args.clone(),
+                modifier: *modifier,
+            },
+            other => other.clone(),
+        }
+    }
+
+    /// `$var andthen/orelse/notandthen .=method` — an implied-`$_` `.=` in the RHS
+    /// mutates the topic, which raku aliases to the chain's root lvalue, so it must
+    /// write back to that variable. Recursively retarget every implied-`$_` `.=`
+    /// (`AssignExpr` to `_`) in the RHS subtree to `root`, descending through nested
+    /// `andthen`/`orelse`/`notandthen` chains (so `$x orelse .=new andthen .=new`
+    /// parses as `$x orelse (… andthen …)` and both `.=` still target `$x`). A
+    /// sub-chain whose own left names a variable rebinds the root for its right.
+    /// Non-`.=` RHS forms (e.g. `$x andthen .say`) are left untouched.
+    fn retarget_chain_rhs(node: &Expr, root: &str) -> Expr {
+        match node {
+            Expr::AssignExpr {
+                name,
+                expr: inner,
+                is_bind: false,
+            } if name == "_" => Expr::AssignExpr {
+                name: root.to_string(),
+                expr: Box::new(Self::subst_topic_var(inner, root)),
+                is_bind: false,
+            },
+            Expr::Grouped(inner) => Expr::Grouped(Box::new(Self::retarget_chain_rhs(inner, root))),
+            Expr::Binary { left, op, right }
+                if matches!(
+                    op,
+                    TokenKind::AndThen | TokenKind::OrElse | TokenKind::NotAndThen
+                ) =>
+            {
+                let left_new = Self::retarget_chain_rhs(left, root);
+                let right_root =
+                    Self::chain_root_lvalue_name(left).unwrap_or_else(|| root.to_string());
+                let right_new = Self::retarget_chain_rhs(right, &right_root);
+                Expr::Binary {
+                    left: Box::new(left_new),
+                    op: op.clone(),
+                    right: Box::new(right_new),
+                }
+            }
+            other => other.clone(),
+        }
+    }
+
     pub(super) fn compile_expr_binary(
         &mut self,
         expr: &Expr,
@@ -25,6 +116,19 @@ impl Compiler {
         op: &TokenKind,
         right: &Expr,
     ) {
+        // `$var andthen/orelse/notandthen .=method` writes the `.=` result back to
+        // the chain's root variable (the topic `$_` aliases it in raku).
+        let retargeted_right;
+        let right: &Expr = if matches!(
+            op,
+            TokenKind::AndThen | TokenKind::OrElse | TokenKind::NotAndThen
+        ) && let Some(root) = Self::chain_root_lvalue_name(left)
+        {
+            retargeted_right = Self::retarget_chain_rhs(right, &root);
+            &retargeted_right
+        } else {
+            right
+        };
         // Special handling for `but` with a literal tuple RHS:
         // `True but (1, "x")` compiles as multiple ButMixinTupleElem operations
         // (one per element), generating per-element type methods with conflict

--- a/t/chained-dotassign-writeback.t
+++ b/t/chained-dotassign-writeback.t
@@ -1,0 +1,40 @@
+use Test;
+
+# `$var andthen/orelse/notandthen .=method` mutates the topic, which Raku aliases
+# to the chain's root variable, so the `.=` writes back to that variable. This
+# holds across nested chains (`$x orelse .=new andthen .=new` parses as
+# `$x orelse (… andthen …)`, yet both `.=` still target `$x`).
+
+plan 5;
+
+{
+    my Int $x1;
+    $x1 notandthen .=new;
+    is-deeply $x1, 0, 'notandthen .=new writes back (Int.new == 0)';
+}
+
+{
+    my Int $x3;
+    $x3 orelse .=new andthen .=new: 43;
+    is-deeply $x3, 43, 'orelse/andthen chain .=new writes back through the root';
+}
+
+{
+    my $s = 'foo';
+    $s andthen .=uc;
+    is-deeply $s, 'FOO', 'andthen .=uc writes back to a defined scalar';
+}
+
+# Non-`.=` chain RHS still reads the topic (no spurious retarget).
+{
+    my $seen;
+    42 andthen $seen = $_;
+    is-deeply $seen, 42, 'andthen topic $_ still readable in a non-.= RHS';
+}
+
+# A plain `orelse` default value is unaffected.
+{
+    my $u;
+    my $r = $u // 99;
+    is-deeply $r, 99, 'defined-or default still works';
+}


### PR DESCRIPTION
## What

`$var andthen/orelse/notandthen .=method` mutates the topic `$_`, which Raku aliases to the chain's root lvalue, so the `.=` must write back to that variable. mutsu set the topic to a *copy*, so:

```raku
my Int $x1; $x1 notandthen .=new; say $x1;   # was: (Int)   now: 0
my Int $x3; $x3 orelse .=new andthen .=new: 43; say $x3;   # was: (Int)  now: 43
```

## How

The compiler retargets an implied-`$_` `.=` (an `AssignExpr` to `_`) in the RHS of an `andthen`/`orelse`/`notandthen` to the chain's root variable, recursing through nested chains — `$x orelse .=new andthen .=new` parses as `$x orelse (… andthen …)`, yet both `.=` still target `$x`. Non-`.=` RHS forms (`$x andthen .say`) are untouched (they still read the topic).

## Impact

- Advances `roast/S03-operators/inplace.t` test 36 (its x1/x3 cases). The remaining x2/x4 cases need fake-infix-adverb-on-method lowering inside an expression chain (`.=self :42moews`, `.=new :42a :70b`) — documented in `TODO_roast/S03.md`.
- New test: `t/chained-dotassign-writeback.t` (5 cases incl. regression guards for topic reads and defined-or).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)