### PR TITLE
fix(assign): string-range hash subscript is a slice over enumerated keys

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -135,6 +135,16 @@ impl Interpreter {
                     crate::value::ArrayKind::List,
                 )
             }
+            // Non-integer (e.g. string) ranges: `%h{'x'..'z'} = ...` is a hash
+            // slice over the enumerated keys `x`, `y`, `z`, not a single
+            // stringified `"x y z"` key. Expand via the range's own list.
+            gr @ Value::GenericRange { .. } if expand_range => {
+                let items = crate::runtime::utils::value_to_list(&gr);
+                Value::Array(
+                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::value::ArrayKind::List,
+                )
+            }
             other => other,
         };
         let raw_val = self.stack.pop().unwrap_or(Value::Nil);

--- a/t/hash-string-range-slice.t
+++ b/t/hash-string-range-slice.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 5;
+
+# A non-integer (string) range hash subscript is a slice over the enumerated
+# keys, not a single stringified key.
+
+{
+    my %h;
+    %h{'x'..'z'} = 1, 2, 3;
+    is %h<x>, 1, q{%h{'x'..'z'} = 1,2,3 sets key x};
+    is %h<y>, 2, '... key y';
+    is %h<z>, 3, '... key z';
+    nok %h{'x y z'}:exists, 'no stringified "x y z" key was created';
+}
+
+# Read path over a string range.
+{
+    my %h = a => 1, b => 2, c => 3;
+    is ~%h{'a'..'c'}, '1 2 3', q{%h{'a'..'c'} reads the enumerated keys};
+}


### PR DESCRIPTION
## Summary
`%h{'x'..'z'} = ...` is a hash slice over the keys `x`, `y`, `z`, not an assignment to a single stringified `"x y z"` key:

```raku
my %h; %h{'x'..'z'} = 1, 2, 3;   # {:x(1), :y(2), :z(3)}  (was {"x y z" => (1,2,3)})
```

The index-normalization in the named index-assign handler expanded only *integer* ranges to a key list; a non-integer `GenericRange` fell through and was stringified into one key. It now expands a `GenericRange` hash subscript via the range's own `.list`.

## Tests
- `S03-operators/assign.t` tests 231-236 now pass.
- Adds `t/hash-string-range-slice.t` (5 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)