### PR TITLE
fix(assign): list-destructure rvalue is the LHS targets, not the RHS

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -170,8 +170,18 @@ impl Compiler {
                     _ => {}
                 }
             }
-            // Leave the RHS list on the stack as the result
-            self.code.emit(OpCode::GetGlobal(tmp_idx));
+            // The rvalue of a list assignment is the LHS list (the targets that
+            // were assigned), read back after the assignment -- NOT the whole RHS.
+            // `(($a, $b) = 1, 2, 3)` in list context is `($a, $b)` = `(1, 2)`, so
+            // its `.elems` is the number of targets. A `*` (Whatever) target is a
+            // discard slot and contributes nothing; `@`/`%` slurpy targets
+            // contribute their (flattened) contents.
+            let result_targets: Vec<Expr> = targets
+                .iter()
+                .filter(|t| !matches!(t, Expr::Whatever))
+                .cloned()
+                .collect();
+            self.compile_expr(&Expr::ArrayLiteral(result_targets));
             return;
         } else if name == "__mutsu_assign_method_lvalue"
             && args.len() >= 4

--- a/t/list-destructure-result.t
+++ b/t/list-destructure-result.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 7;
+
+# The rvalue of a list assignment is the LHS list (the assigned targets), not the
+# whole RHS: `(($a, $b) = 1, 2, 3)` in list context is `($a, $b)`.
+
+{
+    my ($a, $b);
+    my @z = (($a, $b) = 1, 2, 3);
+    is @z.elems, 2, 'list-assignment rvalue has one element per scalar target';
+    is ~@z, '1 2', '... the assigned values';
+    is $a, 1, 'binding is correct ($a)';
+    is $b, 2, 'binding is correct ($b)';
+}
+
+# More than two scalar targets.
+{
+    my ($p, $q, $r);
+    my @z = (($p, $q, $r) = 10, 20, 30);
+    is @z.elems, 3, 'three scalar targets => three-element rvalue';
+    is ~@z, '10 20 30', '... the assigned values';
+}
+
+# The binding still slurps a trailing `@` target correctly.
+{
+    my ($a, @b);
+    ($a, @b) = 1, 2, 3, 4;
+    is ~@b, '2 3 4', 'a trailing slurpy @ target still binds the tail';
+}


### PR DESCRIPTION
## Summary
The rvalue of a list assignment is the LHS list (the targets that were assigned), read back after the assignment — not the whole RHS:

```raku
my ($a, $b); my @z = (($a, $b) = 1, 2, 3);   # @z == (1, 2), .elems == 2
```

Its `.elems` is the number of targets. A `*` (Whatever) discard slot contributes nothing. The `($a, $b, ...) = expr` destructure compilation now returns an array of the target reads rather than leaving the raw RHS on the stack.

## Tests
- `S03-operators/assign.t` test 209 now passes.
- Adds `t/list-destructure-result.t` (7 assertions).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)