### PR TITLE
fix(interp): .self ignores args; andthen/orelse only call a Callable instance RHS

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -186,6 +186,16 @@
       rejects the named arg) and `.=new :42a :70b` (parses to a spurious CALL-ME
       in expression context, though `my Meow $m .= new :42a :70b` in *declaration*
       context works). Separate fake-infix-adverb lowering issue.
+    - **2026-06-28 update**: x2's `.self`-rejects-args and the CALL-ME mis-invoke
+      are fixed — `.self` now ignores arguments (returns the invocant), and
+      `__mutsu_andthen_finalize` only *calls* an instance RHS when it is `Callable`
+      (has `CALL-ME`), so `$x orelse Foo.new` returns the instance instead of
+      throwing CALL-ME. test 36 now passes x1/x2/x3; **only x4 remains**: the
+      4-link chain `… andthen .=new: :10a, :20b` throws "Default constructor …
+      only takes named arguments" — a multi-link colon-arg chain runtime bug
+      (each link works in isolation; only the full chain fails). t/andthen-orelse-instance-rhs.t.
+      Also note: `my $r = ($x orelse <val>)` returns Nil for ANY `<val>` — a
+      separate pre-existing orelse-in-assignment bug.
     - Test 32: (a) `.=` on a class instance with a `STORE` method
       (`(Foo.new).=foo` must invoke `STORE` and return the instance — Proxy-like
       semantics), and (b) `with @a { .=uc }` — an `@`/`%` topic is read-only-for-

--- a/src/runtime/builtins_feed.rs
+++ b/src/runtime/builtins_feed.rs
@@ -129,14 +129,19 @@ impl Interpreter {
         }
         let lhs = args[0].clone();
         let rhs = args[1].clone();
-        if matches!(
-            rhs,
-            Value::Sub(_)
-                | Value::WeakSub(_)
-                | Value::Routine { .. }
-                | Value::Instance { .. }
-                | Value::Mixin(..)
-        ) {
+        // The RHS of `andthen`/`orelse`/`notandthen` is invoked with the topic
+        // only when it is actually callable. A plain instance (`$x orelse
+        // Foo.new`) is a value, not a block — call it only if it is `Callable`
+        // (has a `CALL-ME`), otherwise `Foo.new` would be mis-invoked as `Foo()`.
+        let rhs_is_callable = match &rhs {
+            Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } | Value::Mixin(..) => true,
+            Value::Instance { class_name, .. } => {
+                let cn = class_name.resolve();
+                self.class_has_method(&cn, "CALL-ME")
+            }
+            _ => false,
+        };
+        if rhs_is_callable {
             let saved_topic = self.env.get("_").cloned();
             self.env.insert("_".to_string(), lhs.clone());
             let result = self.eval_call_on_value(rhs, vec![lhs]);

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -32,6 +32,11 @@ impl Interpreter {
             }
             return Err(RuntimeError::emit_signal(target));
         }
+        // `.self` ignores any arguments (e.g. the fake-infix adverbs on
+        // `$x .= self :42moews`); it always returns the invocant.
+        if method == "self" && !args.is_empty() {
+            return self.call_method_with_values(target, "self", Vec::new());
+        }
         // `.sum(:wrap)` / `.sum(:method)`: the only adverb that affects native
         // arrays (`:wrap` selects wrapping overflow) is equivalent here; treat a
         // named-only argument list as a plain `.sum`.

--- a/t/andthen-orelse-instance-rhs.t
+++ b/t/andthen-orelse-instance-rhs.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 5;
+
+# `andthen`/`orelse` must NOT mis-invoke a plain instance RHS as `Foo()`
+# (which failed with "No such method 'CALL-ME'"). The instance is the value.
+{
+    my class Meow { has $.a; }
+    my $x;
+    isa-ok ($x orelse Meow.new), Meow,
+        'orelse instance RHS returns the instance, not a CALL-ME error';
+}
+
+# Same through a method call returning an instance, in a chain position.
+{
+    my class Box { has $.v; }
+    my $x;
+    isa-ok ($x orelse Box.new(:v(1)) andthen $_), Box,
+        'orelse/andthen instance RHS is not mis-invoked';
+}
+
+# `.self` ignores arguments (fake-infix adverbs on `.= self`) and returns self.
+{
+    my Int $x;
+    $x notandthen .=self :42moews :100foos notandthen .=new: 42;
+    is-deeply $x, 42, '.=self ignores fake-infix adverbs; chain continues';
+}
+
+# A plain `.self` with a named arg returns the invocant.
+{
+    my $v = 5;
+    is-deeply $v.self(:ignored), 5, '.self with a named arg returns self';
+}
+
+# Chained `.=new` writeback through orelse/andthen still works.
+{
+    my Int $x3;
+    $x3 orelse .=new andthen .=new: 43;
+    is-deeply $x3, 43, 'orelse/andthen chained .=new writeback';
+}


### PR DESCRIPTION
Two correctness fixes advancing `roast/S03-operators/inplace.t` test 36.

## Fixes

1. **`.self` ignores arguments** and returns the invocant. `$x .= self :42moews` (fake-infix adverbs on `.= self`) previously failed with `No such method 'self'` because `.self` was a strictly 0-arg native method.

2. **`__mutsu_andthen_finalize` only invokes a Callable RHS.** The RHS of `andthen`/`orelse`/`notandthen` is called with the topic only when it is genuinely Callable (a `Sub`/`Routine`/`Mixin`, or an instance with a `CALL-ME` method). A plain instance (`$x orelse Foo.new`) is a value, not a block, so it is returned as-is instead of being mis-invoked as `Foo()` — which threw `No such method 'CALL-ME'`.

## Impact

- `inplace.t` test 36 now passes x1/x2/x3; only **x4** remains — a multi-link colon-arg chain runtime bug (`… andthen .=new: :10a, :20b`; each link works in isolation, only the full 4-link chain fails). Documented in `TODO_roast/S03.md`.
- New test: `t/andthen-orelse-instance-rhs.t` (5 cases).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)