### PR TITLE
fix(whatevercode): a Whatever call argument is a value, not a curry placeholder (whatever.t 126)

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -467,13 +467,22 @@
       `zip` Call form).
     - Tests 108-109: `*++`/`++*` WhateverCode with rw parameters
     - Test 110: `*(42)` should throw X::Method::NotFound
-    - Test 111: Code.ACCEPTS does not preserve container (`=:=`)
+    - Test 111: **STILL FAILS — deep.** `$foo ~~ (* =:= $foo)` must preserve the
+      LHS *container* so `$_ =:= $foo` is True. The RHS WhateverCode invoked
+      directly (`$wc($foo)`) IS True (its `is raw` param aliases $foo's
+      container), but the smartmatch passes the LHS *by value*: the compiler
+      emits `SmartMatchExpr` after `compile_expr(left)`, which pushes the
+      variable's VALUE, not its ContainerRef; the Sub-RHS arm of `smart_match`
+      (seq_helpers/smart_match.rs ~91) then calls the code with `left.clone()` (a
+      fresh value), so `=:=` sees a different container. Fixing needs the
+      smartmatch to pass the LHS variable's container to a Code RHS (container-
+      passing infra through the smartmatch op).
     - Test 115: is_run no-warning check for WhateverCode passed as arg
-    - Test 119: `none 2 ...^ * > expr` precedence (none as list prefix vs sequence op)
-    - Test 121: `Mu ~~ (*)` should return True (parenthesized Whatever is a value →
-      ACCEPTS → True), but bare `Mu ~~ *` autoprimes to a WhateverCode. The VM
-      autoprime (`smart_match_op` in vm_helpers.rs) keys on `Value::Whatever`, so both
-      forms look identical at runtime — needs a parse-time marker for parenthesized `(*)`.
+    - Test 119: `none 2 ...^ * > expr` precedence — **DONE (#4042)**. A listop/call
+      argument now binds `...`/`...^` tighter than the comma via `sequence_only_expr`.
+    - Test 121: `Mu ~~ (*)` — **DONE (#4043)**. A Whatever *value* RHS smartmatches
+      to True; the bare-`*` autoprime moved to parse time (span check distinguishes
+      `*` from `(*)`), so the runtime no longer autoprimes a Whatever value.
     - Tests 125: chained-comparison Whatever-curry (`1 < *+1 < 5`, `22 + *.flip < *² ... < *`)
       — DONE. The chain expands to `(a OP m) && (m OP b)`; count_whatever/replace_whatever_numbered
       now dedup the structurally-equal shared middle `m` so arity = number of distinct
@@ -489,10 +498,28 @@
       via smartmatch `value ~~ PRED` (methods_object_attr_constraints.rs) so a
       Junction predicate (`where 42|3`) threads instead of being (wrongly)
       *called*. Tests t/is-default-where-expr.t.
-    - Test 124: regex whatever curry (`* ~~ /<$_>/` with in-regex `{...}` blocks,
-      `<?{...}>`/`<!{...}>` assertions) — still fails; deep regex-curry work.
-    - Tests 126, 128-131: depend on regex `/<$_>/` curry (124) and call-arg
-      Whatever over-currying (see 75-76: `$sub(*)` must be a Whatever *value*).
+    - Test 120: `use fatal` + WhateverCode curry — **STILL FAILS — deep.**
+      `use fatal; "a".map: *.Int` must throw X::Str::Numeric. `use fatal` DOES
+      work for a direct Failure (`use fatal; "a".Int` throws), but a Failure
+      produced *inside a `.map` block / Seq* (`"a".map({.Int})`, even `.eager`)
+      is NOT auto-thrown when the Seq is sunk in the fatal scope. Needs sink-
+      context fatal-Failure checking through a (lazy) map/Seq — the `use fatal`
+      lexical pragma must reach the element-producing block and the sink must
+      fatalize a contained Failure.
+    - Test 124: regex whatever curry — **STILL FAILS — deep.** The `* ~~ /<$_>/`
+      curry and single-statement `<?{...}>`/`<!{...}>` assertions all work; the
+      failure is that a `Test` call (`pass`/`ok`) INSIDE a `<?{...}>` code
+      assertion does not run and makes the assertion False. Root cause:
+      `eval_regex_code_assertion` (regex/regex_eval.rs ~190) evaluates the block
+      in a FRESH `Interpreter { env, ..Default::default() }`, which loses the TAP
+      state (counter / subtest stack / output sink), so `pass`/`ok` cannot emit to
+      the enclosing subtest and the block errors → False. The regex match is
+      `&self` throughout (regex_match_capture.rs:7), so fixing needs either
+      `&mut self` threaded through the matcher or the TAP state shared into the
+      scratch interpreter (interior mutability) — a substantial regex-engine change.
+    - Tests 126: call-arg Whatever over-currying — **DONE (#4044)**. `$sub(*)` is a
+      Whatever value; `count_whatever`/`replace_whatever_*` now inspect the CallOn
+      target only. Tests 128-131 still depend on 124 (regex `/<$_>/` curry).
     - Tests 42, 114, 117 also fail on raku (todo'd)
 - [ ] roast/S02-types/WHICH.t
   - 1652/1657 pass. Remaining: Nil.raku/gist returns "(Any)" instead of "Nil" (mutsu uses Value::Nil for both Nil and uninitialized Any); subtest using EVAL/start/supply not implemented

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -331,8 +331,13 @@ pub(crate) fn count_whatever(expr: &Expr) -> usize {
         Expr::MethodCall { target, .. } | Expr::DynamicMethodCall { target, .. } => {
             count_whatever(target)
         }
-        Expr::CallOn { target, args } => {
-            count_whatever(target) + args.iter().map(count_whatever).sum::<usize>()
+        Expr::CallOn { target, .. } => {
+            // Only the *target* of an invocation curries. A Whatever passed as a
+            // call *argument* (`$sub(*)`, `&infix:<+>(*, 42)`) is a Whatever value
+            // handed to the callee, NOT a placeholder of the enclosing
+            // WhateverCode — so it must not add to the arity. This mirrors
+            // `contains_whatever`, which already only inspects the target.
+            count_whatever(target)
         }
         // Only check target, not index (subscript handles its own WhateverCode)
         Expr::Index { target, .. } => count_whatever(target),

--- a/src/parser/expr/whatever_replace.rs
+++ b/src/parser/expr/whatever_replace.rs
@@ -138,12 +138,12 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
             args: args.clone(),
             modifier: *modifier,
         },
+        // Only the *target* of an invocation curries; a Whatever passed as a call
+        // *argument* stays a Whatever value (see `count_whatever`/`contains_whatever`),
+        // so the args are left untouched rather than replaced by numbered params.
         Expr::CallOn { target, args } => Expr::CallOn {
             target: Box::new(replace_whatever_numbered(target, counter)),
-            args: args
-                .iter()
-                .map(|a| replace_whatever_numbered(a, counter))
-                .collect(),
+            args: args.clone(),
         },
         Expr::Index {
             target,
@@ -312,9 +312,10 @@ pub(crate) fn replace_whatever_single(expr: &Expr) -> Expr {
             args: args.clone(),
             modifier: *modifier,
         },
+        // Only the target curries; a Whatever call *argument* stays a value.
         Expr::CallOn { target, args } => Expr::CallOn {
             target: Box::new(replace_whatever_single(target)),
-            args: args.iter().map(replace_whatever_single).collect(),
+            args: args.clone(),
         },
         Expr::Index {
             target,

--- a/t/whatevercode-call-arg-value.t
+++ b/t/whatevercode-call-arg-value.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# Only the *target* of an invocation curries into a WhateverCode. A Whatever
+# passed as a call *argument* (`$sub(*)`, `&infix:<+>(*, 42)`) is a Whatever
+# VALUE handed to the callee, not a placeholder of the enclosing WhateverCode,
+# so it must not add to the WhateverCode's arity. mutsu previously counted such
+# argument `*`s as placeholders (`(* + $b(*) + *.flip)` wanted 3 args, not 2).
+# (roast/S02-types/whatever.t "various wild cases".)
+
+plan 5;
+
+my $b = sub (Whatever) { 100 };
+
+# `$b(*)` passes Whatever to $b (returns 100); the outer WhateverCode has 2
+# placeholders (`*` and `*.flip`), taking 2 args.
+is (* + $b(*) + *.flip)(5, 13), 5 + 100 + 31, 'call-arg Whatever is a value, not a placeholder';
+
+# A single placeholder plus a call-arg Whatever -> 1-arg WhateverCode.
+is (* + $b(*))(7), 7 + 100, 'one placeholder + call-arg Whatever = 1 arg';
+
+# The wild-cases line from the roast test.
+is-deeply (* + 42 + $b(*) + *.flip + *.flip²)(5, 17, 13), 1179, 'wild multi-arg case';
+
+# `*.flip` still curries normally (target contains Whatever).
+is (*.flip)('123'), '321', 'method curry on Whatever still works';
+
+# A curried target invoked with a plain arg still curries the target only.
+is (*²)(3), 9, 'exponent curry target invoked with plain arg';


### PR DESCRIPTION
## Summary
Fixes `roast/S02-types/whatever.t` test 126 ("various wild cases"). Only the **target** of an invocation curries into a WhateverCode. A Whatever passed as a call **argument** (`$sub(*)`, `&infix:<+>(*, 42)`) is a Whatever **value** handed to the callee, not a placeholder of the enclosing WhateverCode.

`contains_whatever` already inspected only a `CallOn`'s target, but `count_whatever` and `replace_whatever_numbered`/`replace_whatever_single` also processed the args — so `(* + $b(*) + *.flip)` counted 3 placeholders and demanded 3 arguments instead of 2. All three now inspect the target only, leaving argument Whatevers as values.

## Test plan
- New `t/whatevercode-call-arg-value.t` (5) — PASS.
- `roast/S02-types/whatever.t` test 126 now passes (and 12/44-53/112-129 nested-curry tests still pass).
- `make test` — green (13813 tests).
- Regression: S32-list/{map,grep}, S03-metaops/{cross,reduce}, S32-list/reduce — all PASS.
- CI runs `make test` + `make roast`.

## Remaining whatever.t failures (TODO_roast/S02.md)
111 (container identity through smartmatch→Code), 120 (`use fatal` curry Failure), 124 (regex `/<$_>/` curry). Note: 121 was fixed in #4043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)