### PR TITLE
fix(str): uniprop Decomposition_Type of Number Forms and subscripts

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -290,10 +290,14 @@ fn compatibility_decomposition_type(ch: char) -> String {
     match cp {
         0x00A0 => "Nobreak".to_string(),                 // NO-BREAK SPACE
         0x00B2 | 0x00B3 | 0x00B9 => "Super".to_string(), // Superscripts
+        0x00BC..=0x00BE => "Fraction".to_string(),       // vulgar fractions
         0x2070..=0x207E => "Super".to_string(),
-        0x2080..=0x208E => "Sub".to_string(),
+        0x2080..=0x209C => "Sub".to_string(), // subscripts + Latin subscript letters
         0x2100..=0x214F => "Compat".to_string(), // Letterlike symbols
-        0x2150..=0x218F => "Fraction".to_string(), // Number forms
+        // Number Forms: vulgar fractions, then Roman numerals (Compat).
+        0x2150..=0x215F => "Fraction".to_string(),
+        0x2160..=0x2188 => "Compat".to_string(), // Roman numerals
+        0x2189 => "Fraction".to_string(),
         0x2460..=0x24FF => "Circle".to_string(), // Enclosed alphanumerics
         0x3300..=0x33FF => "Square".to_string(), // CJK compat
         0xFB00..=0xFB06 => "Compat".to_string(), // Latin ligatures

--- a/t/uniprop-decomposition-type-number-forms.t
+++ b/t/uniprop-decomposition-type-number-forms.t
@@ -1,0 +1,32 @@
+use Test;
+
+# Decomposition_Type of Number Forms and related compatibility characters.
+# mutsu previously classified the whole U+2150..U+218F block as Fraction
+# (so Roman numerals were wrong) and missed the Latin subscript letters and
+# the Latin-1 vulgar fractions.
+
+plan 16;
+
+# Vulgar fractions
+is '¼'.uniprop('Decomposition_Type'), 'Fraction', 'one quarter is Fraction';
+is '½'.uniprop('Decomposition_Type'), 'Fraction', 'one half is Fraction';
+is '¾'.uniprop('Decomposition_Type'), 'Fraction', 'three quarters is Fraction';
+is "\x2153".uniprop('Decomposition_Type'), 'Fraction', 'one third is Fraction';
+is "\x215F".uniprop('Decomposition_Type'), 'Fraction', 'numerator one is Fraction';
+is "\x2189".uniprop('Decomposition_Type'), 'Fraction', 'zero thirds is Fraction';
+
+# Roman numerals are Compat, not Fraction
+is "\x2160".uniprop('Decomposition_Type'), 'Compat', 'Roman numeral one is Compat';
+is "\x216C".uniprop('Decomposition_Type'), 'Compat', 'Roman numeral fifty is Compat';
+is "\x2170".uniprop('Decomposition_Type'), 'Compat', 'small roman numeral one is Compat';
+is "\x217F".uniprop('Decomposition_Type'), 'Compat', 'small roman numeral M is Compat';
+
+# Latin subscript letters
+is "\x2090".uniprop('Decomposition_Type'), 'Sub', 'subscript a is Sub';
+is "\x2095".uniprop('Decomposition_Type'), 'Sub', 'subscript h is Sub';
+is "\x209C".uniprop('Decomposition_Type'), 'Sub', 'subscript t is Sub';
+
+# Subscript digits still Sub, superscripts still Super
+is "\x2080".uniprop('Decomposition_Type'), 'Sub', 'subscript zero is Sub';
+is "\x2070".uniprop('Decomposition_Type'), 'Super', 'superscript zero is Super';
+is '²'.uniprop('Decomposition_Type'), 'Super', 'superscript two is Super';


### PR DESCRIPTION
## Summary

Follow-up to #4174. `compatibility_decomposition_type()` tagged the whole `U+2150..U+218F` Number Forms block as `Fraction`, so the **Roman numerals** (`U+2160..U+2188`) were reported as `Fraction` instead of `Compat`. It also missed the Latin-1 vulgar fractions and the Latin subscript letters.

```
"\x2160".uniprop('Decomposition_Type')   # Fraction -> Compat    (Roman numeral one)
'¼'.uniprop('Decomposition_Type')        # Compat   -> Fraction
"\x2090".uniprop('Decomposition_Type')   # Compat   -> Sub        (subscript a)
```

Corrected ranges:
- `U+00BC..U+00BE` → Fraction (vulgar fractions)
- `U+2080..U+209C` → Sub (subscript digits/signs + Latin subscript letters)
- `U+2150..U+215F`, `U+2189` → Fraction; `U+2160..U+2188` → Compat (Roman numerals)

## Test
- New `t/uniprop-decomposition-type-number-forms.t` (16 assertions, cross-checked against `raku`).
- Combined with #4174, the full compatibility-decomposition sweep drops **715 → 175** diffs (the remainder are Font/Small/Super compatibility tags that need per-codepoint UCD data, left for a follow-up).
- `make test` passes (14444 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)