### PR TITLE
fix(thread): route Thread .join to the real thread-join (S17 lock.t condvar)

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -11,6 +11,23 @@
 - [ ] roast/S17-lowlevel/cas-loop.t
 - [ ] roast/S17-lowlevel/cas.t
 - [ ] roast/S17-lowlevel/lock.t
+  - Lock subtest 6/24 → 9/24: `.join` on a Thread now routes to the real
+    thread-join (`dispatch_thread_finish`) instead of the native list-`join`
+    fast path, which stringified the Thread to "Thread(...)" and returned WITHOUT
+    waiting — so captured-outer writes (`$now1`/`@log`) never propagated and the
+    condition-variable tests saw stale values. The condvar wait/signal itself was
+    always correct; only the join was a no-op. FIXED subtests 7-9 (condition
+    variable across threads). Remaining blockers:
+    - subtests 10-24 (`Correct result and no crash in lock/condvar use`): use
+      `$*SCHEDULER.cue({ ... })` with a per-iteration `$out := @out[$i]` binding.
+      The cue callbacks DO write through (values appear) but the per-iteration
+      `$i`/`$out` capture is wrong (`[20 10 20]` vs raku `[0 10 20]`) — a
+      loop-var fresh-binding issue in scheduler-cue callbacks, separate from the
+      Thread.start propagation fix.
+    - "ok 5 - Even from another thread" prints at top level out of order: a
+      `pass` on a `Thread.start` worker *inside a subtest* isn't captured by the
+      subtest (TAP output ordering for Thread.start-in-subtest; cf. #4010 which
+      fixed the start{}/Promise case gated on subtest_depth==0).
 - [x] roast/S17-lowlevel/semaphore.t — **2/2, whitelisted (2026-07-01).**
     The test runs bare `$s.acquire; $r += $i; $s.release` and `@r[$i]++` across
     4000 Promise.start threads. Previously the accumulator raced (last-writer

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -334,6 +334,12 @@ pub(super) fn dispatch(
                     .collect::<Vec<_>>()
                     .join("");
                 Some(Some(Ok(Value::str(joined))))
+            } else if matches!(target, Value::Instance { class_name, .. } if class_name == "Thread")
+            {
+                // `.join` on a Thread is the thread-join primitive (block until the
+                // thread finishes), NOT list-join stringification. Fall through to
+                // the runtime so native_thread routes it to dispatch_thread_finish.
+                Some(None)
             } else {
                 Some(Some(Ok(Value::str(target.to_string_value()))))
             }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -252,7 +252,24 @@ impl Interpreter {
             "grab" => self.dispatch_grab_method(target, args),
             "grabpairs" => self.dispatch_grabpairs_method(target, args),
             "skip" => Some(self.dispatch_skip_method(target, args)),
-            "join" if args.len() <= 1 => self.dispatch_join_method(target, args),
+            "join" if args.len() <= 1 => {
+                // `.join` on a Thread blocks until the thread completes and syncs
+                // its shared captured variables back to the parent (Raku
+                // `Thread.join`). Route it to the real thread join before the
+                // generic list-`join` stringifies the Thread instance to
+                // "Thread(...)" without waiting.
+                if let Value::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } = &target
+                    && class_name == "Thread"
+                {
+                    let attrs = attributes.as_map().clone();
+                    return Some(self.dispatch_thread_finish(&attrs));
+                }
+                self.dispatch_join_method(target, args)
+            }
             "grep" => {
                 // In Raku, .grep returns a Seq. However, when called on an Array,
                 // the result carries rw view bindings that must be preserved (Array kind).

--- a/t/thread-start-join.t
+++ b/t/thread-start-join.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 6;
+
+# `.join` on a Thread must block until the thread completes and sync its
+# captured-variable mutations back to the parent — same as `.finish`. It must
+# NOT be treated as list-`join` (which would stringify the Thread instance to
+# "Thread(...)" and return without waiting).
+
+# Scalar captured-outer write propagates through .join.
+{
+    my $x = 0;
+    Thread.start({ $x = 42 }).join;
+    is $x, 42, 'captured scalar write from a Thread propagates through .join';
+}
+
+# Array captured-outer mutation propagates through .join.
+{
+    my @a;
+    Thread.start({ @a.push(7) }).join;
+    is-deeply @a, [7], 'captured array push from a Thread propagates through .join';
+}
+
+# .finish behaves the same as .join (both are the thread-join primitive).
+{
+    my $y = 0;
+    Thread.start({ $y = 99 }).finish;
+    is $y, 99, 'captured scalar write propagates through .finish too';
+}
+
+# .join actually waits: a slow thread's effect is visible right after .join.
+{
+    my $done = False;
+    my $t = Thread.start({ sleep 0.2; $done = True });
+    $t.join;
+    ok $done, '.join blocks until the (slow) thread finishes';
+}
+
+# Lock condition variable: wait/signal across two threads, coordinated by a lock.
+{
+    my $l = Lock.new;
+    my $c = $l.condition;
+    my @log;
+    my $t1 = Thread.start({
+        $l.protect({
+            @log.push('ale');
+            $c.wait();
+            @log.push('stout');
+        });
+    });
+    until $l.protect({ @log.elems }) == 1 { }
+    my $t2 = Thread.start({
+        $l.protect({
+            @log.push('porter');
+            $c.signal();
+        });
+    });
+    $t1.join();
+    $t2.join();
+    is @log.join(','), 'ale,porter,stout', 'Lock condition variable wait/signal works across threads';
+}
+
+# List .join is unaffected by the Thread special-case.
+{
+    is <a b c>.join('-'), 'a-b-c', 'list .join still works';
+}


### PR DESCRIPTION
## Summary

`.join` on a `Thread` instance was intercepted by the native list-`join` fast path (`builtins/methods_0arg/dispatch_core_str.rs`), which for a non-list receiver just returns `Str(target.to_string_value())` — it **stringified the Thread to `"Thread(...)"` and returned without waiting** for the thread.

`.finish` (the actual join) worked, but the spec — and `roast/S17-lowlevel/lock.t` — uses `.join`.

Because `.join` didn't block, the parent read captured-outer variables *before* the thread had run:

```raku
my $x = 0;
Thread.start({ $x = 42 }).join;
say $x;   # was 0, now 42
```

lock.t's condition-variable tests failed for the same reason — `@log`/`$now1` were read stale. The condvar `wait`/`signal` and the shared-cell writeback were always correct; only the join was a no-op.

## Fix

- The native `join` fast path falls through to the runtime for a `Thread` instance.
- The runtime `.join` dispatch routes a `Thread` instance to `dispatch_thread_finish` (joins the OS thread + syncs shared captured variables back).
- List `.join` is unchanged.

## Impact

- Fixes `lock.t` condition-variable subtests (Lock subtest **6/24 → 9/24**).
- General fix: `Thread.start(...).join` now propagates captured mutations (a real bug beyond lock.t).
- Remaining `lock.t` failures — scheduler-cue per-iteration `$out := @out[$i]` binding (subtests 10-24) and TAP output ordering for a `Thread` inside a subtest — are **separate** and documented in `TODO_roast/S17.md`.

## Verification

- Adds `t/thread-start-join.t` (scalar/array propagation via `.join` and `.finish`, blocking wait, Lock condvar across threads, list-`.join` unchanged) — passes 3× locally.
- `make test` green; `cargo clippy -D warnings` clean; list `.join` verified intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)