### PR TITLE
fix(assign): reverse meta-op assignment `$x R op= $y` targets the right operand

### DIFF
--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -150,6 +150,20 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             };
             return parse_statement_modifier(rest, stmt);
         }
+        // The reverse meta-operator assignment `$x R op= $y` assigns to its
+        // RIGHT operand: `$y = $y op $x` (= `$x R op $y`). So `$x R~= $y` leaves
+        // `$x` unchanged and sets `$y` to `$y ~ $x`, and `$x R op= <literal>`
+        // dies with X::Assignment::RO because the literal is not a container.
+        if meta == "R" {
+            let value = Expr::MetaOp {
+                meta,
+                op,
+                left: Box::new(var_expr),
+                right: Box::new(rhs.clone()),
+            };
+            let assign = crate::parser::expr::precedence::assign_to_target_expr(rhs, value);
+            return parse_statement_modifier(rest, Stmt::Expr(assign));
+        }
         let expr = Expr::MetaOp {
             meta,
             op,

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -332,6 +332,20 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             b'%' => Expr::HashVar(var.to_string()),
             _ => Expr::Var(name.clone()),
         };
+        // The reverse meta-op assignment `$x R op= $y` assigns to its RIGHT
+        // operand (`$y = $y op $x`), so retarget the assignment to `rhs`.
+        if meta == "R" {
+            let value = Expr::MetaOp {
+                meta,
+                op,
+                left: Box::new(var_expr),
+                right: Box::new(rhs.clone()),
+            };
+            return Ok((
+                rest,
+                crate::parser::expr::precedence::assign_to_target_expr(rhs, value),
+            ));
+        }
         return Ok((
             rest,
             Expr::AssignExpr {

--- a/t/reverse-metaop-assign.t
+++ b/t/reverse-metaop-assign.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 6;
+
+# The reverse meta-operator assignment `$x R op= $y` assigns to its RIGHT
+# operand: `$y = $y op $x`. The left operand is left unchanged.
+
+{
+    my ($x, $y) = <a b>;
+    $x R~= $y;
+    is $x, 'a', 'R~= leaves the left operand unchanged';
+    is $y, 'ba', 'R~= assigns $y ~ $x to the right operand';
+}
+
+{
+    my ($x, $y) = (10, 3);
+    $x R-= $y;
+    is $y, -7, 'R-= computes $y - $x into the right operand';
+    is $x, 10, 'R-= leaves the left operand unchanged';
+}
+
+# Expression context: the assignment value is the new right-operand value.
+{
+    my ($x, $y) = (10, 3);
+    my $r = ($x R-= $y);
+    is $r, -7, 'R-= in expression context returns the assigned value';
+}
+
+# The right operand must be a container.
+{
+    my $foo = 'foo';
+    dies-ok { $foo R~= 'foo' }, 'R~= dies when the right operand is a literal';
+}


### PR DESCRIPTION
## Summary
The reverse meta-operator assignment assigns to its **right** operand:

```raku
my ($x, $y) = <a b>; $x R~= $y;   # $x stays "a", $y becomes "ba" (= $y ~ $x)
my ($x, $y) = (10, 3); $x R-= $y; # $x stays 10, $y becomes -7 (= $y - $x)
```

`$x R op= <literal>` dies with `X::Assignment::RO` because the right operand (the literal) is not a container.

Both the statement-level (`assign_stmt`) and expression-level (`try_assign`) `R`-meta compound-assignment paths now retarget the assignment to the RHS lvalue (via `assign_to_target_expr`), the value being the reversed-operand `MetaOp`. Only the `R` reverse meta is affected; `X`/`Z` metaops keep targeting the LHS.

## Tests
- `S03-operators/assign.t` tests 127, 128 now pass.
- Adds `t/reverse-metaop-assign.t` (6 assertions).
- `make test` passes; whitelisted S03-metaops tests (reduce/reverse/cross/zip/eager-hyper) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)