### PR TITLE
fix(vm,runtime): clear stale call arg-sources; hash {||} splat; unbounded range dims

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -61,31 +61,21 @@ cross-thread plain-scalar lexical writeback（旧 §4.1）も escape 解析→Co
   (v2022.12=6.d) でもこのテスト自体がコンパイルに失敗するため、参照実装での検証すらできない。
 - **評価**: 深い機能待ちで、局所修正では進まない。優先度は低い。
 
-### 2.3 multislice lvalue（hash 側の残件）
+### 2.3 multislice lvalue（hash 側）— **DONE (#4355)**
 
-- **対象**: `S32-hash/multislice-6e.t`。array 側（`S32-array/multislice-6e.t`）は
-  **812/812 全通過・whitelist 済み**（この文書の旧「28 失敗」は stale だった）。
-- **進捗（2026-07-09 container-identity slice）**: hash 側 269 fails + test 318 で
-  中断 → **32 fails・535/549 実行**まで前進。直ったもの:
-  - Test 関数の `&` 参照（`my &fn = &is-deeply`）が Nil だった → Routine 値化
-    （318 中断の正体は block 3 冒頭の `(?? &is-deeply !! &non-assignable-ok)(...)`）。
-  - hash multislice の Whatever / key-list 次元 × 全 adverb（:k/:kv/:p/:v/:exists/
-    :delete）— leaf 収集を `Value` パス化し hash 対応。
-  - `\target` bind：hash root の cell 昇格解禁・欠落キーは deep-path `HashEntryRef`、
-    materialize を AssignExprLocal / AssignExpr / SetGlobal / boxed-cell
-    write-through（`Value::store_through_cell`）に配線。
-  - boxed captured `@a`/`%h` の whole-container 再代入が container identity を保持
-    （`cell_store_preserving_container_identity`）。
-  - Pin: `t/hash-multislice-container.t`。
-- **残る根本原因（32 fails・multislice ではない）**: sigilless map param を入れ子
-  呼び出しの引数に渡すと（`.map(-> \k, \v { Pair.new(k,v) })`）、varref の名前ベース
-  再解決が stale env を読む。値が List のとき `k` が最初の chunk の値を繰り返す
-  （文をまたいでも漏れる）。再現:
-  `((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(k,v) })` →
-  `((1,2)=>"A", (1,2)=>"B")`。plain read（`k.raku`）は正しく、call-arg 位置のみ壊れる。
-  main でも再現する pre-existing。**Next slice = この varref-by-name 再解決の修正**
-  （`compile_call_arg` の WrapVarRef / binding_signature の
-  `resolve_sigilless_alias_source_name` 系）。plan mismatch（535/549）も残件。
+- `S32-hash/multislice-6e.t` **549/549 whitelist 済み**（#4354 で 269→32 fails、
+  #4355 で完了）。array 側も whitelist 済み。#4355 の内訳:
+  - 「sigilless map param の varref stale-env」の正体は **stale
+    `pending_call_arg_sources` 残留**: CallMethod(Mut) opcode が callee bind 用に
+    arg-source 名をセットするが、native dispatch（Pair.new 等）は bind しないため
+    残留 → Rust 駆動 `.map` ループの次チャンク bind が残留名で env 再解決し、
+    caller env に漏れた Array 値だけ stale 化。opcode 終了時に names/slots を
+    クリア（CallFunc の set→clear ペアと同じ規約）。Pin: `t/sigilless-map-args.t`。
+  - plan mismatch (535/549) は未実装 2 機能: `%h{|| @list}` 次元 splat
+    （array 側 `@a[||@i]` と同じ 1-dim MultiDimIndex に parse、HyperIndex
+    AST/opcode 削除）と unbounded-end range 次元（`@a[1^..*;1]` を各レベル長で
+    clamp 展開、`1..*` の capacity-overflow panic 修正、multi-`:exists` が
+    `Package("Any")` hole を非存在扱い）。Pin: `t/multidim-splat-lazy.t`。
 
 ---
 
@@ -94,8 +84,8 @@ cross-thread plain-scalar lexical writeback（旧 §4.1）も escape 解析→Co
 かつて element/attribute slot の書き戻しが未整備だった項目が集まっていたが、大半は
 whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314）・`temp.t`・
 `adverbs.t` の typed-hash default・`capture.t`・`is_default.t`・`walk.t` など。詳細は
-`news/2026-06.md` / `news/2026-07.md`）。残るのは multislice hash 側（§2.3）と、
-下記サブキャンペーンの深い残課題。
+`news/2026-06.md` / `news/2026-07.md`）。multislice は array/hash 両側とも完了
+（§2.3、#4355）。残るのは下記サブキャンペーンの深い残課題。
 
 ### 3.1 完了済み（whitelist 済み・詳細は news）
 
@@ -118,7 +108,7 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
 1. **配列/ハッシュ要素 cell 化**
    - 依存文書: `docs/container-identity.md`
    - 変更レイヤ: `value/mod.rs`、`vm_var_assign_ops.rs`、`vm_var_index_ops.rs`
-   - 対象: `splice.t`, multislice（§2.3）
+   - 対象: `splice.t`（multislice は §2.3 で完了・#4355）
    - 完了条件: element bind / take-rw / deep nested write が post-call writeback なしで成立
 2. **属性 accessor を value copy ではなく slot 経由にする**
    - 変更レイヤ: attribute read/write path、instance attr storage

--- a/TODO_roast/S32.md
+++ b/TODO_roast/S32.md
@@ -628,7 +628,7 @@
 - [ ] roast/S32-hash/kv.t
   - 13/27 pass (1-2, 12-20, 22, 24). Good `.kv` support on hashes. Failures: sub form `kv(%hash)` (3-4), `Pair.kv` (5-7), constant hash refs (8-11), rw aliases in kv (21, 23, 25). Only 25 tests reached. Difficulty: Medium
 - [ ] roast/S32-hash/map.t
-- [ ] roast/S32-hash/multislice-6e.t
+- [x] roast/S32-hash/multislice-6e.t — **WHITELISTED (549/549, #4355)**
   - Progression: 144 (multi-dim hash *read* `%h{a;b;c}` fixed — was Nil) -> 153
     (`&&`-vs-`?? !!` precedence #3631 + bare dynamic `:$delete` read #3635) -> 174
     (combined dynamic adverb `:exists:$delete`/`:kv:$delete`/... *read* path). The
@@ -654,16 +654,20 @@
     reassignment through a boxed captured var preserves container identity
     (`cell_store_preserving_container_identity`). Pin:
     `t/hash-multislice-container.t` (25).
-  - Remaining (CANNOT whitelist yet): the 32 fails are all block-3
-    `:kv`/`:exists:kv` shapes, root cause is NOT multislice: a sigilless map
-    param passed as a nested call argument (`.map(-> \k, \v { Pair.new(k,v) })`)
-    resolves the varref by NAME against a stale env entry when the bound value
-    is a List — `k` repeats the first chunk's value (even leaks across
-    statements). Plain reads of `k` are fine; only call-arg positions break.
-    Repro: `((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(k,v) })` gives
-    `((1,2)=>"A", (1,2)=>"B")`. Separate root cause (map param binding /
-    varref-by-name re-resolution), pre-existing — reproduces on main. Also a
-    residual plan mismatch (535/549) to re-check after that fix.
+  - **2026-07-09 (#4355): 549/549, whitelisted.** The 32 fails were a stale
+    `pending_call_arg_sources` leak: CallMethod/CallMethodMut set the
+    arg-source names for the callee's bind, but a native dispatch (Pair.new)
+    never binds; the next map-chunk's sigilless bind (no interleaving call
+    opcode in a Rust-driven loop) took the leftover names and re-resolved its
+    params from leaked Array-valued env keys — hence "List values repeat the
+    first chunk". Fixed by clearing names/slots at opcode exit (mirrors the
+    CallFunc set-then-clear pair). Plan mismatch (535/549) was two missing
+    features, also fixed: `%h{|| @list}` dimension splat (now parses to a
+    1-dim MultiDimIndex like `@a[||@i]`; HyperIndex AST/opcode removed) and
+    unbounded-end range dims (`@a[1^..*;1]` — per-level clamped expansion;
+    `1..*` used to panic with capacity overflow; `:exists` now treats the
+    `Package("Any")` hole mark as non-existing). Pins:
+    `t/sigilless-map-args.t`, `t/multidim-splat-lazy.t`.
 - [ ] roast/S32-hash/pairs.t
   - 17/26 pass (1-2, 4-10, 12-18, 20). Good `.pairs` support on hashes. Failures: element count (3, 11), rw aliases (19, 21), `:p` adverb form (22-26). Difficulty: Medium
 - [ ] roast/S32-hash/perl.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1083,6 +1083,7 @@ roast/S32-hash/iterator.t
 roast/S32-hash/keys_values.t
 roast/S32-hash/kv.t
 roast/S32-hash/map.t
+roast/S32-hash/multislice-6e.t
 roast/S32-hash/pairs.t
 roast/S32-hash/push.t
 roast/S32-hash/slice.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -495,11 +495,6 @@ pub(crate) enum Expr {
         target: Box<Expr>,
         adverb: HyperSliceAdverb,
     },
-    /// Hash hyperindex: %hash{||@keys}
-    HyperIndex {
-        target: Box<Expr>,
-        keys: Box<Expr>,
-    },
 }
 
 /// Secondary adverb on :exists subscript adverb

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -478,12 +478,6 @@ impl Compiler {
                 self.compile_expr(target);
                 self.code.emit(OpCode::HyperSlice(*adverb as u8));
             }
-            // Hash hyperindex: %hash{||@keys}
-            Expr::HyperIndex { target, keys } => {
-                self.compile_expr(target);
-                self.compile_expr(keys);
-                self.code.emit(OpCode::HyperIndex);
-            }
             // Deferred heredoc interpolation
             Expr::HeredocInterpolation(content) => {
                 let resolved = crate::parser::interpolate_heredoc_content(content);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -805,9 +805,6 @@ pub(crate) enum OpCode {
     /// Hash hyperslice: recursively iterate hash with given adverb mode.
     /// Stack: [target] → [result list]
     HyperSlice(u8),
-    /// Hash hyperindex: drill into nested hash by key path.
-    /// Stack: [target, keys] → [value]
-    HyperIndex,
 
     // -- String interpolation --
     StringConcat(u32),

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1480,7 +1480,12 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
             continue;
         }
 
-        // Hash hyperindex: %hash{||@keys} or %hash{|| <a b>, "d"}
+        // Hash dimension splat: %hash{||@keys} or %hash{|| <a b>, "d"} — the
+        // single list expression supplies the semicolon dimensions. Parses to a
+        // one-dimension `MultiDimIndex` (mirroring the array-side `@a[||@i]`),
+        // which the runtime spreads via `expand_pipe_multidim_dims`; the plain
+        // lvalue rewrite (`MultiDimIndexAssign`) and subscript adverbs then
+        // apply unchanged.
         if rest.starts_with("{||")
             && matches!(&expr, Expr::HashVar(_) | Expr::Var(_) | Expr::Index { .. })
         {
@@ -1505,9 +1510,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     r = r2;
                 }
                 let (r2, _) = parse_char(r, '}')?;
-                expr = Expr::HyperIndex {
+                expr = Expr::MultiDimIndex {
                     target: Box::new(expr),
-                    keys: Box::new(Expr::ArrayLiteral(items)),
+                    dimensions: vec![Expr::ArrayLiteral(items)],
                 };
                 rest = r2;
                 continue;
@@ -1515,9 +1520,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 first
             };
             let (r, _) = parse_char(r, '}')?;
-            expr = Expr::HyperIndex {
+            expr = Expr::MultiDimIndex {
                 target: Box::new(expr),
-                keys: Box::new(keys_expr),
+                dimensions: vec![keys_expr],
             };
             rest = r;
             continue;

--- a/src/parser/outer_redecl.rs
+++ b/src/parser/outer_redecl.rs
@@ -514,10 +514,6 @@ fn walk_expr(expr: &Expr, ctx: &mut Ctx) {
             walk_expr(value, ctx);
         }
         Expr::HyperSlice { target, .. } => walk_expr(target, ctx),
-        Expr::HyperIndex { target, keys } => {
-            walk_expr(target, ctx);
-            walk_expr(keys, ctx);
-        }
         Expr::ArrayLiteral(items) | Expr::BracketArray(items, _) | Expr::CaptureLiteral(items) => {
             for it in items {
                 walk_expr(it, ctx);

--- a/src/parser/stmt/assign/paren.rs
+++ b/src/parser/stmt/assign/paren.rs
@@ -386,7 +386,7 @@ pub(crate) fn parenthesized_assign_expr(input: &str) -> PResult<'_, Expr> {
             expr: Box::new(rhs),
             is_bind: false,
         },
-        // Fallback for other lvalue expressions (e.g. HyperIndex %h{|| @a})
+        // Fallback for other lvalue expressions
         other => callable_lvalue_assign_expr(other, Vec::new(), rhs),
     };
     if is_atomic {

--- a/src/parser/stmt/sub_param/where_constraint.rs
+++ b/src/parser/stmt/sub_param/where_constraint.rs
@@ -245,9 +245,6 @@ fn expr_contains_whatever(expr: &Expr) -> bool {
             .iter()
             .any(|(_, value)| value.as_ref().is_some_and(expr_contains_whatever)),
         Expr::HyperSlice { target, .. } => expr_contains_whatever(target),
-        Expr::HyperIndex { target, keys } => {
-            expr_contains_whatever(target) || expr_contains_whatever(keys)
-        }
         _ => false,
     }
 }

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -409,7 +409,11 @@ impl Interpreter {
 
         let mut out = Vec::new();
         for (path, value) in leaves {
-            let raw_exists = !value.is_nil();
+            // A deleted/uninitialized array slot holds the `Package("Any")`
+            // hole mark (same convention as `nested_exists_slice`), so
+            // `@a[...]:exists` after `:delete` reports False, not True.
+            let raw_exists = !value.is_nil()
+                && !matches!(value.view(), ValueView::Package(name) if name == "Any");
             let exists = if negated { !raw_exists } else { raw_exists };
             let key = leaf_key_tuple(path);
             match adverb {
@@ -569,10 +573,14 @@ impl Interpreter {
         // (`%h{1;1..3}`), so expand it to its element list up front — then the
         // existing multi-index path (`has_multi_indices` / collect-leaves) walks
         // each key, exactly as it already does for a comma list (`%h{1;2,3}`).
+        // An unbounded-end range (`1^..*`) is deferred to the per-level walk
+        // below, which knows the axis length to clamp against.
         let indices: Vec<Value> = indices
             .iter()
             .map(|idx| {
-                if idx.is_range() || matches!(idx.view(), ValueView::Seq(_)) {
+                if (idx.is_range() || matches!(idx.view(), ValueView::Seq(_)))
+                    && !crate::runtime::utils::subscript_range_end_unbounded(idx)
+                {
                     Value::array(crate::runtime::utils::value_to_list(idx))
                 } else {
                     idx.clone()
@@ -596,6 +604,20 @@ impl Interpreter {
                     let resolved_idx = result.clone();
                     current = multidim_index(&current, std::slice::from_ref(&resolved_idx));
                     resolved.push(result);
+                }
+                _ if crate::runtime::utils::subscript_range_end_unbounded(idx) => {
+                    // Unbounded-end range dimension (`1^..*`): clamp to this
+                    // level's length now that it is known.
+                    let len = match current.view() {
+                        ValueView::Array(items, ..) => items.len(),
+                        _ => 0,
+                    };
+                    let expanded = Value::array(
+                        crate::runtime::utils::expand_unbounded_range_dim(idx, len)
+                            .unwrap_or_default(),
+                    );
+                    current = multidim_index(&current, std::slice::from_ref(&expanded));
+                    resolved.push(expanded);
                 }
                 _ => {
                     // Coerce a non-Int scalar array index (`"0"`, `0e0`, `0/1`)

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -180,9 +180,6 @@ impl Interpreter {
                 Expr::IndirectCodeLookup { package, .. } => expr_contains_last(package),
                 Expr::SymbolicDeref { expr, .. } => expr_contains_last(expr),
                 Expr::HyperSlice { target, .. } => expr_contains_last(target),
-                Expr::HyperIndex { target, keys } => {
-                    expr_contains_last(target) || expr_contains_last(keys)
-                }
                 _ => false,
             }
         }

--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -426,3 +426,55 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
         _ => vec![val.clone()],
     }
 }
+
+/// True when a subscript range dimension has no usable finite end: `1..*` /
+/// `1^..Inf` style (a Whatever end lowers to `Inf`, and an integer-range end of
+/// `i64::MAX` is the same thing forced through an int range). Expanding such a
+/// range eagerly would allocate ~2^63 elements; a subscript instead clamps it
+/// to the axis length (see `expand_unbounded_range_dim`).
+pub(crate) fn subscript_range_end_unbounded(dim: &Value) -> bool {
+    match dim.view() {
+        ValueView::Range(_, b)
+        | ValueView::RangeExcl(_, b)
+        | ValueView::RangeExclStart(_, b)
+        | ValueView::RangeExclBoth(_, b) => b == i64::MAX,
+        ValueView::GenericRange { end, .. } => match end.as_ref().view() {
+            ValueView::Whatever => true,
+            ValueView::Int(i) => i == i64::MAX,
+            ValueView::Num(f) => f.is_infinite() && f.is_sign_positive(),
+            ValueView::Rat(n, 0) | ValueView::FatRat(n, 0) => n > 0,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// Expand an unbounded-end subscript range dimension against a known axis
+/// length: `@a[1^..*;1]` selects rows 2..len-1 at that level. Only
+/// unbounded-end ranges are handled — a bounded range keeps the generic
+/// expansion (preserving its out-of-bounds Nil semantics). Returns None for
+/// non-ranges, bounded ranges, or a non-integer start.
+pub(crate) fn expand_unbounded_range_dim(dim: &Value, len: usize) -> Option<Vec<Value>> {
+    if !subscript_range_end_unbounded(dim) {
+        return None;
+    }
+    let (start, excl_start) = match dim.view() {
+        ValueView::Range(a, _) | ValueView::RangeExcl(a, _) => (a, false),
+        ValueView::RangeExclStart(a, _) | ValueView::RangeExclBoth(a, _) => (a, true),
+        ValueView::GenericRange {
+            start, excl_start, ..
+        } => match start.as_ref().view() {
+            ValueView::Int(i) => (i, excl_start),
+            ValueView::Num(f) if f.fract() == 0.0 => (f as i64, excl_start),
+            ValueView::Rat(n, d) if d != 0 && n % d == 0 => (n / d, excl_start),
+            _ => return None,
+        },
+        _ => return None,
+    };
+    let start = if excl_start { start + 1 } else { start };
+    let start = start.max(0);
+    if len == 0 || start >= len as i64 {
+        return Some(Vec::new());
+    }
+    Some((start..len as i64).map(Value::int).collect())
+}

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -347,6 +347,39 @@ impl Interpreter {
         quoted: bool,
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        let result = self.exec_call_method_mut_op_impl(
+            code,
+            name_idx,
+            arity,
+            target_name_idx,
+            modifier_idx,
+            quoted,
+            arg_sources_idx,
+        );
+        // The pending arg-source names/slots are scoped to THIS dispatch: a
+        // callee signature bind consumes them, but a native/builtin dispatch
+        // never binds and would leave them behind. A later bind with no
+        // interleaving call opcode (e.g. the next chunk call of a Rust-driven
+        // `.map` loop) would then re-resolve its sigilless params from the
+        // leftover names against stale env keys (S32-hash/multislice-6e.t:
+        // `-> \k, \v { Pair.new(k,v) }` repeated the first chunk). Clear on
+        // every exit, mirroring the CallFunc/CallOnCodeVar set-then-clear pair.
+        self.set_pending_call_arg_sources(None);
+        self.pending_call_arg_source_slots.clear();
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn exec_call_method_mut_op_impl(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        arity: u32,
+        target_name_idx: u32,
+        modifier_idx: Option<u32>,
+        quoted: bool,
+        arg_sources_idx: Option<u32>,
+    ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_method_dispatch();
         // Set pending arg sources for `is rw` dispatch matching
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -253,6 +253,36 @@ impl Interpreter {
         quoted: bool,
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        let result = self.exec_call_method_op_impl(
+            code,
+            name_idx,
+            arity,
+            modifier_idx,
+            quoted,
+            arg_sources_idx,
+        );
+        // The pending arg-source names/slots are scoped to THIS dispatch: a
+        // callee signature bind consumes them, but a native/builtin dispatch
+        // never binds and would leave them behind. A later bind with no
+        // interleaving call opcode (e.g. the next chunk call of a Rust-driven
+        // `.map` loop) would then re-resolve its sigilless params from the
+        // leftover names against stale env keys (S32-hash/multislice-6e.t:
+        // `-> \k, \v { Pair.new(k,v) }` repeated the first chunk). Clear on
+        // every exit, mirroring the CallFunc/CallOnCodeVar set-then-clear pair.
+        self.set_pending_call_arg_sources(None);
+        self.pending_call_arg_source_slots.clear();
+        result
+    }
+
+    fn exec_call_method_op_impl(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        arity: u32,
+        modifier_idx: Option<u32>,
+        quoted: bool,
+        arg_sources_idx: Option<u32>,
+    ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_method_dispatch();
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.set_pending_call_arg_sources(arg_sources.clone());

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2896,11 +2896,6 @@ impl Interpreter {
                 self.exec_hyper_slice_op(*adverb)?;
                 *ip += 1;
             }
-            OpCode::HyperIndex => {
-                self.exec_hyper_index_op()?;
-                *ip += 1;
-            }
-
             // -- String interpolation --
             OpCode::StringConcat(n) => {
                 self.exec_string_concat_op(*n)?;

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 impl Interpreter {
     pub(crate) fn exec_assign_expr_local_op_inner(
@@ -646,36 +645,6 @@ impl Interpreter {
                 }
             }
         }
-    }
-
-    /// Execute HyperIndex opcode: drill into nested hash by key path.
-    pub(super) fn exec_hyper_index_op(&mut self) -> Result<(), RuntimeError> {
-        let keys = self.stack.pop().unwrap();
-        let target = self.stack.pop().unwrap();
-
-        let key_list = match keys.view() {
-            ValueView::Array(items, ..) => items.clone(),
-            ValueView::Seq(items) => {
-                crate::value::Value::array_arc(Arc::new(items.to_vec()).to_vec())
-            }
-            _ => crate::value::Value::array_arc(Arc::new(vec![keys.clone()]).to_vec()),
-        };
-
-        let mut current = target;
-        for key in key_list.iter() {
-            if let Some(next) = current.with_hash_mut(|h| {
-                let k = key.to_string_value();
-                h.get(&k).cloned().unwrap_or(Value::NIL)
-            }) {
-                current = next;
-            } else {
-                current = Value::NIL;
-                break;
-            }
-        }
-
-        self.stack.push(current);
-        Ok(())
     }
 
     /// Wrap an integer value to fit within a native integer type's range.

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -140,7 +140,17 @@ impl Interpreter {
         if dims.is_empty() {
             return None;
         }
-        let dim = Self::normalize_multidim_dim(&dims[0]);
+        // An unbounded-end range dimension (`1^..*`) expands against the
+        // current level's length (normalize alone classifies it as an empty
+        // slice, which would select nothing).
+        let dim = if let ValueView::Array(items, ..) = cur.view()
+            && let Some(indices) =
+                crate::runtime::utils::expand_unbounded_range_dim(&dims[0], items.len())
+        {
+            Value::array(indices)
+        } else {
+            Self::normalize_multidim_dim(&dims[0])
+        };
         let rest = &dims[1..];
         let terminal = rest.is_empty();
 
@@ -420,7 +430,17 @@ impl Interpreter {
             let single = Value::array(vec![target.clone()]);
             return self.multi_dim_index_read(&single, dims);
         }
-        let dim = Self::normalize_multidim_dim(&dims[0]);
+        // An unbounded-end range dimension (`1^..*`, `1..Inf`) selects "from
+        // start to the end of this axis" — expand it against the current
+        // level's length (the target-blind normalize below cannot know it).
+        let dim = if let ValueView::Array(items, ..) = target.view()
+            && let Some(indices) =
+                crate::runtime::utils::expand_unbounded_range_dim(&dims[0], items.len())
+        {
+            Value::array(indices)
+        } else {
+            Self::normalize_multidim_dim(&dims[0])
+        };
         let dim = &dim;
         let rest = &dims[1..];
 
@@ -655,6 +675,13 @@ impl Interpreter {
     }
 
     pub(super) fn normalize_multidim_dim(dim: &Value) -> Value {
+        // An unbounded-end range (`1..*` lowered to an Inf / i64::MAX end)
+        // cannot be expanded eagerly (capacity overflow); the indexing sites
+        // expand it per level via `expand_unbounded_range_dim`. Classify it as
+        // an (empty) slice dimension here without materializing anything.
+        if crate::runtime::utils::subscript_range_end_unbounded(dim) {
+            return Value::array(Vec::new());
+        }
         match dim.view() {
             ValueView::Range(..)
             | ValueView::RangeExcl(..)

--- a/t/multidim-splat-lazy.t
+++ b/t/multidim-splat-lazy.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 14;
+
+# Pin for `%h{|| @list}` (dimension splat over a hash) and unbounded-end range
+# dimensions (`@a[1^..*;1]`) — the remaining plan-mismatch blocks of
+# S32-hash/multislice-6e.t.
+
+# --- hash dimension splat: %h{|| @indices} ---
+{
+    my %hash;
+    my @indices := <a b>, <c>;   # need binding, no containers!
+
+    is-deeply (%hash{|| @indices} = 42,666), (42,666),
+      '|| assignment to non-existing hashes returns the assigned values';
+    is-deeply %hash, { a => { c => 42 }, b => { c => 666 } },
+      '|| initialization works';
+    is-deeply (%hash{|| @indices}:delete), (42,666),
+      '|| deletion returns the expected values';
+    is-deeply %hash, { a => { }, b => { } },
+      '|| hash changed correctly after delete';
+    is-deeply (%hash{|| <a b>, "d"} = 333, 444), (333,444),
+      '|| assignment with an inline dimension list';
+    is-deeply %hash, { a => { d => 333 }, b => { d => 444 } },
+      '|| hash changed correctly';
+    is-deeply %hash{|| "b"}, { d => 444 },
+      '|| single key handled correctly';
+}
+
+# --- unbounded-end range dimensions ---
+{
+    my @a = [1,2,3],[4,5,6],[7,8,9],[10,11,12];
+    is-deeply @a[1^..*;1], (8,11),
+      'excl-start Whatever-ended range dimension';
+    is-deeply @a[1..*;1], (5,8,11),
+      'Whatever-ended range dimension';
+    is-deeply @a[1^..*;1]:exists, (True,True),
+      'unbounded range dimension with :exists';
+    is-deeply @a[1^..*;1]:delete, (8,11),
+      'unbounded range dimension with :delete';
+    is-deeply @a, [[1,2,3],[4,5,6],[7,Any,9],[10,Any,12]],
+      'proper elements were deleted';
+    is-deeply @a[1^..*;1]:exists, (False,False),
+      ':exists reports False for deleted slots';
+    is-deeply @a[1^..*;1], (Any,Any),
+      'deleted slots read back as holes';
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/sigilless-map-args.t
+++ b/t/sigilless-map-args.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Pin for the stale pending_call_arg_sources leak: inside a Rust-driven .map
+# loop, the body's own method-call opcode left its arg-source names behind,
+# and the NEXT iteration's sigilless param bind re-resolved its args by those
+# names against leaked env keys — so List-valued chunks repeated the first
+# iteration's values (S32-hash/multislice-6e.t block 3).
+
+# method-call argument position (the original failing shape)
+is-deeply ((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(k,v) }).List,
+  ((1,2) => "A", (3,4) => "B"),
+  'sigilless List params stay fresh across map iterations (method call args)';
+
+# both params List-valued
+is-deeply ((1,2),(9,9),(3,4),(8,8)).map(-> \k, \v { Pair.new(k,v) }).List,
+  ((1,2) => (9,9), (3,4) => (8,8)),
+  'both List-valued sigilless params stay fresh';
+
+# swapped argument order
+is-deeply ((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(v,k) }).List,
+  ("A" => (1,2), "B" => (3,4)),
+  'swapped arg order stays fresh';
+
+# assignment into a local then return
+is-deeply ((1,2),(9,9),(3,4),(8,8)).map(-> \k, \v { my $p = Pair.new(k,v); $p }).List,
+  ((1,2) => (9,9), (3,4) => (8,8)),
+  'via intermediate local';
+
+# function-call argument position
+sub id($a, $b) { ($a, $b) }
+is-deeply ((1,2),(9,9),(3,4),(8,8)).map(-> \k, \v { id(k, v) }).List,
+  (((1,2),(9,9)), ((3,4),(8,8))),
+  'user sub call args stay fresh';
+
+# builtin function argument position
+is-deeply ((1,2),(9,9),(3,4),(8,8)).map(-> \k, \v { max(k, v) }).List,
+  ((9,9), (8,8)),
+  'builtin call args stay fresh';
+
+# grep sees fresh values too
+is-deeply ((1,2),(9,9),(3,4),(8,8)).grep(-> \k, \v { k[0] > 2 }).List,
+  (((3,4),(8,8)),),
+  'grep sigilless chunk stays fresh';
+
+# plain list body (control case)
+is-deeply ((1,2),(9,9),(3,4),(8,8)).map(-> \k, \v { (k, v) }).List,
+  (((1,2),(9,9)), ((3,4),(8,8))),
+  'plain list body control case';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

Whitelists `roast/S32-hash/multislice-6e.t` (549/549, was 32 fails + 14-test plan mismatch). Closes out BLOCKERS §2.3. Three fixes:

### 1. Stale `pending_call_arg_sources` leak (the sigilless map varref bug)

The `CallMethod`/`CallMethodMut` opcodes set the arg-source name table for the callee's signature bind, but a native/builtin dispatch (e.g. `Pair.new`) never binds, leaving the names behind. The next bind with no interleaving call opcode — the next chunk call of a Rust-driven `.map` loop — re-resolved its sigilless params from the leftover names against leaked env keys, so List-valued chunks repeated the first iteration's values:

```raku
((1,2),"A",(3,4),"B").map(-> \k, \v { Pair.new(k,v) })
# gave ((1,2)=>"A", (1,2)=>"B"); now ((1,2)=>"A", (3,4)=>"B")
```

Fix: clear the names/slots when the opcode completes, mirroring the existing `CallFunc`/`CallOnCodeVar` set-then-clear pairing.

### 2. Hash dimension splat `%h{|| @list}`

Now parses to a one-dimension `MultiDimIndex` (mirroring the array-side `@a[||@i]`), so the existing lvalue rewrite (`MultiDimIndexAssign`), subscript adverbs (`:delete` etc.), and `expand_pipe_multidim_dims` all apply unchanged. The old `HyperIndex` AST node/opcode (read-only nested-key drill with no assignment or adverb support) is removed.

### 3. Unbounded-end range dimensions (`@a[1^..*;1]`)

Expand against the current level's length at each indexing site instead of eagerly materializing the range — `@a[1..*;1]` previously **panicked with capacity overflow**, `@a[1^..*;1]` read Nil. Also the multi-index `:exists` adverb now treats the `Package("Any")` hole mark as non-existing (matching `nested_exists_slice`), so `:exists` after `:delete` reports `(False, False)`.

## Tests

- Pins: `t/sigilless-map-args.t` (8), `t/multidim-splat-lazy.t` (14)
- `roast/S32-hash/multislice-6e.t`: 549/549, whitelisted
- Local `make test` PASS (15668 tests); related roast (S32-array/multislice-6e, S32-hash adverb/slice suites, S09 multidim, map/grep/sigilless) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW