### PR TITLE
feat(class): strict accessors for user classes — undeclared .name throws X::Method::NotFound

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -924,12 +924,21 @@ impl Interpreter {
                 }
                 return Ok(result);
             }
-            // Fallback: auto-generated accessor for public attributes
+            // Fallback: auto-generated accessor for public attributes.
             if args.is_empty() {
                 let cn = class_name.resolve();
                 let class_attrs = self.collect_class_attributes(&cn);
+                // For a *user-declared* class the collected public-attribute list is
+                // authoritative: a `.name` accessor resolves ONLY for a declared
+                // public `has $.name`. An undeclared name (e.g. an unknown named arg
+                // `.new` accepted and stored) is NOT an accessor and falls through to
+                // X::Method::NotFound (Rakudo: `class C {}; C.new(x=>3).x` dies). A
+                // *built-in* class (exception types, ...) keeps its attributes only
+                // in the stored map (not collected), so still read them.
                 if class_attrs.is_empty() {
-                    if let Some(val) = attributes.as_map().get(method) {
+                    if !self.user_declared_classes.contains(&cn)
+                        && let Some(val) = attributes.as_map().get(method)
+                    {
                         // Check for deprecated attribute accessor
                         if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                             self.check_deprecation_for_method(method, &cn, &msg);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1553,6 +1553,16 @@ pub struct Interpreter {
     /// deterministic` (i.e. cacheable in `func_multi_resolve_cache`). The
     /// function analogue of `multi_type_cacheable`.
     pub(crate) func_multi_type_cacheable: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
+    /// Names of classes the user declared with a `class`/`role`/`grammar`/`enum`
+    /// statement (`register_class_decl`). For such a class the collected public-
+    /// attribute list is authoritative: a `.name` accessor resolves ONLY for a
+    /// declared public `has $.name`; an undeclared name (e.g. an unknown named arg
+    /// `.new` accepted and stored) falls through to X::Method::NotFound (Rakudo:
+    /// `class C {}; C.new(x=>3).x` dies). Native/built-in objects (Parameter,
+    /// Signature, exception types, ...) are NOT here — their attributes live only
+    /// in the stored map and are not collected — so the accessor fallback still
+    /// reads them.
+    pub(crate) user_declared_classes: std::collections::HashSet<String>,
     pub(crate) block_declared_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_vars: Vec<HashSet<String>>,
     pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -7,6 +7,28 @@ use crate::ast::{HandleSpec, ParamDef, PhaserKind};
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Recursively surface `has`-attribute declarations nested inside a sub/block
+    /// within a class body (`class C { sub f { has $.x } }`). Descends into
+    /// `sub`/block bodies but NOT into a nested `class`/`role` (which owns its own
+    /// attribute scope). Collects only `HasDecl` statements.
+    fn collect_nested_class_has_decls<'a>(stmts: &'a [Stmt], out: &mut Vec<&'a Stmt>) {
+        for s in stmts {
+            match s {
+                // Own attribute scope / already collected at the top level.
+                Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
+                Stmt::SubDecl { body, .. } => {
+                    for inner in body {
+                        if matches!(inner, Stmt::HasDecl { .. }) {
+                            out.push(inner);
+                        }
+                    }
+                    Self::collect_nested_class_has_decls(body, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
     pub(crate) fn register_class_decl(
         &mut self,
         name: &str,
@@ -15,6 +37,9 @@ impl Interpreter {
         body: &[Stmt],
     ) -> Result<Vec<String>, RuntimeError> {
         self.clear_private_zeroarg_method_cache();
+        // Mark this as a user-declared class so its collected attribute list is
+        // authoritative for accessor resolution (undeclared `.name` -> NotFound).
+        self.user_declared_classes.insert(name.to_string());
         let ClassDeclModifiers {
             class_is_rw,
             is_hidden,
@@ -903,13 +928,19 @@ impl Interpreter {
             .insert("?CLASS".to_string(), Value::Package(Symbol::intern(name)));
         // Flatten SyntheticBlock (from `has ($a, $b)` list form) so inner
         // HasDecl statements are processed at the top level.
-        let flattened_body: Vec<&Stmt> = body
+        let mut flattened_body: Vec<&Stmt> = body
             .iter()
             .flat_map(|s| match s {
                 Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
                 other => vec![other],
             })
             .collect();
+        // An attribute can also be declared inside a nested sub/block within the
+        // class body (`class C { sub f { has $.x } }`) — Rakudo still registers it
+        // on the class. Surface those `has` declarations so the main loop below
+        // registers the attribute (the nested sub itself is still processed
+        // normally; its body's `has` is a compile-time declaration).
+        Self::collect_nested_class_has_decls(body, &mut flattened_body);
         // Pre-scan: collect attribute names declared directly in this class body.
         // Combined with role-composed attributes already in class_def.attributes,
         // this gives the full set of attributes valid for $!attr access.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1645,6 +1645,7 @@ impl Interpreter {
         }
 
         let mut interpreter = Self {
+            user_declared_classes: std::collections::HashSet::new(),
             env: Env::from(env),
             output_sink: Arc::new(RwLock::new(OutputSink::new())),
             warn_output: String::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -329,6 +329,7 @@ impl Interpreter {
             func_def_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),
             func_multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            user_declared_classes: self.user_declared_classes.clone(),
             block_declared_vars: Vec::new(),
             loop_local_vars: Vec::new(),
             loop_local_saved_env: Vec::new(),

--- a/t/strict-undeclared-accessor.t
+++ b/t/strict-undeclared-accessor.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 6;
+
+# Loose-object-model strictness: a `.name` accessor on a USER-declared class
+# resolves ONLY for a declared public `has $.name`. An undeclared name — e.g. an
+# unknown named arg that `.new` accepted and stored — is NOT an accessor and
+# throws X::Method::NotFound (Rakudo). Built-in/native objects, whose attributes
+# live only in the stored map, are unaffected.
+
+# Undeclared accessor on a user class throws.
+my class Empty {}
+throws-like { Empty.new(x => 3).x }, X::Method::NotFound,
+    'undeclared .x on a user class throws X::Method::NotFound';
+
+# A declared public attribute still works.
+my class HasX { has $.x }
+is HasX.new(x => 42).x, 42, 'declared public attribute accessor works';
+
+# Undeclared name on a class that DOES declare other attributes also throws.
+throws-like { HasX.new(x => 1, y => 2).y }, X::Method::NotFound,
+    'undeclared .y throws even when the class declares other attributes';
+
+# An attribute declared inside a nested sub/block is still registered.
+my class NestedHas {
+    sub helper { has $.deep }
+}
+is NestedHas.new(deep => 7).deep, 7, 'nested-scope has $.deep is registered';
+
+# Built-in/native objects expose their attributes via the stored map (loose path
+# intact): a type-check exception's .got/.expected are still accessible.
+my $err;
+{ my Int $a = "x"; CATCH { default { $err = $_ } } }
+ok $err ~~ X::TypeCheck, 'caught a type-check exception';
+is $err.got, "x", 'built-in X::TypeCheck .got still accessible';


### PR DESCRIPTION
## What

Loose-object-model strictness — **campaign PR 1**.

mutsu's `.new(name => val)` accepts unknown named args and stores them, and the accessor fallback then read **any** stored value as a `.name` accessor even when the class declared no such attribute — so `class C {}; C.new(x => 3).x` returned `3` instead of dying (Rakudo throws `X::Method::NotFound`). This is the `S12-attributes/class.t` (test 21) canary and a foundational object-model correctness gap.

## Fix

Track the names of **user-declared** classes (`register_class_decl` populates `user_declared_classes`). For such a class the collected public-attribute list is authoritative — an undeclared `.name` falls through to `X::Method::NotFound`. The accessor fallback's "empty attribute list reads any stored value" branch now fires **only for non-user classes**, i.e. native/built-in objects (Parameter, Signature, exception types, ...) whose attributes legitimately live only in the stored map and are not collected.

The positive-list (`user_declared_classes`) approach is the sound one: an init-time built-in *snapshot* was tried first but is incomplete — many native types (Parameter, Signature, ...) aren't in `registry.classes` yet still expose stored attributes, so they'd wrongly go strict. Tracking what the **user** declared is exact.

Also completes one `collect_class_attributes` gap the strictness exposed: an attribute declared inside a nested sub/block within the class body (`class C { sub f { has $.x } }`) is now surfaced and registered (`collect_nested_class_has_decls`), matching Rakudo (`S12-attributes/instance.t` test 146).

## Verification

`make test` (13105) + `make roast` both green (the only roast blip was the known-flaky `S17-lowlevel/thread.t` timeout, which passes on retry — verified 3×). `t/strict-undeclared-accessor.t`.

## Scope

`S12-attributes/class.t` is **not yet whitelisted** — its remaining failure (test 20) needs BEGIN-EVAL attribute declaration (`class C { BEGIN EVAL q[has $.x] }` must register `$.x`), a separate follow-up. This PR is the foundational strictness step that the rest of the campaign builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)