### PR TITLE
fix(str): .encode('latin1') is true ISO-8859-1, not windows-1252

### DIFF
--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -20,7 +20,13 @@ impl Interpreter {
             },
             EncodingEntry {
                 name: "iso-8859-1".to_string(),
-                alternative_names: vec!["latin-1".to_string()],
+                alternative_names: vec![
+                    "latin-1".to_string(),
+                    "latin1".to_string(),
+                    "iso88591".to_string(),
+                    "iso-88591".to_string(),
+                    "iso_8859_1".to_string(),
+                ],
                 user_type: None,
             },
             EncodingEntry {

--- a/t/encode-latin1-alias.t
+++ b/t/encode-latin1-alias.t
@@ -1,0 +1,27 @@
+use Test;
+
+# The "latin1" encoding name (no hyphen) was not registered as an alias for
+# iso-8859-1, so .encode('latin1') fell through to a windows-1252 codec that
+# silently mapped out-of-range characters (€ -> 0x80) instead of throwing.
+
+plan 12;
+
+# In-range characters (U+0000..U+00FF) encode to their codepoint byte.
+is 'A'.encode('latin1').list, (65,), 'latin1 encodes A';
+is 'café'.encode('latin1').list, (99, 97, 102, 233), 'latin1 encodes café';
+is 'ÿ'.encode('latin1').list, (255,), 'latin1 encodes U+00FF';
+
+# Out-of-range characters throw (must NOT silently map via windows-1252).
+dies-ok { '€'.encode('latin1') }, 'latin1 refuses € (U+20AC)';
+dies-ok { 'Œ'.encode('latin1') }, 'latin1 refuses Œ (U+0152)';
+dies-ok { "\x2018".encode('latin1') }, 'latin1 refuses left single quote';
+dies-ok { "\x0100".encode('latin1') }, 'latin1 refuses U+0100';
+
+# All spellings behave the same as iso-8859-1.
+is 'ÿ'.encode('latin-1').list, (255,), 'latin-1 (hyphen) agrees';
+is 'ÿ'.encode('iso-8859-1').list, (255,), 'iso-8859-1 agrees';
+dies-ok { '€'.encode('iso-8859-1') }, 'iso-8859-1 refuses €';
+
+# Decoding maps bytes 0x00..0xFF directly to U+0000..U+00FF (not windows-1252).
+is Buf.new(0x80).decode('latin1').ord, 0x80, 'latin1 decodes 0x80 to U+0080';
+is Buf.new(0xE9).decode('latin1'), 'é', 'latin1 decodes 0xE9 to é';


### PR DESCRIPTION
## Summary

`.encode('latin1')` silently mis-encoded out-of-range characters instead of throwing:

```
'€'.encode('latin1').list    # was (128), i.e. 0x80  — raku throws
'Œ'.encode('latin1').list    # was (140), i.e. 0x8C  — raku throws
```

The `iso-8859-1` encoding registered only `"latin-1"` (with a hyphen) as an alias, so `.encode('latin1')` (no hyphen) failed to normalise and fell through to the `encoding_rs` codec, which uses WHATWG's **windows-1252** mapping for Latin-1. That mapping silently encodes `€`→`0x80`, `Œ`→`0x8C`, `'`→`0x91`, etc.

Registered `"latin1"`, `"iso88591"`, `"iso-88591"` and `"iso_8859_1"` as aliases so they hit the true ISO-8859-1 encoder (encodes only `U+0000..U+00FF`, errors above).

```
'café'.encode('latin1').list   # (99, 97, 102, 233)   ✓
'ÿ'.encode('latin1').list      # (255,)                ✓
'€'.encode('latin1')           # throws (not representable)  ✓
```

Decoding was already correct (`0x80` → `U+0080`, not `€`).

## Test
- New `t/encode-latin1-alias.t` (12 assertions), cross-checked against `raku`.
- `make test` passes (14768 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)