### PR TITLE
docs(roast): full re-triage of S32-exceptions/misc.t remaining fails

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -211,7 +211,48 @@
       sink-format cluster.
     - test 179 — VCS conflict-marker detection (`<<<<<<<`/`=======`/`>>>>>>>`) →
       X::Comp::AdHoc sorrow+panic with per-line numbers; needs a source line-level
-      pre-lex scan.
+      pre-lex scan. raku reports the 1st `<<<<<<<` as a sorrow, the 2nd as the
+      panic (aborting before later markers, incl. ones inside a quoted heredoc);
+      a lone marker is a bare X::Comp::AdHoc, not a group — rakudo-specific
+      recovery semantics.
+  - **2026-06-29 FULL re-triage of the remaining 24 fails (all probed in
+    isolation; every one is deep or regression-prone — no clean win left after
+    test 15).** Verdicts to avoid re-probing:
+    - 3 `PostDeclaredGrammar` used before its later declaration → X::Undeclared::Symbols
+      (post-declared type). mutsu runs it fine; needs compile-time post-declaration
+      type analysis (mutsu has no general compile-time undeclared check).
+    - 17 `say 1 if 2 if 3 {…}` → X::Syntax::Confused with `pre`/`post` source spans.
+      Source-span-threading blocker (600+ Literal sites), shared with sink-format.
+    - 21/22/177/178 X::Comp::FailGoal — custom `⟨ ⟩` circumfix/postcircumfix
+      unterminated (21/22); `"#={"` `{`-interpolation-block eats the closing `"`
+      (177); `‘…'` curly-single-quote string delimiter not supported + multi-line
+      `line N` reporting (178). Custom-op / quote-slang + source-span work.
+    - 27 `&[doesntexist]` → X::Comp ("Missing infix inside []"). Needs an
+      authoritative "is this a known operator" predicate. ATTEMPTED + REVERTED
+      2026-06-29: a word-based heuristic (`is_infix_word_op` ∪ user-defined,
+      symbolic ops left alone) produces FALSE POSITIVES — `eqv`/`minmax`/`o` are
+      valid infixes absent from `is_infix_word_op`, and `call_infix_routine` is a
+      layered dispatcher with an eval-block catch-all, so there is no clean
+      complete operator set to validate against. Regression risk > one loose
+      (type-only) matcher. Do not retry without a real operator registry.
+    - 84 `sub foo(C of Int)` no-body → X::NotParametric must fire during signature
+      parse BEFORE the missing-body parse error (ordering).
+    - 121 `:foo(42)` + 139-142 special-Num / int / big-int / num sink-warning
+      source-format — needs the warning to echo the literal *source text*, not the
+      evaluated value (source-span threading).
+    - 149/150 bind into undefined list/Int — roast itself marks these
+      `# TODO wrong exception`; even the expected type is unsettled.
+    - 155 `sub foo(@array ($first, @rest)){…}; foo <1 2 3>` → X::TypeCheck::Binding
+      (got IntStr, expected Positional). mutsu mis-binds the single List arg as
+      multiple positionals ("Too many positional arguments in sub-signature
+      binding"); needs proper sub-signature destructure with per-param type checks.
+    - 157/161 backtrace frame counts (`.list.elems == 2`/`== 4`) — rakudo
+      implementation-detail frame counts; documented as not worth matching.
+    - 166 `my \foo = Callable but role :: { }` → X::Method::NotFound ('mixin' on a
+      ParametricRoleGroupHOW). Deep metamodel edge; mutsu's "Cannot use 'but' on a
+      type object" is arguably saner but the wrong type for the matcher.
+    - 168 `no worries` pragma — lexically scoped compiler-warning suppression +
+      the `use :WorryFoo` warning-text format. Needs a pragma + warning-scope system.
   - **2026-06-28: test 49 done (X::Parameter::BadType)** — a `my`-scoped
     class/role/enum whose enclosing block has exited was still resolvable as a
     *type* (only the bare-word path consulted `suppressed_names`). An earlier


### PR DESCRIPTION
## Summary

After landing test 15 (X::Comp::Group gobbled block, #3915), I probed **every** remaining `S32-exceptions/misc.t` failure in isolation and recorded a concrete verdict for each in `TODO_roast/S32.md`, so future sessions don't re-probe.

All 24 remaining failures are **deep** (compile-time type/symbol analysis, source-span threading, per-subsystem sorrow accumulation, custom-op / quote-slang parsing, sub-signature destructure binding, metamodel, pragma + warning-scope system) or **regression-prone / rakudo-implementation-detail**.

Notably records the **test 27 (`&[doesntexist]`) attempt-and-revert**: a word-based "known operator" heuristic produces false positives (`eqv`/`minmax`/`o` are valid infixes absent from `is_infix_word_op`) and there is no clean complete operator registry to validate against — a regression risk not worth one loose (type-only) matcher.

This confirms the 2026-06-27 triage conclusion: misc.t is down to a deep one-off tail with no clean single-test win remaining.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)