### PR TITLE
feat(array): BIND-POS installs a shared container cell aliasing the source variable

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -97,8 +97,19 @@
 - [ ] roast/S32-basics/xxPOS-native.t
 - [ ] roast/S32-basics/xxPOS.t
   - 11/64 pass (1-11). BIND-POS and DELETE-POS now implemented for non-native arrays.
-  - Blocker 1: Sigilless variable naming collision -- `my $a` inside `for ... -> \a` overwrites sigilless `a` because both map to env key `a` (mutsu strips `$` prefix from scalar variables). Causes crash at test 12. Architectural fix required.
-  - Blocker 2: True container binding for BIND-POS not implemented -- changing `$b` after `.BIND-POS(0,$b)` should reflect in array element. Requires shared mutable container (e.g., `Rc<RefCell<Value>>`). Tests 14, 17, 35, 38.
+  - Blocker 1 (file-stopper at test 12): Sigilless variable naming collision -- `my $a`
+    inside `for ... -> \a` overwrites sigilless `a` because both map to env key `a`
+    (mutsu strips the `$` prefix from scalar variables, and a sigilless `\a` declaration
+    has no raw/sigilless flag on `Stmt::VarDecl` to key it distinctly). `a.^name` then
+    returns the scalar's type and `a.BIND-POS` dies with "No such method ... for Int".
+    Minimal repro: `my \a = (1,2,3); my $a = 45; say a;` -> mutsu `45`, raku `(1 2 3)`.
+    Architectural: needs a sigilless-var identity distinct from the sigil-stripped scalar
+    key (parser flag on VarDecl + distinct env keying + sigilless read resolution).
+  - Blocker 2: True container binding for BIND-POS -- DONE. `@a.BIND-POS($i, $x)` now
+    installs a shared `ContainerRef` cell aliasing the caller variable `$x` (mirrors
+    the existing `%h.BIND-KEY` path), so a later `$x = ...` writes through to `@a[$i]`
+    and vice versa. Pin: t/bind-pos-shared-cell.t. (Still gated from whitelist by
+    Blocker 1, which aborts the file before these asserts run in-file.)
   - Blocker 3: Tests 43-53 require xxPOS methods on undefined `$a` (auto-vivification to Array).
   - Blocker 4: Tests 54-58 `#?rakudo skip` block (BIND-POS on Any:U). Even raku fails here.
   - Blocker 5: Tests 61-63 multi-dimensional EXISTS-POS with Failure from negative index.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1360,10 +1360,8 @@ impl Interpreter {
                         updated.resize(i + 1, Value::Package(Symbol::intern("Any")));
                     }
                     updated[i] = Value::ContainerRef(cell);
-                    let new_array = Value::Array(
-                        Arc::new(crate::value::ArrayData::new(updated)),
-                        *arr_kind,
-                    );
+                    let new_array =
+                        Value::Array(Arc::new(crate::value::ArrayData::new(updated)), *arr_kind);
                     self.env_mut().insert(target_name.to_string(), new_array);
                     if let Some((source_name, cell_val)) = bind_source_install {
                         self.set_env_with_main_alias(&source_name, cell_val.clone());

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1313,6 +1313,66 @@ impl Interpreter {
                     _ => {}
                 }
             }
+            // `@a.BIND-POS($i, $x)` binds element `$i` to the caller variable
+            // `$x` as a shared `ContainerRef` cell — the array analog of
+            // BIND-KEY above. A later `$x = ...` writes through to `@a[$i]` (and
+            // vice versa). Only the single-index plain-`Array` case with a scalar
+            // *variable* source is handled here; a literal source (no var) and
+            // multi-dimensional BIND-POS fall through to the slow path, which
+            // stores the immutable `Value::Scalar` bind marker.
+            "BIND-POS"
+                if args.len() == 2
+                    && matches!(&target, Value::Array(..))
+                    && arg_sources
+                        .as_ref()
+                        .and_then(|s| s.get(1))
+                        .and_then(|s| s.as_ref())
+                        .is_some_and(|n| !n.contains('\0')) =>
+            {
+                if let Value::Array(items, arr_kind) = &target
+                    && let Some(i) = match &args[0] {
+                        Value::Int(n) if *n >= 0 => Some(*n as usize),
+                        Value::Num(f) if *f >= 0.0 => Some(*f as usize),
+                        _ => None,
+                    }
+                {
+                    let source_var = arg_sources
+                        .as_ref()
+                        .and_then(|s| s.get(1))
+                        .and_then(|s| s.clone())
+                        .expect("arg_sources[1] present per match guard");
+                    let value = args[1].clone();
+                    // Reuse the source variable's existing cell when it is already
+                    // cell-bound (so all aliases stay shared); otherwise install a
+                    // fresh cell back into the source var.
+                    let mut bind_source_install: Option<(String, Value)> = None;
+                    let cell = match self.env().get(&source_var) {
+                        Some(Value::ContainerRef(cell)) => cell.clone(),
+                        _ => {
+                            let cell = Arc::new(std::sync::Mutex::new(value.clone()));
+                            bind_source_install =
+                                Some((source_var, Value::ContainerRef(cell.clone())));
+                            cell
+                        }
+                    };
+                    let mut updated = items.to_vec();
+                    if i >= updated.len() {
+                        updated.resize(i + 1, Value::Package(Symbol::intern("Any")));
+                    }
+                    updated[i] = Value::ContainerRef(cell);
+                    let new_array = Value::Array(
+                        Arc::new(crate::value::ArrayData::new(updated)),
+                        *arr_kind,
+                    );
+                    self.env_mut().insert(target_name.to_string(), new_array);
+                    if let Some((source_name, cell_val)) = bind_source_install {
+                        self.set_env_with_main_alias(&source_name, cell_val.clone());
+                        self.update_local_if_exists(code, &source_name, &cell_val);
+                    }
+                    self.stack.push(value);
+                    return Ok(());
+                }
+            }
             _ => {}
         }
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1329,7 +1329,26 @@ impl Interpreter {
                         .and_then(|s| s.as_ref())
                         .is_some_and(|n| !n.contains('\0')) =>
             {
-                if let Value::Array(items, arr_kind) = &target
+                // A natively typed array (`array[int]`) cannot hold a boxed
+                // `ContainerRef` cell — BIND-POS on it must throw "Cannot bind to
+                // a natively typed array". Detect it (a var bound to this same
+                // backing Arc whose element type is native) and fall through to
+                // the slow path, which raises that error.
+                let is_native_array = if let Value::Array(items, ..) = &target {
+                    let native_var = self.env().iter().find_map(|(name, bound)| match bound {
+                        Value::Array(existing, ..) if Arc::ptr_eq(existing, items) => Some(*name),
+                        _ => None,
+                    });
+                    native_var.is_some_and(|name| {
+                        self.var_type_constraint(&name.resolve())
+                            .as_deref()
+                            .is_some_and(crate::runtime::native_types::is_native_array_element_type)
+                    })
+                } else {
+                    false
+                };
+                if !is_native_array
+                    && let Value::Array(items, arr_kind) = &target
                     && let Some(i) = match &args[0] {
                         Value::Int(n) if *n >= 0 => Some(*n as usize),
                         Value::Num(f) if *f >= 0.0 => Some(*f as usize),

--- a/t/bind-pos-shared-cell.t
+++ b/t/bind-pos-shared-cell.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 9;
+
+# `@a.BIND-POS($i, $x)` binds element $i to the caller variable $x as a shared
+# container cell: a later `$x = ...` writes through to `@a[$i]` and vice versa.
+# This is the array analog of `%h.BIND-KEY` (which already shares a cell).
+
+{
+    my @a = 42, 666;
+    my $x = 45;
+    is @a.BIND-POS(0, $x), 45, 'BIND-POS returns the bound value';
+    is @a.AT-POS(0), 45, 'element reads the bound value';
+    $x = 90;
+    is @a.AT-POS(0), 90, 'mutating the source variable writes through the element';
+}
+
+# BIND-POS to an index past the end extends the array.
+{
+    my @a = 1, 2;
+    my $d = 67;
+    @a.BIND-POS(3, $d);
+    is @a.AT-POS(3), 67, 'BIND-POS extends the array';
+    $d = 56;
+    is @a.AT-POS(3), 56, 'extended bound element tracks the source';
+}
+
+# Writing through the element updates the source variable too (shared cell).
+{
+    my @a = 1, 2, 3;
+    my $x = 10;
+    @a.BIND-POS(1, $x);
+    @a[1] = 99;
+    is $x, 99, 'assigning the element writes back to the bound variable';
+}
+
+# `@a[$i] := $x` (the binding operator) and BIND-POS share the same mechanism.
+{
+    my @a = 1, 2;
+    my $x = 7;
+    @a[0] := $x;
+    $x = 8;
+    is @a[0], 8, ':= element binding aliases the variable';
+}
+
+# A subscript expression still reads the bound value transparently.
+{
+    my @a = 5, 6;
+    my $x = 100;
+    @a.BIND-POS(0, $x);
+    is @a[0] + 1, 101, 'bound element decontainerizes in value context';
+    is @a.elems, 2, 'BIND-POS in place does not change elems';
+}


### PR DESCRIPTION
## Summary

`@a.BIND-POS($i, $x)` was storing a by-value `Value::Scalar` bind marker, so a later `$x = ...` did **not** reflect in `@a[$i]` (mutsu printed the stale value where raku tracks the change). It now installs a shared `ContainerRef` cell aliasing the caller variable `$x` — the array analog of the existing `%h.BIND-KEY` cell path.

```raku
my @a = 1, 2;
my $x = 45;
@a.BIND-POS(0, $x);
say @a[0];   # 45
$x = 90;
say @a[0];   # before: 45 (wrong)   after: 90 (matches raku)
```

## Mechanism (mirrors `%h.BIND-KEY`)
- The single-index plain-`Array` case with a scalar **variable** source reuses the source variable's existing cell when present, otherwise installs a fresh cell back into the source var, and stores the same cell at the element.
- Reads (`AT-POS`/subscript) decont the cell at the existing `resolve_array_entry` chokepoint; writes (`@a[$i] = ...`) go through `assign_element_slot`, so both directions of the alias stay in sync.
- A literal source (no variable to alias) and multi-dimensional BIND-POS fall through to the existing slow path unchanged.

Part of the first-class container-identity campaign (`docs/container-identity.md`).

## Note on xxPOS.t
`S32-basics/xxPOS.t` is still gated from whitelist by an **unrelated** sigilless-variable naming collision (`my $a` shadows `\a` because both map to env key `a`), which aborts the file at test 12 before these asserts run in-file. Recorded as Blocker 1 in `TODO_roast/S32.md`.

## Testing
- Pin: `t/bind-pos-shared-cell.t` (9 cases).
- `make test`: cargo unit tests + the `t/` suite pass (the only red lines are the known load-flaky `t/io-socket-async-bin.t` and expected die-on-fail markers — all pass in isolation; unrelated to this array-dispatch change).
- `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)