### PR TITLE
fix(default): is default + where/subset compile-time eval (whatever.t 122-123)

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -478,8 +478,21 @@
       — DONE. The chain expands to `(a OP m) && (m OP b)`; count_whatever/replace_whatever_numbered
       now dedup the structurally-equal shared middle `m` so arity = number of distinct
       operands (was double-counting the middle).
-    - Tests 122-124, 126-131 don't run/fail: depend on `where`+`is default`/`BEGIN`
-      compile-time WhateverCode eval, regex `/<$_>/` curry, call-arg Whatever (see 75-76).
+    - Tests 122-123: `where`+`is default` compile-time WhateverCode/Junction eval
+      — **DONE (2026-07-02)**. Three fixes: (1) `check_default_type_mismatch`
+      (compiler/stmt.rs) only rejects a *recognized built-in* base type, never a
+      subset / `where`-desugared `__mutsu_anon_subset_N` (whose membership is a
+      runtime predicate), while still catching a `:U` smiley + concrete literal;
+      (2) an uninitialized scalar `(my $x is default(V))` used as an *expression*
+      now reads the variable back (default applied) instead of returning the raw
+      Nil (compiler/expr_block.rs); (3) a class-attribute `where PRED` is checked
+      via smartmatch `value ~~ PRED` (methods_object_attr_constraints.rs) so a
+      Junction predicate (`where 42|3`) threads instead of being (wrongly)
+      *called*. Tests t/is-default-where-expr.t.
+    - Test 124: regex whatever curry (`* ~~ /<$_>/` with in-regex `{...}` blocks,
+      `<?{...}>`/`<!{...}>` assertions) — still fails; deep regex-curry work.
+    - Tests 126, 128-131: depend on regex `/<$_>/` curry (124) and call-arg
+      Whatever over-currying (see 75-76: `$sub(*)` must be a Whatever *value*).
     - Tests 42, 114, 117 also fail on raku (todo'd)
 - [ ] roast/S02-types/WHICH.t
   - 1652/1657 pass. Remaining: Nil.raku/gist returns "(Any)" instead of "Nil" (mutsu uses Value::Nil for both Nil and uninitialized Any); subtest using EVAL/start/supply not implemented

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -336,6 +336,25 @@ impl Compiler {
                         has_arg: trait_arg.is_some(),
                     });
                 }
+                // An uninitialized scalar declared `is default(V)` used as an
+                // expression (`(my $x is default(42))`, `(my Foo $b is
+                // default(42))`) must evaluate to its default, not the raw Nil the
+                // container was seeded with. The `default` trait was just applied
+                // to the container above; read the variable back so the expression
+                // result reflects it. Gated on an uninitialized (Nil) declaration,
+                // so a real initializer (`my $d is default(42) = "foo"`) still
+                // returns its assigned value.
+                let has_default_trait = custom_traits.iter().any(|(t, _)| t == "default");
+                let is_nil_init = matches!(expr, Expr::Literal(Value::Nil));
+                if has_default_trait
+                    && is_nil_init
+                    && !name.starts_with('@')
+                    && !name.starts_with('%')
+                    && name != "__ANON_STATE__"
+                {
+                    self.code.emit(OpCode::Pop);
+                    self.emit_get_named_var(name);
+                }
             }
             Stmt::Expr(inner_expr) => {
                 self.compile_expr(inner_expr);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -175,10 +175,44 @@ impl Compiler {
     /// Check if a default value expression statically mismatches a type constraint.
     /// Returns `Some(value_repr)` if a mismatch is detected, `None` otherwise.
     fn check_default_type_mismatch(type_constraint: &str, expr: &Expr) -> Option<String> {
-        let effective_constraint = type_constraint
-            .strip_suffix(":D")
-            .or_else(|| type_constraint.strip_suffix(":_"))
-            .unwrap_or(type_constraint);
+        // Split off an optional type smiley (`:D` / `:U` / `:_`).
+        let (effective_constraint, smiley) = if let Some(b) = type_constraint.strip_suffix(":D") {
+            (b, Some('D'))
+        } else if let Some(b) = type_constraint.strip_suffix(":U") {
+            (b, Some('U'))
+        } else if let Some(b) = type_constraint.strip_suffix(":_") {
+            (b, Some('_'))
+        } else {
+            (type_constraint, None)
+        };
+        // Only a recognized concrete built-in type can be rejected at compile
+        // time. A subset / `where`-constrained type (`my $x is default(42) where
+        // * == 42`, compiled to an anonymous `__mutsu_anon_subset_N`) or any
+        // user-defined type narrows membership by a runtime predicate the compiler
+        // cannot evaluate, so it must NOT be statically flagged as a mismatch —
+        // the default may well satisfy it. S02-types/whatever.t "compile time
+        // WhateverCode / Junction evaluation" exercises exactly this.
+        const CHECKABLE_BUILTINS: &[&str] = &[
+            "Int", "Num", "Rat", "Bool", "Str", "Numeric", "Real", "Cool", "Any", "Mu", "Stringy",
+            "Complex", "Rational",
+        ];
+        if !CHECKABLE_BUILTINS.contains(&effective_constraint) {
+            return None;
+        }
+        // A concrete (defined) literal default can never bind to a `:U`
+        // (type-object-only) constraint, e.g. `my Int:U $y is default(0)`.
+        let is_concrete_literal = matches!(
+            expr,
+            Expr::Literal(
+                Value::Int(_) | Value::Num(_) | Value::Str(_) | Value::Bool(_) | Value::Rat(..)
+            )
+        );
+        if smiley == Some('U') && is_concrete_literal {
+            return Some(match expr {
+                Expr::Literal(v) => v.to_string_value(),
+                _ => "?".to_string(),
+            });
+        }
         let value_type = match expr {
             Expr::Literal(Value::Str(s)) => {
                 if effective_constraint != "Str"

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -7,10 +7,13 @@ impl Interpreter {
             Ok(v) => v,
             Err(_) => return false,
         };
-        match self.call_sub_value(pred_val, vec![value.clone()], false) {
-            Ok(result) => result.truthy(),
-            Err(_) => false,
-        }
+        // `has $.x is default(V) where PRED` passes iff `value ~~ PRED`.
+        // Smartmatch handles every predicate shape uniformly: a
+        // Callable/WhateverCode (`* == 42`) is invoked with the value, a Junction
+        // (`42|3`) is threaded, and a plain value/type is compared. Calling the
+        // predicate directly only worked for Callables and mis-handled a Junction
+        // predicate (S02-types/whatever.t "compile time Junction in `where`").
+        self.smart_match_values(value, &pred_val)
     }
 
     /// For a given class, return the ordered list of (role_name, MethodDef) pairs

--- a/t/is-default-where-expr.t
+++ b/t/is-default-where-expr.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# `is default(V)` combined with a `where` clause (WhateverCode or Junction) and
+# used in expression position must evaluate to its default V — mutsu previously
+# (a) rejected the default at compile time as "will never bind" to the anonymous
+# subset the `where` desugars to, and (b) returned Nil for a decl-as-expression.
+# It also must smartmatch a Junction `where` predicate on a class attribute.
+# (roast/S02-types/whatever.t "compile time WhateverCode / Junction evaluation".)
+
+plan 9;
+
+# WhateverCode `where` on a variable, in expression position.
+is (my $a is default(42) where * == 42), 42,
+    'is default + WhateverCode where, decl as expression';
+
+# Junction `where` on a variable, in expression position.
+is (my $b is default(42) where 42|3), 42,
+    'is default + Junction where, decl as expression';
+
+# Plain `is default` decl used as an expression returns the default.
+is (my $c is default(7)), 7, 'is default decl as expression returns default';
+
+# Subset + default on a variable, in expression position.
+{
+    my subset Foo where * == 42;
+    is (my Foo $d is default(42)), 42, 'subset (WhateverCode) + default as expression';
+}
+{
+    my subset Bar where 1|42;
+    is (my Bar $e is default(42)), 42, 'subset (Junction) + default as expression';
+}
+
+# `where` clause + `is default` trait on a class attribute (WhateverCode).
+is (my class { has $.z is default(42) where * == 42 }.new.z), 42,
+    'attribute is default + WhateverCode where';
+
+# `where` clause + `is default` trait on a class attribute (Junction).
+is (my class { has $.z is default(42) where 42|3 }.new.z), 42,
+    'attribute is default + Junction where';
+
+# The subset-permissiveness must not defeat a genuine `:U` mismatch.
+throws-like { EVAL 'my Int:U $y is default(0)' }, X::Parameter::Default::TypeCheck,
+    ':U scalar still rejects a concrete default value';
+
+# A genuine built-in type mismatch is still caught.
+throws-like { EVAL 'my Int $z is default("x")' }, X::Parameter::Default::TypeCheck,
+    'Int scalar still rejects a Str default value';


### PR DESCRIPTION
## Summary
Fixes 2 of the 8 failing subtests in `roast/S02-types/whatever.t` — the "compile time WhateverCode evaluation" (test 122) and "compile time Junction in \`where\` thunk evaluation" (test 123) subtests. `my $x is default(V) where PRED` needed three fixes:

1. **`check_default_type_mismatch`** (`compiler/stmt.rs`): only reject a *recognized built-in base type*. A `where` clause desugars to an anonymous subset (`__mutsu_anon_subset_N`) whose membership is a runtime predicate the compiler cannot evaluate, so a subset/user-typed default must not be statically flagged as "will never bind". A `:U` type-smiley + concrete literal default is still rejected, and a genuine built-in mismatch (`my Int $x is default("x")`) still errors.
2. **decl-as-expression default** (`compiler/expr_block.rs`): an uninitialized scalar `(my $x is default(42))` used as an expression now reads the variable back (default applied) instead of returning the raw `Nil`.
3. **attribute `where` via smartmatch** (`methods_object_attr_constraints.rs`): a class-attribute `where PRED` is enforced via `value ~~ PRED`, so a Junction predicate (`where 42|3`) threads correctly instead of being (wrongly) *called*.

## Test plan
- New `t/is-default-where-expr.t` (9) — PASS.
- `roast/S02-types/whatever.t` tests 122, 123 now pass.
- Existing `t/is-default.t` (incl. the `:U` rejection) — PASS.
- Whitelisted subset/attribute tests (subset-6c/6e, S12-attributes/*) — PASS.
- CI runs `make test` + `make roast`.

## Remaining whatever.t failures (documented in TODO_roast/S02.md, not whitelisted)
111 (container identity through smartmatch→Code), 119 (`none ...^ *` precedence), 120 (`use fatal` curry), 121 (parenthesized `(*)` de-prime — needs a parse-time marker), 124 (regex `/<$_>/` curry), 126 (call-arg Whatever over-currying). Each is a distinct deeper feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)