### PR TITLE
fix(interp): interpolate `%h.method()` and a type object's user `.Str`

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1338,6 +1338,7 @@ roast/integration/advent2013-day20.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t
 roast/integration/advent2014-day05.t
+roast/integration/advent2014-day13.t
 roast/integration/code-blocks-as-sub-args.t
 roast/integration/diamond.t
 roast/integration/eval-and-threads.t

--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -468,9 +468,13 @@ pub(crate) fn try_interpolate_var<'a>(
                 return Some(r);
             }
             let (expr, remainder) = parse_postcircumfix_index(tail, expr);
-            // In qq-like strings, `%hash` without a postcircumfix remains literal.
-            // Only interpolate hash variables for explicit access forms like
-            // `%hash<key>` / `%hash{...}`.
+            // Also allow a trailing method call: `%hash.keys()` (mirrors the
+            // `@array.method()` branch above). `try_parse_interp_method_call`
+            // only commits when the chain ends in parens, matching Raku.
+            let (expr, remainder) = try_parse_interp_method_call(remainder, expr);
+            // In qq-like strings, `%hash` without a postcircumfix or method call
+            // remains literal. Only interpolate for explicit access forms like
+            // `%hash<key>` / `%hash{...}` / `%hash.method()`.
             if remainder.len() == tail.len() {
                 return None;
             }

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -570,6 +570,25 @@ impl Interpreter {
                 result.push_str(&crate::runtime::utils::coerce_to_str(&v));
                 continue;
             }
+            // A type object (`Value::Package`) whose class defines a user
+            // `.Stringy`/`.Str` must dispatch it too: `class A { method Str {"foo"} }`
+            // then `"$x"` / `"{A}"` renders "foo" (mirrors `coerce_stringy_operand`
+            // used by infix `~`). Plain type objects fall through to the default
+            // (empty) stringification.
+            if let Value::Package(name) = &v {
+                let cn = name.resolve().to_string();
+                if self.has_user_method(&cn, "Stringy") {
+                    let r =
+                        self.try_compiled_method_or_interpret(v.clone(), "Stringy", Vec::new())?;
+                    result.push_str(&r.to_string_value());
+                    continue;
+                }
+                if self.has_user_method(&cn, "Str") {
+                    let r = self.try_compiled_method_or_interpret(v.clone(), "Str", Vec::new())?;
+                    result.push_str(&r.to_string_value());
+                    continue;
+                }
+            }
             result.push_str(&crate::runtime::utils::coerce_to_str(&v));
         }
         self.reconcile_caller_after_internal_dispatch(caller_code);

--- a/t/interp-hash-method-and-typeobject-str.t
+++ b/t/interp-hash-method-and-typeobject-str.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 8;
+
+# (1) `%hash.method()` must interpolate in qq strings, like `@array.method()`.
+{
+    my %h = a => 42, b => 666;
+    my $s = "keys = %h.keys().sort()";
+    is $s, "keys = a b", '%h.method() interpolates in a qq string';
+}
+
+{
+    my %h = x => 1, y => 2, z => 3;
+    is "n = %h.elems()", "n = 3", '%h.elems() interpolates';
+}
+
+# A bare `%h` (no postcircumfix / method) stays literal.
+{
+    my %h = a => 1;
+    is "raw = %h", "raw = %h", 'bare %h without accessor stays literal';
+}
+
+# (2) A type object whose class defines a user `.Str` stringifies via it in
+# interpolation (both `$var` and `{ ... }` forms), matching infix `~`.
+{
+    class A {
+        method Str  { "foo" }
+        method gist { "bar" }
+    }
+    my $t = A;
+    is "v = $t",   "v = foo", 'type object interpolates via user .Str ($var form)';
+    is "v = { A }", "v = foo", 'type object interpolates via user .Str ({ } form)';
+    is "v = " ~ A, "v = foo", 'infix ~ agrees (unchanged)';
+}
+
+# A user `.Stringy` takes precedence over `.Str`, as with infix ~.
+{
+    class C {
+        method Stringy { "stringy" }
+        method Str     { "str" }
+    }
+    is "c = { C }", "c = stringy", 'user .Stringy wins over .Str in interpolation';
+}
+
+# A plain type object without a user stringifier stays empty (no crash).
+{
+    class D { }
+    is "d = { D }|", "d = |", 'plain type object interpolates to empty';
+}


### PR DESCRIPTION
## Summary

Two string-interpolation gaps, both exercised by `roast/integration/advent2014-day13.t`:

**1. `"%h.keys()"` did not interpolate.** The `%`-sigil branch of the qq interpolation parser called `parse_postcircumfix_index` but, unlike the `@`-sigil branch, never tried `try_parse_interp_method_call`, so a trailing `.method()` was left literal:

```raku
my %h = a => 42, b => 666;
"keys = %h.keys()"   # before: "keys = %h.keys()"   after: "keys = a b"
```

Mirror the `@`-branch. `try_parse_interp_method_call` only commits when the chain ends in parens, matching Raku (a bare `%h` stays literal).

**2. A type object's user `.Str` was ignored in interpolation.**

```raku
class A { method Str { "foo" } }
my $t = A;
"v = $t"     # before: "v = "    after: "v = foo"
"v = { A }"  # before: "v = "    after: "v = foo"
"v = " ~ A   # already "v = foo" (unchanged)
```

`exec_string_concat_op` only dispatched the user stringifier for `Value::Instance`; a `Value::Package` (type object) fell through to the default empty stringification. Add a `Value::Package` branch mirroring `coerce_stringy_operand` (used by infix `~`). Plain type objects without a user stringifier stay empty (matching Raku's empty string value; Raku additionally warns).

## Tests

- Whitelists `roast/integration/advent2014-day13.t` (13/13).
- New `t/interp-hash-method-and-typeobject-str.t` (8 assertions): `%h.method()` / `%h.elems()` interpolation, bare `%h` stays literal, type object via `.Str` in both `$var` and `{ }` forms, `.Stringy` precedence, plain type object stays empty.
- `make test` PASS (14750). S02-literals quoting / interpolation roast subset green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)