### PR TITLE
fix(regex): .match(:ex) / :exhaustive returns all matches, ordered longest-first

### DIFF
--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -12,6 +12,7 @@ impl Interpreter {
         }
         let text = target.to_string_value();
         let mut overlap = false;
+        let mut exhaustive = false;
         let mut global = false;
         let mut anchored_pos: Option<usize> = None;
         let mut continue_pos: Option<usize> = None;
@@ -22,6 +23,8 @@ impl Interpreter {
             if let Value::Pair(key, value) = arg {
                 if (key == "ov" || key == "overlap") && value.truthy() {
                     overlap = true;
+                } else if (key == "ex" || key == "exhaustive") && value.truthy() {
+                    exhaustive = true;
                 } else if key == "p" || key == "pos" {
                     anchored_pos = Some(value.to_f64() as usize);
                 } else if key == "c" || key == "continue" {
@@ -57,9 +60,15 @@ impl Interpreter {
             }
             _ => return Ok(Value::Nil),
         };
-        if global || overlap || repeat_bounds.is_some() || nth_arg.is_some() {
+        if global || overlap || exhaustive || repeat_bounds.is_some() || nth_arg.is_some() {
             let all = self.regex_match_all_with_captures(&pat, &text);
-            let mut selected = if overlap {
+            let mut selected = if exhaustive {
+                // :exhaustive keeps every possible match, ordered by start
+                // position ascending and, at each position, longest first.
+                let mut all = all;
+                all.sort_by(|a, b| a.from.cmp(&b.from).then(b.to.cmp(&a.to)));
+                all
+            } else if overlap {
                 let mut best_by_start: std::collections::BTreeMap<usize, RegexCaptures> =
                     std::collections::BTreeMap::new();
                 for capture in all {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -582,6 +582,9 @@ impl Interpreter {
                     self.clear_match_state();
                     return false;
                 }
+                // :exhaustive orders matches by start position ascending and,
+                // at each position, longest first.
+                all.sort_by(|a, b| a.from.cmp(&b.from).then(b.to.cmp(&a.to)));
                 let selected = if let Some(needed) = *repeat {
                     let earliest = all.iter().map(|c| c.from).min().unwrap_or(0);
                     all.retain(|c| c.from == earliest);

--- a/t/match-exhaustive.t
+++ b/t/match-exhaustive.t
@@ -1,0 +1,43 @@
+use Test;
+
+# .match(..., :ex) / :exhaustive returns every possible match: at every start
+# position, every possible length, ordered by start ascending and (at each
+# position) longest first. mutsu previously ignored the :ex adverb on .match
+# (returning a single greedy match / nothing), and ordered the m:ex// form
+# shortest-first.
+
+plan 16;
+
+# Fixed-length pattern: exhaustive == every start position
+is "abcabc".match(/a.c/, :ex).elems, 2, 'fixed pattern: two matches';
+is "abcabc".match(/a.c/, :exhaustive).elems, 2, ':exhaustive alias';
+is "banana".match(/a.a/, :ex).elems, 2, 'overlapping fixed matches';
+is "banana".match(/a.a/, :ex)>>.Str.join(","), "ana,ana", 'overlapping match text';
+
+# Variable-length pattern: every length at every position
+is "aaa".match(/a+/, :ex).elems, 6, 'a+ over aaa: six matches';
+is "aaa".match(/a+/, :ex)>>.Str.join(","), "aaa,aa,a,aa,a,a",
+    'longest-first ordering per position';
+is "1234".match(/\d+/, :ex).elems, 10, '\d+ over 1234: ten matches';
+is "1234".match(/\d\d/, :ex).elems, 3, 'two-digit exhaustive: three matches';
+
+# Captures survive
+is "abab".match(/(a)(b)/, :ex).elems, 2, 'captured exhaustive matches';
+is "abab".match(/(a)(b)/, :ex)[0][0].Str, "a", 'capture accessible';
+
+# Literal string pattern
+is "hello".match("l", :ex).elems, 2, 'literal string :ex';
+
+# Empty / no match
+is "".match(/a*/, :ex).elems, 1, 'empty string matches a* once';
+is "abc".match(/x/, :ex).elems, 0, 'no match is empty';
+
+# :ex returns a List
+is "aaa".match(/a+/, :ex).^name, "List", ':ex returns a List';
+
+# The m:ex// form orders the same way
+"aaa" ~~ m:ex/a+/;
+is $/>>.Str.join(","), "aaa,aa,a,aa,a,a", 'm:ex// ordering';
+
+# :g and :ov are unaffected
+is "aaa".match(/a+/, :ov).elems, 3, ':ov still works';

--- a/t/regex-exhaustive-repetition.t
+++ b/t/regex-exhaustive-repetition.t
@@ -6,7 +6,7 @@ my $str = 'abbb';
 my regex rx { a b+ };
 
 ok($str ~~ m:ex:x(2)/<rx>/, 'm:ex:x(2) finds two exhaustive captures');
-is(~$/[0], 'ab', 'first exhaustive capture is shortest match');
+is(~$/[0], 'abbb', 'first exhaustive capture is longest match');
 is(~$/[1], 'abb', 'second exhaustive capture is next match');
 ok($str ~~ m:ex:x(3)/<rx>/, 'm:ex:x(3) finds three exhaustive captures');
 ok($str !~~ m:ex:x(4)/<rx>/, 'm:ex:x(4) fails when only three captures exist');


### PR DESCRIPTION
## Summary

`.match(..., :ex)` (and `:exhaustive`) was not recognized as a multi-match adverb, so it fell through to a single greedy match:

```
"abcabc".match(/a.c/, :ex).elems    # was 0 — raku 2
"aaa".match(/a+/, :ex).elems        # was 1 — raku 6
```

And the `m:ex//` form, while it found the right matches, ordered them shortest-first per position instead of longest-first.

Now `:ex`/`:exhaustive` is recognized in the `.match` dispatch and returns every possible match — at every start position, every possible length — ordered by start position ascending and, at each position, **longest first** (matching raku). Both the `.match` and `m:ex//` paths share the same `(from asc, to desc)` ordering.

```
"aaa".match(/a+/, :ex)>>.Str   # (aaa aa a aa a a)  — matches raku
```

## Test
- New `t/match-exhaustive.t` (16 assertions), cross-checked against `raku`.
- Corrected `t/regex-exhaustive-repetition.t`, which asserted the old shortest-first order; `raku` returns longest-first (`abbb, abb, ab`), which the test now expects.
- `make test` passes (14860 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)