### PR TITLE
fix(assign): computed single-index element assignment itemizes its rvalue

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2118,6 +2118,22 @@ impl Interpreter {
         let idx = self.stack.pop().unwrap_or(Value::Nil);
         let target = self.stack.pop().unwrap_or(Value::Nil);
         let key = idx.to_string_value();
+        // A single scalar index names one element, so the assignment's rvalue is
+        // itemized (like a scalar-variable / named single-index assignment);
+        // `@z = (foo()[$b] = l, l)` => `@z.elems == 1`. A multi-element slice
+        // (list of indices / Range) keeps the flat list.
+        let idx_is_single_element = match &idx {
+            Value::Array(items, kind) => {
+                matches!(kind, crate::value::ArrayKind::ItemList) || items.len() == 1
+            }
+            Value::Seq(items) | Value::Slip(items) => items.len() == 1,
+            Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. } => false,
+            _ => true,
+        };
 
         // Detect bind marker (__mutsu_bind_index_value) and extract the actual value
         let (val, bind_source) = match raw_val {
@@ -2272,7 +2288,12 @@ impl Interpreter {
                         self.update_local_if_exists(code, src, &cell_val);
                     }
                 }
-                self.stack.push(val);
+                let result = if idx_is_single_element {
+                    Self::itemize_value(val)
+                } else {
+                    val
+                };
+                self.stack.push(result);
             }
             Value::HashEntryRef { .. } => {
                 // Resolve the HashEntryRef and assign into the resolved container.

--- a/t/computed-index-single-itemize.t
+++ b/t/computed-index-single-itemize.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 4;
+
+sub l () { 1, 2 }
+
+# A single scalar index on a computed (stack) target names one element, so its
+# assignment rvalue itemizes (like a named single-index assignment). Multi-index
+# slices keep the flat list.
+
+{
+    my @a;
+    sub arr() { @a }
+    my $b = 0;
+    my @z = (arr()[$b] = l, l);
+    is @z.elems, 1, 'foo()[$scalar] = l, l used as rvalue is one itemized element';
+}
+
+{
+    my @a;
+    my @b = (0, 0);
+    my $c = 1;
+    my @z = (@a[@b[$c,]] = l, l);
+    is @z.elems, 1, '@a[@b[$c,]] single computed index is one itemized element';
+}
+
+{
+    my @a;
+    sub arr2() { @a }
+    my @z = (arr2()[0, 1] = 10, 20);
+    is @z.elems, 2, 'a computed 2-index slice keeps both values';
+}
+
+{
+    my @a;
+    sub arr3() { @a }
+    arr3()[0] = 99;
+    is @a[0], 99, 'computed single-index assignment still stores correctly';
+}


### PR DESCRIPTION
## Summary
A single scalar index on a computed (stack) target names one element, so the assignment's rvalue is itemized like a named single-index assignment:

```raku
my @a; sub arr(){ @a }; my @z = (arr()[0] = l, l);   # @z.elems == 1
```

The generic index-assign handler now detects a single scalar index (a 1-element index list / itemized subscript counts as single; a multi-element list or Range is a slice) and itemizes the array-element result.

## Tests
- `S03-operators/assign.t` tests 242, 245 now pass.
- Adds `t/computed-index-single-itemize.t` (4 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)