### PR TITLE
GC steps 6-7: migrate Value::Promise and Value::Channel to Gc

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1392,7 +1392,7 @@ struct PromiseState {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SharedPromise {
-    inner: Arc<(Mutex<PromiseState>, Condvar)>,
+    inner: crate::gc::Gc<(Mutex<PromiseState>, Condvar)>,
 }
 
 // --- SharedChannel: thread-safe channel ---
@@ -1409,7 +1409,7 @@ struct ChannelState {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SharedChannel {
-    inner: Arc<(Mutex<ChannelState>, Condvar)>,
+    inner: crate::gc::Gc<(Mutex<ChannelState>, Condvar)>,
 }
 
 // Compile-time assertions that Value is Send + Sync

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -15,7 +15,7 @@ impl std::fmt::Debug for PromiseState {
 impl SharedPromise {
     /// Returns a raw pointer to the inner Arc data, for use in WHICH identity.
     pub fn arc_ptr(&self) -> *const () {
-        Arc::as_ptr(&self.inner) as *const ()
+        crate::gc::Gc::as_ptr(&self.inner) as *const ()
     }
 
     pub(crate) fn new() -> Self {
@@ -24,7 +24,7 @@ impl SharedPromise {
 
     pub(crate) fn new_with_class(class_name: Symbol) -> Self {
         Self {
-            inner: Arc::new((
+            inner: crate::gc::Gc::new((
                 Mutex::new(PromiseState {
                     status: "Planned".to_string(),
                     result: Value::Nil,
@@ -42,7 +42,7 @@ impl SharedPromise {
     #[allow(dead_code)]
     pub(crate) fn new_kept(result: Value) -> Self {
         Self {
-            inner: Arc::new((
+            inner: crate::gc::Gc::new((
                 Mutex::new(PromiseState {
                     status: "Kept".to_string(),
                     result,
@@ -63,7 +63,7 @@ impl SharedPromise {
     }
 
     pub(crate) fn id(&self) -> usize {
-        Arc::as_ptr(&self.inner) as usize
+        crate::gc::Gc::as_ptr(&self.inner) as usize
     }
 
     /// Store an opaque payload to be handed off to whoever awaits the
@@ -236,20 +236,20 @@ impl SharedPromise {
 
 impl PartialEq for SharedPromise {
     fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
+        crate::gc::Gc::ptr_eq(&self.inner, &other.inner)
     }
 }
 
 impl SharedChannel {
     /// Returns a raw pointer to the inner Arc data, for use in WHICH identity.
     pub fn arc_ptr(&self) -> *const () {
-        Arc::as_ptr(&self.inner) as *const ()
+        crate::gc::Gc::as_ptr(&self.inner) as *const ()
     }
 
     pub(crate) fn new() -> Self {
         let closed_promise = SharedPromise::new();
         Self {
-            inner: Arc::new((
+            inner: crate::gc::Gc::new((
                 Mutex::new(ChannelState {
                     queue: std::collections::VecDeque::new(),
                     send_closed: false,
@@ -357,6 +357,6 @@ impl SharedChannel {
 
 impl PartialEq for SharedChannel {
     fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
+        crate::gc::Gc::ptr_eq(&self.inner, &other.inner)
     }
 }

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -16,13 +16,13 @@
 //! `Junction` is likewise not in the design doc's candidate list and is
 //! excluded.
 
-use std::sync::Mutex;
+use std::sync::{Condvar, Mutex};
 
 use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
 use super::{
-    ArrayData, BagData, HashData, InstanceAttrs, LazyList, MixData, SetData, SharedChannel,
-    SharedPromise, SubData, Value,
+    ArrayData, BagData, ChannelState, HashData, InstanceAttrs, LazyList, MixData, PromiseState,
+    SetData, SharedChannel, SharedPromise, SubData, Value,
 };
 
 impl Value {
@@ -95,7 +95,52 @@ impl Value {
                 fetcher.gc_trace(visit);
                 storer.gc_trace(visit);
             }
+            // Migrated async `Gc<T>` node variants (§11 steps 6-7): yield the
+            // node; its `Trace` impl walks the held result / queue / callbacks.
+            Value::Promise(p) => visit(&p.erased()),
+            Value::Channel(c) => visit(&c.erased()),
             _ => {}
+        }
+    }
+}
+
+/// A promise node's single `Value` edge is its resolved `result`. Its queued
+/// `waiters` are boxed `FnOnce` closures — opaque to a visitor (they may capture
+/// `Value`s, but those are unreachable through this node until the callback runs
+/// and are dropped when the promise resolves), so they are not traced.
+/// Async node migration (§11 step 6).
+impl Trace for (Mutex<PromiseState>, Condvar) {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        if let Ok(state) = self.0.lock() {
+            state.result.gc_trace(visit);
+        }
+    }
+    fn drop_gc_edges(&mut self) {
+        if let Ok(state) = self.0.get_mut() {
+            state.result = Value::Nil;
+            state.waiters.clear();
+        }
+    }
+}
+
+/// A channel node's `Value` edges are its buffered `queue`, its `failure`, and
+/// its `closed_promise` node. Async node migration (§11 step 7).
+impl Trace for (Mutex<ChannelState>, Condvar) {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        if let Ok(state) = self.0.lock() {
+            for v in &state.queue {
+                v.gc_trace(visit);
+            }
+            if let Some(f) = &state.failure {
+                f.gc_trace(visit);
+            }
+            visit(&state.closed_promise.erased());
+        }
+    }
+    fn drop_gc_edges(&mut self) {
+        if let Ok(state) = self.0.get_mut() {
+            state.queue.clear();
+            state.failure = None;
         }
     }
 }
@@ -369,6 +414,12 @@ impl InstanceAttrs {
 }
 
 impl SharedPromise {
+    /// The type-erased GC node handle for this promise (its `Gc` inner), for the
+    /// collector's `Value::Promise` trace edge.
+    pub(crate) fn erased(&self) -> ErasedGc {
+        self.inner.erased()
+    }
+
     #[allow(dead_code)]
     pub(crate) fn visit_gc_children(&self, visitor: &mut dyn RootVisitor) {
         if let Ok(state) = self.inner.0.lock() {
@@ -382,6 +433,12 @@ impl SharedPromise {
 }
 
 impl SharedChannel {
+    /// The type-erased GC node handle for this channel (its `Gc` inner), for the
+    /// collector's `Value::Channel` trace edge.
+    pub(crate) fn erased(&self) -> ErasedGc {
+        self.inner.erased()
+    }
+
     #[allow(dead_code)]
     pub(crate) fn visit_gc_children(&self, visitor: &mut dyn RootVisitor) {
         if let Ok(state) = self.inner.0.lock() {


### PR DESCRIPTION
Async-node `Arc → Gc` migration (ADR-0001 layer 3a, `docs/gc-level1-detailed-design.md` §11 steps 6-7). `SharedPromise`/`SharedChannel` now back their state cell with `Gc<(Mutex<State>, Condvar)>` instead of `Arc`, so promises and channels join the cycle-collector graph — the async cycle class the ADR calls out (a Promise whose `.then` result captures the Promise; a self-referential Channel graph).

Kept the `(Mutex<State>, Condvar)` tuple shape so every `.inner.0` (state lock) / `.inner.1` (condvar) access — and the blocking-await `Condvar` — is unchanged; only the smart pointer flips.

## Changes
- **`impl Trace for (Mutex<PromiseState>, Condvar)`**: traces the resolved `result`; `drop_gc_edges` nils it and clears `waiters` (boxed `FnOnce` callbacks are opaque to tracing, so not walked). **`for (Mutex<ChannelState>, Condvar)`**: traces `queue` + `failure` + `closed_promise` node; clears queue/failure. + `Value::Promise`/`Channel` arms in `gc_trace` and `SharedPromise/SharedChannel::erased()`.
- `value_async.rs`: `Arc::as_ptr/ptr_eq(&self.inner)` → `crate::gc::Gc::…`, `inner: Arc::new(..)` → `Gc::new(..)`. **No weak-promise handles exist**, so no `WeakGc` plumbing needed (unlike Sub/LazyList).

## Testing
- `start{}`/`await`, `Channel.new`/`send`/`close`/`list`, parallel `start` fan-out behave identically.
- 29 `gc::` unit tests green; concurrency local tests green; `gc_ptr` **Miri (Stacked Borrows) green**; `cargo clippy --all-targets -- -D warnings` clean; `make test` green (14076 tests, 0 failures).

**This completes the ADR-0001 layer-3a container/node migration**: every §3.1 candidate — `Hash`/`Array`/`Set`/`Bag`/`Mix`/`ContainerRef`/`Sub`/`Instance`/`LazyList`/`Promise`/`Channel` — is now `Gc`-managed. Remaining GC work is the supply-registry root visitor (§7) and collector hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)