### PR TITLE
fix(zef): unblock `zef install` — can-install, map/grep tail assign, MAIN body errors

### DIFF
--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -191,11 +191,19 @@ impl Interpreter {
                     match self.call_main_with_parsed_args(candidate, &parsed, &sub_main_opts) {
                         Ok(()) => return Ok(()),
                         Err(e) => {
-                            let msg = e.message.to_lowercase();
-                            if msg.contains("constraint")
-                                || msg.contains("type check")
-                                || msg.contains("where")
-                            {
+                            // Fall through to the next candidate ONLY when argument
+                            // binding was rejected (a parameter type / `where`
+                            // constraint mismatch or an arity mismatch) — i.e. this
+                            // candidate does not accept these args. An error raised
+                            // from the *body* of a matched candidate must propagate,
+                            // not be masked as a dispatch failure that prints Usage.
+                            // A broad substring match on "type check"/"where"
+                            // previously swallowed body errors like "Type check
+                            // failed for return value" (X::TypeCheck::Return) and
+                            // "... where hash initializer expected"
+                            // (X::Hash::Store::OddNumber), so `zef install` reported
+                            // Usage instead of the real failure.
+                            if Self::is_main_binding_rejection(&e) {
                                 continue;
                             }
                             return Err(e);
@@ -437,6 +445,30 @@ impl Interpreter {
             i += 1;
         }
         Ok(ParsedMainArgs { positional, named })
+    }
+
+    /// Whether a `MAIN` candidate call error represents *argument binding
+    /// rejection* (so multi-dispatch should try the next candidate) rather than
+    /// an error thrown from a matched candidate's body (which must propagate).
+    ///
+    /// Discriminated by exception class, not a substring match: a parameter type
+    /// / `where` constraint failure is `X::TypeCheck::Argument` /
+    /// `X::TypeCheck::Binding::*`, and an arity mismatch carries a "Too
+    /// few/many positionals passed" message. Body errors such as
+    /// `X::TypeCheck::Return` or `X::Hash::Store::OddNumber` are excluded.
+    fn is_main_binding_rejection(e: &RuntimeError) -> bool {
+        if e.message.contains("Too few positionals passed")
+            || e.message.contains("Too many positionals passed")
+        {
+            return true;
+        }
+        if let Some(ex) = e.exception.as_ref()
+            && let ValueView::Instance { class_name, .. } = ex.as_ref().view()
+        {
+            let name = class_name.resolve();
+            return name == "X::TypeCheck::Argument" || name.starts_with("X::TypeCheck::Binding");
+        }
+        false
     }
 
     fn call_main_with_parsed_args(

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -141,6 +141,17 @@ impl Interpreter {
                 Some(self.cur_inst_uninstall(&prefix, &dist))
             }
             "installed" => Some(self.cur_inst_installed(&prefix)),
+            "can-install" => {
+                // Mirror rakudo's CompUnit::Repository::Installation.can-install:
+                // writable if the prefix is writable, or it does not yet exist and
+                // its parent directory is writable (so it can be created on install).
+                use crate::runtime::native_io::path_is_writable;
+                let prefix_path = std::path::Path::new(&prefix);
+                let can = path_is_writable(prefix_path)
+                    || (!prefix_path.exists()
+                        && prefix_path.parent().map(path_is_writable).unwrap_or(false));
+                Some(Ok(Value::truth(can)))
+            }
             "path-spec" => Some(Ok(Value::str(format!("inst#{prefix}")))),
             "short-id" => Some(Ok(Value::str_from("inst"))),
             "id" => {

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -28,25 +28,49 @@ fn call_arg_to_expr(arg: &crate::ast::CallArg) -> crate::ast::Expr {
     }
 }
 
-/// If the last non-`SetLine` statement of `body` is a bare `Stmt::Call`, replace
-/// it with `Stmt::Expr(Expr::Call)` so the re-compiled block leaves the call's
-/// value on the stack (otherwise a named/slip-arg tail call is compiled as a
-/// value-discarding statement and the map result wrongly falls back to `$_`).
-pub(super) fn normalize_tail_call_for_value(body: &[crate::ast::Stmt]) -> Vec<crate::ast::Stmt> {
-    use crate::ast::{Expr, Stmt};
+/// Normalize the last non-`SetLine` statement of a `.map`/`.grep` block `body`
+/// so the re-compiled block leaves its value on the stack (otherwise the map/grep
+/// result wrongly falls back to the topic `$_`). Two statement shapes compile as
+/// value-discarding statements and need rewriting into their expression form:
+///
+/// - a bare `Stmt::Call` carrying named/slip args (`f(k => v)`) → `Stmt::Expr(Call)`
+/// - a plain `Stmt::Assign` to an already-declared variable (`$x = 9`) →
+///   `Stmt::Expr(AssignExpr)`, so `(1, 2, 3).map({ $x = 9 })` yields the assigned
+///   value, not the topic. Using the assignment *expression* keeps the normal
+///   store (readonly / type-constraint checks) intact.
+pub(super) fn normalize_tail_stmt_for_value(body: &[crate::ast::Stmt]) -> Vec<crate::ast::Stmt> {
+    use crate::ast::{AssignOp, Expr, Stmt};
     let Some(last_idx) = body.iter().rposition(|s| !matches!(s, Stmt::SetLine(_))) else {
         return body.to_vec();
     };
-    if let Stmt::Call { name, args } = &body[last_idx] {
-        let expr_args = args.iter().map(call_arg_to_expr).collect();
-        let mut out = body.to_vec();
-        out[last_idx] = Stmt::Expr(Expr::Call {
-            name: *name,
-            args: expr_args,
-        });
-        out
-    } else {
-        body.to_vec()
+    match &body[last_idx] {
+        Stmt::Call { name, args } => {
+            let expr_args = args.iter().map(call_arg_to_expr).collect();
+            let mut out = body.to_vec();
+            out[last_idx] = Stmt::Expr(Expr::Call {
+                name: *name,
+                args: expr_args,
+            });
+            out
+        }
+        // A plain assignment to an existing variable; compound ops desugar the
+        // operator into the RHS, so `op` is always `Assign` here. A `Feed`-RHS
+        // assignment (`@x = SOURCE ==> SINK`) is left alone — it has its own
+        // sink-context statement lowering.
+        Stmt::Assign {
+            name,
+            expr,
+            op: AssignOp::Assign,
+        } if !matches!(expr, Expr::Feed { .. }) => {
+            let mut out = body.to_vec();
+            out[last_idx] = Stmt::Expr(Expr::AssignExpr {
+                name: name.clone(),
+                expr: Box::new(expr.clone()),
+                is_bind: false,
+            });
+            out
+        }
+        _ => body.to_vec(),
     }
 }
 
@@ -208,7 +232,7 @@ impl Interpreter {
             // `f(k => v)` parses) is compiled as a value-discarding statement, so
             // the result would wrongly fall back to the topic. Normalize such a
             // tail into `Stmt::Expr(Expr::Call)` so its value is preserved.
-            let normalized_body = normalize_tail_call_for_value(&data.body);
+            let normalized_body = normalize_tail_stmt_for_value(&data.body);
             let (code, compiled_fns) = compiler.compile(&normalized_body);
 
             let underscore = "_".to_string();

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -88,7 +88,7 @@ impl Interpreter {
             // to the topic `$_` (see `eval_map_over_items`).
             let compiler = crate::compiler::Compiler::new();
             let normalized_body =
-                super::resolution_map_grep::normalize_tail_call_for_value(&data.body);
+                super::resolution_map_grep::normalize_tail_stmt_for_value(&data.body);
             let (code, compiled_fns) = compiler.compile(&normalized_body);
 
             let underscore = "_".to_string();
@@ -271,7 +271,9 @@ impl Interpreter {
             // a routine is currently on the dynamic call stack.
             let mut compiler = crate::compiler::Compiler::new();
             compiler.lexically_in_routine = !self.routine_stack.is_empty();
-            let (code, compiled_fns) = compiler.compile(&data.body);
+            let normalized_body =
+                super::resolution_map_grep::normalize_tail_stmt_for_value(&data.body);
+            let (code, compiled_fns) = compiler.compile(&normalized_body);
 
             let underscore = "_".to_string();
             let dollar_topic = "$_".to_string();

--- a/t/block-tail-assign-and-main-dispatch.t
+++ b/t/block-tail-assign-and-main-dispatch.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+plan 8;
+
+# --- A block-final assignment to an existing variable carries its value ---
+# `.map({ $x = 9 })` must yield the assigned value, not the topic `$_`.
+my $x;
+is-deeply (1, 2, 3).map({ $x = 9 }).List, (9, 9, 9),
+    'map block ending in $x = 9 yields the assigned value';
+
+# The anonymous scalar `$` assigned in a map block carries its value too.
+is-deeply <a b c>.map({ $ = "X" ~ $_ }).List, ("Xa", "Xb", "Xc"),
+    'map block { $ = ... } yields the assigned anonymous-scalar value';
+
+# do-block parity (unchanged behavior).
+my $y;
+is (do { $y = 42 }), 42, 'do { $y = 42 } yields 42';
+
+# A grep block ending in an assignment is truthy-tested on the assigned value.
+my $z;
+is-deeply (1, 2, 3).grep({ $z = $_ %% 2 }).List, (2,),
+    'grep block ending in $z = ... filters on the assigned value';
+
+# --- MAIN multi-dispatch: body errors propagate, binding rejection falls through ---
+my $prog = $*TMPDIR.add("main-dispatch-{$*PID}.raku");
+sub run-prog($src, *@args) {
+    $prog.spurt: $src;
+    my $proc = run($*EXECUTABLE, $prog, @args, :out, :err);
+    my $out = $proc.out.slurp(:close).chomp;
+    my $err = $proc.err.slurp(:close);
+    ($out, $err);
+}
+
+# Literal-subcommand fallthrough: a non-matching leading literal must reach the
+# next candidate rather than error out.
+my $lit-multi = q:to/RAKU/;
+    multi sub MAIN('go', Str $x) { say "go $x" }
+    multi sub MAIN('stop')       { say "stop" }
+    RAKU
+
+is run-prog($lit-multi, 'go', 'now')[0], 'go now',
+    'MAIN dispatch matches the go subcommand';
+is run-prog($lit-multi, 'stop')[0], 'stop',
+    'MAIN dispatch falls through to the stop subcommand';
+
+# A matched candidate whose body throws a (non-return) type-check error must
+# surface that error, NOT mask it as a "Usage" dispatch failure — the bug that
+# made `zef install` print Usage instead of the real error.
+my ($body-out, $body-err) = run-prog(
+    q:to/RAKU/, 'go');
+    multi sub MAIN('go') { my Int $x = "not-an-int" }
+    RAKU
+like $body-err, /'Type check failed'/,
+    'MAIN body type-check error propagates instead of printing Usage';
+
+# A genuine no-match still prints Usage.
+my ($nomatch-out, $nomatch-err) = run-prog(
+    q:to/RAKU/, 'nope');
+    multi sub MAIN('go') { say "go" }
+    RAKU
+like $nomatch-err, /Usage/, 'a genuine no-match still prints Usage';
+
+$prog.unlink;

--- a/t/compunit-can-install.t
+++ b/t/compunit-can-install.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+# CompUnit::Repository::Installation.can-install mirrors Rakudo: writable if the
+# prefix is writable, or it does not yet exist and its parent is writable (so it
+# can be created on install). zef's `install` command greps repos by
+# `.?can-install` to choose an install target, so a missing method left the whole
+# install pipeline stuck.
+
+plan 3;
+
+my $base = $*TMPDIR.add("can-install-{$*PID}");
+$base.mkdir;
+# Best-effort cleanup: instantiating an Installation may populate the prefix,
+# so a plain rmdir can fail on a non-empty directory — ignore that.
+LEAVE { try { $base.rmdir } }
+
+my $writable = CompUnit::Repository::Installation.new(prefix => $base.absolute);
+ok $writable.can-install, 'writable existing prefix can-install';
+
+my $child = CompUnit::Repository::Installation.new(prefix => $base.add("newchild").absolute);
+ok $child.can-install, 'missing prefix under a writable parent can-install';
+
+my $deep = CompUnit::Repository::Installation.new(prefix => $base.add("a/b/c").absolute);
+nok $deep.can-install, 'missing prefix whose parent also does not exist cannot-install';


### PR DESCRIPTION
Three general-purpose fixes discovered while running the vendored real Zef through mutsu as an `install ./dist` compatibility target. Each is independently correct and regression-tested; together they advance the mzef north-star.

## Fixes

1. **`CompUnit::Repository::Installation.can-install`** was missing, so zef's `.grep(*.?can-install)` for choosing an install target hit `No such method 'can-install'`. Implemented to mirror rakudo: writable if the prefix is writable, or it does not yet exist and its parent is writable (so it can be created on install).

2. **`.map`/`.grep` tail assignment lost its value.** A block whose final statement is a plain assignment to an already-declared variable — `(1,2,3).map({ $x = 9 })`, or the anonymous `$ = expr` idiom zef's `find-meta` uses — wrongly yielded the topic `$_` instead of the assigned value, because the fresh-compiled block body compiled the tail assignment as a value-discarding statement (falling back to the topic). Broadened the map/grep tail normalizer (`normalize_tail_call_for_value` → `normalize_tail_stmt_for_value`) to also rewrite a tail `Stmt::Assign` into `Stmt::Expr(AssignExpr)`, applied on the grep path too. Using the assignment *expression* keeps the normal store (readonly / type-constraint checks) intact — `my $y := 5; (1,2).map({ $y = 9 })` still dies.

3. **MAIN multi-dispatch masked body errors as "Usage".** A broad substring match on `"type check"`/`"where"` swallowed errors raised from a *matched* candidate's body — e.g. `Type check failed for return value` (X::TypeCheck::Return) and `... where hash initializer expected` (X::Hash::Store::OddNumber) — so the command printed the usage message instead of the real failure. Now it falls through to the next candidate only for genuine argument-binding rejection (`X::TypeCheck::Argument` / `X::TypeCheck::Binding::*` or an arity message), discriminated by exception class rather than substring.

## Tests

- `t/compunit-can-install.t` — writable / missing-under-writable-parent / missing-under-missing-parent.
- `t/block-tail-assign-and-main-dispatch.t` — map/grep/anon-`$` tail assignment, do-block parity, MAIN dispatch fallthrough + body-error propagation + genuine-no-match-Usage.

`make test` passes; `S32-list/{map,grep}.t` and `S06-other/main{,-usage}.t` roast tests pass locally.

Note: `zef install` still fails further down the pipeline (a separate `.classify` hash-binding bug and others) — this PR removes the first blockers and makes the remaining errors visible instead of a misleading Usage message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)