### PR TITLE
fix(str): uniprop Bidi_Class of right-to-left script letters

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -110,6 +110,45 @@ pub(crate) fn case_mapping(ch: char, prop: &str) -> String {
     }
 }
 
+/// Default Bidi_Class of a letter (Lu/Ll/Lt/Lm/Lo), determined by its script:
+/// Arabic-family scripts are Arabic_Letter (AL), other right-to-left scripts
+/// are Right_to_Left (R), and everything else is Left_to_Right (L).
+fn bidi_letter_class(ch: char) -> &'static str {
+    match crate::builtins::unicode::unicode_script_name(ch).as_str() {
+        "Arabic" | "Syriac" | "Thaana" | "Sogdian" | "Hanifi_Rohingya" => "AL",
+        "Hebrew"
+        | "Samaritan"
+        | "Mandaic"
+        | "Adlam"
+        | "Nko"
+        | "Yezidi"
+        | "Mende_Kikakui"
+        | "Cypriot"
+        | "Phoenician"
+        | "Nabataean"
+        | "Palmyrene"
+        | "Hatran"
+        | "Elymaic"
+        | "Imperial_Aramaic"
+        | "Manichaean"
+        | "Avestan"
+        | "Chorasmian"
+        | "Kharoshthi"
+        | "Lydian"
+        | "Meroitic_Cursive"
+        | "Meroitic_Hieroglyphs"
+        | "Old_Turkic"
+        | "Old_Hungarian"
+        | "Old_North_Arabian"
+        | "Old_South_Arabian"
+        | "Old_Sogdian"
+        | "Psalter_Pahlavi"
+        | "Inscriptional_Pahlavi"
+        | "Inscriptional_Parthian" => "R",
+        _ => "L",
+    }
+}
+
 /// Bidi_Class property.
 pub(crate) fn unicode_bidi_class(ch: char) -> String {
     let cp = ch as u32;
@@ -143,11 +182,14 @@ pub(crate) fn unicode_bidi_class(ch: char) -> String {
         | 0x066B..=0x066C            // Arabic decimal/thousands separator
         | 0x06DD                     // Arabic end of ayah
         | 0x08E2 => "AN",            // Arabic disputed end of ayah
+        // Arabic tatweel is script=Common (not Arabic) but Bidi_Class=AL.
+        0x0640 => "AL",
         _ => {
             // Use General Category heuristics
             let gc = crate::builtins::unicode::unicode_general_category(ch);
             match gc.as_str() {
-                "Lu" | "Ll" | "Lt" | "Lm" | "Lo" | "Nd" | "Nl" | "No" => "L",
+                "Lu" | "Ll" | "Lt" | "Lm" | "Lo" => bidi_letter_class(ch),
+                "Nd" | "Nl" | "No" => "L",
                 "Mn" | "Me" | "Cf" => "NSM",
                 "Zs" => "WS",
                 "Zl" | "Zp" => "B",

--- a/t/uniprop-bidi-class-rtl-letters.t
+++ b/t/uniprop-bidi-class-rtl-letters.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Bidi_Class of a letter depends on its script: Arabic-family scripts are
+# Arabic_Letter (AL) and other right-to-left scripts are Right_to_Left (R).
+# mutsu previously classified every letter as Left_to_Right (L).
+
+plan 22;
+
+# Arabic-family letters -> AL
+is 'ب'.uniprop('Bidi_Class'), 'AL', 'Arabic beh is AL';
+is 'ا'.uniprop('Bidi_Class'), 'AL', 'Arabic alef is AL';
+is "\x0710".uniprop('Bidi_Class'), 'AL', 'Syriac alaph is AL';
+is "\x0780".uniprop('Bidi_Class'), 'AL', 'Thaana letter is AL';
+is "\x0640".uniprop('Bidi_Class'), 'AL', 'Arabic tatweel (Lm) is AL';
+
+# Hebrew and other RTL scripts -> R
+is 'א'.uniprop('Bidi_Class'), 'R', 'Hebrew alef is R';
+is "\x0800".uniprop('Bidi_Class'), 'R', 'Samaritan letter is R';
+is "\x07CA".uniprop('Bidi_Class'), 'R', 'NKo letter is R';
+is "\x10800".uniprop('Bidi_Class'), 'R', 'Cypriot syllable is R';
+is "\x10900".uniprop('Bidi_Class'), 'R', 'Phoenician letter is R';
+is "\x1E900".uniprop('Bidi_Class'), 'R', 'Adlam letter is R';
+
+# LTR scripts stay L
+is 'A'.uniprop('Bidi_Class'), 'L', 'Latin is L';
+is 'Ω'.uniprop('Bidi_Class'), 'L', 'Greek is L';
+is 'あ'.uniprop('Bidi_Class'), 'L', 'Hiragana is L';
+is '漢'.uniprop('Bidi_Class'), 'L', 'Han is L';
+is 'क'.uniprop('Bidi_Class'), 'L', 'Devanagari is L';
+
+# Numbers and marks are unaffected by the letter rule
+is '5'.uniprop('Bidi_Class'), 'EN', 'ASCII digit is EN';
+is "\x0661".uniprop('Bidi_Class'), 'AN', 'Arabic-Indic digit is AN';
+is 'Ⅴ'.uniprop('Bidi_Class'), 'L', 'Roman numeral (Nl) is L';
+is "\x05B0".uniprop('Bidi_Class'), 'NSM', 'Hebrew point is NSM';
+is "\x064B".uniprop('Bidi_Class'), 'NSM', 'Arabic fathatan is NSM';
+is ' '.uniprop('Bidi_Class'), 'WS', 'space is WS';


### PR DESCRIPTION
## Summary

`unicode_bidi_class()` classified every letter (`Lu/Ll/Lt/Lm/Lo`) as `L` (Left_to_Right) via the General_Category fallback, so Arabic-, Hebrew- and other RTL-script letters were reported as `L` instead of `AL` / `R`.

```
'ب'.uniprop('Bidi_Class')   # L -> AL   (Arabic)
'א'.uniprop('Bidi_Class')   # L -> R    (Hebrew)
```

Classify letters by script:
- **AL** (Arabic_Letter): Arabic, Syriac, Thaana, Sogdian, Hanifi_Rohingya
- **R** (Right_to_Left): Hebrew, Samaritan, Mandaic, Adlam, NKo, Yezidi, Cypriot, Phoenician and the other RTL scripts
- everything else stays **L**
- plus the special case `U+0640` ARABIC TATWEEL (`script=Common` but `Bidi_Class=AL`)

The RTL-script list was derived empirically from `raku` over the full BMP+SMP letter set (each script's letters are homogeneous in Bidi_Class).

## Test
- New `t/uniprop-bidi-class-rtl-letters.t` (22 assertions).
- Over the sampled ranges, divergence from `raku` drops from **1855 → 672**; the remainder are neutral symbols/punctuation (`ON`/`ET`/`AN` — a separate class, left for a follow-up) and UCD data-version differences.
- `make test` passes (14368 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)