### PR TITLE
fix(runtime): construct `(TypeObject but Role).new` composed subtypes

### DIFF
--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -117,6 +117,30 @@ impl Interpreter {
         {
             return self.dispatch_new(Value::package(class_name), args);
         }
+        // Calling .new() on a Mixin(Package, roles) — a *type object* with roles
+        // mixed in via `TypeObject but Role` (`(Base but R).new`, which produces a
+        // `Base+{R}` subtype). Construct the base instance, then compose each
+        // mixed-in role onto it, exactly as `$instance but Role` does (this runs
+        // the roles' BUILD/TWEAK submethods and gives them fresh attribute
+        // defaults on the new instance).
+        if let ValueView::Mixin(inner, mixins) = target.view()
+            && let ValueView::Package(_) = inner.as_ref().view()
+        {
+            let base_instance = self.dispatch_new(inner.as_ref().clone(), args)?;
+            // Composed role names are recorded as `__mutsu_role__<name>` markers in
+            // the mixin map. Sort for a deterministic composition order.
+            let mut role_names: Vec<String> = mixins
+                .keys()
+                .filter_map(|k| k.strip_prefix("__mutsu_role__").map(str::to_string))
+                .collect();
+            role_names.sort();
+            let mut result = base_instance;
+            for role_name in role_names {
+                result =
+                    self.eval_does_values(result, Value::package(Symbol::intern(&role_name)))?;
+            }
+            return Ok(result);
+        }
         // Calling .new() on a concrete Array delegates to the type constructor.
         // If the array has type metadata (e.g. array[str]), use the declared type.
         if let ValueView::Array(..) = target.view() {

--- a/t/but-role-type-object-new.t
+++ b/t/but-role-type-object-new.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# `TypeObject but Role` creates a composed subtype (`Base+{Role}`) whose `.new`
+# constructs a base instance with the role mixed in. mutsu previously wrapped the
+# type object in a value-level Mixin whose `.new` fell through to the
+# "Unknown method value dispatch ... new" error. Regression for zef's
+# `distribution-depends-parsing` recommendation-manager mock
+# (`Zef::Repository but role :: { ... }).new(:backends[])`).
+
+plan 16;
+
+class Base { has $.x; method greet { "base $.x" } }
+
+# --- named role, methods only ---
+role R { method extra { 99 } }
+my $t = (Base but R).new(:x(5));
+ok $t.defined, 'composed type-object .new returns a defined instance';
+is $t.x, 5, 'base attribute initialized via .new';
+is $t.greet, 'base 5', 'base method works on composed instance';
+is $t.extra, 99, 'role method works on composed instance';
+ok $t ~~ R, 'composed instance does the role';
+ok $t ~~ Base, 'composed instance isa the base class';
+
+# --- anonymous role ---
+my $a = (Base but role :: { method anon { 'A' } }).new(:x(1));
+is $a.anon, 'A', 'anonymous role method works';
+is $a.x, 1, 'base attribute with anonymous role';
+
+# --- role with its own attribute + default ---
+role Tagged { has $.tag = 'default'; method describe { "tag:$.tag" } }
+my $g = (Base but Tagged).new(:x(7));
+is $g.tag, 'default', 'role attribute default initialized';
+is $g.describe, 'tag:default', 'role method reads role attribute';
+is $g.x, 7, 'base attribute alongside role attribute';
+ok $g ~~ Tagged, 'does the attribute-bearing role';
+
+# --- two roles composed (parenthesized: `but` is non-associative) ---
+role A { method a { 'a' } }
+role B { method b { 'b' } }
+my $ab = ((Base but A) but B).new(:x(9));
+is $ab.a, 'a', 'first role method';
+is $ab.b, 'b', 'second role method';
+is $ab.x, 9, 'base attribute with two roles';
+ok ($ab ~~ A) && ($ab ~~ B), 'does both roles';


### PR DESCRIPTION
## Problem

`TypeObject but Role` creates a composed subtype (`Base+{Role}`) whose `.new` builds a base instance with the role mixed in:

```raku
class Base { has $.x; method greet { "base $.x" } }
role R { method extra { 99 } }
(Base but R).new(:x(5));   # raku: Base+{R} instance
```

mutsu represented the `but` result as a value-level `Mixin(Package, roles)`, and `.new` had no arm for that shape — it fell through to:

```
X::Method::NotFound: Unknown method value dispatch (fallback disabled): new
```

so the whole construct was unusable on a type object. (`$instance but Role` already worked; only the type-object form was broken.)

## Fix

Add a `.new` arm for `Mixin(Package, roles)` in `dispatch_new`: construct the base instance from the inner package, then compose each mixed-in role (recorded as `__mutsu_role__<name>` markers in the mixin map) onto it via `eval_does_values` — exactly as `$instance but Role` does. This runs the roles' BUILD/TWEAK submethods and gives their attributes fresh defaults on the new instance.

Works for named roles, anonymous roles (`role :: { ... }`), attribute-bearing roles, and multiple composed roles; method dispatch and `~~` role/class checks behave like `$instance but Role`.

## Why it matters (zef)

Surfaced by zef's own `distribution-depends-parsing.rakutest`, whose recommendation-manager mock is `(Zef::Repository but role :: { method plugins(*@) {...} }).new(:backends[])`.

## Tests

- `t/but-role-type-object-new.t` (16 subtests, verified against `raku`)
- `make test` PASS; S14-roles (instantiation/composition/anonymous/basic) + S12-construction/roles-6e roast tests PASS

Note: the composed instance's `.^name` still gists as the base name (`Base`) rather than `Base+{R}` — a pre-existing cosmetic divergence in how `but` names the mixin, orthogonal to this `.new` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)