### PR TITLE
refactor(compiler): bake param→slot map at emit time (§1.5 slice S4)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -89,7 +89,15 @@ broadcast = touches every slot with the name.
       Prefix `++`/`--` and compound-assign-on-local are still by-name — S2b. *(done)*
 - [ ] S3 — `:=` bind: bake source/target slots at emit time instead of
       `resolve_pending_alias_binds` name lookup.
-- [ ] S4 — param-slot precompute: use the scope-correct slot.
+- [x] **S4 — param-slot precompute.** The compiler bakes the positional-param →
+      local-slot map into `CompiledCode::param_local_slots` at emit time (from
+      `local_map`, right after the param `alloc_local` loops, before the body can
+      shadow a param — so it stays the parameter binding slot once §1.4 gives a
+      body `my $x` its own slot). `CompiledFunction::precompute_param_local_slots`
+      uses the baked list instead of searching `code.locals` by name, falling back
+      to the by-name search only for hand-built chunks that never recorded it.
+      Verified byte-identical to the old `position` search across the whole
+      `make test` suite via a temporary `debug_assert_eq!` (never fired). *(done)*
 - [ ] S5+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites.
 - [ ] §1.4 flip + `pop_local_scope` restore.
 - [ ] §1.3 slot-indexed locals + drop BlockScope clone.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -172,6 +172,9 @@ impl Compiler {
                 Self::alloc_sub_signature_locals(&mut sub_compiler, outer_params);
             }
         }
+        // Bake the positional-param → slot map now, while `local_map` still holds
+        // exactly the parameter slots (before the body can shadow them). §1.5.
+        sub_compiler.record_param_local_slots(params, param_defs);
         // Hoist sub declarations within the sub body
         sub_compiler.hoist_sub_decls(body, true);
         // Emit SetSourceLine at the start of the function body so that
@@ -605,6 +608,9 @@ impl Compiler {
                 }
             }
         }
+        // Bake the positional-param → slot map now, while `local_map` still holds
+        // exactly the parameter slots (before the body can shadow them). §1.5.
+        sub_compiler.record_param_local_slots(params, param_defs);
         // Hoist sub declarations within the closure body
         sub_compiler.hoist_sub_decls(body, true);
         // If body contains CATCH/CONTROL, wrap in implicit try. compile_try

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -379,6 +379,39 @@ impl Compiler {
         slot
     }
 
+    /// Record the compiler-authoritative positional-parameter → local-slot map
+    /// into `code.param_local_slots`, so the VM's `precompute_param_local_slots`
+    /// need not re-resolve parameter names by searching `locals` (§1.5).
+    ///
+    /// Must be called immediately after the parameter `alloc_local` loops and
+    /// BEFORE the body is compiled: at that point `local_map[name]` is exactly the
+    /// parameter's slot. (Once §1.4 gives a shadowing body `my $x` its own slot,
+    /// `local_map` for that name would move; recording here captures the parameter
+    /// binding slot unambiguously.) The order and filtering mirror
+    /// `CompiledFunction::precompute_param_local_slots`: positional `param_defs`
+    /// (skipping `named`), or `params` when `param_defs` is empty; a name with no
+    /// allocated slot (e.g. an anonymous `$`) is skipped.
+    fn record_param_local_slots(&mut self, params: &[String], param_defs: &[crate::ast::ParamDef]) {
+        let mut slots: Vec<u32> = Vec::new();
+        if !param_defs.is_empty() {
+            for pd in param_defs {
+                if pd.named {
+                    continue;
+                }
+                if let Some(&slot) = self.local_map.get(&pd.name) {
+                    slots.push(slot);
+                }
+            }
+        } else {
+            for param in params {
+                if let Some(&slot) = self.local_map.get(param) {
+                    slots.push(slot);
+                }
+            }
+        }
+        self.code.param_local_slots = slots;
+    }
+
     /// Designated entry point for a genuine `my`/`state`/`our` DECLARATION.
     ///
     /// **Groundwork, currently behavior-preserving.** It resolves the slot exactly

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1370,6 +1370,15 @@ pub(crate) struct CompiledCode {
     /// Maps local slot indices to qualified package names for `our` variables.
     /// Used by BlockScope restoration to sync local slots from their global values.
     pub(crate) our_locals: Vec<(usize, String)>,
+    /// Compiler-authoritative positional-parameter → local-slot mapping, in the
+    /// order `precompute_param_local_slots` expects (positional `param_defs`, or
+    /// `params` when `param_defs` is empty). Baked at emit time from the
+    /// compiler's `local_map` so `CompiledFunction::precompute_param_local_slots`
+    /// does not have to re-resolve parameter names by searching `locals` (§1.5:
+    /// remove name→slot runtime resolution). Empty when the compiler did not
+    /// record it (e.g. hand-built `CompiledCode::new()` chunks), in which case
+    /// precompute falls back to the by-name search.
+    pub(crate) param_local_slots: Vec<u32>,
     /// Pre-compiled closure bodies embedded in this code chunk.
     pub(crate) closure_compiled_codes: Vec<Arc<CompiledCode>>,
     /// Parallel to `closure_compiled_codes`: `closure_escapes[i]` is true if the
@@ -1557,6 +1566,7 @@ impl CompiledCode {
             simple_locals: Vec::new(),
             state_locals: Vec::new(),
             our_locals: Vec::new(),
+            param_local_slots: Vec::new(),
             closure_compiled_codes: Vec::new(),
             closure_escapes: Vec::new(),
             is_routine: false,
@@ -2658,7 +2668,22 @@ pub(crate) struct CompiledFunction {
 
 impl CompiledFunction {
     /// Pre-compute the mapping from positional parameter index to locals slot index.
+    ///
+    /// Prefers the compiler-baked `code.param_local_slots` (authoritative slots
+    /// recorded from `local_map` at emit time — §1.5, no name search). Falls back
+    /// to the legacy by-name `locals.position` search only for hand-built code
+    /// chunks that never recorded it.
     pub(crate) fn precompute_param_local_slots(&mut self) {
+        if !self.code.param_local_slots.is_empty() {
+            self.param_local_slots = Some(
+                self.code
+                    .param_local_slots
+                    .iter()
+                    .map(|&s| s as usize)
+                    .collect(),
+            );
+            return;
+        }
         let mut slots = Vec::new();
         if !self.param_defs.is_empty() {
             for pd in &self.param_defs {


### PR DESCRIPTION
Part of the §1.4/§1.5/§1.3 lexical-scope campaign (`docs/lexical-scope-slot-campaign.md`), slice **S4 — param-slot precompute**. (roast:1 is doing S3 `:=` bind concurrently.)

## Problem
`CompiledFunction::precompute_param_local_slots` resolved each positional parameter to its local slot by **searching `code.locals` by name** (`position`). That name→slot resolution is exactly what §1.5 removes so that §1.4 (distinct shadow slots) can land safely.

## Change
The compiler now records the positional-param → local-slot mapping into a new `CompiledCode::param_local_slots` field, built from `local_map` **right after the parameter `alloc_local` loops and before the body is compiled**. Recording there captures the parameter *binding* slot unambiguously: once §1.4 gives a shadowing body `my $x` its own slot, `local_map[$x]` would move, but the parameter's slot is already baked.

`precompute_param_local_slots` uses the baked list, falling back to the by-name `position` search only for hand-built code chunks that never recorded it. Both compile paths record it:
- `compile_sub_body`
- `compile_closure_body_with_routine_flag` (which feeds the OTF compile cache in `vm_call_dispatch`)

## Correctness
Behavior-preserving — for a parameter, `position` (first occurrence) already equals the compiler's alloc slot because parameters are allocated first. Verified **byte-identical** to the old search across the entire `make test` suite via a temporary `debug_assert_eq!` comparing baked vs by-name (it never fired), then removed.

## Testing
- `make test` passes (full local suite + roast whitelist).
- Spot-checked recursion, closures, many-param subs, param shadowing against `raku` (match).
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)