### PR TITLE
feat(gist): cap aggregate .gist at the first 100 elements

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -5,6 +5,10 @@ use crate::value::{RuntimeError, Value};
 use super::raku_repr::raku_value;
 use super::{format_temporal_num, gist_array_wrap, range_gist_string};
 
+/// Rakudo caps an aggregate's `.gist` at the first 100 elements, then appends
+/// ` ...`, so a huge array/list does not flood terminal output.
+const GIST_ELEM_CAP: usize = 100;
+
 /// Leaf-value gist for a list/array element: a WhateverCode (`*+1`) gists as
 /// `WhateverCode.new`; everything else uses its string value.
 fn leaf_gist(v: &Value) -> String {
@@ -519,7 +523,20 @@ pub(super) fn dispatch(
                 let inner = rows.join("\n ");
                 return Some(Some(Ok(Value::str(format!("[{}]", inner)))));
             }
-            let inner = items.iter().map(gist_item).collect::<Vec<_>>().join(" ");
+            // `.gist` shows at most the first 100 elements, then ` ...`
+            // (Rakudo caps aggregate gists so a huge array does not flood output).
+            // Only the first 100 are rendered when truncating.
+            let inner = if items.len() > GIST_ELEM_CAP {
+                let mut s = items[..GIST_ELEM_CAP]
+                    .iter()
+                    .map(gist_item)
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                s.push_str(" ...");
+                s
+            } else {
+                items.iter().map(gist_item).collect::<Vec<_>>().join(" ")
+            };
             Some(Ok(Value::str(gist_array_wrap(&inner, *kind))))
         }
         Value::Seq(items) | Value::Slip(items) if method == "gist" => {
@@ -586,7 +603,19 @@ pub(super) fn dispatch(
                     other => leaf_gist(other),
                 }
             }
-            let inner = items.iter().map(gist_item).collect::<Vec<_>>().join(" ");
+            // Like the Array path: a Seq/List gist shows at most the first 100
+            // elements, then ` ...`.
+            let inner = if items.len() > GIST_ELEM_CAP {
+                let mut s = items[..GIST_ELEM_CAP]
+                    .iter()
+                    .map(gist_item)
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                s.push_str(" ...");
+                s
+            } else {
+                items.iter().map(gist_item).collect::<Vec<_>>().join(" ")
+            };
             Some(Ok(Value::str(format!("({})", inner))))
         }
         Value::Slip(items) if method == "raku" || method == "perl" => {

--- a/t/gist-element-cap.t
+++ b/t/gist-element-cap.t
@@ -1,0 +1,24 @@
+# `.gist` of an aggregate shows at most the first 100 elements, then ` ...`
+# (Rakudo caps aggregate gists so a huge array/list does not flood output).
+# `.raku`, `.elems`, and the actual contents are unaffected.
+use Test;
+
+plan 12;
+
+is [1, 2, 3].gist, '[1 2 3]', 'small array gist is full';
+is [1 .. 100].gist.words.tail, '100]', '100-element array gist is not truncated';
+is [1 .. 101].gist.words.tail, '...]', '101-element array gist truncates with ...';
+is [1 .. 102].gist, [1 .. 101].gist, '102 and 101 gist the same (both capped)';
+is [1 .. 1000].gist.words.tail, '...]', '1000-element array gist truncates';
+is [1 .. 101].gist.words.elems, 101, 'truncated gist has 100 elems + "..."';
+
+is (1 .. 101).List.gist.words.tail, '...)', 'List gist truncates with ...';
+is (1 .. 101).Seq.gist.words.tail, '...)', 'Seq gist truncates with ...';
+
+# A Range gists as range notation, unaffected by the element cap.
+is (1 .. 101).gist, '1..101', 'Range gist is range notation, not truncated';
+
+# The cap is display-only: length and contents are intact.
+is [1 .. 1000].elems, 1000, '.elems is not affected by the gist cap';
+is [1 .. 1000][500], 501, 'indexing past the cap still works';
+is [1 .. 3].gist, [1, 2, 3].gist, 'range- and list-built arrays gist alike';


### PR DESCRIPTION
## Summary

`.gist` of an Array/List/Seq now shows at most the first 100 elements, then ` ...`, matching Rakudo (which caps aggregate gists so a huge array does not flood terminal output):

```raku
[1..101].gist     # [1 2 3 ... 100 ...]
[1..1000].gist    # same — capped at 100 + "..."
(1..101).List.gist  # (1 2 ... 100 ...)
(1..101).Seq.gist   # (1 2 ... 100 ...)
```

Only the first 100 elements are rendered when truncating. The cap is display-only: `.elems`, indexing, and `.raku` are unaffected, and a `Range` still gists as range notation (`1..101`), not a capped element list. A lazy/infinite array already renders the bounded `[...]` placeholder (unchanged).

## Verification

- Fixes the `.gist shows only first 100 els` subtest of `roast/S02-types/array.t` (whose aborts were cleared by #4143 + #4144 — array.t now runs all 108)
- New pin `t/gist-element-cap.t` (12 cases: Array/List/Seq truncation, Range unaffected, `.elems`/indexing intact) — all match rakudo
- `make test` — PASS (14132 tests); `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)