### PR TITLE
fix(mro): role-MRO linearization + hides/is-hidden mro_unhidden filtering

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1,6 +1,7 @@
 roast/6.c/S02-names/SETTING-6c.t
 roast/6.c/S02-types/subset-6c.t
 roast/6.c/S05-grammar/parse_and_parsefile-6c.t
+roast/6.c/S12-class/mro-6c.t
 roast/6.c/S14-roles/submethods.t
 roast/6.d/S02-literals/version.t
 roast/6.d/S05-capture/match-object.t

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -220,21 +220,28 @@ impl Interpreter {
 
     /// MRO without hidden classes (no roles)
     pub(super) fn classhow_mro_unhidden_names(&mut self, invocant: &Value) -> Vec<String> {
-        let class_name = match invocant {
-            Value::Package(name) => name.resolve(),
-            Value::Instance { class_name, .. } => class_name.resolve(),
-            other => value_type_name(other).to_string(),
-        };
         let mro = self.classhow_mro_names(invocant);
-        let hidden_parents: HashSet<String> = self
-            .registry()
-            .hidden_defer_parents
-            .get(&class_name)
-            .cloned()
-            .unwrap_or_default();
         let mut hidden_set: HashSet<String> = HashSet::new();
-        for hp in &hidden_parents {
-            hidden_set.insert(hp.clone());
+        // `hides P` is recorded per-declaring-class in `hidden_defer_parents`, so a
+        // parent hidden by an ANCESTOR (`class C3 hides C2; class C4 is C3`) must
+        // still be filtered from `C4.^mro_unhidden`. Aggregate the hidden-parent
+        // sets of every class along the MRO, not just the invocant's.
+        for cls in &mro {
+            if let Some(hps) = self.registry().hidden_defer_parents.get(cls) {
+                for hp in hps {
+                    hidden_set.insert(hp.clone());
+                }
+            }
+            // A `does`-composed role contributes methods but is NOT an MRO entry in
+            // Rakudo's `.^mro_unhidden` (unlike an `is Role` pun, which stays). mutsu
+            // keeps composed roles in `parents` for introspection, so drop the
+            // pure-`does` ones (tracked in `class_does_only_roles`); `is Role` puns
+            // are not recorded there.
+            if let Some(roles) = self.registry().class_does_only_roles.get(cls) {
+                for r in roles {
+                    hidden_set.insert(r.clone());
+                }
+            }
         }
         for hc in &self.registry().hidden_classes {
             hidden_set.insert(hc.clone());

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -1045,6 +1045,34 @@ impl Interpreter {
         // like `A.^add_method(...)` inside the declaration can resolve `A`.
         // Clear stale method wrap chains from a previous class with the same name.
         self.method_wrap_chains.retain(|(cls, _, _), _| cls != name);
+        // `class C hides P` marks parent P hidden from C's (and descendants')
+        // `.^mro_unhidden`. Record it so the mro_unhidden filter can drop P.
+        if !hidden_parents.is_empty() {
+            self.registry_mut()
+                .hidden_defer_parents
+                .entry(name.to_string())
+                .or_default()
+                .extend(hidden_parents.iter().cloned());
+        }
+        // Roles composed via `does` (not `is Role` puns) are not MRO entries in
+        // Rakudo's `.^mro_unhidden`; record them so the filter can drop them.
+        if !does_parents.is_empty() {
+            let does_roles: Vec<String> = does_parents
+                .iter()
+                .filter(|p| {
+                    let base = p.split_once('[').map(|(b, _)| b).unwrap_or(p);
+                    self.registry().roles.contains_key(base)
+                })
+                .cloned()
+                .collect();
+            if !does_roles.is_empty() {
+                self.registry_mut()
+                    .class_does_only_roles
+                    .entry(name.to_string())
+                    .or_default()
+                    .extend(does_roles);
+            }
+        }
         self.registry_mut()
             .classes
             .insert(name.to_string(), class_def.clone());

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -81,6 +81,10 @@ pub(crate) struct Registry {
     /// ambiguous (Raku resolves a qualified role call against the immediate
     /// roles of the consumer).
     pub(crate) class_direct_composed_roles: HashMap<String, Vec<String>>,
+    /// Roles composed PURELY via `does` (not `is Role` puns): class -> [role names].
+    /// A `does`-composed role provides methods but is NOT an MRO entry in Rakudo's
+    /// `.^mro_unhidden`, so this set is filtered out of that introspection.
+    pub(crate) class_does_only_roles: HashMap<String, Vec<String>>,
     /// Roles implicitly composed by enums: enum -> [role names].
     pub(crate) class_enum_roles: HashMap<String, Vec<String>>,
     /// Subs declared inside a class body: class -> (sub name -> value).
@@ -199,6 +203,33 @@ impl Registry {
             vec!["Any".to_string()]
         } else {
             explicit_parents
+        };
+        // Reorder so a `is Role` parent's class-ancestor sits immediately after the
+        // role (`class C3 is R3a is R3b` where `role R3a is C2` -> C3, R3a, C2, C1,
+        // R3b, ...  matching Rakudo's C3 linearization). Registration appends the
+        // role's class-ancestor at the END of `parents`, which would otherwise let a
+        // sibling parent (`is R3b`) sort ahead of it.
+        let parents: Vec<String> = {
+            let mut ordered: Vec<String> = Vec::new();
+            for p in &parents {
+                if !ordered.contains(p) {
+                    ordered.push(p.clone());
+                }
+                if let Some(rps) = self.role_parents.get(p) {
+                    for rp in rps {
+                        let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp).to_string();
+                        if self.classes.contains_key(&rp_base) && !ordered.contains(&rp_base) {
+                            ordered.push(rp_base);
+                        }
+                    }
+                }
+            }
+            for p in &parents {
+                if !ordered.contains(p) {
+                    ordered.push(p.clone());
+                }
+            }
+            ordered
         };
         let mut seqs: Vec<Vec<String>> = Vec::new();
         for parent in &parents {

--- a/t/mro-role-hides.t
+++ b/t/mro-role-hides.t
@@ -1,0 +1,55 @@
+use Test;
+
+plan 6;
+
+# `is Role` where the role inherits a class: the role's class-ancestor is
+# linearized right after the role (C3-linearization order), not after siblings.
+{
+    my class C1 { }
+    my class C2 is C1 { }
+    my role R3a is C2 { }
+    my role R3b { }
+    my class C3 is R3a is R3b { }
+    my class C4 is C3 { }
+    is-deeply C4.^mro[1..5], (C3, R3a.^pun, C2, C1, R3b.^pun),
+        'is-Role class-ancestor linearizes right after the role';
+}
+
+# `class C hides P` drops parent P from .^mro_unhidden (also via an ancestor).
+{
+    my class C1 { }
+    my class C2 is C1 { }
+    my class C3 hides C2 { }
+    my class C4 is C3 { }
+    is-deeply C4.^mro_unhidden[0..*-3], (C4, C3, C1), 'hides on a class (via ancestor)';
+}
+
+# `role R hides P; class C does R`: hide is preserved and the does-role is not
+# an mro_unhidden entry.
+{
+    my class C1 { }
+    my class C2 is C1 { }
+    my role R3a hides C2 { }
+    my class C3 does R3a { }
+    my class C4 is C3 { }
+    is-deeply C4.^mro_unhidden[0..*-3], (C4, C3, C1), 'hides on a consumed does-role';
+}
+
+# `is hidden` on a puned role.
+{
+    my class C1 { }
+    my class C2 is C1 { }
+    my role R3a is C2 is hidden { }
+    my role R3b { }
+    my class C3 is R3a is R3b { }
+    my class C4 is C3 { }
+    is-deeply C4.^mro_unhidden[0..*-3], (C4, C3, C2, C1, R3b.^pun), 'is hidden on a puned role';
+}
+
+# A plain does-role provides methods but is not an mro_unhidden entry.
+{
+    role Greet { method hi { 'hi' } }
+    my class G does Greet { }
+    ok G.new.hi eq 'hi', 'does-role method is composed';
+    nok G.^mro_unhidden.map(*.^name).grep('Greet'), 'does-role is not an mro_unhidden entry';
+}


### PR DESCRIPTION
Whitelists **roast/6.c/S12-class/mro-6c.t** (was the "Hidden classes" subtest failing).

Four coordinated fixes to role-aware MRO semantics:
1. `Registry::compute_class_mro` reorders `parents` so an `is Role` parent whose role inherits a class puts that class-ancestor immediately after the role (`class C3 is R3a is R3b`, `role R3a is C2` → C3, R3a, C2, C1, R3b — Rakudo's C3 linearization). Registration appended the ancestor at the end, letting a sibling parent sort ahead.
2. `class C hides P` now records P into `hidden_defer_parents` (was only used for X::InvalidType).
3. `classhow_mro_unhidden_names` aggregates the hidden-parent sets of **every** class along the MRO (not just the invocant), so a parent hidden by an ancestor is dropped from `.^mro_unhidden`.
4. New `Registry::class_does_only_roles` (from the parser's `does` parents) lets `mro_unhidden` drop purely-`does`-composed roles (methods but not MRO entries in Rakudo), while keeping `is Role` puns.

## Testing
- mro-6c.t 5/5 (whitelisted), new `t/mro-role-hides.t` 6/6.
- S12/S14 role/class roast + role/class/mro t/ suite green.
- CI's make roast is the comprehensive net for blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)