### PR TITLE
fix(assign): single hash-key assignment itemizes its rvalue

### DIFF
--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -349,7 +349,11 @@ impl Interpreter {
                         self.env_mut().insert("*HOME".to_string(), home_val);
                     }
                 }
-                self.stack.push(val);
+                // A single hash-key assignment names one scalar slot, so the
+                // rvalue is itemized (`@z = (%h<x> = 1, 2)` => `@z.elems == 1`).
+                // The fast path only handles a single scalar key (complex indices
+                // are rejected above), so this is always a single-element result.
+                self.stack.push(Self::itemize_value(val));
                 Some(Ok(()))
             }
             None => {
@@ -381,7 +385,7 @@ impl Interpreter {
                         self.env_mut().insert("*HOME".to_string(), home_val);
                     }
                 }
-                self.stack.push(val);
+                self.stack.push(Self::itemize_value(val));
                 Some(Ok(()))
             }
             _ => None, // Not a Hash — fall through to slow path

--- a/t/hash-key-single-itemize.t
+++ b/t/hash-key-single-itemize.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 5;
+
+sub l () { 1, 2 }
+
+# A single hash-key assignment names one scalar slot, so its rvalue is itemized
+# (a following list context sees one element), like a scalar-variable assignment.
+
+{
+    my %a;
+    my @z = (%a<x> = l, l);
+    is @z.elems, 1, '%h<x> = l, l used as an rvalue is one itemized element';
+    ok !@z[1].defined, 'no second element leaked into the list';
+    is %a<x>.elems, 2, 'the whole list (1,2) is stored at the key';
+}
+
+{
+    my %a;
+    my @z = (%a{'x'} = l, l);
+    is @z.elems, 1, q{%h{'x'} = l, l is one itemized element};
+}
+
+# A scalar value passes through unchanged.
+{
+    my %a;
+    %a<x> = 5;
+    is %a<x>, 5, 'a scalar hash-value assignment stores correctly';
+}


### PR DESCRIPTION
## Summary
`%h<x> = l, l` / `%h{'x'} = l, l` names one scalar slot, so its assignment rvalue is itemized, like a scalar-variable / single-index array assignment:

```raku
my %a; my @z = (%a<x> = l, l);   # @z.elems == 1  (one itemized element)
```

The common case is handled by `try_fast_hash_element_assign` (which short-circuits before the general index-assign handler); that fast path rejects every complex/slice index, so its result is always a single-element assignment and now itemizes the pushed rvalue. The stored value is unchanged.

## Tests
- `S03-operators/assign.t` tests 218, 224 now pass.
- Adds `t/hash-key-single-itemize.t` (5 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)