### PR TITLE
fix(parser): sequence operator binds tighter than listop/call args (whatever.t 119)

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -67,7 +67,7 @@ pub(crate) use errors::{
     check_range_precedence_worry, conditional_precedence_too_loose_error, non_associative_error,
     non_associative_pair_error, non_list_associative_error, syntax_exception,
 };
-pub(crate) use list_infix::{list_infix_expr, sequence_expr};
+pub(crate) use list_infix::{list_infix_expr, sequence_expr, sequence_only_expr};
 pub(crate) use list_infix_loop::parse_list_infix_loop;
 pub(crate) use logic::{assign_not_expr_mode, or_expr_mode, or_expr_no_assign_mode};
 pub(crate) use logic2::{junctive_expr_mode, not_expr_mode, or_or_expr_mode};

--- a/src/parser/expr/precedence/list_infix.rs
+++ b/src/parser/expr/precedence/list_infix.rs
@@ -9,6 +9,51 @@ pub(crate) fn list_infix_expr(input: &str) -> PResult<'_, Expr> {
     Ok((rest, left))
 }
 
+/// Sequence (`...`, `...^`) ONLY — no list-infix (Z/X/meta/infix-func) loop.
+/// Used for an unparenthesized call / list-prefix argument, where a single
+/// argument may be a sequence (`none 2 ... 5` = `none(2 ... 5)`) but must NOT
+/// run the list-infix loop, which would misparse a trailing feed operator
+/// (`grep {...} ==> @b`) as part of the argument.
+pub(crate) fn sequence_only_expr(input: &str) -> PResult<'_, Expr> {
+    let (mut rest, mut left) = range_expr(input)?;
+    let mut current_assoc_key: Option<String> = None;
+    loop {
+        let (r, _) = ws(rest)?;
+        if let Some((r2, op, op_str)) = strip_sequence_op(r) {
+            if let Some(prev) = current_assoc_key.as_deref()
+                && prev != op_str
+            {
+                return Err(non_list_associative_error(prev, op_str));
+            }
+            let (r2, _) = ws(r2)?;
+            let (r2, mut right) =
+                comparison_expr_mode(r2, ExprMode::NoSequence).map_err(|err| {
+                    enrich_expected_error(
+                        err,
+                        format!("expected expression after '{op_str}'").as_str(),
+                        r2.len(),
+                    )
+                })?;
+            if contains_whatever(&right) && !matches!(right, Expr::Whatever) {
+                right = wrap_whatevercode(&right);
+            }
+            if contains_whatever(&left) && !matches!(left, Expr::Whatever) {
+                left = wrap_whatevercode(&left);
+            }
+            left = Expr::Binary {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            };
+            current_assoc_key = Some(op_str.to_string());
+            rest = r2;
+            continue;
+        }
+        break;
+    }
+    Ok((rest, left))
+}
+
 /// Sequence (..., ...^) and list-infix (Z, X, meta-ops, infix funcs).
 /// All have Raku precedence level f= (list associative).
 pub(crate) fn sequence_expr(input: &str) -> PResult<'_, Expr> {

--- a/src/parser/expr/precedence/logic2.rs
+++ b/src/parser/expr/precedence/logic2.rs
@@ -234,7 +234,15 @@ pub(crate) fn junctive_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Exp
     let next_fn: fn(&str) -> PResult<'_, Expr> = match mode {
         ExprMode::Full => sequence_expr,
         ExprMode::NoSequence => list_infix_expr,
-        ExprMode::NoSequenceNoFeed | ExprMode::ListopArg => range_expr,
+        // An (unparenthesized) call / list-prefix argument binds the sequence
+        // operator TIGHTER than the comma that separates arguments, so
+        // `none 2 ... 5` is `none(2 ... 5)`, NOT `(none 2) ... 5`. Route the
+        // call-arg mode through `sequence_only_expr` so `...`/`...^` are consumed
+        // inside the argument; comma and the feed operators stay outside. It
+        // deliberately skips the list-infix loop (which would misparse a trailing
+        // `==> @b` feed as part of the argument).
+        ExprMode::NoSequenceNoFeed => sequence_only_expr,
+        ExprMode::ListopArg => range_expr,
     };
     let (mut rest, mut left) = next_fn(input)?;
     let mut last_junction: Option<JunctionInfixOp> = None;

--- a/t/listop-arg-sequence-precedence.t
+++ b/t/listop-arg-sequence-precedence.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# A list-prefix / unparenthesized-call argument binds the sequence operator
+# (`...`/`...^`) TIGHTER than the comma that separates arguments, so
+# `none 2 ... 5` is `none(2 ... 5)`, not `(none 2) ... 5`. Previously mutsu
+# parsed the sequence OUTSIDE the listop (giving `(none(2) 1 2 3 4 5)`).
+# (roast/S02-types/whatever.t "no issues with //= and WhateverCode".)
+
+plan 7;
+
+is (none 2 ... 5).^name, 'Junction', 'none SEQ is a Junction, not a Seq';
+is-deeply (none 2 ... 5), none(2, 3, 4, 5), 'none 2 ... 5 == none(2 ... 5)';
+ok (7 %% none 2 ... 5), '7 is divisible by none of 2..5';
+nok (6 %% none 2 ... 5), '6 IS divisible by one of 2..5';
+
+is (any 1 ... 3).^name, 'Junction', 'any SEQ is a Junction';
+
+# The prime-sieve idiom from the roast test.
+{
+    my @isprime = False, False;
+    my @r = (for 1 .. 10 -> $i {
+        $i if @isprime[$i] //= so $i %% none 2 ...^ * > $i.sqrt.floor;
+    });
+    is-deeply @r, [2, 3, 5, 7], '//= with WhateverCode-terminated none-sequence';
+}
+
+# A trailing feed operator still binds OUTSIDE the listop argument.
+{
+    my @a = 1 .. 4;
+    my @b;
+    @a ==> grep { $_ %% 2 } ==> @b;
+    is-deeply @b, [2, 4], 'feed after a listop-with-block still parses outside the arg';
+}


### PR DESCRIPTION
## Summary
Fixes `roast/S02-types/whatever.t` test 119 ("no issues with //= and WhateverCode"). An unparenthesized call / list-prefix argument binds the sequence operator (`...`/`...^`) **tighter** than the comma separating arguments, so `none 2 ... 5` is `none(2 ... 5)`, not `(none 2) ... 5`. mutsu parsed the sequence *outside* the listop — `none 2 ... 5` gave `(none(2) 1 2 3 4 5)` — which broke the prime-sieve idiom `$i %% none 2 ...^ * > $i.sqrt.floor`.

The call-arg mode (`NoSequenceNoFeed`) now routes through a new `sequence_only_expr` that consumes `...`/`...^` but deliberately **skips the list-infix (Z/X/meta/infix-func) loop** — running that loop would misparse a trailing feed operator (`grep { ... } ==> @b`) as part of the argument. Comma and feed still bind outside the argument.

## Test plan
- New `t/listop-arg-sequence-precedence.t` (7) — PASS.
- `roast/S02-types/whatever.t` test 119 now passes.
- `make test` — green (13806 tests).
- Regression: S03-sequence/*, S03-metaops/{cross,zip}, S03-junctions/misc, S32-list/{grep,map,first}, S03-feeds/basic — all PASS.
- CI runs `make test` + `make roast`.

## Remaining whatever.t failures (documented in TODO_roast/S02.md)
111 (container identity through smartmatch→Code), 120 (`use fatal` curry), 121 (parenthesized `(*)` de-prime), 124 (regex `/<$_>/` curry), 126 (call-arg Whatever over-currying). Next up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)