### PR TITLE
fix(dispatch): nextsame/callsame from a mixed-in role method reaches the base method

### DIFF
--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -120,6 +120,36 @@ impl Interpreter {
                         method_attrs.insert(attr.to_string(), value.clone());
                     }
                 }
+                // Set up a method-dispatch frame so `nextsame`/`callsame` inside
+                // the role method falls through to the mixed-in base object's
+                // method of the same name: `A.new but Role` where the role's
+                // method calls `nextsame` must reach the class's original method.
+                let base_class = match inner.as_ref() {
+                    Value::Instance { class_name, .. } => Some(class_name.resolve().to_string()),
+                    _ => None,
+                };
+                let base_remaining: Vec<(String, MethodDef)> = if let Some(bc) = &base_class {
+                    self.resolve_all_methods_with_owner(bc, lookup_name, &args)
+                        .into_iter()
+                        .filter(|(_, d)| d.is_private == is_private_call)
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                let pushed_base_dispatch = !base_remaining.is_empty();
+                if pushed_base_dispatch {
+                    let rw_params =
+                        super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs);
+                    self.samewith_context_stack
+                        .push((lookup_name.to_string(), Some(target.clone())));
+                    self.method_dispatch_stack.push(super::MethodDispatchFrame {
+                        receiver_class: base_class.clone().unwrap_or_default(),
+                        invocant: target.clone(),
+                        args: args.clone(),
+                        remaining: base_remaining,
+                        rw_params,
+                    });
+                }
                 let method_result = self.run_resolved_method_compiled_or_treewalk(
                     &role_name,
                     &role_name,
@@ -129,6 +159,10 @@ impl Interpreter {
                     args,
                     Some(target.clone()),
                 );
+                if pushed_base_dispatch {
+                    self.method_dispatch_stack.pop();
+                    self.samewith_context_stack.pop();
+                }
                 for (name, previous) in &saved_role_params {
                     if let Some(prev) = previous {
                         self.env.insert(name.clone(), prev.clone());

--- a/t/nextsame-role-mixin.t
+++ b/t/nextsame-role-mixin.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+plan 7;
+
+# `nextsame`/`callsame` inside a role method that was mixed into an instance via
+# `but` (or `does`) must fall through to the base object's method of the same
+# name. Previously such a `nextsame` found no continuation and returned Nil.
+
+{
+    class A1 { method foo { "OH HAI" } }
+    role LogFoo { method foo { nextsame } }
+    my $x = A1.new but LogFoo;
+    is $x.foo, "OH HAI", 'nextsame from a mixed-in role method reaches the base method';
+}
+
+{
+    class A { method foo { "base" } }
+    role R { method foo { "R-" ~ callsame() } }
+    my $x = A.new but R;
+    is $x.foo, "R-base", 'callsame from a mixed-in role method returns the base result';
+}
+
+# A role method that mixes in but does NOT call nextsame still overrides.
+{
+    class A { method foo { "base" } }
+    role R { method foo { "override" } }
+    my $x = A.new but R;
+    is $x.foo, "override", 'role method without nextsame overrides the base method';
+}
+
+# A role method for a *different* name does not disturb the base method.
+{
+    class A { method foo { "base" } }
+    role R { method bar { "rbar" } }
+    my $x = A.new but R;
+    is $x.foo, "base", 'base method still reachable when the role adds a new method';
+    is $x.bar, "rbar", 'role-only method is callable on the mixin';
+}
+
+# nextsame can carry a mutated invocant state through to the base method.
+{
+    class Counter { has $.n is rw = 0; method bump { $!n }
+    }
+    role Trace { method bump { $.n; nextsame } }
+    my $c = Counter.new(n => 5) but Trace;
+    is $c.bump, 5, 'nextsame reaches base accessor-like method with state';
+}
+
+# callsame result can be post-processed by the role method.
+{
+    class Shape { method area { 10 } }
+    role Doubler { method area { 2 * callsame() } }
+    my $s = Shape.new but Doubler;
+    is $s.area, 20, 'callsame result is usable in the role method';
+}


### PR DESCRIPTION
## Summary

`A.new but Role` (or `does Role` on an instance) where the role's method calls `nextsame`/`callsame` returned `Nil` instead of falling through to the base object's method of the same name:

```raku
class A1 { method foo { "OH HAI" } }
role LogFoo { method foo { nextsame } }
(A1.new but LogFoo).foo   # was Nil, now "OH HAI"

class A { method foo { "base" } }
role R { method foo { "R-" ~ callsame() } }
(A.new but R).foo         # was "R-", now "R-base"
```

## Fix

`dispatch_mixin_method_call` ran the role method directly without setting up a method-dispatch frame, so a `nextsame`/`callsame` inside it found no continuation and returned `Nil`. Before running the role method, push a `MethodDispatchFrame` whose `remaining` holds the base object's candidates for the same name — resolved via `resolve_all_methods_with_owner` on the inner instance's class, filtered by public/private to match the call — and pop it afterwards.

- A role method that does **not** call `nextsame` still overrides normally.
- A role method for a **different** name leaves the base method reachable.

This is one of the blockers behind `roast/integration/advent2010-day14.t` (nextsame chapter); that file also needs multi-frame custom-`$*OUT` output capture, so it is not whitelisted here.

## Tests

- New `t/nextsame-role-mixin.t` (7 assertions): nextsame + callsame fall-through, override-without-nextsame, role-only method leaves base reachable, state-carrying invocant, post-processing callsame result.
- `make test` PASS (14795). S12/S14 role/mixin + enum roast subsets (60 files, 1328 tests) green; mixin/callsame `t/` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)