### PR TITLE
fix(our-sub): route inc/dec of an escaped `our` sub's captured lexical through its persisted cell

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -169,6 +169,39 @@ impl Interpreter {
         )
     }
 
+    /// Resolve a bare-name increment/decrement (`$a++`, `--$a`) of a block
+    /// lexical captured by an escaped `our` sub through its persisted shared
+    /// cell. Consulted as the LAST resort in the inc/dec read chain, AFTER the
+    /// env/package lookups: a plain `my sub` that merely shares the variable name
+    /// is called while its declaring block is still live, so its captured `$a`
+    /// resolves through the env cell earlier in the chain and never reaches here.
+    /// Only an escaped `our` sub — whose declaring block has exited, leaving no
+    /// env entry, yet which outlives it in the package registry — falls through
+    /// to the persisted cell. This mirrors what makes reads of such a capture
+    /// work (`escaping_our_read`).
+    ///
+    /// Returns the `ContainerRef` cell only when one is actually recorded (and
+    /// `name` is neither a local nor an upvalue of `code`), so unrelated
+    /// same-named locals/captures and pre-block calls stay untouched.
+    pub(crate) fn escaping_our_incdec_cell(
+        &self,
+        code: &crate::opcode::CompiledCode,
+        name: &str,
+    ) -> Option<Value> {
+        if self.escaping_our_lexical_names.is_empty() {
+            return None;
+        }
+        if code.locals.iter().any(|n| n == name)
+            || code.upvalue_syms.iter().any(|s| s.with_str(|u| u == name))
+        {
+            return None;
+        }
+        // Only intercept when a real persisted cell exists (a `ContainerRef`);
+        // `escaping_our_read` otherwise yields `Nil` (pre-block call), which must
+        // fall through to the normal env chain untouched.
+        self.escaping_our_read(name).filter(|v| v.is_container_ref())
+    }
+
     /// Get a cloned copy of the persisted closure env for a given closure id.
     pub(crate) fn get_closure_env_override(&self, id: u64) -> Option<crate::env::Env> {
         self.closure_env_overrides.get(&id).cloned()

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -199,7 +199,8 @@ impl Interpreter {
         // Only intercept when a real persisted cell exists (a `ContainerRef`);
         // `escaping_our_read` otherwise yields `Nil` (pre-block call), which must
         // fall through to the normal env chain untouched.
-        self.escaping_our_read(name).filter(|v| v.is_container_ref())
+        self.escaping_our_read(name)
+            .filter(|v| v.is_container_ref())
     }
 
     /// Get a cloned copy of the persisted closure env for a given closure id.

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -293,6 +293,7 @@ impl Interpreter {
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
+            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::Int(0));
         // ContainerRef (box-on-capture / `:=`): mutate the shared cell in place so
         // closures over this lexical observe the change and the smart string/Int
@@ -408,6 +409,7 @@ impl Interpreter {
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
+            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::Int(0));
         // ContainerRef (box-on-capture / `:=`): mutate the shared cell in place so
         // closures over this lexical observe the change and the smart string/Int

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -229,6 +229,7 @@ impl Interpreter {
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
+            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::Int(0));
         // ContainerRef: deref for increment, write back through the shared container.
         // Use an atomic read-modify-write under the cell lock so concurrent
@@ -321,6 +322,7 @@ impl Interpreter {
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
+            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::Int(0));
         // ContainerRef: deref for decrement, write back through the shared container.
         // Atomic RMW under the cell lock for concurrent `start` blocks (Track C).

--- a/t/escaped-our-sub-incdec.t
+++ b/t/escaped-our-sub-incdec.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# An `our sub` declared in a bare block closes over the block's `my` lexicals.
+# The registry routine outlives the block, so a call made AFTER the block exits
+# must still see (and mutate) the captured lexical through its persisted shared
+# cell. This exercises the inc/dec path (`$a++`), which previously bypassed the
+# escaped-our-sub cell and read Nil (0), losing the initialization and updates.
+# Regression for roast S02-names-vars/variables-and-packages.t tests 32-34.
+
+plan 8;
+
+# postfix increment, called after the block exits (nested wrapper block)
+{
+    {
+        my $a = 3;
+        our sub grtz { $a++ }
+    }
+    is &OUR::grtz(), 3, 'escaped our sub: postfix ++ sees init (1)';
+    is &OUR::grtz(), 4, 'escaped our sub: postfix ++ accumulates (2)';
+    is &OUR::grtz(), 5, 'escaped our sub: postfix ++ accumulates (3)';
+}
+
+# a plain `my sub` that merely shares the variable name must NOT route through
+# the escaped cell — it is called while its own block is still live.
+{
+    my $a;
+    sub rmbl { $a++ }
+    is rmbl(), 0, 'plain my sub captures its own var (1)';
+    $a++;
+    is rmbl(), 2, 'plain my sub captures its own var (2)';
+}
+
+# prefix increment through an escaped our sub
+{
+    {
+        my $b = 10;
+        our sub bump { ++$b }
+    }
+    is &OUR::bump(), 11, 'escaped our sub: prefix ++ sees init and mutates (1)';
+    is &OUR::bump(), 12, 'escaped our sub: prefix ++ accumulates (2)';
+}
+
+# decrement through an escaped our sub
+{
+    {
+        my $c = 5;
+        our sub drop { $c-- }
+    }
+    is &OUR::drop(), 5, 'escaped our sub: postfix -- sees init (1)';
+}


### PR DESCRIPTION
## Summary

An `our sub` declared in a bare block closes over the block's `my` lexicals but is installed in the package registry, so it outlives the declaring block with no per-sub closure env. Reads of such a capture already resolve through the persisted shared cell (`escaping_our_read`), but the **increment/decrement** path (`$a++`, `--$a`) bypassed it — reading the lexical only via the env/package chain, which after the block exits holds nothing. The captured value was misread as `Nil` (0), so every call lost both the initialization and the accumulated updates.

```raku
{
    my $a = 3;
    our sub grtz { $a++ }
}
say &OUR::grtz();  # was 0, now 3
say &OUR::grtz();  # was 0, now 4
```

## Fix

Add `escaping_our_incdec_cell` as the **last resort** in the four inc/dec read chains (postfix/prefix, increment/decrement). It only fires when:
- the normal env/package chain finds nothing, **and**
- a real persisted `ContainerRef` cell exists, **and**
- the name is neither a local nor an upvalue of the running body.

So a plain `my sub` that merely shares the variable name (called while its declaring block is still live, resolving through the env cell) is untouched, and the existing `ContainerRef` branch mutates the shared cell in place so updates accumulate across calls.

## Impact

Fixes `roast/S02-names-vars/variables-and-packages.t` tests **32-34** (escaped `our sub` accumulation): 7 → 4 subtest failures. The remaining 29-31 (nested-block `BEGIN` compile-time init) and 39 (`$OUTER::_`) are separate slices tracked in `TODO_roast/BLOCKERS.md` §3.1.

## Tests

- New regression test `t/escaped-our-sub-incdec.t` (8/8), covering postfix/prefix `++`, `--`, and the `my sub` non-interference guard.
- `make test`: all 15313 tests pass.
- clippy `-D warnings`, `cargo fmt --check`, and the value-wall ratchet all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)