### PR TITLE
fix(gc): two STW-starvation liveness holes under rapid worker spawn churn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,32 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Phase B（GC）— spawn churn が cooperative STW を飢餓させる 2 つの liveness ホールを修正
+
+`roast/S17-lowlevel/semaphore.t`（RT #128628: 4000 個の `Promise.start` を高速 spawn）が
+`MUTSU_GC=on` で決定的に CI timeout（gc-stress advisory roast で Wstat 124）。gdb でのスレッド
+ダンプと `MUTSU_GC_LOG` の pause 分析（pause_ns≒52ms が collect の大半を占める）から、
+**短命 worker の churn 中は `try_stop_the_world` がほぼ毎回 50ms を浪費する** 2 つの穴を特定:
+
+1. **誕生ウィンドウ**: `spawn_user_thread` は親側で `enter_mutator_worker`（quiescence ターゲット
+   +1）するが、worker が起動して最初の safepoint/safe region に到達するまで QUIESCENT に寄与
+   できない。spawn バースト中はほぼ常に誕生ウィンドウ内のスレッドが存在し、STW が 50ms
+   タイムアウト→100ms cooldown を繰り返す。→ **親が spawn 直前に未起動 worker を quiescent として
+   先取りカウント**（`preregister_worker_quiescent`）し、worker の最初の動作
+   （`worker_started`）で checked-exit する。worker は checked-exit を通るまで Gc 状態に一切
+   触れないので健全（scan 進行中なら park してから開始）。
+2. **exit 通知漏れ**: worker の終了（`exit_mutator_worker`）は quiescence 方程式を「ターゲットを
+   下げる」ことで満たすが、rendezvous condvar を notify しないため、待機中の collector は残り
+   timeout をフルに眠って deadline での再チェックでようやく成立に気付く（52ms pause の正体は
+   これ）。短命 worker churn では停止要求時にほぼ必ず誰かが exit 途中なので、ほぼ全 collect が
+   全額を支払っていた。→ `exit_mutator_worker` から `notify_worker_exit` で collector を起こす。
+
+効果: N=4000 の repro が **60 秒 timeout → 7.6 秒**（debug）。pin =
+`tests/gc_stress.rs::spawn_churn_does_not_starve_stop_the_world`（300 spawn churn で
+`pause_ns_total < 2s`。修正前実測 3.51s / 修正後 数十 ms — どちらの穴が再発しても捕捉）。
+`make test` 1504 files PASS・S17 並行系 GC=on スモーク（stress/start/nonblocking-await/lock）
+VERIFY FAIL=0。
+
 ## 2026-07-04: `S09-subscript/slice.t` を 56/56 で whitelist — nested slice adverbs
 
 最後まで残っていた test 35（`nested slices` subtest、62 assertion）を解決し、`S09-subscript/slice.t`

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -592,9 +592,12 @@ pub(crate) fn enter_mutator_worker() {
 
 /// Register that a user worker thread has finished. Balanced against
 /// `enter_mutator_worker`; run from the worker via an RAII guard so a panic in
-/// user code still decrements.
+/// user code still decrements. Wakes any collector waiting for quiescence —
+/// an exit *lowers* the quiescence target, which is just as satisfying as a
+/// park (see `stw::notify_worker_exit`).
 pub(crate) fn exit_mutator_worker() {
     MUTATOR_WORKER_THREADS.fetch_sub(1, Ordering::AcqRel);
+    super::stw::notify_worker_exit();
 }
 
 /// Whether any user worker thread may currently be mutating the `Gc` graph.

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -58,6 +58,6 @@ pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_sl
 pub(crate) use safepoint::{SafepointKind, armed as gc_safepoints_armed, gc_safepoint};
 #[allow(unused_imports)]
 pub(crate) use stw::{
-    block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point, stw_aware_wait,
-    stw_requested,
+    block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point,
+    preregister_worker_quiescent, stw_aware_wait, stw_requested, worker_started,
 };

--- a/src/gc/stw.rs
+++ b/src/gc/stw.rs
@@ -127,6 +127,21 @@ fn quiescent_enter() {
     rendezvous().1.notify_all();
 }
 
+/// Wake a collector blocked in [`try_stop_the_world`] so it re-evaluates its
+/// quiescence equation. Called from `gc_ptr::exit_mutator_worker`: a worker
+/// EXITING (unregistering) satisfies the equation by lowering `needed`, not by
+/// raising [`QUIESCENT`], so without this wake the collector slept its full
+/// remaining timeout and only noticed at the deadline — during short-lived
+/// worker churn (a `Promise.start` per loop iteration) some worker is almost
+/// always mid-exit at stop time, so nearly every collect paid the whole STW
+/// timeout as pause (S17-lowlevel/semaphore.t: ~50ms × hundreds of collects =
+/// CI timeout).
+pub(crate) fn notify_worker_exit() {
+    if super::gc_ptr::gc_enabled() {
+        rendezvous().1.notify_all();
+    }
+}
+
 /// Leave quiescence. If a (possibly new) stop-the-world is in progress at the
 /// moment of leaving, the collector may already have counted this thread —
 /// re-enter quiescence and park until release, then try to leave again. This
@@ -150,6 +165,34 @@ fn wait_until_released() {
     while stw_requested() {
         let (g, _) = cvar.wait_timeout(guard, Duration::from_millis(10)).unwrap();
         guard = g;
+    }
+}
+
+/// Count a not-yet-started worker thread quiescent on the parent's behalf,
+/// right before `spawn_user_thread` creates it. This closes the *birth window*
+/// (the parent's `enter_mutator_worker` → the worker's first safepoint or safe
+/// region): the unborn worker is already in the quiescence target, but until
+/// it starts executing it cannot park, so during a spawn burst (`Promise.start`
+/// per loop iteration) some thread is almost always inside clone3/thread setup
+/// and `try_stop_the_world` burns its full timeout at nearly every candidate
+/// trigger — S17-lowlevel/semaphore.t (4000 rapid `Promise.start`s) degraded
+/// from seconds to a CI timeout under `MUTSU_GC=on`. Counting the unborn
+/// worker quiescent is sound: it provably touches no `Gc` state until
+/// [`worker_started`] leaves quiescence via the checked protocol.
+pub(crate) fn preregister_worker_quiescent() {
+    if super::gc_ptr::gc_enabled() {
+        quiescent_enter();
+    }
+}
+
+/// The spawned worker's first act (before any user code): become a registered
+/// mutator and leave the parent-granted quiescent state. The checked exit
+/// parks first if a stop-the-world is in progress, so the worker cannot start
+/// mutating refcounts mid-scan. Pairs with [`preregister_worker_quiescent`].
+pub(crate) fn worker_started() {
+    mark_thread_registered(true);
+    if super::gc_ptr::gc_enabled() {
+        quiescent_exit_checked();
     }
 }
 

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -21,6 +21,11 @@ where
     // parent — before the thread exists — so the count is up the instant this
     // returns, then dropped by the worker's RAII guard (panic-safe).
     crate::gc::enter_mutator_worker();
+    // Count the unborn worker quiescent until it actually starts: it touches
+    // no `Gc` state before `worker_started` leaves quiescence (checked), and
+    // without this a spawn burst starves every stop-the-world attempt — see
+    // `gc::stw::preregister_worker_quiescent`.
+    crate::gc::preregister_worker_quiescent();
     std::thread::Builder::new()
         .stack_size(USER_THREAD_STACK_SIZE)
         .spawn(move || {
@@ -32,9 +37,11 @@ where
                 }
             }
             let _guard = WorkerGuard;
-            // Registered-mutator flag: this thread's quiescence now counts
-            // toward (and is required by) the STW rendezvous (gc::stw).
-            crate::gc::mark_thread_registered(true);
+            // Registered-mutator flag + leave the parent-granted quiescent
+            // state (parking first if a scan is in progress): this thread's
+            // quiescence now counts toward (and is required by) the STW
+            // rendezvous (gc::stw).
+            crate::gc::worker_started();
             f()
         })
         .expect("failed to spawn worker thread")

--- a/tests/gc_stress.rs
+++ b/tests/gc_stress.rs
@@ -481,3 +481,56 @@ fn threaded_cycle_churn_is_collected_soundly() {
         "cycle garbage from worker threads must be reclaimed; stderr:\n{err}"
     );
 }
+
+/// Rapid short-lived worker churn (a `Promise.start` per loop iteration, RT
+/// #128628 shape — S17-lowlevel/semaphore.t) must not starve the cooperative
+/// stop-the-world. Two regressions made this degrade from seconds to a CI
+/// timeout under GC=on, each burning ~the full 50ms STW wait at nearly every
+/// collect: (1) the spawn *birth window* — a worker counted in the quiescence
+/// target from `enter_mutator_worker` (parent-side) but unable to park until
+/// it starts running — fixed by parent-side `preregister_worker_quiescent`;
+/// (2) a worker *exit* satisfies the quiescence equation by lowering the
+/// target, which never woke the waiting collector — fixed by
+/// `notify_worker_exit`. Guard both via the accumulated pause total: with
+/// either regression, ~50ms × (collects during 300 spawns) blows far past the
+/// bound (measured pre-fix: multiple seconds; post-fix: tens of ms).
+#[test]
+fn spawn_churn_does_not_starve_stop_the_world() {
+    let src = r#"
+        my Semaphore $s .= new(1);
+        my @p;
+        my $r = 0;
+        for ^300 {
+            my $i = $_;
+            @p.push: Promise.start({ $s.acquire; $r += $i; $s.release; });
+        }
+        await @p;
+        say $r;
+    "#;
+
+    let (out, err, ok) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_EVERY_CANDIDATE", "64"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+
+    assert!(ok, "spawn-churn run must not crash; stderr:\n{err}");
+    assert_eq!(out.trim(), "44850", "semaphore-protected sum must be exact");
+
+    let pause_total_ns = err
+        .lines()
+        .find(|l| l.contains("[mutsu vm-stats] gc:"))
+        .and_then(|l| {
+            l.split_whitespace()
+                .find_map(|tok| tok.strip_prefix("pause_ns_total="))
+        })
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(u64::MAX);
+    assert!(
+        pause_total_ns < 2_000_000_000,
+        "STW must not repeatedly time out under spawn churn; pause_ns_total={pause_total_ns}\nstderr:\n{err}"
+    );
+}


### PR DESCRIPTION
## Summary

`roast/S17-lowlevel/semaphore.t` (RT #128628 shape: 4000 rapid `Promise.start`s through a Semaphore) deterministically hit the per-file timeout under `MUTSU_GC=on` — 10/10 local repro, CI gc-stress advisory roast `Wstat 31744 (exited 124)`. A thread dump plus `MUTSU_GC_LOG` analysis showed most collects pausing **~52ms ≈ the full `try_stop_the_world` timeout**. Two independent holes, each sufficient to burn the whole STW wait at nearly every collect during short-lived worker churn:

### Hole 1 — spawn birth window
`spawn_user_thread` raises the quiescence target parent-side (`enter_mutator_worker`, before `clone3`), but the worker cannot park or enter a safe region until it actually starts running. During a spawn burst some thread is almost always inside thread setup → quiescence unreachable → 50ms timeout → 100ms cooldown → repeat.

**Fix**: the parent counts the unborn worker quiescent (`preregister_worker_quiescent`) right before spawning; the worker's first act (`worker_started`) leaves quiescence via the existing checked-exit protocol (parking first if a scan is in progress). Sound: the worker touches no `Gc` state before that point.

### Hole 2 — worker exit never woke the collector
A worker exiting satisfies the quiescence equation by **lowering the target** (`exit_mutator_worker`), not by raising `QUIESCENT` — and only `quiescent_enter` notified the rendezvous. The collector slept its full remaining timeout and noticed only at the deadline re-check (hence the consistent ~52ms pauses on collects that then *succeeded*). With short-lived workers, some worker is almost always mid-exit at stop time.

**Fix**: `exit_mutator_worker` notifies the rendezvous (`notify_worker_exit`).

## Effect

| workload | before | after |
|---|---|---|
| N=4000 repro (debug) | >60s timeout | **7.6s** |
| semaphore.t, release + GC=on + VERIFY | 124 (30s budget) | **~7.3s**, VERIFY FAIL=0 |
| thread.t, release + GC=on + VERIFY | 124 (debug repro) | **~22s** (budget 30s) |

Note: no `Wstat: 11` (SEGV) appears in the recent CI artifacts — the observable failure mode there is the timeout this PR fixes. If a specific run showed signal 11, please point me at it and I'll chase it separately.

## Pin

`tests/gc_stress.rs::spawn_churn_does_not_starve_stop_the_world`: a 300-spawn churn must keep `pause_ns_total` under 2s — measured **3.51s pre-fix** vs tens of ms post-fix, so either hole regressing trips it.

## Validation

- `make test` PASS (1504 files)
- GC=on smoke over S17 concurrency roast (semaphore/thread/stress/start/nonblocking-await/lock): clean, VERIFY FAIL=0
- unit + gc_stress tests green in both normal and single-threaded stress env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK