### PR TITLE
fix(container): keep typed-array identity on reassign through a shared cell

### DIFF
--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1166,6 +1166,15 @@ impl Interpreter {
                 let arc = arc.clone();
                 if scalar {
                     val = Self::normalize_scalar_assignment_value(val);
+                } else {
+                    // Container identity (§3.1): re-apply the element-type +
+                    // `array[T]` metadata so a typed native array written through
+                    // its shared cell (`my @b := @a; @a = ...`) keeps its identity.
+                    // The metadata-tagging block further below is bypassed by this
+                    // early return, so it must be applied here.
+                    let name = name.clone();
+                    let old = arc.lock().unwrap().clone();
+                    val = self.array_container_writethrough_value(&name, val, &old)?;
                 }
                 arc.lock().unwrap().clone_from(&val);
                 self.flush_local_to_env(code, idx);

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -3,6 +3,70 @@ use std::sync::Arc;
 use unicode_normalization::UnicodeNormalization;
 
 impl Interpreter {
+    /// Container identity (§3.1): compute the value to write THROUGH a shared
+    /// `ContainerRef` cell for a whole-container reassignment of an `@`
+    /// variable (`@a = ...` when `@a`'s slot holds a shared cell — e.g. a
+    /// `:=`-bound alias `my @b := @a` or a loop-var alias `for @src -> @a`).
+    /// Coerces the raw RHS to an Array and re-applies the element-type coercion +
+    /// `array[T]` metadata so a typed native array keeps its identity
+    /// (`@a.WHAT === array[int]`) after the write-through. Non-`@` names return
+    /// `raw` unchanged.
+    pub(super) fn array_container_writethrough_value(
+        &mut self,
+        name: &str,
+        raw: Value,
+        old: &Value,
+    ) -> Result<Value, RuntimeError> {
+        if !name.starts_with('@') {
+            return Ok(raw);
+        }
+        let mut val = crate::runtime::coerce_to_array(raw);
+        val = self.coerce_typed_container_assignment(name, val, false)?;
+        // Prefer a declared constraint (`my int @a`); otherwise inherit the type
+        // identity of the container currently held by the shared cell. A bound
+        // typed array (`for @testing -> @a { @a = ... }`, `my @b := @a`) has no
+        // `var_type_constraint` on the alias name — its `array[T]` identity lives
+        // in the cell's embedded metadata, which a whole reassignment must keep.
+        let info = if let Some(value_type) = loan_env!(self, var_type_constraint(name)) {
+            Some(crate::runtime::ContainerTypeInfo {
+                declared_type: if crate::runtime::native_types::is_native_array_element_type(
+                    &value_type,
+                ) {
+                    Some(format!("array[{value_type}]"))
+                } else {
+                    None
+                },
+                value_type,
+                key_type: None,
+            })
+        } else {
+            self.container_type_metadata(old)
+        };
+        if let Some(info) = info {
+            // Coerce elements to the inherited element type (a bound
+            // `array[int]` must reject/convert non-int values just like a
+            // declared one).
+            if crate::runtime::native_types::is_native_array_element_type(&info.value_type)
+                && let Value::Array(items, kind) = &val
+            {
+                let coerced = self.coerce_typed_array_elements(
+                    name,
+                    &info.value_type,
+                    items,
+                    *kind,
+                    &|_| None,
+                    false,
+                )?;
+                val = Value::Array(
+                    Arc::new(crate::value::ArrayData::new(coerced)),
+                    *kind,
+                );
+            }
+            val = self.tag_container_metadata(val, info);
+        }
+        Ok(val)
+    }
+
     pub(super) fn normalize_scalar_assignment_value(val: Value) -> Value {
         let is_nilish = |v: &Value| match v {
             Value::Nil => true,

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -57,10 +57,7 @@ impl Interpreter {
                     &|_| None,
                     false,
                 )?;
-                val = Value::Array(
-                    Arc::new(crate::value::ArrayData::new(coerced)),
-                    *kind,
-                );
+                val = Value::Array(Arc::new(crate::value::ArrayData::new(coerced)), *kind);
             }
             val = self.tag_container_metadata(val, info);
         }

--- a/t/typed-array-bound-cell-writethrough.t
+++ b/t/typed-array-bound-cell-writethrough.t
@@ -1,0 +1,34 @@
+use Test;
+
+# Container identity (§3.1): a typed array reassigned as a whole THROUGH a shared
+# `ContainerRef` cell (a `:=` bind alias) must keep its `array[T]` identity. The
+# alias name carries no declared `var_type_constraint`, so the write-through path
+# has to inherit the element type from the cell's current value; before the fix
+# `@a = ...` through the bound cell downgraded `array[int]` to a plain `Array`.
+
+plan 6;
+
+{
+    my int @a = 1, 2, 3;
+    my @b := @a;
+    is @a.WHAT.gist, '(array[int])', 'typed array starts as array[int]';
+    @a = 4, 5, 6;
+    is @a.WHAT.gist, '(array[int])', 'array[int] survives whole reassign via bound cell';
+    is @b.WHAT.gist, '(array[int])', 'bound alias also reports array[int]';
+    is @b[1], 5, 'bound alias sees the reassigned contents';
+}
+
+# The element type still guards writes through the bound cell.
+{
+    my int @a = 1, 2, 3;
+    my @b := @a;
+    dies-ok { @a = 'not an int' }, 'element type check still applies via bound cell';
+}
+
+# Untyped bound array is unaffected (stays a plain Array).
+{
+    my @a = 1, 2, 3;
+    my @b := @a;
+    @a = 'x', 'y';
+    is @b, ('x', 'y'), 'untyped bound array reassigns normally';
+}


### PR DESCRIPTION
## Summary

Container identity (§3.1, BLOCKERS.md). A typed native array reassigned as a whole **through a shared `ContainerRef` cell** lost its `array[T]` identity:

```raku
my int @a = 1, 2, 3;
my @b := @a;
@a = 4, 5, 6;
say @a.WHAT;   # was (Array) — should be (array[int])
```

The slow-path `SetLocal` `ContainerRef` write-through wrote the raw element-coerced value straight into the cell and returned early, **bypassing** the metadata-tagging block that runs for a normal (non-aliased) typed-array assignment. The alias name (`@a` bound via `:=`, or a `for @src -> @a` loop var) carries no declared `var_type_constraint`, so the type identity has to be inherited from the cell's current value.

## Fix

New `array_container_writethrough_value` re-applies the element-type coercion and `array[T]` metadata before the write-through:
- prefers a declared constraint (`my int @a`),
- otherwise inherits the embedded `ContainerTypeInfo` from the cell's old value.

The element type still guards writes — a non-int assignment through the bound cell still dies.

## Testing

- New pin test `t/typed-array-bound-cell-writethrough.t` (6 subtests).
- `make test` green (13781 tests).
- Spot-checked `S03-binding/arrays.t`, `S09-typed-arrays/arrays.t`, `S09-typed-arrays/native-shape1-int.t`, `S03-binding/scalars.t` — all PASS.

## Scope note

This is a narrow, regression-free slice of the container-identity campaign. The broader "arrays kept live in list literals" work (the `S32-array/splice.t` self-splice canary) was explored but deferred: making a bare `@a` in a list literal a live `ContainerRef` has a large blast radius across every list/Set/Bag/Hash flatten choke point (none of which currently deref `ContainerRef`) and needs a systematic multi-slice pass. This fix is the safe, independently-valuable piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)