### PR TITLE
feat(gc): migrate Value::Array to Gc<ArrayData> + drop dead arc_contents_mut (§11 step 5c)

### DIFF
--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -474,7 +474,7 @@ pub(crate) fn builtin_sample_value(type_name: &str) -> Option<Value> {
         "Bool" => Value::Bool(true),
         "List" => Value::array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
         "Array" => Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(vec![
+            crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                 Value::Int(1),
                 Value::Int(2),
             ])),

--- a/src/builtins/functions/flat.rs
+++ b/src/builtins/functions/flat.rs
@@ -56,7 +56,7 @@ pub(crate) fn deitemize_flat_operand(v: &Value) -> Value {
                 crate::value::Value::hash_arc_deitemized(h.clone()),
             ));
             Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(pairs)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(pairs)),
                 crate::value::ArrayKind::List,
             )
         }

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -263,7 +263,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     )))
                 } else {
                     Some(Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                         crate::value::ArrayKind::List,
                     )))
                 }

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -122,7 +122,7 @@ pub(super) fn dispatch(
             match target {
                 Value::Package(_) | Value::Nil => Some(Some(Ok(target.clone()))),
                 Value::Array(items, kind) => Some(Some(Ok(Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items.to_vec())),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items.to_vec())),
                     *kind,
                 )))),
                 Value::Hash(map) => Some(Some(Ok(Value::Hash(Value::hash_arc((**map).clone()))))),
@@ -303,7 +303,7 @@ pub(super) fn dispatch(
                     format!("Slip|{:p}", Arc::as_ptr(items))
                 }
                 Value::Array(items, ..) => {
-                    format!("Array|{:p}", Arc::as_ptr(items))
+                    format!("Array|{:p}", crate::gc::Gc::as_ptr(items))
                 }
                 Value::Hash(map) => {
                     format!("Hash|{:p}", crate::gc::Gc::as_ptr(map))

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -354,7 +354,7 @@ pub(crate) fn native_method_0arg(
     if method == "pending" {
         let failures = crate::value::get_pending_failures();
         return Some(Ok(Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(failures)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(failures)),
             crate::value::ArrayKind::List,
         )));
     }

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -1,6 +1,5 @@
 use crate::value::{ArrayKind, RuntimeError, Value};
 use num_traits::{Signed, Zero};
-use std::sync::Arc;
 
 use super::range_endpoint_display;
 
@@ -395,7 +394,7 @@ pub fn raku_value(v: &Value) -> String {
             if *kind == crate::value::ArrayKind::Lazy {
                 return "[...]".to_string();
             }
-            let ptr = Arc::as_ptr(items) as usize;
+            let ptr = crate::gc::Gc::as_ptr(items) as usize;
             let var_name = format!("@Array_{}", ptr);
             // Check for cycle
             let cycle_var = SEEN_PTRS.with(|seen| {

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1093,7 +1093,7 @@ pub(crate) fn native_method_1arg(
             };
             let (non_repeating, repeating) = rat_base_repeating(n, d, radix);
             Some(Ok(Value::Array(
-                Arc::new(crate::value::ArrayData::new(vec![
+                crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                     Value::str(non_repeating),
                     Value::str(repeating),
                 ])),

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -451,7 +451,7 @@ impl Compiler {
             let mut flags: Vec<Value> = chain.iter().map(|(_, p)| Value::Bool(*p)).collect();
             flags.push(Value::Bool(outer_positional));
             let positional_flags_idx = self.code.add_constant(Value::Array(
-                Arc::new(crate::value::ArrayData::new(flags)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(flags)),
                 crate::value::ArrayKind::Array,
             ));
             // Stack order: [value, idx_outermost, ..., idx_innermost]

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -326,7 +326,7 @@ impl<T: Trace + PartialEq + 'static> PartialEq for Gc<T> {
 impl<T: Trace + std::fmt::Debug + 'static> std::fmt::Debug for Gc<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Forward to the pointee so `Value`'s derived `Debug` prints a migrated
-        // `Gc<ArrayData>` exactly like the old `Arc<ArrayData>` did.
+        // `Gc<ArrayData>` exactly like the old `crate::gc::Gc<ArrayData>` did.
         std::fmt::Debug::fmt(&self.inner.value, f)
     }
 }

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -266,7 +266,7 @@ impl Interpreter {
             dispatcher_env.insert(
                 "__mutsu_multi_dispatch_candidates".to_string(),
                 Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(candidate_subs)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(candidate_subs)),
                     crate::value::ArrayKind::List,
                 ),
             );

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -356,10 +356,10 @@ impl Interpreter {
             "__mutsu_bind_index_value" => Ok(Value::Pair(
                 "__mutsu_bind_index_value".to_string(),
                 Box::new(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(vec![
+                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                         args.first().cloned().unwrap_or(Value::Nil),
                         args.get(1).cloned().unwrap_or(Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                             crate::value::ArrayKind::List,
                         )),
                     ])),
@@ -628,7 +628,7 @@ impl Interpreter {
                 } else {
                     // take with multiple args creates a single list element
                     Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(args.clone())),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(args.clone())),
                         crate::value::ArrayKind::List,
                     )
                 };

--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -166,7 +166,7 @@ impl Interpreter {
     pub(super) fn cas_retry_matches(expected_seen: &Value, latest_seen: &Value) -> bool {
         match (expected_seen, latest_seen) {
             (Value::Instance { id: a, .. }, Value::Instance { id: b, .. }) => a == b,
-            (Value::Array(a, ..), Value::Array(b, ..)) => std::sync::Arc::ptr_eq(a, b),
+            (Value::Array(a, ..), Value::Array(b, ..)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Seq(a), Value::Seq(b)) => std::sync::Arc::ptr_eq(a, b),
             (Value::Slip(a), Value::Slip(b)) => std::sync::Arc::ptr_eq(a, b),

--- a/src/runtime/builtins_atomic_cas.rs
+++ b/src/runtime/builtins_atomic_cas.rs
@@ -320,7 +320,7 @@ impl Interpreter {
             if !shared.contains_key(&atomic_key) {
                 drop(shared);
                 let arr = self.env.get(&arr_name).cloned().unwrap_or(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                     crate::value::ArrayKind::Array,
                 ));
                 let mut shared = self.shared_vars.write().unwrap();
@@ -335,7 +335,7 @@ impl Interpreter {
         {
             let mut shared = self.shared_vars.write().unwrap();
             let arr = shared.get(&atomic_key).cloned().unwrap_or(Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                 crate::value::ArrayKind::Array,
             ));
             if let Value::Array(ref elements, kind) = arr {
@@ -353,7 +353,7 @@ impl Interpreter {
                     new_elements[idx] = new_val.clone();
                     shared.insert(
                         atomic_key.clone(),
-                        Value::Array(std::sync::Arc::new(new_elements), kind),
+                        Value::Array(crate::gc::Gc::new(new_elements), kind),
                     );
                     did_swap = true;
                 }

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -46,7 +46,7 @@ impl Interpreter {
                 elements.extend(items);
             }
             let new_arr = Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(elements)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(elements)),
                 crate::value::ArrayKind::Array,
             );
             shared.insert(atomic_key, new_arr.clone());
@@ -90,7 +90,7 @@ impl Interpreter {
             }
             elements[idx] = value.clone();
             let new_arr = Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(elements)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(elements)),
                 crate::value::ArrayKind::Array,
             );
             shared.insert(atomic_key, new_arr.clone());
@@ -170,7 +170,7 @@ impl Interpreter {
             if !shared.contains_key(&atomic_key) {
                 drop(shared);
                 let arr = self.env.get(&arr_name).cloned().unwrap_or(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                     crate::value::ArrayKind::Array,
                 ));
                 let mut shared = self.shared_vars.write().unwrap();
@@ -185,7 +185,7 @@ impl Interpreter {
         {
             let mut shared = self.shared_vars.write().unwrap();
             let arr = shared.get(&atomic_key).cloned().unwrap_or(Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                 crate::value::ArrayKind::Array,
             ));
             // Navigate to the element using the dimension indices
@@ -242,7 +242,7 @@ impl Interpreter {
             } else {
                 new_elements[idx] = Self::multidim_set(&new_elements[idx], &dims[1..], value);
             }
-            Value::Array(std::sync::Arc::new(new_elements), *kind)
+            Value::Array(crate::gc::Gc::new(new_elements), *kind)
         } else {
             arr.clone()
         }

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -77,7 +77,7 @@ impl Interpreter {
                     .or_insert_with(|| Value::real_array(Vec::new()));
                 match entry {
                     Value::Array(values, ..) => {
-                        Arc::make_mut(values).push(item);
+                        crate::gc::Gc::make_mut(values).push(item);
                         Ok(())
                     }
                     Value::Hash(_) => Err(mixed_level_error(name)),

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -267,7 +267,7 @@ impl Interpreter {
                                     // SAFETY: aliased in-place mutation of a shared
                                     // container; see `arc_contents_mut`.
                                     unsafe {
-                                        crate::value::arc_contents_mut(items).items[idx] = new_src;
+                                        crate::value::gc_contents_mut(items).items[idx] = new_src;
                                     }
                                 }
                                 result.push(v);
@@ -304,7 +304,7 @@ impl Interpreter {
                     crate::value::ArrayKind::List
                 };
                 Ok(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(result)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(result)),
                     arr_kind,
                 ))
             }
@@ -320,7 +320,7 @@ impl Interpreter {
                 if itemize_result {
                     // Itemize the result as a list
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(result)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(result)),
                         crate::value::ArrayKind::ItemList,
                     ))
                 } else {

--- a/src/runtime/builtins_collection_listops.rs
+++ b/src/runtime/builtins_collection_listops.rs
@@ -23,7 +23,7 @@ impl Interpreter {
                 if items.is_empty() {
                     make_empty_array_failure("shift")
                 } else {
-                    Arc::make_mut(&mut items).remove(0)
+                    crate::gc::Gc::make_mut(&mut items).remove(0)
                 }
             }
             _ => make_empty_array_failure("shift"),
@@ -55,7 +55,7 @@ impl Interpreter {
         }
         Ok(match args.first().cloned() {
             Some(Value::Array(mut items, ..)) => {
-                let items_mut = Arc::make_mut(&mut items);
+                let items_mut = crate::gc::Gc::make_mut(&mut items);
                 if items_mut.is_empty() {
                     make_empty_array_failure("pop")
                 } else {
@@ -135,7 +135,7 @@ impl Interpreter {
             args.to_vec()
         };
         let list = Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(items)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
             crate::value::ArrayKind::List,
         );
         let mut result = Vec::new();

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -522,7 +522,7 @@ impl Interpreter {
                         mapped.push(apply_hyper_prefix(interp, routine, item.clone())?);
                     }
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(mapped)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(mapped)),
                         kind,
                     ))
                 }
@@ -569,7 +569,7 @@ impl Interpreter {
                 results.push(apply_hyper_prefix(self, &routine, item.clone())?);
             }
             let result = Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                 *kind,
             );
             if mutating {

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -557,7 +557,7 @@ impl Interpreter {
             .filter(|shape| shape.len() > 1);
         if let Some(shape) = dims {
             let dims_val = Value::Array(
-                std::sync::Arc::new(shape.into_iter().map(|n| Value::Int(n as i64)).collect()),
+                crate::gc::Gc::new(shape.into_iter().map(|n| Value::Int(n as i64)).collect()),
                 ArrayKind::List,
             );
             self.env.insert(key, dims_val);

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -96,7 +96,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
         let Value::Array(items, ..) = target else {
             return default();
         };
-        let items = std::sync::Arc::make_mut(items);
+        let items = crate::gc::Gc::make_mut(items);
         let mut out = Vec::with_capacity(items.len());
         for item in items.iter_mut() {
             out.push(multidim_delete(item, &indices[1..]));
@@ -154,7 +154,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
         Value::Num(f) => *f as usize,
         _ => return default(),
     };
-    let items = std::sync::Arc::make_mut(items);
+    let items = crate::gc::Gc::make_mut(items);
     if i >= items.len() {
         return default();
     }
@@ -188,7 +188,7 @@ pub(super) fn make_key_tuple(indices: &[Value]) -> Value {
         return indices[0].clone();
     }
     Value::Array(
-        std::sync::Arc::new(crate::value::ArrayData::new(indices.to_vec())),
+        crate::gc::Gc::new(crate::value::ArrayData::new(indices.to_vec())),
         ArrayKind::List,
     )
 }

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -170,7 +170,7 @@ impl Interpreter {
                         );
                     }
                     new_items[idx] = effective_value.clone();
-                    Value::Array(std::sync::Arc::new(new_items), kind)
+                    Value::Array(crate::gc::Gc::new(new_items), kind)
                 }
                 _ => return Ok(effective_value),
             }
@@ -276,7 +276,7 @@ impl Interpreter {
                 } else {
                     absent_default.clone().unwrap_or(Value::Nil)
                 };
-                (removed, Value::Array(std::sync::Arc::new(new_items), *kind))
+                (removed, Value::Array(crate::gc::Gc::new(new_items), *kind))
             }
             _ => return Ok(absent_default.unwrap_or(Value::Nil)),
         };
@@ -405,7 +405,7 @@ impl Interpreter {
                     let inner = new_items[idx].clone();
                     new_items[idx] = Self::multidim_assign_nested(inner, &dims[1..], value)?;
                 }
-                let result = Value::Array(std::sync::Arc::new(new_items), kind);
+                let result = Value::Array(crate::gc::Gc::new(new_items), kind);
                 // Preserve the shape registration on the new Arc so subsequent
                 // bounds checks (via shaped_array_shape) still work.
                 if let Some(ref shape) = shape {

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -67,12 +67,12 @@ impl Interpreter {
                 if exists {
                     let v = array_to_list(value);
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![key, v])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![key, v])),
                         ArrayKind::List,
                     ))
                 } else {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![])),
                         ArrayKind::List,
                     ))
                 }
@@ -97,12 +97,12 @@ impl Interpreter {
                 if !exists {
                     let v = array_to_list(value);
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![key, v])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![key, v])),
                         ArrayKind::List,
                     ))
                 } else {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![])),
                         ArrayKind::List,
                     ))
                 }
@@ -143,7 +143,7 @@ impl Interpreter {
                 Value::Int(path[0])
             } else {
                 Value::Array(
-                    std::sync::Arc::new(path.into_iter().map(Value::Int).collect()),
+                    crate::gc::Gc::new(path.into_iter().map(Value::Int).collect()),
                     ArrayKind::List,
                 )
             };
@@ -277,7 +277,7 @@ impl Interpreter {
             "kv" => {
                 if raw_exists {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                             key,
                             Value::Bool(exists),
                         ])),
@@ -285,7 +285,7 @@ impl Interpreter {
                     ))
                 } else {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![])),
                         ArrayKind::List,
                     ))
                 }
@@ -331,7 +331,7 @@ impl Interpreter {
                 Value::Int(path[0])
             } else {
                 Value::Array(
-                    std::sync::Arc::new(path.into_iter().map(Value::Int).collect()),
+                    crate::gc::Gc::new(path.into_iter().map(Value::Int).collect()),
                     ArrayKind::List,
                 )
             };
@@ -634,7 +634,7 @@ impl Interpreter {
                     Value::Int(path[0])
                 } else {
                     Value::Array(
-                        std::sync::Arc::new(path.into_iter().map(Value::Int).collect()),
+                        crate::gc::Gc::new(path.into_iter().map(Value::Int).collect()),
                         ArrayKind::List,
                     )
                 };
@@ -694,12 +694,12 @@ impl Interpreter {
                 if exists {
                     let v = array_to_list(value);
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![key, v])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![key, v])),
                         ArrayKind::List,
                     ))
                 } else {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![])),
                         ArrayKind::List,
                     ))
                 }
@@ -760,7 +760,7 @@ impl Interpreter {
                     Value::Int(path[0])
                 } else {
                     Value::Array(
-                        std::sync::Arc::new(path.into_iter().map(Value::Int).collect()),
+                        crate::gc::Gc::new(path.into_iter().map(Value::Int).collect()),
                         ArrayKind::List,
                     )
                 };
@@ -807,7 +807,7 @@ impl Interpreter {
             "kv" => {
                 if raw_exists {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                             key,
                             Value::Bool(exists),
                         ])),
@@ -815,7 +815,7 @@ impl Interpreter {
                     ))
                 } else {
                     Ok(Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![])),
                         ArrayKind::List,
                     ))
                 }

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -377,7 +377,7 @@ impl Interpreter {
                     }
                     Value::Array(items, ..) => {
                         let hole_value = Value::Package(crate::symbol::Symbol::intern(&hole_type));
-                        let arr = std::sync::Arc::make_mut(items);
+                        let arr = crate::gc::Gc::make_mut(items);
                         for idx in &indices {
                             let i = match idx {
                                 Value::Int(i) => *i,

--- a/src/runtime/builtins_operators_coerce.rs
+++ b/src/runtime/builtins_operators_coerce.rs
@@ -240,7 +240,7 @@ impl Interpreter {
         let right_is_array = matches!(right, Value::Array(_, crate::value::ArrayKind::Array));
         if !left_is_array && !right_is_array {
             Ok(Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                 crate::value::ArrayKind::List,
             ))
         } else {

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -116,7 +116,7 @@ impl Interpreter {
                             results.push(v);
                         }
                         return Ok(Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                             crate::value::ArrayKind::List,
                         ));
                     }
@@ -205,7 +205,7 @@ impl Interpreter {
                                 results.push(v);
                             }
                             return Ok(Value::Array(
-                                std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                                crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                                 crate::value::ArrayKind::List,
                             ));
                         }

--- a/src/runtime/builtins_operators_repeat.rs
+++ b/src/runtime/builtins_operators_repeat.rs
@@ -161,7 +161,10 @@ impl Interpreter {
             // Seq → List when used as xx LHS (Raku caches/listifies Seq on repeat)
             Value::Seq(items) => Ok(Value::array(items.as_ref().clone())),
             // xx thunks the LHS: each repetition must be an independent copy
-            Value::Array(items, kind) => Ok(Value::Array(Arc::new(items.as_ref().clone()), *kind)),
+            Value::Array(items, kind) => Ok(Value::Array(
+                crate::gc::Gc::new(items.as_ref().clone()),
+                *kind,
+            )),
             Value::Hash(map) => Ok(Value::Hash(Value::hash_arc(map.as_ref().clone()))),
             _ => Ok(left.clone()),
         }

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -184,7 +184,7 @@ pub(crate) fn multidim_assign_pos(
         updated[i] = new_child;
     }
     Ok(Value::Array(
-        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
         *arr_kind,
     ))
 }
@@ -223,7 +223,7 @@ pub(crate) fn multidim_bind_pos(
         updated[i] = new_child;
     }
     Ok(Value::Array(
-        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
         *arr_kind,
     ))
 }
@@ -268,7 +268,7 @@ pub(crate) fn multidim_delete_pos(
     Ok((
         deleted,
         Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
             *arr_kind,
         ),
     ))

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -143,7 +143,7 @@ impl Interpreter {
                             new_items[i] = val;
                         }
                     }
-                    let mut result = Value::Array(std::sync::Arc::new(new_items), is_arr);
+                    let mut result = Value::Array(crate::gc::Gc::new(new_items), is_arr);
                     crate::runtime::utils::mark_shaped_array(&result, Some(&dims));
                     // Register type metadata for typed shaped arrays (e.g. array[str].new(:shape(5), ...))
                     if let Some(ta) = type_args

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -234,7 +234,7 @@ impl Interpreter {
             && matches!(method, "sum" | "min" | "max" | "Int")
         {
             let arr = Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(items.to_vec())),
+                crate::gc::Gc::new(crate::value::ArrayData::new(items.to_vec())),
                 crate::value::ArrayKind::List,
             );
             return self.call_method_with_values(arr, method, args);
@@ -921,7 +921,7 @@ impl Interpreter {
                             if let Some(existing) = map.get(&key) {
                                 // Key exists: create itemized array
                                 let arr = Value::Array(
-                                    Arc::new(crate::value::ArrayData::new(vec![
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                                         existing.clone(),
                                         *v,
                                     ])),
@@ -937,7 +937,7 @@ impl Interpreter {
                             let map = &mut data.map;
                             if let Some(existing) = map.get(&key) {
                                 let arr = Value::Array(
-                                    Arc::new(crate::value::ArrayData::new(vec![
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                                         existing.clone(),
                                         *v,
                                     ])),
@@ -961,7 +961,10 @@ impl Interpreter {
                         let key = k.as_str().to_string();
                         if let Some(existing) = new_map.get(&key) {
                             let arr = Value::Array(
-                                Arc::new(crate::value::ArrayData::new(vec![existing.clone(), *v])),
+                                crate::gc::Gc::new(crate::value::ArrayData::new(vec![
+                                    existing.clone(),
+                                    *v,
+                                ])),
                                 crate::value::ArrayKind::ItemArray,
                             );
                             new_map.insert(key, arr);
@@ -973,7 +976,10 @@ impl Interpreter {
                         let key = k.to_string_value();
                         if let Some(existing) = new_map.get(&key) {
                             let arr = Value::Array(
-                                Arc::new(crate::value::ArrayData::new(vec![existing.clone(), *v])),
+                                crate::gc::Gc::new(crate::value::ArrayData::new(vec![
+                                    existing.clone(),
+                                    *v,
+                                ])),
                                 crate::value::ArrayKind::ItemArray,
                             );
                             new_map.insert(key, arr);
@@ -1160,7 +1166,7 @@ impl Interpreter {
                                 }
                             };
                             return Ok(Value::Array(
-                                std::sync::Arc::new(crate::value::ArrayData::new(vec![
+                                crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                                     Value::str(volume),
                                     Value::str(dir),
                                     Value::str(file),
@@ -1182,7 +1188,7 @@ impl Interpreter {
                                 ("", path.as_str())
                             };
                         return Ok(Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(vec![
+                            crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                                 Value::str_from(""),
                                 Value::str(dir.to_string()),
                                 Value::str(file.to_string()),
@@ -1360,7 +1366,7 @@ impl Interpreter {
                             .unwrap_or_default();
                         if path.is_empty() {
                             return Ok(Value::Array(
-                                std::sync::Arc::new(crate::value::ArrayData::new(vec![
+                                crate::gc::Gc::new(crate::value::ArrayData::new(vec![
                                     Value::str_from(""),
                                 ])),
                                 crate::value::ArrayKind::List,
@@ -1374,7 +1380,7 @@ impl Interpreter {
                             path.split('/').map(|s| Value::str(s.to_string())).collect()
                         };
                         return Ok(Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(parts)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(parts)),
                             crate::value::ArrayKind::List,
                         ));
                     }
@@ -2144,7 +2150,7 @@ impl Interpreter {
             let shape = crate::runtime::utils::shaped_array_shape(&target);
             let is_native = self.env.iter().any(|(name, bound)| {
                 if let Value::Array(existing, ..) = bound
-                    && std::sync::Arc::ptr_eq(existing, items)
+                    && crate::gc::Gc::ptr_eq(existing, items)
                     && let Some(constraint) = self.var_type_constraint(&name.resolve())
                 {
                     crate::runtime::native_types::is_native_array_element_type(&constraint)
@@ -2275,7 +2281,7 @@ impl Interpreter {
                         && let Some((var_name, constraint)) =
                             self.env.iter().find_map(|(name, bound)| {
                                 if let Value::Array(existing, ..) = bound
-                                    && std::sync::Arc::ptr_eq(existing, items)
+                                    && crate::gc::Gc::ptr_eq(existing, items)
                                     && let Some(constraint) =
                                         self.var_type_constraint(&name.resolve())
                                 {
@@ -2311,7 +2317,7 @@ impl Interpreter {
                     }
                     updated[index] = value.clone();
                     let replacement = Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                         *arr_kind,
                     );
                     if let Some(ref shape) = shape {
@@ -2338,7 +2344,7 @@ impl Interpreter {
                     }
                     updated[index] = Value::Scalar(Box::new(value.clone()));
                     let replacement = Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                         *arr_kind,
                     );
                     if let Some(ref shape) = shape {
@@ -2372,7 +2378,7 @@ impl Interpreter {
                         Value::Nil
                     };
                     let replacement = Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                         *arr_kind,
                     );
                     if let Some(ref shape) = shape {
@@ -2384,7 +2390,7 @@ impl Interpreter {
                 ("clone", _) => {
                     let cloned = items.to_vec();
                     return Ok(Value::Array(
-                        Arc::new(crate::value::ArrayData::new(cloned)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(cloned)),
                         *arr_kind,
                     ));
                 }

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -218,7 +218,7 @@ impl Interpreter {
         // (Arc refcount > 1), mutate in-place so all references see the
         // change. This matches Raku's container semantics.
         if let Value::Array(ref arc, _) = target
-            && Arc::strong_count(arc) > 1
+            && crate::gc::Gc::strong_count(arc) > 1
             && matches!(method, "push" | "append" | "unshift" | "prepend")
         {
             let vals: Vec<Value> = match method {
@@ -231,7 +231,7 @@ impl Interpreter {
             // SAFETY: aliased in-place mutation of a shared array (guarded by
             // strong_count > 1, the exact case that needs the shared write); see
             // `arc_contents_mut`. No borrow into the items is live across this.
-            let data = unsafe { crate::value::arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             if matches!(method, "unshift" | "prepend") {
                 let mut combined = vals;
                 combined.append(&mut data.items);
@@ -254,7 +254,7 @@ impl Interpreter {
                 let normalized = Self::normalize_push_args_for_copy(args);
                 items.extend(normalized);
                 Ok(Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     kind,
                 ))
             }
@@ -262,7 +262,7 @@ impl Interpreter {
                 let flat = flatten_append_args(args);
                 items.extend(flat);
                 Ok(Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     kind,
                 ))
             }
@@ -278,13 +278,13 @@ impl Interpreter {
                 }
                 if items.is_empty() {
                     Ok(Value::Array(
-                        Arc::new(crate::value::ArrayData::new(items)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                         kind,
                     ))
                 } else {
                     items.pop();
                     Ok(Value::Array(
-                        Arc::new(crate::value::ArrayData::new(items)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                         kind,
                     ))
                 }
@@ -298,13 +298,13 @@ impl Interpreter {
                 }
                 if items.is_empty() {
                     Ok(Value::Array(
-                        Arc::new(crate::value::ArrayData::new(items)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                         kind,
                     ))
                 } else {
                     items.remove(0);
                     Ok(Value::Array(
-                        Arc::new(crate::value::ArrayData::new(items)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                         kind,
                     ))
                 }
@@ -315,7 +315,7 @@ impl Interpreter {
                     items.insert(i, arg);
                 }
                 Ok(Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     kind,
                 ))
             }

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -335,7 +335,7 @@ impl Interpreter {
                     Value::Array(filtered_items, fkind) if !indices.is_empty() => {
                         let mut data = (*filtered_items).clone();
                         data.items = shared_cells;
-                        Value::Array(std::sync::Arc::new(data), fkind)
+                        Value::Array(crate::gc::Gc::new(data), fkind)
                     }
                     other => other,
                 };

--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -544,7 +544,7 @@ pub(crate) fn sort_value_generic(
                 let Value::Array(mut items, ..) = target else {
                     unreachable!()
                 };
-                let items_mut = Arc::make_mut(&mut items);
+                let items_mut = crate::gc::Gc::make_mut(&mut items);
                 if return_indices {
                     Ok(Value::array(sort_indices_generic(
                         caller,

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -485,7 +485,7 @@ impl Interpreter {
         env.insert(
             "__mutsu_lazy_map_items".to_string(),
             Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                 crate::value::ArrayKind::List,
             ),
         );
@@ -597,7 +597,7 @@ impl Interpreter {
         match target {
             Value::Array(_, kind) if kind.is_lazy() => Err(RuntimeError::cannot_lazy("pop")),
             Value::Array(mut items, ..) => {
-                let items_mut = Arc::make_mut(&mut items);
+                let items_mut = crate::gc::Gc::make_mut(&mut items);
                 Ok(if items_mut.is_empty() {
                     make_empty_array_failure("pop")
                 } else {

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -629,7 +629,7 @@ impl Interpreter {
             }
             // A plain scalar interprets itself as a single-element List.
             other => Ok(Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(vec![other])),
+                crate::gc::Gc::new(crate::value::ArrayData::new(vec![other])),
                 crate::value::ArrayKind::List,
             )),
         }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -463,7 +463,10 @@ impl Interpreter {
                     }
                     updated_named.insert(
                         child_name,
-                        Value::Array(Arc::new(crate::value::ArrayData::new(updated_items)), *meta),
+                        Value::Array(
+                            crate::gc::Gc::new(crate::value::ArrayData::new(updated_items)),
+                            *meta,
+                        ),
                     );
                 } else {
                     let dispatch_name =

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1828,7 +1828,7 @@ impl Interpreter {
             .entry(attr_name.to_string())
             .or_insert_with(|| Value::real_array(Vec::new()));
         if let Value::Array(items, _) = arr {
-            let items = Arc::make_mut(items);
+            let items = crate::gc::Gc::make_mut(items);
             match method {
                 "push" => {
                     for arg in args {

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -230,7 +230,7 @@ impl Interpreter {
 
     pub(crate) fn overwrite_array_bindings_by_identity(
         &mut self,
-        needle: &std::sync::Arc<crate::value::ArrayData>,
+        needle: &crate::gc::Gc<crate::value::ArrayData>,
         replacement: Value,
     ) {
         let mut keys: Vec<Symbol> = Vec::new();
@@ -242,12 +242,12 @@ impl Interpreter {
         let mut cells: Vec<std::sync::Arc<std::sync::Mutex<Value>>> = Vec::new();
         for (name, value) in self.env.iter() {
             match value {
-                Value::Array(existing, ..) if std::sync::Arc::ptr_eq(existing, needle) => {
+                Value::Array(existing, ..) if crate::gc::Gc::ptr_eq(existing, needle) => {
                     keys.push(*name);
                 }
                 Value::ContainerRef(cell) => {
                     if let Value::Array(existing, ..) = &*cell.lock().unwrap()
-                        && std::sync::Arc::ptr_eq(existing, needle)
+                        && crate::gc::Gc::ptr_eq(existing, needle)
                     {
                         cells.push(cell.clone());
                     }
@@ -310,7 +310,7 @@ impl Interpreter {
     /// share the same array container.
     pub(crate) fn propagate_shared_array_in_instances(
         &mut self,
-        needle: &std::sync::Arc<crate::value::ArrayData>,
+        needle: &crate::gc::Gc<crate::value::ArrayData>,
         replacement: &Value,
     ) {
         let mut updates: Vec<(Symbol, String)> = Vec::new();
@@ -318,7 +318,7 @@ impl Interpreter {
             if let Value::Instance { attributes, .. } = value {
                 for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let Value::Array(arc, ..) = attr_val
-                        && std::sync::Arc::ptr_eq(arc, needle)
+                        && crate::gc::Gc::ptr_eq(arc, needle)
                     {
                         updates.push((*var_name, attr_key.clone()));
                     }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -586,9 +586,9 @@ impl Interpreter {
                     let result = if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key)
                     {
                         let kind = *kind;
-                        let items = Arc::make_mut(arc_items);
+                        let items = crate::gc::Gc::make_mut(arc_items);
                         items.extend(flat_values);
-                        Value::Array(Arc::clone(arc_items), kind)
+                        Value::Array(crate::gc::Gc::clone(arc_items), kind)
                     } else {
                         let mut items = match target {
                             Value::Array(v, ..) => v.to_vec(),
@@ -608,11 +608,11 @@ impl Interpreter {
                     let result = if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key)
                     {
                         let kind = *kind;
-                        let items = Arc::make_mut(arc_items);
+                        let items = crate::gc::Gc::make_mut(arc_items);
                         for (i, arg) in normalized_args.iter().enumerate() {
                             items.insert(i, arg.clone());
                         }
-                        Value::Array(Arc::clone(arc_items), kind)
+                        Value::Array(crate::gc::Gc::clone(arc_items), kind)
                     } else {
                         let items = match target {
                             Value::Array(v, ..) => v.to_vec(),
@@ -633,11 +633,11 @@ impl Interpreter {
                     let result = if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key)
                     {
                         let kind = *kind;
-                        let items = Arc::make_mut(arc_items);
+                        let items = crate::gc::Gc::make_mut(arc_items);
                         for (i, arg) in flat_values.iter().enumerate() {
                             items.insert(i, arg.clone());
                         }
-                        Value::Array(Arc::clone(arc_items), kind)
+                        Value::Array(crate::gc::Gc::clone(arc_items), kind)
                     } else {
                         let items = match target {
                             Value::Array(v, ..) => v.to_vec(),
@@ -671,7 +671,7 @@ impl Interpreter {
                         if arc_items.is_empty() {
                             return Ok(make_empty_array_failure_what("pop", &empty_what));
                         }
-                        let items = Arc::make_mut(arc_items);
+                        let items = crate::gc::Gc::make_mut(arc_items);
                         items.pop().unwrap_or(Value::Nil)
                     } else {
                         let mut items = match target {
@@ -699,7 +699,7 @@ impl Interpreter {
                         if arc_items.is_empty() {
                             return Ok(make_empty_array_failure_what("shift", &empty_what));
                         }
-                        let items = Arc::make_mut(arc_items);
+                        let items = crate::gc::Gc::make_mut(arc_items);
                         items.remove(0)
                     } else {
                         let mut items = match target {
@@ -945,7 +945,7 @@ impl Interpreter {
                         ));
                     }
                     let removed = if let Some(Value::Array(arc_items, _)) = self.env.get_mut(&key) {
-                        let items = Arc::make_mut(arc_items);
+                        let items = crate::gc::Gc::make_mut(arc_items);
                         do_splice(items, &resolved_args)
                     } else {
                         let mut items = match target {
@@ -1188,7 +1188,7 @@ impl Interpreter {
                         } else {
                             normalized_args
                         };
-                        if Arc::strong_count(arc_items) > 1 {
+                        if crate::gc::Gc::strong_count(arc_items) > 1 {
                             // Shared backing array: mutate the interior in place so
                             // every alias observes the push. `Arc::make_mut` would
                             // detach a private copy and lose the write for those
@@ -1199,18 +1199,18 @@ impl Interpreter {
                             // the caller's binding stale. SAFETY: same contract as
                             // `array_push_in_place` — no live borrow into the items,
                             // and we do not re-enter the VM while the borrow is held.
-                            let data = unsafe { crate::value::arc_contents_mut(arc_items) };
+                            let data = unsafe { crate::value::gc_contents_mut(arc_items) };
                             data.items.extend(vals);
                         } else {
-                            Arc::make_mut(arc_items).extend(vals);
+                            crate::gc::Gc::make_mut(arc_items).extend(vals);
                         }
-                        return Ok(Value::Array(Arc::clone(arc_items), kind));
+                        return Ok(Value::Array(crate::gc::Gc::clone(arc_items), kind));
                     }
                     // Interior mutation: if the target Array has shared references
                     // (Arc refcount > 1), mutate in-place so all references see the
                     // change. This matches Raku's container semantics.
                     if let Value::Array(ref arc_items, _) = target
-                        && Arc::strong_count(arc_items) > 1
+                        && crate::gc::Gc::strong_count(arc_items) > 1
                     {
                         let vals = if method == "append" {
                             flatten_append_args(normalized_args)
@@ -1231,8 +1231,10 @@ impl Interpreter {
                     } else {
                         items.extend(normalized_args);
                     }
-                    let result =
-                        Value::Array(Arc::new(crate::value::ArrayData::new(items)), array_flag);
+                    let result = Value::Array(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                        array_flag,
+                    );
                     self.env.insert(key, result.clone());
                     return Ok(result);
                 }
@@ -1250,11 +1252,11 @@ impl Interpreter {
                     }
                     if let Some(Value::Array(arc_items, _)) = self.env.get_mut(&key) {
                         // Shared backing array: in-place interior mutation (see `push`).
-                        let items = if Arc::strong_count(arc_items) > 1 {
+                        let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                             // SAFETY: same contract as `array_push_in_place`.
-                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                            unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
                         } else {
-                            Arc::make_mut(arc_items)
+                            crate::gc::Gc::make_mut(arc_items)
                         };
                         let out = if items.is_empty() {
                             make_empty_array_failure_what("pop", &empty_what)
@@ -1274,7 +1276,10 @@ impl Interpreter {
                     };
                     self.env.insert(
                         key,
-                        Value::Array(Arc::new(crate::value::ArrayData::new(items)), array_flag),
+                        Value::Array(
+                            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                            array_flag,
+                        ),
                     );
                     return Ok(out);
                 }
@@ -1285,16 +1290,16 @@ impl Interpreter {
                         // Shared backing array: mutate the interior in place so
                         // every alias (a by-ref param, a captured-outer slot)
                         // observes the change. See the `push` branch above.
-                        let items = if Arc::strong_count(arc_items) > 1 {
+                        let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                             // SAFETY: same contract as `array_push_in_place`.
-                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                            unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
                         } else {
-                            Arc::make_mut(arc_items)
+                            crate::gc::Gc::make_mut(arc_items)
                         };
                         for (i, arg) in normalized_args.iter().enumerate() {
                             items.insert(i, arg.clone());
                         }
-                        return Ok(Value::Array(Arc::clone(arc_items), kind));
+                        return Ok(Value::Array(crate::gc::Gc::clone(arc_items), kind));
                     }
                     let mut items = match &target {
                         Value::Array(v, ..) => v.to_vec(),
@@ -1303,8 +1308,10 @@ impl Interpreter {
                     for (i, arg) in normalized_args.iter().enumerate() {
                         items.insert(i, arg.clone());
                     }
-                    let result =
-                        Value::Array(Arc::new(crate::value::ArrayData::new(items)), array_flag);
+                    let result = Value::Array(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                        array_flag,
+                    );
                     self.env.insert(key, result.clone());
                     return Ok(result);
                 }
@@ -1313,16 +1320,16 @@ impl Interpreter {
                     if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(&key) {
                         let kind = *kind;
                         // Shared backing array: in-place interior mutation (see `push`).
-                        let items = if Arc::strong_count(arc_items) > 1 {
+                        let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                             // SAFETY: same contract as `array_push_in_place`.
-                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                            unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
                         } else {
-                            Arc::make_mut(arc_items)
+                            crate::gc::Gc::make_mut(arc_items)
                         };
                         for (i, arg) in flat_values.iter().enumerate() {
                             items.insert(i, arg.clone());
                         }
-                        return Ok(Value::Array(Arc::clone(arc_items), kind));
+                        return Ok(Value::Array(crate::gc::Gc::clone(arc_items), kind));
                     }
                     let items = match &target {
                         Value::Array(v, ..) => v.to_vec(),
@@ -1331,12 +1338,15 @@ impl Interpreter {
                     let mut pref: Vec<Value> = flat_values;
                     pref.extend(items);
                     let result = Value::Array(
-                        Arc::new(crate::value::ArrayData::new(pref.clone())),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(pref.clone())),
                         array_flag,
                     );
                     self.env.insert(
                         key,
-                        Value::Array(Arc::new(crate::value::ArrayData::new(pref)), array_flag),
+                        Value::Array(
+                            crate::gc::Gc::new(crate::value::ArrayData::new(pref)),
+                            array_flag,
+                        ),
                     );
                     return Ok(result);
                 }
@@ -1349,11 +1359,11 @@ impl Interpreter {
                     }
                     if let Some(Value::Array(arc_items, _)) = self.env.get_mut(&key) {
                         // Shared backing array: in-place interior mutation (see `push`).
-                        let items = if Arc::strong_count(arc_items) > 1 {
+                        let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                             // SAFETY: same contract as `array_push_in_place`.
-                            unsafe { &mut crate::value::arc_contents_mut(arc_items).items }
+                            unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
                         } else {
-                            Arc::make_mut(arc_items)
+                            crate::gc::Gc::make_mut(arc_items)
                         };
                         let out = if items.is_empty() {
                             make_empty_array_failure_what("shift", &empty_what)
@@ -1373,7 +1383,10 @@ impl Interpreter {
                     };
                     self.env.insert(
                         key,
-                        Value::Array(Arc::new(crate::value::ArrayData::new(items)), array_flag),
+                        Value::Array(
+                            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                            array_flag,
+                        ),
                     );
                     return Ok(out);
                 }
@@ -1836,7 +1849,7 @@ impl Interpreter {
                                 let mut next = existing.to_vec();
                                 next.extend(collected);
                                 let updated_array = Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(next)),
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(next)),
                                     *arr_kind,
                                 );
                                 self.overwrite_array_bindings_by_identity(existing, updated_array);
@@ -1900,7 +1913,7 @@ impl Interpreter {
                                 let mut next = existing.to_vec();
                                 next.extend(collected.clone());
                                 let updated_array = Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(next)),
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(next)),
                                     *arr_kind,
                                 );
                                 self.overwrite_array_bindings_by_identity(existing, updated_array);
@@ -1984,7 +1997,7 @@ impl Interpreter {
                         let mut next = existing.to_vec();
                         next.extend(vals.iter().cloned());
                         let updated_array = Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(next)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(next)),
                             *arr_kind,
                         );
                         self.overwrite_array_bindings_by_identity(existing, updated_array);

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -113,7 +113,7 @@ impl Interpreter {
                 if idx < updated.len() {
                     updated[idx] = value.clone();
                     let replacement = Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                         *kind,
                     );
                     if let Some(var_name) = target_var {
@@ -133,7 +133,7 @@ impl Interpreter {
             let mut updated = items.to_vec();
             updated[idx] = value.clone();
             let replacement = Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                 *kind,
             );
             if let Some(var_name) = target_var {
@@ -338,7 +338,7 @@ impl Interpreter {
                     return Ok(value);
                 }
                 let mut selected_hash: Option<crate::gc::Gc<crate::value::HashData>> = None;
-                let mut selected_array: Option<std::sync::Arc<crate::value::ArrayData>> = None;
+                let mut selected_array: Option<crate::gc::Gc<crate::value::ArrayData>> = None;
 
                 if let Some(var_name) = target_var
                     && let Some(Value::Hash(candidate)) = self.env.get(var_name)
@@ -382,7 +382,7 @@ impl Interpreter {
                         _ => None,
                     });
                     if let Some(first) = candidates.next()
-                        && candidates.all(|other| std::sync::Arc::ptr_eq(&first, &other))
+                        && candidates.all(|other| crate::gc::Gc::ptr_eq(&first, &other))
                     {
                         selected_array = Some(first);
                     }
@@ -402,7 +402,7 @@ impl Interpreter {
                     if i < updated.len() {
                         updated[i] = value.clone();
                         let replacement =
-                            Value::Array(std::sync::Arc::new(updated), ArrayKind::List);
+                            Value::Array(crate::gc::Gc::new(updated), ArrayKind::List);
                         self.overwrite_array_bindings_by_identity(&source_array, replacement);
                         return Ok(value);
                     }

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -109,7 +109,7 @@ impl Interpreter {
                 data.items.resize(idx + 1, Value::Nil);
             }
             data.items[idx] = value.clone();
-            Value::Array(std::sync::Arc::new(data), kind)
+            Value::Array(crate::gc::Gc::new(data), kind)
         } else {
             let key = index_value.to_string_value();
             let mut data = match container {

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -308,7 +308,7 @@ impl Interpreter {
             }
             if let Some(Value::Slip(items) | Value::Seq(items)) = attrs.get(attr_name) {
                 let flattened = Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new((**items).clone())),
+                    crate::gc::Gc::new(crate::value::ArrayData::new((**items).clone())),
                     crate::value::ArrayKind::Array,
                 );
                 attrs.insert(attr_name.clone(), flattened);

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1016,7 +1016,7 @@ impl Interpreter {
                                         new_items[i] = val;
                                     }
                                 }
-                                let result = Value::Array(std::sync::Arc::new(new_items), is_arr);
+                                let result = Value::Array(crate::gc::Gc::new(new_items), is_arr);
                                 crate::runtime::utils::mark_shaped_array(&result, Some(&dims));
                                 result
                             } else {
@@ -1503,7 +1503,7 @@ impl Interpreter {
                         && let Some(Value::Slip(items) | Value::Seq(items)) = attrs.get(attr_name)
                     {
                         let flattened = Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new((**items).clone())),
+                            crate::gc::Gc::new(crate::value::ArrayData::new((**items).clone())),
                             ArrayKind::Array,
                         );
                         attrs.insert(attr_name.clone(), flattened);
@@ -1523,7 +1523,7 @@ impl Interpreter {
                             Value::Array(items, _) => (**items).clone(),
                             _ => crate::value::ArrayData::new(vec![val.clone()]),
                         };
-                        let shaped = Value::Array(std::sync::Arc::new(items), ArrayKind::Shaped);
+                        let shaped = Value::Array(crate::gc::Gc::new(items), ArrayKind::Shaped);
                         crate::runtime::utils::mark_shaped_array(&shaped, Some(&dims));
                         attrs.insert(attr_name.clone(), shaped);
                     }

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -266,14 +266,14 @@ impl Interpreter {
 
     pub(crate) fn overwrite_array_items_by_identity_for_vm(
         &mut self,
-        needle: &std::sync::Arc<crate::value::ArrayData>,
+        needle: &crate::gc::Gc<crate::value::ArrayData>,
         updated_items: Vec<Value>,
         kind: ArrayKind,
     ) {
         self.overwrite_array_bindings_by_identity(
             needle,
             Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(updated_items)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(updated_items)),
                 kind,
             ),
         );

--- a/src/runtime/methods_string_index.rs
+++ b/src/runtime/methods_string_index.rs
@@ -173,7 +173,7 @@ impl Interpreter {
             }
         }
         Ok(Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(results)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(results)),
             crate::value::ArrayKind::List,
         ))
     }

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -97,7 +97,7 @@ impl Interpreter {
                     return Ok(Value::Array(items.clone(), crate::value::ArrayKind::List));
                 }
                 return Ok(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                     crate::value::ArrayKind::List,
                 ));
             }
@@ -113,7 +113,7 @@ impl Interpreter {
         }
         let items = Self::value_to_list(&target);
         Ok(Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(items)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
             crate::value::ArrayKind::List,
         ))
     }

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -277,7 +277,7 @@ impl Interpreter {
             "send" => {
                 let value = args.first().cloned().unwrap_or(Value::Nil);
                 match attrs.get_mut("queue") {
-                    Some(Value::Array(items, ..)) => Arc::make_mut(items).push(value),
+                    Some(Value::Array(items, ..)) => crate::gc::Gc::make_mut(items).push(value),
                     _ => {
                         attrs.insert("queue".to_string(), Value::array(vec![value]));
                     }
@@ -289,7 +289,7 @@ impl Interpreter {
                 if let Some(Value::Array(items, ..)) = attrs.get_mut("queue")
                     && !items.is_empty()
                 {
-                    value = Arc::make_mut(items).remove(0);
+                    value = crate::gc::Gc::make_mut(items).remove(0);
                 }
                 Ok((value, attrs))
             }

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -497,7 +497,7 @@ impl Interpreter {
                     proc_attrs.insert(
                         "command".to_string(),
                         Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(cmd_arr_clone)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(cmd_arr_clone)),
                             crate::value::ArrayKind::List,
                         ),
                     );

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -445,7 +445,8 @@ impl Interpreter {
                     supplier_emit(supplier_id, value.clone());
                 }
                 if let Some(Value::Array(items, ..)) = attrs.get_mut("emitted") {
-                    Arc::make_mut(items).push(args.first().cloned().unwrap_or(Value::Nil));
+                    crate::gc::Gc::make_mut(items)
+                        .push(args.first().cloned().unwrap_or(Value::Nil));
                 } else {
                     attrs.insert(
                         "emitted".to_string(),

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -15,7 +15,7 @@ impl Interpreter {
             "emit" => {
                 let value = args.first().cloned().unwrap_or(Value::Nil);
                 if let Some(Value::Array(items, ..)) = attrs.get_mut("values") {
-                    Arc::make_mut(items).push(value.clone());
+                    crate::gc::Gc::make_mut(items).push(value.clone());
                 } else {
                     attrs.insert("values".to_string(), Value::array(vec![value.clone()]));
                 }
@@ -410,7 +410,7 @@ impl Interpreter {
                 } else if has_unique {
                     if Self::supply_has_active_callback(&tap_cb) {
                         if let Some(Value::Array(items, ..)) = attrs.get_mut("taps") {
-                            Arc::make_mut(items).push(tap_cb.clone());
+                            crate::gc::Gc::make_mut(items).push(tap_cb.clone());
                         } else {
                             attrs.insert("taps".to_string(), Value::array(vec![tap_cb.clone()]));
                         }
@@ -475,7 +475,7 @@ impl Interpreter {
                 } else {
                     if Self::supply_has_active_callback(&tap_cb) {
                         if let Some(Value::Array(items, ..)) = attrs.get_mut("taps") {
-                            Arc::make_mut(items).push(tap_cb.clone());
+                            crate::gc::Gc::make_mut(items).push(tap_cb.clone());
                         } else {
                             attrs.insert("taps".to_string(), Value::array(vec![tap_cb.clone()]));
                         }

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -261,7 +261,7 @@ impl Interpreter {
                             .unwrap_or_else(|_| it.clone());
                         acc.push(m);
                     }
-                    Value::Array(Arc::new(crate::value::ArrayData::new(acc)), *meta)
+                    Value::Array(crate::gc::Gc::new(crate::value::ArrayData::new(acc)), *meta)
                 }
                 _ => {
                     let dn = Interpreter::get_action_name(child).unwrap_or_else(|| k.clone());

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -206,7 +206,7 @@ impl Interpreter {
         }
         if let Value::Array(mut arc, kind) = value {
             if arc.has_type_meta() {
-                let data = Arc::make_mut(&mut arc);
+                let data = crate::gc::Gc::make_mut(&mut arc);
                 data.value_type = None;
                 data.key_type = None;
                 data.declared_type = None;

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -135,7 +135,7 @@ impl Interpreter {
         let Some(Value::Array(arc, kind)) = sv.get_mut(key) else {
             return None;
         };
-        let data = Arc::make_mut(arc);
+        let data = crate::gc::Gc::make_mut(arc);
         if idx >= data.items.len() {
             data.items.resize(idx + 1, Value::Nil);
         }
@@ -143,7 +143,7 @@ impl Interpreter {
         if *kind == ArrayKind::List {
             *kind = ArrayKind::Array;
         }
-        let result = Value::Array(Arc::clone(arc), *kind);
+        let result = Value::Array(crate::gc::Gc::clone(arc), *kind);
         drop(sv);
         if is_thread_clone {
             let dirty_marker = format!("__mutsu_shared_dirty::{key}");

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -403,12 +403,12 @@ impl Interpreter {
             let mut sv = self.shared_vars.write().unwrap();
             // Try in-place mutation via get_mut first (avoids remove+insert overhead)
             if let Some(Value::Array(arc_items, kind)) = sv.get_mut(key) {
-                let items = Arc::make_mut(arc_items);
+                let items = crate::gc::Gc::make_mut(arc_items);
                 items.extend(values);
                 if *kind == ArrayKind::List {
                     *kind = ArrayKind::Array;
                 }
-                let result = Value::Array(Arc::clone(arc_items), *kind);
+                let result = Value::Array(crate::gc::Gc::clone(arc_items), *kind);
                 drop(sv);
                 self.mark_shared_var_dirty(key);
                 if !is_thread_clone {
@@ -419,14 +419,14 @@ impl Interpreter {
             // Fallback: the value might exist but not be an Array yet
             if let Some(shared_value) = sv.remove(key) {
                 if let Value::Array(mut arc_items, kind) = shared_value {
-                    let items = Arc::make_mut(&mut arc_items);
+                    let items = crate::gc::Gc::make_mut(&mut arc_items);
                     items.extend(values);
                     let normalized_kind = if kind == ArrayKind::List {
                         ArrayKind::Array
                     } else {
                         kind
                     };
-                    let result = Value::Array(Arc::clone(&arc_items), normalized_kind);
+                    let result = Value::Array(crate::gc::Gc::clone(&arc_items), normalized_kind);
                     sv.insert(key.to_string(), Value::Array(arc_items, normalized_kind));
                     drop(sv);
                     self.mark_shared_var_dirty(key);
@@ -440,13 +440,13 @@ impl Interpreter {
         }
         // Fallback for non-shared arrays: use Arc::make_mut for COW
         if let Some(Value::Array(arc_items, kind)) = self.env.get_mut(key) {
-            let items = Arc::make_mut(arc_items);
+            let items = crate::gc::Gc::make_mut(arc_items);
             items.extend(values);
             // Normalize @-variables only from List to Array while preserving Shaped.
             if key.starts_with('@') && *kind == ArrayKind::List {
                 *kind = ArrayKind::Array;
             }
-            return Value::Array(Arc::clone(arc_items), *kind);
+            return Value::Array(crate::gc::Gc::clone(arc_items), *kind);
         }
         let mut items = match target_fallback {
             Value::Array(v, ..) => v.to_vec(),
@@ -474,12 +474,12 @@ impl Interpreter {
         let Some(Value::Array(arc_items, kind)) = sv.get_mut(key) else {
             return None;
         };
-        let items = Arc::make_mut(arc_items);
+        let items = crate::gc::Gc::make_mut(arc_items);
         items.extend(values);
         if *kind == ArrayKind::List {
             *kind = ArrayKind::Array;
         }
-        let result = Value::Array(Arc::clone(arc_items), *kind);
+        let result = Value::Array(crate::gc::Gc::clone(arc_items), *kind);
         drop(sv);
         if is_thread_clone {
             let dirty_marker = format!("__mutsu_shared_dirty::{key}");

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -219,7 +219,7 @@ impl Interpreter {
         match value {
             Value::Array(mut arc, kind) => {
                 if arc.default.as_deref() != Some(&default) {
-                    Arc::make_mut(&mut arc).default = Some(Box::new(default));
+                    crate::gc::Gc::make_mut(&mut arc).default = Some(Box::new(default));
                 }
                 Value::Array(arc, kind)
             }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -483,7 +483,7 @@ impl Interpreter {
                     self.env.insert(
                         "/".to_string(),
                         Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                             crate::value::ArrayKind::List,
                         ),
                     );
@@ -494,7 +494,7 @@ impl Interpreter {
                         self.env.insert(
                             "/".to_string(),
                             Value::Array(
-                                std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+                                crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
                                 crate::value::ArrayKind::List,
                             ),
                         );
@@ -1607,7 +1607,7 @@ impl Interpreter {
     /// Check if two values are the same object (pointer equality).
     fn same_object(a: &Value, b: &Value) -> bool {
         match (a, b) {
-            (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
+            (Value::Array(a, _), Value::Array(b, _)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Seq(a), Value::Seq(b)) => Arc::ptr_eq(a, b),
             (Value::Slip(a), Value::Slip(b)) => Arc::ptr_eq(a, b),
             (Value::LazyList(a), Value::LazyList(b)) => Arc::ptr_eq(a, b),

--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -310,7 +310,7 @@ impl Interpreter {
             ),
             Value::LazyList(list) => match self.force_lazy_list(list) {
                 Ok(items) => Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     ArrayKind::List,
                 ),
                 Err(_) => v.clone(),
@@ -322,7 +322,7 @@ impl Interpreter {
                     Ok(forced) => {
                         let items = crate::runtime::utils::value_to_list(&forced);
                         Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                             ArrayKind::List,
                         )
                     }

--- a/src/runtime/test_functions/tap_ok.rs
+++ b/src/runtime/test_functions/tap_ok.rs
@@ -460,7 +460,7 @@ impl Interpreter {
                     }
                 }
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(vec![Value::bag(map)])),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![Value::bag(map)])),
                     *kind,
                 )
             }

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -216,7 +216,7 @@ impl Interpreter {
                                 data.items[i] = elem;
                                 target_env.insert(
                                     source_name.clone(),
-                                    Value::Array(std::sync::Arc::new(data), kind),
+                                    Value::Array(crate::gc::Gc::new(data), kind),
                                 );
                             }
                         }

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -261,7 +261,9 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
 const MAX_ARRAY_EXPAND: i64 = 100_000;
 
 pub(crate) fn coerce_to_array(value: Value) -> Value {
-    fn metadata_shape_for_items(items: &Arc<crate::value::ArrayData>) -> Option<Vec<usize>> {
+    fn metadata_shape_for_items(
+        items: &crate::gc::Gc<crate::value::ArrayData>,
+    ) -> Option<Vec<usize>> {
         items.shape.clone()
     }
 
@@ -274,7 +276,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             // Only rebuild when a cell is actually present (common path keeps
             // sharing the Arc, so there is no per-assignment cost).
             let items = if items.iter().any(|v| matches!(v, Value::ContainerRef(_))) {
-                Arc::new(items.iter().map(|v| v.deref_container()).collect())
+                crate::gc::Gc::new(items.iter().map(|v| v.deref_container()).collect())
             } else {
                 items
             };
@@ -298,7 +300,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
                 // Infinite range — mark as lazy
                 let end = b.min(a.saturating_add(MAX_ARRAY_EXPAND));
                 Value::Array(
-                    Arc::new((a..=end).map(Value::Int).collect()),
+                    crate::gc::Gc::new((a..=end).map(Value::Int).collect()),
                     ArrayKind::Lazy,
                 )
             } else {
@@ -310,7 +312,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             if b == i64::MAX {
                 let end = b.min(a.saturating_add(MAX_ARRAY_EXPAND));
                 Value::Array(
-                    Arc::new((a..end).map(Value::Int).collect()),
+                    crate::gc::Gc::new((a..end).map(Value::Int).collect()),
                     ArrayKind::Lazy,
                 )
             } else {
@@ -322,7 +324,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             if b == i64::MAX {
                 let end = b.min(a.saturating_add(MAX_ARRAY_EXPAND));
                 Value::Array(
-                    Arc::new((a + 1..=end).map(Value::Int).collect()),
+                    crate::gc::Gc::new((a + 1..=end).map(Value::Int).collect()),
                     ArrayKind::Lazy,
                 )
             } else {
@@ -334,7 +336,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             if b == i64::MAX {
                 let end = b.min(a.saturating_add(MAX_ARRAY_EXPAND));
                 Value::Array(
-                    Arc::new((a + 1..end).map(Value::Int).collect()),
+                    crate::gc::Gc::new((a + 1..end).map(Value::Int).collect()),
                     ArrayKind::Lazy,
                 )
             } else {
@@ -374,7 +376,7 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             let infinite = (!start_f.is_finite() || !end_f.is_finite()) && !empty;
             if infinite {
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(value_to_list(&value))),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(value_to_list(&value))),
                     ArrayKind::Lazy,
                 )
             } else {

--- a/src/runtime/utils/errors.rs
+++ b/src/runtime/utils/errors.rs
@@ -192,7 +192,7 @@ pub(crate) fn value_which_key(value: &Value) -> String {
         Value::Instance { id, .. } => {
             format!("{}|{}", value_type_name(value), id)
         }
-        Value::Array(items, ..) => format!("Array|{:p}", Arc::as_ptr(items)),
+        Value::Array(items, ..) => format!("Array|{:p}", crate::gc::Gc::as_ptr(items)),
         Value::Hash(map) => format!("Hash|{:p}", crate::gc::Gc::as_ptr(map)),
         Value::Pair(k, v) => format!("Pair|{}|{}", k, value_which_key(v)),
         Value::ValuePair(k, v) => format!("Pair|{}|{}", value_which_key(k), value_which_key(v)),

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -101,7 +101,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
             crate::value::lazy_list_placeholder("gist", ll.in_array_context())
         }
         Value::Array(items, kind) => {
-            let ptr = std::sync::Arc::as_ptr(items) as usize;
+            let ptr = crate::gc::Gc::as_ptr(items) as usize;
             let is_cycle = SEEN_PTRS.with(|seen| check_and_push(seen, ptr));
             if is_cycle {
                 return match kind {

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -96,7 +96,7 @@ pub(crate) fn mark_shaped_array(value: &Value, shape: Option<&[usize]>) {
 }
 
 pub(crate) fn mark_shaped_array_items(
-    items: &Arc<crate::value::ArrayData>,
+    items: &crate::gc::Gc<crate::value::ArrayData>,
     shape: Option<&[usize]>,
 ) {
     let Some(shape) = shape else {
@@ -113,7 +113,7 @@ pub(crate) fn mark_shaped_array_items(
     // SAFETY: aliased in-place mutation of a shared container; see
     // `arc_contents_mut`. No borrow into the array is live across this write.
     unsafe {
-        crate::value::arc_contents_mut(items).shape = Some(shape.to_vec());
+        crate::value::gc_contents_mut(items).shape = Some(shape.to_vec());
     }
 }
 
@@ -187,7 +187,7 @@ fn rebuild_with_leaves<'a, I: Iterator<Item = &'a Value>>(value: &Value, iter: &
         };
         let mut data = crate::value::ArrayData::new(new_items);
         data.shape = items.shape.clone();
-        Value::Array(Arc::new(data), *kind)
+        Value::Array(crate::gc::Gc::new(data), *kind)
     } else {
         iter.next().cloned().unwrap_or_else(|| value.clone())
     }
@@ -200,7 +200,7 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
         {
             true
         }
-        (Value::Array(a, _), Value::Array(b, _)) => std::sync::Arc::ptr_eq(a, b),
+        (Value::Array(a, _), Value::Array(b, _)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Seq(a), Value::Seq(b)) => std::sync::Arc::ptr_eq(a, b),
         (Value::Slip(a), Value::Slip(b)) => {
             // Empty is a singleton semantic value in Raku even when represented

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -213,7 +213,7 @@ pub(crate) fn reduction_identity(op: &str) -> Value {
         "(.)" | "⊍" | "(+)" | "⊎" => Value::bag(HashMap::new()),
         // Comma: empty list
         "," => Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(Vec::new())),
+            crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
             ArrayKind::List,
         ),
         // Zip: empty Seq (Raku returns a Seq for arity-0 Z)

--- a/src/runtime/value_iterator.rs
+++ b/src/runtime/value_iterator.rs
@@ -26,7 +26,7 @@ pub(crate) enum ValueIterator {
     /// Already-materialized Array elements. Shares the source `Arc` (the
     /// `ArrayData` wrapper derefs to the element vector — no copy).
     ArraySlice {
-        items: Arc<crate::value::ArrayData>,
+        items: crate::gc::Gc<crate::value::ArrayData>,
         idx: usize,
     },
     /// Lazy integer counter. `end == i64::MAX` with `inclusive` represents an

--- a/src/value/aliased_mut.rs
+++ b/src/value/aliased_mut.rs
@@ -1,9 +1,9 @@
 //! The single audited choke point for *aliased, in-place* mutation of a
-//! shared `Arc<ArrayData>` / `Arc<HashData>` container.
+//! shared `crate::gc::Gc<ArrayData>` / `Arc<HashData>` container.
 //!
 //! # Why this exists
 //!
-//! mutsu represents `Value::Array`/`Value::Hash` as `Arc<ArrayData>` /
+//! mutsu represents `Value::Array`/`Value::Hash` as `crate::gc::Gc<ArrayData>` /
 //! `Arc<HashData>` copy-on-write containers that nonetheless carry a *shared
 //! identity*: when a container is bound (`:=`), pushed to through an alias, or
 //! grown through a `ContainerRef`, the mutation must be visible through **every**
@@ -60,7 +60,12 @@ use std::sync::Arc;
 ///
 /// This function does not, and cannot, check these obligations; it is the
 /// single place where the project's container-aliasing invariant is trusted.
-#[allow(clippy::mut_from_ref)]
+///
+/// Currently unused: `Value::Hash` and `Value::Array` — the only containers that
+/// took an aliased in-place write — are now `Gc`-managed and go through
+/// [`crate::gc::gc_contents_mut`]. Kept (allow dead_code) as the audited
+/// primitive for any future still-`Arc` container that needs the same write.
+#[allow(clippy::mut_from_ref, dead_code)]
 pub(crate) unsafe fn arc_contents_mut<T>(arc: &Arc<T>) -> &mut T {
     // SAFETY: delegated to the caller per the contract above. This is the only
     // `Arc::as_ptr as *mut` cast in the codebase.

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -438,7 +438,7 @@ impl Value {
                 thread_local! {
                     static SEEN_ARR_PTRS: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
                 }
-                let ptr = std::sync::Arc::as_ptr(items) as usize;
+                let ptr = crate::gc::Gc::as_ptr(items) as usize;
                 let is_cycle = SEEN_ARR_PTRS.with(|seen| {
                     let s = seen.borrow();
                     s.contains(&ptr)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -314,7 +314,6 @@ mod value_methods_b;
 mod value_methods_c;
 mod value_setbagmix;
 pub(crate) use crate::gc::gc_contents_mut;
-pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use types::what_type_name;
 
 /// Get current time as seconds since UNIX epoch (returns 0.0 on WASM).
@@ -932,7 +931,9 @@ pub enum Value {
         excl_end: bool,
     },
     /// Distinguishes Array, List, and their itemized (Scalar-wrapped) variants.
-    Array(Arc<ArrayData>, ArrayKind),
+    /// GC-migrated (§11 step 5c first wave): backed by a cycle-collectable
+    /// `Gc<ArrayData>` rather than a plain `crate::gc::Gc<ArrayData>`.
+    Array(crate::gc::Gc<ArrayData>, ArrayKind),
     Hash(Gc<HashData>),
     Rat(i64, i64),
     FatRat(i64, i64),

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -323,7 +323,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             excl_end,
         },
         SerValue::Array(items, kind) => Value::Array(
-            Arc::new(items.into_iter().map(ser_to_value).collect()),
+            crate::gc::Gc::new(items.into_iter().map(ser_to_value).collect()),
             kind,
         ),
         SerValue::Hash(map) => Value::hash(

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -2,16 +2,17 @@ use super::*;
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        let match_equals_pair_array = |attrs: &Arc<InstanceAttrs>, arr: &Arc<ArrayData>| {
-            if arr.len() != 2 {
-                return false;
-            }
-            let map = attrs.as_map();
-            let (Some(from), Some(matched)) = (map.get("from"), map.get("str")) else {
-                return false;
+        let match_equals_pair_array =
+            |attrs: &Arc<InstanceAttrs>, arr: &crate::gc::Gc<ArrayData>| {
+                if arr.len() != 2 {
+                    return false;
+                }
+                let map = attrs.as_map();
+                let (Some(from), Some(matched)) = (map.get("from"), map.get("str")) else {
+                    return false;
+                };
+                arr[0] == *from && arr[1] == *matched
             };
-            arr[0] == *from && arr[1] == *matched
-        };
         match (self, other) {
             (Value::Int(a), Value::Int(b)) => a == b,
             (Value::BigInt(a), Value::BigInt(b)) => a == b,

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -32,9 +32,22 @@ impl Value {
     /// the collector is off (design doc §3.1's wave phasing).
     pub(crate) fn gc_trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
         // Only migrated (`Gc<T>`) container variants yield a child; more arms
-        // land as further types migrate (§11 step 5c: `Array`, 5d: `ContainerRef`).
-        if let Value::Hash(data) = self {
-            visit(&data.erased());
+        // land as further types migrate (§11 5d: `ContainerRef`, ...).
+        match self {
+            Value::Hash(data) => visit(&data.erased()),
+            Value::Array(data, _) => visit(&data.erased()),
+            _ => {}
+        }
+    }
+}
+
+impl Trace for ArrayData {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        for v in &self.items {
+            v.gc_trace(visit);
+        }
+        if let Some(d) = &self.default {
+            d.gc_trace(visit);
         }
     }
 }
@@ -194,7 +207,7 @@ mod tests {
             ..Default::default()
         };
         data.default = Some(Box::new(Value::Int(0)));
-        let value = Value::Array(Arc::new(data), crate::value::ArrayKind::Array);
+        let value = Value::Array(crate::gc::Gc::new(data), crate::value::ArrayKind::Array);
 
         let mut visitor = CountingVisitor { count: 0 };
         value.visit_gc_children(&mut visitor);

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -45,7 +45,7 @@ impl Value {
         }
     }
     pub fn array(items: Vec<Value>) -> Self {
-        Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::List)
+        Value::Array(crate::gc::Gc::new(ArrayData::new(items)), ArrayKind::List)
     }
     /// Create a Capture value. Boxes the positional/named payloads (the variant
     /// stores them behind `Box` to keep `Value` small).
@@ -110,7 +110,7 @@ impl Value {
     }
     /// Create a true Array value (from [...] literals).
     pub fn real_array(items: Vec<Value>) -> Self {
-        Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::Array)
+        Value::Array(crate::gc::Gc::new(ArrayData::new(items)), ArrayKind::Array)
     }
     /// Create a true Array value with a single explicitly-assigned index
     /// recorded in the embedded `initialized` set (used when autovivifying a
@@ -121,21 +121,21 @@ impl Value {
         let mut set = std::collections::HashSet::new();
         set.insert(idx);
         data.initialized = Some(set);
-        Value::Array(Arc::new(data), ArrayKind::Array)
+        Value::Array(crate::gc::Gc::new(data), ArrayKind::Array)
     }
     /// Create a shaped (multidimensional) Array value.
     pub fn shaped_array(items: Vec<Value>) -> Self {
-        Value::Array(Arc::new(ArrayData::new(items)), ArrayKind::Shaped)
+        Value::Array(crate::gc::Gc::new(ArrayData::new(items)), ArrayKind::Shaped)
     }
-    /// Build an `Arc<ArrayData>` from a plain element vector.
-    pub fn array_arc(items: Vec<Value>) -> Arc<ArrayData> {
-        Arc::new(ArrayData::new(items))
+    /// Build an `crate::gc::Gc<ArrayData>` from a plain element vector.
+    pub(crate) fn array_arc(items: Vec<Value>) -> crate::gc::Gc<ArrayData> {
+        crate::gc::Gc::new(ArrayData::new(items))
     }
     /// Rebuild an array's backing data with new elements, preserving the
     /// embedded container type metadata of `like` (used by mutators that
     /// reconstruct the vector, so a typed `Array[Int]` stays typed).
-    pub fn array_data_like(like: &ArrayData, items: Vec<Value>) -> Arc<ArrayData> {
-        Arc::new(ArrayData {
+    pub(crate) fn array_data_like(like: &ArrayData, items: Vec<Value>) -> crate::gc::Gc<ArrayData> {
+        crate::gc::Gc::new(ArrayData {
             items,
             value_type: like.value_type.clone(),
             key_type: like.key_type.clone(),

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -21,7 +21,7 @@ impl Value {
         if let Value::Array(arc, _) = self {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the items is live across the push.
-            let data = unsafe { arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             data.items.push(val);
             true
         } else {
@@ -43,7 +43,7 @@ impl Value {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the items is live across the
             // growth/promotion below.
-            let data = unsafe { arc_contents_mut(arc) };
+            let data = unsafe { crate::value::gc_contents_mut(arc) };
             while data.len() <= idx {
                 data.push(Value::Nil);
             }

--- a/src/vm/vm_arith_int_ops.rs
+++ b/src/vm/vm_arith_int_ops.rs
@@ -93,8 +93,10 @@ impl Interpreter {
         } else {
             &var_name
         };
-        self.env_mut()
-            .insert(lookup_key.to_string(), Value::Array(Arc::new(items), kind));
+        self.env_mut().insert(
+            lookup_key.to_string(),
+            Value::Array(crate::gc::Gc::new(items), kind),
+        );
         Ok(Some(result.items))
     }
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1376,7 +1376,9 @@ impl Interpreter {
                 // the slow path, which raises that error.
                 let is_native_array = if let Value::Array(items, ..) = &target {
                     let native_var = self.env().iter().find_map(|(name, bound)| match bound {
-                        Value::Array(existing, ..) if Arc::ptr_eq(existing, items) => Some(*name),
+                        Value::Array(existing, ..) if crate::gc::Gc::ptr_eq(existing, items) => {
+                            Some(*name)
+                        }
                         _ => None,
                     });
                     native_var.is_some_and(|name| {
@@ -1419,8 +1421,10 @@ impl Interpreter {
                         updated.resize(i + 1, Value::Package(Symbol::intern("Any")));
                     }
                     updated[i] = Value::ContainerRef(cell);
-                    let new_array =
-                        Value::Array(Arc::new(crate::value::ArrayData::new(updated)), *arr_kind);
+                    let new_array = Value::Array(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
+                        *arr_kind,
+                    );
                     self.env_mut().insert(target_name.to_string(), new_array);
                     if let Some((source_name, cell_val)) = bind_source_install {
                         self.set_env_with_main_alias(&source_name, cell_val.clone());
@@ -1882,12 +1886,15 @@ impl Interpreter {
                 // here as `CallMethodMut`. Mirror the `ArrayPush` opcode's env-bound
                 // branch (`normalize_push_unshift_args` then extend).
                 let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
-                Arc::make_mut(arc_items).extend(norm);
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                crate::gc::Gc::make_mut(arc_items).extend(norm);
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "append" | "prepend" => {
                 let flat = crate::runtime::flatten_append_args(args.to_vec());
-                let items = Arc::make_mut(arc_items);
+                let items = crate::gc::Gc::make_mut(arc_items);
                 if method == "append" {
                     items.extend(flat);
                 } else {
@@ -1895,28 +1902,36 @@ impl Interpreter {
                         items.insert(i, v);
                     }
                 }
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "unshift" => {
                 let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
-                let items = Arc::make_mut(arc_items);
+                let items = crate::gc::Gc::make_mut(arc_items);
                 for (i, v) in norm.into_iter().enumerate() {
                     items.insert(i, v);
                 }
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "pop" => {
                 if arc_items.is_empty() {
                     crate::runtime::utils::make_empty_array_failure_what("pop", "Array")
                 } else {
-                    Arc::make_mut(arc_items).pop().unwrap_or(Value::Nil)
+                    crate::gc::Gc::make_mut(arc_items)
+                        .pop()
+                        .unwrap_or(Value::Nil)
                 }
             }
             "shift" => {
                 if arc_items.is_empty() {
                     crate::runtime::utils::make_empty_array_failure_what("shift", "Array")
                 } else {
-                    Arc::make_mut(arc_items).remove(0)
+                    crate::gc::Gc::make_mut(arc_items).remove(0)
                 }
             }
             _ => unreachable!(),
@@ -1977,29 +1992,41 @@ impl Interpreter {
         let result = match method {
             "push" => {
                 let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
-                Arc::make_mut(arc_items).extend(norm);
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                crate::gc::Gc::make_mut(arc_items).extend(norm);
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "append" => {
                 let flat = crate::runtime::flatten_append_args(args.to_vec());
-                Arc::make_mut(arc_items).extend(flat);
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                crate::gc::Gc::make_mut(arc_items).extend(flat);
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "unshift" => {
                 let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.to_vec());
-                let items = Arc::make_mut(arc_items);
+                let items = crate::gc::Gc::make_mut(arc_items);
                 for (i, v) in norm.into_iter().enumerate() {
                     items.insert(i, v);
                 }
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "prepend" => {
                 let flat = crate::runtime::flatten_append_args(args.to_vec());
-                let items = Arc::make_mut(arc_items);
+                let items = crate::gc::Gc::make_mut(arc_items);
                 for (i, v) in flat.into_iter().enumerate() {
                     items.insert(i, v);
                 }
-                Value::Array(Arc::clone(arc_items), crate::value::ArrayKind::Array)
+                Value::Array(
+                    crate::gc::Gc::clone(arc_items),
+                    crate::value::ArrayKind::Array,
+                )
             }
             "pop" => {
                 if !args.is_empty() {
@@ -2008,7 +2035,9 @@ impl Interpreter {
                 if arc_items.is_empty() {
                     crate::runtime::utils::make_empty_array_failure_what("pop", "Array")
                 } else {
-                    Arc::make_mut(arc_items).pop().unwrap_or(Value::Nil)
+                    crate::gc::Gc::make_mut(arc_items)
+                        .pop()
+                        .unwrap_or(Value::Nil)
                 }
             }
             "shift" => {
@@ -2018,7 +2047,7 @@ impl Interpreter {
                 if arc_items.is_empty() {
                     crate::runtime::utils::make_empty_array_failure_what("shift", "Array")
                 } else {
-                    Arc::make_mut(arc_items).remove(0)
+                    crate::gc::Gc::make_mut(arc_items).remove(0)
                 }
             }
             _ => return None,
@@ -2145,7 +2174,7 @@ impl Interpreter {
         }
         let count = raw_count.unwrap_or(len - start);
         let end = (start + count).min(len);
-        let items = Arc::make_mut(arc_items);
+        let items = crate::gc::Gc::make_mut(arc_items);
         let removed: Vec<Value> = items.drain(start..end).collect();
         for (i, item) in replacement.into_iter().enumerate() {
             items.insert(start + i, item);

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -123,7 +123,7 @@ impl Interpreter {
                 let mut guard = cell.lock().unwrap();
                 if let Value::Array(arr, kind) = &mut *guard {
                     let kind = *kind;
-                    let items = Arc::make_mut(arr);
+                    let items = crate::gc::Gc::make_mut(arr);
                     match &val {
                         Value::Slip(slip_items) => items.extend(slip_items.iter().cloned()),
                         _ => items.push(val),
@@ -174,7 +174,7 @@ impl Interpreter {
         }
 
         let result = if let Some(Value::Array(arr, kind)) = self.env_mut().get_mut(target_name) {
-            let items = Arc::make_mut(arr);
+            let items = crate::gc::Gc::make_mut(arr);
             match &val {
                 Value::Slip(slip_items) => items.extend(slip_items.iter().cloned()),
                 _ => items.push(val),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -879,15 +879,13 @@ impl Interpreter {
                                 raw_val
                             } else {
                                 Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(vec![
-                                        raw_val,
-                                    ])),
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![raw_val])),
                                     crate::value::ArrayKind::List,
                                 )
                             }
                         }
                         other => Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(vec![other])),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(vec![other])),
                             crate::value::ArrayKind::List,
                         ),
                     }
@@ -2072,7 +2070,7 @@ impl Interpreter {
                     // Comma lists and other non-real arrays become Lists.
                     Value::Array(items, _) => Value::Array(items, crate::value::ArrayKind::List),
                     Value::Seq(items) => Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(items.to_vec())),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items.to_vec())),
                         crate::value::ArrayKind::List,
                     ),
                     // Hash values are flattened to pairs for constant @.
@@ -2082,7 +2080,7 @@ impl Interpreter {
                             .map(|(k, v)| Value::Pair(k.clone(), Box::new(v.clone())))
                             .collect();
                         Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(pairs)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(pairs)),
                             crate::value::ArrayKind::List,
                         )
                     }
@@ -2155,20 +2153,20 @@ impl Interpreter {
                                     Value::Array(items, crate::value::ArrayKind::List)
                                 }
                                 Value::Seq(items) => Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(
                                         items.to_vec(),
                                     )),
                                     crate::value::ArrayKind::List,
                                 ),
                                 other => Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(vec![other])),
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![other])),
                                     crate::value::ArrayKind::List,
                                 ),
                             }
                         }
                     }
                     other => Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![other])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![other])),
                         crate::value::ArrayKind::List,
                     ),
                 };
@@ -2860,7 +2858,7 @@ impl Interpreter {
                         Value::Array(arc, _) => {
                             // SAFETY: aliased in-place clear of a shared container;
                             // see `arc_contents_mut`.
-                            unsafe { crate::value::arc_contents_mut(arc).items.clear() };
+                            unsafe { crate::value::gc_contents_mut(arc).items.clear() };
                         }
                         Value::Hash(arc) => {
                             // SAFETY: aliased in-place clear; see `arc_contents_mut`.
@@ -2878,7 +2876,7 @@ impl Interpreter {
                     match &self.locals[slot] {
                         Value::Array(arc, _) => {
                             // SAFETY: aliased in-place clear; see `arc_contents_mut`.
-                            unsafe { crate::value::arc_contents_mut(arc).items.clear() };
+                            unsafe { crate::value::gc_contents_mut(arc).items.clear() };
                         }
                         Value::Hash(arc) => {
                             // SAFETY: aliased in-place clear; see `arc_contents_mut`.

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -8,7 +8,7 @@ impl Interpreter {
     pub(super) fn clear_aggregate_cell(cell: &std::sync::Arc<std::sync::Mutex<Value>>) {
         let mut guard = cell.lock().unwrap();
         match &mut *guard {
-            Value::Array(arc, _) => std::sync::Arc::make_mut(arc).items.clear(),
+            Value::Array(arc, _) => crate::gc::Gc::make_mut(arc).items.clear(),
             Value::Hash(arc) => crate::gc::Gc::make_mut(arc).map.clear(),
             other => *other = Value::Nil,
         }

--- a/src/vm/vm_helpers_junction.rs
+++ b/src/vm/vm_helpers_junction.rs
@@ -254,7 +254,7 @@ impl Interpreter {
                 })
                 .collect();
             Value::Array(
-                std::sync::Arc::new(crate::value::ArrayData::new(resolved)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(resolved)),
                 kind,
             )
         } else {

--- a/src/vm/vm_hyper_func.rs
+++ b/src/vm/vm_hyper_func.rs
@@ -180,7 +180,7 @@ impl Interpreter {
                 items.into_iter().next().unwrap()
             } else if !left_is_array && !right_is_array {
                 Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             } else {

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -531,13 +531,13 @@ impl Interpreter {
                 // a copy `my @x = @a` keeps its own Arc and is NOT corrupted —
                 // unlike the Arc-identity scan, which over-reaches COW copies.
                 let new_arr = Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(items.clone())),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items.clone())),
                     *kind,
                 );
                 self.write_back_hyper_target_var(code, var, new_arr);
             } else {
                 // Non-variable target (`@b[0]>>++`, `(1,2,3)>>.uc`): write back
-                // in place through the target's `Arc<ArrayData>` so a hyper
+                // in place through the target's `crate::gc::Gc<ArrayData>` so a hyper
                 // mutation on a *nested* element reaches it (the read shares the
                 // inner Arc with the slot holding it), plus the by-identity scan
                 // for any top-level binding that COW-detached.
@@ -545,7 +545,7 @@ impl Interpreter {
                 // `arc_contents_mut`. No borrow into this ArrayData is live
                 // across the write.
                 unsafe {
-                    crate::value::arc_contents_mut(existing).items = items.clone();
+                    crate::value::gc_contents_mut(existing).items = items.clone();
                 }
                 loan_env!(
                     self,
@@ -666,7 +666,7 @@ impl Interpreter {
             _ => ArrayKind::List,
         };
         let result = Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(results)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(results)),
             result_kind,
         );
         // A per-element native method raised a resumable warn: re-raise it once,
@@ -706,11 +706,11 @@ impl Interpreter {
                 }
                 Ok((
                     Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                         *kind,
                     ),
                     Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(mutated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(mutated)),
                         *kind,
                     ),
                 ))
@@ -726,11 +726,11 @@ impl Interpreter {
                 }
                 Ok((
                     Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                         ArrayKind::List,
                     ),
                     Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(mutated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(mutated)),
                         ArrayKind::List,
                     ),
                 ))
@@ -902,13 +902,13 @@ impl Interpreter {
             }
         }
         if let Value::Array(existing, kind) = &target {
-            // In-place write back through the target's `Arc<ArrayData>` so a
+            // In-place write back through the target's `crate::gc::Gc<ArrayData>` so a
             // nested-element hyper mutation reaches the element (see the twin
             // site in `exec_hyper_method_call_op`).
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`.
             unsafe {
-                crate::value::arc_contents_mut(existing).items = items.clone();
+                crate::value::gc_contents_mut(existing).items = items.clone();
             }
             loan_env!(
                 self,
@@ -990,7 +990,7 @@ impl Interpreter {
             _ => ArrayKind::List,
         };
         self.stack.push(Value::Array(
-            std::sync::Arc::new(crate::value::ArrayData::new(results)),
+            crate::gc::Gc::new(crate::value::ArrayData::new(results)),
             result_kind,
         ));
         Ok(())

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -352,7 +352,7 @@ impl Interpreter {
                 .is_none_or(|t| results.iter().all(|v| self.type_matches_value(t, v)));
             return if (!left_is_array && !right_is_array) || !fits_declared_type {
                 Ok(Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(results)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(results)),
                     crate::value::ArrayKind::List,
                 ))
             } else {

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -81,7 +81,7 @@ impl Interpreter {
     pub(super) fn loop_var_unchanged(current: &Value, source_elem: &Value) -> bool {
         use std::sync::Arc;
         match (current, source_elem) {
-            (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
+            (Value::Array(a, _), Value::Array(b, _)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Str(a), Value::Str(b)) => Arc::ptr_eq(a, b) || a == b,
             (Value::Int(a), Value::Int(b)) => a == b,
@@ -222,7 +222,7 @@ impl Interpreter {
         // `.raku`, and shaped `:delete`-dies behaviour).
         let mut new_data = (*items).clone();
         new_data.items[actual_idx] = current_topic;
-        let updated_value = Value::Array(std::sync::Arc::new(new_data), kind);
+        let updated_value = Value::Array(crate::gc::Gc::new(new_data), kind);
         self.write_back_container_source(code, source, &raw_source, updated_value);
     }
 }

--- a/src/vm/vm_loop_writeback_quant.rs
+++ b/src/vm/vm_loop_writeback_quant.rs
@@ -277,7 +277,7 @@ impl Interpreter {
                     let mut updated = items.to_vec();
                     updated[idx] = val;
                     let updated_value = Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                         kind,
                     );
                     self.write_back_container_source(code, source, &source_val, updated_value);
@@ -294,7 +294,7 @@ impl Interpreter {
                     }
                 }
                 let updated_value = Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                     kind,
                 );
                 self.write_back_container_source(code, source, &source_val, updated_value);
@@ -316,7 +316,7 @@ impl Interpreter {
                 let mut updated = items.to_vec();
                 updated[idx] = current_val;
                 let updated_value = Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(updated)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                     kind,
                 );
                 self.write_back_container_source(code, source, &source_val, updated_value);

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1519,7 +1519,7 @@ pub(crate) fn cheaply_unchanged(old: &Value, new: &Value) -> bool {
         (Value::Package(a), Value::Package(b)) => a == b,
         (Value::Nil, Value::Nil) => true,
         (Value::Str(a), Value::Str(b)) => Arc::ptr_eq(a, b),
-        (Value::Array(a, _), Value::Array(b, _)) => Arc::ptr_eq(a, b),
+        (Value::Array(a, _), Value::Array(b, _)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
         // A `ContainerRef` cell is the shared-identity primitive of the
         // single-store design: `my @a := @b` installs the *same* cell into both

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -82,7 +82,7 @@ impl Interpreter {
                 })
             });
             if let Some(Value::Array(arc, _)) = current {
-                Some(Arc::as_ptr(&arc) as usize)
+                Some(crate::gc::Gc::as_ptr(&arc) as usize)
             } else {
                 None
             }
@@ -165,7 +165,7 @@ impl Interpreter {
                         shaped_items.resize(shape[0], Value::Nil);
                     }
                     assigned = Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(shaped_items)),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(shaped_items)),
                         crate::value::ArrayKind::Shaped,
                     );
                     crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
@@ -367,7 +367,7 @@ impl Interpreter {
             {
                 let has_old_ref = stack_arc.iter().any(|v| {
                     if let Value::Array(inner_arc, _) = v {
-                        Arc::as_ptr(inner_arc) as usize == old_ptr
+                        crate::gc::Gc::as_ptr(inner_arc) as usize == old_ptr
                     } else {
                         false
                     }

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -306,7 +306,7 @@ impl Interpreter {
             Value::Array(arc_vec, kind) => {
                 let copied: Vec<Value> = arc_vec.iter().map(Self::deep_copy_value).collect();
                 Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(copied)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(copied)),
                     *kind,
                 )
             }

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -283,7 +283,7 @@ impl Interpreter {
                     let val = match method_name.as_str() {
                         "Slip" => Value::Slip(std::sync::Arc::new(items)),
                         "List" => Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                             crate::value::ArrayKind::List,
                         ),
                         "Seq" => Value::Seq(std::sync::Arc::new(items)),

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -25,7 +25,7 @@ impl Interpreter {
                 if let Some(i) = Self::index_to_usize(key) {
                     // SAFETY: aliased in-place mutation of a shared array; see
                     // `arc_contents_mut`.
-                    let v = &mut unsafe { crate::value::arc_contents_mut(arc) }.items;
+                    let v = &mut unsafe { crate::value::gc_contents_mut(arc) }.items;
                     Self::autoviv_resize(v, i + 1, Value::Nil)?;
                     Value::assign_element_slot(&mut v[i], val);
                 }
@@ -330,7 +330,7 @@ impl Interpreter {
     /// Array/Hash Arc (a clone that has not been copy-on-write forked).
     pub(crate) fn same_container_arc(a: &Value, b: &Value) -> bool {
         match (a, b) {
-            (Value::Array(x, _), Value::Array(y, _)) => Arc::ptr_eq(x, y),
+            (Value::Array(x, _), Value::Array(y, _)) => crate::gc::Gc::ptr_eq(x, y),
             (Value::Hash(x), Value::Hash(y)) => crate::gc::Gc::ptr_eq(x, y),
             _ => false,
         }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -255,7 +255,7 @@ impl Interpreter {
         let old_container_arc_ptr: Option<usize> =
             if let Some(container) = self.env().get(&var_name) {
                 match container {
-                    Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
+                    Value::Array(arc, _) => Some(crate::gc::Gc::as_ptr(arc) as usize),
                     Value::Hash(arc) => Some(crate::gc::Gc::as_ptr(arc) as usize),
                     _ => None,
                 }
@@ -349,28 +349,28 @@ impl Interpreter {
             Value::Range(a, b) if expand_range => {
                 let items: Vec<Value> = (a..=b).map(Value::Int).collect();
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
             Value::RangeExcl(a, b) if expand_range => {
                 let items: Vec<Value> = (a..b).map(Value::Int).collect();
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
             Value::RangeExclStart(a, b) if expand_range => {
                 let items: Vec<Value> = ((a + 1)..=b).map(Value::Int).collect();
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
             Value::RangeExclBoth(a, b) if expand_range => {
                 let items: Vec<Value> = ((a + 1)..b).map(Value::Int).collect();
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
@@ -380,7 +380,7 @@ impl Interpreter {
             gr @ Value::GenericRange { .. } if expand_range => {
                 let items = crate::runtime::utils::value_to_list(&gr);
                 Value::Array(
-                    Arc::new(crate::value::ArrayData::new(items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                     crate::value::ArrayKind::List,
                 )
             }
@@ -495,7 +495,7 @@ impl Interpreter {
                     // across the write. (The old code cast the `ArrayData` pointer
                     // straight to `*mut Vec<Value>`, assuming `items` sits at
                     // offset 0; this types it properly as `&mut ArrayData`.)
-                    let data = unsafe { crate::value::arc_contents_mut(&items) };
+                    let data = unsafe { crate::value::gc_contents_mut(&items) };
                     data.items[i] = Value::Scalar(Box::new(val.clone()));
                     self.stack.push(val);
                     return Ok(());
@@ -551,7 +551,7 @@ impl Interpreter {
                     let mut assigned = Vec::new();
                     attributes.with_attr_mut("bytes", |bytes_val| {
                         if let Value::Array(items, ..) = bytes_val {
-                            let arr = Arc::make_mut(items);
+                            let arr = crate::gc::Gc::make_mut(items);
                             if let Err(e) = Self::autoviv_resize(arr, max_idx + 1, Value::Int(0)) {
                                 resize_err = Some(e);
                                 return;
@@ -574,7 +574,7 @@ impl Interpreter {
                     let mut resize_err = None;
                     attributes.with_attr_mut("bytes", |bytes_val| {
                         if let Value::Array(items, ..) = bytes_val {
-                            let arr = Arc::make_mut(items);
+                            let arr = crate::gc::Gc::make_mut(items);
                             if let Err(e) = Self::autoviv_resize(arr, pos + 1, Value::Int(0)) {
                                 resize_err = Some(e);
                                 return;
@@ -669,7 +669,7 @@ impl Interpreter {
                     // For array variables with junction index, use numeric indices
                     // (descend through any `:=`-bound cell, same as the hash arm).
                     if let Some(Value::Array(items, ..)) = self.env_root_descended_mut(&var_name) {
-                        let arr = Arc::make_mut(items);
+                        let arr = crate::gc::Gc::make_mut(items);
                         Self::autoviv_resize(arr, idx_usize + 1, native_fill.clone())?;
                         arr[idx_usize] = v;
                     }
@@ -708,7 +708,7 @@ impl Interpreter {
                     if let Some(max_idx) = max_index
                         && let Value::Array(items, ..) = container
                     {
-                        let arr = Arc::make_mut(items);
+                        let arr = crate::gc::Gc::make_mut(items);
                         Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
                     }
                     let mut vals_iter = vals.into_iter();
@@ -826,7 +826,7 @@ impl Interpreter {
                         if let Some(max_idx) = Self::slice_key_tree_max_index(top_tree)
                             && let Value::Array(items, ..) = container
                         {
-                            let arr = Arc::make_mut(items);
+                            let arr = crate::gc::Gc::make_mut(items);
                             Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
                         }
                         let mut vals_iter = vals.into_iter();
@@ -848,7 +848,7 @@ impl Interpreter {
                             .max()
                             .unwrap_or(0);
                         if let Value::Array(items, ..) = container {
-                            let arr = Arc::make_mut(items);
+                            let arr = crate::gc::Gc::make_mut(items);
                             Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
                         }
                         // Assign each value to the corresponding index
@@ -1491,7 +1491,7 @@ impl Interpreter {
                                 )?;
                             } else if let Some((slice_indices, vals)) = &range_slice {
                                 if let Value::Array(items, ..) = container {
-                                    let arr = Arc::make_mut(items);
+                                    let arr = crate::gc::Gc::make_mut(items);
                                     if let Some(max_idx) = slice_indices.last().copied()
                                         && max_idx >= arr.len()
                                     {
@@ -1516,19 +1516,19 @@ impl Interpreter {
                                 if let Value::Array(items, ..) = container {
                                     let is_self_array_ref = matches!(
                                         &val,
-                                        Value::Array(source_items, ..) if Arc::ptr_eq(items, source_items)
+                                        Value::Array(source_items, ..) if crate::gc::Gc::ptr_eq(items, source_items)
                                     );
                                     // Use in-place mutation when the array is shared
                                     // (strong_count > 1) to preserve identity semantics
                                     // and support shared `ContainerRef` cell binding.
-                                    let use_inplace =
-                                        Arc::strong_count(items) > 1 && !var_name.starts_with('@');
+                                    let use_inplace = crate::gc::Gc::strong_count(items) > 1
+                                        && !var_name.starts_with('@');
                                     let arr: &mut crate::value::ArrayData = if use_inplace {
                                         // SAFETY: aliased in-place mutation of a
                                         // shared array; see `arc_contents_mut`.
-                                        unsafe { crate::value::arc_contents_mut(items) }
+                                        unsafe { crate::value::gc_contents_mut(items) }
                                     } else {
-                                        Arc::make_mut(items)
+                                        crate::gc::Gc::make_mut(items)
                                     };
                                     Self::autoviv_resize(arr, i + 1, native_fill.clone())?;
                                     if bind_mode && let Some((source_install, cell)) = &bind_cell {
@@ -1811,7 +1811,7 @@ impl Interpreter {
                 .or_else(|| self.env().get(&original_var_name).cloned());
             if let Some(ref container) = current {
                 let new_arc_ptr = match container {
-                    Value::Array(arc, _) => Some(Arc::as_ptr(arc) as usize),
+                    Value::Array(arc, _) => Some(crate::gc::Gc::as_ptr(arc) as usize),
                     Value::Hash(arc) => Some(crate::gc::Gc::as_ptr(arc) as usize),
                     _ => None,
                 };
@@ -2056,7 +2056,7 @@ impl Interpreter {
         if let Some(Value::Array(outer_arr, _kind)) = self.env_root_descended_mut(&var_name)
             && let Ok(inner_i) = inner_key.parse::<usize>()
         {
-            let arr = Arc::make_mut(outer_arr);
+            let arr = crate::gc::Gc::make_mut(outer_arr);
             Self::autoviv_resize(arr, inner_i + 1, native_fill.clone())?;
             // Autovivify the slot if it's not already a container. A
             // `:=`-bound element is a shared `ContainerRef` cell holding a
@@ -2083,14 +2083,14 @@ impl Interpreter {
                     if let Ok(j) = outer_key.parse::<usize>() {
                         // Use interior mutation when the inner array is shared
                         // (e.g., by a `ContainerRef` cell from := binding).
-                        if Arc::strong_count(inner_arr) > 1 {
+                        if crate::gc::Gc::strong_count(inner_arr) > 1 {
                             // SAFETY: aliased in-place mutation of a shared array
                             // (strong_count > 1); see `arc_contents_mut`.
-                            let v = &mut unsafe { crate::value::arc_contents_mut(inner_arr) }.items;
+                            let v = &mut unsafe { crate::value::gc_contents_mut(inner_arr) }.items;
                             Self::autoviv_resize(v, j + 1, Value::Nil)?;
                             Value::assign_element_slot(&mut v[j], val.clone());
                         } else {
-                            let inner = Arc::make_mut(inner_arr);
+                            let inner = crate::gc::Gc::make_mut(inner_arr);
                             Self::autoviv_resize(inner, j + 1, native_fill.clone())?;
                             Value::assign_element_slot(&mut inner[j], val.clone());
                         }
@@ -2175,14 +2175,14 @@ impl Interpreter {
             }
             Value::Array(arr, _) => {
                 if let Ok(i) = outer_key.parse::<usize>() {
-                    if Arc::strong_count(arr) > 1 {
+                    if crate::gc::Gc::strong_count(arr) > 1 {
                         // SAFETY: aliased in-place mutation of a shared array
                         // (strong_count > 1); see `arc_contents_mut`.
-                        let v = &mut unsafe { crate::value::arc_contents_mut(arr) }.items;
+                        let v = &mut unsafe { crate::value::gc_contents_mut(arr) }.items;
                         Self::autoviv_resize(v, i + 1, Value::Nil)?;
                         Value::assign_element_slot(&mut v[i], val);
                     } else {
-                        let a = Arc::make_mut(arr);
+                        let a = crate::gc::Gc::make_mut(arr);
                         Self::autoviv_resize(a, i + 1, Value::Nil)?;
                         Value::assign_element_slot(&mut a[i], val);
                     }
@@ -2379,7 +2379,7 @@ impl Interpreter {
                     match &mut *current {
                         Value::Array(arr_arc, _) => {
                             if let Ok(i) = key.parse::<usize>() {
-                                let arr = Arc::make_mut(arr_arc);
+                                let arr = crate::gc::Gc::make_mut(arr_arc);
                                 Self::autoviv_resize(arr, i + 1, native_fill.clone())?;
                                 // Autovivify if needed. A `ContainerRef` is a
                                 // `:=`-bound cell that holds (and is descended to)
@@ -2422,7 +2422,7 @@ impl Interpreter {
                             match &mut *current {
                                 Value::Array(arr_arc, _) => {
                                     if let Ok(i) = key.parse::<usize>() {
-                                        let arr = Arc::make_mut(arr_arc);
+                                        let arr = crate::gc::Gc::make_mut(arr_arc);
                                         Self::autoviv_resize(
                                             arr,
                                             i + 1,
@@ -2464,7 +2464,7 @@ impl Interpreter {
                     match &mut *current {
                         Value::Array(arr_arc, _) => {
                             if let Ok(i) = key.parse::<usize>() {
-                                let arr = Arc::make_mut(arr_arc);
+                                let arr = crate::gc::Gc::make_mut(arr_arc);
                                 Self::autoviv_resize(arr, i + 1, native_fill.clone())?;
                                 if bind_cell.is_some() {
                                     arr[i] = leaf_val;
@@ -2696,7 +2696,7 @@ impl Interpreter {
                     // SAFETY: aliased in-place mutation of a shared array so the
                     // change is visible to all holders of the same Arc; see
                     // `arc_contents_mut`.
-                    let v = &mut unsafe { crate::value::arc_contents_mut(arc) }.items;
+                    let v = &mut unsafe { crate::value::gc_contents_mut(arc) }.items;
                     Self::autoviv_resize(v, i + 1, Value::Nil)?;
                     match &bind_cell {
                         // Bind mode installs the shared cell at the element;

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -247,7 +247,7 @@ impl Interpreter {
                     Self::autoviv_resize(&mut shaped_items, shape[0], default)?;
                 }
                 assigned = Value::Array(
-                    Arc::new(crate::value::ArrayData::new(shaped_items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(shaped_items)),
                     crate::value::ArrayKind::Shaped,
                 );
                 crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 impl Interpreter {
     /// Return the default fill value for a native type constraint.
@@ -100,7 +99,7 @@ impl Interpreter {
                 } else {
                     return Ok(false);
                 }
-                *attr_value = Value::Array(Arc::new(updated), *kind);
+                *attr_value = Value::Array(crate::gc::Gc::new(updated), *kind);
                 Ok(true)
             }
             Value::Hash(hash) if matches!(idx, Value::Str(_)) => {
@@ -213,7 +212,7 @@ impl Interpreter {
                     return Err(RuntimeError::assignment_ro(None));
                 };
                 if let Value::Array(items, ..) = container {
-                    let arr = Arc::make_mut(items);
+                    let arr = crate::gc::Gc::make_mut(items);
                     Self::autoviv_resize(arr, i + 1, Value::Package(Symbol::intern("Any")))?;
                     arr[i] = value;
                     return Ok(());
@@ -233,7 +232,7 @@ impl Interpreter {
             let Value::Array(items, ..) = container else {
                 return Err(RuntimeError::assignment_ro(None));
             };
-            let arr = Arc::make_mut(items);
+            let arr = crate::gc::Gc::make_mut(items);
             Self::autoviv_resize(arr, i + 1, Value::Package(Symbol::intern("Any")))?;
             arr[i] = value;
             return Ok(());
@@ -262,7 +261,7 @@ impl Interpreter {
         if matches!(idx, Value::Whatever) {
             let indices: Vec<Value> = (0..len).map(Value::Int).collect();
             return Value::Array(
-                Arc::new(crate::value::ArrayData::new(indices)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(indices)),
                 crate::value::ArrayKind::List,
             );
         }
@@ -305,7 +304,10 @@ impl Interpreter {
                         resolved.push(item.clone());
                     }
                 }
-                return Value::Array(Arc::new(crate::value::ArrayData::new(resolved)), kind);
+                return Value::Array(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(resolved)),
+                    kind,
+                );
             }
         }
         idx
@@ -385,7 +387,7 @@ impl Interpreter {
         seen_hashes: &mut Vec<usize>,
     ) -> bool {
         match v {
-            Value::Array(inner_arc, _) => Arc::as_ptr(inner_arc) as usize == old_ptr,
+            Value::Array(inner_arc, _) => crate::gc::Gc::as_ptr(inner_arc) as usize == old_ptr,
             Value::Hash(map) => {
                 let hash_ptr = crate::gc::Gc::as_ptr(map) as usize;
                 if seen_hashes.contains(&hash_ptr) {
@@ -410,12 +412,12 @@ impl Interpreter {
     pub(crate) fn replace_array_refs_in_value(
         v: &mut Value,
         old_ptr: usize,
-        new_array: &Arc<crate::value::ArrayData>,
+        new_array: &crate::gc::Gc<crate::value::ArrayData>,
         kind: ArrayKind,
         seen_hashes: &mut Vec<usize>,
     ) {
         match v {
-            Value::Array(inner_arc, _) if Arc::as_ptr(inner_arc) as usize == old_ptr => {
+            Value::Array(inner_arc, _) if crate::gc::Gc::as_ptr(inner_arc) as usize == old_ptr => {
                 *v = Value::Array(new_array.clone(), kind);
             }
             Value::Hash(map) => {
@@ -494,7 +496,7 @@ impl Interpreter {
             let mut hash_fixup_indices = Vec::new();
             for (i, v) in new_arc.iter().enumerate() {
                 if let Value::Array(inner_arc, _) = v
-                    && Arc::as_ptr(inner_arc) as usize == *old_ptr
+                    && crate::gc::Gc::as_ptr(inner_arc) as usize == *old_ptr
                 {
                     circular_indices.push(i);
                     new_items.push(Value::Nil); // placeholder
@@ -512,7 +514,7 @@ impl Interpreter {
             // SAFETY: result_arc was just created here; building a
             // self-referential cycle and the in-place recursive fixup must alias
             // it. See `arc_contents_mut`.
-            let data = unsafe { crate::value::arc_contents_mut(&result_arc) };
+            let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for idx in &circular_indices {
                 data.items[*idx] = Value::Array(result_arc.clone(), *kind);
             }

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -475,7 +475,7 @@ impl Interpreter {
                 }
                 Value::Array(arr, ..) => {
                     if let Ok(i) = key.parse::<usize>() {
-                        let a = Arc::make_mut(arr);
+                        let a = crate::gc::Gc::make_mut(arr);
                         Self::autoviv_resize(a, i + 1, Value::Nil)?;
                         a[i] = new_val.clone();
                     }
@@ -624,14 +624,15 @@ impl Interpreter {
                         // Use in-place mutation when the array is shared
                         // (strong_count > 1) to preserve identity semantics,
                         // matching the behavior of index assignment.
-                        let use_inplace = Arc::strong_count(arr) > 1 && !name.starts_with('@');
+                        let use_inplace =
+                            crate::gc::Gc::strong_count(arr) > 1 && !name.starts_with('@');
                         let a: &mut crate::value::ArrayData = if use_inplace {
                             // SAFETY: aliased in-place mutation of a shared array
                             // (strong_count > 1, the case that needs the shared
                             // write); see `arc_contents_mut`.
-                            unsafe { crate::value::arc_contents_mut(arr) }
+                            unsafe { crate::value::gc_contents_mut(arr) }
                         } else {
-                            Arc::make_mut(arr)
+                            crate::gc::Gc::make_mut(arr)
                         };
                         // Fill holes with the element type's type object for a
                         // typed array (e.g. `my Int @a; @a[4]++` leaves `(Int)`

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::sync::Arc;
 
 impl Interpreter {
     /// Env key marking a variable as a genuine bound array SLICE (`@slice :=
@@ -437,7 +436,7 @@ impl Interpreter {
         // Capture the old array Arc before assignment for circular reference fixup.
         let old_array_arc = if name.starts_with('@') {
             if let Value::Array(arc, _) = &self.locals[idx] {
-                Some(Arc::as_ptr(arc) as usize)
+                Some(crate::gc::Gc::as_ptr(arc) as usize)
             } else {
                 None
             }
@@ -569,13 +568,13 @@ impl Interpreter {
                     Value::Array(items, kind) if kind.is_real_array() => Value::Array(items, kind),
                     Value::Array(items, _) => Value::Array(items, crate::value::ArrayKind::List),
                     Value::Seq(items) => Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(items.to_vec())),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(items.to_vec())),
                         crate::value::ArrayKind::List,
                     ),
                     Value::LazyList(list) => {
                         let items = self.force_lazy_list_vm(&list)?;
                         Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                             crate::value::ArrayKind::List,
                         )
                     }
@@ -583,7 +582,7 @@ impl Interpreter {
                         let forced = self.force_if_lazy_io_lines(raw_popped)?;
                         let items = runtime::value_to_list(&forced);
                         Value::Array(
-                            std::sync::Arc::new(crate::value::ArrayData::new(items)),
+                            crate::gc::Gc::new(crate::value::ArrayData::new(items)),
                             crate::value::ArrayKind::List,
                         )
                     }
@@ -659,20 +658,20 @@ impl Interpreter {
                                     Value::Array(items, crate::value::ArrayKind::List)
                                 }
                                 Value::Seq(items) => Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(
                                         items.to_vec(),
                                     )),
                                     crate::value::ArrayKind::List,
                                 ),
                                 other => Value::Array(
-                                    std::sync::Arc::new(crate::value::ArrayData::new(vec![other])),
+                                    crate::gc::Gc::new(crate::value::ArrayData::new(vec![other])),
                                     crate::value::ArrayKind::List,
                                 ),
                             }
                         }
                     }
                     other => Value::Array(
-                        std::sync::Arc::new(crate::value::ArrayData::new(vec![other])),
+                        crate::gc::Gc::new(crate::value::ArrayData::new(vec![other])),
                         crate::value::ArrayKind::List,
                     ),
                 }
@@ -850,7 +849,7 @@ impl Interpreter {
                     Self::autoviv_resize(&mut shaped_items, shape[0], default)?;
                 }
                 assigned = Value::Array(
-                    std::sync::Arc::new(crate::value::ArrayData::new(shaped_items)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(shaped_items)),
                     crate::value::ArrayKind::Shaped,
                 );
                 crate::runtime::utils::mark_shaped_array(&assigned, Some(shape));
@@ -877,7 +876,7 @@ impl Interpreter {
                 let items = if items.shape.is_some() {
                     let mut data = (**items).clone();
                     data.shape = None;
-                    std::sync::Arc::new(data)
+                    crate::gc::Gc::new(data)
                 } else {
                     items.clone()
                 };
@@ -936,7 +935,10 @@ impl Interpreter {
                     .iter()
                     .map(|v| if is_hole(v) { def.clone() } else { v.clone() })
                     .collect();
-                val = Value::Array(Arc::new(crate::value::ArrayData::new(replaced)), kind);
+                val = Value::Array(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(replaced)),
+                    kind,
+                );
             }
         }
         // Skip typed container coercion for `:=` binding — it would create

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::sync::Arc;
 use unicode_normalization::UnicodeNormalization;
 
 impl Interpreter {
@@ -57,7 +56,10 @@ impl Interpreter {
                     &|_| None,
                     false,
                 )?;
-                val = Value::Array(Arc::new(crate::value::ArrayData::new(coerced)), *kind);
+                val = Value::Array(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(coerced)),
+                    *kind,
+                );
             }
             val = self.tag_container_metadata(val, info);
         }
@@ -189,7 +191,7 @@ impl Interpreter {
                 explicit_initializer,
             )?;
             return Ok(Value::Array(
-                Arc::new(crate::value::ArrayData::new(coerced_items)),
+                crate::gc::Gc::new(crate::value::ArrayData::new(coerced_items)),
                 kind,
             ));
         }
@@ -339,7 +341,7 @@ impl Interpreter {
                     explicit_initializer,
                 )?;
                 coerced_items.push(Value::Array(
-                    Arc::new(crate::value::ArrayData::new(sub_coerced)),
+                    crate::gc::Gc::new(crate::value::ArrayData::new(sub_coerced)),
                     *sub_kind,
                 ));
                 continue;

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -49,7 +49,7 @@ impl Interpreter {
         let Value::Array(items, ..) = container else {
             return;
         };
-        let arr = Arc::make_mut(items);
+        let arr = crate::gc::Gc::make_mut(items);
         // The explicitly-assigned indices travel with the array (embedded set).
         let initialized = arr.initialized.clone().unwrap_or_default();
         while let Some(last) = arr.last() {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -2013,7 +2013,7 @@ impl Interpreter {
     /// to a sublist (slice). Returns `None` if the index is not a range.
     pub(super) fn resolve_range_index_slice(
         idx: &Value,
-        items: &std::sync::Arc<crate::value::ArrayData>,
+        items: &crate::gc::Gc<crate::value::ArrayData>,
         kind: crate::value::ArrayKind,
         _len: i64,
         vm: &mut Interpreter,

--- a/src/vm/vm_var_index_tracking.rs
+++ b/src/vm/vm_var_index_tracking.rs
@@ -1,7 +1,6 @@
 //! Bound-index / element-share / deleted-index bookkeeping helpers
 //! split from `vm_var_ops` (§7-8 file split).
 use super::*;
-use std::sync::Arc;
 
 impl Interpreter {
     pub(super) fn encode_bound_index(idx: &Value) -> String {
@@ -101,14 +100,14 @@ impl Interpreter {
         // the original would be lost (t/array-push-byref-coherence).
         let use_inplace = !var_name.starts_with('@');
         if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name) {
-            let data: &mut crate::value::ArrayData = if use_inplace && Arc::strong_count(items) > 1
-            {
-                // SAFETY: aliased in-place mutation of a shared array; same
-                // contract as the assignment site's `arc_contents_mut` use.
-                unsafe { crate::value::arc_contents_mut(items) }
-            } else {
-                Arc::make_mut(items)
-            };
+            let data: &mut crate::value::ArrayData =
+                if use_inplace && crate::gc::Gc::strong_count(items) > 1 {
+                    // SAFETY: aliased in-place mutation of a shared array; same
+                    // contract as the assignment site's `arc_contents_mut` use.
+                    unsafe { crate::value::gc_contents_mut(items) }
+                } else {
+                    crate::gc::Gc::make_mut(items)
+                };
             data.initialized
                 .get_or_insert_with(std::collections::HashSet::new)
                 .insert(idx);
@@ -205,7 +204,7 @@ impl Interpreter {
             return;
         }
         if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name)
-            && let Some(set) = Arc::make_mut(items).initialized.as_mut()
+            && let Some(set) = crate::gc::Gc::make_mut(items).initialized.as_mut()
         {
             for i in to_remove {
                 set.remove(&i);

--- a/src/vm/vm_var_multidim_helpers.rs
+++ b/src/vm/vm_var_multidim_helpers.rs
@@ -3,7 +3,6 @@
 use super::*;
 use crate::symbol::Symbol;
 use num_traits::Zero;
-use std::sync::Arc;
 
 impl Interpreter {
     pub(super) fn array_depth(value: &Value) -> usize {
@@ -130,7 +129,7 @@ impl Interpreter {
         if i >= items.len() {
             return Err(RuntimeError::new("Index out of bounds"));
         }
-        let arr = Arc::make_mut(items);
+        let arr = crate::gc::Gc::make_mut(items);
         if indices.len() == 1 {
             Value::assign_element_slot(&mut arr[i], val);
         } else {
@@ -169,7 +168,7 @@ impl Interpreter {
         if i >= items.len() {
             return Ok(hole_value());
         }
-        let arr = Arc::make_mut(items);
+        let arr = crate::gc::Gc::make_mut(items);
         if indices.len() == 1 {
             let prev = arr[i].clone();
             arr[i] = hole_value();

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -737,7 +737,7 @@ impl Interpreter {
             {
                 Self::ensure_array_size(target, i + 1);
                 if let Value::Array(items, ..) = target {
-                    let items = std::sync::Arc::make_mut(items);
+                    let items = crate::gc::Gc::make_mut(items);
                     self.multi_dim_assign_slice(&mut items[i], rest, values, vi)?;
                 }
             } else if let Value::Str(s) = &key {
@@ -780,7 +780,7 @@ impl Interpreter {
         {
             Self::ensure_array_size(target, i + 1);
             if let Value::Array(items, ..) = target {
-                let items = std::sync::Arc::make_mut(items);
+                let items = crate::gc::Gc::make_mut(items);
                 self.multi_dim_assign_scalar(&mut items[i], rest, value)?;
             }
         } else if let Value::Str(s) = &key {
@@ -884,7 +884,7 @@ impl Interpreter {
         match target {
             Value::Array(items, ..) => {
                 if items.len() < min_size {
-                    let items = std::sync::Arc::make_mut(items);
+                    let items = crate::gc::Gc::make_mut(items);
                     items.resize(
                         min_size,
                         Value::Package(crate::symbol::Symbol::intern("Any")),

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -135,7 +135,7 @@ impl Interpreter {
 
     pub(super) fn resolve_array_entry(
         &self,
-        items: &Arc<crate::value::ArrayData>,
+        items: &crate::gc::Gc<crate::value::ArrayData>,
         kind: ArrayKind,
         idx: usize,
         default: Value,

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -57,8 +57,10 @@ impl Interpreter {
                                 }
                             })
                             .collect();
-                        let new_arr =
-                            Value::Array(Arc::new(crate::value::ArrayData::new(replaced)), kind);
+                        let new_arr = Value::Array(
+                            crate::gc::Gc::new(crate::value::ArrayData::new(replaced)),
+                            kind,
+                        );
                         let new_arr = self.tag_container_default(new_arr, default_value.clone());
                         self.locals_set_by_name(code, &name, new_arr.clone());
                         self.set_env_with_main_alias(&name, new_arr);


### PR DESCRIPTION
Second first-wave `Arc → Gc<T>` container migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11 step 5c), same shape as the Hash migration (#4113). `Value::Array` now holds a `Gc<ArrayData>`, so the Bacon-Rajan node header rides on every array. Behavior-preserving.

### What lands
- `impl Trace for ArrayData` (traces items via `Value::gc_trace`) + an `Array` arm added to `Value::gc_trace`.
- Central helpers (`array`/`real_array`/`shaped_array`/`array_arc`/`array_data_like`) now build `Gc` / return `Gc<ArrayData>`.
- ~50 files, **353 → 0** compile errors resolved type-directed: mechanical `Arc::{make_mut,as_ptr,ptr_eq,strong_count,get_mut}` swaps, then global seds for `Value::Array(Arc::new(...))` constructions and `Arc<ArrayData>` type annotations, then a couple of `if/else` branch fixups.
- **Deletes `value::aliased_mut::arc_contents_mut`**: with both Array and Hash on `Gc`, its only callers are gone. Container aliased in-place mutation now funnels through the single `gc_contents_mut` chokepoint — removing the last raw `Arc`-pointer write (the documented Stacked/Tree-Borrows-unsound path) for containers. A soundness win that falls out of the GC integration.

### Verification
- `make test` = **Result: PASS** (1459 files, 14076 tests, no non-flaky failures).
- All **whitelisted** S32-array tests + `S02-types/array.t` + S09 typed arrays pass.
- Container identity/COW (`@b=@a` copies, `@c:=@a` shares, `.WHICH`), multidim `@m[2;2]`, and typed `my Int @t` all preserved.
- `cargo clippy -- -D warnings` clean (incl. `--all-targets`).
- Non-whitelisted `splice.t` (self-referential arrays `@a.push(@a)`) / `multislice-6e.t` (multidim assignability) partial failures are pre-existing feature gaps, unrelated to this migration.

Rebased onto main after the parallel #4114/#4115 Gc-API reconciliation; defers to main's `ptr_eq`/`get_mut`/`make_mut` (this branch's call sites use `Gc::make_mut(&mut x)` UFCS). Next: 5d (`Value::ContainerRef` → `Gc<CellValue>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)