### PR TITLE
feat(otf): OTF-compile module subs with non-coercion return types; fix chmod IntStr allomorph

### DIFF
--- a/src/runtime/builtins_io_fs.rs
+++ b/src/runtime/builtins_io_fs.rs
@@ -228,6 +228,9 @@ impl Interpreter {
             .ok_or_else(|| RuntimeError::new("chmod requires a mode"))?;
         let mode_int = match mode_value {
             Value::Int(i) => i as u32,
+            // An allomorph (e.g. IntStr from `:chmod<0o777>`) carries its
+            // already-evaluated integer in the inner value; coerce through it.
+            Value::Mixin(..) | Value::BigInt(_) => crate::runtime::to_int(&mode_value) as u32,
             Value::Str(s) => u32::from_str_radix(&s, 8).unwrap_or(0),
             other => {
                 return Err(RuntimeError::new(format!(

--- a/src/runtime/native_io/io_path_mutate.rs
+++ b/src/runtime/native_io/io_path_mutate.rs
@@ -177,6 +177,11 @@ impl Interpreter {
                     .ok_or_else(|| RuntimeError::new("chmod requires mode"))?;
                 let mode_int = match mode_value {
                     Value::Int(i) => i as u32,
+                    // An allomorph (e.g. IntStr from `:chmod<0o777>`) carries its
+                    // already-evaluated integer in the inner value; coerce through it.
+                    Value::Mixin(..) | Value::BigInt(_) => {
+                        crate::runtime::to_int(&mode_value) as u32
+                    }
                     Value::Str(s) => u32::from_str_radix(&s, 8).unwrap_or(0),
                     other => {
                         return Err(RuntimeError::new(format!(

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1663,12 +1663,21 @@ impl Interpreter {
     /// the parser stamped on the call's caller-line marker).
     pub(super) fn def_is_otf_compilable_module_single(def: &crate::ast::FunctionDef) -> bool {
         !def.is_rw && !def.is_raw
-            // A return type — especially a coercion return (`--> Foo:D()`) or a
-            // definite/subset constraint — drives extra return-time dispatch
-            // (COERCE / type-check) that the standalone OTF compile does not
-            // reproduce identically when several such subs coexist
-            // (roast/S12-coercion/coercion-return.t). Keep them on the interpreter.
-            && def.return_type.is_none()
+            // A *coercion* return (`--> Foo:D()`, the parens) drives extra
+            // return-time COERCE dispatch that the standalone OTF compile does
+            // not reproduce identically when several such subs coexist
+            // (roast/S12-coercion/coercion-return.t), so it stays on the
+            // interpreter. A plain / definite / subset return (`--> Str:D`,
+            // `--> IO::Path:D`) is fine: the compiled binding re-checks it the
+            // same way the interpreter does. This lets Test::Util's
+            // `make-temp-file`/`make-rand-path` (`--> IO::Path:D`, calling a
+            // module-private sibling) OTF-compile (PR closure-env #3899/#3902
+            // made module-level lexical + private-sibling reads work under OTF;
+            // the chmod-IntStr allomorph fix unblocked S32-io/chdir.t).
+            && def
+                .return_type
+                .as_ref()
+                .is_none_or(|rt| !rt.contains('('))
             && def.param_defs.iter().all(|pd| {
                 !pd.sigilless && pd.sub_signature.is_none() && pd.traits.is_empty()
             })

--- a/t/chmod-allomorph.t
+++ b/t/chmod-allomorph.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 4;
+
+# chmod must accept an IntStr allomorph (e.g. from `<0o777>`), coercing it to
+# the inner integer just like a plain Int argument. Regression: the allomorph
+# (a Mixin value) fell through to "Invalid mode: 0o777".
+
+my $dir = $*TMPDIR.child("mutsu-chmod-allomorph-{$*PID}");
+$dir.mkdir;
+LEAVE { try { .unlink for $dir.dir }; try { $dir.rmdir } }
+
+my $f = $dir.child("f");
+$f.spurt: "x";
+
+lives-ok { $f.chmod: 0o644 },      'chmod with octal Int literal';
+lives-ok { $f.chmod: <0o755> },    'chmod with IntStr allomorph <0o755>';
+lives-ok { $f.chmod: <0o644> },    'chmod with IntStr allomorph <0o644>';
+
+# Int-typed named param binding an allomorph then passed to chmod (the
+# Test::Util make-temp-file :chmod path).
+sub with-mode(IO::Path $p, Int :$chmod) { $p.chmod: $_ with $chmod }
+lives-ok { with-mode($f, :chmod<0o600>) }, 'chmod via Int :$chmod allomorph';

--- a/t/lib/RetTypeOTF.rakumod
+++ b/t/lib/RetTypeOTF.rakumod
@@ -1,0 +1,14 @@
+unit module RetTypeOTF;
+
+my @LOG;
+
+# A module-private (non-exported) sibling sub with a return type.
+sub helper(Int $n --> Int:D) { @LOG.push($n); $n * 2 }
+
+# An exported sub with a non-coercion return type that calls the private
+# sibling and reads a module-level lexical. Both must OTF-compile and still
+# resolve `helper` / `@LOG`, and the `--> Int:D` return-check must hold.
+sub pub(Int $n --> Int:D) is export {
+    my $r = helper($n);
+    $r + @LOG.elems
+}

--- a/t/module-sub-return-type-otf.t
+++ b/t/module-sub-return-type-otf.t
@@ -1,0 +1,17 @@
+use Test;
+use lib 't/lib';
+use RetTypeOTF;
+
+plan 3;
+
+# §2-D multi-dispatch OTF: a non-builtin module single sub with a *non-coercion*
+# return type (`--> Int:D`) is now OTF-compiled to bytecode instead of always
+# tree-walking through call_function_fallback. The exported `pub` and its
+# module-private sibling `helper` (both `--> Int:D`) must compile and still
+# resolve each other plus the module-level lexical `@LOG`. A coercion return
+# (`--> Foo:D()`) stays on the interpreter.
+
+# pub(n) = helper(n) + @LOG.elems = n*2 + (#calls so far)
+is pub(3),  7, 'OTF-compiled module sub with return type calls private sibling';
+is pub(5), 12, 'module-level lexical @LOG accumulates across calls';
+is pub(0),  3, 'third call sees prior log entries';


### PR DESCRIPTION
## What

Two changes that together drop the tree-walk fallback for module single subs with return types (§2-D multi-dispatch OTF):

1. **Relax `def_is_otf_compilable_module_single`** to allow a *non-coercion* return type (`--> Str:D`, `--> IO::Path:D`). Only a coercion return (`--> Foo:D()`, the parens) still stays on the interpreter — that drives extra return-time COERCE dispatch the standalone OTF compile can't reproduce identically (roast/S12-coercion/coercion-return.t). Module-private sibling resolution and module-level lexical reads already work under OTF after the closure-env fixes (#3899/#3902), so this no longer regresses.

2. **Fix `chmod` to accept an IntStr allomorph.** `:chmod<0o777>` binds an IntStr (a `Value::Mixin`) to `Int :$chmod`; raku keeps it as IntStr and `.chmod` coerces to Int. mutsu's two chmod sites (`io_path_mutate.rs`, `builtins_io_fs.rs`) matched only `Value::Int` / `Value::Str`, so the allomorph fell through to `Invalid mode: 0o777`. Now coerced through the inner integer via `to_int`.

## Why this was the actual blocker

The prior campaign attributed the `roast/S32-io/chdir.t` abort to "an OTF-compiled module sub cannot resolve a module-private sibling". That was a misdiagnosis: a minimal repro of private-sibling resolution passes under OTF post-#3899/#3902. The real cause of the test-10 abort was `make-temp-file :chmod<0o777>` -> `chmod` rejecting the IntStr. With the chmod fix, `make-temp-file` / `make-rand-path` (`--> IO::Path:D`) OTF-compile cleanly and chdir.t passes all 82 subtests.

## Tests

- `t/chmod-allomorph.t` — chmod with `<0o755>` / `Int :$chmod` allomorphs
- `t/module-sub-return-type-otf.t` (+ `t/lib/RetTypeOTF.rakumod`) — OTF-compiled `--> Int:D` module sub calling a private `--> Int:D` sibling and reading a module-level lexical

`make test` + `make roast` (211027 tests) both green locally; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)