### PR TITLE
fix(hash): a slice :delete fills absent keys with the container's `is default`

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1329,6 +1329,7 @@ roast/integration/advent2013-day02.t
 roast/integration/advent2013-day06.t
 roast/integration/advent2013-day07.t
 roast/integration/advent2013-day09.t
+roast/integration/advent2013-day12.t
 roast/integration/advent2013-day15.t
 roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -391,11 +391,31 @@ impl Interpreter {
         self.trim_trailing_array_holes(&var_name);
         // If the deleted value is a hole (Nil or type object like Package("Any")),
         // substitute the container's default value if one was set via `is default(...)`.
-        let result = if matches!(&result, Value::Nil | Value::Package(_)) {
-            if let Some(def) = &saved_default {
-                def.clone()
-            } else {
-                result
+        // For a SLICE delete (`%h<a b c>:delete`) the result is a list whose
+        // absent-key entries are holes — replace each of them with the default,
+        // so `my %h is default(42); %h<a b c>:delete` yields `(1, 2, 42)`.
+        let is_hole = |v: &Value| matches!(v, Value::Nil | Value::Package(_));
+        let result = if let Some(def) = &saved_default {
+            match result {
+                ref r if is_hole(r) => def.clone(),
+                Value::Array(items, kind) => {
+                    let replaced: Vec<Value> = items
+                        .iter()
+                        .map(|v| if is_hole(v) { def.clone() } else { v.clone() })
+                        .collect();
+                    Value::Array(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(replaced)),
+                        kind,
+                    )
+                }
+                Value::Seq(items) | Value::Slip(items) => {
+                    let replaced: Vec<Value> = items
+                        .iter()
+                        .map(|v| if is_hole(v) { def.clone() } else { v.clone() })
+                        .collect();
+                    Value::Seq(std::sync::Arc::new(replaced))
+                }
+                other => other,
             }
         } else {
             result

--- a/t/hash-slice-delete-default.t
+++ b/t/hash-slice-delete-default.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `:delete` of an ABSENT key on a hash with `is default(X)` yields X, not Nil —
+# for a SLICE delete too, where each absent key in the result list is filled
+# with the default (single-key delete already did this).
+
+plan 6;
+
+{
+    my %h is default(42) = a => 1, b => 2;
+    is-deeply %h<a b c>:delete, (1, 2, 42), 'slice delete fills absent key with default';
+}
+{
+    my %h is default(42) = a => 1, b => 2;
+    is %h<c>:delete, 42, 'single-key delete of an absent key yields the default';
+    is-deeply %h<x y>:delete, (42, 42), 'slice delete of all-absent keys is all default';
+}
+{
+    # No `is default`: absent keys are the type object (Any), not a default.
+    my %h = a => 1;
+    is-deeply %h<a z>:delete, (1, Any), 'without a default, absent keys are Any';
+}
+{
+    # The delete still removes the present keys.
+    my %h is default(0) = a => 1, b => 2, c => 3;
+    %h<a c q>:delete;
+    is-deeply %h, {b => 2}, 'present keys are actually deleted';
+}
+{
+    my %h is default('x') = one => 1;
+    is-deeply %h<one two>:delete, (1, 'x'), 'string default in a slice delete';
+}


### PR DESCRIPTION
## What

`%h<a b c>:delete` on a hash declared `is default(42)` returned `(1, 2, Nil)` for an absent key `c` instead of `(1, 2, 42)`:

```raku
my %h is default(42) = a => 1, b => 2;
%h<a b c>:delete;   # was (1, 2, Nil), want (1, 2, 42)
```

Single-key `:delete` already substituted the default (via `try_fast_hash_delete`), but the general slice-delete path only replaced a *scalar* hole result — the list result of a slice left each absent-key entry as a `Nil`/type-object hole.

## Fix

The default substitution now also maps over an `Array`/`Seq`/`Slip` delete result, replacing each hole element with the container default — only when the hash actually carries an `is default(...)`, so a plain hash still reports `Any` for absent keys.

## Result

- Whitelists `roast/integration/advent2013-day12.t` (32/32).
- Adds `t/hash-slice-delete-default.t` (6 cases).
- `make test` + hash/delete/subscript roast whitelist subsets (~49 files) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)