### PR TITLE
S09-subscript/slice.t: HyperWhatever hammer index + nested lazy slice bind (55/56)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -290,19 +290,25 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
      へ書き戻らない**既存の**バグも解消（`docs/container-identity.md` の
      Phase 2 系とは独立した bind-time 経路の穴だった）。
   新規テスト: `t/bound-array-slice-arity.t`。
-- **残り 4 件（laziness とは無関係、それぞれ別機能）**:
-  - test 35（62 assertion、18/62 で中断）: ネストインデックスへの slice adverb
-    （`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ）— §3 の
-    container-identity 領域に属する別の大きな機能。
-  - test 54-55: 重複インデックスを含むネスト lazy リストへの **bind**
-    （`@a[lazy 1,2,(4,5),4,5] := ...`）が `=` 代入と異なる挙動（境界での
-    打ち切りなし・返り値が書き込み時点の値）。狭いエッジケースで今回は深追いせず。
-  - test 56: `@a[**]`（HyperWhatever hammer index）。ローカルの `raku` 自体が
-    "not yet implemented. Sorry." を返すため、この環境では参照実装との
-    突き合わせ自体ができない。
-- **Next slice**: 残り 4 件は互いに独立した別機能。test 35（nested slice
-  adverbs）が最も汎用性が高いが §3 container-identity 相当の大仕事。
-  whitelist にはこの 4 件全ての解決が必要。
+- **2026-07-03 解決（test 54-56）**:
+  - test 56（`@a[**]` HyperWhatever hammer index）: index に `Value::HyperWhatever`
+    を受けたとき、ネスト配列を再帰的に降下して全 leaf を flat list として返す分岐を
+    追加（`vm_var_index_ops.rs` の `hyperwhatever_hammer_collect`）。ローカル raku は
+    未実装だが roast の期待値（`[^10].List`）は決定的なので実装可能。
+  - test 54-55（重複インデックスを含むネスト lazy リストへの **bind**
+    `(@a[lazy 1,2,(4,5),4,5] := ...)`）: 式コンテキストの indexed `:=` bind が
+    `__mutsu_bind_index_value` マーカー無しで parse され、VM が `=` 代入扱い
+    （境界打ち切り＋最終状態値）していた。真因は 2 つ:
+    ① `try_parse_assign_expr`（式/括弧経路）の index-target `:=` がマーカーを付けて
+    いなかった → statement 版と同じマーカー付与に修正（`try_assign.rs`）。
+    ② VM 側に bind 専用の分配関数が無く assign と同じ経路 → `bind_slice_key_tree`
+    （write-time 値・境界打ち切りなし）＋ `slice_key_tree_max_index_all` を新設し、
+    LazyList arm で `bind_mode` 分岐（`vm_var_assign_index_named.rs`）。
+    回帰テスト＝`t/hyperwhatever-and-lazy-slice-bind.t`。
+- **残り 1 件（test 35・nested slice adverbs）**: ネストインデックスへの slice adverb
+  （`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ、plan 62）が nested index list に
+  再帰しない（トップレベルのみ処理・`builtins_multidim_subscript.rs`）。§3 の
+  container-identity 領域に属する大きな機能。**whitelist にはこの 1 件の解決が必要。**
 
 ---
 

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -77,12 +77,25 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 b'%' => Expr::HashVar(var.to_string()),
                 _ => Expr::Var(var.to_string()),
             };
+            // Wrap the RHS in the `__mutsu_bind_index_value` marker so the
+            // IndexAssign VM path takes *bind* semantics (write-time values, no
+            // boundary truncation) rather than plain assignment — matching the
+            // statement-level `:=` handler (`simple_expr_stmt::core`). Without
+            // this, an expression-context indexed bind such as
+            // `(@a[lazy 1,2,(4,5),4,5] := "a"...*)` (roast S09-subscript/slice.t
+            // #54-55) was silently treated as `=`.
+            let source_meta =
+                crate::parser::stmt::simple_expr_stmt::lvalue::bind_source_metadata_expr(&rhs);
+            let bind_value = Expr::Call {
+                name: crate::symbol::Symbol::intern("__mutsu_bind_index_value"),
+                args: vec![rhs, source_meta],
+            };
             return Ok((
                 rest,
                 Expr::IndexAssign {
                     target: Box::new(target),
                     index: Box::new(index_expr),
-                    value: Box::new(rhs),
+                    value: Box::new(bind_value),
                     is_positional: true,
                 },
             ));

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -7,7 +7,7 @@ mod idents;
 pub(super) mod modifier;
 mod pub_shims;
 pub(super) mod simple;
-mod simple_expr_stmt;
+pub(crate) mod simple_expr_stmt;
 mod stmtlist;
 mod sub;
 pub(crate) mod sub_param;

--- a/src/parser/stmt/simple_expr_stmt.rs
+++ b/src/parser/stmt/simple_expr_stmt.rs
@@ -1,8 +1,8 @@
 //! Expression-statement parsing: facade re-exporting themed submodules.
 mod core;
 mod let_temp;
-mod lvalue;
-mod predicates;
+pub(crate) mod lvalue;
+pub(crate) mod predicates;
 mod sig_info;
 
 pub(super) use core::expr_stmt;

--- a/src/parser/stmt/simple_expr_stmt/lvalue.rs
+++ b/src/parser/stmt/simple_expr_stmt/lvalue.rs
@@ -106,7 +106,7 @@ pub(super) fn bind_source_name(expr: &Expr) -> Option<String> {
     }
 }
 
-pub(super) fn bind_source_metadata_expr(rhs: &Expr) -> Expr {
+pub(crate) fn bind_source_metadata_expr(rhs: &Expr) -> Expr {
     match rhs {
         Expr::ArrayLiteral(items) => Expr::ArrayLiteral(
             items

--- a/src/parser/stmt/simple_expr_stmt/predicates.rs
+++ b/src/parser/stmt/simple_expr_stmt/predicates.rs
@@ -88,7 +88,7 @@ pub(super) fn is_literal_expr(expr: &Expr) -> bool {
 /// True when the LHS of an indexed `:=` bind targets an immutable container:
 /// a literal scalar (`10[0] := 1`, `"Hi"[0] := 1`) or an all-literal list
 /// (`(1,2)[0] := 3`). Binding into such a target is illegal → X::Bind.
-pub(super) fn index_bind_target_is_immutable(target: &Expr) -> bool {
+pub(crate) fn index_bind_target_is_immutable(target: &Expr) -> bool {
     match target {
         Expr::Literal(v) => matches!(
             v,

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -148,6 +148,53 @@ impl Interpreter {
         }
     }
 
+    /// Max index across ALL leaves of the key tree (unlike
+    /// `slice_key_tree_max_index`, a lazy-origin direct leaf is NOT skipped).
+    /// Used by the bind (`:=`) path, which writes every index (no boundary
+    /// truncation) and so must grow the array to cover the largest one.
+    fn slice_key_tree_max_index_all(key: &SliceKeyTree) -> Option<usize> {
+        match key {
+            SliceKeyTree::Leaf(v) => Self::index_to_usize(v),
+            SliceKeyTree::Nested(children, _) => children
+                .iter()
+                .filter_map(Self::slice_key_tree_max_index_all)
+                .max(),
+        }
+    }
+
+    /// Bind (`:=`) variant of `assign_slice_key_tree`: consume `vals` across the
+    /// (possibly nested) key tree in index-list order, write each leaf, and
+    /// build the returned rvalue directly from the *write-time* values rather
+    /// than a post-write re-read. Two differences from assignment:
+    ///   - a lazy-origin nested list is NOT truncated at the container boundary;
+    ///     every index in the tree is written (extending the array as needed);
+    ///   - the returned value at each position is the value bound there, so a
+    ///     later duplicate index (`@a[lazy 1,2,(4,5),4,5]`) overwrites the
+    ///     earlier write in the container while the return tree still shows each
+    ///     position's own write-time value (roast S09-subscript/slice.t #54-55).
+    fn bind_slice_key_tree(
+        container: &mut Value,
+        key: &SliceKeyTree,
+        vals: &mut std::vec::IntoIter<Value>,
+        marks: &mut Vec<String>,
+    ) -> Result<Value, RuntimeError> {
+        match key {
+            SliceKeyTree::Leaf(k) => {
+                let v = vals.next().unwrap_or(Value::Nil);
+                Self::assign_array_multidim(container, std::slice::from_ref(k), v.clone())?;
+                marks.push(Self::encode_bound_index(k));
+                Ok(v)
+            }
+            SliceKeyTree::Nested(children, _lazy_origin) => {
+                let mut out = Vec::with_capacity(children.len());
+                for child in children {
+                    out.push(Self::bind_slice_key_tree(container, child, vals, marks)?);
+                }
+                Ok(Value::array(out))
+            }
+        }
+    }
+
     pub(crate) fn exec_index_assign_expr_named_op_inner(
         &mut self,
         code: &CompiledCode,
@@ -649,7 +696,16 @@ impl Interpreter {
                     } else {
                         0
                     };
-                    if let Some(max_idx) = Self::slice_key_tree_max_index(&top_tree)
+                    // Bind (`:=`) writes every index with no boundary truncation
+                    // and returns write-time values, so grow to the largest index
+                    // across ALL leaves; assignment (`=`) uses the lazy-origin
+                    // boundary rule.
+                    let max_index = if bind_mode {
+                        Self::slice_key_tree_max_index_all(&top_tree)
+                    } else {
+                        Self::slice_key_tree_max_index(&top_tree)
+                    };
+                    if let Some(max_idx) = max_index
                         && let Value::Array(items, ..) = container
                     {
                         let arr = Arc::make_mut(items);
@@ -657,14 +713,18 @@ impl Interpreter {
                     }
                     let mut vals_iter = vals.into_iter();
                     let mut marks: Vec<String> = Vec::new();
-                    Self::assign_slice_key_tree(
-                        container,
-                        &top_tree,
-                        boundary_len,
-                        &mut vals_iter,
-                        &mut marks,
-                    )?;
-                    let result = Self::read_slice_key_tree(container, &top_tree, boundary_len);
+                    let result = if bind_mode {
+                        Self::bind_slice_key_tree(container, &top_tree, &mut vals_iter, &mut marks)?
+                    } else {
+                        Self::assign_slice_key_tree(
+                            container,
+                            &top_tree,
+                            boundary_len,
+                            &mut vals_iter,
+                            &mut marks,
+                        )?;
+                        Self::read_slice_key_tree(container, &top_tree, boundary_len)
+                    };
                     for encoded in marks {
                         self.mark_initialized_index(&var_name, encoded);
                     }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -641,6 +641,14 @@ impl Interpreter {
             (Value::Array(items, _is_arr), Value::Whatever) => {
                 Value::Array(items, crate::value::ArrayKind::List)
             }
+            // HyperWhatever (**) hammer index on Array: @a[**] recursively
+            // descends through nested arrays and returns every leaf element as a
+            // flat List (e.g. `[0,[1,[2,3]]][**]` == `(0,1,2,3)`).
+            (Value::Array(items, _is_arr), Value::HyperWhatever) => {
+                let mut leaves = Vec::new();
+                Self::hyperwhatever_hammer_collect(&items.items, &mut leaves);
+                Value::array(leaves)
+            }
             (Value::Array(items, is_arr), Value::Int(i)) => {
                 if i < 0 {
                     // Return a Failure wrapping X::OutOfRange — `//` treats it as
@@ -1985,6 +1993,21 @@ fn range_params(v: &Value) -> Option<(i64, i64, bool, bool)> {
 }
 
 impl Interpreter {
+    /// Recursively collect every leaf element of a (possibly deeply nested)
+    /// array into `out`, in depth-first order. Used by the HyperWhatever (`**`)
+    /// hammer index `@a[**]`, which flattens all nested arrays to a single flat
+    /// list of leaves.
+    pub(super) fn hyperwhatever_hammer_collect(items: &[Value], out: &mut Vec<Value>) {
+        for item in items {
+            match item {
+                Value::Array(data, _) => {
+                    Self::hyperwhatever_hammer_collect(&data.items, out);
+                }
+                other => out.push(other.clone()),
+            }
+        }
+    }
+
     /// When indexing an array with a multi-index list (e.g. `@a[0..2, 0..2]`),
     /// check if an individual index element is a Range and, if so, resolve it
     /// to a sublist (slice). Returns `None` if the index is not a range.

--- a/t/hyperwhatever-and-lazy-slice-bind.t
+++ b/t/hyperwhatever-and-lazy-slice-bind.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Two independent S09-subscript/slice.t features:
+#  1. HyperWhatever (`**`) hammer index: `@a[**]` recursively descends nested
+#     arrays and returns every leaf as a flat list (test 56).
+#  2. Nested lazy slice BIND (`:=`) in expression context: unlike assignment
+#     (`=`), a `:=` bind writes every index (no boundary truncation) and the
+#     returned rvalue reflects each position's write-time value (tests 54-55).
+
+plan 8;
+
+# --- HyperWhatever hammer index ---
+{
+    my @a = 0,[1,[2,[3,[4,[5,[6,7,8,9]]]]]];
+    is-deeply @a[**], [^10].List, 'hyperwhatever hammer flattens all leaves';
+}
+{
+    my @a = [1, [2, 3]], [[4], 5];
+    is-deeply @a[**], (1, 2, 3, 4, 5), 'hyperwhatever hammer on mixed nesting';
+}
+{
+    my @a = 1, 2, 3;
+    is-deeply @a[**], (1, 2, 3), 'hyperwhatever hammer on a flat array is identity';
+}
+
+# --- Nested lazy slice bind (expression context) ---
+{
+    my @a = 11..15;
+    is-deeply (@a[lazy 1,2,(4,5)] := "a"...*), ("a","b",("c","d")),
+        'lazy slice bind 1: nested sublist keeps write-time values';
+    is-deeply @a, [11,"a","b",14,"c","d"], 'lazy slice bind 1: final array';
+}
+{
+    my @a = 11..15;
+    is-deeply (@a[lazy 1,2,(4,5),4,5] := "a"...*), ("a","b",("c","d"),"e","f"),
+        'lazy slice bind 2: duplicate indices are NOT truncated (bind)';
+    is-deeply @a, [11,"a","b",14,"e","f"],
+        'lazy slice bind 2: final array reflects last-write-wins for dup indices';
+}
+
+# --- Contrast: assignment (`=`) still truncates at the boundary ---
+{
+    my @a = 11..15;
+    is-deeply (@a[lazy 1,2,(4,5),4,5] = "a"...*), ("a","b",("e","d"),"e"),
+        'lazy slice assignment truncates and returns final-state values';
+}


### PR DESCRIPTION
Advances `S09-subscript/slice.t` from 52/56 to 55/56 by fixing three independent features (tests 54-56). Only test 35 (nested slice adverbs, a larger §3 container-identity feature) remains before whitelisting.

## test 56 — `@a[**]` HyperWhatever hammer index
`@a[**]` now recursively descends nested arrays and returns every leaf as a flat List (`[0,[1,[2,3]]][**]` == `(0,1,2,3)`). Added `hyperwhatever_hammer_collect` + a `Value::HyperWhatever` index arm in `vm_var_index_ops.rs`. (Local raku is NYI here, but the roast expected value `[^10].List` is deterministic.)

## tests 54-55 — nested lazy slice bind (`:=`) in expression context
`(@a[lazy 1,2,(4,5),4,5] := "a"...*)` was silently parsed without the `__mutsu_bind_index_value` marker and executed as plain `=` assignment (boundary truncation + final-state return). Two root causes:
1. `try_parse_assign_expr` (the paren/expression path) didn't wrap the RHS in the bind marker for index targets — now it does, matching the statement-level handler.
2. The VM had no bind-specific distributor. Added `bind_slice_key_tree` (write-time values, no boundary truncation) + `slice_key_tree_max_index_all`, dispatched from the LazyList arm on `bind_mode`.

`simple_expr_stmt::{lvalue,predicates}` and the two bind helpers were made `pub(crate)` so the expression path can reuse them.

## Testing
- `roast/S09-subscript/slice.t`: 52/56 → 55/56 (test 35 remains).
- New regression: `t/hyperwhatever-and-lazy-slice-bind.t` (8 cases).
- All targeted bind/slice/subscript/adverb local tests pass.
- Assignment (`=`) semantics unchanged (still truncates + final-state values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)