### PR TITLE
fix(assign): resolve a WhateverCode array index in a nested assignment

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2016,6 +2016,25 @@ impl Interpreter {
         }
 
         let inner_key = inner_idx.to_string_value();
+        // A WhateverCode array index (`%h<k>[*-0] = v` / `@a[0][*-1] = v`) must be
+        // resolved against the inner container's current length before it becomes
+        // a key — a freshly-vivified inner array is length 0, so `*-0` is 0.
+        // (`to_string_value` on the unresolved WhateverCode yields a non-numeric
+        // key, so the assignment was silently dropped.) `outer_idx` is the trailing
+        // `[...]` subscript; `inner_key` is the container it indexes into.
+        let outer_idx = if matches!(outer_idx, Value::Sub(_)) {
+            let inner_container: Option<Value> = match self.env().get(&var_name) {
+                Some(Value::Hash(map)) => map.get(&inner_key).cloned(),
+                Some(Value::Array(arr, ..)) => inner_key
+                    .parse::<usize>()
+                    .ok()
+                    .and_then(|i| arr.items.get(i).cloned()),
+                _ => None,
+            };
+            self.resolve_whatever_index_for_target(outer_idx, inner_container.as_ref())
+        } else {
+            outer_idx
+        };
         let outer_key = outer_idx.to_string_value();
 
         // If the outer hash has a value type constraint, nested autovivification

--- a/t/nested-whatever-index-assign.t
+++ b/t/nested-whatever-index-assign.t
@@ -1,0 +1,45 @@
+# A WhateverCode array index in a nested assignment (`%h<k>[*-0] = v`,
+# `@a[0][*-1] = v`) is resolved against the inner container's current length
+# before it becomes a key — a freshly-autovivified inner array is length 0, so
+# `*-0` is index 0. Previously the unresolved WhateverCode stringified to a
+# non-numeric key and the assignment was silently dropped.
+use Test;
+
+plan 6;
+
+{
+    my %h;
+    %h<k>[*-0] = 42;
+    is-deeply %h<k>, [42], 'hash-element [*-0] autovivifies element 0';
+}
+{
+    my @a;
+    @a[0][*-0] = 5;
+    is-deeply @a[0], [5], 'array-in-array [*-0] autovivifies element 0';
+}
+{
+    # *-0 on a non-empty inner array appends at the end.
+    my %h;
+    %h<k> = [1, 2, 3];
+    %h<k>[*-0] = 9;
+    is-deeply %h<k>, [1, 2, 3, 9], '[*-0] on a 3-element inner array appends';
+}
+{
+    # *-1 on a non-empty inner array overwrites the last element.
+    my %h;
+    %h<k> = [1, 2, 3];
+    %h<k>[*-1] = 99;
+    is-deeply %h<k>, [1, 2, 99], '[*-1] overwrites the last element';
+}
+{
+    # *-1 on a freshly-vivified (empty) inner array is out of range: no-op.
+    my %h;
+    %h<k>[*-1] = 5;
+    is-deeply %h<k>, [], '[*-1] on an empty inner array is out of range (no store)';
+}
+{
+    # A plain concrete index still works alongside.
+    my %h;
+    %h<k>[2] = 8;
+    is-deeply %h<k>, [Any, Any, 8], 'concrete nested index still autovivifies';
+}


### PR DESCRIPTION
## Summary

`%h<k>[*-0] = 42` (and `@a[0][*-1] = v`) silently dropped the value:

```raku
my %h; %h<k>[*-0] = 42;
say %h<k>;   # rakudo: [42];  mutsu (before): []
```

The trailing `[*-0]` WhateverCode index reached the 2-level nested-assign handler (`exec_index_assign_expr_nested_op`) **unresolved**, so `to_string_value` produced a non-numeric key and nothing was stored.

## Fix

Resolve the WhateverCode against the inner container's current length before it becomes a key (via the existing `resolve_whatever_index_for_target`) — a freshly-vivified inner array is length 0, so `*-0` is index 0; `*-1` on it is out of range (no-op). The concrete-index path and the direct-array WhateverCode path (`@a[*-0] = v`) were already correct.

## Verification

- Fixes test 101 of `roast/S02-types/array.t`. Combined with the merged #4143/#4144/#4146/#4148/#4150/#4152, **array.t now runs all 108 with only the deep test 105 failing** (lazy gather reification + dynamic package ref) — it was aborting at test 62 before this series.
- New pin `t/nested-whatever-index-assign.t` (6 cases: hash-element / array-in-array `[*-0]` autoviv, `[*-0]`/`[*-1]` on populated inner arrays, empty-array `[*-1]` no-op, concrete index) — all match rakudo
- `make test` — PASS (14189 tests); `cargo clippy`/`fmt` — clean

Note: the 3+-level deep-nested handler (`%h<a><b>[*-0]`) is a separate path, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)