### PR TITLE
fix(str): uniprop Bidi_Class separators, terminators and RTL punctuation

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -186,18 +186,46 @@ pub(crate) fn unicode_bidi_class(ch: char) -> String {
         | 0x0660..=0x0669            // Arabic-Indic digits
         | 0x066B..=0x066C            // Arabic decimal/thousands separator
         | 0x06DD                     // Arabic end of ayah
-        | 0x08E2 => "AN",            // Arabic disputed end of ayah
-        // Arabic tatweel is script=Common (not Arabic) but Bidi_Class=AL.
-        0x0640 => "AL",
+        | 0x08E2                     // Arabic disputed end of ayah
+        | 0x10D30..=0x10D39          // Hanifi Rohingya digits
+        | 0x10E60..=0x10E7E => "AN", // Rumi numeral symbols
+        // Arabic tatweel, letter marks, and the Common-script Arabic
+        // punctuation (semicolon, question mark) have Bidi_Class=AL even though
+        // their script is Common rather than Arabic.
+        0x0640 | 0x061C | 0x070F | 0x061B | 0x061F => "AL",
+        // Segment_Separator
+        0x0009 | 0x000B | 0x001F => "S",
+        // Form feed and line separator are Whitespace.
+        0x000C => "WS",
+        // European_Separator (plus/minus signs)
+        0x002B | 0x002D | 0x207A..=0x207B | 0x208A..=0x208B | 0x2212 | 0xFB29 | 0xFE62..=0xFE63
+        | 0xFF0B | 0xFF0D => "ES",
+        // Common_Separator (comma, dot, slash, colon, NBSP, ...)
+        0x002C | 0x002E..=0x002F | 0x003A | 0x00A0 | 0x060C | 0x202F | 0x2044 | 0xFE50 | 0xFE52
+        | 0xFE55 | 0xFF0C | 0xFF0E..=0xFF0F | 0xFF1A => "CS",
+        // European_Terminator (currency, percent, degree, ...)
+        0x0023..=0x0025 | 0x00A2..=0x00A5 | 0x00B0..=0x00B1 | 0x058F | 0x0609..=0x060A | 0x066A
+        | 0x09F2..=0x09F3 | 0x09FB | 0x0AF1 | 0x0BF9 | 0x0E3F | 0x17DB | 0x2030..=0x2034
+        | 0x20A0..=0x20BF | 0x212E | 0x2213 | 0xA838..=0xA839 | 0xFE5F | 0xFE69..=0xFE6A
+        | 0xFF03..=0xFF05 | 0xFFE0..=0xFFE1 | 0xFFE5..=0xFFE6 | 0x11FDD..=0x11FE0
+        | 0x1E2FF => "ET",
         _ => {
             // Use General Category heuristics
             let gc = crate::builtins::unicode::unicode_general_category(ch);
             match gc.as_str() {
                 "Lu" | "Ll" | "Lt" | "Lm" | "Lo" => bidi_letter_class(ch),
                 "Nd" | "Nl" | "No" => "L",
-                "Mn" | "Me" | "Cf" => "NSM",
+                "Mn" | "Me" => "NSM",
+                "Cf" => "BN",
+                // Punctuation in a right-to-left script (e.g. Arabic/Hebrew
+                // punctuation) inherits the script direction (AL / R). Other
+                // punctuation and symbols follow the general default below —
+                // Bidi_Class=ON for neutral symbols is per-codepoint in the UCD
+                // and is not derivable from General_Category alone.
+                "Ps" | "Pe" | "Pi" | "Pf" | "Po" | "Pc" | "Pd" => bidi_letter_class(ch),
                 "Zs" => "WS",
-                "Zl" | "Zp" => "B",
+                "Zl" => "WS",
+                "Zp" => "B",
                 "Cc" => {
                     if cp <= 0x001F || (0x007F..=0x009F).contains(&cp) {
                         if cp == 0x000A

--- a/t/uniprop-bidi-class-separators.t
+++ b/t/uniprop-bidi-class-separators.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Bidi_Class of separators, terminators, format controls and right-to-left
+# script punctuation. mutsu previously returned L / NSM for most of these.
+
+plan 26;
+
+# European_Separator (ES): plus / minus
+is '+'.uniprop('Bidi_Class'), 'ES', 'plus is ES';
+is '-'.uniprop('Bidi_Class'), 'ES', 'hyphen-minus is ES';
+is "\x2212".uniprop('Bidi_Class'), 'ES', 'minus sign is ES';
+
+# Common_Separator (CS): comma, dot, slash, colon, NBSP
+is ','.uniprop('Bidi_Class'), 'CS', 'comma is CS';
+is '.'.uniprop('Bidi_Class'), 'CS', 'full stop is CS';
+is '/'.uniprop('Bidi_Class'), 'CS', 'solidus is CS';
+is ':'.uniprop('Bidi_Class'), 'CS', 'colon is CS';
+is "\xA0".uniprop('Bidi_Class'), 'CS', 'NBSP is CS';
+
+# European_Terminator (ET): currency, percent, degree
+is '$'.uniprop('Bidi_Class'), 'ET', 'dollar is ET';
+is '%'.uniprop('Bidi_Class'), 'ET', 'percent is ET';
+is '#'.uniprop('Bidi_Class'), 'ET', 'number sign is ET';
+is "\xB0".uniprop('Bidi_Class'), 'ET', 'degree sign is ET';
+is "\x20AC".uniprop('Bidi_Class'), 'ET', 'euro sign is ET';
+
+# Segment_Separator (S) and Whitespace
+is "\t".uniprop('Bidi_Class'), 'S', 'tab is S';
+is "\x000B".uniprop('Bidi_Class'), 'S', 'vertical tab is S';
+is "\x000C".uniprop('Bidi_Class'), 'WS', 'form feed is WS';
+is "\x2028".uniprop('Bidi_Class'), 'WS', 'line separator is WS';
+is "\x2029".uniprop('Bidi_Class'), 'B', 'paragraph separator is B';
+
+# Boundary_Neutral (BN): format controls
+is "\xAD".uniprop('Bidi_Class'), 'BN', 'soft hyphen is BN';
+is "\x200B".uniprop('Bidi_Class'), 'BN', 'ZWSP is BN';
+is "\x061C".uniprop('Bidi_Class'), 'AL', 'Arabic letter mark is AL';
+
+# Arabic_Number (AN): Rumi numeral symbols
+is "\x10E60".uniprop('Bidi_Class'), 'AN', 'Rumi digit one is AN';
+
+# Right-to-left script punctuation inherits the script direction
+is "\x061F".uniprop('Bidi_Class'), 'AL', 'Arabic question mark is AL';
+is "\x060C".uniprop('Bidi_Class'), 'CS', 'Arabic comma is CS';
+is "\x05C3".uniprop('Bidi_Class'), 'R', 'Hebrew sof pasuq is R';
+is "\x05BE".uniprop('Bidi_Class'), 'R', 'Hebrew maqaf is R';


### PR DESCRIPTION
## Summary

Follow-up to #4169. Extends the `Bidi_Class` General_Category fallback (which only produced `L`/`NSM`/`WS`/`B`) with the classes determined by specific codepoints or by script direction:

| class | examples |
|-------|----------|
| **ES** European_Separator | `+` `-` `−`, super/subscript & fullwidth signs |
| **CS** Common_Separator | `,` `.` `/` `:` NBSP, Arabic comma |
| **ET** European_Terminator | `$` `%` `#` `°` `€`, currency, per-mille |
| **S** Segment_Separator | tab, vertical tab, unit separator |
| **BN** Boundary_Neutral | format controls (`gc=Cf`), previously mis-tagged `NSM` |
| **AN** | + Hanifi Rohingya digits, Rumi numeral symbols |
| **AL/R** | RTL-script **punctuation** inherits script direction (Arabic/Hebrew punctuation, plus Common-script `U+061B/061C/061F/0640/070F`) |

Form feed and line separator (`Zl`) corrected to `WS`.

The `ES/CS/ET/S/AN` sets are enumerated from the authoritative UCD values (verified against `raku`). Neutral symbols (`Bidi_Class=ON`) are a per-codepoint UCD table with no clean General_Category rule (a blanket `P*→ON` mis-tags ~3700 script-punctuation/Braille/enclosed chars that are `L`), so they are left for a follow-up.

## Test
- New `t/uniprop-bidi-class-separators.t` (26 assertions).
- Over a full BMP+SMP sweep, divergence from `raku` drops **6900 → 6650** with **no regressions** (every changed codepoint matches raku; remaining diffs are the unimplemented `ON` neutrals and UCD data-version differences).
- `make test` passes (14416 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)