### PR TITLE
GC step 10: migrate Value::LazyList to Gc (third wave)

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -63,7 +63,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                             walk_pending: None,
                             cat_pull: None,
                         };
-                        return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
+                        return Some(Ok(Value::LazyList(crate::gc::Gc::new(ll))));
                     }
                     let items: Vec<Value> = (0..*n).map(Value::Int).collect();
                     return Some(Ok(Value::Seq(
@@ -90,7 +90,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                     walk_pending: None,
                     cat_pull: None,
                 };
-                return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
+                return Some(Ok(Value::LazyList(crate::gc::Gc::new(ll))));
             }
             Some(Ok(Value::Seq(
                 crate::builtins::methods_0arg::collection::all_permutations(&items).into(),

--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -114,7 +114,7 @@ pub(crate) fn native_function_2arg(
                     }
                     out.push(items[idx].clone());
                 }
-                return Some(Ok(Value::LazyList(std::sync::Arc::new(
+                return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_cached(out),
                 ))));
             }

--- a/src/builtins/functions/dispatch_variadic.rs
+++ b/src/builtins/functions/dispatch_variadic.rs
@@ -120,7 +120,7 @@ pub(crate) fn native_function_variadic(
                 result.push(Value::array(row));
             }
             if all_lazy {
-                Some(Ok(Value::LazyList(std::sync::Arc::new(
+                Some(Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_cached(result),
                 ))))
             } else {

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -497,11 +497,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 // without materializing the (possibly infinite) generator.
                 Value::LazyList(ll) if ll.is_genuinely_lazy() => {
                     if want_array {
-                        Some(Ok(Value::LazyList(std::sync::Arc::new(
+                        Some(Ok(Value::LazyList(crate::gc::Gc::new(
                             ll.with_array_context(),
                         ))))
                     } else {
-                        Some(Ok(Value::LazyList(std::sync::Arc::new(
+                        Some(Ok(Value::LazyList(crate::gc::Gc::new(
                             ll.with_list_context(),
                         ))))
                     }

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1101,7 +1101,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     walk_pending: None,
                     cat_pull: None,
                 };
-                return Some(Ok(Value::LazyList(std::sync::Arc::new(ll))));
+                return Some(Ok(Value::LazyList(crate::gc::Gc::new(ll))));
             }
             Some(Ok(Value::Seq(all_permutations(&items).into())))
         }
@@ -1125,7 +1125,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             if let Value::LazyList(ll) = target
                 && ll.is_genuinely_lazy()
             {
-                return Some(Ok(Value::LazyList(std::sync::Arc::new(
+                return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                     ll.with_cached_no_sink(),
                 ))));
             }

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -129,7 +129,7 @@ pub(super) fn dispatch(
                         Value::Bool(true),
                     );
                     let cache = list.cache.lock().unwrap().clone();
-                    return Some(Some(Ok(Value::LazyList(std::sync::Arc::new(
+                    return Some(Some(Ok(Value::LazyList(crate::gc::Gc::new(
                         crate::value::LazyList {
                             body: list.body.clone(),
                             env,
@@ -194,7 +194,7 @@ pub(super) fn dispatch(
                 "__mutsu_preserve_lazy_on_array_assign".to_string(),
                 Value::Bool(true),
             );
-            Some(Some(Ok(Value::LazyList(std::sync::Arc::new(
+            Some(Some(Ok(Value::LazyList(crate::gc::Gc::new(
                 crate::value::LazyList {
                     body: vec![],
                     env,

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1299,7 +1299,7 @@ pub(crate) fn native_method_1arg(
                     }
                     cached.extend(cycle);
                 }
-                return Some(Ok(Value::LazyList(Arc::new(
+                return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_cached(cached),
                 ))));
             }
@@ -1465,7 +1465,7 @@ pub(crate) fn native_method_1arg(
                             out.push(v);
                         }
                     }
-                    return Some(Ok(Value::LazyList(Arc::new(
+                    return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                         crate::value::LazyList::new_cached(out),
                     ))));
                 }
@@ -1490,7 +1490,7 @@ pub(crate) fn native_method_1arg(
                             out.push(v);
                         }
                     }
-                    return Some(Ok(Value::LazyList(Arc::new(
+                    return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                         crate::value::LazyList::new_cached(out),
                     ))));
                 }
@@ -1522,7 +1522,7 @@ pub(crate) fn native_method_1arg(
                         }
                         out.push(Value::str(keys[idx].clone()));
                     }
-                    return Some(Ok(Value::LazyList(Arc::new(
+                    return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                         crate::value::LazyList::new_cached(out),
                     ))));
                 }
@@ -1631,7 +1631,7 @@ pub(crate) fn native_method_1arg(
                             out.push(v);
                         }
                     }
-                    return Some(Ok(Value::LazyList(Arc::new(
+                    return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                         crate::value::LazyList::new_cached(out),
                     ))));
                 }
@@ -1640,7 +1640,7 @@ pub(crate) fn native_method_1arg(
                 // sequence-spec lazy list (like `1...*`) instead of eagerly
                 // generating a fixed-size prefix. This renders Rakudo's
                 // `(...)` gist placeholder and can be pulled indefinitely.
-                return Some(Ok(Value::LazyList(Arc::new(
+                return Some(Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_sequence(
                         Vec::new(),
                         crate::value::SequenceSpec::RollPool(items),

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -155,15 +155,32 @@ pub(crate) struct WeakGc<T: Trace + 'static> {
 }
 
 impl<T: Trace + 'static> WeakGc<T> {
-    /// Reconstitute a strong [`Gc`] handle if the node is still alive. Bumps the
-    /// GC-visible strong count and marks the node live (`Black`) — upgrading a
-    /// weak reference *is* taking a new temporary strong reference.
     /// Whether two weak handles point at the same node (`Weak::ptr_eq`), for
     /// `Value::WeakSub` identity comparison.
     pub(crate) fn ptr_eq(a: &WeakGc<T>, b: &WeakGc<T>) -> bool {
         std::sync::Weak::ptr_eq(&a.inner, &b.inner)
     }
 
+    /// Backing-`Arc` strong count of the node (0 if it has been freed). Used by
+    /// the consumed-LazyList registry to prune dead weak entries.
+    pub(crate) fn strong_count(&self) -> usize {
+        self.inner.strong_count()
+    }
+
+    /// Raw `*const T` to the pointee for identity comparison, or null if the node
+    /// is gone. (`Weak::as_ptr` yields the `GcBox`; project the value.)
+    pub(crate) fn as_ptr(&self) -> *const T {
+        let box_ptr = self.inner.as_ptr();
+        if box_ptr.is_null() {
+            std::ptr::null()
+        } else {
+            unsafe { std::ptr::addr_of!((*box_ptr).value) }
+        }
+    }
+
+    /// Reconstitute a strong [`Gc`] handle if the node is still alive. Bumps the
+    /// GC-visible strong count and marks the node live (`Black`) — upgrading a
+    /// weak reference *is* taking a new temporary strong reference.
     pub(crate) fn upgrade(&self) -> Option<Gc<T>> {
         self.inner.upgrade().map(|arc| {
             arc.header.strong.fetch_add(1, Ordering::Relaxed);

--- a/src/runtime/builtins_operators_infix.rs
+++ b/src/runtime/builtins_operators_infix.rs
@@ -221,7 +221,7 @@ impl Interpreter {
                             if !items.is_empty() {
                                 items.remove(0);
                             }
-                            result = Value::LazyList(std::sync::Arc::new(
+                            result = Value::LazyList(crate::gc::Gc::new(
                                 crate::value::LazyList::new_cached(items),
                             ));
                         }

--- a/src/runtime/builtins_operators_repeat.rs
+++ b/src/runtime/builtins_operators_repeat.rs
@@ -121,7 +121,7 @@ impl Interpreter {
     pub(crate) fn make_repeat_lazy_cache_counted(items: Vec<Value>, count: Value) -> Value {
         let mut ll = crate::value::LazyList::new_cached(items);
         ll.elems_count = Some(count);
-        Value::LazyList(std::sync::Arc::new(ll))
+        Value::LazyList(crate::gc::Gc::new(ll))
     }
 
     /// The logical element count of `LHS xx right` when the result is lazy

--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -441,7 +441,7 @@ impl Interpreter {
             result.push(combined);
         }
         if all_lazy {
-            Ok(Value::LazyList(std::sync::Arc::new(
+            Ok(Value::LazyList(crate::gc::Gc::new(
                 crate::value::LazyList::new_cached(result),
             )))
         } else {

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -69,7 +69,7 @@ impl Interpreter {
         visit_opt(visitor, &self.rw_map_topic_capture);
         visit_opt(visitor, &self.action_made);
         visit_opt(visitor, &self.current_grammar_actions);
-        // ForLoopResumeState::LazyGather holds an `Arc<LazyList>`, not a bare
+        // ForLoopResumeState::LazyGather holds an `crate::gc::Gc<LazyList>`, not a bare
         // `Value` — LazyList's internal Value graph is traced starting in the
         // third wave (design doc §11 step 10); revisit once
         // `LazyList::visit_gc_children` exists.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3035,7 +3035,7 @@ impl Interpreter {
                 "antipairs" => crate::value::IndexTransform::AntiPairs,
                 _ => crate::value::IndexTransform::Kv,
             };
-            return Ok(Value::LazyList(std::sync::Arc::new(
+            return Ok(Value::LazyList(crate::gc::Gc::new(
                 crate::value::LazyList::new_index_pipe(target.clone(), transform),
             )));
         }
@@ -3050,7 +3050,7 @@ impl Interpreter {
             && method == "cache"
             && ll.is_genuinely_lazy()
         {
-            return Ok(Value::LazyList(std::sync::Arc::new(
+            return Ok(Value::LazyList(crate::gc::Gc::new(
                 ll.with_cached_no_sink(),
             )));
         }

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -102,7 +102,7 @@ impl Interpreter {
                 return None;
             }
         }
-        Some(Value::LazyList(std::sync::Arc::new(
+        Some(Value::LazyList(crate::gc::Gc::new(
             crate::value::LazyList::new_pipe(target, func, is_grep),
         )))
     }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -514,7 +514,7 @@ impl Interpreter {
             walk_pending: None,
             cat_pull: None,
         };
-        Value::LazyList(std::sync::Arc::new(list))
+        Value::LazyList(crate::gc::Gc::new(list))
     }
 
     /// Dispatch "min" and "max" methods.

--- a/src/runtime/methods_pick_roll.rs
+++ b/src/runtime/methods_pick_roll.rs
@@ -120,7 +120,7 @@ impl Interpreter {
             // sequence-spec lazy list (like `1...*`) instead of eagerly
             // generating a fixed-size prefix, so it renders Rakudo's `(...)`
             // gist placeholder and can be pulled indefinitely.
-            return Ok(Value::LazyList(std::sync::Arc::new(
+            return Ok(Value::LazyList(crate::gc::Gc::new(
                 crate::value::LazyList::new_sequence(
                     Vec::new(),
                     crate::value::SequenceSpec::RollPool(pool),

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -109,7 +109,7 @@ impl Interpreter {
         if let Value::LazyList(ll) = &target
             && ll.is_genuinely_lazy()
         {
-            return Ok(Value::LazyList(std::sync::Arc::new(ll.with_list_context())));
+            return Ok(Value::LazyList(crate::gc::Gc::new(ll.with_list_context())));
         }
         let items = Self::value_to_list(&target);
         Ok(Value::Array(

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -314,7 +314,7 @@ impl Interpreter {
             quiet,
             idx: 0,
         }));
-        Ok(Value::LazyList(std::sync::Arc::new(ll)))
+        Ok(Value::LazyList(crate::gc::Gc::new(ll)))
     }
 
     /// Pull up to `needed` elements of a lazy `WALK(method)()` list by invoking

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -476,7 +476,7 @@ impl Interpreter {
             "handles" => crate::value::CatPullMode::Handles,
             _ => return None,
         };
-        Some(Value::LazyList(std::sync::Arc::new(
+        Some(Value::LazyList(crate::gc::Gc::new(
             crate::value::LazyList::new_cat_pull(cat.clone(), mode),
         )))
     }

--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -767,7 +767,7 @@ impl Interpreter {
                 };
                 let items: Vec<Value> = std::iter::repeat_n(left.clone(), repeat).collect();
                 if lazy {
-                    Ok(Value::LazyList(std::sync::Arc::new(
+                    Ok(Value::LazyList(crate::gc::Gc::new(
                         crate::value::LazyList::new_cached(items),
                     )))
                 } else {

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -615,7 +615,7 @@ impl Interpreter {
                         "__mutsu_preserve_lazy_on_array_assign".to_string(),
                         Value::Bool(true),
                     );
-                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList {
+                    Value::LazyList(crate::gc::Gc::new(crate::value::LazyList {
                         body: list.body.clone(),
                         env,
                         cache: std::sync::Mutex::new(list.cache.lock().unwrap().clone()),

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1610,7 +1610,7 @@ impl Interpreter {
             (Value::Array(a, _), Value::Array(b, _)) => crate::gc::Gc::ptr_eq(a, b),
             (Value::Seq(a), Value::Seq(b)) => Arc::ptr_eq(a, b),
             (Value::Slip(a), Value::Slip(b)) => Arc::ptr_eq(a, b),
-            (Value::LazyList(a), Value::LazyList(b)) => Arc::ptr_eq(a, b),
+            (Value::LazyList(a), Value::LazyList(b)) => crate::gc::Gc::ptr_eq(a, b),
             _ => false,
         }
     }

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -1390,7 +1390,7 @@ impl Interpreter {
                 SeqMode::Closure => None,
             };
             if let Some(spec) = seq_spec {
-                Ok(Value::LazyList(std::sync::Arc::new(
+                Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_sequence(result, spec),
                 )))
             } else if matches!(mode, SeqMode::Closure)
@@ -1407,11 +1407,11 @@ impl Interpreter {
                         .map(|(c, f)| (std::sync::Arc::new(c), std::sync::Arc::new(f))),
                     finished: false,
                 };
-                Ok(Value::LazyList(std::sync::Arc::new(
+                Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_closure_sequence(result, state),
                 )))
             } else {
-                Ok(Value::LazyList(std::sync::Arc::new(
+                Ok(Value::LazyList(crate::gc::Gc::new(
                     crate::value::LazyList::new_cached(result),
                 )))
             }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -705,9 +705,9 @@ impl Interpreter {
                             .filter(|a| !matches!(a, Value::Pair(..)))
                             .collect();
                         match rest.as_slice() {
-                            [Value::LazyList(ll)] if ll.is_genuinely_lazy() => Some(
-                                Value::LazyList(std::sync::Arc::new(ll.with_array_context())),
-                            ),
+                            [Value::LazyList(ll)] if ll.is_genuinely_lazy() => {
+                                Some(Value::LazyList(crate::gc::Gc::new(ll.with_array_context())))
+                            }
                             // A bare infinite range (`f(1..Inf)` / `f(1..*)`) also
                             // stays lazy: convert it to the same reify-on-index lazy
                             // array `my @a = 1..*` produces.

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -1,6 +1,5 @@
 use crate::symbol::Symbol;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 use crate::value::{ArrayKind, EnumValue, JunctionKind, RuntimeError, Value};
 use num_bigint::BigInt;
@@ -64,7 +63,7 @@ pub(crate) fn infinite_int_range_to_lazy_array(value: &Value) -> Option<Value> {
         },
     )
     .with_array_context();
-    Some(Value::LazyList(Arc::new(ll)))
+    Some(Value::LazyList(crate::gc::Gc::new(ll)))
 }
 
 /// Saturating conversion of an arbitrary-precision BigInt to i64.

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -207,7 +207,7 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
             // by distinct empty Slip allocations.
             (a.is_empty() && b.is_empty()) || std::sync::Arc::ptr_eq(a, b)
         }
-        (Value::LazyList(a), Value::LazyList(b)) => std::sync::Arc::ptr_eq(a, b),
+        (Value::LazyList(a), Value::LazyList(b)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Hash(a), Value::Hash(b)) => crate::gc::Gc::ptr_eq(a, b),
         (Value::Sub(a), Value::Sub(b)) => {
             if crate::gc::Gc::ptr_eq(a, b) {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -73,9 +73,9 @@ pub(crate) fn seq_is_lazy(arc_ptr: &Arc<Vec<Value>>) -> bool {
 }
 
 /// Global set tracking consumed LazyList instances (gather-based Seqs).
-static CONSUMED_LAZYLISTS: OnceLock<Mutex<Vec<Weak<LazyList>>>> = OnceLock::new();
+static CONSUMED_LAZYLISTS: OnceLock<Mutex<Vec<crate::gc::WeakGc<LazyList>>>> = OnceLock::new();
 
-fn consumed_lazylists() -> &'static Mutex<Vec<Weak<LazyList>>> {
+fn consumed_lazylists() -> &'static Mutex<Vec<crate::gc::WeakGc<LazyList>>> {
     CONSUMED_LAZYLISTS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
@@ -101,33 +101,24 @@ pub(crate) fn seq_has_deferred_iter(arc_ptr: &Arc<Vec<Value>>) -> bool {
 }
 
 /// Mark a LazyList (from gather) as consumed.
-pub(crate) fn lazylist_consume(arc_ptr: &Arc<LazyList>) -> bool {
+pub(crate) fn lazylist_consume(gc_ptr: &crate::gc::Gc<LazyList>) -> bool {
     let mut list = consumed_lazylists().lock().unwrap();
-    let target_ptr = Arc::as_ptr(arc_ptr);
+    let target_ptr = crate::gc::Gc::as_ptr(gc_ptr);
     list.retain(|w| w.strong_count() > 0);
     for w in list.iter() {
-        if let Some(existing) = w.upgrade()
-            && Arc::as_ptr(&existing) == target_ptr
-        {
+        if w.as_ptr() == target_ptr {
             return false; // already consumed
         }
     }
-    list.push(std::sync::Arc::downgrade(arc_ptr));
+    list.push(crate::gc::Gc::downgrade(gc_ptr));
     true
 }
 
 /// Check if a LazyList has been consumed.
-pub(crate) fn lazylist_is_consumed(arc_ptr: &Arc<LazyList>) -> bool {
+pub(crate) fn lazylist_is_consumed(gc_ptr: &crate::gc::Gc<LazyList>) -> bool {
     let list = consumed_lazylists().lock().unwrap();
-    let target_ptr = Arc::as_ptr(arc_ptr);
-    for w in list.iter() {
-        if let Some(existing) = w.upgrade()
-            && Arc::as_ptr(&existing) == target_ptr
-        {
-            return true;
-        }
-    }
-    false
+    let target_ptr = crate::gc::Gc::as_ptr(gc_ptr);
+    list.iter().any(|w| w.as_ptr() == target_ptr)
 }
 
 /// Mark a Seq as cached (called .cache on it). Cached Seqs do not get consumed.
@@ -987,7 +978,7 @@ pub enum Value {
     /// RaceSeq: result of `.race` — unordered parallel map/grep (worker threads).
     RaceSeq(Arc<Vec<Value>>),
     Slip(Arc<Vec<Value>>),
-    LazyList(Arc<LazyList>),
+    LazyList(crate::gc::Gc<LazyList>),
     Version {
         parts: Vec<VersionPart>,
         plus: bool,
@@ -1245,7 +1236,7 @@ pub(crate) enum ForLoopResumeState {
     },
     /// Resume a lazy-gather for loop at the given element index.
     LazyGather {
-        lazy_list: Arc<LazyList>,
+        lazy_list: crate::gc::Gc<LazyList>,
         next_index: usize,
     },
     /// Resume a C-style / `loop` / `while` loop. These loops carry no iteration

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -240,7 +240,7 @@ impl PartialEq for Value {
                 },
             ) => ak == bk && av == bv,
             (Value::Sub(a), Value::Sub(b)) => a.id == b.id,
-            (Value::LazyList(a), Value::LazyList(b)) => Arc::ptr_eq(a, b),
+            (Value::LazyList(a), Value::LazyList(b)) => crate::gc::Gc::ptr_eq(a, b),
             (
                 Value::Version {
                     parts: ap,

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -21,8 +21,8 @@ use std::sync::Mutex;
 use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
 use super::{
-    ArrayData, BagData, HashData, InstanceAttrs, MixData, SetData, SharedChannel, SharedPromise,
-    SubData, Value,
+    ArrayData, BagData, HashData, InstanceAttrs, LazyList, MixData, SetData, SharedChannel,
+    SharedPromise, SubData, Value,
 };
 
 impl Value {
@@ -47,6 +47,7 @@ impl Value {
             Value::ContainerRef(cell) => visit(&cell.erased()),
             Value::Sub(data) => visit(&data.erased()),
             Value::Instance { attributes, .. } => visit(&attributes.erased()),
+            Value::LazyList(ll) => visit(&ll.erased()),
 
             // Non-node wrappers that own/share `Value`s: recurse. They cannot
             // themselves form a cycle without passing through a `Gc` node above
@@ -96,6 +97,42 @@ impl Value {
             }
             _ => {}
         }
+    }
+}
+
+/// A lazy list captures an `env` and a materialization `cache` of `Value`s, both
+/// of which can close a cycle (a gather/closure sequence that captures the very
+/// list it produces). Third-wave migration (§11 step 10).
+///
+/// First cut traces the `env` + `cache` + `elems_count` — the dominant
+/// env-capture cycle sources. The on-demand spec states (coroutine / lazy-pipe /
+/// closure-seq / scan / walk / cat) also hold `Value`s; leaving them untraced is
+/// *conservative* (a cycle routed only through them is not reclaimed, never
+/// wrongly freed) and is the documented step-10 follow-up.
+impl Trace for LazyList {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        for v in self.env.values() {
+            v.gc_trace(visit);
+        }
+        if let Ok(cache) = self.cache.lock()
+            && let Some(items) = cache.as_ref()
+        {
+            for v in items {
+                v.gc_trace(visit);
+            }
+        }
+        if let Some(n) = &self.elems_count {
+            n.gc_trace(visit);
+        }
+    }
+    fn drop_gc_edges(&mut self) {
+        for v in self.env.values_mut() {
+            *v = Value::Nil;
+        }
+        if let Ok(mut cache) = self.cache.lock() {
+            *cache = None;
+        }
+        self.elems_count = None;
     }
 }
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -470,9 +470,10 @@ impl Interpreter {
                 "antipairs" => crate::value::IndexTransform::AntiPairs,
                 _ => crate::value::IndexTransform::Kv,
             };
-            let pipe = Value::LazyList(std::sync::Arc::new(
-                crate::value::LazyList::new_index_pipe(target.clone(), transform),
-            ));
+            let pipe = Value::LazyList(crate::gc::Gc::new(crate::value::LazyList::new_index_pipe(
+                target.clone(),
+                transform,
+            )));
             self.stack.push(pipe);
             return Ok(());
         }
@@ -482,7 +483,7 @@ impl Interpreter {
             && method == "cache"
             && ll.is_genuinely_lazy()
         {
-            self.stack.push(Value::LazyList(std::sync::Arc::new(
+            self.stack.push(Value::LazyList(crate::gc::Gc::new(
                 ll.with_cached_no_sink(),
             )));
             return Ok(());

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -726,9 +726,10 @@ impl Interpreter {
                 "antipairs" => crate::value::IndexTransform::AntiPairs,
                 _ => crate::value::IndexTransform::Kv,
             };
-            let pipe = Value::LazyList(std::sync::Arc::new(
-                crate::value::LazyList::new_index_pipe(target.clone(), transform),
-            ));
+            let pipe = Value::LazyList(crate::gc::Gc::new(crate::value::LazyList::new_index_pipe(
+                target.clone(),
+                transform,
+            )));
             self.stack.push(pipe);
             return Ok(());
         }
@@ -741,7 +742,7 @@ impl Interpreter {
             && method == "cache"
             && ll.is_genuinely_lazy()
         {
-            self.stack.push(Value::LazyList(std::sync::Arc::new(
+            self.stack.push(Value::LazyList(crate::gc::Gc::new(
                 ll.with_cached_no_sink(),
             )));
             return Ok(());

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -10,7 +10,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         spec: &ForLoopSpec,
-        ll: &crate::value::LazyList,
+        ll: &crate::gc::Gc<crate::value::LazyList>,
         body_start: usize,
         loop_end: usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
@@ -23,30 +23,16 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         spec: &ForLoopSpec,
-        ll: &crate::value::LazyList,
+        ll: &crate::gc::Gc<crate::value::LazyList>,
         start_idx: usize,
         body_start: usize,
         loop_end: usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
-        let ll_arc = {
-            // Get the Arc from somewhere. We need to find the LazyList Arc.
-            // Since we have a &LazyList reference, we reconstruct the Arc
-            // by looking at the cache pointer identity. The caller should
-            // have the Arc available. For now, we create a cheap wrapper
-            // that shares the same cache/coroutine via raw pointer.
-            // Actually, we need to find a way to get the Arc.
-            // Let's use std::sync::Arc::from_raw/into_raw trick.
-            // Since ll comes from Value::LazyList(Arc<LazyList>), we can
-            // reconstruct the Arc from the pointer.
-            // SAFETY: The caller holds an Arc<LazyList> on the stack,
-            // keeping the refcount >= 1 for the duration of this call.
-            unsafe {
-                let ptr = ll as *const crate::value::LazyList;
-                std::sync::Arc::increment_strong_count(ptr);
-                std::sync::Arc::from_raw(ptr)
-            }
-        };
+        // The caller holds the `Gc<LazyList>` handle; clone it directly. (Pre-GC
+        // this reconstructed an `Arc<LazyList>` from a `&LazyList` via
+        // `Arc::from_raw` — unsound now that the value lives inside a `GcBox`.)
+        let ll_arc = ll.clone();
         let param_name = spec
             .param_idx
             .map(|idx| match &code.constants[idx as usize] {

--- a/src/vm/vm_meta_ops.rs
+++ b/src/vm/vm_meta_ops.rs
@@ -102,7 +102,7 @@ impl Interpreter {
                     }
                 }
                 if lazy_inputs {
-                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
+                    Value::LazyList(crate::gc::Gc::new(crate::value::LazyList::new_cached(
                         results,
                     )))
                 } else {
@@ -162,7 +162,7 @@ impl Interpreter {
                     }
                 }
                 if all_lazy {
-                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
+                    Value::LazyList(crate::gc::Gc::new(crate::value::LazyList::new_cached(
                         results,
                     )))
                 } else {
@@ -259,7 +259,7 @@ impl Interpreter {
                     }
                 }
                 if lazy_inputs {
-                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
+                    Value::LazyList(crate::gc::Gc::new(crate::value::LazyList::new_cached(
                         results,
                     )))
                 } else {
@@ -282,7 +282,7 @@ impl Interpreter {
                     results.push(self.combine_meta_tuple(&op, make_tuple, combo)?);
                 }
                 if all_lazy {
-                    Value::LazyList(std::sync::Arc::new(crate::value::LazyList::new_cached(
+                    Value::LazyList(crate::gc::Gc::new(crate::value::LazyList::new_cached(
                         results,
                     )))
                 } else {

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -180,7 +180,7 @@ impl Interpreter {
             computed_count: 0,
         };
         let ll = crate::value::LazyList::new_scan(spec);
-        let ll = std::sync::Arc::new(ll);
+        let ll = crate::gc::Gc::new(ll);
         // Pre-compute an initial batch so that eager consumers (e.g. .Slip,
         // .join) that read the cache directly get a useful prefix.
         const INITIAL_BATCH: usize = 1_000;

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -56,7 +56,7 @@ impl Interpreter {
                 walk_pending: None,
                 cat_pull: None,
             };
-            let val = Value::LazyList(std::sync::Arc::new(list));
+            let val = Value::LazyList(crate::gc::Gc::new(list));
             self.stack.push(val);
             Ok(())
         } else {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -769,7 +769,7 @@ impl Interpreter {
                     Value::LazyList(ref list)
                         if list.coroutine.is_some() || list.is_genuinely_lazy() =>
                     {
-                        Value::LazyList(std::sync::Arc::new(list.with_array_context()))
+                        Value::LazyList(crate::gc::Gc::new(list.with_array_context()))
                     }
                     Value::LazyList(list) => Value::real_array(self.force_lazy_list_vm(&list)?),
                     Value::LazyIoLines { .. } => {
@@ -785,7 +785,7 @@ impl Interpreter {
                             // Preserved into an `@` array: keep it lazy but tag
                             // array context so gist/`.WHAT` render `[...]`/`Array`.
                             Some(Value::Bool(true)) => {
-                                Value::LazyList(std::sync::Arc::new(list.with_array_context()))
+                                Value::LazyList(crate::gc::Gc::new(list.with_array_context()))
                             }
                             _ => Value::real_array(self.force_lazy_list_vm(&list)?),
                         }


### PR DESCRIPTION
Third-wave `Arc → Gc` migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11 step 10). `Value::LazyList` now holds `Gc<LazyList>`, so lazy sequences — which capture an `env` and materialize a `cache` of `Value`s (a gather / closure sequence can capture the very list it produces) — join the cycle-collector graph.

## Changes
- **`impl Trace for LazyList`**: traces `env` + `cache` + `elems_count` (the dominant env-capture cycle sources); `drop_gc_edges` nils them. The on-demand spec states (coroutine / lazy-pipe / closure-seq / scan / walk / cat) also hold `Value`s; leaving them untraced is **conservative** (a cycle routed only through them is not reclaimed, never wrongly freed) — the documented step-10 follow-up. + `Value::LazyList` arm in `gc_trace`.
- **`WeakGc` gains `strong_count` / `as_ptr`**, and the consumed-LazyList registry (`Vec<Weak<LazyList>>` → `Vec<WeakGc<LazyList>>`; `lazylist_consume`/`lazylist_is_consumed`) moves to `Gc`/`WeakGc` (identity via `Gc::as_ptr`).
- **`exec_for_loop_lazy_gather{,_from}`** took `&LazyList` and reconstructed an `Arc<LazyList>` via `Arc::from_raw` — **unsound** now that the value lives inside a `GcBox`. Changed to take `&Gc<LazyList>` and clone the handle directly.
- Mechanical call-site rewrite (~30 files): `Arc::new(LazyList)` → `Gc::new`, `Arc<LazyList>` annotations → `Gc<…>`, `Arc::{clone,ptr_eq,...}` → `Gc::…`.

## Testing
- `.map(*2).lazy` / `lazy gather{}` / infinite `1,2,4,8...*` / `(1..Inf).grep(..)` all behave identically.
- 29 `gc::` unit tests green; `gc_ptr` **Miri (Stacked Borrows) green**; `cargo clippy --all-targets -- -D warnings` clean; `make test` green (14076 tests, 0 failures).

With this, the design §3.1 candidate set is **fully `Gc`-managed**: Hash/Array/Set/Bag/Mix/ContainerRef/Sub/Instance/LazyList. Remaining: the async `Promise`/`Channel`/supply nodes (steps 6-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)