### PR TITLE
fix(assign): $(EXPR) = a, b is item assignment (comma not part of RHS)

### DIFF
--- a/src/parser/stmt/assign/paren.rs
+++ b/src/parser/stmt/assign/paren.rs
@@ -224,6 +224,42 @@ pub(crate) fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
         &rest[1..]
     };
     let (rest, _) = ws(rest)?;
+    // `$(EXPR) = a, b` forces ITEM assignment: `$(...)` names the same container
+    // as EXPR but in item context, so the comma is NOT part of the RHS
+    // (`(($(EXPR) = a), b)`) -- unlike a bare `(@a[0] = a, b)` which is list
+    // assignment and slurps the comma. Parse the RHS comma-blind and fold any
+    // trailing comma list into the parenthesized value.
+    if let Expr::MethodCall {
+        target, name, args, ..
+    } = &lhs
+        && name == "item"
+        && args.is_empty()
+        && !is_atomic
+    {
+        let inner_target = (**target).clone();
+        let (r, value) = expression_no_sequence(rest)?;
+        let assign = crate::parser::expr::precedence::assign_to_target_expr(inner_target, value);
+        let (mut r, _) = ws(r)?;
+        if r.starts_with(',') && !r.starts_with(",,") {
+            let mut items = vec![assign];
+            while r.starts_with(',') && !r.starts_with(",,") {
+                let (c, _) = parse_char(r, ',')?;
+                let (c, _) = ws(c)?;
+                if c.starts_with(')') {
+                    r = c;
+                    break;
+                }
+                let (c, item) = expression_no_sequence(c)?;
+                items.push(item);
+                let (c, _) = ws(c)?;
+                r = c;
+            }
+            let (r, _) = parse_char(r, ')')?;
+            return Ok((r, Expr::ArrayLiteral(items)));
+        }
+        let (r, _) = parse_char(r, ')')?;
+        return Ok((r, assign));
+    }
     // Parse RHS: try chained assignment first, then comma-separated list for multi-value
     // assignment (e.g. `(%h{|| @a} = 42,666)`).
     let (rest, rhs) = match try_parse_assign_expr(rest) {

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -777,6 +777,47 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
     // Generic assignment on non-variable lhs (e.g. `.key = 1`).
     // TODO: Introduce a dedicated assignment AST form for arbitrary lvalues.
     // Current fallback consumes `lhs = rhs` and preserves both sides as expressions.
+    // `$(EXPR) = a, b` forces ITEM assignment: `$(...)` names the same container
+    // as EXPR but in item context, so the comma is NOT part of the RHS
+    // (`($(EXPR) = a), b`) -- unlike a bare `@a[0] = a, b` list assignment. Parse
+    // the RHS comma-blind and leave any trailing comma list for the enclosing
+    // (statement-level) comma expression.
+    if let Expr::MethodCall {
+        target, name, args, ..
+    } = &expr
+        && name == "item"
+        && args.is_empty()
+        && rest.starts_with('=')
+        && !rest.starts_with("==")
+        && !rest.starts_with("=>")
+    {
+        let inner_target = (**target).clone();
+        let r = &rest[1..];
+        let (r, _) = ws(r)?;
+        let (mut r, value) = expression(r)?;
+        let assign = crate::parser::expr::precedence::assign_to_target_expr(inner_target, value);
+        let (r_ws, _) = ws(r)?;
+        r = r_ws;
+        let result = if r.starts_with(',') && !r.starts_with(",,") {
+            let mut items = vec![assign];
+            while r.starts_with(',') && !r.starts_with(",,") {
+                let (c, _) = parse_char(r, ',')?;
+                let (c, _) = ws(c)?;
+                if c.is_empty() || c.starts_with(';') || c.starts_with('}') {
+                    r = c;
+                    break;
+                }
+                let (c, item) = expression(c)?;
+                items.push(item);
+                let (c, _) = ws(c)?;
+                r = c;
+            }
+            Expr::ArrayLiteral(items)
+        } else {
+            assign
+        };
+        return parse_statement_modifier(r, Stmt::Expr(result));
+    }
     if !matches!(expr, Expr::AssignExpr { .. })
         && rest.starts_with('=')
         && !rest.starts_with("==")

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -59,6 +59,30 @@ impl Interpreter {
         let declared_shape_key = format!("__mutsu_shaped_array_dims::{var_name}");
         let has_declared_shape = self.env().contains_key(&declared_shape_key);
         let idx = self.stack.pop().unwrap_or(Value::Nil);
+        // A single scalar index assigns to one element (a scalar slot), so the
+        // assignment's rvalue is itemized just like a scalar-variable assignment
+        // (`@z = (@a[0] = 1, 2)` => `@z.elems == 1`). A slice index (bare list /
+        // Range / Seq) distributes to several elements and keeps the flat list as
+        // its value. Computed from the RAW index before any normalization —
+        // a range that is (incorrectly) stringified to one hash key later must
+        // still be recognized as a slice here. An itemized subscript
+        // (`@a[$(7,8,9)]`, an `ItemList`/`Scalar`-wrapped list) is a single index.
+        let idx_is_single_element = match &idx {
+            Value::Array(_, crate::value::ArrayKind::ItemList) => true,
+            Value::Scalar(inner) => {
+                !inner.is_range() && !matches!(inner.as_ref(), Value::Array(..))
+            }
+            other => !matches!(
+                other,
+                Value::Array(..)
+                    | Value::Range(..)
+                    | Value::RangeExcl(..)
+                    | Value::RangeExclStart(..)
+                    | Value::RangeExclBoth(..)
+                    | Value::Seq(..)
+                    | Value::Slip(..)
+            ),
+        };
         // An *itemized* list/Range subscript (`@a[$(7,8,9)] = …`) is a SINGLE
         // index (its `.Int`, the element count), not a slice — itemization makes
         // it one item. An itemized list reaches here as `ArrayKind::ItemList` (or
@@ -1375,7 +1399,16 @@ impl Interpreter {
                 }
             }
         }
-        self.stack.push(val);
+        // Restricted to positional array elements: hash single-key assignment
+        // exits through other push sites, and a string-range hash subscript
+        // (`%a{'x'..'z'}`) is currently mis-stringified to one key, so treating it
+        // as a single element here would wrongly itemize a slice result.
+        let result = if idx_is_single_element && !var_name.starts_with('%') {
+            Self::itemize_value(val)
+        } else {
+            val
+        };
+        self.stack.push(result);
         Ok(())
     }
 

--- a/t/item-deref-assign-comma.t
+++ b/t/item-deref-assign-comma.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 8;
+
+sub l () { 1, 2 }
+
+# `$(EXPR) = a, b` forces ITEM assignment: the `$(...)` contextualizer names the
+# same container as EXPR but in item context, so the comma is NOT part of the RHS
+# (`($(EXPR) = a), b`) -- unlike a bare `@a[0] = a, b`, which is list assignment.
+
+# Expression context (parenthesized).
+{
+    my @a;
+    my @z = ($(@a[0]) = l, l);
+    is @a[0].elems, 2, '$(@a[0]) = l, l assigns just the first l() (item context)';
+    is @z.elems,    2, 'the trailing comma extends the enclosing list';
+    is @z[0].elems, 2, '@z[0] is the first l() = (1,2)';
+    is @z[1].elems, 2, '@z[1] is the second l() = (1,2)';
+}
+
+# A parenthesized RHS is assigned whole.
+{
+    my @a;
+    $(@a[0]) = (1, 2);
+    is @a[0].elems, 2, '$(@a[0]) = (1, 2) assigns the whole parenthesized list';
+}
+
+# Statement context: item assignment, trailing comma is a sink sibling.
+{
+    my @a;
+    $(@a[0]) = 1, 2;
+    is @a[0], 1, '$(@a[0]) = 1, 2 (statement) assigns just 1';
+}
+
+# Bare `@a[0] = a, b` stays list assignment (comma slurped) -- unchanged.
+{
+    my @a;
+    @a[0] = 1, 2;
+    is @a[0].elems, 2, 'bare @a[0] = 1, 2 slurps the comma (list assignment)';
+    my @z = (@a[0] = 3, 4);
+    is @z.elems, 1, 'bare @a[0] = list, used as rvalue, is one itemized element';
+}


### PR DESCRIPTION
## Summary
The item contextualizer `$(...)` forces **item** assignment: `$(@a[0]) = a, b` assigns only `a` to the element and leaves the comma to the enclosing expression (`($(@a[0]) = a), b`), unlike a bare `@a[0] = a, b` which is list assignment and slurps the whole comma list.

```raku
my @a; $(@a[0]) = 1, 2;   # @a[0] == 1  (item; `, 2` is a sink sibling)
my @a; @a[0]    = 1, 2;   # @a[0] == (1, 2)  (list; comma slurped) -- unchanged
```

Previously both parsed identically (the `.item` lvalue's RHS used the comma-collecting parser), so `$(@a[0]) = l, l` wrongly stored both `l()` results. Both the parenthesized-assignment path (`paren.rs`) and the statement-level path (`simple_expr_stmt/core.rs`) now parse a `.item` MethodCall lvalue's RHS comma-blind and fold any trailing comma into the enclosing value.

## Tests
- `S03-operators/assign.t` tests 198, 199 now pass (22 → 21 failing).
- Adds `t/item-deref-assign-comma.t` (8 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)