### PR TITLE
fix(closure): resolve $OUTER:: against captured lexical scope in stored closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2057,7 +2057,10 @@ impl CompiledCode {
             // is dynamic-scope — resolved against the live call stack — so it is
             // deliberately NOT captured.)
             if let OpCode::GetOuterVar { name_idx, .. } = op
-                && let Some(name) = self.constants.get(*name_idx as usize).and_then(|v| v.as_str())
+                && let Some(name) = self
+                    .constants
+                    .get(*name_idx as usize)
+                    .and_then(|v| v.as_str())
             {
                 if !outer_ref_names.iter().any(|n| n == name) {
                     outer_ref_names.push(name.to_string());

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1475,6 +1475,12 @@ pub(crate) struct CompiledCode {
     /// the entire (~100-entry) captured env. Empty until `compute_free_vars`
     /// runs (during `compute_needs_env_sync`).
     pub(crate) free_var_syms: Vec<Symbol>,
+    /// Bare names this code reads through an `$OUTER::` reference (`$OUTER::x` →
+    /// `x`). Populated by `compute_free_vars` from `GetOuterVar` ops. The closure
+    /// snapshots each such name's captured enclosing value under a reserved
+    /// `__mutsu_outer::<name>` env key so `get_outer_var` can resolve it even after
+    /// the running frame overwrites the plain name (e.g. a fresh topic `$_`).
+    pub(crate) outer_ref_names: Vec<String>,
     /// Free variables (names not in this code's own locals) that this code or a
     /// nested closure *writes* (assign / inc-dec / bind). Folded up from nested
     /// closures so an enclosing scope can tell which of *its* locals are mutated
@@ -1629,6 +1635,7 @@ impl CompiledCode {
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),
             free_var_syms: Vec::new(),
+            outer_ref_names: Vec::new(),
             free_var_writes: Vec::new(),
             free_var_container_writes: Vec::new(),
             named_sub_captures: Vec::new(),
@@ -1994,6 +2001,8 @@ impl CompiledCode {
         // Free `@`/`%` containers mutated in place (push/append/element-assign).
         let mut free_container_writes: std::collections::HashSet<Symbol> =
             std::collections::HashSet::new();
+        // Bare names read via `$OUTER::` (order-preserving, de-duplicated).
+        let mut outer_ref_names: Vec<String> = Vec::new();
         let mut pending_decl = false;
         for op in &self.ops {
             // Read+write free-var set (names referenced from an enclosing scope).
@@ -2038,6 +2047,23 @@ impl CompiledCode {
                     // scoping in grammar actions, t/grammar-reduce-time-dynvar.t),
                     // so they are NOT excluded here.
                     free_writes.insert(Symbol::intern(name));
+                }
+            }
+            // `$OUTER::x` reads the enclosing lexical scope's binding of `x`.
+            // OUTER:: is a *lexical* construct, so the enclosing binding must be
+            // captured into this closure's env (`get_outer_var` resolves it there
+            // once the defining block has exited). The op scan above does not treat
+            // `GetOuterVar` as a name-read, so register the bare name here. (CALLER::
+            // is dynamic-scope — resolved against the live call stack — so it is
+            // deliberately NOT captured.)
+            if let OpCode::GetOuterVar { name_idx, .. } = op
+                && let Some(name) = self.constants.get(*name_idx as usize).and_then(|v| v.as_str())
+            {
+                if !outer_ref_names.iter().any(|n| n == name) {
+                    outer_ref_names.push(name.to_string());
+                }
+                if !own.contains(name) {
+                    free.insert(Symbol::intern(name));
                 }
             }
             match op {
@@ -2222,6 +2248,7 @@ impl CompiledCode {
         self.needs_cell_escaping_our_sub = nceos.into_iter().collect();
         self.needs_cell_escaping_our_sub_free = nceos_free.into_iter().collect();
         self.free_var_syms = free.into_iter().collect();
+        self.outer_ref_names = outer_ref_names;
         self.free_var_writes = free_writes.into_iter().collect();
         self.free_var_container_writes = free_container_writes.into_iter().collect();
         self.captured_mutated_locals = captured_mutated.into_iter().collect();

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -338,6 +338,18 @@ impl Interpreter {
                     flat.insert_sym(*sym, val.clone());
                 }
             }
+            // `$OUTER::x` inside this closure reads the *enclosing* binding of `x`,
+            // which is captured into `flat` right now. But when the closure runs,
+            // its own frame may overwrite that name in the live env (most commonly
+            // the topic `$_`: a bare `sub {...}` establishes a fresh `$_ = Any`).
+            // OUTER:: is lexical, so snapshot the captured enclosing value under a
+            // reserved key the running frame never touches; `get_outer_var` reads
+            // it back regardless of any later same-name overwrite.
+            for name in &cc.outer_ref_names {
+                if let Some(val) = flat.get(name).cloned() {
+                    flat.insert(format!("__mutsu_outer::{name}"), val);
+                }
+            }
             // Drop the closure's own params/locals (e.g. a WhateverCode's `_`
             // topic param) so a stale enclosing `for`/map topic is not inherited
             // and later leaked back to the caller.

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -350,23 +350,40 @@ impl Interpreter {
     /// `depth` is the number of OUTER:: prefixes (1 = immediate outer, 2 = two levels up).
     /// Uses the `outer_scope_locals` stack which is populated by BlockScope operations.
     pub(super) fn get_outer_var(&self, code: &CompiledCode, name: &str, depth: usize) -> Value {
-        let stack_len = self.outer_scope_locals.len();
-        if depth == 0 || stack_len == 0 {
+        if depth == 0 {
             return Value::NIL;
         }
-        // The outer_scope_locals stack has the most recent (innermost) scope at the end.
-        // depth=1 means the immediately enclosing scope (last element).
-        let idx = if depth <= stack_len {
-            stack_len - depth
-        } else {
-            return Value::NIL;
-        };
-        let saved = &self.outer_scope_locals[idx];
-        // Find the local slot for this variable name
-        for (slot, local_name) in code.locals.iter().enumerate() {
-            if local_name == name && slot < saved.len() {
-                return saved[slot].clone();
+        let stack_len = self.outer_scope_locals.len();
+        // Inline nested-block path: `outer_scope_locals` (runtime-saved slots)
+        // reflects the lexical structure of nested bare blocks executed in place,
+        // so it distinguishes multiple same-named `my $a` bindings by depth.
+        if stack_len > 0 && depth <= stack_len {
+            let idx = stack_len - depth;
+            let saved = &self.outer_scope_locals[idx];
+            // Find the local slot for this variable name.
+            for (slot, local_name) in code.locals.iter().enumerate() {
+                if local_name == name && slot < saved.len() {
+                    return saved[slot].clone();
+                }
             }
+        }
+        // Stored-closure path: when a closure is invoked later (after its defining
+        // block has exited), `outer_scope_locals` no longer holds that block's
+        // scope — the closure's *lexical* outer scope was captured into its `env`
+        // at creation time (the flattened enclosing scope). OUTER:: is a lexical
+        // construct, so resolve the name against the captured env rather than the
+        // dynamic runtime stack. The flat capture holds every enclosing lexical,
+        // so a depth>1 access reaches transitive outers too.
+        //
+        // Prefer the reserved `__mutsu_outer::<name>` snapshot: the running frame
+        // may have overwritten the plain name (e.g. a bare `sub {...}` establishes
+        // a fresh topic `$_ = Any`), but the snapshot preserves the captured
+        // enclosing value that `$OUTER::` must see.
+        if let Some(val) = self.env().get(&format!("__mutsu_outer::{name}")) {
+            return val.clone();
+        }
+        if let Some(val) = self.env().get(name) {
+            return val.clone();
         }
         Value::NIL
     }

--- a/t/outer-topic.t
+++ b/t/outer-topic.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 7;
+
+# $OUTER::_ in a stored closure accesses the enclosing topic even after the
+# defining block has exited.
+# https://github.com/Raku/old-issue-tracker/issues/1665
+{
+    my $t;
+    for 'a' {
+        $t = sub { $OUTER::_ };
+    }
+    is $t(), 'a', '$OUTER::_ can access a $_';
+}
+
+# $OUTER::x resolves a named enclosing lexical from a stored closure.
+{
+    my $u;
+    for 'b' {
+        my $x = 'inner-b';
+        $u = sub { $OUTER::x };
+    }
+    is $u(), 'inner-b', '$OUTER::x reaches the enclosing named lexical';
+}
+
+# Inline nested blocks still resolve OUTER by lexical depth (unchanged path).
+{ my $a = 1; {
+   my $a = 2; {
+      my $a = 3;
+      is $a,               3, 'get regular $a';
+      is $OUTER::a,        2, 'get $OUTER::a';
+      is $OUTER::OUTER::a, 1, 'get $OUTER::OUTER::a';
+}}}
+
+# A closure that also uses its own topic keeps them distinct: the sub's own
+# `$_` is a fresh (undefined) topic, while `$OUTER::_` is the enclosing one.
+{
+    my $c;
+    for 'outer' {
+        $c = sub { $_.defined ?? "own-defined" !! "own={$OUTER::_}" };
+    }
+    is $c(), 'own=outer', 'own $_ and $OUTER::_ stay distinct';
+}
+
+# The captured OUTER binding survives multiple later invocations.
+{
+    my $g;
+    for 'z' {
+        $g = sub { $OUTER::_ };
+    }
+    is $g() ~ $g(), 'zz', 'repeated invocations keep the captured topic';
+}


### PR DESCRIPTION
## Summary

`$OUTER::x` inside a closure that is invoked *after* its defining block has exited returned `Nil` (for a named lexical) or the closure's own fresh topic (for `$OUTER::_`) instead of the enclosing binding.

Two root causes, per `TODO_roast/BLOCKERS.md` §3.1:

1. **`get_outer_var` only consulted the runtime `outer_scope_locals` stack**, which reflects the *dynamic* call stack and is empty when a stored closure runs later. `OUTER::` is a *lexical* construct, so it now falls back to the closure's captured `env` (the flattened enclosing scope).

2. **The `$OUTER::x` bare name was never registered as a free variable**, so the enclosing binding was never captured into the closure's env. `compute_free_vars` now registers OUTER bare names.

For the topic `$_`, the running frame overwrites the plain `_` in env (a bare `sub {...}` establishes a fresh `$_ = Any`), clobbering the captured value. The closure now snapshots each OUTER-referenced name under a reserved `__mutsu_outer::<name>` env key at capture time (new `CompiledCode::outer_ref_names`) — a key the running frame never touches — and `get_outer_var` resolves `OUTER::` against it first.

## Result

- Fixes roast `S02-names-vars/variables-and-packages.t` test 39 (`$OUTER::_ can access a $_`).
- New `t/outer-topic.t` covering stored-closure OUTER, named-lexical OUTER, inline nested-block depth (unchanged path), and own-topic-vs-`$OUTER::_` distinctness.
- `make test` passes (Files=1564, Tests=15362). No regression in whitelisted OUTER-using roast tests.

(The remaining `variables-and-packages.t` failures 29–31 are the pre-existing nested-block `BEGIN` initialization gap, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)