### PR TITLE
fix(runtime): resolve imported role alias in an anonymous class `does`

### DIFF
--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -1807,7 +1807,24 @@ impl Interpreter {
                     }
                 }
                 Stmt::DoesDecl { name: role_name } => {
-                    let role_name_str = role_name.resolve();
+                    let raw_role_name = role_name.resolve();
+                    // An imported role referenced by its short alias (`does
+                    // PackageRepo` where the role is registered as
+                    // `MyMod::PackageRepo`) must be resolved to its qualified
+                    // name. `does_parents` on a named class already resolves via
+                    // `resolve_declared_type_name`; the body `DoesDecl` emitted
+                    // for an anonymous `class :: does R` did not, so it failed
+                    // with "Unknown role" for module-exported roles.
+                    let role_name_str = if self.registry().roles.contains_key(&raw_role_name) {
+                        raw_role_name.clone()
+                    } else {
+                        let resolved = self.resolve_declared_type_name(&raw_role_name);
+                        if self.registry().roles.contains_key(&resolved) {
+                            resolved
+                        } else {
+                            raw_role_name.clone()
+                        }
+                    };
                     if !self.registry().roles.contains_key(&role_name_str)
                         && matches!(
                             role_name_str.as_str(),

--- a/t/anon-class-does-imported-role.t
+++ b/t/anon-class-does-imported-role.t
@@ -1,0 +1,46 @@
+use v6;
+use lib 't/lib';
+use Test;
+use AnonDoesRole;
+
+plan 5;
+
+# An anonymous class (`class :: does R`) that composes a role imported by its
+# short alias (`Searchable`, registered as `AnonDoesRole::Searchable`) must
+# resolve the alias to the qualified role — just like a named class does. The
+# body `DoesDecl` emitted for the anonymous class previously looked the role up
+# by its short name only and failed with "Unknown role".
+
+# top-level anonymous class composing an imported role
+{
+    my $c = class :: does Searchable { method search(*@) { "TOP" } };
+    is $c.search("x"), "TOP", "top-level anon class does imported role";
+}
+
+# anonymous class declared inside a sub body
+{
+    sub make { class :: does Searchable { method search(*@) { "SUB" } } }
+    is make().search("x"), "SUB", "anon class does imported role inside sub body";
+}
+
+# anonymous class declared inside a method body
+{
+    class Holder {
+        method plugin { class :: does Searchable { method search(*@) { "METHOD" } } }
+    }
+    is Holder.new.plugin.search("x"), "METHOD",
+        "anon class does imported role inside method body";
+}
+
+# `(BaseClass but role :: {...})` whose role method body declares an anon class
+# doing an imported role — the zef recommendation-manager mock pattern.
+{
+    my $obj = (Repo but role :: {
+        method plugins(*@) {
+            [ class :: does Searchable { method search(*@) { "MIXED" } }, ]
+        }
+    }).new;
+    my @p = $obj.plugins;
+    is @p.elems, 1, "but-role method returns the plugin list";
+    is @p[0].search("x"), "MIXED", "anon class inside but-role method does imported role";
+}

--- a/t/lib/AnonDoesRole.rakumod
+++ b/t/lib/AnonDoesRole.rakumod
@@ -1,0 +1,11 @@
+unit module AnonDoesRole;
+
+# An exported role, referenced by its short alias from the importing scope.
+role Searchable is export {
+    method search(*@) { ... }
+}
+
+# An exported base class used as the `but role` invocant.
+class Repo is export {
+    method plugins { [] }
+}


### PR DESCRIPTION
## Problem

An anonymous class (`class :: does R`) that composes a role imported by its short alias — `does Searchable` where the role is registered as `MyMod::Searchable` — failed with `Unknown role: Searchable`.

A *named* class resolves its `does` targets through `resolve_declared_type_name` (which maps the short alias to the qualified name), but the body `DoesDecl` statement emitted for an anonymous class looked the role up by its raw short name only.

Minimal repro (role exported from a module):
```raku
use MyMod;   # exports `role Searchable`
my $c = class :: does Searchable { method search(*@) { "x" } };  # Unknown role: Searchable
```

This surfaced in zef's `distribution-depends-parsing` test: the recommendation-manager mock builds `class :: does PackageRepository { ... }` inside a `but role` method body, where `PackageRepository` is exported by `use Zef`.

## Fix

In the `Stmt::DoesDecl` handler, when the raw role name is not a known role, resolve it via `resolve_declared_type_name` and retry before erroring — matching how a named class's `does_parents` are resolved.

## Test

`t/anon-class-does-imported-role.t` (5 subtests, fixture `t/lib/AnonDoesRole.rakumod`). `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)