### PR TITLE
fix(gather): cell-promote captured lexicals read by a lazy gather body

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -402,8 +402,11 @@ impl Compiler {
                 && Self::is_dostmt_for(target) =>
             {
                 if let Some(gather_block) = Self::make_lazy_for_gather(target) {
-                    let idx = self.code.add_stmt(Stmt::Block(gather_block));
-                    self.code.emit(OpCode::MakeGather(idx));
+                    let idx = self.code.add_stmt(Stmt::Block(gather_block.clone()));
+                    // Lazy body: cell-promote captured-and-mutated lexicals, as
+                    // for Expr::Gather below.
+                    let cc_idx = self.surface_stashed_body_free_vars(&[], &gather_block);
+                    self.code.emit(OpCode::MakeGather(idx, Some(cc_idx)));
                 } else {
                     self.compile_expr_method_generic(target, name, args, &None, false);
                 }
@@ -701,7 +704,13 @@ impl Compiler {
             Expr::Gather(_) => {
                 if let Expr::Gather(body) = expr {
                     let idx = self.code.add_stmt(Stmt::Block(body.clone()));
-                    self.code.emit(OpCode::MakeGather(idx));
+                    // A gather body pulls lazily after this frame moves on, so a
+                    // captured-and-mutated lexical it reads must be cell-promoted
+                    // or the pull sees a stale env snapshot (`my $x = 1; my $s =
+                    // gather { take $x }; $x = 2` must take 2, not 1). See
+                    // surface_stashed_body_free_vars for the mechanism.
+                    let cc_idx = self.surface_stashed_body_free_vars(&[], body);
+                    self.code.emit(OpCode::MakeGather(idx, Some(cc_idx)));
                 }
             }
             Expr::Eager(inner) => {

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -529,6 +529,36 @@ impl Compiler {
         }
     }
 
+    /// Surface the free variables of a stmt_pool-stashed body (`gather` /
+    /// `whenever`) to this frame's escape analysis. Such a body is
+    /// runtime-compiled against the live env (exec_make_gather_op /
+    /// exec_whenever_scope_op), so the nested-closure free-var scan in
+    /// `compute_free_vars` cannot see which lexicals it reads or writes — a
+    /// captured-and-mutated lexical would stay a stale by-value env snapshot
+    /// instead of being promoted to a shared ContainerRef cell (a gather body
+    /// pulls lazily after the frame moves on; a whenever body fires
+    /// asynchronously, often on another thread). Compile the body once more as
+    /// an ANALYSIS-ONLY escaping closure: only its free-var/needs-cell metadata
+    /// feeds `compute_free_vars`; the compiled code itself is never executed.
+    /// Named subs the analysis compile registers are dropped — the runtime
+    /// compile of the stashed body registers the real ones, and a junk
+    /// duplicate under the analysis closure's package could split `state`
+    /// scoping if a loose lookup resolved to it.
+    /// Returns the analysis closure's index into `closure_compiled_codes` so
+    /// the emitting op can hand it to `box_captured_lexicals` at runtime.
+    pub(crate) fn surface_stashed_body_free_vars(
+        &mut self,
+        params: &[String],
+        body: &[Stmt],
+    ) -> u32 {
+        let fn_keys_before: std::collections::HashSet<String> =
+            self.compiled_functions.keys().cloned().collect();
+        let analysis = self.compile_closure_body(params, &[], body);
+        self.compiled_functions
+            .retain(|k, _| fn_keys_before.contains(k));
+        self.code.add_closure_code(analysis, true)
+    }
+
     /// Compile a closure body to a `CompiledCode` (not stored in compiled_functions).
     /// Used for Lambda, AnonSub, AnonSubParams, and BlockClosure.
     pub(crate) fn compile_closure_body(

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2997,30 +2997,14 @@ impl Compiler {
             } => {
                 self.compile_expr(supply);
                 let body_idx = self.code.add_stmt(Stmt::Block(body.clone()));
-                // The whenever body is stashed in `stmt_pool` and runtime-compiled
-                // against the live env (exec_whenever_scope_op), so the nested-
-                // closure free-var scan in `compute_free_vars` cannot see which
-                // lexicals it reads or writes. Compile the body once more here as
-                // an ANALYSIS-ONLY escaping closure so those free variables surface
-                // in this frame's escape analysis: a whenever body fires
-                // asynchronously (often on another thread), so a captured-and-
-                // mutated lexical must be promoted to a shared ContainerRef cell in
-                // the frame that declares it — otherwise the body reads a stale
-                // by-value env snapshot (Case B: `start { react { whenever $ch {
-                // ...read $gate... } } }` missing the parent's post-registration
-                // `$gate = True`). The compiled code itself is never executed; only
-                // its free-var/needs-cell metadata feeds `compute_free_vars`.
+                // Case B (cross-thread lexicals): surface the runtime-compiled
+                // body's free vars so a captured-and-mutated lexical read
+                // directly in the whenever body (`start { react { whenever $ch
+                // { ...read $gate... } } }`) is cell-promoted and sees the
+                // parent's post-registration writes. See
+                // surface_stashed_body_free_vars for the mechanism.
                 let analysis_param = vec![param.clone().unwrap_or_else(|| "$_".to_string())];
-                let fn_keys_before: std::collections::HashSet<String> =
-                    self.compiled_functions.keys().cloned().collect();
-                let analysis = self.compile_closure_body(&analysis_param, &[], body);
-                // Drop named subs the analysis compile registered: the runtime
-                // compile of the stashed body registers the real ones, and a junk
-                // duplicate under the analysis closure's package could split
-                // `state` scoping if a loose lookup resolved to it.
-                self.compiled_functions
-                    .retain(|k, _| fn_keys_before.contains(k));
-                self.code.add_closure_code(analysis, true);
+                self.surface_stashed_body_free_vars(&analysis_param, body);
                 let param_idx = param
                     .as_ref()
                     .map(|p| self.code.add_constant(Value::str(p.clone())));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -735,7 +735,13 @@ pub(crate) enum OpCode {
     DoGivenExpr {
         body_end: u32,
     },
-    MakeGather(u32),
+    /// Create a lazy gather list from `stmt_pool[.0]`. `.1` indexes the
+    /// analysis-only escaping closure compiled from the same body
+    /// (`surface_stashed_body_free_vars`): exec boxes the captured-and-mutated
+    /// lexicals it names (`box_captured_lexicals`) BEFORE snapshotting the env,
+    /// so a lazy pull after the frame moves on reads the live cell, not a stale
+    /// by-value copy.
+    MakeGather(u32, Option<u32>),
     /// Force eager evaluation of the top-of-stack value (LazyList → Array)
     Eager,
     CallOnValue {
@@ -1731,7 +1737,7 @@ impl CompiledCode {
                 OpCode::ForLoop(..)
                     | OpCode::BlockScope { .. }
                     | OpCode::BlockLocalScope { .. }
-                    | OpCode::MakeGather(_)
+                    | OpCode::MakeGather(..)
                     | OpCode::WheneverScope { .. }
             )
         });

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1299,6 +1299,13 @@ pub(crate) struct GatherCoroutineState {
     pub(crate) stack: Vec<Value>,
     pub(crate) env: Env,
     pub(crate) finished: bool,
+    /// True once the body has run and suspended at least once. The resume
+    /// check must use this, NOT `ip > 0`: a body that is a single compound
+    /// loop op (`gather { loop { take ... } }`) suspends with `ip == 0` and
+    /// its position in `for_loop_resume`, and re-running it from scratch
+    /// instead of resuming double-applies the body's side effects on
+    /// cell-promoted captured lexicals.
+    pub(crate) started: bool,
     /// Saved for-loop iteration state when suspended inside a for loop.
     pub(crate) for_loop_resume: Option<ForLoopResumeState>,
 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3745,8 +3745,8 @@ impl Interpreter {
             }
 
             // -- Closures and registration --
-            OpCode::MakeGather(idx) => {
-                self.exec_make_gather_op(code, *idx)?;
+            OpCode::MakeGather(idx, cc_idx) => {
+                self.exec_make_gather_op(code, *idx, *cc_idx)?;
                 *ip += 1;
             }
             OpCode::Eager => {

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -79,7 +79,7 @@ impl Interpreter {
 
         if let Some(ref coro_mutex) = list.coroutine {
             let coro = coro_mutex.lock().unwrap();
-            if !coro.finished && coro.ip > 0 {
+            if !coro.finished && (coro.ip > 0 || coro.started) {
                 // Resume from saved state
                 ip = coro.ip;
                 self.locals = coro.locals.clone();
@@ -206,6 +206,7 @@ impl Interpreter {
                 stack: self.stack.clone(),
                 env: self.env().clone(),
                 finished: false,
+                started: true,
                 for_loop_resume,
             };
             if let Some(ref coro_mutex) = list.coroutine {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -23,9 +23,19 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         idx: u32,
+        cc_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::Block(body) = stmt {
+            // Box captured-and-mutated lexicals the gather body reads into shared
+            // ContainerRef cells BEFORE snapshotting the env: the body pulls
+            // lazily after this frame moves on, so a by-value copy would miss
+            // later writes (`my $x = 1; my $s = gather { take $x }; $x = 2` must
+            // take 2). The analysis closure (compiled from the same body by
+            // surface_stashed_body_free_vars) names the free vars; the boxing
+            // rules are exactly the closure-capture ones.
+            let analysis_cc = Self::resolve_closure_code(code, cc_idx);
+            self.box_captured_lexicals(code, &analysis_cc);
             let mut env = self.env().clone();
             env.insert("__mutsu_lazylist_from_gather".to_string(), Value::TRUE);
             // Compile the gather body to bytecode for Interpreter-native forcing
@@ -46,6 +56,7 @@ impl Interpreter {
                     stack: Vec::new(),
                     env: crate::env::Env::new(),
                     finished: false,
+                    started: false,
                     for_loop_resume: None,
                 })),
                 lazy_pipe: None,
@@ -516,36 +527,44 @@ impl Interpreter {
                 continue;
             }
             let needs_cell = code.needs_cell_locals.contains(sym);
-            let Some(idx) = sym.with_str(|s| {
-                if s.starts_with('@') || s.starts_with('%') || s.starts_with('&') {
-                    return None;
+            // Resolve to an owned String instead of `with_str`: `with_str` holds
+            // the global symbol table's READ lock across its closure, and the
+            // checks below (`var_type_constraint`, env access) can intern a NEW
+            // string — a same-thread read→write reacquire of the RwLock, which
+            // deadlocks. (Surfaced by the MakeGather boxing path; the closure
+            // creation ops share this code, so keep it lock-free for all.)
+            let s = sym.resolve();
+            if s.starts_with('@') || s.starts_with('%') || s.starts_with('&') {
+                continue;
+            }
+            let is_loop_local = self
+                .loop_local_vars
+                .iter()
+                .any(|set| set.contains(s.as_str()));
+            if !is_loop_local {
+                // Non-loop escaping path (B) only.
+                if !needs_cell {
+                    continue;
                 }
-                let is_loop_local = self.loop_local_vars.iter().any(|set| set.contains(s));
-                if !is_loop_local {
-                    // Non-loop escaping path (B) only.
-                    if !needs_cell {
-                        return None;
-                    }
-                    // A type/`where`-constrained scalar must keep flowing through
-                    // the assignment chokepoint so each mutation re-checks the
-                    // constraint; the ContainerRef write-through bypasses it. Skip
-                    // boxing it (inline `where` desugars to an anonymous subset, so
-                    // var_type_constraint catches block/whatever/`&pred` forms).
-                    // Applied to (B) only — the loop path (A) is left unchanged.
-                    // EXCEPTION: `Mu` is the universal type — every value satisfies
-                    // it, so the ContainerRef write-through bypasses no real check.
-                    // Box `my Mu $s` so captured-outer thunks (metaop `Xxx`/`Zand`)
-                    // share its cell and stay coherent without the blanket reconcile.
-                    let mut tc = loan_env!(self, var_type_constraint(s));
-                    if tc.is_none() {
-                        tc = loan_env!(self, var_type_constraint(s.trim_start_matches('$')));
-                    }
-                    if matches!(tc.as_deref(), Some(t) if t != "Mu") {
-                        return None;
-                    }
+                // A type/`where`-constrained scalar must keep flowing through
+                // the assignment chokepoint so each mutation re-checks the
+                // constraint; the ContainerRef write-through bypasses it. Skip
+                // boxing it (inline `where` desugars to an anonymous subset, so
+                // var_type_constraint catches block/whatever/`&pred` forms).
+                // Applied to (B) only — the loop path (A) is left unchanged.
+                // EXCEPTION: `Mu` is the universal type — every value satisfies
+                // it, so the ContainerRef write-through bypasses no real check.
+                // Box `my Mu $s` so captured-outer thunks (metaop `Xxx`/`Zand`)
+                // share its cell and stay coherent without the blanket reconcile.
+                let mut tc = loan_env!(self, var_type_constraint(&s));
+                if tc.is_none() {
+                    tc = loan_env!(self, var_type_constraint(s.trim_start_matches('$')));
                 }
-                code.locals.iter().rposition(|n| n == s)
-            }) else {
+                if matches!(tc.as_deref(), Some(t) if t != "Mu") {
+                    continue;
+                }
+            }
+            let Some(idx) = code.locals.iter().rposition(|n| *n == s) else {
                 continue;
             };
             let cur = &self.locals[idx];
@@ -569,20 +588,18 @@ impl Interpreter {
             }
             let container = cur.clone().into_container_ref();
             self.locals[idx] = container.clone();
-            sym.with_str(|s| {
-                self.env_mut().insert(s.to_string(), container.clone());
-                // Track C: if a thread is already running (shared_vars active) and a
-                // stale plain snapshot of this name lives in `shared_vars` (seeded
-                // by an earlier `start` before this local was boxed), replace it
-                // with the cell. Otherwise the stale value, marked dirty, would be
-                // written back over the cell by `sync_shared_vars_to_env` after the
-                // next await — disconnecting the parent from the shared cell.
-                // `set_shared_var` only updates entries that already exist, so this
-                // is a no-op when the name was never snapshotted.
-                if self.shared_vars_active {
-                    loan_env!(self, set_shared_var(s, container.clone()));
-                }
-            });
+            self.env_mut().insert(s.clone(), container.clone());
+            // Track C: if a thread is already running (shared_vars active) and a
+            // stale plain snapshot of this name lives in `shared_vars` (seeded
+            // by an earlier `start` before this local was boxed), replace it
+            // with the cell. Otherwise the stale value, marked dirty, would be
+            // written back over the cell by `sync_shared_vars_to_env` after the
+            // next await — disconnecting the parent from the shared cell.
+            // `set_shared_var` only updates entries that already exist, so this
+            // is a no-op when the name was never snapshotted.
+            if self.shared_vars_active {
+                loan_env!(self, set_shared_var(&s, container.clone()));
+            }
         }
     }
 }

--- a/t/gather-lazy-captured-lexical.t
+++ b/t/gather-lazy-captured-lexical.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 4;
+
+# A gather body pulls lazily after the declaring frame moves on, so a
+# captured lexical read inside the body must be promoted to a shared cell:
+# the pull must see writes made after the gather was created, not a stale
+# by-value env snapshot. (MakeGather now carries an analysis-only closure of
+# its body and boxes the captured-and-mutated lexicals it names, exactly like
+# closure creation does.)
+{
+    my $x = 1;
+    my $s = gather { take $x; take $x; };
+    $x = 2;
+    is $s.list.join(' '), '2 2', 'lazy gather body sees post-creation write';
+}
+
+# Same, inside a sub frame (a different boxing site than top-level code).
+{
+    sub f() {
+        my $x = 1;
+        my $s = gather { take $x; take $x; };
+        $x = 2;
+        $s.list.join(' ');
+    }
+    is f(), '2 2', 'lazy gather in a sub frame sees post-creation write';
+}
+
+# A cell-promoted captured counter must be incremented once per produced
+# element across take batches: the second slice must RESUME the suspended
+# coroutine, not re-run the body from scratch (a re-run would double-apply
+# the increments through the shared cell). The body here is a single
+# compound loop op, which suspends with ip == 0 — the resume check must use
+# the coroutine's started flag, not `ip > 0`.
+{
+    my $c = 0;
+    my @seq = lazy gather { loop { $c++; take $c } };
+    is @seq[^4].join(' '), '1 2 3 4', 'coroutine batch 1 through a shared cell';
+    is @seq[^5].join(' '), '1 2 3 4 5', 'coroutine batch 2 resumes instead of re-running';
+}


### PR DESCRIPTION
## Problem

Follow-up to #4345 (whenever Case B): `gather` bodies have the same blind spot. The body is stashed in the `stmt_pool` and runtime-compiled, so its free variables never reach the enclosing frame's escape analysis, and `MakeGather` snapshots the env by value. A lazy pull after the frame moves on reads stale copies:

```raku
my $x = 1;
my $s = gather { take $x; take $x };
$x = 2;
say $s.list;   # mutsu: (1 1) / raku: (2 2)
```

## Fix

Extract the #4345 mechanism into `surface_stashed_body_free_vars` (used by both the whenever arm and the two `MakeGather` emit sites): compile the body once more as an analysis-only escaping closure so captured-and-mutated lexicals are cell-promoted. Unlike whenever — whose enclosing `start`/supply closure runs `box_captured_lexicals` at creation — a gather has no closure-creation op, so `MakeGather` now carries the analysis closure's index and `exec_make_gather_op` boxes through `box_captured_lexicals` itself before snapshotting the env.

## Two latent bugs surfaced by the now-live cells (both fixed)

1. **Symbol-table RwLock deadlock in `box_captured_lexicals`** — it used `Symbol::with_str`, holding the global symbol table's READ lock across `var_type_constraint`/env access, which can intern a new string (WRITE lock): a same-thread read→write reacquire that deadlocks. This hung `S03-metaops/cross.t` (blocked, 0 CPU — confirmed via perf sampling). Resolved to an owned `String`; this also hardens the closure-creation paths sharing the code.

2. **Lazy-gather coroutine resumed only when `ip > 0`** — a body that is a single compound loop op (`gather { loop { take ... } }`) suspends with `ip == 0` and its position in `for_loop_resume`, so a larger slice re-ran the body from scratch. By-value snapshots masked this (each re-run started pristine and produced identical output); a shared cell makes the re-run double-apply the body's increments (`t/scoped-overlay-gather.t` test 7 regressed to `5 6 7 8 9`). Added a `started` flag to `GatherCoroutineState` and resume on it — the coroutine now genuinely resumes instead of relying on re-run determinism.

## Testing

- New guard `t/gather-lazy-captured-lexical.t` (4 tests: post-creation write visibility at top level and in a sub frame, and batch-resume through a shared cell). Output matches `raku`.
- `make test`: all 1586 files / 15515 tests pass (includes `t/scoped-overlay-gather.t` and `t/whenever-cross-thread-lexical.t`).
- Whitelisted roast: all 52 gather/lazy-using files (including the previously-hanging `S03-metaops/cross.t`, all 82 tests), plus all 100 S17/socket files re-run because `box_captured_lexicals` is shared by every closure-creation op — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW