### PR TITLE
fix(assign): computed slice assignment rvalue is the assigned values

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2213,7 +2213,21 @@ impl Interpreter {
                     let v = vals.get(i).cloned().unwrap_or(Value::Nil);
                     self.assign_into_computed_target(&resolved, k, v)?;
                 }
-                self.stack.push(val);
+                // A slice assignment's rvalue is the list of values actually
+                // assigned (`foo()[0,1] = 10, 20, 30` yields `(10, 20)`), truncated
+                // to the number of slots -- not the whole RHS. A 1-element slice
+                // yields one itemized element.
+                let assigned: Vec<Value> = keys
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| vals.get(i).cloned().unwrap_or(Value::Nil))
+                    .collect();
+                let result = if idx_is_single_element {
+                    Self::itemize_value(assigned.into_iter().next().unwrap_or(Value::Nil))
+                } else {
+                    Value::array(assigned)
+                };
+                self.stack.push(result);
                 return Ok(());
             }
         }

--- a/t/computed-slice-result.t
+++ b/t/computed-slice-result.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 4;
+
+sub l () { 1, 2 }
+
+# A slice assignment's rvalue is the list of values actually assigned (truncated
+# to the number of slots), not the whole RHS.
+
+{
+    my @a;
+    sub arr() { @a }
+    my @z = (arr()[0, 1] = 10, 20, 30);
+    is @z.elems, 2, 'computed 2-slot slice rvalue keeps only the 2 assigned values';
+    is ~@z, '10 20', '... which are the first two RHS values';
+}
+
+# A 1-element computed slice yields one itemized element.
+{
+    my @a;
+    sub arr2() { @a }
+    my $b = 0;
+    my @z = (arr2()[$b,] = flat l, l);
+    is @z.elems, 1, 'a 1-slot computed slice yields one element';
+    ok !@z[1].defined, '... with nothing after it';
+}


### PR DESCRIPTION
## Summary
A slice assignment's rvalue is the list of values actually assigned, truncated to the number of slots -- not the whole RHS:

```raku
my @a; sub arr(){ @a }; my @z = (arr()[0,1] = 10, 20, 30);   # @z == (10, 20)
```

A 1-element slice yields one itemized element. The generic index-assign handler's computed-slice path now returns the truncated assigned values.

## Tests
- `S03-operators/assign.t` tests 247, 248 now pass (assign.t down to 11 failing).
- Adds `t/computed-slice-result.t` (4 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)