### PR TITLE
fix(runtime): resolve $?DISTRIBUTION inside routine/method bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ target-local/
 
 # prove --state=save state file (CI roast failure-summary re-run; ephemeral)
 .prove
+
+# Raku precompilation cache dirs left by running `raku` on a test fixture lib
+.precomp/

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -607,6 +607,10 @@ impl Compiler {
         // so carry the method context down. A nested *named sub* is not a method
         // and gets a fresh compiler via compile_sub_body, so it correctly resets.
         sub_compiler.lexically_in_method = self.lexically_in_method;
+        // Propagate the distribution context so `$?DISTRIBUTION` resolves to the
+        // owning module's distribution inside a routine/method body (which is
+        // compiled through this closure-body path), not Nil.
+        sub_compiler.current_distribution = self.current_distribution.clone();
         // Propagate last_source_line so closures inside blocks that
         // lack their own SetLine can still inherit the line from the
         // enclosing statement.

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -3,14 +3,22 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    /// Compile all uncompiled method bodies in a method map.
     /// Compile a single method/submethod body to bytecode in place if it is not
     /// already compiled. Shared by the bulk registration pass and the on-demand
     /// compile in `run_resolved_method_compiled_or_treewalk`. An empty body is
     /// compiled too (to a trivial body returning Nil/self) so that empty `BUILD`/
     /// `TWEAK`/`method foo {}` stubs no longer fall through to the tree-walk
     /// `run_instance_method_resolved` — leaving only delegation forwarders there.
-    pub(crate) fn compile_method_def_in_place(def: &mut super::MethodDef, package_name: &str) {
+    ///
+    /// Seeds the compiler's distribution context so `$?DISTRIBUTION` inside the
+    /// method body resolves to the owning module's distribution (rather than Nil).
+    /// The caller resolves the dist via `resolve_package_distribution` before
+    /// taking the `&mut` registry borrow.
+    pub(crate) fn compile_method_def_in_place_with_dist(
+        def: &mut super::MethodDef,
+        package_name: &str,
+        distribution: Option<Value>,
+    ) {
         // A delegation forwarder (`handles`) has a synthesized/empty body and must
         // keep its delegation routing — compiling its empty body would make paths
         // that check `compiled_code.is_some()` run the empty body (returning Nil)
@@ -25,6 +33,7 @@ impl Interpreter {
             .or(def.role_origin.as_deref())
             .unwrap_or(package_name);
         compiler.set_current_package(method_package.to_string());
+        compiler.current_distribution = distribution;
         // A method always carries an implicit `*%_` / `*@_` slurpy, so `%_` / `@_`
         // are valid lexicals throughout the body (including a nested signature-less
         // `do {}` block). Mark the method context so the do-block placeholder check
@@ -47,10 +56,15 @@ impl Interpreter {
     fn compile_methods_for_map(
         methods: &mut HashMap<String, Vec<super::MethodDef>>,
         package_name: &str,
+        distribution: Option<Value>,
     ) {
         for overloads in methods.values_mut() {
             for def in overloads.iter_mut() {
-                Self::compile_method_def_in_place(def, package_name);
+                Self::compile_method_def_in_place_with_dist(
+                    def,
+                    package_name,
+                    distribution.clone(),
+                );
             }
         }
     }
@@ -93,15 +107,17 @@ impl Interpreter {
 
     /// Compile method bodies for a given class using the bytecode compiler.
     pub(crate) fn compile_class_methods(&mut self, class_name: &str) {
+        let dist = self.resolve_package_distribution(class_name);
         if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
-            Self::compile_methods_for_map(&mut class_def.methods, class_name);
+            Self::compile_methods_for_map(&mut class_def.methods, class_name, dist);
         }
     }
 
     /// Compile method bodies for a given role.
     pub(crate) fn compile_role_methods(&mut self, role_name: &str) {
+        let dist = self.resolve_package_distribution(role_name);
         if let Some(role_def) = self.registry_mut().roles.get_mut(role_name) {
-            Self::compile_methods_for_map(&mut role_def.methods, role_name);
+            Self::compile_methods_for_map(&mut role_def.methods, role_name, dist);
         }
     }
 

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -276,7 +276,8 @@ impl Interpreter {
             // `forward_resolved_delegation` was deleted (#3680). Delegation forwarders
             // keep their synthesized empty body uncompiled.
             if method_def.compiled_code.is_none() && method_def.delegation.is_none() {
-                Self::compile_method_def_in_place(&mut method_def, &owner_class);
+                let dist = self.resolve_package_distribution(&owner_class);
+                Self::compile_method_def_in_place_with_dist(&mut method_def, &owner_class, dist);
             }
             // nextsame/callsame+rw chaining for methods (§D capstone): the stored
             // method args are plain values (no varref), so without an arg source the

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -284,7 +284,8 @@ impl Interpreter {
         // the attr ops and the `final_attrs` commit below.
         let mut method_def = method_def;
         if method_def.compiled_code.is_none() && method_def.delegation.is_none() {
-            Self::compile_method_def_in_place(&mut method_def, owner_class);
+            let dist = self.resolve_package_distribution(owner_class);
+            Self::compile_method_def_in_place_with_dist(&mut method_def, owner_class, dist);
         }
         let writeback_safe_compiled =
             method_def.compiled_code.is_some() && method_def.delegation.is_none();

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -112,6 +112,27 @@ impl Interpreter {
         Value::hash_with_data(Value::hash_arc(result))
     }
 
+    /// Resolve the distribution for a routine's defining package when compiling
+    /// its body on-the-fly (`$?DISTRIBUTION` in the body is a compile-time
+    /// constant). Tries the exact package, then progressively shorter `::`
+    /// prefixes: a method of a nested package/role (e.g. `Zef::Pluggable`) or a
+    /// role composed into another package inherits the distribution recorded for
+    /// its enclosing module (`Zef`), which is the compilation unit that owns the
+    /// source file. Falls back to the currently-loading distribution.
+    pub(crate) fn resolve_package_distribution(&self, pkg: &str) -> Option<Value> {
+        if let Some(dist) = self.package_distributions.get(pkg) {
+            return Some(dist.clone());
+        }
+        let mut rest = pkg;
+        while let Some(idx) = rest.rfind("::") {
+            rest = &rest[..idx];
+            if let Some(dist) = self.package_distributions.get(rest) {
+                return Some(dist.clone());
+            }
+        }
+        self.current_distribution.clone()
+    }
+
     /// Detect a distribution (META6.json) for the given module source path.
     pub(super) fn detect_distribution(source_path: &Path) -> Option<Value> {
         let mut dir = source_path.parent()?;

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -381,7 +381,23 @@ impl Interpreter {
         let saved_distribution = self.current_distribution.clone();
         // First try inst# installation repos (source files have no META6.json nearby)
         let inst_dist = self.detect_inst_distribution(module);
-        if let Some(dist) = inst_dist.or_else(|| Self::detect_distribution(&source_path)) {
+        // Classes/roles this module declares belong to its distribution too, so a
+        // later OTF compile of one of their methods can resolve `$?DISTRIBUTION`
+        // (e.g. a role method reads `$?DISTRIBUTION.meta` — zef's `Pluggable`).
+        // Snapshot the pre-load names so we can record the dist for the new ones.
+        let module_dist = inst_dist.or_else(|| Self::detect_distribution(&source_path));
+        let (before_class_names, before_role_names): (
+            std::collections::HashSet<String>,
+            std::collections::HashSet<String>,
+        ) = if module_dist.is_some() {
+            (
+                self.registry().classes.keys().cloned().collect(),
+                self.registry().roles.keys().cloned().collect(),
+            )
+        } else {
+            Default::default()
+        };
+        if let Some(dist) = &module_dist {
             self.current_distribution = Some(dist.clone());
             // Record the distribution for the module's package name
             // so OTF compilation can resolve $?DISTRIBUTION later.
@@ -391,7 +407,7 @@ impl Interpreter {
             // for unit modules) since the interpreter's current_package may not
             // match the module name during function body evaluation.
             self.package_distributions
-                .insert(self.current_package(), dist);
+                .insert(self.current_package(), dist.clone());
         }
         // Save and restore the language version around module loading.
         // Each module may set its own `use v6.*` which should not leak
@@ -444,6 +460,28 @@ impl Interpreter {
                 &before_function_keys,
                 main_exported,
             );
+        }
+        // Record the module's distribution for every class/role it just declared,
+        // so an OTF compile of one of their methods resolves `$?DISTRIBUTION`.
+        if let Some(dist) = &module_dist {
+            let new_names: Vec<String> = self
+                .registry()
+                .classes
+                .keys()
+                .filter(|k| !before_class_names.contains(*k))
+                .chain(
+                    self.registry()
+                        .roles
+                        .keys()
+                        .filter(|k| !before_role_names.contains(*k)),
+                )
+                .cloned()
+                .collect();
+            for name in new_names {
+                self.package_distributions
+                    .entry(name)
+                    .or_insert_with(|| dist.clone());
+            }
         }
         crate::parser::set_current_language_version(&saved_language_version);
         self.current_distribution = saved_distribution;

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -145,12 +145,9 @@ impl Interpreter {
             if !pkg.is_empty() && pkg != "GLOBAL" {
                 compiler.set_current_package(pkg.to_string());
             }
-            // Resolve $?DISTRIBUTION from the function's defining package
-            compiler.current_distribution = self
-                .package_distributions
-                .get(&pkg)
-                .cloned()
-                .or_else(|| self.current_distribution.clone());
+            // Resolve $?DISTRIBUTION from the function's defining package (or an
+            // enclosing module's distribution for a nested package / role method).
+            compiler.current_distribution = self.resolve_package_distribution(&pkg);
             compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
         };
         let deprecated_info = def.deprecated_message.as_ref().map(|msg| {

--- a/t/dist-in-role-method.t
+++ b/t/dist-in-role-method.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+# $?DISTRIBUTION must resolve to the owning module's distribution inside a routine
+# body (including a role method composed into a class and compiled on demand after
+# the module finished loading), not Nil. Regression for zef's `Zef::Pluggable`
+# `!try-load`, which reads `$?DISTRIBUTION.meta<provides>{...}:exists`.
+
+use lib 't/fixtures/dist-role/lib';
+use DistRoleFixture;
+
+plan 6;
+
+my $c = make-consumer();
+
+ok $c.dist-defined, 'role method: $?DISTRIBUTION is defined (not Nil)';
+ok $c.provides-has('DistRoleFixture'),
+    'role method: $?DISTRIBUTION.meta<provides> knows the provided module';
+nok $c.provides-has('No::Such::Module'),
+    'role method: $?DISTRIBUTION.meta<provides> reports a missing module as absent';
+
+ok sub-dist-defined(), 'exported sub: $?DISTRIBUTION is defined';
+
+# Calling the same role method again uses the cached compiled body — still defined.
+ok $c.dist-defined, 'role method: still defined on second call (cached body)';
+
+# A freshly constructed consumer resolves it too.
+ok make-consumer().dist-defined, 'role method: defined on a second instance';

--- a/t/fixtures/dist-role/META6.json
+++ b/t/fixtures/dist-role/META6.json
@@ -1,0 +1,8 @@
+{
+    "name": "DistRoleFixture",
+    "version": "2.5.0",
+    "auth": "github:mutsu",
+    "provides": {
+        "DistRoleFixture": "lib/DistRoleFixture.rakumod"
+    }
+}

--- a/t/fixtures/dist-role/lib/DistRoleFixture.rakumod
+++ b/t/fixtures/dist-role/lib/DistRoleFixture.rakumod
@@ -1,0 +1,18 @@
+unit module DistRoleFixture;
+
+# A role whose methods read $?DISTRIBUTION. When the role is composed into a class
+# and one of its methods is dispatched (compiled on demand, after the module has
+# finished loading), $?DISTRIBUTION must still resolve to this module's
+# distribution, not Nil. Mirrors zef's `Zef::Pluggable` role, whose `!try-load`
+# reads `$?DISTRIBUTION.meta<provides>`.
+role HasDist is export {
+    method dist-defined { $?DISTRIBUTION.defined }
+    method provides-has(Str $k) { so $?DISTRIBUTION.meta<provides>{$k}:exists }
+}
+
+class Consumer does HasDist is export { }
+
+sub make-consumer() is export { Consumer.new }
+
+# Also exercise a plain exported sub (not a role method) reading $?DISTRIBUTION.
+sub sub-dist-defined() is export { $?DISTRIBUTION.defined }


### PR DESCRIPTION
## Problem

`$?DISTRIBUTION` is a compile-time constant baked into a routine body via `LoadConst`. Two gaps left it as `Nil` for a routine/method compiled *after* its module finished loading:

1. **The key bug:** `compile_closure_body_with_routine_flag` — the path `compile_routine_closure_body` uses for **every** sub/method body — built a fresh sub-compiler but never propagated `current_distribution`, so `$?DISTRIBUTION` in the body always resolved to Nil regardless of the enclosing compiler's distribution context.
2. A method body compiled **on demand** (on first dispatch, after `load_module` restored `current_distribution` to None) had no distribution source at all, because the dispatch-time compile paths didn't consult the module a method's package belongs to.

## Fix

- New `resolve_package_distribution(pkg)` (run_dist.rs): exact package → progressively shorter `::` prefixes → `current_distribution`, so a nested package / role method inherits its enclosing module's distribution.
- `load_module` records the module's distribution for every class/role it declares (so the lookup works after the load finished).
- Thread the resolved distribution into the method-body compile (`compile_method_def_in_place_with_dist`) from the bulk-registration and the two on-demand dispatch callers (class_dispatch, builtins_dispatch_next); the OTF sub compile (vm_call_dispatch) now uses `resolve_package_distribution`.
- Propagate `current_distribution` to the sub-compiler in `compile_closure_body_with_routine_flag`.

## Why it matters (zef)

Surfaced by zef's `Zef::Pluggable` role, whose `!try-load` reads `$?DISTRIBUTION.meta<provides>{$name}:exists`. mutsu threw `No such method 'meta' for invocant of type 'Any'` there because `$?DISTRIBUTION` was Nil (which mutsu conflates with the Any type object), and `Any.meta` is unresolved.

## Tests

- `t/dist-in-role-method.t` (6 subtests) + fixture `t/fixtures/dist-role/` — a role method and an exported sub both read `$?DISTRIBUTION` and its `.meta<provides>`; verified against `raku`.
- `make test` PASS; S11-modules / S11-repository/cur-current-distribution / S22 roast tests PASS.

Note: for an `-I` filesystem lib mutsu reads the real `META6.json` (name/provides), whereas raku synthesizes `name` = lib path; the test asserts `.defined` / `provides-has`, not the exact name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)