### PR TITLE
fix(subset): where-block placeholders, expr-position constraint persistence, capture where (subtypes.t)

### DIFF
--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -154,6 +154,23 @@
 - [ ] roast/S12-methods/what.t
 - [ ] roast/S12-subset/multi-dispatch.t
 - [ ] roast/S12-subset/subtypes.t
+  - 83/90 pass (plan 92; 2 are `group-of` sub-plans). Fixed: placeholder `$^n`
+    binding in `where` blocks (multi dispatch + single-sub binding), expr-position
+    typed-scalar constraint persistence (`ok my Subset $c = 6; $c = 7`),
+    read-only `where`-block params (`where { $^x = ... }` dies), and `where` on a
+    `|c` capture param. Remaining blockers:
+    - test 25: `fail "..."` inside a subset `where` should surface the custom
+      message (needs threading the Failure message out of `type_matches_value`).
+    - test 68: `ok (R ~~ S) ~~ Bool, 'desc'` mis-parses (space-before-paren
+      list-op rule: `ok (...)` is treated as a call with those parens as args).
+    - test 77: using a later signature param in an earlier param's `where`
+      (`sub foo($x where { $x == $y }, $y)`) must raise X::Undeclared at compile
+      time.
+    - test 83: `multi method f(Subset:D $)` + `:D` subset dispatch / redispatch.
+    - test 87: `where Int|Num` (Junction of types) with definiteness smileys.
+    - test 88: `my ($a where 2, \c where "x", Foo $d, "foo") = ...` list-decl
+      postconstraints.
+    - test 89: `&`-sigiled var as the `where` predicate (`where &pos-match`).
 - [ ] roast/S12-subset/type-subset.t
 - [ ] roast/S12-traits/basic.t
   - 1/9 pass. NOT in raku's spectest.data (raku itself fails this test). Tests 2-4 require obsolete `trait_auxiliary:<is>` feature for variable role mixins. Tests 5-8 (class role composition) would pass but EVAL on line 32 kills the program before reaching them. Test 9 (throws-like '%!P' outside class) now works with the NoSelf fix but can't run due to earlier abort.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1029,6 +1029,78 @@ pub(crate) fn collect_unattached_placeholders(stmts: &[Stmt]) -> Vec<String> {
     names
 }
 
+/// Collect placeholder names (`^name`, sigil-stripped) that appear as the
+/// *target* of an assignment inside a `where`-block body — e.g. the `^epic` in
+/// `where { $^epic = "fail" }`. The ordinary `collect_placeholders` walks only
+/// expression positions, so an assign-only placeholder is otherwise invisible.
+/// A `where`-block parameter is read-only, so the caller binds these and marks
+/// them read-only to make `where { $^x = ... }` die.
+pub(crate) fn collect_where_assign_placeholders(stmts: &[Stmt]) -> Vec<String> {
+    let mut names = Vec::new();
+    for stmt in stmts {
+        collect_assign_ph_stmt(stmt, &mut names);
+    }
+    names.dedup();
+    names
+}
+
+fn push_if_placeholder(name: &str, out: &mut Vec<String>) {
+    let bare = name.trim_start_matches(|c: char| "$@%&".contains(c));
+    if let Some(rest) = bare.strip_prefix('^') {
+        let key = format!("^{rest}");
+        if !out.contains(&key) {
+            out.push(key);
+        }
+    }
+}
+
+fn collect_assign_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
+    match stmt {
+        Stmt::Assign { name, expr, .. } | Stmt::VarDecl { name, expr, .. } => {
+            push_if_placeholder(name, out);
+            collect_assign_ph_expr(expr, out);
+        }
+        Stmt::Expr(e)
+        | Stmt::Return(e)
+        | Stmt::Die(e)
+        | Stmt::Fail(e)
+        | Stmt::Take(e, _)
+        | Stmt::Goto(e) => collect_assign_ph_expr(e, out),
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            collect_assign_ph_expr(cond, out);
+            for s in then_branch.iter().chain(else_branch.iter()) {
+                collect_assign_ph_stmt(s, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_assign_ph_expr(expr: &Expr, out: &mut Vec<String>) {
+    match expr {
+        Expr::AssignExpr { name, expr, .. } => {
+            push_if_placeholder(name, out);
+            collect_assign_ph_expr(expr, out);
+        }
+        Expr::Binary { left, right, .. } => {
+            collect_assign_ph_expr(left, out);
+            collect_assign_ph_expr(right, out);
+        }
+        Expr::Unary { expr, .. } => collect_assign_ph_expr(expr, out),
+        Expr::Block(body) | Expr::AnonSub { body, .. } => {
+            for s in body {
+                collect_assign_ph_stmt(s, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn collect_unattached_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
     match stmt {
         Stmt::Expr(e)

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -272,6 +272,28 @@ impl Compiler {
                     name_idx,
                     dynamic: is_dynamic,
                 });
+                // Register a scalar type constraint AFTER `SetVarDynamic` (which
+                // clears any stale same-named constraint) so it persists and is
+                // enforced on *later* assignments — `(my Subset $c = 6); $c = 7`
+                // and `ok my Subset $c = 6; $c = 7`. An expression-position
+                // declaration is compiled here (as `DoStmt(VarDecl)`); the
+                // statement-position VarDecl already emits this `SetVarType`, so
+                // without it the constraint was lost whenever the declaration's
+                // value was consumed (function argument / RHS of `=`). Container
+                // sigils and anonymous scalars are handled by their own branches
+                // above.
+                if !name.starts_with('@')
+                    && !name.starts_with('%')
+                    && name != "__ANON_STATE__"
+                    && let Some(tc) = type_constraint
+                {
+                    let svt_name_idx = self.code.add_constant(Value::str(name.clone()));
+                    let svt_tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                    self.code.emit(OpCode::SetVarType {
+                        name_idx: svt_name_idx,
+                        tc_idx: svt_tc_idx,
+                    });
+                }
                 // `my $ = expr` (anonymous scalar without type constraint) returns
                 // a Scalar container so the caller can store it in an immutable
                 // List and later mutate the element via index assignment.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -400,10 +400,36 @@ impl Interpreter {
                     // reference it during dispatch matching.
                     self.env.insert(pd.name.clone(), arg.clone());
                     let ok = match where_expr.as_ref() {
-                        Expr::AnonSub { body, .. } => self
-                            .eval_block_value(body)
-                            .map(|v| v.truthy())
-                            .unwrap_or(false),
+                        Expr::AnonSub { body, .. } => {
+                            // Bind placeholder params (e.g. `$^n`) to the single
+                            // value under test so `where { $^n < 0 }` works. The
+                            // placeholder is read-only (a `where`-block parameter),
+                            // so `where { $^x = ... }` dies.
+                            let mut ph_keys: Vec<String> = Vec::new();
+                            for ph in crate::ast::collect_placeholders(body)
+                                .iter()
+                                .chain(crate::ast::collect_where_assign_placeholders(body).iter())
+                            {
+                                let key = ph
+                                    .trim_start_matches(|c: char| "$@%&".contains(c))
+                                    .to_string();
+                                if !ph_keys.contains(&key) {
+                                    ph_keys.push(key);
+                                }
+                            }
+                            for key in &ph_keys {
+                                self.env.insert(key.clone(), arg.clone());
+                                self.mark_readonly(key);
+                            }
+                            let r = self
+                                .eval_block_value(body)
+                                .map(|v| v.truthy())
+                                .unwrap_or(false);
+                            for key in &ph_keys {
+                                self.unmark_readonly(key);
+                            }
+                            r
+                        }
                         Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
                             self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
                                 .map(|v| v.truthy())

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -52,10 +52,18 @@ impl Interpreter {
             .map(|(k, v)| (*k, v.clone()))
             .collect();
         let ok = match where_expr.as_ref() {
-            Expr::AnonSub { body, .. } => self
-                .eval_block_value(body)
-                .map(|v| v.truthy())
-                .unwrap_or(false),
+            Expr::AnonSub { body, .. } => {
+                let ph_keys = self.bind_where_placeholders(body, &bound_val);
+                let r = self
+                    .eval_block_value(body)
+                    .map(|v| v.truthy())
+                    .unwrap_or(false);
+                for k in ph_keys {
+                    self.unmark_readonly(&k);
+                    self.env.remove(&k);
+                }
+                r
+            }
             Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
                 self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
                     .map(|v| v.truthy())
@@ -91,6 +99,31 @@ impl Interpreter {
             )));
         }
         Ok(())
+    }
+
+    /// Bind placeholder parameters (e.g. `$^n`) referenced inside a
+    /// `where { ... }` block to the single value under test. Returns the env
+    /// keys inserted so the caller can remove them after the check. In a where
+    /// clause there is exactly one value being tested, so every placeholder is
+    /// bound to that candidate.
+    fn bind_where_placeholders(&mut self, body: &[Stmt], candidate: &Value) -> Vec<String> {
+        let mut keys = Vec::new();
+        let read_phs = crate::ast::collect_placeholders(body);
+        let write_phs = crate::ast::collect_where_assign_placeholders(body);
+        for ph in read_phs.iter().chain(write_phs.iter()) {
+            let key = ph
+                .trim_start_matches(|c: char| "$@%&".contains(c))
+                .to_string();
+            if keys.contains(&key) {
+                continue;
+            }
+            self.env.insert(key.clone(), candidate.clone());
+            // A `where`-block parameter is read-only, so `where { $^x = ... }`
+            // must die rather than silently accept the value.
+            self.mark_readonly(&key);
+            keys.push(key);
+        }
+        keys
     }
 
     fn parameter_binding_error(message: String) -> RuntimeError {
@@ -519,6 +552,43 @@ impl Interpreter {
                     if let Some(sub_params) = &pd.sub_signature {
                         bind_sub_signature_from_value(self, sub_params, &capture_value)?;
                     }
+                    // Enforce a `where` constraint on the capture parameter
+                    // (`sub f(|c where { c.elems == 1 })`). The capture is bound
+                    // under `pd.name`; evaluate the predicate with that name (and
+                    // `$_`) set to the capture value.
+                    if let Some(where_expr) = &pd.where_constraint {
+                        let saved_topic = self.env.get("_").cloned();
+                        self.env.insert("_".to_string(), capture_value.clone());
+                        let ok = match where_expr.as_ref() {
+                            Expr::AnonSub { body, .. } => {
+                                let ph_keys = self.bind_where_placeholders(body, &capture_value);
+                                let r = self
+                                    .eval_block_value(body)
+                                    .map(|v| v.truthy())
+                                    .unwrap_or(false);
+                                for k in ph_keys {
+                                    self.unmark_readonly(&k);
+                                    self.env.remove(&k);
+                                }
+                                r
+                            }
+                            expr => self
+                                .eval_block_value(&[Stmt::Expr(expr.clone())])
+                                .map(|v| self.smart_match(&capture_value, &v))
+                                .unwrap_or(false),
+                        };
+                        if let Some(previous) = saved_topic {
+                            self.env.insert("_".to_string(), previous);
+                        } else {
+                            self.env.remove("_");
+                        }
+                        if !ok {
+                            return Err(Self::parameter_binding_error(format!(
+                                "X::TypeCheck::Binding::Parameter: where constraint failed for parameter '{}'",
+                                pd.name
+                            )));
+                        }
+                    }
                 } else if is_hash_slurpy {
                     // *%hash -- collect Pair arguments into a hash,
                     // excluding args already bound to explicit named parameters.
@@ -655,10 +725,18 @@ impl Interpreter {
                         let saved_topic = self.env.get("_").cloned();
                         self.env.insert("_".to_string(), slurpy_value.clone());
                         let ok = match where_expr.as_ref() {
-                            Expr::AnonSub { body, .. } => self
-                                .eval_block_value(body)
-                                .map(|v| v.truthy())
-                                .unwrap_or(false),
+                            Expr::AnonSub { body, .. } => {
+                                let ph_keys = self.bind_where_placeholders(body, &slurpy_value);
+                                let r = self
+                                    .eval_block_value(body)
+                                    .map(|v| v.truthy())
+                                    .unwrap_or(false);
+                                for k in ph_keys {
+                                    self.unmark_readonly(&k);
+                                    self.env.remove(&k);
+                                }
+                                r
+                            }
                             expr => self
                                 .eval_block_value(&[Stmt::Expr(expr.clone())])
                                 .map(|v| self.smart_match(&slurpy_value, &v))
@@ -1383,10 +1461,18 @@ impl Interpreter {
                         let saved_topic = self.env.get("_").cloned();
                         self.env.insert("_".to_string(), value.clone());
                         let ok = match where_expr.as_ref() {
-                            Expr::AnonSub { body, .. } => self
-                                .eval_block_value(body)
-                                .map(|v| v.truthy())
-                                .unwrap_or(false),
+                            Expr::AnonSub { body, .. } => {
+                                let ph_keys = self.bind_where_placeholders(body, &value);
+                                let r = self
+                                    .eval_block_value(body)
+                                    .map(|v| v.truthy())
+                                    .unwrap_or(false);
+                                for k in ph_keys {
+                                    self.unmark_readonly(&k);
+                                    self.env.remove(&k);
+                                }
+                                r
+                            }
                             // Method calls on $_ (topic) in where constraints:
                             // evaluate and check truthiness of the result, not smart-match.
                             // `where .method: args` is equivalent to `where { .method: args }`.

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -287,10 +287,37 @@ fn where_constraint_matches(
         interpreter.env.insert(pd.name.clone(), candidate.clone());
     }
     let ok = match where_expr {
-        Expr::AnonSub { body, .. } => interpreter
-            .eval_block_value(body)
-            .map(|v| v.truthy())
-            .unwrap_or(false),
+        Expr::AnonSub { body, .. } => {
+            // A `where { ... }` block may reference placeholder parameters
+            // (e.g. `$^n`).  In a where clause there is a single value under
+            // test, so bind every placeholder referenced in the block to the
+            // candidate value (sigil-stripped to the raw `^name` env key). The
+            // placeholder is read-only, so `where { $^x = ... }` dies.
+            let mut ph_keys: Vec<String> = Vec::new();
+            for ph in crate::ast::collect_placeholders(body)
+                .iter()
+                .chain(crate::ast::collect_where_assign_placeholders(body).iter())
+            {
+                let key = ph
+                    .trim_start_matches(|c: char| "$@%&".contains(c))
+                    .to_string();
+                if !ph_keys.contains(&key) {
+                    ph_keys.push(key);
+                }
+            }
+            for key in &ph_keys {
+                interpreter.env.insert(key.clone(), candidate.clone());
+                interpreter.mark_readonly(key);
+            }
+            let r = interpreter
+                .eval_block_value(body)
+                .map(|v| v.truthy())
+                .unwrap_or(false);
+            for key in &ph_keys {
+                interpreter.unmark_readonly(key);
+            }
+            r
+        }
         Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
             interpreter
                 .eval_block_value(&[Stmt::Expr(where_expr.clone())])


### PR DESCRIPTION
Fixes six subtests in `roast/S12-subset/subtypes.t` (now 83/90 pass, up from 77/90) by addressing four distinct root causes around subset / `where` constraints.

## Root causes & fixes

1. **Placeholder params in `where { $^n ... }` were never bound.** The predicate read an undefined `$^n` (numifying to 0), so `multi sub my_abs(Int $n where { $^n < 0 })` never matched. Bind every placeholder referenced in a where block to the single value under test across all four evaluation sites: multi-dispatch matching, single-sub binding (positional/named/slurpy), and signature smartmatch. (tests 3)

2. **Expression-position typed scalar declarations didn't persist the constraint.** `ok my Subset $c = 6` / `my $r = (my Int $c = 6)` left `$c` unconstrained, so a later `$c = 7` was unchecked. The statement-position path already emits `SetVarType`; emit it in the expression path too, AFTER `SetVarDynamic` (which clears stale same-named constraints) so it survives. (tests 16, 22, 23)

3. **`where`-block params are read-only.** `where { $^x = ... }` must die. Mark bound placeholders read-only during predicate evaluation, and also collect assignment-target placeholders (`collect_where_assign_placeholders`) which the expression-only `collect_placeholders` misses. (test 34)

4. **`where` on a `|c` capture param was never enforced.** `sub f(|c where { c.elems == 1 })` ignored the constraint; now evaluated after binding the capture. (test 85)

## Remaining (documented in TODO_roast/S12.md)
Tests 25 (`fail` custom message in subset where), 68 (`ok (...) ~~ Bool` space-before-paren parse), 77 (compile-time X::Undeclared for forward param ref), 83 (`:D` subset multi-method dispatch), 87 (Junction-of-types in where), 88 (list-decl postconstraints), 89 (`&`-sigiled where predicate).

## Testing
- `cargo test`: 477 passed.
- `make test`: only pre-existing non-fatal `t/dotassign-store-and-container-topic.t` failure (confirmed present on `main`).
- Spot-checked whitelisted S06-signature / S12-subset / S02-types/subset tests: no regressions (the two `not ok` lines seen are `# TODO` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)