### PR TITLE
fix(method): unqualified external private call is X::Method::Private::Unqualified

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1,4 +1,6 @@
-use super::methods_signature_errors::{make_method_not_found_error, make_private_permission_error};
+use super::methods_signature_errors::{
+    make_method_not_found_error, make_private_permission_error, make_private_unqualified_error,
+};
 use super::*;
 use crate::symbol::Symbol;
 
@@ -48,6 +50,11 @@ impl Interpreter {
                     .last()
                     .cloned()
                     .or_else(|| Some(self.current_package().to_string()));
+                // An unqualified external private call (`$o!meth` where `$o` is
+                // not `self`) must name the defining package — Raku reports
+                // X::Method::Private::Unqualified rather than the Permission
+                // error used for a qualified-but-untrusted call.
+                let was_qualified = private_rest.contains("::");
                 // Resolve: owner-qualified (!Owner::method) or unqualified (!method)
                 let (pm_name, resolved) =
                     if let Some((owner_class, pm_name)) = private_rest.split_once("::") {
@@ -97,11 +104,14 @@ impl Interpreter {
                                     .is_some_and(|caller| trusted.contains(caller))
                             });
                     if !caller_allowed {
-                        return Err(make_private_permission_error(
-                            pm_name,
-                            &class_name.resolve(),
-                            caller_class.as_deref().unwrap_or("GLOBAL"),
-                        ));
+                        if was_qualified {
+                            return Err(make_private_permission_error(
+                                pm_name,
+                                &class_name.resolve(),
+                                caller_class.as_deref().unwrap_or("GLOBAL"),
+                            ));
+                        }
+                        return Err(make_private_unqualified_error(pm_name));
                     }
                     let (result, updated) = self.run_resolved_method_compiled_or_treewalk(
                         &class_name.resolve(),

--- a/t/private-method-unqualified.t
+++ b/t/private-method-unqualified.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+plan 5;
+
+# Calling a private method on something other than `self` without naming the
+# defining package is X::Method::Private::Unqualified (Raku requires
+# `$obj!Package::meth`). A qualified-but-untrusted call is the *different*
+# X::Method::Private::Permission.
+
+class A {
+    method !secret { 42 }
+    method reveal  { self!secret }   # self!meth is always allowed
+}
+
+# self!meth inside the class is fine.
+is A.new.reveal, 42, 'self!private works inside the class';
+
+# Unqualified external private call -> X::Method::Private::Unqualified.
+{
+    my $a = A.new;
+    throws-like { $a!secret }, X::Method::Private::Unqualified,
+        'unqualified external private call is X::Method::Private::Unqualified';
+}
+
+# Via EVAL too (matches the advent2011-day11 usage).
+throws-like q[ class B { method !s { 1 } }; my $b = B.new; $b!s ],
+    X::Method::Private::Unqualified,
+    'unqualified external private call through EVAL';
+
+# A qualified call to a class that does not trust the caller is Permission.
+{
+    my $a = A.new;
+    throws-like { $a!A::secret }, X::Method::Private::Permission,
+        'qualified untrusted private call is X::Method::Private::Permission';
+}
+
+# X::Method::Private::Unqualified carries the method name.
+{
+    my $a = A.new;
+    my $ex;
+    try { $a!secret; CATCH { default { $ex = $_ } } }
+    is $ex.method, 'secret', 'the exception names the private method';
+}


### PR DESCRIPTION
## Summary

An unqualified private method call on something other than `self` — `\$obj!meth` from *outside* the class — must name the defining package; Raku reports `X::Method::Private::Unqualified` ("Calling private method 'meth' must be fully qualified with the package containing that private method"). mutsu instead reported the *qualified*-call error `X::Method::Private::Permission` ("does not trust GLOBAL").

```raku
class A { method !secret { 42 } }
my $a = A.new;
$a!secret      # was X::Method::Private::Permission, now X::Method::Private::Unqualified
$a!A::secret   # still X::Method::Private::Permission (qualified, untrusted)
A.new.reveal   # self!secret inside the class — unaffected
```

## Fix

In the instance private-call dispatch (`methods_instance_ops.rs`), when the call is unqualified (no `::` in the method name) and the caller is not the owner/trusted, throw `X::Method::Private::Unqualified`. A qualified-but-untrusted call still reports `Permission`, and `self!meth` inside the class is unaffected (the caller is the owner, so no error).

## Tests

- New `t/private-method-unqualified.t` (5 assertions): `self!meth` works, unqualified external call is Unqualified (direct + via EVAL), qualified untrusted is Permission, exception carries the method name.
- `make test` PASS (14815). S12-methods (incl. private.t / trusts.t) roast subset green.
- Advances `roast/integration/advent2011-day11.t` from 6/9 to 7/9 (the file has unrelated remaining failures, so it is not whitelisted here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)