### PR TITLE
fix(hash): preserve value-type metadata for typed hashes declared in expression position

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -97,22 +97,38 @@ impl Compiler {
                     }
                     // Tag the container's element-type metadata so `.of` survives
                     // (and the missing-element default is the element type) when a
-                    // *named* typed array is declared in EXPRESSION position
-                    // (`my $x = (my Str @c)`, `gen my Str @s`). The statement-
+                    // *named* typed array/hash is declared in EXPRESSION position
+                    // (`my $x = (my Str @c)`, `gen my Int %i`). The statement-
                     // position VarDecl emits the same `SetVarType`; without it the
-                    // expr path left `@c.of` = Mu. Restrictions:
-                    //   - `@`-arrays only (`%`-hash tagging perturbs `Associative[T]`
-                    //     binding);
+                    // expr path left `@c.of`/`%i.of` = Mu and a missing typed-hash
+                    // key returned `Any` instead of the value-type default. Restrictions:
                     //   - boxed element types only (native `int`/`num`/`str` change
-                    //     the array storage and would panic in the auto-vivify here);
-                    //   - NOT anonymous `my Int @` — leaving an anonymous typed
-                    //     array untagged in an argument keeps `Positional[T]`
-                    //     type-capture binding working (a pre-existing limitation
-                    //     where a parameterized Array[T] is rejected by `Positional[T]`).
-                    if name.starts_with('@')
+                    //     the storage and would panic in the auto-vivify here);
+                    //   - NOT anonymous `my Int @`/`my Int %` — leaving an anonymous
+                    //     typed container untagged in an argument keeps `Positional[T]`/
+                    //     `Associative[T]` type-capture binding working (a pre-existing
+                    //     limitation where a parameterized Array[T]/Hash[T] is rejected
+                    //     by the role).
+                    //   - object hashes (`my Int %j{Cool}`, encoded as the
+                    //     `"Int{Cool}"` constraint) are excluded: re-tagging the
+                    //     key type in expression position breaks the string-key
+                    //     subscript (`%j<b>:k` returns `()`), the concrete
+                    //     `Associative[T]` perturbation the array-only guard
+                    //     originally avoided.
+                    let is_native_value_type = type_constraint.as_ref().is_some_and(|tc| {
+                        if name.starts_with('@') {
+                            crate::runtime::native_types::is_native_array_element_type(tc)
+                        } else {
+                            crate::runtime::native_types::is_native_int_type(tc)
+                                || matches!(tc.as_str(), "num" | "num32" | "num64" | "str")
+                        }
+                    });
+                    if (name.starts_with('@') || name.starts_with('%'))
                         && !name.contains("__ANON_ARRAY__")
+                        && !name.contains("__ANON_HASH__")
                         && let Some(tc) = type_constraint
-                        && !crate::runtime::native_types::is_native_array_element_type(tc)
+                        && !is_native_value_type
+                        && !(name.starts_with('%') && tc.contains('{'))
                     {
                         let tc_idx = self.code.add_constant(Value::str(tc.clone()));
                         self.code.emit(OpCode::SetVarType { name_idx, tc_idx });

--- a/t/typed-hash-expr-decl-of.t
+++ b/t/typed-hash-expr-decl-of.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 10;
+
+# A typed-hash declaration used in EXPRESSION position (e.g. passed as a sub
+# argument, `gen my Int %i`) must keep its value-type metadata, so `.of` and the
+# missing-key default reflect the value type. Previously the expression-position
+# VarDecl tagged typed *arrays* but not typed *hashes*, leaving `%i.of` = Mu and
+# a missing key returning `Any` instead of the value-type default.
+
+sub gen(\h) { h<a> = 1; h<b> = 2 }
+
+# my $x = my Int %i  (assignment context)
+{
+    my $x = my Int %i;
+    is %i.of.^name, 'Int', 'my $x = my Int %i keeps .of';
+}
+
+# gen my Int %i  (sub-argument context, raw \h param)
+{
+    gen my Int %i;
+    is %i.of.^name, 'Int', 'gen my Int %i keeps .of';
+    is %i<B>.^name, 'Int', 'missing key returns the value-type default';
+    is %i<B>:!v.^name, 'Int', 'missing key :!v returns the value-type default';
+    is-deeply (%i<B>:!p), (B => Int), 'missing key :!p pairs key with the value-type default';
+    is %i<a>, 1, 'existing key value still reads correctly';
+    is-deeply (%i<a>:k), 'a', 'existing key :k still works';
+}
+
+# Statement-position declaration is unchanged (control).
+{
+    my Int %j;
+    %j<x> = 5;
+    is %j.of.^name, 'Int', 'statement-position my Int %j keeps .of';
+    is %j<Q>.^name, 'Int', 'statement-position missing key default';
+}
+
+# An object hash (`%c{Cool}`) in expression position keeps working string-key
+# subscripts — re-tagging its key type would break `%c<b>:k`.
+{
+    gen my %c{Cool};
+    is-deeply (%c<b>:k), 'b', 'object hash string-key subscript survives expr decl';
+}


### PR DESCRIPTION
## Summary

A typed-hash declaration used as an rvalue (`my $x = my Int %i`) or as a sub argument (`gen my Int %i`, raw `\h` param) lost its value-type metadata: `%i.of` became `Mu` and a missing-key access returned `Any` instead of the value-type default.

```raku
sub gen(\h) { h<a> = 1 }
gen my Int %i;
say %i.of.^name;    # before: Mu     after: Int (matches raku)
say %i<B>.^name;    # before: Any    after: Int
say (%i<B>:!p).raku; # before: :B(Any)  after: :B(Int)
```

The expression-position VarDecl path (`compile_expr_do_stmt`) tagged typed **arrays** via `SetVarType` but explicitly skipped **hashes**.

## Fix
Extend the tagging to named `%`-hashes, mirroring the array logic. **Object hashes** (`my Int %j{Cool}`, encoded as the `"Int{Cool}"` constraint) stay excluded: re-tagging their key type in expression position breaks the string-key subscript (`%j<b>:k` returns `()`) — the concrete `Associative[T]` perturbation the original array-only guard avoided.

## Impact
- roast `S32-hash/adverbs.t`: **48 → 31 failures**. The remaining 31 are the object-hash `%c{Cool}`/`%j{Cool}` iterations, which need value-type tagging that does not re-tag the key type — left as future work.
- Part of the first-class container-identity campaign (`docs/container-identity.md`).

## Testing
- Pin: `t/typed-hash-expr-decl-of.t` (10 cases, incl. object-hash subscript survival).
- `make test`: All tests successful (Files=1346, Tests=13219).
- Targeted: S09-typed-arrays/{arrays,hashes}.t, S09-hashes/objecthash.t, S02-types/hash.t all PASS.
- `cargo clippy -D warnings` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)