### PR TITLE
fix(dispatch): multi-method subset param beats its base + Subset:D smartmatch term (subtypes.t 83)

### DIFF
--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -172,30 +172,32 @@ impl Interpreter {
             .map(|(i, _)| i)
             .collect();
         if tied.len() > 1 {
+            // "Narrowness" tie-break: among equally-typed candidates, prefer the
+            // one whose params carry more narrowing constraints — a `where` clause
+            // OR a subset type (a subset is narrower than its base, and its
+            // nominal distance was resolved to the base above, so the two tie).
+            let narrowness = |def: &MethodDef| -> usize {
+                def.param_defs
+                    .iter()
+                    .filter(|p| {
+                        p.where_constraint.is_some()
+                            || p.type_constraint.as_deref().is_some_and(|tc| {
+                                self.registry()
+                                    .subsets
+                                    .contains_key(Self::constraint_base_for_distance(tc))
+                            })
+                    })
+                    .count()
+            };
             let best_where = tied
                 .iter()
-                .map(|&i| {
-                    all_matches[i]
-                        .1
-                        .param_defs
-                        .iter()
-                        .filter(|p| p.where_constraint.is_some())
-                        .count()
-                })
+                .map(|&i| narrowness(&all_matches[i].1))
                 .max()
                 .unwrap_or(0);
             let narrowed: Vec<usize> = tied
                 .iter()
                 .copied()
-                .filter(|&i| {
-                    all_matches[i]
-                        .1
-                        .param_defs
-                        .iter()
-                        .filter(|p| p.where_constraint.is_some())
-                        .count()
-                        == best_where
-                })
+                .filter(|&i| narrowness(&all_matches[i].1) == best_where)
                 .collect();
             if let Some(&i) = narrowed.first() {
                 best_idx = i;
@@ -264,8 +266,17 @@ impl Interpreter {
             }
             if let Some(tc) = &pd.type_constraint {
                 let base = Self::constraint_base_for_distance(tc);
+                // A subset's nominal distance is that of its ultimate base type
+                // (`subset T of Any` ranks like `Any`, not as an unknown type at
+                // distance 500 — which would wrongly lose to a bare `Any`). The
+                // subset's extra narrowness is applied as a tie-break below.
+                let resolved = if self.registry().subsets.contains_key(base) {
+                    self.resolve_subset_base_type(base)
+                } else {
+                    base.to_string()
+                };
                 if arg_idx < args.len() {
-                    total += Self::builtin_type_distance(base, &args[arg_idx]);
+                    total += Self::builtin_type_distance(&resolved, &args[arg_idx]);
                 }
             } else {
                 total += 1000;

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -465,7 +465,9 @@ impl Interpreter {
         if smiley.is_none() {
             return false;
         }
-        interp.has_class(base) || Self::is_builtin_type(base)
+        // `has_type` (not just `has_class`) so a subset / role / enum base is also
+        // recognized — `T:D` for `subset T ...` is a type term, not a bare Str.
+        interp.has_type(base) || Self::is_builtin_type(base)
     }
 
     /// Get the current $*COLLATION settings, falling back to defaults.

--- a/t/multi-method-subset-dispatch.t
+++ b/t/multi-method-subset-dispatch.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A multi *method* whose parameter is a subset type must be preferred over a
+# candidate typed with the subset's base type (a subset is narrower than its
+# base). Previously the method-multi ranker gave a subset the "unknown type"
+# distance, so it wrongly lost to a bare `Any`. Also `$x ~~ Subset:D` (a subset
+# with a definiteness smiley used as a term) must type-check, not string-compare.
+# S12-subset/subtypes.t test 83.
+
+plan 6;
+
+# Method multi: subset beats its base.
+{
+    subset T of List where *[0] eqv 1;
+    class R {
+        multi method f(T $xs)   { 'T' }
+        multi method f(Any $xs) { 'Any' }
+    }
+    is R.f([1, 2]), 'T',   'method multi picks the subset candidate';
+    is R.f([2, 2]), 'Any', 'method multi falls back to base when subset fails';
+}
+
+# Method multi with :D subset smiley + recursion (the roast form).
+{
+    my @results;
+    subset T2 of List where *[0] eqv 1;
+    class R2 {
+        multi method f(T2:D $xs)  { @results.push('T:D'); self.f(42) }
+        multi method f(Any:D $xs) { @results.push($xs) }
+    }
+    R2.f([1, 2]);
+    R2.f([2, 2]);
+    is @results.raku, '["T:D", 42, [2, 2]]', 'multi with :D subset dispatches in order';
+}
+
+# A subset with :D smiley as a smartmatch term.
+{
+    subset Ev of Int where * %% 2;
+    ok  (4 ~~ Ev:D),  'defined value matches Subset:D';
+    nok (3 ~~ Ev:D),  'non-matching value fails Subset:D';
+    nok (Int ~~ Ev:D), 'type object fails Subset:D (needs definite)';
+}


### PR DESCRIPTION
## Summary

BLOCKERS §3 / `S12-subset/subtypes.t` test 83. Two related subset issues:

### 1. Method multi-dispatch ranking
`method_candidate_type_distance` gave a subset-typed param the "unknown type" distance (500), so `multi method f(T $xs)` (subset) **lost** to `multi method f(Any $xs)` — a subset ranked as *less* specific than its own base:

```raku
subset T of List where *[0] eqv 1;
class R { multi method f(T:D $xs) {...}; multi method f(Any:D $xs) {...} }
R.f([1,2])   # was dispatched to Any:D — now to T:D
```

Fix: resolve a subset to its ultimate base type for the nominal distance (so `subset T of Any` ties with `Any`), then break the tie by **narrowness** — prefer params carrying a `where` clause OR a subset type. (Sub multis already ranked this correctly via `candidate_specificity_rank`; only method multis were wrong.)

### 2. `$x ~~ Subset:D` as a term
A subset/role/enum name with a definiteness smiley (`T:D`) used as a term evaluated to the bare Str `"T:D"` (→ string smartmatch → always False), because `is_type_with_smiley` only recognized classes/builtins. Use `has_type` so subsets/roles/enums count, resolving `T:D` to a type object.

## Verification
- New `t/multi-method-subset-dispatch.t`
- `subtypes.t` 85→86/92 (test 83 passes)
- Full `t/` suite: PASS (1436 files); `cargo test`: 477 pass
- 133-file multi-dispatch roast subset (S06-multi / S12): green
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean

## Remaining subtypes.t
68 (role-subset smartmatch, full-file heisenbug), 87 (Junction-of-types where + concreteness), 88 (`my (...)` postconstraints), 89 (`&`-sigil in where); 90 is `# TODO … NYI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)