### PR TITLE
fix(str): uniprop Sentence_Break follows UAX #29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/builtins/uniprop/text_seg.rs
+++ b/src/builtins/uniprop/text_seg.rs
@@ -72,36 +72,86 @@ pub(crate) fn unicode_joining_group(ch: char) -> String {
     }
 }
 
-/// Sentence_Break property.
+/// UAX #29 Sentence_Break=SContinue set.
+fn is_sb_scontinue(cp: u32) -> bool {
+    matches!(
+        cp,
+        0x002C
+            | 0x002D
+            | 0x003A
+            | 0x055D
+            | 0x060C
+            | 0x060D
+            | 0x07F8
+            | 0x1802
+            | 0x1808
+            | 0x2013
+            | 0x2014
+            | 0x3001
+            | 0xFE10
+            | 0xFE11
+            | 0xFE13
+            | 0xFE31
+            | 0xFE32
+            | 0xFE50
+            | 0xFE51
+            | 0xFE55
+            | 0xFF0C
+            | 0xFF0D
+            | 0xFF1A
+            | 0xFF64
+    )
+}
+
+/// Sentence_Break property (UAX #29 SentenceBreakProperty).
 pub(crate) fn unicode_sentence_break(ch: char) -> String {
     let cp = ch as u32;
     match cp {
-        0x000D => "CR".to_string(),
-        0x000A => "LF".to_string(),
-        0x0009 | 0x000B | 0x000C => "Sp".to_string(),
-        _ => {
-            let gc = crate::builtins::unicode::unicode_general_category(ch);
-            match gc.as_str() {
-                "Lu" => "Upper".to_string(),
-                "Ll" => "Lower".to_string(),
-                "Nd" => "Numeric".to_string(),
-                "Zs" => "Sp".to_string(),
-                _ => {
-                    // Check for ATerm (. and similar)
-                    if cp == 0x002E || cp == 0x2024 {
-                        "ATerm".to_string()
-                    } else if super::binary_props::check_binary_property(
-                        ch,
-                        r"^\p{Sentence_Terminal}$",
-                    ) {
-                        "STerm".to_string()
-                    } else {
-                        "Other".to_string()
-                    }
-                }
-            }
-        }
+        0x000D => return "CR".to_string(),
+        0x000A => return "LF".to_string(),
+        0x0085 | 0x2028 | 0x2029 => return "Sep".to_string(),
+        _ => {}
     }
+    let gc = crate::builtins::unicode::unicode_general_category(ch);
+    // Extend: grapheme-extending marks, spacing marks, and ZWJ.
+    if gc == "Mc"
+        || cp == 0x200D
+        || super::binary_props::check_binary_property(ch, r"^\p{Grapheme_Extend}$")
+    {
+        return "Extend".to_string();
+    }
+    if gc == "Cf" {
+        return "Format".to_string();
+    }
+    if super::binary_props::check_binary_property(ch, r"^\p{White_Space}$") {
+        return "Sp".to_string();
+    }
+    if gc == "Nd" {
+        return "Numeric".to_string();
+    }
+    if cp == 0x002E || cp == 0x2024 || cp == 0xFF0E {
+        return "ATerm".to_string();
+    }
+    if super::binary_props::check_binary_property(ch, r"^\p{Sentence_Terminal}$") {
+        return "STerm".to_string();
+    }
+    // Close: open/close/quotation punctuation plus straight quotes.
+    if matches!(gc.as_str(), "Ps" | "Pe" | "Pi" | "Pf") || cp == 0x0022 || cp == 0x0027 {
+        return "Close".to_string();
+    }
+    if is_sb_scontinue(cp) {
+        return "SContinue".to_string();
+    }
+    if gc == "Lt" || super::binary_props::check_binary_property(ch, r"^\p{Uppercase}$") {
+        return "Upper".to_string();
+    }
+    if super::binary_props::check_binary_property(ch, r"^\p{Lowercase}$") {
+        return "Lower".to_string();
+    }
+    if super::binary_props::check_binary_property(ch, r"^\p{Alphabetic}$") {
+        return "OLetter".to_string();
+    }
+    "Other".to_string()
 }
 
 /// Is `cp` in the UAX #29 Word_Break=Katakana set (includes Common-script

--- a/t/uniprop-sentence-break-uax29.t
+++ b/t/uniprop-sentence-break-uax29.t
@@ -1,0 +1,51 @@
+use Test;
+
+# Sentence_Break property (UAX #29). mutsu previously only produced
+# CR/LF/Sp/Upper/Lower/Numeric/ATerm/STerm/Other; verify the full set of
+# classes against Rakudo / the Unicode spec.
+
+plan 28;
+
+# CR / LF / Sep
+is "\r".uniprop('Sentence_Break'), 'CR', 'CR is CR';
+is "\n".uniprop('Sentence_Break'), 'LF', 'LF is LF';
+is "\x0085".uniprop('Sentence_Break'), 'Sep', 'NEL is Sep';
+is "\x2028".uniprop('Sentence_Break'), 'Sep', 'LINE SEPARATOR is Sep';
+is "\x2029".uniprop('Sentence_Break'), 'Sep', 'PARAGRAPH SEPARATOR is Sep';
+
+# Sp
+is "\t".uniprop('Sentence_Break'), 'Sp', 'TAB is Sp';
+is ' '.uniprop('Sentence_Break'), 'Sp', 'SPACE is Sp';
+is "\xA0".uniprop('Sentence_Break'), 'Sp', 'NBSP is Sp';
+
+# Extend (marks + ZWJ)
+is "\x0301".uniprop('Sentence_Break'), 'Extend', 'combining mark is Extend';
+is "\x0903".uniprop('Sentence_Break'), 'Extend', 'spacing mark (Mc) is Extend';
+is "\x200D".uniprop('Sentence_Break'), 'Extend', 'ZWJ is Extend';
+
+# Format
+is "\xAD".uniprop('Sentence_Break'), 'Format', 'soft hyphen is Format';
+is "\x0600".uniprop('Sentence_Break'), 'Format', 'ARABIC NUMBER SIGN is Format';
+
+# Numeric / Upper / Lower / OLetter
+is '5'.uniprop('Sentence_Break'), 'Numeric', 'digit is Numeric';
+is 'A'.uniprop('Sentence_Break'), 'Upper', 'A is Upper';
+is "\x01C5".uniprop('Sentence_Break'), 'Upper', 'titlecase letter is Upper';
+is 'a'.uniprop('Sentence_Break'), 'Lower', 'a is Lower';
+is "\xAA".uniprop('Sentence_Break'), 'Lower', 'feminine ordinal is Lower';
+is "\x05D0".uniprop('Sentence_Break'), 'OLetter', 'Hebrew alef is OLetter';
+is "\x3042".uniprop('Sentence_Break'), 'OLetter', 'Hiragana is OLetter';
+
+# ATerm / STerm
+is '.'.uniprop('Sentence_Break'), 'ATerm', 'full stop is ATerm';
+is "\xFF0E".uniprop('Sentence_Break'), 'ATerm', 'fullwidth full stop is ATerm';
+is '!'.uniprop('Sentence_Break'), 'STerm', 'exclamation is STerm';
+is '?'.uniprop('Sentence_Break'), 'STerm', 'question mark is STerm';
+
+# Close
+is '('.uniprop('Sentence_Break'), 'Close', 'open paren is Close';
+is '"'.uniprop('Sentence_Break'), 'Close', 'quote is Close';
+
+# SContinue
+is ','.uniprop('Sentence_Break'), 'SContinue', 'comma is SContinue';
+is ':'.uniprop('Sentence_Break'), 'SContinue', 'colon is SContinue';


### PR DESCRIPTION
## Summary

`uniprop('Sentence_Break')` only produced `CR`/`LF`/`Sp`/`Upper`/`Lower`/`Numeric`/`ATerm`/`STerm`/`Other`, misreporting entire UAX #29 classes. Implement the full SentenceBreakProperty classification.

### Now classified correctly (all verified against `raku`)
| input | before | after |
|-------|--------|-------|
| `U+0085` / `U+2028` / `U+2029` | Other | **Sep** |
| `U+0903` spacing mark, `U+200D` ZWJ | Other | **Extend** |
| soft hyphen, `U+0600` | Other | **Format** |
| `ª` (U+00AA) | Other | **Lower** |
| Hebrew `א`, Hiragana `あ` | Other | **OLetter** |
| `U+FF0E` fullwidth full stop | STerm | **ATerm** |
| `(` `"` | Other | **Close** |
| `,` `:` | Other | **SContinue** |

- `Extend` = grapheme-extending marks + spacing marks (`gc=Mc`) + ZWJ.
- `Upper` = `Uppercase` or `gc=Lt`; `Lower` = `Lowercase`; `OLetter` = remaining `Alphabetic` — using the derived case/alphabetic properties instead of the old `gc=Lu/Ll`-only approximation.
- `Close` = `Ps`/`Pe`/`Pi`/`Pf` + straight quotes; `SContinue` = the UAX #29 codepoint set; `Sep`, `ATerm`, `STerm`, `Format`, `Sp` per spec.

Only the `.uniprop('Sentence_Break')` query path uses this function.

## Test
- New `t/uniprop-sentence-break-uax29.t` (28 assertions).
- Verified over a ~13,000-codepoint sweep: divergence from `raku` drops from **5646 → ~3300**, the remainder being underlying UCD data-version differences (mutsu's case/alphabetic tables are newer than raku's Unicode version), not classification logic.
- `make test` passes (14301 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)