### PR TITLE
fix(lazy): bind a single lazy/infinite source to a *@ slurpy lazily (§F lazy-seq ④)

### DIFF
--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -663,6 +663,48 @@ impl Interpreter {
                     } else {
                         format!("@{}", pd.name)
                     };
+                    // Single lazy source to a `*@` slurpy: bind the slurpy
+                    // directly to the lazy list (kept lazy — `.is-lazy` True,
+                    // reify-on-index) rather than flattening it, which would hang
+                    // on an infinite source or (below) drop it in as a capped
+                    // prefix. Matches Rakudo's `sub f(*@x){}; f(1..Inf)` → @x lazy.
+                    // Only for the plain (non-alias) `*@` case with exactly one
+                    // remaining positional argument. (lazy-arrays.md L4)
+                    let single_lazy_value: Option<Value> = if !is_alias_slurpy {
+                        let rest: Vec<Value> = args[positional_idx..]
+                            .iter()
+                            .map(|a| unwrap_varref_value(a.clone()))
+                            .filter(|a| !matches!(a, Value::Pair(..)))
+                            .collect();
+                        match rest.as_slice() {
+                            [Value::LazyList(ll)] if ll.is_genuinely_lazy() => Some(
+                                Value::LazyList(std::sync::Arc::new(ll.with_array_context())),
+                            ),
+                            // A bare infinite range (`f(1..Inf)` / `f(1..*)`) also
+                            // stays lazy: convert it to the same reify-on-index lazy
+                            // array `my @a = 1..*` produces.
+                            [other] => {
+                                crate::runtime::utils::infinite_int_range_to_lazy_array(other)
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some(slurpy_value) = single_lazy_value {
+                        if !pd.name.is_empty() {
+                            self.bind_param_value(&slurpy_key, slurpy_value.clone());
+                            self.bind_param_type_constraint(
+                                &slurpy_key,
+                                pd.type_constraint.clone(),
+                            );
+                        }
+                        if let Some(sub_params) = &pd.sub_signature {
+                            bind_sub_signature_from_value(self, sub_params, &slurpy_value)?;
+                        }
+                        positional_idx = args.len();
+                        continue;
+                    }
                     while positional_idx < args.len() {
                         let raw_arg = args[positional_idx].clone();
                         // The source name comes from the varref capture the caller

--- a/t/slurpy-lazy-source.t
+++ b/t/slurpy-lazy-source.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A single lazy/infinite source bound to a `*@` slurpy stays lazy (ANALYSIS §F
+# lazy-seq ④ / lazy-arrays.md L4). Previously `flatten_into_slurpy` dropped a
+# `Value::LazyList` (a `.map` pipeline) in as ONE element, so `@x[0]` returned the
+# whole Seq gist instead of the first element.
+
+plan 6;
+
+# A lazy .map pipeline through a slurpy: elements reify on index, stays lazy.
+{
+    sub f(*@x) { @x[^3].join(',') }
+    is f((1..Inf).map(* * 2)), '2,4,6', 'lazy .map pipeline flattens through *@ slurpy';
+}
+{
+    sub g(*@x) { @x.is-lazy }
+    ok g((1..Inf).map(* * 2)), '*@ slurpy of a lazy .map pipeline is lazy';
+}
+
+# A bare infinite range through a slurpy: stays lazy, reifies on index.
+{
+    sub h(*@x) { @x[0] }
+    is h(1..Inf), 1, '*@ slurpy of an infinite range reifies element 0';
+}
+{
+    sub i(*@x) { @x.is-lazy }
+    ok i(1..Inf), '*@ slurpy of an infinite range is lazy';
+}
+
+# An infinite source returned from a call, then slurped, indexes correctly.
+{
+    sub src { (1..Inf).map(* * 2) }
+    sub j(*@x) { @x[^3].join(',') }
+    is j(src()), '2,4,6', 'slurpy of a returned lazy Seq indexes correctly';
+}
+
+# The lazy slurpy gists as a placeholder rather than hanging.
+{
+    sub k(*@x) { @x.gist }
+    is k(1..Inf), '[...]', 'lazy slurpy gist is a placeholder (no hang)';
+}


### PR DESCRIPTION
## Summary

ANALYSIS §F lazy-seq ④ / `docs/lazy-arrays.md` L4 — "slurpy 真 lazy". Binding a lazy source to a `*@` flattening slurpy went through `flatten_into_slurpy`, whose `other` arm dropped a `Value::LazyList` (e.g. a `.map` pipeline) in as a **single element**. So `@x[0]` returned the whole Seq's gist (`(...)`) and an infinite `.map` pipeline through a slurpy produced garbage:

```raku
sub f(*@x) { @x }
f((1..Inf).map(* * 2))[^3]   # was ((...) (Any) (Any))  →  now (2 4 6)
f(1..Inf).is-lazy            # was False               →  now True
```

## Fix

Add a single-lazy-source fast path to the `*@` slurpy binding (`binding_signature.rs`): when exactly one remaining positional argument is a genuinely-lazy `LazyList` (a lazy Seq / `.map`/`.grep` pipeline) or a bare infinite range (`1..Inf` / `1..*`), bind the slurpy `@x` **directly** to that lazy source — kept lazy (`.is-lazy` True, reify-on-index) — instead of eagerly flattening it (which either hung or dropped it as one element).

- The lazy slurpy gists as `[...]` (no hang).
- Multi-arg and finite cases keep flattening as before.

Matches Rakudo for `f(1..Inf)`, `f(1..*)`, and returned lazy `.map`/`.grep` pipelines.

## Remaining ④ residue
- `is-lazy` preservation after an element *mutation* (partial-reify + lazy tail — `lazy-arrays.md` §4.1)
- `push`/`pop` on a lazy list throwing `X::…` (Rakudo errors)
- `.gist` — already renders placeholders without forcing (L1, done)

## Verification
- New `t/slurpy-lazy-source.t`
- Full `t/` suite: PASS (1432 files); `cargo test`: 477 pass
- 49-file signature/multi/lazy roast subset: green (incl. `slurpy-params.t`)
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)