### PR TITLE
feat(gc): emit all safepoint kinds + MUTSU_GC_AT / MUTSU_GC_COLLECT_NOW / seeded random stress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,18 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y perl
 
       - name: Unit + integration tests (GC on)
-        run: cargo test
+        # Single-threaded: with MUTSU_GC=on, parallel in-process test threads
+        # share the process-global collector state (candidate buffer, mutator
+        # worker count, STW flags), so an interpreter test's safepoint collect
+        # can steal another test's buffered candidates or react to its fake
+        # registered workers — intermittent unit-test failures that are test
+        # isolation artifacts, not GC bugs (seen: buffering_marks_purple_and_
+        # dedupes, collect_is_deferred_while_a_mutator_worker_is_active,
+        # stw_times_out_against_a_non_cooperating_worker). Serializing tests
+        # removes the cross-talk; the multi-threaded GC coverage lives in the
+        # subprocess-based tests/gc_stress.rs and the prove t/ suite below.
+        # Costs ~1s over the parallel run.
+        run: cargo test -- --test-threads=1
         env:
           RUST_MIN_STACK: 8388608
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/PLAN.md
+++ b/PLAN.md
@@ -182,7 +182,6 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
       直近 4 main run 中 1 回 `S17-lowlevel/lock.t` で赤（GC=on 負荷）— STW-aware wait 化後の
       観察を 1 サイクル継続してから昇格（本 branch では 6/6 clean）。
 - [ ] §11 step 11: OS resource 主体 async registry の `Value` edge 追従（必要に応じて）。
-- [ ] call/return/await 等の追加 safepoint 種別・`MUTSU_GC_AT`/random stress。
 - [ ] デフォルト GC=on のトリガ方針（現状 automatic trigger 無指定だと program-end collect のみ）と
       収集方式（同期/非同期）・A' 地ならしの範囲（ADR-0001 §4.2/§4.3）。
 - **Track B（要素 cell 化）と GC は統合キャンペーン（層3a）**。続いて NaN-boxing（層3b・JIT 地ならし）

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -31,6 +31,40 @@
 `make test` 1504 files PASS・S17 並行系 GC=on スモーク（stress/start/nonblocking-await/lock）
 VERIFY FAIL=0。
 
+## 2026-07-05: Phase B（GC）— 全 safepoint 種別の emit ＋ `MUTSU_GC_AT`/`MUTSU_GC_COLLECT_NOW`/random stress（§9.2/§9.2a 完結）
+
+設計メモ §9.2a の safepoint 種別 enum は従来 `Backedge` のみ emit されていた。残り全種別を
+それぞれの再入境界（§1.2: コンテナ借用・ロックを持たない点）に配線し、§9.2 の deferred トリガ
+3 種を実装して deterministic / random stress の全面が揃った:
+
+- **safepoint emission**（すべて `armed` gate 済み＝GC-off は cached load 1 回）:
+  - `call` — `push_call_frame`/`push_light_call_frame` ＋ frame を張らない fast path 3 本
+    （`call_compiled_function_fast`/`_light`/`_positional_light`）の入口。fast path は
+    push_call_frame を通らないため個別 emit が必要（テストで判明）。
+  - `return` — `pop_call_frame`（return-merge 境界。返り値は owned stack root）。
+  - `await` — `SharedPromise::wait` / `SharedChannel::receive_result` の入口（state lock 取得前。
+    collect の finalizer が他の promise/channel に触れ得るため mutex 保持中は不可）。
+  - `react_poll` — react/supply drive loop の 1 poll 単位（既存の無条件 `gc_park_point` は
+    非 armed 時の STW 協調用に残す）。
+  - `lazy_force` — `force_lazy_list_vm` / `force_lazy_list_vm_n` の force/pull 入口。
+  - `nested_run` — `with_nested_registers` の nested-VM 入口。
+  - `thread_join` — hyper/race の全 worker join 後のマージ境界。
+- **`MUTSU_GC_AT=call,return,...`** — 列挙した種別の safepoint でのみ collect（kind ビットマスク）。
+  未知名は warn してスキップ。
+- **`MUTSU_GC_COLLECT_NOW=1`** — `Interpreter::run` 冒頭で 1 回だけ collect（`Once` ガード）。
+  空ヒープ collect は無音の no-op なので `MUTSU_GC_LOG` 有効時はトリガ自体をログする。
+- **random stress** — `MUTSU_GC_RANDOM_RATE=0.0..1.0` ＋ `MUTSU_GC_RANDOM_SEED=<u64>`（未指定は
+  起動時刻由来）。グローバル atomic の splitmix64 で毎 safepoint に確率発火。**seed は必ず
+  stderr へログ**（§9.2 の再現性要件）。seed 固定で決定的。
+
+担保: `tests/gc_stress.rs` に 3 本追加（AT フィルタが listed kind でのみ発火＋回収実証・
+seeded random の出力一致＋seed ログ・collect-now 発火）、既存 13 本含め全通過。並行系 t/ を
+`EVERY_SAFEPOINT` と `AT=await,react_poll,thread_join,call,return` の両モードでスモーク（deadlock なし）。
+`make test` 1502 files 全通過。
+
+PLAN.md §2 の残は「roast advisory の blocking 昇格（観察中）」「§11 step 11（必要に応じて）」
+「デフォルト GC=on のトリガ方針」の 3 点に絞られた。
+
 ## 2026-07-04: `S09-subscript/slice.t` を 56/56 で whitelist — nested slice adverbs
 
 最後まで残っていた test 35（`nested slices` subtest、62 assertion）を解決し、`S09-subscript/slice.t`

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -55,7 +55,9 @@ pub(crate) use gc_ptr::{
 };
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};
 #[allow(unused_imports)]
-pub(crate) use safepoint::{SafepointKind, armed as gc_safepoints_armed, gc_safepoint};
+pub(crate) use safepoint::{
+    SafepointKind, armed as gc_safepoints_armed, gc_safepoint, startup_collect_if_requested,
+};
 #[allow(unused_imports)]
 pub(crate) use stw::{
     block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point,

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -28,6 +28,13 @@ mod stw;
 /// GC statics (candidate buffer, worker count, STW flags, cooldown). The
 /// modules' tests run in parallel threads within one process; without a single
 /// shared lock they interfere through those statics.
+///
+/// NOTE: this lock only serializes the GC modules' own tests. With `MUTSU_GC=on`
+/// (the CI gc-stress job), *interpreter* unit tests in other modules also drive
+/// the collector through VM safepoints and can steal buffered candidates or
+/// react to a test's fake registered workers — so the stress job runs
+/// `cargo test -- --test-threads=1`. A parallel `MUTSU_GC=on cargo test` is
+/// expected to flake; that is test isolation, not a GC bug.
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::sync::{Mutex, MutexGuard, OnceLock};

--- a/src/gc/safepoint.rs
+++ b/src/gc/safepoint.rs
@@ -6,7 +6,7 @@
 //! (design doc §1.2). This module holds the trigger policy and the one hot-path
 //! entry point ([`gc_safepoint`]) the VM calls at those boundaries.
 //!
-//! ## Triggers (first cut, design doc §9.2)
+//! ## Triggers (design doc §9.2)
 //! - `MUTSU_GC=off` (default / unset) disables everything: [`armed`] is `false`,
 //!   so the VM's safepoint check is a single relaxed load that early-returns —
 //!   normal execution pays essentially nothing and never collects.
@@ -15,22 +15,29 @@
 //! - `MUTSU_GC=on` + `MUTSU_GC_EVERY_CANDIDATE=N` — arm a pending collect once
 //!   every `N` candidate pushes; it runs at the next safepoint (never inline in
 //!   `Gc::drop`, which may hold a borrow — §1.2).
-//!
-//! Deferred (design doc §9.2 "first cut では見送ってよい"): `MUTSU_GC_AT`,
-//! `MUTSU_GC_COLLECT_NOW`, random stress. Only the `Backedge` safepoint is wired
-//! for now (call/return/await/thread_join join the enum but are not yet emitted).
+//! - `MUTSU_GC=on` + `MUTSU_GC_AT=call,return,...` — collect at every safepoint
+//!   of the listed kinds only (the [`SafepointKind`] names).
+//! - `MUTSU_GC=on` + `MUTSU_GC_RANDOM_RATE=0.0..1.0` — collect at each safepoint
+//!   with the given probability, from a seeded deterministic PRNG.
+//!   `MUTSU_GC_RANDOM_SEED=<u64>` fixes the seed; unset derives it from the
+//!   startup clock. The seed is always logged so a failing run can be replayed
+//!   (§9.2 "seed を必ずログに出す").
+//! - `MUTSU_GC=on` + `MUTSU_GC_COLLECT_NOW=1` — one collect right at program
+//!   start ([`startup_collect_if_requested`], called from `Interpreter::run`).
 
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use super::collect::collect_cycles_at;
 use super::gc_ptr::gc_enabled;
 
-/// A re-entry boundary at which a collect may run (design doc §9.2a). Only
-/// [`SafepointKind::Backedge`] is emitted so far; the rest are fixed now so the
-/// enum (and a future `MUTSU_GC_AT`) is stable.
+/// A re-entry boundary at which a collect may run (design doc §9.2a). All
+/// kinds are emitted: `Backedge` on both dispatch loops, the rest at their
+/// §9.2a boundary (call-frame push/pop, promise/channel blocking receive,
+/// react drive-loop poll, lazy-list force, nested-register entry, hyper/race
+/// join merge). `Manual` is the explicit-collect reason (`MUTSU_GC_COLLECT_NOW`,
+/// debug hooks).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[allow(dead_code)]
 pub(crate) enum SafepointKind {
     /// Bytecode dispatch loop backward edge (between instructions).
     Backedge,
@@ -54,7 +61,7 @@ pub(crate) enum SafepointKind {
 
 impl SafepointKind {
     /// Short stable name, used as the collect `reason` in `MUTSU_GC_LOG` output
-    /// (and the string a future `MUTSU_GC_AT` would match).
+    /// and the string `MUTSU_GC_AT` matches.
     fn name(self) -> &'static str {
         match self {
             SafepointKind::Backedge => "backedge",
@@ -68,6 +75,26 @@ impl SafepointKind {
             SafepointKind::Manual => "manual",
         }
     }
+
+    /// Bit for the `MUTSU_GC_AT` kind mask.
+    fn bit(self) -> u16 {
+        1 << (self as u16)
+    }
+
+    fn from_name(name: &str) -> Option<SafepointKind> {
+        Some(match name {
+            "backedge" => SafepointKind::Backedge,
+            "call" => SafepointKind::Call,
+            "return" => SafepointKind::Return,
+            "await" => SafepointKind::Await,
+            "react_poll" => SafepointKind::ReactPoll,
+            "lazy_force" => SafepointKind::LazyForce,
+            "nested_run" => SafepointKind::NestedRun,
+            "thread_join" => SafepointKind::ThreadJoin,
+            "manual" => SafepointKind::Manual,
+            _ => return None,
+        })
+    }
 }
 
 /// Resolved trigger policy, read once from the environment.
@@ -77,6 +104,10 @@ struct Triggers {
     armed: bool,
     every_safepoint: bool,
     every_candidate: usize,
+    /// `MUTSU_GC_AT` kind mask (0 = unset).
+    at_mask: u16,
+    /// `MUTSU_GC_RANDOM_RATE` as `f64` bits (0 = random stress off).
+    random_rate_bits: u64,
 }
 
 impl Triggers {
@@ -86,14 +117,20 @@ impl Triggers {
                 armed: false,
                 every_safepoint: false,
                 every_candidate: 0,
+                at_mask: 0,
+                random_rate_bits: 0,
             };
         }
         let every_safepoint = parse_flag("MUTSU_GC_EVERY_SAFEPOINT");
         let every_candidate = parse_count("MUTSU_GC_EVERY_CANDIDATE");
+        let at_mask = parse_at_mask("MUTSU_GC_AT");
+        let random_rate_bits = init_random("MUTSU_GC_RANDOM_RATE", "MUTSU_GC_RANDOM_SEED");
         Triggers {
-            armed: every_safepoint || every_candidate > 0,
+            armed: every_safepoint || every_candidate > 0 || at_mask != 0 || random_rate_bits != 0,
             every_safepoint,
             every_candidate,
+            at_mask,
+            random_rate_bits,
         }
     }
 }
@@ -120,6 +157,84 @@ fn parse_count(var: &str) -> usize {
             0
         }),
     }
+}
+
+/// Comma-separated [`SafepointKind`] names -> kind bitmask. An unknown name
+/// warns and is skipped (the rest of the list still applies).
+fn parse_at_mask(var: &str) -> u16 {
+    let Some(s) = std::env::var(var).ok() else {
+        return 0;
+    };
+    let mut mask = 0u16;
+    for name in s.split(',').map(str::trim).filter(|n| !n.is_empty()) {
+        match SafepointKind::from_name(name) {
+            Some(kind) => mask |= kind.bit(),
+            None => {
+                eprintln!("[mutsu gc] warning: unknown {var} safepoint kind {name:?}, skipping");
+            }
+        }
+    }
+    mask
+}
+
+/// Global PRNG state for the random stress trigger (splitmix64: `fetch_add` of
+/// the golden gamma gives each draw a distinct counter; the finalizer mixes it).
+static RNG_STATE: AtomicU64 = AtomicU64::new(0);
+
+const SPLITMIX_GAMMA: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// Parse the random-stress rate and seed. Returns the rate as `f64` bits
+/// (0 = off). The seed — explicit or clock-derived — is always logged so a
+/// failing stress run can be replayed with `MUTSU_GC_RANDOM_SEED` (§9.2).
+fn init_random(rate_var: &str, seed_var: &str) -> u64 {
+    let Some(rate_s) = std::env::var(rate_var).ok() else {
+        return 0;
+    };
+    let rate = match rate_s.parse::<f64>() {
+        Ok(r) if (0.0..=1.0).contains(&r) => r,
+        _ => {
+            eprintln!(
+                "[mutsu gc] warning: unrecognized {rate_var}={rate_s:?} (want 0.0..=1.0), treating as 0"
+            );
+            return 0;
+        }
+    };
+    if rate == 0.0 {
+        return 0;
+    }
+    let seed = match std::env::var(seed_var).ok() {
+        Some(s) => match s.parse::<u64>() {
+            Ok(seed) => seed,
+            Err(_) => {
+                eprintln!("[mutsu gc] warning: unrecognized {seed_var}={s:?}, deriving from clock");
+                clock_seed()
+            }
+        },
+        None => clock_seed(),
+    };
+    RNG_STATE.store(seed, Ordering::Relaxed);
+    eprintln!("[mutsu gc] random stress: rate={rate} seed={seed}");
+    rate.to_bits()
+}
+
+fn clock_seed() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x5EED)
+}
+
+/// One seeded splitmix64 draw; `true` with probability `rate`.
+fn random_fires(rate_bits: u64) -> bool {
+    let rate = f64::from_bits(rate_bits);
+    let mut x = RNG_STATE
+        .fetch_add(SPLITMIX_GAMMA, Ordering::Relaxed)
+        .wrapping_add(SPLITMIX_GAMMA);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^= x >> 31;
+    // 53 uniform mantissa bits -> [0, 1).
+    ((x >> 11) as f64) * (1.0 / (1u64 << 53) as f64) < rate
 }
 
 fn triggers() -> &'static Triggers {
@@ -167,10 +282,30 @@ pub(crate) fn gc_safepoint(kind: SafepointKind) {
     // until it releases (one load when no stop is requested — see gc::stw).
     super::stw::park_at_safepoint();
     let t = triggers();
-    // `every_safepoint` fires unconditionally; otherwise consume a pending
-    // arming from the candidate counter.
-    let fire = t.every_safepoint || PENDING.swap(false, Ordering::Relaxed);
+    // `every_safepoint` / the `MUTSU_GC_AT` kind list / the random draw fire
+    // directly; otherwise consume a pending arming from the candidate counter.
+    let fire = t.every_safepoint
+        || t.at_mask & kind.bit() != 0
+        || (t.random_rate_bits != 0 && random_fires(t.random_rate_bits))
+        || PENDING.swap(false, Ordering::Relaxed);
     if fire {
         collect_cycles_at(kind.name());
     }
+}
+
+/// `MUTSU_GC_COLLECT_NOW=1`: one collect right at program start (design §9.2).
+/// Called from `Interpreter::run`; a `Once` keeps re-entrant runs (`EVAL`,
+/// REPL lines) from re-collecting.
+pub(crate) fn startup_collect_if_requested() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if gc_enabled() && parse_flag("MUTSU_GC_COLLECT_NOW") {
+            // An empty-heap collect is a silent no-op, so log the trigger
+            // itself (under `MUTSU_GC_LOG`) to make the mode observable.
+            if super::collect::log_mode() != super::collect::LogMode::Off {
+                eprintln!("[mutsu gc] collect-now at startup");
+            }
+            collect_cycles_at(SafepointKind::Manual.name());
+        }
+    });
 }

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -42,6 +42,8 @@ class Pointer {
 
 impl Interpreter {
     pub fn run(&mut self, input: &str) -> Result<String, RuntimeError> {
+        // `MUTSU_GC_COLLECT_NOW=1` (§9.2): one collect right at program start.
+        crate::gc::startup_collect_if_requested();
         let preprocessed = Self::maybe_preprocess_roast_directives(input);
         if !self.env.contains_key("*PROGRAM") {
             self.env

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -217,6 +217,10 @@ impl SharedPromise {
     }
 
     pub(crate) fn wait(&self) -> (Value, String, String) {
+        // GC safepoint (§9.2a `await`): the await entry boundary, before the
+        // state lock is taken (a collect here can run finalizers that touch
+        // other promises/channels, so it must not hold this mutex).
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Await);
         let (lock, cvar) = &*self.inner;
         let state = lock.lock().unwrap();
         // STW-aware: the waiting thread counts as quiescent for the GC's
@@ -286,6 +290,9 @@ impl SharedChannel {
     }
 
     pub(crate) fn receive_result(&self) -> Result<Value, Value> {
+        // GC safepoint (§9.2a `await`): the blocking-receive entry, before the
+        // channel lock is taken — see `SharedPromise::wait`.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Await);
         let (lock, cvar) = &*self.inner;
         let mut state = lock.lock().unwrap();
         loop {

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -15,6 +15,9 @@ impl Interpreter {
         cf: &CompiledFunction,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
+        // GC safepoint (§9.2a `call`): this fast path skips push_call_frame,
+        // so it emits the call safepoint itself.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
         // A routine declared directly in this body is lexical; snapshot the
         // registry so it is removed on return unless it escaped (see

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -8,6 +8,9 @@ impl Interpreter {
         compiled_fns: &HashMap<String, CompiledFunction>,
         func_name: &str,
     ) -> Result<Value, RuntimeError> {
+        // GC safepoint (§9.2a `call`): this fast path skips push_call_frame,
+        // so it emits the call safepoint itself.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
         let param_slots = cf.param_local_slots.as_ref().unwrap();
         let positional_count = param_slots.len();

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -12,6 +12,9 @@ impl Interpreter {
         args: Vec<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<Value, RuntimeError> {
+        // GC safepoint (§9.2a `call`): the light-call boundary skips
+        // push_call_frame, so it emits the call safepoint itself.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -16,6 +16,10 @@ impl Interpreter {
     /// Save the current env, locals, stack depth, and readonly vars into a new
     /// call frame.
     pub(super) fn push_call_frame(&mut self) {
+        // GC safepoint (§9.2a `call`): the frame-push boundary holds no
+        // container borrow. Self-gated — one cached load unless `MUTSU_GC`
+        // arms a trigger.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         crate::vm::vm_stats::record_clone_env();
         // Save the caller env by an O(1) clone (an Arc bump, even when scoped):
         // it is only restored on return, so it need not be flattened. The callee
@@ -38,6 +42,8 @@ impl Interpreter {
     /// Lightweight call frame for simple methods: skips saving readonly vars
     /// since simple methods don't use `:=` binding.
     pub(super) fn push_light_call_frame(&mut self) {
+        // GC safepoint (§9.2a `call`) — see `push_call_frame`.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         crate::vm::vm_stats::record_clone_env();
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
@@ -55,6 +61,9 @@ impl Interpreter {
     /// Pop the most recent call frame and restore locals and readonly vars.
     /// Returns the frame so callers can access `saved_env` for site-specific merge logic.
     pub(super) fn pop_call_frame(&mut self) -> VmCallFrame {
+        // GC safepoint (§9.2a `return`): the frame-pop / return-merge boundary
+        // holds no container borrow (the return value is an owned stack root).
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::Return);
         let mut frame = self
             .call_frames
             .pop()

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -175,6 +175,8 @@ impl Interpreter {
         &mut self,
         list: &LazyList,
     ) -> Result<Vec<Value>, RuntimeError> {
+        // GC safepoint (§9.2a `lazy_force`): the strict-force entry boundary.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::LazyForce);
         let caller_code = self.current_code;
         let r = self.force_lazy_list_vm_inner(list);
         self.reconcile_caller_after_lazy_force(caller_code);
@@ -384,6 +386,8 @@ impl Interpreter {
         list: &LazyList,
         needed: usize,
     ) -> Result<Vec<Value>, RuntimeError> {
+        // GC safepoint (§9.2a `lazy_force`): the bounded pull/resume boundary.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::LazyForce);
         let caller_code = self.current_code;
         let r = self.force_lazy_list_vm_n_inner(list, needed);
         self.reconcile_caller_after_lazy_force(caller_code);

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -127,6 +127,9 @@ impl Interpreter {
                 }
             }
         }
+        // GC safepoint (§9.2a `thread_join`): the hyper/race join-merge
+        // boundary — every batch worker has joined, its results are owned here.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::ThreadJoin);
         // Sync any shared variable updates from threads back to our env
         self.sync_shared_vars_to_env();
         if let Some(e) = first_error {

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -38,8 +38,11 @@ impl Interpreter {
             // GC park point: an idle react loop polls `recv_timeout` without
             // dispatching bytecode, so it would never reach the backedge
             // safepoint — park here so a stop-the-world can proceed while the
-            // loop waits for events.
+            // loop waits for events. (Unconditional: `gc_safepoint` below only
+            // parks when a trigger is armed.)
             crate::gc::gc_park_point();
+            // GC safepoint (§9.2a `react_poll`): one drive-loop poll unit.
+            crate::gc::gc_safepoint(crate::gc::SafepointKind::ReactPoll);
             if let SupplyDrivePolicy::Promise {
                 promise, deadline, ..
             } = &policy

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -223,6 +223,8 @@ impl Interpreter {
     /// (single compiled block) and by the map/sort `run_reuse` loops (many
     /// iterations sharing one fresh-register scope).
     pub(crate) fn with_nested_registers<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        // GC safepoint (§9.2a `nested_run`): the nested-VM entry boundary.
+        crate::gc::gc_safepoint(crate::gc::SafepointKind::NestedRun);
         // Save the per-execution registers (the fields `Interpreter::new` initializes
         // fresh) and reset them to their fresh-Interpreter defaults for the nested run.
         let saved_stack = std::mem::take(&mut self.stack);

--- a/tests/gc_stress.rs
+++ b/tests/gc_stress.rs
@@ -21,6 +21,10 @@ fn run(src: &str, gc: &[(&str, &str)]) -> (String, String, bool) {
         "MUTSU_GC",
         "MUTSU_GC_EVERY_SAFEPOINT",
         "MUTSU_GC_EVERY_CANDIDATE",
+        "MUTSU_GC_AT",
+        "MUTSU_GC_COLLECT_NOW",
+        "MUTSU_GC_RANDOM_RATE",
+        "MUTSU_GC_RANDOM_SEED",
         "MUTSU_GC_VERIFY",
         "MUTSU_GC_LOG",
     ] {
@@ -424,6 +428,129 @@ fn dead_sweep_bounds_threaded_mutation_memory() {
     assert!(
         pause_max_ns < 500_000_000,
         "expected bounded collect pauses with the dead sweep, got pause_ns_max={pause_max_ns}\nstderr:\n{on_err}"
+    );
+}
+
+/// `MUTSU_GC_AT=call,return` collects only at the call/return safepoint kinds
+/// (§9.2): the run must stay correct, actually reclaim the per-call cycles, and
+/// every logged collect reason must be one of the listed kinds.
+#[test]
+fn at_kind_filter_collects_only_at_listed_safepoints() {
+    let src = r#"
+        sub leak-cycle($n) { my %h; %h<self> := %h; %h<n> = $n; $n * 2 }
+        my $sum = 0;
+        for ^30 { $sum += leak-cycle($_) }
+        say $sum;
+    "#;
+
+    let (off, _, ok_off) = run(src, &[]);
+    let (on, err, ok_on) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_AT", "call,return"),
+            ("MUTSU_GC_LOG", "summary"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+
+    assert!(ok_off && ok_on, "runs must succeed; stderr:\n{err}");
+    assert_eq!(off, on, "MUTSU_GC_AT run changed program output");
+    let reasons: Vec<&str> = err
+        .lines()
+        .filter(|l| l.contains("[mutsu gc] start cycle="))
+        .filter_map(|l| {
+            l.split_whitespace()
+                .find_map(|tok| tok.strip_prefix("reason="))
+        })
+        .collect();
+    assert!(
+        !reasons.is_empty(),
+        "expected at least one collect at a call/return safepoint:\n{err}"
+    );
+    // `program-end` is the unconditional final collect (`collect_if_enabled`),
+    // not a safepoint fire — only the *safepoint* reasons must obey the filter.
+    assert!(
+        reasons
+            .iter()
+            .all(|r| *r == "call" || *r == "return" || *r == "program-end"),
+        "collect fired at a kind outside MUTSU_GC_AT=call,return: {reasons:?}\n{err}"
+    );
+    assert!(
+        reasons.iter().any(|r| *r == "call" || *r == "return"),
+        "expected at least one call/return-safepoint collect: {reasons:?}\n{err}"
+    );
+    let reclaimed = err
+        .lines()
+        .find(|l| l.contains("[mutsu vm-stats] gc:"))
+        .and_then(|l| {
+            l.split_whitespace()
+                .find_map(|tok| tok.strip_prefix("reclaimed_nodes="))
+        })
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(0);
+    assert!(
+        reclaimed > 0,
+        "per-call cycles must be reclaimed under MUTSU_GC_AT; stderr:\n{err}"
+    );
+}
+
+/// Seeded random stress (§9.2): `MUTSU_GC_RANDOM_RATE` collects probabilistically
+/// but deterministically for a fixed `MUTSU_GC_RANDOM_SEED` — output must match
+/// GC-off, and the seed must be logged so a failing run can be replayed.
+#[test]
+fn random_stress_is_seeded_and_preserves_output() {
+    let src = r#"
+        my %m;
+        for 1..40 -> $i { my %h; %h<self> := %h; %m{$i % 7} = (%m{$i % 7} // 0) + $i; }
+        say %m.sort.map({ .key ~ "=" ~ .value }).join(",");
+    "#;
+
+    let (off, _, ok_off) = run(src, &[]);
+    let (on, err, ok_on) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_RANDOM_RATE", "0.5"),
+            ("MUTSU_GC_RANDOM_SEED", "42"),
+            ("MUTSU_GC_VERIFY", "1"),
+        ],
+    );
+
+    assert!(ok_off && ok_on, "runs must succeed; stderr:\n{err}");
+    assert_eq!(off, on, "random-stress run changed program output");
+    assert!(
+        err.contains("random stress: rate=0.5 seed=42"),
+        "the random seed must be logged for replay:\n{err}"
+    );
+    assert!(
+        !err.contains("VERIFY FAIL"),
+        "no soundness violations under random stress:\n{err}"
+    );
+}
+
+/// `MUTSU_GC_COLLECT_NOW=1` (§9.2): one collect fires at program start (before
+/// any user code) and the program still runs normally.
+#[test]
+fn collect_now_runs_one_startup_collect() {
+    let src = r#"say "started";"#;
+
+    let (out, err, ok) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_COLLECT_NOW", "1"),
+            ("MUTSU_GC_LOG", "summary"),
+        ],
+    );
+
+    assert!(ok, "collect-now run must succeed; stderr:\n{err}");
+    assert_eq!(out.trim(), "started");
+    // A startup collect on an empty heap is a silent no-op, so the trigger
+    // logs its own firing under MUTSU_GC_LOG.
+    assert!(
+        err.contains("[mutsu gc] collect-now at startup"),
+        "expected the startup collect trigger to fire; stderr:\n{err}"
     );
 }
 


### PR DESCRIPTION
## Summary

Design doc `docs/gc-level1-detailed-design.md` §9.2a fixed the `SafepointKind` enum, but only `Backedge` was emitted. This PR wires **all remaining safepoint kinds** at their re-entry boundaries and implements the **§9.2 deferred trigger set**, completing the deterministic/random GC stress surface (PLAN.md §2 残「追加 safepoint 種別・`MUTSU_GC_AT`/random stress」).

### Safepoint emission (all armed-gated: GC-off pays one cached load)

| kind | boundary |
|---|---|
| `call` | `push_call_frame` / `push_light_call_frame` **+ the three frame-less fast paths** (`call_compiled_function_fast`/`_light`/`_positional_light`) — fast paths skip `push_call_frame`, so without their own emit the `call` kind never fired on hot code (caught by the new test) |
| `return` | `pop_call_frame` (return-merge; return value is an owned stack root) |
| `await` | `SharedPromise::wait` / `SharedChannel::receive_result` entry, **before** the state lock (a collect can run finalizers that touch other promises/channels) |
| `react_poll` | react/supply drive-loop poll unit (the unconditional `gc_park_point` stays for the un-armed STW case) |
| `lazy_force` | `force_lazy_list_vm` / `force_lazy_list_vm_n` entry |
| `nested_run` | `with_nested_registers` entry |
| `thread_join` | hyper/race join-merge after all batch workers joined |

### New triggers (§9.2)

- **`MUTSU_GC_AT=call,return,...`** — collect only at the listed safepoint kinds (bitmask; unknown names warn and are skipped).
- **`MUTSU_GC_COLLECT_NOW=1`** — one collect at program start (`Once`-guarded; logs its firing under `MUTSU_GC_LOG` since an empty-heap collect is a silent no-op).
- **`MUTSU_GC_RANDOM_RATE=0.0..1.0` + `MUTSU_GC_RANDOM_SEED=<u64>`** — seeded splitmix64 probabilistic collect per safepoint; the seed (explicit or clock-derived) is **always logged** for replay (§9.2 「seed を必ずログに出す」). Deterministic for a fixed seed.

## Validation

- `tests/gc_stress.rs`: 3 new tests (AT filter fires only at listed kinds **and** reclaims the per-call cycles; seeded random output identity vs GC-off + seed logging; collect-now firing). All 13 pass.
- Concurrency `t/` files smoked under `MUTSU_GC_EVERY_SAFEPOINT=1` and `MUTSU_GC_AT=await,react_poll,thread_join,call,return` — no deadlocks (the `await` emit is placed before the promise/channel mutex on purpose).
- `make test`: 1502 files / 14614 tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK