### PR TITLE
fix(regex): honour separator quantifiers with a captured atom in the find-all matcher

### DIFF
--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -130,7 +130,7 @@ impl Interpreter {
     ///
     /// Returns `(end, caps)` pairs in LOWEST-priority-first order (for the LIFO
     /// matching stack): shortest match first, longest (greedy) last.
-    fn match_separated_quantifier(
+    pub(super) fn match_separated_quantifier(
         &self,
         token: &RegexToken,
         chars: &[char],

--- a/src/runtime/regex/regex_match_nocap.rs
+++ b/src/runtime/regex/regex_match_nocap.rs
@@ -22,6 +22,26 @@ impl Interpreter {
                 continue;
             }
             let token = &pattern.tokens[idx];
+            // Separator quantifiers (`atom **N %% sep`, `atom +% sep`, ...) whose
+            // atom carries a capture are kept as a native separated token by the
+            // parser (see `expand_ltm_pattern`); the capturing matcher handles
+            // them via `match_separated_quantifier`. This no-capture matcher must
+            // do the same, otherwise it silently ignores the separator and treats
+            // the token as a plain count (so `(\d) ** 4 % '.'` fails to match
+            // "1.2.3.4"). We only need the end positions here, so discard caps.
+            if token.separator.is_some() {
+                for (next, _caps) in self.match_separated_quantifier(
+                    token,
+                    chars,
+                    pos,
+                    &RegexCaptures::default(),
+                    pkg,
+                    pattern,
+                ) {
+                    stack.push((idx + 1, next));
+                }
+                continue;
+            }
             match token.quant {
                 RegexQuant::One => {
                     if let Some(next) = self.regex_match_atom_in_pkg(

--- a/t/comb-separated-quantifier-capture.t
+++ b/t/comb-separated-quantifier-capture.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+plan 6;
+
+# `.comb(/regex/)` (which uses the non-capturing find-all matcher) must honour a
+# separator quantifier whose atom carries a capture, e.g. `(\d) ** 4 % '.'`.
+# Previously the find-all matcher ignored the `%` separator and treated the token
+# as a plain count, so IPv4-style patterns matched nothing.
+
+my $ips = "Go 127.0.0.1, I said! He went to 173.194.32.32.";
+
+is-deeply $ips.comb(/ (\d ** 1..3) ** 4 % '.' /).List,
+    ("127.0.0.1", "173.194.32.32"),
+    '.comb with (capture) ** N % sep finds all IPv4 addresses';
+
+is-deeply "1.2.3.4".comb(/ (\d) ** 4 % '.' /).List,
+    ("1.2.3.4",),
+    '.comb with single-digit captured groups and a separator';
+
+# A non-capturing separated quantifier must keep working.
+is-deeply "1-2-3 44-55".comb(/ \d+ % '-' /).List,
+    ("1-2-3", "44-55"),
+    '.comb with a non-capturing separated quantifier still works';
+
+# The same pattern via ~~ single match and m:g must agree on the match strings.
+is ("127.0.0.1" ~~ / (\d ** 1..3) ** 4 % '.' /).Str, "127.0.0.1",
+    'single ~~ match of a separated capture quantifier';
+
+my @g;
+@g.push(.Str) for "127.0.0.1 5.6.7.8" ~~ m:g/ (\d ** 1..3) ** 4 % '.' /;
+is-deeply @g, ["127.0.0.1", "5.6.7.8"], 'm:g match strings agree with .comb';
+
+# .subst using such a pattern should also match.
+is "127.0.0.1".subst(/ (\d ** 1..3) ** 4 % '.' /, "IP"), "IP",
+    '.subst with a separated capture quantifier matches';


### PR DESCRIPTION
## Summary

`.comb(/regex/)` (and other callers of the non-capturing `regex_find_all` matcher) ignored the `%` separator of a *separated quantifier whose atom carries a capture*, e.g. `(\d) ** 4 % '.'`.

```raku
"Go 127.0.0.1 and 173.194.32.32".comb(/ (\d ** 1..3) ** 4 % '.' /)
# before: ().Seq        after: ("127.0.0.1", "173.194.32.32").Seq
```

The no-capture matcher (`regex_match_end_from_in_pkg`) went straight to its `token.quant` arms without checking `token.separator`, so it treated the token as a plain count and tried to match four *consecutive* digits — which never appear in "1.2.3.4" — yielding no matches. (A non-capturing separated quantifier like `\d+ % '.'` is string-expanded at parse time and was unaffected; only the captured form, kept as a native separated token by #4165, hit this path.)

## Fix

The capturing matcher already special-cases `token.separator.is_some()` via `match_separated_quantifier`. Mirror that check in the no-capture matcher — only the end positions are needed there, so the folded captures are discarded. `match_separated_quantifier` is widened to `pub(super)` so the sibling module can call it.

## Tests

- New `t/comb-separated-quantifier-capture.t` (6 assertions): `.comb`/`.subst` with `(capture) ** N % sep`, non-capturing separated quantifier still works, `~~` single and `m:g` match strings agree.
- `make test` PASS (14644). S05 regex roast suite green.

Note: this fixes match *existence* for these patterns via the find-all path. The `m:g` *nested folded-capture* structure (`$m[0][0]` indexing, needed by `roast/integration/advent2012-day22.t` test 6) is a separate, deeper issue — the global-match capture pipeline (`RegexCaptures.positional: Vec<String>`) cannot yet carry nested captures — so that file is not whitelisted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)