### PR TITLE
fix(map): batch source by block count for full-binding blocks

### DIFF
--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -71,13 +71,54 @@ impl Interpreter {
                     || pd.shape_constraints.is_some()
             });
             if requires_full_binding {
+                // `map` batches the source by the block's `.count` (the number of
+                // positional parameters it will bind): a multi-positional block
+                // such as `-> \a, \b { }` consumes a chunk of that many elements
+                // per call. A slurpy parameter makes `.count` infinite, so the
+                // batch falls back to the required-positional arity (min 1). The
+                // previous code always passed a single element here, so sigilless
+                // / typed / defaulted multi-param blocks were mis-called with one
+                // argument (`Too few positionals passed`).
+                let assumed = data.assumed_positional.len();
+                let positional: Vec<&crate::ast::ParamDef> = data
+                    .param_defs
+                    .iter()
+                    .filter(|pd| !pd.named && !pd.is_invocant)
+                    .collect();
+                let batch = if positional.is_empty() {
+                    data.params.len().saturating_sub(assumed).max(1)
+                } else if positional
+                    .iter()
+                    .any(|pd| pd.slurpy || pd.is_capture_subsignature())
+                {
+                    positional
+                        .iter()
+                        .filter(|pd| {
+                            !pd.slurpy
+                                && !pd.optional_marker
+                                && pd.default.is_none()
+                                && !pd.is_capture_subsignature()
+                        })
+                        .count()
+                        .saturating_sub(assumed)
+                        .max(1)
+                } else {
+                    positional.len().saturating_sub(assumed).max(1)
+                };
                 let mut result = Vec::new();
-                for item in list_items {
-                    let value = self.call_sub_value(Value::Sub(data.clone()), vec![item], false)?;
+                let mut i = 0usize;
+                while i < list_items.len() {
+                    let end = (i + batch).min(list_items.len());
+                    let chunk: Vec<Value> = list_items[i..end].to_vec();
+                    // A short final chunk of a required-arity block raises
+                    // "Too few positionals" (matching raku); an optional trailing
+                    // parameter binds the missing slot to its default / `Any`.
+                    let value = self.call_sub_value(Value::Sub(data.clone()), chunk, false)?;
                     match value {
                         Value::Slip(elems) => result.extend(elems.iter().cloned()),
                         v => result.push(v),
                     }
+                    i = end;
                 }
                 return Ok(Value::array(result));
             }

--- a/t/map-multiarg-full-binding.t
+++ b/t/map-multiarg-full-binding.t
@@ -1,0 +1,55 @@
+use Test;
+
+# `.map` batches the source list by the block's positional-parameter count
+# (its `.count`). Previously a block that required full signature binding
+# (sigilless `\a`, typed, optional or defaulted parameters) was mis-called
+# with a single element per iteration, raising "Too few positionals passed"
+# for a legitimate multi-parameter block over a List/Seq source.
+
+plan 11;
+
+# sigilless multi-parameter block over a List
+is-deeply (1, 2, 3, 4).map(-> \a, \b { "{a}-{b}" }), ("1-2", "3-4").Seq,
+  'sigilless 2-param block chunks a List by 2';
+
+# sigilless multi-parameter block over a Seq/Range
+is-deeply (1 .. 4).map(-> \a, \b { "{a}-{b}" }), ("1-2", "3-4").Seq,
+  'sigilless 2-param block chunks a Range by 2';
+
+# three sigilless parameters
+is-deeply (1, 2, 3, 4, 5, 6).map(-> \a, \b, \c { a + b + c }), (6, 15).Seq,
+  'sigilless 3-param block chunks by 3';
+
+# single sigilless parameter still works (arity 1)
+is-deeply (1, 2, 3).map(-> \a { a * 2 }), (2, 4, 6).Seq,
+  'sigilless 1-param block maps element-wise';
+
+# optional trailing parameter: count is finite, so batch is 2; a short final
+# chunk binds the missing slot to its default (Any here)
+is-deeply (1, 2, 3).map(-> $a, $b? { "$a-{$b // 'x'}" }), ("1-2", "3-x").Seq,
+  'optional 2nd param batches by 2 and tolerates a short final chunk';
+
+# defaulted trailing parameter
+is-deeply (1, 2, 3, 4).map(-> $a, $b = 99 { "$a-$b" }), ("1-2", "3-4").Seq,
+  'defaulted 2nd param batches by 2';
+
+# a required-arity short final chunk dies (matches raku)
+dies-ok { (1, 2, 3).map(-> \a, \b { a }).eager },
+  'short final chunk of a required 2-param block dies';
+
+# slurpy-only block: count is infinite, arity 0 -> batch 1
+is-deeply (1, 2, 3, 4).map(-> *@a { @a.elems }), (1, 1, 1, 1).Seq,
+  'slurpy-only block maps element-wise';
+
+# one required + slurpy: arity 1 -> batch 1
+is-deeply (1, 2, 3, 4).map(-> $a, *@b { "$a:{@b.elems}" }),
+  ("1:0", "2:0", "3:0", "4:0").Seq,
+  'required-plus-slurpy block batches by the required arity';
+
+# sigil multi-parameter block (unchanged fast path) still batches
+is-deeply (1, 2, 3, 4).map(-> $a, $b { "$a-$b" }), ("1-2", "3-4").Seq,
+  'sigil 2-param block chunks by 2';
+
+# sigilless params flow into a Pair.new call
+is-deeply (1, 2, 3, 4).map(-> \a, \b { Pair.new(a, b) }), (1 => 2, 3 => 4).Seq,
+  'sigilless params usable as Pair.new arguments';


### PR DESCRIPTION
## Summary

`.map` batches its source list by the mapper block's positional-parameter count (its `.count`): a multi-parameter block such as `-> $a, $b { }` consumes a chunk of that many elements per call. The fast path already did this via `data.params.len()`, but `eval_map_over_items` (the List/Seq path) took a separate branch for blocks that require full signature binding — **sigilless (`\a`), typed, optional, or defaulted parameters** — and that branch always passed a **single** element per iteration, ignoring arity.

As a result a legitimate multi-parameter block over a List/Seq raised an error instead of chunking:

```raku
(1, 2, 3, 4).map(-> \a, \b { "{a}-{b}" })
# before: Runtime error: Too few positionals passed; expected 2 arguments but got 1
# after:  ("1-2", "3-4")   (matches raku)
```

## Fix

In the `requires_full_binding` branch of `eval_map_over_items`, compute the batch size from the block's positional parameters instead of hard-coding 1:

- finite `.count` → number of positional (non-named) params;
- infinite `.count` (a slurpy / capture parameter) → required-positional arity, min 1;

matching raku's `&code.count` / `&code.arity` batching. A short final chunk of a required-arity block still raises "Too few positionals" (via `call_sub_value`), and an optional trailing parameter binds the missing slot to its default — both matching raku.

The array-variable rw path (`eval_map_over_items_rw`) already chunked by `params.len()`, so `@a.map(-> \a, \b {…})` was unaffected; only the List/Seq path was wrong.

## Tests

- New `t/map-multiarg-full-binding.t` (11 subtests): sigilless 2/3-param chunking over List and Range, single sigilless, optional/defaulted trailing params, required short-chunk dies, slurpy-only and required-plus-slurpy element-wise, sigil-param fast path, and Pair.new-argument flow.
- `make test` passes; clippy/fmt clean.

## Not covered (separate pre-existing issues)

Surfaced while writing tests but out of scope (they also affect the already-arity-chunking rw path, so are not regressions): (1) passing a sigilless-bound `List` as a positional argument to a nested call inside a map body reads a stale value; (2) `Pair` chunk elements bind as named args, so `%h.sort.map(-> \p, \q {…})` still errors. These block `roast/S32-hash/multislice-6e.t` along with the container-identity write-back campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)