### PR TITLE
feat(coerce): Array(...) / List(...) / Hash(...) container-type coercions

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -395,6 +395,7 @@ impl Interpreter {
             "nextcallee" => self.builtin_nextcallee(),
             // Type coercion
             "Int" | "Num" | "Str" | "Bool" | "Uni" => self.builtin_coerce(name, &args),
+            "Array" | "List" | "Hash" => self.builtin_container_coerce(name, &args),
             "UNBASE" => self.builtin_unbase(&args),
             "RADIX_LIST" => self.builtin_radix_list(&args),
             // Grammar helpers

--- a/src/runtime/builtins_coerce.rs
+++ b/src/runtime/builtins_coerce.rs
@@ -1,6 +1,36 @@
 use super::*;
 
 impl Interpreter {
+    /// The container-type coercion calls `Array(...)` / `List(...)` / `Hash(...)`.
+    /// Each argument becomes one element (Raku does not deep-flatten these:
+    /// `Array((1,2), 3).elems` is 2), so the args list is materialized directly.
+    /// A single type-object argument (`Array(Int)`) is a parametric type request
+    /// rather than a value coercion, so it passes through as a `Type(Type)`
+    /// package rendering, mirroring [`builtin_coerce`].
+    pub(super) fn builtin_container_coerce(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        // `Array(Int)` etc.: a lone type-object argument is a parametric type,
+        // not a value list. Render it like the scalar coercions do.
+        if args.len() == 1
+            && let Value::Package(sym) = &args[0]
+        {
+            return Ok(Value::Package(Symbol::intern(&format!(
+                "{name}({})",
+                sym.resolve()
+            ))));
+        }
+        let items: Vec<Value> = args.to_vec();
+        Ok(match name {
+            "Array" => Value::real_array(items),
+            "List" => Value::array(items),
+            "Hash" => crate::runtime::utils::build_hash_from_items(items)?,
+            _ => Value::real_array(items),
+        })
+    }
+
     pub(super) fn builtin_coerce(
         &mut self,
         name: &str,

--- a/t/container-type-coercion.t
+++ b/t/container-type-coercion.t
@@ -1,0 +1,22 @@
+# The container-type coercion calls `Array(...)`, `List(...)`, `Hash(...)`.
+# Each argument becomes one element (rakudo does not deep-flatten these), so
+# `Array(1,2,3)` is a 3-element Array. Previously mutsu reported these as
+# "Unknown function: Array" (S02-types/array.t aborted on `Array(1,2,3)`).
+use Test;
+
+plan 10;
+
+is Array(1, 2, 3).WHAT.gist, '(Array)', 'Array(...) makes an Array';
+ok Array(1, 2, 3) eqv [1, 2, 3], 'Array(1,2,3) makes the correct array';
+is Array(1, 2, 3).elems, 3, 'Array(...) keeps each arg as one element';
+is Array((1, 2), 3).elems, 2, 'Array(...) does NOT deep-flatten a nested list arg';
+
+is List(1, 2, 3).WHAT.gist, '(List)', 'List(...) makes a List';
+ok List(1, 2, 3) eqv (1, 2, 3), 'List(1,2,3) makes the correct list';
+
+is Hash('a', 1, 'b', 2).WHAT.gist, '(Hash)', 'Hash(...) makes a Hash';
+is Hash('a', 1, 'b', 2)<a>, 1, 'Hash(...) pairs up args into entries';
+
+# A lone type-object argument is a parametric type request, not a value list.
+is Array(Int).gist, '(Array(Int))', 'Array(Int) renders as a parametric type';
+is List(Str).gist, '(List(Str))', 'List(Str) renders as a parametric type';


### PR DESCRIPTION
## Summary

Calling a container type as a coercer — `Array(1, 2, 3)`, `List(...)`, `Hash(...)` — previously died with `Unknown function: Array` (it aborted `roast/S02-types/array.t` at `Array(1,2,3).WHAT`). Add these alongside the scalar `Int`/`Num`/`Str`/`Bool` coercions.

```raku
Array(1, 2, 3)        # (Array) — [1, 2, 3]
Array((1, 2), 3).elems # 2 — args are NOT deep-flattened
List(1, 2, 3)         # (List)
Hash('a', 1, 'b', 2)  # (Hash) — a => 1, b => 2
Array(Int)            # parametric type request → .gist (Array(Int))
```

## Details

Each argument becomes one element — rakudo does not deep-flatten these — so the argument list is materialized directly (`Array` → real Array, `List` → List, `Hash` → paired entries via `build_hash_from_items`). A lone type-object argument (`Array(Int)`) is a parametric type request rather than a value list, so it renders as a `Type(Type)` package, mirroring the scalar coercions.

## Verification

- New pin `t/container-type-coercion.t` (10 cases) — all match rakudo
- `make test` — PASS (14110 tests); `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)