### PR TITLE
feat(io): implement IO::CatHandle + fix map block named-tail-call value

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -520,6 +520,41 @@
 - [ ] roast/S32-io/empty.txt
 - [x] roast/S32-io/indir.t
 - [ ] roast/S32-io/io-cathandle.t
+  - **2026-06-29: IO::CatHandle implemented from scratch** (was completely
+    unimplemented — `IO::CatHandle.new` threw X::Method::NotFound). New
+    `src/runtime/native_io/io_cathandle.rs`: a virtual handle reading from a
+    sequence of `IO::Path`/`Str`/`IO::Handle` sources, opening each (paths/strings)
+    and reading to exhaustion before transparently switching. State (`sources`,
+    `pos`, `active`, `chomp`, `nl-in`, `encoding`, `closed`, `on-switch`) lives in
+    the instance attributes, persisted across calls via the mutable-dispatch
+    writeback (`commit_attrs`, like Proc::Async). Methods: new / get / getc / lines
+    / slurp / words / comb / split / read / readchars / next-handle / close /
+    DESTROY / eof / opened / chomp / nl-in / encoding / on-switch / path / IO /
+    handles / Str / gist. Verified end-to-end with explicit sources in
+    t/io-cathandle.t (get crosses files, skips empty files, slurp, close→Nil,
+    encoding/chomp accessors). Top-level roast tests 30 (read-no-early-switch) and
+    31 (lazy list of paths) pass.
+  - **BLOCKER for the 28 subtests — the test's `make-files` helper.** Every
+    subtest builds its inputs via `make-files`, which does
+    `@content.map: { when IO::Handle {$_}; make-temp-file content => $_ }`. That
+    map returns the temp path **stringified to Str** (or the spurt byte-count Int)
+    instead of the `IO::Path` make-temp-file returns, so the later
+    `@ret[$_] .= open` dies with "No such method 'open' for invocant of type Str".
+    Root cause is a compiler bug: a block whose tail is a bare `Stmt::Call` with a
+    **named/slip arg** (`f(k => v)` — how an *imported* sub like make-temp-file
+    parses, since imports are unknown at parse time) is compiled as a
+    value-discarding statement, so the map result falls back to the loop topic `$_`.
+    PARTIALLY FIXED 2026-06-29 (eval_map_over_items normalizes a named/slip tail
+    Stmt::Call to Stmt::Expr — see t/map-imported-named-tail-call.t), but the bug
+    has MULTIPLE map-path manifestations (the slurpy-array `*@content` map path
+    still returns Str; the VM-native-map fast path and make-temp-file's own
+    with/orwith+spurt return interaction are involved). A global compiler fix
+    (mod.rs tail-Stmt::Call → Expr::Call) DID make getc/Str pass but regressed
+    throws-like-any (it bypasses the statement-call path's `__mutsu_test_callsite_line`
+    handling), so it was reverted. Fully unblocking make-files is a separate, deep
+    compiler campaign across all the map paths + the imported-sub tail-call value
+    semantics. Also note: `make-files EXPR».join: "\n"` (listop + hyper-method +
+    colon-arg) is a *second* independent parse bug some subtests hit.
 - [x] roast/S32-io/io-handle.t — **30/30, whitelisted.** All subtests pass.
       29 `.WRITE` / 30 `.EOF/.WRITE` fixed: a user-subclassed IO::Handle that
       overrides WRITE/READ/EOF now routes the high-level methods through the user

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -676,6 +676,20 @@ impl Interpreter {
                     );
                 }
             }
+            if class_name == "IO::CatHandle" && self.is_native_method(&class_name.resolve(), method)
+            {
+                // Every IO::CatHandle method advances internal read state, so route
+                // through the mutable path and commit the updated attributes back to
+                // the receiver's shared cell.
+                let (result, updated) = self.call_native_instance_method_mut(
+                    &class_name.resolve(),
+                    attributes.to_map(),
+                    method,
+                    args,
+                )?;
+                attributes.commit_attrs(updated);
+                return Ok(result);
+            }
             if self.is_native_method(&class_name.resolve(), method) {
                 return self.call_native_instance_method(
                     &class_name.resolve(),

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -515,6 +515,9 @@ impl Interpreter {
                 return self.build_io_path_instance(*class_name, &cn_resolved, &args);
             }
             match base_class_name {
+                "IO::CatHandle" if !self.has_user_method(class_key, "new") => {
+                    return Ok(self.build_io_cathandle(&args));
+                }
                 "IterationBuffer" => {
                     // Shared with the VM's native fast path.
                     return Ok(Self::build_native_iterationbuffer_value(*class_name, &args));

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod canonpath;
 mod helpers;
+mod io_cathandle;
 mod io_handle;
 mod io_path_lexical;
 mod io_path_mutate;

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -1,0 +1,574 @@
+//! `IO::CatHandle` — a virtual handle that reads from a sequence of source
+//! handles/paths one after another. Sources may be `IO::Path`, `Str`, or an
+//! already-opened `IO::Handle`; each is opened (paths/strings) and read to
+//! exhaustion before transparently switching to the next.
+//!
+//! State lives in the instance attributes (persisted across calls via the
+//! shared-attr writeback in the mutable dispatch path):
+//! - `sources`  — Array of the original source values
+//! - `pos`      — Int, index of the next source to open
+//! - `active`   — the currently-open `IO::Handle` value, or `Nil`
+//! - `chomp`    — Bool (applied to each handle as it is opened)
+//! - `nl-in`    — line separator(s), Str or Array
+//! - `encoding` — Str (default `utf8`)
+//! - `closed`   — Bool, set by `.close`/`.DESTROY` (reads then yield `Nil`)
+//! - `on-switch`— Callable invoked when the active handle changes, or `Nil`
+use super::*;
+use std::collections::HashMap;
+
+/// Extract an integer from a `Value::Int` (allomorphs/strings yield `None`).
+fn val_int(v: &Value) -> Option<i64> {
+    match v {
+        Value::Int(i) => Some(*i),
+        _ => None,
+    }
+}
+
+impl Interpreter {
+    /// Build a fresh `IO::CatHandle` instance from positional source values and
+    /// `:chomp` / `:nl-in` / `:encoding` named args (the `.new` constructor).
+    pub(crate) fn build_io_cathandle(&mut self, args: &[Value]) -> Value {
+        let mut sources: Vec<Value> = Vec::new();
+        let mut chomp = Value::Bool(true);
+        let mut nl_in = Value::array(vec![
+            Value::str("\n".to_string()),
+            Value::str("\r\n".to_string()),
+        ]);
+        let mut encoding = Value::str("utf8".to_string());
+        let mut on_switch = Value::Nil;
+        for arg in args {
+            match arg {
+                Value::Pair(k, v) => match k.as_str() {
+                    "chomp" => chomp = (**v).clone(),
+                    "nl-in" => nl_in = (**v).clone(),
+                    "encoding" | "enc" => encoding = (**v).clone(),
+                    "on-switch" => on_switch = (**v).clone(),
+                    _ => {}
+                },
+                // A list/array/Seq argument is flattened into the source
+                // sequence. A Seq backed by a deferred (map) iterator carries no
+                // materialized items, so force it through `.list` first.
+                Value::Array(items, kind) if !kind.is_itemized() => {
+                    sources.extend(items.iter().cloned())
+                }
+                Value::Seq(_) | Value::LazyList(_) => {
+                    let listed = self
+                        .call_method_with_values(arg.clone(), "list", vec![])
+                        .unwrap_or(Value::Nil);
+                    sources.extend(Self::value_to_list(&listed));
+                }
+                other => sources.push(other.clone()),
+            }
+        }
+        let mut attrs: HashMap<String, Value> = HashMap::new();
+        attrs.insert("sources".to_string(), Value::array(sources));
+        attrs.insert("pos".to_string(), Value::Int(0));
+        attrs.insert("active".to_string(), Value::Nil);
+        attrs.insert("chomp".to_string(), chomp);
+        attrs.insert("nl-in".to_string(), nl_in);
+        attrs.insert("encoding".to_string(), encoding);
+        attrs.insert("closed".to_string(), Value::Bool(false));
+        attrs.insert("on-switch".to_string(), on_switch);
+        attrs.insert("path".to_string(), Value::Nil);
+        Value::make_instance(Symbol::intern("IO::CatHandle"), attrs)
+    }
+
+    /// Open one source value into a read handle, applying the cat's `chomp` /
+    /// `nl-in` / `encoding`. Returns `None` when the source cannot be opened.
+    fn cat_open_source(&mut self, src: &Value, attrs: &HashMap<String, Value>) -> Option<Value> {
+        let chomp = attrs.get("chomp").cloned().unwrap_or(Value::Bool(true));
+        let nl_in = attrs
+            .get("nl-in")
+            .cloned()
+            .unwrap_or_else(|| Value::str("\n".to_string()));
+        let enc = attrs
+            .get("encoding")
+            .map(|v| v.to_string_value())
+            .unwrap_or_else(|| "utf8".to_string());
+        match src {
+            Value::Instance { class_name, .. } if class_name == "IO::Handle" => {
+                // Already a handle: ensure it is opened, then push the cat's
+                // chomp / nl-in / encoding onto it.
+                let handle = src.clone();
+                let opened = self
+                    .native_io_handle_method(&handle, "opened", vec![])
+                    .map(|v| v.truthy())
+                    .unwrap_or(false);
+                let handle = if opened {
+                    handle
+                } else {
+                    match self.native_io_handle_method(
+                        &handle,
+                        "open",
+                        vec![Value::Pair("r".to_string(), Box::new(Value::Bool(true)))],
+                    ) {
+                        Ok(v @ Value::Instance { .. }) => v,
+                        _ => return None,
+                    }
+                };
+                let _ = self.native_io_handle_method(&handle, "chomp", vec![chomp]);
+                let _ = self.native_io_handle_method(&handle, "nl-in", vec![nl_in]);
+                if enc != "utf8" {
+                    let _ =
+                        self.native_io_handle_method(&handle, "encoding", vec![Value::str(enc)]);
+                }
+                Some(handle)
+            }
+            _ => {
+                // IO::Path or Str source: open a fresh read handle.
+                let path_str = match src {
+                    Value::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } if class_name == "IO::Path" => attributes
+                        .as_map()
+                        .get("path")
+                        .map(|p| p.to_string_value())
+                        .unwrap_or_default(),
+                    _ => src.to_string_value(),
+                };
+                let io_path = self.make_io_path_instance(&path_str);
+                let mut h_attrs: HashMap<String, Value> = HashMap::new();
+                h_attrs.insert("path".to_string(), io_path);
+                let open_args = vec![
+                    Value::Pair("r".to_string(), Box::new(Value::Bool(true))),
+                    Value::Pair("chomp".to_string(), Box::new(chomp)),
+                    Value::Pair("nl-in".to_string(), Box::new(nl_in)),
+                    Value::Pair("enc".to_string(), Box::new(Value::str(enc))),
+                ];
+                match self.native_io_handle(&h_attrs, "open", open_args) {
+                    Ok(v) if matches!(&v, Value::Instance { class_name, .. } if class_name == "IO::Handle") => {
+                        Some(v)
+                    }
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Invoke a single `IO::Handle` native method on a handle value.
+    fn native_io_handle_method(
+        &mut self,
+        handle: &Value,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        if let Value::Instance { attributes, .. } = handle {
+            self.native_io_handle(&attributes.as_map(), method, args)
+        } else {
+            Ok(Value::Nil)
+        }
+    }
+
+    /// Close the active handle (if any) and open the next source. Returns the new
+    /// active handle, or `Nil` when the sources are exhausted.
+    fn cat_next_handle(&mut self, attrs: &mut HashMap<String, Value>) -> Value {
+        if let Some(active @ Value::Instance { class_name, .. }) =
+            attrs.get("active").cloned().as_ref()
+            && class_name == "IO::Handle"
+        {
+            let _ = self.close_handle_value(active);
+        }
+        let on_switch = attrs.get("on-switch").cloned().unwrap_or(Value::Nil);
+        loop {
+            let pos = attrs.get("pos").and_then(val_int).unwrap_or(0) as usize;
+            let sources: Vec<Value> = match attrs.get("sources") {
+                Some(Value::Array(items, ..)) => items.to_vec(),
+                _ => Vec::new(),
+            };
+            if pos >= sources.len() {
+                attrs.insert("active".to_string(), Value::Nil);
+                attrs.insert("path".to_string(), Value::Nil);
+                return Value::Nil;
+            }
+            attrs.insert("pos".to_string(), Value::Int((pos + 1) as i64));
+            if let Some(handle) = self.cat_open_source(&sources[pos], attrs) {
+                let path_val = self
+                    .native_io_handle_method(&handle, "path", vec![])
+                    .unwrap_or(Value::Nil);
+                attrs.insert("active".to_string(), handle.clone());
+                attrs.insert("path".to_string(), path_val);
+                if matches!(
+                    on_switch,
+                    Value::Sub(_) | Value::Routine { .. } | Value::WeakSub(_)
+                ) {
+                    let _ = self
+                        .eval_call_on_value(on_switch.clone(), vec![handle.clone(), Value::Nil]);
+                }
+                return handle;
+            }
+        }
+    }
+
+    /// Ensure there is an active handle, opening the first/next source if needed.
+    /// Returns `Nil` when nothing more can be read.
+    fn cat_ensure_active(&mut self, attrs: &mut HashMap<String, Value>) -> Value {
+        if let Some(active @ Value::Instance { class_name, .. }) =
+            attrs.get("active").cloned().as_ref()
+            && class_name == "IO::Handle"
+        {
+            return active.clone();
+        }
+        // Don't advance the cursor past sources here unless nothing has opened yet.
+        let pos = attrs.get("pos").and_then(val_int).unwrap_or(0);
+        if pos == 0 {
+            return self.cat_next_handle(attrs);
+        }
+        Value::Nil
+    }
+
+    /// Read the next line across all handles, switching when one is exhausted.
+    fn cat_get(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+        loop {
+            let active = self.cat_ensure_active(attrs);
+            if matches!(active, Value::Nil) {
+                return Ok(Value::Nil);
+            }
+            let line = self.native_io_handle_method(&active, "get", vec![])?;
+            if matches!(line, Value::Nil) {
+                let next = self.cat_next_handle(attrs);
+                if matches!(next, Value::Nil) {
+                    return Ok(Value::Nil);
+                }
+                continue;
+            }
+            return Ok(line);
+        }
+    }
+
+    /// Read one character across all handles.
+    fn cat_getc(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+        loop {
+            let active = self.cat_ensure_active(attrs);
+            if matches!(active, Value::Nil) {
+                return Ok(Value::Nil);
+            }
+            let c = self.native_io_handle_method(&active, "getc", vec![])?;
+            if matches!(c, Value::Nil) {
+                let next = self.cat_next_handle(attrs);
+                if matches!(next, Value::Nil) {
+                    return Ok(Value::Nil);
+                }
+                continue;
+            }
+            return Ok(c);
+        }
+    }
+
+    /// Slurp the remaining content of all handles into one string.
+    fn cat_slurp(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+        if attrs.get("closed").is_some_and(|v| v.truthy()) {
+            return Ok(Value::Nil);
+        }
+        let mut out = String::new();
+        loop {
+            let active = self.cat_ensure_active(attrs);
+            if matches!(active, Value::Nil) {
+                break;
+            }
+            let s = self.native_io_handle_method(&active, "slurp", vec![])?;
+            out.push_str(&s.to_string_value());
+            if matches!(self.cat_next_handle(attrs), Value::Nil) {
+                break;
+            }
+        }
+        Ok(Value::str(out))
+    }
+
+    /// Collect all remaining lines into a Seq.
+    fn cat_lines(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+        let mut lines = Vec::new();
+        loop {
+            let line = self.cat_get(attrs)?;
+            if matches!(line, Value::Nil) {
+                break;
+            }
+            lines.push(line);
+        }
+        Ok(Value::Seq(std::sync::Arc::new(lines)))
+    }
+
+    /// Mutable dispatch for `IO::CatHandle` methods. All reads advance internal
+    /// state, so every method goes through here and the caller writes the updated
+    /// attributes back into the receiver's shared cell.
+    pub(crate) fn native_io_cathandle_mut(
+        &mut self,
+        attributes: HashMap<String, Value>,
+        method: &str,
+        args: Vec<Value>,
+    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        let mut attrs = attributes;
+        let result = match method {
+            "get" => self.cat_get(&mut attrs)?,
+            "getc" => self.cat_getc(&mut attrs)?,
+            "lines" => self.cat_lines(&mut attrs)?,
+            "slurp" => self.cat_slurp(&mut attrs)?,
+            "words" => {
+                let text = match self.cat_slurp(&mut attrs)? {
+                    Value::Nil => return Ok((Value::Nil, attrs)),
+                    v => v.to_string_value(),
+                };
+                let words: Vec<Value> = text
+                    .split_whitespace()
+                    .map(|w| Value::str(w.to_string()))
+                    .collect();
+                Value::Seq(std::sync::Arc::new(words))
+            }
+            "comb" => {
+                let text = match self.cat_slurp(&mut attrs)? {
+                    Value::Nil => return Ok((Value::Nil, attrs)),
+                    v => v.to_string_value(),
+                };
+                let str_val = Value::str(text);
+                self.call_method_with_values(str_val, "comb", args)?
+            }
+            "split" => {
+                let text = match self.cat_slurp(&mut attrs)? {
+                    Value::Nil => return Ok((Value::Nil, attrs)),
+                    v => v.to_string_value(),
+                };
+                let str_val = Value::str(text);
+                self.call_method_with_values(str_val, "split", args)?
+            }
+            "readchars" => {
+                // Read up to N chars across handles.
+                let count = args.first().and_then(val_int).map(|n| n as usize);
+                let mut out = String::new();
+                loop {
+                    let active = self.cat_ensure_active(&mut attrs);
+                    if matches!(active, Value::Nil) {
+                        break;
+                    }
+                    let want = count.map(|c| c.saturating_sub(out.chars().count()));
+                    if want == Some(0) {
+                        break;
+                    }
+                    let chunk_args = match want {
+                        Some(n) => vec![Value::Int(n as i64)],
+                        None => vec![],
+                    };
+                    let chunk = self
+                        .native_io_handle_method(&active, "readchars", chunk_args)?
+                        .to_string_value();
+                    if chunk.is_empty() {
+                        if matches!(self.cat_next_handle(&mut attrs), Value::Nil) {
+                            break;
+                        }
+                        continue;
+                    }
+                    out.push_str(&chunk);
+                    if let Some(c) = count
+                        && out.chars().count() >= c
+                    {
+                        break;
+                    }
+                }
+                Value::str(out)
+            }
+            "read" => {
+                // Read up to N bytes across handles, switching when one is
+                // exhausted but only while more bytes are still wanted.
+                let want = args.first().and_then(val_int).unwrap_or(0).max(0) as usize;
+                let mut bytes: Vec<u8> = Vec::new();
+                while bytes.len() < want {
+                    let active = self.cat_ensure_active(&mut attrs);
+                    if matches!(active, Value::Nil) {
+                        break;
+                    }
+                    let remaining = want - bytes.len();
+                    let chunk = self.native_io_handle_method(
+                        &active,
+                        "read",
+                        vec![Value::Int(remaining as i64)],
+                    )?;
+                    let chunk_bytes: Vec<u8> = Self::buf_as_byte_items(&chunk)
+                        .unwrap_or_default()
+                        .iter()
+                        .filter_map(val_int)
+                        .map(|b| b as u8)
+                        .collect();
+                    if chunk_bytes.is_empty() {
+                        if matches!(self.cat_next_handle(&mut attrs), Value::Nil) {
+                            break;
+                        }
+                        continue;
+                    }
+                    bytes.extend_from_slice(&chunk_bytes);
+                }
+                let mut battrs: HashMap<String, Value> = HashMap::new();
+                battrs.insert(
+                    "bytes".to_string(),
+                    Value::array(bytes.iter().map(|b| Value::Int(*b as i64)).collect()),
+                );
+                Value::make_instance(Symbol::intern("Buf"), battrs)
+            }
+            "next-handle" => self.cat_next_handle(&mut attrs),
+            "close" | "DESTROY" => {
+                if let Some(active @ Value::Instance { class_name, .. }) =
+                    attrs.get("active").cloned().as_ref()
+                    && class_name == "IO::Handle"
+                {
+                    let _ = self.close_handle_value(active);
+                }
+                // Close any remaining un-opened IO::Handle sources too.
+                let handle_sources: Vec<Value> = match attrs.get("sources") {
+                    Some(Value::Array(items, ..)) => items
+                        .iter()
+                        .filter(|v| matches!(v, Value::Instance { class_name, .. } if class_name == "IO::Handle"))
+                        .cloned()
+                        .collect(),
+                    _ => Vec::new(),
+                };
+                for src in &handle_sources {
+                    let _ = self.close_handle_value(src);
+                }
+                attrs.insert("active".to_string(), Value::Nil);
+                attrs.insert("path".to_string(), Value::Nil);
+                attrs.insert("closed".to_string(), Value::Bool(true));
+                let pos = match attrs.get("sources") {
+                    Some(Value::Array(items, ..)) => items.len() as i64,
+                    _ => 0,
+                };
+                attrs.insert("pos".to_string(), Value::Int(pos));
+                Value::Bool(true)
+            }
+            "eof" => {
+                // At EOF when nothing more can be read.
+                if attrs.get("closed").is_some_and(|v| v.truthy()) {
+                    Value::Bool(true)
+                } else {
+                    let active = self.cat_ensure_active(&mut attrs);
+                    if matches!(active, Value::Nil) {
+                        Value::Bool(true)
+                    } else {
+                        let e = self.native_io_handle_method(&active, "eof", vec![])?;
+                        if e.truthy() {
+                            // Peek the next handle to decide true EOF.
+                            let next = self.cat_next_handle(&mut attrs);
+                            Value::Bool(matches!(next, Value::Nil))
+                        } else {
+                            Value::Bool(false)
+                        }
+                    }
+                }
+            }
+            "opened" => Value::Bool(!attrs.get("closed").is_some_and(|v| v.truthy())),
+            "chomp" => {
+                if let Some(arg) = args.into_iter().next() {
+                    attrs.insert("chomp".to_string(), arg.clone());
+                    arg
+                } else {
+                    attrs.get("chomp").cloned().unwrap_or(Value::Bool(true))
+                }
+            }
+            "nl-in" => {
+                if let Some(arg) = args.into_iter().next() {
+                    attrs.insert("nl-in".to_string(), arg.clone());
+                    arg
+                } else {
+                    attrs
+                        .get("nl-in")
+                        .cloned()
+                        .unwrap_or_else(|| Value::str("\n".to_string()))
+                }
+            }
+            "encoding" => {
+                if let Some(arg) = args.into_iter().next() {
+                    let s = arg.to_string_value();
+                    attrs.insert("encoding".to_string(), Value::str(s.clone()));
+                    Value::str(s)
+                } else {
+                    attrs
+                        .get("encoding")
+                        .cloned()
+                        .unwrap_or_else(|| Value::str("utf8".to_string()))
+                }
+            }
+            "on-switch" => {
+                if let Some(arg) = args.into_iter().next() {
+                    attrs.insert("on-switch".to_string(), arg.clone());
+                    arg
+                } else {
+                    attrs.get("on-switch").cloned().unwrap_or(Value::Nil)
+                }
+            }
+            "path" | "IO" => {
+                // Make sure a handle is active so `.path` reflects the current source.
+                if matches!(attrs.get("active"), Some(Value::Nil) | None)
+                    && attrs.get("pos").and_then(val_int).unwrap_or(0) == 0
+                {
+                    let _ = self.cat_ensure_active(&mut attrs);
+                }
+                attrs.get("path").cloned().unwrap_or(Value::Nil)
+            }
+            "handles" => {
+                // The lazy list of handles this cat will read: the active one (if
+                // any) plus the remaining unopened sources opened on demand. For a
+                // simple, eager view, return active + remaining-opened handles.
+                let mut out = Vec::new();
+                loop {
+                    let active = self.cat_ensure_active(&mut attrs);
+                    if matches!(active, Value::Nil) {
+                        break;
+                    }
+                    out.push(active);
+                    if matches!(self.cat_next_handle(&mut attrs), Value::Nil) {
+                        break;
+                    }
+                }
+                Value::Seq(std::sync::Arc::new(out))
+            }
+            "gist" => {
+                // Open the first handle if nothing has been read yet, then render
+                // `IO::CatHandle(opened on <path>.gist)` or `IO::CatHandle(closed)`.
+                if matches!(attrs.get("active"), Some(Value::Nil) | None)
+                    && attrs.get("pos").and_then(val_int).unwrap_or(0) == 0
+                    && !attrs.get("closed").is_some_and(|v| v.truthy())
+                {
+                    let _ = self.cat_ensure_active(&mut attrs);
+                }
+                match attrs.get("active").cloned() {
+                    Some(active @ Value::Instance { .. }) => {
+                        let path = self
+                            .native_io_handle_method(&active, "path", vec![])
+                            .unwrap_or(Value::Nil);
+                        let path_gist = self
+                            .call_method_with_values(path, "gist", vec![])
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default();
+                        Value::str(format!("IO::CatHandle(opened on {})", path_gist))
+                    }
+                    _ => Value::str("IO::CatHandle(closed)".to_string()),
+                }
+            }
+            "Str" => {
+                // The active handle's path as a string (opening the first handle
+                // if needed). On a closed/exhausted cat, fall back to the name.
+                if matches!(attrs.get("active"), Some(Value::Nil) | None)
+                    && attrs.get("pos").and_then(val_int).unwrap_or(0) == 0
+                    && !attrs.get("closed").is_some_and(|v| v.truthy())
+                {
+                    let _ = self.cat_ensure_active(&mut attrs);
+                }
+                match attrs.get("path").cloned() {
+                    Some(p) if !matches!(p, Value::Nil) => Value::str(p.to_string_value()),
+                    _ => Value::str("IO::CatHandle".to_string()),
+                }
+            }
+            "Supply" | "native-descriptor" | "seek" | "tell" | "t" => {
+                return Err(RuntimeError::new(format!(
+                    "No native mutable method '{}' on 'IO::CatHandle'",
+                    method
+                )));
+            }
+            _ => {
+                return Err(RuntimeError::new(format!(
+                    "No native mutable method '{}' on 'IO::CatHandle'",
+                    method
+                )));
+            }
+        };
+        Ok((result, attrs))
+    }
+}

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -290,6 +290,7 @@ impl Interpreter {
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
             "IO::Handle" => self.native_io_handle_mut(attributes, method, args),
+            "IO::CatHandle" => self.native_io_cathandle_mut(attributes, method, args),
             "Proc" => self.native_proc_mut(attributes, method, args),
             "Promise" => self.native_promise_mut(attributes, method, args),
             "Channel" => self.native_channel_mut(attributes, method, args),
@@ -394,6 +395,15 @@ impl Interpreter {
         match dispatch_class.as_deref().unwrap_or(class_name) {
             "IO::Path" => self.native_io_path(attributes, class_name, method, args),
             "IO::Handle" => self.native_io_handle(attributes, method, args),
+            "IO::CatHandle" => {
+                // All IO::CatHandle methods mutate read state; the immutable entry
+                // is only reached for introspection paths, so run the mutable impl
+                // and drop the writeback (callers needing persistence route through
+                // the mutable path in methods_instance_ops).
+                let (result, _updated) =
+                    self.native_io_cathandle_mut(attributes.clone(), method, args)?;
+                Ok(result)
+            }
             "IO::Special" => self.native_io_special(attributes, method, args),
             "IO::Socket::INET" => self.native_socket_inet(attributes, method, args),
             "IO::Socket::Async" => self.native_socket_async(attributes, method, args),

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -1,5 +1,55 @@
 use super::*;
 
+/// Convert a `CallArg` to an `Expr` for expression-level call compilation,
+/// preserving named (`k => v`) and slip (`|v`) args. Mirrors the compiler's
+/// `call_args_to_expr_args`.
+fn call_arg_to_expr(arg: &crate::ast::CallArg) -> crate::ast::Expr {
+    use crate::ast::{CallArg, Expr};
+    use crate::token_kind::TokenKind;
+    match arg {
+        CallArg::Positional(e) | CallArg::Invocant(e) => e.clone(),
+        CallArg::Named {
+            name,
+            value: Some(e),
+        } => Expr::Binary {
+            left: Box::new(Expr::Literal(Value::str(name.clone()))),
+            op: TokenKind::FatArrow,
+            right: Box::new(e.clone()),
+        },
+        CallArg::Named { name, value: None } => Expr::Binary {
+            left: Box::new(Expr::Literal(Value::str(name.clone()))),
+            op: TokenKind::FatArrow,
+            right: Box::new(Expr::Literal(Value::Bool(true))),
+        },
+        CallArg::Slip(e) => Expr::Unary {
+            op: TokenKind::Pipe,
+            expr: Box::new(e.clone()),
+        },
+    }
+}
+
+/// If the last non-`SetLine` statement of `body` is a bare `Stmt::Call`, replace
+/// it with `Stmt::Expr(Expr::Call)` so the re-compiled block leaves the call's
+/// value on the stack (otherwise a named/slip-arg tail call is compiled as a
+/// value-discarding statement and the map result wrongly falls back to `$_`).
+fn normalize_tail_call_for_value(body: &[crate::ast::Stmt]) -> Vec<crate::ast::Stmt> {
+    use crate::ast::{Expr, Stmt};
+    let Some(last_idx) = body.iter().rposition(|s| !matches!(s, Stmt::SetLine(_))) else {
+        return body.to_vec();
+    };
+    if let Stmt::Call { name, args } = &body[last_idx] {
+        let expr_args = args.iter().map(call_arg_to_expr).collect();
+        let mut out = body.to_vec();
+        out[last_idx] = Stmt::Expr(Expr::Call {
+            name: *name,
+            args: expr_args,
+        });
+        out
+    } else {
+        body.to_vec()
+    }
+}
+
 impl Interpreter {
     pub(super) fn eval_map_over_items(
         &mut self,
@@ -108,7 +158,14 @@ impl Interpreter {
             // a routine is currently on the dynamic call stack.
             let mut compiler = crate::compiler::Compiler::new();
             compiler.lexically_in_routine = !self.routine_stack.is_empty();
-            let (code, compiled_fns) = compiler.compile(&data.body);
+            // The map value is taken from the block's tail-expression result (or
+            // the topic `$_` if none was left on the stack). A bare tail
+            // `Stmt::Call` carrying named/slip args (how an imported sub call like
+            // `f(k => v)` parses) is compiled as a value-discarding statement, so
+            // the result would wrongly fall back to the topic. Normalize such a
+            // tail into `Stmt::Expr(Expr::Call)` so its value is preserved.
+            let normalized_body = normalize_tail_call_for_value(&data.body);
+            let (code, compiled_fns) = compiler.compile(&normalized_body);
 
             let underscore = "_".to_string();
             let dollar_topic = "$_".to_string();

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -696,6 +696,54 @@ impl Interpreter {
             },
         );
         classes.insert(
+            "IO::CatHandle".to_string(),
+            ClassDef {
+                parents: Vec::new(),
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: [
+                    "get",
+                    "getc",
+                    "lines",
+                    "words",
+                    "comb",
+                    "split",
+                    "slurp",
+                    "readchars",
+                    "read",
+                    "next-handle",
+                    "close",
+                    "DESTROY",
+                    "eof",
+                    "opened",
+                    "chomp",
+                    "nl-in",
+                    "encoding",
+                    "on-switch",
+                    "path",
+                    "IO",
+                    "handles",
+                    "Str",
+                    "gist",
+                    "Supply",
+                    "native-descriptor",
+                    "seek",
+                    "tell",
+                    "t",
+                ]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+                mro: vec!["IO::CatHandle".to_string()],
+                attribute_types: HashMap::new(),
+                attribute_smileys: HashMap::new(),
+                attribute_built: HashMap::new(),
+                wildcard_handles: Vec::new(),
+                alias_attributes: HashSet::new(),
+                class_level_attrs: HashMap::new(),
+            },
+        );
+        classes.insert(
             "Backtrace".to_string(),
             ClassDef {
                 parents: Vec::new(),

--- a/t/io-cathandle.t
+++ b/t/io-cathandle.t
@@ -1,0 +1,52 @@
+use Test;
+
+# Basic IO::CatHandle: read across several files in sequence.
+
+my $dir = $*TMPDIR.add("mutsu-cathandle-{$*PID}");
+$dir.mkdir;
+LEAVE { try { .unlink for $dir.dir; $dir.rmdir } }
+
+my $f1 = $dir.add("a.txt"); $f1.spurt("a\nb\nc\n");
+my $f2 = $dir.add("b.txt"); $f2.spurt("d\ne\n");
+my $f3 = $dir.add("c.txt"); $f3.spurt("");
+my $f4 = $dir.add("d.txt"); $f4.spurt("f\n");
+
+isa-ok IO::CatHandle.new, IO::CatHandle, 'IO::CatHandle.new';
+
+{
+    my $cat = IO::CatHandle.new: $f1, $f2;
+    is $cat.get, 'a', 'get first line';
+    is $cat.get, 'b', 'get second line';
+    is $cat.get, 'c', 'get third line (still first file)';
+    is $cat.get, 'd', 'get crosses to second file';
+    is $cat.get, 'e', 'get last line';
+    is-deeply $cat.get, Nil, 'get past EOF returns Nil';
+}
+
+{
+    # Empty files in the middle are skipped transparently.
+    my $cat = IO::CatHandle.new: $f1, $f3, $f4;
+    is-deeply $cat.lines.List, ('a', 'b', 'c', 'f'), 'lines skips empty file';
+}
+
+{
+    my $cat = IO::CatHandle.new: $f1, $f2;
+    is $cat.slurp, "a\nb\nc\nd\ne\n", 'slurp concatenates all files';
+}
+
+{
+    my $cat = IO::CatHandle.new: $f1, $f2;
+    is $cat.opened, True, 'opened before close';
+    is $cat.close, True, 'close returns True';
+    is $cat.opened, False, 'not opened after close';
+    is-deeply $cat.slurp, Nil, 'slurp after close returns Nil';
+}
+
+{
+    # chomp / nl-in / encoding accessors.
+    my $cat = IO::CatHandle.new: $f1;
+    is $cat.encoding, 'utf8', 'default encoding';
+    is $cat.chomp, True, 'default chomp';
+}
+
+done-testing;

--- a/t/map-imported-named-tail-call.t
+++ b/t/map-imported-named-tail-call.t
@@ -1,0 +1,28 @@
+use Test;
+
+# A block whose tail statement is a call with a NAMED argument (`f(k => v)`)
+# must return the call's value. Such a call parses as a bare `Stmt::Call` with a
+# `CallArg::Named` (notably for imported subs, which are unknown at parse time);
+# the block-value compilation previously only preserved all-positional tail calls
+# and discarded the result of a named/slip-arg call, so `.map` fell back to
+# returning the loop topic. The subs below return a value DISTINCT from the topic
+# so a regression (returning the topic) is detectable.
+
+sub tagged(:$x) { "got-$x" }
+
+is-deeply (1, 2, 3).map({ tagged(x => $_) }).List, ('got-1', 'got-2', 'got-3'),
+    'map block tail call with named arg returns call value, not topic';
+
+sub two(:$a, :$b) { "$a:$b" }
+is-deeply <p q>.map({ two(a => $_, b => 'Z') }).List, ('p:Z', 'q:Z'),
+    'map block tail call with multiple named args';
+
+sub takeslip(*@xs) { 'slip:' ~ @xs.join(',') }
+is-deeply (1, 2).map({ takeslip(|($_, $_)) }).List, ('slip:1,1', 'slip:2,2'),
+    'map block tail call with slip arg';
+
+# Same when the call is the implicit return of a plain sub.
+sub wrap($v) { tagged(x => $v) }
+is wrap(42), 'got-42', 'sub tail call with named arg returns call value';
+
+done-testing;


### PR DESCRIPTION
## Summary

`IO::CatHandle` was completely unimplemented (`IO::CatHandle.new` threw `X::Method::NotFound`). This adds a native implementation plus a supporting compiler fix uncovered while testing.

### IO::CatHandle
A virtual handle that reads from a sequence of `IO::Path` / `Str` / `IO::Handle` sources, opening each (paths/strings) and reading to exhaustion before transparently switching to the next. State (`sources` / `pos` / `active` / `chomp` / `nl-in` / `encoding` / `closed` / `on-switch`) lives in the instance attributes and is persisted across calls via the mutable-dispatch writeback (`commit_attrs`, like `Proc::Async`).

Methods: `new`, `get`, `getc`, `lines`, `slurp`, `words`, `comb`, `split`, `read`, `readchars`, `next-handle`, `close`, `DESTROY`, `eof`, `opened`, `chomp`, `nl-in`, `encoding`, `on-switch`, `path`, `IO`, `handles`, `Str`, `gist`.

### Compiler fix: map block named-tail-call value
A `.map` block whose tail statement is a **bare call with a named/slip argument** (`f(k => v)` — how an *imported* sub call parses, since imports are unknown at parse time) was compiled as a value-discarding statement, so the map result wrongly fell back to the loop topic `$_`. `eval_map_over_items` now normalizes such a tail into `Stmt::Expr(Expr::Call)` so the call's value is preserved. (A broader global compiler fix was tried but regressed `throws-like-any` by bypassing the statement-call path's test-callsite handling, so the fix is scoped to the map path.)

## Result
- `S32-io/io-cathandle.t` top-level tests 30/31 pass; the 28 subtests remain blocked by the test's `make-files` helper — a deeper multi-path map / imported-sub tail-call-value interaction, documented in `TODO_roast/S32.md`.
- `make test` + `make roast` green locally; `io-handle` and the rest stay green (no regressions).

## Tests
- `t/io-cathandle.t` (get crosses files, skips empty files, slurp, close→Nil, accessors)
- `t/map-imported-named-tail-call.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)