### PR TITLE
docs(adr): Proposed ADR-0005 — 3b-1 NaN-box encoding (pointer-favored) + fold variant-privacy seal into 3b-1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -287,13 +287,17 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       `Value::<Variant>` 参照が **0**（ratchet baseline 0・`make test` 組込）。全構築/マッチが
       `ValueView`/`view()`/accessor/constructor 経由に統一
       （[docs/nanbox-3b0-api-wall.md](docs/nanbox-3b0-api-wall.md)）。
-      **次の着手単位 = variant-privacy seal → 3b-1**:
-      (1) **seal**: `Value` enum の variant を src/value/ private 化（or リネーム）し、
-          外部からの直接構築を型で不可能にする（wall constructor 強制）。ratchet は seal 後も残置。
-      (2) **3b-1 表現スイッチ**: `Value` 48→8 bytes。未決の設計判断＝**エンコーディング選択**
-          （pointer-favored か NaN-favored か。view の `&Arc<T>`/`&Gc<T>` フィールドが参照のままか
-          `ArcRef`/`GcRef` guard type になるかを決める。roadmap §3.2 / wall doc §6）→ **Proposed ADR** を先に書く。
-          小整数幅（48/32-bit inline vs `Gc<i64>`）は int-arith bench で flip 時に決定。
+      **次の着手単位 = 3b-1（seal は統合）**: エンコーディングは
+      **[ADR-0005](docs/adr/0005-nanbox-representation-encoding.md)（Proposed・pointer-favored 推奨）**で決定。
+      variant-privacy seal は単独ステップにしない（wall doc §7.1 の module-boundary 方式は seal に
+      ならないと実証・真の seal=newtype=3b-1 の構造前半なので統合）。スライス:
+      (A) **newtype seal（byte-identical）**: `pub enum Value`→`struct Value(ValueRepr)`。
+          `src/value/` 内部 1293 サイトを `.0` 経由へ機械変換。`ValueRepr` は現行 48B enum のまま＝
+          挙動・サイズ不変、variant が compile-time seal される。
+      (B) **表現差し替え**: `ValueRepr` を pointer-favored NaN-box（8B）へ置換。`view()`/constructor/
+          accessor の中身のみ変更。小整数幅（48/32-bit inline vs `Gc<i64>`）は int-arith bench で決定。
+          ゲート＝make test＋roast＋gc-stress green・§3.2 マイクロベンチ。ratchet は seal 後も残置。
+          着手は **ADR-0005 が Accepted になってから**。
 - **Lever 3: threaded dispatch — 凍結**（2026-07-06 ユーザー承認・[ADR-0004](docs/adr/0004-jit-strategy.md) §2.5 J0）:
       JIT Tier A が dispatch ループ除去で同じ利得をより大きく取るため二重投資を避ける。
       JIT が頓挫した場合のみ復活。

--- a/docs/adr/0005-nanbox-representation-encoding.md
+++ b/docs/adr/0005-nanbox-representation-encoding.md
@@ -1,0 +1,170 @@
+# ADR-0005: NaN-boxing 表現スイッチ（3b-1）のエンコーディング選択と newtype seal 統合
+
+- **Status**: Proposed（承認待ち）
+- **Date**: 2026-07-07
+- **Deciders**: tokuhirom, Claude
+- **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（層3b の位置づけ・順序 3a→3b→4）,
+  [ADR-0004](0004-jit-strategy.md)（JIT は 8B 固定幅 `Value` を前提）,
+  [gc-post-3a-roadmap.md](../gc-post-3a-roadmap.md) §3.2/§3.3（表現方針・スライス分割）,
+  [nanbox-3b0-api-wall.md](../nanbox-3b0-api-wall.md)（3b-0 API 壁・移行レシピ・§6 未決事項・§7 seal）,
+  [PLAN.md](../../PLAN.md) §5 Lever 2
+
+> 3b-0（API 壁）は完了済み — `src/value/` 外の直接 `Value::<Variant>` 参照は **0**（ratchet
+> `check-value-wall.sh` が `make test` で保証）。本 ADR は 3b-1（`Value` 48B→8B の表現スイッチ）の
+> **唯一のブロッキング設計判断＝エンコーディング選択**を決め、あわせて wall doc §7.1 の
+> variant-privacy seal を 3b-1 に統合する方針を確定する。実装は本 ADR が Accepted になってから。
+
+---
+
+## 1. Context（背景）
+
+- `Value` は現在 48B の `enum`（~50 variant、`value_size_guard` テストで `<= 48` を固定）。
+  bench-class の ~50% が `Value::clone`/`drop_in_place`/`Vec::clone`（PERFORMANCE.md）、
+  GC default-on の bench-class +8% 残差も同じ交通量に乗る。3b は `Value` を **8B 固定幅**の
+  NaN-box に変え、これらをまとめて回収する（roadmap §3.1）。JIT（ADR-0004）は 8B 固定幅・
+  タグ判定数命令・レジスタ搭載を前提にしており、3b はその地ならし。
+- 3b-0 で全呼び出し側は `view()`/`ValueView`/accessor/constructor 経由に統一済み。したがって
+  3b-1 は原則 **`src/value/` の内部（表現モジュール）だけ**を書き換える。壁が保たれていれば
+  外部呼び出し側の変更は不要（これが 3b-0 の狙い）。
+- 3b-0 完了時点で判明した重要事実（本 ADR の前提を 1 つ補正する）:
+  wall doc §7.1 が「small・mechanical・~zero churn」と見積もっていた **variant-privacy seal の
+  module-boundary 方式（private サブモジュール ＋ `pub use` 再エクスポート）は実際には seal に
+  ならない**。Rust の enum variant は enum 自体の可視性を継承し、型の再エクスポートで variant も
+  外部から到達可能になる（`pub use repr::Value;` の後 `Value::Int(3)` が外部モジュールで
+  コンパイル可能なことを実証済み）。同一クレート内なので `#[non_exhaustive]` も無効。
+  コンパイル時に真に seal できる唯一の手段は **newtype ラッパー** `struct Value(ValueRepr)`
+  （private field ＋ private `ValueRepr`）であり、これは `src/value/` 内部の直接 variant 参照
+  **1293 箇所**を `.0` 経由へ書き換える大規模リファクタになる。
+
+### 3b-0 で確定した variant 3 分類（roadmap §3.2・wall doc §2 の具体化）
+
+現行 enum を payload 形状で分類する（8B box の格納先を決める）:
+
+- **inline scalar**（ヒープなし・box payload に直接デコード格納、view は by-value）:
+  `Int`（小整数）・`Bool`・`Nil`・`Whatever`・`HyperWhatever`・`Num`（f64 生値）・
+  `Package(Symbol)`。**注意**: `Range*`(2×i64)・`Rat`/`FatRat`(2×i64)・`Complex`(2×f64) は
+  payload が 48bit を超えるため inline 不可 → boxed。
+- **single-pointer（pointer tag）**（`Gc<T>`/`Arc<T>` の生ポインタを payload に）:
+  `Str`・`Array`・`Hash`・`Set`・`Bag`・`Mix`・`Sub`・`WeakSub`・`LazyList`・`ContainerRef`・
+  `Seq`/`HyperSeq`/`RaceSeq`/`Slip`・`Junction`・`Regex`・`BigInt`・`Promise`/`Channel`・
+  `LazyThunk`・`Instance`（下記の付随フィールド問題あり）。
+- **heap-boxed struct**（多フィールド → 1 ヒープ箱に退避）:
+  `GenericRange`・`Range*`・`Rat`/`FatRat`/`BigRat`/`Complex`・`Pair`・`ValuePair`・`Enum`・
+  `RegexWithAdverbs`・`Version`・`Capture`・`Uni`・`Proxy`・`ParametricRole`・`CustomType`・
+  `CustomTypeInstance`・`Scalar`・`Mixin`(2 ポインタ)・`LazyIoLines`・`HashEntryRef`・
+  `CompUnitDepSpec`・`Routine`(3 Symbol)。
+
+**付随フィールド問題**（wall doc §6 の未決事項）: `Array(Gc, ArrayKind)`・`Set/Bag/Mix(Gc, bool)`・
+`Instance{Symbol, Gc, u64}` はポインタ以外の小フィールドを持つ。ポインタ＋付随ビットを 48bit box に
+同居させるか、付随ビットを pointee 側へ移すかの選択がある（§3.3）。
+
+## 2. Decision（提案する決定）
+
+### 2.1 エンコーディング = **pointer-favored（NuN-boxing 型）** を推奨採用
+
+box は 64bit の 1 ワード。**ポインタは低位ビットにクリーンに格納**し、`f64` は
+**オフセット・エンコード**（load/store 時に定数バイアスを加減）で quiet-NaN 空間の外へ退避する。
+inline 小整数・タグは残りのビット空間に割り当てる（正確なビット配分は実装時に確定・§3.1）。
+
+**pointer-favored を選ぶ理由**:
+
+1. **mutsu のホットパスはポインタ支配的**。method dispatch・コンテナアクセス（`Str`/`Array`/
+   `Hash`/`Instance`/`Sub`）が最頻で、pointer-favored はこれらの deref を **マスク操作なし**
+   （生ポインタがそのまま）にできる。
+2. **移行コストが最小**。生ポインタが payload そのものなので `&self.0` を `&Arc<T>`/`&Gc<T>` へ
+   transmute でき、`ValueView` の pointer variant フィールドを **現行の `&'a Arc<T>`/`&'a Gc<T>`
+   のまま維持**できる（wall doc §2/§7.2）。→ `view.rs` の変更が最小、外部呼び出し側の変更ゼロ。
+3. **ヘッドラインベンチは Int 律速**。int-arith・fib は `Int`（両エンコーディングとも inline）を
+   使い、`Num`(f64) は二次的。f64 のオフセット加減は 1 ALU 命令で、非主要パスに乗る。
+
+**却下する対案 = NaN-favored（native double）**: `f64` を生値で持ち、非 f64 を quiet-NaN payload に
+タグ格納する（JSC/LuaJIT 方式）。`Num` 演算がゼロコストになる利点はあるが、(a) ポインタ deref に
+マスク（AND）が要る、(b) `&self.0` がクリーンな `&Arc<T>` にならないため `ValueView` の pointer
+variant フィールドを **by-value guard 型 `ArcRef<'a,T>`/`GcRef<'a,T>`**（`ManuallyDrop` で refcount を
+触らず `Deref` する再構成型）に変える追加実装が要る。mutsu では Num より pointer/Int が支配的なので
+利得が逆。
+
+**両出口を開けたまま進める**: wall doc §2 の移行規則（call site を deref 互換の使い方に限定 —
+`s.clone()`/`s.is_empty()`/`&*s`/`Arc::ptr_eq` は可、`&Arc` 自体の保存やアドレス比較は不可）は
+3b-0 で既に守られている。したがって、後述のベンチ（§3.2）で pointer-favored が Num 重ワークロードで
+不利と実測された場合に限り、guard 型を導入して NaN-favored へ切り替える退路が残る
+（call site 変更は不要、`view.rs` の pointer フィールド型と box 内部のみ差し替え）。
+
+### 2.2 variant-privacy seal は **3b-1 に統合**（単独 PR にしない）
+
+wall doc §7.1 の seal を独立ステップとして先行実施しない。理由:
+
+1. seal の唯一の実効メカニズム（newtype ラッパー）が **3b-1 step 2 の構造的前半そのもの**。
+   3b-1 は `Value` を `struct Value(内部表現)` の newtype にするので、newtype 化＝副作用で
+   variant が compile-time に seal される。単独 seal を挟むと同じ 1293 サイトを二度触る。
+2. wall の後退は ratchet（`check-value-wall.sh`・`make test` 組込）が **決定的に検出**済み。
+   単独 seal の追加価値は「CI 失敗をコンパイル失敗へ前倒し」する belt-and-suspenders のみで、
+   1293 サイトの二重リファクタに見合わない。
+3. ratchet は seal 後も残置する（安価な回帰ネット）。
+
+→ 3b-1 の最初のコミットが **byte-identical な newtype 化**（内部表現はまだ現行 enum のまま
+`struct Value(ValueRepr)` に包むだけ）になり、これが seal を兼ねる（§3.3 step A）。
+
+### 2.3 スライス構成（roadmap §3.3 step 2 を細分化）
+
+3b-1 を「安全な機械変換（構造）」と「危険な表現差し替え（実体）」に分割する:
+
+- **step A（newtype seal・byte-identical）**: `pub enum Value` → `pub struct Value(ValueRepr)`
+  （`ValueRepr` は `src/value/` private の enum、現行 variant をそのまま保持）。`src/value/` 内部の
+  1293 サイトを `.0` 経由へ機械変換。`ValueRepr` は依然 48B なので **挙動・サイズとも不変**。
+  variant は compile-time に seal される。ゲート: make test byte-identical、`value_size_guard` は 48 のまま。
+- **step B（表現差し替え・実体）**: `ValueRepr`（48B enum）を pointer-favored NaN-box（8B）へ置換。
+  `view()`/constructor/accessor/`with_*_mut` の中身だけが変わる。`value_size_guard` を 48→8 に更新。
+  ゲート: make test ＋ full roast ＋ gc-stress green、GC カウンタ不変（型フィルタのスカラ/コンテナ
+  判定がタグ判定に変わるだけ）、§3.2 のマイクロベンチ達成。
+- step A と step B の分割により、**中間状態が常に byte-identical**（step A）→ 危険な変更（step B）は
+  確立済みの newtype 境界の背後だけに閉じる。bisect/レビューも容易。
+
+## 3. 実装時に確定する下位判断（本 ADR では方針のみ）
+
+### 3.1 小整数幅
+
+inline `Int` の幅（48bit inline / 32bit inline / 範囲外は `Gc<i64>` 箱 or `BigInt` 箱行き）は
+**int-arith / fib ベンチで flip 時に決定**（roadmap §3.2）。pointer-favored はタグ空間がやや狭い点に
+注意。既定案: 48bit 級 inline、範囲外は既存の `BigInt` 経路へ委譲（`Gc<i64>` 箱は計測で必要なら）。
+
+### 3.2 受け入れマイクロベンチ（step B ゲート）
+
+- **int-arith 2x**・**fib +30%**（PERFORMANCE.md Phase 4a 期待値）。
+- bench-class の `Value` clone/drop share **50% → 20% 以下**。
+- GC-on bench-class 残差 **+8% → +3% 以下**（roadmap §3.3 の 3b 全体ゲート）。
+- **pointer-favored 妥当性チェック**: `Num` 重ワークロード（複素数/浮動小数ループのマイクロベンチを
+  1 本追加）で回帰が **f64 オフセット 1 命令ぶんに収まる**ことを確認。ここで想定外の回帰が出た場合のみ
+  §2.1 の退路（guard 型で NaN-favored）を発動。
+
+### 3.3 付随フィールドの配置
+
+`Array` の `ArrayKind`・`Set/Bag/Mix` の mutability bool は **box のスペアタグビットに載せる**を
+既定とし、ビットが逼迫した場合に pointee へ移す。`Instance` の `{class_name: Symbol, id: u64}` は
+ポインタ 1 本に収まらないため、`InstanceAttrs`（既に `Gc`）側へ寄せるか専用ヒープ箱にする
+（step B の設計で確定）。
+
+## 4. Consequences
+
+- step A 完了時点で variant は compile-time に seal され、wall doc §7.1 の目的を達成（ratchet は残置）。
+- pointer-favored 採用により `ValueView` の pointer variant フィールドが現行の `&Arc<T>`/`&Gc<T>` の
+  まま維持され、`view.rs` の変更と外部影響が最小化される。
+- `Num` 演算に f64 オフセット加減 1 命令が乗る（非主要パス・§3.2 で妥当性を実測）。
+- Send/Sync は不変（payload はポインタのまま・roadmap §3.4）。タグ操作は 1 モジュールに閉じ込め
+  Miri でユニット検証（roadmap §3.4）。
+- 3b-1 完了で JIT（ADR-0004 J1）の前提「8B 固定幅 `Value`」が満たされる。続いて 3b-2（交通量刈り）。
+
+## 5. Alternatives considered
+
+| 案 | 利点 | 欠点 | 判定 |
+|---|---|---|---|
+| **pointer-favored NaN-box（本 ADR）** | ポインタ deref マスク不要・view 移行最小（`&Arc<T>` 維持）・外部影響ゼロ | f64 にオフセット 1 命令 | **推奨採用** |
+| NaN-favored（native double） | `Num` 演算ゼロコスト | ポインタ deref にマスク・view が guard 型（ArcRef/GcRef）へ追加実装・mutsu は Num 非支配 | 却下（退路として保持） |
+| 単独 variant-privacy seal を先行 | 表現変更と分離してレビュー | 実効メカニズム=newtype=3b-1 step A なので 1293 サイトを二度触る・ratchet で回帰は既に防止済 | 却下（3b-1 に統合） |
+| module-boundary seal（`pub use` 再エクスポート） | churn ゼロの想定だった | **seal にならない**（variant が再エクスポートで漏れる・実証済み） | 却下（実現不能） |
+| 一斉 flip（step A/B 非分割） | コミット数少 | 5b で 479 エラー/型・レビュー/bisect 不能（roadmap §3.3/§3.4） | 却下（段階必須） |
+
+---
+
+*本 ADR は Proposed。承認後、3b-1 step A（newtype seal・byte-identical）から着手し、
+step B（pointer-favored 表現差し替え）を §3.2 のベンチゲートで受け入れる。*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@
 | [0002](0002-phase-a-gate-reassessment.md) | Phase A ゲート再評価 — GC 着手条件の充足確認 | Accepted |
 | [0003](0003-default-on-gc-trigger.md) | デフォルト GC=on のトリガ方針（同期 + バッファサイズ閾値 + adaptive backoff） | Accepted |
 | [0004](0004-jit-strategy.md) | JIT の方式選定とフェーズ計画（Cranelift method JIT・deopt なし） | Accepted |
+| [0005](0005-nanbox-representation-encoding.md) | NaN-boxing 表現スイッチ（3b-1）のエンコーディング選択と newtype seal 統合 | Proposed |

--- a/docs/nanbox-3b0-api-wall.md
+++ b/docs/nanbox-3b0-api-wall.md
@@ -4,7 +4,9 @@ Status: **COMPLETE (2026-07-07).** Direct `Value::<Variant>` uses outside
 `src/value/` = **0** (ratchet baseline 0, enforced by `make test`). Landed as
 slices a–e: a (#4287 exemplars) · b (#4301 `src/vm/`) · c (#4308 `src/builtins/`)
 · d (#4315 `src/runtime/`) · e (#4316 `src/compiler/` + `src/parser/` +
-stragglers). Next: **variant-privacy seal → 3b-1** (see §7).
+stragglers). Next: **3b-1 (encoding decided by [ADR-0005](adr/0005-nanbox-representation-encoding.md),
+Proposed)** — the variant-privacy seal is folded into it, not a standalone step
+(the §7.1 "module-boundary seal" turned out infeasible; see §7).
 Related: [ADR-0001](adr/0001-gc-strategy-and-phasing.md) §3-6,
 [gc-post-3a-roadmap.md](gc-post-3a-roadmap.md) §3.3, [PLAN.md](../PLAN.md) §5 Lever 2
 
@@ -137,30 +139,35 @@ new number; `scripts/check-value-wall.sh --update` rewrites it).
 - Whether `ArrayKind` / the Set/Bag/Mix mutability bool live in spare tag
   bits or inside the pointee.
 
-## 7. Next-session kickoff: variant-privacy seal → 3b-1
+## 7. Next-session kickoff: 3b-1 (seal folded in)
 
 The wall is at 0 but not yet *sealed* — nothing stops a future PR from writing
-`Value::Int(3)` again (the ratchet would catch it in `make test`, but only
-after the fact). The next unit of work, in order:
+`Value::Int(3)` again (the ratchet catches it in `make test`, but only after the
+fact). **Decision (2026-07-07, [ADR-0005](adr/0005-nanbox-representation-encoding.md)
+Proposed): the seal is NOT a standalone step — it is folded into 3b-1 step A.**
 
-### 7.1 Variant-privacy seal (small, mechanical, do first)
-Goal: make direct external variant construction/matching a **compile error**, so
-the ratchet becomes belt-and-suspenders instead of the only guard.
-Two viable mechanisms (pick one, ideally in a Proposed ADR or a short PR
-description):
-- **Make the enum private**: rename `pub enum Value` → keep `Value` public but
-  move the variant list behind a private inner type, or mark the variants
-  `pub(crate)` won't help (same crate). The real lever is a **module boundary**:
-  move the enum into a private submodule of `src/value/` and only re-export the
-  constructors/`view()`/`ValueView`. Callers in other crates-modules already use
-  only those, so this should compile with ~zero churn (that's what slices a–e
-  bought). Verify by building after the visibility change.
-- **Rename variants** (e.g. `Value::Int` → `Value::__Int`) so any stray direct
-  use fails to resolve. Uglier; prefer the module-boundary approach.
-Either way: keep `scripts/check-value-wall.sh` in `make test` as a cheap
-regression net even after the seal.
+### 7.1 Why the standalone "module-boundary seal" was dropped (verified)
+The original plan here assumed a **~zero-churn** seal via a module boundary
+(move the enum into a private submodule, `pub use` only the constructors/`view()`).
+**This does not seal** — verified empirically: `pub use repr::Value;` re-exports
+the *type*, and Rust enum variants inherit the enum's visibility, so external
+modules can still write `Value::Int(3)`. `#[non_exhaustive]` is a no-op within the
+same crate. The **only** compile-time seal is a **newtype wrapper**
+`struct Value(ValueRepr)` (private field, private `ValueRepr`), which requires
+rewriting the **1293** direct variant sites *inside* `src/value/` to go through
+`.0`. That is not "small/mechanical" — and it is exactly the structural first half
+of the 3b-1 representation switch (roadmap §3.3 step 2 makes `Value` a newtype
+anyway). Doing it standalone would touch those 1293 sites twice. So:
+- **Seal = 3b-1 step A** (byte-identical newtype-ization; `ValueRepr` stays the
+  current 48B enum → behavior and size unchanged, variants become compile-time
+  private as a side effect).
+- **Representation flip = 3b-1 step B** (pointer-favored NaN-box behind the newtype).
+- The ratchet (`scripts/check-value-wall.sh` in `make test`) stays as the interim
+  guard until step A lands, and remains afterward as a cheap regression net.
 
-### 7.2 3b-1 representation switch (the big one — write a Proposed ADR first)
+See ADR-0005 §2.2/§2.3 for the full rationale and slice plan.
+
+### 7.2 3b-1 representation switch — encoding decided in ADR-0005 (Proposed)
 `Value` 48 → 8 bytes (NaN-boxed). The one blocking design decision is the
 **encoding** (§6, roadmap §3.2), because it changes the `ValueView` field types:
 - **pointer-favored** (pointers stored as raw low-48-bit, doubles offset-encoded):
@@ -171,11 +178,16 @@ regression net even after the seal.
   reconstruction that `Deref`s without touching the refcount). The wall already
   chose payload reference kinds so BOTH exits stay open (§2), but the call sites
   must be deref-compatible (they are, per the migration rule).
-Deliverable to start the next session: **a Proposed ADR** (`docs/adr/000N-...`)
-choosing the encoding, with an int-arith/fib micro-bench plan to settle
-small-int width (48/32-bit inline vs `Gc<i64>`) and the `ArrayKind`/mutability
-bool placement. Only after the ADR is Accepted does the representation edit
-(rewriting `src/value/` internals + `view()`/constructors) begin — call sites
-outside `src/value/` should not need to change at all if the wall held.
+
+**[ADR-0005](adr/0005-nanbox-representation-encoding.md) (Proposed) recommends
+pointer-favored** — mutsu's hot path is pointer-dominated, so raw-pointer deref +
+`&Arc<T>` view fields unchanged (minimal `view.rs`/zero call-site churn) beats
+NaN-favored's native-double win (Num is secondary here). NaN-favored is kept as a
+documented fall-back (guard types) if a Num-heavy micro-bench regresses. The ADR
+also fixes the slice plan (step A newtype seal → step B representation flip), the
+int-arith/fib bench gates, small-int width (decided at flip), and the
+`ArrayKind`/mutability-bool placement. Only after the ADR is **Accepted** does the
+representation edit begin — call sites outside `src/value/` should not need to
+change at all if the wall held.
 
 GC/JIT sequencing unchanged: 3b-1 → 3b-2 (traffic pruning) → JIT J1 (ADR-0004).


### PR DESCRIPTION
## Summary

3b-0 (the `Value` API wall) is complete — direct `Value::<Variant>` uses outside `src/value/` = **0** (ratchet-enforced in `make test`). The next queued unit in [`docs/nanbox-3b0-api-wall.md` §7](../blob/main/docs/nanbox-3b0-api-wall.md) was *"variant-privacy seal (small, mechanical) → 3b-1"*. Investigation falsified the seal's cheap-mechanism premise, so this PR records the corrected plan as **Proposed ADR-0005** (docs only, no code).

## Key finding (verified empirically)

- The §7.1 **module-boundary seal** (private submodule + `pub use` re-export) **does not seal**: after `pub use repr::Value;`, external modules can still write `Value::Int(3)` — enum variants inherit the enum's visibility, and `#[non_exhaustive]` is a no-op within the same crate.
- The **only** compile-time seal is a **newtype wrapper** `struct Value(ValueRepr)`, which requires rewriting the **1293** direct variant sites *inside* `src/value/` via `.0`. That is exactly the structural first half of the 3b-1 representation switch (roadmap §3.3 step 2 makes `Value` a newtype anyway) — doing it standalone touches those sites twice.

## Decision (ADR-0005, Proposed)

1. **Fold the seal into 3b-1**, not a standalone step:
   - **step A** = byte-identical newtype-ization (`ValueRepr` stays the current 48B enum → behavior & size unchanged; variants become compile-time private as a side effect).
   - **step B** = pointer-favored NaN-box flip behind the newtype.
   - The ratchet stays as the interim guard until step A, and as a regression net after.
2. **Encoding = pointer-favored** (raw-pointer deref, `ValueView` `&Arc<T>`/`&Gc<T>` fields unchanged → minimal `view.rs` / zero call-site churn; mutsu's hot path is pointer-dominated). **NaN-favored kept as a documented fall-back** (guard types `ArcRef`/`GcRef`) if a Num-heavy micro-bench regresses.
3. Bench gates (int-arith 2x / fib +30% / clone-drop share 50%→20%), small-int width (decided at flip), and `ArrayKind`/mutability-bool placement recorded for step-B time.

## Changes (docs only)
- `docs/adr/0005-nanbox-representation-encoding.md` (new, **Proposed**)
- `docs/adr/README.md` — index entry
- `docs/nanbox-3b0-api-wall.md` §7 — record the infeasible-seal finding + point to ADR-0005
- `PLAN.md` §5 Lever 2 — reflect the folded seal + encoding decision

Awaiting review to move ADR-0005 to **Accepted**; implementation (3b-1 step A) begins only after acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)