### PR TITLE
fix(lang): chained .=, slurpy string-range, with/orwith topic in for-loops

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -614,27 +614,41 @@
     t/io-cathandle.t (get crosses files, skips empty files, slurp, close→Nil,
     encoding/chomp accessors). Top-level roast tests 30 (read-no-early-switch) and
     31 (lazy list of paths) pass.
-  - **BLOCKER for the 28 subtests — the test's `make-files` helper.** Every
-    subtest builds its inputs via `make-files`, which does
-    `@content.map: { when IO::Handle {$_}; make-temp-file content => $_ }`. That
-    map returns the temp path **stringified to Str** (or the spurt byte-count Int)
-    instead of the `IO::Path` make-temp-file returns, so the later
-    `@ret[$_] .= open` dies with "No such method 'open' for invocant of type Str".
-    Root cause is a compiler bug: a block whose tail is a bare `Stmt::Call` with a
-    **named/slip arg** (`f(k => v)` — how an *imported* sub like make-temp-file
-    parses, since imports are unknown at parse time) is compiled as a
-    value-discarding statement, so the map result falls back to the loop topic `$_`.
-    PARTIALLY FIXED 2026-06-29 (eval_map_over_items normalizes a named/slip tail
-    Stmt::Call to Stmt::Expr — see t/map-imported-named-tail-call.t), but the bug
-    has MULTIPLE map-path manifestations (the slurpy-array `*@content` map path
-    still returns Str; the VM-native-map fast path and make-temp-file's own
-    with/orwith+spurt return interaction are involved). A global compiler fix
-    (mod.rs tail-Stmt::Call → Expr::Call) DID make getc/Str pass but regressed
-    throws-like-any (it bypasses the statement-call path's `__mutsu_test_callsite_line`
-    handling), so it was reverted. Fully unblocking make-files is a separate, deep
-    compiler campaign across all the map paths + the imported-sub tail-call value
-    semantics. Also note: `make-files EXPR».join: "\n"` (listop + hyper-method +
-    colon-arg) is a *second* independent parse bug some subtests hit.
+  - **2026-06-30: `make-files` helper now works (28→23 failing).** The helper's
+    blockers were a cluster of *general* language bugs, all fixed (see the t/ tests):
+    1. `@content.map: { when IO::Handle {$_}; make-temp-file content => $_ }` over
+       a slurpy `*@content` array returned the loop topic `$_` instead of the call
+       value — the `@`-array **rw** map path did not normalize a named/slip-arg tail
+       call (fixed upstream in #3948, `eval_map_over_items_rw` now applies
+       `normalize_tail_call_for_value`).
+    2. `@ret[$_] .= IO .= absolute` (chained `.=` on an indexed element) lost the
+       writeback — the chain's second `.=` operated on a detached temp. Fixed:
+       `wrap_dot_assign` now re-applies the method to the same element when chaining
+       onto an `IndexAssign`-tail DoBlock; the scalar statement form (`$s .= a .= b`)
+       now bails to the expression parser so the postfix loop chains it.
+       (t/dotassign-chain.t)
+    3. `make-files 'a'..'z'` — a slurpy `*@content` did not flatten a **string**
+       range (only numeric), so `@content` held the Range as one element. Fixed in
+       `flatten_into_slurpy` (delegates non-integer GenericRange to `value_to_list`).
+       (t/slurpy-string-range.t)
+    4. make-temp-file's `with $chmod { } orwith $content { }` threw X::Assignment::RO
+       when run from a map block nested in `for @tests { }` (the comb/other subtests'
+       driver loop): `orwith`/`else`/`with LITERAL` topicalized `$_` via a plain
+       `$_ = …` assignment, which trips the outer loop's read-only `$_` mark. Fixed:
+       those branches now establish the fresh topic via `given` (like the first
+       `with` clause already did). (t/with-orwith-in-loop.t)
+  - **Remaining 23 subtests — per-method IO::CatHandle feature gaps** (deeper,
+    each its own work item):
+    - dynamic `chomp`/`nl-in` changes are not applied to the already-active handle
+      (only to handles opened afterward) — chomp/nl-in subtest.
+    - `cat.comb($matcher)` / words / split / lines / get with non-trivial args
+      sometimes return the cat's `.Str` ("IO::CatHandle()") instead of slurped
+      content for certain random source mixes — a per-arg dispatch / read-position
+      bug with already-opened handle sources.
+    - `getc` does not cluster combining marks into graphemes.
+    - binary `read`/`readchars` across handles (Buf vs decoded) is incomplete.
+    - `seek`/`tell`, `Supply`, `native-descriptor`, `t`, `on-switch` are stubbed or
+      missing.
 - [x] roast/S32-io/io-handle.t — **30/30, whitelisted.** All subtests pass.
       29 `.WRITE` / 30 `.EOF/.WRITE` fixed: a user-subclassed IO::Handle that
       overrides WRITE/READ/EOF now routes the high-level methods through the user

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -163,6 +163,42 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 label: None,
             }
         }
+        // A chained `.=` on an index lvalue (`@a[i] .= m1 .= m2`). The first `.=`
+        // already lowered `@a[i] .= m1` to `do { my idx = i; @a[idx] = @a[idx].m1 }`
+        // (an `IndexAssign` tail), which `lvalue_assign_name` does not recognize.
+        // Re-read `@a[idx]` (now holding m1's result, via the already-declared `idx`
+        // temp), apply this method, and write it back to the same element so the
+        // chain keeps mutating `@a[i]` rather than a detached copy.
+        Expr::DoBlock { body, .. }
+            if matches!(body.last(), Some(Stmt::Expr(Expr::IndexAssign { .. }))) =>
+        {
+            let (idx_target, index, is_positional) = match body.last() {
+                Some(Stmt::Expr(Expr::IndexAssign {
+                    target,
+                    index,
+                    is_positional,
+                    ..
+                })) => (target.clone(), index.clone(), *is_positional),
+                _ => unreachable!(),
+            };
+            let read_expr = Expr::Index {
+                target: idx_target.clone(),
+                index: index.clone(),
+                is_positional,
+            };
+            let new_value = method_call_fn(read_expr);
+            let mut new_body = body.clone();
+            new_body.push(Stmt::Expr(Expr::IndexAssign {
+                target: idx_target,
+                index,
+                value: Box::new(new_value),
+                is_positional,
+            }));
+            Expr::DoBlock {
+                body: new_body,
+                label: None,
+            }
+        }
         // A `do { … }` block whose value is an lvalue (`do { …; ($x .= new) }.= new`)
         // writes the outer `.=` result back to that lvalue. Run the block once (its
         // side effects included), then assign `$x = $x.method`.

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -353,6 +353,18 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
         } else {
             (r, Vec::new())
         };
+        // A chained `.=` (`$s .= uc .= flip`) must be handled by the expression
+        // postfix loop, which threads each step's lvalue back through the next
+        // `.=` (`do { $s = $s.uc; $s = $s.flip }`). The statement shortcut here
+        // only lowers a single `.= method`, so bail to the expression-statement
+        // fallback when another `.=` follows rather than mis-parsing the tail as a
+        // bare topic `$_ .= ...`.
+        {
+            let (r_peek, _) = ws(r)?;
+            if r_peek.starts_with(".=") {
+                return Err(PError::expected("chained .= (handled as expression)"));
+            }
+        }
         let expr = Expr::MethodCall {
             target: Box::new(var_expr),
             name: Symbol::intern(&method_name),

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -263,10 +263,13 @@ pub(crate) fn parse_elsif_chain(
                 (r, None)
             };
             let (r, orwith_body) = block(r)?;
-            // Topicalize $_ and optional param in the orwith body
-            let mut orwith_then = vec![topicalize(&orwith_cond_expr)];
+            // Topicalize $_ and optional param in the orwith body, via `given` so
+            // the fresh topic scope is established by the `given` opcode rather than
+            // a plain `$_ = <cond>` assignment — the latter throws X::Assignment::RO
+            // when the `orwith` is nested in a `for ^N { }` whose `$_` is read-only.
+            let mut orwith_given_body = Vec::new();
             if let Some(ref pname) = orwith_param_name {
-                orwith_then.push(Stmt::VarDecl {
+                orwith_given_body.push(Stmt::VarDecl {
                     name: pname.clone(),
                     expr: orwith_cond_expr.clone(),
                     type_constraint: None,
@@ -279,7 +282,11 @@ pub(crate) fn parse_elsif_chain(
                     where_constraint: None,
                 });
             }
-            orwith_then.extend(orwith_body);
+            orwith_given_body.extend(orwith_body);
+            let orwith_then = vec![Stmt::Given {
+                topic: orwith_cond_expr.clone(),
+                body: orwith_given_body,
+            }];
             // orwith uses .defined as the condition
             last_orwith_cond = Some(orwith_cond_expr.clone());
             let orwith_cond = Expr::MethodCall {
@@ -312,11 +319,14 @@ pub(crate) fn parse_elsif_chain(
         let (r, binding_params) = parse_if_binding_params(r)?;
         let (r, _) = ws(r)?;
         let (r, mut body) = block(r)?;
-        // If the last clause was `orwith`, topicalize $_ in the else body
+        // If the last clause was `orwith`, topicalize $_ in the else body via
+        // `given` (a fresh topic scope) so it is not blocked by an enclosing `for`'s
+        // read-only `$_` (see the orwith branch above).
         if let Some(ref orwith_expr) = last_orwith_cond {
-            let mut topicalized = vec![topicalize(orwith_expr)];
-            topicalized.append(&mut body);
-            body = topicalized;
+            body = vec![Stmt::Given {
+                topic: orwith_expr.clone(),
+                body,
+            }];
         }
         return Ok((
             r,

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -90,22 +90,17 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // `with $x { with foo() { } }` clobbered `$x` with `foo()`'s value.
     let is_literal_topic = matches!(&cond_expr, Expr::Literal(_));
     let route_through_given_tmp = !cond_is_lvalue && !is_literal_topic && param_name.is_none();
-    // Topicalize `$_` for the body. For a literal, wrap it in a Mixin marked
-    // read-only so in-place mutation of `$_` throws X::Assignment::RO. Otherwise
-    // reuse the `$tmp` holding the (once-evaluated) condition value.
-    let topic_assign = if let Expr::Literal(lit) = &cond_expr {
-        let mut overrides = std::collections::HashMap::new();
-        overrides.insert("__mutsu_topic_ro__".to_string(), Value::Bool(true));
-        let wrapped = Value::mixin(lit.clone(), overrides);
-        Stmt::Assign {
-            name: "_".to_string(),
-            op: AssignOp::Assign,
-            expr: Expr::Literal(wrapped),
-        }
-    } else {
-        topicalize(&tmp_var)
-    };
-    let mut with_body = if use_given_alias {
+    // A literal topic (`with 5 { }`) runs under `given <literal>`: that yields a
+    // fresh read-only `$_` topic scope (matching `given`'s immutable-literal
+    // semantics) and, crucially, establishes the topic via the `given` opcode
+    // rather than a plain `$_ = <literal>` assignment — so it nests correctly
+    // inside a `for ^N { }`, whose `$_` readonly mark would otherwise make that
+    // assignment throw X::Assignment::RO.
+    let route_literal_through_given = is_literal_topic && param_name.is_none();
+    // Topicalize `$_` for the body. For a non-literal, non-`given` topic reuse the
+    // `$tmp` holding the (once-evaluated) condition value.
+    let topic_assign = topicalize(&tmp_var);
+    let mut with_body = if use_given_alias || route_literal_through_given {
         Vec::new()
     } else {
         vec![topic_assign]
@@ -245,6 +240,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             topic: tmp_var.clone(),
             body,
         }];
+    } else if route_literal_through_given {
+        with_body = vec![Stmt::Given {
+            topic: cond_expr.clone(),
+            body,
+        }];
     } else {
         with_body.extend(body);
     }
@@ -331,10 +331,13 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
 
         let (r, orwith_body) = block(r)?;
 
-        // Prepend $_ = <orwith_cond_expr> to the body
-        let mut orwith_with_body = vec![topicalize(&orwith_cond_expr)];
+        // Run the body under `given <orwith_cond>` so `$_` is topicalized via the
+        // `given` opcode (which establishes a fresh topic scope) rather than a plain
+        // `$_ = <orwith_cond>` assignment. The latter would throw X::Assignment::RO
+        // when the `orwith` is nested in a `for ^N { }` whose `$_` is read-only.
+        let mut orwith_given_body = Vec::new();
         if let Some(ref pname) = orwith_param_name {
-            orwith_with_body.push(Stmt::VarDecl {
+            orwith_given_body.push(Stmt::VarDecl {
                 name: pname.clone(),
                 expr: orwith_cond_expr.clone(),
                 type_constraint: None,
@@ -347,7 +350,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 where_constraint: None,
             });
         }
-        orwith_with_body.extend(orwith_body);
+        orwith_given_body.extend(orwith_body);
+        let orwith_with_body = vec![Stmt::Given {
+            topic: orwith_cond_expr.clone(),
+            body: orwith_given_body,
+        }];
 
         let orwith_cond_expr_clone = orwith_cond_expr.clone();
         let orwith_cond = Expr::MethodCall {
@@ -380,10 +387,12 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 (r2, None)
             };
             let (r2, else_body) = block(r2)?;
-            // Topicalize $_ in else branch to the orwith condition
-            let mut else_with_topic = vec![topicalize(&orwith_cond_expr_clone)];
+            // Topicalize $_ in else branch to the orwith condition, via `given` so
+            // the fresh topic scope is not blocked by an enclosing `for`'s read-only
+            // `$_` (see the orwith branch above).
+            let mut else_given_body = Vec::new();
             if let Some(ref pname) = else_param {
-                else_with_topic.push(Stmt::VarDecl {
+                else_given_body.push(Stmt::VarDecl {
                     name: pname.clone(),
                     expr: orwith_cond_expr_clone.clone(),
                     type_constraint: None,
@@ -396,7 +405,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                     where_constraint: None,
                 });
             }
-            else_with_topic.extend(else_body);
+            else_given_body.extend(else_body);
+            let else_with_topic = vec![Stmt::Given {
+                topic: orwith_cond_expr_clone.clone(),
+                body: else_given_body,
+            }];
             (r2, else_with_topic)
         } else {
             (r_before_else_ws, Vec::new())
@@ -436,10 +449,12 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
             (r, None)
         };
         let (r, else_body) = block(r)?;
-        // Topicalize $_ in else branch to the with/without condition
-        let mut else_with_topic = vec![topicalize(&tmp_var)];
+        // Topicalize $_ in else branch to the with/without condition, via `given`
+        // (a fresh topic scope) so it is not blocked by an enclosing `for`'s
+        // read-only `$_` (see the orwith branch above).
+        let mut else_given_body = Vec::new();
         if let Some(ref pname) = else_param {
-            else_with_topic.push(Stmt::VarDecl {
+            else_given_body.push(Stmt::VarDecl {
                 name: pname.clone(),
                 expr: tmp_var.clone(),
                 type_constraint: None,
@@ -452,7 +467,11 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
                 where_constraint: None,
             });
         }
-        else_with_topic.extend(else_body);
+        else_given_body.extend(else_body);
+        let else_with_topic = vec![Stmt::Given {
+            topic: tmp_var.clone(),
+            body: else_given_body,
+        }];
         (r, else_with_topic)
     } else {
         // No orwith/else found — don't consume whitespace/newlines past the

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -160,13 +160,24 @@ pub(in crate::runtime) fn flatten_into_slurpy(values: &[Value], out: &mut Vec<Va
                 excl_start,
                 excl_end,
             } => {
-                let a = crate::runtime::to_int(start);
-                let b = crate::runtime::to_int(end);
-                let s = if *excl_start { a + 1 } else { a };
-                let raw_e = if *excl_end { b } else { b + 1 };
-                let e = raw_e.min(s.saturating_add(MAX_SLURPY_RANGE_EXPAND));
-                for i in s..e {
-                    out.push(Value::Int(i));
+                // Only integer-endpoint ranges expand via the fast Int path. A
+                // string range (`"a".."z"`) must expand as its character/string
+                // sequence, so delegate to `value_to_list` which knows how (a
+                // plain `to_int` would collapse both endpoints to 0).
+                if matches!(
+                    (start.as_ref(), end.as_ref()),
+                    (Value::Int(_), Value::Int(_))
+                ) {
+                    let a = crate::runtime::to_int(start);
+                    let b = crate::runtime::to_int(end);
+                    let s = if *excl_start { a + 1 } else { a };
+                    let raw_e = if *excl_end { b } else { b + 1 };
+                    let e = raw_e.min(s.saturating_add(MAX_SLURPY_RANGE_EXPAND));
+                    for i in s..e {
+                        out.push(Value::Int(i));
+                    }
+                } else {
+                    out.extend(crate::runtime::utils::value_to_list(val));
                 }
             }
             other => {

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -16,24 +16,38 @@ impl Interpreter {
         let from = Self::const_str(code, from_idx);
         let to = Self::const_str(code, to_idx);
         let target = self.env().get("_").cloned().unwrap_or(Value::Nil);
-        // If $_ is bound to a read-only topic (e.g. `with 'literal' { ... }`),
-        // tr/// must throw X::Assignment::RO. The `with` desugaring marks the
-        // topic value with a Mixin override `__mutsu_topic_ro__` when the
-        // condition expression is a literal.
-        if !non_destructive
-            && let Value::Mixin(_, overrides) = &target
-            && overrides.contains_key("__mutsu_topic_ro__")
-        {
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert(
-                "message".to_string(),
-                Value::str(format!(
-                    "Cannot modify an immutable Str ({})",
-                    target.to_string_value()
-                )),
+        // If $_ is bound to a read-only topic, a destructive tr/// must throw
+        // X::Assignment::RO. Two cases:
+        //  1. A literal `with`/`given`/`for` topic routed through the `given`
+        //     opcode (or a `for` loop) marks `$_` read-only by name in
+        //     `readonly_vars()`.
+        //  2. The legacy `__mutsu_topic_ro__` Mixin override carried on the
+        //     topic value itself.
+        // A smartmatch RHS (`$x ~~ tr///`) writes through to the matched
+        // variable, so it is never blocked here.
+        if !non_destructive && !self.in_smartmatch_rhs {
+            let mixin_ro = matches!(
+                &target,
+                Value::Mixin(_, overrides) if overrides.contains_key("__mutsu_topic_ro__")
             );
-            attrs.insert("value".to_string(), target);
-            return Err(RuntimeError::typed("X::Assignment::RO", attrs));
+            if mixin_ro || self.readonly_vars().contains("_") {
+                let type_name = match &target {
+                    Value::Int(_) => "Int",
+                    Value::Num(_) => "Num",
+                    _ => "Str",
+                };
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!(
+                        "Cannot modify an immutable {} ({})",
+                        type_name,
+                        target.to_string_value()
+                    )),
+                );
+                attrs.insert("value".to_string(), target);
+                return Err(RuntimeError::typed("X::Assignment::RO", attrs));
+            }
         }
         let text = target.to_string_value();
 

--- a/t/dotassign-chain.t
+++ b/t/dotassign-chain.t
@@ -1,0 +1,73 @@
+use Test;
+
+plan 11;
+
+# Chained `.=` on a scalar (statement form): `$s .= uc .= flip` means
+# `$s = $s.uc.flip` — each step's result feeds the next, assigned back once.
+{
+    my $s = "abc";
+    $s .= uc .= flip;
+    is $s, "CBA", 'chained .= on scalar (statement)';
+}
+
+{
+    my $s = "abcd";
+    $s .= uc .= flip .= lc;
+    is $s, "dcba", 'triple-chained .= on scalar';
+}
+
+# Chained `.=` in expression context.
+{
+    my $s = "abc";
+    ($s .= uc .= flip);
+    is $s, "CBA", 'chained .= on scalar (expression)';
+}
+
+# Chained `.=` on an indexed array element writes back to the element.
+{
+    my @a = "Hello", "World";
+    @a[0] .= lc .= flip;
+    is @a[0], "olleh", 'chained .= on array element';
+    is @a[1], "World", 'sibling element untouched';
+}
+
+{
+    my @a = "a", "b", "c";
+    @a[$_] .= uc .= flip for ^@a;
+    is-deeply @a, ["A", "B", "C"], 'chained .= per-element in for-modifier';
+}
+
+# A single (non-chained) `.=` still works.
+{
+    my $s = "abc";
+    $s .= uc;
+    is $s, "ABC", 'single .= still works';
+}
+
+# Mixed chains preserve evaluation order.
+{
+    my $s = "Hello World";
+    $s .= words .= elems;
+    is $s, 2, 'chained .= producing a number';
+}
+
+# `.=` chain after a method with args.
+{
+    my $s = "a,b,c";
+    $s .= split(",") .= elems;
+    is $s, 3, 'chained .= with method args';
+}
+
+# A chain whose first step changes the type.
+{
+    my $x = "42";
+    $x .= Int .= succ;
+    is $x, 43, 'chained .= across a type change';
+}
+
+# `$_ .= ...` chained.
+{
+    $_ = "abc";
+    $_ .= uc .= flip;
+    is $_, "CBA", 'chained .= on the topic';
+}

--- a/t/slurpy-string-range.t
+++ b/t/slurpy-string-range.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 7;
+
+# A slurpy `*@a` flattens a string range argument to its sequence, like it
+# already does for a numeric range.
+sub count(*@a) { @a.elems }
+
+is count("a".."z"), 26, 'slurpy flattens single-char string range';
+is count(1..5), 5, 'slurpy flattens numeric range';
+is count("aa".."ad"), 4, 'slurpy flattens multi-char string range';
+is count(1, 2, 3), 3, 'slurpy keeps plain list';
+is count("x"), 1, 'slurpy with one scalar';
+
+sub first-last(*@a) { (@a[0], @a[*-1]) }
+is-deeply first-last("a".."e"), ("a", "e"), 'string-range slurpy elements are correct';
+is-deeply first-last(3..7), (3, 7), 'numeric-range slurpy elements are correct';

--- a/t/with-orwith-in-loop.t
+++ b/t/with-orwith-in-loop.t
@@ -1,0 +1,77 @@
+use Test;
+
+plan 9;
+
+# A `with`/`orwith`/`else` block establishes a FRESH topic scope, so it must work
+# even when nested inside a `for ^N { }` whose implicit `$_` is read-only.
+# Previously the `orwith`/`else`/`with LITERAL` topicalization used a plain
+# `$_ = ...` assignment, which threw X::Assignment::RO in that context.
+
+{
+    my @seen;
+    for ^2 { with 5 { @seen.push($_) } }
+    is-deeply @seen, [5, 5], 'with LITERAL inside for ^N';
+}
+
+{
+    my @seen;
+    my $a = Nil;
+    my $b = 7;
+    for ^2 { with $a { } orwith $b { @seen.push($_) } }
+    is-deeply @seen, [7, 7], 'orwith inside for ^N';
+}
+
+{
+    my @seen;
+    for ^2 { with Nil { } else { @seen.push(.defined) } }
+    is-deeply @seen, [False, False], 'with/else inside for ^N';
+}
+
+{
+    my @seen;
+    my $a = Nil;
+    for ^2 { with $a { } orwith Nil { } else { @seen.push("else") } }
+    is-deeply @seen, ["else", "else"], 'orwith/else inside for ^N';
+}
+
+# `orwith` aliases its topic, so `$_` mutation writes back to the source.
+{
+    my $x = 5;
+    with Nil { } orwith $x { $_++ }
+    is $x, 6, 'orwith aliases topic for writeback';
+}
+
+# `with LITERAL` keeps the read-only topic semantics.
+{
+    my $err;
+    {
+        with 5 { $_ = 9 }
+        CATCH { default { $err = .^name } }
+    }
+    ok $err.defined, 'with LITERAL keeps $_ read-only';
+}
+
+# Standalone (non-loop) cases still behave.
+{
+    my $hit = 0;
+    with 42 { $hit = $_ }
+    is $hit, 42, 'plain with LITERAL';
+}
+
+{
+    my $hit = 0;
+    with Nil { } orwith 99 { $hit = $_ }
+    is $hit, 99, 'plain orwith';
+}
+
+# The map-block + for-modifier regression that motivated the fix.
+{
+    sub pick-one($x) { with Nil { } orwith $x { }; $x }
+    my @r;
+    for ^2 {
+        my @m = (1, 2, 3).map({ pick-one($_) });
+        @m[$_] = 9 for (0, 1);
+        @r.push(@m.join(","));
+    }
+    is-deeply @r, ["9,9,3", "9,9,3"], 'orwith in map block under nested for-loops';
+}


### PR DESCRIPTION
## Problem

`roast/S32-io/io-cathandle.t`'s `make-files` helper exercises four *general*
language behaviors, each of which had a correctness bug that left the helper
producing wrong values (Str/Int instead of `IO::Path`/`IO::Handle`, or throwing
`X::Assignment::RO`). These are not IO-specific — they affect any program using
the same constructs.

## Fixes

1. **Chained `.=` writeback.**
   - `$s .= uc .= flip` (scalar, statement form) was mis-parsed: the statement
     `.=` shortcut handled only the first method and left `.= flip` to become a
     bare topic `$_ .= flip`. It now bails to the expression-statement parser,
     whose postfix loop chains `.=` correctly (`$s = $s.uc.flip`).
   - `@a[i] .= m1 .= m2` (indexed, expression form) lost the second method's
     writeback because the first `.=` lowered to an `IndexAssign`-tail DoBlock
     that the next `.=` treated as a non-lvalue temp. `wrap_dot_assign` now
     re-applies the method to the same element (reusing the index temp) when
     chaining onto such a DoBlock.

2. **Slurpy `*@a` flattens a string range.** `sub f(*@a){…}; f("a".."z")` gave
   `@a.elems == 1` (the Range itself) because `flatten_into_slurpy` only expanded
   integer ranges (`to_int` collapsed `"a"`/`"z"` to 0). It now delegates a
   non-integer `GenericRange` to `value_to_list`, matching `("a".."z").list`.

3. **`with`/`orwith`/`else` topic in a `for` loop.** A `with LITERAL { }`,
   `orwith X { }`, or `with/else` block topicalized `$_` via a plain `$_ = …`
   assignment. Inside `for ^N { }` (whose `$_` is read-only) that threw
   `X::Assignment::RO` — e.g. a `with/orwith` inside a map block driven by
   `... for @tests`. These branches now establish the fresh topic via `given`
   (exactly as the first `with` clause already did), which is the correct
   topic-scope mechanism and preserves the read-only-literal / aliasing-variable
   semantics.

## Impact

`io-cathandle.t`'s `make-files` helper now works; the file went from 28 to 23
failing subtests. The remaining failures are per-method `IO::CatHandle` feature
gaps (dynamic `chomp`/`nl-in` on the active handle, `getc` grapheme clustering,
binary `read`/`readchars`, `seek`/`tell`/`Supply`/`native-descriptor`/`t`/
`on-switch`), documented in `TODO_roast/S32.md` for follow-up.

## Tests

- `t/dotassign-chain.t` (11) — scalar/indexed/topic `.=` chains, type changes,
  method args.
- `t/slurpy-string-range.t` (7) — string vs numeric range slurpy flattening.
- `t/with-orwith-in-loop.t` (9) — `with`/`orwith`/`else` nested in `for`,
  including the map-block-under-nested-loops regression; aliasing writeback and
  read-only-literal semantics preserved.
- `make test` passes; `S04-statements/{given,with,unless}.t` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)