### PR TITLE
fix(regex): escaped delimiter in a lookahead, and `<( ... )>` capture markers

### DIFF
--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -388,6 +388,17 @@ impl Interpreter {
                 i += 1;
                 continue;
             }
+            // `<( ... )>` is the capture-marker construct (set match start/end),
+            // NOT a subrule call `<name(args)>`. Emit the `<(` verbatim and keep
+            // scanning the inner pattern (any real subrule calls inside it are
+            // still processed), so its content is not mis-read as an argument
+            // expression.
+            if chars.get(i + 1) == Some(&'(') {
+                out.push('<');
+                out.push('(');
+                i += 2;
+                continue;
+            }
 
             let mut depth = 1usize;
             let start = i + 1;

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -1467,10 +1467,22 @@ impl Interpreter {
                             for _ in 0..keyword.len() {
                                 chars.next();
                             }
-                            // Read the inner pattern up to the closing '>'
+                            // Read the inner pattern up to the closing '>'.
                             let mut inner = String::new();
                             let mut angle_depth = 1usize;
-                            for ch in chars.by_ref() {
+                            while let Some(ch) = chars.next() {
+                                if ch == '\\' {
+                                    // Keep an escaped char (and its backslash)
+                                    // literally so an escaped delimiter (`\>`,
+                                    // `\<`) inside the assertion — e.g.
+                                    // `<!before \>>` — does not prematurely close
+                                    // it or shift the angle-depth count.
+                                    inner.push(ch);
+                                    if let Some(next) = chars.next() {
+                                        inner.push(next);
+                                    }
+                                    continue;
+                                }
                                 if ch == '<' {
                                     angle_depth += 1;
                                     inner.push(ch);

--- a/t/regex-lookahead-escape-and-capture-markers.t
+++ b/t/regex-lookahead-escape-and-capture-markers.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# Two regex-parsing fixes surfaced by zef's `Zef::Identity` REQUIRE grammar
+# (`regex value { '<' ~ '>' [<( [[ <!before \>|\<|\\> . ]+?]* %% ['\\' . ]+ )>] }`).
+
+plan 8;
+
+# --- 1. An escaped delimiter inside a lookahead assertion ------------------
+# `<!before \>>` is "not before a literal `>`": the escaped `\>` must be part of
+# the assertion's inner pattern, not close the `<...>` early.
+ok ('ab' ~~ / [ <!before \>> . ]+ /), 'escaped > inside <!before ...> parses and matches';
+is ~$/, 'ab', 'the lookahead consumes up to (not including) a literal >';
+ok ('a>b' ~~ / ^ [ <!before \>> . ]+ /) && ~$/ eq 'a',
+    'the <!before \> > lookahead stops before a literal >';
+
+# `<?after \<>` — an escaped `<` in a look-behind.
+ok ('a<b' ~~ / . <?after \<> . /), 'escaped < inside <?after ...> parses';
+
+# Alternation of escaped delimiters inside the lookahead.
+ok ('xy' ~~ / [ <!before \>|\<|\\> . ]+ /), '<!before \>|\<|\\> alternation of escaped delimiters';
+
+# --- 2. `<( ... )>` capture markers with complex content ------------------
+# `<(` starts the capture-marker construct, NOT a subrule call `<name(args)>`.
+# Bracket groups / `%%` separators / quotes inside must not be mis-read as a
+# subrule argument expression.
+{
+    ok ('a.b.c' ~~ / x* <( [\w]+ %% '.' )> /), '<( [\w]+ %% "." )> capture markers parse';
+    is ~$/, 'a.b.c', 'the capture markers restrict the match to the inner pattern';
+}
+{
+    # A real subrule call INSIDE the capture markers is still instantiated.
+    grammar G { token part { \w+ };  regex v { <( <part> )> } }
+    is ~G.subparse('foo', :rule<v>), 'foo',
+        'a subrule call inside <( ... )> still works';
+}


### PR DESCRIPTION
Two regex-parsing bugs surfaced by zef's `Zef::Identity` REQUIRE grammar (`regex value { '<' ~ '>' [<( [[ <!before \>|\<|\\> . ]+?]* %% ['\\' . ]+ )>] }`).

## 1. Escaped delimiter in a lookahead assertion

The `<?before>` / `<!before>` / `<?after>` / `<!after>` inner-pattern extractor scanned for the closing `>` by angle-depth counting but ignored `\` escapes, so `<!before \>>` ("not before a literal `>`") ended the assertion at the escaped `\>` — leaving a dangling `>` and a bare `.` ("Quantifier quantifies nothing"). Now an escaped char (and its backslash) is kept literally.

```raku
'ab' ~~ / [ <!before \>> . ]+ /   # mutsu (before): "Quantifier quantifies nothing";  now: matches
```

## 2. `<( ... )>` capture markers mis-read as a subrule call

The arg-instantiation prepass (`instantiate_named_regex_arg_calls`) treated `<( ... )>` like `<name(args)>` and tried to evaluate the whole inner pattern as an argument expression ("Failed to evaluate regex argument expression"), breaking any capture-marker span with bracket groups / `%%` / quotes inside. Now `<(` is recognized as the capture-start marker and emitted verbatim while the inner pattern keeps being scanned (real subrule calls inside it still instantiate).

## Tests

`t/regex-lookahead-escape-and-capture-markers.t` (8 subtests, matches raku). `make test` PASS; S05-grammar / S05-metasyntax roast PASS.

**Scope note:** the full REQUIRE `value` regex still needs more *matcher* work — strict `%%`-separator semantics when the atom overlaps the separator's chars (`a+ %% 'X'` should not match `aaa`), and the `<(…)>` + `~`-goalpost interaction. Those are a separate slice. These two fixes are the parse-level half and are independently correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)