### PR TITLE
fix(str): uniprop Numeric_Type=Digit for single-digit presentation forms

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -29,6 +29,16 @@ pub(crate) fn unicode_numeric_value(ch: char) -> Value {
 }
 
 /// Look up Numeric_Type for uniprop.
+/// UAX #44 Numeric_Type=Digit set: single-digit presentation forms that are
+/// not decimal digits (gc=Nd).
+fn is_numeric_type_digit(cp: u32) -> bool {
+    matches!(cp,
+        0x00B2..=0x00B3 | 0x00B9 | 0x1369..=0x1371 | 0x19DA | 0x2070 | 0x2074..=0x2079
+        | 0x2080..=0x2089 | 0x2460..=0x2468 | 0x2474..=0x247C | 0x2488..=0x2490 | 0x24EA
+        | 0x24F5..=0x24FD | 0x24FF | 0x2776..=0x277E | 0x2780..=0x2788 | 0x278A..=0x2792
+        | 0x10A40..=0x10A43 | 0x10E60..=0x10E68 | 0x11052..=0x1105A | 0x1F100..=0x1F10A)
+}
+
 pub(crate) fn unicode_numeric_type(ch: char) -> String {
     // Check Nd (Decimal)
     static ND_RE: OnceLock<regex::Regex> = OnceLock::new();
@@ -38,16 +48,11 @@ pub(crate) fn unicode_numeric_type(ch: char) -> String {
     if nd_re.is_match(s) {
         return "Decimal".to_string();
     }
-    // Digit type: superscripts/subscripts that are No but behave as Digit
-    // U+00B2 SUPERSCRIPT TWO, U+00B3 SUPERSCRIPT THREE, U+00B9 SUPERSCRIPT ONE
-    // U+2070-U+2079, U+2080-U+2089
+    // Digit type: single-digit (0..9) presentation forms that are not Nd —
+    // superscripts/subscripts and circled/parenthesized/dingbat digits, etc.
+    // (UAX #44 Numeric_Type=Digit set).
     let cp = ch as u32;
-    if cp == 0x00B2
-        || cp == 0x00B3
-        || cp == 0x00B9
-        || (0x2070..=0x2079).contains(&cp)
-        || (0x2080..=0x2089).contains(&cp)
-    {
+    if is_numeric_type_digit(cp) {
         return "Digit".to_string();
     }
     // Check No (Numeric — includes fractions and other numeric chars)

--- a/t/uniprop-numeric-type-digit.t
+++ b/t/uniprop-numeric-type-digit.t
@@ -1,0 +1,51 @@
+use Test;
+
+# Numeric_Type=Digit covers single-digit (0..9) presentation forms that are
+# not decimal digits (gc=Nd): superscripts/subscripts and the circled,
+# parenthesized, full-stop and dingbat digit forms. mutsu previously only
+# recognised the superscript/subscript subset and reported the rest as
+# Numeric.
+
+plan 22;
+
+# Superscripts / subscripts (already worked)
+is '²'.uniprop('Numeric_Type'), 'Digit', 'superscript two is Digit';
+is '⁷'.uniprop('Numeric_Type'), 'Digit', 'superscript seven is Digit';
+is '₃'.uniprop('Numeric_Type'), 'Digit', 'subscript three is Digit';
+
+# Circled digits ①..⑨ and ⓪
+is '①'.uniprop('Numeric_Type'), 'Digit', 'circled one is Digit';
+is '⑨'.uniprop('Numeric_Type'), 'Digit', 'circled nine is Digit';
+is '⓪'.uniprop('Numeric_Type'), 'Digit', 'circled zero is Digit';
+
+# Parenthesized digits ⑴..⑼
+is '⑴'.uniprop('Numeric_Type'), 'Digit', 'parenthesized one is Digit';
+is '⑼'.uniprop('Numeric_Type'), 'Digit', 'parenthesized nine is Digit';
+
+# Digit-with-full-stop ⒈..⒐
+is '⒈'.uniprop('Numeric_Type'), 'Digit', 'digit one full stop is Digit';
+
+# Double-circled ⓵..⓽ and ⓿
+is "\x24F5".uniprop('Numeric_Type'), 'Digit', 'double circled one is Digit';
+is "\x24FF".uniprop('Numeric_Type'), 'Digit', 'negative circled zero is Digit';
+
+# Dingbat circled/negative digits
+is "\x2776".uniprop('Numeric_Type'), 'Digit', 'dingbat negative circled one is Digit';
+is "\x2780".uniprop('Numeric_Type'), 'Digit', 'dingbat circled sans-serif one is Digit';
+
+# Ethiopic digits
+is "\x1369".uniprop('Numeric_Type'), 'Digit', 'ethiopic digit one is Digit';
+
+# Numeric_Value is still correct for these
+is '①'.unival, 1, '① unival is 1';
+is '⓪'.unival, 0, '⓪ unival is 0';
+
+# Non-Digit numeric forms stay Numeric
+is '½'.uniprop('Numeric_Type'), 'Numeric', 'vulgar fraction is Numeric';
+is '⑩'.uniprop('Numeric_Type'), 'Numeric', 'circled ten is Numeric';
+is 'Ⅴ'.uniprop('Numeric_Type'), 'Numeric', 'Roman numeral is Numeric';
+
+# Plain decimal digits and letters unchanged
+is '7'.uniprop('Numeric_Type'), 'Decimal', 'ASCII digit is Decimal';
+is '٣'.uniprop('Numeric_Type'), 'Decimal', 'Arabic-Indic digit is Decimal';
+is 'A'.uniprop('Numeric_Type'), 'None', 'letter is None';


### PR DESCRIPTION
## Summary

`Numeric_Type=Digit` covers single-digit (0..9) presentation forms that are not decimal digits (`gc=Nd`). `unicode_numeric_type()` only recognised the superscript/subscript subset, so the circled, parenthesized, full-stop and dingbat digit forms fell through to the blanket `No → Numeric` rule and reported `Numeric` instead of `Digit`.

```
'①'.uniprop('Numeric_Type')   # Numeric -> Digit   (raku: Digit)
'⑴'.uniprop('Numeric_Type')   # Numeric -> Digit
'⓪'.uniprop('Numeric_Type')   # Numeric -> Digit
```

Replaced the ad-hoc superscript check with the full UAX #44 `Numeric_Type=Digit` codepoint set (128 codepoints: superscripts/subscripts, Ethiopic, New Tai Lue, circled/parenthesized/full-stop/double-circled/dingbat digits, Kharoshthi, Rumi, Brahmi, and the mahjong/domino digit forms).

## Test
- New `t/uniprop-numeric-type-digit.t` (22 assertions).
- Verified against `raku` over a full BMP+SMP sweep: the Digit forms now all match; remaining `Numeric_Type` diffs are pre-existing UCD data-version differences in the `Nd` / Unihan numeric tables.
- `make test` passes (14358 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)