### PR TITLE
fix(assign): ,= on a hash/array reads the LHS as that container

### DIFF
--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -198,7 +198,10 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             remaining_len: err.remaining_len.or(Some(rest.len())),
             exception: None,
         })?;
-        let expr = compound_assigned_value_expr(Expr::Var(name.clone()), op, rhs);
+        // Use the sigil-appropriate lvalue expression so `%h ,= %g` / `@a ,= 3`
+        // read the current container as a Hash/Array (not a scalar `Var("%h")`),
+        // giving the comma operator the two containers to merge/append.
+        let expr = compound_assigned_value_expr(var_expr, op, rhs);
         let stmt = Stmt::Assign {
             name,
             expr,

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -283,15 +283,19 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             }
         };
         let name = format!("{}{}", prefix, var);
+        // Read the current value through the sigil-appropriate lvalue so `%h ,= %g`
+        // / `@a ,= 3` treat the LHS as a Hash/Array container (not a scalar
+        // `Var("h")`), letting the comma operator merge/append the two containers.
+        let lhs_expr = match sigil {
+            b'@' => Expr::ArrayVar(var.to_string()),
+            b'%' => Expr::HashVar(var.to_string()),
+            _ => Expr::Var(var.to_string()),
+        };
         return Ok((
             rest,
             Expr::AssignExpr {
                 name,
-                expr: Box::new(compound_assigned_value_expr(
-                    Expr::Var(var.to_string()),
-                    op,
-                    rhs,
-                )),
+                expr: Box::new(compound_assigned_value_expr(lhs_expr, op, rhs)),
                 is_bind: false,
             },
         ));

--- a/t/comma-assign-container.t
+++ b/t/comma-assign-container.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 6;
+
+# `,=` on a hash merges the right-hand hash into the left (like `%h = %h, %other`).
+{
+    my %part1 = a => 'b';
+    my %part2 = d => 'c';
+    my %both = %part1, %part2;
+
+    my %retval = ( %part1 ,= %part2 );
+    ok %retval eqv %both, ',= works for hashes (return value)';
+    ok %part1  eqv %both, ',= works for hashes (hash modified)';
+}
+
+# `,=` on an array appends (like push).
+{
+    my @a = 1, 2;
+    @a ,= 3, 4;
+    is @a.join('|'), '1|2|3|4', ',= on an array appends';
+}
+
+# statement vs expression context both work.
+{
+    my @a = 1, 2;
+    my @r = (@a ,= 3);
+    is @a.join('|'), '1|2|3', ',= expression context (array modified)';
+    is @r.join('|'), '1|2|3', ',= expression context (return value)';
+}
+
+{
+    my %h = x => 1;
+    %h ,= (y => 2);
+    ok %h eqv {x => 1, y => 2}, ',= statement context on a hash';
+}


### PR DESCRIPTION
## Summary
`%h ,= %g` and `@a ,= 3, 4` (the comma compound-assignment) built the current value as a scalar `Var("%h")` instead of a `HashVar`/`ArrayVar`, so the comma operator saw a scalarized value and produced garbage (`{"" => ...}`) rather than merging/appending.

Both the statement-level (`assign_stmt`) and expression-level (`try_assign`) compound-assignment paths now select the sigil-appropriate lvalue expression:

```raku
my %part1 = a => 'b'; my %part2 = d => 'c';
%part1 ,= %part2;     # %part1 is now {:a("b"), :d("c")}
my @a = 1, 2; @a ,= 3, 4;   # @a is now [1, 2, 3, 4]
```

## Tests
- `S03-operators/assign.t` tests 254, 255 now pass.
- Adds `t/comma-assign-container.t` (6 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)