### PR TITLE
feat(metamodel): implement .^add_fallback for dynamic method fallbacks

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1311,6 +1311,7 @@ roast/integration/advent2012-day24.t
 roast/integration/advent2013-day02.t
 roast/integration/advent2013-day06.t
 roast/integration/advent2013-day07.t
+roast/integration/advent2013-day09.t
 roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -435,6 +435,29 @@ impl Interpreter {
                     class_name
                 )))
             }
+            "add_fallback" if args.len() >= 3 => {
+                // ^add_fallback($type, &condition, &calculator): register a
+                // dynamic method fallback. When a method is not found on a value
+                // of this class, `&condition($obj, $name)` is checked; the first
+                // that returns True has `&calculator($obj, $name)` produce the
+                // method body, which is then invoked with the invocant.
+                let class_name = match &args[0] {
+                    Value::Package(name) => name.resolve(),
+                    Value::Str(name) => name.to_string(),
+                    _ => {
+                        return Err(RuntimeError::new(
+                            "add_fallback target must be a type object",
+                        ));
+                    }
+                };
+                let condition = args[1].clone();
+                let calculator = args[2].clone();
+                self.method_fallbacks
+                    .entry(class_name)
+                    .or_default()
+                    .push((condition, calculator));
+                Ok(Value::Nil)
+            }
             "compose" if !args.is_empty() => {
                 // ^compose recomposes the class (e.g. after add_method)
                 // Rebuild the MRO for the class

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -323,6 +323,7 @@ impl Interpreter {
                 | "add_attribute"
                 | "add_method"
                 | "add_multi_method"
+                | "add_fallback"
                 | "compose"
                 | "methods"
                 | "attributes"

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1740,6 +1740,11 @@ impl Interpreter {
                     return self.proxy_subclass_array_mutate(&attrs_ref, &attr_name, method, &args);
                 }
 
+                // Metamodel method fallback (`.^add_fallback`): before failing,
+                // consult any dynamic fallbacks registered for this value's class.
+                if let Some(result) = self.try_method_fallback(&target, method, &args) {
+                    return result;
+                }
                 let type_name = match &target {
                     Value::Instance { class_name, .. } => class_name.resolve(),
                     Value::Package(name) => name.resolve(),
@@ -1748,6 +1753,66 @@ impl Interpreter {
                 Err(make_method_not_found_error(method, &type_name, false))
             }
         }
+    }
+
+    /// Consult metamodel method fallbacks registered via `.^add_fallback` for a
+    /// value whose method lookup just failed. Returns `Some(result)` when a
+    /// fallback's condition matched (and its calculated method body was invoked),
+    /// or `None` when no fallback applies (the caller then raises NotFound).
+    fn try_method_fallback(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if self.method_fallbacks.is_empty() {
+            return None;
+        }
+        let type_name = match target {
+            Value::Instance { class_name, .. } => class_name.resolve(),
+            Value::Package(name) => name.resolve(),
+            _ => crate::runtime::utils::value_type_name(target).to_string(),
+        };
+        // Consult the class itself first, then its ancestors (MRO).
+        let mut classes = vec![type_name.clone()];
+        classes.extend(
+            self.class_mro(&type_name)
+                .into_iter()
+                .filter(|c| c != &type_name),
+        );
+        let name_val = Value::str(method.to_string());
+        for cn in classes {
+            let Some(fallbacks) = self.method_fallbacks.get(&cn).cloned() else {
+                continue;
+            };
+            for (condition, calculator) in fallbacks {
+                let cond = match self.call_sub_value(
+                    condition,
+                    vec![target.clone(), name_val.clone()],
+                    false,
+                ) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                if !cond.truthy() {
+                    continue;
+                }
+                // The calculator returns the method body (a Callable) for this
+                // name; invoke it with the invocant (and any call args).
+                let method_code = match self.call_sub_value(
+                    calculator,
+                    vec![target.clone(), name_val.clone()],
+                    false,
+                ) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                let mut call_args = vec![target.clone()];
+                call_args.extend_from_slice(args);
+                return Some(self.call_sub_value(method_code, call_args, false));
+            }
+        }
+        None
     }
 
     /// Mutate an array attribute in a Proxy subclass's shared storage.

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -25,6 +25,7 @@ impl Interpreter {
                 | "add_attribute"
                 | "add_method"
                 | "add_multi_method"
+                | "add_fallback"
                 | "compose"
                 | "archetypes"
                 | "name"

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1342,6 +1342,13 @@ pub struct Interpreter {
     /// Method-level wrap chains: (class_name, method_name, candidate_index) ->
     /// stack of (handle_id, wrapper_sub).
     method_wrap_chains: HashMap<(String, String, usize), Vec<(u64, Value)>>,
+    /// Metamodel method fallbacks registered via `.^add_fallback(cond, calc)`:
+    /// class_name -> list of (condition, calculator) code pairs. When a method
+    /// is not found on a value of that class, each condition is called with
+    /// `(invocant, method_name)`; the first that returns True has its calculator
+    /// called with `(invocant, method_name)` to produce the method body, which is
+    /// then invoked with the invocant.
+    method_fallbacks: HashMap<String, Vec<(Value, Value)>>,
     /// Names suppressed by `anon class`. These bare words should error as undeclared.
     suppressed_names: HashSet<String>,
     /// Bare enum variant names poisoned by redeclaration from different enums.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2042,6 +2042,7 @@ impl Interpreter {
             wrap_handle_counter: 0,
             wrap_dispatch_stack: Vec::new(),
             method_wrap_chains: HashMap::new(),
+            method_fallbacks: HashMap::new(),
             suppressed_names: HashSet::new(),
             poisoned_enum_aliases: HashMap::new(),
             enum_scope_names: vec![Vec::new()],

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -273,6 +273,7 @@ impl Interpreter {
             wrap_handle_counter: self.wrap_handle_counter,
             wrap_dispatch_stack: Vec::new(),
             method_wrap_chains: self.method_wrap_chains.clone(),
+            method_fallbacks: self.method_fallbacks.clone(),
             suppressed_names: self.suppressed_names.clone(),
             poisoned_enum_aliases: self.poisoned_enum_aliases.clone(),
             enum_scope_names: self.enum_scope_names.clone(),

--- a/t/metamodel-add-fallback.t
+++ b/t/metamodel-add-fallback.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 4;
+
+# `.^add_fallback($cond, $calc)` registers a dynamic method fallback: when a
+# method is not found on a value of that class, $cond($obj, $name) is checked;
+# the first that returns True has $calc($obj, $name) produce the method body,
+# which is then invoked with the invocant.
+
+# Lisp-style car/cdr accessors on a chain of Pairs (S06/advent2013-day09).
+my $lisp-list = 1 => 2 => 3 => Nil;
+
+Pair.^add_fallback(
+    -> $, $name { $name ~~ /^c<[ad]>+r$/ },
+    -> $, $name {
+        -> $p {
+            $name ~~ /^c(<[ad]>*)(<[ad]>)r$/;
+            my $r = $1 eq 'a' ?? $p.key !! $p.value;
+            $0 ne '' ?? $r."c{$0}r"() !! $r;
+        }
+    }
+);
+
+is $lisp-list.car,   1, 'car returns the key';
+is $lisp-list.cadr,  2, 'cadr walks one cdr then car';
+is $lisp-list.caddr, 3, 'caddr walks two cdrs then car';
+
+# A name that does not match the condition still throws.
+dies-ok { $lisp-list.no-such-method }, 'unmatched method name still throws';


### PR DESCRIPTION
## Summary

Implements `ClassName.^add_fallback(&condition, &calculator)` — the metamodel primitive that registers a **dynamic method fallback** on a class. When a method is not found on a value of that class, each registered `&condition($obj, $name)` is evaluated; the first that returns `True` has its `&calculator($obj, $name)` produce the method body (a `Callable`), which is then invoked with the invocant (and any call args).

This greens `roast/integration/advent2013-day09.t` (21/21, whitelisted) — the Lisp `car`/`cdr` accessor example (`caddr`, `cadr`, ... synthesized on a chain of `Pair`s).

## Changes

- New `method_fallbacks: HashMap<String, Vec<(Value, Value)>>` on the interpreter (class name → `(condition, calculator)` pairs), threaded through the thread-clone.
- `add_fallback` handler in the ClassHOW dispatch, plus its two method-name allow-lists. Builtin types (e.g. `Pair`) get a fallback even without a user `ClassDef`.
- `dispatch_instance_and_fallback` consults a new `try_method_fallback` at its terminal not-found point (class + MRO). The fallback fires **only** when a method genuinely does not resolve *and* a fallback is registered, so normal dispatch is unaffected (guarded by `method_fallbacks.is_empty()`).

## Testing

- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/advent2013-day09.t` → 21/21 PASS
- New `t/metamodel-add-fallback.t` (4 assertions: car/cadr/caddr + unmatched-name-still-throws)
- `make test` → PASS
- `make roast` → in progress locally / verified by CI (change is guarded, no regressions expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)