### PR TITLE
docs(roast): mark S06-advanced/caller.t unpassable (stale test)

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -1,7 +1,25 @@
 # S06 - multi, parameters, routine, signature, traits
 
-- [ ] roast/S06-advanced/caller.t
-  - Not in spectest.data (fails on raku too). 4/22 pass (tests 1,2,6,9). Test uses deprecated `caller()` function and `@_` in methods. Test 3 has wrong hardcoded line number (23 vs actual 17). Tests 4-19 require `caller()` type filtering and `:skip` which are not implemented.
+- [ ] roast/S06-advanced/caller.t — UNPASSABLE (stale test, cannot run on modern raku)
+  - `caller` is not a routine in modern Rakudo (`Undeclared routine: caller`), and the
+    file uses `@_` in a method (compile error on raku). It cannot be verified against raku.
+  - **The `plan` is over-stated**: `plan 22` but only 19 assertions exist (the trailing
+    "WRITEME: label tests" were never written). So even all-passing → `ran 19 of 22` → FAIL.
+    The file can never be whitelisted regardless of mutsu behavior.
+  - The 4 still-failing assertions (1, 3, 4, 7) are **stale / old-Rakudo expectations that
+    mutsu correctly diverges from** — do NOT "fix" them (would require returning wrong values):
+    - Test 3 `caller.line` expects 23, but the call site is line 17 (line 23 is `}`). mutsu
+      returns 17 = correct. The expected number is stale from an older file layout (see the
+      `# (line 33.)` comment on line 24, now actually line 24).
+    - Test 7 `caller().line` expects 32, but line 32 is a comment; the frame's real line is 24.
+      mutsu returns 24 = correct.
+    - Test 4 `WHAT(caller()).gist` expects `Control::Caller()` (old format). Modern Rakudo
+      renders a type object as `(ShortName)` — verified: `IO::Path.gist` is `(Path)` on raku —
+      so mutsu's `(Caller)` matches modern Rakudo.
+    - Test 1 `caller.subname` expects bare `a_sub`, but the passing test 8 expects the
+      `&Main::`-qualified `&Main::try_it_caller`. mutsu always qualifies (`&Main::a_sub`). The
+      only consistent rule (subname = call-site name token) is unverifiable (`caller` absent on
+      raku) and would not help — the file is unpassable on the plan-count alone.
 - [x] roast/S06-advanced/callframe.t
 - [ ] roast/S06-advanced/callsame.t
 - [ ] roast/S06-advanced/dispatching.t


### PR DESCRIPTION
## Summary

`roast/S06-advanced/caller.t` cannot be whitelisted regardless of mutsu behavior, and its 4 still-failing assertions are **stale / old-Rakudo expectations that mutsu correctly diverges from**. This documents the analysis in `TODO_roast/S06.md` so the file is not re-attempted with test-specific hacks.

### Why it is unpassable

- **Over-stated plan**: `plan 22` but only 19 assertions exist (the trailing "WRITEME: label tests" were never written). Even all-passing yields `ran 19 of 22` → FAIL.
- **Cannot run on modern raku**: `caller` is not a routine (`Undeclared routine: caller`), and `@_` in a method is a compile error — so the expectations cannot be verified against raku.

### The 4 failing assertions are stale (mutsu is correct)

| Test | mutsu | expected | verdict |
|------|-------|----------|---------|
| 3 `caller.line` | 17 | 23 | call site is line 17; line 23 is `}`. **mutsu correct**, 23 stale (old layout — see the `# (line 33.)` comment now on line 24) |
| 7 `caller().line` | 24 | 32 | line 32 is a comment; the frame's real line is 24. **mutsu correct** |
| 4 `WHAT(caller()).gist` | `(Caller)` | `Control::Caller()` | modern Rakudo renders `(ShortName)` — verified `IO::Path.gist` is `(Path)` on raku. **mutsu matches modern Rakudo** |
| 1 `caller.subname` | `&Main::a_sub` | `a_sub` | but passing test 8 expects the `&Main::`-qualified form; only-consistent rule unverifiable and would not help (plan-count alone makes it unpassable) |

"Fixing" these would require returning wrong line numbers / old gist formats — a test-specific hack forbidden by the project rules.

## Testing

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)