### PR TITLE
fix(sprintf): exact rational rounding for %e/%E (match Rakudo)

### DIFF
--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -3,7 +3,7 @@ use num_bigint::BigInt;
 
 use super::sprintf_helpers::{
     apply_float_minus_zero, apply_width, format_float_fixed, format_g, format_inf_nan,
-    format_rat_fixed, normalize_sci_exponent, sign_prefix,
+    format_rat_fixed, format_rat_sci, normalize_sci_exponent, sign_prefix,
 };
 pub(crate) use super::sprintf_validate::{
     directives_count_message, sprintf_arg_specs, sprintf_directive_count,
@@ -376,20 +376,28 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                 }
             }
             'e' | 'E' => {
-                let f = float_val();
-                if f.is_infinite() || f.is_nan() {
-                    format_inf_nan(f, plus_sign, space_flag)
+                let p = prec_num.unwrap_or(6);
+                // Use exact rational formatting (exponent from the original
+                // value, mantissa rounded half-away-from-zero and NOT re-
+                // normalized on carry) for numeric args, matching Rakudo; fall
+                // back to float only for non-numeric arguments and inf/nan.
+                if let Some(rendered) = format_rat_sci(arg, p, plus_sign, space_flag, spec == 'E') {
+                    rendered
                 } else {
-                    let p = prec_num.unwrap_or(6);
-                    let is_neg = f.is_sign_negative() && (f != 0.0 || f.is_sign_negative());
-                    let prefix = sign_prefix(is_neg, plus_sign, space_flag);
-                    let abs = f.abs();
-                    let formatted = if spec == 'e' {
-                        normalize_sci_exponent(&format!("{:.*e}", p, abs))
+                    let f = float_val();
+                    if f.is_infinite() || f.is_nan() {
+                        format_inf_nan(f, plus_sign, space_flag)
                     } else {
-                        normalize_sci_exponent(&format!("{:.*E}", p, abs))
-                    };
-                    format!("{}{}", prefix, formatted)
+                        let is_neg = f.is_sign_negative() && (f != 0.0 || f.is_sign_negative());
+                        let prefix = sign_prefix(is_neg, plus_sign, space_flag);
+                        let abs = f.abs();
+                        let formatted = if spec == 'e' {
+                            normalize_sci_exponent(&format!("{:.*e}", p, abs))
+                        } else {
+                            normalize_sci_exponent(&format!("{:.*E}", p, abs))
+                        };
+                        format!("{}{}", prefix, formatted)
+                    }
                 }
             }
             'g' | 'G' => {

--- a/src/runtime/sprintf_helpers.rs
+++ b/src/runtime/sprintf_helpers.rs
@@ -37,17 +37,11 @@ fn f64_to_rational(f: f64) -> (BigInt, BigInt) {
     (numer, denom)
 }
 
-/// Format a numeric value for %f with exact precision (avoids f64 half-to-even
-/// rounding). Uses round-half-away-from-zero like Rakudo. For Num arguments the
-/// f64 is first converted to its exact shortest-decimal rational so that e.g.
-/// `sprintf("%.2f", 1.005e0)` yields `1.01`, matching Rakudo.
-/// Returns None if the argument is not numeric.
-pub(super) fn format_rat_fixed(
-    arg: Option<&Value>,
-    p: usize,
-    plus_sign: bool,
-    space_flag: bool,
-) -> Option<String> {
+/// Extract an exact rational `(numer, denom)` from a numeric sprintf argument,
+/// together with a `neg_zero` flag (for `-0.0` / a `"-..."` string whose value
+/// rounds to zero). Returns None for non-numeric arguments. Shared by the `%f`
+/// and `%e` exact-rounding paths.
+fn extract_rational(arg: Option<&Value>) -> Option<(BigInt, BigInt, bool)> {
     let (numer, denom) = match arg {
         Some(Value::Rat(n, d)) if *d != 0 => (BigInt::from(*n), BigInt::from(*d)),
         Some(Value::FatRat(n, d)) if *d != 0 => (BigInt::from(*n), BigInt::from(*d)),
@@ -62,33 +56,64 @@ pub(super) fn format_rat_fixed(
         },
         _ => return None,
     };
-    // Detect a negatively-signed zero (e.g. -0.0e0) so its sign is preserved.
     let neg_zero = matches!(arg, Some(Value::Num(f)) if f.is_sign_negative())
         || matches!(arg, Some(Value::Str(s)) if s.trim().starts_with('-'));
-    let is_neg = numer < BigInt::from(0) || (numer == BigInt::from(0) && neg_zero);
-    let prefix = sign_prefix(is_neg, plus_sign, space_flag);
-    let abs_numer = if is_neg { -&numer } else { numer };
-    // Compute integer and fractional parts using BigInt arithmetic
-    let int_part = &abs_numer / &denom;
-    let remainder = &abs_numer % &denom;
+    Some((numer, denom, neg_zero))
+}
+
+/// Number of decimal digits in a non-negative `BigInt` (`0` has 1 digit).
+fn ndigits(x: &BigInt) -> i32 {
+    x.to_string().trim_start_matches('-').len() as i32
+}
+
+/// Compare `numer/denom` (with `numer, denom > 0`) against `10^e`, returning the
+/// `Ordering` of the value relative to that power of ten. Uses cross-
+/// multiplication so no fractional powers are needed.
+fn cmp_value_pow10(numer: &BigInt, denom: &BigInt, e: i32) -> std::cmp::Ordering {
+    if e >= 0 {
+        numer.cmp(&(denom * num_traits::pow::pow(BigInt::from(10), e as usize)))
+    } else {
+        (numer * num_traits::pow::pow(BigInt::from(10), (-e) as usize)).cmp(denom)
+    }
+}
+
+/// `floor(log10(numer/denom))` for a strictly-positive rational, computed
+/// exactly with `BigInt` arithmetic.
+fn floor_log10(numer: &BigInt, denom: &BigInt) -> i32 {
+    let mut e = ndigits(numer) - ndigits(denom);
+    while cmp_value_pow10(numer, denom, e) == std::cmp::Ordering::Less {
+        e -= 1;
+    }
+    while cmp_value_pow10(numer, denom, e + 1) != std::cmp::Ordering::Less {
+        e += 1;
+    }
+    e
+}
+
+/// Render `abs_numer/denom` (a non-negative rational) as a fixed-point string
+/// with exactly `p` fractional digits, rounding half away from zero. A carry out
+/// of the fractional part propagates into the integer part (so
+/// `9.995` with `p == 2` becomes `"10.00"`, not `"9.99"`), but the result is
+/// never re-normalized — the caller decides what to do with a mantissa that grew
+/// past its expected range (the `%e` path deliberately keeps `10.00e+00`).
+fn format_rational_fixed_abs(abs_numer: &BigInt, denom: &BigInt, p: usize) -> String {
+    let int_part = abs_numer / denom;
+    let remainder = abs_numer % denom;
     if p == 0 {
-        // Round to integer
         let doubled = &remainder * BigInt::from(2);
-        let rounded = if doubled >= denom {
+        let rounded = if doubled >= *denom {
             &int_part + BigInt::from(1)
         } else {
             int_part
         };
-        return Some(format!("{}{}", prefix, rounded));
+        return rounded.to_string();
     }
-    // Compute p decimal digits of the fractional part
     let scale = num_traits::pow::pow(BigInt::from(10), p);
     let scaled_remainder = &remainder * &scale;
-    // Divide and round
-    let frac_digits = &scaled_remainder / &denom;
-    let frac_remainder = &scaled_remainder % &denom;
+    let frac_digits = &scaled_remainder / denom;
+    let frac_remainder = &scaled_remainder % denom;
     let doubled_frac = &frac_remainder * BigInt::from(2);
-    let (final_int, final_frac) = if doubled_frac >= denom {
+    let (final_int, final_frac) = if doubled_frac >= *denom {
         let rounded_frac = &frac_digits + BigInt::from(1);
         if rounded_frac >= scale {
             (&int_part + BigInt::from(1), BigInt::from(0))
@@ -99,7 +124,74 @@ pub(super) fn format_rat_fixed(
         (int_part, frac_digits)
     };
     let frac_str = format!("{:0>width$}", final_frac, width = p);
-    Some(format!("{}{}.{}", prefix, final_int, frac_str))
+    format!("{final_int}.{frac_str}")
+}
+
+/// Format a numeric value for %f with exact precision (avoids f64 half-to-even
+/// rounding). Uses round-half-away-from-zero like Rakudo. For Num arguments the
+/// f64 is first converted to its exact shortest-decimal rational so that e.g.
+/// `sprintf("%.2f", 1.005e0)` yields `1.01`, matching Rakudo.
+/// Returns None if the argument is not numeric.
+pub(super) fn format_rat_fixed(
+    arg: Option<&Value>,
+    p: usize,
+    plus_sign: bool,
+    space_flag: bool,
+) -> Option<String> {
+    let (numer, denom, neg_zero) = extract_rational(arg)?;
+    let is_neg = numer < BigInt::from(0) || (numer == BigInt::from(0) && neg_zero);
+    let prefix = sign_prefix(is_neg, plus_sign, space_flag);
+    let abs_numer = if is_neg { -&numer } else { numer };
+    let body = format_rational_fixed_abs(&abs_numer, &denom, p);
+    Some(format!("{prefix}{body}"))
+}
+
+/// Format a numeric value for %e/%E with exact precision, matching Rakudo's
+/// scientific formatting. The exponent is `floor(log10(|value|))` of the
+/// *original* value; the mantissa is `|value| / 10^exp` rendered as a
+/// fixed-point number with `p` fractional digits, rounded half away from zero.
+/// Crucially, Rakudo does NOT re-normalize a mantissa that a rounding carry
+/// pushed to `10` or beyond, so `sprintf("%.2e", 9.995)` is `"10.00e+00"`, not
+/// `"1.00e+01"`. Returns None if the argument is not numeric.
+pub(super) fn format_rat_sci(
+    arg: Option<&Value>,
+    p: usize,
+    plus_sign: bool,
+    space_flag: bool,
+    upper: bool,
+) -> Option<String> {
+    let (numer, denom, neg_zero) = extract_rational(arg)?;
+    let is_neg = numer < BigInt::from(0) || (numer == BigInt::from(0) && neg_zero);
+    let prefix = sign_prefix(is_neg, plus_sign, space_flag);
+    let abs_numer = if is_neg { -&numer } else { numer };
+    let e_char = if upper { 'E' } else { 'e' };
+    if abs_numer == BigInt::from(0) {
+        let mantissa = if p == 0 {
+            "0".to_string()
+        } else {
+            format!("0.{}", "0".repeat(p))
+        };
+        return Some(format!("{prefix}{mantissa}{e_char}+00"));
+    }
+    let exp = floor_log10(&abs_numer, &denom);
+    // mantissa = |value| / 10^exp, kept exact as a rational.
+    let (mant_numer, mant_denom) = if exp >= 0 {
+        (
+            abs_numer,
+            &denom * num_traits::pow::pow(BigInt::from(10), exp as usize),
+        )
+    } else {
+        (
+            &abs_numer * num_traits::pow::pow(BigInt::from(10), (-exp) as usize),
+            denom,
+        )
+    };
+    let mantissa = format_rational_fixed_abs(&mant_numer, &mant_denom, p);
+    let exp_sign = if exp >= 0 { '+' } else { '-' };
+    Some(format!(
+        "{prefix}{mantissa}{e_char}{exp_sign}{:02}",
+        exp.unsigned_abs()
+    ))
 }
 
 /// Format a non-negative float using %g/%G rules:

--- a/t/sprintf-e-exact-rounding.t
+++ b/t/sprintf-e-exact-rounding.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# `%e`/`%E` must round the exact numeric value (half away from zero) and take
+# the exponent from the original value, matching Rakudo. In particular the
+# mantissa is NOT re-normalized when a rounding carry pushes it to 10 or beyond
+# (`sprintf("%.2e", 9.995)` is "10.00e+00", not "1.00e+01"). This differs from
+# C printf and from Rust's default half-to-even f64 formatting.
+
+plan 30;
+
+# Exact-tie rounding on Rats (the digit after the cut is exactly 5).
+is sprintf("%.3e", 1.2345),  "1.235e+00", "Rat tie rounds half up (.3e)";
+is sprintf("%.2e", 2.675),   "2.68e+00",  "Rat tie rounds half up (.2e)";
+is sprintf("%.3e", -1.2345), "-1.235e+00", "negative Rat tie rounds away from zero";
+is sprintf("%+.3e", 1234.5), "+1.235e+03", "tie with + flag and exponent";
+
+# Num arguments round their shortest-decimal representation, like %f.
+is sprintf("%.2e", 1.005e0), "1.01e+00", "Num tie rounds half up";
+is sprintf("%.0e", 2.5e0),   "3e+00",    "Num .0e rounds half up";
+
+# Carry out of the mantissa is kept, NOT re-normalized.
+is sprintf("%.2e", 9.995),   "10.00e+00", "mantissa carry keeps 10.00e+00";
+is sprintf("%.2e", 9.9995),  "10.00e+00", "mantissa carry (deeper tie)";
+is sprintf("%.3e", 9.9995),  "10.000e+00", "mantissa carry (.3e)";
+is sprintf("%.0e", 9.995),   "10e+00",    "mantissa carry (.0e)";
+is sprintf("%.2e", 999.5),   "10.00e+02", "carry keeps exponent, mantissa 10.00e+02";
+
+# Basic values without rounding.
+is sprintf("%e", 0),         "0.000000e+00", "zero";
+is sprintf("%.2e", -0e0),    "-0.00e+00",    "negative zero keeps sign";
+is sprintf("%.6e", 27.1),    "2.710000e+01", "27.1 default-ish precision";
+is sprintf("%E", 27.1),      "2.710000E+01", "%E uppercase";
+is sprintf("%.2e", -2.71),   "-2.71e+00",    "negative value";
+is sprintf("%.0e", 27.1),    "3e+01",        "27.1 .0e";
+is sprintf("%.0e", -2.71),   "-3e+00",       "-2.71 .0e";
+
+# Small and large exponents.
+is sprintf("%.3e", 1.235e-04), "1.235e-04",  "small negative exponent";
+is sprintf("%.2e", 0.00012345), "1.23e-04",  "small value";
+is sprintf("%.3e", 0.00012355), "1.236e-04", "small value rounds half up";
+is sprintf("%.3e", 12345678900000), "1.235e+13", "large exponent";
+is sprintf("%.2e", 6.02e23), "6.02e+23", "very large exponent";
+is sprintf("%.2e", 0.000000009995), "10.00e-09", "carry with negative exponent";
+
+# Width and zero padding still apply on top of the exact rendering.
+is sprintf("%020.2e", 3.1415), "0000000000003.14e+00", "zero-padded width";
+is sprintf("%15.2e", -9.995),  "     -10.00e+00",       "space-padded width with carry";
+
+# Repeating fractions (no tie) round correctly.
+is sprintf("%.10e", 1/3), "3.3333333333e-01", "1/3 rounds correctly";
+is sprintf("%.10e", 1/7), "1.4285714286e-01", "1/7 rounds correctly";
+
+# %g scientific path is unaffected by this change.
+is sprintf("%.3g", 1234.5), "1.23e+03", "%g still significant-digit based";
+is sprintf("%g", 100),      "100",      "%g integer";


### PR DESCRIPTION
## What

`sprintf`/`printf`/`zprintf` `%e`/`%E` rendered the argument by converting it to `f64` and using Rust's default `{:.*e}` formatting. That rounds **half-to-even** and **re-normalizes** a mantissa when a rounding carry pushes it to 10 or beyond. Rakudo does neither.

Rakudo's `%e`:
- rounds the **exact** numeric value **half away from zero**, and
- takes the exponent from the **original** value, leaving a carried mantissa un-normalized.

So the old behavior diverged from Rakudo:

| input | format | mutsu (before) | Rakudo / mutsu (after) |
|-------|--------|----------------|------------------------|
| `1.2345` | `%.3e` | `1.234e+00` | `1.235e+00` |
| `2.675`  | `%.2e` | `2.67e+00`  | `2.68e+00`  |
| `1.005e0`| `%.2e` | `1.00e+00`  | `1.01e+00`  |
| `9.995`  | `%.2e` | `9.99e+00`  | `10.00e+00` |
| `999.5`  | `%.2e` | `1.00e+03`  | `10.00e+02` |

## How

Mirror the existing exact-rational `%f` path (`format_rat_fixed`) with a new `format_rat_sci`. The shared pieces are factored out so both specifiers use one implementation:

- `extract_rational` — pull an exact `(numer, denom)` (+ neg-zero flag) from `Rat`/`FatRat`/`BigRat`/`Int`/`Num`/`Str`.
- `floor_log10` — exact `floor(log10(|value|))` via `BigInt` (no `f64` log).
- `format_rational_fixed_abs` — half-away-from-zero fixed-point rendering with carry into the integer part, no re-normalization.

`Num`/`Str` args round their shortest-decimal representation, exactly as `%f` already does. Non-numeric args and inf/nan still fall back to the float path.

## Testing

- New `t/sprintf-e-exact-rounding.t` (30 assertions) pinning ties, mantissa carries, signed/zero values, small/large exponents, width+zero padding, and that `%g` is untouched.
- Verified byte-for-byte against Rakudo across all cases.
- `make test`: 15293 tests pass.
- Whitelisted roast files `sprintf-e.t`, `sprintf-f.t`, `6.d/S32-str/sprintf.t` still pass (no regression).

Note: the non-whitelisted `S32-str/sprintf.t` (v6.e `zprintf`) still fails its 4 `%g` zero-padded-scientific subtests — those assert a separate Rakudo positive-zero-pad quirk unrelated to `%e` rounding and are out of scope here.