### PR TITLE
feat(vm): builtin-MRO all-candidates dispatch for .+/.* (§2, roast hyper.t #407)

### DIFF
--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -466,8 +466,16 @@ impl Interpreter {
     /// Check if a builtin type inherits from a given ancestor type.
     /// Covers the standard Raku type hierarchy for builtin types.
     pub(super) fn type_inherits(type_name: &str, ancestor: &str) -> bool {
-        // Standard hierarchy chains for builtin types
-        let chain: &[&str] = match type_name {
+        Self::builtin_type_mro_chain(type_name).contains(&ancestor)
+    }
+
+    /// The built-in type's MRO chain (self + ancestors), used by `type_inherits`
+    /// and by `.+`/`.*` all-candidates dispatch to count how many MRO levels
+    /// define a method. Roles (e.g. `Positional`) are intentionally omitted: they
+    /// carry no entry in `builtin_type_method_names`, so they never contribute a
+    /// candidate, and omitting them keeps this chain small.
+    pub(crate) fn builtin_type_mro_chain(type_name: &str) -> &'static [&'static str] {
+        match type_name {
             "Int" => &["Int", "Cool", "Any", "Mu"],
             "Num" => &["Num", "Cool", "Any", "Mu"],
             "Rat" | "FatRat" => &["Rat", "Cool", "Any", "Mu"],
@@ -486,7 +494,6 @@ impl Interpreter {
             "Sub" => &["Sub", "Routine", "Block", "Code", "Any", "Mu"],
             "Junction" => &["Junction", "Mu"],
             _ => &["Any", "Mu"],
-        };
-        chain.contains(&ancestor)
+        }
     }
 }

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -254,7 +254,14 @@ impl Interpreter {
             }
         }
 
-        Ok(vec![self.call_method_with_values(target, method, args)?])
+        // Built-in (non-Instance) target: one native handler, but `.+`/`.*`
+        // (and the hyper `».+`/`».*`, which reach this via
+        // `call_method_all_with_temp_target`) must yield one result per MRO level
+        // that defines the method (e.g. `List.elems` + `Any.elems`). §2 builtin-MRO
+        // all-candidates dispatch (roast S03-metaops/hyper.t 407-408).
+        let count = self.builtin_mro_method_candidate_count(&target, method);
+        let result = self.call_method_with_values(target, method, args)?;
+        Ok(vec![result; count])
     }
 
     pub(crate) fn overwrite_array_items_by_identity_for_vm(

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -219,6 +219,37 @@ impl Interpreter {
         }
     }
 
+    /// How many levels of a *built-in* type's MRO define `method`, for `.+`/`.*`
+    /// all-candidates dispatch. mutsu implements a built-in method as one flat
+    /// native handler, but Raku models it as a method object at each MRO level
+    /// that defines it (e.g. `List.elems` AND `Any.elems`), so `<a b>.+elems`
+    /// yields `(2, 2)` — one result per defining level, all from the same handler.
+    /// Data-driven from the per-type method tables (`builtin_type_method_names`,
+    /// the same lists `.^methods`/`.^can` use) intersected with the type's MRO —
+    /// NOT a hard-coded per-method count. Returns 1 for a user `Instance` (its
+    /// candidates come from `resolve_all_methods_with_owner`) or when only one
+    /// level (or none — caller keeps the single native result) defines it.
+    pub(crate) fn builtin_mro_method_candidate_count(
+        &mut self,
+        target: &Value,
+        method: &str,
+    ) -> usize {
+        if matches!(target, Value::Instance { .. } | Value::Mixin(..)) {
+            return 1;
+        }
+        // Use the *introspective* type name (List vs Array distinguished by
+        // ArrayKind), so `<a b>` (List) walks the List MRO, not Array's.
+        let type_name = crate::runtime::value_type_name(target);
+        let count = Self::builtin_type_mro_chain(type_name)
+            .iter()
+            .filter(|cn| {
+                crate::builtins::builtin_type_methods::builtin_type_method_names(cn)
+                    .contains(&method)
+            })
+            .count();
+        count.max(1)
+    }
+
     pub(super) fn call_method_all_with_fallback(
         &mut self,
         target: &Value,
@@ -230,7 +261,12 @@ impl Interpreter {
             && let Some(native_result) =
                 self.try_native_method(target, Symbol::intern(method), args)
         {
-            return Ok(vec![native_result?]);
+            let result = native_result?;
+            // `.+`/`.*` on a built-in: emit one result per MRO level that defines
+            // the method (all identical — same native handler). §2 builtin-MRO
+            // all-candidates dispatch (roast S03-metaops/hyper.t 407-408).
+            let count = self.builtin_mro_method_candidate_count(target, method);
+            return Ok(vec![result; count]);
         }
         loan_env!(
             self,

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -308,7 +308,11 @@ impl Interpreter {
                         if let Some(native_result) =
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                         {
-                            vec![native_result?]
+                            // One result per MRO level defining the method
+                            // (builtin-MRO all-candidates; hyper `».+`).
+                            let r = native_result?;
+                            let count = self.builtin_mro_method_candidate_count(item, &method);
+                            vec![r; count]
                         } else {
                             let (v, updated) = self
                                 .call_method_all_with_temp_target(item, &method, item_args, idx)?;
@@ -321,7 +325,8 @@ impl Interpreter {
                         *item = updated;
                         v
                     };
-                    results.push(Value::real_array(vals));
+                    // `.+`/`.*` yield a List (parens), not an Array.
+                    results.push(Value::array(vals));
                 }
                 Some("*") => {
                     if !skip_native
@@ -329,16 +334,19 @@ impl Interpreter {
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                     {
                         match native_result {
-                            Ok(v) => results.push(Value::real_array(vec![v])),
-                            Err(_) => results.push(Value::real_array(vec![])),
+                            Ok(v) => {
+                                let count = self.builtin_mro_method_candidate_count(item, &method);
+                                results.push(Value::array(vec![v; count]))
+                            }
+                            Err(_) => results.push(Value::array(vec![])),
                         }
                     } else {
                         match self.call_method_all_with_temp_target(item, &method, item_args, idx) {
                             Ok((vals, updated)) => {
                                 *item = updated;
-                                results.push(Value::real_array(vals));
+                                results.push(Value::array(vals));
                             }
-                            Err(_) => results.push(Value::real_array(vec![])),
+                            Err(_) => results.push(Value::array(vec![])),
                         }
                     }
                 }
@@ -846,28 +854,33 @@ impl Interpreter {
                     let vals = if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
-                        vec![native_result?]
+                        let r = native_result?;
+                        let count = self.builtin_mro_method_candidate_count(item, method);
+                        vec![r; count]
                     } else {
                         let (v, updated) =
                             self.call_method_all_with_temp_target(item, method, item_args, idx)?;
                         *item = updated;
                         v
                     };
-                    results.push(Value::real_array(vals));
+                    results.push(Value::array(vals));
                 }
                 Some("*") => {
                     if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
                         match native_result {
-                            Ok(v) => results.push(Value::real_array(vec![v])),
-                            Err(_) => results.push(Value::real_array(vec![])),
+                            Ok(v) => {
+                                let count = self.builtin_mro_method_candidate_count(item, method);
+                                results.push(Value::array(vec![v; count]))
+                            }
+                            Err(_) => results.push(Value::array(vec![])),
                         }
                     } else {
                         match self.call_method_all_with_temp_target(item, method, item_args, idx) {
                             Ok((vals, updated)) => {
                                 *item = updated;
-                                results.push(Value::real_array(vals));
+                                results.push(Value::array(vals));
                             }
                             Err(_) => results.push(Value::real_array(vec![])),
                         }

--- a/t/builtin-mro-all-candidates.t
+++ b/t/builtin-mro-all-candidates.t
@@ -1,0 +1,28 @@
+use Test;
+
+# §2 builtin-MRO all-candidates dispatch: `.+`/`.*` on a built-in type must yield
+# one result per MRO level that defines the method. `List.elems` and `Any.elems`
+# both define elems, so `<a b>.+elems` is (2, 2). Data-driven from the per-type
+# method tables (builtin_type_method_names) intersected with the type's MRO.
+# Mirrors roast/S03-metaops/hyper.t #407.
+
+plan 8;
+
+# Bare `.+`/`.*` on a List: List.elems + Any.elems = 2 candidates, both 2.
+is-deeply <a b>.+elems, (2, 2), '.+elems on a List yields both MRO candidates';
+is-deeply <a b>.*elems, (2, 2), '.*elems on a List yields both MRO candidates';
+
+# The result is a List (parens), not an Array.
+ok <a b>.+elems ~~ List, '.+ returns a List';
+
+# Hyper `».+`/`».*` applies per element.
+my @a := <a b>, <c d e>;
+is-deeply @a».+elems, ((2, 2), (3, 3)), '».+elems (hyper, all candidates)';
+is-deeply @a».*elems, ((2, 2), (3, 3)), '».*elems (hyper, all candidates)';
+
+# Coderef / qualified forms are single-candidate.
+is-deeply @a».+&elems, ((2,), (3,)), '».+& is single-candidate';
+is-deeply @a».+Any::elems, ((2,), (3,)), '».+:: (qualified) is single-candidate';
+
+# `.*` on a method the type does not have yields the empty list.
+is-deeply 42.*no-such-method-xyz, (), '.* on a missing method is ()';

--- a/t/parallel-dispatch-regression.t
+++ b/t/parallel-dispatch-regression.t
@@ -21,8 +21,10 @@ class PDRegMulti {
 }
 
 my @m = (1..2).map({ PDRegMulti.new(v => $_) });
-# Hyper dispatch on @-variable returns Array (same container type as input)
-is-deeply @m».*mul(2), [[2], [4]], 'hyper .* returns all matching method candidates';
-is-deeply @m».+mul(2), [[2], [4]], 'hyper .+ returns all matching method candidates';
+# Hyper dispatch on @-variable returns an Array (same container type as input);
+# each per-element `.+`/`.*` result is itself a List (matches raku:
+# `@m».+mul(2)` is `[(2,), (4,)]`).
+is-deeply @m».*mul(2), [(2,), (4,)], 'hyper .* returns all matching method candidates';
+is-deeply @m».+mul(2), [(2,), (4,)], 'hyper .+ returns all matching method candidates';
 
 is (a => 1, a => 2)>>.<a>, '1 2', 'hyper >>.<key> works on pairs';


### PR DESCRIPTION
## Summary

§2 multi-dispatch: `.+method`/`.*method` (and hyper `».+`/`».*`) on a **built-in** type now yield one result per MRO level that defines the method, matching raku — e.g. `List.elems` and `Any.elems` both define `elems`, so `<a b>.+elems` is `(2, 2)`.

mutsu implements a built-in method as **one flat native handler**, so both candidates run the same handler and return the same value; what was missing was the candidate **count**. That count is derived **data-driven** from the existing per-type method tables (`builtin_type_method_names`, the same lists `.^methods`/`.^can` use) intersected with the type's built-in MRO chain (`builtin_type_mro_chain`, extracted from `type_inherits`) — **not** a hard-coded per-method count (which BLOCKERS explicitly forbids). The `.+`/`.*` result is a List, not an Array.

## Effect

`roast/S03-metaops/hyper.t` #407 (`method call variants respect nodality`) now passes (`».+elems` = `((2, 2), (3, 3))`). hyper.t goes 418→419/420; the remaining #408 is a separate `atomicint`/`&`-nodal-sub-call-count issue.

## Test plan

- `make test` (via `prove t/`): **green** (Files=1456, Failed=0).
- new pin `t/builtin-mro-all-candidates.t` (8 assertions).
- `t/parallel-dispatch-regression.t` updated to raku's actual result: `@m».+mul(2)` is `[(2,), (4,)]`  (outer Array preserved, inner List) — the old `[[2], [4]]` expectation was mutsu's pre-fix Array-inner output; verified against raku.
- Regression-checked S12-methods/multi, instance, S03-metaops/cross, reverse — no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)