### PR TITLE
fix(str): Bidi_Class of European/Arabic digits (EN/AN, not L)

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -120,6 +120,23 @@ pub(crate) fn unicode_bidi_class(ch: char) -> String {
         0x2067 => "RLI",
         0x2068 => "FSI",
         0x2069 => "PDI",
+        // Bidi_Class of a numeric character depends on the specific digit set,
+        // not just its General_Category: European-style digits are EN and
+        // Arabic-Indic digits are AN (both would be `L` under the plain
+        // General_Category heuristic below).
+        0x0030..=0x0039              // ASCII digits
+        | 0x00B2..=0x00B3            // superscript 2, 3
+        | 0x00B9                     // superscript 1
+        | 0x06F0..=0x06F9            // extended Arabic-Indic digits
+        | 0x2070                     // superscript 0
+        | 0x2074..=0x2079            // superscript 4-9
+        | 0x2080..=0x2089            // subscript 0-9
+        | 0xFF10..=0xFF19 => "EN",   // fullwidth digits
+        0x0600..=0x0605             // Arabic number signs
+        | 0x0660..=0x0669            // Arabic-Indic digits
+        | 0x066B..=0x066C            // Arabic decimal/thousands separator
+        | 0x06DD                     // Arabic end of ayah
+        | 0x08E2 => "AN",            // Arabic disputed end of ayah
         _ => {
             // Use General Category heuristics
             let gc = crate::builtins::unicode::unicode_general_category(ch);

--- a/t/uniprop-bidi-class-digits.t
+++ b/t/uniprop-bidi-class-digits.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 12;
+
+# Bidi_Class of a numeric character depends on its specific digit set, not just
+# its General_Category: European-style digits (ASCII, fullwidth, superscript,
+# subscript, extended Arabic-Indic) are EN; Arabic-Indic digits are AN. A plain
+# General_Category heuristic wrongly reports all of them as L.
+
+is '0'.uniprop('Bidi_Class'), 'EN', 'ASCII digit 0 is EN';
+is '9'.uniprop('Bidi_Class'), 'EN', 'ASCII digit 9 is EN';
+is 0xFF10.uniprop('Bidi_Class'), 'EN', 'fullwidth digit is EN';
+is 0x00B2.uniprop('Bidi_Class'), 'EN', 'superscript two is EN';
+is 0x2070.uniprop('Bidi_Class'), 'EN', 'superscript zero is EN';
+is 0x2080.uniprop('Bidi_Class'), 'EN', 'subscript zero is EN';
+is 0x06F0.uniprop('Bidi_Class'), 'EN', 'extended Arabic-Indic digit is EN';
+
+is 0x0660.uniprop('Bidi_Class'), 'AN', 'Arabic-Indic digit zero is AN';
+is 0x0669.uniprop('Bidi_Class'), 'AN', 'Arabic-Indic digit nine is AN';
+
+# Digits of other scripts remain L, and letters/controls are unaffected.
+is '৫'.uniprop('Bidi_Class'), 'L', 'a Bengali digit stays L';
+is 'A'.uniprop('Bidi_Class'), 'L', 'a Latin letter is L';
+is 0x202A.uniprop('Bidi_Class'), 'LRE', 'the LEFT-TO-RIGHT EMBEDDING control is LRE';


### PR DESCRIPTION
## Problem

`.uniprop('Bidi_Class')` derived the value from `General_Category`, so every digit (`Nd`/`No`) came back `L`. But Bidi_Class distinguishes the digit sets: European-style digits (ASCII, fullwidth, superscript, subscript, extended Arabic-Indic) are `EN`, and Arabic-Indic digits are `AN`. So `'5'` reported `L` instead of `EN` and `'٩'` reported `L` instead of `AN`.

## Fix

Add the well-defined EN/AN digit ranges ahead of the `General_Category` fallback. Digits of other scripts (e.g. Bengali) correctly stay `L`, and the existing special-cased directional-formatting controls (`LRE`/`RLE`/... — covered by roast `S15-unicode-information/uniprop.t`) are unchanged.

## Result

No whitelist change (uniprop.t tests a control char for Bidi_Class, which still passes); `make test` green (14210). Verified against Rakudo — a genuine Unicode-property correctness fix.

## Tests
`t/uniprop-bidi-class-digits.t` — EN for ASCII/fullwidth/superscript/subscript/ext-Arabic digits, AN for Arabic-Indic, L for other-script digits and the LRE control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)