### PR TITLE
fix(compunit): can-install walks up to the nearest existing ancestor

### DIFF
--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -144,12 +144,32 @@ impl Interpreter {
             "can-install" => {
                 // Mirror rakudo's CompUnit::Repository::Installation.can-install:
                 // writable if the prefix is writable, or it does not yet exist and
-                // its parent directory is writable (so it can be created on install).
+                // it can be *created* — i.e. the nearest already-existing ancestor
+                // directory is writable. Checking only the immediate parent is
+                // wrong when several path components are missing at once (mutsu's
+                // default `home`/`site` repos live under a not-yet-created
+                // `~/.local/share/mutsu/repo/`; `zef install`'s `auto` target
+                // selection then found no installable repo and died with "Need a
+                // valid installation target to continue").
                 use crate::runtime::native_io::path_is_writable;
                 let prefix_path = std::path::Path::new(&prefix);
-                let can = path_is_writable(prefix_path)
-                    || (!prefix_path.exists()
-                        && prefix_path.parent().map(path_is_writable).unwrap_or(false));
+                let can = if path_is_writable(prefix_path) {
+                    true
+                } else if prefix_path.exists() {
+                    // Exists but not writable.
+                    false
+                } else {
+                    // Walk up to the nearest existing ancestor and check whether
+                    // the missing prefix could be created under it.
+                    let mut ancestor = prefix_path.parent();
+                    loop {
+                        match ancestor {
+                            Some(dir) if dir.exists() => break path_is_writable(dir),
+                            Some(dir) => ancestor = dir.parent(),
+                            None => break false,
+                        }
+                    }
+                };
                 Some(Ok(Value::truth(can)))
             }
             "path-spec" => Some(Ok(Value::str(format!("inst#{prefix}")))),

--- a/t/compunit-can-install.t
+++ b/t/compunit-can-install.t
@@ -1,19 +1,21 @@
 use v6;
 use Test;
 
-# CompUnit::Repository::Installation.can-install mirrors Rakudo: writable if the
-# prefix is writable, or it does not yet exist and its parent is writable (so it
-# can be created on install). zef's `install` command greps repos by
-# `.?can-install` to choose an install target, so a missing method left the whole
-# install pipeline stuck.
+# CompUnit::Repository::Installation.can-install mirrors Rakudo: an install target
+# is installable if the prefix is writable, OR it does not yet exist and can be
+# *created* — i.e. the nearest already-existing ancestor directory is writable.
+# zef's `install` command greps repos by `.?can-install` to choose an install
+# target (the `auto` target picks the first of `site`/`home` that can-install), so
+# getting this wrong stalls the whole install pipeline with "Need a valid
+# installation target to continue".
 
-plan 3;
+plan 4;
 
 my $base = $*TMPDIR.add("can-install-{$*PID}");
 $base.mkdir;
-# Best-effort cleanup: instantiating an Installation may populate the prefix,
-# so a plain rmdir can fail on a non-empty directory — ignore that.
-LEAVE { try { $base.rmdir } }
+# Instantiating an Installation / probing can-install may populate the prefix, so
+# clean up recursively and ignore failures.
+LEAVE { try { .unlink for $base.dir(:recursive).grep(*.f); $base.dir(:recursive).grep(*.d).reverse.map(*.rmdir); $base.rmdir } }
 
 my $writable = CompUnit::Repository::Installation.new(prefix => $base.absolute);
 ok $writable.can-install, 'writable existing prefix can-install';
@@ -21,5 +23,15 @@ ok $writable.can-install, 'writable existing prefix can-install';
 my $child = CompUnit::Repository::Installation.new(prefix => $base.add("newchild").absolute);
 ok $child.can-install, 'missing prefix under a writable parent can-install';
 
+# Several missing path components at once: still installable, because the nearest
+# existing ancestor ($base) is writable and the whole chain can be created. (This
+# is exactly the shape of mutsu's default `~/.local/share/mutsu/repo/home` target
+# on a fresh install.) raku agrees: such a prefix reports can-install=True.
 my $deep = CompUnit::Repository::Installation.new(prefix => $base.add("a/b/c").absolute);
-nok $deep.can-install, 'missing prefix whose parent also does not exist cannot-install';
+ok $deep.can-install, 'deeply-nested creatable prefix (missing ancestors) can-install';
+
+# But a prefix whose only existing ancestor is a non-writable root is NOT
+# installable.
+my $unrootable = CompUnit::Repository::Installation.new(
+    prefix => "/mutsu-nonexistent-root-{$*PID}/repo");
+nok $unrootable.can-install, 'prefix under a non-writable root cannot install';


### PR DESCRIPTION
`CompUnit::Repository::Installation.can-install` reported an install target as **not** installable when several leading path components were missing at once: it only checked the *immediate* parent's writability. mutsu's own default `home`/`site` repos live under a not-yet-created `~/.local/share/mutsu/repo/`, so on a fresh machine both returned False.

zef's `install` picks its `auto` target with `first { .can-install }, <site home>`, so this made `zef install` die with **"Need a valid installation target to continue"** even though the target is perfectly creatable. (Confirmed the same isolated env installs cleanly under real `raku`.)

## Fix
When the prefix does not exist, walk up the ancestor chain to the nearest already-existing directory and check *its* writability — the prefix can be created if some existing ancestor is writable. Matches rakudo, verified against `raku`:
- deeply-nested creatable prefix → `can-install=True`
- prefix whose only existing ancestor is a non-writable root → `can-install=False`

The pre-existing `t/compunit-can-install.t` asserted the OLD (buggy) "deep missing prefix cannot-install" behavior; corrected to match raku and extended with the non-writable-root negative case.

With this, `zef install ./dist` advances past install-target selection (the next blocker is a separate hash-init error in the install step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)