### PR TITLE
feat(gc): MUTSU_GC_LOG (collect logging) + MUTSU_GC_VERIFY (soundness checks) (§9.4/§9.5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -409,6 +409,11 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
          collect を自動起動。`MUTSU_GC_EVERY_SAFEPOINT`/`MUTSU_GC_EVERY_CANDIDATE` トリガ。default off なら
          disarmed で 1 load）。**end-to-end 検証済み**: 実 Raku の self/mutual cycle が collect され、GC-on 出力が
          GC-off と byte 一致（live data 非破壊）。integration test `tests/gc_stress.rs`。
+         - ✅ **デバッグ運用**（§9.4/§9.5）: `MUTSU_GC_LOG=summary|detail|trace`（collect ごとの start/end 行、
+           reason=safepoint 種別、traced/revived/reclaimed/pause_ns。trace は node 単位 reclaim 行）＋
+           `MUTSU_GC_VERIFY=1`（soundness 検証: 回収ノードは strong=0＝生存ノードを解放しない／survivor は
+           black かつ strong 非増加）。実プログラムで VERIFY FAIL=0 を確認（verify が自分の検証ロジックの
+           バグを検出→修正して健全性を実証）。
       6-7,10-11 (残): `Promise`/`Channel` → supply registry root visitor（async cycle）→ `LazyList`
       （third wave）← **次はここ**（設計メモ参照）。call/return/await 等の追加 safepoint 種別・cross-thread
       STW・`MUTSU_GC_AT`/random stress も後続。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -31,6 +31,31 @@ on Arc）の開発に着手した。[docs/gc-level1-detailed-design.md](../docs/
      `Array`/`Hash`/`ContainerRef` の first wave 置換）。unit test（color 遷移・dedup・inert・
      `Send + Sync`）で担保。
 
+## 2026-07-03: Phase B（GC）— デバッグ/検証ツール `MUTSU_GC_LOG` / `MUTSU_GC_VERIFY`（§9.4/§9.5）
+
+collector のデバッグ運用基盤を実装。GC はログ・検証なしでは壊れたとき追跡不能になる（設計メモ §9.4 冒頭）ため、
+collector が本格稼働する前にここを固める。
+
+- **`MUTSU_GC_LOG=summary|detail|trace`**（`gc/collect.rs`）: `off`(既定)/`summary`/`detail`/`trace` の段階別ログ
+  （`1`/`on`=summary 別名）。stderr へ `[mutsu gc]` prefix・`key=value` の grep しやすい固定形式。
+  - `summary`: 非空 collect ごとに `start cycle=N reason=R candidates=C` ／ `end cycle=N traced=T revived=V
+    reclaimed=X roots=C pause_ns=P`。`reason` は safepoint 種別（`backedge`/`program-end`/`manual`…）。
+  - `detail`: `end` 行に `cycles=`（回収サイクル数）追加。
+  - `trace`: 回収ノードごとに `reclaim cycle=N id=…` 行。
+  - safepoint 経由の collect も `collect_cycles_at(reason)` に統一し、`SafepointKind::name()` を reason に渡す。
+- **`MUTSU_GC_VERIFY=1`**（§9.5）: collect 前後に **soundness 不変条件** を検証。
+  - collect 前の pristine snapshot（reachable ノード＋strong）を取り、
+  - **reclaim 前**: 白（回収）ノードは全て strong=0（＝内部サイクル辺だけ＝真のゴミ。strong>0 の回収＝生存
+    ノードの解放＝use-after-free をここで検出）、
+  - **reclaim 後**: survivor は black かつ strong 非増加（scan_black の over-restore/underflow-wrap 検出）。
+  - 実装中、最初 verify が「survivor の strong が pristine に復元されていない」と 2 件 FAIL したが、これは
+    **verify ロジック側の誤り**（回収ゴミから指されていた survivor は当該辺を正当に失うので pristine には戻らない
+    ＝Bacon-Rajan は survivor 辺のみ復元）。正しい不変条件へ修正し FAIL=0 を確認。verify が自らのバグを検出→
+    修正して collector の健全性を実証した形。
+
+検証: integration test `tests/gc_stress.rs::{verify_mode_reports_no_violations, log_modes_emit_expected_lines}`。
+実プログラム（cycle churn / compute）で VERIFY FAIL=0。`make test`（GC off）= Result: PASS、回帰なし。
+
 ## 2026-07-03: Phase B（GC）— `gc_trace` 完全性：wrapper にネストした Gc ノードも辿る（second wave の続き）
 
 second wave（`Sub`/`Instance` → `Gc`、#4123）に続き、コレクタの **辺可視性の穴を塞ぐ** スライス。これまでの

--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -1,9 +1,14 @@
 //! GC Level 1a synchronous cycle collector (ADR-0001 §3-8,
-//! `docs/gc-level1-detailed-design.md` §5 / §9.5 / §11 step 8).
+//! `docs/gc-level1-detailed-design.md` §5 / §9.4 / §9.5 / §11 step 8).
 //!
 //! Bacon-Rajan trial-deletion over the process-global candidate buffer. This is
 //! the first slice that actually *reclaims* garbage: everything before it
 //! (§11 steps 1-7) only built the `Gc` node graph and the candidate buffer.
+//!
+//! Debug surface: `MUTSU_GC_LOG=summary|detail|trace` emits per-collect log
+//! lines (§9.4); `MUTSU_GC_VERIFY=1` checks the collector's soundness invariants
+//! around every collect (§9.5). Both are opt-in and cost nothing on the default
+//! (GC-off) path.
 //!
 //! Scope of this cut:
 //! - **Opt-in.** Reclaim runs from [`collect_cycles`], invoked either manually
@@ -39,7 +44,9 @@
 // `gc_ptr`; removed when a safepoint / builtin invokes `collect_cycles`.
 #![allow(dead_code)]
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use super::gc_ptr::{CollectGuard, Color, ErasedGc, drain_candidates, erased_id, gc_drop_edges};
@@ -66,38 +73,49 @@ fn children(node: &ErasedGc) -> Vec<ErasedGc> {
     kids
 }
 
-fn mark_gray(node: &ErasedGc) {
+/// Per-collect phase counters, for the `MUTSU_GC_LOG` summary/detail lines.
+#[derive(Default)]
+struct Metrics {
+    /// Nodes colored gray (the candidate subgraph size).
+    traced: usize,
+    /// Nodes `scan_black` restored (survivors kept alive by an external ref).
+    revived: usize,
+}
+
+fn mark_gray(node: &ErasedGc, m: &mut Metrics) {
     if node.gc_color() == Color::Gray {
         return;
     }
     node.gc_set_color(Color::Gray);
+    m.traced += 1;
     for child in children(node) {
         child.gc_strong_dec();
-        mark_gray(&child);
+        mark_gray(&child, m);
     }
 }
 
-fn scan(node: &ErasedGc) {
+fn scan(node: &ErasedGc, m: &mut Metrics) {
     if node.gc_color() != Color::Gray {
         return;
     }
     if node.gc_strong() > 0 {
         // Kept alive by an external reference — restore the subgraph.
-        scan_black(node);
+        scan_black(node, m);
     } else {
         node.gc_set_color(Color::White);
         for child in children(node) {
-            scan(&child);
+            scan(&child, m);
         }
     }
 }
 
-fn scan_black(node: &ErasedGc) {
+fn scan_black(node: &ErasedGc, m: &mut Metrics) {
     node.gc_set_color(Color::Black);
+    m.revived += 1;
     for child in children(node) {
         child.gc_strong_inc();
         if child.gc_color() != Color::Black {
-            scan_black(&child);
+            scan_black(&child, m);
         }
     }
 }
@@ -136,23 +154,156 @@ fn reclaim(white: Vec<ErasedGc>, roots: Vec<ErasedGc>) {
     drop(roots);
 }
 
-/// Run one synchronous cycle collection over the current candidate buffer.
+/// GC log verbosity (`MUTSU_GC_LOG`, design §9.4): `summary` = start/end lines
+/// per non-empty collect; `detail` adds the cycle count; `trace` adds a line per
+/// reclaimed node. Unset / `off` = silent. `1`/`on` alias `summary`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum LogMode {
+    Off,
+    Summary,
+    Detail,
+    Trace,
+}
+
+pub(crate) fn log_mode() -> LogMode {
+    static M: OnceLock<LogMode> = OnceLock::new();
+    *M.get_or_init(|| match std::env::var("MUTSU_GC_LOG").ok().as_deref() {
+        None | Some("0") | Some("off") => LogMode::Off,
+        Some("summary") | Some("1") | Some("on") => LogMode::Summary,
+        Some("detail") => LogMode::Detail,
+        Some("trace") => LogMode::Trace,
+        Some(other) => {
+            eprintln!("[mutsu gc] warning: unrecognized MUTSU_GC_LOG={other:?}, using summary");
+            LogMode::Summary
+        }
+    })
+}
+
+/// `MUTSU_GC_VERIFY=1` (design §9.5): check the collector's invariants around
+/// every collect. Opt-in — it costs an extra pristine-strong snapshot walk.
+pub(crate) fn verify_enabled() -> bool {
+    static V: OnceLock<bool> = OnceLock::new();
+    *V.get_or_init(|| match std::env::var("MUTSU_GC_VERIFY").ok().as_deref() {
+        Some("1") => true,
+        None | Some("0") => false,
+        Some(other) => {
+            eprintln!("[mutsu gc] warning: unrecognized MUTSU_GC_VERIFY={other:?}, treating as 0");
+            false
+        }
+    })
+}
+
+fn next_cycle_id() -> u64 {
+    static N: AtomicU64 = AtomicU64::new(0);
+    N.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Snapshot every node reachable from `roots` with its *pristine* strong count
+/// (called before `mark_gray` mutates it), for `MUTSU_GC_VERIFY`. Holding an
+/// `ErasedGc` per node keeps it alive so survivors can be re-inspected after the
+/// collect; the caller drops the garbage entries before `reclaim` so the white
+/// nodes still free. Keyed by node id to dedup the graph.
+fn snapshot_reachable(roots: &[ErasedGc]) -> HashMap<usize, (ErasedGc, usize)> {
+    let mut snap: HashMap<usize, (ErasedGc, usize)> = HashMap::new();
+    let mut stack: Vec<ErasedGc> = roots.to_vec();
+    while let Some(node) = stack.pop() {
+        let id = erased_id(&node);
+        if snap.contains_key(&id) {
+            continue;
+        }
+        let strong = node.gc_strong();
+        for child in children(&node) {
+            stack.push(child);
+        }
+        snap.insert(id, (node, strong));
+    }
+    snap
+}
+
+/// Verify the collector's SOUNDNESS invariant (design §9.5): no node with a live
+/// external reference may be reclaimed. Every reclaimed (white) node must have
+/// GC strong count 0 at reclaim time — trial-deletion having removed all its
+/// internal cycle edges left nothing, i.e. it was genuine garbage. A white node
+/// with `strong > 0` means a still-referenced node is about to be freed
+/// (use-after-free). Runs BEFORE reclaim, while the nodes are still alive.
+fn verify_reclaimed_are_garbage(cycle: u64, white: &[ErasedGc]) -> usize {
+    let mut bad = 0;
+    for node in white {
+        let strong = node.gc_strong();
+        if strong != 0 {
+            bad += 1;
+            eprintln!(
+                "[mutsu gc] VERIFY FAIL cycle={cycle} id={} reclaimed with strong={strong} \
+                 (a still-referenced node is being freed)",
+                erased_id(node),
+            );
+        }
+    }
+    if bad > 0 {
+        eprintln!("[mutsu gc] VERIFY cycle={cycle}: {bad} live node(s) wrongly reclaimed");
+    }
+    bad
+}
+
+/// Verify the post-collect heap sanity of the survivors (design §9.5): each must
+/// end black (no node left stuck gray/white = incomplete scan) and must not have
+/// GAINED references during the collect (`strong_after <= strong_before` — a
+/// survivor only ever loses edges from reclaimed garbage; a larger count means an
+/// over-restore / underflow-wrap in `scan_black`). Runs AFTER reclaim.
+fn verify_survivors(cycle: u64, survivors: &[(ErasedGc, usize)]) -> usize {
+    let mut failures = 0;
+    for (node, strong_before) in survivors {
+        let strong_after = node.gc_strong();
+        let color = node.gc_color();
+        if color != Color::Black || strong_after > *strong_before {
+            failures += 1;
+            eprintln!(
+                "[mutsu gc] VERIFY FAIL cycle={cycle} id={} strong_before={strong_before} \
+                 strong_after={strong_after} color={color:?} (survivor left inconsistent)",
+                erased_id(node),
+            );
+        }
+    }
+    if failures > 0 {
+        eprintln!("[mutsu gc] VERIFY cycle={cycle}: {failures} survivor invariant violation(s)");
+    }
+    failures
+}
+
+/// Run one synchronous cycle collection over the current candidate buffer,
+/// attributing it to `reason` in the `MUTSU_GC_LOG` output (the safepoint kind,
+/// `manual`, or `program-end`).
 ///
 /// Safe to call at any time: with no candidates buffered it is a no-op. Returns
 /// what it reclaimed and records the same into `MUTSU_VM_STATS`.
-pub(crate) fn collect_cycles() -> CollectStats {
+pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
     let start = Instant::now();
     let roots = drain_candidates();
     if roots.is_empty() {
         return CollectStats::default();
     }
     let roots_scanned = roots.len();
+    let mode = log_mode();
+    let verify = verify_enabled();
+    let cycle = if mode != LogMode::Off || verify {
+        next_cycle_id()
+    } else {
+        0
+    };
 
+    if mode != LogMode::Off {
+        eprintln!("[mutsu gc] start cycle={cycle} reason={reason} candidates={roots_scanned}");
+    }
+
+    // Pristine snapshot for verify, before trial-deletion mutates strong counts.
+    let snapshot = verify.then(|| snapshot_reachable(&roots));
+
+    let mut m = Metrics::default();
     for root in &roots {
-        mark_gray(root);
+        mark_gray(root, &mut m);
     }
     for root in &roots {
-        scan(root);
+        scan(root, &mut m);
     }
     let mut white = Vec::new();
     let mut seen = HashSet::new();
@@ -162,9 +313,34 @@ pub(crate) fn collect_cycles() -> CollectStats {
             cycles += 1;
         }
     }
-
     let reclaimed_nodes = white.len();
+
+    // Keep only survivor snapshot handles across reclaim; dropping the garbage
+    // handles here lets `reclaim` actually free the white nodes.
+    let survivors = snapshot.map(|snap| {
+        let white_ids: HashSet<usize> = white.iter().map(erased_id).collect();
+        snap.into_iter()
+            .filter(|(id, _)| !white_ids.contains(id))
+            .map(|(_, entry)| entry)
+            .collect::<Vec<_>>()
+    });
+
+    if mode == LogMode::Trace {
+        for node in &white {
+            eprintln!("[mutsu gc] reclaim cycle={cycle} id={}", erased_id(node));
+        }
+    }
+
+    // Soundness check must run BEFORE reclaim frees the white nodes.
+    if verify {
+        verify_reclaimed_are_garbage(cycle, &white);
+    }
+
     reclaim(white, roots);
+
+    if let Some(survivors) = &survivors {
+        verify_survivors(cycle, survivors);
+    }
 
     let pause_ns = start.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
     record_gc_collection(
@@ -173,6 +349,19 @@ pub(crate) fn collect_cycles() -> CollectStats {
         cycles as u64,
         pause_ns,
     );
+
+    if mode != LogMode::Off {
+        let cycles_field = if mode >= LogMode::Detail {
+            format!(" cycles={cycles}")
+        } else {
+            String::new()
+        };
+        eprintln!(
+            "[mutsu gc] end cycle={cycle} traced={} revived={} reclaimed={reclaimed_nodes}{cycles_field} roots={roots_scanned} pause_ns={pause_ns}",
+            m.traced, m.revived,
+        );
+    }
+
     CollectStats {
         roots_scanned,
         reclaimed_nodes,
@@ -180,36 +369,26 @@ pub(crate) fn collect_cycles() -> CollectStats {
     }
 }
 
+/// Run one collection attributed to `manual` (used by the debug hook / tests).
+pub(crate) fn collect_cycles() -> CollectStats {
+    collect_cycles_at("manual")
+}
+
 /// Debug hook (design doc §9.5): force a collect now, regardless of triggers.
 /// The entry point a future `gc_debug_collect_now` builtin / REPL command and
 /// the integration tests call.
 pub(crate) fn gc_debug_collect_now() -> CollectStats {
-    collect_cycles()
+    collect_cycles_at("manual")
 }
 
-/// Run a collection at a named safepoint if `MUTSU_GC=on`, logging the result
-/// when `MUTSU_GC_LOG=1` (design §9.4). No-op with GC off, so the wired call
-/// sites are free on the default path. This is the seam that turns the
-/// otherwise manual-only collector (`gc_debug_collect_now`) into one that runs
-/// automatically at program safepoints (§11 step 8).
+/// Run a collection at a named safepoint if `MUTSU_GC=on`. No-op with GC off, so
+/// the wired call sites are free on the default path. Logging/verify happen
+/// inside [`collect_cycles_at`] under `MUTSU_GC_LOG` / `MUTSU_GC_VERIFY`.
 pub(crate) fn collect_if_enabled(safepoint: &str) {
     if !super::gc_ptr::gc_enabled() {
         return;
     }
-    let stats = collect_cycles();
-    if gc_log_enabled() && (stats.reclaimed_nodes > 0 || stats.reclaimed_cycles > 0) {
-        eprintln!(
-            "[mutsu gc] collect@{safepoint}: reclaimed {} nodes in {} cycles ({} roots scanned)",
-            stats.reclaimed_nodes, stats.reclaimed_cycles, stats.roots_scanned,
-        );
-    }
-}
-
-/// `MUTSU_GC_LOG=1`/`on` — emit a line per non-empty collection (design §9.4).
-fn gc_log_enabled() -> bool {
-    use std::sync::OnceLock;
-    static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| matches!(std::env::var("MUTSU_GC_LOG").as_deref(), Ok("1") | Ok("on")))
+    collect_cycles_at(safepoint);
 }
 
 #[cfg(test)]

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -24,7 +24,10 @@ mod root_visitor;
 mod safepoint;
 
 #[allow(unused_imports)]
-pub(crate) use collect::{CollectStats, collect_cycles, collect_if_enabled, gc_debug_collect_now};
+pub(crate) use collect::{
+    CollectStats, LogMode, collect_cycles, collect_cycles_at, collect_if_enabled,
+    gc_debug_collect_now, log_mode, verify_enabled,
+};
 #[allow(unused_imports)]
 pub(crate) use gc_ptr::{
     Color, ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, drain_candidates, gc_contents_mut,

--- a/src/gc/safepoint.rs
+++ b/src/gc/safepoint.rs
@@ -23,7 +23,7 @@
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use super::collect::collect_cycles;
+use super::collect::collect_cycles_at;
 use super::gc_ptr::gc_enabled;
 
 /// A re-entry boundary at which a collect may run (design doc §9.2a). Only
@@ -50,6 +50,24 @@ pub(crate) enum SafepointKind {
     ThreadJoin,
     /// Explicit debug / manual collect.
     Manual,
+}
+
+impl SafepointKind {
+    /// Short stable name, used as the collect `reason` in `MUTSU_GC_LOG` output
+    /// (and the string a future `MUTSU_GC_AT` would match).
+    fn name(self) -> &'static str {
+        match self {
+            SafepointKind::Backedge => "backedge",
+            SafepointKind::Call => "call",
+            SafepointKind::Return => "return",
+            SafepointKind::Await => "await",
+            SafepointKind::ReactPoll => "react_poll",
+            SafepointKind::LazyForce => "lazy_force",
+            SafepointKind::NestedRun => "nested_run",
+            SafepointKind::ThreadJoin => "thread_join",
+            SafepointKind::Manual => "manual",
+        }
+    }
 }
 
 /// Resolved trigger policy, read once from the environment.
@@ -141,7 +159,7 @@ pub(crate) fn note_candidate_push() {
 /// a no-op unless [`armed`]; safe to call anywhere the caller holds no borrow
 /// into a `Gc`-managed container (design doc §1.2).
 #[inline]
-pub(crate) fn gc_safepoint(_kind: SafepointKind) {
+pub(crate) fn gc_safepoint(kind: SafepointKind) {
     if !armed() {
         return;
     }
@@ -150,6 +168,6 @@ pub(crate) fn gc_safepoint(_kind: SafepointKind) {
     // arming from the candidate counter.
     let fire = t.every_safepoint || PENDING.swap(false, Ordering::Relaxed);
     if fire {
-        collect_cycles();
+        collect_cycles_at(kind.name());
     }
 }

--- a/tests/gc_stress.rs
+++ b/tests/gc_stress.rs
@@ -107,6 +107,75 @@ fn wrapper_nested_cycles_are_reclaimed_and_preserve_data() {
     );
 }
 
+/// `MUTSU_GC_VERIFY=1` runs the collector's soundness/heap-sanity checks around
+/// every collect; a correct collector must report zero violations on real
+/// programs, cyclic or not.
+#[test]
+fn verify_mode_reports_no_violations() {
+    let programs = [
+        // Heavy cycle churn.
+        r#"for ^40 { my %h; %h<self> := %h; my %x; my %y; %x<y> := %y; %y<x> := %x; }; say "ok";"#,
+        // Compute with live nested structures (nothing should be reclaimed wrongly).
+        r#"my %m; for 1..30 -> $i { %m{$i} = [$i, $i*$i].sum; }; say %m.values.sum;"#,
+    ];
+    for src in programs {
+        let (out, err, ok) = run(
+            src,
+            &[
+                ("MUTSU_GC", "on"),
+                ("MUTSU_GC_EVERY_SAFEPOINT", "1"),
+                ("MUTSU_GC_VERIFY", "1"),
+            ],
+        );
+        assert!(ok, "verify run must not crash; stderr:\n{err}");
+        assert!(!out.is_empty(), "program produced output");
+        assert!(
+            !err.contains("VERIFY FAIL"),
+            "collector verify reported a violation:\n{err}"
+        );
+    }
+}
+
+/// `MUTSU_GC_LOG=summary` emits a start/end line per non-empty collect, and
+/// `trace` emits a per-reclaimed-node line — the debug-log surface (§9.4).
+#[test]
+fn log_modes_emit_expected_lines() {
+    let cyclic = r#"for ^10 { my %h; %h<self> := %h; }; say "ok";"#;
+
+    let (_, summary_err, ok1) = run(
+        cyclic,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_EVERY_SAFEPOINT", "1"),
+            ("MUTSU_GC_LOG", "summary"),
+        ],
+    );
+    assert!(ok1);
+    assert!(
+        summary_err.contains("[mutsu gc] start cycle=")
+            && summary_err.contains("[mutsu gc] end cycle="),
+        "summary log missing start/end lines:\n{summary_err}"
+    );
+    assert!(
+        summary_err.contains("reason=backedge"),
+        "summary log missing the safepoint reason:\n{summary_err}"
+    );
+
+    let (_, trace_err, ok2) = run(
+        cyclic,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_EVERY_SAFEPOINT", "1"),
+            ("MUTSU_GC_LOG", "trace"),
+        ],
+    );
+    assert!(ok2);
+    assert!(
+        trace_err.contains("[mutsu gc] reclaim cycle="),
+        "trace log missing per-node reclaim lines:\n{trace_err}"
+    );
+}
+
 /// A program that repeatedly builds self-referential / mutual cycles and drops
 /// them must actually get those cycles reclaimed (not just leak), and survive.
 #[test]


### PR DESCRIPTION
Debug/verification surface for the cycle collector — critical before it runs in anger, since a GC is untraceable when it breaks without logs (design §9.4).

### `MUTSU_GC_LOG=summary|detail|trace`
Upgrades #4121's boolean flag to the design's levels (`1`/`on` alias `summary`). Emits `[mutsu gc]` `key=value` lines to stderr per **non-empty** collect:
- **summary:** `start cycle=N reason=R candidates=C` / `end cycle=N traced=T revived=V reclaimed=X roots=C pause_ns=P`. `reason` is the safepoint kind (`backedge` / `program-end` / `manual` / ...).
- **detail:** adds `cycles=` to the end line.
- **trace:** a `reclaim cycle=N id=...` line per reclaimed node.

Safepoint collects now route through `collect_cycles_at(reason)` so every path logs uniformly; `SafepointKind::name()` supplies the reason.

### `MUTSU_GC_VERIFY=1` (§9.5)
Snapshots pristine `(node, strong)` before `mark`, then checks the collector's **soundness invariants** around every collect:
- Every reclaimed (white) node has `strong == 0` at reclaim time — **no still-referenced node is freed** (no use-after-free).
- Every survivor ends **black** with `strong_after <= strong_before` (no incomplete scan / over-restore).

Garbage snapshot handles are dropped before `reclaim` so the white nodes still free.

> While building verify it first flagged 2 "survivor strong not restored" violations — which turned out to be a bug **in the VERIFY logic, not the collector**: a survivor pointed to by reclaimed garbage legitimately loses that edge (Bacon-Rajan only restores edges from *surviving* nodes), so it does not return to its pristine count. Corrected to the design's soundness checks; `VERIFY FAIL` is now `0` on real programs — verify caught its own bug, then validated the collector.

### Verification
- New integration tests: `verify_mode_reports_no_violations` (cycle-churn + compute programs, zero violations), `log_modes_emit_expected_lines`.
- `make test` (GC off) = **Result: PASS** (1459 files, 14076 tests, no regression). `cargo clippy -- -D warnings` clean.
- Rebased onto main after #4125 (LazyList → Gc); verify stays clean with LazyList nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)