### PR TITLE
fix(io): custom $*OUT/$*ERR .print accumulates across say/print/put/note

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1298,6 +1298,7 @@ roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t
 roast/integration/advent2009-day17.t
 roast/integration/advent2009-day19.t
+roast/integration/advent2009-day21.t
 roast/integration/advent2009-day22.t
 roast/integration/advent2010-day06.t
 roast/integration/advent2010-day08.t

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -126,12 +126,22 @@ impl Interpreter {
             } else {
                 text.to_string()
             };
+            // A user `$*OUT`/`$*ERR` handle's `print` method can mutate a
+            // captured-outer caller lexical (the classic output-capture idiom:
+            // `my $out; my $*OUT = class { method print(*@a) { $out ~= @a.join } }`).
+            // This internal dispatch has no surrounding `CallMethod` op to drain
+            // the writeback, so across successive `say`/`print` calls the earlier
+            // mutations were lost (only the last write survived). Reconcile the
+            // caller frame afterwards so the accumulation persists (Slice F).
+            let caller_code = self.current_code;
             if self
                 .call_method_with_values(handle, "print", vec![Value::str(payload.clone())])
                 .is_ok()
             {
+                self.reconcile_caller_after_internal_dispatch(caller_code);
                 return Ok(());
             }
+            self.reconcile_caller_after_internal_dispatch(caller_code);
             if name == "$*ERR" {
                 self.output_sink_mut().stderr_output.push_str(&payload);
             }

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -450,7 +450,7 @@ impl Interpreter {
     /// BUILD frame), so the outer `.new` drain finds nothing and the caller's slot
     /// stays stale. Retaining the miss leaves it for the frame that actually owns
     /// the slot.
-    pub(super) fn reconcile_caller_after_internal_dispatch(&mut self, caller_code: usize) {
+    pub(crate) fn reconcile_caller_after_internal_dispatch(&mut self, caller_code: usize) {
         self.current_code = caller_code;
         if caller_code == 0 {
             return;

--- a/t/custom-out-print-accumulation.t
+++ b/t/custom-out-print-accumulation.t
@@ -1,0 +1,68 @@
+use Test;
+
+# The output-capture idiom binds `$*OUT` (or `$*ERR`) to an object whose
+# `print` method appends to a captured outer lexical, then reads that lexical
+# after some `say`/`print`/`put` calls. Successive writes must ACCUMULATE — the
+# internal dispatch to the handle's `print` had no surrounding CallMethod op to
+# drain the captured-lexical writeback, so earlier writes were lost and only the
+# last survived. (Same-frame capture; a capture across a passed code block is a
+# deeper multi-frame case, still open.)
+
+plan 5;
+
+# --- say accumulates through a custom $*OUT ---
+{
+    my $out = "";
+    {
+        my $*OUT = class { method print(*@a) { $out ~= @a.join } }
+        say "a";
+        say "b";
+        say "c";
+    }
+    is $out, "a\nb\nc\n", 'say accumulates through a custom $*OUT.print';
+}
+
+# --- print (no newline) accumulates ---
+{
+    my $out = "";
+    {
+        my $*OUT = class { method print(*@a) { $out ~= @a.join } }
+        print "x";
+        print "y";
+    }
+    is $out, "xy", 'print accumulates through a custom $*OUT.print';
+}
+
+# --- put accumulates ---
+{
+    my $out = "";
+    {
+        my $*OUT = class { method print(*@a) { $out ~= @a.join } }
+        put "1";
+        put "2";
+    }
+    is $out, "1\n2\n", 'put accumulates through a custom $*OUT.print';
+}
+
+# --- note accumulates through a custom $*ERR ---
+{
+    my $err = "";
+    {
+        my $*ERR = class { method print(*@a) { $err ~= @a.join } }
+        note "e1";
+        note "e2";
+    }
+    is $err, "e1\ne2\n", 'note accumulates through a custom $*ERR.print';
+}
+
+# --- capture inside a sub (same frame as the say calls) accumulates ---
+{
+    sub cap() {
+        my $o = "";
+        my $*OUT = class { method print(*@a) { $o ~= @a.join } }
+        say "p";
+        say "q";
+        return $o;
+    }
+    is cap(), "p\nq\n", 'capture within a sub accumulates';
+}


### PR DESCRIPTION
## What

The output-capture idiom binds `$*OUT` (or `$*ERR`) to an object whose `print` method appends to a captured outer lexical, then reads it after some output:

```raku
my $out = "";
my $*OUT = class { method print(*@a) { $out ~= @a.join } }
say "a"; say "b";
# before: $out was "b\n" — only the LAST write survived
# after:  $out is "a\nb\n"
```

## Fix

`say`/`print`/`put`/`note` route through `write_to_named_handle`, which invokes the handle's `print` via `call_method_with_values`. That internal dispatch has no surrounding `CallMethod` op to drain the method's captured-lexical writeback, so each call restarted from the original `$out` and earlier appends were lost. This reconciles the caller frame after the internal `print` dispatch (Slice F) — the same mechanism already used after internal `.Numeric`/`.Str`/`.gist` coercion dispatches.

## Scope

Covers **same-frame** capture (the lexical and the `say`/`print` calls share a frame). A capture **across a passed code block** — `capture-said({ … })`, where `say` runs several frames below the captured lexical — is a deeper multi-frame closure-writeback case that remains open.

## Result

- Adds `t/custom-out-print-accumulation.t` (5 cases: say/print/put/note + in-sub).
- Whitelists `roast/integration/advent2009-day21.t` (a passing output-capture integration test).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)