### PR TITLE
fix(vm): reify a plain `gather` RHS when initializing a typed array

### DIFF
--- a/docs/gc-level1-detailed-design.md
+++ b/docs/gc-level1-detailed-design.md
@@ -538,6 +538,31 @@ Level 1a では **collectable でない**もの:
 
 random は常設 CI に必須ではないが、少なくとも release 前や nightly では回したい。
 
+### 9.3a gc-stress ジョブで観測した失敗ログ
+
+gc-stress ジョブ (`ci.yml` の `gc-stress`: `GC=on` + `MUTSU_GC_EVERY_CANDIDATE=1024`
++ `MUTSU_GC_VERIFY=1` + `MUTSU_ROAST_TIMEOUT_SCALE=2`) は BLOCKING ゲートなので、
+失敗したら「flaky だから再実行」で済ませず、必ず原因を分類してここに記録する。
+
+分類の指針:
+
+- **`VERIFY FAIL` が出た** → heap corruption。GC の本物のバグ。最優先で修正。
+- **`exit 124` + `Failed: 0` (Bad plan, planned N ran M<N)** → per-file timeout。
+  corruption ではない。標準単独実行では通るのに `prove -j4` の並列 CPU 競合下で
+  budget を超えたスレッド多用テスト、というのが典型。`VERIFY FAIL` は出ていないこと
+  を確認したうえで、対象テストの単独実行時間を release + GC-on 設定で測り、負荷 timeout
+  なら `run-roast-test.sh` の per-file timeout を引き上げる。
+- **具体 subtest の `not ok`** → GC のロジック回帰の可能性が高い。単独再現して調査。
+
+観測記録:
+
+- **2026-07-08, PR #4325 (fix-typed-array-gather-init):** `roast/S17-promise/start.t`
+  が `exit 124` (planned 65 / ran 49) で timeout。PR 内容 (typed array の gather init)
+  とは無関係。`VERIFY FAIL` なし。release + GC-on 設定の単独実行では 65/65 pass・~7.5s
+  で安定して通る (3 回計測)。原因は `^300` 個の `start` ブロック生成が `prove -j4` の
+  並列負荷下で 60s (=30s×2) budget を超過したこと。対策として `run-roast-test.sh` で
+  `start.t` の per-file timeout を 60 (scale 後 120) に引き上げた。GC 回帰ではない。
+
 ### 9.4 GC ログは必須
 
 GC はログなしでは壊れたときに追跡不能になる。最初から段階別ログを入れる。

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -28,6 +28,16 @@ per_file_timeout() {
       # This test uses sleep 2*$_ with $_ up to 9, parallel start blocks take ~18s.
       echo 60
       ;;
+    roast/S17-promise/start.t)
+      # Spawns ^300 `start` blocks plus several `sleep 1` waits. Standalone it
+      # runs in ~7.5s even under the gc-stress config (GC=on + VERIFY, release),
+      # but under `prove -j4` the 300-thread spawn contends for cores with the
+      # other three roast processes and blew the default 30s (x2 = 60s under
+      # MUTSU_ROAST_TIMEOUT_SCALE) budget at 49/65 tests. Give it explicit
+      # headroom so parallel CPU contention can't time it out. See
+      # docs/gc-level1-detailed-design.md 9.3a.
+      echo 60
+      ;;
     roast/S29-context/sleep.t)
       # This test has four 3-second sleep calls plus a subprocess, totalling ~18s locally
       # and potentially more on slower CI machines.

--- a/src/vm/vm_misc_typecheck.rs
+++ b/src/vm/vm_misc_typecheck.rs
@@ -18,9 +18,25 @@ impl Interpreter {
         let declared_constraint = base_constraint
             .split_once('(')
             .map_or(base_constraint, |(target, _)| target);
-        let value = self.stack.last().expect("TypeCheck: empty stack").clone();
+        let mut value = self.stack.last().expect("TypeCheck: empty stack").clone();
         if var_name.is_some_and(|name| name.starts_with('%')) {
             return Ok(());
+        }
+        // A *non-lazy* lazy-positional RHS (e.g. a plain `gather` coroutine, whose
+        // view is `LazyList`, not `Array`/`Seq`) is reified here so both native and
+        // boxed typed arrays check/coerce its elements through the normal eager-list
+        // paths below. A single-shot coroutine must be reified exactly once, so
+        // replace the stack value too (the later SetLocal reuses it). A *genuinely*
+        // lazy list is left untouched: native arrays reject it just below as
+        // X::Cannot::Lazy, and boxed arrays keep it lazy (Rakudo checks its
+        // elements only when reified at access time).
+        if var_name.is_some_and(|name| name.starts_with('@'))
+            && let ValueView::LazyList(list) = value.view()
+            && !list.is_genuinely_lazy()
+        {
+            let items = self.force_lazy_list_vm(list)?;
+            value = Value::real_array(items);
+            *self.stack.last_mut().unwrap() = value.clone();
         }
         // Lazy values cannot be stored in native typed arrays
         if var_name.is_some_and(|name| name.starts_with('@'))
@@ -40,6 +56,13 @@ impl Interpreter {
                 .into_iter()
                 .collect(),
             ));
+        }
+        // A genuinely-lazy list bound to a *boxed* typed array stays lazy; accept it
+        // without eager element checking (its elements are checked on reification).
+        if var_name.is_some_and(|name| name.starts_with('@'))
+            && matches!(value.view(), ValueView::LazyList(_))
+        {
+            return Ok(());
         }
         if var_name.is_some_and(|name| name.starts_with('@'))
             && matches!(value.view(), ValueView::Array(..) | ValueView::Seq(_))

--- a/t/typed-array-gather-init.t
+++ b/t/typed-array-gather-init.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# Regression: initializing a typed array from a `gather` block.
+#
+# A plain `gather { ... }` produces a lazy-list value (not an eager Array/Seq).
+# The typed-array TypeCheck path only element-checked Array/Seq values, so a
+# gather RHS fell through to the *scalar* type-check and blew up with
+# "Type check failed in assignment to @a; expected Int, got Array".
+# (This is what made `zef locate ...` fall through to the CLI usage banner:
+#  Zef::Client.resolve builds `my Candidate @results = gather {...}`.)
+
+plan 11;
+
+# Boxed element type, plain gather -> reified and element-checked.
+{
+    my Int @a = gather { take 1; take 2; take 3 };
+    is @a.elems, 3, 'my Int @a = gather {...}: element count';
+    is @a.join(','), '1,2,3', 'my Int @a = gather {...}: values';
+    ok @a[0] ~~ Int, 'my Int @a = gather {...}: elements are Int';
+}
+
+# Str element type.
+{
+    my Str @s = gather { take 'x'; take 'y' };
+    is @s.join(','), 'x,y', 'my Str @s = gather {...} works';
+}
+
+# Native element type: a plain gather is NOT lazy, so it reifies (no X::Cannot::Lazy).
+{
+    my int @n = gather { take 3; take 4 };
+    is @n.join(','), '3,4', 'my int @n = gather {...} reifies into a native array';
+    is @n.elems, 2, 'my int @n = gather {...}: element count';
+}
+
+# Untyped array still works (control).
+{
+    my @m = gather { take 5 };
+    is @m.join(','), '5', 'my @m = gather {...} (untyped) works';
+}
+
+# A gather whose taken value violates the element type must throw
+# X::TypeCheck::Assignment naming the offending element, not "got Array".
+{
+    my $ex;
+    { my Int @e = gather { take 1; take 'oops' }; CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::TypeCheck::Assignment, 'element type mismatch in gather RHS throws X::TypeCheck::Assignment';
+}
+
+# lazy gather: boxed array stays lazy (elements accessible on demand).
+{
+    my Int @b = lazy gather { take 10; take 20 };
+    is @b[0], 10, 'lazy gather into Int @b: first element';
+    is @b[1], 20, 'lazy gather into Int @b: second element';
+}
+
+# lazy gather into a native array is rejected as X::Cannot::Lazy.
+{
+    my $ex;
+    { my int @c = lazy gather { take 7 }; CATCH { default { $ex = $_ } } };
+    isa-ok $ex, X::Cannot::Lazy, 'lazy gather into native array throws X::Cannot::Lazy';
+}


### PR DESCRIPTION
## Summary

`my Int @a = gather { take 1; take 2 }` failed with:

```
Type check failed in assignment to @a; expected Int, got Array
```

A plain `gather { ... }` evaluates to a **lazy-list** value — its `.view()` is `LazyList`, not `Array`/`Seq`. The typed-array `TypeCheck` op only element-checked `Array`/`Seq` RHS values, so a gather result fell through to the **scalar** type-check, which checked the whole lazy list against the element type and reported "got Array". `map`/`grep` were unaffected because they return `Seq`.

## Fix

In `exec_type_check_op_inner`, reify a non-genuinely-lazy `LazyList` (a plain `gather`) into an eager array **once**, replacing the stack value so the later `SetLocal` does not re-consume the single-shot coroutine, then element-check it through the normal path.

- native + plain gather → reifies (matches Rakudo, no more spurious `X::Cannot::Lazy`)
- boxed + plain gather → reifies + element-checks (element mismatch → `X::TypeCheck::Assignment` naming the element)
- native + `lazy gather` → still `X::Cannot::Lazy`
- boxed + `lazy gather` → stays lazy

All four behaviors now match `raku`.

## How this was found

`zef locate <id>` fell through to the CLI usage banner instead of printing "Nothing located". Root cause: `Zef::Client.resolve` builds `my Candidate @results = gather {...}`; the typed-array init blew up mid-method, and the escaping error surfaced as auto-MAIN usage. (Earlier sessions misdiagnosed this as a MAIN multi-dispatch / `@*ARGS` binding problem — dispatch was fine; the method body threw.)

## Tests

- New `t/typed-array-gather-init.t` (11 subtests), passes on both `raku` and `mutsu`.
- `make test`: all 1571 files / 15413 tests pass.
- Targeted roast: `S09-typed-arrays/{arrays,native-int,native-str}.t`, `S02-types/array.t`, `S04-statement-modifiers/for.t` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA