### PR TITLE
fix(multidim): Range/Seq dims, nested-* assign, index coercion, :delete decont

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -52,6 +52,22 @@
     resolver only matched plain `Array`/`Hash`, so cross-frame `@a[i;j;k]:delete`
     / `@a[*-1;*-1;*-1] = v` silently no-op'd. Fixed by reading/mutating through
     the cell. Pin: `t/multidim-container-ref-coherence.t`.
+  - **2026-06-30 (#PR multidim dim-resolution + adverb/delete fixes)**: failures
+    cut to 36 (and all 812 subtests now run; previously 24 aborted mid-file).
+    Five general fixes: (1) `Range`/`Seq` subscript dimensions are normalized to
+    an index list in the read & assign paths (`@a[*;0;^3]`, `@a[0;*;(0...2)]`,
+    `@a[…;(0,1,2).Seq]` were reading `Nil`); (2) multidim assignment rewritten to
+    resolve each dimension against the *actual* nested container as it descends
+    (nested `*;*;*` was using the outermost length at every level, so only the
+    first leaf got written); slice-vs-scalar RHS distribution now matches raku
+    (`@a[0;0;*-1] = (7,8,9)` stores `7`, `@a[0;0;0] = (7,8,9)` stores the list);
+    (3) non-Int array indices (`"0"`/`0e0`/`0/1`) are coerced to Int in the
+    adverb/delete/assign paths (key tuples and element lookup were using the raw
+    values); (4) `:delete` returns the deleted element decontainerized (Array
+    leaf → List) and yields `Nil` for an out-of-range slot (was the `Any`
+    hole-value); (5) static & dynamic `@a[i;j;k]:k:delete` / `:kv:delete` /
+    `:p:delete` now lower to the `_dyn` builtin instead of wrapping the computed
+    key tuple in a `DELETE-KEY` method call (which crashed on a List).
   - **Remaining blockers (not whitelistable here)**:
     - `assignable-ok(\target, …)` binds a multislice as a raw `\target` and checks
       the array's state INSIDE the sub (~26 "check assignability" + "fast-path"
@@ -60,6 +76,9 @@
       single-dim `@a[1]` bound as `\target` — Track B (element `ContainerRef`
       cells, ADR-0001 layer 3a, fused with GC). Do NOT use a post-call-writeback
       workaround: it corrupts state ordering vs `set-up-array` and aborts early.
+    - `@array[|| @indices]` (the `||`-flattening multislice syntax, ~6 failures):
+      `||` should splice a list of per-dimension index tuples into the subscript;
+      mutsu treats it as a single index. Separate parser/lowering feature.
     - The final `@matrix` block (GitHub rakudo#2488, tests ~789-812) uses 6.e-only
       `{set}`-as-slice indices and `:k`/`:kv`/`:p`/`:delete` on multi-dim slices —
       features raku 2022.12 (6.d) itself throws `X::NYI` for, so the expected

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1784,6 +1784,30 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                                     Box::new(Value::Bool(true)),
                                 )));
                                 expr = Expr::Call { name, args };
+                            } else if name == "__mutsu_multidim_subscript_adverb" {
+                                // `@a[i;j;k]:k:delete` (static delete combined with a
+                                // :k/:kv/:p/:v adverb). Convert the static multidim
+                                // adverb call into its `_dyn` form with a constant-true
+                                // delete flag so the element is both read and removed
+                                // (the static form would otherwise be wrapped in a
+                                // `DELETE-KEY` method call on the already-computed key
+                                // tuple — a List — and fail). Args go from
+                                // [target, adverb, dims...] to
+                                // [var_name, adverb, true, dims...].
+                                let target = args.remove(0);
+                                let var_name_str = multidim_target_var_name(&target);
+                                let adverb_name = args.remove(0);
+                                let dims = args;
+                                let mut new_args = vec![
+                                    Expr::Literal(Value::str(var_name_str)),
+                                    adverb_name,
+                                    Expr::Literal(Value::Bool(true)),
+                                ];
+                                new_args.extend(dims);
+                                expr = Expr::Call {
+                                    name: Symbol::intern("__mutsu_multidim_subscript_adverb_dyn"),
+                                    args: new_args,
+                                };
                             } else {
                                 expr = Expr::MethodCall {
                                     target: Box::new(Expr::Call { name, args }),
@@ -1831,6 +1855,35 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                                     Box::new(Value::Bool(true)),
                                 )));
                                 let delete_expr = Expr::Call { name, args };
+                                expr = Expr::Ternary {
+                                    cond: Box::new(cond),
+                                    then_expr: Box::new(delete_expr),
+                                    else_expr: Box::new(original_expr),
+                                };
+                            }
+                        } else if matches!(&original_expr, Expr::Call { name, .. } if name == "__mutsu_multidim_subscript_adverb")
+                        {
+                            // `@a[i;j;k]:k:delete($cond)` — conditional delete with a
+                            // :k/:kv/:p/:v adverb. The no-delete branch keeps the
+                            // original static adverb call; the delete branch lowers to
+                            // the by-name `_dyn` builtin (it must mutate the variable).
+                            // Without this it would wrap the computed key tuple (a
+                            // List) in `DELETE-KEY` and fail.
+                            if let Expr::Call { mut args, .. } = original_expr.clone() {
+                                let target = args.remove(0);
+                                let var_name_str = multidim_target_var_name(&target);
+                                let adverb_name = args.remove(0);
+                                let dims = args;
+                                let mut new_args = vec![
+                                    Expr::Literal(Value::str(var_name_str)),
+                                    adverb_name,
+                                    Expr::Literal(Value::Bool(true)),
+                                ];
+                                new_args.extend(dims);
+                                let delete_expr = Expr::Call {
+                                    name: Symbol::intern("__mutsu_multidim_subscript_adverb_dyn"),
+                                    args: new_args,
+                                };
                                 expr = Expr::Ternary {
                                     cond: Box::new(cond),
                                     then_expr: Box::new(delete_expr),

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -382,12 +382,31 @@ impl Interpreter {
         // index in any dimension is an error (raku throws X::AdHoc), not a
         // silent no-op that yields Any.
         Self::check_shaped_index_bounds(&target_val, &indices)?;
+        // Multi-result mode for Whatever/list indices: collect each leaf, then
+        // delete, returning the deleted values (each decontainerized).
+        if has_multi_indices(&indices) {
+            let mut leaves = Vec::new();
+            multidim_collect_leaves(&target_val, &indices, &[], &mut leaves);
+            if let Some(t) = self.env.get_mut(&var_name) {
+                multidim_delete(t, &indices);
+                self.writeback_multidim_var_to_local(&var_name);
+            }
+            let values: Vec<Value> = leaves.into_iter().map(|(_, v)| array_to_list(v)).collect();
+            return Ok(Value::array(values));
+        }
+        // A non-existent (out-of-range) element deletes to `Nil`, not the `Any`
+        // hole-value that `multidim_delete` returns for a missing slot.
+        if matches!(multidim_index(&target_val, &indices), Value::Nil) {
+            return Ok(Value::Nil);
+        }
         let Some(target) = self.env.get_mut(&var_name) else {
             return Ok(Value::Nil);
         };
         let result = multidim_delete(target, &indices);
         self.writeback_multidim_var_to_local(&var_name);
-        Ok(result)
+        // Decontainerize the deleted element (Array leaf → List), matching
+        // raku's multi-dim `:delete` return value.
+        Ok(array_to_list(result))
     }
 
     /// Validate multidim indices against a shaped array's fixed dimensions.
@@ -496,8 +515,34 @@ impl Interpreter {
                     resolved.push(result);
                 }
                 _ => {
-                    current = multidim_index(&current, std::slice::from_ref(idx));
-                    resolved.push(idx.clone());
+                    // Coerce a non-Int scalar array index (`"0"`, `0e0`, `0/1`)
+                    // to its Int so the key tuple (`:k`/`:p`) and the element
+                    // lookup use `(0,0,0)`, not the raw `("0",0e0,0.0)`. Only do
+                    // this when the current level is an array — a Str into a hash
+                    // is a genuine key and must stay a string.
+                    let coerced = if matches!(&current, Value::Array(..))
+                        && matches!(
+                            idx,
+                            Value::Str(_)
+                                | Value::Num(_)
+                                | Value::Rat(..)
+                                | Value::FatRat(..)
+                                | Value::BigRat(..)
+                        ) {
+                        match idx {
+                            Value::Num(f) if *f >= 0.0 => Value::Int(*f as i64),
+                            Value::Rat(n, d) if *d != 0 => Value::Int(*n / *d),
+                            Value::Str(s) => s
+                                .parse::<i64>()
+                                .map(Value::Int)
+                                .unwrap_or_else(|_| idx.clone()),
+                            _ => idx.clone(),
+                        }
+                    } else {
+                        idx.clone()
+                    };
+                    current = multidim_index(&current, std::slice::from_ref(&coerced));
+                    resolved.push(coerced);
                 }
             }
         }
@@ -531,15 +576,24 @@ impl Interpreter {
                     multidim_delete(t, &indices);
                     self.writeback_multidim_var_to_local(&var_name);
                 }
-                let values: Vec<Value> = leaves.into_iter().map(|(_, v)| v).collect();
+                let values: Vec<Value> =
+                    leaves.into_iter().map(|(_, v)| array_to_list(v)).collect();
                 return Ok(Value::array(values));
+            }
+            // A non-existent (out-of-range) element deletes to `Nil`, not the
+            // `Any` hole-value that `multidim_delete` returns for a missing slot.
+            if matches!(multidim_index(&target, &indices), Value::Nil) {
+                return Ok(Value::Nil);
             }
             let Some(target) = self.env.get_mut(&var_name) else {
                 return Ok(Value::Nil);
             };
             let result = multidim_delete(target, &indices);
             self.writeback_multidim_var_to_local(&var_name);
-            Ok(result)
+            // The deleted element is returned decontainerized — an Array leaf
+            // (`[314]`) comes back as a List (`(314,)`), matching raku's
+            // multi-dim `:delete` (the test's `$resnona` is `$result.List`).
+            Ok(array_to_list(result))
         } else {
             Ok(multidim_index(&target, &indices))
         }
@@ -615,20 +669,24 @@ impl Interpreter {
             return Ok(Value::array(out));
         }
 
+        // Determine existence from a pre-delete read: a non-existent element
+        // reads as `Nil`, whereas `multidim_delete` returns the `Any` hole-value
+        // for an out-of-range slot, which would wrongly look "present".
+        let read_value = multidim_index(&target, &indices);
+        let exists = !matches!(&read_value, Value::Nil);
         let value = if do_delete {
-            if let Some(target) = self.env.get_mut(&var_name) {
+            if exists && let Some(target) = self.env.get_mut(&var_name) {
                 let r = multidim_delete(target, &indices);
                 self.writeback_multidim_var_to_local(&var_name);
                 r
             } else {
-                Value::Nil
+                read_value
             }
         } else {
-            multidim_index(&target, &indices)
+            read_value
         };
 
         let key = make_key_tuple(&indices);
-        let exists = !matches!(&value, Value::Nil);
 
         match adverb.as_str() {
             "k" => Ok(if exists { key } else { Value::Nil }),

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::vm::vm_comparison_ops::expand_range_to_list;
 
 impl Interpreter {
     /// Multi-dimensional indexing: @a[$x;$y;$z]
@@ -121,7 +122,8 @@ impl Interpreter {
             let single = Value::array(vec![target.clone()]);
             return self.multi_dim_index_read(&single, dims);
         }
-        let dim = &dims[0];
+        let dim = Self::normalize_multidim_dim(&dims[0]);
+        let dim = &dim;
         let rest = &dims[1..];
 
         // Hash targets index by key (string), recursing into the nested value
@@ -137,9 +139,12 @@ impl Interpreter {
                     Value::Array(items, ..) => items,
                     _ => return Ok(Value::Nil),
                 };
-                let has_more_multi = rest
-                    .iter()
-                    .any(|v| matches!(v, Value::Whatever | Value::Array(..)));
+                let has_more_multi = rest.iter().any(|v| {
+                    matches!(
+                        Self::normalize_multidim_dim(v),
+                        Value::Whatever | Value::Array(..)
+                    )
+                });
                 let mut out = Vec::with_capacity(items.len());
                 for item in items.iter() {
                     let result = self.multi_dim_index_read(item, rest)?;
@@ -162,9 +167,12 @@ impl Interpreter {
                     Value::Array(items, ..) => items,
                     _ => return Ok(Value::Nil),
                 };
-                let has_more_multi = rest
-                    .iter()
-                    .any(|v| matches!(v, Value::Whatever | Value::Array(..)));
+                let has_more_multi = rest.iter().any(|v| {
+                    matches!(
+                        Self::normalize_multidim_dim(v),
+                        Value::Whatever | Value::Array(..)
+                    )
+                });
                 let mut out = Vec::with_capacity(indices.len());
                 for idx in indices.iter() {
                     let result = if let Some(i) = Self::index_to_usize(idx) {
@@ -254,9 +262,12 @@ impl Interpreter {
         match dim {
             // `*` — all values at this level.
             Value::Whatever => {
-                let has_more_multi = rest
-                    .iter()
-                    .any(|v| matches!(v, Value::Whatever | Value::Array(..)));
+                let has_more_multi = rest.iter().any(|v| {
+                    matches!(
+                        Self::normalize_multidim_dim(v),
+                        Value::Whatever | Value::Array(..)
+                    )
+                });
                 let mut out = Vec::with_capacity(map.len());
                 for v in map.values() {
                     let inner = match v {
@@ -274,9 +285,12 @@ impl Interpreter {
             }
             // A list of keys — slice.
             Value::Array(keys, ..) => {
-                let has_more_multi = rest
-                    .iter()
-                    .any(|v| matches!(v, Value::Whatever | Value::Array(..)));
+                let has_more_multi = rest.iter().any(|v| {
+                    matches!(
+                        Self::normalize_multidim_dim(v),
+                        Value::Whatever | Value::Array(..)
+                    )
+                });
                 let mut out = Vec::with_capacity(keys.len());
                 for key in keys.iter() {
                     let result = read_key(self, &key.to_string_value(), rest)?;
@@ -290,6 +304,25 @@ impl Interpreter {
             }
             // A single key.
             _ => read_key(self, &dim.to_string_value(), rest),
+        }
+    }
+
+    /// Normalize a multi-dim subscript dimension into the shapes the indexing
+    /// logic understands. A `Range`/`Seq` dimension is a multi-index slice, so
+    /// it is expanded into an explicit `Array` of indices (matching how a bare
+    /// `(0,1,2)` list dimension is already handled). Scalars, `Whatever`,
+    /// `WhateverCode` (`Sub`), and `Array` dimensions are returned unchanged.
+    pub(super) fn normalize_multidim_dim(dim: &Value) -> Value {
+        match dim {
+            Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => Value::array(expand_range_to_list(dim)),
+            Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                Value::array(items.as_ref().clone())
+            }
+            _ => dim.clone(),
         }
     }
 
@@ -342,12 +375,16 @@ impl Interpreter {
 
         let var_name = Self::const_str(code, name_idx).to_string();
 
-        // Resolve WhateverCode indices
+        // Resolve WhateverCode indices for the bound-index check and the shaped
+        // path. The non-shaped assignment uses the RAW `dims` instead, because
+        // it resolves each dimension against the actual nested container as it
+        // descends (a flat pre-pass mis-resolves a deeper `*`/slice — it would
+        // use the outermost length, not the inner container's).
         let target_val = self.env().get(&var_name).cloned().unwrap_or(Value::Nil);
-        let dims = self.resolve_multidim_indices_for_assign(&target_val, &dims)?;
+        let resolved_dims = self.resolve_multidim_indices_for_assign(&target_val, &dims)?;
 
         // Check if the index is bound (read-only)
-        let encoded_idx = dims
+        let encoded_idx = resolved_dims
             .iter()
             .map(|d| d.to_string_value())
             .collect::<Vec<_>>()
@@ -390,23 +427,33 @@ impl Interpreter {
         if let Some(cell) = container_cell {
             let mut inner = cell.lock().unwrap();
             if is_shaped {
-                Self::assign_array_multidim(&mut inner, &dims, value.clone())?;
+                Self::assign_array_multidim(&mut inner, &resolved_dims, value.clone())?;
+                drop(inner);
             } else {
-                Self::multi_dim_assign(&mut inner, &dims, value.clone())?;
+                // Move the contents out of the guard so the assignment can
+                // borrow `&mut self` (WhateverCode resolution needs it) without
+                // also holding a borrow tied to `self` through the cell.
+                let mut contents = std::mem::replace(&mut *inner, Value::Nil);
+                drop(inner);
+                self.multi_dim_assign(&mut contents, &dims, value.clone())?;
+                *cell.lock().unwrap() = contents;
             }
-            drop(inner);
             self.stack.push(value);
             return Ok(());
         }
 
-        // Get mutable reference to the target variable
-        if let Some(container) = self.env_mut().get_mut(&var_name) {
+        // Mutate a clone of the target variable, then store it back. (Taking a
+        // `&mut` into env would conflict with the `&mut self` the assignment
+        // needs for WhateverCode resolution.)
+        if self.env().contains_key(&var_name) {
+            let mut container = self.env().get(&var_name).cloned().unwrap_or(Value::Nil);
             if is_shaped {
                 // For shaped arrays, use bounds-checked assignment
-                Self::assign_array_multidim(container, &dims, value.clone())?;
+                Self::assign_array_multidim(&mut container, &resolved_dims, value.clone())?;
             } else {
-                Self::multi_dim_assign(container, &dims, value.clone())?;
+                self.multi_dim_assign(&mut container, &dims, value.clone())?;
             }
+            self.env_mut().insert(var_name.clone(), container);
         }
         // Also sync the updated container into the Interpreter locals slot (if any)
         // so that a later locals write-through does not restore the stale
@@ -448,28 +495,149 @@ impl Interpreter {
         let mut target = self.stack.pop().unwrap_or(Value::Nil);
         let is_shaped = crate::runtime::utils::is_shaped_array(&target);
         if is_shaped {
-            Self::assign_array_multidim(&mut target, &dims, value.clone())?;
+            let resolved_dims = self.resolve_multidim_indices_for_assign(&target, &dims)?;
+            Self::assign_array_multidim(&mut target, &resolved_dims, value.clone())?;
         } else {
-            Self::multi_dim_assign(&mut target, &dims, value.clone())?;
+            self.multi_dim_assign(&mut target, &dims, value.clone())?;
         }
         self.stack.push(value);
         Ok(())
     }
 
-    /// Compute the number of leaf slots for the remaining dimensions.
-    /// Each array dimension contributes its length; scalar dimensions contribute 1.
-    fn remaining_slot_count(dims: &[Value]) -> usize {
-        let mut count = 1usize;
-        for d in dims {
-            if let Value::Array(items, ..) = d {
-                count *= items.len();
-            }
-        }
-        count
+    /// Whether a multi-dim subscript dimension puts the assignment into slice
+    /// (list-distributing) context rather than single-element context. After
+    /// normalization, `Whatever`, an explicit index list, and a `WhateverCode`
+    /// (`Sub`, e.g. `*-1`) all make a multi-dim subscript a slice: raku assigns
+    /// the RHS list element-wise to the selected leaves, so a single leaf takes
+    /// only the first RHS element (`@a[0;0;*-1] = (7,8,9)` stores `7`). A plain
+    /// scalar index keeps single-element semantics (`@a[0;0;0] = (7,8,9)`
+    /// stores the whole list).
+    fn dim_is_multi(dim: &Value) -> bool {
+        matches!(
+            Self::normalize_multidim_dim(dim),
+            Value::Whatever | Value::Array(..) | Value::Sub(..)
+        )
     }
 
-    /// Recursively assign a value into a nested array/hash at the given dimension indices.
+    /// Resolve one assignment dimension against the current `target` container
+    /// into the concrete index/key values it selects. `Whatever` expands to all
+    /// existing indices/keys of `target`; an explicit list resolves any
+    /// `WhateverCode` elements; a bare `WhateverCode` resolves against the
+    /// length of `target`; a scalar passes through unchanged.
+    fn resolve_assign_dim(
+        &mut self,
+        target: &Value,
+        dim: &Value,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        let dim = Self::normalize_multidim_dim(dim);
+        let deref = target.with_deref(|v| v.descalarize().clone());
+        match &dim {
+            Value::Whatever => match &deref {
+                Value::Array(items, ..) => Ok((0..items.len() as i64).map(Value::Int).collect()),
+                Value::Hash(map, ..) => Ok(map.keys().map(|k| Value::str(k.to_string())).collect()),
+                _ => Ok(vec![]),
+            },
+            Value::Array(items, ..) => {
+                let len = match &deref {
+                    Value::Array(arr, ..) => Value::Int(arr.len() as i64),
+                    _ => Value::Int(0),
+                };
+                let mut out = Vec::with_capacity(items.len());
+                for it in items.iter() {
+                    if let Value::Sub(..) = it {
+                        out.push(self.call_sub_value(it.clone(), vec![len.clone()], false)?);
+                    } else {
+                        out.push(it.clone());
+                    }
+                }
+                Ok(out)
+            }
+            Value::Sub(..) => {
+                let len = match &deref {
+                    Value::Array(items, ..) => Value::Int(items.len() as i64),
+                    _ => Value::Int(0),
+                };
+                Ok(vec![self.call_sub_value(dim.clone(), vec![len], false)?])
+            }
+            _ => Ok(vec![dim.clone()]),
+        }
+    }
+
+    /// Recursively assign a value into a nested array/hash at the given
+    /// dimension subscripts. Each dimension is resolved against the *actual*
+    /// nested container as the descent proceeds, so nested `*`/slice/Range/Seq
+    /// dimensions select the correct indices at every level (a flat pre-pass
+    /// cannot — a deeper `*` needs the inner container's length, not the
+    /// outermost). A scalar-only subscript assigns the whole RHS to the single
+    /// leaf; a subscript containing any slice dimension flattens the RHS list
+    /// and assigns element-wise across the leaf cross-product in row-major
+    /// order (extra leaves get `Any`, raku list-assignment semantics).
     fn multi_dim_assign(
+        &mut self,
+        target: &mut Value,
+        dims: &[Value],
+        value: Value,
+    ) -> Result<(), RuntimeError> {
+        if dims.iter().any(Self::dim_is_multi) {
+            let values: Vec<Value> = match value {
+                Value::Array(items, ..) => items.iter().cloned().collect(),
+                other => vec![other],
+            };
+            let mut vi = 0usize;
+            self.multi_dim_assign_slice(target, dims, &values, &mut vi)
+        } else {
+            self.multi_dim_assign_scalar(target, dims, value)
+        }
+    }
+
+    /// Slice-distribution arm of `multi_dim_assign`: walk the leaf
+    /// cross-product in row-major order, pulling the next RHS element for each
+    /// leaf.
+    fn multi_dim_assign_slice(
+        &mut self,
+        target: &mut Value,
+        dims: &[Value],
+        values: &[Value],
+        vi: &mut usize,
+    ) -> Result<(), RuntimeError> {
+        if dims.is_empty() {
+            let v = values
+                .get(*vi)
+                .cloned()
+                .unwrap_or_else(|| Value::Package(crate::symbol::Symbol::intern("Any")));
+            *vi += 1;
+            *target = v;
+            return Ok(());
+        }
+        let keys = self.resolve_assign_dim(target, &dims[0])?;
+        let rest = &dims[1..];
+        for key in keys {
+            if !matches!(target, Value::Hash(..))
+                && let Some(i) = Self::index_to_usize(&key)
+            {
+                Self::ensure_array_size(target, i + 1);
+                if let Value::Array(items, ..) = target {
+                    let items = std::sync::Arc::make_mut(items);
+                    self.multi_dim_assign_slice(&mut items[i], rest, values, vi)?;
+                }
+            } else if let Value::Str(s) = &key {
+                Self::ensure_hash(target);
+                if let Value::Hash(map, ..) = target {
+                    let map = std::sync::Arc::make_mut(map);
+                    let entry = map
+                        .entry(s.as_str().to_string())
+                        .or_insert_with(|| Value::Package(crate::symbol::Symbol::intern("Any")));
+                    self.multi_dim_assign_slice(entry, rest, values, vi)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Scalar (single-leaf) arm of `multi_dim_assign`: navigate one index/key
+    /// per dimension and assign the whole RHS at the leaf.
+    fn multi_dim_assign_scalar(
+        &mut self,
         target: &mut Value,
         dims: &[Value],
         value: Value,
@@ -478,77 +646,35 @@ impl Interpreter {
             *target = value;
             return Ok(());
         }
-
-        let dim = &dims[0];
+        let key = self
+            .resolve_assign_dim(target, &dims[0])?
+            .into_iter()
+            .next()
+            .unwrap_or(Value::Nil);
         let rest = &dims[1..];
-
-        // For multi-index dimensions (arrays of keys/indices), need to distribute values
-        if let Value::Array(indices, ..) = dim {
-            if let Value::Array(values, ..) = &value {
-                // Calculate how many leaf slots each index in this dimension needs
-                let chunk_size = Self::remaining_slot_count(rest);
-                // Distribute values to indices in chunks
-                for (i, idx) in indices.iter().enumerate() {
-                    let chunk_start = i * chunk_size;
-                    let chunk: Vec<Value> = values
-                        .iter()
-                        .skip(chunk_start)
-                        .take(chunk_size)
-                        .cloned()
-                        .collect();
-                    let val = if chunk_size == 1 {
-                        chunk.into_iter().next().unwrap_or(Value::Nil)
-                    } else {
-                        Value::real_array(chunk)
-                    };
-                    Self::multi_dim_assign_single(target, idx, rest, val)?;
-                }
-            } else {
-                // Single value assigned to multiple indices
-                for idx in indices.iter() {
-                    Self::multi_dim_assign_single(target, idx, rest, value.clone())?;
-                }
+        // An array index that arrives as a non-Int scalar (`"0"`, `0e0`, `0/1`)
+        // is coerced to its integer when the target is (or autovivifies to) an
+        // array; only a genuine hash target keeps the string as a key.
+        if !matches!(target, Value::Hash(..))
+            && let Some(i) = Self::index_to_usize(&key)
+        {
+            Self::ensure_array_size(target, i + 1);
+            if let Value::Array(items, ..) = target {
+                let items = std::sync::Arc::make_mut(items);
+                self.multi_dim_assign_scalar(&mut items[i], rest, value)?;
             }
-            return Ok(());
-        }
-
-        // Scalar index/key
-        Self::multi_dim_assign_single(target, dim, rest, value)
-    }
-
-    /// Assign a value at a single index/key, recursing into remaining dimensions.
-    fn multi_dim_assign_single(
-        target: &mut Value,
-        dim: &Value,
-        rest: &[Value],
-        value: Value,
-    ) -> Result<(), RuntimeError> {
-        // Check if the dimension is a string key (for hash access)
-        if let Value::Str(key) = dim {
-            // Hash assignment
+        } else if let Value::Str(s) = &key {
             Self::ensure_hash(target);
             if let Value::Hash(map, ..) = target {
                 let map = std::sync::Arc::make_mut(map);
                 let entry = map
-                    .entry(key.as_str().to_string())
+                    .entry(s.as_str().to_string())
                     .or_insert_with(|| Value::Package(crate::symbol::Symbol::intern("Any")));
-                Self::multi_dim_assign(entry, rest, value)?;
+                self.multi_dim_assign_scalar(entry, rest, value)?;
             }
-            return Ok(());
-        }
-
-        // Numeric index (for array access)
-        let Some(i) = Self::index_to_usize(dim) else {
+        } else {
             return Err(RuntimeError::new("Invalid index for multi-dim assignment"));
-        };
-
-        Self::ensure_array_size(target, i + 1);
-
-        if let Value::Array(items, ..) = target {
-            let items = std::sync::Arc::make_mut(items);
-            Self::multi_dim_assign(&mut items[i], rest, value)?;
         }
-
         Ok(())
     }
 

--- a/t/multidim-dim-resolution-and-adverbs.t
+++ b/t/multidim-dim-resolution-and-adverbs.t
@@ -1,0 +1,76 @@
+use v6.e.PREVIEW;
+use Test;
+
+plan 21;
+
+# Range / Seq / nested-Whatever dimension resolution in reads.
+{
+    my @a = [[[42,666,[314]],],];
+    is-deeply @a[0;0;(0,1,2)], (42,666,[314]),        'List dim read';
+    is-deeply @a[0;*;(0,1,2).Seq], (42,666,[314]),    'Seq dim read flattens';
+    is-deeply @a[*;0;^3], (42,666,[314]),             'Range dim read';
+    is-deeply @a[0;*;(0...2)], (42,666,[314]),        'Seq-from-range dim read';
+    is-deeply @a[*;*;*], (42,666,[314]),              'nested Whatever read';
+}
+
+# Multidim assignment: nested Whatever / Range / Seq distribute across leaves.
+{
+    my @a = [[[42,666,[314]],],];
+    @a[*;*;*] = (7,8,9);
+    is-deeply @a, [[[7,8,9],],],                      'nested * assignment distributes';
+
+    @a = [[[42,666,[314]],],];
+    @a[*;0;^3] = (7,8,9);
+    is-deeply @a, [[[7,8,9],],],                      'Range dim assignment';
+
+    @a = [[[42,666,[314]],],];
+    @a[0;*;(0...2)] = (7,8,9);
+    is-deeply @a, [[[7,8,9],],],                      'Seq dim assignment';
+}
+
+# Slice vs scalar RHS distribution semantics.
+{
+    my @a = [[[42,666,99],],];
+    @a[0;0;0] = (7,8,9);
+    is-deeply @a, [[[(7,8,9),666,99],],],             'scalar subscript stores whole list';
+
+    @a = [[[42,666,99],],];
+    @a[0;0;*-1] = (7,8,9);
+    is-deeply @a, [[[42,666,7],],],                   'WhateverCode subscript is slice (first elem)';
+}
+
+# Non-Int (Str/Num/Rat) array indices coerce in both assignment and adverbs.
+{
+    my @a = [[[42,666,[314]],],];
+    @a["0";0e0;0/1] = 999;
+    is-deeply @a, [[[999,666,[314]],],],              'string/num/rat index assignment';
+
+    @a = [[[42,666,[314]],],];
+    is-deeply (@a["0";0e0;0/1]:k), (0,0,0),           ':k coerces indices';
+    is-deeply (@a["0";0e0;0/1]:v), 42,                ':v with coerced indices';
+    is-deeply (@a["0";0e0;0/1]:p), ((0,0,0) => 42),   ':p with coerced indices';
+}
+
+# :delete returns the deleted element decontainerized, Nil when out of range.
+{
+    my @a = [[[42,666,[314]],],];
+    is-deeply (@a[0;0;2]:delete), (314,),             ':delete returns List (decont)';
+    is-deeply @a, [[[42,666],],],                     ':delete removed the element';
+
+    @a = [[[42,666,[314]],],];
+    is-deeply (@a[0;0;3]:delete), Nil,                ':delete of missing element is Nil';
+}
+
+# Combined adverb + :delete (static and dynamic) on multidim.
+{
+    my @a = [[[42,666,[314]],],];
+    is-deeply (@a[0;0;1]:k:delete), (0,0,1),          ':k:delete static returns key';
+    is-deeply @a, [[[42,Any,[314]],],],               ':k:delete removed element';
+
+    my $del = True;
+    @a = [[[42,666,[314]],],];
+    is-deeply (@a[0;0;1]:kv:delete($del)), ((0,0,1),666), ':kv:delete dynamic';
+
+    @a = [[[42,666,[314]],],];
+    is-deeply (@a[0;0;3]:k:delete), Nil,              ':k:delete of missing element is Nil';
+}


### PR DESCRIPTION
Six general multi-dimensional subscript fixes for `S32-array/multislice-6e.t`, cutting failures to **36** (all 812 subtests now run; 24 previously aborted mid-file).

## Fixes
1. **Range/Seq dimensions** — normalized to an index list in both read & assign paths. `@a[*;0;^3]`, `@a[0;*;(0...2)]`, `@a[...;(0,1,2).Seq]` previously read `Nil`.
2. **Nested-`*` / per-level assignment** — multi-dim assignment now resolves each dimension against the *actual* nested container as it descends, so a deeper `*`/slice uses the inner container's length, not the outermost (nested `*;*;*` only wrote the first leaf before). Slice-vs-scalar RHS distribution matches raku: `@a[0;0;*-1] = (7,8,9)` stores `7`; `@a[0;0;0] = (7,8,9)` stores the whole list.
3. **Non-Int index coercion** — `"0"`/`0e0`/`0/1` coerce to `Int` in the adverb/delete/assign paths (key tuples and lookup used raw values).
4. **`:delete` semantics** — returns the deleted element decontainerized (Array leaf → List) and yields `Nil` for an out-of-range slot (was the `Any` hole-value).
5. **`:k:delete`/`:kv:delete`/`:p:delete`** (static & dynamic) — lower to the `_dyn` builtin instead of wrapping the computed key tuple in a `DELETE-KEY` method call (which crashed on a List).

## Remaining blockers (recorded in `TODO_roast/S32.md`)
- Raw `\target`-bound multislice in-sub writeback (Track B / element `ContainerRef` cells, ADR-0001 layer 3a — fused with GC).
- `@a[|| @indices]` syntax.
- The 6.e-only `{set}`-as-slice tail block (rakudo#2488) that raku itself throws `X::NYI` for.

## Testing
- Pin: `t/multidim-dim-resolution-and-adverbs.t` (21 cases).
- `make test`: no regressions (the one `t/dotassign-store-and-container-topic.t` failure is pre-existing on `main`).
- Related roast (`multidim-assignment.t`, `slice.t`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)