### PR TITLE
fix(signature): read-only param prefix ++/--; a bare @array arg does not auto-flatten

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1292,6 +1292,7 @@ roast/integration/advent2009-day05.t
 roast/integration/advent2009-day06.t
 roast/integration/advent2009-day07.t
 roast/integration/advent2009-day08.t
+roast/integration/advent2009-day09.t
 roast/integration/advent2009-day10.t
 roast/integration/advent2009-day13.t
 roast/integration/advent2009-day14.t

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -234,11 +234,11 @@ impl Interpreter {
                             expanded.extend(named_args);
                             expanded
                         }
-                        Value::Array(items, kind) if !kind.is_itemized() => {
-                            let mut expanded = items.to_vec();
-                            expanded.extend(named_args);
-                            expanded
-                        }
+                        // A bare `@array` argument is a SINGLE Positional in Raku;
+                        // it does NOT auto-flatten to fill several scalar params
+                        // (`sub f($x,$y,$z){}; f(@a)` is a too-few-arguments error —
+                        // only `f(|@a)` flattens). So an Array is left intact here;
+                        // explicit slips arrive as `Value::Slip` and still flatten.
                         Value::Slip(items) => {
                             let mut expanded = items.to_vec();
                             expanded.extend(named_args);

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -171,9 +171,22 @@ impl Interpreter {
     /// Check if a variable is readonly for increment/decrement operations.
     /// Returns Err with X::Multi::NoMatch (like Raku's postfix:<++> dispatch failure).
     pub(crate) fn check_readonly_for_increment(&self, name: &str) -> Result<(), RuntimeError> {
+        self.check_readonly_for_incdec(name, "postfix:<++>")
+    }
+
+    /// Reject an in-place increment/decrement of a read-only variable (a
+    /// non-`is rw`/`is copy` parameter). `op` is the display operator
+    /// (`prefix:<++>`, `postfix:<-->`, ...). Raku models `++`/`--` as multi
+    /// candidates that all require `is rw`, so a read-only argument yields
+    /// `X::Multi::NoMatch` — mirror that here so `sub f($n){ ++$n }` throws.
+    pub(crate) fn check_readonly_for_incdec(
+        &self,
+        name: &str,
+        op: &str,
+    ) -> Result<(), RuntimeError> {
         if self.readonly_vars.contains(name) {
             let msg = format!(
-                "Cannot resolve caller postfix:<++>({}); the parameter requires mutable arguments",
+                "Cannot resolve caller {op}({}); the parameter requires mutable arguments",
                 name
             );
             let mut err = RuntimeError::new(msg.clone());

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -232,6 +232,10 @@ impl Interpreter {
         slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
+        // `++$n` on a read-only parameter (non-`is rw`/`is copy`) is an
+        // X::Multi::NoMatch in Raku (prefix:<++> requires a mutable argument) —
+        // mirror the post-increment check, which already enforces this.
+        self.check_readonly_for_incdec(name, "prefix:<++>")?;
         if let Some(r) = self.try_slotless_attr_incdec(code, name, true, true) {
             return r;
         }
@@ -345,6 +349,8 @@ impl Interpreter {
         slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
+        // `--$n` on a read-only parameter is likewise an X::Multi::NoMatch.
+        self.check_readonly_for_incdec(name, "prefix:<-->")?;
         if let Some(r) = self.try_slotless_attr_incdec(code, name, false, true) {
             return r;
         }

--- a/t/readonly-param-and-no-autoflatten.t
+++ b/t/readonly-param-and-no-autoflatten.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 12;
+
+# --- a read-only parameter (the default) cannot be modified in place ---
+{
+    sub pre-inc($n)  { ++$n }
+    sub pre-dec($n)  { --$n }
+    sub post-inc($n) { $n++ }
+    sub assign($n)   { $n = 5 }
+
+    dies-ok { pre-inc(3)  }, 'prefix ++ on a read-only param dies';
+    dies-ok { pre-dec(3)  }, 'prefix -- on a read-only param dies';
+    dies-ok { post-inc(3) }, 'postfix ++ on a read-only param dies';
+    dies-ok { assign(3)   }, 'assignment to a read-only param dies';
+
+    throws-like { pre-inc(3) }, X::Multi::NoMatch,
+        'prefix ++ throws X::Multi::NoMatch';
+}
+
+# --- `is rw` / `is copy` params remain modifiable ---
+{
+    sub rw-inc($n is rw)     { ++$n }
+    sub copy-inc($n is copy) { ++$n; $n }
+    my $x = 3;
+    rw-inc($x);
+    is $x, 4, 'is rw param: prefix ++ modifies the caller';
+    my $y = 3;
+    is copy-inc($y), 4, 'is copy param: prefix ++ works on the copy';
+    is $y, 3, 'is copy param: caller left unchanged';
+}
+
+# --- a bare @array argument is ONE positional; it does NOT auto-flatten ---
+{
+    sub three($x, $y, $z) { "$x|$y|$z" }
+    my @te = <a b c>;
+
+    dies-ok { three(@te) },
+        'a single @array does not flatten to fill 3 scalar params';
+    is three(|@te), 'a|b|c',
+        'an explicit slip |@array does flatten';
+
+    sub one($x) { $x.elems }
+    is one(@te), 3, 'a single @array binds whole to one param';
+
+    sub two($x, $y) { "$x.elems()|$y" }
+    is two(@te, 9), '3|9', '@array binds to the first param, next arg to the second';
+}


### PR DESCRIPTION
## What

Two argument-binding correctness fixes that together whitelist `roast/integration/advent2009-day09.t` (17/17).

### 1. `++$n` / `--$n` on a read-only parameter

A read-only parameter (the default, non-`is rw`/`is copy`) could be modified with a *prefix* increment/decrement:

```raku
sub up1($n) { ++$n }   # before: silently returned 4; Rakudo: X::Multi::NoMatch
```

Raku models `prefix:<++>`/`prefix:<-->` as multi candidates that all require `is rw`, so a read-only argument is an `X::Multi::NoMatch`. mutsu already threw this for *postfix* `$n++` and for `$n = …`, but not for the prefix forms. The prefix inc/dec ops now go through the same guard (`check_readonly_for_incdec`, generalized from `check_readonly_for_increment` to carry the operator name for an accurate message).

### 2. A bare `@array` argument no longer auto-flattens

```raku
sub f($x, $y, $z) { … }
f(@a)    # before: bound a,b,c; Rakudo: "Too few positionals" error
f(|@a)   # flattens (explicit slip) — unchanged
```

A bare `@array` is a **single** positional in Raku. The single-argument-rule flattening in `bind_sub_signature` no longer expands a non-itemized `Value::Array`; explicit slips still arrive as `Value::Slip` and flatten as before.

## Result

- `roast/integration/advent2009-day09.t` → **17/17**, whitelisted.
- Adds `t/readonly-param-and-no-autoflatten.t` (12 cases).
- `make test` green; signature/binding + list/array roast whitelist subsets (~293 files) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)