### PR TITLE
fix(str): uniprop *_Quick_Check uses authoritative NFC_QC data (Maybe)

### DIFF
--- a/src/builtins/uniprop/lookup.rs
+++ b/src/builtins/uniprop/lookup.rs
@@ -1,53 +1,39 @@
 use crate::value::Value;
 use std::sync::OnceLock;
 
-/// NFC_Quick_Check property.
-fn unicode_nfc_quick_check(ch: char) -> String {
-    use unicode_normalization::UnicodeNormalization;
-    let s = ch.to_string();
-    let nfc: String = s.nfc().collect();
-    if nfc == s {
-        // Could be Yes or Maybe
-        // Check if it's a combining character that might compose with a preceding char
-        if unicode_normalization::char::is_combining_mark(ch) {
-            // Check canonical combining class — characters with CCC > 0
-            // that can compose are "Maybe"
-            let nfd: String = s.nfd().collect();
-            if nfd == s {
-                "Maybe".to_string()
-            } else {
-                "No".to_string()
-            }
-        } else {
-            "Yes".to_string()
-        }
-    } else {
-        "No".to_string()
+/// Render a `*_Quick_Check` result as Raku's full property-value name. Unlike
+/// MoarVM (which returns the short `Y`/`N`/`M` codes — a `#?rakudo.moar todo` in
+/// roast S15-unicode-information/uniprop.t), mutsu returns the full names.
+fn quick_check_name(result: unicode_normalization::IsNormalized) -> String {
+    use unicode_normalization::IsNormalized;
+    match result {
+        IsNormalized::Yes => "Yes",
+        IsNormalized::No => "No",
+        IsNormalized::Maybe => "Maybe",
     }
+    .to_string()
+}
+
+/// NFC_Quick_Check property. Uses the crate's authoritative `NFC_QC` data, so a
+/// character that can compose with a following one (e.g. a Hangul trailing
+/// consonant) is correctly `Maybe`, not `Yes`.
+fn unicode_nfc_quick_check(ch: char) -> String {
+    quick_check_name(unicode_normalization::is_nfc_quick(std::iter::once(ch)))
 }
 
 /// NFD_Quick_Check property.
 fn unicode_nfd_quick_check(ch: char) -> String {
-    use unicode_normalization::UnicodeNormalization;
-    let s = ch.to_string();
-    let nfd: String = s.nfd().collect();
-    if nfd == s { "Yes" } else { "No" }.to_string()
+    quick_check_name(unicode_normalization::is_nfd_quick(std::iter::once(ch)))
 }
 
 /// NFKC_Quick_Check property.
 fn unicode_nfkc_quick_check(ch: char) -> String {
-    use unicode_normalization::UnicodeNormalization;
-    let s = ch.to_string();
-    let nfkc: String = s.nfkc().collect();
-    if nfkc == s { "Yes" } else { "No" }.to_string()
+    quick_check_name(unicode_normalization::is_nfkc_quick(std::iter::once(ch)))
 }
 
 /// NFKD_Quick_Check property.
 fn unicode_nfkd_quick_check(ch: char) -> String {
-    use unicode_normalization::UnicodeNormalization;
-    let s = ch.to_string();
-    let nfkd: String = s.nfkd().collect();
-    if nfkd == s { "Yes" } else { "No" }.to_string()
+    quick_check_name(unicode_normalization::is_nfkd_quick(std::iter::once(ch)))
 }
 
 /// Canonical_Combining_Class property.

--- a/t/uniprop-quick-check.t
+++ b/t/uniprop-quick-check.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 9;
+
+# `.uniprop('NFC_Quick_Check')` (and the NFD/NFKC/NFKD variants) return the full
+# property-value names Yes/No/Maybe using the authoritative NFC_QC data — so a
+# character that can compose with a following one is `Maybe`, not `Yes`. MoarVM
+# returns the short Y/N/M codes and does not compute Maybe (a `#?rakudo.moar
+# todo` in roast S15-unicode-information/uniprop.t); mutsu is more correct.
+
+# NFC_Quick_Check: Yes / No / Maybe.
+is '都'.uniprop('NFC_Quick_Check'),     'Yes',   'a normal ideograph is NFC_QC=Yes';
+is 0x0374.uniprop('NFC_Quick_Check'),   'No',    'U+0374 is NFC_QC=No';
+is "\x[11A8]".uniprop('NFC_Quick_Check'), 'Maybe', 'a Hangul trailing consonant is NFC_QC=Maybe';
+
+# The short alias resolves the same.
+is '都'.uniprop('NFC_QC'), 'Yes', 'the NFC_QC short alias works';
+
+# NFD_Quick_Check is Yes/No only.
+is 'A'.uniprop('NFD_Quick_Check'),      'Yes', 'ASCII "A" is NFD_QC=Yes';
+is "\x[00C0]".uniprop('NFD_Quick_Check'), 'No', 'À (precomposed) is NFD_QC=No';
+
+# NFKC / NFKD quick-check.
+is '①'.uniprop('NFKC_Quick_Check'),     'No',  '① is NFKC_QC=No (has a compatibility decomposition)';
+is '①'.uniprop('NFKD_Quick_Check'),     'No',  '① is NFKD_QC=No';
+is 'a'.uniprop('NFKC_Quick_Check'),     'Yes', 'plain ASCII is NFKC_QC=Yes';


### PR DESCRIPTION
## Problem

`.uniprop('NFC_Quick_Check')` was a hand-rolled heuristic (is the char its own NFC form? is it a combining mark?) that never returned **`Maybe`** for a character that can compose with a *following* one — e.g. a Hangul trailing consonant (U+11A8) came back `Yes` instead of `Maybe`.

## Fix

Use the `unicode-normalization` crate's authoritative `is_nfc_quick` / `is_nfd_quick` / `is_nfkc_quick` / `is_nfkd_quick` (backed by the real `*_Quick_Check` property tables), rendering the `IsNormalized` result as Raku's full value names `Yes`/`No`/`Maybe`.

MoarVM returns the short `Y`/`N`/`M` codes and does not compute `Maybe` (roast `S15-unicode-information/uniprop.t` marks it `#?rakudo.moar todo`), so mutsu is now both **correct and more complete than Rakudo**.

## Result

uniprop.t raw failures **4 → 3** (NFC_Quick_Check "Maybe" now passes; the remaining three — `Unicode_1_Name` and the two Indic categories — need Unicode data tables and are MoarVM-NYI too). No whitelist change (already whitelisted via the todos); `make test` green (14197).

## Tests
`t/uniprop-quick-check.t` — Yes/No/Maybe for NFC, the `NFC_QC` alias, and the NFD/NFKC/NFKD variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)