### PR TITLE
fix(autoviv): nested array-element autoviv fills gaps with Any, not Nil

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2095,7 +2095,7 @@ impl Interpreter {
                             // SAFETY: aliased in-place mutation of a shared array
                             // (strong_count > 1); see `arc_contents_mut`.
                             let v = &mut unsafe { crate::value::gc_contents_mut(inner_arr) }.items;
-                            Self::autoviv_resize(v, j + 1, Value::Nil)?;
+                            Self::autoviv_resize(v, j + 1, native_fill.clone())?;
                             Value::assign_element_slot(&mut v[j], val.clone());
                         } else {
                             let inner = crate::gc::Gc::make_mut(inner_arr);
@@ -2183,15 +2183,19 @@ impl Interpreter {
             }
             Value::Array(arr, _) => {
                 if let Ok(i) = outer_key.parse::<usize>() {
+                    // Autovivified gaps fill with the `Any` type object (matching
+                    // a direct `@a[i] = v`), not `Nil`. A nested hash/array element
+                    // container is untyped here, so `Any` is the correct hole.
+                    let fill = Value::Package(crate::symbol::Symbol::intern("Any"));
                     if crate::gc::Gc::strong_count(arr) > 1 {
                         // SAFETY: aliased in-place mutation of a shared array
                         // (strong_count > 1); see `arc_contents_mut`.
                         let v = &mut unsafe { crate::value::gc_contents_mut(arr) }.items;
-                        Self::autoviv_resize(v, i + 1, Value::Nil)?;
+                        Self::autoviv_resize(v, i + 1, fill)?;
                         Value::assign_element_slot(&mut v[i], val);
                     } else {
                         let a = crate::gc::Gc::make_mut(arr);
-                        Self::autoviv_resize(a, i + 1, Value::Nil)?;
+                        Self::autoviv_resize(a, i + 1, fill)?;
                         Value::assign_element_slot(&mut a[i], val);
                     }
                 }
@@ -2705,7 +2709,11 @@ impl Interpreter {
                     // change is visible to all holders of the same Arc; see
                     // `arc_contents_mut`.
                     let v = &mut unsafe { crate::value::gc_contents_mut(arc) }.items;
-                    Self::autoviv_resize(v, i + 1, Value::Nil)?;
+                    Self::autoviv_resize(
+                        v,
+                        i + 1,
+                        Value::Package(crate::symbol::Symbol::intern("Any")),
+                    )?;
                     match &bind_cell {
                         // Bind mode installs the shared cell at the element;
                         // the same cell is written back to the source var

--- a/t/nested-autoviv-any-fill.t
+++ b/t/nested-autoviv-any-fill.t
@@ -1,0 +1,36 @@
+# Autovivifying a gap in a *nested* array element (`%h<k>[2] = v`, `@a[0][3] = v`)
+# fills the skipped slots with the `Any` type object, exactly like a direct
+# `@a[i] = v` — not `Nil`.
+use Test;
+
+plan 7;
+
+{
+    my %h;
+    %h<k>[2] = 9;
+    is-deeply %h<k>, $[Any, Any, 9], 'hash-element array autoviv fills gaps with Any';
+}
+{
+    my %h;
+    %h<a><b>[1] = 5;
+    is-deeply %h<a><b>, $[Any, 5], 'deeper hash-element array autoviv fills with Any';
+}
+{
+    my @a;
+    @a[0][3] = 7;
+    is-deeply @a[0], $[Any, Any, Any, 7], 'array-in-array autoviv fills with Any';
+}
+{
+    # Matches the direct (non-nested) behavior.
+    my @d;
+    @d[2] = 42;
+    is-deeply @d, [Any, Any, 42], 'direct array autoviv fills with Any (baseline)';
+}
+{
+    # The filled holes are undefined type objects, not defined Nil.
+    my %h;
+    %h<k>[2] = 1;
+    is %h<k>[0].defined, False, 'autoviv hole is undefined';
+    is %h<k>[0].^name, 'Any', 'autoviv hole is the Any type object';
+    is %h<k>[2], 1, 'the assigned element is intact';
+}


### PR DESCRIPTION
## Summary

Autovivifying a gap in a **nested** array element filled the skipped slots with `Value::Nil`, while a direct `@a[i] = v` correctly fills with the `Any` type object:

```raku
my %h; %h<k>[2] = 9;   # rakudo: [Any, Any, 9];  mutsu (before): [Nil, Nil, 9]
my @a; @a[0][3] = 7;   # rakudo: @a[0] is [Any, Any, Any, 7]
```

## Fix

Four `autoviv_resize(..., Value::Nil)` sites in the nested / shared-array (`strong_count > 1` interior mutation) / `assign_into_nested_container` paths now use the container's fill value — `native_fill` where in scope, otherwise the `Any` type object — matching the direct-assignment path (`native_fill_for_constraint` in `vm_var_assign_ops.rs`).

## Verification

- New pin `t/nested-autoviv-any-fill.t` (7 cases: hash-element / deeper hash / array-in-array autoviv, direct baseline, hole is the undefined `Any` type object) — all match rakudo
- `make test` — PASS (14173 tests); `cargo clippy`/`fmt` — clean

Note: a related nested gap remains — a WhateverCode index through nested autoviv (`%h<k>[*-0] = 42`) still loses the value (the WhateverCode is not resolved against the freshly-vivified array before the nested write); that is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)