### PR TITLE
fix(parser): register imported module types so `when X::Foo {}` isn't misflagged

### DIFF
--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -228,6 +228,23 @@ pub(crate) fn extract_exported_names(source: &str) -> Vec<InlineModuleExport> {
         *s.borrow_mut() = saved_scopes;
     });
     set_current_language_version(&saved_language_version);
+    // Register the module's declared type names (classes/roles/enums/grammars)
+    // into the importer's scope. A `use`d module makes its `our`-scoped and
+    // exported types visible to the importer, but mutsu loads modules at run
+    // time, so without this the parser treats those imported types as
+    // undeclared. That in turn misfires heuristics like the `when X::Foo {}`
+    // undeclared-exception gobble check (see `given_when::when_stmt`), breaking
+    // valid code such as `when X::Zef::UnsatisfiableDependency { ... }` in a
+    // file that `use Zef`. Registration happens after the scope restore above so
+    // the names land in the importer's current scope, not the module's discarded
+    // parse scope.
+    {
+        let mut type_names: Vec<String> = Vec::new();
+        collect_module_type_names(&stmts, &mut type_names);
+        for name in &type_names {
+            register_user_type(name);
+        }
+    }
     let mut exports: HashMap<String, InlineModuleExport> = HashMap::new();
     for stmt in &stmts {
         match stmt {
@@ -298,6 +315,31 @@ pub(crate) fn extract_exported_names(source: &str) -> Vec<InlineModuleExport> {
     let mut result: Vec<InlineModuleExport> = exports.into_values().collect();
     result.sort_by(|a, b| a.name.cmp(&b.name));
     result
+}
+
+/// Recursively collect the names of type declarations (class/role/enum/grammar)
+/// found in a parsed module's statement list. Descends into `package`/`module`/
+/// `grammar` bodies (whose members are `our`-scoped) so nested type names are
+/// captured too. These names are registered into the importer's scope so the
+/// parser knows they are declared types rather than undeclared barewords.
+fn collect_module_type_names(stmts: &[Stmt], out: &mut Vec<String>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::ClassDecl { name, .. }
+            | Stmt::RoleDecl { name, .. }
+            | Stmt::EnumDecl { name, .. } => {
+                out.push(name.resolve());
+            }
+            Stmt::Package { name, body, .. } => {
+                // `grammar Foo { ... }` is a Package with kind Grammar; its name
+                // is itself a type. `module`/`package` names are namespaces, but
+                // registering them is harmless and covers grammar declarations.
+                out.push(name.resolve());
+                collect_module_type_names(body, out);
+            }
+            _ => {}
+        }
+    }
 }
 
 fn extract_exported_names_fallback(source: &str) -> Vec<(String, bool)> {

--- a/t/imported-exception-when.t
+++ b/t/imported-exception-when.t
@@ -1,0 +1,53 @@
+use v6;
+# NOTE: a string-literal `use lib` path is required here (not an expression like
+# `$?FILE.IO.parent.add('lib')`): the parser scans `use`d module files at parse
+# time to learn their declared types, and only a literal path updates the
+# parse-time library search path. `prove` runs from the repo root, so `t/lib`
+# resolves.
+use lib 't/lib';
+use Test;
+use ImportedExceptionType;
+
+# An X::/CX:: exception type imported from a used module must be recognized as a
+# declared type by the parser, so `when X::Imported::Boom { ... }` is NOT flagged
+# as an undeclared bareword gobbling its block. Regression: the parser only saw
+# types declared in the current compilation unit, so a `when` matching an imported
+# exception type raised X::Comp::Group("Missing block") at parse time. This broke
+# real code such as Zef's `when X::Zef::UnsatisfiableDependency { ... }` in a file
+# that `use Zef`.
+
+plan 4;
+
+# Plain given/when on the imported exception type.
+{
+    my $r = "no";
+    given X::Imported::Boom.new {
+        when X::Imported::Boom { $r = "matched" }
+        default { $r = "default" }
+    }
+    is $r, "matched", 'imported X:: exception type matches in given/when';
+}
+
+# The imported type is a valid smartmatch target outside given as well.
+ok X::Imported::Boom.new ~~ X::Imported::Boom, 'imported exception smartmatches its own type';
+
+# The exact zef shape: a `when` on the imported type nested inside a CATCH inside
+# a block that is the condition of an `if` (this is what regressed to a parse
+# error before the fix).
+{
+    my @vals = 1, 2, 3;
+    my $branch = "none";
+    if @vals.first({
+            CATCH { when X::Imported::Boom { } }
+            $_ > 2
+        }) -> $ {
+        $branch = "then";
+    } else {
+        $branch = "else";
+    }
+    is $branch, "then", 'when-on-imported-type inside if-condition block parses and runs';
+}
+
+# The undeclared case must still error: a genuinely-unknown X:: bareword gobbles.
+throws-like 'when X::TotallyUndeclared::Nope {}', X::Comp::Group,
+    'genuinely undeclared X:: bareword in when still raises the gobble error';

--- a/t/lib/ImportedExceptionType.rakumod
+++ b/t/lib/ImportedExceptionType.rakumod
@@ -1,0 +1,8 @@
+unit module ImportedExceptionType;
+
+# A top-level (our-scoped) exception class in the X:: namespace, declared outside
+# any `is export` — exactly the shape Zef uses for
+# `class X::Zef::UnsatisfiableDependency is Exception`.
+class X::Imported::Boom is Exception {
+    method message() { "boom" }
+}


### PR DESCRIPTION
## Summary

The parser scans `use`d module files at parse time to learn their exported subs/operators, but it did **not** record the module's declared **type** names (class/role/enum/grammar). So an `X::`/`CX::` exception type imported from a module was treated as an *undeclared* bareword, misfiring the `when` gobble heuristic in `given_when::when_stmt` and raising `X::Comp::Group("Missing block")` at parse time.

This broke real code such as Zef's `when X::Zef::UnsatisfiableDependency { ... }` in a file that `use Zef`, making `use Zef::Client` (and hence the whole `zef` CLI beyond `--help`) fail to compile.

## Fix

After scanning a module, collect its top-level and nested (`package`/`grammar` body) type declaration names and register them into the importer's scope via `register_user_type`, so `is_user_declared_type` recognizes them. Genuinely-undeclared `X::` barewords still gobble their block as before.

## Impact on zef

With this fix (run with `MUTSULIB` pointing at the zef lib):
- `use Zef::Client` now **loads** (previously a parse error).
- `zef --version` reports the real version `0.13.8` (previously "unknown").
- `zef --help` still prints full usage.
- `zef locate`/`info` now reach a **separate, unrelated** runtime blocker (associative indexing on an Array), tracked for follow-up.

## Tests

- New `t/imported-exception-when.t` (+ `t/lib/ImportedExceptionType.rakumod`): an imported `X::` exception type used in `given/when`, in the exact `if`-condition-block shape that regressed for zef, and a check that a genuinely-undeclared `X::` bareword still raises the gobble error.
- Existing `t/comp-group-when-gobbled.t` / `t/comp-group-block-gobbled.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)