### PR TITLE
fix(assign): package-qualified scalar store syncs the `our` lexical alias

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1133,6 +1133,11 @@ impl Interpreter {
                 // restoration (which only preserves env keys that existed
                 // before the block).  `::('name')` falls back to this store.
                 self.set_our_var(name.clone(), val.clone());
+                // Eager `our`-alias sync: a package-qualified store (`$Foo::b = v`)
+                // must be visible immediately through the lexical alias (`$b`)
+                // inside the package, not only after block exit. If a local slot
+                // is `our`-linked to this qualified name, refresh it now.
+                self.sync_our_local_from_qualified(code, &name, &val);
                 // A plain assignment to a package-scope free variable (`our $X`
                 // or a `package { my $X }` lexical) reached by bare name from
                 // inside a named sub must reach the canonical package store too,

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -146,17 +146,23 @@ impl Interpreter {
             "&" => format!("&{}", name),
             _ => name.to_string(),
         };
-        // For $ sigil (item context), take only first element if value is a list.
+        // A `$` symbolic-deref store is a scalar assignment: it stores the whole
+        // value (a list is held itemized), NOT just its first element.
+        // `$::('x') = 1, 2` is already parsed item-assignment (RHS is `1`), so a
+        // list value here is a genuine `$::('x') = (1, 2)` and must be kept whole.
         let value = if sigil == "$" {
-            match &raw_value {
-                Value::Array(items, ..) => items.first().cloned().unwrap_or(Value::Nil),
-                _ => raw_value,
-            }
+            Self::normalize_scalar_assignment_value(raw_value)
         } else {
             raw_value
         };
         self.env_mut().insert(store_name.clone(), value.clone());
         self.update_local_if_exists(code, &store_name, &value);
+        // A package-qualified symbolic store (`$::('Foo::b') = v`) must reach the
+        // `our`-linked lexical alias (`$b`) immediately, like a direct
+        // `$Foo::b = v`; also persist it in the package store so a later
+        // bare/qualified read resolves it.
+        self.set_our_var(store_name.clone(), value.clone());
+        self.sync_our_local_from_qualified(code, &store_name, &value);
         // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a
         // symbolic-deref store (`$::($name) = v`) writes the target lexical by name
         // straight into env. `update_local_if_exists` refreshes the slot only when
@@ -166,7 +172,15 @@ impl Interpreter {
         // set env_dirty) — without this the write is lost once the blanket
         // reconcile is removed (mirrors the regex `:let` path).
         self.note_caller_env_write(&store_name);
-        self.stack.push(value);
+        // A `$` symbolic-deref store is a scalar assignment, so its rvalue is the
+        // *itemized* container value: `flat ($::('x') = 1, 2), ...` keeps the
+        // `(1,2)` as one element (matches a plain scalar assignment result).
+        let result = if sigil == "$" {
+            Self::itemize_value(value)
+        } else {
+            value
+        };
+        self.stack.push(result);
     }
 
     pub(super) fn exec_indirect_type_lookup_store_op(&mut self, code: &CompiledCode) {

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -1,6 +1,29 @@
 use super::*;
 
 impl Interpreter {
+    /// Eagerly refresh any `our`-linked local slot when its package-qualified
+    /// name is written (`$Foo::b = v` / `$::('Foo::b') = v`). An `our $b`
+    /// declaration keeps a local slot (`b`) and a package var (`Foo::b`) linked
+    /// via `our_locals`, but they are otherwise only reconciled at block exit;
+    /// this makes the lexical alias `$b` see a package-qualified write inside the
+    /// same block. No-op when the written name is not `our`-linked to a slot.
+    pub(crate) fn sync_our_local_from_qualified(
+        &mut self,
+        code: &CompiledCode,
+        qualified_name: &str,
+        val: &Value,
+    ) {
+        for (slot, our_name) in &code.our_locals {
+            if our_name == qualified_name && *slot < self.locals.len() {
+                self.locals[*slot] = val.clone();
+                if let Some(local_name) = code.locals.get(*slot) {
+                    let ln = local_name.clone();
+                    self.env_mut().insert(ln, val.clone());
+                }
+            }
+        }
+    }
+
     pub(super) fn exec_state_var_init_op(&mut self, code: &CompiledCode, slot: u32, key_idx: u32) {
         let init_val = self.stack.pop().unwrap_or(Value::Nil);
         let base_key = Self::const_str(code, key_idx);

--- a/t/our-var-package-sync.t
+++ b/t/our-var-package-sync.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 6;
+
+# Inside a package, `our $b` links the lexical alias `$b` to the package variable
+# `Foo::b`; a package-qualified store must be visible immediately through `$b`.
+
+{
+    package Foo {
+        our $b;
+        $Foo::b = 42;
+        is $b, 42, 'direct $Foo::b = 42 is visible through the our alias $b';
+    }
+}
+
+{
+    package Bar {
+        our $b;
+        $::('Bar::b') = 99;
+        is $b, 99, 'symbolic $::(...) store is visible through the our alias';
+    }
+}
+
+# A `$` symbolic-deref store is a scalar assignment: it stores the whole list
+# (itemized), not just the first element, and its rvalue is itemized.
+{
+    sub l () { 1, 2 }
+    package Baz {
+        our $b;
+        my @z = (flat $::('Baz::b') = l(), l());
+        is $b.elems, 2, 'the whole list (1,2) is stored, not just the first item';
+        is @z.elems, 3, 'the assignment rvalue is itemized so flat keeps (1,2)';
+        is @z[0].elems, 2, '@z[0] is the itemized (1,2)';
+    }
+}
+
+# Top-level our still works.
+{
+    our $top = 7;
+    is $GLOBAL::top // $top, 7, 'top-level our variable reads back';
+}


### PR DESCRIPTION
## Summary
Inside a package, `our $b` links a local slot (`b`) to the package variable (`Foo::b`), but they were only reconciled at block exit. So a package-qualified store wrote the package var while the bare lexical `$b` kept reading a stale local slot:

```raku
package Foo { our $b; $Foo::b = 42; say $b }   # was Nil, now 42
```

`SetGlobal` and the symbolic-deref store now eagerly refresh any `our`-linked local slot (and its env key) when its qualified name is written.

Also fixes the `$` symbolic-deref store: it took only the *first* element of a list value (`$::('x') = 1, 2` stored `1`) instead of the whole itemized list, and its rvalue is now itemized like a plain scalar assignment (so `flat ($::('x') = l()), ...` keeps `(1,2)` as one element).

## Tests
- `S03-operators/assign.t` test 194 now passes (16 → 15 failing).
- Adds `t/our-var-package-sync.t` (6 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)