### PR TITLE
fix(class): X::Redeclaration for same-scope class redeclaration

### DIFF
--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -9,6 +9,7 @@ pub(super) struct LexicalScopeSnapshot {
     constant_vars_in_scope: std::collections::HashSet<String>,
     constant_vars_current_scope: std::collections::HashSet<String>,
     my_vars_current_scope: std::collections::HashSet<String>,
+    class_names_current_scope: std::collections::HashSet<String>,
 }
 
 impl Compiler {
@@ -31,6 +32,9 @@ impl Compiler {
             // The entered block starts with no `my` vars of its own, so a same-named
             // `my` inside it shadows (rather than redeclares) an outer one.
             my_vars_current_scope: std::mem::take(&mut self.my_vars_current_scope),
+            // Likewise a same-named class inside an inner block shadows rather
+            // than redeclares the outer one.
+            class_names_current_scope: std::mem::take(&mut self.class_names_current_scope),
         }
     }
 
@@ -46,6 +50,7 @@ impl Compiler {
         self.constant_vars_in_scope = saved.constant_vars_in_scope;
         self.constant_vars_current_scope = saved.constant_vars_current_scope;
         self.my_vars_current_scope = saved.my_vars_current_scope;
+        self.class_names_current_scope = saved.class_names_current_scope;
     }
 
     pub(super) fn apply_dynamic_scope_pragma(&mut self, arg: Option<&Expr>) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -128,6 +128,12 @@ pub(crate) struct Compiler {
     /// (`my $f = 10`) does run the assignment. Tracked here so the VarDecl
     /// compiler can suppress the reset for the bare-redeclaration case.
     my_vars_current_scope: std::collections::HashSet<String>,
+    /// Names of fully-defined classes/roles declared in the *current* lexical
+    /// block only (reset on block entry). Declaring the same class name twice in
+    /// one scope is an X::Redeclaration ("Redeclaration of symbol 'A'"); a stub
+    /// (`class A {...}`) followed by its real definition is NOT a redeclaration,
+    /// and a same-named class in an inner block shadows rather than redeclares.
+    class_names_current_scope: std::collections::HashSet<String>,
     /// Names of constants declared in an *enclosing* compiler (i.e. visible at a
     /// nested closure's definition point). Propagated into child closure
     /// compilers (which otherwise start with empty constant state). Used ONLY to
@@ -218,6 +224,7 @@ impl Compiler {
             constant_vars_in_scope: std::collections::HashSet::new(),
             constant_vars_current_scope: std::collections::HashSet::new(),
             my_vars_current_scope: std::collections::HashSet::new(),
+            class_names_current_scope: std::collections::HashSet::new(),
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             last_source_line: None,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2844,7 +2844,27 @@ impl Compiler {
                 self.code.emit(OpCode::RegisterEnum(idx));
             }
             Stmt::ClassDecl { body, .. } if self.emit_block_placeholder_die(body) => {}
-            Stmt::ClassDecl { .. } => {
+            Stmt::ClassDecl { name, body, .. } => {
+                // Declaring the same class name twice in one lexical scope is an
+                // X::Redeclaration ("Redeclaration of symbol 'A'"), matching Raku's
+                // compile-time check. A stub (`class A {...}`) followed by its real
+                // definition is NOT a redeclaration (the stub carries no full body),
+                // and a same-named class in an inner block shadows rather than
+                // redeclares (the current-scope set is reset on block entry).
+                if !Self::is_stub_class_body(body) {
+                    let cname = name.resolve();
+                    if !self.class_names_current_scope.insert(cname.clone()) {
+                        let sym = cname.rsplit("::").next().unwrap_or(&cname).to_string();
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("symbol".to_string(), Value::str(sym));
+                        attrs.insert("what".to_string(), Value::str_from("symbol"));
+                        let err = Value::make_instance(Symbol::intern("X::Redeclaration"), attrs);
+                        let cidx = self.code.add_constant(err);
+                        self.code.emit(OpCode::LoadConst(cidx));
+                        self.code.emit(OpCode::Die);
+                        return;
+                    }
+                }
                 // Pre-qualify the class name when compiling inside a
                 // `unit module`/`unit class` body so that the runtime
                 // registers it under the correct nested package

--- a/t/class-redeclaration.t
+++ b/t/class-redeclaration.t
@@ -1,0 +1,28 @@
+use Test;
+
+# Declaring the same class name twice in one lexical scope is a compile-time
+# X::Redeclaration ("Redeclaration of symbol 'A'"), matching Raku. mutsu used to
+# silently accept the second declaration. A stub (`class A {...}`) followed by
+# its real definition is NOT a redeclaration, and a same-named class in an inner
+# block shadows (rather than redeclares) an outer one.
+
+plan 6;
+
+throws-like 'class A {}; class A {}', X::Redeclaration,
+    'same-scope class redeclaration throws X::Redeclaration';
+throws-like 'class B { has $.x }; class B { has $.y }', X::Redeclaration,
+    'redeclaration with different bodies still throws';
+throws-like 'role R {}; role R {}', X::Redeclaration,
+    'same-scope role redeclaration also throws X::Redeclaration';
+
+# A stub followed by its real definition is legal.
+lives-ok { EVAL 'class Node { ... }; class Node { has $.v }; Node.new(v => 1)' },
+    'stub class followed by its real definition is not a redeclaration';
+
+# Same class name in two separate blocks shadows, not redeclares.
+lives-ok { EVAL '{ class C { has $.x } }; { class C { has $.y } }' },
+    'same-named class in separate blocks does not redeclare';
+
+# A single ordinary declaration is of course fine.
+lives-ok { EVAL 'class D { has $.z }; D.new(z => 2)' },
+    'single class declaration is fine';


### PR DESCRIPTION
## Summary

Part of PLAN.md §F — typed exceptions (X::Redeclaration).

`class A {}; class A {}` in one lexical scope silently accepted the second declaration; Raku raises a compile-time **X::Redeclaration** ("Redeclaration of symbol 'A'"). The compiler now tracks fully-defined class names per lexical block (a new `class_names_current_scope` set, reset on block entry like the existing `my` / `constant` scope sets) and emits X::Redeclaration when the same name is defined twice in one scope.

### Correctly excluded (not a redeclaration)

- a **stub** (`class A {...}`) followed by its real definition — the stub carries no full body (detected via `is_stub_class_body`);
- a same-named class in an **inner block** — shadowing, not redeclaration (the current-scope set is reset on block entry);
- **`augment class A`** — a distinct `Stmt::AugmentClass`, never reaches this arm.

### Scope

This is the same-compilation-unit case. The cross-EVAL case (`roast/S02-names-vars/names.t` test 142 — three separate EVALs of `class A`) needs runtime package-registry detection with compilation-unit tracking, and stays on the existing `// TODO` in `exec_register_class_op`. So this PR is a genuine correctness improvement (mutsu now matches Raku for the common in-file case) but does not yet whitelist a new roast file.

## Tests

- `t/class-redeclaration.t` (new) — pins the throw (class + role) and the three excluded non-redeclaration shapes (stub→def, separate blocks, single decl).
- `make test` (1429 files, 13860 tests) PASS; clippy clean; class/role roast spot-checks (S12-class/basic, S14-roles/basic) PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)