### PR TITLE
feat(gc): Track B slice 1 — atomic-store element cells (no whole-container COW per cas)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -181,8 +181,12 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 - ✅ **既定値 `MUTSU_GC` は on**（2026-07-05 切替済み — ADR-0003 §5 に受け入れ実測とゲート改訂を記録。
       bench-class ~+8% はユーザー判断で許容、根本削減は層 3b=NaN-boxing）。GC キャンペーン（層 3a）完了。
       残る GC 関連 perf は NaN-boxing（3b）に統合。
-- **Track B（要素 cell 化）と GC は統合キャンペーン（層3a）**。続いて NaN-boxing（層3b・JIT 地ならし）
-  → JIT（層4）。`state @`/`%`・lexical aggregate の真共有（Track C 残）も Track B=層3a に依存。
+- **Track B（要素 cell 化）** — スライス 1 完了: atomic ストア（`__mutsu_atomic_hash/arr::`）の
+  要素を `ContainerRef` セル化（cas/要素代入が全体 COW なしの O(1) RMW に。thread.t test 28 の
+  12.2s→1.6s）。map/array の「構造」は従来どおり COW スナップショット、要素「値」のみセル —
+  この分割が Track B の一般化テンプレート。残: 通常（非 atomic）経路の要素セル化と
+  `state @`/`%`・lexical aggregate の真共有（Track C 残、§6）。続いて NaN-boxing（層3b・JIT 地ならし）
+  → JIT（層4）。
 
 ---
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,27 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Track B スライス 1 — atomic ストアの要素セル化（cas の全体 COW 除去）
+
+ADR-0001 層 3a の Track B（要素 cell 化)に着手。第一スライスとして、スレッド共有の atomic
+ストア（`__mutsu_atomic_hash::` / `__mutsu_atomic_arr::`）の**要素値を `ContainerRef` セル化**した。
+
+- **設計の核**: map/array の**構造**は従来どおり COW スナップショット（他スレッドの読み手が
+  ロックなしで保持する snapshot は不変のまま）、要素の**値**だけがセル（`Gc<Mutex<Value>>`）で
+  in-place 変異。全 snapshot が同一セルを共有するため cross-thread の読みは常に最新値を見る。
+  読み側の `ContainerRef` deref は `%h<k> := $x` バインディング以来の既存機構で、要素読み・算術・
+  比較・grep・sort・stringify まで普遍であることを事前プローブで確認済み。
+- **効果**: `cas %h{$_}` は「op ごとに全 map clone」→「セル Mutex の O(1) RMW」に。
+  S17-lowlevel/thread.t test 28（10k エントリ hash × 30k cas）は **12.2s → 1.6s（GC-off）/
+  21.2s → 1.7s（GC-on）**（debug）。GC-on ペナルティも +74% → +9% に収束（巨大クローンが
+  消えたため GC の随伴交通も消滅）。
+- 実装: コンテナの初回 atomic touch で全要素を一括セル化（1 パス）。`cas`（closure 形式・
+  `.succ`/`.pred` fast path・expected/new 形式）と要素代入（`shared_*_elem_set`）がセル経由。
+  closure は**セルロック外**で実行（Track B の再入規則 = GC safepoint と同じ境界問題、
+  ADR-0001 §3-6）し、compare-and-store で retry。multidim cas 等は従来 COW のまま（TODO）。
+- pin = `t/atomic-elem-cells.t`（churn 正確性・ホットキー競合・セルと通常代入の write-through
+  整合）。`make test` 1529 files PASS・S17 lock/cas/semaphore/thread 系 green。
+
 ## 2026-07-05: Phase B（GC）— **`MUTSU_GC` 既定 on に切替**（GC キャンペーン層 3a 完了）
 
 受け入れ計測と 3 つの仕上げ最適化を経て、**mutsu はデフォルトでサイクルを回収する処理系になった**

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -24,13 +24,6 @@ per_file_timeout() {
       # This test intentionally uses multiple sleep 1 calls and needs >30s.
       echo 60
       ;;
-    roast/S17-lowlevel/thread.t)
-      # Thread-churn workload, sleep-heavy: ~12s GC-off release and within a
-      # few percent of that under the default-on GC since the dead sweep's
-      # batch release moved off the collector thread — but it sat at ~29s on
-      # a loaded CI runner once, so keep explicit headroom.
-      echo 60
-      ;;
     roast/S17-promise/allof.t)
       # This test uses sleep 2*$_ with $_ up to 9, parallel start blocks take ~18s.
       echo 60

--- a/src/runtime/builtins_atomic_cas.rs
+++ b/src/runtime/builtins_atomic_cas.rs
@@ -314,51 +314,19 @@ impl Interpreter {
         // which would overwrite our atomic array with stale local values.
         let atomic_key = format!("__mutsu_atomic_arr::{arr_name}");
 
-        // Initialize shared_vars with the array if not yet set
-        {
-            let shared = self.shared_vars.read().unwrap();
-            if !shared.contains_key(&atomic_key) {
-                drop(shared);
-                let arr = self.env.get(&arr_name).cloned().unwrap_or(Value::Array(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
-                    crate::value::ArrayKind::Array,
-                ));
-                let mut shared = self.shared_vars.write().unwrap();
-                if !shared.contains_key(&atomic_key) {
-                    shared.insert(atomic_key.clone(), arr);
-                }
-            }
-        }
-
+        // Track B element cells: box elements at first atomic touch, then CAS
+        // the one element in place through its cell (no whole-array COW per
+        // op — see `init_celled_atomic_store`).
+        self.init_celled_atomic_store(&atomic_key, &arr_name);
+        let cell = self.celled_array_elem(&atomic_key, &arr_name, index);
         let mut did_swap = false;
         let current;
         {
-            let mut shared = self.shared_vars.write().unwrap();
-            let arr = shared.get(&atomic_key).cloned().unwrap_or(Value::Array(
-                crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
-                crate::value::ArrayKind::Array,
-            ));
-            if let Value::Array(ref elements, kind) = arr {
-                let idx = if index < 0 {
-                    (elements.len() as i64 + index) as usize
-                } else {
-                    index as usize
-                };
-                current = elements.get(idx).cloned().unwrap_or(Value::Int(0));
-                if Self::cas_retry_matches(&current, expected) {
-                    let mut new_elements = (**elements).clone();
-                    while new_elements.len() <= idx {
-                        new_elements.push(Value::Int(0));
-                    }
-                    new_elements[idx] = new_val.clone();
-                    shared.insert(
-                        atomic_key.clone(),
-                        Value::Array(crate::gc::Gc::new(new_elements), kind),
-                    );
-                    did_swap = true;
-                }
-            } else {
-                current = Value::Int(0);
+            let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
+            current = guard.clone();
+            if Self::cas_retry_matches(&current, expected) {
+                *guard = new_val;
+                did_swap = true;
             }
         }
 

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -6,7 +6,203 @@
 use super::*;
 
 impl Interpreter {
+    /// Box `v` into a fresh element cell unless it already is one (Track B
+    /// slice 1 — ADR-0001 layer 3a's element-cell companion).
+    pub(super) fn boxed_elem_cell(v: Value) -> Value {
+        if v.is_container_ref() {
+            v
+        } else {
+            Value::ContainerRef(crate::gc::Gc::new(std::sync::Mutex::new(v)))
+        }
+    }
+
+    /// Ensure the `__mutsu_atomic_hash::`/`__mutsu_atomic_arr::` store node
+    /// for `name` exists with EVERY element value boxed into a `ContainerRef`
+    /// cell — the Track B element-cell representation, applied in ONE pass at
+    /// the container's first atomic touch.
+    ///
+    /// Why cells: the store previously kept plain snapshots, so every atomic
+    /// element RMW had to clone the whole container to publish one element
+    /// (readers on other threads hold the old node without a lock, so
+    /// in-place map mutation would be a data race). That made
+    /// `cas %h{$_}` × 30k on a 10k-entry hash cost ~300M entry copies
+    /// (S17-lowlevel/thread.t test 28: 12.2s GC-off / 21.2s GC-on). With
+    /// element cells the map STRUCTURE stays copy-on-write (readers'
+    /// snapshots remain immutable), while element VALUES mutate in place
+    /// under the cell's own mutex — every holder of any snapshot shares the
+    /// cells, so cross-thread reads stay coherent and an element RMW is O(1).
+    /// Reader-side deref of `ContainerRef` hash/array values is the
+    /// long-standing `%h<k> := $x` binding machinery and is already
+    /// universal on the read paths (element read, arithmetic, compare, grep,
+    /// sort, stringify — probed before this slice landed).
+    pub(super) fn init_celled_atomic_store(&mut self, atomic_key: &str, name: &str) {
+        {
+            let shared = self.shared_vars.read().unwrap();
+            if shared.contains_key(atomic_key) {
+                return;
+            }
+        }
+        let base = self
+            .env
+            .get(name)
+            .cloned()
+            .or_else(|| self.get_shared_var(name));
+        let celled = match base {
+            Some(Value::Hash(h)) => {
+                let mut data = h.as_ref().clone();
+                for v in data.map.values_mut() {
+                    let taken = std::mem::replace(v, Value::Nil);
+                    *v = Self::boxed_elem_cell(taken);
+                }
+                Value::Hash(crate::gc::Gc::new(data))
+            }
+            Some(Value::Array(a, kind)) => {
+                let mut data = a.as_ref().clone();
+                for v in data.items.iter_mut() {
+                    let taken = std::mem::replace(v, Value::Nil);
+                    *v = Self::boxed_elem_cell(taken);
+                }
+                Value::Array(crate::gc::Gc::new(data), kind)
+            }
+            _ => {
+                if name.starts_with('@') {
+                    Value::Array(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
+                        crate::value::ArrayKind::Array,
+                    )
+                } else {
+                    Value::Hash(Value::hash_arc(HashMap::new()))
+                }
+            }
+        };
+        let mut shared = self.shared_vars.write().unwrap();
+        if !shared.contains_key(atomic_key) {
+            shared.insert(atomic_key.to_string(), celled.clone());
+            shared.insert(name.to_string(), celled.clone());
+            drop(shared);
+            self.env.insert(name.to_string(), celled);
+            if let Ok(mut dirty) = self.shared_vars_dirty.write() {
+                dirty.insert(atomic_key.to_string());
+                dirty.insert(name.to_string());
+            }
+        }
+    }
+
+    /// The element cell for `key` in the celled atomic hash store, creating it
+    /// (one COW of the map structure) when the key is missing or was
+    /// overwritten with a plain value by a structural assignment. The returned
+    /// handle is shared by every snapshot of the container, so mutating
+    /// through it is visible everywhere without republishing the node.
+    pub(super) fn celled_hash_elem(
+        &mut self,
+        atomic_key: &str,
+        hash_name: &str,
+        key: &str,
+    ) -> crate::gc::Gc<std::sync::Mutex<Value>> {
+        {
+            let shared = self.shared_vars.read().unwrap();
+            if let Some(Value::Hash(h)) = shared.get(atomic_key)
+                && let Some(Value::ContainerRef(c)) = h.get(key)
+            {
+                return c.clone();
+            }
+        }
+        let mut shared = self.shared_vars.write().unwrap();
+        // Re-check under the write lock (a racer may have boxed it).
+        if let Some(Value::Hash(h)) = shared.get(atomic_key)
+            && let Some(Value::ContainerRef(c)) = h.get(key)
+        {
+            return c.clone();
+        }
+        let mut data = match shared.get(atomic_key) {
+            Some(Value::Hash(h)) => h.as_ref().clone(),
+            _ => crate::value::HashData::default(),
+        };
+        let seed = match data.map.get(key) {
+            Some(Value::ContainerRef(c)) => return c.clone(),
+            Some(v) => v.clone(),
+            None => Value::Int(0),
+        };
+        let cell = crate::gc::Gc::new(std::sync::Mutex::new(seed));
+        data.map
+            .insert(key.to_string(), Value::ContainerRef(cell.clone()));
+        let updated = Value::Hash(crate::gc::Gc::new(data));
+        shared.insert(atomic_key.to_string(), updated.clone());
+        shared.insert(hash_name.to_string(), updated.clone());
+        drop(shared);
+        self.env.insert(hash_name.to_string(), updated);
+        cell
+    }
+
+    /// The element cell at `idx` in the celled atomic array store, creating it
+    /// (one COW, padding missing slots with fresh `0`-cells) when needed.
+    pub(super) fn celled_array_elem(
+        &mut self,
+        atomic_key: &str,
+        arr_name: &str,
+        index: i64,
+    ) -> crate::gc::Gc<std::sync::Mutex<Value>> {
+        let resolve =
+            |arr: &Value, index: i64| -> (usize, Option<crate::gc::Gc<std::sync::Mutex<Value>>>) {
+                if let Value::Array(elements, _) = arr {
+                    let idx = if index < 0 {
+                        (elements.len() as i64 + index).max(0) as usize
+                    } else {
+                        index as usize
+                    };
+                    if let Some(Value::ContainerRef(c)) = elements.get(idx) {
+                        return (idx, Some(c.clone()));
+                    }
+                    (idx, None)
+                } else {
+                    (index.max(0) as usize, None)
+                }
+            };
+        {
+            let shared = self.shared_vars.read().unwrap();
+            if let Some(arr) = shared.get(atomic_key) {
+                let (_, cell) = resolve(arr, index);
+                if let Some(c) = cell {
+                    return c;
+                }
+            }
+        }
+        let mut shared = self.shared_vars.write().unwrap();
+        let arr = shared.get(atomic_key).cloned().unwrap_or(Value::Array(
+            crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
+            crate::value::ArrayKind::Array,
+        ));
+        let (idx, cell) = resolve(&arr, index);
+        if let Some(c) = cell {
+            return c;
+        }
+        let (mut data, kind) = match arr {
+            Value::Array(a, kind) => (a.as_ref().clone(), kind),
+            _ => (
+                crate::value::ArrayData::new(Vec::new()),
+                crate::value::ArrayKind::Array,
+            ),
+        };
+        while data.items.len() <= idx {
+            data.items.push(Self::boxed_elem_cell(Value::Int(0)));
+        }
+        let seed = match &data.items[idx] {
+            Value::ContainerRef(c) => return c.clone(),
+            v => v.clone(),
+        };
+        let cell = crate::gc::Gc::new(std::sync::Mutex::new(seed));
+        data.items[idx] = Value::ContainerRef(cell.clone());
+        let updated = Value::Array(crate::gc::Gc::new(data), kind);
+        shared.insert(atomic_key.to_string(), updated.clone());
+        drop(shared);
+        // Arrays deliberately skip the env mirror: GetLocal consults the
+        // atomic shared key directly (see builtin_cas_array_elem's note).
+        let _ = arr_name;
+        cell
+    }
+
     /// Thread-safe `@arr.push(...)` (and `.unshift`) in shared (threaded)
+    /// context. (and `.unshift`) in shared (threaded)
     /// context.
     ///
     /// A plain `.push` in a thread reads `@arr` from the thread's *local* env
@@ -106,6 +302,23 @@ impl Interpreter {
         value: Value,
     ) -> Value {
         let atomic_key = format!("__mutsu_atomic_arr::{arr_name}");
+        // Track B cell fast path: an already-celled slot is assigned through
+        // its cell in place — every snapshot holder sees it, no COW, no
+        // republish.
+        {
+            let shared = self.shared_vars.read().unwrap();
+            if let Some(Value::Array(elems, _)) = shared.get(&atomic_key)
+                && let Some(Value::ContainerRef(c)) = elems.get(idx)
+            {
+                let cell = c.clone();
+                drop(shared);
+                *cell.lock().unwrap_or_else(|e| e.into_inner()) = value.clone();
+                if let Ok(mut dirty) = self.shared_vars_dirty.write() {
+                    dirty.insert(arr_name.to_string());
+                }
+                return value;
+            }
+        }
         let updated = {
             let mut shared = self.shared_vars.write().unwrap();
             let mut elements: Vec<Value> = match shared.get(&atomic_key) {
@@ -146,6 +359,21 @@ impl Interpreter {
         value: Value,
     ) -> Value {
         let atomic_key = format!("__mutsu_atomic_hash::{hash_name}");
+        // Track B cell fast path — see `shared_array_elem_set`.
+        {
+            let shared = self.shared_vars.read().unwrap();
+            if let Some(Value::Hash(h)) = shared.get(&atomic_key)
+                && let Some(Value::ContainerRef(c)) = h.get(&elem_key)
+            {
+                let cell = c.clone();
+                drop(shared);
+                *cell.lock().unwrap_or_else(|e| e.into_inner()) = value.clone();
+                if let Ok(mut dirty) = self.shared_vars_dirty.write() {
+                    dirty.insert(hash_name.to_string());
+                }
+                return value;
+            }
+        }
         let updated = {
             let mut shared = self.shared_vars.write().unwrap();
             let mut map = match shared.get(&atomic_key) {
@@ -337,22 +565,11 @@ impl Interpreter {
         let code = args[2].clone();
         let atomic_key = format!("__mutsu_atomic_hash::{hash_name}");
 
-        // Initialize shared_vars with the hash if not yet set
-        {
-            let shared = self.shared_vars.read().unwrap();
-            if !shared.contains_key(&atomic_key) {
-                drop(shared);
-                let hash = self
-                    .env
-                    .get(&hash_name)
-                    .cloned()
-                    .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
-                let mut shared = self.shared_vars.write().unwrap();
-                if !shared.contains_key(&atomic_key) {
-                    shared.insert(atomic_key.clone(), hash);
-                }
-            }
-        }
+        // Track B element cells: box every element at the container's first
+        // atomic touch, then RMW individual elements in place through their
+        // cell — no whole-map COW per op (see `init_celled_atomic_store`).
+        self.init_celled_atomic_store(&atomic_key, &hash_name);
+        let cell = self.celled_hash_elem(&atomic_key, &hash_name, &key);
 
         // Check if code is {.succ} or {.pred} for fast path
         if let Value::Sub(ref sub) = code {
@@ -381,45 +598,24 @@ impl Interpreter {
                     None
                 };
                 if let Some(d) = delta {
-                    let mut shared = self.shared_vars.write().unwrap();
-                    let hash = shared
-                        .get(&atomic_key)
-                        .cloned()
-                        .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
-                    if let Value::Hash(ref map) = hash {
-                        let current = map.get(&key).cloned().unwrap_or(Value::Int(0));
-                        let new_val = crate::builtins::arith_add(current, Value::Int(d))?;
-                        let mut new_map = (**map).clone();
-                        new_map.insert(key, new_val);
-                        let updated = Value::Hash(Value::hash_arc(new_map));
-                        shared.insert(atomic_key.clone(), updated.clone());
-                        shared.insert(hash_name.clone(), updated.clone());
-                        drop(shared);
-                        self.env.insert(hash_name.clone(), updated);
-                        if let Ok(mut dirty) = self.shared_vars_dirty.write() {
-                            dirty.insert(atomic_key);
-                            dirty.insert(hash_name);
-                        }
-                        return Ok(Value::Nil);
-                    }
+                    // `.succ`/`.pred` never re-enter the VM, so the whole RMW
+                    // runs under the element cell's own lock — one locked
+                    // add, no retry, no COW, no republish (every snapshot
+                    // shares this cell).
+                    let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
+                    let current = guard.clone();
+                    *guard = crate::builtins::arith_add(current, Value::Int(d))?;
+                    return Ok(Value::Nil);
                 }
             }
         }
 
-        // General CAS loop for hash elements
+        // General CAS retry loop over the element cell. The user closure runs
+        // OUTSIDE the cell lock (it re-enters the VM — the Track B re-entrancy
+        // rule shared with GC safepoints, ADR-0001 §3-6): read, compute, then
+        // compare-and-store under the lock, retrying on interference.
         loop {
-            let current = {
-                let shared = self.shared_vars.read().unwrap();
-                let hash = shared
-                    .get(&atomic_key)
-                    .cloned()
-                    .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
-                if let Value::Hash(ref map) = hash {
-                    map.get(&key).cloned().unwrap_or(Value::Int(0))
-                } else {
-                    Value::Int(0)
-                }
-            };
+            let current = cell.lock().unwrap_or_else(|e| e.into_inner()).clone();
             let new_val = {
                 let call_args = if let Value::Sub(ref sub) = code {
                     if sub.params.is_empty() {
@@ -434,30 +630,11 @@ impl Interpreter {
                 };
                 self.call_sub_value(code.clone(), call_args, true)?
             };
-            // CAS: check if value is still `current`, if so store `new_val`
-            let mut shared = self.shared_vars.write().unwrap();
-            let hash = shared
-                .get(&atomic_key)
-                .cloned()
-                .unwrap_or_else(|| Value::Hash(Value::hash_arc(HashMap::new())));
-            if let Value::Hash(ref map) = hash {
-                let seen = map.get(&key).cloned().unwrap_or(Value::Int(0));
-                if Self::cas_retry_matches(&current, &seen) {
-                    let mut new_map = (**map).clone();
-                    new_map.insert(key, new_val);
-                    let updated = Value::Hash(Value::hash_arc(new_map));
-                    shared.insert(atomic_key.clone(), updated.clone());
-                    shared.insert(hash_name.clone(), updated.clone());
-                    drop(shared);
-                    self.env.insert(hash_name.clone(), updated);
-                    if let Ok(mut dirty) = self.shared_vars_dirty.write() {
-                        dirty.insert(atomic_key);
-                        dirty.insert(hash_name);
-                    }
-                    return Ok(Value::Nil);
-                }
+            let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
+            if Self::cas_retry_matches(&current, &guard) {
+                *guard = new_val;
+                return Ok(Value::Nil);
             }
-            drop(shared);
         }
     }
 }

--- a/t/atomic-elem-cells.t
+++ b/t/atomic-elem-cells.t
@@ -1,0 +1,42 @@
+use Test;
+
+# Track B slice 1: atomic-store element cells. `cas`/assignments on hash and
+# array ELEMENTS in threaded context go through per-element ContainerRef
+# cells instead of cloning the whole container per op (which made 30k cas ops
+# on a 10k-entry hash cost ~300M entry copies — S17-lowlevel/thread.t test 28).
+# These pin exactness (no lost update through the cells) and write-through
+# coherence between cells and later plain access.
+
+plan 5;
+
+# Hash element cas churn: every increment lands, no key lost.
+{
+    my %seen;
+    my $times = 500;
+    %seen{^$times} = (0 xx $times);
+    my @t = (1..3).map: { Thread.start({ cas %seen{$_}, {.succ} for ^$times; }) };
+    .finish for @t;
+    is ([+] %seen.values), 3 * $times, 'hash element cas: every increment lands';
+    is +%seen.keys, $times, 'hash element cas: no key lost';
+    is +%seen.values.grep({ $_ == 3 }), $times, 'hash element cas: each key hit exactly 3 times';
+}
+
+# Single hot key under heavy contention.
+{
+    my %h = x => 0;
+    my @t = (1..4).map: { Thread.start({ cas %h<x>, {.succ} for ^500; }) };
+    .finish for @t;
+    is %h<x>, 2000, 'contended single hash element: exact count';
+}
+
+# Plain access after the cells exist stays coherent (read + assignment write
+# through the cell, then a further cas sees the assigned value).
+{
+    my %h = x => 0;
+    my @t = (1..2).map: { Thread.start({ cas %h<x>, {.succ} for ^200; }) };
+    .finish for @t;
+    %h<x> = %h<x> + 1000;
+    my @t2 = (1..2).map: { Thread.start({ cas %h<x>, {.succ} for ^50; }) };
+    .finish for @t2;
+    is %h<x>, 1500, 'assignment and later cas write through the same element cell';
+}


### PR DESCRIPTION
## Summary

ADR-0001 層 3a の相方 **Track B(要素セル化)の第一スライス**: スレッド共有 atomic ストア(`__mutsu_atomic_hash::` / `__mutsu_atomic_arr::`)の**要素値を `ContainerRef` セル**(`Gc<Mutex<Value>>`)にし、コンテナの初回 atomic touch で 1 パス一括セル化します。

## 設計(Track B の一般化テンプレート)

- **構造 = COW スナップショット(従来どおり)**: 他スレッドの読み手はロックなしの不変 snapshot を保持
- **要素値 = セルで in-place 変異**: 全 snapshot が同一セルを共有 → cross-thread の読みは常に最新、要素 RMW は O(1)
- 読み側の `ContainerRef` deref は `%h<k> := $x` バインディング以来の既存機構(要素読み・算術・比較・grep・sort・stringify・.raku を事前プローブで確認)
- user closure は**セルロック外**で実行(Track B の再入規則 — GC safepoint と同じ境界問題、ADR-0001 §3-6)+ compare-and-store retry

## 効果

従来は `.succ` fast path ですら **op ごとに全コンテナ clone**(10k エントリ hash × 30k cas = ~3 億エントリコピー):

| 計測 | before | after |
|---|---|---|
| test-28 形状(debug) | 12.2s (off) / 21.2s (on) | **1.6s / 1.7s** |
| thread.t 全体(release) | 12〜16s (off) / 22〜31s (on) | **2.4s / 2.6s** |

GC-on ペナルティも +74% → **+5〜9%** に収束(巨大クローンが GC の candidate/dead churn の餌でもあったため)。不要になった thread.t の 60s 予算は削除。

## 範囲

hash 要素 cas(closure 形式・.succ/.pred fast path)、array 要素 cas(expected/new 形式)、要素代入 fast path(`shared_*_elem_set` が既存セルへ COW なし書込み)。multidim cas と非 atomic 経路の要素セル化は次スライス(TODO 記載)。

## 担保

pin = `t/atomic-elem-cells.t`(churn 正確性・ホットキー競合・セル/通常代入の write-through 整合)を素・gc-stress 両構成で反復 green。`make test` 1529 files PASS、S17 lock/cas/semaphore/thread green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK