### PR TITLE
perf(dispatch): memoize multi-function fingerprint by FunctionDef-Arc pointer

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -341,6 +341,21 @@ impl Interpreter {
         fp
     }
 
+    /// Structural fingerprint of a *function* def, memoized by its
+    /// `Arc<FunctionDef>` pointer (see `func_def_fp_cache`). Use this instead of
+    /// `function_body_fingerprint` on the multi-function redispatch hot path
+    /// (`push_multi_dispatch_frame`, which runs over every candidate per multi
+    /// call): the raw call Debug-traverses the whole body AST every time.
+    pub(crate) fn func_def_fingerprint(&mut self, def: &Arc<FunctionDef>) -> u64 {
+        let key = Arc::as_ptr(def) as usize;
+        if let Some((_, fp)) = self.func_def_fp_cache.get(&key) {
+            return *fp;
+        }
+        let fp = crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+        self.func_def_fp_cache.insert(key, (def.clone(), fp));
+        fp
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -489,16 +504,17 @@ impl Interpreter {
         // the time with the process hash seed. The winner is excluded from
         // `remaining` so redispatch targets the OTHER candidates.
         let saved_err = self.take_pending_dispatch_error();
-        let current_fp = self.resolve_function_with_alias(name, args).map(|def| {
-            crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body)
-        });
+        let current_def = self.resolve_function_with_alias(name, args);
+        let current_fp = current_def
+            .as_ref()
+            .map(|def| self.func_def_fingerprint(def));
         if let Some(err) = saved_err {
             self.set_pending_dispatch_error(err);
         }
         let remaining: Vec<std::sync::Arc<super::FunctionDef>> = all_candidates
             .into_iter()
             .filter(|c| {
-                let fp = crate::ast::function_body_fingerprint(&c.params, &c.param_defs, &c.body);
+                let fp = self.func_def_fingerprint(c);
                 Some(fp) != current_fp
             })
             .collect();

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -68,8 +68,7 @@ impl Interpreter {
                 self.args_match_param_types(args, &def.param_defs)
             };
             if type_ok {
-                let fingerprint =
-                    crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+                let fingerprint = self.func_def_fingerprint(&def);
                 if !seen.insert(fingerprint) {
                     continue;
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1531,6 +1531,14 @@ pub struct Interpreter {
     /// reused under a stale entry — it needs no invalidation and is bounded by
     /// the number of distinct method bodies in the program.
     pub(crate) method_body_fp_cache: rustc_hash::FxHashMap<usize, (Arc<Vec<Stmt>>, u64)>,
+    /// Same memoization as `method_body_fp_cache`, but for `Arc<FunctionDef>`
+    /// (the multi *function* redispatch path: `push_multi_dispatch_frame` runs
+    /// `function_body_fingerprint` over every candidate on every multi call to
+    /// pick/skip the winner). Keyed by the `Arc<FunctionDef>` pointer, which
+    /// uniquely identifies the def the fingerprint covers (clones share the Arc;
+    /// distinct defs have distinct Arcs). Holds a strong `Arc` clone so the
+    /// pointer can never free+reuse under a stale entry — no invalidation needed.
+    pub(crate) func_def_fp_cache: rustc_hash::FxHashMap<usize, (Arc<FunctionDef>, u64)>,
     pub(crate) block_declared_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2058,6 +2058,7 @@ impl Interpreter {
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
+            func_def_fp_cache: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -326,6 +326,7 @@ impl Interpreter {
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
+            func_def_fp_cache: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),


### PR DESCRIPTION
## What

Companion to the method-body fingerprint cache (#3911), for the multi **function** dispatch path. Every multi function call runs `function_body_fingerprint` (Debug-traverse the whole body AST + SipHash) multiple times per call:

- `choose_best_matching_candidate` fingerprints each matching candidate to dedup structurally-identical bodies (role-diamond duplicates) — the dominant caller,
- `push_multi_dispatch_frame` fingerprints the winner + every candidate to build the nextsame/callsame remaining-candidate list.

A release profile of a tight multi-function loop (`multi f(Int) {…}` / `multi f(Str) {…}`, 300k calls) showed `function_body_fingerprint` (SipHash-over-Debug + DebugStruct traversal) at **~16% of runtime**.

## Fix

Add `func_def_fp_cache` + `func_def_fingerprint(&Arc<FunctionDef>)` — the exact same sound memoization as the method path: keyed by the `Arc<FunctionDef>` pointer (which uniquely identifies the def — clones share the Arc, distinct defs have distinct Arcs), holding a **strong `Arc` clone** so the pointer can never free+reuse under a stale entry (no invalidation needed). The fingerprint *values* are unchanged, so candidate dedup / winner-skip behavior is byte-identical.

## Result

The 300k multi-function loop drops **25.8s → 19.7s (~24%)**; DebugStruct traversal disappears from the profile's top entries.

This came out of continuing the `samewith` perf investigation onto the function-dispatch path.

## Tests

Existing multi-dispatch correctness coverage (S06-multi/{syntax,type-based,proto,redispatch,subsignature,lexical-multis}.t, S12-methods/defer-next.t, t/method-redispatch-fingerprint.t, t/multi-slip-otf.t) all pass.

`make test` (13072) + `make roast` (211057) both green locally; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)