### PR TITLE
fix(attributes): is default(...) on @/% attrs, object-hash attrs, accessor delete

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -114,7 +114,7 @@
   - 0/? pass. Parse error at line 76
 - [ ] roast/S02-names/indirect.t
   - 0/? pass. Parse error at line 16
-- [ ] roast/S02-names/is_default.t
+- [x] roast/S02-names/is_default.t
   - 124/146 pass. Remaining blockers:
     - Nil assignment to array/hash attribute elements not restoring default
     - Hash/Array subtests with typed keys (%{Str:D}), :delete adverb, is raw params

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -104,6 +104,7 @@ roast/S02-names/caller.t
 roast/S02-names/dynamic-scope.t
 roast/S02-names/identifier.t
 roast/S02-names/indirect.t
+roast/S02-names/is_default.t
 roast/S02-names/is_dynamic.t
 roast/S02-names/name.t
 roast/S02-names/our.t

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -282,6 +282,27 @@ impl Compiler {
                 self.compile_expr(delete_index);
                 let name_idx = self.code.add_constant(Value::str(var_name));
                 self.code.emit(OpCode::DeleteIndexNamed(name_idx));
+            } else if let Expr::MethodCall {
+                target: method_target,
+                name: method_name,
+                args: method_args,
+                ..
+            } = &**delete_target
+                && method_args.is_empty()
+                && let Some(var_name) = Self::method_call_target_var_name(method_target)
+            {
+                // `$obj.attr<key>:delete` — delete through an accessor and write
+                // the modified container back to the attribute (mirrors the
+                // `$obj.attr<key> = v` lvalue path).
+                self.compile_expr(&Expr::Call {
+                    name: Symbol::intern("__mutsu_index_delete_method_lvalue"),
+                    args: vec![
+                        (**method_target).clone(),
+                        Expr::Literal(Value::str(method_name.resolve().to_string())),
+                        (**delete_index).clone(),
+                        Expr::Literal(Value::str(var_name)),
+                    ],
+                });
             } else {
                 self.compile_expr(delete_target);
                 self.compile_expr(delete_index);

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -268,6 +268,26 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         (rest, None)
     };
 
+    // Optional object-hash key-type suffix: has %.a{Str:D}. The key type folds
+    // into the attribute's type constraint as `ValueType{KeyType}`, exactly as a
+    // lexical `my %h{Str:D}` does (see my_decl.rs).
+    let rest = if sigil == b'%'
+        && rest.starts_with('{')
+        && !rest.starts_with("{{")
+        && let Some(end) = rest.find('}')
+    {
+        let key_type = rest[1..end].trim().to_string();
+        let value_tc = type_constraint.take();
+        let combined = match value_tc {
+            Some(v) => format!("{}{{{}}}", v, key_type),
+            None => format!("Any{{{}}}", key_type),
+        };
+        type_constraint = Some(combined);
+        &rest[end + 1..]
+    } else {
+        rest
+    };
+
     let (mut rest, _) = ws(rest)?;
 
     // `of` type constraint can appear before `is` traits: `has $.a of Int is rw`
@@ -671,8 +691,17 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             (rest, Some(expr))
         }
     } else if let Some(default_expr) = is_default_trait.clone() {
-        // `is default(expr)` was used — apply it as the default value
-        (rest, Some(default_expr))
+        // `is default(expr)` was used (no `=` initializer). For a `$`/`&` scalar
+        // attribute the value doubles as the initializer (an unassigned scalar
+        // reads back as its default). For an `@`/`%` container the value is the
+        // *element* default, NOT the container itself — leave the initializer
+        // empty so the container is built empty and gets its `.default` tagged
+        // from the `is_default` trait at construction time.
+        if sigil == b'@' || sigil == b'%' {
+            (rest, None)
+        } else {
+            (rest, Some(default_expr))
+        }
     } else {
         (rest, None)
     };

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -332,6 +332,7 @@ impl Interpreter {
             "__mutsu_assign_method_lvalue" => self.builtin_assign_method_lvalue(&args),
             "__mutsu_push_through_accessor" => self.builtin_push_through_accessor(&args),
             "__mutsu_index_assign_method_lvalue" => self.builtin_index_assign_method_lvalue(&args),
+            "__mutsu_index_delete_method_lvalue" => self.builtin_index_delete_method_lvalue(&args),
             "__mutsu_index_assign_method_lvalue_nested" => {
                 self.builtin_index_assign_method_lvalue_nested(&args)
             }

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -75,9 +75,16 @@ impl Interpreter {
             let tc = self.get_attr_type_constraint(&class_name.resolve(), &method);
             let is_hash_attr = matches!(&current, Value::Hash(_));
             let is_array_attr = matches!(&current, Value::Array(..));
+            // An object hash (`%.h{Str:D}`) checks elements against the value type.
+            let elem_tc = tc.as_deref().map(|t| {
+                crate::runtime::types::split_object_hash_constraint(t)
+                    .0
+                    .to_string()
+            });
             if (is_hash_attr || is_array_attr)
-                && let Some(ref type_constraint) = tc
+                && let Some(ref type_constraint) = elem_tc
                 && !matches!(type_constraint.as_str(), "Mu" | "Any")
+                && !matches!(effective_value, Value::Nil)
                 && !self.type_matches_value(type_constraint, &effective_value)
             {
                 let sigil = if is_hash_attr { "%" } else { "@" };
@@ -198,6 +205,103 @@ impl Interpreter {
             updated,
         )?;
         Ok(effective_value)
+    }
+
+    /// Handle `$obj.method<key>:delete` — element delete through a method accessor.
+    /// Gets the current container (hash/array) via the accessor, removes the
+    /// element, writes the modified container back through the setter, and returns
+    /// the removed value (or the container's `is default(...)` for an absent key).
+    pub(super) fn builtin_index_delete_method_lvalue(
+        &mut self,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        if args.len() < 4 {
+            return Err(RuntimeError::new(
+                "__mutsu_index_delete_method_lvalue expects target, method, index, var_name",
+            ));
+        }
+        let target = args[0].clone();
+        let method = args[1].to_string_value();
+        let index = args[2].clone();
+        let var_name = args[3].to_string_value();
+
+        let current = self.call_method_with_values(target.clone(), &method, Vec::new())?;
+        let current = match &current {
+            Value::ContainerRef(cell) => cell.lock().unwrap().clone(),
+            _ => current,
+        };
+        // The default returned for an absent key: the container's own
+        // `is default(...)`, else the attribute's declared default, else Nil.
+        let absent_default = self.container_default(&current).cloned().or_else(|| {
+            if let Value::Instance { class_name, .. } = &target {
+                self.class_attribute_default(&class_name.resolve(), &method)
+            } else {
+                None
+            }
+        });
+
+        // Save the pre-delete Arc identity so the modified container can be
+        // propagated to every instance/binding sharing it (mirrors the assign path).
+        let old_array_arc = match &current {
+            Value::Array(arc, ..) => Some(arc.clone()),
+            _ => None,
+        };
+        let old_hash_arc = match &current {
+            Value::Hash(arc) => Some(arc.clone()),
+            _ => None,
+        };
+
+        let (removed, updated) = match &current {
+            Value::Hash(h) => {
+                let key = index.to_string_value();
+                let mut new_hash = (**h).clone();
+                let removed = new_hash
+                    .remove(&key)
+                    .unwrap_or_else(|| absent_default.clone().unwrap_or(Value::Nil));
+                (removed, Value::Hash(std::sync::Arc::new(new_hash)))
+            }
+            Value::Array(items, kind) => {
+                let idx = crate::runtime::to_int(&index);
+                let mut new_items = (**items).clone();
+                let removed = if idx >= 0 && (idx as usize) < new_items.len() {
+                    let i = idx as usize;
+                    let r = new_items[i].clone();
+                    // Trailing element shrinks; an interior delete leaves a hole.
+                    if i + 1 == new_items.len() {
+                        new_items.truncate(i);
+                    } else {
+                        new_items[i] = Value::Nil;
+                    }
+                    r
+                } else {
+                    absent_default.clone().unwrap_or(Value::Nil)
+                };
+                (removed, Value::Array(std::sync::Arc::new(new_items), *kind))
+            }
+            _ => return Ok(absent_default.unwrap_or(Value::Nil)),
+        };
+
+        if let Some(old_arc) = &old_array_arc {
+            self.propagate_shared_array_in_instances(old_arc, &updated);
+            self.overwrite_array_bindings_by_identity(old_arc, updated.clone());
+        }
+        if let Some(old_arc) = &old_hash_arc {
+            self.propagate_shared_hash_in_instances(old_arc, &updated);
+            self.overwrite_hash_bindings_by_identity(old_arc, updated.clone());
+        }
+
+        self.assign_method_lvalue_with_values(
+            if var_name.is_empty() {
+                None
+            } else {
+                Some(var_name.as_str())
+            },
+            target,
+            &method,
+            Vec::new(),
+            updated,
+        )?;
+        Ok(removed)
     }
 
     /// Handle nested subscript assignment on a typed attribute accessor.

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -274,6 +274,8 @@ impl Interpreter {
                 attributes.insert(key.clone(), *value.clone());
             }
         }
+        // Embed `is default(...)` element defaults into `@`/`%` containers.
+        self.apply_container_attribute_defaults(&class_name.resolve(), &mut attributes);
         // Run BUILD/TWEAK submethods in MRO order (base-first)
         let mro = self.class_mro(&class_name.resolve());
         // Determine the class's language revision for submethod dispatch rules.

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -121,7 +121,18 @@ impl Interpreter {
         let current = current.map(Value::into_descalarized);
         match current {
             Some(Value::Hash(existing_hash)) => {
-                Self::normalize_hash_like_assignment(existing_hash.map.clone(), value)
+                // Carry the existing container's `is default(...)` onto the result
+                // so a whole-hash rw-accessor writeback (`$o.h<k> = v`, which
+                // round-trips the whole hash) does not strip the element default.
+                let existing_default = existing_hash.default.clone();
+                let mut result =
+                    Self::normalize_hash_like_assignment(existing_hash.map.clone(), value);
+                if let (Value::Hash(arc), Some(def)) = (&mut result, existing_default)
+                    && arc.default.is_none()
+                {
+                    std::sync::Arc::make_mut(arc).default = Some(def);
+                }
+                result
             }
             Some(Value::Array(..)) => super::coerce_to_array(value),
             _ => value,

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -839,16 +839,20 @@ impl Interpreter {
                         self.get_attr_type_constraint(&class_name.resolve(), method)
                     && !matches!(type_constraint.as_str(), "Mu" | "Any")
                 {
+                    // An object hash (`%.h{Str:D}`) declares `ValueType{KeyType}`;
+                    // its elements are checked against the value type only.
+                    let (value_type, _) =
+                        crate::runtime::types::split_object_hash_constraint(&type_constraint);
                     let hash_vals: Vec<Value> = match &value {
                         Value::Hash(h) => h.values().cloned().collect(),
                         _ => Vec::new(),
                     };
                     for v in &hash_vals {
-                        if !self.type_matches_value(&type_constraint, v) {
+                        if !matches!(v, Value::Nil) && !self.type_matches_value(value_type, v) {
                             return Err(RuntimeError::new(format!(
                                 "Type check failed for an element of %{}; expected {} but got {}",
                                 method,
-                                type_constraint,
+                                value_type,
                                 super::utils::value_type_name(v),
                             )));
                         }
@@ -895,9 +899,13 @@ impl Interpreter {
                     && let Some(tc) = self.get_attr_type_constraint(&class_name.resolve(), method)
                     && !matches!(tc.as_str(), "Mu" | "Any")
                 {
+                    // Split an object-hash `ValueType{KeyType}` so the container
+                    // records the value and key constraints separately.
+                    let (value_type, key_type) =
+                        crate::runtime::types::split_object_hash_constraint(&tc);
                     let info = ContainerTypeInfo {
-                        value_type: tc,
-                        key_type: None,
+                        value_type: value_type.to_string(),
+                        key_type: key_type.map(|k| k.to_string()),
                         declared_type: None,
                     };
                     assigned_value = self.tag_container_metadata(assigned_value, info);

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -332,6 +332,8 @@ impl Interpreter {
                 }
             }
         }
+        // Embed `is default(...)` element defaults into `@`/`%` containers.
+        self.apply_container_attribute_defaults(cn_resolved, &mut attrs);
         // Add alias metadata for `has $x` (no twigil) attributes
         self.add_alias_attribute_metadata(cn_resolved, &mut attrs);
         // The gate (`is_native_default_constructible`) allows BUILD/TWEAK-only

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1755,6 +1755,10 @@ impl Interpreter {
                     };
                     attrs.insert(attr_name, val);
                 }
+                // Embed `is default(...)` element defaults into `@`/`%` containers
+                // (evaluating any role-deferred expression while type params are
+                // still bound in `self.env`).
+                self.apply_container_attribute_defaults(class_key, &mut attrs);
                 // Add alias metadata for `has $x` (no twigil) attributes
                 self.add_alias_attribute_metadata(class_key, &mut attrs);
                 self.enforce_attribute_where_constraints(class_key, &class_attrs_info, &attrs)?;

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -480,6 +480,22 @@ impl Interpreter {
                         class_def.attributes.push(attr.clone());
                     }
                 }
+                // Carry each composed-role attribute's deferred `is default(...)`
+                // expression onto the consuming class so it can be evaluated at
+                // construction with this class's type-param bindings in scope.
+                let role_default_exprs: Vec<(String, crate::ast::Expr)> = self
+                    .registry()
+                    .role_attribute_default_exprs
+                    .iter()
+                    .filter(|((r, _), _)| r == base_role_name)
+                    .map(|((_, attr), expr)| (attr.clone(), expr.clone()))
+                    .collect();
+                for (attr, expr) in role_default_exprs {
+                    self.registry_mut()
+                        .class_attribute_default_exprs
+                        .entry((name.to_string(), attr))
+                        .or_insert(expr);
+                }
                 for (mname, overloads) in &role.methods {
                     // Skip methods declared with `my` scope -- they are role-private
                     // and should not be composed into consuming classes.
@@ -1076,8 +1092,16 @@ impl Interpreter {
                         if let Ok(val) =
                             self.eval_block_value(&[Stmt::Expr(is_default_expr.clone())])
                         {
-                            // Type-check the default value against the attribute's type constraint
+                            // Type-check the default value against the attribute's type
+                            // constraint. For an object hash (`%.a{KeyType}`) the
+                            // constraint is `ValueType{KeyType}`; the `is default`
+                            // value is an *element* default, so check it against the
+                            // value type only.
                             if let Some(tc) = type_constraint {
+                                let tc = tc
+                                    .split_once('{')
+                                    .map(|(value_tc, _)| value_tc)
+                                    .unwrap_or(tc.as_str());
                                 let type_ok = if matches!(val, Value::Nil) {
                                     // Nil is only valid for untyped or Nil-accepting attributes
                                     tc == "Any" || tc == "Mu" || tc.contains("Nil")

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -395,7 +395,7 @@ impl Interpreter {
                     is_alias: _,
                     is_our: _,
                     is_my: _,
-                    is_default: _,
+                    is_default,
                     is_type: _,
                     deprecated_message: _,
                     is_built: _,
@@ -403,6 +403,16 @@ impl Interpreter {
                 } => {
                     let attr_name_str = attr_name.resolve();
                     role_def.own_attribute_names.insert(attr_name_str.clone());
+                    // `is default(...)` on a role attribute can reference the role's
+                    // type parameters (`is default(T)`), so it cannot be evaluated
+                    // until composition. Stash the expression keyed by (role, attr);
+                    // it is copied to the consuming class and evaluated at instance
+                    // construction (with type params bound).
+                    if let Some(def_expr) = is_default {
+                        self.registry_mut()
+                            .role_attribute_default_exprs
+                            .insert((name.to_string(), attr_name_str.clone()), def_expr.clone());
+                    }
                     // Check if this attribute already exists from a composed role
                     if let Some(existing) = role_def
                         .attributes

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -89,6 +89,15 @@ pub(crate) struct Registry {
     pub(crate) attribute_build_overrides: HashMap<(String, String), Value>,
     /// Per-attribute default value: (class, attr) -> default value.
     pub(crate) class_attribute_defaults: HashMap<(String, String), Value>,
+    /// Per-attribute `is default(...)` expression for a parametric role, where the
+    /// value cannot be evaluated until the role is composed and its type params
+    /// are bound: (role-base, attr) -> expr. Evaluated at instance construction
+    /// (with role param bindings in scope) to tag `@`/`%` containers.
+    pub(crate) role_attribute_default_exprs: HashMap<(String, String), crate::ast::Expr>,
+    /// Per-attribute deferred `is default(...)` expression carried from a composed
+    /// parametric role onto a consuming class: (class, attr) -> expr. Evaluated at
+    /// construction with the class's role type-param bindings in scope.
+    pub(crate) class_attribute_default_exprs: HashMap<(String, String), crate::ast::Expr>,
     /// Per-attribute declared type: (class, attr) -> type name.
     pub(crate) class_attribute_is_types: HashMap<(String, String), String>,
     /// Per-attribute `does Role` traits: (class, attr) -> role names mixed into

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -353,6 +353,10 @@ impl Interpreter {
         elem_type: &str,
         value: Value,
     ) -> Result<Value, RuntimeError> {
+        // An object-hash attribute (`%.a{Str:D}`) carries its declared type as
+        // `ValueType{KeyType}`; the element type is the value part, and the key
+        // part is tagged onto the container as the key constraint.
+        let (elem_type, key_type) = crate::runtime::types::split_object_hash_constraint(elem_type);
         if elem_type != "Mu" && elem_type != "Any" {
             let display = format!("{}!{}", sigil, attr_name);
             // Collect the values to type-check. A shaped array (`has Int @.g[2;2]`)
@@ -390,7 +394,7 @@ impl Interpreter {
         }
         let info = ContainerTypeInfo {
             value_type: elem_type.to_string(),
-            key_type: None,
+            key_type: key_type.map(|k| k.to_string()),
             declared_type: None,
         };
         Ok(self.tag_container_metadata(value, info))

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -233,6 +233,46 @@ impl Interpreter {
         }
     }
 
+    /// Embed each `@`/`%` attribute's `is default(...)` element default (from
+    /// `class_attribute_defaults`) into the freshly-constructed instance's
+    /// containers, so a missing-element read returns the declared default and
+    /// the value survives copy-on-write. Scalar attributes are skipped (their
+    /// default is carried via `var_defaults` and the unassigned-scalar read).
+    pub(crate) fn apply_container_attribute_defaults(
+        &mut self,
+        class_name: &str,
+        attributes: &mut std::collections::HashMap<String, Value>,
+    ) {
+        let names: Vec<String> = attributes.keys().cloned().collect();
+        for attr_name in names {
+            if !matches!(
+                attributes.get(&attr_name),
+                Some(Value::Array(..)) | Some(Value::Hash(_))
+            ) {
+                continue;
+            }
+            // Prefer the already-evaluated default (non-generic classes); fall back
+            // to a deferred expression carried from a parametric role, evaluated now
+            // (the caller has bound the role's type params in `self.env`).
+            let def = self
+                .class_attribute_default(class_name, &attr_name)
+                .or_else(|| {
+                    let expr = self
+                        .registry()
+                        .class_attribute_default_exprs
+                        .get(&(class_name.to_string(), attr_name.clone()))
+                        .cloned()?;
+                    self.eval_block_value(&[crate::ast::Stmt::Expr(expr)]).ok()
+                });
+            if let Some(def) = def
+                && let Some(val) = attributes.remove(&attr_name)
+            {
+                let tagged = self.tag_container_default(val, def);
+                attributes.insert(attr_name, tagged);
+            }
+        }
+    }
+
     /// Get the element default for a container (Array/Hash).
     pub(crate) fn container_default<'v>(&'v self, value: &'v Value) -> Option<&'v Value> {
         match value {

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -78,6 +78,22 @@ pub(crate) fn strip_type_smiley(constraint: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Split an object-hash constraint of the form `ValueType{KeyType}` into its
+/// value-type and optional key-type parts. A plain constraint (no `{...}`)
+/// returns `(constraint, None)`. The value type governs element type checks; the
+/// key type governs key constraints.
+pub(crate) fn split_object_hash_constraint(constraint: &str) -> (&str, Option<&str>) {
+    if let Some(open) = constraint.find('{')
+        && constraint.ends_with('}')
+    {
+        let value_type = constraint[..open].trim();
+        let key_type = constraint[open + 1..constraint.len() - 1].trim();
+        (value_type, Some(key_type))
+    } else {
+        (constraint, None)
+    }
+}
+
 /// Check if a value is "defined" in the Raku sense.
 /// Type objects (Package) are undefined; concrete values and instances are defined.
 pub(crate) fn value_is_defined(value: &Value) -> bool {

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -496,6 +496,7 @@ impl Interpreter {
                 | "leave"
                 | "__mutsu_assign_method_lvalue"
                 | "__mutsu_index_assign_method_lvalue"
+                | "__mutsu_index_delete_method_lvalue"
         ) || self.in_lvalue_assignment;
         let args = if skip_proxy_fetch {
             args
@@ -578,6 +579,10 @@ impl Interpreter {
         let lvalue_writeback_target = match name.as_str() {
             "__mutsu_assign_method_lvalue" | "__mutsu_index_assign_method_lvalue" => args
                 .get(4)
+                .map(|v| v.to_string_value())
+                .filter(|s| !s.is_empty()),
+            "__mutsu_index_delete_method_lvalue" => args
+                .get(3)
                 .map(|v| v.to_string_value())
                 .filter(|s| !s.is_empty()),
             _ => None,


### PR DESCRIPTION
## Summary

Fixes `roast/S02-names/is_default.t` (BLOCKERS §3.1) — now **146/146**, added to the whitelist.

An `is default(X)` trait on a `@`/`%` attribute was wrongly used as the container's *initializer*: `has %.a is default(42)` made the attribute the scalar `42` rather than an empty hash whose missing-element default is `42`. For a parametric role (`has %.h is default(T)`) the default was dropped entirely. Object-hash attributes (`has %.a{Str:D}`) didn't parse at all.

## Changes

- **Parser**: for `@`/`%` sigils, `is default(X)` becomes the container element default (the `is_default` trait), not the value initializer — the container is built empty and tagged at construction.
- **Construction**: embed each `@`/`%` attribute's `is default(...)` into its container (`apply_container_attribute_defaults`) across all `.new` paths.
- **Parametric roles**: thread the deferred `is default(T)` expression from role registration through composition onto the consuming class, evaluated at construction with the role's type params bound (`role_attribute_default_exprs` → `class_attribute_default_exprs`).
- **Object-hash attributes**: parse `has %.a{Str:D}` (mirrors `my %h{Str:D}`), folding the key type into the attribute type as `ValueType{KeyType}`; `split_object_hash_constraint` splits it back into value/key parts wherever element type checks and container tagging happen.
- **Accessor element delete**: `$obj.attr<key>:delete` now writes the modified container back to the attribute and returns the container default for an absent key (`__mutsu_index_delete_method_lvalue`), mirroring the existing `$obj.attr<key> = v` lvalue writeback.
- A whole-hash rw-accessor writeback no longer strips the container's element default.

## Testing

- `roast/S02-names/is_default.t` → 146/146 PASS.
- `make test` green; targeted roast checks pass (`S12-attributes/{instance,delegation}.t`, `S09-typed-arrays/{arrays,hashes}.t`, `S02-types/hash.t`, `S14-roles/parameterized-*.t`, `S12-construction/roles-6e.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)