### PR TITLE
fix(for): `for @a[*]` whole-array slice aliases elements like `for @a`

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -230,7 +230,11 @@
   - 3/16 pass (tests 1, 3, 5). Failures: lexical array reset per iteration (2, 4), itemized array in for loop (6-7), `for @a -> $x` argument list (8). Only 8 tests reached. Difficulty: Medium
 - [ ] roast/S04-statements/for.t
   - Fatal: `Module not found: MONKEY-TYPING`. Requires `use MONKEY-TYPING` pragma
-  - 105/111 (was 100). Tests 84/85 (`$_ is read-only here`) FIXED via #3968:
+  - 106/111 (was 105). Test 111 (`for @a[*]` holes) FIXED: a whole-array Whatever
+    slice `for @arr[*]` is normalized at compile time to `for @arr`, so it reuses the
+    plain-array per-element write-back (`$_ = 9 for @b[*]` now mutates @b including
+    its holes). Restricted to a var-rooted array target with the exact `[*]` index.
+  - Tests 84/85 (`$_ is read-only here`) FIXED via #3968:
     `.=` on the topic no longer bypasses the read-only mark unless the topic is a
     whole-container source (`given @a` / `with %h`); an immutable topic (`for ^N`,
     `given 42`) now throws as raku does.
@@ -250,7 +254,9 @@
     sink final method call (102, BLOCKED on container identity — implementing
     instance `.sink` dispatch in `SinkPop` regresses sink.t 5/6/7 which guard that
     `is rw`-container-wrapped and `.=` results are NOT sunk; mutsu deconts and sinks
-    them), lazy for-loop laziness (105/107), `for @a[*]` holes (111).
+    them), lazy for-loop laziness (105/107: the `lazy` statement prefix is dropped by
+    the parser on a for-loop, and a lazy for needs a deferred Seq iterator — deep lazy
+    work). [test 111 `for @a[*]` holes now FIXED — see above.]
 - [ ] roast/S04-statements/for_with_only_one_item.t
 - [x] roast/S04-statements/gather.t
   - 39/39. `take-rw EXPR` now carries an `is_rw` flag (`Stmt::Take(Expr, bool)`)

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1506,6 +1506,26 @@ impl Compiler {
                 rw_block,
                 explicit_zero_params,
             } => {
+                // `for @a[*] { ... }` — a whole-array Whatever slice iterates the
+                // same elements as `for @a`, including aliasing for write-back
+                // (`$_ = 9 for @a[*]` mutates @a). Normalize it to the plain array
+                // source so it reuses the per-element write-back path. Restricted to
+                // a var-rooted array target with the exact `[*]` index.
+                if let Expr::Index {
+                    target,
+                    index,
+                    is_positional: true,
+                } = iterable
+                    && matches!(index.as_ref(), Expr::Whatever)
+                    && Self::for_single_array_source(target).is_some()
+                {
+                    let mut rewritten = stmt.clone();
+                    if let Stmt::For { iterable: it, .. } = &mut rewritten {
+                        *it = (**target).clone();
+                    }
+                    self.compile_stmt(&rewritten);
+                    return;
+                }
                 // Element-source writeback: `for %h<k>.values { $_ *= 2 }` /
                 // `for @a[i].values { ... }`. The plain @/%-source writeback only
                 // handles named container variables, so an element source (an


### PR DESCRIPTION
## Summary

`$_ = 9 for @b[*]` should mutate `@b` (including its holes) exactly as `$_ = 9 for @b` does — a `[*]` whole-array slice yields the same lvalue elements as the bare array. mutsu evaluated the slice to copies, so the mutation was lost.

`roast/S04-statements/for.t` test 111 (`holes were changed correctly (for @a[*])`):
- before: `Array[Int].new(Int, Int, Int, Int, Int, 24)`
- after / raku: `Array[Int].new(9, 9, 9, 9, 9, 9)`

### Fix

Normalize `for @arr[*] { ... }` at compile time to `for @arr { ... }` when the iterable is an `Index` with the exact `[*]` (Whatever) index over a var-rooted array target, so it reuses the existing plain-array per-element write-back path. The narrow guard (`for_single_array_source(target).is_some()` + `index == Whatever`) keeps partial slices (`@a[1,3]`) and non-array roots untouched.

### Remaining for.t failures (deep features, documented in TODO_roast/S04.md)

- 90–92: `*@v is raw` slurpy per-element write-through (container identity)
- 105/107: lazy for-loop laziness (the `lazy` statement prefix is dropped by the parser; a lazy for needs a deferred Seq iterator)

for.t: 105/111 → 106/111.

## Testing

- `roast/S04-statements/for.t` test 111 now passes; verified `$_ = 9 for @b[*]` against raku.
- `make test`: PASS, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)