### PR TITLE
fix(gc): Track B slice 3 — state aggregates live in a ContainerRef cell in all modes

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -252,7 +252,14 @@ impl Interpreter {
         {
             return existing.clone();
         }
-        let cell = initial.into_container_ref();
+        // Track B slice 3: aggregates are celled at StateVarInit in every mode,
+        // so the pre-thread seed may already BE a cell — adopt it rather than
+        // double-wrapping (a cell inside a cell would break every deref path).
+        let cell = if initial.is_container_ref() {
+            initial
+        } else {
+            initial.into_container_ref()
+        };
         sv.insert(key.to_string(), cell.clone());
         cell
     }

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -70,7 +70,17 @@ impl Interpreter {
             self.set_state_var(scoped_key.clone(), cell.clone());
             cell
         } else if let Some(stored) = self.get_state_var(&scoped_key) {
-            stored.clone()
+            let stored = stored.clone();
+            // Track B slice 3: upgrade a plain stored aggregate to a cell
+            // (a value written by a pre-cell `set_state_var` plain insert),
+            // so every reader from here on shares one container.
+            if (name.starts_with('@') || name.starts_with('%')) && !stored.is_container_ref() {
+                let cell = stored.into_container_ref();
+                self.set_state_var(scoped_key.clone(), cell.clone());
+                cell
+            } else {
+                stored
+            }
         } else {
             // Coerce @ variables to Array and % variables to Hash,
             // matching the behavior of SetLocal for these sigils.
@@ -81,16 +91,41 @@ impl Interpreter {
             } else {
                 init_val
             };
-            self.set_state_var(scoped_key.clone(), coerced.clone());
-            coerced
+            // Track B slice 3: a `state @a` / `state %h` aggregate lives in a
+            // shared `ContainerRef` cell in ALL modes, not just under an active
+            // thread context. Every closure created in the declaring routine
+            // captures the CELL, so sibling closures from the same factory
+            // share one live container exactly like raku (`mk()` twice used to
+            // give 1,1,2 instead of 1,2,3: each closure env froze its own
+            // aggregate snapshot). Scalars keep the plain store: they are
+            // already shared via box-on-capture escape analysis, and celling
+            // them here would double-box.
+            let val = if name.starts_with('@') || name.starts_with('%') {
+                coerced.into_container_ref()
+            } else {
+                coerced
+            };
+            self.set_state_var(scoped_key.clone(), val.clone());
+            val
         };
         self.locals[slot_idx] = val.clone();
         let name = name.to_string();
         // Only insert into env if the value differs from what's already there.
         // This avoids triggering Arc::make_mut deep clone on the CoW env when
         // the state variable is already initialized with the same value (common
-        // case in tight loops).
-        let needs_env_insert = self.env().get(&name) != Some(&val);
+        // case in tight loops). For a celled aggregate the comparison must be
+        // CELL IDENTITY, not `PartialEq` — `Value::eq` derefs `ContainerRef`, so
+        // a fresh cell holding `[]` compares equal to the plain `[]` that the
+        // decl op pre-seeded in env, and the cell would never reach env (every
+        // name-based reader/writer would then use the detached plain snapshot,
+        // e.g. `state @a; @a = 9,8` right after init read back as empty).
+        let needs_env_insert = match (&val, self.env().get(&name)) {
+            (Value::ContainerRef(cell), Some(Value::ContainerRef(existing))) => {
+                !crate::gc::Gc::ptr_eq(cell, existing)
+            }
+            (Value::ContainerRef(_), _) => true,
+            (_, existing) => existing != Some(&val),
+        };
         if needs_env_insert {
             self.env_mut().insert(name.clone(), val);
         }

--- a/t/state-aggregate-shared-cell.t
+++ b/t/state-aggregate-shared-cell.t
@@ -12,7 +12,36 @@ use Test;
 # outside language guarantees (real rakudo crashes with a MoarVM oops on that
 # shape; mutsu loses some updates but never corrupts).
 
-plan 10;
+plan 18;
+
+# --- Track B slice 3: state aggregates live in a ContainerRef cell in ALL
+# modes (not just under a thread context), so sibling closures returned from
+# the same factory share ONE live container, matching raku. Pre-fix these
+# accumulated per-closure (mk() twice gave 1,1,2 instead of 1,2,3). ---
+
+sub mk-arr() { state @a; -> { @a.push(1); @a.elems } }
+my $a1 = mk-arr();
+my $a2 = mk-arr();
+is $a1(), 1, 'closure-shared state @: first closure first call';
+is $a2(), 2, 'closure-shared state @: sibling closure sees prior push';
+is $a1(), 3, 'closure-shared state @: first closure keeps accumulating';
+
+sub mk-hash() { state %h; -> { %h<k>++; %h<k> } }
+my $h1 = mk-hash();
+my $h2 = mk-hash();
+is $h1(), 1, 'closure-shared state %: first closure first call';
+is $h2(), 2, 'closure-shared state %: sibling closure sees prior increment';
+is $h1(), 3, 'closure-shared state %: first closure keeps accumulating';
+
+# Whole-aggregate assignment as the FIRST op after init must write through
+# the cell (regression: the env insert was skipped when the fresh cell
+# compared PartialEq-equal to the pre-seeded plain empty aggregate, so the
+# assignment landed in a detached snapshot and reads gave 0).
+sub wa() { state @a; @a = 9,8; @a.elems }
+is wa(), 2, 'whole-array assignment on a fresh state cell is visible';
+
+sub wh() { state %h; %h = (k => 1); %h.elems }
+is wh(), 1, 'whole-hash assignment on a fresh state cell is visible';
 
 # Pre-thread baseline: plain state store, and a seed for the migration case.
 sub pa() { state @p; @p.push('x'); @p.elems }


### PR DESCRIPTION
## Summary

Track B slice 3 (ADR-0001 layer 3a companion; continues #4241 / #4245). A `state @a` / `state %h` aggregate now lives in a shared `ContainerRef` cell at `StateVarInit` **unconditionally**, not only under an active thread context. Closures created in the declaring routine capture the CELL, so sibling closures from the same factory share one live container exactly like raku:

```raku
sub mk() { state @a; -> { @a.push(1); @a.elems } }
my $c1 = mk(); my $c2 = mk();
$c1(); $c2(); $c1()   # was 1,1,2 (per-closure env snapshots) — raku: 1,2,3
```

This closes the "closure-to-closure sharing without threads" residual from slice 2 (PLAN §6 item 1) and removes the dual representation (plain snapshot single-thread vs cell under threads) — one mechanism in all modes, per the Track B template. Scalars keep the plain store: they are already shared via box-on-capture escape analysis; celling them here would double-box.

## Supporting fixes the always-on cell exposed

1. **`StateVarInit`'s `needs_env_insert` used `PartialEq`, which derefs `ContainerRef`** — a fresh `cell([])` compared equal to the plain `[]` the decl op pre-seeded in env, so the cell never reached env, and `state @a; @a = 9,8` as the first op wrote into a detached snapshot (reads gave 0). Cells now compare by pointer identity.
2. **`get_or_init_shared_state_cell` adopts an already-celled seed** instead of double-wrapping it (the pre-thread state migration now hands it the plain-mode cell).

## Testing

- Pin `t/state-aggregate-shared-cell.t` 10 → 18 assertions (closure sharing for `@` and `%`, first-op whole-aggregate assignment) — all green on **real raku** too (semantics validated).
- 17-case op matrix (push / index / whole-assign / iterate / interpolate / map / reduce / `.raku` / `Z` / append / `:exists`) byte-identical to raku.
- `make test` PASS (1539 files); `roast/S04-declarations/state.t`, `t/closure-container-capture.t`, `t/atomic-elem-cells.t`, `t/lock.t` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK