### PR TITLE
refactor(vm): bake prefix inc/dec local slot into RMW path (§1.5 slice S3)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -87,7 +87,15 @@ broadcast = touches every slot with the name.
       dual-store concern, not a name→slot ambiguity). `None` for non-local targets
       (`our`/dynamic/temp-value/`AtomicCompoundVar`), which keep the by-name path.
       Prefix `++`/`--` and compound-assign-on-local are still by-name — S2b. *(done)*
-- [ ] S3 — `:=` bind: bake source/target slots at emit time instead of
+- [x] **S3 — prefix `++$x`/`--$x`.** `PreIncrement`/`PreDecrement` gain the same
+      compile-time `Option<u32>` slot; `exec_pre_increment_op`/`exec_pre_decrement_op`
+      mirror the new value into the baked slot instead of `update_local_if_exists`.
+      Same pattern as S2. Behavior-preserving today. *(done)*
+      - Note: prefix `++$a` where `$a` is `:=`-bound does NOT propagate to the alias
+        (`my $b := $a; ++$a` leaves `$b` stale) — a **pre-existing** bug (the prefix
+        path lacks the `local_bind_pairs` propagation that the postfix RMW chokepoint
+        has). Out of scope for the slot-baking; noted for a later fix.
+- [ ] S4 — `:=` bind: bake source/target slots at emit time instead of
       `resolve_pending_alias_binds` name lookup.
 - [ ] S4 — param-slot precompute: use the scope-correct slot.
 - [ ] S5+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites.

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -258,9 +258,9 @@ impl Compiler {
             //    - modifies tmp_val in place
             //    - pushes new value on stack
             if increment {
-                self.code.emit(OpCode::PreIncrement(tmp_val_idx));
+                self.code.emit(OpCode::PreIncrement(tmp_val_idx, None));
             } else {
-                self.code.emit(OpCode::PreDecrement(tmp_val_idx));
+                self.code.emit(OpCode::PreDecrement(tmp_val_idx, None));
             }
             // Stack now has new value; tmp_val also has new value
             // Save new value, we'll push it back at the end

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -39,18 +39,20 @@ impl Compiler {
                     // increments the live variable. Emit the temp save, then the
                     // pre-increment on the underlying variable.
                     self.emit_temp_save(&var);
+                    let slot = self.local_map.get(&var).copied();
                     let name_idx = self.code.add_constant(Value::str(var));
-                    self.code.emit(OpCode::PreIncrement(name_idx));
+                    self.code.emit(OpCode::PreIncrement(name_idx, slot));
                 } else if let Expr::Var(name) = expr {
                     if name.starts_with('!') && name.len() > 1 {
                         self.alloc_local(name);
                     }
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
-                    self.code.emit(OpCode::PreIncrement(name_idx));
+                    let slot = self.local_map.get(name).copied();
+                    self.code.emit(OpCode::PreIncrement(name_idx, slot));
                 } else if let Expr::BareWord(name) = expr {
                     if self.sigilless_locals.contains(name.as_str()) {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
-                        self.code.emit(OpCode::PreIncrement(name_idx));
+                        self.code.emit(OpCode::PreIncrement(name_idx, None));
                     } else {
                         self.compile_expr(&Expr::Call {
                             name: Symbol::intern("__mutsu_incdec_nomatch"),
@@ -60,8 +62,9 @@ impl Compiler {
                 } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
                     self.compile_expr(expr);
                     self.code.emit(OpCode::Pop);
+                    let slot = self.local_map.get(&var_name).copied();
                     let name_idx = self.code.add_constant(Value::str(var_name));
-                    self.code.emit(OpCode::PreIncrement(name_idx));
+                    self.code.emit(OpCode::PreIncrement(name_idx, slot));
                 } else if let Expr::Index { target, index, .. } = expr {
                     if let Some(name) = Self::postfix_index_name(target) {
                         self.compile_expr(index);
@@ -83,18 +86,20 @@ impl Compiler {
                     // `--temp $c`: temporize `$c` then pre-decrement it (see the
                     // `++temp` case above).
                     self.emit_temp_save(&var);
+                    let slot = self.local_map.get(&var).copied();
                     let name_idx = self.code.add_constant(Value::str(var));
-                    self.code.emit(OpCode::PreDecrement(name_idx));
+                    self.code.emit(OpCode::PreDecrement(name_idx, slot));
                 } else if let Expr::Var(name) = expr {
                     if name.starts_with('!') && name.len() > 1 {
                         self.alloc_local(name);
                     }
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
-                    self.code.emit(OpCode::PreDecrement(name_idx));
+                    let slot = self.local_map.get(name).copied();
+                    self.code.emit(OpCode::PreDecrement(name_idx, slot));
                 } else if let Expr::BareWord(name) = expr {
                     if self.sigilless_locals.contains(name.as_str()) {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
-                        self.code.emit(OpCode::PreDecrement(name_idx));
+                        self.code.emit(OpCode::PreDecrement(name_idx, None));
                     } else {
                         self.compile_expr(&Expr::Call {
                             name: Symbol::intern("__mutsu_incdec_nomatch"),
@@ -104,8 +109,9 @@ impl Compiler {
                 } else if let Some(var_name) = Self::extract_vardecl_name(expr) {
                     self.compile_expr(expr);
                     self.code.emit(OpCode::Pop);
+                    let slot = self.local_map.get(&var_name).copied();
                     let name_idx = self.code.add_constant(Value::str(var_name));
-                    self.code.emit(OpCode::PreDecrement(name_idx));
+                    self.code.emit(OpCode::PreDecrement(name_idx, slot));
                 } else if let Expr::Index { target, index, .. } = expr {
                     if let Some(name) = Self::postfix_index_name(target) {
                         self.compile_expr(index);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -770,8 +770,11 @@ pub(crate) enum OpCode {
     UptoRange,
 
     // -- Prefix increment/decrement (returns NEW value) --
-    PreIncrement(u32),
-    PreDecrement(u32),
+    // Optional second field: the compile-time-resolved local slot for the named
+    // scalar (§1.5, mirrors PostIncrement/PostDecrement — docs/lexical-scope-slot-
+    // campaign.md). `None` for a non-local / temp-value target (env-by-name).
+    PreIncrement(u32, Option<u32>),
+    PreDecrement(u32, Option<u32>),
     PreIncrementIndex(u32),
     PreDecrementIndex(u32),
 
@@ -1596,8 +1599,8 @@ impl CompiledCode {
                 | OpCode::SetGlobalRaw(idx)
                 | OpCode::PostIncrement(idx, _)
                 | OpCode::PostDecrement(idx, _)
-                | OpCode::PreIncrement(idx)
-                | OpCode::PreDecrement(idx)
+                | OpCode::PreIncrement(idx, _)
+                | OpCode::PreDecrement(idx, _)
                 | OpCode::GetArrayVar(idx)
                 | OpCode::GetHashVar(idx) => Some(*idx),
                 OpCode::AssignExpr(idx) | OpCode::TopicDotAssign(idx) => Some(*idx),
@@ -1695,8 +1698,8 @@ impl CompiledCode {
                 | OpCode::SetGlobalRaw(idx)
                 | OpCode::PostIncrement(idx, _)
                 | OpCode::PostDecrement(idx, _)
-                | OpCode::PreIncrement(idx)
-                | OpCode::PreDecrement(idx)
+                | OpCode::PreIncrement(idx, _)
+                | OpCode::PreDecrement(idx, _)
                 | OpCode::GetArrayVar(idx)
                 | OpCode::GetHashVar(idx)
                 | OpCode::AssignExpr(idx)
@@ -1754,8 +1757,8 @@ impl CompiledCode {
             | OpCode::SetGlobalRaw(idx)
             | OpCode::PostIncrement(idx, _)
             | OpCode::PostDecrement(idx, _)
-            | OpCode::PreIncrement(idx)
-            | OpCode::PreDecrement(idx)
+            | OpCode::PreIncrement(idx, _)
+            | OpCode::PreDecrement(idx, _)
             | OpCode::GetArrayVar(idx)
             | OpCode::GetHashVar(idx)
             | OpCode::AssignExpr(idx)
@@ -1823,8 +1826,8 @@ impl CompiledCode {
             | OpCode::SetGlobalRaw(idx)
             | OpCode::PostIncrement(idx, _)
             | OpCode::PostDecrement(idx, _)
-            | OpCode::PreIncrement(idx)
-            | OpCode::PreDecrement(idx)
+            | OpCode::PreIncrement(idx, _)
+            | OpCode::PreDecrement(idx, _)
             | OpCode::AssignExpr(idx)
             | OpCode::TopicDotAssign(idx)
             | OpCode::AtomicCompoundVar { name_idx: idx, .. } => Some(*idx),
@@ -2315,8 +2318,8 @@ impl CompiledCode {
                     | OpCode::PostDecrement(..)
                     | OpCode::PostIncrementIndex(_)
                     | OpCode::PostDecrementIndex(_)
-                    | OpCode::PreIncrement(_)
-                    | OpCode::PreDecrement(_)
+                    | OpCode::PreIncrement(..)
+                    | OpCode::PreDecrement(..)
                     | OpCode::PreIncrementIndex(_)
                     | OpCode::PreDecrementIndex(_)
                     | OpCode::MultiDimIndexAssign { .. }

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -383,15 +383,15 @@ impl Interpreter {
             for op in &compiled.ops {
                 match op {
                     crate::opcode::OpCode::SetLocal(slot)
-                    | crate::opcode::OpCode::AssignExprLocal(slot)
-                    | crate::opcode::OpCode::PreIncrement(slot)
-                    | crate::opcode::OpCode::PreDecrement(slot) => {
+                    | crate::opcode::OpCode::AssignExprLocal(slot) => {
                         assigned_slots.insert(*slot as usize);
                     }
-                    // Post inc/dec carry (name_idx, slot); keep the pre-existing
-                    // field-0 behavior for this EVAL-writeback detection (unchanged
-                    // by §1.5 slice S2).
-                    crate::opcode::OpCode::PostIncrement(name_idx, _)
+                    // Inc/dec carry (name_idx, slot); keep the pre-existing field-0
+                    // behavior for this EVAL-writeback detection (unchanged by the
+                    // §1.5 inc/dec slot-baking slices).
+                    crate::opcode::OpCode::PreIncrement(name_idx, _)
+                    | crate::opcode::OpCode::PreDecrement(name_idx, _)
+                    | crate::opcode::OpCode::PostIncrement(name_idx, _)
                     | crate::opcode::OpCode::PostDecrement(name_idx, _) => {
                         assigned_slots.insert(*name_idx as usize);
                     }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2952,12 +2952,12 @@ impl Interpreter {
             }
 
             // -- Prefix increment/decrement --
-            OpCode::PreIncrement(name_idx) => {
-                self.exec_pre_increment_op(code, *name_idx)?;
+            OpCode::PreIncrement(name_idx, slot) => {
+                self.exec_pre_increment_op(code, *name_idx, *slot)?;
                 *ip += 1;
             }
-            OpCode::PreDecrement(name_idx) => {
-                self.exec_pre_decrement_op(code, *name_idx)?;
+            OpCode::PreDecrement(name_idx, slot) => {
+                self.exec_pre_decrement_op(code, *name_idx, *slot)?;
                 *ip += 1;
             }
             OpCode::PreIncrementIndex(name_idx) => {

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -213,11 +213,12 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         // Phase 3 Stage 2: scalar attribute increments read-modify-write the cell.
         let attr_name = Self::const_str(code, name_idx).to_string();
         self.sync_attr_local_from_cell_by_name(code, &attr_name);
-        let r = self.exec_pre_increment_op_inner(code, name_idx);
+        let r = self.exec_pre_increment_op_inner(code, name_idx, slot);
         if r.is_ok() {
             self.mirror_attr_local_to_cell_by_name(code, &attr_name);
         }
@@ -228,6 +229,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
         if let Some(r) = self.try_slotless_attr_incdec(code, name, true, true) {
@@ -307,7 +309,14 @@ impl Interpreter {
         self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
-        self.update_local_if_exists(code, name, &new_val);
+        // §1.5: mirror into the compile-time-baked slot when present (scope-correct
+        // under shadow slots); by-name fallback for a non-local target.
+        match slot {
+            Some(s) if (s as usize) < self.locals.len() => {
+                self.locals[s as usize] = new_val.clone();
+            }
+            _ => self.update_local_if_exists(code, name, &new_val),
+        }
         self.writeback_package_scope_var(name, &new_val);
         self.stack.push(new_val);
         Ok(())
@@ -317,11 +326,12 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         // Phase 3 Stage 2: scalar attribute decrements read-modify-write the cell.
         let attr_name = Self::const_str(code, name_idx).to_string();
         self.sync_attr_local_from_cell_by_name(code, &attr_name);
-        let r = self.exec_pre_decrement_op_inner(code, name_idx);
+        let r = self.exec_pre_decrement_op_inner(code, name_idx, slot);
         if r.is_ok() {
             self.mirror_attr_local_to_cell_by_name(code, &attr_name);
         }
@@ -332,6 +342,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
         if let Some(r) = self.try_slotless_attr_incdec(code, name, false, true) {
@@ -411,7 +422,14 @@ impl Interpreter {
         self.check_incdec_type_constraint(name, &new_val)?;
         self.set_env_with_main_alias(name, new_val.clone());
         self.sync_anon_state_value(name, &new_val);
-        self.update_local_if_exists(code, name, &new_val);
+        // §1.5: mirror into the compile-time-baked slot when present (scope-correct
+        // under shadow slots); by-name fallback for a non-local target.
+        match slot {
+            Some(s) if (s as usize) < self.locals.len() => {
+                self.locals[s as usize] = new_val.clone();
+            }
+            _ => self.update_local_if_exists(code, name, &new_val),
+        }
         self.writeback_package_scope_var(name, &new_val);
         self.stack.push(new_val);
         Ok(())

--- a/t/prefix-incdec-slot-writeback.t
+++ b/t/prefix-incdec-slot-writeback.t
@@ -1,0 +1,48 @@
+use Test;
+
+# §1.5 slice S3: prefix `++$x` / `--$x` write back through the compile-time-baked
+# local slot (exec_pre_increment_op / exec_pre_decrement_op), not a by-name
+# `code.locals` search.
+
+plan 8;
+
+# basic prefix inc/dec on a local (returns the NEW value)
+{
+    my $x = 5;
+    is ++$x, 6, 'prefix ++ returns and stores the new value';
+    is --$x, 5, 'prefix -- returns and stores the new value';
+    is $x, 5, 'the local reflects the writeback';
+}
+
+# a shadowing inner-block prefix inc writes the inner binding; outer is intact
+{
+    my $x = 10;
+    {
+        my $x = 100;
+        is ++$x, 101, 'prefix ++ of an inner shadow writes the inner slot';
+    }
+    is $x, 10, 'the outer binding is untouched by the shadow prefix inc';
+}
+
+# `our` package var prefix inc persists across sub calls
+{
+    our $g = 0;
+    sub bump-g { ++$g }
+    bump-g();
+    bump-g();
+    is $g, 2, 'our-var prefix inc via bare name persists';
+}
+
+# same-frame read after prefix inc sees the mirrored slot value
+{
+    my $n = 0;
+    ++$n;
+    is $n, 1, 'same-frame read after prefix inc sees the new value';
+}
+
+# prefix inc in a hot loop
+{
+    my $c = 0;
+    ++$c for ^1000;
+    is $c, 1000, 'prefix inc in a hot loop';
+}


### PR DESCRIPTION
Third slice of the ANALYSIS §1.4/§1.5/§1.3 lexical-scope-slot campaign (`docs/lexical-scope-slot-campaign.md`). Mirrors #4073 (postfix) for the prefix `++$x` / `--$x` operators.

## This slice (S3)
`PreIncrement` / `PreDecrement` gain a compile-time-resolved `Option<u32>` slot (from `local_map` at emit time). It is threaded through the prefix inc/dec handlers, whose final writeback now mirrors the new value into the baked slot (`self.locals[slot]`) instead of `update_local_if_exists` (a `find_local_slot` by-name `code.locals` search, ambiguous once a shadowing inner `my $x` gets its own slot). `None` covers non-local / temp-value targets → they keep the by-name path. The env-by-name read is left as-is (§1.3).

Behavior-preserving today (one name → one slot).

### Pre-existing bug noted (out of scope)
Prefix `++$a` where `$a` is `:=`-bound does not propagate to the alias (`my $b := $a; ++$a` leaves `$b` stale). This is **pre-existing** (confirmed identical on `main`): the prefix path lacks the `local_bind_pairs` propagation the postfix RMW chokepoint has. Not a regression; left for a later fix.

## Verification
- `make test`: green (13967 tests)
- `cargo clippy -- -D warnings`: clean
- New `t/prefix-incdec-slot-writeback.t`: prefix inc/dec through shadow / `our` / same-frame-read / hot loop
- roast S03-operators/{autoincrement,increment}.t, S04-statements/for.t, S32-scalar/defined.t: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)