### PR TITLE
fix(compiler): .VAR chained on a subscript of a literal no longer underflows

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -313,8 +313,15 @@ impl Compiler {
                 && args.is_empty()
                 && modifier.is_none()
                 && !quoted
-                && matches!(target.as_ref(), Expr::Index { .. }) =>
+                && matches!(target.as_ref(), Expr::Index { target: it, .. }
+                    if Self::index_assign_target_name(it).is_some()) =>
             {
+                // `.VAR` on `@a[0]` / `%h<k>` (a *named* container's element) needs
+                // the element-variable metadata path. A `.VAR` on a subscript of a
+                // literal (`[1,2,3][1].VAR`) has no named source, so it falls
+                // through to the general method dispatch below — otherwise the
+                // special path emitted no value and the next chained method
+                // (`.VAR.^name`) underflowed the stack.
                 self.compile_expr_method_var_on_index(target);
             }
             Expr::MethodCall {

--- a/t/var-on-literal-index.t
+++ b/t/var-on-literal-index.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 8;
+
+# `.VAR` chained after a subscript of a *literal* (not a named variable) used to
+# hit "Interpreter stack underflow in CallMethod": the compiler routed it to the
+# element-variable metadata path, which emitted no value for a literal target, so
+# the following chained method underflowed the stack. It must fall through to the
+# ordinary method dispatch instead.
+
+lives-ok { [1, 2, 3][1].VAR.^name }, '.VAR.^name on an array-literal subscript does not crash';
+lives-ok { (1, 2, 3)[1].VAR.^name }, '.VAR.^name on a list-literal subscript does not crash';
+lives-ok { [1, 2, 3][1].VAR.Str }, '.VAR.Str on an array-literal subscript does not crash';
+
+is [1, 2, 3][1].VAR, 2, '.VAR on a literal subscript yields the element value';
+is (1, 2, 3)[1].VAR, 2, '.VAR on a list-literal subscript yields the element value';
+
+# a list element is not containerized, so its .VAR is the value's own type
+is (1, 2, 3)[1].VAR.^name, 'Int', 'list element .VAR.^name is the value type';
+
+# the named-variable path is unaffected
+{
+    my @a = 1, 2, 3;
+    is @a[1].VAR.^name, 'Scalar', '.VAR.^name on a named array element is Scalar';
+}
+{
+    my %h = a => 1;
+    is %h<a>.VAR.^name, 'Scalar', '.VAR.^name on a named hash element is Scalar';
+}


### PR DESCRIPTION
## What

`[1, 2, 3][1].VAR.^name` (and `(1, 2, 3)[1].VAR.…`) aborted the VM with **"Interpreter stack underflow in CallMethod"**.

## Root cause

The compiler routed any `.VAR` on an `Expr::Index` to the element-variable metadata path (`compile_expr_method_var_on_index`). That path only emits code when the subscript target is a *named* container (`@a` / `%h` / a sigilless alias) — it guards on `index_assign_target_name(index_target)`. For a subscript of a **literal** (`[1,2,3]`), the guard failed silently and the function emitted **no value**, so the next chained method call (`.VAR.^name`) underflowed the stack.

## Fix

Restrict the special-case match guard to indexes whose target has a nameable source, so a `.VAR` on a literal subscript falls through to ordinary method dispatch:

```
(1, 2, 3)[1].VAR.^name   # was: crash → now: Int  (matches Raku's uncontainerized list element)
[1, 2, 3][1].VAR         # was: crash → now: 2
```

The named-variable path is unchanged (`@a[0].VAR.^name` → `Scalar`, `%h<k>.VAR.^name` → `Scalar`).

## Safety

`make test` passes; all 31 whitelisted roast files that use `.VAR`, plus 234 whitelisted `S02`/`S09`/`S32-array`/`S32-list` subscript-heavy files, stay green. Regression test: `t/var-on-literal-index.t` (8 cases).

Note: a subscript of an *array literal* still reports its element's `.VAR` as the value's own type (`Int`) rather than Raku's `Scalar` — that would require containerizing array-literal elements (the itemization / container-identity work) and is out of scope here; this PR only removes the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)