### PR TITLE
feat(parser): leading-:: and symbolic package variable lookup for @ / %

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -119,6 +119,7 @@ roast/S02-one-pass-parsing/misc.t
 roast/S02-packages/package-lookup.t
 roast/S02-types/WHICH.t
 roast/S02-types/anon_block.t
+roast/S02-types/array.t
 roast/S02-types/array_extending.t
 roast/S02-types/array_ref.t
 roast/S02-types/assigning-refs.t

--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -18,6 +18,64 @@ use super::scalar::scalar_var;
 
 static ANON_ARRAY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Parse a leading-`::` qualified variable name after a sigil, i.e. the
+/// `::Pkg::name` / `::Pkg::('name')` form (`input` starts at the first `::`).
+///
+/// Returns `(rest, static_name, dynamic)`:
+/// - `static_name` is the fully-qualified name with `::` separators (e.g.
+///   `Pkg::name`), used when every segment is a static identifier.
+/// - `dynamic` is `Some(expr)` when any segment is a runtime `::('expr')` lookup;
+///   the expression evaluates to the qualified name string (`"Pkg::" ~ name`),
+///   for a `SymbolicDeref`.
+///
+/// Mirrors the qualified-name deduction in `ident/term_literals.rs` so
+/// `@::Pkg::('name')` resolves the same variable as `@Pkg::name`.
+fn parse_leading_colon_qualified(input: &str) -> Option<(&str, String, Option<Expr>)> {
+    let after = input.strip_prefix("::")?;
+    // The first segment must be a static identifier (`::Pkg…`); `::(...)` alone
+    // is the already-handled `@::(expr)` symbolic form.
+    let (mut r, first) = parse_ident_with_hyphens(after).ok()?;
+    let mut full_name = first.to_string();
+    let mut dynamic: Option<Expr> = None;
+    while let Some(r2) = r.strip_prefix("::") {
+        if let Some(after_paren) = r2.strip_prefix('(') {
+            let (r3, _) = ws(after_paren).ok()?;
+            let (r3, seg) = crate::parser::expr::expression(r3).ok()?;
+            let (r3, _) = ws(r3).ok()?;
+            let (r3, _) = parse_char(r3, ')').ok()?;
+            let base = match dynamic.take() {
+                Some(prev) => Expr::Binary {
+                    left: Box::new(prev),
+                    op: crate::token_kind::TokenKind::Tilde,
+                    right: Box::new(Expr::Literal(Value::str("::".to_string()))),
+                },
+                None => Expr::Literal(Value::str(format!("{}::", full_name))),
+            };
+            dynamic = Some(Expr::Binary {
+                left: Box::new(base),
+                op: crate::token_kind::TokenKind::Tilde,
+                right: Box::new(seg),
+            });
+            r = r3;
+        } else if let Ok((r2b, part)) = parse_ident_with_hyphens(r2) {
+            if let Some(dyn_expr) = dynamic.as_mut() {
+                let old = std::mem::replace(dyn_expr, Expr::Literal(Value::Nil));
+                *dyn_expr = Expr::Binary {
+                    left: Box::new(old),
+                    op: crate::token_kind::TokenKind::Tilde,
+                    right: Box::new(Expr::Literal(Value::str(format!("::{}", part)))),
+                };
+            } else {
+                full_name = format!("{}::{}", full_name, part);
+            }
+            r = r2b;
+        } else {
+            break;
+        }
+    }
+    Some((r, full_name, dynamic))
+}
+
 /// Parse an @array variable reference.
 pub(crate) fn array_var(input: &str) -> PResult<'_, Expr> {
     let (input, _) = parse_char(input, '@')?;
@@ -35,6 +93,27 @@ pub(crate) fn array_var(input: &str) -> PResult<'_, Expr> {
             Expr::SymbolicDeref {
                 sigil: "@".to_string(),
                 expr: Box::new(expr),
+            },
+        ));
+    }
+    // Leading-`::` qualified array: `@::Pkg::bar` (static) / `@::Pkg::('bar')`
+    // (symbolic). The leading `::` is optional in Raku, so `@::Pkg::bar` names
+    // the same `@Pkg::bar`; a `::('expr')` segment makes it a runtime lookup.
+    if input.starts_with("::")
+        && input
+            .as_bytes()
+            .get(2)
+            .is_some_and(|&b| b.is_ascii_alphabetic() || b == b'_')
+        && let Some((rest, name, dynamic)) = parse_leading_colon_qualified(input)
+    {
+        return Ok((
+            rest,
+            match dynamic {
+                Some(expr) => Expr::SymbolicDeref {
+                    sigil: "@".to_string(),
+                    expr: Box::new(expr),
+                },
+                None => Expr::ArrayVar(name),
             },
         ));
     }
@@ -144,6 +223,25 @@ pub(crate) fn hash_var(input: &str) -> PResult<'_, Expr> {
             Expr::SymbolicDeref {
                 sigil: "%".to_string(),
                 expr: Box::new(expr),
+            },
+        ));
+    }
+    // Leading-`::` qualified hash: `%::Pkg::h` (static) / `%::Pkg::('h')`.
+    if input.starts_with("::")
+        && input
+            .as_bytes()
+            .get(2)
+            .is_some_and(|&b| b.is_ascii_alphabetic() || b == b'_')
+        && let Some((rest, name, dynamic)) = parse_leading_colon_qualified(input)
+    {
+        return Ok((
+            rest,
+            match dynamic {
+                Some(expr) => Expr::SymbolicDeref {
+                    sigil: "%".to_string(),
+                    expr: Box::new(expr),
+                },
+                None => Expr::HashVar(name),
             },
         ));
     }

--- a/t/symbolic-package-var-lookup.t
+++ b/t/symbolic-package-var-lookup.t
@@ -1,0 +1,29 @@
+use Test;
+
+# A sigil variable can name a package variable through a leading `::`, either
+# statically (`@::Pkg::name`) or symbolically (`@::Pkg::('name')`, where the last
+# segment is a runtime string). The leading `::` is optional, so `@::Pkg::x`
+# names the same variable as `@Pkg::x`.
+
+plan 9;
+
+my package R {
+    our @arr = 1, 2, 3;
+    our %map = a => 10, b => 20;
+}
+
+# --- arrays ---
+is-deeply @R::arr,          [1, 2, 3], 'plain qualified @R::arr';
+is-deeply @::R::arr,        [1, 2, 3], 'leading-:: static @::R::arr';
+is-deeply @::R::('arr'),    [1, 2, 3], 'symbolic @::R::(\'arr\')';
+is @::R::('arr')[1],        2,         'indexing a symbolic array lookup';
+{
+    my $which = 'arr';
+    is-deeply @::R::("$which"), [1, 2, 3], 'symbolic lookup from a runtime string';
+}
+
+# --- hashes ---
+is-deeply %R::map,        {a => 10, b => 20}, 'plain qualified %R::map';
+is-deeply %::R::map,      {a => 10, b => 20}, 'leading-:: static %::R::map';
+is-deeply %::R::('map'),  {a => 10, b => 20}, 'symbolic %::R::(\'map\')';
+is %::R::('map')<b>,      20,                 'indexing a symbolic hash lookup';


### PR DESCRIPTION
## What

A sigil variable can now name a package variable through a leading `::`, statically or symbolically:

```raku
@::Pkg::name        # same as @Pkg::name (leading :: is optional)
@::Pkg::('name')    # symbolic: the last segment is a runtime string
%::Pkg::('name')
```

Previously `@::Pkg::('name')` mis-parsed as a bare anonymous `@` followed by a separate `::Pkg::('name')` indirect-type lookup (the sigil was disconnected), so it yielded `[]`; the static `@::Pkg::name` fell into the anonymous-array path too.

## Fix

`array_var` / `hash_var` now recognize a leading `::Ident…` qualified name and build an `ArrayVar`/`HashVar` (all-static segments) or a `SymbolicDeref` (any `::('expr')` segment), via a shared `parse_leading_colon_qualified` helper that mirrors the qualified-name deduction in `ident/term_literals.rs`.

## Result

- Whitelists `roast/S02-types/array.t` (108/108 — its last failing assertion was `@::R1832::('bar')`).
- Adds `t/symbolic-package-var-lookup.t` (9 cases).
- `make test` + S02/S03/S10 package/names roast whitelist subsets (~179 files) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)