### PR TITLE
fix(gc): Track B slice 2 — state aggregate cells accumulate again (write-through + push path)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -263,7 +263,13 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 
 ## 6. 並行（Track C 残）・構造リファクタ（独立・中長期）
 
-- [ ] **`state @`/`%`・lexical aggregate の真共有**（Track B 要素 cell 基盤に依存＝§2 の層3a 待ち）。
+- [ ] **`state @`/`%`・lexical aggregate の真共有** — Track B スライス 2 で大半解消:
+      shared ctx 下の state 集約 cell への write-through（`set_state_var`）＋ shared `ArrayPush` の
+      cell 経路＋ mut-dispatch の cell ファンネルで、呼び出し間・逐次スレッド間の累積が raku 一致
+      （t/state-aggregate-shared-cell.t、real raku でも全 pass を確認）。残: ① 非スレッドの
+      同一 sub 由来クロージャ間共有（`mk()` × 2 → 1,1,2 / raku は 1,2,3 — cell 非関与の env
+      snapshot 問題）② 高競合の並行「構造」挿入は lost-update（ただし real rakudo は同形で
+      MoarVM oops クラッシュ＝言語保証外。mutsu は不壊で優位）。
 - [ ] Semaphore / nonblocking await / lock 競合（S17・hard・別軸）。
 - [ ] `unsafe` の single-thread 前提コメント是正（`Arc::as_ptr as *mut` を strong_count ガード前提に・
       最終的に要素も cell 化）。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,27 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-05: Track B スライス 2 — `state @`/`%` の cell 共有を修復（累積全滅・push 死の 2 バグ）
+
+`state` 集約はスレッド文脈が有効になると共有 `ContainerRef` cell に移行する（Track C・
+`StateVarInit`）が、**cell への書き戻しが存在せず累積が全滅**していた（決定的:
+一度でもスレッドを spawn すると `state %h; %h<k>++` が 1,1,1...、`state @a; @a.push` も 1,1,...）。
+さらに **cell が非空で seed されると push が "No such method 'push'" で死ぬ**
+（スレッド spawn 時の state migration 経路で main でも再現する既存バグ）。修正 3 点:
+
+1. **`set_state_var` の write-through**: 既存エントリが cell で流入値が素の値なら cell の中へ書く
+   （block-exit の `sync_state_locals` からの書き戻しが cell に届くように）。
+2. **shared ctx の `ArrayPush` fast op に cell 経路**: `state @a` の push を cell ロック下で
+   inner node に COW append（従来は素の cell を invocant に non-mut dispatch へ落ちて死）。
+3. **`call_method_mut_with_values` に cell ファンネル**: cell 内容で dispatch → 変異結果を cell へ
+   畳み戻し → env を cell に再ポイント。
+
+結果: 呼び出し間累積・pre-seed migration・**逐次スレッド間共有**（`f($x)` を 3 スレッドで順次 →
+親が 0,1,2,3 を観測）まで raku 一致。pin = `t/state-aggregate-shared-cell.t`（10 本、real raku
+でも全 pass = 意味論検証済み）。高競合の並行構造挿入は lost-update を許容
+（**real rakudo は同形で MoarVM oops クラッシュ** = 言語保証外。mutsu は決して壊れない）。
+残: 非スレッドのクロージャ間共有（cell 非関与の別バグ、PLAN §6）。
+
 ## 2026-07-05: Track B スライス 1 — atomic ストアの要素セル化（cas の全体 COW 除去）
 
 ADR-0001 層 3a の Track B（要素 cell 化)に着手。第一スライスとして、スレッド共有の atomic

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -218,6 +218,23 @@ impl Interpreter {
     }
 
     pub(crate) fn set_state_var(&mut self, key: String, value: Value) {
+        // Track C/Track B: once a `state` variable lives in a shared
+        // `ContainerRef` cell (StateVarInit under an active thread context),
+        // every writeback must go THROUGH the cell, not replace the store
+        // entry with a plain snapshot. The block-exit sync
+        // (`sync_state_locals`) hands us the mutated plain aggregate; before
+        // this write-through, storing it here severed the cell, so the next
+        // call's StateVarInit re-read the stale cell content and `state @a` /
+        // `state %h` accumulation was lost entirely whenever a thread had
+        // ever been spawned (deterministic: `%h<k>++` returned 1,1,1... —
+        // t/state-aggregate-shared-cell.t). Writing a cell over a cell (the
+        // StateVarInit path itself) keeps the plain insert.
+        if let Some(Value::ContainerRef(cell)) = self.state_vars.get(&key)
+            && !value.is_container_ref()
+        {
+            *cell.lock().unwrap_or_else(|e| e.into_inner()) = value;
+            return;
+        }
         self.state_vars.insert(key, value);
     }
 

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -62,6 +62,33 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // Track B/Track C: an aggregate that lives in a shared `ContainerRef`
+        // cell (a `state @a`/`state %h` under an active thread context — see
+        // `exec_state_var_init_op`). Dispatch on the cell's CONTENT, then fold
+        // the mutated aggregate back INTO the cell and re-point the env at the
+        // cell, so every holder (other closures, other threads, the state
+        // store) observes the mutation and the next op keeps cell semantics.
+        // Without this, `@a.push` on a cell-held state array mis-dispatched
+        // ("No such method 'push' for invocant of type 'Array'") whenever the
+        // cell was seeded non-empty (pre-existing on the thread-spawn
+        // migration path; also every second call once the state write-through
+        // keeps the cell current).
+        if let Value::ContainerRef(cell) = &target {
+            let inner = cell.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            if matches!(inner, Value::Array(..) | Value::Hash(..)) {
+                let cell = cell.clone();
+                let result = self.call_method_mut_with_values(target_var, inner, method, args)?;
+                if let Some(updated) = self.env.get(target_var).cloned()
+                    && !updated.is_container_ref()
+                    && matches!(updated, Value::Array(..) | Value::Hash(..))
+                {
+                    *cell.lock().unwrap_or_else(|e| e.into_inner()) = updated;
+                    self.env
+                        .insert(target_var.to_string(), Value::ContainerRef(cell));
+                }
+                return Ok(result);
+            }
+        }
         let readonly_key = format!("__mutsu_sigilless_readonly::{}", target_var);
         let alias_key = format!("__mutsu_sigilless_alias::{}", target_var);
         let has_sigilless_meta =

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -29,6 +29,34 @@ impl Interpreter {
         if self.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::Nil);
             let target = self.env().get(target_name).cloned().unwrap_or(Value::Nil);
+            // Track B/Track C: a `state @a` under an active thread context is a
+            // shared `ContainerRef` cell. Push INTO the cell under its lock
+            // (COW of the inner node keeps escaped snapshots immutable), so
+            // every holder — other calls, other threads, the state store —
+            // sees the append. Previously this fell through to the plain
+            // method dispatch with the raw cell as invocant and failed with
+            // "No such method 'push'" once the cell was non-empty.
+            if let Value::ContainerRef(cell) = &target {
+                let is_cell_array = matches!(
+                    &*cell.lock().unwrap_or_else(|e| e.into_inner()),
+                    Value::Array(..)
+                );
+                if is_cell_array {
+                    let items = match val {
+                        Value::Slip(items) => items.to_vec(),
+                        other => vec![other],
+                    };
+                    let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
+                    if let Value::Array(arc, _) = &mut *guard {
+                        let data = crate::gc::Gc::make_mut(arc);
+                        data.items.extend(items);
+                    }
+                    let result = guard.clone();
+                    drop(guard);
+                    self.stack.push(result);
+                    return Ok(());
+                }
+            }
             // Only a plain lexical `@name` (not an attribute `@!x`/`@.x` or other
             // twigil'd form) has a single shared identity across threads, so only
             // it may funnel into the name-keyed atomic shared store.

--- a/t/state-aggregate-shared-cell.t
+++ b/t/state-aggregate-shared-cell.t
@@ -1,0 +1,47 @@
+use Test;
+
+# Track B/Track C: `state @a` / `state %h` live in a shared ContainerRef cell
+# once a thread context is active (StateVarInit). These pin that aggregate
+# STATE accumulates through the cell: block-exit writeback goes INTO the cell
+# (set_state_var write-through) and `@a.push` under shared context appends
+# through the cell. Regressions fixed here (deterministic pre-fix):
+#   - %h<k>++ / @a.push returned 1,1,1... once any thread had spawned
+#   - push died ("No such method 'push'") when the cell was seeded non-empty
+#     via the thread-spawn state migration.
+# Deliberately NOT tested: heavily contended concurrent structural inserts —
+# outside language guarantees (real rakudo crashes with a MoarVM oops on that
+# shape; mutsu loses some updates but never corrupts).
+
+plan 10;
+
+# Pre-thread baseline: plain state store, and a seed for the migration case.
+sub pa() { state @p; @p.push('x'); @p.elems }
+is pa(), 1, 'pre-thread state push (plain store)';
+
+# Force the shared (threaded) context on: state vars now live in cells.
+my @warm = (1..1).map: { Thread.start({ 1 }) };
+.finish for @warm;
+
+# Migration: the pre-thread value seeded the cell; pushing onto the
+# non-empty celled array must keep accumulating (died pre-fix).
+is pa(), 2, 'state seeded before thread spawn migrates into the cell';
+is pa(), 3, 'celled state array keeps accumulating after migration';
+
+sub gh() { state %h; %h<k>++; %h<k> }
+is gh(), 1, 'state %h under shared ctx: first call';
+is gh(), 2, 'state %h accumulates through the cell';
+is gh(), 3, 'state %h keeps accumulating';
+
+sub ga() { state @a; @a.push(1); @a.elems }
+is ga(), 1, 'state @a under shared ctx: first push';
+is ga(), 2, 'state @a push goes through the cell';
+
+sub gs() { state $n = 0; $n++; $n }
+gs();
+is gs(), 2, 'scalar state still accumulates (unchanged path)';
+
+# Sequential cross-thread sharing: each thread's element write lands in the
+# same cell the parent reads afterwards (threads serialized => deterministic).
+sub tf($x) { state %seen; %seen{$x} = 1; %seen.keys.sort.join(",") }
+for 1..3 { Thread.start({ tf($_) }).finish }
+is tf(0), '0,1,2,3', 'sequential threads share one state hash cell';


### PR DESCRIPTION
## Summary

Track B スライス 2。スレッド文脈が一度でも有効になると `state` 変数は共有 `ContainerRef` cell に移行します(Track C)が、**集約(`state @a` / `state %h`)はそのモードで決定的に壊れていました**:

- **累積の全滅**: `%h<k>++` が 1,1,1...、`@a.push` が 1,1,...(block-exit の書き戻しが cell を素の snapshot で**置換**してしまい、次回呼び出しの `StateVarInit` が古い cell を読む)
- **push の死**: cell が非空 seed されると `No such method 'push' for invocant of type 'Array'`(スレッド spawn 時の state migration 経路で **main でも再現する既存バグ**)

## 修正(チョークポイント 3 点)

1. **`set_state_var` write-through**: 既存エントリが cell なら素の流入値を cell の**中へ**書く
2. **shared ctx の `ArrayPush` fast op に cell 経路**: cell ロック下で inner node に COW append(構造 COW / 値 in-place という Track B の分割そのまま)
3. **`call_method_mut_with_values` の cell ファンネル**: 内容で dispatch → 変異結果を cell へ畳み戻し → env を cell に再ポイント

## 検証

- pin = `t/state-aggregate-shared-cell.t`(10 assertions)— **real raku でも全 pass** = 意味論をリファレンスで検証済み。呼び出し間累積・pre-seed migration・逐次スレッド間共有(3 スレッド → 親が 0,1,2,3 を観測)をカバー
- 高競合の並行**構造**挿入は lost-update を許容し**テスト対象外**: real rakudo は同形で **MoarVM oops クラッシュ**(`stale hashtable pointer`)= 言語保証外。壊れない mutsu が厳密に安全側
- `make test` PASS(1534 files)/ S04-declarations/state.t / t/lock.t / t/atomic-elem-cells.t / 並行系 t/ green

## 残(PLAN §6 に記載)

非スレッドの同一 sub 由来クロージャ間共有(`mk()` ×2 → 1,1,2 / raku 1,2,3)は cell 非関与の env-snapshot 別バグ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK