### PR TITLE
fix(grep): .grep over an Array returns a Seq (like Raku), not a List

### DIFF
--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -284,12 +284,14 @@ impl Interpreter {
                 self.dispatch_join_method(target, args)
             }
             "grep" => {
-                // In Raku, .grep returns a Seq. However, when called on an Array,
-                // the result carries rw view bindings that must be preserved (Array kind).
-                let is_real_array = matches!(&target, Value::Array(_, k) if k.is_real_array());
+                // In Raku, `.grep` always returns a `Seq` — including over an
+                // Array. `dispatch_grep` builds a `List`-kind array whose elements
+                // are the matched source slots as shared `ContainerRef` cells (so a
+                // writeback loop `for @a.grep(...) { $_++ }` still mutates `@a`
+                // through them); wrapping those same cells in a `Seq` preserves the
+                // writeback while giving the correct `Seq` type.
                 Some(self.dispatch_grep(target, &args).map(|v| {
-                    if !is_real_array && let Value::Array(items, crate::value::ArrayKind::List) = v
-                    {
+                    if let Value::Array(items, crate::value::ArrayKind::List) = v {
                         return Value::Seq(std::sync::Arc::new(items.to_vec()));
                     }
                     v

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -384,10 +384,17 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             }
         }
         Value::Slip(items) | Value::Seq(items) | Value::HyperSeq(items) | Value::RaceSeq(items) => {
-            Value::Array(
-                crate::value::Value::array_arc(items.to_vec()),
-                ArrayKind::Array,
-            )
+            // Like the `Value::Array` arm: assigning to an `@` variable snapshots
+            // element VALUES, so decontainerize any shared `ContainerRef` cells the
+            // Seq carries (e.g. `my @g = @a.grep(...)`, whose Seq references @a's
+            // rw slots) so a later write through the copy does not leak into the
+            // source. Only rebuild when a cell is actually present.
+            let arc = if items.iter().any(|v| matches!(v, Value::ContainerRef(_))) {
+                crate::value::Value::array_arc(items.iter().map(|v| v.deref_container()).collect())
+            } else {
+                crate::value::Value::array_arc(items.to_vec())
+            };
+            Value::Array(arc, ArrayKind::Array)
         }
         Value::LazyList(_) => value,
         // A bare Hash assigned to an @-var flattens into its pairs

--- a/t/grep-array-returns-seq.t
+++ b/t/grep-array-returns-seq.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 9;
+
+# `.grep` always returns a Seq in Raku, including when called on an Array (map
+# already did; grep over an Array used to return a List). The Seq still carries
+# the matched slots as writable containers, so an in-place update loop mutates
+# the source array through them.
+
+my @a = 1, 2, 3;
+is @a.grep(* > 1).WHAT.^name, 'Seq', 'grep over an Array returns a Seq';
+is @a.grep(* > 1).raku, '(2, 3).Seq', 'grep Seq .raku shows .Seq';
+is @a.grep(* > 1).elems, 2, 'grep Seq elems';
+
+# grep over a bare list is (still) a Seq
+is (1, 2, 3).grep(* > 1).WHAT.^name, 'Seq', 'grep over a List returns a Seq';
+
+# writeback through the grep result still works
+{
+    my @b = 1, 2, 3;
+    for @b.grep(* > 1) { $_++ }
+    is-deeply @b, [1, 3, 4], 'for over grep result writes back through the source';
+}
+{
+    my @b = 1, 2, 3;
+    @b.grep(* > 1)>>++;
+    is-deeply @b, [1, 3, 4], 'hyper-increment over grep result writes back';
+}
+
+# a named copy of a grep result owns its values (no writeback)
+{
+    my @b = 1, 2, 3;
+    my @g = @b.grep(* > 1);
+    @g[0]++;
+    is-deeply @b, [1, 2, 3], 'a copied grep result does not write back';
+    is-deeply @g, [3, 3], 'the copy was mutated independently';
+}
+
+# adverbs still work and produce a Seq
+is @a.grep(* > 1, :k).raku, '(1, 2).Seq', 'grep :k adverb returns a Seq of keys';


### PR DESCRIPTION
## What

`@a.grep(...)` returned a `List` while `@a.map(...)` — and `.grep` over a bare list — already returned a `Seq`. Raku returns a `Seq` for all of them:

```
my @a = 1, 2, 3;
@a.grep(* > 1).WHAT.^name   # was List → now Seq
@a.grep(* > 1).raku          # was (2, 3) → now (2, 3).Seq
```

## How

`dispatch_grep` builds a `List`-kind array whose elements are the matched source slots as shared `ContainerRef` cells, so an in-place update loop (`for @a.grep(...) { $_++ }`) mutates `@a` through them. The grep dispatch only wrapped that array in a `Seq` when the invocant was **not** a real array. Wrap it for real arrays too — a `Seq` over the same cells keeps the writeback while giving the correct type.

That exposed a latent gap: `coerce_to_array` decontainerized `ContainerRef` cells for the `Value::Array` arm but **not** the `Value::Seq` arm, so copying the new grep `Seq` into a fresh array (`my @g = @a.grep(...)`) left `@g` aliased to `@a`'s slots (`@g[0]++` leaked back). Mirror the Array-arm decontainerize in the `Seq`/`Slip`/`HyperSeq`/`RaceSeq` arm so `=` snapshots values, as Raku requires.

## Safety

Verified against rakudo:
- `@a.grep(...).WHAT.^name` → `Seq`, `.raku` → `(...).Seq`, `.elems`/adverbs (`:k`) intact.
- writeback preserved: `for @a.grep(* > 1) { $_++ }` and `@a.grep(* > 1)>>++` still mutate `@a`.
- copy independence: `my @g = @a.grep(...); @g[0]++` no longer leaks into `@a`.

`make test` passes; the whitelisted `S02/S03/S04/S06/S07/S32-array/S32-list` roast files stay green. Regression test: `t/grep-array-returns-seq.t` (9 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)