### PR TITLE
fix(clone): Array.clone preserves per-slot metadata (deleted holes, is default)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -121,8 +121,14 @@ pub(super) fn dispatch(
         "clone" => {
             match target {
                 Value::Package(_) | Value::Nil => Some(Some(Ok(target.clone()))),
+                // Clone the whole `ArrayData`, not just its elements, so
+                // per-slot metadata (`initialized` deletion holes, `default`,
+                // `shape`, element type) survives the copy — e.g.
+                // `@a[3]:delete; my @b := @a.clone` keeps `@b[3]:exists` False
+                // (S02-types/array.t test 108). Elements are `Value`-cloned
+                // (shared handles), matching a shallow `.clone`.
                 Value::Array(items, kind) => Some(Some(Ok(Value::Array(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(items.to_vec())),
+                    crate::gc::Gc::new((**items).clone()),
                     *kind,
                 )))),
                 Value::Hash(map) => Some(Some(Ok(Value::Hash(Value::hash_arc((**map).clone()))))),

--- a/src/vm/vm_var_index_tracking.rs
+++ b/src/vm/vm_var_index_tracking.rs
@@ -203,9 +203,16 @@ impl Interpreter {
         if to_remove.is_empty() {
             return;
         }
-        if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name)
-            && let Some(set) = crate::gc::Gc::make_mut(items).initialized.as_mut()
-        {
+        if let Some(Value::Array(items, _)) = self.env_root_descended_mut(var_name) {
+            let data = crate::gc::Gc::make_mut(items);
+            // A freshly-built array tracks "all present" as `initialized = None`.
+            // Materialize the set (0..len) before removing the deleted indices so
+            // the hole is recorded IN the ArrayData — not only in the name-keyed
+            // `__mutsu_deleted_index::` side table, which a `.clone` (bound to a
+            // new name) would not inherit. This makes `@b := @a.clone` preserve a
+            // deleted slot's `:exists` == False (S02-types/array.t test 108).
+            let len = data.len();
+            let set = data.initialized.get_or_insert_with(|| (0..len).collect());
             for i in to_remove {
                 set.remove(&i);
             }

--- a/t/clone-preserves-deleted-slot.t
+++ b/t/clone-preserves-deleted-slot.t
@@ -1,0 +1,42 @@
+# `.clone` copies the whole ArrayData, including per-slot metadata: a deleted
+# slot's hole (`:exists` == False) survives the clone, and so do `is default`
+# and shaped metadata. (roast/S02-types/array.t test 108, rakudo #1434.)
+use Test;
+
+plan 8;
+
+# The deleted-slot :exists state is preserved through .clone.
+{
+    my @a = ^10;
+    @a[3]:delete;
+    is-deeply (@a[3]:exists), False, 'deleted slot :exists is False in the original';
+    my @b := @a.clone;
+    is-deeply (@b[3]:exists), False, 'deleted slot :exists is False in the clone too';
+    is-deeply (@b[4]:exists), True, 'a live slot still exists in the clone';
+    is @b[3].defined, False, 'the cloned deleted slot reads as an undefined hole';
+}
+
+# The clone is an independent copy: mutating one does not affect the other.
+{
+    my @a = 1, 2, 3;
+    my @b = @a.clone;
+    @b[0] = 99;
+    is @a[0], 1, 'clone is an independent copy (mutating clone leaves original)';
+    @a[1] = 77;
+    is @b[1], 2, 'clone is an independent copy (mutating original leaves clone)';
+}
+
+# `is default` survives .clone.
+{
+    my @a is default(42) = 1, 2, 3;
+    my @b = @a.clone;
+    is @b[10], 42, 'is default survives .clone';
+}
+
+# A fresh delete on the clone does not leak back to the original.
+{
+    my @a = ^5;
+    my @b = @a.clone;
+    @b[2]:delete;
+    is-deeply (@a[2]:exists), True, 'deleting in the clone does not affect the original';
+}


### PR DESCRIPTION
## Summary

`Array.clone` rebuilt a fresh `ArrayData` from just the elements (`ArrayData::new(items.to_vec())`), dropping the container's per-slot metadata — most visibly the `initialized` set that records `:delete`d holes:

```raku
my @a = ^10;
@a[3]:delete;
my @b := @a.clone;
@b[3]:exists;   # rakudo: False;  mutsu (before): True  (rakudo #1434)
```

## Fix (two parts)

1. **`unmark_initialized_indices`** now materializes the array's `initialized` set (`0..len`, then drop the deleted indices) when it was the implicit "all present" `None`, so a deletion is recorded **in** the `ArrayData` rather than only in the name-keyed `__mutsu_deleted_index::` side table — which a clone bound to a *new* name can never inherit.
2. **`Array.clone`** now clones the whole `ArrayData` (`(**items).clone()`), so `initialized`, `default`, `shape`, and element type all survive. Elements are still `Value`-cloned (shared handles), matching a shallow `.clone`.

## Verification

- Fixes test 108 of `roast/S02-types/array.t`
- New pin `t/clone-preserves-deleted-slot.t` (8 cases: deleted-hole `:exists` through clone, clone independence both ways, `is default` survival, no delete leak-back) — all match rakudo behavior
- `make test` — PASS (14166 tests); `cargo clippy`/`fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)