### PR TITLE
fix(str): uniprop Decomposition_Type=Small for CJK Small Form Variants

### DIFF
--- a/src/builtins/uniprop/char_props.rs
+++ b/src/builtins/uniprop/char_props.rs
@@ -305,6 +305,7 @@ fn compatibility_decomposition_type(ch: char) -> String {
         // Final / Initial / Medial) is encoded in the character name.
         0xFB50..=0xFDFF | 0xFE70..=0xFEFF => arabic_presentation_form_type(ch),
         0xFE30..=0xFE4F => "Vertical".to_string(), // CJK compat forms
+        0xFE50..=0xFE6F => "Small".to_string(),    // Small Form Variants
         0xFF01..=0xFF5E => "Wide".to_string(),     // Fullwidth
         0xFF61..=0xFFDC => "Narrow".to_string(),   // Halfwidth
         0xFFE0..=0xFFE6 => "Wide".to_string(),

--- a/t/uniprop-decomposition-type-small.t
+++ b/t/uniprop-decomposition-type-small.t
@@ -1,0 +1,20 @@
+use Test;
+
+# The CJK Small Form Variants block (U+FE50..U+FE6F) decomposes with a
+# <small> compatibility tag, so its Decomposition_Type is Small. mutsu
+# previously fell through to Compat.
+
+plan 8;
+
+is "\xFE50".uniprop('Decomposition_Type'), 'Small', 'SMALL COMMA is Small';
+is "\xFE52".uniprop('Decomposition_Type'), 'Small', 'SMALL FULL STOP is Small';
+is "\xFE54".uniprop('Decomposition_Type'), 'Small', 'SMALL SEMICOLON is Small';
+is "\xFE5F".uniprop('Decomposition_Type'), 'Small', 'SMALL NUMBER SIGN is Small';
+is "\xFE6B".uniprop('Decomposition_Type'), 'Small', 'SMALL COMMERCIAL AT is Small';
+
+# Reserved holes in the block have no decomposition
+is "\xFE6F".uniprop('Decomposition_Type'), 'None', 'reserved codepoint is None';
+
+# Neighbouring CJK compat vertical forms are unaffected
+is "\xFE30".uniprop('Decomposition_Type'), 'Vertical', 'vertical two dot leader is Vertical';
+is "\xFF01".uniprop('Decomposition_Type'), 'Wide', 'fullwidth exclamation is Wide';


### PR DESCRIPTION
## Summary

The CJK Small Form Variants block (`U+FE50..U+FE6F`) decomposes to its base punctuation with a `<small>` compatibility tag, so its `Decomposition_Type` is `Small`. `compatibility_decomposition_type()` had no arm for the block and fell through to `Compat`.

```
"\xFE50".uniprop('Decomposition_Type')   # Compat -> Small   (SMALL COMMA)
"\xFE6B".uniprop('Decomposition_Type')   # Compat -> Small   (SMALL COMMERCIAL AT)
```

Reserved holes in the block still report `None`.

## Test
- New `t/uniprop-decomposition-type-small.t` (8 assertions, cross-checked against `raku`).
- Verified against `raku`: 26 codepoints now report `Small`.
- `make test` passes (14523 tests); `roast/S15-unicode-information/uniprop.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)