### PR TITLE
fix(regex,control-flow): unblock Zef::Identity — value grammar + pointy-if value

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -8,11 +8,11 @@ impl Compiler {
                 cond,
                 then_branch,
                 else_branch,
-                ..
+                binding_var,
             } if Self::do_if_branch_supported(then_branch)
                 && Self::do_if_branch_supported(else_branch) =>
             {
-                self.compile_do_if_expr(cond, then_branch, else_branch);
+                self.compile_do_if_expr_bound(cond, then_branch, else_branch, binding_var);
             }
             Stmt::Given { topic, body } => {
                 self.compile_expr(topic);

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -147,13 +147,17 @@ impl Compiler {
                     // taken branch's value (like `do if ...`), not Nil. This
                     // matters e.g. for `do { if $c { ... } }` and statement-form
                     // `with`/`without` (lowered to an `if`) used as expressions.
+                    // The topic-binding form (`if EXPR -> $x { ... }` / an `elsif`
+                    // with a pointy) must go through `compile_do_if_expr_bound` so
+                    // the taken branch's value still flows out (matching the
+                    // `given`/`when` tail path in `compile_when_tail_stmt`).
                     Stmt::If {
                         cond,
                         then_branch,
                         else_branch,
                         binding_var,
-                    } if binding_var.is_none() => {
-                        self.compile_do_if_expr(cond, then_branch, else_branch);
+                    } => {
+                        self.compile_do_if_expr_bound(cond, then_branch, else_branch, binding_var);
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -54,9 +54,7 @@ impl Compiler {
                         then_branch,
                         else_branch,
                         binding_var,
-                    } if binding_var.is_none() => {
-                        self.compile_if_value(cond, then_branch, else_branch)
-                    }
+                    } => self.compile_if_value(cond, then_branch, else_branch, binding_var),
                     Stmt::Block(inner) | Stmt::SyntheticBlock(inner) => {
                         self.compile_block_inline(inner)
                     }
@@ -115,6 +113,7 @@ impl Compiler {
         cond: &Expr,
         then_branch: &[Stmt],
         else_branch: &[Stmt],
+        binding_var: &Option<String>,
     ) {
         // Check for heredoc scope violations before compiling
         if let Some(err) = self.check_heredoc_scope_errors(then_branch) {
@@ -130,7 +129,30 @@ impl Compiler {
             return;
         }
         let needs_at_underscore = Self::body_uses_legacy_args(then_branch);
-        self.compile_expr(cond);
+        // A topic-binding `if EXPR -> $v { ... }` (or a pointy `elsif`): bind the
+        // condition value to `$v` and test the bound variable, mirroring the
+        // statement-form desugar (`{ my $v = EXPR; if $v { ... } }`) that
+        // `compile_do_if_expr_bound` uses. Without this a value-position pointy
+        // `if`/`elsif` fell through to a Nil result (its branch value was lost).
+        if let Some(var_name) = binding_var {
+            let bare_name = var_name.trim_start_matches('$').to_string();
+            let var_decl = Stmt::VarDecl {
+                name: bare_name.clone(),
+                expr: cond.clone(),
+                type_constraint: None,
+                is_state: false,
+                is_our: false,
+                is_dynamic: false,
+                is_export: false,
+                export_tags: vec![],
+                custom_traits: Vec::new(),
+                where_constraint: None,
+            };
+            self.compile_stmt(&var_decl);
+            self.compile_expr(&Expr::Var(bare_name));
+        } else {
+            self.compile_expr(cond);
+        }
         if needs_at_underscore {
             // Duplicate condition for @_ (bare if blocks receive condition as @_).
             self.code.emit(OpCode::Dup);

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -92,16 +92,8 @@ impl Compiler {
         self.code.patch_body_end(idx);
     }
 
-    pub(super) fn compile_do_if_expr(
-        &mut self,
-        cond: &Expr,
-        then_branch: &[Stmt],
-        else_branch: &[Stmt],
-    ) {
-        self.compile_do_if_expr_bound(cond, then_branch, else_branch, &None);
-    }
-
-    /// Like `compile_do_if_expr`, but honours a per-branch topic binding
+    /// Compile an `if`/`elsif` chain in value (expression) position, honouring an
+    /// optional per-branch topic binding
     /// (`if EXPR -> $v { ... }`). When `binding_var` is `Some`, the condition
     /// value is bound to `$v` for the `then` branch — desugared exactly like the
     /// statement-form `if` (`{ my $v = EXPR; if $v { ... } }`) — so a value-mode

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -480,8 +480,8 @@ impl Compiler {
                         then_branch,
                         else_branch,
                         binding_var,
-                    } if binding_var.is_none() => {
-                        sub_compiler.compile_if_value(cond, then_branch, else_branch);
+                    } => {
+                        sub_compiler.compile_if_value(cond, then_branch, else_branch, binding_var);
                         continue;
                     }
                     Stmt::Block(stmts) | Stmt::SyntheticBlock(stmts) => {
@@ -813,8 +813,8 @@ impl Compiler {
                             then_branch,
                             else_branch,
                             binding_var,
-                        } if binding_var.is_none() => {
-                            sub_compiler.compile_if_value(cond, then_branch, else_branch);
+                        } => {
+                            sub_compiler.compile_if_value(cond, then_branch, else_branch, binding_var);
                             continue;
                         }
                         Stmt::Block(stmts) | Stmt::SyntheticBlock(stmts) => {

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -814,7 +814,12 @@ impl Compiler {
                             else_branch,
                             binding_var,
                         } => {
-                            sub_compiler.compile_if_value(cond, then_branch, else_branch, binding_var);
+                            sub_compiler.compile_if_value(
+                                cond,
+                                then_branch,
+                                else_branch,
+                                binding_var,
+                            );
                             continue;
                         }
                         Stmt::Block(stmts) | Stmt::SyntheticBlock(stmts) => {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1208,8 +1208,8 @@ impl Compiler {
                             then_branch,
                             else_branch,
                             binding_var,
-                        } if binding_var.is_none() => {
-                            self.compile_if_value(cond, then_branch, else_branch);
+                        } => {
+                            self.compile_if_value(cond, then_branch, else_branch, binding_var);
                             self.code.emit(OpCode::SetTopic);
                             continue;
                         }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -237,17 +237,27 @@ impl Interpreter {
     ) -> Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)> {
         let mut chains: Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)> = Vec::new();
         let empty = RegexCaptures::default();
-        // First atom (single highest-priority match, matching the non-separator
-        // atom-matching policy elsewhere).
-        if let Some((end, caps)) = self.regex_match_atom_with_capture_in_pkg(
+        // First atom: enumerate EVERY match length (highest-priority first), not
+        // just the single highest-priority one. A frugal atom (`[[.]+?]`) matches
+        // as few chars as possible, but an outer anchor / goalpost following the
+        // separated quantifier (e.g. `'<' ~ '>' [<( [[.]+?]* %% SEP )>]`) may
+        // require the atom to expand. Taking only the shortest match would leave
+        // no candidate for that anchor and the whole pattern would fail to match.
+        let first_matches = self.regex_match_atom_all_with_capture_in_pkg(
             &token.atom,
             chars,
             start,
             &empty,
             pkg,
             pattern.ignore_case,
-        ) && end != start
-        {
+        );
+        // `regex_match_atom_all_with_capture_in_pkg` returns lowest-priority
+        // first; iterate highest-priority first so the chains come out in
+        // highest-priority order for the caller's LIFO stack.
+        for (end, caps) in first_matches.into_iter().rev() {
+            if end == start {
+                continue;
+            }
             let mut atom_caps = vec![caps];
             let mut sep_caps: Vec<RegexCaptures> = Vec::new();
             self.extend_separated_chain(
@@ -297,17 +307,23 @@ impl Interpreter {
                 cur,
                 pkg,
             ) {
-                if let Some((atom_end, acaps)) = self.regex_match_atom_with_capture_in_pkg(
+                // Enumerate every atom-match length after this separator
+                // (highest-priority first), mirroring the first-atom enumeration
+                // so a frugal atom can expand to satisfy a following anchor.
+                let atom_matches = self.regex_match_atom_all_with_capture_in_pkg(
                     &token.atom,
                     chars,
                     sep_end,
                     &empty,
                     pkg,
                     pattern.ignore_case,
-                ) && atom_end > cur
-                {
+                );
+                for (atom_end, acaps) in atom_matches.into_iter().rev() {
+                    if atom_end <= cur {
+                        continue;
+                    }
                     atom_caps.push(acaps);
-                    sep_caps.push(scaps);
+                    sep_caps.push(scaps.clone());
                     self.extend_separated_chain(
                         token, chars, atom_end, pkg, pattern, max, atom_caps, sep_caps, out,
                     );

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1134,4 +1134,3 @@ impl Interpreter {
             .map(std::sync::Arc::new)
     }
 }
-

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -657,8 +657,62 @@ impl Interpreter {
         (first, rest)
     }
 
+    /// Strip insignificant whitespace from a regex pattern for the LTM
+    /// separator-detection regexes, but PRESERVE whitespace that is semantically
+    /// significant: inside quotes (`'a b'`, `"a b"`) and inside angle-bracket
+    /// assertions/subrules (`<!before X>`, where the space separates the keyword
+    /// from its pattern). Blindly stripping all whitespace corrupted such atoms
+    /// (`<!before X>` -> `<!beforeX>`, a wrong subrule call), which made any
+    /// `%%`/`%`-separated quantifier whose atom contained a lookahead fail to
+    /// match (e.g. Zef::Identity's `value` grammar rule). Whitespace inside
+    /// `[...]` / `(...)` groups and at the top level stays insignificant and is
+    /// stripped as before.
+    fn compact_regex_whitespace(pattern: &str) -> String {
+        let mut out = String::with_capacity(pattern.len());
+        let mut escaped = false;
+        let mut quote: Option<char> = None;
+        let mut angle_depth: i32 = 0;
+        for ch in pattern.chars() {
+            if escaped {
+                out.push(ch);
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' => {
+                    out.push(ch);
+                    escaped = true;
+                }
+                '\'' | '"' if quote.is_none() => {
+                    quote = Some(ch);
+                    out.push(ch);
+                }
+                c if quote == Some(c) => {
+                    quote = None;
+                    out.push(ch);
+                }
+                '<' if quote.is_none() => {
+                    angle_depth += 1;
+                    out.push(ch);
+                }
+                '>' if quote.is_none() => {
+                    angle_depth = (angle_depth - 1).max(0);
+                    out.push(ch);
+                }
+                c if c.is_whitespace() => {
+                    // Preserve whitespace only where it carries meaning.
+                    if quote.is_some() || angle_depth > 0 {
+                        out.push(ch);
+                    }
+                }
+                _ => out.push(ch),
+            }
+        }
+        out
+    }
+
     pub(super) fn expand_ltm_pattern(pattern: &str, sigspace: bool) -> String {
-        let compact: String = pattern.chars().filter(|ch| !ch.is_whitespace()).collect();
+        let compact: String = Self::compact_regex_whitespace(pattern);
         if compact.is_empty() {
             return pattern.to_string();
         }
@@ -1080,3 +1134,4 @@ impl Interpreter {
             .map(std::sync::Arc::new)
     }
 }
+

--- a/t/if-topic-binding-value.t
+++ b/t/if-topic-binding-value.t
@@ -1,0 +1,67 @@
+use v6;
+use Test;
+
+# An `if EXPR -> $x { ... }` / pointy `elsif` used in value position must yield
+# the taken branch's value (not Nil). Previously the topic-binding form fell
+# through to a Nil result because the value-if compiler paths guarded on
+# `binding_var.is_none()`.
+
+plan 12;
+
+# --- if with pointy topic, as a sub's implicit return value ---
+sub a($x) { if $x -> $y { "got:$y" } }
+is a("A"), "got:A", "if EXPR -> \$y { } returns branch value";
+nok a("").Bool, "if EXPR -> \$y { } false cond yields a falsy (empty) result";
+
+# --- elsif with pointy topic ---
+sub b($x) {
+    if False { "no" }
+    elsif $x -> $y { "eb:$y" }
+}
+is b("C"), "eb:C", "elsif EXPR -> \$y { } returns branch value";
+
+# --- if/elsif/else chain, elsif taken ---
+sub c($x) {
+    if $x.starts-with('.') { "dot" }
+    elsif $x.uc -> $u { "uc:$u" }
+    else { "else" }
+}
+is c("abc"), "uc:ABC", "elsif pointy in full chain returns branch value";
+is c(".x"),  "dot",    "then branch still wins when its cond is true";
+
+# --- topic variable is actually bound to the condition value ---
+sub d($n) { if $n * 2 -> $doubled { $doubled + 1 } }
+is d(5), 11, "bound topic holds the condition value";
+
+# --- nested elsif chain, second elsif taken ---
+sub e($x) {
+    if False { "a" }
+    elsif False { "b" }
+    elsif $x -> $v { "c:$v" }
+}
+is e("Z"), "c:Z", "second pointy elsif returns branch value";
+
+# --- value position inside do { } ---
+my $r = do if 7 -> $z { $z * 3 };
+is $r, 21, "do if EXPR -> \$z { } yields branch value";
+
+# --- as the value of a `for` body element ---
+my @out = (for 1..3 -> $i { if $i %% 2 -> $ok { "even:$i" } else { "odd:$i" } });
+is @out.join(","), "odd:1,even:2,odd:3", "if pointy inside for body collects values";
+
+# --- multi-statement then branch: last value flows out ---
+sub f($x) {
+    if $x -> $y {
+        my $tmp = $y ~ "!";
+        $tmp ~ "?";
+    }
+}
+is f("hi"), "hi!?", "multi-statement pointy then-branch returns its last value";
+
+# --- plain (non-pointy) if still works (no regression) ---
+sub g($x) { if $x { "plain:$x" } }
+is g("P"), "plain:P", "plain if (no pointy) still returns branch value";
+
+# --- with (already worked) as a control ---
+sub h($x) { with $x -> $y { "wb:$y" } }
+is h("W"), "wb:W", "with EXPR -> \$y { } still returns branch value";

--- a/t/regex-separated-quantifier-lookahead-capture.t
+++ b/t/regex-separated-quantifier-lookahead-capture.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# Regressions found while making Zef::Identity's `value` grammar rule parse.
+# Two independent regex-engine bugs:
+#   (1) The LTM separator (`%%`/`%`) pre-pass stripped ALL whitespace, corrupting
+#       significant whitespace inside `<...>` assertions (`<!before X>` became the
+#       bogus subrule `<!beforeX>`), so any `%%`-separated quantifier whose atom
+#       held a lookahead failed to match.
+#   (2) The native separated-quantifier matcher took only the single
+#       highest-priority match per atom, so a frugal atom (`[[.]+?]`) could not
+#       expand to satisfy a following anchor/goalpost when the whole thing was
+#       wrapped in `<( ... )>` capture markers.
+
+plan 19;
+
+# --- (1) lookahead inside a separated quantifier ---
+ok "abc" ~~ / [ <!before X> . ]+ %% 'Y' /,  "lookahead atom + %% matches";
+is ~$/, "a", "  ... and matches one atom (no separator present)";
+
+ok "abc" ~~ / <!before X> . +% 'Y' /, "leading lookahead + separated quantifier matches";
+is ~$/, "a", "  ... matches the single atom";
+
+ok "a.b.c" ~~ / [ <!before X> . ]+ %% '.' /, "lookahead atom + %% with present separator";
+is ~$/, "a.b.c", "  ... consumes all separated items";
+
+# --- (2) capture markers + separated quantifier + trailing delimiter ---
+ok "<abc>" ~~ / '<' ~ '>' [<( [[.]+?]* %% 'Y' )>] /, "goalpost + <(...)> + frugal %% quantifier";
+is ~$/, "abc", "  ... capture markers restrict to the inner text";
+
+ok "<abc>" ~~ / '<' [<( [[.]+?]* %% 'Y' )>] '>' /, "literal delims + <(...)> + %% quantifier";
+is ~$/, "abc", "  ... inner text captured";
+
+# capture markers + separator WITHOUT a following delimiter still works
+ok "abc" ~~ / [<( . +% 'Y' )>] /, "capture markers + separated quantifier, no trailing anchor";
+is ~$/, "a", "  ... single frugal atom";
+
+# --- the actual Zef::Identity `value` rule, standalone ---
+my regex value { '<' ~ '>' [<( [[ <!before \>|\<|\\> . ]+?]* %% ['\\' . ]+ )>] }
+ok "<0.0.1>" ~~ &value, "Zef::Identity value regex matches <0.0.1>";
+is ~$/, "0.0.1", "  ... captures the inner version string";
+ok "<>" ~~ &value, "Zef::Identity value regex matches empty <>";
+is ~$/, "", "  ... captures empty inner";
+
+# --- the full Zef::Identity grammar TOP ---
+grammar Ident {
+    regex TOP { ^^ <name> [':' <key> <value>]* $$ }
+    regex name  { <-restricted +name-sep>+ }
+    token key   { <-restricted>+ }
+    regex value { '<' ~ '>' [<( [[ <!before \>|\<|\\> . ]+?]* %% ['\\' . ]+ )>] }
+    token restricted { [':' | '<' | '>' | '(' | ')'] }
+    token name-sep   { < :: > }
+}
+my $m = Ident.parse("Foo::Bar:ver<0.0.1>:auth<>:api<>");
+ok $m, "identity string parses";
+is ~$m<name>, "Foo::Bar", "  ... name captured";
+is $m<value>.join("|"), "0.0.1||", "  ... value list captured with empties";


### PR DESCRIPTION
Three independent, general bugs — all surfaced while making the real `Zef::Identity` `REQUIRE` grammar parse an identity string (`Foo::Bar:ver<0.0.1>:auth<>:api<>`), which previously produced an **undefined** object.

## 1. LTM separator whitespace corruption
`expand_ltm_pattern` stripped *all* whitespace before the `%%`/`%` separator-detection regexes and expansion, removing **significant** whitespace inside `<...>` assertions — `<!before X>` became the bogus subrule `<!beforeX>`. Any `%%`-separated quantifier whose atom held a lookahead then failed to match. Fix: `compact_regex_whitespace` preserves whitespace inside quotes and `<...>` groups.

## 2. Native separated-quantifier had no atom-length backtracking
When `<( ... )>` capture markers force the native `match_separated_quantifier` path (the `(` reads as a capture), the chain enumerator took only the single highest-priority match per atom. A frugal atom (`[[.]+?]`) could not expand to satisfy a following anchor/goalpost (`'<' ~ '>' [<( [[.]+?]* %% SEP )>]`), so the whole pattern failed. Fix: enumerate every atom-match length via `regex_match_atom_all_with_capture_in_pkg`.

## 3. `if`/`elsif EXPR -> $x { ... }` lost its value
Every value-position `if` compiler path guarded on `binding_var.is_none()`, so a topic-binding (pointy) `if`/`elsif` fell through to statement mode and yielded `Nil`. Zef::Identity's `elsif REQUIRE.parse(...).ast -> $ident { self.bless(...) }` therefore returned undefined. Fix: thread `binding_var` through `compile_if_value` and drop the `is_none()` guards across all sites (`compile_stmts_value`, `compile_block_inline`, `compile_expr_do_stmt`, sub-body, given-topic).

## Result
`Zef::Identity.new("Foo::Bar:ver<0.0.1>:auth<>:api<>")` now returns a defined object with correct `name`/`version`, and `zef install` advances past identity parsing to install-target selection.

## Tests
- `t/regex-separated-quantifier-lookahead-capture.t` (19 subtests)
- `t/if-topic-binding-value.t` (12 subtests)

`make test` PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)