### PR TITLE
fix(compiler): block-own my $x shadows outer var for nested subs from block start

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -60,13 +60,6 @@
 
 ## 2. 局所修正で進む残り
 
-### 2.1 `S04-declarations/my-6e.t`
-
-- **現状**: 108/109（test 61 のみ失敗）。
-- **論点**: 直近の一斉修正（block-local scope leak 修正、our-sub block-lexical capture 等）で
-  99→106→108 まで前進。残る test 61 は個別に最小再現を取って調査する。
-- **Canary**: `roast/S04-declarations/my-6e.t`
-
 ### 2.2 `S02-types/generics.t`
 
 - **現状**: 0/1（変化なし）。
@@ -315,15 +308,14 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t —
 「次に何をやるか」を 1 本だけ選ぶなら、順番はこう見るのが妥当。
 
 1. **`S06-operator-overloading/infix.t` の残り 7 件**（§2.4）— 局所修正で閉じられる可能性が高い。
-2. **`S04-declarations/my-6e.t` の test 61**（§2.1）— 残り 1 件。
-3. **`S17-lowlevel/lock.t` の race condition**（§6.1）— semaphore.t で確立した
+2. **`S17-lowlevel/lock.t` の race condition**（§6.1）— semaphore.t で確立した
    reconcile/writeback パターンを `Lock` にも適用できれば早い。
-4. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
+3. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
    splice.t / attributes.t / multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-5. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
+4. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
    残りの失敗を分類して潰す。
-6. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
+5. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
    一環として進める。
 
 whitelist を目標にしない §7 の項目は、mutsu 側の一般改善のついでに触れるのはよいが、

--- a/TODO_roast/S04.md
+++ b/TODO_roast/S04.md
@@ -77,7 +77,7 @@
 - [ ] roast/S04-declarations/implicit-parameter.t
 - [ ] roast/S04-declarations/multiple.t
   - 3/8 pass (tests 1-3). Failures: `my ($a, $b) = (1, 2)` destructuring works but `my ($a, @b)` with slurpy not supported; `my ($a, *@b)` splat syntax not implemented; `state` declarations not supported. Difficulty: Medium
-- [ ] roast/S04-declarations/my-6e.t
+- [x] roast/S04-declarations/my-6e.t
   - Conditional declarations now work: `my $x = INIT if/unless COND` keeps the
     *declaration* lexically unconditional (compile-time) and gates only the
     *initializer*. Parser fix: a bare `my $x` now routes through
@@ -225,6 +225,27 @@
       architectural item than a `my-6e.t`-local fix (name resolution would
       need to bind `$x` inside `f` to the innermost enclosing block's *own*
       `my $x` at compile time, independent of execution-order reachability).
+  - **Progress (2026-07-02): 79 fixed — 109/109, file whitelisted.** Rather
+    than the full lexical-scoping rework, a targeted fix: at block entry,
+    for every direct-child plain-scalar `my $x;` that shadows an
+    already-known same-named local (i.e. `alloc_local` would reuse an outer
+    slot), emit a `LoadNil; SetLocal(slot)` reset *before* hoisting any
+    nested `sub` in that block — mirroring the existing `hoist_sub_decls`
+    pre-pass, but resetting the *value* instead of just registering the
+    name. This makes the shadow observable from the very start of the block
+    (matching Raku's block-scope declaration visibility) instead of only
+    from the textual point where the `my` statement executes, without
+    requiring per-block-scoped storage. Scoped narrowly — only fires when
+    the block contains a nested `SubDecl` (the only way to observe the
+    early value) and only for plain lexical scalars (no sigil/twigil) — to
+    avoid clobbering a *type constraint* a sibling block left on a reused
+    `@`/`%` slot (e.g. `my Int @a` earlier, then an untyped `my @a` later
+    sharing the slot: an unconditional Nil reset there fails the typed
+    slot's type check, while a real initializer's value normally satisfies
+    it — this exact regression was caught in `t/array-slice-oob.t`,
+    `t/container-identity-phase2-complete.t`, and
+    `t/typed-array-mutate-preserves-type.t` during development and fixed by
+    narrowing the condition). `src/compiler/stmt.rs`.
 - [x] roast/S04-declarations/smiley.t
 - [ ] roast/S04-declarations/state.t
   - 46/46 pass (test 38 is a rakudo TODO which is expected to fail). Cannot whitelist: test 42 (2M function calls in lives-ok) takes ~20s CPU in release, which risks exceeding 30s wall-clock timeout under load.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -303,6 +303,7 @@ roast/S04-declarations/constant-6.d.t
 roast/S04-declarations/constant.t
 roast/S04-declarations/implicit-parameter.t
 roast/S04-declarations/multiple.t
+roast/S04-declarations/my-6e.t
 roast/S04-declarations/our.t
 roast/S04-declarations/smiley.t
 roast/S04-declarations/state.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -564,6 +564,56 @@ impl Compiler {
                     });
                     self.code.patch_block_pre_end(idx);
                     self.code.patch_block_enter_end(idx);
+                    // Raku's `my` declarations are visible for the entire
+                    // enclosing block, even though the value is only
+                    // (re-)initialized when execution reaches the declaration
+                    // statement. mutsu's per-routine local-slot storage
+                    // (`alloc_local` reuses the slot for a same-named
+                    // declaration) means a block's own `my $x` only shadows a
+                    // same-named outer local once its VarDecl statement
+                    // actually runs — so a hoisted nested `sub` invoked (via
+                    // forward reference) before that point would wrongly
+                    // observe the OUTER value instead of an undefined one.
+                    // Reset such shadowing slots to Nil right at block entry,
+                    // before hoisting nested subs, so the shadow is visible
+                    // from the very start of the block (roast
+                    // S04-declarations/my-6e.t: "declared below the calling
+                    // position"). Scoped narrowly to blocks that actually
+                    // declare a nested `sub` (the only way to observe the
+                    // early value) and to plain `$`-sigil scalars, to avoid
+                    // clobbering a lingering type constraint that a sibling
+                    // block left on a reused `@`/`%` slot (e.g. `my Int @a`
+                    // followed later by an untyped `my @a` sharing the slot —
+                    // an unconditional Nil reset there would fail the typed
+                    // slot's type check; a real initializer's value normally
+                    // satisfies it, so only the premature reset is unsafe).
+                    if stmts.iter().any(|s| matches!(s, Stmt::SubDecl { .. })) {
+                        for s in stmts.iter() {
+                            if let Stmt::VarDecl {
+                                name,
+                                is_state: false,
+                                is_our: false,
+                                custom_traits,
+                                ..
+                            } = s
+                                // Plain lexical scalars store a bare, sigil-stripped
+                                // name (`my $x` -> "x"); `@`/`%`/`&` sigils and
+                                // twigils (`.`/`!`/`*`) keep their marker prefix.
+                                && !name.starts_with('@')
+                                && !name.starts_with('%')
+                                && !name.starts_with('&')
+                                && !name.starts_with('.')
+                                && !name.starts_with('!')
+                                && !name.starts_with('*')
+                                && !name.contains("::")
+                                && let Some(&slot) = self.local_map.get(name.as_str())
+                                && !custom_traits.iter().any(|(t, _)| t == "__constant")
+                            {
+                                self.code.emit(OpCode::LoadNil);
+                                self.code.emit(OpCode::SetLocal(slot));
+                            }
+                        }
+                    }
                     // Hoist sub declarations: register subs first so forward
                     // references like `&fa` work before the sub is textually
                     // declared (Raku sub hoisting semantics).

--- a/t/named-sub-block-lexical-shadow.t
+++ b/t/named-sub-block-lexical-shadow.t
@@ -1,0 +1,51 @@
+use Test;
+
+# A block's own `my $x` shadows a same-named outer-scope variable for the
+# *entire* block, even before the `my` statement executes -- because `sub`
+# declarations are hoisted, a nested named `sub` called via forward
+# reference must see the block's own (still undefined) `$x`, not the outer
+# one. mutsu's per-routine local-slot storage reuses the outer slot for a
+# same-named `my`, so the shadow only used to take effect once the `my`
+# statement itself ran; a forward-referenced call before that point leaked
+# the outer value. roast: S04-declarations/my-6e.t.
+# https://github.com/Raku/old-issue-tracker/issues/2540
+
+plan 4;
+
+{
+    my $x = 1;
+    {
+        nok declare_later().defined,
+            'nested sub sees block-own $x as undefined before its my runs, not outer $x';
+        my $x;
+        sub declare_later {
+            $x;
+        }
+    }
+    is $x, 1, 'outer $x is unaffected by the inner shadow';
+}
+
+# No outer name collision: the previous fix must not regress this case.
+{
+    nok declare_later_fresh().defined,
+        'nested sub sees undefined before a non-shadowing my runs';
+    my $y;
+    sub declare_later_fresh {
+        $y;
+    }
+}
+
+# A block containing a nested sub, but where the shadowed name is a typed
+# `@`/`%` slot reused from a sibling block, must not have its type check
+# clobbered by the reset (regression guard: this fix is scoped to plain
+# scalars only).
+{
+    my Int @a = 1, 2, 3;
+}
+{
+    my @a = 4, 5, 6;
+    sub reads_a { @a }
+    is-deeply reads_a(), [4, 5, 6], 'typed-slot reuse with a nested sub does not throw';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- A block's own `my $x` now shadows a same-named outer-scope variable for the entire block (Raku's block-scope declaration visibility), not just from the textual point of the `my` statement — fixing a nested named `sub` (hoisted, callable via forward reference) that reads the variable before its `my` statement runs.
- `roast/S04-declarations/my-6e.t`: 108/109 → 109/109, added to `roast-whitelist.txt`.
- Root cause: mutsu's per-routine flat local-slot storage (`alloc_local`) reuses the outer slot for a same-named `my`, so the shadow only took effect once the `my` statement itself executed. A block that declares a nested `sub` referencing the shadowed name, called via forward reference before the `my` runs, leaked the outer value.
- Fix is scoped narrowly: only resets plain lexical scalars (no sigil/twigil), and only in blocks that contain a nested `sub` declaration — avoiding an earlier regression I caught locally where an unconditional reset clobbered a type constraint left on a reused `@`/`%` slot by a sibling block (`my Int @a` then later untyped `my @a`).

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `make test` passes (1428 files)
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S04-declarations/my-6e.t` → 109/109 PASS
- [x] New regression test `t/named-sub-block-lexical-shadow.t`, verified matching output against real `raku`
- [x] Regression check against the type-constraint interaction: `t/array-slice-oob.t`, `t/container-identity-phase2-complete.t`, `t/typed-array-mutate-preserves-type.t` all pass
- [x] CI (make test + make roast) — watching in background

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK