### PR TITLE
fix(package): exported MAIN in a package block sees the mainline my lexical

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -169,16 +169,43 @@ impl Interpreter {
     /// block (running under GLOBAL) never resolves here. A name shadowed by the
     /// sub's own `my`/param is a local slot (GetLocal), so it never reaches here.
     pub(super) fn package_scope_lexical(&self, name: &str) -> Option<Value> {
-        if name.contains("::") {
-            return None;
-        }
         let cur = self.current_package();
         if cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
             return None;
         }
+        // `package_lexicals` is keyed by the package's own env name for the
+        // lexical: scalars sigil-less (`CONFIG`), `@`/`%`/`&` keep their sigil
+        // (`@a`). A free-var read reaches this with the name in one of two shapes:
+        //   * BARE (`CONFIG` / `@a`) — emitted when the body compiles under the
+        //     mangled `Pkg::&sub/arity` scope (`compile_sub_body`), which does not
+        //     qualify names. Looked up directly.
+        //   * QUALIFIED (`MyCLI::CONFIG` / `@MyCLI::a`) — emitted when the body
+        //     compiles under the PLAIN package name (`compile_block_raw`, used by
+        //     the `call_function_def` slow path that runs an exported `MAIN`), which
+        //     auto-qualifies free vars. Resolve ONLY when the qualifier is the
+        //     current package, so `$Other::x` from outside never reaches another
+        //     package's `my` lexical (Raku: `my` lexicals are not package-public).
+        let key: std::borrow::Cow<str> = if name.contains("::") {
+            let (sigil, rest) = match name.as_bytes().first() {
+                Some(b @ (b'$' | b'@' | b'%' | b'&')) => (Some(*b as char), &name[1..]),
+                _ => (None, name),
+            };
+            let (pkg, bare) = rest.rsplit_once("::")?;
+            if pkg != cur {
+                return None;
+            }
+            match sigil {
+                // `@`/`%`/`&` lexicals are stored WITH their sigil; a scalar (`$`
+                // or sigil-less) is stored sigil-less.
+                Some(s @ ('@' | '%' | '&')) => std::borrow::Cow::Owned(format!("{s}{bare}")),
+                _ => std::borrow::Cow::Borrowed(bare),
+            }
+        } else {
+            std::borrow::Cow::Borrowed(name)
+        };
         self.package_lexicals
             .get(&cur)
-            .and_then(|m| m.get(name))
+            .and_then(|m| m.get(key.as_ref()))
             .cloned()
     }
 

--- a/t/lib/PackageMainLexical.rakumod
+++ b/t/lib/PackageMainLexical.rakumod
@@ -1,0 +1,12 @@
+package PackageMainLexical {
+    # A `my` lexical assigned in the package-block mainline, read by an exported
+    # MAIN candidate. Before the fix, MAIN ran via the call_function_def slow path
+    # whose body compiles under the plain package name (auto-qualifying `$config`
+    # to `PackageMainLexical::config`), which the package-lexical resolver did not
+    # recognise — so MAIN saw the lexical as undefined.
+    my $config = "from-mainline";
+
+    proto MAIN(|) is export {*}
+    multi sub MAIN('show') is export { say "config=$config" }
+    multi sub MAIN('twice') is export { say "config=$config$config" }
+}

--- a/t/package-main-lexical-capture.t
+++ b/t/package-main-lexical-capture.t
@@ -1,0 +1,49 @@
+use lib $*PROGRAM.parent(1).add("lib");
+use lib $*PROGRAM.parent(1).add("..").add("roast/packages/Test-Helpers/lib");
+use Test;
+use Test::Util;
+
+# An exported MAIN candidate declared inside a `package` block must see a `my`
+# lexical assigned in the package-block mainline, when the program is run via
+# `use Module;` + MAIN auto-dispatch. This is the zef `Zef::CLI` pattern:
+#   package Zef::CLI { my $CONFIG = ...; proto MAIN(|) is export {*};
+#                      multi MAIN('info', ...) { ... $CONFIG ... } }
+# (Uses get_out + is rather than is_run: is_run's result-comparison smartmatch is
+# unrelated to this feature.)
+
+plan 4;
+
+{
+    my %got = get_out(
+        'use PackageMainLexical;', '',
+        :args['show'], :compiler-args['-I', 't/lib'],
+    );
+    is %got<out>, "config=from-mainline\n",
+        'package-block MAIN reads a mainline `my` lexical (via use + MAIN dispatch)';
+}
+
+{
+    my %got = get_out(
+        'use PackageMainLexical;', '',
+        :args['twice'], :compiler-args['-I', 't/lib'],
+    );
+    is %got<out>, "config=from-mainlinefrom-mainline\n",
+        'a second MAIN candidate sees the same mainline lexical';
+}
+
+# A top-level `my` mutated AFTER a sub's declaration is read at its current
+# value when the sub runs (closures share the live container, not a snapshot).
+{
+    my $x = "before";
+    sub read-x() { $x }
+    $x = "after";
+    is read-x(), "after", 'sub reads the live value of a captured outer `my`';
+}
+
+# Same, with accumulation through repeated mutation.
+{
+    my $n = 0;
+    sub bump() { $n++ }
+    bump(); bump(); bump();
+    is $n, 3, 'sub mutating a captured outer `my` accumulates';
+}


### PR DESCRIPTION
## Summary

Follow-up to #3899 (the §2-D / zef north-star package-var work). The zef `Zef::CLI` pattern — a `package Foo { my \$CONFIG = ...; proto MAIN(|) is export {*}; multi MAIN('info', ...) { ... \$CONFIG ... } }` run via `use Foo;` + MAIN auto-dispatch — read `\$CONFIG` as undefined:

```raku
package MyCLI { my $config = "from-mainline";
                multi MAIN('show') is export { say "config=$config" } }
# `use MyCLI;` + arg `show`  =>  was: config=   now: config=from-mainline
```

## Root cause

A free-variable read resolves to the per-package `package_lexicals` store in one of two name shapes, depending on the body's compile scope:

- **BARE** (`config`) — a normal package sub compiles under the mangled `Pkg::&sub/arity` scope (`compile_sub_body`), which does **not** qualify names.
- **QUALIFIED** (`MyCLI::config`) — an exported MAIN runs via the `call_function_def` slow path, whose body compiles under the **plain** package name (`compile_block_raw`), which auto-qualifies free vars.

`package_scope_lexical` (added in #3899) handled only the bare shape and bailed on any `::` name, so the qualified MAIN read fell through to env / our-store (miss) and read as undefined.

## Fix

Teach `package_scope_lexical` the qualified shape: split `Pkg::name`, resolve **only** when the qualifier is the current package (so `\$Other::x` from outside still cannot reach another package's `my` lexical — matching Raku), and reconstruct the store key honouring the sigil convention (`@`/`%`/`&` keep their sigil; `\$`/sigil-less scalars are stored sigil-less). One function changed (`src/vm/vm_env_helpers.rs`).

## Impact on zef

`zef list` / `zef info` now get **past** the `\$CONFIG`-as-`Any` → `try-load(Any)` blocker to the next one (`CompUnit::Repository::FileSystem.resolve`, a separate §H feature).

## Tests

- New `t/package-main-lexical-capture.t` + `t/lib/PackageMainLexical.rakumod` (4 cases): exported MAIN in a package block reads the mainline `my` lexical via `use` + MAIN dispatch (two candidates); plus the live-capture / accumulation cases.
- `cargo clippy -D warnings` clean; unit tests 477/0.
- Spot-checked whitelisted roast: `S04-declarations/{our,multiple}.t`, `S02-names/our.t`, `S10-packages/{scope,export}.t`, `S14-roles/basic.t`, `S19-command-line-options/main{,-eval,-semicolon,-usage}.t` — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)