### PR TITLE
perf(vm): shrink OpCode 192->48 bytes, add per-opcode stats, drop dead opcodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ This is a **bytecode VM** architecture. The VM handles ALL operations natively v
 - **AST** (`ast.rs`): `Expr` (~50 variants) and `Stmt` (~30 variants)
 - **TokenKind** (`token_kind.rs`): Shared operator/token enum used by parser/AST/compiler/runtime expression handling
 - **RuntimeError** (`value.rs`): Runtime/parse error carrier; parse failures now use structured metadata (`code`, `line`, `column`) in addition to `message`
-- **OpCode** (`opcode.rs`): ~100 bytecode instructions, including compound loop ops
+- **OpCode** (`opcode.rs`): ~340 bytecode instructions, including compound loop ops. Keep `size_of::<OpCode>()` <= 48 bytes (pinned by the `opcode_size_guard` test) — box any fat variant payload (see `docs/opcode-design-review.md`)
 
 ### Method dispatch (two-tier)
 

--- a/docs/opcode-design-review.md
+++ b/docs/opcode-design-review.md
@@ -1,0 +1,121 @@
+# Opcode / instruction-set design review (2026-07-06)
+
+A design audit of the bytecode instruction set (`src/opcode.rs`, `OpCode`) and
+its dispatch (`src/vm/vm_exec_dispatch.rs::exec_one`). This records what was
+measured, what was fixed, and what remains as known-but-deferred work, so
+future instruction-set decisions start from data instead of re-auditing.
+
+Related: [ADR-0004](adr/0004-jit-strategy.md) (JIT Tier A subroutine-threads
+this instruction set — it is an asset to preserve, not replace),
+[gc-post-3a-roadmap](gc-post-3a-roadmap.md) §3 (NaN-boxing targets `Value`
+size; `OpCode` size is a separate axis, addressed here).
+
+## Snapshot at audit time
+
+- ~340 `OpCode` variants (CLAUDE.md's "~100" was stale). Biggest families:
+  calls (27), variables (23+), type checking (21+4), functions (21), set ops
+  (18), arithmetic (18).
+- Dispatch: one big `match &code.ops[*ip]` (`exec_one`), fetch by reference,
+  operands are mostly `u32` constant-pool indices. Compound loop ops
+  (`ForLoop`/`WhileLoop`/`CStyleLoop`/`RepeatLoop`) run the whole loop inside a
+  single `exec_one` via nested `run_range` mini-loops — no jump round-trip per
+  iteration. §1.5 slot-baking (`Option<u32>` compiler-resolved local slots) is
+  pervasive and good.
+- No comment/doc treats the dispatch `match` itself as a bottleneck; measured
+  hot costs are env cloning, call dispatch, and `Value` clone/drop (PLAN §5).
+
+## Findings and status
+
+### 1. `size_of::<OpCode>() == 192` bytes — FIXED (now 48)
+
+A Rust enum pads every variant to the widest one, and `Vec<OpCode>` therefore
+paid a 192-byte stride for *every* instruction (`LoadConst`, `Add`, ...). The
+sole driver was `ForLoop`, which carried a 21-field spec inline including
+3× `Vec<String>`, 1× `Vec<Option<u32>>`, 2× `Option<String>`.
+
+Fix: the spec is now `ForLoopSpec` in `opcode.rs` and the variant is
+`ForLoop(Box<ForLoopSpec>)` → `size_of::<OpCode>()` = **48 bytes** (4× smaller
+instruction stream). The VM borrows the boxed spec directly, which also
+removed the per-loop-entry clone of all heap fields (the old dispatch arm
+cloned `label` + 3 Vecs + `single_array_source` into a stack `ForLoopSpec` on
+every loop entry).
+
+Guard: `opcode_size_guard` test pins `size_of::<OpCode>() <= 48`. The widest
+remaining variants are `SmartMatchExpr` and `Subst` (~48B, each one
+`Option<String>` / a few `Option<u32>`s wide). Box any new payload that would
+exceed this.
+
+### 2. Heap payloads inline instead of constant-pool indices — PARTLY OPEN
+
+10 variants carried `String`-family payloads inline; `ForLoop` (the worst) is
+fixed. Still inline, cloned per execution:
+
+- `Last`/`Next`/`Redo` (`Option<String>` label) — cloned into the control-flow
+  signal on every hit (`vm_exec_dispatch.rs` `sig.label = label.clone()`).
+- `WhileLoop`/`CStyleLoop`/`RepeatLoop`/`DoBlockExpr` (`Option<String>` label)
+  — cloned per loop entry.
+- `SmartMatchExpr.lhs_var` (`Option<String>`).
+
+These are per-loop-entry / per-signal (not per-iteration) costs and labels are
+rare, so they were left for a follow-up: migrate labels to constant-pool
+`Option<u32>` like every other name operand. That would also shrink `OpCode`
+below 48.
+
+### 3. Dead variants — FIXED
+
+`IsNil`, `JumpIfNil`, `IndexAutovivify` had live `exec_one` arms but zero
+compiler emit sites; all three removed (the `exec_index_autovivify_op` helper
+stays — it is reached from `IndexAutovivifyLazy`'s fallback). `MultiDimIndex`
+was mis-marked `#[allow(dead_code)]` while actually emitted
+(`compiler/expr.rs`); the stale attribute is removed.
+
+### 4. No per-opcode execution profile — FIXED
+
+`MUTSU_VM_STATS` counted call/env/GC events but not opcode frequency, so
+fusion/shrinking decisions had no empirical basis. `exec_one` now feeds a
+per-opcode histogram (discriminant-keyed; variant name derived once via
+`Debug`), dumped as `opcodes executed total=... (top 30): ...`. Zero cost when
+stats are off (one cached bool load).
+
+First data point (`my $s = 0; for 1..1000 { $s += $_ }`): one iteration of
+`$s += $_` executes 6 ops — `SetSourceLine`, `GetLocal`, `SetLocal`, `Add`,
+`CheckReadOnly`, `GetGlobal`. That immediately suggests follow-up targets:
+`SetSourceLine` fires per statement even in hot loops, and a compound-assign
+to a local still pays a `CheckReadOnly` + env-path `GetGlobal` pair.
+
+### 5. Per-instruction dispatch overhead — OPEN (deferred)
+
+Two unconditional costs run before every instruction's match arm:
+
+- `self.current_code = code as *const _ as usize` (`exec_one` prologue) — a
+  raw-pointer store per instruction; frame-entry granularity would suffice,
+  but the lazy-force reconcile (Slice F) depends on it being exact, so hoisting
+  needs its own verification pass.
+- `trace_log!("vm", ...)` — `trace::is_enabled` (cached config load + phase
+  scan) per instruction even when tracing is off.
+
+Both are small constants but sit on the hottest path in the program. Worth a
+measured pass; not blindly.
+
+### 6. Misleading `Jump(i32)` encoding — OPEN (cosmetic)
+
+Jump payloads are `i32` but hold *absolute* instruction indices (applied as
+`*ip = target as usize`), not relative offsets. Rename/retype (`u32`) when
+next touching the jump family. Also `goto`/label resolution
+(`find_label_target`) is a linear scan of `code.ops`; fine at current usage
+frequency.
+
+## Design verdict (kept for context)
+
+The instruction set's *shape* is sound for this project's trajectory: constant
+-pool operands, compound structured loops, baked local slots, and fused hot
+ops (`AtomicCompoundVar`, `ArrayPush`, `JunctionAnyN`) all survive contact
+with the JIT plan (Tier A translates opcode sequences into helper calls, so
+fewer/fatter semantic ops are an advantage, and the interpreter remains the
+bailout tier — interpreter-side wins keep paying off post-JIT). The problems
+were operational, not architectural: one variant taxing the whole stream's
+memory layout, unmeasured frequency, and accumulated dead weight. Variant
+count (~340) is high but mostly reflects Raku's semantic surface plus
+slot-baked/fused specializations; consolidation (e.g. `ContainerEq`×4,
+`IndexAssign*`×6, `MakeAnonSub`×3) is possible but should be driven by the new
+histogram, not aesthetics.

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -223,30 +223,32 @@ impl Compiler {
             .and_then(|p| self.local_map.get(p.as_str()).copied());
         let source_var_names = Self::for_iterable_var_names(iterable);
         let source_var_locals = self.for_source_var_locals(&source_var_names);
-        let loop_idx = self.code.emit(OpCode::ForLoop {
-            param_idx,
-            param_local,
-            body_end: 0,
-            label: label.clone(),
-            arity,
-            collect: true,
-            restore_topic: true,
-            threaded: false,
-            is_rw: has_rw,
-            do_writeback: has_rw,
-            rw_param_names: Vec::new(),
-            kv_mode: false,
-            source_var_names,
-            source_var_locals,
-            autothread_junctions: false,
-            explicit_zero_params: false,
-            multi_param_names: Vec::new(),
-            loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
-            values_mode: Self::for_iterable_is_values_alias(iterable),
-            single_array_source: Self::for_single_array_source(iterable),
-            single_array_source_local: self
-                .for_single_array_source_local(&Self::for_single_array_source(iterable)),
-        });
+        let loop_idx = self
+            .code
+            .emit(OpCode::ForLoop(Box::new(crate::opcode::ForLoopSpec {
+                param_idx,
+                param_local,
+                body_end: 0,
+                label: label.clone(),
+                arity,
+                collect: true,
+                restore_topic: true,
+                threaded: false,
+                is_rw: has_rw,
+                do_writeback: has_rw,
+                rw_param_names: Vec::new(),
+                kv_mode: false,
+                source_var_names,
+                source_var_locals,
+                autothread_junctions: false,
+                explicit_zero_params: false,
+                multi_param_names: Vec::new(),
+                loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
+                values_mode: Self::for_iterable_is_values_alias(iterable),
+                single_array_source: Self::for_single_array_source(iterable),
+                single_array_source_local: self
+                    .for_single_array_source_local(&Self::for_single_array_source(iterable)),
+            })));
         self.compile_collected_loop_body(&loop_body);
         self.code.patch_loop_end(loop_idx);
         // Balance the ForLoop opcode's deferred param-restore push (see the

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1755,38 +1755,41 @@ impl Compiler {
                     // No param_def means default (Mu) — no autothreading
                     None => false,
                 };
-                let loop_idx = self.code.emit(OpCode::ForLoop {
-                    param_idx,
-                    param_local,
-                    body_end: 0,
-                    label: label.clone(),
-                    arity,
-                    collect: false,
-                    restore_topic,
-                    threaded: matches!(
-                        *mode,
-                        crate::ast::ForMode::Race | crate::ast::ForMode::Hyper
-                    ),
-                    // is_rw: param is writable (don't mark readonly)
-                    is_rw: has_rw || has_copy,
-                    // do_writeback: actually write back modifications to source container
-                    do_writeback: has_rw && !has_copy,
-                    rw_param_names,
-                    kv_mode,
-                    source_var_names,
-                    source_var_locals,
-                    autothread_junctions,
-                    explicit_zero_params: *explicit_zero_params,
-                    multi_param_names: params
-                        .iter()
-                        .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
-                        .collect(),
-                    loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
-                    values_mode: Self::for_iterable_is_values_alias(iterable),
-                    single_array_source: Self::for_single_array_source(iterable),
-                    single_array_source_local: self
-                        .for_single_array_source_local(&Self::for_single_array_source(iterable)),
-                });
+                let loop_idx =
+                    self.code
+                        .emit(OpCode::ForLoop(Box::new(crate::opcode::ForLoopSpec {
+                            param_idx,
+                            param_local,
+                            body_end: 0,
+                            label: label.clone(),
+                            arity,
+                            collect: false,
+                            restore_topic,
+                            threaded: matches!(
+                                *mode,
+                                crate::ast::ForMode::Race | crate::ast::ForMode::Hyper
+                            ),
+                            // is_rw: param is writable (don't mark readonly)
+                            is_rw: has_rw || has_copy,
+                            // do_writeback: actually write back modifications to source container
+                            do_writeback: has_rw && !has_copy,
+                            rw_param_names,
+                            kv_mode,
+                            source_var_names,
+                            source_var_locals,
+                            autothread_junctions,
+                            explicit_zero_params: *explicit_zero_params,
+                            multi_param_names: params
+                                .iter()
+                                .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
+                                .collect(),
+                            loop_var_wraps_element: Self::for_iterable_wraps_pair(iterable),
+                            values_mode: Self::for_iterable_is_values_alias(iterable),
+                            single_array_source: Self::for_single_array_source(iterable),
+                            single_array_source_local: self.for_single_array_source_local(
+                                &Self::for_single_array_source(iterable),
+                            ),
+                        })));
                 // Register sigilless for-params (`-> \v`, `-> \k, \v`) as
                 // sigilless locals while compiling the body so postfix/prefix
                 // `++`/`--` on the bare word (`v--`, `++v`) resolve to an

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -112,6 +112,81 @@ impl CompoundBaseOp {
     }
 }
 
+/// Payload of `OpCode::ForLoop`, boxed to keep `size_of::<OpCode>()` small.
+/// This is by far the widest instruction (it used to carry three `Vec<String>`s
+/// plus two `Option<String>`s inline, padding EVERY opcode in every
+/// `Vec<OpCode>` to 192 bytes — see docs/opcode-design-review.md). The VM
+/// borrows the boxed spec directly, so executing a `for` loop no longer clones
+/// any of these fields.
+#[derive(Debug, Clone)]
+pub(crate) struct ForLoopSpec {
+    pub(crate) param_idx: Option<u32>,
+    pub(crate) param_local: Option<u32>,
+    pub(crate) body_end: u32,
+    pub(crate) label: Option<String>,
+    pub(crate) arity: u32,
+    pub(crate) collect: bool,
+    /// Restore outer `$_` after loop execution (used by postfix/do-for semantics).
+    pub(crate) restore_topic: bool,
+    /// When true, run the loop body in a spawned thread (race for / hyper for).
+    pub(crate) threaded: bool,
+    /// When true, the named param is writable (via `<->`, `is rw`, or `is copy`).
+    pub(crate) is_rw: bool,
+    /// When true, write back modifications to the source container.
+    pub(crate) do_writeback: bool,
+    /// Param names for multi-param rw for loops (used for writeback).
+    pub(crate) rw_param_names: Vec<String>,
+    /// When true, the iterable is from .kv (key-value pairs).
+    /// Writeback only applies to value params (odd-indexed in the chunk).
+    pub(crate) kv_mode: bool,
+    /// Variable names for per-element writeback when the iterable is a list
+    /// of scalar variables (e.g. `for ($a, $b, $c) { $_++ }`).
+    pub(crate) source_var_names: Vec<String>,
+    /// Compiler-baked local slot for each `source_var_names` entry (§1.5): the
+    /// per-element writeback (`write_back_to_source_var`) writes the mutated
+    /// loop value straight into `locals[slot]` instead of re-resolving the
+    /// target name via `update_local_if_exists`. `None` for a target with no
+    /// local slot (`our`/global/undeclared), which keeps the by-name path.
+    /// Parallel to `source_var_names`.
+    pub(crate) source_var_locals: Vec<Option<u32>>,
+    /// When true, Junction items are expanded into their eigenstates
+    /// (parameter type is Any or more specific, not Mu or Junction).
+    pub(crate) autothread_junctions: bool,
+    /// When true, the block explicitly declared zero parameters (`-> {}`).
+    /// Passing any argument should throw "Too many positionals passed".
+    pub(crate) explicit_zero_params: bool,
+    /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
+    /// Used to temporarily clear sigilless readonly flags before binding.
+    pub(crate) multi_param_names: Vec<String>,
+    /// When true, the iterable is a `.pairs`/`.antipairs` transform: the
+    /// loop variable is a `Pair` that *wraps* the source element, not the
+    /// element itself. The plain (topic/named) per-element source writeback
+    /// is suppressed (it would overwrite the element with the Pair); the
+    /// source tag is still kept so the Pair's rw `.value` alias can detect
+    /// immutability and propagate.
+    pub(crate) loop_var_wraps_element: bool,
+    /// When true, the iterable is `%h.values` / `$b.values` on a variable:
+    /// the loop variable (`$_` / a plain named param) aliases the container's
+    /// *value*, so a `$_ = ...` topic assignment writes back to the source by
+    /// key order (`$_ = X for %h.values` mutates `%h`; `for $b.values` mutates
+    /// a mutable MixHash/BagHash). The VM branches on the runtime container
+    /// type. Distinguished from bare `for %h` (Pairs, no value writeback) and
+    /// `.keys` (read-only).
+    pub(crate) values_mode: bool,
+    /// The bare source array variable name for `for @a` (without sigil), when
+    /// the iterable is a single plain array variable. Enables live-array
+    /// iteration: if the loop body pushes onto `@a`, the loop keeps yielding
+    /// the newly-appended tail (raku semantics). `None` for any non-trivial
+    /// iterable. Separate from `source_var_names` (a per-index scalar-list
+    /// writeback mechanism that must NOT be populated for a `@`-source).
+    pub(crate) single_array_source: Option<String>,
+    /// Compiler-baked local slot for `single_array_source` (§1.5): the
+    /// live-array re-read reads `locals[slot]` directly instead of resolving
+    /// the source name via `find_local_slot`. `None` when the source is not a
+    /// resolvable local (keeps the by-name + env fallback).
+    pub(crate) single_array_source_local: Option<u32>,
+}
+
 /// Bytecode operations for the VM.
 #[derive(Debug, Clone)]
 pub(crate) enum OpCode {
@@ -435,10 +510,6 @@ pub(crate) enum OpCode {
         exclude_end: bool,
     },
 
-    // -- Nil check (for defined-or //) --
-    #[allow(dead_code)]
-    IsNil,
-
     // -- Control flow --
     /// No-op label marker for `goto`.
     Label(u32),
@@ -447,9 +518,6 @@ pub(crate) enum OpCode {
     Jump(i32),
     JumpIfFalse(i32),
     JumpIfTrue(i32),
-    /// Jump if top of stack is nil/undefined (without popping)
-    #[allow(dead_code)]
-    JumpIfNil(i32),
     /// Jump if top of stack is not nil/defined (without popping)
     JumpIfNotNil(i32),
     /// Call .defined on top of stack, replace with Bool result
@@ -692,12 +760,7 @@ pub(crate) enum OpCode {
     Index {
         is_positional: bool,
     },
-    /// Like Index, but auto-vivifies intermediate hash entries and returns
-    /// a `HashEntryRef` for the final key.  Used by IndexAutovivifyLazy's
-    /// fallback path for non-hash targets.
-    #[allow(dead_code)]
-    IndexAutovivify,
-    /// Like IndexAutovivify but does NOT create the hash entry if missing.
+    /// Auto-vivifying index that does NOT create the hash entry if missing.
     /// Returns a HashEntryRef that defers creation until write.
     /// Used for the outermost level of `:=` bind so that binding alone
     /// does not autovivify (e.g. `my $b := %h<a><b>` keeps %h empty).
@@ -715,7 +778,6 @@ pub(crate) enum OpCode {
     DeleteIndexExpr,
     /// Multi-dimensional indexing: @a[$x;$y;$z]
     /// Stack: [target, dim0, dim1, ..., dimN] → [result]
-    #[allow(dead_code)]
     MultiDimIndex(u32),
     /// Multi-dimensional index assignment: @a[$x;$y;$z] = value
     /// Stack: [value, dim0, dim1, ..., dimN] (target by name)
@@ -884,73 +946,8 @@ pub(crate) enum OpCode {
     },
     /// For loop. Iterable value must be on stack.
     /// Body opcodes at [ip+1..body_end). VM iterates internally.
-    ForLoop {
-        param_idx: Option<u32>,
-        param_local: Option<u32>,
-        body_end: u32,
-        label: Option<String>,
-        arity: u32,
-        collect: bool,
-        /// Restore outer `$_` after loop execution (used by postfix/do-for semantics).
-        restore_topic: bool,
-        /// When true, run the loop body in a spawned thread (race for / hyper for).
-        threaded: bool,
-        /// When true, the named param is writable (via `<->`, `is rw`, or `is copy`).
-        is_rw: bool,
-        /// When true, write back modifications to the source container.
-        do_writeback: bool,
-        /// Param names for multi-param rw for loops (used for writeback).
-        rw_param_names: Vec<String>,
-        /// When true, the iterable is from .kv (key-value pairs).
-        /// Writeback only applies to value params (odd-indexed in the chunk).
-        kv_mode: bool,
-        /// Variable names for per-element writeback when the iterable is a list
-        /// of scalar variables (e.g. `for ($a, $b, $c) { $_++ }`).
-        source_var_names: Vec<String>,
-        /// Compiler-baked local slot for each `source_var_names` entry (§1.5): the
-        /// per-element writeback (`write_back_to_source_var`) writes the mutated
-        /// loop value straight into `locals[slot]` instead of re-resolving the
-        /// target name via `update_local_if_exists`. `None` for a target with no
-        /// local slot (`our`/global/undeclared), which keeps the by-name path.
-        /// Parallel to `source_var_names`.
-        source_var_locals: Vec<Option<u32>>,
-        /// When true, Junction items are expanded into their eigenstates
-        /// (parameter type is Any or more specific, not Mu or Junction).
-        autothread_junctions: bool,
-        /// When true, the block explicitly declared zero parameters (`-> {}`).
-        /// Passing any argument should throw "Too many positionals passed".
-        explicit_zero_params: bool,
-        /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
-        /// Used to temporarily clear sigilless readonly flags before binding.
-        multi_param_names: Vec<String>,
-        /// When true, the iterable is a `.pairs`/`.antipairs` transform: the
-        /// loop variable is a `Pair` that *wraps* the source element, not the
-        /// element itself. The plain (topic/named) per-element source writeback
-        /// is suppressed (it would overwrite the element with the Pair); the
-        /// source tag is still kept so the Pair's rw `.value` alias can detect
-        /// immutability and propagate.
-        loop_var_wraps_element: bool,
-        /// When true, the iterable is `%h.values` / `$b.values` on a variable:
-        /// the loop variable (`$_` / a plain named param) aliases the container's
-        /// *value*, so a `$_ = ...` topic assignment writes back to the source by
-        /// key order (`$_ = X for %h.values` mutates `%h`; `for $b.values` mutates
-        /// a mutable MixHash/BagHash). The VM branches on the runtime container
-        /// type. Distinguished from bare `for %h` (Pairs, no value writeback) and
-        /// `.keys` (read-only).
-        values_mode: bool,
-        /// The bare source array variable name for `for @a` (without sigil), when
-        /// the iterable is a single plain array variable. Enables live-array
-        /// iteration: if the loop body pushes onto `@a`, the loop keeps yielding
-        /// the newly-appended tail (raku semantics). `None` for any non-trivial
-        /// iterable. Separate from `source_var_names` (a per-index scalar-list
-        /// writeback mechanism that must NOT be populated for a `@`-source).
-        single_array_source: Option<String>,
-        /// Compiler-baked local slot for `single_array_source` (§1.5): the
-        /// live-array re-read reads `locals[slot]` directly instead of resolving
-        /// the source name via `find_local_slot`. `None` when the source is not a
-        /// resolvable local (keeps the by-name + env fallback).
-        single_array_source_local: Option<u32>,
-    },
+    /// The spec is boxed to keep `size_of::<OpCode>()` small (see `ForLoopSpec`).
+    ForLoop(Box<ForLoopSpec>),
     /// Restore the single named for-loop param's prior binding, deferred until
     /// after the loop's LAST/post phasers have run (which must still see the
     /// param bound to its final iteration value). Pairs with the push the
@@ -1387,6 +1384,27 @@ pub(crate) enum OpCode {
     SetSourceLine(i64),
 }
 
+#[cfg(test)]
+mod opcode_size_guard {
+    use super::*;
+    #[test]
+    fn opcode_stays_small() {
+        // Every instruction in a `Vec<OpCode>` is padded to the widest variant,
+        // so one fat variant taxes the fetch/decode cache locality of ALL code.
+        // `ForLoop` used to hold its 21-field spec inline (192 bytes); boxing it
+        // brought `OpCode` to 48 bytes (current widest: `SmartMatchExpr`, `Subst`).
+        //
+        // If this assert fails because you added/widened a variant: do NOT just
+        // bump the limit. First try to keep `OpCode` at the current size —
+        // `Box` the payload (like `ForLoop(Box<ForLoopSpec>)`), move strings to
+        // the constant pool as `u32` indices, or pack flags. Raise the limit
+        // only when none of those work, and record the reasoning in
+        // docs/opcode-design-review.md.
+        let sz = std::mem::size_of::<OpCode>();
+        assert!(sz <= 48, "size_of::<OpCode>() = {sz}, expected <= 48");
+    }
+}
+
 /// A compiled chunk of bytecode.
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledCode {
@@ -1702,7 +1720,7 @@ impl CompiledCode {
         self.captures_env_by_name = self.ops.iter().any(|op| {
             matches!(
                 op,
-                OpCode::ForLoop { .. }
+                OpCode::ForLoop(..)
                     | OpCode::BlockScope { .. }
                     | OpCode::BlockLocalScope { .. }
                     | OpCode::MakeGather(_)
@@ -2398,7 +2416,6 @@ impl CompiledCode {
             OpCode::Jump(offset)
             | OpCode::JumpIfFalse(offset)
             | OpCode::JumpIfTrue(offset)
-            | OpCode::JumpIfNil(offset)
             | OpCode::JumpIfNotNil(offset) => {
                 *offset = target;
             }
@@ -2413,7 +2430,6 @@ impl CompiledCode {
             OpCode::Jump(offset)
             | OpCode::JumpIfFalse(offset)
             | OpCode::JumpIfTrue(offset)
-            | OpCode::JumpIfNil(offset)
             | OpCode::JumpIfNotNil(offset) => {
                 *offset = target;
             }
@@ -2431,7 +2447,7 @@ impl CompiledCode {
         let target = self.ops.len() as u32;
         match &mut self.ops[idx] {
             OpCode::WhileLoop { body_end, .. } => *body_end = target,
-            OpCode::ForLoop { body_end, .. } => *body_end = target,
+            OpCode::ForLoop(spec) => spec.body_end = target,
             OpCode::CStyleLoop { body_end, .. } => *body_end = target,
             OpCode::RepeatLoop { body_end, .. } => *body_end = target,
             OpCode::BlockScope { end, .. } => *end = target,
@@ -2807,7 +2823,7 @@ impl CompiledFunction {
                         | OpCode::CallOnValue { .. }
                         | OpCode::CallOnCodeVar { .. }
                         // ForLoop may have FIRST/NEXT/LAST phasers that need proper state
-                        | OpCode::ForLoop { .. }
+                        | OpCode::ForLoop(..)
                 )
             });
         // A routine declared directly in this body (not inside a nested

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -1,41 +1,9 @@
 use super::*;
 use crate::symbol::Symbol;
 
-pub(super) struct ForLoopSpec {
-    pub(super) param_idx: Option<u32>,
-    pub(super) param_local: Option<u32>,
-    pub(super) body_end: u32,
-    pub(super) label: Option<String>,
-    pub(super) arity: u32,
-    pub(super) collect: bool,
-    pub(super) restore_topic: bool,
-    pub(super) threaded: bool,
-    pub(super) is_rw: bool,
-    pub(super) do_writeback: bool,
-    pub(super) rw_param_names: Vec<String>,
-    pub(super) kv_mode: bool,
-    pub(super) source_var_names: Vec<String>,
-    /// Compiler-baked local slot for each `source_var_names` entry (§1.5).
-    pub(super) source_var_locals: Vec<Option<u32>>,
-    pub(super) autothread_junctions: bool,
-    /// When true, `-> {}` was used — throw on any items.
-    pub(super) explicit_zero_params: bool,
-    /// Names of multi-param bindings (for `-> $a, \b, $c` loops).
-    /// Used to temporarily clear sigilless readonly flags before binding.
-    pub(super) multi_param_names: Vec<String>,
-    /// When true (`.pairs`/`.antipairs`), the loop variable is a `Pair` wrapping
-    /// the element, so the plain per-element source writeback is suppressed.
-    pub(super) loop_var_wraps_element: bool,
-    /// When true (`%h.values` / `$b.values`), the loop variable aliases the
-    /// container's value, so a `$_ = ...` topic writeback updates the source
-    /// (plain Hash or mutable MixHash/BagHash) by key order.
-    pub(super) values_mode: bool,
-    /// Bare source array name for `for @a` (live-array iteration). See the
-    /// `OpCode::ForLoop` field of the same name.
-    pub(super) single_array_source: Option<String>,
-    /// Compiler-baked local slot for `single_array_source` (§1.5).
-    pub(super) single_array_source_local: Option<u32>,
-}
+// The for-loop spec now lives in `opcode.rs` (the `OpCode::ForLoop` payload is
+// `Box<ForLoopSpec>`, so the VM borrows it directly instead of cloning fields).
+pub(super) use crate::opcode::ForLoopSpec;
 
 pub(super) struct WhileLoopSpec {
     pub(super) cond_end: u32,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -115,6 +115,9 @@ impl Interpreter {
             ip,
             std::mem::discriminant(&code.ops[*ip])
         );
+        // Per-opcode execution histogram (MUTSU_VM_STATS=1 only; a single
+        // cached bool load when off). Feeds instruction-set tuning decisions.
+        crate::vm::vm_stats::record_opcode(&code.ops[*ip]);
         // Track the currently-executing frame's code so the lazy-force machinery
         // can reconcile this (caller) frame's local slots from env after a reify
         // that mutated a captured-outer lexical (Slice F). See `current_code`.
@@ -1956,13 +1959,6 @@ impl Interpreter {
                 *ip += 1;
             }
 
-            // -- Nil check --
-            OpCode::IsNil => {
-                let val = self.stack.pop().unwrap();
-                self.stack.push(Value::Bool(matches!(val, Value::Nil)));
-                *ip += 1;
-            }
-
             // -- Control flow --
             OpCode::Label(_) => {
                 *ip += 1;
@@ -1994,15 +1990,6 @@ impl Interpreter {
                 Self::mark_failure_handled_on_stack(&mut self.stack);
                 let val = self.stack.last().unwrap().clone();
                 if self.eval_truthy(&val) {
-                    *ip = *target as usize;
-                } else {
-                    *ip += 1;
-                }
-            }
-            OpCode::JumpIfNil(target) => {
-                Self::mark_failure_handled_on_stack(&mut self.stack);
-                let val = self.stack.last().unwrap();
-                if !runtime::types::value_is_defined(val) {
                     *ip = *target as usize;
                 } else {
                     *ip += 1;
@@ -2801,10 +2788,6 @@ impl Interpreter {
                 self.exec_index_op_with_positional(*is_positional)?;
                 *ip += 1;
             }
-            OpCode::IndexAutovivify => {
-                self.exec_index_autovivify_op()?;
-                *ip += 1;
-            }
             OpCode::IndexAutovivifyLazy => {
                 self.exec_index_autovivify_lazy_op(false)?;
                 *ip += 1;
@@ -3096,53 +3079,8 @@ impl Interpreter {
                 };
                 self.exec_while_loop_op(code, &spec, ip, compiled_fns)?;
             }
-            OpCode::ForLoop {
-                param_idx,
-                param_local,
-                body_end,
-                label,
-                arity,
-                collect,
-                restore_topic,
-                threaded,
-                is_rw,
-                do_writeback,
-                rw_param_names,
-                kv_mode,
-                source_var_names,
-                source_var_locals,
-                autothread_junctions,
-                explicit_zero_params,
-                multi_param_names,
-                loop_var_wraps_element,
-                values_mode,
-                single_array_source,
-                single_array_source_local,
-            } => {
-                let spec = vm_control_ops::ForLoopSpec {
-                    param_idx: *param_idx,
-                    param_local: *param_local,
-                    body_end: *body_end,
-                    label: label.clone(),
-                    arity: *arity,
-                    collect: *collect,
-                    restore_topic: *restore_topic,
-                    threaded: *threaded,
-                    is_rw: *is_rw,
-                    do_writeback: *do_writeback,
-                    rw_param_names: rw_param_names.clone(),
-                    kv_mode: *kv_mode,
-                    source_var_names: source_var_names.clone(),
-                    source_var_locals: source_var_locals.clone(),
-                    autothread_junctions: *autothread_junctions,
-                    explicit_zero_params: *explicit_zero_params,
-                    multi_param_names: multi_param_names.clone(),
-                    loop_var_wraps_element: *loop_var_wraps_element,
-                    values_mode: *values_mode,
-                    single_array_source: single_array_source.clone(),
-                    single_array_source_local: *single_array_source_local,
-                };
-                self.exec_for_loop_op(code, &spec, ip, compiled_fns)?;
+            OpCode::ForLoop(spec) => {
+                self.exec_for_loop_op(code, spec, ip, compiled_fns)?;
             }
             OpCode::RestoreForParam => {
                 // Restore the single named for-loop param's prior binding now

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -51,6 +51,22 @@ fn function_carrier_by_name() -> &'static Mutex<HashMap<String, u64>> {
     BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Per-opcode execution histogram (only populated when stats are on). Keyed by
+/// the opcode's `Discriminant` so the per-instruction cost is one discriminant
+/// hash + counter bump under the mutex; the human-readable variant name is
+/// derived once per variant from the `Debug` representation (truncated at the
+/// first non-identifier character). This is the empirical basis for
+/// instruction-set decisions (which ops to fuse/shrink/remove) — see
+/// docs/opcode-design-review.md.
+#[allow(clippy::type_complexity)]
+fn opcode_histogram()
+-> &'static Mutex<HashMap<std::mem::Discriminant<crate::opcode::OpCode>, (String, u64)>> {
+    static HIST: OnceLock<
+        Mutex<HashMap<std::mem::Discriminant<crate::opcode::OpCode>, (String, u64)>>,
+    > = OnceLock::new();
+    HIST.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// Per-name histogram of method calls that entered the slow-path resolver dispatch
 /// `run_instance_method` (resolve candidate + frame setup + env clone). §B #3680
 /// deleted the tree-walk of the method body, so these now execute the body as
@@ -91,6 +107,33 @@ static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
 pub(crate) fn enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("MUTSU_VM_STATS").is_some())
+}
+
+/// Record one bytecode instruction dispatch (called from `exec_one` when stats
+/// are on). Counts are exact and deterministic; the mutex + hash cost only
+/// exists under `MUTSU_VM_STATS=1`, so use the counts (not wall-clock) from
+/// instrumented runs.
+#[inline]
+pub(crate) fn record_opcode(op: &crate::opcode::OpCode) {
+    if !enabled() {
+        return;
+    }
+    let d = std::mem::discriminant(op);
+    if let Ok(mut map) = opcode_histogram().lock() {
+        match map.get_mut(&d) {
+            Some(entry) => entry.1 += 1,
+            None => {
+                // First time this variant is seen: derive its bare name from the
+                // Debug output (`ForLoop(..)` / `WhileLoop { .. }` -> `ForLoop`).
+                let dbg = format!("{op:?}");
+                let name: String = dbg
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .collect();
+                map.insert(d, (name, 1));
+            }
+        }
+    }
 }
 
 /// Record that an explicit method-call opcode (`.foo(...)`) was executed.
@@ -295,6 +338,25 @@ pub(crate) fn dump() {
     eprintln!(
         "[mutsu vm-stats] gc: collections={gc_collections} candidate_pushes={gc_candidate_pushes} dedup_hits={gc_dedup_hits} reclaimed_nodes={gc_reclaimed_nodes} reclaimed_cycles={gc_reclaimed_cycles} pause_ns_total={gc_pause_ns_total} pause_ns_max={gc_pause_ns_max} roots_scanned={gc_roots_scanned} gc_threshold={gc_threshold}"
     );
+    if let Ok(map) = opcode_histogram().lock()
+        && !map.is_empty()
+    {
+        let total: u64 = map.values().map(|(_, c)| c).sum();
+        let mut entries: Vec<(&String, &u64)> = map.values().map(|(n, c)| (n, c)).collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(30)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] opcodes executed total={} distinct={} (top {}): {}",
+            total,
+            map.len(),
+            top.len(),
+            top.join(" ")
+        );
+    }
     if let Ok(map) = function_fallback_by_name().lock()
         && !map.is_empty()
     {


### PR DESCRIPTION
## Summary

Instruction-set hygiene slice from a design audit of the bytecode ISA (full findings in the new `docs/opcode-design-review.md`):

- **`size_of::<OpCode>()`: 192 → 48 bytes.** The `ForLoop` variant carried its 21-field spec inline (3× `Vec<String>` + `Vec<Option<u32>>` + 2× `Option<String>`), padding every instruction in every `Vec<OpCode>` to 192 bytes. The spec now lives in `opcode.rs` as `ForLoopSpec` and the variant is `ForLoop(Box<ForLoopSpec>)`. The VM borrows the boxed spec directly, which also removes the per-loop-entry clone of all heap fields.
- **Layout pinned by a new `opcode_size_guard` test** (`<= 48`), with a comment instructing future variants to box/pool payloads before raising the limit.
- **Per-opcode execution histogram under `MUTSU_VM_STATS=1`** (discriminant-keyed; variant name derived once from `Debug`; a single cached bool load when off). First data point: one iteration of `$s += $_` in a `for` loop executes 6 ops (`SetSourceLine`, `GetLocal`, `SetLocal`, `Add`, `CheckReadOnly`, `GetGlobal`) — future fusion targets are now measurable.
- **Dead opcodes removed:** `IsNil`, `JumpIfNil`, `IndexAutovivify` had live `exec_one` arms but zero compiler emit sites. Stale `#[allow(dead_code)]` removed from live `MultiDimIndex`.
- CLAUDE.md opcode count corrected (~100 → ~340).

Deferred follow-ups are recorded in the review doc: label strings → constant pool (kills the remaining per-entry clones), `current_code`/trace-check hoisting out of the per-instruction prologue, `Jump(i32)`-holds-absolute-target cleanup.

## Test plan

- `make test` — all 15263 tests in 1556 files pass locally
- roast `S04-statements/{for,last,next,loop}.t` pass
- for-loop smoke (labels, `<->` rw writeback, `.kv`, live-array append, `do for`, scalar-list `$_++` writeback) output matches
- `cargo clippy -- -D warnings` / `cargo fmt` clean
- CI runs full `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK