### PR TITLE
fix(gc): registered-only STW quiescence accounting (fixes main gc-stress)

### DIFF
--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -350,7 +350,7 @@ pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
     // reached in time (an unwrapped blocking site), fall back to the previous
     // behavior: re-queue the suspects and defer the scan. Deferred, never
     // unsound.
-    let _stw: Option<crate::gc::stw::StwGuard> = if crate::gc::mutator_workers_active() {
+    let _stw: Option<crate::gc::stw::StwGuard> = if crate::gc::stw::other_mutators_active() {
         let stw = if suspects.is_empty() || crate::gc::stw::stw_cooldown_active() {
             None
         } else {
@@ -643,10 +643,12 @@ mod tests {
         let stop = std::sync::Arc::new(AtomicBool::new(false));
         let stop2 = stop.clone();
         let worker = std::thread::spawn(move || {
+            super::super::stw::mark_thread_registered(true);
             while !stop2.load(Ordering::Relaxed) {
                 super::super::stw::park_at_safepoint();
                 std::thread::yield_now();
             }
+            super::super::stw::mark_thread_registered(false);
         });
 
         let a = TestNode::new();

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -58,5 +58,6 @@ pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_sl
 pub(crate) use safepoint::{SafepointKind, armed as gc_safepoints_armed, gc_safepoint};
 #[allow(unused_imports)]
 pub(crate) use stw::{
-    block_quiescent, park_at_safepoint as gc_park_point, stw_aware_wait, stw_requested,
+    block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point, stw_aware_wait,
+    stw_requested,
 };

--- a/src/gc/stw.rs
+++ b/src/gc/stw.rs
@@ -28,14 +28,17 @@
 //!   behavior. Timeout is a *liveness* fallback only; it never trades away
 //!   soundness.
 //!
-//! Thread accounting: user worker threads register via
-//! `enter_mutator_worker`/`exit_mutator_worker` (`spawn_user_thread`). With
-//! exactly one additional mutator (the main thread), the number of *other*
-//! mutators the collector must see quiescent is simply the current worker
-//! count — whether the collector runs on main (all workers must be quiescent)
-//! or on a worker (workers-1 + main). A worker that is mid-exit (dropping its
-//! interpreter's `Value`s) is neither quiescent nor unregistered, so the
-//! collector keeps waiting until those drops are done.
+//! Thread accounting: every mutator thread REGISTERS — workers via
+//! `spawn_user_thread` (counter raised parent-side to close the spawn window,
+//! per-thread flag set in the worker) and the CLI main thread via
+//! `mutsu::gc_register_main_thread`. Only registered threads count toward the
+//! quiescence target (`needed = registered_total - self`) and increment the
+//! quiescent counter, so the equation stays self-consistent under arbitrary
+//! extra threads (e.g. `cargo test` harness threads running in-process
+//! interpreters — those obey a stop but are invisible to the accounting). A
+//! worker that is mid-exit (dropping its interpreter's `Value`s) is neither
+//! quiescent nor unregistered, so the collector keeps waiting until those
+//! drops are done.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex, MutexGuard, OnceLock};
@@ -63,6 +66,40 @@ fn now_ms() -> u64 {
 fn rendezvous() -> &'static (Mutex<()>, Condvar) {
     static R: OnceLock<(Mutex<()>, Condvar)> = OnceLock::new();
     R.get_or_init(|| (Mutex::new(()), Condvar::new()))
+}
+
+thread_local! {
+    /// Whether the current thread is a REGISTERED mutator (the CLI main thread
+    /// and every `spawn_user_thread` worker). Only registered threads count
+    /// toward the quiescence target and increment [`QUIESCENT`] — an
+    /// unregistered thread (e.g. a `cargo test` harness thread running an
+    /// in-process interpreter) obeys a stop (it blocks at park points and on
+    /// leaving safe regions) but is invisible to the accounting, so it can
+    /// neither satisfy nor starve another collector's rendezvous. This keeps
+    /// the equation self-consistent under arbitrary thread populations:
+    /// `needed = registered_total - (self if registered)`, and every counted
+    /// quiescent thread is also counted in the target.
+    static REGISTERED_MUTATOR: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Mark the calling thread as a registered mutator (see [`REGISTERED_MUTATOR`]).
+/// Called by `spawn_user_thread` on each worker and by `main` on startup; the
+/// `enter_mutator_worker`/`exit_mutator_worker` counter is maintained
+/// separately (parent-side, to close the spawn window).
+pub(crate) fn mark_thread_registered(on: bool) {
+    REGISTERED_MUTATOR.with(|r| r.set(on));
+}
+
+fn thread_is_registered() -> bool {
+    REGISTERED_MUTATOR.with(|r| r.get())
+}
+
+/// Whether any *other* registered mutator thread exists (the collector uses
+/// this to decide if a stop-the-world is needed at all).
+pub(crate) fn other_mutators_active() -> bool {
+    let total = super::gc_ptr::mutator_worker_count();
+    let self_counted = usize::from(thread_is_registered());
+    total > self_counted
 }
 
 /// Whether a stop-the-world is currently requested. One relaxed load — the
@@ -128,9 +165,16 @@ pub(crate) fn park_at_safepoint() {
 
 #[cold]
 fn park_slow() {
-    quiescent_enter();
-    wait_until_released();
-    quiescent_exit_checked();
+    if thread_is_registered() {
+        quiescent_enter();
+        wait_until_released();
+        quiescent_exit_checked();
+    } else {
+        // Unregistered threads still obey the stop (they may be running an
+        // in-process interpreter, e.g. under `cargo test`), they just do not
+        // count toward the rendezvous.
+        wait_until_released();
+    }
 }
 
 /// Run a blocking operation `f` that provably does not touch the `Gc` graph
@@ -140,6 +184,14 @@ fn park_slow() {
 pub(crate) fn block_quiescent<R>(f: impl FnOnce() -> R) -> R {
     if !super::gc_ptr::gc_enabled() {
         return f();
+    }
+    if !thread_is_registered() {
+        // Not part of the accounting; still refuse to resume mid-scan.
+        let r = f();
+        if stw_requested() {
+            wait_until_released();
+        }
+        return r;
     }
     quiescent_enter();
     let r = f();
@@ -181,6 +233,16 @@ pub(crate) fn stw_aware_wait<'a, T>(
         }
         return guard;
     }
+    if !thread_is_registered() {
+        // Uncounted, but still refuses to leave the wait mid-scan.
+        loop {
+            if ready(&guard) && !stw_requested() {
+                return guard;
+            }
+            let (g, _) = cvar.wait_timeout(guard, Duration::from_millis(10)).unwrap();
+            guard = g;
+        }
+    }
     quiescent_enter();
     loop {
         if ready(&guard) && !stw_requested() {
@@ -220,11 +282,13 @@ pub(crate) fn try_stop_the_world(timeout: Duration) -> Option<StwGuard> {
     let deadline = Instant::now() + timeout;
     let (lock, cvar) = rendezvous();
     let mut guard = lock.lock().unwrap();
+    let self_counted = usize::from(thread_is_registered());
     loop {
         // Re-read the target every iteration: a worker finishing mid-wait
         // unregisters itself (after its `Value` drops are done), lowering the
-        // number of threads that must park.
-        let needed = super::gc_ptr::mutator_worker_count();
+        // number of threads that must park. The collector's own thread, if
+        // registered, is running this very function — exclude it.
+        let needed = super::gc_ptr::mutator_worker_count().saturating_sub(self_counted);
         if QUIESCENT.load(Ordering::Acquire) >= needed {
             drop(guard);
             return Some(StwGuard { _private: () });
@@ -266,10 +330,12 @@ mod tests {
         let stop = std::sync::Arc::new(AtomicBool::new(false));
         let stop2 = stop.clone();
         let handle = std::thread::spawn(move || {
+            mark_thread_registered(true);
             while !stop2.load(Ordering::Relaxed) {
                 park_at_safepoint();
                 std::thread::yield_now();
             }
+            mark_thread_registered(false);
         });
 
         let guard = try_stop_the_world(Duration::from_secs(5));
@@ -306,6 +372,8 @@ mod tests {
         // behavior is only observable under `MUTSU_GC=on` (the CI gc-stress
         // job runs this same test with it set).
         let gc_on = super::super::gc_ptr::gc_enabled();
+        // Counting applies to REGISTERED mutator threads only.
+        mark_thread_registered(true);
         let before = QUIESCENT.load(Ordering::Acquire);
         let r = block_quiescent(|| {
             if gc_on {
@@ -315,6 +383,7 @@ mod tests {
         });
         assert_eq!(r, 42);
         assert_eq!(QUIESCENT.load(Ordering::Acquire), before);
+        mark_thread_registered(false);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,18 @@ pub fn dump_vm_stats() {
     vm::vm_stats::dump();
 }
 
+/// Register the calling thread as the interpreter's main mutator thread for
+/// the GC's cooperative stop-the-world accounting (`gc::stw`). The CLI entry
+/// point calls this once on its big-stack main thread; its quiescence
+/// (blocked in `await`/`.finish`/`sleep`) then counts toward — and is
+/// required by — a collector's rendezvous, exactly like a `spawn_user_thread`
+/// worker's. Embedders that drive `Interpreter` from a long-lived thread and
+/// enable `MUTSU_GC` should call this on that thread too.
+pub fn gc_register_main_thread() {
+    gc::enter_mutator_worker();
+    gc::mark_thread_registered(true);
+}
+
 /// Parse source code and return a pretty-printed AST string.
 pub fn dump_ast(input: &str) -> Result<String, RuntimeError> {
     let (stmts, _) = parse_dispatch::parse_source(input)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,6 +245,10 @@ fn main() {
 }
 
 fn run_main() {
+    // GC STW accounting: this big-stack thread is the interpreter's main
+    // mutator; register it so a worker-side collector can count its
+    // quiescence (blocked in await/.finish/sleep) toward the rendezvous.
+    mutsu::gc_register_main_thread();
     let args: Vec<String> = env::args().collect();
 
     let mut dump_ast = false;

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -27,10 +27,14 @@ where
             struct WorkerGuard;
             impl Drop for WorkerGuard {
                 fn drop(&mut self) {
+                    crate::gc::mark_thread_registered(false);
                     crate::gc::exit_mutator_worker();
                 }
             }
             let _guard = WorkerGuard;
+            // Registered-mutator flag: this thread's quiescence now counts
+            // toward (and is required by) the STW rendezvous (gc::stw).
+            crate::gc::mark_thread_registered(true);
             f()
         })
         .expect("failed to spawn worker thread")


### PR DESCRIPTION
## Summary

Fast-follow for #4186, which merged while its `gc-stress` job was red (`gc-stress` is not a required check — `test`/`wasm-e2e` were green and auto-merge fired). This fixes that job's failure mode.

## Root cause

The gc-stress job's blocking step runs `cargo test` with `MUTSU_GC=on`. There, **unregistered parallel test-harness threads** sat in quiescent waits (sleeps/promise waits inside in-process interpreters) and inflated the global `QUIESCENT` counter. The rendezvous equation (`needed = worker_count`) assumed exactly one unregistered mutator (the real main thread), so a phantom-worker unit test saw its STW "achieved" by stranger threads and the deferred-collect expectations failed.

## Fix: registered-only accounting

- Thread-local **registered flag**: set by `spawn_user_thread` on each worker and by the new `mutsu::gc_register_main_thread()` on the CLI's big-stack main thread.
- Quiescence counting (parking, `block_quiescent`, `stw_aware_wait`) happens ONLY on registered threads. Unregistered threads still **obey** a stop (block at park points, refuse to leave safe regions mid-scan) but are invisible to the accounting — they can neither satisfy nor starve a rendezvous.
- Target: `registered_total − (self if registered)` — self-consistent under arbitrary extra threads: every counted quiescent thread is also counted in the target, so `cargo test`'s parallel workers cancel out instead of faking quiescence.

## Verification

- `cargo test` clean **with and without** `MUTSU_GC=on` (the exact CI failure mode).
- Churn repro: 0 VERIFY FAIL, mid-run reclamation intact (99 collects / **424 cycles** / pause_max ~50 ms with 3 live workers).
- Full `t/` under GC=on stress (serial, CI config): 1495 files PASS.

Note: a separate low-rate parallel-load flake on `t/react-whenever-shared-lexical.t` (1-2 of 36 contended runs) reproduces identically on current main and on this branch — tracked separately, unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK