### PR TITLE
fix(proc-async): single-delivery taps via await-time replay + escape-box tap/act closures

### DIFF
--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -901,10 +901,13 @@
 - [ ] roast/S32-io/socket-accept-and-working-threads.t
 - [ ] roast/S32-io/socket-fail-invalid-values.t
 - [ ] roast/S32-io/socket-host-port-split.t
-- [ ] roast/S32-io/socket-recv-vs-read.t
-  - Hangs (no output at all). Requires a working `IO::Socket::Async.listen(...).tap(...)`
-    server combined with `IO::Socket::INET` client recv/read; mutsu blocks during setup.
-    Deep async-socket + threading feature gap, deferred.
+- [x] roast/S32-io/socket-recv-vs-read.t
+  - 13/13. Test 11 needed cross-thread lexical sharing for `.tap` closures: the tap
+    body `await`ed a promise the parent thread reassigned after registration, but the
+    capture was a clone-time by-value snapshot. Fixed by escape-boxing `.tap`/`.act`
+    closure args (shared `ContainerRef` cells), which first required unifying the
+    Proc::Async tap double-delivery (live-channel act loop + await-time replay) to
+    the replay path only.
 - [ ] roast/S32-io/spurt.t
 - [ ] roast/S32-io/tell.t
 - [ ] roast/S32-io/utf16.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1128,6 +1128,7 @@ roast/S32-io/slurp.t
 roast/S32-io/socket-accept-and-working-threads.t
 roast/S32-io/socket-fail-invalid-values.t
 roast/S32-io/socket-host-port-split.t
+roast/S32-io/socket-recv-vs-read.t
 roast/S32-io/spurt.t
 roast/S32-io/tell.t
 roast/S32-io/utf16.t

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -24,6 +24,17 @@ per_file_timeout() {
       # This test intentionally uses multiple sleep 1 calls and needs >30s.
       echo 60
       ;;
+    roast/S17-supply/syntax.t)
+      # 90 concurrency-heavy subtests: a ^500 react/channel stress loop
+      # (1000 short-lived threads), Supply.interval polling, and fixed
+      # Promise.in waits. Wall-clock is highly load-sensitive (measured
+      # 19-35s run-to-run on an idle 12-core box, debug and release alike,
+      # identical on main); under `prove -j4` on a 4-core CI runner the
+      # default 30s budget times it out mid-file (exit 124, Failed: 0)
+      # while the gc-stress job's 2x-scaled 60s budget passes. Same
+      # rationale as S17-promise/start.t above.
+      echo 60
+      ;;
     roast/S17-promise/allof.t)
       # This test uses sleep 2*$_ with $_ up to 9, parallel start blocks take ~18s.
       echo 60

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -106,16 +106,16 @@ impl Compiler {
     /// after registering the continuation is invisible to the continuation body,
     /// which reads a stale clone-time snapshot.
     ///
-    /// NB: `tap`/`act` are deliberately NOT here. They escape too (the
-    /// socket-listener worker drives them — roast S32-io/socket-recv-vs-read.t
-    /// test 11), but escape-boxing a `.tap` accumulator (`$x ~= $_`) exposes a
-    /// pre-existing double-delivery in the Proc::Async tap path (the live-channel
-    /// async loop AND the await-time replay both fire the tap; the duplicate
-    /// write was silently lost while the capture was a by-value snapshot, but a
-    /// shared cell keeps both — S17-procasync/basic.t test 37). Boxing tap/act
-    /// must wait until that double-delivery is resolved.
+    /// `tap`/`act` escape too: a supply tap callback is stored and later driven
+    /// by whatever thread emits into the supply (e.g. the socket-listener worker
+    /// — roast S32-io/socket-recv-vs-read.t test 11). Boxing their accumulators
+    /// became safe once the Proc::Async tap path was unified to a single
+    /// delivery (the await-time `replay_proc_taps`; the tap-time live-channel
+    /// loop used to fire the same collected output a second time, which a
+    /// by-value snapshot silently swallowed but a shared cell keeps —
+    /// S17-procasync/basic.t test 37).
     pub(super) fn method_escapes_closure_args(name: &str) -> bool {
-        matches!(name, "then")
+        matches!(name, "then" | "tap" | "act")
     }
 
     /// Compile a method call argument. Named args (AssignExpr) are

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -313,7 +313,14 @@ impl Interpreter {
         self.replay_proc_output(stdout_sid, &stdout_taps, collected_stdout);
         self.replay_proc_output(stderr_sid, &stderr_taps, collected_stderr);
 
-        if !collected_merged.is_empty() && !supply_taps.is_empty() {
+        let merged_sid = match attributes.as_map().get("supply_id").map(Value::view) {
+            Some(ValueView::Int(sid)) => Some(sid as u64),
+            _ => None,
+        };
+        let merged_first_replay = merged_sid
+            .map(super::super::native_methods::mark_supply_replayed)
+            .unwrap_or(true);
+        if merged_first_replay && !collected_merged.is_empty() && !supply_taps.is_empty() {
             for tap in &supply_taps {
                 let _ = self.call_sub_value(
                     tap.clone(),
@@ -331,8 +338,15 @@ impl Interpreter {
     /// encoding error" behaviour (roast S17-procasync/encoding.t).
     fn replay_proc_output(&mut self, sid: Option<u64>, value_taps: &[Value], fallback: String) {
         use super::super::native_methods::{
-            get_supply_enc, get_supply_quit_taps, take_supply_collected_bytes,
+            get_supply_enc, get_supply_quit_taps, mark_supply_replayed, take_supply_collected_bytes,
         };
+        // Replay is once-per-stream: a second `await`/`.result` on the same Proc
+        // must not deliver the collected output to the taps again.
+        if let Some(sid) = sid
+            && !mark_supply_replayed(sid)
+        {
+            return;
+        }
         let (text, quit_reason) = match sid {
             Some(sid) => {
                 let enc = get_supply_enc(sid).unwrap_or_else(|| "utf-8".to_string());

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -215,10 +215,15 @@ impl Interpreter {
         let supply_id = super::native_methods::next_supply_id();
         let stdout_descriptor = SharedPromise::new();
         let stderr_descriptor = SharedPromise::new();
+        // `proc_output` marks the supply as a Proc::Async output stream: a plain
+        // `.tap`/`.act` on it is delivered exactly once, by the await/result-time
+        // `replay_proc_taps`, never by the tap-time live-channel loop (which
+        // would double-deliver — see the tap arm in native_supply_mut_methods).
         let mut stdout_supply_attrs = HashMap::new();
         stdout_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
         stdout_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
         stdout_supply_attrs.insert("supply_id".to_string(), Value::int(stdout_id as i64));
+        stdout_supply_attrs.insert("proc_output".to_string(), Value::TRUE);
         stdout_supply_attrs.insert("enc".to_string(), enc.clone());
         stdout_supply_attrs.insert(
             "native_descriptor_promise".to_string(),
@@ -228,6 +233,7 @@ impl Interpreter {
         stderr_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
         stderr_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
         stderr_supply_attrs.insert("supply_id".to_string(), Value::int(stderr_id as i64));
+        stderr_supply_attrs.insert("proc_output".to_string(), Value::TRUE);
         stderr_supply_attrs.insert("enc".to_string(), enc.clone());
         stderr_supply_attrs.insert(
             "native_descriptor_promise".to_string(),
@@ -237,6 +243,7 @@ impl Interpreter {
         merged_supply_attrs.insert("values".to_string(), Value::array(Vec::new()));
         merged_supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
         merged_supply_attrs.insert("supply_id".to_string(), Value::int(supply_id as i64));
+        merged_supply_attrs.insert("proc_output".to_string(), Value::TRUE);
 
         let mut attrs = HashMap::new();
         attrs.insert("cmd".to_string(), Value::array(positional));

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -28,13 +28,13 @@ pub(crate) use state_lock::{acquire_lock, current_thread_id, lock_runtime_by_id,
 // (`crate::vm::vm_react_loop`): the supplier registry accessors it polls.
 pub(in crate::runtime) use state::{
     UdpBoundSocketState, allocate_async_listen_port, get_supply_collected_output, get_supply_enc,
-    get_supply_quit_taps, get_supply_taps, lookup_async_listener, next_async_socket_id,
-    next_supply_id, proc_stdin_map, register_async_connection, register_promise_combinator_sources,
-    register_supply_quit_tap, register_supply_tap, register_udp_bound_socket,
-    set_supply_collected_bytes, set_supply_collected_output, set_supply_enc, supplier_done,
-    supplier_done_deferred, supplier_emit, supplier_id_from_attrs, supplier_quit, supplier_reset,
-    supplier_reset_keep_quit, supply_channel_map, supply_channel_map_pub,
-    take_supply_collected_bytes, udp_port_in_use, update_async_connection,
+    get_supply_quit_taps, get_supply_taps, lookup_async_listener, mark_supply_replayed,
+    next_async_socket_id, next_supply_id, proc_stdin_map, register_async_connection,
+    register_promise_combinator_sources, register_supply_quit_tap, register_supply_tap,
+    register_udp_bound_socket, set_supply_collected_bytes, set_supply_collected_output,
+    set_supply_enc, supplier_done, supplier_done_deferred, supplier_emit, supplier_id_from_attrs,
+    supplier_quit, supplier_reset, supplier_reset_keep_quit, supply_channel_map,
+    supply_channel_map_pub, take_supply_collected_bytes, udp_port_in_use, update_async_connection,
 };
 // Supplier registry accessors driven by the VM-side react/supply loop.
 pub(crate) use state::{

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -632,6 +632,22 @@ pub(in crate::runtime) fn take_supply_collected_bytes(supply_id: u64) -> Option<
         .and_then(|mut map| map.remove(&supply_id))
 }
 
+/// Once-guard for the await/result-time Proc::Async tap replay. Returns `true`
+/// only the first time it is called for a given output-supply id: `await
+/// $p.start` followed by `.result` (or a second `await`) must not deliver the
+/// same collected output to the registered taps again.
+pub(in crate::runtime) fn mark_supply_replayed(supply_id: u64) -> bool {
+    type ReplayedSet = std::sync::Mutex<std::collections::HashSet<u64>>;
+    fn replayed_set() -> &'static ReplayedSet {
+        static SET: OnceLock<ReplayedSet> = OnceLock::new();
+        SET.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+    }
+    replayed_set()
+        .lock()
+        .map(|mut set| set.insert(supply_id))
+        .unwrap_or(false)
+}
+
 /// Register a `quit =>` handler on a Proc::Async output Supply. Unlike ordinary
 /// value taps these fire only when the stream ends in an encoding error.
 pub(in crate::runtime) fn register_supply_quit_tap(supply_id: u64, tap: Value) {

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -179,9 +179,20 @@ impl Interpreter {
                     }
                 }
 
+                // A Proc::Async output supply (`proc_output` marker) is delivered
+                // exactly once, by the await/result-time `replay_proc_taps` — the
+                // tap was registered in the global registry above. Consuming the
+                // live channel (or the collected output) here as well would
+                // deliver the same output twice once the tap closure's captured
+                // lexicals are shared cells (S17-procasync/basic.t test 37), and
+                // taking the channel would starve `react whenever` / `bind-stdin`
+                // consumers of the same stream.
+                let is_proc_output = attrs.contains_key("proc_output");
+
                 // For live/async supplies (e.g., signal), spawn a background thread
                 // to consume events from the channel and call the callback.
-                if let Some(ValueView::Int(sid)) = attrs.get("supply_id").map(Value::view)
+                if !is_proc_output
+                    && let Some(ValueView::Int(sid)) = attrs.get("supply_id").map(Value::view)
                     && let Some(rx) = take_supply_channel(sid as u64)
                 {
                     let mut thread_interp = self.clone_for_thread();
@@ -193,7 +204,8 @@ impl Interpreter {
                     let tap_instance = Value::make_instance(Symbol::intern("Tap"), HashMap::new());
                     return Ok((tap_instance, attrs));
                 }
-                if let Some(ValueView::Int(sid)) = attrs.get("supply_id").map(Value::view)
+                if !is_proc_output
+                    && let Some(ValueView::Int(sid)) = attrs.get("supply_id").map(Value::view)
                     && let Some(collected) = get_supply_collected_output(sid as u64)
                     && !collected.is_empty()
                 {


### PR DESCRIPTION
## Summary

Follow-up to the cross-thread lexical campaign (#4333/#4336): unifies Proc::Async tap delivery to a single deterministic path, then re-enables escape-boxing for `.tap`/`.act` closure arguments.

### The double-delivery bug

Proc::Async output-supply taps had two delivery paths:
1. **tap-time live-channel act loop** — a tap registered after `.start` took the supply channel and consumed it on a worker thread (racy: fires 0/1 depending on scheduling), and
2. **await/result-time `replay_proc_taps`** — delivers the collected output to registry taps on the main thread.

Both fired the same collected output. The duplicate write was silently lost while tap closures captured lexicals by-value, but promoting them to shared cells makes both writes stick (S17-procasync/basic.t test 37 emitted `Hello World\n` twice).

### The fix

- Mark Proc::Async stdout/stderr/merged supplies with a `proc_output` attr. The tap arm no longer consumes their live channel (which also starved `react whenever` / `bind-stdin` consumers of the same stream) nor replays collected output at tap time. Delivery happens exactly once, in `replay_proc_taps`, on the main thread.
- Guard replay with a once-per-supply-id marker (`mark_supply_replayed`) so `await` followed by `.result` (or a second await) does not deliver the output again.
- Re-enable escape-boxing for `.tap`/`.act` closure args (`method_escapes_closure_args`): supply taps are stored and driven later, possibly on another thread, so captured-and-mutated lexicals must be shared `ContainerRef` cells. This fixes the stale-snapshot read in S32-io/socket-recv-vs-read.t test 11 (tap body `await`s a promise the parent thread reassigns after registration — it saw the clone-time Kept promise instead of the new Planned one).

### Tests

- New guard: `t/proc-async-tap-single-delivery.t` (tap-after-start / tap-before-start / await+.result once-only / merged Supply once-only / post-registration lexical visibility).
- **Whitelists `roast/S32-io/socket-recv-vs-read.t`** — 13/13, stable across 5 consecutive runs.
- Local: `make test` PASS (1584 files); all 10 whitelisted S17-procasync files PASS (incl. basic.t test 37 and encoding.t); 13 tap-heavy S17-supply + IO-Socket-Async roast files PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW