### PR TITLE
fix(supply): drive supply blocks outside react — cold whenever replay, live do/on-close

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -410,6 +410,13 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     attributes,
                     ..
                 } if class_name == "Supply" => {
+                    // An on-demand supply (`supply { ... }` block) has no
+                    // materialized values; its body must be run by the
+                    // stateful slow path (`supply_list_values`). Decline so
+                    // dispatch falls through.
+                    if attributes.as_map().contains_key("on_demand_callback") {
+                        return None;
+                    }
                     let items = match attributes.as_map().get("values").map(Value::view) {
                         Some(ValueView::Array(items, ..)) => items.to_vec(),
                         _ => Vec::new(),

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -45,6 +45,11 @@ impl Interpreter {
         attributes: &HashMap<String, Value>,
         wait_until_done: bool,
     ) -> Result<Vec<Value>, RuntimeError> {
+        // An on-demand supply (`supply { ... }` block) materializes by running
+        // its body and replaying cold `whenever` sources synchronously.
+        if attributes.contains_key("on_demand_callback") {
+            return self.supply_get_values(attributes);
+        }
         let mut items = match attributes.get("values").map(Value::view) {
             Some(ValueView::Array(values, ..)) => values.to_vec(),
             _ => Vec::new(),

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -301,9 +301,11 @@ impl Interpreter {
                         .is_some()
                 {
                     let matcher = args.first().cloned().unwrap_or(Value::NIL);
-                    if let Some(live) =
-                        self.make_live_transform_supply(&attributes.as_map(), matcher, true)
-                    {
+                    if let Some(live) = self.make_live_transform_supply(
+                        &attributes.as_map(),
+                        matcher,
+                        crate::runtime::native_methods::TransformMode::Grep,
+                    ) {
                         return Some(Ok(live));
                     }
                 }

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -456,7 +456,11 @@ impl Interpreter {
         let mapper = args.first().cloned().unwrap_or(Value::NIL);
         // Live (Supplier-backed) supply: register a transform tap so the map
         // stays live and forwards each mapped value to the derived supply.
-        if let Some(live) = self.make_live_transform_supply(attributes, mapper.clone(), false) {
+        if let Some(live) = self.make_live_transform_supply(
+            attributes,
+            mapper.clone(),
+            crate::runtime::native_methods::TransformMode::Map,
+        ) {
             return Ok(live);
         }
         let source_values = if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
@@ -493,11 +497,11 @@ impl Interpreter {
     /// that receives the filtered/mapped values. Returns `None` for a
     /// materialized (snapshot) supply so the caller applies the transform
     /// eagerly instead.
-    pub(super) fn make_live_transform_supply(
+    pub(in crate::runtime) fn make_live_transform_supply(
         &mut self,
         attributes: &HashMap<String, Value>,
         callable: Value,
-        is_grep: bool,
+        mode: crate::runtime::native_methods::TransformMode,
     ) -> Option<Value> {
         let source_sid = crate::runtime::native_methods::supplier_id_from_attrs(attributes)?;
         let downstream_sid = crate::runtime::native_methods::next_supplier_id();
@@ -505,7 +509,7 @@ impl Interpreter {
             source_sid,
             downstream_sid,
             callable,
-            is_grep,
+            mode,
         );
         let mut new_attrs = HashMap::new();
         new_attrs.insert("values".to_string(), Value::array(Vec::new()));
@@ -620,26 +624,36 @@ impl Interpreter {
         Ok(())
     }
 
-    /// Handle a `grep`/`map` transform tap emission on a live supply: run the
-    /// callable on the value, then forward the (filtered or mapped) result to
-    /// the downstream supplier and drive its taps.
+    /// Handle a `grep`/`map`/`do` transform tap emission on a live supply: run
+    /// the callable on the value, then forward the (filtered, mapped, or
+    /// original) result to the downstream supplier and drive its taps.
     pub(in crate::runtime) fn handle_supply_transform_emit(
         &mut self,
         downstream_supplier_id: u64,
         callable: Value,
-        is_grep: bool,
+        mode: crate::runtime::native_methods::TransformMode,
         value: Value,
     ) -> Result<(), RuntimeError> {
-        if is_grep {
-            // `grep` uses smart-match semantics (`$_ ~~ matcher`), so a Callable
-            // is called, a type object type-checks, a Regex matches, etc.
-            let keep = self.smart_match_values(&value, &callable);
-            if keep {
+        use crate::runtime::native_methods::TransformMode;
+        match mode {
+            TransformMode::Grep => {
+                // `grep` uses smart-match semantics (`$_ ~~ matcher`), so a
+                // Callable is called, a type object type-checks, a Regex
+                // matches, etc.
+                let keep = self.smart_match_values(&value, &callable);
+                if keep {
+                    self.handle_supply_forward(downstream_supplier_id, value)?;
+                }
+            }
+            TransformMode::Map => {
+                let mapped = self.call_sub_value(callable, vec![value], true)?;
+                self.handle_supply_forward(downstream_supplier_id, mapped)?;
+            }
+            TransformMode::Do => {
+                // Side-effect only: the original value passes through.
+                self.call_sub_value(callable, vec![value.clone()], true)?;
                 self.handle_supply_forward(downstream_supplier_id, value)?;
             }
-        } else {
-            let mapped = self.call_sub_value(callable, vec![value], true)?;
-            self.handle_supply_forward(downstream_supplier_id, mapped)?;
         }
         Ok(())
     }

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -47,11 +47,11 @@ pub(in crate::runtime) use state_scheduler::{
     fake_scheduler_cue_counter, fake_scheduler_init, next_fake_scheduler_id,
 };
 pub(in crate::runtime) use state_supplier::{
-    SupplierEmitAction, ZipAction, acquire_supply_serialize, bump_supplier_done_count,
-    close_all_supplier_taps, close_supplier_channel_taps, create_whenever_done_group,
-    flush_supplier_batch_taps, flush_supplier_line_taps, flush_supplier_words_taps,
-    get_classify_state, get_classify_sub_supplier_ids, get_start_output_supplier_ids,
-    get_supplier_zip_latest_state_ids, get_supplier_zip_state_ids,
+    SupplierEmitAction, TransformMode, ZipAction, acquire_supply_serialize,
+    bump_supplier_done_count, close_all_supplier_taps, close_supplier_channel_taps,
+    create_whenever_done_group, flush_supplier_batch_taps, flush_supplier_line_taps,
+    flush_supplier_words_taps, get_classify_state, get_classify_sub_supplier_ids,
+    get_start_output_supplier_ids, get_supplier_zip_latest_state_ids, get_supplier_zip_state_ids,
     get_transform_output_supplier_ids, last_supplier_tap_id, migrate_switch_inner,
     register_supplier_batch_tap, register_supplier_channel_tap, register_supplier_classify_tap,
     register_supplier_close_callback, register_supplier_done_callback, register_supplier_elems_tap,

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -194,15 +194,10 @@ impl Interpreter {
                 SupplierEmitAction::TransformCall {
                     downstream_supplier_id,
                     callable,
-                    is_grep,
+                    mode,
                     value: val,
                 } => {
-                    self.handle_supply_transform_emit(
-                        downstream_supplier_id,
-                        callable,
-                        is_grep,
-                        val,
-                    )?;
+                    self.handle_supply_transform_emit(downstream_supplier_id, callable, mode, val)?;
                 }
             }
         }

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -84,13 +84,22 @@ struct SupplierTapSubscription {
     closed: bool,
 }
 
+/// How a live transform tap forwards each emitted value to its downstream
+/// supplier: `Map` forwards the callable's return value, `Grep` forwards the
+/// original value when the callable (smart-)matches, `Do` calls the callable
+/// for its side effect and forwards the original value unchanged.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(in crate::runtime) enum TransformMode {
+    Map,
+    Grep,
+    Do,
+}
+
 #[derive(Clone)]
 struct TransformState {
-    /// The `grep`/`map` callable applied to each emitted value.
+    /// The `grep`/`map`/`do` callable applied to each emitted value.
     callable: Value,
-    /// `true` for `grep` (filter: forward the original value when the callable
-    /// is truthy), `false` for `map` (forward the callable's return value).
-    is_grep: bool,
+    mode: TransformMode,
     /// The downstream supplier that receives the forwarded/transformed values.
     downstream_supplier_id: u64,
 }
@@ -818,13 +827,13 @@ pub(in crate::runtime) enum SupplierEmitAction {
         downstream_supplier_id: u64,
         value: Value,
     },
-    /// Transform: run the `grep`/`map` callable on the value, then forward the
-    /// (filtered or mapped) result to the downstream supplier. Needs the
-    /// interpreter to invoke the callable.
+    /// Transform: run the `grep`/`map`/`do` callable on the value, then forward
+    /// the (filtered, mapped, or original) result to the downstream supplier.
+    /// Needs the interpreter to invoke the callable.
     TransformCall {
         downstream_supplier_id: u64,
         callable: Value,
-        is_grep: bool,
+        mode: TransformMode,
         value: Value,
     },
 }
@@ -1031,7 +1040,7 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                 actions.push(SupplierEmitAction::TransformCall {
                     downstream_supplier_id: ts.downstream_supplier_id,
                     callable: ts.callable.clone(),
-                    is_grep: ts.is_grep,
+                    mode: ts.mode,
                     value: emitted_value.clone(),
                 });
             } else {
@@ -1628,15 +1637,15 @@ pub(in crate::runtime) fn register_supplier_flat_tap(
     }
 }
 
-/// Register a `grep`/`map` transform tap on a live supplier: each emitted value
-/// is passed through `callable` and the result forwarded to
-/// `downstream_supplier_id` (for `grep`, the original value is forwarded when
-/// the callable is truthy; for `map`, the callable's return value is forwarded).
+/// Register a `grep`/`map`/`do` transform tap on a live supplier: each emitted
+/// value is passed through `callable` and the result forwarded to
+/// `downstream_supplier_id` (see [`TransformMode`] for what each mode
+/// forwards).
 pub(in crate::runtime) fn register_supplier_transform_tap(
     supplier_id: u64,
     downstream_supplier_id: u64,
     callable: Value,
-    is_grep: bool,
+    mode: TransformMode,
 ) {
     if let Ok(mut map) = supplier_subscriptions_map().lock() {
         map.entry(supplier_id)
@@ -1668,7 +1677,7 @@ pub(in crate::runtime) fn register_supplier_transform_tap(
                 forward_downstream: None,
                 transform_state: Some(TransformState {
                     callable,
-                    is_grep,
+                    mode,
                     downstream_supplier_id,
                 }),
             });

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -280,13 +280,13 @@ impl Interpreter {
                             SupplierEmitAction::TransformCall {
                                 downstream_supplier_id,
                                 callable,
-                                is_grep,
+                                mode,
                                 value: val,
                             } => {
                                 self.handle_supply_transform_emit(
                                     downstream_supplier_id,
                                     callable,
-                                    is_grep,
+                                    mode,
                                     val,
                                 )?;
                             }
@@ -700,13 +700,13 @@ impl Interpreter {
                             SupplierEmitAction::TransformCall {
                                 downstream_supplier_id,
                                 callable,
-                                is_grep,
+                                mode,
                                 value: val,
                             } => {
                                 self.handle_supply_transform_emit(
                                     downstream_supplier_id,
                                     callable,
-                                    is_grep,
+                                    mode,
                                     val,
                                 )?;
                             }

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -373,8 +373,18 @@ impl Interpreter {
             }
             "do" => {
                 // Supply.do($callback) — create a new Supply that calls $callback
-                // as a side-effect for each value, passing values through
+                // as a side-effect for each value, passing values through.
+                // Live (Supplier-backed) supply: register a transform tap so the
+                // callback fires on each live emission (previously the derived
+                // supply dropped the supplier link and the callback never ran).
                 let callback = args.first().cloned().unwrap_or(Value::NIL);
+                if let Some(live) = self.make_live_transform_supply(
+                    attributes,
+                    callback.clone(),
+                    crate::runtime::native_methods::TransformMode::Do,
+                ) {
+                    return Ok(live);
+                }
                 let values = attributes
                     .get("values")
                     .cloned()

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -158,6 +158,23 @@ impl Interpreter {
                 // callbacks; remember its id on the Tap so `.close` fires them.
                 let mut close_supplier_id: Option<u64> = None;
 
+                // A live (Supplier-backed) supply carries `.on-close(...)` /
+                // `closing =>` callbacks in its attributes. Register them on
+                // the source supplier and point the Tap handle at it so
+                // `Tap.close` (and a supplier `done`) fires them; previously
+                // they were never wired on this path.
+                if !attrs.contains_key("on_demand_callback")
+                    && let Some(ValueView::Int(sid)) = attrs.get("supplier_id").map(Value::view)
+                    && let Some(ValueView::Array(cbs, ..)) =
+                        attrs.get("on_close_callbacks").map(Value::view)
+                    && !cbs.is_empty()
+                {
+                    for cb in cbs.iter() {
+                        register_supplier_close_callback(sid as u64, cb.clone());
+                    }
+                    close_supplier_id = Some(sid as u64);
+                }
+
                 // If this Supply has a supply_id (belongs to Proc::Async),
                 // register tap in the global registry so .start can find it
                 if let Some(ValueView::Int(sid)) = attrs.get("supply_id").map(Value::view) {
@@ -390,39 +407,38 @@ impl Interpreter {
                                     whenever_on_close.extend(cbs.iter().cloned());
                                 }
                             } else {
-                                let inner_vals =
-                                    if let ValueView::Instance { attributes: a, .. } =
-                                        inner_supply.view()
-                                    {
-                                        self.supply_list_values(&a.as_map(), true)?
+                                // Cold (supplier-less) whenever source: replay it
+                                // synchronously, capturing the body's emissions so
+                                // they reach the tap subscriber (and do_callbacks)
+                                // via plain_values below, in source order. Before
+                                // this the body's `$emitter.emit` had no registered
+                                // tap and the values were silently dropped. When a
+                                // preceding supplier-backed whenever already
+                                // registered the outer tap on the emitter, the
+                                // emissions were dispatched live during the replay,
+                                // so the captured copies are discarded.
+                                let last_cbs = Self::value_array_items(&arr[2]).unwrap_or_default();
+                                let quit_cbs = Self::value_array_items(&arr[3]).unwrap_or_default();
+                                let (mut captured, unhandled_quit) = self
+                                    .replay_cold_whenever_capture(
+                                        inner_supply,
+                                        &body_cb,
+                                        &last_cbs,
+                                        &quit_cbs,
+                                    );
+                                if !outer_tap_registered {
+                                    plain_values.append(&mut captured);
+                                }
+                                if let Some(reason) = unhandled_quit {
+                                    if let Some(ref qf) = quit_cb {
+                                        self.call_supply_quit_handler(qf.clone(), reason)?;
                                     } else {
-                                        self.supply_list_values(&HashMap::new(), true)?
-                                    };
-                                for v in inner_vals {
-                                    match self.call_sub_value(body_cb.clone(), vec![v], true) {
-                                        Ok(_) => {}
-                                        Err(err) => {
-                                            let reason = err
-                                                .exception
-                                                .as_deref()
-                                                .cloned()
-                                                .unwrap_or_else(|| Value::str(err.message));
-                                            if let Some(ref qf) = quit_cb {
-                                                self.call_supply_quit_handler(qf.clone(), reason)?;
-                                            } else {
-                                                return Err(
-                                                    Self::runtime_error_from_supply_reason(reason),
-                                                );
-                                            }
-                                            return Ok((
-                                                Value::make_instance(
-                                                    Symbol::intern("Tap"),
-                                                    HashMap::new(),
-                                                ),
-                                                attrs,
-                                            ));
-                                        }
+                                        return Err(Self::runtime_error_from_supply_reason(reason));
                                     }
+                                    return Ok((
+                                        Value::make_instance(Symbol::intern("Tap"), HashMap::new()),
+                                        attrs,
+                                    ));
                                 }
                             }
                         } else {

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -40,7 +40,48 @@ impl Interpreter {
     ) -> Result<Vec<Value>, RuntimeError> {
         if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
             let (_, emitted, _) = self.run_on_demand_body(on_demand_cb.clone(), None);
-            Ok(emitted)
+            // Expand `whenever` subscription markers: a cold (supplier-less)
+            // source is replayed synchronously so the body's emissions appear
+            // in source order. A live (supplier-backed) source cannot be
+            // driven synchronously here and is dropped (previously the raw
+            // 4-element marker array leaked through as a value).
+            let mut out = Vec::with_capacity(emitted.len());
+            for item in emitted {
+                let marker = if let ValueView::Array(arr, ..) = item.view()
+                    && arr.len() == 4
+                    && matches!(arr[0].view(), ValueView::Instance { class_name, .. } if class_name == "Supply")
+                {
+                    Some((
+                        arr[0].clone(),
+                        arr[1].clone(),
+                        arr[2].clone(),
+                        arr[3].clone(),
+                    ))
+                } else {
+                    None
+                };
+                let Some((source, body_cb, last_arr, quit_arr)) = marker else {
+                    out.push(item);
+                    continue;
+                };
+                let is_live = matches!(
+                    source.view(),
+                    ValueView::Instance { attributes: a, .. }
+                        if a.as_map().contains_key("supplier_id")
+                );
+                if is_live {
+                    continue;
+                }
+                let last_cbs = Self::value_array_items(&last_arr).unwrap_or_default();
+                let quit_cbs = Self::value_array_items(&quit_arr).unwrap_or_default();
+                let (mut captured, unhandled_quit) =
+                    self.replay_cold_whenever_capture(&source, &body_cb, &last_cbs, &quit_cbs);
+                out.append(&mut captured);
+                if let Some(reason) = unhandled_quit {
+                    return Err(Self::runtime_error_from_supply_reason(reason));
+                }
+            }
+            Ok(out)
         } else {
             Ok(match attributes.get("values").map(Value::view) {
                 Some(ValueView::Array(items, ..)) => items.to_vec(),
@@ -230,6 +271,110 @@ impl Interpreter {
         // CP-3 collapse: run the react drive loop with fresh execution registers
         // in place instead of the `mem::take(self)` + `VM::new` sub-VM.
         self.with_nested_registers(|vm| vm.drive_react_subscriptions_nested(react_subs, policy))
+    }
+
+    /// Replay a cold (supplier-less, channel-less) `whenever` subscription
+    /// marker synchronously, capturing every value the body and its phasers
+    /// emit, in order. Used by the `tap`/`act` path and `supply_get_values`
+    /// (`.list`/`.wait`/combinators) to deliver a `supply { whenever
+    /// Supply.from-list(...) { emit ... } }` block's emissions outside a react
+    /// loop. Lazy source elements are forced; a `done`/`last` from the body
+    /// stops the replay; `next`/`redo` skip to the next value; a `die` runs
+    /// the whenever's QUIT phasers if any are registered, otherwise its reason
+    /// is returned as the second tuple element for the caller to deliver
+    /// (quit callback or hard error). LAST phasers run on normal completion.
+    pub(crate) fn replay_cold_whenever_capture(
+        &mut self,
+        source: &Value,
+        callback: &Value,
+        last_cbs: &[Value],
+        quit_cbs: &[Value],
+    ) -> (Vec<Value>, Option<Value>) {
+        // Materialize the source through `supply_get_values` so a nested
+        // on-demand source (`whenever (supply { ... }) { ... }`) is itself
+        // replayed rather than read as an (empty) values snapshot.
+        let (values, mut quit_reason) = match source.view() {
+            ValueView::Instance { attributes, .. } => {
+                match self.supply_get_values(&attributes.as_map()) {
+                    Ok(items) => (items, None),
+                    Err(err) => (
+                        Vec::new(),
+                        Some(
+                            err.exception
+                                .as_deref()
+                                .cloned()
+                                .unwrap_or_else(|| Value::str(err.message.clone())),
+                        ),
+                    ),
+                }
+            }
+            _ => (Vec::new(), None),
+        };
+
+        fn run_capture(
+            this: &mut Interpreter,
+            cb: Value,
+            args: Vec<Value>,
+            captured: &mut Vec<Value>,
+        ) -> Result<(), RuntimeError> {
+            this.supply_emit_buffer.push(Vec::new());
+            let res = this.call_sub_value(cb, args, true);
+            let mut emitted = this.supply_emit_buffer.pop().unwrap_or_default();
+            captured.append(&mut emitted);
+            res.map(|_| ())
+        }
+
+        let err_to_value = |err: &RuntimeError| -> Value {
+            err.exception
+                .as_deref()
+                .cloned()
+                .unwrap_or_else(|| Value::str(err.message.clone()))
+        };
+
+        let mut captured: Vec<Value> = Vec::new();
+        'replay: for v in values {
+            let lazy = if let ValueView::LazyList(ll) = v.view() {
+                Some(ll.clone())
+            } else {
+                None
+            };
+            let items: Vec<Value> = match lazy {
+                Some(ll) => match self.force_lazy_list(&ll) {
+                    Ok(items) => items,
+                    Err(err) => {
+                        quit_reason = Some(err_to_value(&err));
+                        break 'replay;
+                    }
+                },
+                None => vec![v],
+            };
+            for item in items {
+                if let Err(err) = run_capture(self, callback.clone(), vec![item], &mut captured) {
+                    if err.is_react_done() || err.is_last() {
+                        break 'replay;
+                    }
+                    if err.is_next() || err.is_redo() {
+                        continue;
+                    }
+                    quit_reason = Some(err_to_value(&err));
+                    break 'replay;
+                }
+            }
+        }
+
+        if let Some(reason) = quit_reason {
+            if quit_cbs.is_empty() {
+                return (captured, Some(reason));
+            }
+            for q in quit_cbs {
+                let _ = run_capture(self, q.clone(), vec![reason.clone()], &mut captured);
+            }
+        } else {
+            for l in last_cbs {
+                let _ = run_capture(self, l.clone(), Vec::new(), &mut captured);
+            }
+        }
+        (captured, None)
     }
 
     /// On the `await`/`.Promise` path, replay a finite/static `whenever` source

--- a/t/supply-cold-whenever-nonreact-drive.t
+++ b/t/supply-cold-whenever-nonreact-drive.t
@@ -1,0 +1,97 @@
+use v6;
+use Test;
+
+plan 12;
+
+# A `supply { whenever <cold source> { ... } }` block driven OUTSIDE a react
+# loop (.tap / .list / .wait) must run the whenever body and deliver its
+# emissions. Previously the body's `emit` had no registered tap outside react
+# and the values were silently dropped (tap), or the raw whenever marker
+# leaked / returned empty (.list / .wait).
+
+# --- .tap drives cold whenever sources ---
+{
+    my $sup = supply { whenever Supply.from-list(1, 2, 3) { emit $_ * 10 } };
+    my @got;
+    my $done = 0;
+    $sup.tap({ @got.push($_) }, done => { $done = 1 });
+    is @got.join(','), '10,20,30', 'tap on cold-whenever supply delivers emissions';
+    is $done, 1, 'tap done callback fires after cold whenever completes';
+}
+
+# --- body-level emits and whenever emissions keep source order ---
+{
+    my $sup = supply {
+        emit 0;
+        whenever Supply.from-list(1, 2) { emit $_ }
+    };
+    my @got;
+    $sup.tap({ @got.push($_) });
+    is @got.join(','), '0,1,2', 'plain emits and cold whenever emissions stay in order';
+}
+
+# --- .list / .wait materialize the block ---
+{
+    my $sup = supply { whenever Supply.from-list(1, 2, 3) { emit $_ * 10 } };
+    is $sup.list.join(','), '10,20,30', '.list materializes a cold-whenever supply';
+    is $sup.wait, 30, '.wait returns the last emitted value';
+}
+
+# --- a captured lexical written by the whenever body is visible after ---
+{
+    my $count = 0;
+    my $sup = supply {
+        whenever Supply.from-list(1, 2, 3) { $count++; emit $_ }
+    };
+    $sup.wait;
+    is $count, 3, 'whenever body writes to a captured lexical are visible after .wait';
+}
+
+# --- a lexical the caller reassigns after creation is seen by the body ---
+{
+    my $gate = 0;
+    my $sup = supply { whenever Supply.from-list(1) { emit $gate } };
+    $gate = 9;
+    my @got;
+    $sup.tap({ @got.push($_) });
+    is @got.join(','), '9', 'supply body reads the current lexical value at tap time';
+}
+
+# --- LAST phaser of a cold whenever runs (and may emit) ---
+{
+    my $sup = supply {
+        whenever Supply.from-list(1, 2) { emit $_; LAST { emit 99 } }
+    };
+    is $sup.list.join(','), '1,2,99', 'LAST phaser of a cold whenever runs and emits';
+}
+
+# --- die inside the body routes to the tap quit handler ---
+{
+    my $sup = supply { whenever Supply.from-list(1) { die "boom" } };
+    my $quit = '';
+    $sup.tap({ ; }, quit => { $quit = ~$_ });
+    ok $quit.contains('boom'), 'die in a cold whenever body reaches the quit handler';
+}
+
+# --- Supply.do fires on live emissions ---
+{
+    my $s = Supplier.new;
+    my $seen = 0;
+    my @through;
+    $s.Supply.do({ $seen++ }).tap({ @through.push($_) });
+    $s.emit(7);
+    $s.emit(8);
+    is $seen, 2, 'Supply.do callback fires per live emission';
+    is @through.join(','), '7,8', 'Supply.do passes live values through unchanged';
+}
+
+# --- on-close fires when the tap is closed ---
+{
+    my $s = Supplier.new;
+    my $closed = 0;
+    my $tap = $s.Supply.on-close({ $closed = 1 }).tap({ ; });
+    $tap.close;
+    is $closed, 1, 'on-close callback fires on Tap.close';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Closing BLOCKERS §4 (#4349) included probing the async surface against raku; three supply-plumbing gaps surfaced that no roast file covers. All three are fixed here as general-purpose improvements.

### 1. `supply { whenever <cold source> { ... } }` driven outside react dropped emissions
- `.tap` ran the whenever body, but for a cold (supplier-less) source like `Supply.from-list` the emitter had no registered tap, so every `emit` was silently dropped.
- `.list` / `.wait` returned the raw 4-element whenever marker (or an empty list via the native 0arg fast path) without running the body at all.

Fix: new `replay_cold_whenever_capture` helper — a `supply_emit_buffer`-captured synchronous replay honoring lazy-source forcing, `done`/`last`/`next`/`redo` control flow, and LAST/QUIT phasers. Used from the tap arm's cold branch (emissions flow into `plain_values` in source order, so `do_callbacks` and the done callback keep working) and from `supply_get_values`, which now expands whenever markers for `.list`/`.wait`/`.Channel`/combinators; nested on-demand sources materialize recursively. The native 0arg `.list` fast path declines on-demand supplies so dispatch reaches the stateful slow path.

### 2. `Supply.do` never fired on live emissions
The derived supply dropped the supplier link entirely. The live transform-tap mechanism (previously `is_grep: bool` for map/grep) is generalized to `TransformMode { Map, Grep, Do }`; `Do` invokes the callback for its side effect and forwards the original value.

### 3. `.on-close(...)` on a live supply never fired on `Tap.close`
The tap arm never wired the supply's `on_close_callbacks` for the supplier-backed path. They are now registered as supplier close callbacks with the Tap handle's `close_supplier_id` pointing at the source.

## Testing
- New guard: `t/supply-cold-whenever-nonreact-drive.t` (12 cases, expectations validated against raku; all previously failing paths covered).
- `make test`: 1594 files PASS.
- All 107 whitelisted S17 + socket roast files: PASS (`prove -j4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW