### PR TITLE
fix(vm): stop a nested := bind from clobbering a caller local at the same slot index

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1071,16 +1071,23 @@ impl Interpreter {
                         }
                         // Propagate to saved call frames (env AND locals)
                         for frame in self.call_frames.iter_mut().rev() {
+                            // `code.locals` is this frame's slot layout, not the
+                            // parent's; only write a parent frame's `saved_locals`
+                            // when that frame owns the source lexical (its saved env
+                            // holds the name), else the callee slot index clobbers an
+                            // unrelated same-index local.
                             if frame.saved_env.contains_key(&resolved_source) {
                                 frame
                                     .saved_env
                                     .insert(resolved_source.clone(), container.clone());
-                            }
-                            // Also update saved locals so a later restore doesn't
-                            // overwrite the ContainerRef with a stale plain value.
-                            for (i, local_name) in code.locals.iter().enumerate() {
-                                if local_name == &resolved_source && i < frame.saved_locals.len() {
-                                    frame.saved_locals[i] = container.clone();
+                                // Also update saved locals so a later restore doesn't
+                                // overwrite the ContainerRef with a stale plain value.
+                                for (i, local_name) in code.locals.iter().enumerate() {
+                                    if local_name == &resolved_source
+                                        && i < frame.saved_locals.len()
+                                    {
+                                        frame.saved_locals[i] = container.clone();
+                                    }
                                 }
                             }
                         }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -524,14 +524,18 @@ impl Interpreter {
         // Propagate the shared cell into saved call frames so the sharing
         // survives method returns (env restore).
         for frame in self.call_frames.iter_mut().rev() {
+            // `code.locals` is this frame's slot layout, not the parent's; only
+            // write a parent frame's `saved_locals` when that frame owns the source
+            // lexical (its saved env holds the name), else the callee slot index
+            // clobbers an unrelated same-index local.
             if frame.saved_env.contains_key(&resolved_source) {
                 frame
                     .saved_env
                     .insert(resolved_source.clone(), container.clone());
-            }
-            for (i, local_name) in code.locals.iter().enumerate() {
-                if local_name == &resolved_source && i < frame.saved_locals.len() {
-                    frame.saved_locals[i] = container.clone();
+                for (i, local_name) in code.locals.iter().enumerate() {
+                    if local_name == &resolved_source && i < frame.saved_locals.len() {
+                        frame.saved_locals[i] = container.clone();
+                    }
                 }
             }
         }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1300,14 +1300,22 @@ impl Interpreter {
                 // binding survives method returns (env restore) without
                 // reverting to a stale value (same as the scalar path below).
                 for frame in self.call_frames.iter_mut().rev() {
+                    // Only touch a parent frame that genuinely shares this lexical
+                    // (its saved env holds the name). `code.locals` is THIS frame's
+                    // slot layout, NOT the parent's, so a slot index `i` found here
+                    // means a different variable in a frame that does not have the
+                    // source — writing `saved_locals[i]` there would clobber an
+                    // unrelated same-index local (e.g. a callee's `@p` landing on a
+                    // caller's `$config`). Gate the locals write on the frame owning
+                    // the name.
                     if frame.saved_env.contains_key(&effective_source) {
                         frame
                             .saved_env
                             .insert(effective_source.clone(), container.clone());
-                    }
-                    for (i, local_name) in code.locals.iter().enumerate() {
-                        if local_name == &effective_source && i < frame.saved_locals.len() {
-                            frame.saved_locals[i] = container.clone();
+                        for (i, local_name) in code.locals.iter().enumerate() {
+                            if local_name == &effective_source && i < frame.saved_locals.len() {
+                                frame.saved_locals[i] = container.clone();
+                            }
                         }
                     }
                 }
@@ -1358,14 +1366,19 @@ impl Interpreter {
                 // so the binding survives method returns (env restore) and a
                 // later restore doesn't overwrite with stale values.
                 for frame in self.call_frames.iter_mut().rev() {
+                    // See the note in the outer-frame bind path above: `code.locals`
+                    // is this frame's slot layout, not the parent's, so only write a
+                    // parent frame's `saved_locals` when that frame actually owns the
+                    // source lexical (its saved env holds the name) — otherwise the
+                    // callee's slot index clobbers an unrelated same-index local.
                     if frame.saved_env.contains_key(&resolved_source) {
                         frame
                             .saved_env
                             .insert(resolved_source.clone(), container.clone());
-                    }
-                    for (i, local_name) in code.locals.iter().enumerate() {
-                        if local_name == &resolved_source && i < frame.saved_locals.len() {
-                            frame.saved_locals[i] = container.clone();
+                        for (i, local_name) in code.locals.iter().enumerate() {
+                            if local_name == &resolved_source && i < frame.saved_locals.len() {
+                                frame.saved_locals[i] = container.clone();
+                            }
                         }
                     }
                 }

--- a/t/bind-saved-locals-slot-leak.t
+++ b/t/bind-saved-locals-slot-leak.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# Regression: a `:=` bind of a callee-local container (`$!attr := @p`) inside a
+# nested method/protect block used to propagate its shared cell into EVERY saved
+# call frame's `saved_locals` by the CALLEE's slot index, clobbering an unrelated
+# caller lexical that happened to share that slot index. Concretely, mainline's
+# `$config` (a Hash at slot 1) got overwritten by the callee's empty `@p` (also
+# slot 1 in the callee), so `$config.^name`/`.WHICH` reported `Array` while the
+# value was still a genuine Hash. See tmp/lexical-corruption-repro.raku.
+
+plan 6;
+
+role Plug {
+    has $!plugins;
+    has $!lock = Lock.new;
+    method plugins() {
+        $!lock.protect: {
+            return $!plugins if $!plugins.so;   # guard that does NOT fire
+            my @p;
+            return $!plugins := @p;             # `:=` bind of a callee-local
+        }
+    }
+}
+class Repo does Plug {
+    submethod TWEAK { self.plugins; }
+}
+
+my %h = a => 1, b => 2;
+my $config = %h;
+my $r = Repo.new;
+
+is $config.^name, 'Hash', 'caller lexical keeps its type name after nested :=';
+is $config.WHICH.Str.substr(0, 5), 'Hash|', '.WHICH still reports a Hash';
+ok $config ~~ Hash, 'value still smartmatches Hash';
+nok $config ~~ Array, 'value does not smartmatch Array';
+is $config<a>, 1, 'associative indexing still works';
+is $config.keys.sort.join(','), 'a,b', 'keys are intact';


### PR DESCRIPTION
## Problem

When a `:=` bind establishes a shared `ContainerRef` cell, the VM propagates the
cell into every saved call frame's `saved_locals` so the binding survives method
returns. The slot index was found by scanning the **current (callee)** frame's
`code.locals`, then that same index was written into **each parent frame's**
`saved_locals`. Since every frame has its own slot layout, the callee's slot
index names a *different* variable in the parent.

A callee-local container — e.g. a `Lock.protect` block's `my @p` at slot 1 —
therefore overwrote an unrelated caller lexical sharing that slot index — e.g.
mainline's `$config` at slot 1 — corrupting its apparent type. `$config.^name`
and `.WHICH` reported `Array` while the value was a genuine Hash (`~~ Hash`,
`.keys`, `$config<a>`, associative indexing all still worked). The first read
returned the stale `@p`; a subsequent env-based reconcile healed it, so it was an
intermittent, read-order-dependent corruption.

Minimal repro (mutsu printed `Array`, raku prints `Hash`):

```raku
role Plug {
    has $!plugins;
    has $!lock = Lock.new;
    method plugins() {
        $!lock.protect: {
            return $!plugins if $!plugins.so;   # guard that does NOT fire
            my @p;
            return $!plugins := @p;             # `:=` bind of a callee-local
        }
    }
}
class Repo does Plug { submethod TWEAK { self.plugins } }
my %h = a => 1, b => 2;
my $config = %h;
Repo.new;
say $config.^name;   # was "Array" (BUG), now "Hash"
```

## Fix

Gate each parent frame's `saved_locals` write on that frame **genuinely owning
the source lexical** (its `saved_env` holds the name), mirroring the guard
already used for the `saved_env` propagation right above it. A frame that does
not have the source in scope is now left untouched instead of having an
unrelated same-index local clobbered.

Applied at all three bind/share sites: `vm_var_assign_set_local.rs` (x2),
`vm_var_assign_coerce.rs`, and `vm_exec_dispatch.rs`.

## Impact

This was the gate blocking zef's upstream `distribution-depends-parsing` test 19
(the `Array does not support associative indexing` on `Zef::Client`'s `%!config`);
that symptom is now gone and the test progresses past it.

## Testing

- New regression test `t/bind-saved-locals-slot-leak.t` (6 subtests).
- `make test` passes (cargo test 533/0, prove `t/` clean; the only `-j4` blip was
  `t/io-socket-recv-limit.t`, a network-timing flake that passes in isolation and
  serially).
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
- Spot-checked binding/closure/lock roast + `t/` suites (S03-binding/nested,
  S12-construction/roles-6e, S17-supply/zip-latest, all `t/bind-*`/`t/closure-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)