### PR TITLE
fix(str): reject non-literal fraction strings in numification

### DIFF
--- a/src/runtime/str_numeric.rs
+++ b/src/runtime/str_numeric.rs
@@ -58,7 +58,8 @@ pub(crate) fn parse_raku_str_to_numeric(input: &str) -> Option<Value> {
         return Some(apply_sign(v, sign));
     }
 
-    // Try fraction `N/D` (with optional decimal parts and signed denominators)
+    // Try fraction `N/D` (a plain-integer numerator over an unsigned
+    // plain-integer denominator; the leading sign is already in `sign`).
     if let Some(v) = try_parse_fraction(body, sign) {
         return Some(v);
     }
@@ -490,6 +491,19 @@ fn try_parse_fraction(body: &str, sign: i32) -> Option<Value> {
     let slash_pos = body.find('/')?;
     let num_str = &body[..slash_pos];
     let den_str = &body[slash_pos + 1..];
+
+    // A numeric fraction string is only `[sign]INT/INT`: a plain-integer
+    // numerator over an *unsigned* plain-integer denominator. A decimal part in
+    // either, or a signed denominator, is not a numeric literal and must fail
+    // numification (roast S32-str/numeric.t: `+"3/-2"`, `+"+3/-2"`, `+"3.0/2"`,
+    // `+"3/2.0"` all fail; `"3/2"`, `"-3/2"` are the accepted forms). The leading
+    // sign of the whole fraction was already stripped into `sign`.
+    if num_str.contains('.') || den_str.contains('.') {
+        return None;
+    }
+    if den_str.starts_with('-') || den_str.starts_with('+') {
+        return None;
+    }
 
     // Parse numerator (can be integer or decimal with underscores)
     let (num_n, num_d) = parse_fraction_part(num_str, false)?;

--- a/t/str-numeric-fraction-strict.t
+++ b/t/str-numeric-fraction-strict.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 13;
+
+# A numeric fraction string is only `[sign]INT/INT`: a plain-integer numerator
+# over an *unsigned* plain-integer denominator. A decimal part in either, or a
+# signed denominator, is not a numeric literal and must fail numification
+# (roast S32-str/numeric.t; Rakudo `#?rakudo todo`s these, "Unsure of what
+# val() should accept").
+
+# Accepted forms:
+is-deeply +'3/2',   3/2,   '"3/2" numifies to 3/2';
+is-deeply +'+3/2',  3/2,   '"+3/2" numifies to 3/2';
+is-deeply +'-3/2', -3/2,   '"-3/2" numifies to -3/2';
+is-deeply +'10/4',  10/4,  '"10/4" numifies to 5/2';
+is +'3_0/2', 15,           'underscores in the numerator still parse (30/2 = 15)';
+
+# Rejected forms (should throw X::Str::Numeric):
+dies-ok { +'-3/-2' }, '"-3/-2" (signed denominator) fails';
+dies-ok { +'3/-2'  }, '"3/-2" (signed denominator) fails';
+dies-ok { +'+3/-2' }, '"+3/-2" (signed denominator) fails';
+dies-ok { +'3.0/2' }, '"3.0/2" (decimal numerator) fails';
+dies-ok { +'3/2.0' }, '"3/2.0" (decimal denominator) fails';
+dies-ok { +'3/+2'  }, '"3/+2" (explicitly-signed denominator) fails';
+dies-ok { +'3.5/2' }, '"3.5/2" (decimal numerator) fails';
+dies-ok { +'1/2/3' }, '"1/2/3" fails';


### PR DESCRIPTION
## Problem

`+"3/2"` correctly numifies to `3/2`, but the fraction parser also accepted forms that are **not numeric literals**:
- signed denominator: `"3/-2"`, `"3/+2"`, `"-3/-2"`
- decimal part in either operand: `"3.0/2"`, `"3/2.0"`, `"3.5/2"`

Rakudo fails all of these — roast `S32-str/numeric.t` marks them `#?rakudo todo` (*"Unsure of what val() should accept"*) and asserts they throw.

## Fix

Tighten `try_parse_fraction`: a fraction string is only `[sign]INT/INT` — a plain-integer numerator over an **unsigned** plain-integer denominator (the leading sign of the whole value is already stripped into `sign`). Reject a `.` in either operand or a sign on the denominator. Underscores and the accepted `"3/2"`/`"-3/2"` forms are unchanged.

## Result

With the earlier lone-i fix (#4147), roast `S32-str/numeric.t` now has **0 raw failures** (it was already whitelisted via the fudged `todo`s, so no whitelist change — a genuine numeric-parsing correctness improvement matching the roast spec).

`make test` green (14179); clippy clean.

Tests: `t/str-numeric-fraction-strict.t` — accepted `[sign]INT/INT` (incl. underscores) and the rejected signed-denominator / decimal-operand forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)