### PR TITLE
feat(gc): DESTROY-on-reclaim via Trace::finalize + dead sweep; promote gc-stress t/ to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,14 +179,14 @@ jobs:
     # future work.
     #
     # BLOCKING gates: `cargo test` (the collector unit tests + the gc_stress
-    # integration tests, which assert no verify violations) and the final
-    # "No GC verify violations" step (any `VERIFY FAIL` in the suite = heap
-    # corruption). The `prove t/` and roast steps are `continue-on-error`: they
-    # RUN the whole suite under GC=on (their purpose is to feed real programs to
-    # the collector so the verify step can catch corruption), but they are not
-    # gated on pass/fail — a few tests fail under GC=on on *semantics* the
-    # collector does not yet implement (e.g. `DESTROY`-on-reclaim), which is a
-    # known gap, not corruption. Promote them to blocking once those close.
+    # integration tests, which assert no verify violations), the `prove t/`
+    # step (the whole t/ suite passes under GC=on since the
+    # DESTROY-on-reclaim / dead-sweep slice — a failure is a real GC
+    # regression), and the final "No GC verify violations" step (any
+    # `VERIFY FAIL` in the suite = heap corruption). The roast step remains
+    # `continue-on-error` for one observation cycle (S17 timing tests under
+    # the ~2x GC=on slowdown may be load-sensitive); promote it once it has
+    # stayed green.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -222,12 +222,11 @@ jobs:
         run: cargo build
 
       - name: TAP tests (prove t/, GC on)
-        # Advisory: runs the whole t/ suite under GC on to feed the collector.
-        # Not gated on pass/fail (see job comment); the verify step below is the
-        # hard gate. `|| true` keeps the log tee from failing the step.
-        continue-on-error: true
+        # BLOCKING since the DESTROY-on-reclaim / dead-sweep slice: the whole
+        # t/ suite passes under GC=on, so a failure here is a real GC
+        # regression (semantics or soundness), not a known gap.
         run: |
-          set +e
+          set -o pipefail
           mkdir -p tmp
           prove --merge -e 'timeout 60 target/debug/mutsu' t/ 2>&1 | tee tmp/gc-stress-t.log
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -154,23 +154,26 @@ HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny（end-to-end HTTP 配信）/ Tu
 実装順序は [docs/gc-level1-detailed-design.md](docs/gc-level1-detailed-design.md) §11。
 **完了分**（詳細は news/2026-07.md）: §11 step 1〜4（root/child visitor・`MUTSU_VM_STATS` GC カウンタ・
 `Gc<T>`/node header/candidate buffer）/ step 5 first wave（`Hash`/`Array`/`ContainerRef` の `Arc→Gc`、
-`Set`/`Bag`/`Mix` #4117、dead 化した `arc_contents_mut` 削除）/ step 9 second wave（`Sub`/`Instance`
-attributes #4123、`WeakSub`=`WeakGc`）/ step 8 trial-deletion collector 本体＋safepoint 配線
-（GC-on 出力が GC-off と byte 一致・`tests/gc_stress.rs`）/ `gc_trace` wrapper 完全性 /
-`WeakGc<T>` 仕上げ（循環ブレイクを unit test で実証）/ cross-thread 安全化（minimal STW #4130）/
+`Set`/`Bag`/`Mix` #4117、dead 化した `arc_contents_mut` 削除）/ **step 6-7（`Promise`/`Channel` の Gc 化＋
+supply registry root visitor #4127）** / step 8 trial-deletion collector 本体＋safepoint 配線
+（GC-on 出力が GC-off と byte 一致・`tests/gc_stress.rs`）/ step 9 second wave（`Sub`/`Instance`
+attributes #4123、`WeakSub`=`WeakGc`）/ **step 10（`LazyList` third wave #4125）** / `gc_trace` wrapper
+完全性（#4124/#4134/#4135）/ `WeakGc<T>` 仕上げ / cross-thread 安全化（minimal STW #4130）/
 `make_mut`/`get_mut` uniqueness の `header.strong` 基準化 / デバッグ運用（`MUTSU_GC_LOG`/`MUTSU_GC_VERIFY`）/
-CI `gc-stress` ジョブ。
+CI `gc-stress` ジョブ / **`DESTROY`-on-reclaim（`Trace::finalize` フック＝refcount 死・cycle reclaim の
+両方で発火、Rust `Drop` から分離）＋ dead sweep（strong=0 candidate は trial deletion を経ずに
+worker 稼働中でも解放＝threaded 変異ループの unbounded 蓄積と数秒 pause を解消、pause_max 2.8s→16ms）＋
+inner dispatch（`run_range`）backedge safepoint**。
 
 残:
 
-- [ ] **§11 step 6-7: `Promise`/`Channel` → supply registry root visitor（async cycle）← 次はここ**
-      （設計メモ参照）。
-- [ ] §11 step 10-11: `LazyList`（third wave・最後の Arc コンテナ）。
-- [ ] cross-thread **full STW**（現状は single-threaded 区間限定の collect）。
-- [ ] `DESTROY`-on-reclaim（CI gc-stress の advisory 落ちの主因）。
+- [ ] **CI gc-stress の advisory → blocking 昇格**: `prove t/` は本スライスで全 green（昇格済み）。
+      roast は 1 サイクル advisory で観察後に昇格。
+- [ ] cross-thread **full STW**（現状: dead sweep は並行安全・trial deletion のみ worker join 後に遅延）。
+- [ ] §11 step 11: OS resource 主体 async registry の `Value` edge 追従（必要に応じて）。
 - [ ] call/return/await 等の追加 safepoint 種別・`MUTSU_GC_AT`/random stress。
-- [ ] 未決: 収集方式（同期/非同期）と A' 地ならし（レキシカルスコープ／upvalue index 化）の範囲
-      （ADR-0001 §4.2/§4.3）。
+- [ ] デフォルト GC=on のトリガ方針（現状 automatic trigger 無指定だと program-end collect のみ）と
+      収集方式（同期/非同期）・A' 地ならしの範囲（ADR-0001 §4.2/§4.3）。
 - **Track B（要素 cell 化）と GC は統合キャンペーン（層3a）**。続いて NaN-boxing（層3b・JIT 地ならし）
   → JIT（層4）。`state @`/`%`・lexical aggregate の真共有（Track C 残）も Track B=層3a に依存。
 

--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -49,7 +49,9 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use super::gc_ptr::{CollectGuard, Color, ErasedGc, drain_candidates, erased_id, gc_drop_edges};
+use super::gc_ptr::{
+    CollectGuard, Color, ErasedGc, drain_candidates, erased_id, gc_drop_edges, gc_finalize,
+};
 use crate::vm::vm_stats::record_gc_collection;
 
 /// Outcome of one [`collect_cycles`] run.
@@ -143,6 +145,21 @@ fn collect_white(node: &ErasedGc, out: &mut Vec<ErasedGc>, seen: &mut HashSet<us
 /// counts / re-buffer — see `Gc`'s `Drop`). The `white` handles are dropped
 /// while the guard is still held, so any value-drop cascade is inert too.
 fn reclaim(white: Vec<ErasedGc>, roots: Vec<ErasedGc>) {
+    // Value-level finalizers (Raku DESTROY queueing) run FIRST, while every
+    // node's attributes/edges are still intact — `drop_gc_edges` below would
+    // hand a DESTROY submethod a cleared object. Deliberately OUTSIDE the
+    // CollectGuard: an Instance finalizer snapshots its attribute map, and the
+    // `Value` clones in that snapshot take real strong references that keep the
+    // DESTROY handler's arguments alive past this reclaim (a fellow cycle
+    // member referenced from the snapshot survives — possibly with its own
+    // edges cleared, which matches Raku's "destruction order within a cycle is
+    // unspecified"). Runs after `verify_reclaimed_are_garbage` (the caller's
+    // ordering), since these snapshot clones legitimately raise child strong
+    // counts. Safepoint collects run on the interpreter thread, so the queued
+    // DESTROYs drain at this thread's next drain point.
+    for node in &white {
+        gc_finalize(node);
+    }
     let _guard = CollectGuard::new();
     for node in &white {
         gc_drop_edges(node);
@@ -277,22 +294,68 @@ fn verify_survivors(cycle: u64, survivors: &[(ErasedGc, usize)]) -> usize {
 /// Safe to call at any time: with no candidates buffered it is a no-op. Returns
 /// what it reclaimed and records the same into `MUTSU_VM_STATS`.
 pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
+    let start = Instant::now();
+    let drained = drain_candidates();
+    if drained.is_empty() {
+        return CollectStats::default();
+    }
+    // Partition off nodes whose GC-visible strong count already hit 0: they
+    // died a plain refcount death after being buffered, and only the buffer's
+    // retained handle keeps their allocation alive. They are not cycle
+    // suspects — trial deletion needs live handles to trial-decrement — so run
+    // their value-level finalizer (Raku DESTROY, attributes still intact) and
+    // drop them directly. Skipping mark/scan for these is the difference
+    // between O(live suspects) and O(every dead container snapshot) per
+    // collect: a mutation-heavy loop (e.g. a `cas %h{..}` loop COWing the hash
+    // per iteration) buffers thousands of soon-dead snapshots, which made a
+    // single collect pause for seconds (S17-lowlevel/thread.t under GC=on).
+    // Dropping them here cascades normally (children decrement / buffer /
+    // finalize through `Gc::drop` — no CollectGuard is active).
+    //
+    // This dead sweep is safe even while worker threads mutate the graph: it
+    // only performs ordinary atomic refcount operations (`Arc` drop cascades),
+    // never the trial-deletion bookkeeping. Without it, a threaded
+    // mutation-heavy program deferred EVERY release to one giant post-join
+    // collect and grew memory unboundedly in the meantime (page-fault churn
+    // dominated the profile).
+    let (dead, suspects): (Vec<ErasedGc>, Vec<ErasedGc>) =
+        drained.into_iter().partition(|n| n.gc_strong() == 0);
+    let dead_count = dead.len();
+    if log_mode() == LogMode::Trace {
+        for node in &dead {
+            eprintln!("[mutsu gc] reclaim dead id={}", erased_id(node));
+        }
+    }
+    for node in &dead {
+        gc_finalize(node);
+    }
+    drop(dead);
+
     // Trial deletion is not safe against concurrent mutation: it decrements and
     // restores strong counts, so a worker thread cloning/dropping a `Gc` (or
     // CAS-swapping a pointer) mid-collect corrupts the bookkeeping and can free
     // a still-live node (design doc §13.3 — cross-thread STW is deferred). Until
-    // that lands, decline to collect while any worker thread is active. The
-    // candidates stay buffered (we return before draining) and are reclaimed at
-    // the next safepoint once the threads have joined: reclaim is deferred,
-    // never unsound.
+    // that lands, decline the cycle scan while any worker thread is active: the
+    // suspects go back into the buffer and are scanned at the next safepoint
+    // once the threads have joined. Reclaim is deferred, never unsound.
     if crate::gc::mutator_workers_active() {
-        return CollectStats::default();
+        crate::gc::gc_ptr::requeue_candidates(suspects);
+        if dead_count > 0 {
+            let pause_ns = start.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
+            record_gc_collection(0, dead_count as u64, 0, pause_ns);
+            if log_mode() != LogMode::Off {
+                eprintln!(
+                    "[mutsu gc] dead-sweep reason={reason} dead={dead_count} (cycle scan deferred: workers active)"
+                );
+            }
+        }
+        return CollectStats {
+            roots_scanned: 0,
+            reclaimed_nodes: dead_count,
+            reclaimed_cycles: 0,
+        };
     }
-    let start = Instant::now();
-    let roots = drain_candidates();
-    if roots.is_empty() {
-        return CollectStats::default();
-    }
+    let roots = suspects;
     let roots_scanned = roots.len();
     let mode = log_mode();
     let verify = verify_enabled();
@@ -303,7 +366,10 @@ pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
     };
 
     if mode != LogMode::Off {
-        eprintln!("[mutsu gc] start cycle={cycle} reason={reason} candidates={roots_scanned}");
+        eprintln!(
+            "[mutsu gc] start cycle={cycle} reason={reason} candidates={} dead={dead_count} suspects={roots_scanned}",
+            roots_scanned + dead_count
+        );
     }
 
     // Pristine snapshot for verify, before trial-deletion mutates strong counts.
@@ -324,7 +390,9 @@ pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
             cycles += 1;
         }
     }
-    let reclaimed_nodes = white.len();
+    // Reclaimed = cycle garbage plus the already-dead candidates dropped above
+    // (both are memory the GC pass released; only the former counts as cycles).
+    let reclaimed_nodes = white.len() + dead_count;
 
     // Keep only survivor snapshot handles across reclaim; dropping the garbage
     // handles here lets `reclaim` actually free the white nodes.

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -96,6 +96,25 @@ pub(crate) trait Trace: Send + Sync {
     /// not-yet-migrated nodes have no `Gc` edges); container nodes override it to
     /// clear their `Value`-holding collections.
     fn drop_gc_edges(&mut self) {}
+
+    /// Run this node's *value-level* finalizer (Raku `DESTROY` queueing), once
+    /// per node death. Decouples language-level finalization from Rust `Drop`:
+    /// with GC on, a node's memory drop can be arbitrarily deferred by the
+    /// candidate buffer's retained handle, so waiting for `Drop` would delay
+    /// (or, for a short program, entirely skip) `DESTROY`.
+    ///
+    /// Called from exactly two places, both on an interpreter thread:
+    /// - `Gc::drop`, when the *last live handle* goes away (GC on; the memory
+    ///   may live on in the candidate buffer) — the prompt refcount-death path.
+    /// - the collector's reclaim pass, on proven cycle garbage, BEFORE
+    ///   `drop_gc_edges` clears the node (so a `DESTROY` submethod still sees
+    ///   the attributes).
+    ///
+    /// Implementations must be idempotent (guard with an internal once-flag):
+    /// the eventual Rust `Drop` of the value typically funnels into the same
+    /// logic for the GC-off path. The default does nothing (only `Instance`
+    /// attributes carry a Raku destructor).
+    fn finalize(&self) {}
 }
 
 /// Bacon-Rajan node header stored alongside the value inside a [`GcBox`].
@@ -433,8 +452,18 @@ impl<T: Trace + 'static> Drop for Gc<T> {
         // be reachable only through a cycle that outlives every stack root —
         // record it as a candidate. `prev == 1`: this was the last handle; the
         // `Arc` frees the allocation once its own count reaches zero.
-        if prev > 1 && gc_enabled() {
-            buffer_candidate(self.inner.clone());
+        if gc_enabled() {
+            if prev > 1 {
+                buffer_candidate(self.inner.clone());
+            } else {
+                // Last live handle. The allocation may outlive this drop in the
+                // candidate buffer, deferring the value's Rust `Drop` (and with
+                // it any `Drop`-coupled Raku `DESTROY`) until some future
+                // collect — or forever, in a program too short to trigger one.
+                // Run the value-level finalizer NOW, on the dropping
+                // (interpreter) thread, exactly when refcount death occurs.
+                self.inner.value.finalize();
+            }
         }
     }
 }
@@ -589,6 +618,24 @@ pub(crate) fn drain_candidates() -> Vec<ErasedGc> {
     drained
 }
 
+/// Put still-suspect candidates back into the buffer (the collector drained
+/// them but declined trial deletion — e.g. worker threads were active). Skips
+/// any node a concurrent `Gc::drop` re-buffered since the drain (its `buffered`
+/// flag is already set), so the buffer never holds duplicates.
+pub(crate) fn requeue_candidates(nodes: Vec<ErasedGc>) {
+    if nodes.is_empty() {
+        return;
+    }
+    if let Ok(mut buf) = candidate_buffer().lock() {
+        for node in nodes {
+            if node.header.buffered.swap(true, Ordering::Relaxed) {
+                continue;
+            }
+            buf.push(node);
+        }
+    }
+}
+
 // ---- Collector-facing internals (used by `gc::collect`) --------------------
 
 /// Set while the collector is dropping a garbage node's edges, so `Gc::drop`
@@ -670,6 +717,12 @@ pub(crate) fn gc_drop_edges(node: &ErasedGc) {
     // SAFETY: as above. `Arc::as_ptr` yields the box's genuine heap pointer.
     let boxed = Arc::as_ptr(node) as *mut GcBox<dyn Trace>;
     unsafe { (*boxed).value.drop_gc_edges() };
+}
+
+/// Run a type-erased node's value-level finalizer (see [`Trace::finalize`]).
+/// Shared-reference access — no aliasing concerns.
+pub(crate) fn gc_finalize(node: &ErasedGc) {
+    node.value.finalize();
 }
 
 /// Whether GC candidate registration is active. `off`/unset (the default) makes

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -1,19 +1,6 @@
 use super::*;
 
 impl Interpreter {
-    /// Whether this interpreter is (currently) the only one sharing its
-    /// `shared_vars` — i.e. no `start`/`Promise`/`hyper`/`race` worker is live.
-    ///
-    /// `clone_for_thread` hands each worker an `Arc::clone` of `shared_vars`, so
-    /// a strong count of 1 means execution is single-threaded again. The GC
-    /// safepoint uses this to skip a collect while workers might be mutating a
-    /// shared `Gc` container concurrently (cross-thread cooperative STW is not
-    /// implemented yet — design doc §6). Conservative in the safe direction: a
-    /// transient extra `Arc` clone only *skips* a collect, never runs one racily.
-    pub(crate) fn gc_single_threaded(&self) -> bool {
-        Arc::strong_count(&self.shared_vars) == 1
-    }
-
     /// Create a lightweight clone of this interpreter for use in a spawned thread.
     /// Shares function/class/role/enum definitions but starts with fresh output and test state.
     /// Array (`@`) and scalar (`$`) variables are shared between parent and child via `shared_vars`

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -416,6 +416,11 @@ pub(crate) struct InstanceAttrs {
     attributes: AttrCell,
     id: u64,
     queue_destroy: bool,
+    /// Once-guard for DESTROY queueing: `Trace::finalize` (GC-on refcount
+    /// death / cycle reclaim) and Rust `Drop` (GC-off, and the eventual memory
+    /// drop of a GC node) funnel into the same `finalize_destroy`; whichever
+    /// runs first wins and the other becomes a no-op.
+    finalized: std::sync::atomic::AtomicBool,
 }
 
 /// Type constraints for typed scalar `ContainerRef` cells, keyed by the cell's

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -288,6 +288,12 @@ impl Trace for InstanceAttrs {
     fn drop_gc_edges(&mut self) {
         self.clear_gc_edges();
     }
+    /// Queue the Raku `DESTROY` at node death (last-live-handle drop or cycle
+    /// reclaim) instead of waiting for the memory drop, which the candidate
+    /// buffer can defer indefinitely (t/destroy.t under `MUTSU_GC=on`).
+    fn finalize(&self) {
+        self.finalize_destroy();
+    }
 }
 
 /// The QuantHash datas hold `Value`s only in their `original_keys` back-map

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -65,6 +65,7 @@ impl Clone for InstanceAttrs {
             attributes: Arc::new(RwLock::new(read_attrs(&self.attributes).clone())),
             id: self.id,
             queue_destroy: false,
+            finalized: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -85,6 +86,7 @@ impl InstanceAttrs {
             attributes: cell,
             id,
             queue_destroy,
+            finalized: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -99,6 +101,7 @@ impl InstanceAttrs {
             attributes: cell,
             id,
             queue_destroy,
+            finalized: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -226,9 +229,21 @@ impl PartialEq for InstanceAttrs {
     }
 }
 
-impl Drop for InstanceAttrs {
-    fn drop(&mut self) {
+impl InstanceAttrs {
+    /// Queue this instance's Raku `DESTROY` (once). Shared by Rust `Drop`
+    /// (GC-off: fires at refcount death; GC-on: fires at the node's eventual
+    /// memory drop) and `Trace::finalize` (GC-on: fires at last-live-handle
+    /// drop or at cycle reclaim, while the attributes are still intact) —
+    /// whichever runs first wins via the `finalized` once-flag, which also
+    /// guards the `live_instance_refcounts` bookkeeping from double-decrement.
+    pub(crate) fn finalize_destroy(&self) {
         if !self.queue_destroy {
+            return;
+        }
+        if self
+            .finalized
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
             return;
         }
         // Suppress recursive DESTROY queuing when we're already inside a DESTROY handler
@@ -259,5 +274,11 @@ impl Drop for InstanceAttrs {
                 attributes: read_attrs(&self.attributes).clone(),
             });
         });
+    }
+}
+
+impl Drop for InstanceAttrs {
+    fn drop(&mut self) {
+        self.finalize_destroy();
     }
 }

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -116,12 +116,15 @@ impl Interpreter {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
             // container borrow, so a cycle collect may run here. Off by default —
             // `gc_safepoints_armed()` is a single cached load unless `MUTSU_GC`
-            // enables an automatic trigger. Gated on single-threaded execution:
-            // worker interpreters (`start`/`Promise`/`hyper`/`race`) hold a clone
-            // of `shared_vars`, so `strong_count > 1` means another thread may be
-            // mutating a shared `Gc` container — collecting then would race
-            // (cross-thread cooperative STW is not implemented yet, design §6).
-            if crate::gc::gc_safepoints_armed() && self.gc_single_threaded() {
+            // enables an automatic trigger. Fires on worker threads too: the
+            // collector itself splits the work by thread-safety — the dead sweep
+            // (refcount-dead candidates, plain `Arc` drops) runs even while other
+            // mutators are live, while the trial-deletion cycle scan defers until
+            // `mutator_workers_active()` clears (cross-thread cooperative STW is
+            // not implemented yet, design §6). Without in-thread sweeps, threaded
+            // mutation-heavy loops grew the candidate buffer — and their dead
+            // snapshots' memory — unboundedly until the post-join collect.
+            if crate::gc::gc_safepoints_armed() {
                 crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
             }
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
@@ -367,12 +370,15 @@ impl Interpreter {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
             // container borrow, so a cycle collect may run here. Off by default —
             // `gc_safepoints_armed()` is a single cached load unless `MUTSU_GC`
-            // enables an automatic trigger. Gated on single-threaded execution:
-            // worker interpreters (`start`/`Promise`/`hyper`/`race`) hold a clone
-            // of `shared_vars`, so `strong_count > 1` means another thread may be
-            // mutating a shared `Gc` container — collecting then would race
-            // (cross-thread cooperative STW is not implemented yet, design §6).
-            if crate::gc::gc_safepoints_armed() && self.gc_single_threaded() {
+            // enables an automatic trigger. Fires on worker threads too: the
+            // collector itself splits the work by thread-safety — the dead sweep
+            // (refcount-dead candidates, plain `Arc` drops) runs even while other
+            // mutators are live, while the trial-deletion cycle scan defers until
+            // `mutator_workers_active()` clears (cross-thread cooperative STW is
+            // not implemented yet, design §6). Without in-thread sweeps, threaded
+            // mutation-heavy loops grew the candidate buffer — and their dead
+            // snapshots' memory — unboundedly until the post-join collect.
+            if crate::gc::gc_safepoints_armed() {
                 crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
             }
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
@@ -516,6 +522,16 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let mut ip = start;
         while ip < end {
+            // GC safepoint on the inner dispatch backedge too: compound-loop
+            // ops (for/while bodies) iterate entirely inside ONE `exec_one` of
+            // the outer `run` loop, so without this a tight loop never reaches
+            // a safepoint and candidate-triggered collects (and the dead sweep
+            // that bounds buffer memory) defer to the loop's end. Same borrow
+            // argument as the outer site: between instructions no container
+            // borrow is live (design doc §1.2).
+            if crate::gc::gc_safepoints_armed() {
+                crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
+            }
             if let Err(e) = self.exec_one(code, &mut ip, compiled_fns) {
                 if e.is_goto()
                     && let Some(label) = e.label.as_deref()

--- a/tests/gc_stress.rs
+++ b/tests/gc_stress.rs
@@ -182,8 +182,12 @@ fn log_modes_emit_expected_lines() {
         ],
     );
     assert!(ok2);
+    // A garbage node is reclaimed either by the cycle scan (`reclaim cycle=`)
+    // or, when its refcount already hit 0 in the buffer, by the dead sweep
+    // (`reclaim dead`) — trace mode logs a per-node line in both cases.
     assert!(
-        trace_err.contains("[mutsu gc] reclaim cycle="),
+        trace_err.contains("[mutsu gc] reclaim cycle=")
+            || trace_err.contains("[mutsu gc] reclaim dead"),
         "trace log missing per-node reclaim lines:\n{trace_err}"
     );
 }
@@ -288,5 +292,137 @@ fn cycles_are_reclaimed_during_execution() {
     assert!(
         reclaimed > 0,
         "expected the collector to reclaim cycle nodes, got reclaimed_nodes={reclaimed}\nstderr:\n{err}"
+    );
+}
+
+/// Raku `DESTROY` must fire under GC=on exactly as it does GC-off. The
+/// candidate buffer's retained handle defers the value's Rust `Drop`
+/// indefinitely, so DESTROY queueing is decoupled from `Drop` into
+/// `Trace::finalize`, which runs at last-live-handle drop (refcount death) and
+/// at cycle reclaim. Regression: t/destroy.t returned `got: []` under
+/// `MUTSU_GC=on` before the finalize hook existed.
+#[test]
+fn destroy_fires_on_refcount_death_under_gc() {
+    let src = r#"
+        my @events;
+        class Foo { submethod DESTROY { @events.push("foo") } }
+        my $foo = Foo.new;
+        $foo = Nil;
+        quietly $*VM.request-garbage-collection;
+        say @events.join(",");
+    "#;
+
+    let (off, _, ok_off) = run(src, &[]);
+    let (on, on_err, ok_on) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_EVERY_CANDIDATE", "64"),
+            ("MUTSU_GC_VERIFY", "1"),
+        ],
+    );
+
+    assert!(ok_off, "GC-off run must succeed");
+    assert!(ok_on, "GC-on run must not crash; stderr:\n{on_err}");
+    assert_eq!(off.trim(), "foo", "GC-off DESTROY baseline");
+    assert_eq!(on.trim(), "foo", "GC-on DESTROY must match GC-off");
+    assert!(
+        !on_err.contains("VERIFY FAIL"),
+        "no soundness violations; stderr:\n{on_err}"
+    );
+}
+
+/// An object kept alive ONLY by a reference cycle gets its DESTROY when the
+/// collector reclaims the cycle — the finalize pass runs before
+/// `drop_gc_edges` clears the attributes, so the submethod still sees them.
+#[test]
+fn destroy_fires_on_cycle_reclaim() {
+    let src = r#"
+        my @events;
+        class Node {
+            has $.name;
+            has $.peer is rw;
+            submethod DESTROY { @events.push($!name) }
+        }
+        sub make-cycle() {
+            my $a = Node.new(name => "a");
+            my $b = Node.new(name => "b");
+            $a.peer = $b;
+            $b.peer = $a;
+        }
+        make-cycle();
+        quietly $*VM.request-garbage-collection;
+        say @events.sort.join(",");
+    "#;
+
+    let (on, on_err, ok_on) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_EVERY_SAFEPOINT", "1"),
+            ("MUTSU_GC_VERIFY", "1"),
+        ],
+    );
+
+    assert!(ok_on, "GC-on run must not crash; stderr:\n{on_err}");
+    assert_eq!(
+        on.trim(),
+        "a,b",
+        "both cycle members' DESTROY must fire at reclaim; stderr:\n{on_err}"
+    );
+    assert!(
+        !on_err.contains("VERIFY FAIL"),
+        "no soundness violations; stderr:\n{on_err}"
+    );
+}
+
+/// While worker threads are live the cycle scan defers (no cross-thread STW),
+/// but the dead sweep must still run at safepoints and bound the candidate
+/// buffer: a threaded mutation-heavy loop must not defer every container
+/// release to one giant post-join collect. Guards both correctness (all cas
+/// increments land) and the pause bound (no multi-second single collect).
+#[test]
+fn dead_sweep_bounds_threaded_mutation_memory() {
+    let src = r#"
+        my %seen;
+        my $times = 400;
+        %seen{^$times} = (0 xx $times);
+        my @t = (1..2).map: { Thread.start({
+            cas %seen{$_}, {.succ} for ^$times;
+        }) };
+        .finish for @t;
+        say "sum=", [+] %seen.values;
+    "#;
+
+    let (on, on_err, ok_on) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_EVERY_CANDIDATE", "64"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+
+    assert!(
+        ok_on,
+        "threaded GC-on run must not crash; stderr:\n{on_err}"
+    );
+    assert_eq!(on.trim(), "sum=800", "every cas increment must land");
+
+    // The dead sweep runs during the loop, so the maximum single pause must
+    // stay far below the giant post-join collect it replaced (which scanned
+    // every dead snapshot: seconds). 500ms is a generous CI-load bound.
+    let pause_max_ns = on_err
+        .lines()
+        .find(|l| l.contains("[mutsu vm-stats] gc:"))
+        .and_then(|l| {
+            l.split_whitespace()
+                .find_map(|tok| tok.strip_prefix("pause_ns_max="))
+        })
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(u64::MAX);
+    assert!(
+        pause_max_ns < 500_000_000,
+        "expected bounded collect pauses with the dead sweep, got pause_ns_max={pause_max_ns}\nstderr:\n{on_err}"
     );
 }


### PR DESCRIPTION
## Summary

GC campaign (Phase B) continuation. §11 steps 6-7/10 had already landed (#4127/#4125), so this slice closes the **GC=on semantic gaps** that kept the CI gc-stress prove/roast steps advisory — centered on the design doc's known gap, **DESTROY-on-reclaim**.

## 1. DESTROY decoupled from Rust `Drop` → `Trace::finalize`

Raku DESTROY queueing lived in `impl Drop for InstanceAttrs`. With GC on, the candidate buffer's retained handle defers a node's memory drop to some future collect — or forever in a short program — so DESTROY never fired (`t/destroy.t` got `[]`; `destruction.t` / `destroy-cross-thread-writeback-coherence.t` hung waiting for it).

New idempotent `Trace::finalize(&self)` hook, run at the two death points on the interpreter thread: `Gc::drop` when the last live handle goes (refcount death — same timing as GC=off), and the collector's reclaim pass on proven cycle garbage **before** `drop_gc_edges` clears the node (a DESTROY submethod still sees its attributes).

## 2. Dead sweep: refcount-dead candidates skip trial deletion

`MUTSU_VM_STATS` showed a threaded cas loop buffering ~24k candidates, of which ~24k were already `strong=0` by collect time; scanning them made **one collect pause 4.9 s** (S17-lowlevel/thread.t timed out under GC=on). Dead candidates aren't cycle suspects: finalize + drop them directly. The sweep is ordinary atomic refcounting, so it runs **even while worker threads are live** — only the trial-deletion cycle scan defers (suspects re-queued) until workers join. This bounds the buffer and its retained dead-snapshot memory (page-fault churn dominated the GC=on profile). `pause_ns_max` on the repro: **2.8 s → 16 ms**.

## 3. Safepoints reach worker threads and compound-loop bodies

The backedge safepoint was gated on `gc_single_threaded()` at the call site (no thread ever collected while workers ran; now handled inside the collector, helper deleted), and was absent from `run_range` — the inner dispatch loop compound for/while ops execute bodies through, so a tight loop never reached a safepoint at all.

## CI

gc-stress `prove t/` step promoted **advisory → BLOCKING** (whole t/ suite passes under the stress config). Roast stays advisory for one observation cycle (S17 timing tests under the ~2× GC=on slowdown), then should be promoted.

## Verification

- cargo test, incl. **3 new gc_stress integration tests**: refcount-death DESTROY (GC-on == GC-off), cycle-reclaim DESTROY with intact attrs, dead-sweep pause bound + threaded cas correctness.
- Full `t/` under GC=on stress (serial, CI-identical): **1487 files PASS**.
- Previously-failing GC=on files (destroy.t, destroy-cross-thread-writeback-coherence.t, deref-bind-value-alias.t, destruction.t, watch.t, then.t, thread.t, lock.t, start.t): all PASS, `VERIFY FAIL`=0.
- `make test` (GC off): 1487 files PASS.
- Perf: fib(25) pinned-core instruction count unchanged vs main (37.41G vs 37.45G).
- PLAN.md §2 updated (steps 6-7/10 marked landed; remaining = full STW, roast promotion, step 11, trigger policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK