### PR TITLE
feat(temporal): Date.mm-dd-yyyy / dd-mm-yyyy + separator argument

### DIFF
--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -240,6 +240,32 @@ pub fn format_date(year: i64, month: i64, day: i64) -> String {
     }
 }
 
+/// Format the year component the way `format_date` does (signed 4+ digits,
+/// `+`-prefixed past 9999).
+fn format_year_part(year: i64) -> String {
+    if year < 0 {
+        format!("-{:04}", -year)
+    } else if year > 9999 {
+        format!("+{:04}", year)
+    } else {
+        format!("{:04}", year)
+    }
+}
+
+/// Format a date in one of Raku's `yyyy-mm-dd` / `mm-dd-yyyy` / `dd-mm-yyyy`
+/// orderings, joined by `sep` (default `-`).
+pub fn format_date_ordered(order: &str, year: i64, month: i64, day: i64, sep: &str) -> String {
+    let y = format_year_part(year);
+    let m = format!("{:02}", month);
+    let d = format!("{:02}", day);
+    match order {
+        "mm-dd-yyyy" => format!("{m}{sep}{d}{sep}{y}"),
+        "dd-mm-yyyy" => format!("{d}{sep}{m}{sep}{y}"),
+        // "yyyy-mm-dd"
+        _ => format!("{y}{sep}{m}{sep}{d}"),
+    }
+}
+
 /// Format a DateTime as ISO 8601.
 pub fn format_datetime(
     year: i64,

--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -63,7 +63,9 @@ pub fn date_method_0arg(
             Some(Ok(Value::str(format_date(year, month, day))))
         }
         "Date" => Some(Ok(make_date(year, month, day))),
-        "yyyy-mm-dd" => Some(Ok(Value::str(format_date(year, month, day)))),
+        "yyyy-mm-dd" | "mm-dd-yyyy" | "dd-mm-yyyy" => Some(Ok(Value::str(format_date_ordered(
+            method, year, month, day, "-",
+        )))),
         "succ" => {
             let new_days = days + 1;
             let (ny, nm, nd) = epoch_days_to_civil(new_days);

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -112,6 +112,17 @@ pub(super) fn dispatch_temporal_method(
                     date_later_earlier(year, month, day, args, method)
                         .map(|v| rebless_date_result(v, *class_name, attributes)),
                 ),
+                // `.yyyy-mm-dd($sep)` / `.mm-dd-yyyy($sep)` / `.dd-mm-yyyy($sep)`
+                // with an optional separator string (default `-`).
+                "yyyy-mm-dd" | "mm-dd-yyyy" | "dd-mm-yyyy" => {
+                    let sep = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|| "-".to_string());
+                    Some(Ok(Value::str(temporal::format_date_ordered(
+                        method, year, month, day, &sep,
+                    ))))
+                }
                 "clone" => {
                     let existing_formatter = attributes.as_map().get("formatter").cloned();
                     Some(

--- a/t/date-format-methods.t
+++ b/t/date-format-methods.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Date has yyyy-mm-dd, mm-dd-yyyy and dd-mm-yyyy formatting methods, each with
+# an optional separator (default '-'). mutsu only had yyyy-mm-dd (0-arg).
+
+plan 15;
+
+my $d = Date.new(2024, 1, 5);
+
+# default separator
+is $d.yyyy-mm-dd, "2024-01-05", 'yyyy-mm-dd';
+is $d.mm-dd-yyyy, "01-05-2024", 'mm-dd-yyyy';
+is $d.dd-mm-yyyy, "05-01-2024", 'dd-mm-yyyy';
+
+# custom separator
+is $d.yyyy-mm-dd("/"), "2024/01/05", 'yyyy-mm-dd with /';
+is $d.mm-dd-yyyy("/"), "01/05/2024", 'mm-dd-yyyy with /';
+is $d.dd-mm-yyyy("."), "05.01.2024", 'dd-mm-yyyy with .';
+is $d.yyyy-mm-dd(""), "20240105", 'empty separator';
+
+# zero-padding
+is Date.new(2024, 12, 31).mm-dd-yyyy, "12-31-2024", 'two-digit month/day';
+
+# negative year keeps its sign
+is Date.new(-44, 3, 15).mm-dd-yyyy, "03-15--0044", 'negative year';
+is Date.new(-44, 3, 15).dd-mm-yyyy, "15-03--0044", 'negative year dd-mm';
+
+# years past 9999 get a + prefix
+is Date.new(10000, 1, 1).yyyy-mm-dd, "+10000-01-01", 'year > 9999';
+
+# works off a DateTime's .Date
+is DateTime.new(2024, 1, 15, 10, 0, 0).Date.mm-dd-yyyy, "01-15-2024",
+    'via DateTime.Date';
+
+# succ/pred keep the type so the methods still resolve
+is Date.new(2024, 1, 5).succ.mm-dd-yyyy, "01-06-2024", 'after .succ';
+
+# Date.today produces a 10-char default form
+is Date.today.mm-dd-yyyy.chars, 10, 'today mm-dd-yyyy length';
+is Date.today.dd-mm-yyyy.chars, 10, 'today dd-mm-yyyy length';


### PR DESCRIPTION
## Summary

`Date` only implemented the 0-arg `yyyy-mm-dd`; the sibling orderings `mm-dd-yyyy` and `dd-mm-yyyy` threw `No such method`, and none accepted the optional separator Raku allows (`$sep = '-'`):

```
Date.new(2024,1,5).mm-dd-yyyy        # was: No such method — now "01-05-2024"
Date.new(2024,1,5).dd-mm-yyyy        # was: No such method — now "05-01-2024"
Date.new(2024,1,5).yyyy-mm-dd("/")   # was: No such method — now "2024/01/05"
Date.new(2024,1,5).mm-dd-yyyy("/")   # "01/05/2024"
```

All three orderings are added — the 0-arg default-separator form via the native path, and the custom-separator form via the temporal n-arg dispatch — sharing a `format_date_ordered` helper that preserves the signed / `+`-prefixed year formatting of `format_date` (`Date.new(-44,3,15).mm-dd-yyyy` → `03-15--0044`, `Date.new(10000,1,1).yyyy-mm-dd` → `+10000-01-01`).

## Test
- New `t/date-format-methods.t` (15 assertions), cross-checked against `raku`.
- `make test` passes (14943 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)