### PR TITLE
fix(class): detect undeclared attrs in anonymous methods; X::Attribute::Undeclared does X::Comp

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1313,6 +1313,7 @@ roast/integration/advent2010-day21.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t
 roast/integration/advent2011-day05.t
+roast/integration/advent2011-day15.t
 roast/integration/advent2011-day16.t
 roast/integration/advent2011-day20.t
 roast/integration/advent2011-day22.t

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -1964,6 +1964,17 @@ impl Interpreter {
                         .insert((name.to_string(), method_name), fdef);
                 }
                 _ => {
+                    // An anonymous method (`method { $!x }`) parses as an
+                    // `AnonSubParams` expression statement (with an implicit
+                    // `self` param), NOT a `MethodDecl`, so it bypasses the
+                    // named-method validation above. Validate its body too so an
+                    // undeclared attribute inside it still raises
+                    // X::Attribute::Undeclared at composition time.
+                    if let Stmt::Expr(Expr::AnonSubParams { params, body, .. }) = stmt
+                        && params.first().map(String::as_str) == Some("self")
+                    {
+                        Self::validate_attr_declared_in_class(&class_attr_ctx, body)?;
+                    }
                     // BEGIN phasers and EVAL calls in class bodies may fail
                     // (e.g. `BEGIN EVAL q[has $.x]` or `EVAL q[has $.x]`).
                     // Swallow errors from these so the class still registers.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1627,6 +1627,9 @@ impl Interpreter {
         register_x("X::Undeclared", "X::Comp");
         register_x("X::Undeclared::Symbols", "X::Comp");
 
+        // An undeclared attribute is a compile-time error (does X::Comp).
+        register_x("X::Attribute::Undeclared", "X::Comp");
+
         // X::Redeclaration
         register_x("X::Redeclaration", "X::Comp");
 

--- a/t/anon-method-undeclared-attr.t
+++ b/t/anon-method-undeclared-attr.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 8;
+
+# An undeclared attribute used inside an *anonymous* method (`method { $!x }`)
+# must raise X::Attribute::Undeclared at composition time, just like a named
+# method does. And X::Attribute::Undeclared does X::Comp (it is a compile error).
+
+# (1) anonymous method, undeclared private attribute
+{
+    my $ex;
+    try { EVAL q[ unit class A; method { $!x } ]; CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::Attribute::Undeclared, 'anon method: undeclared $!x is X::Attribute::Undeclared';
+    is $ex.message, 'Attribute $!x not declared in class A', 'anon method: right message';
+    ok $ex ~~ X::Comp, 'anon method: X::Attribute::Undeclared does X::Comp';
+}
+
+# (2) named method still detects it (unchanged) and also does X::Comp
+{
+    my $ex;
+    try { EVAL q[ class B { method m { $!y } } ]; CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::Attribute::Undeclared, 'named method: undeclared $!y is X::Attribute::Undeclared';
+    ok $ex ~~ X::Comp, 'named method: does X::Comp';
+}
+
+# (3) a *declared* attribute inside an anonymous method must NOT error
+{
+    class C {
+        has $.v = 42;
+        method { $!v }   # anonymous method referencing a declared attribute
+    }
+    is C.new.v, 42, 'anon method referencing a declared attribute is fine';
+}
+
+# (4) an anonymous method with no attribute reference must NOT error
+{
+    lives-ok { EVAL q[ class D { method { 99 } } ] },
+        'anon method with no attribute reference composes cleanly';
+}
+
+# (5) a runtime error does NOT do X::Comp (sanity for the hierarchy change)
+{
+    my $ex;
+    try { die 42; CATCH { default { $ex = $_ } } }
+    nok $ex ~~ X::Comp, 'a plain runtime die does not do X::Comp';
+}


### PR DESCRIPTION
## Summary

Two related gaps, both exercised by `roast/integration/advent2011-day15.t`:

**1. Undeclared attribute inside an anonymous method not caught.**

```raku
EVAL q[ unit class A; method { $!x } ]   # before: no error   after: X::Attribute::Undeclared
```

A named `method m { $!x }` parses as `Stmt::MethodDecl` and is validated by `validate_attr_declared_in_class`. A bare `method { ... }` parses as an `AnonSubParams` expression statement (with an implicit `self` param) and fell through the class-body loop's `_` arm, which just ran it without attribute validation. Now the body of such anonymous methods (identified by the implicit leading `self` param) is validated too, so an undeclared attribute raises `X::Attribute::Undeclared` at composition time.

**2. `X::Attribute::Undeclared` did not do `X::Comp`.** It is a compile-time error, so `$! ~~ X::Comp` must be `True`. Registered under `X::Comp` in the exception hierarchy (`runtime_init.rs`).

## Tests

- Whitelists `roast/integration/advent2011-day15.t` (9/9).
- New `t/anon-method-undeclared-attr.t` (8 assertions): anon + named method detection, `~~ X::Comp`, declared attribute in an anon method does not error, anon method without attr refs composes cleanly, a plain runtime `die` does not do X::Comp.
- `make test` PASS (14784). S12/S14 class/role + S32-exceptions roast subsets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)