### PR TITLE
docs(roast): update assign.t status (16 failures)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -147,20 +147,26 @@
     on a hash/array reads the LHS as that container (254, 255); `R op=` reverse
     meta-op assignment targets its RIGHT operand (127, 128); package/global
     scalar assignment itemizes its rvalue (197).
-  - Remaining failures (22) are deep list-vs-item container semantics or niche
-    features, each risking regressions / exposing latent parse bugs:
-    - Element/subscript-assignment result itemization (`@a[0] = l, l` should make
-      `@z` one item; `%a{'x'..'z'}` a flat slice): 211, 214, 218, 224, 231-233,
-      242, 245, 248. The runtime single-vs-slice itemization is entangled with a
-      pre-existing string-range-hash-key stringification bug and with `$(@a[0])`
-      explicit-itemization (attempted; abandoned as net-zero + regressed 199).
-    - Parenthesized list-target binding (`($a) = l, l, l` slurps the list;
+  - ~286/302 pass (16 failing). Fixed since: `$(EXPR) = a, b` item-assignment
+    comma semantics + single-index array element result itemization (198, 199,
+    211); string-range hash subscript is a slice over enumerated keys (231-236);
+    a 1-element array slice itemizes its rvalue (213, 214).
+  - Remaining failures (16) are deep list-vs-item container semantics or niche
+    features, each needing a different subsystem:
+    - Hash single-key result itemization (`%a<x>`/`%a{'x'}`): 218, 224. These
+      exit through a *different* index-assign opcode than the array path (the
+      array single-index/1-slice itemization does not reach them); locating the
+      hash exit is unfinished.
+    - Runtime-index element/callable assignment (`@a[@b[$c,]]`, `foo()[$b]`):
+      242, 245, 248.
+    - Parenthesized list-target binding (`($a) = l, l, l` slurps the whole list;
       `($a,$b) = flat l, l`): 200, 202, 209.
     - Slice-in-list chained list-assignment lvalues (`(@c[1,2], @c[3], @d) = ...`):
       47-50.
+    - Package-qualified scalar STORE not reaching a bare `our` var: even direct
+      `package Foo { our $b; $Foo::b = 42 }` leaves `$b` undefined (the store
+      writes env `Foo::b` but bare `$b` reads a stale local slot). Blocks 194.
     - `~>=`/`~<=` buffer bit-shift assignment (NYI in raku itself): 182, 183.
-    - Symbolic-deref package-scalar STORAGE (`$::('Foo::b') = 42` stores nowhere):
-      194.
     - `,=` container-identity (`@a =:= @a[0]<>`): 288.
     - `%=` on a `:U` target under `use fatal` (rakudo-specific "No zero-arg
       meaning for infix:<%>"): 301.


### PR DESCRIPTION
Records continued assign.t progress and re-categorizes the 16 remaining failures. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)