### PR TITLE
feat(eval): X::Undeclared for assigning to an undeclared variable in a block

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1305,6 +1305,7 @@ roast/integration/advent2009-day19.t
 roast/integration/advent2009-day21.t
 roast/integration/advent2009-day22.t
 roast/integration/advent2010-day06.t
+roast/integration/advent2010-day07.t
 roast/integration/advent2010-day08.t
 roast/integration/advent2010-day10.t
 roast/integration/advent2010-day12.t

--- a/src/runtime/system_eval_vars.rs
+++ b/src/runtime/system_eval_vars.rs
@@ -235,6 +235,16 @@ impl Interpreter {
                 local.insert(name.clone());
                 self.find_undeclared_var_ordered(expr, &mut local)
             }
+            // A bare block `{ ... }` is a nested lexical scope. Inside it, an
+            // assignment to a variable that was never declared (`{ $var = 42 }`)
+            // is X::Undeclared — assignment does not declare in strict mode, and a
+            // block can only assign to a name that is already in scope (an outer
+            // lexical, in `declared`/env) or block-local (`my`/`state`). This
+            // strict assign-target check is confined to blocks; the top-level
+            // ordered scan keeps its lenient assign-as-declaration behavior.
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
+                self.check_block_scope_undeclared(body, declared)
+            }
             // Descend into `sub`/`method` bodies so undeclared variables used
             // inside them (e.g. `sub greet($name) { say "$nam" }`) are caught at
             // EVAL/compile time. The body's lexical scope adds the routine's
@@ -285,6 +295,59 @@ impl Interpreter {
                 None
             }
             _ => None,
+        }
+    }
+
+    /// Check a bare-block body as a nested lexical scope. Variables declared with
+    /// `my`/`state`/etc. inside the block extend `declared` for later statements;
+    /// an assignment whose target is not in scope (nor in the outer env) is
+    /// X::Undeclared. Assignment itself never declares (strict mode), so the
+    /// target is not added to the scope after the check.
+    fn check_block_scope_undeclared(
+        &self,
+        body: &[Stmt],
+        declared: &HashSet<String>,
+    ) -> Option<(&'static str, String, Vec<String>)> {
+        let mut inner = declared.clone();
+        for s in body {
+            if let Stmt::Assign { name, expr, .. } = s {
+                // Check the assignment *target* against the current scope + env.
+                let lhs = Self::assign_lhs_expr(name);
+                if let Some(r) = self.find_undeclared_var_in_expr(&lhs, &inner) {
+                    return Some(r);
+                }
+                // Then check the RHS, treating the target as in scope for a
+                // self-referential `$x = $x + 1`.
+                let mut local = inner.clone();
+                local.insert(name.clone());
+                if let Some(r) = self.find_undeclared_var_ordered(expr, &mut local) {
+                    return Some(r);
+                }
+                // Assignment does not declare: do NOT add the target to `inner`.
+            } else {
+                if let Some(r) = self.find_undeclared_var_in_stmt(s, &inner) {
+                    return Some(r);
+                }
+                // Bring the statement's real (`my`/`state`/loop) declarations into
+                // scope for subsequent statements. `collect_declared_vars` may also
+                // pull in nested assign targets, which only makes the check *less*
+                // strict (a safe false negative).
+                Self::collect_declared_vars(s, &mut inner);
+            }
+        }
+        None
+    }
+
+    /// Build the reference-form expression for an assignment target name
+    /// (`"var"` → `$var`, `"@a"` → `@a`, `"%h"` → `%h`), so the shared
+    /// `find_undeclared_var_in_expr` skip/env logic applies to the LHS.
+    fn assign_lhs_expr(name: &str) -> Expr {
+        if let Some(base) = name.strip_prefix('@') {
+            Expr::ArrayVar(base.to_string())
+        } else if let Some(base) = name.strip_prefix('%') {
+            Expr::HashVar(base.to_string())
+        } else {
+            Expr::Var(name.trim_start_matches('$').to_string())
         }
     }
 

--- a/t/eval-undeclared-block-assign.t
+++ b/t/eval-undeclared-block-assign.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 8;
+
+# In strict mode (the Raku default), assignment never declares. Inside a bare
+# block, assigning to a variable that was never declared is X::Undeclared.
+
+throws-like { EVAL '{ $var = 42 }' }, X::Undeclared,
+    'assignment to an undeclared scalar inside a block dies';
+
+throws-like { EVAL '{ @arr = 1, 2, 3 }' }, X::Undeclared,
+    'assignment to an undeclared array inside a block dies';
+
+throws-like { EVAL '{ %hash = a => 1 }' }, X::Undeclared,
+    'assignment to an undeclared hash inside a block dies';
+
+throws-like { EVAL '{ my $var = 42 }; say $var' }, X::Undeclared,
+    'a block-local my does not leak to the enclosing scope';
+
+# --- cases that MUST NOT die ---
+
+lives-ok { EVAL 'my $x; { $x = 42 }' },
+    'assigning to an outer my inside a block is fine';
+
+lives-ok { EVAL '{ my $y; $y = 42 }' },
+    'assigning to a block-local my is fine';
+
+lives-ok { my $z = 1; EVAL '{ $z = 42 }'; $z == 42 or die },
+    'assigning to a caller lexical inside an EVAL block is fine';
+
+lives-ok { EVAL '{ $_ = 42 }' },
+    'assigning to the topic $_ inside a block is fine';


### PR DESCRIPTION
## What

In strict mode (the Raku default), assignment never declares a variable. mutsu's EVAL-time undeclared-variable check already caught undeclared *references*, but treated a bare assignment target as an implicit declaration, so `EVAL '{ \$var = 42 }'` was silently accepted where rakudo raises `X::Undeclared`.

## How

Add a nested-block scope check (`check_block_scope_undeclared` in `src/runtime/system_eval_vars.rs`): inside a bare block, an assignment whose target is not in scope — not a `my`/`state` declaration, not a caller lexical present in the env — is `X::Undeclared`. Assignment does not extend the scope, so `{ \$x = 1; \$x = 2 }` reports the first use, and a block-local `my` does not leak outward.

The strict assign-target check is **confined to blocks**; the top-level ordered scan keeps its existing lenient assign-as-declaration behavior, so the blast radius is limited to block bodies inside EVAL'd code.

## Safety

These remain legal (verified against rakudo):
- assigning to an outer/caller lexical inside a block,
- assigning to a block-local `my`,
- assigning to the topic `\$_`.

The LHS check reuses the existing conservative `find_undeclared_var_in_expr` skip/env logic (specials, twigils, `::`, dynamic vars, and env membership all pass through).

## Result

Whitelists `integration/advent2010-day07.t` (8/8). Local `make test` passes, and all **176 whitelisted EVAL-bearing roast files** stay green with **zero** false positives.

Regression test: `t/eval-undeclared-block-assign.t` (4 must-throw + 4 must-not-throw cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)