### PR TITLE
feat(gc): supply/promise registry root visitor (§11 step 7, first wave)

### DIFF
--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -7,12 +7,13 @@
 //! later steps of the design doc's implementation order) so root enumeration
 //! is never duplicated at a future collector call site.
 //!
+//! The process-global supply/async registries (`supplier_state_map`,
+//! `supplier_subscriptions_map`, `promise_combinator_map`, `supply_taps_map`,
+//! the whenever-done/zip state maps) are enumerated by
+//! [`Interpreter::visit_supply_registries`] — §11 step 7 first wave.
+//!
 //! Deliberately out of scope for this pass (see the design doc for why each is
 //! sequenced later):
-//! - The process-global supply/async registries (`supplier_state_map`,
-//!   `promise_combinator_map`, `supply_taps_map`, ...) — §11 step 7, a
-//!   separate root-visitor pass mirroring the first/second/third-wave split
-//!   for GC-managed node *types* themselves.
 //! - `LazyList` internals (`env`/`cache`/coroutine/lazy-pipe state) — §11 step
 //!   10 (third wave). A root that merely *points at* a `LazyList` (e.g.
 //!   `ForLoopResumeState::LazyGather`) is noted but not traced through yet.
@@ -36,6 +37,24 @@ impl Interpreter {
         self.visit_lexical_envs(visitor);
         self.visit_dispatch_state(visitor);
         self.visit_persistent_caches(visitor);
+        self.visit_supply_registries(visitor);
+    }
+
+    /// Process-global supply/async registries (design doc §3.4 / §11 step 7).
+    ///
+    /// Unlike the per-interpreter roots above, these registries live in
+    /// process-global statics (`state`/`state_supplier` modules) and are shared
+    /// across every thread's interpreter — the same reason §6.2 mandates a
+    /// global collect. They are root *containers*, never GC-managed nodes: the
+    /// collector must see the `Value`s / async nodes they keep reachable (tap
+    /// callbacks, done/quit/close phasers, emitted values, pending & combinator
+    /// promises, channel sinks) so a supply-held closure/`Promise`/`Channel`
+    /// isn't misjudged garbage. Enumerating them from any interpreter's
+    /// `visit_roots` is correct (visiting a root twice is harmless), mirroring
+    /// how `shared_vars` — also cross-thread `Arc`-shared — is already visited.
+    fn visit_supply_registries(&self, visitor: &mut dyn RootVisitor) {
+        crate::runtime::native_methods::state::visit_supply_state_roots(visitor);
+        crate::runtime::native_methods::state_supplier::visit_supplier_subscription_roots(visitor);
     }
 
     /// Former `VM` struct fields (CP-3 collapse) — the live bytecode
@@ -257,5 +276,23 @@ mod tests {
         interp.visit_roots(&mut visitor);
         // No assertion on the exact count — this just proves the traversal
         // is sound (no panics/deadlocks) against real post-execution state.
+    }
+
+    #[test]
+    fn visit_roots_does_not_deadlock_over_supply_registries() {
+        // Exercise the process-global supply/promise registries populated by a
+        // real supply/react program, proving `visit_supply_registries` neither
+        // panics nor deadlocks against live registry state.
+        let mut interp = Interpreter::new();
+        interp
+            .run(
+                "my $s = Supplier.new; my @got; \
+                 $s.Supply.tap(-> $v { @got.push($v) }); \
+                 $s.emit(1); $s.emit(2); $s.done; say @got.elems;",
+            )
+            .unwrap();
+
+        let mut visitor = CountingVisitor { count: 0 };
+        interp.visit_roots(&mut visitor);
     }
 }

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -168,6 +168,51 @@ pub(crate) fn supplier_snapshot(supplier_id: u64) -> (Vec<Value>, bool, Option<V
     }
 }
 
+/// Enumerate every `Value` (and `Value`-wrapped async node) held live by the
+/// process-global supply/promise registries defined in *this* module, for GC
+/// root enumeration (`Interpreter::visit_roots`; design doc §3.4 / §11 step 7).
+///
+/// These registries are GC **root containers**, not GC-managed nodes: the
+/// collector never frees them, it only needs to see the `Value`s / async nodes
+/// they keep reachable so a supply-held `Promise`/`Channel`/callback closure is
+/// not misjudged as garbage. `Value::Promise` wrapping a `SharedPromise` (etc.)
+/// is created transiently just to feed the visitor — it is not retained.
+///
+/// The blocking `.lock()` matches `visit_roots`' `shared_vars` read: a
+/// root-enumeration pass runs at a re-entry boundary (design doc §1.2) where no
+/// thread holds these locks, and skipping a contended lock would be *unsound*
+/// (a live root could be missed), so we must not `try_lock`-and-skip.
+#[allow(dead_code)] // live once a collector consumes `visit_roots` (step 8)
+pub(in crate::runtime) fn visit_supply_state_roots(visitor: &mut dyn crate::gc::RootVisitor) {
+    if let Ok(map) = supply_taps_map().lock() {
+        for taps in map.values() {
+            for v in taps {
+                visitor.visit_value(v);
+            }
+        }
+    }
+    if let Ok(map) = promise_combinator_map().lock() {
+        for promises in map.values() {
+            for p in promises {
+                visitor.visit_value(&Value::Promise(p.clone()));
+            }
+        }
+    }
+    if let Ok(map) = supplier_state_map().lock() {
+        for state in map.values() {
+            for v in &state.emitted {
+                visitor.visit_value(v);
+            }
+            if let Some(reason) = &state.quit_reason {
+                visitor.visit_value(reason);
+            }
+            for p in &state.pending_promises {
+                visitor.visit_value(&Value::Promise(p.clone()));
+            }
+        }
+    }
+}
+
 pub(crate) fn split_supply_chunks_into_lines(chunks: &[Value], chomp: bool) -> Vec<Value> {
     let mut combined = String::new();
     for chunk in chunks {
@@ -637,5 +682,45 @@ pub(in crate::runtime) fn set_listener_closed(listener_id: u64) {
         && let Some(flag) = map.get(&listener_id)
     {
         flag.store(true, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod gc_root_tests {
+    use super::*;
+
+    struct Collector {
+        seen: Vec<String>,
+    }
+
+    impl crate::gc::RootVisitor for Collector {
+        fn visit_value(&mut self, value: &Value) {
+            if let Value::Str(s) = value {
+                self.seen.push(s.to_string());
+            }
+        }
+    }
+
+    #[test]
+    fn visit_supply_state_roots_sees_emitted_values() {
+        // A high, test-unique id avoids colliding with any other test that
+        // shares this process-global registry (tests run in parallel).
+        let supplier_id = 0xF00D_0001;
+        let sentinel = "__gc_supply_state_root_sentinel__";
+        supplier_emit(supplier_id, Value::str(sentinel.to_string()));
+
+        let mut collector = Collector { seen: Vec::new() };
+        visit_supply_state_roots(&mut collector);
+
+        assert!(
+            collector.seen.iter().any(|s| s == sentinel),
+            "visit_supply_state_roots should enumerate the emitted sentinel"
+        );
+
+        // Leave the registry as we found it (empty for this id).
+        supplier_reset(supplier_id);
+        if let Ok(mut map) = supplier_state_map().lock() {
+            map.remove(&supplier_id);
+        }
     }
 }

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -1739,3 +1739,149 @@ pub(in crate::runtime) fn zip_latest_state_info(zip_latest_state_id: u64) -> (u6
     }
     (0, None)
 }
+
+// ── GC root enumeration ──────────────────────────────────────────────
+//
+// The subscription/whenever/zip registries above are the supply-side half of
+// the process-global supply graph (design doc §3.4). They are GC **root
+// containers**, not GC-managed nodes: `Interpreter::visit_roots` enumerates the
+// `Value`s (tap callbacks, done/quit/close phasers, channel sinks, unique/
+// classify/produce/start/batch/zip state) they keep reachable so a supply-held
+// closure/`Channel` is never misjudged garbage. See `visit_supply_state_roots`
+// in the sibling `state` module for the promise/emit half and the rationale for
+// the blocking `.lock()`.
+
+/// Visit every `Value` held live by one tap subscription's transform state.
+fn visit_tap_roots(tap: &SupplierTapSubscription, visitor: &mut dyn crate::gc::RootVisitor) {
+    visitor.visit_value(&tap.callback);
+    if let Some(channel) = &tap.channel_sink {
+        visitor.visit_value(&Value::Channel(channel.clone()));
+    }
+    if let Some(uf) = &tap.unique_filter {
+        if let Some(f) = &uf.as_fn {
+            visitor.visit_value(f);
+        }
+        if let Some(f) = &uf.with_fn {
+            visitor.visit_value(f);
+        }
+        for (v, _) in &uf.seen {
+            visitor.visit_value(v);
+        }
+    }
+    if let Some(cs) = &tap.classify_state {
+        visitor.visit_value(&cs.mapper);
+        for v in &cs.seen_keys {
+            visitor.visit_value(v);
+        }
+        for (v, _) in &cs.key_supplier_ids {
+            visitor.visit_value(v);
+        }
+    }
+    if let Some(ps) = &tap.produce_state {
+        visitor.visit_value(&ps.callable);
+        if let Some(acc) = &ps.accumulator {
+            visitor.visit_value(acc);
+        }
+    }
+    if let Some(ss) = &tap.start_state {
+        visitor.visit_value(&ss.callable);
+    }
+    if let Some(bs) = &tap.batch_state {
+        for v in &bs.buffer {
+            visitor.visit_value(v);
+        }
+    }
+}
+
+/// Enumerate every `Value` held live by the process-global supply subscription
+/// registries defined in *this* module (design doc §3.4 / §11 step 7).
+#[allow(dead_code)] // live once a collector consumes `visit_roots` (step 8)
+pub(in crate::runtime) fn visit_supplier_subscription_roots(
+    visitor: &mut dyn crate::gc::RootVisitor,
+) {
+    if let Ok(map) = supplier_subscriptions_map().lock() {
+        for subs in map.values() {
+            for tap in &subs.taps {
+                visit_tap_roots(tap, visitor);
+            }
+            for v in &subs.done_callbacks {
+                visitor.visit_value(v);
+            }
+            for v in &subs.quit_callbacks {
+                visitor.visit_value(v);
+            }
+            for v in &subs.whenever_quit_callbacks {
+                visitor.visit_value(v);
+            }
+            for v in &subs.close_callbacks {
+                visitor.visit_value(v);
+            }
+        }
+    }
+    if let Ok(map) = whenever_done_group_map().lock() {
+        for group in map.values() {
+            visitor.visit_value(&group.done_cb);
+        }
+    }
+    if let Ok(map) = zip_state_map().lock() {
+        for state in map.values() {
+            for buf in &state.buffers {
+                for v in buf {
+                    visitor.visit_value(v);
+                }
+            }
+            if let Some(f) = &state.with_fn {
+                visitor.visit_value(f);
+            }
+        }
+    }
+    if let Ok(map) = zip_latest_state_map().lock() {
+        for state in map.values() {
+            for v in state.latest.iter().flatten() {
+                visitor.visit_value(v);
+            }
+            if let Some(f) = &state.with_fn {
+                visitor.visit_value(f);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod gc_root_tests {
+    use super::*;
+
+    struct Collector {
+        seen: Vec<String>,
+    }
+
+    impl crate::gc::RootVisitor for Collector {
+        fn visit_value(&mut self, value: &Value) {
+            if let Value::Str(s) = value {
+                self.seen.push(s.to_string());
+            }
+        }
+    }
+
+    #[test]
+    fn visit_supplier_subscription_roots_sees_tap_callback() {
+        // A high, test-unique id avoids colliding with any other test that
+        // shares this process-global registry (tests run in parallel).
+        let supplier_id = 0xF00D_0002;
+        let sentinel = "__gc_supplier_subscription_root_sentinel__";
+        register_supplier_tap(supplier_id, Value::str(sentinel.to_string()), 0.0);
+
+        let mut collector = Collector { seen: Vec::new() };
+        visit_supplier_subscription_roots(&mut collector);
+
+        assert!(
+            collector.seen.iter().any(|s| s == sentinel),
+            "visit_supplier_subscription_roots should enumerate the tap callback"
+        );
+
+        // Leave the registry as we found it (no entry for this id).
+        if let Ok(mut map) = supplier_subscriptions_map().lock() {
+            map.remove(&supplier_id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extends `Interpreter::visit_roots` — the single root-enumeration site — to cover the process-global **supply/async registries**, completing the GC Level-1 design doc's §11 **step 7 first wave** (`docs/gc-level1-detailed-design.md` §3.4). Follows step 6 (Promise/Channel → `Gc`, #4127).

These registries are GC **root containers**, not GC-managed nodes: the collector never frees them, it only needs to see the `Value`s / async nodes they keep reachable so a supply-held `Promise`/`Channel`/callback closure isn't misjudged garbage.

## What's enumerated

- `state::visit_supply_state_roots`
  - `supply_taps_map` — tap `Value`s
  - `promise_combinator_map` — combinator source `SharedPromise`s
  - `supplier_state_map` — emitted values, quit reason, pending promises
- `state_supplier::visit_supplier_subscription_roots`
  - `supplier_subscriptions_map` — tap callbacks, channel sinks, unique/classify/produce/start/batch transform state; done/quit/whenever-quit/close phaser bodies
  - `whenever_done_group_map`, `zip_state_map`, `zip_latest_state_map`

`SharedPromise`/`SharedChannel` held bare in a registry are wrapped in a transient `Value::Promise`/`Value::Channel` purely to feed the visitor.

## Notes

- The blocking `.lock()` mirrors the existing `shared_vars` read: root enumeration runs at a re-entry boundary (§1.2) where no thread holds these locks, and skipping a contended lock would be **unsound** (a live root could be missed).
- Like `shared_vars`, these are cross-thread process-global registries, so enumerating them from any interpreter's `visit_roots` is correct (visiting a root twice is harmless).
- Still test-only until a collector consumes `visit_roots` at a safepoint (step 8).

## Tests

- Per-module enumeration tests (emitted-value / tap-callback sentinels).
- A `gc_roots` integration test running a real `Supplier` program through the new path to prove no panic/deadlock against live registry state.
- `make test` green (14076 tests, 0 failures); clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)