### PR TITLE
fix(setbagmix): unwrap Bag/Set/Mix-subclass instances in set arithmetic; (+) preserves subclass

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -121,6 +121,7 @@ roast/S02-types/array_ref.t
 roast/S02-types/assigning-refs.t
 roast/S02-types/autovivification.t
 roast/S02-types/bag-iterator.t
+roast/S02-types/bag.t
 roast/S02-types/baggy.t
 roast/S02-types/baghash.t
 roast/S02-types/bool.t

--- a/src/vm/vm_set_arith_ops.rs
+++ b/src/vm/vm_set_arith_ops.rs
@@ -61,8 +61,37 @@ impl Interpreter {
                 Value::bag(a)
             }
         };
-        self.stack
-            .push(runtime::with_set_mutability(result, result_mutable));
+        let result = runtime::with_set_mutability(result, result_mutable);
+        // A `(+)` of two instances of the SAME Bag subclass (`class Foo is Bag`)
+        // returns that subclass, not a plain Bag (roast S02-types/bag.t #252,
+        // rakudo#5190). Baggy subclass instances carry their real Bag in the
+        // `__baggy_data__` attribute (see `construct_baggy_instance`); rewrap the
+        // finished Bag-level union under the same class so both `isa-ok` and the
+        // delegated element access (`$u<k>`, `.elems`, `.keys`) keep working.
+        let result = match (&left, &right) {
+            (
+                Value::Instance {
+                    class_name: lc,
+                    attributes: la,
+                    ..
+                },
+                Value::Instance {
+                    class_name: rc,
+                    attributes: ra,
+                    ..
+                },
+            ) if result_level < 2
+                && lc == rc
+                && la.contains_key("__baggy_data__")
+                && ra.contains_key("__baggy_data__") =>
+            {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("__baggy_data__".to_string(), result);
+                Value::make_instance(*lc, attrs)
+            }
+            _ => result,
+        };
+        self.stack.push(result);
         Ok(())
     }
 
@@ -128,6 +157,15 @@ impl Interpreter {
     /// Coerce a value to a Bag (HashMap<String, i64>)
     fn coerce_to_bag(val: &Value) -> HashMap<String, i64> {
         match val {
+            // A Bag/Set/Mix subclass instance (`class Foo is Bag`) carries its real
+            // quantified collection in `__baggy_data__`; unwrap it so a set/baggy op
+            // sees the elements, not the opaque instance as a single element.
+            Value::Instance { attributes, .. } if attributes.contains_key("__baggy_data__") => {
+                match attributes.as_map().get("__baggy_data__") {
+                    Some(inner) => Self::coerce_to_bag(inner),
+                    None => HashMap::new(),
+                }
+            }
             Value::Bag(b, _) => crate::runtime::utils::bag_counts_as_i64(&b.counts),
             Value::Set(s, _) => s.iter().map(|k| (k.clone(), 1)).collect(),
             Value::Mix(m, _) => m.iter().map(|(k, v)| (k.clone(), *v as i64)).collect(),
@@ -168,6 +206,12 @@ impl Interpreter {
     /// Coerce a value to a Mix (HashMap<String, f64>)
     fn coerce_to_mix(val: &Value) -> HashMap<String, f64> {
         match val {
+            Value::Instance { attributes, .. } if attributes.contains_key("__baggy_data__") => {
+                match attributes.as_map().get("__baggy_data__") {
+                    Some(inner) => Self::coerce_to_mix(inner),
+                    None => HashMap::new(),
+                }
+            }
             Value::Mix(m, _) => m.weights.clone(),
             Value::Bag(b, _) => b
                 .iter()

--- a/t/baggy-subclass-add.t
+++ b/t/baggy-subclass-add.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 6;
+
+# `(+)` of two instances of the SAME Bag subclass returns that subclass,
+# not a plain Bag (roast S02-types/bag.t #252, rakudo#5190).
+my class Foo is Bag {}
+
+my $u = Foo.new("a") (+) Foo.new("b");
+isa-ok $u, Foo, 'Foo (+) Foo is a Foo';
+isa-ok $u, Bag, 'the result is still a Bag';
+is $u<a>, 1, 'union kept the "a" weight';
+is $u<b>, 1, 'union kept the "b" weight';
+
+# Two plain Bags still union to a plain Bag (no spurious subclass wrapping).
+my $p = bag(<a b>) (+) bag(<b c>);
+isa-ok $p, Bag, 'Bag (+) Bag is a plain Bag';
+is $p<b>, 2, 'plain-Bag union adds weights';


### PR DESCRIPTION
Whitelists **roast/S02-types/bag.t** (255 tests — was 1 failure, test 252).

## Root cause
`class Foo is Bag {}` instances store their real quantified collection in the `__baggy_data__` attribute (see `construct_baggy_instance`). The VM set-arithmetic coercions (`coerce_to_bag` / `coerce_to_mix`, used by `(+)` and friends) had no arm for such an instance, so it fell through to `coerce_to_set` and was treated as a single opaque element:
```raku
Foo.new("a") (+) Foo.new("b")   # was bag(Foo() => 2), should be bag(a => 1, b => 1)
```

## Fix
- Add an `Instance` + `__baggy_data__` arm to `coerce_to_bag` / `coerce_to_mix` that unwraps and recurses, so a Baggy subclass contributes its real elements.
- `exec_set_addition_op` rewraps the finished Bag-level union under the common subclass when BOTH operands are instances of the same one, so `Foo.new("a") (+) Foo.new("b")` isa `Foo` (rakudo#5190) while `Bag (+) Bag` stays a plain Bag.

## Testing
- roast/S02-types/bag.t: 255/255, added to whitelist.
- New guard `t/baggy-subclass-add.t` (isa Foo + isa Bag + correct weights + plain-Bag unaffected).
- `make test` + bag/set/mix roast green; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)