### PR TITLE
fix(sort): inline <=> comparator coerces aggregates to .elems like the operator

### DIFF
--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -2,7 +2,33 @@ use super::*;
 use crate::ast::{Expr, Stmt};
 use crate::token_kind::TokenKind;
 
+/// A value that `<=>` coerces to its *element count* (`.Numeric` = `.elems`)
+/// rather than comparing structurally: aggregates and ranges. `compare_values`
+/// (structural, used by `cmp`) would order these element-by-element, so the
+/// inline `{ $^a <=> $^b }` fast path must coerce them to a number first —
+/// matching the real spaceship operator (`exec_spaceship_op`'s numeric bridge).
+fn coerces_to_numeric_length(v: &Value) -> bool {
+    matches!(
+        v,
+        Value::Array(..)
+            | Value::Seq(_)
+            | Value::HyperSeq(_)
+            | Value::RaceSeq(_)
+            | Value::LazyList(_)
+            | Value::Hash(_)
+            | Value::Set(..)
+            | Value::Bag(..)
+            | Value::Mix(..)
+            | Value::Range(..)
+            | Value::RangeExcl(..)
+            | Value::RangeExclStart(..)
+            | Value::RangeExclBoth(..)
+            | Value::GenericRange { .. }
+    )
+}
+
 pub(crate) fn inline_numeric_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use crate::runtime::utils::to_float_value;
     match (a, b) {
         (Value::Int(x), Value::Int(y)) => x.cmp(y),
         (Value::Num(x), Value::Num(y)) => x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
@@ -12,6 +38,17 @@ pub(crate) fn inline_numeric_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
         (Value::Num(x), Value::Int(y)) => x
             .partial_cmp(&(*y as f64))
             .unwrap_or(std::cmp::Ordering::Equal),
+        // `<=>` is numeric: an Array/List/Set/…/Range operand is coerced to its
+        // element count (`.Numeric`), not compared structurally. Coerce and
+        // compare numerically so `sort({ $^a <=> $^b })` orders by `.elems`,
+        // exactly like a standalone `$x <=> $y` (which `cmp` — structural — does
+        // NOT). Scalars (Rat/BigInt/Str/…) keep the exact `compare_values` path.
+        _ if coerces_to_numeric_length(a) || coerces_to_numeric_length(b) => {
+            match (to_float_value(a), to_float_value(b)) {
+                (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal),
+                _ => compare_values(a, b).cmp(&0),
+            }
+        }
         _ => compare_values(a, b).cmp(&0),
     }
 }

--- a/t/sort-spaceship-numeric-coerce.t
+++ b/t/sort-spaceship-numeric-coerce.t
@@ -1,0 +1,44 @@
+# `<=>` is a numeric operator: an Array/List/Set/…/Range operand is coerced to
+# its element count (`.Numeric` = `.elems`) before comparing, NOT compared
+# structurally (that is `cmp`). The inline `{ $^a <=> $^b }` / `* <=> *` sort
+# fast path must match the standalone operator, so a sort by `<=>` over
+# aggregates orders by `.elems`.
+use Test;
+
+plan 10;
+
+# Standalone `<=>` over arrays coerces to .elems (regression baseline).
+is ([1, 2, 9] <=> [3, 4]), More, 'Array <=> Array coerces to .elems (3 <=> 2)';
+is ([1, 2] <=> [3, 4, 5]), Less, 'shorter array is Less';
+is ([1, 2, 3] <=> [4, 5, 6]), Same, 'equal-length arrays are Same';
+is ([1, 2] <=> 5), Less, 'Array <=> Int coerces the array to .elems';
+
+# The inline `{ $^a <=> $^b }` sort fast path must match — order by .elems.
+is-deeply
+    ([1, 2, 9], [3, 4]).sort({ $^a <=> $^b }).map(*.elems).List,
+    (2, 3),
+    'sort({ $^a <=> $^b }) over arrays orders by .elems, not structurally';
+is-deeply
+    ([1, 2, 9], [3, 4]).sort(* <=> *).map(*.elems).List,
+    (2, 3),
+    'sort(* <=> *) over arrays orders by .elems';
+is-deeply
+    ([1, 2, 3], [1], [1, 2]).sort({ $^b <=> $^a }).map(*.elems).List,
+    (3, 2, 1),
+    'reversed { $^b <=> $^a } over arrays orders by .elems descending';
+
+# `cmp` stays structural (must NOT be affected).
+is-deeply
+    ([1, 2, 9], [3, 4]).sort({ $^a cmp $^b }).map(*.elems).List,
+    (3, 2),
+    'sort({ $^a cmp $^b }) stays structural (compares 1 vs 3 first)';
+
+# Numeric scalars keep their exact ordering (Rat precision, not float).
+is-deeply
+    (1/3, 1/2, 1/4).sort({ $^a <=> $^b }).List,
+    (1/4, 1/3, 1/2),
+    'Rat sort by <=> stays exact';
+is-deeply
+    (3, 1, 2).sort({ $^a <=> $^b }).List,
+    (1, 2, 3),
+    'plain Int sort by <=> unaffected';


### PR DESCRIPTION
## Summary

The inline `{ \$^a <=> \$^b }` / `* <=> *` sort fast path (`inline_numeric_cmp`) compared non-Int/Num operands with `compare_values` — a **structural** (element-by-element) comparison, which is `cmp` semantics, not `<=>`.

The real spaceship operator (`exec_spaceship_op`) is **numeric**: it coerces each operand to its `.Numeric` value first, and an Array/List/Set/…/Range coerces to its **element count**. So a sort by `<=>` over arrays ordered them structurally instead of by `.elems`:

```raku
([1,2,9], [3,4]).sort({ $^a <=> $^b }).map(*.elems)
# mutsu (before): (3, 2)   ← structural: 1 vs 3 → [1,2,9] first
# rakudo:         (2, 3)   ← numeric:    3 vs 2 → [3,4] first
```

The standalone `[1,2,9] <=> [3,4]` already returned `More` correctly (via the operator's numeric bridge) — only the sort *inline fast path* diverged.

## Fix

When either operand of the inline `<=>` path coerces-by-length (an aggregate or range), coerce both via `to_float_value` (= `.elems` for those) and compare numerically, matching the standalone operator. Numeric scalars (Rat/BigInt/…) keep the exact `compare_values` path, so `<=>` over Rats stays precise; `cmp` comparators are untouched (they stay structural).

## Verification

- New pin `t/sort-spaceship-numeric-coerce.t` (10 cases: standalone `<=>` over arrays / mixed array-vs-int, inline `{ \$^a <=> \$^b }` & `* <=> *` order-by-elems, `cmp` stays structural, Rat/Int precision) — all match rakudo
- Broad sort regression check (Int/Num/Rat/String comparators) — unchanged
- `make test` — PASS; `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)