### PR TITLE
feat(walk): lazy WALK(method)() — one candidate invoked per pulled element

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -658,6 +658,7 @@ roast/S12-introspection/meta-class.t
 roast/S12-introspection/methods.t
 roast/S12-introspection/parents.t
 roast/S12-introspection/roles.t
+roast/S12-introspection/walk.t
 roast/S12-meta/classhow.t
 roast/S12-meta/grammarhow.t
 roast/S12-meta/primitives.t

--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -61,6 +61,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                             coroutine: None,
                             lazy_pipe: None,
                             closure_seq: None,
+                            walk_pending: None,
                         };
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
                     }
@@ -86,6 +87,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                     coroutine: None,
                     lazy_pipe: None,
                     closure_seq: None,
+                    walk_pending: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1098,6 +1098,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     coroutine: None,
                     lazy_pipe: None,
                     closure_seq: None,
+                    walk_pending: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -154,6 +154,10 @@ pub(super) fn dispatch(
                                 .closure_seq
                                 .as_ref()
                                 .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
+                            walk_pending: list
+                                .walk_pending
+                                .as_ref()
+                                .map(|w| std::sync::Mutex::new(w.lock().unwrap().clone())),
                         },
                     )))));
                 }
@@ -199,6 +203,7 @@ pub(super) fn dispatch(
                     coroutine: None,
                     lazy_pipe: None,
                     closure_seq: None,
+                    walk_pending: None,
                 },
             )))))
         }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -511,6 +511,7 @@ impl Interpreter {
             coroutine: None,
             lazy_pipe: None,
             closure_seq: None,
+            walk_pending: None,
         };
         Value::LazyList(std::sync::Arc::new(list))
     }

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -299,8 +299,53 @@ impl Interpreter {
         if reversed {
             order.reverse();
         }
-        let mut results: Vec<Value> = Vec::with_capacity(order.len());
-        for tag in &order {
+        // Rakudo invokes WALK candidates LAZILY: return a lazy list whose Nth pull
+        // invokes the Nth MRO-level candidate (so `for WALK("foo")() { ... }` calls
+        // exactly one method per iteration). `force_walk_pending` does the per-pull
+        // call — nothing is invoked here.
+        let mut ll = crate::value::LazyList::new_cached(Vec::new());
+        ll.walk_pending = Some(std::sync::Mutex::new(crate::value::WalkPendingState {
+            receiver_class,
+            method_name,
+            targets: order,
+            args,
+            invocant,
+            attributes: attributes_map,
+            quiet,
+            idx: 0,
+        }));
+        Ok(Value::LazyList(std::sync::Arc::new(ll)))
+    }
+
+    /// Pull up to `needed` elements of a lazy `WALK(method)()` list by invoking
+    /// the next MRO-level candidate(s) on demand (one method call per element).
+    pub(crate) fn force_walk_pending(
+        &mut self,
+        list: &crate::value::LazyList,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        // Snapshot the immutable state + current index, releasing the lock before
+        // any re-entrant method call (`run_resolved_method` needs `&mut self`).
+        let (receiver_class, method_name, targets, args, invocant, attributes, quiet, mut idx) = {
+            let st = list.walk_pending.as_ref().unwrap().lock().unwrap();
+            (
+                st.receiver_class.clone(),
+                st.method_name.clone(),
+                st.targets.clone(),
+                st.args.clone(),
+                st.invocant.clone(),
+                st.attributes.clone(),
+                st.quiet,
+                st.idx,
+            )
+        };
+        let mut produced: Vec<Value> = {
+            let cache = list.cache.lock().unwrap();
+            cache.as_ref().cloned().unwrap_or_default()
+        };
+        while produced.len() < needed && idx < targets.len() {
+            let tag = targets[idx].clone();
+            idx += 1;
             let (kind, owner) = match tag.split_once('|') {
                 Some(("C", o)) => (WalkKind::Class, o.to_string()),
                 Some(("R", o)) => (WalkKind::Role, o.to_string()),
@@ -311,22 +356,27 @@ impl Interpreter {
             else {
                 continue;
             };
-            let call = self.run_resolved_method_compiled_or_treewalk(
+            match self.run_resolved_method_compiled_or_treewalk(
                 &receiver_class,
                 &owner,
                 &method_name,
                 method_def,
-                attributes_map.clone(),
+                attributes.clone(),
                 args.clone(),
                 Some(invocant.clone()),
-            );
-            match call {
-                Ok((v, _)) => results.push(v),
-                Err(e) if quiet => results.push(self.fail_error_to_failure_value(&e)),
+            ) {
+                Ok((v, _)) => produced.push(v),
+                Err(e) if quiet => produced.push(self.fail_error_to_failure_value(&e)),
                 Err(e) => return Err(e),
             }
         }
-        Ok(Value::real_array(results))
+        list.walk_pending.as_ref().unwrap().lock().unwrap().idx = idx;
+        *list.cache.lock().unwrap() = Some(produced.clone());
+        Ok(if produced.len() >= needed {
+            produced[..needed].to_vec()
+        } else {
+            produced
+        })
     }
 
     /// Dispatch a method call on a `WalkList` instance. Returns `Ok(None)` for

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -639,6 +639,10 @@ impl Interpreter {
                             .closure_seq
                             .as_ref()
                             .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
+                        walk_pending: list
+                            .walk_pending
+                            .as_ref()
+                            .map(|w| std::sync::Mutex::new(w.lock().unwrap().clone())),
                     }))
                 } else {
                     v

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1245,6 +1245,23 @@ pub(crate) struct GatherCoroutineState {
     pub(crate) for_loop_resume: Option<ForLoopResumeState>,
 }
 
+/// Lazy `WALK(method)` invocation state. `$obj.WALK("foo")()` walks the MRO
+/// calling each level's own `foo` ONE AT A TIME as the result list is pulled
+/// (Rakudo: the calls are lazy — `for WALK("foo")() { ... }` invokes the Nth
+/// candidate on the Nth iteration). `targets` holds the resolved per-level
+/// candidates (`"C|Owner"` / `"R|Owner"` tags); `idx` is the next to invoke.
+#[derive(Debug, Clone)]
+pub(crate) struct WalkPendingState {
+    pub(crate) receiver_class: String,
+    pub(crate) method_name: String,
+    pub(crate) targets: Vec<String>,
+    pub(crate) args: Vec<Value>,
+    pub(crate) invocant: Value,
+    pub(crate) attributes: std::collections::HashMap<String, Value>,
+    pub(crate) quiet: bool,
+    pub(crate) idx: usize,
+}
+
 pub(crate) struct LazyList {
     pub(crate) body: Vec<Stmt>,
     pub(crate) env: Env,
@@ -1273,6 +1290,9 @@ pub(crate) struct LazyList {
     /// When present, more elements are produced on demand by re-invoking the
     /// generator closure over the growing element history.
     pub(crate) closure_seq: Option<Mutex<ClosureSeqState>>,
+    /// Lazy `WALK(method)()` candidate-invocation state (see `WalkPendingState`):
+    /// each pull invokes the next MRO-level candidate.
+    pub(crate) walk_pending: Option<Mutex<WalkPendingState>>,
 }
 
 /// Placeholder string rendered for a genuinely-lazy list under

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -37,6 +37,10 @@ impl Clone for LazyList {
                 .closure_seq
                 .as_ref()
                 .map(|c| Mutex::new(c.lock().unwrap().clone())),
+            walk_pending: self
+                .walk_pending
+                .as_ref()
+                .map(|w| Mutex::new(w.lock().unwrap().clone())),
         }
     }
 }
@@ -96,9 +100,10 @@ impl LazyList {
     }
 
     /// Gate for the VM force/incremental-pull dispatch block: a gather-sourced
-    /// list (eager or `lazy`) or an infinite sequence/closure spec.
+    /// list (eager or `lazy`), an infinite sequence/closure spec, or a lazy
+    /// `WALK(method)()` candidate-invocation list.
     pub(crate) fn needs_vm_lazy_dispatch(&self) -> bool {
-        self.is_from_gather() || self.is_infinite_spec()
+        self.is_from_gather() || self.is_infinite_spec() || self.walk_pending.is_some()
     }
 
     /// Whether this list carries the `lazy` prefix marker (set by the `lazy`
@@ -154,6 +159,7 @@ impl LazyList {
             coroutine: None,
             lazy_pipe: None,
             closure_seq: None,
+            walk_pending: None,
         }
     }
 
@@ -171,6 +177,7 @@ impl LazyList {
             coroutine: None,
             lazy_pipe: None,
             closure_seq: None,
+            walk_pending: None,
         }
     }
 
@@ -188,6 +195,7 @@ impl LazyList {
             coroutine: None,
             lazy_pipe: None,
             closure_seq: None,
+            walk_pending: None,
         }
     }
 
@@ -222,6 +230,7 @@ impl LazyList {
                 index_transform: None,
             })),
             closure_seq: None,
+            walk_pending: None,
         }
     }
 
@@ -260,6 +269,7 @@ impl LazyList {
                 index_transform: Some(transform),
             })),
             closure_seq: None,
+            walk_pending: None,
         }
     }
 
@@ -281,6 +291,7 @@ impl LazyList {
             coroutine: None,
             lazy_pipe: None,
             closure_seq: Some(Mutex::new(state)),
+            walk_pending: None,
         }
     }
 

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -130,7 +130,10 @@ impl Interpreter {
         // iterables, iterate lazily by pulling items one at a time. This avoids
         // materializing infinite sequences.
         if let Value::LazyList(ref ll) = iterable
-            && (ll.coroutine.is_some() || ll.sequence_spec.is_some() || ll.lazy_pipe.is_some())
+            && (ll.coroutine.is_some()
+                || ll.sequence_spec.is_some()
+                || ll.lazy_pipe.is_some()
+                || ll.walk_pending.is_some())
         {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -167,6 +167,12 @@ impl Interpreter {
     }
 
     fn force_lazy_list_vm_inner(&mut self, list: &LazyList) -> Result<Vec<Value>, RuntimeError> {
+        // A lazy `WALK(method)()` list is finite (one element per MRO-level
+        // candidate): force them all by invoking every remaining candidate.
+        if let Some(ref wp) = list.walk_pending {
+            let total = wp.lock().unwrap().targets.len();
+            return self.force_walk_pending(list, total);
+        }
         // Handle scan-based lazy lists: compute elements on demand
         if list.scan_spec.is_some() {
             return self.force_scan_lazy_list(list, 200_000);

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -16,6 +16,12 @@ impl Interpreter {
             }
         }
 
+        // Lazy `WALK(method)()`: invoke the next MRO-level candidate(s) on demand,
+        // one method call per pulled element (Rakudo's lazy WALK semantics).
+        if list.walk_pending.is_some() {
+            return self.force_walk_pending(list, needed);
+        }
+
         // For sequence-spec lazy lists, generate more elements on demand
         if let Some(ref spec) = list.sequence_spec {
             return Self::extend_sequence_cache(list, spec, needed);

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -53,6 +53,7 @@ impl Interpreter {
                 })),
                 lazy_pipe: None,
                 closure_seq: None,
+                walk_pending: None,
             };
             let val = Value::LazyList(std::sync::Arc::new(list));
             self.stack.push(val);

--- a/t/walk-lazy.t
+++ b/t/walk-lazy.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 5;
+
+# `WALK(method)()` invokes the MRO-level candidates LAZILY — one method call per
+# pulled element (Rakudo). `for $obj.WALK("foo")() { ... }` calls exactly one
+# candidate per iteration; assigning the result to an `@`-array reifies (eager).
+
+my class C1 {
+    has $.calls is rw = 0;
+    has @.order;
+    method foo { ++$.calls; @.order.push: 'C1' }
+}
+my class C2 is C1 {
+    method foo { ++$.calls; @.order.push: 'C2' }
+}
+my class C3 is C2 {
+    method foo { ++$.calls; @.order.push: 'C3' }
+}
+
+# Lazy: the Nth iteration triggers exactly the Nth candidate call.
+my $obj = C3.new;
+my @seen-counts;
+my $step = 0;
+for $obj.WALK("foo")() {
+    ++$step;
+    @seen-counts.push: $obj.calls;
+}
+is $step, 3, 'WALK("foo")() yields one element per MRO level';
+is-deeply @seen-counts, [1, 2, 3], 'each iteration invoked exactly one more candidate';
+is-deeply $obj.order, ['C3', 'C2', 'C1'], 'candidates invoked most-derived first';
+
+# Eager reification into an @-array forces all candidates.
+my class A { method m { 1 } }
+my class B is A { method m { 2 } }
+my @r = B.new.WALK("m")();
+is @r.elems, 2, 'WALK result reifies to an array eagerly';
+is-deeply @r, [2, 1], 'eager WALK collects all candidate results';


### PR DESCRIPTION
## What

`$obj.WALK("foo")()` previously invoked every MRO-level candidate **eagerly** when called, returning a strict array. Rakudo invokes them **lazily**: `for WALK("foo")() { ... }` calls exactly one candidate per iteration (so `$obj.call-count` equals the step number at each step).

Closes roast **`S12-introspection/walk.t`** (the "Lazyness" subtest).

## Implementation

A new `LazyList` source kind `walk_pending` (`WalkPendingState`) holds the resolved per-level candidate tags + invocant/args; each pull invokes the next candidate's own method via the existing `run_resolved_method_compiled_or_treewalk`. `walk_list_invoke_direct` now builds this lazy list instead of looping eagerly.

Wired into the lazy infrastructure:
- `force_lazy_list_vm_n_inner` (incremental pull, for `for`-loops) and `force_lazy_list_vm_inner` (full force, for `@`-reification) both gain a `walk_pending` arm; the for-loop lazy gate and `needs_vm_lazy_dispatch` recognize it.
- WALK is finite, so it is **not** `is_genuinely_lazy` — assigning to an `@`-array reifies eagerly (`my @r = B.WALK("m")()` collects all results), while a bare `for` pulls one at a time.

## Tests

`t/walk-lazy.t` (per-iteration call count, MRO order, eager `@`-reification). `make test` (13105) + `make roast` (211217) green; `walk.t` added to whitelist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)