### PR TITLE
fix(assign): greedy @/% slurp in positional list assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -87,21 +87,33 @@ impl Compiler {
             let tmp_idx = self.code.add_constant(Value::str(tmp_name.clone()));
             self.code.emit(OpCode::Dup);
             self.code.emit(OpCode::SetGlobal(tmp_idx));
-            // For each target variable, index into the RHS and assign
+            // For each target variable, index into the RHS and assign.
+            // The FIRST `@`/`%` target is greedy: it slurps all remaining RHS
+            // values via `.skip(i)`, and every target after it receives an empty
+            // container / Nil (`(*, @b, $c) = 1..4` → `@b` is `[2,3,4]`, `$c` is
+            // undefined). `seen_slurpy` tracks that tail consumption.
+            let mut seen_slurpy = false;
             for (i, target) in targets.iter().enumerate() {
                 match target {
                     Expr::Var(var_name) => {
-                        self.code.emit(OpCode::GetGlobal(tmp_idx));
-                        let idx = self.code.add_constant(Value::Int(i as i64));
-                        self.code.emit(OpCode::LoadConst(idx));
-                        self.code.emit(OpCode::Index {
-                            is_positional: true,
-                        });
+                        if seen_slurpy {
+                            let nil_idx = self.code.add_constant(Value::Nil);
+                            self.code.emit(OpCode::LoadConst(nil_idx));
+                        } else {
+                            self.code.emit(OpCode::GetGlobal(tmp_idx));
+                            let idx = self.code.add_constant(Value::Int(i as i64));
+                            self.code.emit(OpCode::LoadConst(idx));
+                            self.code.emit(OpCode::Index {
+                                is_positional: true,
+                            });
+                        }
                         let name_idx = self.code.add_constant(Value::str(var_name.clone()));
                         self.code.emit(OpCode::AssignExpr(name_idx));
                     }
                     Expr::ArrayVar(var_name) => {
-                        let rhs_expr = if i > 0 {
+                        let rhs_expr = if seen_slurpy {
+                            Expr::ArrayLiteral(Vec::new())
+                        } else if i > 0 {
                             Expr::MethodCall {
                                 target: Box::new(Expr::Var(tmp_name.clone())),
                                 name: crate::symbol::Symbol::intern("skip"),
@@ -115,16 +127,27 @@ impl Compiler {
                         self.compile_expr(&rhs_expr);
                         let name_idx = self.code.add_constant(Value::str(format!("@{}", var_name)));
                         self.code.emit(OpCode::AssignExpr(name_idx));
+                        seen_slurpy = true;
                     }
                     Expr::HashVar(var_name) => {
-                        self.code.emit(OpCode::GetGlobal(tmp_idx));
-                        let idx = self.code.add_constant(Value::Int(i as i64));
-                        self.code.emit(OpCode::LoadConst(idx));
-                        self.code.emit(OpCode::Index {
-                            is_positional: true,
-                        });
+                        // A hash target is greedy too: slurp the remaining pairs.
+                        let rhs_expr = if seen_slurpy {
+                            Expr::Hash(Vec::new())
+                        } else if i > 0 {
+                            Expr::MethodCall {
+                                target: Box::new(Expr::Var(tmp_name.clone())),
+                                name: crate::symbol::Symbol::intern("skip"),
+                                args: vec![Expr::Literal(Value::Int(i as i64))],
+                                modifier: None,
+                                quoted: false,
+                            }
+                        } else {
+                            Expr::Var(tmp_name.clone())
+                        };
+                        self.compile_expr(&rhs_expr);
                         let name_idx = self.code.add_constant(Value::str(format!("%{}", var_name)));
                         self.code.emit(OpCode::AssignExpr(name_idx));
+                        seen_slurpy = true;
                     }
                     Expr::Index {
                         target,

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -478,12 +478,16 @@ fn parse_destructuring_with_rhs(
         custom_traits: Vec::new(),
         where_constraint: None,
     }];
-    // In Raku positional list assignment, the FIRST `@`/`%` target is greedy:
-    // it slurps all remaining RHS values, and every target after it receives
-    // nothing (`my ($a, @b, $c) = 1..4` → `@b` is `[2,3,4]`, `$c` is `Any`).
-    // `seen_slurpy` tracks whether such a greedy slurp has already consumed the
-    // tail so subsequent targets are filled with empties instead of mis-indexed
-    // leftover values.
+    // List ASSIGNMENT (`=`) and signature BINDING (`:=`) differ here:
+    //  - assignment: the FIRST `@`/`%` target is greedy — it slurps all
+    //    remaining RHS values, and every target after it receives an empty
+    //    container / Nil (`my ($a, @b, $c) = 1..4` → `@b` = `[2,3,4]`, `$c` = Any).
+    //  - binding: a plain `@`/`%` binds ONE positional argument; only an
+    //    explicit `*@rest` is slurpy (`my ($x, @y, *@r) := (42,[13,17],5,6,7)`
+    //    → `@y` = `[13,17]`, `@r` = `[5,6,7]`).
+    // So the greedy behaviour applies only in assignment mode; binding keeps the
+    // historical "trailing array with nothing non-slurpy after it" heuristic.
+    let has_explicit_slurpy = vars.iter().any(|v| v.is_slurpy);
     let mut seen_slurpy = false;
     for (i, dvar) in vars.iter().enumerate() {
         if dvar.literal_value.is_some() {
@@ -492,16 +496,19 @@ fn parse_destructuring_with_rhs(
 
         let is_array = dvar.name.starts_with('@');
         let is_hash = dvar.name.starts_with('%');
-        // A plain (non-`*`) array/hash in the target list is implicitly greedy,
-        // regardless of what follows it.
-        let is_implicit_slurpy = !seen_slurpy && (is_array || is_hash);
+        let is_implicit_slurpy = if is_binding {
+            !has_explicit_slurpy && is_array && !vars[i + 1..].iter().any(|v| !v.is_slurpy)
+        } else {
+            !seen_slurpy && (is_array || is_hash)
+        };
 
         let effective_tc = dvar
             .per_var_type_constraint
             .clone()
             .or_else(|| type_constraint.clone());
-        let expr = if seen_slurpy {
-            // A target after a greedy slurp gets an empty container / Nil.
+        let expr = if !is_binding && seen_slurpy {
+            // A target after a greedy slurp (assignment mode) gets an empty
+            // container / Nil.
             if is_array {
                 Expr::ArrayLiteral(Vec::new())
             } else if is_hash {

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -478,21 +478,39 @@ fn parse_destructuring_with_rhs(
         custom_traits: Vec::new(),
         where_constraint: None,
     }];
-    let has_explicit_slurpy = vars.iter().any(|v| v.is_slurpy);
+    // In Raku positional list assignment, the FIRST `@`/`%` target is greedy:
+    // it slurps all remaining RHS values, and every target after it receives
+    // nothing (`my ($a, @b, $c) = 1..4` → `@b` is `[2,3,4]`, `$c` is `Any`).
+    // `seen_slurpy` tracks whether such a greedy slurp has already consumed the
+    // tail so subsequent targets are filled with empties instead of mis-indexed
+    // leftover values.
+    let mut seen_slurpy = false;
     for (i, dvar) in vars.iter().enumerate() {
         if dvar.literal_value.is_some() {
             continue;
         }
 
-        let is_implicit_slurpy = !has_explicit_slurpy
-            && dvar.name.starts_with('@')
-            && !vars[i + 1..].iter().any(|v| !v.is_slurpy);
+        let is_array = dvar.name.starts_with('@');
+        let is_hash = dvar.name.starts_with('%');
+        // A plain (non-`*`) array/hash in the target list is implicitly greedy,
+        // regardless of what follows it.
+        let is_implicit_slurpy = !seen_slurpy && (is_array || is_hash);
 
         let effective_tc = dvar
             .per_var_type_constraint
             .clone()
             .or_else(|| type_constraint.clone());
-        let expr = if dvar.is_slurpy || is_implicit_slurpy {
+        let expr = if seen_slurpy {
+            // A target after a greedy slurp gets an empty container / Nil.
+            if is_array {
+                Expr::ArrayLiteral(Vec::new())
+            } else if is_hash {
+                Expr::Hash(Vec::new())
+            } else {
+                Expr::Literal(Value::Nil)
+            }
+        } else if dvar.is_slurpy || is_implicit_slurpy {
+            seen_slurpy = true;
             Expr::Index {
                 target: Box::new(Expr::ArrayVar(array_bare.clone())),
                 index: Box::new(Expr::Binary {

--- a/t/list-assign-greedy-slurp.t
+++ b/t/list-assign-greedy-slurp.t
@@ -1,0 +1,45 @@
+use Test;
+
+# In Raku positional list assignment, the FIRST @/% target is greedy: it slurps
+# all remaining RHS values, and every target after it gets an empty container /
+# Nil. This holds for both `my (...)` destructuring declarations and runtime
+# assignment to an existing parenthesized target list.
+
+plan 13;
+
+# --- my-declaration destructuring ---
+{
+    my ($x, @b, $c) = 1..4;
+    is $x, 1,            'decl: leading scalar takes one element';
+    is ~@b, '2 3 4',     'decl: middle array slurps the rest';
+    nok $c.defined,      'decl: scalar after greedy array is undefined';
+}
+{
+    my (@a, $b) = 1, 2, 3;
+    is ~@a, '1 2 3',     'decl: leading array slurps everything';
+    nok $b.defined,      'decl: trailing scalar after array is undefined';
+}
+{
+    my ($a, %h) = "!", a => 1, b => 2, c => 3;
+    is $a, "!",                         'decl: scalar before hash';
+    is %h.keys.sort.join(","), "a,b,c", 'decl: hash slurps the remaining pairs';
+}
+{
+    my ($a, @b, %h) = 1, 2, 3, (x => 4);
+    is @b.elems, 3,   'decl: first array is greedy (slurps the trailing pair too)';
+    is %h.elems, 0,   'decl: hash after greedy array is empty';
+}
+
+# --- runtime assignment to existing targets ---
+{
+    my (@b, $c);
+    (*, @b, $c) = 1..4;
+    is ~@b, '2 3 4',   'runtime: * skip then greedy array slurp';
+    nok $c.defined,    'runtime: scalar after greedy array is undefined';
+}
+{
+    my ($x, %h);
+    ($x, %h) = "!", a => 1, b => 2;
+    is $x, "!",                       'runtime: scalar before hash';
+    is %h.keys.sort.join(","), "a,b", 'runtime: hash slurps remaining pairs';
+}


### PR DESCRIPTION
## Problem

In Raku positional list assignment, the **first `@`/`%` target is greedy** — it slurps all remaining RHS values, and every target after it gets an empty container / `Nil`:

```raku
my ($x, @b, $c) = 1..4;              # @b = [2,3,4], $c = Any
my ($a, %h) = "!", a=>1, b=>2, c=>3; # %h slurps the trailing pairs
(*, @b, $c) = 1..4;                  # runtime form: same semantics
```

mutsu only handled the narrow "array is effectively last in the list" case and never made `%` greedy, so a mid-list array grabbed a single element and a following scalar picked up a value it should not have.

## Fix

Two desugar paths were involved; both now use a `seen_slurpy` walk:

- **`my (...)` destructuring** (`parser/stmt/decl/destructure.rs`) — the first `@`/`%` reads `tmp[i..]`; targets after it get empty `@`/`%`/`Nil` instead of a mis-indexed leftover.
- **runtime assignment to an existing target list** `(*, @b, $c) = …` (`compiler/expr_call.rs`) — the array already used `.skip(i)`, but scalars after it still indexed `tmp[i]` and hashes never slurped. Same model; `%` now slurps the remaining pairs.

## Result

- `roast/S03-operators/assign.t` **11 → 7** failures (tests 20, 21, 26, 38 fixed).
- Remaining failures are separate, unrelated features (`&infix:<=>` called as a function; slices as list-assignment lvalues) — deferred to follow-up slices.
- New regression test `t/list-assign-greedy-slurp.t` (13 assertions).
- `cargo test` green; assignment/declaration/signature whitelisted tests pass. The only `make test` reds are `t/io-socket-async-*` (network/async, flaky under concurrency; pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)