### PR TITLE
feat(gc): add MUTSU_VM_STATS GC counter framework (ADR-0001/0002 §11 step 3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -381,8 +381,10 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
       進行中の実装順序は [docs/gc-level1-detailed-design.md](docs/gc-level1-detailed-design.md) §11:
       1. ✅ root visitor 導入（`Interpreter::visit_roots()` / `Env::visit_values()`、#4094）
       2. ✅ child visitor 導入（`Value::visit_gc_children()` ＋ `ArrayData`/`HashData`/`SubData`/
-         `InstanceAttrs`/`SharedPromise`/`SharedChannel`）← **いまここ**
-      3. `MUTSU_VM_STATS` の GC カウンタ枠
+         `InstanceAttrs`/`SharedPromise`/`SharedChannel`）
+      3. ✅ `MUTSU_VM_STATS` の GC カウンタ枠（`vm/vm_stats.rs`: collections/candidate_pushes/
+         dedup_hits/reclaimed_nodes/reclaimed_cycles/pause_ns_total/pause_ns_max/roots_scanned。
+         全て 0 固定 — 呼び出し元は §11 step 4 以降）← **いまここ**
       4. `Gc<T>` / node header / candidate buffer の最小実装
       5〜11. `Array`/`Hash`/`ContainerRef` → `Promise`/`Channel` → supply registry → safepoint collect →
       `Sub`/`Instance` → `LazyList`（詳細は設計メモ参照）。

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -67,6 +67,22 @@ static ENV_DEEP_COPY: AtomicU64 = AtomicU64::new(0);
 static ENV_FLUSH: AtomicU64 = AtomicU64::new(0);
 static ENV_SLOTS_FLUSHED: AtomicU64 = AtomicU64::new(0);
 
+// GC Level 1a counters (ADR-0001/0002, docs/gc-level1-detailed-design.md
+// §8/§9.4a, §11 step 3). No candidate buffer or collector exists yet (§11
+// steps 4+), so these all read 0 today — the counter framework is laid down
+// ahead of the collector so instrumentation is never bolted on retroactively.
+// Success criterion once wired in (§8): `gc_candidate_pushes == 0` on the
+// `fib` benchmark, proving the scalar/container type filter keeps int-heavy
+// hot paths GC-cost-free.
+static GC_CANDIDATE_PUSHES: AtomicU64 = AtomicU64::new(0);
+static GC_CANDIDATE_DEDUP_HITS: AtomicU64 = AtomicU64::new(0);
+static GC_COLLECTIONS: AtomicU64 = AtomicU64::new(0);
+static GC_RECLAIMED_NODES: AtomicU64 = AtomicU64::new(0);
+static GC_RECLAIMED_CYCLES: AtomicU64 = AtomicU64::new(0);
+static GC_PAUSE_NS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static GC_PAUSE_NS_MAX: AtomicU64 = AtomicU64::new(0);
+static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
+
 /// Whether instrumentation is active. Resolved once from the environment so the
 /// hot path is a single cached boolean load when the feature is off.
 #[inline]
@@ -172,6 +188,47 @@ pub(crate) fn record_env_flush(slots: u64) {
     }
 }
 
+/// Record a GC cycle-candidate buffer push: a mutation chokepoint flagged a
+/// GC-managed node as a possible cycle member (design doc §4.2). Not called
+/// anywhere yet — the candidate buffer itself lands in §11 step 4.
+#[inline]
+#[allow(dead_code)]
+pub(crate) fn record_gc_candidate_push() {
+    if enabled() {
+        GC_CANDIDATE_PUSHES.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record that a candidate push deduplicated against an already-buffered node
+/// instead of adding a new entry.
+#[inline]
+#[allow(dead_code)]
+pub(crate) fn record_gc_candidate_dedup_hit() {
+    if enabled() {
+        GC_CANDIDATE_DEDUP_HITS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record one completed collect cycle: `roots_scanned` nodes visited from the
+/// root set, `reclaimed_nodes`/`reclaimed_cycles` freed, taking `pause_ns`.
+#[inline]
+#[allow(dead_code)]
+pub(crate) fn record_gc_collection(
+    roots_scanned: u64,
+    reclaimed_nodes: u64,
+    reclaimed_cycles: u64,
+    pause_ns: u64,
+) {
+    if enabled() {
+        GC_COLLECTIONS.fetch_add(1, Ordering::Relaxed);
+        GC_ROOTS_SCANNED.fetch_add(roots_scanned, Ordering::Relaxed);
+        GC_RECLAIMED_NODES.fetch_add(reclaimed_nodes, Ordering::Relaxed);
+        GC_RECLAIMED_CYCLES.fetch_add(reclaimed_cycles, Ordering::Relaxed);
+        GC_PAUSE_NS_TOTAL.fetch_add(pause_ns, Ordering::Relaxed);
+        GC_PAUSE_NS_MAX.fetch_max(pause_ns, Ordering::Relaxed);
+    }
+}
+
 /// Print a one-line summary of Interpreter fallback statistics to stderr.
 ///
 /// No-op unless `MUTSU_VM_STATS` is set. Counts aggregate across worker threads
@@ -213,6 +270,19 @@ pub(crate) fn dump() {
     let slots = ENV_SLOTS_FLUSHED.load(Ordering::Relaxed);
     eprintln!(
         "[mutsu vm-stats] dual-store: clone_env={clone_env} (O(1) Arc bumps) env_deep_copies={deep_copy} (O(env) make_mut) env_flushes={env_flush} slots_flushed={slots}"
+    );
+    // GC Level 1a (§11 step 3): all zero until the collector (§11 step 4+)
+    // starts calling record_gc_candidate_push/record_gc_collection.
+    let gc_collections = GC_COLLECTIONS.load(Ordering::Relaxed);
+    let gc_candidate_pushes = GC_CANDIDATE_PUSHES.load(Ordering::Relaxed);
+    let gc_dedup_hits = GC_CANDIDATE_DEDUP_HITS.load(Ordering::Relaxed);
+    let gc_reclaimed_nodes = GC_RECLAIMED_NODES.load(Ordering::Relaxed);
+    let gc_reclaimed_cycles = GC_RECLAIMED_CYCLES.load(Ordering::Relaxed);
+    let gc_pause_ns_total = GC_PAUSE_NS_TOTAL.load(Ordering::Relaxed);
+    let gc_pause_ns_max = GC_PAUSE_NS_MAX.load(Ordering::Relaxed);
+    let gc_roots_scanned = GC_ROOTS_SCANNED.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] gc: collections={gc_collections} candidate_pushes={gc_candidate_pushes} dedup_hits={gc_dedup_hits} reclaimed_nodes={gc_reclaimed_nodes} reclaimed_cycles={gc_reclaimed_cycles} pause_ns_total={gc_pause_ns_total} pause_ns_max={gc_pause_ns_max} roots_scanned={gc_roots_scanned}"
     );
     if let Ok(map) = function_fallback_by_name().lock()
         && !map.is_empty()


### PR DESCRIPTION
## Summary
- Third slice of GC Level 1a (ADR-0001/[ADR-0002](docs/adr/0002-phase-a-gate-reassessment.md)), following the root visitor (#4094) and child visitor (#4096). Implements `docs/gc-level1-detailed-design.md` §11 step 3.
- Adds the 8 counters from §8/§9.4a (`collections`, `candidate_pushes`, `dedup_hits`, `reclaimed_nodes`, `reclaimed_cycles`, `pause_ns_total`, `pause_ns_max`, `roots_scanned`) plus `record_gc_candidate_push()`/`record_gc_collection()` to `src/vm/vm_stats.rs`, printed as a `[mutsu vm-stats] gc: ...` summary line matching the design doc's recommended format.
- All counters read 0 for now — nothing calls the record functions yet (the candidate buffer/collector land in §11 step 4+). This lays the counter slots down ahead of time, per §8's plan to verify `gc_candidate_pushes == 0` on the fib benchmark once wired in (proving the scalar/container type filter keeps int-heavy hot paths GC-cost-free).

## Test plan
- [x] `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt`
- [x] `cargo test --lib` (485 passed)
- [x] Manual check: `MUTSU_VM_STATS=1 target/debug/mutsu -e 'say 1+1'` prints the new `gc:` summary line with all-zero counters
- [ ] CI `make roast` (unrelated — new counters are dead code outside `MUTSU_VM_STATS`, no execution path touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK