### PR TITLE
fix(class): same-named lexical classes in escaping scopes keep distinct identity

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -19,8 +19,6 @@
   （ローカル raku v2022.12=6.d でも実行不可で全体検証もできない）。
 - `S04-declarations/constant.t` → 演算子 `constant &op := &other` の
   **共有 alias**（現状コピー実装）。68/72、唯一の file-stopper。
-- `S02-literals/allomorphic.t`（§2.6） → **lexical class identity**
-  （同名 `my class` が global registry で後勝ち）。
 
 → **curated §2 Medium 群について「1 失敗の浅いターゲットは枯渇」が結論。** 残りは
 container identity / lazy-iterator / lexical-scope (dual-store) / 並行実行 という
@@ -346,31 +344,24 @@ materialize せず Seq のまま保持し（`.WHAT === Seq`）、`+@foo` は Lis
 - **評価**:
   parameterized role/MOP ほど深くはないが、型オブジェクト側の整理が必要。
 
-### 2.6 `S02-literals/allomorphic.t`
+### 2.6 `S02-literals/allomorphic.t` — ✅ DONE (2026-06-30)
 
-- **難度**: Medium-Hard
-- **論点**:
-  gather ブロックごとに同名 lexical class が別 identity を持つべきなのに、
-  いまは global map で潰れている。
-- **評価**:
-  「parser の小ネタ」ではなく **型宣言 identity** の問題。
-  ただし container identity ほど基盤工事ではない。
-
-- **2026-06-28 確認**: 残り失敗は 16/32/48（IntStr/RatStr/NumStr の `.ACCEPTS`）。
-  同名 `my class IntFoo` が @true gather（`method Numeric { 3 }`）と @false gather
-  （`method Numeric { 42 }`）で二重宣言され、@true の IntFoo.new は Numeric=3 を
-  保つべきだが mutsu は最後の定義（42）で潰す。最小再現:
-  ```raku
-  my @a = gather { my class Foo { method val { 1  } }; take Foo.new };
-  my @b = gather { my class Foo { method val { 99 } }; take Foo.new };
-  say @a[0].val, @b[0].val;   # mutsu: 99 99 / raku: 1 99
-  ```
-  gather 内で作った instance は値としてキャプチャされるが、メソッド dispatch 時に
-  クラス名 "Foo" を global registry で引くため、後勝ちの定義に解決される。
-  **verdict: deep（lexical class identity / dual-store debt）。** `my class` を
-  宣言ごとに別 identity として lexical scope に閉じ込め、instance がその identity を
-  保持する必要がある。同じ家系の課題: [[my-6e EVAL block-local scope leak]] と
-  同じ「block-local 宣言が global store に漏れる」debt。
+- **修正**: 同名 `my class` が宣言サイトごとに固有の identity を持つようにした。
+  - parser が各 `ClassDecl` に安定した `decl_id`（parse 時に採番、ループ本体は
+    同一ノード=同一 id）を付与。
+  - `exec_register_class_op` は、別サイトの同名 lexical class が既に「完全定義
+    （非 stub）」として registry に存在する場合、新しいクラスを mangled な内部名
+    `Foo\u{0}<decl_id>` で登録する。bare 名は lexical env 経由で mangled 名に
+    解決されるので、そのスコープ内の `Foo.new` は自分の identity を持つ instance を
+    生成し、別 gather の同名クラスを潰さない。
+  - stub upgrade（`my class C { ... }` → `my class C { ... }`）は registry 上の
+    既存エントリが stub のため mangle されず、同じエントリに着地する。
+  - `is Parent` の親参照は lexical env を通して解決し、mangled な親にも正しく
+    リンクする（roles-6e.t の同名 `my class C0` 二重宣言を守る）。
+  - 表示（`.^name` / `.gist` / `.raku` / `.WHAT`）は `user_facing_type_name` で
+    `\u{0}` 以降を落とし、ユーザからは常に bare 名に見える。
+- **確認**: allomorphic.t 119/119、roles-6e.t、class-too-late-for-repr.t、
+  `t/lexical-class-identity.t`、make test すべて green。
 
 ### 2.7 multislice lvalue
 

--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -23,22 +23,14 @@
   - 13/14 pass. Test 13 fails: `.tree([&first])` calls `first(self)` — WhateverCode form with closure array argument
 - [ ] roast/S02-literals/adverbs.t
   - 0/? pass. Parse error at line 7
-- [ ] roast/S02-literals/allomorphic.t
-  - **118/119 pass now** (was 117). Test 113 (`.Numeric on :U`) was FIXED by the
-    Mu.Numeric type-object coercion default (#3621) + scope-transparent `quietly`
-    (#3623): `Mu.Numeric` now warns+returns 0 instead of throwing, and `quietly`'s
-    warn-resume completes the guarded assignment inline. The plan-25-vs-ran-34
-    re-execution symptom was a downstream artifact of the `quietly`+warn-resume
-    interaction, now resolved.
-  - **ONLY test 107 (`.ACCEPTS` subtest) remains** — blocked on **per-decl class
-    identity** (Hard). The subtest declares `my class IntFoo {...}` (Numeric→3) in
-    the `@true` gather AND a different `my class IntFoo {...}` (Numeric→42) in the
-    `@false` gather. mutsu keys classes by name in one global registry map, so the
-    two same-named lexical classes collide (verified: both gathers' `IntFoo.new`
-    .Numeric return the SAME value). `IntStr.new(3,"3").ACCEPTS(IntFoo.new)` then
-    compares against the clobbered definition. Needs distinct identity per lexical
-    class declaration (mirror `role_id`/`role_candidates`). Same root as
-    S02-types/allomorphic-style same-name-lexical-class clobbers.
+- [x] roast/S02-literals/allomorphic.t
+  - **119/119 pass** (whitelisted). The `.ACCEPTS` subtest's per-decl class
+    identity blocker is FIXED: each lexical `my class` declaration site now gets a
+    stable parse-time `decl_id`, and a same-named lexical class from a different
+    site (the `@true` vs `@false` gather `IntFoo`) is stored under a mangled
+    internal name so its instances keep their own `.Numeric` definition instead of
+    being clobbered by the later declaration. Display strips the mangling so
+    `.^name`/`.gist`/`.raku` still show the bare name. See `t/lexical-class-identity.t`.
 - [ ] roast/S02-literals/array-interpolation.t
   - 5/12 pass (tests 1, 5, 7, 9, 11). Failures: `@array.[]` interpolation, `@array` without brackets not interpolating, embedded array ref stringification in double-quoted strings
 - [ ] roast/S02-literals/autoref.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -49,6 +49,7 @@ roast/S02-lexical-conventions/unspace.t
 roast/S02-lists/indexing.t
 roast/S02-lists/tree.t
 roast/S02-literals/adverbs.t
+roast/S02-literals/allomorphic.t
 roast/S02-literals/array-interpolation.t
 roast/S02-literals/autoref.t
 roast/S02-literals/char-by-name.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,6 +11,20 @@ fn default_is_positional() -> bool {
     true
 }
 
+/// A process-global counter assigning each `my class`/lexical `ClassDecl`
+/// declaration site a stable id at parse time. Two distinct source
+/// declarations get distinct ids; a single declaration inside a loop keeps one
+/// id across re-executions (the AST node, and thus its `decl_id` value, is
+/// shared). Used to give same-named lexical classes in different scopes their
+/// own type identity. See `Interpreter::exec_register_class_op`.
+static CLASS_DECL_ID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// Allocate the next class-declaration site id (always non-zero; 0 means
+/// "no stable site", e.g. a runtime-synthesized or deserialized node).
+pub(crate) fn next_class_decl_id() -> u64 {
+    CLASS_DECL_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Specifies how delegation (`handles`) should forward methods.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) enum HandleSpec {
@@ -795,6 +809,11 @@ pub(crate) enum Stmt {
         custom_traits: Vec<(String, Option<Expr>)>,
         /// Whether this class was declared with `unit class` (file-scoped body)
         is_unit: bool,
+        /// Stable per-declaration-site id (parse-time assigned, non-zero) used to
+        /// distinguish same-named lexical (`my`) classes in different scopes.
+        /// 0 means "no stable site" (runtime-synthesized or deserialized node).
+        #[serde(skip)]
+        decl_id: u64,
     },
     HasDecl {
         name: Symbol,

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -387,13 +387,14 @@ pub(super) fn dispatch(
             }
         }
         Value::Package(name) => {
+            let resolved = name.resolve();
+            let full = crate::value::user_facing_type_name(&resolved);
             if method == "gist" {
-                let full = name.resolve();
-                let short = full.rsplit("::").next().unwrap_or(&full);
+                let short = full.rsplit("::").next().unwrap_or(full);
                 Some(Ok(Value::str(format!("({})", short))))
             } else {
                 // .raku returns the full type name
-                Some(Ok(Value::str(name.resolve())))
+                Some(Ok(Value::str(full.to_string())))
             }
         }
         Value::Instance {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -91,6 +91,7 @@ impl Compiler {
                 language_version,
                 custom_traits,
                 is_unit,
+                decl_id,
                 ..
             } => {
                 let new_parents: Vec<String> = parents.iter().map(&qualify_parent).collect();
@@ -110,6 +111,7 @@ impl Compiler {
                     language_version: language_version.clone(),
                     custom_traits: custom_traits.clone(),
                     is_unit: *is_unit,
+                    decl_id: *decl_id,
                 }
             }
             Stmt::RoleDecl {

--- a/src/parser/primary/misc/anon_decl.rs
+++ b/src/parser/primary/misc/anon_decl.rs
@@ -128,6 +128,7 @@ pub(crate) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             language_version: crate::parser::current_language_version(),
             custom_traits: Vec::new(),
             is_unit: false,
+            decl_id: crate::ast::next_class_decl_id(),
         })),
     ))
 }

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -191,6 +191,7 @@ pub(crate) fn anon_class_decl(input: &str) -> PResult<'_, Stmt> {
         language_version: super::super::simple::current_language_version(),
         custom_traits: Vec::new(),
         is_unit: false,
+        decl_id: crate::ast::next_class_decl_id(),
     };
     // Emit the class registration followed by unregistering the name from the scope
     let unregister = Stmt::Expr(Expr::Call {
@@ -407,6 +408,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         language_version: super::super::simple::current_language_version(),
         custom_traits,
         is_unit: false,
+        decl_id: crate::ast::next_class_decl_id(),
     };
     let mut stmts = Vec::new();
     for (trait_name, trait_value) in traits {

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -163,6 +163,7 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
             language_version: super::super::simple::current_language_version(),
             custom_traits: Vec::new(),
             is_unit: false,
+            decl_id: crate::ast::next_class_decl_id(),
         },
     ))
 }

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -177,6 +177,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 language_version: super::super::simple::current_language_version(),
                 custom_traits: Vec::new(),
                 is_unit: true,
+                decl_id: crate::ast::next_class_decl_id(),
             },
         ));
     }
@@ -264,6 +265,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 language_version: super::super::simple::current_language_version(),
                 custom_traits: Vec::new(),
                 is_unit: true,
+                decl_id: crate::ast::next_class_decl_id(),
             },
         ));
     }

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -9,8 +9,12 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "name" if args.len() == 1 => Ok(Value::str(match &args[0] {
-                Value::Package(name) => name.resolve(),
-                Value::Instance { class_name, .. } => class_name.resolve(),
+                Value::Package(name) => {
+                    crate::value::user_facing_type_name(&name.resolve()).to_string()
+                }
+                Value::Instance { class_name, .. } => {
+                    crate::value::user_facing_type_name(&class_name.resolve()).to_string()
+                }
                 Value::ParametricRole {
                     base_name,
                     type_args,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -819,14 +819,15 @@ impl Interpreter {
                 }
                 // Collect public attributes for .raku representation
                 let class_key = class_name.resolve();
+                let display_name = crate::value::user_facing_type_name(&class_key);
                 let public_attrs =
                     self.collect_public_raku_attrs(&class_key, &(attributes).as_map());
                 if public_attrs.is_empty() {
-                    return Ok(Value::str(format!("{}.new", class_name)));
+                    return Ok(Value::str(format!("{}.new", display_name)));
                 }
                 return Ok(Value::str(format!(
                     "{}.new({})",
-                    class_name,
+                    display_name,
                     public_attrs.join(", ")
                 )));
             }

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -541,10 +541,16 @@ impl Interpreter {
     /// Dispatch .^name method
     pub(super) fn dispatch_caret_name(&self, target: &Value) -> Result<Value, RuntimeError> {
         Ok(Value::str(match target {
-            Value::Package(name) => name.resolve(),
-            Value::Instance { class_name, .. } => class_name.resolve(),
+            Value::Package(name) => {
+                crate::value::user_facing_type_name(&name.resolve()).to_string()
+            }
+            Value::Instance { class_name, .. } => {
+                crate::value::user_facing_type_name(&class_name.resolve()).to_string()
+            }
             Value::Mixin(inner, _) => match inner.as_ref() {
-                Value::Instance { class_name, .. } => class_name.resolve(),
+                Value::Instance { class_name, .. } => {
+                    crate::value::user_facing_type_name(&class_name.resolve()).to_string()
+                }
                 _ => value_type_name(target).to_string(),
             },
             Value::Promise(p) => p.class_name().resolve(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1321,6 +1321,21 @@ pub struct Interpreter {
     /// Stack of lexically-scoped class names per block scope depth.
     /// When a block scope exits, classes registered in that scope get suppressed.
     lexical_class_scopes: Vec<Vec<String>>,
+    /// Maps a lexical class's bare/qualified name to the source declaration site
+    /// (a stable per-`my class` site id) that currently owns that bare name in
+    /// the registry. A *different* site declaring the same name (e.g. two
+    /// `my class Foo` in separate `gather` blocks) must NOT clobber the first —
+    /// it is instead stored under a mangled internal name so its instances keep
+    /// their own type identity. See `exec_register_class_op`.
+    lexical_class_sites: std::collections::HashMap<String, u64>,
+    /// Per block-scope stack of `(qualified_name, decl_id)` ownership records.
+    /// When a block scope exits, its ownership entries are released from
+    /// `lexical_class_sites`, so a later same-named lexical class declared in a
+    /// *sequential* (already-exited) block reuses the bare name. Bodies that do
+    /// NOT push a block scope — `gather`/coroutine bodies whose produced
+    /// instances escape — keep their ownership, so their same-named siblings are
+    /// given distinct mangled identities. See `pop_lexical_class_scope`.
+    lexical_class_owner_scopes: Vec<Vec<(String, u64)>>,
     /// Last expression value from VM execution, used by REPL for auto-display.
     pub(crate) last_value: Option<Value>,
     /// Pending env updates from regex code blocks, to be synced to VM locals.

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -277,6 +277,7 @@ impl Interpreter {
                 body: _,
                 language_version,
                 custom_traits,
+                decl_id,
                 ..
             } = &stmts[idx]
             {
@@ -295,6 +296,7 @@ impl Interpreter {
                     language_version: language_version.clone(),
                     custom_traits: custom_traits.clone(),
                     is_unit: true,
+                    decl_id: *decl_id,
                 });
             }
             result

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -122,13 +122,24 @@ impl Interpreter {
     /// Push a new lexical class scope frame.
     pub(crate) fn push_lexical_class_scope(&mut self) {
         self.lexical_class_scopes.push(Vec::new());
+        self.lexical_class_owner_scopes.push(Vec::new());
     }
 
-    /// Pop a lexical class scope frame, suppressing all class names registered in it.
+    /// Pop a lexical class scope frame, suppressing all class names registered in
+    /// it and releasing ownership of any lexical class names it claimed, so a
+    /// later same-named lexical class in a sequential scope reuses the bare name
+    /// (see `lexical_class_owner_scopes`).
     pub(crate) fn pop_lexical_class_scope(&mut self) {
         if let Some(names) = self.lexical_class_scopes.pop() {
             for name in names {
                 self.suppressed_names.insert(name);
+            }
+        }
+        if let Some(owned) = self.lexical_class_owner_scopes.pop() {
+            for (qualified, decl_id) in owned {
+                if self.lexical_class_sites.get(&qualified) == Some(&decl_id) {
+                    self.lexical_class_sites.remove(&qualified);
+                }
             }
         }
     }
@@ -137,6 +148,76 @@ impl Interpreter {
     pub(crate) fn register_lexical_class(&mut self, name: String) {
         if let Some(scope) = self.lexical_class_scopes.last_mut() {
             scope.push(name);
+        }
+    }
+
+    /// The declaration site that currently owns the given bare/qualified lexical
+    /// class name in the registry, if any. See `lexical_class_sites`.
+    pub(crate) fn lexical_class_site_owner(&self, name: &str) -> Option<u64> {
+        self.lexical_class_sites.get(name).copied()
+    }
+
+    /// Record `site_id` as the owner of the bare/qualified lexical class name,
+    /// and remember it in the current block scope so ownership is released when
+    /// that scope exits (see `pop_lexical_class_scope`).
+    pub(crate) fn set_lexical_class_site_owner(&mut self, name: String, site_id: u64) {
+        self.lexical_class_sites.insert(name.clone(), site_id);
+        if let Some(frame) = self.lexical_class_owner_scopes.last_mut() {
+            frame.push((name, site_id));
+        }
+    }
+
+    /// Resolve a parent type reference (`is Foo`) through the current lexical env.
+    /// A lexical parent may live in the registry under a mangled storage name; the
+    /// env binds the bare name to that storage name, so `is Foo` links to the Foo
+    /// visible in *this* scope rather than a same-named class from another scope.
+    pub(crate) fn lexical_env_remap_name(&self, name: &str) -> String {
+        if let Some(Value::Package(p)) = self.env().get(name) {
+            let resolved = p.resolve();
+            if resolved != name {
+                return resolved;
+            }
+        }
+        name.to_string()
+    }
+
+    /// Remap a freshly-registered role's recorded class parents through the
+    /// lexical env (see `lexical_env_remap_name`). Mirrors the class-parent
+    /// remapping in `exec_register_class_op` so a role's `is C0` links to the same
+    /// (possibly mangled) lexical class that a class's `is C0` would.
+    pub(crate) fn remap_role_parents_via_env(&mut self, name: &str) {
+        let parents = self.registry().role_parents.get(name).cloned();
+        if let Some(parents) = parents {
+            let remapped: Vec<String> = parents
+                .iter()
+                .map(|p| self.lexical_env_remap_name(p))
+                .collect();
+            if remapped != parents {
+                let mut reg = self.registry_mut();
+                if let Some(v) = reg.role_parents.get_mut(name) {
+                    *v = remapped;
+                }
+            }
+        }
+        // The most recently pushed candidate carries this declaration's own
+        // parents (used for MRO construction); remap those too.
+        let cand_parents = self
+            .registry()
+            .role_candidates
+            .get(name)
+            .and_then(|c| c.last())
+            .map(|c| c.parents.clone());
+        if let Some(cand_parents) = cand_parents {
+            let remapped: Vec<String> = cand_parents
+                .iter()
+                .map(|p| self.lexical_env_remap_name(p))
+                .collect();
+            if remapped != cand_parents {
+                let mut reg = self.registry_mut();
+                if let Some(last) = reg.role_candidates.get_mut(name).and_then(|c| c.last_mut()) {
+                    last.parents = remapped;
+                }
+            }
         }
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2039,6 +2039,8 @@ impl Interpreter {
             enum_scope_names: vec![Vec::new()],
             my_scoped_package_items: HashSet::new(),
             lexical_class_scopes: Vec::new(),
+            lexical_class_sites: HashMap::new(),
+            lexical_class_owner_scopes: Vec::new(),
             last_value: None,
             pending_local_updates: Vec::new(),
             readonly_vars: HashSet::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -255,6 +255,8 @@ impl Interpreter {
             enum_scope_names: self.enum_scope_names.clone(),
             my_scoped_package_items: self.my_scoped_package_items.clone(),
             lexical_class_scopes: self.lexical_class_scopes.clone(),
+            lexical_class_sites: self.lexical_class_sites.clone(),
+            lexical_class_owner_scopes: self.lexical_class_owner_scopes.clone(),
             last_value: None,
             pending_local_updates: Vec::new(),
             readonly_vars: HashSet::new(),

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -6,6 +6,20 @@ pub(crate) fn is_internal_anon_type_name(name: &str) -> bool {
     name.starts_with("__ANON_") && name.ends_with("__")
 }
 
+/// A lexically-scoped `my class`/`my role` whose bare name collides with an
+/// earlier same-named lexical declaration is stored in the registry under a
+/// mangled internal name `Foo\u{0}<site-id>` so its instances keep their own
+/// identity (see `exec_register_class_op`). The `\u{0}` separator can never
+/// appear in a source identifier, so the user-facing name is just everything
+/// before it. This is a pure function so `display.rs` (which has no interpreter
+/// context) can strip the suffix for `.gist`/`.raku`/`say`.
+pub(crate) fn user_facing_type_name(name: &str) -> &str {
+    match name.split_once('\u{0}') {
+        Some((short, _)) => short,
+        None => name,
+    }
+}
+
 /// Format a value for display inside a Capture gist.
 fn capture_value_gist(v: &Value) -> String {
     match v {
@@ -612,10 +626,11 @@ impl Value {
                 format!("CompUnit::DependencySpecification({})", short_name)
             }
             Value::Package(s) => {
-                if is_internal_anon_type_name(&s.resolve()) {
+                let resolved = s.resolve();
+                if is_internal_anon_type_name(&resolved) {
                     "()".to_string()
                 } else {
-                    format!("({})", s)
+                    format!("({})", user_facing_type_name(&resolved))
                 }
             }
             Value::ParametricRole {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -320,6 +320,7 @@ pub(crate) fn current_time_secs_f64() -> f64 {
 }
 
 pub(crate) use display::is_internal_anon_type_name;
+pub(crate) use display::user_facing_type_name;
 pub use display::{format_complex, tclc_str, wordcase_str};
 pub(crate) use error::expected_type_object;
 pub use error::{Control, RuntimeError, RuntimeErrorCode};

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -68,6 +68,7 @@ impl Interpreter {
             body,
             language_version,
             custom_traits,
+            decl_id,
             ..
         } = stmt
         {
@@ -89,10 +90,57 @@ impl Interpreter {
             } else {
                 format!("{current_package}::{resolved_name}")
             };
+            // A lexical (`my`) class is stored in the registry under a *storage
+            // name* that is normally the same as `qualified_name`. But when a
+            // *different* source declaration site reuses the same name *after the
+            // earlier one's scope has exited* (e.g. two `my class Foo` in
+            // separate `gather` blocks), it must not clobber the first one —
+            // instances of the first class still reference it by name. Such a
+            // later, out-of-scope collision is stored under a mangled internal
+            // name `Foo\u{0}<site-id>`. The site id is the parse-time-assigned
+            // `decl_id`, stable across re-executions of the same site (a loop
+            // body keeps one identity) but distinct between sites. `decl_id == 0`
+            // (deserialized/synthesized node) opts out.
+            //
+            // A same-name declaration that is *upgrading a stub* of the same name
+            // (`my class C { ... }` then `my class C { ... }`) is NOT a collision:
+            // it must keep the bare name so the definition lands on the same
+            // registry entry. So only mangle when the existing same-named class
+            // is already a fully-defined (non-stub) class from a different site.
+            let storage_name = if *is_lexical && *decl_id != 0 {
+                match self.lexical_class_site_owner(&qualified_name) {
+                    Some(owner)
+                        if owner != *decl_id
+                            && self.has_class(&qualified_name)
+                            && !self.registry().class_stubs.contains(&qualified_name) =>
+                    {
+                        format!("{qualified_name}\u{0}{decl_id}")
+                    }
+                    _ => {
+                        self.set_lexical_class_site_owner(qualified_name.clone(), *decl_id);
+                        qualified_name.clone()
+                    }
+                }
+            } else {
+                qualified_name.clone()
+            };
             // If the name was previously suppressed (e.g. by a `my class` in an
             // earlier block), clear the suppression before running the class body
             // so that references to the class name inside the body can resolve.
             self.unsuppress_name(&resolved_name);
+            // Parent class references (`is Foo`) are stored by bare name, but a
+            // lexical parent may live in the registry under a mangled storage
+            // name (see `storage_name` above). Resolve each parent through the
+            // current lexical env so `is C0` binds to the C0 visible in *this*
+            // scope, not a same-named class from an unrelated earlier scope.
+            let mapped_parents: Vec<String> = parents
+                .iter()
+                .map(|p| self.lexical_env_remap_name(p))
+                .collect();
+            let mapped_hidden_parents: Vec<String> = hidden_parents
+                .iter()
+                .map(|p| self.lexical_env_remap_name(p))
+                .collect();
             // TODO: Detect redeclaration of package-scoped classes across
             // EVAL boundaries (X::Redeclaration). Currently deferred because
             // distinguishing EVAL re-definitions from normal re-execution
@@ -101,13 +149,13 @@ impl Interpreter {
             let deferred_traits = loan_env!(
                 self,
                 register_class_decl(
-                    &qualified_name,
-                    parents,
+                    &storage_name,
+                    &mapped_parents,
                     crate::runtime::ClassDeclModifiers {
                         class_is_rw: *class_is_rw,
                         is_hidden: *is_hidden,
                         is_lexical: *is_lexical,
-                        hidden_parents,
+                        hidden_parents: &mapped_hidden_parents,
                         does_parents,
                         language_version,
                     },
@@ -116,30 +164,33 @@ impl Interpreter {
             )?;
             // Check for assignment to native read-only params before
             // compiling (X::Assignment::RO::Comp).
-            if let Some(err) = self.check_class_native_readonly_param_errors(&qualified_name) {
+            if let Some(err) = self.check_class_native_readonly_param_errors(&storage_name) {
                 return Err(err);
             }
             // Compile method bodies to bytecode for the fast path
-            self.compile_class_methods(&qualified_name);
+            self.compile_class_methods(&storage_name);
             // Register CUnion repr if present
             if let Some(repr_name) = repr
                 && repr_name == "CUnion"
             {
-                self.register_cunion_class(&qualified_name);
+                self.register_cunion_class(&storage_name);
             }
             // Register the class name in the lexical env so that
             // ::("ClassName") indirect lookups can find it in the current scope.
+            // The bare name resolves to the (possibly mangled) storage name so
+            // that `Foo.new` inside this scope produces instances tagged with
+            // this declaration's identity, not an earlier same-named class's.
             let env = self.env_mut();
             env.insert(
                 "_".to_string(),
-                Value::Package(Symbol::intern(&qualified_name)),
+                Value::Package(Symbol::intern(&storage_name)),
             );
             // Always insert the class type object so that class names take
             // precedence over same-named `$`-sigiled variables (whose stripped
             // name may already be in the env).
             env.insert(
                 qualified_name.clone(),
-                Value::Package(Symbol::intern(&qualified_name)),
+                Value::Package(Symbol::intern(&storage_name)),
             );
             // When a nested class is registered inside another class (e.g. class B inside class A
             // becomes A::B), suppress the short name (B) so it cannot be used outside.
@@ -157,7 +208,7 @@ impl Interpreter {
                 let env = self.env_mut();
                 env.insert(
                     resolved_name.clone(),
-                    Value::Package(Symbol::intern(&qualified_name)),
+                    Value::Package(Symbol::intern(&storage_name)),
                 );
             }
             // When a class is declared with an already-qualified name
@@ -175,7 +226,7 @@ impl Interpreter {
                 // must not make the bare name `Channel` resolve to the user class).
                 if !short.is_empty() && short != qualified_name && !Self::is_builtin_type(&short) {
                     self.env_mut().entry_or_insert_with(short, || {
-                        Value::Package(Symbol::intern(&qualified_name))
+                        Value::Package(Symbol::intern(&storage_name))
                     });
                 }
             }
@@ -184,10 +235,10 @@ impl Interpreter {
             if *is_lexical {
                 self.register_lexical_class(resolved_name.clone());
                 // Also mark as my-scoped so it's excluded from the parent package stash
-                self.mark_my_scoped_package_item(qualified_name.clone());
+                self.mark_my_scoped_package_item(storage_name.clone());
             }
             // Store language revision metadata from the version captured at parse time
-            self.store_language_revision_from_version(&qualified_name, language_version);
+            self.store_language_revision_from_version(&storage_name, language_version);
 
             // Dispatch custom `is` traits via trait_mod:<is> if defined.
             // Merge explicitly parsed custom_traits with deferred_traits
@@ -195,7 +246,7 @@ impl Interpreter {
             let has_trait_mod =
                 self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
             if has_trait_mod && (!custom_traits.is_empty() || !deferred_traits.is_empty()) {
-                let type_obj = Value::Package(Symbol::intern(&qualified_name));
+                let type_obj = Value::Package(Symbol::intern(&storage_name));
                 // Dispatch explicitly parsed custom traits (with args)
                 for (trait_name, trait_arg) in custom_traits {
                     let trait_value = if let Some(arg_expr) = trait_arg {
@@ -297,6 +348,10 @@ impl Interpreter {
                 self,
                 register_role_decl(&qualified_name, type_params, type_param_defs, body, *is_rw,)
             )?;
+            // Link `is Parent` references on this role to the lexical class visible
+            // in this scope (which may be stored under a mangled name), matching
+            // the class-parent remapping in `exec_register_class_op`.
+            self.remap_role_parents_via_env(&qualified_name);
             if *is_export && !self.suppress_exports {
                 // The compiler may have pre-qualified the role name
                 // (e.g. `R1` → `GH2613::R1`) when compiling under a

--- a/t/lexical-class-identity.t
+++ b/t/lexical-class-identity.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Two `my class Foo` declared in separate `gather` blocks are distinct types;
+# instances produced by the first must keep the first class's method bodies even
+# after the second same-named class is declared (the gather bodies' instances
+# escape into @a / @b, so both classes are simultaneously live).
+{
+    my @a = gather { my class Foo { method val { 1 } }; take Foo.new };
+    my @b = gather { my class Foo { method val { 99 } }; take Foo.new };
+    is @a[0].val, 1, "first lexical class keeps its own method body";
+    is @b[0].val, 99, "second lexical class has its own method body";
+}
+
+# Mixed values from two same-named lexical classes coexist correctly.
+{
+    my @vals = gather {
+        my class N { method v { 3 } }
+        take N.new;
+    };
+    my @vals2 = gather {
+        my class N { method v { 42 } }
+        take N.new;
+    };
+    is @vals[0].v,  3,  "first gather's N keeps v=3 after second N declared";
+    is @vals2[0].v, 42, "second gather's N has v=42";
+}
+
+# A single declaration inside a loop is ONE type across iterations.
+{
+    my @t;
+    for 1..3 { my class L { }; @t.push: L }
+    ok @t[0] === @t[1], "loop-declared lexical class is the same type each iteration";
+    ok @t[1] === @t[2], "loop-declared lexical class identity is stable";
+}
+
+# The user-facing name is unaffected by the internal mangling.
+{
+    my @a = gather { my class Named { }; take Named.new };
+    my @b = gather { my class Named { }; take Named.new };
+    is @a[0].^name, "Named", "first same-named lexical class reports its bare name";
+    is @b[0].^name, "Named", "second same-named lexical class reports its bare name";
+}


### PR DESCRIPTION
## Summary

Fixes BLOCKERS.md §2.6 (`S02-literals/allomorphic.t`): same-named `my class` declarations in separate `gather` blocks now have distinct type identities, so an instance produced by the first class keeps its own method bodies even after a second same-named class is declared.

Minimal repro (was `99 99`, raku gives `1 99`):
```raku
my @a = gather { my class Foo { method val { 1  } }; take Foo.new };
my @b = gather { my class Foo { method val { 99 } }; take Foo.new };
say @a[0].val, @b[0].val;   # now: 199
```

## How

- Each `ClassDecl` gets a stable parse-time `decl_id` (one source declaration = one id; a loop body keeps one id across iterations).
- In `exec_register_class_op`, when a same-named fully-defined (non-stub) lexical class from a **different** site already owns the bare name, the new class is stored under a mangled internal name `Foo\u{0}<decl_id>`. The bare name resolves to it via the lexical env, so `Foo.new` in that scope tags instances with this declaration's identity.
- Ownership is tracked per block scope and released on scope exit, so a **sequential** (already-exited) block reuses the bare name (overwrite, no mangle). `gather`/coroutine bodies don't push a block scope, so their ownership persists and their same-named siblings get distinct identities — exactly the allomorphic case.
- Parent references (`is C0`) on both classes and roles are resolved through the lexical env so they link to the class visible in the current scope (matters for `S12-class/mro-6e.t`'s same-named `my class C0` across subtests).
- Display (`.^name` / `.gist` / `.raku` / `.WHAT`) strips the `\u{0}` suffix via `user_facing_type_name`, so the bare name is always shown.

## Tests

- `roast/S02-literals/allomorphic.t` 119/119 → added to whitelist.
- New `t/lexical-class-identity.t`.
- Stub upgrades (`my class C { ... }` then full body) unaffected; `S12` mro/role/construction/introspection tests stay green; `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)