### PR TITLE
docs(roast): update assign.t status (10 failures)

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -147,27 +147,23 @@
     on a hash/array reads the LHS as that container (254, 255); `R op=` reverse
     meta-op assignment targets its RIGHT operand (127, 128); package/global
     scalar assignment itemizes its rvalue (197).
-  - ~286/302 pass (16 failing). Fixed since: `$(EXPR) = a, b` item-assignment
-    comma semantics + single-index array element result itemization (198, 199,
-    211); string-range hash subscript is a slice over enumerated keys (231-236);
-    a 1-element array slice itemizes its rvalue (213, 214).
-  - Remaining failures (16) are deep list-vs-item container semantics or niche
-    features, each needing a different subsystem:
-    - Hash single-key result itemization (`%a<x>`/`%a{'x'}`): 218, 224. These
-      exit through a *different* index-assign opcode than the array path (the
-      array single-index/1-slice itemization does not reach them); locating the
-      hash exit is unfinished.
-    - Runtime-index element/callable assignment (`@a[@b[$c,]]`, `foo()[$b]`):
-      242, 245, 248.
-    - Parenthesized list-target binding (`($a) = l, l, l` slurps the whole list;
-      `($a,$b) = flat l, l`): 200, 202, 209.
+  - ~292/302 pass (10 failing). Fixed since: `$(EXPR) = a, b` item-assignment
+    comma + single-index array element itemization (198, 199, 211); string-range
+    hash subscript slice (231-236); 1-element array slice itemization (213, 214);
+    package-qualified / `our`-alias store sync + `$` symbolic-deref whole-list
+    store (194-197); computed single-index element itemization (242, 245); single
+    hash-key result itemization (218, 224); computed slice rvalue = assigned
+    values (247, 248); list-destructure rvalue = LHS targets (209).
+  - Remaining failures (10), each a different subsystem:
+    - Parenthesized single-scalar / `*` list-target: `($a) = l, l, l` should make
+      `$a` slurp the whole list (elems 3); `($a, *) = ...` should give `$a` one
+      item. Both parse as item-assignment (`($a = 1), 2, 3`) through a recursive
+      parenthesized-assignment path -- NOT the (already-correct) expression-level
+      `assign_not_expr_mode` Grouped-scalar handling. 200, 202.
     - Slice-in-list chained list-assignment lvalues (`(@c[1,2], @c[3], @d) = ...`):
       47-50.
-    - Package-qualified scalar STORE not reaching a bare `our` var: even direct
-      `package Foo { our $b; $Foo::b = 42 }` leaves `$b` undefined (the store
-      writes env `Foo::b` but bare `$b` reads a stale local slot). Blocks 194.
-    - `~>=`/`~<=` buffer bit-shift assignment (NYI in raku itself): 182, 183.
     - `,=` container-identity (`@a =:= @a[0]<>`): 288.
+    - `~>=`/`~<=` buffer bit-shift assignment (NYI in raku itself): 182, 183.
     - `%=` on a `:U` target under `use fatal` (rakudo-specific "No zero-arg
       meaning for infix:<%>"): 301.
 - [ ] roast/S03-operators/autoincrement-range.t


### PR DESCRIPTION
Records assign.t progress (46 -> 10 across 18 PRs) and categorizes the 10 remaining failures. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)