### PR TITLE
fix(concurrency): resolve Lock.protect race condition + array-bind-in-loop corruption

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -34,8 +34,8 @@
   2. **真の lazy 配列 / 無限列** — 残りは `S09-subscript/slice.t` のみ。
   3. **dispatch / 演算子 sugar の desugar surface** — 残りは `hyper.t` のみ
      （`assign.t` は完了、詳細は `news/2026-07.md`）。
-  4. **並行実行基盤（S17）** — 大半は片づいたが、`Lock.protect` に本物の
-     race condition が残っている。
+  4. **並行実行基盤（S17）** — `Lock.protect` の race condition は解決済み
+     （§6 参照）。残るのは `S17-supply/syntax.t` のみ。
 
 ---
 
@@ -243,27 +243,8 @@ surface のうち 1 ファイル。
 ## 6. 並行・非同期（S17）
 
 大半は完了した（semaphore.t、then.t、scheduler/basic.t、supply/migrate.t、supply/stable.t、
-S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t —
-詳細は `news/2026-06.md` / `news/2026-07.md`）。残るのは次の 2 ファイル。
-
-### 6.1 `S17-lowlevel/lock.t` — 本物の race condition
-
-- **現状**: 3 planned に対し TAP 順序異常＋2 失敗。`Thread .join` を実スレッド join に
-  ルーティングする修正（#4026）が landed した後も再現する。
-- **症状**: `Lock.protect` 配下で複数スレッドが共有カウンタを increment するテストで、
-  期待列（10, 20, 30, ..., 1000）に対し実際の出力から特定のインクリメントが欠落したり
-  重複したりする（例: `420` が `0` になる、`10` が丸ごと消える、`710` が二重に出る）。
-  これは shared-scalar coherence の未解決部分であり、`S17-lowlevel/semaphore.t` で行った
-  `call_protect_block` 型の reconcile/writeback への寄せが `Lock` 自体にはまだ
-  適用されていない可能性が高い。
-- **変更レイヤ**: `shared_vars` / `shared_vars_dirty`、`Lock.protect` の critical section
-  entry/exit
-- **Primary files**: `src/runtime/native_methods/state_lock.rs`,
-  `src/runtime/runtime_shared_vars.rs`
-- **Next slice**: `Lock.protect` を `call_protect_block`（既存の resync/writeback
-  chokepoint）へ実際に寄せられているか確認し、寄せられていなければ semaphore.t の修正
-  （#3992）と同じパターンを適用する。TAP 順序異常は別に fire-and-forget スレッド出力の
-  drain タイミングの問題の可能性がある。
+S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowlevel/lock.t —
+詳細は `news/2026-06.md` / `news/2026-07.md`）。残るのは次の 1 ファイル。
 
 ### 6.2 `S17-supply/syntax.t`
 
@@ -318,15 +299,14 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t —
 
 「次に何をやるか」を 1 本だけ選ぶなら、順番はこう見るのが妥当。
 
-1. **`S17-lowlevel/lock.t` の race condition**（§6.1）— semaphore.t で確立した
-   reconcile/writeback パターンを `Lock` にも適用できれば早い。
-2. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
+1. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
    splice.t / attributes.t / multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-3. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
+2. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
    残りの失敗を分類して潰す。
-4. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
+3. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
    一環として進める。
+4. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
 
 `S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が
 深いアーキテクチャ変更を要するため、上記優先順から外した。

--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -14,37 +14,56 @@
 - [ ] roast/S17-lowlevel/cas-loop-int.t
 - [ ] roast/S17-lowlevel/cas-loop.t
 - [ ] roast/S17-lowlevel/cas.t
-- [ ] roast/S17-lowlevel/lock.t
-  - Lock subtest 6/24 → 9/24: `.join` on a Thread now routes to the real
-    thread-join (`dispatch_thread_finish`) instead of the native list-`join`
-    fast path, which stringified the Thread to "Thread(...)" and returned WITHOUT
-    waiting — so captured-outer writes (`$now1`/`@log`) never propagated and the
-    condition-variable tests saw stale values. The condvar wait/signal itself was
-    always correct; only the join was a no-op. FIXED subtests 7-9 (condition
-    variable across threads). Remaining blockers:
-    - subtests 10-24 (`Correct result and no crash in lock/condvar use`): use
-      `$*SCHEDULER.cue({ ... })` with per-iteration `$in := @in[$i]` /
-      `$out := @out[$i]` bindings and a closure `{ $out = $in * 10 }`. Two layers:
-      (a) **read-only `:=` capture per-iteration freeze — FIXED** (a separate
-      general bug, not thread-specific): a closure that READS a `:=`-bound
-      loop-local froze the shared/re-pointed `ContainerRef` (nested, all resolving
-      to the loop's final element) instead of its own iteration's value, so plain
-      closures gave `[50 0 40 50 50]` vs raku `[10 20 30 40 50]`. Now
-      `freeze_readonly_owned_captures` value-snapshots a read-only owned-capture
-      `ContainerRef` into both the captured env and the upvalue slots. See
-      t/loop-bind-closure-capture.t.
-      (b) **REMAINING: thread + shared_vars by-name collision.** In a `cue`/`start`
-      thread, `clone_for_thread` seeds each captured lexical into `shared_vars` by
-      NAME, so same-named per-iteration loop vars (`$i`/`$out`) collapse into one
-      cell — the thread read/write routes to the collided cell instead of the
-      closure's per-iteration owned-capture / box-on-capture cell. Excluding
-      `ContainerRef` from the seeding alone is not enough ($i is a plain Int; the
-      owned-capture-vs-shared_vars read routing needs the thread to prefer the
-      closure's frozen capture). Deeper thread-capture work (§4.1/§4.2).
-    - "ok 5 - Even from another thread" prints at top level out of order: a
-      `pass` on a `Thread.start` worker *inside a subtest* isn't captured by the
-      subtest (TAP output ordering for Thread.start-in-subtest; cf. #4010 which
-      fixed the start{}/Promise case gated on subtest_depth==0).
+- [x] roast/S17-lowlevel/lock.t — **48/48 (both `Lock` and `Lock::Soft` subtests
+    24/24), whitelisted (2026-07-02).**
+  - **Real race condition (the original §6.1 blocker):** `Lock.protect`/
+    `.lock`/`.unlock` never called `enter_critical_section`/
+    `leave_critical_section` (unlike `Semaphore.acquire`/`.release`, fixed for
+    `semaphore.t` above), so the `shared_critical_dirty` resync/writeback
+    chokepoint never fired for `Lock`. Bare `$lock.protect: { $done++; ... }`
+    across threads lost or duplicated increments (`$done`/`$todo` diverged
+    across the 3 separate call sites: the `native_lock` slow path in
+    `concurrency.rs`, and the two VM fast paths in `vm_call_method_ops.rs` /
+    `vm_call_method_mut_ops.rs`). Fixed by adding the same
+    enter/leave-critical-section calls Semaphore already had, in all three
+    places. See t/lock-protect-shared-scalar.t.
+  - **Separate deterministic bug (found while chasing the array-value
+    corruption in subtests 10-24):** `my $x := @a[$i]` inside a loop body
+    corrupted *earlier* iterations' bound array elements — reproducible
+    single-threaded, no lock/thread involved (see t/bind-array-elem-in-loop.t).
+    Root cause: the compiler routed `:=` VarDecl/rebind targets through
+    `compile_call_arg`, which — for an `Expr::Index` argument — unconditionally
+    emits the `is rw` *call-argument* writeback machinery (temp globals
+    `__mutsu_index_rw_arg_N`/`__mutsu_index_rw_orig_N`, meant for `f(@a[$i])`
+    where `f` has an `is rw` param). Those temp names are compile-time-fixed;
+    inside a loop the same bind statement re-executes every iteration, and
+    `SetGlobal`'s "write through an existing `ContainerRef`" semantics (meant
+    for `our`-var rebinding) then wrote the *new* iteration's cell reference
+    into the *previous* iteration's cell, nesting `ContainerRef`s and
+    ultimately aliasing every bound element to the loop's last iteration.
+    Fixed with a new `bind_target_direct` compiler flag, set only at the 3
+    `:=`-bind/rebind call sites, read-and-cleared at the top of
+    `compile_call_arg_with_escape` (so a genuine call nested inside a bind RHS,
+    e.g. `my $x := f(@a[$i])`, still gets normal `is rw` writeback for `f`'s
+    own argument) — when set, skip the writeback temps entirely and just
+    `WrapVarRef` the value the Index compile already produced.
+  - **TAP ordering bug ("ok 5 - Even from another thread" printing out of
+    order):** `Thread.start` unconditionally forced `immediate_stdout = true`
+    on the cloned interpreter, undoing the `parent_in_subtest` buffering
+    `clone_for_thread` already arranges — so a `pass` on a fire-and-forget
+    `Thread.start` worker spawned *inside* a `subtest { ... }` wrote straight
+    to real stdout instead of the subtest's buffer. Fixed by respecting
+    `parent_in_subtest` in `dispatch_thread_start`, and draining
+    `shared_thread_output` both in `dispatch_thread_finish` (explicit
+    `.finish`/`.join`) and in `finish_subtest` (so a subtest that never joins
+    its spawned thread still folds in whatever the thread had buffered by the
+    time the subtest body returns — the thread's `pass` here is effectively
+    instantaneous).
+  - `Lock::Soft` itself was entirely unrecognized as a type (`Lock::Soft.new`
+    silently did nothing). Registered as an MRO-subclass alias of `Lock`
+    (mirroring the existing `Lock::Async` alias), which is sufficient — native
+    dispatch (`native_lock`) already keys off `attributes`, not class name, and
+    the two `.protect` fast paths already fall back correctly via `class_mro`.
 - [x] roast/S17-lowlevel/semaphore.t — **2/2, whitelisted (2026-07-01).**
     The test runs bare `$s.acquire; $r += $i; $s.release` and `@r[$i]++` across
     4000 Promise.start threads. Previously the accumulator raced (last-writer

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,39 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-02: `S17-lowlevel/lock.t` — `Lock.protect` の race condition + 派生バグ2件を解決（whitelist 追加）
+
+BLOCKERS.md §6.1 で追跡していた「本物の race condition」を解決し、48/48（`Lock`・`Lock::Soft` 両
+subtest 24/24）で whitelist 済みとなった。1本の症状の裏に3つの独立したバグがあった。
+
+1. **race condition 本体**: `Lock.protect`/`.lock`/`.unlock` が `Semaphore.acquire`/`.release`
+   （semaphore.t #3992 で導入）と違い `enter_critical_section`/`leave_critical_section` を一度も
+   呼んでおらず、`shared_critical_dirty` の resync/writeback chokepoint が `Lock` に対して機能して
+   いなかった。呼び出し経路が3箇所（`native_lock` slow path と VM 側 fast path 2箇所）に重複して
+   いたため、全て同じパターンで修正。回帰テスト: `t/lock-protect-shared-scalar.t`。
+2. **配列要素 bind の破損（独立したコンパイラバグ）**: `my $x := @a[$i]` をループ内で実行すると
+   *前の*イテレーションで bind した要素が壊れる、という単体（thread 不使用）でも再現するバグを
+   発見。原因は `:=` の VarDecl/rebind コンパイルが `compile_call_arg` を共用しており、
+   `Expr::Index` 引数に対して本来は `f(@a[$i])` の `is rw` 引数書き戻し専用の一時グローバル変数
+   （`__mutsu_index_rw_arg_N`/`__mutsu_index_rw_orig_N`、コンパイル時に固定された名前）を無条件に
+   発行していたこと。ループ内では同じ bind 文が毎回同じ固定グローバル名を再利用するため、
+   `SetGlobal` の「既存 `ContainerRef` への書き込みスルー」（`our` 変数の再バインド用）が働き、
+   新しいイテレーションのセル参照が前のイテレーションのセルに書き込まれてしまっていた。
+   `bind_target_direct` という新しいコンパイラフラグを追加し、3箇所の bind/rebind 呼び出しサイトで
+   のみ立てて `compile_call_arg_with_escape` の先頭で読み取り＆即座にクリアすることで、bind RHS に
+   ネストした本物の関数呼び出し（`my $x := f(@a[$i])`）の `is rw` 書き戻しは温存しつつ、bind 対象
+   自身では該当機構を完全にスキップするようにした。回帰テスト: `t/bind-array-elem-in-loop.t`。
+3. **TAP 出力順序バグ**: `Thread.start` が `clone_for_thread` の `parent_in_subtest` 判定を無視して
+   無条件に `immediate_stdout = true` にしていたため、`subtest { ... }` 内で fire-and-forget
+   起動した thread の `pass` がトップレベル stdout に直接漏れていた（"ok 5" が subtest ヘッダより
+   前に出力される）。`dispatch_thread_start` を `parent_in_subtest` に従わせ、`dispatch_thread_finish`
+   と `finish_subtest`（明示的な `.finish` を呼ばない fire-and-forget パターンのため）の両方に
+   `drain_shared_thread_output()` を追加。
+
+副次的に `Lock::Soft`（JVM 以外では `Lock` と同じ振る舞いのはずの型）が全く型として認識されて
+いなかったことも判明。既存の `Lock::Async` エイリアスパターンに倣い `Lock` の MRO サブクラスとして
+登録するだけで解決した（`native_lock` は attributes ベースで dispatch するため class 名に依存しない）。
+
 ## 2026-07-02: §F 型付き例外 — 非コンテナへの element bind が X::Bind を投げる（#4053）
 
 `(List)[0] := 1` / `(Int)[0] := 1`（型オブジェクトへの positional element bind）が **silent 成功**していた。

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -863,6 +863,7 @@ roast/S17-lowlevel/cas-int.t
 roast/S17-lowlevel/cas-loop-int.t
 roast/S17-lowlevel/cas-loop.t
 roast/S17-lowlevel/cas.t
+roast/S17-lowlevel/lock.t
 roast/S17-lowlevel/semaphore.t
 roast/S17-lowlevel/thread-start-join-stress.t
 roast/S17-lowlevel/thread.t

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -171,6 +171,15 @@ impl Compiler {
     /// Promise and run later on another thread), so the locals it captures and
     /// mutates must be promoted to shared `ContainerRef` cells (escape analysis).
     pub(super) fn compile_call_arg_with_escape(&mut self, arg: &Expr, escaping: bool) {
+        // Read-and-clear immediately: this call is the *direct* bind-target
+        // compile iff the caller just set the flag for us. Clearing it up
+        // front (before any nested `compile_expr`/`compile_call_arg`
+        // recursion below) means a genuine call nested inside a bind RHS
+        // (`my $x := f(@a[$i])`) sees `false` for its own argument compile,
+        // so `f`'s `is rw` writeback machinery is untouched. See the field
+        // doc on `bind_target_direct`.
+        let is_bind_target = self.bind_target_direct;
+        self.bind_target_direct = false;
         // An array multi-dimensional subscript (`@a[0;1;2]`) passed as a raw
         // `\target` / `is rw` argument must alias the underlying nested array
         // slot, so a later `target = v` inside the callee mutates the real
@@ -233,7 +242,23 @@ impl Compiler {
         };
         // For Index expressions, create temp variables for `is rw` writeback
         // and wrap with VarRef so `is rw` parameters can bind through.
-        if matches!(arg, Expr::Index { .. }) {
+        if matches!(arg, Expr::Index { .. }) && is_bind_target {
+            // `:=` bind to an Index expression (`my $x := @a[$i]`): the Index
+            // compile already promoted the element to a first-class
+            // `ContainerRef` cell on the stack (IndexAutovivifyLazyTerminal /
+            // array_slot_ref). Just wrap it with VarRef so SetLocal's
+            // `extract_varref_binding` sees `is_bind = true`. Skip the is-rw
+            // *call-argument* writeback temps entirely: there is no function
+            // call to writeback after here, and those temps are
+            // compile-time-fixed global names — reused verbatim on every
+            // iteration of a loop wrapping this same bind statement, whose
+            // "write through an existing ContainerRef" semantics would
+            // corrupt the *previous* iteration's bound cell instead of
+            // storing a fresh reference to this one.
+            let tmp = format!("__mutsu_bind_index_ref_{}", self.code.constants.len());
+            let name_idx = self.code.add_constant(Value::str(tmp));
+            self.code.emit(OpCode::WrapVarRef(name_idx));
+        } else if matches!(arg, Expr::Index { .. }) {
             let tmp = format!("__mutsu_index_rw_arg_{}", self.code.constants.len());
             let orig = format!("__mutsu_index_rw_orig_{}", self.code.constants.len());
             let tmp_idx = self.code.add_constant(Value::str(tmp.clone()));

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -109,6 +109,19 @@ pub(crate) struct Compiler {
     /// to a cell. Cleared while compiling the inner `target` so only the outermost
     /// index is terminal.
     bind_terminal: bool,
+    /// When true, the *immediate* upcoming `compile_call_arg` call compiles a
+    /// `:=` bind/rebind target (`my $x := @a[$i]`), not a genuine function-call
+    /// argument. `compile_call_arg` reads this once at entry and clears it
+    /// before any nested compilation, so a call nested inside the bind RHS
+    /// (`my $x := f(@a[$i])`) still sees `false` for its own arguments and
+    /// keeps the normal `is rw` writeback machinery. Guards against reusing the
+    /// call-argument `is rw` Index writeback temps (`__mutsu_index_rw_*`) for a
+    /// bind: those temps are compile-time-fixed global names, and inside a loop
+    /// body the same bind statement re-executes every iteration, so the
+    /// call-argument writeback's "write through an existing ContainerRef"
+    /// semantics corrupt the *previous* iteration's bound cell instead of
+    /// storing a fresh one (see the `lock.t` array-corruption investigation).
+    bind_target_direct: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
     /// Subset of `constant_vars` whose declaring lexical block is still open.
@@ -220,6 +233,7 @@ impl Compiler {
             bind_vardecl: false,
             scalar_bind_autovivify: false,
             bind_terminal: false,
+            bind_target_direct: false,
             constant_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
             constant_vars_current_scope: std::collections::HashSet::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1015,6 +1015,7 @@ impl Compiler {
                     self.bind_vardecl = false;
                     self.scalar_bind_autovivify = true;
                     self.bind_terminal = true;
+                    self.bind_target_direct = true;
                     self.compile_call_arg(expr);
                     self.scalar_bind_autovivify = false;
                     self.bind_terminal = false;
@@ -1036,6 +1037,7 @@ impl Compiler {
                     // COW push would then detach the alias.)
                     self.scalar_bind_autovivify = true;
                     self.bind_terminal = true;
+                    self.bind_target_direct = true;
                     self.compile_call_arg(expr);
                     self.scalar_bind_autovivify = false;
                     self.bind_terminal = false;
@@ -1450,6 +1452,7 @@ impl Compiler {
                     if scalar_elem_bind {
                         self.scalar_bind_autovivify = true;
                         self.bind_terminal = true;
+                        self.bind_target_direct = true;
                         self.compile_call_arg(expr);
                         self.scalar_bind_autovivify = false;
                         self.bind_terminal = false;

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -381,9 +381,19 @@ impl Interpreter {
 
         let thread_id = NEXT_THREAD_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
+        // A thread spawned *inside* a subtest must keep buffering its output
+        // through `shared_thread_output` (as `clone_for_thread` already
+        // arranges) rather than writing straight to stdout: its TAP lines are
+        // subtest-internal and must be drained (indented) into the subtest by
+        // `Thread.finish`, not leaked to the real top-level stream ("tests out
+        // of sequence"). Only threads spawned at top level get immediate
+        // stdout so their output lands in real chronological order relative
+        // to the main thread's direct writes.
+        let parent_in_subtest = self.tap.subtest_depth() != 0;
         let mut thread_interp = self.clone_for_thread();
-        // Enable immediate stdout so thread output goes directly to stdout
-        thread_interp.set_immediate_stdout(true);
+        if !parent_in_subtest {
+            thread_interp.set_immediate_stdout(true);
+        }
         let mutsu_tid = thread_id as i64;
         // Use the large user-code stack (matches `start {}` / Promise / Supply
         // worker threads): `Thread.start` runs arbitrary user code, and the
@@ -454,6 +464,12 @@ impl Interpreter {
         }
         // Sync shared variables back to env after thread completes
         self.sync_shared_vars_to_env();
+        // Joining a thread is a synchronization point: flush any output the
+        // thread buffered into `shared_thread_output` (e.g. TAP lines from a
+        // thread spawned inside a subtest, which cannot use immediate stdout —
+        // see `dispatch_thread_start`) so it lands in real chronological order
+        // now, rather than at some later, possibly out-of-order sync point.
+        self.drain_shared_thread_output();
         Ok(Value::Bool(true))
     }
 }

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -24,8 +24,13 @@ impl Interpreter {
                     .ok_or_else(|| RuntimeError::new("Lock.protect could not find lock state"))?;
                 let me = current_thread_id();
                 acquire_lock(&lock, me)?;
+                // Entering the critical section: pull the latest value of any
+                // shared scalar a previous holder committed inside its own
+                // critical section (mirrors Semaphore.acquire).
+                self.enter_critical_section();
                 let code = args.first().cloned().unwrap_or(Value::Nil);
                 let result = self.call_protect_block(&code);
+                self.leave_critical_section();
                 let _ = release_lock(&lock, me);
                 result
             }
@@ -49,6 +54,7 @@ impl Interpreter {
                     Ok(Value::Promise(promise))
                 } else {
                     acquire_lock(&lock, me)?;
+                    self.enter_critical_section();
                     Ok(Value::Nil)
                 }
             }
@@ -68,6 +74,7 @@ impl Interpreter {
                 if is_async {
                     async_release_lock(&lock)?;
                 } else {
+                    self.leave_critical_section();
                     let me = current_thread_id();
                     release_lock(&lock, me)?;
                 }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -526,6 +526,22 @@ impl Interpreter {
             },
         );
         classes.insert(
+            "Lock::Soft".to_string(),
+            ClassDef {
+                parents: vec!["Lock".to_string()],
+                attributes: Vec::new(),
+                methods: HashMap::new(),
+                native_methods: HashSet::new(),
+                mro: vec!["Lock::Soft".to_string(), "Lock".to_string()],
+                attribute_types: HashMap::new(),
+                attribute_smileys: HashMap::new(),
+                attribute_built: HashMap::new(),
+                wildcard_handles: Vec::new(),
+                alias_attributes: HashSet::new(),
+                class_level_attrs: HashMap::new(),
+            },
+        );
+        classes.insert(
             "Lock::ConditionVariable".to_string(),
             ClassDef {
                 parents: Vec::new(),

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -174,6 +174,15 @@ impl Interpreter {
         label: &str,
         run_result: Result<(), RuntimeError>,
     ) -> Result<(), RuntimeError> {
+        // A fire-and-forget thread spawned inside this subtest (`Thread.start`
+        // with no `.finish`/`.join`) buffers its TAP output into
+        // `shared_thread_output` rather than writing immediately (see
+        // `dispatch_thread_start`), since its lines are subtest-internal and
+        // must be indented into this subtest, not leaked to the top-level
+        // stream. Drain it now, before taking the subtest's own output below,
+        // so any such buffered lines are folded into `subtest_output` and get
+        // indented/numbered along with the rest of this subtest's assertions.
+        self.drain_shared_thread_output();
         let mut subtest_output = std::mem::take(&mut self.output_sink_mut().output);
         let subtest_state = self.tap.take_state();
         let subtest_failed = subtest_state.as_ref().map(|s| s.failed).unwrap_or(0);

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -700,11 +700,16 @@ impl Interpreter {
                 .ok_or_else(|| RuntimeError::new("Lock.protect could not find lock state"))?;
             let me = crate::runtime::native_methods::current_thread_id();
             crate::runtime::native_methods::acquire_lock(&lock, me)?;
+            // Entering the critical section: pull the latest value of any
+            // shared scalar a previous holder committed inside its own
+            // critical section (mirrors Semaphore.acquire).
+            self.enter_critical_section();
             let code_val = args.into_iter().next().unwrap_or(Value::Nil);
             let result = match self.try_exec_simple_shared_protect_block(code, &code_val)? {
                 Some(value) => Ok(value),
                 None => self.exec_protect_block_inline(code, &code_val),
             };
+            self.leave_critical_section();
             let _ = crate::runtime::native_methods::release_lock(&lock, me);
             self.stack.push(result?);
             return Ok(());

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -546,11 +546,16 @@ impl Interpreter {
                 .ok_or_else(|| RuntimeError::new("Lock.protect could not find lock state"))?;
             let me = crate::runtime::native_methods::current_thread_id();
             crate::runtime::native_methods::acquire_lock(&lock, me)?;
+            // Entering the critical section: pull the latest value of any
+            // shared scalar a previous holder committed inside its own
+            // critical section (mirrors Semaphore.acquire).
+            self.enter_critical_section();
             let code_val = args.into_iter().next().unwrap_or(Value::Nil);
             let result = match self.try_exec_simple_shared_protect_block(code, &code_val)? {
                 Some(value) => Ok(value),
                 None => self.exec_protect_block_inline(code, &code_val),
             };
+            self.leave_critical_section();
             let _ = crate::runtime::native_methods::release_lock(&lock, me);
             self.stack.push(result?);
             return Ok(());

--- a/t/bind-array-elem-in-loop.t
+++ b/t/bind-array-elem-in-loop.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 4;
+
+# Regression test: `my $x := @a[$i]` inside a loop body must bind a fresh
+# ContainerRef cell to the CURRENT array element on every iteration. A
+# compiler bug reused the `is rw` call-argument writeback machinery (meant
+# for `f(@a[$i])` where `f` has an `is rw` param) for `:=` bind targets too.
+# Those writeback temps are compile-time-fixed global names; inside a loop
+# the same bind statement re-executes every iteration, so on the 2nd+
+# iteration the writeback's "write through an existing ContainerRef" wrongly
+# wrote into the *previous* iteration's bound cell instead of storing a
+# fresh reference, corrupting earlier array elements.
+
+{
+    my @out = 0 xx 5;
+    for 0..4 -> $i {
+        my $slot := @out[$i];
+        $slot = ($i + 1) * 10;
+    }
+    is @out, [10, 20, 30, 40, 50], 'for-loop: my $x := @a[$i] binds a fresh cell per iteration';
+}
+
+{
+    my @out = 0 xx 5;
+    loop (my $i = 0; $i < 5; $i++) {
+        my $slot := @out[$i];
+        $slot = ($i + 1) * 10;
+    }
+    is @out, [10, 20, 30, 40, 50], 'C-style loop: my $x := @a[$i] binds a fresh cell per iteration';
+}
+
+{
+    # Two distinct bindings per iteration (source + destination), matching
+    # the pattern in roast/S17-lowlevel/lock.t.
+    my @in = 1..5;
+    my @out = 0 xx 5;
+    loop (my $i = 0; $i < @in; $i++) {
+        my $in := @in[$i];
+        my $out := @out[$i];
+        $out = $in * 10;
+    }
+    is @out, [10, 20, 30, 40, 50], 'loop with two element binds per iteration stays isolated';
+}
+
+{
+    my @out = 0 xx 3;
+    for 0..2 -> $i {
+        my $slot := @out[$i];
+        $slot = $i;
+    }
+    is @out, [0, 1, 2], 'bound value 0 does not get lost on later iterations';
+}

--- a/t/lock-protect-shared-scalar.t
+++ b/t/lock-protect-shared-scalar.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A bare `Lock.protect` critical section must make a shared scalar's
+# read-modify-write and a shared array element mutation visible to the next
+# holder — the accumulator is genuinely shared across all threads, while the
+# per-iteration loop lexical stays thread-local. Regression test for a bug
+# where `Lock.protect`/`.lock`/`.unlock` never entered the critical-section
+# tracking that `Semaphore.acquire`/`.release` already used (see
+# t/semaphore-shared-scalar.t), so concurrent `Lock`-protected accumulation
+# silently dropped or duplicated updates.
+
+plan 3;
+
+{
+    my Lock $l .= new;
+    my $r = 0;
+    my @p;
+    for ^200 {
+        my $i = $_;
+        @p.push: Promise.start({
+            $l.protect({
+                $r += $i;
+            });
+        });
+    }
+    await @p;
+    is $r, (^200).sum, 'Lock.protect-protected scalar accumulation';
+}
+
+{
+    my Lock $l .= new;
+    my @r;
+    my @p;
+    for ^200 {
+        my $i = $_;
+        @p.push: Promise.start({
+            $l.protect({
+                @r[$i]++;
+            });
+        });
+    }
+    await @p;
+    is-deeply @r, [1 xx 200], 'Lock.protect-protected array element mutation';
+}
+
+{
+    my Lock $l .= new;
+    my $r = 0;
+    my @p;
+    for ^200 {
+        my $i = $_;
+        @p.push: Promise.start({
+            $l.lock;
+            $r += $i;
+            $l.unlock;
+        });
+    }
+    await @p;
+    is $r, (^200).sum, 'explicit Lock.lock/.unlock accumulation';
+}


### PR DESCRIPTION
## Summary
- Fixes `roast/S17-lowlevel/lock.t` (BLOCKERS.md §6.1's "real race condition"), now whitelisted at 48/48 (both `Lock` and `Lock::Soft` subtests).
- Three independent bugs were found while chasing the one failing test:
  1. **The race condition itself**: `Lock.protect`/`.lock`/`.unlock` never called `enter_critical_section`/`leave_critical_section` (unlike `Semaphore.acquire`/`.release`, fixed in #3992), so the `shared_critical_dirty` resync/writeback chokepoint never fired for `Lock`. Fixed across all three call sites (the `native_lock` slow path + two VM fast paths).
  2. **A separate, deterministic compiler bug**: `my $x := @a[$i]` inside a loop body corrupted *earlier* iterations' bound array elements — reproducible single-threaded, no locking involved. Root cause: `:=` bind targets were routed through `compile_call_arg`, which unconditionally emits the `is rw` call-argument writeback machinery (compile-time-fixed temp global names) for `Expr::Index` arguments. Reused every loop iteration, this wrote each new iteration's cell reference into the *previous* iteration's cell. Fixed with a new `bind_target_direct` compiler flag, scoped so a genuine function call nested in a bind RHS still gets normal `is rw` writeback.
  3. **A TAP output-ordering bug**: `Thread.start` forced `immediate_stdout` unconditionally, undoing `clone_for_thread`'s subtest-buffering protection, so a fire-and-forget thread spawned inside a `subtest { ... }` leaked its TAP line to the top-level stream. Fixed by respecting `parent_in_subtest`, and draining `shared_thread_output` in both `Thread.finish` and `finish_subtest`.
- Also registers `Lock::Soft` as an MRO alias of `Lock` (previously unrecognized as a type at all), mirroring the existing `Lock::Async` pattern.

## Test plan
- [x] `cargo test --lib` — 477 passed
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean
- [x] `prove -e target/debug/mutsu t/` — 13884 tests, all pass (includes 2 new regression tests: `t/lock-protect-shared-scalar.t`, `t/bind-array-elem-in-loop.t`)
- [x] Verified both new regression tests fail on pristine `main` and pass with this fix
- [x] `roast/S17-lowlevel/lock.t` — 48/48, run 15× locally with no flakiness
- [x] Spot-checked related roast tests for regressions (semaphore.t, thread-start-join-stress.t, S17-promise/start.t, S07-hyperrace/basics.t) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK