### PR TITLE
fix(str): uniprop Decomposition_Type=Font for math alphanumeric symbols

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -301,6 +301,9 @@ fn compatibility_decomposition_type(ch: char) -> String {
         0x2460..=0x24FF => "Circle".to_string(), // Enclosed alphanumerics
         0x3300..=0x33FF => "Square".to_string(), // CJK compat
         0xFB00..=0xFB06 => "Compat".to_string(), // Latin ligatures
+        // Mathematical Alphanumeric Symbols and the segmented (seven-segment)
+        // digits decompose to their ASCII base with a <font> tag.
+        0x1D400..=0x1D7FF | 0x1FBF0..=0x1FBF9 => "Font".to_string(),
         // Arabic presentation forms: the specific positional form (Isolated /
         // Final / Initial / Medial) is encoded in the character name.
         0xFB50..=0xFDFF | 0xFE70..=0xFEFF => arabic_presentation_form_type(ch),

--- a/t/uniprop-decomposition-type-font.t
+++ b/t/uniprop-decomposition-type-font.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Mathematical Alphanumeric Symbols and the segmented (seven-segment) digits
+# decompose to their ASCII base with a <font> tag, so their
+# Decomposition_Type is Font. mutsu previously reported Compat.
+
+plan 12;
+
+# Mathematical Alphanumeric Symbols (U+1D400..U+1D7FF)
+is "\x1D400".uniprop('Decomposition_Type'), 'Font', 'MATH BOLD CAPITAL A is Font';
+is "\x1D41A".uniprop('Decomposition_Type'), 'Font', 'MATH BOLD SMALL A is Font';
+is "\x1D538".uniprop('Decomposition_Type'), 'Font', 'MATH DOUBLE-STRUCK A is Font';
+is "\x1D49C".uniprop('Decomposition_Type'), 'Font', 'MATH SCRIPT CAPITAL A is Font';
+is "\x1D7CE".uniprop('Decomposition_Type'), 'Font', 'MATH BOLD DIGIT ZERO is Font';
+is "\x1D7FF".uniprop('Decomposition_Type'), 'Font', 'MATH MONOSPACE DIGIT NINE is Font';
+
+# Segmented digits (U+1FBF0..U+1FBF9)
+is "\x1FBF0".uniprop('Decomposition_Type'), 'Font', 'SEGMENTED DIGIT ZERO is Font';
+is "\x1FBF9".uniprop('Decomposition_Type'), 'Font', 'SEGMENTED DIGIT NINE is Font';
+
+# Reserved holes in the math block have no decomposition
+is "\x1D455".uniprop('Decomposition_Type'), 'None', 'reserved math codepoint is None';
+
+# Nearby blocks unaffected
+is '½'.uniprop('Decomposition_Type'), 'Fraction', 'vulgar fraction still Fraction';
+is "\x2070".uniprop('Decomposition_Type'), 'Super', 'superscript still Super';
+is 'A'.uniprop('Decomposition_Type'), 'None', 'plain letter is None';


### PR DESCRIPTION
## Summary

The Mathematical Alphanumeric Symbols block (`U+1D400..U+1D7FF`) and the segmented (seven-segment) digits (`U+1FBF0..U+1FBF9`) decompose to their ASCII base with a `<font>` compatibility tag, so their `Decomposition_Type` is `Font`. `compatibility_decomposition_type()` had no arm for these ranges and fell through to `Compat`.

```
"\x1D400".uniprop('Decomposition_Type')   # Compat -> Font   (MATH BOLD CAPITAL A)
"\x1D7CE".uniprop('Decomposition_Type')   # Compat -> Font   (MATH BOLD DIGIT ZERO)
"\x1FBF0".uniprop('Decomposition_Type')   # Compat -> Font   (SEGMENTED DIGIT ZERO)
```

Reserved holes in the math block have no compatibility decomposition and still report `None`.

## Test
- New `t/uniprop-decomposition-type-font.t` (12 assertions, cross-checked against `raku`).
- Verified against `raku`: 996 math-symbol + 10 segmented-digit codepoints now report `Font`.
- `make test` passes (14519 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)