### PR TITLE
fix(parser): a user sub named like an IO builtin shadows its listop form

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1336,6 +1336,7 @@ roast/integration/advent2013-day15.t
 roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t
+roast/integration/advent2014-day05.t
 roast/integration/code-blocks-as-sub-args.t
 roast/integration/diamond.t
 roast/integration/eval-and-threads.t

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -38,9 +38,21 @@ fn check_io_func_followed_by_loop<'a>(name: &str, rest_after_ws: &'a str) -> PRe
     Ok((rest_after_ws, ()))
 }
 
+/// A user-declared `sub` named like an IO builtin (`say`/`print`/`put`/`note`)
+/// shadows the builtin listop form in its lexical scope: `sub say(...) {...}; say
+/// $x` must call the user sub, not the builtin. Bail out of the builtin-statement
+/// parse so statement dispatch falls through to the general listop-call parser.
+fn shadowed_by_user_sub(name: &str) -> PResult<'_, ()> {
+    if is_user_declared_sub(name) {
+        return Err(PError::expected("io builtin shadowed by user sub"));
+    }
+    Ok(("", ()))
+}
+
 /// Parse a `say` statement.
 pub(crate) fn say_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("say", input).ok_or_else(|| PError::expected("say statement"))?;
+    shadowed_by_user_sub("say")?;
     check_bare_io_func("say", rest)?;
     let (rest, _) = ws1(rest)?;
     check_io_func_followed_by_loop("say", rest)?;
@@ -55,6 +67,7 @@ pub(crate) fn say_stmt(input: &str) -> PResult<'_, Stmt> {
 /// Parse a `print` statement.
 pub(crate) fn print_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("print", input).ok_or_else(|| PError::expected("print statement"))?;
+    shadowed_by_user_sub("print")?;
     check_bare_io_func("print", rest)?;
     let (rest, _) = ws1(rest)?;
     check_io_func_followed_by_loop("print", rest)?;
@@ -69,6 +82,7 @@ pub(crate) fn print_stmt(input: &str) -> PResult<'_, Stmt> {
 /// Parse a `put` statement.
 pub(crate) fn put_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("put", input).ok_or_else(|| PError::expected("put statement"))?;
+    shadowed_by_user_sub("put")?;
     check_bare_io_func("put", rest)?;
     let (rest, _) = ws1(rest)?;
     check_io_func_followed_by_loop("put", rest)?;
@@ -83,6 +97,7 @@ pub(crate) fn put_stmt(input: &str) -> PResult<'_, Stmt> {
 /// Parse a `note` statement.
 pub(crate) fn note_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("note", input).ok_or_else(|| PError::expected("note statement"))?;
+    shadowed_by_user_sub("note")?;
     // `note` with no arguments is valid (prints "Noted\n")
     if let Ok((rest2, _)) = ws1(rest) {
         // Check for colon invocant syntax: `note EXPR:` or `note EXPR: arg1, arg2`

--- a/t/io-builtin-user-sub-shadow.t
+++ b/t/io-builtin-user-sub-shadow.t
@@ -1,0 +1,76 @@
+use v6;
+use Test;
+
+plan 10;
+
+# A user-declared `sub` named like an IO builtin shadows the builtin listop form
+# in its lexical scope: `sub say(...) {...}; say $x` calls the user sub.
+
+{
+    my @s;
+    sub say($a) { @s.push("say:$a") }
+    say "X";
+    is-deeply @s, ["say:X"], 'user sub say shadows builtin (listop form)';
+}
+
+{
+    my @s;
+    sub print($a) { @s.push("print:$a") }
+    print "Y";
+    is-deeply @s, ["print:Y"], 'user sub print shadows builtin (listop form)';
+}
+
+{
+    my @s;
+    sub put($a) { @s.push("put:$a") }
+    put "Z";
+    is-deeply @s, ["put:Z"], 'user sub put shadows builtin (listop form)';
+}
+
+{
+    my @s;
+    sub note($a) { @s.push("note:$a") }
+    note "W";
+    is-deeply @s, ["note:W"], 'user sub note shadows builtin (listop form)';
+}
+
+# Shadowing works from inside a closure that is called later.
+{
+    my @s;
+    sub print($a) { @s.push($a) }
+    my &c = { print "in-closure" };
+    c();
+    is-deeply @s, ["in-closure"], 'user sub print is resolved from a closure';
+}
+
+# Multiple arguments are passed through.
+{
+    my @s;
+    sub say(*@a) { @s.push(@a.join("|")) }
+    say "a", "b", "c";
+    is-deeply @s, ["a|b|c"], 'user sub say receives multiple listop args';
+}
+
+# The builtin is NOT shadowed outside the sub's scope.
+{
+    my @inner;
+    {
+        sub say($a) { @inner.push($a) }
+        say "shadowed";
+    }
+    is-deeply @inner, ["shadowed"], 'inner user sub say captured its call';
+    # Out here `say` is the builtin again; just confirm it does not push.
+    lives-ok { say "outer-builtin" }, 'builtin say works again outside the shadow scope';
+}
+
+# Paren-call form was already fine; keep it covered.
+{
+    my @s;
+    sub print($a) { @s.push($a) }
+    print("paren");
+    is-deeply @s, ["paren"], 'user sub print via paren call';
+}
+
+# The builtin still parses normally when no user sub shadows it.
+lives-ok { say "plain"; print "plain\n"; put "p"; note "n" },
+    'unshadowed IO builtins still parse and run';


### PR DESCRIPTION
## Summary

`sub say(...) {...}; say \$x` (and likewise `print`/`put`/`note`) must call the user-declared sub, not the builtin. mutsu parsed the listop form `say \$x` straight into the builtin `Stmt::Say`/`Print`/`Put`/`Note`, ignoring an in-scope user sub of the same name:

```raku
my @seen;
sub print($a) { @seen.push: $a }
$supply.act: { print " Fizz" if $_ %% 3 }   # went to the *builtin*, @seen stayed empty
```

## Fix

At the start of `say_stmt`/`print_stmt`/`put_stmt`/`note_stmt`, bail out (with a non-fatal parse error) when `is_user_declared_sub(name)` is true, so statement dispatch falls through to the general listop-call parser, which resolves the user sub. The paren-call form (`print("x")`) already worked; only the listop form was affected.

The check is lexically scoped (`is_user_declared_sub` walks the enclosing parse scopes), so:
- the builtin is still used outside the shadowing sub's scope, and
- the builtin is unaffected when no user sub of that name exists.

## Tests

- Whitelists `roast/integration/advent2014-day05.t` (7/7 — a FizzBuzz-via-`Supplier.act` example whose helper is `sub print`).
- New `t/io-builtin-user-sub-shadow.t` (10 assertions): all four builtins shadowed via listop form, from a closure, with multiple args, scope isolation (inner shadow does not leak out), paren-call form, and unshadowed builtins still parse/run.
- `make test` PASS (14715). S32-io / S06-signature roast subset (60 files, 1839 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)