### PR TITLE
refactor(vm): bake rw-arg writeback caller slot via arg-sources (§1.4 shadow leaf)

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -667,7 +667,18 @@ impl Compiler {
             .iter()
             .map(|arg| {
                 if let Some(name) = Self::positional_arg_source_name(arg) {
-                    Value::str(name)
+                    // §1.4/§1.5: bake the caller's local slot for a plain source var
+                    // as `Pair(name, Int(slot))`, so the rw-arg writeback can target
+                    // the LIVE (inner shadow) slot instead of the by-name `position`
+                    // (outer) slot. A source with no local slot, or an encoded
+                    // `key=var` named form, stays a bare `Str(name)`. Decoders extract
+                    // the name from either shape, so existing consumers are unchanged.
+                    match self.local_map.get(&name) {
+                        Some(&slot) if !name.contains('=') => {
+                            Value::Pair(name, Box::new(Value::Int(slot as i64)))
+                        }
+                        _ => Value::str(name),
+                    }
                 } else {
                     Value::Nil
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1051,6 +1051,17 @@ pub struct Interpreter {
     /// class name resolves within its owning class (see `resolve_suppressed_type`).
     constructing_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
+    /// Companion to `pending_call_arg_sources` (§1.4/§1.5): the compiler-baked
+    /// `arg-source name -> caller local slot` for the current call, decoded from the
+    /// `Pair(name, Int(slot))` arg-source entries. Set alongside the names by
+    /// `decode_arg_sources`, taken with them by `bind_function_args_values`.
+    pub(crate) pending_call_arg_source_slots: std::collections::HashMap<String, u32>,
+    /// `rw-arg writeback source name -> caller local slot`, captured at arg-binding
+    /// time (clobber-safe: before the callee body runs) from
+    /// `pending_call_arg_source_slots`. The rw writeback drain
+    /// (`apply_pending_rw_writeback`) prefers this slot over the by-name `position`
+    /// resolution, so the write lands on the LIVE (inner shadow) caller slot.
+    pub(crate) pending_rw_writeback_slots: std::collections::HashMap<String, u32>,
     test_pending_callsite_line: Option<i64>,
     /// Number of active CONTROL handlers in the current VM stack. Tracked
     /// on the interpreter (rather than per-VM) so that nested VMs (e.g.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1755,6 +1755,8 @@ impl Interpreter {
             method_class_stack: Vec::new(),
             constructing_class: None,
             pending_call_arg_sources: None,
+            pending_call_arg_source_slots: std::collections::HashMap::new(),
+            pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -169,6 +169,8 @@ impl Interpreter {
             method_class_stack: Vec::new(),
             constructing_class: None,
             pending_call_arg_sources: None,
+            pending_call_arg_source_slots: std::collections::HashMap::new(),
+            pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -147,6 +147,25 @@ impl Interpreter {
         }
     }
 
+    /// §1.4/§1.5: record the compiler-baked caller slot for each rw-binding source
+    /// into `pending_rw_writeback_slots`, so the rw-arg writeback drain hits the
+    /// live inner-shadow slot. ONLY rw sources are recorded — a non-rw arg source
+    /// must not leave a stale slot that a later same-named writeback would misuse.
+    fn fold_rw_writeback_slots(
+        &mut self,
+        rw_bindings: &[(String, String)],
+        arg_source_slots: &std::collections::HashMap<String, u32>,
+    ) {
+        if arg_source_slots.is_empty() {
+            return;
+        }
+        for (_, source) in rw_bindings {
+            if let Some(&slot) = arg_source_slots.get(source) {
+                self.pending_rw_writeback_slots.insert(source.clone(), slot);
+            }
+        }
+    }
+
     pub(crate) fn bind_function_args_values(
         &mut self,
         param_defs: &[ParamDef],
@@ -236,6 +255,13 @@ impl Interpreter {
         };
         let args = filtered_args.as_slice();
         let arg_sources = self.take_pending_call_arg_sources();
+        // §1.4/§1.5: snapshot the compiler-baked arg-source slots NOW (before any
+        // default-expression evaluation makes a nested call that would clobber the
+        // shared field). Folded into `pending_rw_writeback_slots` at return time for
+        // ONLY the actual rw-binding sources (see `fold_rw_writeback_slots`) — a
+        // non-rw source must NOT be recorded, or its stale slot would be picked up
+        // by an unrelated later writeback of the same name in this frame.
+        let arg_source_slots = std::mem::take(&mut self.pending_call_arg_source_slots);
         let mut rw_bindings = Vec::new();
         let mut raw_nonlvalue_params: Vec<String> = Vec::new();
         if let Some(invocant_value) = self
@@ -262,6 +288,7 @@ impl Interpreter {
                 // No param_defs and no placeholder params -- nothing to bind.
                 // Argument rejection (for named subs with empty signature) is handled
                 // by callers that set `empty_sig` on FunctionDef / CompiledFunction.
+                self.fold_rw_writeback_slots(&rw_bindings, &arg_source_slots);
                 return Ok(rw_bindings);
             }
             // Legacy path: bind positional placeholders ($^a, $^b) by position,
@@ -385,6 +412,7 @@ impl Interpreter {
                 self.env
                     .insert("%_".to_string(), Value::hash(leftover_named));
             }
+            self.fold_rw_writeback_slots(&rw_bindings, &arg_source_slots);
             return Ok(rw_bindings);
         }
         // Pre-compute the set of explicit named parameter keys so that
@@ -1822,6 +1850,7 @@ impl Interpreter {
                 }
             }
         }
+        self.fold_rw_writeback_slots(&rw_bindings, &arg_source_slots);
         Ok(rw_bindings)
     }
 }

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -128,23 +128,40 @@ impl Interpreter {
     }
 
     pub(super) fn decode_arg_sources(
-        &self,
+        &mut self,
         code: &CompiledCode,
         arg_sources_idx: Option<u32>,
     ) -> Option<Vec<Option<String>>> {
+        // §1.4/§1.5: repopulate the companion `name -> slot` map for this call from
+        // the `Pair(name, Int(slot))` arg-source entries. Cleared first so a call
+        // with no slotted sources leaves it empty (no stale slot from a prior call).
+        self.pending_call_arg_source_slots.clear();
         let idx = arg_sources_idx?;
         let Value::Array(items, ..) = &code.constants[idx as usize] else {
             return None;
         };
-        Some(
-            items
-                .iter()
-                .map(|item| match item {
-                    Value::Str(name) => Some(name.to_string()),
-                    _ => None,
-                })
-                .collect(),
-        )
+        let mut slots: Vec<(String, u32)> = Vec::new();
+        let names: Vec<Option<String>> = items
+            .iter()
+            .map(|item| match item {
+                Value::Str(name) => Some(name.to_string()),
+                // A slotted source is `Pair(name, Int(slot))`; extract the name here
+                // (byte-identical for name-only consumers) and record the slot.
+                Value::Pair(name, val) => {
+                    if let Value::Int(slot) = val.as_ref()
+                        && *slot >= 0
+                    {
+                        slots.push((name.clone(), *slot as u32));
+                    }
+                    Some(name.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        for (name, slot) in slots {
+            self.pending_call_arg_source_slots.insert(name, slot);
+        }
+        Some(names)
     }
 
     pub(super) fn unwrap_var_ref_value(value: Value) -> Value {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -842,7 +842,21 @@ impl Interpreter {
         if !self.pending_rw_writeback_sources.is_empty() {
             let sources = std::mem::take(&mut self.pending_rw_writeback_sources);
             for source in sources {
-                if let Some(slot) = self.find_local_slot(code, &source) {
+                // §1.4/§1.5: prefer the compiler-baked caller slot for this source
+                // (folded in at arg-binding time) so the write lands on the LIVE
+                // (inner shadow) slot, not the by-name `position` (outer) slot. Fall
+                // back to the name search for sources with no baked slot (a
+                // captured-outer free-var write, undefine env-identity, …).
+                // Remove (not just read) this source's baked slot: it is consumed by
+                // this drain. A blanket clear would wrongly drop an OUTER call's
+                // still-pending slot when a NESTED call drains first (`f($a)` whose
+                // body calls `g($b)` — g's drain must not lose f's `a` slot).
+                let baked = self
+                    .pending_rw_writeback_slots
+                    .remove(&source)
+                    .map(|s| s as usize)
+                    .filter(|&s| s < self.locals.len());
+                if let Some(slot) = baked.or_else(|| self.find_local_slot(code, &source)) {
                     if !matches!(self.locals[slot], Value::HashEntryRef { .. })
                         && let Some(val) = self.env().get(&source).cloned()
                     {

--- a/t/lexical-scope-slot-writeback.t
+++ b/t/lexical-scope-slot-writeback.t
@@ -7,7 +7,7 @@ use Test;
 # the runtime env restore; the compiler-slot rework is deferred — see the note in
 # ANALYSIS.md §1.4. These cases guard against regressing the observable behavior.)
 
-plan 10;
+plan 12;
 
 # --- shadow read correctness ---
 {
@@ -57,4 +57,17 @@ plan 10;
         { temp $t = 99; is $t, 99, 'temp assigns the inner shadow slot'; }
         is $t, 10, 'temp restore targets the inner (live) shadow slot';
     }
+}
+
+# --- rw-arg writeback through a shadow hits the INNER slot ---
+# (regression: the writeback resolved the source name -> outer slot)
+{
+    sub bump($x is rw) { $x = 99 }
+    my $r = 1;
+    {
+        my $r = 10;
+        bump($r);
+        is $r, 99, 'rw-arg writeback targets the inner (live) shadow slot';
+    }
+    is $r, 1, 'outer $r untouched by inner rw-arg writeback';
 }


### PR DESCRIPTION
§1.4 shadow-slot activation campaign — the rw-arg param writeback class-2 leaf (gated behind `MUTSU_SHADOW_SLOTS`, default OFF = byte-identical).

## Problem
An `is rw` parameter writeback (`sub f($x is rw){...}; f($a)`) refreshes the caller's source variable on return via `apply_pending_rw_writeback` → `find_local_slot` (position = OUTER slot). Under the flag, a call inside a shadow block wrote the outer `$a`, leaving the live inner shadow slot stale:
```raku
my $a = 1;
{ my $a = 10; f($a); say $a }   # was 10, raku says 99
```

## Fix — thread the compiler-baked caller slot from arg-sources to the drain
- `add_arg_sources_constant` bakes a plain source var as `Pair(name, Int(slot))`.
- `decode_arg_sources` extracts the name from either `Str`/`Pair` (byte-identical for name consumers) and repopulates `pending_call_arg_source_slots`.
- `bind_function_args_values` folds those slots into `pending_rw_writeback_slots` **at arg-binding time — before the callee body runs**, so a nested call can't clobber them.
- `apply_pending_rw_writeback` prefers *and removes* the baked slot per source, so a nested call's drain (`f($a)` whose body calls `g($b)`) doesn't drop an outer call's still-pending slot. Falls back to the by-name search for sources with no baked slot (captured-outer free-var writes; undefine/substr-rw env-identity writes — separate leaves).

## Testing
- **Gate OFF (default/CI):** baked slot == the single by-name slot → byte-identical; `make test` green.
- **Gate ON:** rw-arg-in-shadow (incl. the nested-call clobber case → 106) matches `raku`; guard added to `t/lexical-scope-slot-writeback.t` (plan 10 → 12). All rw-param tests pass under both flags.
- `cargo clippy -- -D warnings` / `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)