### PR TITLE
fix(assign): item-deref lvalue `$(EXPR) = value`

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -119,26 +119,26 @@
   - 0/? pass. Panic: `attempt to multiply with overflow` in `i64::pow`. Needs BigInt or checked arithmetic.
 - [x] roast/S03-operators/assign-is-not-binding.t
 - [ ] roast/S03-operators/assign.t
-  - ~167/197 pass (file aborts mid-run at test ~198 of 302). Fixed:
-    `(($c = 3) = 4)` (assignment yields its container as an lvalue), `[op]=`
-    reduce-meta compound assignment in expression context (`@p = ($x [+]= 6)`),
-    chained list assignment `@a = %h = 1, 2` (inner `@`/`%` absorbs the comma
-    list; unblocked tests 52-193), and (this slice) a symbolic-deref assignment
-    used in expression context (`flat $::('b') = l(), l()`): the expression
-    parser now has `SymbolicDeref`/`IndirectTypeLookup` arms on the LHS of `=`,
-    so the `=` is consumed instead of leaving the surrounding `flat` to swallow
-    the bare deref and be mis-read as `flat(...) = ...` ("Unknown call: flat").
-    That unblocked tests 194-197.
-  - Next blocker: `$(@a[0]) = l, l` — item-deref lvalue `$(...)` assignment
-    errors with X::Assignment::RO ("cannot assign through .item on non-instance"),
-    aborting at test ~198. Related still-failing value bugs in the run: a scalar
-    holding a list assigned via symbolic deref reports `.elems == 1` (the
-    `$`-sigil `SymbolicDerefStore` keeps only the first element), and the
-    package-qualified `$::('Foo::b')` store leaves `$b` undefined (name
-    resolution). Beyond that, still failing among the run subtests:
+  - ~256/302 pass; the file now runs to completion (no more mid-run abort).
+    Fixed: `(($c = 3) = 4)` (assignment yields its container as an lvalue),
+    `[op]=` reduce-meta compound assignment in expression context
+    (`@p = ($x [+]= 6)`), chained list assignment `@a = %h = 1, 2` (inner
+    `@`/`%` absorbs the comma list; unblocked tests 52-193), a symbolic-deref
+    assignment in expression context (`flat $::('b') = l(), l()`; unblocked
+    194-197), and (this slice) the item-deref lvalue `$(EXPR) = value`: `$(...)`
+    lowers to `EXPR.item`, but the item contextualizer is transparent as an
+    lvalue, so `method_lvalue_assign_expr` now assigns straight through to `EXPR`
+    (via `assign_to_target_expr`) for the `item`/no-arg method instead of
+    dispatching a `.item` method-lvalue that threw X::Assignment::RO. That
+    removed the abort and unblocked tests 198-302.
+  - Remaining failures (46) are separate features:
     `&infix:<=>`/`infix:<=>(...)` as a callable assignment function (5, 7-8),
     slice-in-list list-assignment lvalues (47-50), various compound-assign
-    operators (`or=`/`orelse=`/`and=`/`xor=`/`R~=`/`~<=`/`~>=`, tests 68-192).
+    operators (`or=`/`orelse=`/`and=`/`xor=`/`R~=`/`~<=`/`~>=`, tests 68-192),
+    and, among the newly-run 198-302, itemization/`.elems` value bugs for a
+    scalar holding a list (symbolic-deref/package-qualified store keeps only the
+    first element; `$(@a[0])`/`($a)` list-vs-item distinctions) plus assorted
+    `@$a`/`%$a`/`$@a` deref-assignment forms.
 - [ ] roast/S03-operators/autoincrement-range.t
   - 5/104 pass.
 - [ ] roast/S03-operators/autoincrement.t

--- a/src/parser/stmt/assign/lvalue.rs
+++ b/src/parser/stmt/assign/lvalue.rs
@@ -7,6 +7,14 @@ pub(crate) fn method_lvalue_assign_expr(
     method_args: Vec<Expr>,
     value: Expr,
 ) -> Expr {
+    // `$(EXPR) = value` lowers `$(EXPR)` to `EXPR.item`, but the item
+    // contextualizer is transparent as an lvalue: it names the same container as
+    // `EXPR`. Assign straight through to `EXPR` (`$(@a[0]) = ...` writes `@a[0]`)
+    // instead of dispatching a `.item` method-lvalue, which has no writable slot
+    // and threw X::Assignment::RO.
+    if method_name == "item" && method_args.is_empty() {
+        return crate::parser::expr::precedence::assign_to_target_expr(target, value);
+    }
     let mut args = vec![
         target,
         Expr::Literal(Value::str(method_name)),

--- a/src/parser/stmt/simple_expr_stmt/lvalue.rs
+++ b/src/parser/stmt/simple_expr_stmt/lvalue.rs
@@ -25,6 +25,13 @@ pub(super) fn method_lvalue_assign_expr(
     method_args: Vec<Expr>,
     value: Expr,
 ) -> Expr {
+    // `$(EXPR) = value` lowers `$(EXPR)` to `EXPR.item`, but the item
+    // contextualizer is transparent as an lvalue: it names the same container as
+    // `EXPR`. Assign straight through to `EXPR` instead of dispatching a `.item`
+    // method-lvalue (which has no writable slot and threw X::Assignment::RO).
+    if method_name == "item" && method_args.is_empty() {
+        return crate::parser::expr::precedence::assign_to_target_expr(target, value);
+    }
     let mut args = vec![
         target,
         Expr::Literal(Value::str(method_name)),

--- a/t/item-deref-lvalue-assign.t
+++ b/t/item-deref-lvalue-assign.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 7;
+
+# `$(EXPR)` is the item contextualizer; as an lvalue it is transparent and
+# names the same container as EXPR, so `$(@a[0]) = ...` writes through to
+# `@a[0]`. It used to lower to a `.item` method-lvalue, which had no writable
+# slot and died with X::Assignment::RO ("cannot assign through .item ...").
+
+{
+    my @a;
+    $(@a[0]) = 5;
+    is @a[0], 5, '$(@a[0]) = scalar writes through to the element';
+}
+
+{
+    sub l { (1, 2) }
+    my @a;
+    # Item assignment binds tighter than the comma: `($(@a[0]) = l), l`.
+    my @z = ($(@a[0]) = l, l);
+    is @a[0].elems, 2, '$(@a[0]) as scalar holds the whole list (elems)';
+    is @z.elems,    2, '... and the outer list keeps two items';
+}
+
+{
+    my $s;
+    $($s) = 42;
+    is $s, 42, '$($scalar) = value writes through to the scalar';
+}
+
+{
+    my %h;
+    $(%h<k>) = 9;
+    is %h<k>, 9, '$(%h<k>) = value writes through to the hash element';
+}
+
+{
+    # In-place update through the item deref.
+    my @a = 10, 20, 30;
+    $(@a[1]) = 99;
+    is @a[1], 99, '$(@a[1]) = value overwrites an existing element';
+    is @a.elems, 3, '... without disturbing the array shape';
+}


### PR DESCRIPTION
## What

`$(EXPR)` is the item contextualizer; the parser lowers it to `EXPR.item`. As an lvalue it is transparent — it names the same container as `EXPR` — but assigning to it dispatched a `.item` method-lvalue (`__mutsu_assign_method_lvalue`) which has no writable slot and threw **X::Assignment::RO** ("cannot assign through .item on non-instance"), aborting `roast/S03-operators/assign.t` at test ~198.

## Fix

`method_lvalue_assign_expr` (both the statement and expression-context copies) now detects the no-arg `item` method and assigns straight through to `EXPR` via `assign_to_target_expr`, so:

- `$(@a[0]) = 5` writes `@a[0]`
- `$($s) = 42` writes `$s`
- `$(%h<k>) = 9` writes the hash element

## Impact

`assign.t` no longer aborts — it runs the full plan (302 tests, ~256 pass; was aborting after 197), unblocking tests 198-302.

The remaining failures are separate features (compound-assign operators, `&infix:<=>` as a function, slice-in-list lvalues, and scalar-holds-list itemization value bugs), tracked in `TODO_roast/S03.md`.

## Tests

- New `t/item-deref-lvalue-assign.t` (7 assertions).
- 477 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)