### PR TITLE
fix(state): share a module sub's state cell across threads via a captured compiled body

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1554,6 +1554,17 @@ pub struct Interpreter {
     pub(crate) pending_caller_var_writeback: Vec<String>,
     pub(crate) local_bind_pairs: Vec<(usize, usize)>,
     pub(crate) otf_compile_cache: HashMap<u64, CompiledFunction>,
+    /// Compiled bodies of subs defined in `use`d modules, captured at module-load
+    /// time and keyed by the sub's body/signature fingerprint. Unlike the per-call
+    /// `otf_compile_cache` (which a worker thread starts *empty* — every thread
+    /// re-OTF-compiles a module sub into a *distinct* body, giving distinct `state`
+    /// cells), this map is a snapshot shared by value into every spawned thread's
+    /// clone. A module sub routed through the same captured body across threads
+    /// reaches its `state` variable under a stable cross-thread key, so
+    /// `await (^N).map: { start f() }` accumulates into one shared cell — the piece
+    /// the per-thread OTF path could not provide. Populated by `load_module`; read
+    /// via `imported_state_body_for_def`. Empty for programs that `use` nothing.
+    pub(crate) imported_compiled_fns: HashMap<u64, std::sync::Arc<CompiledFunction>>,
     pub(crate) state_scope_id: Option<u64>,
     #[allow(clippy::type_complexity)]
     pub(crate) fn_resolve_cache: HashMap<(Symbol, usize, Vec<String>), (String, u64, String)>,

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -419,6 +419,12 @@ impl Interpreter {
             };
             let before_function_keys: std::collections::HashSet<crate::symbol::Symbol> =
                 self.registry().functions.keys().copied().collect();
+            // Capture the module's compiled sub bodies (keyed by fingerprint) so a
+            // caller can dispatch a `state`-bearing module sub through one shared
+            // body across threads instead of re-OTF-compiling it per thread (which
+            // severs the shared `state` cell). Compiled under GLOBAL, matching the
+            // package the module body runs under here.
+            self.capture_module_compiled_fns(&stmts);
             let result = self.run_block(&stmts);
             if pushed_unit {
                 self.unit_module_loading_stack.pop();
@@ -439,5 +445,46 @@ impl Interpreter {
         crate::parser::set_current_language_version(&saved_language_version);
         self.current_distribution = saved_distribution;
         Ok(())
+    }
+
+    /// Compile a module's statements and record each resulting compiled sub body
+    /// into `imported_compiled_fns`, keyed by its body/signature fingerprint. A
+    /// caller resolving one of these subs (via the registry `FunctionDef`, which
+    /// carries the same fingerprint) can then run the *shared* captured body
+    /// instead of OTF-recompiling it — the key to cross-thread `state` sharing for
+    /// module subs (see `imported_compiled_fns`). Pure compilation: runs no user
+    /// code and touches no `env`. Compiles under the current package (GLOBAL, set
+    /// by the caller) so the bodies match the module's own execution.
+    ///
+    /// The shared body is only *consulted* for a `state`-declaring module sub
+    /// (`imported_state_body_for_def`), so a module with no such sub gains nothing
+    /// from capture. Skip the whole (double-)compile in that common case — the vast
+    /// majority of modules declare no `state` sub, and the scan is a cheap AST walk.
+    fn capture_module_compiled_fns(&mut self, stmts: &[crate::ast::Stmt]) {
+        if !Self::module_has_state_sub(stmts) {
+            return;
+        }
+        let (_code, compiled_fns) = self.compile_block_raw(stmts);
+        for cf in compiled_fns.into_values() {
+            self.imported_compiled_fns
+                .entry(cf.fingerprint)
+                .or_insert_with(|| std::sync::Arc::new(cf));
+        }
+    }
+
+    /// True if `stmts` declares at least one `sub`/`proto`/`multi` whose body
+    /// declares a `state` variable (recursing through nested package blocks). Used
+    /// to skip the shared-body capture compile for modules that cannot benefit.
+    fn module_has_state_sub(stmts: &[crate::ast::Stmt]) -> bool {
+        use crate::ast::Stmt;
+        stmts.iter().any(|stmt| match stmt {
+            Stmt::SubDecl { body, .. } | Stmt::ProtoDecl { body, .. } => {
+                crate::runtime::Interpreter::function_body_declares_state(body)
+            }
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
+                Self::module_has_state_sub(body)
+            }
+            _ => false,
+        })
     }
 }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2140,6 +2140,7 @@ impl Interpreter {
             pending_caller_var_writeback: Vec::new(),
             local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),
+            imported_compiled_fns: HashMap::new(),
             state_scope_id: None,
             fn_resolve_cache: HashMap::new(),
             fn_resolve_gen: 0,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -337,6 +337,10 @@ impl Interpreter {
             pending_caller_var_writeback: Vec::new(),
             local_bind_pairs: Vec::new(),
             otf_compile_cache: HashMap::new(),
+            // Share the parent's captured module-sub bodies by value so a `start`
+            // block that calls a module sub with `state` reaches the same compiled
+            // body (and thus the same cross-thread `state` cell) the parent used.
+            imported_compiled_fns: self.imported_compiled_fns.clone(),
             state_scope_id: None,
             fn_resolve_cache: HashMap::new(),
             fn_resolve_gen: 0,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -61,6 +61,13 @@ impl Interpreter {
         if !self.is_interpreter_handled_function(name)
             && let Some(def) = loan_env!(self, resolve_function_with_types(name, &args))
         {
+            // Prefer the cross-thread shared captured body for a `state`-bearing
+            // module sub so its `state` cell stays shared across threads (the
+            // per-call OTF recompile below gives each thread a distinct cell).
+            if let Some(shared) = self.imported_state_body_for_def(&def) {
+                let pkg = self.current_package().to_string();
+                return self.call_shared_state_body(&shared, args, compiled_fns, &pkg, name);
+            }
             return self.compile_and_call_function_def(&def, args, compiled_fns);
         }
         // Dispatch Test functions straight to their typed handler (lever A).

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -757,7 +757,20 @@ impl Interpreter {
             if !self.has_proto(&name)
                 && !self.has_multi_candidates_cached(&name)
                 && let Some(def) = loan_env!(self, resolve_function_with_types(&name, &args))
-                && if crate::runtime::Interpreter::is_builtin_function(&name) {
+            {
+                let is_builtin = crate::runtime::Interpreter::is_builtin_function(&name);
+                if !is_builtin && let Some(shared) = self.imported_state_body_for_def(&def) {
+                    // Cross-thread shared captured body for a `state`-bearing module
+                    // sub (compiled_fns expansion) — keeps its `state` cell shared
+                    // across threads, unlike the per-call OTF recompile below.
+                    let pkg = self.current_package().to_string();
+                    let result =
+                        self.call_shared_state_body(&shared, args, compiled_fns, &pkg, &name)?;
+                    let result = loan_env!(self, maybe_fetch_rw_proxy(result, !shared.is_raw))?;
+                    self.stack.push(result);
+                    return Ok(());
+                }
+                let gate_ok = if is_builtin {
                     // Genuine builtin shadow: strict gate (no default param —
                     // name-cache pollution hazard, PR #3546).
                     Self::def_is_otf_compilable(&def)
@@ -766,16 +779,17 @@ impl Interpreter {
                     // name-cache-safe here (no builtin to mis-bind); interpreter-
                     // coupled bodies/signatures stay excluded.
                     Self::def_is_otf_compilable_module_single(&def)
+                };
+                if gate_ok {
+                    let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
+                    self.stack.push(result);
+                    return Ok(());
                 }
-            {
-                let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
-                self.stack.push(result);
-            } else {
-                crate::vm::vm_stats::record_function_fallback(&name);
-                let result = self.vm_call_function_fallback(&name, &args)?;
-                let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
-                self.stack.push(result);
             }
+            crate::vm::vm_stats::record_function_fallback(&name);
+            let result = self.vm_call_function_fallback(&name, &args)?;
+            let result = loan_env!(self, maybe_fetch_rw_proxy(result, true))?;
+            self.stack.push(result);
         } else if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
             self.stack.push(native_result?);
         } else if let Some(callable) = self.lexical_amp_var_callable(Some(code), &name) {
@@ -1166,7 +1180,25 @@ impl Interpreter {
                     if !self.has_proto(name)
                         && !self.has_multi_candidates_cached(name)
                         && let Some(def) = loan_env!(self, resolve_function_with_types(name, &args))
-                        && if crate::runtime::Interpreter::is_builtin_function(name) {
+                    {
+                        let is_builtin = crate::runtime::Interpreter::is_builtin_function(name);
+                        // Prefer the cross-thread shared captured body for a
+                        // `state`-bearing module sub (compiled_fns expansion): one
+                        // shared body across threads keeps its `state` cell shared,
+                        // which the per-call OTF recompile below cannot.
+                        if !is_builtin && let Some(shared) = self.imported_state_body_for_def(&def)
+                        {
+                            let pkg = self.current_package().to_string();
+                            let result = self.call_shared_state_body(
+                                &shared,
+                                args,
+                                compiled_fns,
+                                &pkg,
+                                name,
+                            )?;
+                            return loan_env!(self, maybe_fetch_rw_proxy(result, !shared.is_raw));
+                        }
+                        let gate_ok = if is_builtin {
                             // Genuine builtin shadow: strict gate (no default —
                             // name-cache pollution hazard, PR #3546).
                             Self::def_is_otf_compilable(&def)
@@ -1175,17 +1207,17 @@ impl Interpreter {
                             // name-cache-safe here (no builtin to mis-bind), but
                             // interpreter-coupled bodies/signatures stay excluded.
                             Self::def_is_otf_compilable_module_single(&def)
+                        };
+                        if gate_ok {
+                            return self.compile_and_call_function_def(&def, args, compiled_fns);
                         }
-                    {
-                        self.compile_and_call_function_def(&def, args, compiled_fns)
-                    } else {
-                        crate::vm::vm_stats::record_function_fallback(name);
-                        self.set_pending_call_arg_sources(arg_sources);
-                        let result = self.vm_call_function_fallback(name, &args);
-                        self.set_pending_call_arg_sources(None);
-                        let result = result?;
-                        loan_env!(self, maybe_fetch_rw_proxy(result, true))
                     }
+                    crate::vm::vm_stats::record_function_fallback(name);
+                    self.set_pending_call_arg_sources(arg_sources);
+                    let result = self.vm_call_function_fallback(name, &args);
+                    self.set_pending_call_arg_sources(None);
+                    let result = result?;
+                    loan_env!(self, maybe_fetch_rw_proxy(result, true))
                 } else if let Some(native_result) =
                     self.try_native_function(Symbol::intern(name), &args)
                 {
@@ -1734,6 +1766,74 @@ impl Interpreter {
     /// test-assertion line context, so an assertion failing inside an OTF-compiled
     /// helper reports the same caller line the interpreter path would (whatever
     /// the parser stamped on the call's caller-line marker).
+    /// The signature/body gates a module single sub must pass to be run as
+    /// compiled bytecode, EXCLUDING the `state` check. Factored out of
+    /// `def_is_otf_compilable_module_single` so the shared-captured-body path
+    /// (`imported_state_body_for_def`) can admit a `state`-bearing module sub —
+    /// which the per-call OTF path excludes (a per-thread recompile severs the
+    /// shared `state` cell), but which the cross-thread shared captured body
+    /// handles correctly.
+    fn def_module_single_sig_body_ok_ignoring_state(def: &crate::ast::FunctionDef) -> bool {
+        def.return_type.as_ref().is_none_or(|rt| !rt.contains('('))
+            && def.param_defs.iter().all(|pd| {
+                let is_capture = pd.slurpy && pd.sigilless;
+                let traits_otf_safe = pd
+                    .traits
+                    .iter()
+                    .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
+                (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
+            })
+            && !Self::module_otf_body_needs_interpreter(&def.body)
+    }
+
+    /// Return the shared captured body for a resolved module sub def IF routing it
+    /// through that body (instead of a per-call OTF recompile) is both safe and
+    /// beneficial. Currently narrowed to `state`-declaring module subs: the shared
+    /// body — snapshotted into every thread's clone — lets `await (^N).map: { start
+    /// f() }` accumulate `f`'s `state` into one cross-thread cell (the per-thread
+    /// OTF path gives each thread its own body and its own cell). Non-`state` subs
+    /// keep their existing OTF/tree-walk routing unchanged (zero blast radius). The
+    /// body must already be captured (`imported_compiled_fns`) and must clear the
+    /// same signature/body gate the OTF path requires (minus the `state` exclusion).
+    pub(super) fn imported_state_body_for_def(
+        &self,
+        def: &crate::ast::FunctionDef,
+    ) -> Option<std::sync::Arc<CompiledFunction>> {
+        if self.imported_compiled_fns.is_empty()
+            || !Self::function_body_declares_state(&def.body)
+            || !Self::def_module_single_sig_body_ok_ignoring_state(def)
+        {
+            return None;
+        }
+        let fp = crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
+        self.imported_compiled_fns.get(&fp).cloned()
+    }
+
+    /// Invoke a shared captured module-sub body (`imported_state_body_for_def`)
+    /// with `state_scope_id` reset to `None` for the duration of the body. A named
+    /// routine's `state` is scoped to the *routine* (one cell keyed by the body's
+    /// compiled position), NOT to any enclosing closure instance. When such a sub
+    /// is called from inside a `start { … }` block, the ambient `state_scope_id`
+    /// is the enclosing closure's id; letting it leak into the body would append a
+    /// per-closure `#c<id>` suffix to the `state` key that `normalize_state_key`
+    /// does not strip, giving each thread (and the parent) a *distinct* cross-thread
+    /// cell — the exact reason `await (^N).map: { start f() }` failed to accumulate.
+    /// Resetting to `None` makes every caller reach the same normalized key, so the
+    /// shared cell accumulates (matching how a same-unit compiled `sub` is called).
+    pub(super) fn call_shared_state_body(
+        &mut self,
+        shared: &CompiledFunction,
+        args: Vec<Value>,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+        pkg: &str,
+        name: &str,
+    ) -> Result<Value, RuntimeError> {
+        let saved_scope = self.state_scope_id.take();
+        let result = self.call_compiled_function_named(shared, args, compiled_fns, pkg, name);
+        self.state_scope_id = saved_scope;
+        result
+    }
+
     pub(super) fn def_is_otf_compilable_module_single(def: &crate::ast::FunctionDef) -> bool {
         // §2 (multi-dispatch VM-ization): `is rw`/`is raw` no longer force the
         // interpreter fallback. The non-module gate (`def_is_otf_compilable`) already
@@ -1752,33 +1852,22 @@ impl Interpreter {
         // module-private sibling) OTF-compile (PR closure-env #3899/#3902
         // made module-level lexical + private-sibling reads work under OTF;
         // the chmod-IntStr allomorph fix unblocked S32-io/chdir.t).
-        def.return_type.as_ref().is_none_or(|rt| !rt.contains('('))
-            && def.param_defs.iter().all(|pd| {
-                // A capture parameter (`|c` / `|c($a, $b)`) is sigilless + slurpy and
-                // binds the argument list read-only (its sub-signature only
-                // destructures that capture), so it does NOT alias-write back to the
-                // caller the way a sigilless *scalar* (`\x`) does — it OTF-compiles
-                // exactly as it does at top level. A sigilless scalar and a
-                // non-capture sub-signature stay excluded (caller-alias writeback
-                // across an EVAL boundary — see the doc comment above).
-                let is_capture = pd.slurpy && pd.sigilless;
-                // Standard binding-time param traits (`is copy`/`is rw`/`is raw`/
-                // `is readonly`/`is required`) are OTF-safe: the compiled binding
-                // path already honors them for builtin-shadow subs (the non-module
-                // gate `def_is_otf_compilable` never checked `traits`), and the
-                // rw/raw caller writeback carries a compile-time caller slot (#4091)
-                // that refreshes the caller variable identically to the interpreter,
-                // including across an EVAL call boundary. Only a NativeCall
-                // marshalling trait (`is encoded('utf8')`) stays excluded here
-                // (interpreter-coupled string marshalling).
-                let traits_otf_safe = pd
-                    .traits
-                    .iter()
-                    .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
-                (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
-            })
+        // Signature/body gates (shared with the cross-thread shared-body path):
+        //   - a *coercion* return (`--> Foo:D()`, the parens) drives extra
+        //     return-time COERCE dispatch the standalone OTF compile does not
+        //     reproduce identically (roast/S12-coercion/coercion-return.t);
+        //   - a capture parameter (`|c`) binds read-only and is fine, but a
+        //     sigilless *scalar* (`\x`) / non-capture sub-signature stays excluded
+        //     (caller-alias writeback across an EVAL boundary — see the doc above);
+        //   - standard binding-time traits (`is copy`/`is rw`/`is raw`/`is
+        //     readonly`/`is required`) are OTF-safe (compiled binding honors them,
+        //     rw/raw writeback carries the #4091 caller slot); only NativeCall
+        //     marshalling (`is encoded('utf8')`) stays excluded.
+        // Plus the `state` exclusion: a per-call OTF recompile would sever a
+        // module sub's shared `state` cell (the cross-thread shared captured body,
+        // `imported_state_body_for_def`, is the path that admits `state`).
+        Self::def_module_single_sig_body_ok_ignoring_state(def)
             && !Self::function_body_declares_state(&def.body)
-            && !Self::module_otf_body_needs_interpreter(&def.body)
     }
 
     /// Recursively detect interpreter-coupled statements/expressions in a module
@@ -1853,7 +1942,7 @@ impl Interpreter {
 
     /// True if the body declares a `state` variable anywhere (recursing through
     /// nested blocks).
-    pub(super) fn function_body_declares_state(body: &[crate::ast::Stmt]) -> bool {
+    pub(crate) fn function_body_declares_state(body: &[crate::ast::Stmt]) -> bool {
         body.iter().any(Self::stmt_declares_state)
     }
 

--- a/t/lib/ModuleStateSub.rakumod
+++ b/t/lib/ModuleStateSub.rakumod
@@ -1,0 +1,23 @@
+unit module ModuleStateSub;
+
+# A module sub with a scalar `state` variable. Callers dispatch it through the
+# captured shared body (compiled_fns expansion) so its `state` cell is shared
+# across `start` threads instead of each thread re-OTF-compiling a distinct body
+# with its own cell.
+our sub bump() is export {
+    state $n = 0;
+    $n++;
+}
+
+# Pre-increment variant returning the new value.
+our sub tick() is export {
+    state $c = 0;
+    return ++$c;
+}
+
+# A module sub with an aggregate `state`.
+our sub collect($x) is export {
+    state @seen;
+    @seen.push($x);
+    return @seen.elems;
+}

--- a/t/module-state-sub-shared-cell.t
+++ b/t/module-state-sub-shared-cell.t
@@ -1,0 +1,25 @@
+use lib 't/lib';
+use Test;
+use ModuleStateSub;
+
+plan 6;
+
+# Sequential calls accumulate the module sub's `state` (routine-scoped cell).
+is tick(), 1, 'module sub state: first sequential call';
+is tick(), 2, 'module sub state: second sequential call';
+is tick(), 3, 'module sub state: third sequential call';
+
+# A module sub's `state` cell is SHARED across `start` threads: 100 concurrent
+# increments accumulate into one cell, so the post-await call observes 100.
+# Before the compiled_fns expansion each worker re-OTF-compiled a distinct body
+# with its own cell, so this returned 0/1 instead of 100.
+await (^100).map: { start bump() };
+is bump(), 100, 'module sub scalar state accumulates across start threads';
+
+# Aggregate `state` (a `state @`) shares its cell across threads too.
+await (^50).map: -> $i { start collect($i) };
+is collect(999), 51, 'module sub aggregate state accumulates across start threads';
+
+# The shared body still behaves correctly for a plain single-threaded call after
+# concurrency has run.
+is tick(), 4, 'module sub state continues sequentially after threaded use';


### PR DESCRIPTION
## Summary

First slice of the **compiled_fns expansion** (PLAN §3, \"本筋は \`compiled_fns\` の拡充\"): give module subs a genuine *shared* compiled body instead of a per-call/per-thread OTF recompile.

### The bug

A module sub with a `state` variable dispatched from `start { … }` blocks did not accumulate:

```raku
# ModuleStateSub.rakumod:  our sub bump() is export { state $n = 0; $n++ }
use ModuleStateSub;
await (^100).map: { start bump() };
say bump();   # raku: 100 — mutsu (before): 0
```

Each worker thread starts with an **empty** `otf_compile_cache`, so it re-OTF-compiled the module sub into a **distinct** body, reaching `state` under a per-thread key — every thread got its own cell. A same-unit compiled `sub` never hit this because its body lives in the unit's `compiled_fns`, shared by `Arc` into every thread. The `def_is_otf_compilable_module_single` gate excluded `state` module subs from OTF for exactly this reason (correct, but a fallback).

### The fix

- **Capture** each `use`d module's compiled sub bodies at load time into a new `imported_compiled_fns` map, keyed by body/signature fingerprint, snapshotted by value into every spawned thread's clone (`Arc<CompiledFunction>` clone = refcount bump → one shared body). Skipped for modules with no `state` sub (cheap AST scan) so the common case pays nothing.
- **Route** a resolved `state`-bearing module sub through that shared body at all three function-dispatch sites (main / slip / compiled-first).
- **Reset `state_scope_id`** for the shared body's duration: a named routine's `state` is routine-scoped, not closure-instance-scoped. The ambient `start`-closure id was leaking into the `state` key, and `normalize_state_key` does not strip the `#c<id>` suffix — so each thread got a distinct normalized key (the actual root cause).

Only `state`-bearing module subs change routing; every other module sub keeps its existing OTF/tree-walk path (**zero blast radius**). Non-state gate exclusions (EVAL CALLER-context, coercion returns, sigilless scalars) are unaffected.

## Test

Pin: `t/module-state-sub-shared-cell.t` (+ `t/lib/ModuleStateSub.rakumod`) — 6 subtests covering sequential state, cross-thread scalar `state`, cross-thread aggregate `state @`, and sequential-after-threaded. Passes identically on real raku.

`make test` PASS (Files=1566, Tests=15377). Related tests (concurrent-state-var, state-aggregate-shared-cell, module-sub-otf-*) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)