### PR TITLE
fix(supply): batch(:seconds) buckets by absolute time periods; de-flake audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Executes compiled bytecode. `vm.rs` holds the (unified `Interpreter`) struct, `r
   8. **Watch the new PR's CI in the background, never foreground-block on it.** Use a `run_in_background` bash poll loop on `gh pr checks <pr-number>` that exits when no check is `pending` (the harness notifies you on completion). Do NOT use foreground `gh pr checks --watch` — it blocks ~13 min and wastes the session. The background watch surfaces a red CI within minutes so you can fix-forward instead of leaving it unnoticed; auto-merge still lands the PR on its own once CI is green. If you have genuinely-independent, non-conflicting work, do it in parallel; in the final stretch there usually isn't any, so the watch itself is the productive thing.
   9. **Before going idle, decide the next slice.** Don't wait on the merge with nothing queued. Re-read the relevant ledger/PLAN (`PLAN.md`, `TODO_roast/BLOCKERS.md`) and pick the next concrete unit of work — start it on a fresh branch off `main` if it's independent of the open PR, or lay out options and confirm with the user when the next step is a strategic fork.
 - If CI fails, fix on the same branch and push again (the background watch notifies you; re-watch after pushing).
-  - **Known flaky:** `roast/S02-names-vars/perl.t` intermittently exits 255 with `Failed: 0` (plan incomplete) — the typed-container alloc/hash-order flaky documented in PLAN.md. Passes ~80% of runs. If CI fails *only* on this with `Failed: 0`, re-trigger CI (push an empty commit) rather than treating it as a regression; confirm locally with a release build a few times first.
+  - **Flaky-looking CI failures:** consult the "Known flaky tests" section below before re-triggering. (`roast/S02-names-vars/perl.t`'s historical `Failed: 0` abort no longer reproduces as of 2026-07-05 and was re-whitelisted — treat a new failure there as real first, per the triage protocol.)
 - **Never close a PR without preserving its knowledge.** If a PR has rebase conflicts, rebase it (manually or with an agent that reads the PR diff via `gh pr diff <number>`). The PR diff itself is the best documentation of the change — do not just close it and write a summary. Reopen and fix it, or have a new agent read the diff and re-implement on a fresh branch.
 - Write all documents, code comments, and commit messages in English.
 - Do not use `echo`, `cat`, `printf`, or heredoc via Bash to create files. Always use the Write tool.
@@ -298,9 +298,14 @@ The strategy is fixed in [docs/adr/0001-gc-strategy-and-phasing.md](docs/adr/000
 
 Some tests are genuinely non-deterministic (concurrency/timing/CI-load sensitive) and fail intermittently. When a `make roast` / `make test` failure is **only** in the list below and your change is unrelated (e.g. an operator/parser fix), treat it as flaky: re-run the single file a few times before assuming a regression. Do **not** remove it from the whitelist.
 
-- `roast/S17-supply/batch.t` and other `S17-supply/*` / `S17-*` concurrency tests — fail occasionally, pass on retry.
-- `t/lock.t` — lock contention / occasional `exit 255` timeout.
-- `roast/S02-types/hash.t`, `roast/S09-typed-arrays/hashes.t` — CI-load-sensitive **timeouts** (bad plan / `exit 255` with `Failed: 0`); pass reliably locally. A *concrete subtest* failure here is NOT load-related — see triage below.
+- `S17-*` concurrency tests — may fail occasionally under heavy parallel load, pass on retry. (A 2026-07-05 audit ran all 97 whitelisted S17 files ×7 `-j4` release sweeps: the only repeat offender was `batch.t`, root-caused and fixed — see below.)
+
+**De-flaked (do NOT treat a failure here as flaky — it's a regression):**
+
+- `t/lock.t` "Lock::Async protects shared array pushes" — was a real lost-update race (listop `push` inside `protect` wrote the base shared_vars key, which a parent-thread stale env sync clobbered wholesale). Fixed in #4167 by routing all plain-lexical shared-array pushes through the `__mutsu_atomic_arr::` store.
+- `roast/S17-supply/batch.t` "we can batch by time and elems" — was a deterministic logic bug, not load flakiness: `batch(:seconds)` anchored its time window to tap-registration `Instant` instead of absolute `time div $seconds` periods, firing a spurious 1-element flush when the tap was registered just after a period boundary. Pin: `t/supply-batch-period.t` (forces the boundary alignment).
+- `roast/S02-names-vars/perl.t` — the historical "typed-container alloc/hash-order" mid-run abort no longer reproduces (2026-07-05: 72 clean runs, debug+release, under 12× CPU contention); re-whitelisted.
+- `roast/S02-types/hash.t`, `roast/S09-typed-arrays/hashes.t` — the "CI-load-sensitive timeout" label is stale: both complete in ~0.3s on a release build now. A failure here is real — see triage below.
 
 Also: before a local `make roast`, `rm -f temp-file-RT-126006-test` — a stale temp file left by an interrupted `roast/S32-io/spurt.t` makes that test abort with "cannot run test while file ... exists".
 

--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -145,14 +145,13 @@
   - 0/? pass. Parse error at line 46
 - [ ] roast/S02-names-vars/names.t
   - 0/? pass. Parse error at line 10
-- [ ] roast/S02-names-vars/perl.t
-    - Removed from roast-whitelist.txt: intermittently bails early ("Bad plan. You
-      planned 114 tests but ran 100", exit 255) ~15-40% of prove runs. All tests that
-      run pass (no `not ok`); the script stops after a nondeterministic point (around
-      the EVAL-in-grep / Buf blocks, tests 101+). Likely the typed-container alloc /
-      hash-order flaky. Direct `mutsu perl.t` runs are 114/114 and deterministic, so
-      the nondeterminism only surfaces under prove. Re-add once the underlying
-      nondeterminism is fixed.
+- [x] roast/S02-names-vars/perl.t (114/114, WHITELISTED)
+    - Re-added 2026-07-05: the historical intermittent early bail ("Bad plan ...
+      ran 100", exit 255, ~15-40% of prove runs; blamed on the typed-container
+      alloc / hash-order flaky) no longer reproduces — 72 consecutive clean
+      prove runs (48 debug + 24 release) under 12x CPU contention. Likely fixed
+      incidentally by the single-store / container campaigns. If it bails again
+      in CI, treat it as a real regression to bisect, not as flaky.
 - [ ] roast/S02-names-vars/signature.t
   - 0/? pass. Parse error at line 10
 - [ ] roast/S02-names-vars/variables-and-packages.t

--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -186,15 +186,20 @@
 - [ ] roast/S17-scheduler/times.t
 - [ ] roast/S17-supply/act.t
 - [ ] roast/S17-supply/basic.t
-- [x] roast/S17-supply/batch.t — **9/9, re-whitelisted (2026-07-01).**
-  - Verified 4/4 clean via `prove -e target/debug/mutsu` (isolation, ~40s each).
-  - Note: mutsu's batch flushing is **emit-driven** (a time-window's leftover
-    values flush when the *next* emit arrives with `last_flush.elapsed() >=
-    seconds`, or on `done`). This MATCHES real Rakudo — a `batch(:seconds)`
-    probe on `raku` also flushes only on the next emit / on `done`, NOT on a
-    background timer. (The earlier "proper fix = timer-driven" note was a
-    misdiagnosis; raku is emit-driven too.) The previous 2026-06-03 removal was
-    for intermittent boundary flakes under heavy parallel `make roast` load.
+- [x] roast/S17-supply/batch.t — **9/9, re-whitelisted (2026-07-01); boundary flake root-caused and fixed (2026-07-05).**
+  - Note: mutsu's batch flushing is **emit-driven** (leftover values flush when
+    the next emit arrives in a new time period, or on `done`). This MATCHES
+    real Rakudo — a `batch(:seconds)` probe on `raku` also flushes only on the
+    next emit / on `done`, NOT on a background timer. (The earlier "proper fix
+    = timer-driven" note was a misdiagnosis; raku is emit-driven too.)
+  - The "intermittent boundary flake under heavy parallel load" (2026-06-03
+    removal; still ~1-in-6 `-j4` release sweeps as of 2026-07-05) was a
+    **deterministic logic bug**, not load noise: the time window was anchored
+    to tap-registration `Instant` (`last_flush.elapsed() >= seconds`), so a tap
+    registered just after a period boundary fired a spurious 1-element flush
+    on the second emit (mutsu emitted batches `1,7,2,7,3` where raku emits
+    `7,3,7,3`). Fixed by bucketing on absolute `time div $seconds` periods
+    (rakudo semantics). Deterministic pin: `t/supply-batch-period.t`.
 - [x] roast/S17-supply/categorize.t (whitelisted) — added the missing
     `Supply.categorize` instance method (multi-key mapper; a value may go to
     several buckets or none), a `Supply.classify`/`.categorize` class-method

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -99,6 +99,7 @@ roast/S02-magicals/subname.t
 roast/S02-names-vars/contextual.t
 roast/S02-names-vars/fmt.t
 roast/S02-names-vars/list_array_perl.t
+roast/S02-names-vars/perl.t
 roast/S02-names-vars/signature.t
 roast/S02-names-vars/varnames.t
 roast/S02-names/SETTING-6e.t

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -123,8 +123,31 @@ struct BatchState {
     buffer: Vec<Value>,
     /// The downstream supplier_id to emit batched lists into
     downstream_supplier_id: u64,
-    /// Timestamp of last flush (for timer-based batching)
-    last_flush: std::time::Instant,
+    /// Absolute wall-clock period (`time div :seconds`, rakudo semantics) of
+    /// the most recent emit. A value arriving in a *different* period flushes
+    /// the pending buffer first. Anchoring to absolute periods (not "elapsed
+    /// since last flush / tap registration") matters: the old
+    /// registration-anchored `Instant` fired a spurious 1-element time-flush
+    /// on the second emit whenever the tap was registered just after a period
+    /// boundary (S17-supply/batch.t "batch by time and elems" flake —
+    /// deterministic repro in that shape, raku emits 7,3,7,3, mutsu emitted
+    /// 1,7,2,7,3).
+    last_period: i64,
+}
+
+/// Absolute wall-clock period index for `batch(:seconds)`: `floor(epoch /
+/// seconds)`, matching rakudo's `time div $seconds` bucketing for integer
+/// seconds.
+fn batch_time_period(seconds: f64) -> i64 {
+    let epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    if seconds > 0.0 {
+        (epoch / seconds).floor() as i64
+    } else {
+        0
+    }
 }
 
 #[derive(Clone, Default)]
@@ -760,18 +783,21 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                     ));
                 }
             } else if let Some(ref mut bs) = tap.batch_state {
-                // Check if we should flush the existing buffer based on time
-                if let Some(seconds) = bs.seconds
-                    && bs.last_flush.elapsed().as_secs_f64() >= seconds
-                    && !bs.buffer.is_empty()
-                {
-                    let batch = std::mem::take(&mut bs.buffer);
-                    let dsid = bs.downstream_supplier_id;
-                    bs.last_flush = std::time::Instant::now();
-                    actions.push(SupplierEmitAction::BatchEmit {
-                        downstream_supplier_id: dsid,
-                        batch,
-                    });
+                // A value arriving in a new absolute time period flushes the
+                // previous period's pending buffer first (rakudo `time div
+                // $seconds` semantics; see BatchState::last_period).
+                if let Some(seconds) = bs.seconds {
+                    let this_period = batch_time_period(seconds);
+                    if this_period != bs.last_period {
+                        if !bs.buffer.is_empty() {
+                            let batch = std::mem::take(&mut bs.buffer);
+                            actions.push(SupplierEmitAction::BatchEmit {
+                                downstream_supplier_id: bs.downstream_supplier_id,
+                                batch,
+                            });
+                        }
+                        bs.last_period = this_period;
+                    }
                 }
                 bs.buffer.push(emitted_value.clone());
                 // Check if we should flush based on elems count
@@ -780,7 +806,6 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                 {
                     let batch = std::mem::take(&mut bs.buffer);
                     let dsid = bs.downstream_supplier_id;
-                    bs.last_flush = std::time::Instant::now();
                     actions.push(SupplierEmitAction::BatchEmit {
                         downstream_supplier_id: dsid,
                         batch,
@@ -1370,7 +1395,7 @@ pub(in crate::runtime) fn register_supplier_batch_tap(
                     seconds,
                     buffer: Vec::new(),
                     downstream_supplier_id,
-                    last_flush: std::time::Instant::now(),
+                    last_period: seconds.map(batch_time_period).unwrap_or(0),
                 }),
                 words_mode: false,
                 words_buffer: String::new(),

--- a/t/supply-batch-period.t
+++ b/t/supply-batch-period.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Supply.batch(:seconds) must bucket by absolute wall-clock period
+# (rakudo's `time div $seconds`), not by elapsed time since tap
+# registration / last flush. The registration-anchored variant fired a
+# spurious 1-element time-flush on the second emit whenever the tap was
+# registered just after a period boundary — the intermittent
+# S17-supply/batch.t "we can batch by time and elems" failure. This test
+# forces that boundary alignment, making the old bug deterministic.
+
+plan 2;
+
+my $seconds = 2;
+my $elems   = 7;
+my $spurt   = 10;
+
+sleep $seconds - now % $seconds;   # land just after a period boundary
+my $s = Supplier.new;
+my $b = $s.Supply.batch( :$elems, :$seconds );   # register at boundary+eps
+sleep $seconds - now % $seconds;   # ~full period until the next boundary
+my $base = time div $seconds;
+
+my @res;
+my $done;
+$b.tap({ @res.push($_) }, :done({ $done = True }));
+$s.emit( time div $seconds ) for ^$spurt;
+sleep $seconds;
+$s.emit( time div $seconds ) for ^$spurt;
+$s.done;
+for ^100 { last if $done; sleep .1 }
+
+is @res.map(*.elems).join(","), "7,3,7,3",
+    'batch(:elems, :seconds) splits on elems and period boundaries only';
+is-deeply @res,
+    [($base xx $elems).List, ($base xx $spurt - $elems).List,
+     ($base+1 xx $elems).List, ($base+1 xx $spurt - $elems).List],
+    'batched values match their emission periods';


### PR DESCRIPTION
## Summary

Root-causes and fixes the last live entry in CLAUDE.md's known-flaky list: **roast/S17-supply/batch.t `we can batch by time and elems`** (~1-in-6 `-j4` release sweeps failed).

## Root cause — a deterministic logic bug, not load noise

`BatchState` anchored its time window to the **tap-registration `Instant`** (`last_flush.elapsed() >= seconds`, reset only on flush). A tap registered just after a wall-clock period boundary — which the roast test's `sleep $seconds - now % $seconds` alignment makes likely under load — saw `elapsed >= seconds` already at the **second emit** of the first spurt and fired a spurious 1-element flush: mutsu emitted batches `1,7,2,7,3` where raku emits `7,3,7,3`. A boundary-aligned standalone repro triggers the old behavior **3/3 deterministically** and matches raku after the fix.

## Fix

Bucket by **absolute wall-clock period** (`floor(epoch / seconds)` — rakudo's `time div $seconds` semantics). A value arriving in a new period flushes the pending buffer first; elems-triggered flushes no longer touch the time anchor. Pin: `t/supply-batch-period.t` (forces the boundary alignment that made the old anchor misfire; verified against real raku).

## Also: 2026-07-05 flaky-list audit

- **`roast/S02-names-vars/perl.t` re-whitelisted** (+1 → whitelist 1352): the historical "typed-container alloc/hash-order" mid-run abort no longer reproduces — 72 clean prove runs (48 debug + 24 release) under 12× CPU contention.
- **CLAUDE.md known-flaky list rewritten**: `t/lock.t` (#4167) and `batch.t` moved to a "de-flaked — treat failures as regressions" section; stale `hash.t`/`hashes.t` "CI-load timeout" entries dropped (both complete in ~0.3 s on release now).
- TODO_roast/S02.md and S17.md updated with the findings.

## Verification (release build)

- S17 whitelist sweep (97 files, `-j4`) ×3: PASS (pre-fix baseline: 1-in-6 sweeps failed on batch.t)
- batch.t ×8 concurrent: PASS
- Lock::Async push stress ×80: all ok (validates #4167 on release too)
- perl.t ×12 concurrent: PASS
- `make test`: 1480 files / 14275 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK