### PR TITLE
docs(plan): GC post-3a roadmap + ADR-0004 JIT strategy (Proposed)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -181,12 +181,16 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 - ✅ **既定値 `MUTSU_GC` は on**（2026-07-05 切替済み — ADR-0003 §5 に受け入れ実測とゲート改訂を記録。
       bench-class ~+8% はユーザー判断で許容、根本削減は層 3b=NaN-boxing）。GC キャンペーン（層 3a）完了。
       残る GC 関連 perf は NaN-boxing（3b）に統合。
-- **Track B（要素 cell 化）** — スライス 1 完了: atomic ストア（`__mutsu_atomic_hash/arr::`）の
-  要素を `ContainerRef` セル化（cas/要素代入が全体 COW なしの O(1) RMW に。thread.t test 28 の
-  12.2s→1.6s）。map/array の「構造」は従来どおり COW スナップショット、要素「値」のみセル —
-  この分割が Track B の一般化テンプレート。残: 通常（非 atomic）経路の要素セル化と
-  `state @`/`%`・lexical aggregate の真共有（Track C 残、§6）。続いて NaN-boxing（層3b・JIT 地ならし）
-  → JIT（層4）。
+- **Track B（要素 cell 化）** — スライス 1（atomic ストア要素セル #4241）/ 2（state aggregate
+  cell 書き戻し #4245）/ 3（state 集約の全モードセル化 — 非スレッドのクロージャ間共有 raku 一致
+  #4251）完了。map/array の「構造」は COW スナップショット、要素「値」のみセル — この分割が
+  Track B の一般化テンプレート。残スライス（T4 multidim cas / T5 typed-constraint 透過 /
+  T6 非 state escaped aggregate probe）と着手条件・ゲートは
+  [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §2 に精緻化済み。
+- **post-3a ロードマップ**: 層3a hardening（H1 継続計測〜H5 background collect の着手トリガ）・
+  層3b NaN-boxing のスライス計画（3b-0 API 壁 → 3b-1 表現スイッチ → 3b-2 交通量刈り）・
+  層3c 凍結条件は [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) 参照。
+  続いて JIT（層4）= [ADR-0004（Proposed）](docs/adr/0004-jit-strategy.md)。
 
 ---
 
@@ -247,15 +251,19 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 - [ ] `Value` clone/drop（bench-class の ~50%）＋ `attributes.to_map()` の毎回クローン ＋
       `call_compiled_method` の属性キー `format!` ＋ instance 構築 HashMap ＋ `merge_method_env` —
       Lever 2（NaN-boxing・GC 後）待ち、ないし属性 materialization の作り直し（深い）。
-- [ ] **Lever 2: NaN-boxing（高 payoff・設計済）= ADR-0001 層3b（JIT の地ならし・GC 後）**: `Value` 48→8 bytes。
-      int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。
-- [ ] **Lever 3: threaded dispatch（中 payoff・ラフ）**: opcode の `match` を関数ポインタテーブルに。
-      命令律速ベンチ 10–30%。
+- [ ] **Lever 2: NaN-boxing = ADR-0001 層3b（JIT の地ならし・GC 後）**: `Value` 48→8 bytes。
+      int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。スライス計画
+      （3b-0 API 壁 → 3b-1 表現スイッチ → 3b-2 交通量刈り）とゲートは
+      [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3。
+- [ ] **Lever 3: threaded dispatch — 凍結提案**（[ADR-0004](docs/adr/0004-jit-strategy.md) §2.5 J0）:
+      JIT Tier A が dispatch ループ除去で同じ利得をより大きく取るため二重投資を避ける。
+      JIT が頓挫した場合のみ復活。
 - [ ] **Lever 4: JIT（Cranelift）= ADR-0001 層4（GC の後）/ Lever 5: 型制約チェックの tight-loop 省略**。
-      cycle collector on Arc の決定で JIT は stack map/forwarding/write barrier 不要・`Arc` inc/dec を
-      emit するだけ。intループのネイティブ化で hot path は GC/refcount コストゼロ（ADR-0001 §3-8）。
-- [ ] **Lever 6: biased reference counting = ADR-0001 層3c（GC 後の独立 perf）**。JIT が intループを
-      ネイティブ化すれば hot path から refcount が消えるため優先度は低め。
+      方式・フェーズ（J1 骨組み → J2 Tier A 網羅 → J3 呼び出し規約/IC → J4 Tier B インライン →
+      J5 既定 on）とゲートは **[ADR-0004（Proposed）](docs/adr/0004-jit-strategy.md)** に策定済み。
+      deopt/stack map なしの subroutine-threading 起点、safepoint poll で GC の STW に協調。
+- [ ] **Lever 6: biased reference counting = ADR-0001 層3c（GC 後の独立 perf）**。凍結 — 着手トリガは
+      「JIT J4 完了後の profile で atomic inc/dec が上位に残る」のみ（gc-post-3a-roadmap §4）。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。
 - 目標: method-call <1.5x、bench-class <1.5x、bench-fib（型制約付き）<2x。
 
@@ -263,13 +271,13 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 
 ## 6. 並行（Track C 残）・構造リファクタ（独立・中長期）
 
-- [ ] **`state @`/`%`・lexical aggregate の真共有** — Track B スライス 2 で大半解消:
-      shared ctx 下の state 集約 cell への write-through（`set_state_var`）＋ shared `ArrayPush` の
-      cell 経路＋ mut-dispatch の cell ファンネルで、呼び出し間・逐次スレッド間の累積が raku 一致
-      （t/state-aggregate-shared-cell.t、real raku でも全 pass を確認）。残: ① 非スレッドの
-      同一 sub 由来クロージャ間共有（`mk()` × 2 → 1,1,2 / raku は 1,2,3 — cell 非関与の env
-      snapshot 問題）② 高競合の並行「構造」挿入は lost-update（ただし real rakudo は同形で
-      MoarVM oops クラッシュ＝言語保証外。mutsu は不壊で優位）。
+- [ ] **`state @`/`%`・lexical aggregate の真共有** — Track B スライス 2+3 でほぼ解消:
+      state 集約は全モードで `ContainerRef` セル（#4245 write-through/cell 経路、#4251 全モード
+      セル化 — 非スレッドの同一 sub 由来クロージャ間共有も raku 一致）。
+      pin = t/state-aggregate-shared-cell.t（18 本、real raku でも全 pass）。残:
+      高競合の並行「構造」挿入の lost-update（real rakudo は同形で MoarVM oops クラッシュ＝
+      言語保証外。mutsu は不壊で優位 — 仕様外のまま維持）と、非 state の escaped aggregate
+      probe（gc-post-3a-roadmap §2 T6）。
 - [ ] Semaphore / nonblocking await / lock 競合（S17・hard・別軸）。
 - [ ] `unsafe` の single-thread 前提コメント是正（`Arc::as_ptr as *mut` を strong_count ガード前提に・
       最終的に要素も cell 化）。

--- a/docs/adr/0004-jit-strategy.md
+++ b/docs/adr/0004-jit-strategy.md
@@ -1,0 +1,127 @@
+# ADR-0004: JIT の方式選定とフェーズ計画（層4）
+
+- **Status**: Proposed（2026-07-05）
+- **Date**: 2026-07-05
+- **Deciders**: tokuhirom, Claude
+- **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（フェーズ順序 3a→3b→4、レベル1 GC が
+  JIT の前提コストを消す判断）, [gc-post-3a-roadmap.md](../gc-post-3a-roadmap.md)（層3b が本 ADR の
+  前提工事）, [PLAN.md](../../PLAN.md) §5 Lever 3/4, PERFORMANCE.md
+
+> ADR-0001 は「JIT は GC の後」「レベル1 GC（non-moving + refcount）なら JIT は stack map /
+> forwarding / write barrier が不要で、`Arc`/`Gc` の inc/dec を emit するだけ」という
+> *順序と前提* を決めた。本 ADR は JIT **そのもの**の方式を決める。
+
+---
+
+## 1. Context（背景）
+
+- 実行系は単一の bytecode VM（`Interpreter`、~330 opcode、`exec_one` の match dispatch）。
+  コンパイル単位は `CompiledCode`（定数プール・indexed locals・`simple_locals`/upvalue 解析済み）。
+- perf 現況（対 raku）: fib(25) 1.0x・int-arith 0.7x と命令律速はほぼ互角だが、
+  **bench-fib（型制約付き）3.2x・method-call 2.7x・bench-class 2.3x** が残る。
+  目標（PLAN §5）: method-call < 1.5x・bench-class < 1.5x・bench-fib < 2x。
+- JIT の期待値（PERFORMANCE.md Phase 4c）: tight numeric loop で 5–10x。
+- GC はレベル1（cycle collector on Arc, default-on）。**non-moving**なのでポインタは動かず、
+  refcount が生存を保証する。safepoint 機構（backedge/call/return/await/...）と
+  cooperative STW は稼働済み — JIT コードはこの safepoint を **poll する側**として参加する。
+- 層3b（NaN-boxing, 8B `Value`）が先行する（ADR-0001 の順序）。JIT は 8B 固定幅の
+  値をレジスタで扱える前提で設計する。
+
+## 2. Decision（提案する決定）
+
+### 2.1 バックエンド = **Cranelift**（JIT モード）
+
+- 理由: pure-Rust で組み込みが軽い（rustc/LLVM ツールチェーン非依存）・コンパイル速度が
+  JIT 向き・wasmtime で実運用実績・non-moving GC と相性の良い「素の関数ポインタ」モデル。
+- 却下: LLVM(inkwell) は生成コード品質最強だがビルド・リンク・コンパイル時間とも
+  重量級で、mutsu の「高速起動」の武器（起動 0.04x）を損ねるリスク。自前 asm template JIT は
+  arch ごとの保守コスト。wasm 経由は間接層が無駄。
+- 依存は **feature flag + 実行時 flag**（`MUTSU_JIT=on|off`、既定は当面 off）で隔離し、
+  JIT なしビルド（非対応 arch）でも full 機能を維持する。
+
+### 2.2 コンパイル単位 = **`CompiledCode` 関数全体**（method JIT）。tracing はしない
+
+- ホット判定: `CompiledCode` ごとの呼び出しカウンタ（+ backedge カウンタ）。閾値超過で
+  コンパイルし、以後のエントリはネイティブ関数ポインタ経由。
+- OSR（実行中ループの途中乗り換え）は **初期スコープ外**（フェーズ J4 で backedge カウンタ
+  からの hot-loop entry を再検討）。mutsu の主要ベンチは関数呼び出し反復なので、
+  entry 置換だけで大半を回収できる。
+- meta-tracing（PyPy 型）は却下: インフラ規模が別次元で、既存 VM 資産を捨てることになる。
+
+### 2.3 実行モデル = **subroutine-threading + inline 化の漸進**（deopt なし）
+
+JIT の最初の形は「opcode 列を、**VM ヘルパ関数呼び出しの列**としてネイティブ化」する
+（= dispatch ループの除去がまず取れる）。その上で高頻度 opcode から順に CLIF へ
+インライン展開していく:
+
+- Tier A（J1–J2）: 全対応 opcode を helper call で直訳。未対応 opcode を含む関数は
+  JIT 対象外（インタプリタのまま）— **guard/deopt/OSR-exit を一切作らない**。
+  「コンパイルできるか」は静的に `CompiledCode` を見て決まるので、実行中の脱最適化が
+  不要になる。これが ADR-0001 の「GC を単純に保つ＝JIT も単純に保つ」路線の JIT 版。
+- Tier B（J3–J4）: Int/Num の算術・比較・分岐・local get/set・定数・小さな呼び出し規約を
+  CLIF に直接展開（NaN-box タグ判定 + fast path、slow path は helper へ）。
+  型プロファイルではなく **タグ分岐**で済ませる（8B NaN-box 前提）。
+- 「JIT が emit する GC 協調コード」は 2 つだけ:
+  1. 値の複製/破棄サイトでの `Gc`/`Arc` inc/dec（Tier B のインライン部のみ。helper call 部は
+     helper 内で従来どおり）
+  2. backedge / call サイトでの **safepoint poll**（`STOP_REQUESTED` チェック → 協調 park）
+
+### 2.4 GC / スレッドとの整合（レベル1 前提の明文化）
+
+- **stack map 不要**: JIT フレームに「collector から見えない生ポインタ」を置いてよい。
+  refcount を正しく保っている限り、参照中の node が回収されることはない
+  （cycle collector は孤立サイクルだけを刈る）。
+- **forwarding 不要**: non-moving なのでコンパイル済みコードに埋めたポインタは不変。
+- **write barrier 不要**: 世代別ではない。ただし mutation chokepoint の
+  candidate push（buffered bit）は helper 経由の変異では従来どおり動く。Tier B で
+  コンテナ変異をインライン化する時は candidate push もセットで emit する（＝コンテナ変異の
+  インライン化は優先度最下位に置き、当面 helper に残す）。
+- **STW**: JIT コードは safepoint poll を挟むので、cooperative STW の quiescence 会計に
+  そのまま参加する。long-running なネイティブループが poll を欠くと STW が飢えるため、
+  **backedge poll は Tier A から必須**とする。
+
+### 2.5 フェーズとゲート
+
+| フェーズ | 内容 | ゲート（受け入れ条件） |
+|---|---|---|
+| **J0** | 前提: 層3b 完了（8B Value）。**Lever 3（threaded dispatch）は凍結**（Tier A が dispatch ループ除去で同じ利得をより大きく取るため、二重投資を避ける） | 3b のゲート（gc-post-3a-roadmap §3.3）達成 |
+| **J1** | Cranelift 組み込み骨組み: feature flag・関数カウンタ・コンパイルキュー・エントリ差し替え。fib 相当の最小 opcode 集合を Tier A で | `MUTSU_JIT=on` で fib/int-arith が JIT 実行され、**on/off で出力 byte 一致**。make test green（on） |
+| **J2** | Tier A opcode カバレッジ拡大（arith/compare/branch/local/const/call-compiled-fn/return）+ CI に **jit-stress ジョブ**（gc-stress と同型: `MUTSU_JIT=on` で make test + roast） | jit-stress green。bench-fib で dispatch 除去分の実測改善（目標 3.2x → ~2.5x） |
+| **J3** | 呼び出し規約の最適化: JIT→JIT 直接呼び出し・method dispatch の inline cache（class Symbol キー）・型制約チェックの JIT 内 fast path | method-call < 1.5x・bench-class < 1.5x・bench-fib < 2x（PLAN §5 目標の達成レバー） |
+| **J4** | Tier B: NaN-box タグ分岐つき算術インライン + hot-loop（backedge カウンタ、必要なら OSR entry） | int ループ 5–10x（PERFORMANCE.md 期待値）。fib ループ内で `gc_candidate_pushes == 0` かつ refcount 操作ゼロ（ADR-0001 §3-8 の完成形） |
+| **J5** | 既定 on 切替: gc-stress × jit-stress のマトリクス green + オーバーヘッド予算（非ホットコードのコンパイルコストが起動 0.04x を悪化させない）を実測して `MUTSU_JIT` 既定 on | 起動ベンチ不変・全 CI green・ADR 更新 |
+
+### 2.6 テスト戦略
+
+- **差分実行が第一ゲート**: 同一プログラムを `MUTSU_JIT=off/on` で走らせ出力 byte 一致
+  （gc-stress で確立した手法の流用）。
+- CI: `jit-stress` ジョブ（J2〜）。将来 `MUTSU_GC=on × MUTSU_JIT=on` は default 同士なので
+  通常ジョブがマトリクスを兼ねる。
+- `MUTSU_VM_STATS` に `jit_compiles` / `jit_entries` / `jit_bailouts`（対象外関数の理由別
+  カウント）を追加し、「何がまだインタプリタに落ちているか」を数字で追う。
+
+## 3. Consequences
+
+- deopt/OSR-exit/stack map を持たない分、**JIT 本体は小さく保てる**が、対応 opcode を
+  含まない関数は丸ごとインタプリタに残る。→ `jit_bailouts` カウンタで対象外の分布を可視化し、
+  カバレッジ拡大を計測駆動にする。
+- Lever 3（threaded dispatch）は凍結。JIT が頓挫した場合のみ復活させる。
+- 層3c（biased RC）の要否判断は J4 完了後の profile まで保留（gc-post-3a-roadmap §4）。
+- Cranelift 依存が増える（ビルド時間・バイナリサイズ）。feature flag で非 JIT ビルドを
+  維持し、リリースバイナリでの既定は J5 で判断する。
+
+## 4. Alternatives considered
+
+| 案 | 利点 | 欠点 | 判定 |
+|---|---|---|---|
+| **Cranelift method JIT（本 ADR）** | 軽量・Rust 統合・JIT 向きコンパイル速度 | ピーク性能は LLVM 未満 | **採用** |
+| LLVM (inkwell) | 最高のコード品質 | ビルド/リンク重量級・コンパイル遅い・起動性能の武器を損ねる | 却下 |
+| 自前 template/copy-patch JIT | 依存ゼロ・最速コンパイル | arch ごとの実装/保守、Tier B 相当の最適化を自作 | 却下（Cranelift の Tier A がほぼ同コストで可搬） |
+| meta-tracing（PyPy 型） | 理論上の適応最適化 | VM 資産の作り直し・年単位 | 却下 |
+| wasm 経由（wasmtime） | sandbox/可搬 | 間接層のオーバーヘッド・GC/host 連携が煩雑 | 却下 |
+| deopt/guard 型 speculative JIT | ピーク性能 | stack 再構築（OSR-exit）実装が本格 VM 級 | 却下（bailout=関数単位不採用で代替） |
+
+---
+
+*本 ADR は Proposed。ユーザー承認後に Accepted へ更新し、J1 着手時に PLAN.md §5 を本 ADR
+参照に差し替える。*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@
 | [0001](0001-gc-strategy-and-phasing.md) | GC 導入の方式選定とフェーズ計画 | Accepted |
 | [0002](0002-phase-a-gate-reassessment.md) | Phase A ゲート再評価 — GC 着手条件の充足確認 | Accepted |
 | [0003](0003-default-on-gc-trigger.md) | デフォルト GC=on のトリガ方針（同期 + バッファサイズ閾値 + adaptive backoff） | Accepted |
+| [0004](0004-jit-strategy.md) | JIT の方式選定とフェーズ計画（Cranelift method JIT・deopt なし） | Proposed |

--- a/docs/gc-post-3a-roadmap.md
+++ b/docs/gc-post-3a-roadmap.md
@@ -1,0 +1,116 @@
+# GC post-3a ロードマップ — hardening / Track B 残 / 層3b NaN-boxing / 層3c
+
+Status: Draft（2026-07-05）
+Related: [ADR-0001](adr/0001-gc-strategy-and-phasing.md), [ADR-0003](adr/0003-default-on-gc-trigger.md),
+[gc-level1-detailed-design.md](gc-level1-detailed-design.md), [ADR-0004 (JIT)](adr/0004-jit-strategy.md), [PLAN.md](../PLAN.md) §2/§5
+
+この文書は **層3a（cycle collector on Arc）完了後** の GC まわりの残作業を、
+着手条件（トリガ）と受け入れゲート付きのスライスに落とすロードマップ。
+ADR-0001 のフェーズ順序（3a → 3b → 4=JIT → 3c 判断）は変えない。
+
+## 0. 現在地（2026-07-05）
+
+- **層3a 完了**: `MUTSU_GC` 既定 on（ADR-0003 §5）。全 safepoint 種別 emit、cooperative
+  cross-thread STW、dead sweep、adaptive threshold トリガ、CI gc-stress blocking。
+- **Track B**: スライス 1（atomic ストア要素セル #4241）/ 2（state aggregate cell 書き戻し #4245）/
+  3（state 集約の全モードセル化 #4251）まで完了。
+- **受け入れ実測の残差**: bench-class GC-on +8%（= `Value` clone/drop 交通量への per-drop
+  buffered-bit 分岐。ユーザー判断で許容済み、**回収は層3b の仕事**）。
+- perf 現況: fib(25) 1.0x / method-call 2.7x / bench-class 2.3x / bench-fib 3.2x（対 raku）。
+
+## 1. 層3a hardening バックログ（随時・小粒）
+
+> 原則: **実測で問題が出たときにやる**。予防的な複雑化はしない（1a を単純に保つことが
+> JIT を載せやすくする、という ADR-0001 §3-8 の連鎖を壊さない）。
+
+| ID | 内容 | 着手トリガ | ゲート |
+|----|------|-----------|--------|
+| H1 | GC オーバーヘッド継続観測: `MUTSU_VM_STATS` の gc カウンタ＋ベンチ表の定期再計測（`benchmarks/run-all.sh`） | 各大型 PR 後 | fib/int で `gc_candidate_pushes == 0` 維持、method-call/bench-class の GC-on 残差が悪化しない |
+| H2 | `Instance` 本体 node と `attributes` cell の分割（設計書 §13-1、唯一の未決） | 循環 reclaim の精度不足か attrs 経由のリーク/過剰トレースが実測された場合のみ | 対象 pin（attr 循環）で reclaim 数一致・VERIFY green |
+| H3 | STW quiescence の未ラップ blocking site 削減: timeout→requeue fallback の発火率を可視化し、発火源を `spawn_user_thread`/safe-region ラップへ移す | `MUTSU_GC_LOG` で fallback 発火が定常的に観測された場合 | churn 系ベンチで fallback 発火 ≈ 0、pause_ns_max 有界 |
+| H4 | root 消費型 full-root VERIFY モード（§11 step 11 の hardening リスト: AsyncSocketConnMap 等の `Value` edge を root visitor に包含） | tracing 型の検証/デバッグ機能が必要になったとき（3b の flip 検証にも有用） | VERIFY(full-root) が gc-stress で green |
+| H5 | Level 1b: background / incremental collect（設計書 §12 で 1a から除外したもの） | `pause_ns_max` が実ワークロードで問題化した実測がある場合のみ。**新 ADR 必須** | — |
+
+## 2. Track B 残スライス（小・GC キャンペーンの尻尾)
+
+スライス 1〜3 で「構造 = COW スナップショット / 要素値 = セル in-place」テンプレートは
+確立済み。残りは全て**このテンプレートの適用漏れ**で、各スライスは
+「raku 突き合わせ pin + make test + 関連 roast」をゲートとする。
+
+- **T4: multidim cas / 残 atomic 経路のセル化**（スライス 1 の TODO）。多次元 `cas` と
+  未セル化の atomic op を要素セル経由に統一する。
+- **T5: `ContainerRef` の typed-constraint 対応（設計書 §3.3 の `CellValue` 化の最小形）**。
+  celled な typed 集約（`my Int %h` が cell に入るケース）で制約情報がセルを透過することを
+  probe し、漏れを塞ぐ。フル `CellValue` 型の導入は 3b と同時に判断（Value 表現を触るのは
+  1 キャンペーン 1 回の原則）。
+- **T6: 非 state の escaped aggregate 捕捉の残件調査**（probe スライス）。
+  slice 3 で state 集約は解決。`my @a` を複数クロージャが捕捉して frame 脱出後に共有変異する
+  形（`docs/` lever C の「非ループ一般コンテナ捕捉」の集約版）を raku と突き合わせ、
+  差異があればセル化スライスを切る。
+- **対象外（変更なし）**: 高競合の並行「構造」挿入の lost-update は仕様外のまま
+  （real rakudo は同形で MoarVM oops。mutsu は不壊で優位 — スライス 2 の結論を維持）。
+
+## 3. 層3b: NaN-boxing（JIT の地ならし・GC 後の本丸）
+
+### 3.1 目的と回収対象
+
+- `Value` 48B → **8B**。bench-class の ~50%（`Value::clone`/`drop_in_place`/`Vec::clone`、
+  PERFORMANCE.md）と、GC default-on の bench-class +8% 残差（per-drop 分岐が乗る母数の交通量）を
+  まとめて回収する。
+- JIT（ADR-0004）の前提: 8B 固定幅・タグ判定が数命令・レジスタに乗る。**3b を JIT より先に行う**
+  （ADR-0001 の順序 3a→3b→4）。
+
+### 3.2 表現方針（ADR-0001 §3-6 の確認 + 具体化）
+
+- 64bit NaN-box: `f64` は生値、非 f64 は quiet-NaN 空間のタグ + 48bit payload。
+  - inline scalar: `Int`(小整数)・`Bool`・`Nil`・`Package/Symbol`・小さな enum 系。
+  - pointer tag: コンテナ系は **`Gc<T>` ポインタをそのまま payload に**（cycle collector は
+    non-moving なのでポインタ安定 — mark ビット再配置問題が起きない、ADR-0001 §3-6-3b）。
+  - boxed fallback: `BigInt`/`BigRat`/`Complex`/`Rat`/Range 系/その他大型 variant は
+    ヒープ箱（`Gc<BoxedValue>` ないし `Arc`）に逃がす。`Str(Arc<String>)` は pointer tag。
+- i64 全域が payload に入らない点に注意: 小整数 (48bit 級) は inline、外は BigInt 箱行きか
+  `Gc<i64>` 箱。**どちらにするかは実装時に int-arith ベンチで決める**。
+
+### 3.3 スライス分割（5b の教訓: 一斉 flip は 479 エラー/型 → 段階必須）
+
+1. **3b-0 API 壁**: `Value` の直接 `match`/構築サイトを accessor/constructor
+   （`as_int()`/`Value::int()`/`is_*()` 等）経由に機械的に寄せる。enum のまま挙動不変。
+   ここが最大の面積（数千サイト）だが完全に機械的・並列スライス可能。
+   ゲート: 各スライスで make test byte-identical。
+2. **3b-1 表現スイッチ**: `Value` の内部表現を `#[cfg]`/newtype で NaN-box 実装に差し替え
+   （accessor の中身だけ変わる）。`value_size_guard` を 48→8 に更新。
+   ゲート: make test + full roast + gc-stress green、GC カウンタ不変（型フィルタの
+   スカラ/コンテナ判定がタグ判定に変わるだけ）。
+3. **3b-2 交通量刈り**: clone/drop が memcpy 8B になった後の残ホットスポット
+   （`attributes.to_map()` 毎回クローン、`call_compiled_method` の `format!` 等、
+   PLAN §5 の既知項目）を profile 順に。
+- ゲート（3b 全体）: int-arith 2x・fib +30%（PERFORMANCE.md Phase 4a の期待値）、
+  bench-class の `Value` clone/drop share 50% → 20% 以下、GC-on bench-class 残差 +8% → +3% 以下。
+
+### 3.4 リスクと対策
+
+- **Send/Sync**: 現行 `Arc`/`Gc` ベースの cross-thread モデルを変えない（payload は
+  ポインタのまま）。
+- **Miri/UB**: タグ操作は 1 モジュールに閉じ込め、Miri でユニット検証（5a/5b と同じ手順）。
+- **flip の巨大さ**: 3b-0 の API 壁が終わっていれば 3b-1 は小さい。壁が終わる前に
+  3b-1 に手を出さない（5b の flip 失敗の再発防止）。
+
+## 4. 層3c: biased reference counting
+
+- **凍結**（ADR-0001 §3-6-3c のまま）。着手トリガ: **JIT(J3/J4) 完了後の profile で
+  `Arc`/`Gc` の atomic inc/dec が上位に残った場合のみ**。JIT が int ループを
+  ネイティブ化すれば hot path から refcount が消える見込みが高く、その場合は永久に不要。
+
+## 5. 順序と依存（全体）
+
+```
+[完了] 3a GC default-on ──┬── H1..H4 hardening（随時・小粒）
+                          ├── T4..T6 Track B 尻尾（小・並行可）
+                          └── 3b NaN-boxing（3b-0 → 3b-1 → 3b-2）
+                                    └── 層4 JIT（ADR-0004: J1 → J2 → J3 → J4）
+                                              └── 3c biased RC（実測トリガでのみ）
+```
+
+- Batteries（PLAN §1）はこの全系列と並行可能（Value 表現に依存しない）。
+- threaded dispatch（PLAN §5 Lever 3）は **JIT と重複するため凍結**を提案
+  （ADR-0004 §4 J0 参照）。


### PR DESCRIPTION
## Summary

The two planning documents requested for the phase after the GC default-on switch (layer 3a complete):

### `docs/gc-post-3a-roadmap.md` — GC まわりの残作業の精緻化

Slices with explicit **start triggers** and **acceptance gates**:

- **§1 layer-3a hardening backlog** (H1–H5): overhead tracking, Instance/attrs node split, STW-quiescence fallback reduction, full-root VERIFY, background collect — each gated on *measured* need, keeping 1a simple per ADR-0001 §3-8.
- **§2 Track B tail** (T4 multidim cas / T5 typed-constraint cell transparency / T6 non-state escaped-aggregate probe). Slices 1–3 (#4241/#4245/#4251) established the structure-COW / value-in-cell template.
- **§3 layer 3b NaN-boxing slice plan**: 3b-0 accessor/constructor API wall (mechanical, parallelizable) → 3b-1 representation switch behind the wall → 3b-2 residual traffic pruning. Gates: int-arith 2x, fib +30%, bench-class `Value` clone/drop 50%→<20%, GC-on residual +8%→+3%. Encodes the step-5b lesson (479 errors/type on a big-bang flip): no flip before the wall is complete.
- **§4 layer 3c biased RC stays frozen** — only trigger is a post-J4 profile still dominated by atomic inc/dec.

### `docs/adr/0004-jit-strategy.md` (Proposed) — JIT 実装計画

- **Backend = Cranelift** (JIT mode), feature-flagged, `MUTSU_JIT` default off until J5.
- **Compile unit = whole `CompiledCode`** (method JIT); hotness via call+backedge counters; no meta-tracing.
- **Execution model = Tier A subroutine-threading** (opcode → helper calls; functions containing unsupported opcodes stay interpreted — **no deopt / OSR-exit / stack maps**), then **Tier B** inlines NaN-box-tagged arithmetic with helper slow paths.
- **GC integration is exactly two emissions**: `Gc`/`Arc` inc/dec at inlined copy/drop sites, and safepoint polls on backedges/calls (level-1 non-moving+refcount GC needs no stack maps/forwarding/barriers — ADR-0001's premise realized).
- **Phases**: J1 skeleton (fib e2e, on/off byte-identical) → J2 Tier A coverage + jit-stress CI → J3 calling convention + inline caches (gate: method-call/bench-class <1.5x) → J4 Tier B (gate: int loops 5–10x, zero refcount/GC in fib loop) → J5 default-on.
- Proposes **freezing perf Lever 3** (threaded dispatch) as redundant with Tier A.

PLAN.md §2/§5/§6 now point at both documents; ADR index updated. ADR-0004 is **Proposed** — awaiting user approval before any J1 work starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK