### PR TITLE
fix(vm,compiler): attribute accessors are slot-based — := binds and .VAR mixins get container identity

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -98,10 +98,9 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
 - `S26-documentation/12-non-breaking-space.t`（top-level BEGIN compile-time hoist）→ `news/2026-07.md`
 - `S02-names-vars/variables-and-packages.t`（nested-block BEGIN hoist）→ `news/2026-07.md`
 
-**残る別軸の残課題**（属性 slot の完全な cell 化待ち・§3.2 item 2）:
-`$my_ref := $obj.attr`（scalar accessor への `:=` 束縛）・`$obj.attr.VAR.role = v`
-（mixin accessor への rw 書込）。closure-captured shared-cell を list へ by-value 捕捉した
-ときのスナップショット追従（return-writeback 系・`splice.t` の `ident4`）も同族。
+**残る別軸の残課題**: closure-captured shared-cell を list へ by-value 捕捉した
+ときのスナップショット追従（return-writeback 系・`splice.t` の `ident4`）。
+（`$my_ref := $obj.attr` と `$obj.attr.VAR.role = v` は §3.2 item 2 で DONE。）
 
 ### 3.2 サブキャンペーンと choke point
 
@@ -110,11 +109,18 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
    - 変更レイヤ: `value/mod.rs`、`vm_var_assign_ops.rs`、`vm_var_index_ops.rs`
    - 対象: `splice.t`（multislice は §2.3 で完了・#4355）
    - 完了条件: element bind / take-rw / deep nested write が post-call writeback なしで成立
-2. **属性 accessor を value copy ではなく slot 経由にする**
-   - 変更レイヤ: attribute read/write path、instance attr storage
-   - 対象: `Attribute.container.VAR does Role` は #4314 で完了（§3.1 参照）。残りは
-     `$my_ref := $obj.attr`（scalar accessor への `:=` 束縛）・`$obj.attr.VAR.role = v`
-     （mixin accessor への rw 書込）
+2. **属性 accessor を value copy ではなく slot 経由にする** — **DONE**
+   - `Attribute.container.VAR does Role` は #4314 で完了（§3.1 参照）。
+   - `$my_ref := $obj.attr`（rw scalar accessor への `:=` 束縛が属性 slot の
+     `ContainerRef` cell を共有・双方向追従・型制約は cell に登録して enforce）と
+     `$obj.attr.VAR does Role` + `$obj.attr.VAR.name = v`（mixin accessor への
+     rw 書込が cell 経由で永続化）を実装。仕組み: `MarkAccessorRefContext`
+     opcode（`:=` bind RHS / `.VAR` チェーンの内側 CallMethod 直前に emit、
+     dispatch 入口で take して 1 dispatch に閉じる）→ fast accessor read が
+     attr slot を cell 昇格して返す。非-rw accessor は raku 同様 decont 値
+     （bind 後の代入は immutable エラー）。Pin: `t/attr-accessor-slot.t`（18、
+     raku 一致）。副産物: `$_ := $d`（SetGlobal 経由 topic bind）が
+     `scalar_bind_context` を消費せず次の SetLocal に残留するバグを修正。
 3. **BEGIN/EVAL/lexical 配列変更の永続化** — **DONE**。
    - top-level BEGIN 版（`S26-documentation/12-non-breaking-space.t`、`run_toplevel_begin_phasers`）・
      nested-block BEGIN 版（`S02-names-vars/variables-and-packages.t`、`reorder_at_level`）とも
@@ -166,11 +172,11 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
 1. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
    multislice hash 側の slot identity を前に進める。
    これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
-   **進捗（2026-07-08）**: whole-container 代入の container-identity（`splice.t`）と
-   属性 container mixin（`S14-traits/attributes.t`・#4314）は完了・whitelist 済み
-   （§3.1 参照）。残るは closure-captured shared-cell を list へ by-value 捕捉したときの
-   スナップショット追従（return-writeback 系）と、属性 slot の完全な cell 化
-   （`:=` 束縛・mixin accessor への rw 書込）。
+   **進捗（2026-07-09）**: whole-container 代入の container-identity（`splice.t`）、
+   属性 container mixin（`S14-traits/attributes.t`・#4314）、属性 slot の完全な
+   cell 化（`:=` 束縛・mixin accessor への rw 書込、§3.2 item 2）は完了。
+   残るは closure-captured shared-cell を list へ by-value 捕捉したときの
+   スナップショット追従（return-writeback 系・`splice.t` の `ident4`）。
 
 かつて 2 番手だった cross-thread lexical writeback campaign（旧 §4.1）は完了
 （`S17-lowlevel/lock.t`・`S32-io/socket-recv-vs-read.t` とも whitelist 済み、

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -331,6 +331,35 @@ impl Compiler {
                 args,
                 modifier,
                 quoted,
+            } if name == "VAR"
+                && args.is_empty()
+                && modifier.is_none()
+                && !quoted
+                && matches!(target.as_ref(), Expr::MethodCall { .. }) =>
+            {
+                // `.VAR` on a method-call result (`$obj.attr.VAR`): flag the
+                // inner dispatch so a public attribute accessor returns the
+                // attribute slot's `ContainerRef` cell — `.VAR` then yields the
+                // attribute's real container (for `does` mixins / `.VAR.attr =`
+                // rw writes) instead of a detached value copy. A non-accessor
+                // inner method ignores the flag (identity `.VAR`, as before).
+                self.compile_expr(target);
+                self.mark_trailing_method_call_as_accessor_ref();
+                let name_idx = self.code.add_constant(Value::str("VAR".to_string()));
+                self.code.emit(OpCode::CallMethod {
+                    name_idx,
+                    arity: 0,
+                    modifier_idx: None,
+                    quoted: false,
+                    arg_sources_idx: None,
+                });
+            }
+            Expr::MethodCall {
+                target,
+                name,
+                args,
+                modifier,
+                quoted,
             } if matches!(
                 target.as_ref(),
                 Expr::Var(_)

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -296,6 +296,35 @@ impl Compiler {
         } else if let Some(name) = source_name {
             let name_idx = self.code.add_constant(Value::str(name));
             self.code.emit(OpCode::WrapVarRef(name_idx));
+        } else if is_bind_target && matches!(arg, Expr::MethodCall { .. }) {
+            // `:=` bind to a method-call RHS (`my $ref := $obj.attr`): flag the
+            // dispatch so a public attribute accessor returns the attribute
+            // slot's `ContainerRef` cell instead of a value copy — the bound
+            // variable then aliases the attribute container (writes through
+            // either side are seen by both). A non-accessor method ignores the
+            // flag and the bind degrades to today's bind-by-value.
+            self.mark_trailing_method_call_as_accessor_ref();
+        }
+    }
+
+    /// Insert a `MarkAccessorRefContext` immediately before the trailing
+    /// `CallMethod`/`CallMethodMut` op (skipping the post-call `Decont` /
+    /// `ContainerizePair` the arg compile may have appended), so that ONE
+    /// dispatch sees the accessor-ref flag. Inserting (rather than emitting
+    /// after the fact) is safe here: any jump patched to the call op's old
+    /// index now lands on the marker and falls through to the same call.
+    /// No-op when the compiled tail is not a method call.
+    pub(super) fn mark_trailing_method_call_as_accessor_ref(&mut self) {
+        let mut i = self.code.ops.len();
+        while i > 0 {
+            match &self.code.ops[i - 1] {
+                OpCode::Decont | OpCode::ContainerizePair => i -= 1,
+                OpCode::CallMethod { .. } | OpCode::CallMethodMut { .. } => {
+                    self.code.ops.insert(i - 1, OpCode::MarkAccessorRefContext);
+                    return;
+                }
+                _ => return,
+            }
         }
     }
 

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1056,6 +1056,7 @@ impl Compiler {
                     self.bind_terminal = false;
                 } else if scalar_bind_decont
                     && (matches!(expr, Expr::ArrayVar(_) | Expr::HashVar(_))
+                        || matches!(expr, Expr::MethodCall { .. })
                         || matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. })))
                 {
                     // A scalar `:=` bind to a *whole* container variable

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1056,7 +1056,6 @@ impl Compiler {
                     self.bind_terminal = false;
                 } else if scalar_bind_decont
                     && (matches!(expr, Expr::ArrayVar(_) | Expr::HashVar(_))
-                        || matches!(expr, Expr::MethodCall { .. })
                         || matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. })))
                 {
                     // A scalar `:=` bind to a *whole* container variable
@@ -1101,6 +1100,17 @@ impl Compiler {
                         expr
                     };
                     self.compile_assignment_rhs_for_target(name, rhs_expr);
+                    // `my $ref := $obj.attr`: flag the trailing accessor
+                    // dispatch to return the attribute slot's ContainerRef cell
+                    // (see MarkAccessorRefContext). Done HERE, on the normal
+                    // assignment-RHS route, rather than by re-routing MethodCall
+                    // RHS through compile_call_arg — that route compiles closure
+                    // args as NON-escaping (the #2746 guard), which would unbox
+                    // the captured outer writes of e.g. `my $v := lazy { $x++ }`
+                    // (statement prefixes like `lazy`/`do` parse as MethodCall).
+                    if scalar_bind_decont && matches!(rhs_expr, Expr::MethodCall { .. }) {
+                        self.mark_trailing_method_call_as_accessor_ref();
+                    }
                 }
                 if let Some(start_idx) = constant_init_phaser_start {
                     self.code.emit(OpCode::CheckPhaserEnd);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -315,6 +315,15 @@ pub(crate) enum OpCode {
     /// Signal that the next SetLocal is a `:=` rebind (not a VarDecl).
     /// Triggers cleanup of old bind pairs and reverse aliases.
     MarkRebindContext,
+    /// Emitted immediately before a `CallMethod`/`CallMethodMut` whose result is
+    /// wanted as a *container* rather than a value copy (a `:=` bind RHS like
+    /// `my $ref := $obj.attr`, or the inner call of a `.VAR` chain like
+    /// `$obj.attr.VAR`). When the call resolves to a public attribute accessor
+    /// read, the attribute slot is promoted to a shared `ContainerRef` cell and
+    /// the cell itself is returned, giving the caller the attribute's container
+    /// identity. Consumed (and unconditionally cleared) at CallMethod entry, so
+    /// it cannot leak past the one dispatch it was emitted for.
+    MarkAccessorRefContext,
     /// Slice 2a/2b (`docs/scalar-array-sharing.md`): signal that the next
     /// SetLocal/AssignExpr assigns to a `$` scalar via plain `=` and that the
     /// named source variable's container should be shared by reference. The

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -225,6 +225,33 @@ impl Interpreter {
             .any(|(attr_name, is_public, ..)| *is_public && attr_name == method_name)
     }
 
+    /// Accessor-slot promotion gate: when `method_name` is a public `is rw`
+    /// attribute accessor, return `Some(declared type constraint)` (`Some(None)`
+    /// for an untyped rw attribute). `None` means the accessor is not rw — a
+    /// want-ref read must NOT promote the slot (raku returns the decont'd value
+    /// there, so `my $r := $obj.ro-attr; $r = v` stays an immutable-value error).
+    pub(crate) fn rw_accessor_type_constraint(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<Option<String>> {
+        let attrs = self.collect_class_attributes(class_name);
+        let is_rw = attrs
+            .iter()
+            .any(|(attr_name, is_public, _default, is_rw, ..)| {
+                *is_public && *is_rw && attr_name == method_name
+            });
+        if !is_rw {
+            return None;
+        }
+        for cn in self.class_mro(class_name) {
+            if let Some(tc) = self.get_attr_type_constraint(&cn, method_name) {
+                return Some(Some(tc));
+            }
+        }
+        Some(None)
+    }
+
     /// Check if an attribute is buildable (can be set via .new).
     pub(crate) fn is_attribute_buildable(&self, class_name: &str, attr_name: &str) -> bool {
         if let Some(class_def) = self.registry().classes.get(class_name) {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -958,6 +958,16 @@ impl Interpreter {
             }
             if method == "clone" {
                 let mut attrs: HashMap<String, Value> = attributes.to_map();
+                // A slot promoted to a `ContainerRef` cell (a `:=`-bound
+                // attribute) must not leak its cell into the clone: snapshot
+                // the inner value so a write to the clone's attribute stays
+                // invisible to the original (raku clones get fresh containers).
+                for v in attrs.values_mut() {
+                    if matches!(v.view(), ValueView::ContainerRef(_)) {
+                        let taken = std::mem::replace(v, Value::NIL);
+                        *v = taken.deref_container();
+                    }
+                }
                 // Build sigil map from class attributes to coerce values properly
                 let class_attrs_info = self.collect_class_attributes(&class_name.resolve());
                 let sigil_map: HashMap<String, char> = class_attrs_info

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -2,6 +2,38 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Whether the role attribute backing a mixin override key
+    /// (`__mutsu_attr__{method}`) is declared `is rw`. Scans the mixin's
+    /// `__mutsu_role__*` entries for a role that declares the attribute; an
+    /// ad-hoc mixin with no declaring role stays writable (matching the
+    /// lenient ad-hoc branch of the Instance mixin path).
+    fn mixin_attr_is_rw(
+        &self,
+        mixins: &std::collections::HashMap<String, Value>,
+        method: &str,
+    ) -> bool {
+        let mut found_attr = false;
+        for role_name in mixins
+            .keys()
+            .filter_map(|k| k.strip_prefix("__mutsu_role__"))
+        {
+            let base = role_name.split('[').next().unwrap_or(role_name);
+            for candidate in [role_name, base] {
+                for (attr_name, is_public, _default, is_rw, _is_required, sigil, ..) in
+                    self.collect_role_attributes_for_class(candidate)
+                {
+                    if attr_name == method && is_public {
+                        if is_rw || sigil == '@' || sigil == '%' {
+                            return true;
+                        }
+                        found_attr = true;
+                    }
+                }
+            }
+        }
+        !found_attr
+    }
+
     pub(crate) fn assign_method_lvalue_with_values(
         &mut self,
         target_var: Option<&str>,
@@ -728,6 +760,38 @@ impl Interpreter {
             }
         }
 
+        // Assignment through a first-class container (`$obj.attr.VAR.name = v`
+        // after `$obj.attr.VAR does Role`): the target is the attribute slot's
+        // `ContainerRef` cell. A role-mixin attribute write updates the mixin
+        // override in place through the cell (visible to every alias); any
+        // other method-lvalue delegates to the inner value.
+        if let ValueView::ContainerRef(cell) = target.view() {
+            let inner = cell.lock().unwrap().clone();
+            if let ValueView::Mixin(minner, mixins) = inner.view() {
+                let mixin_attr_key = format!("__mutsu_attr__{}", method);
+                if mixins.contains_key(&mixin_attr_key) {
+                    if !self.mixin_attr_is_rw(mixins, method) {
+                        return Err(RuntimeError::new(format!(
+                            "X::Assignment::RO: method '{}' is not rw",
+                            method
+                        )));
+                    }
+                    let mut updated = (**mixins).clone();
+                    updated.insert(mixin_attr_key, value.clone());
+                    *cell.lock().unwrap() =
+                        Value::mixin_parts(minner.clone(), std::sync::Arc::new(updated));
+                    return Ok(value);
+                }
+            }
+            return self.assign_method_lvalue_with_values(
+                target_var,
+                inner,
+                method,
+                method_args,
+                value,
+            );
+        }
+
         // Handle Mixin-wrapped instances (e.g. from role punning) by updating
         // the mixin attribute entry directly.
         if let ValueView::Mixin(inner, mixins) = target.view()
@@ -902,8 +966,14 @@ impl Interpreter {
                     method.to_string()
                 };
                 let mut updated = attributes.to_map();
-                let mut assigned_value =
-                    Self::normalize_rw_accessor_assignment(updated.get(&attr_key).cloned(), value);
+                // A slot promoted to a `ContainerRef` cell (a `:=` bind / `.VAR`
+                // mixin took the attribute's container identity) is transparent
+                // to the accessor write: normalize against the inner value and
+                // (below) write through the cell instead of replacing it.
+                let mut assigned_value = Self::normalize_rw_accessor_assignment(
+                    updated.get(&attr_key).cloned().map(|v| v.deref_container()),
+                    value,
+                );
                 // When Nil is assigned to an attribute with `is default(...)`,
                 // restore the default value instead of setting Nil.
                 if assigned_value.is_nil()
@@ -943,7 +1013,10 @@ impl Interpreter {
                     };
                     assigned_value = self.tag_container_metadata(assigned_value, info);
                 }
-                updated.insert(attr_key.clone(), assigned_value.clone());
+                // Write through an existing `ContainerRef` slot (preserving any
+                // `:=`-bound alias of the attribute container); otherwise replace
+                // the entry as a bare value.
+                Value::hash_insert_through(&mut updated, attr_key.clone(), assigned_value.clone());
                 // Always propagate the change into this instance's live shared
                 // cell. This handles chained accessor assignment like
                 // `$outer.inner.arr = ...` where target_var may be None but the

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1522,6 +1522,10 @@ pub struct Interpreter {
     pub(crate) scalar_bind_context: bool,
     pub(crate) bound_decont_active: bool,
     pub(crate) rebind_context: bool,
+    /// Set by `MarkAccessorRefContext` immediately before a CallMethod(Mut)
+    /// whose result is wanted as a container (`:=` bind RHS / `.VAR` chain).
+    /// Consumed and unconditionally cleared at CallMethod entry.
+    pub(crate) accessor_ref_pending: bool,
     pub(crate) constant_context: bool,
     /// Slice 2a (`docs/scalar-array-sharing.md`): set by `MarkArrayShareContext`
     /// just before a `SetLocal` for `$scalar = @arr` / `$scalar = %hash`. Tells

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2133,6 +2133,7 @@ impl Interpreter {
             scalar_bind_context: false,
             bound_decont_active: false,
             rebind_context: false,
+            accessor_ref_pending: false,
             constant_context: false,
             array_share_context: false,
             array_share_source: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -327,6 +327,7 @@ impl Interpreter {
             scalar_bind_context: false,
             bound_decont_active: false,
             rebind_context: false,
+            accessor_ref_pending: false,
             constant_context: false,
             array_share_context: false,
             array_share_source: None,

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -60,9 +60,18 @@ impl Clone for InstanceAttrs {
     /// share the cell — sharing flows through `crate::gc::Gc<InstanceAttrs>`. The copy does
     /// not participate in DESTROY refcounting (`queue_destroy = false`).
     fn clone(&self) -> Self {
+        let mut map = read_attrs(&self.attributes).clone();
+        // Snapshot any `ContainerRef`-promoted slot (a `:=`-bound attribute):
+        // an independent copy must not alias the original's attribute cell.
+        for v in map.values_mut() {
+            if let Value::ContainerRef(cell) = v {
+                let inner = cell.lock().unwrap().clone();
+                *v = inner;
+            }
+        }
         Self {
             class_name: self.class_name,
-            attributes: Arc::new(RwLock::new(read_attrs(&self.attributes).clone())),
+            attributes: Arc::new(RwLock::new(map)),
             id: self.id,
             queue_destroy: false,
             finalized: std::sync::atomic::AtomicBool::new(false),
@@ -156,6 +165,30 @@ impl InstanceAttrs {
     /// idiom), in place under the write lock.
     pub(crate) fn insert_if_absent(&self, key: String, value: Value) {
         write_attrs(&self.attributes).entry(key).or_insert(value);
+    }
+
+    /// Promote the attribute at `key` to a shared `ContainerRef` cell (in place,
+    /// under a single write lock) and return the cell value. If the slot already
+    /// holds a `ContainerRef`, the existing cell is returned — repeated `:=`
+    /// binds / `.VAR` chains on the same attribute alias one container. An
+    /// absent key materializes as a fresh cell holding `Nil`. This gives an
+    /// accessor result container identity: writes through the accessor and reads
+    /// through the bound alias observe the same slot.
+    pub(crate) fn promote_attr_to_container(&self, key: &str) -> Value {
+        let mut guard = write_attrs(&self.attributes);
+        match guard.get_mut(key) {
+            Some(Value::ContainerRef(cell)) => Value::ContainerRef(cell.clone()),
+            Some(slot) => {
+                let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(slot, Value::Nil)));
+                *slot = Value::ContainerRef(cell.clone());
+                Value::ContainerRef(cell)
+            }
+            None => {
+                let cell = crate::gc::Gc::new(Mutex::new(Value::Nil));
+                guard.insert(key.to_string(), Value::ContainerRef(cell.clone()));
+                Value::ContainerRef(cell)
+            }
+        }
     }
 
     /// Phase 3 registry-removal: replace the whole attribute map in place through

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -381,6 +381,9 @@ impl Interpreter {
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_method_dispatch();
+        // Consume (and unconditionally clear) the accessor-ref marker: it is
+        // emitted immediately before this opcode and scoped to this one dispatch.
+        let want_ref = std::mem::take(&mut self.accessor_ref_pending);
         // Set pending arg sources for `is rw` dispatch matching
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.set_pending_call_arg_sources(arg_sources.clone());
@@ -576,9 +579,14 @@ impl Interpreter {
         // potential invocant write-back, so accessor reads land here -- without
         // this they all fell back to the interpreter. The read does not mutate
         // the invocant, so no write-back to `target_name` is needed.
-        if let Some(val) =
-            self.try_fast_accessor_read(&target, &method, &args, modifier.is_some(), quoted)
-        {
+        if let Some(val) = self.try_fast_accessor_read(
+            &target,
+            &method,
+            &args,
+            modifier.is_some(),
+            quoted,
+            want_ref,
+        ) {
             // Pure attribute read: does not mutate the invocant (see comment
             // above), so it does not dirty the caller's locals (Slice 6.3).
             self.stack.push(val);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -69,6 +69,7 @@ impl Interpreter {
         args: &[Value],
         has_modifier: bool,
         quoted: bool,
+        want_ref: bool,
     ) -> Option<Value> {
         if !args.is_empty() || has_modifier || quoted {
             return None;
@@ -139,12 +140,50 @@ impl Interpreter {
         // type); extending it to the mut path means an accessor read on a
         // *variable* (`$obj.x`, compiled as CallMethodMut) no longer falls back
         // to the interpreter.
-        let map = attributes.as_map();
         let priv_key = format!("{}!", method);
-        let val = map.get(method).or_else(|| map.get(&priv_key));
-        match val {
+        let (key, out) = {
+            let map = attributes.as_map();
+            match map.get(method) {
+                Some(v) => (method.to_string(), Some(v.clone())),
+                None => (priv_key.clone(), map.get(&priv_key).cloned()),
+            }
+        };
+        // `:=` bind RHS / `.VAR` chain: return the attribute slot's container
+        // identity (promoting the slot to a shared `ContainerRef` cell) instead
+        // of a value copy. Restricted to scalar-shaped slots — an `@`/`%`
+        // attribute value is already a shared container Arc, and the aggregate
+        // accessor path (with its container type metadata) lives on the
+        // interpreter side.
+        if want_ref
+            && matches!(
+                out,
+                Some(ref v) if !matches!(
+                    v.view(),
+                    ValueView::Array(..) | ValueView::Hash(_) | ValueView::Mixin(..)
+                )
+            )
+            && let Some(type_constraint) = self.rw_accessor_type_constraint(&cn, method)
+        {
+            let cell_val = attributes.promote_attr_to_container(&key);
+            // A typed rw attribute's constraint travels with the cell, so a
+            // later write through the bound alias (`$ref = v`) type-checks
+            // exactly like `$obj.x = v` does.
+            if let ValueView::ContainerRef(cell) = cell_val.view()
+                && let Some(tc) = type_constraint.as_ref()
+                && !matches!(tc.as_str(), "Mu" | "Any")
+            {
+                crate::value::register_container_constraint(cell, tc);
+            }
+            if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
+                loan_env!(self, check_deprecation_for_method(method, &cn, &msg));
+            }
+            return Some(cell_val);
+        }
+        match out {
             Some(v) => {
-                let out = v.clone();
+                // A slot promoted to a `ContainerRef` cell (a prior `:=` bind /
+                // `.VAR` mixin) is transparent to a plain accessor read.
+                let out = v.deref_container();
                 if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                     loan_env!(self, check_deprecation_for_method(method, &cn, &msg));
                 }
@@ -284,6 +323,9 @@ impl Interpreter {
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
         crate::vm::vm_stats::record_method_dispatch();
+        // Consume (and unconditionally clear) the accessor-ref marker: it is
+        // emitted immediately before this opcode and scoped to this one dispatch.
+        let want_ref = std::mem::take(&mut self.accessor_ref_pending);
         let arg_sources = self.decode_arg_sources(code, arg_sources_idx);
         self.set_pending_call_arg_sources(arg_sources.clone());
         let method_raw = Self::const_str(code, name_idx);
@@ -327,8 +369,18 @@ impl Interpreter {
         // (`ContainerRef`, e.g. a `.grep` rw alias / `:=`-bound slot extracted via
         // `.head`/`.first`) is transparent to method dispatch — decontainerize it
         // so the method runs on the inner value (Raku container semantics). `.VAR`
-        // is the one introspection method that wants the container itself.
+        // is the one introspection method that wants the container itself, and
+        // `^name`/`WHAT` right after a `.VAR` report the container type (raku:
+        // `$obj.attr.VAR.^name` is "Scalar", not the inner value's type).
         let target = if matches!(target.view(), ValueView::ContainerRef(_)) && method != "VAR" {
+            if args.is_empty() && matches!(method, "^name" | "WHAT") {
+                self.stack.push(if method == "^name" {
+                    Value::str("Scalar".to_string())
+                } else {
+                    Value::package(crate::symbol::Symbol::intern("Scalar"))
+                });
+                return Ok(());
+            }
             target.deref_container()
         } else {
             target
@@ -443,9 +495,14 @@ impl Interpreter {
         // overlay env (the common `$.attr` read inside a scoped method body) --
         // hence the `flatten_scoped_env` below is placed *after* it, so an
         // accessor read does not collapse the caller's scoped overlay.
-        if let Some(val) =
-            self.try_fast_accessor_read(&target, method, &args, modifier_idx.is_some(), quoted)
-        {
+        if let Some(val) = self.try_fast_accessor_read(
+            &target,
+            method,
+            &args,
+            modifier_idx.is_some(),
+            quoted,
+            want_ref,
+        ) {
             // Pure attribute read: touches no env (see comment above), so it does
             // not dirty the caller's locals (Slice 6.3 — removes the per-accessor
             // env->locals pull that dominated method-heavy code like bench-class).

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -661,6 +661,12 @@ impl Interpreter {
                 let is_bind_ctx = self.bind_context;
                 let is_rebind = self.rebind_context;
                 self.bind_context = false;
+                // Consume the scalar-bind marker here too: a topic bind
+                // (`$_ := $d`) compiles MarkScalarBindContext + SetGlobal, so
+                // without this the flag leaks into the NEXT SetLocal (e.g. a
+                // following `my $a = 0`), which would spuriously treat it as a
+                // value-bind and mark it readonly.
+                self.scalar_bind_context = false;
                 // Slice 2a: `our $n = @z` / a global scalar target reaches SetGlobal,
                 // not SetLocal/AssignExpr. Consume the array-share flag here (the
                 // global copies for now — reference sharing for globals is Slice 2d)
@@ -1118,6 +1124,7 @@ impl Interpreter {
                     if let Some(cell_val) = self.env().get(&name).cloned()
                         && let ValueView::ContainerRef(arc) = cell_val.view()
                     {
+                        self.check_container_cell_constraint(arc, &val)?;
                         // Preserve the inner container's identity (§3): a boxed
                         // captured `@a`/`%h` whole-reassigned here must keep its
                         // backing `Gc` so by-value holders observe the update.
@@ -1132,6 +1139,7 @@ impl Interpreter {
                         && let Some(cell_val) = self.env().get(alias_target.as_str()).cloned()
                         && let ValueView::ContainerRef(arc) = cell_val.view()
                     {
+                        self.check_container_cell_constraint(arc, &val)?;
                         Self::cell_store_preserving_container_identity(arc, &val);
                         *ip += 1;
                         return Ok(());
@@ -1605,6 +1613,10 @@ impl Interpreter {
             }
             OpCode::MarkRebindContext => {
                 self.rebind_context = true;
+                *ip += 1;
+            }
+            OpCode::MarkAccessorRefContext => {
+                self.accessor_ref_pending = true;
                 *ip += 1;
             }
             OpCode::MarkArrayShareSource(name_idx) => {

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,6 +1,25 @@
 use super::*;
 
 impl Interpreter {
+    /// Enforce a `ContainerRef` cell's registered `of`-type constraint before a
+    /// write-through (`$ref = v` on a `:=`-bound typed slot — a typed rw
+    /// attribute accessor bind, or a `my T $` anonymous typed scalar). Mirrors
+    /// the Pair.value enforcement in `methods_mut_method_lvalue.rs`.
+    pub(super) fn check_container_cell_constraint(
+        &mut self,
+        cell: &crate::gc::Gc<std::sync::Mutex<Value>>,
+        val: &Value,
+    ) -> Result<(), RuntimeError> {
+        if let Some(constraint) = crate::value::lookup_container_constraint(cell)
+            && !matches!(constraint.as_str(), "Any" | "Mu")
+            && !val.is_nil()
+            && !self.type_matches_value(&constraint, val)
+        {
+            return Err(RuntimeError::typecheck_assignment(&constraint, val, None));
+        }
+        Ok(())
+    }
+
     /// Slice 2a: clear the aggregate held inside a shared `ContainerRef` cell
     /// (`undefine @ary` where `my $r = @ary` promoted `@ary` to a cell). Uses
     /// `Arc::make_mut` so a copy taken out of the cell (`my @copy = @ary`) is

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -349,7 +349,9 @@ impl Interpreter {
                 // existing whole-reassignment semantics here.
                 let scalar = !name.starts_with('@') && !name.starts_with('%');
                 if scalar && !(self.array_share_active && self.is_array_share_scalar(&name)) {
-                    Value::store_through_cell(arc, &val);
+                    let arc = arc.clone();
+                    self.check_container_cell_constraint(&arc, &val)?;
+                    Value::store_through_cell(&arc, &val);
                     self.stack.push(val);
                     return Ok(());
                 }

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -346,6 +346,18 @@ impl Interpreter {
         // Snapshot for the precise BUILD/TWEAK captured-outer writeback (see
         // exec_does_var_op).
         let pre_env = self.snapshot_carrier_overwritable_env(code);
+        // `does` on a first-class container (`$obj.attr.VAR does Role`): compose
+        // onto the inner value and store the mixin back *through* the cell, so
+        // every alias of the container (the attribute slot, a `:=`-bound var)
+        // observes the mixin. The expression yields the container itself, so a
+        // chained `.name` read/write keeps the container identity.
+        if let ValueView::ContainerRef(cell) = left.view() {
+            let inner = cell.lock().unwrap().clone();
+            let result = self.vm_does_values(inner, right)?;
+            *cell.lock().unwrap() = result;
+            self.stack.push(left);
+            return Ok(());
+        }
         // `$a.container.VAR does Role(...)` inside a custom `trait_mod:<is>`:
         // record the role mixin against the owning attribute so construction
         // applies it to each instance's attribute value.

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -287,6 +287,7 @@ impl Interpreter {
         self.scalar_bind_context = false;
         self.bound_decont_active = false;
         self.rebind_context = false;
+        self.accessor_ref_pending = false;
         self.constant_context = false;
         self.array_share_context = false;
         self.array_share_source = None;

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -119,6 +119,7 @@ impl Interpreter {
                     if scalar {
                         val = Self::normalize_scalar_assignment_value(val);
                     }
+                    self.check_container_cell_constraint(&arc, &val)?;
                     Value::store_through_cell(&arc, &val);
                     self.stack.push(val);
                     self.flush_local_to_env(code, idx);
@@ -396,6 +397,7 @@ impl Interpreter {
             let scalar = !name.starts_with('@') && !name.starts_with('%');
             if scalar && !(self.array_share_active && self.is_array_share_scalar(name)) {
                 let arc = arc.clone();
+                self.check_container_cell_constraint(&arc, &val)?;
                 Value::store_through_cell(&arc, &val);
                 self.flush_local_to_env(code, idx);
                 self.stack.push(val);

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -201,6 +201,28 @@ impl Interpreter {
             let name = &code.locals[idx];
             self.update_bound_decont_marker(name, scalar_bind || is_bind, &raw_popped);
         }
+        // A scalar `:=` bound to a plain VALUE with no named source (`my $r :=
+        // $obj.ro-attr` — a non-rw accessor result, or any value-producing
+        // expression) is bound to that value itself, not a container: a later
+        // `$r = v` is "Cannot assign to an immutable value" in raku. Literal
+        // binds (`my $x := 5`) get this from the parser's MarkReadonly; this
+        // covers the runtime-only cases. Container-valued binds (ContainerRef /
+        // Array / Hash) stay writable through their container, and a Proxy
+        // stays writable through its STORE.
+        if scalar_bind
+            && bind_source.is_none()
+            && !matches!(
+                raw_popped.view(),
+                ValueView::ContainerRef(_)
+                    | ValueView::Array(..)
+                    | ValueView::Hash(_)
+                    | ValueView::Proxy { .. }
+            )
+        {
+            let bare = code.locals[idx].trim_start_matches(['$', '@', '%', '&']);
+            let bare = bare.to_string();
+            self.mark_readonly(&bare);
+        }
         // A sigilless `\target` bound to a multi-dim slice lvalue distributes a
         // plain whole-value reassignment (`target = values`, e.g. as a sub's
         // bare-statement return value) element-wise through its cells — the
@@ -328,6 +350,7 @@ impl Interpreter {
                     if scalar {
                         val = Self::normalize_scalar_assignment_value(val);
                     }
+                    self.check_container_cell_constraint(&arc, &val)?;
                     Value::store_through_cell(&arc, &val);
                     self.flush_local_to_env(code, idx);
                     return Ok(());
@@ -1445,6 +1468,7 @@ impl Interpreter {
                     let old = arc.lock().unwrap().clone();
                     val = self.array_container_writethrough_value(&name, val, &old)?;
                 }
+                self.check_container_cell_constraint(&arc, &val)?;
                 Value::store_through_cell(&arc, &val);
                 self.flush_local_to_env(code, idx);
                 return Ok(());

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -201,22 +201,27 @@ impl Interpreter {
             let name = &code.locals[idx];
             self.update_bound_decont_marker(name, scalar_bind || is_bind, &raw_popped);
         }
-        // A scalar `:=` bound to a plain VALUE with no named source (`my $r :=
-        // $obj.ro-attr` — a non-rw accessor result, or any value-producing
-        // expression) is bound to that value itself, not a container: a later
-        // `$r = v` is "Cannot assign to an immutable value" in raku. Literal
-        // binds (`my $x := 5`) get this from the parser's MarkReadonly; this
-        // covers the runtime-only cases. Container-valued binds (ContainerRef /
-        // Array / Hash) stay writable through their container, and a Proxy
-        // stays writable through its STORE.
+        // A scalar `:=` bound to a plain immutable VALUE with no named source
+        // (`my $r := $obj.ro-attr` — a non-rw accessor result) is bound to that
+        // value itself, not a container: a later `$r = v` is "Cannot assign to
+        // an immutable value" in raku. Literal binds (`my $x := 5`) get this
+        // from the parser's MarkReadonly; this covers the runtime-only cases.
+        // Deliberately an ALLOWLIST of pure immutable scalar kinds: anything
+        // container-like or writable-through (ContainerRef, Proxy STORE,
+        // HashEntryRef deferred binds, `is raw` results, ...) must stay
+        // writable, and an overlooked kind here turns into a hard runtime
+        // error, so the conservative direction is to mark less.
         if scalar_bind
             && bind_source.is_none()
-            && !matches!(
+            && matches!(
                 raw_popped.view(),
-                ValueView::ContainerRef(_)
-                    | ValueView::Array(..)
-                    | ValueView::Hash(_)
-                    | ValueView::Proxy { .. }
+                ValueView::Int(_)
+                    | ValueView::BigInt(_)
+                    | ValueView::Num(_)
+                    | ValueView::Str(_)
+                    | ValueView::Bool(_)
+                    | ValueView::Rat(..)
+                    | ValueView::Complex(..)
             )
         {
             let bare = code.locals[idx].trim_start_matches(['$', '@', '%', '&']);

--- a/t/attr-accessor-slot.t
+++ b/t/attr-accessor-slot.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# Attribute accessors are slot-based (BLOCKERS §3.2 item 2):
+# - `my $ref := $obj.attr` binds the attribute's container (bidirectional)
+# - `$obj.attr.VAR does Role` mixes into the attribute container; the mixin
+#   attribute is readable and rw-writable through `.VAR.name`
+# All expectations verified against rakudo.
+
+plan 18;
+
+class A {
+    has $.x is rw = 10;
+    method bump { $!x++ }
+    method get  { $!x }
+}
+
+# --- bind to rw scalar accessor: container identity ---
+{
+    my $obj = A.new;
+    my $ref := $obj.x;
+    is $ref, 10, 'bound ref reads the attribute value';
+    $obj.x = 20;
+    is $ref, 20, 'accessor write is visible through the bound ref';
+    $ref = 30;
+    is $obj.x, 30, 'ref write is visible through the accessor';
+    $obj.bump;
+    is $ref, 31, 'method-internal $!x++ is visible through the bound ref';
+    $ref = 50;
+    is $obj.get, 50, 'ref write is visible to a method-internal $!x read';
+    is $obj.gist, 'A.new(x => 50)', 'gist renders the inner value, not the cell';
+    is $obj.raku, 'A.new(x => 50)', 'raku renders the inner value, not the cell';
+
+    # clone detaches from the shared slot
+    my $c = $obj.clone;
+    $c.x = 99;
+    is $obj.x, 50, 'clone write does not reach the original attribute';
+    is $ref, 50, 'clone write does not reach the bound ref';
+}
+
+# --- .VAR distinguishes rw container from non-rw value ---
+{
+    class B { has $.y = 5; has $.z is rw = 6 }
+    my $b = B.new;
+    is $b.y.VAR.^name, 'Int', 'non-rw accessor result has no container (.VAR is the value)';
+    is $b.z.VAR.^name, 'Scalar', 'rw accessor result is a Scalar container';
+
+    my $r := $b.y;
+    throws-like { $r = 9 }, Exception, 'assigning through a value-bound ref dies';
+    is $b.y, 5, 'the non-rw attribute is untouched';
+}
+
+# --- typed rw attribute: constraint travels with the bound container ---
+{
+    class C { has Int $.x is rw = 1 }
+    my $c = C.new;
+    my $rc := $c.x;
+    throws-like { $rc = "foo" }, Exception, 'type check enforced through the bound ref';
+    is $c.x, 1, 'failed assignment leaves the attribute untouched';
+    $rc = 42;
+    is $c.x, 42, 'conforming assignment through the bound ref succeeds';
+}
+
+# --- mixin on the attribute container via .VAR does ---
+{
+    role Named { has $.name is rw = "anon" }
+    my $obj = A.new;
+    $obj.x.VAR does Named;
+    is $obj.x.VAR.name, 'anon', 'role attribute readable through .VAR after does';
+    $obj.x.VAR.name = "bob";
+    is $obj.x.VAR.name, 'bob', 'rw write through .VAR.name updates the mixin';
+}

--- a/t/tail-function.t
+++ b/t/tail-function.t
@@ -26,7 +26,5 @@ sub make-predictive-seq($i = 0) {
 }
 
 is-deeply make-predictive-seq.tail, 10, 'tail uses PredictiveIterator count-only path';
-# TODO: $!attr := binding doesn't propagate through $!attr++ (pre-existing)
-todo '$!attr binding propagation';
 is $pulled, 1, 'PredictiveIterator tail calls pull-one once';
 is-deeply (4, 5, 6, 7).tail(-2**100), (), 'tail accepts large negative Int counts';


### PR DESCRIPTION
## Summary

BLOCKERS §3.2 item 2 (属性 accessor を value copy ではなく slot 経由にする) — the two remaining behaviors:

- `my $ref := $obj.attr` — binding to a public **rw** scalar accessor now shares the attribute slot's `ContainerRef` cell: writes through either side (`$obj.attr = v`, `$ref = v`, method-internal `$!attr++`) are visible to both, matching rakudo.
- `$obj.attr.VAR does Role` + `$obj.attr.VAR.name = v` — the mixin composes onto the attribute **container** (stored through the cell) and its rw role attributes are readable/writable through `.VAR`.

## Mechanism

- New `MarkAccessorRefContext` opcode, emitted immediately before the `CallMethod(Mut)` of a scalar `:=` bind RHS and of the inner call of a `.VAR` chain. Consumed (`mem::take`) at dispatch entry — scoped to exactly one dispatch, no pending-state residue (the #4355 lesson).
- `try_fast_accessor_read` promotes the attr map entry to a `ContainerRef` cell (`InstanceAttrs::promote_attr_to_container`, idempotent, single write lock) and returns the cell; plain reads decont promoted entries transparently.
- Promotion is gated on `is rw`: a non-rw accessor keeps returning the decont'd value, and a `:=` to it leaves the ref immutable (`Cannot assign to an immutable value`), as in rakudo. `$b.y.VAR.^name` is `Int` for non-rw, `Scalar` for rw.
- Typed rw attributes register their constraint on the cell; all scalar cell write-through sites now enforce registered constraints, so `my $r := $c.x; $r = "foo"` type-checks like a direct accessor assignment.
- Accessor lvalue writes go through the cell (no clobber); `.clone` snapshots promoted entries so clones detach.
- Fixed a latent flag leak found by the new readonly rule: a topic bind (`$_ := $d`) compiles to `SetGlobal`, which never consumed `scalar_bind_context`, letting it leak into the next `SetLocal`.

## Testing

- Pin: `t/attr-accessor-slot.t` (18 tests, all expectations verified against rakudo).
- `t/tail-function.t` の todo「$!attr binding propagation」が本変更で通るようになったため un-todo。
- `make test` PASS (1600 files / 15668 tests).
- Targeted roast (release build): all 280 whitelisted files under S03-binding / S12-* / S14-* / S02-names-vars / S02-types / S32-array / S32-hash / S06-signature PASS.
- Full roast is delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW