### PR TITLE
fix(decl): same-scope `my` redeclaration without initializer is a value-preserving noop

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -85,6 +85,26 @@
     `my`/`our` decl with a conditional modifier is split into
     `my $x; ($x = INIT) if COND` (`try_split_decl_modifier`). Test:
     t/conditional-my-declaration.t.
+  - Same-scope redeclaration noop now works: redeclaring an existing `my`
+    variable WITHOUT an explicit initializer (`my $f; ...; my $f;` or
+    `my Int $f;`) is a value-preserving no-op (only a "Redeclaration of symbol"
+    warning in Raku). Tracked per-block via `my_vars_current_scope`; the bare
+    redeclaration suppresses the SetLocal reset. Fixed "two lexicals declared in
+    scope is noop" (line 161). Test: t/redeclare-my-noop.t.
+  - Remaining 10 failures are distinct deep features, NOT scope-leak:
+    (1) compile-time forward-reference detection — `$foo` used before `my $foo`
+    in the same statement should throw X::Undeclared (lines 12/19/20); mutsu has
+    no general undeclared-var analysis.
+    (2) EVAL sees the caller pad including later-declared lexicals (lines
+    194/229) — `my` symbols are visible from block start (CHECK time) even
+    before their initializer runs.
+    (3) `our sub` accessing a block lexical before/after the block runs
+    (lines 274/280).
+    (4) undeclared routine checked before run time (line 316).
+    (5) anonymous `my &` should default to the `Callable` type object, not
+    `Any` (line 338).
+    (6) `my sub {42}()` anonymous-sub immediate-call parse (line 363).
+    (7) sigilless assignment subtest (line 404).
   - **Block-local `my` leak fixed** (this PR): a fresh `my $x` declared in an
     `if`/`while` branch no longer leaks into the enclosing scope. The branch
     `BlockLocalScope` op (`exec_block_local_scope_op`) used a shadow-only

--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -8,6 +8,7 @@ pub(super) struct LexicalScopeSnapshot {
     dynamic_scope_names: Option<std::collections::HashSet<String>>,
     constant_vars_in_scope: std::collections::HashSet<String>,
     constant_vars_current_scope: std::collections::HashSet<String>,
+    my_vars_current_scope: std::collections::HashSet<String>,
 }
 
 impl Compiler {
@@ -24,6 +25,9 @@ impl Compiler {
             dynamic_scope_names: self.dynamic_scope_names.clone(),
             constant_vars_in_scope: self.constant_vars_in_scope.clone(),
             constant_vars_current_scope: std::mem::take(&mut self.constant_vars_current_scope),
+            // The entered block starts with no `my` vars of its own, so a same-named
+            // `my` inside it shadows (rather than redeclares) an outer one.
+            my_vars_current_scope: std::mem::take(&mut self.my_vars_current_scope),
         }
     }
 
@@ -36,6 +40,7 @@ impl Compiler {
         // then resolves them via GetBareWord (package/global lookup).
         self.constant_vars_in_scope = saved.constant_vars_in_scope;
         self.constant_vars_current_scope = saved.constant_vars_current_scope;
+        self.my_vars_current_scope = saved.my_vars_current_scope;
     }
 
     pub(super) fn apply_dynamic_scope_pragma(&mut self, arg: Option<&Expr>) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -103,6 +103,14 @@ pub(crate) struct Compiler {
     /// entry). Declaring the same constant twice in one block is an
     /// X::Redeclaration; a shadowing declaration in an inner block is allowed.
     constant_vars_current_scope: std::collections::HashSet<String>,
+    /// Plain `my` variable names declared in the *current* lexical block only
+    /// (reset on block entry). Redeclaring an existing same-scope `my` variable
+    /// *without* an explicit initializer (`my $f` / `my Int $f`) is a no-op in
+    /// Raku — the variable keeps its current value (only a "Redeclaration of
+    /// symbol" warning is emitted). A redeclaration *with* an initializer
+    /// (`my $f = 10`) does run the assignment. Tracked here so the VarDecl
+    /// compiler can suppress the reset for the bare-redeclaration case.
+    my_vars_current_scope: std::collections::HashSet<String>,
     /// Names of constants declared in an *enclosing* compiler (i.e. visible at a
     /// nested closure's definition point). Propagated into child closure
     /// compilers (which otherwise start with empty constant state). Used ONLY to
@@ -183,6 +191,7 @@ impl Compiler {
             constant_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
             constant_vars_current_scope: std::collections::HashSet::new(),
+            my_vars_current_scope: std::collections::HashSet::new(),
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -804,6 +804,43 @@ impl Compiler {
                     self.code.emit(OpCode::Die);
                     return;
                 }
+                // Raku: redeclaring an existing same-scope `my` variable WITHOUT
+                // an explicit initializer (`my $f` / `my Int $f`) is a no-op — the
+                // variable keeps its current value (only a "Redeclaration of symbol"
+                // warning would be emitted). A redeclaration WITH an initializer
+                // (`my $f = 10`) still runs the assignment. `state`/`our`/`constant`
+                // and `:=` binds have their own semantics and are excluded; a
+                // `where`-constrained decl is desugared into a subset above and must
+                // run. Tracking per-scope `my` names lets the bare-redeclaration
+                // case suppress the reset that would otherwise clobber the value.
+                let is_plain_my = !*is_state
+                    && !*is_our
+                    && !is_constant_decl
+                    && !self.bind_vardecl
+                    && where_constraint.is_none();
+                if is_plain_my {
+                    let has_init = custom_traits.iter().any(|(n, _)| n == "__has_initializer");
+                    // Only the default-init form (a bare `my $f;` / `my Int $f;` /
+                    // `my @a;` / `my %h;`, whose RHS is the synthesized empty type
+                    // default) is a value-preserving no-op. A decl with a real RHS
+                    // expression — including internal desugared temps like
+                    // `@__destructure_tmp__` (an `Expr::ArrayLiteral`) that
+                    // legitimately re-run on each `my (...)` destructure — must always
+                    // execute. The synthesized defaults are, by sigil: `Literal(Nil)`
+                    // ($ / &), an empty `Literal(Array)` (@), and an empty
+                    // `Expr::Hash` (%).
+                    let is_default_init = !has_init
+                        && match expr {
+                            Expr::Literal(Value::Nil) => true,
+                            Expr::Literal(Value::Array(ad, _)) => ad.items.is_empty(),
+                            Expr::Hash(pairs) => pairs.is_empty(),
+                            _ => false,
+                        };
+                    let already_declared = !self.my_vars_current_scope.insert(name.clone());
+                    if already_declared && is_default_init {
+                        return;
+                    }
+                }
                 let is_dynamic = *is_dynamic || self.var_is_dynamic(name);
                 let name_idx = self.code.add_constant(Value::str(name.clone()));
                 self.code.emit(OpCode::SetVarDynamic {

--- a/t/redeclare-my-noop.t
+++ b/t/redeclare-my-noop.t
@@ -1,0 +1,59 @@
+use Test;
+
+# Redeclaring an existing same-scope `my` variable WITHOUT an explicit
+# initializer is a no-op in Raku: the variable keeps its current value
+# (only a "Redeclaration of symbol" warning is emitted). A redeclaration
+# WITH an initializer still runs the assignment.
+
+plan 9;
+
+# bare redeclaration preserves the value
+{
+    my $f;
+    $f = 5;
+    my $f; #OK
+    is $f, 5, 'bare redeclaration of $f preserves value';
+}
+
+# typed redeclaration without initializer is also a no-op
+{
+    my $g = 7;
+    my Int $g; #OK
+    is $g, 7, 'typed redeclaration without initializer preserves value';
+}
+
+# redeclaration WITH an initializer runs the assignment
+{
+    my $h = 1;
+    my $h = 2; #OK
+    is $h, 2, 'redeclaration with initializer runs assignment';
+}
+
+# a fresh declaration still resets to the type default
+{
+    my $x = 9;
+    is $x, 9, 'fresh declaration with initializer';
+    my $y;
+    nok $y.defined, 'fresh bare declaration is undefined';
+}
+
+# nested-block shadowing is unaffected (inner is a fresh, undefined var)
+{
+    my $z = 3;
+    {
+        my $z; #OK
+        nok $z.defined, 'inner shadow is a fresh undefined var';
+    }
+    is $z, 3, 'outer value restored after shadow block';
+}
+
+# array/hash bare redeclaration preserves contents
+{
+    my @a = 1, 2, 3;
+    my @a; #OK
+    is @a.join(','), '1,2,3', 'bare @-redeclaration preserves elements';
+
+    my %m = a => 1;
+    my %m; #OK
+    is %m<a>, 1, 'bare %-redeclaration preserves pairs';
+}


### PR DESCRIPTION
## What

In Raku, redeclaring an existing same-scope `my` variable **without** an explicit initializer (`my $f; ...; my $f;`, or `my Int $f;`) is a no-op — the variable keeps its current value (only a "Redeclaration of symbol" warning is emitted). A redeclaration **with** an initializer (`my $f = 10`) still runs the assignment.

Previously mutsu re-ran the default-init on the redeclaration, clobbering the value with the type default (`Nil` / empty `Array` / empty `Hash`).

```raku
my $f; $f = 5; my $f; say $f;   # was: (empty) — now: 5
my @a = 1,2,3; my @a; say @a;   # was: []      — now: [1 2 3]
my $h = 1; my $h = 2; say $h;   # 2 (initializer redecl still runs)
```

## How

Track plain `my` variable names per lexical block in a new `my_vars_current_scope` set, reset on block entry via the existing `push/pop_dynamic_scope_lexical` snapshot (mirroring the constant scope tracking). When a plain `my` decl (not `state`/`our`/`constant`/`:=`-bind/`where`) redeclares a same-scope name **and** its RHS is the synthesized empty type default, suppress the `SetLocal` reset.

The synthesized-default RHS is matched by sigil (`Literal(Nil)` for `$`/`&`, empty `Literal(Array)` for `@`, empty `Expr::Hash` for `%`) so decls with a real RHS — including internal desugared temps like `@__destructure_tmp__` (an `Expr::ArrayLiteral`) that legitimately re-run on each `my (...)` destructure — are unaffected. Nested-block shadowing is unaffected (the set is reset on block entry).

## Result

- `roast/S04-declarations/my-6e.t`: 11 → 10 failures (fixes "two lexicals declared in scope is noop", line 161).
- Remaining 10 failures are distinct deep features (EVAL pad visibility, compile-time forward-ref detection, `our sub` lexical capture, anon `my &` default, parse edge cases) — documented in `TODO_roast/S04.md`.
- New test `t/redeclare-my-noop.t` (9 cases); `make test` green (only pre-existing flaky `t/dotassign-store-and-container-topic.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)