### PR TITLE
fix(for): value-collecting for loop keeps assigned container (for.t #100)

### DIFF
--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -78,6 +78,26 @@ impl Compiler {
                     Stmt::Given { .. } => {
                         self.compile_stmt(stmt);
                     }
+                    // A bare assignment (`$s += $_`, desugared to `Stmt::Assign`)
+                    // in value-final position must yield the assigned container,
+                    // not Nil. Raku assignment is an expression returning the
+                    // lvalue container, so a value-collecting `for` body whose
+                    // last statement is `$s += $_` collects the `$s` container
+                    // each iteration (`(for 1..3 { $s += $_ })` is `(6, 6, 6)`,
+                    // not `(1, 3, 6)`). Route it through `AssignExpr` so it
+                    // leaves the same container the parenthesized form
+                    // `($s += $_)` would.
+                    Stmt::Assign {
+                        name,
+                        expr,
+                        op: op @ (crate::ast::AssignOp::Assign | crate::ast::AssignOp::Bind),
+                    } => {
+                        self.compile_expr(&Expr::AssignExpr {
+                            name: name.clone(),
+                            expr: Box::new(expr.clone()),
+                            is_bind: matches!(op, crate::ast::AssignOp::Bind),
+                        });
+                    }
                     _ => {
                         self.compile_stmt(stmt);
                         self.emit_nil_value();

--- a/t/for-collect-assign-container.t
+++ b/t/for-collect-assign-container.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 5;
+
+# A value-collecting `for` loop whose body's last statement is a bare
+# assignment must collect the assigned *container*, not Nil. Raku assignment
+# is an expression returning the lvalue container, so collecting `$s += $_`
+# each iteration yields the same `$s` container (all read as the final value).
+# https://github.com/Raku/old-issue-tracker/issues/2080 (S04-statements/for.t)
+{
+    my $s = 0;
+    is-deeply (for 1..3 { $s += $_ }), (6, 6, 6),
+        'for loop collects the assigned container (does not decontainerize)';
+}
+
+{
+    sub foo { my $s; (for 1..3 { $s += $_ }) }
+    is-deeply foo(), (6, 6, 6), 'for loops do not decontainerize (in a sub)';
+}
+
+# Plain `=` assignment in the body behaves the same way.
+{
+    my $x = 0;
+    is-deeply (for 1..3 { $x = $_ }), (3, 3, 3),
+        'plain = assignment in for body collects the container';
+}
+
+# The parenthesized form already worked; confirm parity.
+{
+    my $y = 0;
+    is-deeply (for 1..3 { ($y += $_) }), (6, 6, 6),
+        'parenthesized assignment matches the bare form';
+}
+
+# A non-assignment last statement still collects per-iteration values.
+{
+    is-deeply (for 1..3 -> $v { $v * 2 }), (2, 4, 6),
+        'non-assignment body still collects per-iteration values';
+}


### PR DESCRIPTION
## Summary

A `for` loop used in value context collects its body block's last-statement value. When that final statement is a bare assignment (`$s += $_`, which the parser desugars to `Stmt::Assign`), `compile_stmts_value` fell through to the default arm and emitted `Nil`. So:

```raku
sub foo { my $s; (for 1..3 { $s += $_ }) }
foo();   # was (Nil, Nil, Nil), should be (6, 6, 6)
```

Raku assignment is an expression that yields the lvalue **container**, so the parenthesized form `($s += $_)` (parsed as `Stmt::Expr(AssignExpr)`) already collected the `$s` container correctly — all three slots reference the same container, read as `6` at the end. This routes a bare final `Stmt::Assign` / `:=` through the same `AssignExpr` path so the two forms are consistent and the container (not `Nil`) is collected.

This is the same value-yielding behavior `compile_block_inline` already gives `do { ... }` blocks; `compile_stmts_value` (the for-collect / if-value path) simply lacked the `Stmt::Assign` case.

## Test impact

- `roast/S04-statements/for.t`: test 100 ("for loops do not decontainerize") now passes (104 → 105 subtests).
- New `t/for-collect-assign-container.t` (5 cases) pins the behavior, including parity with the parenthesized form.
- Full `make test` passes (13263 tests).

The remaining `for.t` failures (90-92 slurpy-raw element aliasing, 105/107 lazy `for`, 111 `@a[*]` slice writeback) are deeper, separate issues and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)