### PR TITLE
fix(whatever): pass S02-types/whatever.t 131/131

### DIFF
--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -447,8 +447,30 @@
 - [x] roast/S02-types/unicode.t
 - [x] roast/S02-types/version-stress.t
 - [x] roast/S02-types/version.t
-- [ ] roast/S02-types/whatever.t
-  - 130/131 tests run. Blockers:
+- [x] roast/S02-types/whatever.t
+  - **PASSES 131/131 — whitelisted (2026-07-02).** The last four blockers (111, 120,
+    124, and the topic-scoping test 131 that was masked by the 124 abort) were fixed:
+    - Test 111 (`$foo ~~ (* =:= $foo)`): the smartmatch op now records the LHS
+      variable as the call's `arg_sources` before invoking a Code RHS, so the
+      WhateverCode's `is raw` `_` binding aliases `_` to the LHS — `=:=` sees the
+      same container. Scalar-only (`lhs_var` is `Some` only for `Expr::Var`).
+    - Test 120 (`use fatal; "a".map: *.Int`): `use fatal` now fatalizes an unhandled
+      Failure that ends up *inside* a reified list/Seq (new
+      `unhandled_failure_in_list_for_fatal`), checked at the sink (`SinkPop`), block
+      return (`ThrowIfFailure`), and the test-assertion block path
+      (`eval_test_block_value`). Also fixed a latent leak: `use fatal` inside a
+      test-assertion block no longer escapes into the following tests.
+    - Test 124 (regex whatever curry): a `Test` call inside a `<?{...}>`/`<!{...}>`
+      code assertion now works — `eval_regex_code_assertion`'s scratch interpreter
+      inherits the parent's `loaded_modules` + active TAP state so the assertion's
+      boolean is computed correctly (its buffered output is discarded; the real
+      emission comes from the deferred `execute_regex_code_blocks` on the winning path).
+    - Test 131 (`do { $_ = 42; (Int).map(*.new($_)) }`): a WhateverCode whose body
+      references `$_` compiles its `*` to a `__wc_N` param, so its `$_` must stay the
+      caller topic. Fixed the routine-`$_` reset (vm_closure_dispatch) and the general
+      map loop (resolution_map_grep) to not topicalize `$_` to the element for such a
+      WhateverCode (guarded by `_`-is-not-a-param so plain `*.abs` still gets the item).
+  - Historical blocker notes (all resolved):
     - Tests 52-53: Nested WhateverCode currying with user-defined operators (3+ `*` across nested calls)
     - Tests 75-76, 126(subtest 5+): `*` passed as a *call argument* (`&infix:<+>(*, 42)`,
       `$sub(*)`) should be a Whatever *value*, not a curry placeholder. mutsu over-curries
@@ -467,7 +489,7 @@
       `zip` Call form).
     - Tests 108-109: `*++`/`++*` WhateverCode with rw parameters
     - Test 110: `*(42)` should throw X::Method::NotFound
-    - Test 111: **STILL FAILS — deep.** `$foo ~~ (* =:= $foo)` must preserve the
+    - Test 111: **RESOLVED (see summary above).** `$foo ~~ (* =:= $foo)` must preserve the
       LHS *container* so `$_ =:= $foo` is True. The RHS WhateverCode invoked
       directly (`$wc($foo)`) IS True (its `is raw` param aliases $foo's
       container), but the smartmatch passes the LHS *by value*: the compiler
@@ -498,7 +520,7 @@
       via smartmatch `value ~~ PRED` (methods_object_attr_constraints.rs) so a
       Junction predicate (`where 42|3`) threads instead of being (wrongly)
       *called*. Tests t/is-default-where-expr.t.
-    - Test 120: `use fatal` + WhateverCode curry — **STILL FAILS — deep.**
+    - Test 120: `use fatal` + WhateverCode curry — **RESOLVED (see summary above).**
       `use fatal; "a".map: *.Int` must throw X::Str::Numeric. `use fatal` DOES
       work for a direct Failure (`use fatal; "a".Int` throws), but a Failure
       produced *inside a `.map` block / Seq* (`"a".map({.Int})`, even `.eager`)
@@ -506,7 +528,7 @@
       context fatal-Failure checking through a (lazy) map/Seq — the `use fatal`
       lexical pragma must reach the element-producing block and the sink must
       fatalize a contained Failure.
-    - Test 124: regex whatever curry — **STILL FAILS — deep.** The `* ~~ /<$_>/`
+    - Test 124: regex whatever curry — **RESOLVED (see summary above).** The `* ~~ /<$_>/`
       curry and single-statement `<?{...}>`/`<!{...}>` assertions all work; the
       failure is that a `Test` call (`pass`/`ok`) INSIDE a `<?{...}>` code
       assertion does not run and makes the assertion False. Root cause:

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -171,6 +171,7 @@ roast/S02-types/undefined-types.t
 roast/S02-types/unicode.t
 roast/S02-types/version-stress.t
 roast/S02-types/version.t
+roast/S02-types/whatever.t
 roast/S03-binding/arrays.t
 roast/S03-binding/attributes.t
 roast/S03-binding/closure.t

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -146,6 +146,29 @@ impl Interpreter {
         Some(RuntimeError::new("Failed"))
     }
 
+    /// Under `use fatal`, an unhandled Failure that ends up *inside* a reified
+    /// list/`Seq` (rather than as a bare value) must still throw — e.g.
+    /// `use fatal; "a".map: *.Int` produces a `Seq` whose element is the
+    /// WhateverCode's per-item Failure, which Raku throws when the sequence is
+    /// returned/assigned/sunk. This descends one level into a list value and
+    /// returns the first contained unhandled Failure's error. Fatal-gated at the
+    /// call sites, so non-fatal code keeps its soft-Failure lists intact.
+    pub(crate) fn unhandled_failure_in_list_for_fatal(
+        &self,
+        value: &Value,
+    ) -> Option<RuntimeError> {
+        let items: &[Value] = match value {
+            Value::Seq(items)
+            | Value::Slip(items)
+            | Value::HyperSeq(items)
+            | Value::RaceSeq(items) => items,
+            _ => return None,
+        };
+        items
+            .iter()
+            .find_map(|it| self.failure_to_runtime_error_if_unhandled(it))
+    }
+
     pub(crate) fn fail_error_to_failure_value(&self, err: &RuntimeError) -> Value {
         let exception = err.exception.as_deref().cloned().unwrap_or_else(|| {
             let mut attrs = std::collections::HashMap::new();

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -193,6 +193,19 @@ impl Interpreter {
             ..Default::default()
         };
         self.copy_decl_registry_into(&mut interp);
+        // Propagate the `Test` module gating so a test-function call inside a
+        // `<?{ ... }>` / `<!{ ... }>` assertion (`<?{ pass 'x'; True }>`) resolves
+        // to its return value instead of dying as an unknown function — otherwise
+        // the whole probe errors and the assertion wrongly evaluates to False.
+        // The scratch interp buffers its output (immediate_stdout defaults to
+        // false) and is then dropped, so no TAP line is emitted here; the real
+        // emission happens once, on the winning match path, when the assertion's
+        // code block is re-run in the parent interpreter
+        // (`execute_regex_code_blocks`).
+        if self.test_module_loaded() {
+            interp.loaded_modules = self.loaded_modules.clone();
+            interp.tap.ensure_state();
+        }
         match interp.eval_block_value(&stmts) {
             Ok(val) => val.truthy(),
             Err(_) => false,

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -225,14 +225,19 @@ impl Interpreter {
         // A lexical pragma such as `use fatal` inside a test-assertion block
         // (`throws-like { use fatal; ... }`) is scoped to that block. This Rust
         // entry point runs the body directly without the compiler's block-level
-        // import scope, so `fatal_mode` would otherwise leak into the tests that
-        // follow. Save and restore it around the body.
+        // import scope, so a `use fatal` *raised* here would otherwise leak into
+        // the tests that follow. Clear only a block-local raise (off -> on);
+        // never force `fatal_mode` back on, so a block that legitimately lowered
+        // an already-on fatal keeps it off (roast S04-exceptions/fail.t, where an
+        // earlier sub leaked fatal on and a later subtest turns it back off).
         let saved_fatal_mode = self.fatal_mode;
         let result = self.eval_block_value(body);
         // Whether `use fatal` was in effect at the block's end (before the
         // scope-restore below) drives the trailing-Failure check further down.
         let block_fatal_mode = self.fatal_mode;
-        self.fatal_mode = saved_fatal_mode;
+        if !saved_fatal_mode && block_fatal_mode {
+            self.fatal_mode = false;
+        }
         let leaked: Vec<Symbol> = self
             .env
             .keys()

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -222,7 +222,17 @@ impl Interpreter {
         // "our-scoped array/hash has correct value").
         let mut our_names = std::collections::HashSet::new();
         Self::collect_our_decl_names(body, &mut our_names);
+        // A lexical pragma such as `use fatal` inside a test-assertion block
+        // (`throws-like { use fatal; ... }`) is scoped to that block. This Rust
+        // entry point runs the body directly without the compiler's block-level
+        // import scope, so `fatal_mode` would otherwise leak into the tests that
+        // follow. Save and restore it around the body.
+        let saved_fatal_mode = self.fatal_mode;
         let result = self.eval_block_value(body);
+        // Whether `use fatal` was in effect at the block's end (before the
+        // scope-restore below) drives the trailing-Failure check further down.
+        let block_fatal_mode = self.fatal_mode;
+        self.fatal_mode = saved_fatal_mode;
         let leaked: Vec<Symbol> = self
             .env
             .keys()
@@ -238,6 +248,19 @@ impl Interpreter {
             .collect();
         for key in leaked {
             self.env.remove_sym(key);
+        }
+        // Under `use fatal` (in the block's lexical scope), a trailing reified
+        // list/Seq whose element is an unhandled Failure must throw so a
+        // `throws-like { use fatal; "a".map: *.Int }` assertion sees the
+        // exception. A bare trailing Failure is already surfaced by the block's
+        // own return handling; this covers the list-wrapped case that the map's
+        // per-element WhateverCode produces. Gated on the block's own fatal
+        // state (captured above, before the scope-restore).
+        if block_fatal_mode
+            && let Ok(ref val) = result
+            && let Some(err) = self.unhandled_failure_in_list_for_fatal(val)
+        {
+            return Err(err);
         }
         result
     }

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -202,6 +202,23 @@ impl Interpreter {
                 }
             }
 
+            // A WhateverCode whose body references `$_` (`*.new($_)`) compiles its
+            // `*` placeholder to a synthetic `__wc_N` param so the element binds
+            // there, NOT to `$_`; the body's `$_` must stay the caller's topic
+            // (S02 "no scoping issues when using topic variables":
+            // `do { $_ = 42; (Int).map(*.new($_)) }` -> `Int.new(42)`). So for such
+            // a WhateverCode, instead of topicalizing `$_`/`_` to the element, hold
+            // them at the caller's outer topic for every iteration (re-set so a
+            // prior iteration's tail value can't leak into the next one's `$_`).
+            // A plain `*.abs` (no `$_` in the body) keeps `_` AS its placeholder
+            // param, so it must still receive the element — hence the
+            // `_`-is-not-a-param guard.
+            let is_whatever_code = matches!(
+                data.env.get("__mutsu_callable_type"),
+                Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+            ) && !data.params.iter().any(|p| p == "_");
+            let outer_topic = self.env.get("_").cloned();
+
             // CP-3 collapse: run the map loop with fresh execution registers
             // (replaces the `mem::take(self)` + `VM::new` sub-VM, reusing one
             // register scope across all iterations). The closure returns the
@@ -227,8 +244,21 @@ impl Interpreter {
                             if let Some(p) = data.params.get(assumed_count) {
                                 vm.env_mut().insert(p.clone(), item.clone());
                             }
-                            vm.env_mut().insert(underscore.clone(), item.clone());
-                            vm.env_mut().insert(dollar_topic.clone(), item);
+                            if is_whatever_code {
+                                match &outer_topic {
+                                    Some(t) => {
+                                        vm.env_mut().insert(underscore.clone(), t.clone());
+                                        vm.env_mut().insert(dollar_topic.clone(), t.clone());
+                                    }
+                                    None => {
+                                        vm.env_mut().remove(&underscore);
+                                        vm.env_mut().remove(&dollar_topic);
+                                    }
+                                }
+                            } else {
+                                vm.env_mut().insert(underscore.clone(), item.clone());
+                                vm.env_mut().insert(dollar_topic.clone(), item);
+                            }
                         } else {
                             for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                                 if i + idx < list_items.len() {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -400,12 +400,21 @@ impl Interpreter {
         // keeps the enclosing lexical `$_` (mutsu compiles such a bare block as a
         // routine for `return`/`&?ROUTINE` purposes, but its topic must still be
         // the outer `$_`). Skip the reset when an explicit `$_` param is present
-        // or when the signature is made of placeholder params (`$^x`).
+        // or when the signature is made of placeholder params (`$^x`). A
+        // WhateverCode (`*.foo`) is likewise a placeholder block: its `*` compiles
+        // to a synthetic `__wc_N` positional param, and any `$_` in its body must
+        // still refer to the caller's topic (S02 "no scoping issues when using
+        // topic variables": `do { $_ = 42; (Int).map(*.new($_)) }` -> `Int.new(42)`).
         let has_placeholder_param = data.param_defs.iter().any(|pd| {
             pd.name.starts_with('^') || pd.name.starts_with("@^") || pd.name.starts_with("%^")
         });
+        let is_whatever_code = matches!(
+            data.env.get("__mutsu_callable_type"),
+            Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+        );
         if cc.is_routine
             && !has_placeholder_param
+            && !is_whatever_code
             && !data.param_defs.iter().any(|pd| pd.name == "_")
         {
             self.env_mut().insert(

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2181,10 +2181,18 @@ impl Interpreter {
                 // Peek (do not pop): a trailing unhandled Failure must be thrown
                 // so the enclosing CATCH handler (or `try`) sees it, while a
                 // normal value remains on the stack as the block's return value.
-                if let Some(val) = self.stack.last()
-                    && let Some(err) = self.failure_to_runtime_error_if_unhandled(val)
-                {
-                    return Err(err);
+                if let Some(val) = self.stack.last() {
+                    if let Some(err) = self.failure_to_runtime_error_if_unhandled(val) {
+                        return Err(err);
+                    }
+                    // Under `use fatal`, a block/routine that returns a reified
+                    // list/Seq whose element is an unhandled Failure throws too
+                    // (`use fatal; { "a".map: *.Int }()`).
+                    if self.fatal_mode
+                        && let Some(err) = self.unhandled_failure_in_list_for_fatal(val)
+                    {
+                        return Err(err);
+                    }
                 }
                 *ip += 1;
             }
@@ -2300,6 +2308,16 @@ impl Interpreter {
                         _ => {
                             // Sinking an unhandled Failure always throws (Raku behavior)
                             if let Some(err) = self.failure_to_runtime_error_if_unhandled(&val) {
+                                return Err(err);
+                            }
+                            // Under `use fatal`, sinking a reified list/Seq whose
+                            // element is an unhandled Failure also throws (e.g.
+                            // `use fatal; "a".map: *.Int`). Non-fatal code keeps
+                            // its soft-Failure lists (a plain `[Failure]` sink is a
+                            // no-op without fatal).
+                            if self.fatal_mode
+                                && let Some(err) = self.unhandled_failure_in_list_for_fatal(&val)
+                            {
                                 return Err(err);
                             }
                             // Sinking a Proc with non-zero exitcode throws X::Proc::Unsuccessful

--- a/src/vm/vm_smartmatch_ops.rs
+++ b/src/vm/vm_smartmatch_ops.rs
@@ -144,11 +144,25 @@ impl Interpreter {
             } else {
                 right
             }
-        } else if negate {
-            // Smartmatch must NOT force lazy values (lazy ~~ anything → False)
-            self.eval_smartmatch_with_junctions_ex(left, right, true, rhs_is_match_regex)?
         } else {
-            self.eval_smartmatch_with_junctions_ex(left, right, false, rhs_is_match_regex)?
+            // When the RHS is a callable (`$x ~~ (* =:= $y)`), Raku binds the
+            // topic to the code's parameter `is raw` — so a container-identity
+            // body (`Code.ACCEPTS preserves container`) sees the caller's actual
+            // container, not a decontainerized copy. Record the LHS variable as
+            // the argument source so the raw-`_` binding aliases `_` to it (the
+            // same path an explicit `(* =:= $y)($x)` call takes). Harmless for a
+            // by-value param, which ignores `arg_sources`.
+            // `lhs_var` is only `Some` for a scalar LHS (`Expr::Var`); an array /
+            // hash LHS compiles to `ArrayVar` / `HashVar` and yields `None`. The
+            // name is already sigil-less (`$foo` -> `"foo"`), matching the alias
+            // root used by the raw-`_` binding.
+            if matches!(right, Value::Sub(_))
+                && let Some(v) = lhs_var
+                && !v.is_empty()
+            {
+                self.set_pending_call_arg_sources(Some(vec![Some(v.clone())]));
+            }
+            self.eval_smartmatch_with_junctions_ex(left, right, negate, rhs_is_match_regex)?
         };
         self.stack.push(out);
         // Slice 6.3 step 2 — precise env_dirty for smartmatch. Skip the

--- a/t/whatever-code-fixes.t
+++ b/t/whatever-code-fixes.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 12;
+
+# --- Code.ACCEPTS preserves container identity (smartmatch binds topic raw) ---
+{
+    my $foo = "foo";
+    ok $foo ~~ (* =:= $foo), 'smartmatch against WhateverCode preserves container';
+    my $bar = "foo";
+    ok !($foo ~~ (* =:= $bar)), 'distinct containers are not identical';
+}
+
+# --- regex code assertion may call Test functions (runs in the real interp) ---
+{
+    my $x = "foo";
+    ok so($x ~~ /foo <?{ True }>/), 'positive code assertion succeeds';
+    ok !so($x ~~ /foo <?{ False }>/), 'positive code assertion fails on False';
+    ok so($x ~~ /foo <!{ False }>/), 'negative code assertion succeeds on False';
+}
+
+# --- `$_` topic scoping in WhateverCode (not clobbered by the placeholder) ---
+{
+    $_ = 99;
+    my $wc = *.Str ~ $_;
+    is $wc(5), '599', 'WhateverCode `$_` is the caller topic, not the argument';
+    is-deeply (1, 2).map(*.Str ~ $_), ('199', '299'), 'map does not topicalize `$_` for a WhateverCode';
+    is-deeply (do { $_ = 42; (Int).map(*.new($_)) }), (42,).Seq,
+        'no scoping issues when using topic variables';
+}
+
+# --- a plain `*.abs` WhateverCode still receives the element ---
+is-deeply (map *.abs, 1, -2, 3, -4), (1, 2, 3, 4),
+    'plain WhateverCode still binds the element to its placeholder';
+
+# --- `use fatal` propagates into a WhateverCode curry produced by map ---
+{
+    throws-like { use fatal; "a".map: *.Int }, X::Str::Numeric,
+        'use fatal makes a map WhateverCode Failure throw';
+    lives-ok { "a".map: *.Int }, 'without fatal, a map of Failures is a soft list';
+    is-deeply ("1", "2").map(*.Int), (1, 2), 'a successful map WhateverCode is unaffected';
+}


### PR DESCRIPTION
Fix the four remaining blockers in `roast/S02-types/whatever.t` so it passes fully (131/131) and add it to the whitelist.

## Fixes

- **Test 111** (`$foo ~~ (* =:= $foo)` — "Code.ACCEPTS preserves container"): the smartmatch op now records the scalar LHS variable as the call's `arg_sources` before invoking a `Code` RHS, so the WhateverCode's `is raw` `_` binding aliases `_` to the LHS and `=:=` sees the same container — the same path an explicit `(* =:= $foo)($foo)` call already took.

- **Test 120** (`use fatal; "a".map: *.Int` — "WhateverCode curry correctly propagates `use fatal`"): an unhandled `Failure` that ends up *inside* a reified list/`Seq` now throws under `use fatal`, via a new `unhandled_failure_in_list_for_fatal` checked at the sink (`SinkPop`), block return (`ThrowIfFailure`), and the test-assertion block path (`eval_test_block_value`). Also fixes a latent leak where `use fatal` inside a test-assertion block escaped into the tests that followed.

- **Test 124** (regex whatever curry): a `Test` call (`pass`/`ok`) inside a `<?{...}>`/`<!{...}>` code assertion now works. `eval_regex_code_assertion`'s scratch interpreter inherits the parent's `loaded_modules` + active TAP state so the assertion's boolean is computed correctly. Its buffered output is discarded; the real TAP emission comes from the deferred `execute_regex_code_blocks` on the winning match path (no double emission).

- **Test 131** (`do { $_ = 42; (Int).map(*.new($_)) }` — "no scoping issues when using topic variables"; previously masked by the test-124 abort): a WhateverCode whose body references `$_` compiles its `*` to a synthetic `__wc_N` param, so its `$_` must stay the caller topic. The routine-`$_` reset (`vm_closure_dispatch`) and the general map loop (`resolution_map_grep`) no longer topicalize `$_` to the element for such a WhateverCode — guarded by `_`-is-not-a-param so a plain `*.abs` still receives the element.

## Tests

- `roast/S02-types/whatever.t` now passes 131/131 (whitelisted).
- New `t/whatever-code-fixes.t` pins all four behaviors.
- `make test` green (13924 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)