### PR TITLE
fix(parser): register subset names as user types so `~~ S` is a term, not S/// (subtypes.t 68)

### DIFF
--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -207,6 +207,11 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("subset", input).ok_or_else(|| PError::expected("subset declaration"))?;
     let (rest, _) = ws1(rest)?;
     let (rest, name) = qualified_ident(rest)?;
+    // Register the subset as a user-declared type so a later `$x ~~ S` parses `S`
+    // as a type term, not the `S///` non-destructive-substitution operator
+    // (`~~ S/.../.../` is valid, so the bareword `S` after `~~` is otherwise taken
+    // as a substitution — subtypes.t 68). Classes/roles/grammars already do this.
+    super::super::simple::register_user_type(&name);
     let (mut rest, _) = ws(rest)?;
     let mut is_export = false;
     let mut export_tags: Vec<String> = Vec::new();

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -91,6 +91,9 @@ pub(super) fn try_keyword_dispatch(
         if let Some(r) = keyword("subset", after_type) {
             let (r, _) = ws1(r)?;
             let (r, name) = qualified_ident(r)?;
+            // Register so a later `$x ~~ MyStr` parses the name as a type term, not
+            // the `S///` substitution operator (see constant_subset.rs / subtypes.t 68).
+            super::super::simple::register_user_type(&name);
             let (mut r, _) = ws(r)?;
             while let Some(r2) = keyword("is", r) {
                 let (r2, _) = ws1(r2)?;

--- a/t/subset-name-vs-subst-operator.t
+++ b/t/subset-name-vs-subst-operator.t
@@ -1,0 +1,31 @@
+use Test;
+
+# A subset name used as a term (e.g. `$x ~~ S`) must parse as the type, not as
+# the `S///` non-destructive-substitution operator. `~~ S/.../.../ ` is valid, so
+# a bareword `S` (or any subset name) after `~~` was otherwise swallowed as a
+# substitution — especially when a trailing `, 'desc'` and a following line
+# provided the `S,pat,repl,` delimiters. S12-subset/subtypes.t test 68.
+
+plan 6;
+
+{
+    role R { };
+    subset S of R;
+    nok 1 ~~ S,  'a role-based subset name after ~~ is a type, not S///';
+    ok  R ~~ S,  'the role type object matches its subset';
+}
+
+# A real S/// still parses as a substitution when S is not a declared type.
+{
+    my $x = 'abc';
+    my $y = S/b/X/ given $x;
+    is $x, 'abc', 'S/// is non-destructive (source unchanged)';
+    is $y, 'aXc', 'S/// returns the substituted copy';
+}
+
+# `my subset` name is also a term after ~~.
+{
+    my subset Big of Int where * > 100;
+    ok  (200 ~~ Big), 'my-subset name after ~~ matches';
+    nok (3   ~~ Big), 'my-subset name after ~~ rejects';
+}


### PR DESCRIPTION
## Summary

BLOCKERS §3 / `S12-subset/subtypes.t` test 68 — a **full-file heisenbug**. A subset name used as a term after `~~` was parsed as the `S///` non-destructive-substitution operator:

```raku
subset S of R;
nok 1 ~~ S, 'subsets of roles (1)';
ok  R ~~ S, 'subsets of roles (2)';
```

`~~ S/.../.../` is valid (smartmatch against a substitution), so the `S///` parser fires on a bareword `S` after `~~`. It already skips when `S` is a user-declared type (`is_user_declared_type`), but **subset declarations never called `register_user_type`** (unlike class/role/grammar/package). So `S` was taken as `S,pat,repl,` — swallowing lines 246–247's descriptions (the `, '...'` provided the delimiters).

This is why it only reproduced in the full file: in isolation, with a single trailing comma, the `S///` scan failed and backtracked to a term.

## Fix

Call `register_user_type(name)` in both subset parse paths (`subset X` and `my … subset X`), mirroring class/role/grammar. A genuine `S/.../.../` where `S` is *not* a declared type still parses as a substitution (guard unchanged; verified `S/// given $x` and `~~ S///`).

## Verification
- New `t/subset-name-vs-subst-operator.t`
- `subtypes.t` 86→87/92 (test 68 passes; the misparse previously also shifted trailing test numbering)
- Full `t/` suite: PASS (1437 files); `cargo test`: 477 pass
- 252-file S05-regex/subst + S12/S02 roast subset: green
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean

## Remaining subtypes.t
89 (Junction-of-types where + concreteness), 90 (`my (...)` postconstraints), 91 (`&`-sigil in where); 92 is `# TODO … NYI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)