### PR TITLE
fix(vm): `.=` on a read-only topic must throw, not silently bypass

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -210,7 +210,11 @@
   - 3/16 pass (tests 1, 3, 5). Failures: lexical array reset per iteration (2, 4), itemized array in for loop (6-7), `for @a -> $x` argument list (8). Only 8 tests reached. Difficulty: Medium
 - [ ] roast/S04-statements/for.t
   - Fatal: `Module not found: MONKEY-TYPING`. Requires `use MONKEY-TYPING` pragma
-  - 100/111 (was 99). Multi-param pointy blocks now carry a full ParamDef per
+  - 105/111 (was 100). Tests 84/85 (`$_ is read-only here`) FIXED via #3968:
+    `.=` on the topic no longer bypasses the read-only mark unless the topic is a
+    whole-container source (`given @a` / `with %h`); an immutable topic (`for ^N`,
+    `given 42`) now throws as raku does.
+  - Multi-param pointy blocks now carry a full ParamDef per
     param (`params_def` on `Stmt::For`): a short final chunk over required params
     throws `Too few positionals passed; expected N arguments but got M` mid-loop
     (test 49), and `-> $a, $b = 7` applies defaults via an `_.elems > i ?? _[i] !!

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -224,12 +224,21 @@ impl Interpreter {
         code: &CompiledCode,
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
+        // Only a whole-container topic (`given @a` / `with %h`) legitimately
+        // bypasses the read-only mark: `$_` aliases a mutable `@`/`%` source and
+        // the reassigned value is written straight through to it below. When the
+        // topic is a genuinely immutable value (`for ^3`, `given 42`, `for 1,2,3`),
+        // it is read-only with no write-through target, so `.=` must fail with the
+        // usual "Cannot modify an immutable value" error rather than silently
+        // bypassing the mark.
+        let has_container_source = self.topic_container_source.is_some();
         let was_ro = self.is_readonly("_");
-        if was_ro {
+        let bypass = was_ro && has_container_source;
+        if bypass {
             self.unmark_readonly("_");
         }
         let r = self.exec_assign_expr_op(code, name_idx);
-        if was_ro {
+        if bypass {
             self.mark_readonly("_");
         }
         r?;

--- a/t/for-topic-dotassign-readonly.t
+++ b/t/for-topic-dotassign-readonly.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 7;
+
+# A `.=` metaop on the topic must respect read-only topics. When the topic
+# aliases an immutable value (a Range element from `for ^N`, or a bare scalar
+# value in `given`), `.=` must die rather than silently mutate. When it aliases
+# a mutable `@`/`%` container (`given @a`/`with %h`) or a mutable array element
+# (`for @a`), `.=` must write through.
+
+# for over a Range: topic is read-only
+{
+    my $c = 0;
+    dies-ok { for ^8 { .=fmt('%03b'); $c++ } }, 'for ^N: .= on read-only topic dies';
+    is $c, 0, '... and the loop did not advance past the first immutable element';
+}
+
+# given a bare immutable value: topic is read-only
+dies-ok { given 42 { .=succ } }, 'given VALUE: .= on read-only topic dies';
+
+# given @a: topic aliases the whole mutable container, so .= writes through
+{
+    my @a = 1, 2, 3;
+    given @a { .=reverse }
+    is-deeply @a, [3, 2, 1], 'given @a: .= writes through to the container';
+}
+
+# with %h: .= on the whole-hash topic writes through
+{
+    my %h = a => 1, b => 2;
+    with %h { .=Hash }
+    is %h<a>, 1, 'with %h: .= keeps the container usable';
+}
+
+# for @a: topic aliases a mutable array element, so .= mutates it
+{
+    my @a = 1, 2, 3;
+    for @a { .=succ }
+    is-deeply @a, [2, 3, 4], 'for @a: .= mutates each array element';
+}
+
+# for @a: plain assignment to the topic also writes through (sanity)
+{
+    my @a = 1, 2, 3;
+    for @a { $_ = 99 }
+    is-deeply @a, [99, 99, 99], 'for @a: $_ = ... writes through';
+}


### PR DESCRIPTION
## Summary

`exec_topic_dot_assign_op` unconditionally cleared the read-only mark on `$_` before performing the assignment, so the `.=` metaop on a genuinely immutable topic silently mutated a throwaway copy instead of dying:

- `for ^8 { .=fmt('%03b') }` — Range elements are immutable
- `given 42 { .=succ }` — a bare scalar value is read-only

raku throws `Cannot modify an immutable Int (...)` in both cases.

The read-only bypass is only legitimate for a **whole-container** topic (`given @a` / `with %h`), where `$_` aliases a mutable `@`/`%` source and the reassigned value is written straight through to it. This PR gates the bypass on `topic_container_source.is_some()`; when there is no write-through target, the read-only mark is respected and the assignment fails as expected.

## Tests

- Fixes `roast/S04-statements/for.t` tests 84/85 (`$_ is read-only here` / `... and $_ is *always* read-only here`) — for.t now at 105/111 (6 remaining are the deep slurpy-raw / lazy / slice-writeback cases).
- New pin test `t/for-topic-dotassign-readonly.t` covers: read-only Range topic, read-only `given VALUE`, write-through `given @a` / `with %h`, and per-element `for @a` mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)