### PR TITLE
fix(setbagmix): SetHash element ++/--/assign use Bool existence semantics

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -168,6 +168,7 @@ roast/S02-types/range.t
 roast/S02-types/resolved-in-setting.t
 roast/S02-types/set-iterator.t
 roast/S02-types/set.t
+roast/S02-types/sethash.t
 roast/S02-types/sigils-and-types.t
 roast/S02-types/signed-unsigned-native.t
 roast/S02-types/stash.t

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -246,6 +246,10 @@ impl Interpreter {
             .as_deref()
             .unwrap_or(&original_var_name)
             .to_string();
+        // A SetHash element assignment evaluates to the key's Bool existence, not
+        // the assigned value (`$sh<k> = 2` is `Bool::True`); set in the Set store
+        // arm and applied at the final result push.
+        let mut setty_bool_result: Option<Value> = None;
         // §1.4 shadow-slot: the compiler-baked slot is valid only for the
         // target's own name (`original_var_name`). If a sigilless alias redirects
         // to a DIFFERENT variable, the baked slot no longer applies — fall back to
@@ -1438,7 +1442,14 @@ impl Interpreter {
                             _ => unreachable!(),
                         };
                         self.env_mut().insert(var_name.clone(), new_container);
-                        self.stack.push(val);
+                        // A SetHash element assignment evaluates to the key's Bool
+                        // existence (`$sh<k> = 2` is `Bool::True`), not the RHS.
+                        let result = if type_name == "SetHash" {
+                            Value::Bool(val.truthy())
+                        } else {
+                            val.clone()
+                        };
+                        self.stack.push(result);
                         // Update local slot
                         if let Some(new_val) = self.env().get(&var_name).cloned() {
                             self.write_local_slot_or_name(code, eff_slot, &var_name, new_val);
@@ -1637,13 +1648,15 @@ impl Interpreter {
                                 return Err(RuntimeError::assignment_ro(Some("Set")));
                             }
                             let s = crate::gc::Gc::make_mut(set);
-                            if val.truthy() {
+                            let present = val.truthy();
+                            if present {
                                 s.insert(key.clone());
                                 Self::record_quanthash_object_key(&mut s.original_keys, &key, &idx);
                             } else {
                                 s.remove(&key);
                                 Self::forget_quanthash_object_key(&mut s.original_keys, &key);
                             }
+                            setty_bool_result = Some(Value::Bool(present));
                         }
                         Value::Bag(ref mut bag, is_mutable) => {
                             if !is_mutable {
@@ -1875,7 +1888,9 @@ impl Interpreter {
         // Positional array elements only: hash single-key / hash-slice assignment
         // exits through other push sites (not reached here), and this restriction
         // keeps a string-range hash subscript from being mis-itemized.
-        let result = if idx_is_single_element && !var_name.starts_with('%') {
+        let result = if let Some(bool_result) = setty_bool_result {
+            bool_result
+        } else if idx_is_single_element && !var_name.starts_with('%') {
             Self::itemize_value(val)
         } else {
             val

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -522,29 +522,46 @@ impl Interpreter {
         } else {
             Value::Nil
         };
-        let effective = match &current {
-            Value::Nil => {
-                // Check if the container has an `is default(...)` value;
-                // e.g. `my @a is default(42); @a[0]++` should increment 42.
-                // Prefer the value-carried default (HashData/ArrayData) so it
-                // works when the container arrived via a parameter (whose name
-                // is not in the name-keyed `var_defaults` table).
-                let def = container
-                    .as_ref()
-                    .and_then(Self::value_carried_default)
-                    .or_else(|| self.var_default(&name).cloned());
-                match def {
-                    Some(d) if !matches!(d, Value::Nil) => d,
-                    _ => Value::Int(0),
-                }
-            }
-            other => other.clone(),
-        };
-        let effective = Self::normalize_incdec_source(effective);
-        let new_val = if increment {
-            self.increment_value_smart(&effective)?
+        // A SetHash element is Bool-valued: `$sh<k>++` sets the key present and
+        // `$sh<k>--` removes it, and the op evaluates to a Bool (the OLD value for
+        // postfix, the NEW value for prefix) — not the numeric 0/1 the generic
+        // increment would produce.
+        let target_is_set = matches!(container.as_ref(), Some(Value::Set(..)))
+            || matches!(
+                container.as_ref(),
+                Some(Value::Package(sym)) if sym.resolve() == "SetHash"
+            )
+            || declared_type_incdec.as_deref() == Some("SetHash")
+            || declared_constraint_incdec.as_deref() == Some("SetHash");
+        let (effective, new_val) = if target_is_set {
+            let old_present = matches!(&current, Value::Bool(true));
+            (Value::Bool(old_present), Value::Bool(increment))
         } else {
-            self.decrement_value_smart(&effective)?
+            let effective = match &current {
+                Value::Nil => {
+                    // Check if the container has an `is default(...)` value;
+                    // e.g. `my @a is default(42); @a[0]++` should increment 42.
+                    // Prefer the value-carried default (HashData/ArrayData) so it
+                    // works when the container arrived via a parameter (whose name
+                    // is not in the name-keyed `var_defaults` table).
+                    let def = container
+                        .as_ref()
+                        .and_then(Self::value_carried_default)
+                        .or_else(|| self.var_default(&name).cloned());
+                    match def {
+                        Some(d) if !matches!(d, Value::Nil) => d,
+                        _ => Value::Int(0),
+                    }
+                }
+                other => other.clone(),
+            };
+            let effective = Self::normalize_incdec_source(effective);
+            let new_val = if increment {
+                self.increment_value_smart(&effective)?
+            } else {
+                self.decrement_value_smart(&effective)?
+            };
+            (effective, new_val)
         };
         // A Bag/BagHash holds non-negative integer counts: decrementing a weight
         // below 0 clamps the *returned* (and stored) value to 0 (the element is

--- a/t/sethash-element-bool-semantics.t
+++ b/t/sethash-element-bool-semantics.t
@@ -1,0 +1,26 @@
+use Test;
+
+# A SetHash element is Bool-valued: `$sh<k>` is True/False by existence, and
+# ++/--/assignment control that existence, evaluating to a Bool (the OLD value
+# for postfix ++/--, the NEW value for prefix and for assignment). mutsu treated
+# these numerically (0/1/-1) and returned the assigned RHS.
+
+plan 12;
+
+# postfix ++ / -- return the OLD Bool
+{ my SetHash $s; is-deeply $s<a>++, Bool::False, 'postfix ++ returns old False'; is-deeply $s<a>, Bool::True, '...and adds the key'; }
+{ my SetHash $s; is-deeply $s<a>--, Bool::False, 'postfix -- returns old False'; is-deeply $s<a>, Bool::False, '...stays absent'; }
+
+# prefix ++ / -- return the NEW Bool
+{ my SetHash $s; is-deeply ++$s<a>, Bool::True, 'prefix ++ returns new True'; }
+{ my SetHash $s; is-deeply --$s<a>, Bool::False, 'prefix -- returns new False'; }
+
+# postfix -- on a present key returns old True and removes it
+{ my SetHash $s = <a>.SetHash; is-deeply $s<a>--, Bool::True, 'postfix -- on present returns True'; is-deeply $s<a>, Bool::False, '...and removes it'; }
+
+# assignment evaluates to the Bool existence
+{ my SetHash $s; is-deeply ($s<a> = 2), Bool::True, 'truthy assign is True'; }
+{ my SetHash $s; is-deeply ($s<a> = 0), Bool::False, 'falsy assign is False'; }
+
+# BagHash / MixHash keep numeric semantics
+{ my BagHash $b; is $b<a>++, 0, 'BagHash ++ is numeric'; is $b<a>, 1, 'BagHash count'; }


### PR DESCRIPTION
## Summary

A `SetHash` element is Bool-valued (`$sh<k>` is `True`/`False` by key existence), and `++`/`--`/assignment control that existence, evaluating to a **Bool** — the OLD value for postfix `++`/`--`, the NEW value for prefix and for assignment. mutsu handled them numerically:

```
my SetHash $s;
$s<a>++       # was 0  — now Bool::False (and adds the key)
++$s<a>       # was 1  — now Bool::True
--$s<a>       # was -1 — now Bool::False
$s<a> = 2     # was 2  — now Bool::True
```

- **Increment** (`exec_inc_dec_index_op`): for a Set/SetHash target, toggle the key (`++` adds, `--` removes) and evaluate to the appropriate Bool instead of the generic numeric increment.
- **Assignment** (index-store): a SetHash element assignment evaluates to the key's Bool existence (both the undefined-autoviv and existing-Set paths).

BagHash/MixHash keep their numeric weight semantics.

## Impact
Fully passes and **whitelists `roast/S02-types/sethash.t`** (was the last failing subtest, after #4249 / #4253).

## Test
- New `t/sethash-element-bool-semantics.t` (12 assertions), cross-checked against `raku`.
- `roast/S02-types/sethash.t` added to `roast-whitelist.txt` (sorted).
- `make test` passes (15175 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)