### PR TITLE
fix(destructure): bind an absent named-array key to an empty array, not [Any]

### DIFF
--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -644,7 +644,7 @@ fn parse_named_destructuring(
         } else {
             &dvar.name
         };
-        let mut value_expr = Expr::Index {
+        let index_expr = Expr::Index {
             target: Box::new(Expr::HashVar(hash_bare.clone())),
             index: Box::new(Expr::Literal(Value::str(bare_name.to_string()))),
             is_positional: false,
@@ -654,15 +654,34 @@ fn parse_named_destructuring(
         // array. mutsu's destructure lowers to assignment, so de-itemize the value
         // via `.list` for `@`-targets — a no-op for a plain list, but it unwraps a
         // single itemized array so `my (:@even) := classify(...)` yields `[2,4]`.
-        if dvar.name.starts_with('@') {
-            value_expr = Expr::MethodCall {
-                target: Box::new(value_expr),
-                name: crate::symbol::Symbol::intern("list"),
-                args: Vec::new(),
-                modifier: None,
-                quoted: false,
-            };
-        }
+        //
+        // When the key is ABSENT the named-array bind must yield an empty array
+        // (Rakudo parameter-binding semantics), not `[Any]`: a bare `%h<absent>`
+        // is `Any`, and `Any.list` is `(Any,)`, so guard with `:exists` and fall
+        // back to an empty list. `my (:@paths, :@uris) := <a>.classify(...)` must
+        // leave the unmatched `@uris` empty, or a downstream `%(... )` init sees a
+        // stray `(Any,)` and dies with X::Hash::Store::OddNumber.
+        let value_expr = if dvar.name.starts_with('@') {
+            Expr::Ternary {
+                cond: Box::new(Expr::Exists {
+                    target: Box::new(index_expr.clone()),
+                    negated: false,
+                    delete: false,
+                    arg: None,
+                    adverb: crate::ast::ExistsAdverb::None,
+                }),
+                then_expr: Box::new(Expr::MethodCall {
+                    target: Box::new(index_expr),
+                    name: crate::symbol::Symbol::intern("list"),
+                    args: Vec::new(),
+                    modifier: None,
+                    quoted: false,
+                }),
+                else_expr: Box::new(Expr::ArrayLiteral(Vec::new())),
+            }
+        } else {
+            index_expr
+        };
         stmts.push(Stmt::VarDecl {
             name: dvar.name.clone(),
             expr: value_expr,

--- a/t/named-array-destructure-absent-key.t
+++ b/t/named-array-destructure-absent-key.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# A named-array destructuring bind (`my (:@a, :@b) := %hash`) whose key is ABSENT
+# must bind the array to EMPTY, mirroring Rakudo parameter-binding semantics — not
+# `[Any]`. A bare `%h<absent>` is `Any`, and `Any.list` is `(Any,)`, so the naive
+# `%h<key>.list` lowering leaked a stray `(Any,)`. zef's `install` classifies its
+# arguments this way (`my (:@paths, :@uris, :@identities) := @wants.classify(...)`)
+# and a stray `(Any,)` later blew up a `%(...)` hash initializer with
+# X::Hash::Store::OddNumber.
+
+plan 8;
+
+# classify with only some buckets populated: the empty ones bind to []
+{
+    my (:@paths, :@uris, :@identities) := <a ./b c>.classify: -> $w {
+        $w.starts-with('.') ?? <paths> !! <identities>
+    };
+    is-deeply @paths.List,      ('./b',),   'populated bucket binds its elements';
+    is-deeply @identities.List, ('a', 'c'), 'second populated bucket binds its elements';
+    is-deeply @uris.List,       (),         'unmatched bucket binds to an empty array';
+    is @uris.elems, 0, 'unmatched bucket has zero elements (not [Any])';
+}
+
+# itemized buckets are still de-itemized (a classify bucket is an itemized array)
+{
+    my (:@even, :@odd) := (1..5).classify: { $_ %% 2 ?? 'even' !! 'odd' };
+    is-deeply @even.List, (2, 4),    'even bucket de-itemized';
+    is-deeply @odd.List,  (1, 3, 5), 'odd bucket de-itemized';
+}
+
+# a plain hash destructure with a mix of present scalar and absent array
+{
+    my (:$a, :@b) := %(a => 'y');
+    is $a, 'y', 'present scalar key binds';
+    is @b.elems, 0, 'absent array key binds to empty array';
+}


### PR DESCRIPTION
A named-array destructuring bind — `my (:@a, :@b) := %hash` — whose key is **absent** must bind the array to **empty** (Rakudo parameter-binding semantics), not `[Any]`.

## Bug

The destructure desugar lowered every `@`-target to `%tmp<key>.list`. A bare `%h<absent>` is `Any`, and `Any.list` is `(Any,)`, so an unmatched bucket leaked a stray single-element `(Any,)`:

```raku
my (:@paths, :@uris, :@identities) := <a ./b c>.classify: -> $w {
    $w.starts-with('.') ?? <paths> !! <identities>
};
say @uris.raku;   # mutsu (before): [Any]     rakudo: Array[Mu].new()  (empty)
```

## Fix

Guard the `@`-target lowering with `:exists`:

```
@uris = (%tmp<uris>:exists ?? %tmp<uris>.list !! ());
```

Present buckets are still de-itemized (a `.classify` bucket `$[2,4]` → `[2,4]`); absent ones bind to `[]`. Scalar/`%`-targets are unchanged.

## Why it matters

zef's `install` classifies its arguments exactly this way, and the stray `(Any,)` from an unmatched bucket later blew up a `%(...)` hash initializer with `X::Hash::Store::OddNumber` — the next blocker after #4335 on the `zef install` path.

## Tests

`t/named-array-destructure-absent-key.t` — populated buckets bind their elements, unmatched buckets bind to `[]` (not `[Any]`), itemized buckets are still de-itemized, and a mixed present-scalar / absent-array destructure. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)