### PR TITLE
fix(str): uniprop Word_Break follows UAX #29 classification

### DIFF
--- a/src/builtins/uniprop/text_seg.rs
+++ b/src/builtins/uniprop/text_seg.rs
@@ -104,38 +104,76 @@ pub(crate) fn unicode_sentence_break(ch: char) -> String {
     }
 }
 
-/// Word_Break property.
+/// Is `cp` in the UAX #29 Word_Break=Katakana set (includes Common-script
+/// katakana-related marks alongside the Katakana script proper).
+fn is_wb_katakana(cp: u32) -> bool {
+    matches!(cp,
+        0x3031..=0x3035 | 0x309B | 0x309C | 0x30A0..=0x30FA | 0x30FC..=0x30FF
+        | 0x31F0..=0x31FF | 0x32D0..=0x32FE | 0x3300..=0x3357
+        | 0xFF66..=0xFF9D | 0x1B000 | 0x1B164..=0x1B167)
+}
+
+/// Word_Break property (UAX #29 WordBreakProperty).
 pub(crate) fn unicode_word_break(ch: char) -> String {
     let cp = ch as u32;
+    // Line separators, joiners, and explicit punctuation classes.
     match cp {
-        0x000D => "CR".to_string(),
-        0x000A | 0x000B | 0x000C | 0x0085 | 0x2028 | 0x2029 => "LF".to_string(),
-        0x200D => "ZWJ".to_string(),
-        _ => {
-            let gc = crate::builtins::unicode::unicode_general_category(ch);
+        0x000D => return "CR".to_string(),
+        0x000A => return "LF".to_string(),
+        0x000B | 0x000C | 0x0085 | 0x2028 | 0x2029 => return "Newline".to_string(),
+        0x200D => return "ZWJ".to_string(),
+        0x0022 => return "Double_Quote".to_string(),
+        0x0027 => return "Single_Quote".to_string(),
+        // MidNumLet
+        0x002E | 0x2018 | 0x2019 | 0x2024 | 0xFE52 | 0xFF07 | 0xFF0E => {
+            return "MidNumLet".to_string();
+        }
+        // MidLetter
+        0x003A | 0x00B7 | 0x0387 | 0x05F4 | 0x2027 | 0xFE13 | 0xFE55 | 0xFF1A => {
+            return "MidLetter".to_string();
+        }
+        // MidNum
+        0x002C | 0x003B | 0x037E | 0x0589 | 0x060C | 0x060D | 0x066C | 0x07F8 | 0x2044 | 0xFE10
+        | 0xFE14 | 0xFE50 | 0xFE54 | 0xFF0C | 0xFF1B => {
+            return "MidNum".to_string();
+        }
+        _ => {}
+    }
+    if is_wb_katakana(cp) {
+        return "Katakana".to_string();
+    }
+    let gc = crate::builtins::unicode::unicode_general_category(ch);
+    // Connector_Punctuation is exactly the ExtendNumLet base set.
+    if gc == "Pc" {
+        return "ExtendNumLet".to_string();
+    }
+    // Extend: grapheme-extending marks and ZWNJ.
+    if super::binary_props::check_binary_property(ch, r"^\p{Grapheme_Extend}$") {
+        return "Extend".to_string();
+    }
+    // Format controls (joiners and ZWSP already handled above).
+    if gc == "Cf" && cp != 0x200B {
+        return "Format".to_string();
+    }
+    match gc.as_str() {
+        "Nd" => "Numeric".to_string(),
+        "Lu" | "Ll" | "Lt" | "Lm" | "Lo" => {
             let script = crate::builtins::unicode::unicode_script_name(ch);
             if script == "Hebrew" && (gc == "Lo" || gc == "Lm") {
                 return "Hebrew_Letter".to_string();
             }
-            match gc.as_str() {
-                "Lu" | "Ll" | "Lt" | "Lm" | "Lo" => "ALetter".to_string(),
-                "Nd" => "Numeric".to_string(),
-                "Mn" | "Me" | "Mc" => {
-                    if super::binary_props::check_binary_property(ch, r"^\p{Grapheme_Extend}$") {
-                        "Extend".to_string()
-                    } else {
-                        "Other".to_string()
-                    }
-                }
-                _ => {
-                    if super::binary_props::check_binary_property(ch, r"^\p{Extender}$") {
-                        "ExtendNumLet".to_string()
-                    } else {
-                        "Other".to_string()
-                    }
-                }
+            // ALetter excludes ideographs, Hiragana, and Complex_Context
+            // (Line_Break=SA: Thai/Lao/Myanmar/Khmer/...) letters.
+            if super::binary_props::check_binary_property(ch, r"^\p{Ideographic}$")
+                || script == "Hiragana"
+                || unicode_line_break(ch) == "SA"
+            {
+                "Other".to_string()
+            } else {
+                "ALetter".to_string()
             }
         }
+        _ => "Other".to_string(),
     }
 }
 

--- a/t/uniprop-word-break-uax29.t
+++ b/t/uniprop-word-break-uax29.t
@@ -1,0 +1,55 @@
+use Test;
+
+# Word_Break property (UAX #29). mutsu previously classified every letter as
+# ALetter and every non-letter as Other; verify the refined classification
+# matches Rakudo / the Unicode spec.
+
+plan 30;
+
+# ALetter: alphabetic, non-ideographic, non-Hiragana, non-Complex_Context
+is 'A'.uniprop('Word_Break'), 'ALetter', 'Latin letter is ALetter';
+is 'é'.uniprop('Word_Break'), 'ALetter', 'accented Latin is ALetter';
+is 'ㄅ'.uniprop('Word_Break'), 'ALetter', 'Bopomofo is ALetter';
+is 'ꀀ'.uniprop('Word_Break'), 'ALetter', 'Yi is ALetter';
+is '한'.uniprop('Word_Break'), 'ALetter', 'Hangul syllable is ALetter';
+is "\x3005".uniprop('Word_Break'), 'ALetter', 'ideographic iteration mark (non-Ideographic) is ALetter';
+
+# Ideographs / Hiragana / Complex_Context -> Other (not ALetter)
+is '漢'.uniprop('Word_Break'), 'Other', 'Han ideograph is Other';
+is 'あ'.uniprop('Word_Break'), 'Other', 'Hiragana is Other';
+is 'ก'.uniprop('Word_Break'), 'Other', 'Thai letter (Complex_Context) is Other';
+
+# Katakana
+is 'ア'.uniprop('Word_Break'), 'Katakana', 'Katakana letter is Katakana';
+is "\x30FC".uniprop('Word_Break'), 'Katakana', 'prolonged sound mark is Katakana';
+is "\xFF70".uniprop('Word_Break'), 'Katakana', 'halfwidth prolonged mark is Katakana';
+
+# Numeric
+is '9'.uniprop('Word_Break'), 'Numeric', 'digit is Numeric';
+
+# Hebrew_Letter preserved
+is "\xFB1F".uniprop('Word_Break'), 'Hebrew_Letter', 'Hebrew letter is Hebrew_Letter';
+
+# ExtendNumLet (Connector_Punctuation)
+is '_'.uniprop('Word_Break'), 'ExtendNumLet', 'low line is ExtendNumLet';
+is "\x203F".uniprop('Word_Break'), 'ExtendNumLet', 'undertie is ExtendNumLet';
+
+# Punctuation classes
+is "'".uniprop('Word_Break'), 'Single_Quote', 'apostrophe is Single_Quote';
+is '"'.uniprop('Word_Break'), 'Double_Quote', 'quotation mark is Double_Quote';
+is '.'.uniprop('Word_Break'), 'MidNumLet', 'full stop is MidNumLet';
+is "\x2018".uniprop('Word_Break'), 'MidNumLet', 'left single quote is MidNumLet';
+is ':'.uniprop('Word_Break'), 'MidLetter', 'colon is MidLetter';
+is "\x00B7".uniprop('Word_Break'), 'MidLetter', 'middle dot is MidLetter';
+is ','.uniprop('Word_Break'), 'MidNum', 'comma is MidNum';
+is ';'.uniprop('Word_Break'), 'MidNum', 'semicolon is MidNum';
+
+# Line separators
+is "\n".uniprop('Word_Break'), 'LF', 'LF is LF';
+is "\r".uniprop('Word_Break'), 'CR', 'CR is CR';
+is "\x2028".uniprop('Word_Break'), 'Newline', 'LINE SEPARATOR is Newline';
+
+# Extend / ZWJ / Format
+is "\x0301".uniprop('Word_Break'), 'Extend', 'combining mark is Extend';
+is "\x200D".uniprop('Word_Break'), 'ZWJ', 'ZWJ is ZWJ';
+is "\xAD".uniprop('Word_Break'), 'Format', 'soft hyphen is Format';


### PR DESCRIPTION
## Summary

`uniprop('Word_Break')` classified **every** letter as `ALetter` and nearly every non-letter as `Other`, diverging from Rakudo / UAX #29 for a large set of characters.

### Fixed classifications (all verified against `raku`)
| char | before | after (raku) |
|------|--------|--------------|
| `漢` (Han) | ALetter | **Other** |
| `あ` (Hiragana) | ALetter | **Other** |
| `ก` (Thai, Complex_Context) | ALetter | **Other** |
| `々` (non-Ideographic Lm) | ALetter | **ALetter** ✓ |
| `ア` / `ー` / `ｰ` | ALetter | **Katakana** |
| `_` (Connector_Punctuation) | Other | **ExtendNumLet** |
| `'` `"` `.` `:` `,` | Other | **Single_Quote / Double_Quote / MidNumLet / MidLetter / MidNum** |
| U+000B/000C/0085/2028/2029 | LF | **Newline** |
| soft hyphen, U+0600, ZWNJ | Other | **Format / Extend** |

`ALetter` now keys off the **Ideographic** property (so `々` stays `ALetter` while `漢` becomes `Other`), plus explicit exclusions for Hiragana script and `Line_Break=SA` (Thai/Lao/Myanmar/Khmer/...). The Katakana Word_Break set uses the authoritative UAX #29 codepoint ranges. Existing `Hebrew_Letter` handling is preserved.

## Test
- New `t/uniprop-word-break-uax29.t` (30 assertions).
- Verified against `raku` across 53 sample codepoints — **all agree**.
- `make test` passes (14273 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)