### PR TITLE
fix(regex): keep highest-priority alternative on full-match ties (advent2009-day10)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1270,6 +1270,7 @@ roast/integration/advent2009-day05.t
 roast/integration/advent2009-day06.t
 roast/integration/advent2009-day07.t
 roast/integration/advent2009-day08.t
+roast/integration/advent2009-day10.t
 roast/integration/advent2009-day13.t
 roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -2,6 +2,20 @@ use super::super::*;
 use super::regex_helpers::{map_pos, strip_marks_pattern, strip_marks_text};
 
 impl Interpreter {
+    /// Ranking key for selecting the best full (anchored) match: prefer the
+    /// longest end, then more captures. Equal keys are left to the caller's
+    /// STABLE sort, which preserves DFS priority order (highest priority first).
+    fn full_match_rank(m: &(usize, RegexCaptures)) -> (usize, usize, usize, usize) {
+        let (end, caps) = m;
+        let total_named: usize = caps.named.values().map(|v| v.len()).sum();
+        (
+            *end,
+            caps.positional.len(),
+            total_named,
+            caps.code_blocks.len(),
+        )
+    }
+
     pub(in crate::runtime) fn regex_match_with_captures_full_from_start(
         &self,
         pattern: &str,
@@ -20,18 +34,15 @@ impl Interpreter {
             if matches.is_empty() {
                 return None;
             }
-            matches.sort_by_key(|(end, caps)| {
-                let total_named: usize = caps.named.values().map(|v| v.len()).sum();
-                (
-                    *end,
-                    caps.positional.len(),
-                    total_named,
-                    caps.code_blocks.len(),
-                )
-            });
+            // Sort DESCENDING by (end, captures…) with a STABLE sort so that
+            // equal-key matches keep their incoming priority order (the DFS
+            // returns highest-priority first). Then take the FIRST full match.
+            // Using ascending `sort_by_key` + `.rev().find(...)` was wrong: `.rev()`
+            // inverts the priority order of equal-key matches, so the LOWEST-priority
+            // alternative of a `||`/`|` tie won (`^ [ <a> || <b> ] $` picked `<b>`).
+            matches.sort_by(|a, b| Self::full_match_rank(b).cmp(&Self::full_match_rank(a)));
             let (end, mut caps) = matches
                 .into_iter()
-                .rev()
                 .find(|(end, _)| *end == stripped_chars.len())?;
             let from = map_pos(caps.capture_start.unwrap_or(0), &pos_map, orig_len);
             let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
@@ -45,18 +56,12 @@ impl Interpreter {
         if matches.is_empty() {
             return None;
         }
-        matches.sort_by_key(|(end, caps)| {
-            let total_named: usize = caps.named.values().map(|v| v.len()).sum();
-            (
-                *end,
-                caps.positional.len(),
-                total_named,
-                caps.code_blocks.len(),
-            )
-        });
+        // See the comment in the ignore_mark branch above: DESCENDING stable sort
+        // then take the first full match, so equal-key `||`/`|` ties keep the
+        // highest-priority alternative instead of inverting it via `.rev()`.
+        matches.sort_by(|a, b| Self::full_match_rank(b).cmp(&Self::full_match_rank(a)));
         let (end, mut caps) = matches
             .into_iter()
-            .rev()
             .find(|(end, _)| *end == orig_chars.len())?;
         caps.from = caps.capture_start.unwrap_or(0);
         caps.to = caps.capture_end.unwrap_or(end);

--- a/t/regex-alternation-subrule-priority.t
+++ b/t/regex-alternation-subrule-priority.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Regression: in `||`/`|` alternation, when two subrule alternatives match the
+# SAME span and both reach the surrounding anchor, the FIRST (highest-priority)
+# alternative must win. A bug in the full-match selector inverted the priority of
+# equal-rank ties (`.rev().find(...)`), so the LAST alternative won instead.
+
+plan 6;
+
+grammar Ordered {
+    regex a { \w+ }
+    regex b { \w+ }
+    regex TOP { ^ [ <a> || <b> ] $ }
+}
+my $m = Ordered.parse('hello');
+ok $m<a>.defined,  '|| picks the FIRST alternative (a is set)';
+nok $m<b>.defined, '|| does not pick the second alternative (b unset)';
+
+grammar OrderedSwapped {
+    regex a { \w+ }
+    regex b { \w+ }
+    regex TOP { ^ [ <b> || <a> ] $ }   # b first now
+}
+my $m2 = OrderedSwapped.parse('hello');
+ok $m2<b>.defined, 'priority follows written order, not subrule name';
+
+# A real backtracking case: <description> (\N*) must give back chars so the
+# rest of branch 1 can match, and branch 1 (written first) must still win.
+grammar Inventory {
+    regex color { \S+ }
+    regex description { \N* }
+    regex TOP { ^ [ <description> \s+ '(' \s* <color> \s* ')' || <color> \s+ <description> ] $ }
+}
+my $r = Inventory.parse('This is a description (red)');
+is ~$r<description>, 'This is a description', 'branch-1 description via subrule backtracking';
+is ~$r<color>, 'red', 'branch-1 color captured';
+
+# LTM (|) with equal-length subrule matches: first alternative wins the tie.
+grammar Ltm {
+    regex a { \w+ }
+    regex b { \w+ }
+    regex TOP { ^ [ <a> | <b> ] $ }
+}
+ok Ltm.parse('world')<a>.defined, '| (LTM) equal-length tie keeps first alternative';


### PR DESCRIPTION
## Problem

`Grammar.parse` (and other anchored full-match callers) selected the best match in `regex_match_with_captures_full_from_start` with:

```rust
matches.sort_by_key(|(end, caps)| (*end, positional.len, total_named, code_blocks.len)); // ascending
let (end, caps) = matches.into_iter().rev().find(|(end,_)| *end == len)?;
```

The DFS returns matches **highest-priority-first**, and Rust's stable sort preserves that order for equal keys — but `.rev()` then **inverts** it. So when two `||`/`|` alternatives match the **same span** with the **same capture rank**, the engine selected the **lowest-priority** branch.

Minimal repro:

```raku
grammar G { regex a { \w+ }; regex b { \w+ }; regex TOP { ^ [ <a> || <b> ] $ } }
G.parse('hello')<a>.defined;   # mutsu: False (picked <b>!),  raku: True
```

The inline positional form `(\w+) || (\d*\w+)` appeared to work only because both branches yield the *same* captured text, hiding the inverted selection.

## Fix

Replace the ascending-sort + `.rev().find(...)` with a **descending stable sort** (extracted into `full_match_rank`) followed by `.find(end == len)`. Equal-rank ties now keep DFS priority order (first written alternative wins). Distinct-rank selection is byte-identical to before (still prefers longest end, then more captures).

## Result

- `roast/integration/advent2009-day10.t` 4/5 → **5/5** (whitelisted). Its `Inventory` grammar has `<description> \s+ '(' … <color> … ')' || <color> \s+ <description>` where both branches reach `$$`.
- New regression test `t/regex-alternation-subrule-priority.t` (6 assertions).
- `make test` green; all 131 regex/grammar-related whitelisted files (6373 subtests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)