### PR TITLE
fix(hyper): »++/»-- on a subscript slice writes back (and post-increments)

### DIFF
--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -444,6 +444,35 @@ impl Compiler {
         modifier: &Option<char>,
         quoted: bool,
     ) {
+        // A mutating hyper postfix on a subscript/slice (`%h<a b c>»++`,
+        // `@a[0,1]»--`) has no simple `@`/`%` variable name for the generic hyper
+        // path to write back through, so the in/decremented values were computed
+        // and discarded. Desugar it to a post-increment: read the OLD slice, then
+        // mutate it in place through the working `»+=»`/`»-=»` metaop, and leave
+        // the OLD values as the expression result.
+        let resolved = name.resolve();
+        if args.is_empty()
+            && modifier.is_none()
+            && matches!(resolved.as_str(), "postfix:<++>" | "postfix:<-->")
+            && matches!(target, Expr::Index { .. })
+        {
+            let op = if resolved == "postfix:<++>" {
+                "+="
+            } else {
+                "-="
+            };
+            let mutate = Expr::HyperOp {
+                op: op.to_string(),
+                left: Box::new(target.clone()),
+                right: Box::new(Expr::Literal(Value::Int(1))),
+                dwim_left: false,
+                dwim_right: true,
+            };
+            self.compile_expr(target); // OLD slice values (post-increment result)
+            self.compile_expr(&mutate); // mutate in place, pushes NEW
+            self.code.emit(OpCode::Pop); // discard NEW, keep OLD
+            return;
+        }
         self.compile_expr(target);
         let arity = args.len() as u32;
         for arg in args {

--- a/t/hyper-postfix-slice.t
+++ b/t/hyper-postfix-slice.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 12;
+
+# A mutating hyper postfix (`»++` / `»--`) applied to a subscript/slice used to
+# compute the in/decremented values and throw them away, leaving the container
+# unchanged. It must write back to each sliced element (autovivifying), and — as
+# a post-increment — yield the OLD values.
+
+# --- hash slice ---
+{
+    my %h;
+    %h<a b c>»++;
+    is-deeply %h.sort.list, (a => 1, b => 1, c => 1), 'hash-slice »++ autovivifies to 1';
+}
+{
+    my %h = a => 1, b => 2;
+    %h<a b>»++;
+    is-deeply %h.sort.list, (a => 2, b => 3), 'hash-slice »++ increments existing values';
+}
+{
+    my %h = a => 5, b => 10;
+    my @old = %h<a b>»++;
+    is-deeply @old, [5, 10], 'hash-slice »++ returns the OLD values (post-increment)';
+    is-deeply %h.sort.list, (a => 6, b => 11), '...and the hash is mutated';
+}
+{
+    my %h = a => 3, b => 3;
+    %h<a b>»--;
+    is-deeply %h.sort.list, (a => 2, b => 2), 'hash-slice »-- decrements';
+}
+
+# --- array slice ---
+{
+    my @a;
+    @a[0, 1, 2]»++;
+    is-deeply @a, [1, 1, 1], 'array-slice »++ autovivifies';
+}
+{
+    my @a = 1, 2, 3;
+    my @old = @a[0, 1]»++;
+    is-deeply @old, [1, 2], 'array-slice »++ returns the OLD values';
+    is-deeply @a, [2, 3, 3], '...and the array is mutated';
+}
+{
+    my @a = 5, 5;
+    @a[0, 1]»--;
+    is-deeply @a, [4, 4], 'array-slice »-- decrements';
+}
+{
+    my @a = 1, 2, 3;
+    @a[*]»++;
+    is-deeply @a, [2, 3, 4], 'whatever-slice »++ increments every element';
+}
+
+# --- whole-container and single-element forms are unaffected ---
+{
+    my @a = 1, 2, 3;
+    @a»++;
+    is-deeply @a, [2, 3, 4], 'whole-array »++ still works';
+}
+{
+    my %h;
+    %h<a>++;
+    is-deeply %h, {a => 1}, 'single-element ++ still works';
+}


### PR DESCRIPTION
## What

A mutating hyper postfix (`»++` / `»--`) on a subscript/slice silently left the container unchanged:

```
my %h; %h<a b c>»++;   # was {} → now {a => 1, b => 1, c => 1}
my @a; @a[0,1,2]»++;   # was [] → now [1, 1, 1]
```

## Root cause & fix

The hyper method path writes a mutating result back only through a plain `@`/`%` variable name (`@a»++` works). A slice target (`Expr::Index`) has no such name, so the in/decremented values were computed and discarded. (`%h<a b c> »+=» 1` already worked — that metaop writes back to the slice.)

Desugar a mutating hyper postfix on a subscript into a proper **post-increment** in the compiler: read the OLD slice, mutate it in place through the working `»+=»` / `»-=»` path, and leave the OLD values as the expression result:

```
say @a[0,1]»++;          # (1 2), then @a is [2 3 3]
my @old = %h<a b>»++;    # @old = [5 10], hash mutated to a=>6 b=>11
```

The whole-container (`@a»++`) and single-element (`%h<a>++`) forms are untouched.

## Safety

Verified against rakudo for autoviv, existing values, post-increment return, `»--`, and whatever-slices (`@a[*]»++`). `make test` passes; all 359 whitelisted `S02`/`S03-metaops`/`S03-operators`/`S09`/`S12`/`S32-array` files stay green.

Regression test: `t/hyper-postfix-slice.t` (12 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)