### PR TITLE
fix(concurrency): Semaphore critical sections share scalar/array writes (S17 semaphore.t)

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -11,17 +11,20 @@
 - [ ] roast/S17-lowlevel/cas-loop.t
 - [ ] roast/S17-lowlevel/cas.t
 - [ ] roast/S17-lowlevel/lock.t
-- [ ] roast/S17-lowlevel/semaphore.t
-  - Semaphore.acquire/release native methods are now implemented (counting
-    semaphore via shared registry), but the test exercises bare
-    acquire/release around `$r += $i` across 4000 Promise.start threads.
-    Mutsu's cross-thread shared scalar mechanism only re-reads from
-    `shared_vars` for explicit `Lock.protect` blocks; bare critical sections
-    leave the local env stale, so the accumulator races. Fixing this requires
-    either making thread-cloned `$`-sigil reads always go through
-    `shared_vars`, or building a critical-section abstraction around
-    Semaphore.acquire/release that re-syncs and writes back captured
-    variables (analogous to `call_protect_block`). Deferred.
+- [x] roast/S17-lowlevel/semaphore.t — **2/2, whitelisted (2026-07-01).**
+    The test runs bare `$s.acquire; $r += $i; $s.release` and `@r[$i]++` across
+    4000 Promise.start threads. Previously the accumulator raced (last-writer
+    wins) because thread-cloned scalar *reads* prefer the stale local env copy.
+    Fix: a critical-section abstraction. `Semaphore.acquire`/`release` bump a
+    per-interpreter depth; writes performed while held mark a shared
+    `shared_critical_dirty` set; entering a critical section re-syncs exactly
+    those keys from `shared_vars` into the local env. This distinguishes the
+    genuinely-shared accumulator (`$r`, written inside the lock) from a
+    per-iteration loop lexical (`my $i = $_`, written outside any lock, kept
+    thread-local). For `@`/`%` element mutation the COW write lands only in the
+    local env (an `@`-name COW-detaches), so `writeback_critical_var` pushes the
+    whole aggregate back to the shared store after the mutation; the lock
+    serializes the round-trip.
 - [x] roast/S17-lowlevel/thread-start-join-stress.t
   - 1/1 pass.
 - [ ] roast/S17-lowlevel/thread.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -859,6 +859,7 @@ roast/S17-lowlevel/atomic.t
 roast/S17-lowlevel/cas-loop-int.t
 roast/S17-lowlevel/cas-loop.t
 roast/S17-lowlevel/cas.t
+roast/S17-lowlevel/semaphore.t
 roast/S17-lowlevel/thread-start-join-stress.t
 roast/S17-lowlevel/thread.t
 roast/S17-procasync/basic.t

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1286,6 +1286,17 @@ pub struct Interpreter {
     /// `clone_for_thread`). `sync_shared_vars_to_env` only syncs these keys so
     /// that function parameters aren't overwritten with stale values.
     shared_vars_dirty: Arc<RwLock<HashSet<String>>>,
+    /// Keys in shared_vars that were written by some thread *while it held a
+    /// critical section* (Semaphore/Lock). Entering a critical section syncs
+    /// exactly these scalars back into the local env, so a bare
+    /// read-modify-write of a shared accumulator (`$s.acquire; $r += $i;
+    /// $s.release`) reads the value the previous holder committed — while a
+    /// per-iteration loop lexical (`my $i = $_`, written outside any critical
+    /// section) keeps this thread's own captured snapshot.
+    shared_critical_dirty: Arc<RwLock<HashSet<String>>>,
+    /// Depth of nested critical sections (Semaphore/Lock) this interpreter
+    /// currently holds. Writes performed while > 0 mark `shared_critical_dirty`.
+    critical_section_depth: usize,
     /// Registry of encodings (both built-in and user-registered).
     /// Each entry maps a canonical name to an EncodingEntry.
     encoding_registry: Vec<EncodingEntry>,

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -119,13 +119,22 @@ impl Interpreter {
         match method {
             "acquire" => {
                 semaphore_acquire(&rt)?;
+                // Entering the critical section: pull the latest value of any
+                // shared scalar a previous holder committed inside its own
+                // critical section, so `$r += $i` here reads the accumulated
+                // value rather than this thread's stale clone-time copy.
+                self.enter_critical_section();
                 Ok(Value::Nil)
             }
             "try_acquire" => {
                 let ok = semaphore_try_acquire(&rt)?;
+                if ok {
+                    self.enter_critical_section();
+                }
                 Ok(Value::Bool(ok))
             }
             "release" => {
+                self.leave_critical_section();
                 semaphore_release(&rt)?;
                 Ok(Value::Nil)
             }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2023,6 +2023,8 @@ impl Interpreter {
             shared_vars_active: false,
             sigilless_attrs_active: false,
             shared_vars_dirty: Arc::new(RwLock::new(HashSet::new())),
+            shared_critical_dirty: Arc::new(RwLock::new(HashSet::new())),
+            critical_section_depth: 0,
             encoding_registry: Self::builtin_encodings(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -171,6 +171,88 @@ impl Interpreter {
             .unwrap_or(false)
     }
 
+    /// Enter a critical section (Semaphore/Lock). Increments the depth so that
+    /// writes performed while held mark `shared_critical_dirty`, and refreshes
+    /// this thread's env copy of every scalar a previous holder committed inside
+    /// its own critical section.
+    pub(crate) fn enter_critical_section(&mut self) {
+        self.critical_section_depth += 1;
+        self.sync_critical_shared_scalars_to_env();
+    }
+
+    /// Leave a critical section.
+    pub(crate) fn leave_critical_section(&mut self) {
+        self.critical_section_depth = self.critical_section_depth.saturating_sub(1);
+    }
+
+    /// True while this interpreter holds at least one critical section.
+    pub(crate) fn in_critical_section(&self) -> bool {
+        self.critical_section_depth > 0
+    }
+
+    /// Write the current local value of `name` back to the shared store when a
+    /// critical section is held. Used after an in-place element mutation of a
+    /// shared `@`/`%` aggregate (`$s.acquire; @r[$i]++; $s.release`), whose COW
+    /// write lands only in the local env; the lock serializes the whole-
+    /// container round-trip so the next holder re-reads it on entry.
+    pub(crate) fn writeback_critical_var(&mut self, name: &str) {
+        if self.critical_section_depth == 0 || !self.shared_vars_active {
+            return;
+        }
+        if let Some(val) = self.env.get(name).cloned() {
+            self.set_shared_var(name, val);
+        }
+    }
+
+    /// Record that `key` was written while a critical section was held, so the
+    /// next holder re-reads it on entry. Covers scalars and `@`/`%` aggregates
+    /// (whole-container round-trip through the shared store, serialized by the
+    /// lock); internal `__mutsu_` bookkeeping keys manage their own propagation.
+    pub(crate) fn mark_critical_dirty(&self, key: &str) {
+        if key.starts_with("__mutsu_") {
+            return;
+        }
+        if self
+            .shared_critical_dirty
+            .read()
+            .ok()
+            .is_some_and(|d| d.contains(key))
+        {
+            return;
+        }
+        if let Ok(mut d) = self.shared_critical_dirty.write() {
+            d.insert(key.to_string());
+        }
+    }
+
+    /// Refresh this thread's env copies of *scalar* shared variables that some
+    /// thread wrote while holding a critical section, so a bare
+    /// read-modify-write inside a critical section (`$s.acquire; $r += $i;
+    /// $s.release`) reads the value committed by the previous holder rather than
+    /// the stale copy captured when this thread was cloned.
+    ///
+    /// Only keys written *inside* a critical section are pulled: a per-Promise
+    /// loop lexical (`my $i = $_`, assigned outside any critical section) keeps
+    /// this thread's own captured snapshot.
+    fn sync_critical_shared_scalars_to_env(&mut self) {
+        if !self.shared_vars_active {
+            return;
+        }
+        let keys: Vec<String> = {
+            let d = self.shared_critical_dirty.read().unwrap();
+            if d.is_empty() {
+                return;
+            }
+            d.iter().cloned().collect()
+        };
+        let sv = self.shared_vars.read().unwrap();
+        for key in keys {
+            if let Some(val) = sv.get(&key) {
+                self.env.insert(key, val.clone());
+            }
+        }
+    }
+
     pub(crate) fn mark_shared_var_dirty(&self, key: &str) {
         if self
             .shared_vars_dirty
@@ -222,6 +304,11 @@ impl Interpreter {
                 // Mark this key as explicitly updated so sync_shared_vars_to_env
                 // knows to propagate it (vs keys only initialized by clone_for_thread).
                 self.mark_shared_var_dirty(key);
+                // Writes performed inside a critical section are re-read by the
+                // next holder on entry (see `enter_critical_section`).
+                if self.in_critical_section() {
+                    self.mark_critical_dirty(key);
+                }
             }
         }
     }

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -238,6 +238,8 @@ impl Interpreter {
             shared_vars_active: true,
             sigilless_attrs_active: self.sigilless_attrs_active,
             shared_vars_dirty: Arc::clone(&self.shared_vars_dirty),
+            shared_critical_dirty: Arc::clone(&self.shared_critical_dirty),
+            critical_section_depth: 0,
             encoding_registry: self.encoding_registry.clone(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -712,6 +712,11 @@ impl Interpreter {
             if let Some(val) = self.env().get(&name).cloned() {
                 self.update_local_if_exists(code, &name, &val);
             }
+            // Inside a critical section, propagate the whole mutated aggregate to
+            // the shared store: the COW element write above landed only in this
+            // thread's local env (an `@`/`%` name COW-detaches, dropping the
+            // shared Arc link), so the next lock holder must re-read it on entry.
+            self.writeback_critical_var(&name);
         } else {
             // Autovivify typed containers for inc/dec on undefined variables
             let constraint = loan_env!(self, var_type_constraint(&name));

--- a/t/semaphore-shared-scalar.t
+++ b/t/semaphore-shared-scalar.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A bare Semaphore critical section (`$s.acquire; ...; $s.release`) must make a
+# shared scalar's read-modify-write and a shared array element mutation visible
+# to the next holder — the accumulator is genuinely shared across all threads,
+# while the per-iteration loop lexical stays thread-local.
+
+plan 2;
+
+{
+    my Semaphore $s .= new(1);
+    my $r = 0;
+    my @p;
+    for ^200 {
+        my $i = $_;
+        @p.push: Promise.start({
+            $s.acquire;
+            $r += $i;
+            $s.release;
+        });
+    }
+    await @p;
+    is $r, (^200).sum, 'semaphore-protected scalar accumulation';
+}
+
+{
+    my Semaphore $s .= new(1);
+    my @r;
+    my @p;
+    for ^200 {
+        my $i = $_;
+        @p.push: Promise.start({
+            $s.acquire;
+            @r[$i]++;
+            $s.release;
+        });
+    }
+    await @p;
+    is-deeply @r, [1 xx 200], 'semaphore-protected array element mutation';
+}


### PR DESCRIPTION
## Summary

Bare `$s.acquire; \$r += \$i; \$s.release` across many `Promise.start` threads raced: thread-cloned scalar **reads** prefer the stale local env copy, so every thread read the clone-time value and the accumulator collapsed to the last writer's contribution (`\$r` ended at max `\$i`, not the sum). The array form `@r[\$i]++` produced an empty array.

## Fix — a critical-section abstraction keyed off `Semaphore.acquire`/`release`

- A per-interpreter `critical_section_depth` (acquire `++` / release `--`).
- Writes performed while depth > 0 mark a shared `shared_critical_dirty` set.
- Entering a critical section re-syncs exactly those keys from `shared_vars` into the local env.

This distinguishes the genuinely-shared accumulator (`\$r`, written **inside** the lock) from a per-iteration loop lexical (`my \$i = \$_`, written **outside** any lock, which must stay thread-local). A naive "sync all dirty scalars" pull clobbered `\$i` and over-counted.

For `@`/`%` element mutation the COW write lands only in the local env (an `@`-name COW-detaches, dropping the shared `Arc` link), so `writeback_critical_var` pushes the whole aggregate back to the shared store after the mutation; the lock serializes the round-trip.

The new behavior is gated entirely on `in_critical_section()` (depth > 0), which is only true inside a Semaphore critical section — non-semaphore code paths are unaffected.

## Result

- `roast/S17-lowlevel/semaphore.t`: 1/2 → **2/2**; whitelisted.
- Pin test `t/semaphore-shared-scalar.t`.
- Full `t/` suite (13577 tests) + S17 concurrency stress tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)