### PR TITLE
fix(delete): :delete on a nested subscript writes the deletion back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -274,9 +274,47 @@ impl Compiler {
             && let Expr::Index {
                 target: delete_target,
                 index: delete_index,
+                is_positional: delete_positional,
                 ..
             } = target
         {
+            // Nested `:delete` (`%h<a><x>:delete`, `@a[0][1]:delete`): the delete
+            // target is itself a subscript, so there is no simple name to write the
+            // modified container back through — the generic `DeleteIndexExpr` path
+            // would delete from a copy and lose it. Bind a temp to the nested slot
+            // (`my $t := %h<a>`) — which shares its `ContainerRef` cell — and delete
+            // through it, so the deletion reaches the real inner container.
+            if matches!(delete_target.as_ref(), Expr::Index { .. }) {
+                let tmp = format!("__mutsu_nested_del_{}", self.code.constants.len());
+                let bind_decl = Stmt::VarDecl {
+                    name: tmp.clone(),
+                    expr: (**delete_target).clone(),
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: vec![("__scalar_bind".to_string(), None)],
+                    where_constraint: None,
+                };
+                let delete_through = Expr::MethodCall {
+                    target: Box::new(Expr::Index {
+                        target: Box::new(Expr::Var(tmp)),
+                        index: delete_index.clone(),
+                        is_positional: *delete_positional,
+                    }),
+                    name: Symbol::intern("DELETE-KEY"),
+                    args: Vec::new(),
+                    modifier: None,
+                    quoted: false,
+                };
+                self.compile_expr(&Expr::DoBlock {
+                    body: vec![Stmt::MarkBind, bind_decl, Stmt::Expr(delete_through)],
+                    label: None,
+                });
+                return;
+            }
             if let Some(var_name) = Self::postfix_index_name(delete_target) {
                 if Self::index_assign_target_requires_eval(delete_target) {
                     self.compile_expr(delete_target);

--- a/t/nested-delete-writeback.t
+++ b/t/nested-delete-writeback.t
@@ -1,0 +1,51 @@
+use Test;
+
+plan 10;
+
+# `:delete` on a *nested* subscript (`%h<a><x>:delete`) must delete from the
+# inner container and write it back — the generic path deleted from a copy and
+# lost it, so the key survived even though the deleted value was returned.
+
+{
+    my %h = a => {x => 1, y => 2};
+    %h<a><x>:delete;
+    is-deeply %h, {a => {y => 2}}, 'nested <><>:delete removes the inner key';
+}
+{
+    my %h = a => {x => 1, y => 2};
+    %h<a>{"x"}:delete;
+    is-deeply %h, {a => {y => 2}}, 'nested <>{}:delete removes the inner key';
+}
+{
+    my %h = a => {b => {c => 1, d => 2}};
+    %h<a><b><c>:delete;
+    is-deeply %h, {a => {b => {d => 2}}}, 'three-level :delete removes the deepest key';
+}
+{
+    my %h = a => {x => 1, y => 2};
+    my $got = %h<a><x>:delete;
+    is $got, 1, 'nested :delete returns the deleted value';
+    is-deeply %h<a>, {y => 2}, '...and mutates the inner hash';
+}
+{
+    my @a = [1, 2, 3], [4, 5, 6];
+    @a[0][1]:delete;
+    is-deeply @a, [[1, Any, 3], [4, 5, 6]], 'nested array :delete leaves an Any hole';
+}
+{
+    my %h = a => {only => 42};
+    my $got = %h<a><only>:delete;
+    is $got, 42, 'deleting the last inner key returns it';
+    is-deeply %h, {a => {}}, '...leaving an empty inner hash';
+}
+# single-level and slice forms are unaffected
+{
+    my %h = x => 1, y => 2;
+    %h<x>:delete;
+    is-deeply %h, {y => 2}, 'single-level :delete still works';
+}
+{
+    my %h = a => 1, b => 2, c => 3;
+    %h<a b>:delete;
+    is-deeply %h, {c => 3}, 'slice :delete still works';
+}


### PR DESCRIPTION
## What

`%h<a><x>:delete` (and `@a[0][1]:delete`, deeper `%h<a><b><c>:delete`) returned the deleted value but left the inner container untouched — the key survived:

```
my %h = a => {x => 1, y => 2};
%h<a><x>:delete;
say %h.raku;   # was {:a(${:x(1), :y(2)})} → now {:a(${:y(2)})}
```

## Root cause & fix

The compiler's `DELETE-KEY` lowering has a write-back path only when the delete target is a simple `@`/`%` variable or a method accessor. A **nested subscript** target (`%h<a>`) fell through to `DeleteIndexExpr`, which deletes from a *copy* of the inner container and discards it.

Handle a nested delete by binding a temp to the inner slot (`my $t := %h<a>`) — which shares its `ContainerRef` cell — and deleting through it (`$t<x>:delete`), so the deletion reaches the real inner container while still returning the removed value. Single-level and slice `:delete` are unchanged.

## Safety

Verified against rakudo: nested hash/array delete, three-level, deleted-value return, deleting the last inner key, and the unaffected single-level (`%h<x>:delete`) and slice (`%h<a b>:delete`) forms. `make test` passes (a lone flaky `t/react-whenever-shared-lexical.t` S17 concurrency subtest passes 3/3 on retry and is unrelated to this compiler-only change); all 325 whitelisted `S02`/`S03`/`S09`/`S32-array`/`S32-hash` files stay green.

Regression test: `t/nested-delete-writeback.t` (10 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)