### PR TITLE
feat(capture): Channel/Supply/non-Str-key List .Capture + .&-call Pair invocant positional

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -240,14 +240,29 @@
   - 38/69 pass (67 reached). Only 2 failures: test 37 (`Bool::True.but`), test 39 (`Bool::False.but`) — `.but` mixin not implemented on Bool
 - [x] roast/S02-types/built-in.t
 - [ ] roast/S02-types/capture.t
-  - Failed 0 (still aborts at test 33, so not whitelistable). FIXED: (28-29)
-    Capture element container binding — `\($a)`/`\(:$a)` now capture the
-    variable's `ContainerRef` cell, so `$c[0]++`/`$c<a>++` write through to the
-    original (CaptureLiteral tags scalar-var elements with WrapVarRef; MakeCapture
-    boxes the named local; the inc/dec-index op increments through a Capture
-    element cell). Still blocked from whitelist by (31) `(1..*).list.Capture`
-    needing X::Cannot::Lazy (real lazy infinite sequences — mutsu materializes
-    `1..*`) and the post-33 abort that follows it.
+  - 44/46 (Failed 2: subtests 39, 41). FIXED (campaign): interpreter-aware
+    `.Capture` for Channel/Supply (drains the source to a list first) and for a
+    List/Array/Seq holding a non-Str `Pair` key (stringifies the key via its
+    `.Str`, so a custom-class key uses its `method Str`) — `try_interpreter_capture`
+    in methods_call_dispatch.rs, dispatched ahead of the pure `value_to_capture`.
+    Also fixed `.&sub(...)` invocant binding: a literal-colonpair invocant
+    (`:42foo.&f`) is now bound positionally (containerized Pair→ValuePair) instead
+    of splatting into a named argument (general dispatch fix, both
+    CallMethodDynamic and CallMethodDynamicMut Sub branches).
+  - Remaining blockers (both deep, neither whitelistable in this slice):
+    - subtest 39 (`types whose .Capture throws`): `((*)).Capture` /
+      `((*.so)).Capture` must throw X::Cannot::Capture, but mutsu does not
+      terminate Whatever-currying at the parens — `((*))` stays a WhateverCode
+      curry instead of becoming a plain `Whatever`/`WhateverCode` value. Parser-
+      level Whatever-curry termination, separate from Capture.
+    - subtest 41 (`behaves like Mu.Capture`): Mu.Capture on an Instance must
+      return its public attributes as named args (exception `source`, DateTime
+      `year`/`month`/`day`, Duration/Instant `tai`, Promise `status`, ...). mutsu
+      wraps an Instance as a single positional. Native types have NO registered
+      MOP attributes (`.^attributes` empty) and some store state under internal
+      keys that differ from the raku attribute name (Instant/Duration: internal
+      `value` vs raku `tai`), so a generic attribute-map dump is insufficient —
+      this is the "make native types introspectable" main-track work.
 - [ ] roast/S02-types/catch_type_cast_mismatch.t
   - 9/11 pass. Test 3: `[0]` on non-Positional should return self. Test 5: accessing array as hash should fail (throws-like)
 - [ ] roast/S02-types/compact.t

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2469,6 +2469,17 @@ impl Interpreter {
                 _ => None,
             }
         };
+        // `.Capture` on targets that must call user methods or drain a live source
+        // (a `Channel`/`Supply` drains to a list; a List/Array/Seq with a non-Str
+        // Pair key stringifies the key via its `.Str`). The pure native fast path
+        // (`value_to_capture`) handles every other target.
+        if method == "Capture"
+            && args.is_empty()
+            && !bypass_native_fastpath
+            && let Some(r) = self.try_interpreter_capture(&target)
+        {
+            return r;
+        }
         if method == "tail"
             && !bypass_native_fastpath
             && !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply")
@@ -3239,5 +3250,63 @@ impl Interpreter {
 
         // Instance dispatch, package dispatch, and fallback paths
         self.dispatch_instance_and_fallback(target, method, args)
+    }
+
+    /// Interpreter-aware `.Capture` for targets the pure `value_to_capture` can't
+    /// handle: a `Channel`/`Supply` drains to a list first, and a List/Array/Seq
+    /// holding a non-Str `Pair` key needs `.Str` (a custom-class key uses its
+    /// `method Str`) to name it. Returns `None` for every other target (the pure
+    /// native fast path handles those).
+    pub(crate) fn try_interpreter_capture(
+        &mut self,
+        target: &Value,
+    ) -> Option<Result<Value, RuntimeError>> {
+        match target {
+            Value::Channel(_) => Some(
+                self.call_method_with_values(target.clone(), "list", vec![])
+                    .and_then(|list| self.list_to_capture(&list)),
+            ),
+            Value::Instance { class_name, .. } if class_name.resolve() == "Supply" => Some(
+                // `.Seq` taps the supply and collects its emissions (`.list` does
+                // not run an on-demand `supply { ... }` block).
+                self.call_method_with_values(target.clone(), "Seq", vec![])
+                    .and_then(|seq| self.list_to_capture(&seq)),
+            ),
+            Value::Array(..) | Value::Seq(_) | Value::Slip(_) => {
+                let needs_str_key = Self::value_to_list(target).iter().any(
+                    |i| matches!(i, Value::ValuePair(k, _) if !matches!(k.as_ref(), Value::Str(_))),
+                );
+                needs_str_key.then(|| self.list_to_capture(target))
+            }
+            _ => None,
+        }
+    }
+
+    /// Build a Capture from a list: each `Pair` becomes a named argument (its key
+    /// stringified via `.Str`, so a custom-class key uses its `method Str`), every
+    /// other element a positional. Mirrors `List.Capture`.
+    fn list_to_capture(&mut self, list: &Value) -> Result<Value, RuntimeError> {
+        let items = Self::value_to_list(list);
+        let mut positional = Vec::new();
+        let mut named = std::collections::HashMap::new();
+        for item in items {
+            match item {
+                Value::Pair(k, v) => {
+                    named.insert(k, *v);
+                }
+                Value::ValuePair(k, v) => {
+                    let key_str = match k.as_ref() {
+                        Value::Str(s) => s.to_string(),
+                        other => self
+                            .call_method_with_values(other.clone(), "Str", vec![])
+                            .map(|s| s.to_string_value())
+                            .unwrap_or_else(|_| other.to_string_value()),
+                    };
+                    named.insert(key_str, *v);
+                }
+                other => positional.push(other),
+            }
+        }
+        Ok(Value::capture(positional, named))
     }
 }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -3,6 +3,18 @@ use crate::symbol::Symbol;
 use std::sync::Arc;
 
 impl Interpreter {
+    /// The invocant of a `.&sub(...)` call is always bound positionally to the
+    /// sub's first parameter, even when it is a literal colonpair (`:42foo.&f`).
+    /// A bare `Value::Pair` in an argument list is otherwise splatted into a
+    /// named argument, so containerize a Pair invocant into a positional
+    /// `ValuePair` (the same conversion `OpCode::ContainerizePair` performs).
+    fn invocant_as_positional(target: Value) -> Value {
+        match target {
+            Value::Pair(k, v) => Value::ValuePair(Box::new(Value::str(k)), v),
+            other => other,
+        }
+    }
+
     pub(super) fn exec_call_method_dynamic_op(
         &mut self,
         code: &CompiledCode,
@@ -64,7 +76,7 @@ impl Interpreter {
             Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
         ) {
             let mut call_args = Vec::with_capacity(args.len() + 1);
-            call_args.push(target);
+            call_args.push(Self::invocant_as_positional(target));
             call_args.extend(args);
             self.vm_call_on_value(name_val, call_args, None)
         } else {
@@ -292,7 +304,7 @@ impl Interpreter {
             Value::Sub(_) | Value::WeakSub(_) | Value::Routine { .. }
         ) {
             let mut call_args = Vec::with_capacity(args.len() + 1);
-            call_args.push(target);
+            call_args.push(Self::invocant_as_positional(target));
             call_args.extend(args);
             self.vm_call_on_value(name_val, call_args, None)
         } else if modifier.is_none()

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -35,6 +35,15 @@ impl Interpreter {
             }
         }
         let method_name = method_sym.resolve();
+        // `.Capture` that must call user methods / drain a live source (Channel/
+        // Supply, or a non-Str Pair key needing `.Str`) is interpreter-aware; other
+        // targets fall through to the pure native `value_to_capture` below.
+        if method_name == "Capture"
+            && args.is_empty()
+            && let Some(r) = self.try_interpreter_capture(target)
+        {
+            return Some(r);
+        }
         // A `.map`/`.grep` on a lazy source that the interpreter would turn into
         // a lazy pipeline stage (a chained map/grep pipe, an infinite sequence, or
         // a genuinely-lazy `gather { … }.lazy`) must be deferred to the interpreter

--- a/t/capture-channel-supply-amp-invocant.t
+++ b/t/capture-channel-supply-amp-invocant.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 11;
+
+# Channel.Capture drains the channel to a list: Pair elements become nameds,
+# the rest positionals.
+{
+    my $c = Channel.new;
+    $c.send: $_ for |<a b c>, :42z;
+    $c.close;
+    is-deeply $c.Capture, \('a', 'b', 'c', :42z), 'Channel.Capture';
+}
+
+# Supply.Capture taps the supply (running an on-demand `supply { }` block) and
+# collects its emissions.
+is-deeply (supply { .emit for |<a b c>, :42z }).Capture, \('a', 'b', 'c', :42z),
+    'Supply.Capture';
+
+# A List holding a non-Str Pair key stringifies the key via its `.Str` (a
+# custom-class key uses its `method Str`).
+is-deeply (class { method Str { 'foo' } } => 42,).Capture, \(:foo(42)),
+    'List with custom-class Pair key .Capture';
+
+is-deeply (<10> => <20>, 30 => 40).Capture, ('10' => <20>, '30' => 40).Capture,
+    'List with allomorph/numeric Pair keys .Capture';
+
+# A `.&sub(...)` call binds its invocant positionally, even when the invocant is
+# a literal colonpair (which would otherwise splat into a named argument).
+{
+    sub f(\what, $d = 'def') { "{what.raku}|$d" }
+    is :42foo.&f('Pair'), ':foo(42)|Pair', 'literal colonpair invocant is positional';
+
+    my $p = :42foo;
+    is $p.&f('Pair'), ':foo(42)|Pair', 'Pair-valued variable invocant is positional';
+
+    # A Pair-valued invocant that does reach a real named param still works.
+    sub g(\what, :$tag) { "{what.raku}|{$tag // 'none'}" }
+    is :42foo.&g(:tag<x>), ':foo(42)|x', 'invocant positional, explicit named separate';
+}
+
+# `.&method` invocant that is NOT a Pair is unaffected.
+{
+    sub h(\what) { what * 2 }
+    is 21.&h, 42, 'Int invocant via .& unaffected';
+    is 'ab'.&({ $^x ~ $^x }), 'abab', 'Str invocant via .& block unaffected';
+}
+
+# `.&` invocant with a mutating sub (CallMethodDynamicMut path).
+{
+    my @log;
+    sub note-it(\what) { @log.push: what.raku; what }
+    :1a.&note-it;
+    is-deeply @log, [':a(1)'], 'mutating .& path keeps Pair invocant positional';
+}
+
+# A regular method call on a Pair is unaffected (sanity).
+is :42foo.key, 'foo', 'plain method call on a Pair still works';


### PR DESCRIPTION
## Summary

Three related Capture fixes that take roast `S02-types/capture.t` from 42/46 to **44/46** subtests.

### 1. Interpreter-aware `.Capture` for live sources and non-Str Pair keys
The pure native `value_to_capture` cannot drain a live source or call a user method. A new `try_interpreter_capture`, dispatched ahead of the native fast path in both the runtime and VM native-dispatch sites, handles:
- **`Channel.Capture`** — drains the channel to a list (Pair elements → nameds, rest → positionals).
- **`Supply.Capture`** — taps the supply via `.Seq` (so an on-demand `supply { ... }` block actually runs) and collects emissions.
- **List/Array/Seq with a non-Str `Pair` key** — stringifies the key via its `.Str`, so a custom-class key uses its `method Str`.

### 2. `.&sub(...)` invocant binds positionally
`:42foo.&f(...)` now binds the literal-colonpair invocant positionally to the sub's first parameter, instead of splatting it into a named argument. The invocant is containerized `Pair → ValuePair` (the same conversion `OpCode::ContainerizePair` performs) in both the `CallMethodDynamic` and `CallMethodDynamicMut` Sub branches. This is a **general dispatch correctness fix**, not specific to Capture.

Before: `:42foo.&f("Pair")` → `Calling f(Str) will never work ... Unexpected named argument 'foo' passed`
After: binds `\what = :foo(42)`, matching Rakudo.

## Remaining capture.t blockers (deep, not in this slice)
- **subtest 39** — `((*)).Capture` must throw `X::Cannot::Capture`; mutsu does not terminate Whatever-currying at the parens (parser-level).
- **subtest 41** — `Mu.Capture` must return an Instance's public attributes as nameds; native types have no registered MOP attributes and some store state under internal keys (`value` vs raku `tai`), so this is the "make native types introspectable" main-track work.

Both recorded in `TODO_roast/S02.md`.

## Testing
- Pin: `t/capture-channel-supply-amp-invocant.t` (11 cases).
- `make test`: All tests successful (Files=1341, Tests=13180).
- `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)