### PR TITLE
fix(subset): surface a subset where-predicate's fail() message on assignment (subtypes.t 25)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1124,6 +1124,15 @@ pub struct Interpreter {
     /// Cleared per-name on subset redeclaration; starts empty per thread (the
     /// cache is a pure recomputable optimization). See `type_matches_value`.
     subset_predicate_cache: HashMap<String, SubsetPredicateCompiled>,
+    /// Side-channel: the exception raised by the most recent subset `where`
+    /// predicate that failed by *throwing* (a `fail "msg"` inside the `where`,
+    /// e.g. `subset Even of Int where { $_ %% 2 or fail "..." }`). `type_matches_value`
+    /// records it here (returning `false` as usual), so the ASSIGNMENT/binding
+    /// type-check can surface the custom message instead of the generic
+    /// "expected X, got Y". Smartmatch / dispatch callers ignore it (a `where`
+    /// that fails is just "no match" there). Set to `None` before each subset
+    /// predicate runs; consumed (and cleared) by the type-check op.
+    pub(crate) subset_where_fail: Option<Box<RuntimeError>>,
     private_zeroarg_method_cache: HashMap<(String, String), Option<(String, MethodDef)>>,
     module_load_stack: Vec<String>,
     /// The current distribution context ($?DISTRIBUTION).

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1981,6 +1981,7 @@ impl Interpreter {
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
+            subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
             current_distribution: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -201,6 +201,7 @@ impl Interpreter {
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
+            subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
             current_distribution: self.current_distribution.clone(),

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -253,6 +253,16 @@ impl Interpreter {
         compiled
     }
 
+    /// Record the exception raised by a subset `where` predicate that failed by
+    /// throwing (a `fail "msg"` inside the `where`). Only genuine failures /
+    /// user exceptions are kept — a control-flow signal (`return`/`last`/…) is
+    /// not a type-check message. See `subset_where_fail`.
+    fn record_subset_where_fail(&mut self, e: RuntimeError) {
+        if e.is_fail() || e.exception.is_some() {
+            self.subset_where_fail = Some(Box::new(e));
+        }
+    }
+
     pub(crate) fn type_matches_value(&mut self, constraint: &str, value: &Value) -> bool {
         if let Value::Scalar(inner) = value {
             return self.type_matches_value(constraint, inner.as_ref());
@@ -555,6 +565,9 @@ impl Interpreter {
                 return false;
             }
             let predicate_value = self.coerce_value_for_constraint(&subset.base, value.clone());
+            // Clear any stale `where`-`fail` message; captured below if this
+            // subset's predicate fails by throwing (see `subset_where_fail`).
+            self.subset_where_fail = None;
             let ok = if let Some(pred) = &subset.predicate {
                 // A predicate that takes its candidate value through a single
                 // simple variable is equivalent to running its body with that
@@ -589,10 +602,13 @@ impl Interpreter {
                     let compiled = self.compile_subset_predicate(constraint, body);
                     let saved = self.env.get(bind_name).cloned();
                     self.env.insert(bind_name.to_string(), predicate_value);
-                    let result = self
-                        .eval_precompiled_block_fast(&compiled.0, &compiled.1)
-                        .map(|v| v.truthy())
-                        .unwrap_or(false);
+                    let result = match self.eval_precompiled_block_fast(&compiled.0, &compiled.1) {
+                        Ok(v) => v.truthy(),
+                        Err(e) => {
+                            self.record_subset_where_fail(e);
+                            false
+                        }
+                    };
                     if let Some(old) = saved {
                         self.env.insert(bind_name.to_string(), old);
                     } else {
@@ -615,21 +631,45 @@ impl Interpreter {
                     if is_callable_expr {
                         // Evaluate to get a callable, then call with the value
                         match self.eval_precompiled_block_fast(&compiled.0, &compiled.1) {
-                            Ok(callable @ Value::Sub(_)) => self
-                                .call_sub_value(callable, vec![predicate_value], false)
-                                .map(|v| v.truthy())
-                                .unwrap_or(false),
+                            Ok(callable @ Value::Sub(_)) => {
+                                match self.call_sub_value(callable, vec![predicate_value], false) {
+                                    // A `fail "msg"` inside the predicate body
+                                    // returns an unhandled Failure (not an Err) from
+                                    // the sub call; capture its message too.
+                                    Ok(v) => {
+                                        if let Some(e) =
+                                            self.failure_to_runtime_error_if_unhandled(&v)
+                                        {
+                                            self.record_subset_where_fail(e);
+                                            false
+                                        } else {
+                                            v.truthy()
+                                        }
+                                    }
+                                    Err(e) => {
+                                        self.record_subset_where_fail(e);
+                                        false
+                                    }
+                                }
+                            }
                             Ok(v) => v.truthy(),
-                            Err(_) => false,
+                            Err(e) => {
+                                self.record_subset_where_fail(e);
+                                false
+                            }
                         }
                     } else {
                         // Bare expression: set $_ and evaluate directly
                         let saved = self.env.get("_").cloned();
                         self.env.insert("_".to_string(), predicate_value);
-                        let result = self
-                            .eval_precompiled_block_fast(&compiled.0, &compiled.1)
-                            .map(|v| self.smart_match(value, &v))
-                            .unwrap_or(false);
+                        let result =
+                            match self.eval_precompiled_block_fast(&compiled.0, &compiled.1) {
+                                Ok(v) => self.smart_match(value, &v),
+                                Err(e) => {
+                                    self.record_subset_where_fail(e);
+                                    false
+                                }
+                            };
                         if let Some(old) = saved {
                             self.env.insert("_".to_string(), old);
                         } else {

--- a/src/vm/vm_misc_typecheck.rs
+++ b/src/vm/vm_misc_typecheck.rs
@@ -162,6 +162,12 @@ impl Interpreter {
         }
         if runtime::is_known_type_constraint(base_constraint) {
             if !matches!(value, Value::Nil) && !self.type_matches_value(constraint, &value) {
+                // A subset `where { … or fail "msg" }` that failed by throwing
+                // surfaces its own exception (custom message) rather than the
+                // generic type-check error.
+                if let Some(fail) = self.subset_where_fail.take() {
+                    return Err(*fail);
+                }
                 if base_constraint == "Int"
                     && matches!(value, Value::Num(f) if f.is_nan() || f.is_infinite())
                 {
@@ -266,6 +272,11 @@ impl Interpreter {
             && !self.type_matches_value(constraint, &value)
             && !self.is_container_subclass(constraint)
         {
+            // A subset `where { … or fail "msg" }` that failed by throwing surfaces
+            // its own exception (custom message), not the generic type-check error.
+            if let Some(fail) = self.subset_where_fail.take() {
+                return Err(*fail);
+            }
             if bind_mode {
                 return Err(crate::runtime::utils::type_check_binding_typed_error(
                     constraint, &value,

--- a/t/subset-where-fail-message.t
+++ b/t/subset-where-fail-message.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A subset whose `where` predicate fails via `fail "msg"` surfaces that custom
+# message as the type-check exception on assignment, instead of the generic
+# "Type check failed ...; expected X, got Y" (S12-subset/subtypes.t test 25).
+
+plan 4;
+
+# Placeholder-block predicate (the roast form).
+{
+    subset Even of Int where { $^num %% 2 or fail "$num is not even" };
+    throws-like { my Even $e = 1 }, Exception, :message("1 is not even"),
+        'fail() message from a $^-placeholder where surfaces on assignment';
+}
+
+# Topic (`$_`) predicate.
+{
+    subset Big of Int where { $_ > 100 or fail "$_ too small" };
+    throws-like { my Big $b = 3 }, Exception, :message("3 too small"),
+        'fail() message from a $_ where surfaces on assignment';
+}
+
+# A `where` that fails *without* fail() still gives the generic type-check error.
+{
+    subset Odd of Int where { $_ % 2 == 1 };
+    throws-like { my Odd $o = 2 }, X::TypeCheck,
+        'a plain failing where still throws X::TypeCheck (no custom message)';
+}
+
+# Smartmatch against such a subset is just False (the fail is caught), not a throw.
+{
+    subset Ev of Int where { $_ %% 2 or fail "nope" };
+    nok (3 ~~ Ev), 'smartmatch against a fail()-where subset is False, not a throw';
+}


### PR DESCRIPTION
## Summary

BLOCKERS §3 / `S12-subset/subtypes.t` test 25. A subset whose `where` predicate fails by throwing must surface that custom message on assignment:

```raku
subset Even of Int where { $^num %% 2 or fail "$num is not even" };
my Even $e = 1;   # was: "Type check failed ...; expected Even, got Int"
                  # now: "1 is not even"
```

`type_matches_value` reduced the predicate result to `truthy()`, discarding the `fail`. The failure arrives two ways depending on predicate shape:
- a `$_`/topic predicate **throws** (`Err`);
- a `$^`-placeholder / block predicate compiles to a `Sub` whose call returns an **unhandled `Failure`** (`Ok`).

Capture both into a new `subset_where_fail` side-channel (only genuine failures / user exceptions — not control signals), and have the assignment/binding type-check op surface it instead of the generic error. Smartmatch / multi-dispatch callers ignore the side-channel, so `3 ~~ Even` stays `False` (no throw).

## Verification
- New `t/subset-where-fail-message.t` (incl. a guard that smartmatch does *not* throw)
- `subtypes.t` 83→84/92 (test 25 passes)
- Full `t/` suite: PASS (1434 files); `cargo test`: 477 pass
- S12-subset roast whitelist: green; `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean

## Remaining subtypes.t failures (each a distinct feature, follow-ups)
- **68** — role-based subset smartmatch (`subset S of R`), a full-file heisenbug (passes in isolation)
- **77** — a param `where` referencing a *later* param → `X::Undeclared` (needs a scope-aware left-to-right signature check; the shared EVAL undeclared-checker can't descend into `where` blocks without false-positiving block-local `my`)
- **87** — Junction-of-types in `where` + concreteness (`X::Parameter::InvalidConcreteness`)
- **88** — postconstraints in `my (...)` destructuring
- **89** — `&`-sigil variable used in `where`
- **90** — `# TODO custom type checking on hashes NYI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)