### PR TITLE
feat(supply): implement Supply.stable debounce (S17 stable.t)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -929,6 +929,7 @@ roast/S17-supply/snip.t
 roast/S17-supply/sort.t
 roast/S17-supply/split.t
 roast/S17-supply/squish.t
+roast/S17-supply/stable.t
 roast/S17-supply/start.t
 roast/S17-supply/supplier-preserving.t
 roast/S17-supply/syntax-nonblocking-await.t

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -226,7 +226,7 @@ impl Interpreter {
             "minmax" => self.dispatch_minmax_method(target, method, args),
             "snip" => self.dispatch_snip_method(target, method, args),
             "head" | "flat" | "batch" | "throttle" | "comb" | "words" | "wait" | "zip"
-            | "zip-latest" => {
+            | "zip-latest" | "stable" => {
                 if let Value::Instance { class_name, .. } = &target
                     && class_name == "Supply"
                 {

--- a/src/runtime/supply_transform.rs
+++ b/src/runtime/supply_transform.rs
@@ -236,6 +236,25 @@ impl Interpreter {
         } = &target
             && class_name == "Supply"
         {
+            if method == "stable" {
+                let seconds = args.first().map(Value::to_f64).unwrap_or(0.0);
+                // `.stable(0)` is a no-op: return the same Supply so that
+                // `$s === $s.stable(0)` holds.
+                if seconds <= 0.0 {
+                    return Ok(target.clone());
+                }
+                // Best-effort debounce for a materialized (non-live) Supply:
+                // when every value is emitted within the stable window (as with
+                // from-list, which emits instantaneously), only the final value
+                // survives.
+                // TODO: proper timer-based debounce for live Suppliers needs the
+                // async scheduler; that path is exercised only by fudge-skipped
+                // tests today.
+                let attrs = attributes.as_map();
+                let values = self.supply_get_values(&attrs)?;
+                let out: Vec<Value> = values.last().cloned().into_iter().collect();
+                return Ok(self.make_supply_from_values(out, &attrs));
+            }
             self.native_supply(&(attributes).as_map(), method, args.to_vec())
         } else {
             Err(RuntimeError::new(format!(

--- a/t/supply-stable.t
+++ b/t/supply-stable.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Supply.stable($time): debounce transformer.
+# - `.stable(0)` is a no-op and returns the *same* Supply (=== identical).
+# - Calling `stable` on the type object dies.
+
+plan 4;
+
+dies-ok { Supply.stable(1) }, 'stable cannot be called as a class method';
+
+{
+    my $for    = Supply.from-list(1..10);
+    my $stable = $for.stable(0);
+    ok $for === $stable, 'stable by 0 is a no-op (identical supply)';
+
+    my @got;
+    $stable.tap({ @got.push($_) });
+    is-deeply @got, [1..10], 'no-op stable replays all values';
+}
+
+{
+    # For an instantaneously-emitting (materialized) supply, a positive stable
+    # window collapses to just the final value.
+    my @got;
+    Supply.from-list(1..5).stable(2).tap({ @got.push($_) });
+    is-deeply @got, [5], 'instant emission debounces to the last value';
+}


### PR DESCRIPTION
## Summary

`Supply.stable($time)` was unimplemented (`No such method 'stable' for invocant of type 'Supply'`), which aborted `roast/S17-supply/stable.t` after the first test.

## Fix

Implemented in `dispatch_supply_transform` (which has the invocant `Value`, needed for identity):

- **`.stable(0)` is a no-op** and returns the *same* Supply, so `$s === $s.stable(0)` holds.
- For a **materialized (non-live) Supply** whose values are emitted instantaneously (e.g. `from-list`), a positive stable window collapses to just the **final value** — the correct debounce result when every value arrives within the window.

Proper timer-based debounce for live `Supplier`s (needs the async scheduler) is left as a `TODO`; that path is exercised only by fudge-skipped tests today.

## Result

- `roast/S17-supply/stable.t`: 2 → **7 passing**; added to whitelist.
- Pin test `t/supply-stable.t`.
- No regressions in supply transform tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)