### PR TITLE
fix(eval): persist grammar tokens declared inside EVAL so .parse works

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -66,13 +66,17 @@
 - [ ] roast/S17-promise/nonblocking-await.t
 - [ ] roast/S17-promise/single-assignment.t
 - [ ] roast/S17-promise/start.t
-  - 64/65 pass (only 58 fails). Blockers:
+  - 65/65 subtests pass (`Failed: 0`); only the TAP output-ordering blocker below
+    keeps it out of the whitelist. Blockers:
     - Test 45: **FIXED (#3996)** — `s///` replacement now interpolates a
       `$x.method()` postfix call (`$/.chars()`); a bare `$x.meth` stays literal,
       matching qq-string rules. Routed through the per-match dynamic path.
-    - Test 58: EVAL grammar in threads fails (lives-ok) — only remaining failure
-      (tests 51-53 `.backtrace`, 61-64 `uncaught_handler`, 65 TAP-sync now pass).
-    - Also "Tests out of sequence" from the start-block `pass` output ordering:
+    - Test 58: **FIXED** — a `grammar`/`token`/`rule` declared inside EVAL'd code
+      registers its class (merged back into the registry) but its tokens were
+      dropped by the EVAL routine-registry restore, so `.parse` on the returned
+      grammar type object failed with "Unknown method parse". EVAL now preserves
+      newly-registered `token_defs`/`proto_tokens` (see `restore_routine_registry_impl`).
+    - REMAINING blocker: "Tests out of sequence" from the start-block `pass` output ordering:
       a `start`/`Promise.start` block's `pass "..."` runs on a worker thread
       whose output is buffered into the shared thread-output buffer, drained
       only at sync points. Unlike then.t (#3989, drain-at-`.result`), here an

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -153,12 +153,40 @@ impl Interpreter {
                 }
             }
         }
+        // In EVAL context, a `grammar`/`token`/`rule` declared inside the EVAL'd
+        // code registers its class (which IS merged back into `registry.classes`
+        // by the caller) plus its tokens here. Restoring `token_defs`/`proto_tokens`
+        // to the snapshot would drop those tokens, so a later `.parse` on the
+        // returned grammar type object fails with "Unknown method parse". Preserve
+        // newly-registered tokens (keys absent from the snapshot) so the EVAL'd
+        // grammar stays usable, mirroring how EVAL'd classes/roles persist.
+        let mut new_tokens: Vec<(Symbol, Vec<std::sync::Arc<FunctionDef>>)> = Vec::new();
+        let mut new_proto_tokens: Vec<String> = Vec::new();
+        if is_eval {
+            let registry = self.registry();
+            for (key, defs) in &registry.token_defs {
+                if !token_defs.contains_key(key) {
+                    new_tokens.push((*key, defs.clone()));
+                }
+            }
+            for pt in &registry.proto_tokens {
+                if !proto_tokens.contains(pt) {
+                    new_proto_tokens.push(pt.clone());
+                }
+            }
+        }
         let mut registry = self.registry_mut();
         registry.functions = functions;
         registry.proto_functions = proto_functions;
         registry.token_defs = token_defs;
         registry.proto_subs = proto_subs;
         registry.proto_tokens = proto_tokens;
+        for (key, defs) in new_tokens {
+            registry.token_defs.insert(key, defs);
+        }
+        for pt in new_proto_tokens {
+            registry.proto_tokens.insert(pt);
+        }
         // Re-apply only newly added our-scoped functions so they survive block scope exit.
         // In EVAL context, our-scoped functions should NOT leak into the outer lexical
         // scope — they remain accessible only via OUR:: pseudo-package resolution.

--- a/t/eval-grammar-parse.t
+++ b/t/eval-grammar-parse.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 6;
+
+# A grammar declared inside EVAL'd code registers its class *and* its tokens.
+# The tokens must survive the EVAL's routine-registry restore, or a later
+# `.parse` on the returned grammar type object fails with "Unknown method parse".
+
+# Named grammar via EVAL.
+{
+    my \g = EVAL 'grammar G_Named { token TOP { <a> | <b> }; token a { \d }; token b { <[a..z]> } }';
+    is g.^name, 'G_Named', 'EVAL of a named grammar returns the grammar type object';
+    ok g.parse('x').defined, '.parse works on an EVAL-defined named grammar';
+    is g.parse('7')<a>, '7', 'named token matches through EVAL-defined grammar';
+    nok g.parse('1x'), '.parse fails to match when the whole string is not consumed';
+}
+
+# Anonymous grammar via EVAL (fresh class each time).
+{
+    my \g = EVAL 'grammar { token TOP { <a> | <b> }; token a { \d | \s }; token b { a | b } }';
+    ok g.parse('b').defined, '.parse works on an EVAL-defined anonymous grammar';
+}
+
+# Repeated EVAL of fresh grammars parsed in parallel must not crash
+# (rakudo old-issue-tracker #2593: NFA-cache SEGV on first parallel parse).
+{
+    lives-ok {
+        for ^20 {
+            my \g = EVAL 'grammar { token TOP { <a> | <b> }; token a { \d | \s }; token b { a | b } }';
+            await (start g.parse('b')) xx 4;
+        }
+    }, 'parallel parsing of freshly EVAL-defined grammars does not crash';
+}


### PR DESCRIPTION
## Summary

A `grammar`/`token`/`rule` declared inside `EVAL`'d code registers its class (which *is* merged back into the interpreter's class registry after EVAL) but its **tokens were dropped**: `restore_routine_registry_impl` reset `token_defs` / `proto_tokens` to the pre-EVAL snapshot without merging back tokens registered during the EVAL.

A later `.parse` on the returned grammar type object then failed with:

```
X::Method::NotFound: Unknown method value dispatch (fallback disabled): parse
```

because `resolve_token_defs` could no longer find the grammar's `TOP` rule.

### Before
```raku
my \g = EVAL 'grammar { token TOP { <a> | <b> }; token a { \d }; token b { a | b } }';
say g.parse('b');   # Runtime error: Unknown method ... parse
```
### After
```raku
say g.parse('b');   # ｢b｣ / b => ｢b｣
```

## Fix

In EVAL context, preserve `token_defs` / `proto_tokens` whose keys were absent from the snapshot (i.e. newly registered by the EVAL'd grammar), mirroring how EVAL'd classes/roles already persist via the caller's `.extend`.

## Impact

- `EVAL 'grammar { ... }'` now returns a fully usable grammar, incl. under concurrent parsing — fixes `roast/S17-promise/start.t` test 58 (rakudo old-issue-tracker #2593, previously a hard failure).
- **start.t is not whitelisted here**: all 65 subtests now pass (`Failed: 0`), but a separate, pre-existing TAP output-ordering blocker keeps it red under `prove` (a worker-thread `pass` line is drained *after* an intervening main-thread `ok`, so TAP sees "tests out of sequence"). Documented in `TODO_roast/S17.md`.

## Tests

- Adds `t/eval-grammar-parse.t` (named + anonymous EVAL grammars, match/no-match, and the parallel-parse no-crash case), passing 3× locally.
- `make test` green (the one `t/lock.t` blip is the documented lock-contention flaky — re-ran 10/10 three times); `cargo clippy -D warnings` clean; full S05-grammar + eval/threads roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)