### PR TITLE
fix(runtime): a `gather` block evaluates to a Seq, not an Array

### DIFF
--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -9,6 +9,9 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         ValueView::Bool(_) => "Bool",
         ValueView::Array(_, kind) if kind.is_real_array() => "Array",
         ValueView::Array(_, _) => "List",
+        // A `gather` block evaluates to a `Seq` in Raku; other lazy lists
+        // (`lazy for`, arithmetic/closure sequences) present as `Array`/`List`.
+        ValueView::LazyList(ll) if ll.is_from_gather() => "Seq",
         ValueView::LazyList(_) => "Array",
         ValueView::Hash(_) => "Hash",
         ValueView::Range(_, _)

--- a/t/gather-returns-seq.t
+++ b/t/gather-returns-seq.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+plan 12;
+
+# A `gather` block evaluates to a `Seq` in Raku, not an `Array`.
+
+is (gather { take 5 }).^name, 'Seq', 'gather .^name is Seq';
+ok (gather { take 1; take 2 }) ~~ Seq, 'gather result does Seq';
+nok (gather { take 1; take 2 }) ~~ Array, 'gather result is not an Array';
+ok (gather { take 1; take 2 }) ~~ Iterable, 'gather result is Iterable';
+
+# A `--> Seq` return constraint accepts a gather result.
+{
+    sub f(--> Seq) { gather { take 1; take 2; take 3 } }
+    my $r = f();
+    is $r.^name, 'Seq', 'routine with --> Seq returns a Seq';
+    is $r.List, (1, 2, 3), 'the returned Seq reifies correctly';
+}
+
+# Method with `--> Seq` returning gather (the zef PackageRepository.search shape).
+{
+    class Repo {
+        method search(*@names --> Seq) {
+            gather for @names -> $n { take "found:$n" }
+        }
+    }
+    my @r = Repo.new.search('a', 'b');
+    is @r.elems, 2, 'method --> Seq gather yields all elements';
+    is @r[0], 'found:a', 'first element correct';
+    is @r[1], 'found:b', 'second element correct';
+}
+
+# Assigning a gather to an `@` variable still coerces to Array (Seq.Array).
+{
+    my @a = gather { take 1; take 2 };
+    is @a.^name, 'Array', 'gather assigned to @ is an Array';
+    is @a.elems, 2, 'assigned array has the elements';
+}
+
+# An empty gather is still a Seq.
+is (gather { }).^name, 'Seq', 'empty gather is a Seq';


### PR DESCRIPTION
## Problem

`gather { ... }` produced a `LazyList` value that reported its type as `Array`, so:
- `(gather {...}).^name` was `Array` (raku: `Seq`)
- `(gather {...}) ~~ Seq` was `False`, `~~ Array` was `True` (both backwards)
- a `--> Seq` return constraint on a routine returning a gather block failed with `Type check failed for return value; expected Seq but got Array`

Raku specifies `gather` as evaluating to a `Seq`. This blocked zef's `PackageRepository.search(... --> Seq) { gather ... }` shape used by the recommendation-manager mock in `distribution-depends-parsing`.

## Fix

`value_type_name` reports a gather-originated `LazyList` (`is_from_gather()`) as `Seq`. Other lazy lists (`lazy for`, arithmetic/closure sequences) keep their `Array`/`List` type. Assigning a gather to an `@` variable still coerces to `Array` as before.

## Test

`t/gather-returns-seq.t` (12 subtests). `make test` passes; gather roast tests (`S04-statements/gather.t`, integration gather tests) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)