### PR TITLE
fix(vm): reify a finite lazy `.map`/`.grep` pipe returned as a map element

### DIFF
--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -139,6 +139,7 @@ impl Interpreter {
                     // parameter binds the missing slot to its default / `Any`.
                     let value =
                         self.call_sub_value(Value::sub_value(data.clone()), chunk, false)?;
+                    let value = self.reify_finite_pipe_value(value)?;
                     match value.view() {
                         ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
                         _ => result.push(value),
@@ -173,6 +174,7 @@ impl Interpreter {
                     };
                     let value =
                         self.call_sub_value(Value::sub_value(data.clone()), chunk, false)?;
+                    let value = self.reify_finite_pipe_value(value)?;
                     match value.view() {
                         ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
                         _ => result.push(value),
@@ -197,6 +199,7 @@ impl Interpreter {
                     };
                     let value =
                         self.call_sub_value(Value::sub_value(data.clone()), chunk, false)?;
+                    let value = self.reify_finite_pipe_value(value)?;
                     match value.view() {
                         ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
                         _ => result.push(value),
@@ -346,6 +349,11 @@ impl Interpreter {
                                 .cloned()
                                 .or_else(|| vm.env().get("_").cloned())
                                 .unwrap_or(Value::NIL);
+                            // A callback that returns a finite lazy `.map`/`.grep`
+                            // pipe (e.g. `{ gather {...}.grep(...) }`) must reify
+                            // it here — the result array's static readers (`.flat`,
+                            // `for`) can't run the VM to force a nested pipe.
+                            let val = vm.reify_finite_pipe_value(val)?;
                             match val.view() {
                                 ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
                                 _ => result.push(val),
@@ -411,6 +419,7 @@ impl Interpreter {
             let mut result = Vec::new();
             for item in list_items {
                 let value = self.call_sub_value(func.clone(), vec![item], false)?;
+                let value = self.reify_finite_pipe_value(value)?;
                 match value.view() {
                     ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
                     _ => result.push(value),

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -58,6 +58,7 @@ impl Interpreter {
                     {
                         list_items[i] = mutated;
                     }
+                    let value = self.reify_finite_pipe_value(value)?;
                     if let ValueView::Slip(elems) = value.view() {
                         result.extend(elems.iter().cloned());
                     } else {
@@ -174,6 +175,7 @@ impl Interpreter {
                             {
                                 list_items[i] = mutated;
                             }
+                            let val = vm.reify_finite_pipe_value(val)?;
                             if let ValueView::Slip(elems) = val.view() {
                                 result.extend(elems.iter().cloned());
                             } else {

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -181,6 +181,29 @@ impl Interpreter {
         r
     }
 
+    /// If `val` is a lazy `.map`/`.grep` pipe whose source chain bottoms out in
+    /// a provably-finite source (a `gather`, or a finite Array/Seq/Range), force
+    /// it to a reified `Seq` and return that; otherwise return `val` unchanged.
+    ///
+    /// Used when `map`/`grep` collects a callback result that is itself such a
+    /// pipe as an element of the result array. Those elements would otherwise
+    /// reach a container whose *static* readers (`flat_val`/`value_to_list`,
+    /// used by `.flat`/`for`) cannot run the VM to force a pipe, so they pull the
+    /// still-empty pipe cache and yield `()`. Reifying here keeps the element as
+    /// a single `Seq` (raku `(1,).map({(10,20)})` == `((10 20),)`, never
+    /// flattened). An infinite pipe (`(1,).map({1..Inf})`) bottoms out `false`
+    /// and stays lazy, so this can never turn an infinite pipe into a hang.
+    pub(crate) fn reify_finite_pipe_value(&mut self, val: Value) -> Result<Value, RuntimeError> {
+        if let ValueView::LazyList(ll) = val.view()
+            && ll.lazy_pipe.is_some()
+            && ll.pipe_bottoms_out_finite()
+        {
+            let items = self.force_lazy_list_vm(ll)?;
+            return Ok(Value::seq(items));
+        }
+        Ok(val)
+    }
+
     fn force_lazy_list_vm_inner(&mut self, list: &LazyList) -> Result<Vec<Value>, RuntimeError> {
         // A lazy `WALK(method)()` list is finite (one element per MRO-level
         // candidate): force them all by invoking every remaining candidate.

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -75,10 +75,19 @@ impl Interpreter {
                         match call_result {
                             Ok(val) => {
                                 if is_map_flag {
-                                    if let ValueView::Slip(s) = val.view() {
-                                        results.extend(s.iter().cloned());
-                                    } else {
-                                        results.push(val);
+                                    // A callback returning a finite lazy `.map`/
+                                    // `.grep` pipe must reify here — the wrapped
+                                    // HyperSeq's downstream `.flat`/`for` use static
+                                    // readers that cannot force a nested pipe.
+                                    match vm.reify_finite_pipe_value(val) {
+                                        Ok(val) => {
+                                            if let ValueView::Slip(s) = val.view() {
+                                                results.extend(s.iter().cloned());
+                                            } else {
+                                                results.push(val);
+                                            }
+                                        }
+                                        Err(e) => error = Some(e),
                                     }
                                 } else if val.truthy() {
                                     results.push(item.clone());

--- a/t/nested-lazy-pipe-reify.t
+++ b/t/nested-lazy-pipe-reify.t
@@ -1,0 +1,70 @@
+use v6;
+use Test;
+
+# A `.map`/`.grep` callback that returns a FINITE lazy pipe (a `.grep`/`.map`
+# chained on a `gather`) yields that pipe as an element of the result array.
+# The result array's *static* readers (`.flat`, `for`, `value_to_list`) cannot
+# run the VM to force a nested pipe, so before this fix they pulled the still
+# empty pipe cache and produced `()`. Each element must be reified to a Seq.
+
+plan 12;
+
+# --- plain .map (topic $_) ---
+{
+    my @r = (1,).map({ gather { take 10; take 20 }.grep(* > 0) }).flat;
+    is @r.elems, 2, 'flat over map-of-finite-grep-pipe reifies (elems)';
+    is @r, [10, 20], 'flat over map-of-finite-grep-pipe reifies (values)';
+}
+
+# --- the element stays a SINGLE Seq (not flattened into the outer list) ---
+{
+    my @r = (1,).map({ gather { take 10; take 20 }.grep(* > 0) });
+    is @r.elems, 1, 'map result keeps the pipe as one element';
+    is @r[0].^name, 'Seq', 'the element is a Seq';
+    is @r[0], (10, 20), 'the element reifies to its values';
+}
+
+# --- named param -> $r ---
+{
+    my @g = (1,).map(-> $r { gather { take 10; take 20 }.grep(* > 0) }).flat;
+    is @g, [10, 20], 'named-param map over finite pipe reifies';
+}
+
+# --- multi-element source ---
+{
+    my @r = (1, 2).map({ gather { take $_ * 10; take $_ * 20 }.grep(* > 0) }).flat;
+    is @r, [10, 20, 20, 40], 'multi-element map over finite pipe reifies';
+}
+
+# --- rw map (topic writeback) ---
+{
+    my @a = <a b>;
+    my @r = @a.map({ gather { take $_; take $_ ~ "!" }.grep(*.chars > 0) }).flat;
+    is @r, ['a', 'a!', 'b', 'b!'], 'rw map over finite pipe reifies';
+}
+
+# --- hyper batch map -> grep -> flat (the zef Repository.candidates shape) ---
+{
+    my @ids = (1,);
+    my @g = @ids.hyper(:batch(1)).map(-> $r { gather { take 10; take 20 }.grep(* > 0) }).flat;
+    is @g, [10, 20], 'hyper map over finite pipe reifies';
+}
+
+# --- for over the container of pipes ---
+{
+    my @seen;
+    for (1,).map({ gather { take 5 }.grep(* > 0) }) -> $seq {
+        @seen.push($seq.join(','));
+    }
+    is @seen, ['5'], 'for over container-of-pipes forces each element';
+}
+
+# --- an INFINITE pipe element must stay lazy (no hang, no eager force) ---
+{
+    my @r = (1,).map({ (1..Inf).map(* + 1) });
+    is @r[0][^3], (2, 3, 4), 'infinite pipe element stays lazy (plain map)';
+}
+{
+    my @r = (1,).hyper(:batch(1)).map(-> $r { (1..Inf).map(* + 1) });
+    is @r[0][^3], (2, 3, 4), 'infinite pipe element stays lazy (hyper map)';
+}


### PR DESCRIPTION
## Problem

A `.map`/`.grep` callback that returns a **finite** lazy pipe (a `.grep`/`.map` chained on a `gather`) yields that pipe as an element of the result array. The result array's *static* readers (`flat_val`/`value_to_list`, used by `.flat` and `for`) cannot run the VM to force a nested pipe, so they pulled the still-empty pipe cache and produced `()`:

```raku
raku:  (1,).map({ gather { take 10; take 20 }.grep(* > 0) }).flat   # (10 20)
mutsu: (1,).map({ gather { take 10; take 20 }.grep(* > 0) }).flat   # ()  BUG
```

This is exactly the shape of zef's `Zef::Repository.candidates`:
`@repo-group.hyper(:batch(1)).map(-> $r { $r.search(...).grep(*.so) }).flat`, which returned `()` and made `find-prereq-candidates` throw `X::Zef::UnsatisfiableDependency`. It is the 5th blocker on the zef `distribution-depends-parsing` test-19 chain (follow-up to #4367).

## Fix

New `Interpreter::reify_finite_pipe_value` forces a callback result that is a lazy pipe bottoming out in a provably-finite source (reusing #4367's `LazyList::pipe_bottoms_out_finite`) to a reified `Seq`, keeping it as **one** element — never flattened (raku `(1,).map({(10,20)})` == `((10 20),)`). An infinite pipe (`(1,).map({1..Inf})`) bottoms out `false` and stays lazy, so this can never turn an infinite pipe into a hang.

Applied at every map/grep result-collection site:
- `eval_map_over_items` (plain path)
- `eval_map_over_items_rw` (topic-writeback rw path)
- `exec_hyper_race_map_grep` (parallel hyper/race path — the actual zef shape)

## Tests

`t/nested-lazy-pipe-reify.t` (12 subtests): plain/named/rw/hyper map over a finite gather-grep pipe reifies via `.flat`/`for`; the element stays a single `Seq`; infinite pipe elements stay lazy (no hang) for both plain and hyper map.

`make test` passes (1612 files, 15872 tests). Related lazy/gather/hyper roast files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA