### PR TITLE
fix(parser): bind @_/%_ pointy params and coercion-typed for-loop vars

### DIFF
--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -194,7 +194,14 @@ pub(crate) fn arrow_lambda(input: &str) -> PResult<'_, Expr> {
             && first.where_constraint.is_none()
             && first.sub_signature.is_none()
             && first.outer_sub_signature.is_none()
-            && first.code_signature.is_none();
+            && first.code_signature.is_none()
+            // `@_`/`%_` must NOT use the sigil-stripping Lambda path: stripping
+            // leaves the name `_`, and the body's `@_`/`%_` references then
+            // resolve to the shadowing implicit-args / named-args env keys
+            // instead of the bound param. Route them through the param_defs
+            // (AnonSubParams) path, which binds `@_`/`%_` correctly.
+            && first.name != "@_"
+            && first.name != "%_";
         if simple_single {
             // Strip sigil prefix for Lambda (it handles sigils internally)
             let lambda_name = first

--- a/src/parser/stmt/control/for_params.rs
+++ b/src/parser/stmt/control/for_params.rs
@@ -294,14 +294,10 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
 
     let rest = input;
     let mut type_constraint = None;
-    let rest = if let Ok((r, tc)) = ident(rest) {
-        // Preserve type smileys :D, :U, :_ as part of the type constraint.
-        let (r, tc) = if r.starts_with(":D") || r.starts_with(":U") || r.starts_with(":_") {
-            let smiley = &r[..2];
-            (&r[2..], format!("{}{}", tc, smiley))
-        } else {
-            (r, tc)
-        };
+    // Use parse_type_constraint_expr so coercion types (`IO()`, `Int(Str)`),
+    // qualified names, generics (`Array[Int]`) and definedness smileys (:D/:U)
+    // are all consumed before the loop variable (e.g. `-> IO() $current`).
+    let rest = if let Some((r, tc)) = super::super::sub_param::parse_type_constraint_expr(rest) {
         let (r2, _) = ws(r)?;
         if r2.starts_with('$') || r2.starts_with('@') || r2.starts_with('%') || r2.starts_with('&')
         {

--- a/t/pointy-at-underscore-param.t
+++ b/t/pointy-at-underscore-param.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+plan 11;
+
+# A pointy block whose single parameter is `@_` must bind the argument to `@_`,
+# not leave it shadowed by the implicit args array (regression: zef's
+# Zef::Utils::FileSystem `list-paths` uses `-> @_ { grep {...}, @_ }`).
+{
+    my &w := -> @_ { @_.elems };
+    is w((1, 2, 3)), 3, '-> @_ binds argument (elems)';
+}
+
+{
+    my &w := -> @_ { @_[1] };
+    is w((10, 20, 30)), 20, '-> @_ binds argument (indexing)';
+}
+
+{
+    my &w := -> @_ { grep { $_ > 1 }, @_ };
+    is-deeply w((1, 2, 3)).List, (2, 3), '-> @_ works as grep source';
+}
+
+{
+    my &w := -> @_ { map { $_ * 2 }, @_ };
+    is-deeply w((1, 2, 3)).List, (2, 4, 6), '-> @_ works as map source';
+}
+
+{
+    my &w := -> @_ { @_ };
+    is-deeply w((1, 2, 3)).List, (1, 2, 3), '-> @_ returns the whole list';
+}
+
+# `%_` as an explicit pointy parameter binds the argument hash.
+{
+    my &w := -> %_ { %_<a> };
+    is w(%(a => 5, b => 6)), 5, '-> %_ binds the hash argument';
+}
+
+# A named sub with an `@_` parameter still works (unchanged behaviour).
+{
+    sub s(@_) { @_.elems }
+    is s((7, 8)), 2, 'sub with @_ param binds argument';
+}
+
+# Coercion-typed for-loop variables must parse and coerce.
+{
+    my @out;
+    for (1, 2, 3) -> Int() $x { @out.push($x) }
+    is-deeply @out.List, (1, 2, 3), 'for with Int() coercion loop var';
+}
+
+{
+    my @out;
+    for <1 2 3> -> Int() $x { @out.push($x + 1) }
+    is-deeply @out.List, (2, 3, 4), 'for coerces Str elements via Int()';
+}
+
+# Coercion for-loop var over a function-call iterable (the zef idiom).
+{
+    my &wp := -> @_ { grep { $_ > 1 }, @_ };
+    my @out;
+    for wp((1, 2, 3)) -> Int() $x { @out.push($x) }
+    is-deeply @out.List, (2, 3), 'for over -> @_ result with coercion var';
+}
+
+# Coercion with an explicit source type: Str(Int).
+{
+    my @out;
+    for (1, 2) -> Str(Int) $x { @out.push($x ~ '!') }
+    is-deeply @out.List, ('1!', '2!'), 'for with Str(Int) coercion loop var';
+}


### PR DESCRIPTION
Two general parser bugs, both surfaced by running zef's **own upstream test suite** against mutsu (compat north-star). `t/utils-filesystem.rakutest` (`Zef::Utils::FileSystem` `list-paths`/`delete-paths`) now passes 4/4.

## Bug 1 — `-> @_ {...}` / `-> %_ {...}` pointy param not bound
A single-parameter pointy block whose parameter is `@_` (or `%_`) dropped its sigil in the `simple_single` Lambda optimization (`primary/misc/lambda.rs`), leaving the bare name `_`. The body's `@_`/`%_` references then resolved to the shadowing implicit-args / named-args env keys (which are empty), not the bound argument:

```raku
my &w := -> @_ { @_.elems };
say w((1, 2, 3));   # was 0, now 3
```

Fix: exclude `@_`/`%_` from the Lambda optimization so they route through the `param_defs` (AnonSubParams) path — the same path a named `sub s(@_) {...}` already used correctly.

## Bug 2 — coercion-typed for-loop variable misparse
`for LIST -> IO() $x {...}` failed to parse. `parse_for_pointy_param` used a bare `ident` for the type and never consumed the `()` coercion suffix, so `var_name` failed on `Int()...` and the entire `for` statement misparsed as an infix call with a `BareWord("for")` left operand:

```raku
for (1, 2, 3) -> Int() $x { say $x }   # was a parse/bind error, now works
```

Fix: use `parse_type_constraint_expr`, which already handles coercion types (`IO()`, `Int(Str)`), qualified names, generics (`Array[Int]`), and definedness smileys — consistent with `parse_pointy_param`.

## Tests
- New: `t/pointy-at-underscore-param.t` (11 subtests) covering both bugs.
- `make test`: Result PASS (cargo test 533, prove 15593 tests, no regressions).
- zef upstream `utils-filesystem` 4/4, `identity` 6/6, `00-load` 2/2 all still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA