### PR TITLE
fix(array): .pairs .value= writeback keeps the array's kind (not a List)

### DIFF
--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -338,7 +338,13 @@ impl Interpreter {
                     return Ok(value);
                 }
                 let mut selected_hash: Option<crate::gc::Gc<crate::value::HashData>> = None;
-                let mut selected_array: Option<crate::gc::Gc<crate::value::ArrayData>> = None;
+                // Track the source array's `ArrayKind` so the rebuilt array keeps
+                // its Array/Shaped identity (`for @a.pairs { .value = X }` must not
+                // demote `@a` to a bare List).
+                let mut selected_array: Option<(
+                    crate::gc::Gc<crate::value::ArrayData>,
+                    ArrayKind,
+                )> = None;
 
                 if let Some(var_name) = target_var
                     && let Some(Value::Hash(candidate)) = self.env.get(var_name)
@@ -349,10 +355,10 @@ impl Interpreter {
                 if selected_hash.is_none()
                     && let Ok(i) = key.parse::<usize>()
                     && let Some(var_name) = target_var
-                    && let Some(Value::Array(candidate, ..)) = self.env.get(var_name)
+                    && let Some(Value::Array(candidate, kind)) = self.env.get(var_name)
                     && candidate.get(i) == Some(current_value.as_ref())
                 {
-                    selected_array = Some(candidate.clone());
+                    selected_array = Some((candidate.clone(), *kind));
                 }
 
                 if selected_hash.is_none() {
@@ -376,13 +382,13 @@ impl Interpreter {
                     && let Ok(i) = key.parse::<usize>()
                 {
                     let mut candidates = self.env.values().filter_map(|bound| match bound {
-                        Value::Array(arr, ..) if arr.get(i) == Some(current_value.as_ref()) => {
-                            Some(arr.clone())
+                        Value::Array(arr, kind) if arr.get(i) == Some(current_value.as_ref()) => {
+                            Some((arr.clone(), *kind))
                         }
                         _ => None,
                     });
                     if let Some(first) = candidates.next()
-                        && candidates.all(|other| crate::gc::Gc::ptr_eq(&first, &other))
+                        && candidates.all(|(other, _)| crate::gc::Gc::ptr_eq(&first.0, &other))
                     {
                         selected_array = Some(first);
                     }
@@ -395,14 +401,15 @@ impl Interpreter {
                     self.overwrite_hash_bindings_by_identity(&source_hash, replacement);
                     return Ok(value);
                 }
-                if let Some(source_array) = selected_array
+                if let Some((source_array, source_kind)) = selected_array
                     && let Ok(i) = key.parse::<usize>()
                 {
                     let mut updated = (*source_array).clone();
                     if i < updated.len() {
                         updated[i] = value.clone();
-                        let replacement =
-                            Value::Array(crate::gc::Gc::new(updated), ArrayKind::List);
+                        // Preserve the source array's kind (Array/Shaped/…) so the
+                        // writeback does not demote it to a List.
+                        let replacement = Value::Array(crate::gc::Gc::new(updated), source_kind);
                         self.overwrite_array_bindings_by_identity(&source_array, replacement);
                         return Ok(value);
                     }

--- a/t/pairs-value-writeback-array-kind.t
+++ b/t/pairs-value-writeback-array-kind.t
@@ -1,0 +1,41 @@
+use Test;
+
+# `for @a.pairs -> $p { $p.value = X }` writes through to the array element, but
+# must NOT demote the array to a List: the rebuilt array keeps its Array /
+# Shaped / typed identity (previously it became a bare `(...)` List).
+
+plan 7;
+
+{
+    my @a = 1, 2, 3;
+    for @a.pairs -> $p { $p.value = 42 }
+    is-deeply @a, [42, 42, 42], 'plain array stays an Array';
+}
+{
+    my @a = 1, 2, 3;
+    for @a.pairs -> $p { $p.value = $p.value * 10 }
+    is-deeply @a, [10, 20, 30], 'computed writeback stays an Array';
+}
+{
+    my @a[3];
+    for @a.pairs -> $p { $p.value = 7 }
+    is @a.raku, 'Array.new(:shape(3,), [7, 7, 7])', '1D shaped array keeps its shape';
+    is @a.shape.gist, '(3)', 'shape preserved';
+}
+{
+    my Int @a = 1, 2, 3;
+    for @a.pairs -> $p { $p.value = 9 }
+    is @a.WHAT.gist, '(Array[Int])', 'typed array keeps its element type';
+}
+{
+    # only the touched index changes
+    my @a = 10, 20, 30;
+    for @a.pairs -> $p { $p.value = $p.value + 1 if $p.key == 1 }
+    is-deeply @a, [10, 21, 30], 'selective writeback';
+}
+# hash .pairs writeback still works
+{
+    my %h = a => 1, b => 2;
+    for %h.pairs -> $p { $p.value = 9 }
+    is-deeply %h, {a => 9, b => 9}, 'hash .pairs writeback unaffected';
+}


### PR DESCRIPTION
## Summary

`for @a.pairs -> $p { $p.value = X }` (and `.value = X for @a.pairs`) writes the new value back to the element by rebuilding the source array — but it hardcoded `ArrayKind::List`, demoting a plain/typed/shaped array to a bare `(...)` List:

```
my @a = 1,2,3; for @a.pairs -> $p { $p.value = 42 }; @a   # was (42,42,42) — now [42,42,42]
my @a[3];      for @a.pairs -> $p { $p.value = 42 }; @a   # keeps its shape: Array.new(:shape(3,), [42,42,42])
my Int @a = 1,2,3; ...                                    # keeps Array[Int]
```

Capture the source array's `ArrayKind` alongside its data and reuse it when rebuilding — matching the `.values` / `for @a { $_ = X }` writeback which already preserves the kind.

## Test
- New `t/pairs-value-writeback-array-kind.t` (7 assertions), cross-checked against `raku` (plain/typed/shaped arrays, computed & selective writeback, hash `.pairs` unaffected).
- `make test` passes (15125 tests).

Relates to `roast/S02-types/array-shapes.t` (the 1D shaped `.pairs`-writeback case; the remaining test-31 failure is a separate multi-dim-view writeback gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)