### PR TITLE
refactor(compiler): bake for-loop live-array source slot (§1.5 slice S9)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -130,12 +130,19 @@ broadcast = touches every slot with the name.
       byte-identical across the whole `make test` suite via a temporary
       `debug_assert_eq!` (never fired). (The pre-existing `@a does R` / `%h does R`
       `.name`-doesn't-resolve gap is unrelated — identical on `main`.) *(done)*
-- [ ] S9+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+- [x] **S9 — `for @a` live-array source re-read.** The `ForLoop` opcode / `ForLoopSpec`
+      gain a compile-time `single_array_source_local: Option<u32>` (baked from
+      `local_map`, mirroring the VM's bare-then-`@`-sigiled resolution order). The
+      live-array continuation re-read (`vm_for_loop_dispatch.rs`) resolves the source
+      via the S7 `resolve_local_slot` helper with the baked slot instead of
+      `find_local_slot` by name, keeping the `@`-name + env fallback for a `None`
+      slot. Behavior-preserving today; verified byte-identical across the whole
+      `make test` suite via a temporary `debug_assert_eq!` (never fired). *(done)*
+- [ ] S10+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
       for-loop *container* source writeback (`write_back_container_source`,
       `write_back_for_topic_item`, resolved by the runtime-derived
-      `container_ref_var` name — a §1.3 concern); the `single_array_source`
-      live-array re-read (`vm_for_loop_dispatch.rs`); element/index-assign,
-      computed-attr, mixin, hyper writeback, and the ~80 `update_local_if_exists`
+      `container_ref_var` name — a §1.3 concern); element/index-assign,
+      computed-attr twigil cells, hyper writeback, and the ~80 `update_local_if_exists`
       callers generally — migrated onto `resolve_local_slot`/`write_local_slot_or_name`.
 - [ ] §1.4 flip + `pop_local_scope` restore.
 - [ ] §1.3 slot-indexed locals + drop BlockScope clone.

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -244,6 +244,8 @@ impl Compiler {
             loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
             values_mode: Self::for_iterable_is_values_alias(iterable),
             single_array_source: Self::for_single_array_source(iterable),
+            single_array_source_local: self
+                .for_single_array_source_local(&Self::for_single_array_source(iterable)),
         });
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -866,6 +866,18 @@ impl Compiler {
         }
     }
 
+    /// Bake the local slot for a `for @a` live-array source (§1.5). Mirrors the
+    /// VM's runtime resolution order (bare name, then the `@`-sigiled name), which
+    /// — since `code.locals` is built from `local_map` — is exactly this lookup.
+    /// `None` when the source is not a local (keeps the VM's env fallback).
+    fn for_single_array_source_local(&self, source: &Option<String>) -> Option<u32> {
+        let name = source.as_ref()?;
+        self.local_map
+            .get(name)
+            .or_else(|| self.local_map.get(&format!("@{name}")))
+            .copied()
+    }
+
     /// Bake the local slot for each per-element writeback target of a
     /// `for ($a, $b, $c) { ... }` loop (§1.5). `None` for a name that has no
     /// local slot at this point (`our`/global/undeclared), which keeps the

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1774,6 +1774,8 @@ impl Compiler {
                     loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
                     values_mode: Self::for_iterable_is_values_alias(iterable),
                     single_array_source: Self::for_single_array_source(iterable),
+                    single_array_source_local: self
+                        .for_single_array_source_local(&Self::for_single_array_source(iterable)),
                 });
                 // Register sigilless for-params (`-> \v`, `-> \k, \v`) as
                 // sigilless locals while compiling the body so postfix/prefix

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -938,6 +938,11 @@ pub(crate) enum OpCode {
         /// iterable. Separate from `source_var_names` (a per-index scalar-list
         /// writeback mechanism that must NOT be populated for a `@`-source).
         single_array_source: Option<String>,
+        /// Compiler-baked local slot for `single_array_source` (§1.5): the
+        /// live-array re-read reads `locals[slot]` directly instead of resolving
+        /// the source name via `find_local_slot`. `None` when the source is not a
+        /// resolvable local (keeps the by-name + env fallback).
+        single_array_source_local: Option<u32>,
     },
     /// Restore the single named for-loop param's prior binding, deferred until
     /// after the loop's LAST/post phasers have run (which must still see the

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -33,6 +33,8 @@ pub(super) struct ForLoopSpec {
     /// Bare source array name for `for @a` (live-array iteration). See the
     /// `OpCode::ForLoop` field of the same name.
     pub(super) single_array_source: Option<String>,
+    /// Compiler-baked local slot for `single_array_source` (§1.5).
+    pub(super) single_array_source_local: Option<u32>,
 }
 
 pub(super) struct WhileLoopSpec {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3031,6 +3031,7 @@ impl Interpreter {
                 loop_var_wraps_element,
                 values_mode,
                 single_array_source,
+                single_array_source_local,
             } => {
                 let spec = vm_control_ops::ForLoopSpec {
                     param_idx: *param_idx,
@@ -3053,6 +3054,7 @@ impl Interpreter {
                     loop_var_wraps_element: *loop_var_wraps_element,
                     values_mode: *values_mode,
                     single_array_source: single_array_source.clone(),
+                    single_array_source_local: *single_array_source_local,
                 };
                 self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
             }

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -273,9 +273,10 @@ impl Interpreter {
             }
             // Re-read the live source array. In the single-store model `@a` is
             // authoritative in its local slot (the env copy can be stale), so try
-            // the local slot first (bare and `@`-sigiled names), then env.
+            // the local slot first (the compiler-baked slot §1.5, else by name —
+            // bare and `@`-sigiled), then env.
             let live = self
-                .find_local_slot(code, name)
+                .resolve_local_slot(code, spec.single_array_source_local, name)
                 .or_else(|| self.find_local_slot(code, &format!("@{name}")))
                 .map(|s| self.locals[s].clone())
                 .or_else(|| self.env().get(name).cloned());


### PR DESCRIPTION
Part of the §1.4/§1.5/§1.3 lexical-scope campaign (`docs/lexical-scope-slot-campaign.md`), slice **S9 — `for @a` live-array source re-read**. Reuses S7's `resolve_local_slot` helper.

## Problem
`for @a { @a.push(...) }` re-reads the live source array between passes so raku's live-array iteration keeps yielding newly-appended elements. That re-read resolved the source by name via `find_local_slot` → `code.locals.position(name)`, the name→slot runtime resolution §1.5 removes.

## Change
The `ForLoop` opcode / `ForLoopSpec` now carry a compile-time `single_array_source_local: Option<u32>`, baked from `local_map` (mirroring the VM's bare-then-`@`-sigiled resolution order). The re-read goes through the S7 `resolve_local_slot` helper with the baked slot, keeping the `@`-name + env fallback for a `None` slot.

## Correctness
`find_local_slot(x)` == `code.locals.position(x)` == `local_map.get(x)` (as a slot), because `alloc_local` pushes to `code.locals` and records `local_map[name]` together. So the baked `local_map.get(name).or_else(get("@name"))` equals the runtime `find_local_slot(name).or_else(find("@name"))`. Verified **byte-identical** across the entire `make test` suite via a temporary `debug_assert_eq!` (never fired), then removed.

## Testing
- `make test` passes (full local suite + roast whitelist).
- `for @a { @a.push(...) }` live-array growth (count reaches the appended tail) and a plain non-growing loop spot-checked against `raku` (match).
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)