### PR TITLE
fix(coerce): `Str.Int`/`Str.UInt` accept radix and rational string forms

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -548,9 +548,10 @@ pub(super) fn dispatch(
                         Value::Int(0)
                     } else if let Some(v) = parse_raku_int_from_str(s) {
                         v
-                    } else if let Some(v) = runtime::str_numeric::parse_raku_str_to_numeric(s.trim())
-                        .as_ref()
-                        .and_then(numeric_to_int)
+                    } else if let Some(v) =
+                        runtime::str_numeric::parse_raku_str_to_numeric(s.trim())
+                            .as_ref()
+                            .and_then(numeric_to_int)
                     {
                         // raku's `Str.Int` parses via the full numeric grammar
                         // and truncates the result, so numeric string forms the
@@ -593,9 +594,10 @@ pub(super) fn dispatch(
                 Value::Str(s) => {
                     if let Some(v) = parse_raku_int_from_str(s) {
                         Some(v)
-                    } else if let Some(v) = runtime::str_numeric::parse_raku_str_to_numeric(s.trim())
-                        .as_ref()
-                        .and_then(numeric_to_int)
+                    } else if let Some(v) =
+                        runtime::str_numeric::parse_raku_str_to_numeric(s.trim())
+                            .as_ref()
+                            .and_then(numeric_to_int)
                     {
                         // Same numeric-string forms as `.Int` (radix `:16<ff>`,
                         // rational `3/4`, ...): numify then truncate, then the

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -53,6 +53,57 @@ pub(crate) fn str_numeric_failure(s: &str) -> Value {
     Value::make_instance(Symbol::intern("Failure"), failure_attrs)
 }
 
+/// Build the `X::Numeric::CannotConvert` Failure raised when a non-finite Num
+/// (`NaN`/`Inf`/`-Inf`) is coerced to `Int`.
+fn cannot_convert_to_int_failure(source: &Value, f: f64) -> Value {
+    let label = if f.is_nan() {
+        "NaN"
+    } else if f.is_sign_positive() {
+        "Inf"
+    } else {
+        "-Inf"
+    };
+    let msg = format!("Cannot convert {label} to Int: not a finite number");
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(msg));
+    attrs.insert("source".to_string(), source.clone());
+    attrs.insert("target".to_string(), Value::str_from("Int"));
+    let ex = Value::make_instance(Symbol::intern("X::Numeric::CannotConvert"), attrs);
+    let mut failure_attrs = std::collections::HashMap::new();
+    failure_attrs.insert("exception".to_string(), ex);
+    Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+}
+
+/// Truncate a numeric `Value` toward zero to an `Int`, returning `None` for a
+/// non-numeric value. A non-finite `Num` or a zero-denominator `Rational`
+/// yields the same lazy `Failure` a direct `.Int` would. Used both by the
+/// `.Int` coercion arm and by `Str.Int` after parsing a numeric string form
+/// (radix `:16<ff>`, rational `3/4`, ...) through the full numeric grammar,
+/// mirroring raku's "numify then truncate" semantics.
+fn numeric_to_int(target: &Value) -> Option<Value> {
+    Some(match target {
+        Value::Int(i) => Value::Int(*i),
+        Value::BigInt(_) => target.clone(),
+        Value::Num(f) => {
+            if f.is_nan() || f.is_infinite() {
+                cannot_convert_to_int_failure(target, *f)
+            } else {
+                Value::Int(*f as i64)
+            }
+        }
+        Value::Rat(_, 0) | Value::FatRat(_, 0) => {
+            RuntimeError::divide_by_zero_failure_for_method("Int", "Rational")
+        }
+        Value::Rat(n, d) | Value::FatRat(n, d) => Value::Int(*n / *d),
+        Value::BigRat(_, d) if d.is_zero() => {
+            RuntimeError::divide_by_zero_failure_for_method("Int", "Rational")
+        }
+        Value::BigRat(n, d) => Value::Int((n.as_ref() / d.as_ref()).to_i64().unwrap_or(i64::MAX)),
+        Value::Complex(r, _) => Value::Int(*r as i64),
+        _ => return None,
+    })
+}
+
 pub(super) fn dispatch(
     target: &Value,
     method: &str,
@@ -497,6 +548,15 @@ pub(super) fn dispatch(
                         Value::Int(0)
                     } else if let Some(v) = parse_raku_int_from_str(s) {
                         v
+                    } else if let Some(v) = runtime::str_numeric::parse_raku_str_to_numeric(s.trim())
+                        .as_ref()
+                        .and_then(numeric_to_int)
+                    {
+                        // raku's `Str.Int` parses via the full numeric grammar
+                        // and truncates the result, so numeric string forms the
+                        // strict integer parser above rejects — radix `:16<ff>`,
+                        // rational `3/4`, ... — still coerce like their value.
+                        v
                     } else {
                         // Return a Failure (lazy exception) instead of throwing.
                         return Some(Some(Ok(str_numeric_failure(s))));
@@ -532,6 +592,14 @@ pub(super) fn dispatch(
                 Value::Str(s) if s.trim().is_empty() => Some(Value::Int(0)),
                 Value::Str(s) => {
                     if let Some(v) = parse_raku_int_from_str(s) {
+                        Some(v)
+                    } else if let Some(v) = runtime::str_numeric::parse_raku_str_to_numeric(s.trim())
+                        .as_ref()
+                        .and_then(numeric_to_int)
+                    {
+                        // Same numeric-string forms as `.Int` (radix `:16<ff>`,
+                        // rational `3/4`, ...): numify then truncate, then the
+                        // non-negative check below applies.
                         Some(v)
                     } else {
                         // Invalid string: same X::Str::Numeric Failure (with the `⏏`

--- a/t/str-int-radix-coerce.t
+++ b/t/str-int-radix-coerce.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `Str.Int` / `Str.UInt` parse the string through the full numeric grammar and
+# then truncate toward zero, so radix (`:16<ff>`) and rational (`3/4`) string
+# forms coerce like their numeric value — not just plain decimal integers.
+
+plan 20;
+
+# --- radix string forms ---
+is ":16<ff>".Int, 255,   'hex radix string .Int';
+is ":2<101>".Int, 5,     'binary radix string .Int';
+is ":8<17>".Int, 15,     'octal radix string .Int';
+is ":36<z>".Int, 35,     'base-36 radix string .Int';
+is ":16<DEAD_BEEF>".Int, 3735928559, 'radix string with underscores .Int';
+is ":16<ff.8>".Int, 255, 'radix string with fractional part truncates .Int';
+is "  :16<ff>  ".Int, 255, 'radix string with surrounding whitespace .Int';
+
+# --- rational / decimal string forms truncate toward zero ---
+is "3/4".Int, 0,   'rational string .Int truncates';
+is "7/2".Int, 3,   'rational string .Int truncates (7/2 -> 3)';
+is "3.7".Int, 3,   'decimal string .Int truncates';
+is "-3.7".Int, -3, 'negative decimal string .Int truncates toward zero';
+
+# --- plain integer / prefixed forms still work ---
+is "10".Int, 10,     'plain decimal .Int';
+is "0xff".Int, 255,  '0x prefix .Int';
+is "1_000".Int, 1000, 'underscore-separated .Int';
+
+# --- UInt gets the same numeric-string handling ---
+is ":16<ff>".UInt, 255, 'hex radix string .UInt';
+is "3/4".UInt, 0,       'rational string .UInt';
+is "3.7".UInt, 3,       'decimal string .UInt';
+
+# --- invalid / non-finite still fail (as Failures) ---
+ok "foo".Int ~~ Failure,  'non-numeric string .Int is a Failure';
+ok "Inf".Int ~~ Failure,  'Inf string .Int is a Failure';
+is "Inf".Int.exception.^name, 'X::Numeric::CannotConvert',
+    'Inf string .Int fails with X::Numeric::CannotConvert';


### PR DESCRIPTION
## What

`Str.Int` / `Str.UInt` only accepted plain decimal (and `0x`/`0o`/`0b`/`0d`
prefixed) integer strings, throwing an `X::Str::Numeric` error for radix and
rational string forms:

```
":16<ff>".Int      # was: error   raku/now: 255
":2<101>".Int      # was: error   raku/now: 5
":36<z>".Int       # was: error   raku/now: 35
":16<ff.8>".Int    # was: error   raku/now: 255  (fractional radix truncated)
"3/4".Int          # was: error   raku/now: 0
":16<ff>".UInt     # was: error   raku/now: 255
```

Raku's `Str.Int` parses the string through the full numeric grammar and then
truncates toward zero, so any numeric string form coerces like its value — not
just plain integers (`"3.7".Int` was already 3).

## Why

The strict integer parser `parse_raku_int_from_str` handled only decimals and
`0x`/`0o`/`0b`/`0d` prefixes. On its failure, this falls back to the same
`parse_raku_str_to_numeric` that the `.Numeric` coercion already uses (it handles
radix `:N<...>` and rational forms) and truncates the result via a new shared
`numeric_to_int` helper.

The helper reuses the existing non-finite / zero-denominator handling, so a
non-numeric numeric-string case fails correctly: `"Inf".Int` now fails with
`X::Numeric::CannotConvert` (matching raku's exception type) instead of a
string-parse error.

## Test

Regression test `t/str-int-radix-coerce.t` (20 cases). `make test` passes
(15263 tests); whitelisted `S32-num/{int,cool-num,rat}.t` and
`S02-literals/{radix,numeric}.t` still PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)