### PR TITLE
fix(concurrency): fix root cause of S17-promise/then.t's CI-only flake

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -103,6 +103,35 @@
     `.result`. Fix: drain the shared worker-thread output right after `.result`
     unblocks (blocking on a promise is a synchronization point), so callback
     output interleaves in Rakudo's order.
+  - **2026-07-01 follow-up: fixed a CI-only flake in "simple keep"/"simple
+    break" (root cause, not a re-whitelist)**. Root cause: every
+    `.then`/`.andthen`/`.orelse` call on a not-yet-resolved `Promise` used to
+    spawn its own dedicated OS thread that blocked on `Condvar::wait`, woken
+    by the resolver's `notify_all`. Two *sibling* registrations on the same
+    promise (an independent `.then` alongside the head of an `.andthen`
+    chain — exactly this test's "simple keep"/"simple break" shape) therefore
+    raced each other's OS wake-up latency with no ordering guarantee: rare
+    locally, reproducible ~1-in-12 under the CPU contention of CI's parallel
+    roast run (confirmed by running the file 60-80x concurrently locally).
+    Fixed in `SharedPromise` (`value/mod.rs`, `value/value_async.rs`):
+    registrations on a `Planned` promise are now queued (`PromiseState.
+    waiters`) instead of each spawning a thread, and whichever `keep`/
+    `break_with`/`try_keep`/`try_break` call resolves the promise drains and
+    runs every queued waiter **in registration order** on one dedicated
+    thread (`SharedPromise::on_resolve`/`dispatch_waiters`). This makes
+    sibling callback ordering deterministic — the independent `.then`,
+    registered first in source order, is now guaranteed to finish before the
+    `.andthen` chain even starts, matching how `await`-ing the chain's tail
+    is used in the test to assert the independent branch already ran.
+    `promise_chain_method` (`methods_promise.rs`) now calls `on_resolve`
+    instead of manually spawning a thread for the not-yet-resolved case (the
+    already-resolved synchronous fast path, which runs the callback inline
+    via `self` rather than a cloned interpreter, is unchanged). Verified:
+    80/80 concurrent runs of this file pass (release build); full
+    `S17-promise`/`S17-supply`/`S17-lowlevel`/`S17-scheduler`/`S17-channel`/
+    `S07-hyperrace` sweep shows no new failures (the same 4 pre-existing,
+    non-whitelisted files fail identically with and without this change).
+    Regression test: `t/promise-then-sibling-ordering.t`.
 - [ ] roast/S17-scheduler/at.t
 - [x] roast/S17-scheduler/basic.t — **34/34, whitelisted (2026-06-29).** Was
     aborting at test 2 because `$*SCHEDULER.loads` was unimplemented (threw

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -88,11 +88,20 @@ impl Interpreter {
             }
         } else {
             let mut thread_interp = self.clone_for_thread();
-            crate::runtime::builtins_system::spawn_user_thread(move || {
-                let (result, output, stderr) = orig.wait();
-                let status = orig.status();
+            let orig_for_waiter = orig.clone();
+            // Queue this callback on `orig` rather than spawning our own
+            // thread that blocks on `orig.wait()`: whichever `keep`/
+            // `break_with` call resolves `orig` runs every queued waiter in
+            // registration order on one dedicated thread. That ordering
+            // guarantee is what fixes S17-promise/then.t's intermittent CI
+            // failure — a `.then` registered on `orig` alongside an
+            // `.andthen`/`.orelse` chain (also rooted at `orig`) used to each
+            // spawn an independent OS thread racing the same
+            // `Condvar::notify_all` wake-up, so which one actually ran first
+            // depended on OS scheduling and could reorder under load.
+            orig.on_resolve(Box::new(move |status, result, output, stderr| {
                 if should_run(&status) {
-                    let promise_val = Value::Promise(orig.clone());
+                    let promise_val = Value::Promise(orig_for_waiter);
                     let cb_result = thread_interp.call_sub_value(block, vec![promise_val], true);
                     let out = std::mem::take(&mut thread_interp.output_sink_mut().output);
                     let err = std::mem::take(&mut thread_interp.output_sink_mut().stderr_output);
@@ -107,7 +116,7 @@ impl Interpreter {
                 } else {
                     new_promise.break_with(result, output, stderr);
                 }
-            });
+            }));
         }
         ret
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1360,6 +1360,12 @@ pub(crate) struct LazyThunkData {
 
 // --- SharedPromise: thread-safe promise state ---
 
+/// A callback registered via `SharedPromise::on_resolve` while the promise
+/// was still `Planned`. Invoked with (status, result, output, stderr) once
+/// the promise resolves. Boxed so `.then`/`.andthen`/`.orelse` chains can
+/// queue heterogeneous closures.
+pub(crate) type PromiseWaiter = Box<dyn FnOnce(String, Value, String, String) + Send>;
+
 struct PromiseState {
     status: String, // "Planned", "Kept", "Broken"
     result: Value,
@@ -1370,6 +1376,18 @@ struct PromiseState {
     /// thread. Used e.g. to hand off newly-opened IO handle state that
     /// lives inside the per-thread Interpreter.
     thread_payload: Option<Box<dyn std::any::Any + Send>>,
+    /// Callbacks queued by `.then`/`.andthen`/`.orelse` while `Planned`,
+    /// drained and run **in registration order** by whichever `keep`/
+    /// `break_with` call resolves this promise. See `on_resolve` for why:
+    /// without a shared, ordered queue, each combinator call on an
+    /// unresolved promise used to spawn its own OS thread that raced the
+    /// others to wake from the same `Condvar::notify_all`, so sibling
+    /// callbacks (e.g. an independent `.then` alongside an `.andthen`
+    /// chain, both registered on the same promise) had no ordering
+    /// guarantee and could run in either order depending on OS scheduling
+    /// — observable as an intermittent CI-only failure under load
+    /// (S17-promise/then.t "simple keep"/"simple break").
+    waiters: Vec<PromiseWaiter>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -32,6 +32,7 @@ impl SharedPromise {
                     stderr_output: String::new(),
                     class_name,
                     thread_payload: None,
+                    waiters: Vec::new(),
                 }),
                 Condvar::new(),
             )),
@@ -49,6 +50,7 @@ impl SharedPromise {
                     stderr_output: String::new(),
                     class_name: Symbol::intern("Promise"),
                     thread_payload: None,
+                    waiters: Vec::new(),
                 }),
                 Condvar::new(),
             )),
@@ -83,10 +85,13 @@ impl SharedPromise {
         let (lock, cvar) = &*self.inner;
         let mut state = lock.lock().unwrap();
         state.status = "Kept".to_string();
-        state.result = result;
-        state.output = output;
-        state.stderr_output = stderr;
+        state.result = result.clone();
+        state.output = output.clone();
+        state.stderr_output = stderr.clone();
+        let waiters = std::mem::take(&mut state.waiters);
         cvar.notify_all();
+        drop(state);
+        Self::dispatch_waiters(waiters, "Kept".to_string(), result, output, stderr);
     }
 
     /// Try to keep; returns Err(current_status) if already kept/broken.
@@ -97,8 +102,17 @@ impl SharedPromise {
             return Err(state.status.clone());
         }
         state.status = "Kept".to_string();
-        state.result = result;
+        state.result = result.clone();
+        let waiters = std::mem::take(&mut state.waiters);
         cvar.notify_all();
+        drop(state);
+        Self::dispatch_waiters(
+            waiters,
+            "Kept".to_string(),
+            result,
+            String::new(),
+            String::new(),
+        );
         Ok(())
     }
 
@@ -106,10 +120,13 @@ impl SharedPromise {
         let (lock, cvar) = &*self.inner;
         let mut state = lock.lock().unwrap();
         state.status = "Broken".to_string();
-        state.result = error;
-        state.output = output;
-        state.stderr_output = stderr;
+        state.result = error.clone();
+        state.output = output.clone();
+        state.stderr_output = stderr.clone();
+        let waiters = std::mem::take(&mut state.waiters);
         cvar.notify_all();
+        drop(state);
+        Self::dispatch_waiters(waiters, "Broken".to_string(), error, output, stderr);
     }
 
     /// Try to break; returns Err(current_status) if already kept/broken.
@@ -120,9 +137,72 @@ impl SharedPromise {
             return Err(state.status.clone());
         }
         state.status = "Broken".to_string();
-        state.result = error;
+        state.result = error.clone();
+        let waiters = std::mem::take(&mut state.waiters);
         cvar.notify_all();
+        drop(state);
+        Self::dispatch_waiters(
+            waiters,
+            "Broken".to_string(),
+            error,
+            String::new(),
+            String::new(),
+        );
         Ok(())
+    }
+
+    /// Register a callback to run once this promise resolves. If it is
+    /// already resolved, the callback runs synchronously on the caller's
+    /// thread (matching the existing `.then`/`.andthen`/`.orelse` fast path
+    /// for an already-kept/broken promise) and this returns `true`.
+    /// Otherwise the callback is queued and this returns `false`: some
+    /// future `keep`/`try_keep`/`break_with`/`try_break` call will run every
+    /// queued waiter, **in registration order**, on a single dedicated
+    /// thread. Registering into this shared, ordered queue (rather than
+    /// having each caller spawn its own thread that blocks on `wait()`)
+    /// is what makes sibling callbacks on the same promise (e.g. an
+    /// independent `.then` alongside an `.andthen` chain) deterministically
+    /// ordered instead of racing each other's OS thread wake-up latency.
+    pub(crate) fn on_resolve(&self, waiter: PromiseWaiter) -> bool {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        if state.status == "Planned" {
+            state.waiters.push(waiter);
+            false
+        } else {
+            let status = state.status.clone();
+            let result = state.result.clone();
+            let output = state.output.clone();
+            let stderr = state.stderr_output.clone();
+            drop(state);
+            waiter(status, result, output, stderr);
+            true
+        }
+    }
+
+    /// Run every queued waiter, in order, on a single dedicated thread (so
+    /// resolving a promise never blocks the resolver on arbitrary user
+    /// callback code). No-op when there is nothing queued.
+    fn dispatch_waiters(
+        waiters: Vec<PromiseWaiter>,
+        status: String,
+        result: Value,
+        output: String,
+        stderr: String,
+    ) {
+        if waiters.is_empty() {
+            return;
+        }
+        crate::runtime::builtins_system::spawn_user_thread(move || {
+            for waiter in waiters {
+                waiter(
+                    status.clone(),
+                    result.clone(),
+                    output.clone(),
+                    stderr.clone(),
+                );
+            }
+        });
     }
 
     /// Check if promise is resolved (Kept or Broken).

--- a/t/promise-then-sibling-ordering.t
+++ b/t/promise-then-sibling-ordering.t
@@ -1,0 +1,62 @@
+use Test;
+
+# Regression test for the root cause behind roast S17-promise/then.t's
+# intermittent CI-only failure ("simple keep"/"simple break"): `.then`/
+# `.andthen`/`.orelse` registered on a not-yet-resolved Promise used to each
+# spawn their own OS thread that blocked on the promise, then raced every
+# other such thread to wake from the same `Condvar::notify_all` once
+# `.keep`/`.break` fired. Two independent callbacks on the same promise (an
+# `.then` alongside the head of an `.andthen` chain, as in the roast test)
+# therefore had no ordering guarantee and could run in either order
+# depending on OS scheduling -- rare locally, much more likely under CI's
+# parallel test load.
+#
+# Fix: registrations on an unresolved promise are queued and drained by
+# whichever call resolves it, all on one dedicated thread, in registration
+# order. This test locks that ordering guarantee in directly (rather than
+# trying to statistically reproduce the race), and loops many iterations so
+# a regression back to the old "each registration is its own racing thread"
+# behavior would show up as sporadic failures rather than a single lucky
+# pass.
+
+plan 1;
+
+my $iterations = 200;
+my $all-ok = True;
+
+for ^$iterations {
+    my $lock = Lock.new;
+    my @order;
+    my $p1 = Promise.new;
+
+    # Two siblings registered directly on the still-Planned $p1, in this
+    # source order: an independent `.then`, and the head of a 3-hop
+    # `.andthen` chain. `$p2` is the *tail* of that chain (mirrors roast's
+    # "independent-then" alongside the "andthen1 -> andthen2 -> ... ->
+    # final-then" chain). The parenthesized-block form is required here:
+    # chaining `.andthen: {...}.andthen: {...}` (colon-call form) is a
+    # separate, pre-existing Raku parsing ambiguity (colon-call binds the
+    # block loosely, so the second `.andthen` ends up called on the first
+    # block's *return value* instead of the promise it returns) -- the roast
+    # test itself uses the parenthesized form for exactly this reason.
+    $p1.then: { $lock.protect: { @order.push: 'independent' } };
+    my $p2 = $p1
+        .andthen({ $lock.protect: { @order.push: 'chain-1' }; 1 })
+        .andthen({ $lock.protect: { @order.push: 'chain-2' }; 1 })
+        .then({ $lock.protect: { @order.push: 'chain-3' } });
+
+    $p1.keep(1);
+    await $p2;
+
+    # `chain-3` resolving guarantees `chain-1` (queued second on $p1) has
+    # already run, which -- because both siblings drain from $p1's *single*
+    # queue in registration order -- guarantees `independent` (queued first)
+    # ran before it, not merely "eventually, whenever its own thread got
+    # scheduled" (the pre-fix behavior).
+    unless @order.elems == 4 && @order[0] eq 'independent' {
+        $all-ok = False;
+        last;
+    }
+}
+
+ok $all-ok, "sibling .then callbacks on the same promise run in registration order ({$iterations}x)";


### PR DESCRIPTION
## Summary
- Root-causes and fixes the CI-only intermittent failure in `roast/S17-promise/then.t` ("simple keep"/"simple break") that was previously worked around with a CI retrigger in #4005.
- Root cause: every `.then`/`.andthen`/`.orelse` call on a not-yet-resolved `Promise` spawned its own dedicated OS thread that blocked on the promise's `Condvar`, woken by the resolver's `notify_all`. Sibling registrations on the same promise (an independent `.then` alongside the head of an `.andthen` chain — exactly this test's shape) raced each other's OS wake-up latency with no ordering guarantee: rare locally, reproducible ~1-in-12 under the CPU contention of CI's parallel roast run (confirmed by running the file 60-80x concurrently, both debug and release builds).
- Fix: registrations on a `Planned` promise are now queued in the promise's own state instead of each spawning a thread. Whichever `keep`/`break_with`/`try_keep`/`try_break` call resolves the promise drains and runs every queued waiter, **in registration order**, on a single dedicated thread (`SharedPromise::on_resolve`/`dispatch_waiters` in `value/value_async.rs`). This makes sibling callback ordering deterministic instead of racy. `promise_chain_method` (`methods_promise.rs`) now registers via `on_resolve` for the not-yet-resolved case; the already-resolved synchronous fast path (which runs the callback inline via `self`, preserving captured-variable writeback) is unchanged.

## Test plan
- [x] 80/80 concurrent runs of `roast/S17-promise/then.t` pass (release build, both plain and under artificial parallel-process load)
- [x] Full `S17-promise`/`S17-supply`/`S17-lowlevel`/`S17-scheduler`/`S17-channel`/`S07-hyperrace` sweep shows no new failures — confirmed the same 4 pre-existing, non-whitelisted files fail identically with and without this change (`S17-promise/start.t`, `S17-supply/syntax.t`, `S17-lowlevel/lock.t`, `S07-hyperrace/basics.t`)
- [x] `make test` (release build + full `t/` suite) green
- [x] New regression test `t/promise-then-sibling-ordering.t`, verified to fail reliably (3/3) without the fix and pass with it
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK