### PR TITLE
Complete S03-metaops/hyper.t (420/420): builtin-MRO all-candidates dispatch + atomicint closure reset

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -32,8 +32,8 @@
   1. **第一級コンテナ / container identity** — 配列・ハッシュ要素・属性 slot の書き戻し、
      BEGIN/EVAL 時の lexical 永続化。
   2. **真の lazy 配列 / 無限列** — 残りは `S09-subscript/slice.t` のみ。
-  3. **dispatch / 演算子 sugar の desugar surface** — 残りは `hyper.t` のみ
-     （`assign.t` は完了、詳細は `news/2026-07.md`）。
+  3. **dispatch / 演算子 sugar の desugar surface** — 完了（`hyper.t`・`assign.t`
+     とも whitelist 済み、詳細は `news/2026-07.md`）。
   4. **並行実行基盤（S17）** — `Lock.protect` の race condition は解決済み
      （§6 参照）。残るのは `S17-supply/syntax.t` のみ。
 
@@ -308,42 +308,24 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 
 ## 5. dispatch cluster
 
-`wrap.t` / `dispatching.t` / `qualified.t` / `assign.t` は完了済み（詳細は
-`news/2026-06.md` / `news/2026-07.md`）。残るのは演算子 sugar が dispatch へ落ちるまでの
-surface のうち 1 ファイル。
+`wrap.t` / `dispatching.t` / `qualified.t` / `assign.t` / `hyper.t` は完了済み（詳細は
+`news/2026-06.md` / `news/2026-07.md`）。演算子 sugar が dispatch へ落ちるまでの surface は
+すべて whitelist 済みで、このクラスタに残件はない。
 
-### 5.1 `S03-metaops/hyper.t`
+### 5.1 `S03-metaops/hyper.t` — **DONE・whitelist 済み（2026-07-03）**
 
-- **現状（2026-07-03 再検証）**: 418/420、**2 失敗（test 407-408）**。test 362（custom
-  `infix:<+-*/>` の字句解析）は解消済み（`5+-*/2` = `(7 3 10 2.5)`、raku 一致）。残る
-  407-408 は両方とも `».+`/`».*` の **builtin-MRO all-candidates dispatch gap** に blocked
-  （下記参照）。`»."{名前式}"()`（動的メソッド名の compute-once）等の非 `.+`/`.*` 部分は動作。
-- **今回の進捗**: plan mismatch の原因は `<<op>>` 系ハイパーメタ演算子の閉じ `>>` 探索が
-  演算子文字列自体と重なるケース（`<<=>>>` = `<<`+`=>`+`>>`）で誤って最短一致を採用し、
-  以降のファイル全体を静かに打ち切っていたパーサバグだった（`hyper_concat.rs`）。
-  副次的に `set_shared_var`（`@`/`%` への env 書き込み全経路を通る、hyper 専用ではない
-  一般関数）が非スレッド文脈でも List→Array を無条件正規化しており、`:=` で束縛した
-  List の kind を最初の env sync で破壊していた一般バグも発見・修正。さらに `is_listy()`
-  （hyper 分配の判定）に `Value::Slip` が抜けており `|<1 2> >>xx>> 2` が per-element
-  分配されない不具合、および `.i`（postfix imaginary）が dotted 呼び出し
-  （`4.i`/`@a».i`、本来 X::Method::NotFound）と bare 呼び出し
-  （`4\i`/`(expr)i`/`@a»i`、`&postfix:<i>` 演算子）を区別できていなかった不具合を修正。
-  詳細は `TODO_roast/S03.md` の hyper.t エントリと news 参照。
-- **残り 3 件**: (1) test 362 ユーザ定義 custom infix 演算子とビルトイン演算子文字の
-  字句衝突（`infix:<+-*/>` の `*` が Whatever と誤認）、(2)(3) test 407-408 `».+`/`».*` の
-  all-candidates MRO dispatch 未実装（非 hyper の `.+`/`.*` でも同じ欠落を確認済み —
-  mutsu のビルトイン型は List/Any/Cool のような多段クラス階層に渡る重複メソッド定義を
-  モデル化していない、根本的なアーキテクチャギャップ。個別メソッドの候補数を
-  ハードコードするのは禁止されているテスト特化ハックそのものなので不可）。
-  いずれも局所修正では閉じない、それぞれ独立した深掘りが必要な項目。
-- **変更レイヤ**: `src/parser/expr/precedence_meta_ops/hyper_concat.rs`,
-  `src/vm/vm_hyper_method_ops.rs`, `src/vm/vm_hyper_ops.rs`,
-  `src/runtime/runtime_shared_vars.rs`, `src/parser/expr/postfix/loop_.rs`,
-  `src/parser/primary/number.rs`, `src/runtime/builtins_operators_fallback.rs`
-- **Next slice**: 残り 3 件はいずれも大きめの独立作業（custom operator の longest-match
-  字句解析、MRO 多重候補 dispatch の新規実装）。次に着手するなら (2)(3) の
-  all-candidates dispatch が最も汎用的（他の `».+`/`».*` 系テストにも波及しうる）が、
-  スコープはこのファイル単体では収まらない見込み。
+420/420 PASS。最後まで残っていた 2 件を解消:
+- **test 407**（`».+&`/`».*&` の builtin-MRO all-candidates dispatch）: `.+`/`.*` が
+  List/Any/Cool のような多段クラス階層をまたぐ全候補を呼べるよう VM 側で対応
+  （`vm_call_helpers.rs` / `vm_hyper_method_ops.rs` / `methods_call_helpers.rs`）。
+- **test 408**（atomicint のクロージャ内リセット書き戻し）: `subtest {...}` のような
+  ネストしたクロージャフレーム内での `$r = 0`（`atomicint` へのプレーン代入）が共有
+  atomic セルをリセットせず、次の `⚛++` が古い値を読んでいた。真因は
+  `reset_atomic_var_key` が現フレームの `env` でしか name→value_key マッピングを探さず、
+  かつ SetGlobal 経路（自由変数書き込み）にリセット呼び出しが無かったこと。
+  SetGlobal store に SetLocal と同じ atomic リセットを追加し、`reset_atomic_var_key` に
+  shared_vars フォールバックを追加（`vm_exec_dispatch.rs` / `runtime_shared_vars.rs`）。
+  回帰テスト＝`t/atomicint-closure-reset-writeback.t`。
 
 ---
 
@@ -409,12 +391,10 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowl
 1. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
    splice.t / attributes.t / multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-2. **`S03-metaops/hyper.t`**（§5）— plan mismatch の原因を先に特定してから、
-   残りの失敗を分類して潰す。
-3. **`S09-subscript/slice.t`**（§4）— lazy array 起因の失敗は解消済み（2026-07-02）。
-   残り 6 件は test 35（nested slice adverbs、§3 と同根の大仕事）以外は独立した
+2. **`S09-subscript/slice.t`**（§4）— lazy array 起因の失敗は解消済み（2026-07-02）。
+   残り 4 件は test 35（nested slice adverbs、§3 と同根の大仕事）以外は独立した
    小粒な機能ギャップ。
-4. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
+3. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
 
 `S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が
 深いアーキテクチャ変更を要するため、上記優先順から外した。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,30 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-03: `S03-metaops/hyper.t` 完了（420/420、whitelist 追加）
+
+dispatch cluster の最後の 1 ファイル `S03-metaops/hyper.t` を whitelist 化。残り 2 件を解消した。
+
+1. **test 407 — builtin-MRO all-candidates dispatch（`».+&` / `».*&`）**: `.+`/`.*` が
+   List/Any/Cool のような多段クラス階層をまたぐ全候補を呼べるよう VM 側で対応
+   （`src/vm/vm_call_helpers.rs` / `src/vm/vm_hyper_method_ops.rs` /
+   `src/runtime/methods_call_helpers.rs` / `src/runtime/methods_signature_shaped.rs`）。
+2. **test 408 — atomicint のクロージャ内リセット書き戻し**: `subtest {...}` のような
+   ネストしたクロージャフレーム内での `$r = 0`（`atomicint` へのプレーン代入）が共有
+   atomic セルをリセットせず、次の `⚛++` が古い値を読み続けていた（`$runs` が 2→4→6→8 と
+   累積）。真因は 2 つ:
+   - `reset_atomic_var_key` が現フレームの `self.env` でしか `name→value_key` マッピングを
+     探しておらず、マッピングが `shared_vars`（フレーム横断で権威）にしか無いネストフレーム
+     からは silent no-op していた。→ `shared_vars` フォールバックを追加。
+   - そもそもクロージャの自由変数書き込みは SetLocal ではなく **SetGlobal** 経路を通り、
+     そこにリセット呼び出しが無かった。→ SetGlobal store に SetLocal と同じ atomic リセットを
+     追加（`src/vm/vm_exec_dispatch.rs` / `src/runtime/runtime_shared_vars.rs`）。
+   plain int の同型ケースが動いていたのは通常の captured-writeback 機構経由だったため。
+   回帰テスト＝`t/atomicint-closure-reset-writeback.t`。既存の全 atomic/cas roast・
+   local テストで回帰なし。
+
+これで BLOCKERS.md §5 dispatch cluster の残件はゼロになった。
+
 ## 2026-07-02: 真の lazy 配列キャンペーン — `S09-subscript/slice.t` の根本原因 6 件を解消
 
 BLOCKERS.md §4「真の lazy 配列 / 無限列」の最後の 1 ファイルだった

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -193,6 +193,7 @@ roast/S03-junctions/boolean-context.t
 roast/S03-junctions/misc.t
 roast/S03-metaops/cross.t
 roast/S03-metaops/eager-hyper.t
+roast/S03-metaops/hyper.t
 roast/S03-metaops/infix.t
 roast/S03-metaops/misc.t
 roast/S03-metaops/not.t

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -466,8 +466,16 @@ impl Interpreter {
     /// Check if a builtin type inherits from a given ancestor type.
     /// Covers the standard Raku type hierarchy for builtin types.
     pub(super) fn type_inherits(type_name: &str, ancestor: &str) -> bool {
-        // Standard hierarchy chains for builtin types
-        let chain: &[&str] = match type_name {
+        Self::builtin_type_mro_chain(type_name).contains(&ancestor)
+    }
+
+    /// The built-in type's MRO chain (self + ancestors), used by `type_inherits`
+    /// and by `.+`/`.*` all-candidates dispatch to count how many MRO levels
+    /// define a method. Roles (e.g. `Positional`) are intentionally omitted: they
+    /// carry no entry in `builtin_type_method_names`, so they never contribute a
+    /// candidate, and omitting them keeps this chain small.
+    pub(crate) fn builtin_type_mro_chain(type_name: &str) -> &'static [&'static str] {
+        match type_name {
             "Int" => &["Int", "Cool", "Any", "Mu"],
             "Num" => &["Num", "Cool", "Any", "Mu"],
             "Rat" | "FatRat" => &["Rat", "Cool", "Any", "Mu"],
@@ -486,7 +494,6 @@ impl Interpreter {
             "Sub" => &["Sub", "Routine", "Block", "Code", "Any", "Mu"],
             "Junction" => &["Junction", "Mu"],
             _ => &["Any", "Mu"],
-        };
-        chain.contains(&ancestor)
+        }
     }
 }

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -254,7 +254,14 @@ impl Interpreter {
             }
         }
 
-        Ok(vec![self.call_method_with_values(target, method, args)?])
+        // Built-in (non-Instance) target: one native handler, but `.+`/`.*`
+        // (and the hyper `».+`/`».*`, which reach this via
+        // `call_method_all_with_temp_target`) must yield one result per MRO level
+        // that defines the method (e.g. `List.elems` + `Any.elems`). §2 builtin-MRO
+        // all-candidates dispatch (roast S03-metaops/hyper.t 407-408).
+        let count = self.builtin_mro_method_candidate_count(&target, method);
+        let result = self.call_method_with_values(target, method, args)?;
+        Ok(vec![result; count])
     }
 
     pub(crate) fn overwrite_array_items_by_identity_for_vm(

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -456,8 +456,24 @@ impl Interpreter {
 
     pub(crate) fn reset_atomic_var_key(&mut self, name: &str) {
         let name_key = format!("__mutsu_atomic_name::{name}");
-        let Some(Value::Str(value_key)) = self.env.remove(&name_key) else {
-            return;
+        // The name -> value_key mapping is authoritative in `shared_vars`
+        // (it survives across frames), while `env` only mirrors it for the
+        // frame that first registered the atomic. A plain assignment
+        // (`$r = 0`) executed inside a *nested* closure frame therefore may
+        // not find the mapping in this frame's `env` even though the shared
+        // cell still holds the atomic value. Fall back to `shared_vars` so the
+        // reset clears the shared cell in that case too; otherwise a later
+        // `atomic-fetch-add` reads the stale shared value instead of the
+        // freshly-assigned one (roast S03-metaops/hyper.t test 408).
+        let value_key = match self.env.remove(&name_key) {
+            Some(Value::Str(vk)) => vk,
+            _ => {
+                let shared = self.shared_vars.read().unwrap();
+                match shared.get(&name_key) {
+                    Some(Value::Str(vk)) => vk.clone(),
+                    _ => return,
+                }
+            }
         };
         let mut shared = self.shared_vars.write().unwrap();
         shared.remove(value_key.as_str());

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -219,6 +219,37 @@ impl Interpreter {
         }
     }
 
+    /// How many levels of a *built-in* type's MRO define `method`, for `.+`/`.*`
+    /// all-candidates dispatch. mutsu implements a built-in method as one flat
+    /// native handler, but Raku models it as a method object at each MRO level
+    /// that defines it (e.g. `List.elems` AND `Any.elems`), so `<a b>.+elems`
+    /// yields `(2, 2)` — one result per defining level, all from the same handler.
+    /// Data-driven from the per-type method tables (`builtin_type_method_names`,
+    /// the same lists `.^methods`/`.^can` use) intersected with the type's MRO —
+    /// NOT a hard-coded per-method count. Returns 1 for a user `Instance` (its
+    /// candidates come from `resolve_all_methods_with_owner`) or when only one
+    /// level (or none — caller keeps the single native result) defines it.
+    pub(crate) fn builtin_mro_method_candidate_count(
+        &mut self,
+        target: &Value,
+        method: &str,
+    ) -> usize {
+        if matches!(target, Value::Instance { .. } | Value::Mixin(..)) {
+            return 1;
+        }
+        // Use the *introspective* type name (List vs Array distinguished by
+        // ArrayKind), so `<a b>` (List) walks the List MRO, not Array's.
+        let type_name = crate::runtime::value_type_name(target);
+        let count = Self::builtin_type_mro_chain(type_name)
+            .iter()
+            .filter(|cn| {
+                crate::builtins::builtin_type_methods::builtin_type_method_names(cn)
+                    .contains(&method)
+            })
+            .count();
+        count.max(1)
+    }
+
     pub(super) fn call_method_all_with_fallback(
         &mut self,
         target: &Value,
@@ -230,7 +261,12 @@ impl Interpreter {
             && let Some(native_result) =
                 self.try_native_method(target, Symbol::intern(method), args)
         {
-            return Ok(vec![native_result?]);
+            let result = native_result?;
+            // `.+`/`.*` on a built-in: emit one result per MRO level that defines
+            // the method (all identical — same native handler). §2 builtin-MRO
+            // all-candidates dispatch (roast S03-metaops/hyper.t 407-408).
+            let count = self.builtin_mro_method_candidate_count(target, method);
+            return Ok(vec![result; count]);
         }
         loan_env!(
             self,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1108,6 +1108,24 @@ impl Interpreter {
                         return Ok(());
                     }
                 }
+                // A plain assignment to an atomic scalar de-registers its shared
+                // cell so the next atomic op re-seeds from the freshly-stored
+                // value. SetLocal does this at its own store site; SetGlobal is
+                // the path taken when the atomic is a captured free variable
+                // written from a nested closure frame (e.g. `$r = 0` inside a
+                // `subtest {...}` block), and must reset the shared cell too, or
+                // a later atomic-fetch-add reads the stale shared value instead
+                // of the freshly-assigned one (roast S03-metaops/hyper.t #408).
+                if !is_bind_ctx
+                    && !is_rebind
+                    && self.atomic_var_seen()
+                    && !name.starts_with('@')
+                    && !name.starts_with('%')
+                    && !name.starts_with('&')
+                {
+                    let atomic_name = name.strip_prefix('$').unwrap_or(&name).to_string();
+                    loan_env!(self, reset_atomic_var_key(&atomic_name));
+                }
                 if raw_mode && name.starts_with('@') {
                     // For `constant @x`, bypass set_shared_var's List→Array
                     // normalization so the container type (List) is preserved.

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -308,7 +308,11 @@ impl Interpreter {
                         if let Some(native_result) =
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                         {
-                            vec![native_result?]
+                            // One result per MRO level defining the method
+                            // (builtin-MRO all-candidates; hyper `».+`).
+                            let r = native_result?;
+                            let count = self.builtin_mro_method_candidate_count(item, &method);
+                            vec![r; count]
                         } else {
                             let (v, updated) = self
                                 .call_method_all_with_temp_target(item, &method, item_args, idx)?;
@@ -321,7 +325,8 @@ impl Interpreter {
                         *item = updated;
                         v
                     };
-                    results.push(Value::real_array(vals));
+                    // `.+`/`.*` yield a List (parens), not an Array.
+                    results.push(Value::array(vals));
                 }
                 Some("*") => {
                     if !skip_native
@@ -329,16 +334,19 @@ impl Interpreter {
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                     {
                         match native_result {
-                            Ok(v) => results.push(Value::real_array(vec![v])),
-                            Err(_) => results.push(Value::real_array(vec![])),
+                            Ok(v) => {
+                                let count = self.builtin_mro_method_candidate_count(item, &method);
+                                results.push(Value::array(vec![v; count]))
+                            }
+                            Err(_) => results.push(Value::array(vec![])),
                         }
                     } else {
                         match self.call_method_all_with_temp_target(item, &method, item_args, idx) {
                             Ok((vals, updated)) => {
                                 *item = updated;
-                                results.push(Value::real_array(vals));
+                                results.push(Value::array(vals));
                             }
-                            Err(_) => results.push(Value::real_array(vec![])),
+                            Err(_) => results.push(Value::array(vec![])),
                         }
                     }
                 }
@@ -846,28 +854,33 @@ impl Interpreter {
                     let vals = if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
-                        vec![native_result?]
+                        let r = native_result?;
+                        let count = self.builtin_mro_method_candidate_count(item, method);
+                        vec![r; count]
                     } else {
                         let (v, updated) =
                             self.call_method_all_with_temp_target(item, method, item_args, idx)?;
                         *item = updated;
                         v
                     };
-                    results.push(Value::real_array(vals));
+                    results.push(Value::array(vals));
                 }
                 Some("*") => {
                     if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
                         match native_result {
-                            Ok(v) => results.push(Value::real_array(vec![v])),
-                            Err(_) => results.push(Value::real_array(vec![])),
+                            Ok(v) => {
+                                let count = self.builtin_mro_method_candidate_count(item, method);
+                                results.push(Value::array(vec![v; count]))
+                            }
+                            Err(_) => results.push(Value::array(vec![])),
                         }
                     } else {
                         match self.call_method_all_with_temp_target(item, method, item_args, idx) {
                             Ok((vals, updated)) => {
                                 *item = updated;
-                                results.push(Value::real_array(vals));
+                                results.push(Value::array(vals));
                             }
                             Err(_) => results.push(Value::real_array(vec![])),
                         }

--- a/t/atomicint-closure-reset-writeback.t
+++ b/t/atomicint-closure-reset-writeback.t
@@ -1,0 +1,51 @@
+use Test;
+
+# Regression: a plain assignment (`$r = 0`) to an `atomicint` scalar performed
+# from inside a *nested closure frame* (e.g. a `subtest {...}` block) must reset
+# the shared atomic cell, so a subsequent atomic op re-seeds from the assigned
+# value instead of reading the stale shared value.
+#
+# Previously the reset only fired on the SetLocal store path and only when the
+# atomic name->value_key mapping lived in the current frame's env, so the reset
+# silently no-op'd from a nested frame and the atomic value kept accumulating.
+# (roast S03-metaops/hyper.t test 408.)
+
+plan 5;
+
+# --- bare block (same frame): always worked, kept as a guard ---
+{
+    my atomicint $r = 0;
+    sub bump-a is nodal { $r⚛++; 1 }
+    bump-a(); bump-a();
+    $r = 0;
+    bump-a();
+    is $r, 1, 'bare-block: reset then one atomic increment gives 1';
+}
+
+# --- reset inside a subtest closure, atomic op in an outer sub ---
+{
+    my atomicint $runs = 0;
+    sub bump-b is nodal { $runs⚛++; 1 }
+    subtest 'first subtest resets $runs at the end' => {
+        plan 1;
+        bump-b(); bump-b();
+        is $runs, 2, 'two increments';
+        $runs = 0;
+    }
+    subtest 'second subtest sees the reset' => {
+        plan 1;
+        bump-b(); bump-b();
+        is $runs, 2, 'reset from the previous closure took effect';
+        $runs = 0;
+    }
+}
+
+# --- atomic assign / atomic-fetch cross-frame coherence ---
+{
+    my atomicint $c = 10;
+    my $block = { $c = 3; };
+    $block();
+    is atomic-fetch($c), 3, 'plain assign in a closure is visible to atomic-fetch';
+    atomic-add-fetch($c, 4);
+    is $c, 7, 'atomic-add after a closure reset re-seeds from the assigned value';
+}

--- a/t/builtin-mro-all-candidates.t
+++ b/t/builtin-mro-all-candidates.t
@@ -1,0 +1,28 @@
+use Test;
+
+# §2 builtin-MRO all-candidates dispatch: `.+`/`.*` on a built-in type must yield
+# one result per MRO level that defines the method. `List.elems` and `Any.elems`
+# both define elems, so `<a b>.+elems` is (2, 2). Data-driven from the per-type
+# method tables (builtin_type_method_names) intersected with the type's MRO.
+# Mirrors roast/S03-metaops/hyper.t #407.
+
+plan 8;
+
+# Bare `.+`/`.*` on a List: List.elems + Any.elems = 2 candidates, both 2.
+is-deeply <a b>.+elems, (2, 2), '.+elems on a List yields both MRO candidates';
+is-deeply <a b>.*elems, (2, 2), '.*elems on a List yields both MRO candidates';
+
+# The result is a List (parens), not an Array.
+ok <a b>.+elems ~~ List, '.+ returns a List';
+
+# Hyper `».+`/`».*` applies per element.
+my @a := <a b>, <c d e>;
+is-deeply @a».+elems, ((2, 2), (3, 3)), '».+elems (hyper, all candidates)';
+is-deeply @a».*elems, ((2, 2), (3, 3)), '».*elems (hyper, all candidates)';
+
+# Coderef / qualified forms are single-candidate.
+is-deeply @a».+&elems, ((2,), (3,)), '».+& is single-candidate';
+is-deeply @a».+Any::elems, ((2,), (3,)), '».+:: (qualified) is single-candidate';
+
+# `.*` on a method the type does not have yields the empty list.
+is-deeply 42.*no-such-method-xyz, (), '.* on a missing method is ()';

--- a/t/parallel-dispatch-regression.t
+++ b/t/parallel-dispatch-regression.t
@@ -21,8 +21,10 @@ class PDRegMulti {
 }
 
 my @m = (1..2).map({ PDRegMulti.new(v => $_) });
-# Hyper dispatch on @-variable returns Array (same container type as input)
-is-deeply @m».*mul(2), [[2], [4]], 'hyper .* returns all matching method candidates';
-is-deeply @m».+mul(2), [[2], [4]], 'hyper .+ returns all matching method candidates';
+# Hyper dispatch on @-variable returns an Array (same container type as input);
+# each per-element `.+`/`.*` result is itself a List (matches raku:
+# `@m».+mul(2)` is `[(2,), (4,)]`).
+is-deeply @m».*mul(2), [(2,), (4,)], 'hyper .* returns all matching method candidates';
+is-deeply @m».+mul(2), [(2,), (4,)], 'hyper .+ returns all matching method candidates';
 
 is (a => 1, a => 2)>>.<a>, '1 2', 'hyper >>.<key> works on pairs';


### PR DESCRIPTION
Closes the last file in the BLOCKERS.md §5 dispatch cluster: `S03-metaops/hyper.t` now passes 420/420 and is whitelisted.

## Changes

### test 407 — builtin-MRO all-candidates dispatch (`».+&` / `».*&`)
`.+`/`.*` now dispatch across all candidates spanning the multi-level builtin class hierarchy (List/Any/Cool), for both hyper and non-hyper forms.
(`vm_call_helpers.rs`, `vm_hyper_method_ops.rs`, `methods_call_helpers.rs`, `methods_signature_shaped.rs`)

### test 408 — atomicint plain-assign reset from a nested closure frame
`$r = 0` (plain assignment to an `atomicint`) inside a `subtest {...}` block failed to reset the shared atomic cell, so a later `⚛++` read the stale shared value and the counter kept accumulating (`$runs`: 2→4→6→8).

Two root causes:
- `reset_atomic_var_key` only searched the current frame's `env` for the `name → value_key` mapping, which is authoritative in `shared_vars` (survives across frames) — so from a nested frame the reset silently no-op'd. Added a `shared_vars` fallback.
- A captured free-variable write reaches **SetGlobal**, not SetLocal, and SetGlobal had no atomic-reset call. Mirrored the SetLocal reset in the SetGlobal store path, gated on `atomic_var_seen()` so non-atomic programs pay only a bool check.

The equivalent plain-`int` case already worked via the normal captured-writeback mechanism.

## Testing
- `roast/S03-metaops/hyper.t`: 420/420 PASS → added to whitelist.
- New regression: `t/atomicint-closure-reset-writeback.t` (5 cases).
- All atomic/cas roast tests (`atomic.t`, `atomic-ops.t`, `cas.t`, `cas-int.t`, `cas-loop-int.t`) and local atomic/concurrency tests pass.
- `make test` green (14062 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)