### PR TITLE
chore(gc): close §11 step 11 (sound-by-refcount) + raise gc-stress knob to EVERY_CANDIDATE=1024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,14 +169,23 @@ jobs:
 
   gc-stress:
     # Runs the whole test + roast suite with the GC cycle collector ON
-    # (design doc §9.3's `GC=on` stress job). `MUTSU_GC_EVERY_CANDIDATE=64`
-    # collects a cycle every 64 candidate pushes at the next safepoint, and
+    # (design doc §9.3's `GC=on` stress job). `MUTSU_GC_EVERY_CANDIDATE=N`
+    # collects a cycle every N candidate pushes at the next safepoint, and
     # `MUTSU_GC_VERIFY=1` checks the collector's soundness invariants around each
     # collect. The point: the collector, exercised against every program in the
-    # suite, must never corrupt live data. The collector self-gates to
-    # single-threaded regions (shared_vars strong count, design §6), so
-    # concurrency tests run with GC deferred — cross-thread cooperative STW is
-    # future work.
+    # suite, must never corrupt live data. Cross-thread scans run under the
+    # cooperative stop-the-world (design §6.1).
+    #
+    # N=1024, not 64: the trigger fires a FULL trial-deletion scan whose cost
+    # is O(live suspect graph), so a small period is quadratic on workloads
+    # that grow a large live structure while churning candidates —
+    # S17-lowlevel/cas-loop.t (4x1000 cas ops building a linked list) ran
+    # >180s at N=64 (8500+ collects x ~4300 traced nodes each) vs 3.3s at
+    # N=1024, blowing the 30s per-file roast budget. 1024 still drives
+    # thousands of collects across the suite (the soundness/VERIFY coverage
+    # the job exists for) without turning the stress knob into a de facto
+    # different asymptotic class. The production default-on trigger will use
+    # a buffer-size threshold with adaptive backoff instead (ADR-0003).
     #
     # BLOCKING gates: `cargo test` (the collector unit tests + the gc_stress
     # integration tests, which assert no verify violations), the `prove t/`
@@ -184,14 +193,14 @@ jobs:
     # DESTROY-on-reclaim / dead-sweep slice — a failure is a real GC
     # regression), and the final "No GC verify violations" step (any
     # `VERIFY FAIL` in the suite = heap corruption). The roast step remains
-    # `continue-on-error` for one observation cycle (S17 timing tests under
-    # the ~2x GC=on slowdown may be load-sensitive); promote it once it has
-    # stayed green.
+    # `continue-on-error` for one observation cycle after the 2026-07-05
+    # fixes (STW spawn-churn starvation #4205, shared-env phantom edges
+    # #4213, this knob change); promote it once a main run is green.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       MUTSU_GC: "on"
-      MUTSU_GC_EVERY_CANDIDATE: "64"
+      MUTSU_GC_EVERY_CANDIDATE: "1024"
       MUTSU_GC_VERIFY: "1"
     steps:
       - uses: actions/checkout@v4

--- a/PLAN.md
+++ b/PLAN.md
@@ -178,12 +178,15 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 残:
 
-- [ ] **CI gc-stress roast ステップの blocking 昇格**: `prove t/` は blocking 済み。roast advisory は
-      直近 4 main run 中 1 回 `S17-lowlevel/lock.t` で赤（GC=on 負荷）— STW-aware wait 化後の
-      観察を 1 サイクル継続してから昇格（本 branch では 6/6 clean）。
-- [ ] §11 step 11: OS resource 主体 async registry の `Value` edge 追従（必要に応じて）。
-- [ ] デフォルト GC=on のトリガ方針（現状 automatic trigger 無指定だと program-end collect のみ）と
-      収集方式（同期/非同期）・A' 地ならしの範囲（ADR-0001 §4.2/§4.3）。
+- [ ] **CI gc-stress roast ステップの blocking 昇格**: `prove t/` は blocking 済み。advisory roast の
+      失敗 3 クラスは 2026-07-05 に全て解消（STW spawn-churn 飢餓 #4205・共有 env phantom edge
+      #4213・`EVERY_CANDIDATE=64` の quadratic → 1024 へ）— **knob 変更後の main run が green を
+      1 回示したら `continue-on-error` を外す**（news/2026-07.md 参照）。
+- [ ] デフォルト GC=on のトリガ方針（現状 automatic trigger 無指定だと program-end collect のみ）。
+      方式は同期 + candidate バッファ**サイズ**閾値 + adaptive backoff を Proposed ADR-0003 として
+      起票予定（`EVERY_CANDIDATE` 型の push 周期トリガは大きな live graph で quadratic になることを
+      cas-loop.t で実測済み）。A' は step 11 調査により **1a の前提から外れた**（collector は
+      refcount 駆動で root 列挙を消費しない — ADR-0001 §4.3 の狭い解決）。
 - **Track B（要素 cell 化）と GC は統合キャンペーン（層3a）**。続いて NaN-boxing（層3b・JIT 地ならし）
   → JIT（層4）。`state @`/`%`・lexical aggregate の真共有（Track C 残）も Track B=層3a に依存。
 

--- a/docs/gc-level1-detailed-design.md
+++ b/docs/gc-level1-detailed-design.md
@@ -783,7 +783,17 @@ unit test / integration test では random 依存にせず、**明示 collect ho
 8. safepoint で synchronous collect
 9. `Sub` / `Instance` / captured env / attrs を second wave で移行
 10. `LazyList` を third wave として移行
-11. OS resource 主体の async registry で `Value` edge を持つものを必要に応じて追従させる
+11. ✅ OS resource 主体の async registry で `Value` edge を持つものを必要に応じて追従させる
+    — **2026-07-05 調査で「コード変更不要（sound-by-refcount）」としてクローズ**。本実装の
+    collector は candidate バッファ起点の trial deletion で、liveness 判定は GC strong refcount
+    のみ（root visitor は production 未消費・テスト専用）。レジストリが `Value`/`SharedPromise`/
+    `SharedChannel` を保持していれば、その保持自体が external strong ref として scan フェーズで
+    ノードを revive するため、visitor 未カバーでも unsoundness・リーク・VERIFY 誤検出は起きない。
+    edge を持つ未カバーレジストリ（将来 root 消費型の仕組み＝full-root VERIFY / tracing collector
+    を入れる際の hardening リスト）: `AsyncSocketConnMap`（deferred_accept_*）/
+    `AsyncSocketListenerMap`（callback）/ `SupplyChannelMap`（in-flight SupplyEvent）/
+    `PipeProcMap` / `ProcByPidMap`（Proc instance）/ `SignalRegistry`（value, queued Emit）/
+    `uncaught_handler_store` / `FakeSchedulerMap`（callback）/ `LockStateMap.async_waiters`。
 
 ## 12. この設計で捨てるもの
 
@@ -798,7 +808,10 @@ unit test / integration test では random 依存にせず、**明示 collect ho
 残件は 3 つまで絞る。
 
 1. `Instance` は「本体 node」と「attributes cell」を別 node にするか
-2. OS resource 主体の async registry（socket/proc/udp 等）のうち、どこまでを supply first-wave root visitor に同時包含するか
+2. ~~OS resource 主体の async registry（socket/proc/udp 等）のうち、どこまでを supply first-wave root visitor に同時包含するか~~
+   → **解決（2026-07-05・§11 step 11）**: 包含不要。collector は refcount 駆動で root visitor を
+   消費しないため、レジストリの保持は external strong ref として自動的に健全。visitor 拡張は
+   root 消費型の仕組みを導入する時の hardening として §11 step 11 のリストに繰延。
 3. cooperative STW の停止プロトコルを `shared_vars` 系の既存同期とどう共存させるか
 
 この 3 つ以外は、Level 1a では未決にしないほうがよい。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,28 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Phase B（GC）— §11 step 11 クローズ（sound-by-refcount）＋ gc-stress ノブを 1024 へ
+
+- **§11 step 11（OS リソース系 async registry の `Value` edge 追従）を「コード変更不要」でクローズ**。
+  網羅調査の結論: 本実装の collector は candidate バッファ起点の trial deletion で liveness 判定は
+  GC strong refcount のみ。`RootVisitor` 系は production 未消費（全て `#[allow(dead_code)]`・テスト
+  専用）で、レジストリが `Value`/`SharedPromise`/`SharedChannel` を保持していればその保持自体が
+  external strong ref として scan で revive する。よって visitor 未カバーの 9 レジストリ
+  （AsyncSocketConn/Listener・SupplyChannelMap・PipeProc/ProcByPid・SignalRegistry・
+  uncaught_handler_store・FakeSchedulerMap・LockStateMap.async_waiters）は unsoundness・リーク・
+  VERIFY 誤検出のいずれも生まない。リストは将来 root 消費型（full-root VERIFY / tracing）導入時の
+  hardening として設計書 §11 step 11 に記録。副産物: **ADR-0001 §4.3（A' の範囲）は「level-1a の
+  前提としては不要」と狭く解決**。
+- **CI gc-stress の `MUTSU_GC_EVERY_CANDIDATE` を 64→1024 に変更**。push 周期トリガは full scan
+  （O(live suspect graph)）を周期発火するため、live 構造が伸び続けるワークロードで quadratic:
+  `cas-loop.t`（4×1000 cas の linked list 構築）は N=64 で >180 秒（8500+ collects × ~4300 traced/回）、
+  N=1024 で 3.3 秒。1024 でもスイート全体で数千 collect が走り soundness/VERIFY カバレッジは維持。
+  この実測は default-on トリガ設計（ADR-0003 予定: バッファサイズ閾値 + adaptive backoff）の根拠。
+
+これで GC=on advisory roast の失敗 3 クラス（semaphore=STW 飢餓 #4205 / require=phantom edge #4213 /
+cas-*=stress ノブ quadratic）が全て解消。knob 変更後の main run green を確認したら roast ステップを
+blocking へ昇格する。
+
 ## 2026-07-05: Phase B（GC）— 共有 captured-env の phantom edge による偽回収（生存データ破壊）を修正
 
 GC=on advisory roast の `S11-modules/require.t` が決定的に 1 subtest 赤


### PR DESCRIPTION
## Summary

Two GC-campaign bookkeeping items that close out the remaining PLAN.md §2 checklist ahead of the roast blocking promotion.

### §11 step 11 closed — no code needed (sound-by-refcount)

Survey conclusion: the level-1a collector is candidate-buffer **trial deletion** — liveness is decided by GC strong refcounts alone. The `RootVisitor` machinery is production-unconsumed (all `#[allow(dead_code)]`, exercised only by unit tests), and `MUTSU_GC_VERIFY` snapshots candidate-reachable nodes, not roots. A registry holding `Value`/`SharedPromise`/`SharedChannel` keeps those nodes alive through its own counted handles, so the nine edge-bearing unvisited OS-resource registries (AsyncSocketConn/Listener maps, SupplyChannelMap, PipeProc/ProcByPid maps, SignalRegistry, uncaught_handler_store, FakeSchedulerMap, LockStateMap.async_waiters) cause **no unsoundness, no leak, no VERIFY false positives**. The list is recorded in the design doc as future hardening for a root-consuming collector; design open question 2 resolved; ADR-0001 §4.3 (A' scope) resolves narrowly as *not a level-1a prerequisite*.

### CI gc-stress `MUTSU_GC_EVERY_CANDIDATE` 64 → 1024

A push-count-periodic trigger fires a full **O(live suspect graph)** scan, which is quadratic on workloads that grow a large live structure while churning candidates: `S17-lowlevel/cas-loop.t` (4×1000 `cas` ops building a linked list) ran **>180s at N=64** (8500+ collects × ~4300 traced nodes each) vs **3.3s at N=1024** (release, measured) — blowing the 30s per-file roast budget. 1024 still drives thousands of collects across the suite, keeping the job's soundness/VERIFY purpose. Measured release timings at 1024: cas-int 12.6s, cas-loop 3.3s, thread 23.5s — all inside budget. This measurement also grounds the planned production default-on trigger design (buffer-size threshold + adaptive backoff, ADR-0003).

With #4205 (STW spawn-churn starvation) and #4213 (shared-env phantom edges), this clears all three GC=on advisory-roast failure classes; PLAN.md now gates the blocking promotion on one green main run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK