### PR TITLE
fix(vm): keep an array-contextualized Seq (`@$s`) re-iterable in `for`

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -526,9 +526,9 @@ impl Interpreter {
                             .collect();
                         Value::real_array(pairs)
                     }
-                    // Array-contextualizing a Seq (`@$s`) reifies and caches it, so
-                    // it may be read repeatedly. If the Seq's iterator was already
-                    // taken (e.g. by `.skip`/`.iterator`) and not cached, throw.
+                    // Array-contextualizing a Seq (`@$s`) caches it, so it may be
+                    // read repeatedly. If the Seq's iterator was already taken
+                    // (e.g. by `.skip`/`.iterator`) and not cached, throw.
                     ValueView::Seq(items) => {
                         if crate::value::seq_is_consumed(items)
                             && !crate::value::seq_is_cached(items)

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -143,9 +143,13 @@ impl Interpreter {
 
         // A bare `Seq` is single-shot: a `for` loop consumes its iterator, so a
         // second iteration of the SAME Seq throws X::Seq::Consumed (Rakudo). A Seq
-        // assigned into an `@`-array is reified there and stays re-iterable, so
-        // this only fires for a Seq iterated directly (`my \s = …Seq; for s {…}`).
-        if let ValueView::Seq(arc) = iterable.view() {
+        // that was array-contextualized (`@$s`, which marks it cached) stays
+        // re-iterable, so a `for @$s` loop must NOT consume it — otherwise a
+        // second `for @$s` would spuriously throw (surfaced by Zef::Pluggable
+        // iterating `@$backend` across two calls).
+        if let ValueView::Seq(arc) = iterable.view()
+            && !crate::value::seq_is_cached(arc)
+        {
             crate::value::seq_consume(arc)?;
         }
         let raw_items = if let ValueView::LazyList(ll) = iterable.view() {

--- a/t/seq-array-context-reiterate.t
+++ b/t/seq-array-context-reiterate.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+# Array-contextualizing a Seq held in a scalar (`@$s`) reifies it into a
+# re-iterable list, matching Rakudo. A second `for @$s` / read must NOT throw
+# X::Seq::Consumed. Regression for a bug surfaced by `zef list`
+# (Zef::Pluggable!list-plugins iterates `@$backend` where a backend element is a
+# Seq, across two calls).
+
+plan 7;
+
+# 1. Two `for @$s` loops both iterate the full Seq.
+{
+    my $s = (1, 2, 3).map({ $_ });
+    my @first;
+    my @second;
+    for @$s -> $x { @first.push($x) }
+    for @$s -> $x { @second.push($x) }
+    is-deeply @first, [1, 2, 3], 'first  for @$s iterates all elements';
+    is-deeply @second, [1, 2, 3], 'second for @$s re-iterates (no X::Seq::Consumed)';
+}
+
+# 2. A list-context read (.elems) followed by a `for @$s` still iterates.
+{
+    my $s = (10, 20, 30).map({ $_ });
+    is @$s.elems, 3, '@$s.elems reifies without consuming';
+    my @vals;
+    for @$s -> $x { @vals.push($x) }
+    is-deeply @vals, [10, 20, 30], 'for @$s after .elems still iterates all';
+}
+
+# 3. Repeated list-context aggregate reads see the same data.
+{
+    my $s = (1, 2, 3, 4).grep({ $_ %% 2 });   # Seq of (2, 4)
+    is @$s.sum, 6, 'first  @$s.sum';
+    is @$s.sum, 6, 'second @$s.sum (re-iterable)';
+}
+
+# 4. Nested iteration like Zef::Pluggable!list-plugins: a Seq element of an
+#    array iterated via `@$inner` across two outer passes.
+{
+    my @backends = ((1, 2).map({ $_ }),);   # one element, itself a Seq
+    my @collected;
+    for ^2 {
+        for @backends -> $backend {
+            for @$backend -> $plugin { @collected.push($plugin) }
+        }
+    }
+    is-deeply @collected, [1, 2, 1, 2], 'nested @$backend re-iterates across passes';
+}


### PR DESCRIPTION
## Problem

`@$s` (array-contextualizing a Seq held in a scalar) marks the Seq **cached** so it can be read repeatedly, matching Rakudo. But the `for` loop still called `seq_consume()` **unconditionally** on any `Seq` iterable, so a second `for @$s` spuriously threw `X::Seq::Consumed`.

Minimal repro (raku re-iterates fine, mutsu threw):

```raku
my $backend = (1, 2, 3).map({ $_ });   # a Seq
for @$backend -> $x { say $x }          # 1 2 3
for @$backend -> $x { say $x }          # BEFORE: X::Seq::Consumed
```

## Fix

Skip the single-shot `seq_consume()` guard in the `for` loop when the Seq is already cached (`seq_is_cached`). A Seq iterated **directly** (`my \s = ...Seq; for s {...}`) is still consumed on the first pass and correctly throws on the second.

## How it surfaced

`zef list` aborted with `X::Seq::Consumed`. Traced to `Zef::Pluggable!list-plugins`, which iterates `@$backend` where a backend element is a `Seq`, across two `.available` calls — the second pass threw. After this fix `zef list` proceeds past the Seq error to the (environmental) network-fetch stage.

## Tests

- New `t/seq-array-context-reiterate.t` (7 subtests) — verified identical output on `raku`.
- Existing `t/seq-skip-consumed.t` still passes (direct-`.skip` consume + cached-survives-`.skip` cases).
- Full `make test` PASS (1576 files, 15458 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)