### PR TITLE
fix(supply): Supply.skip on a type object throws X::Parameter::InvalidConcreteness

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -20,6 +20,7 @@ roast/6.d/S32-str/sprintf-s.t
 roast/6.d/S32-str/sprintf-u.t
 roast/6.d/S32-str/sprintf-x.t
 roast/6.d/S32-str/sprintf.t
+roast/APPENDICES/A02-some-day-maybe/concreteness.t
 roast/MISC/bug-coverage-stress.t
 roast/S01-perl-5-integration/array.t
 roast/S01-perl-5-integration/basic.t

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2081,6 +2081,15 @@ impl Interpreter {
                 return Ok(Value::str(gist_item(self, &target)));
             }
         }
+        // An instance-only Supply method invoked on the `Supply` TYPE OBJECT is
+        // an X::Parameter::InvalidConcreteness (the invocant is `Supply:D`). These
+        // ones otherwise fall through to the generic `Any` list methods (e.g.
+        // `Supply.skip` would wrongly return a Seq).
+        if matches!(method, "skip") && matches!(&target, Value::Package(name) if name == "Supply") {
+            return Err(RuntimeError::parameter_invalid_concreteness(
+                "Supply", "Supply", method, "self", true, true,
+            ));
+        }
         // Supply type-object method error
         if matches!(
             method,

--- a/t/supply-typeobject-concreteness.t
+++ b/t/supply-typeobject-concreteness.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 3;
+
+# Calling an instance-only Supply method on the Supply TYPE OBJECT is an
+# X::Parameter::InvalidConcreteness (the invocant is constrained to Supply:D).
+throws-like q[Supply.skip], X::Parameter::InvalidConcreteness,
+    'Supply.skip on the type object dies with InvalidConcreteness';
+
+# Supply CLASS methods on the type object keep working.
+lives-ok { Supply.interval(1) }, 'Supply.interval still works on the type object';
+lives-ok { Supply.from-list(1, 2, 3) }, 'Supply.from-list still works';
+
+done-testing;


### PR DESCRIPTION
## Summary

Calling an instance-only Supply method on the `Supply` **type object** must throw `X::Parameter::InvalidConcreteness` (the invocant is constrained to `Supply:D`). mutsu let `Supply.skip` fall through to the generic `Any.skip`, wrongly returning a `Seq` instead of dying.

Add a targeted check in the method dispatch: `.skip` on `Package("Supply")` raises `X::Parameter::InvalidConcreteness` via the existing `parameter_invalid_concreteness` helper. Supply class methods (`.new`, `.interval`, `.from-list`, `.merge`, …) are unaffected; concrete Supply instances are unaffected (the guard matches only the type object).

## Result
- Greens `APPENDICES/A02-some-day-maybe/concreteness.t` (1/1, now whitelisted).
- `make test` green. `make roast` green except a pre-existing **load-sensitive `IO-Socket-Async.t` async timeout** (Failed: 0) — verified unrelated (that test does not use `Supply.skip`; this change is sync-dispatch-only and cannot hang). CI should run it on a cleaner machine.

## Tests
- `t/supply-typeobject-concreteness.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)