### PR TITLE
fix(autoviv): nested `<>`/`{}` ++/--/OP= autovivifies a Hash, not an Array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.18"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.14"
+version = "0.2.19"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -197,7 +197,13 @@ impl Compiler {
     /// 4. Write back tmp_val (which now has new value) via IndexAssign
     /// 5. Return tmp_old (the old value before increment)
     fn compile_nested_postfix_incdec(&mut self, expr: &Expr, increment: bool) {
-        if let Expr::Index { target, index, .. } = expr {
+        if let Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } = expr
+        {
             let tmp_val = format!("__mutsu_nested_incdec_val_{}", self.code.constants.len());
             let tmp_val_idx = self.code.add_constant(Value::str(tmp_val.clone()));
             let tmp_old = format!("__mutsu_nested_incdec_old_{}", self.code.constants.len());
@@ -220,12 +226,16 @@ impl Compiler {
             self.code.emit(OpCode::SetGlobal(tmp_old_idx));
             self.code.emit(OpCode::Pop);
 
-            // 3. Write back the new value (tmp_val) via IndexAssign
+            // 3. Write back the new value (tmp_val) via IndexAssign. Preserve the
+            //    subscript's positional/associative kind so an autovivified
+            //    intermediate container is a Hash for `%h<a><b>++` (associative)
+            //    and an Array for `@a[0][1]++` (positional) — a hardcoded `true`
+            //    here wrongly made `%h<a><b>++` create an Array.
             let assign_expr = Expr::IndexAssign {
                 target: target.clone(),
                 index: index.clone(),
                 value: Box::new(Expr::Var(tmp_val)),
-                is_positional: true,
+                is_positional: *is_positional,
             };
             self.compile_expr(&assign_expr);
             self.code.emit(OpCode::Pop);
@@ -245,7 +255,13 @@ impl Compiler {
     /// 3. Write back tmp_val via IndexAssign
     /// 4. Return the new value
     pub(super) fn compile_nested_prefix_incdec(&mut self, expr: &Expr, increment: bool) {
-        if let Expr::Index { target, index, .. } = expr {
+        if let Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } = expr
+        {
             let tmp_val = format!("__mutsu_nested_preincdec_val_{}", self.code.constants.len());
             let tmp_val_idx = self.code.add_constant(Value::str(tmp_val.clone()));
 
@@ -269,12 +285,13 @@ impl Compiler {
             self.code.emit(OpCode::SetGlobal(tmp_new_idx));
             self.code.emit(OpCode::Pop);
 
-            // 3. Write back the new value via IndexAssign
+            // 3. Write back the new value via IndexAssign (preserve subscript kind
+            //    so `%h<a><b>` autovivifies a Hash, `@a[0][1]` an Array).
             let assign_expr = Expr::IndexAssign {
                 target: target.clone(),
                 index: index.clone(),
                 value: Box::new(Expr::Var(tmp_val)),
-                is_positional: true,
+                is_positional: *is_positional,
             };
             self.compile_expr(&assign_expr);
             self.code.emit(OpCode::Pop);

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -1,6 +1,11 @@
 use super::*;
 
-fn compound_index_assign_expr<F>(target: Expr, index: Expr, build_assigned_value: F) -> Expr
+fn compound_index_assign_expr<F>(
+    target: Expr,
+    index: Expr,
+    is_positional: bool,
+    build_assigned_value: F,
+) -> Expr
 where
     F: FnOnce(Expr) -> Expr,
 {
@@ -9,6 +14,11 @@ where
         TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
     );
     let tmp_idx_expr = Expr::Var(tmp_idx.clone());
+    // The read of the current value stays associative-lenient (`is_positional:
+    // false`): a missing nested element reads as the type object either way, and
+    // a positional read of a not-yet-autovivified intermediate (`@a[0][1] += 1`)
+    // would otherwise error. Only the write-back below needs the true subscript
+    // kind, to autovivify the correct container (Hash vs Array).
     let lhs_expr = Expr::Index {
         target: Box::new(target.clone()),
         index: Box::new(tmp_idx_expr.clone()),
@@ -29,11 +39,15 @@ where
                 custom_traits: Vec::new(),
                 where_constraint: None,
             },
+            // Preserve the subscript's positional/associative kind so an
+            // autovivified intermediate is a Hash for `%h<a><b> += 1`
+            // (associative) and an Array for `@a[0][1] += 1` (positional) —
+            // a hardcoded `true` here wrongly made `%h<a><b> += 1` an Array.
             Stmt::Expr(Expr::IndexAssign {
                 target: Box::new(target),
                 index: Box::new(tmp_idx_expr.clone()),
                 value: Box::new(assigned_value),
-                is_positional: true,
+                is_positional,
             }),
         ],
         label: None,
@@ -97,10 +111,17 @@ pub(crate) fn build_compound_assign_expr(
             expr: Box::new(compound_assigned_value_expr(Expr::HashVar(name), op, rhs)),
             is_bind: false,
         },
-        Expr::Index { target, index, .. } => {
-            return Ok(compound_index_assign_expr(*target, *index, |lhs_expr| {
-                compound_assigned_value_expr(lhs_expr, op, rhs)
-            }));
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+        } => {
+            return Ok(compound_index_assign_expr(
+                *target,
+                *index,
+                is_positional,
+                |lhs_expr| compound_assigned_value_expr(lhs_expr, op, rhs),
+            ));
         }
         Expr::MethodCall {
             target,
@@ -110,9 +131,12 @@ pub(crate) fn build_compound_assign_expr(
             quoted: _,
         } if name == "AT-POS" && args.len() == 1 => {
             let index = args.into_iter().next().unwrap_or(Expr::Literal(Value::Nil));
-            return Ok(compound_index_assign_expr(*target, index, |lhs_expr| {
-                compound_assigned_value_expr(lhs_expr, op, rhs)
-            }));
+            return Ok(compound_index_assign_expr(
+                *target,
+                index,
+                true,
+                |lhs_expr| compound_assigned_value_expr(lhs_expr, op, rhs),
+            ));
         }
         Expr::MethodCall {
             target,
@@ -242,15 +266,22 @@ pub(crate) fn build_custom_compound_assign_expr(
             }),
             is_bind: false,
         },
-        Expr::Index { target, index, .. } => {
-            return Ok(compound_index_assign_expr(*target, *index, |lhs_expr| {
-                Expr::InfixFunc {
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+        } => {
+            return Ok(compound_index_assign_expr(
+                *target,
+                *index,
+                is_positional,
+                |lhs_expr| Expr::InfixFunc {
                     name: op_name,
                     left: Box::new(lhs_expr),
                     right: vec![rhs],
                     modifier: None,
-                }
-            }));
+                },
+            ));
         }
         _ => return Err(PError::expected("assignment expression")),
     })
@@ -319,7 +350,7 @@ pub(crate) fn build_meta_assign_expr(
                     left: Box::new(lhs_expr),
                     right: Box::new(rhs),
                 }),
-                is_positional: true,
+                is_positional,
             }
         }
         _ => return Err(PError::expected("assignment expression")),

--- a/t/nested-assoc-incdec-autoviv.t
+++ b/t/nested-assoc-incdec-autoviv.t
@@ -1,0 +1,71 @@
+use Test;
+
+plan 12;
+
+# `++`/`--`/`OP=` on a nested *associative* subscript must autovivify the
+# intermediate container as a Hash (matching the `= value` path), not an Array.
+# The classic nested-counter idiom `%h<a>{$k}++` relied on this.
+
+{
+    my %h;
+    %h<a><b>++;
+    is-deeply %h, {a => {b => 1}}, 'nested <><>++ autovivifies a Hash';
+}
+{
+    my %h;
+    %h<a>{"b"}++;
+    is-deeply %h, {a => {b => 1}}, 'nested <>{}++ autovivifies a Hash';
+}
+{
+    my %h;
+    %h{"x"}{"y"}++;
+    is-deeply %h, {x => {y => 1}}, 'nested {}{}++ autovivifies a Hash';
+}
+{
+    my %h;
+    %h<a><b><c>++;
+    is-deeply %h, {a => {b => {c => 1}}}, 'three-level ++ autovivifies Hashes';
+}
+{
+    my %h;
+    ++%h<a><b>;
+    is-deeply %h, {a => {b => 1}}, 'prefix ++ on a nested associative subscript';
+}
+{
+    my %h;
+    %h<a><b>--;
+    is-deeply %h, {a => {b => -1}}, 'nested -- autovivifies a Hash';
+}
+{
+    my %h;
+    %h<a><b> += 5;
+    is-deeply %h, {a => {b => 5}}, 'nested += autovivifies a Hash';
+}
+{
+    my %h;
+    %h<a><b> ~= "x";
+    is-deeply %h, {a => {b => "x"}}, 'nested ~= autovivifies a Hash';
+}
+{
+    # the classic nested-counter idiom
+    my %h;
+    %h<counts>{$_}++ for <a b a c a>;
+    is-deeply %h<counts>.sort.list, (a => 3, b => 1, c => 1), 'nested-counter %h<c>{$k}++ works';
+}
+{
+    my %h;
+    %h<x>{$_} += 1 for <a b a>;
+    is-deeply %h<x>.sort.list, (a => 2, b => 1), 'nested-counter with += works';
+}
+# an existing nested value is updated, not replaced
+{
+    my %h = a => {b => 1};
+    %h<a><b> += 10;
+    is-deeply %h, {a => {b => 11}}, 'nested += updates an existing value';
+}
+# positional nested compound-assign is unaffected
+{
+    my @a;
+    @a[0][1] += 3;
+    is-deeply @a, [[Any, 3],], 'positional nested += autovivifies an Array';
+}


### PR DESCRIPTION
## What

`%h<a><b>++`, `%h<a><b> += 1`, and the classic nested-counter idiom
`%h<counts>{$k}++` autovivified the intermediate `%h<a>` as an *Array*
(`{:a($[])}`) instead of a Hash (`{:a(${:b(1)})}`), so the update was lost.
The `%h<a><b> = value` plain-assignment path already got this right.

## Why

The write-back these desugarings emit hardcoded `is_positional: true` on the
`IndexAssign`, which forces Array autovivification regardless of the actual
subscript. This threads the real `is_positional` through instead — in the
nested `++`/`--` compiler helpers (`expr_postfix.rs`) and the
compound-assignment desugaring (`compound_expr.rs`) — so an associative
subscript autovivifies a Hash and a positional one an Array. The
intermediate-read stays associative-lenient so a positional `@a[0][1] += 1`
still autovivifies correctly rather than erroring on the not-yet-existing
element.

Matches raku:

```
my %h; %h<a><b>++;                              # {:a(${:b(1)})}
my %h; %h<a><b> += 5;                           # {:a(${:b(5)})}
my %h; %h<counts>{"x"}++; %h<counts>{"x"}++;    # {:counts(${:x(2)})}
my @a; @a[0][1] += 3;                           # [[Any, 3],]
```

## Test

Regression test: `t/nested-assoc-incdec-autoviv.t`. `make test` passes
(15227 tests, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)