### PR TITLE
fix(list): .batch accepts the named :elems(N) form

### DIFF
--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -796,22 +796,26 @@ pub(crate) fn native_method_1arg(
             }
         }
         "batch" => {
+            // `.batch(N)` and the named `.batch(:elems(N))` are equivalent.
             let n = match arg {
                 Value::Int(i) => *i,
+                Value::Pair(key, val) if key == "elems" || key == "batch" => val.to_f64() as i64,
                 _ => return None,
             };
             if n < 1 {
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("got".to_string(), Value::Int(n));
-                attrs.insert(
-                    "message".to_string(),
-                    Value::str(format!("batch size must be at least 1, got {}", n)),
+                let message = format!(
+                    "Batching sublist length is out of range. Is: {n}, should be in 1..^Inf"
                 );
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "what".to_string(),
+                    Value::str_from("Batching sublist length"),
+                );
+                attrs.insert("got".to_string(), Value::Int(n));
+                attrs.insert("range".to_string(), Value::str_from("1..^Inf"));
+                attrs.insert("message".to_string(), Value::str(message.clone()));
                 let ex = Value::make_instance(Symbol::intern("X::OutOfRange"), attrs);
-                let mut err = RuntimeError::new(format!(
-                    "X::OutOfRange: batch size must be at least 1, got {}",
-                    n
-                ));
+                let mut err = RuntimeError::new(message);
                 err.exception = Some(Box::new(ex));
                 return Some(Err(err));
             }

--- a/t/batch-elems-named.t
+++ b/t/batch-elems-named.t
@@ -1,0 +1,36 @@
+use Test;
+
+# .batch accepts the named form :elems(N) as well as the positional .batch(N).
+# mutsu only handled the positional Int, so :elems threw "No such method
+# 'batch'".
+
+plan 12;
+
+is (1..10).batch(:elems(4)).raku, "((1, 2, 3, 4), (5, 6, 7, 8), (9, 10)).Seq",
+    'Range.batch(:elems(4))';
+is [1, 2, 3, 4, 5].batch(:elems(2)).raku, "((1, 2), (3, 4), (5,)).Seq",
+    'Array.batch(:elems(2))';
+is (1, 2, 3, 4, 5).batch(:elems(2)).raku, "((1, 2), (3, 4), (5,)).Seq",
+    'List.batch(:elems(2))';
+is (1..10).list.batch(:elems(4)).elems, 3, 'List.batch(:elems) count';
+is "abcde".comb.batch(:elems(2)).raku, '(("a", "b"), ("c", "d"), ("e",)).Seq',
+    'Seq.batch(:elems(2))';
+is [1, 2, 3, 4, 5, 6].batch(:elems(3)).map(*.sum).raku, "(6, 15).Seq",
+    ':elems batches feed into map';
+
+# positional form unchanged
+is [1, 2, 3, 4, 5].batch(2).raku, "((1, 2), (3, 4), (5,)).Seq", 'positional batch(2)';
+is (1..10).batch(3).elems, 4, 'positional batch(3) count';
+
+# :elems and positional agree
+is (1..10).batch(:elems(4)).raku, (1..10).batch(4).raku, ':elems == positional';
+
+# zero / negative batch size throws X::OutOfRange
+throws-like { [1, 2, 3].batch(:elems(0)) }, X::OutOfRange,
+    ':elems(0) throws X::OutOfRange';
+throws-like { [1, 2, 3].batch(0) }, X::OutOfRange,
+    'positional 0 throws X::OutOfRange';
+my $msg;
+{ [1, 2, 3].batch(:elems(0)); CATCH { default { $msg = .message } } }
+is $msg, "Batching sublist length is out of range. Is: 0, should be in 1..^Inf",
+    'error message matches raku';


### PR DESCRIPTION
## Summary

`.batch(N)` worked but the equivalent named `.batch(:elems(N))` threw `No such method 'batch'`:

```
(1..10).batch(:elems(4))       # was: No such method — now ((1,2,3,4),(5,6,7,8),(9,10))
[1,2,3,4,5].batch(:elems(2))   # was: No such method — now ((1,2),(3,4),(5,))
```

The handler only matched a positional `Int` and returned `None` for the `:elems` `Pair`, dropping through to no-such-method. Now `:elems(N)` (and `:batch(N)`) are accepted as equivalent to the positional form.

Also aligned the zero/negative-size error with raku: `Batching sublist length is out of range. Is: 0, should be in 1..^Inf` (with `what`/`got`/`range` on the `X::OutOfRange`).

## Test
- New `t/batch-elems-named.t` (12 assertions), cross-checked against `raku`.
- `make test` passes (14913 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)