### PR TITLE
fix(regex): preserve folded/nested captures in global (m:g) match objects

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1326,6 +1326,7 @@ roast/integration/advent2012-day12.t
 roast/integration/advent2012-day13.t
 roast/integration/advent2012-day16.t
 roast/integration/advent2012-day20.t
+roast/integration/advent2012-day22.t
 roast/integration/advent2012-day24.t
 roast/integration/advent2013-day02.t
 roast/integration/advent2013-day06.t

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -266,12 +266,22 @@ impl Interpreter {
         let slash_list = selected
             .iter()
             .map(|c| {
-                Value::make_match_object_with_captures(
+                // Use the full builder so quantified / nested positional captures
+                // (e.g. `(\d) ** 4 % '.'` folding group 0 into a 4-element list)
+                // survive into each `m:g` match object, matching the single-match
+                // path. The short builder dropped `positional_quantified` etc.,
+                // collapsing `$m[0]` to a bare string.
+                Value::make_match_object_full(
                     c.matched.clone(),
                     c.from as i64,
                     c.to as i64,
                     &c.positional,
                     &c.named,
+                    &c.named_subcaps,
+                    &c.positional_subcaps,
+                    &c.positional_quantified,
+                    &c.positional_nil,
+                    None,
                 )
             })
             .collect::<Vec<_>>();

--- a/t/mg-folded-capture.t
+++ b/t/mg-folded-capture.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 7;
+
+# A global match (`m:g`, `.match(:g)`, `~~ m:g`) must preserve the nested/folded
+# positional captures in each Match object, exactly like a single match does.
+# Previously the multi-match path used a string-only Match builder, so a folded
+# group such as `(\d) ** 4 % '.'` collapsed `$m[0]` to a bare string.
+
+my @ip;
+@ip.push(.list) for "127.0.0.1 5.6.7.8" ~~ m:g/ (\d ** 1..3) ** 4 % '.' /;
+
+is +@ip, 2, 'two top-level m:g matches';
+
+my $first = @ip[0][0];
+is $first.Str, "127 0 0 1", 'folded group stringifies to the joined sub-matches';
+is $first.elems, 4, 'folded group has 4 sub-captures';
+is $first[0].Str, "127", 'first sub-capture';
+is $first[3].Str, "1", 'last sub-capture';
+
+my $second = @ip[1][0];
+is $second[1].Str, "6", 'second match folded sub-capture';
+
+# A simple quantified capture via m:g also folds.
+my @words;
+@words.push(.[0].elems) for "aXbXc dXe" ~~ m:g/ (\w) ** 2..3 % 'X' /;
+is-deeply @words, [3, 2], 'm:g folds a plain quantified capture group';


### PR DESCRIPTION
## Summary

A global match (`m:g`, `.match(:g)`, `~~ m:g`) built each `Match` object via the string-only `make_match_object_with_captures`, discarding the `RegexCaptures` `positional_quantified` / `positional_subcaps` / `positional_nil` fields. A quantified capture group therefore collapsed:

```raku
my @ip;
@ip.push(.list) for "127.0.0.1 5.6.7.8" ~~ m:g/ (\d ** 1..3) ** 4 % '.' /;
@ip[0][0]           # before: "1" (bare string)   after: folded 4-element list
@ip[0][0].Str       # before: wrong               after: "127 0 0 1"
@ip[0][0].elems     # before: 0                   after: 4
```

The single-match path (`~~ /regex/`) already used the full builder and folded correctly (#4165); only the global path lost the fold.

## Fix

Rebuild each `m:g` Match in `apply_multi_regex_captures` via `make_match_object_full`, passing the nested capture fields (`named_subcaps`, `positional_subcaps`, `positional_quantified`, `positional_nil`) — mirroring the single-match path. Follow-up to #4203, which fixed match *existence* for these patterns; this fixes their nested *capture structure*.

## Tests

- Whitelists `roast/integration/advent2012-day22.t` (6/6 — IPv4 parsing).
- New `t/mg-folded-capture.t` (7 assertions).
- `make test` green (the only failures were pre-existing flaky IO-Socket-Async timing tests under parallel load — all pass in isolation, and are unrelated to this regex-only change). S05 + regex/match roast subset (111 files, 6008 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)