### PR TITLE
fix(collation): order noncharacters by codepoint in unicmp/coll

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -255,13 +255,14 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。スライス計画
       （3b-0 API 壁 → 3b-1 表現スイッチ → 3b-2 交通量刈り）とゲートは
       [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3。
-- [ ] **Lever 3: threaded dispatch — 凍結提案**（[ADR-0004](docs/adr/0004-jit-strategy.md) §2.5 J0）:
+- **Lever 3: threaded dispatch — 凍結**（2026-07-06 ユーザー承認・[ADR-0004](docs/adr/0004-jit-strategy.md) §2.5 J0）:
       JIT Tier A が dispatch ループ除去で同じ利得をより大きく取るため二重投資を避ける。
       JIT が頓挫した場合のみ復活。
 - [ ] **Lever 4: JIT（Cranelift）= ADR-0001 層4（GC の後）/ Lever 5: 型制約チェックの tight-loop 省略**。
       方式・フェーズ（J1 骨組み → J2 Tier A 網羅 → J3 呼び出し規約/IC → J4 Tier B インライン →
-      J5 既定 on）とゲートは **[ADR-0004（Proposed）](docs/adr/0004-jit-strategy.md)** に策定済み。
+      J5 既定 on）とゲートは **[ADR-0004（Accepted 2026-07-06）](docs/adr/0004-jit-strategy.md)**。
       deopt/stack map なしの subroutine-threading 起点、safepoint poll で GC の STW に協調。
+      着手条件 = 層3b（Lever 2）のゲート達成。
 - [ ] **Lever 6: biased reference counting = ADR-0001 層3c（GC 後の独立 perf）**。凍結 — 着手トリガは
       「JIT J4 完了後の profile で atomic inc/dec が上位に残る」のみ（gc-post-3a-roadmap §4）。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。

--- a/docs/adr/0004-jit-strategy.md
+++ b/docs/adr/0004-jit-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0004: JIT の方式選定とフェーズ計画（層4）
 
-- **Status**: Proposed（2026-07-05）
+- **Status**: Accepted（2026-07-06 ユーザー承認 — Lever 3 凍結を含む）
 - **Date**: 2026-07-05
 - **Deciders**: tokuhirom, Claude
 - **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（フェーズ順序 3a→3b→4、レベル1 GC が
@@ -123,5 +123,5 @@ JIT の最初の形は「opcode 列を、**VM ヘルパ関数呼び出しの列*
 
 ---
 
-*本 ADR は Proposed。ユーザー承認後に Accepted へ更新し、J1 着手時に PLAN.md §5 を本 ADR
-参照に差し替える。*
+*2026-07-06 ユーザー承認により Accepted（Lever 3 の凍結も同時承認）。実装は
+gc-post-3a-roadmap の層3b（NaN-boxing）完了後、§2.5 のフェーズ J1 から着手する。*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,4 +22,4 @@
 | [0001](0001-gc-strategy-and-phasing.md) | GC 導入の方式選定とフェーズ計画 | Accepted |
 | [0002](0002-phase-a-gate-reassessment.md) | Phase A ゲート再評価 — GC 着手条件の充足確認 | Accepted |
 | [0003](0003-default-on-gc-trigger.md) | デフォルト GC=on のトリガ方針（同期 + バッファサイズ閾値 + adaptive backoff） | Accepted |
-| [0004](0004-jit-strategy.md) | JIT の方式選定とフェーズ計画（Cranelift method JIT・deopt なし） | Proposed |
+| [0004](0004-jit-strategy.md) | JIT の方式選定とフェーズ計画（Cranelift method JIT・deopt なし） | Accepted |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1210,6 +1210,7 @@ roast/S32-str/Collation.t
 roast/S32-str/CollationTest_NON_IGNORABLE-0.t
 roast/S32-str/CollationTest_NON_IGNORABLE-1.t
 roast/S32-str/CollationTest_NON_IGNORABLE-2.t
+roast/S32-str/CollationTest_NON_IGNORABLE-3.t
 roast/S32-str/append.t
 roast/S32-str/bool.t
 roast/S32-str/capitalize.t

--- a/src/builtins/collation.rs
+++ b/src/builtins/collation.rs
@@ -116,22 +116,66 @@ pub fn coll_compare(left: &str, right: &str, settings: &CollationSettings) -> Va
 /// - Tertiary: case (ICU Tertiary)
 /// - Quaternary: codepoint comparison (NOT ICU Quaternary; uses raw codepoint order)
 pub fn coll_ordering(left: &str, right: &str, settings: &CollationSettings) -> std::cmp::Ordering {
-    // Compare at each ICU strength level to isolate per-level differences.
-    let at_primary = icu_compare_at_strength(left, right, Strength::Primary);
-    let at_secondary = icu_compare_at_strength(left, right, Strength::Secondary);
-    let at_tertiary = icu_compare_at_strength(left, right, Strength::Tertiary);
-
-    // Extract per-level deltas
-    let delta_primary = at_primary;
-    let delta_secondary = if at_primary == std::cmp::Ordering::Equal {
-        at_secondary
-    } else {
-        std::cmp::Ordering::Equal
+    // ICU4X special-cases Unicode noncharacters in its UCA weighting: U+FFFE and
+    // the other `*FFFE` codepoints are treated as merge separators (a minimal,
+    // near-ignorable primary weight) and U+FFFF as a high sentinel. Raku's
+    // reference collation (MoarVM) instead assigns every "implicit weight"
+    // codepoint (noncharacters and unassigned/private-use, i.e. those with no
+    // DUCET entry) a plain implicit primary weight ordered by codepoint, so they
+    // sort among themselves in codepoint order.
+    //
+    // ICU only mis-orders such codepoints *relative to each other* (e.g.
+    // <reserved-FFF0> vs <noncharacter-FFFE>); it orders an implicit codepoint
+    // against an assigned one (e.g. <noncharacter-10FFFF> vs U+FFFD REPLACEMENT
+    // CHARACTER, which has a real DUCET weight) correctly. So we only override
+    // ICU when the first differing codepoint pair between the two strings is
+    // implicit-weighted on *both* sides; otherwise we defer to ICU.
+    // (See roast/S32-str/CollationTest_NON_IGNORABLE-3.t.)
+    use crate::builtins::unicode::{is_noncharacter, unicode_general_category};
+    let is_implicit_weight = |c: char| -> bool {
+        // General_Category Cn (unassigned, which also covers noncharacters) and
+        // Co (private use) get UCA implicit weights rather than DUCET entries.
+        matches!(unicode_general_category(c).as_str(), "Cn" | "Co")
     };
-    let delta_tertiary = if at_secondary == std::cmp::Ordering::Equal {
-        at_tertiary
+    let has_noncharacter = |s: &str| s.chars().any(|c| is_noncharacter(c as u32));
+    let first_diff_both_implicit =
+        left != right && (has_noncharacter(left) || has_noncharacter(right)) && {
+            let mut lc = left.chars();
+            let mut rc = right.chars();
+            loop {
+                match (lc.next(), rc.next()) {
+                    (Some(l), Some(r)) if l == r => continue,
+                    (Some(l), Some(r)) => break is_implicit_weight(l) && is_implicit_weight(r),
+                    // One string is a prefix of the other: let ICU decide.
+                    _ => break false,
+                }
+            }
+        };
+    let (delta_primary, delta_secondary, delta_tertiary) = if first_diff_both_implicit {
+        (
+            left.cmp(right),
+            std::cmp::Ordering::Equal,
+            std::cmp::Ordering::Equal,
+        )
     } else {
-        std::cmp::Ordering::Equal
+        // Compare at each ICU strength level to isolate per-level differences.
+        let at_primary = icu_compare_at_strength(left, right, Strength::Primary);
+        let at_secondary = icu_compare_at_strength(left, right, Strength::Secondary);
+        let at_tertiary = icu_compare_at_strength(left, right, Strength::Tertiary);
+
+        // Extract per-level deltas
+        let delta_primary = at_primary;
+        let delta_secondary = if at_primary == std::cmp::Ordering::Equal {
+            at_secondary
+        } else {
+            std::cmp::Ordering::Equal
+        };
+        let delta_tertiary = if at_secondary == std::cmp::Ordering::Equal {
+            at_tertiary
+        } else {
+            std::cmp::Ordering::Equal
+        };
+        (delta_primary, delta_secondary, delta_tertiary)
     };
     // Raku's quaternary level uses codepoint comparison
     let delta_quaternary = left.cmp(right);

--- a/src/builtins/unicode.rs
+++ b/src/builtins/unicode.rs
@@ -896,7 +896,7 @@ pub(crate) fn unicode_decimal_digit_value(c: char) -> Option<u32> {
 }
 
 /// Check if a codepoint is a Unicode noncharacter.
-fn is_noncharacter(cp: u32) -> bool {
+pub(crate) fn is_noncharacter(cp: u32) -> bool {
     // U+FDD0..U+FDEF
     if (0xFDD0..=0xFDEF).contains(&cp) {
         return true;

--- a/t/unicmp.t
+++ b/t/unicmp.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 12;
+plan 18;
 
 # Structural infix operators (cmp/leg/coll/unicmp) cannot be used in reduction
 # form: they are diffy and not chaining.
@@ -34,3 +34,23 @@ is-deeply 1 unicmp 2, Less, "1 unicmp 2 is Less";
 # Returns an Order enum
 isa-ok ('a' unicmp 'b'), Order, "unicmp returns an Order";
 ok ('a' unicmp 'b') === Less, "result identity is the Less enum value";
+
+# Noncharacters and other implicit-weight codepoints (unassigned/private-use)
+# sort in codepoint order among themselves, unlike ICU's special handling of
+# U+FFFE (merge separator) and U+FFFF (high sentinel).
+# (regression pin for roast/S32-str/CollationTest_NON_IGNORABLE-3.t)
+is-deeply "\x[FFF0]" unicmp "\x[FFFE]", Less,
+    "reserved-FFF0 unicmp noncharacter-FFFE is Less";
+is-deeply "\x[FFFF]" unicmp "\x[1FFFE]", Less,
+    "noncharacter-FFFF unicmp noncharacter-1FFFE is Less";
+# But an implicit codepoint vs an assigned one (U+FFFD has a real DUCET weight)
+# still defers to full collation: noncharacter-10FFFF sorts before U+FFFD.
+is-deeply "\x[10FFFF]" unicmp "\x[FFFD]", Less,
+    "noncharacter-10FFFF unicmp REPLACEMENT CHARACTER is Less";
+# A shared noncharacter prefix still lets the trailing assigned chars decide.
+is-deeply "\x[FDD0]a" unicmp "\x[FDD0]A", Less,
+    "shared FDD0 prefix: lowercase sorts before uppercase at tertiary";
+is-deeply "\x[FFFE]a" unicmp "\x[FFFE]A", Less,
+    "shared FFFE prefix: lowercase sorts before uppercase at tertiary";
+is-deeply "\x[FDD0]" unicmp "\x[FDD1]", Less,
+    "consecutive noncharacters sort in codepoint order";


### PR DESCRIPTION
## Summary

Fixes Unicode collation ordering of **noncharacters** (and other implicit-weight code points) so `roast/S32-str/CollationTest_NON_IGNORABLE-3.t` passes fully (1369/1369). Added to the whitelist.

## Root cause

`coll_ordering` (used by `unicmp` / `coll` / `.collate`) delegates per-level comparison to ICU4X. ICU4X special-cases some noncharacters in its UCA weighting:

- `U+FFFE` (and the other `*FFFE` code points) → merge separator, a minimal/near-ignorable primary weight
- `U+FFFF` → high sentinel

Raku's reference collation (MoarVM) instead gives every **implicit-weight** code point — noncharacters and unassigned/private-use code points, i.e. those with no DUCET entry — a plain implicit primary weight ordered by **codepoint**, so they sort among themselves in codepoint order.

This caused only 2 subtests to fail before the fix:
- `<reserved-FFF0>` vs `<noncharacter-FFFE>` — expected `Less`, got `More`
- `<noncharacter-FFFF>` vs `<noncharacter-1FFFE>` — expected `Less`, got `More`

## Fix

ICU only mis-orders these code points *relative to each other*; it orders an implicit code point against an **assigned** one correctly (e.g. `<noncharacter-10FFFF>` vs `U+FFFD` REPLACEMENT CHARACTER, which has a real DUCET weight and sorts *after* the implicit block, despite the lower codepoint).

So `coll_ordering` now falls back to codepoint order **only when the first differing codepoint pair between the two strings is implicit-weighted (General_Category `Cn`/`Co`) on both sides**; otherwise it defers to ICU. The all-assigned common path is gated on a cheap noncharacter check, so normal text pays no extra cost.

## Testing

- `roast/S32-str/CollationTest_NON_IGNORABLE-3.t`: 1369/1369 PASS (added to whitelist)
- `CollationTest_NON_IGNORABLE-{0,1,2}.t`, `Collation.t`: still PASS (no regression)
- `t/unicmp.t`: 6 new pin cases (implicit-block codepoint ordering, assigned-vs-implicit deferral, shared-prefix tertiary tiebreak)
- `make test`: 15269 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)