### PR TITLE
fix(bind): throw X::Bind when binding an element into a non-container target

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,19 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-02: §F 型付き例外 — 非コンテナへの element bind が X::Bind を投げる（#4053）
+
+`(List)[0] := 1` / `(Int)[0] := 1`（型オブジェクトへの positional element bind）が **silent 成功**していた。
+generic index-assign op（`IndexAssignGeneric`）が Array / Hash / HashEntryRef / Stash 以外の target を
+no-op の `_` arm で握りつぶしていたため。型オブジェクトには bind する slot が無いので X::Bind を投げるべき
+（roast/S32-exceptions/misc.t が assert）。bind marker（`__mutsu_bind_index_value`）を値抽出時に追跡し、
+bind が非コンテナ fall-through に達したら X::Bind を投げるようにした。defined-Int / Str LHS（`10[0] := 1` 等）は
+元々パース時に invalid bind LHS として弾かれる（同じく X::Bind）。通常代入と Array/Hash element bind は不変。
+
+結果: `S32-exceptions/misc.t`（既 whitelist）の 2 つの `#?rakudo todo 'wrong exception'` ケースが green 化
+（**180/182 → 182/182**）。mutsu は test が期待する X::Bind を正確に投げる（rakudo 自身は BIND-POS の
+型オブジェクトエラーを投げるため roast では TODO）。pin: `t/bind-into-non-container.t`。
+
 ## 2026-07-02: §2 D — `state` を持つ multi 候補 / caching-proto body の OTF 化（#4047）
 
 GC 前の地ならし（PLAN §2 D、multi-dispatch の tree-walk fallback 除去）の一環。`state` を宣言する

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2136,7 +2136,7 @@ impl Interpreter {
         };
 
         // Detect bind marker (__mutsu_bind_index_value) and extract the actual value
-        let (val, bind_source) = match raw_val {
+        let (val, bind_source, was_bind) = match raw_val {
             Value::Pair(ref name, ref payload) if name == "__mutsu_bind_index_value" => {
                 match payload.as_ref() {
                     Value::Array(items, ..) if items.len() >= 2 => {
@@ -2148,12 +2148,12 @@ impl Interpreter {
                             }),
                             _ => None,
                         };
-                        (value, source)
+                        (value, source, true)
                     }
-                    other => (other.clone(), None),
+                    other => (other.clone(), None, true),
                 }
             }
-            other => (other, None),
+            other => (other, None, false),
         };
 
         // Phase 2 Stage 2: a `:=` bind to a stack-computed element target
@@ -2348,6 +2348,21 @@ impl Interpreter {
                 self.stack.push(val);
             }
             _ => {
+                // A `:=` bind of a positional/associative element requires a
+                // bindable container (Array/Hash) as the target. Binding into a
+                // type object (`(List)[0] := 1`, `(Int)[0] := 1`) or any other
+                // non-container value has no slot to bind and must throw X::Bind
+                // (Raku's own message here is the BIND-POS type-object error, but
+                // roast asserts X::Bind — S32-exceptions/misc.t). Without this the
+                // bind silently succeeded.
+                if was_bind {
+                    return Err(RuntimeError::typed(
+                        "X::Bind",
+                        [("target".to_string(), Value::str(target.to_string_value()))]
+                            .into_iter()
+                            .collect(),
+                    ));
+                }
                 self.stack.push(val);
             }
         }

--- a/t/bind-into-non-container.t
+++ b/t/bind-into-non-container.t
@@ -1,0 +1,31 @@
+use Test;
+
+# Binding a positional/associative element into a target that is not a bindable
+# container must throw X::Bind. A type object (`(List)`, `(Int)`) has no element
+# slot to bind, so `(List)[0] := 1` used to silently succeed (the generic
+# index-assign fell through to a no-op arm). It now throws X::Bind, matching
+# roast/S32-exceptions/misc.t (which asserts X::Bind for these). A *defined* Int
+# / Str LHS (`10[0] := 1`, `"Hi"[0] := 1`) is already rejected at parse time as
+# an invalid bind left-hand side, also surfacing as X::Bind.
+
+plan 7;
+
+throws-like '(List)[0] := 1', X::Bind, 'bind into an undefined List type object';
+throws-like '(Int)[0]  := 1', X::Bind, 'bind into an undefined Int type object';
+throws-like '(Any)[0]  := 1', X::Bind, 'bind into an undefined Any type object';
+throws-like '10[0]     := 1', X::Bind, 'bind into a defined Int';
+throws-like '"Hi"[0]   := 1', X::Bind, 'bind into a defined Str';
+
+# A genuine bindable container still binds (no false X::Bind).
+{
+    my @a;
+    @a[0] := my $x;
+    $x = 42;
+    is @a[0], 42, 'binding into an Array element still works (aliases the source)';
+}
+{
+    my %h;
+    %h<k> := my $y;
+    $y = 7;
+    is %h<k>, 7, 'binding into a Hash element still works (aliases the source)';
+}


### PR DESCRIPTION
## Summary

Part of PLAN.md §F — typed exceptions (`S32-exceptions/misc.t`).

`(List)[0] := 1` / `(Int)[0] := 1` — binding a positional element into a **type object** — silently succeeded. The generic index-assign op (`IndexAssignGeneric`) fell through to a no-op `_` arm for any target that is not an Array / Hash / HashEntryRef / Stash, so the bind was dropped with no error. A type object has no element slot to bind, so this must throw **X::Bind** (roast asserts it).

The bind marker (`__mutsu_bind_index_value`) is now tracked through value extraction; when a bind reaches the non-container fall-through arm it raises `X::Bind` instead of silently dropping the write. A defined-Int / Str LHS (`10[0] := 1`, `"Hi"[0] := 1`) was already rejected at parse time as an invalid bind LHS (also X::Bind); plain assignment and genuine Array/Hash element binds are unaffected.

## Impact

`roast/S32-exceptions/misc.t` (already whitelisted): the two `#?rakudo todo 'wrong exception'` cases now pass — **180/182 → 182/182**. mutsu throws the exact `X::Bind` the test asserts, where rakudo itself throws the BIND-POS type-object error (hence the roast TODO).

## Tests

- `t/bind-into-non-container.t` (new) — pins type-object binds (throw X::Bind) and Array/Hash element binds (still alias the source, no false positive).
- `make test` (1427 files, 13845 tests) PASS; clippy clean; `S32-exceptions/misc.t` + `misc2.t` PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)