### PR TITLE
fix(wrap): full-MRO multi-method candidate list so candidates[N].wrap targets the right candidate (S06 wrap.t)

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -52,20 +52,20 @@
 - [ ] roast/S06-advanced/return-prioritization.t
 - [ ] roast/S06-advanced/return.t
 - [ ] roast/S06-advanced/stub.t
-- [ ] roast/S06-advanced/wrap.t
-  - 88/90 run, all pass except TODO 57/58 (`temp`+`wrap` scope removal, `#?rakudo todo`).
-    Only tests 89-90 fail (file aborts at 89).
-  - Fixed (this PR): wrapped-sub-as-bareword-arg bypassed wrap chain (light-call cache +
+- [x] roast/S06-advanced/wrap.t
+  - 90/90 run (tests 57/58 skipped under fudge via `#?rakudo todo`: `temp`+`wrap`
+    scope removal).
+  - Fixed (earlier): wrapped-sub-as-bareword-arg bypassed wrap chain (light-call cache +
     `vm_call_on_value` fast path); `my $foo = foo.new` name collision (Nil `$foo` shadowed
     type `foo`); `sub foo` + inner `my class foo` parsed `foo.new` as `foo().new`;
     `try $obj.x = v` lvalue desugar; `set_rw` Attribute method; `my method`/`my sub NAME {}`
     now evaluate to the routine; single-method `^find_method().wrap()` now participates in
     `nextsame` MRO dispatch.
-  - Tests 89-90 (BLOCKED): `^find_method('bar').candidates` must return the FULL-MRO
-    candidate list sorted by specificity (Rakudo's `candidates[0]` is the inherited
-    `C1: Str $s`, mutsu returns only C2's own `C2: Str:D $s`), so the multi-method wrapper
-    is attached to the wrong candidate and fires at the wrong position. Needs cross-MRO
-    multi-candidate collection in classhow_lookup — broad blast radius, deferred.
+  - Fixed (test 89): `^find_method('bar').candidates` now returns the FULL-MRO candidate
+    list base-class-first (Rakudo's `candidates[0]` is the inherited `C1: Str $s`); each
+    candidate carries its owner class + within-owner index so `.wrap()` keys into the same
+    `(class, method, idx)` slot the dispatcher consults — the wrapper now fires at the
+    correct position. `classhow_lookup_all_candidates` walks the reversed MRO.
 - [ ] roast/S06-currying/assuming-and-mmd.t
 - [ ] roast/S06-currying/misc.t
 - [ ] roast/S06-currying/named.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -470,6 +470,7 @@ roast/S06-advanced/lexical-subs.t
 roast/S06-advanced/recurse.t
 roast/S06-advanced/return.t
 roast/S06-advanced/stub.t
+roast/S06-advanced/wrap.t
 roast/S06-currying/assuming-and-mmd.t
 roast/S06-currying/misc.t
 roast/S06-currying/named.t

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -189,25 +189,42 @@ impl Interpreter {
     }
 
     /// Return all multi method candidates for a class method as Sub values.
+    ///
+    /// A multi method dispatched from `class_name` combines candidates across
+    /// its whole inheritance chain: the candidate list reported by
+    /// `^find_method(name).candidates` includes every multi candidate defined
+    /// in `class_name` and its ancestors, ordered base-class-first (e.g. for
+    /// `class C2 is C1`, C1's candidates precede C2's). Each candidate carries
+    /// the *owner* class and the index within that class's own candidate list
+    /// so that `.wrap()` keys into the same `(class, method, idx)` slot that
+    /// the dispatcher consults when it reaches that candidate (S06-advanced/
+    /// wrap.t GH#2178).
     pub(super) fn classhow_lookup_all_candidates(
         &self,
         class_name: &str,
         method_name: &str,
-        package: crate::symbol::Symbol,
+        _package: crate::symbol::Symbol,
     ) -> Vec<Value> {
         // No user-code re-entry below (pure Value construction), so a let-bound
         // guard is safe.
         let registry = self.registry();
-        let Some(class_def) = registry.classes.get(class_name) else {
-            return Vec::new();
-        };
-        let Some(defs) = class_def.methods.get(method_name) else {
-            return Vec::new();
-        };
-        defs.iter()
-            .enumerate()
-            .map(|(idx, def)| {
-                let mut full_param_defs = vec![Self::make_invocant_param(class_name)];
+        // Walk the MRO base-class-first so the reported candidate order matches
+        // Rakudo's (ancestors before the class itself).
+        let mut stack = Vec::new();
+        let mut mro = registry
+            .compute_class_mro(class_name, &mut stack)
+            .unwrap_or_else(|_| vec![class_name.to_string()]);
+        mro.reverse();
+        let mut out = Vec::new();
+        for owner in &mro {
+            let Some(class_def) = registry.classes.get(owner) else {
+                continue;
+            };
+            let Some(defs) = class_def.methods.get(method_name) else {
+                continue;
+            };
+            for (idx, def) in defs.iter().enumerate() {
+                let mut full_param_defs = vec![Self::make_invocant_param(owner)];
                 full_param_defs.extend(def.param_defs.iter().cloned());
                 let mut env = crate::env::Env::new();
                 // Set callable type for .^name to return Method/Submethod
@@ -222,7 +239,7 @@ impl Interpreter {
                 );
                 env.insert(
                     "__mutsu_lookup_class".to_string(),
-                    Value::str(class_name.to_string()),
+                    Value::str(owner.to_string()),
                 );
                 env.insert(
                     "__mutsu_lookup_method".to_string(),
@@ -232,17 +249,18 @@ impl Interpreter {
                     "__mutsu_lookup_candidate_idx".to_string(),
                     Value::Int(idx as i64),
                 );
-                Value::make_sub(
-                    package,
+                out.push(Value::make_sub(
+                    crate::symbol::Symbol::intern(owner),
                     crate::symbol::Symbol::intern(method_name),
                     def.params.clone(),
                     full_param_defs,
                     (*def.body).clone(),
                     def.is_rw,
                     env,
-                )
-            })
-            .collect()
+                ));
+            }
+        }
+        out
     }
 
     /// Check if a method name belongs to a built-in type (Str, Int, etc.)

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -190,15 +190,21 @@ impl Interpreter {
 
     /// Return all multi method candidates for a class method as Sub values.
     ///
-    /// A multi method dispatched from `class_name` combines candidates across
-    /// its whole inheritance chain: the candidate list reported by
-    /// `^find_method(name).candidates` includes every multi candidate defined
-    /// in `class_name` and its ancestors, ordered base-class-first (e.g. for
-    /// `class C2 is C1`, C1's candidates precede C2's). Each candidate carries
-    /// the *owner* class and the index within that class's own candidate list
-    /// so that `.wrap()` keys into the same `(class, method, idx)` slot that
-    /// the dispatcher consults when it reaches that candidate (S06-advanced/
-    /// wrap.t GH#2178).
+    /// A *multi* method dispatched from `class_name` combines candidates across
+    /// its inheritance chain: the list reported by `^find_method(name).candidates`
+    /// includes every multi candidate defined in `class_name` and its ancestors,
+    /// ordered base-class-first (e.g. for `class C2 is C1`, C1's candidates
+    /// precede C2's). Each candidate carries its *owner* class and the index
+    /// within that owner's own candidate list, so `.wrap()` keys into the same
+    /// `(class, method, idx)` slot the dispatcher consults when it reaches that
+    /// candidate during the `callsame`/`nextsame` MRO walk (S06-advanced/wrap.t
+    /// GH#2178).
+    ///
+    /// A class only contributes when *its own* `method_name` is `multi`: a
+    /// non-multi (single) method in a parent shadows the family rather than
+    /// joining it, so it is not a candidate (S06-advanced/dispatching.t). When
+    /// the resolved method is itself non-multi, only that single method is
+    /// returned without any MRO combination.
     pub(super) fn classhow_lookup_all_candidates(
         &self,
         class_name: &str,
@@ -208,15 +214,34 @@ impl Interpreter {
         // No user-code re-entry below (pure Value construction), so a let-bound
         // guard is safe.
         let registry = self.registry();
-        // Walk the MRO base-class-first so the reported candidate order matches
-        // Rakudo's (ancestors before the class itself).
-        let mut stack = Vec::new();
-        let mut mro = registry
-            .compute_class_mro(class_name, &mut stack)
-            .unwrap_or_else(|_| vec![class_name.to_string()]);
-        mro.reverse();
+
+        let class_method_is_multi = |cls: &str| -> bool {
+            registry
+                .classes
+                .get(cls)
+                .and_then(|cd| cd.methods.get(method_name))
+                .map(|defs| defs.iter().any(|d| d.is_multi))
+                .unwrap_or(false)
+        };
+
+        // Build the owner list base-class-first. A non-multi resolved method
+        // does not combine across the MRO — it is its own sole candidate.
+        let owners: Vec<String> = if class_method_is_multi(class_name) {
+            let mut stack = Vec::new();
+            let mut mro = registry
+                .compute_class_mro(class_name, &mut stack)
+                .unwrap_or_else(|_| vec![class_name.to_string()]);
+            mro.reverse();
+            // Only classes whose own `method_name` is multi join the family.
+            mro.into_iter()
+                .filter(|owner| class_method_is_multi(owner))
+                .collect()
+        } else {
+            vec![class_name.to_string()]
+        };
+
         let mut out = Vec::new();
-        for owner in &mro {
+        for owner in &owners {
             let Some(class_def) = registry.classes.get(owner) else {
                 continue;
             };


### PR DESCRIPTION
## Summary

`roast/S06-advanced/wrap.t` test 89 (\"multi methods with a wrapped one are in order\") was the last failure (89/90). Now 90/90 — whitelisted.

The root cause: `^find_method('bar').candidates` returned only the resolved class's *own* multi candidates. For `class C2 is C1`, it omitted C1's inherited candidates and mis-ordered the list. Rakudo combines candidates across the whole inheritance chain **base-class-first**, so `candidates[0]` is the inherited `C1: Str $s`:

```
(C1: Str $s, *%_)
(C1: $v, *%_)
(C2: Str:D $s, *%_)
(C2: Int $i, *%_)
```

mutsu returned only `C2: Str:D $s` / `C2: Int $i`, so `candidates[0].wrap(...)` attached the wrapper to the wrong candidate and it fired at the wrong dispatch position (`[wrapper::bar C2::bar(Str:D) ...]` instead of `[C2::bar(Str:D) wrapper::bar ...]`).

## Fix

`classhow_lookup_all_candidates` now walks the **reversed MRO** and collects every class's candidates base-class-first. Each candidate carries its **owner class** and the **index within that owner's own candidate list**, so `.wrap()` keys into the same `(class, method, idx)` slot the dispatcher already consults (`get_method_wrap_chain` / `find_method_candidate_index`) when it reaches that candidate during `callsame` MRO walk. The wrapper now fires at the correct position.

## Testing

- `roast/S06-advanced/wrap.t`: 90/90 (was 89/90)
- Verified candidate order + wrap firing position match `raku`
- No regressions in S12-introspection/* and S06-currying/* roast suites
- `cargo clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)