### PR TITLE
GC step 9: migrate Value::Sub + Instance attributes to Gc (second wave)

### DIFF
--- a/src/builtins/buf_write_int.rs
+++ b/src/builtins/buf_write_int.rs
@@ -7,7 +7,6 @@
 
 use crate::symbol::Symbol;
 use crate::value::{InstanceAttrs, RuntimeError, Value};
-use std::sync::Arc;
 
 /// Returns Some((byte_size, is_signed)) if the method is a write-int/uint method.
 pub(crate) fn write_int_info(method: &str) -> Option<(usize, bool)> {
@@ -129,7 +128,7 @@ pub(crate) fn apply_write_int(
 /// The shared attribute cell of a Buf *instance* receiver, captured so a write can be
 /// committed straight back into it (propagating to every binding sharing the same buf).
 struct BufWriteCell<'a> {
-    attributes: &'a Arc<InstanceAttrs>,
+    attributes: &'a crate::gc::Gc<InstanceAttrs>,
     class_sym: Symbol,
     id: u64,
 }

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -142,7 +142,7 @@ pub(super) fn dispatch(
                     // Clone the sub with a new id so state variables are independent
                     let mut new_data = (**data).clone();
                     new_data.id = crate::value::next_instance_id();
-                    Some(Some(Ok(Value::Sub(Arc::new(new_data)))))
+                    Some(Some(Ok(Value::Sub(crate::gc::Gc::new(new_data)))))
                 }
                 Value::Pair(key, value) => {
                     Some(Some(Ok(Value::Pair(key.clone(), Box::new(*value.clone())))))

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -833,7 +833,7 @@ fn format_temporal_num(f: f64) -> String {
 /// Render a `Backtrace::Frame` instance as its `.Str`/`.gist` text.
 /// Shared by the frame's `.Str` handler and by `Backtrace.concise`/`.summary`
 /// so the natively-computed strings stay byte-identical to a `.grep(...).join`.
-fn backtrace_frame_str(attributes: &std::sync::Arc<crate::value::InstanceAttrs>) -> String {
+fn backtrace_frame_str(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> String {
     let map = attributes.as_map();
     let subname = map
         .get("subname")
@@ -856,7 +856,7 @@ fn backtrace_frame_str(attributes: &std::sync::Arc<crate::value::InstanceAttrs>)
 
 /// A `Backtrace::Frame` is a "routine" frame when it has a real subname
 /// (not the synthetic `<unit>` bottom frame and not an anonymous block).
-fn backtrace_frame_is_routine(attributes: &std::sync::Arc<crate::value::InstanceAttrs>) -> bool {
+fn backtrace_frame_is_routine(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> bool {
     let subname = attributes
         .as_map()
         .get("subname")
@@ -900,12 +900,12 @@ pub(crate) fn unicode_foldcase(s: &str) -> String {
 }
 
 fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeError>> {
-    fn has_date_attrs(attributes: &std::sync::Arc<crate::value::InstanceAttrs>) -> bool {
+    fn has_date_attrs(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> bool {
         attributes.contains_key("year")
             && attributes.contains_key("month")
             && attributes.contains_key("day")
     }
-    fn has_datetime_attrs(attributes: &std::sync::Arc<crate::value::InstanceAttrs>) -> bool {
+    fn has_datetime_attrs(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> bool {
         has_date_attrs(attributes)
             && attributes.contains_key("hour")
             && attributes.contains_key("minute")

--- a/src/builtins/methods_narg/buf.rs
+++ b/src/builtins/methods_narg/buf.rs
@@ -43,10 +43,7 @@ pub(crate) fn make_buf_from_int_items(class_name: &str, items: &[Value]) -> Valu
     Value::make_instance(Symbol::intern(class_name), attrs)
 }
 
-pub(crate) fn eval_whatever_code(
-    sub_data: &std::sync::Arc<crate::value::SubData>,
-    arg: i64,
-) -> i64 {
+pub(crate) fn eval_whatever_code(sub_data: &crate::gc::Gc<crate::value::SubData>, arg: i64) -> i64 {
     let param = sub_data
         .params
         .first()

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -146,6 +146,53 @@ pub(crate) struct Gc<T: Trace + 'static> {
     inner: Arc<GcBox<T>>,
 }
 
+/// A non-owning handle to a `Gc` node — the `Gc` analogue of `std::sync::Weak`,
+/// backing `Value::WeakSub`. Does not keep the node alive; `upgrade` returns a
+/// live [`Gc`] handle (a new strong reference) only while the node still exists.
+pub(crate) struct WeakGc<T: Trace + 'static> {
+    inner: std::sync::Weak<GcBox<T>>,
+}
+
+impl<T: Trace + 'static> WeakGc<T> {
+    /// Reconstitute a strong [`Gc`] handle if the node is still alive. Bumps the
+    /// GC-visible strong count and marks the node live (`Black`) — upgrading a
+    /// weak reference *is* taking a new temporary strong reference.
+    /// Whether two weak handles point at the same node (`Weak::ptr_eq`), for
+    /// `Value::WeakSub` identity comparison.
+    pub(crate) fn ptr_eq(a: &WeakGc<T>, b: &WeakGc<T>) -> bool {
+        std::sync::Weak::ptr_eq(&a.inner, &b.inner)
+    }
+
+    pub(crate) fn upgrade(&self) -> Option<Gc<T>> {
+        self.inner.upgrade().map(|arc| {
+            arc.header.strong.fetch_add(1, Ordering::Relaxed);
+            arc.header
+                .color
+                .store(Color::Black as u8, Ordering::Relaxed);
+            Gc { inner: arc }
+        })
+    }
+}
+
+impl<T: Trace + 'static> Clone for WeakGc<T> {
+    fn clone(&self) -> Self {
+        WeakGc {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: Trace + std::fmt::Debug + 'static> std::fmt::Debug for WeakGc<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WeakGc(..)")
+    }
+}
+
+// A weak handle carries no `T` by value, so it is `Send + Sync` on the backing
+// `Weak`'s own guarantees (mirroring `Value::WeakSub`'s old `Weak<SubData>`).
+unsafe impl<T: Trace + 'static> Send for WeakGc<T> {}
+unsafe impl<T: Trace + 'static> Sync for WeakGc<T> {}
+
 impl<T: Trace + 'static> Gc<T> {
     /// Allocate a new managed node holding `value`, with one live handle.
     pub(crate) fn new(value: T) -> Gc<T> {
@@ -154,6 +201,14 @@ impl<T: Trace + 'static> Gc<T> {
                 header: GcHeader::fresh(),
                 value,
             }),
+        }
+    }
+
+    /// A non-owning [`WeakGc`] handle to this node (the `Gc` analogue of
+    /// `Arc::downgrade`), for `Value::WeakSub`.
+    pub(crate) fn downgrade(this: &Gc<T>) -> WeakGc<T> {
+        WeakGc {
+            inner: std::sync::Arc::downgrade(&this.inner),
         }
     }
 

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -24,6 +24,7 @@ mod root_visitor;
 pub(crate) use collect::{CollectStats, collect_cycles, gc_debug_collect_now};
 #[allow(unused_imports)]
 pub(crate) use gc_ptr::{
-    Color, ContainerMakeMut, ErasedGc, Gc, Trace, drain_candidates, gc_contents_mut, gc_enabled,
+    Color, ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, drain_candidates, gc_contents_mut,
+    gc_enabled,
 };
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -322,7 +322,7 @@ impl Interpreter {
             if empty_sig && let Value::Sub(ref data) = sub_val {
                 let mut new_data = (**data).clone();
                 new_data.empty_sig = true;
-                sub_val = Value::Sub(Arc::new(new_data));
+                sub_val = Value::Sub(crate::gc::Gc::new(new_data));
             }
             sub_val
         } else if Self::is_builtin_function(lookup_name) {

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -260,7 +260,7 @@ impl Interpreter {
     pub(super) fn self_attr_cell_target(
         &self,
         name: &str,
-    ) -> Option<(std::sync::Arc<crate::value::InstanceAttrs>, String)> {
+    ) -> Option<(crate::gc::Gc<crate::value::InstanceAttrs>, String)> {
         let bare = name.strip_prefix('!').or_else(|| name.strip_prefix('.'))?;
         if !bare
             .chars()

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -122,7 +122,7 @@ impl Interpreter {
             new_data.env.remove("!");
             new_data.env.remove("$/");
             new_data.env.remove("$!");
-            Value::Sub(std::sync::Arc::new(new_data))
+            Value::Sub(crate::gc::Gc::new(new_data))
         } else {
             block
         };

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1942,7 +1942,7 @@ impl Interpreter {
             attrs.insert("ast".to_string(), value.clone());
             let updated = Value::Instance {
                 class_name: *class_name,
-                attributes: std::sync::Arc::new(crate::value::InstanceAttrs::new(
+                attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
                     *class_name,
                     (attrs).to_map(),
                     *id,

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -167,7 +167,7 @@ impl Interpreter {
                 };
                 meta.insert(
                     "build".to_string(),
-                    Value::Sub(std::sync::Arc::new(sub_data)),
+                    Value::Sub(crate::gc::Gc::new(sub_data)),
                 );
             }
         }

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -251,7 +251,7 @@ impl Interpreter {
     /// Called when a Proc result is retrieved via .result or await.
     pub(in crate::runtime) fn replay_proc_taps(
         &mut self,
-        attributes: &Arc<crate::value::InstanceAttrs>,
+        attributes: &crate::gc::Gc<crate::value::InstanceAttrs>,
     ) {
         let mut stdout_taps = match attributes.as_map().get("stdout_taps") {
             Some(Value::Array(taps, ..)) => taps.to_vec(),

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -479,7 +479,7 @@ impl Interpreter {
     fn create_lazy_map_list(
         &self,
         items: Vec<Value>,
-        callback: &std::sync::Arc<crate::value::SubData>,
+        callback: &crate::gc::Gc<crate::value::SubData>,
     ) -> Value {
         let mut env = self.env.clone();
         env.insert(

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -411,7 +411,7 @@ impl Interpreter {
                 if !closure_keys.is_empty()
                     && let Some(Value::Sub(data_arc)) = self.env.get_mut_sym(key)
                 {
-                    let data_mut = std::sync::Arc::make_mut(data_arc);
+                    let data_mut = crate::gc::Gc::make_mut(data_arc);
                     for closure_key in closure_keys {
                         data_mut.env.insert_sym(closure_key, new_mixin.clone());
                     }
@@ -448,7 +448,7 @@ impl Interpreter {
                 })
                 .collect();
             if !closure_keys.is_empty() {
-                let data_mut = std::sync::Arc::make_mut(data_arc);
+                let data_mut = crate::gc::Gc::make_mut(data_arc);
                 for key in closure_keys {
                     data_mut.env.insert_sym(key, new_mixin.clone());
                 }

--- a/src/runtime/methods_mut_proxy.rs
+++ b/src/runtime/methods_mut_proxy.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::InstanceAttrs;
-use std::sync::Arc;
 
 impl Interpreter {
     pub(crate) fn call_proxy_callback(
@@ -123,7 +122,7 @@ impl Interpreter {
         target_var: Option<&str>,
         class_name: Symbol,
         attributes: &HashMap<String, Value>,
-        attrs_cell: &Arc<InstanceAttrs>,
+        attrs_cell: &crate::gc::Gc<InstanceAttrs>,
         new_value: Value,
     ) -> Result<Value, RuntimeError> {
         let proxy_val = Value::Proxy {

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -72,7 +72,7 @@ impl Interpreter {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn assign_rw_indexed_attr(
         &mut self,
-        attributes: &std::sync::Arc<crate::value::InstanceAttrs>,
+        attributes: &crate::gc::Gc<crate::value::InstanceAttrs>,
         class_name: Symbol,
         target_id: u64,
         target_var: Option<&str>,

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -91,7 +91,7 @@ impl Interpreter {
                     sub_data.assumed_positional.push(arg.clone());
                 }
             }
-            return Some(Ok(Value::Sub(std::sync::Arc::new(sub_data))));
+            return Some(Ok(Value::Sub(crate::gc::Gc::new(sub_data))));
         }
         if method == "candidates" && args.is_empty() {
             return Some(Ok(Value::array(self.routine_candidate_subs(package, name))));
@@ -380,7 +380,7 @@ impl Interpreter {
                     let failure = Value::make_instance(Symbol::intern("Failure"), failure_attrs);
                     let mut mixins = std::collections::HashMap::new();
                     mixins.insert("Failure".to_string(), failure);
-                    Value::mixin(Value::Sub(std::sync::Arc::new(sub_data.clone())), mixins)
+                    Value::mixin(Value::Sub(crate::gc::Gc::new(sub_data.clone())), mixins)
                 };
             let mut incoming_named = std::collections::HashMap::new();
             for arg in args {
@@ -512,12 +512,12 @@ impl Interpreter {
                     let mut mixins = std::collections::HashMap::new();
                     mixins.insert("Failure".to_string(), failure);
                     return Some(Ok(Value::mixin(
-                        Value::Sub(std::sync::Arc::new(next)),
+                        Value::Sub(crate::gc::Gc::new(next)),
                         mixins,
                     )));
                 }
             }
-            return Some(Ok(Value::Sub(std::sync::Arc::new(next))));
+            return Some(Ok(Value::Sub(crate::gc::Gc::new(next))));
         }
         if method == "candidates" && args.is_empty() {
             // Multi-dispatch dispatcher: try name-based lookup first (preserves doc comments)

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -1,14 +1,13 @@
 use crate::builtins::methods_0arg::temporal;
 use crate::value::{RuntimeError, Value};
-use std::sync::Arc;
 
-fn has_date_attrs(attributes: &Arc<crate::value::InstanceAttrs>) -> bool {
+fn has_date_attrs(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> bool {
     attributes.contains_key("year")
         && attributes.contains_key("month")
         && attributes.contains_key("day")
 }
 
-fn has_datetime_attrs(attributes: &Arc<crate::value::InstanceAttrs>) -> bool {
+fn has_datetime_attrs(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> bool {
     has_date_attrs(attributes)
         && attributes.contains_key("hour")
         && attributes.contains_key("minute")
@@ -19,7 +18,7 @@ fn has_datetime_attrs(attributes: &Arc<crate::value::InstanceAttrs>) -> bool {
 fn rebless_datetime_result(
     result: Value,
     target_class_name: crate::symbol::Symbol,
-    original_attrs: &Arc<crate::value::InstanceAttrs>,
+    original_attrs: &crate::gc::Gc<crate::value::InstanceAttrs>,
 ) -> Value {
     if target_class_name == "DateTime" {
         return result;
@@ -46,7 +45,7 @@ fn rebless_datetime_result(
     }
     Value::Instance {
         class_name: target_class_name,
-        attributes: Arc::new(crate::value::InstanceAttrs::new(
+        attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
             target_class_name,
             (merged).to_map(),
             *id,
@@ -59,7 +58,7 @@ fn rebless_datetime_result(
 fn rebless_date_result(
     result: Value,
     target_class_name: crate::symbol::Symbol,
-    original_attrs: &Arc<crate::value::InstanceAttrs>,
+    original_attrs: &crate::gc::Gc<crate::value::InstanceAttrs>,
 ) -> Value {
     if target_class_name == "Date" {
         return result;
@@ -84,7 +83,7 @@ fn rebless_date_result(
     }
     Value::Instance {
         class_name: target_class_name,
-        attributes: Arc::new(crate::value::InstanceAttrs::new(
+        attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
             target_class_name,
             (merged).to_map(),
             *id,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2068,7 +2068,7 @@ mod tests {
             OpCode::SetLocal(2),
         ];
 
-        let block = Arc::new(SubData {
+        let block = crate::gc::Gc::new(SubData {
             package: Symbol::intern("GLOBAL"),
             name: Symbol::intern("__protect_test__"),
             params: vec![],

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -332,7 +332,7 @@ impl Interpreter {
                 id,
             } => Value::Instance {
                 class_name: *class_name,
-                attributes: Arc::new((**attributes).clone()),
+                attributes: crate::gc::Gc::new((**attributes).clone()),
                 id: *id,
             },
             other => other.clone(),

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -368,7 +368,7 @@ impl Interpreter {
                 new_env.insert("$_".to_string(), caller_topic.clone());
             }
             // &?BLOCK: weak self-reference to break reference cycles
-            let block_arc = std::sync::Arc::new(crate::value::SubData {
+            let block_arc = crate::gc::Gc::new(crate::value::SubData {
                 package: data.package,
                 name: data.name,
                 params: data.params.clone(),
@@ -391,7 +391,7 @@ impl Interpreter {
             });
             new_env.insert(
                 "&?BLOCK".to_string(),
-                Value::WeakSub(std::sync::Arc::downgrade(&block_arc)),
+                Value::WeakSub(crate::gc::Gc::downgrade(&block_arc)),
             );
             let block_sub = Value::make_sub_with_id(
                 data.package,

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -350,7 +350,7 @@ impl Interpreter {
 
     pub(crate) fn get_or_compile_protect_block_with_slots(
         &mut self,
-        data: &std::sync::Arc<crate::value::SubData>,
+        data: &crate::gc::Gc<crate::value::SubData>,
     ) -> (
         ProtectBlockCompiled,
         ProtectBlockCompiledFns,

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -5,7 +5,7 @@ use crate::value::signature::{extract_sig_info, signature_smartmatch};
 impl Interpreter {
     /// Extract path and CWD from IO::Path attributes for ACCEPTS comparison.
     fn io_path_attrs_for_accepts(
-        attrs: &std::sync::Arc<crate::value::InstanceAttrs>,
+        attrs: &crate::gc::Gc<crate::value::InstanceAttrs>,
     ) -> (String, String) {
         let path = attrs
             .as_map()

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -210,7 +210,7 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
         (Value::LazyList(a), Value::LazyList(b)) => std::sync::Arc::ptr_eq(a, b),
         (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Sub(a), Value::Sub(b)) => {
-            if std::sync::Arc::ptr_eq(a, b) {
+            if crate::gc::Gc::ptr_eq(a, b) {
                 return true;
             }
             // Named subs with the same package and name are identical
@@ -219,7 +219,7 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
             let b_name = b.name.resolve();
             !a_name.is_empty() && a_name == b_name && a.package == b.package
         }
-        (Value::WeakSub(a), Value::WeakSub(b)) => a.ptr_eq(b),
+        (Value::WeakSub(a), Value::WeakSub(b)) => crate::gc::WeakGc::ptr_eq(a, b),
         (Value::Mixin(a_inner, a_mix), Value::Mixin(b_inner, b_mix)) => {
             a_inner.eqv(b_inner) && a_mix == b_mix
         }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -55,7 +55,7 @@ pub(crate) fn seq_mark_lazy(arc_ptr: &Arc<Vec<Value>>) {
             return; // already tracked
         }
     }
-    list.push(Arc::downgrade(arc_ptr));
+    list.push(std::sync::Arc::downgrade(arc_ptr));
 }
 
 /// Check if a Seq has been marked as lazy.
@@ -112,7 +112,7 @@ pub(crate) fn lazylist_consume(arc_ptr: &Arc<LazyList>) -> bool {
             return false; // already consumed
         }
     }
-    list.push(Arc::downgrade(arc_ptr));
+    list.push(std::sync::Arc::downgrade(arc_ptr));
     true
 }
 
@@ -142,7 +142,7 @@ pub(crate) fn seq_mark_cached(arc_ptr: &Arc<Vec<Value>>) {
             return; // already tracked
         }
     }
-    list.push(Arc::downgrade(arc_ptr));
+    list.push(std::sync::Arc::downgrade(arc_ptr));
 }
 
 /// Check if a Seq has been marked as cached.
@@ -198,7 +198,7 @@ pub(crate) fn seq_consume(arc_ptr: &Arc<Vec<Value>>) -> Result<(), RuntimeError>
             return Err(seq_consumed_error());
         }
     }
-    list.push(Arc::downgrade(arc_ptr));
+    list.push(std::sync::Arc::downgrade(arc_ptr));
     Ok(())
 }
 
@@ -417,7 +417,7 @@ pub(crate) struct InstanceAttrs {
     ///
     /// Cross-frame *sharing* (the Raku object-identity semantics that makes an
     /// in-place mutation visible to every alias) comes from cloning the
-    /// `Arc<InstanceAttrs>` held by `Value::Instance` — that aliases this same
+    /// `crate::gc::Gc<InstanceAttrs>` held by `Value::Instance` — that aliases this same
     /// struct and cell. An explicit `InstanceAttrs::clone` (see the manual
     /// `Clone` impl below) instead makes an *independent* deep copy with a fresh
     /// cell, preserving the long-standing semantics of the legacy writeback
@@ -967,13 +967,13 @@ pub enum Value {
     /// A regex literal carrying adverbs. Boxed payload to keep `Value` small
     /// (this variant has 13 fields).
     RegexWithAdverbs(Box<RegexAdverbs>),
-    Sub(Arc<SubData>),
+    Sub(crate::gc::Gc<SubData>),
     /// A weak reference to a Sub (used for &?BLOCK self-references to break cycles).
     /// Upgrade to the strong value when accessed; returns Nil if expired.
-    WeakSub(Weak<SubData>),
+    WeakSub(crate::gc::WeakGc<SubData>),
     Instance {
         class_name: Symbol,
-        attributes: Arc<InstanceAttrs>,
+        attributes: crate::gc::Gc<InstanceAttrs>,
         id: u64,
     },
     Junction {

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -417,7 +417,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             id,
         } => Value::Instance {
             class_name,
-            attributes: Arc::new(crate::value::InstanceAttrs::new(
+            attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
                 class_name,
                 attributes
                     .into_iter()

--- a/src/value/types_eqv.rs
+++ b/src/value/types_eqv.rs
@@ -168,7 +168,7 @@ impl Value {
             | (Value::RegexWithAdverbs { .. }, Value::RegexWithAdverbs { .. })
             | (Value::Routine { .. }, Value::Routine { .. }) => self == other,
             (Value::Sub(a), Value::Sub(b)) => {
-                if Arc::ptr_eq(a, b) {
+                if crate::gc::Gc::ptr_eq(a, b) {
                     return true;
                 }
                 let a_name = a.name.resolve();

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -3,7 +3,7 @@ use super::*;
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         let match_equals_pair_array =
-            |attrs: &Arc<InstanceAttrs>, arr: &crate::gc::Gc<ArrayData>| {
+            |attrs: &crate::gc::Gc<InstanceAttrs>, arr: &crate::gc::Gc<ArrayData>| {
                 if arr.len() != 2 {
                     return false;
                 }

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -44,8 +44,49 @@ impl Value {
             Value::Bag(data, _) => visit(&data.erased()),
             Value::Mix(data, _) => visit(&data.erased()),
             Value::ContainerRef(cell) => visit(&cell.erased()),
+            Value::Sub(data) => visit(&data.erased()),
+            Value::Instance { attributes, .. } => visit(&attributes.erased()),
             _ => {}
         }
+    }
+}
+
+/// A closure's captured `env` and `.assume`d args hold `Value`s that can close
+/// a cycle (a recursive closure captures itself; two closures capture each
+/// other). Second-wave migration (§11 step 9).
+impl Trace for SubData {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        for v in self.env.values() {
+            v.gc_trace(visit);
+        }
+        for v in &self.assumed_positional {
+            v.gc_trace(visit);
+        }
+        for v in self.assumed_named.values() {
+            v.gc_trace(visit);
+        }
+    }
+    fn drop_gc_edges(&mut self) {
+        for v in self.env.values_mut() {
+            *v = Value::Nil;
+        }
+        self.assumed_positional.clear();
+        self.assumed_named.clear();
+    }
+}
+
+/// An object's per-attribute cell holds `Value`s that can close a cycle
+/// (`$obj.parent = $obj`, mutually-referential objects). The attribute cell is
+/// interior-mutable (`AttrCell = Arc<RwLock<..>>`), so severing is a plain cell
+/// write. Second-wave migration (§11 step 9).
+impl Trace for InstanceAttrs {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        for v in self.as_map().values() {
+            v.gc_trace(visit);
+        }
+    }
+    fn drop_gc_edges(&mut self) {
+        self.clear_gc_edges();
     }
 }
 

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -57,7 +57,7 @@ impl Drop for AttrReadGuard<'_> {
 impl Clone for InstanceAttrs {
     /// Deep, independent copy: a fresh cell with a snapshot of the map. Used for
     /// `.clone`-style independent copies and `temp`/`let` snapshots; it must NOT
-    /// share the cell — sharing flows through `Arc<InstanceAttrs>`. The copy does
+    /// share the cell — sharing flows through `crate::gc::Gc<InstanceAttrs>`. The copy does
     /// not participate in DESTROY refcounting (`queue_destroy = false`).
     fn clone(&self) -> Self {
         Self {
@@ -133,6 +133,14 @@ impl InstanceAttrs {
         write_attrs(&self.attributes).insert(key, value)
     }
 
+    /// Drop every attribute (breaking any `Gc` edge out of this object) — the
+    /// GC collector's cycle-sever for a proven-garbage `Instance` node (§11
+    /// step 8/9). The attribute cell is interior-mutable, so this is a plain
+    /// (Stacked-Borrows-sound) write.
+    pub(crate) fn clear_gc_edges(&self) {
+        write_attrs(&self.attributes).clear();
+    }
+
     /// Mutate one attribute in place under the write lock, returning the
     /// closure's result. Returns `None` if the key is absent. Replaces the old
     /// `get_mut` (which cannot hand out a `&mut` past the guard).
@@ -150,7 +158,7 @@ impl InstanceAttrs {
     /// Phase 3 registry-removal: replace the whole attribute map in place through
     /// this instance's shared cell, deadlock-safe with respect to a same-thread
     /// read guard (see [`write_cell_respecting_reads`]). Because every alias of the
-    /// instance shares this `Arc<InstanceAttrs>` cell, the new map is visible
+    /// instance shares this `crate::gc::Gc<InstanceAttrs>` cell, the new map is visible
     /// everywhere — in this frame, any caller frame, a `ContainerRef`-boxed
     /// capture, a role `Mixin`, or a nested attribute of another instance. This is
     /// the in-place replacement for the legacy id→cell registry writeback

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -261,7 +261,7 @@ impl Value {
         is_rw: bool,
         env: Env,
     ) -> Self {
-        Value::Sub(Arc::new(SubData {
+        Value::Sub(crate::gc::Gc::new(SubData {
             package,
             name,
             params,
@@ -296,7 +296,7 @@ impl Value {
         env: Env,
         id: u64,
     ) -> Self {
-        Value::Sub(Arc::new(SubData {
+        Value::Sub(crate::gc::Gc::new(SubData {
             package,
             name,
             params,
@@ -388,7 +388,7 @@ impl Value {
     /// Build an instance with the given id and a fresh attribute cell. Used for
     /// constructing a value with an explicit id (genuinely new instances, or
     /// sentinel ids). Cross-frame sharing of mutations comes from cloning an
-    /// existing instance's `Arc<InstanceAttrs>` (see [`Value::instance_sharing_cell`]),
+    /// existing instance's `crate::gc::Gc<InstanceAttrs>` (see [`Value::instance_sharing_cell`]),
     /// not from this constructor — so this never reuses another holder's cell.
     pub(crate) fn make_instance_with_id(
         class_name: Symbol,
@@ -397,7 +397,7 @@ impl Value {
     ) -> Self {
         Value::Instance {
             class_name,
-            attributes: Arc::new(InstanceAttrs::new(class_name, attributes, id, true)),
+            attributes: crate::gc::Gc::new(InstanceAttrs::new(class_name, attributes, id, true)),
             id,
         }
     }
@@ -406,18 +406,18 @@ impl Value {
     /// live cell, optionally under a new `class_name` (rebless / role mixin). This
     /// replaces the `make_instance_with_id` rebuild branch, which reused the cell
     /// by looking it up in the global `instance_cells` registry. Sharing the
-    /// `Arc<InstanceAttrs>` directly keeps in-place mutations visible to every
+    /// `crate::gc::Gc<InstanceAttrs>` directly keeps in-place mutations visible to every
     /// existing alias and to the returned value, without the registry.
     pub(crate) fn instance_sharing_cell(
-        attrs: &Arc<InstanceAttrs>,
+        attrs: &crate::gc::Gc<InstanceAttrs>,
         class_name: Symbol,
         id: u64,
     ) -> Value {
         debug_assert_eq!(attrs.id, id, "instance_sharing_cell id mismatch");
         let attributes = if attrs.class_name == class_name {
-            Arc::clone(attrs)
+            crate::gc::Gc::clone(attrs)
         } else {
-            Arc::new(attrs.with_class(class_name))
+            crate::gc::Gc::new(attrs.with_class(class_name))
         };
         Value::Instance {
             class_name,
@@ -431,7 +431,7 @@ impl Value {
     /// for the common writeback-then-rebuild pattern: it replaces the paired
     /// `overwrite_instance_bindings_by_identity(..) + make_instance_with_id(..)`.
     pub(crate) fn write_back_sharing(
-        attrs: &Arc<InstanceAttrs>,
+        attrs: &crate::gc::Gc<InstanceAttrs>,
         class_name: Symbol,
         map: HashMap<String, Value>,
         id: u64,
@@ -454,7 +454,7 @@ impl Value {
                 id,
             } => Value::Instance {
                 class_name,
-                attributes: Arc::new((*attributes).clone()),
+                attributes: crate::gc::Gc::new((*attributes).clone()),
                 id,
             },
             other => other,
@@ -469,7 +469,7 @@ impl Value {
         let id = next_instance_id();
         Value::Instance {
             class_name,
-            attributes: Arc::new(InstanceAttrs::new(
+            attributes: crate::gc::Gc::new(InstanceAttrs::new(
                 class_name,
                 attributes,
                 id,

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -864,7 +864,7 @@ impl Interpreter {
                 attrs.insert("ast".to_string(), value.clone());
                 let updated = Value::Instance {
                     class_name,
-                    attributes: Arc::new(crate::value::InstanceAttrs::new(
+                    attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
                         class_name,
                         (attrs).to_map(),
                         id,
@@ -2064,7 +2064,7 @@ impl Interpreter {
         &mut self,
         target_name: &str,
         inst_class: &Symbol,
-        attributes: &Arc<crate::value::InstanceAttrs>,
+        attributes: &crate::gc::Gc<crate::value::InstanceAttrs>,
         inst_id: u64,
         storage: Value,
     ) {
@@ -2072,7 +2072,7 @@ impl Interpreter {
         new_attrs.insert("__mutsu_array_storage".to_string(), storage);
         let updated_instance = Value::Instance {
             class_name: *inst_class,
-            attributes: Arc::new(crate::value::InstanceAttrs::new(
+            attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
                 *inst_class,
                 new_attrs.to_map(),
                 inst_id,

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -283,7 +283,7 @@ impl Interpreter {
 
         // Push Sub value to block_stack for callframe().code
         // Also set &?BLOCK as a weak self-reference (mirrors resolution.rs)
-        let block_arc = std::sync::Arc::new(crate::value::SubData {
+        let block_arc = crate::gc::Gc::new(crate::value::SubData {
             package: data.package,
             name: data.name,
             params: data.params.clone(),
@@ -306,7 +306,7 @@ impl Interpreter {
         });
         self.env_mut().insert(
             "&?BLOCK".to_string(),
-            Value::WeakSub(std::sync::Arc::downgrade(&block_arc)),
+            Value::WeakSub(crate::gc::Gc::downgrade(&block_arc)),
         );
         self.push_block(Value::Sub(block_arc));
 

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -90,8 +90,8 @@ impl Interpreter {
             // copies the reference but creates a new container, so =:= is False.
             match (&left, &right) {
                 (Value::Package(a), Value::Package(b)) => a == b,
-                (Value::Sub(a), Value::Sub(b)) => std::sync::Arc::ptr_eq(a, b),
-                (Value::WeakSub(a), Value::WeakSub(b)) => a.ptr_eq(b),
+                (Value::Sub(a), Value::Sub(b)) => crate::gc::Gc::ptr_eq(a, b),
+                (Value::WeakSub(a), Value::WeakSub(b)) => crate::gc::WeakGc::ptr_eq(a, b),
                 _ => false,
             }
         };

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1618,7 +1618,7 @@ fn merge_method_env(
 mod cheaply_unchanged_tests {
     use super::cheaply_unchanged;
     use crate::value::Value;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
 
     #[test]
     fn container_ref_same_cell_is_unchanged() {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -98,7 +98,7 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
-            let val = Value::Sub(std::sync::Arc::new(crate::value::SubData {
+            let val = Value::Sub(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.current_package()),
                 name: Symbol::intern(""),
                 params,
@@ -173,7 +173,7 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
-            let val = Value::Sub(std::sync::Arc::new(crate::value::SubData {
+            let val = Value::Sub(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.current_package()),
                 name: Symbol::intern(""),
                 params: params.clone(),

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -41,7 +41,7 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
-            let val = Value::Sub(std::sync::Arc::new(crate::value::SubData {
+            let val = Value::Sub(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.current_package()),
                 name: Symbol::intern(""),
                 params: params.clone(),
@@ -89,7 +89,7 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
-            let val = Value::Sub(std::sync::Arc::new(crate::value::SubData {
+            let val = Value::Sub(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.current_package()),
                 name: Symbol::intern(""),
                 params: vec![],

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -16,7 +16,7 @@ fn io_path_cleanup_absolute(path: &str, cwd: &str) -> String {
 }
 
 /// Extract path and CWD from IO::Path attributes.
-fn io_path_attrs(attrs: &std::sync::Arc<crate::value::InstanceAttrs>) -> (String, String) {
+fn io_path_attrs(attrs: &crate::gc::Gc<crate::value::InstanceAttrs>) -> (String, String) {
     let path = attrs
         .as_map()
         .get("path")

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::symbol::Symbol;
-use std::sync::Arc;
 
 const SELF_HASH_REF_SENTINEL: &str = "__mutsu_self_hash_ref";
 const SELF_ARRAY_REF_SENTINEL: &str = "__mutsu_self_array_ref";
@@ -56,7 +55,7 @@ impl Interpreter {
                     decontainerized: false,
                 };
                 if let Value::Sub(ref mut data) = new_storer {
-                    let data = Arc::make_mut(data);
+                    let data = crate::gc::Gc::make_mut(data);
                     data.env.insert(var_name.to_string(), proxy_for_env);
                 }
             }


### PR DESCRIPTION
Second-wave `Arc → Gc` migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11 step 9), following the first-wave container types. `Value::Sub` now holds `Gc<SubData>` and `Value::Instance`'s `attributes` a `Gc<InstanceAttrs>`, so **closures** (which capture their env — a recursive closure captures itself) and **objects** (`$obj.next = $obj`, mutually-referential nodes) join the cycle-collector graph.

`Pair`/`ValuePair` stay `Box<Value>` — value semantics, no shared `Arc`, cannot form an Arc cycle, so they are out of scope.

## Changes
- **`impl Trace for SubData`** (traces its captured `env` values + `.assume`d args; `drop_gc_edges` nils the env and clears the assumed args) and **`for InstanceAttrs`** (traces the attribute cell's values; `drop_gc_edges` clears the cell via a plain interior-mutable `clear_gc_edges` write). + `Value::Sub`/`Instance` arms in `gc_trace`.
- **`WeakGc<T>` weak handle** — `Value::WeakSub` needs a weak reference to a `Gc` node, which main's `Gc` lacked. Added `WeakGc<T>` (= `Weak<GcBox<T>>`) with `Gc::downgrade` / `WeakGc::upgrade` (upgrade takes a new strong ref, bumping the GC-visible count) / `ptr_eq`, and flipped `WeakSub(Weak<SubData>)` → `WeakSub(WeakGc<SubData>)`.
- Mechanical call-site rewrite (~30 files): `Arc::new(SubData/InstanceAttrs)` → `Gc::new`, `Arc::{make_mut,ptr_eq,clone,...}` → `crate::gc::Gc::…`, type annotations → `Gc<…>`, `Arc::downgrade` at the WeakSub site → `Gc::downgrade`.

## Testing
- Closures / objects / mutual-object cycles behave identically.
- 29 `gc::` unit tests green; `cargo clippy --all-targets -- -D warnings` clean; `make test` green (14076 tests, 0 failures).

With this, the design §3.1 candidate set is fully `Gc`-managed except `LazyList` (third wave, step 10) and the async `Promise`/`Channel`/supply nodes (steps 6-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)