### PR TITLE
fix(vm): bound array slice has fixed arity, writes through to source

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -225,7 +225,7 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 
 ### 4.1 `S09-subscript/slice.t`
 
-- **現状（2026-07-03 更新）**: 51/56。
+- **現状（2026-07-03 更新）**: 52/56。
 - **今回解決した根本原因**（詳細は `TODO_roast/S09.md` の該当エントリ）:
   1. `:=` bind が `sequence_spec`/`closure_seq`/`lazy_pipe` 系 `LazyList` を
      `coroutine` 以外は強制マテリアライズしていた（`vm_var_assign_set_local.rs`）。
@@ -257,13 +257,40 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
   スライス双方に対応、値は uint8 ネイティブ配列と同じ mod 256 マスク、
   範囲外は 0 埋めで自動延伸、immutable な Blob への書き込みは拒否。
   詳細・テストは `TODO_roast/S09.md` / `t/buf-index-slice-assign.t`。
-- **残り 5 件（laziness とは無関係、それぞれ別機能）**:
-  - test 15: `@slice := @array[1,2]; @slice = <A B C D>` で bound slice の
-    固定 arity（余った RHS を捨てる）が未実装。調査済み: 新しい `Value`
-    variant（配列+index list を束ねる slice-view セル）が要る、§3
-    container-identity と同格の本格作業。既存の `ContainerRef`/
-    `HashEntryRef` はどちらも「1 要素」用で、N-index のスライスを表現
-    できない。
+- **2026-07-03 解決**: test 15（bound slice の固定 arity
+  `@slice := @array[1,2]; @slice = <A B C D>` → "A B"）。当初は §3
+  container-identity 相当の新 `Value` variant が要ると見積もったが、
+  **既存の per-element `ContainerRef` cell 機構を再利用するだけで済んだ**
+  （新 variant 不要）:
+  1. コンパイラ（`stmt.rs`）: `@`-sigil の VarDecl bind の RHS が
+     `Expr::Index{is_positional:true,..}`（単一/スライス問わず）のときも
+     `scalar_bind_autovivify`+`bind_terminal` を立てて autovivify-lazy 経路
+     へ通す（従来は `$`-sigil の要素 bind のみ対象だった）。
+  2. VM（`vm_var_index_ops.rs`）: `exec_index_autovivify_lazy_op` の
+     `terminal` 分岐に、index が単一 int でなく Array/Seq/Slip（スライス）
+     の場合の枝を追加。各インデックスを既存の `array_slot_ref(idx, true)`
+     で個別に `ContainerRef` セルへ昇格し、それらセルを要素に持つだけの
+     **プレーンな** `Value::Array` を bind 結果として返す（セル自体は
+     1 要素用のままで、スライスは「セルを持つ配列」という組み合わせで表現）。
+  3. VM（`vm_var_assign_local.rs` / `vm_var_assign_set_local.rs`）:
+     `@`-sigil ローカルへの**丸ごと**代入（式/文の両方）で、現在値が
+     「要素に `ContainerRef` を含む配列」なら、コンテナを置き換えるのでなく
+     **自身の要素数に固定されたまま**各セルへ write-through する新分岐を追加
+     （余った RHS は破棄、不足分は `Any` 埋め）。`@`-sigil ローカルは
+     `code.simple_locals[idx]` が常に `false`（`$`-sigil 専用フラグ）なので、
+     この分岐は各関数の「fast path」でなく「slow path」側に置く必要がある
+     （最初 fast path に書いて到達しないバグを踏んだ — 教訓として記録）。
+  4. 副次修正（`vm_var_assign_set_local.rs`）: 上記 2 で単一 index の
+     container-valued leaf（例 `@x := @array[2]`、要素が Array/Hash 自体）
+     を bind すると `ContainerRef` セルが返るようになった結果、VarDecl bind
+     の既存 Positional 型チェックが `raw_popped` を decont せずに
+     `Value::ContainerRef` を弾いて `X::TypeCheck::Binding` を誤発生
+     （既存の別バグを誘発）。`raw_popped.deref_container()` してから
+     判定するよう修正——ついでに `@x := @array[2]; @x = 5,6;` が `@array`
+     へ書き戻らない**既存の**バグも解消（`docs/container-identity.md` の
+     Phase 2 系とは独立した bind-time 経路の穴だった）。
+  新規テスト: `t/bound-array-slice-arity.t`。
+- **残り 4 件（laziness とは無関係、それぞれ別機能）**:
   - test 35（62 assertion、18/62 で中断）: ネストインデックスへの slice adverb
     （`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ）— §3 の
     container-identity 領域に属する別の大きな機能。
@@ -273,10 +300,9 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
   - test 56: `@a[**]`（HyperWhatever hammer index）。ローカルの `raku` 自体が
     "not yet implemented. Sorry." を返すため、この環境では参照実装との
     突き合わせ自体ができない。
-- **Next slice**: 残り 5 件は互いに独立した別機能。test 15 は専用 `Value`
-  variant を要する§3 相当の作業として着手するなら本腰を入れる想定。test 35
-  （nested slice adverbs）も同根の大仕事。whitelist にはこの 5 件全ての
-  解決が必要。
+- **Next slice**: 残り 4 件は互いに独立した別機能。test 35（nested slice
+  adverbs）が最も汎用性が高いが §3 container-identity 相当の大仕事。
+  whitelist にはこの 4 件全ての解決が必要。
 
 ---
 

--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -60,9 +60,28 @@
     assignment, byte-masks values mod 256 (matching native uint8 array
     semantics), autoextends with zero fill, and rejects writes to immutable
     Blob. New test: `t/buf-index-slice-assign.t`.
-  - **Remaining failures (5/56, unrelated to laziness):**
-    - Test 15: `@slice := @array[1,2]; @slice = <A B C D>` should discard the
-      extra 2 RHS items (bound-slice fixed arity), returns all 4 instead.
+  - **2026-07-03: Test 15 fixed.** `@slice := @array[1,2]; @slice = <A B C D>`
+    must discard the extra 2 RHS items (bound-slice fixed arity) and write
+    through to `@array`, returning `"A B"`. Reused the existing per-element
+    `ContainerRef` cell mechanism instead of adding a new `Value` variant:
+    (1) the compiler (`stmt.rs`) now routes an `@`-sigil VarDecl bind whose
+    RHS is `Expr::Index` (single OR slice) through the same
+    `scalar_bind_autovivify`+`bind_terminal` machinery a scalar element bind
+    already used; (2) `exec_index_autovivify_lazy_op`
+    (`vm_var_index_ops.rs`) gained a slice branch that promotes each index to
+    its own cell via the existing `array_slot_ref` and returns a plain Array
+    holding those cells; (3) whole-array assignment to such a local
+    (`vm_var_assign_local.rs` / `vm_var_assign_set_local.rs`) now detects an
+    array whose elements are cells and writes through each one bounded by
+    its own length, instead of replacing the container — extra RHS
+    discarded, missing RHS padded with `Any`. Also fixed a latent bug this
+    surfaced: a single-index container-valued-leaf bind (`@x := @array[2]`)
+    now correctly returns a `ContainerRef`, which needed a decont fix in the
+    VarDecl bind's Positional type check (`vm_var_assign_set_local.rs`) —
+    this also fixes `@x := @array[2]; @x = 5,6;` not writing back to
+    `@array` (pre-existing, independent of the container-identity Phase 2
+    campaign). New test: `t/bound-array-slice-arity.t`.
+  - **Remaining failures (4/56, unrelated to laziness):**
     - Test 35 (62 sub-assertions, aborts at 18/62): slice adverbs (`:p`, `:k`,
       `:v`, `:kv`, `:exists`, `:delete`, combinations) on a nested-list index —
       a distinct, large feature (container-identity §3 territory).

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1014,7 +1014,17 @@ impl Compiler {
                     self.code.emit(OpCode::GetOurVar(idx));
                 } else if self.bind_vardecl
                     && (!name.starts_with('@') && !name.starts_with('%')
-                        || Self::is_simple_var_expr(expr))
+                        || Self::is_simple_var_expr(expr)
+                        // `my @slice := @array[1,2]` (an `@`-sigil bind to an
+                        // array index/slice expression) must promote each
+                        // indexed element to a shared `ContainerRef` cell —
+                        // same autovivify-lazy + terminal machinery as a
+                        // scalar element bind (`$x := @a[1]`) — so that a
+                        // later whole-array assignment (`@slice = ...`)
+                        // writes through the source array at a FIXED arity
+                        // instead of snapshotting a disconnected copy.
+                        || (name.starts_with('@')
+                            && matches!(expr, Expr::Index { is_positional: true, .. })))
                 {
                     // `:=` binding for VarDecl: use compile_call_arg so WrapVarRef
                     // is emitted and the VM can set up aliases.  For @/% targets,

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -150,6 +150,38 @@ impl Interpreter {
         let raw_val = self.stack.pop().unwrap_or(Value::Nil);
         let name = &code.locals[idx];
         self.check_readonly_for_modify(name)?;
+        // Bound array SLICE write-through (`@slice := @array[1,2]; @slice =
+        // ...`): the local's OWN elements are shared `ContainerRef` cells
+        // (from the bind-time slice promotion, §4 BLOCKERS.md test 15). A
+        // whole-array assignment writes through each cell instead of
+        // replacing the slot, bounded by the slice's own (fixed) arity —
+        // extra RHS values are discarded, matching raku's bound-slice
+        // semantics. `@`-sigil locals are never `simple_locals`, so this
+        // must live here rather than in the fast path above.
+        if name.starts_with('@')
+            && matches!(
+                self.env().get(&Self::bound_array_slice_marker_key(name)),
+                Some(Value::Bool(true))
+            )
+            && let Value::Array(items, ..) = &self.locals[idx]
+            && items.iter().any(Value::is_container_ref)
+        {
+            let cells: Vec<Value> = items.iter().cloned().collect();
+            let rhs_vals = self.assignment_rhs_values(&raw_val)?;
+            let mut result = Vec::with_capacity(cells.len());
+            for (i, cell_val) in cells.iter().enumerate() {
+                let v = rhs_vals
+                    .get(i)
+                    .cloned()
+                    .unwrap_or_else(|| Value::Package(Symbol::intern("Any")));
+                if let Value::ContainerRef(cell) = cell_val {
+                    *cell.lock().unwrap() = v.clone();
+                }
+                result.push(v);
+            }
+            self.stack.push(Value::array(result));
+            return Ok(());
+        }
         let mut val = if name.starts_with('%') {
             self.coerce_hash_var_value(name, raw_val)?
         } else if name.starts_with('@') {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -2,6 +2,16 @@ use super::*;
 use std::sync::Arc;
 
 impl Interpreter {
+    /// Env key marking a variable as a genuine bound array SLICE (`@slice :=
+    /// @array[1,2]`, §4 BLOCKERS.md test 15) — set only at the exact bind
+    /// moment that produces an array of per-element `ContainerRef` cells, and
+    /// cleared on every redeclaration of the same name. See the write-through
+    /// checks in `vm_var_assign_local.rs` and this file's non-bind path for
+    /// why "elements are cells" alone is not a safe trigger.
+    pub(super) fn bound_array_slice_marker_key(name: &str) -> String {
+        format!("__mutsu_bound_array_slice::{name}")
+    }
+
     pub(super) fn exec_set_local_op(
         &mut self,
         code: &CompiledCode,
@@ -183,6 +193,14 @@ impl Interpreter {
             if matches!(self.locals[idx], Value::ContainerRef(_)) {
                 self.locals[idx] = Value::Nil;
             }
+            // Clear a stale bound-array-slice marker (§4 BLOCKERS.md test 15)
+            // left over from an earlier same-named variable — a fresh
+            // declaration (bind or not) must not inherit "this array's
+            // elements are write-through cells" from a prior scope/iteration.
+            // Re-set below, in the `is_bind` arm, only if THIS declaration is
+            // genuinely a bound array slice.
+            self.env_mut()
+                .remove(&Self::bound_array_slice_marker_key(name));
         }
 
         // Lazily convert pending alias bind names into local_bind_pairs.
@@ -373,6 +391,39 @@ impl Interpreter {
         }
 
         let name = &code.locals[idx];
+        // Bound array SLICE write-through (`@slice := @array[1,2]; @slice =
+        // ...;` as a statement): the local's OWN elements are shared
+        // `ContainerRef` cells (from the bind-time slice promotion, §4
+        // BLOCKERS.md test 15). A whole-array assignment writes through each
+        // cell instead of replacing the slot, bounded by the slice's own
+        // (fixed) arity — extra RHS values are discarded, matching raku's
+        // bound-slice semantics. `@`-sigil locals are never `simple_locals`,
+        // so this must live here rather than in the fast path above. See the
+        // mirror-image handling in `vm_var_assign_local.rs`'s
+        // expression-context assignment.
+        if !is_bind
+            && !is_rebind
+            && name.starts_with('@')
+            && matches!(
+                self.env().get(&Self::bound_array_slice_marker_key(name)),
+                Some(Value::Bool(true))
+            )
+            && let Value::Array(items, ..) = &self.locals[idx]
+            && items.iter().any(Value::is_container_ref)
+        {
+            let cells: Vec<Value> = items.iter().cloned().collect();
+            let rhs_vals = self.assignment_rhs_values(&raw_popped)?;
+            for (i, cell_val) in cells.iter().enumerate() {
+                if let Value::ContainerRef(cell) = cell_val {
+                    let v = rhs_vals
+                        .get(i)
+                        .cloned()
+                        .unwrap_or_else(|| Value::Package(Symbol::intern("Any")));
+                    *cell.lock().unwrap() = v;
+                }
+            }
+            return Ok(());
+        }
         // Capture the old hash Arc before assignment for circular reference fixup.
         let old_hash_arc = if name.starts_with('%') {
             if let Value::Hash(arc) = &self.locals[idx] {
@@ -628,7 +679,13 @@ impl Interpreter {
             } else if is_bind {
                 // `:=` binding preserves the container type (e.g. List stays List).
                 // Type-check: only Positional values can be bound to @-sigiled vars.
-                let is_positional = match &raw_popped {
+                // A single-index terminal element bind (`@x := @array[2]`) may
+                // arrive here as a `ContainerRef` cell (promoted so a later
+                // whole-array assignment writes through the source element) —
+                // decont it first so the Positional check inspects the actual
+                // bound value, not the cell wrapper.
+                let decontained_popped = raw_popped.deref_container();
+                let is_positional = match &decontained_popped {
                     Value::Array(..)
                     | Value::LazyList(_)
                     | Value::LazyIoLines { .. }
@@ -752,6 +809,23 @@ impl Interpreter {
                     }
                 }
             };
+            // Mark a genuine bound array SLICE (`@slice := @array[1,2]`, §4
+            // BLOCKERS.md test 15): its OWN elements are shared `ContainerRef`
+            // cells from the bind-time slice promotion (`vm_var_index_ops.rs`).
+            // This marker is the ONLY safe trigger for the write-through
+            // behavior in `vm_var_assign_local.rs`/this file's non-bind path —
+            // "elements are cells" alone is NOT a safe signal, since unrelated
+            // machinery (e.g. `.grep`'s rw-topic element promotion) can also
+            // leave cell elements in a plain array that must NOT get the
+            // fixed-arity write-through treatment.
+            if is_bind
+                && name.starts_with('@')
+                && let Value::Array(items, ..) = &assigned
+                && items.iter().any(Value::is_container_ref)
+            {
+                self.env_mut()
+                    .insert(Self::bound_array_slice_marker_key(name), Value::Bool(true));
+            }
             // Preserve shaped array property on re-assignment, but only if the
             // new value is NOT already a shaped array (e.g. from Array.new(:shape(...)))
             let assigned_has_own_shape = crate::runtime::utils::shaped_array_shape(&assigned)

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -158,6 +158,18 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Normalize a bind-time array-slice index (`@array[1,2]`) to a list of
+    /// positions. Returns `None` for a single-index value (handled by the
+    /// existing `index_to_usize` path instead) or an unconvertible index.
+    fn slice_bind_indices(index: &Value) -> Option<Vec<usize>> {
+        let items: &[Value] = match index {
+            Value::Array(items, _) => items,
+            Value::Seq(items) | Value::Slip(items) => items,
+            _ => return None,
+        };
+        items.iter().map(Self::index_to_usize).collect()
+    }
+
     /// Lazy variant of IndexAutovivify: returns a HashEntryRef without creating
     /// the hash entry if it doesn't exist. Used for `:=` bind expressions
     /// so that `my $b := %h<a><b>` doesn't autovivify until assignment.
@@ -197,6 +209,19 @@ impl Interpreter {
                     } else {
                         self.stack.push(Value::Nil);
                     }
+                } else if let Some(indices) = Self::slice_bind_indices(&index) {
+                    // Bound array SLICE (`@slice := @array[1,2]`): promote each
+                    // indexed element to a shared cell (same mechanism as the
+                    // single-index case above) and hand back a plain Array
+                    // holding those cells. Its OWN fixed length becomes the
+                    // slice's arity — a later whole-array assignment writes
+                    // through each cell bounded by that length, discarding
+                    // extra RHS values (raku's bound-slice semantics).
+                    let cells = indices
+                        .into_iter()
+                        .map(|idx| resolved.array_slot_ref(idx, true).unwrap_or(Value::Nil))
+                        .collect();
+                    self.stack.push(Value::array(cells));
                 } else {
                     self.stack.push(resolved);
                     self.stack.push(index);

--- a/t/bound-array-slice-arity.t
+++ b/t/bound-array-slice-arity.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `my @slice := @array[1,2]` binds @slice to a fixed-arity view over
+# @array's elements 1 and 2. A later whole-array assignment writes through
+# those elements, bounded by @slice's OWN (fixed) length — extra RHS values
+# are discarded and missing ones pad with Any (roast
+# S09-subscript/slice.t test 15).
+
+plan 8;
+
+{
+    my @array = <a b c d>;
+    my @slice := @array[1,2];
+    is ~(@slice = <A B C D>), "A B",
+        'bound slice assignment discards extra RHS values';
+    is-deeply @array, ["a", "A", "B", "d"],
+        'bound slice assignment writes through to the source array';
+}
+
+{
+    my @array = <a b c d>;
+    my @slice := @array[1,2];
+    is ~(@slice = ("Z",)), "Z ",
+        'bound slice assignment with fewer RHS values pads with Any';
+    is @array[2].WHAT, Any, 'missing bound slice element becomes Any';
+}
+
+{
+    # identity: the bound slice's elements ARE @array's elements, and stay
+    # bound even after a plain (non-`:=`) whole-array reassignment.
+    my @array = <a b c d>;
+    my @slice := @array[1,2];
+    ok @array[1] =:= @slice[0], 'bound slice element shares identity with source';
+    @slice = <A B C D>;
+    @array[1] = "Z";
+    is @slice[0], "Z", 'bound slice stays bound after a whole-array reassignment';
+}
+
+{
+    # a single-index bind to a container-valued leaf writes through too.
+    my @array = 1, 2, [3, 4];
+    my @x := @array[2];
+    @x = 5, 6;
+    is-deeply @array, [1, 2, [5, 6]],
+        'single-index container-valued-leaf bind writes through';
+}
+
+{
+    # ordinary whole-container bind (not an index/slice) is unaffected.
+    my @array = 1, 2, 3;
+    my @b := @array;
+    @b = 9, 8, 7;
+    is-deeply @array, [9, 8, 7], 'plain whole-container bind still works';
+}


### PR DESCRIPTION
## Summary
- `my @slice := @array[1,2]; @slice = <A B C D>` must discard the extra 2 RHS values (a bound slice's arity is fixed at bind time) and write through to `@array`, returning `"A B"` (`roast/S09-subscript/slice.t` test 15, part of `TODO_roast/BLOCKERS.md` §4).
- Reuses the existing per-element `ContainerRef` cell mechanism instead of adding a new `Value` variant — see the commit message / `TODO_roast/S09.md` for the detailed design (compiler routing, `exec_index_autovivify_lazy_op` slice branch, write-through gated on a dedicated bind-time marker).
- Also fixes a latent bug this surfaced: `@x := @array[2]; @x = 5,6;` (single-index container-valued-leaf bind) previously silently failed to write back to `@array`.
- Important correctness note baked into the fix: "an array's elements are `ContainerRef` cells" is *not* by itself a safe signal that it's a bound slice -- `.grep`'s rw-topic element promotion can leave cell elements in an unrelated plain array. The write-through is gated on a dedicated marker set only at the exact bind moment and cleared on every redeclaration.

## Test plan
- [x] New `t/bound-array-slice-arity.t` (8 assertions), verified against real `raku` first
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S09-subscript/slice.t` -- failures reduced from 4 (test 15, 35, 54-56) to 3 (test 35, 54-56 only)
- [x] Regression-checked the `.grep` rw-topic interaction that an earlier version of this fix broke (`t/mutating-method-colon.t`, `t/grep-cell-read-deref.t`)
- [x] `make test` -- all green (1453 files, 14033 tests)
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` -- clean

Generated with Claude Code

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK