### PR TITLE
fix(vm): don't leak the WhateverCode identity marker into inner blocks

### DIFF
--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -358,6 +358,15 @@ impl Interpreter {
                     flat.remove_sym(Symbol::intern(name));
                 }
             }
+            // `__mutsu_callable_type` is closure-IDENTITY metadata (e.g. the
+            // WhateverCode marker), set on the genuine closure's own env AFTER
+            // capture (see the `is_whatever_code` insert in the caller). It must
+            // never be inherited: an ordinary inner block created inside a
+            // WhateverCode body would otherwise capture the marker and be
+            // mis-treated as a WhateverCode itself — e.g. the `.map` loop would
+            // then hold `$_` at the outer topic instead of binding it to the
+            // element (`*.map({ $_ })` saw the whole list, not each item).
+            flat.remove_sym(Symbol::intern("__mutsu_callable_type"));
             return flat;
         }
         let free: std::collections::HashSet<Symbol> = cc.free_var_syms.iter().copied().collect();
@@ -374,6 +383,13 @@ impl Interpreter {
         let flat = self.clone_env();
         let mut map: std::collections::HashMap<Symbol, Value> = std::collections::HashMap::new();
         for (k, v) in flat.iter() {
+            // `__mutsu_callable_type` is closure-identity metadata (the
+            // WhateverCode marker), (re)installed on the genuine closure's own env
+            // after capture. Never inherit it, or an ordinary inner block would be
+            // mis-detected as a WhateverCode (see the by-name path above).
+            if k.with_str(|s| s == "__mutsu_callable_type") {
+                continue;
+            }
             let keep = free.contains(k)
                 || k.with_str(|s| !crate::env::is_plain_user_lexical(s) && !own_locals.contains(s));
             if keep {

--- a/t/whatever-map-topic.t
+++ b/t/whatever-map-topic.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+# A WhateverCode's `*` placeholder compiles to a `$_`-named topic param. An
+# ordinary inner block created inside the WhateverCode body (e.g. the block
+# argument to `.map`) must NOT inherit the WhateverCode's identity marker, or
+# the `.map` loop mis-treats the inner block as a WhateverCode and holds `$_`
+# at the outer topic (the whole list) instead of binding it to each element.
+
+plan 8;
+
+my $h = { :a(1) };
+
+# 1) single-element list argument
+{
+    my @names = (*.map({ $_.^name }))(($h,));
+    is @names[0], 'Hash', 'inner $_ in *.map is the element (single-elem list)';
+}
+
+# 2) two-element list argument
+{
+    my @names = (*.map({ $_.^name }))(($h, $h));
+    is @names.elems, 2, 'two elements mapped';
+    is @names[0], 'Hash', 'inner $_ is element (elem 0)';
+    is @names[1], 'Hash', 'inner $_ is element (elem 1)';
+}
+
+# 3) actual value transformation through the inner $_
+{
+    my @doubled = (*.map({ $_ * 2 }))((10, 20, 30));
+    is-deeply @doubled.List, (20, 40, 60), 'inner $_ arithmetic per element';
+}
+
+# 4) associative index on the mapped element (the zef Repository pattern)
+{
+    my @keys = (*.map({ $_<k> }))(({ :k(42) },));
+    is @keys[0], 42, 'inner $_<k> indexes the element hash, not the list';
+}
+
+# 5) nested: WhateverCode inside WhateverCode still binds its own topic
+{
+    my @r = (*.map(*.map({ $_ + 1 })))(((1, 2), (3, 4)));
+    is-deeply @r[0].List, (2, 3), 'nested map inner + outer topics independent';
+}
+
+# 6) grep parity (was already correct; guard against regression)
+{
+    my @g = (*.grep({ $_ > 1 }))((0, 1, 2, 3));
+    is-deeply @g.List, (2, 3), 'inner $_ in *.grep is the element';
+}


### PR DESCRIPTION
## Problem

A WhateverCode's captured environment carries a `__mutsu_callable_type = "WhateverCode"` identity marker. `capture_closure_env` was inheriting that marker into **ordinary inner blocks** created inside a WhateverCode body — e.g. the `{ ... }` block argument to `.map` in `*.map({ $_ })`.

The eager `.map` loop keys its `is_whatever_code` special-case (`resolution_map_grep.rs`) off that marker. When it's (erroneously) set, the loop holds `$_` at the *outer* topic instead of binding it to each element. So:

```raku
my $h = { :a(1) };
say (*.map({ $_.^name }))(($h,));   # was (List), should be (Hash)
```

and `$_<key>` on the element then threw `Type Array does not support associative indexing`.

Isolated triage:
- `(*.grep({ $_ }))((\$h,))` — fine (grep never had this path).
- `(*.map(-> \$x { $x }))((\$h,))` — fine (inner uses `\$x`, not `\$_`).
- `*.map({ \$_ })` — broke (inner block uses `\$_`, inherits the marker).

## Fix

Strip `__mutsu_callable_type` from the captured env in both `capture_closure_env` paths. Genuine WhateverCodes re-install the marker on their **own** env after capture, so they are unaffected; only the erroneous inheritance into inner blocks is removed.

## Impact

Unblocks `Zef::Client` construction — its `recommendation-manager` default runs `%!config<Repository>.tree({\$_}, *.map({ \$_<options>... }))`, which hit exactly this bug. `zef locate`/`info` now advance past the associative-indexing error. `zef --version`/`--help` continue to work.

## Tests

- New `t/whatever-map-topic.t` (8 subtests: single/multi-element lists, arithmetic, hash indexing, nested WhateverCode, grep parity).
- Verified the S02 topic-scoping cases the code comments cite still pass (`do { \$_ = 42; (Int).map(*.new(\$_)) }` → `(42)`; `* ~~ /\$r/` grep-in-`for`).
- Full `make test` PASS (1569 files, 15394 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)