### PR TITLE
fix(assign): finish S03 assign.t — slice-in-list width, (($a)) slurp, ,= list precedence, ~>/~<, %= on :U

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -118,7 +118,7 @@
 - [ ] roast/S03-operators/arith.t
   - 0/? pass. Panic: `attempt to multiply with overflow` in `i64::pow`. Needs BigInt or checked arithmetic.
 - [x] roast/S03-operators/assign-is-not-binding.t
-- [ ] roast/S03-operators/assign.t
+- [x] roast/S03-operators/assign.t
   - ~256/302 pass; the file now runs to completion (no more mid-run abort).
     Fixed: `(($c = 3) = 4)` (assignment yields its container as an lvalue),
     `[op]=` reduce-meta compound assignment in expression context
@@ -154,18 +154,22 @@
     store (194-197); computed single-index element itemization (242, 245); single
     hash-key result itemization (218, 224); computed slice rvalue = assigned
     values (247, 248); list-destructure rvalue = LHS targets (209).
-  - Remaining failures (10), each a different subsystem:
-    - Parenthesized single-scalar / `*` list-target: `($a) = l, l, l` should make
-      `$a` slurp the whole list (elems 3); `($a, *) = ...` should give `$a` one
-      item. Both parse as item-assignment (`($a = 1), 2, 3`) through a recursive
-      parenthesized-assignment path -- NOT the (already-correct) expression-level
-      `assign_not_expr_mode` Grouped-scalar handling. 200, 202.
+  - 302/302 pass (whitelisted). Fixed the final 5-subsystem residue:
+    - Parenthesized single-scalar list-target `($a) = l, l, l`: a parenthesized
+      lone scalar directly followed by `=` is a LIST assignment and slurps the
+      whole RHS as an itemized list (elems 3). `paren_expr` now wraps a bare
+      `($var)` in `Grouped` when an item-assignment `=` follows, so the `=`
+      handler keeps the comma-absorbing list-assignment RHS. 200.
     - Slice-in-list chained list-assignment lvalues (`(@c[1,2], @c[3], @d) = ...`):
-      47-50.
-    - `,=` container-identity (`@a =:= @a[0]<>`): 288.
-    - `~>=`/`~<=` buffer bit-shift assignment (NYI in raku itself): 182, 183.
-    - `%=` on a `:U` target under `use fatal` (rakudo-specific "No zero-arg
-      meaning for infix:<%>"): 301.
+      the list-destructure loop tracks a running RHS offset and consumes a
+      positional slice's WIDTH of items (assigned as a slice), not one item. 47-50.
+    - `,=` list precedence / self-reference (`@a =:= @a[0]<>`): `,=` desugars to
+      `@a = @a, RHS` as an `ArrayLiteral([lhs, rhs])` (the whole RHS is one
+      element, `@a[0]` is the array itself) instead of a flattening `,`-Binary. 288.
+    - `~>`/`~<` string bit-shift operators implemented (byte-string treated as a
+      big-endian bit string): 182, 183.
+    - `%=` on a `:U` target: `infix:<%>` has no zero-arg identity, so a compound
+      `%=` on an undefined LHS throws. 301.
 - [ ] roast/S03-operators/autoincrement-range.t
   - 5/104 pass.
 - [ ] roast/S03-operators/autoincrement.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -201,6 +201,7 @@ roast/S03-operators/also.t
 roast/S03-operators/andthen.t
 roast/S03-operators/arith.t
 roast/S03-operators/assign-is-not-binding.t
+roast/S03-operators/assign.t
 roast/S03-operators/autoincrement-range.t
 roast/S03-operators/autoincrement.t
 roast/S03-operators/autovivification.t

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -88,12 +88,16 @@ impl Compiler {
             self.code.emit(OpCode::Dup);
             self.code.emit(OpCode::SetGlobal(tmp_idx));
             // For each target variable, index into the RHS and assign.
-            // The FIRST `@`/`%` target is greedy: it slurps all remaining RHS
-            // values via `.skip(i)`, and every target after it receives an empty
-            // container / Nil (`(*, @b, $c) = 1..4` → `@b` is `[2,3,4]`, `$c` is
-            // undefined). `seen_slurpy` tracks that tail consumption.
+            // `offset` is the running count of RHS items already consumed. Each
+            // scalar target consumes one item; a positional *slice* target
+            // (`@a[1,2]`) consumes as many items as its width, assigned as a
+            // slice. The FIRST `@`/`%` target is greedy: it slurps all remaining
+            // RHS values via `.skip(offset)`, and every target after it receives
+            // an empty container / Nil (`(*, @b, $c) = 1..4` → `@b` is `[2,3,4]`,
+            // `$c` is undefined). `seen_slurpy` tracks that tail consumption.
             let mut seen_slurpy = false;
-            for (i, target) in targets.iter().enumerate() {
+            let mut offset: usize = 0;
+            for target in targets.iter() {
                 match target {
                     Expr::Var(var_name) => {
                         if seen_slurpy {
@@ -101,7 +105,7 @@ impl Compiler {
                             self.code.emit(OpCode::LoadConst(nil_idx));
                         } else {
                             self.code.emit(OpCode::GetGlobal(tmp_idx));
-                            let idx = self.code.add_constant(Value::Int(i as i64));
+                            let idx = self.code.add_constant(Value::Int(offset as i64));
                             self.code.emit(OpCode::LoadConst(idx));
                             self.code.emit(OpCode::Index {
                                 is_positional: true,
@@ -109,15 +113,16 @@ impl Compiler {
                         }
                         let name_idx = self.code.add_constant(Value::str(var_name.clone()));
                         self.code.emit(OpCode::AssignExpr(name_idx));
+                        offset += 1;
                     }
                     Expr::ArrayVar(var_name) => {
                         let rhs_expr = if seen_slurpy {
                             Expr::ArrayLiteral(Vec::new())
-                        } else if i > 0 {
+                        } else if offset > 0 {
                             Expr::MethodCall {
                                 target: Box::new(Expr::Var(tmp_name.clone())),
                                 name: crate::symbol::Symbol::intern("skip"),
-                                args: vec![Expr::Literal(Value::Int(i as i64))],
+                                args: vec![Expr::Literal(Value::Int(offset as i64))],
                                 modifier: None,
                                 quoted: false,
                             }
@@ -133,11 +138,11 @@ impl Compiler {
                         // A hash target is greedy too: slurp the remaining pairs.
                         let rhs_expr = if seen_slurpy {
                             Expr::Hash(Vec::new())
-                        } else if i > 0 {
+                        } else if offset > 0 {
                             Expr::MethodCall {
                                 target: Box::new(Expr::Var(tmp_name.clone())),
                                 name: crate::symbol::Symbol::intern("skip"),
-                                args: vec![Expr::Literal(Value::Int(i as i64))],
+                                args: vec![Expr::Literal(Value::Int(offset as i64))],
                                 modifier: None,
                                 quoted: false,
                             }
@@ -154,10 +159,33 @@ impl Compiler {
                         index,
                         is_positional,
                     } => {
-                        let rhs_item = Expr::Index {
-                            target: Box::new(Expr::Var(tmp_name.clone())),
-                            index: Box::new(Expr::Literal(Value::Int(i as i64))),
-                            is_positional: true,
+                        // A positional slice (`@a[1,2]`) is a multi-item target:
+                        // it consumes `width` RHS items and receives them as a
+                        // slice. A single-index target consumes one item.
+                        let width = if *is_positional {
+                            match index.as_ref() {
+                                Expr::ArrayLiteral(items) => items.len().max(1),
+                                _ => 1,
+                            }
+                        } else {
+                            1
+                        };
+                        let rhs_item = if width > 1 {
+                            Expr::Index {
+                                target: Box::new(Expr::Var(tmp_name.clone())),
+                                index: Box::new(Expr::ArrayLiteral(
+                                    (offset..offset + width)
+                                        .map(|k| Expr::Literal(Value::Int(k as i64)))
+                                        .collect(),
+                                )),
+                                is_positional: true,
+                            }
+                        } else {
+                            Expr::Index {
+                                target: Box::new(Expr::Var(tmp_name.clone())),
+                                index: Box::new(Expr::Literal(Value::Int(offset as i64))),
+                                is_positional: true,
+                            }
                         };
                         self.compile_expr(&Expr::IndexAssign {
                             target: target.clone(),
@@ -166,8 +194,12 @@ impl Compiler {
                             is_positional: *is_positional,
                         });
                         self.code.emit(OpCode::Pop);
+                        offset += width;
                     }
-                    _ => {}
+                    _ => {
+                        // Whatever (`*`) discard slot consumes one item.
+                        offset += 1;
+                    }
                 }
             }
             // The rvalue of a list assignment is the LHS list (the targets that

--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -284,6 +284,25 @@ pub(crate) fn paren_expr(input: &str) -> PResult<'_, Expr> {
         } else {
             result
         };
+        // `($a) = ...` — a parenthesized single scalar directly followed by an
+        // item-assignment `=` is a LIST assignment: the lone target slurps the
+        // whole RHS as an itemized list (`($a) = 1, 2, 3` → `$a` is `$(1, 2, 3)`,
+        // `.elems` 3), unlike a bare `$a = 1, 2, 3` (item assignment, `$a` is 1).
+        // Wrap in `Grouped` so the `=` handler (logic.rs) keeps the
+        // comma-absorbing list-assignment RHS instead of the item-assignment one.
+        let result = if matches!(&result, Expr::Var(_)) {
+            let after = input.trim_start();
+            if after.starts_with('=')
+                && !after.starts_with("==")
+                && !after.starts_with("=>")
+            {
+                Expr::Grouped(Box::new(result))
+            } else {
+                result
+            }
+        } else {
+            result
+        };
         return Ok((input, result));
     }
     // Comma-separated list with sequence operator detection

--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -292,10 +292,7 @@ pub(crate) fn paren_expr(input: &str) -> PResult<'_, Expr> {
         // comma-absorbing list-assignment RHS instead of the item-assignment one.
         let result = if matches!(&result, Expr::Var(_)) {
             let after = input.trim_start();
-            if after.starts_with('=')
-                && !after.starts_with("==")
-                && !after.starts_with("=>")
-            {
+            if after.starts_with('=') && !after.starts_with("==") && !after.starts_with("=>") {
                 Expr::Grouped(Box::new(result))
             } else {
                 result

--- a/src/parser/stmt/assign/op.rs
+++ b/src/parser/stmt/assign/op.rs
@@ -166,6 +166,23 @@ fn autoviv_compound_lhs(lhs: Expr, op: CompoundAssignOp) -> Expr {
             then_expr: Box::new(lhs),
             else_expr: Box::new(Expr::Literal(Value::Int(1))),
         }
+    } else if matches!(op, CompoundAssignOp::Mod) {
+        // `$x op= $y` on an undefined `$x` seeds the container with the
+        // operator's zero-arg identity value. `infix:<%>` has no zero-arg
+        // meaning, so `$x %= $y` on an undefined `$x` throws.
+        Expr::Ternary {
+            cond: Box::new(Expr::Call {
+                name: Symbol::intern("defined"),
+                args: vec![lhs.clone()],
+            }),
+            then_expr: Box::new(lhs),
+            else_expr: Box::new(Expr::Call {
+                name: Symbol::intern("die"),
+                args: vec![Expr::Literal(Value::str(
+                    "No zero-arg meaning for infix:<%>".to_string(),
+                ))],
+            }),
+        }
     } else {
         lhs
     }
@@ -241,6 +258,13 @@ pub(crate) fn compound_assigned_value_expr(lhs: Expr, op: CompoundAssignOp, rhs:
             then_expr: Box::new(then_branch),
             else_expr: Box::new(else_branch),
         }
+    } else if matches!(op, CompoundAssignOp::Comma) {
+        // `@a ,= X` has list precedence and desugars to `@a = @a, X`. The whole
+        // RHS becomes a SINGLE element, so `@a` becomes `[@a_old, X]` — a
+        // self-reference in `[0]`, NOT a flattening append. An `ArrayLiteral`
+        // (rather than a `,`-`Binary`, which flattens both operands into a flat
+        // list) matches the direct `@a = @a, (...)` structure.
+        Expr::ArrayLiteral(vec![lhs, rhs])
     } else {
         Expr::Binary {
             left: Box::new(autoviv_compound_lhs(lhs, op)),

--- a/src/vm/vm_bitwise_ops.rs
+++ b/src/vm/vm_bitwise_ops.rs
@@ -235,19 +235,85 @@ impl Interpreter {
             .push(Value::str(String::from_utf8_lossy(&result).into_owned()));
     }
 
-    /// String bitwise shift left (~<): not yet implemented in Raku either.
-    /// TODO: Implement when Raku spec is finalized for this operator.
+    /// String bitwise shift left (~<): treat the left string's bytes as a
+    /// big-endian bit string and shift it left by N bits (`"a" ~< 8` → `"a\0"`,
+    /// i.e. the value times 2**N, appending low-order zero bits).
     pub(super) fn exec_str_shift_left_op(&mut self) {
-        let _right = self.stack.pop().unwrap();
-        let _left = self.stack.pop().unwrap();
-        self.stack.push(Value::Nil);
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let n = shift_count(&right);
+        let l = left.to_string_value();
+        let out = str_shift_left_bytes(l.as_bytes(), n);
+        self.stack
+            .push(Value::str(String::from_utf8_lossy(&out).into_owned()));
     }
 
-    /// String bitwise shift right (~>): not yet implemented in Raku either.
-    /// TODO: Implement when Raku spec is finalized for this operator.
+    /// String bitwise shift right (~>): treat the left string's bytes as a
+    /// big-endian bit string and shift it right by N bits (`"aa" ~> 8` → `"a"`,
+    /// dropping the low-order N bits).
     pub(super) fn exec_str_shift_right_op(&mut self) {
-        let _right = self.stack.pop().unwrap();
-        let _left = self.stack.pop().unwrap();
-        self.stack.push(Value::Nil);
+        let right = self.stack.pop().unwrap();
+        let left = self.stack.pop().unwrap();
+        let n = shift_count(&right);
+        let l = left.to_string_value();
+        let out = str_shift_right_bytes(l.as_bytes(), n);
+        self.stack
+            .push(Value::str(String::from_utf8_lossy(&out).into_owned()));
     }
+}
+
+/// Coerce a shift-count operand to a non-negative bit count.
+fn shift_count(v: &Value) -> usize {
+    match v {
+        Value::Int(i) => (*i).max(0) as usize,
+        Value::Num(f) => (*f as i64).max(0) as usize,
+        other => other.to_string_value().parse::<i64>().unwrap_or(0).max(0) as usize,
+    }
+}
+
+/// Read bit `k` (counted from the least-significant bit) of a big-endian byte
+/// string, where `bytes[bytes.len()-1]` is the least-significant byte.
+fn get_bit_be(bytes: &[u8], k: usize) -> bool {
+    let byte_from_end = k / 8;
+    if byte_from_end >= bytes.len() {
+        return false;
+    }
+    let idx = bytes.len() - 1 - byte_from_end;
+    (bytes[idx] >> (k % 8)) & 1 == 1
+}
+
+fn set_bit_be(bytes: &mut [u8], k: usize) {
+    let byte_from_end = k / 8;
+    let idx = bytes.len() - 1 - byte_from_end;
+    bytes[idx] |= 1 << (k % 8);
+}
+
+fn str_shift_left_bytes(input: &[u8], n: usize) -> Vec<u8> {
+    let in_bits = input.len() * 8;
+    if in_bits == 0 {
+        return Vec::new();
+    }
+    let out_len = (in_bits + n).div_ceil(8).max(1);
+    let mut out = vec![0u8; out_len];
+    for k in 0..in_bits {
+        if get_bit_be(input, k) {
+            set_bit_be(&mut out, k + n);
+        }
+    }
+    out
+}
+
+fn str_shift_right_bytes(input: &[u8], n: usize) -> Vec<u8> {
+    let in_bits = input.len() * 8;
+    if n >= in_bits {
+        return Vec::new();
+    }
+    let out_len = (in_bits - n).div_ceil(8).max(1);
+    let mut out = vec![0u8; out_len];
+    for k in n..in_bits {
+        if get_bit_be(input, k) {
+            set_bit_be(&mut out, k - n);
+        }
+    }
+    out
 }

--- a/t/comma-assign-container.t
+++ b/t/comma-assign-container.t
@@ -1,8 +1,12 @@
 use Test;
 
-plan 6;
+plan 8;
 
-# `,=` on a hash merges the right-hand hash into the left (like `%h = %h, %other`).
+# `,=` desugars to `$x = $x, RHS` and has list precedence (the whole RHS is the
+# second operand). See roast S03-operators/assign.t (RT #76414).
+
+# On a hash, `%h ,= %other` is `%h = %h, %other`, which flattens both hashes to
+# pairs and re-hashes them: a merge.
 {
     my %part1 = a => 'b';
     my %part2 = d => 'c';
@@ -13,19 +17,23 @@ plan 6;
     ok %part1  eqv %both, ',= works for hashes (hash modified)';
 }
 
-# `,=` on an array appends (like push).
+# On an array, `@a ,= 3, 4` is `@a = @a, (3, 4)`: the array becomes a two-element
+# list whose first element is the (now self-referential) array itself and whose
+# second element is the itemized RHS list.
 {
     my @a = 1, 2;
     @a ,= 3, 4;
-    is @a.join('|'), '1|2|3|4', ',= on an array appends';
+    is @a.elems, 2, ',= on an array does NOT flatten-append';
+    ok @a[0] =:= @a, ',= inserts the array itself as element 0 (self-reference)';
+    is @a[1].join('|'), '3|4', ',= inserts the whole RHS list as element 1';
 }
 
 # statement vs expression context both work.
 {
     my @a = 1, 2;
     my @r = (@a ,= 3);
-    is @a.join('|'), '1|2|3', ',= expression context (array modified)';
-    is @r.join('|'), '1|2|3', ',= expression context (return value)';
+    is @a.elems, 2, ',= expression context (array modified)';
+    is @r.elems, 2, ',= expression context (return value)';
 }
 
 {


### PR DESCRIPTION
## Summary

Fixes the final 5 failing subsystems in `roast/S03-operators/assign.t` and adds it to the whitelist (302/302 pass).

Failing tests fixed: 47-50, 182-183, 200, 288, 301.

## Changes

- **Slice-in-list list-destructure** (`(@c[1,2], @c[3], @d) = ...`; tests 47-50): the list-target loop now tracks a running RHS offset and consumes a positional slice's *width* of items (assigned as a slice) instead of one item per target.
- **Parenthesized single-scalar list-target** (`($a) = l, l, l`; test 200): a bare `($var)` directly followed by an item-assignment `=` is a **list** assignment where the lone scalar slurps the whole RHS as an itemized list (`.elems` 3). `paren_expr` wraps such a `($var)` in `Grouped` so the `=` handler keeps the comma-absorbing list-assignment RHS.
- **`,=` list precedence / self-reference** (`@a ,= 3, 4` → `@a = @a, (3, 4)`; test 288): desugar to `ArrayLiteral([lhs, rhs])` (the whole RHS is one element and `@a[0]` is the array itself) instead of a flattening `,`-Binary.
- **`~>` / `~<` string bit-shift operators** (tests 182-183): implement them — the byte string is treated as a big-endian bit string (`"a" ~< 8` → `"a\0"`, `"aa" ~> 8` → `"a"`). They were previously stubbed to `Nil`.
- **`%=` on an undefined (`:U`) LHS** (test 301): `infix:<%>` has no zero-arg identity, so a compound `%=` on an undefined LHS throws (matching `autoviv_compound_lhs`'s existing identity handling for `*=`/`**=`).

`t/comma-assign-container.t` is updated to the spec-correct `,=` semantics (roast is authoritative): `,=` does not flatten-append.

## Testing

- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S03-operators/assign.t` → 302/302 PASS
- `make test` → PASS
- `make roast` → PASS (0 failures, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)