### PR TITLE
fix(compunit): repository-for-name('core') + repo-chain/next-repo methods

### DIFF
--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -49,7 +49,7 @@ impl Interpreter {
                             new_args,
                         ));
                     }
-                    if matches!(name.as_str(), "site" | "home" | "vendor" | "perl")
+                    if matches!(name.as_str(), "site" | "home" | "vendor" | "perl" | "core")
                         && let Some(dir) = Self::default_repo_dir(&name)
                     {
                         let new_args = vec![Value::pair(

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -496,6 +496,41 @@ impl Interpreter {
             {
                 return result;
             }
+            // CompUnit::Repository base methods shared by every repository kind
+            // (FileSystem / Installation / ...). `repo-chain` walks the
+            // `next-repo` links starting at self; mutsu's repositories are not
+            // chained (each `$*REPO` is a standalone repo), so the chain is just
+            // `(self,)` unless a `next-repo` attribute has been set. Without this,
+            // `$*REPO.repo-chain` (zef's `list-installed`) died with
+            // "No such method 'repo-chain'".
+            if class_name.resolve().starts_with("CompUnit::Repository") {
+                match method {
+                    "repo-chain" => {
+                        let mut chain = vec![target.clone()];
+                        let mut cursor = attributes.as_map().get("next-repo").cloned();
+                        while let Some(next) = cursor {
+                            if !next.truthy() {
+                                break;
+                            }
+                            if let ValueView::Instance { attributes, .. } = next.view() {
+                                cursor = attributes.as_map().get("next-repo").cloned();
+                            } else {
+                                cursor = None;
+                            }
+                            chain.push(next);
+                        }
+                        return Ok(Value::array(chain));
+                    }
+                    "next-repo" => {
+                        return Ok(attributes
+                            .as_map()
+                            .get("next-repo")
+                            .cloned()
+                            .unwrap_or(Value::NIL));
+                    }
+                    _ => {}
+                }
+            }
             if class_name == "CompUnit::Repository::Installation"
                 && let Some(result) = self.dispatch_cur_installation_method(
                     &(attributes).as_map(),

--- a/t/compunit-repo-chain.t
+++ b/t/compunit-repo-chain.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# CompUnit::Repository gaps surfaced by loading zef:
+#  - repository-for-name('core') must return a real repository (was Nil), so
+#    `.candidates('CORE')` works (empty, matching rakudo) instead of throwing
+#    "No such method 'candidates' for invocant of type 'Any'".
+#  - every CompUnit::Repository answers `.repo-chain` / `.next-repo` (was
+#    "No such method 'repo-chain'" on a FileSystem repo via `$*REPO.repo-chain`).
+
+plan 8;
+
+# repository-for-name('core')
+{
+    my $core = CompUnit::RepositoryRegistry.repository-for-name('core');
+    ok $core.defined, 'repository-for-name("core") is defined (not Nil)';
+    is $core.^name, 'CompUnit::Repository::Installation', 'core is an Installation repo';
+    is $core.candidates('CORE').elems, 0, 'core .candidates("CORE") is empty (no throw)';
+}
+
+# repo-chain / next-repo on a named repository
+{
+    my $site = CompUnit::RepositoryRegistry.repository-for-name('site');
+    isa-ok $site.repo-chain, List, '.repo-chain returns a List';
+    ok $site.repo-chain.elems >= 1, '.repo-chain contains at least self';
+    ok $site.repo-chain[0] === $site, '.repo-chain starts with self';
+}
+
+# repo-chain on the default $*REPO (a FileSystem repo)
+{
+    my @chain = $*REPO.repo-chain;
+    ok @chain.elems >= 1, '$*REPO.repo-chain has at least one repo';
+    isa-ok @chain[0], CompUnit::Repository, '$*REPO.repo-chain[0] does CompUnit::Repository';
+}


### PR DESCRIPTION
## Problem

Two `CompUnit::Repository` gaps surfaced while constructing `Zef::Client` (loading zef):

1. **`repository-for-name('core')` returned `Nil`.** The handler only recognized `site`/`home`/`vendor`/`perl` (plus `file#`). zef's `Zef::Client` TWEAK runs:
   ```raku
   @!ignore = CompUnit::RepositoryRegistry
       .repository-for-name('core')
       .candidates('CORE')
       .map(*.meta<provides>.keys.Slip)...
   ```
   A `Nil` `'core'` made `.candidates` throw `No such method 'candidates' for invocant of type 'Any'` (and downstream `No such method 'meta' for ... 'Any'`).

2. **No `repo-chain` / `next-repo` method** on any `CompUnit::Repository`, so `$*REPO.repo-chain` (in `Zef::Client.list-installed`) threw `No such method 'repo-chain' for ... CompUnit::Repository::FileSystem`.

## Fix

1. Add `'core'` to the recognized `repository-for-name` names. It now returns a `CompUnit::Repository::Installation` whose `.candidates('CORE')` is empty — matching rakudo.
2. Add shared `repo-chain` / `next-repo` handlers for every `CompUnit::Repository::*` class. `repo-chain` walks `next-repo` links from `self`; mutsu's repositories aren't chained, so it yields `(self,)` (rakudo yields its full 6-repo chain, but a single-repo chain is correct for mutsu's simplified `$*REPO` model). `next-repo` returns the attribute or `Nil`.

## Verification

Both verified in isolation against rakudo:
- `repository-for-name('core').candidates('CORE').elems` → `0` (was a throw)
- `$*REPO.repo-chain` → a `List` starting with `self` (was a throw)

New regression test `t/compunit-repo-chain.t` (8 subtests). Targeted local run of the CompUnit + module + whatever-map tests all PASS; full `make test` + `make roast` delegated to CI.

Advances `zef locate`/`info` past the client-construction crash (the remaining `zef locate` MAIN-dispatch-to-usage behavior is a separate, deeper issue tracked for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)