### PR TITLE
fix(array): shaped-array rows stored as Arrays, not Lists

### DIFF
--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -139,6 +139,16 @@ impl Interpreter {
                                 dims[1] - 1
                             )));
                         }
+                        // A shaped-array row is a mutable sub-Array: normalize a
+                        // List/Seq row (e.g. `<a b>`) to `ArrayKind::Array` so it
+                        // renders as `[...]` and behaves like the `[a, b]` form.
+                        use crate::value::ArrayKind;
+                        let val = match val {
+                            Value::Array(items, ArrayKind::List) => {
+                                Value::Array(items, ArrayKind::Array)
+                            }
+                            other => other,
+                        };
                         if i < new_items.len() {
                             new_items[i] = val;
                         }

--- a/t/shaped-array-row-kind.t
+++ b/t/shaped-array-row-kind.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A shaped array's rows are mutable sub-Arrays. Populating a multi-dim shaped
+# array with List rows (e.g. `<a b>`) must store them as Arrays (`[a, b]`), not
+# Lists (`(a, b)`), matching raku — so `.raku` and element mutation behave right.
+
+plan 6;
+
+is Array.new(:shape(2,2), <a b>, <c d>).raku,
+   'Array.new(:shape(2, 2), ["a", "b"], ["c", "d"])',
+   'Array.new with List rows renders rows as Arrays';
+
+is Array.new(:shape(2,2), [1,2], [3,4]).raku,
+   'Array.new(:shape(2, 2), [1, 2], [3, 4])',
+   'explicit Array rows unaffected';
+
+{
+    my @a[2;2] = <a b>, <c d>;
+    is @a.raku, 'Array.new(:shape(2, 2), ["a", "b"], ["c", "d"])',
+       'shaped assignment stores Array rows';
+}
+
+# multi-dim indexing still works
+{
+    my $a = Array.new(:shape(2,2), <a b>, <c d>);
+    is $a[0;1], 'b', 'index [0;1]';
+    is $a[1;0], 'c', 'index [1;0]';
+}
+
+# 1D shaped array with a flat list is unaffected
+{
+    my @a[3] = 1, 2, 3;
+    is @a.raku, 'Array.new(:shape(3,), [1, 2, 3])', '1D shaped unaffected';
+}


### PR DESCRIPTION
## Summary

A multi-dim shaped array's rows are mutable sub-Arrays. When populated from **List** rows (`Array.new(:shape(2,2), <a b>, <c d>)`, or `my @a[2;2] = <a b>, <c d>`), mutsu stored each row with `ArrayKind::List`, so `.raku` rendered them as `(a, b)` instead of `[a, b]`:

```
Array.new(:shape(2,2), <a b>, <c d>).raku
# was: Array.new(:shape(2, 2), ("a", "b"), ("c", "d"))
# now: Array.new(:shape(2, 2), ["a", "b"], ["c", "d"])   # matches raku
```

Normalize a `List`-kind row to `ArrayKind::Array` during shaped population, matching the explicit `[a, b]` form (already correct) and raku. Explicit-Array rows and 1D shaped arrays are unaffected.

## Impact
Improves `roast/S02-types/array-shapes.t` fidelity (the shaped-row rendering). Test 30 itself remains blocked by a separate `my @c[2;2] .= new(...)` decl-form bug (populates only 1 element), tracked separately.

## Test
- New `t/shaped-array-row-kind.t` (6 assertions), cross-checked against `raku`.
- `make test` passes (15189 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)