### PR TITLE
fix(num): render a Num in scientific notation outside [1e-4, 1e15)

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -107,9 +107,10 @@ pub(crate) fn format_num_str(f: f64) -> String {
     let sign = if f < 0.0 { "-" } else { "" };
 
     // For numbers that are naturally expressible without scientific notation
-    // (roughly 1e-4 to 1e15), use fixed-point representation.
-    // For others, use scientific notation.
-    if (1e-4..1e16).contains(&abs_f) {
+    // (the half-open magnitude window [1e-4, 1e15)), use fixed-point
+    // representation. For others, use scientific notation — matching `Num.Str`,
+    // so `1e15` prints `1e+15` while `9e14` stays `900000000000000`.
+    if (1e-4..1e15).contains(&abs_f) {
         // Find shortest fixed-point round-trip representation
         for prec in 0..=20 {
             let candidate = format!("{sign}{abs_f:.prec$}");
@@ -142,7 +143,15 @@ pub(crate) fn format_num_str(f: f64) -> String {
             } else {
                 mantissa
             };
-            return format!("{sign}{mantissa}e{exp_str}");
+            // Raku always writes the exponent with an explicit sign and a
+            // 2-digit minimum (`1e-05`, `1e+20`, `1e-100`), matching `Num.Str`.
+            let exp_num: i32 = exp_str.parse().unwrap_or(0);
+            let exp_fmt = if exp_num < 0 {
+                format!("-{:02}", exp_num.unsigned_abs())
+            } else {
+                format!("+{:02}", exp_num)
+            };
+            return format!("{sign}{mantissa}e{exp_fmt}");
         }
     }
 

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -375,7 +375,16 @@ impl Value {
                         format!("{}", *f as i64)
                     }
                 } else {
-                    format!("{}", f)
+                    // Fractional Num: Raku renders in scientific notation once the
+                    // magnitude leaves [1e-4, 1e15) — e.g. `1e-5` prints `1e-05`,
+                    // not `0.00001`. Rust's `{}` never switches to scientific, so
+                    // apply the same threshold as the integer-valued branch.
+                    let abs = f.abs();
+                    if !(1e-4..1e15).contains(&abs) {
+                        format_num_scientific(*f)
+                    } else {
+                        format!("{}", f)
+                    }
                 }
             }
             Value::Str(s) => (**s).clone(),

--- a/t/num-scientific-notation.t
+++ b/t/num-scientific-notation.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 22;
+
+# A Num renders in scientific notation once its magnitude leaves the window
+# [1e-4, 1e15) — both in string context (`.Str`/`.gist`/`~`) and in `.raku`,
+# with the exponent written with an explicit sign and a 2-digit minimum
+# (`1e-05`, `1e+20`, `1e-100`). (A Rat like `0.00001` always stays decimal.)
+
+# --- string context (.Str / say) ---
+is ~1e-5,   '1e-05',  'small Num stringifies in scientific notation';
+is ~1.5e-5, '1.5e-05', 'small fractional Num scientific';
+is ~9.99e-5,'9.99e-05', 'just under 1e-4 is scientific';
+is ~1e-4,   '0.0001', '1e-4 exactly stays decimal';
+is ~1e-10,  '1e-10',  'tiny Num scientific with 2-digit exponent';
+is ~5e-8,   '5e-08',  'exponent zero-padded to 2 digits';
+is ~1e15,   '1e+15',  'large Num scientific at 1e15';
+is ~9e14,   '900000000000000', 'just under 1e15 stays decimal';
+is ~1.5,    '1.5',    'normal-range Num stays decimal';
+is ~0.001,  '0.001',  'normal small Num stays decimal';
+
+# --- .raku ---
+is (1e-5).raku,    '1e-05',   '.raku small Num scientific';
+is (1.5e-5).raku,  '1.5e-05', '.raku small fractional scientific';
+is (1e15).raku,    '1e+15',   '.raku large Num scientific';
+is (1e14).raku,    '100000000000000e0', '.raku just under 1e15 is fixed with e0';
+is (1e20).raku,    '1e+20',   '.raku positive exponent has + sign';
+is (1e-100).raku,  '1e-100',  '.raku 3-digit exponent unpadded';
+is (1.23456e-6).raku, '1.23456e-06', '.raku keeps mantissa, pads exponent';
+is (-1e-5).raku,   '-1e-05',  '.raku negative small Num';
+is (0.1).raku,     '0.1',     '.raku normal Num stays decimal';
+
+# --- a Rat literal is unaffected ---
+is ~0.00001, '0.00001', 'a Rat stays decimal even below 1e-4';
+is (0.00001).WHAT.^name, 'Rat', '0.00001 is a Rat, not a Num';
+
+# --- inside a list .raku ---
+is [1e-5, 1e15, 2.5].raku, '[1e-05, 1e+15, 2.5]', 'scientific rendering inside a list';


### PR DESCRIPTION
## What

A `Num` whose magnitude is `< 1e-4` printed in expanded decimal instead of Raku's scientific form:

```
say 1e-5        # was 0.00001  → now 1e-05
say (1e-5).raku # was 1e-5     → now 1e-05
say 1e15        # was 1000000000000000e0 (.raku) → now 1e+15
```

## Root cause & fix

- **`.Str`/`.gist`** (`display.rs`): the scientific threshold was only applied to *integer-valued* Nums (`f.fract() == 0.0`); a fractional small Num fell through to Rust's `{}`, which never switches to scientific. Applied the same `[1e-4, 1e15)` magnitude window to the fractional branch.
- **`.raku`/`.perl`** (`raku_repr::format_num_str`): used an upper bound of `1e16` (so `1e15` printed `1000000000000000e0` rather than `1e+15`) and emitted the exponent with no sign or zero-padding. Aligned the window to `[1e-4, 1e15)` and write the exponent with an explicit sign and a 2-digit minimum (`1e-05`, `1e+20`, `1e-100`), matching `Num.Str`.

A `Rat` (the literal `0.00001`) is unaffected — only `Num` uses scientific notation.

## Safety

Verified across the full magnitude range against rakudo (`.Str`, `.gist`, `~`, `.raku`, inside lists). `make test` passes; 586 of 589 whitelisted numeric/string/output-heavy roast files stay green — the other 3 (`gb2312`/`gb18030`/`shiftjis` encode-decode) are a local-harness artifact (they resolve `$test-folder` only under `scripts/run-roast-test.sh`, where they pass 5/5) and fail identically on `main` without this change.

Regression test: `t/num-scientific-notation.t` (22 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)