### PR TITLE
fix(lazy): nested lazy-sublist slice assignment/binding + 5 related lazy-array bugs

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -5,8 +5,8 @@
 個々の失敗を片端から潰すためではなく、
 **今どこを直せば何がまとめて動くか**を判断するために使う。
 
-**最終更新 2026-07-01**（2026-06-29〜07-01 の大量の完了項目を `news/2026-06.md` /
-`news/2026-07.md` に移し、残件のみを再集計した版）
+**最終更新 2026-07-02**（§4 真の lazy 配列 / 無限列キャンペーンの
+`S09-subscript/slice.t` 根本原因 6 件を解消・再集計）
 
 ## この文書の読み方
 
@@ -220,20 +220,51 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 ## 4. 真の lazy 配列 / 無限列
 
 `eqv` の both-lazy ガードと `+a`/`+@a` の Seq single-pass consumption は完了済み
-（詳細は `news/2026-06.md`）。残るのは 1 ファイルのみ。
+（詳細は `news/2026-06.md`）。lazy 配列そのものの基盤（L1-L2b、`docs/lazy-arrays.md`
+参照）も完了済み。残るのは 1 ファイルのみ、かつ根本原因の大半は解決済み。
 
 ### 4.1 `S09-subscript/slice.t`
 
-- **現状**: 32/56（24 失敗）。以前は途中で中断していたが、周辺の一般修正で最後まで
-  実行が通るようになった。
-- **論点**: sequence-literal-in-index、slice adverbs、lazy semantics が絡む。
-  `docs/lazy-arrays.md` の L2b-L4 と同じ話 — Array が lazy を保ったまま
-  mutation / slice / slurpy に耐えられない。
-- **変更レイヤ**: `LazyList` 表現、`@`-assign preserve、mutation 時 reify、slice/index
-- **Primary files**: `src/runtime/resolution_lazy.rs`, `src/runtime/methods_call_dispatch.rs`,
-  `src/runtime/methods_type_coerce.rs`
-- **Next slice**: 24 件の失敗を種類ごとに分類し、`docs/lazy-arrays.md` に沿って
-  reify/mutation を進める。
+- **現状（2026-07-02 更新）**: 50/56（実行は 56/56 まで完走するようになった。以前は
+  test 39/56 でネスト lazy サブリスト代入の未実装により panic して中断していた）。
+- **今回解決した根本原因**（詳細は `TODO_roast/S09.md` の該当エントリ）:
+  1. `:=` bind が `sequence_spec`/`closure_seq`/`lazy_pipe` 系 `LazyList` を
+     `coroutine` 以外は強制マテリアライズしていた（`vm_var_assign_set_local.rs`）。
+  2. `LazyList::is_genuinely_lazy()` が「有限リストに `.lazy` を掛けた」ケース
+     （cache のみで coroutine/body なし）を見逃し `.is-lazy` が `False` になっていた
+     （`value_lazy.rs`）。
+  3. `lazy`/`eager`/`hyper` 文prefix のパーサが後続のカンマリスト全体でなく先頭の
+     1 項だけを対象にしていた深いバグ（`lazy 3,4,5` が `(3.lazy, 4, 5)` に、
+     `lazy 1...*` が `(1.lazy)...*` にパースされていた）。`return` の
+     `parse_comma_or_expr` と同様に全体を消費するよう修正
+     （`parser/expr/postfix/loop_.rs`）。
+  4. read 側でネストした `LazyList` サブインデックス（`@a[1,(lazy 3,4,5)]`）が
+     再帰されていなかった（`vm_var_index_ops.rs`）。
+  5. フラットなスライス代入（`@a[1,3] = ...`）を式コンテキスト（`say (...)` 等）で
+     使うと env にしか書き戻らず locals とズレる dual-store bug
+     （`vm_var_assign_index_named.rs`、early return が共有の locals-resync tail を
+     skip していた）。
+  6. ネスト lazy サブリストへの代入・bind（`@a[1,(lazy 3,4,5)] = "a"...*` や
+     トップレベル `@a[lazy 1,2,(4,5)] = ...`）が未実装で panic していた——新設の
+     `SliceKeyTree`（write pass `assign_slice_key_tree` ＋ 代入完了後に再読込して
+     nested な返り値を組み立てる `read_slice_key_tree`。重複インデックスは
+     「書き込み時点の値」でなく「最終状態」を返すため別パスが必要）で解消。
+- **残り 6 件（laziness とは無関係、それぞれ別機能）**:
+  - test 15: `@slice := @array[1,2]; @slice = <A B C D>` で bound slice の
+    固定 arity（余った RHS を捨てる）が未実装。
+  - test 31: Buf スライス代入 (`$b[0,1] = 2,3`) 未実装。
+  - test 35（62 assertion、18/62 で中断）: ネストインデックスへの slice adverb
+    （`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ）— §3 の
+    container-identity 領域に属する別の大きな機能。
+  - test 54-55: 重複インデックスを含むネスト lazy リストへの **bind**
+    （`@a[lazy 1,2,(4,5),4,5] := ...`）が `=` 代入と異なる挙動（境界での
+    打ち切りなし・返り値が書き込み時点の値）。狭いエッジケースで今回は深追いせず。
+  - test 56: `@a[**]`（HyperWhatever hammer index）。ローカルの `raku` 自体が
+    "not yet implemented. Sorry." を返すため、この環境では参照実装との
+    突き合わせ自体ができない。
+- **Next slice**: 残り 6 件は互いに独立した別機能。着手するなら test 35
+  （nested slice adverbs）が最も汎用性が高いが、§3 のコンテナ identity
+  キャンペーンと同根の大仕事。whitelist にはこの 6 件全ての解決が必要。
 
 ---
 
@@ -339,8 +370,9 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowl
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
 2. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
    残りの失敗を分類して潰す。
-3. **`S09-subscript/slice.t`**（§4）— 24 件を種類ごとに分類し、lazy array 基盤工事の
-   一環として進める。
+3. **`S09-subscript/slice.t`**（§4）— lazy array 起因の失敗は解消済み（2026-07-02）。
+   残り 6 件は test 35（nested slice adverbs、§3 と同根の大仕事）以外は独立した
+   小粒な機能ギャップ。
 4. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
 
 `S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が

--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -19,15 +19,51 @@
 - [ ] roast/S09-multidim/XX-POS-on-undimensioned.t
 - [ ] roast/S09-subscript/multidim-assignment.t
 - [ ] roast/S09-subscript/slice.t
-  - Raku itself fails at test 22 (eval-lives-ok with `*..* ` despite `#?rakudo skip`) and halts
-  - mutsu passes 29/39 tests; remaining blockers:
-    - Sequence literal parsing in index context (`0,2...*` parsed as `[0, (2...*)]` instead of Seq)
-    - Slice adverbs (`:p`, `:k`, `:v`, `:kv`, `:exists`, `:delete`) with nested indices
-    - `lazy` prefix not producing proper lazy semantics for index truncation
-    - Slice assignment/binding with nested indices
-    - Buf slice assignment
-    - `gather`/`take` with lazy iterable caching
-    - `**` (hyperwhatever hammer) indexing
+  - Local `raku` itself fails at test 22 (`*..*` eval-lives-ok) and halts with a
+    bad plan, so it cannot validate this file end-to-end — treat per-assertion
+    checks against a fresh `raku -e` snippet, not a full-file run.
+  - **2026-07-02: all 56 planned tests now RUN to completion** (was aborting at
+    test 39/56 with an uncaught "Index out of bounds" panic from nested lazy
+    sublist assignment). Root-caused and fixed as part of the true-lazy-array
+    campaign (BLOCKERS.md §4):
+    - `:=` binding a `sequence_spec`/`closure_seq`/`lazy_pipe` `LazyList` (e.g.
+      `(0...*).cache`) was forced to a capped 100k Array instead of staying
+      lazy — only `coroutine` lists were preserved (`vm_var_assign_set_local.rs`).
+    - `LazyList::is_genuinely_lazy()` missed a `.lazy`-on-a-finite-list literal
+      (`lazy 3,4,5` — cache-only, no coroutine/body) — `.is-lazy` reported
+      `False` (`value_lazy.rs`).
+    - The `lazy`/`eager`/`hyper` statement-prefix parser only wrapped the FIRST
+      comma-list term (`lazy 3,4,5` parsed as `(3.lazy, 4, 5)`, and
+      `lazy 1...*` as `(1.lazy)...*`) — fixed to consume the whole list like
+      `return`'s `parse_comma_or_expr` (`parser/expr/postfix/loop_.rs`).
+    - A nested `LazyList` sub-index (`@a[1,(lazy 3,4,5)]`) wasn't recursed into
+      on read (`vm_var_index_ops.rs`).
+    - A flat slice assignment (`@a[1,3] = ...`) used as a sub-expression (e.g.
+      `say (@a[1,3] = "x","y")`) mutated only the `env` copy, not the `locals`
+      slot, because that code path returns early and skipped the shared
+      locals-resync tail (`vm_var_assign_index_named.rs`).
+    - Nested-lazy-sublist slice **assignment and binding** (`@a[1,(lazy
+      3,4,5)] = "a"...*`, plus a bare top-level `@a[lazy 1,2,(4,5)] = ...`)
+      were entirely unimplemented (crashed) — added a `SliceKeyTree` (write
+      pass `assign_slice_key_tree` + a separate post-write `read_slice_key_tree`
+      to build the nested rvalue, since a duplicate index can be overwritten
+      after its own write) in `vm_var_assign_index_named.rs`. New test:
+      `t/nested-lazy-slice.t`.
+  - **Remaining failures (6/56, unrelated to laziness):**
+    - Test 15: `@slice := @array[1,2]; @slice = <A B C D>` should discard the
+      extra 2 RHS items (bound-slice fixed arity), returns all 4 instead.
+    - Test 31: Buf slice assignment (`$b[0,1] = 2,3`) not implemented.
+    - Test 35 (62 sub-assertions, aborts at 18/62): slice adverbs (`:p`, `:k`,
+      `:v`, `:kv`, `:exists`, `:delete`, combinations) on a nested-list index —
+      a distinct, large feature (container-identity §3 territory).
+    - Tests 54-55: a duplicate-index nested-lazy-list **binding** edge case
+      (`@a[lazy 1,2,(4,5),4,5] := ...`) diverges from the `=` assignment
+      semantics we matched — Rakudo's bind here does not truncate at the
+      boundary and returns write-time (not final) values, unlike `=`. Narrow,
+      low-ROI; not chased further this session.
+    - Test 56: `@a[**]` (HyperWhatever "hammer" index) — local `raku` itself
+      throws "not yet implemented. Sorry." for this, so it cannot even be
+      verified against the reference implementation here.
 - [ ] roast/S09-typed-arrays/arrays.t
 - [ ] roast/S09-typed-arrays/hashes.t
   - 44/47 pass (test 25 is TODO, tests 42-44 fail)

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,63 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-02: 真の lazy 配列キャンペーン — `S09-subscript/slice.t` の根本原因 6 件を解消
+
+BLOCKERS.md §4「真の lazy 配列 / 無限列」の最後の 1 ファイルだった
+`S09-subscript/slice.t` が、以前は test 39/56 で未実装機能への panic により
+中断していたのを、56/56 まで完走するように修正した（whitelist にはまだ入って
+いない — 残り 6 件は laziness と無関係の別機能、詳細は `TODO_roast/S09.md`）。
+1 つのテストファイルの背後に、根本原因の異なる 6 つのバグ/未実装機能があった:
+
+1. **`:=` bind が genuinely-lazy な `LazyList` を強制マテリアライズしていた**:
+   `coroutine` 系のみ lazy 保持されており、`sequence_spec`/`closure_seq`/
+   `lazy_pipe`（`(0...*).cache` のような無限シーケンス）は bind 時に 100k cap
+   の Array へ変換されていた。BIND は `=` 代入と違いコンテナをそのまま束縛する
+   ため、mutation 対応を気にする必要がなく、常に lazy 保持してよい
+   （`vm_var_assign_set_local.rs`）。
+2. **`LazyList::is_genuinely_lazy()` が「有限リストへの `.lazy`」を見逃す**:
+   `lazy 3,4,5` は cache のみで coroutine/body を持たないため、旧ロジックの
+   `(coroutine.is_some() || !body.is_empty() || ...) && is_lazy_marked()` が
+   false になり `.is-lazy` が `False` を返していた。`is_lazy_marked()` は
+   `lazy` prefix/`.lazy` 呼び出し専用マーカーなので、それだけで十分と判明
+   （`value_lazy.rs`）。
+3. **`lazy`/`eager`/`hyper` 文prefix のパーサが後続のカンマリスト全体を
+   ラップしていなかった**: `expression_no_sequence` が単一項しか読まないため、
+   `lazy 3,4,5` は `(3.lazy, 4, 5)` に、`lazy 1...*` は `(1.lazy)...*` に
+   パースされていた。`return` の `parse_comma_or_expr` と同様にカンマ区切り
+   リスト全体を消費する `parse_prefix_listop_operand` を新設して修正
+   （`parser/expr/postfix/loop_.rs`）。地味だが `lazy`/`eager`/`hyper` を
+   使うあらゆるコードに影響する広い一般バグだった。
+4. **read 側でネストした `LazyList` サブインデックスが再帰されていなかった**:
+   `@a[1,(lazy 3,4,5)]` の `(lazy 3,4,5)` 部分が `Value::Array`/`Seq`/`Slip`
+   としか照合されておらず、`Value::LazyList` は非対応だった
+   （`vm_var_index_ops.rs`）。
+5. **フラットなスライス代入を式コンテキストで使うと書き込みが消える
+   dual-store bug**: `@a[1,3] = "x","y"` は bare 文なら正しく動くが、
+   `say (@a[1,3] = "x","y")` のように式として使うと `env` 側のコピーにしか
+   書き戻らず `locals` スロットとズレて古い値が読まれる。スライス代入の
+   分岐だけが早期 return しており、共有の locals-resync 末尾処理を
+   スキップしていたのが原因（`vm_var_assign_index_named.rs`）。laziness とは
+   無関係の一般的な正しさのバグ。
+6. **ネスト lazy サブリストへの代入・bind が未実装**: `@a[1,(lazy 3,4,5)] =
+   "a"...*` やトップレベル `@a[lazy 1,2,(4,5)] = ...` は "Index out of
+   bounds" で panic していた。新設の `SliceKeyTree` で write pass
+   (`assign_slice_key_tree`) と、代入完了後にコンテナを読み直して nested な
+   返り値を組み立てる `read_slice_key_tree` を分離実装（重複インデックスが
+   後続の書き込みで上書きされるケースで、Raku の返り値が「書き込み時点の値」
+   でなく「最終状態」を反映するため、単一パスでは構築できない）。
+   `boundary_len`（代入開始前の元の長さ、autoviv-resize 前にスナップショット）
+   を使い、lazy 由来のネストは境界で打ち切り・plain なネストは通常通り伸長する、
+   という raku の挙動を再現した。
+
+回帰テスト: `t/nested-lazy-slice.t`（新規）。副次的に発見した既存バグの
+regression として `t/gather-lazy.t` を壊しかけたが（#2 の修正を BIND 側にも
+そのまま適用したところ、plain gather の `:=` bind が forced されるように
+なってしまった — plain gather は `.is-lazy` False だが bind では forcing しては
+いけない）、`coroutine.is_some() || is_genuinely_lazy()` の OR 条件に修正して
+解消。`make test` フルパス・`docs/lazy-arrays.md` 記載の回帰監視対象 roast
+ファイル群も全て確認済み。
+
 ## 2026-07-02: `S17-lowlevel/lock.t` — `Lock.protect` の race condition + 派生バグ2件を解決（whitelist 追加）
 
 BLOCKERS.md §6.1 で追跡していた「本物の race condition」を解決し、48/48（`Lock`・`Lock::Soft` 両

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -28,6 +28,42 @@ use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::Value;
 
+/// Parse the operand of a `lazy`/`eager`/`hyper` statement prefix: like
+/// `return`'s `parse_comma_or_expr`, these bind looser than the comma
+/// operator, so `lazy 3,4,5` must wrap the *entire* list `(3,4,5)` rather
+/// than just the first term (which `expression_no_sequence` alone would
+/// parse, leaving the trailing `,4,5` to be misread as siblings by whatever
+/// list the prefix expression itself sits in).
+fn parse_prefix_listop_operand(input: &str) -> PResult<'_, Expr> {
+    let (rest, first) = expression_no_sequence(input)?;
+    let (r, _) = ws(rest)?;
+    if !r.starts_with(',') || r.starts_with(",,") {
+        return Ok((rest, first));
+    }
+    let (r, _) = parse_char(r, ',')?;
+    let (r, _) = ws(r)?;
+    if r.starts_with(';') || r.is_empty() || r.starts_with('}') || r.starts_with(')') {
+        return Ok((r, Expr::ArrayLiteral(vec![first])));
+    }
+    let mut items = vec![first];
+    let (mut r, second) = expression_no_sequence(r)?;
+    items.push(second);
+    loop {
+        let (r2, _) = ws(r)?;
+        if !r2.starts_with(',') {
+            return Ok((r2, Expr::ArrayLiteral(items)));
+        }
+        let (r2, _) = parse_char(r2, ',')?;
+        let (r2, _) = ws(r2)?;
+        if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')') {
+            return Ok((r2, Expr::ArrayLiteral(items)));
+        }
+        let (r2, next) = expression_no_sequence(r2)?;
+        items.push(next);
+        r = r2;
+    }
+}
+
 pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
     if let Some(rest) = input.strip_prefix("++⚛") {
         let (rest, expr) = postfix_expr(rest)?;
@@ -272,7 +308,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
         if let Ok((r2, stmt)) = crate::parser::stmt::lazy_for_stmt_pub(r) {
             return Ok((r2, Expr::DoStmt(Box::new(stmt))));
         }
-        let (r, expr) = expression_no_sequence(r)?;
+        let (r, expr) = parse_prefix_listop_operand(r)?;
         return Ok((
             r,
             Expr::MethodCall {
@@ -288,7 +324,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
     if input.starts_with("hyper") && !is_ident_char(input.as_bytes().get(5).copied()) {
         let r = &input[5..];
         let (r, _) = ws(r)?;
-        let (r, expr) = expression_no_sequence(r)?;
+        let (r, expr) = parse_prefix_listop_operand(r)?;
         return Ok((
             r,
             Expr::MethodCall {
@@ -304,7 +340,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
     if input.starts_with("eager") && !is_ident_char(input.as_bytes().get(5).copied()) {
         let r = &input[5..];
         let (r, _) = ws(r)?;
-        let (r, expr) = expression_no_sequence(r)?;
+        let (r, expr) = parse_prefix_listop_operand(r)?;
         return Ok((r, Expr::Eager(Box::new(expr))));
     }
     // ^expr — upto operator: ^5 means 0..^5

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -97,6 +97,25 @@ impl LazyList {
         self.is_genuinely_lazy() && self.cat_pull.is_none()
     }
 
+    /// Whether iterating this list could hang or be unsafe to consume twice
+    /// right now (a live generator with no complete cache yet) — as opposed
+    /// to `is_genuinely_lazy()`, which answers `.is-lazy` and is also True for
+    /// an explicitly `lazy`-marked but ALREADY fully-cached, finite list
+    /// (`lazy 3,4,5`, or `(lazy ^2).cache`). `eqv` on two such same-type lazy
+    /// operands must throw ONLY when forcing could actually hang/misbehave —
+    /// a cache-only list (no coroutine/sequence_spec/etc, regardless of the
+    /// `lazy` marker) is safe to compare (roast S03-operators/eqv.t: "eqv
+    /// between identical lazy Seqs does not die" after `.cache`).
+    pub(crate) fn eqv_would_hang(&self) -> bool {
+        self.sequence_spec.is_some()
+            || self.lazy_pipe.is_some()
+            || self.closure_seq.is_some()
+            || self.scan_spec.is_some()
+            || self.cat_pull.is_some()
+            || ((self.coroutine.is_some() || !self.body.is_empty() || self.compiled_code.is_some())
+                && self.is_lazy_marked())
+    }
+
     /// Whether this list was produced from a `gather` block (carries the
     /// `__mutsu_lazylist_from_gather` env marker).
     pub(crate) fn is_from_gather(&self) -> bool {

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -74,16 +74,18 @@ impl LazyList {
     /// `lazy` — a plain `gather` is `.is-lazy` `False` in Rakudo and must
     /// materialize on gist/Str rather than render a placeholder.
     pub(crate) fn is_genuinely_lazy(&self) -> bool {
-        if self.sequence_spec.is_some()
+        self.sequence_spec.is_some()
             || self.lazy_pipe.is_some()
             || self.closure_seq.is_some()
             || self.scan_spec.is_some()
             || self.cat_pull.is_some()
-        {
-            return true;
-        }
-        (self.coroutine.is_some() || !self.body.is_empty() || self.compiled_code.is_some())
-            && self.is_lazy_marked()
+            // The `__mutsu_preserve_lazy_on_array_assign` marker is set
+            // exclusively by an explicit `lazy` prefix / `.lazy` method call
+            // (see `dispatch_core_str.rs`), including on an already-finite
+            // list (`lazy 3,4,5` caches its 3 items but stays `.is-lazy` True
+            // in Rakudo) — so the marker alone is sufficient regardless of
+            // whether the list also carries a coroutine/body/compiled_code.
+            || self.is_lazy_marked()
     }
 
     /// Whether gist/Str/raku should render a `...` placeholder rather than

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -513,7 +513,7 @@ impl Interpreter {
     /// `.List`-coerced one is `List`, a `.Array`/`@`-coerced one is `Array`.
     fn lazy_eqv_type(v: &Value) -> Option<&'static str> {
         match v {
-            Value::LazyList(ll) if ll.is_genuinely_lazy() => Some(if ll.in_array_context() {
+            Value::LazyList(ll) if ll.eqv_would_hang() => Some(if ll.in_array_context() {
                 "Array"
             } else if ll.in_list_context() {
                 "List"

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -5,7 +5,149 @@ use std::sync::Arc;
 
 type BindSourceCell = (Option<String>, Arc<std::sync::Mutex<Value>>);
 
+/// A flat slice-assign key (`@a[1,(lazy 3,4,5)] = ...`), pre-resolved so the
+/// mutable-container recursion below never needs `&mut self` (a nested key's
+/// `LazyList` must be forced up front, before `env_root_descended_mut` takes
+/// out a `&mut Value` borrow on `self.env`).
+enum SliceKeyTree {
+    Leaf(Value),
+    /// A nested sublist target (`(3,4,5)` or `(lazy 3,4,5)`). The `bool` marks
+    /// whether the ORIGINAL value was genuinely lazy: Raku stops distributing
+    /// into a lazy nested sublist as soon as a leaf index runs past the
+    /// container's current length (mirrors the read-side `is_lazy_index`
+    /// stop-at-boundary rule), whereas a plain nested list autovivifies/fills
+    /// with `Any` like a top-level slice would.
+    Nested(Vec<SliceKeyTree>, bool),
+}
+
 impl Interpreter {
+    fn build_slice_key_tree(&mut self, key: &Value) -> Result<SliceKeyTree, RuntimeError> {
+        match key {
+            Value::LazyList(ll) => {
+                let items = self.force_lazy_list_vm(ll)?;
+                let children = items
+                    .iter()
+                    .map(|item| self.build_slice_key_tree(item))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(SliceKeyTree::Nested(children, true))
+            }
+            Value::Array(items, _) => {
+                let children = items
+                    .iter()
+                    .map(|item| self.build_slice_key_tree(item))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(SliceKeyTree::Nested(children, false))
+            }
+            Value::Seq(items) | Value::Slip(items) => {
+                let children = items
+                    .iter()
+                    .map(|item| self.build_slice_key_tree(item))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(SliceKeyTree::Nested(children, false))
+            }
+            other => Ok(SliceKeyTree::Leaf(other.clone())),
+        }
+    }
+
+    /// Largest leaf index in a NON-lazy-origin key tree, used to autoviv-resize
+    /// the container before assigning. A lazy-origin nested list must NOT grow
+    /// the array — it is bounded by the container's *current* length instead
+    /// (`assign_slice_key_tree` below), matching the read-side rule.
+    fn slice_key_tree_max_index(key: &SliceKeyTree) -> Option<usize> {
+        match key {
+            SliceKeyTree::Leaf(v) => Self::index_to_usize(v),
+            SliceKeyTree::Nested(children, lazy_origin) => children
+                .iter()
+                .filter_map(|c| {
+                    // A leaf living DIRECTLY under a lazy-origin nested list is
+                    // bounded rather than extended (see doc comment above). A
+                    // nested sub-tree still recurses on its own rules even when
+                    // its parent is lazy-origin (`@a[lazy 1,2,(4,5)]`'s `(4,5)`
+                    // is a plain sublist and DOES extend the array).
+                    if *lazy_origin && matches!(c, SliceKeyTree::Leaf(_)) {
+                        None
+                    } else {
+                        Self::slice_key_tree_max_index(c)
+                    }
+                })
+                .max(),
+        }
+    }
+
+    /// Recursively distribute `vals` across a (possibly nested) nested slice
+    /// key tree, writing each leaf through `assign_array_multidim`. Pure
+    /// side-effecting write pass — see `read_slice_key_tree` for building the
+    /// returned rvalue, which must be a SEPARATE post-write read: a duplicate
+    /// index appearing twice in the same key tree (`@a[lazy 1,2,(4,5),4,5]`)
+    /// overwrites an earlier write, and Raku's assignment result reflects the
+    /// FINAL value at each position, not the value seen at write time.
+    ///
+    /// `boundary_len` is the container's length *before* this slice-assign
+    /// began (captured once by the caller, ahead of any autoviv-resize) — a
+    /// FIXED snapshot, not re-read per node. Raku's lazy-origin stop-at-
+    /// boundary check is against that original length even after a sibling
+    /// plain nested sublist has already grown the array earlier in the same
+    /// operation (`@a[lazy 1,2,(4,5),4,5]`'s trailing `4,5` must still stop
+    /// at the pre-assignment length 5, not the length-6 the `(4,5)` sibling
+    /// just grew it to).
+    fn assign_slice_key_tree(
+        container: &mut Value,
+        key: &SliceKeyTree,
+        boundary_len: usize,
+        vals: &mut std::vec::IntoIter<Value>,
+        marks: &mut Vec<String>,
+    ) -> Result<(), RuntimeError> {
+        match key {
+            SliceKeyTree::Leaf(k) => {
+                let v = vals.next().unwrap_or(Value::Nil);
+                Self::assign_array_multidim(container, std::slice::from_ref(k), v)?;
+                marks.push(Self::encode_bound_index(k));
+                Ok(())
+            }
+            SliceKeyTree::Nested(children, lazy_origin) => {
+                for child in children {
+                    if *lazy_origin
+                        && let SliceKeyTree::Leaf(k) = child
+                        && let Some(i) = Self::index_to_usize(k)
+                        && i >= boundary_len
+                    {
+                        break;
+                    }
+                    Self::assign_slice_key_tree(container, child, boundary_len, vals, marks)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Build the nested rvalue of a slice assignment by reading the container
+    /// back AFTER all writes (`assign_slice_key_tree`) — see its doc comment
+    /// for why this must be a separate post-write pass.
+    fn read_slice_key_tree(container: &Value, key: &SliceKeyTree, boundary_len: usize) -> Value {
+        match key {
+            SliceKeyTree::Leaf(k) => Self::index_to_usize(k)
+                .and_then(|i| match container {
+                    Value::Array(items, ..) => items.get(i).cloned(),
+                    _ => None,
+                })
+                .unwrap_or(Value::Nil),
+            SliceKeyTree::Nested(children, lazy_origin) => {
+                let mut out = Vec::with_capacity(children.len());
+                for child in children {
+                    if *lazy_origin
+                        && let SliceKeyTree::Leaf(k) = child
+                        && let Some(i) = Self::index_to_usize(k)
+                        && i >= boundary_len
+                    {
+                        break;
+                    }
+                    out.push(Self::read_slice_key_tree(container, child, boundary_len));
+                }
+                Value::array(out)
+            }
+        }
+    }
+
     pub(crate) fn exec_index_assign_expr_named_op_inner(
         &mut self,
         code: &CompiledCode,
@@ -389,6 +531,55 @@ impl Interpreter {
             return Ok(());
         }
         match &idx {
+            // Top-level lazy index list: `@a[lazy 1,2,(4,5)] = ...`. Mirrors the
+            // `Value::Array` slice arm below but for a bare `LazyList` subscript
+            // (not wrapped in an outer Array) — the whole list is genuinely lazy,
+            // so distribution into ITS direct leaves stops at the container's
+            // current length (`assign_slice_key_tree`), while any plain nested
+            // sublist inside it (like `(4,5)` above) still extends normally.
+            Value::LazyList(_) if is_positional && var_name.starts_with('@') => {
+                let vals = self.assignment_rhs_values(&val)?;
+                let top_tree = self.build_slice_key_tree(&idx)?;
+                if let Some(container) = self.env_root_descended_mut(&var_name)
+                    && matches!(container, Value::Array(..))
+                {
+                    let boundary_len = if let Value::Array(items, ..) = container {
+                        items.len()
+                    } else {
+                        0
+                    };
+                    if let Some(max_idx) = Self::slice_key_tree_max_index(&top_tree)
+                        && let Value::Array(items, ..) = container
+                    {
+                        let arr = Arc::make_mut(items);
+                        Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
+                    }
+                    let mut vals_iter = vals.into_iter();
+                    let mut marks: Vec<String> = Vec::new();
+                    Self::assign_slice_key_tree(
+                        container,
+                        &top_tree,
+                        boundary_len,
+                        &mut vals_iter,
+                        &mut marks,
+                    )?;
+                    let result = Self::read_slice_key_tree(container, &top_tree, boundary_len);
+                    for encoded in marks {
+                        self.mark_initialized_index(&var_name, encoded);
+                    }
+                    // Early return (like the `Value::Array` slice arm), so repeat
+                    // the locals resync the shared tail would otherwise do.
+                    if let Some(slot) = self.find_local_slot(code, &var_name)
+                        && let Some(updated) = self.env().get(&var_name).cloned()
+                    {
+                        self.locals[slot] = updated;
+                    }
+                    self.stack.push(result);
+                    return Ok(());
+                }
+                // Not an array container after all (e.g. a hash) — fall through
+                // to the shared generic tail below.
+            }
             Value::Array(keys, ..) => {
                 let mut vals = self.assignment_rhs_values(&val)?;
                 // Per-element type check for slice assignment to a typed array,
@@ -406,6 +597,26 @@ impl Interpreter {
                         }
                     }
                 }
+                // A nested sublist key (`@a[1,(lazy 3,4,5)] = ...`) must be
+                // resolved to a `SliceKeyTree` BEFORE `env_root_descended_mut`
+                // takes out a `&mut Value` borrow on `self.env` below — forcing
+                // a nested `LazyList` needs `&mut self`, which would otherwise
+                // conflict with that borrow.
+                let has_nested_key = keys.iter().any(|k| {
+                    matches!(
+                        k,
+                        Value::Array(..) | Value::Seq(..) | Value::Slip(..) | Value::LazyList(..)
+                    )
+                });
+                let key_trees = if has_nested_key {
+                    let trees = keys
+                        .iter()
+                        .map(|k| self.build_slice_key_tree(k))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Some(SliceKeyTree::Nested(trees, false))
+                } else {
+                    None
+                };
                 // Descend through a whole-container `:=` bound cell (`my @x :=
                 // @a`) so an array slice assignment mutates the shared inner
                 // Array (every alias observes it) instead of falling through to
@@ -416,6 +627,7 @@ impl Interpreter {
                     let is_shaped =
                         has_declared_shape || crate::runtime::utils::is_shaped_array(container);
                     let mut initialized_marks: Vec<String> = Vec::new();
+                    let mut nested_result: Option<Value> = None;
                     if is_shaped {
                         if bind_mode && is_bound_index {
                             return Err(RuntimeError::assignment_ro(None));
@@ -439,6 +651,33 @@ impl Interpreter {
                         }
                     } else if keys.is_empty() {
                         // Empty slice assignment (e.g. @n[*] on empty array): no-op
+                    } else if let Some(top_tree) = &key_trees {
+                        // Flat slice assignment with a nested sublist key:
+                        // @a[1,(lazy 3,4,5)] = ... — auto-extend for non-lazy-
+                        // origin leaves only; a lazy-origin nested sublist is
+                        // bounded by the container's current length instead
+                        // (`assign_slice_key_tree`).
+                        let boundary_len = if let Value::Array(items, ..) = container {
+                            items.len()
+                        } else {
+                            0
+                        };
+                        if let Some(max_idx) = Self::slice_key_tree_max_index(top_tree)
+                            && let Value::Array(items, ..) = container
+                        {
+                            let arr = Arc::make_mut(items);
+                            Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
+                        }
+                        let mut vals_iter = vals.into_iter();
+                        Self::assign_slice_key_tree(
+                            container,
+                            top_tree,
+                            boundary_len,
+                            &mut vals_iter,
+                            &mut initialized_marks,
+                        )?;
+                        nested_result =
+                            Some(Self::read_slice_key_tree(container, top_tree, boundary_len));
                     } else {
                         // Flat slice assignment: @a[2,3,4,6] = <foo bar foo bar>
                         // Auto-extend the array to accommodate all indices
@@ -465,12 +704,27 @@ impl Interpreter {
                         self.mark_bound_index(&var_name, encoded_idx);
                     }
                     // A 1-element slice (`@a[0,]`) names a single scalar slot, so
-                    // its rvalue itemizes like a single-index assignment.
-                    let result = if idx_is_single_element {
+                    // its rvalue itemizes like a single-index assignment. A
+                    // nested-key assignment (`@a[1,(lazy 3,4,5)] = ...`) instead
+                    // returns the nested shape built while assigning.
+                    let result = if let Some(nested) = nested_result {
+                        nested
+                    } else if idx_is_single_element {
                         Self::itemize_value(val)
                     } else {
                         val
                     };
+                    // This arm returns early (unlike the single-index write path,
+                    // which falls through to the shared tail below), so it must
+                    // repeat the locals resync here too — otherwise a slice
+                    // assignment mutates only the `env` copy while a variable
+                    // that also has a `locals` slot (the common case) keeps
+                    // reading its stale pre-assignment value.
+                    if let Some(slot) = self.find_local_slot(code, &var_name)
+                        && let Some(updated) = self.env().get(&var_name).cloned()
+                    {
+                        self.locals[slot] = updated;
+                    }
                     self.stack.push(result);
                     return Ok(());
                 }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -698,10 +698,21 @@ impl Interpreter {
                     return Err(err);
                 }
                 match raw_popped {
-                    Value::LazyList(ref list) if list.coroutine.is_some() => {
-                        // Gather-based lazy list with coroutine: preserve laziness,
-                        // tagging it as living in `@` array context so gist/`.WHAT`
-                        // render `[...]`/`Array` rather than `(...)`/`Seq`.
+                    // `:=` binds the container itself rather than copying values
+                    // into a fresh Array, so — unlike plain `=` assignment, which
+                    // must stay conservative about mutation support (see
+                    // docs/lazy-arrays.md L2) — ANY genuinely-lazy list (gather
+                    // coroutine, infinite sequence/closure spec, lazy pipe, scan)
+                    // can be bound without forcing. A *plain* (non-`lazy`-marked)
+                    // gather is `.is-lazy` False (`is_genuinely_lazy()` alone
+                    // would miss it) but binding must still not force it — that
+                    // is the whole point of `:=` vs `=` (t/gather-lazy.t tests
+                    // 1/3) — so `coroutine.is_some()` is checked too. Tag it as
+                    // living in `@` array context so gist/`.WHAT` render
+                    // `[...]`/`Array` rather than `(...)`/`Seq`.
+                    Value::LazyList(ref list)
+                        if list.coroutine.is_some() || list.is_genuinely_lazy() =>
+                    {
                         Value::LazyList(std::sync::Arc::new(list.with_array_context()))
                     }
                     Value::LazyList(list) => Value::real_array(self.force_lazy_list_vm(&list)?),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -685,9 +685,15 @@ impl Interpreter {
                         };
                         let effective_idx = resolved_idx.as_ref().unwrap_or(idx);
                         // Nested list index: @a[0,(1,2)] => (a[0], (a[1], a[2]))
+                        // A `LazyList` sublist (`@a[1,(lazy 3,4,5)]`) recurses too,
+                        // so the nested slice gets the lazy stop-at-boundary
+                        // semantics via the top-level `is_lazy_index` normalization.
                         if matches!(
                             effective_idx,
-                            Value::Array(..) | Value::Seq(..) | Value::Slip(..)
+                            Value::Array(..)
+                                | Value::Seq(..)
+                                | Value::Slip(..)
+                                | Value::LazyList(..)
                         ) {
                             self.stack.push(target.clone());
                             self.stack.push(effective_idx.clone());

--- a/t/eqv-lazy.t
+++ b/t/eqv-lazy.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 16;
+plan 18;
 
 # `.List` / `.Array` on a genuinely-lazy sequence preserve laziness (they must
 # NOT materialize the infinite tail) and report the coerced `.WHAT`.
@@ -33,4 +33,16 @@ plan 16;
     lives-ok { (1…∞) eqv (1…∞).List }, 'both lazy but different type lives';
     lives-ok { (1…∞) eqv (1, 3)     }, 'only one lazy lives';
     lives-ok { (1…∞).List eqv (1…3).List }, 'one lazy List lives';
+}
+
+# A `lazy`-marked but already fully-cached FINITE list (`.is-lazy` True, but
+# nothing left to force) is safe to `eqv` even against itself — roast
+# S03-operators/eqv.t 'eqv between identical lazy Seqs does not die'.
+{
+    my $a = lazy ^2;
+    my $b = $a;
+    $a.cache;
+    my $result;
+    lives-ok { $result = $a eqv $b }, 'eqv between identical cached lazy Seqs does not die';
+    is-deeply $result, True, 'eqv between identical cached lazy Seqs returns True';
 }

--- a/t/nested-lazy-slice.t
+++ b/t/nested-lazy-slice.t
@@ -1,0 +1,75 @@
+use Test;
+
+# `lazy LIST` must wrap the WHOLE comma-separated list, not just the first
+# term (parser bug: `lazy 3,4,5` was parsing as `(3.lazy, 4, 5)`).
+{
+    my $x = (lazy 3, 4, 5);
+    is $x.is-lazy, True, 'lazy on a finite list literal reports is-lazy True';
+    dies-ok { $x.elems }, '.elems on a lazy-marked list throws (matches Rakudo)';
+    is $x[2], 5, 'the full 3-item comma list survives (index 2 unreachable if truncated)';
+}
+{
+    my @idx := (0...*).cache;
+    is @idx.is-lazy, True, '.cache on an infinite sequence stays lazy when := bound';
+    is @idx[200000], 200000, 'lazy-bound .cache reifies on out-of-cache index';
+}
+
+# Nested lazy sublist as a read-side index element: distribution stops at
+# the container's boundary instead of filling with Any past the end.
+{
+    my @a = 1 .. 5;
+    is-deeply @a[1, (lazy 3, 4, 5)], (2, (4, 5)), 'nested lazy sublist read stops at array boundary';
+    is-deeply @a[lazy 1, 2, (4, 5)], (2, 3, (5, Any)), 'plain nested sublist inside a lazy list does not stop early';
+}
+
+# Nested lazy sublist as an assignment/bind target.
+{
+    my @a = 11 .. 15;
+    is-deeply (@a[1, (lazy 3, 4, 5)] = "a" ... *), ("a", ("b", "c")),
+        'assigning through a nested lazy sublist returns the nested shape';
+    is-deeply @a, [11, "a", 13, "b", "c"],
+        'assigning through a nested lazy sublist stops writes at the boundary';
+}
+{
+    my @a = 11 .. 15;
+    is-deeply (@a[1, (lazy 3, 4, 5)] := "a" ... *), ("a", ("b", "c")),
+        'binding through a nested lazy sublist returns the nested shape';
+    is-deeply @a, [11, "a", 13, "b", "c"],
+        'binding through a nested lazy sublist stops writes at the boundary';
+}
+
+# Top-level lazy index list (not wrapped in an outer Array): a plain nested
+# sublist inside it still autoviv-extends normally.
+{
+    my @a = 11 .. 15;
+    is-deeply (@a[lazy 1, 2, (4, 5)] = "a" ... *), ("a", "b", ("c", "d")),
+        'assigning through a top-level lazy list with a plain nested sublist';
+    is-deeply @a, [11, "a", "b", 14, "c", "d"],
+        'the plain nested sublist extends the array past its original length';
+}
+
+# Duplicate indices (direct leaf appearing both inside a plain nested
+# sublist and again at the top level): the top-level occurrence is bounded
+# by the ORIGINAL (pre-assignment) length, even though the nested sibling
+# already grew the array earlier in the same operation. The returned value
+# reflects each position's FINAL state (a post-write read), not the value
+# seen at write time.
+{
+    my @a = 11 .. 15;
+    is-deeply (@a[lazy 1, 2, (4, 5), 4, 5] = "a" ... *), ("a", "b", ("e", "d"), "e"),
+        'duplicate trailing indices stop at the pre-assignment boundary';
+    is-deeply @a, [11, "a", "b", 14, "e", "d"],
+        'the nested write is visible, then overwritten once more before the boundary stop';
+}
+
+# Flat (non-nested) slice assignment used as a sub-expression (not a bare
+# statement) must still write back to the array — a dual-store bug made the
+# mutation visible only through the assignment's own return value.
+{
+    my @a = (1, 2, 3, 4, 5);
+    say (@a[1, 3] = "x", "y");
+    is-deeply @a, [1, "x", 3, "y", 5],
+        'slice assignment used as a say() argument still mutates the array';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- Fixes six independent root causes blocking BLOCKERS.md §4 (true lazy arrays / infinite sequences), surfaced by `roast/S09-subscript/slice.t`, which now runs all 56 planned tests to completion (previously aborted at 39/56 on an uncaught panic).
- `:=` binding a `sequence_spec`/`closure_seq`/`lazy_pipe` `LazyList` (e.g. `(0...*).cache`) was force-materialized to a capped 100k Array; only `coroutine` lists stayed lazy.
- `LazyList::is_genuinely_lazy()` missed a `.lazy`-on-a-finite-list literal (cache-only, no coroutine/body), so `.is-lazy` wrongly reported `False`.
- The `lazy`/`eager`/`hyper` statement-prefix parser only wrapped the first term of a following comma list (`lazy 3,4,5` parsed as `(3.lazy, 4, 5)`, and `lazy 1...*` as `(1.lazy)...*`) — a general bug affecting any use of these prefixes with a list, fixed to consume the whole list like `return`'s `parse_comma_or_expr`.
- A nested `LazyList` sub-index (`@a[1,(lazy 3,4,5)]`) wasn't recursed into on read.
- A flat slice assignment used as a sub-expression (`say (@a[1,3] = "x","y")`) wrote only to the `env` copy, not the `locals` slot — a dual-store bug from an early return skipping the shared locals-resync tail.
- Nested-lazy-sublist slice assignment/binding (`@a[1,(lazy 3,4,5)] = "a"...*`, plus a bare top-level `@a[lazy 1,2,(4,5)] = ...`) was entirely unimplemented (panicked) — added `SliceKeyTree` with a write pass and a separate post-write read-back pass (needed since a duplicate index's returned value reflects its final, possibly-overwritten state, not the value seen at write time).

See `TODO_roast/S09.md` and `news/2026-07.md` for full root-cause detail. Six remaining `slice.t` failures (Buf slice assign, bound-slice fixed arity, nested-slice adverbs, a bind-vs-assign duplicate-index edge case, and an unimplemented-in-Rakudo `[**]` hyperwhatever index) are unrelated to laziness and out of scope for this PR.

## Test plan
- [x] `make test` (full release-build `t/` suite) passes.
- [x] New `t/nested-lazy-slice.t` (16 assertions) passes against both mutsu and reference `raku`.
- [x] `roast/S09-subscript/slice.t` runs 56/56 (was 39/56 aborting).
- [x] Regression watch-list from `docs/lazy-arrays.md` (S32-array/create.t, delete-adverb.t, delete-adverb-native.t, S32-list/{flat,join,grep,map,first,head}.t, S03-sequence/misc.t, S07-iterators/range-iterator.t, S09-subscript/multidim-assignment.t) all pass.
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK