### PR TITLE
fix(react): share captured-outer lexicals across sibling whenever callbacks (S17 syntax.t test 57)

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -180,10 +180,18 @@
 - [ ] roast/S17-supply/supplier-preserving.t
 - [ ] roast/S17-supply/syntax-nonblocking-await.t
 - [ ] roast/S17-supply/syntax.t
-  - 88/90 deterministic (3 debug runs: same 2 fails, no hang/flaky tail in
-    debug — #3018 cleared the busy-spin). Remaining 2: test 75 and test 90.
+  - 88/90 deterministic. Remaining 2: test 75 and test 90.
     Whitelist still gated on release/CI stability of the 2000-react interval-done
     stress (lines 543-550).
+  - test 57 (multiple channels in whenever blocks, cross-whenever `$order`
+    accumulation): **FIXED** — a `whenever` callback shares the enclosing react
+    block's lexicals, but each closure call persisted its captured-outer free vars
+    as per-instance state (keyed by the callback's Sub id) and restored that stale
+    snapshot on re-entry, clobbering a sibling whenever's update to the same
+    lexical (`$order` -> `13` instead of `123`). `call_react_callback` now clears
+    the callback's per-instance captured state before each invocation, so it reads
+    the shared lexical from the live caller env (which every sibling writes back
+    to). Tests `t/react-whenever-shared-lexical.t`.
   - test 75 (`Supply.on-demand(..., closing => {})`): the `closing` callback is
     now captured (dispatch_supply_on_demand stores it as `on_close_callbacks`)
     and fired by the **react event-loop** on-demand branch — synchronous body

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -250,6 +250,16 @@ impl Interpreter {
         self.closure_captured_state.insert((id, name), value);
     }
 
+    /// Drop all per-closure-instance captured-variable state for a closure id.
+    /// Used by the react drive loop so a `whenever`/`LAST`/`QUIT` callback re-reads
+    /// its captured-outer lexicals from the live caller env (which every sibling
+    /// callback in the same react block writes back to) instead of restoring a
+    /// stale per-instance snapshot that would clobber a sibling's update.
+    pub(crate) fn clear_closure_captured_state_for(&mut self, id: u64) {
+        self.closure_captured_state
+            .retain(|(entry_id, _), _| *entry_id != id);
+    }
+
     pub(crate) fn current_once_scope(&self) -> Option<u64> {
         // When inside a closure call, __mutsu_callable_id identifies the
         // specific closure clone.  This must take priority over the

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -43,6 +43,17 @@ impl Interpreter {
         cb: &Value,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // A `whenever`/`LAST`/`QUIT` callback shares the enclosing react block's
+        // lexicals. Each closure call persists its captured-outer free vars as
+        // per-instance state (keyed by the callback's Sub id) and restores that
+        // snapshot on re-entry. For a react callback that is wrong: on re-entry it
+        // would restore a *stale* snapshot of a shared lexical (e.g. `my $order`
+        // that a sibling `whenever` just updated), clobbering the sibling's write.
+        // Drop this callback's per-instance state so it reads the shared lexical
+        // from the live caller env — which every sibling writes back to.
+        if let Value::Sub(data) = cb {
+            self.clear_closure_captured_state_for(data.id);
+        }
         let topic = args.first().cloned();
         self.vm_call_map_block(cb, args, topic, false)
     }

--- a/t/react-whenever-shared-lexical.t
+++ b/t/react-whenever-shared-lexical.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 3;
+
+# Multiple `whenever` blocks in one `react` share the enclosing block's
+# lexicals. A captured-outer variable mutated by more than one whenever must
+# accumulate every sibling's write; the per-closure-instance captured state
+# must not restore a stale snapshot that clobbers a sibling's update.
+
+# Two channels feeding two whenevers that both append to `$order`, coordinated
+# via Promises so the writes strictly interleave c1 -> c2 -> c1.
+{
+    my $c1 = Channel.new;
+    my $c2 = Channel.new;
+    my $p1 = Promise.new;
+    my $p2 = Promise.new;
+    start { $c1.send(1); await $p2; $c1.send(3); $c1.close(); }
+    start { await $p1; $c2.send(2); $c2.close(); }
+    my $order = '';
+    react {
+        whenever $c1 { $order ~= $_; $p1.keep(True) unless $p1; }
+        whenever $c2 { $order ~= $_; $p2.keep(True); }
+    }
+    is $order, '123', 'sibling whenevers accumulate writes to a shared lexical';
+}
+
+# A single whenever re-entered many times still accumulates into a shared
+# captured-outer counter (per-instance state must reflect the live value).
+{
+    my $c = Channel.new;
+    start { $c.send($_) for 1..5; $c.close(); }
+    my $sum = 0;
+    react {
+        whenever $c { $sum += $_; }
+    }
+    is $sum, 15, 're-entered whenever accumulates into a captured-outer counter';
+}
+
+# A captured-outer array shared across two whenevers collects from both.
+{
+    my $c1 = Channel.new;
+    my $c2 = Channel.new;
+    start { $c1.send('a'); $c2.send('b'); $c1.close(); $c2.close(); }
+    my @seen;
+    react {
+        whenever $c1 { @seen.push: $_; }
+        whenever $c2 { @seen.push: $_; }
+    }
+    is @seen.sort.join, 'ab', 'both whenevers push into a shared captured-outer array';
+}


### PR DESCRIPTION
## Summary

Fixes a captured-outer variable clobbering bug across sibling `whenever` callbacks in a `react` block. This clears `roast/S17-supply/syntax.t` **test 57** (multiple channels in whenever blocks).

Multiple `whenever` blocks in one `react` share the enclosing block's lexicals. But each closure call persists its captured-outer free vars as **per-instance state** (keyed by the callback's `Sub` id) and restores that snapshot on re-entry. For a react callback that is wrong: when two whenevers both mutate the same captured-outer lexical, a whenever re-entered *after* a sibling updated the shared value restores its own **stale** per-instance snapshot, clobbering the sibling's write.

```raku
my $order = '';
react {
    whenever $c1 { $order ~= $_; ... }   # gets 1, then 3
    whenever $c2 { $order ~= $_; ... }   # gets 2
}
# expected '123', mutsu produced '13' (c2's '2' clobbered)
```

## Fix

`call_react_callback` drops the callback's per-instance captured state before each invocation (new `clear_closure_captured_state_for`), so it reads the shared lexical from the **live caller env** — which every sibling writes back to. State accumulation still works because the live env carries the running value.

## Verification

- `syntax.t` test 57 now passes; failures reduced 3 → 2.
- **Full S17 promise+supply suite (69 files, 1039 tests) passes** — no react regression.
- `make test` green; `cargo clippy -D warnings` clean.
- Adds `t/react-whenever-shared-lexical.t` (sibling accumulation, re-entry counter, shared array), passing 3× locally.

## Not included (documented in TODO_roast/S17.md)

`syntax.t` is **not yet whitelisted**. Two deeper react event-loop issues remain, to be tackled separately (approved approach (A) — land this verified fix, isolate the risk):
- **test 75**: nested `whenever $on-demand-supply`'s `closing` callback (tap-path + async start-block close).
- **test 90**: a cross-thread `whenever start { emit }` feeding a sibling Supplier consumer vs `done` ordering in the drive loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)