### PR TITLE
fix(io): lazy IO::CatHandle.lines/.handles + CR-LF/utf8-c8 reads (io-cathandle.t 5→2)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -730,15 +730,30 @@
        as an expression, not a statement-call that drops the postfix
        (`known_call_stmt` bails to the expression parser). Unblocked
        native-descriptor and t subtests.
-  - **Remaining 5 subtests — deeper gaps** (each its own work item):
-    - chomp/nl-in: needs *lazy* `.lines` (pulling advances the cat and reflects the
-      current chomp/nl-in attributes mid-stream); our `.lines` is eager.
-    - handles: needs a *lazy* `.handles` Seq tied to the live cat (pulling switches
-      handles); our `.handles` is eager and closes handles as it iterates.
-    - on-switch (9/11): test 1 needs lazy `.lines`; test 11 needs captured-outer
-      writeback of the on-switch callback through `slurp`'s nested dispatch.
-    - encoding / perl: `utf8-c8` encoding is unsupported (encoding subtest); `.raku`
-      round-trip + IO::CatHandle `eqv` for the perl subtest.
+  - **2026-07-01: lazy `.lines`/`.handles` + chomp/encoding fixes (5→2 failing).**
+    `.lines` (no `$limit`/`:close`) and `.handles` now return a genuinely-lazy
+    `LazyList` backed by a *live* cat instance (new `CatPullSpec` /
+    `LazyList::new_cat_pull`, sharing the cat's attribute cell). Each pull reads
+    the next line / handle from the same cat, so mid-iteration changes to
+    `.chomp`/`.nl-in`/`.encoding` take effect and `.path`/`on-switch` track the
+    current handle. Wired into every lazy-list site (index, `for`, `.map`/`.grep`
+    lazy-pipe, `force_lazy_list_vm`/`force_lazy_list`, sink, `.cache`). Supporting
+    general fixes: (a) line reading prefers the **longest** matching `nl-in`
+    separator (`"\r\n"` is one ending, not `"\n"` leaving a stray `"\r"`); (b)
+    text-mode reads normalize the CR-LF grapheme to `"\n"` (universal newline /
+    NFG); (c) `.cache` on a genuinely-lazy list stays lazy (returns a no-op-on-sink
+    view) instead of force-materializing; (d) `readchars` honours a `utf8-c8`
+    handle encoding (synthetic graphemes for invalid bytes). Passing now: chomp/
+    nl-in, encoding, handles, and on-switch test 1 (lazy `for $cat.lines`).
+  - **Remaining 2 subtests — deeper gaps** (each its own work item):
+    - on-switch (10/11): test 11 needs captured-outer writeback of the on-switch
+      callback fired from native dispatch — the closure's single write to an outer
+      `my $args` is lost unless the body also *reads* `$args` (a locals↔env
+      dual-store coherence gap; reproduces only when the callback runs nested
+      inside `slurp`/`next-handle`, not from a user-sub call).
+    - perl: `.raku` must emit a fully reconstructable `IO::CatHandle.new(...)` and
+      `is-deeply $cat.raku.EVAL, $cat` needs structural `eqv` over two cats
+      (including their handle objects' attributes).
 - [x] roast/S32-io/io-handle.t — **30/30, whitelisted.** All subtests pass.
       29 `.WRITE` / 30 `.EOF/.WRITE` fixed: a user-subclassed IO::Handle that
       overrides WRITE/READ/EOF now routes the high-level methods through the user

--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -62,6 +62,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                             lazy_pipe: None,
                             closure_seq: None,
                             walk_pending: None,
+                            cat_pull: None,
                         };
                         return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
                     }
@@ -88,6 +89,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                     lazy_pipe: None,
                     closure_seq: None,
                     walk_pending: None,
+                    cat_pull: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1099,6 +1099,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     lazy_pipe: None,
                     closure_seq: None,
                     walk_pending: None,
+                    cat_pull: None,
                 };
                 return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
             }
@@ -1116,6 +1117,18 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             Some(Ok(Value::Seq(combinations_all(&items).into())))
         }
         "cache" => {
+            // A genuinely-lazy list (infinite sequence, lazy pipe, cat-handle
+            // pull, …) must stay lazy under `.cache`: Rakudo's `.cache` reifies
+            // and caches elements on demand, it does not force the whole list.
+            // Forcing here would defeat e.g. `(my $l = $cat.lines).cache` whose
+            // later `$l[2,3]` must reflect mid-iteration attribute changes.
+            if let Value::LazyList(ll) = target
+                && ll.is_genuinely_lazy()
+            {
+                return Some(Ok(Value::LazyList(std::sync::Arc::new(
+                    ll.with_cached_no_sink(),
+                ))));
+            }
             let items = target
                 .as_list_items()
                 .map(|items| items.to_vec())

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -158,6 +158,10 @@ pub(super) fn dispatch(
                                 .walk_pending
                                 .as_ref()
                                 .map(|w| std::sync::Mutex::new(w.lock().unwrap().clone())),
+                            cat_pull: list
+                                .cat_pull
+                                .as_ref()
+                                .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
                         },
                     )))));
                 }
@@ -204,6 +208,7 @@ pub(super) fn dispatch(
                     lazy_pipe: None,
                     closure_seq: None,
                     walk_pending: None,
+                    cat_pull: None,
                 },
             )))))
         }

--- a/src/runtime/handle_read.rs
+++ b/src/runtime/handle_read.rs
@@ -19,9 +19,14 @@ impl Interpreter {
             }
             read_any = true;
             buffer.push(byte[0]);
+            // Prefer the LONGEST matching separator so `"\r\n"` is treated as one
+            // line ending rather than splitting at the trailing `"\n"` and leaving
+            // a stray `"\r"` (when `nl-in` carries both `"\n"` and `"\r\n"`).
             if let Some(matched_len) = separators
                 .iter()
-                .find_map(|sep| buffer.ends_with(sep).then_some(sep.len()))
+                .filter(|sep| buffer.ends_with(sep.as_slice()))
+                .map(|sep| sep.len())
+                .max()
             {
                 if chomp {
                     buffer.truncate(buffer.len().saturating_sub(matched_len));
@@ -41,7 +46,18 @@ impl Interpreter {
         chomp: bool,
     ) -> Result<Option<String>, RuntimeError> {
         match Self::read_record_bytes(reader, separators, chomp)? {
-            Some(buffer) => Ok(Some(String::from_utf8_lossy(&buffer).to_string())),
+            Some(buffer) => {
+                let s = String::from_utf8_lossy(&buffer).to_string();
+                // Raku text-mode reads normalize the CR-LF grapheme to a single
+                // "\n" (universal newline / NFG), even when CR-LF is not itself
+                // the line separator (e.g. reading "6\r\n" with `nl-in => "♥"`
+                // yields "6\n").
+                Ok(Some(if s.contains("\r\n") {
+                    s.replace("\r\n", "\n")
+                } else {
+                    s
+                }))
+            }
             None => Ok(None),
         }
     }

--- a/src/runtime/handle_read_chars.rs
+++ b/src/runtime/handle_read_chars.rs
@@ -38,6 +38,53 @@ impl Interpreter {
         Ok(Some(String::from_utf8_lossy(&bytes).to_string()))
     }
 
+    /// Read one character from a `utf8-c8` (UTF-8 Clean-8) stream. Valid UTF-8
+    /// decodes normally; a byte that cannot start/complete a valid sequence
+    /// becomes one synthetic grapheme (`decode_utf8_c8`). Continuation bytes of a
+    /// rejected sequence are rewound (Seek) so the next read re-examines them.
+    fn read_utf8_c8_char<R: Read + std::io::Seek>(
+        reader: &mut R,
+    ) -> Result<Option<String>, RuntimeError> {
+        let io_err = |err| RuntimeError::new(format!("Failed to read: {}", err));
+        let mut first = [0u8; 1];
+        let n = reader.read(&mut first).map_err(io_err)?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let lead = first[0];
+        let expected_len = match lead {
+            0x00..=0x7F => return Ok(Some((lead as char).to_string())),
+            0xC2..=0xDF => 2usize,
+            0xE0..=0xEF => 3usize,
+            0xF0..=0xF4 => 4usize,
+            // Invalid lead byte (lone continuation, 0xC0/0xC1, 0xF5+): one
+            // synthetic grapheme for this single byte.
+            _ => return Ok(Some(crate::runtime::utf8_c8::decode_utf8_c8(&[lead]))),
+        };
+        let mut rest = vec![0u8; expected_len - 1];
+        let mut total = 0usize;
+        while total < rest.len() {
+            let r = reader.read(&mut rest[total..]).map_err(io_err)?;
+            if r == 0 {
+                break;
+            }
+            total += r;
+        }
+        let mut bytes = vec![lead];
+        bytes.extend_from_slice(&rest[..total]);
+        match std::str::from_utf8(&bytes) {
+            Ok(s) => Ok(Some(s.to_string())),
+            Err(_) => {
+                // Invalid sequence: emit a synthetic grapheme for the lead byte
+                // and rewind the continuation bytes for the next read.
+                reader
+                    .seek(std::io::SeekFrom::Current(-(total as i64)))
+                    .map_err(io_err)?;
+                Ok(Some(crate::runtime::utf8_c8::decode_utf8_c8(&[lead])))
+            }
+        }
+    }
+
     /// Read one character from a UTF-16 stream.
     /// `big_endian` controls byte order. Handles surrogate pairs.
     fn read_utf16_char<R: Read>(
@@ -204,14 +251,25 @@ impl Interpreter {
                         if limit == 0 {
                             return Ok(String::new());
                         }
+                        let is_c8 = encoding == "utf8-c8";
                         let mut out = String::new();
                         for _ in 0..limit {
-                            let Some(ch) = Self::read_utf8_char(file)? else {
+                            let ch = if is_c8 {
+                                Self::read_utf8_c8_char(file)?
+                            } else {
+                                Self::read_utf8_char(file)?
+                            };
+                            let Some(ch) = ch else {
                                 break;
                             };
                             out.push_str(&ch);
                         }
                         Ok(out)
+                    } else if encoding == "utf8-c8" {
+                        let mut bytes = Vec::new();
+                        file.read_to_end(&mut bytes)
+                            .map_err(|err| RuntimeError::new(format!("Failed to read: {}", err)))?;
+                        Ok(crate::runtime::utf8_c8::decode_utf8_c8(&bytes))
                     } else {
                         let mut bytes = Vec::new();
                         file.read_to_end(&mut bytes)

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2992,7 +2992,7 @@ impl Interpreter {
         // which materializes its elements.)
         if let Value::LazyList(ll) = &target
             && matches!(method, "gist" | "Str" | "raku" | "perl")
-            && ll.is_genuinely_lazy()
+            && ll.renders_lazy_placeholder()
         {
             return Ok(Value::str(crate::value::lazy_list_placeholder(
                 method,
@@ -3017,6 +3017,21 @@ impl Interpreter {
             )));
         }
 
+        // `.cache` on a genuinely-lazy list must stay lazy: Rakudo's `.cache`
+        // reifies and caches elements on demand, it does not force the list. A
+        // `LazyList` already caches pulled elements internally, so `.cache` is a
+        // no-op that returns it unchanged. Forcing here would defeat e.g.
+        // `(my $l = $cat.lines).cache` whose later `$l[2,3]` must reflect
+        // mid-iteration changes to the cat's `.nl-in`/`.chomp`.
+        if let Value::LazyList(ll) = &target
+            && method == "cache"
+            && ll.is_genuinely_lazy()
+        {
+            return Ok(Value::LazyList(std::sync::Arc::new(
+                ll.with_cached_no_sink(),
+            )));
+        }
+
         // Force LazyList and re-dispatch as Seq
         if let Value::LazyList(ll) = &target
             && Self::should_force_lazy_list(method)
@@ -3026,7 +3041,7 @@ impl Interpreter {
             // `is_lazy_pipe_source`); a laziness-preserving coercion returns the
             // list unchanged. Neither forces the (possibly infinite) sequence (L2b).
             && !(matches!(method, "map" | "grep")
-                && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather()))
+                && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather() || ll.cat_pull.is_some()))
             && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && crate::runtime::Interpreter::lazy_pipe_preserving_coercion(method))
         {

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -512,6 +512,7 @@ impl Interpreter {
             lazy_pipe: None,
             closure_seq: None,
             walk_pending: None,
+            cat_pull: None,
         };
         Value::LazyList(std::sync::Arc::new(list))
     }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -686,6 +686,13 @@ impl Interpreter {
             }
             if class_name == "IO::CatHandle" && self.is_native_method(&class_name.resolve(), method)
             {
+                // Lazy `.lines` (no `$limit`/`:close`) and `.handles` return a
+                // lazy list backed by the live cat (sharing its attribute cell),
+                // so mid-iteration `.chomp`/`.nl-in`/`.encoding` changes apply and
+                // `.path`/on-switch track the current handle (Rakudo semantics).
+                if let Some(lazy) = Self::cathandle_lazy_method(&target, method, &args) {
+                    return Ok(lazy);
+                }
                 // Every IO::CatHandle method advances internal read state, so route
                 // through the mutable path and commit the updated attributes back to
                 // the receiver's shared cell.

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2229,6 +2229,16 @@ impl Interpreter {
             }
 
             if self.is_native_method(&class_name.resolve(), method) {
+                // Lazy `IO::CatHandle.lines` (no `$limit`/`:close`) / `.handles`
+                // return a lazy list backed by the live cat (sharing its cell),
+                // so mid-iteration `.chomp`/`.nl-in`/`.encoding` changes apply and
+                // `.path`/on-switch track the current handle (Rakudo semantics).
+                if class_name == "IO::CatHandle" {
+                    let cat = Value::instance_sharing_cell(&attributes, class_name, target_id);
+                    if let Some(lazy) = Self::cathandle_lazy_method(&cat, method, &args) {
+                        return Ok(lazy);
+                    }
+                }
                 // Try mutable dispatch first; if no mutable handler, fall back to immutable
                 match self.call_native_instance_method_mut(
                     &class_name.resolve(),

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -110,6 +110,37 @@ impl Interpreter {
         let _ = self.eval_call_on_value(on_switch.clone(), call_args);
     }
 
+    /// The currently-open active `IO::Handle` value, if any.
+    fn cat_active_handle(attrs: &HashMap<String, Value>) -> Option<Value> {
+        match attrs.get("active") {
+            Some(active @ Value::Instance { class_name, .. }) if class_name == "IO::Handle" => {
+                Some(active.clone())
+            }
+            _ => None,
+        }
+    }
+
+    /// Push the cat's current `chomp` / `nl-in` / `encoding` onto the active
+    /// handle so the *next* read reflects them. The cat's settings are
+    /// authoritative; Rakudo's rw `.chomp`/`.nl-in`/`.encoding` setters update
+    /// the live handle, but mutsu's accessor-assignment path writes the attribute
+    /// without notifying the handle, so we re-sync before every read instead.
+    /// Re-pushing an unchanged value is a harmless idempotent field set.
+    fn cat_sync_active_settings(&mut self, attrs: &HashMap<String, Value>) {
+        let Some(active) = Self::cat_active_handle(attrs) else {
+            return;
+        };
+        if let Some(chomp) = attrs.get("chomp").cloned() {
+            let _ = self.native_io_handle_method(&active, "chomp", vec![chomp]);
+        }
+        if let Some(nl_in) = attrs.get("nl-in").cloned() {
+            let _ = self.native_io_handle_method(&active, "nl-in", vec![nl_in]);
+        }
+        if let Some(enc) = attrs.get("encoding").cloned() {
+            let _ = self.native_io_handle_method(&active, "encoding", vec![enc]);
+        }
+    }
+
     /// Open one source value into a read handle, applying the cat's `chomp` /
     /// `nl-in` / `encoding`. Returns `None` when the source cannot be opened.
     fn cat_open_source(&mut self, src: &Value, attrs: &HashMap<String, Value>) -> Option<Value> {
@@ -279,6 +310,7 @@ impl Interpreter {
             if matches!(active, Value::Nil) {
                 return Ok(Value::Nil);
             }
+            self.cat_sync_active_settings(attrs);
             let line = self.native_io_handle_method(&active, "get", vec![])?;
             if matches!(line, Value::Nil) {
                 let next = self.cat_next_handle(attrs);
@@ -298,6 +330,7 @@ impl Interpreter {
             if matches!(active, Value::Nil) {
                 return Ok(Value::Nil);
             }
+            self.cat_sync_active_settings(attrs);
             let c = self.native_io_handle_method(&active, "getc", vec![])?;
             if matches!(c, Value::Nil) {
                 let next = self.cat_next_handle(attrs);
@@ -417,6 +450,37 @@ impl Interpreter {
         attrs.insert("pos".to_string(), Value::Int(pos));
     }
 
+    /// For `.lines` (no positional `$limit` / `:close`) and `.handles`, build a
+    /// lazy list backed by the *live* cat instance `cat` (sharing its attribute
+    /// cell). Each element is pulled on demand by reading from / advancing the
+    /// cat, so mid-iteration attribute changes take effect and `.path`/on-switch
+    /// track the current handle — matching Rakudo's lazy iterators. Returns
+    /// `None` (use the eager path) for `.lines($limit)` / `.lines(:close)`.
+    pub(crate) fn cathandle_lazy_method(
+        cat: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Value> {
+        let mode = match method {
+            "lines" => {
+                // A positional `$limit` or a `:close` adverb keeps the eager path,
+                // which already returns the bounded/closing result directly.
+                let has_limit_or_close = args.iter().any(|a| {
+                    matches!(a, Value::Int(_)) || matches!(a, Value::Pair(k, _) if k == "close")
+                });
+                if has_limit_or_close {
+                    return None;
+                }
+                crate::value::CatPullMode::Lines
+            }
+            "handles" => crate::value::CatPullMode::Handles,
+            _ => return None,
+        };
+        Some(Value::LazyList(std::sync::Arc::new(
+            crate::value::LazyList::new_cat_pull(cat.clone(), mode),
+        )))
+    }
+
     /// Mutable dispatch for `IO::CatHandle` methods. All reads advance internal
     /// state, so every method goes through here and the caller writes the updated
     /// attributes back into the receiver's shared cell.
@@ -496,6 +560,7 @@ impl Interpreter {
                     if want == Some(0) {
                         break;
                     }
+                    self.cat_sync_active_settings(&attrs);
                     let chunk_args = match want {
                         Some(n) => vec![Value::Int(n as i64)],
                         None => vec![],
@@ -592,6 +657,7 @@ impl Interpreter {
             "chomp" => {
                 if let Some(arg) = args.into_iter().next() {
                     attrs.insert("chomp".to_string(), arg.clone());
+                    self.cat_sync_active_settings(&attrs);
                     arg
                 } else {
                     attrs.get("chomp").cloned().unwrap_or(Value::Bool(true))
@@ -600,6 +666,7 @@ impl Interpreter {
             "nl-in" => {
                 if let Some(arg) = args.into_iter().next() {
                     attrs.insert("nl-in".to_string(), arg.clone());
+                    self.cat_sync_active_settings(&attrs);
                     arg
                 } else {
                     attrs
@@ -612,6 +679,7 @@ impl Interpreter {
                 if let Some(arg) = args.into_iter().next() {
                     let s = arg.to_string_value();
                     attrs.insert("encoding".to_string(), Value::str(s.clone()));
+                    self.cat_sync_active_settings(&attrs);
                     Value::str(s)
                 } else {
                     attrs

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -643,6 +643,10 @@ impl Interpreter {
                             .walk_pending
                             .as_ref()
                             .map(|w| std::sync::Mutex::new(w.lock().unwrap().clone())),
+                        cat_pull: list
+                            .cat_pull
+                            .as_ref()
+                            .map(|c| std::sync::Mutex::new(c.lock().unwrap().clone())),
                     }))
                 } else {
                     v

--- a/src/runtime/resolution_lazy.rs
+++ b/src/runtime/resolution_lazy.rs
@@ -22,6 +22,12 @@ impl Interpreter {
                 "Cannot coerce an infinite lazy list to a strict list",
             ));
         }
+        // A lazy `IO::CatHandle.lines`/`.handles` list is finite: pull from the
+        // live cat until exhausted (cache always starts non-empty, so this must
+        // run before the cache short-circuit below).
+        if list.cat_pull.is_some() {
+            return self.force_cat_pull(list, usize::MAX);
+        }
         if let Some(cached) = list.cache.lock().unwrap().clone() {
             return Ok(cached);
         }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1184,6 +1184,33 @@ pub(crate) enum IndexTransform {
     Kv,
 }
 
+/// What a [`CatPullSpec`] lazy list pulls from its backing `IO::CatHandle`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatPullMode {
+    /// `.lines`: each pull reads the next line across all handles (`.get`).
+    Lines,
+    /// `.handles`: the first pull yields the currently-active handle, then each
+    /// subsequent pull advances to the next handle (`.next-handle`).
+    Handles,
+}
+
+/// Lazy `IO::CatHandle.lines` / `.handles` generator. Holds the live cat
+/// instance (sharing its attribute cell with the user's `$cat`), so each pull
+/// reads/advances the *same* cat — letting mid-iteration changes to
+/// `.chomp`/`.nl-in`/`.encoding` take effect and `.path`/`on-switch` track the
+/// current handle, exactly as Rakudo's lazy iterators do.
+#[derive(Debug, Clone)]
+pub(crate) struct CatPullSpec {
+    /// The backing `IO::CatHandle` instance (shares its `AttrCell`).
+    pub(crate) cat: Value,
+    /// Whether to pull lines or handles.
+    pub(crate) mode: CatPullMode,
+    /// `Handles` only: whether the current-active handle was already yielded.
+    pub(crate) started: bool,
+    /// Set once the cat is exhausted so further pulls stop.
+    pub(crate) done: bool,
+}
+
 /// Saved for-loop state for resuming a gather coroutine mid-iteration.
 #[derive(Debug, Clone)]
 pub(crate) enum ForLoopResumeState {
@@ -1294,6 +1321,9 @@ pub(crate) struct LazyList {
     /// Lazy `WALK(method)()` candidate-invocation state (see `WalkPendingState`):
     /// each pull invokes the next MRO-level candidate.
     pub(crate) walk_pending: Option<Mutex<WalkPendingState>>,
+    /// Lazy `IO::CatHandle.lines` / `.handles` generator (see `CatPullSpec`):
+    /// each pull reads the next line / handle from the live cat instance.
+    pub(crate) cat_pull: Option<Mutex<CatPullSpec>>,
 }
 
 /// Placeholder string rendered for a genuinely-lazy list under

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -41,6 +41,10 @@ impl Clone for LazyList {
                 .walk_pending
                 .as_ref()
                 .map(|w| Mutex::new(w.lock().unwrap().clone())),
+            cat_pull: self
+                .cat_pull
+                .as_ref()
+                .map(|c| Mutex::new(c.lock().unwrap().clone())),
         }
     }
 }
@@ -74,11 +78,21 @@ impl LazyList {
             || self.lazy_pipe.is_some()
             || self.closure_seq.is_some()
             || self.scan_spec.is_some()
+            || self.cat_pull.is_some()
         {
             return true;
         }
         (self.coroutine.is_some() || !self.body.is_empty() || self.compiled_code.is_some())
             && self.is_lazy_marked()
+    }
+
+    /// Whether gist/Str/raku should render a `...` placeholder rather than
+    /// materializing this list. True for genuinely-lazy lists EXCEPT a
+    /// `cat_pull` (`IO::CatHandle.lines`/`.handles`), which is finite — it reads
+    /// to the end of the cat's handles — so it must materialize and render its
+    /// elements (and compare structurally under `is-deeply`).
+    pub(crate) fn renders_lazy_placeholder(&self) -> bool {
+        self.is_genuinely_lazy() && self.cat_pull.is_none()
     }
 
     /// Whether this list was produced from a `gather` block (carries the
@@ -103,7 +117,10 @@ impl LazyList {
     /// list (eager or `lazy`), an infinite sequence/closure spec, or a lazy
     /// `WALK(method)()` candidate-invocation list.
     pub(crate) fn needs_vm_lazy_dispatch(&self) -> bool {
-        self.is_from_gather() || self.is_infinite_spec() || self.walk_pending.is_some()
+        self.is_from_gather()
+            || self.is_infinite_spec()
+            || self.walk_pending.is_some()
+            || self.cat_pull.is_some()
     }
 
     /// Whether this list carries the `lazy` prefix marker (set by the `lazy`
@@ -145,6 +162,29 @@ impl LazyList {
         cloned
     }
 
+    /// Marker set by `.cache` on a genuinely-lazy list: the result is a cached,
+    /// re-iterable view, so sinking it is a no-op (it must NOT drain the
+    /// underlying source). A bare lazy Seq sunk still drains; only the
+    /// `.cache`-returned view carries this marker.
+    pub(crate) const CACHED_NO_SINK_MARKER: &'static str = "__mutsu_lazylist_cached_no_sink";
+
+    /// Whether this list is a `.cache`-returned view whose sink is a no-op.
+    pub(crate) fn is_cached_no_sink(&self) -> bool {
+        matches!(
+            self.env.get(Self::CACHED_NO_SINK_MARKER),
+            Some(Value::Bool(true))
+        )
+    }
+
+    /// Return a clone tagged as a `.cache`-returned view (no-op on sink).
+    pub(crate) fn with_cached_no_sink(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned
+            .env
+            .insert(Self::CACHED_NO_SINK_MARKER.to_string(), Value::Bool(true));
+        cloned
+    }
+
     /// Create a pre-cached lazy list (no body to evaluate).
     pub(crate) fn new_cached(items: Vec<Value>) -> Self {
         Self {
@@ -160,6 +200,7 @@ impl LazyList {
             lazy_pipe: None,
             closure_seq: None,
             walk_pending: None,
+            cat_pull: None,
         }
     }
 
@@ -178,6 +219,7 @@ impl LazyList {
             lazy_pipe: None,
             closure_seq: None,
             walk_pending: None,
+            cat_pull: None,
         }
     }
 
@@ -196,6 +238,7 @@ impl LazyList {
             lazy_pipe: None,
             closure_seq: None,
             walk_pending: None,
+            cat_pull: None,
         }
     }
 
@@ -231,6 +274,7 @@ impl LazyList {
             })),
             closure_seq: None,
             walk_pending: None,
+            cat_pull: None,
         }
     }
 
@@ -270,6 +314,7 @@ impl LazyList {
             })),
             closure_seq: None,
             walk_pending: None,
+            cat_pull: None,
         }
     }
 
@@ -292,6 +337,34 @@ impl LazyList {
             lazy_pipe: None,
             closure_seq: Some(Mutex::new(state)),
             walk_pending: None,
+            cat_pull: None,
+        }
+    }
+
+    /// Create a lazy `IO::CatHandle.lines` / `.handles` list backed by a live
+    /// cat instance (sharing its attribute cell). Each element is pulled on
+    /// demand by reading from / advancing the cat, so mid-iteration changes to
+    /// the cat's attributes take effect.
+    pub(crate) fn new_cat_pull(cat: Value, mode: crate::value::CatPullMode) -> Self {
+        Self {
+            body: Vec::new(),
+            env: crate::env::Env::new(),
+            cache: Mutex::new(Some(Vec::new())),
+            compiled_code: None,
+            compiled_fns: None,
+            elems_count: None,
+            scan_spec: None,
+            sequence_spec: None,
+            coroutine: None,
+            lazy_pipe: None,
+            closure_seq: None,
+            walk_pending: None,
+            cat_pull: Some(Mutex::new(crate::value::CatPullSpec {
+                cat,
+                mode,
+                started: false,
+                done: false,
+            })),
         }
     }
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -437,7 +437,7 @@ impl Interpreter {
         // the gather-coroutine force below, which would hang on an infinite list.
         if let Value::LazyList(ref ll) = target
             && matches!(method.as_str(), "gist" | "Str" | "raku" | "perl")
-            && ll.is_genuinely_lazy()
+            && ll.renders_lazy_placeholder()
         {
             self.stack
                 .push(Value::str(crate::value::lazy_list_placeholder(
@@ -476,6 +476,17 @@ impl Interpreter {
             self.stack.push(pipe);
             return Ok(());
         }
+        // `.cache` on a genuinely-lazy list stays lazy (caches on demand); see
+        // the matching note in the non-mut dispatch path.
+        if let Value::LazyList(ref ll) = target
+            && method == "cache"
+            && ll.is_genuinely_lazy()
+        {
+            self.stack.push(Value::LazyList(std::sync::Arc::new(
+                ll.with_cached_no_sink(),
+            )));
+            return Ok(());
+        }
         let target = if let Value::LazyList(ref ll) = target
             && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(&method)
@@ -487,7 +498,7 @@ impl Interpreter {
             // Laziness-preserving coercions return the list unchanged (native
             // dispatch) — neither forces.
             && !(matches!(method.as_str(), "map" | "grep")
-                && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather()))
+                && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather() || ll.cat_pull.is_some()))
             && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && Self::lazy_pipe_preserving_coercion(&method))
             // On an infinite sequence/closure spec the count/numeric coercions

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -682,7 +682,7 @@ impl Interpreter {
         // `lazy_pipe` and is forced & rendered normally below.
         if let Value::LazyList(ref ll) = target
             && matches!(method, "gist" | "Str" | "raku" | "perl")
-            && ll.is_genuinely_lazy()
+            && ll.renders_lazy_placeholder()
         {
             self.stack
                 .push(Value::str(crate::value::lazy_list_placeholder(
@@ -727,6 +727,20 @@ impl Interpreter {
             self.stack.push(pipe);
             return Ok(());
         }
+        // `.cache` on a genuinely-lazy list must stay lazy: Rakudo's `.cache`
+        // reifies on demand, it does not force. A `LazyList` already caches
+        // pulled elements internally, so return it unchanged — this keeps
+        // `(my $l = $cat.lines).cache` lazy so later slice reads still reflect
+        // mid-iteration changes to the cat's `.nl-in`/`.chomp`.
+        if let Value::LazyList(ref ll) = target
+            && method == "cache"
+            && ll.is_genuinely_lazy()
+        {
+            self.stack.push(Value::LazyList(std::sync::Arc::new(
+                ll.with_cached_no_sink(),
+            )));
+            return Ok(());
+        }
         let target = if let Value::LazyList(ref ll) = target
             && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(method)
@@ -739,7 +753,7 @@ impl Interpreter {
             // Laziness-preserving coercions return the list unchanged (native
             // dispatch) — neither forces.
             && !(matches!(method, "map" | "grep")
-                && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather()))
+                && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather() || ll.cat_pull.is_some()))
             && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && Self::lazy_pipe_preserving_coercion(method))
             // On an infinite sequence/closure spec the count/numeric coercions

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2272,6 +2272,11 @@ impl Interpreter {
                         return Ok(());
                     }
                     match &val {
+                        // A `.cache`-returned view is a cached, re-iterable list;
+                        // sinking it is a no-op and must NOT drain the underlying
+                        // source (e.g. `(my $l = $cat.lines).cache;` keeps the cat
+                        // unread). A bare lazy Seq still drains below.
+                        Value::LazyList(list) if list.is_cached_no_sink() => {}
                         Value::LazyList(list) => {
                             self.force_lazy_list_vm(list)?;
                         }

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -133,7 +133,11 @@ impl Interpreter {
             && (ll.coroutine.is_some()
                 || ll.sequence_spec.is_some()
                 || ll.lazy_pipe.is_some()
-                || ll.walk_pending.is_some())
+                || ll.walk_pending.is_some()
+                // `for $cat.lines` / `for $cat.handles`: pull one element per
+                // iteration so `on-switch` fires and `.path` tracks the current
+                // handle inside the loop body (Rakudo's lazy semantics).
+                || ll.cat_pull.is_some())
         {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -214,6 +214,13 @@ impl Interpreter {
             return Self::extend_sequence_cache(list, spec, MAX_ARRAY_EXPAND);
         }
 
+        // A lazy `IO::CatHandle.lines` / `.handles` list is finite (it reads to
+        // the end of the cat's handles): force it fully by pulling until the cat
+        // is exhausted.
+        if list.cat_pull.is_some() {
+            return self.force_cat_pull(list, usize::MAX);
+        }
+
         // Check cache first
         if let Some(cached) = list.cache.lock().unwrap().clone() {
             return Ok(cached);

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -22,6 +22,12 @@ impl Interpreter {
             return self.force_walk_pending(list, needed);
         }
 
+        // Lazy `IO::CatHandle.lines` / `.handles`: pull the next line / handle
+        // from the live cat instance on demand.
+        if list.cat_pull.is_some() {
+            return self.force_cat_pull(list, needed);
+        }
+
         // For sequence-spec lazy lists, generate more elements on demand
         if let Some(ref spec) = list.sequence_spec {
             return Self::extend_sequence_cache(list, spec, needed);
@@ -374,6 +380,86 @@ impl Interpreter {
                     cache.get_or_insert_with(Vec::new).extend(produced);
                 }
             }
+        }
+    }
+
+    /// Produce at least `needed` elements of a lazy `IO::CatHandle.lines` /
+    /// `.handles` list (a `LazyList` carrying a [`crate::value::CatPullSpec`]).
+    ///
+    /// Each element is pulled from the *live* cat instance: `.lines` calls
+    /// `.get`, `.handles` yields the current active handle then `.next-handle`
+    /// for each subsequent one. Because the cat shares its attribute cell with
+    /// the user's `$cat`, mid-iteration mutations (`.chomp = …`, `.nl-in = …`,
+    /// `.encoding: …`) take effect on later pulls and `.path`/`on-switch` track
+    /// the current handle, matching Rakudo's lazy iterators.
+    pub(crate) fn force_cat_pull(
+        &mut self,
+        list: &LazyList,
+        needed: usize,
+    ) -> Result<Vec<Value>, RuntimeError> {
+        use crate::value::CatPullMode;
+        loop {
+            // Fast path: enough cached, or the cat is exhausted.
+            {
+                let cache = list.cache.lock().unwrap();
+                let done = list
+                    .cat_pull
+                    .as_ref()
+                    .map(|p| p.lock().unwrap().done)
+                    .unwrap_or(true);
+                if let Some(c) = cache.as_ref()
+                    && (c.len() >= needed || done)
+                {
+                    let n = needed.min(c.len());
+                    return Ok(c[..n].to_vec());
+                }
+            }
+
+            // Snapshot the spec without holding its lock across the (re-entrant)
+            // method call into the cat.
+            let (cat, mode, started) = {
+                let spec = list.cat_pull.as_ref().unwrap().lock().unwrap();
+                (spec.cat.clone(), spec.mode, spec.started)
+            };
+
+            let pulled: Value = match mode {
+                CatPullMode::Lines => self.call_method_with_values(cat.clone(), "get", vec![])?,
+                CatPullMode::Handles if !started => {
+                    // First pull: the currently-active handle, opened on demand
+                    // but without advancing past it.
+                    {
+                        let mut spec = list.cat_pull.as_ref().unwrap().lock().unwrap();
+                        spec.started = true;
+                    }
+                    // `.path` ensures the first source is opened if nothing has
+                    // been read yet, then we read the live active handle.
+                    let _ = self.call_method_with_values(cat.clone(), "path", vec![]);
+                    match &cat {
+                        Value::Instance { attributes, .. } => attributes
+                            .as_map()
+                            .get("active")
+                            .cloned()
+                            .unwrap_or(Value::Nil),
+                        _ => Value::Nil,
+                    }
+                }
+                CatPullMode::Handles => {
+                    self.call_method_with_values(cat.clone(), "next-handle", vec![])?
+                }
+            };
+
+            if matches!(pulled, Value::Nil) {
+                let mut spec = list.cat_pull.as_ref().unwrap().lock().unwrap();
+                spec.done = true;
+                drop(spec);
+                let cache = list.cache.lock().unwrap();
+                let c = cache.as_ref().cloned().unwrap_or_default();
+                let n = needed.min(c.len());
+                return Ok(c[..n].to_vec());
+            }
+
+            let mut cache = list.cache.lock().unwrap();
+            cache.get_or_insert_with(Vec::new).push(pulled);
         }
     }
 }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -54,6 +54,7 @@ impl Interpreter {
                 lazy_pipe: None,
                 closure_seq: None,
                 walk_pending: None,
+                cat_pull: None,
             };
             let val = Value::LazyList(std::sync::Arc::new(list));
             self.stack.push(val);

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -436,6 +436,7 @@ impl Interpreter {
                 || ll.lazy_pipe.is_some()
                 || ll.sequence_spec.is_some()
                 || ll.closure_seq.is_some()
+                || ll.cat_pull.is_some()
             {
                 // Gather-based lazy list / lazy map-grep pipeline / infinite
                 // arithmetic-or-closure sequence: force only as many elements as
@@ -449,6 +450,27 @@ impl Interpreter {
                     }
                     Value::RangeExcl(_, end) if *end > 0 => {
                         self.force_lazy_list_vm_n(ll, *end as usize)?
+                    }
+                    // A list of non-negative integer indices (`$s[2, 3]`): force
+                    // only up to the largest index + 1, keeping the tail lazy so
+                    // later pulls still see mid-iteration changes (e.g. a cat
+                    // handle whose `.nl-in` is reset between slice reads).
+                    _ if index.as_list_items().is_some_and(|items| {
+                        !items.is_empty()
+                            && items.iter().all(|v| matches!(v, Value::Int(i) if *i >= 0))
+                    }) =>
+                    {
+                        let max = index
+                            .as_list_items()
+                            .unwrap()
+                            .iter()
+                            .filter_map(|v| match v {
+                                Value::Int(i) => Some(*i as usize),
+                                _ => None,
+                            })
+                            .max()
+                            .unwrap_or(0);
+                        self.force_lazy_list_vm_n(ll, max.saturating_add(1))?
                     }
                     _ => self.force_lazy_list_vm(ll)?,
                 }

--- a/t/io-cathandle-lazy.t
+++ b/t/io-cathandle-lazy.t
@@ -1,0 +1,63 @@
+use Test;
+
+# Lazy IO::CatHandle.lines / .handles backed by a live cat instance:
+# mid-iteration changes to .chomp / .nl-in take effect, .handles is consumable
+# concurrently, CR-LF is one line ending and normalizes to "\n", and a lazy
+# `for $cat.lines` interleaves with the body so the cat stays mid-stream.
+
+plan 9;
+
+my $seq = 0;
+sub tmpfile($content) {
+    my $p = $*TMPDIR.add("mutsu-cat-{$*PID}-{$seq++}");
+    $p.spurt: $content;
+    $p
+}
+
+# --- lazy .lines reflects mid-iteration .chomp / .nl-in changes ---
+{
+    my $cat = IO::CatHandle.new: tmpfile("0\n1\r\n2Z\n3V4"), tmpfile(''), tmpfile("5\nZ6\r\n♥7♥");
+    (my $lines = $cat.lines).cache;
+    is-deeply $lines[^2], ("0", "1"), 'lazy lines: default chomp/nl-in';
+    $cat.chomp = False;
+    $cat.nl-in = [<Z V>];
+    is-deeply $lines[2, 3], ("2Z", "\n3V"), 'lazy lines: nl-in change applies mid-stream';
+    is-deeply $lines[4, 5], ("4", "5\nZ"), 'lazy lines: change carries to next handle';
+    $cat.chomp = True;
+    $cat.nl-in = '♥';
+    is-deeply $lines[6, 7], ("6\n", "7"), 'lazy lines: CR-LF normalizes to \n';
+    $cat.close;
+}
+
+# --- CR-LF is one line ending (longest-match separator) ---
+{
+    my $cat = IO::CatHandle.new: tmpfile("a\r\nb\r\nc");
+    is-deeply $cat.lines, ("a", "b", "c"), 'CR-LF is a single line ending';
+}
+
+# --- lazy .handles is consumable concurrently with the cat ---
+{
+    my $cat := IO::CatHandle.new: tmpfile("a1\na2\na3\na4"), tmpfile("b1\nb2\nb3\nb4"), tmpfile("c1\nc2\nc3\nc4");
+    is-deeply $cat.handles.map({ eager .lines: 2 }),
+        (<a1 a2>, <b1 b2>, <c1 c2>).Seq, 'lazy .handles: reads 2 lines per handle';
+}
+
+# --- lazy `for $cat.lines` interleaves with the body (on-switch + .path) ---
+{
+    my $ln;
+    my $cat = IO::CatHandle.new: :on-switch(-> { $ln = 1 }),
+        tmpfile("a\nb\nc"), tmpfile("d\ne");
+    my @nums = gather for $cat.lines { take $ln++ }
+    is-deeply @nums, [1, 2, 3, 1, 2], 'lazy for: on-switch resets per file';
+}
+
+# --- readchars honours utf8-c8 (round-trips against Buf.decode) ---
+{
+    my $cat = IO::CatHandle.new: tmpfile('foo'), tmpfile(Buf.new(200));
+    $cat.encoding: 'ascii';
+    is $cat.readchars(3), 'foo', 'readchars: ascii prefix';
+    $cat.encoding: 'utf8-c8';
+    is-deeply $cat.readchars(1), Buf.new(200).decode('utf8-c8'),
+        'readchars: utf8-c8 synthetic grapheme';
+    $cat.close;
+}


### PR DESCRIPTION
## Summary

Makes `IO::CatHandle` read methods genuinely lazy and tied to the live cat, fixing
3 of the 5 remaining `roast/S32-io/io-cathandle.t` failures (chomp/nl-in, encoding,
handles) plus most of the on-switch subtest.

`.lines` (no `$limit`/`:close`) and `.handles` now return a genuinely-lazy
`LazyList` backed by a **live** cat instance (new `CatPullSpec` /
`LazyList::new_cat_pull`, sharing the cat's attribute cell). Each pull reads the
next line / handle from the *same* cat, so:
- mid-iteration changes to `.chomp`/`.nl-in`/`.encoding` take effect,
- `.path` / `on-switch` track the current handle,
- `.handles` is consumable concurrently with the cat,
- `for $cat.lines { ... }` interleaves with the body (on-switch fires per file).

The `cat_pull` generator is wired into every lazy-list path: incremental index,
`for` iteration, `.map`/`.grep` lazy-pipe source, `force_lazy_list_vm` /
`force_lazy_list` (finite full force), sink, and `.cache` (now stays lazy via a
no-op-on-sink view instead of force-materializing).

### Supporting general fixes
- **Longest-match line separator** — `"\r\n"` is a single line ending, not a split
  at the trailing `"\n"` that leaves a stray `"\r"` (when `nl-in` carries both).
- **CR-LF normalization** — text-mode reads normalize the CR-LF grapheme to `"\n"`
  (universal newline / NFG), even when CR-LF is not itself the separator.
- **utf8-c8 readchars** — `readchars` honours a `utf8-c8` handle encoding (one
  synthetic grapheme per invalid byte; continuation bytes rewound via `Seek`).

## Result
`roast/S32-io/io-cathandle.t`: **5 failing → 2**. Newly passing: chomp/nl-in,
encoding, handles, on-switch test 1.

Remaining (documented in `TODO_roast/S32.md`, each its own deeper work item):
- on-switch test 11 — captured-outer writeback of an on-switch callback fired from
  native dispatch (a locals↔env dual-store coherence gap).
- perl — `.raku` EVAL round-trip + structural `eqv` over two cats.

## Tests
- `make test` passes (no regressions).
- Adds `t/io-cathandle-lazy.t` (9 assertions, passes on both mutsu and rakudo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)