### PR TITLE
fix(regex): `ATOM+ %% SEP` matches one ATOM per item, not a greedy run

### DIFF
--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -740,9 +740,21 @@ impl Interpreter {
             };
             let sp = if use_spaced { " " } else { "" };
             if let Some((prefix, quantified_tail)) = Self::split_simple_quantified_atom(&atom) {
+                // `quantified_tail` still carries its trailing quantifier (e.g.
+                // "\w+", "u*"). Split it off and translate it into the repetition
+                // count, otherwise the atom is double-quantified: `\w+ %% X` would
+                // expand to `\w+ (X \w+)*` (each iteration greedily eats a run)
+                // instead of `\w (X \w)*` (one `\w` per separated item).
+                let q = quantified_tail.chars().last().unwrap_or('+');
+                let base = &quantified_tail[..quantified_tail.len() - q.len_utf8()];
+                let count = match q {
+                    '*' => "0..*",
+                    '?' => "0..1",
+                    _ => "1..*",
+                };
                 return build_with_rest(format!(
                     "{prefix}{sp}{}",
-                    expand(&quantified_tail, "1..*", sep_mode, sep)
+                    expand(base, count, sep_mode, sep)
                 ));
             }
             // Handle prefix + quantified bracket: e.g. `'u'<cp>+` where 'u' is a

--- a/t/comb-separated-quantifier-capture.t
+++ b/t/comb-separated-quantifier-capture.t
@@ -18,9 +18,12 @@ is-deeply "1.2.3.4".comb(/ (\d) ** 4 % '.' /).List,
     ("1.2.3.4",),
     '.comb with single-digit captured groups and a separator';
 
-# A non-capturing separated quantifier must keep working.
+# A non-capturing separated quantifier must keep working. `\d+ % '-'` is
+# "`\d`, one or more, separated by `-`" = `\d (- \d)*`, so a bare run of digits
+# ("44") matches only its first digit before the separator is required — matching
+# Rakudo: `"1-2-3 44-55".comb(/ \d+ % '-' /)` is `(1-2-3 4 4-5 5)`.
 is-deeply "1-2-3 44-55".comb(/ \d+ % '-' /).List,
-    ("1-2-3", "44-55"),
+    ("1-2-3", "4", "4-5", "5"),
     '.comb with a non-capturing separated quantifier still works';
 
 # The same pattern via ~~ single match and m:g must agree on the match strings.

--- a/t/regex-separator-quantifier-strict.t
+++ b/t/regex-separator-quantifier-strict.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# `ATOM+ %% SEP` means "one or more ATOM, separated by SEP" = `ATOM (SEP ATOM)*`,
+# so each ATOM is matched a single item at a time with SEP required between
+# items. mutsu's string-based LTM expansion double-quantified a simple atom that
+# carried its own trailing quantifier (`\w+ %% X` expanded to `\w+ (X \w+)*`),
+# letting each item greedily eat a whole run — so `\w+ %% 'X'` wrongly matched
+# `"abc"` (should stop at `"a"`).
+
+plan 12;
+
+# --- the separator must appear BETWEEN items ------------------------------
+is ~($_ given ('abc' ~~ / ^ \w+ %% 'X' /)), 'a',
+    '\w+ %% X stops at the first item when no separator follows';
+is ~($_ given ('aaa' ~~ / ^ a+ %% '.' /)), 'a',
+    'a+ %% . stops at the first item';
+is ~($_ given ('abc' ~~ / ^ .+ %% 'X' /)), 'a',
+    '.+ %% X stops at the first item';
+ok !('abc' ~~ / ^ \w+ %% 'X' $ /),
+    '\w+ %% X anchored does not match a run with no separators';
+
+# --- but a properly separated run matches fully ---------------------------
+ok ('aXbXc' ~~ / ^ \w+ %% 'X' $ /), '\w+ %% X matches a separated run';
+is ~$/, 'aXbXc', '... and consumes the whole separated run';
+ok ('a.b.c' ~~ / ^ \w+ %% '.' $ /), '\w+ %% . matches a dotted run';
+
+# --- `*` and `?` quantifier variants --------------------------------------
+is ~($_ given ('abc' ~~ / ^ \w* %% 'X' /)), 'a',
+    '\w* %% X stops at the first item';
+ok ('' ~~ / ^ \w* %% 'X' $ /), '\w* %% X matches the empty string';
+
+# --- regression guards: existing separator forms still work ---------------
+ok ('1.2.3.4' ~~ / ^ (\d) ** 4 % '.' $ /), '(\d) ** 4 % "." still matches 1.2.3.4';
+ok ('1,2,3' ~~ / ^ \d+ % ',' $ /), '\d+ % "," still matches 1,2,3';
+ok ('a-b-c' ~~ / ^ \w+ %% '-' $ /), '\w+ %% "-" still matches a-b-c';


### PR DESCRIPTION
`ATOM+ %% SEP` means "one or more ATOM, separated by SEP" = `ATOM (SEP ATOM)*`: each item is a single ATOM, and SEP is **required** between items.

## Bug

mutsu's string-based LTM expansion (`expand_ltm_pattern`) double-quantified a simple atom that carried its own trailing quantifier: `split_simple_quantified_atom` returned the tail *with* its `+`/`*`/`?` (e.g. `"\w+"`), and the caller re-expanded it at count `1..*` → `\w+ (X \w+)*` instead of `\w (X \w)*`. So each separated item greedily ate a whole run:

```raku
'abc' ~~ / \w+ %% 'X' /            # mutsu (before): "abc";  raku: "a"
"1-2-3 44-55".comb(/ \d+ % '-' /)  # mutsu (before): (1-2-3 44-55);  raku: (1-2-3 4 4-5 5)
```

## Fix

Strip the tail's trailing quantifier and translate it into the expansion count (`+`→`1..*`, `*`→`0..*`, `?`→`0..1`) so the base atom is quantified once. Bracket-delimited atoms (`<[a..z]>+ %% X`) already stripped correctly via `strip_bracket_quantifier`; this aligns the simple-atom path.

## Tests

- `t/comb-separated-quantifier-capture.t` encoded the OLD (wrong) grouping `("1-2-3", "44-55")` — corrected to Rakudo's `("1-2-3", "4", "4-5", "5")` (verified against `raku`).
- New `t/regex-separator-quantifier-strict.t` (12 subtests, matches raku), incl. regression guards for `(\d) ** 4 % '.'`, `\d+ % ','`, `\w+ %% '-'`.

`make test` PASS.

**Scope note:** surfaced by zef's `Zef::Identity` REQUIRE `value` regex (`… %% ['\\' . ]+`). That full regex still needs the frugal-nested-group `%%` case (`[[.]+?]* %% …`) and the `<(…)>` + `~`-goalpost interaction — separate slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)