### PR TITLE
refactor(compiler): bake IndexAssignExprNamed target local slot (§1.4 shadow leaf)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -138,12 +138,28 @@ broadcast = touches every slot with the name.
       `find_local_slot` by name, keeping the `@`-name + env fallback for a `None`
       slot. Behavior-preserving today; verified byte-identical across the whole
       `make test` suite via a temporary `debug_assert_eq!` (never fired). *(done)*
-- [ ] S10+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+- [x] **S11 — element/index-assign target slot** (`$a<x> = 42` / `$a<a b c> »=» 42`
+      on a shadowed `$a`; also `@a[i] = v`). `IndexAssignExprNamed` gains a compile-
+      time `target_slot` (baked at its 6 emit sites: `expr_method.rs` ×2,
+      `expr_closure.rs` ×2, `expr_ops.rs`, `expr_call.rs`). `exec_index_assign_expr_
+      named_op_inner` computes `eff_slot`/`orig_slot` (gated on `shadow_slots_active()`,
+      cleared to `None` when a sigilless alias redirects to a different variable) and
+      routes its 7 *target-var* resolvers (3 `find_local_slot` → `resolve_local_slot`,
+      4 `update_local_if_exists`/`original_var_name` → `write_local_slot_or_name`)
+      through the baked slot; the `source_name`/`src` `:=`-cell sites keep by-name.
+      **GATED on `shadow_slots_active()`** because `resolve_local_slot` treats an
+      out-of-range baked slot as "not local" (returns `None` instead of a by-name
+      search), which diverged on chained slice-lvalue assignment; OFF stays
+      byte-identical. `roast/S13-overloading/metaoperators.t` #14-16 green ON.
+      Validated OFF with `make roast` (map.t/hash.t transient failures were CPU-
+      starvation flaky, not this change). *(#4090-pending)*
+- [ ] S12+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
       for-loop *container* source writeback (`write_back_container_source`,
       `write_back_for_topic_item`, resolved by the runtime-derived
-      `container_ref_var` name — a §1.3 concern); element/index-assign,
-      computed-attr twigil cells, hyper writeback, and the ~80 `update_local_if_exists`
-      callers generally — migrated onto `resolve_local_slot`/`write_local_slot_or_name`.
+      `container_ref_var` name — a §1.3 concern); the nested/deep/generic index-assign
+      variants (`IndexAssignExprNested`/`DeepNested`/`Generic`), computed-attr twigil
+      cells, hyper `»=»` multi-key writeback, and the remaining `update_local_if_exists`
+      callers — migrated onto `resolve_local_slot`/`write_local_slot_or_name`.
 - [~] §1.4 flip + `pop_local_scope` restore — **landed gated** behind
       `MUTSU_SHADOW_SLOTS` (default off = byte-identical). See the
       "shadow-slot activation, gated" section below. Default flip pends §1.3.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -252,6 +252,7 @@ impl Compiler {
             } = &args[0]
             && let Some(var_name) = Self::postfix_index_name(index_target)
         {
+            let target_slot = self.local_map.get(&var_name).copied();
             let tmp_target_name = format!(
                 "__mutsu_tmp_assign_method_target_{}",
                 self.code.constants.len()
@@ -285,6 +286,7 @@ impl Compiler {
             self.code.emit(OpCode::IndexAssignExprNamed {
                 name_idx: var_name_idx,
                 is_positional: true,
+                target_slot,
             });
             self.code.emit(OpCode::Pop);
             self.code.emit(OpCode::GetGlobal(tmp_result_idx));

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -422,6 +422,7 @@ impl Compiler {
             return;
         }
         if let Some(name) = Self::index_assign_target_name(target) {
+            let target_slot = self.local_map.get(&name).copied();
             if Self::index_assign_target_requires_eval(target) {
                 self.compile_expr(target);
                 self.code.emit(OpCode::Pop);
@@ -439,6 +440,7 @@ impl Compiler {
             self.code.emit(OpCode::IndexAssignExprNamed {
                 name_idx,
                 is_positional: outer_positional,
+                target_slot,
             });
         } else if let Some((name, chain)) = Self::index_assign_deep_nested_target(target) {
             // Deep nested index assignment (3+ levels): @a[i][j][k]... = val
@@ -533,12 +535,14 @@ impl Compiler {
             // When map's closure has an `is rw` parameter and returns it unchanged,
             // the result is a list of containers bound to the original array elements.
             // Assignment through them writes back to the original array.
+            let target_slot = self.local_map.get(&arr_name).copied();
             self.compile_expr(value);
             self.compile_expr(index);
             let name_idx = self.code.add_constant(Value::str(arr_name));
             self.code.emit(OpCode::IndexAssignExprNamed {
                 name_idx,
                 is_positional: outer_positional,
+                target_slot,
             });
         } else if let Expr::ArrayLiteral(elements) = target {
             // List construction container assignment:

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -146,6 +146,7 @@ impl Compiler {
         } = target
         {
             let var_name = Self::postfix_index_name(idx_target).unwrap_or_default();
+            let target_slot = self.local_map.get(&var_name).copied();
             let name_resolved = name.resolve();
             let arity = args.len() as u32;
             let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
@@ -184,6 +185,7 @@ impl Compiler {
                 self.code.emit(OpCode::IndexAssignExprNamed {
                     name_idx: var_name_idx,
                     is_positional: true,
+                    target_slot,
                 });
                 self.code.emit(OpCode::Pop);
                 self.code.emit(OpCode::GetGlobal(tmp_result_idx));
@@ -206,6 +208,7 @@ impl Compiler {
                 self.code.emit(OpCode::IndexAssignExprNamed {
                     name_idx: var_name_idx,
                     is_positional: true,
+                    target_slot,
                 });
             }
         } else {

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -270,11 +270,13 @@ impl Compiler {
                     // For slice hyper-assign like @a[0..2] >>~=>> "x",
                     // compile an IndexAssign to write the hyper result back.
                     if let Some(name) = Self::index_assign_target_name(target) {
+                        let target_slot = self.local_map.get(&name).copied();
                         self.compile_expr(index);
                         let name_idx = self.code.add_constant(Value::str(name));
                         self.code.emit(OpCode::IndexAssignExprNamed {
                             name_idx,
                             is_positional: *is_positional,
+                            target_slot,
                         });
                     }
                     // For complex targets without a simple name, leave result on stack.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -24,7 +24,7 @@ static STATE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 /// substrate the campaign greens slice-by-slice before the default is flipped —
 /// the same env-var-gated pattern the env_dirty campaign used. See
 /// docs/lexical-scope-slot-campaign.md and ANALYSIS.md §1.4.
-fn shadow_slots_active() -> bool {
+pub(crate) fn shadow_slots_active() -> bool {
     use std::sync::OnceLock;
     static ACTIVE: OnceLock<bool> = OnceLock::new();
     *ACTIVE.get_or_init(|| std::env::var_os("MUTSU_SHADOW_SLOTS").is_some())

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -808,6 +808,13 @@ pub(crate) enum OpCode {
     IndexAssignExprNamed {
         name_idx: u32,
         is_positional: bool,
+        /// §1.4 shadow-slot: the compiler-resolved local slot for the target var
+        /// (`local_map[name]` at emit time), or `None` for a non-local target
+        /// (global/dynamic/undeclared). The exec prefers this baked slot over the
+        /// by-name `find_local_slot` (position = outer) so a shadowing inner-block
+        /// `my $a` writes its own slot. Byte-identical with shadows off (baked ==
+        /// position). See docs/lexical-scope-slot-campaign.md.
+        target_slot: Option<u32>,
     },
     IndexAssignPseudoStashNamed {
         stash_name_idx: u32,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2897,9 +2897,15 @@ impl Interpreter {
             OpCode::IndexAssignExprNamed {
                 name_idx,
                 is_positional,
+                target_slot,
             } => {
                 let pre = self.array_hash_attr_env_snapshot(code, *name_idx);
-                self.exec_index_assign_expr_named_op(code, *name_idx, *is_positional)?;
+                self.exec_index_assign_expr_named_op(
+                    code,
+                    *name_idx,
+                    *is_positional,
+                    *target_slot,
+                )?;
                 self.mirror_array_hash_attr_to_cell(code, *name_idx, pre);
                 *ip += 1;
             }

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -397,6 +397,7 @@ impl Interpreter {
         code: &CompiledCode,
         name_idx: u32,
         is_positional: bool,
+        target_slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         // A lazy `@`-array must reify its prefix before an element assignment
         // (`@a[i] = v`) — the assign machinery needs a materialized backing. (L2)
@@ -458,7 +459,8 @@ impl Interpreter {
         } else {
             None
         };
-        let result = self.exec_index_assign_expr_named_op_inner(code, name_idx, is_positional);
+        let result =
+            self.exec_index_assign_expr_named_op_inner(code, name_idx, is_positional, target_slot);
         // Restore metadata on the post-assignment container when the
         // identity-keyed map lost it OR holds a stale entry. Copy-on-write
         // changes the hash's Arc pointer (the metadata key), and freed pointers

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -153,6 +153,7 @@ impl Interpreter {
         code: &CompiledCode,
         name_idx: u32,
         is_positional: bool,
+        target_slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let original_var_name = Self::const_str(code, name_idx).to_string();
         // Resolve sigilless alias: if `h` is a sigilless alias for `%a`,
@@ -171,6 +172,31 @@ impl Interpreter {
             .as_deref()
             .unwrap_or(&original_var_name)
             .to_string();
+        // §1.4 shadow-slot: the compiler-baked slot is valid only for the
+        // target's own name (`original_var_name`). If a sigilless alias redirects
+        // to a DIFFERENT variable, the baked slot no longer applies — fall back to
+        // by-name resolution for the alias target. `eff_slot` is what the target-
+        // var writeback resolvers below should use (via `resolve_local_slot` /
+        // `write_local_slot_or_name`); the separate `source_name`/`src` `:=`-cell
+        // sites keep their own by-name resolution (a distinct variable).
+        //
+        // GATED on `shadow_slots_active()`: with the gate OFF (default / CI) we pass
+        // `None`, so every resolver falls back to the original `find_local_slot`
+        // by-name search — byte-identical to before. The baked slot is NOT a pure
+        // drop-in for `find_local_slot`: `resolve_local_slot` treats an out-of-range
+        // baked slot as "not local here" (returns `None` instead of searching by
+        // name), which diverges on chained slice-lvalue assignment
+        // (`(@b[*-3,…] = @a) = …`, `roast/S02-types/array.t` #62). Only the shadow
+        // build needs the baked slot (to disambiguate duplicate `code.locals` names).
+        let shadow_active = crate::compiler::shadow_slots_active();
+        let eff_slot = if shadow_active && sigilless_alias_target.is_none() {
+            target_slot
+        } else {
+            None
+        };
+        // The baked slot is for `original_var_name` (the pre-alias target name), so
+        // the sigilless-alias write-back below uses it directly — also gated OFF.
+        let orig_slot = if shadow_active { target_slot } else { None };
         // Pre-compute fill value for native typed arrays (e.g. int->0, num->0e0, str->"")
         // Must be done before mutable borrows to avoid borrow conflicts.
         let native_fill = {
@@ -558,7 +584,7 @@ impl Interpreter {
             }
         }
         if !self.env().contains_key(&var_name)
-            && let Some(slot) = self.find_local_slot(code, &var_name)
+            && let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
         {
             self.set_env_with_main_alias(&var_name, self.locals[slot].clone());
         }
@@ -644,7 +670,7 @@ impl Interpreter {
                     }
                     // Early return (like the `Value::Array` slice arm), so repeat
                     // the locals resync the shared tail would otherwise do.
-                    if let Some(slot) = self.find_local_slot(code, &var_name)
+                    if let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
                         && let Some(updated) = self.env().get(&var_name).cloned()
                     {
                         self.locals[slot] = updated;
@@ -795,7 +821,7 @@ impl Interpreter {
                     // assignment mutates only the `env` copy while a variable
                     // that also has a `locals` slot (the common case) keeps
                     // reading its stale pre-assignment value.
-                    if let Some(slot) = self.find_local_slot(code, &var_name)
+                    if let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
                         && let Some(updated) = self.env().get(&var_name).cloned()
                     {
                         self.locals[slot] = updated;
@@ -1320,7 +1346,7 @@ impl Interpreter {
                         self.stack.push(val);
                         // Update local slot
                         if let Some(new_val) = self.env().get(&var_name).cloned() {
-                            self.update_local_if_exists(code, &var_name, &new_val);
+                            self.write_local_slot_or_name(code, eff_slot, &var_name, new_val);
                         }
                         return Ok(());
                     }
@@ -1673,7 +1699,7 @@ impl Interpreter {
             }
         }
         if let Some(updated) = self.get_env_with_main_alias(&var_name) {
-            self.update_local_if_exists(code, &var_name, &updated);
+            self.write_local_slot_or_name(code, eff_slot, &var_name, updated.clone());
             // Write the whole topic back to its source variable only when the
             // source is a scalar (e.g. `for $x { $_[1] = ... }`). For array/hash
             // sources (`for @a { $_[1] = ... }`), the for-loop's own per-element
@@ -1701,7 +1727,7 @@ impl Interpreter {
             {
                 let tagged = self.tag_container_default(updated.clone(), def);
                 self.set_env_with_main_alias(&var_name, tagged.clone());
-                self.update_local_if_exists(code, &var_name, &tagged);
+                self.write_local_slot_or_name(code, eff_slot, &var_name, tagged);
             }
         }
         // When operating through a sigilless alias (e.g., `h` → `%a`),
@@ -1712,7 +1738,7 @@ impl Interpreter {
         {
             self.env_mut()
                 .insert(original_var_name.clone(), updated_container.clone());
-            self.update_local_if_exists(code, &original_var_name, &updated_container);
+            self.write_local_slot_or_name(code, orig_slot, &original_var_name, updated_container);
         }
         // After element assignment, Arc::make_mut may have created a new Arc
         // (COW). Sync HashEntryRef locals whose root `hash` Arc pointed to the

--- a/t/index-assign-shadow-slot.t
+++ b/t/index-assign-shadow-slot.t
@@ -1,0 +1,37 @@
+use Test;
+
+# §1.4 shadow-slot leaf: element/index assignment on a variable that shadows an
+# enclosing same-name binding must write the inner (live) shadow's container, not
+# the outer (first) same-name slot. The IndexAssignExprNamed target store now
+# prefers the compile-time-baked local slot. Passes with the shadow-slot gate off
+# (shared slot) AND on (distinct slots). Mirrors roast/S13-overloading/
+# metaoperators.t #14-16. See docs/lexical-scope-slot-campaign.md.
+
+plan 6;
+
+# Scalar auto-vivified to a hash, inside a shadow.
+my $a = 1;
+{
+    my $a;
+    $a<x> = 42;
+    is $a<x>, 42, 'index-assign auto-vivifies the inner shadow';
+}
+is $a, 1, 'outer scalar untouched by inner index-assign';
+
+# Hyper index-assign to a shadowed scalar-hash.
+my $h = 'outer';
+{
+    my $h;
+    $h<a b c> »=» 7;
+    is $h<a>, 7, 'hyper index-assign hits the inner shadow (a)';
+    is $h<c>, 7, 'hyper index-assign hits the inner shadow (c)';
+}
+is $h, 'outer', 'outer scalar untouched by inner hyper index-assign';
+
+# Array element assignment into a shadow.
+my @arr = 1, 2, 3;
+{
+    my @arr = 0, 0, 0;
+    @arr[1] = 99;
+    is @arr[1], 99, 'array element assign hits the inner shadow';
+}


### PR DESCRIPTION
## Summary

§1.4 shadow-slot class-2 leaf: element/index assignment on a shadowed target.

`$a<x> = 42` / `$a<a b c> »=» 42` (single-key `»=»` collapses to `IndexAssign`) and `@a[i] = v` on a `my $a`/`my @a` that shadows an enclosing same-name binding wrote the auto-vivified container back to the **outer** (first) `code.locals` slot, because `IndexAssignExprNamed` resolved its target var by name (`find_local_slot` = position). `roast/S13-overloading/metaoperators.t` #14-16 (`my $a; $a<a b c> »=» 42`) exercised this.

`IndexAssignExprNamed` now carries a compile-time `target_slot` (baked from `local_map` at its **6 emit sites**). `exec_index_assign_expr_named_op_inner` derives `eff_slot`/`orig_slot` and routes its **7 target-var resolvers** (3 `find_local_slot` → `resolve_local_slot`, 4 `update_local_if_exists`/`original_var_name` → `write_local_slot_or_name`) through the baked slot; the `source_name`/`src` `:=`-cell sites keep by-name (a distinct variable, future slice), and a sigilless-alias redirect clears the slot.

## Gating

**GATED on `shadow_slots_active()`.** With the gate OFF (default / CI) `eff_slot`/`orig_slot` are `None`, so every resolver falls back to the original by-name `find_local_slot` — **byte-identical**. Not a pure drop-in because `resolve_local_slot` treats an out-of-range baked slot as "not local" (returns `None` instead of a by-name search), which diverges on chained slice-lvalue assignment (`(@b[*-3,…] = @a) = …`). Only the shadow build needs the baked slot to disambiguate duplicate `code.locals` names.

## Test plan

- `make test` (default, gate off): green, Files=1452.
- OFF validated with `make roast` on the index-assign-heavy whitelist (S02/S03/S09 subscript+autoviv, metaoperators, hash, map) — clean. (Transient map.t/hash.t failures during dev were CPU-starvation flaky from unrelated hung procs; confirmed passing clean and on `main`.)
- `roast/S13-overloading/metaoperators.t` #14-16 green under `MUTSU_SHADOW_SLOTS=1`.
- new pin `t/index-assign-shadow-slot.t` passes **off and on**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)