### PR TITLE
refactor(compiler): bake undefine($scalar) local slot (§1.4 shadow leaf)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -223,3 +223,37 @@ is flipped and the `exec_block_scope_op` whole-`locals` clone is removed.
 **Task split:** this branch owns the shadow-side compiler machinery (declare/pop);
 the env↔locals slot-indexing (§1.3) is the sibling half. Keep the gate OFF-default
 until both halves make the toggle-ON survey green.
+
+## §1.4 toggle-ON roast survey (2026-07-03, debug, full whitelist 1345)
+
+`MUTSU_SHADOW_SLOTS=1 MUTSU_BIN=target/debug/mutsu prove -e scripts/run-roast-test.sh
+$(cat roast-whitelist.txt)` → **102 files fail**; re-running only those 102 with the
+gate OFF, **19 also fail** (flaky / pre-existing) leaving **83 genuine toggle-ON
+regressions**. Every regression involves a variable actually shadowing an enclosing
+same-name binding (non-shadowed `my $x` is byte-identical even ON, since
+`declare_local` first-declaration → `alloc_local` and `pop` leaves `None` entries).
+By synopsis: S32 16, S17 14, S02 14, S04 12, S03 10, S06 5, S09 4, misc 8. Root-cause
+classes and the burndown owner:
+
+- **class-2 leaf writeback (this campaign, bakeable — prefer the compile-time slot):**
+  - `undefine($scalar)` → the rewrite hand-emitted `AssignExpr(name)`; **fixed** by
+    `emit_undefine_scalar_store` preferring `AssignExprLocal(slot)` like the general
+    assign path (`roast/S32-scalar/defined.t` #31 now green ON). *(done, this branch)*
+  - `let`/`temp` restore (`S04-.../let.t`, `temp.t`): the scope-exit restore resolves
+    the saved var by name → outer slot. Next leaf slice.
+  - rw-arg writeback (`S06-traits/is-rw.t`, `lvalue-subroutines.t`, `substr-rw.t`):
+    `pending_rw_writeback_sources` by name.
+  - hyper / metaop writeback (`S03-metaops/cross.t`, `zip.t`, `reverse.t`,
+    `eager-hyper.t`): `write_back` target resolved by name.
+  - for-loop rw / quanthash `.value`/`.kv` writeback (`S04-statements/for.t`,
+    `S32-array/delete-adverb*.t`).
+- **class-1 env↔locals dual store (§1.3, sibling half):** the name-keyed env cannot
+  hold two live `$x`. Dominates S17 concurrency (shared-var writeback across threads:
+  `S17-supply/*`, `S17-scheduler/*`, `Channel.t`, `lock.t`) and S02 aggregate
+  writeback (`hash.t`, `set.t`, `baghash.t`, `capture.t`, `pair.t`). Not bakeable by
+  a single compile-time slot; needs slot-indexed locals.
+
+**Plan:** burn down class-2 leaves one slot-bake PR at a time (each behavior-
+preserving with the gate off, verified by the toggle-ON roast file flipping green);
+class-1 is unblocked only by the §1.3 half. Flip the gate default and drop the
+`exec_block_scope_op` `locals.clone()` once the toggle-ON whitelist survey is green.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -2,6 +2,22 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Compiler {
+    /// Emit the store half of `undefine($scalar)` (`$scalar = Any`, value already
+    /// on the stack). Prefers the compile-time-baked `AssignExprLocal(slot)` when
+    /// the name resolves to a local — mirroring the general assignment path in
+    /// `compile_expr_assign` — so a shadowing inner-block `my $x` writes to its own
+    /// slot instead of the by-name `AssignExpr` resolving to the outer slot (§1.4
+    /// shadow-slot leaf, ANALYSIS.md §1.4; `roast/S32-scalar/defined.t` #31). With
+    /// shadow slots off this is byte-equivalent (the shadow shares the outer slot).
+    fn emit_undefine_scalar_store(&mut self, vname: &str) {
+        if let Some(&slot) = self.local_map.get(vname) {
+            self.code.emit(OpCode::AssignExprLocal(slot));
+        } else {
+            let name_idx = self.code.add_constant(Value::str(vname.to_string()));
+            self.code.emit(OpCode::AssignExpr(name_idx));
+        }
+    }
+
     pub(super) fn compile_expr_call(&mut self, name: &Symbol, args: &[Expr]) {
         // (state $x) = expr  /  (state @x) = expr  /  (state %x) = expr
         // The parser emits __mutsu_assign_callable_lvalue(DoStmt(VarDecl{..}), [], rhs).
@@ -475,8 +491,7 @@ impl Compiler {
                             .code
                             .add_constant(Value::Package(crate::symbol::Symbol::intern("Any")));
                         self.code.emit(OpCode::LoadConst(any_idx));
-                        let name_idx = self.code.add_constant(Value::str(vname));
-                        self.code.emit(OpCode::AssignExpr(name_idx));
+                        self.emit_undefine_scalar_store(&vname);
                     }
                     return;
                 }
@@ -509,8 +524,7 @@ impl Compiler {
                         .code
                         .add_constant(Value::Package(crate::symbol::Symbol::intern("Any")));
                     self.code.emit(OpCode::LoadConst(any_idx));
-                    let name_idx = self.code.add_constant(Value::str(vname));
-                    self.code.emit(OpCode::AssignExpr(name_idx));
+                    self.emit_undefine_scalar_store(&vname);
                 }
             } else if matches!(&args[0], Expr::Index { target, .. } if matches!(**target, Expr::HashVar(_) | Expr::ArrayVar(_) | Expr::Var(_)))
             {

--- a/t/undefine-shadow-slot.t
+++ b/t/undefine-shadow-slot.t
@@ -1,0 +1,24 @@
+use Test;
+
+# §1.4 shadow-slot leaf: `undefine($x)` on a variable that shadows an enclosing
+# same-name binding must clear the inner (live) binding, not the outer one. The
+# undefine rewrite now prefers the compile-time-baked local slot
+# (AssignExprLocal) like the general assignment path. Passes with the shadow-slot
+# gate off (shadow shares the outer slot) AND on (distinct slots). Mirrors
+# roast/S32-scalar/defined.t #31. See docs/lexical-scope-slot-campaign.md.
+
+plan 4;
+
+my $foo = 42;
+{
+    my $foo = "inner";
+    undefine($foo);
+    ok !$foo.defined, 'undefine clears the inner shadow';
+}
+ok $foo.defined, 'outer binding untouched by inner undefine';
+is $foo, 42, 'outer value intact';
+
+# undefine on a non-shadowed variable still works.
+my $bar = 7;
+undefine($bar);
+ok !$bar.defined, 'undefine on a plain (non-shadowed) scalar';


### PR DESCRIPTION
## Summary

First §1.4 shadow-slot **leaf burndown** slice on top of the gated activation (#4083).

`undefine($foo)` is rewritten to `$foo = Any`, but its store half hand-emitted the by-name `AssignExpr(name)` instead of the slot-preferring path the general assignment (`compile_expr_assign`) already uses. Under `MUTSU_SHADOW_SLOTS=1`, when the target shadows an enclosing same-name binding, the by-name resolver finds the **outer** (first) `code.locals` slot, so undefine cleared the wrong binding.

New `emit_undefine_scalar_store` prefers `AssignExprLocal(slot)` when the name resolves to a local, falling back to `AssignExpr(name)` for globals/dynamics. With shadow slots off this is **byte-equivalent** (the shadow shares the outer slot); with them on it writes the inner slot.

Concretely fixes `roast/S32-scalar/defined.t` #31 under the toggle (the block-local `my Mu $foo` shadows the mainline `my $foo`, and `undefine($foo)` inside a nested block must clear the inner one).

## Investigation recorded

`docs/lexical-scope-slot-campaign.md` now has the full toggle-ON roast survey: **102 whitelist files fail with `MUTSU_SHADOW_SLOTS=1`; 19 are flaky/pre-existing (also fail off), leaving 83 genuine regressions**, categorized:
- **class-2 leaf writeback** (this campaign, bakeable): undefine *(fixed here)*, `let`/`temp` restore, rw-arg (`is-rw`, `substr-rw`, lvalue-subs), hyper/metaop (`cross`/`zip`/`reverse`), for-loop rw / quanthash.
- **class-1 env↔locals dual store** (§1.3 sibling half): S17 concurrency + S02 aggregate writeback — not bakeable by a single slot; needs slot-indexed locals.

## Test plan

- `make test` (default, gate off): **PASS**, Files=1449, Failed=0.
- `t/undefine-shadow-slot.t`: new pin, passes **off and on**.
- `roast/S32-scalar/defined.t` under `MUTSU_SHADOW_SLOTS=1`: #31 now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)