### PR TITLE
docs(roast): record S17-supply/syntax.t test 90 root-cause blocker

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -208,7 +208,37 @@
     only collects on_close from INNER whenevers (`whenever_on_close`), not the
     tapped supply itself. Deeper (tap path + async start + close-marker).
   - test 90 (two `whenever`s each `last` + a `whenever start` feeding both via a
-    Supplier::Preserving, cross-whenever LAST ordering) — the hard case; deferred.
+    Supplier::Preserving, cross-whenever LAST ordering) — **the hard case; deferred**
+    after a full root-cause investigation (2026-07-01). It needs THREE independent
+    react/supply features, not one:
+    1. **Reliable thread-fed supplier delivery.** The react drive loop delivers a
+       `whenever $supplier.Supply` by *polling* `supplier_snapshot(supplier_id)` on
+       the main thread. When the emitter runs on another thread and calls `done`
+       right after `emit`, the `done` handler synchronously calls `supplier_reset`
+       (native_supplier_methods.rs ~348), which CLEARS `state.emitted` — before the
+       poll reads it. So values emitted just before `done` are lost. Proven by
+       instrumentation: `[T3] emit sid=1 newlen=2` immediately followed by
+       `[T2] snapshot sid=1 EMPTY` on the SAME global map. Works only when the emit
+       is on the *main* thread (e.g. `whenever Supply.interval { emit }`), because
+       the loop delivers synchronously before any reset. A push-based **channel tap**
+       fix (register_supplier_channel_tap so emit `ch.send`s at emit time, surviving
+       the reset; drive loop drains `sub.channel`) fixes the plain case
+       (plaintimer/serdone/extfeed go `[]`→`[1,2]`) BUT regresses non-plain supplies:
+       routing ALL supplier_id react subs through channel taps hangs
+       `S17-promise/nonblocking-await.t` (async-socket `whenever $client.Supply(:bin)`
+       — its close path doesn't close the channel tap). Must be scoped strictly to
+       in-process Supplier-backed supplies + close-path rework.
+    2. **grep/map forwarding on a *live* supply (UNIMPLEMENTED).**
+       `whenever $supplier.Supply.grep(*>0)` never forwards filtered values —
+       `native_supply_dispatch` has no `grep`/`map` arm, so a live grep'd supply is
+       not wired to forward from its source supplier. `greptimer.p6` (grep, no
+       done-race) gives `[]` vs raku `[1,2]`.
+    3. **drain-on-done.** `whenever start { emit; done }` — the start-whenever's
+       `done` breaks the react loop before the sibling supplier sub drains its
+       buffered values (`plainwhen.p6`). Needs a final-drain pass over channel/
+       supplier subs before ending on `done`.
+    test 57 (multiple-channel cross-whenever `$order` accumulation) was the tractable
+    slice and is FIXED (#4018). 75 and 90 are multi-feature react/supply work.
   - `last`/`next` inside a `whenever` in a `react` (tests 72, 84-87): the react
     loop now maps the body's control signals via `run_react_consumer` (`done`
     ends react, `next` skips the value, `last` stops just that whenever + fires


### PR DESCRIPTION
## Summary

Documents the full root-cause analysis of `roast/S17-supply/syntax.t` **test 90** in `TODO_roast/S17.md`, so the next attempt starts from the confirmed causes rather than re-deriving them.

**Note on the assigned task:** `roast/S17-promise/allof.t` (the nominal §4 target) is already whitelisted and passes 13/13 — no fix was needed. The useful deliverable from this investigation is the test-90 blocker documentation.

## test 90 findings

A full investigation (with instrumentation) showed test 90 needs **three independent, substantial react/supply features**, not one:

1. **Reliable thread-fed supplier delivery.** The react drive loop delivers `whenever $supplier.Supply` by *polling* `supplier_snapshot` on the main thread. When the emitter runs on another thread and calls `done` right after `emit`, the `done` handler's `supplier_reset` **clears the emitted buffer before the poll reads it** — proven by `[T3] emit sid=1 newlen=2` immediately followed by `[T2] snapshot sid=1 EMPTY` on the same global map. A push-based channel-tap fix works for plain in-process Suppliers (`[]`→`[1,2]`) but **regresses async-socket supplies** (hangs `S17-promise/nonblocking-await.t`), so it needs strict scoping + close-path rework.
2. **grep/map forwarding on a live supply is unimplemented** — `native_supply_dispatch` has no `grep`/`map` arm, so `whenever $supplier.Supply.grep(*>0)` forwards nothing.
3. **drain-on-done** — a `whenever start { emit; done }` ends the react before the sibling supplier sub drains its buffered values.

`test 57` (the tractable slice) was already fixed in #4018.

## Scope

Docs-only (`TODO_roast/S17.md`). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)