### PR TITLE
fix(vm): hoisted sub keeps first write to a later-declared captured `my`

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -156,7 +156,24 @@
 - [ ] roast/S02-names-vars/signature.t
   - 0/? pass. Parse error at line 10
 - [ ] roast/S02-names-vars/variables-and-packages.t
-  - 0/? pass. Parse error at line 35
+  - 30/39 pass (was 26/39). Fixed 24-25, 27-28: a hoisted sub that mutates a
+    `my $x` declared *after* it (called before the declaration runs) now keeps
+    its first write — the captured-outer writeback in
+    `call_compiled_function_named_inner` propagates `free_var_writes` names to
+    the restored caller env even when the name is not yet present there.
+  - Remaining 9 failures are all deep, blocked on infrastructure:
+    - 29-31 (BEGIN init): `my $a; BEGIN { $a = 3 }; sub baz { $a++ }` called
+      before the declaration must see `3` — needs compile-time BEGIN execution
+      (BLOCKERS §3.4 / declaration-model redesign).
+    - 32-34 (`&OUR::grtz`): an `our sub` defined in an inner block, accessed by
+      name after that block exits, must capture the inner `my $a = 3` — needs
+      real closure-env capture for name-resolved subs (closure-env gap, same as
+      §2-D / zef). Anonymous `sub {...}` escaping by value already works.
+    - 37-38 (`X::Redeclaration::Outer`): compile-time error when redeclaring a
+      name (`my $i`) inside a block that already referenced the outer `$i` —
+      needs scope-aware compile-time redeclaration analysis.
+    - 39 (`$OUTER::_`): a sub closing over the enclosing for-loop topic `$_`
+      via `$OUTER::_` — same closure-capture gap (topic not captured).
 - [ ] roast/S02-names-vars/varnames.t
   - 0/? pass. Parse error at line 34
 - [x] roast/S02-one-pass-parsing/less-than.t

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -476,6 +476,12 @@ impl Interpreter {
                         || s == "%_"
                         || local_names.contains(s)
                         || rw_sources.contains(s)
+                        // Compiler-internal bookkeeping symbols (e.g. the
+                        // `__mutsu_sigilless_readonly::p` marker emitted for a
+                        // `my \p = ...` capture) are not user lexicals and must
+                        // never leak into the caller env — doing so corrupts the
+                        // caller's own later declarations of the bare name.
+                        || s.starts_with("__mutsu")
                         // Dynamic vars (`$*x`) are reconciled by
                         // pop_caller_env_with_writeback, not the lexical merge.
                         || s.as_bytes().get(1) == Some(&b'*')

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -456,6 +456,38 @@ impl Interpreter {
                     restored_env.insert_sym(*k, v.clone());
                 }
             }
+            // A captured-outer write to an enclosing lexical that is not yet
+            // present in the caller env is dropped by the `contains_key`-gated
+            // merge above. This happens when a hoisted sub is *called before* the
+            // `my $x` declaration it closes over has run (the declaration is
+            // compile-time, so the lexical genuinely exists, but the runtime env
+            // entry is created only when the `my` statement executes). Such a name
+            // is recorded in `free_var_writes` (the body writes a free var), so
+            // propagate the callee's new value into the restored caller env
+            // unconditionally — otherwise the first call's write is lost and the
+            // accumulation starts one call late (`0,0,1,2` instead of `0,1,2,3`).
+            for sym in &cf.code.free_var_writes {
+                if restored_env.contains_key_sym(*sym) {
+                    continue;
+                }
+                let skip = sym.with_str(|s| {
+                    s == "_"
+                        || s == "@_"
+                        || s == "%_"
+                        || local_names.contains(s)
+                        || rw_sources.contains(s)
+                        // Dynamic vars (`$*x`) are reconciled by
+                        // pop_caller_env_with_writeback, not the lexical merge.
+                        || s.as_bytes().get(1) == Some(&b'*')
+                });
+                if skip {
+                    continue;
+                }
+                if let Some(v) = self.env().get_sym(*sym) {
+                    let v = v.clone();
+                    restored_env.insert_sym(*sym, v);
+                }
+            }
             *self.env_mut() = restored_env;
         }
 

--- a/t/hoisted-sub-captures-later-my.t
+++ b/t/hoisted-sub-captures-later-my.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 6;
+
+# A hoisted sub that closes over a `my $x` declared *after* it must keep every
+# write, even when it is called before the declaration statement runs at
+# runtime. The declaration is compile-time, so the lexical container exists;
+# previously the first call's mutation was dropped (`0,0,1` instead of `0,1,2`).
+# Regression for roast S02-names-vars/variables-and-packages.t tests 24-25/27-28.
+
+{
+    is foo(), 0, "first call to hoisted sub (var not yet declared)";
+    is foo(), 1, "second call keeps the first write";
+    is foo(), 2, "third call accumulates";
+
+    my $a;
+    sub foo { $a++ }
+}
+
+# Same, but the `my` carries a runtime initializer that has not executed yet at
+# call time — the calls still see the uninitialized (0) value and accumulate.
+{
+    is bar(), 0, "runtime part of `my` not yet executed (1)";
+    is bar(), 1, "runtime part of `my` not yet executed (2)";
+    is bar(), 2, "runtime part of `my` not yet executed (3)";
+
+    my $a = 3;
+    sub bar { $a++ }
+}

--- a/t/hoisted-sub-captures-later-my.t
+++ b/t/hoisted-sub-captures-later-my.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 6;
+plan 7;
 
 # A hoisted sub that closes over a `my $x` declared *after* it must keep every
 # write, even when it is called before the declaration statement runs at
@@ -26,4 +26,19 @@ plan 6;
 
     my $a = 3;
     sub bar { $a++ }
+}
+
+# The free-var-write propagation must not leak compiler-internal bookkeeping
+# symbols into the caller env. A sub whose body uses a sigilless `my \p`
+# capture records an internal `__mutsu_sigilless_readonly::p` marker as a free
+# var write; if that marker leaked into the caller, a later `(my $p = ...)` in
+# the caller scope was wrongly treated as a write to a readonly sigilless `p`
+# and threw X::Assignment::RO. Regression for roast S29-os/system.t 34-35.
+{
+    sub gen() { my \p = 42; p }
+    my $ok = do {
+        my $x = gen();
+        (my $p = $x + 1) ?? $p !! -1;
+    };
+    is $ok, 43, "sigilless-capture internal marker does not leak to caller scope";
 }


### PR DESCRIPTION
## Summary

A sub hoisted to the top of its block that mutates a `my $x` declared *after* it lost its first write when called before the declaration statement ran at runtime:

```raku
foo(); foo(); foo();   # returned 0,0,1 — should be 0,1,2
my $a;
sub foo { $a++ }
```

The `my` declaration is compile-time, so the lexical container genuinely exists at call time, but mutsu creates the runtime env entry only when the `my` statement executes. The captured-outer writeback merge in `call_compiled_function_named_inner` is gated on `restored_env.contains_key`, so the first call's write to the not-yet-present `$a` was dropped; subsequent calls saw the leaked entry and accumulated, producing the one-call lag.

## Fix

Propagate `free_var_writes` names (the body's captured-outer writes) into the restored caller env unconditionally, so the write survives the first call. Dynamic vars (`$*x`) are skipped — they are reconciled separately by `pop_caller_env_with_writeback`.

## Impact

- Fixes `roast/S02-names-vars/variables-and-packages.t` subtests 24-25/27-28 (26→30 of 39).
- Remaining 9 failures need compile-time `BEGIN` execution, name-resolved-sub closure capture (`&OUR::grtz`, `$OUTER::_`), and `X::Redeclaration::Outer` — all deep, documented in `TODO_roast/S02.md`.
- New regression test: `t/hoisted-sub-captures-later-my.t`.
- No regressions: full `make test` (only a pre-existing, unrelated `t/dotassign-store-and-container-topic.t` failure that also fails on `main`), plus a broad whitelist subset (S02/S04/S06/S09/S11/S12/S32 dispatch-heavy categories) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)