### PR TITLE
fix(builtins): descend into itemized arrays for .keys/.values/.kv/.pairs/.antipairs

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -407,6 +407,13 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 ValueView::Pair(key, _) => Some(Ok(Value::seq(vec![Value::str(key.clone())]))),
                 ValueView::ValuePair(key, _) => Some(Ok(Value::seq(vec![key.clone()]))),
                 ValueView::Nil => Some(Ok(Value::seq(Vec::new()))),
+                // `.keys` reports positional indices of the array's own elements,
+                // independent of itemization: an itemized array (`$[...]`) is still
+                // an Array here, not a single opaque list element. Using the backing
+                // `items` directly avoids `value_to_list`, which (correctly, for
+                // flattening) collapses an itemized array to one element and would
+                // make `.keys` yield only `(0,)`.
+                ValueView::Array(items, _) => Some(Ok(Value::seq(positional_keys(items)))),
                 ValueView::Set(s, _) => {
                     Some(Ok(Value::seq(s.iter().map(|k| s.typed_key(k)).collect())))
                 }
@@ -442,6 +449,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     Some(Ok(Value::seq(vec![value.clone()])))
                 }
                 ValueView::Nil => Some(Ok(Value::seq(Vec::new()))),
+                // Mirror the `.keys` arm: `.values` yields the array's own elements
+                // regardless of itemization, so an itemized array (`$[...]`) does not
+                // collapse to a single element via `value_to_list`.
+                ValueView::Array(items, _) => Some(Ok(Value::seq(items.to_vec()))),
                 ValueView::Set(s, _) => {
                     Some(Ok(Value::seq(s.iter().map(|_| Value::TRUE).collect())))
                 }
@@ -497,6 +508,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     Some(Ok(Value::seq(vec![key.clone(), value.clone()])))
                 }
                 ValueView::Nil => Some(Ok(Value::seq(Vec::new()))),
+                // Index/value pairs of the array's own elements, itemization-agnostic
+                // (an itemized `$[...]` must not collapse to one element).
+                ValueView::Array(items, _) => Some(Ok(Value::seq(positional_kv(items)))),
                 ValueView::Set(s, _) => {
                     let mut kv = Vec::new();
                     for k in s.iter() {
@@ -594,6 +608,8 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 ValueView::Pair(_, _) | ValueView::ValuePair(_, _) => {
                     Some(Ok(Value::seq(vec![target.clone()])))
                 }
+                // Index => value pairs of the array's own elements, itemization-agnostic.
+                ValueView::Array(items, _) => Some(Ok(Value::seq(positional_pairs(items)))),
                 ValueView::Package(_) => None, // let runtime handle (may be enum type)
                 _ if target.is_range() => Some(Ok(Value::seq(positional_pairs(
                     &crate::runtime::utils::value_to_list(target),
@@ -701,6 +717,8 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     }
                     Some(Ok(Value::seq(pairs)))
                 }
+                // Value => index pairs of the array's own elements, itemization-agnostic.
+                ValueView::Array(items, _) => Some(Ok(Value::seq(positional_antipairs(items)))),
                 ValueView::Package(_) => None, // let runtime handle (may be enum type)
                 _ if target.is_range() => {
                     let values = crate::runtime::utils::value_to_list(target);

--- a/t/itemized-array-keys-values.t
+++ b/t/itemized-array-keys-values.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# An itemized array (`$[...]`) is still an Array for introspection methods like
+# .keys/.values/.kv/.pairs/.antipairs: they report the array's own elements and
+# do NOT collapse the itemized array into a single opaque list element (which is
+# the correct behavior only for list flattening). Regression for the Zef
+# `Zef::Utils::SystemQuery::system-collapse` `for $data.keys` traversal, which
+# received an itemized array and silently dropped every element past the first.
+
+plan 25;
+
+# --- itemized array, no hash element ---
+my $a = $["A", "B", "C"];
+is $a.elems, 3, 'itemized array elems';
+is-deeply $a.keys.List, (0, 1, 2), 'itemized array keys';
+is-deeply $a.values.List, ("A", "B", "C"), 'itemized array values';
+is-deeply $a.kv.List, (0, "A", 1, "B", 2, "C"), 'itemized array kv';
+is-deeply $a.pairs.List, (0 => "A", 1 => "B", 2 => "C"), 'itemized array pairs';
+is-deeply $a.antipairs.List, ("A" => 0, "B" => 1, "C" => 2), 'itemized array antipairs';
+
+# --- itemized array containing a Hash element (the Zef case) ---
+my $b = $["Zef::Client", {:from("native"), :name("unknown")}];
+is $b.elems, 2, 'itemized array with hash elems';
+is-deeply $b.keys.List, (0, 1), 'itemized array with hash keys';
+is $b.values.elems, 2, 'itemized array with hash values count';
+is $b.values[0], "Zef::Client", 'itemized array with hash values[0]';
+is $b.values[1]<name>, "unknown", 'itemized array with hash values[1] is the hash';
+is $b.kv.elems, 4, 'itemized array with hash kv count';
+is $b.pairs.elems, 2, 'itemized array with hash pairs count';
+is $b.pairs[1].key, 1, 'itemized array with hash pairs[1] key';
+is $b.pairs[1].value<name>, "unknown", 'itemized array with hash pairs[1] value';
+is $b.antipairs.elems, 2, 'itemized array with hash antipairs count';
+
+# --- via a scalar variable holding an array (implicitly itemized) ---
+my $c = ["X", {:y(2)}];
+is-deeply $c.keys.List, (0, 1), 'scalar-held array keys';
+is $c.values.elems, 2, 'scalar-held array values count';
+
+# --- for-loop over itemized array keys drives every index ---
+my @seen;
+for $b.keys -> $k { @seen.push($k) }
+is-deeply @seen.List, (0, 1), 'for over itemized keys visits every index';
+
+# --- plain (non-itemized) array unchanged ---
+my @plain = ("A", "B", "C");
+is-deeply @plain.keys.List, (0, 1, 2), 'plain array keys unchanged';
+is-deeply @plain.values.List, ("A", "B", "C"), 'plain array values unchanged';
+is-deeply @plain.kv.List, (0, "A", 1, "B", 2, "C"), 'plain array kv unchanged';
+is-deeply @plain.pairs.List, (0 => "A", 1 => "B", 2 => "C"), 'plain array pairs unchanged';
+
+# --- itemized array in flattening context stays a single element (the point of
+#     itemization): .keys/.values descend, but flat/list context does not. ---
+my @flat = flat "head", $["x", "y"];
+is @flat.elems, 2, 'itemized array does NOT flatten in list context';
+is-deeply @flat[1].List, ("x", "y"), 'itemized array preserved as one element';


### PR DESCRIPTION
## Problem

An itemized array (`\$[...]`) is still an `Array` for introspection methods, but mutsu's `.keys`/`.values`/`.kv`/`.pairs`/`.antipairs` handlers had no explicit `Array` arm. They fell through to `value_to_list(target)`, which — correctly, for list flattening — collapses an itemized array into a single opaque element. Result:

```raku
my $a = $["A", "B", "C"];
$a.elems;   # 3  (correct, uses as_list_items)
$a.keys;    # mutsu: (0,)          raku: (0, 1, 2)
$a.values;  # mutsu: ($["A"..],)   raku: ("A", "B", "C")
```

`.elems` was already correct because it uses `as_list_items`, which descends regardless of itemization.

## Fix

Add an explicit `ValueView::Array(items, _)` arm to each of the five handlers, building the positional keys/values/pairs from the backing `items` directly. Plain-array behavior is unchanged (it already produced the same result via `value_to_list`); only the itemized case is corrected.

## Why it matters (zef)

Surfaced by Zef's `Zef::Utils::SystemQuery::system-collapse`, which traverses a depends structure with `for \$data.keys`. When the structure was an itemized array — exactly what `Zef::Distribution.depends-specs` produces — every element past the first was silently dropped, so the native/hash-based dependency spec (`{from:native, name:{by-distro.name:{...}}}`) vanished entirely.

Fixes zef's own `distribution-depends-parsing.rakutest` tests 3, 4, 17, 18 (16/35 → 18/35).

## Tests

- `t/itemized-array-keys-values.t` (25 subtests, verified against `raku`)
- `make test` PASS; relevant S32-list / S02-literals / S03-operators roast tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)