### PR TITLE
fix(test): `.=` on non-STORE non-lvalue expects X::Assignment::RO

### DIFF
--- a/t/dotassign-store-and-container-topic.t
+++ b/t/dotassign-store-and-container-topic.t
@@ -42,12 +42,14 @@ plan 16;
     is $news, 1, 'target expression evaluated exactly once';
 }
 
-# An object WITHOUT a STORE method keeps the plain method-call value (mutsu's
-# historical lax behavior for `.=` on a non-lvalue).
+# An object WITHOUT a STORE method is not a container, so it is not an lvalue.
+# `X.=meth` is `X = X.meth`, which cannot assign through an immutable non-lvalue:
+# it throws X::Assignment::RO (#3968 made `.=` on a read-only target throw rather
+# than silently yielding the method result).
 {
     my class NoStore { method foo { 99 } }
-    my $r = (NoStore.new).=foo;
-    is $r, 99, 'no STORE method => plain method result';
+    throws-like { (NoStore.new).=foo }, X::Assignment::RO,
+        'no STORE method on a non-lvalue target => X::Assignment::RO';
 }
 {
     is (3.7).Int, 3, 'sanity: non-lvalue method call still works';


### PR DESCRIPTION
## Summary

`t/dotassign-store-and-container-topic.t` aborted at test 6 because that test still encoded the **old lax** behavior of `.=` on a non-lvalue.

`(NoStore.new).=foo` is `X = X.meth` where `X` is an immutable `NoStore` instance with no `STORE` method, so the assignment cannot write through the target. Since **#3968** made `.=` on a read-only target throw rather than silently yielding the method result, this now correctly throws `X::Assignment::RO` — matching Rakudo:

```
$ raku -e 'my class NoStore { method foo { 99 } }; my $r = (NoStore.new).=foo'
Cannot modify an immutable NoStore (NoStore.new)
```

Test 6 is updated from `is $r, 99` to `throws-like { (NoStore.new).=foo }, X::Assignment::RO`.

## Testing

- `t/dotassign-store-and-container-topic.t`: 16/16 pass (was aborting at test 6).
- `make test`: PASS, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)