### PR TITLE
fix(cli): parse-error snippet no longer panics on multi-byte source lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,9 +102,12 @@ fn format_parse_error(err: &RuntimeError, source: &str, program_name: &str) -> S
         if line >= 1 && line <= source_lines.len() {
             let src_line = source_lines[line - 1];
             let col = err.column().unwrap_or(1);
-            let col_idx = col.saturating_sub(1).min(src_line.len());
-            let before = &src_line[..col_idx];
-            let after = &src_line[col_idx..];
+            // `col` is a 1-based character column, so split the line by
+            // character position (not byte offset) to avoid slicing inside a
+            // multi-byte UTF-8 character.
+            let col_idx = col.saturating_sub(1).min(src_line.chars().count());
+            let before: String = src_line.chars().take(col_idx).collect();
+            let after: String = src_line.chars().skip(col_idx).collect();
             out.push_str(&format!("------>{}{}\n", before, after));
             let padding = " ".repeat(7 + col_idx);
             out.push_str(&format!("{}^", padding));

--- a/t/parse-error-multibyte-column.t
+++ b/t/parse-error-multibyte-column.t
@@ -1,0 +1,40 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+# A parse error whose column falls after (or inside) a multi-byte UTF-8
+# character must not crash the compiler. Previously format_parse_error() sliced
+# the source line at a character column used as a byte offset, panicking with
+# "byte index N is not a char boundary".
+
+plan 3;
+
+# Multi-byte characters (é, î) before the offending token.
+is_run(
+    'say "aéî"" if False;',
+    {
+        status => sub { 0 != $^a },
+        err    => rx/'SORRY'/,
+    },
+    'parse error after multi-byte chars reports SORRY, not a panic',
+);
+
+# The error output must not contain a Rust panic message.
+is_run(
+    'my $x = "ключ"" ;',
+    {
+        status => sub { 0 != $^a },
+        err    => sub { $^e !~~ /:i 'panic' | 'char boundary'/ },
+    },
+    'parse error after Cyrillic chars does not panic',
+);
+
+# Sanity: an ASCII parse error still reports SORRY.
+is_run(
+    'my $x = 1 1;',
+    {
+        status => sub { 0 != $^a },
+        err    => rx/'SORRY'/,
+    },
+    'ASCII parse error still reports SORRY',
+);


### PR DESCRIPTION
## Summary

Feeding mutsu a malformed program whose parse error falls after a multi-byte UTF-8 character crashed the compiler with a Rust panic instead of printing the error:

```
$ mutsu -e 'say "aéî"" if False;'
thread '<unnamed>' panicked at src/main.rs:106:35:
byte index 23 is not a char boundary; it is inside 'î' (bytes 22..24) of ...
```

`format_parse_error()` split the offending source line with `&src_line[..col]` using the parse error's column, but the parser reports the column as a **1-based character position** (`chars().count()`). On a line containing multi-byte characters before the error, that character column used as a **byte offset** could land inside a character and panic.

## Fix

Split the line by character position (`chars().take()/skip()`) instead of byte offset. The same program now prints:

```
===SORRY!=== Error while compiling ...
expected statement: ...
at ...:1
------>say "aéî"" if False;
                    ^
```

## Test
- New `t/parse-error-multibyte-column.t` (3 assertions via `is_run`) covering Latin, Cyrillic and ASCII parse errors, and asserting the error output contains no Rust panic message.
- `make test` passes (14641 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)