### PR TITLE
fix(regex): carry the subject string into m:g match objects' .orig

### DIFF
--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -262,7 +262,11 @@ impl Interpreter {
     }
 
     /// Apply multiple regex captures (for :g, :ov, :ex) -- set $/ to list of Match objects.
-    pub(in crate::runtime) fn apply_multi_regex_captures(&mut self, selected: &[RegexCaptures]) {
+    pub(in crate::runtime) fn apply_multi_regex_captures(
+        &mut self,
+        selected: &[RegexCaptures],
+        orig: &str,
+    ) {
         let slash_list = selected
             .iter()
             .map(|c| {
@@ -271,6 +275,11 @@ impl Interpreter {
                 // survive into each `m:g` match object, matching the single-match
                 // path. The short builder dropped `positional_quantified` etc.,
                 // collapsing `$m[0]` to a bare string.
+                //
+                // `orig` is the whole subject string so each match's `.orig`
+                // (and nested captures' `.orig`) reports the source text, matching
+                // the single-match path and `.match(:g)` — the `~~ m:g/.../` path
+                // previously passed `None`, leaving `.orig` empty.
                 Value::make_match_object_full(
                     c.matched.clone(),
                     c.from as i64,
@@ -281,7 +290,7 @@ impl Interpreter {
                     &c.positional_subcaps,
                     &c.positional_quantified,
                     &c.positional_nil,
-                    None,
+                    Some(orig),
                 )
             })
             .collect::<Vec<_>>();

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -382,7 +382,7 @@ impl Interpreter {
                 if selected.len() == 1 {
                     self.apply_single_regex_captures(&selected[0]);
                 } else {
-                    self.apply_multi_regex_captures(&selected);
+                    self.apply_multi_regex_captures(&selected, &text);
                 }
                 true
             }
@@ -450,7 +450,7 @@ impl Interpreter {
                     self.clear_match_state();
                     return false;
                 };
-                self.apply_multi_regex_captures(&selected);
+                self.apply_multi_regex_captures(&selected, &text);
                 true
             }
             // :g (global) -- find all non-overlapping matches
@@ -510,7 +510,7 @@ impl Interpreter {
                         self.execute_regex_code_blocks(&cap.code_blocks);
                     }
                 }
-                self.apply_multi_regex_captures(&selected);
+                self.apply_multi_regex_captures(&selected, &text);
                 true
             }
             // :ov (overlap) -- find longest match at each starting position
@@ -552,7 +552,7 @@ impl Interpreter {
                     }
                 }
                 let selected: Vec<_> = best_by_start.into_values().collect();
-                self.apply_multi_regex_captures(&selected);
+                self.apply_multi_regex_captures(&selected, &text);
                 true
             }
             // :ex (exhaustive) -- find ALL possible matches
@@ -596,7 +596,7 @@ impl Interpreter {
                 } else {
                     all
                 };
-                self.apply_multi_regex_captures(&selected);
+                self.apply_multi_regex_captures(&selected, &text);
                 true
             }
             // Array/List ~~ Regex: iterate elements, match each individually

--- a/t/match-global-orig.t
+++ b/t/match-global-orig.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# `$str ~~ m:g/.../` (and the other multi-match adverb paths :x/:ov/:ex/:nth)
+# builds a list of Match objects. Each match's `.orig` must report the whole
+# subject string, matching the single-match path and `.match(:g)`. The
+# `~~ m:g` path previously passed `None` as the origin, leaving `.orig` empty
+# (and rendering as `:orig("")` in `.raku`).
+
+plan 8;
+
+{
+    my @m = "a1b2" ~~ m:g/(\w)/;
+    is @m[0].orig, "a1b2", 'm:g match .orig reports the subject string (1)';
+    is @m[1].orig, "a1b2", 'm:g match .orig reports the subject string (2)';
+}
+
+{
+    # nested positional captures also carry orig
+    my @m = "a1b2" ~~ m:g/(\w)(\d)/;
+    is @m[0][0].orig, "a1b2", 'm:g nested capture .orig reports the subject string';
+    is @m[0].Str, "a1", 'm:g match .Str still correct';
+}
+
+{
+    # :ov (overlap) path
+    my @m = "aaa" ~~ m:ov/a+/;
+    is @m[0].orig, "aaa", 'm:ov match .orig reports the subject string';
+}
+
+{
+    # :x(N) path
+    my @m = "aXbXc" ~~ m:x(2)/\w/;
+    is @m[1].orig, "aXbXc", 'm:x(N) match .orig reports the subject string';
+}
+
+{
+    # :nth multi path
+    my @m = "a1b2c3" ~~ m:nth(1,2)/(\w)/;
+    is @m[0].orig, "a1b2c3", 'm:nth multi match .orig reports the subject string';
+}
+
+{
+    # the single-match path is unaffected
+    is ("abc" ~~ /b/).orig, "abc", 'single match .orig unaffected';
+}


### PR DESCRIPTION
## Problem

`\$str ~~ m:g/.../` builds a list of `Match` objects, but each match's
`.orig` was empty (rendered as `:orig(\"\")` in `.raku`), diverging from both
the single-match path and `.match(:g)`, which report the whole subject string:

```raku
my @m = "a1b2" ~~ m:g/(\w)/;
say @m[0].orig;   # was "" (empty), now "a1b2"
```

`raku` reports `a1b2`.

## Cause

The multi-match adverb paths (`:g`, `:x(N)`, `:ov`, `:ex`, and multi-index
`:nth`) all funnel through `apply_multi_regex_captures`, which built each
match object with `make_match_object_full(..., None)` — passing `None` for
the origin string, so `.orig` (and nested captures' `.orig`) came back empty.

## Fix

Thread the subject text into `apply_multi_regex_captures` and pass it as the
`orig` argument, so every m:g match object and its nested captures report the
correct `.orig`. All five multi-match call sites already have the subject
`text` in scope. The single-match path is unaffected.

## Verification

`.raku` output for `"a1b2" ~~ m:g/(\w)(\d)/` is now byte-identical to `raku`.
Regression test `t/match-global-orig.t` covers `:g`, nested captures, `:ov`,
`:x(N)`, multi-`:nth`, and the unchanged single-match path.

`make test` passes; related regex roast tests (`S05-modifier/global.t`,
`S05-match/capturing-contexts.t`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)