### PR TITLE
feat(parser): detect VCS conflict markers as X::Comp compile error (misc.t #179)

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -46,11 +46,74 @@ use crate::value::{RuntimeError, Value};
 
 thread_local! {
     static PARSE_WARNINGS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    /// 1-based line numbers of detected VCS conflict markers (`<<<<<<<` blocks).
+    static VCS_CONFLICT_MARKERS: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Add a warning message during parsing. Collected and emitted after parse completes.
 pub(super) fn add_parse_warning(msg: String) {
     PARSE_WARNINGS.with(|w| w.borrow_mut().push(msg));
+}
+
+/// Record a detected VCS conflict marker (`<<<<<<<` ... `>>>>>>>` block) at the
+/// given 1-based line. Collected during parsing and, if any were found, turned
+/// into an `X::Comp::Group` (or a lone `X::Comp::AdHoc`) after the parse — this
+/// mirrors rakudo's "Found a version control conflict marker" compile error.
+pub(super) fn record_vcs_conflict_marker(line: i64) {
+    VCS_CONFLICT_MARKERS.with(|m| m.borrow_mut().push(line));
+}
+
+/// Take and clear the collected VCS conflict markers, deduplicating by line
+/// (parser backtracking may re-visit the same marker more than once).
+fn take_vcs_conflict_markers() -> Vec<i64> {
+    let all: Vec<i64> = VCS_CONFLICT_MARKERS.with(|m| m.borrow_mut().drain(..).collect());
+    let mut seen = std::collections::HashSet::new();
+    let mut lines = Vec::new();
+    for line in all {
+        if seen.insert(line) {
+            lines.push(line);
+        }
+    }
+    lines
+}
+
+/// Build the compile-time error rakudo raises for VCS conflict markers. A single
+/// marker becomes a bare `X::Comp::AdHoc`; two or more become an
+/// `X::Comp::Group` whose `sorrows` hold all but the last marker and whose
+/// `panic` is the last one. Each carries `payload`/`message`/`line`.
+fn build_vcs_conflict_error(lines: &[i64]) -> RuntimeError {
+    const PAYLOAD: &str = "Found a version control conflict marker";
+    let make_adhoc = |line: i64| -> Value {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("payload".to_string(), Value::str(PAYLOAD.to_string()));
+        attrs.insert("message".to_string(), Value::str(PAYLOAD.to_string()));
+        attrs.insert("line".to_string(), Value::Int(line));
+        Value::make_instance(crate::symbol::Symbol::intern("X::Comp::AdHoc"), attrs)
+    };
+
+    let mut err = RuntimeError::new(PAYLOAD);
+    err.code = Some(RuntimeErrorCode::ParseGeneric);
+    if lines.len() <= 1 {
+        let line = lines.first().copied().unwrap_or(1);
+        err.line = Some(line as usize);
+        err.exception = Some(Box::new(make_adhoc(line)));
+        return err;
+    }
+
+    let (panic_line, sorrow_lines) = lines.split_last().unwrap();
+    let sorrows: Vec<Value> = sorrow_lines.iter().map(|&l| make_adhoc(l)).collect();
+    let panic = make_adhoc(*panic_line);
+    let mut group_attrs = std::collections::HashMap::new();
+    group_attrs.insert("sorrows".to_string(), Value::array(sorrows));
+    group_attrs.insert("worries".to_string(), Value::array(vec![]));
+    group_attrs.insert("panic".to_string(), panic);
+    group_attrs.insert("message".to_string(), Value::str(PAYLOAD.to_string()));
+    err.line = Some(*panic_line as usize);
+    err.exception = Some(Box::new(Value::make_instance(
+        crate::symbol::Symbol::intern("X::Comp::Group"),
+        group_attrs,
+    )));
+    err
 }
 
 /// Take and clear all parse warnings collected during the last parse.
@@ -153,6 +216,7 @@ fn with_parse_hint(mut err: RuntimeError) -> RuntimeError {
 pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), RuntimeError> {
     // Clear any stale parse warnings from previous/backtracked parses
     PARSE_WARNINGS.with(|w| w.borrow_mut().clear());
+    VCS_CONFLICT_MARKERS.with(|m| m.borrow_mut().clear());
     let memo_enabled = parse_memo_enabled();
     if memo_enabled {
         expr::reset_expression_memo();
@@ -239,6 +303,14 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
             }
         }
     };
+
+    // A VCS conflict marker is a compile-time error and takes precedence over
+    // whatever the surrounding statements parsed to (rakudo reports it even when
+    // the rest of the unit parses cleanly).
+    let conflict_markers = take_vcs_conflict_markers();
+    if !conflict_markers.is_empty() {
+        return Err(build_vcs_conflict_error(&conflict_markers));
+    }
 
     if memo_enabled && crate::trace::is_enabled("parse") {
         let (stmt_hits, stmt_misses, stmt_stores) = stmt::statement_memo_stats();

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -207,6 +207,16 @@ pub(crate) fn stmt_list_with_mode(
         if r.is_empty() || r.starts_with('}') {
             return Ok((r, stmts));
         }
+        // VCS conflict markers (`<<<<<<<` ... `=======` ... `>>>>>>>`): record the
+        // opening-marker line and skip the whole block, so the surrounding code
+        // still parses. The collected markers become an X::Comp::Group (or a lone
+        // X::Comp::AdHoc) after the parse — mirroring rakudo's
+        // "Found a version control conflict marker" compile error.
+        if let Some((after_block, marker_line)) = detect_vcs_conflict_block(r) {
+            crate::parser::record_vcs_conflict_marker(marker_line);
+            rest = after_block;
+            continue;
+        }
         if allow_mainline_capture
             && let Ok((after_decl, mut main_sub)) = sub::top_level_main_semicolon_decl(r)
         {
@@ -397,4 +407,54 @@ fn consume_stray_close_paren(input: &str) -> &str {
         }
     }
     input
+}
+
+/// Returns true if `line` (a single source line, trailing `\n` already removed)
+/// is a VCS conflict marker: exactly seven of `ch` (`<`/`=`/`>`/`|`), not an
+/// eighth, followed by horizontal whitespace or end-of-line. Matching rakudo,
+/// `<<<<<<< HEAD`, `=======`, and `>>>>>>> branch` all qualify.
+fn is_conflict_marker_line(line: &str, ch: u8) -> bool {
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i] == ch {
+        i += 1;
+    }
+    if i != 7 {
+        return false;
+    }
+    match bytes.get(7) {
+        None => true,
+        Some(&b) => b == b' ' || b == b'\t',
+    }
+}
+
+/// First line of `s` (without the trailing newline).
+fn first_line(s: &str) -> &str {
+    match s.find('\n') {
+        Some(i) => &s[..i],
+        None => s,
+    }
+}
+
+/// If `r` begins (at beginning-of-line) with a `<<<<<<<` VCS conflict marker,
+/// returns the input remaining after the whole conflict block — consumed
+/// through the matching `>>>>>>>` line, or to end-of-input if there is none —
+/// together with the 1-based line number of the opening marker.
+fn detect_vcs_conflict_block(r: &str) -> Option<(&str, i64)> {
+    if !is_conflict_marker_line(first_line(r), b'<') {
+        return None;
+    }
+    let line = crate::parser::primary::current_line_number(r);
+    let mut rest = r;
+    loop {
+        let (cur, after) = match rest.find('\n') {
+            Some(i) => (&rest[..i], &rest[i + 1..]),
+            None => (rest, ""),
+        };
+        if is_conflict_marker_line(cur, b'>') || after.is_empty() {
+            return Some((after, line));
+        }
+        rest = after;
+    }
 }

--- a/t/vcs-conflict-marker.t
+++ b/t/vcs-conflict-marker.t
@@ -1,0 +1,68 @@
+use Test;
+
+# A source file containing Git/VCS conflict markers must be a compile-time
+# error: rakudo reports "Found a version control conflict marker". A single
+# conflict block throws a bare X::Comp::AdHoc; multiple blocks throw an
+# X::Comp::Group whose sorrows hold all but the last marker and whose panic is
+# the last one. Markers inside quotes/heredocs are NOT detected.
+
+use MONKEY-SEE-NO-EVAL;
+
+plan 11;
+
+# Single conflict block -> X::Comp::AdHoc at the opening marker line.
+{
+    my $code = q:to/END/;
+        say 'a';
+        <<<<<<< HEAD
+        say 'b';
+        =======
+        say 'c';
+        >>>>>>> branch
+        say 'd';
+        END
+    my $ex;
+    { $code.EVAL; CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::Comp::AdHoc, 'single block throws X::Comp::AdHoc';
+    is $ex.line, 2, 'opening marker reported at line 2';
+    is $ex.payload, 'Found a version control conflict marker', 'payload set';
+}
+
+# Two conflict blocks -> X::Comp::Group; the marker inside the inner heredoc is
+# NOT counted as a conflict.
+{
+    my $code = q:to/END/;
+        say 'first both';
+        <<<<<<< HEAD
+        say 'your';
+        =======
+        say 'their';
+        >>>>>>> branch
+
+        say 'middle both';
+
+        <<<<<<< HEAD
+        say 'your';
+        =======
+        say 'their';
+        >>>>>>> branch
+
+        q:to/QUOTED/;
+        <<<<<<< HEAD
+        this is not
+        =======
+        a vcs conflict
+        >>>>>>> branch
+        QUOTED
+        END
+    my $ex;
+    { $code.EVAL; CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::Comp::Group, 'two blocks throw X::Comp::Group';
+    is $ex.sorrows.elems, 1, 'one sorrow collected';
+    isa-ok $ex.sorrows[0], X::Comp::AdHoc, 'sorrow is X::Comp::AdHoc';
+    is $ex.sorrows[0].line, 2, 'first marker (sorrow) at line 2';
+    is $ex.sorrows[0].payload, 'Found a version control conflict marker', 'sorrow payload';
+    isa-ok $ex.panic, X::Comp::AdHoc, 'panic is X::Comp::AdHoc';
+    is $ex.panic.line, 10, 'second marker (panic) at line 10';
+    is $ex.panic.payload, 'Found a version control conflict marker', 'panic payload';
+}


### PR DESCRIPTION
## Summary

A source file containing Git/VCS conflict markers (`<<<<<<<` … `=======` … `>>>>>>>`) is now a compile-time error, matching rakudo's *"Found a version control conflict marker"*. This implements `roast/S32-exceptions/misc.t` test 179.

## How it works

- Detection happens in the statement loop at beginning-of-line: an opening `<<<<<<<` marker is recorded and the whole conflict block (through the matching `>>>>>>>` line) is skipped, so the surrounding code still parses.
- Markers inside quotes/heredocs are consumed as part of their statement and never reach the statement loop, so they are correctly **not** detected (per the test's inner `q:to/QUOTED/` block).
- The collected markers are turned into an exception after the parse:
  - a single marker → bare `X::Comp::AdHoc`
  - two or more → `X::Comp::Group` whose `sorrows` hold all but the last marker and whose `panic` is the last one
  - each carries `payload` / `message` / `line` (`payload` = `"Found a version control conflict marker"`).

For the roast test, this yields `X::Comp::Group` with one sorrow at line 2 and a panic at line 10 — exactly what rakudo produces.

## Tests

- `roast/S32-exceptions/misc.t` test 179 now passes.
- New `t/vcs-conflict-marker.t` (11 assertions) covering single-block (`X::Comp::AdHoc`) and multi-block (`X::Comp::Group`) cases, including the not-detected-in-heredoc case.
- `make test` passes (13249 tests); parser unit tests pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)