### PR TITLE
fix(runtime): honor `next`/`last` loop control inside `.first`

### DIFF
--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -469,7 +469,16 @@ pub(crate) fn find_first_match_generic(
         let actual_idx = if from_end { len - 1 - idx } else { idx };
         let item = list_items[actual_idx].clone();
         let matched = match pattern {
-            Some(p) => matcher.item_matches(p, &item)?,
+            // A block matcher may run `next`/`last` (loop control). `next` skips
+            // the current element (treat as non-matching); `last` stops the scan
+            // and returns the CURRENT element as the match (Rakudo behaviour, e.g.
+            // `(5,1,2).first({ last if $_ == 1; $_ > 10 })` returns 1).
+            Some(p) => match matcher.item_matches(p, &item) {
+                Ok(m) => m,
+                Err(e) if e.is_next() => false,
+                Err(e) if e.is_last() => return Ok(Some((actual_idx, item))),
+                Err(e) => return Err(e),
+            },
             None => true,
         };
         if matched {

--- a/t/first-loop-control.t
+++ b/t/first-loop-control.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# `next`/`last` loop control inside a `.first`/`first` block. Rakudo:
+#   * `next` skips the current element (treat as non-matching, keep scanning)
+#   * `last` stops the scan and returns the CURRENT element as the match
+# Regression for a bug where either threw X::ControlFlow (surfaced by
+# Zef::Repository::Ecosystems.update using `$!mirrors.first: -> $uri { ... next ... }`).
+
+plan 9;
+
+# next skips an element, later one matches
+is (1, 2, 3, 4).first({ next if $_ == 2; $_ > 1 }), 3, 'method .first: next skips element';
+
+# sub form
+is (first { next if $_ == 2; $_ > 1 }, 1, 2, 3, 4), 3, 'sub first: next skips element';
+
+# :end (reversed scan) with next
+is (1, 2, 3, 4).first({ next if $_ == 4; $_ > 1 }, :end), 3, '.first :end with next';
+
+# last returns the current element (even though the block body is false for it)
+is (5, 1, 2, 3).first({ last if $_ == 1; $_ > 10 }), 1, '.first: last returns current element (A)';
+is (5, 6, 1, 2).first({ last if $_ == 1; $_ > 10 }), 1, '.first: last returns current element (B)';
+
+# a normal match before `last` fires wins
+is (1, 2, 3, 4).first({ last if $_ == 3; $_ > 1 }), 2, '.first: earlier normal match beats last';
+
+# last on the very first element returns it
+is (7, 8, 9).first({ last }), 7, '.first: bare last returns first element';
+
+# next on every element => no match (undefined result)
+nok (1, 2, 3).first({ next; True }).defined, '.first: next-always yields no match';
+
+# last never fires and nothing matches => no match
+nok (1, 2, 3).first({ last if $_ == 99; $_ > 10 }).defined, '.first: no match yields undefined';


### PR DESCRIPTION
## Problem

A block matcher passed to `.first`/`first` may run `next` or `last`. mutsu propagated the control exception as `X::ControlFlow` instead of handling it, aborting the call:

```raku
(1, 2, 3, 4).first({ next if $_ == 2; $_ > 1 });   # BEFORE: Runtime error: X::ControlFlow
```

`map`/`grep` already handled loop control; `.first` did not.

## Rakudo semantics (verified against `raku`)

- `next` skips the current element (treat as non-matching, keep scanning)
- `last` stops the scan and returns the **current** element as the match — e.g. `(5,1,2).first({ last if $_ == 1; $_ > 10 })` returns `1`

## Fix

Catch the loop-control signal in `find_first_match_generic` (shared by the interpreter and VM matchers): `next` → non-match, `last` → return the current element.

## How it surfaced

`zef list` aborted with `X::ControlFlow` from `Zef::Repository::Ecosystems.update`, which uses `$!mirrors.first: -> $uri { ... next unless ... }`.

## Tests

- New `t/first-loop-control.t` (9 subtests) — verified identical output on `raku`.
- `roast/S32-list/first*.t` + `S04-phasers/first.t` still pass.
- Full `make test` PASS (1576 files, 15460 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)