### PR TITLE
fix(str): qualified-name pair keys are values; Bool keys render without parens

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -567,12 +567,12 @@ pub fn raku_value(v: &Value) -> String {
                 }
             }
             let key_repr = match key.as_ref() {
-                // Non-string keys that would be ambiguous as barewords need parens
-                Value::Pair(_, _)
-                | Value::ValuePair(_, _)
-                | Value::Package(_)
-                | Value::Nil
-                | Value::Bool(_) => format!("({})", raku_value(key)),
+                // Non-string keys that would be ambiguous as barewords need parens.
+                // A Bool key is NOT wrapped: `Bool::True` already renders
+                // unambiguously (raku prints `Bool::True => "a"`, not `(...)`).
+                Value::Pair(_, _) | Value::ValuePair(_, _) | Value::Package(_) | Value::Nil => {
+                    format!("({})", raku_value(key))
+                }
                 _ => raku_value(key),
             };
             format!("{} => {}", key_repr, raku_value(value))

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -77,9 +77,14 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
             // Auto-quote bareword on LHS of => only for plain barewords.
             // Parenthesized forms like `(Mu) => 4` must preserve the original value key.
             let consumed = &input[..input.len() - rest.len()];
-            let is_bareword = matches!(&expr, Expr::BareWord(_));
+            // A qualified name (`Bool::True`, `Foo::Bar`) is NOT autoquoted — it is
+            // evaluated to its value, so `Bool::True => "a"` has the Bool *value*
+            // as its (positional) key, matching raku.
+            let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
             let left = match expr {
-                Expr::BareWord(ref name) if !consumed.trim_start().starts_with('(') => {
+                Expr::BareWord(ref name)
+                    if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+                {
                     Expr::Literal(Value::str(name.clone()))
                 }
                 _ => expr,
@@ -137,9 +142,11 @@ pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> 
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(_));
+        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
-            Expr::BareWord(ref name) if !consumed.trim_start().starts_with('(') => {
+            Expr::BareWord(ref name)
+                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+            {
                 Expr::Literal(Value::str(name.clone()))
             }
             _ => expr,
@@ -185,9 +192,11 @@ pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(_));
+        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
-            Expr::BareWord(ref name) if !consumed.trim_start().starts_with('(') => {
+            Expr::BareWord(ref name)
+                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+            {
                 Expr::Literal(Value::str(name.clone()))
             }
             _ => expr,
@@ -237,9 +246,11 @@ pub(in crate::parser) fn listop_arg_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(_));
+        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
-            Expr::BareWord(ref name) if !consumed.trim_start().starts_with('(') => {
+            Expr::BareWord(ref name)
+                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+            {
                 Expr::Literal(Value::str(name.clone()))
             }
             _ => expr,
@@ -281,9 +292,11 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(_));
+        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
-            Expr::BareWord(ref name) if !consumed.trim_start().starts_with('(') => {
+            Expr::BareWord(ref name)
+                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+            {
                 Expr::Literal(Value::str(name.clone()))
             }
             _ => expr,

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -197,6 +197,19 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             if should_wrap_whatevercode(&value) {
                 value = wrap_whatevercode(&value);
             }
+            // A qualified name (`Bool::True`, `Foo::Bar`) is NOT autoquoted — it
+            // is evaluated to its value, so `Bool::True => "a"` has the Bool
+            // *value* as its (positional) key, matching raku.
+            if name.contains("::") {
+                return Ok((
+                    r2,
+                    Expr::PositionalPair(Box::new(Expr::Binary {
+                        left: Box::new(Expr::BareWord(name)),
+                        op: crate::token_kind::TokenKind::FatArrow,
+                        right: Box::new(value),
+                    })),
+                ));
+            }
             return Ok((
                 r2,
                 Expr::Binary {
@@ -1223,6 +1236,19 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         // Use parse_fat_arrow_value for right-associative chaining:
         // a => b => c parses as a => (b => c)
         let (r2, value) = parse_fat_arrow_value(r2)?;
+        // A qualified name (`Bool::True`, `Foo::Bar`) is NOT autoquoted — it is
+        // evaluated to its value, so `Bool::True => "a"` has the Bool *value* as
+        // its (positional) key, matching raku.
+        if name.contains("::") {
+            return Ok((
+                r2,
+                Expr::PositionalPair(Box::new(Expr::Binary {
+                    left: Box::new(Expr::BareWord(name)),
+                    op: crate::token_kind::TokenKind::FatArrow,
+                    right: Box::new(value),
+                })),
+            ));
+        }
         return Ok((
             r2,
             Expr::Binary {

--- a/t/qualified-name-pair-key.t
+++ b/t/qualified-name-pair-key.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A qualified name on the LHS of `=>` (e.g. Bool::True, Order::Less) is a value,
+# not an autoquoted string: `Bool::True => "a"` has the Bool VALUE as its key.
+# And a Pair with a Bool-value key renders as `Bool::True => ...` (no parens),
+# unlike a type object which renders as `(Int) => ...`.
+
+plan 14;
+
+# Qualified enum name key is the value, not a string
+is (Bool::True => "a").key.WHAT.gist, "(Bool)", 'Bool::True key is a Bool';
+is (Bool::False => "a").key.WHAT.gist, "(Bool)", 'Bool::False key is a Bool';
+is (Order::Less => 1).key.WHAT.gist, "(Order)", 'Order::Less key is an Order';
+
+# .raku rendering: Bool value key has no parens; type object key has parens
+is (Bool::True => "a").raku, 'Bool::True => "a"', 'Bool::True Pair.raku';
+is (Bool::False => "b").raku, 'Bool::False => "b"', 'Bool::False Pair.raku';
+is (Int => 1).key.WHAT.gist, "(Str)", 'bare type name Int autoquotes to Str';
+is Pair.new(Int, 1).raku, '(Int) => 1', 'type-object key keeps parens';
+is Pair.new(Nil, 1).raku, '(Nil) => 1', 'Nil key keeps parens';
+
+# Simple identifiers still autoquote (named-arg keys)
+is (a => 1).key.WHAT.gist, "(Str)", 'simple name a autoquotes';
+is (True => 1).raku, ':True(1)', 'simple True autoquotes to adverbial pair';
+
+# A Bool value works as a hash key
+my %h = Bool::True => "x";
+is %h{True}, "x", 'Bool::True usable as a hash key';
+
+# SetHash.antipairs (the roast case): the antipair key is Bool::True
+my $sh = SetHash.new: <a b b c c c>;
+is-deeply $sh.antipairs.sort(*.value),
+    (Bool::True => "a", Bool::True => "b", Bool::True => "c"),
+    'SetHash.antipairs keys are Bool::True';
+
+# Named arguments unaffected
+sub f(:$x) { $x }
+is f(x => 5), 5, 'named arg x => 5 still binds';
+sub g(:$verbose) { $verbose }
+is g(:verbose), True, 'colonpair named arg';


### PR DESCRIPTION
## Summary

Two related bugs in `Foo::Bar => value` pairs (found via `roast/S02-types/sethash.t` `.antipairs`):

1. **A qualified name on the LHS of `=>` was autoquoted to a string.** So `Bool::True => "a"` had the *string* `"Bool::True"` as its key instead of the Bool *value*. Simple identifiers (`a`, `Int`, `True`) still autoquote — only names containing `::` are now evaluated to their value (a positional pair), matching raku:

```
(Bool::True => "a").key.WHAT   # was (Str) — now (Bool)
(Order::Less => 1).key.WHAT    # was (Str) — now (Order)
```

2. **A Pair whose key is a Bool *value* rendered as `(Bool::True) => ...`** (type-object paren style). raku prints `Bool::True => ...` — a Bool key is unambiguous and needs no parens (unlike a type object / `Nil` / nested Pair, which keep them):

```
(Bool::True => "a").raku   # was (Bool::True) => "a" — now Bool::True => "a"
Pair.new(Int, 1).raku      # (Int) => 1   (unchanged, correct)
```

Simple-name autoquoting (`a => 1`, named args `f(x => 5)`, colonpairs) is unchanged.

## Impact
Fixes the `.antipairs produces correct result` subtests in `roast/S02-types/sethash.t`.

## Test
- New `t/qualified-name-pair-key.t` (14 assertions), cross-checked against `raku`.
- `make test` passes (15037 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)