### PR TITLE
fix(capture): Promise.Capture status + imported-sub `.method` parse (S02 capture.t 45→46, whitelist)

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -248,8 +248,17 @@
 - [ ] roast/S02-types/bool.t
   - 38/69 pass (67 reached). Only 2 failures: test 37 (`Bool::True.but`), test 39 (`Bool::False.but`) — `.but` mixin not implemented on Bool
 - [x] roast/S02-types/built-in.t
-- [ ] roast/S02-types/capture.t
-  - 45/46 (Failed 1: subtest 41). FIXED subtest 39 (`types whose .Capture
+- [x] roast/S02-types/capture.t
+  - 46/46 (whitelisted). Subtest 41 closed by two independent fixes:
+    (1) `Promise.Capture` now exposes `:status(PromiseStatus::<status>)` as a
+    package-qualified enum term (so it `eqv`s the literal `PromiseStatus::Planned`);
+    (2) statement-level parse bug: an imported/known sub immediately followed by a
+    postfix `.method`/`[...]` with no whitespace (`make-temp-file.open(:w)`) was
+    parsed as `make-temp-file($_.open(:w))` — `known_call_stmt` greedily fed the
+    leading `.method` as a topic-method-call listop argument. Now it bails to the
+    expression-statement parser (mirroring the existing `foo(...).bar` guard) so
+    the postfix chain attaches to `make-temp-file()`.
+  - Earlier: 45/46 (Failed 1: subtest 41). FIXED subtest 39 (`types whose .Capture
     throws`): `((*)).Capture` / `((*.so)).Capture` now throw X::Cannot::Capture.
     Whatever-currying now terminates at an *extra* layer of parens — `(*)` (one
     paren) still curries (`(*).Capture` → WhateverCode), but `((*))` (a whole

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -124,6 +124,7 @@ roast/S02-types/baggy.t
 roast/S02-types/baghash.t
 roast/S02-types/bool.t
 roast/S02-types/built-in.t
+roast/S02-types/capture.t
 roast/S02-types/catch_type_cast_mismatch.t
 roast/S02-types/compact.t
 roast/S02-types/declare.t

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -970,6 +970,21 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             }
             Ok(Value::capture(vec![], named))
         }
+        // Promise follows Mu.Capture: its public `.status` accessor becomes a
+        // named argument. The value is the `PromiseStatus` enum constant (a
+        // package-qualified term, e.g. `PromiseStatus::Planned`) so it `eqv`s
+        // the literal `PromiseStatus::<status>`.
+        Value::Promise(shared) => {
+            let mut named = HashMap::new();
+            named.insert(
+                "status".to_string(),
+                Value::Package(crate::symbol::Symbol::intern(&format!(
+                    "PromiseStatus::{}",
+                    shared.status()
+                ))),
+            );
+            Ok(Value::capture(vec![], named))
+        }
         // Nil.Capture → empty capture
         Value::Nil => Ok(Value::capture(vec![], HashMap::new())),
         // Types whose .Capture throws X::Cannot::Capture

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -416,6 +416,18 @@ pub(crate) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
         }
     }
 
+    // A bare zero-arg call immediately followed (no whitespace) by a postfix
+    // method chain or subscript (`make-temp-file.open(:w)`, `make-temp-file[0]`)
+    // is `make-temp-file().open(:w)` — an *expression*, not a topic-method-call
+    // listop argument. Without this bail, `parse_stmt_call_args` below greedily
+    // parses the leading `.open(...)` as `$_.open(...)` and feeds it as an
+    // argument (`make-temp-file($_.open(:w))`). Raku requires whitespace between a
+    // listop name and a `.method` topic argument, so only bail when the dot
+    // abuts the name. Let the expression-statement parser own the postfix chain.
+    if !had_ws && ((rest.starts_with('.') && !rest.starts_with("..")) || rest.starts_with('[')) {
+        return Err(PError::expected("known function call"));
+    }
+
     // In Raku, `foo(args)` (no space) = paren call, but `foo (expr)` (space) = listop call.
     // When there was whitespace before `(`, treat `(` as expression grouping, not call parens.
     let (rest, args) = if had_ws {


### PR DESCRIPTION
## Summary

Adds `roast/S02-types/capture.t` (46/46) to the whitelist by closing the
last failing sub-item in subtest 41 (*types whose .Capture behaves like
Mu.Capture*). Two independent root causes:

1. **`Promise.Capture` status** — `value_to_capture` now maps a
   `Value::Promise` to `\(:status(PromiseStatus::<status>))`, where the
   status is the package-qualified enum term (e.g. `PromiseStatus::Planned`)
   so it `eqv`s the `PromiseStatus::Planned` literal the test compares
   against. Previously a Promise hit the single-positional default
   (`\(Promise(Planned))`) and the Capture had no `status` named arg.

2. **Imported-sub `.method` statement parse** — `make-temp-file.open(:w)`
   (imported/known sub, immediately followed with no whitespace by a postfix
   `.method`/`[...]`) was parsed by `known_call_stmt` as a topic-method-call
   listop argument: `make-temp-file($_.open(:w))`. `known_call_stmt` now
   bails to the expression-statement parser (mirroring the existing
   `foo(...).bar` guard) when a `.`/`[` abuts the sub name, so the postfix
   chain attaches to `make-temp-file()`. Raku requires whitespace between a
   listop name and a `.method` topic argument, so only the no-whitespace
   case is redirected; `is-deeply .List, ...` (space form) is unchanged.

## Testing

- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S02-types/capture.t` → PASS (46/46)
- `make test` → 13507 tests, 0 failures
- 137 whitelisted Test::Util-using roast tests + broad S02/S03/S04 spot-checks → all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)