### PR TITLE
fix(regex): a `[...]`-group atom with a separator is quantified once per item

### DIFF
--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -380,6 +380,59 @@ impl Interpreter {
         Some((body.to_string(), count_spec.to_string()))
     }
 
+    /// Strip a trailing simple quantifier from a whole-atom `[...]` group, e.g.
+    /// `[.]+` -> `("[.]", "1..*")`, `[[.]+?]*` -> `("[[.]+?]", "0..*")`. Returns
+    /// `None` unless the atom is exactly one balanced `[...]` group followed by a
+    /// single `?`/`+`/`*`. Used by the separator (`%`/`%%`) LTM expansion so a
+    /// bracket-group atom is quantified once per separated item (`[.]+ %% X` ->
+    /// `[.] (X [.])*`), not double-quantified (`[.]+ (X [.]+)*`).
+    fn strip_group_quantifier(atom: &str) -> Option<(String, String)> {
+        let quant = atom.chars().last()?;
+        if !matches!(quant, '?' | '+' | '*') {
+            return None;
+        }
+        let body = &atom[..atom.len() - quant.len_utf8()];
+        if !body.starts_with('[') || !body.ends_with(']') {
+            return None;
+        }
+        // The `[...]` group must be balanced and span the entire body (it closes
+        // only at the final `]`), tracking backslash escapes and quotes so a `]`
+        // inside `[ '\]' ]` / `[ \] ]` doesn't end it early.
+        let mut depth = 0i32;
+        let mut escaped = false;
+        let mut quote: Option<char> = None;
+        let cs: Vec<char> = body.chars().collect();
+        for (i, &ch) in cs.iter().enumerate() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' => escaped = true,
+                '\'' | '"' if quote.is_none() => quote = Some(ch),
+                c if quote == Some(c) => quote = None,
+                '[' if quote.is_none() => depth += 1,
+                ']' if quote.is_none() => {
+                    depth -= 1;
+                    if depth == 0 && i != cs.len() - 1 {
+                        return None; // group closes before the end
+                    }
+                }
+                _ => {}
+            }
+        }
+        if depth != 0 {
+            return None;
+        }
+        let count_spec = match quant {
+            '*' => "0..*",
+            '+' => "1..*",
+            '?' => "0..1",
+            _ => return None,
+        };
+        Some((body.to_string(), count_spec.to_string()))
+    }
+
     /// Split `'u'<cp>+` into `("'u'", "<cp>", "1..*")`.
     /// Returns `(prefix, bracket_atom, count_spec)` when the atom ends with a
     /// bracket-delimited sub-rule + simple quantifier, and there is a non-empty
@@ -769,6 +822,11 @@ impl Interpreter {
             }
             // Handle bracket-delimited atoms with quantifiers (e.g. `<value>*`)
             if let Some((base, count_spec)) = Self::strip_bracket_quantifier(&atom) {
+                return build_with_rest(expand(&base, &count_spec, sep_mode, sep));
+            }
+            // Handle a `[...]` group atom with a trailing quantifier (`[.]+`,
+            // `[[.]+?]*`): quantify the group once per separated item.
+            if let Some((base, count_spec)) = Self::strip_group_quantifier(&atom) {
                 return build_with_rest(expand(&base, &count_spec, sep_mode, sep));
             }
             return build_with_rest(expand(&atom, "1..*", sep_mode, sep));

--- a/t/regex-group-separator-strict.t
+++ b/t/regex-group-separator-strict.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# A `[...]`-group atom with a trailing quantifier and a `%`/`%%` separator must
+# be quantified ONCE per separated item — `[.]+ %% X` = `[.] (X [.])*`. mutsu's
+# LTM string-expansion only stripped the quantifier off angle-bracket subrule
+# atoms (`<foo>+`), so a square-bracket group fell through and was
+# double-quantified (`[.]+ (X [.]+)*`), letting each item eat a greedy run.
+
+plan 9;
+
+is ~($_ given ('abc' ~~ / [.]+ %% 'X' /)), 'a',
+    '[.]+ %% X stops at the first item (no separator follows)';
+is ~($_ given ('abc' ~~ / [\w]+ %% 'X' /)), 'a',
+    '[\w]+ %% X stops at the first item';
+is ~($_ given ('abc' ~~ / [ \w ]* %% 'X' /)), 'a',
+    '[ \w ]* %% X stops at the first item';
+
+# A properly separated run still matches whole.
+is ~($_ given ('a-b-c' ~~ / [\w]+ %% '-' /)), 'a-b-c',
+    '[\w]+ %% "-" matches a separated run';
+
+# The item group itself may contain a quantifier / a frugal quantifier.
+is ~($_ given ('ab,ab' ~~ / [ab]+ %% ',' /)), 'ab,ab',
+    '[ab]+ %% "," treats each "ab" run as one item';
+is ~($_ given ('0.0.1' ~~ / [[ . ]+?]* %% [ '\\' . ]+ /)), '0',
+    'frugal-nested group [[.]+?]* %% [\\ .]+ takes a single frugal item';
+
+# Nested groups with the separator, fully separated.
+is ~($_ given ('12-34-56' ~~ / [\d ** 2]+ %% '-' /)), '12-34-56',
+    '[\d ** 2]+ %% "-" matches two-digit groups separated by "-"';
+
+# Regression guards: angle-bracket subrule atoms and simple atoms still work.
+grammar G { token v { <[a..z]> } }
+is ~($_ given ('abc' ~~ / <G::v>+ %% 'X' /)), 'a',
+    '<subrule>+ %% X still stops at the first item';
+is ~($_ given ('a-b-c' ~~ / <[a..z]>+ %% '-' /)), 'a-b-c',
+    '<[a..z]>+ %% "-" still matches a separated run';


### PR DESCRIPTION
Follow-up to #4342 (`%%`/`%` separator strictness): a bracket-**group** atom with a trailing quantifier was still double-quantified by the LTM string-expansion.

## Bug

`strip_bracket_quantifier` deliberately only strips angle-bracket subrule atoms (`<foo>+`), so a `[...]` group fell through to the `expand(&atom, "1..*", …)` fallthrough with its own quantifier intact → `[.]+ (X [.]+)*`, each separated item greedily eating a whole run:

```raku
'abc' ~~ / [.]+ %% 'X' /                       # mutsu (before): "abc";  raku: "a"
'0.0.1' ~~ / [[ . ]+?]* %% [ '\\' . ]+ /       # mutsu (before): "0.0.1"; raku: "0"
```

## Fix

Add `strip_group_quantifier`: strips a trailing `?`/`+`/`*` off a whole-atom balanced `[...]` group (tracking escapes/quotes) and maps it to the expansion count, so the group is quantified once per separated item (`[.] (X [.])*`). Also fixes the frugal-nested-group form `[[.]+?]* %% ['\\' . ]+` used by zef's `Zef::Identity` REQUIRE `value` regex.

## Tests

`t/regex-group-separator-strict.t` (9 subtests, matches raku), incl. regression guards for `<subrule>+ %% X` and `<[a..z]>+ %% '-'`. `make test` PASS.

**Scope note:** the full REQUIRE `value` regex now needs only the last piece — the `~`-goalpost + frugal-quantifier backtracking through the `<(…)>` capture markers (so `'<0.0.1>'` backtracks the frugal inner until the goalpost `'>'` matches). Separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)