### PR TITLE
fix(map): preserve named/slip-arg tail call value in @-array rw map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -32,7 +32,7 @@ fn call_arg_to_expr(arg: &crate::ast::CallArg) -> crate::ast::Expr {
 /// it with `Stmt::Expr(Expr::Call)` so the re-compiled block leaves the call's
 /// value on the stack (otherwise a named/slip-arg tail call is compiled as a
 /// value-discarding statement and the map result wrongly falls back to `$_`).
-fn normalize_tail_call_for_value(body: &[crate::ast::Stmt]) -> Vec<crate::ast::Stmt> {
+pub(super) fn normalize_tail_call_for_value(body: &[crate::ast::Stmt]) -> Vec<crate::ast::Stmt> {
     use crate::ast::{Expr, Stmt};
     let Some(last_idx) = body.iter().rposition(|s| !matches!(s, Stmt::SetLine(_))) else {
         return body.to_vec();

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -74,9 +74,16 @@ impl Interpreter {
             };
             let mut result = Vec::new();
 
-            // Compile once, reuse VM for every iteration (same as eval_map_over_items)
+            // Compile once, reuse VM for every iteration (same as eval_map_over_items).
+            // Normalize a bare tail `Stmt::Call` carrying named/slip args (how an
+            // imported sub call like `f(k => v)` parses) into `Stmt::Expr(Expr::Call)`
+            // so its value is preserved as the block's result; otherwise it compiles
+            // as a value-discarding statement and the map result wrongly falls back
+            // to the topic `$_` (see `eval_map_over_items`).
             let compiler = crate::compiler::Compiler::new();
-            let (code, compiled_fns) = compiler.compile(&data.body);
+            let normalized_body =
+                super::resolution_map_grep::normalize_tail_call_for_value(&data.body);
+            let (code, compiled_fns) = compiler.compile(&normalized_body);
 
             let underscore = "_".to_string();
             let dollar_topic = "$_".to_string();

--- a/t/map-rw-tail-call-named-arg.t
+++ b/t/map-rw-tail-call-named-arg.t
@@ -1,0 +1,30 @@
+use Test;
+
+# A bare tail `Stmt::Call` carrying named args (how an imported/module sub call
+# like `f(k => v)` parses) used to be compiled as a value-discarding statement on
+# the `@array.map` rw path (`eval_map_over_items_rw`), so the map result wrongly
+# fell back to the topic `$_` instead of the call's return value. The non-rw path
+# (`eval_map_over_items`) already normalized the tail; this test pins the rw path.
+
+plan 6;
+
+# A module-style sub returning a distinct type, called with a named arg as the
+# block's tail statement. Mapping a *concrete @-array* (the rw path) must return
+# the sub's value, not the topic.
+sub wrap(:$content) returns Str { "wrapped:$content" }
+
+my @items = 1, 2, 3;
+my @mapped = @items.map: { wrap content => $_ };
+is @mapped[0], "wrapped:1", "named-arg tail call on rw map returns sub value (1)";
+is @mapped[1], "wrapped:2", "named-arg tail call on rw map returns sub value (2)";
+is @mapped[2], "wrapped:3", "named-arg tail call on rw map returns sub value (3)";
+
+# The same over a literal list (the non-rw path) already worked; keep it pinned.
+my @lit = (10, 20).map: { wrap content => $_ };
+is @lit[0], "wrapped:10", "named-arg tail call on list map returns sub value (1)";
+is @lit[1], "wrapped:20", "named-arg tail call on list map returns sub value (2)";
+
+# Positional tail call already worked; guard against regressions.
+sub double($n) { $n * 2 }
+my @pos = (1, 2, 3).map: { double $_ };
+is @pos.join(","), "2,4,6", "positional tail call on map still works";


### PR DESCRIPTION
## Problem

`@array.map: { f(k => v) }` returned the wrong value when the block's tail was a bare call carrying **named** (or slip) args to an imported/module-style sub. The result was the map topic `$_` instead of the call's return value.

Minimal repro:

```raku
sub wrap(:$content) returns Str { "wrapped:$content" }
my @items = 1, 2, 3;
say @items.map({ wrap content => $_ });   # got (1 2 3), want (wrapped:1 wrapped:2 wrapped:3)
```

This surfaced in `roast/S32-io/io-cathandle.t`: Test::Util's `make-files` does `@content.map: { ...; make-temp-file content => $_ }`, so every source came back as the topic `Str` instead of an `IO::Path`, breaking the whole test's setup.

## Root cause

A tail call with named/slip args parses as `Stmt::Call` and compiles as a **value-discarding statement**, so nothing is left on the stack and the map loop falls back to the topic `$_`.

The non-rw map path (`eval_map_over_items`) already guards against this by normalizing the tail into `Stmt::Expr(Expr::Call)` via `normalize_tail_call_for_value`. The concrete `@`-array **rw** path (`eval_map_over_items_rw`) compiled `data.body` directly and missed that normalization.

## Fix

Make `normalize_tail_call_for_value` `pub(super)` and apply it on the rw path too. Both map paths now preserve the tail call's value. Positional tail calls and literal-list maps were unaffected and stay working.

## Tests

- New `t/map-rw-tail-call-named-arg.t` pins the rw-path named-arg tail call, the list-path case, and a positional regression guard.
- `make test` passes (13307 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)