### PR TITLE
test(supply): de-flake react-nested-whenever-on-demand-close (drop fixed-timer race)

### DIFF
--- a/t/react-nested-whenever-on-demand-close.t
+++ b/t/react-nested-whenever-on-demand-close.t
@@ -10,6 +10,13 @@ use Test;
 # It also verifies a bare `whenever $sod { }` statement does NOT clobber `$sod`
 # with its Tap (which would make the next tap a no-op): the compiler only
 # bridges the tap out through the supply var for `do whenever` expressions.
+#
+# Exit deterministically once `closing` has fired at least once (`done if
+# $closed`) instead of racing a fixed `Promise.in(0.4)` timer: under load the
+# interval timer's first tick could slip past the 0.4s window (0 ticks -> the
+# 0.4s timer wins -> closed=0), which made subtest 2 flaky in CI. A generous
+# 5s backstop keeps a genuine regression (closing never fires) failing cleanly
+# with closed=0 rather than hanging.
 
 plan 3;
 
@@ -22,8 +29,9 @@ plan 3;
     react {
         whenever Supply.interval(0.02) {
             whenever $sod { }
+            done if $closed;
         }
-        whenever Promise.in(0.4) { done }
+        whenever Promise.in(5) { done }
     }
     ok $closed, "async on-demand closing fires from a nested whenever (closed=$closed)";
 }
@@ -37,8 +45,9 @@ plan 3;
     react {
         whenever Supply.interval(0.02) {
             whenever $sod { }
+            done if $closed;
         }
-        whenever Promise.in(0.4) { done }
+        whenever Promise.in(5) { done }
     }
     ok $closed, "sync on-demand closing fires from a nested whenever (closed=$closed)";
 }


### PR DESCRIPTION
## Problem

`t/react-nested-whenever-on-demand-close.t` subtest 2 (`sync on-demand closing fires from a nested whenever`) is flaky in CI (it failed the `test` job on an unrelated PR). It exits its `react` block on a fixed `Promise.in(0.4) { done }` timer while relying on `Supply.interval(0.02)` to have ticked at least once — the tick taps the on-demand supply, fires its `closing` callback, and does `$closed++`.

Under load the interval timer's **first** tick can slip past the 0.4s window, so the 0.4s timer wins the race and the react exits with `closed=0`. Verified locally: **24/24 parallel runs produced `closed=0`** — deterministically losing under load, not just occasionally.

## Fix

Make the test deterministic without depending on wall-clock timer ordering:
- Exit as soon as `closing` has actually fired: `done if $closed` inside the interval `whenever`.
- Keep a generous **5s backstop** (`whenever Promise.in(5) { done }`) so a genuine regression (closing never fires from a nested whenever — the #4327 behavior this test guards) still fails cleanly with `closed=0` instead of hanging.

The nested-whenever + on-demand-closing coverage is unchanged; only the exit condition no longer races a fixed timer.

## Verification

- 24/24 parallel-load runs now pass (was 0/20 under the same load).
- 5/5 single runs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)