### PR TITLE
fix(parser): listop/colon-method args stop before loose word-logical ops

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -171,7 +171,31 @@
   - 11/41 pass.
 - [x] roast/S03-operators/infixed-function.t
 - [ ] roast/S03-operators/inplace.t
-  - **2026-06-28: 36/38 pass (2 failing: 32, 36).** Landed:
+  - **2026-06-29: 37/38 pass (1 failing: 32).** Landed: listop / colon-method
+    argument lists now stop before the loose word-logical operators
+    (`andthen`/`and`/`or`/`orelse`/`notandthen`/`xor`), matching Raku precedence
+    (`f $x andthen $y` is `(f $x) andthen $y`). New `ExprMode::ListopArg` gates
+    the word-logical-op loops in `expr/precedence/logic.rs`; `listop_arg_expr`
+    and every colon-arg parser (`postfix/loop_.rs`, `postfix/dot_assign.rs`,
+    `primary/regex/lit.rs` topic-method) use it. This fixed test 36's 4-link
+    `… andthen .=new: :10a, :20b` chain (the colon-arg list was swallowing the
+    trailing `andthen`). Also: `(X.self).=meth` === `X.=meth` (`.self` returns
+    the invocant unchanged) — `wrap_dot_assign` unwraps identity `.self` calls so
+    the `.=` writes back through the underlying variable. t/listop-arg-loose-
+    logical-precedence.t.
+  - **Remaining (32):** the `coverage for performance optimizations` subtest:
+    - (a) `.=` on a class instance with a `STORE` method (`(Foo.new).=foo` must
+      invoke `STORE($x)` and return the instance — a custom-container/Proxy STORE
+      protocol where assigning to an object with a STORE method calls it). raku
+      itself throws on `my $t := Foo.new; $t = 99`, so this is specific to the
+      `.=` metaop on an rvalue with STORE; deep container-protocol work.
+    - (b) `with @a { .=uc }` — an `@`/`%` topic is read-only-for-reassign in
+      mutsu's `given`/`with` (Raku errors on `$_ = $_.uc` too, but ALLOWS the
+      `.=` metaop). Distinguishing `.=` from a plain `$_ = …` requires an
+      AST-level marker (both currently compile to the same `Assign`-to-`_`), so a
+      naive "make container topics writable" approach wrongly drops the
+      raku-correct throw on `$_ = …` (regresses t/with-topic-alias.t). Deferred.
+  - **2026-06-28: (historical) 36/38 pass (2 failing: 32, 36).** Landed:
     - (#3894) string-block method names (`."{$c++; "new"}"`), inline-decl /
       do-block `.=` targets (`(my Int $x .= new).= new`, `do {…}.= new`), and
       scalar parameterized-container type checks (`my Array[Numeric] $x = …`).

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -230,7 +230,7 @@ pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr
 /// `@a ==> grep {...} ==> @b` keeps the feed operators outside of grep's arguments.
 #[allow(dead_code)]
 pub(in crate::parser) fn listop_arg_expr(input: &str) -> PResult<'_, Expr> {
-    let (rest, mut expr) = precedence::ternary_mode(input, operators::ExprMode::NoSequenceNoFeed)?;
+    let (rest, mut expr) = precedence::ternary_mode(input, operators::ExprMode::ListopArg)?;
     let (r, _) = ws(rest)?;
     if r.starts_with("=>") && !r.starts_with("==>") {
         let r = &r[2..];

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -635,6 +635,11 @@ pub(in crate::parser) enum ExprMode {
     NoSequence,
     /// For listop arguments: excludes both sequence (...) and feed (==>) operators.
     NoSequenceNoFeed,
+    /// For listop / colon-method argument elements: like `NoSequenceNoFeed`, but
+    /// also stops before the loose word-logical operators (`and`/`or`/`andthen`/
+    /// `orelse`/`notandthen`/`xor`), which are looser than the comma-list of a
+    /// listop call. `f $x andthen $y` is `(f $x) andthen $y`, not `f($x andthen $y)`.
+    ListopArg,
 }
 
 pub(super) fn enrich_expected_error(

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -1,6 +1,6 @@
 use super::call_method::{QuotedMethodName, parse_quoted_method_name};
 use crate::ast::{Expr, Stmt};
-use crate::parser::expr::expression;
+use crate::parser::expr::listop_arg_expr;
 use crate::parser::helpers::ws;
 use crate::parser::parse_result::{PResult, parse_char};
 use crate::parser::primary::{colonpair_expr, parse_call_arg_list, primary};
@@ -32,10 +32,21 @@ fn lvalue_assign_name(e: &Expr) -> Option<String> {
 /// For index expressions, generates an `IndexAssign` wrapped in a `DoBlock`.
 /// For non-lvalue targets, returns the method call as-is.
 pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) -> Expr) -> Expr {
-    // Unwrap Grouped to get at the inner expression
-    let target = match target {
-        Expr::Grouped(inner) => *inner,
-        other => other,
+    // Unwrap Grouped and identity `.self` calls to get at the lvalue. `.self`
+    // returns its invocant unchanged, so `(X.self).=meth` is exactly `X.=meth`
+    // (the assignment writes back through `X`).
+    let mut target = target;
+    let target = loop {
+        let is_self_call = matches!(
+            &target,
+            Expr::MethodCall { name, args, modifier: None, .. }
+                if name.resolve() == "self" && args.is_empty()
+        );
+        target = match target {
+            Expr::Grouped(inner) => *inner,
+            Expr::MethodCall { target: inner, .. } if is_self_call => *inner,
+            other => break other,
+        };
     };
     match &target {
         Expr::Var(name) => Expr::AssignExpr {
@@ -273,10 +284,13 @@ pub(crate) fn parse_dot_assign<'a>(input: &'a str, expr: Expr) -> PResult<'a, Ex
         let (r2, _) = parse_char(r2, ')')?;
         (r2, a)
     } else if r_before_ws.starts_with(':') && !r_before_ws.starts_with("::") {
-        // Colon-arg syntax: .=method: arg (no space before colon)
+        // Colon-arg syntax: .=method: arg (no space before colon). The arg list
+        // is a comma-list at listop precedence, so each element stops before the
+        // loose word-logical ops (`andthen`/`and`/`or`): `$x .=new: 1 andthen $y`
+        // is `($x .=new: 1) andthen $y`, not `$x .=new(1 andthen $y)`.
         let r2 = &r[1..];
         let (r2, _) = ws(r2)?;
-        let (r2, first_arg) = expression(r2)?;
+        let (r2, first_arg) = listop_arg_expr(r2)?;
         let mut args = vec![first_arg];
         let mut r_inner = r2;
         loop {
@@ -299,7 +313,7 @@ pub(crate) fn parse_dot_assign<'a>(input: &'a str, expr: Expr) -> PResult<'a, Ex
                 r_inner = r3;
                 break;
             }
-            let (r3, next) = expression(r3)?;
+            let (r3, next) = listop_arg_expr(r3)?;
             args.push(next);
             r_inner = r3;
         }

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -20,7 +20,7 @@ use crate::ast::{ExistsAdverb, Expr, HyperSliceAdverb, Stmt};
 use crate::parser::expr::operators::{
     PrefixUnaryOp, parse_postfix_update_op, parse_prefix_unary_op,
 };
-use crate::parser::expr::{expression, expression_no_sequence};
+use crate::parser::expr::{expression, expression_no_sequence, listop_arg_expr};
 use crate::parser::helpers::{consume_unspace, is_ident_char, split_angle_words, ws};
 use crate::parser::parse_result::{PError, PResult, parse_char, take_while1};
 use crate::parser::primary::{colonpair_expr, parse_block_body, parse_call_arg_list, primary};
@@ -854,7 +854,11 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     } else {
                         let r3 = &r2[1..];
                         let (r3, _) = ws(r3)?;
-                        expression(r3)?
+                        // A colon-method arg list (`.m: a, b`) is a comma-list at
+                        // listop precedence, so each element stops before the loose
+                        // word-logical ops (`andthen`/`and`/`or`): `.m: $x andthen $y`
+                        // is `(.m: $x) andthen $y`, not `.m($x andthen $y)`.
+                        listop_arg_expr(r3)?
                     };
                     let mut args = vec![first_arg];
                     let mut r_inner = r3;
@@ -878,7 +882,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             r_inner = r4;
                             break;
                         }
-                        let (r4, next) = expression(r4)?;
+                        let (r4, next) = listop_arg_expr(r4)?;
                         args.push(next);
                         r_inner = r4;
                     }
@@ -1047,7 +1051,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 if r2.starts_with(':') && !r2.starts_with("::") {
                     let r3 = &r2[1..];
                     let (r3, _) = ws(r3)?;
-                    let (r3, first_arg) = expression(r3)?;
+                    let (r3, first_arg) = listop_arg_expr(r3)?;
                     let mut args = vec![first_arg];
                     let mut r_inner = r3;
                     loop {
@@ -1062,7 +1066,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             r_inner = r4;
                             break;
                         }
-                        let (r4, next) = expression(r4)?;
+                        let (r4, next) = listop_arg_expr(r4)?;
                         args.push(next);
                         r_inner = r4;
                     }

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -4,6 +4,9 @@ pub(crate) fn or_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (mut rest, mut left) = assign_or_and_expr(input, mode)?;
     loop {
         let (r, _) = ws(rest)?;
+        if mode == ExprMode::ListopArg {
+            break;
+        }
         if let Some((op @ (LogicalOp::Or | LogicalOp::XorXor | LogicalOp::OrElse), len)) =
             parse_word_logical_op(r)
         {
@@ -40,6 +43,9 @@ pub(crate) fn or_expr_no_assign_mode(input: &str, mode: ExprMode) -> PResult<'_,
     let (mut rest, mut left) = and_expr_no_assign_mode(input, mode)?;
     loop {
         let (r, _) = ws(rest)?;
+        if mode == ExprMode::ListopArg {
+            break;
+        }
         if let Some((op @ (LogicalOp::Or | LogicalOp::XorXor | LogicalOp::OrElse), len)) =
             parse_word_logical_op(r)
         {
@@ -70,6 +76,9 @@ pub(crate) fn and_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (mut rest, mut left) = assign_not_expr_mode(input, mode)?;
     loop {
         let (r, _) = ws(rest)?;
+        if mode == ExprMode::ListopArg {
+            break;
+        }
         if let Some((op @ (LogicalOp::And | LogicalOp::AndThen | LogicalOp::NotAndThen), len)) =
             parse_word_logical_op(r)
         {
@@ -103,6 +112,9 @@ pub(crate) fn and_expr_no_assign_mode(input: &str, mode: ExprMode) -> PResult<'_
     let (mut rest, mut left) = not_expr_mode(input, mode)?;
     loop {
         let (r, _) = ws(rest)?;
+        if mode == ExprMode::ListopArg {
+            break;
+        }
         if let Some((op @ (LogicalOp::And | LogicalOp::AndThen | LogicalOp::NotAndThen), len)) =
             parse_word_logical_op(r)
         {

--- a/src/parser/expr/precedence/logic2.rs
+++ b/src/parser/expr/precedence/logic2.rs
@@ -234,7 +234,7 @@ pub(crate) fn junctive_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Exp
     let next_fn: fn(&str) -> PResult<'_, Expr> = match mode {
         ExprMode::Full => sequence_expr,
         ExprMode::NoSequence => list_infix_expr,
-        ExprMode::NoSequenceNoFeed => range_expr,
+        ExprMode::NoSequenceNoFeed | ExprMode::ListopArg => range_expr,
     };
     let (mut rest, mut left) = next_fn(input)?;
     let mut last_junction: Option<JunctionInfixOp> = None;

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -937,10 +937,13 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
                 let (r, _) = parse_char(r, ')')?;
                 (r, args)
             } else if r_before_ws.starts_with(':') && !r_before_ws.starts_with("::") {
-                // Colon-arg form: .=method: arg
+                // Colon-arg form: .=method: arg. The arg list is a comma-list at
+                // listop precedence, so each element stops before the loose
+                // word-logical ops (`andthen`/`and`/`or`): `.=new: 1 andthen $y`
+                // is `(.=new: 1) andthen $y`, not `.=new(1 andthen $y)`.
                 let r = &r_before_ws[1..];
                 let (r, _) = ws(r)?;
-                let (r, first_arg) = crate::parser::expr::expression(r)?;
+                let (r, first_arg) = crate::parser::expr::listop_arg_expr(r)?;
                 let mut args = vec![first_arg];
                 let mut r_inner = r;
                 loop {
@@ -959,7 +962,7 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
                     }
                     let r2 = &r2[1..];
                     let (r2, _) = ws(r2)?;
-                    let (r2, next) = crate::parser::expr::expression(r2)?;
+                    let (r2, next) = crate::parser::expr::listop_arg_expr(r2)?;
                     args.push(next);
                     r_inner = r2;
                 }

--- a/t/listop-arg-loose-logical-precedence.t
+++ b/t/listop-arg-loose-logical-precedence.t
@@ -1,0 +1,75 @@
+use Test;
+
+plan 12;
+
+# Listop / colon-method argument lists are a comma-list at listop precedence, so
+# each element stops before the loose word-logical operators (`andthen`/`and`/
+# `or`/`orelse`/`notandthen`): `f $x andthen $y` is `(f $x) andthen $y`, not
+# `f($x andthen $y)`.
+{
+    my @log;
+    sub f($x) { @log.push("f:$x"); $x }
+    is (f 1 andthen 2), 2, 'f 1 andthen 2 === (f 1) andthen 2';
+
+    @log = ();
+    f 1 andthen @log.push('then');
+    is-deeply @log, ['f:1', 'then'], 'andthen runs after the listop call, not inside its args';
+
+    @log = ();
+    f 0 orelse @log.push('else');
+    is-deeply @log, ['f:0'], 'orelse short-circuits on a true listop result';
+}
+
+# `.method: args andthen ...` stops the colon-arg list at `andthen`.
+{
+    my class Bar { has $.a; has $.b }
+    my $made = 'no';
+    my Bar $x;
+    $x .=new: :10a, :20b andthen ($made = 'yes');
+    is-deeply $x, Bar.new(:10a, :20b), '.=new: :10a, :20b stops before andthen';
+    is $made, 'yes', 'andthen branch ran after the .=new colon-arg list';
+}
+
+# Chained `.=new` / `notandthen` / `orelse` / `andthen` with mixed arg forms
+# (regression coverage for roast S03-operators/inplace.t subtest 36).
+{
+    my Int $x1;
+    $x1 notandthen .=new;
+    is-deeply $x1, 0, 'notandthen .=new (no args)';
+
+    my Int $x2;
+    $x2 orelse .=new andthen .=new: 43;
+    is-deeply $x2, 43, 'orelse .=new andthen .=new: 43';
+
+    my class Meow { has $.a; has $.b }
+    my Meow $x4;
+    $x4 orelse .=new :42a :70b andthen .=new
+      andthen .=new: :100b andthen .=new: :10a, :20b;
+    is-deeply $x4, Meow.new(:10a, :20b), 'chain of different ops with .=new colon-args';
+}
+
+# Comma-separated colon-arg lists still collect every element.
+{
+    my @collected;
+    sub g(*@a) { @collected = @a }
+    g 1, 2, 3;
+    is-deeply @collected, [1, 2, 3], 'comma-separated listop args still collected';
+}
+
+# `(X.self).=meth` === `X.=meth` (`.self` returns the invocant unchanged), so the
+# `.=` writes back through the underlying variable.
+{
+    my @a = 'FOO';
+    (@a.self).=lc;
+    is-deeply @a, ['foo'], '(@a.self).=lc writes back through @a';
+}
+{
+    my $s = 'foo';
+    ($s.self).=uc;
+    is $s, 'FOO', '($s.self).=uc writes back through $s';
+}
+{
+    my $n = 3.7;
+    ($n.self).=Int;
+    is $n, 3, '($n.self).=Int writes back through $n';
+}


### PR DESCRIPTION
## Summary

A listop or colon-method argument list (`f $x, $y` / `.m: $x, $y` / `.=new: :a, :b`) is a comma-list at listop precedence, so each element must stop before the loose word-logical operators (`andthen`/`and`/`or`/`orelse`/`notandthen`/`xor`), which are looser than the comma. `f $x andthen $y` is `(f $x) andthen $y`, not `f($x andthen $y)`.

Previously the colon-arg parsers used the full `expression()`, which greedily consumed a trailing `andthen`/`orelse` into the argument list. This broke chained `.=` constructs such as the 4-link `$x orelse .=new :a :b andthen .=new andthen .=new: :c andthen .=new: :d, :e` (roast `S03-operators/inplace.t` subtest 36).

## Changes

- Add `ExprMode::ListopArg`, which gates the word-logical-op loops in `expr/precedence/logic.rs` (and routes `junctive_expr_mode` like `NoSequenceNoFeed`). `listop_arg_expr` now parses at this mode, and every colon-arg element parser (`postfix/loop_.rs`, `postfix/dot_assign.rs`, `primary/regex/lit.rs` leading-dot topic method) routes through it.
- `wrap_dot_assign` unwraps identity `.self` calls: `(X.self).=meth` is exactly `X.=meth` (`.self` returns its invocant unchanged), so the `.=` writes back through the underlying variable (`(@a.self).=lc` mutates `@a`).

## Result

`roast/S03-operators/inplace.t` goes 36/38 → 37/38. The remaining subtest 32 is blocked by the STORE-on-`.=`-instance container protocol (documented in `TODO_roast/S03.md`).

## Testing

- `make test` passes.
- `make roast` passes (no whitelisted regression from the broad precedence change).
- New `t/listop-arg-loose-logical-precedence.t` (12 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)