### PR TITLE
fix(bind): binding to a WhateverCode subscript throws X::Bind::Slice

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -381,6 +381,34 @@ impl Compiler {
         value: &Expr,
         outer_positional: bool,
     ) {
+        // Binding (`:=`) to a WhateverCode subscript (`@a[*-1] := 42`) is illegal:
+        // the index is a computed slice, not a fixed container slot, so rakudo
+        // throws X::Bind::Slice ("Cannot bind to Array slice"). A slice bind
+        // (`@a[0,1] := ...`) and a plain variable-index bind (`@a[$i] := ...`)
+        // stay valid. Emit a runtime throw so `throws-like { ... }` catches it
+        // (a parse-time error would abort the whole enclosing file).
+        if matches!(
+            value,
+            Expr::Call { name, .. } if *name == "__mutsu_bind_index_value"
+        ) && matches!(
+            index,
+            Expr::Lambda {
+                is_whatever_code: true,
+                ..
+            }
+        ) {
+            self.compile_expr(&Expr::Call {
+                name: Symbol::intern("die"),
+                args: vec![Expr::MethodCall {
+                    target: Box::new(Expr::BareWord("X::Bind::Slice".to_string())),
+                    name: Symbol::intern("new"),
+                    args: vec![],
+                    modifier: None,
+                    quoted: false,
+                }],
+            });
+            return;
+        }
         if let Expr::BareWord(name) = target
             && name == "s"
             && let Some(pattern) = Self::topic_subst_pattern_from_index(index)

--- a/t/bind-to-whatever-index.t
+++ b/t/bind-to-whatever-index.t
@@ -1,0 +1,37 @@
+# Binding (`:=`) to a WhateverCode subscript (`@a[*-1] := 42`) is illegal — the
+# index is a computed slice, not a fixed container slot — so rakudo throws
+# X::Bind::Slice ("Cannot bind to Array slice"). A plain slice bind and a
+# variable-index bind stay valid.
+use Test;
+
+plan 7;
+
+throws-like { my @a; @a[*-1] := 42 }, X::Bind::Slice,
+    'binding [*-1] of an empty array throws X::Bind::Slice';
+throws-like { my @a = 1, 2, 3; @a[*-1] := 42 }, X::Bind::Slice,
+    'binding [*-1] of a non-empty array throws X::Bind::Slice';
+throws-like { my @a = 1, 2, 3; @a[*-2] := 42 }, X::Bind::Slice,
+    'binding [*-2] throws X::Bind::Slice';
+
+# Valid binds are unaffected.
+{
+    my @a = 1, 2, 3;
+    @a[0, 1] := 4, 5;
+    is ~@a, '4 5 3', 'a slice bind (@a[0,1] := ...) stays valid';
+}
+{
+    my @a = 1, 2, 3;
+    my $i = 1;
+    @a[$i] := 42;
+    is ~@a, '1 42 3', 'a variable-index bind (@a[$i] := ...) stays valid';
+}
+{
+    # A single concrete-index bind shares a container cell (element aliasing).
+    my @a = 1, 2, 3;
+    my $x = 9;
+    @a[0] := $x;
+    $x = 7;
+    is @a[0], 7, 'a single concrete-index bind aliases the container';
+    @a[0] = 5;
+    is $x, 5, '...and writes through both ways';
+}


### PR DESCRIPTION
## Summary

`@a[*-1] := 42` binds to a **computed** subscript (a WhateverCode), which is not a fixed container slot, so rakudo throws `X::Bind::Slice` ("Cannot bind to Array slice"):

```raku
my @a = 1, 2, 3;
@a[*-1] := 42;   # rakudo: X::Bind::Slice;  mutsu (before): bogus "Effective index out of range"
```

## Fix

Detect the case in `compile_expr_index_assign` — a `:=` bind (`__mutsu_bind_index_value` value) whose index is a `Lambda { is_whatever_code: true }` — and emit a runtime `die X::Bind::Slice.new`, so `throws-like { ... }` catches it (a parse-time error would abort the whole enclosing file, which is why this is a runtime throw). A WhateverCode index always throws, regardless of the array's length.

Valid binds are unaffected:
- slice bind `@a[0,1] := 4,5` → `[4 5 3]`
- variable-index bind `@a[$i] := 42`
- single concrete-index bind `@a[0] := $x` (element aliasing, shares a container cell both ways)

## Verification

- Fixes tests 69, 73 of `roast/S02-types/array.t` (the two X::Bind::Slice subtests). With the merged #4143/#4144/#4146, array.t now runs all 108 with only the deep test 105 + niche 101/108 remaining.
- New pin `t/bind-to-whatever-index.t` (7 cases: throws for `*-1`/`*-2` on empty/non-empty, slice/variable/concrete binds stay valid) — all match rakudo
- `make test` — PASS (14161 tests); `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)