### PR TITLE
fix(closures): per-iteration freeze for read-only := loop-local captures

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -19,11 +19,24 @@
     always correct; only the join was a no-op. FIXED subtests 7-9 (condition
     variable across threads). Remaining blockers:
     - subtests 10-24 (`Correct result and no crash in lock/condvar use`): use
-      `$*SCHEDULER.cue({ ... })` with a per-iteration `$out := @out[$i]` binding.
-      The cue callbacks DO write through (values appear) but the per-iteration
-      `$i`/`$out` capture is wrong (`[20 10 20]` vs raku `[0 10 20]`) — a
-      loop-var fresh-binding issue in scheduler-cue callbacks, separate from the
-      Thread.start propagation fix.
+      `$*SCHEDULER.cue({ ... })` with per-iteration `$in := @in[$i]` /
+      `$out := @out[$i]` bindings and a closure `{ $out = $in * 10 }`. Two layers:
+      (a) **read-only `:=` capture per-iteration freeze — FIXED** (a separate
+      general bug, not thread-specific): a closure that READS a `:=`-bound
+      loop-local froze the shared/re-pointed `ContainerRef` (nested, all resolving
+      to the loop's final element) instead of its own iteration's value, so plain
+      closures gave `[50 0 40 50 50]` vs raku `[10 20 30 40 50]`. Now
+      `freeze_readonly_owned_captures` value-snapshots a read-only owned-capture
+      `ContainerRef` into both the captured env and the upvalue slots. See
+      t/loop-bind-closure-capture.t.
+      (b) **REMAINING: thread + shared_vars by-name collision.** In a `cue`/`start`
+      thread, `clone_for_thread` seeds each captured lexical into `shared_vars` by
+      NAME, so same-named per-iteration loop vars (`$i`/`$out`) collapse into one
+      cell — the thread read/write routes to the collided cell instead of the
+      closure's per-iteration owned-capture / box-on-capture cell. Excluding
+      `ContainerRef` from the seeding alone is not enough ($i is a plain Int; the
+      owned-capture-vs-shared_vars read routing needs the thread to prefer the
+      closure's frozen capture). Deeper thread-capture work (§4.1/§4.2).
     - "ok 5 - Even from another thread" prints at top level out of order: a
       `pass` on a `Thread.start` worker *inside a subtest* isn't captured by the
       subtest (TAP output ordering for Thread.start-in-subtest; cf. #4010 which

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -84,7 +84,15 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
-            let upvalues = self.capture_upvalues(code, &compiled_code);
+            let mut upvalues = self.capture_upvalues(code, &compiled_code);
+            let mut captured_env = self.capture_closure_env(code, &compiled_code);
+            self.freeze_readonly_owned_captures(
+                code,
+                &compiled_code,
+                &owned_captures,
+                &mut captured_env,
+                &mut upvalues,
+            );
             let cc_source_line = compiled_code
                 .as_ref()
                 .and_then(|cc| cc.source_line)
@@ -100,7 +108,7 @@ impl Interpreter {
                 is_raw: false,
                 // Upvalue snapshot (single-store Slice E): capture only free vars,
                 // shadow-meta, and system names; see `capture_closure_env`.
-                env: self.capture_closure_env(code, &compiled_code),
+                env: captured_env,
                 assumed_positional: Vec::new(),
                 assumed_named: std::collections::HashMap::new(),
                 id: crate::value::next_instance_id(),
@@ -141,9 +149,16 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
-            let upvalues = self.capture_upvalues(code, &compiled_code);
+            let mut upvalues = self.capture_upvalues(code, &compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
             let mut env = self.capture_closure_env(code, &compiled_code);
+            self.freeze_readonly_owned_captures(
+                code,
+                &compiled_code,
+                &owned_captures,
+                &mut env,
+                &mut upvalues,
+            );
             if let Some(rt) = return_type {
                 env.insert("__mutsu_return_type".to_string(), Value::str(rt.clone()));
             }
@@ -194,6 +209,59 @@ impl Interpreter {
     /// closure's `owned_captures`: read at call time from its own frozen captured
     /// env so each loop iteration's closure sees its own value (Raku
     /// per-iteration binding), immune to the dual-store slot re-injection.
+    /// Value-freeze a *read-only* `:=`-bound loop capture in a just-built closure
+    /// env. `my $in := @a[$i]` makes `$in` a `ContainerRef` aliasing an element;
+    /// the loop re-points the same lexical each iteration, so a closure that only
+    /// READS `$in` (an `owned_capture` not in `captured_mutated_locals`) would
+    /// otherwise freeze the shared/re-pointed cell and every iteration's closure
+    /// resolves to the loop's final binding (roast S17-lowlevel/lock.t cue tests,
+    /// `$out = $in * 10`). A *mutated* capture is boxed into a genuinely-shared
+    /// cell by `box_captured_lexicals` and must keep its live `ContainerRef`, so
+    /// only the read-only ones are snapshotted to a plain value.
+    pub(super) fn freeze_readonly_owned_captures(
+        &self,
+        code: &CompiledCode,
+        cc: &Option<std::sync::Arc<CompiledCode>>,
+        owned_captures: &[Symbol],
+        env: &mut Env,
+        upvalues: &mut [Option<Value>],
+    ) {
+        let cc_upvalue_syms: &[Symbol] = cc
+            .as_ref()
+            .map(|c| c.upvalue_syms.as_slice())
+            .unwrap_or(&[]);
+        for sym in owned_captures {
+            // A *mutated* capture is boxed into a genuinely-shared cell by
+            // `box_captured_lexicals` and must keep its live `ContainerRef`.
+            if code.captured_mutated_locals.contains(sym) {
+                continue;
+            }
+            if !matches!(env.get_sym(*sym), Some(Value::ContainerRef(_))) {
+                continue;
+            }
+            // Deep-deref: the per-iteration binding can nest (`$in`'s own cell
+            // wrapping the element cell, plus prior iterations' wrappers).
+            let mut v = env.get_sym(*sym).cloned().unwrap();
+            let mut guard = 0;
+            while let Value::ContainerRef(_) = v {
+                v = v.into_deref();
+                guard += 1;
+                if guard > 64 {
+                    break;
+                }
+            }
+            env.insert_sym(*sym, v.clone());
+            // The read path resolves a free var from the upvalue snapshot (Slice
+            // E), captured from the creating frame's slot — which holds the same
+            // shared `ContainerRef`. Freeze that entry to the snapshot too.
+            if let Some(uv_idx) = cc_upvalue_syms.iter().position(|s| s == sym)
+                && let Some(slot) = upvalues.get_mut(uv_idx)
+            {
+                *slot = Some(v);
+            }
+        }
+    }
+
     pub(super) fn compute_owned_captures(
         &self,
         compiled_code: &Option<std::sync::Arc<CompiledCode>>,

--- a/t/loop-bind-closure-capture.t
+++ b/t/loop-bind-closure-capture.t
@@ -1,0 +1,69 @@
+use Test;
+
+plan 5;
+
+# A closure created in a loop body that captures a `:=`-bound loop-local
+# (`my $x := @a[$i]`) read-only must freeze that iteration's binding, so each
+# closure reads its own element — not the loop's final binding.
+
+# Read a single `:=`-bound capture.
+{
+    my @in = 1..5;
+    my @cb;
+    for ^5 -> $i {
+        my $in := @in[$i];
+        @cb.push: { $in * 10 };
+    }
+    my @r = @cb.map({ $_() });
+    is-deeply @r, [10, 20, 30, 40, 50], 'read-only := capture is per-iteration';
+}
+
+# Two `:=`-bound captures, one read + one write.
+{
+    my @in = 1..5;
+    my @out = 0 xx 5;
+    my @cb;
+    for ^5 -> $i {
+        my $in  := @in[$i];
+        my $out := @out[$i];
+        @cb.push: { $out = $in * 10 };
+    }
+    $_() for @cb;
+    is-deeply @out, [10, 20, 30, 40, 50], 'read+write := captures are per-iteration';
+}
+
+# C-style loop with `:=` bindings.
+{
+    my @in = 1..4;
+    my @out = 0 xx 4;
+    my @cb;
+    loop (my $i = 0; $i < @in; $i++) {
+        my $in  := @in[$i];
+        my $out := @out[$i];
+        @cb.push: { $out = $in + 100 };
+    }
+    $_() for @cb;
+    is-deeply @out, [101, 102, 103, 104], 'C-style loop := captures are per-iteration';
+}
+
+# A regular `my $x = ...` capture (not `:=`) still works.
+{
+    my @cb;
+    for ^3 -> $i {
+        my $x = $i * 2;
+        @cb.push: { $x };
+    }
+    my @r = @cb.map({ $_() });
+    is-deeply @r, [0, 2, 4], 'plain my capture is per-iteration';
+}
+
+# A mutated capture keeps a live shared cell (accumulator), not a value freeze.
+{
+    my $sum = 0;
+    my @cb;
+    for ^3 {
+        @cb.push: { $sum++ };
+    }
+    $_() for @cb;
+    is $sum, 3, 'mutated capture stays a live shared cell';
+}


### PR DESCRIPTION
## Summary

A closure created in a loop body that **reads** a `:=`-bound loop-local (`my $in := @a[$i]`) froze the wrong value. The `:=` binding makes `$in` a `ContainerRef` aliasing an element; the loop re-points the same lexical each iteration, so the closure's owned-capture snapshot kept the shared/re-pointed cell (nested, all resolving to the loop's **final** element).

```raku
my @in = 1..5; my @out = 0 xx 5; my @cb;
for ^5 -> $i { my $in := @in[$i]; my $out := @out[$i];
               @cb.push: { $out = $in * 10 } }
$_() for @cb;
# @out was [50 0 0 50 50], should be [10 20 30 40 50]
```

## Fix

`freeze_readonly_owned_captures` value-snapshots a **read-only** owned-capture `ContainerRef` (deep-deref) into both the captured env **and the upvalue slots** (the read path resolves free vars from the upvalue snapshot — freezing only the env was not enough). A **mutated** capture is boxed into a genuinely-shared cell by `box_captured_lexicals` and keeps its live `ContainerRef`, so only read-only owned captures are snapshotted (accumulators still work).

## Context

Found while working on `roast/S17-lowlevel/lock.t` (its `$*SCHEDULER.cue` tests read `$out = $in * 10`). This fixes the plain-closure layer; **lock.t additionally needs a deeper thread + `shared_vars` per-iteration fix** (same-named per-iteration loop vars collide by name in the thread's shared-var store), tracked in `TODO_roast/S17.md`. So this PR does not whitelist lock.t on its own — it fixes a real, general closure-capture correctness bug.

## Verification

- Adds `t/loop-bind-closure-capture.t` (read-only `:=` capture, read+write `:=`, C-style loop, plain `my`, mutated accumulator) — passes 3× locally.
- `make test` green; `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)