### PR TITLE
test(roast): whitelist S17-lowlevel/cas-int.t (24/24)

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -6,7 +6,11 @@
   - 1/1 pass.
 - [ ] roast/S17-lowlevel/atomic-ops.t
 - [ ] roast/S17-lowlevel/atomic.t
-- [x] roast/S17-lowlevel/cas-int.t
+- [x] roast/S17-lowlevel/cas-int.t — **24/24, whitelisted (2026-07-01).**
+    `cas(@a[$i], $orig, $new)` on array elements captured per-iteration in
+    competing threads (tests 11-24) reached only ok 10 until the read-only `:=`
+    loop-capture per-iteration freeze (#4028) landed; now all 24 pass (~10s
+    release).
 - [ ] roast/S17-lowlevel/cas-loop-int.t
 - [ ] roast/S17-lowlevel/cas-loop.t
 - [ ] roast/S17-lowlevel/cas.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -858,6 +858,7 @@ roast/S17-channel/stress.t
 roast/S17-channel/subscription-drain-in-react.t
 roast/S17-lowlevel/atomic-ops.t
 roast/S17-lowlevel/atomic.t
+roast/S17-lowlevel/cas-int.t
 roast/S17-lowlevel/cas-loop-int.t
 roast/S17-lowlevel/cas-loop.t
 roast/S17-lowlevel/cas.t


### PR DESCRIPTION
## Summary

Whitelists `roast/S17-lowlevel/cas-int.t` (24/24).

`cas(@a[$i], $orig, $new)` on array/hash elements captured per-iteration in competing threads (subtests 11-24) reached only `ok 10` until the read-only `:=` loop-capture per-iteration freeze (#4028) landed — a closure reading a `:=`-bound loop-local froze the loop's *final* element instead of its own iteration's. With that fixed, all 24 subtests pass reliably.

## Verification

- 24/24 pass, 3/3 runs in release (~10s each, via `scripts/run-roast-test.sh` proper harness).
- Whitelist stays sorted.

Note: the manager's requested `atomicint.t` does not exist under `roast/S17-lowlevel/`; `cas-int.t` is the atomic-int (`atomicint`/`cas`) test that was newly unblocked by #4028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)