### PR TITLE
fix(whatever): rw params, bare-Whatever invocation, +@ slurpy, regex capture (S02-types/whatever.t)

### DIFF
--- a/src/builtins/arith/add_sub.rs
+++ b/src/builtins/arith/add_sub.rs
@@ -18,6 +18,16 @@ pub(crate) fn arith_add(left: Value, right: Value) -> Result<Value, RuntimeError
     // Phase 2 element container: a `:=`-bound element cell may reach an arith op
     // directly (e.g. `@a.reduce(&[+])` folds raw items); read through the cell.
     let (left, right) = (left.into_deref(), right.into_deref());
+    // A bare Whatever value reaching `+` is NOT a curry point (those are wrapped
+    // into a WhateverCode at parse time). Numifying it dies in Raku, e.g.
+    // `&infix:<+>(*, 42)` invokes `+` with a Whatever argument.
+    if matches!(left, Value::Whatever | Value::HyperWhatever)
+        || matches!(right, Value::Whatever | Value::HyperWhatever)
+    {
+        return Err(RuntimeError::new(
+            "Cannot resolve caller Numeric(Whatever:D: ); none of these signatures matches:\n    (Mu:U \\v: *%_)".to_string(),
+        ));
+    }
     // Mixin-wrapped Range + Real (or Real + Mixin Range): perform Range arithmetic and re-wrap
     if let Some(result) = mixin_range_arith(left.clone(), right.clone(), arith_add)
         .or_else(|| mixin_range_arith(right.clone(), left.clone(), arith_add))

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -232,7 +232,38 @@ impl Compiler {
         } else {
             vec![param.to_string()]
         };
-        let mut compiled = self.compile_closure_body(&params, &[], body);
+        // A single-`*` WhateverCode whose body *mutates* the `_` placeholder
+        // (`*++`, `*--`, `++*`, `* =:= $x`, `*.=foo`) binds `_` `is raw`, so the
+        // mutation/identity reaches the caller's container (S02 "WhateverCode
+        // parameters are rw"). Read-only bodies keep `_` by value (no param_defs),
+        // which avoids a topic-`_` writeback leak in `for`/grep frames.
+        let wc_raw = is_whatever_code && param == "_" && whatever_lambda_body_mutates_topic(body);
+        let wc_param_defs: Vec<crate::ast::ParamDef> = if wc_raw {
+            vec![crate::ast::ParamDef {
+                name: "_".to_string(),
+                default: None,
+                multi_invocant: true,
+                required: false,
+                named: false,
+                slurpy: false,
+                sigilless: false,
+                type_constraint: None,
+                literal_value: None,
+                sub_signature: None,
+                where_constraint: None,
+                traits: vec!["raw".to_string()],
+                double_slurpy: false,
+                onearg: false,
+                optional_marker: false,
+                outer_sub_signature: None,
+                code_signature: None,
+                is_invocant: false,
+                shape_constraints: None,
+            }]
+        } else {
+            Vec::new()
+        };
+        let mut compiled = self.compile_closure_body(&params, &wc_param_defs, body);
         // A pointy block (`-> $x {...}`) is a `Block`, not a `Sub`. A WhateverCode
         // (`*+1`, also an `Expr::Lambda`) is tagged separately via callable_type.
         if !is_whatever_code {
@@ -244,7 +275,7 @@ impl Compiler {
             name: Symbol::intern(""),
             name_expr: None,
             params: params.clone(),
-            param_defs: Vec::new(),
+            param_defs: wc_param_defs,
             return_type: None,
             associativity: None,
             precedence_trait: None,
@@ -252,7 +283,7 @@ impl Compiler {
             body: body.to_vec(),
             multi: false,
             is_rw: false,
-            is_raw: false,
+            is_raw: wc_raw,
             is_export: false,
             export_tags: Vec::new(),
             is_test_assertion: false,
@@ -659,5 +690,70 @@ impl Compiler {
             };
             self.compile_expr(&ro_call);
         }
+    }
+}
+
+/// Whether a single-`*` WhateverCode body (the `*` already lowered to `Var("_")`)
+/// *mutates* its placeholder or depends on its container identity, requiring the
+/// `_` parameter to bind `is raw`: `*++`/`*--`/`++*`/`--*`, `* =:= $x`, `*.=foo`.
+fn whatever_lambda_body_mutates_topic(body: &[Stmt]) -> bool {
+    body.iter().any(|stmt| match stmt {
+        Stmt::Expr(e) => expr_mutates_topic(e),
+        _ => false,
+    })
+}
+
+fn is_topic_var(e: &Expr) -> bool {
+    matches!(e, Expr::Var(name) if name == "_")
+}
+
+fn expr_refs_topic(e: &Expr) -> bool {
+    if is_topic_var(e) {
+        return true;
+    }
+    match e {
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => expr_refs_topic(expr),
+        Expr::Binary { left, right, .. } => expr_refs_topic(left) || expr_refs_topic(right),
+        Expr::MethodCall { target, .. } => expr_refs_topic(target),
+        _ => false,
+    }
+}
+
+fn expr_mutates_topic(e: &Expr) -> bool {
+    match e {
+        // `*++` / `*--`
+        Expr::PostfixOp {
+            op: TokenKind::PlusPlus | TokenKind::MinusMinus,
+            expr,
+        } => expr_refs_topic(expr) || expr_mutates_topic(expr),
+        // `++*` / `--*`
+        Expr::Unary {
+            op: TokenKind::PlusPlus | TokenKind::MinusMinus,
+            expr,
+        } => expr_refs_topic(expr) || expr_mutates_topic(expr),
+        Expr::Unary { expr, .. } => expr_mutates_topic(expr),
+        Expr::PostfixOp { expr, .. } => expr_mutates_topic(expr),
+        // `* =:= $x` — container identity needs the same container.
+        Expr::Binary {
+            op: TokenKind::Ident(name),
+            left,
+            right,
+        } if name == "=:=" => {
+            expr_refs_topic(left)
+                || expr_refs_topic(right)
+                || expr_mutates_topic(left)
+                || expr_mutates_topic(right)
+        }
+        Expr::Binary { left, right, .. } => expr_mutates_topic(left) || expr_mutates_topic(right),
+        // `*.=foo` — mutating method-assign on the placeholder.
+        Expr::MethodCall {
+            target,
+            modifier: Some('='),
+            ..
+        } if expr_refs_topic(target) => true,
+        Expr::MethodCall { target, args, .. } => {
+            expr_mutates_topic(target) || args.iter().any(expr_mutates_topic)
+        }
+        _ => false,
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1809,6 +1809,44 @@ impl CompiledCode {
     /// resolved by this code's locals. Nested closures have already had their
     /// own `free_var_syms` computed (they are finalized before being embedded),
     /// so they are folded in directly without re-walking their ops.
+    /// Extract sigil'd variable references (`$r`, `@a`, `%h`, `&rule`) from a
+    /// regex pattern string, for closure free-variable analysis. Conservative: it
+    /// over-approximates (an extra captured var is harmless), and skips capture
+    /// references like `$0`/`$<name>` (sigil not followed by an identifier start).
+    fn regex_interpolated_var_names(pattern: &str) -> Vec<String> {
+        let bytes = pattern.as_bytes();
+        let mut names = Vec::new();
+        let mut i = 0;
+        while i < bytes.len() {
+            let c = bytes[i];
+            if matches!(c, b'$' | b'@' | b'%' | b'&') {
+                let start_ident = i + 1;
+                if start_ident < bytes.len()
+                    && (bytes[start_ident].is_ascii_alphabetic() || bytes[start_ident] == b'_')
+                {
+                    let mut j = start_ident;
+                    while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_')
+                    {
+                        j += 1;
+                    }
+                    // Scalars ($x) are stored sigil-less in `locals`/`env` ("x"),
+                    // while @/%/& lexicals keep their sigil. Match that convention
+                    // so the free-var name lines up with the local slot / env key.
+                    let name = if c == b'$' {
+                        pattern[start_ident..j].to_string()
+                    } else {
+                        pattern[i..j].to_string()
+                    };
+                    names.push(name);
+                    i = j;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        names
+    }
+
     pub(crate) fn compute_free_vars(&mut self) {
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let mut free: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
@@ -1877,6 +1915,26 @@ impl CompiledCode {
                     pending_decl = false;
                 }
                 _ => {}
+            }
+        }
+        // Regex literals interpolate lexical variables at match time (`/<$r>/`,
+        // `/$x/`, `/<&rule>/`). Those reads happen inside the regex engine, not via
+        // a name-const op, so the op scan above misses them. A closure that stores
+        // such a regex (e.g. `-> $r { * ~~ /<$r>/ }`) must still capture `$r`, so
+        // scan every regex constant for sigil'd variable references and treat them
+        // as free vars (unless this body declares them).
+        for c in &self.constants {
+            let pattern = match c {
+                Value::Regex(s) => Some(s.as_str()),
+                Value::RegexWithAdverbs(a) => Some(a.pattern.as_str()),
+                _ => None,
+            };
+            if let Some(pattern) = pattern {
+                for name in Self::regex_interpolated_var_names(pattern) {
+                    if !own.contains(name.as_str()) {
+                        free.insert(Symbol::intern(&name));
+                    }
+                }
             }
         }
         // Fold nested closures: their free vars are ours unless we declare them;

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -35,6 +35,12 @@ pub(crate) fn should_wrap_whatevercode(expr: &Expr) -> bool {
             op: TokenKind::Ident(name),
             ..
         } if name == "o" => false,
+        // `*(args)` invokes a *bare* Whatever value — it does not curry. Whatever
+        // has no `CALL-ME`, so this dies at runtime (X::Method::NotFound). Only a
+        // CallOn on a *compound* curry target (`*[0](...)`, `*.foo(...)`) wraps the
+        // target into a WhateverCode and invokes it (handled by the target-wrap arm
+        // in `expression`). Keep the bare-target CallOn unwrapped here.
+        Expr::CallOn { target, .. } if is_whatever(target) => false,
         // List replication `xx` does not Whatever-curry a *bare* `*` operand: a
         // standalone `*` is the Whatever value, repeated literally. `* xx 2` is
         // `(*, *)`; `1 xx *`/`1 x *` is the infinite-repeat form. None wrap into a
@@ -197,24 +203,14 @@ pub(crate) fn contains_whatever(expr: &Expr) -> bool {
         Expr::MethodCall { target, .. } | Expr::DynamicMethodCall { target, .. } => {
             contains_whatever(target) || is_wrapped_whatevercode(target)
         }
-        Expr::CallOn { target, args } => {
-            // Already-wrapped WhateverCode args (Lambda/AnonSubParams with
-            // is_whatever_code: true) are opaque values, not raw Whatever
-            // placeholders.  Only bare * or compound-Whatever args should
-            // trigger auto-currying of the whole CallOn.
+        Expr::CallOn { target, .. } => {
+            // Only the *target* of an invocation can curry: `(*.foo).(x)` invokes
+            // the curried `*.foo`, and `*[0]([1,2,3])` invokes the curried `*[0]`.
+            // A bare `*` (or compound Whatever) passed as a call *argument* is NOT
+            // a curry point — it is a Whatever value handed to the callee. So
+            // `&infix:<+>(*, 42)` invokes `&infix:<+>` with a Whatever argument
+            // (which dies in `+`), it does NOT make a closure.
             contains_whatever(target)
-                || args.iter().any(|a| {
-                    !matches!(
-                        a,
-                        Expr::Lambda {
-                            is_whatever_code: true,
-                            ..
-                        } | Expr::AnonSubParams {
-                            is_whatever_code: true,
-                            ..
-                        }
-                    ) && contains_whatever(a)
-                })
         }
         // Only check target, not index: @a[*-1] should NOT make the whole expr a WhateverCode.
         // The [*-1] subscript handles its own WhateverCode wrapping.

--- a/src/parser/expr/whatever_wrap.rs
+++ b/src/parser/expr/whatever_wrap.rs
@@ -211,7 +211,10 @@ pub(crate) fn wrap_whatevercode(expr: &Expr) -> Expr {
     let wc_count = count_whatever(expr);
 
     if wc_count <= 1 && !expr_contains_topic(expr) {
-        // Single-arg: use Lambda with param "_" for backward compat
+        // Single-arg: use Lambda with param "_" for backward compat (this keeps the
+        // `deepmap`/hyper container-passing path working, which binds each leaf to
+        // the topic `_`). `compile_expr_lambda` marks `_` `is raw` when the body
+        // mutates the placeholder (`*++`, `* =:= $x`), so mutation/identity work.
         // Use a special single-arg replacer that maps * and nested single-arg WC to $_
         let body_expr = replace_whatever_single(expr);
         Expr::Lambda {
@@ -239,7 +242,9 @@ pub(crate) fn wrap_whatevercode(expr: &Expr) -> Expr {
                 literal_value: None,
                 sub_signature: None,
                 where_constraint: None,
-                traits: Vec::new(),
+                // WhateverCode parameters are `is raw`, so `*++`/`*.=foo` can
+                // mutate the argument's container and write back to the caller.
+                traits: vec!["raw".to_string()],
                 double_slurpy: false,
                 onearg: false,
                 optional_marker: false,
@@ -274,7 +279,8 @@ pub(crate) fn wrap_whatevercode(expr: &Expr) -> Expr {
                     literal_value: None,
                     sub_signature: None,
                     where_constraint: None,
-                    traits: Vec::new(),
+                    // WhateverCode parameters are `is raw` (mutable, write back).
+                    traits: vec!["raw".to_string()],
                     double_slurpy: false,
                     onearg: false,
                     optional_marker: false,

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -93,6 +93,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
     // Slurpy marker for pointy params: *@a, *%h, *$x, *&cb, and double-slurpy variants.
     let mut slurpy = false;
     let mut double_slurpy = false;
+    let mut onearg = false;
     if rest.starts_with("**")
         && rest.len() > 2
         && matches!(rest.as_bytes()[2], b'@' | b'%' | b'$' | b'&')
@@ -105,6 +106,14 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         && matches!(rest.as_bytes()[1], b'@' | b'%' | b'$' | b'&')
     {
         slurpy = true;
+        rest = &rest[1..];
+    } else if rest.starts_with('+')
+        && rest.len() > 1
+        && matches!(rest.as_bytes()[1], b'@' | b'%' | b'$' | b'&')
+    {
+        // Single-argument-rule slurpy: `-> +@foo { ... }`.
+        slurpy = true;
+        onearg = true;
         rest = &rest[1..];
     }
 
@@ -419,7 +428,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             named,
             slurpy,
             double_slurpy,
-            onearg: false,
+            onearg,
             sigilless: false,
             type_constraint,
             literal_value: None,

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -922,6 +922,13 @@ impl Interpreter {
                             // caller's variable.
                             let alias_key = format!("__mutsu_sigilless_alias::{}", pd.name);
                             self.env.insert(alias_key, Value::str(source_name));
+                        } else if matches!(&args[positional_idx], Value::ContainerRef(_)) {
+                            // A bare `ContainerRef` cell (e.g. the leaf container
+                            // `deepmap`/hyper passes by reference) IS a writable
+                            // lvalue even without a source variable name: the raw
+                            // param binds the shared cell and mutations through it
+                            // (`*++`, `*--`) write to the source slot. Keep it
+                            // mutable (do NOT mark readonly).
                         } else if is_rw {
                             return Err(RuntimeError::new(format!(
                                 "X::Parameter::RW: '{}' expects a writable variable argument",

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -256,16 +256,45 @@ impl Interpreter {
             return self.clone_env();
         };
         if cc.captures_env_by_name || crate::opcode::reflective_name_access_possible() {
-            return self.clone_env();
+            let mut flat = self.clone_env();
+            // Even when capturing the whole env by name, a slot-only local (a
+            // pointy-block/sub parameter that this frame never mirrors into `env`,
+            // e.g. `-> $r { * ~~ /<$r>/ }` where `$r` is read only inside a stored
+            // regex) can be missing from the cloned env. Pull this frame's
+            // free-var slots from the live local store so such captures survive.
+            for sym in &cc.free_var_syms {
+                if let Some(slot) = sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+                    && let Some(val) = self.locals.get(slot)
+                {
+                    flat.insert_sym(*sym, val.clone());
+                }
+            }
+            // Drop the closure's own params/locals (e.g. a WhateverCode's `_`
+            // topic param) so a stale enclosing `for`/map topic is not inherited
+            // and later leaked back to the caller.
+            for name in &cc.locals {
+                if !cc.free_var_syms.iter().any(|s| s.with_str(|x| x == name)) {
+                    flat.remove_sym(Symbol::intern(name));
+                }
+            }
+            return flat;
         }
         let free: std::collections::HashSet<Symbol> = cc.free_var_syms.iter().copied().collect();
+        // The closure's own parameters/locals (e.g. a WhateverCode's `_` param)
+        // shadow any same-named enclosing binding, so they must NOT be inherited
+        // from the creating frame's env. Capturing the enclosing `_` (a `for`/map
+        // topic) into a `_`-param WhateverCode would leak that stale topic back to
+        // the caller on return (`* ~~ /<$r>/` invoked inside a grep-in-`for`).
+        let own_locals: std::collections::HashSet<&str> =
+            cc.locals.iter().map(|s| s.as_str()).collect();
         // Flatten once (same as `clone_env`), then keep only the upvalue set,
         // shadow-meta, and system names. The base tier (GLOBAL_BASE) is never in
         // the overlay and stays reachable through the flat env's tail lookup.
         let flat = self.clone_env();
         let mut map: std::collections::HashMap<Symbol, Value> = std::collections::HashMap::new();
         for (k, v) in flat.iter() {
-            let keep = free.contains(k) || k.with_str(|s| !crate::env::is_plain_user_lexical(s));
+            let keep = free.contains(k)
+                || k.with_str(|s| !crate::env::is_plain_user_lexical(s) && !own_locals.contains(s));
             if keep {
                 map.insert(*k, v.clone());
             }

--- a/t/block-local-my-scope.t
+++ b/t/block-local-my-scope.t
@@ -128,7 +128,7 @@ plan 24;
     my $x = 99;
     my @c;
     for 1..3 -> $i { my $x = $i; @c.push({ $x }) }
-    is @c.map(*.()).join(','), '1,2,3', 'per-iteration my captured correctly';
+    is @c.map({.()}).join(','), '1,2,3', 'per-iteration my captured correctly';
     is $x, 99, 'closure-capturing loop does not clobber outer $x';
 }
 

--- a/t/loop-body-local-closure-capture.t
+++ b/t/loop-body-local-closure-capture.t
@@ -32,14 +32,14 @@ plan 15;
 {
     my @c;
     for <a b c> { my $s = $_; @c.push({ $s }) }
-    is @c.map(*.()).join(','), 'a,b,c', 'for-list body-local closures';
+    is @c.map({.()}).join(','), 'a,b,c', 'for-list body-local closures';
 }
 
 # for with a named param, body-local derived value
 {
     my @c;
     for 1..3 -> $v { my $y = $v * 2; @c.push({ $y }) }
-    is @c.map(*.()).join(','), '2,4,6', 'for -> body-local derived closures';
+    is @c.map({.()}).join(','), '2,4,6', 'for -> body-local derived closures';
 }
 
 # while loop
@@ -47,14 +47,14 @@ plan 15;
     my @c;
     my $k = 0;
     while $k < 3 { my $z = $k; @c.push({ $z }); $k++ }
-    is @c.map(*.()).join(','), '0,1,2', 'while body-local closures';
+    is @c.map({.()}).join(','), '0,1,2', 'while body-local closures';
 }
 
 # C-style loop
 {
     my @c;
     loop (my $i = 0; $i < 3; $i++) { my $w = $i; @c.push({ $w }) }
-    is @c.map(*.()).join(','), '0,1,2', 'C-style body-local closures';
+    is @c.map({.()}).join(','), '0,1,2', 'C-style body-local closures';
 }
 
 # repeat loop
@@ -62,7 +62,7 @@ plan 15;
     my @c;
     my $m = 0;
     repeat { my $p = $m; @c.push({ $p }); $m++ } while $m < 3;
-    is @c.map(*.()).join(','), '0,1,2', 'repeat body-local closures';
+    is @c.map({.()}).join(','), '0,1,2', 'repeat body-local closures';
 }
 
 # an intervening call between loop and closure invocation must not corrupt it

--- a/t/multitier-overlay-env.t
+++ b/t/multitier-overlay-env.t
@@ -85,7 +85,7 @@ class Loops {
     method collect() {
         my @c;
         for 1..3 -> $i { @c.push({ $i }) }
-        @c.map(*.()).join(',');
+        @c.map({.()}).join(',');
     }
 }
 is Loops.new.collect(), '1,2,3', 'per-iteration capture inside a method';

--- a/t/whatever-rw-and-currying.t
+++ b/t/whatever-rw-and-currying.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 13;
+
+# A bare Whatever passed as a *call argument* is not a curry point; invoking the
+# `+` op routine with it numifies the Whatever, which dies (it does not make a
+# closure). `*(42)` likewise invokes a bare Whatever (no CALL-ME) and dies.
+dies-ok { &infix:<+>(*, 42) }, '&infix:<+>(*, 42) dies (not a closure)';
+dies-ok { &infix:<R+>(*, 42) }, '&infix:<R+>(*, 42) dies (not a closure)';
+dies-ok { *(42) }, '*(42) invokes a bare Whatever and dies';
+
+# WhateverCode parameters are `is raw`: a mutating placeholder writes back to the
+# caller's container.
+{
+    my $*f = 1;
+    my $*g = 2;
+    my sub f ($i) { $i($*f) }
+    my sub g ($i) { $i($*g) }
+    my sub fg ($i) { $i($*f, $*g) }
+    lives-ok { f(*++); g(*--); fg(*++ + *--) }, 'rw WhateverCode calls live';
+    is "$*f $*g", '3 0', 'WhateverCode parameters are rw';
+}
+
+# `*.foo` / read-only currying still curries and stays a Code.
+isa-ok (* + 1), Code, '* + 1 is a WhateverCode';
+is (* + 1)(41), 42, '* + 1 invokes correctly';
+
+# `*++` / `++*` curry into a Code.
+isa-ok (*++), Code, '*++ is some kind of code';
+isa-ok (++*), Code, '++* is some kind of code';
+
+# A WhateverCode stored in a `deepmap` leaf mutates through the leaf container.
+{
+    my @a = (10, 20);
+    my @r = @a.deepmap(*--);
+    is @r[0], 10, 'deepmap(*--) returns the old value';
+    is @a[0], 9, 'deepmap(*--) mutates the source leaf';
+}
+
+# A pointy block can take a `+@` single-argument-rule slurpy parameter.
+{
+    my $b = -> +@foo { @foo.elems };
+    is $b(1, 2, 3), 3, 'pointy block with +@ slurpy parameter';
+}
+
+# A WhateverCode that interpolates an outer lexical only inside a stored regex
+# still captures that lexical (closure free-variable analysis scans regex
+# literals).
+{
+    my @rx = <foo bar>.map(-> $r { * ~~ /<$r>/ });
+    is @rx[0]('foo').so, True, 'regex `<$r>` in WhateverCode captures outer param';
+}


### PR DESCRIPTION
## Summary

Advances `roast/S02-types/whatever.t` from **116-run / 7-fail** (the file aborted mid-run on an uncaught error, losing tests 117–131) to **130-run**, fixing several Whatever/WhateverCode behaviours around container preservation, currying, and closure capture.

## Changes

- **Bare `*` as a call argument no longer curries.** `&infix:<+>(*, 42)` invokes `+` with a Whatever (which dies on numification) instead of building a closure. Only the *target* of a CallOn can curry (`*[0](...)`, `*.foo.(...)`). `arith_add` now errors when an operand is a bare `Whatever`/`HyperWhatever`. (tests 75–76)
- **`*(42)` invokes a bare Whatever** (no `CALL-ME`) and dies, rather than currying. (test 110)
- **WhateverCode parameters bind `is raw`** when the body mutates the placeholder (`*++`, `*--`, `++*`, `* =:= $x`, `*.=foo`), so the mutation / container identity reaches the caller's container. Read-only bodies keep the by-value `_` param to avoid a topic-`_` writeback leak in `for`/grep frames. A `ContainerRef` argument to a raw param (the leaf that `deepmap`/hyper passes by reference) is treated as a writable lvalue, so `@a.deepmap(*--)` keeps mutating through. (tests 108–109)
- **Pointy blocks accept a `+@`/`+%`/`+$`/`+&` single-argument-rule slurpy** parameter (`-> +@foo { ... }`). (test 115)
- **Closure free-variable analysis scans regex literals** for interpolated lexicals, so a WhateverCode that uses an outer parameter only inside a stored regex (`-> $r { * ~~ /<$r>/ }`) captures it. A closure no longer inherits the enclosing `for`/map topic `_` when it declares its own `_` param. (unblocks the mid-file abort)

## Note on `*.()`

`*.()` is now (correctly, matching rakudo, which throws `X::Method::NotFound` for `Whatever`) a bare-Whatever invocation that dies. Three local closure-capture tests relied on the old erroneous currying of `*.()` to mean "call each closure"; they are updated to the idiomatic `.map({.()})`.

## Testing

- `make test`: green except the pre-existing `t/dotassign-store-and-container-topic.t` failure (confirmed failing on `main` too; unrelated to this change).
- New `t/whatever-rw-and-currying.t` (13 assertions) covers the rw params, bare-Whatever invocation, `+@` slurpy, `deepmap(*--)`, and regex-capture behaviours.
- Spot-checked `roast/S32-list/deepmap.t`, `roast/S03-operators/inplace.t`, `roast/S06-signature/slurpy-and-interpolation.t`: all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)