### PR TITLE
refactor(vm): bake `$x does Role` mixin writeback slot (§1.5 slice S8)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -122,7 +122,11 @@ broadcast = touches every slot with the name.
       baked slot instead of `find_local_slot` / `locals_set_by_name` by name. These
       two helpers are the reusable slot-preferring primitives for the remaining leaf
       sites. Behavior-preserving today. *(done)*
-- [ ] S8+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+- [x] **S8 — `$x does Role` mixin writeback.** `DoesVar` gains a compile-time
+      `Option<u32>` slot; `exec_does_var_op` writes the mixed-in value back through
+      `write_local_slot_or_name` with the baked slot instead of `update_local_if_exists`
+      (by-name search). The sole mixin name→slot site. Behavior-preserving today. *(done)*
+- [ ] S9+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
       for-loop *container* source writeback (`write_back_container_source`,
       `write_back_for_topic_item`, resolved by the runtime-derived
       `container_ref_var` name — a §1.3 concern); the `single_array_source`

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -570,8 +570,9 @@ impl Compiler {
                     self.code.emit(OpCode::SetDoesContext(true));
                     self.compile_expr(right);
                     self.code.emit(OpCode::SetDoesContext(false));
+                    let slot = self.local_map.get(&name).copied();
                     let name_idx = self.code.add_constant(Value::str(name));
-                    self.code.emit(OpCode::DoesVar(name_idx));
+                    self.code.emit(OpCode::DoesVar(name_idx, slot));
                     return;
                 }
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -380,7 +380,12 @@ pub(crate) enum OpCode {
     // -- Type check --
     Isa,
     Does,
-    DoesVar(u32),
+    /// `$x does Role` on a named variable. First field is the variable's name
+    /// (const-pool index); the optional second is its compile-time-resolved local
+    /// slot (§1.5: the mixed-in value is written back through this exact slot
+    /// instead of a by-name `code.locals` search — docs/lexical-scope-slot-
+    /// campaign.md). `None` for a non-local / EVAL-carrier target.
+    DoesVar(u32, Option<u32>),
     /// Set/clear the in_does_rhs flag so role calls return Pairs instead of
     /// throwing X::Coerce::Impossible during `does` RHS evaluation.
     SetDoesContext(bool),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1715,8 +1715,8 @@ impl Interpreter {
                 self.exec_does_op(code)?;
                 *ip += 1;
             }
-            OpCode::DoesVar(name_idx) => {
-                self.exec_does_var_op(code, *name_idx)?;
+            OpCode::DoesVar(name_idx, slot) => {
+                self.exec_does_var_op(code, *name_idx, *slot)?;
                 *ip += 1;
             }
             OpCode::SetDoesContext(flag) => {

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -325,6 +325,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         name_idx: u32,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
@@ -340,7 +341,9 @@ impl Interpreter {
         self.carrier_writeback_changed_aggregates(code, &pre_env);
         let name = Self::const_str(code, name_idx).to_string();
         self.env_mut().insert(name.clone(), updated.clone());
-        self.update_local_if_exists(code, &name, &updated);
+        // §1.5: mirror through the compile-time-baked slot (scope-correct under
+        // shadow slots); by-name fallback for a non-local target.
+        self.write_local_slot_or_name(code, slot, &name, updated.clone());
         // Capture Mixin value for trait_mod writeback: when `$r does Role`
         // runs inside a trait_mod:<is>, the Mixin needs to propagate back
         // to the outer scope's `&name` variable.

--- a/t/does-var-slot-writeback.t
+++ b/t/does-var-slot-writeback.t
@@ -1,0 +1,38 @@
+use Test;
+
+# §1.5 slice S8: `$x does Role` on a named variable writes the mixed-in value
+# back through the compile-time-baked local slot (DoesVar), not a by-name
+# `code.locals` search.
+
+plan 6;
+
+role Greet { method greet { 'hi' } }
+
+# basic `does` on a local variable
+{
+    my $x = 42;
+    $x does Greet;
+    is $x.greet, 'hi', 'the mixed-in role method is callable';
+    is $x, 42, 'the underlying value is preserved';
+}
+
+# a shadowing inner-block `does` mixes into the inner binding; outer is intact
+{
+    my $x = 1;
+    {
+        my $x = 2;
+        $x does Greet;
+        is $x.greet, 'hi', 'inner shadow gets the role';
+        is $x, 2, 'inner value preserved';
+    }
+    ok !($x ~~ Greet), 'the outer binding did not get the role';
+}
+
+# a `submethod TWEAK` run by the mixin can mutate a captured-outer lexical
+{
+    my $n = 0;
+    role Counter { submethod TWEAK { $n++ } }
+    my $x = 1;
+    $x does Counter;
+    is $n, 1, 'captured-outer lexical mutated by the mixin TWEAK';
+}


### PR DESCRIPTION
Eighth slice of the ANALYSIS §1.4/§1.5/§1.3 lexical-scope-slot campaign (`docs/lexical-scope-slot-campaign.md`), reusing the `resolve_local_slot`/`write_local_slot_or_name` helpers from the delete-op slice.

## This slice (S8)
`DoesVar` (`$x does Role` on a named variable) gains a compile-time-resolved `Option<u32>` slot (from `local_map` at emit time). `exec_does_var_op` now writes the mixed-in value back through `write_local_slot_or_name` with the baked slot instead of `update_local_if_exists` (a `find_local_slot` by-name `code.locals` search, ambiguous once a shadowing inner `my $x` gets its own slot). This is the **sole** mixin name→slot site.

`None` covers a non-local / EVAL-carrier target → keeps the by-name path. Behavior-preserving today (one name → one slot).

## Verification
- `make test`: green (13982 tests)
- `cargo clippy -- -D warnings`: clean
- New `t/does-var-slot-writeback.t`: does-on-a-local through shadow + a captured-outer TWEAK mutation
- whitelisted roast S14-roles/{mixin-6e,parameterized-mixin}.t: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)