### PR TITLE
ci(gc): scale roast per-file timeouts 2x in the gc-stress job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,11 @@ jobs:
       MUTSU_GC: "on"
       MUTSU_GC_EVERY_CANDIDATE: "1024"
       MUTSU_GC_VERIFY: "1"
+      # GC=on + VERIFY runs the roast suite ~2x slower across the board;
+      # scale every per-file timeout accordingly (see run-roast-test.sh) —
+      # S17-lowlevel/thread.t sat at ~24s against the 30s GC-off budget and
+      # timed out on a loaded runner the first time this step ran blocking.
+      MUTSU_ROAST_TIMEOUT_SCALE: "2"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -72,6 +72,17 @@ needs_roast_cwd() {
 
 test_file="$1"
 file_timeout=$(per_file_timeout "$test_file")
+# MUTSU_ROAST_TIMEOUT_SCALE: integer multiplier on every per-file timeout.
+# The CI gc-stress job sets 2: with MUTSU_GC=on + MUTSU_GC_VERIFY=1 the suite
+# runs ~2x slower across the board (collector scans + verify snapshots), so
+# fixed budgets tuned for GC-off leave no headroom — S17-lowlevel/thread.t
+# measured 23.5s locally against the 30s default and timed out on a loaded
+# runner the first time the GC=on roast step ran as a blocking gate. Scaling
+# the whole schedule encodes "same tests, slower mode" once, instead of
+# per-file whack-a-mole after each flake.
+if [[ "${MUTSU_ROAST_TIMEOUT_SCALE:-1}" =~ ^[0-9]+$ ]] && [ "${MUTSU_ROAST_TIMEOUT_SCALE:-1}" -gt 1 ]; then
+  file_timeout=$((file_timeout * MUTSU_ROAST_TIMEOUT_SCALE))
+fi
 if needs_roast_cwd "$test_file"; then
   abs_bin="$(cd "$(dirname "$MUTSU_BIN")" && pwd)/$(basename "$MUTSU_BIN")"
   abs_test="$(cd "$(dirname "$test_file")" && pwd)/$(basename "$test_file")"


### PR DESCRIPTION
## Summary

The first **blocking** run of the GC=on roast step (#4219, on the docs-only #4220) timed out on `S17-lowlevel/thread.t` (exit 124, ran 26/29). It measures ~24s locally (release + VERIFY) against the 30s GC-off-tuned budget — no headroom on a loaded runner.

GC=on + `MUTSU_GC_VERIFY=1` runs the suite ~2x slower across the board (collector scans + verify snapshots), so encode that once at the mechanism level instead of per-file whack-a-mole:

- `scripts/run-roast-test.sh` honors `MUTSU_ROAST_TIMEOUT_SCALE` — an integer multiplier applied to **every** per-file timeout (default 1, validated as a number).
- The gc-stress job sets it to **2**. GC-off jobs are unaffected.

Note: #4220 auto-merged despite the red gc-stress because gc-stress is **not a branch-protection required check** — once this lands green, the follow-up is to add gc-stress to the required checks so the blocking promotion actually gates merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK