### PR TITLE
refactor(vm): bake DoesVar mixin-writeback local slot (§1.5 slice S8)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -122,7 +122,15 @@ broadcast = touches every slot with the name.
       baked slot instead of `find_local_slot` / `locals_set_by_name` by name. These
       two helpers are the reusable slot-preferring primitives for the remaining leaf
       sites. Behavior-preserving today. *(done)*
-- [ ] S8+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+- [x] **S8 — `$x does R` in-place mixin writeback.** The `DoesVar` opcode gains a
+      compile-time `Option<u32>` slot (baked from `local_map` at emit time, for the
+      `$x`/`@a`/`%h` target); `exec_does_var_op` mirrors the mixed-in value into the
+      baked slot via the S7 `write_local_slot_or_name` helper instead of
+      `update_local_if_exists` by name. Behavior-preserving today; verified
+      byte-identical across the whole `make test` suite via a temporary
+      `debug_assert_eq!` (never fired). (The pre-existing `@a does R` / `%h does R`
+      `.name`-doesn't-resolve gap is unrelated — identical on `main`.) *(done)*
+- [ ] S9+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
       for-loop *container* source writeback (`write_back_container_source`,
       `write_back_for_topic_item`, resolved by the runtime-derived
       `container_ref_var` name — a §1.3 concern); the `single_array_source`

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -570,8 +570,9 @@ impl Compiler {
                     self.code.emit(OpCode::SetDoesContext(true));
                     self.compile_expr(right);
                     self.code.emit(OpCode::SetDoesContext(false));
+                    let slot = self.local_map.get(&name).copied();
                     let name_idx = self.code.add_constant(Value::str(name));
-                    self.code.emit(OpCode::DoesVar(name_idx));
+                    self.code.emit(OpCode::DoesVar(name_idx, slot));
                     return;
                 }
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -380,7 +380,10 @@ pub(crate) enum OpCode {
     // -- Type check --
     Isa,
     Does,
-    DoesVar(u32),
+    /// `$x does R` in-place mixin. `.0` = constant index of the target variable
+    /// name; `.1` = compiler-baked local slot for that name (§1.5), `None` when the
+    /// target is not a resolvable local (falls back to the by-name writeback).
+    DoesVar(u32, Option<u32>),
     /// Set/clear the in_does_rhs flag so role calls return Pairs instead of
     /// throwing X::Coerce::Impossible during `does` RHS evaluation.
     SetDoesContext(bool),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1715,8 +1715,8 @@ impl Interpreter {
                 self.exec_does_op(code)?;
                 *ip += 1;
             }
-            OpCode::DoesVar(name_idx) => {
-                self.exec_does_var_op(code, *name_idx)?;
+            OpCode::DoesVar(name_idx, slot) => {
+                self.exec_does_var_op(code, *name_idx, *slot)?;
                 *ip += 1;
             }
             OpCode::SetDoesContext(flag) => {

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -325,6 +325,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
@@ -340,7 +341,8 @@ impl Interpreter {
         self.carrier_writeback_changed_aggregates(code, &pre_env);
         let name = Self::const_str(code, name_idx).to_string();
         self.env_mut().insert(name.clone(), updated.clone());
-        self.update_local_if_exists(code, &name, &updated);
+        // §1.5: mirror into the compiler-baked local slot when known, else by name.
+        self.write_local_slot_or_name(code, slot, &name, updated.clone());
         // Capture Mixin value for trait_mod writeback: when `$r does Role`
         // runs inside a trait_mod:<is>, the Mixin needs to propagate back
         // to the outer scope's `&name` variable.


### PR DESCRIPTION
Part of the §1.4/§1.5/§1.3 lexical-scope campaign (`docs/lexical-scope-slot-campaign.md`), slice **S8 — `$x does R` in-place mixin writeback**. (S6/S7 by roast:1 already landed; this reuses S7's `write_local_slot_or_name` helper.)

## Problem
`$x does R` (or `@a does R` / `%h does R`) mixes a role into the variable in place and writes the mixed-in value back to the target. `exec_does_var_op` resolved that target via `update_local_if_exists` → `code.locals.position(name)`, the name→slot runtime resolution §1.5 removes.

## Change
The `DoesVar` opcode now carries a compile-time `Option<u32>` slot, baked from `local_map` at emit time for the target variable (`$x`/`@a`/`%h`). `exec_does_var_op` mirrors the value into the baked slot via the S7 `write_local_slot_or_name` helper, falling back to the by-name search only for a `None` slot (a non-local target).

## Correctness
`update_local_if_exists(name)` is exactly `locals[position(name)] = val`, so the baked path is equivalent iff the baked slot equals `position(name)` — which holds because `alloc_local` records `local_map[name]` = the slot pushed to `code.locals`. Verified **byte-identical** across the entire `make test` suite via a temporary `debug_assert_eq!` (never fired), then removed.

Note: `@a does R` / `%h does R` where `.name` (a role method/attr) does not resolve is a **pre-existing** gap — confirmed identical on `main` (via `git stash`) both before and after this change. Out of scope here.

## Testing
- `make test` passes (full local suite + roast whitelist).
- Scalar `$x does R` / `$s does R` (Int and Str invocants) spot-checked against `raku` (match).
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)