### PR TITLE
fix(meta): store and expose the :api declarator adverb via .^api

### DIFF
--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -421,7 +421,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     };
     let mut stmts = Vec::new();
     for (trait_name, trait_value) in traits {
-        if trait_name == "ver" || trait_name == "auth" {
+        if trait_name == "ver" || trait_name == "auth" || trait_name == "api" {
             stmts.push(meta_setter_stmt(&name, &trait_name, trait_value));
         }
     }

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -188,7 +188,7 @@ pub(crate) fn module_decl(input: &str) -> PResult<'_, Stmt> {
     }
     let mut stmts = Vec::new();
     for (trait_name, trait_value) in traits {
-        if trait_name == "ver" || trait_name == "auth" {
+        if trait_name == "ver" || trait_name == "auth" || trait_name == "api" {
             stmts.push(meta_setter_stmt(&name, &trait_name, trait_value));
         }
     }

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -450,10 +450,10 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
         language_version: super::super::simple::current_language_version(),
         custom_traits,
     };
-    // Emit __MUTSU_SET_META__ calls for ver/auth traits (like class declarations)
+    // Emit __MUTSU_SET_META__ calls for ver/auth/api traits (like class declarations)
     let mut meta_stmts = Vec::new();
     for (trait_name, trait_value) in traits {
-        if trait_name == "ver" || trait_name == "auth" {
+        if trait_name == "ver" || trait_name == "auth" || trait_name == "api" {
             meta_stmts.push(meta_setter_stmt(&name, &trait_name, trait_value));
         }
     }

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -92,6 +92,28 @@ impl Interpreter {
                 };
                 Ok(Value::str(value.to_string_value()))
             }
+            "api" if args.len() == 1 => {
+                let invocant_name = match args[0].view() {
+                    ValueView::Package(name) => name,
+                    ValueView::Instance { class_name, .. } => class_name,
+                    _ => {
+                        return Err(RuntimeError::new(
+                            "X::Method::NotFound: Unknown method value dispatch (fallback disabled): api",
+                        ));
+                    }
+                };
+                // A declared `:api(...)` is stored in type_metadata; a type with no
+                // `:api` has an empty-string api in Rakudo (`class C {}; C.^api` eq
+                // ""), so default to "" rather than throwing.
+                if let Some(value) = self
+                    .type_metadata
+                    .get(&invocant_name.resolve())
+                    .and_then(|meta| meta.get("api").cloned())
+                {
+                    return Ok(Value::str(value.to_string_value()));
+                }
+                Ok(Value::str(String::new()))
+            }
             "isa" if args.len() == 2 => {
                 // Allow calling .^isa on an instance: use the instance's class.
                 let class_name = match args[0].view() {

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -312,6 +312,7 @@ impl Interpreter {
             "name"
                 | "ver"
                 | "auth"
+                | "api"
                 | "mro"
                 | "mro_unhidden"
                 | "archetypes"

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -31,6 +31,7 @@ impl Interpreter {
                 | "name"
                 | "ver"
                 | "auth"
+                | "api"
                 | "mro"
                 | "mro_unhidden"
                 | "methods"

--- a/t/meta-api.t
+++ b/t/meta-api.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# `.^api` (the metamodel `api` accessor) reads a type's declared `:api(...)`.
+# Previously mutsu (1) never stored the `:api` adverb (only `:ver`/`:auth`), and
+# (2) `.^api` wasn't a recognized ClassHOW method, so `Foo.^api` threw
+# `No such method 'api' for invocant of type 'Perl6::Metamodel::ClassHOW'`.
+# zef's `Zef::Pluggable !try-load` reads `Zef.^api`.
+
+plan 7;
+
+module ModWithApi:api<3> { }
+is ~ModWithApi.^api, '3', 'module :api<3> is readable via .^api';
+
+class ClassWithApi:api<7> { }
+is ~ClassWithApi.^api, '7', 'class :api<7> is readable via .^api';
+
+# A type with no declared :api has an empty-string api (matches Rakudo).
+class NoApi { }
+is ClassWithApi.^api ne '', True, 'declared api is non-empty';
+is NoApi.^api, '', 'class with no :api has empty-string api';
+
+module NoApiMod { }
+is NoApiMod.^api, '', 'module with no :api has empty-string api';
+
+# .^ver and .^auth still work alongside :api on the same declaration.
+module Full:ver<1.2.3>:auth<github:me>:api<5> { }
+is ~Full.^ver, '1.2.3', 'ver still works with api present';
+is ~Full.^api, '5', 'api works with ver/auth present';


### PR DESCRIPTION
## Problem

`.^api` (the metamodel `api` accessor) reads a type's declared `:api(...)`, but mutsu:

1. **never stored the `:api` adverb** — the three parser sites that emit `__MUTSU_SET_META__` for a declaration's `:ver`/`:auth` adverbs skipped `:api`; and
2. **`.^api` wasn't a recognized ClassHOW method**, so `Foo.^api` threw `No such method 'api' for invocant of type 'Perl6::Metamodel::ClassHOW'`.

```raku
module M:api<3> { }
M.^api;         # threw; raku: IntStr.new(3, "3")
class C { }
C.^api;         # threw; raku: ""
```

## Fix

- Emit `__MUTSU_SET_META__(name, "api", value)` for a `:api(...)` adverb on class / module / role declarations (`class_decl.rs`, `grammar_module.rs`, `role_decl.rs`), alongside the existing `:ver`/`:auth` handling.
- Add an `api` handler to `dispatch_classhow_method`: returns the stored api, or the empty string for a type with no declared `:api` (matching Rakudo's `class C {}; C.^api eq ""`).
- Register `api` in `is_classhow_method` and `classhow_find_method` so the call routes to the HOW dispatch instead of erroring.

## Why it matters (zef)

Surfaced by zef's `Zef::Pluggable` role, whose `!try-load` reads `Zef.^api` (`$api-matcher = $identity.api || do { $plugin-is-core ?? Zef.^api !! True }`).

## Tests

- `t/meta-api.t` (7 subtests) — module/class `:api` readable, empty-string default, coexists with `:ver`/`:auth`; verified against `raku`.
- `make test` PASS; S12-introspection/meta-class, S02-types/subset-6e, S14-roles/basic, S11-repository/cur-candidates roast tests PASS.

Note: for a numeric `:api<3>` raku returns an `IntStr` allomorph while mutsu returns a `Str` (the string value matches); raku additionally throws on a *role*'s `.^api` (ParametricRoleGroupHOW), so the test covers module/class only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)