### PR TITLE
perf(dispatch): memoize method-body fingerprint by body-Arc pointer

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -324,6 +324,23 @@ impl Interpreter {
         multi
     }
 
+    /// Structural fingerprint of a method body, memoized by its body-`Arc`
+    /// pointer (see `method_body_fp_cache`). Use this instead of calling
+    /// `function_body_fingerprint` directly on the method-redispatch hot path
+    /// (`nextsame`/`samewith`/multi-method deferral): the raw call
+    /// Debug-traverses the entire body AST every time, which a perf profile of a
+    /// samewith-tight loop showed dominating the redispatch cost.
+    pub(crate) fn method_def_fingerprint(&mut self, def: &MethodDef) -> u64 {
+        let key = Arc::as_ptr(&def.body) as usize;
+        if let Some((_, fp)) = self.method_body_fp_cache.get(&key) {
+            return *fp;
+        }
+        let fp = crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+        self.method_body_fp_cache
+            .insert(key, (def.body.clone(), fp));
+        fp
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -355,13 +372,13 @@ impl Interpreter {
         }
         // Identify the chosen candidate and skip exactly that one
         let chosen = self.resolve_method_with_owner(receiver_class, method_name, args);
-        let chosen_fp = chosen.as_ref().map(|(_, def)| {
-            crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body)
-        });
+        let chosen_fp = chosen
+            .as_ref()
+            .map(|(_, def)| self.method_def_fingerprint(def));
         let mut remaining: Vec<(String, super::MethodDef)> = Vec::new();
         let mut skipped_chosen = false;
         for (owner, def) in all_candidates {
-            let fp = crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+            let fp = self.method_def_fingerprint(&def);
             if !skipped_chosen && Some(fp) == chosen_fp {
                 skipped_chosen = true;
                 continue;

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -82,16 +82,11 @@ impl Interpreter {
                                method_def: &MethodDef|
          -> Vec<(String, MethodDef)> {
             let all = this.resolve_all_methods_with_owner(receiver_class_name, method_name, &args);
-            let chosen_fp = crate::ast::function_body_fingerprint(
-                &method_def.params,
-                &method_def.param_defs,
-                &method_def.body,
-            );
+            let chosen_fp = this.method_def_fingerprint(method_def);
             let mut remaining = Vec::new();
             let mut skipped = false;
             for (owner, def) in all {
-                let fp =
-                    crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+                let fp = this.method_def_fingerprint(&def);
                 if !skipped && fp == chosen_fp {
                     skipped = true;
                     continue;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1517,6 +1517,20 @@ pub struct Interpreter {
     /// Structural (registry-shape) only, so it is sound to key on `(class, method)`
     /// and is cleared with the other method caches on any registry change.
     pub(crate) dispatch_multi_candidate: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
+    /// Memoized structural fingerprint of a method body, keyed by the *pointer*
+    /// of its `Arc<Vec<Stmt>>` body. `function_body_fingerprint` Debug-traverses
+    /// the whole body AST, which dominated the method-redispatch hot path
+    /// (`build_remaining` / `prepare_method_dispatch_frame`, reached by every
+    /// `nextsame`/`samewith` and multi-method call) — perf showed ~8% of a
+    /// samewith-tight-loop in SipHash-over-Debug. A `MethodDef` clone shares its
+    /// body `Arc`, and two *distinct* methods always have distinct body `Arc`s
+    /// (clones are the only way to share one, and clones carry identical
+    /// params/param_defs), so the body-`Arc` pointer uniquely identifies the
+    /// `(params, param_defs, body)` tuple the fingerprint covers. The cache holds
+    /// a strong `Arc` clone of each body so the pointer can never be freed and
+    /// reused under a stale entry — it needs no invalidation and is bounded by
+    /// the number of distinct method bodies in the program.
+    pub(crate) method_body_fp_cache: rustc_hash::FxHashMap<usize, (Arc<Vec<Stmt>>, u64)>,
     pub(crate) block_declared_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2057,6 +2057,7 @@ impl Interpreter {
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
+            method_body_fp_cache: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -325,6 +325,7 @@ impl Interpreter {
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
+            method_body_fp_cache: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/t/method-redispatch-fingerprint.t
+++ b/t/method-redispatch-fingerprint.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 6;
+
+# The method-redispatch path (`nextsame`/`samewith`/multi-method deferral)
+# identifies the chosen candidate by its body fingerprint to skip it in the
+# remaining-candidate list. That fingerprint is now memoized by body-Arc pointer
+# (method_body_fp_cache); these tests lock in that the memoization preserves
+# exact dispatch behavior.
+
+# nextsame walks to the next more-general multi candidate.
+my class N {
+    multi method m(Int $x) { "int:" ~ callsame() }
+    multi method m($x)     { "any:$x" }
+}
+is N.new.m(5),   'int:any:5', 'callsame from Int candidate reaches Any candidate';
+is N.new.m('z'), 'any:z',     'non-Int dispatches straight to Any candidate';
+
+# samewith re-dispatches with new args through the same multi.
+my class S {
+    multi method m(Int $x) { samewith $x.Str }
+    multi method m(Str $x) { "str:$x" }
+}
+is S.new.m(42), 'str:42', 'samewith redispatches Int -> Str candidate';
+
+# Repeated calls must stay correct (cache hit path, many iterations).
+my @out;
+my class R {
+    multi method m(Int $x) { @out.push('i'); samewith $x.Str }
+    multi method m(Str)    { @out.push('s') }
+}
+R.new.m($_) for ^50;
+is @out.grep('i').elems, 50, 'samewith Int leg ran 50x under cache';
+is @out.grep('s').elems, 50, 'samewith Str leg ran 50x under cache';
+
+# nextsame in a loop (the defer-next.t shape) keeps producing the same result.
+my @r;
+my class L {
+    multi method m(Int $x where * > 0) { @r.push('>0'); nextsame }
+    multi method m(Int $x where * < 10){ @r.push('<10'); nextsame }
+    multi method m(Int)                 { @r.push('generic') }
+}
+L.new.m(5) for ^3;
+is @r, ['>0','<10','generic', '>0','<10','generic', '>0','<10','generic'],
+    'nextsame chain stable across repeated calls';


### PR DESCRIPTION
## What

The method-redispatch path (`nextsame`/`samewith`/multi-method deferral, via `build_remaining` in `class_dispatch.rs` and `push_method_dispatch_frame` in `accessors_state.rs`) identifies the chosen candidate by its **body fingerprint** to skip it in the remaining-candidate list. `function_body_fingerprint` Debug-traverses the *entire* method body AST and SipHashes it.

A perf profile of a samewith-tight loop (the `S12-methods/defer-next.t` shape — `multi method m(Int $x) { samewith $x.Str }`, 100k iters) showed this at **~8% of runtime** (SipHash-over-Debug).

## Fix

Memoize the fingerprint: `method_body_fp_cache` maps a body-`Arc<Vec<Stmt>>` pointer to its fingerprint.

Soundness: a `MethodDef` clone shares its body `Arc`, and two *distinct* methods always have distinct body `Arc`s (cloning is the only way to share one, and clones carry identical params/param_defs), so the body-`Arc` pointer uniquely identifies the `(params, param_defs, body)` tuple the fingerprint covers. The cache holds a **strong `Arc` clone** of each body, so the pointer can never be freed and reused under a stale entry — no invalidation needed, bounded by the number of distinct method bodies in the program.

## Result

Profile after: `function_body_fingerprint` drops from ~8% to ~1% on that loop. The structural-dedup semantics (skip the chosen candidate; dedup role-diamond identical methods) are unchanged — same fingerprint values, just computed once.

This came out of investigating the dominant `samewith` fallback: the real redispatch cost was this fingerprinting, not the samewith shim or any OTF fallback.

## Tests

`t/method-redispatch-fingerprint.t` — nextsame/samewith/multi-method dispatch correctness across repeated (cache-hit) calls.

`make test` (13072) + `make roast` (211057) both green locally; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)