### PR TITLE
fix(wrap): resolve seven S06-advanced/wrap.t blockers (88/90 pass)

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -35,10 +35,19 @@
 - [ ] roast/S06-advanced/return.t
 - [ ] roast/S06-advanced/stub.t
 - [ ] roast/S06-advanced/wrap.t
-  - 65/69 pass (4 failures); 21 subtests not run (require advanced features like trait_mod, MOP)
-  - Test 63,66: Closure lexical write-back in wrappers (general closure scoping issue)
-  - Test 68: sub redeclaration in inner block scope (X::Redeclaration error)
-  - Test 69: `reverse ^3` returns Any (missing reverse on ranges)
+  - 88/90 run, all pass except TODO 57/58 (`temp`+`wrap` scope removal, `#?rakudo todo`).
+    Only tests 89-90 fail (file aborts at 89).
+  - Fixed (this PR): wrapped-sub-as-bareword-arg bypassed wrap chain (light-call cache +
+    `vm_call_on_value` fast path); `my $foo = foo.new` name collision (Nil `$foo` shadowed
+    type `foo`); `sub foo` + inner `my class foo` parsed `foo.new` as `foo().new`;
+    `try $obj.x = v` lvalue desugar; `set_rw` Attribute method; `my method`/`my sub NAME {}`
+    now evaluate to the routine; single-method `^find_method().wrap()` now participates in
+    `nextsame` MRO dispatch.
+  - Tests 89-90 (BLOCKED): `^find_method('bar').candidates` must return the FULL-MRO
+    candidate list sorted by specificity (Rakudo's `candidates[0]` is the inherited
+    `C1: Str $s`, mutsu returns only C2's own `C2: Str:D $s`), so the multi-method wrapper
+    is attached to the wrong candidate and fires at the wrong position. Needs cross-MRO
+    multi-candidate collection in classhow_lookup — broad blast radius, deferred.
 - [ ] roast/S06-currying/assuming-and-mmd.t
 - [ ] roast/S06-currying/misc.t
 - [ ] roast/S06-currying/named.t

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -502,6 +502,24 @@ impl Compiler {
                     self.compile_expr(&Expr::Var(name.clone()));
                 }
             }
+            Stmt::SubDecl {
+                name,
+                name_expr: None,
+                ..
+            }
+            | Stmt::MethodDecl {
+                name,
+                name_expr: None,
+                ..
+            } if !name.resolve().is_empty() => {
+                // A named sub/method declaration in expression position
+                // (`my sub foo {...}`, `my method foo {...}`) registers the routine
+                // and evaluates to the routine object itself (raku: a Sub / Method
+                // value), so it can be stored or passed (e.g. to `.wrap`).
+                self.compile_stmt(stmt);
+                let name_idx = self.code.add_constant(Value::str(name.resolve()));
+                self.code.emit(OpCode::GetCodeVar(name_idx));
+            }
             _ => {
                 self.compile_stmt(stmt);
                 self.code.emit(OpCode::LoadNil);

--- a/src/parser/expr/postfix/call_method.rs
+++ b/src/parser/expr/postfix/call_method.rs
@@ -7,6 +7,13 @@ pub(crate) fn auto_invoke_bareword_method_target(expr: Expr) -> Expr {
     let Expr::BareWord(name) = expr else {
         return expr;
     };
+    // When a name is declared as a type (class/role/grammar/enum) in scope, a
+    // bareword-dot like `foo.new` is a method call on the type object, NOT a
+    // call to a same-named sub. The type shadows the sub for this syntax — e.g.
+    // a file-scope `sub foo` plus an inner `my class foo` (S06-advanced/wrap.t).
+    if crate::parser::stmt::simple::is_user_declared_type(&name) {
+        return Expr::BareWord(name);
+    }
     if crate::parser::stmt::simple::is_user_declared_sub(&name)
         || crate::parser::stmt::simple::is_imported_function(&name)
     {

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -29,6 +29,48 @@ use super::predicates::{
 };
 use super::sig_info::{SigParamInfo, extract_signature_param_infos, extract_static_named_map};
 
+/// Desugar `LVALUE = RHS` for a method-call / sub-call / callable lvalue into the
+/// corresponding `__mutsu_assign_*` call expression. Mirrors the inline handling
+/// of the main `=` assignment path; factored out so a statement-prefix-wrapped
+/// lvalue (`try $obj.x = v`) can push the assignment *inside* the prefix.
+fn lvalue_assign_to_expr(lvalue: Expr, rhs: Expr) -> Expr {
+    match lvalue {
+        Expr::MethodCall {
+            target,
+            name,
+            args,
+            modifier,
+            quoted: _,
+        } => {
+            if name == "AT-POS" && args.len() == 1 {
+                Expr::IndexAssign {
+                    target: target.clone(),
+                    index: Box::new(args[0].clone()),
+                    value: Box::new(rhs),
+                    is_positional: true,
+                }
+            } else {
+                let target_var_name = match target.as_ref() {
+                    Expr::Var(v) => Some(v.clone()),
+                    Expr::ArrayVar(v) => Some(format!("@{}", v)),
+                    Expr::HashVar(v) => Some(format!("%{}", v)),
+                    Expr::DoStmt(s) => decl_target_var_name(s),
+                    _ => None,
+                };
+                let method_name = if modifier == Some('!') {
+                    format!("!{}", name.resolve())
+                } else {
+                    name.resolve()
+                };
+                method_lvalue_assign_expr(*target, target_var_name, method_name, args, rhs)
+            }
+        }
+        Expr::Call { name, args } => named_sub_lvalue_assign_expr(name.resolve(), args, rhs),
+        Expr::CallOn { target, args } => callable_lvalue_assign_expr(*target, args, rhs),
+        other => callable_lvalue_assign_expr(other, Vec::new(), rhs),
+    }
+}
+
 /// Parse an expression statement (fallback).
 pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
     // Topic mutating method call: .=method(args)
@@ -837,6 +879,20 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 expr: inner,
                 value: Box::new(rhs),
             }),
+            // `(try LVALUE) = RHS` / `(do LVALUE) = RHS`: a statement prefix binds
+            // looser than `=`, so the assignment belongs *inside* the prefix:
+            // `try (LVALUE = RHS)`. Without this the Try node itself becomes the
+            // lvalue ("cannot assign through non-callable value").
+            Expr::Try { body, catch } if matches!(body.as_slice(), [Stmt::Expr(_)]) => {
+                let inner = match body.into_iter().next() {
+                    Some(Stmt::Expr(e)) => e,
+                    _ => unreachable!(),
+                };
+                Stmt::Expr(Expr::Try {
+                    body: vec![Stmt::Expr(lvalue_assign_to_expr(inner, rhs))],
+                    catch,
+                })
+            }
             target => {
                 if let Some(stmt) = grouped_assign_lvalue_stmt(&target, rhs.clone()) {
                     stmt

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -167,6 +167,71 @@ impl Interpreter {
         if !self.method_dispatch_stack.is_empty() {
             let frame_idx = self.method_dispatch_stack.len() - 1;
             let is_override = override_args.is_some();
+            // If the next MRO candidate carries a method-level wrap chain, route the
+            // call through its wrappers so a `nextsame` reaching a wrapped parent
+            // method runs ...->wrapper->original->... in order (S06-advanced/wrap.t
+            // GH#2178). The initial dispatch (class_dispatch.rs) applies wraps only
+            // to the first method called; without this, a wrapper added to a parent
+            // method via `^find_method(...).wrap(...)` is skipped on `nextsame`.
+            //
+            // The candidate is NOT removed here: only the wrappers are pushed onto
+            // the wrap-dispatch stack. When the wrappers' `nextsame` chain is
+            // exhausted (sub_id == 0) it falls through to this same method frame,
+            // and the `!is_inside_wrap_dispatch()` guard is then true — so the
+            // original candidate body runs once via the normal path below and its
+            // own `nextsame` continues the rest of the MRO.
+            if !is_override && !self.is_inside_wrap_dispatch() {
+                let peeked = self.method_dispatch_stack[frame_idx]
+                    .remaining
+                    .first()
+                    .cloned();
+                if let Some((owner_class, method_def)) = peeked {
+                    let method_name_now = self
+                        .samewith_context_stack
+                        .last()
+                        .map(|(n, _)| n.clone())
+                        .unwrap_or_default();
+                    if !method_name_now.is_empty()
+                        && let Some(cand_idx) = self.find_method_candidate_index(
+                            &owner_class,
+                            &method_name_now,
+                            &method_def,
+                        )
+                        && let Some(chain) = self
+                            .get_method_wrap_chain(&owner_class, &method_name_now, cand_idx)
+                            .cloned()
+                    {
+                        let invocant = self.env.get("self").cloned().unwrap_or_else(|| {
+                            self.method_dispatch_stack[frame_idx].invocant.clone()
+                        });
+                        // The wrap dispatch expects the invocant at position 0; the
+                        // method frame's stored args do not include it.
+                        let mut wrap_call_args = vec![invocant];
+                        wrap_call_args.extend(self.method_dispatch_stack[frame_idx].args.clone());
+                        let outermost = chain.last().unwrap().1.clone();
+                        let mut wrap_remaining: Vec<Value> = Vec::new();
+                        for i in (0..chain.len() - 1).rev() {
+                            wrap_remaining.push(chain[i].1.clone());
+                        }
+                        let frame = WrapDispatchFrame {
+                            sub_id: 0,
+                            remaining: wrap_remaining,
+                            args: wrap_call_args.clone(),
+                        };
+                        self.wrap_dispatch_stack.push(frame);
+                        let result = self.call_sub_value(outermost, wrap_call_args, false);
+                        self.wrap_dispatch_stack.pop();
+                        let result = result?;
+                        if tail_call {
+                            return Err(RuntimeError {
+                                return_value: Some(result),
+                                ..RuntimeError::new("")
+                            });
+                        }
+                        return Ok(result);
+                    }
+                }
+            }
             let (receiver_class, invocant, mut call_args, owner_class, mut method_def, rw_params) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
                 let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1980,6 +1980,8 @@ impl Interpreter {
                         self.cleanup_wrap_name_entries(sub_id);
                     }
                 }
+                // Invalidate light-call caches so the sub re-resolves (see wrap).
+                self.fn_resolve_gen += 1;
                 return Ok(Value::Bool(true));
             }
             return Err(RuntimeError::new(

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -42,15 +42,20 @@ impl Interpreter {
             if let Some(rt) = &def.return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
-            if has_multi {
-                env.insert(
-                    "__mutsu_lookup_class".to_string(),
-                    Value::str(class_name_str.clone()),
-                );
-                env.insert(
-                    "__mutsu_lookup_method".to_string(),
-                    Value::str(method_name.to_string()),
-                );
+            env.insert(
+                "__mutsu_lookup_class".to_string(),
+                Value::str(class_name_str.clone()),
+            );
+            env.insert(
+                "__mutsu_lookup_method".to_string(),
+                Value::str(method_name.to_string()),
+            );
+            // A single (non-multi) method is candidate 0; recording it lets
+            // `.wrap()` register a method-level wrap chain that participates in
+            // MRO `nextsame` dispatch (S06-advanced/wrap.t GH#2178). Multi methods
+            // are wrapped via the `.candidates[N]` path, which carries its own idx.
+            if !has_multi {
+                env.insert("__mutsu_lookup_candidate_idx".to_string(), Value::Int(0));
             }
             return Some(Value::make_sub(
                 class_name,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -266,6 +266,14 @@ impl Interpreter {
                             .cloned()
                             .unwrap_or(Value::Bool(false)));
                     }
+                    "set_rw" => {
+                        // Mark the attribute as read-write. The generated accessor
+                        // for a `has $.x is rw` is already rw; for an attribute that
+                        // a custom `trait_mod:<is>` makes rw, record it on the meta
+                        // so `.rw`/`.readonly` introspection reflects the change.
+                        attributes.insert("is_rw".to_string(), Value::Bool(true));
+                        return Ok(target.clone());
+                    }
                     "rw" => {
                         return Ok(attributes
                             .as_map()

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -788,6 +788,11 @@ impl Interpreter {
                 .entry(sub_id)
                 .or_default()
                 .push((handle_id, wrapper));
+            // A previously-resolved call to this sub may be cached in the
+            // name-keyed light-call caches, which bypass `wrap_chains`. Bump the
+            // resolution generation so the next call re-resolves and dispatches
+            // through the new wrapper.
+            self.fn_resolve_gen += 1;
             // Store mapping from sub_id to function name for named call dispatch
             if !func_name.is_empty() {
                 self.wrap_sub_names.insert(sub_id, func_name.clone());
@@ -830,6 +835,8 @@ impl Interpreter {
                         self.cleanup_wrap_name_entries(sub_id);
                     }
                 }
+                // Invalidate light-call caches so the sub re-resolves (see wrap).
+                self.fn_resolve_gen += 1;
                 return Some(Ok(Value::Bool(true)));
             }
             // Extract handle-id from the WrapHandle argument
@@ -852,6 +859,8 @@ impl Interpreter {
                 if chain.is_empty() {
                     self.cleanup_wrap_name_entries(sub_id);
                 }
+                // Invalidate light-call caches so the sub re-resolves (see wrap).
+                self.fn_resolve_gen += 1;
                 return Some(Ok(Value::Bool(true)));
             }
             return Some(Err(RuntimeError::new(

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -368,6 +368,18 @@ impl Interpreter {
             return self.walk_list_invoke_direct(&target, args);
         }
 
+        // Wrap-aware dispatch: a Sub that has an active wrap chain must be
+        // invoked through its wrappers. The compiled fast path below bypasses
+        // the wrap chain, so route such a Sub through `call_sub_value` (which
+        // checks `wrap_chains`). Skip when already dispatching this sub's chain
+        // to avoid re-entering the wrappers from the original-sub leg.
+        if let Value::Sub(ref data) = target
+            && self.has_wrap_chain(data.id)
+            && !self.is_wrap_dispatching(data.id)
+        {
+            return self.call_sub_value(target, args, false);
+        }
+
         // Fast path: Sub with compiled_code
         if let Value::Sub(ref data) = target
             && let Some(ref cc) = data.compiled_code

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -88,6 +88,16 @@ impl Interpreter {
             // Pseudo-package names (MY, CORE, OUTER, CALLER, etc.) resolve to
             // Package values so that .WHO/.WHAT etc. work correctly.
             Value::Package(Symbol::intern(name))
+        } else if (self.has_type(name) || Self::is_builtin_type(name))
+            && matches!(self.env().get(name), Some(Value::Nil))
+        {
+            // A bareword that names a type resolves to the type object. A same-named
+            // `$`-sigiled scalar (`my $foo` where a class `foo` exists) is stored
+            // sigil-stripped under the same env key; while it is still unassigned
+            // (Nil) it must NOT shadow the type — `$foo` and `foo` are distinct
+            // symbols in Raku. This notably affects `my $foo = foo.new`, whose RHS
+            // resolves `foo` before the `$foo` slot is assigned.
+            Value::Package(Symbol::intern(Self::resolve_type_alias(name)))
         } else if let Some(v) = self.env().get(name) {
             if matches!(v, Value::Enum { .. } | Value::Nil)
                 || matches!(v, Value::Package(pkg) if pkg.resolve() != name)
@@ -163,6 +173,15 @@ impl Interpreter {
             || Self::is_type_with_smiley(name, self)
         {
             Value::Package(Symbol::intern(Self::resolve_type_alias(name)))
+        } else if let Some(sub_id) = self.wrap_sub_id_for_name(name)
+            && !self.is_wrap_dispatching(sub_id)
+            && let Some(sub_val) = self.get_wrapped_sub(name)
+        {
+            // A wrapped sub used as a bareword term must dispatch through its
+            // wrap chain. The `&name` env entry is a fresh Sub whose id differs
+            // from the wrap-chain key, so it would bypass the wrappers — check
+            // the wrap chain BEFORE the plain `&name` callable below.
+            self.vm_call_on_value(sub_val, Vec::new(), Some(compiled_fns))?
         } else if let Some(callable) = self.env().get(&format!("&{name}")).cloned()
             && matches!(
                 callable,
@@ -170,11 +189,6 @@ impl Interpreter {
             )
         {
             self.vm_call_on_value(callable, Vec::new(), Some(compiled_fns))?
-        } else if let Some(sub_id) = self.wrap_sub_id_for_name(name)
-            && !self.is_wrap_dispatching(sub_id)
-            && let Some(sub_val) = self.get_wrapped_sub(name)
-        {
-            self.vm_call_on_value(sub_val, Vec::new(), Some(compiled_fns))?
         } else if Interpreter::is_test_function_name(name)
             && self.test_mode_active()
             // Only try test function dispatch for hyphenated names (e.g.


### PR DESCRIPTION
## Summary

Takes `roast/S06-advanced/wrap.t` from **aborting at test 70 (12 failures)** to **running 88/90** — only the multi-method-candidate-wrap ordering tests 89–90 remain (deferred; they need cross-MRO candidate collection in `^find_method().candidates`).

Each fix is a general correctness improvement, not a test-specific hack:

1. **Wrapped sub used as a bareword argument bypassed its wrap chain.** The name-keyed light-call caches and the `vm_call_on_value` compiled fast path both skip `wrap_chains`. Now `fn_resolve_gen` is bumped on wrap/unwrap/restore, and a `Sub` with an active wrap chain is routed through `call_sub_value`. (fixes wrap.t 22, 29–47, 56)
2. **`my $foo = foo.new` name collision.** A `$`-sigilled scalar shares its sigil-stripped env key with a same-named type; while still `Nil` (the RHS is evaluated before the slot is assigned) it shadowed the type. A bareword that names a type now resolves to the type object over a `Nil` same-named scalar.
3. **`sub foo` + inner `my class foo`.** `foo.new` was parsed as `foo().new`. A bareword that names a declared type is now a method call on the type, not a call to a same-named sub.
4. **`try $obj.x = v`.** A statement prefix binds looser than `=`, so the assignment now desugars *inside* the prefix (`try ($obj.x = v)`) instead of making the `Try` node the lvalue.
5. **`Attribute.set_rw`** is implemented.
6. **`my method NAME {...}` / `my sub NAME {...}` in expression position** now evaluate to the routine object (so it can be passed to `.wrap`).
7. **Single (non-multi) method wrapped via `^find_method(...).wrap(...)`** now participates in `nextsame` MRO dispatch.

## Deferred (tests 89–90)

`^find_method('bar').candidates` must return the **full-MRO** candidate list sorted by specificity (Rakudo's `candidates[0]` is the inherited `C1: Str $s`; mutsu returns only C2's own `C2: Str:D $s`), so the multi-method wrapper attaches to the wrong candidate and fires at the wrong position. This needs cross-MRO multi-candidate collection in `classhow_lookup` (broad blast radius), documented in `TODO_roast/S06.md`.

## Testing

- `make test`: no regressions. The only failing files are pre-existing — `dotassign-store-and-container-topic.t` fails identically on `main` (verified by stash), and `tail-function.t` is a load-sensitive flaky that passes 6/6 in isolation.
- Verified no regressions in related whitelisted tests (S06-advanced/callsame, dispatching, lexical-subs, return; S06-multi/redispatch, positional-vs-named, syntax, type-based; S12-class/basic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)