### PR TITLE
feat(io): user-subclassable IO::Handle with WRITE/READ/EOF dispatch

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -457,9 +457,19 @@
 - [ ] roast/S32-io/empty.txt
 - [x] roast/S32-io/indir.t
 - [ ] roast/S32-io/io-cathandle.t
-- [ ] roast/S32-io/io-handle.t (28/30 subtests pass; tests 22, 23, 24 fixed.
-      Remaining 2:
-      22 `.say method` — FIXED: nested-`with`/`given` topic-source isolation.
+- [x] roast/S32-io/io-handle.t — **30/30, whitelisted.** All subtests pass.
+      29 `.WRITE` / 30 `.EOF/.WRITE` fixed: a user-subclassed IO::Handle that
+      overrides WRITE/READ/EOF now routes the high-level methods through the user
+      methods via `try_user_io_handle_method` (dispatched before the native
+      file-handle path). Output (print/put/say/printf/print-nl/write/spurt) encodes
+      to a Buf and calls user WRITE; input (eof/slurp/get/getc/lines/words/split/
+      comb/read/readchars) drains via user READ + EOF (byte-wise for line/char
+      reads so consumption is exact — no buffer). `nl-in` for a handle-less
+      subclass is stored in the instance attr through the shared cell. Also fixed
+      a general `Buf.splice(offset, count, …)` bug (it ignored the args and
+      removed everything). Tests: t/io-handle-user-subclass.t, t/buf-splice-count.t.
+      Earlier fixes (now part of the full pass):
+      22 `.say method` — nested-`with`/`given` topic-source isolation.
       Root cause was `topic_source_var` aliasing: `given $x` (or `with $x`,
       which desugars to `given $x`) sets `topic_source_var = $x` so that
       `$_ = ...` in the body writes back to `$x`. An inner `with LITERAL`
@@ -481,8 +491,6 @@
       `write_back_sharing` mechanism replaces the receiver's attributes. On open
       error a Failure is returned and the receiver is left unopened.
       Regression test: t/io-handle-open-mutates-receiver.t.
-      29 `.WRITE`, 30 `.EOF/.WRITE` need a user-subclassable IO::Handle with
-      polymorphic READ/WRITE/EOF dispatch. Substantial feature.)
 - [x] roast/S32-io/io-path-cygwin.t
 - [ ] roast/S32-io/io-path-extension.t
 - [ ] roast/S32-io/io-path-subclasses.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1050,6 +1050,7 @@ roast/S32-io/child-secure.t
 roast/S32-io/copy.t
 roast/S32-io/dir.t
 roast/S32-io/indir.t
+roast/S32-io/io-handle.t
 roast/S32-io/io-path-cygwin.t
 roast/S32-io/io-path-extension.t
 roast/S32-io/io-path-subclasses.t

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -203,6 +203,26 @@ impl Interpreter {
             }
             return Ok(value);
         }
+        // nl-in / nl-out setter for a USER SUBCLASS of IO::Handle (overrides
+        // READ/WRITE/EOF, no OS handle): store the value in the instance attribute
+        // through the shared cell so the user IO read path (`.lines`/`.get`) and
+        // output path see it. See `try_user_io_handle_method`.
+        if matches!(method, "nl-in" | "nl-out" | "encoding")
+            && let Value::Instance {
+                class_name,
+                attributes,
+                ..
+            } = &target
+            && attributes.as_map().get("handle").is_none()
+            && self
+                .class_mro(&class_name.resolve())
+                .iter()
+                .any(|c| c == "IO::Handle")
+            && class_name.resolve() != "IO::Handle"
+        {
+            attributes.insert(method.to_string(), value.clone());
+            return Ok(value);
+        }
         // nl-out setter for IO::Handle
         if method == "nl-out"
             && let Value::Instance {

--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -305,7 +305,7 @@ impl Interpreter {
         target_var: &str,
         target: Value,
         method: &str,
-        _args: Vec<Value>,
+        args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         let (class_name_sym, mut bytes, orig_id, attrs_cell) = if let Value::Instance {
             class_name,
@@ -384,17 +384,69 @@ impl Interpreter {
                 Ok(shifted)
             }
             "splice" => {
-                // .splice() with no args: returns all elements, empties the Buf
-                let spliced_bytes = bytes.clone();
-                bytes.clear();
+                // .splice(offset?, count?, replacement*): remove `count` elements
+                // at `offset` (defaults: offset 0, count = rest), insert the
+                // replacement bytes, return a Buf of the removed elements. With no
+                // args this removes everything (offset 0, count = len). A negative
+                // offset/count counts from the end (Raku semantics).
+                let len = bytes.len() as i64;
+                let resolve = |v: &Value| -> i64 {
+                    match v {
+                        Value::Int(i) => *i,
+                        Value::Whatever => len,
+                        Value::Num(n) => *n as i64,
+                        Value::Str(s) => s.parse::<i64>().unwrap_or(0),
+                        Value::Mixin(inner, _) => match inner.as_ref() {
+                            Value::Int(i) => *i,
+                            _ => 0,
+                        },
+                        _ => 0,
+                    }
+                };
+                let offset = match args.first() {
+                    Some(v) => {
+                        let o = resolve(v);
+                        if o < 0 { (len + o).max(0) } else { o.min(len) }
+                    }
+                    None => 0,
+                };
+                let count = match args.get(1) {
+                    Some(v) => {
+                        let c = resolve(v);
+                        if c < 0 { (len - offset + c).max(0) } else { c }
+                    }
+                    None => len - offset,
+                };
+                let start = offset as usize;
+                let end = ((offset + count).min(len).max(offset)) as usize;
+                // Replacement bytes: flatten any remaining args (Buf/Blob bytes or
+                // integer bytes).
+                let mut replacement: Vec<Value> = Vec::new();
+                for arg in args.iter().skip(2) {
+                    match arg {
+                        Value::Instance { attributes, .. }
+                            if matches!(
+                                attributes.as_map().get("bytes"),
+                                Some(Value::Array(..))
+                            ) =>
+                        {
+                            if let Some(Value::Array(items, ..)) = attributes.as_map().get("bytes")
+                            {
+                                replacement.extend(items.iter().cloned());
+                            }
+                        }
+                        Value::Array(items, ..) => replacement.extend(items.iter().cloned()),
+                        other => replacement.push(Value::Int(resolve(other) & 0xff)),
+                    }
+                }
+                let removed: Vec<Value> = bytes.splice(start..end, replacement).collect();
                 let mut attrs = HashMap::new();
                 attrs.insert("bytes".to_string(), Value::array(bytes));
                 let updated =
                     Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
                 self.env.insert(target_var.to_string(), updated);
-                // Return a Buf with the spliced elements
                 let mut result_attrs = HashMap::new();
-                result_attrs.insert("bytes".to_string(), Value::array(spliced_bytes));
+                result_attrs.insert("bytes".to_string(), Value::array(removed));
                 Ok(Value::make_instance(class_name_sym, result_attrs))
             }
             _ => unreachable!(),

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -167,6 +167,11 @@ impl Interpreter {
             // otherwise pre-empt them. Returns `None` (falling through to that
             // fallback unchanged) for any receiver/method/args it cannot handle
             // natively, so this is behavior-invariant.
+            // User-subclassed IO::Handle (overrides WRITE/READ/EOF): route the
+            // high-level methods through the user methods before the native path.
+            if let Some(result) = self.try_user_io_handle_method(&target, method, &args) {
+                return result;
+            }
             if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
                 return result;
             }

--- a/src/vm/vm_call_method_compiled_io.rs
+++ b/src/vm/vm_call_method_compiled_io.rs
@@ -1,6 +1,371 @@
 use super::*;
 
 impl Interpreter {
+    /// Build a `Buf[uint8]` value from raw bytes (for a user `WRITE(Blob)` arg).
+    fn make_uint8_buf(bytes: Vec<u8>) -> Value {
+        crate::builtins::buf_write_num::make_buf_value("Buf", bytes)
+    }
+
+    /// Call a user-subclassed `IO::Handle`'s `WRITE(Blob:D)` with `bytes`.
+    fn call_user_io_write(
+        &mut self,
+        target: &Value,
+        bytes: Vec<u8>,
+    ) -> Result<Value, RuntimeError> {
+        let buf = Self::make_uint8_buf(bytes);
+        self.call_method_with_values(target.clone(), "WRITE", vec![buf])
+    }
+
+    /// Call a user-subclassed `IO::Handle`'s `EOF` predicate.
+    fn call_user_io_eof(&mut self, target: &Value) -> Result<bool, RuntimeError> {
+        Ok(self
+            .call_method_with_values(target.clone(), "EOF", vec![])?
+            .truthy())
+    }
+
+    /// Call a user-subclassed `IO::Handle`'s `READ(n)`, returning the raw bytes.
+    fn call_user_io_read(&mut self, target: &Value, n: usize) -> Result<Vec<u8>, RuntimeError> {
+        let r = self.call_method_with_values(target.clone(), "READ", vec![Value::Int(n as i64)])?;
+        Ok(Self::extract_buf_bytes(&r))
+    }
+
+    /// Drain the rest of a user handle: read chunks via `READ` until `EOF`.
+    fn read_all_user_io(&mut self, target: &Value) -> Result<Vec<u8>, RuntimeError> {
+        let mut out = Vec::new();
+        loop {
+            if self.call_user_io_eof(target)? {
+                break;
+            }
+            let chunk = self.call_user_io_read(target, 65536)?;
+            if chunk.is_empty() {
+                break;
+            }
+            out.extend(chunk);
+        }
+        Ok(out)
+    }
+
+    /// The line separators for a user handle: the instance's `nl-in` attribute
+    /// (a Str or list of Str set via `$fh.nl-in = ...`), defaulting to `["\n"]`.
+    fn user_io_line_separators(target: &Value) -> Vec<Vec<u8>> {
+        let raw = match target {
+            Value::Instance { attributes, .. } => attributes.as_map().get("nl-in").cloned(),
+            _ => None,
+        };
+        let seps: Vec<Vec<u8>> = match raw {
+            Some(Value::Array(items, ..)) => items
+                .iter()
+                .map(|v| v.to_string_value().into_bytes())
+                .collect(),
+            Some(Value::Str(s)) => vec![s.as_bytes().to_vec()],
+            Some(other) => vec![other.to_string_value().into_bytes()],
+            None => Vec::new(),
+        };
+        if seps.is_empty() {
+            vec![b"\n".to_vec()]
+        } else {
+            seps
+        }
+    }
+
+    /// Read one line from a user handle by consuming bytes via `READ(1)` until a
+    /// separator suffix is seen (then chomped) or `EOF`. Returns `None` at EOF.
+    fn read_user_io_line(
+        &mut self,
+        target: &Value,
+        seps: &[Vec<u8>],
+    ) -> Result<Option<Vec<u8>>, RuntimeError> {
+        if self.call_user_io_eof(target)? {
+            return Ok(None);
+        }
+        let mut line: Vec<u8> = Vec::new();
+        loop {
+            if self.call_user_io_eof(target)? {
+                break;
+            }
+            let b = self.call_user_io_read(target, 1)?;
+            if b.is_empty() {
+                break;
+            }
+            line.extend(&b);
+            if let Some(sep) = seps.iter().find(|s| !s.is_empty() && line.ends_with(s)) {
+                line.truncate(line.len() - sep.len());
+                break;
+            }
+        }
+        Ok(Some(line))
+    }
+
+    /// Read one character (a complete UTF-8 scalar) from a user handle. Returns
+    /// `None` at EOF. Reads the leading byte, then the continuation bytes implied
+    /// by its UTF-8 length.
+    fn read_user_io_char(&mut self, target: &Value) -> Result<Option<String>, RuntimeError> {
+        if self.call_user_io_eof(target)? {
+            return Ok(None);
+        }
+        let lead = self.call_user_io_read(target, 1)?;
+        let Some(&b0) = lead.first() else {
+            return Ok(None);
+        };
+        let extra = if b0 < 0x80 {
+            0
+        } else if b0 >> 5 == 0b110 {
+            1
+        } else if b0 >> 4 == 0b1110 {
+            2
+        } else if b0 >> 3 == 0b11110 {
+            3
+        } else {
+            0
+        };
+        let mut bytes = vec![b0];
+        for _ in 0..extra {
+            let nb = self.call_user_io_read(target, 1)?;
+            if nb.is_empty() {
+                break;
+            }
+            bytes.extend(nb);
+        }
+        Ok(Some(String::from_utf8_lossy(&bytes).into_owned()))
+    }
+
+    /// Dispatch high-level `IO::Handle` methods on a USER SUBCLASS that overrides
+    /// `WRITE`/`READ`/`EOF` (roast S32-io/io-handle.t `.WRITE` / `.EOF/.WRITE`
+    /// subtests). Such a handle has no underlying OS file: the high-level output
+    /// methods (`print`/`put`/`say`/`printf`/`print-nl`/`write`/`spurt`) are
+    /// implemented by encoding to bytes and calling the user `WRITE`. State that
+    /// the native path keeps in the handle table (encoding, `nl-out`) is not
+    /// available, so `encoding` defaults to UTF-8 and `nl-out` to "\n".
+    ///
+    /// Returns `None` (fall through) for the exact `IO::Handle` class (the native
+    /// file path owns it), a receiver whose class does not inherit `IO::Handle`,
+    /// a class that overrides neither `WRITE` nor `READ`, a junction argument, or
+    /// a method this user path does not implement.
+    pub(crate) fn try_user_io_handle_method(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let class_name = match target {
+            Value::Instance { class_name, .. } => class_name.resolve(),
+            _ => return None,
+        };
+        if class_name == "IO::Handle" {
+            return None;
+        }
+        if !self
+            .class_mro(&class_name)
+            .iter()
+            .any(|c| c == "IO::Handle")
+        {
+            return None;
+        }
+        let has_write = self.has_user_method(&class_name, "WRITE");
+        let has_read = self.has_user_method(&class_name, "READ");
+        if !has_write && !has_read {
+            return None;
+        }
+        if args.iter().any(|a| matches!(a, Value::Junction { .. })) {
+            return None;
+        }
+
+        // `encoding` is accepted but not stored (defaults to UTF-8 for the user
+        // byte path); the TWEAK `self.encoding: 'utf8'` in the spec relies only on
+        // it not throwing. A `Nil` arg (binary) returns Nil like the native path.
+        if method == "encoding" {
+            return match args.first() {
+                Some(Value::Nil) => Some(Ok(Value::Nil)),
+                Some(arg) => {
+                    let enc = arg.to_string_value();
+                    Some(Ok(if enc == "bin" {
+                        Value::Nil
+                    } else {
+                        Value::str(enc)
+                    }))
+                }
+                None => Some(Ok(Value::str("utf-8".to_string()))),
+            };
+        }
+
+        if has_write {
+            // `nl-out` for the newline-appending methods; default "\n".
+            let nl_out = match target {
+                Value::Instance { attributes, .. } => attributes
+                    .as_map()
+                    .get("nl-out")
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "\n".to_string()),
+                _ => "\n".to_string(),
+            };
+            // Raw-byte methods first: their argument is (or may be) a Blob.
+            match method {
+                "write" => {
+                    let mut out = Vec::new();
+                    for arg in args {
+                        if Self::is_buf_value(arg) {
+                            out.extend(self.supply_chunk_to_bytes(arg, "utf-8"));
+                        } else {
+                            out.extend(loan_env!(self, render_str_value(arg)).into_bytes());
+                        }
+                    }
+                    return Some(
+                        self.call_user_io_write(target, out)
+                            .map(|_| Value::Bool(true)),
+                    );
+                }
+                "spurt" => {
+                    let cv = args
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| Value::Str(String::new().into()));
+                    let bytes = if Self::is_buf_value(&cv) {
+                        Self::extract_buf_bytes(&cv)
+                    } else {
+                        cv.to_string_value().into_bytes()
+                    };
+                    return Some(
+                        self.call_user_io_write(target, bytes)
+                            .map(|_| Value::Bool(true)),
+                    );
+                }
+                _ => {}
+            }
+            // Text methods: build the string content then append `nl-out`.
+            let (content, newline) = match method {
+                "print" => {
+                    let mut c = String::new();
+                    for arg in args {
+                        c.push_str(&loan_env!(self, render_str_value(arg)));
+                    }
+                    (c, false)
+                }
+                "put" => {
+                    let mut c = String::new();
+                    for arg in args {
+                        c.push_str(&loan_env!(self, render_str_value(arg)));
+                    }
+                    (c, true)
+                }
+                "say" => {
+                    let mut c = String::new();
+                    for arg in args {
+                        c.push_str(&loan_env!(self, render_gist_value(arg)));
+                    }
+                    (c, true)
+                }
+                "printf" => {
+                    let fmt = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_default();
+                    let rest = if args.is_empty() { &[][..] } else { &args[1..] };
+                    if let Err(e) =
+                        crate::runtime::sprintf::validate_sprintf_directives(&fmt, rest.len())
+                    {
+                        return Some(Err(e));
+                    }
+                    (
+                        crate::runtime::sprintf::format_sprintf_args(&fmt, rest),
+                        false,
+                    )
+                }
+                "print-nl" => (String::new(), true),
+                _ => return None,
+            };
+            let mut text = content;
+            if newline {
+                text.push_str(&nl_out);
+            }
+            return Some(
+                self.call_user_io_write(target, text.into_bytes())
+                    .map(|_| Value::Bool(true)),
+            );
+        }
+
+        if has_read {
+            match method {
+                "eof" => return Some(self.call_user_io_eof(target).map(Value::Bool)),
+                "slurp" => {
+                    let bytes = match self.read_all_user_io(target) {
+                        Ok(b) => b,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    return Some(Ok(Value::str(String::from_utf8_lossy(&bytes).into_owned())));
+                }
+                "get" => {
+                    let seps = Self::user_io_line_separators(target);
+                    return Some(match self.read_user_io_line(target, &seps) {
+                        Ok(Some(line)) => {
+                            Ok(Value::str(String::from_utf8_lossy(&line).into_owned()))
+                        }
+                        Ok(None) => Ok(Value::Nil),
+                        Err(e) => Err(e),
+                    });
+                }
+                "getc" => {
+                    return Some(match self.read_user_io_char(target) {
+                        Ok(Some(c)) => Ok(Value::str(c)),
+                        Ok(None) => Ok(Value::Nil),
+                        Err(e) => Err(e),
+                    });
+                }
+                "read" => {
+                    let n = match args.first() {
+                        Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                        Some(Value::Num(f)) if *f >= 0.0 => *f as usize,
+                        _ => 0,
+                    };
+                    return Some(self.call_user_io_read(target, n).map(Self::make_uint8_buf));
+                }
+                "readchars" => {
+                    let n = match args.first() {
+                        Some(Value::Int(i)) if *i >= 0 => *i as usize,
+                        Some(Value::Num(f)) if *f >= 0.0 => *f as usize,
+                        _ => 0,
+                    };
+                    let mut s = String::new();
+                    for _ in 0..n {
+                        match self.read_user_io_char(target) {
+                            Ok(Some(c)) => s.push_str(&c),
+                            Ok(None) => break,
+                            Err(e) => return Some(Err(e)),
+                        }
+                    }
+                    return Some(Ok(Value::str(s)));
+                }
+                "lines" => {
+                    let seps = Self::user_io_line_separators(target);
+                    let mut out = Vec::new();
+                    loop {
+                        match self.read_user_io_line(target, &seps) {
+                            Ok(Some(line)) => {
+                                out.push(Value::str(String::from_utf8_lossy(&line).into_owned()))
+                            }
+                            Ok(None) => break,
+                            Err(e) => return Some(Err(e)),
+                        }
+                    }
+                    return Some(Ok(Value::Seq(std::sync::Arc::new(out))));
+                }
+                // words/split/comb operate on the fully-read, decoded text by
+                // delegating to the corresponding Str method (which already
+                // implements the regex/whitespace semantics).
+                "words" | "split" | "comb" => {
+                    let bytes = match self.read_all_user_io(target) {
+                        Ok(b) => b,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    let text = Value::str(String::from_utf8_lossy(&bytes).into_owned());
+                    return Some(self.call_method_with_values(text, method, args.to_vec()));
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+
     /// Interpreter-native dispatch for the pure-handle methods of an `IO::Handle`
     /// (`close`/`tell`/`eof`/`seek`/`opened`/`t` plus the PR-D Tier-1
     /// setters/getters `chomp`/`nl-out`/`out-buffer`/`encoding` and

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -99,6 +99,12 @@ impl Interpreter {
             // generic native-method fallback below. These methods mutate only the
             // shared handle-table state (not the receiver binding), so the native
             // path returns the result directly; `None` falls through unchanged.
+            // User-subclassed IO::Handle (overrides WRITE/READ/EOF): route the
+            // high-level methods through the user methods before the native
+            // file-handle path (which would fail — no OS handle).
+            if let Some(result) = self.try_user_io_handle_method(&target, method, &args) {
+                return result;
+            }
             if let Some(result) = self.try_native_io_handle_method(&target, method, &args) {
                 return result;
             }

--- a/t/buf-splice-count.t
+++ b/t/buf-splice-count.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Buf.splice(offset, count, replacement?) must honor the offset/count args
+# (previously it ignored them and removed everything). Regression for the user
+# IO::Handle `READ(\n) { $!data.splice: 0, n }` path in io-handle.t.
+
+plan 10;
+
+{
+    my $b = Buf.new(1, 2, 3, 4, 5);
+    is-deeply $b.splice.List, (1, 2, 3, 4, 5), 'no-arg splice removes all';
+    is $b.elems, 0, '...and empties the Buf';
+}
+
+{
+    my $b = Buf.new(1, 2, 3, 4, 5);
+    is-deeply $b.splice(0, 1).List, (1,), 'splice(0,1) removes one element';
+    is-deeply $b.List, (2, 3, 4, 5), '...leaving the rest';
+}
+
+{
+    my $b = Buf.new(1, 2, 3, 4, 5);
+    is-deeply $b.splice(1, 2).List, (2, 3), 'splice(1,2) removes a middle slice';
+    is-deeply $b.List, (1, 4, 5), '...leaving the surrounding elements';
+}
+
+{
+    my $b = Buf.new(1, 2, 3, 4, 5);
+    is-deeply $b.splice(2).List, (3, 4, 5), 'splice(offset) removes to the end';
+    is-deeply $b.List, (1, 2), '...leaving the prefix';
+}
+
+{
+    my $b = Buf.new(1, 2, 3, 4, 5);
+    is-deeply $b.splice(1, 2, Buf.new(9, 9, 9)).List, (2, 3),
+        'splice with replacement returns the removed slice';
+    is-deeply $b.List, (1, 9, 9, 9, 4, 5), '...and inserts the replacement';
+}

--- a/t/io-handle-user-subclass.t
+++ b/t/io-handle-user-subclass.t
@@ -1,0 +1,86 @@
+use Test;
+
+# A user-defined IO::Handle subclass that overrides WRITE/READ/EOF: the
+# high-level methods (print/say/.../slurp/lines/get/...) dispatch through the
+# user methods, with no underlying OS file. Regression for roast
+# S32-io/io-handle.t `.WRITE` and `.EOF/.WRITE` subtests.
+
+plan 15;
+
+# --- Output via user WRITE ---------------------------------------------------
+{
+    my $fh := my class MyOut is IO::Handle {
+        has Buf[uint8] $.data .= new;
+        submethod TWEAK { self.encoding: 'utf8' }
+        method WRITE (Blob:D \data --> True) { $!data.append: data }
+    }.new;
+
+    $fh.print:  'print ';
+    $fh.printf: 'pri%s', 'ntf ';
+    $fh.put:    'put';
+    $fh.say:    my class { method gist { 'say' } }.new;
+    $fh.spurt:  'spurt text ';
+    $fh.spurt:  'spurt bin '.encode;
+    $fh.write:  'write'.encode;
+    $fh.print-nl;
+
+    is-deeply $fh.data.decode.lines,
+        ('print printf put', 'say', 'spurt text spurt bin write'),
+        'all writing methods route through user WRITE';
+}
+
+# --- Input via user READ/EOF -------------------------------------------------
+my $make = my class MyIn is IO::Handle {
+    has Buf[uint8] $.data .= new: "I ♥ Raku\nprogramming".encode;
+    submethod TWEAK { self.encoding: 'utf8' }
+    method READ(\bytes) { $!data.splice: 0, bytes }
+    method EOF { ! $!data }
+};
+
+{
+    my $fh := $make.new;
+    is-deeply $fh.eof,   False, 'eof before read';
+    is-deeply $fh.slurp, "I ♥ Raku\nprogramming", '.slurp via READ';
+    is-deeply $fh.eof,   True,  'eof after slurp';
+}
+
+{
+    my $fh := $make.new;
+    is-deeply $fh.lines, ('I ♥ Raku', 'programming').Seq, '.lines via READ';
+    is-deeply $fh.eof,   True, 'eof after lines';
+}
+
+{
+    my $fh := $make.new;
+    $fh.nl-in = [<ak gra>];
+    is-deeply $fh.lines, ('I ♥ R', "u\npro", 'mming').Seq,
+        '.lines with custom nl-in';
+}
+
+{
+    my $fh := $make.new;
+    is-deeply $fh.words, <I ♥ Raku programming>».Str.Seq, '.words via READ';
+}
+
+{
+    my $fh := $make.new;
+    is-deeply $fh.split(/ak/), ("I ♥ R", "u\nprogramming").Seq, '.split via READ';
+}
+
+{
+    my $fh := $make.new;
+    is-deeply $fh.get,  'I ♥ Raku',    'first .get reads one line';
+    is-deeply $fh.eof,  False,         'eof: data remains after first get';
+    is-deeply $fh.get,  'programming', 'second .get reads the rest';
+    is-deeply $fh.get,  Nil,           'third .get returns Nil at EOF';
+}
+
+{
+    my $fh := $make.new;
+    is-deeply ($fh.getc xx 5), ('I', ' ', '♥', ' ', 'R').Seq, 'five .getc calls';
+}
+
+{
+    my $fh := $make.new;
+    is-deeply $fh.read(7).decode, "I ♥ R", '.read(7) returns 7 bytes';
+}


### PR DESCRIPTION
## Summary

A user-defined `IO::Handle` subclass that overrides `WRITE`/`READ`/`EOF` can now be used as a handle with **no underlying OS file** — the high-level methods dispatch through the user methods (roast `S32-io/io-handle.t` `.WRITE` and `.EOF/.WRITE` subtests).

```raku
my $fh := my class MyHandle is IO::Handle {
    has Buf[uint8] $.data .= new;
    submethod TWEAK { self.encoding: 'utf8' }
    method WRITE (Blob:D \data --> True) { $!data.append: data }
}.new;
$fh.print: 'hi'; $fh.put: 'there';   # → routed to WRITE
```

## What's new

`try_user_io_handle_method` runs before the native file-handle path for an `IO::Handle` subclass instance:
- **Output** (`print`/`put`/`say`/`printf`/`print-nl`/`write`/`spurt`): build the payload, encode to a `Buf[uint8]`, call user `WRITE(Blob:D)`.
- **Input** (`eof`/`slurp`/`get`/`getc`/`lines`/`words`/`split`/`comb`/`read`/`readchars`): drive user `READ`/`EOF`. Line/char reads consume byte-wise via `READ(1)` (exact consumption, no buffer); `slurp`/`words`/`split`/`comb` read to EOF then delegate to the `Str` method. `nl-in` set via `$fh.nl-in = ...` is stored in the instance attribute through the shared cell.
- `encoding` is accepted (defaults UTF-8) so `submethod TWEAK { self.encoding: 'utf8' }` doesn't throw.

## Bonus bug fix

Fixes a general `Buf.splice(offset, count, replacement?)` bug — it **ignored its args and always removed everything**. Now honors offset/count (negative-from-end), inserts the replacement, and returns the removed slice, matching `Array.splice`/rakudo. This is what makes the spec's `method READ(\n) { $!data.splice: 0, n }` consume exactly `n` bytes.

## Result

`io-handle.t` now passes **30/30** and is added to the whitelist. The full IO three-brothers (io-handle/io-path/io-special) are now complete.

Tests: `t/io-handle-user-subclass.t` (15), `t/buf-splice-count.t` (10). `make test` passes (13043 tests, Result: PASS); Buf.splice edge cases verified against raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY