### PR TITLE
fix(str): .encode error message matches raku (display name + decimal codepoint)

### DIFF
--- a/src/runtime/methods_string_encoding.rs
+++ b/src/runtime/methods_string_encoding.rs
@@ -80,6 +80,27 @@ impl Interpreter {
         self.encode_with_encoding(input, encoding_name)
     }
 
+    /// Raku's human-readable name for an encoding, used in encode error
+    /// messages (e.g. `ascii` -> `ASCII`, `windows-1252` -> `Windows-1252`).
+    fn encoding_display_name(enc: &str) -> String {
+        match enc {
+            "ascii" => "ASCII".to_string(),
+            "iso-8859-1" | "latin1" => "Latin-1".to_string(),
+            _ if enc.starts_with("windows-") => format!("Windows-{}", &enc["windows-".len()..]),
+            _ if enc.starts_with("utf") => enc.to_uppercase(),
+            _ => enc.to_string(),
+        }
+    }
+
+    /// The `X::AdHoc` message Raku raises when a codepoint cannot be encoded.
+    fn encode_codepoint_error(enc: &str, ch: char) -> RuntimeError {
+        RuntimeError::new(format!(
+            "Error encoding {} string: could not encode codepoint {}",
+            Self::encoding_display_name(enc),
+            ch as u32
+        ))
+    }
+
     pub(super) fn encode_with_encoding(
         &self,
         input: &str,
@@ -96,10 +117,7 @@ impl Interpreter {
             "ascii" => {
                 for ch in input.chars() {
                     if (ch as u32) > 0x7F {
-                        return Err(RuntimeError::new(format!(
-                            "Error encoding ascii string: character '{}' (U+{:04X}) is not representable",
-                            ch, ch as u32
-                        )));
+                        return Err(Self::encode_codepoint_error("ascii", ch));
                     }
                 }
                 Ok(input.bytes().collect())
@@ -107,10 +125,7 @@ impl Interpreter {
             "iso-8859-1" => {
                 for ch in input.chars() {
                     if (ch as u32) > 0xFF {
-                        return Err(RuntimeError::new(format!(
-                            "Error encoding iso-8859-1 string: character '{}' (U+{:04X}) is not representable",
-                            ch, ch as u32
-                        )));
+                        return Err(Self::encode_codepoint_error("iso-8859-1", ch));
                     }
                 }
                 Ok(input.chars().map(|c| c as u8).collect())
@@ -125,10 +140,7 @@ impl Interpreter {
                         let s = ch.to_string();
                         let (encoded, _, had_errors) = enc.encode(&s);
                         if had_errors || !Self::char_is_encodable(ch, &encoded, enc) {
-                            return Err(RuntimeError::new(format!(
-                                "Error encoding {} string: could not encode codepoint 0x{:x}",
-                                encoding, ch as u32
-                            )));
+                            return Err(Self::encode_codepoint_error(&encoding, ch));
                         }
                     }
                     if matches!(encoding.as_str(), "windows-1251" | "windows-1252") {

--- a/t/encode-error-message.t
+++ b/t/encode-error-message.t
@@ -1,0 +1,43 @@
+use Test;
+
+# When .encode cannot represent a codepoint, Raku raises an X::AdHoc whose
+# message names the encoding in its human-readable form and reports the
+# offending codepoint in decimal:
+#   "Error encoding ASCII string: could not encode codepoint 233"
+# mutsu used a different wording ("character 'é' (U+00E9) is not representable")
+# for ascii/latin1 and a hex codepoint for the other single-byte encodings.
+
+plan 8;
+
+sub encode-error($s, $enc) {
+    my $msg;
+    { $s.encode($enc); CATCH { default { $msg = .message } } }
+    $msg;
+}
+
+is encode-error("café", "ascii"),
+    "Error encoding ASCII string: could not encode codepoint 233",
+    'ASCII error message (decimal codepoint)';
+is encode-error("\x[2603]", "ascii"),
+    "Error encoding ASCII string: could not encode codepoint 9731",
+    'ASCII with astral-ish codepoint';
+is encode-error("€", "latin1"),
+    "Error encoding Latin-1 string: could not encode codepoint 8364",
+    'Latin-1 via latin1 alias';
+is encode-error("€", "iso-8859-1"),
+    "Error encoding Latin-1 string: could not encode codepoint 8364",
+    'Latin-1 via iso-8859-1';
+is encode-error("\x[2603]", "windows-1252"),
+    "Error encoding Windows-1252 string: could not encode codepoint 9731",
+    'Windows-1252';
+is encode-error("\x[2603]", "windows-1251"),
+    "Error encoding Windows-1251 string: could not encode codepoint 9731",
+    'Windows-1251';
+
+# The raised exception is an X::AdHoc (matching raku)
+my $type;
+{ "café".encode("ascii"); CATCH { default { $type = .^name } } }
+is $type, "X::AdHoc", 'encode error is X::AdHoc';
+
+# Encodable strings still round-trip
+is "hello".encode("ascii").decode("ascii"), "hello", 'ASCII round-trips';


### PR DESCRIPTION
## Summary

When `.encode` cannot represent a codepoint it raises an `X::AdHoc`, but mutsu's message diverged from raku:

```
"café".encode("ascii")
# was:  Error encoding ascii string: character 'é' (U+00E9) is not representable
# raku: Error encoding ASCII string: could not encode codepoint 233
```

The `ascii`/`iso-8859-1` arms used an entirely different wording, and the generic single-byte path reported the codepoint in **hex** with a lower-cased encoding name. All three now route through a shared `encode_codepoint_error` that uses Raku's human-readable encoding name (`ASCII`, `Latin-1`, `Windows-1252`, ...) and a **decimal** codepoint, matching raku exactly:

```
"café".encode("ascii")          # Error encoding ASCII string: could not encode codepoint 233
"€".encode("latin1")            # Error encoding Latin-1 string: could not encode codepoint 8364
"☃".encode("windows-1252")      # Error encoding Windows-1252 string: could not encode codepoint 9731
```

The raised exception stays `X::AdHoc` (as in raku).

## Test
- New `t/encode-error-message.t` (8 assertions), cross-checked against `raku`.
- `make test` passes (14956 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)