### PR TITLE
fix(vm): restore current_code around nested/ephemeral block runs

### DIFF
--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -247,6 +247,20 @@ impl Interpreter {
         let saved_state_scope_id = self.state_scope_id.take();
         let saved_gather_for_loop_resume = self.gather_for_loop_resume.take();
         let saved_rw_map_topic_capture = self.rw_map_topic_capture.take();
+        // `current_code` is the raw address of the *caller's* live `CompiledCode`
+        // (see `exec_one`'s `self.current_code = code as *const CompiledCode as
+        // usize;` and the unsafe deref in `writeback_multidim_var_to_local`).
+        // `f` below runs a nested, ephemeral `CompiledCode` (e.g. a `dies-ok { }`
+        // block's `compile_block_value` result, owned by a stack-local in
+        // `eval_block_value`) that is dropped the instant `f` returns. Without
+        // restoring the caller's address here, `current_code` is left dangling —
+        // pointing at freed stack memory the next nested call's frame promptly
+        // reuses — and any *later* unsafe deref of it is undefined behavior
+        // (observed as a SIGABRT "slice::from_raw_parts requires the pointer to
+        // be aligned and non-null" panic inside `builtin_multidim_delete`,
+        // roast S32-array/multislice-6e.t, whenever a `dies-ok`/`lives-ok`/
+        // `throws-like`/EVAL block ran earlier in the same program).
+        let saved_current_code = self.current_code;
 
         self.in_smartmatch_rhs = false;
         self.transliterate_in_smartmatch = false;
@@ -303,6 +317,7 @@ impl Interpreter {
         self.state_scope_id = saved_state_scope_id;
         self.gather_for_loop_resume = saved_gather_for_loop_resume;
         self.rw_map_topic_capture = saved_rw_map_topic_capture;
+        self.current_code = saved_current_code;
 
         // The nested run shares `self.env` and may have mutated outer lexicals
         // (e.g. a deferred role-body statement writing an enclosing `my $x`).

--- a/t/multidim-delete-after-ephemeral-block-coherence.t
+++ b/t/multidim-delete-after-ephemeral-block-coherence.t
@@ -1,0 +1,19 @@
+use Test;
+plan 2;
+
+# Regression: `current_code` (the raw address of the currently-executing
+# CompiledCode, read back by `writeback_multidim_var_to_local` after a
+# multidim `:delete`) was not saved/restored around a nested, ephemeral
+# block run (`with_nested_registers`, used by `dies-ok`/`lives-ok`/
+# `throws-like`/EVAL). After such a block returned and its temporary
+# CompiledCode was dropped, `current_code` was left dangling, and a later
+# multidim `:delete` with a Whatever/negative index (which triggers the
+# writeback) dereferenced it -- undefined behavior (SIGABRT: "slice::
+# from_raw_parts requires the pointer to be aligned and non-null"),
+# reproduced by roast/S32-array/multislice-6e.t.
+dies-ok { die "warm up an ephemeral compiled block" },
+  'an ephemeral block runs and returns first';
+
+my @a = [[[42, 666, [314]], ], ];
+is @a[*-1;0;0]:delete, 42,
+  'multidim delete with a Whatever index after an ephemeral block does not crash';


### PR DESCRIPTION
## Summary
- Fixes a real, reproducible **SIGABRT / undefined behavior** crash (not caught by `make roast`, since the triggering file isn't whitelisted): `current_code` (the raw `usize` address of the currently-executing `CompiledCode`, unsafely dereferenced by `writeback_multidim_var_to_local` to mirror a multidim `:delete` back into the caller's local slot) was never saved/restored by `with_nested_registers` — the shared entry point every `dies-ok`/`lives-ok`/`throws-like`/EVAL ephemeral block run goes through.
- After such a nested block returns, its temporary `CompiledCode` (owned by a stack-local in `eval_block_value`) is dropped, but `current_code` was left pointing at that now-freed stack memory. A later multidim `:delete` with a Whatever/negative index dereferences the dangling pointer.
- Found while investigating an unrelated PR: the crash appeared in `roast/S32-array/multislice-6e.t`, bisected to confirm it's present on `main` independent of that PR — a memory-layout-shifting refactor elsewhere was enough to flip it from "lucky" (freed memory not yet reused) to a hard, deterministic crash.
- Fix: add `current_code` to the save/restore list in `with_nested_registers`, exactly like every other per-execution register there.
- Added a minimal 2-statement regression test (`t/multidim-delete-after-ephemeral-block-coherence.t`) that reliably reproduced the crash before this fix.

## Test plan
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt`
- [x] `make test` (13840 prove tests + unit tests) — all pass
- [x] `roast/S32-array/multislice-6e.t` — no more crash (784/812, matching its pre-existing known-failure baseline; the remaining 28 are pre-existing unrelated multislice-lvalue gaps tracked in `TODO_roast/`)
- [x] New regression test confirmed to crash on the pre-fix binary and pass on the post-fix binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK