### PR TITLE
fix(multi): OTF-compile state-bearing multi candidates and caching-proto bodies

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,28 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-02: §2 D — `state` を持つ multi 候補 / caching-proto body の OTF 化（#4047）
+
+GC 前の地ならし（PLAN §2 D、multi-dispatch の tree-walk fallback 除去）の一環。`state` を宣言する
+multi 候補（および caching-proto body `proto cached($a){ state %cache; %cache{$a} //= {*} }`）が、
+「OTF-compile すると `state` cell の同一性を失う」という前提で tree-walk interpreter fallback に
+強制されていた。実際には失われない: `otf_compile_cache`（fingerprint+package keyed）が候補ごとに
+安定した compiled body を返すため、`state` key（`__state_{pkg}::{$var}@{ip}`、compiled opcode 位置を
+埋め込む）は call 間で安定し、候補の `/n`-suffixed package が distinct 候補の `state` cell を分離する。
+
+4 つの multi-candidate OTF fork と非-trivial-proto-body fork から `function_body_declares_state`
+除外を撤去。これは **fallback 除去に加えて correctness bug も修正**する: tree-walk fallback は
+distinct な同名候補（`multi f(Int){state $c} multi f(Str){state $c}`）で `state` cell を共有しており、
+proto 経由だと `1,2,3,4,5`（誤）を返していた（正 = `1,2,1,2,3`）。
+
+interpreter に残す境界は signature **alternates**（`multi f(A) | (B) { state $c }`）のみ: これは 1 つの
+routine で `state` を全 alternate に共有する（compile 時の state_group）。alternates は body 同一の別々の
+候補として登録されるため、per-alternate body fingerprint で keying する OTF は共有を分裂させてしまう。
+resolved な per-candidate `FunctionDef` は alternate marker を持たないので、登録時に
+`multi_alternate_signature_names`（`FxHashSet<Symbol>`）へ記録し、新しい
+`multi_candidate_state_forces_interpreter` gate が参照する。pin: `t/multi-candidate-state-otf.t`（OTF の勝ち筋）
+＋ 既存 `t/multi-signature-alternates.t`（alternate 共有）。
+
 ## 2026-07-01: dispatch cluster — `wrap.t` / `dispatching.t` 完了（whitelist 追加）
 
 - **`S06-advanced/wrap.t`**（90/90、#3973 で 7 ブロッカー解消、#3981 で仕上げ）: 候補選択が multi-method の

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1580,6 +1580,14 @@ pub struct Interpreter {
     /// Structural (registry-shape) only, so it is sound to key on `(class, method)`
     /// and is cleared with the other method caches on any registry change.
     pub(crate) dispatch_multi_candidate: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
+    /// Sub names declared with signature *alternates* (`multi f(A) | (B) {...}`).
+    /// Such a routine's `state` cell is shared across all its alternates via a
+    /// compile-time state_group; the OTF-compile path fragments that sharing (each
+    /// alternate compiles to its own body + `state` key), so a state-bearing
+    /// candidate of such a name must stay on the interpreter. Tracked at
+    /// registration because the resolved per-candidate `FunctionDef` carries no
+    /// alternate marker. See `multi_candidate_state_forces_interpreter`.
+    pub(crate) multi_alternate_signature_names: rustc_hash::FxHashSet<Symbol>,
     /// Memoized structural fingerprint of a method body, keyed by the *pointer*
     /// of its `Arc<Vec<Stmt>>` body. `function_body_fingerprint` Debug-traverses
     /// the whole body AST, which dominated the method-redispatch hot path

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2120,6 +2120,7 @@ impl Interpreter {
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
+            multi_alternate_signature_names: rustc_hash::FxHashSet::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_def_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -352,6 +352,7 @@ impl Interpreter {
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
+            multi_alternate_signature_names: self.multi_alternate_signature_names.clone(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_def_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -730,7 +730,7 @@ impl Interpreter {
             if !self.is_interpreter_handled_function(&name)
                 && let Some(def) = loan_env!(self, resolve_function_with_types(&name, &args))
                 && Self::def_is_otf_compilable_multi_candidate(&def)
-                && !Self::function_body_declares_state(&def.body)
+                && !self.multi_candidate_state_forces_interpreter(&name, &def)
             {
                 let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
                 self.stack.push(result);
@@ -1127,7 +1127,7 @@ impl Interpreter {
                         // single/builtin-shadow paths). See
                         // `def_is_otf_compilable_multi_candidate`.
                         && Self::def_is_otf_compilable_multi_candidate(&def)
-                        && !Self::function_body_declares_state(&def.body)
+                        && !self.multi_candidate_state_forces_interpreter(name, &def)
                     {
                         self.compile_and_call_function_def(&def, args, compiled_fns)
                     } else {
@@ -1344,7 +1344,7 @@ impl Interpreter {
         // default param is safe to OTF here — see
         // `def_is_otf_compilable_multi_candidate`.
         if !Self::def_is_otf_compilable_multi_candidate(&def)
-            || Self::function_body_declares_state(&def.body)
+            || self.multi_candidate_state_forces_interpreter(name, &def)
         {
             return None;
         }
@@ -1400,12 +1400,20 @@ impl Interpreter {
         }
         // Rewrite `{*}` -> `__PROTO_DISPATCH__()` and require the resulting body +
         // the proto's own signature to be OTF-compilable. `state` in the proto body
-        // would break the body-fingerprint state cache, so exclude it too.
+        // (the caching-proto pattern `proto cached($a) { state %cache; ... {*} }`) is
+        // NOT excluded for a single-signature proto: `otf_compile_function_def`
+        // caches the compiled proto body by fingerprint+package, so its `state` key
+        // (which embeds the compiled opcode position) is stable across calls, and the
+        // proto's `/n`-suffixed package keeps it distinct from any candidate's own
+        // `state`. The persisted state cell therefore survives call-to-call exactly
+        // as the interpreter's does. A proto with signature *alternates* + `state`
+        // stays on the interpreter (see `multi_candidate_state_forces_interpreter`):
+        // its shared-across-alternates cell would fragment per compiled body.
         let rewritten = crate::runtime::Interpreter::rewrite_proto_dispatch_stmts(&proto.body);
         let mut proto_def = proto.clone();
         proto_def.body = rewritten;
         if !Self::def_is_otf_compilable(&proto_def)
-            || Self::function_body_declares_state(&proto_def.body)
+            || self.multi_candidate_state_forces_interpreter(name, &proto_def)
         {
             return None;
         }
@@ -1491,7 +1499,7 @@ impl Interpreter {
             // the non-default ones already are. Permit defaults (see
             // `def_is_otf_compilable_multi_candidate`).
             && Self::def_is_otf_compilable_multi_candidate(&def)
-            && !Self::function_body_declares_state(&def.body)
+            && !self.multi_candidate_state_forces_interpreter(&proto_name, &def)
         {
             // pending_call_arg_sources is still set (resolution only reads it);
             // `compile_and_call_function_def`'s bind consumes it for the rw chain.
@@ -1808,17 +1816,42 @@ impl Interpreter {
     }
 
     /// True if the body declares a `state` variable anywhere (recursing through
-    /// nested blocks). A multi candidate whose body uses `state` must NOT be
-    /// OTF-compiled in the multi fork: signature alternates
-    /// `(A) | (B) { state $x }` share one state cell via a compile-time
-    /// state_group, but the OTF cache keys on the body fingerprint (which
-    /// includes the per-alternate signature), so each alternate would get its
-    /// own state and the sharing would break. Keep those on the interpreter,
-    /// which honors the shared state_group. (Single-candidate OTF subs are
-    /// unaffected — their fingerprint is stable across calls — but excluding any
-    /// state-bearing multi body is the safe, simple guard.)
+    /// nested blocks).
     pub(super) fn function_body_declares_state(body: &[crate::ast::Stmt]) -> bool {
         body.iter().any(Self::stmt_declares_state)
+    }
+
+    /// Whether a resolved multi candidate's `state` usage forces it back onto the
+    /// interpreter instead of OTF-compiling it.
+    ///
+    /// A plain single-signature candidate with `state` is fine to OTF: the
+    /// per-candidate `otf_compile_cache` gives it a stable compiled body (so its
+    /// `state` key, which embeds the compiled opcode position, is stable across
+    /// calls), and the candidate's `/n`-suffixed package keeps distinct
+    /// candidates' `state` cells apart. This is strictly more correct than the
+    /// interpreter fallback, which shared one cell between two distinct
+    /// same-named candidates (`multi f(Int){state $c} multi f(Str){state $c}`).
+    ///
+    /// The one case that MUST stay on the interpreter is a candidate of a name
+    /// declared with signature *alternates* — `multi f(A $x) | (B $x) { state $c }`
+    /// is ONE routine whose `state` cell is shared across both alternates via a
+    /// compile-time state_group. The alternates register as separate candidates
+    /// with identical bodies, and the OTF cache keys on the body fingerprint
+    /// (which includes the per-alternate signature), so each alternate would get
+    /// its own compiled body and its own `state` cell, breaking the sharing the
+    /// interpreter honors (t/multi-signature-alternates.t). The resolved
+    /// per-candidate `FunctionDef` carries no alternate marker, so we consult the
+    /// `multi_alternate_signature_names` set recorded at registration.
+    pub(super) fn multi_candidate_state_forces_interpreter(
+        &self,
+        name: &str,
+        def: &crate::ast::FunctionDef,
+    ) -> bool {
+        !self.multi_alternate_signature_names.is_empty()
+            && Self::function_body_declares_state(&def.body)
+            && self
+                .multi_alternate_signature_names
+                .contains(&Symbol::intern(name))
     }
 
     fn stmt_declares_state(stmt: &crate::ast::Stmt) -> bool {

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -224,6 +224,16 @@ impl Interpreter {
                         self.record_exported_sub_value(pkg, resolved_name.clone(), val.clone());
                     }
                 }
+                if !signature_alternates.is_empty() {
+                    // Remember that this name was declared with signature alternates,
+                    // whose `state` cell is shared across all alternates. A resolved
+                    // per-candidate `FunctionDef` carries no alternate marker, so the
+                    // OTF-dispatch gate consults this set to keep state-bearing
+                    // candidates of such a name on the interpreter (which honors the
+                    // shared cell). See `multi_candidate_state_forces_interpreter`.
+                    self.multi_alternate_signature_names
+                        .insert(Symbol::intern(&resolved_name));
+                }
                 for (alt_params, alt_param_defs) in signature_alternates {
                     self.loan_env_for(|i| {
                         i.register_sub_decl(

--- a/t/multi-candidate-state-otf.t
+++ b/t/multi-candidate-state-otf.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A multi candidate (or a proto body) that declares `state` used to be forced
+# onto the tree-walk interpreter fallback, because the OTF-compiled candidate
+# was assumed to lose its `state` cell identity. It does not: the per-candidate
+# `otf_compile_cache` gives each candidate a stable compiled body (stable state
+# key), and the candidate's `/n`-suffixed package keeps distinct candidates'
+# `state` cells apart. Removing that exclusion both drops the fallback and fixes
+# a real bug: the tree-walk fallback shared one `state` cell between two
+# candidates that used the same `state` variable name.
+
+plan 6;
+
+# Two proto'd multi candidates, each with its OWN `state $c` under the SAME name.
+# The interpreter fallback wrongly shared one cell (produced 1,2,3,4,5); the
+# compiled path keeps them separate.
+{
+    proto f(|) {*}
+    multi f(Int $n) { state $c = 0; $c++; "i:$c" }
+    multi f(Str $s) { state $c = 0; $c++; "s:$c" }
+    is f(1),   "i:1", "Int candidate state starts at 1";
+    is f(2),   "i:2", "Int candidate state increments independently";
+    is f("a"), "s:1", "Str candidate state is isolated (not shared with Int)";
+    is f("b"), "s:2", "Str candidate state increments independently";
+}
+
+# The caching-proto pattern: `state` lives in the proto body, `{*}` redispatches
+# to the candidate only on a cache miss.
+{
+    my $called = "";
+    proto cached($a) { state %cache; %cache{$a} //= {*} }
+    multi cached($a) { $called ~= $a; $a x 2 }
+    is cached("a"), "aa", "caching proto returns candidate result";
+    cached("b");
+    cached("a");   # cache hit: candidate must NOT run again
+    is $called, "ab", "cached value did not cause an extra candidate call";
+}


### PR DESCRIPTION
## Summary

Part of PLAN.md §2 D — removing multi-dispatch tree-walk fallbacks ahead of GC (the "GC 前の地ならし" campaign).

A multi candidate (or a caching-proto body) that declared `state` was forced onto the tree-walk interpreter fallback, on the assumption that an OTF-compiled candidate would lose its `state` cell identity. **It does not:** `otf_compile_cache` gives each candidate a stable compiled body (so its `state` key, which embeds the compiled opcode position, is stable across calls), and the candidate's `/n`-suffixed package keeps distinct candidates' `state` cells apart.

Removing the blanket `function_body_declares_state` exclusion from the four multi-candidate OTF forks and the non-trivial-proto-body fork both:

1. **Drops the fallback** — `proto f + multi f(...){state...}` and the caching-proto pattern (`proto cached($a){ state %cache; %cache{$a} //= {*} }`) now run as compiled bytecode (0 interpreter fallbacks, verified with `MUTSU_VM_STATS=1`).
2. **Fixes a real correctness bug** — the tree-walk fallback shared ONE `state` cell between two *distinct* same-named candidates: `multi f(Int){state $c} multi f(Str){state $c}` reached via a proto produced `1,2,3,4,5` instead of the correct `1,2,1,2,3`. The compiled path keeps them isolated.

## The boundary that must stay on the interpreter

A candidate of a name declared with signature **alternates** — `multi f(A) | (B) { state $c }` — is ONE routine whose `state` cell is shared across all alternates via a compile-time `state_group`. The OTF path keys on the per-alternate body fingerprint, so it would fragment that sharing. The resolved per-candidate `FunctionDef` carries no alternate marker, so a new `multi_alternate_signature_names` set is recorded at registration and consulted by the new `multi_candidate_state_forces_interpreter` gate. (An earlier revision that dropped this exclusion regressed `t/multi-signature-alternates.t`; the set-based gate restores it.)

## Tests

- `t/multi-candidate-state-otf.t` (new) — pins the two OTF wins (distinct-candidate `state` isolation + caching-proto `state`).
- `t/multi-signature-alternates.t` — continues to pin the shared-alternate-state case.
- `make test` (1425 files, 13838 tests) PASS; clippy clean; whitelisted S04/S06-multi roast tests PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)