### PR TITLE
fix(promise): drain worker-thread output at .result sync point (S17 then.t)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -881,6 +881,7 @@ roast/S17-promise/lock-async.t
 roast/S17-promise/nonblocking-await.t
 roast/S17-promise/single-assignment.t
 roast/S17-promise/stress.t
+roast/S17-promise/then.t
 roast/S17-scheduler/at.t
 roast/S17-scheduler/basic.t
 roast/S17-scheduler/every.t

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -124,6 +124,12 @@ impl Interpreter {
                 // Wait for the promise to resolve (blocks if Planned)
                 let (result, _, _) = shared.wait();
                 self.sync_shared_vars_to_env();
+                // Blocking on a promise is a synchronization point: any output a
+                // `.then`/`.andthen`/`.orelse` callback produced on its worker
+                // thread must be flushed to real stdout before we return, so it
+                // interleaves in the same order Rakudo produces (callback output
+                // appears while the main thread is blocked in `.result`).
+                self.drain_shared_thread_output();
                 let status = shared.status();
                 if status == "Broken" {
                     // .result on a Broken promise throws the cause as X::AdHoc

--- a/t/promise-then-callback-output-order.t
+++ b/t/promise-then-callback-output-order.t
@@ -1,0 +1,29 @@
+use Test;
+
+# A `.then` callback runs on a worker thread. Its output must interleave with
+# the main thread's output in the same order Rakudo produces: the callback's
+# output appears while the main thread is blocked in `.result`, before the
+# statement that reads `.result` proceeds. Regression pin for the drain at the
+# `.result` synchronization point.
+
+plan 4;
+
+{
+    my $p1 = Promise.new;
+    my $p2 = $p1.then(-> $res {
+        is $res.result, 42, "callback sees kept value";   # test 1
+        101
+    });
+    $p1.keep(42);
+    is $p2.result, 101, "then promise result";            # test 2
+}
+
+{
+    my $p1 = Promise.new;
+    my $p2 = $p1.then(-> $res {
+        is $res.status, Broken, "callback sees broken status"; # test 3
+        "recovered"
+    });
+    $p1.break("boom");
+    is $p2.result, "recovered", "then promise recovered value"; # test 4
+}


### PR DESCRIPTION
## Summary

A `.then`/`.andthen`/`.orelse` callback runs on a worker thread whose stdout is buffered into the shared thread-output buffer (so concurrent output stays in real chronological order). That buffer was only drained on `await` and at program exit — **not** on `.result`.

As a result, a callback's output stayed buffered past the `.result` that reads its value and flushed at the next `await` instead, producing `Tests out of sequence` in TAP output (the shared test counter was already correct — only the flush order was wrong).

## Fix

Blocking on a promise is itself a synchronization point, so drain the shared worker-thread output right after `.result` unblocks. Callback output now interleaves in the same order Rakudo produces (callback output appears while the main thread is blocked in `.result`).

## Result

- `roast/S17-promise/then.t`: 13 out-of-sequence → **19 passing**; added to whitelist.
- Pin test `t/promise-then-callback-output-order.t`.
- No regressions in related concurrency tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)