### PR TITLE
[codex] roast: advance misc blockers

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1537,11 +1537,17 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // bare ..." (e.g. `ord.Cool`). A real call (`ord $x` / `ord('A')`) parses as
     // a listop/call before reaching this fallback, so it is unaffected.
     if is_terminator_or_dot && matches!(name.as_str(), "ord" | "chr" | "lc" | "uc" | "abs") {
-        return Err(PError::fatal(format!(
+        let message = format!(
             "X::Obsolete: Unsupported use of bare \"{name}\".  In Raku please use: \
              .{name} if you meant to call it as a method on $_, or use an explicit \
              invocant or argument."
-        )));
+        );
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("old".to_string(), Value::str(name.clone()));
+        attrs.insert("replacement".to_string(), Value::str(format!(".{name}")));
+        attrs.insert("message".to_string(), Value::str(message.clone()));
+        let exception = Value::make_instance(Symbol::intern("X::Obsolete"), attrs);
+        return Err(PError::fatal_with_exception(message, Box::new(exception)));
     }
 
     // Method-like: .new, .elems etc. is handled at expression level

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -68,6 +68,54 @@ fn condition_expr(input: &str) -> PResult<'_, Expr> {
     }
 }
 
+fn render_expr_brief(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::BareWord(s) => Some(s.clone()),
+        Expr::Var(s) => Some(format!("${s}")),
+        Expr::ArrayVar(s) => Some(format!("@{s}")),
+        Expr::HashVar(s) => Some(format!("%{s}")),
+        Expr::Literal(v) => Some(v.to_string_value()),
+        Expr::Grouped(inner) => render_expr_brief(inner),
+        Expr::Unary { expr, .. } => render_expr_brief(expr),
+        Expr::Binary { left, right, .. } => {
+            let l = render_expr_brief(left)?;
+            let r = render_expr_brief(right)?;
+            Some(format!("{l} {r}"))
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn make_block_gobbled_group_error(what: &str) -> PError {
+    let sorrow_message =
+        format!("Expression '{what}' was gobbled by a block; parenthesize it or add a separator");
+    let mut sorrow_attrs = std::collections::HashMap::new();
+    sorrow_attrs.insert("what".to_string(), Value::str(what.to_string()));
+    sorrow_attrs.insert("message".to_string(), Value::str(sorrow_message.clone()));
+    let sorrow = Value::make_instance(Symbol::intern("X::Syntax::BlockGobbled"), sorrow_attrs);
+
+    let mut panic_attrs = std::collections::HashMap::new();
+    panic_attrs.insert("what".to_string(), Value::str("block".to_string()));
+    panic_attrs.insert(
+        "message".to_string(),
+        Value::str("Missing block".to_string()),
+    );
+    let panic = Value::make_instance(Symbol::intern("X::Syntax::Missing"), panic_attrs);
+
+    let group_message = format!("{sorrow_message}\nMissing block");
+    let mut group_attrs = std::collections::HashMap::new();
+    group_attrs.insert("sorrows".to_string(), Value::array(vec![sorrow]));
+    group_attrs.insert("worries".to_string(), Value::array(vec![]));
+    group_attrs.insert("panic".to_string(), panic);
+    group_attrs.insert("message".to_string(), Value::str(group_message.clone()));
+    let exception = Value::make_instance(Symbol::intern("X::Comp::Group"), group_attrs);
+    PError::fatal_with_exception(group_message, Box::new(exception))
+}
+
+pub(super) fn block_gobbled_group_from_expr(expr: &Expr) -> Option<PError> {
+    render_expr_brief(expr).map(|what| make_block_gobbled_group_error(&what))
+}
+
 /// Build a fatal, structured `X::Obsolete` parse error carrying `old` /
 /// `replacement` attributes so that `throws-like` can match them.
 pub(in crate::parser) fn make_obsolete_error(

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -73,6 +73,27 @@ pub(crate) fn lazy_for_body(input: &str) -> PResult<'_, Stmt> {
     for_stmt_with_mode(input, crate::ast::ForMode::Lazy)
 }
 
+fn gobbled_block_anchor(source: &str) -> Option<String> {
+    let before_block = source.rsplit_once('{')?.0.trim_end();
+    let before_block = before_block
+        .strip_suffix(',')
+        .unwrap_or(before_block)
+        .trim_end();
+    if before_block.is_empty() {
+        return None;
+    }
+    let anchor = before_block
+        .rsplit(',')
+        .next()
+        .unwrap_or(before_block)
+        .trim();
+    if anchor.is_empty() {
+        None
+    } else {
+        Some(anchor.to_string())
+    }
+}
+
 /// Scan for `<->` (rw pointy block) in the input, returning its byte offset.
 /// This must handle nesting to avoid matching inside strings, brackets, etc.
 fn find_rw_pointy_block(input: &str) -> Option<usize> {
@@ -134,6 +155,7 @@ fn find_rw_pointy_block(input: &str) -> Option<usize> {
 fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stmt> {
     let rest = keyword("for", input).ok_or_else(|| PError::expected("for statement"))?;
     let (rest, _) = ws1(rest)?;
+    let iterable_input = rest;
     // Perl 5 `for my $x (LIST) { }` foreach syntax.
     if looks_like_p5_foreach(rest) {
         return Err(p5_foreach_error());
@@ -174,6 +196,12 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
     // (`for 1, 2` → X::Syntax::Missing, what => 'block'). Fail fatally so the
     // statement dispatcher does not fall back to reparsing `for` as a term.
     if !rest.starts_with('{') {
+        let consumed = &iterable_input[..iterable_input.len().saturating_sub(rest.len())];
+        if consumed.contains('{')
+            && let Some(anchor) = gobbled_block_anchor(consumed)
+        {
+            return Err(make_block_gobbled_group_error(&anchor));
+        }
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("what".to_string(), Value::str("block".to_string()));
         attrs.insert(

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -244,11 +244,24 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
             && let Some(&first) = parsed_kinds.first()
             && (parsed_kinds.len() >= 2 || !second_modifier_allowed(first, next_kw))
         {
+            let consumed_len = input.len().saturating_sub(rest.len());
+            let pre = input[..consumed_len].trim_end().to_string();
+            let post = rest
+                .strip_prefix(next_kw)
+                .unwrap_or(rest)
+                .trim_start()
+                .to_string();
             let mut attrs = std::collections::HashMap::new();
             attrs.insert(
                 "message".to_string(),
                 crate::value::Value::str("Missing semicolon".to_string()),
             );
+            attrs.insert(
+                "reason".to_string(),
+                crate::value::Value::str("Missing semicolon".to_string()),
+            );
+            attrs.insert("pre".to_string(), crate::value::Value::str(pre));
+            attrs.insert("post".to_string(), crate::value::Value::str(post));
             let ex = crate::value::Value::make_instance(
                 crate::symbol::Symbol::intern("X::Syntax::Confused"),
                 attrs,

--- a/src/parser/stmt/simple_expr_stmt/predicates.rs
+++ b/src/parser/stmt/simple_expr_stmt/predicates.rs
@@ -90,10 +90,12 @@ pub(super) fn is_literal_expr(expr: &Expr) -> bool {
 /// (`(1,2)[0] := 3`). Binding into such a target is illegal → X::Bind.
 pub(super) fn index_bind_target_is_immutable(target: &Expr) -> bool {
     match target {
+        Expr::Grouped(inner) => index_bind_target_is_immutable(inner),
         Expr::Literal(v) => matches!(
             v,
             Value::Int(_) | Value::Str(_) | Value::Num(_) | Value::Rat(..) | Value::Bool(_)
         ),
+        Expr::BareWord(name) => crate::runtime::Interpreter::is_builtin_type(name),
         Expr::ArrayLiteral(elems) => {
             !elems.is_empty() && elems.iter().all(|e| matches!(e, Expr::Literal(_)))
         }

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -6,6 +6,9 @@
 //! `mod.rs` at their original visibility.
 
 use super::*;
+use crate::ast::Expr;
+use crate::symbol::Symbol;
+use crate::value::Value;
 
 /// Parse a block: { stmts }
 /// Pushes/pops a lexical import scope so that `use` inside a block
@@ -187,6 +190,34 @@ fn has_statement_separator(rest: &str) -> bool {
     true
 }
 
+fn first_when_cond(body: &[Stmt]) -> Option<&Expr> {
+    for stmt in body {
+        match stmt {
+            Stmt::When { cond, .. } => return Some(cond),
+            Stmt::SetLine(_) => {}
+            _ => return None,
+        }
+    }
+    None
+}
+
+fn illegal_decimal_group_error() -> PError {
+    let sorrow_message = "Decimal point must be followed by digit".to_string();
+    let mut sorrow_attrs = std::collections::HashMap::new();
+    sorrow_attrs.insert("message".to_string(), Value::str(sorrow_message.clone()));
+    let sorrow = Value::make_instance(
+        Symbol::intern("X::Syntax::Number::IllegalDecimal"),
+        sorrow_attrs,
+    );
+    let mut group_attrs = std::collections::HashMap::new();
+    group_attrs.insert("sorrows".to_string(), Value::array(vec![sorrow]));
+    group_attrs.insert("worries".to_string(), Value::array(vec![]));
+    group_attrs.insert("panic".to_string(), Value::Nil);
+    group_attrs.insert("message".to_string(), Value::str(sorrow_message.clone()));
+    let exception = Value::make_instance(Symbol::intern("X::Comp::Group"), group_attrs);
+    PError::fatal_with_exception(sorrow_message, Box::new(exception))
+}
+
 pub(crate) fn stmt_list_with_mode(
     input: &str,
     allow_mainline_capture: bool,
@@ -302,6 +333,13 @@ pub(crate) fn stmt_list_with_mode(
         let line_valid = crate::parser::primary::is_within_original_source(r);
         match statement(r) {
             Ok((r, stmt)) => {
+                if stmts.is_empty()
+                    && let Stmt::Catch(body) | Stmt::Control(body) = &stmt
+                    && let Some(cond) = first_when_cond(body)
+                    && let Some(err) = super::control::block_gobbled_group_from_expr(cond)
+                {
+                    return Err(err);
+                }
                 // In Raku, after a statement-ending block (e.g. `sub f { 3 }`),
                 // a semicolon, newline, closing brace, or end-of-input is required
                 // before the next statement.  `sub f { 3 } sub g { 3 }` on a
@@ -331,6 +369,16 @@ pub(crate) fn stmt_list_with_mode(
             Err(e) => {
                 if e.is_fatal() {
                     return Err(e);
+                }
+                if stmts.is_empty() {
+                    let probe = r.trim();
+                    if probe.ends_with('.')
+                        && probe[..probe.len().saturating_sub(1)]
+                            .chars()
+                            .all(|c| c.is_ascii_digit())
+                    {
+                        return Err(illegal_decimal_group_error());
+                    }
                 }
                 let consumed = input.len() - r.len();
                 let line_num = input[..consumed].matches('\n').count() + 1;

--- a/src/parser/stmt/sub/sub_decl.rs
+++ b/src/parser/stmt/sub/sub_decl.rs
@@ -216,8 +216,14 @@ pub(crate) fn sub_decl_body(
     } else {
         rest
     };
-    // Detect forward declaration: `sub name(...);`.
-    if let Some(rest) = rest.strip_prefix(';') {
+    // Detect forward declaration: `sub name(...);` or the same declaration at
+    // end-of-input with no body.
+    if rest.trim().is_empty() || rest.starts_with(';') {
+        let rest = if let Some(rest) = rest.strip_prefix(';') {
+            rest
+        } else {
+            rest
+        };
         // Merge return type for forward declarations too
         let fwd_return_type = return_type.clone().or(traits.return_type.clone());
         if allow_main_semicolon_decl && name == "MAIN" && !multi {

--- a/src/parser/stmt/sub/sub_name.rs
+++ b/src/parser/stmt/sub/sub_name.rs
@@ -41,11 +41,26 @@ pub(crate) fn null_operator_error(name: &str) -> Option<PError> {
     if !inner.trim().is_empty() {
         return None;
     }
-    let message = "Null operator is not allowed".to_string();
-    let mut attrs = std::collections::HashMap::new();
-    attrs.insert("message".to_string(), Value::str(message.clone()));
-    let ex = Value::make_instance(Symbol::intern("X::Syntax::Extension::Null"), attrs);
-    Some(PError::fatal_with_exception(message, Box::new(ex)))
+    let panic_message = "Null operator is not allowed".to_string();
+    let mut panic_attrs = std::collections::HashMap::new();
+    panic_attrs.insert("message".to_string(), Value::str(panic_message.clone()));
+    let panic = Value::make_instance(Symbol::intern("X::Syntax::Extension::Null"), panic_attrs);
+
+    let mut worry_attrs = std::collections::HashMap::new();
+    worry_attrs.insert(
+        "payload".to_string(),
+        Value::str("Pair with <> really means an empty list, not null string".to_string()),
+    );
+    let worry = Value::make_instance(Symbol::intern("X::AdHoc"), worry_attrs);
+
+    let group_message = panic_message.clone();
+    let mut group_attrs = std::collections::HashMap::new();
+    group_attrs.insert("sorrows".to_string(), Value::array(vec![]));
+    group_attrs.insert("worries".to_string(), Value::array(vec![worry]));
+    group_attrs.insert("panic".to_string(), panic);
+    group_attrs.insert("message".to_string(), Value::str(group_message.clone()));
+    let group = Value::make_instance(Symbol::intern("X::Comp::Group"), group_attrs);
+    Some(PError::fatal_with_exception(group_message, Box::new(group)))
 }
 
 pub(crate) fn parse_sub_name_inner(input: &str) -> PResult<'_, String> {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1507,6 +1507,7 @@ impl Interpreter {
         // X::Syntax hierarchy (syntax errors, subtypes of X::Comp)
         register_x("X::Syntax", "X::Comp");
         register_x("X::Syntax::Confused", "X::Syntax");
+        register_x("X::Syntax::BlockGobbled", "X::Syntax");
         register_x("X::Syntax::Extension::Null", "X::Syntax");
         register_x("X::Syntax::Missing", "X::Syntax");
         register_x("X::Syntax::VirtualCall", "X::Syntax");

--- a/src/runtime/system_eval_names.rs
+++ b/src/runtime/system_eval_names.rs
@@ -1,6 +1,486 @@
 use super::*;
 
 impl Interpreter {
+    fn find_unknown_code_var_in_expr(
+        &self,
+        expr: &Expr,
+        declared: &HashSet<String>,
+    ) -> Option<String> {
+        match expr {
+            Expr::CodeVar(name)
+                if (name.starts_with("infix:<")
+                    || name.starts_with("prefix:<")
+                    || name.starts_with("postfix:<"))
+                    && !self.has_function(name)
+                    && !self.has_multi_function(name)
+                    && !declared.contains(name) =>
+            {
+                Some(name.clone())
+            }
+            Expr::Binary { left, right, .. } => self
+                .find_unknown_code_var_in_expr(left, declared)
+                .or_else(|| self.find_unknown_code_var_in_expr(right, declared)),
+            Expr::Unary { expr, .. }
+            | Expr::Grouped(expr)
+            | Expr::Eager(expr)
+            | Expr::Itemize(expr)
+            | Expr::DeitemizeForBind(expr)
+            | Expr::IndirectTypeLookup(expr)
+            | Expr::ZenSlice(expr) => self.find_unknown_code_var_in_expr(expr, declared),
+            Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+                self.find_unknown_code_var_in_expr(target, declared)
+                    .or_else(|| {
+                        args.iter()
+                            .find_map(|arg| self.find_unknown_code_var_in_expr(arg, declared))
+                    })
+            }
+            Expr::DynamicMethodCall {
+                target,
+                name_expr,
+                args,
+                ..
+            }
+            | Expr::HyperMethodCallDynamic {
+                target,
+                name_expr,
+                args,
+                ..
+            } => self
+                .find_unknown_code_var_in_expr(target, declared)
+                .or_else(|| self.find_unknown_code_var_in_expr(name_expr, declared))
+                .or_else(|| {
+                    args.iter()
+                        .find_map(|arg| self.find_unknown_code_var_in_expr(arg, declared))
+                }),
+            Expr::Call { args, .. }
+            | Expr::CaptureLiteral(args)
+            | Expr::ArrayLiteral(args)
+            | Expr::BracketArray(args, _) => args
+                .iter()
+                .find_map(|arg| self.find_unknown_code_var_in_expr(arg, declared)),
+            Expr::StringInterpolation(parts) => parts
+                .iter()
+                .find_map(|part| self.find_unknown_code_var_in_expr(part, declared)),
+            _ => None,
+        }
+    }
+
+    fn find_unknown_code_var_in_stmt(
+        &self,
+        stmt: &Stmt,
+        declared: &HashSet<String>,
+    ) -> Option<String> {
+        match stmt {
+            Stmt::Expr(expr) => self.find_unknown_code_var_in_expr(expr, declared),
+            Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => {
+                self.find_unknown_code_var_in_expr(expr, declared)
+            }
+            Stmt::Say(es) | Stmt::Print(es) | Stmt::Put(es) | Stmt::Note(es) => es
+                .iter()
+                .find_map(|expr| self.find_unknown_code_var_in_expr(expr, declared)),
+            Stmt::Block(body)
+            | Stmt::SyntheticBlock(body)
+            | Stmt::Catch(body)
+            | Stmt::Control(body)
+            | Stmt::Default(body)
+            | Stmt::React { body }
+            | Stmt::Phaser { body, .. } => body
+                .iter()
+                .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared)),
+            Stmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => self
+                .find_unknown_code_var_in_expr(cond, declared)
+                .or_else(|| {
+                    then_branch
+                        .iter()
+                        .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                })
+                .or_else(|| {
+                    else_branch
+                        .iter()
+                        .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                }),
+            Stmt::For { iterable, body, .. }
+            | Stmt::Whenever {
+                supply: iterable,
+                body,
+                ..
+            } => self
+                .find_unknown_code_var_in_expr(iterable, declared)
+                .or_else(|| {
+                    body.iter()
+                        .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                }),
+            Stmt::While { cond, body, .. } => self
+                .find_unknown_code_var_in_expr(cond, declared)
+                .or_else(|| {
+                    body.iter()
+                        .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                }),
+            Stmt::Loop {
+                init,
+                cond,
+                step,
+                body,
+                ..
+            } => init
+                .as_deref()
+                .and_then(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                .or_else(|| {
+                    cond.as_ref()
+                        .and_then(|expr| self.find_unknown_code_var_in_expr(expr, declared))
+                })
+                .or_else(|| {
+                    step.as_ref()
+                        .and_then(|expr| self.find_unknown_code_var_in_expr(expr, declared))
+                })
+                .or_else(|| {
+                    body.iter()
+                        .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                }),
+            Stmt::Given { topic, body } | Stmt::When { cond: topic, body } => self
+                .find_unknown_code_var_in_expr(topic, declared)
+                .or_else(|| {
+                    body.iter()
+                        .find_map(|stmt| self.find_unknown_code_var_in_stmt(stmt, declared))
+                }),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn check_eval_unknown_code_vars(&self, stmts: &[Stmt]) -> Result<(), RuntimeError> {
+        let mut declared: HashSet<String> = HashSet::new();
+        for stmt in stmts {
+            Self::collect_declared_routine_names(stmt, &mut declared);
+        }
+        for stmt in stmts {
+            if let Some(name) = self.find_unknown_code_var_in_stmt(stmt, &declared) {
+                let suggestions = self.suggest_routine_names(&name);
+                return Err(RuntimeError::undeclared_routine_symbols(
+                    &name,
+                    format!("Undeclared routine:\n    {} used at line 1", name),
+                    suggestions,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_eval_when_undeclared_types(
+        &self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        let mut local_classes: HashSet<String> = HashSet::new();
+        let mut declared: HashSet<String> = HashSet::new();
+        for stmt in stmts {
+            if let Stmt::ClassDecl { name, .. } = stmt {
+                local_classes.insert(name.resolve());
+            }
+            if let Stmt::RoleDecl { name, .. } = stmt {
+                local_classes.insert(name.resolve());
+            }
+            Self::collect_declared_vars(stmt, &mut declared);
+            Self::collect_declared_routine_names(stmt, &mut declared);
+        }
+        for stmt in stmts {
+            if let Some(name) =
+                self.find_undeclared_when_type_in_stmt(stmt, &local_classes, &declared)
+            {
+                let suggestions = self.suggest_type_names(&name);
+                let sorrow = RuntimeError::undeclared_type_symbols(
+                    &name,
+                    format!("Undeclared name:\n    {} used at line 1", name),
+                    suggestions,
+                )
+                .exception
+                .map(|v| *v)
+                .unwrap_or(Value::Nil);
+                let mut group_attrs = std::collections::HashMap::new();
+                group_attrs.insert("sorrows".to_string(), Value::array(vec![sorrow]));
+                group_attrs.insert("worries".to_string(), Value::array(vec![]));
+                group_attrs.insert("panic".to_string(), Value::Nil);
+                group_attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!("Undeclared name:\n    {} used at line 1", name)),
+                );
+                return Err(RuntimeError::typed("X::Comp::Group", group_attrs));
+            }
+        }
+        Ok(())
+    }
+
+    fn find_undeclared_when_type_in_stmt(
+        &self,
+        stmt: &Stmt,
+        local_classes: &HashSet<String>,
+        declared: &HashSet<String>,
+    ) -> Option<String> {
+        match stmt {
+            Stmt::Given { body, .. }
+            | Stmt::Block(body)
+            | Stmt::SyntheticBlock(body)
+            | Stmt::Catch(body)
+            | Stmt::Control(body)
+            | Stmt::Default(body)
+            | Stmt::React { body }
+            | Stmt::Phaser { body, .. } => body.iter().find_map(|stmt| {
+                self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+            }),
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => then_branch
+                .iter()
+                .find_map(|stmt| {
+                    self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+                })
+                .or_else(|| {
+                    else_branch.iter().find_map(|stmt| {
+                        self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+                    })
+                }),
+            Stmt::For { body, .. } | Stmt::While { body, .. } | Stmt::Whenever { body, .. } => {
+                body.iter().find_map(|stmt| {
+                    self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+                })
+            }
+            Stmt::Loop { init, body, .. } => init
+                .as_deref()
+                .and_then(|stmt| {
+                    self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+                })
+                .or_else(|| {
+                    body.iter().find_map(|stmt| {
+                        self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+                    })
+                }),
+            Stmt::When { cond, body } => self
+                .find_undeclared_name_in_expr(cond, local_classes, declared)
+                .or_else(|| {
+                    body.iter().find_map(|stmt| {
+                        self.find_undeclared_when_type_in_stmt(stmt, local_classes, declared)
+                    })
+                }),
+            _ => None,
+        }
+    }
+
+    fn stmt_declares_type_name(stmt: &Stmt) -> Option<String> {
+        match stmt {
+            Stmt::ClassDecl { name, .. }
+            | Stmt::RoleDecl { name, .. }
+            | Stmt::EnumDecl { name, .. }
+            | Stmt::SubsetDecl { name, .. } => Some(name.resolve()),
+            Stmt::Package { name, kind, .. }
+                if !matches!(
+                    kind,
+                    crate::ast::PackageKind::Module | crate::ast::PackageKind::Package
+                ) =>
+            {
+                Some(name.resolve())
+            }
+            _ => None,
+        }
+    }
+
+    fn find_undeclared_type_in_type_body(
+        &self,
+        stmts: &[Stmt],
+        visible_types: &HashSet<String>,
+    ) -> Option<String> {
+        for stmt in stmts {
+            match stmt {
+                Stmt::MethodDecl { body, .. }
+                | Stmt::SubDecl { body, .. }
+                | Stmt::TokenDecl { body, .. }
+                | Stmt::RuleDecl { body, .. }
+                | Stmt::Block(body)
+                | Stmt::SyntheticBlock(body)
+                | Stmt::Default(body)
+                | Stmt::Catch(body)
+                | Stmt::Control(body)
+                | Stmt::React { body }
+                | Stmt::Phaser { body, .. } => {
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::ClassDecl { name, body, .. } | Stmt::RoleDecl { name, body, .. } => {
+                    let mut nested_visible = visible_types.clone();
+                    nested_visible.insert(name.resolve());
+                    if let Some(name) =
+                        self.find_undeclared_type_in_type_body(body, &nested_visible)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::If {
+                    cond,
+                    then_branch,
+                    else_branch,
+                    ..
+                } => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(cond, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) =
+                        self.find_undeclared_type_in_type_body(then_branch, visible_types)
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) =
+                        self.find_undeclared_type_in_type_body(else_branch, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::For { iterable, body, .. } => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(iterable, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::While { cond, body, .. } => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(cond, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::Loop {
+                    init,
+                    cond,
+                    step,
+                    body,
+                    ..
+                } => {
+                    if let Some(init) = init.as_deref()
+                        && let Some(name) =
+                            self.find_undeclared_name_in_stmt(init, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(cond) = cond
+                        && let Some(name) =
+                            self.find_undeclared_name_in_expr(cond, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(step) = step
+                        && let Some(name) =
+                            self.find_undeclared_name_in_expr(step, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::Whenever { supply, body, .. } => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(supply, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::Given { topic, body } => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(topic, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                Stmt::When { cond, body } => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_expr(cond, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                    if let Some(name) = self.find_undeclared_type_in_type_body(body, visible_types)
+                    {
+                        return Some(name);
+                    }
+                }
+                _ => {
+                    if let Some(name) =
+                        self.find_undeclared_name_in_stmt(stmt, visible_types, &HashSet::new())
+                    {
+                        return Some(name);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    pub(crate) fn check_eval_type_body_forward_refs(
+        &self,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        let mut visible_types: HashSet<String> = HashSet::new();
+        for stmt in stmts {
+            match stmt {
+                Stmt::ClassDecl { name, body, .. } | Stmt::RoleDecl { name, body, .. } => {
+                    let mut body_visible = visible_types.clone();
+                    body_visible.insert(name.resolve());
+                    if let Some(missing) =
+                        self.find_undeclared_type_in_type_body(body, &body_visible)
+                    {
+                        let suggestions = self.suggest_type_names(&missing);
+                        return Err(RuntimeError::undeclared_type_symbols(
+                            &missing,
+                            format!("Undeclared name:\n    {} used at line 1", missing),
+                            suggestions,
+                        ));
+                    }
+                }
+                Stmt::Package { body, .. } => {
+                    if let Some(missing) =
+                        self.find_undeclared_type_in_type_body(body, &visible_types)
+                    {
+                        let suggestions = self.suggest_type_names(&missing);
+                        return Err(RuntimeError::undeclared_type_symbols(
+                            &missing,
+                            format!("Undeclared name:\n    {} used at line 1", missing),
+                            suggestions,
+                        ));
+                    }
+                }
+                _ => {}
+            }
+            if let Some(name) = Self::stmt_declares_type_name(stmt) {
+                visible_types.insert(name);
+            }
+        }
+        Ok(())
+    }
+
     /// Check for undeclared type names in EVAL'd code.
     /// Walks the AST looking for BareWord expressions that start with uppercase
     /// and aren't known types, classes, or packages. This mirrors Raku's
@@ -108,6 +588,9 @@ impl Interpreter {
     }
 
     pub(crate) fn check_eval_undeclared_names(&self, stmts: &[Stmt]) -> Result<(), RuntimeError> {
+        self.check_eval_unknown_code_vars(stmts)?;
+        self.check_eval_when_undeclared_types(stmts)?;
+        self.check_eval_type_body_forward_refs(stmts)?;
         // Collect class/role names and locally-declared variables/subs from
         // this EVAL code. Both are valid references so they should not be
         // flagged as undeclared bareword names.
@@ -350,6 +833,44 @@ impl Interpreter {
             Expr::Unary { expr, .. } => {
                 self.find_undeclared_name_in_expr(expr, local_classes, declared)
             }
+            Expr::Grouped(expr)
+            | Expr::Eager(expr)
+            | Expr::Itemize(expr)
+            | Expr::DeitemizeForBind(expr)
+            | Expr::IndirectTypeLookup(expr)
+            | Expr::ZenSlice(expr) => {
+                self.find_undeclared_name_in_expr(expr, local_classes, declared)
+            }
+            Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+                self.find_undeclared_name_in_expr(target, local_classes, declared)
+                    .or_else(|| {
+                        args.iter().find_map(|arg| {
+                            self.find_undeclared_name_in_expr(arg, local_classes, declared)
+                        })
+                    })
+            }
+            Expr::DynamicMethodCall {
+                target,
+                name_expr,
+                args,
+                ..
+            }
+            | Expr::HyperMethodCallDynamic {
+                target,
+                name_expr,
+                args,
+                ..
+            } => self
+                .find_undeclared_name_in_expr(target, local_classes, declared)
+                .or_else(|| self.find_undeclared_name_in_expr(name_expr, local_classes, declared))
+                .or_else(|| {
+                    args.iter().find_map(|arg| {
+                        self.find_undeclared_name_in_expr(arg, local_classes, declared)
+                    })
+                }),
+            Expr::Call { args, .. } | Expr::CaptureLiteral(args) | Expr::ArrayLiteral(args) => args
+                .iter()
+                .find_map(|arg| self.find_undeclared_name_in_expr(arg, local_classes, declared)),
             Expr::StringInterpolation(parts) => {
                 for part in parts {
                     if let Some(name) =
@@ -360,11 +881,6 @@ impl Interpreter {
                 }
                 None
             }
-            // A list/array literal (e.g. the parenthesised `(Foo, Bar)` body of an
-            // enum) — scan each element for an undeclared bareword term.
-            Expr::ArrayLiteral(items) => items
-                .iter()
-                .find_map(|e| self.find_undeclared_name_in_expr(e, local_classes, declared)),
             _ => None,
         }
     }

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -55,6 +55,9 @@ impl RuntimeError {
         let mut map = HashMap::new();
         map.insert(name.to_string(), Value::array(arr.clone()));
         attrs.insert("type_suggestion".to_string(), Value::hash(map));
+        let mut post_types = HashMap::new();
+        post_types.insert(name.to_string(), Value::Bool(true));
+        attrs.insert("post_types".to_string(), Value::hash(post_types));
         attrs.insert("suggestions".to_string(), Value::array(arr));
         Self::typed("X::Undeclared::Symbols", attrs)
     }

--- a/t/grammar-postdeclared-in-method-undeclared.t
+++ b/t/grammar-postdeclared-in-method-undeclared.t
@@ -1,0 +1,13 @@
+use Test;
+
+throws-like q[
+    class GrammarUserClass {
+        method bar { PostDeclaredGrammar.parse('OH HAI'); }
+    }
+    grammar PostDeclaredGrammar {
+        rule TOP { .* }
+    }
+    GrammarUserClass.bar;
+], X::Undeclared::Symbols, 'later grammar is not visible inside an earlier method body';
+
+done-testing;


### PR DESCRIPTION
This PR advances `roast/S32-exceptions/misc.t` by pushing on several grouped compile-time and parse-time blockers.

What changed:
- Added grouped exception shaping for several `X::Comp::Group` cases, including missing-block and null-operator paths.
- Tightened `EVAL` prechecks for undeclared grammar/type/code references so earlier method bodies and `when` clauses fail with the expected typed exceptions.
- Fixed a handful of exception payload/attribute mismatches (`X::Undeclared::Symbols`, `X::Syntax::Confused`, `X::Obsolete`, `X::Bind`, etc.).
- Added a regression test for a forward grammar reference inside an earlier method body.

Why:
- `misc.t` was still failing on a cluster of exception-shaping and parser edge cases. The goal here was to chip away at the broad blocker set rather than only one file-local symptom.

Validation:
- `cargo build`
- `cargo fmt --all`
- `prove -e target/debug/mutsu t/grammar-postdeclared-in-method-undeclared.t`
- `prove -e target/debug/mutsu roast/S32-exceptions/misc.t` (still failing, but reduced further)
