### PR TITLE
fix(operators): .= metaop on an is-rw accessor writes through the attribute slot

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -437,7 +437,19 @@ materialize せず Seq のまま保持し（`.WHAT === Seq`）、`+@foo` は Lis
    - 完了条件: element bind / take-rw / deep nested write が post-call writeback なしで成立
 2. **属性 accessor を value copy ではなく slot 経由にする**
    - 変更レイヤ: attribute read/write path、instance attr storage、methods instance ops
-   - 対象: `S12-attributes/clone.t`, `S14-traits/attributes.t`, `S12-introspection/walk.t`
+   - 対象: `S14-traits/attributes.t`
+   - 状況:
+     - `S12-attributes/clone.t`（whitelist 済み, PR #2253）と
+       `S12-introspection/walk.t`（whitelist 済み）は既に通過済み。
+     - `$obj.attr .= meth`（`is rw` accessor への `.=` メタop）は属性 slot へ
+       書き戻すよう修正済み（`wrap_dot_assign` に method-call lvalue アームを追加）。
+     - 残るのは `S14-traits/attributes.t` の 5–8（`Attribute.container.VAR does Role`）。
+       これは「scalar 属性が Scalar コンテナを VAR として持ち、合成時に role を
+       mixin し、それがインスタンスの per-attribute コンテナに伝播する」という
+       深いコンテナ表現が必要。mutsu の scalar 属性は値を直接保持し VAR は Any を
+       返すため、ここは main track（slot identity 再設計）待ち。
+     - 残課題: `$my_ref := $obj.attr`（scalar accessor への `:=` 束縛）も同じく
+       属性 slot の cell 化が必要（配列/ハッシュ要素 `$r := @a[0]` は既に動く）。
 3. **typed-hash default / Capture 書き戻し / wrapper capture**
    - 変更レイヤ: hash missing-key default、Capture bind/writeback、wrap closure env
    - 対象: `S32-hash/adverbs.t`, `S02-types/capture.t`, `S02-types/whatever.t`

--- a/src/parser/expr/postfix/dot_assign.rs
+++ b/src/parser/expr/postfix/dot_assign.rs
@@ -210,6 +210,109 @@ pub(crate) fn wrap_dot_assign(target: Expr, method_call_fn: impl FnOnce(Expr) ->
                 args: vec![lhs, Expr::ArrayLiteral(Vec::new()), value],
             }
         }
+        // A method-call lvalue (`$obj.attr .= meth`). In Raku `$obj.attr .= meth`
+        // is `$obj.attr = $obj.attr.meth`, so when `.attr` is an `is rw` accessor
+        // the result is written back through the accessor (the attribute slot), not
+        // snapshotted. We restrict this to a no-modifier, no-argument method call —
+        // the common accessor shape — and keep the runtime `STORE` check so a Proxy
+        // accessor (`$obj.proxy-attr`) still routes through `.STORE`. Evaluate the
+        // invocant once, read the current value once, then branch at runtime:
+        //   do { my $inv = INVOCANT;
+        //        my $cur = $inv.attr;
+        //        $cur.^can("STORE")
+        //            ?? do { $cur.STORE($cur.meth); $cur }
+        //            !! ($inv.attr = $cur.meth) }
+        // For a non-lvalue invocant (`Foo.new.=meth`) the writeback path raises
+        // X::Assignment::RO at runtime, matching Raku's "Cannot modify an immutable
+        // value".
+        Expr::MethodCall {
+            target: inv,
+            name: acc_name,
+            args: acc_args,
+            modifier: None,
+            quoted,
+        } if acc_args.is_empty() => {
+            use std::sync::atomic::Ordering;
+            let n = crate::parser::stmt::simple::TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let inv_tmp = format!("__mutsu_dotassign_inv_{}", n);
+            let cur_tmp = format!("__mutsu_dotassign_cur_{}", n);
+            let inv_var = Expr::Var(inv_tmp.clone());
+            let cur_var = Expr::Var(cur_tmp.clone());
+            let acc_name = *acc_name;
+            let quoted = *quoted;
+            // Read the current accessor value (evaluated once into `$cur`).
+            let read_expr = Expr::MethodCall {
+                target: Box::new(inv_var.clone()),
+                name: acc_name,
+                args: Vec::new(),
+                modifier: None,
+                quoted,
+            };
+            // `$cur.meth(margs)` — the mutating method applied to the current value.
+            let meth_result = method_call_fn(cur_var.clone());
+            // STORE branch: container accessor (Proxy) updates in place.
+            let store_call = Expr::MethodCall {
+                target: Box::new(cur_var.clone()),
+                name: Symbol::intern("STORE"),
+                args: vec![meth_result.clone()],
+                modifier: None,
+                quoted: false,
+            };
+            let then_expr = Expr::DoBlock {
+                body: vec![Stmt::Expr(store_call), Stmt::Expr(cur_var.clone())],
+                label: None,
+            };
+            // Writeback branch: `$inv.attr = $cur.meth` through the accessor slot.
+            let writeback = crate::parser::stmt::assign::method_lvalue_assign_expr(
+                inv_var,
+                Some(inv_tmp.clone()),
+                acc_name.resolve().to_string(),
+                Vec::new(),
+                meth_result,
+            );
+            let can_store = Expr::MethodCall {
+                target: Box::new(cur_var),
+                name: Symbol::intern("can"),
+                args: vec![Expr::Literal(Value::str("STORE".to_string()))],
+                modifier: Some('^'),
+                quoted: false,
+            };
+            let ternary = Expr::Ternary {
+                cond: Box::new(can_store),
+                then_expr: Box::new(then_expr),
+                else_expr: Box::new(writeback),
+            };
+            Expr::DoBlock {
+                body: vec![
+                    Stmt::VarDecl {
+                        name: inv_tmp,
+                        expr: *inv.clone(),
+                        type_constraint: None,
+                        is_state: false,
+                        is_our: false,
+                        is_dynamic: false,
+                        is_export: false,
+                        export_tags: Vec::new(),
+                        custom_traits: Vec::new(),
+                        where_constraint: None,
+                    },
+                    Stmt::VarDecl {
+                        name: cur_tmp,
+                        expr: read_expr,
+                        type_constraint: None,
+                        is_state: false,
+                        is_our: false,
+                        is_dynamic: false,
+                        is_export: false,
+                        export_tags: Vec::new(),
+                        custom_traits: Vec::new(),
+                        where_constraint: None,
+                    },
+                    Stmt::Expr(ternary),
+                ],
+                label: None,
+            }
+        }
         // A non-lvalue target (`(Foo.new).=meth`, `Foo.new.=meth`, ...). In Raku
         // `X.=meth` is `X = X.meth`; when X (evaluated once) provides a `STORE`
         // method it is a custom container, so this becomes `X.STORE(X.meth)` and

--- a/t/dot-assign-accessor.t
+++ b/t/dot-assign-accessor.t
@@ -1,0 +1,105 @@
+use Test;
+
+# `.=` metaop on an `is rw` accessor writes the result back through the
+# attribute slot (`$obj.attr .= meth` is `$obj.attr = $obj.attr.meth`),
+# rather than snapshotting the accessor's value into a throwaway temporary.
+
+plan 12;
+
+class Counter {
+    has $.n is rw;
+}
+
+{
+    my $c = Counter.new(n => 1);
+    $c.n .= succ;
+    is $c.n, 2, 'scalar accessor .= succ writes back';
+}
+
+{
+    my $c = Counter.new(n => 1);
+    ($c.n).=succ;
+    is $c.n, 2, 'grouped accessor (.= ) writes back';
+}
+
+{
+    my $c = Counter.new(n => 'a');
+    $c.n .= uc;
+    is $c.n, 'A', 'string accessor .= uc writes back';
+}
+
+{
+    my $c = Counter.new(n => 5);
+    my $r = ($c.n .= succ);
+    is $r, 6, '.= returns the new value';
+    is $c.n, 6, '... and the attribute is updated';
+}
+
+class Holder {
+    has @.items is rw;
+}
+
+{
+    my $h = Holder.new(items => [3, 1, 2]);
+    $h.items .= sort;
+    is-deeply $h.items, [1, 2, 3], 'array accessor .= sort writes back';
+}
+
+# `.=` with method arguments on an accessor.
+class Box {
+    has $.s is rw;
+}
+{
+    my $b = Box.new(s => 'hello world');
+    $b.s .= subst('world', 'raku');
+    is $b.s, 'hello raku', 'accessor .= subst(args) writes back';
+}
+
+# A Proxy-returning `is rw` accessor still routes through STORE rather than the
+# attribute-slot writeback path.
+my @stored;
+class Proxied {
+    method val is rw {
+        Proxy.new(
+            FETCH => method () { 10 },
+            STORE => method ($v) { @stored.push($v) },
+        )
+    }
+}
+{
+    my $p = Proxied.new;
+    $p.val .= succ;
+    is-deeply @stored, [11], 'Proxy accessor .= succ routes through STORE';
+}
+
+# Plain variable `.=` is unchanged.
+{
+    my $x = 41;
+    $x .= succ;
+    is $x, 42, 'plain scalar variable .= succ still works';
+}
+
+# Array element `.=` is unchanged.
+{
+    my @a = 1, 2, 3;
+    @a[0] .= succ;
+    is-deeply @a, [2, 2, 3], 'array element .= succ still works';
+}
+
+# Non-lvalue method call (constructor) `.=` on a typed declaration still works.
+{
+    my Counter $c .= new(n => 7);
+    is $c.n, 7, 'typed-declaration .= new still works';
+}
+
+# Chained: accessor whose value is itself an object, `.=` on a nested accessor.
+class Outer {
+    has Counter $.inner is rw;
+}
+{
+    my $o = Outer.new(inner => Counter.new(n => 1));
+    $o.inner.n .= succ;
+    is $o.inner.n, 2, 'nested accessor .= succ writes back';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

`$obj.attr .= meth` is `$obj.attr = $obj.attr.meth`, so when `.attr` is an `is rw` accessor the result must be written back through the accessor (the attribute slot), not snapshotted into a throwaway temporary.

Previously `wrap_dot_assign` routed a method-call target through the generic non-lvalue fallback, which evaluated `my $t = $obj.attr`, computed `$t.meth`, and discarded it — `$obj.attr` stayed unchanged.

### Before
```raku
class C { has $.x is rw }
my $c = C.new(x => 1);
$c.x .= succ;
say $c.x;   # mutsu: 1   raku: 2
```

### After
```raku
$c.x .= succ;
say $c.x;   # 2  ✓
```

## Approach

Add an explicit arm in `wrap_dot_assign` for a no-modifier, no-argument method call (the common accessor shape):

1. Evaluate the invocant once into a temp.
2. Read the current accessor value once into a temp.
3. Branch at runtime on `.^can("STORE")`:
   - **STORE present** (a Proxy accessor): route through `.STORE($cur.meth)` in place — preserves existing Proxy semantics.
   - **otherwise**: write back via `$inv.attr = $cur.meth` through the existing `__mutsu_assign_method_lvalue` machinery, which already handles `is rw` accessors, Proxy STORE, and raises `X::Assignment::RO` for a non-lvalue invocant (matching Raku's "Cannot modify an immutable value").

Plain-variable (`$x .= succ`), array-element (`@a[0] .= succ`), and typed-declaration (`my C $c .= new`) forms are unchanged.

## Context

Sub-campaign #2 of `TODO_roast/BLOCKERS.md` §3.1 (attribute accessor slot vs value copy). While investigating the originally-named `S12-attributes/clone.t`, I found it (and `S12-introspection/walk.t`) already pass and are whitelisted; the `.=`-accessor-writeback gap is a concrete, general piece of the same family. The doc is updated to reflect this and to record that the remaining `S14-traits/attributes.t` needs the deeper `Scalar`-container-`VAR` role-mixin representation (main track).

## Tests

- New `t/dot-assign-accessor.t` (12 assertions), verified identical output on `raku` and `mutsu`.
- `make test` green; whitelisted S03-metaops and S12-attributes roast tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)