### PR TITLE
docs(S17): mark then.t/stable.t passing; record start.t ordering blocker

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -69,8 +69,25 @@
     - Test 58: EVAL grammar in threads fails (lives-ok)
     - Tests 61-64: `$*SCHEDULER.uncaught_handler` not implemented
     - Test 65: TAP counter sync issue in threads
+    - Also "Tests out of sequence" from the start-block `pass` output ordering:
+      a `start`/`Promise.start` block's `pass "..."` runs on a worker thread
+      whose output is buffered into the shared thread-output buffer, drained
+      only at sync points. Unlike then.t (#3989, drain-at-`.result`), here an
+      `isa-ok` runs *between* the thread's `pass` and the `.result`, so the
+      draining still lands the buffered `ok` after the intervening `ok`. The
+      correct fix is to make thread-clone stdout flush *immediately* to real
+      stdout when the parent has `immediate_stdout` on (matching Rakudo, where
+      all threads share real stdout), rather than buffering + draining. This is
+      a broad change to `clone_for_thread`/`OutputSink::emit` — validate against
+      the whole S17 concurrency suite before landing.
 - [ ] roast/S17-promise/stress.t
-- [ ] roast/S17-promise/then.t
+- [x] roast/S17-promise/then.t — **19/19, whitelisted (2026-07-01, #3989).**
+    Was aborting with "Tests out of sequence": a `.then`/`.andthen`/`.orelse`
+    callback runs on a worker thread whose stdout is buffered into the shared
+    thread-output buffer, which was only drained on `await`/exit — not on
+    `.result`. Fix: drain the shared worker-thread output right after `.result`
+    unblocks (blocking on a promise is a synchronization point), so callback
+    output interleaves in Rakudo's order.
 - [ ] roast/S17-scheduler/at.t
 - [x] roast/S17-scheduler/basic.t — **34/34, whitelisted (2026-06-29).** Was
     aborting at test 2 because `$*SCHEDULER.loads` was unimplemented (threw
@@ -154,7 +171,13 @@
 - [ ] roast/S17-supply/sort.t
 - [ ] roast/S17-supply/split.t
 - [ ] roast/S17-supply/squish.t
-- [ ] roast/S17-supply/stable.t
+- [x] roast/S17-supply/stable.t — **7/7, whitelisted (2026-07-01, #3990).**
+    `Supply.stable($time)` was unimplemented ("No such method 'stable'").
+    Implemented in `dispatch_supply_transform`: `.stable(0)` is a no-op that
+    returns the same Supply (=== identical); for a materialized (non-live)
+    Supply whose values emit instantaneously (from-list), a positive window
+    collapses to the final value. Proper timer-based debounce for live
+    Suppliers (needs the async scheduler) is a TODO; that path is fudge-skipped.
 - [ ] roast/S17-supply/start.t
 - [ ] roast/S17-supply/supplier-preserving.t
 - [ ] roast/S17-supply/syntax-nonblocking-await.t


### PR DESCRIPTION
Documentation-only follow-up to #3989 (then.t) and #3990 (stable.t).

- Marks `S17-promise/then.t` and `S17-supply/stable.t` as passing/whitelisted in `TODO_roast/S17.md`.
- Records the root-cause analysis of `S17-promise/start.t`'s remaining "Tests out of sequence" failure: it needs **immediate** thread-clone stdout (matching Rakudo's shared real stdout) rather than the buffer+drain mechanism that #3989 extended to `.result`. Preserved for the next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)