### PR TITLE
fix(parser): longest-token matching for user-declared symbol infix operators

### DIFF
--- a/TODO_roast/S03.md
+++ b/TODO_roast/S03.md
@@ -40,6 +40,21 @@
 - [ ] roast/S03-metaops/cross.t
 - [ ] roast/S03-metaops/eager-hyper.t
 - [ ] roast/S03-metaops/hyper.t
+  - 2 subtest fails (407, 408) — was 3. Fixed test 362 (custom symbol-operator
+    longest-token matching: a user `sub infix:<+-*/>` now wins over the built-in
+    `+` prefix at additive level, so `5 +-*/ 2` parses as one operator instead of
+    `5 + (-*/2)`; see `additive_expr` in
+    `parser/expr/precedence_meta_ops/arith.rs`, guarded to fire only when a
+    built-in op would grab a PREFIX of the custom symbol — word operators keep
+    their associativity/precedence machinery).
+  - BLOCKED (407/408) on native-type method-object MULTIPLICITY: `».+`/`».*`
+    metamethods on a List need `<a b>.+elems` == `(2, 2)` because Rakudo's
+    `List.^can("elems")` returns TWO distinct `Any::elems` multi methods (with 3
+    and 2 candidates respectively — a Rakudo-internal setup detail). mutsu has a
+    single native `elems` implementation per type, so `.+elems` yields `(2,)`.
+    Matching the exact count would require inventing per-type native method
+    tables with Rakudo's exact multiplicity = a test-specific hardcode
+    (forbidden). §5-class blocker (rakudo-internal detail), like sprintf/Collation.
   - 3 sub-subtest fails (was 5, was ~20, was 154). Fixed since the 5-failure
     pass: `is_listy()` (the hyper-op distribution gate) didn't include
     `Value::Slip`, so `|<1 2> >>xx>> 2` treated the whole slipped list as one

--- a/src/parser/expr/precedence_meta_ops/arith.rs
+++ b/src/parser/expr/precedence_meta_ops/arith.rs
@@ -122,6 +122,42 @@ pub(crate) fn additive_expr(input: &str) -> PResult<'_, Expr> {
         if block_newline_terminates(input, rest, r) {
             break;
         }
+        // Longest-token rule (Raku LTM): a user-declared *symbol* infix that is
+        // LONGER than the built-in additive operator starting at this position
+        // wins — e.g. `sub infix:<+-*/>` makes `5 +-*/ 2` one operator, not
+        // `5 + (-*/2)`. Only applies when the custom operator sits at additive
+        // precedence (its declared level, or the default for a trait-less infix),
+        // so a `is tighter`/`is looser` custom op is still handled at its own level.
+        if let Some((uname, ulen)) =
+            crate::parser::stmt::simple::match_user_declared_infix_symbol_op(r)
+        {
+            let builtin_len = parse_additive_op(r).map(|(_, l)| l).unwrap_or(0);
+            let is_additive_level =
+                match crate::parser::stmt::simple::lookup_custom_infix_precedence(&uname) {
+                    Some(level) => level == crate::parser::stmt::simple::PREC_ADDITIVE,
+                    None => true, // trait-less infix defaults to additive precedence
+                };
+            // Only override when a built-in operator would otherwise grab a
+            // PREFIX of the custom symbol (`+` inside `+-*/`). When no built-in
+            // matches here (`builtin_len == 0`, e.g. a word operator `rr`), leave
+            // it to the normal custom-infix machinery, which honors the operator's
+            // associativity/precedence traits.
+            if builtin_len > 0 && ulen > builtin_len && is_additive_level {
+                let r2 = &r[ulen..];
+                let (r2, _) = ws(r2)?;
+                let (r2, right) = multiplicative_expr(r2).map_err(|err| {
+                    enrich_expected_error(err, "expected expression after infix operator", r2.len())
+                })?;
+                left = Expr::InfixFunc {
+                    name: uname,
+                    left: Box::new(left),
+                    right: vec![right],
+                    modifier: None,
+                };
+                rest = r2;
+                continue;
+            }
+        }
         if let Some((op, len)) = parse_additive_op(r) {
             let r = &r[len..];
             let (r, _) = ws(r)?;

--- a/t/custom-symbol-infix-longest-token.t
+++ b/t/custom-symbol-infix-longest-token.t
@@ -1,0 +1,26 @@
+use Test;
+
+# Longest-token matching (Raku LTM) for user-declared *symbol* infix operators.
+# A custom operator whose symbol is longer than — and starts with — a built-in
+# operator must win: `sub infix:<+-*/>` makes `5 +-*/ 2` one operator, not
+# `5 + (-*/2)` (which would treat `*` as a Whatever).
+
+plan 5;
+
+{
+    sub infix:<+-*/>($a, $b) {
+        ( { $a + $b }, { $a - $b }, { $a * $b }, { $a / $b } )>>.()
+    }
+    is-deeply (5 +-*/ 2), (7, 3, 10, 2.5), 'infix:<+-*/> parses as one operator';
+}
+
+# A custom operator starting with the built-in `-` (additive level).
+{
+    sub infix:<-=->($a, $b) { $a * 100 + $b }
+    is (7 -=- 3), 703, 'infix:<-=-> beats built-in -';
+}
+
+# Built-in operators still work when no custom operator shadows them.
+is (5 + 2), 7, 'built-in + still works';
+is (5 - 2), 3, 'built-in - still works';
+is (5 * 2), 10, 'built-in * still works';


### PR DESCRIPTION
## Summary

S03-metaops/hyper.t **test 362**. A user-declared symbol operator whose text starts with — and is longer than — a built-in operator was shadowed by the built-in:

```raku
sub infix:<+-*/>($a, $b) { ( {$a+$b}, {$a-$b}, {$a*$b}, {$a/$b} )>>.() }
5 +-*/ 2   # was parsed as 5 + (-*/2), with * mis-read as a Whatever
```

`additive_expr` now applies Raku's **longest-token rule**: before matching the built-in additive operator, if an in-scope user symbol infix matches a longer token here (and sits at additive precedence — its declared level, or the default for a trait-less infix), it wins. Guarded to fire only when a built-in operator would otherwise grab a **prefix** of the custom symbol (`builtin_len > 0`), so word operators (`infix:<rr> is assoc<right>`) keep their existing associativity/precedence machinery.

## Testing
- New pin test `t/custom-symbol-infix-longest-token.t` (5 subtests).
- `make test` green (13811); `t/operator-associativity-traits.t` stays green (verified the guard).

## hyper.t status
Now down to **407/408**, both blocked on native-type method-object multiplicity: `<a b>.+elems` must be `(2, 2)` because Rakudo's `List.^can("elems")` returns two distinct `Any::elems` multis (3 and 2 candidates) — a Rakudo-internal setup detail. mutsu has a single native `elems` implementation per type, so matching the exact count would require inventing per-type native method tables with Rakudo's exact multiplicity (a test-specific hardcode). Recorded as a §5-class blocker in `TODO_roast/S03.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)