### PR TITLE
fix(str): uniprop Decomposition_Type of Arabic presentation forms

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -240,6 +240,22 @@ pub(crate) fn unicode_decomposition_type(ch: char) -> String {
     "None".to_string()
 }
 
+/// Positional form (Isolated / Final / Initial / Medial) of an Arabic
+/// presentation-form character, read from its Unicode name suffix.
+fn arabic_presentation_form_type(ch: char) -> String {
+    let name = crate::builtins::unicode::unicode_char_name(ch);
+    if name.ends_with("INITIAL FORM") {
+        "Initial".to_string()
+    } else if name.ends_with("MEDIAL FORM") {
+        "Medial".to_string()
+    } else if name.ends_with("FINAL FORM") {
+        "Final".to_string()
+    } else {
+        // Isolated forms and everything else in these blocks.
+        "Isolated".to_string()
+    }
+}
+
 fn compatibility_decomposition_type(ch: char) -> String {
     let cp = ch as u32;
     // Heuristic mapping based on common compatibility decomposition types
@@ -253,11 +269,12 @@ fn compatibility_decomposition_type(ch: char) -> String {
         0x2460..=0x24FF => "Circle".to_string(), // Enclosed alphanumerics
         0x3300..=0x33FF => "Square".to_string(), // CJK compat
         0xFB00..=0xFB06 => "Compat".to_string(), // Latin ligatures
-        0xFB50..=0xFDFF => "Isolated".to_string(), // Arabic pres forms
+        // Arabic presentation forms: the specific positional form (Isolated /
+        // Final / Initial / Medial) is encoded in the character name.
+        0xFB50..=0xFDFF | 0xFE70..=0xFEFF => arabic_presentation_form_type(ch),
         0xFE30..=0xFE4F => "Vertical".to_string(), // CJK compat forms
-        0xFE70..=0xFEFF => "Isolated".to_string(), // Arabic pres forms B
-        0xFF01..=0xFF5E => "Wide".to_string(),   // Fullwidth
-        0xFF61..=0xFFDC => "Narrow".to_string(), // Halfwidth
+        0xFF01..=0xFF5E => "Wide".to_string(),     // Fullwidth
+        0xFF61..=0xFFDC => "Narrow".to_string(),   // Halfwidth
         0xFFE0..=0xFFE6 => "Wide".to_string(),
         0xFFE8..=0xFFEE => "Narrow".to_string(),
         _ => "Compat".to_string(),

--- a/t/uniprop-decomposition-type-arabic.t
+++ b/t/uniprop-decomposition-type-arabic.t
@@ -1,0 +1,31 @@
+use Test;
+
+# Decomposition_Type of Arabic presentation forms encodes the positional
+# form (Isolated / Final / Initial / Medial). mutsu previously reported
+# every character in these blocks as Isolated.
+
+plan 14;
+
+# Arabic Presentation Forms-B (FE70-FEFF): BEH forms
+is "\xFE8F".uniprop('Decomposition_Type'), 'Isolated', 'BEH isolated is Isolated';
+is "\xFE90".uniprop('Decomposition_Type'), 'Final', 'BEH final is Final';
+is "\xFE91".uniprop('Decomposition_Type'), 'Initial', 'BEH initial is Initial';
+is "\xFE92".uniprop('Decomposition_Type'), 'Medial', 'BEH medial is Medial';
+
+# ALEF (only isolated/final)
+is "\xFE8D".uniprop('Decomposition_Type'), 'Isolated', 'ALEF isolated is Isolated';
+is "\xFE8E".uniprop('Decomposition_Type'), 'Final', 'ALEF final is Final';
+
+# LAM (four forms)
+is "\xFEDD".uniprop('Decomposition_Type'), 'Isolated', 'LAM isolated is Isolated';
+is "\xFEDE".uniprop('Decomposition_Type'), 'Final', 'LAM final is Final';
+is "\xFEDF".uniprop('Decomposition_Type'), 'Initial', 'LAM initial is Initial';
+is "\xFEE0".uniprop('Decomposition_Type'), 'Medial', 'LAM medial is Medial';
+
+# Arabic Presentation Forms-A (FB50-FDFF): ligatures are Isolated
+is "\xFB50".uniprop('Decomposition_Type'), 'Isolated', 'ALEF WASLA isolated is Isolated';
+is "\xFDF2".uniprop('Decomposition_Type'), 'Isolated', 'ALLAH ligature is Isolated';
+
+# A form with an initial variant in Forms-A
+is "\xFB54".uniprop('Decomposition_Type'), 'Initial', 'BEEH initial is Initial';
+is "\xFB55".uniprop('Decomposition_Type'), 'Medial', 'BEEH medial is Medial';


### PR DESCRIPTION
## Summary

`compatibility_decomposition_type()` reported every character in the Arabic Presentation Forms-A (`U+FB50..U+FDFF`) and Forms-B (`U+FE70..U+FEFF`) blocks as `Isolated`, but each carries a specific positional form.

```
"\xFE90".uniprop('Decomposition_Type')   # Isolated -> Final    (BEH final form)
"\xFE91".uniprop('Decomposition_Type')   # Isolated -> Initial  (BEH initial form)
"\xFE92".uniprop('Decomposition_Type')   # Isolated -> Medial   (BEH medial form)
```

The positional form is encoded in the character name (`... INITIAL FORM` / `... MEDIAL FORM` / `... FINAL FORM`, otherwise Isolated), so it is read from the existing name table — **no new data required**.

## Test
- New `t/uniprop-decomposition-type-arabic.t` (14 assertions, all cross-checked against `raku`).
- Over a full sweep of the compatibility-decomposition ranges, divergence from `raku` drops **715 → 223** (the remainder are other compatibility types — Font/Small/Super/Sub — still handled by the existing range heuristic, left for a follow-up).
- `make test` passes (14444 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)