### PR TITLE
fix(multidim): bounds-check the :delete local writeback (panic)

### DIFF
--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -439,7 +439,18 @@ impl Interpreter {
             // that invoked this builtin (an ancestor on the call stack, valid
             // for the synchronous duration of this call).
             let code = unsafe { &*(caller_code as *const crate::opcode::CompiledCode) };
-            if let Some(slot) = code.locals.iter().position(|n| n == var_name) {
+            // `slot` is a position in the *caller code's* local-name table, but
+            // `self.locals` is the currently-executing frame's locals vec. When
+            // this builtin runs nested below a different frame, that frame can
+            // have fewer locals than the caller code names (the two are not the
+            // same length), so the slot index may be out of range — guard it to
+            // avoid an index-out-of-bounds panic (regression from #3748 surfaced
+            // by S32-array/multislice-6e.t). A missing slot means the local does
+            // not exist in this frame, so the env value already holds the result
+            // and skipping the mirror is correct.
+            if let Some(slot) = code.locals.iter().position(|n| n == var_name)
+                && slot < self.locals.len()
+            {
                 self.locals[slot] = updated;
             }
         }


### PR DESCRIPTION
## Summary

`writeback_multidim_var_to_local` (added in #3748) finds the variable's slot in the **caller code's** local-name table (`code.locals`, via the `current_code` raw pointer) but indexes the **currently-executing frame's** `self.locals` with it. When the builtin runs nested below a frame with fewer locals than the caller code names, the slot is out of range and `self.locals[slot] = updated` panics:

```
thread panicked at src/runtime/builtins_multidim_ops.rs:443:
index out of bounds: the len is 13 but the index is 38
```

Surfaced by `roast/S32-array/multislice-6e.t` in the GC-phase roast-history snapshot — a **panic regression from #3748** (the previous snapshot had 0 panics).

## Fix

Guard the write with `slot < self.locals.len()`. A missing slot means the local does not exist in this frame, so the env value already holds the post-delete result and skipping the mirror is correct (the conservative pre-#3748 behavior).

## Verification

- `multislice-6e.t` now runs to completion instead of panicking.
- The multidim `:delete` writeback tests still pass: `t/multidim-dynamic-delete-adverb.t`, `t/multidim-shaped-delete-bounds.t`, `t/multidim-assign-shared-container.t`, `t/multidim-hash-read.t`, `t/multidim-indexing.t`, `t/hash-delete-adverb.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pWzNvodg4iyQEM45uaxjY