### PR TITLE
fix(vm): reify a finite `.map`/`.grep` pipe over a gather source

### DIFF
--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -134,6 +134,52 @@ impl LazyList {
         self.sequence_spec.is_some() || self.closure_seq.is_some()
     }
 
+    /// Whether this `.map`/`.grep` lazy pipe bottoms out in a *definitively
+    /// finite* source, so a strict reification (`.List`/`for`/`.flat`/gist) can
+    /// force it to completion instead of keeping it lazy. Conservative: returns
+    /// `true` ONLY when every stage of the source chain is provably finite
+    /// (a `gather` coroutine — gathers always terminate —, a finite `Array`/
+    /// `Seq`/`Slip`, or a finite `Range`); returns `false` for an infinite range,
+    /// an infinite sequence/closure spec, a `cat_pull`, or any unrecognized
+    /// source. Worst case a genuinely-finite pipe stays lazy (status quo) — it
+    /// never turns an infinite pipe into a hang.
+    pub(crate) fn pipe_bottoms_out_finite(&self) -> bool {
+        let spec = match self.lazy_pipe.as_ref() {
+            Some(p) => p,
+            None => return false,
+        };
+        let source = spec.lock().unwrap().source.clone();
+        Self::value_source_is_finite(&source)
+    }
+
+    fn value_source_is_finite(source: &Value) -> bool {
+        match source.view() {
+            ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_) => true,
+            // A finite integer range has a concrete end (`i64::MAX` is the
+            // sentinel for `..*`/`..Inf`, i.e. infinite).
+            ValueView::Range(_, b)
+            | ValueView::RangeExcl(_, b)
+            | ValueView::RangeExclStart(_, b)
+            | ValueView::RangeExclBoth(_, b) => b != i64::MAX,
+            ValueView::GenericRange { end, .. } => {
+                let end_f = end.to_f64();
+                !(end_f.is_infinite() && end_f.is_sign_positive())
+            }
+            ValueView::LazyList(ll) => {
+                if ll.lazy_pipe.is_some() {
+                    ll.pipe_bottoms_out_finite()
+                } else if ll.is_infinite_spec() || ll.cat_pull.is_some() {
+                    false
+                } else {
+                    // A gather coroutine (or an already-materialized gather body)
+                    // is finite; sequence/closure/cat specs were ruled out above.
+                    ll.coroutine.is_some() || ll.is_from_gather() || !ll.body.is_empty()
+                }
+            }
+            _ => false,
+        }
+    }
+
     /// Gate for the VM force/incremental-pull dispatch block: a gather-sourced
     /// list (eager or `lazy`), an infinite sequence/closure spec, or a lazy
     /// `WALK(method)()` candidate-invocation list.

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -842,8 +842,14 @@ impl Interpreter {
             // dispatch) — neither forces.
             && !(matches!(method, "map" | "grep")
                 && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather() || ll.cat_pull.is_some()))
+            // A laziness-preserving coercion (`.List`/`.list`/`.Array`/`.values`/
+            // `.cache`) returns an infinite pipe unchanged, but a FINITE pipe
+            // (one bottoming out in a `gather`/finite source) must reify — else
+            // `gather { … }.grep(…).List` yields an unforced `(...)` and `.flat`/
+            // `for` see nothing.
             && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
-                && Self::lazy_pipe_preserving_coercion(method))
+                && Self::lazy_pipe_preserving_coercion(method)
+                && !ll.pipe_bottoms_out_finite())
             // On an infinite sequence/closure spec the count/numeric coercions
             // produce a *soft* X::Cannot::Lazy Failure (recoverable with `//`),
             // emitted by the 0-arg native dispatch — they must not be hard-forced.
@@ -856,8 +862,11 @@ impl Interpreter {
                 Some(n) => self.force_lazy_list_vm_n(ll, n)?,
                 // A strict force of an infinite list (lazy pipeline / infinite
                 // sequence / closure spec) cannot terminate: raise
-                // X::Cannot::Lazy with this method's name.
-                None if ll.lazy_pipe.is_some() || ll.is_infinite_spec() => {
+                // X::Cannot::Lazy with this method's name. A finite pipe (gather/
+                // finite source) is forceable, so it falls through to the force.
+                None if (ll.lazy_pipe.is_some() || ll.is_infinite_spec())
+                    && !ll.pipe_bottoms_out_finite() =>
+                {
                     return Err(RuntimeError::cannot_lazy(method));
                 }
                 None => self.force_lazy_list_vm(ll)?,

--- a/t/finite-gather-pipe-reify.t
+++ b/t/finite-gather-pipe-reify.t
@@ -1,0 +1,66 @@
+use v6;
+use Test;
+
+plan 14;
+
+# A `.map`/`.grep` pipeline over a *finite* `gather` source must fully reify
+# when materialized (`.List`/`.elems`/`for`/`.Array`), instead of returning an
+# unforced `(...)`. An INFINITE pipeline (`(1..Inf).map(...)`) must stay lazy.
+
+# --- finite gather + grep ---
+{
+    my $g = gather { take 1; take 2; take 3 };
+    is $g.grep(* > 1).List, (2, 3), 'grep over finite gather reifies via .List';
+    is $g.grep(* > 1).elems, 2, 'grep over finite gather reifies via .elems';
+}
+
+# --- finite gather + map ---
+{
+    is (gather { take 1; take 2; take 3 }).map(* + 10).List, (11, 12, 13),
+        'map over finite gather reifies via .List';
+    is (gather { take 1; take 2; take 3 }).map(* + 10).Array, [11, 12, 13],
+        'map over finite gather reifies via .Array';
+}
+
+# --- for-loop over a finite gather pipe ---
+{
+    my @collected;
+    for gather { take 1; take 2 }.grep(* > 0) -> $x { @collected.push($x) }
+    is @collected, [1, 2], 'for loop over finite gather grep pipe iterates all';
+}
+
+# --- chained grep + map over a finite gather ---
+{
+    is (gather { take 1; take 2; take 3; take 4 }).grep(* %% 2).map(* * 10).List,
+        (20, 40), 'chained grep+map over finite gather reifies';
+}
+
+# --- .join / .sum over a finite gather pipe ---
+{
+    is (gather { take 1; take 2; take 3 }).map(* + 1).join(','), '2,3,4',
+        '.join over finite gather map pipe';
+    is (gather { take 1; take 2; take 3 }).grep(* > 1).sum, 5,
+        '.sum over finite gather grep pipe';
+}
+
+# --- INFINITE pipeline must remain lazy (no hang, slice works) ---
+{
+    is (1..Inf).map(* + 1).List[^3], (2, 3, 4),
+        'infinite range map stays lazy (slice)';
+    is (1..Inf).grep(* %% 2).head(3), (2, 4, 6),
+        'infinite range grep stays lazy (head)';
+    dies-ok { (1..Inf).map(* + 1).elems },
+        'infinite range map .elems still raises (cannot be reified)';
+}
+
+# --- assigning a finite gather pipe to an array reifies ---
+{
+    my @a = gather { take 5; take 6 }.map(* + 1);
+    is @a, [6, 7], 'finite gather pipe assigned to @ reifies';
+    is @a.elems, 2, 'assigned array has all elements';
+}
+
+# --- empty finite gather pipe ---
+{
+    is (gather { }).grep(* > 0).List, (), 'empty gather grep pipe is empty';
+}


### PR DESCRIPTION
## Problem

A `.map`/`.grep` chained directly on a `gather { … }` produced a lazy pipe that did not reify when materialized:

```raku
raku:  gather { take 1; take 2; take 3 }.grep(* > 1).List   # (2 3)
mutsu: gather { take 1; take 2; take 3 }.grep(* > 1).List   # (...)   ← bug
```

`.elems`/`for`/`.join`/`.sum` over such a pipe saw nothing — even though `[0]` indexing and `eager` (both of which call `force_lazy_list_vm`) forced it correctly.

Cause: `.List`/`.list`/`.Array`/`.values`/`.cache` are `lazy_pipe_preserving_coercion`s that return any `lazy_pipe` list unchanged, and a strict force of any `lazy_pipe` raised `X::Cannot::Lazy`. Both guards are correct for an **infinite** pipe (`(1..Inf).map(…).List` must stay lazy) but wrong for a **finite** one whose source chain bottoms out in a gather.

## Fix

`LazyList::pipe_bottoms_out_finite()` walks the `.map`/`.grep` source chain and returns true only for provably-finite bottoms (a gather coroutine, a finite Array/Seq/Slip, a finite Range) — conservative, so an infinite or unrecognized source still stays lazy (worst case: status quo, never a new hang). The two dispatch guards in `vm_call_method_ops` let a finite pipe fall through to `force_lazy_list_vm` instead of preserving/erroring.

Still lazy (unchanged, verified): `(1..Inf).map(…).List[^3]`, `.grep(…).head(n)`, and `.elems` on an infinite pipe still raises `X::Cannot::Lazy`.

## Known follow-up (deeper, separate)

A lazy pipe nested *inside a container* (`@a.map({ gather{…}.grep(…) }).flat`, the zef `Repository.candidates` shape) still isn't reified — the static list builtins (`flat_val`/`value_to_list`) read the pipe's cache without a VM force. That needs a VM-level nested-force pass and is left for a follow-up.

## Test

`t/finite-gather-pipe-reify.t` (14 subtests). `make test` passes; gather roast tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)