### PR TITLE
ci: make t/ TAP suite fatal in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo build
 
       - name: TAP tests (prove t/)
-        run: prove -e 'timeout 30 target/debug/mutsu' t/ || echo "TAP tests had failures (non-fatal; roast is authoritative)"
+        run: prove -e 'timeout 30 target/debug/mutsu' t/
 
       - name: Build (release, for roast)
         # The repo sets `[profile.release] debug = true` for local perf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,7 @@ Also: before a local `make roast`, `rm -f temp-file-RT-126006-test` — a stale 
 3. **debug vs release.** A debug-only timeout on a heavy test can be load; a failure that reproduces in *release* is real (CI uses release).
 4. Only label flaky if it actually **passes on retry**; note the pass/fail ratio when you do.
 
-Caveat: the `t/` TAP suite is **non-fatal** in CI (`prove ... t/ || echo "non-fatal; roast is authoritative"`), so a deterministic `t/` failure stays green in CI and can hide indefinitely. Don't rely on CI to surface `t/` regressions — check `tmp/make-test.log` locally.
+The `t/` TAP suite is **fatal** in CI (`prove ... t/`, no `|| echo` fallback) — a deterministic `t/` failure fails the CI job, same as roast.
 
 ## Delegate the full roast run to CI
 

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -15,6 +15,10 @@ impl Interpreter {
         } else {
             None
         };
+        if args.len() == 2 && Self::is_lazy_pipe_source(&args[1]) {
+            let method_args: Vec<Value> = func.into_iter().collect();
+            return self.call_method_with_values(args[1].clone(), "map", method_args);
+        }
         let mut list_items = Vec::new();
         for (idx, arg) in args.iter().skip(1).enumerate() {
             // Check if this argument came from a $ variable (itemized container).
@@ -101,21 +105,16 @@ impl Interpreter {
                 "Cannot use Bool as Matcher with '.match'. Did you mean to use $_ ~~ ... instead?",
             ));
         }
-        if args.len() == 2
-            && let Value::GenericRange { end, .. } = &args[1]
-        {
-            let end_f = end.to_f64();
-            if end_f.is_infinite() && end_f.is_sign_positive() {
-                let mut method_args: Vec<Value> = func.into_iter().collect();
-                if has_k {
-                    method_args.push(Value::Pair("k".to_string(), Box::new(Value::Bool(true))));
-                } else if has_kv {
-                    method_args.push(Value::Pair("kv".to_string(), Box::new(Value::Bool(true))));
-                } else if has_p {
-                    method_args.push(Value::Pair("p".to_string(), Box::new(Value::Bool(true))));
-                }
-                return self.call_method_with_values(args[1].clone(), "grep", method_args);
+        if args.len() == 2 && Self::is_lazy_pipe_source(&args[1]) {
+            let mut method_args: Vec<Value> = func.into_iter().collect();
+            if has_k {
+                method_args.push(Value::Pair("k".to_string(), Box::new(Value::Bool(true))));
+            } else if has_kv {
+                method_args.push(Value::Pair("kv".to_string(), Box::new(Value::Bool(true))));
+            } else if has_p {
+                method_args.push(Value::Pair("p".to_string(), Box::new(Value::Bool(true))));
             }
+            return self.call_method_with_values(args[1].clone(), "grep", method_args);
         }
         let mut list_items = Vec::new();
         for arg in args.iter().skip(1) {


### PR DESCRIPTION
## Summary
- The `prove t/` CI step was wrapped with `|| echo "...non-fatal..."`, so a deterministic `t/` regression could stay green in CI indefinitely.
- Make it fatal, matching the roast step, and update the CLAUDE.md caveat that documented the old non-fatal behavior.
- **Known issue surfaced by this change:** `t/grep-lazy-range.t` and `t/map-first-lazy-range.t` currently hang (sub-form `grep()`/`map()` over an infinite Range don't stay lazy under subscripting). Fixing these on this branch as follow-up commits before merging.

## Test plan
- [x] `cargo build`
- [ ] `prove -e 'timeout 30 target/debug/mutsu' t/` passes cleanly (fixing remaining hangs)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK