### PR TITLE
fix(hyper): fix xx/Slip hyper distribution and dotted-vs-bare postfix :<i> dispatch

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -186,24 +186,33 @@ surface のうち 1 ファイル。
 
 ### 5.1 `S03-metaops/hyper.t`
 
-- **現状**: 420 planned 全実行、5 失敗（test 77, 362, 407-408, 411）。plan mismatch は解消。
+- **現状**: 420 planned 全実行、3 失敗（test 362, 407-408）。plan mismatch は解消。
 - **今回の進捗**: plan mismatch の原因は `<<op>>` 系ハイパーメタ演算子の閉じ `>>` 探索が
   演算子文字列自体と重なるケース（`<<=>>>` = `<<`+`=>`+`>>`）で誤って最短一致を採用し、
   以降のファイル全体を静かに打ち切っていたパーサバグだった（`hyper_concat.rs`）。
   副次的に `set_shared_var`（`@`/`%` への env 書き込み全経路を通る、hyper 専用ではない
   一般関数）が非スレッド文脈でも List→Array を無条件正規化しており、`:=` で束縛した
-  List の kind を最初の env sync で破壊していた一般バグも発見・修正。詳細は
-  `TODO_roast/S03.md` の hyper.t エントリと news 参照。
-- **残り 5 件**: (1) test 77 `.i` の dotted-vs-backslash 区別（AST 未分化）、
-  (2) test 362 ユーザ定義 custom infix 演算子とビルトイン演算子文字の字句衝突
-  （`infix:<+-*/>` の `*` が Whatever と誤認）、(3)(4) test 407-408 `».+`/`».*` の
-  all-candidates MRO dispatch 未実装、(5) test 411 `xx` の per-element hyper 分配。
+  List の kind を最初の env sync で破壊していた一般バグも発見・修正。さらに `is_listy()`
+  （hyper 分配の判定）に `Value::Slip` が抜けており `|<1 2> >>xx>> 2` が per-element
+  分配されない不具合、および `.i`（postfix imaginary）が dotted 呼び出し
+  （`4.i`/`@a».i`、本来 X::Method::NotFound）と bare 呼び出し
+  （`4\i`/`(expr)i`/`@a»i`、`&postfix:<i>` 演算子）を区別できていなかった不具合を修正。
+  詳細は `TODO_roast/S03.md` の hyper.t エントリと news 参照。
+- **残り 3 件**: (1) test 362 ユーザ定義 custom infix 演算子とビルトイン演算子文字の
+  字句衝突（`infix:<+-*/>` の `*` が Whatever と誤認）、(2)(3) test 407-408 `».+`/`».*` の
+  all-candidates MRO dispatch 未実装（非 hyper の `.+`/`.*` でも同じ欠落を確認済み —
+  mutsu のビルトイン型は List/Any/Cool のような多段クラス階層に渡る重複メソッド定義を
+  モデル化していない、根本的なアーキテクチャギャップ。個別メソッドの候補数を
+  ハードコードするのは禁止されているテスト特化ハックそのものなので不可）。
   いずれも局所修正では閉じない、それぞれ独立した深掘りが必要な項目。
 - **変更レイヤ**: `src/parser/expr/precedence_meta_ops/hyper_concat.rs`,
   `src/vm/vm_hyper_method_ops.rs`, `src/vm/vm_hyper_ops.rs`,
-  `src/runtime/runtime_shared_vars.rs`
-- **Next slice**: 残り 5 件のうち (3)(4) の all-candidates dispatch から着手するのが
-  最も汎用的（他の `».+`/`».*` 系テストにも波及しうる）。
+  `src/runtime/runtime_shared_vars.rs`, `src/parser/expr/postfix/loop_.rs`,
+  `src/parser/primary/number.rs`, `src/runtime/builtins_operators_fallback.rs`
+- **Next slice**: 残り 3 件はいずれも大きめの独立作業（custom operator の longest-match
+  字句解析、MRO 多重候補 dispatch の新規実装）。次に着手するなら (2)(3) の
+  all-candidates dispatch が最も汎用的（他の `».+`/`».*` 系テストにも波及しうる）が、
+  スコープはこのファイル単体では収まらない見込み。
 
 ---
 

--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -40,7 +40,26 @@
 - [ ] roast/S03-metaops/cross.t
 - [ ] roast/S03-metaops/eager-hyper.t
 - [ ] roast/S03-metaops/hyper.t
-  - 5 sub-subtest fails (was ~20, was 154). Fixed (latest pass): the parser
+  - 3 sub-subtest fails (was 5, was ~20, was 154). Fixed since the 5-failure
+    pass: `is_listy()` (the hyper-op distribution gate) didn't include
+    `Value::Slip`, so `|<1 2> >>xx>> 2` treated the whole slipped list as one
+    scalar `xx` operand instead of distributing per element (test 411); the
+    dotted-vs-bare distinction for postfix `i` is now tracked at the parser
+    level in both the non-hyper (`loop_.rs` main postfix chain) and hyper
+    postfix-name paths — `4\i`/`4i`/`(expr)i`/`(expr)\i`/`@a»i` compile to the
+    `&postfix:<i>` operator call (or, for hyper, a `HyperMethodCall` named
+    `postfix:<i>`) while `.i`/`».i` remain plain method-name lookups; `"i"`/
+    `"Complex-i"` are removed from the native method-dispatch tables entirely
+    so `4.i`/`@a».i` correctly throw `X::Method::NotFound` (test 77). The
+    `&postfix:<i>` fallback (`builtins_operators_fallback.rs`) also needed a
+    restored special case: applying `i` to an existing `Complex` (directly,
+    or via a `.Numeric` coercion that returns one) rotates it 90° instead of
+    trying to coerce it to a plain float, matching the removed
+    `dispatch_core_numeric.rs` behavior (`roast/S32-num/{real-bridge,
+    cool-num}.t` regressed and were fixed during this change — always grep
+    the whole roast tree for a construct before deleting its old dispatch
+    path, not just the target file's own tests).
+  - Fixed (5-failure pass): the parser
     mis-lexed `<<op>>`-style hyper metaops whose operator text ends in `>`
     (e.g. `<<=>>>`, the hypered fat-arrow) as a quote-words literal instead of
     a hyper metaop, which silently truncated the whole rest of the file after
@@ -94,29 +113,28 @@
     *recursively* through nested Iterables/Hashes and write any in-place leaf
     mutation back through every level (the "distribution for unary postfix
     autoincr" subtests). See `t/hyper-precedence-deep.t`.
-  - Remaining blockers (5 subtests, test numbers as of the latest pass):
-    (1) test 77, `4.i` (dotted method-call form) must throw
-    `X::Method::NotFound` while `4\i` (backslash postfix form) still works —
-    both currently compile to the identical `MethodCall` AST node (no
-    dotted-vs-bare distinction is tracked anywhere), and `"i"` is registered
-    as a real dispatchable method rather than only reachable via the
-    postfix-operator desugar; (2) test 362, a user-declared custom infix
-    operator whose name is a run of symbol characters overlapping the
-    tokenizer's own operators (`sub infix:<+-*/>`, then `5+-*/2`) gets
-    mis-lexed — `+`, `-` consume fine but `*` is read as `Whatever` in term
-    position instead of continuing to match the longer declared-operator
-    name, so the whole hyper hand-off inside its body never runs; needs
-    longest-match lookahead against declared custom operators before falling
-    back to single-char builtins; (3)/(4) tests 407-408, the `».+`/`».*`
+  - Remaining blockers (3 subtests, test numbers as of the latest pass):
+    (1) test 362, a user-declared custom infix operator whose name is a run
+    of symbol characters overlapping the tokenizer's own operators
+    (`sub infix:<+-*/>`, then `5+-*/2`) gets mis-lexed — `+`, `-` consume
+    fine but `*` is read as `Whatever` in term position instead of
+    continuing to match the longer declared-operator name, so the whole
+    hyper hand-off inside its body never runs; needs longest-match
+    lookahead against declared custom operators before falling back to
+    single-char builtins; (2)/(3) tests 407-408, the `».+`/`».*`
     "all-candidates" hyper modifiers on a plain method name (`».+elems`,
     `».+"elems"()`, `».+Any::elems`) return a single-candidate
     `Array`-kind result (`[2]`) instead of gathering every matching
     MRO candidate into a `List` (`(2, 2)`) — needs real multi-candidate MRO
     dispatch for hyper `+`/`*`, not just the sub-ref (`».+&`) and dynamic
-    (`».+$var`) forms which already work; (5) test 411, `<1 2> >>xx>> 2`
-    must hyper-distribute `xx` per-element (each element replicated into its
-    own `(e, e).Seq`) but mutsu treats the whole LHS list as a single `xx`
-    operand, replicating the list itself instead of its elements.
+    (`».+$var`) forms which already work. This is a genuine architectural
+    gap, not a quick fix: mutsu's native/builtin types (List/Any/Cool) don't
+    model multiple redundant method definitions stacked across a class
+    hierarchy the way real Raku's builtin classes do (confirmed the same gap
+    exists in the *non-hyper* `.+`/`.*` form too — `@a.+elems` also returns
+    only one candidate). Do not hardcode a candidate count per method name;
+    that would be exactly the test-specific hack the project's conventions
+    prohibit.
 - [ ] roast/S03-metaops/infix.t
   - `plan` now accepts integral Num/Rat values, so early `plan expects Int` abort is fixed.
   - Runs 5076/5076, 4176 pass (was 328 run / 116 pass on bare main). Implemented:

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -1,11 +1,11 @@
 use super::{int_lsb_value, int_msb_value, is_infinite_range, range_elems_lazy_failure};
 use crate::builtins::rng::builtin_rand;
-/// Numeric and element methods: elems, default, Complex-i/i, abs, lsb, msb, rand,
+/// Numeric and element methods: elems, default, abs, lsb, msb, rand,
 /// uc, lc, fc, tc, sign
 use crate::runtime;
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::Signed;
 
 /// Check if a Package type object is calling a :D-requiring numeric method.
 /// Returns X::Parameter::InvalidConcreteness error if so.
@@ -175,21 +175,6 @@ pub(super) fn dispatch(
                 _ => return Some(None),
             };
             Some(Some(Ok(result)))
-        }
-        "Complex-i" | "i" => {
-            let imag = match target {
-                Value::Int(i) => *i as f64,
-                Value::Num(f) => *f,
-                Value::Rat(n, d) if *d != 0 => *n as f64 / *d as f64,
-                Value::FatRat(n, d) if *d != 0 => *n as f64 / *d as f64,
-                Value::BigInt(n) => n.to_f64().unwrap_or(0.0),
-                Value::BigRat(n, d) if !d.is_zero() => {
-                    n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)
-                }
-                Value::Complex(r, i) => return Some(Some(Ok(Value::Complex(-*i, *r)))),
-                _ => return Some(None),
-            };
-            Some(Some(Ok(Value::Complex(0.0, imag))))
         }
         "abs" => {
             let result = match target {

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -505,7 +505,7 @@ pub(crate) fn native_method_0arg(
             | "acos" | "atan" | "sinh" | "cosh" | "tanh" | "sec" | "cosec" | "cotan" | "asec"
             | "acosec" | "acotan" | "sech" | "cosech" | "cotanh" | "asech" | "acosech"
             | "acotanh" | "atan2" | "narrow" | "polymod" | "base" | "chr" | "expmod" | "lsb"
-            | "msb" | "is-int" | "i" | "Complex-i" => {
+            | "msb" | "is-int" => {
                 let coerced = if let Ok(i) = s.parse::<i64>() {
                     Value::Int(i)
                 } else if let Ok(f) = s.parse::<f64>() {

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -2184,6 +2184,7 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
             }
 
             // Check for ».method / >>.method and modifier forms like ».?method, ».+method, »!Type::meth.
+            let had_dot = after_hyper.starts_with('.');
             let r = after_hyper.strip_prefix('.').unwrap_or(after_hyper);
             // Hyper dotted postfix update: >>.++ / >>.--
             if let Some((op, len)) = parse_postfix_update_op(r) {
@@ -2404,7 +2405,17 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 parsed_static_name
             };
             if let Some((r, name)) = parsed_static_name {
-                let name = Symbol::intern(&name);
+                // Bare (non-dotted) hyper postfix on a builtin wordy postfix
+                // operator (currently just `i`, e.g. `@a»i`) calls the
+                // *operator* (`&postfix:<i>`), not a method — `i` is not a
+                // real dispatchable method (`@a».i` correctly throws
+                // X::Method::NotFound). Mirrors the non-hyper `4\i` vs `4.i`
+                // distinction (`strip_imaginary_suffix` in `primary/number.rs`).
+                let name = if !had_dot && modifier.is_none() && name == "i" {
+                    Symbol::intern("postfix:<i>")
+                } else {
+                    Symbol::intern(&name)
+                };
                 if r.starts_with('(') {
                     let (r, _) = parse_char(r, '(')?;
                     let (r, _) = ws(r)?;
@@ -2721,26 +2732,23 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
 
         // Postfix i (imaginary number): (expr)i or (expr)\i → Complex(0, expr)
         // The \i form uses unspace to separate the postfix from the preceding token
-        // (e.g. Inf\i avoids being parsed as the identifier "Infi").
+        // (e.g. Inf\i avoids being parsed as the identifier "Infi"). This is the
+        // `&postfix:<i>` *operator*, not a dispatchable method — `(expr).i` (the
+        // dotted method-call form) correctly throws X::Method::NotFound, so this
+        // compiles to a function call rather than `Expr::MethodCall`.
         if rest.starts_with("\\i") && !is_ident_char(rest.as_bytes().get(2).copied()) {
             rest = &rest[2..];
-            expr = Expr::MethodCall {
-                target: Box::new(expr),
-                name: Symbol::intern("i"),
-                args: vec![],
-                modifier: None,
-                quoted: false,
+            expr = Expr::Call {
+                name: Symbol::intern("postfix:<i>"),
+                args: vec![expr],
             };
             continue;
         }
         if rest.starts_with('i') && !is_ident_char(rest.as_bytes().get(1).copied()) {
             rest = &rest[1..];
-            expr = Expr::MethodCall {
-                target: Box::new(expr),
-                name: Symbol::intern("i"),
-                args: vec![],
-                modifier: None,
-                quoted: false,
+            expr = Expr::Call {
+                name: Symbol::intern("postfix:<i>"),
+                args: vec![expr],
             };
             continue;
         }

--- a/src/parser/primary/number.rs
+++ b/src/parser/primary/number.rs
@@ -7,6 +7,23 @@ fn decimal_digit_value(c: char) -> Option<u32> {
     crate::builtins::unicode::unicode_decimal_digit_value(c)
 }
 
+/// Recognize the imaginary-number literal suffix after a numeral: bare `i`
+/// (`4i`) or the backslash-escaped `\i` (`4\i`). The backslash form is Raku's
+/// generic "don't continue scanning the previous token" disambiguator; unlike
+/// the dotted `.i` method-call syntax, both forms are the postfix *operator*
+/// (`&postfix:<i>`), not a real dispatchable method — `4.i` correctly throws
+/// X::Method::NotFound. Returns the remaining input after the suffix.
+fn strip_imaginary_suffix(rest: &str) -> Option<&str> {
+    let after = rest
+        .strip_prefix('i')
+        .or_else(|| rest.strip_prefix("\\i"))?;
+    if after.starts_with(|c: char| c.is_alphanumeric() || c == '_') {
+        None
+    } else {
+        Some(after)
+    }
+}
+
 /// Build a fatal parse error with X::Str::Numeric exception for invalid radix digits.
 fn make_radix_digit_error(base: u32, body: &str, pos: usize) -> PError {
     let message = format!(
@@ -292,18 +309,16 @@ pub(super) fn integer(input: &str) -> PResult<'_, Expr> {
             let full = format!("{}{}", clean, exp_part);
             let n: f64 = full.parse().unwrap_or(0.0);
             // Check for imaginary suffix
-            if r2.starts_with('i')
-                && !r2[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_')
-            {
-                return Ok((&r2[1..], Expr::Literal(Value::Complex(0.0, n))));
+            if let Some(r3) = strip_imaginary_suffix(r2) {
+                return Ok((r3, Expr::Literal(Value::Complex(0.0, n))));
             }
             return Ok((r2, Expr::Literal(Value::Num(n))));
         }
     }
-    // Check for imaginary suffix: 4i
-    if rest.starts_with('i') && !rest[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_') {
+    // Check for imaginary suffix: 4i / 4\i
+    if let Some(r) = strip_imaginary_suffix(rest) {
         let n: i64 = clean.parse().unwrap_or(0);
-        return Ok((&rest[1..], Expr::Literal(Value::Complex(0.0, n as f64))));
+        return Ok((r, Expr::Literal(Value::Complex(0.0, n as f64))));
     }
     // Try i64 first, fall back to BigInt for large integers
     if let Ok(n) = clean.parse::<i64>() {
@@ -354,19 +369,15 @@ pub(super) fn decimal(input: &str) -> PResult<'_, Expr> {
     if let Some(exp) = exp_part {
         let full = format!("{}{}", num_str, exp);
         let n: f64 = full.parse().unwrap_or(0.0);
-        if rest.starts_with('i')
-            && !rest[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_')
-        {
-            return Ok((&rest[1..], Expr::Literal(Value::Complex(0.0, n))));
+        if let Some(r) = strip_imaginary_suffix(rest) {
+            return Ok((r, Expr::Literal(Value::Complex(0.0, n))));
         }
         Ok((rest, Expr::Literal(Value::Num(n))))
     } else {
         // Check for imaginary suffix first
         let n: f64 = num_str.parse().unwrap_or(0.0);
-        if rest.starts_with('i')
-            && !rest[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_')
-        {
-            return Ok((&rest[1..], Expr::Literal(Value::Complex(0.0, n))));
+        if let Some(r) = strip_imaginary_suffix(rest) {
+            return Ok((r, Expr::Literal(Value::Complex(0.0, n))));
         }
         // Produce Rat: numerator = int_part * 10^frac_digits + frac_part, denominator = 10^frac_digits
         let frac_digits = frac_clean.len() as u32;
@@ -439,18 +450,14 @@ pub(super) fn dot_decimal(input: &str) -> PResult<'_, Expr> {
     if let Some(exp) = exp_part {
         let full = format!("{}{}", num_str, exp);
         let n: f64 = full.parse().unwrap_or(0.0);
-        if rest.starts_with('i')
-            && !rest[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_')
-        {
-            return Ok((&rest[1..], Expr::Literal(Value::Complex(0.0, n))));
+        if let Some(r) = strip_imaginary_suffix(rest) {
+            return Ok((r, Expr::Literal(Value::Complex(0.0, n))));
         }
         Ok((rest, Expr::Literal(Value::Num(n))))
     } else {
         let n: f64 = format!("0.{}", frac_clean).parse().unwrap_or(0.0);
-        if rest.starts_with('i')
-            && !rest[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_')
-        {
-            return Ok((&rest[1..], Expr::Literal(Value::Complex(0.0, n))));
+        if let Some(r) = strip_imaginary_suffix(rest) {
+            return Ok((r, Expr::Literal(Value::Complex(0.0, n))));
         }
         let frac_digits = frac_clean.len() as u32;
         let denom = 10i64.pow(frac_digits);

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -152,6 +152,12 @@ impl Interpreter {
                         } else {
                             arg.clone()
                         };
+                        // Applying `i` to an existing Complex (directly, or via a
+                        // `.Numeric` coercion that returns one) rotates it 90°
+                        // (multiplies by i): `(r+ei)\i == -e+ri`.
+                        if let Value::Complex(r, i) = coerced {
+                            return Ok(Value::Complex(-i, r));
+                        }
                         let n = crate::runtime::coerce_to_numeric(coerced);
                         let num_val = match &n {
                             Value::Int(i) => *i as f64,

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -98,6 +98,7 @@ impl Interpreter {
                 | Value::Set(..)
                 | Value::Bag(..)
                 | Value::Mix(..)
+                | Value::Slip(..)
         )
     }
 


### PR DESCRIPTION
## Summary
- `is_listy()` (the hyper-op distribution gate) didn't include `Value::Slip`, so `|<1 2> >>xx>> 2` treated the whole slipped list as a single `xx` operand instead of distributing per element.
- `4.i`/`@a».i` (dotted method-call form) must throw `X::Method::NotFound` while `4\i`/`4i`/`(expr)i`/`(expr)\i`/`@a»i` (bare postfix-operator form) still work — both previously compiled to the identical `MethodCall`/`HyperMethodCall` AST node naming a real dispatchable `"i"`/`"Complex-i"` method. The dotted-vs-bare distinction is now tracked at parse time in both the main postfix chain and the hyper postfix-name path; bare forms compile to the `&postfix:<i>` operator call instead of a method call, and `"i"`/`"Complex-i"` are removed from the native method-dispatch tables entirely.
- Restored a special case in the `&postfix:<i>` fallback: applying `i` to an existing `Complex` (directly, or via a `.Numeric` coercion that returns one) rotates it 90° instead of erroring, matching the removed method-dispatch behavior. Caught and fixed two roast regressions from this during development (`roast/S32-num/real-bridge.t`, `roast/S32-num/cool-num.t`).

`roast/S03-metaops/hyper.t` goes from 415/420 to 417/420 passing (follow-up to #4036). Remaining 3 failures are independent, deeper issues documented in `TODO_roast/S03.md`.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `make test` passes (release build + full `t/` suite)
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S03-metaops/hyper.t` — 417/420
- [x] Manually re-verified all roast files touching `\i`/postfix `i` (`S02-literals/{numeric,allomorphic}.t`, `S02-types/type.t`, `S03-operators/assign.t`, `S32-list/tail.t`, `S32-num/{complex,cool-num,real-bridge,roots,sqrt,stringify}.t`, `S32-str/{numeric,val}.t`, `6.d/S32-num/sqrt.t`) still pass
- [ ] CI `make roast`

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK