### PR TITLE
fix(vm): implement Buf/Blob index and slice assignment

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -5,8 +5,8 @@
 個々の失敗を片端から潰すためではなく、
 **今どこを直せば何がまとめて動くか**を判断するために使う。
 
-**最終更新 2026-07-02**（§4 真の lazy 配列 / 無限列キャンペーンの
-`S09-subscript/slice.t` 根本原因 6 件を解消・再集計）
+**最終更新 2026-07-03**（§4 `S09-subscript/slice.t` の Buf スライス代入
+[test 31] を解消・再集計）
 
 ## この文書の読み方
 
@@ -225,8 +225,7 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 
 ### 4.1 `S09-subscript/slice.t`
 
-- **現状（2026-07-02 更新）**: 50/56（実行は 56/56 まで完走するようになった。以前は
-  test 39/56 でネスト lazy サブリスト代入の未実装により panic して中断していた）。
+- **現状（2026-07-03 更新）**: 51/56。
 - **今回解決した根本原因**（詳細は `TODO_roast/S09.md` の該当エントリ）:
   1. `:=` bind が `sequence_spec`/`closure_seq`/`lazy_pipe` 系 `LazyList` を
      `coroutine` 以外は強制マテリアライズしていた（`vm_var_assign_set_local.rs`）。
@@ -249,10 +248,22 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
      `SliceKeyTree`（write pass `assign_slice_key_tree` ＋ 代入完了後に再読込して
      nested な返り値を組み立てる `read_slice_key_tree`。重複インデックスは
      「書き込み時点の値」でなく「最終状態」を返すため別パスが必要）で解消。
-- **残り 6 件（laziness とは無関係、それぞれ別機能）**:
+- **2026-07-03 解決**: test 31（Buf スライス代入 `$b[0,1] = 2,3`）。原因は
+  Buf/Blob（`Value::Instance`）に対する index-assign 専用パスが存在せず、
+  汎用フォールバックが「未初期化コンテナ」と誤認して `$b` をハッシュ
+  `{0=>2, 1=>3}` で丸ごと上書きしていたこと。`InstanceAttrs::with_attr_mut`
+  経由で共有 "bytes" セルへ直接書き込む専用分岐を追加（変数の再束縛不要
+  ＝ Buf の identity は共有 attribute cell 側にあるため）。単一 index・
+  スライス双方に対応、値は uint8 ネイティブ配列と同じ mod 256 マスク、
+  範囲外は 0 埋めで自動延伸、immutable な Blob への書き込みは拒否。
+  詳細・テストは `TODO_roast/S09.md` / `t/buf-index-slice-assign.t`。
+- **残り 5 件（laziness とは無関係、それぞれ別機能）**:
   - test 15: `@slice := @array[1,2]; @slice = <A B C D>` で bound slice の
-    固定 arity（余った RHS を捨てる）が未実装。
-  - test 31: Buf スライス代入 (`$b[0,1] = 2,3`) 未実装。
+    固定 arity（余った RHS を捨てる）が未実装。調査済み: 新しい `Value`
+    variant（配列+index list を束ねる slice-view セル）が要る、§3
+    container-identity と同格の本格作業。既存の `ContainerRef`/
+    `HashEntryRef` はどちらも「1 要素」用で、N-index のスライスを表現
+    できない。
   - test 35（62 assertion、18/62 で中断）: ネストインデックスへの slice adverb
     （`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ）— §3 の
     container-identity 領域に属する別の大きな機能。
@@ -262,9 +273,10 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
   - test 56: `@a[**]`（HyperWhatever hammer index）。ローカルの `raku` 自体が
     "not yet implemented. Sorry." を返すため、この環境では参照実装との
     突き合わせ自体ができない。
-- **Next slice**: 残り 6 件は互いに独立した別機能。着手するなら test 35
-  （nested slice adverbs）が最も汎用性が高いが、§3 のコンテナ identity
-  キャンペーンと同根の大仕事。whitelist にはこの 6 件全ての解決が必要。
+- **Next slice**: 残り 5 件は互いに独立した別機能。test 15 は専用 `Value`
+  variant を要する§3 相当の作業として着手するなら本腰を入れる想定。test 35
+  （nested slice adverbs）も同根の大仕事。whitelist にはこの 5 件全ての
+  解決が必要。
 
 ---
 

--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -49,10 +49,20 @@
       to build the nested rvalue, since a duplicate index can be overwritten
       after its own write) in `vm_var_assign_index_named.rs`. New test:
       `t/nested-lazy-slice.t`.
-  - **Remaining failures (6/56, unrelated to laziness):**
+  - **2026-07-03: Test 31 fixed.** `$b[i] = v` / `$b[i,j] = v,w` on a Buf fell
+    through the generic index-assign catch-all, which treated the `Buf`
+    `Instance` as an uninitialized container and silently replaced it with a
+    plain Array/Hash (`{0 => 2, 1 => 3}`) instead of mutating its bytes.
+    Added a dedicated Buf/Blob branch in `exec_index_assign_expr_named_op_inner`
+    (`vm_var_assign_index_named.rs`) that writes through `InstanceAttrs::with_attr_mut`
+    on the shared "bytes" array — no variable rebind needed, since Buf identity
+    lives in the shared attribute cell. Handles both single-index and slice
+    assignment, byte-masks values mod 256 (matching native uint8 array
+    semantics), autoextends with zero fill, and rejects writes to immutable
+    Blob. New test: `t/buf-index-slice-assign.t`.
+  - **Remaining failures (5/56, unrelated to laziness):**
     - Test 15: `@slice := @array[1,2]; @slice = <A B C D>` should discard the
       extra 2 RHS items (bound-slice fixed arity), returns all 4 instead.
-    - Test 31: Buf slice assignment (`$b[0,1] = 2,3`) not implemented.
     - Test 35 (62 sub-assertions, aborts at 18/62): slice adverbs (`:p`, `:k`,
       `:v`, `:kv`, `:exists`, `:delete`, combinations) on a nested-list index —
       a distinct, large feature (container-identity §3 territory).

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -444,6 +444,81 @@ impl Interpreter {
                 return Err(RuntimeError::typed("X::Assignment::RO", attrs));
             }
         }
+        // Buf/Blob element and slice assignment (`$b[i] = v` / `$b[i,j] = v,w`):
+        // mutate the underlying "bytes" array in place through the instance's
+        // shared attribute cell. Buf identity lives in that cell (not the
+        // variable slot it happens to be stored in), so no `env_root_descended_mut`
+        // rebind is needed — a `with_attr_mut` write is visible to every alias.
+        // `:=`-binding to a Buf index is not handled here (falls through to the
+        // generic path below, unchanged from before this fix).
+        if !bind_mode
+            && let Some(Value::Instance {
+                attributes,
+                class_name,
+                ..
+            }) = self.env().get(&var_name)
+        {
+            let cn = class_name.resolve();
+            if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                if crate::runtime::utils::is_blob_like_class(&cn) {
+                    return Err(RuntimeError::assignment_ro(Some("Blob")));
+                }
+                let attributes = attributes.clone();
+                if let Value::Array(keys, ..) = &idx {
+                    let vals = self.assignment_rhs_values(&val)?;
+                    let indices = keys
+                        .iter()
+                        .map(|k| {
+                            Self::index_to_usize(k)
+                                .ok_or_else(|| RuntimeError::new("Index out of range"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let max_idx = indices.iter().copied().max().unwrap_or(0);
+                    let mut resize_err = None;
+                    let mut assigned = Vec::new();
+                    attributes.with_attr_mut("bytes", |bytes_val| {
+                        if let Value::Array(items, ..) = bytes_val {
+                            let arr = Arc::make_mut(items);
+                            if let Err(e) = Self::autoviv_resize(arr, max_idx + 1, Value::Int(0)) {
+                                resize_err = Some(e);
+                                return;
+                            }
+                            for (i, &pos) in indices.iter().enumerate() {
+                                let v = vals.get(i).cloned().unwrap_or(Value::Nil);
+                                let byte = crate::runtime::to_int(&v) & 0xff;
+                                arr[pos] = Value::Int(byte);
+                                assigned.push(Value::Int(byte));
+                            }
+                        }
+                    });
+                    if let Some(e) = resize_err {
+                        return Err(e);
+                    }
+                    self.stack.push(Value::array(assigned));
+                    return Ok(());
+                } else if let Some(pos) = Self::index_to_usize(&idx) {
+                    let byte = crate::runtime::to_int(&val) & 0xff;
+                    let mut resize_err = None;
+                    attributes.with_attr_mut("bytes", |bytes_val| {
+                        if let Value::Array(items, ..) = bytes_val {
+                            let arr = Arc::make_mut(items);
+                            if let Err(e) = Self::autoviv_resize(arr, pos + 1, Value::Int(0)) {
+                                resize_err = Some(e);
+                                return;
+                            }
+                            arr[pos] = Value::Int(byte);
+                        }
+                    });
+                    if let Some(e) = resize_err {
+                        return Err(e);
+                    }
+                    self.stack.push(val);
+                    return Ok(());
+                } else {
+                    return Err(RuntimeError::new("Index out of range"));
+                }
+            }
+        }
         let encoded_idx = Self::encode_bound_index(&idx);
         // Slice 2b: is the existing element a `=` value share (`@aoa[i] = @row`)?
         // A non-bind reassignment to such an element REPLACES the shared cell

--- a/t/buf-index-slice-assign.t
+++ b/t/buf-index-slice-assign.t
@@ -1,0 +1,53 @@
+use Test;
+
+# `$b[i] = v` and `$b[i,j] = v,w` on a Buf were both broken: the generic
+# index-assign fallback treated the Buf `Instance` as an uninitialized
+# container and silently replaced it with a plain Array/Hash instead of
+# mutating its underlying byte storage (roast S09-subscript/slice.t test 31,
+# "can assign to a Buf slice").
+
+plan 10;
+
+{
+    my $b = Buf.new(0, 0, 0);
+    $b[0] = 5;
+    is-deeply $b, Buf.new(5, 0, 0), 'single-index assignment mutates the Buf';
+}
+
+{
+    my $b = Buf.new(0, 0);
+    $b[0, 1] = 2, 3;
+    is-deeply $b, Buf.new(2, 3), 'can assign to a Buf slice';
+}
+
+{
+    # byte-masking: values are wrapped mod 256, like a native uint8 array.
+    my $b = Buf.new(0, 0);
+    is ($b[0] = 300), 300, 'single-index assignment expression yields the original value';
+    is-deeply $b, Buf.new(44, 0), 'single-index assignment masks the stored byte to 0..255';
+}
+
+{
+    my $b = Buf.new(0, 0);
+    is-deeply ($b[0, 1] = 300, -1), (44, 255), 'slice assignment expression yields masked bytes';
+    is-deeply $b, Buf.new(44, 255), 'slice assignment masks each stored byte to 0..255';
+}
+
+{
+    # out-of-bounds indices autoextend with zero fill, like a native array.
+    my $b = Buf.new(0, 0);
+    $b[4] = 9;
+    is-deeply $b, Buf.new(0, 0, 0, 0, 9), 'single-index assignment autoextends with zero fill';
+}
+
+{
+    my $b = Buf.new(0, 0);
+    $b[3, 4] = 7, 8;
+    is-deeply $b, Buf.new(0, 0, 0, 7, 8), 'slice assignment autoextends with zero fill';
+}
+
+{
+    my $b = Blob.new(1, 2, 3);
+    dies-ok { $b[0] = 9 }, 'single-index assignment to an immutable Blob dies';
+    dies-ok { $b[0, 1] = 9, 8 }, 'slice assignment to an immutable Blob dies';
+}


### PR DESCRIPTION
## Summary
- `$b[i] = v` and `$b[i,j] = v,w` on a `Buf` fell through the generic index-assign catch-all, which treated the `Buf` `Instance` as an uninitialized container and silently replaced it with a plain Array/Hash instead of mutating its bytes.
- Adds a dedicated Buf/Blob branch in `exec_index_assign_expr_named_op_inner` that writes through `InstanceAttrs::with_attr_mut` on the shared "bytes" array — no variable rebind needed, since Buf identity lives in the shared attribute cell.
- Handles both single-index and slice assignment, masks values mod 256 (matching native uint8 array semantics), autoextends with zero fill, and rejects writes to an immutable `Blob`.
- Fixes `roast/S09-subscript/slice.t` test 31 ("can assign to a Buf slice"), part of `TODO_roast/BLOCKERS.md` §4.

## Test plan
- [x] New `t/buf-index-slice-assign.t` (10 assertions), verified against real `raku` first
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S09-subscript/slice.t` — failures reduced from 6 to 5 (remaining: test 15, 35, 54-56, unrelated pre-existing gaps)
- [x] `make test` — all green
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK