### PR TITLE
fix(array): .List/.Array on a shaped array flattens + fills Nil with the default

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -290,6 +290,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 crate::value::seq_mark_cached(items);
                 Some(Ok(Value::array(items.to_vec())))
             }
+            // A shaped array falls through to the slow path, which flattens all
+            // dimensions and replaces Nil slots with the type-default.
+            Value::Array(..) if crate::runtime::utils::is_shaped_array(target) => None,
             Value::Array(items, _) => Some(Ok(Value::array(items.to_vec()))),
             Value::GenericRange {
                 start,
@@ -457,6 +460,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     };
                     Some(Ok(wrap(bytes)))
                 }
+                // A shaped array falls through to the slow path (flatten + Nil
+                // → type-default). Non-shaped arrays keep the fast path.
+                Value::Array(..) if crate::runtime::utils::is_shaped_array(target) => None,
                 Value::Array(items, kind) => {
                     if method == "Array" && !kind.is_real_array() {
                         Some(Ok(Value::real_array(items.to_vec())))

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -11,6 +11,22 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
+        // `.List`/`.list`/`.Array` on a shaped array flattens all dimensions and
+        // replaces uninitialized (`Nil`) slots with the container's type-default.
+        if matches!(method, "List" | "list" | "Array")
+            && args.is_empty()
+            && let Some(flat) = self.shaped_flatten_with_default(&target)
+        {
+            let kind = if method == "Array" {
+                crate::value::ArrayKind::Array
+            } else {
+                crate::value::ArrayKind::List
+            };
+            return Some(Ok(Value::Array(
+                crate::gc::Gc::new(crate::value::ArrayData::new(flat)),
+                kind,
+            )));
+        }
         match method {
             "Seq" if args.is_empty() => Some(self.dispatch_seq_coercion(target)),
             "list" | "Array" if args.is_empty() => {

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -75,6 +75,31 @@ impl Interpreter {
         })
     }
 
+    /// `.List`/`.Array` on a shaped array flattens all dimensions to a plain
+    /// sequence of elements, with uninitialized (`Nil`) slots replaced by the
+    /// container's type-default (`Any`, or the native/typed element default):
+    /// `my @a[2;2]` → `(Any, Any, Any, Any)`, `my Int @a[3]` → `(Int, Int, Int)`.
+    /// Returns `None` when `target` is not a shaped array (normal coercion runs).
+    pub(super) fn shaped_flatten_with_default(&mut self, target: &Value) -> Option<Vec<Value>> {
+        let depth = crate::runtime::utils::shaped_array_shape(target)?.len();
+        let default = self.typed_container_default(target);
+        let mut out = Vec::new();
+        Self::flatten_shaped_dims(target, depth, &default, &mut out);
+        Some(out)
+    }
+
+    fn flatten_shaped_dims(v: &Value, depth: usize, default: &Value, out: &mut Vec<Value>) {
+        match v {
+            Value::Array(items, _) if depth > 0 => {
+                for it in items.iter() {
+                    Self::flatten_shaped_dims(it, depth - 1, default, out);
+                }
+            }
+            Value::Nil => out.push(default.clone()),
+            other => out.push(other.clone()),
+        }
+    }
+
     /// Dispatch .List coercion method
     pub(super) fn dispatch_list_coercion(&self, target: Value) -> Result<Value, RuntimeError> {
         if let Value::Instance {

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -312,7 +312,7 @@ impl Interpreter {
         Ok(Some(result))
     }
 
-    pub(super) fn typed_container_default(&mut self, target: &Value) -> Value {
+    pub(crate) fn typed_container_default(&mut self, target: &Value) -> Value {
         // Check for explicit `is default(...)` on the container first.
         if let Some(def) = self.container_default(target) {
             return def.clone();

--- a/t/shaped-array-list-coerce.t
+++ b/t/shaped-array-list-coerce.t
@@ -1,0 +1,34 @@
+use Test;
+
+# `.List`/`.Array` on a shaped array flattens all dimensions, replacing
+# uninitialized (Nil) slots with the container's type-default (Any).
+
+plan 8;
+
+{
+    my @a[2;2];
+    is-deeply @a.List, (Any, Any, Any, Any), '.List on uninited 2x2 shaped';
+    is-deeply @a.Array, [Any, Any, Any, Any], '.Array on uninited 2x2 shaped';
+}
+{
+    my @a[4];
+    is-deeply @a.List, (Any, Any, Any, Any), '.List on uninited 1D shaped';
+}
+{
+    my @a[2;2] = [1, 2], [3, 4];
+    is-deeply @a.List, (1, 2, 3, 4), '.List flattens a populated 2x2';
+    is-deeply @a.Array, [1, 2, 3, 4], '.Array flattens a populated 2x2';
+}
+# .Array returns a fresh copy: mutating it does not touch the shaped array
+{
+    my @a[3];
+    my @b = @a.Array;
+    @b[0] = 99;
+    is-deeply @a[0], Any, '.Array is a copy, shaped array untouched';
+}
+# plain arrays / lists are unaffected
+{
+    my @a = 1, 2, 3;
+    is-deeply @a.List, (1, 2, 3), 'plain array .List unaffected';
+    is-deeply @a.Array, [1, 2, 3], 'plain array .Array unaffected';
+}


### PR DESCRIPTION
## Summary

`.List`/`.Array`/`.list` on a shaped array must flatten every dimension into a plain sequence, with uninitialized (`Nil`) slots replaced by the container's type-default (`Any`):

```
my @a[2;2]; @a.List    # was (Array.new(:shape(2,), [Nil, Nil]), ...) — now (Any, Any, Any, Any)
my @a[2;2]; @a.Array   # now [Any, Any, Any, Any]
my @a[2;2] = [1,2],[3,4]; @a.List   # (1, 2, 3, 4)
```

The fast-path coercion returned the raw (nested, Nil-holding) backing store. Now shaped arrays fall through to the slow path (`is_shaped_array` guard), which recursively flattens `shape.len()` dimensions and substitutes the type-default for `Nil` via `typed_container_default`. Non-shaped arrays and lists keep the fast path unchanged.

## Impact
Closes the **".List on uninited shaped array"** and **".Array on uninited shaped array"** subtests in `roast/S02-types/array-shapes.t` (15 → 10 failing across this session).

## Test
- New `t/shaped-array-list-coerce.t` (8 assertions), cross-checked against `raku` (uninited/populated, 1D/2D, `.Array` is a fresh copy, plain arrays/lists unaffected).
- `make test` passes (15207 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)