### PR TITLE
docs(roast): record S17-supply/syntax.t status after #4035

### DIFF
--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -234,9 +234,23 @@
 - [ ] roast/S17-supply/supplier-preserving.t
 - [ ] roast/S17-supply/syntax-nonblocking-await.t
 - [ ] roast/S17-supply/syntax.t
-  - 88/90 deterministic. Remaining 2: test 75 and test 90.
-    Whitelist still gated on release/CI stability of the 2000-react interval-done
-    stress (lines 543-550).
+  - Status 2026-07-01 (post #4035, prove x3): three tests still block whitelist,
+    none a clean single fix:
+    - **test 90** — fails 3/3 (deterministic). Needs 3 independent react/supply
+      features (thread-fed supplier delivery, grep/map forwarding on a live
+      supply, drain-on-done); see the test-90 breakdown below. Hard, deferred.
+    - **test 75** — now FLAKY (~1/3 pass) after #4035 made the `closing` callback
+      fire via the `.tap` path. The remaining non-determinism is the cross-thread
+      plain-scalar writeback of `$closed++` (a worker-thread write to a main
+      lexical only sometimes propagates) — the §4.1/§4.2 thread-capture gap
+      (same as lock.t 10-24). Deferred.
+    - **test 53** — FLAKY (~2/3 fail under prove load). `supply {}` whenever
+      mutual-exclusion ordering race (two `start`-thread emits into two whenevers;
+      the "only one whenever at a time" guarantee is not enforced, so the emit
+      order into `@collected` races). The minimal repro passes 20/20 in isolation;
+      the flake shows up only under the full-file / parallel load. Deferred.
+    Whitelisting requires all three deterministic PLUS the 2000-react
+    interval-done stress (lines 543-550) — multi-PR deep concurrency work.
   - test 57 (multiple channels in whenever blocks, cross-whenever `$order`
     accumulation): **FIXED** — a `whenever` callback shares the enclosing react
     block's lexicals, but each closure call persisted its captured-outer free vars


### PR DESCRIPTION
## Summary
Documentation-only update to `TODO_roast/S17.md` recording the current status of `roast/S17-supply/syntax.t` after #4035.

After #4035 made the on-demand `closing` callback fire via the `.tap` path, **test 75** went from deterministic-fail to **flaky** (~1/3 pass) — the remaining non-determinism is the cross-thread plain-scalar writeback of `$closed++` (§4.1/§4.2 thread-capture gap, same as lock.t 10-24).

- **test 90** — deterministic fail; needs 3 independent react/supply features (thread-fed delivery, grep/map on a live supply, drain-on-done).
- **test 75** — flaky; cross-thread scalar writeback race.
- **test 53** — flaky; `supply {}` whenever mutual-exclusion ordering race (minimal repro passes 20/20 in isolation).

Whitelisting requires all three deterministic plus the 2000-react interval-done stress — multi-PR deep concurrency work, deferred.

## Test plan
- Docs-only; no code change. CI runs `make test` + `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)