### PR TITLE
refactor(vm): bake temp/let restore local slot (§1.4 shadow leaf)

### DIFF
--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -174,11 +174,13 @@ impl Compiler {
     /// Emit a `temp` save for the named scalar variable: its current value is
     /// pushed onto the let-saves stack and restored at the enclosing scope's exit.
     fn emit_temp_save(&mut self, var: &str) {
+        let slot = self.local_map.get(var).copied();
         let name_idx = self.code.add_constant(Value::str(var.to_string()));
         self.code.emit(OpCode::LetSave {
             name_idx,
             index_mode: false,
             is_temp: true,
+            slot,
         });
     }
 }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3006,6 +3006,14 @@ impl Compiler {
                 // Emit LetSave: saves current value of the variable
                 let name_idx = self.code.add_constant(Value::str(name.clone()));
                 let has_index = index.is_some();
+                // Bake the scalar's slot for the scope-exit restore (§1.4/§1.5).
+                // Index mode (`temp @a[$i]`) restores a container ELEMENT, not the
+                // named variable's slot, so keep the by-name path there.
+                let slot = if has_index {
+                    None
+                } else {
+                    self.local_map.get(name).copied()
+                };
                 if let Some(idx_expr) = index {
                     self.compile_expr(idx_expr);
                 }
@@ -3013,6 +3021,7 @@ impl Compiler {
                     name_idx,
                     index_mode: has_index,
                     is_temp: *is_temp,
+                    slot,
                 });
                 // Compile the assignment if value is provided
                 if let Some(val_expr) = value {
@@ -3046,11 +3055,13 @@ impl Compiler {
                 method_args,
                 value,
             } => {
+                let slot = self.local_map.get(var_name).copied();
                 let name_idx = self.code.add_constant(Value::str(var_name.clone()));
                 self.code.emit(OpCode::LetSave {
                     name_idx,
                     index_mode: false,
                     is_temp: true,
+                    slot,
                 });
                 let assign_expr = Expr::Call {
                     name: Symbol::intern("__mutsu_assign_method_lvalue"),

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1363,6 +1363,11 @@ pub(crate) enum OpCode {
         name_idx: u32,
         index_mode: bool,
         is_temp: bool,
+        /// Compiler-baked local slot for the saved variable (§1.4/§1.5): the
+        /// scope-exit restore writes `locals[slot]` directly instead of resolving
+        /// the name via `find_local_slot` (position = OUTER slot, wrong for a live
+        /// inner shadow). `None` for a non-local target (falls back to by-name).
+        slot: Option<u32>,
     },
 
     /// Block with `let` scope management. Executes body, then checks

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -223,19 +223,25 @@ impl Interpreter {
 
     /// Push a saved variable value for `let`/`temp` scope management.
     /// `is_temp`: true for `temp` (always restore), false for `let` (restore on failure only).
-    pub(crate) fn let_saves_push(&mut self, name: String, value: Value, is_temp: bool) {
+    pub(crate) fn let_saves_push(
+        &mut self,
+        name: String,
+        value: Value,
+        is_temp: bool,
+        slot: Option<u32>,
+    ) {
         // Take an independent snapshot: an instance value must be deep-copied so
         // a later in-place mutation through its shared cell does not corrupt the
         // saved-for-restore value (Phase 3, Stage 1).
         self.let_saves
-            .push((name, value.into_temp_snapshot(), is_temp));
+            .push((name, value.into_temp_snapshot(), is_temp, slot));
     }
 
     /// Restore one `let`/`temp` save. For an instance, write the saved
     /// attributes back into the *live* shared cell of the variable's current
     /// binding so every alias sees the restoration and object identity (id +
     /// cell) is preserved, rather than rebinding the name to a detached copy.
-    fn restore_let_value(&mut self, name: String, restored: Value) {
+    fn restore_let_value(&mut self, name: String, restored: Value, slot: Option<u32>) {
         // A boxed (shared-cell) binding: write the restored value THROUGH the live
         // cell so the owner's local slot (which holds the same Arc) sees the
         // restoration, rather than replacing the env entry with a detached plain
@@ -248,15 +254,28 @@ impl Interpreter {
             arc.lock().unwrap().clone_from(&restored);
             return;
         }
-        // Non-cell restore writes the saved value into `env` by name only; record
-        // it so the block-exit op refreshes the owning local slot precisely
-        // (`apply_pending_rw_writeback`) instead of relying on the blanket
-        // env→locals pull (env_dirty-removal substrate). The owner is usually this
-        // same frame (a bare `{ temp $x = … }` block), but a `temp`/`let` inside a
-        // nested callee owns the slot a frame up — record on both the drop-on-miss
-        // and retain-on-miss lists so either reaches it.
-        self.pending_rw_writeback_sources.push(name.clone());
-        self.record_caller_var_writeback(&name);
+        // §1.4/§1.5: when the compiler baked THIS frame's slot for `name`, write it
+        // directly so a live INNER shadow is restored — not the OUTER slot that a
+        // by-name `find_local_slot` (position) would pick. A baked slot means the
+        // name is a local of the current routine frame (its owner IS this frame),
+        // so the caller-frame writeback machinery is unnecessary. With the shadow
+        // gate OFF the baked slot equals the single (position) slot, so this is
+        // byte-identical to the old by-name drain, just applied at restore time.
+        //
+        // Non-cell restore also writes the saved value into `env` by name (below)
+        // for by-name readers. With NO baked slot (a non-local target, or a
+        // `temp`/`let` whose owner is a caller frame) fall back to the name-based
+        // `pending_rw_writeback` drain, recording both the drop-on-miss and
+        // retain-on-miss lists so either reaches the owning frame's slot.
+        match slot {
+            Some(s) if (s as usize) < self.locals.len() => {
+                self.locals[s as usize] = restored.clone();
+            }
+            _ => {
+                self.pending_rw_writeback_sources.push(name.clone());
+                self.record_caller_var_writeback(&name);
+            }
+        }
         if let Value::Instance {
             attributes: saved_attrs,
             ..
@@ -298,9 +317,9 @@ impl Interpreter {
     /// Restore all variables from let_saves starting at `mark`, then truncate.
     pub(crate) fn restore_let_saves(&mut self, mark: usize) {
         for i in (mark..self.let_saves.len()).rev() {
-            let (name, old_val, _is_temp) = self.let_saves[i].clone();
+            let (name, old_val, _is_temp, slot) = self.let_saves[i].clone();
             let restored = self.resolve_restore_value(&name, &old_val);
-            self.restore_let_value(name, restored);
+            self.restore_let_value(name, restored, slot);
         }
         self.let_saves.truncate(mark);
     }
@@ -309,20 +328,20 @@ impl Interpreter {
     /// For `let`, only restore if the block returned an unsuccessful value.
     pub(crate) fn resolve_let_saves_on_success(&mut self, mark: usize, success: bool) {
         // Collect restore actions first to avoid borrow conflicts.
-        let restores: Vec<(String, Value)> = (mark..self.let_saves.len())
+        let restores: Vec<(String, Value, Option<u32>)> = (mark..self.let_saves.len())
             .rev()
             .filter_map(|i| {
-                let (ref name, ref old_val, is_temp) = self.let_saves[i];
+                let (ref name, ref old_val, is_temp, slot) = self.let_saves[i];
                 if is_temp || !success {
-                    Some((name.clone(), old_val.clone()))
+                    Some((name.clone(), old_val.clone(), slot))
                 } else {
                     None
                 }
             })
             .collect();
-        for (name, old_val) in restores {
+        for (name, old_val, slot) in restores {
             let restored = self.resolve_restore_value(&name, &old_val);
-            self.restore_let_value(name, restored);
+            self.restore_let_value(name, restored, slot);
         }
         self.let_saves.truncate(mark);
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1274,7 +1274,11 @@ pub struct Interpreter {
     /// so the lock never contends across threads. Collapses to a plain VM field
     /// once the Interpreter execution path is removed (PLAN.md ④/⑤).
     instance_type_metadata: Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>,
-    let_saves: Vec<(String, Value, bool)>,
+    /// `let`/`temp` save stack: (name, saved value, is_temp, compiler-baked slot).
+    /// The baked slot (§1.4/§1.5) lets the scope-exit restore write `locals[slot]`
+    /// directly instead of resolving the name to the OUTER slot via
+    /// `find_local_slot`. `None` for a non-local target (by-name fallback).
+    let_saves: Vec<(String, Value, bool, Option<u32>)>,
     pub(super) supply_emit_buffer: Vec<Vec<Value>>,
     pub(super) supply_emit_timed_buffer: Vec<Vec<(Value, std::time::Instant)>>,
     /// Active streaming consumers for on-demand `supply { ... }` bodies driven by

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3917,8 +3917,9 @@ impl Interpreter {
                 name_idx,
                 index_mode,
                 is_temp,
+                slot,
             } => {
-                self.exec_let_save_op(code, *name_idx, *index_mode, *is_temp);
+                self.exec_let_save_op(code, *name_idx, *index_mode, *is_temp, *slot);
                 *ip += 1;
             }
             OpCode::LetBlock { body_end } => {

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -262,6 +262,7 @@ impl Interpreter {
         name_idx: u32,
         index_mode: bool,
         is_temp: bool,
+        slot: Option<u32>,
     ) {
         let name = Self::const_str(code, name_idx).to_string();
         if index_mode {
@@ -294,7 +295,7 @@ impl Interpreter {
         } else {
             old_val
         };
-        self.let_saves_push(name, save_val, is_temp);
+        self.let_saves_push(name, save_val, is_temp, slot);
     }
 
     /// Recursively deep-copy a Value so that Array/Hash snapshots are

--- a/t/lexical-scope-slot-writeback.t
+++ b/t/lexical-scope-slot-writeback.t
@@ -7,7 +7,7 @@ use Test;
 # the runtime env restore; the compiler-slot rework is deferred — see the note in
 # ANALYSIS.md §1.4. These cases guard against regressing the observable behavior.)
 
-plan 8;
+plan 10;
 
 # --- shadow read correctness ---
 {
@@ -46,4 +46,15 @@ plan 8;
     my $n = 5;
     { my $n = 100; $n++; is $n, 101, 'post-increment hits inner shadow'; }
     is $n, 5, 'outer $n untouched by inner ++';
+}
+
+# --- temp restore through a shadow hits the INNER slot ---
+# (regression: the scope-exit restore resolved the name -> outer slot)
+{
+    my $t = 1;
+    {
+        my $t = 10;
+        { temp $t = 99; is $t, 99, 'temp assigns the inner shadow slot'; }
+        is $t, 10, 'temp restore targets the inner (live) shadow slot';
+    }
 }


### PR DESCRIPTION
§1.4 shadow-slot activation campaign — a class-2 leaf writeback slot-bake (gated behind `MUTSU_SHADOW_SLOTS`, default OFF = byte-identical).

## Problem
`temp $x` / `let $x` restore their target at scope exit via `restore_let_value`, which pushed the name to `pending_rw_writeback_sources` and drained it through `find_local_slot` → `position` (the OUTER slot). Under `MUTSU_SHADOW_SLOTS=1`, a `temp $x` inside a shadow block restored the outer `$x`, leaving the live inner shadow slot stale:
```raku
my $t = 1;
{ my $t = 10; { temp $t = 99; } say $t }  # was 99, raku says 10
```

## Fix
Bake the scalar's slot into the `LetSave` opcode (from `local_map` at emit time), thread it through the `let_saves` stack `(name, value, is_temp, slot)` to `restore_let_value`, and write `self.locals[slot]` directly. `None` — a non-local target, or a `temp`/`let` whose owner is a caller frame (dynamic `$*x`), or `temp @a[$i]` element mode — keeps the by-name `pending_rw_writeback` path. Same pattern as S5/S7.

## Testing
- **Gate OFF (default/CI):** the baked slot equals the single by-name slot, so byte-identical — `make test` green.
- **Gate ON:** `temp`-in-shadow now matches `raku`; guard added to `t/lexical-scope-slot-writeback.t` (plan 8 → 10). `let-temp.t`, `let-temp-restore-writeback-coherence.t`, `temp-scope-restore.t` pass under both flags. temp-in-sub (dynamic var) and array-temp restore verified against raku.
- `cargo clippy -- -D warnings` / `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)