### PR TITLE
fix(num/seq): Num.gist matches .Str; arithmetic sequence keeps a rational step exact

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1326,6 +1326,7 @@ roast/integration/advent2013-day02.t
 roast/integration/advent2013-day06.t
 roast/integration/advent2013-day07.t
 roast/integration/advent2013-day09.t
+roast/integration/advent2013-day15.t
 roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -672,12 +672,17 @@ pub(super) fn dispatch(
             Some(Ok(Value::str(i.to_string())))
         }
         Value::Int(i) => Some(Ok(Value::str(format!("{}", i)))),
-        Value::Num(f) => {
+        Value::Num(_f) => {
             if method == "raku" || method == "perl" {
                 Some(Ok(Value::str(raku_value(target))))
             } else {
-                // gist
-                Some(Ok(Value::str(format!("{}", f))))
+                // gist == Str for a Num: use the canonical Num→Str formatter,
+                // which renders Inf/-Inf/NaN with their proper casing and applies
+                // scientific notation for very large / small magnitudes. The raw
+                // `format!("{}", f)` produced Rust's lowercase `inf`/`-inf` and
+                // never switched to scientific (e.g. `1e20.gist` was the full
+                // 21-digit integer instead of `1e+20`).
+                Some(Ok(Value::str(target.to_string_value())))
             }
         }
         Value::Complex(r, i) => {

--- a/src/runtime/seq_helpers/seq_arithmetic.rs
+++ b/src/runtime/seq_helpers/seq_arithmetic.rs
@@ -259,6 +259,74 @@ impl Interpreter {
         }
     }
 
+    /// The exact rational difference `b - a` of two Int/Rat sequence seeds,
+    /// reduced to lowest terms. `None` if either seed is not exactly rational or
+    /// the arithmetic overflows `i64`. Used to carry an arithmetic sequence's step
+    /// as an exact `Rat` (`0, 1/10 … 1` stays `0.1 0.2 0.3 …`, not the float
+    /// `0.30000000000000004`).
+    pub(in crate::runtime) fn seq_rat_diff(a: &Value, b: &Value) -> Option<(i64, i64)> {
+        let (an, ad) = Self::seq_value_to_rat(a)?;
+        let (bn, bd) = Self::seq_value_to_rat(b)?;
+        // b - a = (bn*ad - an*bd) / (bd*ad)
+        let num = (bn as i128) * (ad as i128) - (an as i128) * (bd as i128);
+        let den = (bd as i128) * (ad as i128);
+        if den == 0 {
+            return None;
+        }
+        let (mut num, mut den) = (num, den);
+        if den < 0 {
+            num = -num;
+            den = -den;
+        }
+        let g = {
+            let (mut x, mut y) = (num.unsigned_abs(), den.unsigned_abs());
+            while y != 0 {
+                let t = y;
+                y = x % y;
+                x = t;
+            }
+            x.max(1) as i128
+        };
+        let (n, d) = (num / g, den / g);
+        if (i64::MIN as i128..=i64::MAX as i128).contains(&n)
+            && (i64::MIN as i128..=i64::MAX as i128).contains(&d)
+        {
+            Some((n as i64, d as i64))
+        } else {
+            None
+        }
+    }
+
+    /// Add a rational step `num/den` to a sequence value, preserving the exact
+    /// `Rat`/`Int` type (falling back to `Num` only on overflow). The rational
+    /// counterpart of [`seq_add`], used for arithmetic sequences whose step is a
+    /// genuine fraction so exactness is not lost to float accumulation.
+    pub(in crate::runtime) fn seq_add_rat(val: &Value, num: i64, den: i64) -> Value {
+        match val {
+            Value::Int(i) => {
+                // i + num/den = (i*den + num) / den
+                if let Some(nn) = i.checked_mul(den).and_then(|x| x.checked_add(num)) {
+                    make_rat(nn, den)
+                } else {
+                    Value::Num(*i as f64 + num as f64 / den as f64)
+                }
+            }
+            Value::Rat(n, d) => {
+                // n/d + num/den = (n*den + num*d) / (d*den)
+                if let (Some(a), Some(b), Some(dd)) =
+                    (n.checked_mul(den), num.checked_mul(*d), d.checked_mul(den))
+                    && let Some(nn) = a.checked_add(b)
+                {
+                    make_rat(nn, dd)
+                } else {
+                    Value::Num(*n as f64 / *d as f64 + num as f64 / den as f64)
+                }
+            }
+            Value::Num(f) => Value::Num(*f + num as f64 / den as f64),
+            _ => Value::Num(Self::seq_value_to_f64(val).unwrap_or(0.0) + num as f64 / den as f64),
+        }
+    }
+
     // Multiply a sequence value by a rational ratio (num/den), preserving Rat type
     pub(in crate::runtime) fn seq_mul_rat(val: &Value, num: i64, den: i64) -> Value {
         match val {

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -611,6 +611,24 @@ impl Interpreter {
             SeqMode::Closure
         };
 
+        // Carry the arithmetic step as an EXACT rational when the sequence is
+        // arithmetic, every seed is Int/Rat, and the step is a genuine fraction
+        // (`den != 1`). The generation step then adds the fraction exactly
+        // (`0, 1/10 … 1` yields `0.1 0.2 0.3 …`, not float `0.30000000000000004`).
+        // A whole-number step keeps the existing `seq_add` path so an integer
+        // sequence (`1, 2 … 10`) stays `Int` rather than becoming `Rat`.
+        let rat_step: Option<(i64, i64)> = if matches!(mode, SeqMode::Arithmetic(_))
+            && seeds.len() >= 2
+            && seeds.iter().all(|v| Self::seq_value_to_rat(v).is_some())
+        {
+            match Self::seq_rat_diff(&seeds[seeds.len() - 2], &seeds[seeds.len() - 1]) {
+                Some((n, d)) if d != 1 => Some((n, d)),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         // Check for "wrong side" sequences: arithmetic with endpoint on wrong side
         if let SeqMode::Arithmetic(step) = &mode
             && let Some(ref ep) = endpoint
@@ -1148,6 +1166,8 @@ impl Interpreter {
                             self.env = saved;
                             self.var_bindings = saved_vb;
                             v
+                        } else if let Some((sn, sd)) = rat_step {
+                            Self::seq_add_rat(last, sn, sd)
                         } else {
                             Self::seq_add(last, *step)
                         }

--- a/t/num-gist-and-rat-sequence.t
+++ b/t/num-gist-and-rat-sequence.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 16;
+
+# --- Num.gist renders Inf/-Inf/NaN and large/small magnitudes like .Str ---
+is Inf.gist,   'Inf',   'Inf.gist';
+is (-Inf).gist, '-Inf', '-Inf.gist';
+is NaN.gist,   'NaN',   'NaN.gist';
+is (1e20).gist, '1e+20', 'large magnitude gist uses scientific notation';
+is (1e15).gist, '1e+15', '1e15 gist uses scientific notation';
+is (0.1).gist, '0.1',   'ordinary Num gist';
+is (100e0).gist, '100', 'integer-valued Num gist';
+# gist and Str agree for a Num (Raku semantics)
+is (1e20).gist, (1e20).Str, 'Num gist == Str (large)';
+is Inf.gist, Inf.Str, 'Num gist == Str (Inf)';
+
+# --- an arithmetic sequence with a rational step stays exact (Rat), not float ---
+{
+    is (0, 1/10 ... 1).gist, '(0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1)',
+        'rational-step arithmetic series is exact';
+    my @s = (0, 1/10 ... 1);
+    isa-ok @s[3], Rat, 'element is a Rat, not a Num';
+    is @s[3], 3/10, 'element equals the exact rational';
+}
+{
+    is (0, 1/3 ... 1)[2], 2/3, 'third element of 1/3-step series is exactly 2/3';
+}
+
+# --- an integer-step sequence stays Int (no Rat regression) ---
+{
+    my @i = (1, 2 ... 5);
+    isa-ok @i[2], Int, 'integer-step sequence stays Int';
+    is (1, 2 ... 5).gist, '(1 2 3 4 5)', 'integer sequence renders as integers';
+}
+
+# --- a genuinely float sequence is unaffected ---
+{
+    isa-ok (0e0, 0.5e0 ... 2e0)[1], Num, 'Num-seeded sequence stays Num';
+}


### PR DESCRIPTION
## What

Two fixes that together whitelist `roast/integration/advent2013-day15.t` (30/30).

### 1. `Num.gist` rendered `inf` and never used scientific notation

`Num.gist` used `format!("{}", f)`, so:
- `Inf.gist` → `inf` (Rakudo: `Inf`), `(-Inf).gist` → `-inf`
- `1e20.gist` → the full 21-digit integer instead of `1e+20`

For a `Num`, `.gist` == `.Str` in Raku, so gist now routes through the canonical `to_string_value` Num formatter (which already handled Inf/-Inf/NaN casing and large/small magnitudes).

### 2. Arithmetic sequence lost Rat exactness

An arithmetic sequence with a fractional step accumulated in `f64`:

```
(0, 1/10 ... 1)   before: 0 0.1 0.2 0.30000000000000004 …   (each a Num)
                  after:  0 0.1 0.2 0.3 …                    (exact Rats)
```

The step was only ever stored as `f64`. Now, when every seed is `Int`/`Rat` and the deduced step is a genuine fraction (`den != 1`), the step is carried as an exact rational and added with a new `seq_add_rat` (the rational counterpart of `seq_add`). A whole-number step keeps the existing `seq_add` path, so `(1, 2 … 10)` stays `Int` and a `Num`-seeded sequence stays `Num` — no type regressions.

## Result

- `roast/integration/advent2013-day15.t` → **30/30**, whitelisted.
- Adds `t/num-gist-and-rat-sequence.t` (16 cases). `make test` green; numeric + sequence roast whitelist subsets stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)