### PR TITLE
fix(package): named subs see/mutate package vars on every call

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -382,6 +382,9 @@ impl Compiler {
             named_param_slots: None,
             deprecated_info,
             declared_locals: None,
+            // The declaring package, matching the package component of this
+            // function's `compiled_fns` key (built from `self.current_package`).
+            package: self.current_package.clone(),
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_param_slots();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2430,6 +2430,15 @@ pub(crate) struct CompiledFunction {
     /// (which should be restored after recursive calls) from captured outer vars
     /// (which should keep their modified values).
     pub(crate) declared_locals: Option<std::collections::HashSet<String>>,
+    /// The package this routine was declared in (e.g. `"P"` for a sub in
+    /// `package P { ... }`, `"GLOBAL"` for a top-level sub). The dispatch sets
+    /// `current_package` from this on entry so package-scoped variable
+    /// resolution (`our $x` / a `package { my $x }` lexical read or written from
+    /// inside the sub) works on EVERY call — not just the first OTF compile,
+    /// which was the only path that previously used the defining package. Call
+    /// sites pass the *caller's* package, which is wrong for a by-name call into
+    /// another package; this authoritative field fixes all of them at once.
+    pub(crate) package: String,
 }
 
 impl CompiledFunction {

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -170,6 +170,7 @@ impl Interpreter {
             named_param_slots: None,
             deprecated_info,
             declared_locals: None,
+            package: pkg.clone(),
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_param_slots();

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -2,6 +2,31 @@ use super::*;
 use crate::runtime::types::unwrap_varref_value;
 
 impl Interpreter {
+    /// Switch `current_package` to a compiled routine's declaring package for the
+    /// duration of its body, returning the previous package to restore on exit
+    /// (`None` when no switch was needed). This is what makes package-scoped
+    /// variable resolution (`our $x` / a `package { my $x }` lexical read or
+    /// written from inside the routine) work on EVERY dispatch path — fast, light,
+    /// positional-light — not just the OTF/named path that already set it. The
+    /// gate (real, non-mangled, non-GLOBAL package) keeps the hot GLOBAL-function
+    /// path (fib, ...) free of any lock/string churn: it returns `None` cheaply.
+    pub(super) fn enter_routine_package(&mut self, cf: &CompiledFunction) -> Option<String> {
+        if !cf.package.is_empty() && cf.package != "GLOBAL" && !cf.package.contains("::&") {
+            let saved = self.current_package();
+            self.set_current_package(cf.package.clone());
+            Some(saved)
+        } else {
+            None
+        }
+    }
+
+    /// Restore the package saved by [`enter_routine_package`].
+    pub(super) fn leave_routine_package(&mut self, saved: Option<String>) {
+        if let Some(s) = saved {
+            self.set_current_package(s);
+        }
+    }
+
     /// Check if a compiled function is eligible for the fast call path.
     /// Returns true for simple functions that don't need the full call machinery.
     /// State variables are supported: both `state_locals` load/sync and anonymous

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -87,6 +87,13 @@ impl Interpreter {
             }
         }
 
+        // Set current_package to the routine's declaring package so package-scoped
+        // variable resolution (`our $x` / a `package { my $x }` lexical) works on
+        // this fast path too. The fast path is taken for cached 2nd+ calls and does
+        // NOT otherwise set current_package, so a by-name call into another package
+        // (`P::show()` from GLOBAL) would run the body under GLOBAL and silently
+        // lose package-var reads/writes.
+        let saved_package = self.enter_routine_package(cf);
         let let_mark = self.let_saves_len();
         let mut ip = 0;
         let mut result = Ok(());
@@ -254,6 +261,8 @@ impl Interpreter {
                 }
             });
         }
+
+        self.leave_routine_package(saved_package);
 
         let final_result = match result {
             Ok(()) if fail_bypass => Ok(ret_val),

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -105,6 +105,10 @@ impl Interpreter {
 
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
+        // Run the body under the routine's declaring package (set after the
+        // arity/type-check early returns above, which run under the caller's
+        // package). Restored after the env merge below.
+        let saved_package = self.enter_routine_package(cf);
 
         let mut ip = 0;
         let mut result = Ok(());
@@ -188,6 +192,7 @@ impl Interpreter {
                 }
             }
         }
+        self.leave_routine_package(saved_package);
 
         // Return type check (if specified). Allows type objects, Nil, and Failure through.
         if result.is_ok()

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -246,6 +246,9 @@ impl Interpreter {
 
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
+        // Run the body under the routine's declaring package (set after the
+        // required-param early returns above). Restored after the env merge below.
+        let saved_package = self.enter_routine_package(cf);
 
         // Execute the function body
         let mut ip = 0;
@@ -329,6 +332,7 @@ impl Interpreter {
                 }
             }
         }
+        self.leave_routine_package(saved_package);
 
         // Slice F (env<->locals coherence): record the captured-outer variables
         // this body writes so the call-site op writes them straight through to the

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -116,10 +116,24 @@ impl Interpreter {
         }
 
         // Set current_package to the function's defining package so that default
-        // value expressions can resolve package-scoped functions (e.g. &double).
+        // value expressions can resolve package-scoped functions (e.g. &double)
+        // AND package-scoped variables (`our $x`, a `package { my $x }` lexical)
+        // are resolvable from inside the sub on every call. Callers pass the
+        // *caller's* package as `fn_package`, which is wrong for a by-name call
+        // into another package (`P::inc()` from `GLOBAL`); the authoritative
+        // declaring package lives on the CompiledFunction. Only the first OTF
+        // compile previously set it correctly (via `def.package`), so a 2nd+
+        // call read/wrote package vars under `GLOBAL` and silently lost them.
+        // Skip a mangled state-scope package (`Pkg::&sub/arity`, used for nested
+        // subs) and fall back to the passed name in that case.
+        let def_package: &str = if !cf.package.is_empty() && !cf.package.contains("::&") {
+            cf.package.as_str()
+        } else {
+            fn_package
+        };
         let saved_package = self.current_package().to_string();
-        if !fn_package.is_empty() && fn_package != "GLOBAL" {
-            self.set_current_package(fn_package.to_string());
+        if !def_package.is_empty() && def_package != "GLOBAL" {
+            self.set_current_package(def_package.to_string());
         }
         // When the function has where constraints and there is a &name Sub in
         // env (which carries closure env), merge the Sub's captured variables

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -105,6 +105,119 @@ impl Interpreter {
             .and_then(|bare| self.get_our_var(&bare).cloned())
     }
 
+    /// Reconstruct the package-qualified key for a bare free-variable name
+    /// referenced from inside one of `cur`'s named subs (where the compiler
+    /// leaves the name unqualified because the sub-body compile scope is a
+    /// mangled `Pkg::&sub/arity` name). e.g. `("X", "P")` -> `Some("P::X")`,
+    /// `("@a", "P")` -> `Some("@P::a")`. Returns `None` for names that are
+    /// already qualified, sigil-stripped twigils, or positional captures —
+    /// mirroring the `GetGlobal` bare-name read fallback so reads and writes
+    /// resolve to the same canonical store.
+    fn package_qualified_candidate(name: &str, cur: &str) -> Option<String> {
+        if name.contains("::") || cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
+            return None;
+        }
+        let bare_first = name.trim_start_matches(['$', '@', '%', '&']);
+        let first_ch = bare_first.chars().next()?;
+        if matches!(first_ch, '_' | '/' | '!' | '?' | '*' | '.' | '=') || first_ch.is_ascii_digit()
+        {
+            return None;
+        }
+        let candidate = if let Some(rest) = name.strip_prefix('$') {
+            format!("${cur}::{rest}")
+        } else if let Some(rest) = name.strip_prefix('@') {
+            format!("@{cur}::{rest}")
+        } else if let Some(rest) = name.strip_prefix('%') {
+            format!("%{cur}::{rest}")
+        } else if let Some(rest) = name.strip_prefix('&') {
+            format!("&{cur}::{rest}")
+        } else {
+            format!("{cur}::{name}")
+        };
+        Some(candidate)
+    }
+
+    /// Read a bare free-variable name from the enclosing package's variable
+    /// store: the `our` store via the reconstructed `Pkg::name` key, or the
+    /// package-block `my` lexical store (`package_lexicals`). Mirrors the
+    /// `GetGlobal` read fallbacks so the fused `AtomicCompoundVar` / inc-dec
+    /// RMW paths see the same value a plain `Var` read would. Returns the raw
+    /// stored value (the caller decont's if needed).
+    pub(super) fn read_package_scope_var(&self, name: &str) -> Option<Value> {
+        let cur = self.current_package();
+        if let Some(candidate) = Self::package_qualified_candidate(name, &cur)
+            && let Some(v) = self.get_our_var(&candidate)
+        {
+            return Some(v.clone());
+        }
+        self.package_lexicals
+            .get(&cur)
+            .and_then(|m| m.get(name))
+            .cloned()
+    }
+
+    /// Return the value of a bare package-block `my` lexical (`package P { my $x;
+    /// sub f { $x } }`) recorded in `package_lexicals` by `exec_package_scope_op`.
+    /// This store is the *authoritative* lexical scope a package's named subs close
+    /// over, so callers consult it BEFORE `env`: two stale `env` shadows would
+    /// otherwise win — a boxed lexical's prior-call return-merge copy, and the
+    /// package block's own `my $x` top-level local slot flushed to `env` as the
+    /// type object after the block exits. A returned `ContainerRef` is the live
+    /// shared cell (writes mutate it in place); a plain value is the current
+    /// snapshot (writes go via `writeback_package_scope_var`). Gated on a real
+    /// (non-GLOBAL, non-mangled) `current_package`, so a bare reference after the
+    /// block (running under GLOBAL) never resolves here. A name shadowed by the
+    /// sub's own `my`/param is a local slot (GetLocal), so it never reaches here.
+    pub(super) fn package_scope_lexical(&self, name: &str) -> Option<Value> {
+        if name.contains("::") {
+            return None;
+        }
+        let cur = self.current_package();
+        if cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
+            return None;
+        }
+        self.package_lexicals
+            .get(&cur)
+            .and_then(|m| m.get(name))
+            .cloned()
+    }
+
+    /// Write-back companion of [`read_package_scope_var`]: if a bare free
+    /// variable resolves to an existing package-scope store entry (`our` var
+    /// or package-block `my` lexical), update it in place so a mutation made
+    /// from inside a named sub persists across calls. Returns `true` when an
+    /// entry was found and updated. A SetGlobal / RMW of a name that is NOT a
+    /// package-scope var (a fresh global, a dynamic var, `$_`, ...) returns
+    /// `false` and the caller's normal store path applies unchanged.
+    pub(super) fn writeback_package_scope_var(&mut self, name: &str, val: &Value) -> bool {
+        let cur = self.current_package();
+        if let Some(candidate) = Self::package_qualified_candidate(name, &cur)
+            && self.get_our_var(&candidate).is_some()
+        {
+            self.set_our_var(candidate.clone(), val.clone());
+            // Keep an existing qualified env entry coherent for a same-frame
+            // read by the qualified name (`$P::X`).
+            if self.env().contains_key(&candidate) {
+                self.set_env_with_main_alias(&candidate, val.clone());
+            }
+            return true;
+        }
+        if let Some(m) = self.package_lexicals.get_mut(&cur)
+            && let Some(slot) = m.get_mut(name)
+        {
+            // A boxed lexical's cell is shared with every reader; mutate it in
+            // place rather than replacing the entry with a plain value (which
+            // would sever the sharing). A plain entry is replaced directly.
+            if let Value::ContainerRef(arc) = slot {
+                arc.lock().unwrap().clone_from(val);
+            } else {
+                *slot = val.clone();
+            }
+            return true;
+        }
+        false
+    }
+
     /// Strip pseudo-package qualifiers (GLOBAL::, OUR::, MY::) from a
     /// sigiled variable name, returning the bare variable name.
     /// e.g. "$GLOBAL::x" → Some("x"), "$OUR::x" → Some("x")

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -191,7 +191,17 @@ impl Interpreter {
                     return Ok(());
                 }
                 let val = self
-                    .get_env_with_main_alias(name)
+                    // A package-block `my` lexical is stored in `package_lexicals`;
+                    // it is the authoritative store for a bare free-variable read from
+                    // inside that package's named subs, and must be read BEFORE `env`.
+                    // Two stale `env` shadows would otherwise win: a boxed lexical's
+                    // prior-call return-merge copy, and the package block's own
+                    // `my $x` top-level local slot flushed to `env` as the type object
+                    // after the block exits (`sync_env_from_locals`). Gated on a real
+                    // `current_package`, so a bare reference after the block (under
+                    // GLOBAL) does not resolve here.
+                    .package_scope_lexical(name)
+                    .or_else(|| self.get_env_with_main_alias(name))
                     .or_else(|| {
                         // Fall back to the persistent our_vars store for `our`-scoped
                         // variables accessed via package-qualified names (e.g., $Pkg::var).
@@ -1116,6 +1126,12 @@ impl Interpreter {
                 // restoration (which only preserves env keys that existed
                 // before the block).  `::('name')` falls back to this store.
                 self.set_our_var(name.clone(), val.clone());
+                // A plain assignment to a package-scope free variable (`our $X`
+                // or a `package { my $X }` lexical) reached by bare name from
+                // inside a named sub must reach the canonical package store too,
+                // otherwise the write lands only on the bare env/our key that the
+                // `GetGlobal` read fallback never consults. No-op otherwise.
+                self.writeback_package_scope_var(&name, &val);
                 // Track topic mutations for map rw writeback
                 if name == "_" {
                     self.env_mut()

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -274,7 +274,9 @@ impl Interpreter {
             return Ok(());
         }
         let val = self
-            .get_env_with_main_alias(name)
+            .package_scope_lexical(name)
+            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Int(0));
         // ContainerRef (box-on-capture / `:=`): mutate the shared cell in place so
@@ -297,6 +299,7 @@ impl Interpreter {
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
+        self.writeback_package_scope_var(name, &new_val);
         self.stack.push(new_val);
         Ok(())
     }
@@ -375,7 +378,9 @@ impl Interpreter {
             return Ok(());
         }
         let val = self
-            .get_env_with_main_alias(name)
+            .package_scope_lexical(name)
+            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Int(0));
         // ContainerRef (box-on-capture / `:=`): mutate the shared cell in place so
@@ -398,6 +403,7 @@ impl Interpreter {
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
         self.update_local_if_exists(code, name, &new_val);
+        self.writeback_package_scope_var(name, &new_val);
         self.stack.push(new_val);
         Ok(())
     }

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -272,10 +272,22 @@ impl Interpreter {
         // `package Zef::CLI { my $CONFIG = preprocess-args-config-mutate(...); ... }`).
         for (k, v) in current_env.iter() {
             if !saved_env.contains_key_sym(*k) && !k.contains_str("::") && !k.starts_with("__") {
+                let bare = k.resolve();
+                // Record ONLY genuine `my` lexicals. An `our` package variable also
+                // leaves a bare env key here, but it has a qualified twin in the
+                // `our` store (`Pkg::name`) that is the authoritative value — and it
+                // can be set from OUTSIDE the package (`$Pkg::msg = ...`), which this
+                // bare snapshot would not see. Recording it would let the stale
+                // declaration-time snapshot shadow the real `our` value on read
+                // (`package_scope_lexical` is consulted before the `our` fallback).
+                let qualified = format!("{name}::{bare}");
+                if self.get_our_var(&qualified).is_some() || current_env.contains_key(&qualified) {
+                    continue;
+                }
                 self.package_lexicals
                     .entry(name.clone())
                     .or_default()
-                    .insert(k.resolve(), v.clone());
+                    .insert(bare, v.clone());
             }
         }
         for (k, v) in current_env.iter() {

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -61,7 +61,15 @@ impl Interpreter {
         // Default to Nil (NOT Int(0) like `++`) so `my $w; $w ~= "z"` yields "z",
         // not "0z"; the binary op descalarizes/numifies/stringifies Nil itself.
         let raw_val = self
-            .get_env_with_main_alias(name)
+            // A package-scope free variable (`our $X` / `package { my $X }`)
+            // reached by bare name from inside a named sub is not in the local
+            // env; read it from the canonical package store so the fused RMW
+            // operates on the current value, not Nil (mirrors `GetGlobal`). A
+            // boxed lexical's cell is authoritative and must win over a stale
+            // plain `env` copy left by a prior call's return-merge.
+            .package_scope_lexical(name)
+            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Nil);
         // ContainerRef cell: atomic RMW under the cell lock so concurrent
@@ -201,7 +209,9 @@ impl Interpreter {
             return Ok(());
         }
         let raw_val = self
-            .get_env_with_main_alias(name)
+            .package_scope_lexical(name)
+            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Int(0));
         // ContainerRef: deref for increment, write back through the shared container.
@@ -289,7 +299,9 @@ impl Interpreter {
             return Ok(());
         }
         let raw_val = self
-            .get_env_with_main_alias(name)
+            .package_scope_lexical(name)
+            .or_else(|| self.get_env_with_main_alias(name))
+            .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
             .unwrap_or(Value::Int(0));
         // ContainerRef: deref for decrement, write back through the shared container.

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -679,6 +679,12 @@ impl Interpreter {
         let new_val = self.maybe_wrap_native_int(name, new_val);
         self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
+        // A compound assign / inc-dec to a package-scope free variable (`our $X`
+        // or a `package { my $X }` lexical) reached from inside a named sub uses
+        // the bare name; mirror the value back into the canonical package store
+        // so the mutation persists across calls (the env write above is only the
+        // same-frame view). No-op for non-package-scope names.
+        self.writeback_package_scope_var(name, &new_val);
         // Track topic mutations for the rw-map writeback (`@a.map({ $_ += 1 })`).
         // A compound assign / inc-dec to `$_` lands here via the fused
         // `AtomicCompoundVar` path; the plain-assign path (`AssignExpr`) records

--- a/t/package-sub-lexical-mutation.t
+++ b/t/package-sub-lexical-mutation.t
@@ -1,0 +1,114 @@
+use Test;
+
+# A named sub in a `package`/`module` block closes over the block's `my`
+# lexicals AND the package's `our` variables. Mutations made through one
+# by-name call must persist and be visible to later by-name calls (the
+# declaring package is restored on EVERY dispatch path, not just the first
+# on-the-fly compile).
+
+plan 18;
+
+# --- read-only `my` lexical, called more than once -------------------------
+{
+    package P1 { my $X = "v"; our sub show() { $X } }
+    is P1::show(), "v", "read-only my lexical, 1st call";
+    is P1::show(), "v", "read-only my lexical, 2nd call (was Nil)";
+}
+
+# --- module behaves like package -------------------------------------------
+{
+    module M1 { my $X = "m"; our sub show() { $X } }
+    is M1::show(), "m", "module my lexical, 1st call";
+    is M1::show(), "m", "module my lexical, 2nd call";
+}
+
+# --- `my` lexical mutated by `++` accumulates across calls ------------------
+{
+    package P2 { my $X = 1; our sub inc() { $X++ }; our sub get() { $X } }
+    P2::inc(); P2::inc();
+    is P2::get(), 3, "my lexical ++ accumulates across by-name calls";
+}
+
+# --- compound assign `$X = $X + n` accumulates -----------------------------
+{
+    package P3 { my $X = 0; our sub bump() { $X = $X + 10 }; our sub get() { $X } }
+    P3::bump(); P3::bump(); P3::bump();
+    is P3::get(), 30, "my lexical compound-assign accumulates";
+}
+
+# --- nested unqualified call mutating the shared lexical --------------------
+{
+    package P4 {
+        my $X = 0;
+        our sub inc() { $X++ }
+        our sub run() { inc(); inc(); inc(); $X }
+    }
+    is P4::run(), 3, "nested unqualified inc, 1st run";
+    is P4::run(), 6, "nested unqualified inc accumulates into 2nd run";
+}
+
+# --- string concat through a parameterised sub -----------------------------
+{
+    package P5 {
+        my $log = "";
+        our sub add($s) { $log ~= $s }
+        our sub dump() { $log }
+    }
+    P5::add("a"); P5::add("b"); P5::add("c");
+    is P5::dump(), "abc", "concat into my lexical via param sub";
+}
+
+# --- pre-increment / pre-decrement -----------------------------------------
+{
+    package P6 { my $n = 5; our sub up() { ++$n }; our sub down() { --$n }; our sub get() { $n } }
+    P6::up(); P6::up(); P6::down();
+    is P6::get(), 6, "pre-inc/pre-dec on my lexical";
+}
+
+# --- `our` package variable, read repeatedly -------------------------------
+{
+    package P7 { our $X = 10; our sub show() { $X } }
+    is P7::show(), 10, "read-only our var, 1st call";
+    is P7::show(), 10, "read-only our var, 2nd call (was Nil)";
+}
+
+# --- `our` package variable mutated across calls ---------------------------
+{
+    package P8 { our $X = 1; our sub inc() { $X = $X + 1 }; our sub get() { $X } }
+    P8::inc(); P8::inc();
+    is P8::get(), 3, "our var mutated accumulates across calls";
+}
+
+# --- `our` var via `++` ----------------------------------------------------
+{
+    package P9 { our $X = 0; our sub inc() { $X++ }; our sub get() { $X } }
+    P9::inc(); P9::inc(); P9::inc();
+    is P9::get(), 3, "our var ++ accumulates across calls";
+}
+
+# --- array lexical mutated in place ----------------------------------------
+{
+    package P10 {
+        my @a;
+        our sub add($x) { @a.push($x) }
+        our sub all() { @a.join(",") }
+    }
+    P10::add(1); P10::add(2); P10::add(3);
+    is P10::all(), "1,2,3", "my array push accumulates across calls";
+}
+
+# --- multi-level package name ----------------------------------------------
+{
+    package A::B { my $X = 5; our sub bump() { $X++ }; our sub get() { $X } }
+    A::B::bump(); A::B::bump();
+    is A::B::get(), 7, "multi-level package name shares lexical";
+}
+
+# --- two packages with same lexical name stay isolated ---------------------
+{
+    package Q1 { my $X = 100; our sub inc() { $X++ }; our sub get() { $X } }
+    package Q2 { my $X = 200; our sub inc() { $X++ }; our sub get() { $X } }
+    Q1::inc(); Q2::inc(); Q2::inc();
+    is Q1::get(), 101, "same-named lexical isolated per package (Q1)";
+    is Q2::get(), 202, "same-named lexical isolated per package (Q2)";
+}


### PR DESCRIPTION
## Summary

A named sub in a `package`/`module` block closes over the block's `my` lexicals **and** the package's `our` variables. #3881 made the *first* by-name call resolve them, but a second call read/wrote them under the wrong package and silently lost the value. This is the §2-D / zef north-star gap.

```raku
package P { my $X = 1; our sub inc() { $X++ }; our sub get() { $X } }
P::inc(); P::inc(); say P::get();   # was: 1   now: 3 (raku: 3)

package P { our $X = 10; our sub show() { $X } }
P::show(); P::show();               # was: 10, Nil   now: 10, 10
```

## Root causes (both fixed generally)

1. **Wrong `current_package` on cached dispatch.** Inside a package sub the compiler leaves free-variable names unqualified (the body's compile scope is the mangled `Pkg::&sub/arity`), so resolution depends on the runtime `current_package`. Only the on-the-fly compile path set it from the routine's defining package; the cached fast/light/positional-light paths passed the *caller's* package, so a by-name call into another package ran the body under `GLOBAL`. Fix: record the declaring package on `CompiledFunction` and switch to it on entry across **all** dispatch paths (new `enter_routine_package`/`leave_routine_package`, gated to a real non-GLOBAL package so the hot GLOBAL path — fib — pays only a string compare).

2. **Writes never reached the canonical store, and a stale `env` shadow beat the read.** `our`/`my` package vars are read by reconstructing `Pkg::name` / `package_lexicals`, but plain `SetGlobal`/RMW/inc-dec wrote only the bare `env` name. Fix: add `writeback_package_scope_var` (mirrors the read; mutates a boxed lexical's shared cell in place, updates the `our` store otherwise) and read the package lexical **before** `env` (`package_scope_lexical`) so neither a boxed lexical's prior-call return-merge copy nor the package block's own `my \$x` top-level slot (flushed to `env` as the type object after the block) shadows the live value. `our` vars are excluded from `package_lexicals` so a `\$Pkg::msg = ...` set from outside still wins (roast `S04-declarations/our.t`).

## Tests

- New `t/package-sub-lexical-mutation.t` (18 cases): read-only `my`/`our`, `++`/compound/concat accumulation, nested unqualified calls, arrays, multi-level package names, per-package isolation, module = package.
- `make test` passes (477 unit tests, full `t/` suite); `cargo clippy -D warnings` clean.
- Spot-checked whitelisted roast: `S04-declarations/our.t`, `S02-names/{our,name,dynamic-scope}.t`, `S10-packages/{scope,export,joined-namespaces}.t`, `S04-declarations/{state,multiple}.t`, `S06-multi/syntax.t`, `S12-class/basic.t`, `S32-list/grep.t` — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)