### PR TITLE
docs(roast): update assign.t status (46 -> 22 failures)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -141,14 +141,29 @@
     following list context sees one element (`@p = ($x = 3, 4)` -> `((3,4),)`).
     A parenthesized scalar item-assignment is tighter than the comma:
     `($x = l(), 3, 4)` parses as `(($x = l()), 3, 4)`, not `$x = (l(), 3, 4)`.
-  - Remaining failures (32) are separate features:
-    `&infix:<=>`/`infix:<=>(...)` as a callable assignment function (5, 7-8),
-    slice-in-list list-assignment lvalues (47-50), `R~=` reversed metaop on a
-    non-container (127-128), `~>=`/`~<=` buffer-shift assignment (182-183),
-    assigning `Nil` to an untyped scalar resetting it to `Any` (157, 162),
-    `,=` on hashes / list precedence (254-255, 288), `%=` with a `:U` target
-    throwing under `use fatal` (301), and the deep `lhs treats X as scalar/list`
-    item-vs-list assignment-LHS block (many `#?rakudo todo`, 194-248).
+  - ~280/302 pass (22 failing). Fixed since: `&infix:<=>`/`infix:<=>(...)` as a
+    callable assignment function that assigns to arg0 + type-checks (5, 7-8);
+    `Nil`-reassignment to an untyped scalar resets it to `Any` (157, 162); `,=`
+    on a hash/array reads the LHS as that container (254, 255); `R op=` reverse
+    meta-op assignment targets its RIGHT operand (127, 128); package/global
+    scalar assignment itemizes its rvalue (197).
+  - Remaining failures (22) are deep list-vs-item container semantics or niche
+    features, each risking regressions / exposing latent parse bugs:
+    - Element/subscript-assignment result itemization (`@a[0] = l, l` should make
+      `@z` one item; `%a{'x'..'z'}` a flat slice): 211, 214, 218, 224, 231-233,
+      242, 245, 248. The runtime single-vs-slice itemization is entangled with a
+      pre-existing string-range-hash-key stringification bug and with `$(@a[0])`
+      explicit-itemization (attempted; abandoned as net-zero + regressed 199).
+    - Parenthesized list-target binding (`($a) = l, l, l` slurps the list;
+      `($a,$b) = flat l, l`): 200, 202, 209.
+    - Slice-in-list chained list-assignment lvalues (`(@c[1,2], @c[3], @d) = ...`):
+      47-50.
+    - `~>=`/`~<=` buffer bit-shift assignment (NYI in raku itself): 182, 183.
+    - Symbolic-deref package-scalar STORAGE (`$::('Foo::b') = 42` stores nowhere):
+      194.
+    - `,=` container-identity (`@a =:= @a[0]<>`): 288.
+    - `%=` on a `:U` target under `use fatal` (rakudo-specific "No zero-arg
+      meaning for infix:<%>"): 301.
 - [ ] roast/S03-operators/autoincrement-range.t
   - 5/104 pass.
 - [ ] roast/S03-operators/autoincrement.t


### PR DESCRIPTION
Records this session's S03-operators/assign.t progress and categorizes the 22 remaining failures by blocking feature. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)