### PR TITLE
fix(runtime): default `@!`/`%!` attributes to empty Array/Hash in `bless`

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -242,7 +242,7 @@ impl Interpreter {
         // Initialize with default attribute values
         let mut attributes = HashMap::new();
         if self.registry().classes.contains_key(&class_name.resolve()) {
-            for (attr_name, _is_public, default, _is_rw, _, _, _) in
+            for (attr_name, _is_public, default, _is_rw, _, sigil, _) in
                 self.collect_class_attributes(&class_name.resolve())
             {
                 let val = if let Some(Expr::Literal(ref lit_val)) = default {
@@ -251,6 +251,31 @@ impl Interpreter {
                     lit_val.clone()
                 } else if let Some(expr) = default {
                     self.eval_block_value(&[Stmt::Expr(expr)])?
+                } else if sigil == '@' {
+                    // A `@`-sigil attribute with no default is an empty Array,
+                    // not Nil (matches `dispatch_new`). Leaving it Nil makes
+                    // `@!attr.elems` return 1 (Any.elems) and corrupts guards.
+                    let mut arr = Value::real_array(Vec::new());
+                    let tc = self
+                        .registry()
+                        .classes
+                        .get(&class_name.resolve())
+                        .and_then(|cd| cd.attribute_types.get(&attr_name))
+                        .cloned();
+                    if let Some(tc) = tc {
+                        arr = self.tag_container_metadata(
+                            arr,
+                            super::ContainerTypeInfo {
+                                value_type: tc,
+                                key_type: None,
+                                declared_type: None,
+                            },
+                        );
+                    }
+                    arr
+                } else if sigil == '%' {
+                    // A `%`-sigil attribute with no default is an empty Hash.
+                    Value::hash(HashMap::new())
                 } else {
                     // Native types have zero/empty defaults instead of Nil
                     let type_constraint =

--- a/t/bless-container-attr-defaults.t
+++ b/t/bless-container-attr-defaults.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+plan 12;
+
+# A custom `new` that routes through `self.bless(...)` must still default
+# unassigned `@!`/`%!` attributes to an empty Array/Hash, not leave them Nil.
+# Leaving an array attribute as Nil makes `@!attr.elems` return 1 (Any.elems),
+# which silently corrupts any guard like `return @!cache if @!cache.elems`.
+
+# --- direct bless ---
+{
+    class A { has @!c; method probe { @!c } }
+    my $a = A.bless;
+    is $a.probe.^name, 'Array', 'direct bless: @! attr defaults to Array';
+    is $a.probe.elems, 0, 'direct bless: @! attr is empty';
+}
+
+{
+    class B { has %!h; method probe { %!h } }
+    my $b = B.bless;
+    is $b.probe.^name, 'Hash', 'direct bless: %! attr defaults to Hash';
+    is $b.probe.elems, 0, 'direct bless: %! attr is empty';
+}
+
+{
+    class C { has @.pub; }
+    my $c = C.bless;
+    is $c.pub.^name, 'Array', 'direct bless: @. public attr defaults to Array';
+    is $c.pub.elems, 0, 'direct bless: @. public attr is empty';
+}
+
+# --- typed array attribute keeps its element type ---
+{
+    class D { has Int @!c; method probe { @!c } }
+    my $d = D.bless;
+    is $d.probe.^name, 'Array[Int]', 'direct bless: typed @! attr keeps element type';
+    is $d.probe.elems, 0, 'direct bless: typed @! attr is empty';
+}
+
+# --- custom new -> bless with extra named arg (Zef::Distribution pattern) ---
+{
+    class E {
+        has $.name;
+        has @!cache;
+        method new(*%_) { self.bless(|%_, :meta(%_)) }
+        method lazy-list(--> Array) {
+            return @!cache if @!cache.elems;   # guard must not fire on empty
+            my @r = ();
+            return @!cache := @r;
+        }
+    }
+    my $e = E.new(:name<x>);
+    is $e.name, 'x', 'custom new: named attr set';
+    my $ll := $e.lazy-list;
+    is $ll.^name, 'Array', 'custom new: guarded lazy list returns Array';
+    is $ll.elems, 0, 'custom new: guarded lazy list is empty';
+}
+
+# --- scalar attr with no default is still Any ---
+{
+    class F { has $!s; method probe { $!s } }
+    is F.bless.probe.^name, 'Any', 'direct bless: $! attr with no default stays Any';
+}


### PR DESCRIPTION
## Problem

A custom `new` that constructs via `self.bless(...)` — e.g. the Zef::Distribution pattern `method new(*%_) { self.bless(|%_, :meta(%_)) }` — left unassigned `@`/`%`-sigil attributes as `Nil` instead of an empty `Array`/`Hash`.

`dispatch_new` already defaults containers by sigil, but `dispatch_bless` only handled native `int`/`num`/`str` scalars and fell through to `Value::NIL` for everything else.

The corruption is silent and dangerous: a `Nil` array attribute reports `.elems == 1` (`Any.elems`), so a guard like `return @!cache if @!cache.elems` fires on an "empty" cache and returns the `Nil`. This is exactly why `Zef::Distribution.provides-specs` returned `Any` — breaking `contains-spec` → `spec-matcher` with `No such method 'spec-matcher' for invocant of type 'Any'` — in zef's `distribution-depends-parsing` upstream test.

Minimal repro:
```raku
class D { has @!c; method probe { say @!c.elems, " ", @!c.^name } }
D.bless.probe;   # mutsu (before): 1 Any   raku: 0 Array
```

## Fix

In `dispatch_bless`, default `@`-sigil attributes to an empty `Array` (tagged with the declared element type when present) and `%`-sigil attributes to an empty `Hash`, mirroring `dispatch_new`.

## Test

`t/bless-container-attr-defaults.t` (12 subtests). `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)