### PR TITLE
fix(subst): call a Callable replacement when the pattern is a plain string

### DIFF
--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -522,14 +522,53 @@ impl Interpreter {
                     for &idx in &keep {
                         let (start, end) = str_matches[idx];
                         result.push_str(&text[last_end..start]);
-                        result.push_str(&transforms.apply(&replacement_str, &text[start..end]));
+                        let matched_text = &text[start..end];
+                        let caps = is_closure.then(|| RegexCaptures {
+                            matched: matched_text.to_string(),
+                            from: char_indices[idx].0,
+                            to: char_indices[idx].1,
+                            ..Default::default()
+                        });
+                        let repl = self.eval_subst_replacement_cased(
+                            &replacement_val,
+                            is_closure,
+                            &replacement_str,
+                            matched_text,
+                            caps.as_ref(),
+                            Some(&text),
+                            transforms,
+                        )?;
+                        result.push_str(&repl);
                         last_end = end;
                     }
                     result.push_str(&text[last_end..]);
                     Ok(Value::str(result))
+                } else if let Some(bpos) = text.find(pat.as_str()) {
+                    // Single (first-match) replacement.
+                    let end = bpos + pat.as_str().len();
+                    let matched_text = &text[bpos..end];
+                    let caps = is_closure.then(|| RegexCaptures {
+                        matched: matched_text.to_string(),
+                        from: text[..bpos].chars().count(),
+                        to: text[..end].chars().count(),
+                        ..Default::default()
+                    });
+                    let repl = self.eval_subst_replacement_cased(
+                        &replacement_val,
+                        is_closure,
+                        &replacement_str,
+                        matched_text,
+                        caps.as_ref(),
+                        Some(&text),
+                        transforms,
+                    )?;
+                    let mut result = String::with_capacity(text.len());
+                    result.push_str(&text[..bpos]);
+                    result.push_str(&repl);
+                    result.push_str(&text[end..]);
+                    Ok(Value::str(result))
                 } else {
-                    let repl = transforms.apply(&replacement_str, pat.as_str());
-                    Ok(Value::str(text.replacen(pat.as_str(), &repl, 1)))
+                    Ok(Value::str(text))
                 }
             }
             _ => {

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -102,6 +102,18 @@ impl Interpreter {
             self.env.insert("$_".to_string(), match_val.clone());
             self.env.insert("_".to_string(), match_val);
         }
+        // A pointy replacement block (`-> $m { $m.uc }`) receives the match as its
+        // argument, not just via the `$_` topic. Bind its first parameter to the
+        // current topic (the match, set just above) so an explicit signature works.
+        if let Some(first) = sub_data.params.first() {
+            let pname = first.trim_start_matches(['$', '@', '%', '&']);
+            if !pname.is_empty()
+                && pname != "_"
+                && let Some(topic) = self.env.get("_").cloned()
+            {
+                self.env.insert(pname.to_string(), topic);
+            }
+        }
         let result = self.eval_block_value(&sub_data.body).unwrap_or(Value::Nil);
         // Propagate the block's writes to its closed-over lexicals back to the
         // caller before restoring the outer env, skipping the injected

--- a/t/subst-string-pattern-closure.t
+++ b/t/subst-string-pattern-closure.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 12;
+
+# `.subst` with a *string* (literal) pattern and a Callable replacement used to
+# drop the match (replacing with the empty string) because the string-pattern
+# path never invoked the closure. It must call the closure with the match, like
+# the regex-pattern path.
+
+is "abcabc".subst("a", *.uc, :g),        'AbcAbc',   'WhateverCode replacement, :g';
+is "abc".subst("b", *.uc),               'aBc',      'WhateverCode replacement, single';
+is "hello".subst("l", *.uc, :g),         'heLLo',    'WhateverCode replacement over repeats';
+is "abcabc".subst("a", { "X" }, :g),     'XbcXbc',   'block replacement ignoring the match';
+is "abcabc".subst("a", { $_.uc }, :g),   'AbcAbc',   'block replacement using $_';
+is "abcabc".subst("a", -> $m { $m.uc }, :g), 'AbcAbc', 'pointy block replacement binds its parameter';
+is "hello world".subst("o", { "0" }, :g), 'hell0 w0rld', 'block replacement, multiple matches';
+
+# a plain string replacement still works
+is "aaa".subst("a", "b", :g),            'bbb',      'plain string replacement, :g';
+is "abc".subst("a", "X"),                'Xbc',      'plain string replacement, single';
+
+# no match leaves the string unchanged
+is "test".subst("x", *.uc),              'test',     'no match leaves the string unchanged';
+
+# the pointy-parameter fix also applies to the regex-pattern path
+is "abcabc".subst(/a/, -> $m { $m.uc }, :g), 'AbcAbc', 'regex pattern with pointy replacement';
+is "a1b2".subst(/(\d)/, -> $m { $m[0] + 10 }, :g), 'a11b12', 'regex pointy replacement sees captures';


### PR DESCRIPTION
## What

`.subst` with a **string** (literal) pattern and a Callable replacement dropped the match instead of calling the closure:

```
"abcabc".subst("a", *.uc, :g)          # was "bcbc"  → now "AbcAbc"
"abcabc".subst("a", { "X" }, :g)       # was "bcbc"  → now "XbcXbc"
"abc".subst("b", *.uc)                 # was "ac"    → now "aBc"
```

## Root cause & fix

The string-pattern branch of `dispatch_subst` always used the static `replacement_str`, which is empty for a Callable replacement — it never invoked the closure. Only the regex-pattern branch did.

Route the string-pattern branch (both the single and `:g`/adverb paths) through the same `eval_subst_replacement_cased` helper, passing a synthetic `RegexCaptures` (matched text + char offsets) so `$_`/`$/` are the match and a `WhateverCode`/block/pointy replacement is called per match.

While there, fix a latent bug in that helper that affected the **regex path too**: a pointy replacement block (`-> $m { $m.uc }`) never had its parameter bound, so `$m` was undefined and produced the empty string. Bind the block's first parameter to the match (the topic) before running the body:

```
"abcabc".subst(/a/, -> $m { $m.uc }, :g)   # was "bcbc" → now "AbcAbc"
```

## Safety

Verified against rakudo across WhateverCode / block / `$_` / pointy replacements, single and `:g`, plain-string replacements, and no-match. `make test` passes; all 505 whitelisted `S02`/`S03`/`S04`/`S05`/`S32-str` files show no real subtest failures (the 3 `gb2312`/`gb18030`/`shiftjis` encode-decode files are a local-harness `$test-folder` artifact — they pass under `scripts/run-roast-test.sh` and fail identically on `main`).

Regression test: `t/subst-string-pattern-closure.t` (12 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)