### PR TITLE
feat(operator): export operator methods via `import ClassName` (S06 infix.t 14→42)

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -92,15 +92,17 @@
       Code items cannot be rebound"; the block is `#?rakudo skip`-fudged).
     - Tests 1-10 and 12-13 pass. Test 11 (`infix:<;>`) fails (the unfudged file
       evaluates `3 ; 2` as `2`, not `5`); this matches a `#?rakudo todo`.
-    - `import C { method ... is export }` no longer dies with "No exports found"
-      (a class with `is export` methods is now recorded as having exports), so
-      execution reaches tests 12-15 (was 11).
-    - Remaining blocker for tests 14-15: method-form operator dispatch. `~$obj`
-      does not call `method prefix:<~>` on an instance, and the infix `as`
-      operator-form method is not usable as a real infix (`$obj as OtherClass`
-      fails to parse). Needs unary/infix dispatch to consult instance
-      operator-methods plus parser support for user-defined infix from imported
-      operator methods. This is a separate, larger feature.
+    - Tests 12-15 (the `method prefix:<~>/prefix:<+>/infix:<as> is export` +
+      `import MyClass` block) now pass: an exported operator method is registered
+      as a typed multi *sub form* whose invocant becomes the first positional and
+      whose body re-dispatches to the method. `import` copies it into the
+      importing package, and the imported operator symbol is also seeded into the
+      EVAL parser so runtime re-parses recognize it (e.g. `$obj as OtherClass`
+      inside EVAL).
+    - Now runs 42/50. Remaining failures (22-23, 28, 31-32, 35, 40) are unrelated
+      operator features: `is assoc('non')` non-associative parse errors, MMD on
+      `infix:<==>`/`infix:<+>`, `infix:<+>()` empty-arity candidates, and
+      longest-token operator matching (`*+`, `~eq`). Separate, larger features.
 - [ ] roast/S06-operator-overloading/methods.t
 - [ ] roast/S06-operator-overloading/prefix.t
 - [ ] roast/S06-operator-overloading/semicolon.t

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -381,6 +381,14 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     // from regex/substitution operators (e.g. `S` vs `S///`).
     super::super::simple::register_user_type(&name);
 
+    // Record `is export` operator methods so `import ClassName` teaches the
+    // parser the new operator symbols (`method infix:<as> is export` makes `as`
+    // a usable infix in code parsed after the `import`).
+    let exported_ops = super::package_decl::extract_exported_operator_methods(&body);
+    if !exported_ops.is_empty() {
+        super::super::simple::register_inline_module_exports(&name, exported_ops);
+    }
+
     // Validate declarator traits: only 'ver', 'auth', and 'api' are allowed on class names
     for (trait_name, _) in &traits {
         if trait_name != "ver" && trait_name != "auth" && trait_name != "api" {

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -39,6 +39,47 @@ pub(crate) fn extract_exported_subs(
     names
 }
 
+/// Extract names of `is export` *operator methods* (`method prefix:<~> is
+/// export`, `method infix:<as> is export`, ...) from a class/role body. These
+/// are exposed by `import ClassName` as importable operator *subs*, so the
+/// parser must learn the new operator symbols (e.g. `as` becomes a known infix)
+/// when the `import` statement is parsed.
+pub(crate) fn extract_exported_operator_methods(
+    stmts: &[Stmt],
+) -> Vec<super::super::simple::InlineModuleExportSpec> {
+    let mut names = Vec::new();
+    for stmt in stmts {
+        match stmt {
+            Stmt::MethodDecl {
+                name, is_export, ..
+            } if *is_export => {
+                let resolved = name.resolve();
+                if is_operator_categorical_name(&resolved) {
+                    names.push((resolved.to_string(), None, None));
+                }
+            }
+            Stmt::SyntheticBlock(inner) => {
+                names.extend(extract_exported_operator_methods(inner));
+            }
+            _ => {}
+        }
+    }
+    names
+}
+
+/// True for a categorical operator declaration name (`prefix:<...>`,
+/// `infix:<...>`, `postfix:<...>`, `circumfix:<...>`, `postcircumfix:<...>`).
+fn is_operator_categorical_name(name: &str) -> bool {
+    const CATEGORIES: &[&str] = &[
+        "prefix:",
+        "postfix:",
+        "infix:",
+        "circumfix:",
+        "postcircumfix:",
+    ];
+    CATEGORIES.iter().any(|c| name.starts_with(c)) && name.ends_with('>')
+}
+
 /// Recursively collect exported sub names (descending into nested blocks),
 /// returning the first symbol that is exported more than once. In Raku two
 /// `is export` declarations of the same symbol within one package raise

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -7,6 +7,133 @@ use crate::ast::{HandleSpec, ParamDef, PhaserKind};
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// True for a categorical operator name such as `prefix:<~>`, `infix:<as>`,
+    /// `postfix:<!>`, `circumfix:<[ ]>`, etc.
+    fn is_operator_categorical_name(name: &str) -> bool {
+        const CATEGORIES: &[&str] = &[
+            "prefix:",
+            "postfix:",
+            "infix:",
+            "circumfix:",
+            "postcircumfix:",
+        ];
+        CATEGORIES.iter().any(|c| name.starts_with(c)) && name.ends_with('>')
+    }
+
+    /// Register an importable *sub form* for an `is export` operator method.
+    ///
+    /// Raku exposes `method prefix:<~> is export` (etc.) as a sub whose invocant
+    /// becomes the first positional argument and whose body re-dispatches to the
+    /// method. `import ClassName` copies it into the importing package so that
+    /// `~$obj` / `$obj as $x` resolve to the class's operator overload.
+    fn register_exported_operator_method_sub(
+        &mut self,
+        class_name: &str,
+        op_name: &str,
+        method_param_defs: &[ParamDef],
+        tags: Vec<String>,
+    ) {
+        let mut sub_param_defs: Vec<ParamDef> = Vec::new();
+        let mut forward_args: Vec<crate::ast::Expr> = Vec::new();
+        // The invocant (`$self:`) turns into the first positional argument, typed
+        // to the declaring class so dispatch only fires for that class's values.
+        let rest: &[ParamDef] = if method_param_defs.first().is_some_and(|p| p.is_invocant) {
+            let mut inv = method_param_defs[0].clone();
+            inv.is_invocant = false;
+            inv.traits.retain(|t| t != "invocant");
+            if inv.type_constraint.is_none() {
+                inv.type_constraint = Some(class_name.to_string());
+            }
+            sub_param_defs.push(inv);
+            &method_param_defs[1..]
+        } else {
+            sub_param_defs.push(ParamDef {
+                name: "self".to_string(),
+                default: None,
+                multi_invocant: true,
+                required: true,
+                named: false,
+                slurpy: false,
+                double_slurpy: false,
+                onearg: false,
+                sigilless: false,
+                type_constraint: Some(class_name.to_string()),
+                literal_value: None,
+                sub_signature: None,
+                where_constraint: None,
+                traits: Vec::new(),
+                optional_marker: false,
+                outer_sub_signature: None,
+                code_signature: None,
+                is_invocant: false,
+                shape_constraints: None,
+            });
+            method_param_defs
+        };
+        let invocant_name = sub_param_defs[0].name.clone();
+        for p in rest {
+            sub_param_defs.push(p.clone());
+            if !p.named && !p.slurpy && !p.is_capture_subsignature() {
+                forward_args.push(crate::ast::Expr::Var(p.name.clone()));
+            }
+        }
+        let body = vec![Stmt::Expr(crate::ast::Expr::MethodCall {
+            target: Box::new(crate::ast::Expr::Var(invocant_name)),
+            name: Symbol::intern(op_name),
+            args: forward_args,
+            modifier: None,
+            quoted: true,
+        })];
+        let params: Vec<String> = sub_param_defs.iter().map(|p| p.name.clone()).collect();
+        let def = FunctionDef {
+            package: Symbol::intern(class_name),
+            name: Symbol::intern(op_name),
+            params,
+            param_defs: sub_param_defs.clone(),
+            body,
+            is_test_assertion: false,
+            is_rw: false,
+            is_raw: false,
+            is_method: false,
+            empty_sig: false,
+            return_type: None,
+            is_default: false,
+            deprecated_message: None,
+        };
+        // Register as a typed multi candidate under the class package, mirroring
+        // the `multi sub` registration keys so `import` copies it and operator
+        // dispatch type-checks the invocant.
+        let is_positional = |p: &ParamDef| {
+            !p.named && (!p.slurpy || p.name == "_capture") && !p.is_capture_subsignature()
+        };
+        let arity = sub_param_defs.iter().filter(|p| is_positional(p)).count();
+        let type_sig: Vec<&str> = sub_param_defs
+            .iter()
+            .filter(|p| is_positional(p))
+            .map(|p| p.type_constraint.as_deref().unwrap_or("Any"))
+            .collect();
+        let arc = std::sync::Arc::new(def);
+        if type_sig.iter().any(|t| *t != "Any") {
+            let typed_fq = format!(
+                "{}::{}/{}:{}",
+                class_name,
+                op_name,
+                arity,
+                type_sig.join(",")
+            );
+            self.registry_mut()
+                .functions
+                .entry(Symbol::intern(&typed_fq))
+                .or_insert_with(|| arc.clone());
+        }
+        let fq = format!("{}::{}/{}", class_name, op_name, arity);
+        self.registry_mut()
+            .functions
+            .entry(Symbol::intern(&fq))
+            .or_insert(arc);
+        self.register_exported_sub(class_name.to_string(), op_name.to_string(), tags);
+    }
+
     /// Recursively surface `has`-attribute declarations nested inside a sub/block
     /// within a class body (`class C { sub f { has $.x } }`). Descends into
     /// `sub`/block bodies but NOT into a nested `class`/`role` (which owns its own
@@ -1370,11 +1497,26 @@ impl Interpreter {
                         } else {
                             method_export_tags.clone()
                         };
-                        self.register_exported_var(
-                            name.to_string(),
-                            format!("&{}", resolved_method_name),
-                            tags,
-                        );
+                        if Self::is_operator_categorical_name(&resolved_method_name) {
+                            // An operator method (`method prefix:<~> is export`,
+                            // `method infix:<as> is export`, ...) is importable as
+                            // a *sub* whose invocant becomes the first (typed)
+                            // positional and whose body dispatches back to the
+                            // method. `import ClassName` then makes `~$obj` /
+                            // `$obj as $x` resolve to it.
+                            self.register_exported_operator_method_sub(
+                                name,
+                                &resolved_method_name,
+                                &effective_param_defs,
+                                tags,
+                            );
+                        } else {
+                            self.register_exported_var(
+                                name.to_string(),
+                                format!("&{}", resolved_method_name),
+                                tags,
+                            );
+                        }
                     }
                     // Apply custom trait_mod:<is> for each non-builtin trait on methods
                     if !method_custom_traits.is_empty() {

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -191,6 +191,15 @@ impl Interpreter {
             if !import_all && !is_mandatory && symbol_tags.is_disjoint(&requested) {
                 continue;
             }
+            // An imported operator sub (e.g. `method infix:<as> is export`'s
+            // sub form) must be visible to the EVAL parser so code parsed at
+            // runtime recognizes the new operator symbol.
+            if matches!(
+                name.split_once(":<").map(|(c, _)| c),
+                Some("prefix" | "postfix" | "infix" | "circumfix" | "postcircumfix")
+            ) {
+                self.imported_operator_names.insert(name.clone());
+            }
             let source_single = format!("{module}::{name}");
             let source_prefix = format!("{module}::{name}/");
             let target_single = format!("{target_pkg}::{name}");

--- a/t/import-operator-method.t
+++ b/t/import-operator-method.t
@@ -1,0 +1,37 @@
+use Test;
+
+# `method prefix:<~> is export` / `method infix:<as> is export` declares an
+# operator method that `import ClassName` exposes as a sub form: `~$obj` and
+# `$obj as $x` then dispatch to the class's operator overload.
+
+plan 8;
+
+{
+    class OtherClass {
+        has $.x is rw;
+    }
+
+    class MyClass {
+        method prefix:<~> is export { "hi" }
+        method prefix:<+> is export { 42 }
+        method infix:<as>($self: OtherClass $to) is export {
+            my $obj = $to.new;
+            $obj.x = 23;
+            return $obj;
+        }
+    }
+    import MyClass;
+
+    my $obj;
+    lives-ok { $obj = MyClass.new }, "instantiation works";
+    lives-ok { ~$obj }, "object can be stringified";
+    is ~$obj, "hi", "prefix:<~> dispatches to the method";
+    is +$obj, 42, "prefix:<+> dispatches to the method";
+    is ($obj as OtherClass).x, 23, "infix:<as> dispatches to the method";
+    # The new operator must also be visible inside EVAL (runtime re-parse).
+    is EVAL('($obj as OtherClass).x'), 23, "infix:<as> visible in EVAL";
+
+    # The overload only applies to the declaring class; builtins still work.
+    is ~5, "5", "builtin prefix:<~> still works for other types";
+    is +"7", 7, "builtin prefix:<+> still works for other types";
+}


### PR DESCRIPTION
## Summary

A class method declared with an operator-categorical name and `is export`
(`method prefix:<~> is export`, `method infix:<as> is export`, ...) is now
importable as a **sub form**: after `import ClassName`, `~$obj` / `$obj as $x`
dispatch to the class's operator overload.

```raku
class OtherClass { has $.x is rw; }
class MyClass {
    method prefix:<~> is export { "hi" }
    method infix:<as>($self: OtherClass $to) is export { my $o = $to.new; $o.x = 23; $o }
}
import MyClass;
my $obj = MyClass.new;
say ~$obj;                          # hi
say ($obj as OtherClass).x;         # 23
say EVAL('($obj as OtherClass).x'); # 23
```

## How

- At class registration, an exported operator method registers a **typed multi
  candidate** under `Class::op/arity:types` whose invocant becomes the first
  (typed) positional and whose body re-dispatches to the method. `import` copies
  it into the importing package via the existing exported-sub machinery, so
  operator dispatch type-checks the invocant — builtins (`~5`, `+"7"`) still
  apply to other types.
- The parser learns the new operator symbols at `import` parse time (so
  `$obj as OtherClass` parses), and runtime `import_module` seeds the imported
  operator names into the EVAL parser so runtime re-parses recognize them too.

## Tests

- New `t/import-operator-method.t` (8 subtests).
- `roast/S06-operator-overloading/infix.t` now runs 42/50 (previously aborted at
  test 14). Remaining failures (22-23, 28, 31-32, 35, 40) are unrelated operator
  features: `is assoc('non')` parse errors, operator MMD, empty-arity candidates,
  and longest-token matching.
- `make test` passes (13535 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)