### PR TITLE
fix(str): uniprop Grapheme_Cluster_Break follows UAX #29

### DIFF
--- a/src/builtins/uniprop/text_seg.rs
+++ b/src/builtins/uniprop/text_seg.rs
@@ -41,7 +41,12 @@ pub(crate) fn unicode_grapheme_cluster_break(ch: char) -> String {
         0x1160..=0x11A7 | 0xD7B0..=0xD7C6 => return "V".to_string(),
         0x11A8..=0x11FF | 0xD7CB..=0xD7FB => return "T".to_string(),
         0xAC00..=0xD7A3 => {
-            return if (cp - 0xAC00).is_multiple_of(28) { "LV" } else { "LVT" }.to_string();
+            return if (cp - 0xAC00).is_multiple_of(28) {
+                "LV"
+            } else {
+                "LVT"
+            }
+            .to_string();
         }
         _ => {}
     }

--- a/src/builtins/uniprop/text_seg.rs
+++ b/src/builtins/uniprop/text_seg.rs
@@ -1,23 +1,60 @@
-/// Grapheme_Cluster_Break property.
+/// UAX #29 Grapheme_Cluster_Break=Prepend set.
+fn is_gcb_prepend(cp: u32) -> bool {
+    matches!(cp,
+        0x0600..=0x0605 | 0x06DD | 0x070F | 0x08E2 | 0x0D4E | 0x110BD | 0x110CD
+        | 0x111C2 | 0x111C3 | 0x1193F | 0x11941 | 0x11A3A | 0x11A84..=0x11A89 | 0x11D46)
+}
+
+/// Spacing marks (gc=Mc) that are NOT Grapheme_Cluster_Break=SpacingMark: they
+/// are either Extend (handled earlier) or Other. Listing them keeps a plain
+/// gc=Mc test from over-classifying them as SpacingMark.
+fn is_gcb_spacingmark_exception(cp: u32) -> bool {
+    matches!(cp,
+        0x09BE | 0x09D7 | 0x0B3E | 0x0B57 | 0x0BBE | 0x0BD7 | 0x0CC2 | 0x0CD5 | 0x0CD6
+        | 0x0D3E | 0x0D57 | 0x0DCF | 0x0DDF | 0x102B | 0x102C | 0x1038 | 0x1062..=0x1064
+        | 0x1067..=0x106D | 0x1083 | 0x1087..=0x108C | 0x108F | 0x109A..=0x109C | 0x1A61
+        | 0x1A63 | 0x1A64 | 0x1B35 | 0x302E | 0x302F | 0xAA7B | 0xAA7D | 0x1133E | 0x11357
+        | 0x114B0 | 0x114BD | 0x115AF | 0x11930 | 0x1D165 | 0x1D16E..=0x1D172)
+}
+
+/// Grapheme_Cluster_Break property (UAX #29 GraphemeBreakProperty).
 pub(crate) fn unicode_grapheme_cluster_break(ch: char) -> String {
     let cp = ch as u32;
     match cp {
-        0x000D => "CR",
-        0x000A => "LF",
-        0x200D => "ZWJ",
-        _ => {
-            // Use regex for Extend
-            if super::binary_props::check_binary_property(ch, r"^\p{Grapheme_Extend}$") {
-                return "Extend".to_string();
-            }
-            let gc = crate::builtins::unicode::unicode_general_category(ch);
-            if gc == "Cc" || gc == "Cf" {
-                return "Control".to_string();
-            }
-            return "Other".to_string();
-        }
+        0x000D => return "CR".to_string(),
+        0x000A => return "LF".to_string(),
+        0x200D => return "ZWJ".to_string(),
+        // Regional indicator symbols.
+        0x1F1E6..=0x1F1FF => return "Regional_Indicator".to_string(),
+        _ => {}
     }
-    .to_string()
+    // Prepend must precede Extend/Control (some Prepend are gc=Cf).
+    if is_gcb_prepend(cp) {
+        return "Prepend".to_string();
+    }
+    if super::binary_props::check_binary_property(ch, r"^\p{Grapheme_Extend}$") {
+        return "Extend".to_string();
+    }
+    // Hangul jamo / syllables.
+    match cp {
+        0x1100..=0x115F | 0xA960..=0xA97C => return "L".to_string(),
+        0x1160..=0x11A7 | 0xD7B0..=0xD7C6 => return "V".to_string(),
+        0x11A8..=0x11FF | 0xD7CB..=0xD7FB => return "T".to_string(),
+        0xAC00..=0xD7A3 => {
+            return if (cp - 0xAC00).is_multiple_of(28) { "LV" } else { "LVT" }.to_string();
+        }
+        _ => {}
+    }
+    // SpacingMark: spacing combining marks plus U+0E33 / U+0EB3.
+    let gc = crate::builtins::unicode::unicode_general_category(ch);
+    if (gc == "Mc" && !is_gcb_spacingmark_exception(cp)) || cp == 0x0E33 || cp == 0x0EB3 {
+        return "SpacingMark".to_string();
+    }
+    // Control: line/paragraph separators, control and format characters.
+    if gc == "Cc" || gc == "Cf" || gc == "Zl" || gc == "Zp" {
+        return "Control".to_string();
+    }
+    "Other".to_string()
 }
 
 /// Joining_Type property.

--- a/t/uniprop-grapheme-cluster-break-uax29.t
+++ b/t/uniprop-grapheme-cluster-break-uax29.t
@@ -1,0 +1,49 @@
+use Test;
+
+# Grapheme_Cluster_Break property (UAX #29). mutsu previously only
+# distinguished CR/LF/ZWJ/Extend/Control/Other; verify the full set of
+# classes against Rakudo / the Unicode spec.
+
+plan 26;
+
+# Basic
+is 'a'.uniprop('Grapheme_Cluster_Break'), 'Other', 'letter is Other';
+is "\n".uniprop('Grapheme_Cluster_Break'), 'LF', 'LF is LF';
+is "\r".uniprop('Grapheme_Cluster_Break'), 'CR', 'CR is CR';
+is "\x200D".uniprop('Grapheme_Cluster_Break'), 'ZWJ', 'ZWJ is ZWJ';
+is "\x0301".uniprop('Grapheme_Cluster_Break'), 'Extend', 'combining mark is Extend';
+is "\x0009".uniprop('Grapheme_Cluster_Break'), 'Control', 'TAB is Control';
+
+# Regional indicators
+is "\x1F1E6".uniprop('Grapheme_Cluster_Break'), 'Regional_Indicator', 'RI A is Regional_Indicator';
+is "\x1F1FF".uniprop('Grapheme_Cluster_Break'), 'Regional_Indicator', 'RI Z is Regional_Indicator';
+
+# Hangul jamo
+is "\x1100".uniprop('Grapheme_Cluster_Break'), 'L', 'leading jamo is L';
+is "\x115F".uniprop('Grapheme_Cluster_Break'), 'L', 'jamo filler is L';
+is "\xA960".uniprop('Grapheme_Cluster_Break'), 'L', 'extended-A jamo is L';
+is "\x1160".uniprop('Grapheme_Cluster_Break'), 'V', 'vowel jamo is V';
+is "\xD7B0".uniprop('Grapheme_Cluster_Break'), 'V', 'extended-B vowel jamo is V';
+is "\x11A8".uniprop('Grapheme_Cluster_Break'), 'T', 'trailing jamo is T';
+is "\xD7CB".uniprop('Grapheme_Cluster_Break'), 'T', 'extended-B trailing jamo is T';
+
+# Hangul syllables
+is "\xAC00".uniprop('Grapheme_Cluster_Break'), 'LV', '가 (LV syllable) is LV';
+is "\xAC01".uniprop('Grapheme_Cluster_Break'), 'LVT', '각 (LVT syllable) is LVT';
+is "\xD7A3".uniprop('Grapheme_Cluster_Break'), 'LVT', 'last hangul syllable is LVT';
+
+# Prepend
+is "\x0600".uniprop('Grapheme_Cluster_Break'), 'Prepend', 'ARABIC NUMBER SIGN is Prepend';
+is "\x0D4E".uniprop('Grapheme_Cluster_Break'), 'Prepend', 'MALAYALAM LETTER DOT REPH is Prepend';
+
+# SpacingMark
+is "\x0903".uniprop('Grapheme_Cluster_Break'), 'SpacingMark', 'DEVANAGARI SIGN VISARGA is SpacingMark';
+is "\x0E33".uniprop('Grapheme_Cluster_Break'), 'SpacingMark', 'THAI SARA AM is SpacingMark';
+is "\x0EB3".uniprop('Grapheme_Cluster_Break'), 'SpacingMark', 'LAO SARA AM is SpacingMark';
+
+# SpacingMark exceptions (spacing marks that are NOT SpacingMark)
+is "\x102B".uniprop('Grapheme_Cluster_Break'), 'Other', 'MYANMAR VOWEL SIGN TALL AA is Other';
+is "\x1A61".uniprop('Grapheme_Cluster_Break'), 'Other', 'TAI THAM VOWEL SIGN A is Other';
+
+# Format
+is "\xAD".uniprop('Grapheme_Cluster_Break'), 'Control', 'soft hyphen (Cf) is Control';


### PR DESCRIPTION
## Summary

`uniprop('Grapheme_Cluster_Break')` only distinguished `CR`/`LF`/`ZWJ`/`Extend`/`Control`/`Other`, so entire UAX #29 classes were misreported as `Other` (or `Control`).

### Now classified correctly (all verified against `raku`)
| input | before | after |
|-------|--------|-------|
| `U+1100` leading jamo | Other | **L** |
| `U+1160` vowel jamo | Other | **V** |
| `U+11A8` trailing jamo | Other | **T** |
| `가` `U+AC00` | Other | **LV** |
| `각` `U+AC01` | Other | **LVT** |
| `U+1F1E6` regional indicator | Other | **Regional_Indicator** |
| `U+0600` ARABIC NUMBER SIGN | Control | **Prepend** |
| `U+0903` DEVANAGARI VISARGA | Other | **SpacingMark** |
| `U+0E33` THAI SARA AM | Other | **SpacingMark** |

- `LV`/`LVT` split by the 28-jamo modulus over `U+AC00..U+D7A3` (11,172 syllables previously all `Other`).
- `Prepend` is checked before Extend/Control since several members are `gc=Cf`.
- `SpacingMark` = `gc=Mc` (plus `U+0E33`/`U+0EB3`) minus the exception set of spacing marks that are actually Extend/Other (e.g. `U+102B`, `U+1A61`).
- `Control` extended to line/paragraph separators (`Zl`/`Zp`).

Only the `.uniprop('Grapheme_Cluster_Break')` query path uses this function — grapheme **segmentation** is unaffected (separate code path).

## Test
- New `t/uniprop-grapheme-cluster-break-uax29.t` (26 assertions).
- Verified against `raku` over a ~29,000-codepoint sweep; the remaining diffs are underlying UCD data-version differences (mutsu's `gc`/`Grapheme_Extend` tables vs raku's Unicode version), not classification logic.
- `make test` passes (14299 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)