### PR TITLE
docs(plan): record 3b-0 Value API wall complete; queue seal -> 3b-1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -283,10 +283,17 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。スライス計画
       （3b-0 API 壁 → 3b-1 表現スイッチ → 3b-2 交通量刈り）とゲートは
       [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3。
-      **3b-0 着手済み**: 壁 API（`ValueView`/`view()`/accessor/constructor、
-      [docs/nanbox-3b0-api-wall.md](docs/nanbox-3b0-api-wall.md)）と ratchet
-      （`scripts/check-value-wall.sh`・`make test` 組込・baseline 17757）が landed。
-      残り = 直接 variant 参照の機械的移行（ディレクトリ単位スライス・並列可）→ 0 で封印 → 3b-1。
+      **★3b-0 完了（2026-07-07・#4315 slice d + #4316 slice e）**: `src/value/` 外の直接
+      `Value::<Variant>` 参照が **0**（ratchet baseline 0・`make test` 組込）。全構築/マッチが
+      `ValueView`/`view()`/accessor/constructor 経由に統一
+      （[docs/nanbox-3b0-api-wall.md](docs/nanbox-3b0-api-wall.md)）。
+      **次の着手単位 = variant-privacy seal → 3b-1**:
+      (1) **seal**: `Value` enum の variant を src/value/ private 化（or リネーム）し、
+          外部からの直接構築を型で不可能にする（wall constructor 強制）。ratchet は seal 後も残置。
+      (2) **3b-1 表現スイッチ**: `Value` 48→8 bytes。未決の設計判断＝**エンコーディング選択**
+          （pointer-favored か NaN-favored か。view の `&Arc<T>`/`&Gc<T>` フィールドが参照のままか
+          `ArcRef`/`GcRef` guard type になるかを決める。roadmap §3.2 / wall doc §6）→ **Proposed ADR** を先に書く。
+          小整数幅（48/32-bit inline vs `Gc<i64>`）は int-arith bench で flip 時に決定。
 - **Lever 3: threaded dispatch — 凍結**（2026-07-06 ユーザー承認・[ADR-0004](docs/adr/0004-jit-strategy.md) §2.5 J0）:
       JIT Tier A が dispatch ループ除去で同じ利得をより大きく取るため二重投資を避ける。
       JIT が頓挫した場合のみ復活。

--- a/docs/nanbox-3b0-api-wall.md
+++ b/docs/nanbox-3b0-api-wall.md
@@ -1,6 +1,10 @@
 # 3b-0: the `Value` API wall (NaN-boxing enabler)
 
-Status: In progress (slice a landed)
+Status: **COMPLETE (2026-07-07).** Direct `Value::<Variant>` uses outside
+`src/value/` = **0** (ratchet baseline 0, enforced by `make test`). Landed as
+slices a–e: a (#4287 exemplars) · b (#4301 `src/vm/`) · c (#4308 `src/builtins/`)
+· d (#4315 `src/runtime/`) · e (#4316 `src/compiler/` + `src/parser/` +
+stragglers). Next: **variant-privacy seal → 3b-1** (see §7).
 Related: [ADR-0001](adr/0001-gc-strategy-and-phasing.md) §3-6,
 [gc-post-3a-roadmap.md](gc-post-3a-roadmap.md) §3.3, [PLAN.md](../PLAN.md) §5 Lever 2
 
@@ -116,7 +120,7 @@ any regression shows up in `benchmarks/` (fib / int-arith) immediately.
   each updates the ratchet baseline downward.
 - **final**: baseline hits 0 outside `src/value/`; add the variant-privacy
   seal (rename variants or make the enum private) so no new direct use can
-  land; then 3b-1 can start.
+  land; then 3b-1 can start. **All slices a–e landed 2026-07-07 — baseline is 0.**
 
 **Ratchet**: `scripts/check-value-wall.sh` counts direct variant mentions
 outside `src/value/` and fails if the count *rises* above
@@ -132,3 +136,46 @@ new number; `scripts/check-value-wall.sh --update` rewrites it).
   by int-arith bench at flip time (roadmap §3.2).
 - Whether `ArrayKind` / the Set/Bag/Mix mutability bool live in spare tag
   bits or inside the pointee.
+
+## 7. Next-session kickoff: variant-privacy seal → 3b-1
+
+The wall is at 0 but not yet *sealed* — nothing stops a future PR from writing
+`Value::Int(3)` again (the ratchet would catch it in `make test`, but only
+after the fact). The next unit of work, in order:
+
+### 7.1 Variant-privacy seal (small, mechanical, do first)
+Goal: make direct external variant construction/matching a **compile error**, so
+the ratchet becomes belt-and-suspenders instead of the only guard.
+Two viable mechanisms (pick one, ideally in a Proposed ADR or a short PR
+description):
+- **Make the enum private**: rename `pub enum Value` → keep `Value` public but
+  move the variant list behind a private inner type, or mark the variants
+  `pub(crate)` won't help (same crate). The real lever is a **module boundary**:
+  move the enum into a private submodule of `src/value/` and only re-export the
+  constructors/`view()`/`ValueView`. Callers in other crates-modules already use
+  only those, so this should compile with ~zero churn (that's what slices a–e
+  bought). Verify by building after the visibility change.
+- **Rename variants** (e.g. `Value::Int` → `Value::__Int`) so any stray direct
+  use fails to resolve. Uglier; prefer the module-boundary approach.
+Either way: keep `scripts/check-value-wall.sh` in `make test` as a cheap
+regression net even after the seal.
+
+### 7.2 3b-1 representation switch (the big one — write a Proposed ADR first)
+`Value` 48 → 8 bytes (NaN-boxed). The one blocking design decision is the
+**encoding** (§6, roadmap §3.2), because it changes the `ValueView` field types:
+- **pointer-favored** (pointers stored as raw low-48-bit, doubles offset-encoded):
+  `&self.0` transmutes to `&Arc<T>`/`&Gc<T>`, so view keeps `&'a Arc<T>` /
+  `&'a Gc<T>` fields **unchanged** — cheapest migration.
+- **NaN-favored** (tag bits inside the u64): view fields for pointer variants
+  become by-value guard types `ArcRef<'a,T>`/`GcRef<'a,T>` (a `ManuallyDrop`
+  reconstruction that `Deref`s without touching the refcount). The wall already
+  chose payload reference kinds so BOTH exits stay open (§2), but the call sites
+  must be deref-compatible (they are, per the migration rule).
+Deliverable to start the next session: **a Proposed ADR** (`docs/adr/000N-...`)
+choosing the encoding, with an int-arith/fib micro-bench plan to settle
+small-int width (48/32-bit inline vs `Gc<i64>`) and the `ArrayKind`/mutability
+bool placement. Only after the ADR is Accepted does the representation edit
+(rewriting `src/value/` internals + `view()`/constructors) begin — call sites
+outside `src/value/` should not need to change at all if the wall held.
+
+GC/JIT sequencing unchanged: 3b-1 → 3b-2 (traffic pruning) → JIT J1 (ADR-0004).

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,29 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-07: 3b-0 `Value` API 壁 **完成**（NaN-boxing の地ならし・#4315 slice d + #4316 slice e）
+
+層3b（NaN-boxing・[ADR-0001](../docs/adr/0001-gc-strategy-and-phasing.md)）の第一段 **3b-0 = API 壁**を
+完成させた。`src/value/` 外の直接 `Value::<Variant>` 構築/パターンマッチが **0** になり、すべてが
+`Value::view()`/`ValueView`/`Value::int()` 系 constructor/`with_*_mut`/`as_*` 経由に統一された。
+これで 3b-1（`Value` 48→8 bytes の表現スイッチ）が call site を触らずに可能になる。
+
+- **slice d（#4315）**: `src/runtime/` 8728→0。268 ファイルを同一チェックアウト・4並列エージェント
+  バッチ×4ウェーブで移植。view.rs に `version`/`comp_unit_dep_spec`/`promise`/`channel` constructor 追加。
+  途中サブエージェントがアカウントのセッション上限に到達し wave 4 が半移植で停止したが、
+  「直接 variant はまだコンパイル可能（壁はラチェットのみ）」を利用して green checkpoint を刻み、
+  リセット後に残 37 ファイルを再バッチして完走。
+- **slice e（#4316）**: `src/compiler/`+`src/parser/`+stragglers（env/opcode/gc/precomp/repl）549→0。
+  parser は `Expr::Literal(Value::Int(n))` の AST リテラル構築と `#[test]` の `matches!` が主。
+  `Value::regex_with_adverbs` constructor 追加。`check-value-wall.sh` の 0 件時
+  `set -euo pipefail` クラッシュバグ（`grep -v` が no-match で exit 1）も修正。
+- 累積: slices a（#4287）→ b（#4301 src/vm/）→ c（#4308 src/builtins/）→ d → e。ratchet baseline は
+  17759 → 0。詳細と次段（variant-privacy seal → 3b-1 のエンコーディング判断）は
+  [docs/nanbox-3b0-api-wall.md](../docs/nanbox-3b0-api-wall.md) §7。
+- 遭遇したフレーク/罠: rebase がバックグラウンド `make test` とレース → 古いバイナリ×新テストで幻 FAIL、
+  S17 `semaphore.t` の GC+負荷 SEGV（再実行で green）、CI rustc 1.96 の `unused_variables` が
+  ローカル 1.92 より厳しく view バインディングを検出（nightly 1.95 で事前検証可）。
+
 ## 2026-07-07: nested-block `BEGIN` を compile-time 相当に hoist（`S02-names-vars/variables-and-packages.t` whitelist）
 
 bare block **内**の `BEGIN` も、Raku ではコンパイル時に走るため、ブロック内でソース順に BEGIN より


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the 3b-0 wall completion (#4315 slice d + #4316 slice e). Prepares the next session with a clear resume point.

- `docs/nanbox-3b0-api-wall.md`: status → **COMPLETE** (baseline 0); adds **§7 next-session kickoff** — variant-privacy seal, then a Proposed ADR choosing the 3b-1 encoding (pointer-favored vs NaN-favored) with the small-int-width/tag-bit questions to settle at flip time.
- `PLAN.md` Lever 2: 3b-0 marked done; next unit = seal → 3b-1 with the open encoding decision spelled out.
- `news/2026-07.md`: records the milestone (slices a–e, ratchet 17759 → 0) and the flakes/traps hit (rebase↔make-test race, S17 semaphore.t GC SEGV, CI 1.96 stricter `unused_variables`).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXuRg6W4GW4EAQwdYiFGPK