### PR TITLE
fix(parser): accept parenthesized :ver/:auth/:api version adverbs on use

### DIFF
--- a/src/parser/stmt/decl/use_decl.rs
+++ b/src/parser/stmt/decl/use_decl.rs
@@ -90,17 +90,27 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
                     rest = after;
                     continue;
                 }
-                // Version/auth/api selectors (`:ver<...>`, `:auth<...>`, `:api<...>`)
-                // are NOT import tags — they refine which distribution to load.
-                // Consume their `<...>` value and discard, instead of treating the
-                // name as an import tag (which produced `no such tag 'ver'`).
-                let is_dist_selector =
-                    matches!(tag_name.as_str(), "ver" | "auth" | "api") && r.starts_with('<');
-                if is_dist_selector {
+                // Version/auth/api selectors are NOT import tags — they refine
+                // which distribution to load. Both the angle-bracket literal form
+                // (`:ver<1.0>`, `:auth<github:foo>`) and the parenthesized-expression
+                // form (`use Zef:ver($?DISTRIBUTION.meta<version>):auth(Zef.^auth)`,
+                // used throughout zef) must be consumed and discarded, instead of
+                // treating the name as an import tag (which produced `no such tag
+                // 'ver'` / `'auth'`).
+                let is_dist_selector = matches!(tag_name.as_str(), "ver" | "auth" | "api");
+                if is_dist_selector && r.starts_with('<') {
                     let after = match r[1..].find('>') {
                         Some(end) => &r[end + 2..],
                         None => return Err(PError::expected("closing '>' in version adverb")),
                     };
+                    let (after, _) = ws(after)?;
+                    let after = after.strip_prefix(',').unwrap_or(after);
+                    let (after, _) = ws(after)?;
+                    rest = after;
+                    continue;
+                }
+                if is_dist_selector && r.starts_with('(') {
+                    let after = skip_balanced_parens(r);
                     let (after, _) = ws(after)?;
                     let after = after.strip_prefix(',').unwrap_or(after);
                     let (after, _) = ws(after)?;

--- a/t/use-version-adverb-parens.t
+++ b/t/use-version-adverb-parens.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 4;
+
+# A `use` statement may carry version/authority/api selector adverbs. These are
+# NOT import tags — they refine which distribution to load. Both the angle-bracket
+# literal form (`:ver<1.0>`) and the parenthesized-expression form
+# (`:ver($expr)`, `:auth(Zef.^auth)`) must be consumed and discarded rather than
+# treated as import tags. Regression: zef modules open with
+#   use Zef:ver($?DISTRIBUTION.meta<version>):api(...):auth(...);
+# which previously died with `no such tag 'ver'/'auth'`.
+
+# 1. Angle-bracket selector form still parses and loads.
+lives-ok { EVAL 'use Test:ver<1.0>; my $x = 42; $x.so' }, ':ver<...> angle-bracket selector';
+
+# 2. Parenthesized selector form parses and loads (the zef idiom).
+lives-ok { EVAL 'use Test:ver(1.0):api(1):auth(q{github:test}); my $x = 42; $x.so' },
+    ':ver(...):api(...):auth(...) parenthesized selectors';
+
+# 3. A parenthesized selector with a complex expression value.
+lives-ok { EVAL 'use Test:ver("6.c" // "*"):auth("github:" ~ "x"); my $x = 42; $x.so' },
+    'parenthesized selector with expression value';
+
+# 4. Selector adverbs do not consume a following real import argument.
+lives-ok { EVAL 'use Test:ver(1.0) <ok>; my $x = 42; $x.so' },
+    'selector adverb followed by import list';


### PR DESCRIPTION
## Problem
A `use` statement may carry version/authority/api **selector adverbs** that refine which distribution to load — these are *not* import tags. mutsu already skipped the angle-bracket literal form (`use Foo:ver<1.0>`), but the parenthesized-expression form used throughout zef fell through to the import-tag path:

```raku
use Zef:ver($?DISTRIBUTION.meta<version> // '*'):api(...):auth(...);
```

This died with `Error while importing from 'Zef': no such tag 'ver'/'auth' declared`, blocking `use Zef::Distribution`, `use Zef::Config`, etc.

## Fix
`parser/stmt/decl/use_decl.rs`: consume and discard `:ver(...)`, `:auth(...)`, `:api(...)` via `skip_balanced_parens`, mirroring the existing angle-bracket handling.

## Impact
Surfaced by running zef's own upstream test suite against mutsu (compat north-star). `distribution-depends-parsing` goes from **0/35 → 16/35** (it previously died at module load). The remaining failures need `Zef::Utils::SystemQuery` `by-distro.*` resolution and `{any:[...]}` alternation specs — a separate slice.

## Tests
- New: `t/use-version-adverb-parens.t` (4 subtests) — angle-bracket + parenthesized selector forms, complex expression values, and selector-followed-by-import-list.
- `make test`: Result PASS (cargo test 533, prove all green, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA