### PR TITLE
fix(str): numify "lone i" imaginary units ("i", "3+i", "-i")

### DIFF
--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -735,8 +735,10 @@ fn try_parse_complex(s: &str) -> Option<Value> {
         // Parse imaginary part (strip leading sign)
         let (imag_sign, imag_body) = strip_sign(imag_str);
         let imag_val = if imag_body.is_empty() {
-            // bare +i or -i: not handled here (rakudo skips these too)
-            return None;
+            // Bare "+i"/"-i" as the imaginary part: the coefficient is 1, e.g.
+            // "3+i" => 3+1i, "10-i" => 10-1i. (Rakudo skips these — "cannot
+            // handle lone i yet"; mutsu handles them.)
+            1.0
         } else if imag_body == "Inf" || imag_body == "NaN" {
             // Inf/NaN as imaginary component requires `\i` suffix
             if !has_backslash_i {
@@ -753,9 +755,13 @@ fn try_parse_complex(s: &str) -> Option<Value> {
         let imag_val = if imag_sign < 0 { -imag_val } else { imag_val };
         Some(Value::Complex(real_val, imag_val))
     } else {
-        // Pure imaginary: "42i", "-3.5i", "4_2i", "Inf\i", etc.
+        // Pure imaginary: "42i", "-3.5i", "4_2i", "Inf\i", "i", "-i", etc.
         let (imag_sign, imag_body) = strip_sign(without_i);
-        let imag_val = if imag_body == "Inf" {
+        let imag_val = if imag_body.is_empty() {
+            // Lone "i"/"+i"/"-i": the coefficient is 1 (0+1i / 0-1i). (Rakudo
+            // skips these — "cannot handle lone i yet"; mutsu handles them.)
+            1.0
+        } else if imag_body == "Inf" {
             if has_backslash_i {
                 f64::INFINITY
             } else {

--- a/t/str-numeric-lone-i.t
+++ b/t/str-numeric-lone-i.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 12;
+
+# Numifying a string with a "lone i" — an imaginary unit written without an
+# explicit coefficient — yields a coefficient of 1 (or -1 with a leading sign),
+# both as a pure imaginary and as the imaginary part of a full complex number.
+# Rakudo skips these ("cannot handle lone i yet"); mutsu handles them
+# (roast S32-str/numeric.t "can handle − (U+2212) minus as regular minus").
+
+is-deeply +'i',    0+1i, 'lone i';
+is-deeply +'+i',   0+1i, 'lone +i';
+is-deeply +'-i',   0-1i, 'lone -i';
+is-deeply +'−i',   0-1i, 'lone -i with U+2212 minus';
+
+is-deeply +'3+i',  3+1i, 'number + i';
+is-deeply +'3-i',  3-1i, 'number - i';
+is-deeply +'−10−i', -10-1i, 'both parts with U+2212 minus';
+
+# Explicit coefficients still work unchanged.
+is-deeply +'10i',   0+10i, 'number with i (coefficient present)';
+is-deeply +'3+2i',  3+2i,  'both parts with coefficients';
+
+# Non-numeric strings ending in "i" still fail (not treated as complex).
+dies-ok { +'hi' },   'a non-numeric string ending in i still fails';
+dies-ok { +'abci' }, 'another non-numeric i-suffixed string fails';
+dies-ok { +'i-j' },  'a bogus complex-ish string fails';


### PR DESCRIPTION
## Problem

String→number coercion required an explicit coefficient before `i`: `+"10i"` gave `0+10i`, but a **lone imaginary unit** (`"i"`, `"+i"`, `"-i"`) and a complex with a coefficient-less imaginary part (`"3+i"`, `"10-i"`) failed with `X::Str::Numeric` — `try_parse_complex` bailed on an empty coefficient.

## Fix

Treat an empty imaginary coefficient as **1** (with the sign), in both:
- the pure-imaginary branch — `"i"`/`"+i"`/`"-i"` → `0±1i`
- the real+imaginary branch — `"3+i"` → `3+1i`, `"−10−i"` → `-10-1i` (U+2212 minus included)

Non-numeric strings ending in `i` (`"hi"`, `"abci"`) still fail — only an empty (or bare-sign) coefficient is accepted.

## Result

This is the "lone i" half of roast `S32-str/numeric.t`'s "can handle − (U+2212) minus" subtest, which Rakudo `#?rakudo skip`s (*"cannot handle lone i yet"*) — so mutsu is now **more correct than Rakudo** here. numeric.t raw failures 6 → 5 (the rest are `#?rakudo todo` `val()` cases); the file was already whitelisted, so no whitelist change — a genuine numeric-parsing correctness improvement.

`make test` green (14132); clippy clean.

Tests: `t/str-numeric-lone-i.t` — lone/signed i, U+2212 minus, both-parts, explicit coefficients unchanged, non-numeric i-suffixed strings still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)