### PR TITLE
fix(smartmatch): a Whatever RHS value smartmatches to True (whatever.t 121)

### DIFF
--- a/src/parser/expr/precedence/comparison.rs
+++ b/src/parser/expr/precedence/comparison.rs
@@ -221,6 +221,10 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
     if let Some((op, len)) = parse_comparison_op(r) {
         let r = &r[len..];
         let (r, _) = ws(r)?;
+        // Start of the (whitespace-trimmed) RHS input — used below to tell a bare
+        // `*` operand (`X ~~ *`, which autoprimes to a WhateverCode) apart from a
+        // parenthesized `(*)` (a Whatever *value*, which smartmatches to True).
+        let rhs_start = r;
         // Track whether the smartmatch RHS is a regex literal.  When it is,
         // chaining with subsequent comparison operators (eq, ==, …) must be
         // suppressed because the regex literal terminates the smartmatch RHS
@@ -311,6 +315,31 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                         left: Box::new(Expr::Var("_".to_string())),
                         op: op.token_kind(),
                         right: Box::new(right),
+                    };
+                    return Ok((
+                        r,
+                        Expr::Lambda {
+                            param: "_".to_string(),
+                            body: vec![crate::ast::Stmt::Expr(sm_expr)],
+                            is_whatever_code: true,
+                        },
+                    ));
+                }
+            }
+            // Bare `X ~~ *` autoprimes to a WhateverCode `-> $a { X ~~ $a }`.
+            // A parenthesized `X ~~ (*)` (or a variable holding a Whatever) is a
+            // Whatever *value* and must smartmatch to True instead — those keep
+            // `Expr::Whatever` as the RHS and reach the runtime smartmatch, which
+            // returns True for a Whatever RHS. We distinguish the two the same way
+            // as the LHS: a true bare `*` operand's consumed text does not start
+            // with `(`.
+            if matches!(&right, Expr::Whatever) {
+                let rhs_text = rhs_start[..rhs_start.len() - r.len()].trim_start();
+                if !rhs_text.starts_with('(') {
+                    let sm_expr = Expr::Binary {
+                        left: Box::new(left),
+                        op: op.token_kind(),
+                        right: Box::new(Expr::Var("_".to_string())),
                     };
                     return Ok((
                         r,

--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -187,35 +187,14 @@ impl Interpreter {
         right: Value,
         rhs_is_match_regex: bool,
     ) -> Result<Value, RuntimeError> {
-        // When RHS is Whatever, autoprime: return a WhateverCode that takes
-        // one argument and smartmatches LHS against it.
-        // In Raku, `$x ~~ *` produces `-> $a { $x ~~ $a }`.
-        if matches!(&right, Value::Whatever) {
-            use crate::ast::{Expr, Stmt};
-            use crate::env::Env;
-            let mut env = Env::new();
-            env.insert(
-                "__mutsu_callable_type".to_string(),
-                Value::str_from("WhateverCode"),
-            );
-            // Capture the LHS value in the closure environment
-            env.insert("__wc_sm_lhs".to_string(), left);
-            let param = "__wc_0".to_string();
-            let body = vec![Stmt::Expr(Expr::Binary {
-                left: Box::new(Expr::Var("__wc_sm_lhs".to_string())),
-                op: crate::token_kind::TokenKind::SmartMatch,
-                right: Box::new(Expr::Var(param.clone())),
-            })];
-            return Ok(Value::make_sub(
-                Symbol::intern("GLOBAL"),
-                Symbol::intern("<whatevercode-smartmatch>"),
-                vec![param],
-                Vec::new(),
-                body,
-                false,
-                env,
-            ));
-        }
+        // A Whatever *value* on the RHS smartmatches to True (`X ~~ *` is always
+        // True per Whatever's ACCEPTS). The autoprime of a *syntactic* bare `*`
+        // (`$x ~~ *` → `-> $a { $x ~~ $a }`) is handled at parse time in the
+        // precedence parser, which can tell a bare `*` from a parenthesized `(*)`
+        // / a variable holding a Whatever — those reach here as a Whatever value
+        // and must be True, not re-primed. So do NOT autoprime here; fall through
+        // to `vm_smart_match`, whose `pure_smart_match((_, Whatever)) => true`
+        // arm returns True.
         let is_regex = matches!(
             &right,
             Value::Regex(_)

--- a/t/smartmatch-whatever-value.t
+++ b/t/smartmatch-whatever-value.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# A Whatever *value* on the RHS of `~~` smartmatches to True (`X ~~ *` is always
+# True per Whatever's ACCEPTS). A *syntactic* bare `*` autoprimes to a
+# WhateverCode. mutsu previously autoprimed a Whatever value at runtime, so a
+# parenthesized `(*)` or a variable holding a Whatever wrongly produced a
+# WhateverCode instead of True. (roast/S02-types/whatever.t
+# "Mu:U smartmatches as True with Whatever".)
+
+plan 9;
+
+# Parenthesized `(*)` is a Whatever value -> smartmatch is True.
+is-deeply (Mu ~~ (*)), True, 'Mu ~~ (*) is True';
+is-deeply (42 ~~ (*)), True, 'Int ~~ (*) is True';
+is-deeply ("x" ~~ (*)), True, 'Str ~~ (*) is True';
+
+# A variable holding a Whatever value -> smartmatch is True.
+{
+    my $w = *;
+    is-deeply (42 ~~ $w), True, 'value ~~ $whatever-var is True';
+    is-deeply (Mu ~~ $w), True, 'Mu ~~ $whatever-var is True';
+}
+
+# A *bare* `*` on the RHS still autoprimes to a WhateverCode.
+ok (42 ~~ *) ~~ WhateverCode, 'bare X ~~ * autoprimes to a WhateverCode';
+is (42 ~~ *)(42), True, 'the autoprimed WhateverCode smartmatches its arg';
+
+# A WhateverCode RHS is still invoked (not treated as a Whatever value).
+is-deeply (5 ~~ (* > 3)), True, 'X ~~ (WhateverCode) invokes it (true)';
+is-deeply (2 ~~ (* > 3)), False, 'X ~~ (WhateverCode) invokes it (false)';


### PR DESCRIPTION
## Summary
Fixes `roast/S02-types/whatever.t` test 121 ("Mu:U smartmatches as True with Whatever"). `X ~~ *` where the `*` is a Whatever **value** — a parenthesized `(*)`, or a variable holding a Whatever — must smartmatch to **True** (Whatever's `ACCEPTS` is always True). mutsu autoprimed *any* `Value::Whatever` RHS at runtime into a WhateverCode, so `Mu ~~ (*)` wrongly produced a WhateverCode.

The autoprime of a *syntactic* bare `*` (`$x ~~ *` → `-> $a { $x ~~ $a }`) now happens at **parse time** in the precedence parser, which already distinguishes a bare `*` operand from a parenthesized `(*)` for the LHS — this adds the same span check for the RHS. With the bare case handled at parse time, the runtime `smart_match_op` no longer autoprimes a Whatever RHS and falls through to `pure_smart_match((_, Whatever)) => true`.

## Test plan
- New `t/smartmatch-whatever-value.t` (9) — PASS.
- `roast/S02-types/whatever.t` test 121 now passes.
- `make test` — green (13806 tests).
- All whitelisted `roast/S03-smartmatch/*` tests (incl. `disorganized.t`'s `("foo" ~~ *) ~~ WhateverCode`) — PASS.
- CI runs `make test` + `make roast`.

## Remaining whatever.t failures (TODO_roast/S02.md)
111 (container identity through smartmatch→Code), 120 (`use fatal` curry), 124 (regex `/<$_>/` curry), 126 (call-arg Whatever over-currying). Next up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)