### PR TITLE
feat(operators): .= metaop writes through a read-only container topic (closes inplace.t)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -170,31 +170,33 @@
 - [ ] roast/S03-operators/increment.t
   - 11/41 pass.
 - [x] roast/S03-operators/infixed-function.t
-- [ ] roast/S03-operators/inplace.t
-  - **2026-06-29: 37/38 pass (1 failing: 32).** Landed: listop / colon-method
-    argument lists now stop before the loose word-logical operators
-    (`andthen`/`and`/`or`/`orelse`/`notandthen`/`xor`), matching Raku precedence
-    (`f $x andthen $y` is `(f $x) andthen $y`). New `ExprMode::ListopArg` gates
-    the word-logical-op loops in `expr/precedence/logic.rs`; `listop_arg_expr`
-    and every colon-arg parser (`postfix/loop_.rs`, `postfix/dot_assign.rs`,
-    `primary/regex/lit.rs` topic-method) use it. This fixed test 36's 4-link
-    `… andthen .=new: :10a, :20b` chain (the colon-arg list was swallowing the
-    trailing `andthen`). Also: `(X.self).=meth` === `X.=meth` (`.self` returns
-    the invocant unchanged) — `wrap_dot_assign` unwraps identity `.self` calls so
-    the `.=` writes back through the underlying variable. t/listop-arg-loose-
-    logical-precedence.t.
-  - **Remaining (32):** the `coverage for performance optimizations` subtest:
-    - (a) **DONE** (this PR) — `.=` on a non-lvalue whose (evaluated-once) target
-      has a `STORE` method now desugars to
+- [x] roast/S03-operators/inplace.t
+  - **2026-06-29: 38/38 pass, whitelisted.** Final two fixes:
+    - **(32) `.=` STORE container + container topic.** (a) `.=` on a non-lvalue
+      whose (evaluated-once) target has a `STORE` method desugars to
       `do { my $t = EXPR; $t.^can("STORE") ?? do { $t.STORE($t.meth); $t } !! $t.meth }`,
-      so `(Foo.new).=foo` invokes `STORE(42)` and yields the instance (objects
-      without STORE keep the plain method result). t/dotassign-store-container.t.
-    - (b) `with @a { .=uc }` — an `@`/`%` topic is read-only-for-reassign in
-      mutsu's `given`/`with` (Raku errors on `$_ = $_.uc` too, but ALLOWS the
-      `.=` metaop). Distinguishing `.=` from a plain `$_ = …` requires an
-      AST-level marker (both currently compile to the same `Assign`-to-`_`), so a
-      naive "make container topics writable" approach wrongly drops the
-      raku-correct throw on `$_ = …` (regresses t/with-topic-alias.t). Deferred.
+      so `(Foo.new).=foo` invokes `STORE(42)` and yields the instance (no STORE =>
+      plain method result). (b) the `.=` metaop on a whole-container topic
+      (`with @a { .=uc }`) writes through to the source. The `.=` metaop is
+      distinguished from a plain `$_ = …` by routing the *statement*-level
+      `.=`-on-`$_` paths (`stmt/simple_expr_stmt/core.rs`,
+      `stmt/assign/assign_stmt.rs`) through a `__mutsu_topic_dotassign` marker
+      compiled to the new `OpCode::TopicDotAssign`, which bypasses the topic's
+      read-only mark and writes through to the `@`/`%` `topic_container_source`
+      with container coercion. A plain `$_ = …` keeps the normal path and still
+      throws X::Assignment::RO (so `given @a { $_ = 5 }` errors, matching raku).
+      The *expression*-level leading-dot `.=` (e.g. an `andthen`/`orelse` chain
+      RHS) keeps the plain `AssignExpr` form so the chain-retarget mechanism still
+      works. `map`'s native rw classifier (`vm_native_map.rs`) recognizes the new
+      marker as a topic mutation. t/dotassign-store-and-container-topic.t.
+    - **(36) listop / colon-method args** now stop before the loose word-logical
+      operators (`andthen`/`and`/`or`/`orelse`/`notandthen`/`xor`), matching Raku
+      precedence (`f $x andthen $y` is `(f $x) andthen $y`). New
+      `ExprMode::ListopArg` gates the word-logical-op loops in
+      `expr/precedence/logic.rs`; `listop_arg_expr` and every colon-arg parser use
+      it. Fixed test 36's 4-link `… andthen .=new: :10a, :20b` chain. Also
+      `(X.self).=meth` === `X.=meth` (`.self` is identity). t/listop-arg-loose-
+      logical-precedence.t.
   - **2026-06-28: (historical) 36/38 pass (2 failing: 32, 36).** Landed:
     - (#3894) string-block method names (`."{$c++; "new"}"`), inline-decl /
       do-block `.=` targets (`(my Int $x .= new).= new`, `do {…}.= new`), and

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -221,6 +221,7 @@ roast/S03-operators/gcd.t
 roast/S03-operators/identity.t
 roast/S03-operators/increment.t
 roast/S03-operators/infixed-function.t
+roast/S03-operators/inplace.t
 roast/S03-operators/is-divisible-by.t
 roast/S03-operators/lcm.t
 roast/S03-operators/list-quote-junction.t

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -213,6 +213,17 @@ impl Compiler {
                 self.code.emit(OpCode::MakeCapture(items.len() as u32));
             }
             // Expression-level function call
+            // `.=`-on-topic marker (`$_ .= meth` / `.=meth`): compile the method
+            // result, then `TopicDotAssign` (assigns `$_` bypassing the
+            // whole-container read-only mark and writes through to a container
+            // topic source). See `parser::expr::postfix::dot_assign` / `topic_method_call`.
+            Expr::Call { name, args }
+                if name.resolve() == "__mutsu_topic_dotassign" && args.len() == 1 =>
+            {
+                self.compile_expr(&args[0]);
+                let name_idx = self.code.add_constant(Value::str("_".to_string()));
+                self.code.emit(OpCode::TopicDotAssign(name_idx));
+            }
             Expr::Call { name, args } => {
                 self.compile_expr_call(name, args);
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -750,6 +750,12 @@ pub(crate) enum OpCode {
 
     // -- Assignment as expression --
     AssignExpr(u32),
+    /// `.=` metaop on the topic `$_` (`$_ = $_.meth`). Like `AssignExpr` of `_`,
+    /// but bypasses the read-only mark a whole-container topic (`given @a`) puts
+    /// on `$_` and, for such a topic, writes the reassigned value straight through
+    /// to the `@`/`%` source container. The operand (the method result) is on the
+    /// stack; the constant index names `_`.
+    TopicDotAssign(u32),
     /// Assignment as expression for local variable (indexed slot)
     AssignExprLocal(u32),
     /// Fused compound assignment to a NAMED (env) scalar: `$x OP= rhs`.
@@ -1501,7 +1507,7 @@ impl CompiledCode {
                 | OpCode::PreDecrement(idx)
                 | OpCode::GetArrayVar(idx)
                 | OpCode::GetHashVar(idx) => Some(*idx),
-                OpCode::AssignExpr(idx) => Some(*idx),
+                OpCode::AssignExpr(idx) | OpCode::TopicDotAssign(idx) => Some(*idx),
                 _ => None,
             };
             if let Some(idx) = name_idx
@@ -1600,7 +1606,8 @@ impl CompiledCode {
                 | OpCode::PreDecrement(idx)
                 | OpCode::GetArrayVar(idx)
                 | OpCode::GetHashVar(idx)
-                | OpCode::AssignExpr(idx) => Some(*idx),
+                | OpCode::AssignExpr(idx)
+                | OpCode::TopicDotAssign(idx) => Some(*idx),
                 _ => None,
             };
             if let Some(idx) = name_idx
@@ -1659,6 +1666,7 @@ impl CompiledCode {
             | OpCode::GetArrayVar(idx)
             | OpCode::GetHashVar(idx)
             | OpCode::AssignExpr(idx)
+            | OpCode::TopicDotAssign(idx)
             | OpCode::AtomicCompoundVar { name_idx: idx, .. } => Some(*idx),
             _ => None,
         }
@@ -1725,6 +1733,7 @@ impl CompiledCode {
             | OpCode::PreIncrement(idx)
             | OpCode::PreDecrement(idx)
             | OpCode::AssignExpr(idx)
+            | OpCode::TopicDotAssign(idx)
             | OpCode::AtomicCompoundVar { name_idx: idx, .. } => Some(*idx),
             _ => None,
         }
@@ -2089,6 +2098,7 @@ impl CompiledCode {
                 OpCode::SetGlobal(_)
                     | OpCode::SetGlobalRaw(_)
                     | OpCode::AssignExpr(_)
+                    | OpCode::TopicDotAssign(_)
                     | OpCode::AssignExprLocal(_)
                     | OpCode::AtomicCompoundVar { .. }
                     | OpCode::IndexAssignExprNamed { .. }

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -50,6 +50,11 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
         };
     };
     match &target {
+        // NOTE: an *expression*-position `$_ .= meth` keeps the plain `AssignExpr`
+        // form (so a chain-retarget can redirect the implied `$_`). The whole-
+        // container topic write-through (`given @a { $_ .= uc }`) is a *statement*
+        // and is handled via the `__mutsu_topic_dotassign` marker in the statement
+        // assign parser instead.
         Expr::Var(name) => Expr::AssignExpr {
             name: name.clone(),
             expr: Box::new(method_call_fn(target)),

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -991,6 +991,12 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
                 modifier: None,
                 quoted: false,
             };
+            // NOTE: a leading-dot `.=meth` in *expression* position (e.g. the RHS
+            // of an `andthen`/`orelse` chain) keeps the plain `AssignExpr` form so
+            // the chain-retarget mechanism can redirect the implied `$_` to the
+            // chain root variable. The whole-container topic write-through (`given
+            // @a { .=uc }`) is handled by the *statement*-level `.=` paths via the
+            // `__mutsu_topic_dotassign` marker instead.
             return Ok((
                 r,
                 Expr::AssignExpr {

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -267,10 +267,17 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
                     modifier: None,
                 },
             };
-            let stmt = Stmt::Assign {
-                name,
-                expr: method_expr,
-                op: AssignOp::Assign,
+            let stmt = if name == "_" {
+                Stmt::Expr(Expr::Call {
+                    name: Symbol::intern("__mutsu_topic_dotassign"),
+                    args: vec![method_expr],
+                })
+            } else {
+                Stmt::Assign {
+                    name,
+                    expr: method_expr,
+                    op: AssignOp::Assign,
+                }
             };
             return parse_statement_modifier(r_final, stmt);
         }
@@ -353,10 +360,20 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             modifier: None,
             quoted: false,
         };
-        let stmt = Stmt::Assign {
-            name,
-            expr,
-            op: AssignOp::Assign,
+        // `$_ .= meth`: route the topic metaop through `__mutsu_topic_dotassign`
+        // so it can reassign a read-only whole-container topic while a plain
+        // `$_ = ...` still throws X::Assignment::RO.
+        let stmt = if name == "_" {
+            Stmt::Expr(Expr::Call {
+                name: Symbol::intern("__mutsu_topic_dotassign"),
+                args: vec![expr],
+            })
+        } else {
+            Stmt::Assign {
+                name,
+                expr,
+                op: AssignOp::Assign,
+            }
         };
         return parse_statement_modifier(r, stmt);
     }

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -48,17 +48,20 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
         } else {
             (rest, Vec::new())
         };
-        let stmt = Stmt::Assign {
-            name: "_".to_string(),
-            expr: Expr::MethodCall {
+        // The `.=` metaop on the topic. Route through the `__mutsu_topic_dotassign`
+        // marker (compiled to `TopicDotAssign`) so it can reassign a read-only
+        // whole-container topic (`given @a { .=uc }`, writing through to `@a`)
+        // while a plain `$_ = ...` keeps throwing X::Assignment::RO.
+        let stmt = Stmt::Expr(Expr::Call {
+            name: Symbol::intern("__mutsu_topic_dotassign"),
+            args: vec![Expr::MethodCall {
                 target: Box::new(Expr::Var("_".to_string())),
                 name: Symbol::intern(&method_name),
                 args,
                 modifier: None,
                 quoted: false,
-            },
-            op: AssignOp::Assign,
-        };
+            }],
+        });
         return parse_statement_modifier(rest, stmt);
     }
 
@@ -355,6 +358,15 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             quoted: false,
         };
         match expr {
+            // `$_ .= meth`: route the topic metaop through `__mutsu_topic_dotassign`
+            // (see the leading-dot case above).
+            Expr::Var(name) if name == "_" => {
+                let stmt = Stmt::Expr(Expr::Call {
+                    name: Symbol::intern("__mutsu_topic_dotassign"),
+                    args: vec![make_rhs(Expr::Var("_".to_string()))],
+                });
+                return parse_statement_modifier(r, stmt);
+            }
             Expr::Var(name) => {
                 let stmt = Stmt::Assign {
                     name: name.clone(),

--- a/src/parser/stmt/tests_2.rs
+++ b/src/parser/stmt/tests_2.rs
@@ -107,8 +107,13 @@ fn parse_topic_mutating_method_stmt() {
     let (rest, stmts) = program(".=fmt('%03b');").unwrap();
     assert_eq!(rest, "");
     assert_eq!(stmts.len(), 1);
-    // .=method on topic assigns back to $_
-    assert!(matches!(&stmts[0], Stmt::Assign { name, .. } if name == "_"));
+    // `.=method` on the topic is the `.=` metaop (`$_ = $_.method`), routed through
+    // the `__mutsu_topic_dotassign` marker so it can reassign a read-only whole-
+    // container topic while a plain `$_ = ...` still throws X::Assignment::RO.
+    assert!(matches!(
+        &stmts[0],
+        Stmt::Expr(Expr::Call { name, .. }) if name.resolve() == "__mutsu_topic_dotassign"
+    ));
 }
 
 #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1372,6 +1372,13 @@ pub struct Interpreter {
     pub(crate) container_ref_var: Option<String>,
     pub(crate) container_ref_reversed: bool,
     pub(crate) topic_source_var: Option<String>,
+    /// The `@`/`%` source variable when `$_` is a whole-container topic
+    /// (`given @a` / `with %h`), where `$_` aliases the entire container. A `.=`
+    /// metaop on the topic (`TopicDotAssign`) writes the reassigned `$_` straight
+    /// through to this source with container-assignment coercion. Distinct from
+    /// `topic_source_var`, which a `for @a` element loop also sets but where `$_`
+    /// is a single element (handled by the per-element writeback, not this).
+    pub(crate) topic_container_source: Option<String>,
     pub(crate) element_source: Option<(String, Value, bool)>,
     pub(crate) quanthash_bind_params: Vec<String>,
     pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2062,6 +2062,7 @@ impl Interpreter {
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,
+            topic_container_source: None,
             element_source: None,
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -281,6 +281,7 @@ impl Interpreter {
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,
+            topic_container_source: None,
             element_source: None,
             quanthash_bind_params: Vec::new(),
             for_param_restore_stack: Vec::new(),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2915,6 +2915,10 @@ impl Interpreter {
                 self.exec_assign_expr_op(code, *name_idx)?;
                 *ip += 1;
             }
+            OpCode::TopicDotAssign(name_idx) => {
+                self.exec_topic_dot_assign_op(code, *name_idx)?;
+                *ip += 1;
+            }
             OpCode::AtomicCompoundVar { name_idx, op } => {
                 self.exec_atomic_compound_var_op(code, *name_idx, *op)?;
                 *ip += 1;

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -27,6 +27,7 @@ impl Interpreter {
         let saved_topic = self.env().get("_").cloned();
         let saved_when = self.when_matched();
         let saved_topic_source = self.topic_source_var.take();
+        let saved_container_source = self.topic_container_source.take();
         let saved_element_source = self.element_source.take();
         let container_binding = self.container_ref_var.take();
         // An element-source topic (`given %h<k>` / `given @a[i]`) aliases an
@@ -36,6 +37,16 @@ impl Interpreter {
         let element_source = saved_element_source.clone();
         if element_source.is_none() {
             self.topic_source_var = container_binding.clone();
+        }
+        // A whole-container topic (`given @a` / `with %h`): `$_` aliases the whole
+        // container, so a `.=` metaop on the topic (TopicDotAssign) writes the
+        // reassigned value straight through to the `@`/`%` source. Record it so the
+        // `.=`-on-`$_` opcode can do that (an element loop never sets this).
+        if element_source.is_none()
+            && let Some(src) = &container_binding
+            && (src.starts_with('@') || src.starts_with('%'))
+        {
+            self.topic_container_source = Some(src.clone());
         }
         self.env_mut().insert("_".to_string(), topic);
         loan_env!(self, set_when_matched(false));
@@ -89,6 +100,7 @@ impl Interpreter {
                 this.unmark_readonly(p);
             }
             this.topic_source_var = saved_topic_source.clone();
+            this.topic_container_source = saved_container_source.clone();
             // `element_source` is a one-shot signal set by `TagElementSource`
             // immediately before this `Given`, so consuming it must clear it (not
             // restore the just-set value). Re-setting `saved_element_source` here

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -212,6 +212,60 @@ impl Interpreter {
         r
     }
 
+    /// `.=` metaop on the topic `$_` (`$_ = $_.meth`). Identical to `AssignExpr`
+    /// of `_` except that it (1) bypasses the read-only mark a whole-container
+    /// topic (`given @a`) places on `$_` — the `.=` metaop is always allowed even
+    /// where a plain `$_ = ...` throws X::Assignment::RO — and (2) for such a
+    /// whole-container topic, writes the reassigned value straight through to the
+    /// `@`/`%` source with container-assignment coercion (`@a = "FOO"` => `["FOO"]`),
+    /// so the mutation is visible immediately inside the block.
+    pub(super) fn exec_topic_dot_assign_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let was_ro = self.is_readonly("_");
+        if was_ro {
+            self.unmark_readonly("_");
+        }
+        let r = self.exec_assign_expr_op(code, name_idx);
+        if was_ro {
+            self.mark_readonly("_");
+        }
+        r?;
+        // Whole-container topic (`given @a`/`with %h`): `$_` aliases the container,
+        // so the reassigned value is list-/hash-assigned back to the source. The
+        // assignment result (the method value, e.g. `"FOO"`) is on the stack top.
+        if let Some(src) = self.topic_container_source.clone() {
+            let val = self.stack.last().cloned().unwrap_or(Value::Nil);
+            let written = if src.starts_with('@') {
+                if matches!(val, Value::Array(..)) {
+                    val
+                } else {
+                    crate::runtime::utils::coerce_to_array(val)
+                }
+            } else if src.starts_with('%') {
+                if matches!(val, Value::Hash(_)) {
+                    val
+                } else {
+                    crate::runtime::utils::coerce_to_hash(val)
+                }
+            } else {
+                val
+            };
+            self.set_env_with_main_alias(&src, written.clone());
+            self.update_local_if_exists(code, &src, &written);
+            // Keep `$_` (which aliases the container) and the expression value in
+            // sync with the coerced container value.
+            self.set_env_with_main_alias("_", written.clone());
+            self.update_local_if_exists(code, "_", &written);
+            if let Some(top) = self.stack.last_mut() {
+                *top = written;
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn exec_get_env_index_op(&mut self, code: &CompiledCode, key_idx: u32) {
         let key = Self::const_str(code, key_idx);
         let val = if let Some(Value::Hash(env_hash)) = self.env().get("%*ENV") {

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -338,6 +338,9 @@ fn classify_expr(expr: &Expr) -> Option<bool> {
             Some(classify_expr(target)? | classify_exprs(args)?)
         }
         Expr::CallOn { target, args } => Some(classify_expr(target)? | classify_exprs(args)?),
+        // The `.=`-on-topic marker (`$_ .= meth` / `.=meth`) mutates `$_`, exactly
+        // like the `Stmt::Assign { name: "_" }` case in `classify_stmt`.
+        Expr::Call { name, .. } if name.resolve() == "__mutsu_topic_dotassign" => Some(true),
         Expr::Call { args, .. } => classify_exprs(args),
         Expr::StringInterpolation(items)
         | Expr::ArrayLiteral(items)

--- a/t/dotassign-store-and-container-topic.t
+++ b/t/dotassign-store-and-container-topic.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 9;
+plan 16;
 
 # `X.=meth` is `X = X.meth`. When the (evaluated-once) target X provides a
 # `STORE` method it is a custom container, so the `.=` becomes `X.STORE(X.meth)`
@@ -62,4 +62,43 @@ plan 9;
     my @a = <c a b>;
     @a .= sort;
     is-deeply @a, ['a', 'b', 'c'], '.= on an array lvalue assigns the sorted list';
+}
+
+# The `.=` metaop on a whole-container topic (`given @a` / `with @a`) writes
+# through to the source container immediately. `$_` aliases the container, so a
+# *plain* `$_ = ...` still throws (read-only), but the `.=` metaop is allowed.
+{
+    my @a = 'foo';
+    with @a { .=uc; is-deeply @a, ['FOO'], '.=uc on container topic writes through immediately' }
+}
+{
+    my @a = 'foo';
+    given @a { $_ .= uc }
+    is-deeply @a, ['FOO'], '$_ .= uc (spaced) on container topic writes back';
+}
+{
+    my @a = 'foo';
+    given @a { $_.=uc }
+    is-deeply @a, ['FOO'], '$_.=uc (no space) on container topic writes back';
+}
+{
+    my $a = 'foo';
+    with $a { .=uc }
+    is $a, 'FOO', '.=uc on a scalar topic writes back';
+}
+{
+    my @a = 1, 2;
+    throws-like { given @a { $_ = 5 } }, X::Assignment::RO,
+        'plain $_ = ... on a read-only container topic still throws';
+}
+{
+    # for-loop element topic is unaffected (per-element, not whole-container).
+    my @a = <x y>;
+    for @a { .=uc }
+    is-deeply @a, ['X', 'Y'], 'for @a { .=uc } mutates each element';
+}
+{
+    $_ = -42;
+    .=abs;
+    is $_, 42, '.=abs on a plain top-level $_ topic works';
 }


### PR DESCRIPTION
## Summary

The `.=` metaop on the topic `$_` (`given @a { .=uc }` / `with @a { $_ .= uc }`) must reassign-through to the source container, even though mutsu marks a whole-container topic `$_` read-only so a *plain* `$_ = ...` throws `X::Assignment::RO` (matching raku, which rejects `$_ = $_.uc` but allows `.=uc`).

`.=` and `$_ = $_.meth` compile to the same `Assign`-to-`_`, so they are distinguished **at the source**: the *statement*-level `.=`-on-`$_` parse paths now emit a `__mutsu_topic_dotassign` marker, compiled to the new `OpCode::TopicDotAssign`. That opcode assigns `$_` bypassing the read-only mark and, for a whole-container topic, writes the value straight through to the `@`/`%` `topic_container_source` with container-assignment coercion (`@a = "FOO"` ⇒ `["FOO"]`), immediately visible inside the block. A plain `$_ = ...` keeps the normal path and still throws.

## Design notes

- The *expression*-level leading-dot `.=` (e.g. an `andthen`/`orelse` chain RHS) deliberately keeps the plain `AssignExpr` form so the existing chain-retarget mechanism still redirects the implied `$_` to the chain root.
- `for @a { .=uc }` (per-element topic) is unaffected — it never sets `topic_container_source`.
- `map`'s native rw classifier (`vm_native_map.rs`) recognizes the new marker as a topic mutation.
- A plain `$_ = 5` on a container topic still throws `X::Assignment::RO` (verified), so this does **not** regress `t/with-topic-alias.t`.

## Result

Closes **roast/S03-operators/inplace.t (38/38)** — together with the already-merged `.=`-STORE-container fix (#3936, subtest 32) and listop-arg precedence fix (#3933, subtest 36) — and adds it to the whitelist.

## Testing

- `make test` passes.
- `make roast` passes with inplace.t whitelisted (no other whitelisted regression).
- `t/dotassign-store-and-container-topic.t` (16 cases); updated the parser unit test asserting the topic `.=` AST shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)