### PR TITLE
feat(subscript): nested slice adverbs + Range slice adverbs (whitelist S09-subscript/slice.t)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -221,11 +221,13 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 
 `eqv` の both-lazy ガードと `+a`/`+@a` の Seq single-pass consumption は完了済み
 （詳細は `news/2026-06.md`）。lazy 配列そのものの基盤（L1-L2b、`docs/lazy-arrays.md`
-参照）も完了済み。残るのは 1 ファイルのみ、かつ根本原因の大半は解決済み。
+参照）も完了済み。**`S09-subscript/slice.t` は 2026-07-04 に 56/56 で whitelist 済み**
+（残っていた test 35 = nested slice adverbs を解決。詳細は `news/2026-07.md` /
+`TODO_roast/S09.md`）。このセクションに開いている残件はない。
 
-### 4.1 `S09-subscript/slice.t`
+### 4.1 `S09-subscript/slice.t` — **DONE・whitelist 済み（2026-07-04）**
 
-- **現状（2026-07-03 更新）**: 52/56。
+- **現状**: 56/56 PASS。
 - **今回解決した根本原因**（詳細は `TODO_roast/S09.md` の該当エントリ）:
   1. `:=` bind が `sequence_spec`/`closure_seq`/`lazy_pipe` 系 `LazyList` を
      `coroutine` 以外は強制マテリアライズしていた（`vm_var_assign_set_local.rs`）。
@@ -305,10 +307,12 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
     （write-time 値・境界打ち切りなし）＋ `slice_key_tree_max_index_all` を新設し、
     LazyList arm で `bind_mode` 分岐（`vm_var_assign_index_named.rs`）。
     回帰テスト＝`t/hyperwhatever-and-lazy-slice-bind.t`。
-- **残り 1 件（test 35・nested slice adverbs）**: ネストインデックスへの slice adverb
-  （`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ、plan 62）が nested index list に
-  再帰しない（トップレベルのみ処理・`builtins_multidim_subscript.rs`）。§3 の
-  container-identity 領域に属する大きな機能。**whitelist にはこの 1 件の解決が必要。**
+- **test 35（nested slice adverbs）解決済み（2026-07-04）**: ネストインデックスへの
+  slice adverb（`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` の組み合わせ、plan 62）が
+  nested index list に再帰するよう、4 経路（`builtin_subscript_adverb` /
+  `ExistsIndexAdv` / `DeleteIndexNamed` / `DELETE-KEY`+adverb compiler routing）を
+  additive に再帰化。Range/Seq/List target の coerce（`("a".."z")[3,5]:k`）も追加。
+  container-identity §3 とは独立した read/format 再帰＋leaf delete で完結した。
 
 ---
 
@@ -397,10 +401,12 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowl
 1. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
    splice.t / attributes.t / multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-2. **`S09-subscript/slice.t`**（§4）— lazy array 起因の失敗は解消済み（2026-07-02）。
-   残り 4 件は test 35（nested slice adverbs、§3 と同根の大仕事）以外は独立した
-   小粒な機能ギャップ。
-3. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
+   **注（2026-07-04 調査）**: `splice.t` の 35 失敗は全て self-splice（`@a.splice(*,0,@a)`）
+   の 1 原因＝リストリテラル `(10,0,@a)` が @a を live コンテナ参照で保持するが、
+   `@a = ^10`（whole-array 代入）が既存コンテナを in-place 更新せず**再束縛**するため、
+   リストの参照が旧空コンテナを指す。whole-array 代入の container-identity（要素 cell の
+   一段上＝コンテナ cell）が本丸で、blast radius 大。
+2. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
 
 `S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が
 深いアーキテクチャ変更を要するため、上記優先順から外した。

--- a/TODO_roast/S09.md
+++ b/TODO_roast/S09.md
@@ -18,7 +18,7 @@
     and bind restrictions work after the Native Typed Arrays work.
 - [ ] roast/S09-multidim/XX-POS-on-undimensioned.t
 - [ ] roast/S09-subscript/multidim-assignment.t
-- [ ] roast/S09-subscript/slice.t
+- [x] roast/S09-subscript/slice.t — **DONE (56/56, whitelisted 2026-07-04)**
   - Local `raku` itself fails at test 22 (`*..*` eval-lives-ok) and halts with a
     bad plan, so it cannot validate this file end-to-end — treat per-assertion
     checks against a fresh `raku -e` snippet, not a full-file run.
@@ -81,18 +81,35 @@
     this also fixes `@x := @array[2]; @x = 5,6;` not writing back to
     `@array` (pre-existing, independent of the container-identity Phase 2
     campaign). New test: `t/bound-array-slice-arity.t`.
-  - **Remaining failures (4/56, unrelated to laziness):**
-    - Test 35 (62 sub-assertions, aborts at 18/62): slice adverbs (`:p`, `:k`,
-      `:v`, `:kv`, `:exists`, `:delete`, combinations) on a nested-list index —
-      a distinct, large feature (container-identity §3 territory).
-    - Tests 54-55: a duplicate-index nested-lazy-list **binding** edge case
-      (`@a[lazy 1,2,(4,5),4,5] := ...`) diverges from the `=` assignment
-      semantics we matched — Rakudo's bind here does not truncate at the
-      boundary and returns write-time (not final) values, unlike `=`. Narrow,
-      low-ROI; not chased further this session.
-    - Test 56: `@a[**]` (HyperWhatever "hammer" index) — local `raku` itself
-      throws "not yet implemented. Sorry." for this, so it cannot even be
-      verified against the reference implementation here.
+  - **2026-07-04: Test 35 fixed — file now fully passes (56/56).** The last
+    failure was the `nested slices` subtest (62 assertions): slice adverbs
+    (`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` and negated/combined forms) on a
+    *nested* index list (`("a".."z")[(3, (30, (5,)))]:k`) must recurse the index
+    tree and preserve its shape in the result, rather than flattening one level
+    and treating a sub-list as a scalar index. Implemented as an additive
+    recursion across the four adverb code paths (flat/non-nested behavior is
+    byte-identical):
+    - `:k`/`:v`/`:p`/`:kv` — `builtin_subscript_adverb` (`builtins_multidim_subscript.rs`)
+      gained a positional recursion (`format_positional_slice_level`): a nested
+      sub-list index yields ONE nested list element (recursed), a scalar index
+      contributes its formatted entries in place. Also coerces a Range/Seq/List
+      *target* (`("a".."z")[3,5]:k` — previously returned `Nil`) to an array view,
+      with a coerced list reporting a missing element as `Nil` (not the `Any` a
+      real `@`-array reports).
+    - `:exists`/`:!exists` (+`:kv`/`:p` companions) — the single-dim `Index`
+      path (`ExistsIndexAdv` opcode, `vm_var_exists_ops.rs`) detects a nested
+      slice and recurses (`nested_exists_slice`), distinct from a multidim
+      `@a[1;2]` coordinate walk.
+    - plain `:delete` — the `DeleteIndexNamed` opcode (`vm_var_delete_ops.rs`)
+      recurses via `exec_nested_slice_delete`: returns the deleted values in the
+      tree's shape and removes every leaf slot.
+    - `:delete:kv`/`:delete:k`/… — the compiler (`expr_method.rs`) routes a
+      `DELETE-KEY` on an `Index` carrying a `:k`/`:v`/`:p`/`:kv` adverb pair to
+      the `__mutsu_subscript_adverb` slice path with the delete flag, which now
+      also syncs the mutated array back to its local slot
+      (`writeback_multidim_var_to_local`).
+  - Tests 54-55 and 56 (previously listed as remaining) already pass on `main`;
+    the nested-slice fix closed the last gap.
 - [ ] roast/S09-typed-arrays/arrays.t
 - [ ] roast/S09-typed-arrays/hashes.t
   - 44/47 pass (test 25 is TODO, tests 42-44 fail)

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,33 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-04: `S09-subscript/slice.t` を 56/56 で whitelist — nested slice adverbs
+
+最後まで残っていた test 35（`nested slices` subtest、62 assertion）を解決し、`S09-subscript/slice.t`
+を whitelist した。ネストしたインデックスリスト（`("a".."z")[(3, (30, (5,)))]`）への slice adverb
+（`:p`/`:k`/`:v`/`:kv`/`:exists`/`:delete` と否定版・組み合わせ）が、インデックス木を再帰して
+その形を結果に保つよう実装した。従来はトップレベルのみ処理し、サブリストを 1 個のスカラー
+インデックス（範囲外）として扱っていた。
+
+adverb は 4 つの独立した経路に分かれているため、それぞれに **additive** な再帰を入れた
+（フラット／非ネストの挙動は byte-identical に保ち、回帰ゼロ）:
+
+- **`:k`/`:v`/`:p`/`:kv`** — `builtin_subscript_adverb`（`builtins_multidim_subscript.rs`）に
+  positional 再帰 `format_positional_slice_level` を追加。ネストしたサブリストは 1 個のネスト
+  リスト要素（再帰結果）に、スカラーはその場に展開。加えて Range/Seq/List の **target** を
+  array view に coerce（`("a".."z")[3,5]:k` は従来 `Nil` を返していた）。coerce したリストの
+  欠損要素は `Nil`（実 `@`-array の `Any` ではなく）。
+- **`:exists`/`:!exists`（+`:kv`/`:p`）** — 単一次元 `Index` の `ExistsIndexAdv` opcode
+  （`vm_var_exists_ops.rs`）がネストスライスを検出して `nested_exists_slice` で再帰。multidim
+  `@a[1;2]` の座標 walk とは区別。
+- **素の `:delete`** — `DeleteIndexNamed` opcode（`vm_var_delete_ops.rs`）が `exec_nested_slice_delete`
+  で再帰。削除値を木の形で返し、全 leaf slot を削除。
+- **`:delete:kv`/`:delete:k`/…** — `DELETE-KEY`(Index + adverb pair) をコンパイラ
+  （`expr_method.rs`）が delete フラグ付きの `__mutsu_subscript_adverb` slice 経路へルーティング。
+  delete 変更を local slot へ同期（`writeback_multidim_var_to_local`）する修正も追加。
+
+新テスト不要（roast slice.t がカバー）。`make test` / adverbs 系 roast に回帰なし。
+
 ## 2026-07-04: Phase B（GC）— weak reference（`WeakGc<T>`）の仕上げ：循環参照ブレイクを実証
 
 ADR-0001 layer 3a の仕上げとして、weak reference による循環参照ブレイクを完成・検証した。primitive

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -579,6 +579,7 @@ roast/S09-multidim/indexing.t
 roast/S09-multidim/methods.t
 roast/S09-multidim/subs.t
 roast/S09-subscript/multidim-assignment.t
+roast/S09-subscript/slice.t
 roast/S09-typed-arrays/arrays.t
 roast/S09-typed-arrays/hashes.t
 roast/S09-typed-arrays/native-decl.t

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -335,6 +335,51 @@ impl Compiler {
             });
             return;
         }
+        // `@a[...]:delete:kv` (delete listed first) reaches the compiler as
+        // `DELETE-KEY` on an `Index` carrying a single `:k`/`:v`/`:p`/`:kv` adverb
+        // pair (`"kv" => True`, `:!kv` => `"kv" => False`). Route it to the same
+        // `__mutsu_subscript_adverb` slice path with the `delete` flag set, so the
+        // key/value slice is computed *and* the addressed slots are removed.
+        if name == "DELETE-KEY"
+            && modifier.is_none()
+            && let Expr::Index {
+                target: idx_target,
+                index: idx_index,
+                ..
+            } = target
+            && args.len() == 1
+            && let Expr::Binary {
+                left,
+                op: crate::token_kind::TokenKind::FatArrow,
+                right,
+            } = &args[0]
+            && let Expr::Literal(Value::Str(mode)) = left.as_ref()
+            && matches!(mode.as_ref().as_str(), "k" | "v" | "p" | "kv")
+            && let Expr::Literal(Value::Bool(positive)) = right.as_ref()
+        {
+            let mode_str = if *positive {
+                mode.to_string()
+            } else {
+                format!("not-{mode}")
+            };
+            let var_name = Self::postfix_index_name(idx_target).unwrap_or_default();
+            let call_args = vec![
+                (**idx_target).clone(),
+                (**idx_index).clone(),
+                Expr::Literal(Value::str(mode_str)),
+                Expr::Literal(Value::str(var_name)),
+                Expr::Binary {
+                    left: Box::new(Expr::Literal(Value::str_from("delete"))),
+                    op: crate::token_kind::TokenKind::FatArrow,
+                    right: Box::new(Expr::Literal(Value::Bool(true))),
+                },
+            ];
+            self.compile_expr(&Expr::Call {
+                name: Symbol::intern("__mutsu_subscript_adverb"),
+                args: call_args,
+            });
+            return;
+        }
         self.compile_expr(target);
         let arity = args.len() as u32;
         let arg_sources_idx = self.add_arg_sources_constant(args);

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -218,6 +218,19 @@ impl Interpreter {
         let adverb = args[2].to_string_value();
         let raw_indices = &args[3..];
         let indices = self.resolve_multidim_indices(target, raw_indices)?;
+        // A nested single-dimension slice (`@a[(3, (30, (5,)))]:exists`) is a
+        // structure-preserving slice, NOT a multidim coordinate walk: recurse the
+        // index tree and report an existence Bool per leaf, keeping the nesting.
+        if indices.len() == 1
+            && let Some(inner) = Self::nested_index_elements(&indices[0])
+            && inner
+                .iter()
+                .any(|e| Self::nested_index_elements(e).is_some())
+            && let Some(items) = Self::positional_exists_items(target)
+        {
+            let out = Self::nested_exists_slice(&items, &inner, negated, &adverb);
+            return Ok(Value::array(out));
+        }
         if let Value::Instance {
             class_name,
             attributes,
@@ -310,6 +323,92 @@ impl Interpreter {
             "v" => Ok(Value::Bool(exists)),
             _ => Ok(Value::Bool(exists)),
         }
+    }
+
+    /// The positional element view (with unfilled-slot info folded into the
+    /// values) for a nested `:exists` slice, or `None` for a non-positional
+    /// target. A real array keeps its hole marks (`Package("Any")` in an
+    /// uninitialized slot); a Range/List is fully filled.
+    pub(crate) fn positional_exists_items(target: &Value) -> Option<Vec<Value>> {
+        match target {
+            Value::Array(items, ..) => Some(items.to_vec()),
+            t if t.is_range()
+                || matches!(
+                    t,
+                    Value::Seq(_) | Value::HyperSeq(_) | Value::RaceSeq(_) | Value::LazyList(_)
+                ) =>
+            {
+                Some(crate::runtime::utils::value_to_list(t))
+            }
+            _ => None,
+        }
+    }
+
+    /// One level of a nested `:exists`/`:!exists` slice: a sub-list index recurses
+    /// into ONE nested list element; a scalar index reports whether that slot
+    /// exists (negated by `:!exists`), formatted by the companion adverb
+    /// (`none`/`k`/`v`/`kv`/`p`).
+    pub(crate) fn nested_exists_slice(
+        items: &[Value],
+        indices: &[Value],
+        negated: bool,
+        adverb: &str,
+    ) -> Vec<Value> {
+        let mut out = Vec::new();
+        for idx in indices {
+            if let Some(sub) = Self::nested_index_elements(idx) {
+                out.push(Value::array(Self::nested_exists_slice(
+                    items, &sub, negated, adverb,
+                )));
+                continue;
+            }
+            let i = match idx {
+                Value::Int(i) => *i,
+                Value::Num(f) => *f as i64,
+                _ => idx.to_string_value().parse::<i64>().unwrap_or(-1),
+            };
+            let raw_exists = i >= 0
+                && (i as usize) < items.len()
+                && !matches!(&items[i as usize], Value::Package(name) if name == "Any");
+            let exists = if negated { !raw_exists } else { raw_exists };
+            let key = Value::Int(i);
+            match adverb {
+                // `:k` / `:kv` / `:p` keep only actually-existing keys.
+                "k" => {
+                    if raw_exists {
+                        out.push(key);
+                    }
+                }
+                "kv" => {
+                    if raw_exists {
+                        out.push(key);
+                        out.push(Value::Bool(exists));
+                    }
+                }
+                "p" => {
+                    if raw_exists {
+                        out.push(Value::ValuePair(
+                            Box::new(key),
+                            Box::new(Value::Bool(exists)),
+                        ));
+                    }
+                }
+                // `:!kv` / `:!p` keep every attempted key.
+                "not-kv" => {
+                    out.push(key);
+                    out.push(Value::Bool(exists));
+                }
+                "not-p" => {
+                    out.push(Value::ValuePair(
+                        Box::new(key),
+                        Box::new(Value::Bool(exists)),
+                    ));
+                }
+                // `none` and `v` report a Bool for every index.
+                _ => out.push(Value::Bool(exists)),
+            }
+        }
+        out
     }
 
     /// Multi-result :exists adverb handler for Whatever/list indices.

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -144,7 +144,26 @@ impl Interpreter {
                 "__mutsu_subscript_adverb expects target, index, and mode",
             ));
         }
-        let target = args[0].clone();
+        // A positional slice adverb can target any Positional, not just a stored
+        // `@`-array: `("a".."z")[3,5]:k` indexes a Range, `(1,2,3)[*]:v` a List.
+        // Coerce those to a plain array view up-front so the Array arm below owns
+        // the value/key/exists logic (a Hash target keeps its own path).
+        let mut target_is_coerced_list = false;
+        let target = {
+            let t = args[0].clone();
+            if !matches!(&t, Value::Array(..) | Value::Hash(_))
+                && (t.is_range()
+                    || matches!(
+                        &t,
+                        Value::Seq(_) | Value::HyperSeq(_) | Value::RaceSeq(_) | Value::LazyList(_)
+                    ))
+            {
+                target_is_coerced_list = true;
+                Value::real_array(crate::runtime::utils::value_to_list(&t))
+            } else {
+                t
+            }
+        };
         let index = args[1].clone();
         let mode = args[2].to_string_value();
         let var_name = args
@@ -266,59 +285,119 @@ impl Interpreter {
         }
         let is_multi = indices.len() != 1 || force_list;
 
-        let mut rows: Vec<(Value, Value, bool)> = Vec::with_capacity(indices.len());
-        match &target {
-            Value::Array(items, ..) => {
-                // The set of explicitly element-assigned indices travels with
-                // the array value (embedded `ArrayData::initialized`), so a slot
-                // holding a `Package("Any")` hole is distinguished from a real
-                // `Any` value even after the array crosses scopes/closures.
-                let bound_map = items.initialized.as_ref();
-                // The missing-element default comes from the array's *element
-                // type*. Read it from the container value itself (embedded
-                // metadata / `is default`) FIRST so it survives rebinding — e.g.
-                // `for $@s, Str -> @a { @a[11]:!v }` where the loop variable has
-                // no type constraint but the bound array still carries `.of=Str`.
-                // Fall back to the declared variable's default/type, then Any.
-                let container_default = self.container_default(&target).cloned().or_else(|| {
+        // Positional targets (real arrays, plus Ranges/Seqs/Lists coerced above)
+        // own a recursive path so a *nested* sub-list index preserves its nesting
+        // in the result — `@a[(3, (30, (5,)))]:k` yields `(3, ((5,),))`, not a
+        // flattened list. A Hash target keeps the original flat path below.
+        if let Value::Array(items, ..) = &target {
+            // The set of explicitly element-assigned indices travels with the
+            // array value (embedded `ArrayData::initialized`), so a slot holding a
+            // `Package("Any")` hole is distinguished from a real `Any` value even
+            // after the array crosses scopes/closures.
+            let bound_map: Option<std::collections::HashSet<usize>> = items.initialized.clone();
+            let items_snap: Vec<Value> = items.to_vec();
+            // The missing-element default comes from the array's *element type*.
+            // Read it from the container value itself (embedded metadata /
+            // `is default`) FIRST so it survives rebinding — e.g.
+            // `for $@s, Str -> @a { @a[11]:!v }` where the loop variable has no
+            // type constraint but the bound array still carries `.of=Str`. Fall
+            // back to the declared variable's default/type, then Any.
+            let container_default = self.container_default(&target).cloned().or_else(|| {
+                var_name
+                    .as_ref()
+                    .and_then(|name| self.var_default(name).cloned())
+            });
+            let type_constraint_default = self
+                .container_type_metadata(&target)
+                .map(|info| info.value_type)
+                .filter(|t| !t.is_empty())
+                .or_else(|| {
                     var_name
                         .as_ref()
-                        .and_then(|name| self.var_default(name).cloned())
-                });
-                let type_constraint_default = self
-                    .container_type_metadata(&target)
-                    .map(|info| info.value_type)
-                    .filter(|t| !t.is_empty())
-                    .or_else(|| {
-                        var_name
-                            .as_ref()
-                            .and_then(|name| self.var_type_constraint(name))
-                    })
-                    .map(|t| Value::Package(Symbol::intern(&t)));
-                let missing_value = container_default
-                    .or(type_constraint_default)
-                    .unwrap_or_else(|| Value::Package(Symbol::intern("Any")));
-                for idx in &indices {
-                    let i = match idx {
-                        Value::Int(i) => *i,
-                        Value::Num(f) => *f as i64,
-                        _ => idx.to_string_value().parse::<i64>().unwrap_or(-1),
-                    };
-                    let key = Value::Int(i);
-                    if i < 0 || i as usize >= items.len() {
-                        rows.push((key, missing_value.clone(), false));
-                        continue;
-                    }
-                    let ui = i as usize;
-                    let exists = if let Some(set) = bound_map {
-                        set.contains(&ui)
-                            || !matches!(&items[ui], Value::Package(name) if name == "Any")
+                        .and_then(|name| self.var_type_constraint(name))
+                })
+                .map(|t| Value::Package(Symbol::intern(&t)));
+            // A Range/List coerced to an array view has no container element
+            // type, so a missing element reads back as `Nil` (matching
+            // `("a".."z")[30]:!v`), not the `Any` a real `@`-array reports.
+            let missing_value = container_default
+                .or(type_constraint_default)
+                .unwrap_or_else(|| {
+                    if target_is_coerced_list {
+                        Value::Nil
                     } else {
-                        true
-                    };
-                    rows.push((key, items[ui].clone(), exists));
+                        Value::Package(Symbol::intern("Any"))
+                    }
+                });
+
+            // `:delete` companion (`:delete:kv` etc): remove every *leaf* index of
+            // the (possibly nested) index tree from the live binding, then format
+            // the pre-delete snapshot. The value/key/exists reported are the
+            // pre-deletion state (captured in `items_snap`).
+            if delete_after && let Some(var_name) = var_name.as_ref() {
+                let hole_type = self
+                    .var_type_constraint(var_name)
+                    .unwrap_or_else(|| "Any".to_string());
+                let mut leaves: Vec<i64> = Vec::new();
+                Self::collect_slice_leaf_indices(&indices, &mut leaves);
+                if let Some(Value::Array(live, ..)) = self.env.get_mut(var_name) {
+                    let hole_value = Value::Package(crate::symbol::Symbol::intern(&hole_type));
+                    let arr = crate::gc::Gc::make_mut(live);
+                    for i in &leaves {
+                        if *i >= 0 && (*i as usize) < arr.len() {
+                            arr[*i as usize] = hole_value.clone();
+                        }
+                    }
+                    // Trim trailing holes.
+                    while let Some(last) = arr.last() {
+                        let is_hole = match last {
+                            Value::Nil => true,
+                            Value::Package(name) => name == "Any" || name == hole_type.as_str(),
+                            _ => false,
+                        };
+                        if is_hole {
+                            arr.pop();
+                        } else {
+                            break;
+                        }
+                    }
+                    // Sync the env mutation back to the local slot (dual store) so
+                    // a later read of the array observes the deletion.
+                    self.writeback_multidim_var_to_local(var_name);
                 }
             }
+
+            if !is_multi {
+                let (key, value, exists) = Self::resolve_positional_scalar(
+                    &items_snap,
+                    bound_map.as_ref(),
+                    &missing_value,
+                    &indices[0],
+                );
+                if !keep_missing && !exists {
+                    return Ok(Value::array(Vec::new()));
+                }
+                return Ok(match kind {
+                    "kv" => Value::array(vec![key, value]),
+                    "p" => Value::ValuePair(Box::new(key), Box::new(value)),
+                    "k" => key,
+                    "v" => value,
+                    _ => Value::Nil,
+                });
+            }
+            let out = Self::format_positional_slice_level(
+                &items_snap,
+                bound_map.as_ref(),
+                &missing_value,
+                &indices,
+                kind,
+                keep_missing,
+            );
+            return Ok(Value::array(out));
+        }
+
+        let mut rows: Vec<(Value, Value, bool)> = Vec::with_capacity(indices.len());
+        match &target {
             Value::Hash(map) => {
                 // The missing-key default comes from the Hash's *value type* — read
                 // it from the container value itself (via container metadata /
@@ -362,48 +441,14 @@ impl Interpreter {
             _ => return Ok(Value::Nil),
         }
 
-        if delete_after && let Some(var_name) = var_name.as_ref() {
-            // Get hole type before mutable borrow
-            let hole_type = self
-                .var_type_constraint(var_name)
-                .unwrap_or_else(|| "Any".to_string());
-            if let Some(container) = self.env.get_mut(var_name) {
-                match container {
-                    Value::Hash(map) => {
-                        let h = crate::gc::Gc::make_mut(map);
-                        for idx in &indices {
-                            h.remove(&idx.to_string_value());
-                        }
-                    }
-                    Value::Array(items, ..) => {
-                        let hole_value = Value::Package(crate::symbol::Symbol::intern(&hole_type));
-                        let arr = crate::gc::Gc::make_mut(items);
-                        for idx in &indices {
-                            let i = match idx {
-                                Value::Int(i) => *i,
-                                Value::Num(f) => *f as i64,
-                                _ => idx.to_string_value().parse::<i64>().unwrap_or(-1),
-                            };
-                            if i >= 0 && (i as usize) < arr.len() {
-                                arr[i as usize] = hole_value.clone();
-                            }
-                        }
-                        // Trim trailing holes
-                        while let Some(last) = arr.last() {
-                            let is_hole = match last {
-                                Value::Nil => true,
-                                Value::Package(name) => name == "Any" || name == hole_type.as_str(),
-                                _ => false,
-                            };
-                            if is_hole {
-                                arr.pop();
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                    _ => {}
-                }
+        // Hash `:delete` companion (arrays handled in the positional path above).
+        if delete_after
+            && let Some(var_name) = var_name.as_ref()
+            && let Some(Value::Hash(map)) = self.env.get_mut(var_name)
+        {
+            let h = crate::gc::Gc::make_mut(map);
+            for idx in &indices {
+                h.remove(&idx.to_string_value());
             }
         }
 
@@ -440,5 +485,109 @@ impl Interpreter {
             }
         }
         Ok(Value::array(out))
+    }
+
+    /// One level of a positional slice adverb (`:k`/`:v`/`:p`/`:kv`) applied to
+    /// `items`. A *nested* index element (a sub-list/Range) recurses and becomes
+    /// ONE nested list element in the output, preserving the index tree's shape;
+    /// a scalar index contributes its formatted key/value entries in place.
+    pub(crate) fn format_positional_slice_level(
+        items: &[Value],
+        bound_map: Option<&std::collections::HashSet<usize>>,
+        missing_value: &Value,
+        indices: &[Value],
+        kind: &str,
+        keep_missing: bool,
+    ) -> Vec<Value> {
+        let mut out = Vec::new();
+        for idx in indices {
+            if let Some(sub) = Self::nested_index_elements(idx) {
+                let sub_out = Self::format_positional_slice_level(
+                    items,
+                    bound_map,
+                    missing_value,
+                    &sub,
+                    kind,
+                    keep_missing,
+                );
+                out.push(Value::array(sub_out));
+                continue;
+            }
+            let (key, value, exists) =
+                Self::resolve_positional_scalar(items, bound_map, missing_value, idx);
+            if !keep_missing && !exists {
+                continue;
+            }
+            match kind {
+                "kv" => {
+                    out.push(key);
+                    out.push(value);
+                }
+                "p" => out.push(Value::ValuePair(Box::new(key), Box::new(value))),
+                "k" => out.push(key),
+                "v" => out.push(value),
+                _ => {}
+            }
+        }
+        out
+    }
+
+    /// If `idx` is a nested sub-slice (a non-itemized list / Seq / Range used as
+    /// an index element), return its direct elements for recursion; else `None`
+    /// (it is a scalar leaf index).
+    pub(crate) fn nested_index_elements(idx: &Value) -> Option<Vec<Value>> {
+        match idx {
+            Value::Array(items, kind) if !kind.is_itemized() => Some(items.to_vec()),
+            Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
+                Some(items.to_vec())
+            }
+            r if r.is_range() => Some(crate::runtime::utils::value_to_list(r)),
+            _ => None,
+        }
+    }
+
+    /// Resolve one scalar index against `items`, returning `(key, value, exists)`.
+    /// Out-of-range or unfilled slots report the container's `missing_value` with
+    /// `exists = false`.
+    fn resolve_positional_scalar(
+        items: &[Value],
+        bound_map: Option<&std::collections::HashSet<usize>>,
+        missing_value: &Value,
+        idx: &Value,
+    ) -> (Value, Value, bool) {
+        let i = match idx {
+            Value::Int(i) => *i,
+            Value::Num(f) => *f as i64,
+            _ => idx.to_string_value().parse::<i64>().unwrap_or(-1),
+        };
+        let key = Value::Int(i);
+        if i < 0 || i as usize >= items.len() {
+            return (key, missing_value.clone(), false);
+        }
+        let ui = i as usize;
+        let exists = match bound_map {
+            Some(set) => {
+                set.contains(&ui) || !matches!(&items[ui], Value::Package(name) if name == "Any")
+            }
+            None => true,
+        };
+        (key, items[ui].clone(), exists)
+    }
+
+    /// Collect every *leaf* integer index of a (possibly nested) slice index tree,
+    /// for `:delete` to remove each addressed slot.
+    pub(crate) fn collect_slice_leaf_indices(indices: &[Value], out: &mut Vec<i64>) {
+        for idx in indices {
+            if let Some(sub) = Self::nested_index_elements(idx) {
+                Self::collect_slice_leaf_indices(&sub, out);
+                continue;
+            }
+            let i = match idx {
+                Value::Int(i) => *i,
+                Value::Num(f) => *f as i64,
+                _ => idx.to_string_value().parse::<i64>().unwrap_or(-1),
+            };
+            out.push(i);
+        }
     }
 }

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -307,6 +307,16 @@ impl Interpreter {
         } else {
             idx
         };
+        // A nested single-dim slice delete (`@a[(3, (30, (5,)))]:delete`) returns
+        // the deleted values in the index tree's shape and removes every leaf slot.
+        if let Some(inner) = Self::nested_index_elements(&idx)
+            && inner
+                .iter()
+                .any(|e| Self::nested_index_elements(e).is_some())
+            && matches!(self.env().get(&var_name), Some(Value::Array(..)))
+        {
+            return self.exec_nested_slice_delete(code, &var_name, slot, &inner);
+        }
         // For typed arrays (e.g. `my Int @a`), deleted elements become
         // the type object (e.g. `Int`) instead of `Any`.
         let hole_type =
@@ -418,6 +428,51 @@ impl Interpreter {
         // the container pointer).
         if let Some(container) = self.env().get(&var_name).cloned() {
             self.write_local_slot_or_name(code, slot, &var_name, container);
+        }
+        self.stack.push(result);
+        Ok(())
+    }
+
+    /// Plain `:delete` on a nested single-dim slice (`@a[(3, (30, (5,)))]:delete`):
+    /// return the deleted values in the index tree's shape (missing slots read as
+    /// the array's hole type) and remove every addressed leaf slot.
+    fn exec_nested_slice_delete(
+        &mut self,
+        code: &CompiledCode,
+        var_name: &str,
+        slot: Option<u32>,
+        inner: &[Value],
+    ) -> Result<(), RuntimeError> {
+        let hole_type =
+            loan_env!(self, var_type_constraint(var_name)).unwrap_or_else(|| "Any".to_string());
+        // Snapshot the pre-delete contents for the returned (value) tree.
+        let items_snap: Vec<Value> = match self.env().get(var_name) {
+            Some(Value::Array(items, ..)) => items.to_vec(),
+            _ => Vec::new(),
+        };
+        let missing = Value::Package(crate::symbol::Symbol::intern(&hole_type));
+        // Plain `:delete` returns the values, keeping missing slots (as the hole).
+        let result = Value::array(Self::format_positional_slice_level(
+            &items_snap,
+            None,
+            &missing,
+            inner,
+            "v",
+            true,
+        ));
+        // Remove every leaf index through the shared flat-delete machinery.
+        let mut leaves = Vec::new();
+        Self::collect_slice_leaf_indices(inner, &mut leaves);
+        let flat_idx = Value::array(leaves.iter().map(|i| Value::Int(*i)).collect::<Vec<_>>());
+        if let Some(container) = self.env_mut().get_mut(var_name) {
+            let _ = Self::delete_from_container(container, flat_idx.clone(), &hole_type)?;
+        }
+        self.unmark_initialized_indices(var_name, &flat_idx);
+        self.mark_deleted_indices(var_name, &flat_idx);
+        self.unmark_bound_indices(var_name, &flat_idx);
+        self.trim_trailing_array_holes(var_name);
+        if let Some(container) = self.env().get(var_name).cloned() {
+            self.write_local_slot_or_name(code, slot, var_name, container);
         }
         self.stack.push(result);
         Ok(())

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -70,6 +70,26 @@ impl Interpreter {
             }
             let target = self.stack.pop().unwrap_or(Value::Nil);
             Self::throw_if_failure(&target)?;
+            // A nested single-dim slice (`@a[(3, (30, (5,)))]:exists`) preserves
+            // its index-tree shape in the result, so it recurses rather than
+            // walking a flat pair list. Distinct from a multidim `@a[1;2]` walk.
+            if let Some(inner) = Self::nested_index_elements(&idx)
+                && inner
+                    .iter()
+                    .any(|e| Self::nested_index_elements(e).is_some())
+                && let Some(items) = Self::positional_exists_items(&target)
+            {
+                let adverb = match adverb_bits {
+                    1 => "kv",
+                    2 => "not-kv",
+                    3 => "p",
+                    4 => "not-p",
+                    _ => "none",
+                };
+                let out = Self::nested_exists_slice(&items, &inner, effective_negated, adverb);
+                self.stack.push(Value::array(out));
+                return Ok(());
+            }
             if let Some(map) = match &target {
                 Value::Hash(map) => Some(map.clone()),
                 Value::Instance {


### PR DESCRIPTION
## Summary

Implements **structure-preserving slice adverbs over a nested index list**, closing the last failing subtest of `roast/S09-subscript/slice.t` (now **56/56**, whitelisted).

`("a".."z")[(3, (30, (5,)))]:k` now recurses the index tree and yields `(3, ((5,),))` — mutsu previously flattened one level and treated the sub-list as a single (out-of-range) scalar index. Also coerces a Range/Seq/List **target** to an array view, so `("a".."z")[3,5]:k` works (previously returned `Nil`).

## What changed (4 additive recursions)

The slice adverbs live in four independent code paths. Each gained an **additive** recursion — a nested sub-list index recurses into ONE nested list element, a scalar index behaves exactly as before, so flat/non-nested slices are byte-identical (no regressions):

| adverb | path | file |
|---|---|---|
| `:k` `:v` `:p` `:kv` (+`:!`) | `builtin_subscript_adverb` → `format_positional_slice_level` | `runtime/builtins_multidim_subscript.rs` |
| `:exists` `:!exists` (+`:kv`/`:p`) | `ExistsIndexAdv` opcode → `nested_exists_slice` | `vm/vm_var_exists_ops.rs`, `runtime/builtins_multidim_ops.rs` |
| plain `:delete` | `DeleteIndexNamed` opcode → `exec_nested_slice_delete` | `vm/vm_var_delete_ops.rs` |
| `:delete:kv` `:delete:k` … | compiler routes `DELETE-KEY`+adverb → `__mutsu_subscript_adverb` w/ delete flag | `compiler/expr_method.rs` |

Additional fixes surfaced along the way:
- **Range/Seq/List target coercion** for slice adverbs (`("a".."z")[3,5]:k`), with a coerced list reporting a missing element as `Nil` (a real `@`-array reports `Any`/its element type).
- **delete writeback sync**: the `__mutsu_subscript_adverb` delete path now syncs the mutated array back to its local slot (`writeback_multidim_var_to_local`) so `@a[...]:delete:kv` is observed by later reads — this dual-store sync was missing.

## Verification

- `roast/S09-subscript/slice.t` — **56/56 PASS** (added to whitelist)
- `make test` — PASS (14076 tests)
- Adverb-heavy roast files (`S32-array/adverbs`, `S32-hash/adverbs`, `S32-hash/slice`, `S02-types/hash`, `S09-multidim/indexing`, `S32-array/exists-adverb`, `S09-typed-arrays/arrays`) — all still PASS
- `cargo clippy --all-targets` / `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)