### PR TITLE
docs(plan): point GC campaign's next-session marker at §11 step 4

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -384,8 +384,12 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
          `InstanceAttrs`/`SharedPromise`/`SharedChannel`）
       3. ✅ `MUTSU_VM_STATS` の GC カウンタ枠（`vm/vm_stats.rs`: collections/candidate_pushes/
          dedup_hits/reclaimed_nodes/reclaimed_cycles/pause_ns_total/pause_ns_max/roots_scanned。
-         全て 0 固定 — 呼び出し元は §11 step 4 以降）← **いまここ**
-      4. `Gc<T>` / node header / candidate buffer の最小実装
+         全て 0 固定 — 呼び出し元は §11 step 4 以降）
+      4. `Gc<T>` / node header / candidate buffer の最小実装 ← **次はここ（次セッション開始点）**。
+         設計メモ §5.1（node header: strong refcount 相当・color/state・buffered フラグ・
+         `trace(&mut Visitor)` vtable 相当）と §1（Level 1a=同期・協調 collector、safepoint は
+         再入境界に限定）を先に読むこと。まだ `Value` のどの variant も `Arc→Gc` に置換しない
+         （それは step 5 以降の first wave）。
       5〜11. `Array`/`Hash`/`ContainerRef` → `Promise`/`Channel` → supply registry → safepoint collect →
       `Sub`/`Instance` → `LazyList`（詳細は設計メモ参照）。
       **Track B（要素 cell 化）と GC は統合キャンペーン（層3a・`Arc → Gc<T>` 一斉置換）**。続いて NaN-boxing


### PR DESCRIPTION
## Summary
- Steps 1-3 of the GC Level 1a campaign are merged (#4094, #4096, #4099). Moves PLAN.md's "いまここ" marker to step 4 (`Gc<T>`/node header/candidate buffer) with a pointer to the design doc sections to read first (§5.1 node header fields, §1 synchronous/cooperative collector model), so a future session can resume immediately.

## Test plan
- Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK