### PR TITLE
feat(str): Str.wordcase accepts :where and :filter adverbs

### DIFF
--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -194,6 +194,7 @@ impl Interpreter {
             }
             "match" => Some(self.dispatch_match_method(target, &args)),
             "subst" => Some(self.dispatch_subst(target, &args)),
+            "wordcase" if !args.is_empty() => Some(self.dispatch_wordcase(target, &args)),
             "comb" if !args.is_empty() => {
                 if matches!(&target, Value::Instance { class_name, .. } if class_name == "Supply") {
                     Some(self.dispatch_supply_transform(target, "comb", &args))

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -112,6 +112,54 @@ impl Interpreter {
         }
     }
 
+    /// `.wordcase(:&filter = &tclc, :$where = True)`: title-case each word,
+    /// but only words that smart-match `:where`, transformed by `:filter`.
+    pub(crate) fn dispatch_wordcase(
+        &mut self,
+        target: Value,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
+        let text = target.to_string_value();
+        let mut filter: Option<Value> = None;
+        let mut where_matcher: Option<Value> = None;
+        for arg in args {
+            if let Value::Pair(key, value) = arg {
+                match key.as_str() {
+                    "filter" => filter = Some((**value).clone()),
+                    "where" => where_matcher = Some((**value).clone()),
+                    _ => {}
+                }
+            }
+        }
+
+        let mut result = String::new();
+        for (segment, is_word) in crate::value::wordcase_segments(&text) {
+            if !is_word {
+                result.push_str(&segment);
+                continue;
+            }
+            let word = Value::str(segment.clone());
+            // `:where` selects which words are transformed (default: all).
+            let selected = match &where_matcher {
+                Some(m) => self.smart_match(&word, m),
+                None => true,
+            };
+            if !selected {
+                result.push_str(&segment);
+                continue;
+            }
+            // `:filter` transforms the selected word (default: tclc).
+            let transformed = match &filter {
+                Some(f) => self
+                    .call_sub_value(f.clone(), vec![word], false)?
+                    .to_string_value(),
+                None => crate::value::tclc_str(&segment),
+            };
+            result.push_str(&transformed);
+        }
+        Ok(Value::str(result))
+    }
+
     pub(crate) fn dispatch_subst(
         &mut self,
         target: Value,

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -84,13 +84,24 @@ pub fn tclc_str(s: &str) -> String {
 /// Apply wordcase to a string: find words matching <ident>+ % <[ - ' ]>
 /// and apply tclc to each word. Non-word characters pass through unchanged.
 pub fn wordcase_str(s: &str) -> String {
+    wordcase_with(s, tclc_str)
+}
+
+/// Split `s` into (segment, is_word) runs the way Raku's `wordcase` does: a
+/// "word" starts with an alphabetic/underscore character and may join further
+/// identifiers via `-`/`'`. Non-word characters are returned as their own
+/// (segment, false) runs so callers can rebuild the string verbatim.
+pub fn wordcase_segments(s: &str) -> Vec<(String, bool)> {
     let chars: Vec<char> = s.chars().collect();
     let len = chars.len();
-    let mut result = String::new();
+    let mut segments = Vec::new();
     let mut i = 0;
-
+    let mut gap_start = 0;
     while i < len {
         if chars[i].is_alphabetic() || chars[i] == '_' {
+            if gap_start < i {
+                segments.push((chars[gap_start..i].iter().collect(), false));
+            }
             let word_start = i;
             // Consume first ident: [alpha|_] \w*
             i += 1;
@@ -113,11 +124,26 @@ pub fn wordcase_str(s: &str) -> String {
                     break;
                 }
             }
-            let word: String = chars[word_start..i].iter().collect();
-            result.push_str(&tclc_str(&word));
+            segments.push((chars[word_start..i].iter().collect(), true));
+            gap_start = i;
         } else {
-            result.push(chars[i]);
             i += 1;
+        }
+    }
+    if gap_start < len {
+        segments.push((chars[gap_start..len].iter().collect(), false));
+    }
+    segments
+}
+
+/// `wordcase_str` with a custom per-word transform.
+pub fn wordcase_with(s: &str, mut transform: impl FnMut(&str) -> String) -> String {
+    let mut result = String::new();
+    for (segment, is_word) in wordcase_segments(s) {
+        if is_word {
+            result.push_str(&transform(&segment));
+        } else {
+            result.push_str(&segment);
         }
     }
     result

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -324,7 +324,7 @@ pub(crate) fn current_time_secs_f64() -> f64 {
 
 pub(crate) use display::is_internal_anon_type_name;
 pub(crate) use display::user_facing_type_name;
-pub use display::{format_complex, tclc_str, wordcase_str};
+pub use display::{format_complex, tclc_str, wordcase_segments, wordcase_str};
 pub(crate) use error::expected_type_object;
 pub use error::{Control, RuntimeError, RuntimeErrorCode};
 // SubData is re-exported so callers can destructure Value::Sub(data)

--- a/t/wordcase-adverbs.t
+++ b/t/wordcase-adverbs.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Str.wordcase accepts :where (which words to transform) and :filter (the
+# transform, default tclc). mutsu previously only implemented the 0-arg form,
+# so any adverb threw "No such method 'wordcase'".
+
+plan 15;
+
+# :where selects which words are title-cased
+is "foo bar bazz".wordcase(:where(*.chars > 3)), "foo bar Bazz",
+    ':where(*.chars > 3) title-cases only the long word';
+is "hello world foo".wordcase(:where(*.starts-with("h"))), "Hello world foo",
+    ':where(*.starts-with)';
+is "foo123 bar".wordcase(:where(* ~~ /\d/)), "Foo123 bar",
+    ':where with a regex matcher';
+
+# :filter is the per-word transform
+is "hello world".wordcase(:filter(*.uc)), "HELLO WORLD", ':filter(*.uc)';
+is "a b c".wordcase(:filter({ $_ ~ "!" })), "a! b! c!", ':filter with a block';
+
+# combined
+is "abc def".wordcase(:filter(*.uc), :where(*.chars == 3)), "ABC DEF",
+    ':filter + :where';
+is "one two three".wordcase(:filter(*.uc), :where(*.chars > 3)), "one two THREE",
+    ':filter applied only to matching words';
+
+# the plain 0-arg form is unchanged
+is "hello world".wordcase, "Hello World", 'bare wordcase';
+is "HELLO".wordcase, "Hello", 'wordcase lowercases the tail';
+is "aBc dEf".wordcase, "Abc Def", 'wordcase normalizes mixed case';
+
+# hyphenated / apostrophe words are single words
+is "the-quick brown".wordcase, "The-quick Brown", 'hyphen keeps one word';
+is "it's a test".wordcase, "It's A Test", 'apostrophe keeps one word';
+
+# punctuation / spacing preserved
+is "  spaced,  out ".wordcase(:filter(*.uc)), "  SPACED,  OUT ",
+    'non-word runs preserved';
+
+# empty string
+is "".wordcase(:filter(*.uc)), "", 'empty string';
+
+# no word matches :where -> unchanged
+is "a b c".wordcase(:where(*.chars > 5)), "a b c", 'no matching word is a no-op';


### PR DESCRIPTION
## Summary

`.wordcase` only implemented the 0-arg form, so any adverb threw `No such method 'wordcase' for invocant of type 'Str'`. Raku's signature is `wordcase(:&filter = &tclc, :$where = True)`:

```
"foo bar bazz".wordcase(:where(*.chars > 3))   # "foo bar Bazz"
"hello world".wordcase(:filter(*.uc))          # "HELLO WORLD"
"abc def".wordcase(:filter(*.uc), :where(*.chars == 3))  # "ABC DEF"
```

- **`:where`** selects which words are transformed — each word is smart-matched against it (default: all words).
- **`:filter`** is the per-word transform (default: title-case / `tclc`).

Word segmentation is factored out of `wordcase_str` into `wordcase_segments` / `wordcase_with`, so the 0-arg path is byte-for-byte unchanged (hyphenated and apostrophe words stay single words).

## Test
- New `t/wordcase-adverbs.t` (15 assertions), cross-checked against `raku`.
- `make test` passes (14916 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)