### PR TITLE
fix(hash): typed object-hash value-type default in expr-position decl + Pair.Str type-object value

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -411,7 +411,11 @@ materialize せず Seq のまま保持し（`.WHAT === Seq`）、`+@foo` は Lis
 - `S14-traits/attributes.t`
 - `S12-subset/subtypes.t` の一部
 - `S02-types/whatever.t` のうち container preservation 系
-- `S32-hash/adverbs.t` の typed-hash default survival
+- ~~`S32-hash/adverbs.t` の typed-hash default survival~~ — DONE (whitelisted):
+  expression-position object-hash declarations (`gen my Int %j{Cool}`) now tag
+  the value-type half of the constraint so missing-key adverb defaults resolve
+  to the element type, and `Pair.Str` stringifies a type-object value as `""`
+  (raku `eq`-compares `(k => Any)` and `(k => Mu)` equal in `is`).
 - `S32-array/splice.t`
 - `S02-names/is_default.t`
 
@@ -454,7 +458,7 @@ materialize せず Seq のまま保持し（`.WHAT === Seq`）、`+@foo` は Lis
        属性 slot の cell 化が必要（配列/ハッシュ要素 `$r := @a[0]` は既に動く）。
 3. **typed-hash default / Capture 書き戻し / wrapper capture**
    - 変更レイヤ: hash missing-key default、Capture bind/writeback、wrap closure env
-   - 対象: `S32-hash/adverbs.t`, `S02-types/capture.t`, `S02-types/whatever.t`
+   - 対象: ~~`S32-hash/adverbs.t`~~ (DONE), `S02-types/capture.t`, `S02-types/whatever.t`
 4. **BEGIN/EVAL/lexical 配列変更の永続化**
    - 変更レイヤ: env/local coherence、block escape、BEGIN 実行時 lexical carrier
    - 対象: `S26-documentation/12-non-breaking-space.t`, `temp.t`, package/var tests

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -535,20 +535,26 @@
       form), X::Syntax::Confused, X::Comp::FailGoal, various X::Syntax::Regex::*, etc.
   - Difficulty: Very High (effectively requires implementing a compile-time error pass and
     ~30 exception types). Should be tackled incrementally per feature, not as one PR.
-- [ ] roast/S32-hash/adverbs.t
-  - 1069/1128 pass (was 823). Landed: zen-slice adverbs (`%h{}:k/:v/:kv/:p` and
-    negations/args), X::Adverb for unknown (`:foo`) and conflicting (`:k:v`)
-    subscript adverbs with correct `.what`/`.source`/`.nogo`/`.unexpected`
-    (`unexpected` is now a list; `what` is `{} slice`/`[] slice` for a pure
-    unknown-adverb zen error, `slice` when a nogo combination is present),
-    `%h.name`/`@a.name` returning the sigil'd variable name, and Range keys as
-    multi-key hash slices (`%h{"b".."c"}` and with adverbs).
-  - Remaining 59: typed-hash value-type default for a *missing* key must survive
-    rebinding — `for $%i -> %h { %h<missing>:!p }` should default to `Int` (the
-    `my Int %i` value type), but the loop variable `%h` carries no type
-    constraint and the bound Hash *value* does not carry its value-type metadata.
-    This is the first-class-container-identity limitation (value-carried type),
-    owned by the main engineer per BLOCKERS.md — not fixable from here.
+- [x] roast/S32-hash/adverbs.t — **DONE, 1128/1128, whitelisted.** Landed:
+    zen-slice adverbs (`%h{}:k/:v/:kv/:p` and negations/args), X::Adverb for
+    unknown (`:foo`) and conflicting (`:k:v`) subscript adverbs with correct
+    `.what`/`.source`/`.nogo`/`.unexpected`, `%h.name`/`@a.name`, and Range keys
+    as multi-key hash slices. Final two fixes for the typed-hash value-type
+    default group:
+    1. An object-hash declared in EXPRESSION position (`gen my Int %j{Cool}` as a
+       call argument) now tags the **value-type half** of its `Int{Cool}`
+       constraint onto the value (`expr_block.rs`), so a missing-key read resolves
+       to the element type (`Int`) instead of `Any`. (The `{Cool}` key half is
+       intentionally NOT re-tagged in expr position — a raw-binding mutation
+       (`sub gen(\h){ h{$_}=... }`) stores plain string keys, so marking the value
+       `.WHICH`-keyed would break Str-key adverbs; full object-hash keying through
+       raw binding is deferred.)
+    2. `Pair.Str` now stringifies a type-object value in Str context as `""`
+       (`display.rs` `to_str_context`), not its `.gist` `(Any)`. Test's `is`
+       `eq`-compares `(k => Any)` and `(k => Mu)` equal (both `"k\t"`), matching
+       raku — this is what passes the `:!p`/`:p($no)` missing-key adverb tests for
+       the `Mu`/`Int` object-hash iterations even though the actual default is
+       `Any` (raku bug #5419, TODO'd for the bare value/`:!v` tests).
 - [ ] roast/S32-hash/antipairs.t
 - [ ] roast/S32-hash/delete-adverb.t
 - [ ] roast/S32-hash/delete.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1035,6 +1035,7 @@ roast/S32-encoding/decoder.t
 roast/S32-encoding/encoder.t
 roast/S32-encoding/registry.t
 roast/S32-exceptions/misc2.t
+roast/S32-hash/adverbs.t
 roast/S32-hash/antipairs.t
 roast/S32-hash/delete-adverb.t
 roast/S32-hash/delete.t

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -110,11 +110,19 @@ impl Compiler {
                     //     limitation where a parameterized Array[T]/Hash[T] is rejected
                     //     by the role).
                     //   - object hashes (`my Int %j{Cool}`, encoded as the
-                    //     `"Int{Cool}"` constraint) are excluded: re-tagging the
-                    //     key type in expression position breaks the string-key
-                    //     subscript (`%j<b>:k` returns `()`), the concrete
-                    //     `Associative[T]` perturbation the array-only guard
-                    //     originally avoided.
+                    //     `"Int{Cool}"` constraint): the FULL constraint is NOT
+                    //     re-tagged in expression position, because re-applying the
+                    //     key-type half (`{Cool}`) marks the value `.WHICH`-keyed
+                    //     while a subsequent raw-binding mutation (`gen my Int
+                    //     %j{Cool}` → `sub gen(\h){ h{$_}=... }`) still stores plain
+                    //     string keys (the callee's `h` carries no var-level key
+                    //     constraint), so adverbs (`%j<b>:k`) would `.WHICH`-look-up
+                    //     keys that were stored plain and miss. Instead we tag only
+                    //     the VALUE-type half (`Int`), which is all the missing-key
+                    //     default needs (`%j<B>:!p` → `B => (Int)`); the hash stays
+                    //     plain-string-keyed so every Str-key adverb keeps working.
+                    //     (Fully unifying object-hash keying through raw-binding
+                    //     mutation is the larger change deferred here.)
                     let is_native_value_type = type_constraint.as_ref().is_some_and(|tc| {
                         if name.starts_with('@') {
                             crate::runtime::native_types::is_native_array_element_type(tc)
@@ -128,10 +136,21 @@ impl Compiler {
                         && !name.contains("__ANON_HASH__")
                         && let Some(tc) = type_constraint
                         && !is_native_value_type
-                        && !(name.starts_with('%') && tc.contains('{'))
                     {
-                        let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                        // For an object hash (`%h{KeyType}`), strip the `{...}` key
+                        // part and tag only the value type, so the value stays
+                        // plain-string-keyed (see the note above).
+                        let value_tc = if name.starts_with('%') {
+                            tc.split('{').next().unwrap_or(tc)
+                        } else {
+                            tc
+                        };
+                        if value_tc.is_empty() {
+                            // Bare `my %h{KeyType}` (no value type): nothing to tag.
+                        } else {
+                            let tc_idx = self.code.add_constant(Value::str(value_tc.to_string()));
+                            self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                        }
                     }
                     // Read back the coerced value (SetGlobal coerces list->hash for %)
                     let name_idx2 = self.code.add_constant(Value::str(name.clone()));

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -617,9 +617,15 @@ impl Value {
                     .collect::<Vec<_>>()
                     .join(" ")
             }
-            Value::Pair(k, v) => format!("{}\t{}", k, v.to_string_value()),
+            // Pair `.Str` is `key.Str ~ "\t" ~ value.Str`; an undefined type-object
+            // value stringifies to "" in Str context (raku warns + empty), NOT to
+            // its `.gist` `(Any)`. Using `to_str_context` here is what makes
+            // `(B => Any).Str eq (B => Mu).Str` (both "B\t"), so `is %h<k>:!p,
+            // (k => SomeType)` compares equal for any type-object default
+            // (S32-hash/adverbs object-hash missing-key defaults).
+            Value::Pair(k, v) => format!("{}\t{}", k, v.to_str_context()),
             Value::ValuePair(k, v) => {
-                format!("{}\t{}", k.to_string_value(), v.to_string_value())
+                format!("{}\t{}", k.to_str_context(), v.to_str_context())
             }
             Value::Enum { key, .. } => key.resolve(),
             Value::CompUnitDepSpec { short_name } => {

--- a/t/object-hash-expr-decl-value-type.t
+++ b/t/object-hash-expr-decl-value-type.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 14;
+
+# An object hash (`%h{KeyType}`) declared in EXPRESSION position — e.g. as a
+# call argument `gen my Int %j{Cool}` — must carry its declared value type so a
+# missing-key read defaults to the element type, not Any.
+
+sub gen(\h) {
+    my Int $i = 0;
+    h{$_} = ++$i for 'a'..'d';
+}
+
+gen my Int %j{Cool};
+
+# Existing keys behave normally (plain Str-key adverbs keep working).
+is %j<b>, 2, 'existing key value';
+is (%j<b>:k), 'b', 'existing key :k';
+is (%j<b>:!p), (b => 2), 'existing key :!p';
+is %j.elems, 4, 'gen populated 4 keys';
+
+# Missing-key reads default to the value type (Int), surviving expr-position decl.
+is %j<Z>, Int, 'missing key value defaults to Int';
+is (%j<Z>:!v), Int, 'missing key :!v defaults to Int';
+is (%j<Z>:!p), (Z => Int), 'missing key :!p defaults to Int';
+is (%j<b Z>:!p), (b => 2, Z => Int), 'mixed key :!p';
+
+# Pair.Str stringifies a type-object value to "" in Str context (raku `eq`).
+is (B => Any).Str, "B\t", 'Pair.Str of (B => Any) is "B\t"';
+is (B => Int).Str, "B\t", 'Pair.Str of (B => Int) is "B\t"';
+is (B => 5).Str, "B\t5", 'Pair.Str keeps a defined value';
+
+# `is` compares two type-object pair values as equal (both stringify to "k\t").
+is (B => Any), (B => Mu), 'is treats (B => Any) and (B => Mu) as equal';
+is (b => 2, C => Any), (b => 2, C => Mu), 'is on a list of type-object pairs';
+
+# A bare object hash (no value type) keeps a normal scalar default.
+my %c{Cool};
+%c<a> = 1;
+is (%c<a>:!p), (a => 1), 'bare object hash existing key :!p';


### PR DESCRIPTION
## Summary

Closes `roast/S32-hash/adverbs.t` (1128/1128, added to whitelist). Two root-cause fixes for the typed-hash missing-key-default group (BLOCKERS.md §3.1):

1. **Object-hash value-type in expression position.** An object hash declared as a call argument (`gen my Int %j{Cool}`, parsed as `DoStmt(VarDecl)`) was not tagging its declared value type, so a missing-key read defaulted to `Any` instead of the element type. The expr-position `VarDecl` path now strips the `{KeyType}` half of the `Int{Cool}` constraint and tags only the value type (`Int`).

   The key-type half is intentionally NOT re-tagged here: a raw-binding mutation (`sub gen(\h){ h{$_}=... }`) stores plain string keys, so marking the value `.WHICH`-keyed would break every Str-key adverb (`%j<b>:k` → `()`). Fully unifying object-hash keying through raw binding is the larger deferred change.

2. **`Pair.Str` of a type-object value.** `Pair.Str` stringified a type-object value as its `.gist` (`(Any)`) instead of `""` (raku Str context). Test's `is` `eq`-compares stringified values, so raku treats `(k => Any)` and `(k => Mu)` as equal (both `"k\t"`); mutsu reported them as different. `Pair`/`ValuePair` `to_string_value` now use `to_str_context`, so a type-object value coerces to `""`.

## Tests

- `t/object-hash-expr-decl-value-type.t` (new) — verified byte-identical output under `raku`.
- `roast/S32-hash/adverbs.t` now fully passes; added to `roast-whitelist.txt`.
- `make test` green (the only failures were flaky concurrency/subprocess tests — `io-socket-async-bin.t`, `dotassign-store-and-container-topic.t` — which pass individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)