### PR TITLE
fix(subscript): multi-dim slice lvalues, missing-leaf autoviv, || spread, :delete:k order (S32 multislice-6e)

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -43,7 +43,7 @@
 - [ ] roast/S32-array/exists-adverb.t
 - [ ] roast/S32-array/keys_values.t
 - [ ] roast/S32-array/kv.t
-- [ ] roast/S32-array/multislice-6e.t
+- [x] roast/S32-array/multislice-6e.t
   - **2026-06-29 (#PR multidim ContainerRef coherence)**: failures cut 605 → 157.
     Root cause of the bulk (~160 of them, all "is array as expected after
     deletion"): a file-scoped `@array` mutated from `set-up-array` is a shared

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1048,6 +1048,7 @@ roast/S32-array/end.t
 roast/S32-array/exists-adverb.t
 roast/S32-array/keys_values.t
 roast/S32-array/kv.t
+roast/S32-array/multislice-6e.t
 roast/S32-array/pairs.t
 roast/S32-array/perl.t
 roast/S32-array/pop.t

--- a/src/parser/expr/postfix/adverb.rs
+++ b/src/parser/expr/postfix/adverb.rs
@@ -316,6 +316,31 @@ pub(crate) fn subscript_adverb_expr_with_cond(
     adverb: &'static str,
     cond: Option<Expr>,
 ) -> Expr {
+    // `@a[...]:delete:k` (delete adverb BEFORE the value adverb): the leading
+    // `:delete` already lowered the multislice to a `__mutsu_multidim_delete`
+    // call `(var, dims...)`. Combine it with this value adverb (`:k`/`:kv`/`:p`/
+    // `:v`) into the same delete+adverb `_dyn` form the reverse `:k:delete`
+    // order produces, so both orders read the removed elements as
+    // keys/kv-pairs/pairs/values. Args become [var, adverb, True(delete), dims...].
+    if let Expr::Call { name, args } = &expr
+        && *name == Symbol::intern("__mutsu_multidim_delete")
+        && !args.is_empty()
+    {
+        let mut new_args = vec![
+            args[0].clone(),
+            Expr::Literal(Value::str(adverb.to_string())),
+            Expr::Literal(Value::TRUE),
+        ];
+        new_args.extend(args[1..].iter().cloned());
+        if let Some(cond_expr) = cond {
+            new_args.push(Expr::Literal(Value::str("__adverb_cond__".to_string())));
+            new_args.push(cond_expr);
+        }
+        return Expr::Call {
+            name: Symbol::intern("__mutsu_multidim_subscript_adverb_dyn"),
+            args: new_args,
+        };
+    }
     // Handle MultiDimIndex: @a[0;0;0]:kv etc.
     if let Expr::MultiDimIndex { target, dimensions } = expr {
         let mut args = vec![*target, Expr::Literal(Value::str(adverb.to_string()))];

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -463,7 +463,16 @@ impl Interpreter {
             ));
         }
         let var_name = args[0].to_string_value();
-        let raw_indices = args[1..].to_vec();
+        let mut raw_indices = args[1..].to_vec();
+        // `@a[|| @list]:delete` passes the `||` operand list as a single
+        // dimension; expand its elements into the real dimensions (the delete
+        // counterpart of `expand_pipe_multidim_dims`). A single-dimension
+        // multidim subscript is only ever produced by `||`.
+        if raw_indices.len() == 1
+            && let Some(items) = raw_indices[0].as_list_items()
+        {
+            raw_indices = items.to_vec();
+        }
         let target_val = self.env.get(&var_name).cloned().unwrap_or(Value::NIL);
         let indices = self.resolve_multidim_indices(&target_val, &raw_indices)?;
         // A shaped array (`my @a[2;2]`) has fixed dimensions; an out-of-range

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -11,6 +11,16 @@ use super::*;
 /// _)`, produced by `pair_as_positional` for `.first`/etc. over Hash/Pair
 /// elements) is passed, it must bind to such a plain param positionally rather
 /// than be siphoned off as a named argument.
+/// Whether `value` is a multi-dimensional slice lvalue produced by
+/// `MultiDimIndexBindRef` for a subscript with a slice dimension — a plain,
+/// non-empty list whose elements are ALL shared `ContainerRef` cells (one per
+/// selected leaf). A raw `\target` bound to such a value is writable: a later
+/// `target = v` distributes the RHS element-wise through the cells.
+fn is_multidim_slice_cells(value: &crate::value::Value) -> bool {
+    matches!(value.view(), crate::value::ValueView::Array(items, ..)
+        if !items.is_empty() && items.iter().all(crate::value::Value::is_container_ref))
+}
+
 fn legacy_has_plain_positional_param(params: &[String]) -> bool {
     params.iter().any(|p| {
         !p.starts_with(':')
@@ -1226,15 +1236,34 @@ impl Interpreter {
                     if pd.sigilless {
                         let alias_key = sigilless_alias_key(&pd.name);
                         let readonly_key = sigilless_readonly_key(&pd.name);
-                        if matches!(value.view(), ValueView::ContainerRef(_)) {
+                        if matches!(value.view(), ValueView::ContainerRef(_))
+                            || is_multidim_slice_cells(&value)
+                        {
                             // A multi-dimensional subscript lvalue (`@a[0;1;2]`)
                             // arrives as a shared `ContainerRef` cell aliasing the
-                            // real array/hash element. Bind the raw `\target` param
-                            // to the cell as a writable, anonymous alias so a later
-                            // `target = v` writes through to the underlying
-                            // container (and is visible immediately).
+                            // real array/hash element (single scalar leaf), or — for
+                            // a subscript with a slice dimension (`@a[0;0;(0,1,2)]`,
+                            // `@a[*;0;0]`) — as a plain list whose elements are all
+                            // shared `ContainerRef` cells (one per selected leaf).
+                            // Bind the raw `\target` param to it as a writable,
+                            // anonymous alias so a later `target = v` writes through
+                            // to the underlying container (distributing element-wise
+                            // for the slice case) and is visible immediately.
                             self.env.remove(&alias_key);
                             self.env.insert(readonly_key, Value::FALSE);
+                            // Mark a genuine multi-dim slice lvalue so the assign
+                            // ops know to distribute a whole-value assignment
+                            // through its cells. "Elements are all cells" alone is
+                            // NOT a safe trigger — `.grep`'s rw-topic promotion can
+                            // also leave a cell-list in an unrelated scalar, which
+                            // must keep plain replace semantics (roast
+                            // S03-operators/assign.t `$x = $x.grep(...)`).
+                            if is_multidim_slice_cells(&value) {
+                                self.env.insert(
+                                    Self::bound_array_slice_marker_key(&pd.name),
+                                    Value::TRUE,
+                                );
+                            }
                         } else if let Some((source_name, inner)) = varref_from_value(&raw_arg) {
                             let resolved_source =
                                 self.resolve_sigilless_alias_source_name(&source_name);

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -29,6 +29,59 @@ impl Value {
         }
     }
 
+    /// Ensure array element `idx` exists and is a descendable Array, creating
+    /// it (and filling any gap with the element type object) when missing or a
+    /// scalar hole. Returns the child Array value (sharing the inner `Arc`, so a
+    /// later leaf promotion lands in the real container) — the array analogue of
+    /// `hash_autovivify` for an *intermediate* multi-dim descent level. Returns
+    /// `None` if `self` is not an Array or the existing element is a non-array
+    /// container (a Hash — a shape the caller cannot descend as an array index).
+    pub fn ensure_array_child(&self, idx: usize) -> Option<Value> {
+        let Value::Array(arc, _kind) = self else {
+            return None;
+        };
+        // SAFETY: aliased in-place mutation of a shared container; see
+        // `arc_contents_mut`. No borrow into the items is live across the write.
+        let data = unsafe { crate::value::gc_contents_mut(arc) };
+        let hole = data
+            .default
+            .as_ref()
+            .map(|d| (**d).clone())
+            .unwrap_or_else(|| {
+                Value::Package(Symbol::intern(data.value_type.as_deref().unwrap_or("Any")))
+            });
+        while data.len() <= idx {
+            data.push(hole.clone());
+        }
+        // Only vivify an empty slot (`Nil`/type-object hole). A real scalar leaf
+        // (`Int`/`Str`/…) or a `Hash` is NOT overwritten — returning `None` there
+        // makes the caller fall back to a plain read, so a read-only use of the
+        // subscript cannot corrupt existing data.
+        let is_hole = |v: &Value| matches!(v, Value::Nil | Value::Package(..));
+        // Deref an existing ContainerRef cell so we inspect/replace its inner value.
+        if let Value::ContainerRef(cell) = &data[idx] {
+            let inner = cell.lock().unwrap().clone();
+            match &inner {
+                Value::Array(..) => return Some(inner),
+                v if is_hole(v) => {
+                    let fresh = Value::real_array(Vec::new());
+                    *cell.lock().unwrap() = fresh.clone();
+                    return Some(fresh);
+                }
+                _ => return None,
+            }
+        }
+        match &data[idx] {
+            Value::Array(..) => Some(data[idx].clone()),
+            v if is_hole(v) => {
+                let fresh = Value::real_array(Vec::new());
+                data[idx] = fresh.clone();
+                Some(fresh)
+            }
+            _ => None,
+        }
+    }
+
     /// Bind to array element `idx`, promoting it to a first-class container
     /// (Phase 2). The element is replaced in place with a shared
     /// `ContainerRef` cell (reusing an existing one), and that same cell is

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -344,6 +344,18 @@ impl Interpreter {
                     return Ok(());
                 }
             }
+            // A sigilless `\target` bound to a multi-dim slice lvalue distributes
+            // the RHS element-wise through its cells (the env-named counterpart
+            // of the `exec_assign_expr_local_op_inner` write-through — reached
+            // when the assignment happens inside a closure that captured
+            // `target`, e.g. a `subtest { ... }` block).
+            if let Some(holder) = current.clone()
+                && let Some(res) = self.distribute_bound_multidim_slice(&name, &holder, &val)
+            {
+                res?;
+                self.stack.push(val);
+                return Ok(());
+            }
         }
         // Circular hash reference fixup
         if name.starts_with('%') {

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -50,6 +50,25 @@ impl Interpreter {
             return Ok(());
         }
 
+        // A sigilless `\target` bound to a multi-dim slice lvalue distributes a
+        // whole-value assignment (`target = values`) element-wise through its
+        // leaf cells — the raw analogue of the `@slice := @array[1,2]; @slice =
+        // ...` bound-slice write-through below (gated on the bind-time marker,
+        // NOT "elements are cells", to avoid colliding with `.grep`'s rw-topic
+        // cell promotion).
+        {
+            let name = code.locals[idx].clone();
+            let holder = self.locals[idx].clone();
+            if let Some(rhs) = self.stack.last().cloned()
+                && let Some(res) = self.distribute_bound_multidim_slice(&name, &holder, &rhs)
+            {
+                // The RHS is both the distributed source and the assignment
+                // result; leave it on the stack top as the expression value.
+                res?;
+                return Ok(());
+            }
+        }
+
         // Fast path for simple scalar variables — skip all metadata checks
         if code.simple_locals[idx] {
             let mut val = self.stack.pop().unwrap_or(Value::NIL);

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -7,8 +7,60 @@ impl Interpreter {
     /// cleared on every redeclaration of the same name. See the write-through
     /// checks in `vm_var_assign_local.rs` and this file's non-bind path for
     /// why "elements are cells" alone is not a safe trigger.
-    pub(super) fn bound_array_slice_marker_key(name: &str) -> String {
+    pub(crate) fn bound_array_slice_marker_key(name: &str) -> String {
         format!("__mutsu_bound_array_slice::{name}")
+    }
+
+    /// If `name` is a raw `\target` bound to a multi-dim slice lvalue (marked at
+    /// bind time by `is_multidim_slice_cells`) whose current value `holder` is a
+    /// non-empty list of `ContainerRef` cells, distribute `rhs` element-wise
+    /// through the cells (mutating the real nested container) and return the
+    /// value to push as the assignment result. Returns `None` when this is not
+    /// such a binding, so the caller falls back to normal assignment.
+    ///
+    /// The bind-time marker — NOT "all elements are cells" — is the trigger:
+    /// `.grep`'s rw-topic promotion can also leave a cell-list in an unrelated
+    /// scalar (`$x = $x.grep(...)`, roast S03-operators/assign.t) that must keep
+    /// plain replace semantics.
+    pub(crate) fn distribute_bound_multidim_slice(
+        &mut self,
+        name: &str,
+        holder: &Value,
+        rhs: &Value,
+    ) -> Option<Result<(), RuntimeError>> {
+        if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
+            return None;
+        }
+        if !matches!(
+            self.env()
+                .get(&Self::bound_array_slice_marker_key(name))
+                .map(Value::view),
+            Some(ValueView::Bool(true))
+        ) {
+            return None;
+        }
+        let cells: Vec<Value> = match holder.view() {
+            ValueView::Array(items, ..)
+                if !items.is_empty() && items.iter().all(Value::is_container_ref) =>
+            {
+                items.iter().cloned().collect()
+            }
+            _ => return None,
+        };
+        let rhs_vals = match self.assignment_rhs_values(rhs) {
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
+        };
+        for (i, cell_val) in cells.iter().enumerate() {
+            let v = rhs_vals
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern("Any")));
+            if let ValueView::ContainerRef(cell) = cell_val.view() {
+                cell.lock().unwrap().clone_from(&v);
+            }
+        }
+        Some(Ok(()))
     }
 
     pub(super) fn exec_set_local_op(
@@ -148,6 +200,21 @@ impl Interpreter {
         {
             let name = &code.locals[idx];
             self.update_bound_decont_marker(name, scalar_bind || is_bind, &raw_popped);
+        }
+        // A sigilless `\target` bound to a multi-dim slice lvalue distributes a
+        // plain whole-value reassignment (`target = values`, e.g. as a sub's
+        // bare-statement return value) element-wise through its cells — the
+        // `SetLocal` counterpart of the same write-through in
+        // `exec_assign_expr_local_op_inner` / `exec_assign_expr_op_inner`.
+        // Excluded for a `:=` bind / declaration, which replaces the binding.
+        if !is_bind && !is_vardecl && !is_rebind && !scalar_bind {
+            let name = code.locals[idx].clone();
+            let holder = self.locals[idx].clone();
+            if let Some(res) = self.distribute_bound_multidim_slice(&name, &holder, &raw_popped) {
+                res?;
+                self.stack.push(raw_popped);
+                return Ok(());
+            }
         }
         // A redeclaration (`my @a` in a new scope) must not inherit the
         // `is default(...)` trait from an earlier same-named variable,

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -11,6 +11,7 @@ impl Interpreter {
             dims.push(self.stack.pop().unwrap_or(Value::NIL));
         }
         dims.reverse();
+        let dims = Self::expand_pipe_multidim_dims(dims);
         let target = self.stack.pop().unwrap_or(Value::NIL);
 
         // For shaped arrays, check bounds before reading
@@ -39,15 +40,151 @@ impl Interpreter {
             dims.push(self.stack.pop().unwrap_or(Value::NIL));
         }
         dims.reverse();
+        let dims = Self::expand_pipe_multidim_dims(dims);
         let target = self.stack.pop().unwrap_or(Value::NIL);
 
         if let Some(slot) = self.multi_dim_slot_ref(&target, &dims)? {
             self.stack.push(slot);
-        } else {
-            let result = self.multi_dim_index_read(&target, &dims)?;
-            self.stack.push(result);
+            return Ok(());
         }
+        // A subscript containing a slice dimension (`*` or an index list) over
+        // ALREADY-EXISTING leaves selects several leaves that cannot collapse to
+        // one cell. Promote each selected leaf to a shared `ContainerRef` cell
+        // and hand back a plain list of those cells — the array analogue of the
+        // `@slice := @array[1,2]` bound-slice (see `array_slot_ref` /
+        // `slice_bind_indices`). A `\raw` / `is rw` parameter bound to this list
+        // then distributes a `target = values` assignment element-wise through
+        // the cells (see the sigilless bound-slice write-through in the assign
+        // ops), while a read decontainerizes each cell transparently. Missing
+        // leaves and hash roots fall back to the plain (non-aliasing) read.
+        let is_slice = dims.iter().any(|d| {
+            matches!(
+                Self::normalize_multidim_dim(d).view(),
+                ValueView::Whatever | ValueView::Array(..)
+            )
+        });
+        if is_slice {
+            let deref_target = match target.view() {
+                ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+                ValueView::Scalar(inner) => inner.clone(),
+                _ => target.clone(),
+            };
+            if !matches!(deref_target.view(), ValueView::Hash(..)) {
+                let mut cells = Vec::new();
+                if self
+                    .collect_multi_dim_leaf_cells(&deref_target, &dims, &mut cells)
+                    .is_some()
+                {
+                    self.stack.push(Value::array(cells));
+                    return Ok(());
+                }
+            }
+        } else if let Some(cell) = self.multi_dim_scalar_autoviv_cell(&target, &dims) {
+            // All-scalar dims over a MISSING leaf: autovivify the path (creating
+            // any absent intermediate arrays) and promote the terminal element
+            // to a shared `ContainerRef` cell, so a `\raw` / `is rw` bind can
+            // write to a not-yet-existent leaf (`@a[0;0;3] = v`). Eager, like the
+            // single-index `:=` bind (`my $s := @a[5]`). Restricted to holes by
+            // `ensure_array_child` / `array_slot_ref`, so a read-only use over an
+            // existing structure is untouched.
+            self.stack.push(cell);
+            return Ok(());
+        }
+        let result = self.multi_dim_index_read(&target, &dims)?;
+        self.stack.push(result);
         Ok(())
+    }
+
+    /// Autovivifying all-scalar-dimension descent for `MultiDimIndexBindRef`.
+    /// Walks each scalar index, creating any missing intermediate array level,
+    /// and returns the terminal element promoted to a shared `ContainerRef`
+    /// cell. Returns `None` if a dimension is non-numeric, or the descent meets a
+    /// real (non-hole) scalar / hash where a further array index still needs to
+    /// descend — the caller then falls back to a plain (non-aliasing) read.
+    fn multi_dim_scalar_autoviv_cell(&mut self, target: &Value, dims: &[Value]) -> Option<Value> {
+        if dims.is_empty() {
+            return None;
+        }
+        let mut cur = match target.view() {
+            ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+            ValueView::Scalar(inner) => inner.clone(),
+            _ => target.clone(),
+        };
+        if !matches!(cur.view(), ValueView::Array(..)) {
+            return None;
+        }
+        for (i, dim) in dims.iter().enumerate() {
+            let terminal = i + 1 == dims.len();
+            let resolved = self
+                .resolve_whatever_code_index(dim, &cur)
+                .unwrap_or_else(|| dim.clone());
+            let idx = Self::index_to_usize(&resolved)?;
+            if terminal {
+                return cur.array_slot_ref(idx, true);
+            }
+            cur = cur.ensure_array_child(idx)?;
+        }
+        None
+    }
+
+    /// Descend a nested array through the (possibly slice) dimensions, promoting
+    /// every selected leaf to a shared `ContainerRef` cell and pushing the cells
+    /// into `out` in row-major order. Returns `None` (caller falls back to a
+    /// plain read) if any selected path is missing, out of bounds, or reaches a
+    /// non-array where a further dimension still needs to descend — autovivifying
+    /// a missing slot here would corrupt a read-only use of the same subscript.
+    fn collect_multi_dim_leaf_cells(
+        &mut self,
+        cur: &Value,
+        dims: &[Value],
+        out: &mut Vec<Value>,
+    ) -> Option<()> {
+        if dims.is_empty() {
+            return None;
+        }
+        let items_len = match cur.view() {
+            ValueView::Array(items, ..) => items.len(),
+            _ => return None,
+        };
+        let dim = Self::normalize_multidim_dim(&dims[0]);
+        let rest = &dims[1..];
+        let terminal = rest.is_empty();
+
+        // Resolve this dimension into the concrete list of integer indices it
+        // selects against the CURRENT container.
+        let indices: Vec<usize> = match dim.view() {
+            ValueView::Whatever => (0..items_len).collect(),
+            ValueView::Array(idxs, ..) => {
+                let mut v = Vec::with_capacity(idxs.len());
+                for it in idxs.iter() {
+                    let resolved = self
+                        .resolve_whatever_code_index(it, cur)
+                        .unwrap_or_else(|| it.clone());
+                    v.push(Self::index_to_usize(&resolved)?);
+                }
+                v
+            }
+            _ => {
+                let resolved = self
+                    .resolve_whatever_code_index(&dim, cur)
+                    .unwrap_or_else(|| dim.clone());
+                vec![Self::index_to_usize(&resolved)?]
+            }
+        };
+
+        // A `Whatever` (`*`) dimension only ever yields existing indices, so a
+        // bare-slice read over an existing structure adds no elements. A missing
+        // index reached through an EXPLICIT index (a list dim or the terminal
+        // dim) autovivifies, matching the assignment semantics.
+        for i in indices {
+            if terminal {
+                out.push(cur.array_slot_ref(i, true)?);
+            } else {
+                let child = cur.ensure_array_child(i)?;
+                self.collect_multi_dim_leaf_cells(&child, rest, out)?;
+            }
+        }
+        Some(())
     }
 
     /// Descend a nested array/hash through all-scalar dimensions, promoting the
@@ -461,6 +598,22 @@ impl Interpreter {
     /// it is expanded into an explicit `Array` of indices (matching how a bare
     /// `(0,1,2)` list dimension is already handled). Scalars, `Whatever`,
     /// `WhateverCode` (`Sub`), and `Array` dimensions are returned unchanged.
+    /// Expand a `||`-spread subscript's single dimension into the real
+    /// dimensions. `@a[|| @list]` parses to a one-dimension `MultiDimIndex`
+    /// whose sole dimension is the `||` operand list; each ELEMENT of that list
+    /// is a subscript dimension (`@a[|| ((0,1),0)]` ≡ `@a[(0,1);0]`). A single-
+    /// dimension `MultiDimIndex` is produced ONLY by `||` (a `;`-list has 2+
+    /// dims and a lone index parses to `Index`), so this expansion is
+    /// unambiguous. A scalar operand (`@a[|| 5]` ≡ `@a[5]`) stays one dimension.
+    pub(super) fn expand_pipe_multidim_dims(dims: Vec<Value>) -> Vec<Value> {
+        if dims.len() == 1
+            && let Some(items) = dims[0].as_list_items()
+        {
+            return items.to_vec();
+        }
+        dims
+    }
+
     pub(super) fn normalize_multidim_dim(dim: &Value) -> Value {
         match dim.view() {
             ValueView::Range(..)
@@ -520,6 +673,7 @@ impl Interpreter {
             dims.push(self.stack.pop().unwrap_or(Value::NIL));
         }
         dims.reverse();
+        let dims = Self::expand_pipe_multidim_dims(dims);
         let value = self.stack.pop().unwrap_or(Value::NIL);
 
         let var_name = Self::const_str(code, name_idx).to_string();
@@ -641,6 +795,7 @@ impl Interpreter {
             dims.push(self.stack.pop().unwrap_or(Value::NIL));
         }
         dims.reverse();
+        let dims = Self::expand_pipe_multidim_dims(dims);
         let mut target = self.stack.pop().unwrap_or(Value::NIL);
         let is_shaped = crate::runtime::utils::is_shaped_array(&target);
         if is_shaped {

--- a/t/multidim-slice-lvalue.t
+++ b/t/multidim-slice-lvalue.t
@@ -1,0 +1,74 @@
+use v6.e.PREVIEW;
+use Test;
+
+# Pins the multi-dimensional slice lvalue / `||` subscript / `:delete:k` fixes
+# exercised by roast/S32-array/multislice-6e.t.
+
+plan 17;
+
+my @array;
+sub set-up { @array = [[[42,666,[314]],],]; }
+
+# --- A raw `\target` bound to a multi-dim slice lvalue distributes on assign ---
+sub assign-through(\target, \values) { target = values }
+
+# single scalar leaf (existing)
+set-up;
+is-deeply assign-through(@array[0;0;0], 999), 999, 'scalar leaf assign returns value';
+is-deeply @array, [[[999,666,[314]],],], 'scalar leaf mutated in place';
+
+# list slice dimension over existing leaves distributes element-wise
+set-up;
+is-deeply assign-through(@array[0;0;(0,1,2)], (7,8,9)), (7,8,9), 'slice assign returns list';
+is-deeply @array, [[[7,8,9],],], 'slice distributed element-wise';
+
+# whatever slice dimension
+set-up;
+assign-through(@array[*;0;0], (777,));
+is-deeply @array, [[[777,666,[314]],],], 'whatever-dim slice mutated leaf';
+
+# missing scalar leaf autovivifies through the raw bind
+set-up;
+assign-through(@array[0;0;3], 999);
+is-deeply @array, [[[42,666,[314],999],],], 'missing leaf autovivified';
+set-up;
+assign-through(@array[1;0;0], 999);
+is-deeply @array, [[[42,666,[314]],],[[999],]], 'missing top-level autovivified';
+
+# The write must be visible immediately (inside the callee), not deferred.
+sub check-inside(\target, \values, @expect) {
+    target = values;
+    is-deeply @array, @expect, 'write visible immediately inside callee';
+}
+set-up;
+check-inside(@array[0;0;(0,1,2)], (1,2,3), [[[1,2,3],],]);
+
+# ... and through a captured closure (subtest-style capture)
+sub via-closure(\target, \values, @expect) {
+    my $r;
+    { $r = (target = values) }
+    is-deeply @array, @expect, 'write visible through captured closure';
+}
+set-up;
+via-closure(@array[0;0;(0,1,2)], (4,5,6), [[[4,5,6],],]);
+
+# --- `||` spreads a list into subscript dimensions ---
+{
+    my @a;
+    my @indices := (0,1), 0;
+    is-deeply (@a[|| @indices] = 42, 666), (42,666), '|| assign returns values';
+    is-deeply @a, [[42],[666]], '|| initialised nested arrays';
+    is-deeply (@a[|| @indices] = 7, 8), (7,8), '|| reassign';
+    is-deeply @a, [[7],[8]], '|| reassigned in place';
+    is-deeply (@a[|| @indices]:delete), (7,8), '|| :delete returns values';
+    is-deeply @a, [[],[]], '|| :delete removed leaves';
+    is-deeply @a[|| 1], [], '|| single index (emptied leaf)';
+}
+
+# --- `:delete:k` / `:delete:kv` / `:delete:p` (delete BEFORE the value adverb) ---
+{
+    my @m = [1,2,3], [4,5,6], [7,8,9];
+    is-deeply @m[*; {1,2}]:delete:k,
+      ((0,1),(0,2),(1,1),(1,2),(2,1),(2,2)),
+      ':delete:k yields coordinate keys';
+}


### PR DESCRIPTION
Makes `roast/S32-array/multislice-6e.t` pass (812/812) and adds it to the whitelist.

Five related gaps in multi-dimensional subscript handling:

1. **Slice-dimension lvalue aliasing.** A raw `\target` / `is rw` param bound to a multi-dim subscript with a slice dimension (`@a[0;0;(0,1,2)]`, `@a[*;0;0]`) now aliases the selected leaves. `MultiDimIndexBindRef` promotes each leaf to a shared `ContainerRef` cell and hands back a cell-list; a whole-value `target = values` distributes the RHS element-wise through the cells — the array analogue of the existing `@slice := @array[1,2]` bound slice. The write is visible immediately, including inside a captured closure (`subtest { ... }`), across all three assign paths (`SetLocal`, `AssignExprLocal`, env-named). The distribution is gated on a **bind-time marker**, not "elements are cells", so it does not collide with `.grep`'s rw-topic cell promotion (`$x = $x.grep(...)`, S03-operators/assign.t).

2. **Missing-leaf autovivification.** A missing leaf reached through all-scalar dims (`@a[0;0;3]`) or a slice/explicit terminal (`@a[*;0;3]`) autovivifies through the raw bind (new `ensure_array_child`, hole-only so a read-only use is safe), matching the single-index `:=` bind.

3. **`||` dimension spread.** `@a[|| @list]` spreads the operand list's elements into subscript dimensions (`@a[|| ((0,1),0)]` ≡ `@a[(0,1);0]`) for reads, assigns, binds, and `:delete`. A single-dimension `MultiDimIndex` is only ever produced by `||`, so the expansion is unambiguous.

4. **`:delete:k` adverb order.** `:delete:k` / `:delete:kv` / `:delete:p` (delete adverb BEFORE the value adverb) now yields keys/kv-pairs/pairs, matching the reverse `:k:delete` order.

## Testing
- `roast/S32-array/multislice-6e.t`: 812/812 (added to whitelist)
- New pin: `t/multidim-slice-lvalue.t` (17 assertions)
- Full whitelist re-run (1370 files, ~217k tests) green; `make test` green
- Regression caught and fixed pre-merge: an earlier "all cells" heuristic hung `S03-operators/assign.t` via `.grep` rw-topic cells — now marker-gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)