### PR TITLE
fix(phasers): run nested-block BEGIN before reads that precede it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutsu"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -132,33 +132,21 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 
 ### 3.1 残っている対象
 
-- `S02-names-vars/variables-and-packages.t`（32/39、7 失敗: test 29-34, 39）
-  — 残り 7 失敗が独立した深い lexical/scoping/BEGIN 問題。2026-07-02 に各グループを root-cause 精査した結果:
-  - **test 29-31（BEGIN block init）**: `{ baz(); ...; my $a; BEGIN { $a = 3 }; sub baz { $a++ } }` が
-    3,4,5 でなく **0,1,2**。`BEGIN { $a = 3 }` が compile-time に走らないため `$a` が 3 に初期化されない。
-    → BEGIN compile-time execution（declaration model 再設計・medium-large）。
-  - **test 32-34（escaped `our sub`）**: `{ my $a = 3; our sub grtz { $a++ } }; &OUR::grtz()` が
-    3,4,5 でなく **0,1** / **0,0,1**。★**block 内で呼べば 3,4 で正しい**が、block 退出後は 0。
-    根因＝`escaped_our_lexical_cells["a"]` が **0-seed** の cell を保持（0→1 と increment するので cell 自体は
-    persist されている）。`my $a=3` を実行する code frame の `needs_cell_escaping_our_sub` に "a" が入って
-    おらず（nested block/closure の **code レベルで cell 分類が別 frame に落ちている**＝`nceos` vs `nceos_free` の
-    own/free 判定、opcode.rs:2129-2147）、assignment 時 boxing の persist branch（vm_var_assign_set_local.rs:54）
-    が発火しない。hoisted RegisterSub が `my $a=3` 前に空 cell を persist し、in-place persist が cell(3) で
-    上書きできていない。★assignment 時に persist を足す fix（試行済）は branch 非発火で**無効**＝
-    `collect_escaping_our_lexical_names`（accessors_state.rs:137・`_free` を読まない）と box_decl 両方の
-    code-level 分類を直す必要。
-  - ~~**test 37-38（X::Redeclaration::Outer）**~~ — **DONE（post-parse scope walker）**。
-    `sub s($i is copy){ for ...{ @a.push($i); my $i=1 } }` が silent だった。新設
-    `src/parser/outer_redecl.rs` が「あるスコープで outer binding を **参照した後に** 同名を
-    `my`/`state` 再宣言する」場合に compile-time `X::Redeclaration::Outer` を投げる（同一スコープ
-    での参照→再宣言のときのみ発火。redecl-before-use・deeper-nested-ref・sibling-block は非発火）。
-    回帰テスト＝`t/outer-redeclaration.t`。
-  - **test 39（`$OUTER::_`）**: `for "a" { $t = sub { $OUTER::_ } }; $t()` が 'a' でなく **Nil**。
-    **2 バグ**: ①`$OUTER::x` は `GetOuterVar`→`get_outer_var`（vm_var_get_ops.rs:357）が closure の captured
-    env でなく `outer_scope_locals`（lexical block nesting 用）を見るため closure 呼び出し時に空→Nil
-    （skip-own-scope セマンティクスも要）②`for "a" { sub {$_} }` 自体が topic `$_` を capture できず `(Any)`。
-  - ★全て load-bearing な closure-capture / declaration-model に触る高リスク変更。盲目的な部分 fix は避け、
-    1 グループずつ専用セッションで攻めること。最も infra が揃うのは 32-34（`escaped_our_lexical_cells` 機構）。
+- ~~`S02-names-vars/variables-and-packages.t`~~ — **DONE・whitelist 済み（2026-07-07）**。
+  最後まで残っていた nested-block BEGIN（test 29-31: `{ is baz(),3; ...; my $a; BEGIN { $a = 3 }; sub baz { $a++ } }`
+  が 3,4,5 でなく 0,1,2）を解消。root-cause＝ネストした bare block 内の `BEGIN` が compile-time に走らず
+  source 順（reads の後）で実行されるため、BEGIN より前に textual に出る read（forward-declared sub 経由）が
+  初期化を観測できない。修正（`src/runtime/phasers.rs::reorder_at_level`）は AST 再配置で BEGIN をブロック内の
+  reads より前へ hoist するが、宣言/代入/初期化を跨がないよう厳しく gate する:
+  - `reorder_recursive`/`reorder_at_level` に `is_top` を追加。top-level は従来どおり
+    `run_toplevel_begin_phasers` に任せ、この pass では hoist しない。
+  - ネスト BEGIN は「その BEGIN より前に read（Say/Call/…）があり、かつ barrier（宣言・代入・初期化子）が
+    無い」場合のみ hoist（`first_read_idx < idx < first_barrier_idx`）。これで `class C; BEGIN {…C…}`
+    （begin.t 7）・`has $.a; BEGIN {…set_build…}`（S12 defaults）・`my $x=42; BEGIN {…}; constant c=$x`
+    （constant.t 27）の in-source 順序を壊さず、read-after BEGIN（begin-compile-time.t 11）も従来どおり
+    in-place で動く。CHECK/INIT を持つブロックは従来挙動（全 BEGIN を先頭 bucket へ）を維持。
+  回帰テスト＝`t/begin-nested-block.t`（`t/begin-compile-time.t` も回帰なし）。test 32-34（escaped `our sub`）・
+  37-38（X::Redeclaration::Outer）・39（`$OUTER::_`）は #4235/#4305 等で既に解消済みだった。
 - `S14-traits/attributes.t`（4/8、bad plan：8 planned に対し 4 で中断）
   — `Attribute.container.VAR does Role` に必要な「scalar 属性が Scalar コンテナを VAR として
   持ち、合成時に role を mixin し、それがインスタンスの per-attribute コンテナに伝播する」
@@ -212,9 +200,9 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
      意味論が乖離するため、シンボル解決や例外を起こしうる BEGIN（class 参照 / forward sub 呼び / `1/0.Int`）は
      hoist せず in-place 経路（`X::Comp::BeginTime` ラップ込み）に任せる。純粋な値代入 BEGIN のみ hoist。
   回帰テスト＝`t/begin-compile-time.t`（`t/begin-phaser-begintime.t` も回帰なし）。
-  **残る別スライス（nested-block BEGIN）**: `variables-and-packages.t` test 29-31（下記）は
-  bare block **内**の BEGIN で、この top-level 専用機構では拾えない。`[[project_begin_compile_time_timing]]`
-  の深い declaration-model 層が別途必要。
+  **nested-block BEGIN（`variables-and-packages.t` test 29-31）も DONE・whitelist 済み（2026-07-07）**：
+  bare block **内**の BEGIN を、read の後・barrier（宣言/代入/初期化）の前という条件でのみ hoist する
+  AST 再配置で解消（`reorder_at_level`、§3.1 参照）。
 
 ### 3.2 サブキャンペーンと choke point
 
@@ -226,11 +214,10 @@ element/attribute slot の書き戻しが未整備な項目が集まっている
 2. **属性 accessor を value copy ではなく slot 経由にする**
    - 変更レイヤ: attribute read/write path、instance attr storage
    - 対象: `S14-traits/attributes.t` の残り（`Attribute.container.VAR does Role`）
-3. **BEGIN/EVAL/lexical 配列変更の永続化**
-   - 変更レイヤ: env/local coherence、block escape、BEGIN 実行時 lexical carrier
-   - 対象: `S02-names-vars/variables-and-packages.t`（nested-block BEGIN, test 29-31）。
-     top-level BEGIN 版（`S26-documentation/12-non-breaking-space.t`）は DONE・whitelist 済み
-     （§3.1 参照、`run_toplevel_begin_phasers`）。残るは bare block **内**の BEGIN。
+3. **BEGIN/EVAL/lexical 配列変更の永続化** — **DONE**。
+   - top-level BEGIN 版（`S26-documentation/12-non-breaking-space.t`、`run_toplevel_begin_phasers`）・
+     nested-block BEGIN 版（`S02-names-vars/variables-and-packages.t`、`reorder_at_level`）とも
+     whitelist 済み（§3.1 参照）。
 
 コード choke point:
 

--- a/TODO_roast/S02.md
+++ b/TODO_roast/S02.md
@@ -154,25 +154,14 @@
       in CI, treat it as a real regression to bisect, not as flaky.
 - [ ] roast/S02-names-vars/signature.t
   - 0/? pass. Parse error at line 10
-- [ ] roast/S02-names-vars/variables-and-packages.t
-  - 30/39 pass (was 26/39). Fixed 24-25, 27-28: a hoisted sub that mutates a
-    `my $x` declared *after* it (called before the declaration runs) now keeps
-    its first write — the captured-outer writeback in
-    `call_compiled_function_named_inner` propagates `free_var_writes` names to
-    the restored caller env even when the name is not yet present there.
-  - Remaining 9 failures are all deep, blocked on infrastructure:
-    - 29-31 (BEGIN init): `my $a; BEGIN { $a = 3 }; sub baz { $a++ }` called
-      before the declaration must see `3` — needs compile-time BEGIN execution
-      (BLOCKERS §3.4 / declaration-model redesign).
-    - 32-34 (`&OUR::grtz`): an `our sub` defined in an inner block, accessed by
-      name after that block exits, must capture the inner `my $a = 3` — needs
-      real closure-env capture for name-resolved subs (closure-env gap, same as
-      §2-D / zef). Anonymous `sub {...}` escaping by value already works.
-    - 37-38 (`X::Redeclaration::Outer`): compile-time error when redeclaring a
-      name (`my $i`) inside a block that already referenced the outer `$i` —
-      needs scope-aware compile-time redeclaration analysis.
-    - 39 (`$OUTER::_`): a sub closing over the enclosing for-loop topic `$_`
-      via `$OUTER::_` — same closure-capture gap (topic not captured).
+- [x] roast/S02-names-vars/variables-and-packages.t
+  - 39/39 pass, whitelisted (2026-07-07). The last block (29-31, nested-block
+    BEGIN init) is fixed by hoisting a nested `BEGIN` ahead of the reads that
+    textually precede it — but only when it sits after a read and before the
+    first barrier (declaration/assignment/initializer), so `class C; BEGIN
+    {...C...}` etc. keep their in-source order. See BLOCKERS §3.1 and
+    `t/begin-nested-block.t`. Groups 32-34/37-38/39 were resolved earlier
+    (#4235/#4305 and closure-capture work).
 - [ ] roast/S02-names-vars/varnames.t
   - 0/? pass. Parse error at line 34
 - [x] roast/S02-one-pass-parsing/less-than.t

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,37 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-07: nested-block `BEGIN` を compile-time 相当に hoist（`S02-names-vars/variables-and-packages.t` whitelist）
+
+bare block **内**の `BEGIN` も、Raku ではコンパイル時に走るため、ブロック内でソース順に BEGIN より
+**前**にある read（forward-declared sub 経由など）がその副作用を観測する。例：
+
+```raku
+{
+    is baz(), 3, ...;   # 3,4,5 を期待（raku）
+    is baz(), 4, ...;
+    is baz(), 5, ...;
+    my $a; BEGIN { $a = 3 };
+    sub baz { $a++ }
+}
+```
+
+mutsu は nested BEGIN を source 位置で inline 実行していたため、`baz()` が `$a` 初期化前に呼ばれ 0,1,2 に
+なっていた。修正（`src/runtime/phasers.rs::reorder_at_level`）は phaser 再配置 pass に `is_top` を通し、
+ネストブロックでのみ BEGIN をブロック内の read より前へ hoist する。ただし宣言/代入/初期化を跨がないよう
+厳格に gate する:
+
+- top-level BEGIN は従来どおり `run_toplevel_begin_phasers` に委ね、この pass では hoist しない（`is_top`）。
+- ネスト BEGIN は「その BEGIN より前に read（`Say`/`Call`/…）があり、かつ barrier（宣言・代入・変数初期化子）が
+  無い」場合のみ hoist（`first_read_idx < idx < first_barrier_idx`）。これにより
+  `class C; BEGIN {…C…}`（`S04-phasers/begin.t` test 7）・`has $.a; BEGIN {…set_build…}`（`S12-attributes/defaults.t`）・
+  `my $x=42; BEGIN {…}; constant c=$x`（`S04-declarations/constant.t` test 27）の in-source 順序を壊さず、
+  read-after BEGIN（`t/begin-compile-time.t` test 11）も従来どおり in-place で動く。
+- CHECK/INIT を含むブロックは従来挙動（全 BEGIN を先頭 bucket へ hoist）を維持。
+
+これで `variables-and-packages.t` が 39/39 になり whitelist 済み（残っていた test 29-31 を解消。32-34/37-38/39 は
+#4235/#4305 等で既に解消済みだった）。回帰テスト＝`t/begin-nested-block.t`。
+
 ## 2026-07-06: top-level `BEGIN` を compile-time 実行（`S26-documentation/12-non-breaking-space.t` whitelist）
 
 Raku の `BEGIN { ... }` はコンパイル時に走るため、ソース順で BEGIN より**前**にある read が

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -102,6 +102,7 @@ roast/S02-names-vars/fmt.t
 roast/S02-names-vars/list_array_perl.t
 roast/S02-names-vars/perl.t
 roast/S02-names-vars/signature.t
+roast/S02-names-vars/variables-and-packages.t
 roast/S02-names-vars/varnames.t
 roast/S02-names/SETTING-6e.t
 roast/S02-names/bare-sigil.t

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -25,7 +25,7 @@ fn next_temp_name() -> String {
 /// - INIT/CHECK PhaserExpr (rvalue) inside closures are extracted to the
 ///   enclosing scope so they run once, not per-call.
 pub(crate) fn reorder_phasers(stmts: &mut Vec<Stmt>) {
-    reorder_recursive(stmts);
+    reorder_recursive(stmts, true);
 }
 
 /// EVAL-specific phaser reordering.  In addition to the standard
@@ -38,7 +38,7 @@ pub(crate) fn reorder_phasers(stmts: &mut Vec<Stmt>) {
 /// declared subs from a parent scope (the EVAL scope is already the
 /// outermost scope), so lifting BEGIN from them is safe.
 pub(crate) fn reorder_phasers_for_eval(stmts: &mut Vec<Stmt>) {
-    reorder_recursive(stmts);
+    reorder_recursive(stmts, true);
     // Second pass: lift BEGIN from closure bodies to the top level.
     let mut extra_begin: Vec<Stmt> = Vec::new();
     for stmt in stmts.iter_mut() {
@@ -67,7 +67,7 @@ pub(crate) fn reorder_phasers_for_eval(stmts: &mut Vec<Stmt>) {
             stmts.insert(insert_pos + i, s);
         }
         // Re-run reorder to properly sort the newly inserted phasers
-        reorder_recursive(stmts);
+        reorder_recursive(stmts, true);
     }
 }
 
@@ -98,7 +98,7 @@ fn lift_begin_from_eval_expr(expr: &mut Expr, begin: &mut Vec<Stmt>) {
     }
 }
 
-fn reorder_recursive(stmts: &mut Vec<Stmt>) {
+fn reorder_recursive(stmts: &mut Vec<Stmt>, is_top: bool) {
     // Flatten SyntheticBlocks so VarDecls get hoisted properly.
     flatten_synthetic_blocks(stmts);
 
@@ -114,7 +114,7 @@ fn reorder_recursive(stmts: &mut Vec<Stmt>) {
     );
 
     // Per-block reordering at this level.
-    reorder_at_level(stmts, lifted_begin, lifted_check, lifted_init);
+    reorder_at_level(stmts, lifted_begin, lifted_check, lifted_init, is_top);
 
     // Recurse into child statements.
     for stmt in stmts.iter_mut() {
@@ -672,6 +672,7 @@ fn reorder_at_level(
     extra_begin: Vec<Stmt>,
     extra_check: Vec<Stmt>,
     extra_init: Vec<Stmt>,
+    is_top: bool,
 ) {
     let mut var_decls: Vec<Stmt> = Vec::new();
     let mut use_stmts: Vec<Stmt> = Vec::new();
@@ -680,7 +681,18 @@ fn reorder_at_level(
     let mut init: Vec<Vec<Stmt>> = Vec::new();
     let mut rest: Vec<Stmt> = Vec::new();
 
-    let has_phasers = stmts.iter().any(|s| {
+    // A statement-level BEGIN phaser in a *nested* block must also trigger
+    // reordering so the BEGIN is hoisted ahead of the block's plain code — its
+    // side effects have to be visible to reads that textually precede it (Raku
+    // runs BEGIN at compile time). Top-level BEGINs are handled separately by
+    // `run_toplevel_begin_phasers` before this pass, so a bare top-level BEGIN
+    // is deliberately left in place here (it either already ran at compile time
+    // or is non-hoistable and must run at its original source position).
+    //
+    // These are the phaser conditions that already triggered reordering before
+    // nested-BEGIN hoisting was added; when any hold, BEGINs keep their old
+    // behavior (all hoisted into the `begin` bucket, ahead of CHECK/INIT).
+    let has_other_phasers = stmts.iter().any(|s| {
         matches!(
             s,
             Stmt::Phaser {
@@ -693,11 +705,36 @@ fn reorder_at_level(
         || !extra_init.is_empty()
         || stmts.iter().any(stmt_has_phaser_expr);
 
-    if !has_phasers {
+    // A nested BEGIN is hoisted only to make its compile-time side effects
+    // visible to a *read that textually precedes it* — Raku runs BEGIN at
+    // compile time. It must NOT be hoisted above a declaration, assignment, or
+    // variable initializer it might depend on (those share the source/compile
+    // ordering, e.g. `class Foo; BEGIN {...Foo...}`, `has $.a; BEGIN
+    // {...set_build...}`, `my $x = 42; BEGIN {...}; constant c = $x`), and there
+    // is no point hoisting when every read already follows it (a read-after
+    // BEGIN works in place). `first_barrier_idx` is the first such non-hoistable
+    // statement; `first_read_idx` is the first read. A BEGIN hoists iff it sits
+    // after a read and before the first barrier. Top-level BEGINs are handled
+    // separately by `run_toplevel_begin_phasers` and left in place here. Other
+    // phasers (CHECK/INIT) are never barriers — BEGINs always run before them.
+    let first_barrier_idx = stmts
+        .iter()
+        .position(|s| !stmt_is_hoist_safe(s) && !matches!(s, Stmt::Phaser { .. }))
+        .unwrap_or(usize::MAX);
+    let first_read_idx = stmts.iter().position(is_read_stmt).unwrap_or(usize::MAX);
+    let nested_begin_hoistable = |idx: usize| first_read_idx < idx && idx < first_barrier_idx;
+    let has_nested_begin = !is_top
+        && !has_other_phasers
+        && stmts
+            .iter()
+            .enumerate()
+            .any(|(i, s)| is_begin_phaser(s) && nested_begin_hoistable(i));
+
+    if !has_other_phasers && !has_nested_begin {
         return;
     }
 
-    for stmt in stmts.drain(..) {
+    for (idx, stmt) in stmts.drain(..).enumerate() {
         if let Stmt::Phaser { kind, body } = &stmt {
             match kind {
                 PhaserKind::Begin => {
@@ -706,8 +743,16 @@ fn reorder_at_level(
                     // slot allocation for array/hash container assignments.
                     // They are placed in a separate bucket so they run before
                     // CHECK blocks (BEGIN runs first in forward order, then
-                    // CHECK runs in reverse order).
-                    begin.push(stmt);
+                    // CHECK runs in reverse order). With CHECK/INIT present (or
+                    // at top level) all BEGINs hoist as before; a bare-BEGIN
+                    // nested block only hoists a BEGIN that sits after a read and
+                    // before the first barrier, leaving the rest in place.
+                    let hoist = is_top || has_other_phasers || nested_begin_hoistable(idx);
+                    if hoist {
+                        begin.push(stmt);
+                    } else {
+                        rest.push(stmt);
+                    }
                     continue;
                 }
                 PhaserKind::Check => {
@@ -801,6 +846,64 @@ fn reorder_at_level(
     stmts.extend(rest);
 }
 
+/// True if `stmt` is a statement-level `BEGIN` phaser.
+fn is_begin_phaser(stmt: &Stmt) -> bool {
+    matches!(
+        stmt,
+        Stmt::Phaser {
+            kind: PhaserKind::Begin,
+            ..
+        }
+    )
+}
+
+/// True if `stmt` is a "read": a statement that observes program state and
+/// would miss a later BEGIN's compile-time side effects if the BEGIN ran after
+/// it. Used to decide whether hoisting a nested BEGIN above it is worthwhile.
+fn is_read_stmt(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => true,
+        Stmt::Call { .. } => true,
+        Stmt::Expr(e) => !matches!(e, Expr::AssignExpr { .. }),
+        _ => false,
+    }
+}
+
+/// True if a nested `BEGIN` phaser may be hoisted above `stmt`. Only pure reads
+/// and bare (uninitialized) declarations qualify: a BEGIN runs at compile time
+/// and its effects should be visible to such reads that textually precede it.
+/// Anything that declares a compile-time entity (`class`/`sub`/`has`/...),
+/// assigns, or initializes a variable is a *barrier* — those are part of the
+/// same source/compile-time ordering the BEGIN must not jump over.
+fn stmt_is_hoist_safe(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => true,
+        // A bare routine call (including test-function listops like `is`/`ok`)
+        // is a runtime read the BEGIN may run before.
+        Stmt::Call { .. } => true,
+        Stmt::SetLine(_) => true,
+        Stmt::Use { .. } => true,
+        // A bare declaration (no initializer) creates a container but performs
+        // no runtime work, so a BEGIN may safely run before it.
+        Stmt::VarDecl { expr, .. } => is_empty_vardecl_init(expr),
+        // A plain expression statement is a read unless it is an assignment.
+        Stmt::Expr(e) => !matches!(e, Expr::AssignExpr { .. }),
+        _ => false,
+    }
+}
+
+/// True if a `VarDecl` initializer is the synthesized empty/absent default
+/// (`my $x;` / `my @a;` / `my %h;`), i.e. the declaration has no real init.
+fn is_empty_vardecl_init(expr: &Expr) -> bool {
+    use crate::value::ValueView;
+    match expr {
+        Expr::Literal(v) if v.is_nil() => true,
+        Expr::Literal(v) => matches!(v.view(), ValueView::Array(items, _) if items.is_empty()),
+        Expr::Hash(items) => items.is_empty(),
+        _ => false,
+    }
+}
+
 /// True if a statement declares a variable, either directly (`VarDecl`) or
 /// nested inside a `SyntheticBlock` (as produced by `will <phaser>` traits).
 fn stmt_declares_var(stmt: &Stmt) -> bool {
@@ -838,10 +941,10 @@ fn recurse_into_stmt(stmt: &mut Stmt) {
         | Stmt::RoleDecl { body, .. }
         | Stmt::Subtest { body, .. }
         | Stmt::Package { body, .. } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::Phaser { body, .. } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::If {
             cond,
@@ -850,27 +953,27 @@ fn recurse_into_stmt(stmt: &mut Stmt) {
             ..
         } => {
             recurse_into_expr(cond);
-            reorder_recursive(then_branch);
-            reorder_recursive(else_branch);
+            reorder_recursive(then_branch, false);
+            reorder_recursive(else_branch, false);
         }
         Stmt::While { cond, body, .. } | Stmt::When { cond, body } => {
             recurse_into_expr(cond);
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::For { iterable, body, .. } => {
             recurse_into_expr(iterable);
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::Loop { body, .. } | Stmt::React { body } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::Given { topic, body } => {
             recurse_into_expr(topic);
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::Whenever { supply, body, .. } => {
             recurse_into_expr(supply);
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
             recurse_into_expr(e);
@@ -881,7 +984,7 @@ fn recurse_into_stmt(stmt: &mut Stmt) {
         Stmt::SubDecl { body, .. }
         | Stmt::MethodDecl { body, .. }
         | Stmt::ProtoDecl { body, .. } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Stmt::Label { stmt: inner, .. } => {
             recurse_into_stmt(inner);
@@ -897,15 +1000,15 @@ fn recurse_into_expr(expr: &mut Expr) {
         | Expr::AnonSubParams { body: stmts, .. }
         | Expr::Gather(stmts)
         | Expr::DoBlock { body: stmts, .. } => {
-            reorder_recursive(stmts);
+            reorder_recursive(stmts, false);
         }
         Expr::Lambda { body, .. } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         Expr::Try { body, catch } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
             if let Some(c) = catch {
-                reorder_recursive(c);
+                reorder_recursive(c, false);
             }
         }
         Expr::Binary { left, right, .. }
@@ -938,7 +1041,7 @@ fn recurse_into_expr(expr: &mut Expr) {
             recurse_into_expr(else_expr);
         }
         Expr::PhaserExpr { body, .. } => {
-            reorder_recursive(body);
+            reorder_recursive(body, false);
         }
         _ => {}
     }

--- a/t/begin-nested-block.t
+++ b/t/begin-nested-block.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 5;
+
+# A BEGIN inside a nested (bare) block runs at compile time, so its side
+# effects are visible to reads (via a closure) that textually precede it.
+{
+    is baz(), 3, 'nested BEGIN init visible to earlier read (1)';
+    is baz(), 4, 'nested BEGIN init visible to earlier read (2)';
+    is baz(), 5, 'nested BEGIN init visible to earlier read (3)';
+
+    my $a; BEGIN { $a = 3 };
+    sub baz { $a++ }
+}
+
+# A declaration that precedes a BEGIN it depends on must stay before it: the
+# BEGIN must not be hoisted above the class it references.
+{
+    class SomeClass { };
+    my $var;
+    BEGIN { $var = SomeClass };
+    isa-ok $var, SomeClass, 'declaration before BEGIN is kept before it';
+}
+
+# A runtime initializer before a BEGIN is a barrier: the BEGIN stays in place
+# so a later constant sees the BEGIN-updated value.
+{
+    my $foo = 42;
+    BEGIN { $foo = 23 }
+    constant timecheck = $foo;
+    is timecheck, 23, 'constant initializer sees BEGIN-updated value';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## What

A `BEGIN { ... }` inside a bare **nested** block runs at compile time in Raku, so reads that textually precede it — e.g. via a forward-declared sub closing over the BEGIN-initialized variable — must observe its side effects:

```raku
{
    is baz(), 3, ...;   # want 3,4,5
    is baz(), 4, ...;
    is baz(), 5, ...;
    my $a; BEGIN { $a = 3 };
    sub baz { $a++ }
}
```

mutsu compiled the nested `BEGIN` inline at its source position, so `baz()` ran before `$a` was initialized and returned `0,1,2` instead of `3,4,5` (the last open failures, test 29-31, of `S02-names-vars/variables-and-packages.t`).

## How

Thread `is_top` through the phaser-reorder pass (`src/runtime/phasers.rs`) and, for **nested** blocks only, hoist a statement-level `BEGIN` ahead of the block's reads — but only when it sits **after a read** and **before the first barrier** (a declaration, assignment, or variable initializer). This narrow gate keeps the in-source ordering intact for constructs the BEGIN legitimately depends on:

- `class C; BEGIN {...C...}` — `S04-phasers/begin.t` test 7
- `has $.a; BEGIN {...set_build...}` — `S12-attributes/defaults.t`
- `my $x = 42; BEGIN {...}; constant c = $x` — `S04-declarations/constant.t` test 27
- read-after-BEGIN stays in place — `t/begin-compile-time.t` test 11

Top-level BEGINs remain handled by `run_toplevel_begin_phasers`; blocks with CHECK/INIT keep their existing behavior (all BEGINs hoisted ahead of CHECK).

## Result

- Whitelists `roast/S02-names-vars/variables-and-packages.t` (39/39).
- Regression test: `t/begin-nested-block.t`.
- `make test` green; whitelisted phaser-using roast suite (46 files) + S02/S04 whitelist (80 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)