### PR TITLE
fix(subset): param where referencing a later param is X::Undeclared (subtypes.t 77)

### DIFF
--- a/src/runtime/system_eval_vars.rs
+++ b/src/runtime/system_eval_vars.rs
@@ -245,6 +245,9 @@ impl Interpreter {
                 body,
                 ..
             } => {
+                if let Some(r) = Self::find_undeclared_var_in_param_wheres(param_defs) {
+                    return Some(r);
+                }
                 let mut inner = declared.clone();
                 Self::add_routine_locals(params, body, &mut inner);
                 Self::add_sub_signature_locals(param_defs, &mut inner);
@@ -256,6 +259,9 @@ impl Interpreter {
                 body,
                 ..
             } => {
+                if let Some(r) = Self::find_undeclared_var_in_param_wheres(param_defs) {
+                    return Some(r);
+                }
                 let mut inner = declared.clone();
                 Self::add_routine_locals(params, body, &mut inner);
                 Self::add_sub_signature_locals(param_defs, &mut inner);
@@ -298,6 +304,111 @@ impl Interpreter {
     /// and `@rest`. The simplified `params: Vec<String>` only records the outer
     /// parameter name, so these inner names would otherwise be flagged as
     /// undeclared when used in the body.
+    /// A parameter's `where` constraint is checked left-to-right: it may name the
+    /// parameter it constrains and any *earlier* parameter, but referencing a
+    /// *later* parameter is `X::Undeclared` (that param is not in scope yet). Walk
+    /// the signature accumulating bound names, and for each `where` flag a
+    /// reference to a name that only becomes a parameter later. Matches
+    /// `sub foo($x where { $x == $y }, $y) {}` → X::Undeclared. (subtypes.t 77)
+    fn find_undeclared_var_in_param_wheres(
+        param_defs: &[crate::ast::ParamDef],
+    ) -> Option<(&'static str, String, Vec<String>)> {
+        let bare = |n: &str| n.trim_start_matches(['$', '@', '%', '&']).to_string();
+        // Names of params that appear *after* index i, for each i.
+        let all_names: Vec<String> = param_defs
+            .iter()
+            .filter(|pd| !pd.name.is_empty())
+            .map(|pd| bare(&pd.name))
+            .collect();
+        let mut seen_upto = HashSet::new();
+        for (i, pd) in param_defs
+            .iter()
+            .filter(|pd| !pd.name.is_empty())
+            .enumerate()
+        {
+            let self_name = bare(&pd.name);
+            // The param may reference itself and earlier params in its own `where`.
+            seen_upto.insert(self_name.clone());
+            if let Some(where_expr) = &pd.where_constraint {
+                let mut refs = HashSet::new();
+                Self::collect_where_var_refs(where_expr, &mut refs);
+                // A reference to a param declared strictly later is undeclared.
+                for r in &refs {
+                    let is_later_param = all_names.iter().skip(i + 1).any(|later| later == r)
+                        && !seen_upto.contains(r);
+                    if is_later_param {
+                        return Some(("$", r.clone(), Vec::new()));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Collect the bare names of all `$`/`@`/`%`/`&` variables referenced anywhere
+    /// in `expr`, descending through the expression / block forms a `where`
+    /// constraint can take. Conservative: unhandled forms are simply not walked
+    /// (this only ever *misses* references, never invents them).
+    fn collect_where_var_refs(expr: &Expr, out: &mut HashSet<String>) {
+        use Expr::*;
+        match expr {
+            Var(n) | ArrayVar(n) | HashVar(n) | CodeVar(n) => {
+                out.insert(n.clone());
+            }
+            Grouped(e) | ZenSlice(e) | PositionalPair(e) | Eager(e) | Itemize(e) => {
+                Self::collect_where_var_refs(e, out)
+            }
+            Unary { expr, .. } | PostfixOp { expr, .. } => Self::collect_where_var_refs(expr, out),
+            Binary { left, right, .. } => {
+                Self::collect_where_var_refs(left, out);
+                Self::collect_where_var_refs(right, out);
+            }
+            Ternary {
+                cond,
+                then_expr,
+                else_expr,
+            } => {
+                Self::collect_where_var_refs(cond, out);
+                Self::collect_where_var_refs(then_expr, out);
+                Self::collect_where_var_refs(else_expr, out);
+            }
+            Index { target, index, .. } => {
+                Self::collect_where_var_refs(target, out);
+                Self::collect_where_var_refs(index, out);
+            }
+            MethodCall { target, args, .. } | CallOn { target, args } => {
+                Self::collect_where_var_refs(target, out);
+                args.iter()
+                    .for_each(|a| Self::collect_where_var_refs(a, out));
+            }
+            Call { args, .. } => args
+                .iter()
+                .for_each(|a| Self::collect_where_var_refs(a, out)),
+            StringInterpolation(parts) | ArrayLiteral(parts) | CaptureLiteral(parts) => parts
+                .iter()
+                .for_each(|p| Self::collect_where_var_refs(p, out)),
+            Block(stmts) | AnonSub { body: stmts, .. } | Lambda { body: stmts, .. } => {
+                Self::collect_where_var_refs_in_stmts(stmts, out)
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_where_var_refs_in_stmts(stmts: &[Stmt], out: &mut HashSet<String>) {
+        for s in stmts {
+            match s {
+                Stmt::Expr(e) => Self::collect_where_var_refs(e, out),
+                Stmt::Assign { expr, .. } | Stmt::VarDecl { expr, .. } => {
+                    Self::collect_where_var_refs(expr, out)
+                }
+                Stmt::Say(es) | Stmt::Print(es) | Stmt::Put(es) | Stmt::Note(es) => {
+                    es.iter().for_each(|e| Self::collect_where_var_refs(e, out))
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn add_sub_signature_locals(param_defs: &[crate::ast::ParamDef], out: &mut HashSet<String>) {
         for pd in param_defs {
             Self::collect_param_sub_signature(&pd.sub_signature, out);

--- a/t/param-where-forward-ref.t
+++ b/t/param-where-forward-ref.t
@@ -1,0 +1,27 @@
+use Test;
+
+# A parameter's `where` constraint is scoped left-to-right: referencing a param
+# declared LATER in the same signature is X::Undeclared at compile time, but
+# referencing the param itself or an earlier param (or an outer lexical) is fine.
+# S12-subset/subtypes.t test 77.
+
+plan 5;
+
+throws-like 'sub foo($x where { $x == $y }, $y) { }', X::Undeclared,
+    'where referencing a later param is X::Undeclared';
+
+lives-ok { EVAL 'sub f($a, $b where { $b > $a }) { }' },
+    'where referencing an earlier param is fine';
+
+lives-ok { EVAL 'sub g($x where { $x > 0 }) { }' },
+    'where referencing the param itself is fine';
+
+# The whole thing still works at runtime.
+{
+    sub h($a, $b where { $b > $a }) { $a + $b }
+    is h(1, 5), 6, 'earlier-param where enforced and value returned';
+}
+{
+    sub h2($a, $b where { $b > $a }) { $a + $b }
+    dies-ok { h2(5, 1) }, 'earlier-param where rejects a bad argument';
+}


### PR DESCRIPTION
## Summary

BLOCKERS §3 / `S12-subset/subtypes.t` test 77. A parameter's `where` constraint is scoped left-to-right: it may name the param it constrains and any *earlier* param, but referencing a param declared *later* in the same signature is a compile-time X::Undeclared:

```raku
EVAL 'sub foo($x where { $x == $y }, $y) { }'   # X::Undeclared ($y)
```

The EVAL undeclared-variable checker never inspected param `where` constraints, so this compiled silently.

## Fix

`find_undeclared_var_in_param_wheres`: walk the signature left-to-right, and for each `where` collect its variable references (descending through the block/expr forms a `where` can take) and flag any that matches a **later** parameter's name.

Checking only against the *later-param name set* keeps false positives out — a self/earlier-param reference, an outer lexical, or a block-local `my` inside the `where` is never a later param, so it is not flagged. Verified:

```raku
sub f($a, $b where { $b > $a }) { }   # compiles + runs (earlier param OK)
sub g($x where { $x > 0 }) { }        # self-ref OK
```

## Verification
- New `t/param-where-forward-ref.t`
- `subtypes.t` 84→85/92 (test 77 passes)
- Full `t/` suite: PASS (1435 files); `cargo test`: 477 pass
- 66-file EVAL/undeclared-heavy roast subset (S12-subset / S06-signature / S02-names / S04-declarations / S32-exceptions / where): green
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean

## Remaining subtypes.t failures (follow-ups)
68 (role-subset smartmatch, full-file heisenbug), 83 (multi with `:D` subset dispatch), 87 (Junction-of-types where + concreteness), 88 (`my (...)` destructuring postconstraints), 89 (`&`-sigil in where); 90 is `# TODO … NYI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)