### PR TITLE
fix(promise): box lexicals captured by a .then closure as shared cells

### DIFF
--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -101,8 +101,9 @@ impl Compiler {
         self.compile_expr(target);
         let arity = args.len() as u32;
         let arg_sources_idx = self.add_arg_sources_constant(args);
+        let esc = Self::method_escapes_closure_args(&name.resolve());
         for arg in args {
-            self.compile_method_arg(arg);
+            self.compile_method_arg_with_escape(arg, esc);
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
@@ -424,8 +425,9 @@ impl Compiler {
         self.compile_expr(target);
         let arity = args.len() as u32;
         let arg_sources_idx = self.add_arg_sources_constant(args);
+        let esc = Self::method_escapes_closure_args(&name.resolve());
         for arg in args {
-            self.compile_method_arg(arg);
+            self.compile_method_arg_with_escape(arg, esc);
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -97,13 +97,41 @@ impl Compiler {
         false
     }
 
+    /// Methods that STORE their closure argument for later invocation on
+    /// another thread rather than calling it immediately. A closure passed to
+    /// `Promise.then` runs on the thread pool when the promise is kept, so it
+    /// genuinely escapes the call frame — the locals it captures-and-mutates must
+    /// be promoted to shared `ContainerRef` cells (the same escape rule that
+    /// `start {...}` uses). Without this a lexical the parent thread reassigns
+    /// after registering the continuation is invisible to the continuation body,
+    /// which reads a stale clone-time snapshot.
+    ///
+    /// NB: `tap`/`act` are deliberately NOT here. They escape too (the
+    /// socket-listener worker drives them — roast S32-io/socket-recv-vs-read.t
+    /// test 11), but escape-boxing a `.tap` accumulator (`$x ~= $_`) exposes a
+    /// pre-existing double-delivery in the Proc::Async tap path (the live-channel
+    /// async loop AND the await-time replay both fire the tap; the duplicate
+    /// write was silently lost while the capture was a by-value snapshot, but a
+    /// shared cell keeps both — S17-procasync/basic.t test 37). Boxing tap/act
+    /// must wait until that double-delivery is resolved.
+    pub(super) fn method_escapes_closure_args(name: &str) -> bool {
+        matches!(name, "then")
+    }
+
     /// Compile a method call argument. Named args (AssignExpr) are
     /// compiled as Pair values so they survive VM execution.
     pub(super) fn compile_method_arg(&mut self, arg: &Expr) {
-        // A method argument is passed to the callee, not stored in the caller
-        // frame, so a closure argument is conservatively NON-escaping (same
-        // #2746 guard as compile_call_arg).
-        self.with_escape(false, |s| {
+        self.compile_method_arg_with_escape(arg, false);
+    }
+
+    /// Like [`compile_method_arg`] but lets the caller force the closure
+    /// argument into an escaping position (for supply-consuming methods; see
+    /// [`method_escapes_closure_args`]).
+    pub(super) fn compile_method_arg_with_escape(&mut self, arg: &Expr, escaping: bool) {
+        // A method argument is normally passed to the callee, not stored in the
+        // caller frame, so a closure argument is conservatively NON-escaping
+        // (the #2746 guard). `tap`/`act` override this with `escaping = true`.
+        self.with_escape(escaping, |s| {
             s.with_suppress_pair_capture(true, |s| {
                 if let Expr::AssignExpr { name, expr, .. } = arg {
                     // `foo(arg = 1)` in method-call argument position is treated as a

--- a/t/then-captured-lexical-cross-thread.t
+++ b/t/then-captured-lexical-cross-thread.t
@@ -1,0 +1,23 @@
+use Test;
+
+# A closure passed to `Promise.then` runs later on the thread pool when the
+# promise is kept, so it escapes the call frame. A lexical it captures which
+# the parent reassigns *after* registering the continuation must be a shared
+# cell, so the continuation observes the new value rather than a stale
+# clone-time snapshot. Same class as the `.tap`/`.act` escape fix.
+
+plan 1;
+
+my $gate;
+my $p = Promise.new;
+my $seen;
+my $done = $p.then(-> $x {
+    $seen = $gate.defined ?? $gate.status.Str !! "undef";
+});
+$gate = Promise.new;   # reassign AFTER .then registered
+$p.keep(True);
+await $done;
+is $seen, 'Planned',
+    '.then continuation sees the parent-reassigned lexical (shared cell)';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Problem

A closure passed to `Promise.then` runs on the thread pool when the promise is kept, so it genuinely escapes the call frame — exactly like a `start {...}` block. But method-call arguments were compiled in a conservative NON-escaping position, so a lexical the continuation captures-and-mutates was never promoted to a shared `ContainerRef` cell.

Consequence: a lexical the parent thread reassigns **after** registering the continuation was invisible to the continuation body, which read a stale clone-time snapshot (mutsu returned the pre-reassignment value where raku sees the new one).

## Fix

Mark `.then` closure args as escaping (`method_escapes_closure_args`), so the captured-and-mutated lexical is boxed into a shared cell — the same sound mechanism `start` uses (a cell always tracks later mutations; a by-value snapshot is only correct if the var is never mutated).

`tap`/`act` are **deliberately excluded** for now. They escape too (the socket-listener worker drives them — `S32-io/socket-recv-vs-read.t` test 11), but escape-boxing a `.tap` accumulator (`$x ~= $_`) exposes a *pre-existing* double-delivery in the Proc::Async tap path: the live-channel async loop AND the await-time replay both fire the tap, and the duplicate stayed invisible only while the capture was a by-value snapshot (one write lost). A shared cell keeps both → `S17-procasync/basic.t` test 37 doubles its output. Resolving that proc-async double-delivery is tracked in `TODO_roast/S32.md`; until then tap/act stay non-escaping.

## Verification

- New guard `t/then-captured-lexical-cross-thread.t` passes.
- `S17-procasync/basic.t` test 37 unaffected (tap/act unchanged), GC on and off.
- promise / supply / thread / react / whenever / procasync suites all green; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)