### PR TITLE
fix(supply): preserve tap-callback writeback across quit handler (S17 syntax.t)

### DIFF
--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -514,6 +514,18 @@ impl Interpreter {
                 if let Some(quit_reason) = on_demand_quit {
                     if let Some(quit_fn) = quit_cb {
                         self.call_supply_quit_handler(quit_fn, quit_reason)?;
+                        // Dispatching the quit callback clears
+                        // `pending_rw_writeback_sources`
+                        // (call_compiled_closure_with_topic), which drops the tap
+                        // callback's captured-outer writes recorded above. Re-record
+                        // them after the handler so the enclosing `.tap` call site
+                        // still drains the tap block's scalar writes (e.g.
+                        // `$emits-run++` in `supply { emit ...; die }`).
+                        if let Value::Sub(ref data) = tap_cb
+                            && let Some(code) = data.compiled_code.clone()
+                        {
+                            self.record_eager_block_free_var_writeback(&code, &data.params);
+                        }
                     } else {
                         return Err(Self::runtime_error_from_supply_reason(quit_reason));
                     }

--- a/t/supply-emit-then-die-tap-writeback.t
+++ b/t/supply-emit-then-die-tap-writeback.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 6;
+
+# A `supply { emit ...; die }` block delivers the emits that ran before the
+# die, then runs the quit callback. The tap callback's captured-outer scalar
+# writes (e.g. `$emits-run++`) must propagate back to the caller even though
+# dispatching the quit callback clears the pending rw-writeback sources.
+{
+    my $s = supply {
+        emit 'onions';
+        die 'poop';
+    }
+
+    my $emits-run = 0;
+    my $dones-run = 0;
+    my $quits-run = 0;
+    $s.tap({ $emits-run++ }, done => { $dones-run++ }, quit => { $quits-run++ });
+    is $emits-run, 1, 'emit before die runs emit subscription once';
+    is $dones-run, 0, 'die never runs done subscription';
+    is $quits-run, 1, 'die runs quit subscription once';
+}
+
+# Two emits before a die: both captured-outer increments propagate.
+{
+    my $s = supply {
+        emit 'a';
+        emit 'b';
+        die 'x';
+    }
+
+    my $emits-run = 0;
+    my $quits-run = 0;
+    $s.tap({ $emits-run++ }, quit => { $quits-run++ });
+    is $emits-run, 2, 'both emits before die propagate to caller scalar';
+    is $quits-run, 1, 'quit callback ran once';
+}
+
+# Sanity: no die, captured-outer write still propagates (unchanged behavior).
+{
+    my $s = supply { emit 'a'; emit 'b'; }
+    my $emits-run = 0;
+    $s.tap({ $emits-run++ });
+    is $emits-run, 2, 'emits without die propagate';
+}


### PR DESCRIPTION
## Summary

A `supply { emit ...; die }` block delivers the emits that ran before the `die`, then runs the `quit` callback. The tap callback's captured-outer scalar writes (e.g. `\$emits-run++`) were recorded into `pending_rw_writeback_sources`, but the subsequent quit-handler dispatch clears that list at the start of every compiled closure call (`call_compiled_closure_with_topic`), dropping the tap writes. As a result `\$emits-run` stayed `0` in the caller.

The fix re-records the tap callback's captured-outer writes **after** the quit handler runs, so the enclosing `.tap` call site still drains them. This mirrors the sibling clobber fixes (S5 junction eigenstate, S6 CONTROL handler).

## Result

`roast/S17-supply/syntax.t` test 15 (`Block with emit then die runs emit subscription once`) now passes.

Remaining `syntax.t` failures (57, 75, 90) are deep concurrency features (on-demand supply close after `done`, cross-`whenever` `last` with LAST blocks) tracked separately. Test 53 is a known concurrency flaky.

## Testing

- New pin: `t/supply-emit-then-die-tap-writeback.t` (6 subtests)
- All `t/supply*.t` / `t/react*.t` / `t/*whenever*.t` pass
- CI runs full `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)