### PR TITLE
fix(incdec): ++/-- on a WhateverCode-indexed element writes back

### DIFF
--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -401,8 +401,16 @@ impl Interpreter {
             .as_deref()
             .is_some_and(|t| t == "SetHash");
         let idx_val = self.stack.pop().unwrap_or(Value::Nil);
-        let key = idx_val.to_string_value();
         let container = self.get_env_with_main_alias(&name);
+        // Resolve a WhateverCode / Whatever index (`@a[*-1]++`, `@a[*-2]--`)
+        // against the container's length before using it as the key — otherwise
+        // the raw closure stringifies to a bogus key and the increment is lost.
+        let idx_val = if matches!(idx_val, Value::Sub(_) | Value::Whatever) {
+            self.resolve_whatever_index_for_target(idx_val, container.as_ref())
+        } else {
+            idx_val
+        };
+        let key = idx_val.to_string_value();
         // `$c[0]++` / `$c<a>++` on a Capture: when the element is a shared
         // `ContainerRef` cell (built from `\($a)` / `\(:$a)`), increment *through*
         // the cell so the original variable observes the change. The generic

--- a/t/incdec-whatever-index.t
+++ b/t/incdec-whatever-index.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 11;
+
+# `++`/`--` on a subscript with a WhateverCode index (`@a[*-1]++`) used to
+# stringify the raw closure into a bogus key and lose the update. The index must
+# be resolved against the container length first, like the `+=` path already did.
+
+{
+    my @a = 1, 2, 3;
+    @a[*-1]++;
+    is-deeply @a, [1, 2, 4], 'postfix ++ on @a[*-1] increments the last element';
+}
+{
+    my @a = 1, 2, 3;
+    @a[*-2]++;
+    is-deeply @a, [1, 3, 3], '@a[*-2]++ targets the correct element';
+}
+{
+    my @a = 1, 2, 3;
+    ++@a[*-1];
+    is-deeply @a, [1, 2, 4], 'prefix ++ on @a[*-1] increments';
+}
+{
+    my @a = 1, 2, 3;
+    @a[*-1]--;
+    is-deeply @a, [1, 2, 2], 'postfix -- on @a[*-1] decrements';
+}
+{
+    my @a = 1, 2, 3;
+    my $old = @a[*-1]++;
+    is $old, 3, 'postfix ++ returns the OLD value';
+    is-deeply @a, [1, 2, 4], '...and mutates the element';
+}
+{
+    my @a = 5, 5, 5;
+    @a[*-1]++ for 1 .. 3;
+    is-deeply @a, [5, 5, 8], 'repeated @a[*-1]++ accumulates';
+}
+{
+    my @a = 1, 2, 3;
+    my $i = *-1;
+    @a[$i]++;
+    is-deeply @a, [1, 2, 4], 'a WhateverCode stored in a variable also resolves';
+}
+
+# a literal index and a hash key are unaffected
+{
+    my @a = 1, 2, 3;
+    @a[2]++;
+    is-deeply @a, [1, 2, 4], 'literal index ++ still works';
+}
+{
+    my %h = a => 1;
+    %h<a>++;
+    is-deeply %h, {a => 2}, 'hash-key ++ still works';
+}
+{
+    my @a = 1, 2, 3;
+    @a[0]++;
+    is-deeply @a, [2, 2, 3], 'first-element ++ still works';
+}


### PR DESCRIPTION
## What

`@a[*-1]++` (and `@a[*-2]--`, prefix `++@a[*-1]`, a `*-1` stored in a variable) left the array unchanged:

```
my @a = 1, 2, 3;
@a[*-1]++;   # was [1, 2, 3] → now [1, 2, 4]
```

## Root cause & fix

`exec_inc_dec_index_op` popped the index and used `idx_val.to_string_value()` directly as the key. For a WhateverCode index (`*-1`) that stringifies the raw closure into a bogus key, so the increment landed on a non-existent slot and was lost. A literal index (`@a[2]++`) worked, and the `@a[*-1] += 10` metaop path already resolved the closure.

Resolve a `WhateverCode`/`Whatever` subscript against the container via the existing `resolve_whatever_index_for_target` before computing the key. Now `@a[*-1]++` targets the last element — for both prefix and postfix, `++` and `--`, returning the OLD value as a post-increment (`say @a[*-1]++` → `3`). Literal indices and hash keys are untouched.

## Safety

Verified against rakudo: postfix/prefix, `++`/`--`, `*-2`, repeated increment, a WhateverCode bound to a variable, and the unaffected literal-index / hash-key / first-element forms. `make test` passes; all 405 whitelisted `S02`/`S03`/`S09`/`S12`/`S32-array` files stay green.

Regression test: `t/incdec-whatever-index.t` (11 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)