### PR TITLE
feat(scheduler): $*SCHEDULER.loads, cue arg-validation, uncaught_handler routing

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -72,7 +72,18 @@
 - [ ] roast/S17-promise/stress.t
 - [ ] roast/S17-promise/then.t
 - [ ] roast/S17-scheduler/at.t
-- [ ] roast/S17-scheduler/basic.t
+- [x] roast/S17-scheduler/basic.t — **34/34, whitelisted (2026-06-29).** Was
+    aborting at test 2 because `$*SCHEDULER.loads` was unimplemented (threw
+    X::Method::NotFound). Implemented: (1) `.loads` returns the outstanding
+    (spawned-but-unfinished) async-task count via a global atomic counter
+    (incremented before an async cue spawn, decremented when the callback
+    finishes); a synchronous CurrentThreadScheduler cue runs inline and never
+    increments it, so `.loads` is 0 once idle. (2) `cue` now validates
+    mutually-exclusive scheduling adverbs synchronously (`:in`+`:at`,
+    `:every`+`:times`+`:stop`, and `:every` on a CurrentThreadScheduler) instead
+    of silently accepting them (the `dies-ok` cases). (3) an uncaught exception
+    from a cue with no `:catch` is routed to the scheduler's `uncaught_handler`
+    (was silently swallowed). t/scheduler-loads-cue.t.
 - [ ] roast/S17-scheduler/every.t
 - [ ] roast/S17-scheduler/in.t
 - [ ] roast/S17-scheduler/times.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -871,6 +871,7 @@ roast/S17-promise/nonblocking-await.t
 roast/S17-promise/single-assignment.t
 roast/S17-promise/stress.t
 roast/S17-scheduler/at.t
+roast/S17-scheduler/basic.t
 roast/S17-scheduler/every.t
 roast/S17-scheduler/in.t
 roast/S17-scheduler/times.t

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -191,6 +191,28 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "cue" => {
+                // Validate mutually-exclusive scheduling adverbs up front (raku
+                // throws synchronously here, before the callback is ever run).
+                let has_in = Self::named_value(&args, "in").is_some();
+                let has_at = Self::named_value(&args, "at").is_some();
+                let has_every = Self::named_value(&args, "every").is_some();
+                let has_times = Self::named_value(&args, "times").is_some();
+                let has_stop = Self::named_value(&args, "stop").is_some();
+                if has_in && has_at {
+                    return Err(RuntimeError::new(
+                        "Cannot specify :in and :at at the same time",
+                    ));
+                }
+                if has_every && has_times && has_stop {
+                    return Err(RuntimeError::new(
+                        "Cannot specify :every, :times and :stop at the same time",
+                    ));
+                }
+                if is_current_thread && has_every {
+                    return Err(RuntimeError::new(
+                        "Cannot specify :every in a CurrentThreadScheduler",
+                    ));
+                }
                 let callback = args.first().cloned().unwrap_or(Value::Nil);
                 let times_explicit = Self::scheduler_times_arg(&args)?;
                 let delay = Self::scheduler_delay(&args)?;
@@ -232,11 +254,16 @@ impl Interpreter {
                     self.scheduler_run_sync(params)?;
                 } else {
                     let mut thread_interp = self.clone_for_thread();
+                    // Track the spawned task so `$*SCHEDULER.loads` reflects it
+                    // until the callback finishes (mark started before spawn so a
+                    // racing `.loads` never undercounts).
+                    state_scheduler::scheduler_task_started();
                     // Large user-code stack: the scheduled callback runs user VM
                     // code, which overflows the default thread stack on deep
                     // nesting. See `USER_THREAD_STACK_SIZE`.
                     crate::runtime::builtins_system::spawn_user_thread(move || {
                         thread_interp.scheduler_run_async(params);
+                        state_scheduler::scheduler_task_finished();
                     });
                 }
                 Ok(cancellation)
@@ -244,6 +271,12 @@ impl Interpreter {
             "uncaught_handler" => {
                 // Getter: return current uncaught_handler or Nil
                 Ok(state_scheduler::get_uncaught_handler().unwrap_or(Value::Nil))
+            }
+            "loads" => {
+                // Number of outstanding (spawned-but-unfinished) scheduled tasks.
+                // A CurrentThreadScheduler cue runs inline (never increments), so
+                // this is 0 once the scheduler is idle.
+                Ok(Value::Int(state_scheduler::scheduler_loads() as i64))
             }
             _ => Err(RuntimeError::new(format!(
                 "No native method '{}' on Scheduler",
@@ -330,6 +363,16 @@ impl Interpreter {
                         .map(|boxed| *boxed)
                         .unwrap_or_else(|| Value::str(e.message));
                     let _ = self.call_sub_value(catch.clone(), vec![exception], true);
+                } else if let Some(handler) = state_scheduler::get_uncaught_handler() {
+                    // No per-cue :catch: an uncaught exception goes to the
+                    // scheduler's uncaught_handler (raku semantics). Pass a real
+                    // exception object so `$exception.message` works.
+                    let exception = e.exception.map(|boxed| *boxed).unwrap_or_else(|| {
+                        let mut attrs = HashMap::new();
+                        attrs.insert("message".to_string(), Value::str(e.message.clone()));
+                        Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
+                    });
+                    let _ = self.call_sub_value(handler, vec![exception], true);
                 }
                 Ok(false)
             }

--- a/src/runtime/native_methods/state_scheduler.rs
+++ b/src/runtime/native_methods/state_scheduler.rs
@@ -25,6 +25,39 @@ pub(in crate::runtime) fn set_uncaught_handler(handler: Value) {
     }
 }
 
+// --- Outstanding scheduled-task counter (for $*SCHEDULER.loads) ---
+
+static OUTSTANDING_TASKS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Record that an asynchronously-scheduled task has been spawned.
+pub(in crate::runtime) fn scheduler_task_started() {
+    OUTSTANDING_TASKS.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Record that a previously-spawned asynchronous task has finished.
+pub(in crate::runtime) fn scheduler_task_finished() {
+    // Saturating decrement so a stray finish can never underflow to a huge count.
+    let mut cur = OUTSTANDING_TASKS.load(Ordering::SeqCst);
+    while cur > 0 {
+        match OUTSTANDING_TASKS.compare_exchange_weak(
+            cur,
+            cur - 1,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => break,
+            Err(actual) => cur = actual,
+        }
+    }
+}
+
+/// Number of outstanding (spawned but not yet completed) scheduled tasks.
+/// A synchronous (CurrentThreadScheduler) cue runs inline and never increments
+/// this, so it is 0 whenever the scheduler is idle.
+pub(in crate::runtime) fn scheduler_loads() -> u64 {
+    OUTSTANDING_TASKS.load(Ordering::SeqCst)
+}
+
 // --- FakeScheduler support (for Test::Tap) ---
 
 /// A scheduled item in a FakeScheduler.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -422,7 +422,7 @@ impl Interpreter {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["cue", "uncaught_handler"]
+                native_methods: ["cue", "uncaught_handler", "loads"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
@@ -441,7 +441,7 @@ impl Interpreter {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["cue", "uncaught_handler"]
+                native_methods: ["cue", "uncaught_handler", "loads"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),

--- a/t/scheduler-loads-cue.t
+++ b/t/scheduler-loads-cue.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 8;
+
+# $*SCHEDULER.loads — outstanding scheduled-task count (0 when idle).
+is $*SCHEDULER.loads, 0, '.loads is 0 on an idle scheduler';
+
+# cue arg validation: mutually-exclusive scheduling adverbs throw synchronously.
+dies-ok { $*SCHEDULER.cue({ 1 }, :at(now + 2), :in(1)) },
+    'cue dies on :in + :at';
+dies-ok { $*SCHEDULER.cue({ 1 }, :every(0.1), :times(10), :stop({ 1 })) },
+    'cue dies on :every + :times + :stop';
+
+# CurrentThreadScheduler runs cue synchronously.
+{
+    my $sched = CurrentThreadScheduler.new;
+    dies-ok { $sched.cue({ 1 }, :every(1)) },
+        'CurrentThreadScheduler cue dies on :every';
+
+    my $ran = False;
+    $sched.cue({ $ran = True });
+    is $ran, True, 'sync cue runs the callback inline';
+    is $sched.loads, 0, '.loads is 0 after a synchronous cue';
+
+    # An uncaught exception from a sync cue (no :catch) goes to uncaught_handler.
+    my $msg;
+    $sched.uncaught_handler = sub ($ex) { $msg = $ex.message };
+    $sched.cue({ die 'boom' });
+    is $msg, 'boom', 'uncaught_handler receives a sync cue exception';
+    $sched.uncaught_handler = Nil;
+
+    # A :catch handler takes precedence and receives the exception.
+    my $caught;
+    $sched.cue({ die 'kaboom' }, :catch(-> $ex { $caught = $ex.message }));
+    is $caught, 'kaboom', ':catch handler receives the exception';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Greens `S17-scheduler/basic.t` (34/34, now whitelisted), which previously aborted at test 2 because `$*SCHEDULER.loads` was unimplemented (threw `X::Method::NotFound`). Three foundational scheduler features:

- **`.loads`** — returns the number of outstanding (spawned-but-unfinished) asynchronous tasks via a global atomic counter (incremented before an async cue spawn, decremented when the callback finishes). A synchronous `CurrentThreadScheduler` cue runs inline and never increments it, so `.loads` is 0 once idle.
- **`cue` argument validation** — mutually-exclusive scheduling adverbs now throw synchronously (raku validates before running the callback): `:in`+`:at`, `:every`+`:times`+`:stop`, and `:every` on a `CurrentThreadScheduler`. These are the `dies-ok` cases.
- **uncaught_handler routing** — an uncaught exception from a cue with no `:catch` is now routed to the scheduler's `uncaught_handler` (was silently swallowed), passing a real exception object so `$exception.message` works.

## Result
- `S17-scheduler/basic.t`: 34/34, whitelisted (was aborting at test 2). Deterministic (5/5).
- `make test` (13132) + `make roast` (211217) green locally; no regressions.

## Tests
- `t/scheduler-loads-cue.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)