### PR TITLE
fix(our-sub): block-lexical capture for `our sub` in a bare block (S04 my-6e.t 80,81)

### DIFF
--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -155,20 +155,24 @@
       (`destructure.rs`: `collect_nested_group_vars` flattens nested target
       groups). The precise nested *value* binding is `#?rakudo skip`-ped even on
       rakudo, so flattening-without-error is all that is required.
-  - **Remaining blockers (deep; test not whitelistable until solved):**
+  - **Progress (2026-07-01): 80,81 fixed (108/109). `our sub` block-lexical
+    capture** — an `our sub` declared in a bare block now closes over the block's
+    `my` lexicals. The compiler marks those captured locals
+    (`needs_cell_escaping_our_sub`, gated on the `our` sub via `compiling_our_sub`;
+    `our`-declared vars excluded by `our_locals` slot), boxes them into a shared
+    cell at their decl site, and the sub's source-order `RegisterSub` persists the
+    cell into `escaped_our_lexical_cells` (keyed to the sub's declaration, NOT the
+    box site, so a same-named sibling-block `my` cannot pollute it). A free-var read
+    inside the escaped sub resolves through the cell (`escaping_our_read`, seeded
+    name set `escaping_our_lexical_names` at run start), short-circuiting the
+    leaked-env shadow; a read before the block correctly yields undefined. Test:
+    t/our-sub-block-lexical-capture.t. (Writes from inside the escaped sub do not
+    yet accumulate through the cell — reads only; not exercised by this roast file.)
+  - **Remaining blocker (deep; test not whitelistable until solved):**
     - 61: `dies-ok { EVAL '$x = "abc"'; my Int $x; }` — the (later-declared)
       typed lexical's constraint must be in effect at block start so the EVAL's
       assignment is a type error. Needs forward-`my` hoisting into the EVAL pad
       *with* its type; mutsu's EVAL has no access to the enclosing block AST.
-    - 80,81: `&OUR::access_lexical_a()` resolves but the closure body's `$a`
-      resolves to a same-named *outer* lexical (top-level `my $a = 1`) instead of
-      the inner block's `$a`. Root cause is the general closure-shadowing leak:
-      at closure dispatch the captured env is merged with `entry_or_insert`, so a
-      live caller var of the same name wins over the captured one (affects plain
-      `my $a=1; { my $a=42; $f = sub {$a} }; $f()` → 1, should be 42). The sound
-      fix is box-on-capture for read-only shadowing block-locals (ADR-0001 cell
-      substrate); 80's "before" case additionally needs the inner slot
-      pre-allocated/shadowing before the block runs.
 - [x] roast/S04-declarations/smiley.t
 - [ ] roast/S04-declarations/state.t
   - 46/46 pass (test 38 is a rakudo TODO which is expected to fail). Cannot whitelist: test 42 (2M function calls in lives-ok) takes ~20s CPU in release, which risks exceeding 30s wall-clock timeout under load.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -406,6 +406,35 @@ impl Compiler {
         self.code
             .named_sub_captures
             .push((nf_writes, cf.code.needs_cell_named_sub_free.clone()));
+        // An `our sub` is installed into the package registry and outlives its
+        // declaring block, but a registry routine has no per-sub closure env. So
+        // every lexical it READS or WRITES must be boxed into a shared cell at its
+        // declaration site AND persisted into `escaped_our_lexical_cells`, so a call
+        // made after the block reads the live cell instead of `Nil`. Contribute the
+        // sub's full free-var set (reads ∪ writes ∪ bubbled ancestor needs) so
+        // `compute_free_vars` can mark our own locals for decl-site boxing.
+        if self.compiling_our_sub {
+            let mut esc = cf.code.free_var_syms.clone();
+            esc.extend(cf.code.free_var_writes.iter().copied());
+            esc.extend(cf.code.free_var_container_writes.iter().copied());
+            esc.extend(cf.code.needs_cell_named_sub_free.iter().copied());
+            esc.extend(cf.code.needs_cell_escaping_our_sub_free.iter().copied());
+            // Only genuine `my` lexicals are captured this way. Exclude dynamic
+            // (`$*X`), attribute (`$!x`/`$.x`), special (`$/`, `$0`, `$_`, `$!`) and
+            // other twigled names: those resolve through their own stores (dynamic
+            // scope, the self-attribute cell, the match var, ...), and boxing them
+            // would break e.g. a dynamic-var write reaching the caller. A plain
+            // lexical's bare name starts with an ASCII letter.
+            esc.retain(|sym| {
+                sym.with_str(|s| {
+                    s.trim_start_matches(['$', '@', '%', '&'])
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_ascii_alphabetic())
+                })
+            });
+            self.code.escaping_our_sub_captures.push(esc);
+        }
         self.compiled_functions.insert(key, cf);
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -152,6 +152,13 @@ pub(crate) struct Compiler {
     /// non-escaping (immediately-invoked) classification, so call arguments and
     /// control-construct blocks never over-box (the #2746 perf guard).
     escaping_position: bool,
+    /// True while compiling the body of an `our`-scoped named sub. An `our sub` is
+    /// installed into the package registry and stays callable after its declaring
+    /// block exits, so the lexicals it reads/writes must be boxed into shared cells
+    /// and persisted (see `CompiledCode::escaping_our_sub_captures`). Read in
+    /// `compile_sub_body_with_deprecation` when contributing the sub's captures to
+    /// the enclosing scope.
+    pub(crate) compiling_our_sub: bool,
     /// True only for the outermost compilation unit (the mainline / a top-level
     /// EVAL). Used to detect placeholder variables (`$^x`, `@_`, ...) that appear
     /// outside any sub or block -> X::Placeholder::Mainline.
@@ -198,6 +205,7 @@ impl Compiler {
             pending_index_rw_writebacks: Vec::new(),
             current_distribution: None,
             escaping_position: false,
+            compiling_our_sub: false,
             is_mainline: false,
             suppress_pair_capture: false,
             synthetic_block_body: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2572,6 +2572,11 @@ impl Compiler {
                         })
                     }
                 });
+                // An `our sub` outlives its declaring block via the package
+                // registry; flag the body compile so its read/write lexical
+                // captures are boxed + persisted (escaping_our_sub_captures).
+                let prev_our = self.compiling_our_sub;
+                self.compiling_our_sub = custom_traits.iter().any(|(t, _)| t == "__our_scoped");
                 self.compile_sub_body_with_deprecation(
                     &name_str,
                     params,
@@ -2584,6 +2589,7 @@ impl Compiler {
                     *is_raw,
                     deprecated_info.clone(),
                 );
+                self.compiling_our_sub = prev_our;
                 for (alt_params, alt_param_defs) in signature_alternates {
                     self.compile_sub_body_with_deprecation(
                         &name_str,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1408,6 +1408,24 @@ pub(crate) struct CompiledCode {
     /// that declares the local folds it into its own `needs_cell_named_sub`
     /// (mirrors `needs_cell_free_vars` for closures).
     pub(crate) needs_cell_named_sub_free: Vec<Symbol>,
+    /// Free-variable captures of directly-nested *`our`-scoped* named subs. Unlike
+    /// a plain `my sub`, an `our sub` is installed into the package registry and
+    /// stays callable *after* its declaring block exits, but a registry routine has
+    /// no per-sub closure env. So the lexicals it READS (not just writes) must be
+    /// boxed into a shared `ContainerRef` cell at their declaration site AND
+    /// persisted into `Interpreter::escaped_our_lexical_cells`, so a call made after
+    /// the block reads the live cell instead of `Nil`. Each entry is one our-sub's
+    /// full free-var set (reads ∪ writes ∪ bubbled ancestor cell-needs). Computed
+    /// into `needs_cell_escaping_our_sub` / `_free` by `compute_free_vars`.
+    pub(crate) escaping_our_sub_captures: Vec<Vec<Symbol>>,
+    /// Own locals captured (read or written) by a directly-nested `our`-scoped named
+    /// sub. The VM boxes these at their declaration site and persists the cell so the
+    /// escaped sub resolves them after the block exits. See `escaping_our_sub_captures`.
+    pub(crate) needs_cell_escaping_our_sub: Vec<Symbol>,
+    /// Escaping-our-sub captures of a NON-own (ancestor) lexical, bubbled up so the
+    /// ancestor that declares the local folds it into its own
+    /// `needs_cell_escaping_our_sub` (mirrors `needs_cell_named_sub_free`).
+    pub(crate) needs_cell_escaping_our_sub_free: Vec<Symbol>,
     /// Own locals that are BOTH captured by a nested closure AND mutated after
     /// their declaration (reassigned/inc-dec in this scope, or written from
     /// inside a nested closure). Such a local must be a shared container so the
@@ -1504,6 +1522,9 @@ impl CompiledCode {
             named_sub_captures: Vec::new(),
             needs_cell_named_sub: Vec::new(),
             needs_cell_named_sub_free: Vec::new(),
+            escaping_our_sub_captures: Vec::new(),
+            needs_cell_escaping_our_sub: Vec::new(),
+            needs_cell_escaping_our_sub_free: Vec::new(),
             captured_mutated_locals: Vec::new(),
             needs_cell_locals: Vec::new(),
             needs_cell_free_vars: Vec::new(),
@@ -2005,6 +2026,19 @@ impl CompiledCode {
                 }
             }
         }
+        // Escaping-our-sub cell requirements bubbled up from nested scopes (an
+        // `our sub` declared inside a nested block whose captured lexical we own).
+        let mut nceos: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
+        let mut nceos_free: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
+        for nested in &self.closure_compiled_codes {
+            for sym in &nested.needs_cell_escaping_our_sub_free {
+                if sym.with_str(|s| own.contains(s)) {
+                    nceos.insert(*sym);
+                } else {
+                    nceos_free.insert(*sym);
+                }
+            }
+        }
         // Named-sub decl-site boxing (kept entirely separate from the closure
         // analysis above): a local that a directly-nested named sub WRITES must be
         // a shared cell so the sub's by-name env write and the owner's slot read
@@ -2034,6 +2068,38 @@ impl CompiledCode {
         }
         self.needs_cell_named_sub = ncns.into_iter().collect();
         self.needs_cell_named_sub_free = ncns_free.into_iter().collect();
+        // Escaping-our-sub decl-site boxing: a local that a directly-nested
+        // `our sub` READS or WRITES must be boxed into a shared cell AND persisted
+        // (the registry routine outlives the block, with no closure env), so a call
+        // after the block reads the live cell. Both reads and writes count here —
+        // unlike `needs_cell_named_sub` (writes only), because a read-only capture
+        // would otherwise resolve to `Nil` once the block scope is gone.
+        // EXCLUDE `our`-declared vars: an `our sub` that reads an `our $msg` in the
+        // same package block resolves it through the package/our store (handled by
+        // the existing `GetGlobal` fallbacks), NOT the escaping-my-lexical cell. The
+        // captured name maps to a local slot that is also recorded in `our_locals`.
+        let our_slots: std::collections::HashSet<usize> =
+            self.our_locals.iter().map(|(slot, _)| *slot).collect();
+        for syms in &self.escaping_our_sub_captures {
+            for sym in syms {
+                let is_our_local = sym.with_str(|s| {
+                    self.locals
+                        .iter()
+                        .position(|l| l == s)
+                        .is_some_and(|slot| our_slots.contains(&slot))
+                });
+                if is_our_local {
+                    continue;
+                }
+                if sym.with_str(|s| own.contains(s)) {
+                    nceos.insert(*sym);
+                } else {
+                    nceos_free.insert(*sym);
+                }
+            }
+        }
+        self.needs_cell_escaping_our_sub = nceos.into_iter().collect();
+        self.needs_cell_escaping_our_sub_free = nceos_free.into_iter().collect();
         self.free_var_syms = free.into_iter().collect();
         self.free_var_writes = free_writes.into_iter().collect();
         self.free_var_container_writes = free_container_writes.into_iter().collect();

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -127,6 +127,48 @@ impl Interpreter {
         &mut self.env
     }
 
+    /// Recursively collect every `needs_cell_escaping_our_sub` name from `code` and
+    /// its nested closure codes into `escaping_our_lexical_names`. Called once at
+    /// program start so the set is populated before any block runs.
+    pub(crate) fn collect_escaping_our_lexical_names(
+        &mut self,
+        code: &crate::opcode::CompiledCode,
+    ) {
+        for sym in &code.needs_cell_escaping_our_sub {
+            self.escaping_our_lexical_names.insert(sym.resolve());
+        }
+        for nested in &code.closure_compiled_codes {
+            self.collect_escaping_our_lexical_names(nested);
+        }
+    }
+
+    /// Resolve a free-variable read of a block lexical captured by an `our`-scoped
+    /// named sub (`escaping_our_lexical_names`). Returns:
+    ///   * `Some(cell)` — the persisted shared cell, once the declaring block has
+    ///     run and recorded it (`escaped_our_lexical_cells`).
+    ///   * `Some(Nil)`  — when the name IS such a capture but no cell is recorded
+    ///     yet (a call BEFORE the block runs). This deliberately SHORT-CIRCUITS the
+    ///     normal env lookup so an unrelated leaked `env` value from a sibling block
+    ///     cannot shadow the (still-undefined) captured lexical.
+    ///   * `None`       — not an escaping-our capture, or read outside any routine
+    ///     (a bare top-level reference must not see the closure's private lexical):
+    ///     the caller resolves normally.
+    pub(crate) fn escaping_our_read(&self, name: &str) -> Option<Value> {
+        if self.escaping_our_lexical_names.is_empty()
+            || self.routine_stack.is_empty()
+            || name.contains("::")
+            || !self.escaping_our_lexical_names.contains(name)
+        {
+            return None;
+        }
+        Some(
+            self.escaped_our_lexical_cells
+                .get(name)
+                .cloned()
+                .unwrap_or(Value::Nil),
+        )
+    }
+
     /// Get a cloned copy of the persisted closure env for a given closure id.
     pub(crate) fn get_closure_env_override(&self, id: u64) -> Option<crate::env::Env> {
         self.closure_env_overrides.get(&id).cloned()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1181,6 +1181,29 @@ pub struct Interpreter {
     /// subs (where `current_package == Foo`), so it does not leak the lexical to
     /// bare references after the block (which run under `GLOBAL`).
     pub(crate) package_lexicals: HashMap<String, HashMap<String, Value>>,
+    /// Shared cells for block lexicals captured by an `our`-scoped named sub
+    /// declared inside a *bare* block (not a package block). Unlike a `my sub`, an
+    /// `our sub` is installed into the package registry and stays callable after
+    /// the block exits, but a registry routine carries no per-sub closure env. When
+    /// the captured local (`my $a`) is declared, the VM boxes it into a shared
+    /// `ContainerRef` cell and records it here keyed by the variable name; a
+    /// free-var read inside the escaped sub resolves through this cell
+    /// (`escaping_our_read`), so `our sub f { $a }` called after the block sees the
+    /// live value (Raku semantics). Populated by the sub's source-order
+    /// `RegisterSub` (`exec_register_sub_op`) once the captured local has been boxed
+    /// — keyed to the sub's declaration, not the box site, so a same-named sibling-
+    /// block `my` cannot pollute it. A read BEFORE the block runs misses (the cell is
+    /// not yet recorded), correctly yielding the undefined value.
+    pub(crate) escaped_our_lexical_cells: HashMap<String, Value>,
+    /// Names of block lexicals that are captured by an `our`-scoped named sub
+    /// (the union of every code's `needs_cell_escaping_our_sub`). Seeded once at the
+    /// start of `run()` from the top-level code, so it is known BEFORE the declaring
+    /// block executes. A free-variable read of such a name from inside a routine
+    /// resolves through `escaped_our_lexical_cells` ONLY — never the shared env —
+    /// so an unrelated leaked `env` value from a sibling block cannot shadow it, and
+    /// a read before the block correctly yields the undefined value (the cell is not
+    /// recorded yet). Empty for ordinary programs: zero cost.
+    pub(crate) escaping_our_lexical_names: std::collections::HashSet<String>,
     state_vars: HashMap<String, Value>,
     /// Per-closure-instance captured-variable state, keyed by
     /// (closure instance id, captured variable Symbol). This is the hot

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -125,6 +125,11 @@ impl Interpreter {
         compiler.set_current_package(self.current_package());
         compiler.is_mainline = true;
         let (code, compiled_fns) = compiler.compile(&body_main);
+        // Seed the escaping-our-sub lexical names from the compiled top-level code
+        // (and its nested closures), so a free-variable read inside such an `our`
+        // sub resolves through the persisted shared cell — known BEFORE the
+        // declaring block runs. See `escaping_our_lexical_names`.
+        self.collect_escaping_our_lexical_names(&code);
         // CP-3 collapse: the Interpreter *is* the bytecode VM now, so run the
         // compiled mainline directly (outermost run → fresh registers) instead of
         // the `mem::take(self)` + `VM::new` + `*self = interp` ping-pong.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1998,6 +1998,8 @@ impl Interpreter {
             fatal_mode: false,
             our_vars: HashMap::new(),
             package_lexicals: HashMap::new(),
+            escaped_our_lexical_cells: HashMap::new(),
+            escaping_our_lexical_names: std::collections::HashSet::new(),
             state_vars: HashMap::new(),
             closure_captured_state: HashMap::new(),
             once_values: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -202,6 +202,8 @@ impl Interpreter {
             fatal_mode: self.fatal_mode,
             our_vars: HashMap::new(),
             package_lexicals: self.package_lexicals.clone(),
+            escaped_our_lexical_cells: self.escaped_our_lexical_cells.clone(),
+            escaping_our_lexical_names: self.escaping_our_lexical_names.clone(),
             state_vars: HashMap::new(),
             // Mirror state_vars: a thread clone starts with no persisted
             // closure captured state (falls back to the captured-env initial

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -200,7 +200,14 @@ impl Interpreter {
                     // after the block exits (`sync_env_from_locals`). Gated on a real
                     // `current_package`, so a bare reference after the block (under
                     // GLOBAL) does not resolve here.
-                    .package_scope_lexical(name)
+                    // An `our sub` declared in a bare block reads a block `my`
+                    // lexical that is out of scope by the time the registry routine
+                    // runs (no per-sub closure env), and the shared `env` may hold an
+                    // unrelated leaked value from a sibling block. Resolve such a
+                    // capture through its persisted shared cell ONLY — see
+                    // `escaping_our_read` — short-circuiting the env lookup.
+                    .escaping_our_read(name)
+                    .or_else(|| self.package_scope_lexical(name))
                     .or_else(|| self.get_env_with_main_alias(name))
                     .or_else(|| {
                         // Fall back to the persistent our_vars store for `our`-scoped

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -243,6 +243,27 @@ impl Interpreter {
                     })?;
                 }
             }
+            // An `our sub` declared in a bare block closes over the block's `my`
+            // lexicals, but a registry routine has no per-sub closure env and the
+            // block scope is dropped on exit. When this `RegisterSub` runs in SOURCE
+            // ORDER (after the `my $a = ...` that the sub captures — `RegisterSub` is
+            // emitted both hoisted at block top AND in place), the captured local is
+            // already a boxed shared cell in `env`. Persist those cells into
+            // `escaped_our_lexical_cells` so a call made AFTER the block reads the
+            // live value. Keyed to the sub's own declaration (not the box site), so
+            // an unrelated sibling-block `my $a` cannot pollute the map; the hoisted
+            // top-of-block registration runs before the box and finds no cell, so it
+            // correctly persists nothing (a call before the block reads undefined).
+            if custom_traits.iter().any(|(t, _)| t == "__our_scoped")
+                && !self.escaping_our_lexical_names.is_empty()
+            {
+                let names: Vec<String> = self.escaping_our_lexical_names.iter().cloned().collect();
+                for name in names {
+                    if let Some(cell @ Value::ContainerRef(_)) = self.env().get(&name).cloned() {
+                        self.escaped_our_lexical_cells.insert(name, cell);
+                    }
+                }
+            }
             // Note: we intentionally do NOT push the Sub onto the stack or
             // store it in env here. The interpreter's trailing_sub_value
             // mechanism handles returning the Sub when it's the last statement

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -25,13 +25,25 @@ impl Interpreter {
         name_idx: u32,
         ip: &mut usize,
     ) -> Result<(), RuntimeError> {
-        let val = match self.upvalues.get(index as usize) {
-            Some(Some(v)) => v.clone(),
-            // `None` entry (non-cell capture) or out-of-range (non-standard path):
-            // read the captured scalar live from env by name.
-            _ => {
-                let name = Self::const_str(code, name_idx);
-                self.get_env_with_main_alias(name).unwrap_or(Value::Nil)
+        // An `our sub` declared in a bare block reads its captured block lexical
+        // by-name with no upvalue array of its own; `self.upvalues` may still hold a
+        // STALE entry from an unrelated prior closure call, so resolve such a capture
+        // through its persisted shared cell FIRST (see `escaping_our_read`), ignoring
+        // the upvalue slot entirely. Gated on a non-empty name set so ordinary
+        // closures pay only an `is_empty` check on this hot path.
+        let val = if !self.escaping_our_lexical_names.is_empty()
+            && let Some(v) = self.escaping_our_read(Self::const_str(code, name_idx))
+        {
+            v
+        } else {
+            match self.upvalues.get(index as usize) {
+                Some(Some(v)) => v.clone(),
+                // `None` entry (non-cell capture) or out-of-range (non-standard
+                // path): read the captured scalar live from env by name.
+                _ => {
+                    let name = Self::const_str(code, name_idx);
+                    self.get_env_with_main_alias(name).unwrap_or(Value::Nil)
+                }
             }
         };
         let val = if let Value::LazyThunk(ref thunk_data) = val {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -37,6 +37,10 @@ impl Interpreter {
         // here would over-box unrelated same-named locals (same-named `my` locals
         // share one slot) and break e.g. `let`-restore in a sibling block.
         let box_decl = self.vardecl_context && !code.needs_cell_named_sub.is_empty();
+        // An `our sub` declared in a bare block captures this local but outlives the
+        // block (it lives in the package registry, with no closure env). Box the
+        // local AND persist the cell so a call after the block reads the live value.
+        let box_decl_our = self.vardecl_context && !code.needs_cell_escaping_our_sub.is_empty();
         let r = self.exec_set_local_op_inner(code, idx);
         // Phase 3 Stage 2: write-through scalar attribute writes to the cell.
         if r.is_ok() {
@@ -45,6 +49,19 @@ impl Interpreter {
                 && let Some(sym) = code.locals_sym.get(idx as usize)
                 && code.needs_cell_named_sub.contains(sym)
             {
+                self.box_decl_local_cell(code, idx as usize);
+            }
+            if box_decl_our
+                && let Some(sym) = code.locals_sym.get(idx as usize)
+                && code.needs_cell_escaping_our_sub.contains(sym)
+            {
+                // Box the captured local into a shared cell so the escaped `our` sub
+                // and the owner alias one cell. The PERSIST into
+                // `escaped_our_lexical_cells` is deferred to the sub's source-order
+                // `RegisterSub` (see `exec_register_sub_op`), NOT done here — same-
+                // named `my` locals share one slot, so an unrelated sibling-block
+                // `my $a` reaches this same site and must not pollute the persisted
+                // map with its value.
                 self.box_decl_local_cell(code, idx as usize);
             }
         }

--- a/t/our-sub-block-lexical-capture.t
+++ b/t/our-sub-block-lexical-capture.t
@@ -1,0 +1,56 @@
+use Test;
+
+# An `our sub` declared inside a bare block closes over the block's `my`
+# lexicals. The sub is installed into the package at compile time, so it is
+# callable via OUR:: before its declaring block has run (returning the
+# undefined value), and returns the captured value once the block has run.
+# https://github.com/Raku/old-issue-tracker/issues/1908
+
+plan 6;
+
+{
+    nok &OUR::access_lexical_a().defined,
+        'our-sub captured lexical is undefined before the block runs';
+    {
+        my $a = 42;
+        our sub access_lexical_a() { $a }
+    }
+    is &OUR::access_lexical_a(), 42,
+        'our-sub returns captured lexical value after the block runs';
+}
+
+# A sibling block declaring a same-named `my` lexical must NOT pollute the
+# captured value (same-named locals share a slot in the VM).
+{
+    {
+        my $b = 7;   # unrelated, not captured by an our-sub
+    }
+    nok &OUR::grab_b().defined,
+        'unrelated sibling my $b does not leak into the captured cell';
+    {
+        my $b = 99;
+        our sub grab_b() { $b }
+    }
+    is &OUR::grab_b(), 99, 'our-sub captures its own block lexical';
+}
+
+# An `our sub` reading an `our` package var still resolves through the package
+# store (not the escaping-lexical mechanism).
+{
+    package Gee {
+        our $msg;
+        our sub talk { $msg }
+    }
+    $Gee::msg = "hello";
+    is Gee::talk, "hello", 'our-sub still reads our-vars via the package store';
+}
+
+# Multiple captured lexicals in one block.
+{
+    {
+        my $x = 1;
+        my $y = 2;
+        our sub sum_xy() { $x + $y }
+    }
+    is &OUR::sum_xy(), 3, 'our-sub captures multiple block lexicals';
+}


### PR DESCRIPTION
## Summary

Fixes the `our sub` block-lexical capture failures (tests 80, 81) in
`roast/S04-declarations/my-6e.t`, taking it from 106 → **108/109** passing.

An `our sub` declared inside a bare block closes over that block's `my`
lexicals:

```raku
{
    nok &OUR::access_lexical_a().defined, 'undefined before the block runs';
    {
        my $a = 42;
        our sub access_lexical_a() { $a }
    }
    is &OUR::access_lexical_a(), 42, 'captured value after the block runs';
}
```

mutsu installs `our sub`s into the package registry, where a routine has no
per-sub closure env — so the captured `$a` resolved to `Nil`, or (with the
single-store env polluted by an unrelated sibling-block `my $a`) to a wrong
value.

## Mechanism

- **Compiler**: when compiling an `our`-scoped named sub, contribute its
  *plain-lexical* free vars to `escaping_our_sub_captures`. `compute_free_vars`
  folds them into `needs_cell_escaping_our_sub` for the owner's locals.
  Dynamic/attribute/special twigled names (`$*X`, `$!x`, `$/`, …) and
  `our`-declared vars (via `our_locals` slots) are **excluded** — they resolve
  through their own stores.
- **VM**: the captured `my $a` is boxed into a shared `ContainerRef` cell at its
  decl site; the sub's **source-order** `RegisterSub` persists that cell into
  `escaped_our_lexical_cells`, keyed to the sub's *declaration* (not the box
  site) so a same-named sibling-block `my $a` cannot pollute it. The hoisted
  top-of-block registration runs before the box, finds no cell, and persists
  nothing — so a call *before* the block correctly reads the undefined value.
- **Read**: `escaping_our_lexical_names` (seeded at run start) marks which names
  are such captures; a free-var read inside a routine resolves through the cell
  (`escaping_our_read`), short-circuiting the leaked env shadow.

## Scope / limitations

- Reads only — writes from inside the escaped sub do not yet accumulate through
  the cell (not exercised by this roast file).
- Test 61 (`dies-ok { EVAL '\$x = \"abc\"'; my Int \$x; }`) still fails: it needs
  forward typed-`my` hoisting into the EVAL pad, a separate declaration-model
  issue documented in `TODO_roast/S04.md`.

## Testing

- `t/our-sub-block-lexical-capture.t` (new, 6 cases) — matches `raku` output.
- `make test` green (13533 tests); fixed a transient regression in
  `t/dynamic-var-not-package-qualified.t` (dynamic `$*X` written from an
  `our sub`) by the twigle exclusion above.
- `roast/S04-declarations/our.t` still passes (the `our sub` reading an `our`
  var path is excluded from the new mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)