### PR TITLE
fix(assign): symbolic-deref assignment in expression context

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -119,16 +119,23 @@
   - 0/? pass. Panic: `attempt to multiply with overflow` in `i64::pow`. Needs BigInt or checked arithmetic.
 - [x] roast/S03-operators/assign-is-not-binding.t
 - [ ] roast/S03-operators/assign.t
-  - ~158/193 pass (file aborts mid-run at test ~194 of 302). Fixed:
+  - ~167/197 pass (file aborts mid-run at test ~198 of 302). Fixed:
     `(($c = 3) = 4)` (assignment yields its container as an lvalue), `[op]=`
     reduce-meta compound assignment in expression context (`@p = ($x [+]= 6)`),
-    and (this slice) chained list assignment `@a = %h = 1, 2`: the inner `@`/`%`
-    target now absorbs the comma list on its right (`@a = (%h = (1, 2))`), which
-    previously made `%h` take only `1` and threw an odd-elements hash-init error,
-    aborting the file at test ~52. That unblocked tests 52-193.
-  - Next blocker: `flat $::('Foo::b') = l(), l()` — `flat` combined with a
-    symbolic-deref (`$::(...)`) assignment fatally errors, aborting the rest of
-    the file at test ~194. Beyond that, still failing among the run subtests:
+    chained list assignment `@a = %h = 1, 2` (inner `@`/`%` absorbs the comma
+    list; unblocked tests 52-193), and (this slice) a symbolic-deref assignment
+    used in expression context (`flat $::('b') = l(), l()`): the expression
+    parser now has `SymbolicDeref`/`IndirectTypeLookup` arms on the LHS of `=`,
+    so the `=` is consumed instead of leaving the surrounding `flat` to swallow
+    the bare deref and be mis-read as `flat(...) = ...` ("Unknown call: flat").
+    That unblocked tests 194-197.
+  - Next blocker: `$(@a[0]) = l, l` — item-deref lvalue `$(...)` assignment
+    errors with X::Assignment::RO ("cannot assign through .item on non-instance"),
+    aborting at test ~198. Related still-failing value bugs in the run: a scalar
+    holding a list assigned via symbolic deref reports `.elems == 1` (the
+    `$`-sigil `SymbolicDerefStore` keeps only the first element), and the
+    package-qualified `$::('Foo::b')` store leaves `$b` undefined (name
+    resolution). Beyond that, still failing among the run subtests:
     `&infix:<=>`/`infix:<=>(...)` as a callable assignment function (5, 7-8),
     slice-in-list list-assignment lvalues (47-50), various compound-assign
     operators (`or=`/`orelse=`/`and=`/`xor=`/`R~=`/`~<=`/`~>=`, tests 68-192).

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -191,7 +191,13 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
     // `($x) = 1, 2` — keeps the comma-absorbing RHS. We test the pre-unwrap
     // expression so a grouped `($x)` stays on the list-assignment path. (The
     // statement-level counterpart lives in `stmt/assign.rs::assign_stmt`.)
-    let scalar_item_assign = matches!(&expr, Expr::Var(_));
+    // A symbolic scalar deref (`$::('name') = ...`) is an item assignment too, so
+    // it binds tighter than the comma (`flat $::('b') = l(), l()` is
+    // `flat (($::('b') = l()), l())`). An `@`/`%` symbolic deref keeps the
+    // comma-absorbing list-assignment RHS.
+    let scalar_item_assign = matches!(&expr, Expr::Var(_))
+        || matches!(&expr, Expr::SymbolicDeref { sigil, .. } if sigil == "$")
+        || matches!(&expr, Expr::IndirectTypeLookup(_));
     let (r, rhs) = if scalar_item_assign {
         ternary_mode(r, mode)?
     } else {
@@ -271,6 +277,26 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             Expr::MultiDimIndexAssign {
                 target,
                 dimensions,
+                value: Box::new(rhs),
+            },
+        )),
+        // `$::('name') = expr` in expression context (e.g. as a listop argument
+        // `flat $::('b') = l()`). Without this arm the assignment falls through to
+        // `_ => (rest, expr)` below, leaving the `=` unconsumed so the surrounding
+        // listop swallows the bare deref and the outer parser mis-reads the whole
+        // `flat $::('b')` as an assignable call. Mirrors `assign_to_target_expr`.
+        Expr::SymbolicDeref { sigil, expr } => Ok((
+            r,
+            Expr::SymbolicDerefAssign {
+                sigil,
+                expr,
+                value: Box::new(rhs),
+            },
+        )),
+        Expr::IndirectTypeLookup(inner) => Ok((
+            r,
+            Expr::IndirectTypeLookupAssign {
+                expr: inner,
                 value: Box::new(rhs),
             },
         )),

--- a/t/symbolic-deref-assign-expr.t
+++ b/t/symbolic-deref-assign-expr.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 5;
+
+# A symbolic scalar deref `$::('name') = ...` used in *expression* context
+# (e.g. as a list-prefix / expr-listop argument) must be recognised as an
+# assignment. Previously the expression parser had no arm for `SymbolicDeref`
+# on the LHS of `=`, so the `=` was left unconsumed and a surrounding listop
+# like `flat` swallowed the bare deref -- the outer parser then mis-read
+# `flat $::('b')` as an assignable call and died with "Unknown call: flat".
+
+{
+    our $b;
+    my $r = ($::('b') = 5);
+    is $r, 5, 'parenthesised symbolic-deref assignment yields the value';
+    is $b, 5, '... and writes through to the target';
+}
+
+{
+    sub l { (1, 2) }
+    our $c;
+    # `flat` is an expr-listop; its argument is the assignment expression. This
+    # used to die at parse/lower time with "Unknown call: flat".
+    my @z;
+    lives-ok { @z = (flat $::('c') = l(), l()) },
+        'flat + symbolic-deref assignment parses (no "Unknown call: flat")';
+    ok @z.elems > 0, '... and produces a flattened list';
+    ok $c.defined, '... and the target was written through';
+}


### PR DESCRIPTION
## What

`$::('name') = expr` used in expression context — most visibly as an expr-listop argument, `flat $::('b') = l(), l()` — was not recognised as an assignment. The expression-level assign handler (`assign_not_expr_mode`) had no match arm for an `Expr::SymbolicDeref` / `Expr::IndirectTypeLookup` LHS, so it fell through to `_ => (rest, expr)` and left the `=` unconsumed. The surrounding `flat` then swallowed the bare deref and the outer parser mis-read the whole `flat $::('b')` as an assignable call, lowering to `__mutsu_assign_named_sub_lvalue("flat", ...)` which died at run time with **"Unknown call: flat"**.

## Fix

Add `SymbolicDeref`/`IndirectTypeLookup` arms that build `SymbolicDerefAssign` / `IndirectTypeLookupAssign` (mirroring `assign_to_target_expr`), and treat a `$` (scalar) symbolic deref as an *item* assignment so it binds tighter than the comma (`flat $::('b') = l(), l()` is `flat (($::('b') = l()), l())`, not a list-assign that absorbs the trailing `, l()`).

## Impact

`roast/S03-operators/assign.t` previously aborted at test ~194; it now runs to ~198 (the next blocker is the separate `$(@a[0]) = ...` item-deref lvalue), unblocking tests 194-197.

The remaining value discrepancies in tests 194-197 (a scalar-held list reporting `.elems == 1`; package-qualified symbolic store leaving the target undefined) are separate runtime bugs, documented in `TODO_roast/S03.md`.

## Tests

- New `t/symbolic-deref-assign-expr.t` (5 assertions).
- Existing symbolic-deref `t/` tests + 477 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)