### PR TITLE
refactor(compiler): gated §1.4 shadow-slot activation (MUTSU_SHADOW_SLOTS)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -144,5 +144,82 @@ broadcast = touches every slot with the name.
       `container_ref_var` name — a §1.3 concern); element/index-assign,
       computed-attr twigil cells, hyper writeback, and the ~80 `update_local_if_exists`
       callers generally — migrated onto `resolve_local_slot`/`write_local_slot_or_name`.
-- [ ] §1.4 flip + `pop_local_scope` restore.
+- [~] §1.4 flip + `pop_local_scope` restore — **landed gated** behind
+      `MUTSU_SHADOW_SLOTS` (default off = byte-identical). See the
+      "shadow-slot activation, gated" section below. Default flip pends §1.3.
 - [ ] §1.3 slot-indexed locals + drop BlockScope clone.
+
+## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
+
+A naive flip was implemented and measured, then reverted (branch
+`refactor/lexical-scope-1.4`, no code landed). The flip:
+
+- `declare_local`: allocate a **fresh** slot for a shadowing `my $x` (name already
+  in an enclosing scope frame), same-scope redeclaration reuses, first declaration
+  creates.
+- `pop_local_scope`: restore `local_map[name]` to the outer slot (`Some(prev)`) or
+  remove it (`None`) on scope exit.
+
+Reads compiled correctly (each `GetLocal(slot)` uses the compile-time `local_map`),
+and simple shadow tests (`my $x=1; { my $x=2; $x++; say $x } say $x` → `2 3 1`)
+passed. But the full `t/` suite broke **57+ files through the `r`- prefix alone
+(~40 % of the alphabet), i.e. an estimated ~120–140 total** — a catastrophic blast
+radius. The failures cluster into exactly the three coupled mechanisms the campaign
+predicted, confirming §1.4 is **not** a standalone slice:
+
+1. **§1.3 env↔locals dual store (the dominant class).** `env` is a name-keyed
+   `HashMap`; two live `$x` collapse to one env entry. `exec_get_local_op` /
+   `exec_set_local_op` and the `BlockScope` save/restore all key off
+   `code.locals[idx]` *by name*, so duplicate names cross-contaminate. Failing
+   families: `*-writeback-coherence`, `*-captured-outer-coherence`,
+   `closure-container-capture`, `cross-thread-shared-var`, `concurrent-cell`,
+   `env-dirty-reconcile-coherence`, `lock-protect-*`, `element-*`, `pair-value-*`.
+2. **§1.5 un-baked leaf writebacks (~80 `update_local_if_exists`/`find_local_slot`
+   callers).** These resolve name→slot by `position` = the **outer** (first) slot,
+   so an `undefine`/rw-arg/hyper/element writeback aimed at the live inner shadow
+   hits the outer slot. Failing families: `method-rw-param-writeback`,
+   `proto-rw-redispatch`, `nextsame-rw-redispatch`, `for-quanthash-values-rw`,
+   `hyper-meta-assign-list`, `capture-element-writethrough`.
+3. **Compile-time scope-exit resolution.** `pop_local_scope` removing a name from
+   `local_map` changed how a post-block reference compiles (`block-lexical-scope.t`
+   "chained our/my does not leak" no longer dies with X::Undeclared).
+
+**Conclusion (decisive):** the flip cannot land as the default until (a) the
+env-as-source-of-truth for locals is slot-indexed (§1.3) so duplicate names stop
+colliding, and (b) every remaining leaf writeback carries a compile-time slot
+(§1.5 S10+). Baking leaf sites one-at-a-time still leaves class 1 (env coherence)
+fatal, so **§1.3 is the load-bearing prerequisite** — it must come before, or fused
+with, the default flip. The per-variable opcode leaf slices (S1–S9) are done; the
+remaining leaf sites are multi-var / runtime-derived and do not reduce class-1
+breakage. See ANALYSIS.md §1.4 調査メモ.
+
+## §1.4 shadow-slot activation, gated (2026-07-03, branch `refactor/lexical-scope-1.4-shadow`)
+
+Rather than revert-and-wait, the shadow-slot allocation now **lands behind an
+env-var gate** (`MUTSU_SHADOW_SLOTS`), the same pattern the env_dirty campaign used
+(`MUTSU_NO_BLANKET_RECONCILE`, …). This is the shadow-half of the campaign, run in
+parallel with the §1.3/env substrate half.
+
+- **`declare_local`** (gate on): a same-scope redeclaration reuses; a name bound in
+  an enclosing scope becomes a genuine shadow with its **own fresh slot**; a first
+  declaration allocates normally.
+- **`pop_local_scope`** (gate on): restores the outer binding in `local_map` for
+  every shadowed name on scope exit. `None` (first-declaration) entries are left in
+  `local_map` (monotonic, matching the default build) so the runtime
+  `block_declared_vars` machinery keeps enforcing out-of-scope errors — this avoids
+  the naive flip's class-3 (`block-lexical-scope.t`) breakage.
+- **Gate off (default / CI):** both functions take an early return that is
+  byte-identical to the pre-campaign code (`alloc_local` get-or-create; pop is a
+  no-op). CI stays green.
+
+`MUTSU_SHADOW_SLOTS=1` toggle-ON baseline (2026-07-03, debug `prove t/`): shadowing
+is correct for simple cases (`2 3 1 30 20 10` on nested `my $x`/`my $y`), but the
+suite still shows the class-1 + class-2 breakage above (closure-capture,
+captured-outer-writeback, cross-thread, quanthash-rw, …). That failure set is the
+campaign's burndown target: the §1.3 half drives class-1 to zero (slot-indexed env)
+and the §1.5 S10+ leaf baking drives class-2 to zero, after which the gate default
+is flipped and the `exec_block_scope_op` whole-`locals` clone is removed.
+
+**Task split:** this branch owns the shadow-side compiler machinery (declare/pop);
+the env↔locals slot-indexing (§1.3) is the sibling half. Keep the gate OFF-default
+until both halves make the toggle-ON survey green.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -8,6 +8,27 @@ use crate::token_kind::TokenKind;
 use crate::value::Value;
 
 static STATE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// §1.4 shadow-slot activation gate (`MUTSU_SHADOW_SLOTS`).
+///
+/// When set, [`Compiler::declare_local`] gives a shadowing inner-block `my $x`
+/// its **own** fresh local slot (instead of sharing the outer `$x`'s slot) and
+/// [`Compiler::pop_local_scope`] restores the outer binding in `local_map` on
+/// scope exit. The DEFAULT (unset) build is byte-identical: `declare_local`
+/// resolves like `alloc_local` (get-or-create by name), so shadowing correctness
+/// keeps relying on the runtime `BlockScope` env restore.
+///
+/// Activation alone is NOT yet coherent: the name-keyed env store cannot hold two
+/// live `$x` (§1.3 dual-store) and ~80 by-name leaf writebacks resolve to the
+/// outer slot (§1.5 remaining leaf sites). This toggle is the development
+/// substrate the campaign greens slice-by-slice before the default is flipped —
+/// the same env-var-gated pattern the env_dirty campaign used. See
+/// docs/lexical-scope-slot-campaign.md and ANALYSIS.md §1.4.
+fn shadow_slots_active() -> bool {
+    use std::sync::OnceLock;
+    static ACTIVE: OnceLock<bool> = OnceLock::new();
+    *ACTIVE.get_or_init(|| std::env::var_os("MUTSU_SHADOW_SLOTS").is_some())
+}
 mod expr;
 mod expr_binary;
 mod expr_block;
@@ -430,9 +451,50 @@ impl Compiler {
     /// push/pop plumbing and the single declaration entry point — is the substrate
     /// that campaign builds on. See ANALYSIS.md §1.4.
     fn declare_local(&mut self, name: &str) -> u32 {
-        let slot = self.alloc_local(name);
+        if !shadow_slots_active() {
+            // DEFAULT build: behavior-preserving. Resolve like `alloc_local`
+            // (get-or-create by name); a nested `my $x` shares the outer slot.
+            let slot = self.alloc_local(name);
+            if let Some(frame) = self.local_scopes.last_mut() {
+                frame.entry(name.to_string()).or_insert(None);
+            }
+            return slot;
+        }
+        // §1.4 shadow-slot activation (gated by `MUTSU_SHADOW_SLOTS`).
+        //
+        // - Same-scope redeclaration (`my $x; my $x`) reuses the existing slot.
+        // - A name already bound in an ENCLOSING scope is a genuine shadow: give
+        //   it a fresh slot (a second `code.locals` entry with the same name) and
+        //   record the outer slot to restore on scope exit.
+        // - Otherwise it is a first declaration: allocate normally.
+        let in_current_scope = self
+            .local_scopes
+            .last()
+            .is_some_and(|f| f.contains_key(name));
+        if in_current_scope {
+            return *self
+                .local_map
+                .get(name)
+                .expect("current-scope declaration must be in local_map");
+        }
+        let prev = self.local_map.get(name).copied();
+        let slot = if prev.is_some() {
+            let s = self.code.locals.len() as u32;
+            let is_simple = name.starts_with('$')
+                && !name.starts_with("$*")
+                && !name.contains("::")
+                && name != "_"
+                && !name.starts_with('.')
+                && !name.starts_with('!');
+            self.code.locals.push(name.to_string());
+            self.code.simple_locals.push(is_simple);
+            self.local_map.insert(name.to_string(), s);
+            s
+        } else {
+            self.alloc_local(name)
+        };
         if let Some(frame) = self.local_scopes.last_mut() {
-            frame.entry(name.to_string()).or_insert(None);
+            frame.insert(name.to_string(), prev);
         }
         slot
     }
@@ -449,7 +511,23 @@ impl Compiler {
     /// slots, this is where a `Some(prev)` entry will restore the outer binding in
     /// `local_map` (see [`declare_local`]).
     fn pop_local_scope(&mut self) {
-        self.local_scopes.pop();
+        let Some(frame) = self.local_scopes.pop() else {
+            return;
+        };
+        if !shadow_slots_active() {
+            // DEFAULT build: behavior-preserving no-op (frame already dropped).
+            return;
+        }
+        // §1.4 shadow-slot activation: restore the outer binding for every name
+        // this scope shadowed. A `None` entry was a first declaration in this
+        // scope; leave its slot in `local_map` (monotonic, matching the default
+        // build) so a later reference still resolves to a slot and the runtime
+        // `block_declared_vars` machinery keeps enforcing out-of-scope errors.
+        for (name, prev) in frame {
+            if let Some(outer_slot) = prev {
+                self.local_map.insert(name, outer_slot);
+            }
+        }
     }
 
     fn emit_set_named_var(&mut self, name: &str) {

--- a/t/lexical-shadow-slots.t
+++ b/t/lexical-shadow-slots.t
@@ -1,0 +1,43 @@
+use Test;
+
+# §1.4 lexical shadow slots. These pass in the default build (shadowing correct
+# via the runtime BlockScope restore) AND under MUTSU_SHADOW_SLOTS=1 (distinct
+# compile-time slots). They pin the shadow-slot activation machinery in
+# src/compiler/mod.rs (declare_local / pop_local_scope). See
+# docs/lexical-scope-slot-campaign.md.
+
+plan 9;
+
+# Simple one-level shadow: inner `my $x` does not disturb the outer binding.
+my $x = 1;
+{
+    my $x = 2;
+    is $x, 2, 'inner shadow reads its own value';
+    $x++;
+    is $x, 3, 'inner shadow mutation stays inner';
+}
+is $x, 1, 'outer value restored after block';
+
+# Nested shadows: each level has its own binding.
+my $y = 10;
+{
+    my $y = 20;
+    {
+        my $y = 30;
+        is $y, 30, 'innermost shadow';
+    }
+    is $y, 20, 'middle shadow restored after innermost block';
+}
+is $y, 10, 'outermost restored after all blocks';
+
+# Sibling blocks each shadow independently and do not leak between each other.
+my $z = 100;
+{
+    my $z = 1;
+    is $z, 1, 'first sibling shadow';
+}
+{
+    my $z = 2;
+    is $z, 2, 'second sibling shadow independent of the first';
+}
+is $z, 100, 'outer restored after both sibling blocks';


### PR DESCRIPTION
## Summary

Activate the lexical scope stack for **shadow variables** (§1.4) behind an env-var gate `MUTSU_SHADOW_SLOTS`, the same gated pattern the env_dirty campaign used. This is the shadow-side compiler machinery of the §1.4/§1.5/§1.3 lexical-scope campaign; the env↔locals slot-indexing (§1.3) is the sibling half (parallel worker).

**Default (gate off) is byte-identical** — `declare_local` resolves like `alloc_local` (a nested `my $x` shares the outer slot) and `pop_local_scope` is a no-op. The full `t/` suite stays green: `Files=1448, Tests=13994, Failed=0`.

## With `MUTSU_SHADOW_SLOTS=1`

- `declare_local` gives a shadowing inner-block `my $x` its **own fresh slot** (same-scope redeclaration reuses; first declaration allocates normally).
- `pop_local_scope` restores the outer binding in `local_map` on scope exit. First-declaration (`None`) entries stay in `local_map` (monotonic, matching the default build) so the runtime `block_declared_vars` machinery keeps enforcing out-of-scope errors — this avoids the naive flip's `block-lexical-scope.t` breakage.

Simple/nested/sibling shadowing is correct in **both** modes (new pin `t/lexical-shadow-slots.t`, verified passing off and on).

## Why gated, not default-on

An empirical flip measurement (documented in `docs/lexical-scope-slot-campaign.md`) showed a naive default-on flip breaks ~120 `t/` files, confirming ANALYSIS.md §1.4's 調査メモ: shadow-slot activation is coupled to **§1.3** (the name-keyed env dual store cannot hold two live `$x`) and the **§1.5 S10+** leaf writebacks (~80 by-name `update_local_if_exists`/`find_local_slot` callers resolve to the outer slot). The toggle-ON suite is the campaign's burndown surface; the §1.3 half drives the env-coherence failures to zero and S10+ drives the leaf failures to zero, after which the gate default is flipped and the `exec_block_scope_op` whole-`locals` clone is removed.

## Test plan

- `make test` (default, gate off) — green, byte-identical.
- `t/lexical-shadow-slots.t` — passes off **and** on.
- `MUTSU_SHADOW_SLOTS=1 prove t/` — documented baseline (class-1/class-2 breakage), tracked in the campaign doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)