### PR TITLE
fix(regex): match a user grammar token inside a character class

### DIFF
--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -635,9 +635,14 @@ impl Interpreter {
                         }
                     }
                 };
-                let pos_match = positive
-                    .iter()
-                    .any(|item| match_class_item(item, &chars_to_check));
+                // An empty `positive` means "any character" (a purely-negated
+                // enumerated class like `<-restricted +subrule>` after the
+                // positive user-subrule is desugared into an alternation branch):
+                // the class matches any char that is not in `negative`.
+                let pos_match = positive.is_empty()
+                    || positive
+                        .iter()
+                        .any(|item| match_class_item(item, &chars_to_check));
                 let neg_match = negative
                     .iter()
                     .any(|item| match_class_item(item, &chars_to_check));

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -540,6 +540,14 @@ impl Interpreter {
     ) -> Option<RegexAtom> {
         let mut positive_items: Vec<ClassItem> = Vec::new();
         let mut negative_items: Vec<ClassItem> = Vec::new();
+        // Positive user-defined grammar-token names (e.g. `+name-sep`) that must be
+        // matched as whole subrules (they may consume >1 char) rather than as
+        // single-char class items. Desugared into an alternation at the end.
+        let mut subrule_branches: Vec<String> = Vec::new();
+        // Whether a *negated* item resolves to a user grammar token (`<-restricted>`).
+        // A plain negated `CharClass` cannot resolve such a token at match time, so
+        // route the class through `CompositeClass` (which does) instead.
+        let mut negative_has_grammar_token = false;
         let mut remaining = input.trim();
         // A leading bracket class with no sign (`[a..z] +digit`) is an implicit
         // positive first item: the `+`/`-` only separates the subsequent parts.
@@ -582,10 +590,15 @@ impl Interpreter {
                 let class_end = Self::find_combined_class_part_end(remaining);
                 let class_name = remaining[..class_end].trim();
                 remaining = remaining[class_end..].trim_start();
-                let item = if let Some(prop) = class_name.strip_prefix(':') {
-                    ClassItem::UnicodePropItem {
+                if let Some(prop) = class_name.strip_prefix(':') {
+                    let item = ClassItem::UnicodePropItem {
                         name: prop.to_string(),
                         negated: false,
+                    };
+                    if adding {
+                        positive_items.push(item);
+                    } else {
+                        negative_items.push(item);
                     }
                 } else {
                     // Check if this is a known built-in character class name
@@ -605,15 +618,16 @@ impl Interpreter {
                             | "print"
                             | "ws"
                     );
-                    if !is_known_builtin {
-                        // Check if the name resolves as a grammar token in the current package
-                        let is_grammar_token = !self.current_package().is_empty()
-                            && self.resolve_token_defs(class_name).is_some();
+                    // Check if the name resolves as a grammar token in the current package
+                    let is_grammar_token = !is_known_builtin
+                        && !self.current_package().is_empty()
+                        && self.resolve_token_defs(class_name).is_some();
+                    if !is_known_builtin && !is_grammar_token {
                         // "No such method" is a runtime resolution failure, not a
                         // parse-time syntax error: such patterns are meant to die
                         // at match time (`dies-ok`), not at compile time. In
                         // `Validate` mode treat the unknown name as opaque.
-                        if !is_grammar_token && mode == RegexParseMode::Match {
+                        if mode == RegexParseMode::Match {
                             let msg = format!(
                                 "No such method '{}' for invocant of type 'Match'",
                                 class_name
@@ -624,30 +638,98 @@ impl Interpreter {
                             return None;
                         }
                     }
-                    ClassItem::NamedBuiltin(class_name.to_string())
-                };
-                if adding {
-                    positive_items.push(item);
-                } else {
-                    negative_items.push(item);
+                    // A *positive* user-defined grammar token may match a
+                    // MULTI-character sequence (e.g. `token name-sep { '::' }`),
+                    // which a single-char char class cannot express. Collect it as
+                    // an alternation branch (desugared below) so the subrule is
+                    // matched as a whole unit. Builtins stay as efficient
+                    // single-char class items; a *negated* user token keeps the
+                    // single-char CompositeClass negation (all the enumerated-class
+                    // negative form supports).
+                    if adding && is_grammar_token {
+                        subrule_branches.push(class_name.to_string());
+                    } else {
+                        let item = ClassItem::NamedBuiltin(class_name.to_string());
+                        if adding {
+                            positive_items.push(item);
+                        } else {
+                            if is_grammar_token {
+                                negative_has_grammar_token = true;
+                            }
+                            negative_items.push(item);
+                        }
+                    }
                 }
             }
         }
-        if positive_items.is_empty() && negative_items.is_empty() {
+        if positive_items.is_empty() && negative_items.is_empty() && subrule_branches.is_empty() {
             return None;
         }
-        if positive_items.is_empty() {
-            // Purely negated: <-alpha> means "any character NOT matching alpha"
-            Some(RegexAtom::CharClass(CharClass {
-                items: negative_items,
-                negated: true,
-            }))
+        if subrule_branches.is_empty() {
+            // No user-subrule parts — the original char-class atoms.
+            if positive_items.is_empty() {
+                // A negated user grammar token (`<-restricted>`) must resolve at
+                // match time, which the plain negated `CharClass` path cannot do —
+                // route it through `CompositeClass` (empty positive = "any char").
+                if negative_has_grammar_token {
+                    return Some(RegexAtom::CompositeClass {
+                        positive: positive_items,
+                        negative: negative_items,
+                    });
+                }
+                // Purely negated: <-alpha> means "any character NOT matching alpha"
+                return Some(RegexAtom::CharClass(CharClass {
+                    items: negative_items,
+                    negated: true,
+                }));
+            }
+            return Some(RegexAtom::CompositeClass {
+                positive: positive_items,
+                negative: negative_items,
+            });
+        }
+        // The single-char portion of the enumerated class. Always a
+        // `CompositeClass` (not a negated `CharClass`) so that negated
+        // grammar-token items resolve at match time; the CompositeClass matcher
+        // treats an empty `positive` as "any char" (see its `pos_match` fallback).
+        let class_atom = if positive_items.is_empty() && negative_items.is_empty() {
+            None
         } else {
             Some(RegexAtom::CompositeClass {
                 positive: positive_items,
                 negative: negative_items,
             })
+        };
+        // Desugar an enumerated class carrying positive user-subrules into an
+        // LTM alternation: `<-restricted +name-sep>` -> `[ <name-sep> | <-restricted> ]`.
+        // The subrule branches are non-capturing (char classes never capture).
+        let make_pattern = |atom: RegexAtom| RegexPattern {
+            tokens: vec![RegexToken {
+                atom,
+                quant: RegexQuant::One,
+                named_capture: None,
+                secondary_named_capture: None,
+                hash_capture: None,
+                force_list_capture: false,
+                ratchet: false,
+                frugal: false,
+                separator: None,
+            }],
+            anchor_start: false,
+            anchor_end: false,
+            ignore_case: false,
+            ignore_mark: false,
+        };
+        let mut branches: Vec<RegexPattern> = subrule_branches
+            .into_iter()
+            // Prefix with `.` so the subrule is matched *silently* (no named
+            // capture) — a character class never captures.
+            .map(|name| make_pattern(RegexAtom::Named(format!(".{name}"))))
+            .collect();
+        if let Some(atom) = class_atom {
+            branches.push(make_pattern(atom));
         }
+        Some(RegexAtom::Alternation(branches))
     }
 
     /// Whether a bracket-class string (`[a..z] +digit`) is followed by a

--- a/t/regex-charclass-subrule-union.t
+++ b/t/regex-charclass-subrule-union.t
@@ -1,0 +1,82 @@
+use v6;
+use Test;
+
+# A character class may union in a user-defined grammar token that matches a
+# MULTI-character sequence: `<+name-sep>` where `token name-sep { '::' }`. mutsu's
+# char class was single-char-only, so such a class never matched. This is the
+# construct zef's `Zef::Identity` REQUIRE grammar uses for module names
+# (`regex name { <-restricted +name-sep>+ }`).
+
+plan 9;
+
+grammar G {
+    regex name       { <-restricted +name-sep>+ }
+    token restricted { <[ : < > ( ) ]> }
+    token name-sep   { '::' }
+}
+
+# The multi-char subrule matches inside the class.
+ok G.subparse('::', :rule<name>).defined, 'bare <+name-sep> matches the "::" sequence';
+
+# A qualified name flows across the `::` separator, stopping at a restricted char.
+{
+    my $m = G.subparse('Foo::Bar', :rule<name>);
+    ok $m.defined, 'name matches across "::"';
+    is ~$m, 'Foo::Bar', 'name captures the whole qualified identifier';
+}
+
+# The class stops at a restricted char (`:` alone is restricted, only `::` passes).
+{
+    my $m = G.subparse('Foo::Bar:ver', :rule<name>);
+    is ~$m, 'Foo::Bar', 'name stops before a lone restricted ":"';
+}
+
+# The unioned subrule is matched SILENTLY (a char class never captures).
+{
+    my $m = G.subparse('Foo::Bar', :rule<name>);
+    is $m.hash.keys.elems, 0, 'the unioned subrule does not leak a capture';
+}
+
+# A single-char user token union still works (regression guard).
+grammar H {
+    regex word    { <+letter +digit>+ }
+    token letter  { <[a..z]> }
+    token digit   { <[0..9]> }
+}
+{
+    my $m = H.subparse('ab12', :rule<word>);
+    is ~$m, 'ab12', 'single-char user-token union still matches';
+}
+
+# Purely-negated user token alone (regression guard: <-restricted> resolves the
+# grammar token, not "match nothing").
+grammar K {
+    regex body       { <-restricted>+ }
+    token restricted { <[ : ]> }
+}
+{
+    my $m = K.subparse('abc:def', :rule<body>);
+    is ~$m, 'abc', '<-restricted> negation resolves the grammar token';
+}
+
+# The subrule can be tried first (LTM) so a longer subrule match wins over a
+# single class char at the same spot.
+grammar L {
+    regex t        { <+single +ab>+ }
+    token single   { <[a..z]> }
+    token ab       { 'ab' }
+}
+{
+    # "ab" — LTM should let either interpretation match the full string.
+    my $m = L.subparse('abc', :rule<t>);
+    is ~$m, 'abc', 'LTM alternation over class + multi-char subrule matches greedily';
+}
+
+# The exact zef REQUIRE name shape.
+grammar REQUIRE {
+    regex name       { <-restricted +name-sep>+ }
+    token restricted { [ ':' | '<' | '>' | '(' | ')' ] }
+    token name-sep   { < :: > }
+}
+is ~REQUIRE.subparse('Acme::Foo::Bar', :rule<name>), 'Acme::Foo::Bar',
+    'zef REQUIRE-style name matches a multi-part qualified name';


### PR DESCRIPTION
A character class could not union in (or subtract) a user-defined grammar token that a single-char class item cannot represent.

## Bug

```raku
grammar G {
    regex name       { <-restricted +name-sep>+ }
    token restricted { <[ : < > ( ) ]> }
    token name-sep   { '::' }
}
G.subparse('Foo::Bar', :rule<name>);   # mutsu: no match / wrong;  raku: 「Foo::Bar」
```

Two related failures:
- **`<+name-sep>`** where `name-sep` matches the MULTI-char `::` — the char class was single-char only, so it never matched.
- **`<-restricted>`** (negated user token) — compiled to a plain negated `CharClass` whose matcher only knows *builtin* class names, so `restricted` resolved to "no builtin" and the negation matched **every** character.

This is exactly zef's `Zef::Identity` REQUIRE grammar (`regex name { <-restricted +name-sep>+ }`, `token key { <-restricted>+ }`), so `Zef::Identity.new("Foo::Bar:ver<…>")` returned an undefined object and cascaded into a bogus `X::Hash::Store::OddNumber` on the `zef install` path (surfaced now that #4335 stopped masking it).

## Fix (`parse_combined_class`)

- A **positive** user grammar-token item desugars the whole enumerated class into an LTM alternation: `<-restricted +name-sep>` → `[ <.name-sep> | <-restricted> ]`. The subrule branch is silent (`.`-prefixed) — a char class never captures.
- A **negated** user grammar-token class is emitted as a `CompositeClass` (which resolves grammar tokens at match time) instead of a negated `CharClass`.
- The `CompositeClass` matcher now treats an empty `positive` as "any char", so the purely-negated form means "any char not in negative".

Builtin single-char classes (`<+alpha>`, `<-digit>`, …) are unchanged.

## Tests

`t/regex-charclass-subrule-union.t` (9 subtests, matches raku): multi-char subrule union, cross-`::` name matching, silent (no leaked capture), single-char user-token union, negated-user-token resolution, LTM, and the zef REQUIRE-name shape. `make test` PASS; S05-grammar / S05-metasyntax roast tests PASS.

**Scope note:** the full REQUIRE grammar also needs the `value` regex features (`~` goalpost, `<(…)>`, `%%`) — a separate blocker. This PR fixes only the character-class-subrule half, so `name` and `key` now match correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)