### PR TITLE
ci(gc): add GC=on stress job; fix cross-thread race + container-identity under GC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,112 @@ jobs:
 
       - name: Run E2E tests
         run: node wasm-demo/e2e.test.mjs
+
+  gc-stress:
+    # Runs the whole test + roast suite with the GC cycle collector ON
+    # (design doc §9.3's `GC=on` stress job). `MUTSU_GC_EVERY_CANDIDATE=64`
+    # collects a cycle every 64 candidate pushes at the next safepoint, and
+    # `MUTSU_GC_VERIFY=1` checks the collector's soundness invariants around each
+    # collect. The point: the collector, exercised against every program in the
+    # suite, must never corrupt live data. The collector self-gates to
+    # single-threaded regions (shared_vars strong count, design §6), so
+    # concurrency tests run with GC deferred — cross-thread cooperative STW is
+    # future work.
+    #
+    # BLOCKING gates: `cargo test` (the collector unit tests + the gc_stress
+    # integration tests, which assert no verify violations) and the final
+    # "No GC verify violations" step (any `VERIFY FAIL` in the suite = heap
+    # corruption). The `prove t/` and roast steps are `continue-on-error`: they
+    # RUN the whole suite under GC=on (their purpose is to feed real programs to
+    # the collector so the verify step can catch corruption), but they are not
+    # gated on pass/fail — a few tests fail under GC=on on *semantics* the
+    # collector does not yet implement (e.g. `DESTROY`-on-reclaim), which is a
+    # known gap, not corruption. Promote them to blocking once those close.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MUTSU_GC: "on"
+      MUTSU_GC_EVERY_CANDIDATE: "64"
+      MUTSU_GC_VERIFY: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-gcstress-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-gcstress-${{ runner.os }}-
+
+      - name: Install prove
+        run: sudo apt-get update && sudo apt-get install -y perl
+
+      - name: Unit + integration tests (GC on)
+        run: cargo test
+        env:
+          RUST_MIN_STACK: 8388608
+
+      - name: Build (debug, for TAP tests)
+        run: cargo build
+
+      - name: TAP tests (prove t/, GC on)
+        # Advisory: runs the whole t/ suite under GC on to feed the collector.
+        # Not gated on pass/fail (see job comment); the verify step below is the
+        # hard gate. `|| true` keeps the log tee from failing the step.
+        continue-on-error: true
+        run: |
+          set +e
+          mkdir -p tmp
+          prove --merge -e 'timeout 60 target/debug/mutsu' t/ 2>&1 | tee tmp/gc-stress-t.log
+
+      - name: Build (release, for roast)
+        run: cargo build --release
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "false"
+
+      - name: Clean precomp cache and restore roast files
+        run: |
+          rm -rf ~/.cache/mutsu/precomp
+          git checkout -- roast/
+
+      - name: Roast tests (make roast, GC on)
+        # Advisory (see the prove-t/ step): runs the whitelist under GC on so the
+        # verify step can catch collector corruption on the roast programs.
+        continue-on-error: true
+        run: |
+          set +e
+          mkdir -p tmp
+          prove -j4 --merge -e 'scripts/run-roast-test.sh' \
+            $(cat roast-whitelist.txt) 2>&1 | tee tmp/gc-stress-roast.log
+        env:
+          MUTSU_BIN: target/release/mutsu
+
+      - name: No GC verify violations
+        # `MUTSU_GC_VERIFY` logs `VERIFY FAIL` to stderr but does not by itself
+        # fail the process, so a heap-corruption bug could pass unnoticed. Fail
+        # the job if any collect reported a soundness violation.
+        run: |
+          if grep -q "VERIFY FAIL" tmp/gc-stress-t.log tmp/gc-stress-roast.log; then
+            echo "::error::GC collector reported VERIFY FAIL under stress"
+            grep -n "VERIFY FAIL" tmp/gc-stress-t.log tmp/gc-stress-roast.log | head -30
+            exit 1
+          fi
+          echo "No GC verify violations across the suite."
+
+      - name: Upload GC stress logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gc-stress-logs
+          path: |
+            tmp/gc-stress-t.log
+            tmp/gc-stress-roast.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/PLAN.md
+++ b/PLAN.md
@@ -416,12 +416,22 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
            バグを検出→修正して健全性を実証）。
       6-7,10-11 (残): `Promise`/`Channel` → supply registry root visitor（async cycle）→ `LazyList`
       （third wave）← **次はここ**（設計メモ参照）。call/return/await 等の追加 safepoint 種別・cross-thread
-      STW・`MUTSU_GC_AT`/random stress も後続。
+      full STW・`MUTSU_GC_AT`/random stress も後続。
          - ✅ **weak reference（`WeakGc<T>`）仕上げ**: primitive は #4123 で `WeakSub` 用に追加済み
            （`Gc::downgrade`/`upgrade`/`ptr_eq`/`strong_count`/`as_ptr`）。dangling constructor `WeakGc::new()`
            ＋ `Gc::weak_count` を補完し、**循環参照ブレイクのセマンティクスを unit test で実証**（weak back-edge が
            strong cycle を refcount だけで解体＝collector 不要／collected cycle の weak observer は `upgrade()→None`）。
            weak 辺は `gc_trace`/root visitor で非トレース（strong count に載らないので proactive に cycle を断つ）。
+         - ✅ **cross-thread 安全化(minimal STW, #4130)**: safepoint collect を single-threaded 区間に限定
+           （worker interpreter は `shared_vars` を `Arc::clone` するので `strong_count > 1` の間は collect skip）。
+           これで `start`/`Promise`/`hyper`/`race` 中の並行 mutation とのデータレース/panic を回避（full STW は後続）。
+         - ✅ **`make_mut`/`get_mut` の uniqueness を `header.strong`(live handle)基準に修正**: candidate buffer の
+           Arc ref で Arc count が水増しされ、GC=on 時に spurious COW→container identity 破壊が起きていた（GC=off は
+           Arc count==strong で不変）。
+         - ✅ **CI `gc-stress` ジョブ**（`.github/workflows/ci.yml`）: `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=64
+           MUTSU_GC_VERIFY=1` で全 test+roast を実行。cargo test ＋ `VERIFY FAIL` 検出はブロッキング（heap 破壊を
+           gate）、prove t/・roast は advisory（`DESTROY`-on-reclaim 等の未実装 GC セマンティクスで一部落ちるが
+           破壊ではないため非ブロック）。**残: cross-thread full STW / `DESTROY`-on-reclaim**。
       **Track B（要素 cell 化）と GC は統合キャンペーン（層3a・`Arc → Gc<T>` 一斉置換）**。続いて NaN-boxing
       （層3b・JIT 地ならし）→ JIT（層4）。未決は収集方式（同期/非同期）と A' 地ならしの範囲（ADR §4.2/§4.3）。
 - [ ] 制御フロー（`return`/`last`/`next`/`take`/`emit`）を `RuntimeError` god-struct から `enum Control` へ分離（ANALYSIS §2.4）。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -53,6 +53,30 @@ on Arc）の開発に着手した。[docs/gc-level1-detailed-design.md](../docs/
      `Array`/`Hash`/`ContainerRef` の first wave 置換）。unit test（color 遷移・dedup・inert・
      `Send + Sync`）で担保。
 
+## 2026-07-03: Phase B（GC）— CI `gc-stress` ジョブ + cross-thread 安全化 + container-identity 修正
+
+GC=on で全スイートを継続検証する CI ジョブ（設計メモ §9.3）を追加。その de-risk で **2つの実バグを発見・修正**した。
+
+- **cross-thread データレース → single-threaded gate で修正**: safepoint collect が `start`/`Promise`/`hyper`/`race`
+  の worker thread と並行して共有コンテナを触るとデータレース/panic（`t/lock.t` の VERIFY FAIL、
+  `start-panic-boundary.t` の実 panic）。worker interpreter は `shared_vars` を `Arc::clone` するので
+  `Interpreter::gc_single_threaded()`（`Arc::strong_count(shared_vars) == 1`）で **single-threaded 区間に限定**して
+  collect する minimal cooperative STW を実装。main/worker 両ループが gate されるので並行 collect が起きない。
+  full STW（並行 collect の正しさ）は後続。
+- **container identity 破壊 → `make_mut`/`get_mut` を `header.strong` 基準に修正**: GC=on 時、candidate buffer が
+  ノードの `Arc` clone を保持するため `Arc` count が水増しされ、`Arc::get_mut` ベースの uniqueness 判定が
+  spurious に COW→ スライス代入 lvalue 等の container identity（aliasing）を破壊していた。live handle 数
+  （`header.strong`、buffer ref を除外）で判定するよう修正（GC=off は Arc count==strong なので不変）。
+- **CI `gc-stress` ジョブ**（`.github/workflows/ci.yml`）: `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=64
+  MUTSU_GC_VERIFY=1` で `cargo test` ＋ `prove t/` ＋ roast whitelist を実行。**ブロッキング gate = cargo test
+  ＋「VERIFY FAIL 検出でジョブ fail」**（heap 破壊を確実に捕捉）。`prove t/`・roast は `continue-on-error`
+  （advisory）: `DESTROY`-on-reclaim 等 collector 未実装の GC セマンティクスで一部テストが落ちるが、これは破壊
+  ではなく既知ギャップなので非ブロック（実装後に昇格）。gc_stress integration test は env をクリアして
+  ambient `MUTSU_GC` に依存しないよう修正。
+
+検証: GC-off `make test` = Result: PASS（回帰なし）。GC-on で cargo test 全通過・prove t/ と whitelisted roast
+sample で **VERIFY FAIL=0**（collector 健全）・concurrency テスト（lock/start/hyper-race）通過。
+
 ## 2026-07-03: Phase B（GC）— デバッグ/検証ツール `MUTSU_GC_LOG` / `MUTSU_GC_VERIFY`（§9.4/§9.5）
 
 collector のデバッグ運用基盤を実装。GC はログ・検証なしでは壊れたとき追跡不能になる（設計メモ §9.4 冒頭）ため、

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -260,13 +260,26 @@ impl<T: Trace + 'static> Gc<T> {
         Arc::ptr_eq(&a.inner, &b.inner)
     }
 
-    /// Mutable access to the pointee IFF this is the only live handle to the node
-    /// (no other `Gc` handle and — when GC is enabled — no retained candidate
-    /// buffer clone). Returns `None` when the node is shared. Mirrors
-    /// `Arc::get_mut`, the non-cloning half of the `Arc::make_mut` sites the
-    /// container migration replaces.
+    /// Mutable access to the pointee IFF this is the only *live* handle to the
+    /// node. Uniqueness is judged by the GC-visible strong count (live `Gc`
+    /// handles), NOT the backing `Arc`'s count: with `MUTSU_GC` on, the candidate
+    /// buffer retains an extra `Arc` clone of a possibly-cyclic node, which would
+    /// make an `Arc::get_mut` check return `None` spuriously and, via
+    /// [`Gc::make_mut`], sever container identity (Raku aliasing). Returns `None`
+    /// when genuinely shared.
     pub(crate) fn get_mut(&mut self) -> Option<&mut T> {
-        Arc::get_mut(&mut self.inner).map(|b| &mut b.value)
+        if self.inner.header.strong.load(Ordering::Relaxed) == 1 {
+            // SAFETY: sole live handle, so no other live-handle borrow into the
+            // value exists. A buffered node's retained `Arc` never dereferences
+            // the value except at a collect safepoint (same contract as
+            // `gc_contents_mut`), so this aliased `&mut` is sound. The pointer
+            // comes from `Arc::as_ptr` (not a `&`-to-`&mut` cast), dodging the
+            // `invalid_reference_casting` lint.
+            let boxed = Arc::as_ptr(&self.inner) as *mut GcBox<T>;
+            Some(unsafe { &mut (*boxed).value })
+        } else {
+            None
+        }
     }
 
     /// The GC-visible strong count (live `Gc` handles to this node).
@@ -350,7 +363,12 @@ impl<T: Trace + Clone + 'static> Gc<T> {
     /// distribution even though the retarget goes through the backing `Arc`
     /// directly rather than `Gc::clone`/`Gc::drop`.
     pub(crate) fn make_mut(&mut self) -> &mut T {
-        if Arc::get_mut(&mut self.inner).is_none() {
+        // Uniqueness by GC-visible strong count, NOT the `Arc` count: the
+        // candidate buffer (MUTSU_GC on) holds an extra `Arc` clone of a
+        // possibly-cyclic node, so an `Arc::get_mut` check would COW spuriously
+        // and sever container identity (Raku aliasing broke on e.g. slice-
+        // assignment lvalues). `header.strong` excludes the buffer's ref.
+        if self.inner.header.strong.load(Ordering::Relaxed) != 1 {
             // Shared: this handle is moving off the old node onto a fresh copy.
             self.inner.header.strong.fetch_sub(1, Ordering::Relaxed);
             let cloned = self.inner.value.clone();
@@ -359,9 +377,9 @@ impl<T: Trace + Clone + 'static> Gc<T> {
                 value: cloned,
             });
         }
-        &mut Arc::get_mut(&mut self.inner)
-            .expect("unique after copy-on-write")
-            .value
+        // Sole live handle. SAFETY / lint: see `Gc::get_mut`.
+        let boxed = Arc::as_ptr(&self.inner) as *mut GcBox<T>;
+        unsafe { &mut (*boxed).value }
     }
 }
 
@@ -837,9 +855,12 @@ mod tests {
     #[test]
     fn drop_does_not_buffer_when_gc_disabled() {
         // Default (MUTSU_GC unset) => gc_enabled() is false, so a
-        // drop-with-survivors must NOT push a candidate.
+        // drop-with-survivors must NOT push a candidate. Under the GC=on CI
+        // stress run the opposite is the point (it DOES buffer), so skip.
+        if gc_enabled() {
+            return;
+        }
         let _serial = lock_buffer_tests();
-        assert!(!gc_enabled(), "test assumes MUTSU_GC is unset");
         drain_candidates();
         let gc = Gc::new(Leaf);
         let clone = gc.clone();

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -1,6 +1,19 @@
 use super::*;
 
 impl Interpreter {
+    /// Whether this interpreter is (currently) the only one sharing its
+    /// `shared_vars` — i.e. no `start`/`Promise`/`hyper`/`race` worker is live.
+    ///
+    /// `clone_for_thread` hands each worker an `Arc::clone` of `shared_vars`, so
+    /// a strong count of 1 means execution is single-threaded again. The GC
+    /// safepoint uses this to skip a collect while workers might be mutating a
+    /// shared `Gc` container concurrently (cross-thread cooperative STW is not
+    /// implemented yet — design doc §6). Conservative in the safe direction: a
+    /// transient extra `Arc` clone only *skips* a collect, never runs one racily.
+    pub(crate) fn gc_single_threaded(&self) -> bool {
+        Arc::strong_count(&self.shared_vars) == 1
+    }
+
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
     /// Shares function/class/role/enum definitions but starts with fresh output and test state.
     /// Array (`@`) and scalar (`$`) variables are shared between parent and child via `shared_vars`

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -116,8 +116,12 @@ impl Interpreter {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
             // container borrow, so a cycle collect may run here. Off by default —
             // `gc_safepoints_armed()` is a single cached load unless `MUTSU_GC`
-            // enables an automatic trigger.
-            if crate::gc::gc_safepoints_armed() {
+            // enables an automatic trigger. Gated on single-threaded execution:
+            // worker interpreters (`start`/`Promise`/`hyper`/`race`) hold a clone
+            // of `shared_vars`, so `strong_count > 1` means another thread may be
+            // mutating a shared `Gc` container — collecting then would race
+            // (cross-thread cooperative STW is not implemented yet, design §6).
+            if crate::gc::gc_safepoints_armed() && self.gc_single_threaded() {
                 crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
             }
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
@@ -363,8 +367,12 @@ impl Interpreter {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
             // container borrow, so a cycle collect may run here. Off by default —
             // `gc_safepoints_armed()` is a single cached load unless `MUTSU_GC`
-            // enables an automatic trigger.
-            if crate::gc::gc_safepoints_armed() {
+            // enables an automatic trigger. Gated on single-threaded execution:
+            // worker interpreters (`start`/`Promise`/`hyper`/`race`) hold a clone
+            // of `shared_vars`, so `strong_count > 1` means another thread may be
+            // mutating a shared `Gc` container — collecting then would race
+            // (cross-thread cooperative STW is not implemented yet, design §6).
+            if crate::gc::gc_safepoints_armed() && self.gc_single_threaded() {
                 crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
             }
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {

--- a/tests/gc_stress.rs
+++ b/tests/gc_stress.rs
@@ -14,6 +14,18 @@ use std::process::Command;
 fn run(src: &str, gc: &[(&str, &str)]) -> (String, String, bool) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
     cmd.arg("-e").arg(src);
+    // Start from a clean GC configuration regardless of the ambient environment
+    // (the `gc-stress` CI job runs `cargo test` with `MUTSU_GC=on`), so each test
+    // controls exactly the mode it exercises.
+    for k in [
+        "MUTSU_GC",
+        "MUTSU_GC_EVERY_SAFEPOINT",
+        "MUTSU_GC_EVERY_CANDIDATE",
+        "MUTSU_GC_VERIFY",
+        "MUTSU_GC_LOG",
+    ] {
+        cmd.env_remove(k);
+    }
     for (k, v) in gc {
         cmd.env(k, v);
     }


### PR DESCRIPTION
Adds the design §9.3 `gc-stress` CI job — runs the whole test + roast suite with the cycle collector ON (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=64 MUTSU_GC_VERIFY=1`). **De-risking it locally surfaced two real bugs, both fixed here** — the job is only viable because of them.

### Bug 1 — cross-thread data race (concurrency panic / VERIFY FAIL)
A safepoint collect on one thread races with a `start`/`Promise`/`hyper`/`race` worker mutating a shared `Gc` container — reproduced as `t/lock.t` VERIFY FAIL and real panics in `start-panic-boundary.t`. **Fix:** a minimal cooperative gate — the backedge safepoint only collects when `Interpreter::gc_single_threaded()` (`Arc::strong_count(shared_vars) == 1`, i.e. no worker holds a clone). Both the main and worker dispatch loops gate on it, so no collect runs concurrently with a mutator. Full cross-thread STW (collecting *during* parallelism) is future work.

### Bug 2 — container identity broken under GC=on
The candidate buffer retains an `Arc` clone of a node, inflating the `Arc` count, so `make_mut`/`get_mut`'s `Arc::get_mut` uniqueness check COW'd spuriously and **severed Raku aliasing** (e.g. slice-assignment lvalues). **Fix:** judge uniqueness by `header.strong` (live `Gc` handles, excluding the buffer ref). GC-off is unchanged (Arc count == header.strong with no buffer), and the `get_mut` unit tests now pass under GC=on too.

### The job
- **Blocking:** `cargo test` (collector unit tests + gc_stress integration tests, which assert no verify violations) and a **"No GC verify violations"** step (any `VERIFY FAIL` == heap corruption).
- **Advisory (`continue-on-error`):** `prove t/` and roast — they run the whole suite under GC=on to feed the collector real programs, but a few tests fail on GC *semantics* the collector doesn't implement yet (`DESTROY`-on-reclaim), a known gap, not corruption. Promote when closed.
- `tests/gc_stress.rs` clears the ambient GC env so it isn't perturbed by the job.

### Verification
- GC-off `make test` = **Result: PASS** (no regression). `cargo clippy -- -D warnings` clean.
- GC-on: `cargo test` all pass; `prove t/` + whitelisted roast sample **VERIFY FAIL = 0**; concurrency tests (lock/start/hyper-race) pass; async (Promise/Channel from #4127) + cycles run clean under GC=on stress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)