### PR TITLE
feat(gc): first-wave Arc→Gc — Value::Hash → Gc<HashData> (§11 step 5a/5b)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -389,7 +389,14 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
          `Gc<T>` ＋ `GcHeader`(strong count/`Color`/buffered) ＋ `Trace` trait ＋ process-global
          candidate buffer(dedup)。`MUTSU_GC` 未設定なら drop で candidate 登録しない=inert。
          `record_gc_candidate_push`/`dedup_hit` を配線。`Value` variant は未置換=step 5 以降）。
-      5. `Array`/`Hash`/`ContainerRef` を first wave として `Arc→Gc` 置換 ← **次はここ（次セッション開始点）**。
+      5. first wave `Arc→Gc` 置換（型ごとにスライス）:
+         - 5a. ✅ `Gc<T>` を `Arc<T>` の drop-in 化（`make_mut`/`get_mut`/`ptr_eq`/`strong_count_of`/
+           `as_ptr`/`erased`/`From`/`Debug`/`AsRef`/`PartialEq` ＋ free `gc_contents_mut` ＋
+           `ContainerMakeMut` bridge trait）。移行を機械的 call-site rewrite に落とす前提工事。
+         - 5b. ✅ `Value::Hash` → `Gc<HashData>`（`impl Trace for HashData` ＋ `Value::gc_trace` Hash arm、
+           49 ファイルの `Arc::*`→`Gc::*` 置換。全 whitelisted hash roast green・container identity 保存）。
+         - 5c. `Value::Array` → `Gc<ArrayData>` ← **次はここ（次セッション開始点）**。5b と同型・約 1400 サイト。
+         - 5d. `Value::ContainerRef` → `Gc<CellValue>`（§3.3、`Arc<Mutex<Value>>` の cell 再設計）。
       6〜11. `Promise`/`Channel` → supply registry → safepoint collect（trial-deletion 本体）→
       `Sub`/`Instance` → `LazyList`（詳細は設計メモ参照）。
       **Track B（要素 cell 化）と GC は統合キャンペーン（層3a・`Arc → Gc<T>` 一斉置換）**。続いて NaN-boxing

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -31,6 +31,30 @@ on Arc）の開発に着手した。[docs/gc-level1-detailed-design.md](../docs/
      `Array`/`Hash`/`ContainerRef` の first wave 置換）。unit test（color 遷移・dedup・inert・
      `Send + Sync`）で担保。
 
+## 2026-07-03: Phase B（GC）first wave 着手 — `Value::Hash` を `Gc<HashData>` へ移行（§11 step 5）
+
+step 4（`Gc<T>` 基盤）に続き、ADR-0001 layer 3a の first wave（コンテナ系 `Arc → Gc<T>` 一斉置換）を
+型ごとのスライスで開始した。
+
+- **5a. `Gc<T>` を `Arc<T>` の drop-in 化**: `make_mut`/`get_mut`/`ptr_eq`/`strong_count_of`/`as_ptr`/
+  `erased`/`From`/`Debug`/`AsRef`/`PartialEq`（Arc と同じく値比較・identity は `ptr_eq`）＋ free
+  `gc_contents_mut`（`aliased_mut::arc_contents_mut` の Gc 版・同じ unsoundness 契約）＋
+  `ContainerMakeMut` bridge trait（`Arc<T>`/`Gc<T>` 両対応の COW `make_mut`、部分移行中に共有マクロが
+  Array(Arc)/Hash(Gc) をまたげるように）。uniqueness は `header.strong`（live GC handle、candidate buffer の
+  Arc を除外）で判定＝buffer 有無に関わらず現行 `Arc::strong_count` と同一挙動→移行は behavior-preserving。
+- **5b. `Value::Hash(Arc<HashData>)` → `Value::Hash(Gc<HashData>)`**: `impl Trace for HashData`（map の
+  Value を `Value::gc_trace` 経由で辿る）＋ `Value::gc_trace` の Hash arm を追加し、変異は `gc_contents_mut`、
+  COW は `Gc::make_mut`、identity は `Gc::ptr_eq` に置換。49 ファイル・約 180 コンパイルエラーを型駆動で解消
+  （大半は機械的 `Arc::*`→`Gc::*`、残りはヘルパ signature `&Arc<HashData>`→`&Gc<HashData>` と
+  `Value::Hash(Arc::new)`→`Gc::new`）。
+
+検証: `value_stays_small` が green＝`Gc<HashData>` は Arc と同じ 1 word で `Value` は肥大しない。全
+whitelisted S32-hash roast（delete/exists/kv/pairs/push/slice/iterator/invert/map …）＋ S02-types/hash.t が
+green。container identity（`my %g := %h; %g<d>=4` が `%h<d>` に反映 / bound は同 `.WHICH`・代入コピーは別
+`.WHICH`）も保存。非 whitelist の multislice-6e（multi-dim slice assignability）/perl.t（scalar-deconted
+perlify）の既存部分失敗は本移行と無関係（機能未実装）。`MUTSU_GC` 未設定では candidate 登録なし＝ハッシュ
+clone/drop あたり atomic 1 命令のみ。次は 5c（`Value::Array` → `Gc<ArrayData>`、同型・約 1400 サイト）。
+
 ## 2026-07-03: `S03-metaops/hyper.t` 完了（420/420、whitelist 追加）
 
 dispatch cluster の最後の 1 ファイル `S03-metaops/hyper.t` を whitelist 化。残り 2 件を解消した。

--- a/src/builtins/map_hash_coerce.rs
+++ b/src/builtins/map_hash_coerce.rs
@@ -15,7 +15,6 @@ use crate::runtime::utils::set_hash_original_keys;
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// Build an `X::Hash::Store::OddNumber` error for an odd element count.
 fn make_odd_number_error(items: &[Value]) -> RuntimeError {
@@ -189,7 +188,7 @@ pub(crate) fn to_map(target: Value) -> Result<Value, RuntimeError> {
     // Embed the `Map` declared-type in the Hash Arc (pure; no side table).
     if let Value::Hash(mut arc) = result {
         if arc.declared_type.as_deref() != Some("Map") {
-            let data = Arc::make_mut(&mut arc);
+            let data = crate::gc::Gc::make_mut(&mut arc);
             data.declared_type = Some("Map".to_string());
         }
         Ok(Value::Hash(arc))

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -306,7 +306,7 @@ pub(super) fn dispatch(
                     format!("Array|{:p}", Arc::as_ptr(items))
                 }
                 Value::Hash(map) => {
-                    format!("Hash|{:p}", Arc::as_ptr(map))
+                    format!("Hash|{:p}", crate::gc::Gc::as_ptr(map))
                 }
                 Value::Promise(p) => {
                     format!("Promise|{:p}", p.arc_ptr())

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -619,7 +619,7 @@ fn dispatch_capture(
             // Capture.hash returns an immutable Map, not a mutable Hash.
             let mut data = crate::value::HashData::new(map);
             data.declared_type = Some("Map".to_string());
-            Some(Ok(Value::Hash(std::sync::Arc::new(data))))
+            Some(Ok(Value::Hash(crate::gc::Gc::new(data))))
         }
         "list" => Some(Ok(Value::array(positional.to_vec()))),
         "elems" => Some(Ok(Value::Int(positional.len() as i64))),

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -603,7 +603,7 @@ pub fn raku_value(v: &Value) -> String {
                 static SEEN_HASH_PTRS: std::cell::RefCell<Vec<(usize, String)>> = const { std::cell::RefCell::new(Vec::new()) };
                 static HASH_CYCLE_FOUND: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
             }
-            let ptr = Arc::as_ptr(map) as usize;
+            let ptr = crate::gc::Gc::as_ptr(map) as usize;
             let var_name = format!("%hash_{}", ptr);
             let cycle_var = SEEN_HASH_PTRS.with(|seen| {
                 seen.borrow()

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -16,20 +16,21 @@
 //! - the process-global candidate buffer — where a drop that leaves the node
 //!   with surviving handles records it as a possible cycle root (§4.2 / §5.2).
 //!
-//! Deliberately NOT in this step:
-//! - No `Value` variant is migrated to `Gc<T>` (that is the first wave, §11
-//!   step 5+). Nothing outside this module's tests constructs a `Gc<T>` yet, so
-//!   this is inert with respect to every production execution path.
+//! State of the migration (§11 step 5):
+//! - `Value::Hash` is the first variant migrated to `Gc<HashData>` (step 5b), so
+//!   `Gc`'s `Clone`/`Drop`/`make_mut`/... run in production now. Candidate
+//!   buffering still only happens under `MUTSU_GC=on` (default off), so ordinary
+//!   runs pay just an atomic refcount op per hash clone/drop and push nothing.
+//! - `Array`/`ContainerRef` (steps 5c/5d) remain `Arc`; the [`ContainerMakeMut`]
+//!   bridge lets shared container macros work across the mixed state meanwhile.
 //! - No trial-deletion reclaim runs. [`drain_candidates`] hands the buffered
 //!   nodes to a future synchronous collector (§11 step 8); until then the
 //!   `Color`/strong-count bookkeeping is maintained but never acted on.
 
-// Every item here is inert in a production build: nothing constructs a `Gc<T>`
-// until the first-wave `Arc → Gc` migration (§11 step 5), so `Gc`'s `Drop`/
-// `Clone` are never instantiated and the candidate-buffer path is unreachable
-// outside `#[cfg(test)]`. The machinery is deliberately compiled in ahead of
-// that (design doc §9.1: "compiled in, default off"), hence the module-wide
-// dead-code allow — removed when the first Value variant becomes `Gc`-managed.
+// The collector-facing surface (Color scan states, drain_candidates,
+// buffer_as_candidate, trace_children, ...) is not exercised until the
+// synchronous collector lands (§11 step 8), so keep a module-wide dead-code
+// allow rather than sprinkling per-item ones; drop it when step 8 wires them up.
 #![allow(dead_code)]
 
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
@@ -324,11 +325,50 @@ impl<T: Trace + 'static> From<T> for Gc<T> {
     }
 }
 
+impl<T: Trace + 'static> AsRef<T> for Gc<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner.value
+    }
+}
+
+impl<T: Trace + PartialEq + 'static> PartialEq for Gc<T> {
+    /// Value equality, matching `Arc<T>`'s `PartialEq` (compares pointees, with
+    /// a same-node fast path) — NOT pointer identity. Use [`Gc::ptr_eq`] for
+    /// identity.
+    fn eq(&self, other: &Self) -> bool {
+        Gc::ptr_eq(self, other) || self.inner.value == other.inner.value
+    }
+}
+
 impl<T: Trace + std::fmt::Debug + 'static> std::fmt::Debug for Gc<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Forward to the pointee so `Value`'s derived `Debug` prints a migrated
         // `Gc<ArrayData>` exactly like the old `Arc<ArrayData>` did.
         std::fmt::Debug::fmt(&self.inner.value, f)
+    }
+}
+
+/// Copy-on-write `make_mut` bridged over both `Arc<T>` and `Gc<T>`, so a shared
+/// macro/generic that mutates a container works while only *some* container
+/// variants have migrated from `Arc` to `Gc` (§11 step 5 lands one type at a
+/// time). Once every container variant is `Gc`, call sites can use `Gc::make_mut`
+/// directly and this bridge can be retired.
+pub(crate) trait ContainerMakeMut {
+    type Inner;
+    fn container_make_mut(&mut self) -> &mut Self::Inner;
+}
+
+impl<T: Clone> ContainerMakeMut for Arc<T> {
+    type Inner = T;
+    fn container_make_mut(&mut self) -> &mut T {
+        Arc::make_mut(self)
+    }
+}
+
+impl<T: Trace + Clone + 'static> ContainerMakeMut for Gc<T> {
+    type Inner = T;
+    fn container_make_mut(&mut self) -> &mut T {
+        Gc::make_mut(self)
     }
 }
 
@@ -508,7 +548,11 @@ mod tests {
         assert_eq!(Gc::strong_count_of(&a), 2);
         *Gc::make_mut(&mut a) = Cell(9);
         assert_eq!(*a, Cell(9));
-        assert_eq!(*alias, Cell(2), "the alias must not see the post-clone write");
+        assert_eq!(
+            *alias,
+            Cell(2),
+            "the alias must not see the post-clone write"
+        );
         assert_eq!(Gc::strong_count_of(&a), 1, "a is a fresh unique node");
     }
 
@@ -519,7 +563,10 @@ mod tests {
         let alias = a.clone();
         assert!(Gc::get_mut(&mut a).is_none(), "aliased => no unique &mut");
         drop(alias);
-        assert!(Gc::get_mut(&mut a).is_some(), "unique again after alias drops");
+        assert!(
+            Gc::get_mut(&mut a).is_some(),
+            "unique again after alias drops"
+        );
     }
 
     #[test]
@@ -531,7 +578,11 @@ mod tests {
         // SAFETY: no other borrow into the value is live across this write.
         unsafe { *gc_contents_mut(&a) = Cell(7) };
         assert_eq!(*a, Cell(7));
-        assert_eq!(*alias, Cell(7), "the shared write is visible through the alias");
+        assert_eq!(
+            *alias,
+            Cell(7),
+            "the shared write is visible through the alias"
+        );
     }
 
     #[test]

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -173,6 +173,75 @@ impl<T: Trace + 'static> Gc<T> {
         self.inner.value.trace(visit);
     }
 
+    /// A type-erased [`ErasedGc`] handle to this node (a fresh `Arc` clone
+    /// coerced to `dyn Trace`). This is how a parent node exposes a `Gc` child
+    /// to the collector's tracer, and how a candidate is retained in the
+    /// buffer. Bumps the backing `Arc`'s count but NOT the GC-visible
+    /// `header.strong`, so an erased handle held by the collector does not read
+    /// as a live program reference.
+    pub(crate) fn erased(&self) -> ErasedGc {
+        self.inner.clone()
+    }
+
+    // ---- `Arc<T>` drop-in API ----------------------------------------------
+    //
+    // These mirror the `Arc::` associated functions the pre-GC container code
+    // used on `Arc<ArrayData>` / `Arc<HashData>`, so migrating a `Value`
+    // variant from `Arc<T>` to `Gc<T>` (§11 step 5+) is a mechanical
+    // call-site rewrite (`Arc::foo(x)` -> `Gc::foo(x)`) rather than a
+    // behavioral change. Uniqueness is judged by `header.strong` (live GC
+    // handles, excluding the candidate buffer's retained `Arc`), which equals
+    // what `Arc::strong_count` reported before the buffer existed — so COW
+    // behavior is preserved whether or not `MUTSU_GC` is on.
+
+    /// `Arc::ptr_eq` analog: whether two handles designate the same node.
+    pub(crate) fn ptr_eq(a: &Gc<T>, b: &Gc<T>) -> bool {
+        Arc::ptr_eq(&a.inner, &b.inner)
+    }
+
+    /// `Arc::strong_count` analog in associated-fn form (the method
+    /// [`Gc::strong_count`] returns the same value). Live GC handles only.
+    pub(crate) fn strong_count_of(this: &Gc<T>) -> usize {
+        this.inner.header.strong.load(Ordering::Relaxed)
+    }
+
+    /// `Arc::as_ptr` analog: a raw pointer to the *value* (past the node
+    /// header), matching what `Arc::as_ptr` yields for a plain `Arc<T>`.
+    pub(crate) fn as_ptr(this: &Gc<T>) -> *const T {
+        &this.inner.value as *const T
+    }
+
+    /// `Arc::get_mut` analog. Returns `&mut T` only when this is the sole live
+    /// GC handle (`header.strong == 1`), ignoring the backing `Arc`'s weak/
+    /// buffer references. Sound because a buffered node's value is read only at
+    /// a collect safepoint, never concurrently with a live-handle mutation
+    /// (same contract as [`gc_contents_mut`]).
+    pub(crate) fn get_mut(this: &mut Gc<T>) -> Option<&mut T> {
+        if this.inner.header.strong.load(Ordering::Relaxed) == 1 {
+            // SAFETY: sole live handle => no other live-handle borrow into this
+            // value exists. See `gc_contents_mut`'s contract.
+            Some(unsafe { &mut *(Gc::as_ptr(this) as *mut T) })
+        } else {
+            None
+        }
+    }
+
+    /// `Arc::make_mut` analog (copy-on-write). If more than one live GC handle
+    /// exists, clone the value into a fresh node and rebind `this`; then return
+    /// `&mut` to the now-unique value. Matches the COW semantics the pre-GC
+    /// `Arc::make_mut(&mut Arc<ArrayData>)` sites relied on.
+    pub(crate) fn make_mut(this: &mut Gc<T>) -> &mut T
+    where
+        T: Clone,
+    {
+        if this.inner.header.strong.load(Ordering::Relaxed) != 1 {
+            let cloned = this.inner.value.clone();
+            *this = Gc::new(cloned);
+        }
+        // SAFETY: exactly one live handle after the check/clone above.
+        unsafe { &mut *(Gc::as_ptr(this) as *mut T) }
+    }
+
     /// Offer this node to the candidate buffer as a possible cycle root,
     /// bypassing the `MUTSU_GC` gate. Used by tests and (later) by an explicit
     /// `gc_debug_collect_now`-style hook.
@@ -247,6 +316,38 @@ impl<T: Trace + 'static> Drop for Gc<T> {
             buffer_candidate(self.inner.clone());
         }
     }
+}
+
+impl<T: Trace + 'static> From<T> for Gc<T> {
+    fn from(value: T) -> Gc<T> {
+        Gc::new(value)
+    }
+}
+
+impl<T: Trace + std::fmt::Debug + 'static> std::fmt::Debug for Gc<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Forward to the pointee so `Value`'s derived `Debug` prints a migrated
+        // `Gc<ArrayData>` exactly like the old `Arc<ArrayData>` did.
+        std::fmt::Debug::fmt(&self.inner.value, f)
+    }
+}
+
+/// `Gc<T>` analog of [`crate::value::aliased_mut::arc_contents_mut`]: a `&mut T`
+/// aliasing a shared node's value for a deliberate aliased in-place mutation of
+/// a container (Raku container identity — a push through one alias must be
+/// visible through every holder of the same node).
+///
+/// # Safety
+///
+/// Same contract as `arc_contents_mut`: the caller must ensure no other borrow
+/// into this value is live for the duration of the returned `&mut`, and no
+/// concurrent access from another thread. The candidate buffer's retained `Arc`
+/// adds no new hazard — a buffered node's value is read only at a collect
+/// safepoint, never concurrently with a live mutation.
+#[allow(clippy::mut_from_ref)]
+pub(crate) unsafe fn gc_contents_mut<T: Trace + 'static>(gc: &Gc<T>) -> &mut T {
+    // SAFETY: delegated to the caller per the contract above.
+    unsafe { &mut *(Gc::as_ptr(gc) as *mut T) }
 }
 
 /// Process-global cycle-candidate buffer (design doc §5.2: "buffer は
@@ -337,10 +438,16 @@ mod tests {
             if let Ok(guard) = self.child.lock()
                 && let Some(child) = guard.as_ref()
             {
-                let erased: ErasedGc = child.inner.clone();
-                visit(&erased);
+                visit(&child.erased());
             }
         }
+    }
+
+    /// Clonable leaf node carrying a payload, for COW / mutation tests.
+    #[derive(Clone, Debug, PartialEq)]
+    struct Cell(i64);
+    impl Trace for Cell {
+        fn trace(&self, _visit: &mut dyn FnMut(&ErasedGc)) {}
     }
 
     #[test]
@@ -376,6 +483,62 @@ mod tests {
         let mut seen = 0;
         gc.trace_children(&mut |_erased| seen += 1);
         assert_eq!(seen, 0);
+    }
+
+    #[test]
+    fn ptr_eq_distinguishes_shared_from_independent() {
+        let a = Gc::new(Cell(1));
+        let shared = a.clone();
+        let b = Gc::new(Cell(1));
+        assert!(Gc::ptr_eq(&a, &shared), "clones share the node");
+        assert!(!Gc::ptr_eq(&a, &b), "independent nodes differ");
+    }
+
+    #[test]
+    fn make_mut_shares_when_unique_and_cows_when_aliased() {
+        // Unique: make_mut writes in place, both this handle and any later
+        // clone observe it.
+        let mut a = Gc::new(Cell(1));
+        *Gc::make_mut(&mut a) = Cell(2);
+        assert_eq!(*a, Cell(2));
+
+        // Aliased: make_mut clones, so the write is NOT visible through the
+        // pre-existing alias (Arc::make_mut COW semantics).
+        let alias = a.clone();
+        assert_eq!(Gc::strong_count_of(&a), 2);
+        *Gc::make_mut(&mut a) = Cell(9);
+        assert_eq!(*a, Cell(9));
+        assert_eq!(*alias, Cell(2), "the alias must not see the post-clone write");
+        assert_eq!(Gc::strong_count_of(&a), 1, "a is a fresh unique node");
+    }
+
+    #[test]
+    fn get_mut_is_some_only_when_unique() {
+        let mut a = Gc::new(Cell(1));
+        assert!(Gc::get_mut(&mut a).is_some());
+        let alias = a.clone();
+        assert!(Gc::get_mut(&mut a).is_none(), "aliased => no unique &mut");
+        drop(alias);
+        assert!(Gc::get_mut(&mut a).is_some(), "unique again after alias drops");
+    }
+
+    #[test]
+    fn gc_contents_mut_writes_through_a_shared_node() {
+        // Unlike make_mut, gc_contents_mut mutates the shared node in place, so
+        // an alias DOES observe the write (Raku shared-container identity).
+        let a = Gc::new(Cell(1));
+        let alias = a.clone();
+        // SAFETY: no other borrow into the value is live across this write.
+        unsafe { *gc_contents_mut(&a) = Cell(7) };
+        assert_eq!(*a, Cell(7));
+        assert_eq!(*alias, Cell(7), "the shared write is visible through the alias");
+    }
+
+    #[test]
+    fn from_and_debug_forward_to_the_value() {
+        let gc: Gc<Cell> = Cell(5).into();
+        assert_eq!(*gc, Cell(5));
+        assert_eq!(format!("{gc:?}"), format!("{:?}", Cell(5)));
     }
 
     #[test]

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -184,21 +184,13 @@ impl<T: Trace + 'static> Gc<T> {
         self.inner.clone()
     }
 
-    // ---- `Arc<T>` drop-in API ----------------------------------------------
+    // ---- `Arc<T>` drop-in API (supplements the `ptr_eq`/`get_mut`/`make_mut`
+    // added in #4112) --------------------------------------------------------
     //
-    // These mirror the `Arc::` associated functions the pre-GC container code
-    // used on `Arc<ArrayData>` / `Arc<HashData>`, so migrating a `Value`
-    // variant from `Arc<T>` to `Gc<T>` (§11 step 5+) is a mechanical
-    // call-site rewrite (`Arc::foo(x)` -> `Gc::foo(x)`) rather than a
-    // behavioral change. Uniqueness is judged by `header.strong` (live GC
-    // handles, excluding the candidate buffer's retained `Arc`), which equals
-    // what `Arc::strong_count` reported before the buffer existed — so COW
-    // behavior is preserved whether or not `MUTSU_GC` is on.
-
-    /// `Arc::ptr_eq` analog: whether two handles designate the same node.
-    pub(crate) fn ptr_eq(a: &Gc<T>, b: &Gc<T>) -> bool {
-        Arc::ptr_eq(&a.inner, &b.inner)
-    }
+    // The container migration (§11 step 5) rewrites the pre-GC `Arc::` calls on
+    // `ArrayData`/`HashData` to their `Gc` equivalents. #4112 landed
+    // `ptr_eq`/`get_mut`/`make_mut`; these two add the remaining `Arc::`
+    // associated fns the migration's call sites use.
 
     /// `Arc::strong_count` analog in associated-fn form (the method
     /// [`Gc::strong_count`] returns the same value). Live GC handles only.
@@ -210,37 +202,6 @@ impl<T: Trace + 'static> Gc<T> {
     /// header), matching what `Arc::as_ptr` yields for a plain `Arc<T>`.
     pub(crate) fn as_ptr(this: &Gc<T>) -> *const T {
         &this.inner.value as *const T
-    }
-
-    /// `Arc::get_mut` analog. Returns `&mut T` only when this is the sole live
-    /// GC handle (`header.strong == 1`), ignoring the backing `Arc`'s weak/
-    /// buffer references. Sound because a buffered node's value is read only at
-    /// a collect safepoint, never concurrently with a live-handle mutation
-    /// (same contract as [`gc_contents_mut`]).
-    pub(crate) fn get_mut(this: &mut Gc<T>) -> Option<&mut T> {
-        if this.inner.header.strong.load(Ordering::Relaxed) == 1 {
-            // SAFETY: sole live handle => no other live-handle borrow into this
-            // value exists. See `gc_contents_mut`'s contract.
-            Some(unsafe { &mut *(Gc::as_ptr(this) as *mut T) })
-        } else {
-            None
-        }
-    }
-
-    /// `Arc::make_mut` analog (copy-on-write). If more than one live GC handle
-    /// exists, clone the value into a fresh node and rebind `this`; then return
-    /// `&mut` to the now-unique value. Matches the COW semantics the pre-GC
-    /// `Arc::make_mut(&mut Arc<ArrayData>)` sites relied on.
-    pub(crate) fn make_mut(this: &mut Gc<T>) -> &mut T
-    where
-        T: Clone,
-    {
-        if this.inner.header.strong.load(Ordering::Relaxed) != 1 {
-            let cloned = this.inner.value.clone();
-            *this = Gc::new(cloned);
-        }
-        // SAFETY: exactly one live handle after the check/clone above.
-        unsafe { &mut *(Gc::as_ptr(this) as *mut T) }
     }
 
     /// Offer this node to the candidate buffer as a possible cycle root,

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -17,5 +17,7 @@ mod gc_ptr;
 mod root_visitor;
 
 #[allow(unused_imports)]
-pub(crate) use gc_ptr::{Color, ErasedGc, Gc, Trace, drain_candidates, gc_enabled};
+pub(crate) use gc_ptr::{
+    Color, ErasedGc, Gc, Trace, drain_candidates, gc_contents_mut, gc_enabled,
+};
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -8,16 +8,16 @@
 //!   `Interpreter::visit_roots` / `Env::visit_values` to enumerate every
 //!   `Value` reachable from execution state (§11 steps 1-2).
 //! - [`gc_ptr`] — [`Gc<T>`], its Bacon-Rajan node header, the [`Trace`] trait,
-//!   and the process-global cycle-candidate buffer (§11 step 4). This is the
-//!   managed-pointer *type machinery* a synchronous cycle collector needs; no
-//!   `Value` variant is migrated to `Gc<T>` yet (first wave, §11 step 5+) and
-//!   no trial-deletion reclaim runs yet (§11 step 8).
+//!   and the process-global cycle-candidate buffer (§11 step 4). `Value::Hash`
+//!   is migrated to `Gc<HashData>` (§11 step 5b, first wave); `Array`/
+//!   `ContainerRef` follow (§11 steps 5c/5d). No trial-deletion reclaim runs
+//!   yet (§11 step 8); candidate buffering is off unless `MUTSU_GC=on`.
 
 mod gc_ptr;
 mod root_visitor;
 
 #[allow(unused_imports)]
 pub(crate) use gc_ptr::{
-    Color, ErasedGc, Gc, Trace, drain_candidates, gc_contents_mut, gc_enabled,
+    Color, ContainerMakeMut, ErasedGc, Gc, Trace, drain_candidates, gc_contents_mut, gc_enabled,
 };
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -167,7 +167,7 @@ impl Interpreter {
         match (expected_seen, latest_seen) {
             (Value::Instance { id: a, .. }, Value::Instance { id: b, .. }) => a == b,
             (Value::Array(a, ..), Value::Array(b, ..)) => std::sync::Arc::ptr_eq(a, b),
-            (Value::Hash(a), Value::Hash(b)) => std::sync::Arc::ptr_eq(a, b),
+            (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Seq(a), Value::Seq(b)) => std::sync::Arc::ptr_eq(a, b),
             (Value::Slip(a), Value::Slip(b)) => std::sync::Arc::ptr_eq(a, b),
             _ => expected_seen == latest_seen,

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -126,7 +126,7 @@ impl Interpreter {
                 },
             };
             Value::hash_insert_through(&mut map.map, elem_key, value.clone());
-            let new_hash = Value::Hash(std::sync::Arc::new(map));
+            let new_hash = Value::Hash(crate::gc::Gc::new(map));
             shared.insert(atomic_key, new_hash.clone());
             new_hash
         };

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -92,14 +92,14 @@ impl Interpreter {
                     .or_insert_with(|| Value::hash(HashMap::new()));
                 match entry {
                     Value::Hash(map) => {
-                        let map = Arc::make_mut(map);
+                        let map = crate::gc::Gc::make_mut(map);
                         insert_nested_bucket(map, &path[1..], item, name)
                     }
                     Value::Array(..) => Err(mixed_level_error(name)),
                     _ => {
                         *entry = Value::hash(HashMap::new());
                         if let Value::Hash(map) = entry {
-                            let map = Arc::make_mut(map);
+                            let map = crate::gc::Gc::make_mut(map);
                             insert_nested_bucket(map, &path[1..], item, name)
                         } else {
                             Ok(())
@@ -368,7 +368,7 @@ impl Interpreter {
             return hash;
         }
         if let Value::Hash(mut arc) = hash {
-            let data = std::sync::Arc::make_mut(&mut arc);
+            let data = crate::gc::Gc::make_mut(&mut arc);
             data.key_type = Some("Any".to_string());
             data.original_keys = Some(object_keys);
             return Value::Hash(arc);

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -344,7 +344,7 @@ impl Interpreter {
                                     // SAFETY: aliased in-place mutation of a shared
                                     // container; see `arc_contents_mut`.
                                     unsafe {
-                                        crate::value::arc_contents_mut(map)
+                                        crate::value::gc_contents_mut(map)
                                             .map
                                             .insert(k.clone(), new_src);
                                     }

--- a/src/runtime/builtins_collection_extrema.rs
+++ b/src/runtime/builtins_collection_extrema.rs
@@ -167,7 +167,7 @@ impl Interpreter {
 
     fn extrema_from_hash(
         &mut self,
-        map: &std::sync::Arc<crate::value::HashData>,
+        map: &crate::gc::Gc<crate::value::HashData>,
         by: Option<Value>,
         want_max: bool,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -404,7 +404,7 @@ impl Interpreter {
             Value::Hash(target_arc) => {
                 for (name, env_val) in self.env().iter() {
                     if let Value::Hash(env_arc) = env_val
-                        && std::sync::Arc::ptr_eq(target_arc, env_arc)
+                        && crate::gc::Gc::ptr_eq(target_arc, env_arc)
                     {
                         return Some(name.resolve());
                     }

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -125,10 +125,10 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
     if let Value::Hash(map) = target {
         let key = head.to_string_value();
         if indices.len() == 1 {
-            let map_mut = std::sync::Arc::make_mut(map);
+            let map_mut = crate::gc::Gc::make_mut(map);
             return map_mut.remove(&key).unwrap_or_else(default);
         }
-        let map_mut = std::sync::Arc::make_mut(map);
+        let map_mut = crate::gc::Gc::make_mut(map);
         return match map_mut.get_mut(&key) {
             Some(inner) => multidim_delete(inner, &indices[1..]),
             None => default(),

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -258,7 +258,7 @@ impl Interpreter {
                 let removed = new_hash
                     .remove(&key)
                     .unwrap_or_else(|| absent_default.clone().unwrap_or(Value::Nil));
-                (removed, Value::Hash(std::sync::Arc::new(new_hash)))
+                (removed, Value::Hash(crate::gc::Gc::new(new_hash)))
             }
             Value::Array(items, kind) => {
                 let idx = crate::runtime::to_int(&index);

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -370,7 +370,7 @@ impl Interpreter {
             if let Some(container) = self.env.get_mut(var_name) {
                 match container {
                     Value::Hash(map) => {
-                        let h = std::sync::Arc::make_mut(map);
+                        let h = crate::gc::Gc::make_mut(map);
                         for idx in &indices {
                             h.remove(&idx.to_string_value());
                         }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -907,12 +907,12 @@ impl Interpreter {
                 unreachable!()
             };
             // Check if we can mutate in-place (shared reference)
-            if Arc::strong_count(arc) > 1 {
+            if crate::gc::Gc::strong_count_of(arc) > 1 {
                 // SAFETY: aliased in-place mutation of a shared hash (guarded by
                 // strong_count > 1, the exact case that needs the shared write);
                 // see `arc_contents_mut`. No borrow into the map is live across
                 // each insert.
-                let data = unsafe { crate::value::arc_contents_mut(arc) };
+                let data = unsafe { crate::value::gc_contents_mut(arc) };
                 for arg in args {
                     match arg {
                         Value::Pair(k, v) => {

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -130,7 +130,7 @@ impl Interpreter {
                 if let (Value::Hash(arc), Some(def)) = (&mut result, existing_default)
                     && arc.default.is_none()
                 {
-                    std::sync::Arc::make_mut(arc).default = Some(def);
+                    crate::gc::Gc::make_mut(arc).default = Some(def);
                 }
                 result
             }
@@ -273,19 +273,19 @@ impl Interpreter {
 
     pub(crate) fn overwrite_hash_bindings_by_identity(
         &mut self,
-        needle: &std::sync::Arc<crate::value::HashData>,
+        needle: &crate::gc::Gc<crate::value::HashData>,
         replacement: Value,
     ) {
         let mut keys: Vec<Symbol> = Vec::new();
         let mut cells: Vec<std::sync::Arc<std::sync::Mutex<Value>>> = Vec::new();
         for (name, value) in self.env.iter() {
             match value {
-                Value::Hash(existing) if std::sync::Arc::ptr_eq(existing, needle) => {
+                Value::Hash(existing) if crate::gc::Gc::ptr_eq(existing, needle) => {
                     keys.push(*name);
                 }
                 Value::ContainerRef(cell) => {
                     if let Value::Hash(existing) = &*cell.lock().unwrap()
-                        && std::sync::Arc::ptr_eq(existing, needle)
+                        && crate::gc::Gc::ptr_eq(existing, needle)
                     {
                         cells.push(cell.clone());
                     }
@@ -337,7 +337,7 @@ impl Interpreter {
     /// Same as `propagate_shared_array_in_instances` but for Hash attributes.
     pub(crate) fn propagate_shared_hash_in_instances(
         &mut self,
-        needle: &std::sync::Arc<crate::value::HashData>,
+        needle: &crate::gc::Gc<crate::value::HashData>,
         replacement: &Value,
     ) {
         let mut updates: Vec<(Symbol, String)> = Vec::new();
@@ -345,7 +345,7 @@ impl Interpreter {
             if let Value::Instance { attributes, .. } = value {
                 for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let Value::Hash(arc) = attr_val
-                        && std::sync::Arc::ptr_eq(arc, needle)
+                        && crate::gc::Gc::ptr_eq(arc, needle)
                     {
                         updates.push((*var_name, attr_key.clone()));
                     }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1084,7 +1084,7 @@ impl Interpreter {
                             }
                         }
                         if let Some(Value::Hash(arc_hash)) = self.env.get_mut(&key) {
-                            let hash = Arc::make_mut(arc_hash);
+                            let hash = crate::gc::Gc::make_mut(arc_hash);
                             for (k, v) in kv_pairs {
                                 let wk = if is_object_hash {
                                     crate::runtime::utils::value_which_key(&k)
@@ -1098,7 +1098,7 @@ impl Interpreter {
                                 }
                                 Self::hash_push_insert(hash, wk, v, is_push);
                             }
-                            return Ok(Value::Hash(Arc::clone(arc_hash)));
+                            return Ok(Value::Hash(arc_hash.clone()));
                         }
                         // No existing hash in the variable: build a fresh typed
                         // hash from the pushed pairs (preserving the constraints).
@@ -1121,19 +1121,19 @@ impl Interpreter {
                             hd.key_type = key_constraint;
                         }
                         hd.value_type = value_constraint;
-                        let result = Value::Hash(Arc::new(hd));
+                        let result = Value::Hash(crate::gc::Gc::new(hd));
                         self.env.insert(key, result.clone());
                         return Ok(result);
                     }
 
                     // Fast path: COW via Arc::make_mut (O(1) when refcount=1)
                     if let Some(Value::Hash(arc_hash)) = self.env.get_mut(&key) {
-                        let hash = Arc::make_mut(arc_hash);
+                        let hash = crate::gc::Gc::make_mut(arc_hash);
                         let pairs = Self::hash_push_collect_pairs(args);
                         for (k, v) in pairs {
                             Self::hash_push_insert(hash, k, v, is_push);
                         }
-                        return Ok(Value::Hash(Arc::clone(arc_hash)));
+                        return Ok(Value::Hash(arc_hash.clone()));
                     }
 
                     // Fallback: create from target value

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -337,7 +337,7 @@ impl Interpreter {
                     self.quanthash_set_weight(&code, &source, key, &value)?;
                     return Ok(value);
                 }
-                let mut selected_hash: Option<std::sync::Arc<crate::value::HashData>> = None;
+                let mut selected_hash: Option<crate::gc::Gc<crate::value::HashData>> = None;
                 let mut selected_array: Option<std::sync::Arc<crate::value::ArrayData>> = None;
 
                 if let Some(var_name) = target_var
@@ -367,7 +367,7 @@ impl Interpreter {
                         _ => None,
                     });
                     if let Some(first) = candidates.next()
-                        && candidates.all(|other| std::sync::Arc::ptr_eq(&first, &other))
+                        && candidates.all(|other| crate::gc::Gc::ptr_eq(&first, &other))
                     {
                         selected_hash = Some(first);
                     }

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -123,7 +123,7 @@ impl Interpreter {
                 }
             };
             data.map.insert(key, value.clone());
-            Value::Hash(std::sync::Arc::new(data))
+            Value::Hash(crate::gc::Gc::new(data))
         };
         updated.insert(attr_name.to_string(), new_container);
         if let Some(var_name) = target_var {

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -91,7 +91,7 @@ impl Interpreter {
                     || $arc.key_type != $info.key_type
                     || $arc.declared_type != $info.declared_type
                 {
-                    let data = Arc::make_mut(&mut $arc);
+                    let data = crate::gc::ContainerMakeMut::container_make_mut(&mut $arc);
                     data.value_type = new_vt;
                     data.key_type = $info.key_type.clone();
                     data.declared_type = $info.declared_type.clone();
@@ -200,7 +200,7 @@ impl Interpreter {
     pub(crate) fn clear_hash_type_metadata(value: Value) -> Value {
         if let Value::Hash(mut arc) = value {
             if arc.has_type_meta() {
-                Arc::make_mut(&mut arc).clear_type_meta();
+                crate::gc::Gc::make_mut(&mut arc).clear_type_meta();
             }
             return Value::Hash(arc);
         }

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -59,8 +59,12 @@ impl Interpreter {
         let Some(Value::Hash(arc)) = sv.get_mut(key) else {
             return None;
         };
-        Value::hash_insert_through(&mut Arc::make_mut(arc).map, elem_key, value.clone());
-        let result = Value::Hash(Arc::clone(arc));
+        Value::hash_insert_through(
+            &mut crate::gc::Gc::make_mut(arc).map,
+            elem_key,
+            value.clone(),
+        );
+        let result = Value::Hash(arc.clone());
         drop(sv);
         if is_thread_clone {
             // Mark dirty once per key (a per-key env marker avoids re-locking the

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -225,7 +225,7 @@ impl Interpreter {
             }
             Value::Hash(mut map) => {
                 if map.default.as_deref() != Some(&default) {
-                    Arc::make_mut(&mut map).default = Some(Box::new(default));
+                    crate::gc::Gc::make_mut(&mut map).default = Some(Box::new(default));
                 }
                 Value::Hash(map)
             }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -705,7 +705,7 @@ impl Interpreter {
                     {
                         attributes.with_attr_mut("named", |named| {
                             if let Value::Hash(named_hash) = named {
-                                let named_hash = std::sync::Arc::make_mut(named_hash);
+                                let named_hash = crate::gc::Gc::make_mut(named_hash);
                                 for (hash_name, entries) in &captures.hash_captures {
                                     let mut hash_map: HashMap<String, Value> = HashMap::new();
                                     for (key, value) in entries {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -182,7 +182,7 @@ pub(crate) fn set_hash_original_keys(value: Value, original_keys: HashMap<String
         return value;
     }
     if let Value::Hash(mut arc) = value {
-        Arc::make_mut(&mut arc).original_keys = Some(original_keys);
+        crate::gc::Gc::make_mut(&mut arc).original_keys = Some(original_keys);
         return Value::Hash(arc);
     }
     value

--- a/src/runtime/utils/errors.rs
+++ b/src/runtime/utils/errors.rs
@@ -193,7 +193,7 @@ pub(crate) fn value_which_key(value: &Value) -> String {
             format!("{}|{}", value_type_name(value), id)
         }
         Value::Array(items, ..) => format!("Array|{:p}", Arc::as_ptr(items)),
-        Value::Hash(map) => format!("Hash|{:p}", Arc::as_ptr(map)),
+        Value::Hash(map) => format!("Hash|{:p}", crate::gc::Gc::as_ptr(map)),
         Value::Pair(k, v) => format!("Pair|{}|{}", k, value_which_key(v)),
         Value::ValuePair(k, v) => format!("Pair|{}|{}", value_which_key(k), value_which_key(v)),
         Value::Enum { enum_type, key, .. } => {

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -127,7 +127,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
             }
         }
         Value::Hash(items) => {
-            let ptr = std::sync::Arc::as_ptr(items) as usize;
+            let ptr = crate::gc::Gc::as_ptr(items) as usize;
             let is_cycle = SEEN_PTRS.with(|seen| check_and_push(seen, ptr));
             if is_cycle {
                 return "{...}".to_string();

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -208,7 +208,7 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
             (a.is_empty() && b.is_empty()) || std::sync::Arc::ptr_eq(a, b)
         }
         (Value::LazyList(a), Value::LazyList(b)) => std::sync::Arc::ptr_eq(a, b),
-        (Value::Hash(a), Value::Hash(b)) => std::sync::Arc::ptr_eq(a, b),
+        (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Sub(a), Value::Sub(b)) => {
             if std::sync::Arc::ptr_eq(a, b) {
                 return true;

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -487,7 +487,7 @@ impl Value {
                 thread_local! {
                     static SEEN_HASH_PTRS: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
                 }
-                let ptr = std::sync::Arc::as_ptr(items) as usize;
+                let ptr = crate::gc::Gc::as_ptr(items) as usize;
                 let is_cycle = SEEN_HASH_PTRS.with(|seen| {
                     let s = seen.borrow();
                     s.contains(&ptr)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock, Weak};
 
 use crate::ast::{ParamDef, Stmt};
 use crate::env::Env;
+use crate::gc::Gc;
 use crate::opcode::{CompiledCode, CompiledFunction};
 use crate::symbol::Symbol;
 use num_bigint::BigInt as NumBigInt;
@@ -312,6 +313,7 @@ mod value_methods_a;
 mod value_methods_b;
 mod value_methods_c;
 mod value_setbagmix;
+pub(crate) use crate::gc::gc_contents_mut;
 pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use types::what_type_name;
 
@@ -931,7 +933,7 @@ pub enum Value {
     },
     /// Distinguishes Array, List, and their itemized (Scalar-wrapped) variants.
     Array(Arc<ArrayData>, ArrayKind),
-    Hash(Arc<HashData>),
+    Hash(Gc<HashData>),
     Rat(i64, i64),
     FatRat(i64, i64),
     BigRat(Box<NumBigInt>, Box<NumBigInt>),
@@ -1067,7 +1069,7 @@ pub enum Value {
     /// It also serves `is raw` reduce lvalue descent (`hash_autovivify`), where
     /// the entry is eagerly created first so the path is always length 1.
     HashEntryRef {
-        hash: Arc<HashData>,
+        hash: Gc<HashData>,
         path: Vec<String>,
     },
 }

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -16,9 +16,44 @@
 //! `Junction` is likewise not in the design doc's candidate list and is
 //! excluded.
 
-use crate::gc::{RootVisitor, visit_map_values};
+use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
 use super::{ArrayData, HashData, InstanceAttrs, SharedChannel, SharedPromise, SubData, Value};
+
+impl Value {
+    /// Hand each direct GC-managed (`Gc<T>`) child of this value to `visit`.
+    ///
+    /// Distinct from [`Value::visit_gc_children`], which visits `&Value` for
+    /// root enumeration: `gc_trace` yields the erased `Gc` node handles the
+    /// cycle collector walks between managed nodes. Only variants already
+    /// migrated to `Gc<T>` (§11 step 5+) yield a child; the rest are no-ops. A
+    /// not-yet-migrated container that transitively holds a `Gc` node is a graph
+    /// edge that bypasses the Gc graph until it too migrates — acceptable while
+    /// the collector is off (design doc §3.1's wave phasing).
+    pub(crate) fn gc_trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        // Only migrated (`Gc<T>`) container variants yield a child; more arms
+        // land as further types migrate (§11 step 5c: `Array`, 5d: `ContainerRef`).
+        if let Value::Hash(data) = self {
+            visit(&data.erased());
+        }
+    }
+}
+
+impl Trace for HashData {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        for v in self.map.values() {
+            v.gc_trace(visit);
+        }
+        if let Some(keys) = &self.original_keys {
+            for v in keys.values() {
+                v.gc_trace(visit);
+            }
+        }
+        if let Some(d) = &self.default {
+            d.gc_trace(visit);
+        }
+    }
+}
 
 impl Value {
     #[allow(dead_code)]
@@ -175,7 +210,7 @@ mod tests {
             map,
             ..Default::default()
         };
-        let value = Value::Hash(Arc::new(data));
+        let value = Value::Hash(crate::gc::Gc::new(data));
 
         let mut visitor = CountingVisitor { count: 0 };
         value.visit_gc_children(&mut visitor);

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -149,14 +149,14 @@ impl Value {
     /// or a `HashData` (a cloned/rebuilt hash whose container metadata is then
     /// preserved) via `Into<HashData>`.
     pub fn hash(map: impl Into<HashData>) -> Self {
-        Value::Hash(Arc::new(map.into()))
+        Value::Hash(Gc::new(map.into()))
     }
 
-    /// Build an `Arc<HashData>` from a map or `HashData`. Lets call sites that
-    /// constructed `Value::Hash(Arc::new(x))` keep their shape as
+    /// Build a `Gc<HashData>` from a map or `HashData`. Lets call sites that
+    /// constructed `Value::Hash(crate::gc::Gc::new(x))` keep their shape as
     /// `Value::Hash(Value::hash_arc(x))` while the variant moved to `HashData`.
-    pub fn hash_arc(map: impl Into<HashData>) -> Arc<HashData> {
-        Arc::new(map.into())
+    pub(crate) fn hash_arc(map: impl Into<HashData>) -> Gc<HashData> {
+        Gc::new(map.into())
     }
 
     /// Coerce a value into item context (`.item` method).
@@ -175,21 +175,21 @@ impl Value {
     /// only when the flag actually changes, so `.WHICH` identity is preserved
     /// for an already-itemized hash). Used by the `Itemize`/`ItemizeVar` opcodes
     /// and `.item` to mark a `$`-sourced hash as a single list-context element.
-    pub(crate) fn hash_arc_itemized(h: Arc<HashData>) -> Arc<HashData> {
+    pub(crate) fn hash_arc_itemized(h: Gc<HashData>) -> Gc<HashData> {
         if h.itemized {
             h
         } else {
             let mut data = (*h).clone();
             data.itemized = true;
-            Arc::new(data)
+            Gc::new(data)
         }
     }
 
-    pub(crate) fn hash_arc_deitemized(h: Arc<HashData>) -> Arc<HashData> {
+    pub(crate) fn hash_arc_deitemized(h: Gc<HashData>) -> Gc<HashData> {
         if h.itemized {
             let mut data = (*h).clone();
             data.itemized = false;
-            Arc::new(data)
+            Gc::new(data)
         } else {
             h
         }
@@ -306,7 +306,7 @@ impl Value {
         if let Value::Hash(arc) = self {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
-            let data = unsafe { arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             if !data.map.contains_key(key) {
                 let new_hash = Value::hash(HashMap::new());
                 data.map.insert(key.to_string(), new_hash);
@@ -335,7 +335,7 @@ impl Value {
         if let Value::Hash(arc) = self {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
-            let data = unsafe { arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             match data.map.get_mut(key) {
                 Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
                 Some(elem @ (Value::Array(..) | Value::Hash(..))) => Some(elem.clone()),
@@ -376,7 +376,7 @@ impl Value {
         if let Value::Hash(arc) = self {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
-            let data = unsafe { arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             match data.map.get_mut(key) {
                 Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
                 Some(elem @ (Value::Array(..) | Value::Hash(..))) if !terminal => {
@@ -410,7 +410,7 @@ impl Value {
         if let Value::Hash(arc) = self {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
-            let data = unsafe { arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             Value::hash_insert_through(&mut data.map, key.to_string(), val.clone());
             Some(val)
         } else {
@@ -429,14 +429,14 @@ impl Value {
         let any = || Value::Package(crate::symbol::Symbol::intern("Any"));
         let mut cur = hash.clone();
         for k in &path[..path.len() - 1] {
-            let ptr = Arc::as_ptr(&cur);
+            let ptr = crate::gc::Gc::as_ptr(&cur);
             match unsafe { (*ptr).get(k.as_str()) } {
                 Some(Value::Hash(inner)) => cur = inner.clone(),
                 _ => return any(),
             }
         }
         let last = path.last().unwrap();
-        let ptr = Arc::as_ptr(&cur);
+        let ptr = crate::gc::Gc::as_ptr(&cur);
         unsafe { (*ptr).get(last.as_str()).cloned().unwrap_or_else(any) }
     }
 
@@ -444,16 +444,16 @@ impl Value {
     /// return the `(terminal hash Arc, terminal key)` so the caller can insert.
     /// Missing/non-hash intermediate levels are replaced with fresh empty hashes
     /// (interior mutation, so all holders of the shared Arc observe them).
-    pub fn hash_entry_terminal(&self) -> Option<(Arc<HashData>, String)> {
+    pub(crate) fn hash_entry_terminal(&self) -> Option<(Gc<HashData>, String)> {
         let Value::HashEntryRef { hash, path } = self else {
             return None;
         };
         let mut cur = hash.clone();
         for k in &path[..path.len() - 1] {
             // SAFETY: aliased in-place mutation of a shared hash; see
-            // `arc_contents_mut`. No borrow into the map is live across the write.
+            // `gc_contents_mut`. No borrow into the map is live across the write.
             let next = {
-                let data = unsafe { arc_contents_mut(&cur) };
+                let data = unsafe { gc_contents_mut(&cur) };
                 match data.map.get(k) {
                     Some(Value::Hash(inner)) => inner.clone(),
                     _ => {

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -7,7 +7,7 @@ impl Value {
         if let Some((arc, key)) = self.hash_entry_terminal() {
             // SAFETY: aliased in-place mutation of a shared hash; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
-            let data = unsafe { arc_contents_mut(&arc) };
+            let data = unsafe { crate::value::gc_contents_mut(&arc) };
             Value::hash_insert_through(&mut data.map, key, val);
         }
     }

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -171,7 +171,7 @@ impl Interpreter {
                 // promoted when re-evaluated). They are the same container iff
                 // the element currently stored at that slot IS this cell.
                 if let Some((arc, key)) = Self::extract_hash_ref(other) {
-                    let ptr = Arc::as_ptr(&arc);
+                    let ptr = crate::gc::Gc::as_ptr(&arc);
                     if let Some(Value::ContainerRef(elem_cell)) =
                         unsafe { (*ptr).get(key.as_str()) }
                     {
@@ -186,7 +186,7 @@ impl Interpreter {
         let a_ref = Self::extract_hash_ref(a);
         let b_ref = Self::extract_hash_ref(b);
         if let (Some((a_arc, a_key)), Some((b_arc, b_key))) = (a_ref, b_ref) {
-            Arc::ptr_eq(&a_arc, &b_arc) && a_key == b_key
+            crate::gc::Gc::ptr_eq(&a_arc, &b_arc) && a_key == b_key
         } else {
             // Both are the same value identity (for non-hash-ref cases)
             crate::runtime::values_identical(a, b)
@@ -197,13 +197,13 @@ impl Interpreter {
     /// to, walking its `path` READ-ONLY. Returns `None` if any intermediate level
     /// is missing or not a hash (the deferred path is not yet materialized, so it
     /// has no stable container identity).
-    fn extract_hash_ref(val: &Value) -> Option<(Arc<crate::value::HashData>, String)> {
+    fn extract_hash_ref(val: &Value) -> Option<(crate::gc::Gc<crate::value::HashData>, String)> {
         let Value::HashEntryRef { hash, path } = val else {
             return None;
         };
         let mut cur = hash.clone();
         for k in &path[..path.len() - 1] {
-            let ptr = Arc::as_ptr(&cur);
+            let ptr = crate::gc::Gc::as_ptr(&cur);
             match unsafe { (*ptr).get(k.as_str()) } {
                 Some(Value::Hash(inner)) => cur = inner.clone(),
                 _ => return None,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2864,7 +2864,7 @@ impl Interpreter {
                         }
                         Value::Hash(arc) => {
                             // SAFETY: aliased in-place clear; see `arc_contents_mut`.
-                            unsafe { crate::value::arc_contents_mut(arc).map.clear() };
+                            unsafe { crate::value::gc_contents_mut(arc).map.clear() };
                         }
                         // Slice 2a: a `=`-array-shared source (`my $r = @ary`) holds
                         // the aggregate inside a shared `ContainerRef` cell; clear it
@@ -2882,7 +2882,7 @@ impl Interpreter {
                         }
                         Value::Hash(arc) => {
                             // SAFETY: aliased in-place clear; see `arc_contents_mut`.
-                            unsafe { crate::value::arc_contents_mut(arc).map.clear() };
+                            unsafe { crate::value::gc_contents_mut(arc).map.clear() };
                         }
                         Value::ContainerRef(cell) => Self::clear_aggregate_cell(cell),
                         _ => {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -9,7 +9,7 @@ impl Interpreter {
         let mut guard = cell.lock().unwrap();
         match &mut *guard {
             Value::Array(arc, _) => std::sync::Arc::make_mut(arc).items.clear(),
-            Value::Hash(arc) => std::sync::Arc::make_mut(arc).map.clear(),
+            Value::Hash(arc) => crate::gc::Gc::make_mut(arc).map.clear(),
             other => *other = Value::Nil,
         }
     }

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -82,7 +82,7 @@ impl Interpreter {
         use std::sync::Arc;
         match (current, source_elem) {
             (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
-            (Value::Hash(a), Value::Hash(b)) => Arc::ptr_eq(a, b),
+            (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Str(a), Value::Str(b)) => Arc::ptr_eq(a, b) || a == b,
             (Value::Int(a), Value::Int(b)) => a == b,
             (Value::Num(a), Value::Num(b)) => a == b,

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1520,7 +1520,7 @@ pub(crate) fn cheaply_unchanged(old: &Value, new: &Value) -> bool {
         (Value::Nil, Value::Nil) => true,
         (Value::Str(a), Value::Str(b)) => Arc::ptr_eq(a, b),
         (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
-        (Value::Hash(a), Value::Hash(b)) => Arc::ptr_eq(a, b),
+        (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
         // A `ContainerRef` cell is the shared-identity primitive of the
         // single-store design: `my @a := @b` installs the *same* cell into both
         // the env entry and the local slot for both names. Without this arm the

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -63,7 +63,7 @@ impl Interpreter {
                 })
             });
             if let Some(Value::Hash(arc)) = current {
-                Some(Arc::as_ptr(&arc) as usize)
+                Some(crate::gc::Gc::as_ptr(&arc) as usize)
             } else {
                 None
             }
@@ -348,7 +348,7 @@ impl Interpreter {
             {
                 let has_old_ref = stack_arc.values().any(|v| {
                     if let Value::Hash(inner_arc) = v {
-                        Arc::as_ptr(inner_arc) as usize == old_ptr
+                        crate::gc::Gc::as_ptr(inner_arc) as usize == old_ptr
                     } else {
                         false
                     }

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -18,7 +18,7 @@ impl Interpreter {
                 let k = Value::hash_key_encode(key);
                 // SAFETY: aliased in-place mutation of a shared hash; see
                 // `arc_contents_mut`. No live borrow into the map.
-                let hd = unsafe { crate::value::arc_contents_mut(arc) };
+                let hd = unsafe { crate::value::gc_contents_mut(arc) };
                 Value::hash_insert_through(&mut hd.map, k, val);
             }
             Value::Array(arc, _) => {
@@ -64,7 +64,7 @@ impl Interpreter {
                 let cell = Arc::new(std::sync::Mutex::new(val));
                 // SAFETY: aliased in-place mutation of a shared hash; see
                 // `arc_contents_mut`. No live borrow into the map.
-                let hd = unsafe { crate::value::arc_contents_mut(&arc) };
+                let hd = unsafe { crate::value::gc_contents_mut(&arc) };
                 Value::hash_insert_through(&mut hd.map, key, Value::ContainerRef(cell.clone()));
                 cell
             }
@@ -331,7 +331,7 @@ impl Interpreter {
     pub(crate) fn same_container_arc(a: &Value, b: &Value) -> bool {
         match (a, b) {
             (Value::Array(x, _), Value::Array(y, _)) => Arc::ptr_eq(x, y),
-            (Value::Hash(x), Value::Hash(y)) => Arc::ptr_eq(x, y),
+            (Value::Hash(x), Value::Hash(y)) => crate::gc::Gc::ptr_eq(x, y),
             _ => false,
         }
     }

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -248,7 +248,7 @@ impl Interpreter {
         let env = self.env();
         match env.get(var_name) {
             Some(Value::Hash(hash_arc)) => {
-                let strong_count = Arc::strong_count(hash_arc);
+                let strong_count = crate::gc::Gc::strong_count_of(hash_arc);
                 // Reject if the hash Arc has more than 2 refs (e.g. HashEntryRef binding)
                 // strong_count == 1: only env holds it (no local slot)
                 // strong_count == 2: env + locals hold it (common case in for loops)
@@ -297,7 +297,7 @@ impl Interpreter {
                 }
                 if let Some(Value::Hash(hash)) = self.env_mut().get_mut(var_name) {
                     Value::hash_insert_through(
-                        &mut Arc::make_mut(hash).map,
+                        &mut crate::gc::Gc::make_mut(hash).map,
                         key.clone(),
                         val.clone(),
                     );

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -256,7 +256,7 @@ impl Interpreter {
             if let Some(container) = self.env().get(&var_name) {
                 match container {
                     Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
-                    Value::Hash(arc) => Some(Arc::as_ptr(arc) as usize),
+                    Value::Hash(arc) => Some(crate::gc::Gc::as_ptr(arc) as usize),
                     _ => None,
                 }
             } else {
@@ -662,7 +662,7 @@ impl Interpreter {
                         );
                     }
                     if let Some(Value::Hash(hash)) = self.env_root_descended_mut(&var_name) {
-                        let h = Arc::make_mut(hash);
+                        let h = crate::gc::Gc::make_mut(hash);
                         h.insert(k, v);
                     }
                 } else if let Some(idx_usize) = Self::index_to_usize(key) {
@@ -956,7 +956,7 @@ impl Interpreter {
                 let mut pending_source_cells: Vec<(String, Arc<std::sync::Mutex<Value>>)> =
                     Vec::new();
                 if let Some(Value::Hash(hash)) = self.env_mut().get_mut(&var_name) {
-                    let h = Arc::make_mut(hash);
+                    let h = crate::gc::Gc::make_mut(hash);
                     for (i, key) in keys.iter().enumerate() {
                         let k = if slice_is_object_hash {
                             runtime::utils::value_which_key(key)
@@ -1416,7 +1416,7 @@ impl Interpreter {
                         Value::Hash(ref mut hash) => {
                             let is_self_hash_ref = matches!(
                                 &val,
-                                Value::Hash(source_hash) if Arc::ptr_eq(hash, source_hash)
+                                Value::Hash(source_hash) if crate::gc::Gc::ptr_eq(hash, source_hash)
                             );
                             // Use in-place mutation instead of Arc::make_mut when the
                             // hash is shared (strong_count > 1) AND the variable is a
@@ -1435,7 +1435,7 @@ impl Interpreter {
                             // modifications propagate to the bound source.
                             // %-sigiled vars have names like "%h", scalar vars
                             // have names without a sigil prefix (e.g. "bar").
-                            let use_inplace = Arc::strong_count(hash) > 1
+                            let use_inplace = crate::gc::Gc::strong_count_of(hash) > 1
                                 && (!var_name.starts_with('%') || is_bound_hash_var);
                             // Mutate the whole `HashData` (map + embedded
                             // object-hash original keys) so the original-key map
@@ -1443,9 +1443,9 @@ impl Interpreter {
                             let hd: &mut crate::value::HashData = if use_inplace {
                                 // SAFETY: aliased in-place mutation of a shared
                                 // hash; see `arc_contents_mut`.
-                                unsafe { crate::value::arc_contents_mut(hash) }
+                                unsafe { crate::value::gc_contents_mut(hash) }
                             } else {
-                                Arc::make_mut(hash)
+                                crate::gc::Gc::make_mut(hash)
                             };
                             if bind_mode && let Some((source_install, cell)) = &bind_cell {
                                 // Phase 2 Stage 2: a `:=`-bound entry holds a
@@ -1812,7 +1812,7 @@ impl Interpreter {
             if let Some(ref container) = current {
                 let new_arc_ptr = match container {
                     Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
-                    Value::Hash(arc) => Some(Arc::as_ptr(arc) as usize),
+                    Value::Hash(arc) => Some(crate::gc::Gc::as_ptr(arc) as usize),
                     _ => None,
                 };
                 if let Some(new_ptr) = new_arc_ptr {
@@ -1821,7 +1821,7 @@ impl Interpreter {
                         for local in self.locals.iter_mut() {
                             // Only update refs that pointed to the OLD container.
                             if let Value::HashEntryRef { hash, .. } = local
-                                && Arc::as_ptr(hash) as usize == old_ptr
+                                && crate::gc::Gc::as_ptr(hash) as usize == old_ptr
                                 && let Value::Hash(new_arc) = container
                             {
                                 *hash = new_arc.clone();
@@ -2097,13 +2097,13 @@ impl Interpreter {
                     }
                 }
                 Value::Hash(inner_hash) => {
-                    if Arc::strong_count(inner_hash) > 1 {
+                    if crate::gc::Gc::strong_count_of(inner_hash) > 1 {
                         // SAFETY: aliased in-place mutation of a shared hash
                         // (strong_count > 1); see `arc_contents_mut`.
-                        let hd = unsafe { crate::value::arc_contents_mut(inner_hash) };
+                        let hd = unsafe { crate::value::gc_contents_mut(inner_hash) };
                         Value::hash_insert_through(&mut hd.map, outer_key.clone(), val.clone());
                     } else {
-                        let h = Arc::make_mut(inner_hash);
+                        let h = crate::gc::Gc::make_mut(inner_hash);
                         Value::hash_insert_through(h, outer_key.clone(), val.clone());
                     }
                 }
@@ -2131,13 +2131,14 @@ impl Interpreter {
             // `.WHICH` pointer identity. When shared, keep the make_mut COW
             // detach. The cast MUST target `HashData` (not its inner map) —
             // see docs/hashdata-migration-plan.md "Latent UB found & fixed".
-            let oh: &mut crate::value::HashData = if Arc::strong_count(outer_hash) == 1 {
+            let oh: &mut crate::value::HashData = if crate::gc::Gc::strong_count_of(outer_hash) == 1
+            {
                 // SAFETY: single strong holder; in-place avoids the make_mut
                 // relocation that would break `.WHICH` identity. See
                 // `arc_contents_mut`.
-                unsafe { crate::value::arc_contents_mut(outer_hash) }
+                unsafe { crate::value::gc_contents_mut(outer_hash) }
             } else {
-                Arc::make_mut(outer_hash)
+                crate::gc::Gc::make_mut(outer_hash)
             };
             // Vivify the missing entry as Array if the OUTER (second) subscript
             // is positional (e.g. `%h<key>[42] = ...`), otherwise as Hash.
@@ -2188,7 +2189,11 @@ impl Interpreter {
                 }
             }
             Value::Hash(h) => {
-                Value::hash_insert_through(&mut Arc::make_mut(h).map, outer_key.to_string(), val);
+                Value::hash_insert_through(
+                    &mut crate::gc::Gc::make_mut(h).map,
+                    outer_key.to_string(),
+                    val,
+                );
             }
             _ => {}
         }
@@ -2395,7 +2400,7 @@ impl Interpreter {
                             }
                         }
                         Value::Hash(hash_arc) => {
-                            let hash = Arc::make_mut(hash_arc);
+                            let hash = crate::gc::Gc::make_mut(hash_arc);
                             if !hash.contains_key(key.as_str()) {
                                 let new_val = if next_positional {
                                     Value::real_array(Vec::new())
@@ -2432,7 +2437,7 @@ impl Interpreter {
                                     }
                                 }
                                 Value::Hash(hash_arc) => {
-                                    let hash = Arc::make_mut(hash_arc);
+                                    let hash = crate::gc::Gc::make_mut(hash_arc);
                                     let new_val = if next_positional {
                                         Value::real_array(Vec::new())
                                     } else {
@@ -2469,7 +2474,7 @@ impl Interpreter {
                             }
                         }
                         Value::Hash(hash_arc) => {
-                            let hash = Arc::make_mut(hash_arc);
+                            let hash = crate::gc::Gc::make_mut(hash_arc);
                             if bind_cell.is_some() {
                                 hash.insert(key.clone(), leaf_val);
                             } else {
@@ -2673,7 +2678,7 @@ impl Interpreter {
                 };
                 // SAFETY: aliased in-place mutation of a shared hash so the change
                 // is visible to all holders of the same Arc; see `arc_contents_mut`.
-                let hd = unsafe { crate::value::arc_contents_mut(arc) };
+                let hd = unsafe { crate::value::gc_contents_mut(arc) };
                 Value::hash_insert_through(&mut hd.map, key.clone(), stored);
                 // For a fresh-cell bind, write the cell back to the source var
                 // so both sides alias the same container.

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -220,7 +220,7 @@ impl Interpreter {
                 }
             }
             if let Some(Value::Hash(hash)) = self.env_mut().get_mut(source_name) {
-                let h = Arc::make_mut(hash);
+                let h = crate::gc::Gc::make_mut(hash);
                 h.insert(idx_str.to_string(), value);
                 return Ok(());
             }
@@ -335,7 +335,7 @@ impl Interpreter {
             // Check if any values in the hash reference the old Arc.
             let has_old_ref = new_arc.values().any(|v| {
                 if let Value::Hash(inner_arc) = v {
-                    Arc::as_ptr(inner_arc) as usize == *old_ptr
+                    crate::gc::Gc::as_ptr(inner_arc) as usize == *old_ptr
                 } else {
                     false
                 }
@@ -349,7 +349,7 @@ impl Interpreter {
             let mut circular_keys = Vec::new();
             for (k, v) in new_arc.iter() {
                 if let Value::Hash(inner_arc) = v
-                    && Arc::as_ptr(inner_arc) as usize == *old_ptr
+                    && crate::gc::Gc::as_ptr(inner_arc) as usize == *old_ptr
                 {
                     circular_keys.push(k.clone());
                     // Placeholder - will be replaced below
@@ -366,7 +366,7 @@ impl Interpreter {
             // self-referential cycle requires the in-place write (a freshly
             // created Arc cannot be made cyclic via `get_mut`). See
             // `arc_contents_mut`; no borrow into the map is live across the write.
-            let data = unsafe { crate::value::arc_contents_mut(&result_arc) };
+            let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for key in &circular_keys {
                 data.map
                     .insert(key.clone(), Value::Hash(result_arc.clone()));
@@ -387,7 +387,7 @@ impl Interpreter {
         match v {
             Value::Array(inner_arc, _) => Arc::as_ptr(inner_arc) as usize == old_ptr,
             Value::Hash(map) => {
-                let hash_ptr = Arc::as_ptr(map) as usize;
+                let hash_ptr = crate::gc::Gc::as_ptr(map) as usize;
                 if seen_hashes.contains(&hash_ptr) {
                     return false;
                 }
@@ -419,7 +419,7 @@ impl Interpreter {
                 *v = Value::Array(new_array.clone(), kind);
             }
             Value::Hash(map) => {
-                let hash_ptr = Arc::as_ptr(map) as usize;
+                let hash_ptr = crate::gc::Gc::as_ptr(map) as usize;
                 if seen_hashes.contains(&hash_ptr) {
                     return;
                 }
@@ -435,7 +435,7 @@ impl Interpreter {
                     let mut self_ref_keys = Vec::new();
                     for (k, hv) in map.iter() {
                         if let Value::Hash(inner_arc) = hv
-                            && Arc::as_ptr(inner_arc) as usize == hash_ptr
+                            && crate::gc::Gc::as_ptr(inner_arc) as usize == hash_ptr
                         {
                             self_ref_keys.push(k.clone());
                             new_map.insert(k.clone(), Value::Nil);
@@ -444,14 +444,14 @@ impl Interpreter {
                         }
                     }
                     let new_hash_arc = Value::hash_arc(new_map);
-                    let new_hash_ptr = Arc::as_ptr(&new_hash_arc) as usize;
+                    let new_hash_ptr = crate::gc::Gc::as_ptr(&new_hash_arc) as usize;
                     // Mark the new hash as seen so recursive calls don't
                     // re-enter it via self-referencing values.
                     seen_hashes.push(new_hash_ptr);
                     // SAFETY: new_hash_arc was just created here; the
                     // self-reference insert and the in-place recursive fixup must
                     // alias it. See `arc_contents_mut`.
-                    let data = unsafe { crate::value::arc_contents_mut(&new_hash_arc) };
+                    let data = unsafe { crate::value::gc_contents_mut(&new_hash_arc) };
                     for key in &self_ref_keys {
                         data.map
                             .insert(key.clone(), Value::Hash(new_hash_arc.clone()));

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -468,7 +468,7 @@ impl Interpreter {
             match &mut updated {
                 Value::Hash(h) => {
                     Value::hash_insert_through(
-                        &mut Arc::make_mut(h).map,
+                        &mut crate::gc::Gc::make_mut(h).map,
                         key.clone(),
                         new_val.clone(),
                     );
@@ -602,16 +602,17 @@ impl Interpreter {
                     // in place so the caller observes the change. `Arc::make_mut`
                     // would COW-detach and silently drop the write (the array
                     // path already special-cased this; the hash path did not).
-                    let use_inplace = Arc::strong_count(h) > 1 && !name.starts_with('%');
+                    let use_inplace =
+                        crate::gc::Gc::strong_count_of(h) > 1 && !name.starts_with('%');
                     if use_inplace {
                         // SAFETY: aliased in-place mutation of a shared hash
                         // (strong_count > 1, the shared-cell case); mirrors the
                         // array arm's `arc_contents_mut` usage.
-                        let h = unsafe { crate::value::arc_contents_mut(h) };
+                        let h = unsafe { crate::value::gc_contents_mut(h) };
                         Value::hash_insert_through(&mut h.map, key.clone(), new_val.clone());
                     } else {
                         Value::hash_insert_through(
-                            &mut Arc::make_mut(h).map,
+                            &mut crate::gc::Gc::make_mut(h).map,
                             key.clone(),
                             new_val.clone(),
                         );

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -427,7 +427,7 @@ impl Interpreter {
         // Capture the old hash Arc before assignment for circular reference fixup.
         let old_hash_arc = if name.starts_with('%') {
             if let Value::Hash(arc) = &self.locals[idx] {
-                Some(Arc::as_ptr(arc) as usize)
+                Some(crate::gc::Gc::as_ptr(arc) as usize)
             } else {
                 None
             }

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -106,7 +106,7 @@ impl Interpreter {
         let env = self.env();
         match env.get(var_name) {
             Some(Value::Hash(hash_arc)) => {
-                let strong_count = Arc::strong_count(hash_arc);
+                let strong_count = crate::gc::Gc::strong_count_of(hash_arc);
                 if strong_count > 2 {
                     return None;
                 }
@@ -130,7 +130,7 @@ impl Interpreter {
                     self.locals[slot] = Value::Nil;
                 }
                 let removed = if let Some(Value::Hash(hash)) = self.env_mut().get_mut(var_name) {
-                    Arc::make_mut(hash).remove(&key)
+                    crate::gc::Gc::make_mut(hash).remove(&key)
                 } else {
                     None
                 };
@@ -515,26 +515,26 @@ impl Interpreter {
         Ok(match container {
             Value::Hash(hash) => match idx {
                 Value::Whatever => {
-                    let h = Arc::make_mut(hash);
+                    let h = crate::gc::Gc::make_mut(hash);
                     let removed: Vec<Value> = h.values().cloned().collect();
                     h.clear();
                     Value::array(removed)
                 }
                 Value::Num(f) if f.is_infinite() && f.is_sign_positive() => {
-                    let h = Arc::make_mut(hash);
+                    let h = crate::gc::Gc::make_mut(hash);
                     let removed: Vec<Value> = h.values().cloned().collect();
                     h.clear();
                     Value::array(removed)
                 }
                 Value::Array(keys, ..) => {
-                    let h = Arc::make_mut(hash);
+                    let h = crate::gc::Gc::make_mut(hash);
                     let removed = keys
                         .iter()
                         .map(|key| h.remove(&key.to_string_value()).unwrap_or(Value::Nil))
                         .collect();
                     Value::array(removed)
                 }
-                _ => Arc::make_mut(hash)
+                _ => crate::gc::Gc::make_mut(hash)
                     .remove(&idx.to_string_value())
                     .unwrap_or(Value::Nil),
             },

--- a/src/vm/vm_var_index_tracking.rs
+++ b/src/vm/vm_var_index_tracking.rs
@@ -27,7 +27,7 @@ impl Interpreter {
     pub(super) fn mark_bound_index(&mut self, var_name: &str, encoded: String) {
         let key = format!("__mutsu_bound_index::{}", var_name);
         if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
-            Arc::make_mut(map).insert(encoded, Value::Bool(true));
+            crate::gc::Gc::make_mut(map).insert(encoded, Value::Bool(true));
             return;
         }
         let mut map = std::collections::HashMap::new();
@@ -44,7 +44,7 @@ impl Interpreter {
     pub(super) fn mark_element_share(&mut self, var_name: &str, encoded: String) {
         let key = format!("__mutsu_elem_share::{}", var_name);
         if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
-            Arc::make_mut(map).insert(encoded, Value::Bool(true));
+            crate::gc::Gc::make_mut(map).insert(encoded, Value::Bool(true));
             return;
         }
         let mut map = std::collections::HashMap::new();
@@ -65,7 +65,7 @@ impl Interpreter {
     pub(super) fn clear_element_share(&mut self, var_name: &str, encoded: &str) {
         let key = format!("__mutsu_elem_share::{}", var_name);
         if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
-            Arc::make_mut(map).remove(encoded);
+            crate::gc::Gc::make_mut(map).remove(encoded);
         }
     }
 
@@ -73,7 +73,7 @@ impl Interpreter {
     pub(super) fn remove_bound_index(&mut self, var_name: &str, encoded: &str) {
         let key = format!("__mutsu_bound_index::{}", var_name);
         if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
-            Arc::make_mut(map).remove(encoded);
+            crate::gc::Gc::make_mut(map).remove(encoded);
         }
     }
 
@@ -83,7 +83,7 @@ impl Interpreter {
         {
             let deleted_key = format!("__mutsu_deleted_index::{}", var_name);
             if let Some(Value::Hash(map)) = self.env_mut().get_mut(&deleted_key) {
-                Arc::make_mut(map).remove(&encoded);
+                crate::gc::Gc::make_mut(map).remove(&encoded);
             }
         }
         // Record the assigned index in the array's *embedded* `initialized`
@@ -121,12 +121,12 @@ impl Interpreter {
     pub(super) fn mark_deleted_indices(&mut self, var_name: &str, idx: &Value) {
         let key = format!("__mutsu_deleted_index::{}", var_name);
         let map = if let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) {
-            Arc::make_mut(map)
+            crate::gc::Gc::make_mut(map)
         } else {
             let m = std::collections::HashMap::new();
             self.env_mut().insert(key.clone(), Value::hash(m));
             match self.env_mut().get_mut(&key) {
-                Some(Value::Hash(map)) => Arc::make_mut(map),
+                Some(Value::Hash(map)) => crate::gc::Gc::make_mut(map),
                 _ => return,
             }
         };
@@ -139,7 +139,7 @@ impl Interpreter {
         let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) else {
             return;
         };
-        let m = Arc::make_mut(map);
+        let m = crate::gc::Gc::make_mut(map);
         Self::unmark_index_entries(m, idx);
     }
 
@@ -187,7 +187,7 @@ impl Interpreter {
         let Some(Value::Hash(map)) = self.env_mut().get_mut(&key) else {
             return;
         };
-        let m = Arc::make_mut(map);
+        let m = crate::gc::Gc::make_mut(map);
         Self::unmark_index_entries(m, idx);
     }
 

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -743,7 +743,7 @@ impl Interpreter {
             } else if let Value::Str(s) = &key {
                 Self::ensure_hash(target);
                 if let Value::Hash(map, ..) = target {
-                    let map = std::sync::Arc::make_mut(map);
+                    let map = crate::gc::Gc::make_mut(map);
                     let entry = map
                         .entry(s.as_str().to_string())
                         .or_insert_with(|| Value::Package(crate::symbol::Symbol::intern("Any")));
@@ -786,7 +786,7 @@ impl Interpreter {
         } else if let Value::Str(s) = &key {
             Self::ensure_hash(target);
             if let Value::Hash(map, ..) = target {
-                let map = std::sync::Arc::make_mut(map);
+                let map = crate::gc::Gc::make_mut(map);
                 let entry = map
                     .entry(s.as_str().to_string())
                     .or_insert_with(|| Value::Package(crate::symbol::Symbol::intern("Any")));

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -81,7 +81,7 @@ impl Interpreter {
 
     pub(super) fn resolve_hash_entry(
         &self,
-        items: &Arc<crate::value::HashData>,
+        items: &crate::gc::Gc<crate::value::HashData>,
         key: &str,
     ) -> Value {
         match items.get(key) {
@@ -106,7 +106,10 @@ impl Interpreter {
 
     /// Resolve all sentinel entries in a hash, returning a new hash with
     /// bound variable references replaced by their current values.
-    pub(super) fn resolve_hash_for_iteration(&self, items: &Arc<crate::value::HashData>) -> Value {
+    pub(super) fn resolve_hash_for_iteration(
+        &self,
+        items: &crate::gc::Gc<crate::value::HashData>,
+    ) -> Value {
         let mut resolved = HashMap::new();
         for (key, value) in items.iter() {
             let resolved_value = match value {


### PR DESCRIPTION
First-wave `Arc → Gc<T>` container migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11 step 5). Migrates the **first** container variant, `Value::Hash`, from `Arc<HashData>` to `Gc<HashData>` — so the Bacon-Rajan cycle-collector node header (from #4110) now rides on every hash. Behavior-preserving.

### 5a — `Gc<T>` becomes a drop-in for `Arc<T>`
Adds the `Arc::` associated-fn surface the container code relies on: `make_mut` / `get_mut` / `ptr_eq` / `strong_count_of` / `as_ptr` / `erased`, plus `From` / `Debug` / `AsRef` / `PartialEq` (value equality like `Arc`; identity via `ptr_eq`), the free `gc_contents_mut` (Gc analog of `aliased_mut::arc_contents_mut`, same unsoundness contract), and a `ContainerMakeMut` bridge trait implemented for **both** `Arc<T>` and `Gc<T>` so shared container-mutation macros work while `Array`/`ContainerRef` are still `Arc`.

**Key invariant:** uniqueness/COW is judged by `header.strong` (live GC handles, *excluding* the candidate buffer's retained `Arc`), which equals what `Arc::strong_count` reported before the buffer existed — so COW behavior is identical whether `MUTSU_GC` is on or off.

### 5b — flip `Value::Hash`
- `impl Trace for HashData` (traces its map's `Value`s via the new `Value::gc_trace`, which yields the erased `Gc` of already-migrated variants; more arms land with Array/ContainerRef).
- 49 files: mechanical `Arc::{make_mut,as_ptr,ptr_eq,strong_count,get_mut}` / `arc_contents_mut` on hashes rewritten to `Gc` equivalents; hash-typed helper signatures `&Arc<HashData>` → `&Gc<HashData>`; `Value::Hash(Arc::new)` → `Gc::new`.

### Verification
- `value_stays_small` green — `Gc` is one word like `Arc`; `Value` does not grow.
- All **whitelisted** S32-hash roast tests + `S02-types/hash.t` pass.
- Container identity preserved: `my %g := %h; %g<d>=4` visible through `%h`; bound hashes share `.WHICH`, assignment copies differ.
- `make test` green modulo known-flaky async-socket tests (pass 3/3 in isolation). Non-whitelisted `multislice-6e.t`/`perl.t` partial failures are pre-existing feature gaps (multi-dim slice assignability / scalar-deconted perlify), unrelated to container identity.
- `cargo clippy -- -D warnings` clean.

With `MUTSU_GC` unset (default) a hash clone/drop is one atomic refcount op and buffers nothing. Next: 5c (`Value::Array` → `Gc<ArrayData>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)