### PR TITLE
refactor(vm): bake postfix inc/dec local slot into RMW chokepoint (§1.5 slice S2)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -79,8 +79,14 @@ broadcast = touches every slot with the name.
       writeback writes `self.locals[slot]` directly, falling back to by-name only
       for a `None` slot (global LHS / EVAL-carrier outer lexical). Behavior-
       preserving today. *(done)*
-- [ ] S2 — RMW chokepoint: thread the compile-time slot into
-      `store_named_scalar_rmw_result` (opcode operand for the inc/dec/compound ops).
+- [x] **S2 — RMW chokepoint (postfix `$x++`/`$x--`).** `PostIncrement`/`PostDecrement`
+      carry a compile-time `Option<u32>` slot; it is threaded to
+      `store_named_scalar_rmw_result`, which mirrors the new value into the baked
+      slot and uses it as the `local_bind_pairs` source instead of the by-name
+      `code.locals` search. The env-by-name RMW *read* is left as-is (a §1.3
+      dual-store concern, not a name→slot ambiguity). `None` for non-local targets
+      (`our`/dynamic/temp-value/`AtomicCompoundVar`), which keep the by-name path.
+      Prefix `++`/`--` and compound-assign-on-local are still by-name — S2b. *(done)*
 - [ ] S3 — `:=` bind: bake source/target slots at emit time instead of
       `resolve_pending_alias_binds` name lookup.
 - [ ] S4 — param-slot precompute: use the scope-correct slot.

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -9,13 +9,14 @@ impl Compiler {
                 self.alloc_local(name);
             }
             let name_idx = self.code.add_constant(Value::str(name.clone()));
-            self.code.emit(OpCode::PostIncrement(name_idx));
+            let slot = self.local_map.get(name).copied();
+            self.code.emit(OpCode::PostIncrement(name_idx, slot));
         } else if let Expr::BareWord(name) = expr {
             if self.sigilless_locals.contains(name.as_str()) {
                 // Sigilless rw binding (e.g. for-loop `-> \v { v++ }`): the bare
-                // word IS the env var, so increment it in place by name.
+                // word IS the env var (no local slot), so increment it by name.
                 let name_idx = self.code.add_constant(Value::str(name.clone()));
-                self.code.emit(OpCode::PostIncrement(name_idx));
+                self.code.emit(OpCode::PostIncrement(name_idx, None));
             } else {
                 self.compile_expr(&Expr::Call {
                     name: Symbol::intern("__mutsu_incdec_nomatch"),
@@ -26,8 +27,9 @@ impl Compiler {
             // state/my declarator in expression position: `state $x++`, `my $x.++`
             self.compile_expr(expr);
             self.code.emit(OpCode::Pop);
+            let slot = self.local_map.get(&var_name).copied();
             let name_idx = self.code.add_constant(Value::str(var_name));
-            self.code.emit(OpCode::PostIncrement(name_idx));
+            self.code.emit(OpCode::PostIncrement(name_idx, slot));
         } else if let Expr::Index { target, index, .. } = expr {
             if let Some(name) = Self::postfix_index_name(target) {
                 self.compile_expr(index);
@@ -64,7 +66,7 @@ impl Compiler {
                 let tmp_result_idx = self.code.add_constant(Value::str(tmp_result_name.clone()));
                 self.compile_expr(expr);
                 self.code.emit(OpCode::SetGlobal(tmp_value_idx));
-                self.code.emit(OpCode::PostIncrement(tmp_value_idx));
+                self.code.emit(OpCode::PostIncrement(tmp_value_idx, None));
                 self.code.emit(OpCode::SetGlobal(tmp_result_idx));
                 let assign_expr = Expr::Call {
                     name: Symbol::intern("__mutsu_assign_method_lvalue"),
@@ -100,12 +102,13 @@ impl Compiler {
                 self.alloc_local(name);
             }
             let name_idx = self.code.add_constant(Value::str(name.clone()));
-            self.code.emit(OpCode::PostDecrement(name_idx));
+            let slot = self.local_map.get(name).copied();
+            self.code.emit(OpCode::PostDecrement(name_idx, slot));
         } else if let Expr::BareWord(name) = expr {
             if self.sigilless_locals.contains(name.as_str()) {
-                // Sigilless rw binding (e.g. for-loop `-> \v { v-- }`).
+                // Sigilless rw binding (e.g. for-loop `-> \v { v-- }`) — env var.
                 let name_idx = self.code.add_constant(Value::str(name.clone()));
-                self.code.emit(OpCode::PostDecrement(name_idx));
+                self.code.emit(OpCode::PostDecrement(name_idx, None));
             } else {
                 self.compile_expr(&Expr::Call {
                     name: Symbol::intern("__mutsu_incdec_nomatch"),
@@ -115,8 +118,9 @@ impl Compiler {
         } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
             self.compile_expr(expr);
             self.code.emit(OpCode::Pop);
+            let slot = self.local_map.get(&var_name).copied();
             let name_idx = self.code.add_constant(Value::str(var_name));
-            self.code.emit(OpCode::PostDecrement(name_idx));
+            self.code.emit(OpCode::PostDecrement(name_idx, slot));
         } else if let Expr::Index { target, index, .. } = expr {
             if let Some(name) = Self::postfix_index_name(target) {
                 self.compile_expr(index);
@@ -153,7 +157,7 @@ impl Compiler {
                 let tmp_result_idx = self.code.add_constant(Value::str(tmp_result_name.clone()));
                 self.compile_expr(expr);
                 self.code.emit(OpCode::SetGlobal(tmp_value_idx));
-                self.code.emit(OpCode::PostDecrement(tmp_value_idx));
+                self.code.emit(OpCode::PostDecrement(tmp_value_idx, None));
                 self.code.emit(OpCode::SetGlobal(tmp_result_idx));
                 let assign_expr = Expr::Call {
                     name: Symbol::intern("__mutsu_assign_method_lvalue"),
@@ -208,9 +212,9 @@ impl Compiler {
             //    - pushes old value on stack
             //    - sets tmp_val = old +/- 1
             if increment {
-                self.code.emit(OpCode::PostIncrement(tmp_val_idx));
+                self.code.emit(OpCode::PostIncrement(tmp_val_idx, None));
             } else {
-                self.code.emit(OpCode::PostDecrement(tmp_val_idx));
+                self.code.emit(OpCode::PostDecrement(tmp_val_idx, None));
             }
             // Stack now has old value; tmp_val has new value
             self.code.emit(OpCode::SetGlobal(tmp_old_idx));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -780,8 +780,14 @@ pub(crate) enum OpCode {
     GetCodeVar(u32),
 
     // -- Postfix operators --
-    PostIncrement(u32),
-    PostDecrement(u32),
+    // The optional second field is the compile-time-resolved local slot for the
+    // named scalar (§1.5: bakes the scope-correct slot so the RMW writeback
+    // mirrors the exact slot instead of a by-name `code.locals` search, which is
+    // ambiguous once a name occupies several slots — docs/lexical-scope-slot-
+    // campaign.md). `None` for a non-local (global / `our` / dynamic / a temp
+    // value target), where the writeback stays env-by-name.
+    PostIncrement(u32, Option<u32>),
+    PostDecrement(u32, Option<u32>),
     PostIncrementIndex(u32),
     PostDecrementIndex(u32),
     /// Named index assignment: `var[idx] = value` where `var` is a known
@@ -1588,8 +1594,8 @@ impl CompiledCode {
                 OpCode::GetGlobal(idx)
                 | OpCode::SetGlobal(idx)
                 | OpCode::SetGlobalRaw(idx)
-                | OpCode::PostIncrement(idx)
-                | OpCode::PostDecrement(idx)
+                | OpCode::PostIncrement(idx, _)
+                | OpCode::PostDecrement(idx, _)
                 | OpCode::PreIncrement(idx)
                 | OpCode::PreDecrement(idx)
                 | OpCode::GetArrayVar(idx)
@@ -1687,8 +1693,8 @@ impl CompiledCode {
                 OpCode::GetGlobal(idx)
                 | OpCode::SetGlobal(idx)
                 | OpCode::SetGlobalRaw(idx)
-                | OpCode::PostIncrement(idx)
-                | OpCode::PostDecrement(idx)
+                | OpCode::PostIncrement(idx, _)
+                | OpCode::PostDecrement(idx, _)
                 | OpCode::PreIncrement(idx)
                 | OpCode::PreDecrement(idx)
                 | OpCode::GetArrayVar(idx)
@@ -1746,8 +1752,8 @@ impl CompiledCode {
             OpCode::GetGlobal(idx)
             | OpCode::SetGlobal(idx)
             | OpCode::SetGlobalRaw(idx)
-            | OpCode::PostIncrement(idx)
-            | OpCode::PostDecrement(idx)
+            | OpCode::PostIncrement(idx, _)
+            | OpCode::PostDecrement(idx, _)
             | OpCode::PreIncrement(idx)
             | OpCode::PreDecrement(idx)
             | OpCode::GetArrayVar(idx)
@@ -1815,8 +1821,8 @@ impl CompiledCode {
         match op {
             OpCode::SetGlobal(idx)
             | OpCode::SetGlobalRaw(idx)
-            | OpCode::PostIncrement(idx)
-            | OpCode::PostDecrement(idx)
+            | OpCode::PostIncrement(idx, _)
+            | OpCode::PostDecrement(idx, _)
             | OpCode::PreIncrement(idx)
             | OpCode::PreDecrement(idx)
             | OpCode::AssignExpr(idx)
@@ -2305,8 +2311,8 @@ impl CompiledCode {
                     | OpCode::IndexAssignDeepNested { .. }
                     | OpCode::IndexAssignGeneric
                     | OpCode::IndexAssignPseudoStashNamed { .. }
-                    | OpCode::PostIncrement(_)
-                    | OpCode::PostDecrement(_)
+                    | OpCode::PostIncrement(..)
+                    | OpCode::PostDecrement(..)
                     | OpCode::PostIncrementIndex(_)
                     | OpCode::PostDecrementIndex(_)
                     | OpCode::PreIncrement(_)

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -385,10 +385,15 @@ impl Interpreter {
                     crate::opcode::OpCode::SetLocal(slot)
                     | crate::opcode::OpCode::AssignExprLocal(slot)
                     | crate::opcode::OpCode::PreIncrement(slot)
-                    | crate::opcode::OpCode::PreDecrement(slot)
-                    | crate::opcode::OpCode::PostIncrement(slot)
-                    | crate::opcode::OpCode::PostDecrement(slot) => {
+                    | crate::opcode::OpCode::PreDecrement(slot) => {
                         assigned_slots.insert(*slot as usize);
+                    }
+                    // Post inc/dec carry (name_idx, slot); keep the pre-existing
+                    // field-0 behavior for this EVAL-writeback detection (unchanged
+                    // by §1.5 slice S2).
+                    crate::opcode::OpCode::PostIncrement(name_idx, _)
+                    | crate::opcode::OpCode::PostDecrement(name_idx, _) => {
+                        assigned_slots.insert(*name_idx as usize);
                     }
                     _ => {}
                 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2878,12 +2878,12 @@ impl Interpreter {
             }
 
             // -- Postfix operators --
-            OpCode::PostIncrement(name_idx) => {
-                self.exec_post_increment_op(code, *name_idx)?;
+            OpCode::PostIncrement(name_idx, slot) => {
+                self.exec_post_increment_op(code, *name_idx, *slot)?;
                 *ip += 1;
             }
-            OpCode::PostDecrement(name_idx) => {
-                self.exec_post_decrement_op(code, *name_idx)?;
+            OpCode::PostDecrement(name_idx, slot) => {
+                self.exec_post_decrement_op(code, *name_idx, *slot)?;
                 *ip += 1;
             }
             OpCode::PostIncrementIndex(name_idx) => {

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -114,7 +114,9 @@ impl Interpreter {
         // Plain env scalar: compute old OP rhs, store via the shared `++` tail so
         // METHOD captured-outer propagation is identical to `++` by construction.
         let new_val = self.apply_compound_base_op(op, raw_val, rhs)?;
-        let stored = self.store_named_scalar_rmw_result(code, name, new_val)?;
+        // `AtomicCompoundVar` is only emitted for a NON-local target (the compiler
+        // skips it when `local_map` has the name), so there is no baked slot here.
+        let stored = self.store_named_scalar_rmw_result(code, name, None, new_val)?;
         self.stack.push(stored);
         Ok(())
     }
@@ -123,11 +125,12 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         // Phase 3 Stage 2: scalar attribute increments read-modify-write the cell.
         let attr_name = Self::const_str(code, name_idx).to_string();
         self.sync_attr_local_from_cell_by_name(code, &attr_name);
-        let r = self.exec_post_increment_op_inner(code, name_idx);
+        let r = self.exec_post_increment_op_inner(code, name_idx, slot);
         if r.is_ok() {
             self.mirror_attr_local_to_cell_by_name(code, &attr_name);
         }
@@ -177,6 +180,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         // Lazily convert pending alias bind names into local_bind_pairs.
         self.resolve_pending_alias_binds(code);
@@ -254,7 +258,7 @@ impl Interpreter {
         }
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.increment_value_smart(&val)?;
-        self.store_named_scalar_rmw_result(code, name, new_val)?;
+        self.store_named_scalar_rmw_result(code, name, slot, new_val)?;
         self.stack.push(val);
         Ok(())
     }
@@ -263,11 +267,12 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         // Phase 3 Stage 2: scalar attribute decrements read-modify-write the cell.
         let attr_name = Self::const_str(code, name_idx).to_string();
         self.sync_attr_local_from_cell_by_name(code, &attr_name);
-        let r = self.exec_post_decrement_op_inner(code, name_idx);
+        let r = self.exec_post_decrement_op_inner(code, name_idx, slot);
         if r.is_ok() {
             self.mirror_attr_local_to_cell_by_name(code, &attr_name);
         }
@@ -278,6 +283,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
         if let Some(r) = self.try_slotless_attr_incdec(code, name, false, false) {
@@ -332,7 +338,7 @@ impl Interpreter {
         }
         let val = self.normalize_incdec_source_with_type(name, raw_val);
         let new_val = self.decrement_value_smart(&val)?;
-        self.store_named_scalar_rmw_result(code, name, new_val)?;
+        self.store_named_scalar_rmw_result(code, name, slot, new_val)?;
         self.stack.push(val);
         Ok(())
     }

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -735,6 +735,11 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name: &str,
+        // §1.5: compile-time-resolved local slot for `name`, when it is a
+        // current-scope local. Drives the slot mirror + `local_bind_pairs` source
+        // resolution below instead of a by-name `code.locals` search (ambiguous
+        // once a name occupies several slots). `None` = non-local / no baked slot.
+        slot: Option<u32>,
         new_val: Value,
     ) -> Result<Value, RuntimeError> {
         let new_val = self.maybe_wrap_native_int(name, new_val);
@@ -757,7 +762,15 @@ impl Interpreter {
                 .insert("__mutsu_rw_map_topic__".to_string(), new_val.clone());
         }
         self.sync_anon_state_value(name, &new_val);
-        self.update_local_if_exists(code, name, &new_val);
+        // §1.5: mirror into the compile-time-baked slot when present (scope-correct
+        // even once a name occupies several slots); fall back to the by-name
+        // resolution for a non-local / no-baked-slot target.
+        match slot {
+            Some(s) if (s as usize) < self.locals.len() => {
+                self.locals[s as usize] = new_val.clone();
+            }
+            _ => self.update_local_if_exists(code, name, &new_val),
+        }
         // Slice F: an inc/dec (`$*foo++`) of a caller-declared dynamic variable
         // writes only `env` by name; record it so the call-site drain writes it
         // through to the caller frame's slot (mirrors the SetGlobal path).
@@ -766,7 +779,13 @@ impl Interpreter {
         }
         // Propagate via local_bind_pairs (for `:=` bindings within this scope
         // or cross-scope bindings resolved by resolve_pending_alias_binds).
-        if let Some(source_idx) = code.locals.iter().position(|n| n == name) {
+        // §1.5: prefer the baked slot as the bind-pair source; fall back to the
+        // by-name lookup for a non-local target.
+        let source_idx = match slot {
+            Some(s) => Some(s as usize),
+            None => code.locals.iter().position(|n| n == name),
+        };
+        if let Some(source_idx) = source_idx {
             let mut env_updates = Vec::new();
             for &(src, tgt) in &self.local_bind_pairs {
                 if src == source_idx {

--- a/t/rmw-slot-writeback.t
+++ b/t/rmw-slot-writeback.t
@@ -1,0 +1,59 @@
+use Test;
+
+# §1.5 slice S2: `$x++` / `$x--` write back through the compile-time-baked local
+# slot (store_named_scalar_rmw_result), not a by-name `code.locals` search.
+
+plan 8;
+
+# basic postfix inc/dec on a local
+{
+    my $x = 5;
+    $x++;
+    $x++;
+    $x--;
+    is $x, 6, 'postfix ++/-- on a local';
+}
+
+# a shadowing inner-block increment writes the inner binding; the outer is intact
+{
+    my $x = 10;
+    {
+        my $x = 100;
+        $x++;
+        is $x, 101, 'inc of an inner shadow writes the inner slot';
+    }
+    is $x, 10, 'the outer binding is untouched by the shadow inc';
+}
+
+# a `:=` alias sees the increment through the shared binding
+{
+    my $a = 1;
+    my $b := $a;
+    $a++;
+    is $a, 2, ':= source after inc';
+    is $b, 2, ':= alias reflects the inc';
+}
+
+# `our` package var increment persists across sub calls
+{
+    our $g = 0;
+    sub bump-g { $g++ }
+    bump-g();
+    bump-g();
+    is $g, 2, 'our-var inc via bare name persists';
+}
+
+# read after write in the same frame reads the mirrored slot, not a stale value
+{
+    my $n = 0;
+    $n++;
+    my $seen = $n;
+    is $seen, 1, 'same-frame read after inc sees the new value';
+}
+
+# hot loop
+{
+    my $c = 0;
+    $c++ for ^1000;
+    is $c, 1000, 'inc in a hot loop';
+}


### PR DESCRIPTION
Second slice of the ANALYSIS §1.4/§1.5/§1.3 lexical-scope-slot campaign (`docs/lexical-scope-slot-campaign.md`). Follows #4071 (S1: SmartMatchExpr `lhs_slot`).

## This slice (S2)
`PostIncrement` / `PostDecrement` gain a compile-time-resolved `Option<u32>` slot (from `local_map` at emit time). It is threaded through the inc/dec op handlers into `store_named_scalar_rmw_result`, the read-modify-write chokepoint, which now:
- **mirrors** the new value into the baked slot (`self.locals[slot]`) instead of `update_local_if_exists` (a `find_local_slot` by-name `code.locals` search), and
- uses the baked slot as the `local_bind_pairs` (`:=`) **source** instead of `code.locals.iter().position(...)`.

Both by-name resolutions become ambiguous once a shadowing inner `my $x` gets its own slot; the baked slot is scope-correct. The env-by-name RMW **read** is intentionally left untouched — that is the §1.3 dual store, not a name→slot ambiguity.

`None` covers non-local targets (`our` / dynamic / sigilless env var / temp-value target / `AtomicCompoundVar`, which the compiler only emits for non-locals) → they keep the by-name path.

Behavior-preserving today (one name → one slot). Prefix `++`/`--` and compound-assign-on-a-local are still by-name (slice S2b).

## Verification
- `make test`: green (13952 tests)
- `cargo clippy -- -D warnings`: clean
- New `t/rmw-slot-writeback.t`: postfix inc/dec through shadow / `:=` / `our` / same-frame-read / hot loop
- roast S03-operators/autoincrement*, S04-statements/for.t, S32-scalar/defined.t, S03-binding/scalars.t: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)