### PR TITLE
feat(classify): object-hash result for non-Str classifier keys (§3.3)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -500,29 +500,31 @@ closure-based infinite sequence はかなり進んだが、
   `src/runtime/methods_call_dispatch.rs`,
   `src/runtime/methods_type_coerce.rs`
 
-### 3.3 object-hash / junction key
+### 3.3 object-hash / junction key — **DONE (classify.t whitelisted, 2026-06-29)**
 
-- `S32-list/classify.t`
+- ~~`S32-list/classify.t`~~ **PASS / whitelisted**
 
-`objecthash.t` 自体はもう whitelisted なので、
-旧版の「%{Mu} 全体が未着手」という書き方は粗すぎた。
-今残っているのは、**junction を key にした classify 結果の取り出し**という、
-より狭い意味論の問題。
+`classify`/`categorize` keyed by a non-`Str` classifier result (e.g. a Junction
+from `*.contains: any ...`) now builds an OBJECT hash. Implemented in:
+- `builtins_collection_classify.rs`: `classify_finish_hash` marks the result an
+  object hash (`key_type=Some("Any")` + `original_keys`) when any first-level key
+  is non-Str.
+- `builtins/methods_0arg/collection.rs` `.keys`: honor `has_typed_keys()` (was
+  Set/Bag/Mix `__setty_origin`-only) so object-hash keys come back as real objects.
+- `vm/vm_var_index_ops.rs`: BOTH junction-subscript autothreading sites now skip
+  threading on an object hash (`has_typed_keys()`, peeking through Scalar/
+  ContainerRef) → falls to the `.WHICH`/encoding key lookup; and the object-hash
+  key type-check is skipped for `Any`/`Mu` key types (which accept a Junction key
+  that `type_matches_value` would otherwise autothread+reject).
+- `parser/primary/ident/predicates.rs`: added `classify`/`categorize` to
+  `is_listop` so the bare-sub list-op form `classify *.meth, @list` parses (was
+  read as `classify * (.meth ...)` infix-multiply → "Cannot convert string to
+  number 'classify'").
 
-- **変更レイヤ**:
-  classify 実装、Hash key storage、subscript lookup の junction 分岐
-- **最初の 1 PR**:
-  classify が `Str` key ではなく object-preserving hash を作れるようにする
-- **完了条件**:
-  Junction key が stringify されず object として保存され、`$h{any(...)}` が
-  auto-thread ではなく key lookup になること
-- **Next slice**:
-  classify の result hash を object-preserving key storage に切り替える
-- **Canary tests**:
-  `roast/S32-list/classify.t`
-- **Primary files**:
-  `src/runtime/builtins_collection_classify.rs`,
-  `src/runtime/supply_classify.rs`, `src/value/mod.rs`, hash subscript lookup path
+Pin: `t/classify-object-hash.t`. NOTE: a *declared* object hash `my %h{Any}` with
+an Array/object KEY in a STORE (`%h{[1,2]} = ...`) is still treated as a slice on
+the write path — broader object-hash subscript STORE remains future work (the
+classify result is read-only, so this PR's read path suffices).
 
 ### 3.4 dispatch-sensitive cluster
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1088,6 +1088,7 @@ roast/S32-list/batch.t
 roast/S32-list/categorize-list.t
 roast/S32-list/categorize.t
 roast/S32-list/classify-list.t
+roast/S32-list/classify.t
 roast/S32-list/combinations.t
 roast/S32-list/create.t
 roast/S32-list/cross.t

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -391,17 +391,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
             match target {
                 Value::Hash(map) => {
-                    // Use original typed keys for object hashes that were
-                    // created from Set/Bag/Mix .hash coercion and tagged
-                    // with a __setty_origin marker in original_keys.
-                    let has_setty_origin = if let Some(orig) =
-                        crate::runtime::utils::hash_original_keys_snapshot(target)
-                    {
-                        orig.contains_key("__mutsu_setty_origin")
-                    } else {
-                        false
-                    };
-                    let keys: Vec<Value> = if has_setty_origin {
+                    // Object hashes (`.WHICH`-keyed: `my %h{Any}`, a Set/Bag/Mix
+                    // `.hash`, or a `classify` keyed by non-Str values) yield their
+                    // real key objects; a plain hash yields decoded Str keys.
+                    let keys: Vec<Value> = if map.has_typed_keys() {
                         map.keys()
                             .map(|k| crate::runtime::utils::hash_typed_key(target, k))
                             .collect()

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -111,6 +111,8 @@ pub(crate) fn is_listop(name: &str) -> bool {
             | "grep"
             | "map"
             | "sort"
+            | "classify"
+            | "categorize"
             | "any"
             | "all"
             | "none"

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -205,6 +205,14 @@ impl Interpreter {
         let mut expected_level: Option<usize> = None;
         let mut expected_multi_level: Option<bool> = None;
 
+        // Object-hash key preservation (§3.3): when the classifier returns a
+        // non-`Str` key (e.g. a Junction from `*.contains: any 'a','f'`), the
+        // bucket key is stored under its stringification but the result must be an
+        // *object hash* so `$result{ any(...) }` is a by-key lookup (not junction
+        // autothreading) and `.keys` yields the real key objects. Records each
+        // first-level non-Str key object under its encoded string.
+        let mut object_keys: HashMap<String, Value> = HashMap::new();
+
         for item in &items {
             let mapped = match &mapper {
                 Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. } => {
@@ -298,6 +306,13 @@ impl Interpreter {
                 } else {
                     expected_level = Some(path.len());
                 }
+                if let Some(first) = path.first()
+                    && !matches!(first, Value::Str(_))
+                {
+                    object_keys
+                        .entry(first.to_string_value())
+                        .or_insert_with(|| first.clone());
+                }
                 insert_nested_bucket(&mut buckets, path, mapped_item.clone(), name)?;
             }
         }
@@ -315,7 +330,10 @@ impl Interpreter {
                 } else if let Some(counts) = mix_counts.clone() {
                     updated = Some(Value::mix(counts));
                 } else if into_target.is_some() {
-                    updated = Some(Value::hash(buckets.clone()));
+                    updated = Some(Self::classify_finish_hash(
+                        buckets.clone(),
+                        object_keys.clone(),
+                    ));
                 }
                 if let Some(new_value) = updated {
                     if has_proxy {
@@ -334,6 +352,27 @@ impl Interpreter {
             return Ok(Value::mix(counts));
         }
 
-        Ok(Value::hash(buckets))
+        Ok(Self::classify_finish_hash(buckets, object_keys))
+    }
+
+    /// Wrap classify's bucket map in a `Value::Hash`, marking it an *object hash*
+    /// (typed keys) when any classifier key was non-`Str` (e.g. a Junction). An
+    /// object hash makes `$result{ $key }` a by-key lookup rather than junction
+    /// autothreading, and `.keys` yield the real key objects.
+    fn classify_finish_hash(
+        buckets: HashMap<String, Value>,
+        object_keys: HashMap<String, Value>,
+    ) -> Value {
+        let hash = Value::hash(buckets);
+        if object_keys.is_empty() {
+            return hash;
+        }
+        if let Value::Hash(mut arc) = hash {
+            let data = std::sync::Arc::make_mut(&mut arc);
+            data.key_type = Some("Any".to_string());
+            data.original_keys = Some(object_keys);
+            return Value::Hash(arc);
+        }
+        hash
     }
 }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -85,9 +85,12 @@ impl Interpreter {
         };
 
         // Junction autothreading: when indexing a hash with a junction key,
-        // expand the junction and create a slot ref for each element.
+        // expand the junction and create a slot ref for each element. EXCEPT on an
+        // *object hash* (typed keys, §3.3): there a Junction is a genuine key
+        // object (e.g. a `classify` result keyed by Junctions), so it is looked up
+        // by its `.WHICH`/encoding via the normal path below, not autothreaded.
         if let Value::Junction { kind, values } = &index
-            && matches!(&resolved, Value::Hash(_))
+            && matches!(&resolved, Value::Hash(arc) if !arc.has_typed_keys())
         {
             let kind = kind.clone();
             let junction_values = values.clone();
@@ -287,7 +290,23 @@ impl Interpreter {
             self.stack.push(Value::junction(kind.clone(), results));
             return Ok(());
         }
-        if let Value::Junction { kind, values } = &index {
+        // A Junction *key* autothreads over the subscript — EXCEPT on an object
+        // hash (typed keys, §3.3), where the Junction is a genuine key object
+        // (e.g. a `classify` result keyed by Junctions) looked up by encoding via
+        // the normal path below. Peek through a `Scalar`/`ContainerRef` wrapper
+        // (a `:=`-bound result) to find the underlying hash.
+        let target_is_object_hash = {
+            let mut probe = &target;
+            let inner;
+            if let Value::ContainerRef(cell) = probe {
+                inner = cell.lock().unwrap().clone();
+                probe = &inner;
+            }
+            matches!(probe.descalarize(), Value::Hash(arc) if arc.has_typed_keys())
+        };
+        if let Value::Junction { kind, values } = &index
+            && !target_is_object_hash
+        {
             let mut results = Vec::with_capacity(values.len());
             for value in values.iter() {
                 self.stack.push(target.clone());
@@ -502,9 +521,13 @@ impl Interpreter {
             if let Some(key_type) = self.hash_key_type(&hash_val)
                 && !matches!(index, Value::Whatever | Value::Nil | Value::Sub(..))
             {
+                // `Any`/`Mu` key types accept every object (including a Junction
+                // key, which `type_matches_value` would otherwise autothread and
+                // reject). Skip the per-key check for them.
+                let key_unconstrained = matches!(key_type.as_str(), "Any" | "Mu");
                 if let Value::Array(ref keys, ..) = index {
                     for k in keys.iter() {
-                        if !self.type_matches_value(&key_type, k) {
+                        if !key_unconstrained && !self.type_matches_value(&key_type, k) {
                             return Err(RuntimeError::new(format!(
                                 "Type check failed for object hash key; expected {} but got {} ({})",
                                 key_type,
@@ -536,7 +559,7 @@ impl Interpreter {
                     self.stack.push(result);
                     return Ok(());
                 }
-                if !self.type_matches_value(&key_type, &index) {
+                if !key_unconstrained && !self.type_matches_value(&key_type, &index) {
                     return Err(RuntimeError::new(format!(
                         "Type check failed for object hash key; expected {} but got {} ({})",
                         key_type,

--- a/t/classify-object-hash.t
+++ b/t/classify-object-hash.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 9;
+
+# §3.3 object-hash / junction key: `classify` (and `categorize`) keyed by a
+# non-Str classifier result (e.g. a Junction from `*.contains: any ...`) builds
+# an OBJECT hash. Its keys stay real objects (not stringified), `$h{ $key }` is a
+# by-key lookup (NOT junction autothreading), and the bare-sub form parses as a
+# list operator (`classify *.meth, @list`).
+
+my @l := <abc axz abcdef axyf cbd xyz>;
+
+# Method form.
+my $m := @l.classify: *.contains: any 'a', 'f';
+is $m.keys.map(*.^name).unique.join, 'Junction', 'method: object keys stay Junction';
+is-deeply $m{ any(False, False) }.sort, <cbd xyz>,     'method: non-matching key lookup';
+is-deeply $m{ any(True,  False) }.sort, <abc axz>,     'method: part-matching key lookup';
+is-deeply $m{ any(True,  True)  }.sort, <abcdef axyf>, 'method: full-matching key lookup';
+
+# Bare-sub (list-op) form — `classify *.meth, @list` must parse, not be read as
+# `classify * (.meth ...)` (infix multiply).
+my $s := classify *.contains( any 'a', 'f' ), @l;
+is $s.keys.map(*.^name).unique.join, 'Junction', 'sub: object keys stay Junction';
+is-deeply $s{ any(True, False) }.sort, <abc axz>, 'sub: by-key lookup';
+
+# A plain (Str-keyed) classify is unchanged: Str keys, and a junction subscript on
+# a PLAIN hash still autothreads.
+my $c := <apple banana avocado>.classify(*.substr(0, 1));
+is $c.keys.map(*.^name).unique.join, 'Str', 'plain classify keeps Str keys';
+my %plain = a => 1, b => 2;
+is-deeply %plain{ any('a', 'b') }, any(1, 2), 'plain hash junction subscript still autothreads';
+
+# categorize bare-sub form parses too.
+my $cat := categorize *.contains( any 'a', 'f' ), @l;
+ok $cat.keys.elems >= 2, 'categorize sub form parses and runs';


### PR DESCRIPTION
## What

`classify`/`categorize` keyed by a non-`Str` classifier result — e.g. a Junction from `*.contains: any 'a','f'` — now builds an **object hash**, matching Rakudo: its keys stay real objects (not stringified), and `$result{ $key }` is a by-key lookup instead of junction autothreading.

Closes roast **`S32-list/classify.t` (40/40)**, the BLOCKERS §3.3 object-hash / junction-key canary.

## Changes

- **classify** (`builtins_collection_classify.rs`): `classify_finish_hash` marks the result an object hash (`key_type=Some("Any")` + `original_keys`) when any first-level classifier key is non-Str.
- **`.keys`** (`builtins/methods_0arg/collection.rs`): now honors `has_typed_keys()` (previously Set/Bag/Mix `__setty_origin`-only), so an object hash returns its real key objects.
- **subscript** (`vm/vm_var_index_ops.rs`): both junction-subscript autothreading sites skip threading on an object hash (`has_typed_keys()`, peeking through a `Scalar`/`ContainerRef` `:=` wrapper) and fall to the `.WHICH`/encoding key lookup; the object-hash key type-check is skipped for `Any`/`Mu` key types (which accept a Junction key that `type_matches_value` would otherwise autothread and reject).
- **parser** (`parser/primary/ident/predicates.rs`): added `classify`/`categorize` to `is_listop` so the bare-sub list-op form `classify *.meth, @list` parses (was read as `classify * (.meth ...)` infix-multiply → "Cannot convert string to number 'classify'").

## Scope / not in scope

A plain (Str-keyed) classify is unchanged, and a junction subscript on a **plain** hash still autothreads (verified). A declared object hash `my %h{Any}` with an object KEY in a **store** (`%h{[1,2]} = ...`) is still slice-treated on the write path — broader object-hash STORE is future work; the classify result is read-only so this PR's read path suffices.

## Tests

`t/classify-object-hash.t` (method + bare-sub forms, junction key lookup, plain-classify/plain-hash regression). `make test` (13084) + `make roast` (211057) both green locally; classify.t added to whitelist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)