### PR TITLE
fix(gc): defer cycle collection while worker threads are active (stop-the-world)

### DIFF
--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -509,7 +509,11 @@ mod tests {
         // and, crucially, the candidates stay buffered (not drained-and-lost).
         enter_mutator_worker();
         let stats = collect_cycles();
-        assert_eq!(stats, CollectStats::default(), "deferred: no-op while active");
+        assert_eq!(
+            stats,
+            CollectStats::default(),
+            "deferred: no-op while active"
+        );
         assert_eq!(
             DROPS.load(Ordering::Relaxed) - before,
             0,
@@ -519,7 +523,10 @@ mod tests {
         // Once the worker is gone, the still-buffered cycle is reclaimed.
         exit_mutator_worker();
         let stats = collect_cycles();
-        assert_eq!(stats.reclaimed_nodes, 2, "candidates survived to be collected");
+        assert_eq!(
+            stats.reclaimed_nodes, 2,
+            "candidates survived to be collected"
+        );
         assert_eq!(DROPS.load(Ordering::Relaxed) - before, 2);
     }
 

--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -277,6 +277,17 @@ fn verify_survivors(cycle: u64, survivors: &[(ErasedGc, usize)]) -> usize {
 /// Safe to call at any time: with no candidates buffered it is a no-op. Returns
 /// what it reclaimed and records the same into `MUTSU_VM_STATS`.
 pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
+    // Trial deletion is not safe against concurrent mutation: it decrements and
+    // restores strong counts, so a worker thread cloning/dropping a `Gc` (or
+    // CAS-swapping a pointer) mid-collect corrupts the bookkeeping and can free
+    // a still-live node (design doc §13.3 — cross-thread STW is deferred). Until
+    // that lands, decline to collect while any worker thread is active. The
+    // candidates stay buffered (we return before draining) and are reclaimed at
+    // the next safepoint once the threads have joined: reclaim is deferred,
+    // never unsound.
+    if crate::gc::mutator_workers_active() {
+        return CollectStats::default();
+    }
     let start = Instant::now();
     let roots = drain_candidates();
     if roots.is_empty() {
@@ -474,6 +485,42 @@ mod tests {
             2,
             "both TestNodes were actually freed"
         );
+    }
+
+    #[test]
+    fn collect_is_deferred_while_a_mutator_worker_is_active() {
+        use super::super::gc_ptr::{enter_mutator_worker, exit_mutator_worker};
+        let _g = lock();
+        drain_candidates();
+        let before = DROPS.load(Ordering::Relaxed);
+
+        // A reclaimable cycle sits in the candidate buffer.
+        let a = TestNode::new();
+        let b = TestNode::new();
+        TestNode::link(&a, &b);
+        TestNode::link(&b, &a);
+        a.buffer_as_candidate();
+        b.buffer_as_candidate();
+        drop(a);
+        drop(b);
+
+        // While a worker thread may be mutating the graph, the collector must
+        // decline (trial deletion needs stop-the-world): nothing is reclaimed
+        // and, crucially, the candidates stay buffered (not drained-and-lost).
+        enter_mutator_worker();
+        let stats = collect_cycles();
+        assert_eq!(stats, CollectStats::default(), "deferred: no-op while active");
+        assert_eq!(
+            DROPS.load(Ordering::Relaxed) - before,
+            0,
+            "nothing freed while a worker is active"
+        );
+
+        // Once the worker is gone, the still-buffered cycle is reclaimed.
+        exit_mutator_worker();
+        let stats = collect_cycles();
+        assert_eq!(stats.reclaimed_nodes, 2, "candidates survived to be collected");
+        assert_eq!(DROPS.load(Ordering::Relaxed) - before, 2);
     }
 
     #[test]

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -497,6 +497,42 @@ fn buffer_candidate(node: ErasedGc) {
     super::safepoint::note_candidate_push();
 }
 
+/// Number of user worker threads (`start`/`Promise`/`hyper`/`race`/Supply
+/// callbacks) that may be concurrently mutating the `Gc` graph.
+///
+/// The level-1a collector's trial deletion (`mark_gray` decrements each node's
+/// strong count, `scan_black` restores it) is **not** safe against concurrent
+/// mutation: a worker thread that clones/drops a `Gc` or CAS-swaps a pointer
+/// mid-collect races the collector's refcount bookkeeping, which manifests as
+/// strong-count underflow and freed-but-live nodes (design doc §13.3 — the
+/// cross-thread STW protocol is the deferred open question). Until a real
+/// stop-the-world lands, the collector simply declines to run while any worker
+/// thread is active (see `collect::collect_cycles_at`): candidates keep
+/// accumulating and are reclaimed at the next safepoint after the threads join.
+/// Reclaim is deferred, never unsound.
+static MUTATOR_WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+/// Register that a user worker thread is about to start (or is running). Called
+/// on the *parent* thread before the worker is spawned so the count is raised
+/// the instant `spawn_user_thread` returns, closing the window in which the
+/// parent could reach a safepoint and collect while the worker comes up.
+pub(crate) fn enter_mutator_worker() {
+    MUTATOR_WORKER_THREADS.fetch_add(1, Ordering::AcqRel);
+}
+
+/// Register that a user worker thread has finished. Balanced against
+/// `enter_mutator_worker`; run from the worker via an RAII guard so a panic in
+/// user code still decrements.
+pub(crate) fn exit_mutator_worker() {
+    MUTATOR_WORKER_THREADS.fetch_sub(1, Ordering::AcqRel);
+}
+
+/// Whether any user worker thread may currently be mutating the `Gc` graph.
+/// The collector gates on this to preserve stop-the-world.
+pub(crate) fn mutator_workers_active() -> bool {
+    MUTATOR_WORKER_THREADS.load(Ordering::Acquire) > 0
+}
+
 /// Drain the candidate buffer, clearing each node's `buffered` flag, and return
 /// the nodes. The synchronous collector (§11 step 8) will consume this to run
 /// trial-deletion; exposed now as the seam between candidate registration and

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -30,8 +30,8 @@ pub(crate) use collect::{
 };
 #[allow(unused_imports)]
 pub(crate) use gc_ptr::{
-    Color, ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, drain_candidates, gc_contents_mut,
-    gc_enabled,
+    Color, ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, drain_candidates, enter_mutator_worker,
+    exit_mutator_worker, gc_contents_mut, gc_enabled, mutator_workers_active,
 };
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};
 #[allow(unused_imports)]

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -15,9 +15,24 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
+    // Mark a mutator worker as active so the GC collector declines to run while
+    // this thread may be touching the `Gc` graph (trial deletion needs
+    // stop-the-world; see `gc::mutator_workers_active`). Raised here on the
+    // parent — before the thread exists — so the count is up the instant this
+    // returns, then dropped by the worker's RAII guard (panic-safe).
+    crate::gc::enter_mutator_worker();
     std::thread::Builder::new()
         .stack_size(USER_THREAD_STACK_SIZE)
-        .spawn(f)
+        .spawn(move || {
+            struct WorkerGuard;
+            impl Drop for WorkerGuard {
+                fn drop(&mut self) {
+                    crate::gc::exit_mutator_worker();
+                }
+            }
+            let _guard = WorkerGuard;
+            f()
+        })
         .expect("failed to spawn worker thread")
 }
 


### PR DESCRIPTION
## Summary

Found while running `make roast` with GC forced on (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=100 MUTSU_GC_VERIFY=1`): the level-1a cycle collector is **not thread-safe**. Its trial deletion (`mark_gray` decrements each node's strong count, `scan_black` restores it) races any concurrent mutation, so a `start`/Promise/hyper/race worker thread that clones/drops a `Gc` (or CAS-swaps a pointer) mid-collect corrupts the refcount bookkeeping — strong-count underflow and **freed-but-still-live nodes**.

### Symptoms (before fix, GC on)
- `roast/S17-lowlevel/cas-loop.t` (a CAS-built linked list), `S17-lowlevel/lock.t`, `S16-io/handles-between-threads.t` **deterministically failed**.
- `MUTSU_GC_VERIFY=1` reported **~940k "survivor invariant violation"** underflows across the suite.
- A **single-threaded** linked list under the same aggressive collection is 100% clean → isolates the cause to concurrent mutation (the design doc's deferred §13.3 cross-thread STW open question).

## Fix

Gate `collect_cycles_at` on a process-global mutator-worker counter:

- `spawn_user_thread` (the single chokepoint for user worker threads) raises the count **on the parent** before the thread is spawned, and drops it via an **RAII guard** when the worker finishes (panic-safe).
- While any worker is active, the collector declines to run — candidates stay buffered (we return *before* draining) and are reclaimed at the next safepoint once the threads join. **Reclaim is deferred, never unsound.**
- Single-threaded collection is unchanged (count stays 0).

## Result (same stress config, after fix)
- Previously-failing concurrency tests **pass**; verify violations from worker threads → **0**.
- Full GC-on roast sweep: **0 correctness failures** (`not ok`). Remaining failures are timeouts (exit 124) from GC+VERIFY overhead exceeding the 30s per-file limit — pure stress artifacts.
- GC is **off by default** (`MUTSU_GC` unset), so normal execution and CI are unaffected. `make test` green (14076 tests).

## Known follow-up
Long-lived async-I/O threads (socket listeners, Proc::Async readers, Supply timers) emitting `Value`s from raw `std::thread::spawn` are **not** counted — gating them would disable GC for the lifetime of any open socket/supply. They leave a small residual of verify diagnostics under stress but no observed correctness failure. The real fix is cross-thread STW (design doc §13.3), which remains deferred.

## Tests
- `collect_is_deferred_while_a_mutator_worker_is_active` — the collector is a no-op while a worker is active, and the still-buffered cycle is reclaimed once it exits.
- The 5 `gc_stress` integration tests still reclaim single-threaded cycles (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)