### PR TITLE
fix(regex): :nth(*) / :nth(*-1) resolves Whatever against the match count

### DIFF
--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -202,7 +202,7 @@ impl Interpreter {
 
     /// Resolve :nth argument (Value) into a list of 1-based indices.
     /// Validates that values are positive and monotonically increasing.
-    fn resolve_nth_value_indices(
+    pub(in crate::runtime) fn resolve_nth_value_indices(
         &mut self,
         val: &Value,
         total_matches: usize,
@@ -403,6 +403,23 @@ impl Interpreter {
             Value::LazyList(ll) => {
                 let forced = self.force_lazy_list_bridge(ll)?;
                 Self::collect_nth_list_indices(&forced, total_matches, &mut indices)?;
+            }
+            // Bare `*` selects the last match.
+            Value::Whatever => {
+                if total_matches >= 1 {
+                    indices.push(total_matches);
+                }
+            }
+            // A WhateverCode (`*-1`, `*-2`, …) is applied to the match count, so
+            // `:nth(*-1)` is the second-to-last match. An out-of-range result
+            // selects nothing (rather than erroring like a literal `:nth(0)`).
+            Value::Sub(_) => {
+                let result =
+                    self.call_sub_value(val.clone(), vec![Value::Int(total_matches as i64)], false)?;
+                let i = Self::value_to_nth_int(&result)?;
+                if i >= 1 && (i as usize) <= total_matches {
+                    indices.push(i as usize);
+                }
             }
             _ => {
                 let i = Self::value_to_nth_int(val)?;

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -414,8 +414,11 @@ impl Interpreter {
             // `:nth(*-1)` is the second-to-last match. An out-of-range result
             // selects nothing (rather than erroring like a literal `:nth(0)`).
             Value::Sub(_) => {
-                let result =
-                    self.call_sub_value(val.clone(), vec![Value::Int(total_matches as i64)], false)?;
+                let result = self.call_sub_value(
+                    val.clone(),
+                    vec![Value::Int(total_matches as i64)],
+                    false,
+                )?;
                 let i = Self::value_to_nth_int(&result)?;
                 if i >= 1 && (i as usize) <= total_matches {
                     indices.push(i as usize);

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -59,6 +59,19 @@ impl Interpreter {
     /// Expand a `:nth`/`:st`/`:nd`/`:rd`/`:th` adverb argument into a list of
     /// 1-based match indices. Accepts an Int, an Array of Ints, or any Range
     /// variant (`:nth(1..3)`).
+    /// Is `value` a `WhateverCode` (e.g. `*-1`)? Those carry a
+    /// `__mutsu_callable_type` marker in their captured environment.
+    fn is_whatever_code_value(value: &Value) -> bool {
+        matches!(
+            value,
+            Value::Sub(data)
+                if matches!(
+                    data.env.get("__mutsu_callable_type"),
+                    Some(Value::Str(kind)) if kind.as_str() == "WhateverCode"
+                )
+        )
+    }
+
     fn subst_nth_indices(value: &Value) -> Vec<i64> {
         match value {
             Value::Int(n) => vec![*n],
@@ -108,6 +121,9 @@ impl Interpreter {
         let mut positional: Vec<Value> = Vec::new();
         let mut global = false;
         let mut nth: Option<Vec<i64>> = None;
+        // `:nth(*)` / `:nth(*-1)` can only be resolved once the match count is
+        // known, so keep the raw Whatever/WhateverCode for deferred resolution.
+        let mut nth_deferred: Vec<Value> = Vec::new();
         let mut x_count: Option<Value> = None;
         let mut pos_start: Option<usize> = None;
         let mut continue_from: Option<usize> = None;
@@ -121,8 +137,16 @@ impl Interpreter {
                     // select 1-based match indices. The argument may be an Int, a
                     // list of Ints, or a Range (`:nth(1..3)`).
                     "nth" | "st" | "nd" | "rd" | "th" => {
-                        let idxs = Self::subst_nth_indices(value);
-                        nth.get_or_insert_with(Vec::new).extend(idxs);
+                        if matches!(value.as_ref(), Value::Whatever)
+                            || Self::is_whatever_code_value(value)
+                        {
+                            // Resolved later against the match count.
+                            nth_deferred.push((**value).clone());
+                            nth.get_or_insert_with(Vec::new);
+                        } else {
+                            let idxs = Self::subst_nth_indices(value);
+                            nth.get_or_insert_with(Vec::new).extend(idxs);
+                        }
                     }
                     "1st" | "first" if value.truthy() => nth = Some(vec![1]),
                     "2nd" | "second" if value.truthy() => nth = Some(vec![2]),
@@ -271,6 +295,19 @@ impl Interpreter {
                     // If no :g, :x, :nth - single match mode
                     if !pat_global && x_count.is_none() && nth.is_none() {
                         selected.truncate(1);
+                    }
+
+                    // Resolve any deferred `:nth(*)` / `:nth(*-1)` now that the
+                    // match count is known.
+                    if !nth_deferred.is_empty() {
+                        let total = selected.len();
+                        let mut extra: Vec<i64> = Vec::new();
+                        for spec in &nth_deferred {
+                            let resolved = self.resolve_nth_value_indices(spec, total)?;
+                            extra.extend(resolved.into_iter().map(|i| i as i64));
+                        }
+                        extra.sort_unstable();
+                        nth.get_or_insert_with(Vec::new).extend(extra);
                     }
 
                     // Apply :nth - select specific 1-based match indices

--- a/src/vm/vm_subst_apply.rs
+++ b/src/vm/vm_subst_apply.rs
@@ -31,7 +31,7 @@ impl Interpreter {
         if let Some(raw) = nth_spec {
             // :nth may carry a comma-separated list of 1-based indices, e.g.
             // `:nth(1,3)`. Indices must be >= 1 and monotonically increasing.
-            let nth_list = Self::parse_subst_nth_spec(raw)?;
+            let nth_list = Self::parse_subst_nth_spec(raw, all_matches.len())?;
             let mut selected: Vec<(usize, usize)> = Vec::new();
             for &n in &nth_list {
                 if n <= all_matches.len() {
@@ -99,7 +99,7 @@ impl Interpreter {
     /// Parse an `:nth` spec into a list of 1-based indices. Accepts a single
     /// integer or a comma-separated list (e.g. `1,3`). Validates that every
     /// index is >= 1 and that the list is monotonically increasing.
-    fn parse_subst_nth_spec(raw: &str) -> Result<Vec<usize>, RuntimeError> {
+    fn parse_subst_nth_spec(raw: &str, total: usize) -> Result<Vec<usize>, RuntimeError> {
         let token = raw.trim();
         if token.eq_ignore_ascii_case("-Inf") {
             return Err(RuntimeError::new("Invalid :nth index (-Inf)"));
@@ -111,9 +111,26 @@ impl Interpreter {
             if part.is_empty() {
                 continue;
             }
-            let n = part
-                .parse::<i64>()
-                .map_err(|_| RuntimeError::new(format!("Invalid :nth index ({part})")))?;
+            // `*` is the last match and `*-N` counts back from it, resolved
+            // against the match count. A Whatever-derived index that falls out
+            // of range selects nothing (rather than erroring like a literal).
+            let (n, from_whatever) = if part == "*" {
+                (total as i64, true)
+            } else if let Some(rest) = part.strip_prefix("*-") {
+                let sub = rest
+                    .trim()
+                    .parse::<i64>()
+                    .map_err(|_| RuntimeError::new(format!("Invalid :nth index ({part})")))?;
+                (total as i64 - sub, true)
+            } else {
+                let n = part
+                    .parse::<i64>()
+                    .map_err(|_| RuntimeError::new(format!("Invalid :nth index ({part})")))?;
+                (n, false)
+            };
+            if from_whatever && (n < 1 || n as usize > total) {
+                continue;
+            }
             if n < 1 {
                 return Err(RuntimeError::new(format!(
                     "Attempt to retrieve before :1st match -- :nth({n})"

--- a/t/nth-whatevercode.t
+++ b/t/nth-whatevercode.t
@@ -1,0 +1,36 @@
+use Test;
+
+# :nth on .subst / .match accepts a Whatever (`*`, the last match) or a
+# WhateverCode (`*-1`, `*-2`, ...) resolved against the match count. mutsu
+# previously evaluated the Whatever eagerly to 0, throwing "Attempt to retrieve
+# before :1st match".
+
+plan 16;
+
+# subst with Whatever / WhateverCode
+is "a1b2c3".subst(/\d/, "X", :nth(*)), "a1b2cX", 'subst :nth(*) hits last match';
+is "a1b2c3".subst(/\d/, "X", :nth(*-1)), "a1bXc3", 'subst :nth(*-1) is second-to-last';
+is "aaaa".subst(/a/, "b", :nth(*-2)), "abaa", 'subst :nth(*-2)';
+is "aaaaa".subst(/a/, "X", :nth(*-1)), "aaaXa", 'subst :nth(*-1) over five';
+
+# match with Whatever / WhateverCode
+is "a1b2c3".match(/\d/, :nth(*)).Str, "3", 'match :nth(*) is last';
+is "a1b2c3".match(/\d/, :nth(*-1)).Str, "2", 'match :nth(*-1)';
+
+# Out-of-range Whatever selects nothing (no error)
+is "a1b2c3".match(/\d/, :nth(*-5)), Nil, 'match :nth(*-5) beyond range is Nil';
+is "abc".subst(/x/, "Y", :nth(*)), "abc", 'subst :nth(*) with no matches is a no-op';
+
+# Plain integer / range / list forms still work
+is "a1b2c3".subst(/\d/, "X", :nth(1)), "aXb2c3", 'subst :nth(1)';
+is "aaaa".subst(/a/, "b", :nth(2)), "abaa", 'subst :nth(2)';
+is "aaaa".subst(/a/, "b", :nth(2..3)), "abba", 'subst :nth(2..3)';
+is "aaaa".subst(/a/, "b", :nth(1,3)), "baba", 'subst :nth(1,3)';
+is "aaaa".subst(/a/, "b", :2nd), "abaa", 'subst :2nd';
+is "abcabc".match(/b/, :nth(2)).from, 4, 'match :nth(2)';
+is "aaa".match(/a/, :nth(1..2)).elems, 2, 'match :nth(1..2)';
+
+# s/// with WhateverCode nth
+my $s = "a1b2c3";
+$s ~~ s:nth(*)/\d/Z/;
+is $s, "a1b2cZ", 's:nth(*)/// hits last match';


### PR DESCRIPTION
## Summary

`:nth` on `.subst`, `.match` and `s///` accepts a `Whatever` (`*`, the last match) or a `WhateverCode` (`*-1`, `*-2`, ...) resolved against the number of matches. mutsu evaluated the Whatever eagerly to `0`, so:

```
"a1b2c3".subst(/\d/, "X", :nth(*))    # threw — now "a1b2cX"
"a1b2c3".subst(/\d/, "X", :nth(*-1))  # threw — now "a1bXc3"
"a1b2c3".match(/\d/, :nth(*-1))       # threw — now match "2"
$s ~~ s:nth(*)/\d/Z/                  # threw — now hits last match
```

## Fix
- **`.match`**: `resolve_nth_value_indices` handles `Value::Whatever` (last match) and a WhateverCode `Value::Sub` (applied to the match count).
- **`.subst`**: the `:nth` value is kept raw and resolved once the match count is known, reusing the same helper.
- **`s///`**: `parse_subst_nth_spec` now takes the match count and understands `*` / `*-N`.

An out-of-range Whatever result (`:nth(*-5)` with 3 matches, or `:nth(*)` with none) selects nothing instead of erroring, matching raku. Integer/range/list `:nth` forms are unchanged.

## Test
- New `t/nth-whatevercode.t` (16 assertions), cross-checked against `raku`.
- `make test` passes (14876 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)