### PR TITLE
feat(parser): bodyless sub parameterizing non-parametric type throws X::NotParametric (misc.t #84)

### DIFF
--- a/src/parser/stmt/sub/sub_decl.rs
+++ b/src/parser/stmt/sub/sub_decl.rs
@@ -296,6 +296,51 @@ pub(crate) fn sub_decl_body(
         ));
     }
     if rest.is_empty() {
+        // A bodyless `sub foo(C of Int)` whose signature parameterizes a
+        // non-parametric user type (`C[Int]`) must report X::NotParametric, not
+        // "missing block" — raku evaluates the `of` parameterization while
+        // parsing the signature, before noticing the absent body. We can't tell
+        // parametric from non-parametric here, so emit a bodyless stub and let
+        // the compile-time pre-pass (validate_param_type_constraints) raise
+        // X::NotParametric for declared classes/packages. Only do this when the
+        // base names a user-declared type, so builtin parametric forms like
+        // `sub foo(Array[Int])` still report the missing block.
+        let parameterizes_user_type = param_defs.iter().any(|pd| {
+            pd.type_constraint
+                .as_deref()
+                .and_then(|tc| tc.split_once('['))
+                .map(|(base, _)| base.trim())
+                .is_some_and(|base| {
+                    !base.is_empty()
+                        && base.starts_with(|c: char| c.is_ascii_uppercase())
+                        && super::super::simple::is_user_declared_type(base)
+                })
+        });
+        if parameterizes_user_type {
+            let merged_return_type = return_type.or(traits.return_type);
+            return Ok((
+                rest,
+                Stmt::SubDecl {
+                    name: Symbol::intern(&name),
+                    name_expr,
+                    params,
+                    param_defs,
+                    return_type: merged_return_type,
+                    associativity: traits.associativity,
+                    precedence_trait: traits.precedence_trait,
+                    signature_alternates,
+                    body: Vec::new(),
+                    multi,
+                    is_rw: traits.is_rw,
+                    is_raw: traits.is_raw,
+                    is_export: traits.is_export,
+                    export_tags: traits.export_tags,
+                    is_test_assertion: traits.is_test_assertion,
+                    supersede,
+                    custom_traits: traits.custom_traits,
+                },
+            ));
+        }
         return Err(PError::expected("sub body '{ ... }'"));
     }
     let (rest, body) = if param_defs.iter().any(|p| p.sigilless) {

--- a/t/not-parametric.t
+++ b/t/not-parametric.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 10;
+plan 11;
 
 # Parameterizing a non-parametric type (a plain class / package / module) with
 # `[T]` throws X::NotParametric. Only roles and built-in container types accept
@@ -20,6 +20,12 @@ throws-like 'my module M { }; sub foo(M of Int) { }', X::NotParametric,
     'module "of" parameter is not parameterizable';
 throws-like 'my class C { }; sub foo(C of Int) { }', X::NotParametric,
     'class "of" parameter is not parameterizable';
+
+# Even a bodyless sub declaration reports X::NotParametric: raku evaluates the
+# `of` parameterization while parsing the signature, before noticing the missing
+# block, so the parameterization error wins.
+throws-like 'my class C { }; sub foo(C of Int)', X::NotParametric,
+    'bodyless class "of" parameter is not parameterizable';
 
 # Built-in container types and roles ARE parameterizable.
 {


### PR DESCRIPTION
## Summary

`roast/S32-exceptions/misc.t` test 84 (`throws-like 'my class C { }; sub foo(C of Int)', X::NotParametric`) failed because the parser rejected the bodyless `sub foo(C of Int)` with a generic "missing block" parse error *before* the compile-time pre-pass could raise the correct `X::NotParametric`.

raku evaluates the `of` parameterization while parsing the signature, before noticing the absent body — so the parameterization error wins over the missing-block error.

## Change

When a bodyless sub's signature parameterizes a **user-declared** type (constraint stored as `C[Int]`), emit a bodyless stub `SubDecl` and let the existing `validate_param_type_constraints` pre-pass raise `X::NotParametric`. Builtin parametric forms like `sub foo(Array[Int])` still report the missing block, since the base is not a user-declared type.

## Tests

- `roast/S32-exceptions/misc.t`: test 84 now passes (11 → 10 remaining failures).
- `t/not-parametric.t`: added a bodyless-sub case (plan 10 → 11).
- `make test` PASS; `cargo clippy -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)