### PR TITLE
fix(classify): classify/categorize is Hash[Any,Mu]; object-hash .raku pairs

### DIFF
--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -333,6 +333,7 @@ impl Interpreter {
                     updated = Some(Self::classify_finish_hash(
                         buckets.clone(),
                         object_keys.clone(),
+                        false,
                     ));
                 }
                 if let Some(new_value) = updated {
@@ -352,7 +353,14 @@ impl Interpreter {
             return Ok(Value::mix(counts));
         }
 
-        Ok(Self::classify_finish_hash(buckets, object_keys))
+        // Only the standalone `.classify`/`.categorize` (no `:into` target) mints a
+        // fresh `Hash[Any,Mu]`; `classify-list`/`:into(%h)` classify into an
+        // existing container and keep its type.
+        Ok(Self::classify_finish_hash(
+            buckets,
+            object_keys,
+            into_target.is_none(),
+        ))
     }
 
     /// Wrap classify's bucket map in a `Value::Hash`, marking it an *object hash*
@@ -383,12 +391,33 @@ impl Interpreter {
     fn classify_finish_hash(
         buckets: HashMap<String, Value>,
         object_keys: HashMap<String, Value>,
+        standalone: bool,
     ) -> Value {
         let buckets: HashMap<String, Value> = buckets
             .into_iter()
             .map(|(k, v)| (k, Self::itemize_bucket_value(v)))
             .collect();
         let hash = Value::hash(buckets);
+        // The standalone `.classify`/`.categorize` always return a fresh
+        // `Hash[Any,Mu]` in Raku: the value type is `Any` (each bucket is an
+        // itemized array) and the key type is the most general `Mu` (keys can be
+        // anything the mapper returns). Classifying *into* an existing container
+        // (`classify-list`, `:into(%h)`) instead keeps the invocant's own type
+        // (a plain `Hash`, `BagHash`, ...), so only tag when standalone.
+        if standalone {
+            if let Value::Hash(mut arc) = hash {
+                let data = crate::gc::Gc::make_mut(&mut arc);
+                data.value_type = Some("Any".to_string());
+                data.key_type = Some("Mu".to_string());
+                if !object_keys.is_empty() {
+                    data.original_keys = Some(object_keys);
+                }
+                return Value::Hash(arc);
+            }
+            return hash;
+        }
+        // Classifying into an existing plain hash: preserve the object-hash
+        // tagging (typed keys) but not the `Any`/`Mu` type-object constraint.
         if object_keys.is_empty() {
             return hash;
         }

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -247,11 +247,6 @@ impl Interpreter {
                     .collect();
             return Ok(Value::str(format!("Map.new(({}))", parts.join(","))));
         }
-        // When key type is non-string (e.g. Int), use `key => value` format
-        // instead of colonpair `:key(value)` format.
-        let use_arrow = info.key_type.is_some()
-            && info.key_type.as_deref() != Some("Str")
-            && info.key_type.as_deref() != Some("Str(Any)");
         let parts: Vec<String> = sorted_keys
             .iter()
             .map(|k| {
@@ -265,21 +260,24 @@ impl Interpreter {
                             .unwrap_or_else(|_| format!("{:?}", v))
                     }
                 };
-                // Object hashes store `.WHICH` string keys; serialize the
-                // original typed key (`1`, not `Int|1`; `a`, not `Str|a`).
+                // Object hashes store `.WHICH` string keys; serialize the original
+                // typed key (`1`, not `Int|1`; `a`, not `Str|a`). Raku renders each
+                // pair per its *key*, independent of the hash's key-type: a Str key
+                // that is a valid identifier becomes a colonpair `:key(value)`;
+                // every other key (a non-Str key, or a Str needing quotes) becomes
+                // `key => value` with the key rendered via `.raku`.
                 let typed = map.typed_key(k);
-                let key_disp = match &typed {
-                    Value::Str(s) => (**s).clone(),
-                    _ => crate::builtins::methods_0arg::raku_value(&typed),
-                };
-                if use_arrow {
-                    format!("{} => {}", key_disp, value_repr())
-                } else if let Value::Bool(true) = v {
-                    format!(":{}", key_disp)
-                } else if let Value::Bool(false) = v {
-                    format!(":!{}", key_disp)
-                } else {
-                    format!(":{}({})", key_disp, value_repr())
+                match &typed {
+                    Value::Str(s)
+                        if crate::builtins::methods_0arg::raku_repr::is_adverbial_pair_key(s) =>
+                    {
+                        format!(":{}({})", s, value_repr())
+                    }
+                    _ => format!(
+                        "{} => {}",
+                        crate::builtins::methods_0arg::raku_value(&typed),
+                        value_repr()
+                    ),
                 }
             })
             .collect();

--- a/t/classify-hash-any-mu-raku.t
+++ b/t/classify-hash-any-mu-raku.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 10;
+
+# classify/categorize always return `Hash[Any,Mu]` in Raku, and object-hash
+# `.raku` renders each pair per its key: a Str identifier key becomes a
+# colonpair `:key(value)`, everything else becomes `key => value`.
+
+# --- classify / categorize type object + .raku ---
+
+is (1,2,3,4).classify(* %% 2).WHAT.^name, 'Hash[Any,Mu]',
+    'classify with Bool keys is Hash[Any,Mu]';
+
+is <apple banana avocado>.classify(*.substr(0,1)).WHAT.^name, 'Hash[Any,Mu]',
+    'classify with Str keys is Hash[Any,Mu]';
+
+is (1,2,3,4).categorize(* %% 2).WHAT.^name, 'Hash[Any,Mu]',
+    'categorize is Hash[Any,Mu]';
+
+is (1,2,3,4).classify(* %% 2).raku,
+    '(my Any %{Mu} = Bool::False => $[1, 3], Bool::True => $[2, 4])',
+    'classify Bool-key .raku uses arrow for non-Str keys';
+
+is <apple banana avocado>.classify(*.substr(0,1)).raku,
+    '(my Any %{Mu} = :a($["apple", "avocado"]), :b($["banana"]))',
+    'classify Str-key .raku uses colonpairs';
+
+# lookups still work after the metadata tag
+{
+    my %c = <apple banana avocado>.classify(*.substr(0,1));
+    is-deeply %c<a>, ['apple', 'avocado'], 'Str-key classify bucket lookup works';
+}
+
+# --- object-hash .raku pair rendering rules ---
+
+my %h{Mu};
+%h<a> = 1;
+%h{"a b"} = 2;
+%h<foo-bar> = 3;
+%h{1} = 4;
+is %h.raku,
+    '(my Any %{Mu} = 1 => 4, :a(1), "a b" => 2, :foo-bar(3))',
+    'per-key colonpair vs arrow: Str idents colonpair, others arrow';
+
+my %b{Mu};
+%b<a> = True;
+is %b.raku, '(my Any %{Mu} = :a(Bool::True))',
+    'a Bool value renders in full (:a(Bool::True)), not the :a shorthand';
+
+my Int %i{Int};
+%i{5} = 10;
+is %i.raku, '(my Int %{Int} = 5 => 10)', 'Int-keyed hash uses arrow';
+
+my Int %s{Str};
+%s<x> = 1;
+is %s.raku, '(my Int %{Str} = :x(1))', 'Str-keyed hash uses colonpair';


### PR DESCRIPTION
## What

Two related object-hash rendering fixes, surfaced by probing `(1,2,3,4).classify(* %% 2).raku` against rakudo.

### 1. `classify`/`categorize` return `Hash[Any,Mu]`

The standalone `.classify`/`.categorize` now tag their result hash as `Hash[Any,Mu]` (value type `Any`, key type `Mu`), matching Raku:

```
(1,2,3,4).classify(* %% 2).WHAT.^name   # was Hash[,Any] → now Hash[Any,Mu]
(1,2,3,4).classify(* %% 2).raku          # (my Any %{Mu} = Bool::False => $[1, 3], Bool::True => $[2, 4])
```

Classifying **into** an existing container (`classify-list`, `categorize-list`, `:into(%h)`) keeps the invocant's own type (a plain `Hash`, `BagHash`, `MixHash`, ...), so the `Any`/`Mu` tag is applied only when the result is a freshly-minted hash (no `:into` target).

### 2. Object-hash `.raku` renders each pair per its key

`.raku` on a constrained/object hash now decides colonpair-vs-arrow **per key** instead of by a single hash-wide rule:

- a `Str` key that is a valid identifier → colonpair `:key(value)`
- any other key (non-`Str`, or a `Str` needing quotes) → `key => value`

Previously a `%{Mu}` / `%{Any}` hash rendered every pair with `=>`, so a string-keyed classify result printed `a => ...` where Raku prints `:a(...)`. The stale Bool-value shorthand (`:a` / `:!a`) is dropped, since Raku renders `:a(Bool::True)` in full here.

## Safety

- `make test` passes (fixed the `t/set-op-mutability.t` `classify-list on Hash -> Hash` case by scoping the tag to standalone classify).
- All 172 whitelisted hash/array/type/operator roast files stay green; `S32-hash/perl.t` has the same 12 pre-existing (unrelated, Scalar-vs-deconted) failures before and after — verified identical.
- Verified against rakudo across colonpair/arrow edge cases: space keys, hyphen identifiers, digit-leading keys, `Int`/`Str`/`Mu`/`Any` key types, and Bool values.

Regression test: `t/classify-hash-any-mu-raku.t` (10 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)