### PR TITLE
fix(container-identity): itemize bound container cells in hash .raku/.gist (Track B Phase 5)

### DIFF
--- a/docs/element-element-bind-plan.md
+++ b/docs/element-element-bind-plan.md
@@ -267,13 +267,23 @@ trusting the change.
 
 ## Phase 5 — container-cell leak hardening
 
+> **Status (2026-07-04):** Phases 1–4 landed; nested.t is 43/43 and repros A–D
+> match rakudo. Audited the leak paths below — the scalar-cell and most
+> container-cell paths already decont correctly. The one remaining divergence
+> found and fixed: **`.raku`/`.gist` of a hash containing a *container-valued*
+> bound element did not itemize the held aggregate** (`{:a([1, 2])}` instead of
+> rakudo's `{:a($[1, 2])}`). `raku_hash_value` now derefs a `ContainerRef` and
+> itemizes on the *held* type (`src/builtins/methods_0arg/raku_repr.rs`); pinned
+> by `t/container-cell-raku-render.t`. The behavioral itemization (`.VAR`,
+> list-context non-flatten) was already correct — this was rendering-only.
+
 Container cells now flow into more paths. Like the Stage-1 `.values` leak (#2908)
 and the Stage-2 array-copy leak (#2914), AUDIT + decont `ContainerRef` in:
-- `.kv`, `.pairs`, `.antipairs`, `.invert`, `.list`, `.Hash`/`.Array` coercions
-- `.raku`/`.gist` rendering of a hash/array containing a bound element
-- positional/associative **slices** (`@a[1,2]`, `%h<a b>`)
-- `for`/iteration over a hash/array with a bound element
-- sort/compare (the original `.values.sort` leak shape)
+- `.kv`, `.pairs`, `.antipairs`, `.invert`, `.list`, `.Hash`/`.Array` coercions — audited OK
+- `.raku`/`.gist` rendering of a hash/array containing a bound element — **fixed (2026-07-04)**
+- positional/associative **slices** (`@a[1,2]`, `%h<a b>`) — audited OK
+- `for`/iteration over a hash/array with a bound element — audited OK
+- sort/compare (the original `.values.sort` leak shape) — audited OK
 
 Each only matters when a bound cell is present, so guard with
 `iter().any(is ContainerRef)` to keep the common path zero-cost (the #2914 pattern).

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -263,7 +263,14 @@ fn raku_hash_value(v: &Value) -> String {
     if base.starts_with(['$', '@', '%']) {
         return base;
     }
-    match v {
+    // A `:=`-bound hash element holds a `ContainerRef` cell; itemize based on the
+    // aggregate it *holds* so it renders like a plain hash value — `{:a($[1, 2])}`,
+    // not `{:a([1, 2])}` (Phase 5 leak hardening, `docs/element-element-bind-plan.md`).
+    let effective = match v {
+        Value::ContainerRef(cell) => cell.lock().unwrap().clone(),
+        other => other.clone(),
+    };
+    match &effective {
         Value::Array(..) | Value::Hash(_) => format!("${base}"),
         Value::Seq(_) => format!("$({base})"),
         _ => base,

--- a/t/container-cell-raku-render.t
+++ b/t/container-cell-raku-render.t
@@ -1,0 +1,58 @@
+# Phase 5 leak hardening (docs/element-element-bind-plan.md): a `:=`-bound
+# hash element holds a shared `ContainerRef` cell. `.raku`/`.gist` of the
+# enclosing hash must itemize the held aggregate exactly like a plain hash value
+# (`{:a($[1, 2])}`, not `{:a([1, 2])}`), so a bound element is indistinguishable
+# from an unbound one in the rendering.
+use Test;
+
+plan 8;
+
+{
+    my %h = a => [1, 2], b => [3, 4];
+    my $x := %h<a>;
+    $x.push(9);
+    is %h.raku, '{:a($[1, 2, 9]), :b($[3, 4])}',
+        'bound array-valued hash element itemizes in .raku like an unbound one';
+    is %h.gist, '{a => [1 2 9], b => [3 4]}',
+        'bound array-valued hash element renders in .gist like an unbound one';
+}
+
+{
+    my %h = a => [1, 2], b => { x => 5 };
+    my $x := %h<a>;
+    my $y := %h<b>;
+    $x.push(9);
+    $y<x> = 50;
+    is %h.raku, '{:a($[1, 2, 9]), :b(${:x(50)})}',
+        'mixed array- and hash-valued bound elements both itemize';
+}
+
+{
+    # A bound cell nested one level deeper (hash-in-hash) still itemizes.
+    my %g = outer => { inner => [7, 8] };
+    my $z := %g<outer>;
+    $z<inner>.push(9);
+    is %g.raku, '{:outer(${:inner($[7, 8, 9])})}',
+        'nested bound hash element itemizes its own aggregate values';
+    is %g.gist, '{outer => {inner => [7 8 9]}}', 'nested bound element .gist matches';
+}
+
+{
+    # An array of bound hashes: array elements de-itemize (raku strips `$`),
+    # so a bound hash element renders as a plain `{...}` — NOT double-itemized.
+    my @a = { p => 1 }, { q => 2 };
+    my $w := @a[0];
+    $w<p> = 100;
+    is @a.raku, '[{:p(100)}, {:q(2)}]',
+        'bound hash element inside an array is not double-itemized';
+    is @a.gist, '[{p => 100} {q => 2}]', 'bound hash element in array .gist matches';
+}
+
+{
+    # The bound element still behaves as an itemized Scalar container (not just
+    # a rendering fix): it does not flatten in list context.
+    my %h = a => [1, 2];
+    my $x := %h<a>;
+    my @flat = %h<a>, %h<a>;
+    is @flat.elems, 2, 'bound array-valued hash element stays itemized (no flatten)';
+}


### PR DESCRIPTION
## Summary

Container-identity campaign (Track B / `docs/element-element-bind-plan.md`) **Phase 5 leak-hardening**. A `:=`-bound hash element holds a shared `ContainerRef` cell (Phase 2 element cells). When `.raku`/`.gist` rendered a hash containing a **container-valued** bound element, mutsu did not itemize the held aggregate:

```raku
my %h = a => [1, 2], b => [3, 4];
my $x := %h<a>;
$x.push(9);
say %h.raku;
# mutsu (before): {:a([1, 2, 9]), :b($[3, 4])}   ← bound element not itemized
# rakudo:         {:a($[1, 2, 9]), :b($[3, 4])}
```

So a `:=`-bound element rendered differently from an unbound sibling.

## Fix

`raku_hash_value` (`src/builtins/methods_0arg/raku_repr.rs`) now derefs a `ContainerRef` and itemizes based on the **held** value's type (Array/Hash → `$…`, Seq → `$(…)`), exactly as a plain hash value is itemized. The behavioral itemization (`.VAR` is `Scalar`, list-context non-flatten) was already correct — this was a rendering-only leak.

This closes the last open item in the plan's Phase 5 audit; the scalar-cell and other container-cell paths (`.kv`/`.pairs`/`.antipairs`/`.invert`/slices/`for`/sort/coercions) were audited against rakudo and already decont correctly.

## Verification

- New pin `t/container-cell-raku-render.t` — 8 cases (array/hash-valued bound elements, mixed, nested hash-in-hash, array-of-bound-hashes, `.gist`, non-flatten) — all match rakudo
- `roast/S03-binding/nested.t` — stays 43/43 (repros A–D from the plan all match rakudo)
- Existing element-cell pins (`element-bind-cell.t`, `array-bind-cell.t`) — pass
- `make test` — PASS (14093 tests); `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)