### PR TITLE
fix(gc): shared captured-env maps were multiply-traced, falsely reclaiming live nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,33 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Phase B（GC）— 共有 captured-env の phantom edge による偽回収（生存データ破壊）を修正
+
+GC=on advisory roast の `S11-modules/require.t` が決定的に 1 subtest 赤
+（`$*PROGRAM.parent(2)` が `/packages/...` に化けて chdir 失敗）。ノード watch 計装で追跡した結果、
+**`$*PROGRAM` の IO::Path Instance の attrs ノードが最初の collect（cycle=0）で偽回収**され、
+`drop_gc_edges` が生きている属性 map を空にしていた（`.Str` が "" になる）。VERIFY は沈黙
+（カウントが一貫して誤っているため検出不能）。
+
+原因は **Trace の 1:1 ルール違反**: closure の captured env の overlay map（`Arc<SymMap>`）は同一
+フレーム由来の全 closure に Arc 共有されるが、`SubData::trace` は各保持者から map の中身を
+inline トレースしていた。map は各 `Gc` ハンドルを **1 回だけ**所有するのに、N 個の共有者が
+それぞれ辺を主張すると trial deletion で N-1 個の phantom edge 分だけ過剰減算され、外部参照を
+持つ生存ノードが white 化して回収される。`value_gc::uniquely_owned` として確立済みのルール
+（共有 Arc ラッパーは唯一保持時のみトレース）の適用漏れ。`LazyList::trace` も同罪。さらに
+`drop_gc_edges` は共有 map に `values_mut()`（= COW クローン）をかけ、reclaim 中に `Gc::clone`
+を走らせてカウントを汚す二次バグも同居していた。
+
+修正: `Env::gc_overlay_uniquely_owned()`（overlay Arc の strong_count==1）を追加し、
+`SubData`/`LazyList` の `trace`/`drop_gc_edges` の env 走査を唯一保持時のみに制限。共有 map は
+external root holder として保守側に倒す（そこ経由のみのサイクルは繰延 — 破壊はしない）。
+capture 時に `clone_env` で flatten される通常の closure capture は fresh map = 唯一保持なので、
+主要な closure サイクル回収能力は不変（gc_stress の回収系テスト全通過で確認）。
+
+pin = `value_gc::tests::shared_captured_env_edges_are_not_claimed_per_sharer`（共有 map + 2 closure
+の 4 ノード実サイクル: 生存 hash は strong/内容とも無傷、実サイクルは回収 — ゲート無効化で
+確実に fail することを確認済み）。`make test` 1513 files PASS・require.t GC=on 58/58。
+
 ## 2026-07-05: Phase B（GC）— spawn churn が cooperative STW を飢餓させる 2 つの liveness ホールを修正
 
 `roast/S17-lowlevel/semaphore.t`（RT #128628: 4000 個の `Promise.start` を高速 spawn）が

--- a/src/env.rs
+++ b/src/env.rs
@@ -467,6 +467,22 @@ impl Env {
         self.cow_mut().values_mut()
     }
 
+    /// Whether this env's overlay map (`inner`) is uniquely owned by this `Env`
+    /// handle — i.e. no other `Env` clone (another closure's capture, a saved
+    /// call frame, the live interpreter env) shares the same `Arc<SymMap>`.
+    ///
+    /// GC edge rule (see `value_gc::uniquely_owned`): a `Trace` impl may claim
+    /// the map's contained `Gc` handles as its own edges ONLY when it is the
+    /// map's sole holder. The map owns each handle once, so N sharers each
+    /// tracing it would report N phantom edge sets and over-decrement live
+    /// nodes during trial deletion — a false reclaim that empties live data
+    /// (observed: `$*PROGRAM`'s IO::Path attrs wiped in
+    /// roast/S11-modules/require.t under `MUTSU_GC=on`).
+    #[inline]
+    pub(crate) fn gc_overlay_uniquely_owned(&self) -> bool {
+        Arc::strong_count(&self.inner) == 1
+    }
+
     /// GC root enumeration (ADR-0001/0002, `docs/gc-level1-detailed-design.md`
     /// §2.2/§11 step 1): visit every `Value` reachable from this env, including
     /// the `parent` overlay chain. Unlike `iter`/`keys`/`values` (overlay-only,

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -226,8 +226,12 @@ impl Trace for (Mutex<ChannelState>, Condvar) {
 /// wrongly freed) and is the documented step-10 follow-up.
 impl Trace for LazyList {
     fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
-        for v in self.env.values() {
-            v.gc_trace(visit);
+        // Same shared-overlay rule as `SubData::trace`: claim the captured
+        // env map's edges only as its sole holder.
+        if self.env.gc_overlay_uniquely_owned() {
+            for v in self.env.values() {
+                v.gc_trace(visit);
+            }
         }
         if let Ok(cache) = self.cache.lock()
             && let Some(items) = cache.as_ref()
@@ -241,8 +245,11 @@ impl Trace for LazyList {
         }
     }
     fn drop_gc_edges(&mut self) {
-        for v in self.env.values_mut() {
-            *v = Value::Nil;
+        // Sever only a uniquely-owned overlay — see `SubData::drop_gc_edges`.
+        if self.env.gc_overlay_uniquely_owned() {
+            for v in self.env.values_mut() {
+                *v = Value::Nil;
+            }
         }
         if let Ok(mut cache) = self.cache.lock() {
             *cache = None;
@@ -256,8 +263,20 @@ impl Trace for LazyList {
 /// other). Second-wave migration (§11 step 9).
 impl Trace for SubData {
     fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
-        for v in self.env.values() {
-            v.gc_trace(visit);
+        // The captured env's overlay map is `Arc`-shared across every closure
+        // captured from the same frame (an env clone is an Arc bump). The map
+        // owns its `Gc` handles ONCE, so trace them from this node only when
+        // it is the map's sole holder — otherwise N sharers would each claim
+        // the same edges and over-decrement live nodes during trial deletion
+        // (false reclaim: `$*PROGRAM`'s attrs wiped in S11-modules/require.t).
+        // A shared map acts as an external root holder instead: conservative —
+        // a cycle routed solely through it defers (never corrupts). Flattened
+        // captures (`clone_env` at Sub creation) build a fresh map, so the
+        // common closure-capture cycles stay uniquely owned and collectable.
+        if self.env.gc_overlay_uniquely_owned() {
+            for v in self.env.values() {
+                v.gc_trace(visit);
+            }
         }
         for v in &self.assumed_positional {
             v.gc_trace(visit);
@@ -267,8 +286,14 @@ impl Trace for SubData {
         }
     }
     fn drop_gc_edges(&mut self) {
-        for v in self.env.values_mut() {
-            *v = Value::Nil;
+        // Sever only a uniquely-owned overlay, mirroring `trace`: a shared map
+        // is still in use by its other holders — and `values_mut` on it would
+        // COW-clone the whole map mid-reclaim, running `Gc::clone`s that
+        // corrupt the collector's scratch counts.
+        if self.env.gc_overlay_uniquely_owned() {
+            for v in self.env.values_mut() {
+                *v = Value::Nil;
+            }
         }
         self.assumed_positional.clear();
         self.assumed_named.clear();
@@ -609,6 +634,114 @@ mod tests {
 
     fn fresh_hash_node() -> Value {
         Value::Hash(crate::gc::Gc::new(HashData::default()))
+    }
+
+    /// Build a minimal `SubData` capturing `env`, for the shared-env trace tests.
+    fn sub_capturing(env: crate::env::Env, id: u64) -> SubData {
+        SubData {
+            package: crate::symbol::Symbol::intern("GLOBAL"),
+            name: crate::symbol::Symbol::intern("__gc_test__"),
+            params: vec![],
+            param_defs: vec![],
+            body: vec![],
+            is_rw: false,
+            is_raw: false,
+            env,
+            assumed_positional: vec![],
+            assumed_named: std::collections::HashMap::new(),
+            id,
+            empty_sig: false,
+            is_bare_block: false,
+            compiled_code: None,
+            deprecated_message: None,
+            source_line: None,
+            source_file: None,
+            owned_captures: Vec::new(),
+            upvalues: Vec::new(),
+        }
+    }
+
+    /// Pin for the shared-captured-env phantom-edge bug: closures cloned from
+    /// the same frame share one `Arc<SymMap>` overlay, which owns each of its
+    /// `Gc` handles ONCE — but `SubData::trace` used to inline the map's edges
+    /// into EVERY sharer's child list. Two garbage closures sharing a map that
+    /// held a live hash then claimed two phantom edges, drove the hash's
+    /// GC-strong count (map +1, external local +1 = 2) to 0, and trial
+    /// deletion falsely reclaimed it — wiping live data (observed as
+    /// `$*PROGRAM`'s IO::Path attrs emptied in roast/S11-modules/require.t
+    /// under `MUTSU_GC=on`, VERIFY silent because the counts were consistently
+    /// wrong). With the uniqueness rule a shared map's edges belong to no
+    /// single node: the hash keeps its external count and must survive, while
+    /// the genuinely-garbage sub/cell cycle is still reclaimed.
+    #[test]
+    fn shared_captured_env_edges_are_not_claimed_per_sharer() {
+        let _serial = crate::gc::test_support::serial_lock();
+        drop(crate::gc::drain_candidates());
+
+        // A live hash node: one handle held here (external), one inside the
+        // shared env map below.
+        let hash = crate::gc::Gc::new(HashData {
+            map: {
+                let mut m = std::collections::HashMap::new();
+                m.insert("alive".to_string(), Value::Int(42));
+                m
+            },
+            ..Default::default()
+        });
+
+        // One env map holding the hash, shared by TWO closures (and kept
+        // shared through the collect by `env` itself — 3 Arc holders).
+        let mut env = crate::env::Env::new();
+        env.insert("%h".to_string(), Value::Hash(hash.clone()));
+
+        // The closures form a genuine garbage cycle through `ContainerRef`
+        // cells in their (owned, always-traced) assumed args:
+        //   sub1 -> cellA -> sub2 -> cellB -> sub1
+        let cell_a = crate::gc::Gc::new(std::sync::Mutex::new(Value::Nil));
+        let cell_b = crate::gc::Gc::new(std::sync::Mutex::new(Value::Nil));
+        let mut sd1 = sub_capturing(env.clone(), 1);
+        sd1.assumed_positional
+            .push(Value::ContainerRef(cell_a.clone()));
+        let sub1 = crate::gc::Gc::new(sd1);
+        let mut sd2 = sub_capturing(env.clone(), 2);
+        sd2.assumed_positional
+            .push(Value::ContainerRef(cell_b.clone()));
+        let sub2 = crate::gc::Gc::new(sd2);
+        *cell_a.lock().unwrap() = Value::Sub(sub2.clone());
+        *cell_b.lock().unwrap() = Value::Sub(sub1.clone());
+
+        // Make the closures cycle suspects and drop every local handle into
+        // the cycle. Counts at the collect: sub1/sub2 = 1 (their cell),
+        // cellA/cellB = 1 (their sub), hash = 2 (local + shared map).
+        sub1.buffer_as_candidate();
+        sub2.buffer_as_candidate();
+        drop(sub1);
+        drop(sub2);
+        drop(cell_a);
+        drop(cell_b);
+
+        let stats = crate::gc::collect_cycles();
+
+        // Pre-fix, BOTH subs traced the shared map: two phantom decrements
+        // took the hash from 2 to 0 and the "cycle" swallowed it — the node
+        // was reclaimed and drop_gc_edges emptied the live map. Post-fix the
+        // hash is untouched while the 4-node sub/cell cycle is still garbage.
+        assert_eq!(
+            hash.strong_count(),
+            2,
+            "live hash GC-strong must stay (external local + shared env map)"
+        );
+        assert_eq!(
+            hash.map.get("alive"),
+            Some(&Value::Int(42)),
+            "live hash contents must survive a collect over env-sharing closures"
+        );
+        assert!(
+            stats.reclaimed_nodes >= 4,
+            "the genuine sub/cell cycle must still be reclaimed, got {}",
+            stats.reclaimed_nodes
+        );
+        drop(env);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

GC=on runs of `roast/S11-modules/require.t` deterministically failed subtest 23 (`can change directory and require a module`): `$*PROGRAM.parent(2)` evaluated to `/packages/...` because **$*PROGRAM's IO::Path Instance attrs node had been falsely reclaimed as cycle garbage** at the run's first collect — `drop_gc_edges` emptied the live attribute map, so `.Str` became `""`. `MUTSU_GC_VERIFY` stayed silent: the strong counts were *consistently* wrong, so the frozen-view invariants held. (Tracked down with a per-node watch instrumentation correlating the node id against `MUTSU_GC_LOG=trace` reclaim lines.)

## Root cause — a violation of the 1:1 trace/handle rule

A closure's captured env overlay map (`Arc<SymMap>`) is shared by every closure captured from the same frame. `SubData::trace` inlined the map's contents into **every sharer's** child list — but the map owns each `Gc` handle **once**. N sharers claiming the same edges over-decrement the target by N−1 phantom edges during trial deletion, driving externally-referenced live nodes to strong 0 → white → reclaimed.

This is exactly the rule `value_gc::uniquely_owned` already encodes for Arc-shared wrappers (Seq/Junction/Capture/…); the env-map case was missed. `LazyList::trace` had the same hole. A second bug rode along: `drop_gc_edges` called `values_mut()` on a shared map, **COW-cloning the whole map mid-reclaim** and running `Gc::clone`s that corrupt the collector's scratch counts (observed as a `clone at strong 0` during reclaim).

## Fix

- `Env::gc_overlay_uniquely_owned()` — overlay `Arc` strong_count == 1.
- `SubData` / `LazyList` `trace` + `drop_gc_edges` touch the captured env only as its sole holder. A shared map acts as an external root holder — conservative: a cycle routed solely through it defers, never corrupts.
- Common closure captures flatten via `clone_env` into a fresh (unique) map, so the important closure-capture cycle collection is unaffected — all gc_stress reclaim tests stay green.

## Pin

`value_gc::tests::shared_captured_env_edges_are_not_claimed_per_sharer`: a live hash in a map shared by two garbage closures (genuine 4-node cycle via `ContainerRef` cells) must survive with contents and strong count intact while the cycle is still reclaimed. Verified to **fail with the uniqueness gate disabled** (exact original corruption) and pass with it.

## Validation

- `make test` PASS (1513 files)
- `require.t` 58/58 under `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=64 MUTSU_GC_VERIFY=1` (repeated)
- GC-on smoke: `S17-lowlevel/lock.t`, `t/destroy.t`
- Full `cargo test` in both normal and single-threaded stress env

Together with #4205 this clears 2 of the 3 remaining GC=on advisory-roast failure classes (left: the `cas-*.t` stress-knob quadratic — CI-config follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK