### PR TITLE
fix(parser): my @a.[2] = 42 applies the postcircumfix to the declared variable

### DIFF
--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -82,6 +82,58 @@ pub(super) fn my_decl_assign_or_default(input: &str, s: MyDeclState) -> PResult<
         return handle_method_call_assign(stripped, s);
     }
 
+    // Dotted postcircumfix on the just-declared variable:
+    // `my @a.[2] = 42` / `my @a.{k} = v` is `(my @a).[2] = 42` — it just calls
+    // `postcircumfix:<[ ]>`, no shaped array is created. Declare the variable and
+    // apply the subscript (assignment) in a scopeless SyntheticBlock so the
+    // declaration lands in the enclosing scope. Handles the unspace form too
+    // (`my @a\  .[2]`).
+    {
+        let after_unspace = rest.strip_prefix('\\').map(str::trim_start).unwrap_or(rest);
+        if after_unspace.starts_with(".[")
+            || after_unspace.starts_with(".{")
+            || after_unspace.starts_with(".<")
+        {
+            let base = Expr::Var(s.name.clone());
+            let (r2, lhs) = super::super::super::expr::postfix_expr_continue(rest, base)?;
+            let (r2, _) = ws(r2)?;
+            let decl_expr = default_decl_expr(
+                s.is_array,
+                s.is_hash,
+                s.shape_dims.as_deref(),
+                s.type_constraint.as_deref(),
+            );
+            let decl = Stmt::VarDecl {
+                name: s.name.clone(),
+                expr: decl_expr,
+                type_constraint: s.type_constraint.clone(),
+                is_state: s.is_state,
+                is_our: s.is_our,
+                is_dynamic: s.has_dynamic_trait,
+                is_export: s.has_export_trait,
+                export_tags: s.export_tags.clone(),
+                custom_traits: s.custom_traits.clone(),
+                where_constraint: s.where_constraint.clone(),
+            };
+            let (r3, tail_expr) =
+                if r2.starts_with('=') && !r2.starts_with("==") && !r2.starts_with("=>") {
+                    let (r, _) = ws(&r2[1..])?;
+                    let (r, rhs) = parse_assign_expr_or_comma(r)?;
+                    (
+                        r,
+                        crate::parser::expr::precedence::assign_to_target_expr(lhs, rhs),
+                    )
+                } else {
+                    (r2, lhs)
+                };
+            let block = Stmt::SyntheticBlock(vec![decl, Stmt::Expr(tail_expr)]);
+            if s.apply_modifier {
+                return parse_statement_modifier(r3, block);
+            }
+            return Ok((r3, block));
+        }
+    }
+
     // Binding := or ::=
     if let Some(stripped) = rest.strip_prefix("::=").or_else(|| rest.strip_prefix(":=")) {
         return handle_binding(stripped, s);

--- a/t/my-decl-dotted-postcircumfix.t
+++ b/t/my-decl-dotted-postcircumfix.t
@@ -1,0 +1,54 @@
+use Test;
+
+# `my @a.[2] = 42` is `(my @a).[2] = 42`: the dotted postcircumfix applies to
+# the just-declared variable (no shaped array is created). mutsu previously
+# dropped the `.[2] = 42`, parsing it as a separate `$_.[2] = 42` statement and
+# leaving `@a` empty.
+
+plan 10;
+
+{
+    my @arr1.[2] = 42;
+    is-deeply @arr1, [Any, Any, 42], 'my @a.[2] = 42 assigns the declared array';
+}
+{
+    my @arr2\  .[2] = "foo";
+    is-deeply @arr2, [Any, Any, "foo"], 'unspace form my @a\ .[2] = ...';
+}
+{
+    my @a.[0] = 1;
+    is-deeply @a, [1], 'index 0';
+}
+{
+    my %h.<k> = 5;
+    is-deeply %h, {k => 5}, 'dotted hash postcircumfix .<k>';
+}
+{
+    my %h2.{"x"} = 9;
+    is %h2<x>, 9, 'dotted hash postcircumfix .{...}';
+}
+
+# The variable really lands in the enclosing scope (not a nested block)
+{
+    my @a.[1] = 7;
+    @a[3] = 9;
+    is-deeply @a, [Any, 7, Any, 9], 'declared @a is usable afterwards';
+}
+
+# Plain and shaped declarations are unaffected
+{
+    my @a = 1, 2, 3;
+    is-deeply @a, [1, 2, 3], 'plain array decl unaffected';
+}
+{
+    my @a[3] = 1, 2, 3;
+    is @a.shape.gist, '(3)', 'shaped decl (bracket) unaffected';
+}
+{
+    my %h = a => 1;
+    is %h<a>, 1, 'plain hash decl unaffected';
+}
+{
+    my $x = 5;
+    is $x, 5, 'scalar decl unaffected';
+}


### PR DESCRIPTION
## Summary

`my @a.[2] = 42` is `(my @a).[2] = 42` — the dotted postcircumfix subscripts the just-declared variable (raku: *"just calls &postcircumfix:<[ ]>, no shaped array is created"*). mutsu dropped the `.[2] = 42`, declaring an empty `@a` and parsing the tail as a separate `$_.[2] = 42` statement:

```
my @a.[2] = 42; say @a.raku    # was [] — now [Any, Any, 42]
```

After a `my @a`/`my %h` declaration, a following `.[...]`/`.{...}`/`.<...>` (including the unspace form `my @a\ .[2]`) is now recognized and emitted as a scopeless `SyntheticBlock` of the declaration plus the subscript assignment on the declared variable, so it lands in the enclosing scope.

## Impact
Fixes the "dotted form" subtests in `roast/S02-types/array-shapes.t` (15 → 13 failing; the rest are unrelated shaped-array blockers).

## Test
- New `t/my-decl-dotted-postcircumfix.t` (10 assertions), cross-checked against `raku` (includes the unspace form, `.{...}`/`.<...>` hash forms, and regression checks that plain/shaped/scalar declarations are unaffected).
- `make test` passes (15089 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)