### PR TITLE
GC step 5d: migrate Value::Set/Bag/Mix from Arc to Gc

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -126,15 +126,18 @@ pub(super) fn dispatch(
                     *kind,
                 )))),
                 Value::Hash(map) => Some(Some(Ok(Value::Hash(Value::hash_arc((**map).clone()))))),
-                Value::Set(data, mutable) => {
-                    Some(Some(Ok(Value::Set(Arc::new((**data).clone()), *mutable))))
-                }
-                Value::Bag(data, mutable) => {
-                    Some(Some(Ok(Value::Bag(Arc::new((**data).clone()), *mutable))))
-                }
-                Value::Mix(data, mutable) => {
-                    Some(Some(Ok(Value::Mix(Arc::new((**data).clone()), *mutable))))
-                }
+                Value::Set(data, mutable) => Some(Some(Ok(Value::Set(
+                    crate::gc::Gc::new((**data).clone()),
+                    *mutable,
+                )))),
+                Value::Bag(data, mutable) => Some(Some(Ok(Value::Bag(
+                    crate::gc::Gc::new((**data).clone()),
+                    *mutable,
+                )))),
+                Value::Mix(data, mutable) => Some(Some(Ok(Value::Mix(
+                    crate::gc::Gc::new((**data).clone()),
+                    *mutable,
+                )))),
                 Value::Sub(data) => {
                     // Clone the sub with a new id so state variables are independent
                     let mut new_data = (**data).clone();

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -707,7 +707,7 @@ pub(crate) fn to_mixhash(target: Value) -> Result<Value, RuntimeError> {
         // that ever changes, hand the value back unmodified rather than panic.
         return Ok(coerced);
     };
-    let data = std::sync::Arc::make_mut(&mut arc);
+    let data = crate::gc::Gc::make_mut(&mut arc);
     data.value_type = Some("Real".to_string());
     data.key_type = None;
     data.declared_type = Some("MixHash".to_string());

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -414,7 +414,7 @@ impl Interpreter {
             Value::Bag(target_arc, _) => {
                 for (name, env_val) in self.env().iter() {
                     if let Value::Bag(env_arc, _) = env_val
-                        && std::sync::Arc::ptr_eq(target_arc, env_arc)
+                        && crate::gc::Gc::ptr_eq(target_arc, env_arc)
                     {
                         return Some(name.resolve());
                     }
@@ -424,7 +424,7 @@ impl Interpreter {
             Value::Mix(target_arc, _) => {
                 for (name, env_val) in self.env().iter() {
                     if let Value::Mix(env_arc, _) = env_val
-                        && std::sync::Arc::ptr_eq(target_arc, env_arc)
+                        && crate::gc::Gc::ptr_eq(target_arc, env_arc)
                     {
                         return Some(name.resolve());
                     }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1497,7 +1497,10 @@ impl Interpreter {
                 }
             }
             let new_elements: std::collections::HashSet<String> = elements.into_iter().collect();
-            let new_set = Value::Set(Arc::new(crate::value::SetData::new(new_elements)), true);
+            let new_set = Value::Set(
+                crate::gc::Gc::new(crate::value::SetData::new(new_elements)),
+                true,
+            );
             self.env.insert(target_var.to_string(), new_set);
             return Ok(
                 if grabbed.len() == 1 && args.is_empty() && method == "grab" {
@@ -1613,7 +1616,10 @@ impl Interpreter {
                 }
             }
             // Update the original variable
-            let new_bag = Value::Bag(Arc::new(crate::value::BagData::new(remaining)), true);
+            let new_bag = Value::Bag(
+                crate::gc::Gc::new(crate::value::BagData::new(remaining)),
+                true,
+            );
             self.env.insert(target_var.to_string(), new_bag);
             return Ok(if grabbed.len() == 1 && args.is_empty() {
                 grabbed.into_iter().next().unwrap()
@@ -1695,7 +1701,7 @@ impl Interpreter {
                 }
             }
             // Update the original variable
-            let new_mix = Value::Mix(Arc::new(remaining), true);
+            let new_mix = Value::Mix(crate::gc::Gc::new(remaining), true);
             self.env.insert(target_var.to_string(), new_mix);
             return Ok(if grabbed.len() == 1 && args.is_empty() {
                 grabbed.into_iter().next().unwrap()

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -940,11 +940,11 @@ pub enum Value {
     BigRat(Box<NumBigInt>, Box<NumBigInt>),
     Complex(f64, f64),
     /// Set (immutable) or SetHash (mutable). The bool is `true` for mutable (SetHash).
-    Set(Arc<SetData>, bool),
+    Set(crate::gc::Gc<SetData>, bool),
     /// Bag (immutable) or BagHash (mutable). The bool is `true` for mutable (BagHash).
-    Bag(Arc<BagData>, bool),
+    Bag(crate::gc::Gc<BagData>, bool),
     /// Mix (immutable) or MixHash (mutable). The bool is `true` for mutable (MixHash).
-    Mix(Arc<MixData>, bool),
+    Mix(crate::gc::Gc<MixData>, bool),
     CompUnitDepSpec {
         short_name: Symbol,
     },

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -18,7 +18,10 @@
 
 use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
-use super::{ArrayData, HashData, InstanceAttrs, SharedChannel, SharedPromise, SubData, Value};
+use super::{
+    ArrayData, BagData, HashData, InstanceAttrs, MixData, SetData, SharedChannel, SharedPromise,
+    SubData, Value,
+};
 
 impl Value {
     /// Hand each direct GC-managed (`Gc<T>`) child of this value to `visit`.
@@ -36,7 +39,43 @@ impl Value {
         match self {
             Value::Hash(data) => visit(&data.erased()),
             Value::Array(data, _) => visit(&data.erased()),
+            Value::Set(data, _) => visit(&data.erased()),
+            Value::Bag(data, _) => visit(&data.erased()),
+            Value::Mix(data, _) => visit(&data.erased()),
             _ => {}
+        }
+    }
+}
+
+/// The QuantHash datas hold `Value`s only in their `original_keys` back-map
+/// (the primary `elements`/`counts`/`weights` maps are keyed by string and hold
+/// no `Value`s), so tracing that map covers every GC child.
+impl Trace for SetData {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        if let Some(keys) = &self.original_keys {
+            for v in keys.values() {
+                v.gc_trace(visit);
+            }
+        }
+    }
+}
+
+impl Trace for BagData {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        if let Some(keys) = &self.original_keys {
+            for v in keys.values() {
+                v.gc_trace(visit);
+            }
+        }
+    }
+}
+
+impl Trace for MixData {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        if let Some(keys) = &self.original_keys {
+            for v in keys.values() {
+                v.gc_trace(visit);
+            }
         }
     }
 }

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -122,15 +122,15 @@ impl Value {
         }
     }
     pub fn set(s: HashSet<String>) -> Self {
-        Value::Set(Arc::new(SetData::new(s)), false)
+        Value::Set(crate::gc::Gc::new(SetData::new(s)), false)
     }
     pub fn set_hash(s: HashSet<String>) -> Self {
-        Value::Set(Arc::new(SetData::new(s)), true)
+        Value::Set(crate::gc::Gc::new(SetData::new(s)), true)
     }
     /// Create a Set with preserved original key types.
     pub fn set_typed(elements: HashSet<String>, original_keys: HashMap<String, Value>) -> Self {
         Value::Set(
-            Arc::new(SetData::with_original_keys(elements, original_keys)),
+            crate::gc::Gc::new(SetData::with_original_keys(elements, original_keys)),
             false,
         )
     }
@@ -140,7 +140,7 @@ impl Value {
         original_keys: HashMap<String, Value>,
     ) -> Self {
         Value::Set(
-            Arc::new(SetData::with_original_keys(elements, original_keys)),
+            crate::gc::Gc::new(SetData::with_original_keys(elements, original_keys)),
             true,
         )
     }
@@ -151,23 +151,29 @@ impl Value {
             .collect()
     }
     pub fn bag(m: HashMap<String, i64>) -> Self {
-        Value::Bag(Arc::new(BagData::new(Self::bag_counts_from_i64(m))), false)
+        Value::Bag(
+            crate::gc::Gc::new(BagData::new(Self::bag_counts_from_i64(m))),
+            false,
+        )
     }
     pub fn bag_hash(m: HashMap<String, i64>) -> Self {
-        Value::Bag(Arc::new(BagData::new(Self::bag_counts_from_i64(m))), true)
+        Value::Bag(
+            crate::gc::Gc::new(BagData::new(Self::bag_counts_from_i64(m))),
+            true,
+        )
     }
     /// Create a Bag from an arbitrary-precision BigInt count map.
     pub fn bag_big(m: HashMap<String, NumBigInt>) -> Self {
-        Value::Bag(Arc::new(BagData::new(m)), false)
+        Value::Bag(crate::gc::Gc::new(BagData::new(m)), false)
     }
     /// Create a BagHash from an arbitrary-precision BigInt count map.
     pub fn bag_hash_big(m: HashMap<String, NumBigInt>) -> Self {
-        Value::Bag(Arc::new(BagData::new(m)), true)
+        Value::Bag(crate::gc::Gc::new(BagData::new(m)), true)
     }
     /// Create a Bag with preserved original key types.
     pub fn bag_typed(counts: HashMap<String, i64>, original_keys: HashMap<String, Value>) -> Self {
         Value::Bag(
-            Arc::new(BagData::with_original_keys(
+            crate::gc::Gc::new(BagData::with_original_keys(
                 Self::bag_counts_from_i64(counts),
                 original_keys,
             )),
@@ -180,7 +186,7 @@ impl Value {
         original_keys: HashMap<String, Value>,
     ) -> Self {
         Value::Bag(
-            Arc::new(BagData::with_original_keys(counts, original_keys)),
+            crate::gc::Gc::new(BagData::with_original_keys(counts, original_keys)),
             false,
         )
     }
@@ -190,7 +196,7 @@ impl Value {
         original_keys: HashMap<String, Value>,
     ) -> Self {
         Value::Bag(
-            Arc::new(BagData::with_original_keys(
+            crate::gc::Gc::new(BagData::with_original_keys(
                 Self::bag_counts_from_i64(counts),
                 original_keys,
             )),
@@ -203,17 +209,17 @@ impl Value {
         original_keys: HashMap<String, Value>,
     ) -> Self {
         Value::Bag(
-            Arc::new(BagData::with_original_keys(counts, original_keys)),
+            crate::gc::Gc::new(BagData::with_original_keys(counts, original_keys)),
             true,
         )
     }
     pub fn mix(mut m: HashMap<String, f64>) -> Self {
         m.retain(|_, weight| *weight != 0.0);
-        Value::Mix(Arc::new(MixData::new(m)), false)
+        Value::Mix(crate::gc::Gc::new(MixData::new(m)), false)
     }
     pub fn mix_hash(mut m: HashMap<String, f64>) -> Self {
         m.retain(|_, weight| *weight != 0.0);
-        Value::Mix(Arc::new(MixData::new(m)), true)
+        Value::Mix(crate::gc::Gc::new(MixData::new(m)), true)
     }
     pub fn mix_with_original_keys(
         mut weights: HashMap<String, f64>,
@@ -221,7 +227,7 @@ impl Value {
     ) -> Self {
         weights.retain(|_, weight| *weight != 0.0);
         Value::Mix(
-            Arc::new(MixData::with_original_keys(weights, original_keys)),
+            crate::gc::Gc::new(MixData::with_original_keys(weights, original_keys)),
             false,
         )
     }
@@ -231,7 +237,7 @@ impl Value {
     ) -> Self {
         weights.retain(|_, weight| *weight != 0.0);
         Value::Mix(
-            Arc::new(MixData::with_original_keys(weights, original_keys)),
+            crate::gc::Gc::new(MixData::with_original_keys(weights, original_keys)),
             true,
         )
     }

--- a/src/vm/vm_loop_writeback_quant.rs
+++ b/src/vm/vm_loop_writeback_quant.rs
@@ -25,7 +25,7 @@ impl Interpreter {
                 } else {
                     b.counts.insert(key, count);
                 }
-                Value::Bag(std::sync::Arc::new(b), true)
+                Value::Bag(crate::gc::Gc::new(b), true)
             }
             Some(Value::Mix(mix, true)) => {
                 let weight = Self::mix_assignment_weight(value)?;
@@ -35,7 +35,7 @@ impl Interpreter {
                 } else {
                     m.insert(key, weight);
                 }
-                Value::Mix(std::sync::Arc::new(m), true)
+                Value::Mix(crate::gc::Gc::new(m), true)
             }
             Some(Value::Set(set, true)) => {
                 let mut s = (*set).clone();
@@ -44,7 +44,7 @@ impl Interpreter {
                 } else {
                     s.elements.remove(&key);
                 }
-                Value::Set(std::sync::Arc::new(s), true)
+                Value::Set(crate::gc::Gc::new(s), true)
             }
             _ => return Ok(()),
         };

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1398,7 +1398,10 @@ impl Interpreter {
                                 if val.truthy() {
                                     items.insert(key.clone());
                                 }
-                                Value::Set(Arc::new(crate::value::SetData::new(items)), true)
+                                Value::Set(
+                                    crate::gc::Gc::new(crate::value::SetData::new(items)),
+                                    true,
+                                )
                             }
                             _ => unreachable!(),
                         };
@@ -1601,7 +1604,7 @@ impl Interpreter {
                             if !is_mutable {
                                 return Err(RuntimeError::assignment_ro(Some("Set")));
                             }
-                            let s = Arc::make_mut(set);
+                            let s = crate::gc::Gc::make_mut(set);
                             if val.truthy() {
                                 s.insert(key.clone());
                             } else {
@@ -1612,7 +1615,7 @@ impl Interpreter {
                             if !is_mutable {
                                 return Err(RuntimeError::assignment_ro(Some("Bag")));
                             }
-                            let b = Arc::make_mut(bag);
+                            let b = crate::gc::Gc::make_mut(bag);
                             let count = Self::bag_assignment_count(&val)?;
                             if count == num_bigint::BigInt::from(0) {
                                 b.remove(&key);
@@ -1624,7 +1627,7 @@ impl Interpreter {
                             if !is_mutable {
                                 return Err(RuntimeError::assignment_ro(Some("Mix")));
                             }
-                            let m = Arc::make_mut(mix);
+                            let m = crate::gc::Gc::make_mut(mix);
                             let weight = Self::mix_assignment_weight(&val)?;
                             if weight == 0.0 {
                                 m.remove(&key);
@@ -1663,7 +1666,7 @@ impl Interpreter {
                                         items.insert(key.clone());
                                     }
                                     *container = Value::Set(
-                                        Arc::new(crate::value::SetData::new(items)),
+                                        crate::gc::Gc::new(crate::value::SetData::new(items)),
                                         true,
                                     );
                                 }

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -1,6 +1,5 @@
 use super::*;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 impl Interpreter {
     /// Apply a fused compound-assignment base operator to `left OP right` by
@@ -651,7 +650,7 @@ impl Interpreter {
                         return Err(RuntimeError::assignment_ro(Some("Mix")));
                     }
                     let weight = Self::mix_assignment_weight(&new_val)?;
-                    let m = Arc::make_mut(mix);
+                    let m = crate::gc::Gc::make_mut(mix);
                     if new_val.truthy() {
                         m.insert(key.clone(), weight);
                     } else {
@@ -663,7 +662,7 @@ impl Interpreter {
                     if !*is_mutable {
                         return Err(RuntimeError::assignment_ro(Some("Set")));
                     }
-                    let s = Arc::make_mut(set);
+                    let s = crate::gc::Gc::make_mut(set);
                     if new_val.truthy() {
                         s.insert(key.clone());
                     } else {
@@ -675,7 +674,7 @@ impl Interpreter {
                     if !*is_mutable {
                         return Err(RuntimeError::assignment_ro(Some("Bag")));
                     }
-                    let b = Arc::make_mut(bag);
+                    let b = crate::gc::Gc::make_mut(bag);
                     let n = match &new_val {
                         Value::Int(i) => num_bigint::BigInt::from(*i),
                         Value::BigInt(big) => (**big).clone(),
@@ -716,8 +715,10 @@ impl Interpreter {
                             if new_val.truthy() {
                                 items.insert(key.clone());
                             }
-                            *container_value =
-                                Value::Set(Arc::new(crate::value::SetData::new(items)), true);
+                            *container_value = Value::Set(
+                                crate::gc::Gc::new(crate::value::SetData::new(items)),
+                                true,
+                            );
                             true
                         }
                         _ => false,
@@ -768,7 +769,7 @@ impl Interpreter {
                         if new_val.truthy() {
                             items.insert(key.clone());
                         }
-                        Value::Set(Arc::new(crate::value::SetData::new(items)), true)
+                        Value::Set(crate::gc::Gc::new(crate::value::SetData::new(items)), true)
                     }
                     _ => unreachable!(),
                 };

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::sync::Arc;
 
 impl Interpreter {
     /// Resolve WhateverCode indices for array deletion.
@@ -547,18 +546,18 @@ impl Interpreter {
             Value::Array(..) => Self::delete_from_array(container, idx, hole_type)?,
             Value::Set(set, _) => match idx {
                 Value::Array(keys, ..) => {
-                    let s = Arc::make_mut(set);
+                    let s = crate::gc::Gc::make_mut(set);
                     let removed = keys
                         .iter()
                         .map(|key| Value::Bool(s.remove(&key.to_string_value())))
                         .collect();
                     Value::array(removed)
                 }
-                _ => Value::Bool(Arc::make_mut(set).remove(&idx.to_string_value())),
+                _ => Value::Bool(crate::gc::Gc::make_mut(set).remove(&idx.to_string_value())),
             },
             Value::Bag(bag, _) => match idx {
                 Value::Array(keys, ..) => {
-                    let b = Arc::make_mut(bag);
+                    let b = crate::gc::Gc::make_mut(bag);
                     let removed = keys
                         .iter()
                         .map(|key| {
@@ -568,14 +567,14 @@ impl Interpreter {
                     Value::array(removed)
                 }
                 _ => Value::from_bigint(
-                    Arc::make_mut(bag)
+                    crate::gc::Gc::make_mut(bag)
                         .remove(&idx.to_string_value())
                         .unwrap_or_default(),
                 ),
             },
             Value::Mix(mix, _) => match idx {
                 Value::Array(keys, ..) => {
-                    let m = Arc::make_mut(mix);
+                    let m = crate::gc::Gc::make_mut(mix);
                     let removed = keys
                         .iter()
                         .map(|key| Value::Num(m.remove(&key.to_string_value()).unwrap_or(0.0)))
@@ -583,7 +582,7 @@ impl Interpreter {
                     Value::array(removed)
                 }
                 _ => Value::Num(
-                    Arc::make_mut(mix)
+                    crate::gc::Gc::make_mut(mix)
                         .remove(&idx.to_string_value())
                         .unwrap_or(0.0),
                 ),

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -294,21 +294,21 @@ impl Interpreter {
                                         data.weights.clone(),
                                         typed_keys,
                                     );
-                                    Value::Mix(std::sync::Arc::new(new_data), mutable)
+                                    Value::Mix(crate::gc::Gc::new(new_data), mutable)
                                 }
                                 Value::Bag(data, mutable) => {
                                     let new_data = crate::value::BagData::with_original_keys(
                                         data.counts.clone(),
                                         typed_keys,
                                     );
-                                    Value::Bag(std::sync::Arc::new(new_data), mutable)
+                                    Value::Bag(crate::gc::Gc::new(new_data), mutable)
                                 }
                                 Value::Set(data, mutable) => {
                                     let new_data = crate::value::SetData::with_original_keys(
                                         data.elements.clone(),
                                         typed_keys,
                                     );
-                                    Value::Set(std::sync::Arc::new(new_data), mutable)
+                                    Value::Set(crate::gc::Gc::new(new_data), mutable)
                                 }
                                 other => other,
                             };


### PR DESCRIPTION
Third first-wave `Arc → Gc` container migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11), same recipe as `Value::Hash` (#4113) and `Value::Array` (#4116). `Set`/`Bag`/`Mix` now hold `Gc<SetData>`/`Gc<BagData>`/`Gc<MixData>`, joining the cycle-collector graph.

**Based on #4116** (the Array migration) so the diff here is only the Set/Bag/Mix change; GitHub retargets this to `main` once #4116 merges.

## Behavior-preserving
Uniqueness/COW is judged by the GC-visible strong count (= what `Arc::strong_count` reported before the candidate buffer existed). Candidate buffering only happens under `MUTSU_GC=on` (default off).

## Changes
- `impl Trace for SetData/BagData/MixData` — trace their `original_keys` back-map `Value`s via `Value::gc_trace` (the primary `elements`/`counts`/`weights` maps are string-keyed and hold no `Value`s) + `Value::Set/Bag/Mix` arms in `gc_trace`.
- Mechanical call-site rewrite (~10 files): `Arc::new(SetData/…)` → `Gc::new`, `Arc::{make_mut,ptr_eq,as_ptr,clone}(qh)` → `crate::gc::Gc::…`, `Arc<SetData/BagData/MixData>` annotations → `Gc<…>`.

## Testing
- Set membership / Bag counts / Mix weights / set union verified by hand.
- 24 `gc::` unit tests green; **Miri (Stacked Borrows) green**; `cargo clippy --all-targets -- -D warnings` clean; `make test` green (14076 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)