### PR TITLE
fix(splice): item/uc nested-listop parse + typed-array element typecheck (S32 splice.t)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -75,6 +75,16 @@
 - [ ] roast/S32-array/shift.t
   - 11/33 pass (1, 11-12, 21-27, 33). Similar to pop: sub form `shift(@arr)` broken, method form has issues. Post-exhaustion returns undefined/Failure correctly. Difficulty: Medium
 - [ ] roast/S32-array/splice.t
+  - 357/392 pass (plan now completes; was 346/381 — the file aborted at test 382
+    on `item splice`). **2026-06-30**, two more fixes:
+    - `item splice @a, …` (and `uc reverse …`, etc.): a value-producing named
+      unary / builtin bareword followed by another builtin call now nests as a
+      call argument (`item(splice(@a, …))`) instead of misparsing the inner word
+      as a user-defined infix operator. New `next_word_is_builtin_term_op`
+      predicate gates the listop-arg path. This unblocked tests 382-392.
+    - `splice @a, …, <wrong-type>` on a typed array (`my Int @a`) now type-checks
+      each replacement element against the declared element type and throws
+      `X::TypeCheck::Splice` (tests 384-385, `dies-ok` &splice/.splice type-safe).
   - 346/381 pass (was ~136). **2026-06-28**, two fixes:
     - (#3885) `SetGlobal` store path: a list assignment to a name with no
       *declared* element type that currently holds an element-typed container

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1428,7 +1428,8 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             || hyphen_forward_call
             || is_user_sub
             || is_imported_sub
-            || crate::parser::stmt::simple::is_known_call(&name))
+            || crate::parser::stmt::simple::is_known_call(&name)
+            || crate::parser::primary::ident::predicates::next_word_is_builtin_term_op(r))
             && let Ok((r2, arg)) = parse_listop_arg(r)
         {
             let (r2, invocant_colon_call) =

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -226,6 +226,54 @@ pub(crate) fn is_expr_listop(name: &str) -> bool {
     ) || crate::parser::stmt::simple::is_imported_function(name)
 }
 
+/// True when `input` begins with a builtin function word that produces a value
+/// usable as a term argument — a list-prefix op (`reverse`/`join`/`map`/…, via
+/// [`is_listop`]) or a value-producing named unary (`uc`/`lc`/`item`/`splice`/…).
+///
+/// Used so a builtin/named-unary bareword immediately followed by another builtin
+/// call nests as a call argument (`item reverse 1,2,3` => `item(reverse(1,2,3))`,
+/// `uc reverse "ab","cd"`) instead of misparsing the inner word as a user-defined
+/// infix operator in the precedence loop.
+pub(crate) fn next_word_is_builtin_term_op(input: &str) -> bool {
+    let first = match input.chars().next() {
+        Some(c) => c,
+        None => return false,
+    };
+    if !(first.is_alphabetic() || first == '_') {
+        return false;
+    }
+    let mut end = first.len_utf8();
+    for ch in input[end..].chars() {
+        if ch.is_alphanumeric() || ch == '_' || ch == '-' {
+            end += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let word = &input[..end];
+    is_listop(word)
+        || matches!(
+            word,
+            "splice"
+                | "item"
+                | "uc"
+                | "lc"
+                | "tc"
+                | "tclc"
+                | "fc"
+                | "wordcase"
+                | "flip"
+                | "chop"
+                | "chomp"
+                | "ord"
+                | "ords"
+                | "chr"
+                | "chrs"
+                | "chars"
+                | "defined"
+        )
+}
+
 /// Check if a name is an infix word operator (should not be treated as a listop call).
 pub(crate) fn is_infix_word_op(name: &str) -> bool {
     matches!(

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -806,6 +806,54 @@ impl Interpreter {
                             }
                         }
                     }
+                    // Type-check splice replacement values against the array's
+                    // declared element type (`my Int @a` splice must reject a Str),
+                    // mirroring the element check applied to typed-array assignment.
+                    if let Some(constraint) = self.var_type_constraint(&key)
+                        && !matches!(constraint.as_str(), "" | "Any" | "Mu")
+                    {
+                        for arg in args.iter().skip(2) {
+                            let candidates: Vec<&Value> = match arg {
+                                Value::Array(items, _) => items.iter().collect(),
+                                other => vec![other],
+                            };
+                            for v in candidates {
+                                if !matches!(v, Value::Nil)
+                                    && !self.type_matches_value(&constraint, v)
+                                {
+                                    return Err(RuntimeError::typed(
+                                        "X::TypeCheck::Splice",
+                                        [
+                                            (
+                                                "message".to_string(),
+                                                Value::str(format!(
+                                                    "Type check failed for an element of @{}; expected {} but got {}",
+                                                    key.trim_start_matches('@'),
+                                                    constraint,
+                                                    crate::runtime::utils::value_type_name(v)
+                                                )),
+                                            ),
+                                            ("action".to_string(), Value::str_from("splice")),
+                                            (
+                                                "got".to_string(),
+                                                Value::Package(crate::symbol::Symbol::intern(
+                                                    crate::runtime::utils::value_type_name(v),
+                                                )),
+                                            ),
+                                            (
+                                                "expected".to_string(),
+                                                Value::Package(crate::symbol::Symbol::intern(
+                                                    &constraint,
+                                                )),
+                                            ),
+                                        ]
+                                        .into_iter()
+                                        .collect(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
                     let mut resolved_args = args.clone();
                     // Resolve callable for offset (arg 0) with array length
                     if let Some(arg @ (Value::Sub(..) | Value::WeakSub(..))) = args.first()


### PR DESCRIPTION
## Summary

Two fixes advancing `roast/S32-array/splice.t` from 346/381 (file aborted at test 382) to **357/392** (plan now completes).

### 1. `item splice` / `uc reverse` nested-listop argument parsing
A value-producing named unary or builtin bareword followed by another builtin call now nests as a call argument instead of misparsing the inner word as a user-defined infix operator:

```raku
item splice @a, 5, 3   # now item(splice(@a, 5, 3)), was "Two terms in a row"
uc reverse "ab","cd"   # now uc(reverse(...)) => "CD AB", was "(ab uc)cd"
```

A new `next_word_is_builtin_term_op` predicate gates the user-func listop-arg path so the named unary consumes the following builtin call. This unblocked tests 382-392 (the file previously threw at line 214 and aborted, so 11 tests never ran).

### 2. Typed-array splice element type-check
`splice` on a typed array now type-checks each replacement element against the declared element type and throws `X::TypeCheck::Splice` on mismatch, matching `.push`:

```raku
my Int @a = 1, 2, 3;
splice @a, 1, 1, 'not an integer';   # now dies (X::TypeCheck::Splice)
@a.splice(1, 1, 'not an integer');   # now dies
```

### Remaining
The 35 still-failing subtests are all the `splice(@a, …, @a)` "push/replace self" cases, which require first-class element container identity (Track B / ADR-0001) and are not fixable standalone.

## Test
- `make test`: no new failures (the two flagged `t/` files — `dotassign-store-and-container-topic.t`, `tail-function.t` — fail/flake identically on clean `main`).
- Spot-checked `roast/S32-list/reverse.t`, `roast/S32-str/uc.t`, `roast/S02-literals/quoting.t`: all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)