### PR TITLE
fix(io): grapheme-cluster readchars($n) on file handles

### DIFF
--- a/src/runtime/builtins_io_stream.rs
+++ b/src/runtime/builtins_io_stream.rs
@@ -115,7 +115,7 @@ impl Interpreter {
             // Read one grapheme cluster (base + extending codepoints), matching
             // `.chars`/`.comb`; seekable files use the grapheme path, other
             // targets fall back to a single codepoint.
-            if let Some(g) = self.read_grapheme_from_handle_value(&handle)? {
+            if let Some(g) = self.read_grapheme_from_handle_value(&handle, 1)? {
                 return Ok(if g.is_empty() {
                     Value::Nil
                 } else {

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -239,14 +239,15 @@ impl IoHandleState {
         }
     }
 
-    /// VM-native single-grapheme read for `.getc` on a seekable File+UTF8
-    /// handle: a base codepoint plus any codepoints that extend the same
-    /// grapheme cluster (combining marks, ZWJ sequences, ...), matching
-    /// `.chars`/`.comb` and Rakudo's NFG `.getc`. The one codepoint that begins
-    /// the next grapheme is over-read to find the boundary and seeked back, so a
-    /// subsequent read sees the correct position. Empty string = EOF. Caller
-    /// guarantees [`can_native_text_write`].
-    pub(crate) fn read_grapheme_native(&mut self) -> Result<String, RuntimeError> {
+    /// VM-native grapheme read for `.getc`/`.readchars` on a seekable File+UTF8
+    /// handle: up to `count` grapheme clusters, each a base codepoint plus any
+    /// codepoints that extend the same cluster (combining marks, ZWJ sequences,
+    /// ...), matching `.chars`/`.comb` and Rakudo's NFG semantics. The one
+    /// codepoint that begins the next cluster is over-read to find the boundary
+    /// and seeked back, so a subsequent read sees the correct position. Fewer
+    /// than `count` (incl. empty) means EOF was reached. Caller guarantees
+    /// [`can_native_text_write`].
+    pub(crate) fn read_grapheme_native(&mut self, count: usize) -> Result<String, RuntimeError> {
         use std::io::Seek;
         use unicode_segmentation::UnicodeSegmentation;
         if self.closed {
@@ -258,29 +259,34 @@ impl IoHandleState {
             .file
             .as_mut()
             .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-        let Some(mut cluster) = Interpreter::read_utf8_char(file)? else {
-            return Ok(String::new()); // EOF
-        };
-        // A binary handle keeps single-codepoint semantics (no grapheme
-        // clustering over raw bytes).
-        if is_bin {
-            return Ok(cluster);
-        }
-        loop {
-            let Some(ch) = Interpreter::read_utf8_char(file)? else {
-                break; // EOF: cluster ends here
+        let mut out = String::new();
+        for _ in 0..count {
+            let Some(mut cluster) = Interpreter::read_utf8_char(file)? else {
+                break; // EOF
             };
-            let combined = format!("{cluster}{ch}");
-            if combined.graphemes(true).count() == 1 {
-                cluster = combined; // `ch` extends the grapheme
-            } else {
-                // `ch` begins the next grapheme — put it back.
-                file.seek(std::io::SeekFrom::Current(-(ch.len() as i64)))
-                    .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                break;
+            // A binary handle keeps single-codepoint semantics (no grapheme
+            // clustering over raw bytes).
+            if is_bin {
+                out.push_str(&cluster);
+                continue;
             }
+            loop {
+                let Some(ch) = Interpreter::read_utf8_char(file)? else {
+                    break; // EOF: cluster ends here
+                };
+                let combined = format!("{cluster}{ch}");
+                if combined.graphemes(true).count() == 1 {
+                    cluster = combined; // `ch` extends the grapheme
+                } else {
+                    // `ch` begins the next grapheme — put it back.
+                    file.seek(std::io::SeekFrom::Current(-(ch.len() as i64)))
+                        .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                    break;
+                }
+            }
+            out.push_str(&cluster);
         }
-        Ok(cluster)
+        Ok(out)
     }
 
     /// Add to this handle's `bytes_written` counter. Used by the VM's Stdout

--- a/src/runtime/handle_read_chars.rs
+++ b/src/runtime/handle_read_chars.rs
@@ -305,20 +305,21 @@ impl Interpreter {
         })
     }
 
-    /// Read one **grapheme cluster** from a seekable file handle for `.getc`:
-    /// a base codepoint plus any codepoints that extend the same grapheme
-    /// (combining marks, ZWJ sequences, ...), matching Rakudo's NFG `.getc` and
-    /// mutsu's own grapheme-based `.chars`/`.comb`. The one codepoint that
-    /// begins the *next* grapheme is over-read to find the boundary and then
-    /// seeked back, so no cross-read pushback state is needed and a subsequent
-    /// read sees the correct position.
+    /// Read up to `count` **grapheme clusters** from a seekable file handle for
+    /// `.getc`/`.readchars`: each is a base codepoint plus any codepoints that
+    /// extend the same grapheme (combining marks, ZWJ sequences, ...), matching
+    /// Rakudo's NFG semantics and mutsu's own grapheme-based `.chars`/`.comb`.
+    /// The one codepoint that begins the *next* grapheme is over-read to find
+    /// the boundary and then seeked back, so no cross-read pushback state is
+    /// needed and a subsequent read sees the correct position.
     ///
     /// Returns `Ok(None)` when this fast path does not apply (non-file target or
-    /// a non-default encoding); the caller then falls back to a single-codepoint
-    /// read. `Ok(Some(""))` signals EOF.
+    /// a non-default encoding); the caller then falls back to a codepoint read.
+    /// Fewer than `count` clusters (incl. `Ok(Some(""))`) means EOF.
     pub(super) fn read_grapheme_from_handle_value(
         &mut self,
         handle_value: &Value,
+        count: usize,
     ) -> Result<Option<String>, RuntimeError> {
         use std::io::Seek;
         use unicode_segmentation::UnicodeSegmentation;
@@ -329,7 +330,7 @@ impl Interpreter {
             let enc = state.encoding.to_lowercase();
             let is_default_utf8 = enc.is_empty() || enc == "utf-8" || enc == "utf8";
             if !is_default_utf8 || !matches!(state.target, IoHandleTarget::File) {
-                // Grapheme-aware getc only covers seekable default-utf8 files;
+                // Grapheme-aware read only covers seekable default-utf8 files;
                 // let the caller use the plain codepoint path otherwise.
                 return Ok(None);
             }
@@ -338,25 +339,29 @@ impl Interpreter {
                 .file
                 .as_mut()
                 .ok_or_else(|| RuntimeError::new("IO::Handle is not attached to a file"))?;
-            let Some(mut cluster) = Self::read_utf8_char(file)? else {
-                return Ok(Some(String::new())); // EOF
-            };
-            loop {
-                let Some(ch) = Self::read_utf8_char(file)? else {
-                    break; // EOF: the cluster ends here
+            let mut out = String::new();
+            for _ in 0..count {
+                let Some(mut cluster) = Self::read_utf8_char(file)? else {
+                    break; // EOF
                 };
-                let combined = format!("{cluster}{ch}");
-                if combined.graphemes(true).count() == 1 {
-                    // `ch` extends the current grapheme.
-                    cluster = combined;
-                } else {
-                    // `ch` begins the next grapheme — put it back.
-                    file.seek(std::io::SeekFrom::Current(-(ch.len() as i64)))
-                        .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
-                    break;
+                loop {
+                    let Some(ch) = Self::read_utf8_char(file)? else {
+                        break; // EOF: the cluster ends here
+                    };
+                    let combined = format!("{cluster}{ch}");
+                    if combined.graphemes(true).count() == 1 {
+                        // `ch` extends the current grapheme.
+                        cluster = combined;
+                    } else {
+                        // `ch` begins the next grapheme — put it back.
+                        file.seek(std::io::SeekFrom::Current(-(ch.len() as i64)))
+                            .map_err(|err| RuntimeError::new(format!("Failed to seek: {}", err)))?;
+                        break;
+                    }
                 }
+                out.push_str(&cluster);
             }
-            Ok(Some(cluster))
+            Ok(Some(out))
         })
     }
 }

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -345,7 +345,7 @@ impl Interpreter {
                     // codepoints), matching `.chars`/`.comb`. Seekable files use
                     // the grapheme path; other targets fall back to a single
                     // codepoint.
-                    match self.read_grapheme_from_handle_value(&target_val)? {
+                    match self.read_grapheme_from_handle_value(&target_val, 1)? {
                         Some(s) if s.is_empty() => Ok(Value::Nil), // EOF
                         Some(s) => Ok(Value::str(s)),
                         None => {
@@ -372,6 +372,14 @@ impl Interpreter {
                 } else {
                     None
                 };
+                // A bounded readchars reads that many GRAPHEMES (matching
+                // `.getc`/NFG); an unbounded read (whole file) is the same string
+                // either way. Non-file / non-utf8 handles fall back to codepoints.
+                if let Some(n) = count
+                    && let Some(s) = self.read_grapheme_from_handle_value(&target_val, n)?
+                {
+                    return Ok(Value::str(s));
+                }
                 Ok(Value::str(
                     self.read_chars_from_handle_value(&target_val, count)?,
                 ))

--- a/src/vm/vm_call_method_compiled_io.rs
+++ b/src/vm/vm_call_method_compiled_io.rs
@@ -879,7 +879,7 @@ impl Interpreter {
                 // One grapheme cluster (base + extending codepoints), matching
                 // `.chars`/`.comb`; empty -> Nil (as `getc`). `read_grapheme_native`
                 // itself keeps single-codepoint semantics for a `:bin` handle.
-                Some(state.read_grapheme_native().map(|s| {
+                Some(state.read_grapheme_native(1).map(|s| {
                     if s.is_empty() {
                         Value::Nil
                     } else {
@@ -906,7 +906,13 @@ impl Interpreter {
                         }
                     },
                 };
-                Some(state.read_chars_native(count).map(Value::str))
+                // Read graphemes for a bounded count (matching `.getc`/NFG);
+                // an unbounded read (whole file) is the same string either way.
+                let result = match count {
+                    Some(n) => state.read_grapheme_native(n),
+                    None => state.read_chars_native(None),
+                };
+                Some(result.map(Value::str))
             }
             _ => None,
         }

--- a/t/io-getc-grapheme.t
+++ b/t/io-getc-grapheme.t
@@ -1,10 +1,11 @@
 use Test;
 
-plan 6;
+plan 9;
 
 # `.getc` returns a full grapheme cluster (base codepoint + extending
 # codepoints), matching `.chars`/`.comb` and Rakudo's NFG semantics — not a
 # single codepoint. Covers both the direct IO::Handle path and IO::CatHandle.
+# `.readchars($n)` reads $n graphemes for the same reason.
 
 sub graphemes-of($handle) {
     my @res;
@@ -48,4 +49,14 @@ my $h = $r.open;
 $h.getc for ^3;
 is-deeply [$h.getc xx 3], [Nil xx 3], 'getc past EOF yields Nil';
 
-$p.unlink; $q.unlink; $f1.unlink; $f2.unlink; $r.unlink;
+# `.readchars($n)` reads $n GRAPHEMES, not codepoints.
+my $g = $*TMPDIR.add("mutsu-getc-readchars-{$*PID}");
+$g.spurt("a\x[308]\x[308]b\x[308]c");   # graphemes: a¨¨, b¨, c
+is $g.open.readchars(2), "a\x[308]\x[308]" ~ "b\x[308]",
+    'readchars(2) reads 2 whole graphemes';
+is $g.open.readchars(1), "a\x[308]\x[308]",
+    'readchars(1) reads 1 whole grapheme';
+is $g.open.readchars(100), "a\x[308]\x[308]" ~ "b\x[308]" ~ "c",
+    'readchars past EOF returns all graphemes';
+
+$p.unlink; $q.unlink; $f1.unlink; $f2.unlink; $r.unlink; $g.unlink;


### PR DESCRIPTION
## Context

While confirming the S32-io frontier (all whitelisted except `socket-recv-vs-read.t`, which is blocked on cross-thread container sharing), I found that `.readchars($n)` has the **same grapheme gap** #4138 fixed for `.getc`: it read `$n` **codepoints** instead of `$n` graphemes, diverging from `.chars`/`.comb` and Rakudo's NFG semantics.

`readchars("a\x[308]\x[308]b").readchars(2)` returned the first 2 codepoints instead of the first 2 graphemes (`"a\x[308]\x[308]"`, `"b"`). `readchars.t` only uses precomposed characters, so it never caught it.

## Fix

Generalize the two grapheme readers from #4138 to a count:
- `IoHandleState::read_grapheme_native(count)` — VM-native path
- `Interpreter::read_grapheme_from_handle_value(handle, count)` — interpreter path

Both now read up to `count` whole grapheme clusters. A bounded `readchars($n)` routes through them for seekable default-utf8 File handles; an unbounded read (whole file) and non-file/non-utf8/`:bin` handles keep existing behavior (same string either way). `.getc` is unchanged (`count = 1`).

## Validation
- readchars now matches raku (2 graphemes for `readchars(2)`), getc still 1 grapheme.
- roast S16-io/readchars.t, getc.t, S32-io/io-cathandle.t still pass; `make test` green (14103).
- `t/io-getc-grapheme.t` extended with readchars(1)/(2)/past-EOF grapheme assertions.

> Note: this is an IO/compat consistency improvement (readchars.t is already whitelisted and doesn't test combiners, so no whitelist change). The S32-io whitelist frontier is otherwise complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)