### PR TITLE
fix(assign): itemize the rvalue of a package/global scalar assignment

### DIFF
--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -425,7 +425,12 @@ impl Interpreter {
             self.set_env_with_main_alias(&sv, val.clone());
             self.update_local_if_exists(code, &sv, &val);
         }
-        self.stack.push(val);
+        // A scalar assignment used as an rvalue yields the *itemized* container
+        // value, so a following list context treats it as one element (matching
+        // the local-var path). Covers package-qualified / global scalars
+        // (`@z = ($Foo::c = 3, 4)` -> `((3,4),)`). `@`/`%`/`&` keep their value.
+        self.stack
+            .push(Self::itemize_scalar_assign_result(&name, val));
         Ok(())
     }
 

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -615,8 +615,12 @@ impl Interpreter {
     /// The rvalue produced by a *scalar* assignment expression is the itemized
     /// container value, so a following list context sees it as one element:
     /// `@p = ($x = 3, 4)` gives `((3,4),)`. `@`/`%`/`&` names keep their value.
+    ///
+    /// The topic `$_` is excluded: when it aliases a whole container (`given @a {
+    /// .=reverse }`) the assignment writes back through the alias, and itemizing
+    /// the result would wrap the container written back to `@a`.
     pub(crate) fn itemize_scalar_assign_result(name: &str, val: Value) -> Value {
-        if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
+        if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') || name == "_" {
             val
         } else {
             Self::itemize_value(val)


### PR DESCRIPTION
## Summary
Extends the scalar-assignment result itemization (from the local-var path) to the non-local `AssignExpr` path, so a package-qualified / global scalar used as an rvalue yields the itemized container value:

```raku
our $c;
my @z = (flat $Foo::c = 1, 2);   # @z.elems == 3, not flattened
```

The itemize helper now also excludes the topic `$_`: when it aliases a whole container (`given @a { .=reverse }`) the assignment writes back through the alias, and itemizing the result would wrap the container written back to `@a`.

## Tests
- `S03-operators/assign.t` test 197 now passes (46 → 22 failures overall this session).
- `make test` passes (including `t/for-topic-dotassign-readonly.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)