### PR TITLE
feat(gc): migrate Value::ContainerRef to Gc<Mutex<Value>> (§11 step 5d)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -393,12 +393,15 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
          - 5a. ✅ `Gc<T>` を `Arc<T>` の drop-in 化（`make_mut`/`get_mut`/`ptr_eq`/`strong_count_of`/
            `as_ptr`/`erased`/`From`/`Debug`/`AsRef`/`PartialEq` ＋ free `gc_contents_mut` ＋
            `ContainerMakeMut` bridge trait）。移行を機械的 call-site rewrite に落とす前提工事。
-         - 5b. ✅ `Value::Hash` → `Gc<HashData>`（`impl Trace for HashData` ＋ `Value::gc_trace` Hash arm、
-           49 ファイルの `Arc::*`→`Gc::*` 置換。全 whitelisted hash roast green・container identity 保存）。
-         - 5c. `Value::Array` → `Gc<ArrayData>` ← **次はここ（次セッション開始点）**。5b と同型・約 1400 サイト。
-         - 5d. `Value::ContainerRef` → `Gc<CellValue>`（§3.3、`Arc<Mutex<Value>>` の cell 再設計）。
+         - 5b. ✅ `Value::Hash` → `Gc<HashData>`（`impl Trace for HashData`、49 ファイル。whitelisted hash roast green）。
+         - 5c. ✅ `Value::Array` → `Gc<ArrayData>`（~50 ファイル。**dead 化した `arc_contents_mut` 削除**＝
+           コンテナの生ポインタ書き込みは `gc_contents_mut` 一本に集約）。
+         - 5d. ✅ `Value::ContainerRef(Arc<Mutex<Value>>)` → `Gc<Mutex<Value>>`（`impl Trace for Mutex<Value>`＝
+           self-bind cycle が Gc graph で辿れる。§3.3 の typed-constraint `CellValue` は将来の Track B に延期）。
+         - **→ first wave（Array/Hash/ContainerRef）完了。** `Set`/`Bag`/`Mix` も移行済み（#4117）。
+           残る Arc コンテナは `Sub`/`Instance`/`LazyList`（後続 wave）。
       6〜11. `Promise`/`Channel` → supply registry → safepoint collect（trial-deletion 本体）→
-      `Sub`/`Instance` → `LazyList`（詳細は設計メモ参照）。
+      `Sub`/`Instance` → `LazyList` ← **次はここ**（詳細は設計メモ参照）。
       **Track B（要素 cell 化）と GC は統合キャンペーン（層3a・`Arc → Gc<T>` 一斉置換）**。続いて NaN-boxing
       （層3b・JIT 地ならし）→ JIT（層4）。未決は収集方式（同期/非同期）と A' 地ならしの範囲（ADR §4.2/§4.3）。
 - [ ] 制御フロー（`return`/`last`/`next`/`take`/`emit`）を `RuntimeError` god-struct から `enum Control` へ分離（ANALYSIS §2.4）。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -31,6 +31,29 @@ on Arc）の開発に着手した。[docs/gc-level1-detailed-design.md](../docs/
      `Array`/`Hash`/`ContainerRef` の first wave 置換）。unit test（color 遷移・dedup・inert・
      `Send + Sync`）で担保。
 
+## 2026-07-03: Phase B（GC）first wave 完了 — `Value::Array`（5c）＋ `Value::ContainerRef`（5d）を `Gc` へ移行
+
+Hash（5b）に続き first wave の残り 2 コンテナを移行し、Array/Hash/ContainerRef の `Arc → Gc<T>` 置換
+（ADR-0001 layer 3a の first wave）を完了した。
+
+- **5c. `Value::Array(Arc<ArrayData>)` → `Gc<ArrayData>`**（#4116）: `impl Trace for ArrayData` ＋ `gc_trace`
+  Array arm。~50 ファイル・353→0 コンパイルエラーを型駆動で解消。**dead 化した
+  `value::aliased_mut::arc_contents_mut` を削除**（Array/Hash 両移行で唯一の利用者が消えた）→ コンテナの
+  「共有 Arc 内容への生ポインタ書き込み」（Stacked/Tree Borrows 違反の documented unsound 経路）が消え、
+  `gc_contents_mut` 一本の chokepoint に集約された。
+- **5d. `Value::ContainerRef(Arc<Mutex<Value>>)` → `Gc<Mutex<Value>>`**: `impl Trace for Mutex<Value>`（lock →
+  inner の `gc_trace`）＝ bind cell が Gc graph のノードになり、self-bind cycle（`%h<k> := %h` / `@a[0] := @a`）が
+  collector から辿れる。最小の migration（破壊サイトは構築＋型注釈のみ；215 個の `ContainerRef(` サイトの大半は
+  `.lock()`/match で `Gc` deref のまま不変）。sed が非 Value な `Mutex<String>`/`Mutex<Option<ChildStdin>>`/
+  `Mutex<HashMap>` を巻き込んだ 4 箇所は個別に revert。§3.3 の typed-constraint `CellValue` 化は将来の Track B に延期
+  （現状 ContainerRef は型制約を持たないため `Gc<Mutex<Value>>` が忠実な 1:1）。
+
+検証: 両スライスとも `make test` = Result: PASS（1459ファイル/14076テスト）。5c は全 whitelisted array roast、
+5d は全 S03-binding roast（scalars/arrays/hashes/nested/ro/closure）green。binding 意味論（`:=`・要素 bind・
+`=:=` identity・rw param・cross-thread shared push）保存。`Set`/`Bag`/`Mix` も並行 PR #4117 で移行済み。残る Arc
+コンテナは `Sub`/`Instance`（後続 wave）・`LazyList`（third wave）。次は §11 step 6+（`Promise`/`Channel` →
+supply registry → safepoint collect の trial-deletion 本体）。
+
 ## 2026-07-03: Phase B（GC）first wave 着手 — `Value::Hash` を `Gc<HashData>` へ移行（§11 step 5）
 
 step 4（`Gc<T>` 基盤）に続き、ADR-0001 layer 3a の first wave（コンテナ系 `Arc → Gc<T>` 一斉置換）を

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -17,12 +17,15 @@
 //!   with surviving handles records it as a possible cycle root (§4.2 / §5.2).
 //!
 //! State of the migration (§11 step 5):
-//! - `Value::Hash` is the first variant migrated to `Gc<HashData>` (step 5b), so
-//!   `Gc`'s `Clone`/`Drop`/`make_mut`/... run in production now. Candidate
-//!   buffering still only happens under `MUTSU_GC=on` (default off), so ordinary
-//!   runs pay just an atomic refcount op per hash clone/drop and push nothing.
-//! - `Array`/`ContainerRef` (steps 5c/5d) remain `Arc`; the [`ContainerMakeMut`]
-//!   bridge lets shared container macros work across the mixed state meanwhile.
+//! - The whole first wave is migrated to `Gc<_>`: `Value::Hash` → `Gc<HashData>`
+//!   (5b), `Value::Array` → `Gc<ArrayData>` (5c), `Value::ContainerRef` →
+//!   `Gc<Mutex<Value>>` (5d). So `Gc`'s `Clone`/`Drop`/`make_mut`/... run in
+//!   production. Candidate buffering still only happens under `MUTSU_GC=on`
+//!   (default off), so ordinary runs pay just an atomic refcount op per
+//!   container clone/drop and push nothing.
+//! - `Set`/`Bag`/`Mix` are also `Gc<_>` now (#4117). `Sub`/`Instance`/`LazyList`
+//!   remain `Arc` (later waves); the [`ContainerMakeMut`] bridge lets shared
+//!   container macros work across the still-mixed state meanwhile.
 //! - No trial-deletion reclaim runs. [`drain_candidates`] hands the buffered
 //!   nodes to a future synchronous collector (§11 step 8); until then the
 //!   `Color`/strong-count bookkeeping is maintained but never acted on.

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -8,10 +8,10 @@
 //!   `Interpreter::visit_roots` / `Env::visit_values` to enumerate every
 //!   `Value` reachable from execution state (§11 steps 1-2).
 //! - [`gc_ptr`] — [`Gc<T>`], its Bacon-Rajan node header, the [`Trace`] trait,
-//!   and the process-global cycle-candidate buffer (§11 step 4). `Value::Hash`
-//!   is migrated to `Gc<HashData>` (§11 step 5b, first wave); `Array`/
-//!   `ContainerRef` follow (§11 steps 5c/5d). No trial-deletion reclaim runs
-//!   yet (§11 step 8); candidate buffering is off unless `MUTSU_GC=on`.
+//!   and the process-global cycle-candidate buffer (§11 step 4). The first wave
+//!   is migrated to `Gc<_>`: `Value::Hash` (5b), `Value::Array` (5c),
+//!   `Value::ContainerRef` (5d). No trial-deletion reclaim runs yet (§11 step
+//!   8); candidate buffering is off unless `MUTSU_GC=on`.
 
 mod gc_ptr;
 mod root_visitor;

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -224,7 +224,7 @@ impl Interpreter {
         block: &Value,
         leaf: &Value,
     ) -> Result<(Value, Value), RuntimeError> {
-        let cell = std::sync::Arc::new(std::sync::Mutex::new(leaf.clone()));
+        let cell = crate::gc::Gc::new(std::sync::Mutex::new(leaf.clone()));
         let res = self.call_sub_value(
             block.clone(),
             vec![Value::ContainerRef(cell.clone())],

--- a/src/runtime/builtins_system_run.rs
+++ b/src/runtime/builtins_system_run.rs
@@ -176,7 +176,10 @@ impl Interpreter {
                     let in_pipe = if let Some(stdin) = stdin_handle {
                         // Store in proc_stdin_map for .print/.close
                         if let Ok(mut map) = super::native_methods::proc_stdin_map().lock() {
-                            map.insert(pid as u32, Arc::new(std::sync::Mutex::new(Some(stdin))));
+                            map.insert(
+                                pid as u32,
+                                std::sync::Arc::new(std::sync::Mutex::new(Some(stdin))),
+                            );
                         }
                         let mut in_attrs = HashMap::new();
                         in_attrs.insert("proc-pid".to_string(), Value::Int(pid));

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -315,7 +315,7 @@ impl Interpreter {
                 for &i in &indices {
                     let cell = match &promoted[i] {
                         v @ Value::ContainerRef(_) => v.clone(),
-                        other => Value::ContainerRef(std::sync::Arc::new(std::sync::Mutex::new(
+                        other => Value::ContainerRef(crate::gc::Gc::new(std::sync::Mutex::new(
                             other.clone(),
                         ))),
                     };

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -239,7 +239,7 @@ impl Interpreter {
         // variable's own value — matches `needle`. Write the replacement THROUGH
         // the cell (never replace the var's value, which would sever the share)
         // so every alias of the cell observes the element write.
-        let mut cells: Vec<std::sync::Arc<std::sync::Mutex<Value>>> = Vec::new();
+        let mut cells: Vec<crate::gc::Gc<std::sync::Mutex<Value>>> = Vec::new();
         for (name, value) in self.env.iter() {
             match value {
                 Value::Array(existing, ..) if crate::gc::Gc::ptr_eq(existing, needle) => {
@@ -277,7 +277,7 @@ impl Interpreter {
         replacement: Value,
     ) {
         let mut keys: Vec<Symbol> = Vec::new();
-        let mut cells: Vec<std::sync::Arc<std::sync::Mutex<Value>>> = Vec::new();
+        let mut cells: Vec<crate::gc::Gc<std::sync::Mutex<Value>>> = Vec::new();
         for (name, value) in self.env.iter() {
             match value {
                 Value::Hash(existing) if crate::gc::Gc::ptr_eq(existing, needle) => {

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -600,7 +600,7 @@ fn tcp_stream_map() -> &'static TcpStreamMap {
 
 pub(in crate::runtime) fn register_tcp_stream(conn_id: u64, stream: TcpStream) {
     if let Ok(mut map) = tcp_stream_map().lock() {
-        map.insert(conn_id, Arc::new(std::sync::Mutex::new(stream)));
+        map.insert(conn_id, std::sync::Arc::new(std::sync::Mutex::new(stream)));
     }
 }
 

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -261,7 +261,7 @@ impl Interpreter {
 
                 // Store stdin in global registry if piped
                 if let Some(stdin) = child.stdin.take() {
-                    let stdin_arc = Arc::new(std::sync::Mutex::new(Some(stdin)));
+                    let stdin_arc = std::sync::Arc::new(std::sync::Mutex::new(Some(stdin)));
                     if w_flag && let Ok(mut map) = proc_stdin_map().lock() {
                         map.insert(pid, stdin_arc.clone());
                     }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -941,7 +941,7 @@ impl Interpreter {
                                 })
                                 .filter(|s| s.starts_with('@') || s.starts_with('%'))
                         {
-                            bound_value = Value::ContainerRef(std::sync::Arc::new(
+                            bound_value = Value::ContainerRef(crate::gc::Gc::new(
                                 std::sync::Mutex::new(bound_value),
                             ));
                             rw_bindings.push((pd.name.clone(), source_name));
@@ -1679,9 +1679,9 @@ impl Interpreter {
                             && let Some(source_name) = &source_name
                             && (source_name.starts_with('@') || source_name.starts_with('%'))
                         {
-                            value = Value::ContainerRef(std::sync::Arc::new(
-                                std::sync::Mutex::new(value),
-                            ));
+                            value = Value::ContainerRef(crate::gc::Gc::new(std::sync::Mutex::new(
+                                value,
+                            )));
                             rw_bindings.push((pd.name.clone(), source_name.clone()));
                         }
                         self.bind_param_value(&pd.name, value);

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -294,7 +294,7 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
 /// fall back to the normal value identity rules.
 fn capture_elem_identical(a: &Value, b: &Value) -> bool {
     match (a, b) {
-        (Value::ContainerRef(x), Value::ContainerRef(y)) => std::sync::Arc::ptr_eq(x, y),
+        (Value::ContainerRef(x), Value::ContainerRef(y)) => crate::gc::Gc::ptr_eq(x, y),
         (Value::ContainerRef(_), _) | (_, Value::ContainerRef(_)) => false,
         _ => values_identical(a, b),
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -441,8 +441,8 @@ fn typed_container_constraints() -> &'static Mutex<HashMap<usize, String>> {
 }
 
 /// Record that the `ContainerRef` cell `cell` has the `of`-type `type_name`.
-pub fn register_container_constraint(cell: &Arc<Mutex<Value>>, type_name: &str) {
-    let ptr = Arc::as_ptr(cell) as usize;
+pub fn register_container_constraint(cell: &crate::gc::Gc<Mutex<Value>>, type_name: &str) {
+    let ptr = crate::gc::Gc::as_ptr(cell) as usize;
     typed_container_constraints()
         .lock()
         .unwrap()
@@ -450,8 +450,8 @@ pub fn register_container_constraint(cell: &Arc<Mutex<Value>>, type_name: &str) 
 }
 
 /// Look up the `of`-type constraint of a `ContainerRef` cell, if any.
-pub fn lookup_container_constraint(cell: &Arc<Mutex<Value>>) -> Option<String> {
-    let ptr = Arc::as_ptr(cell) as usize;
+pub fn lookup_container_constraint(cell: &crate::gc::Gc<Mutex<Value>>) -> Option<String> {
+    let ptr = crate::gc::Gc::as_ptr(cell) as usize;
     typed_container_constraints()
         .lock()
         .unwrap()
@@ -1039,7 +1039,7 @@ pub enum Value {
     Scalar(Box<Value>),
     /// A shared mutable Scalar container for `:=` binding.
     /// Two variables bound together share the same `ContainerRef`.
-    ContainerRef(Arc<Mutex<Value>>),
+    ContainerRef(Gc<Mutex<Value>>),
     /// A lazy thunk: wraps a Sub that is evaluated on first access and cached.
     /// Used by `lazy { ... }` statement prefix.
     LazyThunk(Arc<LazyThunkData>),
@@ -1467,7 +1467,7 @@ mod hash_chokepoint_tests {
         // A `:=`-bound element holds a shared `ContainerRef` cell; a later
         // assignment to the key must write *through* the cell (preserving the
         // binding), not replace the entry with a bare value.
-        let cell = Arc::new(Mutex::new(Value::Int(1)));
+        let cell = crate::gc::Gc::new(Mutex::new(Value::Int(1)));
         let mut map = HashMap::new();
         map.insert("k".to_string(), Value::ContainerRef(cell.clone()));
         Value::hash_insert_through(&mut map, "k".to_string(), Value::Int(99));

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -311,7 +311,7 @@ impl PartialEq for Value {
             // ContainerRef: deref and compare inner values.
             // Check Arc pointer identity first to avoid deadlock on same-Arc comparison.
             (Value::ContainerRef(a), Value::ContainerRef(b)) => {
-                if Arc::ptr_eq(a, b) {
+                if crate::gc::Gc::ptr_eq(a, b) {
                     return true;
                 }
                 let a_val = a.lock().unwrap().clone();

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -16,6 +16,8 @@
 //! `Junction` is likewise not in the design doc's candidate list and is
 //! excluded.
 
+use std::sync::Mutex;
+
 use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
 use super::{
@@ -34,14 +36,14 @@ impl Value {
     /// edge that bypasses the Gc graph until it too migrates — acceptable while
     /// the collector is off (design doc §3.1's wave phasing).
     pub(crate) fn gc_trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
-        // Only migrated (`Gc<T>`) container variants yield a child; more arms
-        // land as further types migrate (§11 5d: `ContainerRef`, ...).
+        // Only migrated (`Gc<T>`) container variants yield a child.
         match self {
             Value::Hash(data) => visit(&data.erased()),
             Value::Array(data, _) => visit(&data.erased()),
             Value::Set(data, _) => visit(&data.erased()),
             Value::Bag(data, _) => visit(&data.erased()),
             Value::Mix(data, _) => visit(&data.erased()),
+            Value::ContainerRef(cell) => visit(&cell.erased()),
             _ => {}
         }
     }
@@ -76,6 +78,17 @@ impl Trace for MixData {
             for v in keys.values() {
                 v.gc_trace(visit);
             }
+        }
+    }
+}
+
+impl Trace for Mutex<Value> {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        // The bind cell's inner value is the single edge out of a `ContainerRef`
+        // node — this is what makes self-binding cycles (`%h<k> := %h`,
+        // `@a[0] := @a`) reachable through the Gc graph.
+        if let Ok(inner) = self.lock() {
+            inner.gc_trace(visit);
         }
     }
 }
@@ -280,7 +293,7 @@ mod tests {
 
     #[test]
     fn container_ref_visits_its_locked_value() {
-        let cell = Value::ContainerRef(Arc::new(std::sync::Mutex::new(Value::Int(7))));
+        let cell = Value::ContainerRef(crate::gc::Gc::new(std::sync::Mutex::new(Value::Int(7))));
         let mut visitor = CountingVisitor { count: 0 };
         cell.visit_gc_children(&mut visitor);
         assert_eq!(visitor.count, 1);

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -243,7 +243,7 @@ impl Value {
 
     /// Create a new shared container holding this value.
     pub fn into_container_ref(self) -> Value {
-        Value::ContainerRef(Arc::new(Mutex::new(self)))
+        Value::ContainerRef(crate::gc::Gc::new(Mutex::new(self)))
     }
 
     /// Assign `val` into an array/hash element `slot`. When the slot already
@@ -340,7 +340,7 @@ impl Value {
                 Some(Value::ContainerRef(cell)) => Some(Value::ContainerRef(cell.clone())),
                 Some(elem @ (Value::Array(..) | Value::Hash(..))) => Some(elem.clone()),
                 Some(elem) => {
-                    let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
+                    let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
                     *elem = Value::ContainerRef(cell.clone());
                     Some(Value::ContainerRef(cell))
                 }
@@ -388,7 +388,7 @@ impl Value {
                     Some(elem.clone())
                 }
                 Some(elem) => {
-                    let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
+                    let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
                     *elem = Value::ContainerRef(cell.clone());
                     Some(Value::ContainerRef(cell))
                 }

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -61,7 +61,7 @@ impl Value {
             if !terminal && matches!(elem, Value::Array(..) | Value::Hash(..)) {
                 return Some(elem.clone());
             }
-            let cell = Arc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
+            let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
             *elem = Value::ContainerRef(cell.clone());
             Some(Value::ContainerRef(cell))
         } else {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1279,7 +1279,8 @@ impl Interpreter {
                             let cell = match self.env().get(&var_name) {
                                 Some(Value::ContainerRef(cell)) => cell.clone(),
                                 _ => {
-                                    let cell = Arc::new(std::sync::Mutex::new(value.clone()));
+                                    let cell =
+                                        crate::gc::Gc::new(std::sync::Mutex::new(value.clone()));
                                     bind_source_install =
                                         Some((var_name, Value::ContainerRef(cell.clone())));
                                     cell
@@ -1317,7 +1318,8 @@ impl Interpreter {
                             let cell = match self.env().get(&var_name) {
                                 Some(Value::ContainerRef(cell)) => cell.clone(),
                                 _ => {
-                                    let cell = Arc::new(std::sync::Mutex::new(value.clone()));
+                                    let cell =
+                                        crate::gc::Gc::new(std::sync::Mutex::new(value.clone()));
                                     bind_source_install =
                                         Some((var_name, Value::ContainerRef(cell.clone())));
                                     cell
@@ -1410,7 +1412,7 @@ impl Interpreter {
                     let cell = match self.env().get(&source_var) {
                         Some(Value::ContainerRef(cell)) => cell.clone(),
                         _ => {
-                            let cell = Arc::new(std::sync::Mutex::new(value.clone()));
+                            let cell = crate::gc::Gc::new(std::sync::Mutex::new(value.clone()));
                             bind_source_install =
                                 Some((source_var, Value::ContainerRef(cell.clone())));
                             cell

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -132,7 +132,7 @@ impl Interpreter {
         if let (Some(Value::ContainerRef(l)), Some(Value::ContainerRef(r))) = (
             self.raw_element_at_encoded(left_source),
             self.raw_element_at_encoded(right_source),
-        ) && Arc::ptr_eq(&l, &r)
+        ) && crate::gc::Gc::ptr_eq(&l, &r)
         {
             self.stack.push(Value::Bool(true));
             return;
@@ -162,7 +162,7 @@ impl Interpreter {
         // checked here, not in `values_identical`, which `===` uses to compare
         // *values* and therefore must read through a cell.)
         match (a, b) {
-            (Value::ContainerRef(x), Value::ContainerRef(y)) => return Arc::ptr_eq(x, y),
+            (Value::ContainerRef(x), Value::ContainerRef(y)) => return crate::gc::Gc::ptr_eq(x, y),
             (Value::ContainerRef(cell), other) | (other, Value::ContainerRef(cell)) => {
                 // A `:=`-bound hash element is promoted to a `ContainerRef` cell
                 // (Phase 2 Stage 1). The OTHER side may still be a HashEntryRef
@@ -175,7 +175,7 @@ impl Interpreter {
                     if let Some(Value::ContainerRef(elem_cell)) =
                         unsafe { (*ptr).get(key.as_str()) }
                     {
-                        return Arc::ptr_eq(cell, elem_cell);
+                        return crate::gc::Gc::ptr_eq(cell, elem_cell);
                     }
                 }
                 return false;

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -83,7 +83,7 @@ impl Interpreter {
                     _ => None,
                 });
             let cell = existing_cell.unwrap_or_else(|| {
-                let cell = std::sync::Arc::new(std::sync::Mutex::new(val.clone()));
+                let cell = crate::gc::Gc::new(std::sync::Mutex::new(val.clone()));
                 let cell_val = Value::ContainerRef(cell.clone());
                 self.set_env_with_main_alias(&src_name, cell_val.clone());
                 self.update_local_if_exists(code, &src_name, &cell_val);

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1443,7 +1443,7 @@ impl Interpreter {
                 // value (e.g. into a Pair value) and is enforced on assignment.
                 let type_name = Self::const_str(code, *type_idx).to_string();
                 let val = self.stack.pop().unwrap_or(Value::Nil);
-                let cell = std::sync::Arc::new(std::sync::Mutex::new(val));
+                let cell = crate::gc::Gc::new(std::sync::Mutex::new(val));
                 crate::value::register_container_constraint(&cell, &type_name);
                 self.stack.push(Value::ContainerRef(cell));
                 *ip += 1;

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -5,7 +5,7 @@ impl Interpreter {
     /// (`undefine @ary` where `my $r = @ary` promoted `@ary` to a cell). Uses
     /// `Arc::make_mut` so a copy taken out of the cell (`my @copy = @ary`) is
     /// detached rather than emptied; every alias of the cell observes the clear.
-    pub(super) fn clear_aggregate_cell(cell: &std::sync::Arc<std::sync::Mutex<Value>>) {
+    pub(super) fn clear_aggregate_cell(cell: &crate::gc::Gc<std::sync::Mutex<Value>>) {
         let mut guard = cell.lock().unwrap();
         match &mut *guard {
             Value::Array(arc, _) => crate::gc::Gc::make_mut(arc).items.clear(),

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1529,7 +1529,7 @@ pub(crate) fn cheaply_unchanged(old: &Value, new: &Value) -> bool {
         // (and `merge_method_env` over-signalled env_dirty for a method that
         // returned the same cell). Same Arc => genuinely unchanged; distinct Arcs
         // stay "changed" (conservative).
-        (Value::ContainerRef(a), Value::ContainerRef(b)) => Arc::ptr_eq(a, b),
+        (Value::ContainerRef(a), Value::ContainerRef(b)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Instance { id: a, .. }, Value::Instance { id: b, .. }) => a == b,
         _ => false,
     }
@@ -1627,7 +1627,7 @@ mod cheaply_unchanged_tests {
         // (same Arc) must report "unchanged" so the reverse-sync survey does not
         // count a bound container as effective stale, and `merge_method_env` does
         // not over-signal env_dirty for a method returning the same cell.
-        let cell = Arc::new(Mutex::new(Value::array(vec![Value::Int(1)])));
+        let cell = crate::gc::Gc::new(Mutex::new(Value::array(vec![Value::Int(1)])));
         let a = Value::ContainerRef(cell.clone());
         let b = Value::ContainerRef(cell);
         assert!(cheaply_unchanged(&a, &b));
@@ -1637,8 +1637,12 @@ mod cheaply_unchanged_tests {
     fn container_ref_distinct_cells_are_changed() {
         // Distinct cells (even with equal contents) stay "changed" — the test is
         // conservative Arc identity, never deep value equality.
-        let a = Value::ContainerRef(Arc::new(Mutex::new(Value::array(vec![Value::Int(1)]))));
-        let b = Value::ContainerRef(Arc::new(Mutex::new(Value::array(vec![Value::Int(1)]))));
+        let a = Value::ContainerRef(crate::gc::Gc::new(Mutex::new(Value::array(vec![
+            Value::Int(1),
+        ]))));
+        let b = Value::ContainerRef(crate::gc::Gc::new(Mutex::new(Value::array(vec![
+            Value::Int(1),
+        ]))));
         assert!(!cheaply_unchanged(&a, &b));
     }
 }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -508,7 +508,7 @@ impl Interpreter {
             Value::ContainerRef(arc) => arc.clone(),
             _ => match self.env().get(&resolved_source) {
                 Some(Value::ContainerRef(arc)) => arc.clone(),
-                _ => std::sync::Arc::new(std::sync::Mutex::new(val.clone())),
+                _ => crate::gc::Gc::new(std::sync::Mutex::new(val.clone())),
             },
         };
         let container = Value::ContainerRef(cell);

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::sync::Arc;
 
 impl Interpreter {
     /// Assign a single value into a stack-computed Hash/Array `target` at `key`
@@ -61,7 +60,7 @@ impl Interpreter {
                 let Some((arc, key)) = token.hash_entry_terminal() else {
                     return false;
                 };
-                let cell = Arc::new(std::sync::Mutex::new(val));
+                let cell = crate::gc::Gc::new(std::sync::Mutex::new(val));
                 // SAFETY: aliased in-place mutation of a shared hash; see
                 // `arc_contents_mut`. No live borrow into the map.
                 let hd = unsafe { crate::value::gc_contents_mut(&arc) };

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -3,7 +3,7 @@ use crate::symbol::Symbol;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-type BindSourceCell = (Option<String>, Arc<std::sync::Mutex<Value>>);
+type BindSourceCell = (Option<String>, crate::gc::Gc<std::sync::Mutex<Value>>);
 
 /// A flat slice-assign key (`@a[1,(lazy 3,4,5)] = ...`), pre-resolved so the
 /// mutable-container recursion below never needs `&mut self` (a nested key's
@@ -944,7 +944,7 @@ impl Interpreter {
                                 Some(Value::ContainerRef(cell)) => Some((None, cell.clone())),
                                 _ => Some((
                                     Some(source_name.clone()),
-                                    Arc::new(std::sync::Mutex::new(v)),
+                                    crate::gc::Gc::new(std::sync::Mutex::new(v)),
                                 )),
                             }
                         } else {
@@ -953,8 +953,10 @@ impl Interpreter {
                         slice_bind_cells.push(entry);
                     }
                 }
-                let mut pending_source_cells: Vec<(String, Arc<std::sync::Mutex<Value>>)> =
-                    Vec::new();
+                let mut pending_source_cells: Vec<(
+                    String,
+                    crate::gc::Gc<std::sync::Mutex<Value>>,
+                )> = Vec::new();
                 if let Some(Value::Hash(hash)) = self.env_mut().get_mut(&var_name) {
                     let h = crate::gc::Gc::make_mut(hash);
                     for (i, key) in keys.iter().enumerate() {
@@ -1224,7 +1226,10 @@ impl Interpreter {
                 // Phase 2 Stage 2: a single-level element bind (`@a[i] := ...`,
                 // `%h<k> := ...`) stores a shared `ContainerRef` cell. The cell
                 // is written back to the source var after the write completes.
-                let mut pending_source_cell: Option<(String, Arc<std::sync::Mutex<Value>>)> = None;
+                let mut pending_source_cell: Option<(
+                    String,
+                    crate::gc::Gc<std::sync::Mutex<Value>>,
+                )> = None;
                 // Whether the bind stored a shared cell at the element (skips
                 // the bound-index side table — the cell IS the alias).
                 let mut stored_bind_cell = false;
@@ -1246,7 +1251,7 @@ impl Interpreter {
                             Some(Value::ContainerRef(cell)) => Some((None, cell.clone())),
                             _ => Some((
                                 Some(source_name.clone()),
-                                Arc::new(std::sync::Mutex::new(val.clone())),
+                                crate::gc::Gc::new(std::sync::Mutex::new(val.clone())),
                             )),
                         }
                     } else {
@@ -2326,9 +2331,9 @@ impl Interpreter {
         // the old `BOUND_ARRAY_REF_SENTINEL` by-name back-reference lost at depth.
         let (val, bind_source) = Self::unwrap_bind_index_value(val);
         let bind_source = bind_source.filter(|s| !s.contains("\x00idx\x00"));
-        let bind_cell: Option<Arc<std::sync::Mutex<Value>>> = bind_source
+        let bind_cell: Option<crate::gc::Gc<std::sync::Mutex<Value>>> = bind_source
             .as_ref()
-            .map(|_| Arc::new(std::sync::Mutex::new(val.clone())));
+            .map(|_| crate::gc::Gc::new(std::sync::Mutex::new(val.clone())));
 
         // Extract positional flags from constant
         let flags_val = code.constants[positional_flags_idx as usize].clone();
@@ -2597,7 +2602,7 @@ impl Interpreter {
                 Some(Value::ContainerRef(cell)) => Some((None, cell.clone())),
                 _ => Some((
                     Some(source_name.clone()),
-                    Arc::new(std::sync::Mutex::new(val.clone())),
+                    crate::gc::Gc::new(std::sync::Mutex::new(val.clone())),
                 )),
             }
         } else {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1094,7 +1094,7 @@ impl Interpreter {
                     Value::ContainerRef(arc) => arc.clone(),
                     _ => match self.env().get(&effective_source) {
                         Some(Value::ContainerRef(arc)) => arc.clone(),
-                        _ => std::sync::Arc::new(std::sync::Mutex::new(val.clone())),
+                        _ => crate::gc::Gc::new(std::sync::Mutex::new(val.clone())),
                     },
                 };
                 // A bound `@`/`%` variable adopts the *source* container's

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -644,7 +644,7 @@ impl Interpreter {
     /// caller falls back to the (non-atomic) smart path.
     pub(super) fn atomic_container_incdec(
         &mut self,
-        arc: &std::sync::Arc<std::sync::Mutex<Value>>,
+        arc: &crate::gc::Gc<std::sync::Mutex<Value>>,
         name: &str,
         increment: bool,
         post: bool,


### PR DESCRIPTION
Final first-wave `Arc → Gc<T>` container migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11 step 5d). `Value::ContainerRef` — the shared `:=` bind cell — moves from `Arc<Mutex<Value>>` to `Gc<Mutex<Value>>`, so bind cells become Gc graph nodes and self-binding cycles (`%h<k> := %h`, `@a[0] := @a`) are reachable through the collector.

### What lands
- `impl Trace for Mutex<Value>` (lock → `inner.gc_trace`) + a `ContainerRef` arm in `Value::gc_trace`. The inner value is the single edge out of a `ContainerRef` node.
- **Smallest** of the first-wave migrations: only the `Arc::new(Mutex::new(..))` constructions and `Arc<Mutex<Value>>` type annotations break; the 215 `ContainerRef(` sites are mostly `.lock()` / match arms that keep working through `Gc`'s `Deref`. Global seds handled constructions + types; 4 non-`Value` Mutex sites the seds over-reached (`Mutex<String>` / `Mutex<Option<ChildStdin>>` / `Mutex<HashMap>`) were reverted individually.
- §3.3's typed-constraint `CellValue` is deferred to a future Track B refinement: `ContainerRef` carries no type constraint today, so `Gc<Mutex<Value>>` is the faithful 1:1 translation.

### Verification
- `make test` = **Result: PASS** (1459 files, 14076 tests, no non-flaky failures).
- All `S03-binding` roast tests pass (scalars/arrays/hashes/nested/ro/closure); binding semantics — `:=`, element bind, `=:=` identity, `is rw` params, cross-thread shared push — all preserved.
- `cargo clippy -- -D warnings` clean.

Rebased onto main after the parallel #4117 (Set/Bag/Mix → Gc) landed; merged the additive `gc_trace` arms and `Trace` impls. With this + #4117, the whole first wave (Array/Hash/Set/Bag/Mix/ContainerRef) is `Gc`; `Sub`/`Instance`/`LazyList` remain `Arc` for later waves. Next: §11 step 6+ (Promise/Channel → supply registry → the synchronous trial-deletion collector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)