### PR TITLE
fix(for): is-rw slurpy write-through + lazy for-loop (S04 for.t → whitelist)

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -228,9 +228,22 @@
   - 32/32 pass.
 - [ ] roast/S04-statements/for-scope.t
   - 3/16 pass (tests 1, 3, 5). Failures: lexical array reset per iteration (2, 4), itemized array in for loop (6-7), `for @a -> $x` argument list (8). Only 8 tests reached. Difficulty: Medium
-- [ ] roast/S04-statements/for.t
-  - Fatal: `Module not found: MONKEY-TYPING`. Requires `use MONKEY-TYPING` pragma
-  - 106/111 (was 105). Test 111 (`for @a[*]` holes) FIXED: a whole-array Whatever
+- [x] roast/S04-statements/for.t
+  - 111/111 (was 106). Whitelisted. Tests 90-92 (`is rw` slurpy `*@v is raw`) and
+    105/107 (lazy for-loop) FIXED:
+    - Slurpy `*@v is raw`/`is rw`: each caller argument is aliased, so a body
+      mutation of `@v[i]` (or `for @v { $_++ }` / `for @v -> $x is rw`) flows back
+      to the i-th caller source. The old varref-element approach broke plain reads
+      of `@v[i]` and never wrote back. Now the slurpy binds the plain (deref'd)
+      element values and records a per-element writeback in `rw_bindings`
+      (`encode_slurpy_rw_param`: slurpy env key + element index + source index)
+      that `apply_rw_bindings_to_env` distributes back to each scalar/array-element
+      source at return.
+    - `lazy for` now compiles to `(gather { for ... { take ... } }).lazy` (the
+      `.lazy` was previously missing, so the gather ran eagerly on assignment).
+    - Test 65 is `#?rakudo todo` (label-less `last` Nil-vs-()), so it passes under
+      fudge.
+  - Test 111 (`for @a[*]` holes) FIXED: a whole-array Whatever
     slice `for @arr[*]` is normalized at compile time to `for @arr`, so it reuses the
     plain-array per-element write-back (`$_ = 9 for @b[*]` now mutates @b including
     its holes). Restricted to a var-rooted array target with the exact `[*]` index.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -342,6 +342,7 @@ roast/S04-statement-modifiers/without.t
 roast/S04-statement-parsing/hash.t
 roast/S04-statements/do.t
 roast/S04-statements/for-scope.t
+roast/S04-statements/for.t
 roast/S04-statements/for_with_only_one_item.t
 roast/S04-statements/gather.t
 roast/S04-statements/given.t

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -302,10 +302,19 @@ impl Compiler {
             rw_block: false,
             explicit_zero_params: false,
         };
-        // Build gather block wrapping the for loop
+        // Build gather block wrapping the for loop, then mark it `.lazy` so the
+        // body does not run until the resulting Seq is consumed (`lazy for`
+        // semantics — S04 for.t "Lazy for loop does not execute until asked").
         let gather_body = vec![inner_for];
         let gather_expr = AExpr::Gather(gather_body);
-        self.compile_expr(&gather_expr);
+        let lazy_expr = AExpr::MethodCall {
+            target: Box::new(gather_expr),
+            name: crate::symbol::Symbol::intern("lazy"),
+            args: Vec::new(),
+            modifier: None,
+            quoted: false,
+        };
+        self.compile_expr(&lazy_expr);
     }
 
     /// Compile `do while` / `do until` expression: collect each iteration value.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -238,7 +238,6 @@ impl Interpreter {
         let arg_sources = self.take_pending_call_arg_sources();
         let mut rw_bindings = Vec::new();
         let mut raw_nonlvalue_params: Vec<String> = Vec::new();
-        let mut raw_slurpy_sources = std::collections::HashSet::new();
         if let Some(invocant_value) = self
             .env
             .get("self")
@@ -649,34 +648,63 @@ impl Interpreter {
                     }
                 } else {
                     let mut items = Vec::new();
-                    let is_raw_slurpy = pd.traits.iter().any(|t| t == "raw");
+                    // `*@v is raw` / `*@v is rw`: each caller argument is aliased,
+                    // so a body mutation of `@v[i]` (or `for @v { $_++ }`) flows
+                    // back to the i-th caller source. Build the slurpy with the
+                    // plain (deref'd) element values — wrapping them in varref
+                    // captures would break plain reads of `@v[i]` — and record a
+                    // per-element writeback in `rw_bindings` (keyed by the slurpy
+                    // env name + element index) that `apply_rw_bindings_to_env`
+                    // distributes back to each source at return.
+                    let is_alias_slurpy =
+                        pd.traits.iter().any(|t| t == "raw" || t == "rw") && !pd.name.is_empty();
+                    let slurpy_key = if pd.name.starts_with('@') {
+                        pd.name.clone()
+                    } else {
+                        format!("@{}", pd.name)
+                    };
                     while positional_idx < args.len() {
                         let raw_arg = args[positional_idx].clone();
-                        if is_raw_slurpy
-                            && let Some((source_name, source_value, source_index)) =
-                                indexed_varref_from_value(&raw_arg)
+                        // The source name comes from the varref capture the caller
+                        // wraps lvalue arguments in (`WrapVarRef`); fall back to the
+                        // `arg_sources` table for paths that pass plain values.
+                        let varref = indexed_varref_from_value(&raw_arg);
+                        let arg_source = arg_sources
+                            .as_ref()
+                            .and_then(|names| names.get(positional_idx))
+                            .and_then(|n| n.as_ref())
+                            .cloned();
+                        if is_alias_slurpy
+                            && let Some(source_name) =
+                                varref.as_ref().map(|(n, _, _)| n.clone()).or(arg_source)
+                            && !matches!(unwrap_varref_value(raw_arg.clone()), Value::Pair(..))
                         {
-                            if raw_slurpy_sources.insert(source_name.clone()) {
-                                rw_bindings.push((source_name.clone(), source_name.clone()));
-                            }
-                            self.env.insert(source_name.clone(), source_value.clone());
+                            let source_value = match &varref {
+                                Some((_, v, _)) => v.clone(),
+                                None => raw_arg.clone(),
+                            };
+                            let source_index = varref.as_ref().and_then(|(_, _, i)| *i);
                             if !pd.double_slurpy
                                 && let Value::Array(arr, kind) = &source_value
                                 && !kind.is_itemized()
                             {
+                                // An array source (`incr(@arr)`): each element of
+                                // `@arr` becomes a slurpy element aliasing `@arr[idx]`.
                                 for (idx, item) in arr.iter().cloned().enumerate() {
-                                    items.push(make_varref_value(
+                                    rw_bindings.push((
+                                        encode_slurpy_rw_param(&slurpy_key, items.len(), Some(idx)),
                                         source_name.clone(),
-                                        item,
-                                        Some(idx),
                                     ));
+                                    items.push(item);
                                 }
                             } else {
-                                items.push(make_varref_value(
+                                // A scalar source (`incr($a, $b)`) or an indexed
+                                // element passed by reference (`incr(@a[0])`).
+                                rw_bindings.push((
+                                    encode_slurpy_rw_param(&slurpy_key, items.len(), source_index),
                                     source_name,
-                                    source_value,
-                                    source_index,
                                 ));
+                                items.push(source_value);
                             }
                             positional_idx += 1;
                             continue;

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -14,12 +14,12 @@ mod type_registry;
 // Re-export public items from submodules
 pub(crate) use coercion::{coerce_impossible_error, is_coercion_constraint, parse_coercion_type};
 pub(in crate::runtime) use signature::{
-    bind_named_rename_sub_signature, bind_sub_signature_from_value, flatten_into_slurpy,
-    indexed_varref_from_value, sigilless_alias_key, sigilless_readonly_key,
+    bind_named_rename_sub_signature, bind_sub_signature_from_value, encode_slurpy_rw_param,
+    flatten_into_slurpy, indexed_varref_from_value, sigilless_alias_key, sigilless_readonly_key,
     sub_signature_matches_value, sub_signature_target_from_remaining_args, varref_from_value,
     wrap_native_int_for_binding,
 };
-pub(crate) use signature::{make_varref_value, unwrap_varref_value};
+pub(crate) use signature::{decode_slurpy_rw_param, make_varref_value, unwrap_varref_value};
 // Internal re-exports used by submodules via `use super::*`
 use signature::code_signature_matches_value;
 
@@ -194,6 +194,47 @@ impl Interpreter {
         target_env: &mut crate::env::Env,
     ) {
         for (param_name, source_name) in rw_bindings {
+            // A `*@v is raw`/`is rw` slurpy element writeback: read the (possibly
+            // body-mutated) element from the callee's slurpy array and write it
+            // back to its caller source — a scalar (`$a`) or an array element
+            // (`@arr[idx]`).
+            if let Some((slurpy_key, elem_idx, src_idx)) = decode_slurpy_rw_param(param_name) {
+                let Some(elem) = self.env.get(slurpy_key).and_then(|v| match v {
+                    Value::Array(arr, _) => arr.items.get(elem_idx).cloned(),
+                    _ => None,
+                }) else {
+                    continue;
+                };
+                match src_idx {
+                    Some(i) => {
+                        // Array source: replace element `i` in the caller's array,
+                        // preserving the rest of the container's metadata.
+                        if let Some(Value::Array(arr, kind)) = target_env.get(source_name).cloned()
+                        {
+                            let mut data = (*arr).clone();
+                            if i < data.items.len() {
+                                data.items[i] = elem;
+                                target_env.insert(
+                                    source_name.clone(),
+                                    Value::Array(std::sync::Arc::new(data), kind),
+                                );
+                            }
+                        }
+                    }
+                    None => {
+                        // Scalar source: write through a shared cell if one exists
+                        // (preserving aliases), else replace the value.
+                        if let Some(Value::ContainerRef(arc)) = target_env.get(source_name)
+                            && !elem.is_container_ref()
+                        {
+                            *arc.lock().unwrap() = elem;
+                        } else {
+                            target_env.insert(source_name.clone(), elem);
+                        }
+                    }
+                }
+                continue;
+            }
             if let Some(updated) = self.env.get(param_name).cloned() {
                 // When the caller's variable already holds a shared `ContainerRef`
                 // cell (e.g. an inner `$a := $arg` re-bound the rw param into the

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -197,6 +197,52 @@ pub(crate) fn make_varref_value(name: String, value: Value, source_index: Option
     Value::capture(Vec::new(), named)
 }
 
+/// Sentinel prefix marking a `*@v is rw`/`is raw` slurpy element writeback entry
+/// inside the `rw_bindings` list. A slurpy `is raw`/`is rw` param aliases each
+/// caller argument: when the body mutates `@v[i]` (or `for @v { $_++ }`), the
+/// new value must flow back to the i-th caller source. A plain `(param, source)`
+/// rw-binding can't express this (the whole slurpy array maps to many distinct
+/// sources, possibly at distinct indices), so each element gets its own entry
+/// whose `param_name` encodes the slurpy env key, the element index in the
+/// slurpy array, and the index within the source (for an array source). The
+/// `source_name` stays clean (`"a"`, `"@arr"`) so the call-site
+/// `pending_rw_writeback_sources` collection refreshes the right caller slot.
+const SLURPY_RW_MARKER: &str = "\u{1}S\u{1}";
+
+/// Encode a slurpy element writeback into an `rw_bindings` param-name slot.
+/// `slurpy_key` is the callee env key (`"@v"`), `elem_idx` the element's position
+/// in the slurpy array, `src_idx` the index within an array source (`None` for a
+/// scalar source).
+pub(in crate::runtime) fn encode_slurpy_rw_param(
+    slurpy_key: &str,
+    elem_idx: usize,
+    src_idx: Option<usize>,
+) -> String {
+    let src = match src_idx {
+        Some(i) => i as i64,
+        None => -1,
+    };
+    format!("{SLURPY_RW_MARKER}{slurpy_key}\u{1}{elem_idx}\u{1}{src}")
+}
+
+/// Decode a slurpy element writeback param-name. Returns
+/// `(slurpy_key, elem_idx, src_idx)` or `None` if `param` is an ordinary
+/// rw-binding param name.
+pub(crate) fn decode_slurpy_rw_param(param: &str) -> Option<(&str, usize, Option<usize>)> {
+    let rest = param.strip_prefix(SLURPY_RW_MARKER)?;
+    // From the right: src, elem, key. The key (`"@v"`) never contains \u{1}.
+    let mut parts = rest.rsplitn(3, '\u{1}');
+    let src = parts.next()?;
+    let elem = parts.next()?;
+    let key = parts.next()?;
+    let elem_idx: usize = elem.parse().ok()?;
+    let src_idx = match src.parse::<i64>().ok()? {
+        i if i >= 0 => Some(i as usize),
+        _ => None,
+    };
+    Some((key, elem_idx, src_idx))
+}
+
 pub(in crate::runtime) fn sigilless_alias_key(name: &str) -> String {
     format!("__mutsu_sigilless_alias::{}", name)
 }

--- a/t/for-slurpy-rw-lazy.t
+++ b/t/for-slurpy-rw-lazy.t
@@ -1,0 +1,51 @@
+use Test;
+
+plan 9;
+
+# `is rw`/`is raw` on a slurpy parameter aliases each caller argument, so body
+# mutations flow back to the caller's variables (S04-statements/for.t 90-92).
+{
+    sub incr1 (*@v is raw) { @v[0]++; @v[1]++; };
+    sub incr2 (*@v is raw) { for @v { $_++ } };
+    sub incr3 (*@v is raw) { for @v -> $x is rw { $x++ } };
+    my ($a, $b) = (0, 0);
+    incr1($a, $b);
+    is-deeply [$a, $b], [1, 1], 'direct element mutation of raw slurpy writes back';
+    incr2($a, $b);
+    is-deeply [$a, $b], [2, 2], 'for @slurpy { $_++ } writes back';
+    incr3($a, $b);
+    is-deeply [$a, $b], [3, 3], 'for @slurpy -> $x is rw { $x++ } writes back';
+}
+
+# Three distinct sources, written independently.
+{
+    sub bump (*@v is raw) { @v[0] += 10; @v[2] += 30; };
+    my ($x, $y, $z) = (1, 2, 3);
+    bump($x, $y, $z);
+    is-deeply [$x, $y, $z], [11, 2, 33], 'sparse writes to distinct sources';
+}
+
+# An array variable passed to a raw slurpy aliases its elements.
+{
+    sub incrA (*@v is raw) { @v[0]++; @v[1]++; };
+    my @arr = (10, 20);
+    incrA(@arr);
+    is-deeply @arr, [11, 21], 'array-source raw slurpy writes back to elements';
+}
+
+# A non-lvalue argument to a raw slurpy is simply read-only (no write-back, no error).
+{
+    sub readonly (*@v is raw) { @v[0] + @v[1] };
+    is readonly(3, 4), 7, 'raw slurpy with literal args reads correctly';
+}
+
+# `lazy for` does not run its body until the resulting Seq is consumed, and
+# does no more work than required (S04-statements/for.t 105/107).
+{
+    my $loops = 0;
+    my @values = lazy for ^10 { $loops++; $_ }
+    is $loops, 0, 'lazy for does not execute until asked for values';
+    is-deeply @values[^5].List, (0, 1, 2, 3, 4).List,
+        'lazy for produces correct values on demand';
+    is $loops, 5, 'lazy for does no more work than required';
+}


### PR DESCRIPTION
Completes `roast/S04-statements/for.t` (106→111, now whitelisted) via two unrelated fixes.

## `*@v is raw` / `*@v is rw` slurpy write-through (tests 90-92)

A slurpy `is raw`/`is rw` parameter aliases each caller argument, so a body
mutation of `@v[i]` — or `for @v { $_++ }` / `for @v -> $x is rw { $x++ }` —
must flow back to the i-th caller source.

The previous implementation wrapped each slurpy element in a varref capture,
which broke plain reads (`@v[0]` returned the capture, not the value) and never
wrote back. Now the slurpy binds the plain (deref'd) element values and records
a per-element writeback in `rw_bindings` (`encode_slurpy_rw_param` encodes the
slurpy env key + element index + source index). `apply_rw_bindings_to_env`
distributes each (possibly body-mutated) element back to its source — a scalar
(`$a`) or an array element (`@arr[idx]`) — at return.

## `lazy for` laziness (tests 105/107)

`lazy for ^10 { ... }` already compiled to `gather { for ... { take ... } }`,
but the gather ran eagerly on assignment because the `.lazy` marker was dropped.
It now compiles to `(gather { ... }).lazy`, so the body does not run until the
resulting Seq is consumed.

## Tests

- New regression: `t/for-slurpy-rw-lazy.t` (9 subtests).
- `roast/S04-statements/for.t` added to the whitelist (test 65 is `#?rakudo todo`).
- Verified no regressions across slurpy/signature/rw/for/lazy/gather t/ and roast tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)