### PR TITLE
fix(io): IO::CatHandle comb/split/.IO dispatch + hyper colon-args

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -685,18 +685,36 @@
        `$_ = …` assignment, which trips the outer loop's read-only `$_` mark. Fixed:
        those branches now establish the fresh topic via `given` (like the first
        `with` clause already did). (t/with-orwith-in-loop.t)
-  - **Remaining 23 subtests — per-method IO::CatHandle feature gaps** (deeper,
-    each its own work item):
+  - **2026-06-30: comb/split/lines/get/read/opened fixed (23→16 failing).** Five
+    general/cathandle fixes (see t/io-cathandle-read-dispatch.t):
+    1. `cat.comb($matcher)` / `.split` returned the cat's `.Str` ("IO::CatHandle()")
+       for string/regex matchers — the native string-coercion dispatch guards that
+       defer Supply/IO::Handle/IO::Path/IO::Pipe did not include `IO::CatHandle`, so
+       those methods stringified the cat instead of slurping. Added `IO::CatHandle`
+       to all six guard sites (comb/split 1-/2-arg, dispatch_match, call_dispatch).
+    2. `.IO` on an IO handle reached via the slow path (e.g. an array element,
+       `@h[0].IO`, used by `make-files`' `.= IO`) hit the generic `"IO"` coercion arm
+       that stringifies the receiver → `IO::Path.new("IO::Handle()")`. The arm now
+       defers IO::Handle/IO::Pipe/IO::CatHandle to their own `.IO` method. This was a
+       general bug affecting any handle not held in a plain scalar.
+    3. Hyper method call with colon-arg syntax (`@x».join: "-"`) failed to parse; the
+       static-name hyper path only handled `»name(args)` / `»name`. Added colon-arg /
+       adverb handling mirroring the regular `.method:` path.
+    4. `cat.lines($limit)` / `.lines(:close)` now honour the positional limit and the
+       `:close` adverb (shared `cat_close` helper).
+    5. `cat.read` returns `Buf[uint8]` (was generic `Buf`) and defaults to a 65536-byte
+       chunk when called with no count; `.opened` now reflects active-handle presence
+       (False on an empty/exhausted cat).
+  - **Remaining 16 subtests — deeper per-method gaps** (each its own work item):
     - dynamic `chomp`/`nl-in` changes are not applied to the already-active handle
       (only to handles opened afterward) — chomp/nl-in subtest.
-    - `cat.comb($matcher)` / words / split / lines / get with non-trivial args
-      sometimes return the cat's `.Str` ("IO::CatHandle()") instead of slurped
-      content for certain random source mixes — a per-arg dispatch / read-position
-      bug with already-opened handle sources.
     - `getc` does not cluster combining marks into graphemes.
-    - binary `read`/`readchars` across handles (Buf vs decoded) is incomplete.
-    - `seek`/`tell`, `Supply`, `native-descriptor`, `t`, `on-switch` are stubbed or
-      missing.
+    - binary mode (`:bin`): char reads must throw `X::IO::BinaryMode` (new exception,
+      also needed on IO::Handle); binary `slurp` must return a `Buf`.
+    - `utf8-c8` encoding is unsupported (encoding/slurp subtests).
+    - `seek`/`tell`, `Supply`, `native-descriptor`, `t`, `on-switch`, `next-handle`
+      callback counting, `.raku` round-trip (perl), user subclassing (new),
+      `handles` lazy list, and `path`/`IO` IO::Path identity remain stubbed/missing.
 - [x] roast/S32-io/io-handle.t — **30/30, whitelisted.** All subtests pass.
       29 `.WRITE` / 30 `.EOF/.WRITE` fixed: a user-subclassed IO::Handle that
       overrides WRITE/READ/EOF now routes the high-level methods through the user

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -486,7 +486,8 @@ pub(crate) fn native_method_1arg(
             if let Value::Instance { class_name, .. } = target
                 && (class_name == "Supply"
                     || class_name == "IO::Handle"
-                    || class_name == "IO::Pipe")
+                    || class_name == "IO::Pipe"
+                    || class_name == "IO::CatHandle")
             {
                 return None;
             }
@@ -504,7 +505,8 @@ pub(crate) fn native_method_1arg(
                 && (class_name == "Supply"
                     || class_name == "IO::Handle"
                     || class_name == "IO::Path"
-                    || class_name == "IO::Pipe")
+                    || class_name == "IO::Pipe"
+                    || class_name == "IO::CatHandle")
             {
                 return None;
             }

--- a/src/builtins/methods_narg/dispatch_2arg.rs
+++ b/src/builtins/methods_narg/dispatch_2arg.rs
@@ -80,7 +80,10 @@ pub(crate) fn native_method_2arg(
 
     if method == "split" {
         if let Value::Instance { class_name, .. } = target
-            && (class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe")
+            && (class_name == "Supply"
+                || class_name == "IO::Handle"
+                || class_name == "IO::Pipe"
+                || class_name == "IO::CatHandle")
         {
             return None;
         }
@@ -98,7 +101,8 @@ pub(crate) fn native_method_2arg(
             && (class_name == "Supply"
                 || class_name == "IO::Handle"
                 || class_name == "IO::Path"
-                || class_name == "IO::Pipe")
+                || class_name == "IO::Pipe"
+                || class_name == "IO::CatHandle")
         {
             return None;
         }

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -2390,6 +2390,54 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     rest = r;
                     continue;
                 }
+                // Colon-arg syntax: »name: arg, arg2 (no space before the colon).
+                // A space before ':' means an adverb (colon-pair) argument instead.
+                let has_space_before_colon =
+                    r.starts_with(' ') || r.starts_with('\t') || r.starts_with('\n');
+                let (r_cln, _) = ws(r)?;
+                if r_cln.starts_with(':') && !r_cln.starts_with("::") {
+                    let (r3, first_arg) = if has_space_before_colon {
+                        colonpair_expr(r_cln)?
+                    } else {
+                        let r3 = &r_cln[1..];
+                        let (r3, _) = ws(r3)?;
+                        listop_arg_expr(r3)?
+                    };
+                    let mut args = vec![first_arg];
+                    let mut r_inner = r3;
+                    loop {
+                        let (r4, _) = ws(r_inner)?;
+                        if r4.starts_with(':')
+                            && !r4.starts_with("::")
+                            && let Ok((r5, next)) = colonpair_expr(r4)
+                        {
+                            args.push(next);
+                            r_inner = r5;
+                            continue;
+                        }
+                        if !r4.starts_with(',') {
+                            break;
+                        }
+                        let r4 = &r4[1..];
+                        let (r4, _) = ws(r4)?;
+                        if r4.starts_with(';') || r4.starts_with('}') || r4.is_empty() {
+                            r_inner = r4;
+                            break;
+                        }
+                        let (r4, next) = listop_arg_expr(r4)?;
+                        args.push(next);
+                        r_inner = r4;
+                    }
+                    expr = Expr::HyperMethodCall {
+                        target: Box::new(expr),
+                        name,
+                        args,
+                        modifier,
+                        quoted: false,
+                    };
+                    rest = r_inner;
+                    continue;
+                }
                 expr = Expr::HyperMethodCall {
                     target: Box::new(expr),
                     name,

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2803,7 +2803,7 @@ impl Interpreter {
         // Skip for Supply (handled by Supply pipeline) and IO::Handle/IO::Pipe
         // (handled by native IO dispatch which reads the content first).
         if method == "split"
-            && !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe")
+            && !matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe" || class_name == "IO::CatHandle")
             && !matches!(&target, Value::Package(name) if name.resolve().starts_with("IO::Spec"))
         {
             return self.handle_split_method(target, args);

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -179,7 +179,7 @@ impl Interpreter {
                     Some(self.dispatch_supply_transform(target, "comb", &args))
                 } else if matches!(&target, Value::Instance { class_name, .. }
                     if matches!(class_name.resolve().as_str(),
-                        "IO::Handle" | "IO::Path" | "IO::Pipe"))
+                        "IO::Handle" | "IO::Path" | "IO::Pipe" | "IO::CatHandle"))
                 {
                     // Defer to native IO dispatch so file content is read first.
                     None
@@ -198,6 +198,14 @@ impl Interpreter {
                                 if k.to_string_value() == "CWD" || k.to_string_value() == "SPEC")
                 }) =>
             {
+                // IO handle objects have their own `.IO` (returning the path of
+                // the open file); never coerce them via stringification.
+                if matches!(&target, Value::Instance { class_name, .. }
+                    if matches!(class_name.resolve().as_str(),
+                        "IO::Handle" | "IO::Pipe" | "IO::CatHandle"))
+                {
+                    return None;
+                }
                 // `.IO` on an IO::Path (sub)class type object returns the type
                 // object itself, so `IO::Path::Unix === IO::Path::Unix.IO`.
                 if let Value::Package(name) = &target {

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -277,17 +277,71 @@ impl Interpreter {
         Ok(Value::str(out))
     }
 
-    /// Collect all remaining lines into a Seq.
-    fn cat_lines(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
-        let mut lines = Vec::new();
-        loop {
-            let line = self.cat_get(attrs)?;
-            if matches!(line, Value::Nil) {
-                break;
+    /// Collect remaining lines into a Seq, honouring an optional positional
+    /// `$limit` (max number of lines) and a `:close` named arg.
+    fn cat_lines(
+        &mut self,
+        attrs: &mut HashMap<String, Value>,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let mut limit: Option<i64> = None;
+        let mut close = false;
+        for arg in args {
+            match arg {
+                Value::Pair(k, v) if k == "close" => close = v.truthy(),
+                Value::Int(n) => limit = Some(*n),
+                _ => {}
             }
-            lines.push(line);
+        }
+        let mut lines = Vec::new();
+        if limit != Some(0) {
+            loop {
+                if let Some(n) = limit
+                    && lines.len() as i64 >= n
+                {
+                    break;
+                }
+                let line = self.cat_get(attrs)?;
+                if matches!(line, Value::Nil) {
+                    break;
+                }
+                lines.push(line);
+            }
+        }
+        if close {
+            self.cat_close(attrs);
         }
         Ok(Value::Seq(std::sync::Arc::new(lines)))
+    }
+
+    /// Close the active handle and all `IO::Handle` sources, marking the cat
+    /// closed. Shared by `.close`/`.DESTROY` and `:close` read adverbs.
+    fn cat_close(&mut self, attrs: &mut HashMap<String, Value>) {
+        if let Some(active @ Value::Instance { class_name, .. }) =
+            attrs.get("active").cloned().as_ref()
+            && class_name == "IO::Handle"
+        {
+            let _ = self.close_handle_value(active);
+        }
+        let handle_sources: Vec<Value> = match attrs.get("sources") {
+            Some(Value::Array(items, ..)) => items
+                .iter()
+                .filter(|v| matches!(v, Value::Instance { class_name, .. } if class_name == "IO::Handle"))
+                .cloned()
+                .collect(),
+            _ => Vec::new(),
+        };
+        for src in &handle_sources {
+            let _ = self.close_handle_value(src);
+        }
+        attrs.insert("active".to_string(), Value::Nil);
+        attrs.insert("path".to_string(), Value::Nil);
+        attrs.insert("closed".to_string(), Value::Bool(true));
+        let pos = match attrs.get("sources") {
+            Some(Value::Array(items, ..)) => items.len() as i64,
+            _ => 0,
+        };
+        attrs.insert("pos".to_string(), Value::Int(pos));
     }
 
     /// Mutable dispatch for `IO::CatHandle` methods. All reads advance internal
@@ -303,7 +357,7 @@ impl Interpreter {
         let result = match method {
             "get" => self.cat_get(&mut attrs)?,
             "getc" => self.cat_getc(&mut attrs)?,
-            "lines" => self.cat_lines(&mut attrs)?,
+            "lines" => self.cat_lines(&mut attrs, &args)?,
             "slurp" => self.cat_slurp(&mut attrs)?,
             "words" => {
                 let text = match self.cat_slurp(&mut attrs)? {
@@ -370,7 +424,9 @@ impl Interpreter {
             "read" => {
                 // Read up to N bytes across handles, switching when one is
                 // exhausted but only while more bytes are still wanted.
-                let want = args.first().and_then(val_int).unwrap_or(0).max(0) as usize;
+                // `.read` with no explicit count uses IO::Handle's default chunk
+                // size (65536 bytes), matching rakudo.
+                let want = args.first().and_then(val_int).unwrap_or(65536).max(0) as usize;
                 let mut bytes: Vec<u8> = Vec::new();
                 while bytes.len() < want {
                     let active = self.cat_ensure_active(&mut attrs);
@@ -397,41 +453,12 @@ impl Interpreter {
                     }
                     bytes.extend_from_slice(&chunk_bytes);
                 }
-                let mut battrs: HashMap<String, Value> = HashMap::new();
-                battrs.insert(
-                    "bytes".to_string(),
-                    Value::array(bytes.iter().map(|b| Value::Int(*b as i64)).collect()),
-                );
-                Value::make_instance(Symbol::intern("Buf"), battrs)
+                // `.read` always returns a `Buf[uint8]` (buf8) in Raku.
+                Self::make_buf(bytes)
             }
             "next-handle" => self.cat_next_handle(&mut attrs),
             "close" | "DESTROY" => {
-                if let Some(active @ Value::Instance { class_name, .. }) =
-                    attrs.get("active").cloned().as_ref()
-                    && class_name == "IO::Handle"
-                {
-                    let _ = self.close_handle_value(active);
-                }
-                // Close any remaining un-opened IO::Handle sources too.
-                let handle_sources: Vec<Value> = match attrs.get("sources") {
-                    Some(Value::Array(items, ..)) => items
-                        .iter()
-                        .filter(|v| matches!(v, Value::Instance { class_name, .. } if class_name == "IO::Handle"))
-                        .cloned()
-                        .collect(),
-                    _ => Vec::new(),
-                };
-                for src in &handle_sources {
-                    let _ = self.close_handle_value(src);
-                }
-                attrs.insert("active".to_string(), Value::Nil);
-                attrs.insert("path".to_string(), Value::Nil);
-                attrs.insert("closed".to_string(), Value::Bool(true));
-                let pos = match attrs.get("sources") {
-                    Some(Value::Array(items, ..)) => items.len() as i64,
-                    _ => 0,
-                };
-                attrs.insert("pos".to_string(), Value::Int(pos));
+                self.cat_close(&mut attrs);
                 Value::Bool(true)
             }
             "eof" => {
@@ -454,7 +481,17 @@ impl Interpreter {
                     }
                 }
             }
-            "opened" => Value::Bool(!attrs.get("closed").is_some_and(|v| v.truthy())),
+            "opened" => {
+                // `.opened` reflects whether there is currently an active source
+                // handle: a closed/exhausted cat (or one with no sources) is not
+                // open. Opening the first source on demand matches rakudo.
+                if attrs.get("closed").is_some_and(|v| v.truthy()) {
+                    Value::Bool(false)
+                } else {
+                    let active = self.cat_ensure_active(&mut attrs);
+                    Value::Bool(matches!(active, Value::Instance { .. }))
+                }
+            }
             "chomp" => {
                 if let Some(arg) = args.into_iter().next() {
                     attrs.insert("chomp".to_string(), arg.clone());

--- a/t/io-cathandle-read-dispatch.t
+++ b/t/io-cathandle-read-dispatch.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 12;
+
+# --- General fix 1: hyper method call with colon-arg syntax (»name: args) ---
+my @joined = (('a', 'b'), ('c', 'd'))».join: '-';
+is-deeply @joined, ['a-b', 'c-d'], 'hyper method call with colon-arg syntax';
+my @subs = <foo bar baz>».substr: 0, 2;
+is-deeply @subs, ['fo', 'ba', 'ba'],
+    'hyper method colon-args with multiple positionals';
+
+# --- General fix 2: .IO on an IO::Handle stored in an array element must
+# dispatch the handle's .IO (returning its path), not stringify the handle. ---
+{
+    my $f = 'tmp/cathandle-dispatch-a.txt'.IO;
+    $f.spurt('hi');
+    my @h = ($f.open,);
+    isa-ok @h[0].IO, IO::Path, '.IO on array-element handle returns an IO::Path';
+    is @h[0].IO.absolute, $f.absolute,
+        '.IO on array-element handle yields the open file path';
+    @h[0].close;
+}
+
+# --- IO::CatHandle read methods across a mix of source types ---
+{
+    my $a = 'tmp/cathandle-a.txt'.IO; $a.spurt("a\nb\nc");
+    my $b = 'tmp/cathandle-b.txt'.IO; $b.spurt("d\ne");
+    my $c = 'tmp/cathandle-c.txt'.IO; $c.spurt("f\ng\nh");
+
+    is-deeply IO::CatHandle.new($a, $b, $c).lines.List,
+        <a b c d e f g h>.List, 'cat .lines reads across handles';
+
+    is-deeply IO::CatHandle.new($a, $b, $c).lines(3).List,
+        <a b c>.List, 'cat .lines($limit) honours the limit';
+
+    is-deeply IO::CatHandle.new($a, $b, $c).lines(0).List,
+        ().List, 'cat .lines(0) returns nothing';
+
+    is IO::CatHandle.new($a, $b, $c).slurp, "a\nb\ncd\nef\ng\nh",
+        'cat .slurp concatenates content';
+
+    # comb with a string/regex matcher reads file content, not the object gist.
+    is-deeply IO::CatHandle.new($a).comb(/\w/).List, <a b c>.List,
+        'cat .comb(Regex) reads handle content';
+
+    # split likewise.
+    is-deeply IO::CatHandle.new($a).split("\n").List, <a b c>.List,
+        'cat .split(Str) reads handle content';
+
+    # .opened reflects active-handle presence.
+    is-deeply IO::CatHandle.new.opened, False, 'empty cat is not opened';
+
+    # .read with no count uses a sane default and yields a Buf[uint8].
+    is-deeply IO::CatHandle.new($a).read, Buf[uint8].new("a\nb\nc".encode),
+        'cat .read default size returns Buf[uint8]';
+}


### PR DESCRIPTION
## Summary

Five fixes around `IO::CatHandle` read-method dispatch and a hyper-method parser gap, taking `roast/S32-io/io-cathandle.t` from **7 → 15** passing subtests. Three of the fixes are general (not cathandle-specific).

The supervisor task targeted `roast/S32-io/io-handle.t`, but that test already passes 30/30 and is whitelisted (landed in #3903); `lock.t` likewise landed (#3952). The genuine remaining sibling in the IO trio is `io-cathandle.t`, so this PR advances it.

## Fixes

1. **comb/split stringified the cat.** `cat.comb($matcher)` / `.split` with a string or regex matcher returned the cat's `.Str` (`"IO::CatHandle()"`) instead of reading its content — the native string-coercion guards that defer `Supply`/`IO::Handle`/`IO::Path`/`IO::Pipe` did not include `IO::CatHandle`. Added it to all six guard sites.

2. **`.IO` on a slow-path handle stringified the receiver.** `@h[0].IO` (an `IO::Handle` reached via the slow path, e.g. an array element — as `make-files` does via `.= IO`) hit the generic `"IO"` coercion arm and produced `IO::Path.new("IO::Handle()")`. The arm now defers `IO::Handle`/`IO::Pipe`/`IO::CatHandle` to their own `.IO` method. **General bug** for any handle not held in a plain scalar.

3. **Hyper method colon-args.** `@x».join: "-"` failed to parse — the static-name hyper path only handled `»name(args)` / `»name`. Added colon-arg / adverb handling mirroring the regular `.method:` path. **General parser feature.**

4. **`IO::CatHandle.lines`** now honours a positional `$limit` and the `:close` adverb (shared `cat_close` helper).

5. **`IO::CatHandle.read`** returns `Buf[uint8]` (was generic `Buf`) and defaults to a 65536-byte chunk; **`.opened`** reflects active-handle presence.

## Tests

- New `t/io-cathandle-read-dispatch.t` (12 assertions covering all five fixes).
- Regression-checked whitelisted hyper/comb/split/IO roast tests (`S03-metaops/*`, `S07-hyperrace/for.t`, `S32-io/io-handle.t`, `S32-io/io-path.t`, `S32-str/{comb,split}.t`, `S05-substitution/subst.t`) — all PASS.
- `io-cathandle.t` is **not** whitelisted here: 16 subtests still fail (binary-mode exceptions, utf8-c8, seek/tell, Supply, user subclassing, perl round-trip, …), tracked in `TODO_roast/S32.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)