### PR TITLE
fix(assign): index/slice assignment is an lvalue for chained assignment

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -74,6 +74,32 @@ impl Compiler {
             return;
         } else if name == "__mutsu_assign_callable_lvalue"
             && args.len() == 3
+            && let Expr::IndexAssign {
+                target,
+                index,
+                is_positional,
+                ..
+            } = &args[0]
+        {
+            // `(@a[i] = v) = w` / `(@a[i,j] = @x) = @y` (the S02-types/array.t
+            // "hat trick"): an index/slice assignment yields the assigned
+            // element(s) as an lvalue, so the outer assignment writes through to
+            // the SAME subscript. Run the inner assignment for its side effect,
+            // then assign the RHS to `@a[i]` again — mirroring the scalar
+            // `($c = 3) = 4` case above. The re-assignment's own result stays on
+            // the stack (assignment is an expression).
+            self.compile_expr(&args[0]);
+            self.code.emit(OpCode::Pop);
+            let outer = Expr::IndexAssign {
+                target: target.clone(),
+                index: index.clone(),
+                value: Box::new(args[2].clone()),
+                is_positional: *is_positional,
+            };
+            self.compile_expr(&outer);
+            return;
+        } else if name == "__mutsu_assign_callable_lvalue"
+            && args.len() == 3
             && let Expr::Ternary {
                 cond,
                 then_expr,

--- a/t/chained-index-assignment-lvalue.t
+++ b/t/chained-index-assignment-lvalue.t
@@ -1,0 +1,61 @@
+# A parenthesized assignment is itself an lvalue: `($x = 5) = 6` writes through
+# to `$x` again. This must work for an index/slice assignment target too
+# (`(@a[i] = v) = w`), not just a scalar variable — the "hat trick" from
+# roast/S02-types/array.t. The inner assignment runs for its side effect, then
+# the outer RHS is assigned to the SAME subscript.
+use Test;
+
+plan 9;
+
+# Scalar chained assignment (baseline — already worked).
+{
+    my $x;
+    ($x = 5) = 6;
+    is $x, 6, 'scalar ($x = 5) = 6 writes through';
+}
+
+# Single array element as a chained-assignment lvalue.
+{
+    my @a = 0, 0, 0;
+    (@a[0] = 5) = 7;
+    is @a[0], 7, '(@a[0] = 5) = 7 writes through to @a[0]';
+    is @a[1], 0, 'other elements untouched';
+}
+
+# Single hash element as a chained-assignment lvalue.
+{
+    my %h;
+    (%h<k> = 1) = 2;
+    is %h<k>, 2, '(%h<k> = 1) = 2 writes through to %h<k>';
+}
+
+# Slice as a chained-assignment lvalue.
+{
+    my @b = 0, 0, 0, 0;
+    (@b[0, 1] = 1, 2) = 8, 9;
+    is ~@b, '8 9 0 0', '(@b[0,1] = 1,2) = 8,9 writes the slice';
+}
+
+# The S02-types/array.t "hat trick": assign to an end-indexed slice, then use
+# that as an lvalue for a reversed end-indexed slice of the source.
+{
+    my @array14 = 'a', 'b', 'c', 'd';
+    my @c = 0 .. 3;
+    ((@c[*-3, *-2, *-1, *-4] = @array14) = @array14[*-1, *-2, *-3, *-4]);
+    is ~@c, 'a d c b', 'hat trick: chained end-indexed slice lvalue';
+}
+
+# The chained assignment is an expression: its value is the final assignment.
+{
+    my @d = 0, 0;
+    my $r = ((@d[0] = 1) = 42);
+    is $r, 42, 'chained index assignment yields the final assigned value';
+    is @d[0], 42, '...and @d[0] holds it';
+}
+
+# Nested-container element chained assignment.
+{
+    my @aoa = [0, 0], [0, 0];
+    (@aoa[0][1] = 5) = 9;
+    is @aoa[0][1], 9, 'chained assignment through a nested element writes through';
+}


### PR DESCRIPTION
## Summary

A parenthesized assignment is itself an lvalue, so `(\$x = 5) = 6` writes through to `\$x` again. This worked for a scalar variable but threw `Cannot modify an immutable value (cannot assign through non-callable value)` for an **index/slice** assignment target (`(@a[i] = v) = w`):

```raku
my @a = 0, 0, 0;
(@a[0] = 5) = 7;   # before: throws;  after: @a[0] == 7
```

The compiler's `__mutsu_assign_callable_lvalue` had special-case arms for the scalar `AssignExpr`, `DoStmt(VarDecl)`, `Ternary`, and list-`ArrayLiteral` inner targets, but **none for `IndexAssign`**, so an index/slice inner assignment fell through to the runtime handler, which only accepts a callable/Proxy lvalue.

## Fix

Add an `IndexAssign` arm to `compile_expr_call`, mirroring the scalar `(\$c = 3) = 4` case: run the inner index/slice assignment for its side effect, then assign the outer RHS to the **same** subscript.

This unblocks the S02-types/array.t "hat trick":

```raku
((@b[*-3,*-2,*-1,*-4] = @array14) = @array14[*-1,*-2,*-3,*-4])
```

which previously threw and aborted the whole file. **`roast/S02-types/array.t` now runs 92/108** (was 61) — the remaining failures are separate features (`Array(...)` coercion, `X::Bind::Slice` for `@a[*-1] := 42`), left for follow-ups.

## Verification

- New pin `t/chained-index-assignment-lvalue.t` (9 cases: scalar baseline, single element, hash element, slice, the hat trick, expression value, nested-container element) — all match rakudo
- `make test` — PASS (14100 tests); `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)