### PR TITLE
refactor(vm): classify re-dispatch primitives as interpreter carriers, not fallbacks (§2)

### DIFF
--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -258,10 +258,28 @@ impl Interpreter {
     /// in a separate stats bucket (lever A). The remaining coupling — that the
     /// shared env/classes/roles registries are owned by the `Interpreter` struct
     /// — is a lever B (state ownership) concern, not a dispatch fallback.
+    ///
+    /// The re-dispatch primitives (`samewith`/`callsame`/`nextsame`/`callwith`/
+    /// `nextwith`/`nextcallee`/`lastcall`) are carriers too: each re-enters normal
+    /// dispatch (`call_function` / `call_sub_value` / `call_method_with_values`) to
+    /// run the *next / same* candidate, and that candidate body runs **compiled**
+    /// (function OTF and method-execution are both VM-native — ledger §D). So the
+    /// interpreter carries the re-dispatch primitive but does not tree-walk the
+    /// user code it redispatches to; counting them as tree-walk fallbacks overstated
+    /// the §2 function-fallback metric.
     pub(super) fn is_interpreter_carrier_function(name: &str) -> bool {
-        name == "EVAL"
-            || name == "EVALFILE"
-            || name.contains("SETTING::")
+        matches!(
+            name,
+            "EVAL"
+                | "EVALFILE"
+                | "samewith"
+                | "callsame"
+                | "nextsame"
+                | "callwith"
+                | "nextwith"
+                | "nextcallee"
+                | "lastcall"
+        ) || name.contains("SETTING::")
             || name.contains("OUTER::")
             || name.contains("CALLER::")
             || name.contains("DYNAMIC::")


### PR DESCRIPTION
## Summary

§2 multi-dispatch fallback accounting fix. `samewith`/`callsame`/`nextsame`/`callwith`/`nextwith`/`nextcallee`/`lastcall` were counted as **tree-walk function fallbacks** by the `MUTSU_VM_STATS` metric, but they are **carriers**: each re-enters normal dispatch (`call_function` / `call_sub_value` / `call_method_with_values`) to run the next/same candidate, and that candidate body runs **compiled** (function OTF + method-execution are both VM-native, ledger §D). The interpreter carries the re-dispatch primitive; it does not tree-walk the user code it redispatches to.

This overstated the §2 function-fallback surface — e.g. `S06-multi/subsignature.t` reported 10.6% "fallback", 8 of which were `samewith`. After this fix it reports **3.0%** real function-fallback; the residual (`f`/`foo`/`moose`/`waz`) is rare proto-operator edge cases.

## Why behavior-neutral

`is_interpreter_carrier_function` is used only for:
1. the stats bucket (no-op unless `MUTSU_VM_STATS` is set), and
2. `lexical_amp_var_callable`, where all seven names are already excluded one line earlier via `is_control_flow_function_name`.

So default execution is byte-identical.

## Finding

Measured with `MUTSU_VM_STATS=1`: **function multi-dispatch fallback is essentially complete** (0–3% real tree-walk across S06-multi/S12 files after this fix). The remaining §2 function-fallbacks are one-off proto/operator edge cases (`moose` = `proto prefix:<moose>`, etc.), not a broad category. The larger interpreter coupling now lives in method-call fallback (a different, `runtime/methods.rs` slow-path category) and the intentionally correctness-gated module-sub OTF exclusions (`state`/`EVAL`/`rw`/`raw`/return-coercion).

## Test plan

- Behavior-neutral (stats bucketing only); relies on CI `make test` + `make roast`.
- Verified S06-multi/subsignature, S12-methods/multi, S06-multi/proto, type-based still run correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)