### PR TITLE
fix(str): uniprop Numeric_Type is Numeric for CJK numeral ideographs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -62,6 +62,12 @@ pub(crate) fn unicode_numeric_type(ch: char) -> String {
     if nl_re.is_match(s) {
         return "Numeric".to_string();
     }
+    // Ideographs and other letters that carry a numeric value (e.g. the CJK
+    // numerals 一 二 三 十 百 千 万) have Numeric_Type=Numeric even though their
+    // General_Category is Lo rather than a Number category.
+    if !matches!(unicode_numeric_value(ch), Value::Num(n) if n.is_nan()) {
+        return "Numeric".to_string();
+    }
     "None".to_string()
 }
 

--- a/t/uniprop-numeric-type-cjk.t
+++ b/t/uniprop-numeric-type-cjk.t
@@ -1,0 +1,36 @@
+use Test;
+
+# CJK numeral ideographs carry a numeric value and therefore have
+# Numeric_Type=Numeric, even though their General_Category is Lo (not a
+# Number category). mutsu previously reported Numeric_Type=None for them
+# while still returning the correct Numeric_Value / .unival.
+
+plan 20;
+
+# 一二三四五六七八九十
+is '一'.uniprop('Numeric_Type'), 'Numeric', '一 is Numeric_Type=Numeric';
+is '二'.uniprop('Numeric_Type'), 'Numeric', '二 is Numeric';
+is '三'.uniprop('Numeric_Type'), 'Numeric', '三 is Numeric';
+is '五'.uniprop('Numeric_Type'), 'Numeric', '五 is Numeric';
+is '九'.uniprop('Numeric_Type'), 'Numeric', '九 is Numeric';
+is '十'.uniprop('Numeric_Type'), 'Numeric', '十 is Numeric';
+is '百'.uniprop('Numeric_Type'), 'Numeric', '百 is Numeric';
+is '千'.uniprop('Numeric_Type'), 'Numeric', '千 is Numeric';
+is '万'.uniprop('Numeric_Type'), 'Numeric', '万 is Numeric';
+is '億'.uniprop('Numeric_Type'), 'Numeric', '億 is Numeric';
+
+# Numeric_Type stays consistent with the numeric value
+is '一'.uniprop('Numeric_Value'), '1', '一 Numeric_Value is 1';
+is '十'.uniprop('Numeric_Value'), '10', '十 Numeric_Value is 10';
+is '億'.unival, 100000000, '億 unival is 100000000';
+
+# Existing categories still classify correctly
+is '5'.uniprop('Numeric_Type'), 'Decimal', 'ASCII digit is Decimal';
+is '½'.uniprop('Numeric_Type'), 'Numeric', 'vulgar fraction is Numeric';
+is 'Ⅴ'.uniprop('Numeric_Type'), 'Numeric', 'Roman numeral (Nl) is Numeric';
+is '²'.uniprop('Numeric_Type'), 'Digit', 'superscript two is Digit';
+
+# Non-numeric characters are None
+is 'A'.uniprop('Numeric_Type'), 'None', 'letter is None';
+is '愛'.uniprop('Numeric_Type'), 'None', 'non-numeric ideograph is None';
+is '〇'.uniprop('Numeric_Type'), 'Numeric', 'ideographic zero is Numeric';


### PR DESCRIPTION
## Summary

`'一'.uniprop('Numeric_Type')` returned `None` even though `'一'.uniprop('Numeric_Value')` / `'一'.unival` already returned `1`. `unicode_numeric_type()` only recognised the `Nd`/`No`/`Nl` number categories plus a small superscript `Digit` set, so CJK numeral ideographs (`一 二 三 十 百 千 万 億`, ...) — which are `gc=Lo` — fell through to `None`. Numeric_Type and Numeric_Value were internally inconsistent.

### Fix
Add a fallback: any character that carries a numeric value but isn't a Number-category codepoint has `Numeric_Type=Numeric`, matching raku and keeping the two properties consistent.

```
'一'.uniprop('Numeric_Type')   # None -> Numeric   (raku: Numeric; unival 1)
'億'.uniprop('Numeric_Type')   # None -> Numeric   (unival 100000000)
```

## Test
- New `t/uniprop-numeric-type-cjk.t` (20 assertions).
- Verified over a ~15,000-codepoint sweep: divergence from `raku` drops from 102 to 81 in the sampled ranges; every character the change touches now matches raku. (The residual diffs are pre-existing UCD data-version differences in the numeric-value table, unrelated to this change.)
- `make test` passes (14308 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)