### PR TITLE
fix(decl): hoist nested `our sub`, conflicting-types/missing-init/::-capture (my-6e.t)

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -93,44 +93,56 @@
     and removes the fresh ones from env + frame slot on exit. Fixes subtests
     18 (`$b is not available in this scope`) and 25 (`$e is not available`).
     Test: t/block-local-my-no-leak.t.
+  - **Progress (2026-06-30): mid-file abort fixed; all 109 tests now run**
+    (was: ran 79/109, aborted at test 80). Pass count 74 → 98. Fixes landed
+    in this slice:
+    - **`our sub` nested-block hoisting** (`hoist_nested_our_subs`,
+      compiler `mod.rs` + `helpers_ast_utils.rs`): an `our sub` declared inside
+      a nested block is now registered into the package at unit start, so
+      `&OUR::name()` resolves before the declaring block runs (Raku installs
+      `our sub`s at compile time). This removed the `Unknown function` abort
+      that previously killed tests 80-109.
+    - **`my Int $a of Str`** → X::Syntax::Variable::ConflictingTypes (postfix
+      `of` after an explicit prefix type), `my_decl.rs`. Fixes test 106.
+    - **`my (\a)` / `my (\a, \b)`** with no initializer →
+      X::Syntax::Term::MissingInitializer (`destructure.rs`). Fixes 99/100.
+    - **`my ::a $a`** type-capture constraint no longer dies "Type '::a' is not
+      declared" — `::T` constraints are treated as an unconstrained capture
+      (compiler `stmt.rs`). Fixes test 84.
   - **Remaining blockers (each a separate deep feature; test not whitelistable
     until all are solved):**
     - 3,4: use-before-declaration in the *same statement* (`$ret = $foo ~ my
-      $foo`) must throw `X::Undeclared` at compile time. mutsu hoists the `my`
-      so `$foo` is visible before its declaration point. Needs compile-time
-      pre-declaration visibility analysis within a statement.
+      $foo`) must throw `X::Undeclared` at compile time. mutsu has no
+      compile-time undeclared-variable check at all (`$undeclared` → Nil), so
+      this is a broad, high-blast-radius feature.
     - 46: a same-scope `my` *redeclaration* (`my $f; $f=5; my $f`) must be a
       noop that keeps the value (Raku only warns). mutsu's no-initializer
-      `my $f` resets the slot to Nil. Needs compile-time same-scope
-      redeclaration detection.
-    - 52: EVAL of a later-declared-but-uninitialized caller lexical
-      (`eval_elsewhere('!$y.defined')` where `my $y` comes after the call).
-      Deep dual-store / closure-capture interaction: EVAL reads caller
-      lexicals from captured *slot cells*, not env, and a prior top-level
-      `EVAL('my $y = 2')` contaminates the captured `$y` cell. Not an
-      env-cleanup problem (env never retains the EVAL's `my`).
-    - 61: `dies-ok { EVAL '$x = "abc"'; my Int $x; }` — type error must fire
-      for assignment to a (later-declared) typed lexical seen by EVAL.
-    - abort at 80: `&OUR::access_lexical_a()` for an `our sub` declared in a
-      nested block, accessed before/after the block runs. Needs compile-time
-      installation of `our sub` into the package stash + `OUR::` qualified
-      routine resolution. Currently throws `Unknown function`, aborting the
-      rest of the file (tests 81-109 never run).
-  - Remaining failures are deeper, mostly separate issues:
-    (a) **EVAL block-local scope leak** (tests 3-4/18/25): a `my` declared in a
-    now-closed inner block stays in `self.env`, so `EVAL '$b'` finds it instead
-    of throwing X::Undeclared. ROOT CAUSE is general (not EVAL-only): `my $b` in
-    `if (1) { my $b = 1 }` leaks to the outer scope (`say $b` after the block
-    prints the value; raku makes it a compile error). This is the locals↔env
-    dual-store debt — block-local `my` vars are not removed from `env` on block
-    exit. A naive removal would break closures that capture the block-local
-    (test 100-116 keeps `$e` alive through a closure), so the fix must remove the
-    outer-scope binding while preserving the closure's shared cell. Architectural.
-    (b) **`our sub` forward reference** (~line 273) throws and aborts the rest of
-    the file (ran 79/109): `&OUR::access_lexical_a()` is called before its
-    declaring block ran.
-    (c) misc: `do {my $a = 3; $a}` value (46), slurpy `*%p` + later `my %p` (52),
-    EVAL type-error timing (61).
+      `my $f` resets the slot to Nil. mutsu uses 1 slot per name per unit, so
+      distinguishing a same-scope redeclaration from an inner-block shadow
+      needs a per-lexical-scope declared-name stack in the compiler (BlockScope
+      already save/restores the shadow case correctly).
+    - 52: EVAL of a later-declared caller lexical (`eval_elsewhere('!$y.defined')`
+      where `my $y` comes after the call). Passes in isolation; fails in-file
+      because `$y`/`$a` share one unit slot polluted by earlier declarations.
+    - 61: `dies-ok { EVAL '$x = "abc"'; my Int $x; }` — the (later-declared)
+      typed lexical's constraint must be in effect at block start for EVAL.
+    - 80,81: `&OUR::access_lexical_a()` now resolves (no abort) but returns the
+      wrong value: (80) the closure captures the shared unit `$a` slot polluted
+      by other `my $a` decls (1-slot-per-name); (81) after the block exits the
+      closure does not keep the inner `$a=42` alive (closure-escape lifetime,
+      same family as lexical-subs.t#9). Both are container-identity / GC
+      substrate (ADR-0001).
+    - 90: EVAL of code calling an undeclared routine must die at CHECK time
+      (before side effects run). mutsu resolves calls at runtime, so the
+      preceding `$bad = 1` executes first.
+    - 94: anonymous `my &` (no name/value) must be the `Callable` type object
+      (`(my &) eqv Callable`); mutsu produces a closure value.
+    - 103: `my sub {42}()` — postcircumfix `()` on an anonymous `my sub` is a
+      parse error in mutsu ("comma or statement end after argument").
+    - 107: nested sigilless destructuring *assignment*
+      (`my (\d, (\e, (\f, (\g, \h)))) = ...`) throws "Cannot modify an
+      immutable value", aborting the subtest before the `#?rakudo skip` line
+      (the `:=` bind form works). Also fails on rakudo without fudge.
 - [x] roast/S04-declarations/smiley.t
 - [ ] roast/S04-declarations/state.t
   - 46/46 pass (test 38 is a rakudo TODO which is expected to fail). Cannot whitelist: test 42 (2M function calls in lives-ok) takes ~20s CPU in release, which risks exceeding 30s wall-clock timeout under load.

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -250,6 +250,46 @@ impl Compiler {
         Some((name, chain))
     }
 
+    /// Register `our`-scoped subs declared inside *nested* blocks early, so
+    /// they are reachable via the `OUR::` pseudo-package before (or regardless
+    /// of whether) the declaring block has executed. Raku installs `our sub`s
+    /// into the package at compile time, so `&OUR::foo()` resolves even when
+    /// called from an enclosing or sibling scope before the block that
+    /// textually contains the declaration has run.
+    ///
+    /// Only plain `Block`/`SyntheticBlock` nesting is traversed: an `our sub`
+    /// inside a routine/class body closes over that body's frame, so hoisting
+    /// it to the unit level would be wrong. Direct (depth-0) children are left
+    /// to `hoist_sub_decls`, which already registers them.
+    pub(super) fn hoist_nested_our_subs(&mut self, stmts: &[Stmt]) {
+        fn collect(stmts: &[Stmt], depth: usize, out: &mut Vec<Stmt>) {
+            for stmt in stmts {
+                match stmt {
+                    Stmt::SubDecl { custom_traits, .. }
+                        if depth > 0 && custom_traits.iter().any(|(t, _)| t == "__our_scoped") =>
+                    {
+                        out.push(stmt.clone());
+                    }
+                    Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
+                        collect(body, depth + 1, out);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let mut nested = Vec::new();
+        collect(stmts, 0, &mut nested);
+        for mut hoisted in nested {
+            if let Stmt::SubDecl { custom_traits, .. } = &mut hoisted {
+                custom_traits.retain(|(t, _)| {
+                    t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
+                });
+            }
+            let idx = self.code.add_stmt(hoisted);
+            self.code.emit(OpCode::RegisterSub(idx));
+        }
+    }
+
     /// Hoist sub declarations: emit RegisterSub for all SubDecl statements
     /// before executing the rest of the block, so that `&name` references
     /// are available before the sub declaration appears in source order.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -848,6 +848,10 @@ impl Compiler {
             return (self.code, self.compiled_functions);
         }
         self.hoist_sub_decls(stmts, false);
+        // Register `our` subs declared inside nested blocks early so they are
+        // reachable via `OUR::` before their declaring block runs (Raku
+        // installs `our sub`s into the package at compile time).
+        self.hoist_nested_our_subs(stmts);
         // If the top-level body contains a CATCH or CONTROL block, wrap in
         // an implicit try so the phaser can observe exceptions / control
         // signals from the surrounding statements.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -714,6 +714,18 @@ impl Compiler {
                     }
                     _ => type_constraint.clone(),
                 };
+                // A `::T` type-capture constraint (`my ::a $a`) introduces a
+                // fresh type variable rather than naming an existing type. With
+                // no value to capture from, the captured type is unconstrained
+                // (Mu), so we drop the constraint instead of trying to resolve
+                // `::a` as a real type (which would die "Type '::a' is not
+                // declared").
+                // TODO: bind the capture name (`a`) as a type alias for the
+                // declared/inferred type so `::a` is usable as a type later.
+                let owned_type_constraint = match owned_type_constraint {
+                    Some(tc) if tc.starts_with("::") => None,
+                    other => other,
+                };
                 let type_constraint = &owned_type_constraint;
                 // X::Dynamic::Package: dynamic variables cannot have package-like names
                 if Self::is_dynamic_package_var(name) {

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -275,6 +275,25 @@ pub(in crate::parser::stmt) fn parse_destructuring_decl(
             type_constraint,
         );
     }
+    // A sigilless term in a grouped declaration (`my (\a)`, `my (\a, \b)`)
+    // has no implicit default and so requires an initializer, exactly like a
+    // bare `my \a`. Without one, rakudo rejects it at compile time with
+    // X::Syntax::Term::MissingInitializer.
+    if vars.iter().any(|v| v.sigilless) {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert(
+            "message".to_string(),
+            crate::value::Value::str("Term definition requires an initializer".to_string()),
+        );
+        let ex = crate::value::Value::make_instance(
+            crate::symbol::Symbol::intern("X::Syntax::Term::MissingInitializer"),
+            attrs,
+        );
+        return Err(PError::fatal_with_exception(
+            "Term definition requires an initializer".to_string(),
+            Box::new(ex),
+        ));
+    }
     // No assignment
     let (rest, _) = ws(rest)?;
     let (rest, _) = opt_char(rest, ';');

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -603,6 +603,33 @@ fn parse_variable_traits<'a>(
         let (r, _) = ws1(after_of)?;
         let (r, tc) = parse_type_constraint_expr(r).ok_or_else(|| PError::expected("type"))?;
         let (r, _) = ws(r)?;
+        // A postfix `of Type` that follows an explicit prefix type
+        // (`my Int $a of Str`) declares the type twice, which is
+        // X::Syntax::Variable::ConflictingTypes.
+        if let Some(outer) = type_constraint.as_ref() {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert(
+                "outer".to_string(),
+                crate::value::Value::Package(crate::symbol::Symbol::intern(outer)),
+            );
+            attrs.insert(
+                "inner".to_string(),
+                crate::value::Value::Package(crate::symbol::Symbol::intern(&tc)),
+            );
+            let msg = format!(
+                "{} not allowed here; variable list already declared with type {}",
+                tc, outer
+            );
+            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+            let ex = crate::value::Value::make_instance(
+                crate::symbol::Symbol::intern("X::Syntax::Variable::ConflictingTypes"),
+                attrs,
+            );
+            return Err(PError::fatal_with_exception(
+                format!("X::Syntax::Variable::ConflictingTypes: {}", msg),
+                Box::new(ex),
+            ));
+        }
         *type_constraint = Some(tc);
         rest = r;
     }


### PR DESCRIPTION
## Summary

Advances `roast/S04-declarations/my-6e.t` from **ran 79/109 (aborted at test 80)** to **all 109 tests running** (pass count 74 → 98). The mid-file abort previously killed tests 80-109. Each fix is a genuine, general improvement, not a test-specific hack.

### Fixes

- **`our sub` nested-block hoisting** (`hoist_nested_our_subs`): an `our sub` declared inside a nested block is now registered into the package at unit start, so `&OUR::name()` resolves before the declaring block runs — matching Raku's compile-time installation of `our` subs. This removes the `Unknown function` abort.
- **`my Int $a of Str`** → `X::Syntax::Variable::ConflictingTypes` (postfix `of` after an explicit prefix type).
- **`my (\a)` / `my (\a, \b)`** with no initializer → `X::Syntax::Term::MissingInitializer` (grouped sigilless terms require an initializer, like a bare `my \a`).
- **`my ::a $a`** type-capture constraint no longer dies `Type '::a' is not declared`; a `::T` constraint is treated as an unconstrained capture.

### Remaining (documented in `TODO_roast/S04.md`)

The remaining my-6e.t failures are deeper substrate features: compile-time `X::Undeclared` for variables/routines, same-scope redeclaration noop, 1-slot-per-name closure capture, and closure-escape lifetime (ADR-0001 / container-identity family).

### Testing

- `my-6e.t`: 109/109 run, 11 failing (was abort).
- No whitelisted-test regressions: verified `S04-declarations/{our,constant,state}.t`, `S06-signature/types.t`, `S09-typed-arrays/{arrays,native-int,native-str,native-shape1-int}.t`, `S02-names-vars/contextual.t` all pass.
- `make test` green (the `t/die-on-fail.t`, `t/dotassign-store-and-container-topic.t`, `t/tail-function.t` failures are pre-existing and unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)