### PR TITLE
refactor(error): box RuntimeError cold fields (272→120 B), drop 51 result_large_err allows

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Arithmetic operator implementations: facade re-exporting themed submodules.
 //!
 //! Split from the original monolithic `arith.rs`. Each submodule owns a

--- a/src/builtins/arith/add_sub.rs
+++ b/src/builtins/arith/add_sub.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Addition and subtraction arithmetic operators.
 
 use super::range::{mixin_range_arith, mixin_range_arith_val, range_offset};

--- a/src/builtins/arith/mul_div_mod.rs
+++ b/src/builtins/arith/mul_div_mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Multiplication, division, and modulo arithmetic operators.
 
 use super::range::{mixin_range_arith, mixin_range_arith_val, range_divide, range_scale};

--- a/src/builtins/arith/pow_negate.rs
+++ b/src/builtins/arith/pow_negate.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Power (exponentiation) and unary negation operators.
 
 use super::rat::{bigint_ratio_to_f64, is_fat_rat_like, make_fat_rat};

--- a/src/builtins/arith/range.rs
+++ b/src/builtins/arith/range.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Range-arithmetic helpers: offset, scale, divide, and mixin-range wrappers.
 
 use crate::value::{RuntimeError, Value, make_rat};

--- a/src/builtins/arith/rat.rs
+++ b/src/builtins/arith/rat.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Rational-number and BigNum helper utilities used by arith ops.
 
 use crate::value::{Value, make_rat};

--- a/src/builtins/arith/temporal.rs
+++ b/src/builtins/arith/temporal.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 //! Date, Instant, and Duration arithmetic helpers.
 
 use super::rat::to_big_rat_parts;

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 mod dispatch_0arg;
 mod dispatch_1arg;
 mod dispatch_2arg;

--- a/src/builtins/functions/dispatch_0arg.rs
+++ b/src/builtins/functions/dispatch_0arg.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use super::time::builtin_times;
 use crate::builtins::rng::{builtin_rand, builtin_srand_auto};
 use crate::value::{RuntimeError, Value};

--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use super::flat::{deitemize_flat_operand, flat_val, is_infinite_range};
 use super::math::factorial_bigint;
 use super::uniparse::uniparse_impl;

--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use super::flat::join_flat;
 use super::math::is_extrema_named_pair;
 use crate::builtins::rng::builtin_rand;

--- a/src/builtins/functions/dispatch_3arg.rs
+++ b/src/builtins/functions/dispatch_3arg.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::value::{RuntimeError, Value};
 
 pub(crate) fn native_function_3arg(

--- a/src/builtins/functions/dispatch_variadic.rs
+++ b/src/builtins/functions/dispatch_variadic.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use super::dispatch_2arg::native_function_2arg;
 use super::flat::{deitemize_flat_operand, flat_val, is_infinite_range};
 use super::math::{gcd_u64, generic_range_as_bigint, is_extrema_named_pair};

--- a/src/builtins/functions/flat.rs
+++ b/src/builtins/functions/flat.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::value::{ArrayKind, Value};
 
 pub(crate) fn is_infinite_range(value: &Value) -> bool {

--- a/src/builtins/functions/junction.rs
+++ b/src/builtins/functions/junction.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::value::Value;
 
 /// Build a `Junction` for the `any`/`all`/`one`/`none` constructors.

--- a/src/builtins/functions/math.rs
+++ b/src/builtins/functions/math.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::value::Value;
 use num_bigint::BigInt as NumBigInt;
 

--- a/src/builtins/functions/sprintf_fmt.rs
+++ b/src/builtins/functions/sprintf_fmt.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::runtime;
 use crate::value::{RuntimeError, Value};
 

--- a/src/builtins/functions/time.rs
+++ b/src/builtins/functions/time.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::value::{ArrayKind, RuntimeError, Value};
 
 /// Perl 5-compatible `times` builtin: returns `($user, $system)` CPU times in seconds.

--- a/src/builtins/functions/uniparse.rs
+++ b/src/builtins/functions/uniparse.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 use std::collections::HashMap;

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::runtime;
 use crate::symbol::Symbol;
 use crate::value::{ArrayKind, EnumValue, RuntimeError, Value};

--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 use std::collections::HashMap;

--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use super::temporal::*;
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};

--- a/src/builtins/methods_narg/allomorph.rs
+++ b/src/builtins/methods_narg/allomorph.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::symbol::Symbol;
 use crate::value::Value;
 use num_traits::{ToPrimitive, Zero};

--- a/src/builtins/methods_narg/base.rs
+++ b/src/builtins/methods_narg/base.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::value::{RuntimeError, Value};
 use std::sync::Arc;
 

--- a/src/builtins/methods_narg/buf.rs
+++ b/src/builtins/methods_narg/buf.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 use num_bigint::BigInt;

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use super::allomorph::{allomorph_accepts, out_of_range_failure};
 use super::base::{
     BaseDigits, f64_to_rat, parse_radix_checked, range_pick_n_fast, rat_base_repeating, rat_to_base,

--- a/src/builtins/methods_narg/dispatch_2arg.rs
+++ b/src/builtins/methods_narg/dispatch_2arg.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use super::allomorph::out_of_range_failure;
 use super::base::{BaseDigits, f64_to_rat, rat_to_base};
 use super::buf::{

--- a/src/builtins/methods_narg/flatten.rs
+++ b/src/builtins/methods_narg/flatten.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::value::{ArrayKind, Value};
 use std::sync::Arc;
 

--- a/src/builtins/methods_narg/fmt_contains.rs
+++ b/src/builtins/methods_narg/fmt_contains.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use super::str_match::is_str_or_match_receiver;
 use crate::runtime;
 use crate::value::{RuntimeError, Value};

--- a/src/builtins/methods_narg/indent.rs
+++ b/src/builtins/methods_narg/indent.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::value::Value;
 use num_traits::ToPrimitive;
 

--- a/src/builtins/methods_narg/numeric.rs
+++ b/src/builtins/methods_narg/numeric.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::runtime;
 use crate::value::Value;
 use num_bigint::BigInt;

--- a/src/builtins/methods_narg/str_match.rs
+++ b/src/builtins/methods_narg/str_match.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::value::{RuntimeError, Value};
 
 pub(crate) fn is_str_or_match_receiver(target: &Value) -> bool {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 pub(crate) mod arith;
 pub(crate) mod buf_bits;
 pub(crate) mod buf_write_int;

--- a/src/builtins/parse_base.rs
+++ b/src/builtins/parse_base.rs
@@ -9,8 +9,6 @@
 //! - `X::Syntax::Number::RadixOutOfRange` when radix is not in 2..36
 //! - `X::Str::Numeric` for malformed input (with `source`, `pos`, `reason`)
 
-#![allow(clippy::result_large_err)]
-
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value, make_big_rat};
 use num_bigint::BigInt;

--- a/src/builtins/split.rs
+++ b/src/builtins/split.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 use std::sync::Arc;

--- a/src/doc_mode.rs
+++ b/src/doc_mode.rs
@@ -296,7 +296,6 @@ fn decode_named_entities(entity: &str) -> String {
         .collect()
 }
 
-#[allow(clippy::result_large_err)]
 fn validate_pod_blocks(source: &str) -> Result<(), RuntimeError> {
     let mut stack: Vec<String> = Vec::new();
 
@@ -347,7 +346,6 @@ fn validate_pod_blocks(source: &str) -> Result<(), RuntimeError> {
     Ok(())
 }
 
-#[allow(clippy::result_large_err)]
 fn run_doc_init_blocks(source: &str) -> Result<(String, i64, bool), RuntimeError> {
     let (stmts, _) = parse_dispatch::parse_source(source)?;
     // Filter out SetLine annotations for DOC INIT block detection
@@ -381,7 +379,6 @@ fn run_doc_init_blocks(source: &str) -> Result<(String, i64, bool), RuntimeError
     ))
 }
 
-#[allow(clippy::result_large_err)]
 pub fn run_doc_mode(source: &str) -> Result<DocModeResult, RuntimeError> {
     validate_pod_blocks(source)?;
     let (mut output, status, halted) = run_doc_init_blocks(source)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub fn dump_vm_stats() {
 }
 
 /// Parse source code and return a pretty-printed AST string.
-#[allow(clippy::result_large_err)]
 pub fn dump_ast(input: &str) -> Result<String, RuntimeError> {
     let (stmts, _) = parse_dispatch::parse_source(input)?;
     Ok(format!("{:#?}", stmts))

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,13 +95,13 @@ fn format_parse_error(err: &RuntimeError, source: &str, program_name: &str) -> S
     out.push_str(&short_msg);
     out.push('\n');
 
-    if let Some(line) = err.line {
+    if let Some(line) = err.line() {
         out.push_str(&format!("at {}:{}\n", program_name, line));
 
         let source_lines: Vec<&str> = source.lines().collect();
         if line >= 1 && line <= source_lines.len() {
             let src_line = source_lines[line - 1];
-            let col = err.column.unwrap_or(1);
+            let col = err.column().unwrap_or(1);
             let col_idx = col.saturating_sub(1).min(src_line.len());
             let before = &src_line[..col_idx];
             let after = &src_line[col_idx..];
@@ -111,7 +111,7 @@ fn format_parse_error(err: &RuntimeError, source: &str, program_name: &str) -> S
         }
     }
 
-    if let Some(hint) = &err.hint {
+    if let Some(hint) = err.hint() {
         out.push('\n');
         out.push_str(hint);
     }
@@ -122,32 +122,32 @@ fn format_parse_error(err: &RuntimeError, source: &str, program_name: &str) -> S
 fn print_error(prefix: &str, err: &RuntimeError, source: Option<&str>, program_name: Option<&str>) {
     // For runtime errors with a backtrace, use the Raku-style format:
     // message\n  in sub foo at file line N\n  in block <unit> at file line N
-    if err.backtrace.is_some() && err.code.is_none() {
+    if err.backtrace().is_some() && err.code().is_none() {
         eprintln!("{}", err.message);
-        if let Some(ref bt) = err.backtrace {
+        if let Some(bt) = err.backtrace() {
             eprintln!("{}", bt);
         }
         return;
     }
 
     // For parse errors with source context, show a nice snippet
-    if let (Some(code), Some(src), Some(name)) = (err.code, source, program_name)
+    if let (Some(code), Some(src), Some(name)) = (err.code(), source, program_name)
         && code.is_parse()
-        && err.line.is_some()
+        && err.line().is_some()
     {
         eprintln!("{}", format_parse_error(err, src, name));
         return;
     }
 
     eprintln!("{}: {}", prefix, err.message);
-    if let Some(line) = err.line {
-        if let Some(col) = err.column {
+    if let Some(line) = err.line() {
+        if let Some(col) = err.column() {
             eprintln!("  at line {}, column {}", line, col);
         } else {
             eprintln!("  at line {}", line);
         }
     }
-    if let Some(hint) = &err.hint {
+    if let Some(hint) = err.hint() {
         eprintln!("  hint: {}", hint);
     }
 }

--- a/src/parse_dispatch.rs
+++ b/src/parse_dispatch.rs
@@ -4,7 +4,6 @@ use crate::value::RuntimeError;
 
 /// Parse source code.
 /// Returns `(statements, Option<finish_content>)`.
-#[allow(clippy::result_large_err)]
 pub(crate) fn parse_source(input: &str) -> Result<(Vec<Stmt>, Option<String>), RuntimeError> {
     parser::parse_program(input)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -92,10 +92,10 @@ fn build_vcs_conflict_error(lines: &[i64]) -> RuntimeError {
     };
 
     let mut err = RuntimeError::new(PAYLOAD);
-    err.code = Some(RuntimeErrorCode::ParseGeneric);
+    err.set_code(Some(RuntimeErrorCode::ParseGeneric));
     if lines.len() <= 1 {
         let line = lines.first().copied().unwrap_or(1);
-        err.line = Some(line as usize);
+        err.set_line(Some(line as usize));
         err.exception = Some(Box::new(make_adhoc(line)));
         return err;
     }
@@ -108,7 +108,7 @@ fn build_vcs_conflict_error(lines: &[i64]) -> RuntimeError {
     group_attrs.insert("worries".to_string(), Value::array(vec![]));
     group_attrs.insert("panic".to_string(), panic);
     group_attrs.insert("message".to_string(), Value::str(PAYLOAD.to_string()));
-    err.line = Some(*panic_line as usize);
+    err.set_line(Some(*panic_line as usize));
     err.exception = Some(Box::new(Value::make_instance(
         crate::symbol::Symbol::intern("X::Comp::Group"),
         group_attrs,
@@ -205,14 +205,13 @@ fn parse_error_hint(message: &str) -> Option<&'static str> {
 
 fn with_parse_hint(mut err: RuntimeError) -> RuntimeError {
     if let Some(hint) = parse_error_hint(&err.message) {
-        err.hint = Some(hint.to_string());
+        err.set_hint(Some(hint.to_string()));
     }
     err
 }
 
 /// Parse a full program using the nom-based parser.
 /// Returns `(statements, Option<finish_content>)`.
-#[allow(clippy::result_large_err)]
 pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), RuntimeError> {
     // Clear any stale parse warnings from previous/backtracked parses
     PARSE_WARNINGS.with(|w| w.borrow_mut().clear());
@@ -265,7 +264,7 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
             if e.is_fatal() {
                 // Fatal parse errors (e.g. bare say/print/put) pass through directly
                 let mut err = RuntimeError::new(format!("{}", e));
-                err.code = Some(RuntimeErrorCode::ParseGeneric);
+                err.set_code(Some(RuntimeErrorCode::ParseGeneric));
                 if let Some(ex) = e.exception {
                     err.exception = Some(ex);
                 }
@@ -298,7 +297,7 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                 }
             } else {
                 let mut err = RuntimeError::new(format!("Confused. parse error: {}", e));
-                err.code = Some(RuntimeErrorCode::ParseGeneric);
+                err.set_code(Some(RuntimeErrorCode::ParseGeneric));
                 Err(with_parse_hint(err))
             }
         }
@@ -336,7 +335,6 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
 
 /// Like `parse_program`, but pre-registers operator sub names so the parser
 /// recognizes them during EVAL.
-#[allow(clippy::result_large_err)]
 pub(crate) fn parse_program_with_operators(
     input: &str,
     operator_names: &[String],
@@ -352,7 +350,6 @@ pub(crate) fn parse_program_with_operators(
     )
 }
 
-#[allow(clippy::result_large_err)]
 pub(crate) fn parse_program_with_operators_and_user_subs(
     input: &str,
     operator_names: &[String],
@@ -448,9 +445,9 @@ mod tests {
         let err = parse_program("}").unwrap_err();
         assert!(err.message.contains("line 1, column 1"));
         assert!(err.message.contains("unparsed input"));
-        assert!(matches!(err.code, Some(RuntimeErrorCode::ParseUnparsed)));
-        assert_eq!(err.line, Some(1));
-        assert_eq!(err.column, Some(1));
+        assert!(matches!(err.code(), Some(RuntimeErrorCode::ParseUnparsed)));
+        assert_eq!(err.line(), Some(1));
+        assert_eq!(err.column(), Some(1));
     }
 
     #[test]
@@ -459,8 +456,8 @@ mod tests {
         assert!(err.message.contains("line 2"));
         assert!(err.message.contains("column"));
         assert!(err.message.contains("parse error"));
-        assert!(matches!(err.code, Some(RuntimeErrorCode::ParseExpected)));
-        assert_eq!(err.line, Some(2));
+        assert!(matches!(err.code(), Some(RuntimeErrorCode::ParseExpected)));
+        assert_eq!(err.line(), Some(2));
     }
 
     #[test]
@@ -474,8 +471,7 @@ mod tests {
         let err = parse_program("$x.").unwrap_err();
         assert!(err.message.contains("parse error"));
         assert!(
-            err.hint
-                .as_deref()
+            err.hint()
                 .is_some_and(|hint| hint.contains("method-call syntax"))
         );
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -107,7 +107,7 @@ fn process_line(
         }
         Err(err) => {
             // If it looks like incomplete input (parse error), try accumulating
-            if err.code.is_some_and(|c| c.is_parse()) && is_incomplete(accumulated) {
+            if err.code().is_some_and(|c| c.is_parse()) && is_incomplete(accumulated) {
                 return (LineResult::Continue, None);
             }
             Some(format!("Error: {}\n", err.message))

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -212,7 +212,7 @@ impl Interpreter {
             Some(Value::WeakSub(weak)) => {
                 if let Some(sub) = weak.upgrade() {
                     if Some(sub.id) != current_callable_id && Some(sub.id) != current_block_id {
-                        sig.leave_callable_id = Some(sub.id);
+                        sig.set_leave_callable_id(Some(sub.id));
                     }
                 } else {
                     return Err(RuntimeError::new("Callable has been freed"));
@@ -220,11 +220,11 @@ impl Interpreter {
             }
             Some(Value::Sub(data)) => {
                 if Some(data.id) != current_callable_id && Some(data.id) != current_block_id {
-                    sig.leave_callable_id = Some(data.id);
+                    sig.set_leave_callable_id(Some(data.id));
                 }
             }
             Some(Value::Routine { package, name, .. }) => {
-                sig.leave_routine = Some(format!("{package}::{name}"));
+                sig.set_leave_routine(Some(format!("{package}::{name}")));
             }
             Some(Value::Nil) => {}
             Some(Value::Package(name)) if name == "Any" => {}
@@ -238,9 +238,9 @@ impl Interpreter {
                         _ => None,
                     });
                 if let Some(id) = caller_callable_id {
-                    sig.leave_callable_id = Some(id);
+                    sig.set_leave_callable_id(Some(id));
                 } else if let Some(frame) = self.routine_stack_top() {
-                    sig.leave_routine = Some(format!("{}::{}", frame.package, frame.name));
+                    sig.set_leave_routine(Some(format!("{}::{}", frame.package, frame.name)));
                 }
             }
             Some(Value::Package(name)) if name == "Block" => {}

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -559,13 +559,13 @@ impl Interpreter {
             // Non-local return targeting a different callable: propagate
             if let Err(ref e) = result
                 && e.return_value.is_some()
-                && e.return_target_callable_id.is_some()
+                && e.return_target_callable_id().is_some()
             {
                 let my_id = self.env.get(&callable_key).and_then(|v| match v {
                     Value::Int(i) => Some(*i as u64),
                     _ => None,
                 });
-                if my_id != e.return_target_callable_id {
+                if my_id != e.return_target_callable_id() {
                     return result;
                 }
             }

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -270,7 +270,7 @@ impl Interpreter {
         // Non-local return targeting a different callable: propagate without absorbing
         if let Err(ref e) = call_result
             && e.return_value.is_some()
-            && let Some(_target_id) = e.return_target_callable_id
+            && let Some(_target_id) = e.return_target_callable_id()
         {
             // The callable_id for this function is resolved from env.
             let callable_key = format!("__mutsu_callable_id::{}::{}", def.package, def.name);
@@ -278,7 +278,7 @@ impl Interpreter {
                 Value::Int(i) => Some(*i as u64),
                 _ => None,
             });
-            if my_id != e.return_target_callable_id {
+            if my_id != e.return_target_callable_id() {
                 return call_result;
             }
         }
@@ -575,7 +575,7 @@ impl Interpreter {
 
     /// Enhance a binding error with function name, call profile, and signature info.
     pub(crate) fn enhance_binding_error(
-        err: RuntimeError,
+        mut err: RuntimeError,
         func_name: &str,
         param_defs: &[crate::ast::ParamDef],
         args: &[Value],
@@ -584,6 +584,9 @@ impl Interpreter {
         if err.is_return() || err.is_last() || err.is_next() || func_name.is_empty() {
             return err;
         }
+        // Capture the hint before `err.exception` is (possibly) moved out below,
+        // so the later `set_hint` does not clash with that partial move.
+        let hint = err.take_hint();
         // Build call profile: func_name(Type1, Type2, ...)
         let arg_types: Vec<String> = Self::arg_type_names(args);
         let call_profile = format!("{}({})", func_name, arg_types.join(", "));
@@ -687,7 +690,7 @@ impl Interpreter {
                 enhanced.exception = Some(ex);
             }
         }
-        enhanced.hint = err.hint;
+        enhanced.set_hint(hint);
         enhanced
     }
 }

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use crate::builtins::methods_0arg::temporal;
 use crate::value::{RuntimeError, Value};
 use std::sync::Arc;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use crate::symbol::Symbol;
 use std::collections::{HashMap, HashSet};
 use std::env;

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -13,7 +13,7 @@ impl Interpreter {
     /// the original error message and backtrace in its gist.
     pub(crate) fn wrap_react_died(inner: RuntimeError) -> RuntimeError {
         let original_message = inner.message.clone();
-        let backtrace_str = inner.backtrace.clone().unwrap_or_default();
+        let backtrace_str = inner.backtrace().unwrap_or_default().to_string();
         let mut gist = format!(
             "A react block:\n\nDied because of the exception:\n    {}",
             original_message

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -726,7 +726,7 @@ impl Interpreter {
             spec.trim()
         );
         let mut err = RuntimeError::new(&message);
-        err.code = Some(crate::value::RuntimeErrorCode::ParseGeneric);
+        err.set_code(Some(crate::value::RuntimeErrorCode::ParseGeneric));
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("message".to_string(), Value::str(message.clone()));
         attrs.insert("payload".to_string(), Value::str(message));

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -434,10 +434,10 @@ impl Interpreter {
             let result = match self.eval_block_value(&data.body) {
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", data.package, data.name);
-                    let matches_frame = if let Some(target_id) = e.leave_callable_id {
+                    let matches_frame = if let Some(target_id) = e.leave_callable_id() {
                         target_id == data.id
-                    } else if let Some(target_routine) = e.leave_routine.as_ref() {
-                        target_routine == &routine_key
+                    } else if let Some(target_routine) = e.leave_routine() {
+                        target_routine == routine_key
                     } else {
                         e.label.is_none()
                     };
@@ -589,14 +589,14 @@ impl Interpreter {
                 // Only propagate non-local return if we can identify the target
                 // routine (via __mutsu_callable_id in captured env or already set).
                 // If no target exists, catch it locally (e.g., supply block done+return).
-                let has_target = e.return_target_callable_id.is_some()
+                let has_target = e.return_target_callable_id().is_some()
                     || data.env.contains_key("__mutsu_callable_id");
                 if has_target {
                     let mut e = result.unwrap_err();
-                    if e.return_target_callable_id.is_none()
+                    if e.return_target_callable_id().is_none()
                         && let Some(Value::Int(id)) = data.env.get("__mutsu_callable_id")
                     {
-                        e.return_target_callable_id = Some(*id as u64);
+                        e.set_return_target_callable_id(Some(*id as u64));
                     }
                     return Err(e);
                 }

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -263,10 +263,10 @@ impl Interpreter {
                             // detection works when the map is forced lazily after
                             // the enclosing routine has exited.
                             if e.is_return()
-                                && e.return_target_callable_id.is_none()
+                                && e.return_target_callable_id().is_none()
                                 && let Some(Value::Int(id)) = data.env.get("__mutsu_callable_id")
                             {
-                                e.return_target_callable_id = Some(*id as u64);
+                                e.set_return_target_callable_id(Some(*id as u64));
                             }
                             return Err(e);
                         }

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -218,7 +218,7 @@ impl Interpreter {
         let ok = eval_result.is_ok();
         let eval_err_msg = match &eval_result {
             Err(e) => {
-                let msg = if e.code.is_some_and(|c| c.is_parse()) {
+                let msg = if e.code().is_some_and(|c| c.is_parse()) {
                     format!("Unable to parse expression; {}", e.message)
                 } else {
                     e.message.clone()

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -108,10 +108,10 @@ impl Interpreter {
                             // EVAL'd code reports the EVAL pseudo-file and the
                             // line within that source (Raku exposes `.filename`
                             // matching /EVAL/ and `.line`).
+                            let line = e.line().unwrap_or(1) as i64;
                             if let Some(ref mut exc_box) = e.exception
                                 && let Value::Instance { attributes, .. } = exc_box.as_mut()
                             {
-                                let line = e.line.unwrap_or(1) as i64;
                                 attributes.insert_if_absent("line".to_string(), Value::Int(line));
                                 attributes.insert_if_absent(
                                     "filename".to_string(),
@@ -266,7 +266,7 @@ impl Interpreter {
                         || err.message.contains("X::Redeclaration")
                         || err.message.contains("parse error")
                         // Any error with a parse error code is a compile-time error
-                        || err.code.is_some_and(|c| c.is_parse())
+                        || err.code().is_some_and(|c| c.is_parse())
                 } else if expected_normalized == "X::AdHoc" {
                     // X::AdHoc matches any ad-hoc error
                     true
@@ -493,10 +493,10 @@ impl Interpreter {
                             // EVAL'd code reports the EVAL pseudo-file and the
                             // line within that source (Raku exposes `.filename`
                             // matching /EVAL/ and `.line`).
+                            let line = e.line().unwrap_or(1) as i64;
                             if let Some(ref mut exc_box) = e.exception
                                 && let Value::Instance { attributes, .. } = exc_box.as_mut()
                             {
-                                let line = e.line.unwrap_or(1) as i64;
                                 attributes.insert_if_absent("line".to_string(), Value::Int(line));
                                 attributes.insert_if_absent(
                                     "filename".to_string(),

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -73,13 +73,39 @@ pub enum Control {
     Done,
 }
 
+/// Cold, rarely-set routing/diagnostic fields of a [`RuntimeError`], boxed
+/// behind a single `Option<Box<..>>` so the common error carries none of them
+/// inline. Keeping these out of `RuntimeError` shrinks it below Clippy's
+/// `result_large_err` threshold (was 272 B), so the ~1280 `Result<_,
+/// RuntimeError>` signatures no longer need `#[allow(clippy::result_large_err)]`
+/// (ANALYSIS §2.2 / §7-4). Every field is accessed through the getter/setter
+/// methods on `RuntimeError`; the box is allocated lazily on first write.
+#[derive(Debug, Default)]
+pub struct RuntimeErrorCold {
+    /// Parse-error classification (set only for parse failures).
+    pub code: Option<RuntimeErrorCode>,
+    /// 1-based source line of a parse failure.
+    pub line: Option<usize>,
+    /// 1-based source column of a parse failure.
+    pub column: Option<usize>,
+    /// A human-readable hint appended to the rendered error.
+    pub hint: Option<String>,
+    /// A `LEAVE`/routine unwind targets a routine frame via this callable ID.
+    pub leave_callable_id: Option<u64>,
+    /// A `LEAVE`/routine unwind targets a routine frame via this `Pkg::name`.
+    pub leave_routine: Option<String>,
+    /// For non-local returns (CX::Return from a block), the callable ID of the
+    /// lexically enclosing routine that the return targets.
+    pub return_target_callable_id: Option<u64>,
+    /// Container name for Scalar container binding (e.g. when/default returning $a)
+    pub container_name: Option<String>,
+    /// Formatted backtrace string from the call stack at the point of error.
+    pub backtrace: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct RuntimeError {
     pub message: String,
-    pub code: Option<RuntimeErrorCode>,
-    pub line: Option<usize>,
-    pub column: Option<usize>,
-    pub hint: Option<String>,
     pub return_value: Option<Value>,
     /// The control-flow signal this error carries, if any (see `Control`).
     /// Replaces the former `is_*` bools for the migrated signals; read via the
@@ -96,17 +122,12 @@ pub struct RuntimeError {
     /// single-signal `control` enum and stays a separate flag.
     pub is_leave: bool,
     pub label: Option<String>,
-    pub leave_callable_id: Option<u64>,
-    pub leave_routine: Option<String>,
-    /// For non-local returns (CX::Return from a block), the callable ID of the
-    /// lexically enclosing routine that the return targets.
-    pub return_target_callable_id: Option<u64>,
-    /// Container name for Scalar container binding (e.g. when/default returning $a)
-    pub container_name: Option<String>,
     /// Structured exception object (e.g. X::AdHoc, X::Promise::Vowed)
     pub exception: Option<Box<Value>>,
-    /// Formatted backtrace string from the call stack at the point of error.
-    pub backtrace: Option<String>,
+    /// Cold routing/diagnostic fields, allocated lazily. Accessed via the
+    /// getter/setter methods below; `pub(crate)` only so the `..RuntimeError::new()`
+    /// functional-update idiom keeps working at construction sites.
+    pub(crate) cold: Option<Box<RuntimeErrorCold>>,
 }
 
 /// The runtime type-object Value for a type *name*, used as the `.expected`
@@ -125,22 +146,87 @@ impl RuntimeError {
     pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            code: None,
-            line: None,
-            column: None,
-            hint: None,
             return_value: None,
             control: None,
             fail_handled: false,
             is_leave: false,
             label: None,
-            leave_callable_id: None,
-            leave_routine: None,
-            return_target_callable_id: None,
-            container_name: None,
             exception: None,
-            backtrace: None,
+            cold: None,
         }
+    }
+
+    // ----- cold-field accessors (read) -----
+    //
+    // These mirror the former public fields; a `None` cold box reads as `None`.
+
+    pub fn code(&self) -> Option<RuntimeErrorCode> {
+        self.cold.as_ref().and_then(|c| c.code)
+    }
+    pub fn line(&self) -> Option<usize> {
+        self.cold.as_ref().and_then(|c| c.line)
+    }
+    pub fn column(&self) -> Option<usize> {
+        self.cold.as_ref().and_then(|c| c.column)
+    }
+    pub fn hint(&self) -> Option<&str> {
+        self.cold.as_ref().and_then(|c| c.hint.as_deref())
+    }
+    pub fn leave_callable_id(&self) -> Option<u64> {
+        self.cold.as_ref().and_then(|c| c.leave_callable_id)
+    }
+    pub fn leave_routine(&self) -> Option<&str> {
+        self.cold.as_ref().and_then(|c| c.leave_routine.as_deref())
+    }
+    pub fn return_target_callable_id(&self) -> Option<u64> {
+        self.cold.as_ref().and_then(|c| c.return_target_callable_id)
+    }
+    pub fn container_name(&self) -> Option<&str> {
+        self.cold.as_ref().and_then(|c| c.container_name.as_deref())
+    }
+    pub fn backtrace(&self) -> Option<&str> {
+        self.cold.as_ref().and_then(|c| c.backtrace.as_deref())
+    }
+
+    /// Move the container name out of the error, leaving it `None`.
+    pub(crate) fn take_container_name(&mut self) -> Option<String> {
+        self.cold.as_mut().and_then(|c| c.container_name.take())
+    }
+    /// Move the hint out of the error, leaving it `None`.
+    pub(crate) fn take_hint(&mut self) -> Option<String> {
+        self.cold.as_mut().and_then(|c| c.hint.take())
+    }
+
+    // ----- cold-field accessors (write) -----
+    //
+    // Each lazily allocates the cold box on first write via `cold_mut`.
+
+    fn cold_mut(&mut self) -> &mut RuntimeErrorCold {
+        self.cold.get_or_insert_with(Default::default)
+    }
+    pub(crate) fn set_code(&mut self, v: Option<RuntimeErrorCode>) {
+        self.cold_mut().code = v;
+    }
+    pub(crate) fn set_line(&mut self, v: Option<usize>) {
+        self.cold_mut().line = v;
+    }
+    pub(crate) fn set_hint(&mut self, v: Option<String>) {
+        self.cold_mut().hint = v;
+    }
+    pub(crate) fn set_leave_callable_id(&mut self, v: Option<u64>) {
+        self.cold_mut().leave_callable_id = v;
+    }
+    pub(crate) fn set_leave_routine(&mut self, v: Option<String>) {
+        self.cold_mut().leave_routine = v;
+    }
+    pub(crate) fn set_return_target_callable_id(&mut self, v: Option<u64>) {
+        self.cold_mut().return_target_callable_id = v;
+    }
+    pub(crate) fn set_container_name(&mut self, v: Option<String>) {
+        self.cold_mut().container_name = v;
+    }
+    pub(crate) fn set_backtrace(&mut self, v: Option<String>) {
+        self.cold_mut().backtrace = v;
     }
 
     /// `return` control signal (non-local return carrying `return_value`).
@@ -260,21 +346,18 @@ impl RuntimeError {
     ) -> Self {
         Self {
             message: message.into(),
-            code: Some(code),
-            line: Some(line),
-            column: Some(column),
-            hint: None,
+            cold: Some(Box::new(RuntimeErrorCold {
+                code: Some(code),
+                line: Some(line),
+                column: Some(column),
+                ..Default::default()
+            })),
             return_value: None,
             control: None,
             fail_handled: false,
             is_leave: false,
             label: None,
-            leave_callable_id: None,
-            leave_routine: None,
-            return_target_callable_id: None,
-            container_name: None,
             exception: None,
-            backtrace: None,
         }
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -159,14 +159,12 @@ pub(crate) fn seq_is_cached(arc_ptr: &Arc<Vec<Value>>) -> bool {
 }
 
 /// Build a structured X::Seq::Consumed error.
-#[allow(clippy::result_large_err)]
 pub(crate) fn seq_consumed_error() -> RuntimeError {
     seq_consumed_error_for("Seq")
 }
 
 /// Build a structured X::Seq::Consumed error naming the consumed type
 /// (e.g. "Seq", "HyperSeq", "RaceSeq").
-#[allow(clippy::result_large_err)]
 pub(crate) fn seq_consumed_error_for(type_name: &str) -> RuntimeError {
     let msg = format!(
         "The iterator of this {type_name} is already in use/consumed by another {type_name} \
@@ -187,7 +185,6 @@ pub(crate) fn seq_consumed_error_for(type_name: &str) -> RuntimeError {
 
 /// Mark a Seq (identified by its Arc) as consumed.
 /// Returns Err if the Seq was already consumed.
-#[allow(clippy::result_large_err)]
 pub(crate) fn seq_consume(arc_ptr: &Arc<Vec<Value>>) -> Result<(), RuntimeError> {
     let mut list = consumed_seqs().lock().unwrap();
     // Clean up expired Weak references and check for duplicates

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -184,7 +184,6 @@ impl InstanceAttrs {
     /// Phase 3 cell-CAS: atomically read-modify-write one attribute under a
     /// single write lock (atomic add / increment / decrement). Returns
     /// `(old, new)`; an error from `f` leaves the attribute unchanged.
-    #[allow(clippy::result_large_err)]
     pub(crate) fn fetch_update(
         &self,
         key: &str,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -335,7 +335,7 @@ impl Interpreter {
         // `.throw`/`.rethrow` on an exception instance: attach a backtrace built
         // from the current call stack. The `die`/`fail` opcodes do this, but an
         // explicit `ExceptionObject.throw` goes through method dispatch and would
-        // otherwise carry no frames (so `.backtrace.list` would be empty).
+        // otherwise carry no frames (so `.backtrace().list` would be empty).
         let target = if matches!(method, "throw" | "rethrow")
             && args.is_empty()
             && matches!(

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -233,10 +233,10 @@ impl Interpreter {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{fn_package}::{fn_name}");
-                    let matches_frame = if let Some(target_id) = e.leave_callable_id {
+                    let matches_frame = if let Some(target_id) = e.leave_callable_id() {
                         Some(target_id) == callable_id
-                    } else if let Some(target_routine) = e.leave_routine.as_ref() {
-                        target_routine == &routine_key
+                    } else if let Some(target_routine) = e.leave_routine() {
+                        target_routine == routine_key
                     } else {
                         e.label.is_none()
                     };
@@ -258,7 +258,7 @@ impl Interpreter {
                 Err(e) if e.return_value.is_some() => {
                     // Non-local return: if the signal targets a specific callable,
                     // only catch it if this routine is the target.
-                    if let Some(target_id) = e.return_target_callable_id
+                    if let Some(target_id) = e.return_target_callable_id()
                         && callable_id != Some(target_id)
                     {
                         loan_env!(self, restore_let_saves(let_mark));

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -510,10 +510,10 @@ impl Interpreter {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", data.package, data.name);
-                    let matches_frame = if let Some(target_id) = e.leave_callable_id {
+                    let matches_frame = if let Some(target_id) = e.leave_callable_id() {
                         target_id == data.id
-                    } else if let Some(target_routine) = e.leave_routine.as_ref() {
-                        target_routine == &routine_key
+                    } else if let Some(target_routine) = e.leave_routine() {
+                        target_routine == routine_key
                     } else {
                         e.label.is_none()
                     };
@@ -554,13 +554,13 @@ impl Interpreter {
                         // Only propagate if we can identify the target routine.
                         // If no target exists (e.g., supply block done+return),
                         // catch it locally.
-                        let has_target = e.return_target_callable_id.is_some()
+                        let has_target = e.return_target_callable_id().is_some()
                             || data.env.contains_key("__mutsu_callable_id");
                         if has_target {
-                            if e.return_target_callable_id.is_none()
+                            if e.return_target_callable_id().is_none()
                                 && let Some(Value::Int(id)) = data.env.get("__mutsu_callable_id")
                             {
-                                e.return_target_callable_id = Some(*id as u64);
+                                e.set_return_target_callable_id(Some(*id as u64));
                             }
                             loan_env!(self, restore_let_saves(let_mark));
                             handled_let_saves = true;
@@ -571,7 +571,7 @@ impl Interpreter {
                     }
                     // Routine closures: check if the return targets a specific
                     // callable; if so, only catch if it matches this closure.
-                    if let Some(target_id) = e.return_target_callable_id
+                    if let Some(target_id) = e.return_target_callable_id()
                         && target_id != data.id
                     {
                         loan_env!(self, restore_let_saves(let_mark));

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -349,8 +349,8 @@ impl Interpreter {
                     }
                     Err(e)
                         if e.is_leave
-                            && e.leave_callable_id.is_none()
-                            && e.leave_routine.is_none()
+                            && e.leave_callable_id().is_none()
+                            && e.leave_routine().is_none()
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
                         if let Some(v) = e.return_value {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::result_large_err)]
 use super::*;
 
 impl Interpreter {
@@ -3143,7 +3142,7 @@ impl Interpreter {
                 let current_file = self.current_source_file();
                 let mut err = self.runtime_error_from_exception_value(val, "Died", false);
                 if !backtrace_str.is_empty() {
-                    err.backtrace = Some(backtrace_str);
+                    err.set_backtrace(Some(backtrace_str));
                 }
                 // Attach backtrace, line, and file to the exception value
                 if let Some(ref mut exc_box) = err.exception

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -410,8 +410,8 @@ impl Interpreter {
                     }
                     Err(e)
                         if e.is_leave
-                            && e.leave_callable_id.is_none()
-                            && e.leave_routine.is_none()
+                            && e.leave_callable_id().is_none()
+                            && e.leave_routine().is_none()
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
                         if writes_back_loop_var {

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -126,8 +126,8 @@ impl Interpreter {
                     }
                     Err(e)
                         if e.is_leave
-                            && e.leave_callable_id.is_none()
-                            && e.leave_routine.is_none()
+                            && e.leave_callable_id().is_none()
+                            && e.leave_routine().is_none()
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
                         if let Some(v) = e.return_value {

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -115,8 +115,8 @@ impl Interpreter {
                     }
                     Err(e)
                         if e.is_leave
-                            && e.leave_callable_id.is_none()
-                            && e.leave_routine.is_none()
+                            && e.leave_callable_id().is_none()
+                            && e.leave_routine().is_none()
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
                         break 'for_loop;

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -167,11 +167,13 @@ impl Interpreter {
                 }
                 self.stack.truncate(stack_base);
             }
-            Err(e) if e.is_succeed() => {
+            Err(mut e) if e.is_succeed() => {
+                // Take the container name before moving `return_value` out (a
+                // method borrow of `e` cannot coexist with a partial move).
+                self.container_ref_var = e.take_container_name();
                 if let Some(v) = e.return_value {
                     last = v;
                 }
-                self.container_ref_var = e.container_name;
                 loan_env!(self, set_when_matched(true));
             }
             Err(e) => {
@@ -278,7 +280,7 @@ impl Interpreter {
                 let last = self.stack.last().cloned().unwrap_or(Value::Nil);
                 let mut sig = RuntimeError::succeed_signal();
                 sig.return_value = Some(last);
-                sig.container_name = self.container_ref_var.take();
+                sig.set_container_name(self.container_ref_var.take());
                 return Err(sig);
             }
         }
@@ -307,7 +309,7 @@ impl Interpreter {
         let last = self.stack.last().cloned().unwrap_or(Value::Nil);
         let mut sig = RuntimeError::succeed_signal();
         sig.return_value = Some(last);
-        sig.container_name = self.container_ref_var.take();
+        sig.set_container_name(self.container_ref_var.take());
         *ip = end;
         Err(sig)
     }

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -89,7 +89,7 @@ impl Interpreter {
     /// An explicit `ExceptionObject.throw` is dispatched natively, so the
     /// `throw` invocation never appears as its own callframe on the routine
     /// stack. Raku, by contrast, includes the `Exception.throw` setting frame at
-    /// the top of `.backtrace.list` (it is hidden from the rendered gist as a
+    /// the top of `.backtrace().list` (it is hidden from the rendered gist as a
     /// setting frame, but still counts toward `.list.elems`). Passing the method
     /// name here reproduces that extra structured-only frame.
     pub(super) fn build_backtrace_value_with_leading(&self, leading: Option<&str>) -> Value {

--- a/src/vm/vm_loop_cstyle_repeat.rs
+++ b/src/vm/vm_loop_cstyle_repeat.rs
@@ -69,8 +69,8 @@ impl Interpreter {
                     }
                     Err(e)
                         if e.is_leave
-                            && e.leave_callable_id.is_none()
-                            && e.leave_routine.is_none()
+                            && e.leave_callable_id().is_none()
+                            && e.leave_routine().is_none()
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
                         if let Some(v) = e.return_value {
@@ -178,8 +178,8 @@ impl Interpreter {
                     }
                     Err(e)
                         if e.is_leave
-                            && e.leave_callable_id.is_none()
-                            && e.leave_routine.is_none()
+                            && e.leave_callable_id().is_none()
+                            && e.leave_routine().is_none()
                             && Self::label_matches(&e.label, label) =>
                     {
                         if let Some(v) = e.return_value {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -536,11 +536,11 @@ impl Interpreter {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", owner_class, method_name);
-                    let matches_frame = if let Some(_target_id) = e.leave_callable_id {
+                    let matches_frame = if let Some(_target_id) = e.leave_callable_id() {
                         // Methods don't have callable IDs, so this won't match
                         false
-                    } else if let Some(target_routine) = e.leave_routine.as_ref() {
-                        target_routine == &routine_key
+                    } else if let Some(target_routine) = e.leave_routine() {
+                        target_routine == routine_key
                     } else {
                         e.label.is_none()
                     };
@@ -562,7 +562,7 @@ impl Interpreter {
                 Err(e) if e.return_value.is_some() => {
                     // Non-local return: if the signal targets a specific callable,
                     // only catch it if this method is the target.
-                    if let Some(target_id) = e.return_target_callable_id
+                    if let Some(target_id) = e.return_target_callable_id()
                         && target_id != method_callable_id
                     {
                         loan_env!(self, restore_let_saves(let_mark));
@@ -772,7 +772,7 @@ impl Interpreter {
         } else {
             match final_result {
                 Ok(v) => Ok(v),
-                Err(e) if e.return_value.is_some() && e.return_target_callable_id.is_none() => {
+                Err(e) if e.return_value.is_some() && e.return_target_callable_id().is_none() => {
                     Ok(e.return_value.unwrap())
                 }
                 Err(e) => Err(e),
@@ -1272,10 +1272,10 @@ impl Interpreter {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", owner_class, method_name);
-                    let matches_frame = if let Some(_target_id) = e.leave_callable_id {
+                    let matches_frame = if let Some(_target_id) = e.leave_callable_id() {
                         false
-                    } else if let Some(target_routine) = e.leave_routine.as_ref() {
-                        target_routine == &routine_key
+                    } else if let Some(target_routine) = e.leave_routine() {
+                        target_routine == routine_key
                     } else {
                         e.label.is_none()
                     };
@@ -1295,7 +1295,7 @@ impl Interpreter {
                     break;
                 }
                 Err(e) if e.return_value.is_some() => {
-                    if let Some(target_id) = e.return_target_callable_id
+                    if let Some(target_id) = e.return_target_callable_id()
                         && target_id != method_callable_id
                     {
                         loan_env!(self, restore_let_saves(let_mark));
@@ -1452,7 +1452,7 @@ impl Interpreter {
         } else {
             match final_result {
                 Ok(v) => Ok(v),
-                Err(e) if e.return_value.is_some() && e.return_target_callable_id.is_none() => {
+                Err(e) if e.return_value.is_some() && e.return_target_callable_id().is_none() => {
                     Ok(e.return_value.unwrap())
                 }
                 Err(e) => Err(e),

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -108,8 +108,8 @@ impl Interpreter {
                 }
                 Err(e)
                     if e.is_leave
-                        && e.leave_callable_id.is_none()
-                        && e.leave_routine.is_none()
+                        && e.leave_callable_id().is_none()
+                        && e.leave_routine().is_none()
                         && Self::label_matches(&e.label, &label) =>
                 {
                     self.stack.truncate(stack_base);

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -341,10 +341,10 @@ impl Interpreter {
                 } else {
                     let mut exc_attrs = std::collections::HashMap::new();
                     exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
-                    if let Some(line) = e.line {
+                    if let Some(line) = e.line() {
                         exc_attrs.insert("line".to_string(), Value::Int(line as i64));
                     }
-                    if let Some(ref bt) = e.backtrace {
+                    if let Some(bt) = e.backtrace() {
                         // Build a Backtrace object from the string for
                         // legacy errors that only have a string backtrace.
                         let bt_val = Self::backtrace_value_from_string(bt);


### PR DESCRIPTION
## Summary

`RuntimeError` was **272 bytes**, tripping Clippy's `result_large_err` lint on the ~1280 `Result<_, RuntimeError>` signatures across the interpreter — silenced by **51** `#[allow(clippy::result_large_err)]` attributes scattered through the tree (ANALYSIS §2.2 / §7-4 item 4).

This moves the nine cold, rarely-set routing/diagnostic fields into a new `RuntimeErrorCold` struct held behind a single lazily-allocated `Option<Box<..>>`:

- `code` / `line` / `column` (parse-error location)
- `hint`
- `leave_callable_id` / `leave_routine`
- `return_target_callable_id`
- `container_name`
- `backtrace`

The common error now carries none of them inline, so `size_of::<RuntimeError>()` drops to **120 B** (below the 128 B threshold) and **all 51 allow attributes are removed**.

## Mechanics

- Every moved field is reached through generated accessors — `code()`, `line()`, `set_hint(..)`, `set_leave_routine(..)`, `take_container_name()`, `take_hint()`, etc. The cold box is allocated lazily on first write (`cold_mut`).
- The `..RuntimeError::new()` functional-update idiom at construction sites keeps working via a `pub(crate) cold` field; read accessors are `pub` so the `mutsu` bin crate (`main.rs`) can use them.
- Pure mechanical refactor — **no behavior change**.

## Verification

- `cargo test`: 477 unit tests pass
- Full `t/` suite: PASS (1420 files, 13806 tests)
- `cargo clippy --all-targets -- -D warnings`: clean (no `result_large_err`, no new warnings)
- `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)