### PR TITLE
fix(vm,runtime): element mutations write through the shared container node (container identity §3)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -98,17 +98,29 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
 - `S26-documentation/12-non-breaking-space.t`（top-level BEGIN compile-time hoist）→ `news/2026-07.md`
 - `S02-names-vars/variables-and-packages.t`（nested-block BEGIN hoist）→ `news/2026-07.md`
 
-**残る別軸の残課題**: closure-captured shared-cell を list へ by-value 捕捉した
-ときのスナップショット追従（return-writeback 系・`splice.t` の `ident4`）。
+**closure-captured shared-cell の by-value list 捕捉スナップショット追従
+（return-writeback 系・`splice.t` の `ident4`）は DONE** — §3.2 item 1 の
+element-mutation in-place 化で一括解決（`t/container-identity-mutation.t` の
+cell:/returned-capture ケースが pin）。
 （`$my_ref := $obj.attr` と `$obj.attr.VAR.role = v` は §3.2 item 2 で DONE。）
 
 ### 3.2 サブキャンペーンと choke point
 
-1. **配列/ハッシュ要素 cell 化**
+1. **配列/ハッシュ要素 cell 化** — **element mutation の in-place 化は DONE**
    - 依存文書: `docs/container-identity.md`
    - 変更レイヤ: `value/mod.rs`、`vm_var_assign_ops.rs`、`vm_var_index_ops.rs`
-   - 対象: `splice.t`（multislice は §2.3 で完了・#4355）
-   - 完了条件: element bind / take-rw / deep nested write が post-call writeback なしで成立
+   - **DONE (2026-07-09)**: 全 element-level mutation（push/pop/shift/unshift/
+     splice/append/prepend・要素/slice 代入・hash key write/:delete/++/--・
+     multidim・nested・typed/defaulted・ContainerRef cell 経路）を
+     `Gc::make_mut`（COW detach）から共有ノードへの in-place 書込
+     （`gc_data_mut`/`gc_contents_mut`）へ切替。copy 独立性は copy 時 detach
+     （`Value::detach_shared_container` — `my @b = @a` / `is copy` param）が担保。
+     by-value holder（`(0, @a)` capture・要素・scalar）が全 mutation を追従。
+     副修正: `@a[i].splice` の返り値誤 writeback（compiler の pop/shift ブランチへ
+     合流）・slow-path `do_splice` の self-splice replacement 読みを drain 前へ。
+     Pin: `t/container-identity-mutation.t`（55、raku 一致）。
+   - 残: post-call writeback 機構そのものの削減（push 系 method-on-index の
+     result-writeback は in-place により冗長になったが残置・害なし）。
 2. **属性 accessor を value copy ではなく slot 経由にする** — **DONE**
    - `Attribute.container.VAR does Role` は #4314 で完了（§3.1 参照）。
    - `$my_ref := $obj.attr`（rw scalar accessor への `:=` 束縛が属性 slot の
@@ -133,10 +145,11 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
 - whole-container / env-local coherence: `docs/env-locals-coherence.md`,
   `src/vm/vm_env_helpers.rs`, `SetLocal` / `flush_local_to_env` / bound-container metadata
 
-- **Next slice**: `splice.t` の self-splice ケースから、配列 write を helper 経由へさらに
-  寄せて post-call writeback 依存を 1 段減らす。
+- **Next slice**: 残る `Gc::make_mut` サイト（`vm_var_multidim_ops.rs`・
+  `runtime/builtins_multidim.rs`・shared_vars 経路等）の棚卸し — 変数自身の
+  コンテナ mutation なら `gc_data_mut` へ、派生コピーの構築なら現状維持。
 - **Canary tests**: `roast/S32-array/splice.t`,
-  `roast/S02-names-vars/variables-and-packages.t`
+  `roast/S02-names-vars/variables-and-packages.t`, `t/container-identity-mutation.t`
 
 ---
 
@@ -170,13 +183,12 @@ whitelist 済み（`splice.t`・`whatever.t`・`S14-traits/attributes.t`（#4314
 「次に何をやるか」を 1 本だけ選ぶなら、これ:
 
 1. **第一級コンテナ campaign**（§3）— `docs/container-identity.md` に沿って
-   multislice hash 側の slot identity を前に進める。
-   これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
+   進める。これは腰を据えた基盤工事で、個々のテストを直接潰すより効果が大きい。
    **進捗（2026-07-09）**: whole-container 代入の container-identity（`splice.t`）、
    属性 container mixin（`S14-traits/attributes.t`・#4314）、属性 slot の完全な
-   cell 化（`:=` 束縛・mixin accessor への rw 書込、§3.2 item 2）は完了。
-   残るは closure-captured shared-cell を list へ by-value 捕捉したときの
-   スナップショット追従（return-writeback 系・`splice.t` の `ident4`）。
+   cell 化（§3.2 item 2）、**element mutation の in-place 化（§3.2 item 1）と
+   ident4 系スナップショット追従**まで完了。残るは §3.2 の Next slice
+   （残 `make_mut` サイトの棚卸し）と post-call writeback 機構の削減。
 
 かつて 2 番手だった cross-thread lexical writeback campaign（旧 §4.1）は完了
 （`S17-lowlevel/lock.t`・`S32-io/socket-recv-vs-read.t` とも whitelist 済み、

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -177,11 +177,36 @@ pub(super) fn dispatch(
                 // `shape`, element type) survives the copy — e.g.
                 // `@a[3]:delete; my @b := @a.clone` keeps `@b[3]:exists` False
                 // (S02-types/array.t test 108). Elements are `Value`-cloned
-                // (shared handles), matching a shallow `.clone`.
-                ValueView::Array(items, kind) => Some(Some(Ok(Value::array_with_kind(
-                    crate::gc::Gc::new((**items).clone()),
-                    kind,
-                )))),
+                // (shared handles), matching a shallow `.clone` — EXCEPT for a
+                // shaped array, whose rows are its own storage: rakudo's
+                // `.clone` gives independent containers per dimension
+                // (rakudo#3334, S09-multidim/methods.t), and with in-place
+                // element writes (container identity §3) shared rows would
+                // alias `@a[1;1] = v` into the clone.
+                ValueView::Array(items, kind) => {
+                    let mut data = (**items).clone();
+                    if kind == crate::value::ArrayKind::Shaped || data.shape.is_some() {
+                        fn clone_rows(v: &Value) -> Value {
+                            match v.view() {
+                                ValueView::Array(rows, k) => {
+                                    let mut d = (**rows).clone();
+                                    for item in d.items.iter_mut() {
+                                        *item = clone_rows(item);
+                                    }
+                                    Value::array_with_kind(crate::gc::Gc::new(d), k)
+                                }
+                                _ => v.clone(),
+                            }
+                        }
+                        for item in data.items.iter_mut() {
+                            *item = clone_rows(item);
+                        }
+                    }
+                    Some(Some(Ok(Value::array_with_kind(
+                        crate::gc::Gc::new(data),
+                        kind,
+                    ))))
+                }
                 ValueView::Hash(map) => Some(Some(Ok(Value::hash_with_data(Value::hash_arc(
                     (**map).clone(),
                 ))))),

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -152,7 +152,12 @@ impl Compiler {
             let name_resolved = name.resolve();
             let arity = args.len() as u32;
             let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
-            if matches!(name_resolved.as_str(), "pop" | "shift") {
+            // pop/shift/splice return something OTHER than the mutated array
+            // (the removed element(s)), so the writeback must store the
+            // mutated INVOCANT back into the element and yield the method
+            // result separately. push/append/unshift/prepend return the
+            // array itself, so the plain result-writeback branch suffices.
+            if matches!(name_resolved.as_str(), "pop" | "shift" | "splice") {
                 let tmp_target_name = format!(
                     "__mutsu_tmp_index_method_target_{}",
                     self.code.constants.len()

--- a/src/runtime/methods_collection_ops/unique_squish.rs
+++ b/src/runtime/methods_collection_ops/unique_squish.rs
@@ -242,8 +242,23 @@ impl Interpreter {
             return Ok(Value::seq(Vec::new()));
         }
 
+        // Snapshot the env BY VALUE (container contents detached): the eager
+        // pass below runs the user callbacks whose side effects (`@with.push`)
+        // now mutate containers IN PLACE through the shared backing node
+        // (container identity §3) — a plain `env.clone()` would share those
+        // nodes, making the changed-value diff below blind and the revert a
+        // no-op, so the lazy iterator's re-run would double the side effects.
         let env_before_callbacks = if as_func.is_some() || with_func.is_some() {
-            Some(self.env.clone())
+            let mut snapshot = self.env.clone();
+            let detach: Vec<(crate::symbol::Symbol, Value)> = snapshot
+                .iter()
+                .filter(|(_, v)| matches!(v.view(), ValueView::Array(..) | ValueView::Hash(..)))
+                .map(|(k, v)| (*k, v.clone().detach_shared_container()))
+                .collect();
+            for (k, v) in detach {
+                snapshot.insert_sym(k, v);
+            }
+            Some(snapshot)
         } else {
             None
         };

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -630,7 +630,8 @@ impl Interpreter {
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
-                            let items = crate::gc::Gc::make_mut(arc_items);
+                            // Container identity (§3): append through a shared node.
+                            let items = crate::value::gc_data_mut(arc_items);
                             items.extend(flat_values.iter().cloned());
                             Value::array_with_kind(crate::gc::Gc::clone(arc_items), kind)
                         }) {
@@ -654,7 +655,8 @@ impl Interpreter {
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
-                            let items = crate::gc::Gc::make_mut(arc_items);
+                            // Container identity (§3): insert through a shared node.
+                            let items = crate::value::gc_data_mut(arc_items);
                             for (i, arg) in normalized_args.iter().enumerate() {
                                 items.insert(i, arg.clone());
                             }
@@ -681,7 +683,8 @@ impl Interpreter {
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
-                            let items = crate::gc::Gc::make_mut(arc_items);
+                            // Container identity (§3): insert through a shared node.
+                            let items = crate::value::gc_data_mut(arc_items);
                             for (i, arg) in flat_values.iter().enumerate() {
                                 items.insert(i, arg.clone());
                             }
@@ -731,7 +734,8 @@ impl Interpreter {
                             .get_mut(&key)
                             .unwrap()
                             .with_array_mut(|arc_items, _| {
-                                crate::gc::Gc::make_mut(arc_items)
+                                // Container identity (§3): pop through a shared node.
+                                crate::value::gc_data_mut(arc_items)
                                     .pop()
                                     .unwrap_or(Value::NIL)
                             })
@@ -771,7 +775,8 @@ impl Interpreter {
                             .get_mut(&key)
                             .unwrap()
                             .with_array_mut(|arc_items, _| {
-                                crate::gc::Gc::make_mut(arc_items).remove(0)
+                                // Container identity (§3): shift through a shared node.
+                                crate::value::gc_data_mut(arc_items).remove(0)
                             })
                             .unwrap()
                     } else {
@@ -818,8 +823,11 @@ impl Interpreter {
                             .unwrap_or(len.saturating_sub(start) as i64)
                             .max(0) as usize;
                         let end = (start + count).min(len);
-                        let removed: Vec<Value> = items.drain(start..end).collect();
-                        // Collect all replacement values from args[2..]
+                        // Collect all replacement values from args[2..] BEFORE
+                        // draining: `items` is now mutated in place through the
+                        // shared backing node (container identity §3), so a
+                        // self-splice replacement (`splice(@a, .., @a)`) aliases
+                        // `items` and must be snapshotted pre-drain.
                         let mut new_items: Vec<Value> = Vec::new();
                         for arg in args.iter().skip(2) {
                             match arg.view() {
@@ -829,6 +837,7 @@ impl Interpreter {
                                 _ => new_items.push(arg.clone()),
                             }
                         }
+                        let removed: Vec<Value> = items.drain(start..end).collect();
                         for (i, item) in new_items.into_iter().enumerate() {
                             items.insert(start + i, item);
                         }
@@ -1022,7 +1031,8 @@ impl Interpreter {
                     }
                     let removed = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, _| {
-                            let items = crate::gc::Gc::make_mut(arc_items);
+                            // Container identity (§3): splice through a shared node.
+                            let items = crate::value::gc_data_mut(arc_items);
                             do_splice(items, &resolved_args)
                         }) {
                         r
@@ -1174,7 +1184,8 @@ impl Interpreter {
                                 .get_mut(&key)
                                 .unwrap()
                                 .with_hash_mut(|arc_hash| {
-                                    let hash = crate::gc::Gc::make_mut(arc_hash);
+                                    // Container identity (§3): push through a shared node.
+                                    let hash = crate::value::gc_data_mut(arc_hash);
                                     for (k, v) in kv_pairs {
                                         let wk = if is_object_hash {
                                             crate::runtime::utils::value_which_key(&k)
@@ -1230,7 +1241,8 @@ impl Interpreter {
                             .get_mut(&key)
                             .unwrap()
                             .with_hash_mut(|arc_hash| {
-                                let hash = crate::gc::Gc::make_mut(arc_hash);
+                                // Container identity (§3): push through a shared node.
+                                let hash = crate::value::gc_data_mut(arc_hash);
                                 for (k, v) in pairs {
                                     Self::hash_push_insert(hash, k, v, is_push);
                                 }

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -89,15 +89,21 @@ impl Interpreter {
             crate::runtime::utils::mark_shaped_array(&value, Some(dims));
             return Ok(value);
         }
-        let child = Self::make_shaped_array(&dims[1..])?;
-        crate::runtime::utils::mark_shaped_array(&child, Some(&dims[1..]));
         let mut items = Vec::new();
         items.try_reserve(len).map_err(|_| {
             RuntimeError::new(format!(
                 "Cannot allocate shaped array of {len} elements: memory allocation failed"
             ))
         })?;
-        items.extend((0..len).map(|_| child.clone()));
+        // Each row must be a DISTINCT container (fresh backing `Gc` per row):
+        // element writes mutate through the shared node (container identity
+        // §3), so rows cloned from one child would all observe each other's
+        // writes (`@md[0;0] = v` would set `[1;0]` too).
+        for _ in 0..len {
+            let child = Self::make_shaped_array(&dims[1..])?;
+            crate::runtime::utils::mark_shaped_array(&child, Some(&dims[1..]));
+            items.push(child);
+        }
         let value = Value::shaped_array(items);
         crate::runtime::utils::mark_shaped_array(&value, Some(dims));
         Ok(value)

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1233,6 +1233,14 @@ impl Interpreter {
                         .clone()
                         .or_else(|| pd.type_constraint.clone());
                     let mut value = unwrap_varref_value(raw_arg.clone());
+                    // Container identity (§3): an `is copy` container param owns
+                    // a DISTINCT container. Mutations now write through the
+                    // shared backing node (no COW detach), so the copy must
+                    // detach HERE or `@b.push` inside the sub would reach the
+                    // caller's `@a`.
+                    if is_copy {
+                        value = value.detach_shared_container();
+                    }
                     if pd.sigilless {
                         let alias_key = sigilless_alias_key(&pd.name);
                         let readonly_key = sigilless_readonly_key(&pd.name);

--- a/src/value/aliased_mut.rs
+++ b/src/value/aliased_mut.rs
@@ -87,3 +87,32 @@ pub(crate) unsafe fn gc_contents_mut<T: crate::gc::Trace + 'static>(
     // SAFETY: delegated to the caller per the same contract as arc_contents_mut.
     unsafe { &mut *(crate::gc::Gc::as_ptr(gc) as *mut T) }
 }
+
+/// Shared-aware mutable access to a container's backing data for a mutation
+/// of the *variable's own container* (container identity, §3): when the node
+/// is aliased (`strong_count > 1` — e.g. the array was captured by value into
+/// a list `(0, @a)`, stored in an element, or bound), write THROUGH the
+/// shared node so every holder observes the mutation; when exclusively owned,
+/// plain `Gc::make_mut` access (which does not clone at `strong_count == 1`).
+///
+/// This is the mutation-side counterpart of `detach_shared_container`: Raku
+/// `=` copy semantics are enforced at copy time (detach), so a mutation must
+/// never COW-detach the container from its aliases.
+///
+/// # Safety (inherited)
+///
+/// The aliased branch is [`gc_contents_mut`] — the caller must uphold the
+/// same contract: no other borrow into this node live for the duration of
+/// the returned `&mut`, and no concurrent access from another thread.
+pub(crate) fn gc_data_mut<T: crate::gc::Trace + Clone + 'static>(
+    gc: &mut crate::gc::Gc<T>,
+) -> &mut T {
+    if crate::gc::Gc::strong_count(gc) > 1 {
+        // SAFETY: audited aliased in-place container write per the module
+        // contract; callers keep no competing borrow live across the returned
+        // `&mut` (single-threaded VM mutation paths).
+        unsafe { gc_contents_mut(gc) }
+    } else {
+        crate::gc::Gc::make_mut(gc)
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -306,6 +306,7 @@ mod value_methods_c;
 mod value_setbagmix;
 mod view;
 pub(crate) use crate::gc::gc_contents_mut;
+pub(crate) use aliased_mut::gc_data_mut;
 pub(crate) use types::what_type_name;
 pub use view::ValueView;
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1081,10 +1081,17 @@ pub enum Value {
     ///   at a time by `exec_index_autovivify_lazy_op`.
     ///
     /// It also serves `is raw` reduce lvalue descent (`hash_autovivify`), where
-    /// the entry is eagerly created first so the path is always length 1.
+    /// the entry is eagerly created first so the path is always length 1 —
+    /// those tokens set `eager: true` and reads see through to the (already
+    /// created) plain entry value. A deferred bind token (`eager: false`)
+    /// connects on read ONLY via the `ContainerRef` cell installed by a write
+    /// through the bound var: with in-place hash writes (container identity
+    /// §3) an independent `%g<x><y> = 42` reaches the token's captured root,
+    /// and rakudo does not retro-bind that (t/phantom-entry-bind.t).
     HashEntryRef {
         hash: Gc<HashData>,
         path: Vec<String>,
+        eager: bool,
     },
 }
 

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -785,6 +785,7 @@ mod tests {
         let value = Value::HashEntryRef {
             hash,
             path: vec!["k".to_string()],
+            eager: false,
         };
         assert_eq!(gc_trace_node_count(&value), 1);
     }

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -63,11 +63,17 @@ impl Clone for InstanceAttrs {
         let mut map = read_attrs(&self.attributes).clone();
         // Snapshot any `ContainerRef`-promoted slot (a `:=`-bound attribute):
         // an independent copy must not alias the original's attribute cell.
+        // Likewise detach Array/Hash attribute values: element mutations write
+        // through the shared backing node (container identity §3), so a copy
+        // sharing the `Gc` would observe the original's `@!attr.push` — an
+        // independent copy must own distinct containers (rakudo `.clone`
+        // clones each `has` container too).
         for v in map.values_mut() {
             if let Value::ContainerRef(cell) = v {
                 let inner = cell.lock().unwrap().clone();
                 *v = inner;
             }
+            *v = std::mem::replace(v, Value::NIL).detach_shared_container();
         }
         Self {
             class_name: self.class_name,

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -443,6 +443,16 @@ impl Value {
     /// READ-ONLY (no autovivification). Returns `Any` if any intermediate level
     /// is missing or not a hash, or if the terminal key is absent — so a bind to
     /// a not-yet-existent entry reads as `Any` without polluting `:exists`.
+    ///
+    /// A deferred missing-key bind connects ONLY when written THROUGH the
+    /// bound var (`store_through_cell` installs a `ContainerRef` cell at the
+    /// path on first write). A terminal holding a plain value was written
+    /// independently through the hash path AFTER the bind — rakudo does not
+    /// retro-bind that (t/phantom-entry-bind.t), so it reads as `Any` here.
+    /// (Pre-§3, the independent write COW-detached the root and the token's
+    /// captured `Gc` stayed empty, which masked this; in-place hash writes
+    /// now reach the captured root, so the connect condition must be the
+    /// cell identity, not mere path existence.)
     pub fn hash_entry_read(&self) -> Value {
         let Value::HashEntryRef { hash, path } = self else {
             return self.clone();
@@ -458,7 +468,12 @@ impl Value {
         }
         let last = path.last().unwrap();
         let ptr = crate::gc::Gc::as_ptr(&cur);
-        unsafe { (*ptr).get(last.as_str()).cloned().unwrap_or_else(any) }
+        match unsafe { (*ptr).get(last.as_str()) } {
+            Some(Value::ContainerRef(cell)) => {
+                cell.lock().unwrap_or_else(|e| e.into_inner()).clone()
+            }
+            _ => any(),
+        }
     }
 
     /// Walk-CREATE the intermediate hashes of a `HashEntryRef`'s `path` and

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -332,9 +332,13 @@ impl Value {
                 let new_hash = Value::hash(HashMap::new());
                 data.map.insert(key.to_string(), new_hash);
             }
+            // The entry exists (created just above if missing): an EAGER token,
+            // whose reads see through to the plain entry value (`is raw`
+            // reduce lvalue descent).
             Some(Value::HashEntryRef {
                 hash: arc.clone(),
                 path: vec![key.to_string()],
+                eager: true,
             })
         } else {
             None
@@ -416,6 +420,7 @@ impl Value {
                 None => Some(Value::HashEntryRef {
                     hash: arc.clone(),
                     path: vec![key.to_string()],
+                    eager: false,
                 }),
             }
         } else {
@@ -453,8 +458,11 @@ impl Value {
     /// captured `Gc` stayed empty, which masked this; in-place hash writes
     /// now reach the captured root, so the connect condition must be the
     /// cell identity, not mere path existence.)
+    /// An EAGER token (`hash_autovivify`, `is raw` reduce descent) reads
+    /// through to the plain entry value — its entry was created with the
+    /// token, so path existence IS the connection.
     pub fn hash_entry_read(&self) -> Value {
-        let Value::HashEntryRef { hash, path } = self else {
+        let Value::HashEntryRef { hash, path, eager } = self else {
             return self.clone();
         };
         let any = || Value::Package(crate::symbol::Symbol::intern("Any"));
@@ -472,6 +480,7 @@ impl Value {
             Some(Value::ContainerRef(cell)) => {
                 cell.lock().unwrap_or_else(|e| e.into_inner()).clone()
             }
+            Some(v) if *eager => v.clone(),
             _ => any(),
         }
     }
@@ -481,7 +490,7 @@ impl Value {
     /// Missing/non-hash intermediate levels are replaced with fresh empty hashes
     /// (interior mutation, so all holders of the shared Arc observe them).
     pub(crate) fn hash_entry_terminal(&self) -> Option<(Gc<HashData>, String)> {
-        let Value::HashEntryRef { hash, path } = self else {
+        let Value::HashEntryRef { hash, path, .. } = self else {
             return None;
         };
         let mut cur = hash.clone();

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -677,6 +677,51 @@ impl Value {
         }
     }
 
+    /// Container-identity in-place mutation (§3): run `f` on the SHARED
+    /// `ArrayData` backing this `Array` value, writing through the node so
+    /// every by-value holder of the same container (an `@a` captured into a
+    /// list, a `\(@a)`, an element holding the array) observes the write.
+    /// `Gc::make_mut` (COW) is wrong for a mutation of a variable's own
+    /// container — it detaches the container from its aliases the moment the
+    /// backing is shared; Raku `=` copy semantics are enforced at copy time
+    /// instead (`detach_shared_container`). Returns `None` for non-`Array`.
+    #[inline]
+    pub(crate) fn with_array_inplace<R>(
+        &self,
+        f: impl FnOnce(&mut ArrayData, ArrayKind) -> R,
+    ) -> Option<R> {
+        match self {
+            Value::Array(gc, kind) => {
+                // SAFETY: audited aliased in-place container write (see
+                // value::aliased_mut) — callers ensure no other borrow into
+                // this node is live across `f` and no cross-thread access.
+                let data = unsafe { crate::value::gc_contents_mut(gc) };
+                Some(f(data, *kind))
+            }
+            _ => None,
+        }
+    }
+
+    /// Raku `=` copy semantics: if this Array/Hash's backing `Gc` is SHARED
+    /// with another holder, return a fresh-`Gc` shallow copy (elements/values
+    /// stay shared references — only the outer container is duplicated); a
+    /// singly-owned container or non-container value passes through
+    /// unchanged. This is the copy-time counterpart of the in-place mutation
+    /// paths (container identity §3): mutations write through the shared
+    /// node, so every place with copy semantics (`my @b = @a`, `is copy`
+    /// params) must detach at copy time.
+    pub(crate) fn detach_shared_container(self) -> Value {
+        match &self {
+            Value::Array(gc, kind) if gc.strong_count() > 1 => {
+                Value::array_with_kind(crate::gc::Gc::new((**gc).clone()), *kind)
+            }
+            Value::Hash(gc) if gc.strong_count() > 1 => {
+                Value::hash_with_data(crate::gc::Gc::new((**gc).clone()))
+            }
+            _ => self,
+        }
+    }
+
     /// Run `f` on the hash payload if this is exactly a `Hash`.
     /// Returns `None` (without calling `f`) otherwise.
     #[inline]

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -121,6 +121,7 @@ pub enum ValueView<'a> {
     HashEntryRef {
         hash: &'a Gc<HashData>,
         path: &'a Vec<String>,
+        eager: bool,
     },
 }
 
@@ -246,7 +247,11 @@ impl Value {
                 kv: *kv,
                 words: *words,
             },
-            Value::HashEntryRef { hash, path } => ValueView::HashEntryRef { hash, path },
+            Value::HashEntryRef { hash, path, eager } => ValueView::HashEntryRef {
+                hash,
+                path,
+                eager: *eager,
+            },
         }
     }
 
@@ -506,10 +511,15 @@ impl Value {
         Value::LazyList(l)
     }
 
-    /// Construct a `HashEntryRef` vivification token.
+    /// Construct a DEFERRED `HashEntryRef` vivification token (`eager: false`
+    /// — connects on read only through the cell a bound-var write installs).
     #[inline]
     pub(crate) fn hash_entry_ref(hash: Gc<HashData>, path: Vec<String>) -> Self {
-        Value::HashEntryRef { hash, path }
+        Value::HashEntryRef {
+            hash,
+            path,
+            eager: false,
+        }
     }
 
     /// Construct a `LazyIoLines` iterator over a file handle (boxing the
@@ -793,7 +803,7 @@ impl Value {
         f: impl FnOnce(&mut Gc<HashData>, &mut Vec<String>) -> R,
     ) -> Option<R> {
         match self {
-            Value::HashEntryRef { hash, path } => Some(f(hash, path)),
+            Value::HashEntryRef { hash, path, .. } => Some(f(hash, path)),
             _ => None,
         }
     }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1934,16 +1934,22 @@ impl Interpreter {
         if matches!(method, "pop" | "shift") && !args.is_empty() {
             return None;
         }
-        // The receiver must be exactly the array currently bound to this name, so
-        // an in-place `Arc::make_mut` writeback is correct. Descend through a
-        // whole-container `:=` bound cell (`my @x := @a`) so the mutation writes
-        // back through the shared cell (every alias observes it).
+        // The receiver must be exactly the array currently bound to this name.
+        // Container identity (§3): mutate through the SHARED backing node
+        // (`gc_contents_mut`, no COW) so every by-value holder of the same
+        // array — a `(0, @a)` capture, an element holding the array — observes
+        // the mutation. Descend through a whole-container `:=` bound cell
+        // (`my @x := @a`) so the mutation writes through the shared cell.
         let result =
             self.env_root_descended_mut(target_name)?
                 .with_array_mut(|arc_items, kind| {
                     if !matches!(*kind, crate::value::ArrayKind::Array) {
                         return None;
                     }
+                    // SAFETY: audited aliased in-place container write (see
+                    // value::aliased_mut); no other borrow into this node is
+                    // live across the mutation below.
+                    let items = unsafe { crate::value::gc_contents_mut(arc_items) };
                     Some(match method {
                         "push" => {
                             // `@a.push` compiles to `ArrayPush` only for single-arg pushes on
@@ -1953,7 +1959,7 @@ impl Interpreter {
                             let norm = crate::runtime::Interpreter::normalize_push_unshift_args(
                                 args.to_vec(),
                             );
-                            crate::gc::Gc::make_mut(arc_items).extend(norm);
+                            items.extend(norm);
                             Value::array_with_kind(
                                 crate::gc::Gc::clone(arc_items),
                                 crate::value::ArrayKind::Array,
@@ -1961,7 +1967,6 @@ impl Interpreter {
                         }
                         "append" | "prepend" => {
                             let flat = crate::runtime::flatten_append_args(args.to_vec());
-                            let items = crate::gc::Gc::make_mut(arc_items);
                             if method == "append" {
                                 items.extend(flat);
                             } else {
@@ -1978,7 +1983,6 @@ impl Interpreter {
                             let norm = crate::runtime::Interpreter::normalize_push_unshift_args(
                                 args.to_vec(),
                             );
-                            let items = crate::gc::Gc::make_mut(arc_items);
                             for (i, v) in norm.into_iter().enumerate() {
                                 items.insert(i, v);
                             }
@@ -1988,21 +1992,19 @@ impl Interpreter {
                             )
                         }
                         "pop" => {
-                            if arc_items.is_empty() {
+                            if items.is_empty() {
                                 crate::runtime::utils::make_empty_array_failure_what("pop", "Array")
                             } else {
-                                crate::gc::Gc::make_mut(arc_items)
-                                    .pop()
-                                    .unwrap_or(Value::NIL)
+                                items.pop().unwrap_or(Value::NIL)
                             }
                         }
                         "shift" => {
-                            if arc_items.is_empty() {
+                            if items.is_empty() {
                                 crate::runtime::utils::make_empty_array_failure_what(
                                     "shift", "Array",
                                 )
                             } else {
-                                crate::gc::Gc::make_mut(arc_items).remove(0)
+                                items.remove(0)
                             }
                         }
                         _ => unreachable!(),
@@ -2239,10 +2241,12 @@ impl Interpreter {
                 }
             }
         }
-        // The receiver must be exactly the array currently bound to this name, so
-        // an in-place `Arc::make_mut` writeback is correct. Compute the splice
-        // bounds from the live binding's length (not `target`). Descend through a
-        // whole-container `:=` bound cell so the splice writes through the cell.
+        // The receiver must be exactly the array currently bound to this name.
+        // Container identity (§3): splice through the SHARED backing node (no
+        // COW) so by-value holders of the same array observe it. Compute the
+        // splice bounds from the live binding's length (not `target`). Descend
+        // through a whole-container `:=` bound cell so the splice writes
+        // through the cell.
         let removed =
             self.env_root_descended_mut(target_name)?
                 .with_array_mut(|arc_items, kind| {
@@ -2257,7 +2261,10 @@ impl Interpreter {
                     }
                     let count = raw_count.unwrap_or(len - start);
                     let end = (start + count).min(len);
-                    let items = crate::gc::Gc::make_mut(arc_items);
+                    // SAFETY: audited aliased in-place container write (see
+                    // value::aliased_mut); no other borrow into this node is
+                    // live across the mutation below.
+                    let items = unsafe { crate::value::gc_contents_mut(arc_items) };
                     let removed: Vec<Value> = items.drain(start..end).collect();
                     for (i, item) in replacement.into_iter().enumerate() {
                         items.insert(start + i, item);

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -207,7 +207,7 @@ impl Interpreter {
     /// is missing or not a hash (the deferred path is not yet materialized, so it
     /// has no stable container identity).
     fn extract_hash_ref(val: &Value) -> Option<(crate::gc::Gc<crate::value::HashData>, String)> {
-        let ValueView::HashEntryRef { hash, path } = val.view() else {
+        let ValueView::HashEntryRef { hash, path, .. } = val.view() else {
             return None;
         };
         let mut cur = hash.clone();

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -149,27 +149,29 @@ impl Interpreter {
             // The shared cell itself keeps every alias coherent.
             if let ValueView::ContainerRef(cell) = target.view() {
                 let cell = cell.clone();
-                let mut guard = cell.lock().unwrap();
+                let guard = cell.lock().unwrap();
+                let inner = guard.clone();
+                drop(guard);
+                // Container identity (§3): write through the shared backing
+                // node so by-value holders of the same array observe the push.
                 let mut val_slot = Some(val);
-                let arr_result = (*guard).with_array_mut(|arr, kind| {
-                    let kind = *kind;
-                    let items = crate::gc::Gc::make_mut(arr);
-                    let val = val_slot.take().expect("push value present");
-                    match val.view() {
-                        ValueView::Slip(slip_items) => items.extend(slip_items.iter().cloned()),
-                        _ => items.push(val),
-                    }
-                    Value::array_with_kind(arr.clone(), kind)
-                });
-                if let Some(result) = arr_result {
-                    drop(guard);
-                    self.stack.push(result);
+                let pushed = inner
+                    .with_array_inplace(|data, _| {
+                        let val = val_slot.take().expect("push value present");
+                        match val.view() {
+                            ValueView::Slip(slip_items) => {
+                                data.items.extend(slip_items.iter().cloned())
+                            }
+                            _ => data.items.push(val),
+                        }
+                    })
+                    .is_some();
+                if pushed {
+                    self.stack.push(inner);
                     return Ok(());
                 }
                 // Non-array inner (e.g. Hash): generic clone-and-write-back.
                 let val = val_slot.take().expect("push value present");
-                let inner = guard.clone();
-                drop(guard);
                 let result = loan_env!(self, call_method_with_values(inner, "push", vec![val]))?;
                 *cell.lock().unwrap() = result.clone();
                 self.stack.push(result);
@@ -201,26 +203,22 @@ impl Interpreter {
             }
         }
 
-        // Find the local slot and drop it to allow in-place mutation
-        let local_slot = self.find_local_slot(code, target_name);
-        if let Some(slot) = local_slot {
-            self.locals[slot] = Value::NIL;
-        }
-
         let mut val_slot = Some(val);
-        let pushed = self.env_mut().get_mut(target_name).and_then(|v| {
-            v.with_array_mut(|arr, kind| {
-                let items = crate::gc::Gc::make_mut(arr);
+        // Container identity (§3): append through the shared backing node —
+        // no COW, no local-slot zeroing dance — so every by-value holder of
+        // the same array (a `(0, @a)` capture, an element) sees the push.
+        let target = self.env().get(target_name).cloned();
+        let pushed = target.as_ref().and_then(|v| {
+            v.with_array_inplace(|data, _| {
                 let val = val_slot.take().expect("push value present");
                 match val.view() {
-                    ValueView::Slip(slip_items) => items.extend(slip_items.iter().cloned()),
-                    _ => items.push(val),
+                    ValueView::Slip(slip_items) => data.items.extend(slip_items.iter().cloned()),
+                    _ => data.items.push(val),
                 }
-                Value::array_with_kind(arr.clone(), *kind)
             })
         });
         let result = match pushed {
-            Some(result) => result,
+            Some(()) => target.expect("array target present"),
             None => {
                 let val = val_slot.take().expect("push value present");
                 // Auto-vivify: create new array
@@ -233,10 +231,8 @@ impl Interpreter {
             }
         };
 
-        // Restore local slot
-        if let Some(slot) = local_slot {
-            self.locals[slot] = result.clone();
-        }
+        // Keep the local slot coherent with env (dual-store write-through).
+        self.update_local_if_exists(code, target_name, &result);
 
         self.stack.push(result);
         // Slice 6.3 step 2: no env_dirty mark. This native push path mutates only

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -184,7 +184,17 @@ impl Interpreter {
                 }
             };
         let total_items = chunked_items.len();
+        // `is copy` loop param (is_rw set, do_writeback suppressed): the param
+        // owns a DISTINCT container per iteration. Mutations write through the
+        // shared backing node (container identity §3), so binding the element
+        // value as-is would let `@row[0] = v` reach the source element.
+        let param_is_copy = spec.is_rw && !spec.do_writeback;
         'for_loop: for (idx, item) in chunked_items.into_iter().enumerate().skip(resume_index) {
+            let item = if param_is_copy {
+                item.detach_shared_container()
+            } else {
+                item
+            };
             // `topic_source_var` drives the whole-topic writeback for a scalar
             // source (`for $x { $_[1] = ... }` writes the mutated `$_` back to
             // `$x`). For a `.values` loop over a mutable QuantHash the topic is a

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1066,7 +1066,14 @@ impl Interpreter {
                 continue;
             }
             if arg_idx < args.len() {
-                let val = args[arg_idx].clone();
+                let mut val = args[arg_idx].clone();
+                // `is copy` container param owns a DISTINCT container: element
+                // mutations write through the shared backing node (container
+                // identity §3), so an undetached copy would leak `@a.push`
+                // back to the caller's array.
+                if pd.is_some_and(|pd| pd.traits.iter().any(|t| t == "copy")) {
+                    val = val.detach_shared_container();
+                }
                 if let Some(constraint) = pd.and_then(|pd| pd.type_constraint.as_ref())
                     && !self.type_matches_value(constraint, &val)
                 {

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -53,7 +53,11 @@ impl Interpreter {
                 (raw_val, None)
             };
         // Capture old hash Arc pointer for circular reference fixup, and the
-        // backing `Gc` for the in-place whole-container reassignment below.
+        // backing `Gc` for the in-place whole-container reassignment below. A
+        // celled `@`/`%` aggregate (a `state @foo` / captured boxed container)
+        // holds a `ContainerRef` — capture the cell so the store below goes
+        // THROUGH it (identity + copy semantics) instead of clobbering it.
+        let mut inplace_container_cell: Option<crate::gc::Gc<std::sync::Mutex<Value>>> = None;
         let mut inplace_old_hash: Option<crate::gc::Gc<crate::value::HashData>> = None;
         let old_hash_arc = if name.starts_with('%') {
             let current = self.get_env_with_main_alias(&name).or_else(|| {
@@ -65,13 +69,18 @@ impl Interpreter {
                     }
                 })
             });
-            if let Some(ValueView::Hash(arc)) = current.as_ref().map(Value::view) {
-                if !name.contains("__ANON") {
-                    inplace_old_hash = Some(arc.clone());
+            match current.as_ref().map(Value::view) {
+                Some(ValueView::Hash(arc)) => {
+                    if !name.contains("__ANON") {
+                        inplace_old_hash = Some(arc.clone());
+                    }
+                    Some(crate::gc::Gc::as_ptr(arc) as usize)
                 }
-                Some(crate::gc::Gc::as_ptr(arc) as usize)
-            } else {
-                None
+                Some(ValueView::ContainerRef(cell)) => {
+                    inplace_container_cell = Some(cell.clone());
+                    None
+                }
+                _ => None,
             }
         } else {
             None
@@ -89,13 +98,18 @@ impl Interpreter {
                     }
                 })
             });
-            if let Some(ValueView::Array(arc, _)) = current.as_ref().map(Value::view) {
-                if !name.contains("__ANON") {
-                    inplace_old_array = Some(arc.clone());
+            match current.as_ref().map(Value::view) {
+                Some(ValueView::Array(arc, _)) => {
+                    if !name.contains("__ANON") {
+                        inplace_old_array = Some(arc.clone());
+                    }
+                    Some(crate::gc::Gc::as_ptr(arc) as usize)
                 }
-                Some(crate::gc::Gc::as_ptr(arc) as usize)
-            } else {
-                None
+                Some(ValueView::ContainerRef(cell)) => {
+                    inplace_container_cell = Some(cell.clone());
+                    None
+                }
+                _ => None,
             }
         } else {
             None
@@ -455,6 +469,19 @@ impl Interpreter {
         {
             let (new_gc, kind) = (new_gc.clone(), kind);
             val = Self::array_inplace_reassign(old_gc, &new_gc, kind);
+        } else if let Some(cell) = &inplace_container_cell {
+            // A celled `@`/`%` aggregate (`(state @foo) = @bar`): store through
+            // the cell with the inner container's identity preserved (contents
+            // copied — `=` copy semantics — so a later `@foo[0]++` cannot reach
+            // the RHS source array), and keep the CELL installed in env/locals.
+            Self::cell_store_preserving_container_identity(cell, &val);
+            let cell_val = Value::container_ref(cell.clone());
+            self.update_local_if_exists(code, &name, &cell_val);
+            self.set_env_with_main_alias(&name, cell_val);
+            self.sync_anon_state_value(&name, &val);
+            self.stack
+                .push(Self::itemize_scalar_assign_result(&name, val));
+            return Ok(());
         }
         self.update_local_if_exists(code, &name, &val);
         self.set_env_with_main_alias(&name, val.clone());

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -291,34 +291,35 @@ impl Interpreter {
             ValueView::ContainerRef(arc) => arc.lock().unwrap().clone(),
             _ => old_val.clone(),
         };
-        // For temp, deep-copy Array/Hash so the snapshot is independent of
-        // future mutations (Arc is shared, so a shallow clone wouldn't work).
-        let save_val = if is_temp {
-            Self::deep_copy_value(&old_val)
-        } else {
-            old_val
-        };
+        // Deep-copy Array/Hash so the snapshot is independent of future
+        // mutations: element writes go through the shared backing node
+        // (container identity §3), so a shallow clone would observe every
+        // later `@a[i] = v` / `%h<k> = v` and the restore would be a no-op.
+        // `let` needs this as much as `temp` (it restores on block failure).
+        let save_val = Self::deep_copy_value(&old_val);
         self.let_saves_push(name, save_val, is_temp, slot);
     }
 
     /// Recursively deep-copy a Value so that Array/Hash snapshots are
-    /// independent of future in-place mutations (the inner Arc would otherwise
-    /// be shared).
+    /// independent of future in-place mutations (the backing node is shared,
+    /// so a shallow clone wouldn't work). Preserves the container's embedded
+    /// metadata (type parameters, defaults, shape, object-hash keys) so a
+    /// restored `my %h{Pair}` / `my @a is default(...)` keeps its identity.
     fn deep_copy_value(val: &Value) -> Value {
         match val.view() {
             ValueView::Array(arc_vec, kind) => {
-                let copied: Vec<Value> = arc_vec.iter().map(Self::deep_copy_value).collect();
-                Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(copied)),
-                    kind,
-                )
+                let mut data = (**arc_vec).clone();
+                for v in data.items.iter_mut() {
+                    *v = Self::deep_copy_value(v);
+                }
+                Value::array_with_kind(crate::gc::Gc::new(data), kind)
             }
             ValueView::Hash(arc_map) => {
-                let copied: std::collections::HashMap<String, Value> = arc_map
-                    .iter()
-                    .map(|(k, v)| (k.clone(), Self::deep_copy_value(v)))
-                    .collect();
-                Value::hash_with_data(Value::hash_arc(copied))
+                let mut data = (**arc_map).clone();
+                for v in data.map.values_mut() {
+                    *v = Self::deep_copy_value(v);
+                }
+                Value::hash_with_data(crate::gc::Gc::new(data))
             }
             _ => val.clone(),
         }

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -40,9 +40,12 @@ impl Interpreter {
         // uses `set_state_var` directly, never a cell) is unaffected.
         let val = if self.shared_vars_active {
             let coerced_initial = if name.starts_with('@') {
-                runtime::coerce_to_array(init_val)
+                // `=` init copies (container identity §3) — see the non-shared
+                // branch below.
+                runtime::coerce_to_array(init_val).detach_shared_container()
             } else if name.starts_with('%') {
                 self.coerce_object_to_hash(init_val)
+                    .detach_shared_container()
             } else {
                 init_val
             };
@@ -83,11 +86,16 @@ impl Interpreter {
             }
         } else {
             // Coerce @ variables to Array and % variables to Hash,
-            // matching the behavior of SetLocal for these sigils.
+            // matching the behavior of SetLocal for these sigils. Like
+            // SetLocal, the `=` initialization COPIES (container identity §3):
+            // detach a backing node shared with the initializer so a later
+            // `@foo[0]++` on the state var does not reach the source array
+            // (`(state @foo) = @bar`, S04-declarations/state.t).
             let coerced = if name.starts_with('@') {
-                runtime::coerce_to_array(init_val)
+                runtime::coerce_to_array(init_val).detach_shared_container()
             } else if name.starts_with('%') {
                 self.coerce_object_to_hash(init_val)
+                    .detach_shared_container()
             } else {
                 init_val
             };

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -881,7 +881,8 @@ impl Interpreter {
                         if let Some(max_idx) = Self::slice_key_tree_max_index(top_tree) {
                             container
                                 .with_array_mut(|items, _| -> Result<(), RuntimeError> {
-                                    let arr = crate::gc::Gc::make_mut(items);
+                                    // Container identity (§3): resize in place.
+                                    let arr = crate::value::gc_data_mut(items);
                                     Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
                                     Ok(())
                                 })
@@ -907,7 +908,8 @@ impl Interpreter {
                             .unwrap_or(0);
                         container
                             .with_array_mut(|items, _| -> Result<(), RuntimeError> {
-                                let arr = crate::gc::Gc::make_mut(items);
+                                // Container identity (§3): resize in place.
+                                let arr = crate::value::gc_data_mut(items);
                                 Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
                                 Ok(())
                             })
@@ -1509,25 +1511,17 @@ impl Interpreter {
                                 val.view(),
                                 ValueView::Hash(source_hash) if crate::gc::Gc::ptr_eq(hash, source_hash)
                             );
-                            // Use in-place mutation instead of Arc::make_mut when the
-                            // hash is shared (strong_count > 1) AND the variable is a
-                            // scalar ($) container.  This preserves Raku's object
-                            // identity semantics: when a hash is stored in an array
-                            // slot via `$arr[i] = $hash`, mutations through the original
-                            // variable must be visible through the array.
+                            // Container identity (§3): a key write on a SHARED
+                            // hash mutates through the backing node so every
+                            // by-value holder of the same container (`(0, %h)`,
+                            // `$arr[i] = %h`, a `:=` bound alias) observes it.
+                            // COW here would detach the container from its
+                            // aliases; Raku `=` copy semantics are enforced at
+                            // copy time instead (`detach_shared_container`).
                             // In-place mutation goes through the audited
-                            // `arc_contents_mut` choke point below, guarded by
+                            // `gc_contents_mut` choke point below, guarded by
                             // `strong_count > 1` (see its safety contract).
-                            // For %-sigiled hash variables (e.g. `%h is copy`),
-                            // normally use COW.  For scalar ($) variables holding
-                            // hashes, use in-place mutation to preserve identity.
-                            // Exception: when a %-sigiled variable is bound via
-                            // `:=` (marked readonly), use in-place mutation so
-                            // modifications propagate to the bound source.
-                            // %-sigiled vars have names like "%h", scalar vars
-                            // have names without a sigil prefix (e.g. "bar").
-                            let use_inplace = crate::gc::Gc::strong_count_of(hash) > 1
-                                && (!var_name.starts_with('%') || is_bound_hash_var);
+                            let use_inplace = crate::gc::Gc::strong_count_of(hash) > 1;
                             // Mutate the whole `HashData` (map + embedded
                             // object-hash original keys) so the original-key map
                             // travels with the hash through copy-on-write.
@@ -1614,11 +1608,13 @@ impl Interpreter {
                                         val.view(),
                                         ValueView::Array(source_items, ..) if crate::gc::Gc::ptr_eq(items, source_items)
                                     );
-                                    // Use in-place mutation when the array is shared
-                                    // (strong_count > 1) to preserve identity semantics
-                                    // and support shared `ContainerRef` cell binding.
-                                    let use_inplace = crate::gc::Gc::strong_count(items) > 1
-                                        && !var_name.starts_with('@');
+                                    // Container identity (§3): an element write
+                                    // on a SHARED array mutates through the
+                                    // backing node so every by-value holder of
+                                    // the same container observes it (COW would
+                                    // detach; copies detach at copy time via
+                                    // `detach_shared_container`).
+                                    let use_inplace = crate::gc::Gc::strong_count(items) > 1;
                                     let arr: &mut crate::value::ArrayData = if use_inplace {
                                         // SAFETY: aliased in-place mutation of a
                                         // shared array; see `arc_contents_mut`.
@@ -2192,7 +2188,8 @@ impl Interpreter {
                     let Ok(inner_i) = inner_key.parse::<usize>() else {
                         return Ok(false);
                     };
-                    let arr = crate::gc::Gc::make_mut(outer_arr);
+                    // Container identity (§3): write through a shared node.
+                    let arr = crate::value::gc_data_mut(outer_arr);
                     Self::autoviv_resize(arr, inner_i + 1, native_fill.clone())?;
                     // Autovivify the slot if it's not already a container. A
                     // `:=`-bound element is a shared `ContainerRef` cell holding a
@@ -2220,21 +2217,12 @@ impl Interpreter {
                     } else if let Some(r) =
                         arr[inner_i].with_array_mut(|inner_arr, _| -> Result<(), RuntimeError> {
                             if let Ok(j) = outer_key.parse::<usize>() {
-                                // Use interior mutation when the inner array is shared
-                                // (e.g., by a `ContainerRef` cell from := binding).
-                                if crate::gc::Gc::strong_count(inner_arr) > 1 {
-                                    // SAFETY: aliased in-place mutation of a shared array
-                                    // (strong_count > 1); see `arc_contents_mut`.
-                                    let v =
-                                        &mut unsafe { crate::value::gc_contents_mut(inner_arr) }
-                                            .items;
-                                    Self::autoviv_resize(v, j + 1, native_fill.clone())?;
-                                    Value::assign_element_slot(&mut v[j], val.clone());
-                                } else {
-                                    let inner = crate::gc::Gc::make_mut(inner_arr);
-                                    Self::autoviv_resize(inner, j + 1, native_fill.clone())?;
-                                    Value::assign_element_slot(&mut inner[j], val.clone());
-                                }
+                                // Container identity (§3): write through a
+                                // shared inner node (a `ContainerRef` cell
+                                // alias, a by-value holder).
+                                let inner = crate::value::gc_data_mut(inner_arr);
+                                Self::autoviv_resize(inner, j + 1, native_fill.clone())?;
+                                Value::assign_element_slot(&mut inner[j], val.clone());
                             }
                             Ok(())
                         })
@@ -2242,19 +2230,10 @@ impl Interpreter {
                         r?;
                     } else {
                         let _ = arr[inner_i].with_hash_mut(|inner_hash| {
-                            if crate::gc::Gc::strong_count_of(inner_hash) > 1 {
-                                // SAFETY: aliased in-place mutation of a shared hash
-                                // (strong_count > 1); see `arc_contents_mut`.
-                                let hd = unsafe { crate::value::gc_contents_mut(inner_hash) };
-                                Value::hash_insert_through(
-                                    &mut hd.map,
-                                    outer_key.clone(),
-                                    val.clone(),
-                                );
-                            } else {
-                                let h = crate::gc::Gc::make_mut(inner_hash);
-                                Value::hash_insert_through(h, outer_key.clone(), val.clone());
-                            }
+                            // Container identity (§3): write through a shared
+                            // inner node.
+                            let hd = crate::value::gc_data_mut(inner_hash);
+                            Value::hash_insert_through(&mut hd.map, outer_key.clone(), val.clone());
                         });
                     }
                     Ok(true)
@@ -2279,22 +2258,18 @@ impl Interpreter {
         self.env_root_descended_mut(&var_name)
             .and_then(|container| {
                 container.with_hash_mut(|outer_hash| -> Result<(), RuntimeError> {
-                    // At refcount 1, write in place via the raw pointer (same pattern
-                    // as the bound-cell Array arm below): `Arc::make_mut` relocates a
-                    // Weak-guarded (metadata-bearing, e.g. object-hash / `is default`)
-                    // hash even when it is the only strong holder, which would break
-                    // `.WHICH` pointer identity. When shared, keep the make_mut COW
-                    // detach. The cast MUST target `HashData` (not its inner map) —
-                    // see docs/hashdata-migration-plan.md "Latent UB found & fixed".
+                    // Container identity (§3): write in place via the raw
+                    // pointer both when exclusively owned (`Arc::make_mut`
+                    // would relocate a Weak-guarded metadata-bearing hash and
+                    // break `.WHICH` pointer identity — see
+                    // docs/hashdata-migration-plan.md "Latent UB found &
+                    // fixed") and when shared (COW would detach the container
+                    // from its by-value holders). The cast MUST target
+                    // `HashData` (not its inner map).
+                    // SAFETY: audited aliased in-place container write; no
+                    // other borrow into this node is live across the write.
                     let oh: &mut crate::value::HashData =
-                        if crate::gc::Gc::strong_count_of(outer_hash) == 1 {
-                            // SAFETY: single strong holder; in-place avoids the make_mut
-                            // relocation that would break `.WHICH` identity. See
-                            // `arc_contents_mut`.
-                            unsafe { crate::value::gc_contents_mut(outer_hash) }
-                        } else {
-                            crate::gc::Gc::make_mut(outer_hash)
-                        };
+                        unsafe { crate::value::gc_contents_mut(outer_hash) };
                     // Vivify the missing entry as Array if the OUTER (second) subscript
                     // is positional (e.g. `%h<key>[42] = ...`), otherwise as Hash.
                     let inner_val = oh.entry(inner_key).or_insert_with(|| {
@@ -2336,25 +2311,19 @@ impl Interpreter {
                 // a direct `@a[i] = v`), not `Nil`. A nested hash/array element
                 // container is untyped here, so `Any` is the correct hole.
                 let fill = Value::package(crate::symbol::Symbol::intern("Any"));
-                if crate::gc::Gc::strong_count(arr) > 1 {
-                    // SAFETY: aliased in-place mutation of a shared array
-                    // (strong_count > 1); see `arc_contents_mut`.
-                    let v = &mut unsafe { crate::value::gc_contents_mut(arr) }.items;
-                    Self::autoviv_resize(v, i + 1, fill)?;
-                    Value::assign_element_slot(&mut v[i], val.clone());
-                } else {
-                    let a = crate::gc::Gc::make_mut(arr);
-                    Self::autoviv_resize(a, i + 1, fill)?;
-                    Value::assign_element_slot(&mut a[i], val.clone());
-                }
+                // Container identity (§3): write through a shared node.
+                let a = crate::value::gc_data_mut(arr);
+                Self::autoviv_resize(a, i + 1, fill)?;
+                Value::assign_element_slot(&mut a[i], val.clone());
             }
             Ok(())
         }) {
             r?;
         } else {
             let _ = target.with_hash_mut(|h| {
+                // Container identity (§3): write through a shared node.
                 Value::hash_insert_through(
-                    &mut crate::gc::Gc::make_mut(h).map,
+                    &mut crate::value::gc_data_mut(h).map,
                     outer_key.to_string(),
                     val.clone(),
                 );

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -580,17 +580,10 @@ impl Interpreter {
     /// historical copy-on-write masking (a shared `Gc` that only *appears*
     /// independent because the next mutation reallocated) breaks once whole-
     /// container reassignment writes in place (§3): the in-place write would reach
-    /// the aliased source.
+    /// the aliased source. Thin wrapper over [`Value::detach_shared_container`]
+    /// (also used by `is copy` parameter binding).
     pub(super) fn detach_shared_container(val: Value) -> Value {
-        match val.view() {
-            ValueView::Array(gc, kind) if gc.strong_count() > 1 => {
-                Value::array_with_kind(crate::gc::Gc::new((**gc).clone()), kind)
-            }
-            ValueView::Hash(gc) if gc.strong_count() > 1 => {
-                Value::hash_with_data(crate::gc::Gc::new((**gc).clone()))
-            }
-            _ => val,
-        }
+        val.detach_shared_container()
     }
 
     /// Store a whole-container reassignment through a `ContainerRef` cell while

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -480,10 +480,11 @@ impl Interpreter {
                 self.decrement_value_smart(&effective)?
             };
             let mut updated = inner;
+            // Container identity (§3): write through the shared backing node.
             if updated
                 .with_hash_mut(|h| {
                     Value::hash_insert_through(
-                        &mut crate::gc::Gc::make_mut(h).map,
+                        &mut crate::value::gc_data_mut(h).map,
                         key.clone(),
                         new_val.clone(),
                     );
@@ -492,7 +493,7 @@ impl Interpreter {
                 && let Some(arr_result) =
                     updated.with_array_mut(|arr, _kind| -> Result<(), RuntimeError> {
                         if let Ok(i) = key.parse::<usize>() {
-                            let a = crate::gc::Gc::make_mut(arr);
+                            let a = crate::value::gc_data_mut(arr);
                             Self::autoviv_resize(a, i + 1, Value::NIL)?;
                             a[i] = new_val.clone();
                         }
@@ -638,7 +639,9 @@ impl Interpreter {
                 // in place so the caller observes the change. `Arc::make_mut`
                 // would COW-detach and silently drop the write (the array
                 // path already special-cased this; the hash path did not).
-                let use_inplace = crate::gc::Gc::strong_count_of(h) > 1 && !name.starts_with('%');
+                // Container identity (§3): no sigil carve-out — a shared hash
+                // mutates through the backing node for every holder.
+                let use_inplace = crate::gc::Gc::strong_count_of(h) > 1;
                 if use_inplace {
                     // SAFETY: aliased in-place mutation of a shared hash
                     // (strong_count > 1, the shared-cell case); mirrors the
@@ -658,11 +661,10 @@ impl Interpreter {
             } else if let Some(res) =
                 container_value.with_array_mut(|arr, _| -> Result<bool, RuntimeError> {
                     if let Ok(i) = idx_val.to_string_value().parse::<usize>() {
-                        // Use in-place mutation when the array is shared
-                        // (strong_count > 1) to preserve identity semantics,
-                        // matching the behavior of index assignment.
-                        let use_inplace =
-                            crate::gc::Gc::strong_count(arr) > 1 && !name.starts_with('@');
+                        // Container identity (§3): no sigil carve-out — a
+                        // shared array mutates through the backing node for
+                        // every holder, matching index assignment.
+                        let use_inplace = crate::gc::Gc::strong_count(arr) > 1;
                         let a: &mut crate::value::ArrayData = if use_inplace {
                             // SAFETY: aliased in-place mutation of a shared array
                             // (strong_count > 1, the case that needs the shared
@@ -691,7 +693,8 @@ impl Interpreter {
                         return Err(RuntimeError::assignment_ro(Some("Mix")));
                     }
                     let weight = Self::mix_assignment_weight(&new_val)?;
-                    let m = crate::gc::Gc::make_mut(mix);
+                    // Container identity (§3): write through a shared node.
+                    let m = crate::value::gc_data_mut(mix);
                     if new_val.truthy() {
                         m.insert(key.clone(), weight);
                     } else {
@@ -706,7 +709,8 @@ impl Interpreter {
                     if !*is_mutable {
                         return Err(RuntimeError::assignment_ro(Some("Set")));
                     }
-                    let s = crate::gc::Gc::make_mut(set);
+                    // Container identity (§3): write through a shared node.
+                    let s = crate::value::gc_data_mut(set);
                     if new_val.truthy() {
                         s.insert(key.clone());
                     } else {
@@ -721,7 +725,8 @@ impl Interpreter {
                     if !*is_mutable {
                         return Err(RuntimeError::assignment_ro(Some("Bag")));
                     }
-                    let b = crate::gc::Gc::make_mut(bag);
+                    // Container identity (§3): write through a shared node.
+                    let b = crate::value::gc_data_mut(bag);
                     let n = match new_val.view() {
                         ValueView::Int(i) => num_bigint::BigInt::from(i),
                         ValueView::BigInt(big) => (**big).clone(),

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -46,7 +46,8 @@ impl Interpreter {
             return;
         };
         container.with_array_mut(|items, _| {
-            let arr = crate::gc::Gc::make_mut(items);
+            // Container identity (§3): trim through the shared backing node.
+            let arr = crate::value::gc_data_mut(items);
             // The explicitly-assigned indices travel with the array (embedded set).
             let initialized = arr.initialized.clone().unwrap_or_default();
             while let Some(last) = arr.last() {
@@ -131,7 +132,9 @@ impl Interpreter {
                     .env_mut()
                     .get_mut(var_name)
                     .and_then(|v| {
-                        v.with_hash_mut(|hash| crate::gc::Gc::make_mut(hash).remove(&key))
+                        // Container identity (§3): remove through the shared
+                        // backing node.
+                        v.with_hash_mut(|hash| crate::value::gc_data_mut(hash).remove(&key))
                     })
                     .flatten();
                 let removed = removed.or(container_default).unwrap_or(Value::NIL);
@@ -593,28 +596,30 @@ impl Interpreter {
         idx: Value,
         hole_type: &str,
     ) -> Result<Value, RuntimeError> {
+        // Container identity (§3): delete through the shared backing node so
+        // every by-value holder of the same container observes the removal.
         if let Some(removed) = container.with_hash_mut(|hash| match idx.view() {
             ValueView::Whatever => {
-                let h = crate::gc::Gc::make_mut(hash);
+                let h = crate::value::gc_data_mut(hash);
                 let removed: Vec<Value> = h.values().cloned().collect();
                 h.clear();
                 Value::array(removed)
             }
             ValueView::Num(f) if f.is_infinite() && f.is_sign_positive() => {
-                let h = crate::gc::Gc::make_mut(hash);
+                let h = crate::value::gc_data_mut(hash);
                 let removed: Vec<Value> = h.values().cloned().collect();
                 h.clear();
                 Value::array(removed)
             }
             ValueView::Array(keys, ..) => {
-                let h = crate::gc::Gc::make_mut(hash);
+                let h = crate::value::gc_data_mut(hash);
                 let removed = keys
                     .iter()
                     .map(|key| h.remove(&key.to_string_value()).unwrap_or(Value::NIL))
                     .collect();
                 Value::array(removed)
             }
-            _ => crate::gc::Gc::make_mut(hash)
+            _ => crate::value::gc_data_mut(hash)
                 .remove(&idx.to_string_value())
                 .unwrap_or(Value::NIL),
         }) {
@@ -633,20 +638,20 @@ impl Interpreter {
         }
         if let Some(removed) = container.with_set_mut(|set, _| match idx.view() {
             ValueView::Array(keys, ..) => {
-                let s = crate::gc::Gc::make_mut(set);
+                let s = crate::value::gc_data_mut(set);
                 let removed = keys
                     .iter()
                     .map(|key| Value::truth(s.remove(&key.to_string_value())))
                     .collect();
                 Value::array(removed)
             }
-            _ => Value::truth(crate::gc::Gc::make_mut(set).remove(&idx.to_string_value())),
+            _ => Value::truth(crate::value::gc_data_mut(set).remove(&idx.to_string_value())),
         }) {
             return Ok(removed);
         }
         if let Some(removed) = container.with_bag_mut(|bag, _| match idx.view() {
             ValueView::Array(keys, ..) => {
-                let b = crate::gc::Gc::make_mut(bag);
+                let b = crate::value::gc_data_mut(bag);
                 let removed = keys
                     .iter()
                     .map(|key| {
@@ -656,7 +661,7 @@ impl Interpreter {
                 Value::array(removed)
             }
             _ => Value::from_bigint(
-                crate::gc::Gc::make_mut(bag)
+                crate::value::gc_data_mut(bag)
                     .remove(&idx.to_string_value())
                     .unwrap_or_default(),
             ),
@@ -665,7 +670,7 @@ impl Interpreter {
         }
         if let Some(removed) = container.with_mix_mut(|mix, _| match idx.view() {
             ValueView::Array(keys, ..) => {
-                let m = crate::gc::Gc::make_mut(mix);
+                let m = crate::value::gc_data_mut(mix);
                 let removed = keys
                     .iter()
                     .map(|key| Value::num(m.remove(&key.to_string_value()).unwrap_or(0.0)))
@@ -673,7 +678,7 @@ impl Interpreter {
                 Value::array(removed)
             }
             _ => Value::num(
-                crate::gc::Gc::make_mut(mix)
+                crate::value::gc_data_mut(mix)
                     .remove(&idx.to_string_value())
                     .unwrap_or(0.0),
             ),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -238,7 +238,7 @@ impl Interpreter {
             // the deferred bind autovivifies the full path on write.
             _ if matches!(target.view(), ValueView::HashEntryRef { .. }) => {
                 let key = Value::hash_key_encode(&index);
-                let ValueView::HashEntryRef { hash, path } = target.view() else {
+                let ValueView::HashEntryRef { hash, path, .. } = target.view() else {
                     unreachable!()
                 };
                 let hash = hash.clone();

--- a/src/vm/vm_var_index_tracking.rs
+++ b/src/vm/vm_var_index_tracking.rs
@@ -109,22 +109,21 @@ impl Interpreter {
         let Ok(idx) = encoded.parse::<usize>() else {
             return;
         };
-        // Mutate the array in place when it is shared by-ref through a scalar
-        // ($) container, mirroring the assignment path's `use_inplace` choice
-        // (vm_var_assign_index_named). Using `Arc::make_mut` here would clone a
-        // shared array and sever the by-ref alias, so a subsequent `.push` on
-        // the original would be lost (t/array-push-byref-coherence).
-        let use_inplace = !var_name.starts_with('@');
+        // Mutate the array in place when it is shared, mirroring the
+        // assignment path's `use_inplace` choice (vm_var_assign_index_named,
+        // container identity §3 — no sigil carve-out). Using `Arc::make_mut`
+        // here would clone a shared array and sever the by-ref alias, so a
+        // subsequent `.push` on the original would be lost
+        // (t/array-push-byref-coherence).
         if let Some(root) = self.env_root_descended_mut(var_name) {
             root.with_array_mut(|items, _| {
-                let data: &mut crate::value::ArrayData =
-                    if use_inplace && crate::gc::Gc::strong_count(items) > 1 {
-                        // SAFETY: aliased in-place mutation of a shared array; same
-                        // contract as the assignment site's `arc_contents_mut` use.
-                        unsafe { crate::value::gc_contents_mut(items) }
-                    } else {
-                        crate::gc::Gc::make_mut(items)
-                    };
+                let data: &mut crate::value::ArrayData = if crate::gc::Gc::strong_count(items) > 1 {
+                    // SAFETY: aliased in-place mutation of a shared array; same
+                    // contract as the assignment site's `arc_contents_mut` use.
+                    unsafe { crate::value::gc_contents_mut(items) }
+                } else {
+                    crate::gc::Gc::make_mut(items)
+                };
                 data.initialized
                     .get_or_insert_with(std::collections::HashSet::new)
                     .insert(idx);
@@ -234,7 +233,8 @@ impl Interpreter {
         }
         if let Some(root) = self.env_root_descended_mut(var_name) {
             root.with_array_mut(|items, _| {
-                let data = crate::gc::Gc::make_mut(items);
+                // Container identity (§3): write through a shared node.
+                let data = crate::value::gc_data_mut(items);
                 // A freshly-built array tracks "all present" as `initialized = None`.
                 // Materialize the set (0..len) before removing the deleted indices so
                 // the hole is recorded IN the ArrayData — not only in the name-keyed

--- a/src/vm/vm_var_multidim_helpers.rs
+++ b/src/vm/vm_var_multidim_helpers.rs
@@ -127,7 +127,8 @@ impl Interpreter {
             if i >= items.len() {
                 return Err(RuntimeError::new("Index out of bounds"));
             }
-            let arr = crate::gc::Gc::make_mut(items);
+            // Container identity (§3): write through a shared backing node.
+            let arr = crate::value::gc_data_mut(items);
             if indices.len() == 1 {
                 Value::assign_element_slot(&mut arr[i], val);
             } else {
@@ -168,7 +169,8 @@ impl Interpreter {
             if i >= items.len() {
                 return Ok(hole_value());
             }
-            let arr = crate::gc::Gc::make_mut(items);
+            // Container identity (§3): write through a shared backing node.
+            let arr = crate::value::gc_data_mut(items);
             if indices.len() == 1 {
                 let prev = arr[i].clone();
                 arr[i] = hole_value();

--- a/t/container-identity-mutation.t
+++ b/t/container-identity-mutation.t
@@ -1,0 +1,108 @@
+use Test;
+
+# Element-level mutations (push/pop/shift/unshift/splice/append/prepend,
+# element/slice assignment, hash key writes, :delete, ++/--) mutate the
+# variable's container IN PLACE, so every by-value holder of the same
+# container — an `@a` captured into a list `(0, @a)`, an element, a scalar —
+# observes the mutation (Raku container identity, BLOCKERS §3.2 item 1).
+# Copies (`my @b = @a`, `is copy` params, `.clone`) stay detached: `=` copy
+# semantics are enforced at copy time, not by copy-on-write at mutation time.
+
+plan 55;
+
+# --- array method mutations visible through a by-value capture ---
+{ my @a = 1,2;   my $c = (0, @a); @a.push(9);        is $c[1].join(','), '1,2,9',   'push visible through capture'; }
+{ my @a = 1,2;   my $c = (0, @a); @a.pop;            is $c[1].join(','), '1',       'pop visible through capture'; }
+{ my @a = 1,2;   my $c = (0, @a); @a.shift;          is $c[1].join(','), '2',       'shift visible through capture'; }
+{ my @a = 1,2;   my $c = (0, @a); @a.unshift(0);     is $c[1].join(','), '0,1,2',   'unshift visible through capture'; }
+{ my @a = 1,2,3; my $c = (0, @a); @a.splice(1,1);    is $c[1].join(','), '1,3',     'splice visible through capture'; }
+{ my @a = 1,2;   my $c = (0, @a); @a.append(3,4);    is $c[1].join(','), '1,2,3,4', 'append visible through capture'; }
+{ my @a = 1,2;   my $c = (0, @a); @a.prepend(0);     is $c[1].join(','), '0,1,2',   'prepend visible through capture'; }
+{ my @a = 1,2;   my $c = (0, @a); @a.push(8, 9);     is $c[1].join(','), '1,2,8,9', 'multi-arg push visible through capture'; }
+{ my @a = 1,2,3; my $c = (0, @a); @a.splice(1,1,<x y>); is $c[1].join(','), '1,x,y,3', 'splice with replacement visible'; }
+
+# --- element / slice writes ---
+{ my @a = 1,2;   my $c = (0, @a); @a[0] = 9;         is $c[1].join(','), '9,2',     'element assign visible'; }
+{ my @a = 1,2;   my $c = (0, @a); @a[2] = 3;         is $c[1].join(','), '1,2,3',   'element extend visible'; }
+{ my @a = 1,2;   my $c = (0, @a); @a[0]++;           is $c[1].join(','), '2,2',     'element increment visible'; }
+{ my @a = 1,2,3; my $c = (0, @a); @a[0,1] = 8,9;     is $c[1].join(','), '8,9,3',   'slice assign visible'; }
+{ my @a = 1,2;   my $c = (0, @a); @a[*-1] = 9;       is $c[1].join(','), '1,9',     'whatever-index assign visible'; }
+{ my @a = 1,2;   my $c = (0, @a); @a = 7,8;          is $c[1].join(','), '7,8',     'whole-array reassign visible (identity)'; }
+
+# --- hash writes ---
+{ my %h = a=>1;      my $c = (0, %h); %h<b> = 2;     is $c[1].keys.sort.join(','), 'a,b', 'hash key assign visible'; }
+{ my %h = a=>1,b=>2; my $c = (0, %h); %h<a>:delete;  is $c[1].keys.sort.join(','), 'b',   'hash key delete visible'; }
+{ my %h = a=>1;      my $c = (0, %h); %h<a>++;       is $c[1]<a>, 2,                      'hash key increment visible'; }
+{ my %h = a=>1;      my $c = (0, %h); %h = c=>3;     is $c[1].keys.sort.join(','), 'c',   'whole-hash reassign visible (identity)'; }
+{ my %h = a=>1;      my $c = (0, %h); %h.push((b => 2)); is $c[1].keys.sort.join(','), 'a,b', 'hash push visible'; }
+{ my %h = a=>1,b=>2,c=>3; my $c = (0, %h); %h<a b>:delete; is $c[1].keys.sort.join(','), 'c', 'hash slice delete visible'; }
+{ my %h = a=>{x=>1}; my $c = (0, %h); %h<a><y> = 2;  is $c[1]<a>.keys.sort.join(','), 'x,y', 'nested hash key assign visible'; }
+
+# --- array :delete (with trailing-hole trim) ---
+{ my @a = 1,2,3; my $c = (0, @a); @a[2]:delete;      is $c[1].elems, 2, 'array delete + trim visible'; }
+
+# --- identity assertions ---
+{
+    my @arr = 0..9;
+    my $cap = (0, @arr);
+    ok $cap[1] =:= @arr, 'capture shares container identity';
+    @arr.push(10);
+    ok $cap[1] =:= @arr, 'identity preserved across push';
+    is $cap[1].elems, 11, 'capture sees the push';
+}
+
+# --- closure-captured (shared-cell) variables behave the same ---
+{ my @a = 1,2; my $f = { @a.elems };   my $c = (0, @a); @a.push(9); is $c[1].join(','), '1,2,9', 'cell: push visible'; }
+{ my @a = 1,2; my $f = { @a.push(9) }; my $c = (0, @a); $f();      is $c[1].join(','), '1,2,9', 'cell: closure push visible'; }
+{ my @a = 1,2; my $f = { @a.elems };   my $c = (0, @a); @a[0] = 9; is $c[1].join(','), '9,2',   'cell: element assign visible'; }
+{ my @a = 1,2; my $f = { @a[0] = 9 };  my $c = (0, @a); $f();      is $c[1].join(','), '9,2',   'cell: closure element assign visible'; }
+{ my %h = a=>1; my $f = { %h.elems };  my $c = (0, %h); %h<b> = 2; is $c[1].keys.sort.join(','), 'a,b', 'cell: hash key assign visible'; }
+{ my %h = a=>1; my $f = { %h<b> = 2 }; my $c = (0, %h); $f();      is $c[1].keys.sort.join(','), 'a,b', 'cell: closure hash key assign visible'; }
+{ my @a = 1,2; my $f = { @a = 7,8 };   my $c = (0, @a); $f();      is $c[1].join(','), '7,8',   'cell: closure whole reassign visible'; }
+
+# --- typed / defaulted containers (slow-path dispatch) ---
+{ my Int @a = 1,2; my $c = (0, @a); @a.push(9); is $c[1].join(','), '1,2,9', 'typed array push visible'; }
+{ my Int @a = 1,2; my $c = (0, @a); @a[0] = 9;  is $c[1].join(','), '9,2',   'typed array element assign visible'; }
+{ my Int @a = 1,2; my $c = (0, @a); @a.pop;     is $c[1].join(','), '1',     'typed array pop visible'; }
+{ my Int %h = a=>1; my $c = (0, %h); %h<b> = 2; is $c[1].keys.sort.join(','), 'a,b', 'typed hash key assign visible'; }
+{ my @a is default(42) = 1,2; my $c = (0, @a); @a.push(9); is $c[1].join(','), '1,2,9', 'defaulted array push visible'; }
+
+# --- := bound alias + capture ---
+{ my @a = 1,2; my @b := @a; my $c = (0, @a); @b.push(9); is $c[1].join(','), '1,2,9', 'bound-alias push visible through capture'; }
+
+# --- deep structures ---
+{ my %h = a=>[1]; my $c = (0, %h); %h<a>.push(2);   is $c[1]<a>.join(','), '1,2', 'array-in-hash push visible'; }
+{ my @a = [1,2], [3,4]; my $c = (0, @a); @a[0][0] = 9;      is $c[1][0].join(','), '9,2', 'nested element assign visible'; }
+{ my @a = [1,2], [3,4]; my $c = (0, @a); @a[0].splice(0,1); is $c[1][0].join(','), '2',   'element splice mutates in place'; }
+{ my @a = [1,2], [3,4]; is @a[0].splice(0,1).join(','), '1', 'element splice returns removed elements'; }
+
+# --- return-writeback shape: sub-local captured into a returned list ---
+{
+    sub make() { my @inner = 1,2; ( { @inner.push(9) }, (0, @inner) ) }
+    my ($cb, $cap) = make();
+    $cb();
+    is $cap[1].join(','), '1,2,9', 'returned capture tracks later closure mutation';
+}
+
+# --- copies stay detached (copy-time detach, not mutation-time COW) ---
+{ my @a = 1,2; my @b = @a; @a.push(9);  is @b.join(','), '1,2',   'my @b = @a copy unaffected by source push'; }
+{ my @a = 1,2; my @b = @a; @b.push(9);  is @a.join(','), '1,2',   'source unaffected by copy push'; }
+{ my %h = a=>1; my %g = %h; %h<b> = 2;  is %g.keys.join(','), 'a', 'hash copy unaffected by source write'; }
+{ my @a = 1,2; my @b = @a.clone; @a.push(9); is @b.join(','), '1,2', '.clone unaffected by source push'; }
+{
+    my @a = 1, 2;
+    sub f(@b is copy) { @b.push(9); @b.join(',') }
+    is f(@a), '1,2,9', 'is copy param gets its own container';
+    is @a.join(','), '1,2', 'is copy param mutation does not reach caller';
+}
+{
+    my %h = a => 1;
+    sub g(%b is copy) { %b<z> = 9; %b.keys.sort.join(',') }
+    is g(%h), 'a,z', 'is copy hash param gets its own container';
+    is %h.keys.join(','), 'a', 'is copy hash param mutation does not reach caller';
+}
+
+# --- reference holders keep tracking (non-copy '=' targets) ---
+{ my @a = 1,2; my @outer; @outer[0] = @a; @a.push(9); is @outer[0].join(','), '1,2,9', 'element holding array tracks push'; }
+{ my @a = 1,2; my %h; %h<k> = @a; @a.push(9);         is %h<k>.join(','), '1,2,9',    'hash value holding array tracks push'; }
+{ my @a = 1,2; my $s = @a; @a.push(9);                is $s.join(','), '1,2,9',       'scalar holding array tracks push'; }


### PR DESCRIPTION
## Summary

BLOCKERS §3.2 item 1 (第一級コンテナ campaign): element-level mutations now mutate the variable's container **in place through the shared backing node**, so every by-value holder of the same container — an `@a` captured into a list `(0, @a)`, an element, a scalar — observes the mutation, matching Raku container identity. Previously every such mutation went through `Gc::make_mut`, which COW-detaches the moment the backing `Gc` is shared, silently orphaning captures (probed: 20/26 basic mutation ops failed vs raku; all 57 probe cases now match).

This also closes the **ident4** sub-case (BLOCKERS §5: closure-captured shared-cell arrays captured by value into a list did not track later cell updates — the return-writeback family).

## Mechanism

- New `gc_data_mut` helper (`value/aliased_mut.rs`): write through the shared node (`gc_contents_mut`) when `strong_count > 1`, plain `Gc::make_mut` when exclusively owned. Converted the mutation chokepoints in `vm_data_push_ops` / `vm_call_method_mut_ops` (fast paths), `methods_mut_dispatch` (slow path), `vm_var_assign_index_named` / `vm_var_assign_post_incdec` / `vm_var_delete_ops` / `vm_var_index_tracking` / `vm_var_multidim_helpers` (element/slice/delete/incdec/multidim), removing the sigil-based COW carve-outs (`!var_name.starts_with('@')`).
- Copy semantics are enforced **at copy time**, not by mutation-time COW: `my @b = @a` already detaches (#4354); `is copy` parameter binding now detaches too (`Value::detach_shared_container`, applied in `binding_signature.rs`).

## Real bugs found & fixed

1. `@a[i].splice(...)` wrote the method's **return value** (removed elements) back into the element (`[[1],…]` instead of `[[2],…]`). Splice now uses the pop/shift invocant-writeback branch in `compile_expr_method_on_index`.
2. Slow-path `do_splice` read replacement args **after** draining, so self-splice (`splice(@a, .., @a)`) inserted post-drain state (caught by `array[int]` self-splice subtests in `roast/S32-array/splice.t`).
3. `make_shaped_array` cloned one child row for all rows: every row of `my @md[2;2]` shared a backing `Gc`, so element writes aliased across rows once writes became in-place (caught by `roast/S02-types/multi_dimensional_array.t`).

## Verification

- `t/container-identity-mutation.t` (new, 55 cases) — passes under mutsu **and** raku.
- 3 probe scripts vs raku: 57/57 match (mutation visibility, copy independence for `my @b = @a` / `.clone` / `is copy`, typed/defaulted/shaped/cell/nested paths).
- `make test` green (release build + full `t/`).
- Local roast: all 224 whitelisted files across S02-types / S03-operators / S06-signature / S06-traits / S09-typed-arrays / S32-array / S32-hash pass (30298 tests), including the §3 canaries `splice.t` and `variables-and-packages.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW