### PR TITLE
fix(classify): each classify/categorize bucket is an itemized array

### DIFF
--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -644,13 +644,28 @@ fn parse_named_destructuring(
         } else {
             &dvar.name
         };
+        let mut value_expr = Expr::Index {
+            target: Box::new(Expr::HashVar(hash_bare.clone())),
+            index: Box::new(Expr::Literal(Value::str(bare_name.to_string()))),
+            is_positional: false,
+        };
+        // A named `@`-sigil destructure target binds (`:=`) the hash value, which
+        // spreads an itemized array (e.g. a `.classify` bucket `$[2,4]`) into the
+        // array. mutsu's destructure lowers to assignment, so de-itemize the value
+        // via `.list` for `@`-targets — a no-op for a plain list, but it unwraps a
+        // single itemized array so `my (:@even) := classify(...)` yields `[2,4]`.
+        if dvar.name.starts_with('@') {
+            value_expr = Expr::MethodCall {
+                target: Box::new(value_expr),
+                name: crate::symbol::Symbol::intern("list"),
+                args: Vec::new(),
+                modifier: None,
+                quoted: false,
+            };
+        }
         stmts.push(Stmt::VarDecl {
             name: dvar.name.clone(),
-            expr: Expr::Index {
-                target: Box::new(Expr::HashVar(hash_bare.clone())),
-                index: Box::new(Expr::Literal(Value::str(bare_name.to_string()))),
-                is_positional: false,
-            },
+            expr: value_expr,
             type_constraint: type_constraint.clone(),
             is_state,
             is_our: false,

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -359,10 +359,35 @@ impl Interpreter {
     /// (typed keys) when any classifier key was non-`Str` (e.g. a Junction). An
     /// object hash makes `$result{ $key }` a by-key lookup rather than junction
     /// autothreading, and `.keys` yield the real key objects.
+    /// Itemize each bucket's value list so `%classified<key>` behaves as a
+    /// single (non-flattening) array — Raku stores each bucket as `$[...]`, so
+    /// `my @a = %c<k>` yields one element and `for %c<k> {}` runs once. Recurses
+    /// into nested categorize buckets (multi-level paths become nested hashes).
+    fn itemize_bucket_value(v: Value) -> Value {
+        match v {
+            Value::Array(items, kind) => Value::Array(items, kind.itemize()),
+            Value::Hash(mut arc) => {
+                let data = crate::gc::Gc::make_mut(&mut arc);
+                let keys: Vec<String> = data.map.keys().cloned().collect();
+                for k in keys {
+                    if let Some(val) = data.map.remove(&k) {
+                        data.map.insert(k, Self::itemize_bucket_value(val));
+                    }
+                }
+                Value::Hash(arc)
+            }
+            other => other,
+        }
+    }
+
     fn classify_finish_hash(
         buckets: HashMap<String, Value>,
         object_keys: HashMap<String, Value>,
     ) -> Value {
+        let buckets: HashMap<String, Value> = buckets
+            .into_iter()
+            .map(|(k, v)| (k, Self::itemize_bucket_value(v)))
+            .collect();
         let hash = Value::hash(buckets);
         if object_keys.is_empty() {
             return hash;

--- a/t/classify-bucket-itemized.t
+++ b/t/classify-bucket-itemized.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+plan 9;
+
+# `.classify` / `.categorize` store each bucket as an itemized array (`$[...]`),
+# so a bucket does not flatten when assigned to an `@`-array and iterates as a
+# single element — matching Raku.
+
+{
+    my %c = (1, 2, 3, 4).classify(* %% 2);
+
+    is %c{True}.elems, 2, 'bucket .elems sees the inner elements';
+    is %c{True}[0],     2, 'bucket positional index works on the inner array';
+
+    my @flat = %c{True};
+    is @flat.elems, 1, 'assigning a bucket to @-array does not flatten (itemized)';
+
+    my $iterations = 0;
+    $iterations++ for %c{True};
+    is $iterations, 1, 'iterating a bucket runs once (itemized array)';
+}
+
+{
+    my %c = (1, 2, 3, 4).categorize({ $_ %% 2 ?? 'even' !! 'odd' });
+    my @flat = %c<even>;
+    is @flat.elems, 1, 'categorize bucket is itemized too';
+    is %c<even>.elems, 2, 'categorize bucket inner elems';
+    is-deeply %c<even>.List, (2, 4), 'categorize bucket contents';
+}
+
+# A bucket with a single element is still itemized (one, not zero flattening).
+{
+    my %c = (5,).classify({ 'only' });
+    my @flat = %c<only>;
+    is @flat.elems, 1, 'single-element bucket stays itemized';
+    is %c<only>[0], 5, 'single-element bucket content';
+}


### PR DESCRIPTION
## Summary

Raku stores each `.classify`/`.categorize` bucket as an *itemized* array (`\$[...]`), so a bucket does not flatten when assigned to an `@`-array and iterates as a single element:

```raku
my %c = (1,2,3,4).classify(* %% 2);
my @a = %c{True};    # Raku: 1 element ($[2,4]);  mutsu was 2 (flattened)
.say for %c{True};   # Raku: runs once ([2 4]);    mutsu ran twice ("2","4")
```

mutsu built each bucket as a plain (non-itemized) array, so it flattened on list assignment and iterated its elements.

## Fix

In `classify_finish_hash`, itemize each bucket's value list (recursing into nested categorize buckets, which are hashes). `.elems` and positional indexing still see the inner elements — only list-context flattening/iteration changes, matching Raku.

## Tests

- New `t/classify-bucket-itemized.t` (9 assertions): non-flattening on `@`-assignment, single-iteration `for`, inner `.elems`/index still work, categorize + single-element buckets.
- `make test` PASS (14848). All whitelisted classify/categorize roast tests (`S32-list/{classify,categorize,classify-list,categorize-list}.t`, `S17-supply/{classify,categorize}.t` — 211 tests) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)