### PR TITLE
fix(str): .encode result is an immutable Blob, not a mutable Buf

### DIFF
--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -255,7 +255,7 @@ impl Interpreter {
                     class_name,
                     attributes,
                     ..
-                } if crate::runtime::utils::is_buf_like_class(&class_name.resolve()) => {
+                } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
                     // Buf argument: decode as UTF-8
                     if let Some(Value::Array(items, _)) = attributes.as_map().get("bytes") {
                         let bytes: Vec<u8> = items

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -416,7 +416,7 @@ impl Interpreter {
                     class_name,
                     attributes,
                     ..
-                }) if crate::runtime::utils::is_buf_like_class(&class_name.resolve()) => {
+                }) if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
                     if let Some(Value::Array(items, _)) = attributes.as_map().get("bytes") {
                         let bytes: Vec<u8> = items
                             .iter()

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -508,14 +508,11 @@ impl Interpreter {
                     {
                         let class = class_name.resolve();
                         let class_ok = if base == "Buf" {
-                            class == "Buf" || class.starts_with("Buf[") || class.starts_with("buf")
+                            crate::runtime::utils::is_buf_like_class(&class)
                         } else {
-                            class == "Blob"
-                                || class == "Buf"
-                                || class.starts_with("Blob[")
-                                || class.starts_with("blob")
-                                || class.starts_with("Buf[")
-                                || class.starts_with("buf")
+                            // A Blob constraint accepts Buf-like types too (Buf
+                            // does Blob), plus the immutable encoding buffers.
+                            crate::runtime::utils::is_buf_or_blob_class(&class)
                         };
                         if !class_ok {
                             return false;

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -111,19 +111,22 @@ pub(crate) fn strip_utf8_bom(s: String) -> String {
     }
 }
 
-/// Check if a class name represents a Buf-like type (Buf, Buf[uint8], buf8, etc.)
+/// Check if a class name represents a (mutable) Buf-like type (Buf, Buf[uint8],
+/// buf8, etc.). The encoding types (utf8/utf16/...) are immutable Blobs, not
+/// Bufs, so they are excluded here (see `is_blob_like_class`).
 pub(crate) fn is_buf_like_class(cn: &str) -> bool {
-    matches!(
-        cn,
-        "Buf" | "buf8" | "buf16" | "buf32" | "buf64" | "utf8" | "utf16"
-    ) || cn.starts_with("Buf[")
+    matches!(cn, "Buf" | "buf8" | "buf16" | "buf32" | "buf64")
+        || cn.starts_with("Buf[")
         || cn.starts_with("buf")
 }
 
-/// Check if a class name represents a Blob-like type (Blob, Blob[uint8], blob8, etc.)
+/// Check if a class name represents a Blob-like type (Blob, Blob[uint8], blob8,
+/// and the immutable encoding buffers utf8/utf16/utf32).
 pub(crate) fn is_blob_like_class(cn: &str) -> bool {
-    matches!(cn, "Blob" | "blob8" | "blob16" | "blob32" | "blob64")
-        || cn.starts_with("Blob[")
+    matches!(
+        cn,
+        "Blob" | "blob8" | "blob16" | "blob32" | "blob64" | "utf8" | "utf16" | "utf32"
+    ) || cn.starts_with("Blob[")
         || cn.starts_with("blob")
 }
 

--- a/t/encode-utf8-is-blob.t
+++ b/t/encode-utf8-is-blob.t
@@ -1,0 +1,38 @@
+use Test;
+
+# The result of .encode (a utf8/utf16/utf32 buffer) is an immutable Blob, not a
+# mutable Buf. mutsu previously classified utf8 as Buf-like, so `~~ Buf` was
+# True and its elements could be mutated.
+
+plan 16;
+
+my $enc = "hi".encode;
+
+# Type membership
+nok $enc ~~ Buf, 'encode result is not a Buf';
+ok $enc ~~ Blob, 'encode result is a Blob';
+ok $enc ~~ Blob[uint8], 'encode result is a Blob[uint8]';
+nok $enc ~~ Buf[uint8], 'encode result is not a Buf[uint8]';
+
+# A Buf is both Buf and Blob
+ok buf8.new(1) ~~ Buf, 'buf8 is a Buf';
+ok buf8.new(1) ~~ Blob, 'buf8 is a Blob';
+
+# Immutability: mutating an encode result throws
+dies-ok { my $b = "hi".encode; $b[0] = 200 }, 'cannot mutate an encode result';
+
+# A real Buf is mutable
+lives-ok { my $b = buf8.new(1, 2); $b[0] = 9 }, 'buf8 element is mutable';
+
+# All the read operations still work on the encoded Blob
+is $enc.decode, 'hi', 'encode roundtrips through decode';
+is $enc.elems, 2, 'elems';
+is $enc.bytes, 2, 'bytes';
+is $enc[0], 104, 'indexing';
+is $enc.subbuf(1).list, (105,), 'subbuf';
+is $enc.reverse.list, (105, 104), 'reverse';
+is "café".encode.list, (99, 97, 102, 195, 169), 'utf-8 bytes';
+
+# A Blob-typed parameter accepts an encode result
+sub takes-blob(Blob $b) { $b.decode }
+is takes-blob("hi".encode), 'hi', 'Blob parameter accepts an encode result';


### PR DESCRIPTION
## Summary

`.encode` returns a `utf8`/`utf16`/`utf32` buffer, which in Raku is an **immutable Blob** subtype. mutsu classified those as Buf-like:

```
"hi".encode ~~ Buf          # was True   — raku False
my $b = "hi".encode; $b[0] = 200   # was allowed — raku throws (immutable)
```

Moved `utf8`/`utf16`/`utf32` from `is_buf_like_class` to `is_blob_like_class`, so:
- `~~ Buf` / `~~ Buf[uint8]` is `False`, `~~ Blob` / `~~ Blob[uint8]` is `True`;
- mutating an encode result now raises (its elements are immutable);
- Buf-only mutators (write-bits, ...) no longer apply to it.

The read paths that consumed a Buf-like instance (decode-as-UTF-8 in `EVAL`, byte extraction) now accept any Buf-or-Blob, so encode results still `decode`, index, `subbuf`, `reverse` and pass to `Blob`-typed parameters. The parameterized Buf/Blob type match was switched to the shared helpers.

## Test
- New `t/encode-utf8-is-blob.t` (16 assertions), cross-checked against `raku`.
- `make test` passes (14833 tests; the one failure was the known-flaky `t/concurrent-compound-assign.t` — passes 4/4 locally, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)