### PR TITLE
fix(assign): infix:<=> called as a function assigns to arg0

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -1,6 +1,50 @@
 use super::*;
 
 impl Compiler {
+    /// Lower a call to the assignment/bind operator used as a function
+    /// (`infix:<=>(lvalue, val)` / `infix:<:=>(lvalue, val)`) into an ordinary
+    /// assignment expression targeting `lvalue`.
+    fn lower_infix_assign_call(opname: &str, target: Expr, value: Expr) -> Expr {
+        let is_bind = opname == "infix:<:=>";
+        let target = match target {
+            Expr::Grouped(inner) => *inner,
+            other => other,
+        };
+        match target {
+            Expr::Var(name) => Expr::AssignExpr {
+                name,
+                expr: Box::new(value),
+                is_bind,
+            },
+            Expr::ArrayVar(name) => Expr::AssignExpr {
+                name: format!("@{}", name),
+                expr: Box::new(value),
+                is_bind,
+            },
+            Expr::HashVar(name) => Expr::AssignExpr {
+                name: format!("%{}", name),
+                expr: Box::new(value),
+                is_bind,
+            },
+            Expr::Index {
+                target,
+                index,
+                is_positional,
+            } => Expr::IndexAssign {
+                target,
+                index,
+                value: Box::new(value),
+                is_positional,
+            },
+            // Any other lvalue shape: fall back to the generic named-sub lvalue
+            // assignment helper (mirrors the parser's `assign_to_target_expr`).
+            other => Expr::Call {
+                name: crate::symbol::Symbol::intern("__mutsu_assign_callable_lvalue"),
+                args: vec![other, Expr::ArrayLiteral(Vec::new()), value],
+            },
+        }
+    }
+
     pub(super) fn compile_expr(&mut self, expr: &Expr) {
         match expr {
             Expr::Whatever => {
@@ -223,6 +267,37 @@ impl Compiler {
                 self.compile_expr(&args[0]);
                 let name_idx = self.code.add_constant(Value::str("_".to_string()));
                 self.code.emit(OpCode::TopicDotAssign(name_idx));
+            }
+            // The assignment operator called as a function: `infix:<=>($x, 0)`
+            // and `&infix:<=>.($x, 0)` (CallOn) mean `$x = 0`. `infix:<=>` is a
+            // reserved special form handled by the compiler, so lower the call to
+            // an ordinary assignment (which binds arg0 as an lvalue and applies
+            // type checks). Same for the bind form `infix:<:=>`.
+            Expr::Call { name, args }
+                if args.len() == 2
+                    && matches!(name.resolve().as_str(), "infix:<=>" | "infix:<:=>") =>
+            {
+                let lowered = Self::lower_infix_assign_call(
+                    &name.resolve(),
+                    args[0].clone(),
+                    args[1].clone(),
+                );
+                self.compile_expr(&lowered);
+            }
+            Expr::CallOn { target, args }
+                if args.len() == 2
+                    && matches!(
+                        target.as_ref(),
+                        Expr::CodeVar(n) if n == "infix:<=>" || n == "infix:<:=>"
+                    ) =>
+            {
+                let opname = match target.as_ref() {
+                    Expr::CodeVar(n) => n.clone(),
+                    _ => unreachable!(),
+                };
+                let lowered =
+                    Self::lower_infix_assign_call(&opname, args[0].clone(), args[1].clone());
+                self.compile_expr(&lowered);
             }
             Expr::Call { name, args } => {
                 self.compile_expr_call(name, args);

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -216,23 +216,37 @@ impl Interpreter {
         {
             return Err(err);
         }
-        // When assigning Nil to a typed variable, reset to the type object
-        let mut val =
-            if matches!(val, Value::Nil) && !name.starts_with('@') && !name.starts_with('%') {
-                if let Some(constraint) = loan_env!(self, var_type_constraint(&name)) {
-                    if constraint == "Mu" {
-                        val
-                    } else {
-                        let nominal =
-                            loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
-                        Value::Package(Symbol::intern(&nominal))
-                    }
-                } else {
+        // Validate/coerce against a scalar type constraint. Nil resets to the
+        // type object; a non-Nil value that violates the constraint throws
+        // X::TypeCheck::Assignment (e.g. `infix:<=>($int, "foo")`), matching the
+        // SetLocal path -- expression-context assignment to a captured typed
+        // scalar must type-check just like a statement-level one.
+        let mut val = if !name.starts_with('@')
+            && !name.starts_with('%')
+            && let Some(constraint) = loan_env!(self, var_type_constraint(&name))
+        {
+            if matches!(val, Value::Nil) {
+                if constraint == "Mu" {
                     val
+                } else {
+                    let nominal =
+                        loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
+                    Value::Package(Symbol::intern(&nominal))
                 }
+            } else if !self.type_matches_value(&constraint, &val) {
+                return Err(runtime::utils::type_check_assignment_typed_error(
+                    &name,
+                    &constraint,
+                    &val,
+                ));
+            } else if !matches!(val, Value::Package(_)) {
+                loan_env!(self, try_coerce_value_for_constraint(&constraint, val))?
             } else {
                 val
-            };
+            }
+        } else {
+            val
+        };
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
         if matches!(self.env().get(&readonly_key), Some(Value::Bool(true)))

--- a/t/infix-assign-as-function.t
+++ b/t/infix-assign-as-function.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 7;
+
+# The assignment operator called as a function assigns to its first argument.
+
+{
+    my $x = 1;
+    infix:<=>($x, 0);
+    is $x, 0, 'infix:<=>($x, 0) assigns 0 to $x';
+}
+
+{
+    my $x = 1;
+    &infix:<=>.($x, 0);
+    is $x, 0, '&infix:<=>.($x, 0) assigns 0 to $x';
+}
+
+{
+    my Int $y;
+    lives-ok { &infix:<=>($y, 3) }, 'assignment as function respects a matching type';
+    is $y, 3, 'the value was assigned';
+    dies-ok { &infix:<=>($y, 'foo') }, 'assignment as function type-checks (dies on mismatch)';
+}
+
+# Also works when the target is captured by an enclosing closure.
+{
+    my Int $z = 5;
+    my $set = { &infix:<=>($z, 9) };
+    $set();
+    is $z, 9, 'assignment as function through a closure-captured target';
+    my $bad = { &infix:<=>($z, 'nope') };
+    dies-ok { $bad() }, 'type check applies to a closure-captured typed target';
+}


### PR DESCRIPTION
## Summary
The assignment operator called as a function now assigns to its first argument (an lvalue), matching Raku:

```raku
my $x = 1; infix:<=>($x, 0);    # $x == 0
my $x = 1; &infix:<=>.($x, 0);  # $x == 0
```

`infix:<=>` (and the bind form `infix:<:=>`) is a reserved special form handled by the compiler, so the call is lowered to an ordinary assignment expression targeting arg0 — applying the usual lvalue and type-check semantics.

This also closes a gap the lowering exposed: the expression-context `AssignExpr` path (used when the target is a closure-captured scalar reached by name) did not validate a scalar type constraint for a non-Nil value, so `&infix:<=>($int, "foo")` inside a block silently succeeded. It now throws `X::TypeCheck::Assignment` like the statement-level path.

## Tests
- `S03-operators/assign.t`: tests 5, 7, 8 now pass.
- Adds `t/infix-assign-as-function.t` (7 assertions).
- `make test` passes (Result: PASS, no dubious).

🤖 Generated with [Claude Code](https://claude.com/claude-code)