### PR TITLE
fix(supply): live grep/map forwarding + react emit-order delivery (syntax.t test 90)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -343,13 +343,18 @@ S17-promise/start.t、S07-hyperrace/basics.t、S17-lowlevel/cas-int.t、S17-lowl
 
 ### 6.2 `S17-supply/syntax.t`
 
-- **現状**: 88/90（test 75, 90 が失敗）。根本原因分析は `TODO_roast/S17.md` に記録済み:
+- **現状**: 88/90（test 75, 53 が失敗。**test 90 は 2026-07-08 に修正済み**）。
+  根本原因分析は `TODO_roast/S17.md` に記録済み:
+  - **test 90 (FIXED)**: live `Supply.grep`/`.map` 転送タップ + react loop の
+    supplier pre-drain（emit-before-done 順序保証）+ グローバル emit 順マージ
+    （`emit_seqs` で sibling `whenever $s.grep(...)` を emit 順に interleave）で
+    決定的に通過。pin=`t/supply-live-grep-map-react-order.t`。
   - test 75: nested `whenever`（on-demand supply が `whenever Supply.interval {}` の
-    内側にある場合）は react loop でなく非-react tap 経路（`native_supply_mut`
-    tap/act）を通るため、その async body 完了時の `on_close_callbacks` 発火が
-    react-loop 側の仕組みに乗らない。
-  - test 90: 2 つの `whenever` がそれぞれ `last` する cross-whenever ordering — hard case、
-    据え置き。
+    内側にある場合）の `closing => { $closed++ }` が cross-thread plain-scalar
+    writeback（worker→main lexical）で伝播しない別軸（§4.1/§4.2 thread-capture gap、
+    lock.t 10-24 と同じ）。cross-thread-lexical campaign 待ち。
+  - test 53: `supply {}` の whenever 相互排他順序 race（full-file parallel load 下のみ
+    flaky、単体では 6/6 pass）。
 - **Canary**: `roast/S17-supply/syntax.t`
 
 ### 6.3 async IO / Proc::Async / socket supplies（変化なし）

--- a/TODO_roast/S17.md
+++ b/TODO_roast/S17.md
@@ -258,23 +258,30 @@
 - [ ] roast/S17-supply/supplier-preserving.t
 - [ ] roast/S17-supply/syntax-nonblocking-await.t
 - [ ] roast/S17-supply/syntax.t
-  - Status 2026-07-01 (post #4035, prove x3): three tests still block whitelist,
-    none a clean single fix:
-    - **test 90** — fails 3/3 (deterministic). Needs 3 independent react/supply
-      features (thread-fed supplier delivery, grep/map forwarding on a live
-      supply, drain-on-done); see the test-90 breakdown below. Hard, deferred.
-    - **test 75** — now FLAKY (~1/3 pass) after #4035 made the `closing` callback
-      fire via the `.tap` path. The remaining non-determinism is the cross-thread
-      plain-scalar writeback of `$closed++` (a worker-thread write to a main
-      lexical only sometimes propagates) — the §4.1/§4.2 thread-capture gap
-      (same as lock.t 10-24). Deferred.
+  - Status 2026-07-08: **test 90 FIXED** (deterministic, 10/10 in isolation). The
+    three features it needed all landed: (a) live `Supply.grep`/`Supply.map`
+    forwarding — a Supplier-backed `.grep`/`.map` now registers a transform tap on
+    the source and forwards filtered/mapped values to a live derived supply
+    (`register_supplier_transform_tap` + `handle_supply_transform_emit`); (b) the
+    react drive loop pre-drains supplier subscriptions before running a
+    receiver-source (`start`/Promise) consumer, so values emitted before a sibling
+    `done` are still delivered (Raku ordering guarantee); (c) supplier emits carry
+    a global sequence number (`emit_seqs`) so `drain_supplier_subs_ordered` merges
+    sibling `whenever $s.grep(...)` supplies into global emit order rather than
+    draining one fully before the next. Pin: `t/supply-live-grep-map-react-order.t`.
+    Two tests still block whitelist:
+    - **test 75** — FLAKY→now fails deterministically (0/6 in isolation). Nested
+      `whenever $sod {}` on-demand supply with a `closing => { $closed++ }`
+      callback: the `$closed++` is a cross-thread plain-scalar writeback (a
+      worker-thread write to a main lexical) — the §4.1/§4.2 thread-capture gap
+      (same as lock.t 10-24). Separate cross-thread-lexical campaign. Deferred.
     - **test 53** — FLAKY (~2/3 fail under prove load). `supply {}` whenever
       mutual-exclusion ordering race (two `start`-thread emits into two whenevers;
       the "only one whenever at a time" guarantee is not enforced, so the emit
-      order into `@collected` races). The minimal repro passes 20/20 in isolation;
+      order into `@collected` races). The minimal repro passes 6/6 in isolation;
       the flake shows up only under the full-file / parallel load. Deferred.
-    Whitelisting requires all three deterministic PLUS the 2000-react
-    interval-done stress (lines 543-550) — multi-PR deep concurrency work.
+    Whitelisting requires test 75 (cross-thread scalar writeback) PLUS the
+    2000-react interval-done stress (lines 543-550) — multi-PR deep concurrency work.
   - test 57 (multiple channels in whenever blocks, cross-whenever `$order`
     accumulation): **FIXED** — a `whenever` callback shares the enclosing react
     block's lexicals, but each closure call persisted its captured-outer free vars

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -285,6 +285,28 @@ impl Interpreter {
                 self.dispatch_join_method(target, args)
             }
             "grep" => {
+                // `Supply.grep` on a *live* (Supplier-backed) supply must stay
+                // live: register a filter transform tap that forwards matching
+                // values to a derived supply. A materialized supply
+                // (`Supply.from-list`, on-demand) falls through to `dispatch_grep`
+                // below, which already filters its buffered values with correct
+                // smart-match semantics (grep(Int)/grep(/rx/) etc.).
+                if let ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } = target.view()
+                    && class_name == "Supply"
+                    && crate::runtime::native_methods::supplier_id_from_attrs(&attributes.as_map())
+                        .is_some()
+                {
+                    let matcher = args.first().cloned().unwrap_or(Value::NIL);
+                    if let Some(live) =
+                        self.make_live_transform_supply(&attributes.as_map(), matcher, true)
+                    {
+                        return Some(Ok(live));
+                    }
+                }
                 // In Raku, `.grep` always returns a `Seq` — including over an
                 // Array. `dispatch_grep` builds a `List`-kind array whose elements
                 // are the matched source slots as shared `ContainerRef` cells (so a

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -454,6 +454,11 @@ impl Interpreter {
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let mapper = args.first().cloned().unwrap_or(Value::NIL);
+        // Live (Supplier-backed) supply: register a transform tap so the map
+        // stays live and forwards each mapped value to the derived supply.
+        if let Some(live) = self.make_live_transform_supply(attributes, mapper.clone(), false) {
+            return Ok(live);
+        }
         let source_values = if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
             let emitter = Value::make_instance(Symbol::intern("Supplier"), {
                 let mut a = HashMap::new();
@@ -481,6 +486,33 @@ impl Interpreter {
             attributes.get("live").cloned().unwrap_or(Value::FALSE),
         );
         Ok(Value::make_instance(Symbol::intern("Supply"), attrs))
+    }
+
+    /// If `attributes` describes a live (Supplier-backed) supply, register a
+    /// `grep`/`map` transform tap on it and return a new live derived Supply
+    /// that receives the filtered/mapped values. Returns `None` for a
+    /// materialized (snapshot) supply so the caller applies the transform
+    /// eagerly instead.
+    pub(super) fn make_live_transform_supply(
+        &mut self,
+        attributes: &HashMap<String, Value>,
+        callable: Value,
+        is_grep: bool,
+    ) -> Option<Value> {
+        let source_sid = crate::runtime::native_methods::supplier_id_from_attrs(attributes)?;
+        let downstream_sid = crate::runtime::native_methods::next_supplier_id();
+        crate::runtime::native_methods::register_supplier_transform_tap(
+            source_sid,
+            downstream_sid,
+            callable,
+            is_grep,
+        );
+        let mut new_attrs = HashMap::new();
+        new_attrs.insert("values".to_string(), Value::array(Vec::new()));
+        new_attrs.insert("taps".to_string(), Value::array(Vec::new()));
+        new_attrs.insert("supplier_id".to_string(), Value::int(downstream_sid as i64));
+        new_attrs.insert("live".to_string(), Value::TRUE);
+        Some(Value::make_instance(Symbol::intern("Supply"), new_attrs))
     }
 
     /// Handle Supply.reduce method
@@ -584,6 +616,30 @@ impl Interpreter {
                 Self::sleep_for_supply_delay(delay_seconds);
                 self.call_sub_value(tap, vec![emitted], true)?;
             }
+        }
+        Ok(())
+    }
+
+    /// Handle a `grep`/`map` transform tap emission on a live supply: run the
+    /// callable on the value, then forward the (filtered or mapped) result to
+    /// the downstream supplier and drive its taps.
+    pub(in crate::runtime) fn handle_supply_transform_emit(
+        &mut self,
+        downstream_supplier_id: u64,
+        callable: Value,
+        is_grep: bool,
+        value: Value,
+    ) -> Result<(), RuntimeError> {
+        if is_grep {
+            // `grep` uses smart-match semantics (`$_ ~~ matcher`), so a Callable
+            // is called, a type object type-checks, a Regex matches, etc.
+            let keep = self.smart_match_values(&value, &callable);
+            if keep {
+                self.handle_supply_forward(downstream_supplier_id, value)?;
+            }
+        } else {
+            let mapped = self.call_sub_value(callable, vec![value], true)?;
+            self.handle_supply_forward(downstream_supplier_id, mapped)?;
         }
         Ok(())
     }

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -38,7 +38,8 @@ pub(in crate::runtime) use state::{
 };
 // Supplier registry accessors driven by the VM-side react/supply loop.
 pub(crate) use state::{
-    next_supplier_id, supplier_register_promise, supplier_snapshot, take_promise_combinator_sources,
+    next_supplier_id, supplier_register_promise, supplier_snapshot, supplier_snapshot_seqs,
+    take_promise_combinator_sources,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
 pub(in crate::runtime) use state_lock::next_semaphore_id;
@@ -50,21 +51,21 @@ pub(in crate::runtime) use state_supplier::{
     close_supplier_channel_taps, create_whenever_done_group, flush_supplier_batch_taps,
     flush_supplier_line_taps, flush_supplier_words_taps, get_classify_state,
     get_classify_sub_supplier_ids, get_start_output_supplier_ids,
-    get_supplier_zip_latest_state_ids, get_supplier_zip_state_ids, last_supplier_tap_id,
-    migrate_switch_inner, register_supplier_batch_tap, register_supplier_channel_tap,
-    register_supplier_classify_tap, register_supplier_close_callback,
-    register_supplier_done_callback, register_supplier_elems_tap, register_supplier_flat_tap,
-    register_supplier_lines_tap, register_supplier_migrate_tap, register_supplier_produce_tap,
-    register_supplier_quit_callback, register_supplier_start_tap, register_supplier_tap,
-    register_supplier_tap_with_head_limit, register_supplier_unique_tap,
-    register_supplier_whenever_quit_callback, register_supplier_words_tap,
-    register_supplier_zip_latest_tap, register_supplier_zip_tap, register_zip_latest_state,
-    register_zip_state, supplier_done_count, supplier_emit_callbacks, supplier_produce_update_acc,
-    supplier_tap_count, supplier_unique_get_seen, supplier_unique_mark_seen,
-    take_supplier_close_callbacks, take_supplier_done_callbacks, take_supplier_quit_callbacks,
-    take_supplier_whenever_quit_callbacks, update_classify_state, whenever_done_group_decrement,
-    zip_buffer_value, zip_latest_buffer_value, zip_latest_source_done, zip_latest_state_info,
-    zip_source_done, zip_state_info,
+    get_supplier_zip_latest_state_ids, get_supplier_zip_state_ids,
+    get_transform_output_supplier_ids, last_supplier_tap_id, migrate_switch_inner,
+    register_supplier_batch_tap, register_supplier_channel_tap, register_supplier_classify_tap,
+    register_supplier_close_callback, register_supplier_done_callback, register_supplier_elems_tap,
+    register_supplier_flat_tap, register_supplier_lines_tap, register_supplier_migrate_tap,
+    register_supplier_produce_tap, register_supplier_quit_callback, register_supplier_start_tap,
+    register_supplier_tap, register_supplier_tap_with_head_limit, register_supplier_transform_tap,
+    register_supplier_unique_tap, register_supplier_whenever_quit_callback,
+    register_supplier_words_tap, register_supplier_zip_latest_tap, register_supplier_zip_tap,
+    register_zip_latest_state, register_zip_state, supplier_done_count, supplier_emit_callbacks,
+    supplier_produce_update_acc, supplier_tap_count, supplier_unique_get_seen,
+    supplier_unique_mark_seen, take_supplier_close_callbacks, take_supplier_done_callbacks,
+    take_supplier_quit_callbacks, take_supplier_whenever_quit_callbacks, update_classify_state,
+    whenever_done_group_decrement, zip_buffer_value, zip_latest_buffer_value,
+    zip_latest_source_done, zip_latest_state_info, zip_source_done, zip_state_info,
 };
 
 use super::*;

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -191,6 +191,19 @@ impl Interpreter {
                 } => {
                     self.handle_supply_forward(downstream_supplier_id, val)?;
                 }
+                SupplierEmitAction::TransformCall {
+                    downstream_supplier_id,
+                    callable,
+                    is_grep,
+                    value: val,
+                } => {
+                    self.handle_supply_transform_emit(
+                        downstream_supplier_id,
+                        callable,
+                        is_grep,
+                        val,
+                    )?;
+                }
             }
         }
         Ok(())

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -159,9 +159,22 @@ pub(in crate::runtime) fn supply_channel_map_pub()
 #[derive(Debug, Default)]
 struct SupplierRuntimeState {
     emitted: Vec<Value>,
+    /// Global monotonic sequence number for each emitted value, parallel to
+    /// `emitted`. Assigned at `emit` time from a process-wide counter so the
+    /// react drive loop can merge values from several supplier-backed
+    /// subscriptions (e.g. two `whenever $s.grep(...)` derived supplies) back
+    /// into their original cross-supplier emit order.
+    emit_seqs: Vec<u64>,
     done: bool,
     quit_reason: Option<Value>,
     pending_promises: Vec<SharedPromise>,
+}
+
+/// Process-wide monotonic counter handing out an emit sequence number for every
+/// `supplier_emit`, so cross-supplier delivery order can be reconstructed.
+pub(crate) fn next_emit_seq() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 type SupplierStateMap = std::sync::Mutex<HashMap<u64, SupplierRuntimeState>>;
@@ -329,12 +342,32 @@ pub(crate) fn supplier_register_promise(supplier_id: u64, promise: SharedPromise
 }
 
 pub(in crate::runtime) fn supplier_emit(supplier_id: u64, value: Value) {
+    let seq = next_emit_seq();
     if let Ok(mut map) = supplier_state_map().lock() {
         let state = map.entry(supplier_id).or_default();
         if state.done || state.quit_reason.is_some() {
             return;
         }
         state.emitted.push(value);
+        state.emit_seqs.push(seq);
+    }
+}
+
+/// Like [`supplier_snapshot`], but also returns the per-value emit sequence
+/// numbers (parallel to the values), for cross-supplier order reconstruction.
+pub(crate) fn supplier_snapshot_seqs(
+    supplier_id: u64,
+) -> (Vec<Value>, Vec<u64>, bool, Option<Value>) {
+    if let Ok(mut map) = supplier_state_map().lock() {
+        let state = map.entry(supplier_id).or_default();
+        (
+            state.emitted.clone(),
+            state.emit_seqs.clone(),
+            state.done,
+            state.quit_reason.clone(),
+        )
+    } else {
+        (Vec::new(), Vec::new(), false, None)
     }
 }
 
@@ -395,6 +428,7 @@ pub(in crate::runtime) fn supplier_reset(supplier_id: u64) {
         state.done = false;
         state.quit_reason = None;
         state.emitted.clear();
+        state.emit_seqs.clear();
     }
 }
 

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -72,10 +72,27 @@ struct SupplierTapSubscription {
     /// supplier (used by `migrate` to pipe the currently-active inner supply
     /// into the migrate output supplier).
     forward_downstream: Option<u64>,
+    /// Transform tap: each emitted value is passed through a `grep`/`map`
+    /// callable and the (filtered or mapped) result is re-emitted to a
+    /// downstream supplier. Used by `Supply.grep`/`Supply.map` on a live
+    /// (Supplier-backed) supply so the transform stays live rather than
+    /// snapshotting the source.
+    transform_state: Option<TransformState>,
     /// Stable identifier so taps can be closed individually.
     tap_id: u64,
     /// When set, this tap is closed and should no longer receive emits.
     closed: bool,
+}
+
+#[derive(Clone)]
+struct TransformState {
+    /// The `grep`/`map` callable applied to each emitted value.
+    callable: Value,
+    /// `true` for `grep` (filter: forward the original value when the callable
+    /// is truthy), `false` for `map` (forward the callable's return value).
+    is_grep: bool,
+    /// The downstream supplier that receives the forwarded/transformed values.
+    downstream_supplier_id: u64,
 }
 
 #[derive(Clone)]
@@ -243,6 +260,7 @@ pub(in crate::runtime) fn register_supplier_migrate_tap(master_sid: u64, downstr
                     current_inner_tap_id: None,
                 }),
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -279,6 +297,7 @@ fn register_supplier_forward_tap(inner_sid: u64, downstream_sid: u64) -> u64 {
                 closed: false,
                 migrate_state: None,
                 forward_downstream: Some(downstream_sid),
+                transform_state: None,
             });
     }
     tap_id
@@ -379,6 +398,7 @@ pub(in crate::runtime) fn register_supplier_channel_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -432,6 +452,7 @@ pub(in crate::runtime) fn register_supplier_tap(supplier_id: u64, tap: Value, de
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -470,6 +491,7 @@ pub(in crate::runtime) fn register_supplier_tap_with_head_limit(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -508,6 +530,7 @@ pub(in crate::runtime) fn register_supplier_lines_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -545,6 +568,7 @@ pub(in crate::runtime) fn register_supplier_words_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -589,6 +613,7 @@ pub(in crate::runtime) fn register_supplier_elems_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -663,6 +688,15 @@ pub(in crate::runtime) enum SupplierEmitAction {
     /// Forward: re-emit a value verbatim to the given downstream supplier.
     ForwardEmit {
         downstream_supplier_id: u64,
+        value: Value,
+    },
+    /// Transform: run the `grep`/`map` callable on the value, then forward the
+    /// (filtered or mapped) result to the downstream supplier. Needs the
+    /// interpreter to invoke the callable.
+    TransformCall {
+        downstream_supplier_id: u64,
+        callable: Value,
+        is_grep: bool,
         value: Value,
     },
 }
@@ -865,6 +899,13 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                     downstream_supplier_id: downstream_sid,
                     value: emitted_value.clone(),
                 });
+            } else if let Some(ref ts) = tap.transform_state {
+                actions.push(SupplierEmitAction::TransformCall {
+                    downstream_supplier_id: ts.downstream_supplier_id,
+                    callable: ts.callable.clone(),
+                    is_grep: ts.is_grep,
+                    value: emitted_value.clone(),
+                });
             } else {
                 actions.push(SupplierEmitAction::Call(
                     tap.callback.clone(),
@@ -958,6 +999,7 @@ pub(in crate::runtime) fn register_supplier_unique_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -999,6 +1041,7 @@ pub(in crate::runtime) fn register_supplier_produce_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -1042,6 +1085,7 @@ pub(in crate::runtime) fn register_supplier_start_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -1127,6 +1171,7 @@ pub(in crate::runtime) fn register_supplier_classify_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -1410,6 +1455,7 @@ pub(in crate::runtime) fn register_supplier_batch_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -1449,8 +1495,72 @@ pub(in crate::runtime) fn register_supplier_flat_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
+}
+
+/// Register a `grep`/`map` transform tap on a live supplier: each emitted value
+/// is passed through `callable` and the result forwarded to
+/// `downstream_supplier_id` (for `grep`, the original value is forwarded when
+/// the callable is truthy; for `map`, the callable's return value is forwarded).
+pub(in crate::runtime) fn register_supplier_transform_tap(
+    supplier_id: u64,
+    downstream_supplier_id: u64,
+    callable: Value,
+    is_grep: bool,
+) {
+    if let Ok(mut map) = supplier_subscriptions_map().lock() {
+        map.entry(supplier_id)
+            .or_default()
+            .taps
+            .push(SupplierTapSubscription {
+                callback: Value::NIL,
+                line_mode: false,
+                line_chomp: true,
+                line_buffer: String::new(),
+                delay_seconds: 0.0,
+                unique_filter: None,
+                classify_state: None,
+                elems_trace: None,
+                head_limit: None,
+                head_count: 0,
+                produce_state: None,
+                start_state: None,
+                batch_state: None,
+                words_mode: false,
+                words_buffer: String::new(),
+                flat_downstream: None,
+                channel_sink: None,
+                zip_tap: None,
+                zip_latest_tap: None,
+                tap_id: next_tap_id(),
+                closed: false,
+                migrate_state: None,
+                forward_downstream: None,
+                transform_state: Some(TransformState {
+                    callable,
+                    is_grep,
+                    downstream_supplier_id,
+                }),
+            });
+    }
+}
+
+/// Get the downstream supplier ids of all `grep`/`map` transform taps on this
+/// supplier, so a source `done` can be propagated to the derived supplies.
+pub(in crate::runtime) fn get_transform_output_supplier_ids(supplier_id: u64) -> Vec<u64> {
+    let mut result = Vec::new();
+    if let Ok(map) = supplier_subscriptions_map().lock()
+        && let Some(subs) = map.get(&supplier_id)
+    {
+        for tap in &subs.taps {
+            if let Some(ref ts) = tap.transform_state {
+                result.push(ts.downstream_supplier_id);
+            }
+        }
+    }
+    result
 }
 
 /// Flush any remaining values in batch tap buffers when the supplier is done.
@@ -1538,6 +1648,7 @@ pub(in crate::runtime) fn register_supplier_zip_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }
@@ -1578,6 +1689,7 @@ pub(in crate::runtime) fn register_supplier_zip_latest_tap(
                 closed: false,
                 migrate_state: None,
                 forward_downstream: None,
+                transform_state: None,
             });
     }
 }

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -277,6 +277,19 @@ impl Interpreter {
                             } => {
                                 self.handle_supply_forward(downstream_supplier_id, val)?;
                             }
+                            SupplierEmitAction::TransformCall {
+                                downstream_supplier_id,
+                                callable,
+                                is_grep,
+                                value: val,
+                            } => {
+                                self.handle_supply_transform_emit(
+                                    downstream_supplier_id,
+                                    callable,
+                                    is_grep,
+                                    val,
+                                )?;
+                            }
                         }
                     }
                 }
@@ -319,6 +332,13 @@ impl Interpreter {
                     }
                     // Propagate done to start-transform output suppliers
                     for out_sid in get_start_output_supplier_ids(supplier_id) {
+                        supplier_done(out_sid);
+                        for done_cb in take_supplier_done_callbacks(out_sid) {
+                            let _ = self.invoke_done_callback(done_cb);
+                        }
+                    }
+                    // Propagate done to grep/map transform output suppliers
+                    for out_sid in get_transform_output_supplier_ids(supplier_id) {
                         supplier_done(out_sid);
                         for done_cb in take_supplier_done_callbacks(out_sid) {
                             let _ = self.invoke_done_callback(done_cb);
@@ -667,6 +687,19 @@ impl Interpreter {
                             } => {
                                 self.handle_supply_forward(downstream_supplier_id, val)?;
                             }
+                            SupplierEmitAction::TransformCall {
+                                downstream_supplier_id,
+                                callable,
+                                is_grep,
+                                value: val,
+                            } => {
+                                self.handle_supply_transform_emit(
+                                    downstream_supplier_id,
+                                    callable,
+                                    is_grep,
+                                    val,
+                                )?;
+                            }
                         }
                     }
                 }
@@ -719,6 +752,13 @@ impl Interpreter {
                     }
                     // Propagate done to start-transform output suppliers
                     for out_sid in get_start_output_supplier_ids(sid) {
+                        supplier_done(out_sid);
+                        for done_cb in take_supplier_done_callbacks(out_sid) {
+                            let _ = self.invoke_done_callback(done_cb);
+                        }
+                    }
+                    // Propagate done to grep/map transform output suppliers
+                    for out_sid in get_transform_output_supplier_ids(sid) {
                         supplier_done(out_sid);
                         for done_cb in take_supplier_done_callbacks(out_sid) {
                             let _ = self.invoke_done_callback(done_cb);

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -2,13 +2,148 @@
 //! split from `vm_react_loop` (§7-8 file split).
 use super::*;
 use crate::runtime::native_methods::{
-    SupplyEvent, supplier_snapshot, take_promise_combinator_sources,
+    SupplyEvent, supplier_snapshot_seqs, take_promise_combinator_sources,
 };
 use crate::runtime::subtest::{ReactSubscription, SupplyDrivePolicy};
 use std::sync::mpsc;
 use std::time::Duration;
 
 impl Interpreter {
+    /// Deliver every value currently buffered across all supplier-backed
+    /// subscriptions to their `whenever` consumers, merged into a single global
+    /// emit order (by each value's emit sequence number), then honour any
+    /// per-supplier `done`/`quit` signals. Returns `Ok(true)` if a consumer
+    /// raised react `done`; propagates `Err` for an unhandled supplier `quit`.
+    ///
+    /// Global-order merge (rather than draining one supplier fully before the
+    /// next) is what makes sibling `whenever $s.grep(...)` derived supplies
+    /// interleave the way Raku delivers them — each value reaches its consumer
+    /// in the order it was `emit`ted into the source, across suppliers. It also
+    /// honours Raku's ordering guarantee that values emitted before a later
+    /// terminating event are still delivered, since the polling loop calls this
+    /// both at the top of each iteration and just before running a receiver
+    /// (Promise / `start`) source's consumer.
+    fn drain_supplier_subs_ordered(
+        &mut self,
+        react_subs: &mut [ReactSubscription],
+    ) -> Result<bool, RuntimeError> {
+        // Deliver the globally-earliest pending value, one at a time; re-scan
+        // each round because a consumer may emit more or mark subs done.
+        loop {
+            let mut best: Option<(u64, usize, Value)> = None;
+            for (i, sub) in react_subs.iter().enumerate() {
+                if sub.done {
+                    continue;
+                }
+                let Some(sid) = sub.supplier_id else {
+                    continue;
+                };
+                if let Some(limit) = sub.head_limit
+                    && sub.emit_count >= limit
+                {
+                    continue;
+                }
+                let (values, seqs, _done, _quit) = supplier_snapshot_seqs(sid);
+                let idx = sub.supplier_next_index;
+                if idx < values.len() {
+                    let seq = seqs.get(idx).copied().unwrap_or(0);
+                    if best.as_ref().is_none_or(|(bseq, _, _)| seq < *bseq) {
+                        best = Some((seq, i, values[idx].clone()));
+                    }
+                }
+            }
+            let Some((_seq, i, value)) = best else {
+                break;
+            };
+            react_subs[i].supplier_next_index += 1;
+            if react_subs[i].is_lines {
+                let chunk = value.to_string_value();
+                react_subs[i].line_buffer.push_str(&chunk);
+                while let Some(pos) = react_subs[i].line_buffer.find('\n') {
+                    let line = react_subs[i].line_buffer[..pos].to_string();
+                    react_subs[i].line_buffer = react_subs[i].line_buffer[pos + 1..].to_string();
+                    if self.run_react_consumer(&mut react_subs[i], Value::str(line))? {
+                        return Ok(true);
+                    }
+                    if react_subs[i].done {
+                        break;
+                    }
+                    react_subs[i].emit_count += 1;
+                    if self.head_limit_reached(&mut react_subs[i])? {
+                        break;
+                    }
+                }
+            } else {
+                if self.run_react_consumer(&mut react_subs[i], value)? {
+                    return Ok(true);
+                }
+                if !react_subs[i].done {
+                    react_subs[i].emit_count += 1;
+                    self.head_limit_reached(&mut react_subs[i])?;
+                }
+            }
+        }
+        // All pending values delivered — now honour per-supplier done/quit.
+        for i in 0..react_subs.len() {
+            if react_subs[i].done {
+                continue;
+            }
+            let Some(sid) = react_subs[i].supplier_id else {
+                continue;
+            };
+            let (values, _seqs, done, quit) = supplier_snapshot_seqs(sid);
+            if react_subs[i].supplier_next_index < values.len() {
+                continue;
+            }
+            if let Some(error) = quit {
+                let mut handled = false;
+                for quit_cb in react_subs[i].quit_callbacks.clone() {
+                    self.call_supply_quit_handler(quit_cb, error.clone())?;
+                    handled = true;
+                }
+                if handled {
+                    react_subs[i].done = true;
+                    continue;
+                }
+                Self::run_react_close_callbacks(self, react_subs);
+                let quit_err = crate::runtime::Interpreter::runtime_error_from_supply_reason(error);
+                return Err(crate::runtime::Interpreter::wrap_react_died(quit_err));
+            }
+            if done {
+                if react_subs[i].is_lines && !react_subs[i].line_buffer.is_empty() {
+                    let remaining = std::mem::take(&mut react_subs[i].line_buffer);
+                    let cb = react_subs[i].callback.clone();
+                    match self.call_react_callback(&cb, vec![Value::str(remaining)]) {
+                        Err(e) if e.is_react_done() => return Ok(true),
+                        other => {
+                            other?;
+                        }
+                    }
+                }
+                for cb in react_subs[i].last_callbacks.clone() {
+                    self.call_react_callback(&cb, Vec::new())?;
+                }
+                react_subs[i].done = true;
+            }
+        }
+        Ok(false)
+    }
+
+    /// If `sub` has reached its `head`/`.head(N)` limit, fire its LAST callbacks
+    /// and mark it done. Returns whether the limit was reached.
+    fn head_limit_reached(&mut self, sub: &mut ReactSubscription) -> Result<bool, RuntimeError> {
+        if let Some(limit) = sub.head_limit
+            && sub.emit_count >= limit
+        {
+            for cb in sub.last_callbacks.clone() {
+                self.call_react_callback(&cb, Vec::new())?;
+            }
+            sub.done = true;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     /// Shared subscription drive loop backing both `react { ... }` and the
     /// `await $supply` / `$supply.Promise` paths. `react`-built and
     /// promise-built subscriptions poll through here; `policy` selects how each
@@ -58,9 +193,23 @@ impl Interpreter {
                     return Ok(());
                 }
             }
+            // Phase 1: deliver all buffered supplier values in global emit order
+            // (so sibling `whenever $s.grep(...)` supplies interleave correctly),
+            // and honour supplier done/quit.
+            if self.drain_supplier_subs_ordered(&mut react_subs)? {
+                break 'react_loop;
+            }
+            // Phase 2: poll the non-supplier subscriptions (on-demand / channel /
+            // receiver sources).
             let mut all_done = true;
-            for sub in react_subs.iter_mut() {
+            for si in 0..react_subs.len() {
+                let sub = &mut react_subs[si];
                 if sub.done {
+                    continue;
+                }
+                // Supplier-backed subs were fully serviced in phase 1.
+                if sub.supplier_id.is_some() {
+                    all_done = false;
                     continue;
                 }
                 all_done = false;
@@ -109,116 +258,43 @@ impl Interpreter {
                     }
                     continue;
                 }
-                if let Some(supplier_id) = sub.supplier_id {
-                    let (values, done, quit) = supplier_snapshot(supplier_id);
-                    while sub.supplier_next_index < values.len() {
-                        // Check head_limit before processing more values
-                        if let Some(limit) = sub.head_limit
-                            && sub.emit_count >= limit
-                        {
-                            // Reached the head limit — mark as done
-                            for callback in &sub.last_callbacks {
-                                self.call_react_callback(&callback.clone(), Vec::new())?;
-                            }
-                            sub.done = true;
-                            break;
-                        }
-                        let value = values[sub.supplier_next_index].clone();
-                        sub.supplier_next_index += 1;
-                        if sub.is_lines {
-                            let chunk = value.to_string_value();
-                            sub.line_buffer.push_str(&chunk);
-                            while let Some(pos) = sub.line_buffer.find('\n') {
-                                let line = sub.line_buffer[..pos].to_string();
-                                sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
-                                if self.run_react_consumer(sub, Value::str(line))? {
-                                    break 'react_loop;
-                                }
-                                if sub.done {
-                                    break;
-                                }
-                                sub.emit_count += 1;
-                                if let Some(limit) = sub.head_limit
-                                    && sub.emit_count >= limit
-                                {
-                                    for callback in &sub.last_callbacks {
-                                        self.call_react_callback(&callback.clone(), Vec::new())?;
-                                    }
-                                    sub.done = true;
-                                    break;
-                                }
-                            }
-                        } else {
-                            if self.run_react_consumer(sub, value)? {
-                                break 'react_loop;
-                            }
-                            // `last` in the body marked this whenever done; stop
-                            // pulling further values from the source.
-                            if sub.done {
-                                break;
-                            }
-                            sub.emit_count += 1;
-                            if let Some(limit) = sub.head_limit
-                                && sub.emit_count >= limit
-                            {
-                                for callback in &sub.last_callbacks {
-                                    self.call_react_callback(&callback.clone(), Vec::new())?;
-                                }
-                                sub.done = true;
-                                break;
-                            }
-                        }
-                    }
-                    if let Some(error) = quit {
-                        let mut handled = false;
-                        for quit_cb in &sub.quit_callbacks {
-                            self.call_supply_quit_handler(quit_cb.clone(), error.clone())?;
-                            handled = true;
-                        }
-                        if handled {
-                            sub.done = true;
-                            continue;
-                        }
-                        Self::run_react_close_callbacks(self, &react_subs);
-                        let quit_err =
-                            crate::runtime::Interpreter::runtime_error_from_supply_reason(error);
-                        return Err(crate::runtime::Interpreter::wrap_react_died(quit_err));
-                    }
-                    if done {
-                        if sub.is_lines && !sub.line_buffer.is_empty() {
-                            let remaining = std::mem::take(&mut sub.line_buffer);
-                            match self.call_react_callback(
-                                &sub.callback.clone(),
-                                vec![Value::str(remaining)],
-                            ) {
-                                Err(e) if e.is_react_done() => break 'react_loop,
-                                other => {
-                                    other?;
-                                }
-                            }
-                        }
-                        for callback in &sub.last_callbacks {
-                            self.call_react_callback(&callback.clone(), Vec::new())?;
-                        }
-                        sub.done = true;
-                    }
+                if react_subs[si].receiver.is_none() {
+                    react_subs[si].done = true;
                     continue;
                 }
-                let Some(receiver) = sub.receiver.as_ref() else {
-                    sub.done = true;
-                    continue;
-                };
-                if let Some(promise) = sub.promise.as_ref()
-                    && let Some(sources) = take_promise_combinator_sources(promise)
+                if let Some(promise) = react_subs[si].promise.clone()
+                    && let Some(sources) = take_promise_combinator_sources(&promise)
                 {
                     for source in sources {
                         source.result_blocking();
                     }
                     continue;
                 }
+                // Poll the receiver with a short timeout. The `Result` is owned, so
+                // the borrow of the receiver ends on this line — freeing
+                // `react_subs` for the pre-drain below.
+                let poll = react_subs[si]
+                    .receiver
+                    .as_ref()
+                    .map(|r| r.recv_timeout(timeout));
+                // Raku ordering guarantee: values `emit`ted into a supplier
+                // *before* the event this receiver just delivered are causally
+                // earlier and must reach their `whenever`s first — even when that
+                // event's callback ends the react (e.g. `whenever start { emit … }`
+                // finishing while a sibling `whenever` calls `done`, so the sibling
+                // supplier's already-emitted values would otherwise be lost). Drain
+                // every supplier subscription before running this receiver's
+                // consumer, so their pending values are delivered in source order.
+                if matches!(poll, Some(Ok(SupplyEvent::Emit(_))))
+                    && matches!(policy, SupplyDrivePolicy::React)
+                    && self.drain_supplier_subs_ordered(&mut react_subs)?
+                {
+                    break 'react_loop;
+                }
+                let sub = &mut react_subs[si];
                 // Try to receive with a short timeout
-                match receiver.recv_timeout(timeout) {
-                    Ok(SupplyEvent::Emit(value)) => match &mut policy {
+                match poll {
+                    Some(Ok(SupplyEvent::Emit(value))) => match &mut policy {
                         SupplyDrivePolicy::Promise {
                             promise,
                             last_value,
@@ -277,7 +353,7 @@ impl Interpreter {
                             }
                         }
                     },
-                    Ok(SupplyEvent::Done) => {
+                    Some(Ok(SupplyEvent::Done)) => {
                         if matches!(policy, SupplyDrivePolicy::Promise { .. }) {
                             // Inner supply done: the promise resolves through the
                             // supplier registry, not the channel close — just
@@ -302,7 +378,7 @@ impl Interpreter {
                             sub.done = true;
                         }
                     }
-                    Ok(SupplyEvent::Quit(error)) => {
+                    Some(Ok(SupplyEvent::Quit(error))) => {
                         if matches!(policy, SupplyDrivePolicy::Promise { .. }) {
                             // On the await path an inner quit just retires the
                             // receiver; the promise is resolved/broken elsewhere.
@@ -325,8 +401,8 @@ impl Interpreter {
                             }
                         }
                     }
-                    Err(mpsc::RecvTimeoutError::Timeout) => {}
-                    Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    Some(Err(mpsc::RecvTimeoutError::Timeout)) | None => {}
+                    Some(Err(mpsc::RecvTimeoutError::Disconnected)) => {
                         sub.done = true;
                     }
                 }

--- a/t/supply-live-grep-map-react-order.t
+++ b/t/supply-live-grep-map-react-order.t
@@ -1,0 +1,108 @@
+use Test;
+
+# Regression tests for:
+#  1. `Supply.grep` / `Supply.map` on a *live* (Supplier-backed) supply must
+#     stay live and forward filtered/mapped values to taps (previously the
+#     derived supply was a dead empty snapshot).
+#  2. The react drive loop must deliver values `emit`ted into a supplier before a
+#     later terminating event (Raku's ordering guarantee), and must interleave
+#     sibling `whenever $s.grep(...)` supplies in global emit order.
+
+plan 6;
+
+# 1. Live grep forwards to a tap synchronously.
+{
+    my @got;
+    my $sup = Supplier::Preserving.new;
+    $sup.Supply.grep(* > 0).tap(-> $v { @got.push: $v });
+    $sup.emit(-1);
+    $sup.emit(5);
+    $sup.emit(0);
+    $sup.emit(7);
+    is-deeply @got, [5, 7], 'live Supply.grep forwards matching values to a tap';
+}
+
+# 2. Live grep with a type-object matcher uses smart-match semantics.
+{
+    my @got;
+    my $sup = Supplier::Preserving.new;
+    $sup.Supply.grep(Int).tap(-> $v { @got.push: $v });
+    $sup.emit(1);
+    $sup.emit("x");
+    $sup.emit(2);
+    is-deeply @got, [1, 2], 'live Supply.grep(Int) smart-matches';
+}
+
+# 3. Live map forwards mapped values to a tap.
+{
+    my @got;
+    my $sup = Supplier::Preserving.new;
+    $sup.Supply.map(* + 100).tap(-> $v { @got.push: $v });
+    $sup.emit(1);
+    $sup.emit(2);
+    is-deeply @got, [101, 102], 'live Supply.map forwards mapped values to a tap';
+}
+
+# 4. react: a `whenever start { emit … }` whose completion callback calls `done`
+#    must not swallow the values emitted before it.
+{
+    my @out;
+    my $inputs = Supplier::Preserving.new;
+    my $s = $inputs.Supply;
+    react {
+        whenever $s {
+            @out.push: $_;
+        }
+        whenever start {
+            for ^5 { $inputs.emit($_) }
+        } {
+            @out.push: "fin";
+            done;
+        }
+    }
+    is-deeply @out, [0, 1, 2, 3, 4, "fin"],
+        'values emitted before a sibling done are delivered first';
+}
+
+# 5. react: sibling `whenever $s.grep(...)` supplies interleave in emit order.
+{
+    my @out;
+    my $inputs = Supplier::Preserving.new;
+    my $s = $inputs.Supply;
+    react {
+        whenever $s.grep(* > 0) { @out.push: "p$_" }
+        whenever $s.grep(* < 0) { @out.push: "n$_" }
+        whenever start {
+            for 1..3 {
+                $inputs.emit($_);
+                $inputs.emit(-$_);
+            }
+        } {
+            done;
+        }
+    }
+    is-deeply @out, ["p1", "n-1", "p2", "n-2", "p3", "n-3"],
+        'sibling grep whenevers interleave in global emit order';
+}
+
+# 6. react grep whenever with `last` fires its LAST phaser with the topic.
+{
+    my @out;
+    my $inputs = Supplier::Preserving.new;
+    my $s = $inputs.Supply;
+    react {
+        whenever $s.grep(* > 0) {
+            last if $_ > 2;
+            @out.push: $_;
+            LAST { @out.push: "last $_" }
+        }
+        whenever start {
+            for 1..5 { $inputs.emit($_) }
+        } {
+            @out.push: "done";
+            done;
+        }
+    }
+    is-deeply @out, [1, 2, "last 3", "done"],
+        'grep whenever last fires LAST phaser with the triggering topic';
+}


### PR DESCRIPTION
## Summary

`roast/S17-supply/syntax.t` test 90 was a deterministic 3/3 failure. It needed three coordinated react/supply features, all landed here:

1. **Live `Supply.grep`/`Supply.map` forwarding.** A `.grep`/`.map` on a Supplier-backed (live) supply returned a dead, empty snapshot supply, so `whenever $s.grep(...)` inside `react` never received emitted values. Now a transform tap is registered on the source supplier that runs the grep (smart-match) / map callable and forwards the result to a live derived supply, propagating `done`. Materialized (`from-list`/on-demand) supplies keep filtering eagerly through the existing correct `dispatch_grep` path.

2. **React ordering guarantee.** The drive loop now pre-drains all supplier subscriptions before running a receiver-source (`start`/Promise) consumer, so values emitted before a sibling `whenever` calls `done` are still delivered.

3. **Global emit order.** `supplier_emit` stamps each value with a process-wide sequence number; `drain_supplier_subs_ordered` merges pending values across all supplier subscriptions by that sequence, so sibling `whenever $s.grep(...)` supplies interleave the way Raku delivers them, rather than one-supplier-at-a-time.

## Result

- `roast/S17-supply/syntax.t` test 90: deterministic **10/10** pass in isolation (was 0/3).
- Tests 75 (cross-thread `$closed++` writeback) and 53 (supply mutual-exclusion race, flaky only under parallel load) still block whitelisting — separate concurrency campaigns, documented in `TODO_roast/`.
- `make test` (15408 tests) passes; all whitelisted S17 tests pass.

## Test

Pin: `t/supply-live-grep-map-react-order.t` (6 cases: live grep/map tap forwarding, smart-match grep, emit-before-done ordering, sibling-grep interleave, grep `last`+LAST phaser). Verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW