### PR TITLE
fix(subst): interpolate $x.method() postfix calls in s/// replacement

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -66,12 +66,12 @@
 - [ ] roast/S17-promise/nonblocking-await.t
 - [ ] roast/S17-promise/single-assignment.t
 - [ ] roast/S17-promise/start.t
-  - 49/65 pass (1-50 except 45). Blockers:
-    - Test 45: substitution replacement `$/.chars()` not interpolated (replacement treated as literal)
-    - Tests 51-53: `.backtrace` method not implemented on exceptions
-    - Test 58: EVAL grammar in threads fails (lives-ok)
-    - Tests 61-64: `$*SCHEDULER.uncaught_handler` not implemented
-    - Test 65: TAP counter sync issue in threads
+  - 64/65 pass (only 58 fails). Blockers:
+    - Test 45: **FIXED (#3996)** — `s///` replacement now interpolates a
+      `$x.method()` postfix call (`$/.chars()`); a bare `$x.meth` stays literal,
+      matching qq-string rules. Routed through the per-match dynamic path.
+    - Test 58: EVAL grammar in threads fails (lives-ok) — only remaining failure
+      (tests 51-53 `.backtrace`, 61-64 `uncaught_handler`, 65 TAP-sync now pass).
     - Also "Tests out of sequence" from the start-block `pass` output ordering:
       a `start`/`Promise.start` block's `pass "..."` runs on a worker thread
       whose output is buffered into the shared thread-output buffer, drained

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -316,6 +316,138 @@ pub(super) fn take_var_name(input: &str) -> Option<usize> {
     Some(end)
 }
 
+/// Variable-name matcher for `s///` replacement interpolation. Like
+/// [`take_var_name`] but also recognizes the special match variables that can
+/// legitimately start an interpolated term: `$/` (the whole Match) and the
+/// numbered captures `$0`, `$1`, ... . Returns the byte length of the name
+/// (excluding the leading sigil, which the caller has already consumed).
+fn subst_take_var_name(input: &str) -> Option<usize> {
+    match input.chars().next()? {
+        // `$/` — the Match object for the current substitution.
+        '/' => Some(1),
+        // `$0`, `$12`, ... — numbered positional captures.
+        c if c.is_ascii_digit() => {
+            let mut end = 0usize;
+            for (idx, ch) in input.char_indices() {
+                if ch.is_ascii_digit() {
+                    end = idx + ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            Some(end)
+        }
+        _ => take_var_name(input),
+    }
+}
+
+/// Consume a method-name identifier (`.name` postfix, sigil-less) and return its
+/// byte length, or `None` if `input` does not start with an identifier.
+fn subst_take_method_ident(input: &str) -> Option<usize> {
+    let first = input.chars().next()?;
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return None;
+    }
+    let mut end = first.len_utf8();
+    for (idx, ch) in input.char_indices().skip(1) {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            end = idx + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    Some(end)
+}
+
+/// Length (including both delimiters) of a balanced bracket run that `input`
+/// starts with (`open` .. matching `close`), respecting nesting. `None` if
+/// `input` does not start with `open` or the brackets are unbalanced.
+fn subst_balanced_len(input: &str, open: u8, close: u8) -> Option<usize> {
+    let bytes = input.as_bytes();
+    if bytes.first() != Some(&open) {
+        return None;
+    }
+    let mut depth = 0i32;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == open {
+            depth += 1;
+        } else if b == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i + 1);
+            }
+        }
+    }
+    None
+}
+
+/// Scan a `$`-interpolation term for a method-call postfix chain. `after` is the
+/// text right after the `$` sigil. Returns the byte length of
+/// `<varname><postfix-chain>` (NOT counting `$`) when the chain contains at least
+/// one `.method(...)` call — Raku interpolates `$x.meth()` but leaves a bare
+/// `$x.meth` (no parens) literal. Returns `None` otherwise, so the caller keeps
+/// the plain `$var` / `$var[idx]` behavior. Bracket postfixes (`[..]`, `{..}`,
+/// `<..>`) chain through, but on their own (no method call) do not trigger the
+/// expression-eval path.
+pub(super) fn subst_method_call_term(after: &str) -> Option<usize> {
+    let vlen = subst_take_var_name(after)?;
+    let bytes = after.as_bytes();
+    let mut i = vlen;
+    let mut saw_call = false;
+    loop {
+        if bytes.get(i) == Some(&b'.') {
+            let Some(id_len) = subst_take_method_ident(&after[i + 1..]) else {
+                break;
+            };
+            let after_id = i + 1 + id_len;
+            if bytes.get(after_id) == Some(&b'(') {
+                let close = subst_balanced_len(&after[after_id..], b'(', b')')?;
+                i = after_id + close;
+                saw_call = true;
+                continue;
+            }
+            // A bare `.method` without parens is literal text: stop here.
+            break;
+        }
+        let bracket = match bytes.get(i) {
+            Some(b'[') => Some((b'[', b']')),
+            Some(b'{') => Some((b'{', b'}')),
+            Some(b'<') => Some((b'<', b'>')),
+            _ => None,
+        };
+        if let Some((open, close)) = bracket {
+            let clen = subst_balanced_len(&after[i..], open, close)?;
+            i += clen;
+            continue;
+        }
+        break;
+    }
+    saw_call.then_some(i)
+}
+
+/// True if `template` contains at least one `$var.method(...)` interpolation term
+/// (or `$/.method(...)`). Such a replacement must be interpolated *per match*
+/// (like a `{...}` code block) so `$/` and the captures are bound to the current
+/// match when the method call runs.
+pub(super) fn subst_has_method_call_interp(template: &str) -> bool {
+    let bytes = template.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i += 2;
+            continue;
+        }
+        if (bytes[i] == b'$' || bytes[i] == b'@')
+            && i + 1 < bytes.len()
+            && subst_method_call_term(&template[i + 1..]).is_some()
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 pub(super) fn normalize_subst_replacement(template: &str) -> String {
     let mut out = String::new();
     let mut chars = template.chars().peekable();

--- a/src/vm/vm_subst_apply.rs
+++ b/src/vm/vm_subst_apply.rs
@@ -396,6 +396,28 @@ impl Interpreter {
                     continue;
                 }
             }
+            // Handle $var.method() interpolation (Raku: `$x.meth()` interpolates
+            // the method call; a bare `$x.meth` leaves `.meth` literal). This also
+            // covers `$/.chars()` and capture-var method calls. Evaluate the whole
+            // term as an expression, like a `{...}` code block, so `$/`, `$0`, ...
+            // (bound per match by the dynamic path) resolve correctly.
+            if (bytes[i] == b'$' || bytes[i] == b'@')
+                && i + 1 < bytes.len()
+                && let Some(term_len) = subst_method_call_term(&template[i + 1..])
+            {
+                let expr_src = &template[i..i + 1 + term_len];
+                let parsed = crate::parse_dispatch::parse_source(expr_src);
+                if let Ok((stmts, _)) = parsed {
+                    let saved_topic = self.env().get("_").cloned();
+                    let val = loan_env!(self, eval_block_value(&stmts)).unwrap_or(Value::Nil);
+                    if let Some(topic) = saved_topic {
+                        self.env_mut().insert("_".to_string(), topic);
+                    }
+                    out.push_str(&val.to_string_value());
+                    i += 1 + term_len;
+                    continue;
+                }
+            }
             // Handle $var and $var[idx]
             if bytes[i] == b'$' && i + 1 < bytes.len() {
                 let after = &template[i + 1..];

--- a/src/vm/vm_subst_exec.rs
+++ b/src/vm/vm_subst_exec.rs
@@ -21,9 +21,11 @@ impl Interpreter {
         let pattern = Self::const_str(code, pattern_idx).to_string();
         let raw_replacement = normalize_subst_replacement(Self::const_str(code, replacement_idx));
         // A replacement containing a `{...}` code block (e.g. from `s[...] = $0 x 2`)
-        // must be evaluated *per match*, with `$/`, `$0`, ... bound to that match.
-        // For replacements without code blocks, interpolate once up front.
-        let has_code_block = raw_replacement.contains('{');
+        // or a `$x.method()` interpolation must be evaluated *per match*, with `$/`,
+        // `$0`, ... bound to that match. For plain replacements, interpolate once up
+        // front.
+        let has_code_block =
+            raw_replacement.contains('{') || subst_has_method_call_interp(&raw_replacement);
         let replacement = if has_code_block {
             raw_replacement.clone()
         } else {
@@ -297,9 +299,11 @@ impl Interpreter {
         let pattern = Self::const_str(code, pattern_idx).to_string();
         let raw_replacement = normalize_subst_replacement(Self::const_str(code, replacement_idx));
         // A replacement containing a `{...}` code block (e.g. from `s[...] = $0 x 2`)
-        // must be evaluated *per match*, with `$/`, `$0`, ... bound to that match.
-        // For replacements without code blocks, interpolate once up front.
-        let has_code_block = raw_replacement.contains('{');
+        // or a `$x.method()` interpolation must be evaluated *per match*, with `$/`,
+        // `$0`, ... bound to that match. For plain replacements, interpolate once up
+        // front.
+        let has_code_block =
+            raw_replacement.contains('{') || subst_has_method_call_interp(&raw_replacement);
         let replacement = if has_code_block {
             raw_replacement.clone()
         } else {

--- a/t/subst-method-call-interp.t
+++ b/t/subst-method-call-interp.t
@@ -1,0 +1,70 @@
+use Test;
+
+plan 8;
+
+# Raku interpolates a method call WITH parens in an s/// replacement
+# (`$x.meth()`), but leaves a bare `$x.meth` (no parens) literal — matching
+# double-quoted string interpolation rules.
+
+{
+    my $x = "hello";
+    my $name = "wor";
+    $x ~~ s/hello/$name.uc()/;
+    is $x, "WOR", 'method call with parens is interpolated in replacement';
+}
+
+{
+    my $y = "hello";
+    my $name = "wor";
+    $y ~~ s/hello/$name.uc/;
+    is $y, "wor.uc", 'bare method (no parens) is left literal';
+}
+
+# `$/.chars()` — the Match variable with a method call, bound per match.
+{
+    my $foo = "barbaz";
+    $foo ~~ s/.+/$/.chars()/;
+    is $foo, "6", '$/.chars() interpolates the match length';
+}
+
+# The over-sharing-of-$/ idiom from roast S17-promise/start.t.
+{
+    is ([+] map -> $n {
+            my $foo = "barbaz" x $n;
+            $foo ~~ s/.+/$/.chars()/;
+            $foo || 0
+        }, ^100),
+        29700,
+        '$/.chars() across many substitutions sums correctly';
+}
+
+# Method-call interpolation works with :g (global) too, re-evaluated per match.
+{
+    my $s = "ab cd ef";
+    my $sep = "-";
+    $s ~~ s:g/\s/$sep.uc()/;
+    is $s, "ab-cd-ef", 'method-call replacement re-runs per match under :g';
+}
+
+# Chained postfix: `$x[0].uc()`.
+{
+    my @a = "foo", "bar";
+    my $t = "X";
+    $t ~~ s/X/@a[0].uc()/;
+    is $t, "FOO", 'indexed method call is interpolated';
+}
+
+# A plain variable replacement (no method) still works.
+{
+    my $t = "AB";
+    my $r = "z";
+    $t ~~ s/A/$r/;
+    is $t, "zB", 'plain variable replacement unaffected';
+}
+
+# A `{...}` code block replacement still works.
+{
+    my $t = "test";
+    $t ~~ s/es/{"X" x 2}/;
+    is $t, "tXXt", 'code-block replacement unaffected';
+}


### PR DESCRIPTION
## Summary

The `s///` replacement is interpolated at runtime by a hand-rolled walker (`interpolate_subst_replacement_with_closures`) that handled `$var`, `$var[idx]`, `${name}` and `{...}` code blocks — but **not** a `$var.method()` postfix call. Plain qq strings interpolate `$x.meth()` correctly (the parser builds proper AST), so the two diverged:

```raku
my $name = "wor";
"hello" ~~ s/hello/$name.uc()/;   # mutsu: "wor.uc()"  raku: "WOR"
```

## Fix

Match Raku's double-quoted-string rule: a method call **with** parens (`$x.meth()`, `$/.chars()`, `@a[0].uc()`) is interpolated as an expression, while a bare `$x.meth` (no parens) leaves `.meth` literal.

- `subst_method_call_term` detects a `$`/`@` term followed by a postfix chain containing at least one `.method(...)` call (bracket postfixes chain through).
- The whole term is evaluated via `parse_source` + `eval_block_value` — the same path `{...}` blocks already use.
- Any replacement containing such a term is routed through the per-match **dynamic** path (`subst_has_method_call_interp`), so `$/`, `$0`, ... are bound to the current match when the method call runs.

## Result

Fixes **roast/S17-promise/start.t test 45** ("No wrong answers due to over-sharing of `$/`", `s/.+/$/.chars()/`), which now passes. (The file is not yet whitelisted: test 58 — parallel grammar parsing — and the start-block `pass`-ordering issue remain, both documented in `TODO_roast/S17.md`.)

## Tests

- `t/subst-method-call-interp.t` (8 cases: method-with-parens, bare-method-literal, `$/.chars()`, the start.t over-sharing idiom, `:g` re-eval, indexed method call, plain-var and code-block replacements unaffected).
- No regressions: `t/subst-*.t` / `t/regex-*.t` / `t/match-*.t` (197 tests) and roast S05-substitution/S05-metasyntax all pass; cargo unit tests 477 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)