### PR TITLE
docs(adr): ADR-0003 accepted — default-on GC trigger policy

### DIFF
--- a/docs/adr/0003-default-on-gc-trigger.md
+++ b/docs/adr/0003-default-on-gc-trigger.md
@@ -1,6 +1,6 @@
 # ADR-0003: デフォルト GC=on のトリガ方針（level-1a の production トリガ）
 
-- **Status**: Proposed
+- **Status**: Accepted（2026-07-05 ユーザー承認）
 - **Date**: 2026-07-05
 - **Relates to**: [ADR-0001](0001-gc-strategy-and-phasing.md)（§4.2 起動方式 / §4.3 A' 範囲）,
   [ADR-0002](0002-phase-a-gate-reassessment.md), `docs/gc-level1-detailed-design.md` §9
@@ -74,4 +74,4 @@ gc-stress の全ステップ blocking 化（#4219）。しかし GC は**依然 
 
 ---
 
-*Status が Proposed の間は実装に着手しない。Accepted への昇格はユーザー承認による。*
+*2026-07-05 ユーザー承認により Accepted。実装は §2 の Decision に従い、§2-3 のゲートを満たして default-on を切り替える。*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,4 +21,4 @@
 |---|---|---|
 | [0001](0001-gc-strategy-and-phasing.md) | GC 導入の方式選定とフェーズ計画 | Accepted |
 | [0002](0002-phase-a-gate-reassessment.md) | Phase A ゲート再評価 — GC 着手条件の充足確認 | Accepted |
-| [0003](0003-default-on-gc-trigger.md) | デフォルト GC=on のトリガ方針（同期 + バッファサイズ閾値 + adaptive backoff） | Proposed |
+| [0003](0003-default-on-gc-trigger.md) | デフォルト GC=on のトリガ方針（同期 + バッファサイズ閾値 + adaptive backoff） | Accepted |


### PR DESCRIPTION
ユーザー承認(2026-07-05)により ADR-0003 の Status を Proposed → **Accepted** に更新。

決定内容(確定): 同期 collect(既存 PENDING/safepoint/STW 網を使用)+ candidate バッファ**サイズ**閾値 + adaptive backoff(`clamp(BASE, 2×survivors, MAX)`)。A' は繰延。既定値 off→on の切替は §2-3 の計測ゲート(出力 byte 一致・pause 有界・fib≈0・method-call/bench-class <5%)を満たしてから。

production 前例との整合: PHP 7.3 の Zend GC(同じ Bacon-Rajan 系)は root buffer 閾値 + 空振り時の閾値引き上げ、CPython は full collection を長寿命オブジェクト増分 25% ルールでゲート — いずれも同じ anti-quadratic 構造。

併せて、キャンペーン中に見つかった required-check の穴も封鎖済み: ruleset `main` は test + wasm-e2e + **gc-stress** を必須化(gc-stress 赤で auto-merge 不可)。

次スライス: トリガ実装(`MUTSU_GC_THRESHOLD` + adaptive backoff)→ 受け入れ計測 → default-on 切替 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK