### PR TITLE
fix(proc-async): encoding-aware stdout/stderr and quit-on-decode-error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -87,12 +87,12 @@
     thread-specific.
 - [ ] roast/S17-procasync/basic.t
 - [ ] roast/S17-procasync/bind-handles.t
-- [ ] roast/S17-procasync/encoding.t
-  - Deferred. Requires multiple unrelated language gaps:
-    1. Supply `tap(quit => ...)` must fire when child output is invalid UTF-8 (encoding-error detection at the read layer).
-    2. `Proc::Async.new(..., :enc('latin-1'))` constructor must encode stdin writes (`print`/`put`/`say`/`write`) and decode stdout/stderr per the requested encoding instead of always treating bytes as UTF-8.
-    3. Per-call encoding override on `$proc.stdout(:enc(...))` / `$proc.stderr(:enc(...))`.
-    4. `$*IN.slurp` currently returns empty even when stdin has bytes available, so the child scripts in this test cannot read their input. This is a prerequisite that affects more than just this test.
+- [x] roast/S17-procasync/encoding.t
+  - Passes 13/13. Implemented: (1) `tap(quit => ...)` fires when child output is invalid for the
+    stream encoding (reader thread now retains the raw bytes; the await-time replay decodes them and
+    fires the registered `quit` taps on a decode error); (2) constructor `:enc` encodes stdin writes
+    (`print`/`put`/`say`/`write`) and decodes stdout/stderr; (3) per-call `$proc.stdout(:enc(...))` /
+    `$proc.stderr(:enc(...))` override. `put` was also added to the Proc::Async native-method routing.
 - [ ] roast/S17-procasync/kill.t
 - [ ] roast/S17-procasync/many-processes-no-close-stdin.t
   - Was passing trivially (colon-pair hash parsed as block, is_run expectations not tested). Now properly tests expectations; fails because Proc::Async not supported.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -882,6 +882,7 @@ roast/S17-lowlevel/thread-start-join-stress.t
 roast/S17-lowlevel/thread.t
 roast/S17-procasync/basic.t
 roast/S17-procasync/bind-handles.t
+roast/S17-procasync/encoding.t
 roast/S17-procasync/kill.t
 roast/S17-procasync/many-processes-no-close-stdin.t
 roast/S17-procasync/no-runaway-file-limit.t

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -296,24 +296,18 @@ impl Interpreter {
             _ => format!("{}{}", collected_stdout, collected_stderr),
         };
 
-        if !collected_stdout.is_empty() && !stdout_taps.is_empty() {
-            for tap in &stdout_taps {
-                let _ = self.call_sub_value(
-                    tap.clone(),
-                    vec![Value::str(collected_stdout.clone())],
-                    true,
-                );
-            }
-        }
-        if !collected_stderr.is_empty() && !stderr_taps.is_empty() {
-            for tap in &stderr_taps {
-                let _ = self.call_sub_value(
-                    tap.clone(),
-                    vec![Value::str(collected_stderr.clone())],
-                    true,
-                );
-            }
-        }
+        let stdout_sid = match attributes.as_map().get("stdout_supply_id") {
+            Some(Value::Int(sid)) => Some(*sid as u64),
+            _ => None,
+        };
+        let stderr_sid = match attributes.as_map().get("stderr_supply_id") {
+            Some(Value::Int(sid)) => Some(*sid as u64),
+            _ => None,
+        };
+
+        self.replay_proc_output(stdout_sid, &stdout_taps, collected_stdout);
+        self.replay_proc_output(stderr_sid, &stderr_taps, collected_stderr);
+
         if !collected_merged.is_empty() && !supply_taps.is_empty() {
             for tap in &supply_taps {
                 let _ = self.call_sub_value(
@@ -321,6 +315,71 @@ impl Interpreter {
                     vec![Value::str(collected_merged.clone())],
                     true,
                 );
+            }
+        }
+    }
+
+    /// Replay one Proc::Async output stream (stdout or stderr) to its value and
+    /// `quit` taps. The raw bytes captured by the reader thread are decoded with
+    /// the stream's effective encoding (`get_supply_enc`); on a decode error the
+    /// registered `quit =>` handlers fire, matching Rakudo's "Supply quit on
+    /// encoding error" behaviour (roast S17-procasync/encoding.t).
+    fn replay_proc_output(&mut self, sid: Option<u64>, value_taps: &[Value], fallback: String) {
+        use super::super::native_methods::{
+            get_supply_enc, get_supply_quit_taps, take_supply_collected_bytes,
+        };
+        let (text, quit_reason) = match sid {
+            Some(sid) => {
+                let enc = get_supply_enc(sid).unwrap_or_else(|| "utf-8".to_string());
+                match take_supply_collected_bytes(sid) {
+                    Some(raw) => self.decode_proc_stream(&raw, &enc),
+                    // No raw bytes captured (e.g. binary mode): use the string the
+                    // reader thread already collected.
+                    None => (fallback, None),
+                }
+            }
+            None => (fallback, None),
+        };
+        if !text.is_empty() {
+            for tap in value_taps {
+                let _ = self.call_sub_value(tap.clone(), vec![Value::str(text.clone())], true);
+            }
+        }
+        if let Some(reason) = quit_reason
+            && let Some(sid) = sid
+        {
+            for quit_tap in get_supply_quit_taps(sid) {
+                let _ = self.call_supply_quit_handler(quit_tap, reason.clone());
+            }
+        }
+    }
+
+    /// Decode a Proc::Async output stream's raw bytes. Returns the decoded text
+    /// (the valid prefix, if a decode error interrupts it) and an optional quit
+    /// reason when the stream contains bytes that are invalid for its encoding.
+    fn decode_proc_stream(&self, raw: &[u8], enc: &str) -> (String, Option<Value>) {
+        let normalized = enc.to_ascii_lowercase();
+        let is_utf8 = matches!(normalized.as_str(), "utf-8" | "utf8" | "");
+        if is_utf8 {
+            match std::str::from_utf8(raw) {
+                Ok(s) => (s.replace("\r\n", "\n"), None),
+                Err(e) => {
+                    let valid = std::str::from_utf8(&raw[..e.valid_up_to()])
+                        .unwrap_or("")
+                        .replace("\r\n", "\n");
+                    (
+                        valid,
+                        Some(super::super::native_proc_async::malformed_utf8_quit_value()),
+                    )
+                }
+            }
+        } else {
+            match self.decode_with_encoding(raw, enc) {
+                Ok(s) => (s.replace("\r\n", "\n"), None),
+                Err(_) => (
+                    String::new(),
+                    Some(super::super::native_proc_async::malformed_utf8_quit_value()),
+                ),
             }
         }
     }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -668,6 +668,7 @@ impl Interpreter {
                         | "bind-stderr"
                         | "ready"
                         | "print"
+                        | "put"
                         | "say"
                         | "stdout"
                         | "stderr"

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -159,6 +159,7 @@ impl Interpreter {
                         | "bind-stderr"
                         | "ready"
                         | "print"
+                        | "put"
                         | "say"
                         | "command"
                         | "started"

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -27,12 +27,14 @@ pub(crate) use state_lock::{acquire_lock, current_thread_id, lock_runtime_by_id,
 // re-exported `pub(crate)` below for the VM-side react/supply drive loop
 // (`crate::vm::vm_react_loop`): the supplier registry accessors it polls.
 pub(in crate::runtime) use state::{
-    UdpBoundSocketState, allocate_async_listen_port, get_supply_collected_output, get_supply_taps,
-    lookup_async_listener, next_async_socket_id, next_supply_id, proc_stdin_map,
-    register_async_connection, register_promise_combinator_sources, register_supply_tap,
-    register_udp_bound_socket, set_supply_collected_output, supplier_done, supplier_done_deferred,
-    supplier_emit, supplier_id_from_attrs, supplier_quit, supplier_reset, supplier_reset_keep_quit,
-    supply_channel_map, supply_channel_map_pub, udp_port_in_use, update_async_connection,
+    UdpBoundSocketState, allocate_async_listen_port, get_supply_collected_output, get_supply_enc,
+    get_supply_quit_taps, get_supply_taps, lookup_async_listener, next_async_socket_id,
+    next_supply_id, proc_stdin_map, register_async_connection, register_promise_combinator_sources,
+    register_supply_quit_tap, register_supply_tap, register_udp_bound_socket,
+    set_supply_collected_bytes, set_supply_collected_output, set_supply_enc, supplier_done,
+    supplier_done_deferred, supplier_emit, supplier_id_from_attrs, supplier_quit, supplier_reset,
+    supplier_reset_keep_quit, supply_channel_map, supply_channel_map_pub,
+    take_supply_collected_bytes, udp_port_in_use, update_async_connection,
 };
 // Supplier registry accessors driven by the VM-side react/supply loop.
 pub(crate) use state::{

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -26,6 +26,27 @@ fn supply_collected_map() -> &'static SupplyCollectedMap {
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
+type SupplyCollectedBytesMap = std::sync::Mutex<HashMap<u64, Vec<u8>>>;
+
+fn supply_collected_bytes_map() -> &'static SupplyCollectedBytesMap {
+    static MAP: OnceLock<SupplyCollectedBytesMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+type SupplyQuitTapsMap = std::sync::Mutex<HashMap<u64, Vec<Value>>>;
+
+fn supply_quit_taps_map() -> &'static SupplyQuitTapsMap {
+    static MAP: OnceLock<SupplyQuitTapsMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+type SupplyEncMap = std::sync::Mutex<HashMap<u64, String>>;
+
+fn supply_enc_map() -> &'static SupplyEncMap {
+    static MAP: OnceLock<SupplyEncMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
 type PromiseCombinatorMap = std::sync::Mutex<HashMap<usize, Vec<SharedPromise>>>;
 
 fn promise_combinator_map() -> &'static PromiseCombinatorMap {
@@ -555,6 +576,54 @@ pub(in crate::runtime) fn set_supply_collected_output(supply_id: u64, output: St
 
 pub(in crate::runtime) fn get_supply_collected_output(supply_id: u64) -> Option<String> {
     supply_collected_map()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&supply_id).cloned())
+}
+
+/// Store the raw (undecoded) bytes read from a Proc::Async output stream, so the
+/// `await`-time replay can decode them with the stream's effective encoding
+/// (which may be `latin-1`/`utf-8` set on the constructor or per-`stdout`/`stderr`
+/// tap). Keyed by the output Supply's `supply_id`.
+pub(in crate::runtime) fn set_supply_collected_bytes(supply_id: u64, bytes: Vec<u8>) {
+    if let Ok(mut map) = supply_collected_bytes_map().lock() {
+        map.insert(supply_id, bytes);
+    }
+}
+
+pub(in crate::runtime) fn take_supply_collected_bytes(supply_id: u64) -> Option<Vec<u8>> {
+    supply_collected_bytes_map()
+        .lock()
+        .ok()
+        .and_then(|mut map| map.remove(&supply_id))
+}
+
+/// Register a `quit =>` handler on a Proc::Async output Supply. Unlike ordinary
+/// value taps these fire only when the stream ends in an encoding error.
+pub(in crate::runtime) fn register_supply_quit_tap(supply_id: u64, tap: Value) {
+    if let Ok(mut map) = supply_quit_taps_map().lock() {
+        map.entry(supply_id).or_default().push(tap);
+    }
+}
+
+pub(in crate::runtime) fn get_supply_quit_taps(supply_id: u64) -> Vec<Value> {
+    if let Ok(map) = supply_quit_taps_map().lock() {
+        map.get(&supply_id).cloned().unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+/// Record the effective decode encoding for a Proc::Async output Supply, as seen
+/// at tap time (per-tap `:enc` overrides the constructor `:enc`).
+pub(in crate::runtime) fn set_supply_enc(supply_id: u64, enc: String) {
+    if let Ok(mut map) = supply_enc_map().lock() {
+        map.insert(supply_id, enc);
+    }
+}
+
+pub(in crate::runtime) fn get_supply_enc(supply_id: u64) -> Option<String> {
+    supply_enc_map()
         .lock()
         .ok()
         .and_then(|map| map.get(&supply_id).cloned())

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -64,7 +64,7 @@ fn feed_utf8_incremental(
 
 /// The exception value sent on a `SupplyEvent::Quit` when a Proc::Async output
 /// stream contains malformed UTF-8.
-fn malformed_utf8_quit_value() -> Value {
+pub(in crate::runtime) fn malformed_utf8_quit_value() -> Value {
     let mut attrs = HashMap::new();
     attrs.insert(
         "message".to_string(),
@@ -356,12 +356,14 @@ impl Interpreter {
                     let stdout_handle = child_stdout.map(|stdout| {
                         let tx = stdout_channel;
                         let bin_mode = stdout_bin;
+                        let sid = stdout_supply_id;
                         // Emits Buf `Value`s (Gc nodes): registered mutator,
                         // pipe reads quiescent.
                         crate::runtime::builtins_system::spawn_user_thread(move || {
                             use std::io::Read;
                             let mut stdout = stdout;
                             let mut collected = String::new();
+                            let mut raw: Vec<u8> = Vec::new();
                             let mut buf = [0u8; 4096];
                             let mut pending: Vec<u8> = Vec::new();
                             let mut quit = false;
@@ -369,6 +371,7 @@ impl Interpreter {
                                 match crate::gc::block_quiescent(|| stdout.read(&mut buf)) {
                                     Ok(0) => break,
                                     Ok(n) => {
+                                        raw.extend_from_slice(&buf[..n]);
                                         if bin_mode {
                                             if let Some(ref tx) = tx {
                                                 let buf_val = make_buf_value(&buf[..n]);
@@ -394,6 +397,13 @@ impl Interpreter {
                             }
                             if !quit && let Some(ref tx) = tx {
                                 let _ = tx.send(SupplyEvent::Done);
+                            }
+                            // Retain the raw bytes so the await-time replay can
+                            // decode them with the stream's effective encoding
+                            // (the channel/`collected` path above only handles the
+                            // default UTF-8 case).
+                            if let Some(sid) = sid {
+                                set_supply_collected_bytes(sid, raw);
                             }
                             collected
                         })
@@ -403,11 +413,13 @@ impl Interpreter {
                     let stderr_handle = child_stderr.map(|stderr| {
                         let tx = stderr_channel;
                         let bin_mode = stderr_bin;
+                        let sid = stderr_supply_id;
                         // Same as the stdout reader: registered + quiescent reads.
                         crate::runtime::builtins_system::spawn_user_thread(move || {
                             use std::io::Read;
                             let mut stderr = stderr;
                             let mut collected = String::new();
+                            let mut raw: Vec<u8> = Vec::new();
                             let mut buf = [0u8; 4096];
                             let mut pending: Vec<u8> = Vec::new();
                             let mut quit = false;
@@ -415,6 +427,7 @@ impl Interpreter {
                                 match crate::gc::block_quiescent(|| stderr.read(&mut buf)) {
                                     Ok(0) => break,
                                     Ok(n) => {
+                                        raw.extend_from_slice(&buf[..n]);
                                         if bin_mode {
                                             if let Some(ref tx) = tx {
                                                 let buf_val = make_buf_value(&buf[..n]);
@@ -440,6 +453,9 @@ impl Interpreter {
                             }
                             if !quit && let Some(ref tx) = tx {
                                 let _ = tx.send(SupplyEvent::Done);
+                            }
+                            if let Some(sid) = sid {
+                                set_supply_collected_bytes(sid, raw);
                             }
                             collected
                         })
@@ -625,7 +641,14 @@ impl Interpreter {
                             Vec::new()
                         }
                     }
-                    Value::Str(s) => s.as_bytes().to_vec(),
+                    Value::Str(s) => {
+                        let enc = attrs
+                            .get("enc")
+                            .map(Value::to_string_value)
+                            .unwrap_or_else(|| "utf-8".to_string());
+                        self.encode_with_encoding(s.as_str(), &enc)
+                            .unwrap_or_else(|_| s.as_bytes().to_vec())
+                    }
                     _ => Vec::new(),
                 };
 
@@ -776,7 +799,29 @@ impl Interpreter {
                         &[("handle", Value::str_from(method))],
                     ));
                 }
+                // A per-tap `:enc` (e.g. `$proc.stdout(:enc('latin-1'))`) overrides
+                // the constructor `:enc` for this stream's decode. Return a Supply
+                // whose `enc` attribute carries the override so the tap records it.
                 let value = attrs.get(method).cloned().unwrap_or(Value::Nil);
+                let value = if let Some(enc_pair) = args.iter().find_map(|arg| match arg {
+                    Value::Pair(key, v) if key == "enc" => Some(v.to_string_value()),
+                    _ => None,
+                }) {
+                    if let Value::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } = &value
+                    {
+                        let mut new_attrs = attributes.as_map().clone();
+                        new_attrs.insert("enc".to_string(), Value::str(enc_pair));
+                        Value::make_instance(*class_name, new_attrs)
+                    } else {
+                        value
+                    }
+                } else {
+                    value
+                };
                 Ok((value, attrs))
             }
             "Supply" => {
@@ -806,7 +851,7 @@ impl Interpreter {
                 attrs.insert("supply_selected".to_string(), Value::Bool(true));
                 Ok((attrs.get("supply").cloned().unwrap_or(Value::Nil), attrs))
             }
-            "print" | "say" => {
+            "print" | "put" | "say" => {
                 if !attrs.get("w").is_some_and(|v| v.truthy()) {
                     return Err(proc_async_error(
                         "X::Proc::Async::OpenForWriting",
@@ -827,12 +872,20 @@ impl Interpreter {
                     p.break_with(err, String::new(), String::new());
                     return Ok((Value::Promise(p), attrs));
                 }
-                // Write string to stdin of process
+                // Write string to stdin of process, encoded with the constructor
+                // `:enc` (`say`/`put` add a trailing newline).
                 let data = args.first().cloned().unwrap_or(Value::Nil);
                 let mut s = data.to_string_value();
-                if method == "say" {
+                if method == "say" || method == "put" {
                     s.push('\n');
                 }
+                let enc = attrs
+                    .get("enc")
+                    .map(Value::to_string_value)
+                    .unwrap_or_else(|| "utf-8".to_string());
+                let bytes = self
+                    .encode_with_encoding(&s, &enc)
+                    .unwrap_or_else(|_| s.as_bytes().to_vec());
                 if let Some(Value::Int(pid)) = attrs.get("pid") {
                     let pid = *pid as u32;
                     if let Ok(map) = proc_stdin_map().lock()
@@ -843,7 +896,7 @@ impl Interpreter {
                             && let Some(ref mut stdin) = *guard
                         {
                             use std::io::Write;
-                            let _ = stdin.write_all(s.as_bytes());
+                            let _ = stdin.write_all(&bytes);
                             let _ = stdin.flush();
                         }
                     }

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -137,10 +137,23 @@ impl Interpreter {
 
                 // If this Supply has a supply_id (belongs to Proc::Async),
                 // register tap in the global registry so .start can find it
-                if let Some(Value::Int(sid)) = attrs.get("supply_id")
-                    && Self::supply_has_active_callback(&tap_cb)
-                {
-                    register_supply_tap(*sid as u64, tap_cb.clone());
+                if let Some(Value::Int(sid)) = attrs.get("supply_id") {
+                    let sid = *sid as u64;
+                    if Self::supply_has_active_callback(&tap_cb) {
+                        register_supply_tap(sid, tap_cb.clone());
+                    }
+                    // A `quit =>` handler on a Proc::Async output Supply fires only
+                    // when the stream ends in a decode error; record it so the
+                    // await-time replay can invoke it.
+                    if let Some(ref qf) = quit_cb {
+                        register_supply_quit_tap(sid, qf.clone());
+                    }
+                    // Remember the effective decode encoding (a per-tap
+                    // `stdout(:enc(...))` overrides the constructor `:enc`), so the
+                    // replay decodes the raw bytes correctly.
+                    if let Some(enc) = attrs.get("enc").map(Value::to_string_value) {
+                        set_supply_enc(sid, enc);
+                    }
                 }
 
                 // For live/async supplies (e.g., signal), spawn a background thread

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -346,6 +346,7 @@ impl Interpreter {
                     "close-stdin",
                     "ready",
                     "print",
+                    "put",
                     "say",
                 ]
                 .iter()


### PR DESCRIPTION
## Summary

Makes `Proc::Async` output/input streams honour their encoding on both sides, so **`roast/S17-procasync/encoding.t` now passes 13/13** (previously 3 of the first 5 subtests failed and the file aborted at subtest 6). The reference `raku` passes all 13, so this is a genuine compatibility gain.

## What was broken

1. **`quit =>` handlers were dropped on `Proc::Async` supplies.** A `$proc.stdout.tap(quit => {...})` never fired even when the child wrote invalid UTF-8 — the tap path only registered *value* callbacks for streams identified by `supply_id`.
2. **`:enc` was ignored.** `print`/`put`/`say`/`write` always wrote UTF-8 bytes, and stdout/stderr were always decoded as UTF-8, so `:enc('latin-1')` round-trips produced wrong byte counts / empty strings.
3. **`$proc.stdout(:enc(...))` per-call override was ignored.**
4. **`put` was not routed** to the native `Proc::Async` handler (it errored with "No such method 'put'").

## Changes

- The stdout/stderr reader thread now retains the **raw bytes** it read. The await-time replay (`replay_proc_taps`) decodes them with the stream's effective encoding and fires the registered `quit` handlers on a decode error (valid-prefix is still emitted to value taps first).
- Constructor `:enc` is applied to stdin writes and to stdout/stderr decoding.
- Per-call `$proc.stdout(:enc(...))` / `$proc.stderr(:enc(...))` overrides the constructor encoding for that stream.
- Added `put` to the three `Proc::Async` native-method routing tables.
- New per-`supply_id` registries carry the raw bytes, `quit` taps, and effective encoding from the reader thread to the replay step.

## Testing

- `roast/S17-procasync/encoding.t` → 13/13 (verified under `scripts/run-roast-test.sh`), added to `roast-whitelist.txt`.
- All 9 previously-whitelisted `S17-procasync/*` tests still pass (no regressions).
- `make test` green (15269 tests, 0 failures; cargo tests 529 passed).
- `cargo fmt` + `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)