### PR TITLE
fix(regex): fold captures of a separator-quantified capturing group (**N %sep)

### DIFF
--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -646,6 +646,20 @@ impl Interpreter {
             // capture folding that preserves the Match structure.
             let atom_has_capture =
                 Self::atom_contains_capture(atom) || Self::atom_contains_named_capture(atom);
+            // The separator form `**N..M %sep` was previously always string-
+            // expanded, which renumbers a capturing atom's group into one
+            // spurious positional slot per repetition (`(\d)**4 % '.'` yielded
+            // `0,1,2,3` instead of folding all four into group `0`). The native
+            // `match_separated_quantifier` path now folds separated captures
+            // correctly, so when the atom or the separator carries a capture
+            // (and sigspace is off — the spaced expansion still inserts `<ws>`
+            // the native path lacks), defer to it. Mirrors the bare-`%` path.
+            let sep_has_capture = sep.is_some_and(|s| {
+                Self::atom_contains_capture(s) || Self::atom_contains_named_capture(s)
+            });
+            if sep_mode.is_some() && !sigspace && (atom_has_capture || sep_has_capture) {
+                return pattern.to_string();
+            }
             if is_single_atom && (sep_mode.is_some() || !atom_has_capture) {
                 // Detect empty range (e.g. 2..1) before LTM expansion
                 let (parsed_min, parsed_max) = Self::parse_quantifier_range(count_spec);

--- a/t/regex-separator-quant-capture.t
+++ b/t/regex-separator-quant-capture.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A capturing group under a `**N`/`**N..M` quantifier WITH a `%`/`%%` separator
+# folds every repetition into a single positional group (index 0), matching
+# Raku's Match layout — NOT one spurious positional slot per repetition. This
+# was broken for the exact/range `**` forms because the string-based LTM
+# expansion renumbered the captures (`(\d)**4 % '.'` yielded groups 0,1,2,3);
+# the native separator-quantifier matcher folds them correctly.
+
+plan 10;
+
+# --- exact count ---
+{
+    my $m = "a1b" ~~ / (\w) ** 2 % \d /;
+    ok $m, 'exact **2 % sep matches';
+    is $m[0].elems, 2, 'exact **2 %: group 0 folds both repetitions';
+    is $m[0].map(*.Str).join(','), 'a,b', 'exact **2 %: folded captures are correct';
+}
+
+# --- range count ---
+{
+    my $m = "a1b2c" ~~ / (\w) ** 1..3 % \d /;
+    is $m[0].elems, 3, 'range **1..3 %: group 0 folds all three repetitions';
+    is $m[0].map(*.Str).join(','), 'a,b,c', 'range **1..3 %: folded captures are correct';
+}
+
+# --- the IPv4 canary (nested quantified captures) ---
+{
+    my $m = "127.0.0.1" ~~ / (\d ** 1..3) ** 4 % '.' /;
+    is $m[0].elems, 4, 'nested (\d**1..3)**4 % ".": four octets folded into group 0';
+    is $m[0].map(*.Str).join('|'), '127|0|0|1', 'nested: octet captures are correct';
+}
+
+# --- `.match` exposes the same folded structure ---
+{
+    my $m = "10.20.30.40".match(/ (\d ** 1..3) ** 4 % '.' /);
+    is $m[0].elems, 4, '.match: four octets folded into group 0';
+    is $m[0][2].Str, '30', '.match: individual octet is addressable';
+}
+
+# --- plain `+ %` (already worked) still folds ---
+{
+    my $m = "a,b,c" ~~ / (\w)+ % ',' /;
+    is $m[0].elems, 3, '+ %: group 0 folds all repetitions';
+}


### PR DESCRIPTION
## What

A capturing group under an exact/range `**` quantifier with a `%`/`%%` separator — `(\d ** 1..3) ** 4 % '.'`, `(\w) ** 2 % \d` — must fold every repetition into a **single positional group (index 0)**, matching Raku's Match layout.

mutsu's `expand_ltm_pattern` always **string-expanded** the `**N..M %sep` form, which duplicates the atom text and renumbers a capturing atom's group into one spurious positional slot per repetition. So `(\d)**4 % '.'` produced groups `0,1,2,3` (each a scalar Match) instead of folding all four into group `0` as a List:

```
"127.0.0.1" ~~ / (\d ** 1..3) ** 4 % '.' /
  before: $m[0] = ｢127｣           (only the first octet; $m[1..3] separate)
  after:  $m[0] = (｢127｣ ｢0｣ ｢0｣ ｢1｣)   ✓ matches Rakudo
```

## Fix

The native `match_separated_quantifier` path already folds separated captures correctly (it drives the `+ %` / `* %` forms). This mirrors the bare-`%` path's existing guard: when the quantified atom **or** the separator carries a capture (and sigspace is off — the spaced expansion still inserts `<ws>` the native path lacks), defer the `**N..M %sep` form to the native parser instead of string-expanding it.

Fixes `~~ / /` and `.match`. Adds `t/regex-separator-quant-capture.t` (10 cases). `make test` green; the S05 regex whitelist subset stays green.

## Follow-up

The `m:g//` quote form and `.comb` reach the matcher through separate dispatch paths (regex `ACCEPTS` / `regex_find_all`) that expose the folded capture differently, so `roast/integration/advent2012-day22.t` is not yet fully green — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)