### PR TITLE
fix(operators): pass S06-operator-overloading/infix.t (comma overload + equiv non-chaining)

### DIFF
--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -86,7 +86,7 @@
 - [ ] roast/S06-multi/value-based.t
 - [ ] roast/S06-operator-overloading/circumfix.t
 - [ ] roast/S06-operator-overloading/imported-subs.t
-- [ ] roast/S06-operator-overloading/infix.t
+- [x] roast/S06-operator-overloading/infix.t
     - NOTE: rakudo itself cannot even compile this file (line 40
       `&infix:<plus> := { ... }` -> "Cannot bind to '&infix:<plus>' because
       Code items cannot be rebound"; the block is `#?rakudo skip`-fudged).
@@ -180,18 +180,21 @@
         `raku` exactly (confirmed `BEGIN my $plus = '+'` is required for
         real raku too — it resolves the interpolated name at the point the
         statement executes, same as mutsu's runtime resolution).
-      - **Remaining (31-32, `sub infix:<,>(...)`): a deep, higher-risk
-        feature — overriding the comma operator itself, which is a hardcoded
-        list/arg-separator token used pervasively throughout the parser (list
-        literals, call arguments, hash literals, ...), not a generically
-        dispatched infix operator. Real raku only honors this override
-        inside a fresh `EVAL` (a new compilation unit re-parses with the
-        newly-declared operator already in the operator table); the *same*
-        file's non-EVAL'd top-level `5, 5` stays a plain list even after
-        `sub infix:<,>` is declared earlier in the file. Not attempted —
-        would need comma to route through the extensible user-operator
-        table the same way `sub infix:<*+>` etc. already do, without
-        breaking every other use of `,` as a separator.**
+      - **DONE (2026-07-02): 50/50, whitelisted.** The final two blockers:
+        - 31-32 (`sub infix:<,>(...)`): a user-overloaded list-associative
+          comma now intercepts a bare value-list before it becomes a `List`.
+          `MakeArray` checks `try_comma_overload` (guarded on the normally-empty
+          `user_declared_infix_ops` set) and, when `infix:<,>` is registered,
+          dispatches all operands to it at once. Argument-list commas
+          (`f(a, b)`) compile directly, not through `MakeArray`, so they are
+          unaffected — matching raku (value lists only).
+        - 49-50 (`is equiv(&infix:<==>)` custom op): a user operator never
+          chains even when `equiv` copies a built-in chain op's precedence.
+          `list_infix_loop` only collects the full operand run for genuine
+          list/right/non associativity now; `left`, `chain`, and the
+          precedence-trait placeholders `equiv`/`tighter`/`looser` fold
+          left-associatively via the outer loop (`6 op 4 op 2` == `(6 op 4) op 2`,
+          not one n-ary `op(6,4,2)` call).
 - [ ] roast/S06-operator-overloading/methods.t
 - [ ] roast/S06-operator-overloading/prefix.t
 - [ ] roast/S06-operator-overloading/semicolon.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -492,6 +492,7 @@ roast/S06-multi/unpackability.t
 roast/S06-multi/value-based.t
 roast/S06-operator-overloading/circumfix.t
 roast/S06-operator-overloading/imported-subs.t
+roast/S06-operator-overloading/infix.t
 roast/S06-operator-overloading/methods.t
 roast/S06-operator-overloading/prefix.t
 roast/S06-operator-overloading/semicolon.t

--- a/src/parser/expr/precedence/list_infix_loop.rs
+++ b/src/parser/expr/precedence/list_infix_loop.rs
@@ -418,7 +418,15 @@ pub(crate) fn parse_list_infix_loop<'a>(
                 .unwrap_or_else(|| "left".to_string());
             let mut args = vec![left.clone(), right];
             r = r2;
-            if assoc != "left" {
+            // Only genuine associativity values collect the full operand run here:
+            // `list` (pass all to the routine), `right` (right-fold), `non` (reject
+            // >2), and `chain` (expanded pairwise downstream). The precedence-trait
+            // placeholders `equiv`/`tighter`/`looser` are NOT associativity and must
+            // fold left-associatively via the outer loop like `left`: a user operator
+            // never chains merely because `is equiv(&infix:<==>)` copied a built-in
+            // chain op's precedence — rakudo keeps it non-chaining, so `6 op 4 op 2`
+            // is `(6 op 4) op 2`, not one n-ary `op(6,4,2)` call.
+            if matches!(assoc.as_str(), "list" | "right" | "non" | "chain") {
                 loop {
                     let (r_ws, _) = ws(r)?;
                     let ws_between = &r[..r.len() - r_ws.len()];

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -78,6 +78,42 @@ impl Interpreter {
         Ok(())
     }
 
+    /// When the user has overloaded the list-associative comma operator
+    /// (`sub infix:<,> {...}`), a bare value-list expression (`5, 5`) dispatches
+    /// to that sub with ALL comma operands at once (raku's `infix:<,>` is
+    /// list-associative), instead of building a `List`. Returns `true` when the
+    /// call was made (result pushed); `false` when no override applies, in which
+    /// case the operands are left on the stack for normal list construction.
+    ///
+    /// Guarded on the (normally empty) `user_declared_infix_ops` set so ordinary
+    /// list construction pays only a set-emptiness check. Argument-list commas
+    /// (`f(a, b)`) are compiled directly, not through `MakeArray`, so they are
+    /// unaffected — matching raku, where `infix:<,>` overloads value lists only.
+    pub(super) fn try_comma_overload(&mut self, n: u32) -> Result<bool, RuntimeError> {
+        if n < 2
+            || self.user_declared_infix_ops.is_empty()
+            || !self.user_declared_infix_ops.contains("infix:<,>")
+        {
+            return Ok(false);
+        }
+        let n = n as usize;
+        let start = self.stack.len() - n;
+        let args: Vec<Value> = self.stack.drain(start..).collect();
+        if let Some(def) = loan_env!(self, resolve_function_with_types("infix:<,>", &args)) {
+            let empty_fns = HashMap::new();
+            let result = self.compile_and_call_function_def(&def, args, &empty_fns)?;
+            self.stack.push(result);
+            Ok(true)
+        } else {
+            // No candidate matched the operand count: restore the stack and let
+            // normal list construction proceed.
+            for a in args {
+                self.stack.push(a);
+            }
+            Ok(false)
+        }
+    }
+
     /// Try to dispatch a binary operation to a user-defined infix operator.
     /// Returns Some(result) if a user-defined candidate matched, None otherwise.
     pub(super) fn try_user_infix(

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2405,7 +2405,11 @@ impl Interpreter {
 
             // -- Composite --
             OpCode::MakeArray(n) => {
-                self.exec_make_array_op(*n, false);
+                // A user-overloaded list-associative `infix:<,>` intercepts the
+                // bare value-list before it becomes a List.
+                if !self.try_comma_overload(*n)? {
+                    self.exec_make_array_op(*n, false);
+                }
                 *ip += 1;
             }
             OpCode::MakeRealArray(n) => {


### PR DESCRIPTION
Passes `roast/S06-operator-overloading/infix.t` 50/50 (was 48/50, aborting at test 49) with two general fixes.

## 1. User-overloaded list-associative `infix:<,>` (tests 31-32)
`EVAL('sub infix:<,>($a, $b) { 42 }; 5, 5')` now returns 42. A `sub infix:<,>` intercepts a bare value-list before it becomes a `List`: `MakeArray` consults `try_comma_overload`, and when `infix:<,>` is registered it dispatches all comma operands to the sub at once (raku's comma is list-associative — `5,5,5` would call `infix:<,>(5,5,5)`).

- Guarded on the normally-empty `user_declared_infix_ops` set, so ordinary list construction pays only an is-empty check.
- Argument-list commas (`f(a, b)`) compile directly, not through `MakeArray`, so they are unaffected — matching raku, where the override applies to value lists only (`say(5,5)` stays `55`, but `my @a = 5,5` becomes `[42]`).

## 2. `is equiv(&infix:<==>)` custom operators no longer chain (tests 49-50)
`6 is-eq⨧ 4 is-eq⨧ 2` was compiled to a single 3-arg call `infix:<is-eq⨧>(6,4,2)` and died with "will never work". The `equiv`/`tighter`/`looser` precedence traits are stored in the associativity slot as a placeholder string, which made the parser collect the operand run into one n-ary call. But these are *precedence* traits, not associativity — a user operator never chains merely because it copied a chain op's precedence (rakudo keeps it non-chaining).

`list_infix_loop` now collects the full operand run only for the genuine associativity values `list`/`right`/`non`/`chain`; `equiv`/`tighter`/`looser` fold left-associatively via the outer loop like `left` (`6 op 4 op 2` == `(6 op 4) op 2`). Genuine `is assoc<chain>` still chains pairwise.

## Testing
- `roast/S06-operator-overloading/infix.t` 50/50 (added to whitelist).
- `make test` passes (full local suite + roast whitelist).
- `t/operator-associativity-traits.t` (all 4 assoc kinds) stays green; verified regression across S03-operators/S03-metaops/S06-operator-overloading.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)