### PR TITLE
docs(roast): record generics.t and constant.t deep-feature investigations

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -260,6 +260,11 @@
 - [ ] roast/S02-types/generics.t
   - 0/1 pass. Raku (Rakudo v2022.12) itself fails to compile this test: "Type too complex to form a definite type" at line 15 (T:D inside parameterized role). Test uses v6.e.PREVIEW features.
   - Blockers: (1) `my T $v .= new;` in parameterized role body - type param T not recognized as type constraint during role registration (role body code is evaluated eagerly, not deferred until composition); (2) Nominalizables T:D, T:U, T(), T:D() inside parameterized role; (3) `my package G { class A is Array[T] {} }` nested package with type param; (4) `has @.a is G::A` typed attribute from generic class
+  - 2026-06-28 deeper probe (assertions, all needed since plan 6 is all-or-nothing):
+    - `T` alone resolves correctly to the bound type inside a composed role method (`method m { T }` on `CInt does R[Int]` returns Int). `T:D`/`T:U` also work as type objects.
+    - **Coercion type TERMS are unimplemented**: `Int()` returns `Nil` (parsed as `Call{name:"Int", args:[]}` → `builtin_coerce` with no arg), should be the coercion type `Int(Any)`; `Int:D()` → "Unknown function: Int:D". raku 6.d DOES support these (`(Int()).raku` = "Int(Any)"), so this sub-feature is validatable and general (coercion type as a value, not just in a signature/return-type string). Fix would route an empty-paren call on a *type* name to a coercion-type value with `.^name`/`.raku`/`.gist` = "Int(Any)". Won't flip generics.t alone (assertions 3-6 still blocked).
+    - **`class A is Array[Int] {}` subclassing is broken**: `.push` fails with "No such method 'push' for invocant of type 'A'" (raku: `Array[Int].new(1,2)`). Subclassing a parameterized `Array[T]` with working array methods is the prerequisite for assertions 3-6 and the `R::G::A[Int]:D` naming. Large (parser + type system + Array-subclass method machinery).
+  - Verdict: NOT a "Medium" — a deep multi-feature 6.e stack (coercion type terms + Array[T] subclassing + nested generic classes + per-composition re-instantiation). Local raku v2022.12 (6.d) cannot run the full test, so the whole-test expected output is unvalidatable here. Deferred per user (2026-06-28).
 - [ ] roast/S02-types/hash_ref.t
   - 0/? pass. Parse error at line 40
 - [ ] roast/S02-types/hash.t

--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -20,22 +20,44 @@
       it now emits a real bind, which hits the readonly path and throws
       (X::Assignment::RO). rakudo throws X::Bind::Rebind instead, but these
       subtests only assert that the bind raises. (t/constant-rebind.t)
-    - Test 44: enum-variant access through a constant type alias (`G::c` where
-      `my constant G = F::B`) does not parse.
-    - Test 46: `constant fib := 0, 1, *+* ... *; fib[100]` — indexing a lazy
-      infinite sequence (even bound to a plain `@`-var) returns Nil; deep VM
-      lazy-iterator issue, unrelated to constants.
+    - Test 44 (enum-variant access through a constant type alias, `G::c` where
+      `my constant G = F::B`) currently PASSES — the block's `==`/`===` assertions
+      hold. (`G::c` itself still gists as the enum type object "(B)" rather than
+      the value "c", a latent qualified-name resolution gap, but it does not fail
+      this test.) Stale "does not parse" note corrected 2026-06-28.
+    - Test 46: `constant fib := 0, 1, *+* ... *; fib[100]` — works in isolation
+      now (returns 354224848179261915075). Only unreachable because of the
+      operator-block abort below.
     - Test 56: redeclaring a constant in the same lexical block now throws
       X::Redeclaration (compile-time, with `.symbol`); inner-block shadowing is
       still allowed. FIXED.
-    - Tests 69-72 do not run: the file aborts at test 69 on multi-candidate
-      *sharing* via a constant operator binding (`constant &infix:<comet> :=
-      &infix:<snowman>` then a new `multi infix:<comet>` candidate must also be
-      visible through `snowman`); plus tests 70-71 need the `ExportConstant`
-      module and 72 needs a regex stored in a `constant $`-sigil term.
-    Difficulty: Medium per-fix, but full whitelist still blocked by the
-    lazy-sequence (46), constant-aliased qualified name (44), and multi-sharing
-    (69) features.
+    - Tests 69-72 do not run: the file aborts at the operator-synonym block
+      (roast lines 363-375) with "Redeclaration of routine 'infix:<comet>'".
+      2026-06-28 probe: the post-abort blocks (ExportConstant module 70-71, the
+      regex-in-constant 72, the lazy `constant fib` 46 indexing, and the
+      `constant %escapes` map-built hash) ALL work in isolation now — so the
+      operator-synonym block is the SOLE remaining file-stopper.
+      Root cause: `constant &infix:<comet> := &infix:<snowman>` must make comet
+      and snowman the SAME routine object so a `multi sub infix:<comet>(Str,Int)`
+      candidate is visible through BOTH names (`"B" snowman 4` uses the candidate
+      added to comet). But mutsu's operator `constant &op := &other` *copies* the
+      routine renamed to the new name (`&infix:<comet>` is a fresh `sub
+      infix:<comet>` with its own WHICH, not a reference to snowman), so the two
+      names cannot share candidates and `multi sub infix:<comet>` is flagged as a
+      redeclaration of the copy.
+      Note: the NON-operator twin already aliases correctly (`constant &h := &g`
+      where g is a multi sub: `&h` holds g's `Sub` and `h(...)` dispatches g's
+      candidates). A register-time fix that redirects a `multi sub h` to extend
+      the aliased target g (detect `&h` holding a `Sub` of a different identity)
+      was prototyped and worked for the Sub case, but does NOT help the operator
+      case (the copy has the new name, so there is no identity link to follow)
+      and risks misfiring on `my &foo = &bar; multi sub foo`. The real fix is to
+      make the operator `constant &op := &other` bind a shared reference instead
+      of copying — a deeper change to the operator constant-bind / routine
+      identity. Reverted the prototype.
+    Difficulty: full whitelist blocked by the operator multi-sharing (69, needs
+    shared-not-copied routine identity), the lazy-sequence index (46), and the
+    constant-aliased qualified name (44).
 - [ ] roast/S04-declarations/implicit-parameter.t
 - [ ] roast/S04-declarations/multiple.t
   - 3/8 pass (tests 1-3). Failures: `my ($a, $b) = (1, 2)` destructuring works but `my ($a, @b)` with slurpy not supported; `my ($a, *@b)` splat syntax not implemented; `state` declarations not supported. Difficulty: Medium


### PR DESCRIPTION
Documentation-only update to `TODO_roast/` capturing this session's investigation of two BLOCKERS "Medium" targets that turned out to be blocked by deep features.

## S02-types/generics.t (6.e "Nominalizable generic")
- `T` resolves correctly inside a composed role method (`method m { T }` on `CInt does R[Int]` → `Int`); `T:D`/`T:U` work.
- **Gaps**: coercion type *terms* are unimplemented (`Int()` → `Nil`, `Int:D()` → "Unknown function: Int:D"; raku 6.d gives `Int(Any)`/`Int:D(Any)`), and `class A is Array[Int] {}` subclassing is broken (`.push` fails with "No such method 'push'").
- Full test needs coercion type terms + `Array[T]` subclassing + nested generic classes + per-composition re-instantiation. Local raku v2022.12 (6.d) cannot run the 6.e test, so the whole-test expected output is unvalidatable here.

## S04-declarations/constant.t (68/72)
- The **sole** remaining file-stopper is the operator-synonym block (abort at "Redeclaration of routine 'infix:<comet>'"). All post-abort blocks (ExportConstant module, regex-in-constant, lazy `constant fib` indexing, map-built `constant %escapes`) work in isolation.
- Root cause: operator `constant &op := &other` **copies** the routine renamed to the new name (own WHICH) instead of binding a shared reference, so comet/snowman cannot share a later `multi` candidate. The non-operator twin (`constant &h := &g`) already aliases correctly.
- Corrected stale notes (test 44 passes; test 46 works in isolation).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY