### PR TITLE
feat(str): .encode($encoding, $form) applies a Unicode normalization form

### DIFF
--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -79,15 +79,36 @@ impl Interpreter {
         Ok(Value::Nil)
     }
 
+    /// Apply a Unicode normalization form before encoding. Accepts the short
+    /// names (`C`/`D`/`KC`/`KD`) and the full `NF*` names; an unrecognized value
+    /// is left as-is (encode as written), so a non-form second positional never
+    /// changes the bytes.
+    fn normalize_for_encode(s: &str, form: &str) -> String {
+        use unicode_normalization::UnicodeNormalization;
+        match form {
+            "C" | "NFC" => s.nfc().collect(),
+            "D" | "NFD" => s.nfd().collect(),
+            "KC" | "NFKC" => s.nfkc().collect(),
+            "KD" | "NFKD" => s.nfkd().collect(),
+            _ => s.to_string(),
+        }
+    }
+
     pub(super) fn dispatch_encode(
         &mut self,
         target: &Value,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
-        // Extract the first positional (non-Pair) argument as the encoding name
-        let encoding = args
+        // Positional args: [0] = encoding name, [1] = Unicode normalization form
+        // (`C`/`D`/`KC`/`KD` i.e. NFC/NFD/NFKC/NFKD). Rakudo `#?rakudo skip`s the
+        // normalization-form parameter ("We do not handle NDF yet"); mutsu
+        // applies it (roast S32-str/encode.t "encoding to UTF-8, with NFD").
+        let positionals: Vec<&Value> = args
             .iter()
-            .find(|v| !matches!(v, Value::Pair(..)))
+            .filter(|v| !matches!(v, Value::Pair(..)))
+            .collect();
+        let encoding = positionals
+            .first()
             .map(|v| v.to_string_value())
             .unwrap_or_else(|| "utf-8".to_string());
         let replacement = Self::named_value(args, "replacement").map(|v| {
@@ -101,7 +122,11 @@ impl Interpreter {
             .find_encoding(&encoding)
             .map(|e| e.name.as_str().to_lowercase())
             .unwrap_or_else(|| encoding.to_lowercase());
-        let input = target.to_string_value();
+        let raw_input = target.to_string_value();
+        let input = match positionals.get(1).map(|v| v.to_string_value()) {
+            Some(nf) => Self::normalize_for_encode(&raw_input, &nf),
+            None => raw_input,
+        };
         let translated = self.translate_newlines_for_encode(&input);
         let mut attrs = HashMap::new();
         let type_name = match normalized_encoding.as_str() {

--- a/t/str-encode-normalization-form.t
+++ b/t/str-encode-normalization-form.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 8;
+
+# `.encode($encoding, $form)` applies a Unicode normalization form before
+# encoding: C/NFC, D/NFD, KC/NFKC, KD/NFKD. Rakudo skips this in
+# roast S32-str/encode.t ("We do not handle NDF yet"); mutsu implements it.
+# (encode.t's own assertion compares with `Buf` via `eqv`, but `.encode`
+# returns `utf8`, and `utf8 eqv Buf` is False even in Rakudo — so this checks
+# the produced bytes directly.)
+
+# 'ä' (U+00E4) decomposes under NFD to 'a' + U+0308 (combining diaeresis).
+is-deeply 'ä'.encode('utf8', 'D').list, (0x61, 0xcc, 0x88),
+    'encode with NFD decomposes the precomposed character';
+is-deeply 'ä'.encode('utf8', 'NFD').list, (0x61, 0xcc, 0x88),
+    'the full "NFD" name works too';
+
+# NFC keeps / recomposes the precomposed form.
+is-deeply 'ä'.encode('utf8', 'C').list, (0xc3, 0xa4),
+    'encode with NFC keeps the precomposed character';
+is-deeply "a\x[308]".encode('utf8', 'C').list, (0xc3, 0xa4),
+    'NFC composes a base + combining mark';
+
+# Default (no form) encodes as written.
+is-deeply 'ä'.encode('utf8').list, (0xc3, 0xa4),
+    'encode without a form leaves the string as-is';
+
+# NFKD applies a compatibility decomposition (① -> "1").
+is-deeply "\x[2460]".encode('utf8', 'KD').list, (0x31,),
+    'encode with NFKD applies compatibility decomposition';
+
+# An unrecognized second positional is ignored (bytes unchanged).
+is-deeply 'abc'.encode('utf8', 'bogus').list, (0x61, 0x62, 0x63),
+    'an unrecognized normalization form leaves the bytes unchanged';
+
+# ASCII round-trips regardless of form.
+is-deeply 'abc'.encode('utf8', 'D').list, (0x61, 0x62, 0x63),
+    'ASCII is unchanged under NFD';


### PR DESCRIPTION
## Summary

`.encode` ignored its **second positional argument**, the Unicode normalization form. Apply it before encoding: `C`/`NFC`, `D`/`NFD`, `KC`/`NFKC`, `KD`/`NFKD` (via the `unicode-normalization` crate mutsu already uses for `.nfc` case-folding).

So `'ä'.encode('utf8', 'D')` now yields the NFD bytes `61 cc 88` (`a` + combining diaeresis) instead of the precomposed `c3 a4`.

## Safety

Additive: normalization only runs when a second positional is present **and** names a recognized form. An unrecognized value (or no second arg) leaves the string exactly as before, so all existing `.encode` calls are unchanged. `make test` green (14173).

## Roast note

Rakudo `#?rakudo skip`s this in `S32-str/encode.t` (*"We do not handle NDF yet"*), so mutsu is now more capable than Rakudo here. That roast subtest can't be whitelisted regardless: it asserts `.encode(...) eqv Buf.new(...)`, but `.encode` returns `utf8` and `utf8 eqv Buf` is `False` even in Rakudo — a bug in the test's comparison, not the encoding. So this is a genuine encoding-capability feature verified via a dedicated t/ test.

## Tests
`t/str-encode-normalization-form.t` — NFD/NFC/NFKD byte output, full `NF*` names, default/unrecognized-form pass-through, ASCII invariance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)