### PR TITLE
fix(vm,runtime): stop in-loop recursion leaking a callee's loop var into caller

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -976,6 +976,73 @@ pub(crate) enum AssignOp {
 ///
 /// This is used at parse time to detect implicit block parameters so that
 /// constructs like `{ $^a + $^b }` automatically introduce parameters.
+/// Collect the names a routine body binds *locally* — `for`/`while`/`loop`/`given`
+/// pointy parameters and every nested `my` declaration — so the interpreter's
+/// return env merge does not write them back over a same-named *caller* lexical.
+/// Without this, a routine that recurses into a same-named `for` loop and
+/// early-returns (e.g. Zef's `system-collapse`) leaks its inner loop parameter's
+/// last value into the caller (the caller's loop variable / hash key is corrupted).
+/// Scalar names only (matching the caller's scalar-writeback filter); `@`/`%`
+/// binders are handled by the Array/Hash writeback path.
+pub(crate) fn collect_routine_body_local_names(
+    stmts: &[Stmt],
+    out: &mut std::collections::HashSet<String>,
+) {
+    fn add_scalar(name: &str, out: &mut std::collections::HashSet<String>) {
+        let bare = name.strip_prefix('\\').unwrap_or(name);
+        if !bare.is_empty() && !bare.starts_with('@') && !bare.starts_with('%') {
+            out.insert(bare.to_string());
+        }
+    }
+    for stmt in stmts {
+        match stmt {
+            Stmt::VarDecl { name, .. } => add_scalar(name, out),
+            Stmt::For {
+                param,
+                params,
+                body,
+                ..
+            } => {
+                if let Some(p) = param {
+                    add_scalar(p, out);
+                }
+                for p in params {
+                    add_scalar(p, out);
+                }
+                collect_routine_body_local_names(body, out);
+            }
+            Stmt::If {
+                then_branch,
+                else_branch,
+                binding_var,
+                ..
+            } => {
+                if let Some(v) = binding_var {
+                    add_scalar(v, out);
+                }
+                collect_routine_body_local_names(then_branch, out);
+                collect_routine_body_local_names(else_branch, out);
+            }
+            Stmt::While { body, .. }
+            | Stmt::Loop { body, .. }
+            | Stmt::React { body }
+            | Stmt::Block(body)
+            | Stmt::SyntheticBlock(body)
+            | Stmt::Default(body)
+            | Stmt::Catch(body)
+            | Stmt::Control(body) => collect_routine_body_local_names(body, out),
+            Stmt::Given { body, .. } | Stmt::When { body, .. } => {
+                collect_routine_body_local_names(body, out)
+            }
+            Stmt::Whenever { body, .. } => collect_routine_body_local_names(body, out),
+            Stmt::Label { stmt, .. } => {
+                collect_routine_body_local_names(std::slice::from_ref(stmt), out)
+            }
+            _ => {}
+        }
+    }
+}
+
 pub(crate) fn collect_placeholders(stmts: &[Stmt]) -> Vec<String> {
     let mut names = Vec::new();
     for stmt in stmts {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1621,6 +1621,32 @@ pub(crate) struct CompiledCode {
 }
 
 impl CompiledCode {
+    /// Names that are *local* to this body: declared local slots plus the
+    /// parameter names bound by any `for` loop in the body. Used by the
+    /// interpreter sub-call path to keep a callee's `for`-loop parameter (or a
+    /// body-local `my`) from being written back into a same-named *caller*
+    /// lexical during the return env merge (a callee that recurses into a
+    /// same-named `for` loop and early-returns would otherwise leak its last
+    /// loop value into the caller). Mirrors `CompiledFunction::compute_declared_locals`.
+    pub(crate) fn body_local_names(&self) -> std::collections::HashSet<String> {
+        let mut names: std::collections::HashSet<String> =
+            self.locals.iter().cloned().collect();
+        for op in &self.ops {
+            if let OpCode::ForLoop(spec) = op {
+                if let Some(idx) = spec.param_idx
+                    && let Some(crate::value::ValueView::Str(name)) =
+                        self.constants.get(idx as usize).map(crate::value::Value::view)
+                {
+                    names.insert(name.to_string());
+                }
+                for name in &spec.multi_param_names {
+                    names.insert(name.clone());
+                }
+            }
+        }
+        names
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             ops: Vec::new(),
@@ -2890,16 +2916,40 @@ impl CompiledFunction {
         for p in &self.params {
             declared.insert(p.clone());
         }
-        // Scan opcodes for SetVarDynamic which marks `my` declarations
+        // Scan opcodes for SetVarDynamic which marks `my` declarations, and
+        // ForLoop which binds its loop parameter(s). A `for` param (`-> $idx`) is
+        // callee-local: it is bound by the ForLoop op into env, not via a `my`
+        // (SetVarDynamic) or the function signature, so without collecting it here
+        // the scoped-overlay return merge would leak the callee's last loop value
+        // into a caller lexical of the same name (recursion into a same-named
+        // `for` loop that early-returns).
         for op in &self.code.ops {
-            if let OpCode::SetVarDynamic { name_idx, .. } = op
-                && let Some(crate::value::ValueView::Str(name)) = self
-                    .code
-                    .constants
-                    .get(*name_idx as usize)
-                    .map(crate::value::Value::view)
-            {
-                declared.insert(name.to_string());
+            match op {
+                OpCode::SetVarDynamic { name_idx, .. } => {
+                    if let Some(crate::value::ValueView::Str(name)) = self
+                        .code
+                        .constants
+                        .get(*name_idx as usize)
+                        .map(crate::value::Value::view)
+                    {
+                        declared.insert(name.to_string());
+                    }
+                }
+                OpCode::ForLoop(spec) => {
+                    if let Some(idx) = spec.param_idx
+                        && let Some(crate::value::ValueView::Str(name)) = self
+                            .code
+                            .constants
+                            .get(idx as usize)
+                            .map(crate::value::Value::view)
+                    {
+                        declared.insert(name.to_string());
+                    }
+                    for name in &spec.multi_param_names {
+                        declared.insert(name.clone());
+                    }
+                }
+                _ => {}
             }
         }
         self.declared_locals = Some(declared);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1621,33 +1621,6 @@ pub(crate) struct CompiledCode {
 }
 
 impl CompiledCode {
-    /// Names that are *local* to this body: declared local slots plus the
-    /// parameter names bound by any `for` loop in the body. Used by the
-    /// interpreter sub-call path to keep a callee's `for`-loop parameter (or a
-    /// body-local `my`) from being written back into a same-named *caller*
-    /// lexical during the return env merge (a callee that recurses into a
-    /// same-named `for` loop and early-returns would otherwise leak its last
-    /// loop value into the caller). Mirrors `CompiledFunction::compute_declared_locals`.
-    pub(crate) fn body_local_names(&self) -> std::collections::HashSet<String> {
-        let mut names: std::collections::HashSet<String> = self.locals.iter().cloned().collect();
-        for op in &self.ops {
-            if let OpCode::ForLoop(spec) = op {
-                if let Some(idx) = spec.param_idx
-                    && let Some(crate::value::ValueView::Str(name)) = self
-                        .constants
-                        .get(idx as usize)
-                        .map(crate::value::Value::view)
-                {
-                    names.insert(name.to_string());
-                }
-                for name in &spec.multi_param_names {
-                    names.insert(name.clone());
-                }
-            }
-        }
-        names
-    }
-
     pub(crate) fn new() -> Self {
         Self {
             ops: Vec::new(),

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1629,13 +1629,14 @@ impl CompiledCode {
     /// same-named `for` loop and early-returns would otherwise leak its last
     /// loop value into the caller). Mirrors `CompiledFunction::compute_declared_locals`.
     pub(crate) fn body_local_names(&self) -> std::collections::HashSet<String> {
-        let mut names: std::collections::HashSet<String> =
-            self.locals.iter().cloned().collect();
+        let mut names: std::collections::HashSet<String> = self.locals.iter().cloned().collect();
         for op in &self.ops {
             if let OpCode::ForLoop(spec) = op {
                 if let Some(idx) = spec.param_idx
-                    && let Some(crate::value::ValueView::Str(name)) =
-                        self.constants.get(idx as usize).map(crate::value::Value::view)
+                    && let Some(crate::value::ValueView::Str(name)) = self
+                        .constants
+                        .get(idx as usize)
+                        .map(crate::value::Value::view)
                 {
                     names.insert(name.to_string());
                 }

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -91,11 +91,10 @@ impl Interpreter {
         for pd in &def.param_defs {
             Self::collect_sub_signature_names(&pd.sub_signature, &mut names);
         }
-        for stmt in &def.body {
-            if let Stmt::VarDecl { name, .. } = stmt {
-                names.insert(name.clone());
-            }
-        }
+        // Collect for-loop parameters and *nested* `my` declarations (not just
+        // top-level VarDecls) so a callee's body-local binding never leaks into a
+        // same-named caller lexical on the return env merge.
+        crate::ast::collect_routine_body_local_names(&def.body, &mut names);
         names
     }
 

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -542,22 +542,8 @@ impl Interpreter {
                 for pd in &data.param_defs {
                     Self::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
                 }
-                // A `for`-loop parameter (or body-local `my`) is NOT a captured
-                // outer variable: it is declared by this body and must not be
-                // written back over a same-named caller lexical (a callee that
-                // recurses into a same-named `for` loop and early-returns would
-                // otherwise leak its last loop value into the caller).
-                let body_local_names = data
-                    .compiled_code
-                    .as_ref()
-                    .map(|cc| cc.body_local_names())
-                    .unwrap_or_default();
                 for (k, v) in self.env.iter() {
-                    if k == "_"
-                        || k == "@_"
-                        || subsig_names.contains(&k.resolve())
-                        || k.with_str(|s| body_local_names.contains(s))
-                    {
+                    if k == "_" || k == "@_" || subsig_names.contains(&k.resolve()) {
                         continue;
                     }
                     if matches!(v.view(), ValueView::Array(..)) {

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -542,8 +542,22 @@ impl Interpreter {
                 for pd in &data.param_defs {
                     Self::collect_sub_signature_names(&pd.sub_signature, &mut subsig_names);
                 }
+                // A `for`-loop parameter (or body-local `my`) is NOT a captured
+                // outer variable: it is declared by this body and must not be
+                // written back over a same-named caller lexical (a callee that
+                // recurses into a same-named `for` loop and early-returns would
+                // otherwise leak its last loop value into the caller).
+                let body_local_names = data
+                    .compiled_code
+                    .as_ref()
+                    .map(|cc| cc.body_local_names())
+                    .unwrap_or_default();
                 for (k, v) in self.env.iter() {
-                    if k == "_" || k == "@_" || subsig_names.contains(&k.resolve()) {
+                    if k == "_"
+                        || k == "@_"
+                        || subsig_names.contains(&k.resolve())
+                        || k.with_str(|s| body_local_names.contains(s))
+                    {
                         continue;
                     }
                     if matches!(v.view(), ValueView::Array(..)) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -284,6 +284,15 @@ pub(crate) struct VmCallFrame {
     /// state. Light-frame method path counterpart to `readonly_added`.
     pub readonly_removed: Vec<String>,
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
+    /// The caller's loop-body-local declaration scopes. These VM fields track
+    /// which `my` names a `for`/`while` body declared so they can be restored at
+    /// loop exit (see `pop_loop_local_scope`). A compiled-function body runs via
+    /// its own `exec_one` mini-loop (not `run()`, which saves them), so without
+    /// snapshotting them here a callee invoked from inside a loop body would
+    /// register its own `my` declarations in the *caller's* active loop scope and
+    /// have them clobbered at the caller's loop exit.
+    pub saved_loop_local_vars: Vec<HashSet<String>>,
+    pub saved_loop_local_saved_env: Vec<HashMap<String, Value>>,
 }
 
 // CP-3 collapse: the bytecode Interpreter has been fully dissolved into the `Interpreter`

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -61,6 +61,15 @@ impl Interpreter {
         };
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack_depth = self.stack.len();
+        // Isolate the caller's loop-body-local declaration scope. `run()` saves
+        // and restores these per invocation; this fast path bypasses `run()` and
+        // drives the body via `exec_one`, so without this a callee's `my $x`
+        // (or its own for/while loop) would register in the *caller's* active
+        // loop-local scope and get restored (clobbered) at the caller's loop
+        // exit. Repro: `sub f { my $r=0; for ^2 { f() if ...; $r+=100 }; $r }` —
+        // the inner `my $r` polluted the outer loop's scope, resetting $r to 0.
+        let saved_loop_local_vars = std::mem::take(&mut self.loop_local_vars);
+        let saved_loop_local_saved_env = std::mem::take(&mut self.loop_local_saved_env);
 
         // Raku: routines get their own $_ initialized to (Any).
         let saved_topic = if cf.code.is_routine {
@@ -173,6 +182,8 @@ impl Interpreter {
 
         // Restore state
         self.locals = saved_locals;
+        self.loop_local_vars = saved_loop_local_vars;
+        self.loop_local_saved_env = saved_loop_local_saved_env;
 
         // Restore env: if env was mutated, merge non-local changes back.
         // When has_locals is false, saved_env is None and no restore is needed

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -35,6 +35,8 @@ impl Interpreter {
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
+            saved_loop_local_vars: std::mem::take(&mut self.loop_local_vars),
+            saved_loop_local_saved_env: std::mem::take(&mut self.loop_local_saved_env),
         };
         self.call_frames.push(frame);
     }
@@ -54,6 +56,8 @@ impl Interpreter {
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
+            saved_loop_local_vars: std::mem::take(&mut self.loop_local_vars),
+            saved_loop_local_saved_env: std::mem::take(&mut self.loop_local_saved_env),
         };
         self.call_frames.push(frame);
     }
@@ -71,6 +75,8 @@ impl Interpreter {
         self.locals = std::mem::take(&mut frame.saved_locals);
         self.upvalues = std::mem::take(&mut frame.saved_upvalues);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
+        self.loop_local_vars = std::mem::take(&mut frame.saved_loop_local_vars);
+        self.loop_local_saved_env = std::mem::take(&mut frame.saved_loop_local_saved_env);
         if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
             // Slow path: restore the whole snapshot (covers any `:=` marking).
             self.restore_readonly_vars(readonly);

--- a/t/recursion-loop-param-leak.t
+++ b/t/recursion-loop-param-leak.t
@@ -1,0 +1,90 @@
+use v6;
+use Test;
+
+plan 7;
+
+# A routine that recurses from *inside* its own `for`/`while` loop must not let
+# the recursive callee clobber the caller's loop accumulator or loop parameter.
+# Both the compiled VM path and the interpreter (sub-with-inner-sub / module)
+# path are exercised.
+
+# 1. Accumulator survives recursion inside the loop body (VM path).
+{
+    my $n = 0;
+    sub acc() {
+        $n = $n + 1;
+        my $r = 0;
+        for ^2 -> $i {
+            acc() if $n < 2;
+            $r = $r + 100;
+        }
+        return $r;
+    }
+    is acc(), 200, 'accumulator survives in-loop recursion';
+}
+
+# 2. Nested hash build via recursion (the system-collapse shape, VM path).
+{
+    sub collapse($data) {
+        return $data unless $data ~~ Hash;
+        my %return;
+        for $data.keys -> $idx {
+            given $idx {
+                when /^ 'stop' / { return "RESOLVED"; }
+                default { %return{$idx} = collapse($data{$idx}); }
+            }
+        }
+        return %return;
+    }
+    my %d = (a => "x", b => { "stop.x" => "deep" });
+    my %got = collapse(%d);
+    is %got<a>, "x", 'outer key a preserved';
+    is %got<b>, "RESOLVED", 'nested key b resolved (loop param not leaked)';
+}
+
+# 3. Loop parameter is not leaked across recursion (both keys correct).
+{
+    sub keys-ok($data) {
+        return $data unless $data ~~ Hash;
+        my %out;
+        for $data.keys.sort -> $k {
+            given $k {
+                when /^ 'zap' / { return "Z"; }
+                default { %out{$k} = keys-ok($data{$k}); }
+            }
+        }
+        return %out;
+    }
+    my %d = (name => { "zap.q" => 1 }, from => "native");
+    my %got = keys-ok(%d);
+    is %got<name>, "Z", 'key "name" not corrupted to inner loop key';
+    is %got<from>, "native", 'sibling key "from" preserved';
+}
+
+# 4. Same, but the routine declares an inner `my sub` (routes through the
+#    interpreter path instead of the compiled VM path).
+{
+    sub collapse2($data) {
+        return $data unless $data ~~ Hash;
+        my sub helper($x) { return $x }
+        my $return = $data.WHAT.new;
+        for $data.keys -> $idx {
+            given $idx {
+                when /^ 'stop' / {
+                    my $h = helper($idx);
+                    return "RESOLVED";
+                }
+                default {
+                    my $val = collapse2($data{$idx});
+                    $return{$idx} = $val if $return ~~ Hash;
+                }
+            }
+        }
+        return $return;
+    }
+    my %d = (a => "x", name => { "stop.x" => "deep" });
+    my %got = collapse2(%d);
+    is %got<a>, "x", 'interpreter path: outer key a preserved';
+    is %got<name>, "RESOLVED", 'interpreter path: key "name" not corrupted';
+}
+


### PR DESCRIPTION
## Bug
A routine that recurses from **inside its own `for` loop** leaked the callee's loop parameter (and body-local `my`) into a same-named **caller** lexical on return, corrupting the caller's loop variable / accumulator:

```raku
my $n = 0;
sub acc() {
    $n = $n + 1;
    my $r = 0;
    for ^2 -> $i { acc() if $n < 2; $r = $r + 100 }
    return $r;
}
say acc();   # was 0, should be 200
```

Surfaced by running zef's own upstream test suite against mutsu: `Zef::Utils::SystemQuery::system-collapse` recurses over a `by-distro.name` query, and mutsu returned the outer result key `{name => X}` as `{"by-distro.name" => X}` — the inner loop's `$idx` clobbered the outer's.

## Root cause & fix
The callee's loop-local binding was written back over a same-named caller lexical. Fixed on **both** execution paths:

- **Compiled VM path** — `push_call_frame`/`pop_call_frame` and the 0-arg fast path (`vm_call_fast.rs`) now save/restore `loop_local_vars` / `loop_local_saved_env`. These paths run the body via their own `exec_one` loop, bypassing `run()` (which already isolated them), so a callee's `my` / inner loop registered in the *caller's* active loop-local scope and got clobbered at the caller's loop exit.
- `CompiledFunction::compute_declared_locals` now also collects `for`-loop parameter names, so the scoped-overlay return merge filters them.
- **Interpreter path** (a sub with an inner `my sub` routes through `call_function_fallback` → `routine_writeback_excluded_names`) now recurses via new `ast::collect_routine_body_local_names` to exclude `for`-loop params and *nested* `my` declarations from the return env writeback.

## Impact
Takes zef's upstream `distribution-depends-parsing` test from **0/35 → 16/35** (it previously died mid-file with a corrupted dependency structure). The remaining failures need `Zef::Distribution.depends-specs` native/hash handling — a separate slice.

## Tests
- New: `t/recursion-loop-param-leak.t` (7 subtests) covering both the VM and interpreter paths, `for` and nested-`given/when`-early-return shapes.
- `make test`: Result PASS (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA