### PR TITLE
fix(vm): coerce an object bound to a %-sigil target to a Hash

### DIFF
--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -59,6 +59,19 @@ impl Interpreter {
             {
                 match sigil_of(key) {
                     '@' | '%' => {
+                        // A `%`-attribute bound to a non-Hash object is
+                        // list-contextualized like Raku's `Hash.STORE` (an object
+                        // with a custom `.iterator`/`.list` contributes its pairs).
+                        // That re-enters user code, which this native fast path
+                        // must not do, so defer to the interpreter slow path.
+                        if sigil_of(key) == '%'
+                            && matches!(
+                                val.view(),
+                                ValueView::Instance { class_name, .. } if class_name != "Match"
+                            )
+                        {
+                            return None;
+                        }
                         // Coerce exactly as the interpreter's shared helper does
                         // (List/Range -> Array, array-of-Pairs -> Hash, …).
                         attrs.insert(

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1428,6 +1428,17 @@ impl Interpreter {
                                     value = self.coerce_value_for_constraint(tc, value);
                                 }
                                 let coerced = Self::coerce_attr_value_by_sigil(value, sigil);
+                                // A `%`-sigil attribute bound to a non-Hash object
+                                // list-contextualizes it (Raku's Hash.STORE): an
+                                // object with a custom `.iterator`/`.list` (e.g.
+                                // `handles`) contributes its pairs.
+                                let coerced = if sigil == '%'
+                                    && matches!(coerced.view(), ValueView::Instance { .. })
+                                {
+                                    self.coerce_object_to_hash(coerced)
+                                } else {
+                                    coerced
+                                };
                                 // An `is Type` container attribute (`has @.a is
                                 // Buf`) coerces its provided value to the declared
                                 // container type (Buf, BagHash, Array[T], ...).

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -71,6 +71,27 @@ impl Interpreter {
         }
     }
 
+    /// Coerce a value bound to a `%`-sigil target (variable or attribute) to a
+    /// Hash, list-contextualizing a non-Hash object the way Raku's `Hash.STORE`
+    /// does. An object with a custom `.iterator`/`.list` (e.g. delegated via
+    /// `handles <iterator list>`) contributes its pairs, so `my %h = $obj` /
+    /// `has %.x` bound to such an object materializes those pairs into the hash
+    /// instead of degrading to a single stringified key.
+    ///
+    /// A plain object without a custom list interface has `.list` == `(self,)`,
+    /// which coerces to the same scalar fallback as the object itself, so this
+    /// is safe for any Instance. `Match` keeps its dedicated `%(...)` handling
+    /// in `coerce_to_hash`.
+    pub(crate) fn coerce_object_to_hash(&mut self, value: Value) -> Value {
+        if let ValueView::Instance { class_name, .. } = value.view()
+            && class_name != "Match"
+            && let Ok(listed) = self.call_method_with_values(value.clone(), "list", Vec::new())
+        {
+            return crate::runtime::utils::coerce_to_hash(listed);
+        }
+        crate::runtime::utils::coerce_to_hash(value)
+    }
+
     /// Coerce a value based on attribute sigil: @ → Array, % → Hash
     pub(crate) fn coerce_attr_value_by_sigil(val: Value, sigil: char) -> Value {
         match sigil {

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -91,7 +91,7 @@ impl Interpreter {
             None
         };
         let mut val = if name.starts_with('%') {
-            let hash_val = runtime::coerce_to_hash(raw_val);
+            let hash_val = self.coerce_object_to_hash(raw_val);
             // Resolve hash sentinel entries (bound variable refs) when assigning
             // to a new hash variable. Assignment creates new containers, so bound
             // refs must be resolved to their current values.

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -42,7 +42,7 @@ impl Interpreter {
             let coerced_initial = if name.starts_with('@') {
                 runtime::coerce_to_array(init_val)
             } else if name.starts_with('%') {
-                runtime::coerce_to_hash(init_val)
+                self.coerce_object_to_hash(init_val)
             } else {
                 init_val
             };
@@ -87,7 +87,7 @@ impl Interpreter {
             let coerced = if name.starts_with('@') {
                 runtime::coerce_to_array(init_val)
             } else if name.starts_with('%') {
-                runtime::coerce_to_hash(init_val)
+                self.coerce_object_to_hash(init_val)
             } else {
                 init_val
             };

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -176,7 +176,7 @@ impl Interpreter {
             {
                 runtime::utils::build_hash_from_items(vec![value])?
             }
-            _ => runtime::coerce_to_hash(value),
+            _ => self.coerce_object_to_hash(value),
         };
         // Resolve hash sentinel entries (self-refs) and decont `:=`-bound
         // `ContainerRef` cells when assigning to a new hash variable:

--- a/t/object-to-hash-coercion.t
+++ b/t/object-to-hash-coercion.t
@@ -1,0 +1,44 @@
+use Test;
+
+# An object with a hash-like interface (via `handles`) bound to a `%`-sigil
+# target is list-contextualized like Raku's `Hash.STORE`: its pairs are
+# materialized into a real Hash instead of the object being kept verbatim.
+
+plan 12;
+
+class HashLike {
+    has %.h handles <AT-KEY EXISTS-KEY keys values kv iterator list>;
+}
+
+# --- `has %.attr` bound to a hash-like object ------------------------------
+class Wrapper {
+    has %.config;
+}
+
+my $obj = HashLike.new(h => { a => 1, b => 2 });
+my $w = Wrapper.new(config => $obj);
+
+is $w.config.^name, 'Hash', 'object bound to %.attr becomes a Hash';
+is $w.config<a>, 1, 'first pair materialized into the %.attr hash';
+is $w.config<b>, 2, 'second pair materialized into the %.attr hash';
+
+# --- plain `my %h = $obj` --------------------------------------------------
+my %m = $obj;
+is %m.^name, 'Hash', 'my %h = $obj coerces to a Hash';
+is %m<a>, 1, 'my %h = $obj materializes first pair';
+is %m<b>, 2, 'my %h = $obj materializes second pair';
+
+# --- a real Hash / array-of-pairs still coerces as before ------------------
+is Wrapper.new(config => { p => 9 }).config<p>, 9, 'plain Hash still binds';
+is Wrapper.new(config => (q => 8, r => 7)).config<r>, 7, 'array of pairs still binds';
+is Wrapper.new.config.^name, 'Hash', 'unspecified %.attr defaults to empty Hash';
+
+# --- anonymous class, mirroring zef's $CONFIG wrapper ----------------------
+my $cfg = class :: {
+    has %.hash handles <AT-KEY EXISTS-KEY keys values kv iterator list>;
+}.new(hash => { Fetch => [1, 2], Repository => [3] });
+
+my $c = Wrapper.new(config => $cfg);
+is $c.config.^name, 'Hash', 'anon-class config wrapper becomes a Hash';
+is $c.config<Fetch>.elems, 2, 'anon-class hash value preserved (elems)';
+is $c.config<Repository>[0], 3, 'anon-class hash value preserved (indexing)';


### PR DESCRIPTION
## Summary

Raku's `Hash.STORE` list-contextualizes a non-Hash object bound to a `%`-sigil variable or attribute: an object with a custom `.iterator`/`.list` (e.g. delegated via `handles <iterator list>`) contributes its pairs. mutsu kept the object verbatim, so `my %h = $obj` or `has %.x` bound to such an object degraded to a single stringified key via the `coerce_to_hash` `_ =>` fallback.

```raku
class Conf { has %.hash handles <AT-KEY EXISTS-KEY keys values kv iterator list>; }
my $obj = Conf.new(hash => {a => 1, b => 2});
class Client { has %.config; }
my $c = Client.new(config => $obj);
say $c.config.^name;   # was: Conf   now: Hash  (raku: Hash)
say $c.config<a>;      # was: (Any)  now: 1     (raku: 1)
```

## Fix

- New interpreter helper `Interpreter::coerce_object_to_hash` materializes a non-`Match` Instance via its `.list` and re-coerces the result. A plain object without a custom list interface has `.list == (self,)`, which coerces to the same scalar fallback as the object itself, so this is safe for any Instance.
- Wired into the `%h =` VarDecl path (`vm_var_assign_coerce.rs`), the SetLocal/SetGlobal assign path (`vm_misc_assign.rs`), the `state %h` paths (`vm_misc_scope.rs`), and the object constructor `%`-attribute binding (`methods_object_dispatch_new.rs`).
- The native default-ctor fast path (`methods_object_default_ctor.rs`) now returns `None` for a `%`-attr bound to a non-`Match` object so the interpreter slow path (which runs the coercion) handles it, keeping the fast path free of user-code re-entry.

This is the object → `%`-attribute coercion gap that blocked zef's `$CONFIG` → `Zef::Client.new(:config($CONFIG))` binding.

## Known limitation (out of scope)

A `does Iterable`/`does Associative` object whose `.list` returns `(self,)` but whose `.iterator` yields pairs is still not coerced — raku's `Hash.STORE` drains `.iterator` directly, which mutsu's `.list` does not follow for a non-Iterable object's handles-delegated `.iterator`. zef's anon config class handles both `iterator` and `list`, so it is unaffected. A full fix would drain `.iterator` (pull-one re-entrancy) and is deferred.

## Tests

- New `t/object-to-hash-coercion.t` (12 subtests).
- `make test` passes (1573 files, 15431 tests, Failed: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA