### PR TITLE
fix(container): capture element-mutated free containers in closures

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1907,6 +1907,15 @@ impl CompiledCode {
                 && !own.contains(name.as_str())
             {
                 free_container_writes.insert(Symbol::intern(name));
+                // A container mutated ONLY via element-assign (`%h{$k} = v`,
+                // `@a[$i] = v`) must ALSO be captured as a free variable, exactly
+                // like one mutated via a method (`%h.push`, already a name-read op).
+                // Otherwise the closure never carries the container, so a wrapper's
+                // hash element-assign is lost on return (its copy-on-write result is
+                // neither shared with the caller nor persisted for writeback). An
+                // array happened to survive via shared in-place mutation, but a hash
+                // element-assign copy-on-writes and needs the capture + writeback.
+                free.insert(Symbol::intern(name));
             }
             // Name-based writes: either a free-var write or an own-local mutation.
             if let Some(idx) = Self::op_name_write_const_idx(op)

--- a/t/wrap-closure-container-capture.t
+++ b/t/wrap-closure-container-capture.t
@@ -1,0 +1,64 @@
+use Test;
+
+plan 6;
+
+# A wrapper closure that mutates a captured outer container must have that
+# mutation visible to the caller after the wrapped call returns. Previously a
+# container mutated ONLY via element-assign (`%h{$k} = v`) was not captured as a
+# free variable, so a wrapper's hash element-assign was lost on return (its
+# copy-on-write result was neither shared with the caller nor persisted for the
+# closure writeback). Scalars, array element-assign (shared in place) and
+# `.push` already worked; this covers the hash element-assign gap.
+
+# Hash element-assign inside a wrapper.
+{
+    my %h;
+    sub f($x) { 42 }
+    &f.wrap(-> $x { %h{$x} = 99; callwith($x) });
+    f(5);
+    is-deeply %h, {5 => 99}, 'hash element-assign in a wrapper is visible to the caller';
+}
+
+# Accumulating across several calls.
+{
+    my %seen;
+    sub g($x) { $x * 2 }
+    &g.wrap(-> $x { %seen{$x} = True; callwith($x) });
+    g(1); g(2); g(3);
+    is-deeply %seen, {1 => True, 2 => True, 3 => True}, 'hash accumulates across wrapped calls';
+}
+
+# Array element-assign (already worked, keep as a guard).
+{
+    my @a = 0, 0, 0;
+    sub h($x) { 7 }
+    &h.wrap(-> $x { @a[$x] = 99; callwith($x) });
+    h(1);
+    is-deeply @a, [0, 99, 0], 'array element-assign in a wrapper is visible to the caller';
+}
+
+# Scalar assign (already worked, keep as a guard).
+{
+    my $s = 0;
+    sub k($x) { 1 }
+    &k.wrap(-> $x { $s = 99; callwith($x) });
+    k(5);
+    is $s, 99, 'scalar assign in a wrapper is visible to the caller';
+}
+
+# Hash .push inside a wrapper (already worked, keep as a guard).
+{
+    my %m;
+    sub p($x) { 1 }
+    &p.wrap(-> $x { %m.push($x => 1); callwith($x) });
+    p(5);
+    is-deeply %m, {5 => 1}, 'hash .push in a wrapper is visible to the caller';
+}
+
+# The wrapped call still returns the correct value.
+{
+    my %h;
+    sub q($x) { $x + 100 }
+    &q.wrap(-> $x { %h{$x} = 1; callwith($x) });
+    is q(5), 105, 'wrapped call returns the original result';
+}


### PR DESCRIPTION
## Summary

Part of the **§3.1 container-identity campaign** (TODO_roast/BLOCKERS.md): route container mutations through the closure capture/writeback surface instead of relying on incidental shared-`Arc` in-place mutation.

A closure that mutates an outer container **only via element-assign** (`%h{$k} = v` / `@a[$i] = v`) did not capture that container as a free variable. `compute_free_vars` recorded it in `free_container_writes` (used for cell boxing) but **not** in `free_var_syms` (the captured set). A container mutated via a method (`%h.push`) is a name-read op, so it *was* already captured.

Consequence: a wrapper closure's hash element-assign was lost on return. The copy-on-write result was neither shared with the caller (unlike an array element-assign, which mutates the shared `Arc` in place) nor persisted for the closure writeback (which only walks captured vars). So:

```raku
our %cache;
&f.wrap(-> $x { %cache{$x} = callwith($x) });
f(5);
say %cache;   # was {} — the wrapper's write was lost
```

## Fix

When `compute_free_vars` records a container element-write, also add the container to `free_var_syms` so it is captured (and thus written back) exactly like a `.push`-mutated container.

## Testing

- New `t/wrap-closure-container-capture.t` (6 assertions: hash element-assign, accumulation across calls, array/scalar/`.push` guards, return value).
- `make test` → PASS
- `make roast` → PASS (Files=1337, 0 failures — no regressions)
- `roast/S06-advanced/wrap.t` (90) and `dispatching.t` (8) still pass.

Note: this is the writeback half of the wrap fix. The remaining half — a recursive self-call inside a wrapped routine's body re-entering the wrapper chain (so `is Cached` memoization greens `roast/integration/advent2011-day04.t`) — is a separate, riskier change to wrap re-entrancy and is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)