### PR TITLE
fix(shape): a BigInt shaped-array dimension throws X::IllegalDimensionInShape

### DIFF
--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -21,6 +21,7 @@ impl Interpreter {
         } else {
             match shape_val {
                 Value::Int(i) => vec![Value::Int(i)],
+                Value::BigInt(ref n) => vec![Value::BigInt(n.clone())],
                 Value::Package(ref name) => {
                     // Enum type as shape: use the number of enum variants
                     if let Some(variants) = self.registry().enum_types.get(&name.resolve()) {
@@ -45,6 +46,11 @@ impl Interpreter {
                 Value::Num(f) if *f > 0.0 => *f as usize,
                 Value::Num(f) => {
                     return Err(RuntimeError::illegal_dimension_in_shape(*f as i64));
+                }
+                // A dimension that overflows i64 (parsed as a BigInt) is always
+                // illegal: either negative, or far too large to allocate.
+                Value::BigInt(n) => {
+                    return Err(RuntimeError::illegal_dimension_in_shape_bigint(n.as_ref()));
                 }
                 Value::Package(name) => {
                     if let Some(variants) = self.registry().enum_types.get(&name.resolve()) {

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -330,6 +330,20 @@ impl RuntimeError {
         Self::typed("X::IllegalDimensionInShape", attrs)
     }
 
+    /// Like `illegal_dimension_in_shape`, but for a dimension that does not fit
+    /// in `i64` (`my @a[99999999999999999999]`, or `-9223372036854775808` which
+    /// parses as a BigInt): keep the exact value in the message.
+    pub(crate) fn illegal_dimension_in_shape_bigint(dim: &num_bigint::BigInt) -> Self {
+        let msg = format!(
+            "Illegal dimension in shape: {}. All dimensions must be integers bigger than 0",
+            dim
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert("dim".to_string(), Value::bigint(dim.clone()));
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::IllegalDimensionInShape", attrs)
+    }
+
     /// X::Adverb - Unsupported adverb combination on subscript access
     pub(crate) fn x_adverb(
         what: &str,

--- a/t/shape-illegal-dimension-bigint.t
+++ b/t/shape-illegal-dimension-bigint.t
@@ -1,0 +1,30 @@
+use Test;
+
+# A shaped-array dimension that overflows i64 (parsed as a BigInt) must throw
+# X::IllegalDimensionInShape, like small illegal dims. `-9223372036854775808`
+# parses as a BigInt (the unsigned literal overflows i64 before negation), and a
+# huge positive dimension is unallocatable.
+
+plan 8;
+
+throws-like 'my @a[0]', X::IllegalDimensionInShape, 'zero dimension';
+throws-like 'my @a[-5]', X::IllegalDimensionInShape, 'small negative dimension';
+throws-like 'my @a[-9223372036854775808,-2]', X::IllegalDimensionInShape,
+    'i64::MIN (BigInt) dimension, multi-dim';
+throws-like 'my @a[99999999999999999999]', X::IllegalDimensionInShape,
+    'huge positive BigInt dimension';
+throws-like 'my @a[-99999999999999999999]', X::IllegalDimensionInShape,
+    'huge negative BigInt dimension';
+
+# The message keeps the exact (BigInt) value
+my $msg;
+{ my @a[99999999999999999999]; CATCH { default { $msg = .message } } }
+is $msg, 'Illegal dimension in shape: 99999999999999999999. All dimensions must be integers bigger than 0',
+    'exact BigInt value in the message';
+
+# Valid dimensions still work
+lives-ok { my @a[3]; @a[0] = 1 }, 'valid dimension lives';
+{
+    my @a[2; 3];
+    is @a.shape.gist, '(2 3)', 'valid multi-dim shape';
+}


### PR DESCRIPTION
## Summary

`shaped_dims_from_new_args` only checked `Int`/`Num` dimensions; a dimension that overflows i64 (parsed as a `BigInt`) fell through to "not a shape", so these silently did nothing instead of throwing:

```
my @a[-9223372036854775808,-2]   # unsigned literal overflows i64 before negation
my @a[99999999999999999999]      # too large to allocate
```

Now any `BigInt` dimension is treated as illegal (negative, or unallocatably large) and raises `X::IllegalDimensionInShape` via a new BigInt-aware constructor that keeps the exact value in the message (`Illegal dimension in shape: 99999999999999999999. ...`).

## Impact
Fixes the `X::IllegalDimensionInShape` subtest in `roast/S02-types/array-shapes.t`.

## Test
- New `t/shape-illegal-dimension-bigint.t` (8 assertions), cross-checked against `raku` (zero/small-negative/i64::MIN/huge-positive/huge-negative dims, exact message, and valid dims still work).
- `make test` passes (15115 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)