### PR TITLE
feat(gc): finish WeakGc<T> weak references — prove cycle-breaking (layer 3a)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -417,6 +417,11 @@ MIME::Base64 1.2.5（#3427）/ IO::Blob（builtin 型サブクラスの user ove
       6-7,10-11 (残): `Promise`/`Channel` → supply registry root visitor（async cycle）→ `LazyList`
       （third wave）← **次はここ**（設計メモ参照）。call/return/await 等の追加 safepoint 種別・cross-thread
       STW・`MUTSU_GC_AT`/random stress も後続。
+         - ✅ **weak reference（`WeakGc<T>`）仕上げ**: primitive は #4123 で `WeakSub` 用に追加済み
+           （`Gc::downgrade`/`upgrade`/`ptr_eq`/`strong_count`/`as_ptr`）。dangling constructor `WeakGc::new()`
+           ＋ `Gc::weak_count` を補完し、**循環参照ブレイクのセマンティクスを unit test で実証**（weak back-edge が
+           strong cycle を refcount だけで解体＝collector 不要／collected cycle の weak observer は `upgrade()→None`）。
+           weak 辺は `gc_trace`/root visitor で非トレース（strong count に載らないので proactive に cycle を断つ）。
       **Track B（要素 cell 化）と GC は統合キャンペーン（層3a・`Arc → Gc<T>` 一斉置換）**。続いて NaN-boxing
       （層3b・JIT 地ならし）→ JIT（層4）。未決は収集方式（同期/非同期）と A' 地ならしの範囲（ADR §4.2/§4.3）。
 - [ ] 制御フロー（`return`/`last`/`next`/`take`/`emit`）を `RuntimeError` god-struct から `enum Control` へ分離（ANALYSIS §2.4）。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,28 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-04: Phase B（GC）— weak reference（`WeakGc<T>`）の仕上げ：循環参照ブレイクを実証
+
+ADR-0001 layer 3a の仕上げとして、weak reference による循環参照ブレイクを完成・検証した。primitive
+`WeakGc<T>` 自体は #4123 で `Value::WeakSub`（再帰クロージャの自己参照）用に既に追加済み（`Gc::downgrade` /
+`upgrade` / `ptr_eq` / `strong_count` / `as_ptr` / Clone / Debug / Send+Sync）で、consumed-LazyList registry でも
+使用中。今回はその API を仕上げ、cycle-breaking セマンティクスを unit test で実証した。
+
+- **API 補完**: `WeakGc::new()`（`Weak::new()` 相当の永久 dangling — `upgrade()` は常に None。weak slot の
+  空初期化用）＋ `Gc::weak_count()`（weak observer 数。node は strong=0 で value を drop、weak は allocation
+  だけ延命するので reclaimed node を復活させない）。
+- **cycle-breaking の実証**（`gc::gc_ptr` unit test）:
+  - `weak_back_edge_breaks_a_cycle_without_the_collector`: `A --strong--> B --weak--> A` の back-edge を weak に
+    すると、weak は strong count に載らない（`gc_trace`/root visitor で非トレース）ので **refcount だけで A/B
+    両方が解放される＝collector 不要でサイクルが解体される**（実 drop カウンタで検証）。
+  - `weak_observer_of_a_collected_strong_cycle_sees_none`: strong cycle を collector が回収した後、その weak
+    observer は `upgrade()→None`（reclaimed node を weak が復活させない）。
+  - `upgrade_is_some_while_alive_none_after_drop` / `dangling_weak_upgrades_to_none`。
+
+これで循環参照は **(1) 事前に weak 辺で断つ（proactive、closure self-ref 等）** と **(2) trial-deletion
+collector で回収する（reactive）** の両輪が揃った。`make test` = Result: PASS（gc unit test 33 本 green・回帰なし）。
+primitive は既存の追加のみで production 実行経路は不変。
+
 ## 2026-07-03: Phase B（GC）着手 — cycle collector on Arc の基盤スライス（ADR-0002）
 
 ADR-0002 で Phase A（roast 目標）達成を確認し、GC（Phase B・ADR-0001 のレベル1 = cycle collector

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -155,6 +155,19 @@ pub(crate) struct WeakGc<T: Trace + 'static> {
 }
 
 impl<T: Trace + 'static> WeakGc<T> {
+    /// A permanently-dangling weak handle (`Weak::new()`) whose [`upgrade`]
+    /// always returns `None`. For initializing a weak slot that starts empty —
+    /// e.g. a not-yet-set back-reference in a cycle-breaking design, where the
+    /// forward link is a strong [`Gc`] and the back link is a `WeakGc` so the
+    /// cycle never keeps itself alive.
+    ///
+    /// [`upgrade`]: WeakGc::upgrade
+    pub(crate) fn new() -> WeakGc<T> {
+        WeakGc {
+            inner: std::sync::Weak::new(),
+        }
+    }
+
     /// Whether two weak handles point at the same node (`Weak::ptr_eq`), for
     /// `Value::WeakSub` identity comparison.
     pub(crate) fn ptr_eq(a: &WeakGc<T>, b: &WeakGc<T>) -> bool {
@@ -223,11 +236,21 @@ impl<T: Trace + 'static> Gc<T> {
     }
 
     /// A non-owning [`WeakGc`] handle to this node (the `Gc` analogue of
-    /// `Arc::downgrade`), for `Value::WeakSub`.
+    /// `Arc::downgrade`), for `Value::WeakSub`. A weak handle does not count
+    /// toward the node staying alive, so a reference made weak (rather than a
+    /// [`Gc`] clone) breaks any cycle it would otherwise close.
     pub(crate) fn downgrade(this: &Gc<T>) -> WeakGc<T> {
         WeakGc {
             inner: std::sync::Arc::downgrade(&this.inner),
         }
+    }
+
+    /// Number of live [`WeakGc`] handles observing this node. A node with weak
+    /// observers but no strong handle keeps only its *allocation* alive (its
+    /// value is dropped when the strong count hits 0), so an outstanding weak
+    /// reference never resurrects reclaimed data — `upgrade` returns `None`.
+    pub(crate) fn weak_count(this: &Gc<T>) -> usize {
+        Arc::weak_count(&this.inner)
     }
 
     /// Two handles point at the same node (`Arc::ptr_eq`). The GC container
@@ -900,6 +923,115 @@ mod tests {
             gc.strong_count(),
             before,
             "erased view is not a user handle"
+        );
+    }
+
+    // ---- Weak references (cycle breaking) ----------------------------------
+
+    static WEAK_DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    /// A node with a strong forward link and a weak back link, so a two-node
+    /// cycle can be closed with the back edge made weak. `trace` yields ONLY the
+    /// strong child — a `WeakGc` is not a GC edge, which is exactly what lets it
+    /// break the cycle. Bumps `WEAK_DROPS` when freed.
+    struct WNode {
+        strong: Mutex<Option<Gc<WNode>>>,
+        weak: Mutex<Option<WeakGc<WNode>>>,
+    }
+    impl WNode {
+        fn new() -> Gc<WNode> {
+            Gc::new(WNode {
+                strong: Mutex::new(None),
+                weak: Mutex::new(None),
+            })
+        }
+    }
+    impl Trace for WNode {
+        fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+            if let Ok(g) = self.strong.lock()
+                && let Some(child) = g.as_ref()
+            {
+                visit(&child.erased());
+            }
+            // `self.weak` is deliberately NOT traced.
+        }
+        fn drop_gc_edges(&mut self) {
+            *self.strong.get_mut().unwrap() = None;
+            *self.weak.get_mut().unwrap() = None;
+        }
+    }
+    impl Drop for WNode {
+        fn drop(&mut self) {
+            WEAK_DROPS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn dangling_weak_upgrades_to_none() {
+        let w: WeakGc<Cell> = WeakGc::new();
+        assert!(w.upgrade().is_none());
+    }
+
+    #[test]
+    fn upgrade_is_some_while_alive_none_after_drop() {
+        let a = Gc::new(Cell(7));
+        let w = Gc::downgrade(&a);
+        assert_eq!(Gc::weak_count(&a), 1);
+        assert!(w.upgrade().is_some(), "alive => upgradeable");
+        drop(a);
+        assert!(w.upgrade().is_none(), "dropped => not upgradeable");
+    }
+
+    #[test]
+    fn weak_back_edge_breaks_a_cycle_without_the_collector() {
+        let _serial = lock_buffer_tests();
+        drain_candidates();
+        let before = WEAK_DROPS.load(Ordering::Relaxed);
+
+        // A --strong--> B --weak--> A : the back edge is weak, so the cycle
+        // never keeps itself alive; plain refcounting frees both.
+        let a = WNode::new();
+        let b = WNode::new();
+        *a.strong.lock().unwrap() = Some(b.clone());
+        *b.weak.lock().unwrap() = Some(Gc::downgrade(&a));
+        assert_eq!(a.strong_count(), 1, "the weak back-edge does not count");
+
+        drop(a);
+        drop(b);
+
+        assert_eq!(
+            WEAK_DROPS.load(Ordering::Relaxed) - before,
+            2,
+            "both nodes freed by refcounting alone — the weak edge broke the cycle"
+        );
+        // Nothing should have been buffered as a cycle candidate.
+        assert!(drain_candidates().is_empty());
+    }
+
+    #[test]
+    fn weak_observer_of_a_collected_strong_cycle_sees_none() {
+        let _serial = lock_buffer_tests();
+        drain_candidates();
+
+        // A <--strong--> B strong cycle, plus a weak observer of A.
+        let a = WNode::new();
+        let b = WNode::new();
+        *a.strong.lock().unwrap() = Some(b.clone());
+        *b.strong.lock().unwrap() = Some(a.clone());
+        let observer = Gc::downgrade(&a);
+        assert!(observer.upgrade().is_some());
+
+        // Make them collectable garbage: buffer, then drop the external handles.
+        a.buffer_as_candidate();
+        b.buffer_as_candidate();
+        drop(a);
+        drop(b);
+
+        let stats = super::super::collect::collect_cycles();
+        assert_eq!(stats.reclaimed_nodes, 2, "the strong cycle is reclaimed");
+        assert!(
+            observer.upgrade().is_none(),
+            "a weak observer never resurrects a reclaimed node"
         );
     }
 }


### PR DESCRIPTION
Finishes weak-reference support as the ADR-0001 **layer 3a** cycle-breaking mechanism.

The `WeakGc<T>` primitive already existed (added in #4123 for `Value::WeakSub` — recursive-closure self-reference — and used by the consumed-LazyList registry): `Gc::downgrade` / `upgrade` / `ptr_eq` / `strong_count` / `as_ptr` / Clone / Debug / Send+Sync. This rounds it out and — crucially — **proves the cycle-breaking semantics with tests**.

### API completion
- `WeakGc::new()` — a permanently-dangling weak (`Weak::new()` parity) whose `upgrade()` is always `None`, for empty weak slots (e.g. a not-yet-set back-reference in a cycle-breaking design).
- `Gc::weak_count()` — weak observers of a node. The value is dropped at strong 0, so a weak never resurrects reclaimed data.

### Cycle-breaking proof (`gc::gc_ptr` unit tests)
- **`weak_back_edge_breaks_a_cycle_without_the_collector`**: `A --strong--> B --weak--> A`. A weak back edge is **not a GC edge** (not traced) and does **not count toward strong**, so plain refcounting frees both nodes — the collector isn't needed. Verified with a real drop counter.
- **`weak_observer_of_a_collected_strong_cycle_sees_none`**: after the collector reclaims a strong cycle, a weak observer of a member sees `upgrade() → None`.
- `upgrade_is_some_while_alive_none_after_drop`, `dangling_weak_upgrades_to_none`.

Cycle handling now has both halves: **break proactively** with a weak edge (closure self-ref, etc.) and **reclaim reactively** with the trial-deletion collector.

### Verification
- Purely additive to `gc_ptr.rs` (new methods + tests); **no production path changes**.
- `make test` = **Result: PASS** (33 gc unit tests, no regression). `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)