### PR TITLE
fix(str): .NFC/.NFD/.NFKC/.NFKD gist shows the normalization form

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -12,6 +12,20 @@ const GIST_ELEM_CAP: usize = 100;
 /// Leaf-value gist for a list/array element: a WhateverCode (`*+1`) gists as
 /// `WhateverCode.new`; everything else uses its string value.
 fn leaf_gist(v: &Value) -> String {
+    if let Value::Uni(u) = v {
+        // A Uni / normalization form gists as e.g. NFKC:0x<0066 0066>.
+        let cps: Vec<String> = u
+            .text
+            .chars()
+            .map(|c| format!("{:04X}", c as u32))
+            .collect();
+        let form = if u.form.is_empty() {
+            "Uni"
+        } else {
+            u.form.as_str()
+        };
+        return format!("{}:0x<{}>", form, cps.join(" "));
+    }
     if let Value::Sub(data) = v
         && matches!(
             data.env.get("__mutsu_callable_type"),

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -554,15 +554,31 @@ pub(crate) fn native_method_0arg(
                     .chars()
                     .map(|c| format!("0x{:04X}", c as u32))
                     .collect();
+                // A normalization form appends the form, e.g. Uni.new(...).NFKC
+                let suffix = if u.form.is_empty() {
+                    String::new()
+                } else {
+                    format!(".{}", u.form)
+                };
                 return Some(Ok(Value::str(format!(
-                    "Uni.new({})",
-                    codepoints.join(", ")
+                    "Uni.new({}){}",
+                    codepoints.join(", "),
+                    suffix
                 ))));
             }
             "gist" => {
                 let codepoints: Vec<String> =
                     text.chars().map(|c| format!("{:04X}", c as u32)).collect();
-                return Some(Ok(Value::str(format!("Uni:0x<{}>", codepoints.join(" ")))));
+                let form = if u.form.is_empty() {
+                    "Uni"
+                } else {
+                    u.form.as_str()
+                };
+                return Some(Ok(Value::str(format!(
+                    "{}:0x<{}>",
+                    form,
+                    codepoints.join(" ")
+                ))));
             }
             "NFC" | "NFD" | "NFKC" | "NFKD" => {
                 let normalized: String = match method {

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -83,6 +83,21 @@ pub(crate) fn gist_value(value: &Value) -> String {
         }
     }
     match value {
+        // A Uni / normalization form gists as e.g. NFKC:0x<0066 0066>, not as
+        // the plain decoded text.
+        Value::Uni(u) => {
+            let cps: Vec<String> = u
+                .text
+                .chars()
+                .map(|c| format!("{:04X}", c as u32))
+                .collect();
+            let form = if u.form.is_empty() {
+                "Uni"
+            } else {
+                u.form.as_str()
+            };
+            format!("{}:0x<{}>", form, cps.join(" "))
+        }
         // A `:=`-bound element holds a `ContainerRef` cell; render the held
         // value so a bound element gists like a plain one (Phase 5 leak).
         Value::ContainerRef(cell) => gist_value(&cell.lock().unwrap()),

--- a/t/uni-normalization-gist.t
+++ b/t/uni-normalization-gist.t
@@ -1,0 +1,29 @@
+use Test;
+
+# The .NFC/.NFD/.NFKC/.NFKD methods return a Uni in the given normalization
+# form. Its gist (and hence `say`) is `FORM:0x<codepoints>`, and its .raku
+# appends the form — mutsu previously rendered the plain decoded text.
+
+plan 12;
+
+# gist / say
+is "ﬀ".NFKC.gist, 'NFKC:0x<0066 0066>', 'NFKC gist shows form + codepoints';
+is "①".NFKC.gist, 'NFKC:0x<0031>', 'NFKC gist of circled one';
+is "café".NFD.gist, 'NFD:0x<0063 0061 0066 0065 0301>', 'NFD gist decomposes é';
+is "a".NFC.gist, 'NFC:0x<0061>', 'NFC gist';
+is "a".NFKD.gist, 'NFKD:0x<0061>', 'NFKD gist';
+
+# .raku appends the form
+is "ﬀ".NFKC.raku, 'Uni.new(0x0066, 0x0066).NFKC', 'NFKC raku appends form';
+is "a".NFC.raku, 'Uni.new(0x0061).NFC', 'NFC raku appends form';
+
+# .Str still returns the decoded text (print uses .Str)
+is "ﬀ".NFKC.Str, 'ff', 'NFKC Str is decoded text';
+is "café".NFD.Str, 'café', 'NFD Str is decoded text';
+
+# Type name and codepoint methods are unchanged
+is "ﬀ".NFKC.^name, 'NFKC', 'NFKC type name';
+is "ﬀ".NFKC.codes, 2, 'NFKC codes counts codepoints';
+
+# Inside an aggregate, the element gists with its form too
+is ["a".NFC, "b".NFD].gist, '[NFC:0x<0061> NFD:0x<0062>]', 'Uni elements gist with form';


### PR DESCRIPTION
## Summary

`say "ﬀ".NFKC` printed the decoded text `ff` instead of the Uni gist:

```
say "ﬀ".NFKC        # was  ff        — raku: NFKC:0x<0066 0066>
say "café".NFD       # was  café      — raku: NFD:0x<0063 0061 0066 0065 0301>
```

The `Uni` value produced by the normalization methods was rendered via its **string value** on the say/gist fast paths, and the `.gist`/`.raku` methods hard-coded the literal `"Uni"` form.

- Add a `Value::Uni` case to `gist_value` (the say/gist fast path) and `leaf_gist` (aggregate-element gist), rendering `FORM:0x<hex codepoints>`.
- Use the value's form (`NFC`/`NFD`/`NFKC`/`NFKD`) in the `.gist` method instead of `"Uni"`.
- Append the form in `.raku`, e.g. `Uni.new(0x0066, 0x0066).NFKC`.

`.Str` still returns the decoded text (so `print` is unchanged), and the type name / `.codes` / `.list` are unaffected.

## Test
- New `t/uni-normalization-gist.t` (12 assertions), cross-checked against `raku`, including a Uni element inside an array.
- `make test` passes (14768 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)