### PR TITLE
feat(phaser): run top-level BEGIN blocks at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -194,22 +194,27 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
   list へ by-value 捕捉した参照は cell 更新を追えない（＝ sub の外で捕捉参照を読む
   `ident4` 系）。これは return-writeback / cell スナップショット問題で、[[project_declaration_model_hoisted_cell_clobber]]
   と同族。splice.t は sub 内で捕捉参照を読むため影響を受けず PASS。
-- `S26-documentation/12-non-breaking-space.t`（1/2、test 2 が失敗）
-  — 2026-07-02 に root-cause 確定＝**BEGIN が compile-time でなく source 順 runtime 実行**される問題。
-  test は末尾 `BEGIN { @nbchars = [...]; @bchars = [...] }` で配列を設定し、冒頭 line 8
-  `my $nbchar-count = @nbchars.elems` で読む。raku は BEGIN を compile-time 実行するので line 8 が読む時
-  @nbchars は既に 4 要素だが、mutsu は BEGIN を line 108 の位置で実行→line 8 の read が pre-BEGIN(空)を見て
-  `$nbchar-count = 0`→`plan 0+1`＝`plan 1`＋`for 0..^0`＝0 反復で subtest が 0 test 実行→fail。
-  最小再現: `my @a; my $c = @a.elems; BEGIN { @a = 1,2,3 }; say $c` が mutsu=0/raku=4。
-  ★注意: `my @a; BEGIN { @a = 1,2,3 }; say @a.elems`（read が BEGIN の**後**）は mutsu も 3 で正しい
-  ＝問題は read が BEGIN より**前**の時のみ。
-  **試行と blocker**: 冒頭 `compile()` に「top-level BEGIN と bare `my` decl を front に hoist」する
-  `hoist_begin_phasers` を実装したが、**identity reorder（順序保持の to_vec）は 3 で正しいのに、
-  bucket-reorder（bare_decls+begins+rest に分割再結合）は interspersed した `SetLine` 等も動かすため
-  以前 pass していた `my @a; BEGIN` すら 0 に壊す**（compile-order / local-slot / SetLine 依存が判明）→revert。
-  正攻法は AST 再配置でなく **BEGIN body を compile-time に sub-interpreter で eval して初期状態に反映**
-  （raku 準拠）か bytecode-level の BEGIN prelude。declaration-model と同じ深い層で、専用セッション要。
-  [[project_declaration_model_hoisted_cell_clobber]] / [[project_begin_compile_time_timing]] と同族。
+- ~~`S26-documentation/12-non-breaking-space.t`（1/2、test 2 が失敗）~~ — **DONE・whitelist 済み
+  （2026-07-06）**。root-cause＝**top-level BEGIN が compile-time でなく source 順 runtime 実行**される
+  問題（`my @a; my $c = @a.elems; BEGIN { @a = 1,2,3 }; say $c` が mutsu=0/raku=3）。
+  修正（`run_toplevel_begin_phasers`・`src/runtime/run_prelude.rs`）は AST 再配置ではなく BLOCKERS が推す
+  「**BEGIN body を compile-time に sub-interpreter（`eval_block_value`）で eval → 共有 env に反映**」方式:
+  1. `run()` 内で `reorder_phasers` の**前**（`preregister_top_level_subs` の後）に top-level の
+     hoistable な `Stmt::Phaser{Begin}` を `eval_block_value` で実行し `body_main` から除去。
+     `eval_block_value` は plain lexical 書き込みを共有 `env` に残す（`&`-callable キーのみ隔離）ので
+     seed が永続する。reorder より前に消すことで「`my $c = @a.elems` init が BEGIN より前に
+     bucket される」旧 revert の破綻を回避。
+  2. hoist 後、seed された変数の no-init `my` 宣言（`Literal(Array/Hash 空)`・`Literal(Nil)`）を
+     `body_main` から drop（`drop_seeded_noinit_decls`、`my (@a,@b)` の SyntheticBlock も 1 段降下）—
+     raku 同様「container は compile-time に 1 度だけ作られ、runtime の宣言は再初期化しない」を再現。
+  3. **hoistable gate は保守的**（`begin_body_is_hoistable`）: body に宣言・BareWord・Call のいずれも
+     無いこと。理由＝`eval_block_value` は name 解決と sink-context のエラー forcing で mainline VM と
+     意味論が乖離するため、シンボル解決や例外を起こしうる BEGIN（class 参照 / forward sub 呼び / `1/0.Int`）は
+     hoist せず in-place 経路（`X::Comp::BeginTime` ラップ込み）に任せる。純粋な値代入 BEGIN のみ hoist。
+  回帰テスト＝`t/begin-compile-time.t`（`t/begin-phaser-begintime.t` も回帰なし）。
+  **残る別スライス（nested-block BEGIN）**: `variables-and-packages.t` test 29-31（下記）は
+  bare block **内**の BEGIN で、この top-level 専用機構では拾えない。`[[project_begin_compile_time_timing]]`
+  の深い declaration-model 層が別途必要。
 
 ### 3.2 サブキャンペーンと choke point
 
@@ -223,8 +228,9 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
    - 対象: `S14-traits/attributes.t` の残り（`Attribute.container.VAR does Role`）
 3. **BEGIN/EVAL/lexical 配列変更の永続化**
    - 変更レイヤ: env/local coherence、block escape、BEGIN 実行時 lexical carrier
-   - 対象: `S26-documentation/12-non-breaking-space.t`、
-     `S02-names-vars/variables-and-packages.t`
+   - 対象: `S02-names-vars/variables-and-packages.t`（nested-block BEGIN, test 29-31）。
+     top-level BEGIN 版（`S26-documentation/12-non-breaking-space.t`）は DONE・whitelist 済み
+     （§3.1 参照、`run_toplevel_begin_phasers`）。残るは bare block **内**の BEGIN。
 
 コード choke point:
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,36 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-06: top-level `BEGIN` を compile-time 実行（`S26-documentation/12-non-breaking-space.t` whitelist）
+
+Raku の `BEGIN { ... }` はコンパイル時に走るため、ソース順で BEGIN より**前**にある read が
+その副作用を観測する（`my @a; my $c = @a.elems; BEGIN { @a = 1,2,3 }; say $c` は raku=3）。
+mutsu は BEGIN を inline compile して source 位置で実行していたため read-before で `$c=0` になっていた。
+`S26-documentation/12-non-breaking-space.t`（末尾 BEGIN で `@nbchars` を設定し冒頭で `.elems` を読む）が
+これで失敗していた。
+
+**修正（`src/runtime/run_prelude.rs::run_toplevel_begin_phasers`、`src/runtime/run.rs`）** — BLOCKERS が
+推していた「AST 再配置ではなく **BEGIN body を compile-time に sub-interpreter で eval → 初期状態に反映**」方式:
+
+1. `run()` で `reorder_phasers` の**前**（`preregister_top_level_subs` の後）に、top-level の hoistable な
+   `Stmt::Phaser{Begin}` を `eval_block_value` で実行し `body_main` から除去。`eval_block_value` は
+   plain lexical 書き込みを共有 `env` に残す（`&`-callable キーのみ隔離）ので seed が永続する。
+   reorder より**前**に消すのが要点で、これにより「`my $c = @a.elems` の init が BEGIN より前に
+   bucket される」旧 revert（`hoist_begin_phasers`）の破綻を回避した。
+2. hoist 後、seed された変数の no-init `my` 宣言（`Literal(Array/Hash 空)`・`Literal(Nil)`）を
+   `drop_seeded_noinit_decls` で `body_main` から drop（`my (@a,@b)` の SyntheticBlock も 1 段降下）。
+   raku 同様「container は compile-time に 1 度だけ作られ、runtime の宣言は再初期化しない」を再現する。
+   実 init 付き（`my @a = 9,9,9`）は drop しないので runtime init が BEGIN 値を上書きする（raku 準拠）。
+3. **hoistable gate は保守的**（`begin_body_is_hoistable`）: body に宣言・BareWord・Call のいずれも
+   無い純粋な値代入 BEGIN のみ hoist。`eval_block_value` は name 解決と sink-context のエラー forcing で
+   mainline VM と意味論が乖離するため、シンボル解決や例外を起こしうる BEGIN（class 参照 / forward sub 呼び /
+   `BEGIN { 1/0 .Int }`）は hoist せず in-place 経路（`X::Comp::BeginTime` ラップ込み）に委ねる。
+
+回帰テスト＝`t/begin-compile-time.t`（11 tests、mutsu/raku 両方 green）。`t/begin-phaser-begintime.t`
+（BEGIN エラーの BeginTime ラップ）も回帰なし。nested-block **内**の BEGIN
+（`variables-and-packages.t` test 29-31）はこの top-level 専用機構の対象外で、declaration-model の
+深い層が別途必要（BLOCKERS §3.1 参照）。
+
 ## 2026-07-05: Track B スライス 2 — `state @`/`%` の cell 共有を修復（累積全滅・push 死の 2 バグ）
 
 `state` 集約はスレッド文脈が有効になると共有 `ContainerRef` cell に移行する（Track C・

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1003,6 +1003,7 @@ roast/S26-documentation/07c-tables.t
 roast/S26-documentation/08-formattingcodes.t
 roast/S26-documentation/09-configuration.t
 roast/S26-documentation/10-doc-cli.t
+roast/S26-documentation/12-non-breaking-space.t
 roast/S26-documentation/14-defn.t
 roast/S26-documentation/15-numbered-alias.t
 roast/S26-documentation/block-leading-user-format.t

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -119,6 +119,16 @@ impl Interpreter {
                 .collect();
             body_main.splice(0..0, enter_stmts);
         }
+        // Run top-level BEGIN phasers at compile time (before the mainline), so
+        // reads textually preceding a BEGIN see its side effects. Removes the
+        // pre-run BEGINs from `body_main`; leaves non-hoistable ones (see
+        // `run_toplevel_begin_phasers`) in place. This runs *before*
+        // `reorder_phasers` so the hoisted BEGINs are gone before that pass
+        // buckets declarations — otherwise a `my $c = @a.elems` initializer
+        // could be reordered ahead of a BEGIN that populates `@a`. Hoistable
+        // BEGINs make no calls, so they do not need `preregister_top_level_subs`
+        // to have run first.
+        self.run_toplevel_begin_phasers(&mut body_main);
         crate::runtime::phasers::reorder_phasers(&mut body_main);
         self.update_raku_version_from_parser();
         self.check_eval_param_type_constraints(&body_main)?;

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -255,6 +255,174 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Execute top-level `BEGIN { ... }` phaser blocks at compile time (before
+    /// the mainline runs), so that a read appearing textually *before* the
+    /// BEGIN in source order observes its side effects. In Raku, BEGIN runs at
+    /// compile time; mutsu otherwise compiles it inline and runs it in source
+    /// position, so e.g. `my @a; my $c = @a.elems; BEGIN { @a = 1,2,3 }` would
+    /// see `$c == 0` instead of `3`.
+    ///
+    /// Only "hoistable" BEGIN blocks are pre-run: their body must declare no
+    /// outer-visible symbols (`sub`/`class`/`role`/...). A hoisted BEGIN runs
+    /// via the sub-interpreter (`eval_block_value`), whose plain lexical writes
+    /// persist into the shared `env` (only `&`-callable keys are isolated), and
+    /// it is then removed from `body_main` so it does not run a second time.
+    ///
+    /// If pre-running a BEGIN throws — e.g. it references a `class` declared
+    /// later in source that is not yet registered — the `env` is rolled back
+    /// and the BEGIN is left in place to run at its original position, so
+    /// dependency cases keep working exactly as before.
+    pub(crate) fn run_toplevel_begin_phasers(&mut self, body_main: &mut Vec<Stmt>) {
+        let has_candidate = body_main.iter().any(|s| {
+            matches!(s, Stmt::Phaser { kind: crate::ast::PhaserKind::Begin, body }
+                if Self::begin_body_is_hoistable(body))
+        });
+        if !has_candidate {
+            return;
+        }
+        let mut new_body: Vec<Stmt> = Vec::with_capacity(body_main.len());
+        let mut hoisted_any = false;
+        for stmt in std::mem::take(body_main) {
+            let hoistable_body = match &stmt {
+                Stmt::Phaser {
+                    kind: crate::ast::PhaserKind::Begin,
+                    body,
+                } if Self::begin_body_is_hoistable(body) => Some(body),
+                _ => None,
+            };
+            if let Some(body) = hoistable_body {
+                let snapshot = self.env.clone();
+                match self.eval_block_value(body) {
+                    Ok(_) => {
+                        hoisted_any = true;
+                        continue; // consumed: dropped from the mainline
+                    }
+                    Err(_) => {
+                        // Roll back partial writes and keep the BEGIN in place
+                        // so it runs (successfully) at its original source
+                        // position during the mainline.
+                        self.env = snapshot;
+                    }
+                }
+            }
+            new_body.push(stmt);
+        }
+        if hoisted_any {
+            // A hoisted BEGIN wrote its lexicals into `env` at compile time. The
+            // mainline still contains the bare `my @a;` declarations for those
+            // vars, which would reset them to empty. Drop the no-init reset for
+            // any variable the BEGIN already populated so the seeded value
+            // survives into the mainline (Raku creates the container once, at
+            // compile time; the runtime declaration does not re-initialize it).
+            Self::drop_seeded_noinit_decls(&mut new_body, &self.env);
+        }
+        *body_main = new_body;
+    }
+
+    /// A top-level BEGIN is safe to pre-execute at compile time only when its
+    /// body is a self-contained sequence of value assignments — no
+    /// declarations, no barewords, and no calls. The narrowness is deliberate:
+    /// the pre-run goes through the `eval_block_value` sub-interpreter, whose
+    /// semantics diverge from the mainline VM for name resolution and for
+    /// sink-context error forcing, so anything that could resolve a symbol or
+    /// raise an exception must stay on the mainline (in-place) path instead.
+    ///
+    /// - Declarations (`sub`/`class`/`role`/...) inside a BEGIN are not visible
+    ///   outside it in Raku anyway, and pre-running then discarding the
+    ///   sub-interpreter's registries must not silently drop one.
+    /// - A bareword may name a `class`/`role`/`enum`/type object not registered
+    ///   until the mainline runs, so pre-executing would capture a wrong value.
+    /// - A call may target a routine not yet registered at compile time, or may
+    ///   throw — both of which are handled correctly only by the mainline path
+    ///   (which wraps BEGIN-time errors in `X::Comp::BeginTime`).
+    ///
+    /// The `BareWord(`/`Call` markers are matched in the AST debug form, which
+    /// catches them at any nesting depth without a bespoke full-AST walker. All
+    /// call-shaped `Expr` variants (`Call`, `MethodCall`, `HyperMethodCall`,
+    /// `CallOn`, `DynamicMethodCall`, ...) contain `Call` in their name.
+    fn begin_body_is_hoistable(body: &[Stmt]) -> bool {
+        let has_decl = body.iter().any(|s| {
+            matches!(
+                s,
+                Stmt::SubDecl { .. }
+                    | Stmt::ClassDecl { .. }
+                    | Stmt::RoleDecl { .. }
+                    | Stmt::EnumDecl { .. }
+                    | Stmt::Package { .. }
+                    | Stmt::ProtoDecl { .. }
+                    | Stmt::MethodDecl { .. }
+                    | Stmt::SubsetDecl { .. }
+                    | Stmt::TokenDecl { .. }
+                    | Stmt::RuleDecl { .. }
+                    | Stmt::Use { .. }
+            )
+        });
+        if has_decl {
+            return false;
+        }
+        let debug = format!("{body:?}");
+        !debug.contains("BareWord(") && !debug.contains("Call")
+    }
+
+    /// Remove the no-init reset of plain `my`/`our`-free declarations whose
+    /// variable a hoisted top-level BEGIN already populated in `env`. Descends
+    /// one level into `SyntheticBlock` (which carries `my (@a, @b)` group
+    /// declarations). Only plain, unadorned, empty-default declarations are
+    /// touched — anything with a type constraint, trait, `state`/`our`/`is
+    /// dynamic`/`is export`, or a real initializer is left intact.
+    fn drop_seeded_noinit_decls(body: &mut Vec<Stmt>, env: &crate::env::Env) {
+        body.retain_mut(|stmt| match stmt {
+            Stmt::SyntheticBlock(inner) => {
+                Self::drop_seeded_noinit_decls(inner, env);
+                !inner.is_empty()
+            }
+            _ => match Self::plain_noinit_vardecl_name(stmt) {
+                Some(name) => env.get(name).is_none(),
+                None => true,
+            },
+        });
+    }
+
+    /// If `stmt` is a plain `my $x;` / `my @a;` / `my %h;` with the synthesized
+    /// empty-container default and no adornments, return the variable name (in
+    /// env-key form). Otherwise `None`.
+    fn plain_noinit_vardecl_name(stmt: &Stmt) -> Option<&str> {
+        if let Stmt::VarDecl {
+            name,
+            expr,
+            type_constraint,
+            is_state,
+            is_our,
+            is_dynamic,
+            is_export,
+            custom_traits,
+            where_constraint,
+            ..
+        } = stmt
+        {
+            if *is_state
+                || *is_our
+                || *is_dynamic
+                || *is_export
+                || type_constraint.is_some()
+                || !custom_traits.is_empty()
+                || where_constraint.is_some()
+            {
+                return None;
+            }
+            let is_default = match expr {
+                Expr::Literal(Value::Nil) => true,
+                Expr::Literal(Value::Array(d, _)) => d.items.is_empty(),
+                Expr::Hash(items) => items.is_empty(),
+                _ => false,
+            };
+            if is_default {
+                return Some(name.as_str());
+            }
+        }
+        None
+    }
+
     /// If the first non-Use/non-Package statement is a `unit class Foo;` (ClassDecl with empty
     /// body), merge all subsequent method/sub declarations into the class body.
     pub(super) fn merge_unit_class(stmts: Vec<Stmt>) -> Vec<Stmt> {

--- a/t/begin-compile-time.t
+++ b/t/begin-compile-time.t
@@ -1,0 +1,68 @@
+use Test;
+
+# Top-level BEGIN phasers run at compile time, so a read that appears textually
+# *before* the BEGIN in source order observes its side effects. mutsu otherwise
+# compiled BEGIN inline and ran it in source position. These declarations must
+# be at the file's top level (the mainline) — that is the scope this handles.
+
+plan 11;
+
+# read-before-BEGIN: array
+my @arr;
+my $arr-count = @arr.elems;
+BEGIN { @arr = 1, 2, 3 }
+is $arr-count, 3, 'array populated by later BEGIN is visible to earlier read';
+
+# read-before-BEGIN: grouped declaration `my (@g1, @g2)`
+my (@g1, @g2);
+my $g1-count = @g1.elems;
+BEGIN { @g1 = 1, 2, 3, 4 }
+is $g1-count, 4, 'grouped array decl seeded by BEGIN';
+is @g2.elems, 0, 'untouched grouped var stays empty';
+
+# read-before-BEGIN: scalar
+my $sca;
+my $sca-seen = $sca;
+BEGIN { $sca = 42 }
+is $sca-seen, 42, 'scalar populated by later BEGIN visible to earlier read';
+
+# read-before-BEGIN: hash
+my %hsh;
+my $hsh-count = %hsh.elems;
+BEGIN { %hsh = (a => 1, b => 2) }
+is $hsh-count, 2, 'hash populated by later BEGIN visible to earlier read';
+
+# read-after-BEGIN still works (was already correct)
+my @after;
+BEGIN { @after = 5, 6, 7 }
+is @after.elems, 3, 'read after BEGIN still works';
+
+# a real runtime initializer runs at runtime and overrides the BEGIN value
+my @init = 9, 9, 9;
+BEGIN { @init = 1, 2, 3 }
+is @init.join(','), '9,9,9', 'runtime initializer overrides compile-time BEGIN';
+
+# multiple BEGINs all run (at compile time) before an earlier runtime read
+my ($p, $q);
+my $before = "$p|$q";
+BEGIN { $p = 'P' }
+BEGIN { $q = 'Q' }
+is $before, 'P|Q', 'multiple BEGINs all run before an earlier read';
+
+# a BEGIN that references a class declared earlier must still see it: such a
+# BEGIN is left in place (barewords are not pre-executed), and the class is
+# registered before it runs.
+class C { method greet { 'hi' } }
+my $cv;
+BEGIN { $cv = C }
+is $cv.^name, 'C', 'BEGIN referencing an earlier class captures the class';
+is $cv.new.greet, 'hi', 'the captured class is usable';
+
+# nested-block BEGIN reading-after still works (not hoisted, runs in place)
+my $nested;
+{
+    my @na;
+    BEGIN { @na = 1, 2 }
+    $nested = @na.elems;
+}
+is $nested, 2, 'nested-block BEGIN read-after works';


### PR DESCRIPTION
## What

Raku runs `BEGIN { ... }` at **compile time**, so a read that appears textually *before* a BEGIN in source order observes its side effects:

```raku
my @a; my $c = @a.elems; BEGIN { @a = 1, 2, 3 }; say $c;   # raku: 3
```

mutsu compiled BEGIN inline and ran it in source position, so `$c` was `0`. This whitelists **`roast/S26-documentation/12-non-breaking-space.t`**, whose trailing `BEGIN { @nbchars = [...] }` sets an array that an early `.elems` read (used for `plan`) depends on.

## How

`run_toplevel_begin_phasers` (`src/runtime/run_prelude.rs`, wired in `src/runtime/run.rs`) uses the compile-time sub-interpreter approach `BLOCKERS.md` recommends — not the AST bucket-reorder that a prior reverted `hoist_begin_phasers` tried:

1. In `run()`, **before** `reorder_phasers`, execute each top-level *hoistable* `Stmt::Phaser{Begin}` via `eval_block_value` (whose plain lexical writes persist into the shared `env`) and remove it from `body_main`. Running before reorder prevents a `my $c = @a.elems` initializer being bucketed ahead of the BEGIN that populates `@a`.
2. Drop the no-init reset of `my` declarations for variables a hoisted BEGIN already populated (`drop_seeded_noinit_decls`) — Raku creates the container once at compile time; the runtime declaration does not re-initialize it. A real initializer (`my @a = 9,9,9`) is kept and overrides (per Raku).
3. **Conservative hoistable gate** (`begin_body_is_hoistable`): only pure value assignments — no declarations, barewords, or calls. `eval_block_value` diverges from the mainline VM on name resolution and sink-context error forcing, so BEGINs that resolve symbols or can throw (class refs, forward-sub calls, `BEGIN { 1/0 .Int }`) stay on the in-place path (which wraps BEGIN-time errors in `X::Comp::BeginTime`).

## Tests

- New `t/begin-compile-time.t` (11 tests, green on both mutsu and raku).
- `t/begin-phaser-begintime.t` (BEGIN error → `X::Comp::BeginTime`) and `t/forward-declaration.t` unaffected.
- `make test`: PASS (1557 files / 15274 tests). Phaser/BEGIN roast tests re-verified green.

Nested (in-block) BEGIN remains out of scope (`variables-and-packages.t` 29-31 need the deeper declaration-model layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)