### PR TITLE
fix(bind): array element bind-autoviv fills gaps with Any, not Nil

### DIFF
--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -44,8 +44,19 @@ impl Value {
             // `arc_contents_mut`. No borrow into the items is live across the
             // growth/promotion below.
             let data = unsafe { crate::value::gc_contents_mut(arc) };
+            // Autovivifying past the end fills the gap with the element's type
+            // object (`Any`, or the declared element type / `is default` value),
+            // matching Raku — `my @a; my $r := @a[5]; $r = 1` yields
+            // `[Any, Any, Any, Any, Any, 1]`, not `Nil` holes.
+            let hole = data
+                .default
+                .as_ref()
+                .map(|d| (**d).clone())
+                .unwrap_or_else(|| {
+                    Value::Package(Symbol::intern(data.value_type.as_deref().unwrap_or("Any")))
+                });
             while data.len() <= idx {
-                data.push(Value::Nil);
+                data.push(hole.clone());
             }
             let elem = &mut data[idx];
             if let Value::ContainerRef(cell) = elem {

--- a/t/bind-autoviv-hole-fill.t
+++ b/t/bind-autoviv-hole-fill.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 8;
+
+# Binding a scalar to a not-yet-existing array element (`my $r := @a[5]`) and
+# assigning through it autovivifies the array. The gap it opens must be filled
+# with the element's type object (`Any`, or the declared element type), matching
+# Raku — not `Nil`.
+
+{
+    my @a;
+    my $r := @a[5];
+    $r = 1;
+    is-deeply @a, [Any, Any, Any, Any, Any, 1], 'bind-autoviv past the end fills Any holes';
+}
+{
+    my @a = 1, 2;
+    my $r := @a[5];
+    $r = 9;
+    is-deeply @a, [1, 2, Any, Any, Any, 9], 'bind-autoviv keeps existing elements, fills Any';
+}
+{
+    my @a;
+    my $r := @a[2];
+    $r = 1;
+    is @a[0].WHAT.^name, 'Any', 'a hole is the Any type object';
+    nok @a[0].defined, 'a hole is undefined';
+}
+{
+    my Int @a;
+    my $r := @a[3];
+    $r = 5;
+    is @a[0].WHAT.^name, 'Int', 'a typed array fills holes with its element type';
+    is-deeply @a[0 .. 2].map(*.^name), ('Int', 'Int', 'Int'), 'all holes are the element type';
+}
+# an ordinary autovivifying assignment is unchanged
+{
+    my @a;
+    @a[5] = 1;
+    is-deeply @a, [Any, Any, Any, Any, Any, 1], 'plain @a[5] = 1 still fills Any';
+}
+# binding to an existing element still writes through
+{
+    my @a = 1, 2, 3;
+    my $r := @a[1];
+    $r = 99;
+    is-deeply @a, [1, 99, 3], 'binding an existing element writes through';
+}


### PR DESCRIPTION
## What

Binding a scalar to a not-yet-existing array element and assigning through it filled the gap with `Nil` instead of Raku's `Any`:

```
my @a; my $r := @a[5]; $r = 1;
say @a.raku;   # was [Nil, Nil, Nil, Nil, Nil, 1] → now [Any, Any, Any, Any, Any, 1]
```

## Root cause & fix

`array_slot_ref` — the `:=` element-bind / autovivification path — grew the backing vector by pushing `Value::Nil` for each gap slot. The ordinary `@a[5] = 1` autoextension already fills `Any`.

Fill the gap with the element's **type object** instead: the declared element type for a typed array (`my Int @a` → `Int` holes), the `is default` value when one is set, or `Any` otherwise. Binding to an existing element is unchanged.

## Safety

Verified against rakudo for untyped, pre-populated, typed (`Array[Int]`), and default arrays, plus the unaffected plain-assignment and existing-element paths. `make test` passes; all 482 whitelisted `S02`/`S03`/`S04`/`S09`/`S12`/`S32-array` files stay green.

Regression test: `t/bind-autoviv-hole-fill.t` (8 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)