### PR TITLE
feat(operators): .= on a STORE-container non-lvalue invokes STORE

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -184,11 +184,11 @@
     the `.=` writes back through the underlying variable. t/listop-arg-loose-
     logical-precedence.t.
   - **Remaining (32):** the `coverage for performance optimizations` subtest:
-    - (a) `.=` on a class instance with a `STORE` method (`(Foo.new).=foo` must
-      invoke `STORE($x)` and return the instance — a custom-container/Proxy STORE
-      protocol where assigning to an object with a STORE method calls it). raku
-      itself throws on `my $t := Foo.new; $t = 99`, so this is specific to the
-      `.=` metaop on an rvalue with STORE; deep container-protocol work.
+    - (a) **DONE** (this PR) — `.=` on a non-lvalue whose (evaluated-once) target
+      has a `STORE` method now desugars to
+      `do { my $t = EXPR; $t.^can("STORE") ?? do { $t.STORE($t.meth); $t } !! $t.meth }`,
+      so `(Foo.new).=foo` invokes `STORE(42)` and yields the instance (objects
+      without STORE keep the plain method result). t/dotassign-store-container.t.
     - (b) `with @a { .=uc }` — an `@`/`%` topic is read-only-for-reassign in
       mutsu's `given`/`with` (Raku errors on `$_ = $_.uc` too, but ALLOWS the
       `.=` metaop). Distinguishing `.=` from a plain `$_ = …` requires an
@@ -220,12 +220,18 @@
       (each link works in isolation; only the full chain fails). t/andthen-orelse-instance-rhs.t.
       Also note: `my $r = ($x orelse <val>)` returns Nil for ANY `<val>` — a
       separate pre-existing orelse-in-assignment bug.
-    - Test 32: (a) `.=` on a class instance with a `STORE` method
-      (`(Foo.new).=foo` must invoke `STORE` and return the instance — Proxy-like
-      semantics), and (b) `with @a { .=uc }` — an `@`/`%` topic is read-only-for-
-      reassign in mutsu's `given`/`with`, so `$_ = $_.uc` throws; raku aliases the
-      topic writably. Both need topic/Proxy write-through (deeper than the chained
-      retarget above).
+    - Test 32: (a) **DONE** — `.=` on a non-lvalue whose (evaluated-once) target
+      has a `STORE` method now desugars to
+      `do { my $t = EXPR; $t.^can("STORE") ?? do { $t.STORE($t.meth); $t } !! $t.meth }`,
+      so `(Foo.new).=foo` invokes `STORE(42)` and yields the instance (objects
+      without STORE keep the plain method result). t/dotassign-store-container.t.
+      (b) **still failing**: `with @a { .=uc }` — an `@`/`%` topic is read-only-
+      for-reassign in mutsu's `given`/`with`, so the `.=` metaop (which compiles
+      to `$_ = $_.uc`, identical to a plain `$_ = $_.uc`) is rejected; raku allows
+      the `.=` metaop but rejects the plain reassign. Distinguishing them needs an
+      AST-level `.=`-origin marker on the topic assignment (a naive "make the
+      container topic writable" approach regresses the raku-correct throw on
+      `$_ = …`, see t/with-topic-alias.t). Deferred.
 - [ ] roast/S03-operators/is-divisible-by.t
   - 7/16 pass.
 - [x] roast/S03-operators/lcm.t

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -5,6 +5,7 @@ use crate::parser::helpers::ws;
 use crate::parser::parse_result::{PResult, parse_char};
 use crate::parser::primary::{colonpair_expr, parse_call_arg_list, primary};
 use crate::symbol::Symbol;
+use crate::value::Value;
 
 pub(crate) fn atomic_var_name(expr: &Expr) -> Option<String> {
     match expr {
@@ -204,7 +205,70 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 args: vec![lhs, Expr::ArrayLiteral(Vec::new()), value],
             }
         }
-        _ => method_call_fn(target),
+        // A non-lvalue target (`(Foo.new).=meth`, `Foo.new.=meth`, ...). In Raku
+        // `X.=meth` is `X = X.meth`; when X (evaluated once) provides a `STORE`
+        // method it is a custom container, so this becomes `X.STORE(X.meth)` and
+        // the expression value is the container X itself (not STORE's return). An
+        // object without STORE keeps mutsu's historical plain-method-call value
+        // (Raku errors with "Cannot modify an immutable ..." there, but that path
+        // is untested and the lax form is relied on elsewhere). Bind the target to
+        // a temp so it is evaluated exactly once, then branch at runtime on
+        // `.^can("STORE")`:
+        //   do { my $t = TARGET;
+        //        $t.^can("STORE") ?? do { $t.STORE($t.meth); $t } !! $t.meth }
+        _ => {
+            use std::sync::atomic::Ordering;
+            let tmp = format!(
+                "__mutsu_dotassign_{}",
+                crate::parser::stmt::simple::TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
+            );
+            let tmp_var = Expr::Var(tmp.clone());
+            // `method_call_fn` is `FnOnce`; call it once against the temp and clone
+            // the resulting `$t.meth(args)` for both the STORE argument and the
+            // no-STORE fallback (both branches share the same target `$t`).
+            let meth_result = method_call_fn(tmp_var.clone());
+            let can_store = Expr::MethodCall {
+                target: Box::new(tmp_var.clone()),
+                name: Symbol::intern("can"),
+                args: vec![Expr::Literal(Value::str("STORE".to_string()))],
+                modifier: Some('^'),
+                quoted: false,
+            };
+            let store_call = Expr::MethodCall {
+                target: Box::new(tmp_var.clone()),
+                name: Symbol::intern("STORE"),
+                args: vec![meth_result.clone()],
+                modifier: None,
+                quoted: false,
+            };
+            let then_expr = Expr::DoBlock {
+                body: vec![Stmt::Expr(store_call), Stmt::Expr(tmp_var.clone())],
+                label: None,
+            };
+            let ternary = Expr::Ternary {
+                cond: Box::new(can_store),
+                then_expr: Box::new(then_expr),
+                else_expr: Box::new(meth_result),
+            };
+            Expr::DoBlock {
+                body: vec![
+                    Stmt::VarDecl {
+                        name: tmp,
+                        expr: target,
+                        type_constraint: None,
+                        is_state: false,
+                        is_our: false,
+                        is_dynamic: false,
+                        is_export: false,
+                        export_tags: Vec::new(),
+                        custom_traits: Vec::new(),
+                        where_constraint: None,
+                    },
+                    Stmt::Expr(ternary),
+                ],
+                label: None,
+            }
+        }
     }
 }
 

--- a/src/parser/stmt/tests_2.rs
+++ b/src/parser/stmt/tests_2.rs
@@ -116,8 +116,11 @@ fn parse_paren_expr_mutating_method_stmt() {
     let (rest, stmts) = program("(class { method foo() { self } }.new).=foo;").unwrap();
     assert_eq!(rest, "");
     assert_eq!(stmts.len(), 1);
-    // .= on non-lvalue expression is parsed as a method call in expression context
-    assert!(matches!(&stmts[0], Stmt::Expr(Expr::MethodCall { .. })));
+    // `.=` on a non-lvalue expression desugars to a `do { my $t = EXPR; ... }`
+    // block that, at runtime, invokes `$t.STORE($t.foo)` when the (evaluated-once)
+    // target provides a `STORE` method (custom container) and otherwise yields the
+    // plain `$t.foo` method result.
+    assert!(matches!(&stmts[0], Stmt::Expr(Expr::DoBlock { .. })));
 }
 
 #[test]

--- a/t/dotassign-store-container.t
+++ b/t/dotassign-store-container.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 9;
+
+# `X.=meth` is `X = X.meth`. When the (evaluated-once) target X provides a
+# `STORE` method it is a custom container, so the `.=` becomes `X.STORE(X.meth)`
+# and the whole expression evaluates to the container X itself (not STORE's
+# return value). https://github.com/rakudo/rakudo/commit/7fe23136da
+
+{
+    my @log;
+    my class Foo {
+        method STORE ($x) { @log.push("STORE:$x"); 'store-ret' }
+        method foo { 42 }
+    }
+    my $r = (Foo.new).=foo;
+    is-deeply @log, ['STORE:42'], 'STORE called once with the method result';
+    isa-ok $r, Foo, '.= on a class instantiation returns the container, not STORE return';
+}
+
+{
+    my class Bar {
+        has $.v is rw;
+        method STORE ($x) { $!v = $x; self }
+        method double { 21 }
+    }
+    my $r = (Bar.new).=double;
+    isa-ok $r, Bar, 'STORE container result is the instance';
+    is $r.v, 21, 'STORE mutated the instance with the method result';
+}
+
+# The target is evaluated exactly once (no double construction / double method
+# side effects).
+{
+    my $news = 0;
+    my class Baz {
+        method STORE ($x) {}
+        method foo { 7 }
+    }
+    sub make { $news++; Baz.new }
+    (make).=foo;
+    is $news, 1, 'target expression evaluated exactly once';
+}
+
+# An object WITHOUT a STORE method keeps the plain method-call value (mutsu's
+# historical lax behavior for `.=` on a non-lvalue).
+{
+    my class NoStore { method foo { 99 } }
+    my $r = (NoStore.new).=foo;
+    is $r, 99, 'no STORE method => plain method result';
+}
+{
+    is (3.7).Int, 3, 'sanity: non-lvalue method call still works';
+}
+
+# `.=` on a real lvalue variable is unaffected (assigns the method result).
+{
+    my $s = 'abc';
+    $s .= uc;
+    is $s, 'ABC', '.= on a scalar lvalue assigns the method result';
+
+    my @a = <c a b>;
+    @a .= sort;
+    is-deeply @a, ['a', 'b', 'c'], '.= on an array lvalue assigns the sorted list';
+}


### PR DESCRIPTION
## Summary

`X.=meth` is `X = X.meth`. When the target X (evaluated once) provides a `STORE` method it is a custom container, so the assignment dispatches to `X.STORE(X.meth)` and the whole expression evaluates to **the container X itself** (not STORE's return value), matching rakudo (commit 7fe23136da).

Previously `.=` on a non-lvalue target (`(Foo.new).=foo`, `Foo.new.=meth`, ...) was lowered to a bare method call with no write-back, so STORE was never invoked.

## Change

`wrap_dot_assign`'s non-lvalue fallthrough now binds the target to a temp (evaluated exactly once) and branches at runtime on `.^can("STORE")`:

```raku
do { my $t = EXPR;
     $t.^can("STORE") ?? do { $t.STORE($t.meth); $t } !! $t.meth }
```

An object without a STORE method keeps mutsu's historical plain-method-call value (raku errors there with "Cannot modify an immutable ...", but that path is untested and the lax form is relied on elsewhere).

## Result

Fixes the `.= on a class instantiation` case of roast `S03-operators/inplace.t` subtest 32. (The subtest still fails overall on its separate `with @a { .=uc }` container-topic case — documented in `TODO_roast/S03.md`.)

## Testing

- `make test` passes.
- `make roast` passes (no whitelisted regression from the non-lvalue `.=` fallthrough change).
- New `t/dotassign-store-container.t` (9 cases); updated the parser unit test that asserted the old bare-method-call AST shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)