### PR TITLE
fix(regex): value-typed properties in <+:...>/<-:...> character classes

### DIFF
--- a/src/runtime/unicode.rs
+++ b/src/runtime/unicode.rs
@@ -7,6 +7,16 @@ thread_local! {
 }
 
 pub(super) fn check_unicode_property(name: &str, c: char) -> bool {
+    // Paren-argument form Prop("Value") / Prop(Value): the <+:Prop(...)>
+    // character-class combining syntax embeds the value in the name string.
+    if let Some(open) = name.find('(')
+        && name.ends_with(')')
+        && open > 0
+    {
+        let prop = &name[..open];
+        let args = &name[open + 1..name.len() - 1];
+        return check_unicode_property_with_args(prop, args, c);
+    }
     // Handle Unicode block properties (InXxx) separately since the regex crate
     // doesn't support the unicode-block feature
     if let Some(block_name) = name.strip_prefix("In")

--- a/t/regex-charclass-property-value.t
+++ b/t/regex-charclass-property-value.t
@@ -1,0 +1,32 @@
+use Test;
+
+# The character-class combining forms <+:Prop("Value")> and <-:Prop("Value")>
+# embed the property value in the class-item name. mutsu only handled the
+# angle-bracket <Value> form there, so value-typed properties (Line_Break,
+# Bidi_Class, East_Asian_Width, ...) failed inside <+...>/<-...>.
+
+plan 14;
+
+# <+:Prop("Value")> inclusion
+ok "漢" ~~ /<+:Line_Break("ID")>/, 'plus Line_Break ID matches ideograph';
+nok "A" ~~ /<+:Line_Break("ID")>/, 'plus Line_Break ID does not match Latin';
+ok "ب" ~~ /<+:Bidi_Class("AL")>/, 'plus Bidi_Class AL matches Arabic';
+ok "5" ~~ /<+:Bidi_Class("EN")>/, 'plus Bidi_Class EN matches digit';
+ok "漢" ~~ /<+:East_Asian_Width("W")>/, 'plus East_Asian_Width W matches ideograph';
+
+# quantified
+ok "ب漢" ~~ /^<+:Bidi_Class("AL")>+/, 'quantified plus form matches leading Arabic';
+
+# <-:Prop("Value")> exclusion
+ok "A" ~~ /<-:Line_Break("ID")>/, 'minus Line_Break ID matches non-ideograph';
+nok "漢" ~~ /<-:Line_Break("ID")>/, 'minus Line_Break ID excludes ideograph';
+
+# combined with other class items
+ok "5" ~~ /<[a..z]+:Bidi_Class("EN")>/, 'combined range + property matches digit';
+ok "x" ~~ /<[a..z]+:Bidi_Class("EN")>/, 'combined range + property matches letter';
+
+# existing forms still work
+ok "漢" ~~ /<:Line_Break("ID")>/, 'assertion form still works';
+ok "A" ~~ /<+alpha>/, 'built-in class still works';
+ok "A" ~~ /<+:Lu>/, 'plus General_Category still works';
+ok "A" ~~ /<+:Script("Latin")>/, 'plus Script still works';


### PR DESCRIPTION
## Summary

Follow-up to #4209. The character-class combining forms `<+:Prop("Value")>` and `<-:Prop("Value")>` store the whole `Prop("Value")` string as the class-item name and evaluate it with `check_unicode_property()`. That function only understood the angle-bracket `Prop<Value>` form, so value-typed properties inside `<+...>`/`<-...>` always failed to match:

```
"漢" ~~ /<+:Line_Break("ID")>/    # was False, raku True
"ب" ~~ /<+:Bidi_Class("AL")>/    # was False, raku True
```

Handle the paren-argument form `Prop("Value")` / `Prop(Value)` in `check_unicode_property()` by delegating to `check_unicode_property_with_args` (which strips the quotes and falls back to the uniprop matcher).

## Test
- New `t/regex-charclass-property-value.t` (14 assertions): inclusion `<+:...>`, exclusion `<-:...>`, quantified, and combined `<[a..z]+:Prop(...)>` forms, all cross-checked against `raku`.
- `make test` passes (14746 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)