### PR TITLE
fix(str): zprintf %g strips trailing zeros (0 renders as "0")

### DIFF
--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -410,8 +410,15 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                             prefix, formatted_mantissa, e_char, exp_sign, exp_digits
                         )
                     } else {
-                        // Fixed notation: same as %f with p decimal places
-                        format!("{}{:.*}", prefix, p, abs)
+                        // Fixed notation: p decimal places, then strip trailing
+                        // zeros (and a bare trailing decimal point) like standard
+                        // `%g` — so 0 renders as "0", not "0.000000". The `#`
+                        // (alternate) flag keeps the trailing zeros.
+                        let mut body = format!("{:.*}", p, abs);
+                        if !hash_flag && body.contains('.') {
+                            body.truncate(body.trim_end_matches('0').trim_end_matches('.').len());
+                        }
+                        format!("{prefix}{body}")
                     }
                 } else {
                     let is_neg = f.is_sign_negative() && (f != 0.0 || f.is_sign_negative());

--- a/t/zprintf-g-strip-zeros.t
+++ b/t/zprintf-g-strip-zeros.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 10;
+
+# zprintf's `%g`/`%G` fixed-notation output strips trailing zeros (and a bare
+# trailing decimal point), like standard C `%g`: a zero renders as "0", not
+# "0.000000". The `#` (alternate) flag keeps the zeros. Covers the
+# roast S32-str/sprintf.t "zprintf with Numeric/Str type objects" subtest.
+
+is zprintf('%g',   0),      '0',    '%g of 0 strips to "0"';
+is zprintf('%.2g', 0),      '0',    '%.2g of 0 strips to "0"';
+is zprintf('%G',   0),      '0',    '%G of 0 strips to "0"';
+is zprintf('%g',   3e0),    '3',    '%g of 3.0 strips to "3"';
+is zprintf('%.4g', 3.1e0),  '3.1',  '%.4g of 3.1 strips trailing zeros';
+is zprintf('%.2g', 3.1415), '3.14', '%.2g keeps significant fraction digits';
+
+# A type object (undefined) formats as 0 under `quietly`.
+is (quietly zprintf('%g',   Int)), '0', '%g of a type object is "0"';
+is (quietly zprintf('%.2g', Num)), '0', '%.2g of a type object is "0"';
+
+# The `#` flag keeps the trailing zeros.
+is zprintf('%#.2g', 0),     '0.00', '%#.2g keeps trailing zeros';
+is zprintf('%#g',   3e0),   '3.000000', '%#g keeps trailing zeros';


### PR DESCRIPTION
## Problem

zprintf's `%g`/`%G` fixed-notation path formats the precision as decimal places but never stripped the trailing zeros standard `%g` removes. So a zero — or a Numeric/Str **type object**, which formats as 0 — rendered as `"0.000000"` / `"0.00"` instead of `"0"`. This is the `%g`/`%.2g` half of the roast `S32-str/sprintf.t` "zprintf with Numeric/Str type objects" subtest.

## Fix

Strip trailing zeros and a bare trailing decimal point in the fixed-notation branch, honoring the `#` (alternate) flag which keeps them. Non-zero fractions are unaffected (`%.2g` of 3.1415 is still `"3.14"`), so the passing `%g` cases stay green.

## Result
- `sprintf.t`: the "type objects" subtest now passes (**5 → 4** failing subtests).
- Remaining failures are the `%020.2g` scientific-notation cases — the test expects `"34.1e+30"` for `3.1415e30`, a v6.e `zprintf` quirk whose expected mantissa doesn't derive from the input by any standard normalization, and which I can't verify against the local **v6.d** rakudo (zprintf is a v6.e feature). So the file stays unwhitelisted, but this is a genuine standard-`%g` correctness fix.
- `make test` green (14113).

## Tests
`t/zprintf-g-strip-zeros.t` — `%g`/`%G` of 0 and type objects strip to `"0"`, non-zero fractions kept, `#` flag keeps trailing zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)