### PR TITLE
fix(vm,runtime): make_mut site inventory — variable-container mutations write through the shared node (container identity §3)

### DIFF
--- a/src/runtime/builtins_collection_listops.rs
+++ b/src/runtime/builtins_collection_listops.rs
@@ -24,7 +24,10 @@ impl Interpreter {
                 if items.is_empty() {
                     make_empty_array_failure("shift")
                 } else {
-                    crate::gc::Gc::make_mut(&mut items).remove(0)
+                    // Write through the shared node: the arg is the caller's
+                    // own array container (container identity, §3) — a COW
+                    // detach here would silently drop the removal.
+                    crate::value::gc_data_mut(&mut items).remove(0)
                 }
             }
             _ => make_empty_array_failure("shift"),
@@ -56,11 +59,13 @@ impl Interpreter {
         }
         Ok(match args.first().cloned().and_then(|v| v.into_array()) {
             Some((mut items, _)) => {
-                let items_mut = crate::gc::Gc::make_mut(&mut items);
-                if items_mut.is_empty() {
+                if items.is_empty() {
                     make_empty_array_failure("pop")
                 } else {
-                    items_mut.pop().unwrap_or(Value::NIL)
+                    // Same shared-node write-through as `builtin_shift` above.
+                    crate::value::gc_data_mut(&mut items)
+                        .pop()
+                        .unwrap_or(Value::NIL)
                 }
             }
             _ => make_empty_array_failure("pop"),

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -110,7 +110,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
         if matches!(target.view(), ValueView::Hash(..)) {
             return target
                 .with_hash_mut(|map| {
-                    let map_mut = crate::gc::Gc::make_mut(map);
+                    let map_mut = crate::value::gc_data_mut(map);
                     if indices.len() == 1 {
                         let out: Vec<Value> = map_mut.drain().map(|(_, v)| v).collect();
                         Value::array(out)
@@ -126,7 +126,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
         }
         return target
             .with_array_mut(|items, _kind| {
-                let items = crate::gc::Gc::make_mut(items);
+                let items = crate::value::gc_data_mut(items);
                 let mut out = Vec::with_capacity(items.len());
                 for item in items.iter_mut() {
                     out.push(multidim_delete(item, &indices[1..]));
@@ -159,10 +159,10 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
         return target
             .with_hash_mut(|map| {
                 if indices.len() == 1 {
-                    let map_mut = crate::gc::Gc::make_mut(map);
+                    let map_mut = crate::value::gc_data_mut(map);
                     return map_mut.remove(&key).unwrap_or_else(default);
                 }
-                let map_mut = crate::gc::Gc::make_mut(map);
+                let map_mut = crate::value::gc_data_mut(map);
                 match map_mut.get_mut(&key) {
                     Some(inner) => multidim_delete(inner, &indices[1..]),
                     None => default(),
@@ -188,7 +188,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
                 ValueView::Num(f) => f as usize,
                 _ => return default(),
             };
-            let items = crate::gc::Gc::make_mut(items_gc);
+            let items = crate::value::gc_data_mut(items_gc);
             if i >= items.len() {
                 return default();
             }

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -354,7 +354,7 @@ impl Interpreter {
                         entry.with_array_mut(|live, _| {
                             let hole_value =
                                 Value::package(crate::symbol::Symbol::intern(&hole_type));
-                            let arr = crate::gc::Gc::make_mut(live);
+                            let arr = crate::value::gc_data_mut(live);
                             for i in &leaves {
                                 if *i >= 0 && (*i as usize) < arr.len() {
                                     arr[*i as usize] = hole_value.clone();
@@ -465,7 +465,7 @@ impl Interpreter {
             && let Some(entry) = self.env.get_mut(var_name)
         {
             entry.with_hash_mut(|map| {
-                let h = crate::gc::Gc::make_mut(map);
+                let h = crate::value::gc_data_mut(map);
                 for idx in &indices {
                     h.remove(&idx.to_string_value());
                 }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -612,7 +612,10 @@ impl Interpreter {
             return Err(RuntimeError::cannot_lazy("pop"));
         }
         if let Some(result) = target.with_array_mut(|items, _| {
-            let items_mut = crate::gc::Gc::make_mut(items);
+            // The mutated node may be shared with a live holder (this fallback
+            // takes `target` by value with no write-back), so write through
+            // the shared node — container identity (§3).
+            let items_mut = crate::value::gc_data_mut(items);
             if items_mut.is_empty() {
                 make_empty_array_failure("pop")
             } else {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1953,7 +1953,7 @@ impl Interpreter {
             .entry(attr_name.to_string())
             .or_insert_with(|| Value::real_array(Vec::new()));
         if let Some(result) = arr.with_array_mut(|items, _| -> Result<Value, RuntimeError> {
-            let items = crate::gc::Gc::make_mut(items);
+            let items = crate::value::gc_data_mut(items);
             match method {
                 "push" => {
                     for arg in args {

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -475,7 +475,8 @@ impl Interpreter {
                 sv.insert(key.to_string(), shared_value);
             }
         }
-        // Fallback for non-shared arrays: use Arc::make_mut for COW
+        // Fallback for non-shared arrays: write through the shared node so
+        // same-thread by-value holders observe the push (container identity §3).
         if matches!(
             self.env.get(key).map(Value::view),
             Some(ValueView::Array(..))
@@ -485,7 +486,7 @@ impl Interpreter {
                 .get_mut(key)
                 .unwrap()
                 .with_array_mut(|arc_items, kind| {
-                    let items = crate::gc::Gc::make_mut(arc_items);
+                    let items = crate::value::gc_data_mut(arc_items);
                     items.extend(values);
                     // Normalize @-variables only from List to Array while preserving Shaped.
                     if key.starts_with('@') && *kind == ArrayKind::List {

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -83,6 +83,63 @@ impl Interpreter {
         Err(err)
     }
 
+    /// Identity-preserving STORE for a declared QuantHash variable:
+    /// `%s = <a b>` on a `my %s is SetHash` writes the coerced contents INTO
+    /// the variable's existing container node (keeping the node's embedded
+    /// type metadata), so every holder of that node — the env mirror the
+    /// trait op installed, `:=` binds, by-value captures — observes the
+    /// reassignment (container identity §3). Without this, the coercion
+    /// returns a fresh node that `SetLocal` stores only into the local slot,
+    /// leaving the env mirror stale (a later name-based subscript assign then
+    /// mutates the stale empty container and clobbers the slot on writeback).
+    /// Falls through when the variable has no existing same-kind container.
+    fn quanthash_store_preserving_identity(&mut self, name: &str, coerced: Value) -> Value {
+        let existing = self.env().get(name).cloned();
+        match (existing.as_ref().map(Value::view), coerced.view()) {
+            (Some(ValueView::Set(old, mutable)), ValueView::Set(new, _))
+                if !crate::gc::Gc::ptr_eq(old, new) =>
+            {
+                let mut data = (**new).clone();
+                data.value_type = old.value_type.clone();
+                data.key_type = old.key_type.clone();
+                data.declared_type = old.declared_type.clone();
+                // SAFETY: audited aliased in-place container write; see
+                // `value::aliased_mut` (no other borrow live, single write).
+                unsafe {
+                    *crate::value::gc_contents_mut(old) = data;
+                }
+                Value::set_parts(old.clone(), mutable)
+            }
+            (Some(ValueView::Bag(old, mutable)), ValueView::Bag(new, _))
+                if !crate::gc::Gc::ptr_eq(old, new) =>
+            {
+                let mut data = (**new).clone();
+                data.value_type = old.value_type.clone();
+                data.key_type = old.key_type.clone();
+                data.declared_type = old.declared_type.clone();
+                // SAFETY: as above.
+                unsafe {
+                    *crate::value::gc_contents_mut(old) = data;
+                }
+                Value::bag_parts(old.clone(), mutable)
+            }
+            (Some(ValueView::Mix(old, mutable)), ValueView::Mix(new, _))
+                if !crate::gc::Gc::ptr_eq(old, new) =>
+            {
+                let mut data = (**new).clone();
+                data.value_type = old.value_type.clone();
+                data.key_type = old.key_type.clone();
+                data.declared_type = old.declared_type.clone();
+                // SAFETY: as above.
+                unsafe {
+                    *crate::value::gc_contents_mut(old) = data;
+                }
+                Value::mix_parts(old.clone(), mutable)
+            }
+            _ => coerced,
+        }
+    }
+
     pub(super) fn coerce_hash_var_value(
         &mut self,
         name: &str,
@@ -100,7 +157,8 @@ impl Interpreter {
                 Some(ValueView::Bag(_, _) | ValueView::Mix(_, _) | ValueView::Set(_, _))
             );
             if is_quanthash_container {
-                return self.try_compiled_method_or_interpret(value, trait_name, vec![]);
+                let coerced = self.try_compiled_method_or_interpret(value, trait_name, vec![])?;
+                return Ok(self.quanthash_store_preserving_identity(name, coerced));
             }
         }
         if self.check_readonly_for_modify(name).is_err()
@@ -139,7 +197,8 @@ impl Interpreter {
             let result = runtime::utils::coerce_value_to_quanthash(&value);
             // SetHash should be mutable
             if let ValueView::Set(items, _) = result.view() {
-                return Ok(Value::set_parts(items.clone(), true));
+                let coerced = Value::set_parts(items.clone(), true);
+                return Ok(self.quanthash_store_preserving_identity(name, coerced));
             }
             return Ok(result);
         }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -669,10 +669,26 @@ impl Interpreter {
                 self.remove_bound_index(&var_name, &encoded_idx);
             }
         }
-        if !self.env().contains_key(&var_name)
+        let env_needs_slot_pull = match self.env().get(&var_name).map(Value::view) {
+            None => true,
+            // A hoisted declaration placeholder (type object / Nil) is NOT the
+            // live container — the real value may live only in the local slot
+            // (e.g. `my %s is SetHash = <a>`). Writing against the placeholder
+            // would autovivify a fresh container and clobber the slot value.
+            Some(ValueView::Nil) | Some(ValueView::Package(_)) => true,
+            Some(_) => false,
+        };
+        if env_needs_slot_pull
             && let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
         {
-            self.set_env_with_main_alias(&var_name, self.locals[slot].clone());
+            let slot_val = self.locals[slot].clone();
+            // Only override an existing env placeholder with a real container;
+            // when env lacks the key entirely, mirror the slot as before.
+            if !self.env().contains_key(&var_name)
+                || !matches!(slot_val.view(), ValueView::Nil | ValueView::Package(_))
+            {
+                self.set_env_with_main_alias(&var_name, slot_val);
+            }
         }
         // Junction autothreading: when writing back with a junction index,
         // expand the junction and assign each element separately.
@@ -705,7 +721,7 @@ impl Interpreter {
                     }
                     if let Some(container) = self.env_root_descended_mut(&var_name) {
                         let _ = container.with_hash_mut(|hash| {
-                            let h = crate::gc::Gc::make_mut(hash);
+                            let h = crate::value::gc_data_mut(hash);
                             h.insert(k, v);
                         });
                     }
@@ -715,7 +731,7 @@ impl Interpreter {
                     self.env_root_descended_mut(&var_name)
                         .and_then(|container| {
                             container.with_array_mut(|items, _| -> Result<(), RuntimeError> {
-                                let arr = crate::gc::Gc::make_mut(items);
+                                let arr = crate::value::gc_data_mut(items);
                                 Self::autoviv_resize(arr, idx_usize + 1, native_fill.clone())?;
                                 arr[idx_usize] = v;
                                 Ok(())
@@ -757,7 +773,7 @@ impl Interpreter {
                     if let Some(max_idx) = max_index {
                         container
                             .with_array_mut(|items, _| -> Result<(), RuntimeError> {
-                                let arr = crate::gc::Gc::make_mut(items);
+                                let arr = crate::value::gc_data_mut(items);
                                 Self::autoviv_resize(arr, max_idx + 1, native_fill.clone())?;
                                 Ok(())
                             })
@@ -1025,7 +1041,7 @@ impl Interpreter {
                 )> = Vec::new();
                 if let Some(entry) = self.env_mut().get_mut(&var_name) {
                     let _ = entry.with_hash_mut(|hash| {
-                        let h = crate::gc::Gc::make_mut(hash);
+                        let h = crate::value::gc_data_mut(hash);
                         for (i, key) in keys.iter().enumerate() {
                             let k = if slice_is_object_hash {
                                 runtime::utils::value_which_key(key)
@@ -1578,7 +1594,7 @@ impl Interpreter {
                         } else if let Some((slice_indices, vals)) = &range_slice {
                             container
                                 .with_array_mut(|items, _| -> Result<(), RuntimeError> {
-                                    let arr = crate::gc::Gc::make_mut(items);
+                                    let arr = crate::value::gc_data_mut(items);
                                     if let Some(max_idx) = slice_indices.last().copied()
                                         && max_idx >= arr.len()
                                     {
@@ -1728,7 +1744,7 @@ impl Interpreter {
                         if !*is_mutable {
                             return Err(RuntimeError::assignment_ro(Some("Set")));
                         }
-                        let s = crate::gc::Gc::make_mut(set);
+                        let s = crate::value::gc_data_mut(set);
                         let present = val.truthy();
                         if present {
                             s.insert(key.clone());
@@ -1745,7 +1761,7 @@ impl Interpreter {
                         if !*is_mutable {
                             return Err(RuntimeError::assignment_ro(Some("Bag")));
                         }
-                        let b = crate::gc::Gc::make_mut(bag);
+                        let b = crate::value::gc_data_mut(bag);
                         let count = Self::bag_assignment_count(&val)?;
                         if count == num_bigint::BigInt::from(0) {
                             b.remove(&key);
@@ -1761,7 +1777,7 @@ impl Interpreter {
                         if !*is_mutable {
                             return Err(RuntimeError::assignment_ro(Some("Mix")));
                         }
-                        let m = crate::gc::Gc::make_mut(mix);
+                        let m = crate::value::gc_data_mut(mix);
                         let weight = Self::mix_assignment_weight(&val)?;
                         if weight == 0.0 {
                             m.remove(&key);
@@ -2522,7 +2538,7 @@ impl Interpreter {
                     if let Some(next) =
                         cur.with_array_mut(|arr_arc, _| -> Result<*mut Value, RuntimeError> {
                             if let Ok(i) = key.parse::<usize>() {
-                                let arr = crate::gc::Gc::make_mut(arr_arc);
+                                let arr = crate::value::gc_data_mut(arr_arc);
                                 Self::autoviv_resize(arr, i + 1, native_fill.clone())?;
                                 // Autovivify if needed. A `ContainerRef` is a
                                 // `:=`-bound cell that holds (and is descended to)
@@ -2549,7 +2565,7 @@ impl Interpreter {
                     {
                         current = next?;
                     } else if let Some(next) = cur.with_hash_mut(|hash_arc| {
-                        let hash = crate::gc::Gc::make_mut(hash_arc);
+                        let hash = crate::value::gc_data_mut(hash_arc);
                         if !hash.contains_key(key.as_str()) {
                             let new_val = if next_positional {
                                 Value::real_array(Vec::new())
@@ -2572,7 +2588,7 @@ impl Interpreter {
                         if let Some(next) =
                             cur.with_array_mut(|arr_arc, _| -> Result<*mut Value, RuntimeError> {
                                 if let Ok(i) = key.parse::<usize>() {
-                                    let arr = crate::gc::Gc::make_mut(arr_arc);
+                                    let arr = crate::value::gc_data_mut(arr_arc);
                                     Self::autoviv_resize(
                                         arr,
                                         i + 1,
@@ -2591,7 +2607,7 @@ impl Interpreter {
                         {
                             current = next?;
                         } else if let Some(next) = cur.with_hash_mut(|hash_arc| {
-                            let hash = crate::gc::Gc::make_mut(hash_arc);
+                            let hash = crate::value::gc_data_mut(hash_arc);
                             let new_val = if next_positional {
                                 Value::real_array(Vec::new())
                             } else {
@@ -2617,7 +2633,7 @@ impl Interpreter {
                     let cur = &mut *current;
                     if let Some(r) = cur.with_array_mut(|arr_arc, _| -> Result<(), RuntimeError> {
                         if let Ok(i) = key.parse::<usize>() {
-                            let arr = crate::gc::Gc::make_mut(arr_arc);
+                            let arr = crate::value::gc_data_mut(arr_arc);
                             Self::autoviv_resize(arr, i + 1, native_fill.clone())?;
                             if bind_cell.is_some() {
                                 arr[i] = leaf_val.clone();
@@ -2630,7 +2646,7 @@ impl Interpreter {
                         r?;
                     } else if cur
                         .with_hash_mut(|hash_arc| {
-                            let hash = crate::gc::Gc::make_mut(hash_arc);
+                            let hash = crate::value::gc_data_mut(hash_arc);
                             if bind_cell.is_some() {
                                 hash.insert(key.clone(), leaf_val.clone());
                             } else {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -216,7 +216,7 @@ impl Interpreter {
                     return Err(RuntimeError::assignment_ro(None));
                 };
                 if let Some(res) = container.with_array_mut(|items, _| {
-                    let arr = crate::gc::Gc::make_mut(items);
+                    let arr = crate::value::gc_data_mut(items);
                     Self::autoviv_resize(arr, i + 1, Value::package(Symbol::intern("Any")))?;
                     arr[i] = value.take().unwrap_or(Value::NIL);
                     Ok(())
@@ -231,7 +231,7 @@ impl Interpreter {
                 .get_mut(source_name)
                 .and_then(|v| {
                     v.with_hash_mut(|hash| {
-                        let h = crate::gc::Gc::make_mut(hash);
+                        let h = crate::value::gc_data_mut(hash);
                         h.insert(idx_str.to_string(), value);
                     })
                 })
@@ -246,7 +246,7 @@ impl Interpreter {
                 return Err(RuntimeError::assignment_ro(None));
             };
             let Some(res) = container.with_array_mut(|items, _| {
-                let arr = crate::gc::Gc::make_mut(items);
+                let arr = crate::value::gc_data_mut(items);
                 Self::autoviv_resize(arr, i + 1, Value::package(Symbol::intern("Any")))?;
                 arr[i] = value;
                 Ok(())

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -994,7 +994,7 @@ impl Interpreter {
                 Self::ensure_array_size(target, i + 1);
                 target
                     .with_array_mut(|items, _| {
-                        let items = crate::gc::Gc::make_mut(items);
+                        let items = crate::value::gc_data_mut(items);
                         self.multi_dim_assign_slice(&mut items[i], rest, values, vi)
                     })
                     .transpose()?;
@@ -1002,7 +1002,7 @@ impl Interpreter {
                 Self::ensure_hash(target);
                 target
                     .with_hash_mut(|map| {
-                        let map = crate::gc::Gc::make_mut(map);
+                        let map = crate::value::gc_data_mut(map);
                         let entry = map.entry(s.as_str().to_string()).or_insert_with(|| {
                             Value::package(crate::symbol::Symbol::intern("Any"))
                         });
@@ -1041,7 +1041,7 @@ impl Interpreter {
             Self::ensure_array_size(target, i + 1);
             target
                 .with_array_mut(|items, _| {
-                    let items = crate::gc::Gc::make_mut(items);
+                    let items = crate::value::gc_data_mut(items);
                     self.multi_dim_assign_scalar(&mut items[i], rest, value)
                 })
                 .transpose()?;
@@ -1049,7 +1049,7 @@ impl Interpreter {
             Self::ensure_hash(target);
             target
                 .with_hash_mut(|map| {
-                    let map = crate::gc::Gc::make_mut(map);
+                    let map = crate::value::gc_data_mut(map);
                     let entry = map
                         .entry(s.as_str().to_string())
                         .or_insert_with(|| Value::package(crate::symbol::Symbol::intern("Any")));
@@ -1144,7 +1144,7 @@ impl Interpreter {
         if target
             .with_array_mut(|items, _| {
                 if items.len() < min_size {
-                    let items = crate::gc::Gc::make_mut(items);
+                    let items = crate::value::gc_data_mut(items);
                     items.resize(
                         min_size,
                         Value::package(crate::symbol::Symbol::intern("Any")),

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -220,7 +220,13 @@ impl Interpreter {
                     Some(ValueView::Set(_, _) | ValueView::Bag(_, _) | ValueView::Mix(_, _)) => {
                         true
                     }
-                    _ => false,
+                    Some(ValueView::Nil) | Some(ValueView::Package(_)) | None => false,
+                    // A scalar initializer — `my %s is SetHash = <a>` (a single
+                    // angle-quoted word is a Str, not a List), a Pair, an Int
+                    // weight, ... — is an init value to coerce; treating it as
+                    // "no initializer" would overwrite the slot with an EMPTY
+                    // QuantHash and silently drop the initialization.
+                    Some(_) => true,
                 };
                 let mut instance = if has_init_values {
                     let init_val = current_val.unwrap();

--- a/t/container-identity-mutation.t
+++ b/t/container-identity-mutation.t
@@ -8,7 +8,7 @@ use Test;
 # Copies (`my @b = @a`, `is copy` params, `.clone`) stay detached: `=` copy
 # semantics are enforced at copy time, not by copy-on-write at mutation time.
 
-plan 55;
+plan 60;
 
 # --- array method mutations visible through a by-value capture ---
 { my @a = 1,2;   my $c = (0, @a); @a.push(9);        is $c[1].join(','), '1,2,9',   'push visible through capture'; }
@@ -101,6 +101,13 @@ plan 55;
     is g(%h), 'a,z', 'is copy hash param gets its own container';
     is %h.keys.join(','), 'a', 'is copy hash param mutation does not reach caller';
 }
+
+# --- multidim (semicolon) subscript mutations visible through a capture ---
+{ my @a = [1,2],[3,4]; my $c = (0, @a); @a[0;1] = 99;      is $c[1][0][1], 99,  'multidim element assign visible'; }
+{ my %h = a=>{x=>1};   my $c = (0, %h); %h{'a';'x'} = 42;  is $c[1]<a><x>, 42,  'multidim hash assign visible'; }
+{ my @a = [1,2],[3,4]; my $c = (0, @a); @a[*;*] = 9,8,7,6; is $c[1][1].join(','), '7,6', 'multidim whatever-slice assign visible'; }
+{ my @a = [1,2],[3,4]; my $c = (0, @a); @a[0;1]:delete;    is $c[1][0].elems, 1, 'multidim delete visible'; }
+{ my @a = [1,2],[3,4]; my $c = (0, @a); @a[0;3] = 9;       is $c[1][0].elems, 4, 'multidim autoviv grow visible'; }
 
 # --- reference holders keep tracking (non-copy '=' targets) ---
 { my @a = 1,2; my @outer; @outer[0] = @a; @a.push(9); is @outer[0].join(','), '1,2,9', 'element holding array tracks push'; }

--- a/t/quanthash-declared-init-identity.t
+++ b/t/quanthash-declared-init-identity.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Declared QuantHash (`my %s is SetHash/BagHash/MixHash`) initialization and
+# container identity (§3):
+# - a SCALAR initializer (`= <a>` — a single angle-quoted word is a Str, not a
+#   List) must initialize the container, not be dropped as "no initializer"
+# - subscript assignment writes through the variable's own container node, so
+#   `:=` binds and closure captures observe it, while `=` copies stay detached
+# - whole reassignment (`%s = <x>`) preserves the container's identity
+
+plan 16;
+
+# --- scalar (Str) initializer ---
+{ my %s is SetHash = <a>; is %s.keys.join(','), 'a', 'SetHash Str initializer lands'; }
+{ my %b is BagHash = <p>; is %b.keys.join(','), 'p', 'BagHash Str initializer lands'; }
+{ my %m is MixHash = <m>; is %m.keys.join(','), 'm', 'MixHash Str initializer lands'; }
+{ my %s is SetHash = <a>; %s<b> = True; is %s.keys.sort.join(','), 'a,b', 'subscript assign after Str init keeps prior contents'; }
+
+# --- subscript assign visible through := bind ---
+{ my %u is SetHash = <a b>; my %v := %u; %u<c> = True; is %v.keys.sort.join(','), 'a,b,c', 'SetHash := bind observes subscript assign'; }
+{ my %u is BagHash = <k>;   my %v := %u; %u<l> = 2;    is %v.keys.sort.join(','), 'k,l', 'BagHash := bind observes subscript assign'; }
+{ my %u is MixHash = <k>;   my %v := %u; %u<l> = 0.5;  is %v.keys.sort.join(','), 'k,l', 'MixHash := bind observes subscript assign'; }
+
+# --- subscript assign visible through a closure capture ---
+{ my %w is SetHash = <a>; my $cl = { %w.keys.sort.join(',') }; %w<b> = True; is $cl(), 'a,b', 'closure capture observes SetHash subscript assign'; }
+{ my %x is BagHash = <p>; my $cl = { %x.keys.sort.join(',') }; %x<q> = 2;    is $cl(), 'p,q', 'closure capture observes BagHash subscript assign'; }
+
+# --- copies stay detached ---
+{ my %s is SetHash = <a>; my %t is SetHash = %s; %t<z> = True; is %s.keys.join(','), 'a', 'SetHash copy mutation does not reach source'; }
+{ my %p is BagHash = <k k>; my %q is BagHash = %p; %q<m> = 3;  is %p.keys.join(','), 'k', 'BagHash copy mutation does not reach source'; }
+{ my %s is SetHash = <a b>; my %t = %s; %s<c> = True; is %t.keys.sort.join(','), 'a,b', 'plain copy unaffected by source subscript assign'; }
+
+# --- whole reassignment preserves identity (visible through := bind) ---
+{ my %u is SetHash = <a b>; my %v := %u; %u = <x>; is %v.keys.join(','), 'x', 'whole reassign observed through := bind'; }
+
+# --- reassign keeps declared type and coercion ---
+{
+    my %w is SetHash = <a>;
+    %w = <b c>;
+    %w<d> = True;
+    is %w.keys.sort.join(','), 'b,c,d', 'reassign then subscript assign accumulate';
+    is %w.WHAT.raku, 'SetHash', 'reassign keeps SetHash type';
+}
+
+# --- SetHash element assignment evaluates to Bool ---
+{ my %s is SetHash; is-deeply (%s<k> = 2), True, 'SetHash element assign yields Bool existence'; }


### PR DESCRIPTION
## Summary

Completes the "remaining `Gc::make_mut` site inventory" slice of container identity §3 (follow-up to #4362), plus three declared-QuantHash bugs the pin tests uncovered.

### make_mut sweep (commit 1)

Inventoried all ~70 remaining `Gc::make_mut` call sites and converted the **34 that mutate a variable's own container** to `gc_data_mut` (write through the shared node) so by-value holders, `:=` binds, and captures observe the mutation instead of being severed by a COW detach:

- **multidim subscripts**: `@a[0;1] = v`, `@a[*;*] = ...`, `%h{k1;k2} = v`, multidim/slice `:delete` — all were probe-verified invisible through a `(0, @a)` capture (4/4 divergences from raku fixed)
- **vm_var_assign_index_named.rs** (14): junction-index writes, hash-slice inserts, range-slice autoviv grow, Set/Bag/MixHash element assign (now symmetric with the already-converted delete side; `my %v := %u; %u<c> = True` visible through the bind), nested-descent chain
- varref-target assigns, function-form `shift`/`pop`, fallback `.pop`, Proxy-subclass array mutators, non-shared env push fallback

Sites intentionally **kept** on `make_mut` (classified, not blanket-converted): fresh/derived result construction, declaration-time metadata tagging ("store the returned value back" contract), ContainerRef-cell COW where the cell is the identity, `strong_count==1` else-arms of already-guarded blocks, and the shared_vars/threading lock+sync protocol paths.

### Declared QuantHash fixes (commit 2)

1. `my %s is SetHash = <a>` dropped the initializer entirely (a single angle-quoted word is a Str; the trait op treated any scalar as "no initializer" and overwrote the slot with an empty QuantHash)
2. Whole reassignment left the env mirror stale → a later subscript assign clobbered the slot; reassignment now STOREs into the existing container node, preserving identity and embedded type metadata (`=` copies stay detached, probe-verified)
3. Index-assign entry pull also refreshes env from the local slot when env holds a hoisted declaration placeholder

## Tests

- Pins: `t/container-identity-mutation.t` +5 multidim cases (60, raku-verified), new `t/quanthash-declared-init-identity.t` (16, raku-verified)
- Local: full `prove t/` 1608 files PASS, cargo test 549 PASS, targeted roast (S02-types setty/hash/array, S03 set ops, S09-multidim/subscript/typed-arrays/autoviv, S32-array/hash mutation + multislice, S06-signature) ~8,200 tests PASS

## Remaining (next slice)

Post-call writeback reduction for push-family method-on-index is deferred: the writeback is load-bearing for autovivification (`my @a; @a[2].push(3)`) and needs an autoviv-first redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW