### PR TITLE
fix(io): pass APPENDICES io-cathandle.t (X::NYI write methods, X::Obsolete slurp-rest, closed .Str)

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -21,6 +21,7 @@ roast/6.d/S32-str/sprintf-u.t
 roast/6.d/S32-str/sprintf-x.t
 roast/6.d/S32-str/sprintf.t
 roast/APPENDICES/A02-some-day-maybe/concreteness.t
+roast/APPENDICES/A02-some-day-maybe/io-cathandle.t
 roast/MISC/bug-coverage-stress.t
 roast/S01-perl-5-integration/array.t
 roast/S01-perl-5-integration/basic.t

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -1,6 +1,13 @@
 use super::*;
 
 impl Interpreter {
+    /// Whether `v` is an `IO::CatHandle` instance. Used to keep the generic
+    /// 0-arg `.say`/`.print`/`.put`/`.printf` "stringify the invocant" behavior
+    /// from shadowing the cat's own (X::NYI) write methods.
+    fn is_io_cathandle(v: &Value) -> bool {
+        matches!(v, Value::Instance { class_name, .. } if class_name == "IO::CatHandle")
+    }
+
     /// Dispatch methods by name - first group (string, IO, coercion, misc).
     /// Returns Some(result) if the method was handled, None to fall through.
     #[allow(clippy::too_many_lines)]
@@ -67,10 +74,23 @@ impl Interpreter {
             "from-loop" | "from_loop" if matches!(&target, Value::Package(name) if name == "Seq") => {
                 Some(self.dispatch_seq_from_loop(args))
             }
-            "say" if args.is_empty() => Some(self.dispatch_say(&target)),
-            "print" if args.is_empty() => Some(self.dispatch_print(&target)),
-            "put" if args.is_empty() => Some(self.dispatch_put(&target)),
-            "printf" if args.is_empty() => Some(self.dispatch_printf(&target)),
+            // `$obj.say`/`.print`/`.put`/`.printf` (no args) stringify and print the
+            // invocant — EXCEPT on an IO::CatHandle, where these are write methods
+            // that route to the native handler (which raises X::NYI on a read-only
+            // cat). Without this guard the generic form would silently print the
+            // cat's gist instead of throwing.
+            "say" if args.is_empty() && !Self::is_io_cathandle(&target) => {
+                Some(self.dispatch_say(&target))
+            }
+            "print" if args.is_empty() && !Self::is_io_cathandle(&target) => {
+                Some(self.dispatch_print(&target))
+            }
+            "put" if args.is_empty() && !Self::is_io_cathandle(&target) => {
+                Some(self.dispatch_put(&target))
+            }
+            "printf" if args.is_empty() && !Self::is_io_cathandle(&target) => {
+                Some(self.dispatch_printf(&target))
+            }
             "sprintf" if args.is_empty() => Some(self.dispatch_sprintf(&target)),
             "sprintf" => {
                 // Method form `$format.sprintf(*@args)` == `sprintf($format, @args)`

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -756,7 +756,9 @@ impl Interpreter {
                 }
                 match attrs.get("path").cloned() {
                     Some(p) if !matches!(p, Value::Nil) => Value::str(p.to_string_value()),
-                    _ => Value::str("IO::CatHandle".to_string()),
+                    // A closed/exhausted or zero-source cat has no active path;
+                    // rakudo renders it as `<closed IO::CatHandle>`.
+                    _ => Value::str("<closed IO::CatHandle>".to_string()),
                 }
             }
             "lock" | "unlock" => {
@@ -898,6 +900,40 @@ impl Interpreter {
                     class_name.resolve(),
                     parts.join(", ")
                 ))
+            }
+            // Write and low-level byte methods are not implemented on a read-only
+            // cat handle; rakudo raises X::NYI for each.
+            "flush" | "out-buffer" | "print" | "printf" | "print-nl" | "put" | "say" | "write"
+            | "WRITE" | "READ" | "EOF" => {
+                let feature = format!("IO::CatHandle.{}", method);
+                let mut ex_attrs = HashMap::new();
+                ex_attrs.insert("feature".to_string(), Value::str(feature.clone()));
+                let mut err = RuntimeError::new(format!("{} not yet implemented. Sorry.", feature));
+                err.exception = Some(Box::new(Value::make_instance(
+                    Symbol::intern("X::NYI"),
+                    ex_attrs,
+                )));
+                return Err(err);
+            }
+            // `.slurp-rest` is obsolete; use `.slurp` with an IO::CatHandle.
+            "slurp-rest" => {
+                let mut ex_attrs = HashMap::new();
+                ex_attrs.insert("old".to_string(), Value::str("slurp-rest".to_string()));
+                ex_attrs.insert("replacement".to_string(), Value::str("slurp".to_string()));
+                ex_attrs.insert(
+                    "when".to_string(),
+                    Value::str("with IO::CatHandle".to_string()),
+                );
+                let msg = "Unsupported use of slurp-rest with IO::CatHandle; \
+                           in Raku please use: slurp"
+                    .to_string();
+                ex_attrs.insert("message".to_string(), Value::str(msg.clone()));
+                let mut err = RuntimeError::new(msg);
+                err.exception = Some(Box::new(Value::make_instance(
+                    Symbol::intern("X::Obsolete"),
+                    ex_attrs,
+                )));
+                return Err(err);
             }
             _ => {
                 return Err(RuntimeError::new(format!(

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -752,6 +752,21 @@ impl Interpreter {
                     "unlock",
                     "raku",
                     "perl",
+                    // Write/low-level methods are NYI on a read-only cat; the
+                    // native handler raises X::NYI for them (rakudo does too).
+                    "flush",
+                    "out-buffer",
+                    "print",
+                    "printf",
+                    "print-nl",
+                    "put",
+                    "say",
+                    "write",
+                    "WRITE",
+                    "READ",
+                    "EOF",
+                    // Obsolete: `.slurp-rest` -> `.slurp`.
+                    "slurp-rest",
                 ]
                 .iter()
                 .map(|s| s.to_string())


### PR DESCRIPTION
`roast/APPENDICES/A02-some-day-maybe/io-cathandle.t` was 0/13; now 13/13 and whitelisted. (The `S32-io/io-cathandle.t` variant already passes.)

An `IO::CatHandle` is a read-only concatenation of source handles, so its write and low-level byte methods are not implemented. Matching rakudo:

- **Write / low-level methods throw X::NYI** — `flush`, `out-buffer`, `print`, `printf`, `print-nl`, `put`, `say`, `write`, `WRITE`, `READ`, `EOF`. Added to the class's `native_methods` list so they reach the native handler (previously X::Method::NotFound).
- **`.slurp-rest` throws X::Obsolete** with `:old<slurp-rest>`, `:replacement<slurp>`, `:when('with IO::CatHandle')`.
- **`.Str` on a closed/exhausted/zero-source cat** renders `<closed IO::CatHandle>` (was the bare type name).
- **0-arg `.say`/`.print`/`.put`/`.printf`** are intercepted by a generic "stringify-and-print the invocant" path (`$obj.say` == `say $obj`); that path is now guarded to skip `IO::CatHandle` so the cat's own X::NYI write methods win. Verified `42.say`, `"x".print`, `(1,2,3).put` etc. still work.

## Testing
- APPENDICES io-cathandle.t 13/13 (whitelisted); S32-io/io-cathandle.t + all S16-io tests stay green.
- `make test` passes (full local suite + roast whitelist).
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)