### PR TITLE
fix(destructure): enforce literal/where postconstraints in my (...) + yield the list (subtypes.t 90)

### DIFF
--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -317,6 +317,10 @@ fn describe_useless(expr: &Expr) -> Option<String> {
         Expr::Var(n) if n.starts_with("__ANON_STATE_") => Some("unnamed $ variable".to_string()),
         Expr::Var(n) if n.starts_with(['$', '@', '%', '&']) => None,
         Expr::Var(n) => Some(format!("${}", n)),
+        // The trailing result read a `my (...)` destructuring block leaves — an
+        // internal `@__destructure_tmp__` — is not a user-written bare array, so
+        // it must not produce a spurious sink warning on `my ($a,$b) = 1,2;`.
+        Expr::ArrayVar(n) if n == "__destructure_tmp__" => None,
         Expr::ArrayVar(n) => Some(format!("@{}", n)),
         Expr::HashVar(n) => Some(format!("%{}", n)),
         Expr::ArrayLiteral(elems) if elems.is_empty() => Some("()".to_string()),

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -490,7 +490,29 @@ fn parse_destructuring_with_rhs(
     let has_explicit_slurpy = vars.iter().any(|v| v.is_slurpy);
     let mut seen_slurpy = false;
     for (i, dvar) in vars.iter().enumerate() {
-        if dvar.literal_value.is_some() {
+        if let Some(lit) = &dvar.literal_value {
+            // A bare literal element (`my ("foo") = ...`) is a postconstraint: the
+            // i-th assigned value must smartmatch the literal, else
+            // X::TypeCheck::Assignment. Emit a throwaway declaration whose
+            // where-constraint IS the literal (identical to `$ where "foo"`, which
+            // already enforces this), reading the i-th temp element. (subtypes.t 90)
+            let read = Expr::Index {
+                target: Box::new(Expr::ArrayVar(array_bare.clone())),
+                index: Box::new(Expr::Literal(Value::Int(i as i64))),
+                is_positional: true,
+            };
+            stmts.push(Stmt::VarDecl {
+                name: format!("__destructure_lit_{i}"),
+                expr: read,
+                type_constraint: None,
+                is_state,
+                is_our: false,
+                is_dynamic: false,
+                is_export: false,
+                export_tags: Vec::new(),
+                custom_traits: Vec::new(),
+                where_constraint: Some(Box::new(lit.clone())),
+            });
             continue;
         }
 
@@ -568,6 +590,13 @@ fn parse_destructuring_with_rhs(
             stmts.push(Stmt::MarkReadonly(dvar.name.clone()));
         }
     }
+    // Yield the assigned list as the block's value (`(my ($a,$b) = 1,2)` is `(1 2)`,
+    // not the last element). This also keeps the per-element check declarations off
+    // the block-final position, so a postconstraint (`where`/literal) on the LAST
+    // element still enforces in value context — e.g. an EVAL'd `my (\b, "foo") =
+    // ...` whose trailing `MarkSigillessReadonly` would otherwise leave a
+    // constrained decl block-final and skip its check. (subtypes.t 90)
+    stmts.push(Stmt::Expr(Expr::ArrayVar(array_bare)));
     Ok((rest, Stmt::SyntheticBlock(stmts)))
 }
 

--- a/t/destructure-literal-postconstraint.t
+++ b/t/destructure-literal-postconstraint.t
@@ -1,0 +1,34 @@
+use Test;
+
+# Postconstraints on `my (...)` destructuring targets (S12-subset/subtypes.t 90):
+#  - a bare literal element (`my ("foo")`) is a constraint the assigned value must
+#    match, else X::TypeCheck::Assignment;
+#  - the enforcement holds in value position and with a preceding sigilless element;
+#  - and `(my (...) = list)` yields the assigned list, not just the last element.
+
+plan 9;
+
+throws-like 'my ("foo") = "bar"', X::TypeCheck::Assignment,
+    'single bare-literal target rejects a non-matching value';
+lives-ok { my ("foo") = "foo" }, 'single bare-literal target accepts a match';
+
+throws-like 'my ($a, "foo") = 1, "bar"', X::TypeCheck::Assignment,
+    'literal target after a plain var is enforced';
+
+# A sigilless element before the literal must not disable the literal check
+# (the trailing-result fix keeps the constrained decl off block-final position).
+throws-like 'my (\b where "x", "foo") = "x", "bar"', X::TypeCheck::Assignment,
+    'literal enforced even after a matching sigilless where-element';
+throws-like 'my (\b, $c where 5) = "x", 9', X::TypeCheck::Assignment,
+    'a where element after a sigilless element is enforced';
+
+# The where-literal / where-type single-arg cases keep working.
+throws-like 'my ($a where 2) = 3',   X::TypeCheck::Assignment, 'where literal';
+throws-like 'my ($b where Int) = .1', X::TypeCheck::Assignment, 'where type';
+
+# `(my (...) = LIST)` in expression context yields the assigned list.
+{
+    my $r = (my ($x, $y) = 1, 2);
+    is $r.elems, 2, 'destructuring assignment yields the full list (elems)';
+    is $r.join(','), '1,2', 'destructuring assignment yields the full list (values)';
+}


### PR DESCRIPTION
## Summary

BLOCKERS §3 / `S12-subset/subtypes.t` test 90 (postconstraints on variables in `my (...)`). Two fixes:

### 1. Bare literal target
`my ("foo") = "bar"` silently succeeded — the destructure desugar `continue`d past a literal element, dropping the constraint. Emit a throwaway declaration whose where-constraint **is** the literal (identical to `$ where "foo"`), so a non-matching value raises `X::TypeCheck::Assignment`. `my ("foo") = "foo"` still lives.

### 2. Yield the assigned list / enforce a block-final constraint
The destructure `SyntheticBlock` ended with the last element's declaration, so:
- `(my ($a,$b) = 1,2)` returned `2`, not `(1 2)` (latent return-value bug); and
- when a constrained decl (`where`/literal) was **block-final in value position** *and* preceded by a sigilless element's `MarkSigillessReadonly`, its check was **skipped** — so an EVAL'd `my (\b where "x", "foo") = "x", "bar"` did not throw. (This only reproduced via `throws-like`'s EVAL, i.e. value position — the "full-file" nature of the failure.)

Append a trailing `@__destructure_tmp__` read: the block now yields the assigned list (matching Rakudo) **and** no per-element constraint decl is block-final, so its check always fires. The synthetic temp is exempted from the "Useless use … in sink context" warning.

## Verification
- New `t/destructure-literal-postconstraint.t`
- `subtypes.t` 87→88/92 (test 90 passes)
- Full `t/` suite: PASS (1438 files); `cargo test`: 477 pass
- 114-file binding/declaration/subset roast subset: green (the return-value change's blast radius)
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean

## Remaining subtypes.t
89 (Junction-of-types `where` + `X::Parameter::InvalidConcreteness`), 91 (nested-slurpy destructuring signature `*@ ($x, *@ ($,$,$, $y, *@))`); 92 is `# TODO … NYI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)