### PR TITLE
fix(io): IO::CatHandle next-handle/on-switch/open/new/Supply/binary-mode (io-cathandle.t 16→5)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -705,16 +705,40 @@
     5. `cat.read` returns `Buf[uint8]` (was generic `Buf`) and defaults to a 65536-byte
        chunk when called with no count; `.opened` now reflects active-handle presence
        (False on an empty/exhausted cat).
-  - **Remaining 16 subtests — deeper per-method gaps** (each its own work item):
-    - dynamic `chomp`/`nl-in` changes are not applied to the already-active handle
-      (only to handles opened afterward) — chomp/nl-in subtest.
-    - `getc` does not cluster combining marks into graphemes.
-    - binary mode (`:bin`): char reads must throw `X::IO::BinaryMode` (new exception,
-      also needed on IO::Handle); binary `slurp` must return a `Buf`.
-    - `utf8-c8` encoding is unsupported (encoding/slurp subtests).
-    - `seek`/`tell`, `Supply`, `native-descriptor`, `t`, `on-switch`, `next-handle`
-      callback counting, `.raku` round-trip (perl), user subclassing (new),
-      `handles` lazy list, and `path`/`IO` IO::Path identity remain stubbed/missing.
+  - **2026-06-30: next-handle/on-switch/open/new/IO/path/native-descriptor/t/
+    readchars/slurp/Supply fixed (16→5 failing).** Fixes:
+    1. `new`/`open` now eagerly open the first source handle (matching rakudo's
+       `new`→`open`→`next-handle`), and `next-handle` fires `on-switch` on *every*
+       call — including exhaustion (`Nil, $old`) and post-exhaustion (`Nil, Nil`).
+       `on-switch` is invoked with the right number of args per the callable's
+       `.count` (`>=2`→`($new,$old)`, `1`→`($new)`, else `()`). next-handle subtest
+       now passes; on-switch 9/11.
+    2. `open` is a no-op returning the invocant; user subclasses of IO::CatHandle
+       (`class Foo is IO::CatHandle {}`) inherit native `.new` and return the
+       subclass (new subtest).
+    3. `.IO`/`.path` preserve the source IO::Path's `CWD` (an IO::Path's `.IO` is
+       itself; clone it directly instead of rebuilding against the process cwd).
+    4. binary mode (`:bin`): char reads (get/getc/lines/words/comb/split/readchars)
+       throw `X::IO::BinaryMode`; binary `slurp` returns a `Buf[uint8]`.
+    5. `.Supply` emits the concatenated content as a non-live Supply, chunked by
+       `:size` (binary→`buf8` chunks, text→`Str` chunks).
+    6. General fix: `Blob`/`Buf` `.batch(n)` iterates its byte *values* (was treating
+       the whole buf as a single element) — needed by the Supply binary subtest's
+       expected `$str.encode.batch(2)`.
+    7. General parser fix: a parenthesised known/imported call immediately followed
+       by a postfix method/subscript (`make-temp-file(:content($_)).open`) is parsed
+       as an expression, not a statement-call that drops the postfix
+       (`known_call_stmt` bails to the expression parser). Unblocked
+       native-descriptor and t subtests.
+  - **Remaining 5 subtests — deeper gaps** (each its own work item):
+    - chomp/nl-in: needs *lazy* `.lines` (pulling advances the cat and reflects the
+      current chomp/nl-in attributes mid-stream); our `.lines` is eager.
+    - handles: needs a *lazy* `.handles` Seq tied to the live cat (pulling switches
+      handles); our `.handles` is eager and closes handles as it iterates.
+    - on-switch (9/11): test 1 needs lazy `.lines`; test 11 needs captured-outer
+      writeback of the on-switch callback through `slurp`'s nested dispatch.
+    - encoding / perl: `utf8-c8` encoding is unsupported (encoding subtest); `.raku`
+      round-trip + IO::CatHandle `eqv` for the perl subtest.
 - [x] roast/S32-io/io-handle.t — **30/30, whitelisted.** All subtests pass.
       29 `.WRITE` / 30 `.EOF/.WRITE` fixed: a user-subclassed IO::Handle that
       overrides WRITE/READ/EOF now routes the high-level methods through the user

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -818,7 +818,12 @@ pub(crate) fn native_method_1arg(
                 return Some(Err(err));
             }
             let n = n as usize;
-            let items = runtime::value_to_list(target);
+            // A Blob/Buf batches its byte *values* (it is iterated as a list of
+            // its bytes), not as a single opaque element.
+            let items = match crate::builtins::methods_narg::buf::buf_get_bytes(target) {
+                Some(bytes) => bytes.into_iter().map(|b| Value::Int(b as i64)).collect(),
+                None => runtime::value_to_list(target),
+            };
             let batches: Vec<Value> = items
                 .chunks(n)
                 .map(|chunk| Value::array(chunk.to_vec()))

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -400,6 +400,22 @@ pub(crate) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
         return parse_statement_modifier(rest, Stmt::ReactDone);
     }
 
+    // A parenthesised call (`foo(...)`) whose result is immediately followed by a
+    // postfix method chain or subscript (`foo(...).bar`, `foo(...)[0]`) is an
+    // *expression*, not a statement-level call: parsing it here would drop the
+    // postfix (e.g. `make-temp-file(:content($_)).open` losing `.open`). Bail so
+    // the expression-statement parser handles the whole postfix chain.
+    let is_paren_call = !had_ws && rest.starts_with('(');
+    if is_paren_call {
+        let after_call = skip_balanced_parens(rest);
+        let after_call = after_call.trim_start();
+        if (after_call.starts_with('.') && !after_call.starts_with(".."))
+            || after_call.starts_with('[')
+        {
+            return Err(PError::expected("known function call"));
+        }
+    }
+
     // In Raku, `foo(args)` (no space) = paren call, but `foo (expr)` (space) = listop call.
     // When there was whitespace before `(`, treat `(` as expression grouping, not call parens.
     let (rest, args) = if had_ws {

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -514,9 +514,19 @@ impl Interpreter {
                 // VM's `try_native_io_path_construct`.
                 return self.build_io_path_instance(*class_name, &cn_resolved, &args);
             }
+            // A user subclass of IO::CatHandle (e.g. `class Foo is IO::CatHandle {}`)
+            // inherits the native `.new`, returning an instance of the subclass.
+            let is_cathandle_like = base_class_name == "IO::CatHandle"
+                || self
+                    .class_mro(class_key)
+                    .iter()
+                    .any(|name| name == "IO::CatHandle");
+            if is_cathandle_like && !self.has_user_method(class_key, "new") {
+                return Ok(self.build_io_cathandle(*class_name, &args));
+            }
             match base_class_name {
                 "IO::CatHandle" if !self.has_user_method(class_key, "new") => {
-                    return Ok(self.build_io_cathandle(&args));
+                    return Ok(self.build_io_cathandle(*class_name, &args));
                 }
                 "IterationBuffer" => {
                     // Shared with the VM's native fast path.

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -27,7 +27,7 @@ fn val_int(v: &Value) -> Option<i64> {
 impl Interpreter {
     /// Build a fresh `IO::CatHandle` instance from positional source values and
     /// `:chomp` / `:nl-in` / `:encoding` named args (the `.new` constructor).
-    pub(crate) fn build_io_cathandle(&mut self, args: &[Value]) -> Value {
+    pub(crate) fn build_io_cathandle(&mut self, class_name: Symbol, args: &[Value]) -> Value {
         let mut sources: Vec<Value> = Vec::new();
         let mut chomp = Value::Bool(true);
         let mut nl_in = Value::array(vec![
@@ -36,6 +36,7 @@ impl Interpreter {
         ]);
         let mut encoding = Value::str("utf8".to_string());
         let mut on_switch = Value::Nil;
+        let mut bin = false;
         for arg in args {
             match arg {
                 Value::Pair(k, v) => match k.as_str() {
@@ -43,6 +44,7 @@ impl Interpreter {
                     "nl-in" => nl_in = (**v).clone(),
                     "encoding" | "enc" => encoding = (**v).clone(),
                     "on-switch" => on_switch = (**v).clone(),
+                    "bin" => bin = v.truthy(),
                     _ => {}
                 },
                 // A list/array/Seq argument is flattened into the source
@@ -68,10 +70,44 @@ impl Interpreter {
         attrs.insert("nl-in".to_string(), nl_in);
         attrs.insert("encoding".to_string(), encoding);
         attrs.insert("closed".to_string(), Value::Bool(false));
+        attrs.insert("bin".to_string(), Value::Bool(bin));
         attrs.insert("on-switch".to_string(), on_switch);
         attrs.insert("path".to_string(), Value::Nil);
         attrs.insert("nl-out".to_string(), Value::str("\n".to_string()));
-        Value::make_instance(Symbol::intern("IO::CatHandle"), attrs)
+        // Raku's `IO::CatHandle.new` immediately opens the first source handle
+        // (via `.open` -> `.next-handle`), firing the `on-switch` callback once
+        // for that initial handle. Reproduce that eager open so `.next-handle`,
+        // `.on-switch` counting and `.opened` match rakudo.
+        let _ = self.cat_next_handle(&mut attrs);
+        Value::make_instance(class_name, attrs)
+    }
+
+    /// Invoke the `on-switch` callback for a handle transition, passing the new
+    /// and old handles. The number of arguments forwarded follows the callable's
+    /// `.count` (rakudo: `>=2` -> `($new, $old)`, `1` -> `($new)`, else `()`).
+    fn cat_fire_on_switch(&mut self, on_switch: &Value, new: Value, old: Value) {
+        if !matches!(
+            on_switch,
+            Value::Sub(_) | Value::Routine { .. } | Value::WeakSub(_)
+        ) {
+            return;
+        }
+        let count = self
+            .call_method_with_values(on_switch.clone(), "count", vec![])
+            .ok();
+        let n = match count {
+            Some(Value::Int(i)) => i,
+            Some(Value::Num(f)) if f.is_infinite() => i64::MAX,
+            _ => 2,
+        };
+        let call_args = if n >= 2 {
+            vec![new, old]
+        } else if n == 1 {
+            vec![new]
+        } else {
+            vec![]
+        };
+        let _ = self.eval_call_on_value(on_switch.clone(), call_args);
     }
 
     /// Open one source value into a read handle, applying the cat's `chomp` /
@@ -165,12 +201,16 @@ impl Interpreter {
     /// Close the active handle (if any) and open the next source. Returns the new
     /// active handle, or `Nil` when the sources are exhausted.
     fn cat_next_handle(&mut self, attrs: &mut HashMap<String, Value>) -> Value {
-        if let Some(active @ Value::Instance { class_name, .. }) =
-            attrs.get("active").cloned().as_ref()
-            && class_name == "IO::Handle"
-        {
-            let _ = self.close_handle_value(active);
-        }
+        // Remember the previously-active handle: it becomes the `$old` argument
+        // to `on-switch` and must be closed before we open the next source.
+        let old = match attrs.get("active").cloned() {
+            Some(active) if matches!(&active, Value::Instance { class_name, .. } if class_name == "IO::Handle") =>
+            {
+                let _ = self.close_handle_value(&active);
+                active
+            }
+            _ => Value::Nil,
+        };
         let on_switch = attrs.get("on-switch").cloned().unwrap_or(Value::Nil);
         loop {
             let pos = attrs.get("pos").and_then(val_int).unwrap_or(0) as usize;
@@ -181,6 +221,9 @@ impl Interpreter {
             if pos >= sources.len() {
                 attrs.insert("active".to_string(), Value::Nil);
                 attrs.insert("path".to_string(), Value::Nil);
+                // Exhaustion still fires on-switch with a Nil active handle,
+                // matching rakudo (so the count is `handles + 1`).
+                self.cat_fire_on_switch(&on_switch, Value::Nil, old);
                 return Value::Nil;
             }
             attrs.insert("pos".to_string(), Value::Int((pos + 1) as i64));
@@ -189,19 +232,24 @@ impl Interpreter {
                 // not the opened handle's absolutized path: raku's
                 // `is-deeply $cat.path, @files.map(*.IO)[$n]` compares against
                 // the source's own IO::Path (which preserves the relative path
-                // string as written), so derive it from the source value.
-                let path_val = self
-                    .call_method_with_values(sources[pos].clone(), "IO", vec![])
-                    .unwrap_or(Value::Nil);
+                // string *and* its `CWD`), so derive it from the source value.
+                // An IO::Path's `.IO` is itself, so clone it directly to keep
+                // the original `CWD` (routing through method dispatch rebuilds
+                // the path against the process cwd and loses it).
+                let path_val = match &sources[pos] {
+                    p @ Value::Instance { class_name, .. }
+                        if class_name == "IO::Path"
+                            || class_name.resolve().starts_with("IO::Path::") =>
+                    {
+                        p.clone()
+                    }
+                    _ => self
+                        .call_method_with_values(sources[pos].clone(), "IO", vec![])
+                        .unwrap_or(Value::Nil),
+                };
                 attrs.insert("active".to_string(), handle.clone());
                 attrs.insert("path".to_string(), path_val);
-                if matches!(
-                    on_switch,
-                    Value::Sub(_) | Value::Routine { .. } | Value::WeakSub(_)
-                ) {
-                    let _ = self
-                        .eval_call_on_value(on_switch.clone(), vec![handle.clone(), Value::Nil]);
-                }
+                self.cat_fire_on_switch(&on_switch, handle.clone(), old);
                 return handle;
             }
         }
@@ -266,6 +314,26 @@ impl Interpreter {
     fn cat_slurp(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
         if attrs.get("closed").is_some_and(|v| v.truthy()) {
             return Ok(Value::Nil);
+        }
+        // A binary-mode cat slurps raw bytes into a `Buf[uint8]`.
+        if attrs.get("bin").is_some_and(|v| v.truthy()) {
+            let mut bytes: Vec<u8> = Vec::new();
+            loop {
+                let active = self.cat_ensure_active(attrs);
+                if matches!(active, Value::Nil) {
+                    break;
+                }
+                let chunk = self.native_io_handle_method(&active, "slurp", vec![])?;
+                if let Some(items) = Self::buf_as_byte_items(&chunk) {
+                    bytes.extend(items.iter().filter_map(val_int).map(|b| b as u8));
+                } else {
+                    bytes.extend(chunk.to_string_value().into_bytes());
+                }
+                if matches!(self.cat_next_handle(attrs), Value::Nil) {
+                    break;
+                }
+            }
+            return Ok(Self::make_buf(bytes));
         }
         let mut out = String::new();
         loop {
@@ -354,12 +422,36 @@ impl Interpreter {
     /// attributes back into the receiver's shared cell.
     pub(crate) fn native_io_cathandle_mut(
         &mut self,
+        class_name: Symbol,
         attributes: HashMap<String, Value>,
         method: &str,
         args: Vec<Value>,
     ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
         let mut attrs = attributes;
+        // Character-oriented reads are illegal on a binary-mode cat handle.
+        if attrs.get("bin").is_some_and(|v| v.truthy())
+            && matches!(
+                method,
+                "get" | "getc" | "lines" | "words" | "comb" | "split" | "readchars"
+            )
+        {
+            let mut ex_attrs = HashMap::new();
+            let msg = format!("Cannot do '.{method}' on a handle in binary mode");
+            ex_attrs.insert("message".to_string(), Value::str(msg.clone()));
+            ex_attrs.insert("trying".to_string(), Value::str(method.to_string()));
+            let mut err = RuntimeError::new(msg);
+            err.exception = Some(Box::new(Value::make_instance(
+                Symbol::intern("X::IO::BinaryMode"),
+                ex_attrs,
+            )));
+            return Err(err);
+        }
         let result = match method {
+            "open" => {
+                // `.open` is a no-op that returns the invocant: `new` already
+                // opened the first source handle, so just hand back `self`.
+                Value::make_instance(class_name, attrs.clone())
+            }
             "get" => self.cat_get(&mut attrs)?,
             "getc" => self.cat_getc(&mut attrs)?,
             "lines" => self.cat_lines(&mut attrs, &args)?,
@@ -636,10 +728,57 @@ impl Interpreter {
                 }
             }
             "Supply" => {
-                return Err(RuntimeError::new(format!(
-                    "No native mutable method '{}' on 'IO::CatHandle'",
-                    method
-                )));
+                // Emit the remaining content of the cat as a (non-live) Supply.
+                // `:size` chunks the *concatenated* content across all handles
+                // (default: one chunk). Binary cats emit `buf8` chunks; text
+                // cats emit `Str` chunks of `:size` characters.
+                let size = args
+                    .iter()
+                    .find_map(|a| match a {
+                        Value::Pair(name, val) if name == "size" => {
+                            val_int(val).map(|i| i as usize)
+                        }
+                        _ => None,
+                    })
+                    .filter(|&s| s > 0);
+                let is_bin = attrs.get("bin").is_some_and(|v| v.truthy());
+                let mut values: Vec<Value> = Vec::new();
+                if is_bin {
+                    let mut bytes: Vec<u8> = Vec::new();
+                    loop {
+                        let active = self.cat_ensure_active(&mut attrs);
+                        if matches!(active, Value::Nil) {
+                            break;
+                        }
+                        let chunk = self.native_io_handle_method(&active, "slurp", vec![])?;
+                        if let Some(items) = Self::buf_as_byte_items(&chunk) {
+                            bytes.extend(items.iter().filter_map(val_int).map(|b| b as u8));
+                        } else {
+                            bytes.extend(chunk.to_string_value().into_bytes());
+                        }
+                        if matches!(self.cat_next_handle(&mut attrs), Value::Nil) {
+                            break;
+                        }
+                    }
+                    let step = size.unwrap_or(bytes.len().max(1));
+                    for chunk in bytes.chunks(step) {
+                        values.push(Self::make_buf(chunk.to_vec()));
+                    }
+                } else {
+                    let text = match self.cat_slurp(&mut attrs)? {
+                        Value::Nil => String::new(),
+                        v => v.to_string_value(),
+                    };
+                    let chars: Vec<char> = text.chars().collect();
+                    let step = size.unwrap_or(chars.len().max(1));
+                    for chunk in chars.chunks(step) {
+                        values.push(Value::str(chunk.iter().collect::<String>()));
+                    }
+                }
+                let mut supply_attrs = HashMap::new();
+                supply_attrs.insert("live".to_string(), Value::Bool(false));
+                supply_attrs.insert("values".to_string(), Value::array(values));
+                Value::make_instance(Symbol::intern("Supply"), supply_attrs)
             }
             _ => {
                 return Err(RuntimeError::new(format!(

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -290,7 +290,9 @@ impl Interpreter {
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
             "IO::Handle" => self.native_io_handle_mut(attributes, method, args),
-            "IO::CatHandle" => self.native_io_cathandle_mut(attributes, method, args),
+            "IO::CatHandle" => {
+                self.native_io_cathandle_mut(Symbol::intern(class_name), attributes, method, args)
+            }
             "Proc" => self.native_proc_mut(attributes, method, args),
             "Promise" => self.native_promise_mut(attributes, method, args),
             "Channel" => self.native_channel_mut(attributes, method, args),
@@ -400,8 +402,12 @@ impl Interpreter {
                 // is only reached for introspection paths, so run the mutable impl
                 // and drop the writeback (callers needing persistence route through
                 // the mutable path in methods_instance_ops).
-                let (result, _updated) =
-                    self.native_io_cathandle_mut(attributes.clone(), method, args)?;
+                let (result, _updated) = self.native_io_cathandle_mut(
+                    Symbol::intern(class_name),
+                    attributes.clone(),
+                    method,
+                    args,
+                )?;
                 Ok(result)
             }
             "IO::Special" => self.native_io_special(attributes, method, args),

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -712,6 +712,7 @@ impl Interpreter {
                     "readchars",
                     "read",
                     "next-handle",
+                    "open",
                     "close",
                     "DESTROY",
                     "eof",


### PR DESCRIPTION
## Summary

Brings `roast/S32-io/io-cathandle.t` from 16 failing subtests down to **5** (10 newly passing: next-handle, on-switch→9/11, open, new, IO, path, native-descriptor, t, readchars, slurp, Supply).

## Changes

- **`new`/`open` eager open + `on-switch` semantics**: `new`/`open` now open the first source handle immediately (rakudo's `new`→`open`→`next-handle`). `next-handle` fires `on-switch` on *every* call — including exhaustion (`Nil, $old`) and post-exhaustion (`Nil, Nil`) — with the argument count chosen by the callable's `.count` (`>=2`→`($new,$old)`, `1`→`($new)`, else `()`).
- **`open` + subclassing**: `.open` is a no-op returning the invocant; user subclasses (`class Foo is IO::CatHandle {}`) inherit native `.new` via an MRO check and return the subclass instance.
- **`.IO`/`.path` CWD identity**: preserve the source IO::Path's `CWD` (an IO::Path's `.IO` is itself; clone it directly rather than rebuilding against the process cwd).
- **Binary mode (`:bin`)**: char reads (get/getc/lines/words/comb/split/readchars) throw `X::IO::BinaryMode`; binary `slurp` returns a `Buf[uint8]`.
- **`.Supply`**: emits the concatenated content as a non-live Supply, chunked by `:size` (binary→`buf8` chunks, text→`Str` chunks).
- **General fix — `Blob`/`Buf` `.batch(n)`**: now iterates the byte *values* instead of treating the whole buf as a single element (needed by the Supply binary subtest's expected `$str.encode.batch(2)`).
- **General parser fix**: a parenthesised known/imported call immediately followed by a postfix method/subscript (e.g. `make-temp-file(:content($_)).open`) now parses as an expression instead of a statement-call that drops the postfix (`known_call_stmt` bails to the expression parser).

## Remaining 5 subtests (deeper features, documented in `TODO_roast/S32.md`)

- chomp/nl-in & handles: need a *lazy* `.lines`/`.handles` tied to the live cat.
- on-switch (9/11): lazy `.lines` (test 1) + captured-outer writeback through `slurp` (test 11).
- encoding / perl: `utf8-c8` encoding; `.raku` round-trip + IO::CatHandle `eqv`.

## Testing

- `make test`: PASS (1374 files, 13507 tests).
- Spot-checked `roast/S32-list/batch.t`, `roast/S17-supply/batch.t`, `roast/S32-io/io-handle.t`, `roast/S04-statements/last.t`, `roast/S02-literals/quoting.t` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)