### PR TITLE
docs(blockers): drop stale S06 infix.t entry (already 50/50 + whitelisted)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -100,26 +100,6 @@
   同一の基盤工事が前提条件。単体の parser/dispatch 修正では閉じない。
   次に着手するなら §3 のキャンペーンとして本腰を入れる想定で計画すること。
 
-### 2.4 `S06-operator-overloading/infix.t`
-
-- **現状（2026-07-02 更新）**: 48/50（残り 2 失敗: test 31-32 のみ）。test 11, 33 は
-  rakudo 自身が divergent としている既知の TODO で数に入らない。
-- **経緯**: `import ClassName` 経由の演算子メソッド export（#3982）→ 35/42 → LTM 拡張・
-  `is assoc('non')`・user-declared `infix:<+>`/`infix:<+=>` fast-path override・
-  `infix:OP:[...]`/`infix:OP:«...»` 呼び出し構文で 42/44 → `&infix:<<$var>>`/`«$var»`/
-  `[$var]`（interpolating/expression な演算子名参照。詳細は `TODO_roast/S06.md`）の
-  ランタイム解決を追加して 48/50 まで前進。
-- **残り (test 31-32)**: `sub infix:<,>($a,$b){...}` によるカンマ演算子そのものの
-  オーバーロード（EVAL 内限定）。カンマは list/引数区切りとしてパーサ全体に
-  ハードコードされた特殊トークンであり、他の user 演算子のような汎用 dispatch
-  経路に乗っていない。real raku でも EVAL の外（同一ファイルのトップレベル）では
-  効かない——EVAL は新しいコンパイル単位として、宣言済みの演算子テーブルを
-  引き継いで再パースするため機能する、という compile-time な仕組み。
-- **評価**: 深い・リスクの高いアーキテクチャ変更（カンマを他の user 演算子と同じ
-  拡張可能テーブル経由にする必要があり、あらゆる箇所の区切り用途を壊さずに行う
-  必要がある）。安易に着手しない。whitelist するにはこの 2 件を解決する必要がある。
-- **Canary**: `roast/S06-operator-overloading/infix.t`
-
 ---
 
 ## 3. 第一級コンテナ / container identity
@@ -422,9 +402,6 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowl
    （§3.1 参照）。残るは closure-captured shared-cell を list へ by-value 捕捉したときの
    スナップショット追従（return-writeback 系）と、attribute slot の cell 化。
 2. **`S17-supply/syntax.t`**（§6.2）— test 75/90 は個別に深掘りが必要（hard case）。
-
-`S06-operator-overloading/infix.t`（§2.4）は残り 2 件（カンマ演算子オーバーロード）が
-深いアーキテクチャ変更を要するため、上記優先順から外した。
 
 whitelist を目標にしない §7 の項目は、mutsu 側の一般改善のついでに触れるのはよいが、
 そのファイル単体を通すことを目的にしない。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -572,6 +572,17 @@ dispatch cluster の最後の 1 ファイル `S03-metaops/hyper.t` を whitelist
 
 これで BLOCKERS.md §5 dispatch cluster の残件はゼロになった。
 
+## 2026-07-02: `S06-operator-overloading/infix.t` — カンマ演算子オーバーロード対応で 50/50（whitelist 追加、#4072）
+
+BLOCKERS.md §2.4 の残り 2 件（test 31-32）だった `sub infix:<,>($a,$b){...}` による
+カンマ演算子そのもののオーバーロード（`EVAL('sub infix:<,>($a,$b){42}; 5,5')` → 42）と、
+`is equiv` で定義した custom 演算子の非チェイン化を解消し、`roast/S06-operator-overloading/infix.t`
+が 50/50 になり whitelist 済み（PR #4072）。test 11・33 は rakudo 自身が divergent とする既知の
+`# TODO` で、TAP 上は問題にならない。
+
+（本エントリは BLOCKERS.md §2.4 が #4072 後に更新漏れで残っていたため、2026-07-07 に事後記録したもの。
+実装内容の詳細は PR #4072 の diff を参照。）
+
 ## 2026-07-02: 真の lazy 配列キャンペーン — `S09-subscript/slice.t` の根本原因 6 件を解消
 
 BLOCKERS.md §4「真の lazy 配列 / 無限列」の最後の 1 ファイルだった


### PR DESCRIPTION
## What

`TODO_roast/BLOCKERS.md` §2.4 still claimed `S06-operator-overloading/infix.t` was **48/50** with test 31-32 (comma-operator overload) open and needing a "deep, risky architectural change".

That is stale: PR #4072 (`399e6fbc`, 2026-07-02) implemented `sub infix:<,>` overloading and whitelisted the file. It now passes **50/50** and is already in `roast-whitelist.txt` (line 505). Verified locally:

```
$ MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S06-operator-overloading/infix.t
Files=1, Tests=50 ... Result: PASS
```

(test 11 / 33 are rakudo-divergent `# TODO`s, so they don't count against the pass.)

## Changes

- Remove the stale §2.4 block from `TODO_roast/BLOCKERS.md`.
- Remove the §8 "おすすめ着手順" mention that pointed at it.
- Add the missing #4072 record to `news/2026-07.md` (per the CLAUDE.md rule: whitelisted items move out of BLOCKERS.md into news/).

Docs-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBrnMQtz8PG21keHAkfzKr