### PR TITLE
fix(container): hash multislice \target binds, Whatever adverbs, Test-fn &-refs, boxed-cell identity

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -61,38 +61,31 @@ cross-thread plain-scalar lexical writeback（旧 §4.1）も escape 解析→Co
   (v2022.12=6.d) でもこのテスト自体がコンパイルに失敗するため、参照実装での検証すらできない。
 - **評価**: 深い機能待ちで、局所修正では進まない。優先度は低い。
 
-### 2.3 multislice lvalue（array/hash）
+### 2.3 multislice lvalue（hash 側の残件）
 
-- **対象**: `S32-array/multislice-6e.t`（784/812、28 失敗）、
-  `S32-hash/multislice-6e.t`（318 実行時点で plan mismatch、90 失敗——ファイルが途中で中断）。
-- **論点**: `@a[0;0;0] = 999`、`%h<a;b;c> = 999` の lvalue 書き戻し経路。
-- **根本原因**: single subscript と multislice が同じ「書き戻し可能 target 集合」抽象を
-  返していない。array 側はかなり前進した（605→157→28 まで縮小）が、hash 側はまだ
-  Track B（要素 cell 化・ADR-0001 層3a・GC と統合キャンペーン）待ちで大きく残っている。
-- **変更レイヤ**: `vm_var_index_ops` / `vm_var_assign_ops` / lvalue binding surface
-- **Next slice**: array 側の残り 28 件から着手し、hash 側の plan mismatch（中断の原因）を
-  先に切り分ける。
-- **Primary files**: `src/vm/vm_var_index_ops.rs`, `src/vm/vm_var_assign_ops.rs`
-- **調査結果（2026-07-02）**: array 側の 28 失敗（例: test 245, line 120）を再現したところ、
-  直接代入 `@array[0;0;3] = 999`（境界外インデックスへの自動延伸）自体は正しく動く：
-  ```
-  my @array = [[[42,666,[314]],],];
-  @array[0;0;3] = 999;  # OK: [[[42, 666, [314], 999],],]
-  ```
-  失敗するのは、この**境界外・自動延伸が必要な多次元インデックス式を sigilless bind
-  （`\target`）でサブルーチン引数として渡し、後から `target = 999` で代入する**ケース
-  （テストの `assignable-ok(\target, \values, @result)` ヘルパーが使うパターン）：
-  ```
-  sub f(\target, \values) { target = values }
-  f(@array[0;0;3], 999);  # mutsu: 何もしない（Nil を返す）; raku: 正しく延伸して代入
-  ```
-  つまり根本原因は「lvalue 書き戻し経路」一般ではなく、**§3 のコンテナ id キャンペーン
-  （配列/ハッシュ要素の cell 化）そのもの**——多次元インデックス式が返す「書き込み可能な
-  参照」が、値としてキャプチャされた後もオリジナルの配列への自動延伸込みの書き込みを
-  実現できる第一級コンテナ（cell）になっていない。§2 の「局所修正」の範疇を超え、§3.2 の
-  「配列/ハッシュ要素 cell 化」（`docs/container-identity.md`、対象に `splice.t` と並記）と
-  同一の基盤工事が前提条件。単体の parser/dispatch 修正では閉じない。
-  次に着手するなら §3 のキャンペーンとして本腰を入れる想定で計画すること。
+- **対象**: `S32-hash/multislice-6e.t`。array 側（`S32-array/multislice-6e.t`）は
+  **812/812 全通過・whitelist 済み**（この文書の旧「28 失敗」は stale だった）。
+- **進捗（2026-07-09 container-identity slice）**: hash 側 269 fails + test 318 で
+  中断 → **32 fails・535/549 実行**まで前進。直ったもの:
+  - Test 関数の `&` 参照（`my &fn = &is-deeply`）が Nil だった → Routine 値化
+    （318 中断の正体は block 3 冒頭の `(?? &is-deeply !! &non-assignable-ok)(...)`）。
+  - hash multislice の Whatever / key-list 次元 × 全 adverb（:k/:kv/:p/:v/:exists/
+    :delete）— leaf 収集を `Value` パス化し hash 対応。
+  - `\target` bind：hash root の cell 昇格解禁・欠落キーは deep-path `HashEntryRef`、
+    materialize を AssignExprLocal / AssignExpr / SetGlobal / boxed-cell
+    write-through（`Value::store_through_cell`）に配線。
+  - boxed captured `@a`/`%h` の whole-container 再代入が container identity を保持
+    （`cell_store_preserving_container_identity`）。
+  - Pin: `t/hash-multislice-container.t`。
+- **残る根本原因（32 fails・multislice ではない）**: sigilless map param を入れ子
+  呼び出しの引数に渡すと（`.map(-> \k, \v { Pair.new(k,v) })`）、varref の名前ベース
+  再解決が stale env を読む。値が List のとき `k` が最初の chunk の値を繰り返す
+  （文をまたいでも漏れる）。再現:
+  `((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(k,v) })` →
+  `((1,2)=>"A", (1,2)=>"B")`。plain read（`k.raku`）は正しく、call-arg 位置のみ壊れる。
+  main でも再現する pre-existing。**Next slice = この varref-by-name 再解決の修正**
+  （`compile_call_arg` の WrapVarRef / binding_signature の
+  `resolve_sigilless_alias_source_name` 系）。plan mismatch（535/549）も残件。
 
 ---
 

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -640,13 +640,30 @@
     now reads/mutates through the `ContainerRef` cell that a file-scoped `%hash`
     written by `set-up-hash` carries (it previously only matched plain
     `Array`/`Hash` and silently no-op'd). Pin: `t/multidim-container-ref-coherence.t`.
-  - Remaining (CANNOT whitelist yet):
-    - test 2 "check assignability with 999": `(%h{a;b;c} = v)` bound as a raw
-      `\target` and assigned/checked INSIDE the sub -- needs TRUE first-class
-      element containers (Track B, ADR-0001 layer 3a, fused with GC).
-    - whatever-in-dimension hash slice adverbs (`%h{*;*;"x"}:delete`,
-      `:exists`, ...) still produce wrong results in the multi-whatever section,
-      and an uncaught error there aborts the file at test 318/549.
+  - **2026-07-09 (container-identity campaign slice)**: 269 fails / abort at
+    318 -> **32 fails, 535/549 ran**. Fixed in one slice: (a) `&is-deeply`-style
+    Test-function `&`-references (Routine value via `resolve_code_var`) — the
+    318 abort was block 3's `($det ?? &is-deeply !! &non-assignable-ok)(...)`;
+    (b) Whatever/key-list dims in ALL hash multislice adverbs (`:k/:kv/:p/:v/
+    :exists/:delete` — `multidim_collect_leaves` now walks hashes with `Value`
+    paths, `multidim_index`/`multidim_delete` got Whatever-over-Hash arms);
+    (c) `\target` binds of hash multislices — `multi_dim_slot_ref` hash root
+    un-bailed, missing keys yield a deep-path `HashEntryRef`, materialization
+    added to AssignExprLocal / AssignExpr / SetGlobal and boxed-cell
+    write-through (`Value::store_through_cell`); (d) whole-hash/array
+    reassignment through a boxed captured var preserves container identity
+    (`cell_store_preserving_container_identity`). Pin:
+    `t/hash-multislice-container.t` (25).
+  - Remaining (CANNOT whitelist yet): the 32 fails are all block-3
+    `:kv`/`:exists:kv` shapes, root cause is NOT multislice: a sigilless map
+    param passed as a nested call argument (`.map(-> \k, \v { Pair.new(k,v) })`)
+    resolves the varref by NAME against a stale env entry when the bound value
+    is a List — `k` repeats the first chunk's value (even leaks across
+    statements). Plain reads of `k` are fine; only call-arg positions break.
+    Repro: `((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(k,v) })` gives
+    `((1,2)=>"A", (1,2)=>"B")`. Separate root cause (map param binding /
+    varref-by-name re-resolution), pre-existing — reproduces on main. Also a
+    residual plan mismatch (535/549) to re-check after that fix.
 - [ ] roast/S32-hash/pairs.t
   - 17/26 pass (1-2, 4-10, 12-18, 20). Good `.pairs` support on hashes. Failures: element count (3, 11), rw aliases (19, 21), `:p` adverb form (22-26). Difficulty: Medium
 - [ ] roast/S32-hash/perl.t

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -208,21 +208,15 @@ impl Compiler {
         // doc on `bind_target_direct`.
         let is_bind_target = self.bind_target_direct;
         self.bind_target_direct = false;
-        // An array multi-dimensional subscript (`@a[0;1;2]`) passed as a raw
-        // `\target` / `is rw` argument must alias the underlying nested array
+        // A multi-dimensional subscript (`@a[0;1;2]`, `%h{"a";"b"}`) passed as a
+        // raw `\target` / `is rw` argument must alias the underlying nested
         // slot, so a later `target = v` inside the callee mutates the real
         // container and is visible immediately. Emit a `MultiDimIndexBindRef`
         // that descends to the leaf and promotes it to a shared `ContainerRef`
-        // cell; the callee binds through it. Slice dimensions (`@a[*; 0,1]`)
-        // can't collapse to a single cell, so the op pushes the read value as a
-        // fallback. A HASH subscript (`%h{"a";"b"}`) is deliberately NOT routed
-        // here: promoting a hash leaf to a cell mutates the shared hash `Arc`
-        // in place, which would corrupt other values that alias it (e.g. a
-        // snapshot captured into a `for` list), so hash multislices keep the
-        // plain read path below.
-        if let Expr::MultiDimIndex { target, dimensions } = arg
-            && !matches!(target.as_ref(), Expr::HashVar(_))
-        {
+        // cell (a missing hash leaf gets a deferred `HashEntryRef`); the callee
+        // binds through it. Slice dimensions that can't collapse to one cell
+        // yield a list of leaf cells, or fall back to the plain read value.
+        if let Expr::MultiDimIndex { target, dimensions } = arg {
             self.compile_expr(target);
             for dim in dimensions {
                 self.compile_expr(dim);

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -323,6 +323,13 @@ impl Interpreter {
             sub_val
         } else if Self::is_builtin_function(lookup_name) {
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
+        } else if self.test_module_loaded() && Self::is_test_function_name(lookup_name) {
+            // Test-framework functions (&is-deeply, &pass, ...) are implemented
+            // as Rust methods (runtime/test_functions.rs), not declared subs, so
+            // the function-def lookup above misses them. Expose them as Routine
+            // values so `my &fn = &is-deeply; fn(...)` dispatches through the
+            // Routine call path, which routes test names to the Test dispatcher.
+            Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
         } else if bare_name.starts_with('*') {
             // Dynamic code vars (&*foo) can point to routines that are resolved
             // at call time (including builtins not listed in is_builtin_function).

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -21,14 +21,24 @@ pub(super) fn multidim_index(target: &Value, indices: &[Value]) -> Value {
     let head = &indices[0];
     // Whatever (*) means "all elements of this dimension"
     if matches!(head.view(), ValueView::Whatever) {
-        let ValueView::Array(items, ..) = target.view() else {
-            return Value::NIL;
-        };
-        let mut out = Vec::with_capacity(items.len());
-        for item in items.iter() {
-            out.push(multidim_index(item, &indices[1..]));
+        match target.view() {
+            ValueView::Array(items, ..) => {
+                let mut out = Vec::with_capacity(items.len());
+                for item in items.iter() {
+                    out.push(multidim_index(item, &indices[1..]));
+                }
+                return Value::array(out);
+            }
+            // Hash level: `*` selects every value at this level.
+            ValueView::Hash(map) => {
+                let mut out = Vec::with_capacity(map.len());
+                for v in map.values() {
+                    out.push(multidim_index(v, &indices[1..]));
+                }
+                return Value::array(out);
+            }
+            _ => return Value::NIL,
         }
-        return Value::array(out);
     }
     // List/Array as index means "multiple indices in this dimension"
     if let ValueView::Array(idx_items, ..) = head.view() {
@@ -95,6 +105,25 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
     let head = &indices[0];
     // Whatever (*) means "all elements of this dimension"
     if matches!(head.view(), ValueView::Whatever) {
+        // Hash level: `*` deletes through every value at this level (a
+        // terminal `*` removes all entries).
+        if matches!(target.view(), ValueView::Hash(..)) {
+            return target
+                .with_hash_mut(|map| {
+                    let map_mut = crate::gc::Gc::make_mut(map);
+                    if indices.len() == 1 {
+                        let out: Vec<Value> = map_mut.drain().map(|(_, v)| v).collect();
+                        Value::array(out)
+                    } else {
+                        let mut out = Vec::with_capacity(map_mut.len());
+                        for v in map_mut.values_mut() {
+                            out.push(multidim_delete(v, &indices[1..]));
+                        }
+                        Value::array(out)
+                    }
+                })
+                .unwrap_or_else(default);
+        }
         return target
             .with_array_mut(|items, _kind| {
                 let items = crate::gc::Gc::make_mut(items);
@@ -202,13 +231,15 @@ pub(super) fn make_key_tuple(indices: &[Value]) -> Value {
     )
 }
 
-/// Collect (path, value) leaves from a multi-dimensional array,
-/// expanding Whatever and Array indices along the way.
+/// Collect (path, value) leaves from a multi-dimensional array or hash,
+/// expanding Whatever and Array indices along the way. Path elements are the
+/// concrete index/key values (`Int` for array levels, `Str` for hash keys), so
+/// the `:k`/`:kv`/`:p` adverbs can rebuild the key tuple losslessly.
 pub(super) fn multidim_collect_leaves(
     target: &Value,
     indices: &[Value],
-    prefix: &[i64],
-    out: &mut Vec<(Vec<i64>, Value)>,
+    prefix: &[Value],
+    out: &mut Vec<(Vec<Value>, Value)>,
 ) {
     if let ValueView::ContainerRef(_) | ValueView::Scalar(_) = target.view() {
         return target.with_deref(|inner| {
@@ -224,36 +255,52 @@ pub(super) fn multidim_collect_leaves(
     let rest = &indices[1..];
 
     if matches!(head.view(), ValueView::Whatever) {
-        if let ValueView::Array(items, ..) = target.view() {
-            for (i, item) in items.iter().enumerate() {
-                let mut p = prefix.to_vec();
-                p.push(i as i64);
-                multidim_collect_leaves(item, rest, &p, out);
+        match target.view() {
+            ValueView::Array(items, ..) => {
+                for (i, item) in items.iter().enumerate() {
+                    let mut p = prefix.to_vec();
+                    p.push(Value::int(i as i64));
+                    multidim_collect_leaves(item, rest, &p, out);
+                }
             }
+            // Hash level: `*` walks every entry, recording the (typed) key.
+            ValueView::Hash(map) => {
+                for (k, v) in map.iter() {
+                    let mut p = prefix.to_vec();
+                    p.push(map.typed_key(k));
+                    multidim_collect_leaves(v, rest, &p, out);
+                }
+            }
+            _ => {}
         }
         return;
     }
     if let ValueView::Array(idx_items, ..) = head.view() {
         for idx in idx_items.iter() {
-            let i = match idx.view() {
-                ValueView::Int(n) => n,
-                _ => idx.to_string_value().parse::<i64>().unwrap_or(0),
-            };
             let mut p = prefix.to_vec();
-            p.push(i);
+            p.push(idx.clone());
             let child = multidim_index(target, std::slice::from_ref(idx));
             multidim_collect_leaves(&child, rest, &p, out);
         }
         return;
     }
-    let i = match head.view() {
-        ValueView::Int(n) => n,
-        _ => head.to_string_value().parse::<i64>().unwrap_or(0),
-    };
     let mut p = prefix.to_vec();
-    p.push(i);
+    p.push(head.clone());
     let child = multidim_index(target, std::slice::from_ref(head));
     multidim_collect_leaves(&child, rest, &p, out);
+}
+
+/// Build the key tuple for one collected leaf path: a single-dimension path is
+/// the bare key; a multi-dimension path is a List of the keys.
+pub(super) fn leaf_key_tuple(path: Vec<Value>) -> Value {
+    if path.len() == 1 {
+        path.into_iter().next().unwrap()
+    } else {
+        Value::array_with_kind(
+            crate::gc::Gc::new(crate::value::ArrayData::new(path)),
+            ArrayKind::List,
+        )
+    }
 }
 
 /// Check if any index in the list is a Whatever or an Array (multi-index).

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::value::ArrayKind;
 
 use super::builtins_multidim::{
-    array_to_list, has_multi_indices, make_key_tuple, multidim_collect_leaves, multidim_delete,
-    multidim_index,
+    array_to_list, has_multi_indices, leaf_key_tuple, make_key_tuple, multidim_collect_leaves,
+    multidim_delete, multidim_index,
 };
 
 impl Interpreter {
@@ -139,14 +139,7 @@ impl Interpreter {
         let mut out = Vec::new();
         for (path, value) in leaves {
             let exists = !value.is_nil();
-            let key = if path.len() == 1 {
-                Value::int(path[0])
-            } else {
-                Value::array_with_kind(
-                    crate::gc::Gc::new(path.into_iter().map(Value::int).collect()),
-                    ArrayKind::List,
-                )
-            };
+            let key = leaf_key_tuple(path);
             match adverb {
                 "k" => {
                     if exists {
@@ -418,14 +411,7 @@ impl Interpreter {
         for (path, value) in leaves {
             let raw_exists = !value.is_nil();
             let exists = if negated { !raw_exists } else { raw_exists };
-            let key = if path.len() == 1 {
-                Value::int(path[0])
-            } else {
-                Value::array_with_kind(
-                    crate::gc::Gc::new(path.into_iter().map(Value::int).collect()),
-                    ArrayKind::List,
-                )
-            };
+            let key = leaf_key_tuple(path);
             match adverb {
                 "none" => out.push(Value::truth(exists)),
                 "kv" => {
@@ -727,14 +713,7 @@ impl Interpreter {
             let mut out = Vec::new();
             for (path, value) in leaves {
                 let exists = !value.is_nil();
-                let key = if path.len() == 1 {
-                    Value::int(path[0])
-                } else {
-                    Value::array_with_kind(
-                        crate::gc::Gc::new(path.into_iter().map(Value::int).collect()),
-                        ArrayKind::List,
-                    )
-                };
+                let key = leaf_key_tuple(path);
                 match adverb.as_str() {
                     "k" => {
                         if exists {
@@ -850,14 +829,7 @@ impl Interpreter {
             for (path, value) in leaves {
                 let raw_exists = !value.is_nil();
                 let exists = if negated { !raw_exists } else { raw_exists };
-                let key = if path.len() == 1 {
-                    Value::int(path[0])
-                } else {
-                    Value::array_with_kind(
-                        crate::gc::Gc::new(path.into_iter().map(Value::int).collect()),
-                        ArrayKind::List,
-                    )
-                };
+                let key = leaf_key_tuple(path);
                 match adverb.as_str() {
                     "none" => out.push(Value::truth(exists)),
                     "kv" => {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1236,8 +1236,10 @@ impl Interpreter {
                     if pd.sigilless {
                         let alias_key = sigilless_alias_key(&pd.name);
                         let readonly_key = sigilless_readonly_key(&pd.name);
-                        if matches!(value.view(), ValueView::ContainerRef(_))
-                            || is_multidim_slice_cells(&value)
+                        if matches!(
+                            value.view(),
+                            ValueView::ContainerRef(_) | ValueView::HashEntryRef { .. }
+                        ) || is_multidim_slice_cells(&value)
                         {
                             // A multi-dimensional subscript lvalue (`@a[0;1;2]`)
                             // arrives as a shared `ContainerRef` cell aliasing the

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -229,6 +229,27 @@ impl Value {
         }
     }
 
+    /// Store `val` through a `ContainerRef` cell. If the cell currently holds a
+    /// `HashEntryRef` deferred token (a boxed `\target` bound to a
+    /// not-yet-existent hash key — e.g. the escape analysis boxed a captured
+    /// sigilless param before its first write), first materialize the binding:
+    /// this cell ITSELF is installed at the token's path (walk-creating any
+    /// intermediate hashes), so the hash entry and every holder of the cell
+    /// alias the same container from then on. A plain `clone_from` would
+    /// overwrite the token and silently drop the hash alias.
+    pub(crate) fn store_through_cell(arc: &crate::gc::Gc<Mutex<Value>>, val: &Value) {
+        let mut inner = arc.lock().unwrap();
+        if matches!(&*inner, Value::HashEntryRef { .. })
+            && let Some((hash_arc, key)) = inner.hash_entry_terminal()
+        {
+            // SAFETY: aliased in-place mutation of a shared container; see
+            // `arc_contents_mut`. No borrow into the map is live across the write.
+            let hd = unsafe { crate::value::gc_contents_mut(&hash_arc) };
+            Value::hash_insert_through(&mut hd.map, key, Value::ContainerRef(arc.clone()));
+        }
+        inner.clone_from(val);
+    }
+
     /// Assign a value into a `ContainerRef`.
     /// Returns `true` if the value was a ContainerRef and the assignment happened.
     pub fn assign_into_container(&self, new_val: Value) -> bool {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1118,7 +1118,10 @@ impl Interpreter {
                     if let Some(cell_val) = self.env().get(&name).cloned()
                         && let ValueView::ContainerRef(arc) = cell_val.view()
                     {
-                        arc.lock().unwrap().clone_from(&val);
+                        // Preserve the inner container's identity (§3): a boxed
+                        // captured `@a`/`%h` whole-reassigned here must keep its
+                        // backing `Gc` so by-value holders observe the update.
+                        Self::cell_store_preserving_container_identity(arc, &val);
                         *ip += 1;
                         return Ok(());
                     }
@@ -1129,7 +1132,32 @@ impl Interpreter {
                         && let Some(cell_val) = self.env().get(alias_target.as_str()).cloned()
                         && let ValueView::ContainerRef(arc) = cell_val.view()
                     {
-                        arc.lock().unwrap().clone_from(&val);
+                        Self::cell_store_preserving_container_identity(arc, &val);
+                        *ip += 1;
+                        return Ok(());
+                    }
+                    // First write through a missing-key bind reached as a captured
+                    // free variable (an env entry holding a `HashEntryRef` deferred
+                    // token, e.g. a `\target` bound to `%h{$a;$b;$c}` written from
+                    // a closure invoked by name): materialize the path into a
+                    // shared `ContainerRef` cell — the SetGlobal counterpart of the
+                    // SetLocal / AssignExpr materialization.
+                    if !name.starts_with('@')
+                        && !name.starts_with('%')
+                        && let Some(token) = self.env().get(&name).cloned()
+                        && matches!(token.view(), ValueView::HashEntryRef { .. })
+                        && let Some((arc, key)) = token.hash_entry_terminal()
+                    {
+                        let cell = crate::gc::Gc::new(std::sync::Mutex::new(val.clone()));
+                        // SAFETY: aliased in-place mutation of a shared hash; see
+                        // `arc_contents_mut`. No live borrow into the map.
+                        let hd = unsafe { crate::value::gc_contents_mut(&arc) };
+                        Value::hash_insert_through(
+                            &mut hd.map,
+                            key,
+                            Value::container_ref(cell.clone()),
+                        );
+                        self.set_env_with_main_alias(&name, Value::container_ref(cell));
                         *ip += 1;
                         return Ok(());
                     }

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -52,7 +52,9 @@ impl Interpreter {
             } else {
                 (raw_val, None)
             };
-        // Capture old hash Arc pointer for circular reference fixup.
+        // Capture old hash Arc pointer for circular reference fixup, and the
+        // backing `Gc` for the in-place whole-container reassignment below.
+        let mut inplace_old_hash: Option<crate::gc::Gc<crate::value::HashData>> = None;
         let old_hash_arc = if name.starts_with('%') {
             let current = self.get_env_with_main_alias(&name).or_else(|| {
                 code.locals.iter().position(|n| n == &name).and_then(|idx| {
@@ -64,6 +66,9 @@ impl Interpreter {
                 })
             });
             if let Some(ValueView::Hash(arc)) = current.as_ref().map(Value::view) {
+                if !name.contains("__ANON") {
+                    inplace_old_hash = Some(arc.clone());
+                }
                 Some(crate::gc::Gc::as_ptr(arc) as usize)
             } else {
                 None
@@ -71,7 +76,9 @@ impl Interpreter {
         } else {
             None
         };
-        // Capture old array Arc pointer for circular reference fixup.
+        // Capture old array Arc pointer for circular reference fixup, and the
+        // backing `Gc` for the in-place whole-container reassignment below.
+        let mut inplace_old_array: Option<crate::gc::Gc<crate::value::ArrayData>> = None;
         let old_array_arc = if name.starts_with('@') {
             let current = self.get_env_with_main_alias(&name).or_else(|| {
                 code.locals.iter().position(|n| n == &name).and_then(|idx| {
@@ -83,6 +90,9 @@ impl Interpreter {
                 })
             });
             if let Some(ValueView::Array(arc, _)) = current.as_ref().map(Value::view) {
+                if !name.contains("__ANON") {
+                    inplace_old_array = Some(arc.clone());
+                }
                 Some(crate::gc::Gc::as_ptr(arc) as usize)
             } else {
                 None
@@ -339,10 +349,39 @@ impl Interpreter {
                 // existing whole-reassignment semantics here.
                 let scalar = !name.starts_with('@') && !name.starts_with('%');
                 if scalar && !(self.array_share_active && self.is_array_share_scalar(&name)) {
-                    arc.lock().unwrap().clone_from(&val);
+                    Value::store_through_cell(arc, &val);
                     self.stack.push(val);
                     return Ok(());
                 }
+            }
+            // First write through a missing-key bind reached by name (a
+            // `HashEntryRef` deferred token, e.g. a `\target` bound to
+            // `%h{$a;$b;$c}` written inside a closure that captured `target`,
+            // like a `subtest { ... }` block): materialize the path into a
+            // shared `ContainerRef` cell. The name-based counterpart of the
+            // SetLocal / AssignExprLocal materialization.
+            if matches!(
+                current.as_ref().map(Value::view),
+                Some(ValueView::HashEntryRef { .. })
+            ) && !name.starts_with('@')
+                && !name.starts_with('%')
+                && let Some(token) = current.as_ref()
+                && let Some((arc, key)) = token.hash_entry_terminal()
+            {
+                let cell = crate::gc::Gc::new(std::sync::Mutex::new(val.clone()));
+                // SAFETY: aliased in-place mutation of a shared hash; see
+                // `arc_contents_mut`. No live borrow into the map.
+                let hd = unsafe { crate::value::gc_contents_mut(&arc) };
+                Value::hash_insert_through(&mut hd.map, key, Value::container_ref(cell.clone()));
+                let cell_val = Value::container_ref(cell);
+                if let Some(idx) = code.locals.iter().position(|n| n == &name)
+                    && idx < self.locals.len()
+                {
+                    self.locals[idx] = cell_val.clone();
+                }
+                self.set_env_with_main_alias(&name, cell_val);
+                self.stack.push(val);
+                return Ok(());
             }
             // A sigilless `\target` bound to a multi-dim slice lvalue distributes
             // the RHS element-wise through its cells (the env-named counterpart
@@ -396,6 +435,24 @@ impl Interpreter {
                     *stack_top = val.clone();
                 }
             }
+        }
+        // Container identity (§3, splice.t): a plain whole-hash/array
+        // reassignment reached by NAME (e.g. a captured outer `%h = ...` inside
+        // a sub) mutates the EXISTING container in place, mirroring the SetLocal
+        // slot path, so every other holder of the same backing `Gc` (a by-value
+        // capture in a list, the caller's local slot) observes the update.
+        if let Some(old_gc) = &inplace_old_hash
+            && let ValueView::Hash(new_gc) = val.view()
+            && !crate::gc::Gc::ptr_eq(old_gc, new_gc)
+        {
+            let new_gc = new_gc.clone();
+            val = Self::hash_inplace_reassign(old_gc, &new_gc);
+        } else if let Some(old_gc) = &inplace_old_array
+            && let ValueView::Array(new_gc, kind) = val.view()
+            && !crate::gc::Gc::ptr_eq(old_gc, new_gc)
+        {
+            let (new_gc, kind) = (new_gc.clone(), kind);
+            val = Self::array_inplace_reassign(old_gc, &new_gc, kind);
         }
         self.update_local_if_exists(code, &name, &val);
         self.set_env_with_main_alias(&name, val.clone());

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -69,6 +69,21 @@ impl Interpreter {
             }
         }
 
+        // First write through a missing-key bind (a local holding a
+        // `HashEntryRef` deferred token, e.g. a `\target` bound to
+        // `%h{$a;$b;$c}` with a not-yet-existent key): materialize the path
+        // into a shared `ContainerRef` cell. Mirrors the statement-form
+        // `SetLocal` path; without this the expression-context assignment
+        // (`(target = v)`) replaces the token and the hash never sees the write.
+        if matches!(self.locals[idx].view(), ValueView::HashEntryRef { .. }) {
+            let val = self.stack.pop().unwrap_or(Value::NIL);
+            if self.materialize_bound_slot_to_cell(code, idx, val.clone()) {
+                self.stack.push(val);
+                return Ok(());
+            }
+            self.stack.push(val);
+        }
+
         // Fast path for simple scalar variables — skip all metadata checks
         if code.simple_locals[idx] {
             let mut val = self.stack.pop().unwrap_or(Value::NIL);
@@ -105,7 +120,7 @@ impl Interpreter {
                     if scalar {
                         val = Self::normalize_scalar_assignment_value(val);
                     }
-                    arc.lock().unwrap().clone_from(&val);
+                    Value::store_through_cell(&arc, &val);
                     self.stack.push(val);
                     self.flush_local_to_env(code, idx);
                     return Ok(());
@@ -382,7 +397,7 @@ impl Interpreter {
             let scalar = !name.starts_with('@') && !name.starts_with('%');
             if scalar && !(self.array_share_active && self.is_array_share_scalar(name)) {
                 let arc = arc.clone();
-                arc.lock().unwrap().clone_from(&val);
+                Value::store_through_cell(&arc, &val);
                 self.flush_local_to_env(code, idx);
                 self.stack.push(val);
                 return Ok(());

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -593,6 +593,46 @@ impl Interpreter {
         }
     }
 
+    /// Store a whole-container reassignment through a `ContainerRef` cell while
+    /// PRESERVING the inner container's identity: when the cell currently holds
+    /// an Array/Hash and the new value is the same container kind, copy the new
+    /// contents into the EXISTING backing `Gc` (via `*_inplace_reassign`) instead
+    /// of swapping the cell to a fresh pointer. A boxed captured `@a`/`%h`
+    /// (escape analysis promotes captured+mutated outer containers to cells)
+    /// whole-reassigned from a nested frame otherwise orphans every by-value
+    /// holder of the old backing `Gc` (e.g. `%h` captured into a list). Non
+    /// matching shapes fall back to a plain store.
+    pub(super) fn cell_store_preserving_container_identity(
+        arc: &crate::gc::Gc<std::sync::Mutex<Value>>,
+        val: &Value,
+    ) {
+        let mut inner = arc.lock().unwrap();
+        let replacement = match (&*inner, val) {
+            (Value::Hash(old_gc), Value::Hash(new_gc))
+                if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+            {
+                Some(Self::hash_inplace_reassign(old_gc, new_gc))
+            }
+            (Value::Array(old_gc, _), Value::Array(new_gc, kind))
+                if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
+            {
+                Some(Self::array_inplace_reassign(old_gc, new_gc, *kind))
+            }
+            _ => None,
+        };
+        match replacement {
+            Some(v) => *inner = v,
+            None => {
+                drop(inner);
+                // A cell holding a `HashEntryRef` deferred token (a boxed
+                // `\target` bound to a missing hash key) materializes on first
+                // write: `store_through_cell` installs the cell at the token's
+                // path before storing, so the hash and the binding stay aliased.
+                Value::store_through_cell(arc, val);
+            }
+        }
+    }
+
     /// The `Hash` analogue of [`array_inplace_reassign`]. Redirects any
     /// self-referencing hash value that pointed at `new_gc` back to `old_gc`.
     pub(super) fn hash_inplace_reassign(

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -607,16 +607,16 @@ impl Interpreter {
         val: &Value,
     ) {
         let mut inner = arc.lock().unwrap();
-        let replacement = match (&*inner, val) {
-            (Value::Hash(old_gc), Value::Hash(new_gc))
+        let replacement = match (inner.view(), val.view()) {
+            (ValueView::Hash(old_gc), ValueView::Hash(new_gc))
                 if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
             {
                 Some(Self::hash_inplace_reassign(old_gc, new_gc))
             }
-            (Value::Array(old_gc, _), Value::Array(new_gc, kind))
+            (ValueView::Array(old_gc, _), ValueView::Array(new_gc, kind))
                 if !crate::gc::Gc::ptr_eq(old_gc, new_gc) =>
             {
-                Some(Self::array_inplace_reassign(old_gc, new_gc, *kind))
+                Some(Self::array_inplace_reassign(old_gc, new_gc, kind))
             }
             _ => None,
         };

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -328,7 +328,7 @@ impl Interpreter {
                     if scalar {
                         val = Self::normalize_scalar_assignment_value(val);
                     }
-                    arc.lock().unwrap().clone_from(&val);
+                    Value::store_through_cell(&arc, &val);
                     self.flush_local_to_env(code, idx);
                     return Ok(());
                 }
@@ -1445,7 +1445,7 @@ impl Interpreter {
                     let old = arc.lock().unwrap().clone();
                     val = self.array_container_writethrough_value(&name, val, &old)?;
                 }
-                arc.lock().unwrap().clone_from(&val);
+                Value::store_through_cell(&arc, &val);
                 self.flush_local_to_env(code, idx);
                 return Ok(());
             }

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -156,7 +156,15 @@ impl Interpreter {
             };
             for key in keys {
                 if terminal {
-                    out.push(cur.hash_slot_ref(&key, true)?);
+                    let slot = cur.hash_slot_ref(&key, true)?;
+                    // A missing key yields a `HashEntryRef` vivification token,
+                    // which must not leak into a plain slice READ of the same
+                    // subscript (`is-deeply %h{"a";"b";("c","x")}, (42, Any)`)
+                    // — fall back to the non-aliasing read instead.
+                    if matches!(slot.view(), ValueView::HashEntryRef { .. }) {
+                        return None;
+                    }
+                    out.push(slot);
                 } else {
                     let child = match cur.hash_slot_ref(&key, false)? {
                         v if matches!(v.view(), ValueView::ContainerRef(_)) => {

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -69,15 +69,13 @@ impl Interpreter {
                 ValueView::Scalar(inner) => inner.clone(),
                 _ => target.clone(),
             };
-            if !matches!(deref_target.view(), ValueView::Hash(..)) {
-                let mut cells = Vec::new();
-                if self
-                    .collect_multi_dim_leaf_cells(&deref_target, &dims, &mut cells)
-                    .is_some()
-                {
-                    self.stack.push(Value::array(cells));
-                    return Ok(());
-                }
+            let mut cells = Vec::new();
+            if self
+                .collect_multi_dim_leaf_cells(&deref_target, &dims, &mut cells)
+                .is_some()
+            {
+                self.stack.push(Value::array(cells));
+                return Ok(());
             }
         } else if let Some(cell) = self.multi_dim_scalar_autoviv_cell(&target, &dims) {
             // All-scalar dims over a MISSING leaf: autovivify the path (creating
@@ -142,13 +140,43 @@ impl Interpreter {
         if dims.is_empty() {
             return None;
         }
+        let dim = Self::normalize_multidim_dim(&dims[0]);
+        let rest = &dims[1..];
+        let terminal = rest.is_empty();
+
+        // Hash level: an explicit key (or key list) selects entries by name.
+        // A `*` dimension over a hash falls back to the plain read — hash
+        // iteration order is unspecified, so a positional `target = values`
+        // distribution over it would be meaningless.
+        if matches!(cur.view(), ValueView::Hash(..)) {
+            let keys: Vec<String> = match dim.view() {
+                ValueView::Whatever => return None,
+                ValueView::Array(idxs, ..) => idxs.iter().map(Value::hash_key_encode).collect(),
+                _ => vec![Value::hash_key_encode(&dim)],
+            };
+            for key in keys {
+                if terminal {
+                    out.push(cur.hash_slot_ref(&key, true)?);
+                } else {
+                    let child = match cur.hash_slot_ref(&key, false)? {
+                        v if matches!(v.view(), ValueView::ContainerRef(_)) => {
+                            v.with_deref(|inner| inner.clone())
+                        }
+                        v => v,
+                    };
+                    if !matches!(child.view(), ValueView::Array(..) | ValueView::Hash(..)) {
+                        return None;
+                    }
+                    self.collect_multi_dim_leaf_cells(&child, rest, out)?;
+                }
+            }
+            return Some(());
+        }
+
         let items_len = match cur.view() {
             ValueView::Array(items, ..) => items.len(),
             _ => return None,
         };
-        let dim = Self::normalize_multidim_dim(&dims[0]);
-        let rest = &dims[1..];
-        let terminal = rest.is_empty();
 
         // Resolve this dimension into the concrete list of integer indices it
         // selects against the CURRENT container.
@@ -218,12 +246,6 @@ impl Interpreter {
             ValueView::Scalar(inner) => inner.clone(),
             _ => target.clone(),
         };
-        // A hash-rooted multislice is intentionally not aliased: promoting a hash
-        // leaf to a cell mutates the shared hash `Arc` in place, corrupting other
-        // values that alias it. Fall back to a plain read for hash roots.
-        if matches!(cur.view(), ValueView::Hash(..)) {
-            return Ok(None);
-        }
 
         for (i, dim) in dims.iter().enumerate() {
             let terminal = i + 1 == dims.len();
@@ -253,7 +275,17 @@ impl Interpreter {
                 ValueView::Hash(map, ..) => {
                     let key = Value::hash_key_encode(&resolved);
                     if !map.contains_key(&key) {
-                        return Ok(None);
+                        // Missing key: defer vivification with a deep-path
+                        // `HashEntryRef` covering this and all remaining keys.
+                        // A read resolves it to `Any` (`hash_entry_read`); the
+                        // first write walk-creates the intermediate hashes
+                        // (`hash_entry_terminal`), so `%h{$a;$b;$c} = v` through
+                        // a `\target` / `is rw` bind autovivifies like raku.
+                        let mut path = vec![key];
+                        for d in &dims[i + 1..] {
+                            path.push(Value::hash_key_encode(d));
+                        }
+                        return Ok(Some(Value::hash_entry_ref(map.clone(), path)));
                     }
                     match cur.hash_slot_ref(&key, terminal) {
                         Some(v) => v,

--- a/t/hash-multislice-container.t
+++ b/t/hash-multislice-container.t
@@ -1,0 +1,101 @@
+use v6.e.PREVIEW;
+use Test;
+
+plan 25;
+
+# --- Test-function references (&is-deeply etc.) -------------------------
+{
+    my &fn = &is-deeply;
+    ok &fn.defined, 'Test function &-reference is defined';
+    &fn((1, 2).sort, (1, 2), 'calling a Test function through an &-var works');
+    (True ?? &pass !! &flunk)('conditional Test-function reference dispatches');
+}
+
+# --- Whatever / list dims in hash multislice adverbs --------------------
+{
+    my %hash = a => { b => { c => 42, d => 666, e => { f => 314 } } };
+    is-deeply (%hash{*;"b";"c"}:exists), (True,), ':exists with Whatever dim';
+    is-deeply (%hash{*;"b";"x"}:exists), (False,), ':exists Whatever + missing leaf';
+    is-deeply (%hash{*;"b";"c"}:k), (("a","b","c"),), ':k rebuilds string key tuple';
+    is-deeply (%hash{*;"b";"c"}:kv), (("a","b","c"), 42), ':kv with Whatever dim';
+    is-deeply (%hash{*;"b";"c"}:p), (Pair.new(("a","b","c"), 42),), ':p with Whatever dim';
+    is-deeply (%hash{*;"b";"c"}:v), (42,), ':v with Whatever dim';
+    is-deeply (%hash{"a";"b";("c","d")}:v), (42, 666), ':v with key-list dim';
+    is-deeply (%hash{"a";"b";("c","d")}:k),
+      (("a","b","c"), ("a","b","d")), ':k with key-list dim';
+
+    is-deeply (%hash{*;"b";"c"}:delete), (42,), ':delete with Whatever dim';
+    is-deeply %hash, %(a => { b => { d => 666, e => { f => 314 } } }),
+      ':delete with Whatever dim removed the right leaf';
+}
+
+# --- \target binds a hash multislice lvalue ------------------------------
+sub assign-it(\target, \values) { target = values }
+
+{
+    my %h = a => { b => { c => 42 } };
+    assign-it(%h{"a";"b";"c"}, 999);
+    is %h<a><b><c>, 999, 'sigilless bind writes an existing hash multislice leaf';
+}
+
+{
+    my %h = a => { b => { c => 42 } };
+    assign-it(%h{"a";"b";"x"}, 999);
+    is %h<a><b><x>, 999, 'sigilless bind vivifies a missing terminal key';
+    is %h<a><b><c>, 42, 'sibling key untouched by vivification';
+}
+
+{
+    my %h = a => { b => { c => 42 } };
+    assign-it(%h{"x";"y";"z"}, 7);
+    is %h<x><y><z>, 7, 'sigilless bind walk-creates a fully missing path';
+}
+
+{
+    my %h = a => { b => { c => 1, d => 2 } };
+    assign-it(%h{"a";"b";("c","d")}, (10, 20));
+    is %h<a><b><c>, 10, 'list-dim bind distributes element-wise (1)';
+    is %h<a><b><d>, 20, 'list-dim bind distributes element-wise (2)';
+}
+
+# expression-context assignment through the bind (the roast assignable-ok shape)
+{
+    my %h = a => { b => { c => 42 } };
+    sub expr-assign(\target, \values) { my $r = (target = values); $r }
+    is expr-assign(%h{"a";"b";"x"}, 5), 5, 'expression-context assign returns the value';
+    is %h<a><b><x>, 5, 'expression-context assign reaches the hash';
+}
+
+# assignment inside a closure that captured the bound target
+{
+    my %h = a => { b => { c => 42 } };
+    sub closure-assign(\target, \values) {
+        my &blk = { target = values; };
+        blk();
+    }
+    closure-assign(%h{"a";"b";"x"}, 999);
+    is %h<a><b><x>, 999, 'closure-context assign vivifies through the capture';
+    closure-assign(%h{"a";"b";"c"}, 777);
+    is %h<a><b><c>, 777, 'closure-context assign writes an existing leaf';
+}
+
+# --- whole-container reassignment keeps container identity ---------------
+{
+    my %h = a => 1;
+    my @list = "x", %h;
+    sub restock(--> Nil) { %h = a => 2; }
+    restock();
+    is-deeply @list[1]<a>, 2,
+      'cross-frame whole-hash reassign updates a by-value list capture';
+}
+
+{
+    my @a = 1, 2;
+    my @list = "x", @a;
+    sub refill(--> Nil) { @a = 3, 4; }
+    refill();
+    is-deeply @list[1][0], 3,
+      'cross-frame whole-array reassign updates a by-value list capture';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Container-identity campaign slice (BLOCKERS §2.3/§3): `S32-hash/multislice-6e.t` goes from **269 fails + abort at test 318/549** to **32 fails, 535/549 ran**. Four root-cause fixes, all general-purpose:

1. **Test-framework `&`-references** — `my &fn = &is-deeply; &fn(...)` resolved to Nil (test functions are Rust methods, not declared subs). `resolve_code_var` now returns a `Routine` value for test-function names when the Test module is loaded; the Routine call path already dispatches them. This was the cause of the file aborting at test 318 (block 3 opens with `($det ?? &is-deeply !! &non-assignable-ok)(...)`).
2. **Whatever / key-list dims in hash multislice adverbs** — `%h{*;"b";"c"}:exists/:k/:kv/:p/:v/:delete` returned `()`: the multi-result leaf collector was array-only (`Vec<i64>` paths, Whatever expansion only over Arrays). `multidim_collect_leaves` now walks hashes recording `Value` paths (typed Str keys / Int indices); `multidim_index` / `multidim_delete` gained Whatever-over-Hash arms.
3. **`\target` binds of hash multislices alias the real slot** — `sub f(\t) { t = v }; f(%h{$a;$b;$c})` threw X::Assignment::RO or silently dropped the write. `multi_dim_slot_ref` no longer bails on hash roots (scalar leaves promote to shared `ContainerRef` cells in place, reusing the Phase-2 machinery); a missing key yields a deep-path `HashEntryRef` vivification token, whose first-write materialization is wired into AssignExprLocal, name-based AssignExpr, SetGlobal, and the boxed-cell write-through (`Value::store_through_cell`) — statement, expression, and closure contexts all autovivify like raku.
4. **Boxed-cell whole-container reassignment preserves container identity** — a captured+mutated `%h` is boxed to a cell by escape analysis; whole reassignment (`%h = ...` in a nested frame) swapped the cell to a fresh `HashData`, orphaning by-value holders (e.g. `%h` captured into a for-loop list — the roast's `$leftover` snapshots). `cell_store_preserving_container_identity` copies contents into the existing backing `Gc` via the existing `*_inplace_reassign` helpers; the name-based AssignExpr path gained the same in-place reassign the SetLocal slot path already had.

The remaining 32 failures are a **separate pre-existing root cause** (sigilless map params passed as nested call args — `.map(-> \k, \v { Pair.new(k,v) })` — resolve varrefs against a stale env entry; reproduces on main). Documented as the next slice in TODO_roast/S32.md and BLOCKERS.md §2.3.

## Testing

- New pin: `t/hash-multislice-container.t` (25 tests, verified against raku)
- `make test` PASS (1594 files / 15599 tests)
- Regression battery: S32-array/multislice-6e.t (812/812), splice.t, S03-binding {nested,scalars,hashes,arrays,closure}.t, S02-types/hash.t, S32-hash/slice.t, S04 let.t/temp.t — all PASS
- Perf canary int.t: 0.14s (no regression)
- clippy clean, cargo fmt applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW