### PR TITLE
fix(regex): `@<name>=` capture is a List only for a capturing atom

### DIFF
--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2927,6 +2927,21 @@ impl Interpreter {
                     quant,
                     RegexQuant::ZeroOrMore | RegexQuant::OneOrMore | RegexQuant::Repeat(..)
                 );
+            // An `@<name>=` array-sigil alias only produces a List when the
+            // aliased atom is itself a *capturing* construct — a capture group
+            // (`@<x>=(\w)`) or a subrule call (`@<x>=<alpha>`, `@<x>=<myrule>`),
+            // quantified or not. Aliasing a plain atom (metachar `@<x>=\w+`,
+            // non-capturing group `@<x>=[\w]+`, or char class `@<x>=<[a..z]>`)
+            // matches once and yields a single Match, exactly like the scalar
+            // `$<name>=` form. `user_alias_is_array` alone (set for every
+            // `@<name>=`) wrongly forced a List for these non-capturing atoms.
+            // Decide here, from the original `atom` before it may be moved into a
+            // wrapping group below. Builtin subrules like `<alpha>`/`<digit>`
+            // parse as a `CharClass` atom but set a `secondary_named` capture, so
+            // that presence is what distinguishes them from a raw `<[a..z]>`.
+            let force_list_capture = user_alias_is_array
+                && (matches!(atom, RegexAtom::CaptureGroup(_) | RegexAtom::Named(_))
+                    || secondary_named.is_some());
             if wrap_named_quant {
                 let inner = RegexToken {
                     atom,
@@ -2951,7 +2966,7 @@ impl Interpreter {
                     named_capture: primary_named,
                     hash_capture: None,
                     secondary_named_capture: secondary_named,
-                    force_list_capture: user_alias_is_array,
+                    force_list_capture,
                     ratchet: token_ratchet,
                     frugal: token_frugal,
                     separator: None,
@@ -2963,7 +2978,7 @@ impl Interpreter {
                     named_capture: primary_named,
                     hash_capture,
                     secondary_named_capture: secondary_named,
-                    force_list_capture: user_alias_is_array,
+                    force_list_capture,
                     ratchet: token_ratchet,
                     frugal: token_frugal,
                     separator: token_separator,

--- a/t/named-array-capture-arity.t
+++ b/t/named-array-capture-arity.t
@@ -1,0 +1,47 @@
+use Test;
+
+# `@<name>=` array-sigil named capture only yields a List (Array) when the
+# aliased atom is itself a capturing construct: a capture group `(...)` or a
+# subrule call `<alpha>`. Aliasing a plain atom (metachar, non-capturing group,
+# or char class `<[...]>`) matches once and yields a single Match, exactly like
+# the scalar `$<name>=` form.
+
+plan 16;
+
+# --- non-capturing atoms => single Match ---
+"abc" ~~ /@<c>=\w+/;
+is $<c>.^name, 'Match', 'metachar quantified @<c>=\w+ is a Match';
+is $<c>.Str, 'abc', '  ... with the whole span as its value';
+
+"abc" ~~ /@<c>=[\w]+/;
+is $<c>.^name, 'Match', 'non-capturing group @<c>=[\w]+ is a Match';
+
+"abc" ~~ /@<c>=<[a..z]>/;
+is $<c>.^name, 'Match', 'char class @<c>=<[a..z]> is a Match';
+is $<c>.Str, 'a', '  ... matching one char';
+
+"abc" ~~ /@<c>=<[a..z]>+/;
+is $<c>.^name, 'Match', 'quantified char class @<c>=<[a..z]>+ is a Match';
+is $<c>.Str, 'abc', '  ... spanning the whole run';
+
+# --- capturing constructs => Array (List) ---
+"abc" ~~ /@<c>=(\w)/;
+is $<c>.^name, 'Array', 'capture group @<c>=(\w) is an Array';
+is $<c>.elems, 1, '  ... with one element';
+
+"abc" ~~ /@<c>=(\w)+/;
+is $<c>.^name, 'Array', 'quantified capture group @<c>=(\w)+ is an Array';
+is $<c>.elems, 3, '  ... one Match per iteration';
+is $<c>[1].Str, 'b', '  ... elements preserve per-iteration matches';
+
+"abc" ~~ /@<c>=<alpha>/;
+is $<c>.^name, 'Array', 'subrule @<c>=<alpha> is an Array';
+
+"abc" ~~ /@<c>=<alpha>+/;
+is $<c>.^name, 'Array', 'quantified subrule @<c>=<alpha>+ is an Array';
+
+# --- scalar `$<name>=` alias is unaffected: always a single Match ---
+"abc" ~~ /$<c>=\w+/;
+is $<c>.^name, 'Match', 'scalar $<c>=\w+ stays a Match';
+"abc" ~~ /$<c>=(\w)/;
+is $<c>.^name, 'Match', 'scalar $<c>=(\w) is a single Match (group aliased)';


### PR DESCRIPTION
## What

An `@<name>=` array-sigil named capture unconditionally forced List context, so
these all produced an `Array` wrapping a single `Match` instead of a bare `Match`:

```
"abc" ~~ /@<c>=\w+/;     say $<c>.^name;   # was Array, raku: Match
"abc" ~~ /@<c>=[\w]+/;   say $<c>.^name;   # was Array, raku: Match
"abc" ~~ /@<c>=<[a..z]>/;say $<c>.^name;   # was Array, raku: Match
```

Raku only yields a List when the aliased atom is itself a **capturing** construct
— a capture group (`@<c>=(\w)`) or a subrule call (`@<c>=<alpha>`), quantified or
not. Aliasing a plain metachar, a non-capturing group, or a char class matches
once and yields a single `Match`, exactly like the scalar `$<name>=` form:

| pattern | raku / now |
|---|---|
| `@<c>=\w+` | Match |
| `@<c>=[\w]+` | Match |
| `@<c>=<[a..z]>` / `@<c>=<[a..z]>+` | Match |
| `@<c>=(\w)` / `@<c>=(\w)+` | Array |
| `@<c>=<alpha>` / `@<c>=<alpha>+` | Array |

## Why

The `@<name>=` alias set `force_list_capture` on every aliased atom. This decides
it instead from the original atom **before** the quantifier-hoisting path may wrap
it in a non-capturing group (`@<c>=\w+` gets wrapped, so gating at match time could
not distinguish it from `@<c>=<alpha>+`). Builtin subrules like `<alpha>`/`<digit>`
parse as a `CharClass` atom but set a *secondary named capture*, so that presence
is what distinguishes them from a raw `<[a..z]>` char class.

## Test

Regression test `t/named-array-capture-arity.t` (16 cases). `make test` passes
(15243 tests); whitelisted `S05-capture/{named,alias,dot,match-object}.t` still PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)