### PR TITLE
feat(concurrency): diagnose `whenever` outside a `supply`/`react` block

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -24,6 +24,7 @@ roast/6.d/S32-str/sprintf-x.t
 roast/6.d/S32-str/sprintf.t
 roast/APPENDICES/A02-some-day-maybe/concreteness.t
 roast/APPENDICES/A02-some-day-maybe/io-cathandle.t
+roast/MISC/bug-coverage-6.d.t
 roast/MISC/bug-coverage-stress.t
 roast/S01-perl-5-integration/array.t
 roast/S01-perl-5-integration/basic.t

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,6 +5,7 @@ mod parse_result;
 mod primary;
 mod sink_warn;
 mod stmt;
+mod whenever_scope;
 use std::sync::OnceLock;
 
 pub(crate) fn is_imported_function(name: &str) -> bool {
@@ -123,6 +124,29 @@ fn build_vcs_conflict_error(lines: &[i64]) -> RuntimeError {
     err.exception = Some(Box::new(Value::make_instance(
         crate::symbol::Symbol::intern("X::Comp::Group"),
         group_attrs,
+    )));
+    err
+}
+
+/// Build the compile-time error rakudo raises when a `whenever` block appears
+/// outside the lexical scope of a `supply`/`react` block: `X::Comp::WheneverOutOfScope`.
+fn build_whenever_out_of_scope_error(line: i64) -> RuntimeError {
+    const MESSAGE: &str =
+        "Cannot have a 'whenever' block outside the scope of a 'supply' or 'react' block";
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(MESSAGE.to_string()));
+    attrs.insert("payload".to_string(), Value::str(MESSAGE.to_string()));
+    if line > 0 {
+        attrs.insert("line".to_string(), Value::Int(line));
+    }
+    let mut err = RuntimeError::new(MESSAGE);
+    err.set_code(Some(RuntimeErrorCode::ParseGeneric));
+    if line > 0 {
+        err.set_line(Some(line as usize));
+    }
+    err.exception = Some(Box::new(Value::make_instance(
+        crate::symbol::Symbol::intern("X::Comp::WheneverOutOfScope"),
+        attrs,
     )));
     err
 }
@@ -266,6 +290,10 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                     line_num,
                     col_num,
                 ))
+            } else if let Some(line) = whenever_scope::find_out_of_scope_whenever(&stmts) {
+                // A `whenever` outside a `supply`/`react` block is a compile-time
+                // error in rakudo (X::Comp::WheneverOutOfScope).
+                Err(build_whenever_out_of_scope_error(line))
             } else {
                 sink_warn::add_sink_warnings(&stmts);
                 Ok((stmts, finish_content))

--- a/src/parser/stmt/control/react.rs
+++ b/src/parser/stmt/control/react.rs
@@ -14,8 +14,23 @@ pub(crate) fn react_stmt(input: &str) -> PResult<'_, Stmt> {
             },
         ));
     }
-    let (rest, body) = block(rest)?;
-    Ok((rest, Stmt::React { body }))
+    // `react { ... }` block form.
+    if let Ok((rest, body)) = block(rest) {
+        return Ok((rest, Stmt::React { body }));
+    }
+    // `react STATEMENT` blorst form (e.g. `react foo`). A `react` takes a
+    // block-or-statement; when it's a bare statement, parse a single expression
+    // as the body. This is mainly needed so that programs like
+    // `sub foo { whenever ... }; react foo` parse at all — the actual
+    // "whenever outside react/supply scope" compile error is diagnosed by the
+    // post-parse whenever-scope check, matching rakudo.
+    let (rest, expr) = expression(rest)?;
+    Ok((
+        rest,
+        Stmt::React {
+            body: vec![Stmt::Expr(expr)],
+        },
+    ))
 }
 
 /// Parse `whenever` block.

--- a/src/parser/whenever_scope.rs
+++ b/src/parser/whenever_scope.rs
@@ -1,0 +1,152 @@
+//! Post-parse check for `whenever` blocks that appear outside the lexical scope
+//! of a `react` / `supply` block.
+//!
+//! Rakudo raises a compile-time `X::Comp::WheneverOutOfScope`
+//! ("Cannot have a 'whenever' block outside the scope of a 'supply' or 'react'
+//! block") when a `whenever` is not lexically enclosed by a `react` block or a
+//! `supply` block. Crossing *any* routine boundary (a `sub`/`method`/pointy or
+//! anonymous closure) breaks that enclosure — only inline blocks (`for`, `if`,
+//! bare `{ }`, a `whenever` body, etc.) preserve it.
+//!
+//! This walker mirrors that rule structurally on the AST. It tracks a single
+//! boolean `in_scope` ("are we lexically inside a react/supply block, without
+//! having crossed a routine boundary?"):
+//!
+//! * `react { ... }` sets it true for the body.
+//! * The emitter closure that `supply { ... }` lowers to (a `Lambda` whose
+//!   parameter name starts with `__mutsu_supply_emitter_`) sets it true.
+//! * A genuine routine boundary (named `sub`/`method` decl, `sub { }`, pointy
+//!   or parameterised closure, and any non-emitter `Lambda`) resets it to false.
+//! * Every other construct preserves it.
+//!
+//! When a `whenever` is reached with `in_scope == false`, we record its line.
+//!
+//! The walker is intentionally conservative: an unhandled container is simply
+//! not recursed into, which can only *miss* an out-of-scope `whenever` (a false
+//! negative). A legitimate `whenever` inside a `react`/`supply` block is never
+//! reachable behind a routine-boundary reset, so this can never produce a false
+//! positive that would reject valid concurrency code.
+
+use crate::ast::{Expr, Stmt};
+
+const SUPPLY_EMITTER_PREFIX: &str = "__mutsu_supply_emitter_";
+
+/// Returns the 1-based source line of the first `whenever` block found outside
+/// the scope of a `react`/`supply` block, or `None` if every `whenever` is
+/// properly scoped.
+pub(crate) fn find_out_of_scope_whenever(stmts: &[Stmt]) -> Option<i64> {
+    let mut line = 0i64;
+    let mut found: Option<i64> = None;
+    walk_stmts(stmts, false, &mut line, &mut found);
+    found
+}
+
+fn walk_stmts(stmts: &[Stmt], in_scope: bool, line: &mut i64, found: &mut Option<i64>) {
+    for s in stmts {
+        walk_stmt(s, in_scope, line, found);
+    }
+}
+
+fn walk_stmt(stmt: &Stmt, in_scope: bool, line: &mut i64, found: &mut Option<i64>) {
+    match stmt {
+        Stmt::SetLine(n) => *line = *n,
+
+        // Scope openers.
+        Stmt::React { body } => walk_stmts(body, true, line, found),
+        Stmt::Whenever { supply, body, .. } => {
+            if !in_scope && found.is_none() {
+                *found = Some(*line);
+            }
+            walk_expr(supply, in_scope, line, found);
+            // A whenever body is itself inside a react/supply scope, and nested
+            // `whenever` blocks are allowed there.
+            walk_stmts(body, true, line, found);
+        }
+
+        // Routine / package boundaries: reset scope for the body.
+        Stmt::SubDecl { body, .. }
+        | Stmt::MethodDecl { body, .. }
+        | Stmt::ClassDecl { body, .. }
+        | Stmt::RoleDecl { body, .. }
+        | Stmt::Package { body, .. } => {
+            walk_stmts(body, false, line, found);
+        }
+
+        // Inline blocks / control flow: preserve scope.
+        Stmt::Block(body)
+        | Stmt::SyntheticBlock(body)
+        | Stmt::Default(body)
+        | Stmt::Catch(body)
+        | Stmt::Control(body)
+        | Stmt::Given { body, .. }
+        | Stmt::When { body, .. }
+        | Stmt::While { body, .. }
+        | Stmt::Subtest { body, .. } => walk_stmts(body, in_scope, line, found),
+        Stmt::For { body, iterable, .. } => {
+            walk_expr(iterable, in_scope, line, found);
+            walk_stmts(body, in_scope, line, found);
+        }
+        Stmt::Loop { body, init, .. } => {
+            if let Some(init) = init {
+                walk_stmt(init, in_scope, line, found);
+            }
+            walk_stmts(body, in_scope, line, found);
+        }
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            walk_stmts(then_branch, in_scope, line, found);
+            walk_stmts(else_branch, in_scope, line, found);
+        }
+        Stmt::Label { stmt, .. } => walk_stmt(stmt, in_scope, line, found),
+
+        // Expression-bearing statements: descend into the expression to reach
+        // `supply { }` emitters and closures.
+        Stmt::Expr(e) | Stmt::VarDecl { expr: e, .. } | Stmt::Assign { expr: e, .. } => {
+            walk_expr(e, in_scope, line, found);
+        }
+        Stmt::Take(e, _) => walk_expr(e, in_scope, line, found),
+
+        _ => {}
+    }
+}
+
+fn walk_expr(expr: &Expr, in_scope: bool, line: &mut i64, found: &mut Option<i64>) {
+    match expr {
+        // The `supply { }` sugar lowers to `Supply.on-demand(-> $emitter { ... })`
+        // where the emitter closure name marks a genuine supply scope.
+        Expr::Lambda { param, body, .. } => {
+            let opens_scope = param.starts_with(SUPPLY_EMITTER_PREFIX);
+            walk_stmts(body, opens_scope, line, found);
+        }
+        // `sub { }` (is_block == false) is a routine boundary; a bare block
+        // `{ }` (is_block == true) is inline and preserves scope.
+        Expr::AnonSub { body, is_block, .. } => {
+            walk_stmts(body, in_scope && *is_block, line, found);
+        }
+        Expr::AnonSubParams { body, .. } => walk_stmts(body, false, line, found),
+
+        // Inline block-valued expressions preserve scope.
+        Expr::Block(body) | Expr::Gather(body) => walk_stmts(body, in_scope, line, found),
+        Expr::DoBlock { body, .. } => walk_stmts(body, in_scope, line, found),
+        Expr::DoStmt(s) => walk_stmt(s, in_scope, line, found),
+
+        // Call / method-call arguments may carry the supply emitter closure or
+        // other block arguments.
+        Expr::Call { args, .. } => {
+            for a in args {
+                walk_expr(a, in_scope, line, found);
+            }
+        }
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+            walk_expr(target, in_scope, line, found);
+            for a in args {
+                walk_expr(a, in_scope, line, found);
+            }
+        }
+
+        _ => {}
+    }
+}

--- a/t/whenever-out-of-scope.t
+++ b/t/whenever-out-of-scope.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A `whenever` block outside the lexical scope of a `supply`/`react` block is a
+# compile-time error: X::Comp::WheneverOutOfScope.
+
+# whenever inside a sub, called from react — still out of scope (routine boundary).
+throws-like ｢sub foo { whenever Promise.in(1) { say 1 } }; react foo｣,
+    X::Comp::WheneverOutOfScope, 'whenever in a sub is out of react scope';
+
+# whenever inside a raw pointy closure (not a supply block).
+throws-like ｢my $c = -> $e { whenever Promise.in(1) { say 1 } }｣,
+    X::Comp::WheneverOutOfScope, 'whenever in a raw closure is out of scope';
+
+# bare top-level whenever.
+throws-like ｢whenever Promise.in(1) { say 1 }｣,
+    X::Comp::WheneverOutOfScope, 'bare top-level whenever is out of scope';
+
+# whenever inside a method.
+throws-like ｢class C { method m { whenever Promise.in(1) { say 1 } } }｣,
+    X::Comp::WheneverOutOfScope, 'whenever in a method is out of scope';
+
+# Legitimate uses must NOT throw.
+lives-ok ｢react { whenever Promise.in(1) { done } }｣,
+    'whenever directly in a react block is fine';
+
+lives-ok ｢my $s = supply { whenever Promise.in(1) { emit 1 } }｣,
+    'whenever directly in a supply block is fine';
+
+lives-ok ｢react { for 1..2 { whenever Promise.in(1) { done } } }｣,
+    'whenever in an inline for-loop inside react is fine';
+
+lives-ok ｢react { whenever Promise.in(1) { whenever Promise.in(2) { done } } }｣,
+    'nested whenever inside react is fine';


### PR DESCRIPTION
## Summary

A `whenever` block that is not lexically enclosed by a `supply`/`react` block is a **compile-time** error in rakudo — `X::Comp::WheneverOutOfScope` ("Cannot have a 'whenever' block outside the scope of a 'supply' or 'react' block"). Crossing any routine boundary (a `sub`/`method`/pointy or anonymous closure) breaks that enclosure; only inline blocks (`for`, `if`, bare `{ }`, a `whenever` body, …) preserve it. mutsu previously accepted such code silently.

```raku
sub foo { whenever Promise.in(2) { say 'hi' } }; react foo
# rakudo & now mutsu: X::Comp::WheneverOutOfScope
```

## Changes

- **`src/parser/whenever_scope.rs`** (new): a post-parse AST walk tracking a single `in_scope` boolean. `react { }` and the `supply { }` emitter closure (a `Lambda` named `__mutsu_supply_emitter_*`) open the scope; routine/package boundaries (`sub`/`method`/`class`/`role`/`package` decls, `sub { }`, pointy/parameterised closures, non-emitter `Lambda`) reset it; inline blocks preserve it. On a `whenever` reached with `in_scope == false`, its line is recorded.
  - **No false positives:** the walk is conservative — an unhandled container is simply not recursed into (a false negative at worst), and a legitimate `whenever` inside react/supply is never reachable behind a routine-boundary reset, so valid concurrency code is never rejected.
- **`parse_program`** raises `X::Comp::WheneverOutOfScope` when the walk finds one.
- **`react STATEMENT`** (blorst form, e.g. `react foo`) now parses, so `sub foo { whenever ... }; react foo` reaches the diagnostic instead of a bare parse error.

## Tests

- Whitelists `roast/MISC/bug-coverage-6.d.t` (1/1).
- New `t/whenever-out-of-scope.t` (8 assertions): out-of-scope cases (sub/method/raw-closure/top-level) throw; legitimate cases (react, supply, inline for inside react, nested whenever) live.
- `make test` PASS (14638). Whitelisted S17 supply/react tests verified green locally (no false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)