### PR TITLE
fix(setbagmix): SetHash/BagHash/MixHash retain object keys, not strings

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -21,6 +21,33 @@ enum SliceKeyTree {
 }
 
 impl Interpreter {
+    /// Record the original object key when a non-string value is used as a
+    /// QuantHash (Set/Bag/Mix) subscript (`$sh{1001} = 42`). Set/Bag/Mix store
+    /// their keys stringified; the `original_keys` side table lets `.keys`/
+    /// `.raku` recover the object (`1001`, an Int) rather than the string.
+    fn record_quanthash_object_key(
+        original_keys: &mut Option<std::collections::HashMap<String, Value>>,
+        key: &str,
+        idx: &Value,
+    ) {
+        if matches!(idx, Value::Str(_)) {
+            return;
+        }
+        original_keys
+            .get_or_insert_with(std::collections::HashMap::new)
+            .insert(key.to_string(), idx.clone());
+    }
+
+    /// Drop an original-object key when its QuantHash element is removed.
+    fn forget_quanthash_object_key(
+        original_keys: &mut Option<std::collections::HashMap<String, Value>>,
+        key: &str,
+    ) {
+        if let Some(ok) = original_keys.as_mut() {
+            ok.remove(key);
+        }
+    }
+
     fn build_slice_key_tree(&mut self, key: &Value) -> Result<SliceKeyTree, RuntimeError> {
         match key {
             Value::LazyList(ll) => {
@@ -1612,8 +1639,10 @@ impl Interpreter {
                             let s = crate::gc::Gc::make_mut(set);
                             if val.truthy() {
                                 s.insert(key.clone());
+                                Self::record_quanthash_object_key(&mut s.original_keys, &key, &idx);
                             } else {
                                 s.remove(&key);
+                                Self::forget_quanthash_object_key(&mut s.original_keys, &key);
                             }
                         }
                         Value::Bag(ref mut bag, is_mutable) => {
@@ -1624,8 +1653,10 @@ impl Interpreter {
                             let count = Self::bag_assignment_count(&val)?;
                             if count == num_bigint::BigInt::from(0) {
                                 b.remove(&key);
+                                Self::forget_quanthash_object_key(&mut b.original_keys, &key);
                             } else {
                                 b.insert(key.clone(), count);
+                                Self::record_quanthash_object_key(&mut b.original_keys, &key, &idx);
                             }
                         }
                         Value::Mix(ref mut mix, is_mutable) => {
@@ -1636,8 +1667,10 @@ impl Interpreter {
                             let weight = Self::mix_assignment_weight(&val)?;
                             if weight == 0.0 {
                                 m.remove(&key);
+                                Self::forget_quanthash_object_key(&mut m.original_keys, &key);
                             } else {
                                 m.insert(key.clone(), weight);
+                                Self::record_quanthash_object_key(&mut m.original_keys, &key, &idx);
                             }
                         }
                         // Autovivify typed containers: MixHash, BagHash, SetHash

--- a/t/quanthash-object-keys.t
+++ b/t/quanthash-object-keys.t
@@ -1,0 +1,75 @@
+use Test;
+
+# Assigning a non-string object as a SetHash/BagHash/MixHash key must retain the
+# object, not stringify it: `$sh{1001} = 42` keeps the Int `1001` as the key
+# (closes roast/S02-types/sethash.t "retains object, not container").
+
+plan 14;
+
+# SetHash: the key stays the Int object even after the source var mutates
+{
+    my $o = SetHash.new;
+    my $i = 1001;
+    $o{$i} = 42;
+    $i++;
+    is-deeply $o.keys, (1001,).Seq, 'SetHash retains Int object key';
+    is $o.keys[0].WHAT.gist, '(Int)', 'SetHash key is an Int';
+}
+
+# BagHash
+{
+    my $b = BagHash.new;
+    my $i = 1001;
+    $b{$i} = 42;
+    $i++;
+    is-deeply $b.keys, (1001,).Seq, 'BagHash retains Int object key';
+    is $b.keys[0].WHAT.gist, '(Int)', 'BagHash key is an Int';
+}
+
+# MixHash
+{
+    my $m = MixHash.new;
+    $m{1001} = 2.5;
+    is-deeply $m.keys, (1001,).Seq, 'MixHash retains Int object key';
+    is $m.keys[0].WHAT.gist, '(Int)', 'MixHash key is an Int';
+}
+
+# Bool object key
+{
+    my $o = SetHash.new;
+    $o{True} = 1;
+    is $o.keys[0].WHAT.gist, '(Bool)', 'Bool object key retained';
+    is $o.keys.raku, '(Bool::True,).Seq', 'Bool key renders as Bool::True';
+}
+
+# String keys are unaffected
+{
+    my $o = SetHash.new;
+    $o<abc> = True;
+    is-deeply $o.keys, ("abc",).Seq, 'string key stays a string';
+    is $o.keys[0].WHAT.gist, '(Str)', 'string key is a Str';
+}
+
+# Removing an object key drops it (and its original-key record)
+{
+    my $o = SetHash.new;
+    $o{1001} = 42;
+    $o{1001} = 0;
+    is-deeply $o.keys, ().Seq, 'removed object key is gone';
+}
+
+# Multiple object keys
+{
+    my $o = SetHash.new;
+    $o{10} = 1;
+    $o{20} = 1;
+    is-deeply $o.keys.sort, (10, 20).Seq, 'multiple Int object keys';
+    is $o.elems, 2, 'two elements';
+}
+
+# BagHash weight still works with an object key
+{
+    my $b = BagHash.new;
+    $b{7} = 3;
+    is $b{7}, 3, 'BagHash weight retained for object key';
+}


### PR DESCRIPTION
## Summary

Assigning a non-string object as a `SetHash`/`BagHash`/`MixHash` key stringified it, so `.keys`/`.raku` returned the string instead of the object:

```
my $o = SetHash.new; my $i = 1001; $o{$i} = 42; $i++;
$o.keys;          # was ("1001",) — now (1001,)
$o.keys[0].WHAT   # was (Str) — now (Int)
```

Set/Bag/Mix store keys stringified alongside an `original_keys` side table to recover the object (already used when constructing from mixed-type data), but the element-store path never populated it. Now the original key is recorded there for non-string subscripts, and dropped when the element is removed. String keys are unaffected.

## Impact
Fixes the `SetHash/BagHash/MixHash retains object, not container` subtests in `roast/S02-types/sethash.t` (5 → 1 failing; the remaining one is an unrelated `$sh<key>++` semantics issue).

The bare-autoviv path (`my SetHash $sh; $sh{1001}=1`) still stringifies — its constructors drop the declared type, so it's left as a follow-up.

## Test
- New `t/quanthash-object-keys.t` (14 assertions), cross-checked against `raku`.
- `make test` passes (15073 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)