### PR TITLE
fix(str): uniprop Line_Break is ID for ideographic-script letters

### DIFF
--- a/src/builtins/uniprop/text_seg.rs
+++ b/src/builtins/uniprop/text_seg.rs
@@ -183,6 +183,16 @@ pub(crate) fn unicode_line_break(ch: char) -> String {
                     match script.as_str() {
                         "Thai" | "Lao" | "Myanmar" | "Khmer" | "Javanese" | "Tai_Tham"
                         | "New_Tai_Lue" | "Tai_Le" => "SA".to_string(),
+                        // Ideographic scripts have Line_Break=ID (not AL), e.g. a
+                        // CJK ideograph or a Hiragana/Katakana letter.
+                        "Han"
+                        | "Hiragana"
+                        | "Katakana"
+                        | "Bopomofo"
+                        | "Yi"
+                        | "Tangut"
+                        | "Nushu"
+                        | "Khitan_Small_Script" => "ID".to_string(),
                         _ => "AL".to_string(),
                     }
                 }

--- a/t/uniprop-line-break-ideographic.t
+++ b/t/uniprop-line-break-ideographic.t
@@ -1,0 +1,30 @@
+use Test;
+
+# Line_Break property for ideographic-script letters must be ID (Ideographic),
+# not the generic AL (Alphabetic) fallback used for other letters.
+
+plan 12;
+
+# Han (CJK ideographs)
+is '漢'.uniprop('Line_Break'), 'ID', "Han ideograph is Line_Break=ID";
+is '字'.uniprop('Line_Break'), 'ID', "another Han ideograph is ID";
+
+# Hiragana / Katakana
+is 'あ'.uniprop('Line_Break'), 'ID', "Hiragana is ID";
+is 'ア'.uniprop('Line_Break'), 'ID', "Katakana is ID";
+
+# Bopomofo, Yi
+is 'ㄅ'.uniprop('Line_Break'), 'ID', "Bopomofo is ID";
+is 'ꀀ'.uniprop('Line_Break'), 'ID', "Yi syllable is ID";
+
+# Codepoint form works too
+is 0x6F22.uniprop('Line_Break'), 'ID', "0x6F22 (漢) via codepoint is ID";
+is 0x3042.uniprop('Line_Break'), 'ID', "0x3042 (あ) via codepoint is ID";
+
+# Non-ideographic letters remain AL
+is 'A'.uniprop('Line_Break'), 'AL', "Latin letter stays AL";
+is 'α'.uniprop('Line_Break'), 'AL', "Greek letter stays AL";
+
+# Existing behaviour still holds
+is "\n".uniprop('Line_Break'), 'LF', 'newline is LF';
+is 0x200D.uniprop('Line_Break'), 'ZWJ', 'ZWJ is ZWJ';


### PR DESCRIPTION
## Summary

`'漢'.uniprop('Line_Break')` (and Hiragana/Katakana/Bopomofo/Yi/…) returned `AL` instead of `ID`.

`unicode_line_break()` handled the Southeast-Asian `SA` scripts specially but let every other letter fall through to the generic `AL` (Alphabetic) fallback. Ideographic-script letters have Unicode `Line_Break=ID` (Ideographic).

Added an `ID` branch for `Han`, `Hiragana`, `Katakana`, `Bopomofo`, `Yi`, `Tangut`, `Nushu`, `Khitan_Small_Script` in the `Lu|Ll|Lt|Lm|Lo` arm, mirroring the existing `SA` handling.

### Before / After
```
'漢'.uniprop('Line_Break')  # AL  ->  ID   (raku: ID)
'あ'.uniprop('Line_Break')  # AL  ->  ID
```

## Test
- New `t/uniprop-line-break-ideographic.t` (12 assertions) pins ID for ideographic letters and confirms Latin/Greek stay `AL`.
- `make test` passes; `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)