### PR TITLE
fix(decl): an inline `my @a = expr` re-assigns a fresh container each evaluation

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -61,19 +61,36 @@ impl Compiler {
                     self.code.emit(OpCode::StateVarInit(slot, key_idx));
                     self.code.emit(OpCode::GetLocal(slot));
                 } else if name.starts_with('@') || name.starts_with('%') {
+                    // A container decl WITH an explicit initializer (`my @o = $x`)
+                    // must RE-ASSIGN on every evaluation, so `(my @o = $x)` in a
+                    // loop yields the current `$x` rather than a value frozen at
+                    // the first iteration. A BARE container decl (`my @a`) keeps
+                    // the "initialize once per declaration site" behavior (via the
+                    // `__do_decl_init` marker), so repeated evaluation reuses the
+                    // current lexical value instead of resetting it.
+                    let has_initializer =
+                        custom_traits.iter().any(|(t, _)| t == "__has_initializer");
                     let marker_name = format!(
                         "__do_decl_init_{}",
                         STATE_COUNTER.fetch_add(1, Ordering::Relaxed)
                     );
                     let marker_slot = self.alloc_local(&marker_name);
-                    // Container declarations in expression position (`my @a`) should
-                    // initialize once per declaration site and then keep using the
-                    // current lexical value on repeated evaluation (e.g. in loops).
-                    self.code.emit(OpCode::GetLocal(marker_slot));
-                    let jump_have_value = self.code.emit(OpCode::JumpIfNotNil(0));
-                    self.code.emit(OpCode::Pop);
+                    let jump_have_value = if has_initializer {
+                        None
+                    } else {
+                        self.code.emit(OpCode::GetLocal(marker_slot));
+                        let j = self.code.emit(OpCode::JumpIfNotNil(0));
+                        self.code.emit(OpCode::Pop);
+                        Some(j)
+                    };
                     self.compile_expr(expr);
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
+                    // Mark a fresh declaration so SetGlobal creates a NEW container
+                    // (not an in-place reuse of the previous evaluation's), keeping
+                    // `push @a2, my @o = $_` iterations independent.
+                    if has_initializer {
+                        self.code.emit(OpCode::MarkVarDeclContext);
+                    }
                     self.code.emit(OpCode::SetGlobal(name_idx));
                     // Apply an `is default(...)` trait BEFORE reading the value back,
                     // so the container's embedded default travels with the value
@@ -159,18 +176,24 @@ impl Compiler {
                     } else {
                         self.code.emit(OpCode::GetHashVar(name_idx2));
                     }
-                    self.code.emit(OpCode::Dup);
-                    self.code.emit(OpCode::SetLocal(marker_slot));
-                    let jump_end = self.code.emit(OpCode::Jump(0));
-                    self.code.patch_jump(jump_have_value);
-                    self.code.emit(OpCode::Pop);
-                    let name_idx = self.code.add_constant(Value::str(name.clone()));
-                    if name.starts_with('@') {
-                        self.code.emit(OpCode::GetArrayVar(name_idx));
-                    } else {
-                        self.code.emit(OpCode::GetHashVar(name_idx));
+                    if let Some(jump_have_value) = jump_have_value {
+                        // Bare-decl path: cache the value in the marker so a later
+                        // evaluation reuses it instead of re-initializing.
+                        self.code.emit(OpCode::Dup);
+                        self.code.emit(OpCode::SetLocal(marker_slot));
+                        let jump_end = self.code.emit(OpCode::Jump(0));
+                        self.code.patch_jump(jump_have_value);
+                        self.code.emit(OpCode::Pop);
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        if name.starts_with('@') {
+                            self.code.emit(OpCode::GetArrayVar(name_idx));
+                        } else {
+                            self.code.emit(OpCode::GetHashVar(name_idx));
+                        }
+                        self.code.patch_jump(jump_end);
                     }
-                    self.code.patch_jump(jump_end);
+                    // With an initializer, the freshly re-assigned value read back
+                    // above is already the result — no marker branch needed.
                 } else {
                     // For `our` redeclarations with no initializer (expr is Nil),
                     // load the existing package variable value instead of Nil.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1133,9 +1133,29 @@ impl Interpreter {
                 // stable container identity. Gate on the env already holding a
                 // matching container (so a fresh declaration, whose env slot is
                 // absent/Nil, keeps fresh identity) and on a plain assignment.
+                // A `my @a = …` *declaration* reaching SetGlobal in expression
+                // position (`push @a2, my @o = $_`) must NOT reuse the previous
+                // iteration's container — each `my` is a fresh array, so a value
+                // captured by an earlier iteration keeps its own contents.
+                let sg_is_vardecl = self.vardecl_context;
+                self.vardecl_context = false;
+                if sg_is_vardecl
+                    && !is_bind_ctx
+                    && !is_rebind
+                    && bind_source.is_none()
+                    && (name.starts_with('@') || name.starts_with('%'))
+                    && matches!(val, Value::Array(..) | Value::Hash(..))
+                {
+                    // Fresh `my @a`/`my %h` declaration: own a DISTINCT container
+                    // (Raku `=` copy semantics), never reuse the prior iteration's
+                    // backing `Gc`. Detaching a shared source (`my @o = @b`) also
+                    // preserves copy independence.
+                    val = Self::detach_shared_container(val);
+                }
                 if !is_bind_ctx
                     && !is_rebind
                     && !raw_mode
+                    && !sg_is_vardecl
                     && bind_source.is_none()
                     && !name.contains("__ANON")
                     && (name.starts_with('@') || name.starts_with('%'))

--- a/t/expr-vardecl-container-reassign.t
+++ b/t/expr-vardecl-container-reassign.t
@@ -1,0 +1,64 @@
+use Test;
+
+# A container declaration WITH an initializer used in EXPRESSION position
+# (`(my @o = $x)`, e.g. `push @a, my @o = $_`) must RE-ASSIGN and produce a
+# FRESH container on every evaluation. It used to initialize only once per
+# declaration site (a `__do_decl_init` marker), so in a loop the expression
+# froze at the first iteration's value.
+
+plan 8;
+
+# --- the expression value tracks the current initializer each iteration ---
+{
+    my @seen;
+    for ^3 -> $x { @seen.push: (my @o = $x).gist }
+    is-deeply @seen, ['[0]', '[1]', '[2]'], 'array (my @o = $x) re-evaluates each iteration';
+}
+{
+    my @seen;
+    for ^3 -> $x { @seen.push: (my %o = (k => $x)).<k> }
+    is-deeply @seen, [0, 1, 2], 'hash (my %o = ...) re-evaluates each iteration';
+}
+
+# --- each iteration yields a FRESH container (push captures distinct arrays) ---
+{
+    my @a;
+    for ^3 { push @a, my @o = $_ }
+    is-deeply @a, [[0], [1], [2]], 'push of an inline `my @o = $_` captures independent arrays';
+}
+{
+    my @a;
+    for ^3 -> $k { push @a, my %o = (v => $k) }
+    is-deeply @a.map(*.<v>).List, (0, 1, 2), 'push of an inline `my %o = ...` captures independent hashes';
+}
+
+# --- `Empty, $_` (the S02-types/array.t canary) ---
+{
+    my @a2;
+    for ^5 { push @a2, my @o = Empty, $_ }
+    is-deeply @a2, [[0], [1], [2], [3], [4]], 'push @a2, my @o = Empty, $_';
+}
+
+# --- copy independence is preserved (`my @c = @src`) ---
+{
+    my @src = 1, 2, 3;
+    my @c = @src;
+    @c[0] = 99;
+    is-deeply @src, [1, 2, 3], 'my @c = @src does not alias the source';
+}
+
+# --- a BARE `my @a` (no initializer) still initializes once per site ---
+{
+    my @out;
+    for ^3 {
+        my @acc;
+        @acc.push($_);
+        @out.push(@acc.elems);
+    }
+    is-deeply @out, [1, 1, 1], 'bare `my @acc` is fresh each iteration (statement form)';
+}
+
+# --- the assignment value is usable directly ---
+{
+    is (my @r = 1, 2, 3).elems, 3, 'return value of an inline array assignment';
+}


### PR DESCRIPTION
## What

A container declaration WITH an initializer used in **expression position** — `(my @o = $x)`, e.g. `push @a, my @o = $_` — initialized only **once** per declaration site (guarded by a `__do_decl_init` marker), so in a loop the expression froze at the first iteration's value:

```raku
my @a; for ^3 { push @a, my @o = $_ };   # was [[0],[0],[0]], want [[0],[1],[2]]
for ^3 -> $x { say (my @o = $x) }         # was [0][0][0], want [0][1][2]
```

## Fix

1. **compiler** (`expr_block.rs`): a container VarDecl-as-expression with an explicit initializer (`__has_initializer`) now **re-assigns** on every evaluation instead of consulting the once-only marker. A bare `my @a` (no initializer) keeps the init-once-per-site behavior. It also emits `MarkVarDeclContext` so the store is treated as a declaration.

2. **VM** (`vm_exec_dispatch.rs`, SetGlobal): honor `vardecl_context` — a `my` declaration must own a **distinct** container, so it detaches a shared source (copy semantics) and never reuses the previous iteration's backing `Gc` via the whole-container in-place path (§3 / #4162). This keeps each pushed `my @o` independent.

## Result

- Fixes 3 of the 4 failing assertions in `roast/S02-types/array.t`'s "no funny business in assignment" subtest (the 4th needs symbolic `@::Pkg::('name')` lookup — a separate parser gap, so the file is not yet whitelisted).
- Adds `t/expr-vardecl-container-reassign.t` (8 cases).
- `make test` + container/assign/decl roast whitelist subsets (~389 files) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)