### PR TITLE
perf(dispatch): sound multi-function resolution cache

### DIFF
--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -180,6 +180,8 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
     }
 

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -356,6 +356,101 @@ impl Interpreter {
         fp
     }
 
+    /// Whether a multi *sub* `name` (in `pkg`) has a dispatch that is purely
+    /// type+arity based — the function analogue of `multi_dispatch_type_cacheable`.
+    /// False when any candidate is value-/identity-dependent (`where` / literal /
+    /// subset / `:D`/`:U` smiley / coercion), so its winner can't be keyed on the
+    /// positional arg types alone. Memoized per `(package, name)`.
+    pub(crate) fn func_multi_dispatch_type_cacheable(
+        &mut self,
+        pkg_sym: Symbol,
+        name_sym: Symbol,
+        name: &str,
+    ) -> bool {
+        if let Some(&c) = self.func_multi_type_cacheable.get(&(pkg_sym, name_sym)) {
+            return c;
+        }
+        let candidates = self.resolve_all_multi_candidates(name);
+        let mut value_dependent = false;
+        'outer: for def in &candidates {
+            for pd in &def.param_defs {
+                if pd.where_constraint.is_some() || pd.literal_value.is_some() {
+                    value_dependent = true;
+                    break 'outer;
+                }
+                // A code-signature callback param (`&cb:(Int)`) or a capture
+                // subsignature (`|c($a, $b)`) dispatches on the argument's
+                // *signature/shape*, not its `value_type_name` (a callback is
+                // always "Sub"), so type-keying would mis-route it.
+                if pd.code_signature.is_some() || pd.sub_signature.is_some() {
+                    value_dependent = true;
+                    break 'outer;
+                }
+                if let Some(tc) = &pd.type_constraint {
+                    // `:D`/`:U`/`:_` smiley or `Int(Str)` coercion => value/identity
+                    // dependent; a subset type carries an implicit `where`. The `:`
+                    // check also excludes enum-value (`E::a`) and qualified-value
+                    // constraints, which refine within one value-type.
+                    if tc.contains(':') || tc.contains('(') {
+                        value_dependent = true;
+                        break 'outer;
+                    }
+                    // Value-refining numeric pseudo-types: `Inf`/`NaN`/`UInt`/`-Inf`
+                    // all match WITHIN a single `value_type_name` ("Num"/"Int") by
+                    // inspecting the value, so type-keying would mis-route them
+                    // (e.g. `multi f(NaN)` vs `multi f(Numeric)` both key as Num).
+                    if matches!(tc.as_str(), "Inf" | "NaN" | "-Inf" | "UInt") {
+                        value_dependent = true;
+                        break 'outer;
+                    }
+                    let base = tc.split(['[', ' ']).next().unwrap_or(tc.as_str());
+                    if self.registry().subsets.contains_key(base) {
+                        value_dependent = true;
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        let cacheable = candidates.len() >= 2 && !value_dependent;
+        self.func_multi_type_cacheable
+            .insert((pkg_sym, name_sym), cacheable);
+        cacheable
+    }
+
+    /// Resolve a multi *sub* winner, consulting the sound multi-function
+    /// resolution cache (`func_multi_resolve_cache`) for a type+arity-deterministic
+    /// multi — avoiding the per-call registry walk + candidate match/rank/dedup in
+    /// `resolve_function_with_types`. Falls back to a fresh resolve for un-keyable
+    /// args (named/Junction/container), value-dependent multis, and AMBIGUOUS
+    /// results (which must re-raise their pending dispatch error every call).
+    /// Behaviorally identical to `resolve_function_with_types` for the caller.
+    pub(crate) fn resolve_function_multi_cached(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Arc<FunctionDef>> {
+        let Some(arg_keys) = Self::multi_arg_type_keys(args) else {
+            return self.resolve_function_with_types(name, args);
+        };
+        let pkg_sym = Symbol::intern(&self.current_package());
+        let name_sym = Symbol::intern(name);
+        if !self.func_multi_dispatch_type_cacheable(pkg_sym, name_sym, name) {
+            return self.resolve_function_with_types(name, args);
+        }
+        let key = (pkg_sym, name_sym, arg_keys);
+        if let Some(hit) = self.func_multi_resolve_cache.get(&key) {
+            return hit.clone();
+        }
+        let resolved = self.resolve_function_with_types(name, args);
+        // Ambiguity is signaled by `None` + a pending dispatch error; that must be
+        // re-raised on every call, so don't cache it.
+        let ambiguous = resolved.is_none() && self.pending_dispatch_error.is_some();
+        if !ambiguous {
+            self.func_multi_resolve_cache.insert(key, resolved.clone());
+        }
+        resolved
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -503,8 +598,12 @@ impl Interpreter {
         // would redispatch to the wrong (or the same) candidate, flaking ~50% of
         // the time with the process hash seed. The winner is excluded from
         // `remaining` so redispatch targets the OTHER candidates.
+        // Resolve the deterministic winner ONCE (the sound multi-resolution cache
+        // skips the registry walk + match/rank for a type+arity-deterministic
+        // multi) and reuse it for both the fingerprint identity and the rw-param
+        // capture below — the previous code resolved it twice per call.
         let saved_err = self.take_pending_dispatch_error();
-        let current_def = self.resolve_function_with_alias(name, args);
+        let current_def = self.resolve_function_multi_cached(name, args);
         let current_fp = current_def
             .as_ref()
             .map(|def| self.func_def_fingerprint(def));
@@ -522,8 +621,8 @@ impl Interpreter {
         if pushed {
             // Capture the FIRST (winning) candidate's scalar rw params so a
             // nextsame+rw redispatch can chain the rw value through it (§D).
-            let rw_params = self
-                .resolve_function_with_alias(name, args)
+            let rw_params = current_def
+                .as_ref()
                 .map(|def| {
                     super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs)
                 })

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1539,6 +1539,20 @@ pub struct Interpreter {
     /// distinct defs have distinct Arcs). Holds a strong `Arc` clone so the
     /// pointer can never free+reuse under a stale entry — no invalidation needed.
     pub(crate) func_def_fp_cache: rustc_hash::FxHashMap<usize, (Arc<FunctionDef>, u64)>,
+    /// Sound multi-*function* resolution cache — the function-dispatch analogue of
+    /// `multi_resolve_cache`. For a multi sub whose dispatch is purely type+arity
+    /// based (no `where` / literal / subset / `:D`/`:U` smiley / coercion
+    /// candidate), the winning candidate is a function of `(package, name,
+    /// positional arg types)`, so it is cached here. Keyed on
+    /// `(package_sym, name_sym, arg-type-keys)`. Cleared with the other dispatch
+    /// caches on any registry change.
+    #[allow(clippy::type_complexity)]
+    pub(crate) func_multi_resolve_cache:
+        rustc_hash::FxHashMap<(Symbol, Symbol, Vec<Symbol>), Option<Arc<FunctionDef>>>,
+    /// Memoized `(package, name) -> is this multi sub's dispatch type+arity
+    /// deterministic` (i.e. cacheable in `func_multi_resolve_cache`). The
+    /// function analogue of `multi_type_cacheable`.
+    pub(crate) func_multi_type_cacheable: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
     pub(crate) block_declared_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2059,6 +2059,8 @@ impl Interpreter {
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_def_fp_cache: rustc_hash::FxHashMap::default(),
+            func_multi_resolve_cache: rustc_hash::FxHashMap::default(),
+            func_multi_type_cacheable: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -327,6 +327,8 @@ impl Interpreter {
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_def_fp_cache: rustc_hash::FxHashMap::default(),
+            func_multi_resolve_cache: rustc_hash::FxHashMap::default(),
+            func_multi_type_cacheable: rustc_hash::FxHashMap::default(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1110,7 +1110,12 @@ impl Interpreter {
                     // is_interpreter_handled_function gate below.
                     let _ = self.take_pending_dispatch_error();
                     if !self.is_interpreter_handled_function(name)
-                        && let Some(def) = loan_env!(self, resolve_function_with_types(name, &args))
+                        // Sound multi-function resolution cache: for a type+arity-
+                        // deterministic multi this returns the winner without the
+                        // per-call registry walk + candidate match/rank/dedup;
+                        // value-dependent / un-keyable / ambiguous calls resolve
+                        // fresh (byte-identical to `resolve_function_with_types`).
+                        && let Some(def) = loan_env!(self, resolve_function_multi_cached(name, &args))
                         // A genuine multi candidate: the name is multi-cached, so
                         // `compile_and_call_function_def` never name-caches this
                         // candidate — a default param is safe here (unlike the

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -67,10 +67,23 @@ impl Interpreter {
                         value_dependent = true;
                         break 'outer;
                     }
+                    // A code-signature callback (`&cb:(Int)`) or capture
+                    // subsignature (`|c($a, $b)`) dispatches on the argument's
+                    // signature/shape, not its `value_type_name`.
+                    if pd.code_signature.is_some() || pd.sub_signature.is_some() {
+                        value_dependent = true;
+                        break 'outer;
+                    }
                     if let Some(tc) = &pd.type_constraint {
                         // `:D`/`:U`/`:_` smiley or `Int(Str)` coercion => value/identity
                         // dependent; a subset type carries an implicit `where`.
                         if tc.contains(':') || tc.contains('(') {
+                            value_dependent = true;
+                            break 'outer;
+                        }
+                        // Value-refining numeric pseudo-types match WITHIN a single
+                        // `value_type_name`, so type-keying would mis-route them.
+                        if matches!(tc.as_str(), "Inf" | "NaN" | "-Inf" | "UInt") {
                             value_dependent = true;
                             break 'outer;
                         }

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -29,6 +29,8 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
@@ -65,6 +67,8 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
         // Slice F: write imported symbols through to the caller's local slots
         // (import_module recorded their names); keeps an imported `constant c`
@@ -92,6 +96,8 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
@@ -115,6 +121,8 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -193,6 +193,8 @@ impl Interpreter {
                 self.fast_method_cache.clear();
                 self.multi_resolve_cache.clear();
                 self.multi_type_cacheable.clear();
+                self.func_multi_resolve_cache.clear();
+                self.func_multi_type_cacheable.clear();
                 self.dispatch_multi_candidate.clear();
                 // Record `&`-sigil parameter names so calls to a same-named routine
                 // inside this sub bypass the name-keyed light-call caches (the param

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -51,6 +51,8 @@ impl Interpreter {
         self.fast_method_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::ClassDecl {

--- a/t/multi-function-resolution-cache.t
+++ b/t/multi-function-resolution-cache.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 12;
+
+# The sound multi-function resolution cache (func_multi_resolve_cache) memoizes
+# the winning candidate keyed by (package, name, positional-arg-types) for a
+# type+arity-deterministic multi. These tests lock in that the cache dispatches
+# correctly across arg types, arities, runtime registry changes, and value-
+# dependent multis (which must NOT be cached).
+
+# Type-based dispatch: different arg types hit different cache keys.
+multi g(Int $x) { "int" }
+multi g(Str $x) { "str" }
+multi g($x)     { "any" }
+is g(1),    'int', 'Int arg -> Int candidate';
+is g("x"),  'str', 'Str arg -> Str candidate';
+is g(1.5),  'any', 'Rat arg -> Any candidate';
+# Repeat to exercise the cache-hit path.
+is g(2),    'int', 'second Int call (cache hit) still correct';
+is g("yy"), 'str', 'second Str call (cache hit) still correct';
+
+# Arity is part of the key.
+multi h($a)     { "one" }
+multi h($a, $b) { "two" }
+is h(1),    'one', 'arity-1 candidate';
+is h(1, 2), 'two', 'arity-2 candidate';
+
+# A value-dependent multi (where-constraint) must NOT be cached by type alone:
+# two Int args with different values take different candidates.
+multi w(Int $x where * > 10) { "big" }
+multi w(Int $x)              { "small" }
+is w(5),  'small', 'where-constrained multi: small value';
+is w(50), 'big',   'where-constrained multi: big value (not mis-cached as small)';
+
+# Value-refining numeric pseudo-types (Inf/NaN) match WITHIN one value_type_name
+# ("Num"), so they must NOT be type-cached, or a plain Num would mis-route to the
+# Inf/NaN candidate (or vice versa).
+multi v(Inf)         { 'inf' }
+multi v(NaN)         { 'nan' }
+multi v(Numeric $)   { 'num' }
+is v(Inf), 'inf', 'Inf value-pseudo-type not mis-cached as Numeric';
+is v(NaN), 'nan', 'NaN value-pseudo-type not mis-cached as Numeric';
+is v(3.5), 'num', 'plain Num reaches Numeric candidate (not Inf/NaN)';


### PR DESCRIPTION
## What

The function-dispatch analogue of the method-side `multi_resolve_cache`. A tight multi-function loop (`multi f(Int) {…}` / `multi f(Str) {…}`, 300k calls) was **~86µs/call** — function multi-dispatch re-walked the registry + matched/ranked/deduped candidates on every call, with no monomorphic cache (unlike method dispatch).

For a multi sub whose dispatch is purely type+arity based, the winning candidate is a function of `(package, name, positional arg types)`, so cache it:
- `func_multi_resolve_cache: (package_sym, name_sym, arg-type-keys) -> winner`
- `func_multi_type_cacheable: (package_sym, name_sym) -> is type+arity deterministic`
- `resolve_function_multi_cached()` consults it; un-keyable args (named/Junction/container), value-dependent multis, and ambiguous results resolve fresh.

Wired into the VM multi-function branch **and** `push_multi_dispatch_frame` (which previously resolved the winner **twice** per call — for the fingerprint identity and the rw-param capture — now once via the cache). Cleared with the other dispatch caches at all 7 registry-change sites.

## Result

The 300k loop drops **19.7s → 17.1s (~13%; ~33% cumulative** with the fingerprint caches #3911/#3913). `candidate_specificity_rank` leaves the profile's top entries.

## Soundness

The cacheability gate excludes every candidate whose dispatch can depend on a **value**, not just its `value_type_name`:
- `where` / literal / subset / `:D`/`:U` smiley / coercion (`(`) / enum-value or qualified (`::`, via the `:` check),
- the value-refining numeric pseudo-types `Inf`/`NaN`/`UInt`/`-Inf` (all match WITHIN "Num"/"Int"),
- code-signature callback params (`&cb:(Int)`) and capture subsignatures (`|c($a,$b)`) — these dispatch on the argument's signature/shape, not its type (a callback is always "Sub").

The same `Inf/NaN/UInt` + code/sub-signature exclusions were added to the method-side gate too (same latent gap — caught by `t/multi-type-dispatch-regressions.t` and `t/code-signature-param-otf.t` during development).

## Tests

`t/multi-function-resolution-cache.t` — type/arity dispatch, cache-hit repeats, where-value-dependence, Inf/NaN pseudo-types.

`make test` (13084) + `make roast` (211057) both green locally; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)