### PR TITLE
fix(regex): propagate `<(` / `)>` capture markers out of groups and goalposts

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -499,6 +499,16 @@ pub(super) fn merge_regex_captures(
     for (k, v) in src.hash_captures.drain() {
         dst.hash_captures.entry(k).or_default().extend(v);
     }
+    // Propagate `<(` / `)>` capture-marker positions from the merged-in side so a
+    // sub-pattern that sets the match boundaries is not lost when its captures are
+    // folded into an outer result — e.g. `'<' ~ '>' [<( \w+ )>]`, where the
+    // goalpost merges the inner (marker-carrying) captures into the goal's.
+    if src.capture_start.is_some() {
+        dst.capture_start = src.capture_start;
+    }
+    if src.capture_end.is_some() {
+        dst.capture_end = src.capture_end;
+    }
     dst
 }
 

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -197,6 +197,14 @@ impl Interpreter {
                     .positional_quantified
                     .append(&mut inner_caps.positional_quantified);
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                // A `<(` / `)>` capture marker inside the group sets the match
+                // boundaries for the whole pattern; propagate it out of the group.
+                if inner_caps.capture_start.is_some() {
+                    new_caps.capture_start = inner_caps.capture_start;
+                }
+                if inner_caps.capture_end.is_some() {
+                    new_caps.capture_end = inner_caps.capture_end;
+                }
                 out.push((end, new_caps));
             }
             // Reverse inner match order so LIFO stack respects frugal/greedy priority.

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -39,6 +39,13 @@ impl Interpreter {
                         new_caps
                             .positional_quantified
                             .append(&mut inner_caps.positional_quantified);
+                        // Propagate a `<(` / `)>` capture marker set inside the group.
+                        if inner_caps.capture_start.is_some() {
+                            new_caps.capture_start = inner_caps.capture_start;
+                        }
+                        if inner_caps.capture_end.is_some() {
+                            new_caps.capture_end = inner_caps.capture_end;
+                        }
                         (next, new_caps)
                     });
             }

--- a/t/regex-capture-marker-in-group.t
+++ b/t/regex-capture-marker-in-group.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# `<(` / `)>` set the overall match's start/end. When the markers sit inside a
+# non-capturing group `[...]` (or are reached through a `~`-goalpost), those
+# positions must propagate out to the whole Match — mutsu dropped them when
+# folding a sub-pattern's captures into the outer result, so the match kept its
+# outer extent (`"<abc>"` instead of the marked `"abc"`).
+
+plan 7;
+
+# --- markers directly (regression guard) ----------------------------------
+is ~($_ given ('<abc>' ~~ / '<' <( \w+ )> '>' /)), 'abc',
+    'bare <( ... )> markers set the match extent';
+
+# --- markers inside a `[...]` group ---------------------------------------
+is ~($_ given ('<abc>' ~~ / '<' [<( \w+ )>] '>' /)), 'abc',
+    '<( ... )> inside a [ ] group propagates the extent out';
+
+is ~($_ given ('x42y' ~~ / 'x' [<( \d+ )>] 'y' /)), '42',
+    '<( ... )> in a group with surrounding literals';
+
+# --- markers reached through a `~` goalpost -------------------------------
+is ~($_ given ('<abc>' ~~ / '<' ~ '>' [<( \w+ )>] /)), 'abc',
+    '<( ... )> in a group under a ~ goalpost sets the extent';
+
+# --- a frugal inner still backtracks to satisfy the goalpost --------------
+is ~($_ given ('<0.0.1>' ~~ / '<' ~ '>' [<( .+? )>] /)), '0.0.1',
+    'a frugal inner under the goalpost expands to reach the goal';
+
+# --- only the marked span is captured, surrounding text is excluded -------
+{
+    my $m = 'aXbYc' ~~ / a <( . )> b <( . )> /;  # last <( wins for start
+    # After two <( markers the *last* start wins; end is the last )> (implicit end).
+    ok $m.defined, 'multiple <( markers parse and match';
+}
+
+# --- named capture inside the marked group is still recorded --------------
+{
+    my $m = '<abc>' ~~ / '<' [<( $<w>=(\w+) )>] '>' /;
+    is (~$m.<w>), 'abc', 'a named capture inside the marked group is preserved';
+}


### PR DESCRIPTION
`<(` and `)>` set the overall Match's start/end. When the markers sat inside a non-capturing group `[...]` — or were reached through a `~`-goalpost (which folds the inner marker-carrying captures into the goal's) — the `capture_start` / `capture_end` positions were **dropped**: `merge_regex_captures` and the two `RegexAtom::Group` capture handlers copied named/positional captures but not the marker offsets.

```raku
'<abc>' ~~ / '<' [<( \w+ )>] '>' /       # mutsu (before): "<abc>";  raku: "abc"
'<abc>' ~~ / '<' ~ '>' [<( \w+ )>] /     # mutsu (before): "<abc>";  raku: "abc"
```

## Fix

Carry `capture_start` / `capture_end` from the merged-in side in `merge_regex_captures`, and out of both `Group` handlers.

## Tests

`t/regex-capture-marker-in-group.t` (7 subtests, matches raku). `make test` PASS.

**Scope note:** part of getting zef's `Zef::Identity` REQUIRE `value` regex (`'<' ~ '>' [<( … )>]`) to capture only its inner. That regex additionally needs `%%`-separator + frugal-quantifier backtracking under the goalpost (`[[.]+?]* %% […]` must expand the frugal item until the goalpost `'>'` matches) — a separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)