### PR TITLE
fix(gather): a trailing comma in a `take` argument is ignored (`take X,` == `take X`)

### DIFF
--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -113,6 +113,18 @@ pub(crate) fn die_stmt(input: &str) -> PResult<'_, Stmt> {
     parse_statement_modifier(rest, stmt)
 }
 
+/// A trailing comma in a `take` argument (`take X,`) parses as a one-element
+/// comma list. Raku treats `take X,` as `take X` (the trailing comma is a
+/// separator, not a list constructor), so unwrap the lone element — otherwise
+/// `take ['x', $a, $b],` would gather the wrapper `(['x', $a, $b],)` instead of
+/// the array itself. (`take X, Y` keeps its multi-element list.)
+fn unwrap_single_trailing_comma(expr: crate::ast::Expr) -> crate::ast::Expr {
+    match expr {
+        crate::ast::Expr::ArrayLiteral(mut items) if items.len() == 1 => items.pop().unwrap(),
+        other => other,
+    }
+}
+
 /// Parse `take` or `take-rw` statement.
 pub(crate) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
     // Try `take-rw` first (longer match wins)
@@ -120,6 +132,7 @@ pub(crate) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
         && let Ok((rest, _)) = ws1(rest)
     {
         let (rest, expr) = parse_comma_or_expr(rest)?;
+        let expr = unwrap_single_trailing_comma(expr);
         // `take-rw`: is_rw=true. The compiler captures the source container so the
         // gathered value keeps container identity (`=:=`) with the original lvalue.
         return parse_statement_modifier(rest, Stmt::Take(expr, true));
@@ -127,6 +140,7 @@ pub(crate) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("take", input).ok_or_else(|| PError::expected("take statement"))?;
     let (rest, _) = ws1(rest)?;
     let (rest, expr) = parse_comma_or_expr(rest)?;
+    let expr = unwrap_single_trailing_comma(expr);
     parse_statement_modifier(rest, Stmt::Take(expr, false))
 }
 

--- a/t/take-trailing-comma.t
+++ b/t/take-trailing-comma.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A trailing comma in a `take` argument must be ignored: `take X,` == `take X`.
+# It must NOT wrap the value in a 1-element list.
+
+# scalar value
+{
+    my @r = gather { take 5, };
+    is @r.elems, 1, 'take 5, yields one element';
+    is @r[0], 5, 'take 5, yields the scalar 5 (not a list)';
+}
+
+# array value
+{
+    my @r = gather { take [1, 2], };
+    is @r.elems, 1, 'take [1,2], yields one element';
+    is-deeply @r[0], [1, 2], 'take [1,2], yields the array itself';
+}
+
+# parenthesized list value
+{
+    my @r = gather { take (5, 6), };
+    is @r.elems, 1, 'take (5,6), yields one element';
+    is-deeply @r[0], (5, 6), 'take (5,6), yields the list itself';
+}
+
+# without trailing comma behaves identically
+{
+    my @r = gather { take 42 };
+    is @r.elems, 1, 'take 42 yields one element';
+    is @r[0], 42, 'take 42 yields the scalar 42';
+}


### PR DESCRIPTION
## Summary

`take X,` (a `take` with a trailing comma) was parsed as `Take(ArrayLiteral([X]))` — a one-element list — so `gather { take 5, }` produced `((5,),)` instead of `(5,)`. Raku treats a trailing comma in a `take` argument the same as no comma at all (`take X,` == `take X`).

## Fix

Add `unwrap_single_trailing_comma`, applied after `parse_comma_or_expr` in both the `take` and `take-rw` branches of `src/parser/stmt/simple/control_stmts.rs`. It strips a spurious one-element `ArrayLiteral` wrapper produced solely by the trailing comma, so the value is taken as-is.

## Test

New `t/take-trailing-comma.t` (8 assertions) covering scalar / array / parenthesized-list values, with and without the trailing comma.

Verified: `make test` (14590 tests PASS), whitelisted `roast/S04-statements/gather.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)