### PR TITLE
fix(parser): untyped `my @a .= new(...)` invokes .new on the variable

### DIFF
--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -511,20 +511,29 @@ fn handle_method_call_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     // parameterized by the element constraint, e.g. `my Int @x .= new` calls
     // `Array[Int].new`, and `my Array of Bool @x .= new` calls
     // `Array[Array[Bool]].new` — not `Int.new` / `Array[Bool].new`.
-    let target_name = match &s.type_constraint {
+    let target_expr = match &s.type_constraint {
         Some(c) if s.name.starts_with('@') => {
             if crate::runtime::native_types::is_native_array_element_type(c) {
-                format!("array[{c}]")
+                Expr::BareWord(format!("array[{c}]"))
             } else {
-                format!("Array[{c}]")
+                Expr::BareWord(format!("Array[{c}]"))
             }
         }
-        Some(c) if s.name.starts_with('%') => format!("Hash[{c}]"),
-        Some(c) => c.clone(),
-        None => s.name.clone(),
+        Some(c) if s.name.starts_with('%') => Expr::BareWord(format!("Hash[{c}]")),
+        Some(c) => Expr::BareWord(c.clone()),
+        // Untyped: `.= new` desugars to `$var = $var.new(...)`, so the invocant is
+        // the variable itself, NOT a type named after it. Using a `@c`-named
+        // `BareWord` mis-dispatched (e.g. `my @c .= new(:shape(2,2), ...)` built
+        // only a 1-element array). Mirror the `@c = @c.new(...)` var-read expr.
+        None => match s.name.chars().next() {
+            Some('@') => Expr::ArrayVar(s.name[1..].to_string()),
+            Some('%') => Expr::HashVar(s.name[1..].to_string()),
+            Some('$') => Expr::Var(s.name[1..].to_string()),
+            _ => Expr::BareWord(s.name.clone()),
+        },
     };
     let expr = Expr::MethodCall {
-        target: Box::new(Expr::BareWord(target_name)),
+        target: Box::new(target_expr),
         name: Symbol::intern(&method_name),
         args,
         modifier: None,

--- a/t/method-call-assign-untyped-decl.t
+++ b/t/method-call-assign-untyped-decl.t
@@ -1,0 +1,28 @@
+use Test;
+
+# `my @a .= new(...)` desugars to `@a = @a.new(...)`: the invocant is the
+# variable, not a type named `@a`. mutsu built a `@a`-named BareWord target,
+# which mis-dispatched (`my @c[2;2] .= new(:shape(2,2), ...)` built only a
+# 1-element array instead of the 2x2 shaped array).
+
+plan 8;
+
+{
+    my @c[2;2] .= new(:shape(2,2), <a b>, <c d>);
+    is @c.elems, 2, 'shaped .= new populates all rows';
+    is @c[0;1], 'b', 'row 0 col 1';
+    is @c[1;0], 'c', 'row 1 col 0';
+}
+{
+    my @a .= new(1, 2, 3);
+    is-deeply @a, [1, 2, 3], 'plain array .= new';
+}
+# Scalars / hashes / typed / class decls are unaffected
+{ my $x .= new; is $x.WHAT.gist, '(Any)', 'untyped scalar .= new is Any.new'; }
+{ my %h .= new; is %h.WHAT.gist, '(Hash)', 'untyped hash .= new is Hash.new'; }
+{ my Int @x .= new; is @x.WHAT.gist, '(Array[Int])', 'typed array .= new uses Array[Int]'; }
+{
+    class C { has $.n }
+    my C $o .= new(n => 5);
+    is $o.n, 5, 'typed class .= new';
+}


### PR DESCRIPTION
## Summary

`.= new` in a declaration desugars to `$var = $var.new(...)`, so the invocant is the variable itself. For an **untyped** declaration mutsu built the target as a `BareWord` named after the variable (`@c`), which mis-dispatched:

```
my @c[2;2] .= new(:shape(2,2), <a b>, <c d>)   # built a 1-element array, not the 2x2 shaped array
```

Build the untyped `.=`-method target as the variable-read expr (`ArrayVar` / `HashVar` / `Var`, mirroring the `@a = @a.new(...)` desugaring). Typed decls (`my Int @x .= new` → `Array[Int].new`), class decls (`my C $o .= new(...)`), and sigilless names are unchanged.

## Impact
Closes the **"@c[some shape] accepts a .new: :shape(same shape)"** subtest in `roast/S02-types/array-shapes.t` (combined with #4265's row-kind fix).

## Test
- New `t/method-call-assign-untyped-decl.t` (8 assertions), cross-checked against `raku` (shaped `.= new`, plain array, scalar→Any, hash→Hash, typed→Array[Int], class).
- `make test` passes (15191 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)