### PR TITLE
feat(otf): OTF-compile proto-dispatch calls with slipped args (CallFuncSlip)

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -684,7 +684,24 @@ impl Interpreter {
                 return Ok(());
             }
         }
-        if !self.has_proto(&name)
+        if self.has_proto(&name)
+            && let Some(def) = self.vm_resolve_trivial_proto_candidate(&name, &args)
+        {
+            // VM-native trivial-proto dispatch with slipped args (`proto pp(|){*};
+            // multi pp($a,$b); pp(1, |@x)`). Mirrors the non-slip proto branch in
+            // `dispatch_func_call_inner`: resolve the winning candidate via the
+            // VM-owned registry and run it as compiled bytecode. Without this the
+            // slip path tree-walks every proto'd call whose args slip.
+            let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
+            self.stack.push(result);
+        } else if self.has_proto(&name)
+            && let Some(result) =
+                self.vm_try_run_nontrivial_proto_body(&name, args.clone(), compiled_fns)
+        {
+            // Non-trivial proto body (`proto pp($x){ ...; {*} }`) run as compiled
+            // bytecode; the `{*}` still redispatches to the winning candidate.
+            self.stack.push(result?);
+        } else if !self.has_proto(&name)
             && let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args)
         {
             let cf_auto_fetch = !cf.is_raw;

--- a/t/multi-slip-otf.t
+++ b/t/multi-slip-otf.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 12;
 
 # §2-D multi-dispatch OTF: a multi call whose arguments are *slipped* at the
 # call site (`f(1, |@x)`) is compiled to OpCode::CallFuncSlip, a separate
@@ -32,3 +32,19 @@ my @ints = 2;
 my @strs = "y";
 is tt(1, |@ints),   'ii', 'slip preserves Int typing for dispatch';
 is tt("x", |@strs), 'ss', 'slip preserves Str typing for dispatch';
+
+# A `proto` with slipped args: the slip path also lacked the proto-OTF branches
+# (trivial-proto candidate + non-trivial proto body) the non-slip path has.
+proto pp(|) { * }
+multi pp($a)     { "p-one" }
+multi pp($a, $b) { "p-two" }
+my @pp = 2;
+is pp(1, |@pp), 'p-two', 'trivial proto dispatch with slipped args';
+is pp(1),       'p-one', 'trivial proto without slip still works';
+
+proto deep($x, |) { my $r = {*}; "[$r]" }
+multi deep($x)     { "q1" }
+multi deep($x, $y) { "q2" }
+my @dd = 9;
+is deep(1, |@dd), '[q2]', 'non-trivial proto body with slipped args';
+is deep(5),       '[q1]', 'non-trivial proto body without slip still works';


### PR DESCRIPTION
## What

Follow-up to the multi-slip OTF fix (#3909): the slipped-args dispatch path (`OpCode::CallFuncSlip`, used for `f(1, |@x)`) also lacked the two *proto* OTF branches the non-slip `dispatch_func_call_inner` has — trivial-proto candidate resolution and non-trivial proto-body compilation. So a `proto`'d call whose args slip tree-walked through `call_function_fallback`:

```raku
proto pp(|) { * }
multi pp($a)     { ... }
multi pp($a, $b) { ... }
pp(1, |@x)   # slipped -> CallFuncSlip -> fell back
```

This adds both branches to `exec_call_func_slip_op`, ahead of the compiled-fn / multi-candidate branches, mirroring the non-slip path:
- `vm_resolve_trivial_proto_candidate` runs a trivial-body proto's winning candidate as compiled bytecode
- `vm_try_run_nontrivial_proto_body` compiles a real proto body whose `{*}` still redispatches to the winner

Slipped proto calls now OTF-compile (0 fallback) for both trivial and non-trivial bodies.

## Tests

Extends `t/multi-slip-otf.t` with trivial-proto and non-trivial-proto-body slip cases.

`make test` (13066) + `make roast` (211057) both green locally; no regressions (S06-multi/proto.t, type-based.t, syntax.t, lexical-multis.t all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)