### PR TITLE
feat(exceptions): X::Redeclaration for duplicate sub/token in a type body

### DIFF
--- a/TODO_roast/S10.md
+++ b/TODO_roast/S10.md
@@ -1,6 +1,21 @@
 # S10 - packages
 
 - [ ] roast/S10-packages/basic.t
+  - 169/183 pass (was 165). **2026-06-29: tests 33-36 fixed** — a duplicate
+    non-`multi` `sub` (or `token`/`regex`) declared inside a class / grammar /
+    package / module body now throws X::Redeclaration on the EVAL/throws-like
+    compile path (`dup_routine_in_body` in `check_eval_class_redeclarations`,
+    wired into the ClassDecl/RoleDecl/Package arms; grammar tokens land in a
+    ClassDecl body). t/redeclaration-in-body.t.
+  - Remaining 14 fails are deeper / different roots:
+    - 12-21 (reference to grammar/module/role/class/package BEFORE definition
+      dies + name in message): compile-time post-declared-type detection. mutsu
+      has no general compile-time undeclared-symbol check, and the EVAL-path
+      registry check is gated to `::`-qualified names because simple names leak
+      into the global registry from block-scoped decls (the lexical-scope-leak
+      / dual-store limitation — same family as my-6e.t / allomorphic.t).
+    - 2 / 30 (nested-package autovivification), 53 (`module M is Nonexistent`),
+      57 (`Too late for semicolon form`): each its own package-semantics gap.
 - [ ] roast/S10-packages/export.t
 - [ ] roast/S10-packages/joined-namespaces.t
 - [ ] roast/S10-packages/nested-use.t

--- a/src/runtime/system_eval_redecl.rs
+++ b/src/runtime/system_eval_redecl.rs
@@ -92,6 +92,68 @@ impl Interpreter {
             None
         };
 
+        // Within one class/grammar/package/module body, two non-`multi` `sub`s
+        // (or two `token`s/`regex`es) of the same name are an X::Redeclaration,
+        // just like at the top level. (`my`/`our`-scoped methods/tokens are
+        // covered by `dup_scoped_method`; this covers plain `sub`/`token`.)
+        let dup_routine_in_body = |body: &[Stmt]| -> Option<RuntimeError> {
+            let mut seen_subs: HashMap<String, bool> = HashMap::new();
+            let mut seen_tokens: HashSet<String> = HashSet::new();
+            for s in body {
+                match s {
+                    Stmt::SubDecl { name, multi, .. } => {
+                        let n = name.resolve().to_string();
+                        if n.is_empty() {
+                            continue;
+                        }
+                        match seen_subs.get(&n) {
+                            None => {
+                                seen_subs.insert(n, *multi);
+                            }
+                            Some(prev_all_multi) => {
+                                if *prev_all_multi && *multi {
+                                    // all-multi so far: still allowed
+                                } else {
+                                    let mut attrs = std::collections::HashMap::new();
+                                    attrs.insert("symbol".to_string(), Value::str(n.clone()));
+                                    attrs.insert(
+                                        "what".to_string(),
+                                        Value::str("routine".to_string()),
+                                    );
+                                    attrs.insert(
+                                        "message".to_string(),
+                                        Value::str(format!(
+                                            "Redeclaration of routine '{}'. Did you mean to declare a multi-sub?",
+                                            n
+                                        )),
+                                    );
+                                    return Some(RuntimeError::typed("X::Redeclaration", attrs));
+                                }
+                            }
+                        }
+                    }
+                    Stmt::TokenDecl { name, .. } => {
+                        let n = name.resolve().to_string();
+                        if n.is_empty() {
+                            continue;
+                        }
+                        if !seen_tokens.insert(n.clone()) {
+                            let mut attrs = std::collections::HashMap::new();
+                            attrs.insert("symbol".to_string(), Value::str(n.clone()));
+                            attrs.insert("what".to_string(), Value::str("regex".to_string()));
+                            attrs.insert(
+                                "message".to_string(),
+                                Value::str(format!("Redeclaration of regex '{}'", n)),
+                            );
+                            return Some(RuntimeError::typed("X::Redeclaration", attrs));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            None
+        };
+
         let type_redeclaration = |name: &str| -> RuntimeError {
             let mut attrs = std::collections::HashMap::new();
             attrs.insert("symbol".to_string(), Value::str(name.to_string()));
@@ -177,6 +239,9 @@ impl Interpreter {
                     if let Some(err) = dup_scoped_method(body) {
                         return Err(err);
                     }
+                    if let Some(err) = dup_routine_in_body(body) {
+                        return Err(err);
+                    }
                     let name = name.resolve().to_string();
                     // X::TooLateForREPR: the repr must be fixed at the initial
                     // declaration. If an earlier declaration of this class had a
@@ -219,6 +284,9 @@ impl Interpreter {
                     if let Some(err) = dup_scoped_method(body) {
                         return Err(err);
                     }
+                    if let Some(err) = dup_routine_in_body(body) {
+                        return Err(err);
+                    }
                     (name.resolve().to_string(), body_is_stub(body))
                 }
                 Stmt::SubsetDecl { name, .. } => (name.resolve().to_string(), false),
@@ -238,6 +306,17 @@ impl Interpreter {
                         seen_types.insert(vname.clone(), false);
                     }
                     (name.resolve().to_string(), false)
+                }
+                Stmt::Package { body, .. } => {
+                    // `package`/`module` bodies: a duplicate `sub` is the same
+                    // X::Redeclaration as inside a class. (The package name itself
+                    // shares the type namespace, but block-scoped leakage makes a
+                    // registry-based check unsafe, so only the in-body routine
+                    // check runs here.)
+                    if let Some(err) = dup_routine_in_body(body) {
+                        return Err(err);
+                    }
+                    continue;
                 }
                 _ => continue,
             };

--- a/t/redeclaration-in-body.t
+++ b/t/redeclaration-in-body.t
@@ -1,0 +1,26 @@
+use Test;
+
+# A duplicate non-multi `sub` (or `token`/`regex`) declared inside a
+# class / grammar / package / module body is an X::Redeclaration, just like at
+# the top level. (Detected on the EVAL / throws-like compile path.)
+
+throws-like q[class A { sub a { 1 }; sub a { 1 } }],
+    X::Redeclaration, 'sub redeclared in class dies';
+throws-like q[package P { sub p { 1 }; sub p { 1 } }],
+    X::Redeclaration, 'sub redeclared in package dies';
+throws-like q[module M { sub m { 1 }; sub m { 1 } }],
+    X::Redeclaration, 'sub redeclared in module dies';
+throws-like q[grammar G { token b { 'b' }; token b { 'b' } }],
+    X::Redeclaration, 'token redeclared in grammar dies';
+
+# A `multi sub` may be repeated; mixing multi and non-multi may not.
+lives-ok { EVAL q[class OK { multi sub f($x) { 1 }; multi sub f($x, $y) { 2 } }] },
+    'multi subs of the same name in a class are allowed';
+throws-like q[class Bad { sub g { 1 }; multi sub g { 2 } }],
+    X::Redeclaration, 'sub then multi sub of the same name dies';
+
+# A single sub is fine.
+lives-ok { EVAL q[class Fine { sub h { 1 } }] },
+    'a single sub in a class is fine';
+
+done-testing;


### PR DESCRIPTION
## Summary

A duplicate non-`multi` `sub` (or `token`/`regex`) declared inside a class / grammar / package / module body is an `X::Redeclaration` in raku, just like at the top level. mutsu only detected top-level routine redeclaration, so `class A { sub a {}; sub a {} }` silently compiled.

Add `dup_routine_in_body` to the EVAL/throws-like compile-time check (`check_eval_class_redeclarations`): it flags a second non-multi `sub` of the same name (`X::Redeclaration`, "Did you mean to declare a multi-sub?") and a duplicate `token`/`regex`. Wired into the `ClassDecl`, `RoleDecl` and `Package` arms (grammar tokens land in a `ClassDecl` body; package/module bodies are `Stmt::Package`). `multi` subs may still repeat; mixing multi and non-multi dies.

## Result
- `S10-packages/basic.t` tests 33-36 now pass (**165 → 169/183**).
- Remaining fails are the compile-time post-declared-type cluster (12-21, blocked on the lexical-scope leak / dual-store limitation) and assorted package-semantics gaps, documented in `TODO_roast/S10.md`.
- `make test` (13186) + `make roast` (211220) green; no regressions.

## Tests
- `t/redeclaration-in-body.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)