### PR TITLE
fix(str): sprintf numeric directives parse radix-prefixed string args

### DIFF
--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -10,6 +10,13 @@ pub(crate) use super::sprintf_validate::{
     validate_sprintf_arg_types, validate_sprintf_directives,
 };
 
+/// Numify a string argument the way Raku does when a numeric directive (%d,
+/// %x, %f, ...) is given a string: this honours radix prefixes (0x/0o/0b),
+/// underscores and rationals, so sprintf("%d", "0x1F") is 31, not 0.
+fn sprintf_numify_str(s: &str) -> Option<Value> {
+    super::str_numeric::parse_raku_str_to_numeric(s.trim())
+}
+
 pub(crate) fn format_sprintf(fmt: &str, arg: Option<&Value>) -> String {
     match arg {
         Some(value) => format_sprintf_impl(fmt, std::slice::from_ref(value), false),
@@ -172,10 +179,18 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                 use num_traits::ToPrimitive;
                 (n.as_ref() / d.as_ref()).to_i64().unwrap_or(0)
             }
-            Some(Value::Str(s)) => s
-                .trim()
-                .parse::<i64>()
-                .unwrap_or_else(|_| s.trim().parse::<f64>().unwrap_or(0.0) as i64),
+            Some(Value::Str(s)) => match sprintf_numify_str(s) {
+                Some(Value::Int(i)) => i,
+                Some(Value::BigInt(bi)) => {
+                    num_traits::ToPrimitive::to_i64(bi.as_ref()).unwrap_or(0)
+                }
+                Some(Value::Num(f)) => f as i64,
+                Some(Value::Rat(n, d)) if d != 0 => n / d,
+                _ => s
+                    .trim()
+                    .parse::<i64>()
+                    .unwrap_or_else(|_| s.trim().parse::<f64>().unwrap_or(0.0) as i64),
+            },
             Some(Value::Bool(true)) => 1,
             Some(Value::Bool(false)) => 0,
             _ => 0,
@@ -189,10 +204,15 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             Some(Value::BigRat(n, d)) if d.as_ref() != &num_bigint::BigInt::from(0) => {
                 n.as_ref() / d.as_ref()
             }
-            Some(Value::Str(s)) => s
-                .trim()
-                .parse::<BigInt>()
-                .unwrap_or_else(|_| BigInt::from(s.trim().parse::<f64>().unwrap_or(0.0) as i64)),
+            Some(Value::Str(s)) => match sprintf_numify_str(s) {
+                Some(Value::BigInt(bi)) => (*bi).clone(),
+                Some(Value::Int(i)) => BigInt::from(i),
+                Some(Value::Num(f)) => BigInt::from(f as i64),
+                Some(Value::Rat(n, d)) if d != 0 => BigInt::from(n / d),
+                _ => s.trim().parse::<BigInt>().unwrap_or_else(|_| {
+                    BigInt::from(s.trim().parse::<f64>().unwrap_or(0.0) as i64)
+                }),
+            },
             Some(Value::Bool(true)) => BigInt::from(1),
             Some(Value::Bool(false)) => BigInt::from(0),
             _ => BigInt::from(0),
@@ -207,7 +227,15 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                 let result = n.as_ref() * BigInt::from(1_000_000_000i64) / d.as_ref();
                 result.to_f64().unwrap_or(0.0) / 1_000_000_000.0
             }
-            Some(Value::Str(s)) => s.trim().parse::<f64>().unwrap_or(0.0),
+            Some(Value::Str(s)) => match sprintf_numify_str(s) {
+                Some(Value::Int(i)) => i as f64,
+                Some(Value::Num(f)) => f,
+                Some(Value::Rat(n, d)) if d != 0 => n as f64 / d as f64,
+                Some(Value::BigInt(bi)) => {
+                    num_traits::ToPrimitive::to_f64(bi.as_ref()).unwrap_or(0.0)
+                }
+                _ => s.trim().parse::<f64>().unwrap_or(0.0),
+            },
             _ => 0.0,
         };
         let rendered = match spec {

--- a/t/sprintf-string-radix.t
+++ b/t/sprintf-string-radix.t
@@ -1,0 +1,25 @@
+use Test;
+
+# sprintf numeric directives (%d, %x, %o, %b, %f) given a string argument must
+# numify it the Raku way, honouring radix prefixes (0x/0o/0b/0d) and
+# underscores. Previously the string was parsed with a plain integer parser, so
+# "0x1F" became 0.
+
+plan 14;
+
+is sprintf("%d", "0x1F"), '31', '%d parses hex string';
+is sprintf("%d", "0b101"), '5', '%d parses binary string';
+is sprintf("%d", "0o17"), '15', '%d parses octal string';
+is sprintf("%d", "0d99"), '99', '%d parses 0d decimal string';
+is sprintf("%d", "-0x1F"), '-31', '%d parses negative hex string';
+is sprintf("%x", "0x1F"), '1f', '%x parses hex string';
+is sprintf("%o", "0o17"), '17', '%o parses octal string';
+is sprintf("%b", "0b101"), '101', '%b parses binary string';
+is sprintf("%f", "0x10"), '16.000000', '%f parses hex string';
+
+# Plain decimal strings and numbers unchanged.
+is sprintf("%d", "42"), '42', '%d plain decimal string';
+is sprintf("%d", "1_000"), '1000', '%d underscore-separated string';
+is sprintf("%d", "3.9"), '3', '%d truncates decimal string';
+is sprintf("%d", 255), '255', '%d integer argument';
+is sprintf("%x", 255), 'ff', '%x integer argument';


### PR DESCRIPTION
## Summary

sprintf's integer/float directives (`%d`, `%i`, `%x`, `%o`, `%b`, `%f`, ...) coerced a `Str` argument with a plain `parse::<i64>()` / `parse::<f64>()`, so a string carrying a radix prefix numified to `0`:

```
sprintf("%d", "0x1F")   # was 0, now 31
sprintf("%d", "0b101")  # was 0, now 5
sprintf("%d", "0o17")   # was 0, now 15
sprintf("%x", "0x1F")   # was 0, now 1f
```

(While `+"0x1F"` and `"0x1F".Int` already gave `31` — sprintf just used a weaker parser.)

Routed the `Str` coercion in the int/bigint/float extractors through `parse_raku_str_to_numeric` — the same numification `+"0x1F"` uses — which honours the `0x`/`0o`/`0b`/`0d` prefixes, underscores and rationals. Non-numeric strings still fall back to `0`.

## Test
- New `t/sprintf-string-radix.t` (14 assertions), cross-checked against `raku`.
- `make test` passes (14790 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)