### PR TITLE
fix(array/hash): whole-container assignment preserves container identity (splice.t)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -168,9 +168,30 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 - ~~`S02-types/whatever.t`（122/130、8 失敗: test 111, 119-124, 126）~~ — **DONE（#4067、131/131）**。
   — WhateverCode の over-currying（CallOn-arg branch で握りすぎる）。他ケースを壊さない
   narrow fix が必要。
-- `S32-array/splice.t`（357/392、35 失敗）
-  — self-splice / push-replace-self が true first-class element container を要求する
-  container identity の canary。
+- ~~`S32-array/splice.t`（357/392、35 失敗）~~ — **DONE・whitelist 済み（2026-07-05）**。
+  全 35 失敗は 1 原因＝whole-container 代入（`@a = ...`）がコンテナを**再束縛**していたこと。
+  raku は `@a = ...` を**既存コンテナの in-place 更新**として扱うため、`(5,0,@a)` の
+  ように list へ by-value で捕捉された `@a` 参照が後の再代入を観測できる。mutsu は
+  `Value::Array` の backing `Gc` を置換していたので、捕捉側は旧 `Gc` を見続け self-splice
+  で余分な要素が入った。修正（`vm_var_assign_set_local.rs` / `vm_exec_dispatch.rs` の
+  SetLocal・SetGlobal 両経路）:
+  1. plain な whole-container 代入（`=`、`my`/`:=` 以外）は既存 `Gc` の中身を
+     `gc_contents_mut` で in-place 更新し、pointer identity を保つ
+     （`array_inplace_reassign` / `hash_inplace_reassign`、自己参照は `new_gc`→`old_gc`
+     へ張り替え）。
+  2. raku の `=` コピー意味論を保つため、`my @b = @a` 等の**新規宣言/非in-place経路**で
+     backing `Gc` が共有（strong_count>1）なら fresh `Gc` の shallow-copy へ detach
+     （`detach_shared_container`）。これで `@b !=:= @a` になり、in-place 化しても
+     コピー独立性が壊れない（従来は COW で偶然独立に見えていた既存の非互換も是正）。
+  3. 匿名コンテナ（`my %`/`my @` は単一スロット名 `%__ANON_HASH__` を再利用）は
+     in-place 対象から除外（各宣言は別 logical 変数）。pointy-block（`given @c -> @p`）
+     退出時に `@p` のスロット値もクリア（alias 残留コンテナの in-place 破壊を防止）。
+  回帰テスト＝`t/container-identity-whole-assign.t`。
+  **残る深いサブケース（本項の対象外・別スライス）**: `@a` が compilation-unit 内で
+  closure に capture されると shared-cell（`ContainerRef`）表現に切り替わり、その状態で
+  list へ by-value 捕捉した参照は cell 更新を追えない（＝ sub の外で捕捉参照を読む
+  `ident4` 系）。これは return-writeback / cell スナップショット問題で、[[project_declaration_model_hoisted_cell_clobber]]
+  と同族。splice.t は sub 内で捕捉参照を読むため影響を受けず PASS。
 - `S26-documentation/12-non-breaking-space.t`（1/2、test 2 が失敗）
   — 2026-07-02 に root-cause 確定＝**BEGIN が compile-time でなく source 順 runtime 実行**される問題。
   test は末尾 `BEGIN { @nbchars = [...]; @bchars = [...] }` で配列を設定し、冒頭 line 8
@@ -399,13 +420,12 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowl
 「次に何をやるか」を 1 本だけ選ぶなら、順番はこう見るのが妥当。
 
 1. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
-   splice.t / attributes.t / multislice hash 側の slot identity を前に進める。
+   attributes.t / multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-   **注（2026-07-04 調査）**: `splice.t` の 35 失敗は全て self-splice（`@a.splice(*,0,@a)`）
-   の 1 原因＝リストリテラル `(10,0,@a)` が @a を live コンテナ参照で保持するが、
-   `@a = ^10`（whole-array 代入）が既存コンテナを in-place 更新せず**再束縛**するため、
-   リストの参照が旧空コンテナを指す。whole-array 代入の container-identity（要素 cell の
-   一段上＝コンテナ cell）が本丸で、blast radius 大。
+   **進捗（2026-07-05）**: whole-container 代入の container-identity（`@a = ...` の
+   in-place 化＋`=` コピーの fresh-`Gc` detach）は完了し `splice.t` は whitelist 済み
+   （§3.1 参照）。残るは closure-captured shared-cell を list へ by-value 捕捉したときの
+   スナップショット追従（return-writeback 系）と、attribute slot の cell 化。
 2. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
 
 `S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1045,6 +1045,7 @@ roast/S32-array/pop.t
 roast/S32-array/push.t
 roast/S32-array/rotate.t
 roast/S32-array/shift.t
+roast/S32-array/splice.t
 roast/S32-array/unshift.t
 roast/S32-basics/pairup.t
 roast/S32-basics/warn.t

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -981,7 +981,7 @@ impl Interpreter {
                 {
                     return Err(RuntimeError::assignment_ro(None));
                 }
-                if let Some(source_name) = bind_source {
+                if let Some(source_name) = bind_source.as_ref() {
                     let mut resolved_source = source_name.clone();
                     let mut seen = std::collections::HashSet::new();
                     while seen.insert(resolved_source.clone()) {
@@ -996,7 +996,7 @@ impl Interpreter {
                     // Propagate readonly status from the source variable.
                     // Binding to a readonly parameter should make the target
                     // readonly as well (persisted in env for cross-scope survival).
-                    let source_readonly = self.is_readonly(&source_name);
+                    let source_readonly = self.is_readonly(source_name);
                     self.env_mut()
                         .insert(readonly_key.clone(), Value::Bool(source_readonly));
                     if source_readonly {
@@ -1123,6 +1123,50 @@ impl Interpreter {
                 {
                     let atomic_name = name.strip_prefix('$').unwrap_or(&name).to_string();
                     loan_env!(self, reset_atomic_var_key(&atomic_name));
+                }
+                // Container identity (§3, splice.t): a plain whole-container
+                // *reassignment* of a free/outer `@`/`%` variable reached through
+                // SetGlobal (e.g. `@a = ...` inside a nested sub where `@a` is a
+                // top-level lexical) must mutate the EXISTING backing container in
+                // place, so any by-value holder of the same `Gc` (an `@a` captured
+                // into a list `(0, @a)` / a `\param`) observes the update — Raku's
+                // stable container identity. Gate on the env already holding a
+                // matching container (so a fresh declaration, whose env slot is
+                // absent/Nil, keeps fresh identity) and on a plain assignment.
+                if !is_bind_ctx
+                    && !is_rebind
+                    && !raw_mode
+                    && bind_source.is_none()
+                    && !name.contains("__ANON")
+                    && (name.starts_with('@') || name.starts_with('%'))
+                {
+                    match (self.env().get(&name), &val) {
+                        (Some(Value::Array(old_gc, _)), Value::Array(new_gc, kind))
+                            if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+                        {
+                            let (old_gc, new_gc, kind) = (old_gc.clone(), new_gc.clone(), *kind);
+                            val = Self::array_inplace_reassign(&old_gc, &new_gc, kind);
+                        }
+                        (Some(Value::Hash(old_gc)), Value::Hash(new_gc))
+                            if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+                        {
+                            let (old_gc, new_gc) = (old_gc.clone(), new_gc.clone());
+                            val = Self::hash_inplace_reassign(&old_gc, &new_gc);
+                        }
+                        // No reusable same-typed container already stored under this
+                        // name (a first assignment): the `@`/`%` var must own a
+                        // DISTINCT container per Raku `=` copy semantics, so detach
+                        // from any shared backing `Gc`.
+                        (existing, Value::Array(..) | Value::Hash(..))
+                            if !matches!(
+                                existing,
+                                Some(Value::Array(..)) | Some(Value::Hash(..))
+                            ) =>
+                        {
+                            val = Self::detach_shared_container(val);
+                        }
+                        _ => {}
+                    }
                 }
                 if raw_mode && name.starts_with('@') {
                     // For `constant @x`, bypass set_shared_var's List→Array

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -98,6 +98,19 @@ impl Interpreter {
                 this.env_mut()
                     .remove(&format!("__mutsu_bound_decont::{}", p));
                 this.unmark_readonly(p);
+                // A pointy param (`-> @p`) is block-scoped: its aliased container
+                // value must NOT linger in `@p`'s env/local slot past the block.
+                // If it does, a later block reusing the name — especially an
+                // `is copy` copy-assign (`given @c -> @p is copy {...}`) — would
+                // find the previous block's source container still sitting in the
+                // slot and, under whole-container in-place reassignment (§3),
+                // clobber that unrelated source. Clearing the value (the alias
+                // markers alone are not enough) keeps the next reuse clean. Done
+                // after the writeback above, which already read `@p`'s final value.
+                if p.starts_with('@') || p.starts_with('%') {
+                    this.env_mut().remove(p.as_str());
+                    this.update_local_if_exists(code, p, &Value::Nil);
+                }
             }
             this.topic_source_var = saved_topic_source.clone();
             this.topic_container_source = saved_container_source.clone();

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -531,4 +531,73 @@ impl Interpreter {
             *new_arc = result_arc;
         }
     }
+
+    /// Container identity (§3, splice.t): copy `new_gc`'s array contents into the
+    /// original backing `old_gc` in place — preserving the pointer identity every
+    /// by-value holder of `old_gc` shares (an `@a` captured into a list `(0, @a)` /
+    /// a `\param`) — and redirect any self-reference that (after circular-ref
+    /// fixup) pointed at the about-to-be-dropped `new_gc` back to `old_gc`. Returns
+    /// the `Value::Array` that should be stored in the slot (backed by `old_gc`).
+    pub(super) fn array_inplace_reassign(
+        old_gc: &crate::gc::Gc<crate::value::ArrayData>,
+        new_gc: &crate::gc::Gc<crate::value::ArrayData>,
+        kind: ArrayKind,
+    ) -> Value {
+        let new_ptr = crate::gc::Gc::as_ptr(new_gc) as usize;
+        let mut new_data = (**new_gc).clone();
+        let mut seen = Vec::new();
+        for item in new_data.items.iter_mut() {
+            Self::replace_array_refs_in_value(item, new_ptr, old_gc, kind, &mut seen);
+        }
+        // SAFETY: single audited aliased in-place write; `new_data` is a fresh
+        // clone and no borrow into `old_gc`'s contents is live across the write.
+        unsafe {
+            *crate::value::gc_contents_mut(old_gc) = new_data;
+        }
+        Value::Array(old_gc.clone(), kind)
+    }
+
+    /// Ensure a `@`/`%`-var value-assignment owns a DISTINCT container, matching
+    /// Raku `=` copy semantics (`my @b = @a` yields `@b !=:= @a`). If the
+    /// array/hash's backing `Gc` is *shared* with another holder, return a fresh-
+    /// `Gc` shallow copy (elements/values stay shared references — only the outer
+    /// container is duplicated). A singly-owned `Gc` is already exclusive and
+    /// returned unchanged; non-container values pass through. Without this, mutsu's
+    /// historical copy-on-write masking (a shared `Gc` that only *appears*
+    /// independent because the next mutation reallocated) breaks once whole-
+    /// container reassignment writes in place (§3): the in-place write would reach
+    /// the aliased source.
+    pub(super) fn detach_shared_container(val: Value) -> Value {
+        match val {
+            Value::Array(gc, kind) if gc.strong_count() > 1 => {
+                Value::Array(crate::gc::Gc::new((*gc).clone()), kind)
+            }
+            Value::Hash(gc) if gc.strong_count() > 1 => {
+                Value::Hash(crate::gc::Gc::new((*gc).clone()))
+            }
+            other => other,
+        }
+    }
+
+    /// The `Value::Hash` analogue of [`array_inplace_reassign`]. Redirects any
+    /// self-referencing hash value that pointed at `new_gc` back to `old_gc`.
+    pub(super) fn hash_inplace_reassign(
+        old_gc: &crate::gc::Gc<crate::value::HashData>,
+        new_gc: &crate::gc::Gc<crate::value::HashData>,
+    ) -> Value {
+        let new_ptr = crate::gc::Gc::as_ptr(new_gc) as usize;
+        let mut new_data = (**new_gc).clone();
+        for v in new_data.map.values_mut() {
+            if let Value::Hash(inner) = v
+                && crate::gc::Gc::as_ptr(inner) as usize == new_ptr
+            {
+                *v = Value::Hash(old_gc.clone());
+            }
+        }
+        // SAFETY: as above — single audited aliased in-place write.
+        unsafe {
+            *crate::value::gc_contents_mut(old_gc) = new_data;
+        }
+        Value::Hash(old_gc.clone())
+    }
 }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -443,6 +443,46 @@ impl Interpreter {
         } else {
             None
         };
+        // Container identity (§3, BLOCKERS.md splice.t): a plain whole-array/hash
+        // *assignment* (`@a = ...`, not `my @a = ...` and not `:=`) mutates the
+        // EXISTING container in place, so any other holder of the same backing
+        // `Gc` (e.g. `@a` captured by value into a list `(0, @a)` / a `\param`
+        // capture) observes the update — matching Raku's stable container
+        // identity. We snapshot the live backing `Gc` here and, after all the
+        // value-shaping/metadata logic has produced the final container, copy
+        // its contents back into this original `Gc` rather than swapping the
+        // slot to a fresh pointer. Only for real reassignment: a `my` decl
+        // creates a fresh container each time (a captured reference from a
+        // prior iteration must NOT see the new declaration's value).
+        // Anonymous containers (`my %`, `my @`) all compile to the single reused
+        // slot name `%__ANON_HASH__` / `@__ANON_ARRAY__`, so each successive
+        // declaration is a DISTINCT logical variable that merely shares a slot.
+        // In-place reassignment there would alias two unrelated anonymous
+        // containers (e.g. `(my % = ...), (my % = ...)` in a list), so exclude
+        // anon names and let them take the fresh-container (replace) path.
+        let is_anon_container = name.contains("__ANON");
+        let inplace_old_array: Option<crate::gc::Gc<crate::value::ArrayData>> =
+            if name.starts_with('@') && !is_bind && !is_rebind && !is_vardecl && !is_anon_container
+            {
+                if let Value::Array(gc, _) = &self.locals[idx] {
+                    Some(gc.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+        let inplace_old_hash: Option<crate::gc::Gc<crate::value::HashData>> =
+            if name.starts_with('%') && !is_bind && !is_rebind && !is_vardecl && !is_anon_container
+            {
+                if let Value::Hash(gc) = &self.locals[idx] {
+                    Some(gc.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
         let mut val = if name.starts_with('%') {
             if has_explicit_initializer
                 && !is_constant
@@ -1389,6 +1429,38 @@ impl Interpreter {
             };
             let stored = std::mem::replace(&mut self.locals[idx], Value::Nil);
             self.locals[idx] = self.tag_container_metadata(stored, info);
+        }
+        // Container identity (§3, splice.t): copy the final container's contents
+        // back into the ORIGINAL backing `Gc` so aliases (a by-value `@a` capture
+        // in a list / a `\param`) observe this reassignment. The slot already
+        // holds the fully-shaped, metadata-tagged value; we reuse that shape but
+        // keep the original pointer. Skip when the pointer is already the same
+        // (e.g. a self-referential `@a = @a`), which needs no copy.
+        if let Some(old_gc) = &inplace_old_array
+            && let Value::Array(new_gc, kind) = &self.locals[idx]
+            && !crate::gc::Gc::ptr_eq(old_gc, new_gc)
+        {
+            let (new_gc, kind) = (new_gc.clone(), *kind);
+            self.locals[idx] = Self::array_inplace_reassign(old_gc, &new_gc, kind);
+        } else if let Some(old_gc) = &inplace_old_hash
+            && let Value::Hash(new_gc) = &self.locals[idx]
+            && !crate::gc::Gc::ptr_eq(old_gc, new_gc)
+        {
+            let new_gc = new_gc.clone();
+            self.locals[idx] = Self::hash_inplace_reassign(old_gc, &new_gc);
+        } else if inplace_old_array.is_none()
+            && inplace_old_hash.is_none()
+            && !is_bind
+            && (name.starts_with('@') || name.starts_with('%'))
+        {
+            // No reusable same-typed container in the slot (a fresh `my @b = @a`
+            // declaration, or a slot that did not hold an array/hash): the `@`/`%`
+            // var must own a DISTINCT container per Raku `=` copy semantics, so
+            // detach from any shared backing `Gc`. (A reassignment whose slot
+            // already holds an array/hash goes through the in-place branches above
+            // and keeps its identity.)
+            let cur = std::mem::replace(&mut self.locals[idx], Value::Nil);
+            self.locals[idx] = Self::detach_shared_container(cur);
         }
         // Use the potentially fixed-up value for env/shared_vars.
         let val = self.locals[idx].clone();

--- a/t/container-identity-whole-assign.t
+++ b/t/container-identity-whole-assign.t
@@ -1,0 +1,65 @@
+use Test;
+
+# Whole-container assignment (`@a = ...`, `%h = ...`) mutates the EXISTING
+# container in place, preserving its identity so a by-value holder of the same
+# container (an `@a` captured into a list) observes the reassignment — Raku's
+# stable container identity. At the same time `=` still COPIES (`my @b = @a`
+# yields a distinct container). See roast/S32-array/splice.t / BLOCKERS §3.
+#
+# NB: each block uses distinct variable names — a variable captured by a closure
+# anywhere in the compilation unit switches to a shared-cell representation whose
+# by-value snapshot semantics are a separate, still-open sub-case.
+
+plan 15;
+
+# --- array reassignment is observed through a captured reference ---
+{
+    my @arr = 0..9;
+    my $cap = (0, @arr);
+    ok $cap[1] =:= @arr, 'list element shares @arr container identity';
+    @arr = ^5;
+    is $cap[1].join(','), '0,1,2,3,4', 'reassignment visible through captured ref';
+    ok $cap[1] =:= @arr, 'identity preserved across whole-array reassignment';
+    @arr = 7, 8;
+    is $cap[1].join(','), '7,8', 'second reassignment also visible';
+}
+
+# --- but `=` still copies: `my @cpy = @src` is a distinct container ---
+{
+    my @src = 1, 2, 3;
+    my @cpy = @src;
+    nok @cpy =:= @src, 'my @cpy = @src produces a distinct container';
+    @cpy = 7, 8, 9;
+    is @src.join(','), '1,2,3', '@src unaffected by later @cpy reassignment (copy)';
+    is @cpy.join(','), '7,8,9', '@cpy holds its own values';
+}
+
+# --- hashes behave the same way ---
+{
+    my %tbl = a => 1, b => 2;
+    my $cap = (0, %tbl);
+    %tbl = c => 3;
+    is $cap[1]<c>, 3, 'hash reassignment visible through captured ref';
+    ok $cap[1] =:= %tbl, 'hash identity preserved across reassignment';
+
+    my %orig = x => 1;
+    my %dup = %orig;
+    nok %dup =:= %orig, 'my %dup = %orig produces a distinct hash';
+    %dup = y => 2;
+    is %orig<x>, 1, '%orig unaffected by later %dup reassignment (copy)';
+}
+
+# --- self-referential comma-assignment still works ---
+{
+    my @sr = 1, 2;
+    @sr ,= 3, 4;
+    is @sr.elems, 2, ',= does not flatten-append';
+    ok @sr[0] =:= @sr, ',= self-reference (element 0 is the array itself)';
+}
+
+# --- anonymous containers stay distinct (shared slot name) ---
+{
+    my @anon = (my % is default(42)), (my % is default(42) = o => 768);
+    is @anon[0]<o>, 42, 'first anonymous hash keeps its own (default) value';
+    is @anon[1]<o>, 768, 'second anonymous hash keeps its own value';
+}


### PR DESCRIPTION
## What

Raku treats `@a = ...` / `%h = ...` as an **in-place update of the existing container**, so a by-value holder of the same container (an `@a` captured into a list `(0, @a)` / a `\param` capture) observes the reassignment. mutsu was *replacing* the backing `Gc`, so a captured reference kept seeing the old container — the `S32-array/splice.t` self-splice canary inserted a stale snapshot and produced extra elements (35 failing subtests).

## Fix

In both the SetLocal and SetGlobal store paths:

1. **In-place whole-container assignment.** A plain `=` (not `my`/`:=`) copies the final container's contents back into the original backing `Gc` (`array_inplace_reassign` / `hash_inplace_reassign`), preserving pointer identity. Self-references from the circular-ref fixup are redirected from the discarded `Gc` back to the original.
2. **Preserve `=` copy semantics.** A fresh declaration / non-in-place store detaches a *shared* backing `Gc` (strong_count > 1) into a fresh-`Gc` shallow copy (`detach_shared_container`), so `my @b = @a` yields `@b !=:= @a`. Previously copy independence relied on copy-on-write masking (which in-place would defeat); this also corrects the pre-existing `my @b = @a` ⇒ `@b =:= @a` incompatibility.
3. **Slot-reuse guards.** Anonymous containers (`my %`/`my @`, all sharing `%__ANON_HASH__`) are excluded from in-place reassignment; a pointy block (`given @c -> @p`) clears `@p`'s slot value on exit so a later reuse cannot in-place-clobber the prior block's source.

## Result

- `roast/S32-array/splice.t`: 357 → **392/392**, whitelisted (BLOCKERS.md §8's top-priority item).
- New `t/container-identity-whole-assign.t`; `make test` green; container-heavy whitelist subset (392 files / 33026 subtests) green.

The remaining sub-case — a closure-captured container in shared-cell (`ContainerRef`) form, snapshotted by value into a list and read *after* the capturing frame returns — is a separate return-writeback slice tracked in BLOCKERS.md §3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)