### PR TITLE
fix(io): strict UTF-8 for open-handle slurp (malformed byte throws)

### DIFF
--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+/// Decode bytes as strict UTF-8, mirroring `IO::Path.slurp`: an invalid byte
+/// sequence is an error (surfaced as an `X::AdHoc`), not a lossy U+FFFD
+/// substitution. Used by the default-encoding text reads on an open handle so
+/// they match path-level slurp and Rakudo.
+fn decode_utf8_strict(bytes: Vec<u8>) -> Result<String, RuntimeError> {
+    String::from_utf8(bytes).map_err(|e| {
+        RuntimeError::new(format!(
+            "Malformed UTF-8 at byte offset {}",
+            e.utf8_error().valid_up_to()
+        ))
+    })
+}
+
 impl Interpreter {
     /// Mutable dispatch for `IO::Handle` methods that mutate the receiver in
     /// place. Currently only `.open`: in Raku `$fh.open(...)` opens the handle
@@ -686,7 +699,11 @@ impl Interpreter {
                     let decoded = self.decode_with_encoding(&all_bytes, &handle_encoding)?;
                     Ok(Value::str(decoded))
                 } else {
-                    Ok(Value::str(String::from_utf8_lossy(&all_bytes).to_string()))
+                    // Strict UTF-8, matching `IO::Path.slurp` (`read_to_string`)
+                    // and Rakudo: a malformed byte throws rather than silently
+                    // becoming U+FFFD. Non-utf8 encodings (incl. the lenient
+                    // `utf8-c8`) took the `decode_with_encoding` branch above.
+                    Ok(Value::str(decode_utf8_strict(all_bytes)?))
                 }
             }
             "split" => {

--- a/t/io-cathandle-malformed-utf8.t
+++ b/t/io-cathandle-malformed-utf8.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 3;
+
+# IO::CatHandle.slurp over a file containing an invalid UTF-8 byte must throw
+# (strict decoding), matching IO::Path.slurp and Rakudo — not silently yield a
+# U+FFFD replacement character.
+
+my $bad = $*TMPDIR.add("mutsu-cat-bad-utf8-{$*PID}");
+$bad.spurt(Buf.new(200));  # 0xC8: a lone continuation-less byte, invalid UTF-8
+
+dies-ok { IO::CatHandle.new($bad).slurp },
+    'IO::CatHandle.slurp throws on a malformed UTF-8 byte';
+
+# A utf8-c8 CatHandle is lenient by design: the same bad byte round-trips.
+lives-ok { IO::CatHandle.new(:encoding<utf8-c8>, $bad).slurp },
+    'utf8-c8 CatHandle tolerates the byte that strict utf8 rejects';
+
+$bad.unlink;
+
+# Valid UTF-8 content (including multibyte) still slurps correctly.
+my $a = $*TMPDIR.add("mutsu-cat-ok-a-{$*PID}");
+my $b = $*TMPDIR.add("mutsu-cat-ok-b-{$*PID}");
+$a.spurt("hé");
+$b.spurt("llo ♥");
+
+is IO::CatHandle.new($a, $b).slurp, "héllo ♥",
+    'IO::CatHandle.slurp concatenates valid multibyte UTF-8 across files';
+
+$a.unlink;
+$b.unlink;


### PR DESCRIPTION
## Problem

`IO::Path.slurp` decodes strictly (`read_to_string` → a malformed UTF-8 byte throws `X::AdHoc`), but the **open-handle** text-slurp path used `String::from_utf8_lossy`, silently substituting U+FFFD. `IO::CatHandle.slurp` reads through that native handle path, so it inherited the lossy behavior and never threw on invalid input — diverging from `IO::Path.slurp` and Rakudo.

Surfaced by `roast/S32-io/io-cathandle.t` → "file containing single non-valid-UTF8 byte throws in utf8 slurp". (That subtest is `#?rakudo.moar todo` — upstream Rakudo *also* fails it, returning an empty string; mutsu is now **more correct** than Rakudo here.)

## Fix

Decode the **default-encoding (utf8)** handle slurp strictly via a new `decode_utf8_strict` helper. `utf8-c8` and other named encodings already took the `decode_with_encoding` branch and stay lenient/round-tripping as designed; `:bin` returns a `Buf` unchanged. Only the default-utf8 text slurp changes.

## Scope / safety

- `io-cathandle.t` is already whitelisted (passes with fudge); this removes the underlying **raw** failure and improves real malformed-input detection — no whitelist change, pure correctness.
- The remaining raw failure ("getc on text with combiners") is a `#?rakudo todo` grapheme-across-file-boundary bug Rakudo also fails; out of scope.
- Valid content (incl. multibyte) unaffected; `make test` green (14076 tests); clippy clean.

## Tests
`t/io-cathandle-malformed-utf8.t` — strict utf8 throws, utf8-c8 tolerates the same byte, valid multibyte concatenates across files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)