### PR TITLE
fix(assign): reassigning Nil to an untyped scalar resets it to Any

### DIFF
--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -220,7 +220,8 @@ impl Interpreter {
         // type object; a non-Nil value that violates the constraint throws
         // X::TypeCheck::Assignment (e.g. `infix:<=>($int, "foo")`), matching the
         // SetLocal path -- expression-context assignment to a captured typed
-        // scalar must type-check just like a statement-level one.
+        // scalar must type-check just like a statement-level one. An untyped
+        // scalar resets Nil to the default type object Any.
         let mut val = if !name.starts_with('@')
             && !name.starts_with('%')
             && let Some(constraint) = loan_env!(self, var_type_constraint(&name))
@@ -245,7 +246,9 @@ impl Interpreter {
                 val
             }
         } else {
-            val
+            // Untyped scalar: Nil resets to the default type object Any (a no-op
+            // for `@`/`%` containers).
+            self.reset_nil_untyped_scalar(&name, val)
         };
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -623,6 +623,30 @@ impl Interpreter {
         }
     }
 
+    /// Assigning `Nil` to an *untyped* scalar container resets it to the
+    /// container's default type object, `Any` (`my $x = 5; $x = Nil` leaves
+    /// `$x =:= Any`). Typed scalars reset to their own type object, handled
+    /// separately. Only applies to genuine user scalar names — not `@`/`%`/`&`
+    /// containers (which hold Nil as an element) nor internal `__mutsu_` temps.
+    ///
+    /// A scalar with an explicit `is default(X)` trait keeps its own default (the
+    /// caller has already applied it), even when that default is `Nil` — e.g.
+    /// `my $foo is default(Nil) = 42; $foo = Nil` leaves `$foo` as `Nil`, not
+    /// `Any` — so such vars are excluded here.
+    pub(crate) fn reset_nil_untyped_scalar(&self, name: &str, val: Value) -> Value {
+        if matches!(val, Value::Nil)
+            && !name.starts_with('@')
+            && !name.starts_with('%')
+            && !name.starts_with('&')
+            && !name.contains("__mutsu")
+            && self.var_default(name).is_none()
+        {
+            Value::Package(crate::symbol::Symbol::intern("Any"))
+        } else {
+            val
+        }
+    }
+
     /// De-itemize a `for … -> @a` chunk element while preserving its element
     /// type. An element-typed array (`array[int]`) keeps its type — only the
     /// itemization/scalar wrap is stripped, which is exactly the de-itemization

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -120,6 +120,7 @@ impl Interpreter {
                 self.stack
                     .push(Self::itemize_scalar_assign_result(name, val));
             } else {
+                let val = self.reset_nil_untyped_scalar(name, val);
                 self.locals[idx] = val.clone();
                 self.stack
                     .push(Self::itemize_scalar_assign_result(name, val));
@@ -255,6 +256,10 @@ impl Interpreter {
             if !matches!(val, Value::Nil | Value::Package(_)) {
                 val = loan_env!(self, try_coerce_value_for_constraint(&constraint, val))?;
             }
+        } else {
+            // Untyped scalar: assigning Nil resets it to the default type
+            // object Any (the reset guard is a no-op for `@`/`%` containers).
+            val = self.reset_nil_untyped_scalar(name, val);
         }
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -286,6 +286,16 @@ impl Interpreter {
                 let val = Self::wrap_native_int_by_constraint(&constraint, val)?;
                 self.locals[idx] = val;
             } else {
+                // Untyped scalar: *reassigning* Nil resets it to the default type
+                // object Any (`$x = 5; $x = Nil` -> Any). Declarations (`my $x`,
+                // `my $x = <Nil-valued expr>`) keep their existing Nil path — a
+                // narrower scope that fixes the reassignment case without touching
+                // the declaration-time Nil handling.
+                let val = if is_vardecl {
+                    val
+                } else {
+                    self.reset_nil_untyped_scalar(name, val)
+                };
                 self.locals[idx] = val;
             }
             // Track lazy-thunk readonly: mark when storing a LazyThunk,
@@ -873,6 +883,12 @@ impl Interpreter {
             }
             // Wrap native integer values on assignment (overflow wrapping)
             val = Self::wrap_native_int_by_constraint(&constraint, val)?;
+        } else if !is_bind && !is_vardecl {
+            // Untyped scalar: *reassigning* Nil resets it to the default type
+            // object Any (`$x = Nil` leaves `$x =:= Any`). Declarations keep their
+            // existing Nil path. The reset guard is a no-op for `@`/`%` containers
+            // and internal temps.
+            val = self.reset_nil_untyped_scalar(name, val);
         }
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);

--- a/t/nil-reset-scalar.t
+++ b/t/nil-reset-scalar.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 8;
+
+# Reassigning Nil to an untyped scalar container resets it to the default type
+# object, Any (Raku container semantics). Typed scalars reset to their own type.
+
+{
+    my $x = 5;
+    $x = Nil;
+    ok $x === Any, 'reassigning Nil to an untyped scalar yields Any';
+    nok $x.defined, 'the reset value is undefined';
+}
+
+{
+    # xor/^^ of two true values yields Nil, which resets the scalar to Any.
+    my $x = 42;
+    $x ^^= 15;
+    ok $x === Any, '^^= with two true arguments yields Nil -> Any';
+    $x ^^= 'xyzzy';
+    is $x, 'xyzzy', "^^= doesn't permanently falsify scalars";
+}
+
+{
+    my $x = 42;
+    $x xor= 15;
+    ok $x === Any, 'xor= with two true arguments yields Nil -> Any';
+}
+
+{
+    # A typed scalar resets to its own type object, not Any.
+    my Int $y = 5;
+    $y = Nil;
+    ok $y === Int, 'reassigning Nil to a typed scalar yields the type object';
+}
+
+{
+    # `@`/`%` element assignment is unaffected: it may hold Nil directly.
+    my @a = 1, 2;
+    @a[0] = Nil;
+    ok !@a[0].defined, 'array element assigned Nil is undefined';
+    is @a.elems, 2, 'array keeps its shape';
+}


### PR DESCRIPTION
## Summary
Reassigning `Nil` to an untyped scalar container resets it to the default type object `Any` (Raku container semantics):

```raku
my $x = 5; $x = Nil;   # $x =:= Any
my $x = 42; $x ^^= 15; # ^^ of two true values yields Nil -> $x =:= Any
```

Typed scalars already reset to their own type object (`my Int $y = Nil` → `Int`).

Scoped to **reassignment** (`is_vardecl` false) so declaration-time Nil handling (`my $x;`, `my $match = grammar.parse()` returning Nil) is untouched — those feed subsystems (EVAL lexical capture, `Nil`-vs-`Any` indexing) with separate latent gaps that are out of scope here.

## Tests
- `S03-operators/assign.t`: 32 → 30 failures (tests 157, 162).
- Adds `t/nil-reset-scalar.t` (8 assertions).
- `make test` passes; targeted whitelist sweeps (nil/undef/assign/scalar/context) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)