### PR TITLE
feat(otf): OTF-compile multi-dispatch calls with slipped args (CallFuncSlip)

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -693,6 +693,31 @@ impl Interpreter {
             let result = self.maybe_fetch_rw_proxy(result, cf_auto_fetch)?;
             self.stack.push(result);
             // Slice 6.3 step 2: precise env_dirty from the named-call merge.
+        } else if self.has_multi_candidates_cached(&name) && !self.has_proto(&name) {
+            // User-defined multi candidates reached with *slipped* args
+            // (`multi f($a,$b); f(1, |@x)`). The non-slip path resolves and
+            // OTF-compiles the winning candidate in `dispatch_func_call_inner`;
+            // the slip path lacked that branch, so the `user_function_matches_call`
+            // arm below swallowed the multi call and always tree-walked. Mirror
+            // the non-slip multi branch: resolve the unambiguous winner (the
+            // resolver already flattened/saw the slipped args) and run it as
+            // compiled bytecode when OTF-compilable, else fall back. Ambiguity is
+            // signalled by `None` + a pending dispatch error, so clear any stale
+            // one first.
+            let _ = self.take_pending_dispatch_error();
+            if !self.is_interpreter_handled_function(&name)
+                && let Some(def) = loan_env!(self, resolve_function_with_types(&name, &args))
+                && Self::def_is_otf_compilable_multi_candidate(&def)
+                && !Self::function_body_declares_state(&def.body)
+            {
+                let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
+                self.stack.push(result);
+            } else {
+                crate::vm::vm_stats::record_function_fallback(&name);
+                let result = self.vm_call_function_fallback(&name, &args)?;
+                let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
+                self.stack.push(result);
+            }
         } else if loan_env!(self, user_function_matches_call(&name, &args)) {
             // A user-defined sub shadows a same-named builtin (③ PR-2). OTF-compile
             // the resolved def to bytecode when it is a plain single candidate and

--- a/t/multi-slip-otf.t
+++ b/t/multi-slip-otf.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 8;
+
+# §2-D multi-dispatch OTF: a multi call whose arguments are *slipped* at the
+# call site (`f(1, |@x)`) is compiled to OpCode::CallFuncSlip, a separate
+# dispatch path that lacked the multi-candidate OTF branch. It swallowed multi
+# calls into call_function_fallback. The branch now resolves and OTF-compiles
+# (or correctly falls back for) the winning candidate, matching the non-slip
+# path.
+
+# Slipped args resolve to the right arity candidate.
+multi ff($a)      { "one" }
+multi ff($a, $b)  { "two" }
+my @one = 2;
+my @none;
+is ff(1, |@one),  'two', 'slip expands to 2-arg candidate';
+is ff(1, |@none), 'one', 'empty slip resolves to 1-arg candidate';
+is ff(1),         'one', 'no slip still works';
+
+# A genuine capture-param candidate, recursively slipping the capture.
+multi with_cap($a)          { $a }
+multi with_cap($a, $b, |cap){ with_cap($a + $b, |cap) }
+is with_cap(1,2,3,4,5,6), 21, 'recursive |cap multi (S06-multi/syntax)';
+is with_cap(10),          10, 'capture multi base case';
+is with_cap(3, 4),         7, 'capture multi with empty trailing capture';
+
+# Type-based multi with a slipped typed arg picks the right candidate.
+multi tt(Int $a, Int $b) { "ii" }
+multi tt(Str $a, Str $b) { "ss" }
+my @ints = 2;
+my @strs = "y";
+is tt(1, |@ints),   'ii', 'slip preserves Int typing for dispatch';
+is tt("x", |@strs), 'ss', 'slip preserves Str typing for dispatch';


### PR DESCRIPTION
## What

§2-D multi-dispatch OTF: a `multi` call whose arguments are *slipped* at the call site (`multi f(\$a,\$b); f(1, |@x)`) compiles to `OpCode::CallFuncSlip` — a separate dispatch path from the non-slip `CallFunc`. That path's hand-rolled dispatch chain in `exec_call_func_slip_op` lacked the multi-candidate OTF branch the non-slip `dispatch_func_call_inner` has, so its `user_function_matches_call` arm swallowed every slipped multi call into `call_function_fallback` (tree-walk).

This adds the missing branch, mirroring the non-slip multi fork: when `has_multi_candidates_cached(name) && !has_proto(name)`, resolve the unambiguous winning candidate (the resolver sees the already-flattened args) and run it as compiled bytecode when OTF-compilable, else fall back.

## Impact

Zeroes the fallback for recursive capture-param multis like `roast/S06-multi/syntax.t`'s `with_cap`:

```raku
multi with_cap($a)           { $a }
multi with_cap($a, $b, |cap) { with_cap($a + $b, |cap) }   # slips every recursive call
```

(~5 fallbacks/run → 0). A single sub with `|cap` and a multi without slipped args already OTF-compiled; only the *combination* (multi + slipped call args) fell back.

## Tests

`t/multi-slip-otf.t` — arity selection, empty/non-empty slip, type-based dispatch through a slipped arg, recursive `|cap` base/step cases.

`make test` (13062) + `make roast` (211057) both green locally; no regressions (S06-multi/proto.t, type-based.t, lexical-multis.t, S06-currying/positional.t all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)