### PR TITLE
ci(gc): promote the gc-stress roast step to a blocking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,15 +187,12 @@ jobs:
     # different asymptotic class. The production default-on trigger will use
     # a buffer-size threshold with adaptive backoff instead (ADR-0003).
     #
-    # BLOCKING gates: `cargo test` (the collector unit tests + the gc_stress
-    # integration tests, which assert no verify violations), the `prove t/`
-    # step (the whole t/ suite passes under GC=on since the
-    # DESTROY-on-reclaim / dead-sweep slice — a failure is a real GC
-    # regression), and the final "No GC verify violations" step (any
-    # `VERIFY FAIL` in the suite = heap corruption). The roast step remains
-    # `continue-on-error` for one observation cycle after the 2026-07-05
-    # fixes (STW spawn-churn starvation #4205, shared-env phantom edges
-    # #4213, this knob change); promote it once a main run is green.
+    # EVERY step is a BLOCKING gate (roast promoted 2026-07-05 after the
+    # advisory-era failure classes were fixed — #4205/#4213/#4215): `cargo
+    # test` (collector unit tests + gc_stress integration tests), `prove t/`,
+    # the roast whitelist, and the final "No GC verify violations" step (any
+    # `VERIFY FAIL` in the suite = heap corruption). A failure anywhere here
+    # is a real GC regression.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -261,11 +258,14 @@ jobs:
           git checkout -- roast/
 
       - name: Roast tests (make roast, GC on)
-        # Advisory (see the prove-t/ step): runs the whitelist under GC on so the
-        # verify step can catch collector corruption on the roast programs.
-        continue-on-error: true
+        # BLOCKING (promoted 2026-07-05): the whole whitelist passes under
+        # GC=on since the three advisory-era failure classes were fixed — STW
+        # spawn-churn starvation (#4205), shared-env phantom edges (#4213),
+        # and the EVERY_CANDIDATE=64 quadratic (#4215, knob now 1024). A
+        # failure here is a real GC regression, same as the prove-t/ step.
+        # Keep `set -o pipefail` so prove's exit status survives the tee.
         run: |
-          set +e
+          set -o pipefail
           mkdir -p tmp
           prove -j4 --merge -e 'scripts/run-roast-test.sh' \
             $(cat roast-whitelist.txt) 2>&1 | tee tmp/gc-stress-roast.log

--- a/PLAN.md
+++ b/PLAN.md
@@ -178,10 +178,6 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 残:
 
-- [ ] **CI gc-stress roast ステップの blocking 昇格**: `prove t/` は blocking 済み。advisory roast の
-      失敗 3 クラスは 2026-07-05 に全て解消（STW spawn-churn 飢餓 #4205・共有 env phantom edge
-      #4213・`EVERY_CANDIDATE=64` の quadratic → 1024 へ）— **knob 変更後の main run が green を
-      1 回示したら `continue-on-error` を外す**（news/2026-07.md 参照）。
 - [ ] デフォルト GC=on のトリガ方針（現状 automatic trigger 無指定だと program-end collect のみ）。
       方式は同期 + candidate バッファ**サイズ**閾値 + adaptive backoff を Proposed ADR-0003 として
       起票予定（`EVERY_CANDIDATE` 型の push 周期トリガは大きな live graph で quadratic になることを

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,15 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Phase B（GC）— CI gc-stress の roast ステップを blocking へ昇格
+
+`MUTSU_GC=on` の advisory roast は #4215（knob 1024）の PR run で **Result: PASS** を確認。
+advisory 時代の失敗 3 クラス（STW spawn-churn 飢餓 #4205・共有 env phantom edge #4213・
+`EVERY_CANDIDATE=64` quadratic #4215）が全て解消したため、`continue-on-error` を外して
+gc-stress ジョブの**全ステップを blocking gate 化**した（cargo test / prove t/ / roast whitelist /
+VERIFY FAIL 検出）。以後、GC=on でのスイート失敗は既知ギャップではなく実リグレッションとして
+CI が止める。roast ステップは `set +e` → `set -o pipefail` に変更（tee 越しに prove の exit を透過）。
+
 ## 2026-07-05: Phase B（GC）— §11 step 11 クローズ（sound-by-refcount）＋ gc-stress ノブを 1024 へ
 
 - **§11 step 11（OS リソース系 async registry の `Value` edge 追従）を「コード変更不要」でクローズ**。


### PR DESCRIPTION
## Summary

The GC=on advisory roast printed **Result: PASS** on the #4215 PR run — the exact tree with all three advisory-era failure classes fixed:

| class | fix |
|---|---|
| STW spawn-churn starvation (semaphore.t 10/10 timeout) | #4205 |
| shared captured-env phantom edges → false reclaim of live data (require.t) | #4213 |
| `EVERY_CANDIDATE=64` push-periodic quadratic (cas-loop.t >180s) | #4215 (knob → 1024) |

Measured per-file budgets at the new knob (release + VERIFY): semaphore ~7s, cas-int ~13s, cas-loop ~3s, thread ~24s against the 30s limit.

## Change

- Drop `continue-on-error` from the gc-stress roast step; `set +e` → `set -o pipefail` so prove's exit status survives the `tee`.
- Job header comment updated: **every gc-stress step is now a blocking gate** (cargo test / prove t/ / roast whitelist / VERIFY FAIL detection). A GC=on suite failure is a real regression, not a known gap.
- Removes the PLAN.md §2 promotion item; news entry added.

This PR's own CI validates the promotion — its roast step already runs as blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK