### PR TITLE
fix(str): .Num/.Numeric/.Real reject "inf"/"nan" keyword strings

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -42,6 +42,23 @@ fn str_numeric_exception_attrs(s: &str) -> std::collections::HashMap<String, Val
 /// Build a lazy `Failure` wrapping an `X::Str::Numeric` exception for a string
 /// that cannot be numified — the shape raku's `.Int`/`.Num` produce on a bad
 /// string (the exception only fires when the Failure is sunk/used).
+/// Parse a string to `f64` the strict Raku way. Rust's `f64::parse` accepts the
+/// keywords `inf`/`infinity`/`nan` (case-insensitive, optionally signed), but
+/// Raku only accepts the exact tokens `Inf`/`+Inf`/`-Inf`/`NaN` for non-finite
+/// values. Finite overflow (`1e999` -> `Inf`) is still accepted.
+pub(crate) fn parse_raku_str_f64(normalized: &str) -> Option<f64> {
+    let body = normalized
+        .strip_prefix(['+', '-'])
+        .unwrap_or(normalized)
+        .to_ascii_lowercase();
+    if matches!(body.as_str(), "inf" | "infinity" | "nan")
+        && !matches!(normalized, "Inf" | "+Inf" | "-Inf" | "NaN")
+    {
+        return None;
+    }
+    normalized.parse::<f64>().ok()
+}
+
 pub(crate) fn str_numeric_failure(s: &str) -> Value {
     let ex = Value::make_instance(
         Symbol::intern("X::Str::Numeric"),
@@ -614,7 +631,7 @@ pub(super) fn dispatch(
                     } else {
                         // Normalize U+2212 MINUS SIGN to ASCII hyphen-minus
                         let normalized = trimmed.replace('\u{2212}', "-");
-                        if let Ok(f) = normalized.parse::<f64>() {
+                        if let Some(f) = parse_raku_str_f64(&normalized) {
                             Value::Num(f)
                         } else {
                             // An invalid string yields a lazy X::Str::Numeric Failure,
@@ -681,7 +698,7 @@ pub(super) fn dispatch(
                 Value::Str(s) => {
                     if let Ok(i) = s.trim().parse::<i64>() {
                         Value::Int(i)
-                    } else if let Ok(f) = s.trim().parse::<f64>() {
+                    } else if let Some(f) = parse_raku_str_f64(s.trim()) {
                         Value::Num(f)
                     } else {
                         // Same X::Str::Numeric Failure (typed, with the `⏏` marker)

--- a/t/str-num-inf-nan.t
+++ b/t/str-num-inf-nan.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Raku accepts only the exact tokens Inf/+Inf/-Inf/NaN when coercing a string
+# to a number; the lower-case keywords inf/nan and the full word "Infinity" are
+# NOT valid numeric strings. mutsu's .Num/.Numeric/.Real used Rust's lenient
+# float parser, which accepted "inf"/"nan"/"Infinity" — inconsistent with the
+# prefix + operator, which already rejected them.
+
+plan 18;
+
+# Valid non-finite tokens
+is "Inf".Num, Inf, '"Inf".Num';
+is "+Inf".Num, Inf, '"+Inf".Num';
+is "-Inf".Num, -Inf, '"-Inf".Num';
+ok "NaN".Num.isNaN, '"NaN".Num is NaN';
+is "Inf".Numeric, Inf, '"Inf".Numeric';
+is "Inf".Real, Inf, '"Inf".Real';
+
+# Finite overflow still yields Inf (it is a valid numeric literal)
+is "1e999".Num, Inf, '"1e999".Num overflows to Inf';
+is "-1e999".Num, -Inf, '"-1e999".Num';
+
+# Rust's lenient keywords are rejected, matching raku
+throws-like { "inf".Num }, X::Str::Numeric, '"inf".Num throws';
+throws-like { "nan".Num }, X::Str::Numeric, '"nan".Num throws';
+throws-like { "Infinity".Num }, X::Str::Numeric, '"Infinity".Num throws';
+throws-like { "+NaN".Num }, X::Str::Numeric, '"+NaN".Num throws';
+throws-like { "-NaN".Num }, X::Str::Numeric, '"-NaN".Num throws';
+throws-like { "inf".Numeric }, X::Str::Numeric, '"inf".Numeric throws';
+throws-like { "inf".Real }, X::Str::Numeric, '"inf".Real throws';
+
+# Ordinary numeric strings are unaffected
+is "3.14".Num, 3.14e0, '"3.14".Num';
+is "-5".Num, -5e0, '"-5".Num';
+is "".Num, 0e0, 'empty string coerces to 0';


### PR DESCRIPTION
## Summary

Rust's `f64::parse` accepts the keywords `inf`/`infinity`/`nan` (case-insensitive, optionally signed), so mutsu's `.Num`/`.Numeric`/`.Real` wrongly accepted them:

```
"inf".Num        # was Inf  — raku throws X::Str::Numeric
"nan".Num        # was NaN  — raku throws
"Infinity".Num   # was Inf  — raku throws
"+NaN".Num       # was NaN  — raku throws
```

Raku only accepts the exact tokens `Inf`/`+Inf`/`-Inf`/`NaN` for non-finite values — which is already what mutsu's prefix `+` operator does, so `.Num` was inconsistent with `+`.

Routed the string→f64 coercion through a new `parse_raku_str_f64` that rejects the lenient keyword forms while still accepting finite overflow (`1e999` → `Inf`, as raku does).

## Test
- New `t/str-num-inf-nan.t` (18 assertions), cross-checked against `raku`.
- `make test` passes (14981 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)