### PR TITLE
fix(compiler): surface whenever-body free vars to escape analysis for cell promotion

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2997,6 +2997,30 @@ impl Compiler {
             } => {
                 self.compile_expr(supply);
                 let body_idx = self.code.add_stmt(Stmt::Block(body.clone()));
+                // The whenever body is stashed in `stmt_pool` and runtime-compiled
+                // against the live env (exec_whenever_scope_op), so the nested-
+                // closure free-var scan in `compute_free_vars` cannot see which
+                // lexicals it reads or writes. Compile the body once more here as
+                // an ANALYSIS-ONLY escaping closure so those free variables surface
+                // in this frame's escape analysis: a whenever body fires
+                // asynchronously (often on another thread), so a captured-and-
+                // mutated lexical must be promoted to a shared ContainerRef cell in
+                // the frame that declares it — otherwise the body reads a stale
+                // by-value env snapshot (Case B: `start { react { whenever $ch {
+                // ...read $gate... } } }` missing the parent's post-registration
+                // `$gate = True`). The compiled code itself is never executed; only
+                // its free-var/needs-cell metadata feeds `compute_free_vars`.
+                let analysis_param = vec![param.clone().unwrap_or_else(|| "$_".to_string())];
+                let fn_keys_before: std::collections::HashSet<String> =
+                    self.compiled_functions.keys().cloned().collect();
+                let analysis = self.compile_closure_body(&analysis_param, &[], body);
+                // Drop named subs the analysis compile registered: the runtime
+                // compile of the stashed body registers the real ones, and a junk
+                // duplicate under the analysis closure's package could split
+                // `state` scoping if a loose lookup resolved to it.
+                self.compiled_functions
+                    .retain(|k, _| fn_keys_before.contains(k));
+                self.code.add_closure_code(analysis, true);
                 let param_idx = param
                     .as_ref()
                     .map(|p| self.code.add_constant(Value::str(p.clone())));

--- a/t/whenever-cross-thread-lexical.t
+++ b/t/whenever-cross-thread-lexical.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 3;
+
+# Case B guard: a lexical read or written DIRECTLY inside a `whenever` body
+# that runs on another thread (react inside start) must share state with the
+# parent thread. The whenever body is stashed in the stmt_pool and
+# runtime-compiled, so the compiler's Stmt::Whenever arm compiles it once more
+# as an analysis-only escaping closure to surface its free variables to the
+# enclosing frame's escape analysis; captured-and-mutated lexicals are then
+# promoted to shared ContainerRef cells. Without that, the body reads a stale
+# by-value env snapshot taken when the start block was created.
+#
+# A Channel (buffered) makes both directions deterministic: the body only
+# fires after the parent's send, which happens-after the parent's writes.
+
+# Read direction: the parent writes $gate after the start block has captured
+# its env; the whenever body must see the updated value.
+{
+    my $gate = False;
+    my $c = Channel.new;
+    my $seen;
+    my $p = start {
+        react {
+            whenever $c {
+                $seen = $gate;
+                done;
+            }
+        }
+    }
+    $gate = True;
+    $c.send(1);
+    await $p;
+    ok $seen, 'whenever body sees the parent post-registration write';
+}
+
+# Write direction: scalar and array mutations made inside the whenever body
+# must be visible to the parent after await.
+{
+    my $count = 0;
+    my @seen;
+    my $c = Channel.new;
+    my $p = start {
+        react {
+            whenever $c -> $v {
+                $count++;
+                @seen.push($v);
+                done if $count == 3;
+            }
+        }
+    }
+    $c.send($_) for 1..3;
+    await $p;
+    is $count, 3, 'whenever body scalar writes are visible to the parent';
+    is @seen.join(','), '1,2,3', 'whenever body array pushes are visible to the parent';
+}


### PR DESCRIPTION
## Problem (cross-thread lexical campaign, Case B)

A lexical read **directly** inside a `whenever` body running on another thread misses the parent thread's post-registration writes:

```raku
my $gate = False;
my $ch = Supplier.new;
my $p = start {
    react {
        whenever $ch.Supply {
            say "gate is {$gate}";   # mutsu: False (stale) / raku: True
            done;
        }
    }
}
sleep 0.2;
$gate = True;
$ch.emit(1);
await $p;
```

Root cause: the `whenever` body is stashed in the `stmt_pool` and runtime-compiled against the live env (`exec_whenever_scope_op`), so the nested-closure free-var scan in `compute_free_vars` never sees which lexicals it reads or writes. `$gate` therefore never reaches the enclosing frame's escape analysis and is not promoted to a shared `ContainerRef` cell — the body reads a stale by-value env snapshot taken when the `start` block was created. Inserting an unrelated escaping closure that mentions `$gate` "fixed" it, which confirmed the missing-surface diagnosis.

## Fix

In the compiler's `Stmt::Whenever` arm, compile the body once more as an **analysis-only escaping closure** and register it with `add_closure_code(_, true)`. The existing escape analysis then does the rest unchanged: free variables fold into the enclosing frame, cell requirements bubble to the declaring frame (`needs_cell_free_vars`), and the VM boxes the lexical into a shared cell — the same sound mechanism as for named escaping closures (roles-6e lesson: cells, not snapshots). The analysis code is never executed. Named subs registered as a compile side effect are dropped to avoid junk duplicates under the analysis closure's package (which could split `state` scoping via loose lookups).

This fixes both directions: parent writes become visible to the whenever body (read), and body writes become visible to the parent after `await` (write).

## Testing

- New guard `t/whenever-cross-thread-lexical.t` (3 tests, Channel-based so fully deterministic). Verified the read-direction test **fails without the fix** and passes with it; output matches `raku`.
- `make test`: all 1585 files / 15512 tests pass.
- Whitelisted roast: all of `S17-supply` (55 files), `S17-procasync`, `S17-promise`, `S17-scheduler`, `S17-channel/subscription-drain-in-react.t`, `socket-recv-vs-read.t`, `socket-accept-and-working-threads.t`, plus every other whitelisted test using `whenever` (`MISC/bug-coverage-6.d.t`, `S16-io/watch.t`, `S17-channel/basic.t`, `S32-io/IO-Socket-Async.t`, `io-cathandle.t`) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW