### PR TITLE
feat(gc): ADR-0003 production trigger — candidate-buffer size threshold with adaptive backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/PLAN.md
+++ b/PLAN.md
@@ -178,10 +178,12 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 残:
 
-- [ ] デフォルト GC=on のトリガ方針 → **[ADR-0003](docs/adr/0003-default-on-gc-trigger.md)（Proposed）
-      で起票済み**（同期 + candidate バッファサイズ閾値 + adaptive backoff。ADR-0001 §4.2/§4.3 の
-      未決を解決する提案）。Accepted 後に実装 → 受け入れ計測（出力一致・pause 有界・オーバーヘッド
-      予算）→ 既定値 on 切替、の順。
+- [ ] **既定値 `MUTSU_GC` off → on の切替**（GC キャンペーン最終手）。production トリガは
+      [ADR-0003](docs/adr/0003-default-on-gc-trigger.md)（Accepted）どおり**実装済み**
+      （`MUTSU_GC_THRESHOLD`・adaptive backoff。GC=on なら default で有効）。残る切替ゲート =
+      受け入れ計測: fib で `gc_candidate_pushes==0`（ADR-0001 の型フィルタゲート）／
+      method-call・bench-class の GC-on オーバーヘッド < 5%／churn 系 wall-clock ≤ GC-off 比 ~1.2x。
+      計測が通ったら `gc_enabled()` の既定を反転する切替 PR。
 - **Track B（要素 cell 化）と GC は統合キャンペーン（層3a）**。続いて NaN-boxing（層3b・JIT 地ならし）
   → JIT（層4）。`state @`/`%`・lexical aggregate の真共有（Track C 残）も Track B=層3a に依存。
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,30 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Phase B（GC）— ADR-0003 production トリガ実装（サイズ閾値 + adaptive backoff）
+
+Accepted となった [ADR-0003](../docs/adr/0003-default-on-gc-trigger.md) の production トリガを実装。
+これで `MUTSU_GC=on` は stress 変数なしで**実行中に自動でサイクルを回収**する（従来は program-end
+collect のみ）。default-on 切替前の最後の機構が揃った。
+
+- **トリガ**: `buffer_candidate` が push 後のバッファ長を `note_buffer_len` へ渡し、実効閾値到達で
+  既存の `PENDING` を arm → 次の safepoint で同期 collect（既存の cooperative STW 経路をそのまま使用）。
+- **adaptive backoff**: collect ごとに `threshold = clamp(BASE, 2 × survivors, MAX=1M)`
+  （`note_collect_survivors`）。survivors = scan_black で revive された生存ノード数。STW timeout で
+  suspects を requeue する deferral パスも requeue 数を survivors として報告（未走査の生存 suspect が
+  バッファに残るため、backoff なしでは push ごとに drain/requeue が空回りする）。
+- **チューナブル**: `MUTSU_GC_THRESHOLD`（BASE。既定 16384・`0` で無効化）。実効閾値は
+  `MUTSU_VM_STATS` の gc 行に `gc_threshold=` として出力（適応の観測点）。
+- **実測**: garbage churn（400 自己サイクル・BASE=256）= 11 collects・2758 ノード回収・出力は
+  GC-off と一致。live chain 800 ノード（cas-loop 型・BASE=64）= **4 collects のみ**で閾値 64→1604 に
+  適応（固定周期なら ~13 回、伸長する live graph の全走査を繰り返す）。PHP 7.3 Zend GC の
+  「root buffer 閾値 + 空振り時の引き上げ」と同構造。
+- 担保: `tests/gc_stress.rs` に 2 本追加（stress 変数なしで mid-run 回収 + 出力一致／live suspect で
+  閾値上昇 + collect 数の対数的上限）。`make test` 1519 files PASS・素の GC=on で S17 並行系スモーク
+  （semaphore/lock/cas-loop）VERIFY FAIL=0。
+
+残りは受け入れ計測（fib push==0・method-call/bench-class <5%・churn ≤1.2x）→ 既定値 on 切替のみ。
+
 ## 2026-07-05: Phase B（GC）— CI gc-stress の roast ステップを blocking へ昇格
 
 `MUTSU_GC=on` の advisory roast は #4215（knob 1024）の PR run で **Result: PASS** を確認。

--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -357,6 +357,11 @@ pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
             crate::gc::stw::try_stop_the_world(std::time::Duration::from_millis(50))
         };
         if stw.is_none() {
+            // The requeued suspects went unscanned and stay in the buffer;
+            // count them as survivors for the ADR-0003 adaptive threshold so
+            // the size trigger backs off instead of re-arming a drain/requeue
+            // round-trip on every push over the (still-exceeded) threshold.
+            crate::gc::safepoint::note_collect_survivors(suspects.len());
             crate::gc::gc_ptr::requeue_candidates(suspects);
             if dead_count > 0 {
                 let pause_ns = start.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
@@ -450,6 +455,11 @@ pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
         cycles as u64,
         pause_ns,
     );
+    // ADR-0003 adaptive threshold: the revived (live) portion of the scanned
+    // subgraph is what the next scan would re-trace for nothing — back the
+    // size trigger off proportionally (clamped to BASE when the scan was
+    // productive).
+    crate::gc::safepoint::note_collect_survivors(m.revived);
 
     if mode != LogMode::Off {
         let cycles_field = if mode >= LogMode::Detail {

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -558,13 +558,18 @@ fn buffer_candidate(node: ErasedGc) {
     node.header
         .color
         .store(Color::Purple as u8, Ordering::Relaxed);
-    if let Ok(mut buf) = candidate_buffer().lock() {
+    let len = if let Ok(mut buf) = candidate_buffer().lock() {
         buf.push(node);
-    }
+        buf.len()
+    } else {
+        0
+    };
     record_gc_candidate_push();
-    // May arm a pending collect (MUTSU_GC_EVERY_CANDIDATE); never collects inline
-    // here — this runs from `Gc::drop`, which can hold a borrow (design §1.2).
+    // May arm a pending collect (the MUTSU_GC_EVERY_CANDIDATE stress period,
+    // or the ADR-0003 production size threshold); never collects inline here —
+    // this runs from `Gc::drop`, which can hold a borrow (design §1.2).
     super::safepoint::note_candidate_push();
+    super::safepoint::note_buffer_len(len);
 }
 
 /// Number of user worker threads (`start`/`Promise`/`hyper`/`race`/Supply

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -63,7 +63,9 @@ pub(crate) use gc_ptr::{
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};
 #[allow(unused_imports)]
 pub(crate) use safepoint::{
-    SafepointKind, armed as gc_safepoints_armed, gc_safepoint, startup_collect_if_requested,
+    SafepointKind, armed as gc_safepoints_armed,
+    current_size_threshold as gc_current_size_threshold, gc_safepoint,
+    startup_collect_if_requested,
 };
 #[allow(unused_imports)]
 pub(crate) use stw::{

--- a/src/gc/safepoint.rs
+++ b/src/gc/safepoint.rs
@@ -24,6 +24,17 @@
 //!   (§9.2 "seed を必ずログに出す").
 //! - `MUTSU_GC=on` + `MUTSU_GC_COLLECT_NOW=1` — one collect right at program
 //!   start ([`startup_collect_if_requested`], called from `Interpreter::run`).
+//!
+//! ## Production trigger (ADR-0003, on by default under `MUTSU_GC=on`)
+//! - Candidate-buffer **size** threshold with adaptive backoff: a collect is
+//!   armed when the buffer reaches the effective threshold, and after each
+//!   collect `threshold = clamp(BASE, 2 × survivors, MAX)` — a scan that
+//!   mostly re-proved liveness backs off (the fixed-period rescan of a large
+//!   live suspect set is quadratic; measured on S17-lowlevel/cas-loop.t), a
+//!   productive scan falls back toward BASE. `MUTSU_GC_THRESHOLD` sets BASE
+//!   (default 16384; `0` disables the size trigger). Same production shape as
+//!   PHP 7.3's Zend GC (root-buffer threshold that raises itself on
+//!   unproductive collects).
 
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -108,7 +119,18 @@ struct Triggers {
     at_mask: u16,
     /// `MUTSU_GC_RANDOM_RATE` as `f64` bits (0 = random stress off).
     random_rate_bits: u64,
+    /// Production trigger (ADR-0003): BASE of the candidate-buffer size
+    /// threshold. Defaults ON whenever `MUTSU_GC=on` (`MUTSU_GC_THRESHOLD`
+    /// overrides; `0` disables). 0 here = size trigger off.
+    threshold_base: usize,
 }
+
+/// Default BASE for the ADR-0003 size threshold (starting point pending the
+/// acceptance measurements; tune via `MUTSU_GC_THRESHOLD`).
+const THRESHOLD_BASE_DEFAULT: usize = 16384;
+/// Upper clamp for the adaptive threshold: bounds worst-case buffer memory
+/// while still backing far out of rescan churn on huge live suspect sets.
+const THRESHOLD_MAX: usize = 1 << 20;
 
 impl Triggers {
     fn from_env() -> Triggers {
@@ -119,18 +141,33 @@ impl Triggers {
                 every_candidate: 0,
                 at_mask: 0,
                 random_rate_bits: 0,
+                threshold_base: 0,
             };
         }
         let every_safepoint = parse_flag("MUTSU_GC_EVERY_SAFEPOINT");
         let every_candidate = parse_count("MUTSU_GC_EVERY_CANDIDATE");
         let at_mask = parse_at_mask("MUTSU_GC_AT");
         let random_rate_bits = init_random("MUTSU_GC_RANDOM_RATE", "MUTSU_GC_RANDOM_SEED");
+        let threshold_base = match std::env::var("MUTSU_GC_THRESHOLD").ok().as_deref() {
+            None => THRESHOLD_BASE_DEFAULT,
+            Some(s) => s.parse::<usize>().unwrap_or_else(|_| {
+                eprintln!(
+                    "[mutsu gc] warning: unrecognized MUTSU_GC_THRESHOLD={s:?}, using default"
+                );
+                THRESHOLD_BASE_DEFAULT
+            }),
+        };
         Triggers {
-            armed: every_safepoint || every_candidate > 0 || at_mask != 0 || random_rate_bits != 0,
+            armed: every_safepoint
+                || every_candidate > 0
+                || at_mask != 0
+                || random_rate_bits != 0
+                || threshold_base > 0,
             every_safepoint,
             every_candidate,
             at_mask,
             random_rate_bits,
+            threshold_base,
         }
     }
 }
@@ -254,6 +291,54 @@ pub(crate) fn armed() -> bool {
 /// next safepoint).
 static CANDIDATE_PUSHES: AtomicUsize = AtomicUsize::new(0);
 static PENDING: AtomicBool = AtomicBool::new(false);
+
+/// ADR-0003 adaptive size threshold. `0` = not yet adapted (use the BASE from
+/// `MUTSU_GC_THRESHOLD`); otherwise the clamped `2 × survivors` from the last
+/// collect. A scan that mostly re-proves liveness raises it (backing out of
+/// the fixed-period rescan pathology measured on cas-loop.t); a scan that
+/// reclaims most of its input lets it fall back toward BASE.
+static ADAPTIVE_THRESHOLD: AtomicUsize = AtomicUsize::new(0);
+
+/// The size threshold currently in effect, or 0 when the size trigger is
+/// disabled (`MUTSU_GC_THRESHOLD=0` or GC off). Also surfaced in the
+/// `MUTSU_VM_STATS` gc line so tests/operators can observe adaptation.
+pub(crate) fn current_size_threshold() -> usize {
+    let base = triggers().threshold_base;
+    if base == 0 {
+        return 0;
+    }
+    match ADAPTIVE_THRESHOLD.load(Ordering::Relaxed) {
+        0 => base,
+        adapted => adapted,
+    }
+}
+
+/// Record the candidate buffer's length after a push (called from
+/// `gc_ptr::buffer_candidate`, outside the buffer lock). Arms a pending
+/// collect when the buffer reaches the effective size threshold (ADR-0003).
+#[inline]
+pub(crate) fn note_buffer_len(len: usize) {
+    let eff = current_size_threshold();
+    if eff != 0 && len >= eff {
+        PENDING.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Adapt the size threshold after a collect: `clamp(BASE, 2 × survivors, MAX)`
+/// (ADR-0003 §2-2). `survivors` is the live portion of the scanned subgraph —
+/// the nodes the next scan would re-trace for nothing. The deferred path (STW
+/// timeout re-queues its suspects unscanned) reports the requeued count as
+/// survivors for the same reason: they stay in the buffer, and without the
+/// backoff every subsequent push over the threshold would re-arm a drain/
+/// requeue round-trip against the same stuck set.
+pub(crate) fn note_collect_survivors(survivors: usize) {
+    let base = triggers().threshold_base;
+    if base == 0 {
+        return;
+    }
+    let next = survivors.saturating_mul(2).clamp(base, THRESHOLD_MAX);
+    ADAPTIVE_THRESHOLD.store(next, Ordering::Relaxed);
+}
 
 /// Record a candidate-buffer push (called from `gc_ptr::buffer_candidate`).
 /// Under `MUTSU_GC_EVERY_CANDIDATE=N`, arms a pending collect every `N` pushes.

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -288,8 +288,12 @@ pub(crate) fn dump() {
     let gc_pause_ns_total = GC_PAUSE_NS_TOTAL.load(Ordering::Relaxed);
     let gc_pause_ns_max = GC_PAUSE_NS_MAX.load(Ordering::Relaxed);
     let gc_roots_scanned = GC_ROOTS_SCANNED.load(Ordering::Relaxed);
+    // The ADR-0003 size trigger's effective threshold at exit (BASE unless a
+    // collect adapted it; 0 = size trigger disabled). Observable proof of the
+    // adaptive backoff for tests/operators.
+    let gc_threshold = crate::gc::gc_current_size_threshold();
     eprintln!(
-        "[mutsu vm-stats] gc: collections={gc_collections} candidate_pushes={gc_candidate_pushes} dedup_hits={gc_dedup_hits} reclaimed_nodes={gc_reclaimed_nodes} reclaimed_cycles={gc_reclaimed_cycles} pause_ns_total={gc_pause_ns_total} pause_ns_max={gc_pause_ns_max} roots_scanned={gc_roots_scanned}"
+        "[mutsu vm-stats] gc: collections={gc_collections} candidate_pushes={gc_candidate_pushes} dedup_hits={gc_dedup_hits} reclaimed_nodes={gc_reclaimed_nodes} reclaimed_cycles={gc_reclaimed_cycles} pause_ns_total={gc_pause_ns_total} pause_ns_max={gc_pause_ns_max} roots_scanned={gc_roots_scanned} gc_threshold={gc_threshold}"
     );
     if let Ok(map) = function_fallback_by_name().lock()
         && !map.is_empty()

--- a/tests/gc_stress.rs
+++ b/tests/gc_stress.rs
@@ -25,6 +25,7 @@ fn run(src: &str, gc: &[(&str, &str)]) -> (String, String, bool) {
         "MUTSU_GC_COLLECT_NOW",
         "MUTSU_GC_RANDOM_RATE",
         "MUTSU_GC_RANDOM_SEED",
+        "MUTSU_GC_THRESHOLD",
         "MUTSU_GC_VERIFY",
         "MUTSU_GC_LOG",
     ] {
@@ -659,5 +660,99 @@ fn spawn_churn_does_not_starve_stop_the_world() {
     assert!(
         pause_total_ns < 2_000_000_000,
         "STW must not repeatedly time out under spawn churn; pause_ns_total={pause_total_ns}\nstderr:\n{err}"
+    );
+}
+
+/// Pull the `key=N` counter out of the `[mutsu vm-stats] gc:` summary line.
+fn gc_stat(err: &str, key: &str) -> u64 {
+    let prefix = format!("{key}=");
+    err.lines()
+        .find(|l| l.contains("[mutsu vm-stats] gc:"))
+        .and_then(|l| {
+            l.split_whitespace()
+                .find_map(|tok| tok.strip_prefix(prefix.as_str()))
+        })
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(u64::MAX)
+}
+
+/// ADR-0003 production trigger: with ONLY `MUTSU_GC=on` (no stress vars), the
+/// candidate-buffer size threshold must fire collects mid-run — garbage
+/// cycles get reclaimed before program end, and the output is identical to
+/// GC-off. (Pre-ADR-0003, plain GC=on meant program-end collect only.)
+#[test]
+fn size_threshold_trigger_collects_without_stress_vars() {
+    let src = r#"for ^400 { my %h; %h<self> := %h; }; say "done";"#;
+
+    let (off, _, ok_off) = run(src, &[]);
+    let (on, err, ok_on) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_THRESHOLD", "256"),
+            ("MUTSU_GC_VERIFY", "1"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+
+    assert!(ok_off && ok_on, "runs must succeed; stderr:\n{err}");
+    assert_eq!(off, on, "size-threshold run changed program output");
+    assert!(
+        !err.contains("VERIFY FAIL"),
+        "no soundness violations under the size trigger:\n{err}"
+    );
+    // Mid-run collects (threshold crossings) plus the program-end one.
+    let collections = gc_stat(&err, "collections");
+    assert!(
+        collections >= 2,
+        "size threshold must fire before program end; collections={collections}\n{err}"
+    );
+    assert!(
+        gc_stat(&err, "reclaimed_nodes") > 0,
+        "cycle garbage must be reclaimed; stderr:\n{err}"
+    );
+}
+
+/// ADR-0003 adaptive backoff: a workload whose candidates are mostly a GROWING
+/// LIVE structure (the cas-loop.t shape — every scan re-proves liveness) must
+/// raise the effective threshold (`2 × survivors`) instead of re-scanning the
+/// live graph on a fixed period, keeping the collect count logarithmic-ish
+/// rather than pushes/BASE.
+#[test]
+fn adaptive_threshold_backs_off_on_live_suspects() {
+    let src = r#"
+        class Node { has $.v; has $.next }
+        my $head = Node;
+        for ^800 { $head = Node.new(v => $_, next => $head); }
+        say $head.v;
+    "#;
+
+    let (out, err, ok) = run(
+        src,
+        &[
+            ("MUTSU_GC", "on"),
+            ("MUTSU_GC_THRESHOLD", "64"),
+            ("MUTSU_GC_VERIFY", "1"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+
+    assert!(ok, "live-chain run must succeed; stderr:\n{err}");
+    assert_eq!(out.trim(), "799", "live chain must stay intact");
+    assert!(
+        !err.contains("VERIFY FAIL"),
+        "no soundness violations on a live suspect graph:\n{err}"
+    );
+    let threshold = gc_stat(&err, "gc_threshold");
+    assert!(
+        threshold > 64,
+        "unproductive scans must raise the threshold (2 x survivors); gc_threshold={threshold}\n{err}"
+    );
+    // ~830 candidate pushes at BASE=64 would be ~13 fixed-period scans of the
+    // growing chain; the geometric backoff needs only a handful (4 measured).
+    let collections = gc_stat(&err, "collections");
+    assert!(
+        collections <= 8,
+        "adaptive backoff must bound rescans of a growing live graph; collections={collections}\n{err}"
     );
 }


### PR DESCRIPTION
## Summary

Accepted となった [ADR-0003](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0003-default-on-gc-trigger.md) の production トリガを実装。**素の `MUTSU_GC=on`(stress 変数なし)で実行中に自動でサイクル回収**が走るようになります(従来は program-end collect のみ)。default-on 切替前の最後の機構です。

## 実装

- **トリガ**: `buffer_candidate` が push 後のバッファ長を `note_buffer_len` に渡し、実効閾値到達で既存 `PENDING` を arm → 次の safepoint で同期 collect(既存の cooperative STW 経路をそのまま使用)。
- **adaptive backoff**: collect ごとに `threshold = clamp(BASE, 2 × survivors, MAX=1M)`。survivors = `scan_black` が revive した生存ノード数。STW timeout の deferral パスも requeue 数を survivors として報告(未走査の生存 suspect がバッファに残るため、backoff なしでは push ごとに drain/requeue が空回りする)。
- **チューナブル**: `MUTSU_GC_THRESHOLD`(BASE。既定 16384・`0` で無効)。実効閾値は `MUTSU_VM_STATS` の gc 行に `gc_threshold=` として出力。

## 実測

| ワークロード | 結果 |
|---|---|
| garbage churn(400 自己サイクル・BASE=256) | 11 collects・2758 ノード回収・出力 GC-off と byte 一致 |
| live chain 800 ノード(cas-loop 型・BASE=64) | **4 collects のみ**・閾値 64→1604 に適応(固定周期なら ~13 回の全 live graph 再走査) |

PHP 7.3 Zend GC(同じ Bacon-Rajan 系)の「root buffer 閾値 + 空振り時の自動引き上げ」と同構造です。

## 担保

- `tests/gc_stress.rs` +2: stress 変数なしの mid-run 回収 + 出力一致 / live suspect での閾値上昇 + collect 数の対数的上限
- `make test` 1519 files PASS / 素の GC=on で S17 semaphore・lock・cas-loop スモーク(VERIFY FAIL=0)/ cargo test 通常・stress 両環境 green

## 残り(PLAN.md §2)

受け入れ計測(fib `gc_candidate_pushes==0`・method-call/bench-class <5%・churn ≤1.2x)→ `gc_enabled()` 既定反転の切替 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK