### PR TITLE
fix(dispatch): OTF-compile module subs with standard param traits

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -211,10 +211,14 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 - [ ] default-param OTF の builtin-shadow 単一候補（name-cache 汚染リスクがあるため意図的に除外を維持中）。
 - [ ] モジュール sub OTF に残る interpreter 結合構文: `state` / `EVAL` / `EVALFILE` / `start` /
-      `CATCH` / `CONTROL` / phaser / ネスト宣言 / subtest / sigilless scalar（`\x`）/ 戻り型 coercion
+      `CATCH` / `CONTROL` / phaser / ネスト宣言 / subtest / sigilless scalar（`\x`）/ 戻り型 coercion /
+      `is encoded(...)`（NativeCall marshalling）
       （ゲート実体 = `def_is_otf_compilable_module_single`、`vm/vm_call_func_ops.rs`）。
-      `is rw`/`is raw` は #4091（rw-arg のコンパイル時 caller slot 化）でゲートから外れた。
-      本筋は `compiled_fns` の拡充。
+      標準 param trait（`is copy`/`is rw`/`is raw`/`is readonly`/`is required`）はゲートから外れた
+      （旧 `pd.traits.is_empty()` の一律除外を解除。compiled binding は元々これらを処理していた＝
+      builtin-shadow ゲート `def_is_otf_compilable` は trait 未チェック。加えて tree-walk fallback が
+      黙って落としていた `is rw` の caller writeback が OTF 化で修正された。担保 =
+      `t/module-sub-otf-trait-params.t`）。本筋は `compiled_fns` の拡充。
 - [ ] `@_` slurpy recursive sub（別カテゴリ）。`@a[1..*]` 再帰の immutable-List bug は §4 扱い。
 - 完了済み（計測で確認）: bare multi OTF / `state` 候補・caching-proto body（#4047）/ `code_signature`
   param（#3883）/ capture param。signature alternates の `state` 共有のみ interpreter 境界として

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1715,8 +1715,14 @@ impl Interpreter {
     ///   - `EVAL`/`EVALFILE` with a `CALLER::` context, `subtest`, `CATCH`/
     ///     `CONTROL` handlers, phasers, `start` (all couple to the interpreter's
     ///     caller / test / dispatch context — Test::Util's `throws-like-any`),
-    ///   - `is rw`/`is raw`/sigilless params whose alias writeback to the caller
+    ///   - a sigilless *scalar* (`\x`) param whose alias writeback to the caller
     ///     must survive across an `EVAL` boundary (t/sigilless-params).
+    ///
+    /// `is rw`/`is raw`/`is copy`/`is readonly`/`is required` params are NOW
+    /// allowed (§2 multi-dispatch VM-ization): the compiled binding already
+    /// honored them for builtin shadows, and the rw/raw caller writeback carries
+    /// a compile-time caller slot (#4091). Only `is encoded(...)` (NativeCall)
+    /// stays excluded.
     ///
     /// Defaults ARE allowed (name-cache-safe: no same-named builtin to mis-bind,
     /// and a single candidate always resolves to this def). Bodies and
@@ -1756,8 +1762,20 @@ impl Interpreter {
                 // non-capture sub-signature stay excluded (caller-alias writeback
                 // across an EVAL boundary — see the doc comment above).
                 let is_capture = pd.slurpy && pd.sigilless;
-                (is_capture || (!pd.sigilless && pd.sub_signature.is_none()))
-                    && pd.traits.is_empty()
+                // Standard binding-time param traits (`is copy`/`is rw`/`is raw`/
+                // `is readonly`/`is required`) are OTF-safe: the compiled binding
+                // path already honors them for builtin-shadow subs (the non-module
+                // gate `def_is_otf_compilable` never checked `traits`), and the
+                // rw/raw caller writeback carries a compile-time caller slot (#4091)
+                // that refreshes the caller variable identically to the interpreter,
+                // including across an EVAL call boundary. Only a NativeCall
+                // marshalling trait (`is encoded('utf8')`) stays excluded here
+                // (interpreter-coupled string marshalling).
+                let traits_otf_safe = pd
+                    .traits
+                    .iter()
+                    .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
+                (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
             })
             && !Self::function_body_declares_state(&def.body)
             && !Self::module_otf_body_needs_interpreter(&def.body)

--- a/t/lib/TraitParamOtf.rakumod
+++ b/t/lib/TraitParamOtf.rakumod
@@ -1,0 +1,27 @@
+unit module TraitParamOtf;
+
+# Module subs with standard binding-time param traits (is copy / is rw / is raw
+# / is readonly / is required). Before the §2 gate relaxation these were forced
+# onto the interpreter fallback by `pd.traits.is_empty()` in
+# def_is_otf_compilable_module_single, even though the compiled binding path
+# already handled them (def_is_otf_compilable, the builtin-shadow gate, never
+# checked param traits). The interpreter fallback also silently dropped the
+# `is rw` caller writeback; OTF-compiling fixes it (compile-time caller slot).
+
+# is copy: a fresh writable local copy, no writeback to the caller.
+sub bump-copy($n is copy) is export { $n++; $n * 2 }
+
+# is rw: writes back to the caller's variable.
+sub set-rw($x is rw) is export { $x = 99 }
+
+# is raw: binds the argument without decontainerizing.
+sub raw-id($x is raw) is export { $x }
+
+# is readonly (explicit): same as the default binding.
+sub ro-id($x is readonly) is export { $x + 1 }
+
+# is required (redundant with positional, but exercises the trait).
+sub req-id($x is required) is export { $x * 3 }
+
+# rw with a default value (name-cache-safe for a non-builtin module sub).
+sub rw-or($x is rw, $bump = 1) is export { $x = $x + $bump }

--- a/t/module-sub-otf-trait-params.t
+++ b/t/module-sub-otf-trait-params.t
@@ -1,0 +1,47 @@
+use Test;
+use lib 't/lib';
+use TraitParamOtf;
+
+# §2 multi-dispatch VM-ization: a non-builtin module single sub with a standard
+# binding-time param trait (is copy / is rw / is raw / is readonly / is required)
+# now OTF-compiles to bytecode instead of tree-walking through
+# call_function_fallback. The compiled binding honors the trait exactly as the
+# interpreter would, and the `is rw` caller writeback (which the interpreter
+# fallback silently dropped) now reaches the caller via the compile-time caller
+# slot. These check byte-identical behavior against raku.
+
+plan 9;
+
+# 1. is copy: local mutation does not touch the caller.
+is bump-copy(5), 12, 'is copy param: local mutation, doubled';
+
+# 2-3. is rw: writes back to the caller's variable.
+my $v = 10;
+set-rw($v);
+is $v, 99, 'is rw param writes back to caller';
+
+my $w = 0;
+set-rw($w);
+is $w, 99, 'is rw param writes back again (cache hit)';
+
+# 4. is raw: binds without decontainerizing.
+is raw-id(42), 42, 'is raw param round-trips value';
+
+# 5. is readonly (explicit).
+is ro-id(7), 8, 'is readonly param';
+
+# 6. is required.
+is req-id(4), 12, 'is required param';
+
+# 7-9. is rw with a default trailing param.
+my $a = 5;
+rw-or($a);
+is $a, 6, 'is rw + default: default bump applied';
+
+my $b = 5;
+rw-or($b, 10);
+is $b, 15, 'is rw + default: explicit bump applied';
+
+my $c = 100;
+rw-or($c, 0);
+is $c, 100, 'is rw + default: zero bump';


### PR DESCRIPTION
## Summary

`def_is_otf_compilable_module_single` gated every non-builtin module single sub carrying a param trait onto the interpreter tree-walk fallback, via a blanket `pd.traits.is_empty()` check (`src/vm/vm_call_func_ops.rs`). The compiled binding path already handled these traits — the builtin-shadow gate `def_is_otf_compilable` never checked param traits, so trait-bearing builtin shadows already OTF-compiled. The exclusion was **stale**: both the doc comment and `PLAN.md` already claimed `is rw`/`is raw` were freed by the #4091 compile-time caller slot, but the code still excluded them.

This PR relaxes the gate to allow the standard binding-time param traits (`is copy` / `is rw` / `is raw` / `is readonly` / `is required`), keeping only the NativeCall marshalling trait `is encoded(...)` excluded (interpreter-coupled string marshalling).

## Bonus correctness fix

The interpreter fallback **silently dropped the `is rw` caller writeback** for module subs:

```raku
sub set-rw($x is rw) is export { $x = 99 }
my $v = 10; set-rw($v); say $v;   # raku: 99, mutsu (before): 10
```

OTF-compiling routes the writeback through the compile-time caller slot (#4091), so `$v` is now `99`, matching raku.

## Testing

- New pin `t/module-sub-otf-trait-params.t` (9 subtests, all pass on real raku; verified `interpreter_fallbacks` drops 4→0 via `MUTSU_VM_STATS`).
- `make test` PASS (1564 files).
- Locally re-ran whitelisted S06-signature / S12-coercion / S04 / S32-exceptions subsets through the fudge harness — clean (the only "failures" were debug-build parallel-load timeouts, each passing when run individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)