### PR TITLE
feat(temp): complete temp semantics — sub-exit restore, ++temp, TEMP{}, nested lvalues (temp.t)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -405,7 +405,10 @@ materialize せず Seq のまま保持し（`.WHAT === Seq`）、`+@foo` は Lis
 
 - `S02-types/capture.t`
 - `S02-names-vars/variables-and-packages.t`
-- `S04-blocks-and-statements/temp.t`
+- ~~`S04-blocks-and-statements/temp.t`~~ — DONE (whitelisted): `temp`
+  restoration on sub/recursive exit, `++temp`, the NYI `TEMP {}` phaser,
+  multi-level indexed lvalues (`temp $s[1]<k>[1] = v`, via whole-base-container
+  save), and `temp $*undeclared` -> `X::Dynamic::NotFound`.
 - `S14-traits/attributes.t`
 - `S12-subset/subtypes.t` の一部
 - `S02-types/whatever.t` のうち container preservation 系

--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -4,7 +4,7 @@
 - [ ] roast/S04-blocks-and-statements/pointy-rw.t
 - [ ] roast/S04-blocks-and-statements/pointy.t
   - 7/21 pass (4-7, 13-15). Pointy blocks work in list context. Failures: `-> $x { }` without parens (1), immediately invoked pointy (2-3), block control exceptions (8-9), return from pointy (10-11), `$^a` in pointy (12), .signature (16), YOU_ARE_HERE (17-19). Only 19 reached. Difficulty: Medium
-- [ ] roast/S04-blocks-and-statements/temp.t
+- [x] roast/S04-blocks-and-statements/temp.t
 - [ ] roast/S04-declarations/constant-6.d.t
 - [x] roast/S04-declarations/constant.t
   - 72/72 pass (69 ok + 3 TODO). FULLY PASSING (whitelisted 2026-06-30).

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -294,6 +294,7 @@ roast/S03-smartmatch/signature-signature.t
 roast/S04-blocks-and-statements/let.t
 roast/S04-blocks-and-statements/pointy-rw.t
 roast/S04-blocks-and-statements/pointy.t
+roast/S04-blocks-and-statements/temp.t
 roast/S04-declarations/constant-6.d.t
 roast/S04-declarations/constant.t
 roast/S04-declarations/implicit-parameter.t

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -33,7 +33,15 @@ impl Compiler {
                 self.code.emit(OpCode::BoolCoerce);
             }
             TokenKind::PlusPlus => {
-                if let Expr::Var(name) = expr {
+                if let Some(var) = Self::temp_call_var(expr) {
+                    // `++temp $c`: `temp $c` temporizes `$c` (saved for restoration
+                    // at scope exit) and yields it as an lvalue, so the `++`
+                    // increments the live variable. Emit the temp save, then the
+                    // pre-increment on the underlying variable.
+                    self.emit_temp_save(&var);
+                    let name_idx = self.code.add_constant(Value::str(var));
+                    self.code.emit(OpCode::PreIncrement(name_idx));
+                } else if let Expr::Var(name) = expr {
                     if name.starts_with('!') && name.len() > 1 {
                         self.alloc_local(name);
                     }
@@ -71,7 +79,13 @@ impl Compiler {
                 }
             }
             TokenKind::MinusMinus => {
-                if let Expr::Var(name) = expr {
+                if let Some(var) = Self::temp_call_var(expr) {
+                    // `--temp $c`: temporize `$c` then pre-decrement it (see the
+                    // `++temp` case above).
+                    self.emit_temp_save(&var);
+                    let name_idx = self.code.add_constant(Value::str(var));
+                    self.code.emit(OpCode::PreDecrement(name_idx));
+                } else if let Expr::Var(name) = expr {
                     if name.starts_with('!') && name.len() > 1 {
                         self.alloc_local(name);
                     }
@@ -135,5 +149,30 @@ impl Compiler {
                 });
             }
         }
+    }
+
+    /// If `expr` is `temp $var` parsed as a `Call("temp", [Var])` (i.e. `temp`
+    /// used as an lvalue expression rather than a statement, such as the operand
+    /// of `++`/`--`), return the underlying simple variable name.
+    fn temp_call_var(expr: &Expr) -> Option<String> {
+        if let Expr::Call { name, args } = expr
+            && name.resolve() == "temp"
+            && args.len() == 1
+            && let Expr::Var(var) = &args[0]
+        {
+            return Some(var.clone());
+        }
+        None
+    }
+
+    /// Emit a `temp` save for the named scalar variable: its current value is
+    /// pushed onto the let-saves stack and restored at the enclosing scope's exit.
+    fn emit_temp_save(&mut self, var: &str) {
+        let name_idx = self.code.add_constant(Value::str(var.to_string()));
+        self.code.emit(OpCode::LetSave {
+            name_idx,
+            index_mode: false,
+            is_temp: true,
+        });
     }
 }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2781,6 +2781,15 @@ impl Compiler {
                 is_temp,
                 undefine_first,
             } => {
+                // Temporizing a never-declared dynamic variable (`temp $*foo`)
+                // throws X::Dynamic::NotFound — you can only `temp`/`let` a variable
+                // that is already in scope. Emit the guard before the save (a no-op
+                // for non-dynamic names and for an already-declared dynamic). Skip
+                // it for the element form (`temp $*arr[0]`), which temporizes a
+                // container element rather than the dynamic itself.
+                if index.is_none() {
+                    self.maybe_emit_dynamic_var_check(name);
+                }
                 // If undefine_first is set, assign Nil to the variable before saving.
                 // This makes LetSave capture the undefined state, so on scope exit
                 // the variable is restored to undefined (and its default value applies).

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -177,6 +177,21 @@ pub(crate) fn phaser_stmt(input: &str) -> PResult<'_, Stmt> {
         (r, PhaserKind::Quit)
     } else if let Some(r) = keyword("CLOSE", input) {
         (r, PhaserKind::Close)
+    } else if let Some(r) = keyword("TEMP", input) {
+        // `TEMP { ... }` is the temporization phaser. It is NYI in Rakudo: the
+        // block is parsed but its body is never executed (and no restoration is
+        // performed), so `TEMP {{ $x = $y }}` is effectively a no-op. Match that
+        // behavior — consume the block and emit nothing — rather than running the
+        // block inline (which `BareWord("TEMP")` + a bare `{ ... }` block would
+        // do, wrongly executing the body).
+        let (r, _) = ws(r)?;
+        let (r, _body) = if r.starts_with('{') {
+            block(r)?
+        } else {
+            let (r, s) = statement(r)?;
+            (r, vec![s])
+        };
+        return parse_statement_modifier(r, Stmt::Block(Vec::new()));
     } else {
         return Err(PError::expected("phaser keyword"));
     };

--- a/src/parser/stmt/simple_expr_stmt/let_temp.rs
+++ b/src/parser/stmt/simple_expr_stmt/let_temp.rs
@@ -128,6 +128,20 @@ pub(crate) fn let_stmt(input: &str) -> PResult<'_, Stmt> {
     )
 }
 
+/// Walk an indexed lvalue chain down to its base variable and return the env
+/// key used by `LetSave` for that variable (scalars drop their `$` sigil;
+/// arrays/hashes keep their `@`/`%`). Returns `None` for non-variable bases
+/// (e.g. a method call), which the multi-level `temp` lowering cannot save.
+fn lvalue_base_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Var(n) => Some(n.clone()),
+        Expr::ArrayVar(n) => Some(format!("@{}", n)),
+        Expr::HashVar(n) => Some(format!("%{}", n)),
+        Expr::Index { target, .. } => lvalue_base_name(target),
+        _ => None,
+    }
+}
+
 /// Parse a variable from `undefine(...)` or `undefine $var` inside a `temp` context.
 fn parse_temp_undefine_var(input: &str) -> Result<(&str, String), PError> {
     if let Some(inner) = input.strip_prefix('(') {
@@ -162,8 +176,32 @@ fn parse_temp_undefine_var(input: &str) -> Result<(&str, String), PError> {
 pub(crate) fn temp_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("temp", input).ok_or_else(|| PError::expected("temp statement"))?;
     let (rest, _) = ws1(rest)?;
-    // temp on lvalue method call: `temp $obj.method = value`
     if let Ok((expr_rest, expr)) = expression(rest) {
+        // temp on a *multi-level* indexed lvalue: `temp $s[1]<k>[1] = 23`.
+        // `expression` parses the whole `lvalue = value` into a nested
+        // `IndexAssign` (its `target` is itself an `Index`). The single-level
+        // `temp @a[i] = v` / `temp %h<k> = v` forms below cannot represent this
+        // chain, so handle it here: temporize the *whole* base container (saved
+        // and restored at scope exit, mirroring the single-level whole-container
+        // save) and then run the full nested assignment. The two run inline in
+        // the current scope via a `SyntheticBlock` (no fresh let-saves mark).
+        if let Expr::IndexAssign { target, .. } = &expr
+            && matches!(target.as_ref(), Expr::Index { .. })
+            && let Some(save_name) = lvalue_base_name(target)
+        {
+            let save_stmt = Stmt::Let {
+                name: save_name,
+                index: None,
+                value: None,
+                is_temp: true,
+                undefine_first: false,
+            };
+            return parse_statement_modifier(
+                expr_rest,
+                Stmt::SyntheticBlock(vec![save_stmt, Stmt::Expr(expr)]),
+            );
+        }
+        // temp on lvalue method call: `temp $obj.method = value`
         let (expr_rest_ws, _) = ws(expr_rest)?;
         if expr_rest_ws.starts_with('=')
             && !expr_rest_ws.starts_with("==")

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -131,6 +131,14 @@ impl Interpreter {
             }
         }
 
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): restore any `temp` bindings the body introduced so a
+        // `sub f { temp $x = ... }` with no explicit return does not leak the
+        // temporized value into the caller's scope.
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_let_saves_on_success(let_mark, true);
+        }
+
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::Nil)

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -146,6 +146,14 @@ impl Interpreter {
             }
         }
 
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): restore any `temp` bindings the body introduced so a
+        // `sub f { temp $x = ... }` with no explicit return does not leak the
+        // temporized value into the caller's scope.
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_let_saves_on_success(let_mark, true);
+        }
+
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::Nil)

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -287,6 +287,14 @@ impl Interpreter {
             }
         }
 
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): restore any `temp` bindings the body introduced so a
+        // `sub f { temp $x = ... }` with no explicit return does not leak the
+        // temporized value into the caller's scope.
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_let_saves_on_success(let_mark, true);
+        }
+
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::Nil)

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -294,6 +294,14 @@ impl Interpreter {
             }
         }
 
+        // Natural fall-through completion (no explicit return / fail / error
+        // break arm): restore any `temp` bindings the body introduced so a
+        // `sub f { temp $x = ... }` with no explicit return does not leak the
+        // temporized value into the caller's scope.
+        if result.is_ok() && explicit_return.is_none() && !fail_bypass {
+            self.resolve_let_saves_on_success(let_mark, true);
+        }
+
         let mut ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
                 self.stack.pop().unwrap_or(Value::Nil)

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -500,6 +500,11 @@ impl Interpreter {
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
         let mut fail_bypass = false;
+        // Track whether a break arm already resolved this frame's `let`/`temp`
+        // saves, so the natural fall-through completion below can restore any
+        // `temp` bindings the body introduced (e.g. `sub f { temp $x = ... }`
+        // with no explicit return) instead of leaking them into the caller.
+        let mut handled_let_saves = false;
         while ip < cc.ops.len() {
             match self.exec_one(cc, &mut ip, compiled_fns) {
                 Ok(()) => {}
@@ -519,11 +524,13 @@ impl Interpreter {
                         explicit_return = Some(ret_val.clone());
                         self.stack.truncate(saved_stack_depth);
                         self.stack.push(ret_val);
-                        self.discard_let_saves(let_mark);
+                        self.resolve_let_saves_on_success(let_mark, true);
+                        handled_let_saves = true;
                         result = Ok(());
                         break;
                     }
                     loan_env!(self, restore_let_saves(let_mark));
+                    handled_let_saves = true;
                     result = Err(e);
                     break;
                 }
@@ -534,7 +541,8 @@ impl Interpreter {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.discard_let_saves(let_mark);
+                    self.resolve_let_saves_on_success(let_mark, true);
+                    handled_let_saves = true;
                     result = Ok(());
                     break;
                 }
@@ -555,6 +563,7 @@ impl Interpreter {
                                 e.return_target_callable_id = Some(*id as u64);
                             }
                             loan_env!(self, restore_let_saves(let_mark));
+                            handled_let_saves = true;
                             result = Err(e);
                             break;
                         }
@@ -566,6 +575,7 @@ impl Interpreter {
                         && target_id != data.id
                     {
                         loan_env!(self, restore_let_saves(let_mark));
+                        handled_let_saves = true;
                         result = Err(e);
                         break;
                     }
@@ -573,7 +583,8 @@ impl Interpreter {
                     explicit_return = Some(ret_val.clone());
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(ret_val);
-                    self.discard_let_saves(let_mark);
+                    self.resolve_let_saves_on_success(let_mark, true);
+                    handled_let_saves = true;
                     result = Ok(());
                     break;
                 }
@@ -581,6 +592,7 @@ impl Interpreter {
                     fail_bypass = true;
                     let failure = self.fail_error_to_failure_value(&e);
                     loan_env!(self, restore_let_saves(let_mark));
+                    handled_let_saves = true;
                     self.stack.truncate(saved_stack_depth);
                     self.stack.push(failure);
                     result = Ok(());
@@ -588,6 +600,7 @@ impl Interpreter {
                 }
                 Err(e) => {
                     loan_env!(self, restore_let_saves(let_mark));
+                    handled_let_saves = true;
                     result = Err(e);
                     break;
                 }
@@ -595,6 +608,13 @@ impl Interpreter {
             if self.is_halted() {
                 break;
             }
+        }
+
+        // Natural fall-through completion (no explicit return / break arm): a
+        // routine body that ends with `temp $x = ...` must restore the `temp`
+        // binding here, otherwise it leaks into the caller's scope.
+        if !handled_let_saves {
+            self.resolve_let_saves_on_success(let_mark, true);
         }
 
         let ret_val = if result.is_ok() {

--- a/t/temp-scope-restore.t
+++ b/t/temp-scope-restore.t
@@ -1,0 +1,73 @@
+use Test;
+
+plan 11;
+
+# `temp` saves a variable's value and restores it when the enclosing scope
+# exits. These cover the cases that previously failed: restoration on *sub*
+# exit, recursive temps, `++temp`, the `TEMP { }` phaser, multi-level indexed
+# lvalues, and temping a non-existent dynamic.
+
+# Restoration on bare-block exit.
+{
+    my $a = 42;
+    { temp $a = 23; is $a, 23, 'temp changed the variable in a block'; }
+    is $a, 42, 'temp restored the variable after the block';
+}
+
+# Restoration on *sub* exit (no explicit return).
+{
+    my $value = 0;
+    my sub non-recursive { temp $value = $value + 1; }
+    non-recursive();
+    is $value, 0, 'temp restored on sub exit';
+}
+
+# Restoration across recursion.
+{
+    my $value = 0;
+    my sub recursive(Int $limit) {
+        temp $value = $value + 1;
+        recursive($limit - 1) if $limit > 0;
+    }
+    recursive(10);
+    is $value, 0, 'temp restored across recursive calls';
+}
+
+# `++temp $x`: temporize and increment in one expression.
+{
+    my $depth = 0;
+    my $c = 1;
+    sub a {
+        ++temp $c;
+        a() if ++$depth < 3;
+    }
+    a();
+    is $c, 1, 'recursive nested ++temp restored properly';
+}
+
+# `TEMP { }` phaser is NYI (matches Rakudo): the block never runs.
+{
+    my $next = 0;
+    sub advance() {
+        my $curr = $next++;
+        TEMP {{ $next = $curr }}
+        return $curr;
+    }
+    is advance(), 0, 'TEMP block does not restore (1)';
+    is advance(), 1, 'TEMP block does not restore (2)';
+    is $next, 2, 'TEMP block leaves $next advanced';
+}
+
+# Multi-level indexed lvalue.
+{
+    my $struct = [ "x", { key => [ "y", 42 ] } ];
+    { temp $struct[1]<key>[1] = 23;
+      is $struct[1]<key>[1], 23, 'temp changed a nested array/hash element'; }
+    is $struct[1]<key>[1], 42, 'temp restored the nested element';
+}
+
+# Temping a never-declared dynamic variable throws.
+throws-like { temp $*undeclared-dyn = 42 }, X::Dynamic::NotFound,
+    'temp on a non-existent dynamic throws X::Dynamic::NotFound';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Makes `roast/S04-blocks-and-statements/temp.t` pass (all 46 subtests) and adds it to the whitelist. This is BLOCKERS.md §3.1.

## What was broken

`temp` temporization had several gaps that left `temp.t` failing (and aborting mid-file):

1. **No restoration on routine exit.** All sub/method dispatch paths only restored `temp` bindings on an *explicit* `return`. A body that ended naturally with `temp $x = ...` (e.g. `sub f { temp $value = $value + 1 }`) leaked the temporized value into the caller, and recursive temps never unwound.
2. **`++temp $c` aborted** with *"the parameter requires mutable arguments"* — `temp $c` as an expression compiled to a `Call("temp", …)` that `++` could not treat as an lvalue.
3. **`TEMP { … }`** was parsed as a bare `BareWord("TEMP")` followed by a block and *ran the block inline* — wrong. It is NYI in Rakudo (the block never executes).
4. **Multi-level indexed lvalues** (`temp $s[1]<k>[1] = 23`) mis-parsed: only `$s[1]` was temporized and the rest became a broken assignment.
5. **`temp $*undeclared`** did not throw `X::Dynamic::NotFound`.

## Fix

- Restore `temp` saves on natural fall-through completion of every dispatch path, and on the success break arms (the method/closure paths were `discard`ing temps instead of restoring them).
- Compile `++temp $c` / `--temp $c` to a temp-save plus a pre-inc/dec on the underlying variable.
- Parse `TEMP { … }` as a phaser and discard the body (matches Rakudo's NYI behavior).
- Lower a multi-level `temp` lvalue to a whole-base-container temp save plus the full nested assignment (mirroring the existing single-level `temp @a[i]` whole-container save).
- Emit the dynamic-var-declared guard for `temp`/`let` so temporizing a never-declared dynamic throws `X::Dynamic::NotFound`.

## Tests

- `roast/S04-blocks-and-statements/temp.t` → 46/46, added to `roast-whitelist.txt`.
- New `t/temp-scope-restore.t` (11 focused cases).
- `make test` green (13357 tests). Verified no regression locally in S04 phasers/statements/declarations and `let.t`; `for.t`'s 8 failures are pre-existing and identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)