### PR TITLE
fix(parser): resolve &infix:<<$var>> / «$var» / [$var] operator names at runtime

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -102,11 +102,22 @@
 
 ### 2.4 `S06-operator-overloading/infix.t`
 
-- **現状**: 35/42（7 失敗: test 22-23, 28, 31-32, 35, 40）。
-- **経緯**: `import ClassName` 経由の演算子メソッド export（#3982）で 14→35 まで前進したが、
-  直近のコミットメッセージが示唆する「ほぼ完了」には未達。test 11 は rakudo 自身が
-  `#?rakudo todo` で divergent としている既知の1件で、それとは別に 7 件が未解決。
-- **評価**: whitelist する前にこの 7 件を個別に潰す必要がある。安易に whitelist しないこと。
+- **現状（2026-07-02 更新）**: 48/50（残り 2 失敗: test 31-32 のみ）。test 11, 33 は
+  rakudo 自身が divergent としている既知の TODO で数に入らない。
+- **経緯**: `import ClassName` 経由の演算子メソッド export（#3982）→ 35/42 → LTM 拡張・
+  `is assoc('non')`・user-declared `infix:<+>`/`infix:<+=>` fast-path override・
+  `infix:OP:[...]`/`infix:OP:«...»` 呼び出し構文で 42/44 → `&infix:<<$var>>`/`«$var»`/
+  `[$var]`（interpolating/expression な演算子名参照。詳細は `TODO_roast/S06.md`）の
+  ランタイム解決を追加して 48/50 まで前進。
+- **残り (test 31-32)**: `sub infix:<,>($a,$b){...}` によるカンマ演算子そのものの
+  オーバーロード（EVAL 内限定）。カンマは list/引数区切りとしてパーサ全体に
+  ハードコードされた特殊トークンであり、他の user 演算子のような汎用 dispatch
+  経路に乗っていない。real raku でも EVAL の外（同一ファイルのトップレベル）では
+  効かない——EVAL は新しいコンパイル単位として、宣言済みの演算子テーブルを
+  引き継いで再パースするため機能する、という compile-time な仕組み。
+- **評価**: 深い・リスクの高いアーキテクチャ変更（カンマを他の user 演算子と同じ
+  拡張可能テーブル経由にする必要があり、あらゆる箇所の区切り用途を壊さずに行う
+  必要がある）。安易に着手しない。whitelist するにはこの 2 件を解決する必要がある。
 - **Canary**: `roast/S06-operator-overloading/infix.t`
 
 ---
@@ -307,16 +318,18 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t —
 
 「次に何をやるか」を 1 本だけ選ぶなら、順番はこう見るのが妥当。
 
-1. **`S06-operator-overloading/infix.t` の残り 7 件**（§2.4）— 局所修正で閉じられる可能性が高い。
-2. **`S17-lowlevel/lock.t` の race condition**（§6.1）— semaphore.t で確立した
+1. **`S17-lowlevel/lock.t` の race condition**（§6.1）— semaphore.t で確立した
    reconcile/writeback パターンを `Lock` にも適用できれば早い。
-3. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
+2. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
    splice.t / attributes.t / multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-4. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
+3. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
    残りの失敗を分類して潰す。
-5. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
+4. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
    一環として進める。
+
+`S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が
+深いアーキテクチャ変更を要するため、上記優先順から外した。
 
 whitelist を目標にしない §7 の項目は、mutsu 側の一般改善のついでに触れるのはよいが、
 そのファイル単体を通すことを目的にしない。

--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -148,11 +148,50 @@
       - Remaining 2 failures (31-32, `sub infix:<,>(...)`) are a deep feature:
         overriding the comma operator itself, which is used pervasively for
         list construction/call args — not attempted.
-      - New mid-file abort discovered further in (test 45,
-        `&infix:<<$plus>>(3,4)` / `&infix:«$plus»`/`&infix:[$plus]` — a
-        *variable*, not a literal, inside the operator-name brackets, needing a
-        genuine dynamic/runtime symbolic operator lookup): not attempted, would
-        need its own investigation.
+      - **Progress (2026-07-02): 48/50 (was 42/44; mid-file abort at test 45
+        fixed). Only 31-32 remain.** `&infix:<<$plus>>(3,4)` / `&infix:«$plus»`
+        / `&infix:[$plus]` (a *variable*, not a literal, inside the
+        operator-name brackets) now resolve the operator name at runtime.
+        Root cause: `parse_operator_code_ref_suffix`
+        (`parser/primary/var/sigil_vars.rs`) built a `CodeVar(String)` — a
+        compile-time constant name — for ALL four delimiter forms, including
+        the two (`<<...>>`/`«...»`) that are qq-style *interpolating* quotes
+        in Raku (mirroring the existing `<...>` vs `<<...>>`/`«...»`
+        distinction already implemented for ordinary word-quote lists in
+        `angle_words.rs`) and `[...]`, which takes a full expression (not
+        just a quoted-string literal). A separate, earlier-run legacy path
+        (`parse_sub_name_pub` → `sub_name.rs::parse_sub_name_inner`) has its
+        own `:<<...>>`/`:«...»` handling that only resolves through a
+        *compile-time-constant* registry (`constant NAME = "lit"`
+        declarations) and silently falls back to the raw unresolved text
+        (`"$plus"`) otherwise — gated off via a `!op_name.contains(['$', '@',
+        '%'])` guard so it no longer shadows the fix.
+        Fix: for the interpolating/expression forms, build the operator name
+        as `Expr::SymbolicDeref { sigil: "&", expr: <category ~ name_expr ~
+        ">"> }` — the SAME node already used for `&::("infix:<+>")` symbolic
+        code-var dereference, whose compiler/VM support (`expr.rs`,
+        `vm_misc_codevar.rs`) needed no changes; `<<...>>`/`«...»` content is
+        parsed via the qq-interpolation engine
+        (`quote_adverbs::process_content_with_flags`), `[...]` via a full
+        expression parse. The literal `:<...>` form is untouched (stays a
+        `CodeVar` compile-time constant, required for e.g. `my
+        &infix:<c> = {...}` assignment-target semantics). Test:
+        `t/operator-reference-double-angle.t` (extended), matches real
+        `raku` exactly (confirmed `BEGIN my $plus = '+'` is required for
+        real raku too — it resolves the interpolated name at the point the
+        statement executes, same as mutsu's runtime resolution).
+      - **Remaining (31-32, `sub infix:<,>(...)`): a deep, higher-risk
+        feature — overriding the comma operator itself, which is a hardcoded
+        list/arg-separator token used pervasively throughout the parser (list
+        literals, call arguments, hash literals, ...), not a generically
+        dispatched infix operator. Real raku only honors this override
+        inside a fresh `EVAL` (a new compilation unit re-parses with the
+        newly-declared operator already in the operator table); the *same*
+        file's non-EVAL'd top-level `5, 5` stays a plain list even after
+        `sub infix:<,>` is declared earlier in the file. Not attempted —
+        would need comma to route through the extensible user-operator
+        table the same way `sub infix:<*+>` etc. already do, without
+        breaking every other use of `,` as a separator.**
 - [ ] roast/S06-operator-overloading/methods.t
 - [ ] roast/S06-operator-overloading/prefix.t
 - [ ] roast/S06-operator-overloading/semicolon.t

--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::ast::Expr;
 use crate::parser::helpers::{is_raku_identifier_start, normalize_raku_identifier, ws};
 use crate::parser::parse_result::{PError, PResult, parse_char};
+use crate::value::Value;
 
 use super::adverb::parse_var_name_adverb_suffixes;
 use super::ident::{
@@ -423,6 +424,15 @@ pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
                 || n.starts_with("postcircumfix:<")
                 || n.starts_with("trait_mod:<")
         )
+        // `parse_sub_name_pub` only resolves a `:<<...>>`/`:«...»` operator
+        // name through the compile-time-*constant* registry (`constant`
+        // declarations), falling back to the raw, unresolved text when the
+        // name isn't a registered constant (e.g. `BEGIN my $plus = '+'`).
+        // A leftover interpolation sigil in the resolved name means that
+        // fallback fired, so skip this static path and let the slower
+        // `parse_operator_code_ref_suffix` path below build a genuine
+        // runtime lookup instead.
+        && !op_name.contains(['$', '@', '%'])
     {
         return Ok((op_rest, Expr::CodeVar(op_name)));
     }
@@ -435,9 +445,30 @@ pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
             name,
             "infix" | "prefix" | "postfix" | "term" | "circumfix" | "postcircumfix" | "trait_mod"
         )
-        && let Some((r, full_name)) = parse_operator_code_ref_suffix(name, rest)
+        && let Some((r, suffix)) = parse_operator_code_ref_suffix(name, rest)
     {
-        return Ok((r, Expr::CodeVar(full_name)));
+        let code_var_expr = match suffix {
+            OperatorCodeRefSuffix::Static(full_name) => Expr::CodeVar(full_name),
+            // `:<<...>>` / `:«...»` / a bare `:[...]` interpolate/evaluate their
+            // content at runtime (unlike the literal `:<...>` form), so the
+            // operator name is only known at runtime. Build it as string
+            // concatenation and resolve it the same way `&::("infix:<+>")`
+            // does (SymbolicDeref), rather than a compile-time CodeVar
+            // constant.
+            OperatorCodeRefSuffix::Dynamic(name_expr) => Expr::SymbolicDeref {
+                sigil: "&".to_string(),
+                expr: Box::new(Expr::Binary {
+                    left: Box::new(Expr::Binary {
+                        left: Box::new(Expr::Literal(Value::str(format!("{name}:<")))),
+                        op: crate::token_kind::TokenKind::Tilde,
+                        right: Box::new(name_expr),
+                    }),
+                    op: crate::token_kind::TokenKind::Tilde,
+                    right: Box::new(Expr::Literal(Value::str(">".to_string()))),
+                }),
+            },
+        };
+        return Ok((r, code_var_expr));
     }
     let full_name = if twigil.is_empty() {
         normalize_raku_identifier(name)
@@ -447,13 +478,32 @@ pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
     Ok((rest, Expr::CodeVar(full_name)))
 }
 
-fn parse_operator_code_ref_suffix<'a>(category: &str, rest: &'a str) -> Option<(&'a str, String)> {
+/// The operator name suffix (`:<+>`, `:<<$plus>>`, `:«$plus»`, `:[$plus]`)
+/// following an extended identifier category (`infix`, `prefix`, ...).
+enum OperatorCodeRefSuffix {
+    /// `:<...>` (and the quoted-string `:['...']`/`:["..."]` forms) — the
+    /// operator name is known at compile time.
+    Static(String),
+    /// `:<<...>>` / `:«...»` (qq-style interpolation) or a bare `:[expr]`
+    /// (a runtime expression) — the operator name is only known at
+    /// runtime.
+    Dynamic(Expr),
+}
+
+fn parse_operator_code_ref_suffix<'a>(
+    category: &str,
+    rest: &'a str,
+) -> Option<(&'a str, OperatorCodeRefSuffix)> {
     if let Some(after_open) = rest.strip_prefix(":<<")
         && let Some(end_pos) = after_open.find(">>")
     {
         let symbol = after_open[..end_pos].trim();
         let after_close = &after_open[end_pos + 2..];
-        return Some((after_close, format!("{category}:<{symbol}>")));
+        let name_expr = crate::parser::primary::quote_adverbs::process_content_with_flags(
+            symbol,
+            &crate::parser::primary::quote_adverbs::QuoteFlags::qq_double(),
+        );
+        return Some((after_close, OperatorCodeRefSuffix::Dynamic(name_expr)));
     }
 
     if let Some(after_open) = rest.strip_prefix(":<") {
@@ -467,7 +517,10 @@ fn parse_operator_code_ref_suffix<'a>(category: &str, rest: &'a str) -> Option<(
                     if depth == 0 {
                         let symbol = &after_open[..i];
                         let after_close = &after_open[i + 1..];
-                        return Some((after_close, format!("{category}:<{symbol}>")));
+                        return Some((
+                            after_close,
+                            OperatorCodeRefSuffix::Static(format!("{category}:<{symbol}>")),
+                        ));
                     }
                 }
                 '<' => depth += 1,
@@ -484,7 +537,11 @@ fn parse_operator_code_ref_suffix<'a>(category: &str, rest: &'a str) -> Option<(
     {
         let symbol = after_open[..end_pos].trim();
         let after_close = &after_open[end_pos + '\u{bb}'.len_utf8()..];
-        return Some((after_close, format!("{category}:<{symbol}>")));
+        let name_expr = crate::parser::primary::quote_adverbs::process_content_with_flags(
+            symbol,
+            &crate::parser::primary::quote_adverbs::QuoteFlags::qq_double(),
+        );
+        return Some((after_close, OperatorCodeRefSuffix::Dynamic(name_expr)));
     }
 
     if let Some(after_open) = rest.strip_prefix(":['")
@@ -494,7 +551,10 @@ fn parse_operator_code_ref_suffix<'a>(category: &str, rest: &'a str) -> Option<(
             .replace("\\'", "'")
             .replace("\\\\", "\\");
         let after_close = &after_open[end_pos + 2..];
-        return Some((after_close, format!("{category}:<{symbol}>")));
+        return Some((
+            after_close,
+            OperatorCodeRefSuffix::Static(format!("{category}:<{symbol}>")),
+        ));
     }
 
     if let Some(after_open) = rest.strip_prefix(":[\"")
@@ -502,7 +562,19 @@ fn parse_operator_code_ref_suffix<'a>(category: &str, rest: &'a str) -> Option<(
     {
         let symbol = &after_open[..end_pos];
         let after_close = &after_open[end_pos + 2..];
-        return Some((after_close, format!("{category}:<{symbol}>")));
+        return Some((
+            after_close,
+            OperatorCodeRefSuffix::Static(format!("{category}:<{symbol}>")),
+        ));
+    }
+
+    // A bare expression inside `[...]` (no quotes), e.g. `&infix:[$plus]` —
+    // the operator name is a runtime value, not a string literal.
+    if let Some(after_open) = rest.strip_prefix(":[")
+        && let Ok((after_expr, expr)) = crate::parser::expr::expression(after_open)
+        && let Some(after_close) = after_expr.strip_prefix(']')
+    {
+        return Some((after_close, OperatorCodeRefSuffix::Dynamic(expr)));
     }
 
     None

--- a/t/operator-reference-double-angle.t
+++ b/t/operator-reference-double-angle.t
@@ -1,7 +1,18 @@
 use Test;
 
-plan 2;
+plan 5;
 
 my &eq = &infix:<<(==)>>;
 ok eq(42, 42), '&infix:<<(==)>> returns a callable infix operator';
 ok !eq(42, 41), '&infix:<<(==)>> callable preserves infix semantics';
+
+# `<<...>>` / `«...»` / `[...]` interpolate/evaluate their content at
+# runtime, unlike the literal `<...>` form -- the enclosed variable/
+# expression names the operator dynamically. roast:
+# S06-operator-overloading/infix.t.
+{
+    BEGIN my $plus = '+';
+    is &infix:<<$plus>>(3, 4), 7, '&infix:<<$var>> resolves the operator name at runtime';
+    is &infix:«$plus»(3, 4), 7, '&infix:«$var» resolves the operator name at runtime';
+    is &infix:[$plus](3, 4), 7, '&infix:[$var] resolves the operator name at runtime';
+}


### PR DESCRIPTION
## Summary
- `&category:<<...>>` and `&category:«...»` are qq-style *interpolating* quotes in Raku (mirroring the existing `<...>` vs `<<...>>`/`«...»` distinction already implemented for ordinary word-quote lists), and `&category:[...]` takes a full expression — none of these are compile-time string literals. mutsu's parser built a compile-time `CodeVar(String)` constant for all four delimiter forms, so a variable/expression inside the brackets was captured as its literal, unevaluated source text.
- A separate, earlier-run legacy path (`parse_sub_name_pub`) had its own handling that only resolves through a compile-time *constant* registry (`constant NAME = "lit"` declarations), silently falling back to raw unresolved text otherwise — gated off via a "contains an interpolation sigil" guard.
- Fix: build the operator name as `Expr::SymbolicDeref { sigil: "&", expr: <category ~ name_expr ~ ">"> }` for the interpolating/expression forms — the same node already used for `&::("infix:<+>")`, so no compiler/VM changes were needed. The literal `:<...>` form is untouched.
- `roast/S06-operator-overloading/infix.t`: 44/50 → 48/50. Only tests 31-32 remain (comma-operator overload via EVAL) — documented in `TODO_roast/S06.md`/`BLOCKERS.md` as a deep, out-of-scope architecture change (comma is a hardcoded list/arg separator throughout the parser, not a generically dispatched operator). File is **not** added to the whitelist since it still has 2 failing tests.

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `make test` passes (1430 files)
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S06-operator-overloading/infix.t` → 48/50 (was 44/50)
- [x] Extended regression test `t/operator-reference-double-angle.t`, verified matching output against real `raku` (including the `BEGIN` requirement for compile-time-visible interpolated names)
- [x] CI (make test + make roast) — watching in background

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK