### PR TITLE
fix(hyper): postfix:<i> is an operator not a .i method; lazy-Seq gist placeholder

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -689,6 +689,18 @@ pub(super) fn dispatch(
                 raku_value(target)
             })))
         }
+        // A genuinely-lazy (infinite) list renders a `(...)`/`[...]`/`...`
+        // placeholder rather than materializing — e.g. `[2,3].roll(*).gist`
+        // (raku: `(...)`). Finite/`cat_pull` lazy lists fall through to force.
+        Value::LazyList(ll)
+            if (method == "gist" || method == "raku" || method == "perl")
+                && ll.renders_lazy_placeholder() =>
+        {
+            Some(Ok(Value::str(crate::value::lazy_list_placeholder(
+                method,
+                ll.in_array_context(),
+            ))))
+        }
         Value::LazyList(_) => None, // fall through to runtime to force
         _ => Some(Ok(Value::str(target.to_string_value()))),
     })

--- a/t/postfix-i-vs-method-i.t
+++ b/t/postfix-i-vs-method-i.t
@@ -1,0 +1,31 @@
+use Test;
+
+# `postfix:<i>` (imaginary) is an OPERATOR, not a `.i` method. The bare dotted
+# form `4.i` (and its hyper `».i`) must fail with X::Method::NotFound, while the
+# postfix operator forms (`4i`, `4\i`, `(3)i`, `(2i)i`, `»i`/`>>i`) build Complex.
+
+plan 12;
+
+# Postfix operator forms build Complex.
+is 4i,        Complex.new(0, 4), '4i literal';
+is 4\i,       Complex.new(0, 4), '4\i unspace form';
+is (3)i,      Complex.new(0, 3), '(expr)i on a paren term';
+is (2i)i,     Complex.new(-2, 0), 'postfix i on an imaginary';
+is (2i + 3)i, Complex.new(-2, 3), 'postfix i on a Complex';
+
+# Hyper postfix operator (no dot) distributes.
+is-deeply (2, 3)»i,  (Complex.new(0, 2), Complex.new(0, 3)), '(2,3)»i';
+is-deeply (2, 3)>>i, (Complex.new(0, 2), Complex.new(0, 3)), '(2,3)>>i';
+
+# The dotted method `.i` does not exist.
+throws-like { 4.i }, X::Method::NotFound,
+    message => *.starts-with("No such method 'i'"), '4.i throws';
+throws-like { (2, 3)>>.i }, X::Method::NotFound, '>>.i throws';
+
+# A user-defined method `i` is not shadowed by the operator.
+my class D { method i { 42 } };
+is D.i,   42, 'user method i works';
+is D.i(), 42, 'user method i() works';
+
+# A genuinely-lazy (infinite) sequence gists as a placeholder, not materialized.
+is (1, 2, 3 ... *).gist, '(...)', 'infinite sequence gist is (...)';


### PR DESCRIPTION
## Summary

Progress on **S03-metaops/hyper.t** (§3 BLOCKERS). Fixes test 77 and a general lazy-gist bug.

### `postfix:<i>` vs `.i` method (test 77)
`4.i` must fail with `X::Method::NotFound` — `i` (imaginary) is the **operator** `postfix:<i>`, not a method. mutsu conflated them (both compiled to a `MethodCall`/hyper name `"i"` served by a native numeric `"i"` method), so `4.i` wrongly produced `0+4i`.

- **Parser**: the postfix-i handler (`(expr)i` / `(expr)\i`) now emits the internal name `Complex-i`; a no-dot hyper `»i`/`>>i` emits `postfix:<i>`. The dotted forms (`4.i`, `».i`) stay method name `i`.
- **Numeric dispatch**: the native op matches only `Complex-i`, not the bare `i` method — so `.i` falls through to `X::Method::NotFound`, while a user-defined `method i` still dispatches normally.
- **VM hyper**: `postfix:<i>` computed via the internal `Complex-i` op.

### Lazy-Seq gist placeholder (general improvement)
A genuinely-lazy (infinite) `LazyList` now renders `(...)`/`[...]`/`...` from `.gist`/`.raku` instead of materializing (raku: `(1,2,3...*).gist` is `(...)`). Surfaced while investigating `».roll(*)`.

## Testing
- New pin test `t/postfix-i-vs-method-i.t` (12 subtests).
- `make test` green (13785 tests).
- `S32-num/complex.t` (whitelisted, uses `(3)i`/`3\i`/`(2i)i` postfix forms) stays green.

## Not whitelisted yet — remaining failures are separate features
hyper.t still fails 362, 407-408, 411:
- **362**: custom symbol-operator (`sub infix:<+-*/>`) parsing — the parser doesn't longest-match user-defined symbol operators, so `5 +-*/ 2` parses as `5 + -*/2`.
- **407/408**: `».+`/`».*` metamethod multiplicity — `<a b>.+elems` is `(2, 2)` in Rakudo because `List.^can("elems")` has **2** entries. mutsu's native types have one impl per method; matching the exact count would require hardcoding native-type method tables (disallowed).
- **411**: prefix `|` (slip) precedence — `|<1 2> >>xx>> 2` should be `|(… >>xx>> …)` but mutsu binds `|` tighter than the hyper infix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)