### PR TITLE
fix(io): IO::Path stat readers return Instant/IntStr and fail X::IO::DoesNotExist

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -3,6 +3,7 @@ roast/6.c/S02-types/subset-6c.t
 roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S12-class/mro-6c.t
 roast/6.c/S14-roles/submethods.t
+roast/6.c/S32-io/file-tests.t
 roast/6.d/S02-literals/version.t
 roast/6.d/S05-capture/match-object.t
 roast/6.d/S09-multidim/indexing.t

--- a/src/runtime/native_io.rs
+++ b/src/runtime/native_io.rs
@@ -14,7 +14,6 @@ mod path_spec;
 mod resolve;
 
 pub(crate) use helpers::{
-    IoPathExtensionPartsSpec, io_exception, io_exception_failure, io_path_metadata,
-    io_path_missing_failure, numeric_limit_arg, path_is_executable, path_is_readable,
-    path_is_writable,
+    IoPathExtensionPartsSpec, io_exception, io_exception_failure, io_path_missing_failure,
+    numeric_limit_arg, path_is_executable, path_is_readable, path_is_writable,
 };

--- a/src/runtime/native_io/helpers.rs
+++ b/src/runtime/native_io/helpers.rs
@@ -54,28 +54,6 @@ pub(crate) fn io_path_missing_failure(path: &str, method: &str) -> Value {
     Value::make_instance(Symbol::intern("Failure"), failure_attrs)
 }
 
-fn io_path_missing_error(path: &str, method: &str) -> RuntimeError {
-    let message = format!("Failed to find '{}' while trying to do '.{}'", path, method);
-    let mut attrs = HashMap::new();
-    attrs.insert("message".to_string(), Value::str(message.clone()));
-    attrs.insert("path".to_string(), Value::str(path.to_string()));
-    attrs.insert("trying".to_string(), Value::str(method.to_string()));
-    let mut err = RuntimeError::new(message);
-    err.exception = Some(Box::new(Value::make_instance(
-        Symbol::intern("X::IO::DoesNotExist"),
-        attrs,
-    )));
-    err
-}
-
-pub(crate) fn io_path_metadata(
-    path: &Path,
-    display_path: &str,
-    method: &str,
-) -> Result<fs::Metadata, RuntimeError> {
-    fs::metadata(path).map_err(|_| io_path_missing_error(display_path, method))
-}
-
 #[cfg(unix)]
 fn path_access(path: &Path, mode: libc::c_int) -> bool {
     use std::ffi::CString;

--- a/src/runtime/native_io/io_path_stat.rs
+++ b/src/runtime/native_io/io_path_stat.rs
@@ -255,77 +255,71 @@ impl Interpreter {
                     ))
                 }
             },
-            "mode" => {
-                let metadata = fs::metadata(path_buf)
-                    .map_err(|err| RuntimeError::new(format!("Failed to stat '{}': {}", p, err)))?;
-                #[cfg(unix)]
-                {
-                    let mode = metadata.permissions().mode() & 0o777;
-                    Ok(Value::str(format!("{:04o}", mode)))
-                }
-                #[cfg(not(unix))]
-                {
-                    let mode = if metadata.permissions().readonly() {
-                        "0444"
-                    } else {
-                        "0666"
+            // `.mode` returns an `IntStr` allomorph (`.Int` = the octal mode value,
+            // `.Str` = the zero-padded octal string) and fails with
+            // `X::IO::DoesNotExist` on a missing path (roast S32-io/file-tests.t).
+            "mode" => match fs::metadata(path_buf) {
+                Ok(metadata) => {
+                    #[cfg(unix)]
+                    let (mode, s) = {
+                        let m = metadata.permissions().mode() & 0o777;
+                        (m as i64, format!("{:04o}", m))
                     };
-                    Ok(Value::str(mode.to_string()))
+                    #[cfg(not(unix))]
+                    let (mode, s) = if metadata.permissions().readonly() {
+                        (0o444, "0444".to_string())
+                    } else {
+                        (0o666, "0666".to_string())
+                    };
+                    Self::build_native_allomorph_value("IntStr", &[Value::Int(mode), Value::str(s)])
                 }
-            }
-            "s" => {
-                let size = io_path_metadata(path_buf, p, method)?.len();
-                Ok(Value::Int(size as i64))
-            }
-            "created" => {
-                let ts = fs::metadata(path_buf)
-                    .and_then(|meta| meta.created())
-                    .map(Self::system_time_to_int)
-                    .map_err(|err| {
-                        RuntimeError::new(format!("Failed to get created time '{}': {}", p, err))
-                    })?;
-                Ok(Value::Int(ts))
-            }
-            "modified" => {
-                let ts = fs::metadata(path_buf)
-                    .and_then(|meta| meta.modified())
-                    .map(Self::system_time_to_int)
-                    .map_err(|err| {
-                        RuntimeError::new(format!("Failed to get modified time '{}': {}", p, err))
-                    })?;
-                Ok(Value::Int(ts))
-            }
-            "accessed" => {
-                let ts = fs::metadata(path_buf)
-                    .and_then(|meta| meta.accessed())
-                    .map(Self::system_time_to_int)
-                    .map_err(|err| {
-                        RuntimeError::new(format!("Failed to get accessed time '{}': {}", p, err))
-                    })?;
-                Ok(Value::Int(ts))
-            }
+                Err(_) => Ok(io_path_missing_failure(p, "mode")),
+            },
+            "s" => match fs::metadata(path_buf) {
+                Ok(meta) => Ok(Value::Int(meta.len() as i64)),
+                // `.s` on a missing path fails with `X::IO::DoesNotExist` (a Failure),
+                // not a thrown generic error (roast S32-io/file-tests.t).
+                Err(_) => Ok(io_path_missing_failure(p, "s")),
+            },
+            // `.created`/`.modified`/`.accessed`/`.changed` return an `Instant` in
+            // Raku, and fail with `X::IO::DoesNotExist` (a Failure) on a missing
+            // path — not a plain Int / generic error (roast S32-io/file-tests.t).
+            "created" => match fs::metadata(path_buf).and_then(|meta| meta.created()) {
+                Ok(t) => Ok(Value::make_instant_from_posix(
+                    Self::system_time_to_int(t) as f64
+                )),
+                Err(_) => Ok(io_path_missing_failure(p, "created")),
+            },
+            "modified" => match fs::metadata(path_buf).and_then(|meta| meta.modified()) {
+                Ok(t) => Ok(Value::make_instant_from_posix(
+                    Self::system_time_to_int(t) as f64
+                )),
+                Err(_) => Ok(io_path_missing_failure(p, "modified")),
+            },
+            "accessed" => match fs::metadata(path_buf).and_then(|meta| meta.accessed()) {
+                Ok(t) => Ok(Value::make_instant_from_posix(
+                    Self::system_time_to_int(t) as f64
+                )),
+                Err(_) => Ok(io_path_missing_failure(p, "accessed")),
+            },
             "changed" => {
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::MetadataExt;
-                    let meta = fs::metadata(path_buf).map_err(|err| {
-                        RuntimeError::new(format!("Failed to get changed time '{}': {}", p, err))
-                    })?;
-                    Ok(Value::Int(meta.ctime()))
+                    match fs::metadata(path_buf) {
+                        Ok(meta) => Ok(Value::make_instant_from_posix(meta.ctime() as f64)),
+                        Err(_) => Ok(io_path_missing_failure(p, "changed")),
+                    }
                 }
                 #[cfg(not(unix))]
                 {
-                    // On non-Unix platforms, fall back to modified time
-                    let ts = fs::metadata(path_buf)
-                        .and_then(|meta| meta.modified())
-                        .map(Self::system_time_to_int)
-                        .map_err(|err| {
-                            RuntimeError::new(format!(
-                                "Failed to get changed time '{}': {}",
-                                p, err
-                            ))
-                        })?;
-                    Ok(Value::Int(ts))
+                    // On non-Unix platforms, fall back to modified time.
+                    match fs::metadata(path_buf).and_then(|meta| meta.modified()) {
+                        Ok(t) => Ok(Value::make_instant_from_posix(
+                            Self::system_time_to_int(t) as f64
+                        )),
+                        Err(_) => Ok(io_path_missing_failure(p, "changed")),
+                    }
                 }
             }
             _ => unreachable!("io_path_stat_result called with non-stat method"),

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -475,7 +475,12 @@ impl Value {
 
     /// Create an Instant value from the current system time.
     pub(crate) fn make_instant_now() -> Self {
-        let posix = current_time_secs_f64();
+        Self::make_instant_from_posix(current_time_secs_f64())
+    }
+
+    /// Build an `Instant` from a POSIX timestamp (seconds). Used by IO::Path's
+    /// `.modified`/`.accessed`/`.changed`, which return an `Instant` in Raku.
+    pub(crate) fn make_instant_from_posix(posix: f64) -> Self {
         let tai = crate::builtins::methods_0arg::temporal::posix_to_instant(posix);
         let mut attrs = HashMap::new();
         attrs.insert("value".to_string(), Value::Num(tai));


### PR DESCRIPTION
Whitelists **roast/6.c/S32-io/file-tests.t** (was 5 failures). IO::Path stat readers now match Rakudo's types and missing-path behavior:

- `.created`/`.modified`/`.accessed`/`.changed` return an `Instant` (new `Value::make_instant_from_posix`), not a raw epoch `Int`.
- `.mode` returns an `IntStr` allomorph (`.Int` = octal mode, `.Str` = "0NNN"), not a plain `Str`.
- `.s` / `.mode` / the four timestamp readers return an `X::IO::DoesNotExist` Failure on a missing path, not a thrown generic error (so `fails-like`/`nok` hold).

Removed the now-dead `io_path_metadata`/`io_path_missing_error` helpers. file-tests.t 16/16; io-path.t unchanged; clippy/make test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)