### PR TITLE
fix(supply): fire on-demand supply's own closing callback on the .tap path

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -252,15 +252,25 @@
     (`-> $s { $s.emit; $s.done }`) fires it inline via `body_ran_done`; an async
     `start { ... }` body registers a source-less subscription so
     run_react_close_callbacks fires it at react end. Both work standalone
-    (t/supply-on-demand-closing.t). **test 75 itself still fails** because there
-    the `whenever $sod` is NESTED inside `whenever Supply.interval { ... }`: a
-    nested whenever registers while supply_emit_buffer is empty (the loop already
-    popped it) → run_whenever_with_value takes the NON-react `.tap` path
-    (native_supply_mut tap/act ~2300-2730), NOT the react loop. To pass test 75
-    the tapped on-demand supply's own `on_close_callbacks` must be fired from the
-    TAP path when its (async start-block) body completes — that path currently
-    only collects on_close from INNER whenevers (`whenever_on_close`), not the
-    tapped supply itself. Deeper (tap path + async start + close-marker).
+    (t/supply-on-demand-closing.t). The NESTED case (`whenever $sod` inside
+    `whenever Supply.interval`) takes the non-react `.tap` path because the drive
+    loop pops supply_emit_buffer before running the interval callback.
+  - test 75 TAP-path closing FIXED 2026-07-01: the `.tap` path now fires the
+    tapped on-demand supply's OWN `on_close_callbacks` — a synchronous body fires
+    closing inline; an async `start { emit; done }` body registers closing on the
+    emitter's `done` and registers the outer tap so the thread's emit reaches the
+    subscriber (t/supply-on-demand-closing-tap.t; native_supply_mut_methods.rs on-
+    demand branch). Proven: the nested test-75 structure gives `$closed==1` when
+    `$closed` is an `atomicint`.
+  - **test 75 STILL fails** — remaining blocker is cross-thread scalar writeback:
+    the plain (non-atomic) `$closed++` inside `closing` runs on the `start`-block
+    worker thread, and mutsu's per-thread interpreter clone does not propagate a
+    mutated captured *scalar* back to the main lexical (only atomics / critical
+    sections / `@`-`%` aggregates do). So `my $closed = 0` ends at 0 (fails `ok
+    $closed`) even though closing fired. Same gap as lock.t tests 10-24 (§4.1/§4.2
+    thread-capture). Secondary: `$sod` degrades to a `Tap` after the first
+    interval tick (repeated `.tap` on the same var rebinds it), so only tick 1
+    runs the on-demand body. Both are deep/deferred.
   - test 90 (two `whenever`s each `last` + a `whenever start` feeding both via a
     Supplier::Preserving, cross-whenever LAST ordering) — **the hard case; deferred**
     after a full root-cause investigation (2026-07-01). It needs THREE independent

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -371,6 +371,41 @@ impl Interpreter {
                             register_supplier_done_callback(emitter_supplier_id, complete_marker);
                         }
                     }
+                    // The tapped on-demand supply's own `closing => { ... }`
+                    // callbacks (stored on the Supply as `on_close_callbacks`) fire
+                    // when it closes. A synchronous body that already ran `done`
+                    // fires them now; an async body (e.g. `start { emit; done }`)
+                    // registers them to fire when the emitter later signals `done`,
+                    // and — since a plain async body registers no inner whenever —
+                    // the outer tap must also be registered on the emitter so the
+                    // thread's `emit`s reach the tap subscriber.
+                    let own_close_cbs: Vec<Value> = match attrs.get("on_close_callbacks") {
+                        Some(Value::Array(cbs, ..)) => cbs.to_vec(),
+                        _ => Vec::new(),
+                    };
+                    if !own_close_cbs.is_empty() {
+                        let (_, emitter_done, _) = supplier_snapshot(emitter_supplier_id);
+                        if body_done || emitter_done {
+                            for cb in &own_close_cbs {
+                                self.call_sub_value(cb.clone(), vec![], true)?;
+                            }
+                        } else {
+                            for cb in &own_close_cbs {
+                                register_supplier_close_callback(emitter_supplier_id, cb.clone());
+                            }
+                            register_supplier_done_callback(
+                                emitter_supplier_id,
+                                Self::make_supply_close_marker(emitter_supplier_id),
+                            );
+                            if !outer_tap_registered && Self::supply_has_active_callback(&tap_cb) {
+                                register_supplier_tap(
+                                    emitter_supplier_id,
+                                    tap_cb.clone(),
+                                    delay_seconds,
+                                );
+                            }
+                        }
+                    }
                     plain_values
                 } else if has_unique {
                     if Self::supply_has_active_callback(&tap_cb) {

--- a/t/supply-on-demand-closing-tap.t
+++ b/t/supply-on-demand-closing-tap.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# `Supply.on-demand(..., closing => { ... })` tapped DIRECTLY with `.tap`
+# (not via `react whenever`): the `closing` callback must still fire when the
+# supply closes. Previously the `.tap` path ignored the tapped supply's own
+# `on_close_callbacks`, so `closing` never ran.
+
+plan 4;
+
+# Synchronous body that emits then sends done, tapped with `.tap`.
+{
+    my $closed = 0;
+    my @got;
+    my $sod = Supply.on-demand:
+        -> $s { $s.emit(42); $s.done },
+        closing => { $closed++ };
+    $sod.tap(-> $v { @got.push($v) });
+    is-deeply @got, [42], 'tap consumer sees the emitted value';
+    is $closed, 1, 'closing fires for a synchronous on-demand supply tapped with .tap';
+}
+
+# Asynchronous body (start block), tapped with `.tap`.
+{
+    my $closed = 0;
+    my $sod = Supply.on-demand:
+        -> $s { start { $s.emit(1); $s.done } },
+        closing => { $closed++ };
+    $sod.tap(-> $v { });
+    sleep 0.5;
+    ok $closed, 'closing fires for an async (start-block) on-demand supply tapped with .tap';
+}
+
+# Two values then done, tapped with `.tap`.
+{
+    my @got;
+    my $n = 0;
+    my $sod = Supply.on-demand:
+        -> $s { $s.emit('a'); $s.emit('b'); $s.done },
+        closing => { $n++ };
+    $sod.tap(-> $v { @got.push($v) });
+    is-deeply @got, ['a', 'b'], 'tap consumer sees all emitted values';
+}


### PR DESCRIPTION
## Summary
`Supply.on-demand(..., closing => { ... })` tapped directly with `.tap` (not via `react whenever`) never fired its `closing` callback — the tap path only collected on-close callbacks from **inner** whenevers, never the tapped supply's own `on_close_callbacks`.

Now the on-demand `.tap` branch, after processing the body's emissions:
- fires the supply's own closing callbacks inline when the body already ran `done` synchronously (or the emitter is already done);
- otherwise (async `start { emit; done }` body) registers them on the emitter's `done` via a close marker, and registers the outer tap on the emitter so the worker thread's `emit`s reach the subscriber.

## Impact on roast S17-supply/syntax.t test 75
This advances test 75: the `closing` callback now **provably fires** (the nested `whenever $sod` inside `whenever Supply.interval` structure yields `$closed == 1` when `$closed` is an `atomicint`). test 75 still fails only on the remaining **cross-thread plain-scalar writeback** gap — a worker-thread `$closed++` inside `closing` does not propagate to the main lexical (the same §4.1/§4.2 thread-capture issue as lock.t tests 10-24). Documented in `TODO_roast/S17.md`.

## Test plan
- New `t/supply-on-demand-closing-tap.t` (sync + async + multi-value) — 4/4 PASS.
- Existing `t/supply-on-demand-closing.t` (react-whenever path) — still 4/4 PASS.
- Regression: `roast/S17-supply/{on-demand,act,do,throttle,delayed,schedule-on,unique,classify,categorize}.t` — all PASS.
- CI runs `make test` + `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)