### PR TITLE
fix(gather): slipping a gather runs its body; lazy gather stays lazy until eager

### DIFF
--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -619,6 +619,26 @@ impl Interpreter {
     fn dispatch_eager_method(&mut self, target: Value) -> Result<Value, RuntimeError> {
         match target {
             Value::LazyList(list) => Ok(Value::array(self.force_lazy_list_bridge(&list)?)),
+            Value::Array(ref items, kind)
+                if items.iter().any(|v| matches!(v, Value::LazyList(_))) =>
+            {
+                // `.eager` reifies a lazy TAIL preserved inside the array (a
+                // `|(lazy gather …)` slipped into `@a` sits as a `LazyList`
+                // element). Force each such element so its deferred body/side
+                // effects run now, flattening the produced values in place.
+                let mut out = Vec::with_capacity(items.len());
+                for it in items.iter() {
+                    if let Value::LazyList(ll) = it {
+                        out.extend(self.force_lazy_list_bridge(ll)?);
+                    } else {
+                        out.push(it.clone());
+                    }
+                }
+                Ok(Value::Array(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(out)),
+                    kind,
+                ))
+            }
             Value::Array(..) | Value::Seq(..) | Value::Slip(..) => Ok(target),
             Value::Range(..)
             | Value::RangeExcl(..)

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -37,7 +37,7 @@ impl Interpreter {
         pulled
     }
 
-    pub(super) fn exec_make_slip_op(&mut self) {
+    pub(super) fn exec_make_slip_op(&mut self) -> Result<(), RuntimeError> {
         let val = self.stack.pop().unwrap();
         // Slipping (`|EXPR`) always flattens through containers/itemization, e.g.
         // `|$_` where the topic is an itemized Seq element must expand the Seq's
@@ -51,7 +51,27 @@ impl Interpreter {
         {
             let pulled = self.materialize_deferred_seq(items_arc);
             self.stack.push(Value::slip(pulled));
-            return;
+            return Ok(());
+        }
+        // A `gather`-sourced `LazyList` slipped with `|` must run its body: a
+        // plain `gather` is FORCED now (side effects included) and yields its
+        // taken values; the `match` arm below only read the still-empty cache, so
+        // `|(gather { $x++; take … })` slipped nothing and never ran `$x++`. An
+        // explicitly-`lazy` gather (`|(lazy gather …)`) stays lazy so its side
+        // effects fire only on later reification (`@a.eager`) — pushing the
+        // `LazyList` value itself preserves that deferred tail. Non-gather lazy
+        // lists (infinite `scan_spec`/`sequence_spec` reductions like
+        // `|[\+] 1..*`) fall through to the `match` arm's bounded force.
+        if let Value::LazyList(ll) = &val
+            && ll.is_from_gather()
+        {
+            if ll.is_genuinely_lazy() {
+                self.stack.push(Value::slip(vec![val.clone()]));
+            } else {
+                let pulled = self.force_lazy_list_vm(ll)?;
+                self.stack.push(Value::slip(pulled));
+            }
+            return Ok(());
         }
         let items = match &val {
             Value::Array(items, ..) => (*items).to_vec(),
@@ -87,6 +107,7 @@ impl Interpreter {
             _ => vec![val],
         };
         self.stack.push(Value::slip(items));
+        Ok(())
     }
 
     pub(super) fn exec_not_op(&mut self) {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1410,7 +1410,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::MakeSlip => {
-                self.exec_make_slip_op();
+                self.exec_make_slip_op()?;
                 *ip += 1;
             }
             OpCode::Decont => {

--- a/t/slip-gather-side-effects.t
+++ b/t/slip-gather-side-effects.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Slipping a `gather` with `|` must run the gather's body (side effects and all)
+# and yield the taken values — reading its still-empty cache made
+# `|(gather { … })` slip nothing and skip the side effects. An explicitly-`lazy`
+# gather stays lazy: its body runs only on later reification (`.eager`).
+
+plan 8;
+
+# --- a plain gather is forced when slipped: values AND side effects ---
+{
+    my $ran = 0;
+    my @a = |(gather { $ran++; take 5; take 6 });
+    is @a.elems, 2, 'slip of a plain gather yields its taken values';
+    is @a[1], 6, 'slipped gather values are correct';
+    is $ran, 1, 'the plain gather body ran (side effect fired)';
+}
+
+# --- a slipped gather with no take still runs its side effect ---
+{
+    my $ran = 0;
+    my @a = |(gather { $ran++ }), 1;
+    is-deeply @a, [1], 'empty gather slips nothing';
+    is $ran, 1, 'the empty gather body still ran';
+}
+
+# --- an explicitly-lazy gather is NOT forced by the slip ---
+{
+    my $marker = 0;
+    my @a = |(gather { $marker++ }), 1, |(lazy gather { $marker++ });
+    is $marker, 1, 'only the non-lazy gather reified on assignment';
+    @a.eager;
+    is $marker, 2, 'eagerizing reifies the preserved lazy gather tail';
+}
+
+# --- an infinite scan reduction slipped with | still reifies on demand ---
+{
+    my \d = 0, |[\+] 1..*;
+    is d[5], 15, 'prefix | on an infinite scan reduction reifies on index';
+}


### PR DESCRIPTION
## What

`|(gather { … })` read the gather's still-empty cache instead of forcing it, so the slip yielded no values and the body's side effects never ran:

```raku
my $ran = 0;
my @a = |(gather { $ran++; take 5 });
# before: @a was [], $ran was 0
# after:  @a is [5], $ran is 1
```

## Fix

In `exec_make_slip_op` (prefix `|`), a `gather`-sourced `LazyList` is now handled explicitly:

- A **plain** `gather` is FORCED via the VM (`force_lazy_list_vm`) so its body runs and its taken values are slipped.
- An explicitly-**`lazy`** gather (`|(lazy gather …)`) stays lazy — the `LazyList` value is preserved as a slip element so its side effects fire only on later reification. `dispatch_eager_method` now reifies such a preserved `LazyList` tail inside an array, so `@a.eager` runs it.
- **Non-gather** lazy lists (infinite `scan_spec`/`sequence_spec` reductions such as `|[\+] 1..*`) are unchanged — they fall through to the existing bounded force.

`exec_make_slip_op` becomes fallible (a forced gather body may throw).

## Result

- Adds `t/slip-gather-side-effects.t` (8 cases).
- Fixes 2 of the 4 failing assertions in `roast/S02-types/array.t`'s "no funny business in assignment" subtest (the other two — symbolic `@::Pkg::('name')` lookup and an `Empty, $_`/`push` container-identity case — are separate, still open, so that file is not yet whitelisted).
- `make test` + gather/lazy/reduce roast whitelist subset stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)