### PR TITLE
fix(hyperrace): enforce single-iterator contract on HyperSeq/RaceSeq (S07 basics.t 87->90)

### DIFF
--- a/TODO_roast/S07.md
+++ b/TODO_roast/S07.md
@@ -1,10 +1,9 @@
 # S07 - iterators, lazy
 
-- [ ] roast/S07-hyperrace/basics.t
-  - HyperSeq/RaceSeq types implemented, most tests pass
-  - BLOCKER: Tests 7, 18, 44, 55 use Promise/await inside .hyper/.race .map blocks that require actual parallelism — deadlocks in single-threaded mode
-  - BLOCKER: Test 90 uses concurrent `start` blocks — requires threading
-  - Remaining: tests 33-37, 70-74 (Buf slice .fmt comparison), test 84 (s/.../.../ in hyper context), tests 88-89 (X::Seq::Consumed)
+- [x] roast/S07-hyperrace/basics.t
+  - Single-iterator contract for HyperSeq/RaceSeq (rakudo #4413): a second `.iterator`
+    throws X::Seq::Consumed; concurrent workers resolve to exactly one winner via the
+    atomic `seq_consume` registry (tests 88-90).
 - [ ] roast/S07-hyperrace/for.t
 - [x] roast/S07-hyperrace/stress.t
 - [ ] roast/S07-iterationbuffer/iterationbuffer.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -553,6 +553,7 @@ roast/S06-traits/native-is-copy.t
 roast/S06-traits/native-is-rw.t
 roast/S06-traits/precedence.t
 roast/S06-traits/slurpy-is-rw.t
+roast/S07-hyperrace/basics.t
 roast/S07-hyperrace/for.t
 roast/S07-hyperrace/stress.t
 roast/S07-iterationbuffer/iterationbuffer.t

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -7,8 +7,13 @@ use crate::value::Value;
 /// before a statement terminator. Used to decide whether `try STMT` should
 /// attempt parsing as an assignment/binding statement.
 pub(crate) fn looks_like_binding(input: &str) -> bool {
-    // Scan for `:=` before `;`, `}`, or end of input
-    let search_len = input.len().min(200);
+    // Scan for `:=` before `;`, `}`, or end of input. Snap the 200-byte window
+    // down to the nearest char boundary so a multi-byte char (e.g. `⚛`) straddling
+    // byte 200 doesn't panic the slice.
+    let mut search_len = input.len().min(200);
+    while search_len > 0 && !input.is_char_boundary(search_len) {
+        search_len -= 1;
+    }
     let search = &input[..search_len];
     for (i, c) in search.char_indices() {
         if c == ';' || c == '}' {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2961,6 +2961,23 @@ impl Interpreter {
                 "hyper" => return Ok(Value::HyperSeq(items)),
                 "race" => return Ok(Value::RaceSeq(items)),
                 "is-lazy" => return Ok(Value::Bool(false)),
+                "iterator" if args.is_empty() => {
+                    // A HyperSeq/RaceSeq allows only a single iterator (rakudo #4413):
+                    // a second `.iterator` throws X::Seq::Consumed. The consumed-state
+                    // is tracked on the inner Arc via the shared Seq registry.
+                    let type_name = if is_hyper { "HyperSeq" } else { "RaceSeq" };
+                    // `seq_consume` atomically checks-and-marks under one lock, so
+                    // concurrent workers racing for the single iterator resolve to
+                    // exactly one winner (rakudo #4413 concurrency contract).
+                    if crate::value::seq_consume(&items).is_err() {
+                        return Err(crate::value::seq_consumed_error_for(type_name));
+                    }
+                    let array_target = Value::Array(
+                        crate::value::Value::array_arc(items.to_vec()),
+                        crate::value::ArrayKind::List,
+                    );
+                    return self.call_method_with_values(array_target, method, args);
+                }
                 "map" | "grep" => {
                     let array_target = Value::Array(
                         crate::value::Value::array_arc(items.to_vec()),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -161,13 +161,22 @@ pub(crate) fn seq_is_cached(arc_ptr: &Arc<Vec<Value>>) -> bool {
 /// Build a structured X::Seq::Consumed error.
 #[allow(clippy::result_large_err)]
 pub(crate) fn seq_consumed_error() -> RuntimeError {
-    let msg = "The iterator of this Seq is already in use/consumed by another Seq \
-               (you might solve this by adding .cache on usages of the Seq, or by \
-               assigning the Seq into an array)";
+    seq_consumed_error_for("Seq")
+}
+
+/// Build a structured X::Seq::Consumed error naming the consumed type
+/// (e.g. "Seq", "HyperSeq", "RaceSeq").
+#[allow(clippy::result_large_err)]
+pub(crate) fn seq_consumed_error_for(type_name: &str) -> RuntimeError {
+    let msg = format!(
+        "The iterator of this {type_name} is already in use/consumed by another {type_name} \
+         (you might solve this by adding .cache on usages of the {type_name}, or by \
+         assigning the {type_name} into an array)"
+    );
     let mut attrs = HashMap::new();
-    attrs.insert("message".to_string(), Value::str(msg.to_string()));
+    attrs.insert("message".to_string(), Value::str(msg.clone()));
     let ex = Value::make_instance(crate::symbol::Symbol::intern("X::Seq::Consumed"), attrs);
-    let mut err = RuntimeError::new(msg);
+    let mut err = RuntimeError::new(&msg);
     err.exception = Some(Box::new(ex));
     err
 }

--- a/src/vm/vm_call_method_compiled_coerce.rs
+++ b/src/vm/vm_call_method_compiled_coerce.rs
@@ -187,7 +187,11 @@ impl Interpreter {
             return Some(target.clone());
         }
         // Seq: consumed-state + `squish` env mutation are interpreter-owned.
-        if matches!(target, Value::Seq(_)) {
+        // HyperSeq/RaceSeq: single-iterator consumed-state is interpreter-owned too.
+        if matches!(
+            target,
+            Value::Seq(_) | Value::HyperSeq(_) | Value::RaceSeq(_)
+        ) {
             return None;
         }
         Some(crate::builtins::iterator_construct::build_iterator_instance(target))

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1038,6 +1038,30 @@ impl Interpreter {
                     self.stack.push(wrapped);
                     return Ok(());
                 }
+                "iterator" if args.is_empty() => {
+                    // A HyperSeq/RaceSeq allows only a single iterator (rakudo #4413):
+                    // a second `.iterator` throws X::Seq::Consumed. The consumed-state
+                    // is tracked on the inner Arc via the shared Seq registry.
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    let type_name = if is_hyper { "HyperSeq" } else { "RaceSeq" };
+                    // `seq_consume` atomically checks-and-marks under one lock, so
+                    // concurrent workers racing for the single iterator resolve to
+                    // exactly one winner (rakudo #4413 concurrency contract).
+                    if crate::value::seq_consume(&items_arc).is_err() {
+                        return Err(crate::value::seq_consumed_error_for(type_name));
+                    }
+                    let array_target = Value::Array(
+                        crate::value::Value::array_arc(items_arc.to_vec()),
+                        crate::value::ArrayKind::List,
+                    );
+                    let iter =
+                        crate::builtins::iterator_construct::build_iterator_instance(&array_target);
+                    self.stack.push(iter);
+                    return Ok(());
+                }
                 _ => {
                     // For all other methods, convert to List and delegate
                 }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -942,6 +942,33 @@ impl Interpreter {
                     // Large list: fall through to array-based dispatch
                     Some(matches!(&target, Value::HyperSeq(_)))
                 }
+                "iterator" if args.is_empty() => {
+                    // A HyperSeq/RaceSeq allows only a single iterator (rakudo #4413):
+                    // a second `.iterator` throws X::Seq::Consumed. The consumed-state
+                    // is tracked on the inner Arc via the shared Seq registry.
+                    let items_arc = match &target {
+                        Value::HyperSeq(items) | Value::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    let type_name = if matches!(&target, Value::HyperSeq(_)) {
+                        "HyperSeq"
+                    } else {
+                        "RaceSeq"
+                    };
+                    // `seq_consume` atomically checks-and-marks under one lock, so
+                    // concurrent workers racing for the single iterator resolve to
+                    // exactly one winner (rakudo #4413 concurrency contract).
+                    if crate::value::seq_consume(&items_arc).is_err() {
+                        return Err(crate::value::seq_consumed_error_for(type_name));
+                    }
+                    let list = Value::Array(
+                        crate::value::Value::array_arc(items_arc.to_vec()),
+                        crate::value::ArrayKind::List,
+                    );
+                    let iter = crate::builtins::iterator_construct::build_iterator_instance(&list);
+                    self.stack.push(iter);
+                    return Ok(());
+                }
                 _ => None,
             }
         } else {

--- a/t/hyperseq-single-iterator.t
+++ b/t/hyperseq-single-iterator.t
@@ -1,0 +1,49 @@
+use Test;
+
+plan 6;
+
+# HyperSeq/RaceSeq allow only a single iterator (rakudo #4413):
+# a second .iterator throws X::Seq::Consumed.
+
+throws-like { (.iterator, .iterator) given (^10).hyper },
+    X::Seq::Consumed,
+    'second .iterator on a HyperSeq throws X::Seq::Consumed';
+
+throws-like { (.iterator, .iterator) given (^10).race },
+    X::Seq::Consumed,
+    'second .iterator on a RaceSeq throws X::Seq::Consumed';
+
+# A fresh HyperSeq/RaceSeq each has its own iterator budget.
+lives-ok { (^10).hyper.iterator; (^10).hyper.iterator },
+    'distinct HyperSeq values each allow one iterator';
+
+# The first .iterator succeeds and yields an Iterator.
+{
+    my $h = (^3).hyper;
+    my $it = $h.iterator;
+    ok $it.defined, 'first .iterator on HyperSeq returns a defined Iterator';
+}
+
+# Concurrent workers racing for the single iterator: exactly one wins.
+{
+    my $seq = (^10).hyper;
+    my atomicint $succeeded = 0;
+    my atomicint $thrown = 0;
+    my $starter = Promise.new;
+    my @w;
+    for ^10 {
+        @w.push: start {
+            await $starter;
+            my $rc = try $seq.iterator;
+            with $rc {
+                ++⚛$succeeded;
+            } else {
+                ++⚛$thrown if $! ~~ X::Seq::Consumed;
+            }
+        }
+    }
+    $starter.keep;
+    await Promise.allof(@w);
+    is $succeeded, 1, 'exactly one concurrent worker acquires the HyperSeq iterator';
+    is $thrown, 9, 'the other nine workers get X::Seq::Consumed';
+}


### PR DESCRIPTION
## Summary

Makes `roast/S07-hyperrace/basics.t` fully pass (87/90 → 90/90) and whitelists it.

A `HyperSeq`/`RaceSeq` allows only **one** iterator (rakudo/rakudo#4413): a second `.iterator` must throw `X::Seq::Consumed`, and under concurrent access exactly one worker acquires the iterator while the rest throw.

Previously `.iterator` on a HyperSeq/RaceSeq was silently converted to a `List` in every dispatch path (the interpreter's `call_method_with_values`, and both the `CallMethod` / `CallMethodMut` VM delegation blocks), so consumed-state was never tracked and every call succeeded — failing tests 88, 89 and 90.

## Changes

- **Consumed-state tracking**: track it on the inner `Arc<Vec<Value>>` via the existing Seq registry. `seq_consume` is atomic (check-and-mark under one lock), so racing workers resolve to a single winner; the loser maps to a type-specific `X::Seq::Consumed`. New `seq_consumed_error_for(type_name)` produces the HyperSeq/RaceSeq wording.
- Handle `.iterator` explicitly in all three dispatch sites **before** the List conversion, and exclude HyperSeq/RaceSeq from the compiled `try_native_iterator_construct` fast path (interpreter-owned, like Seq).
- **Char-boundary panic fix** in `looks_like_binding`: the 200-byte scan window now snaps down to a char boundary, so a multi-byte char (e.g. `⚛`) straddling byte 200 no longer panics the slice. This general parser bug blocked test 90's `start`-block body.

## Tests

- Adds `t/hyperseq-single-iterator.t` (single-iterator throw + concurrent one-winner contract).
- Whitelists `roast/S07-hyperrace/basics.t` (verified passing 3× locally, incl. the concurrent subtest).
- `make test` passes; `for.t`/`stress.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)