### PR TITLE
fix(runtime): a mixin object runs inherited methods with self bound to the mixin

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3345,6 +3345,36 @@ impl Interpreter {
                     return Ok(value.clone());
                 }
             }
+            // A user-declared method not overridden by the mixin roles is an
+            // inherited class method. Run it with `self` bound to the MIXIN
+            // wrapper (not the bare inner instance) so a nested `self.foo`
+            // re-dispatches through the mixin roles and finds their overrides —
+            // e.g. `C.new but role { method who {...} }` where the class's
+            // inherited `call-who` does `self.who` must reach the role's
+            // override, not the base `who`. Auto-generated attribute accessors
+            // and native/builtin methods are NOT declared class methods, so
+            // they keep the plain inner-delegation path below (which resolves
+            // them) — and they never do nested self-dispatch, so the invocant
+            // binding does not matter for them.
+            if let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = inner.as_ref().view()
+            {
+                let cls = class_name.resolve().to_string();
+                if self.class_has_method(&cls, method) {
+                    let attrs = attributes.to_map();
+                    let (result, updated) =
+                        self.run_instance_method(&cls, attrs, method, args, Some(target.clone()))?;
+                    // Propagate attribute mutations back to the inner instance so
+                    // state changes made by the class method persist.
+                    if let ValueView::Instance { attributes, .. } = inner.as_ref().view() {
+                        attributes.commit_attrs(updated);
+                    }
+                    return Ok(result);
+                }
+            }
             return self.call_method_with_values(inner.as_ref().clone(), method, args);
         }
 

--- a/t/mixin-inherited-method-self-dispatch.t
+++ b/t/mixin-inherited-method-self-dispatch.t
@@ -1,0 +1,76 @@
+use v6;
+use Test;
+
+# When an object is created with a runtime role mixin (`C.new but role {...}`,
+# or `(C but role {...}).new`), a method inherited from the class/base role must
+# run with `self` bound to the MIXED object — so a nested `self.foo` inside that
+# inherited method re-dispatches through the mixin roles and finds their
+# overrides, rather than resolving against the bare inner instance.
+#
+# This is the shape of zef's recommendation-manager mock:
+# `(Zef::Repository but role { method plugins {...} }).new(:backends[])`, whose
+# inherited `Zef::Repository.candidates` calls `self.plugins` and must reach the
+# mixin's `plugins`, not the base `Pluggable.plugins`.
+
+plan 8;
+
+# --- (C but role).new: inherited method's self.foo hits the mixin override ---
+{
+    role R {
+        method who() { "BASE" }
+        method call-who() { self.who }
+    }
+    class C does R { }
+    my $obj = (C but role :: { method who() { "OVERRIDE" } }).new;
+    is $obj.who, "OVERRIDE", "direct call hits mixin override";
+    is $obj.call-who, "OVERRIDE", "inherited method self-dispatch hits mixin override";
+}
+
+# --- C.new but role: same, via the postfix mixin form ---
+{
+    class D {
+        method label() { "D-base" }
+        method describe() { "label=" ~ self.label }
+    }
+    my $obj = D.new but role :: { method label() { "D-mixed" } };
+    is $obj.label, "D-mixed", "postfix-but direct override";
+    is $obj.describe, "label=D-mixed", "postfix-but inherited self-dispatch override";
+}
+
+# --- attribute mutation via an inherited method still persists (self=Mixin) ---
+{
+    role Acc {
+        has @.items;
+        method add($x) { @!items.push($x) }
+        method count() { @!items.elems }
+    }
+    class E does Acc { }
+    my $obj = (E but role :: { method tag() { "T" } }).new;
+    $obj.add(10);
+    $obj.add(20);
+    is $obj.count, 2, "attr mutation through inherited method persists under mixin";
+    is $obj.tag, "T", "mixin method coexists with inherited attr-mutating methods";
+}
+
+# --- multi-level self-dispatch: inherited -> inherited -> override ---
+{
+    role Chain {
+        method a() { self.b }
+        method b() { self.c }
+        method c() { "chain-BASE" }
+    }
+    class F does Chain { }
+    my $obj = (F but role :: { method c() { "chain-OVERRIDE" } }).new;
+    is $obj.a, "chain-OVERRIDE", "multi-hop self-dispatch reaches mixin override";
+}
+
+# --- inherited method taking args, nested self-dispatch with args ---
+{
+    role G {
+        method scale($n) { self.base-value * $n }
+        method base-value() { 1 }
+    }
+    class H does G { }
+    my $obj = (H but role :: { method base-value() { 10 } }).new;
+    is $obj.scale(3), 30, "inherited method with args reaches mixin override via self";
+}


### PR DESCRIPTION
## Problem

When an object is created with a runtime role mixin (`(C but role {...}).new` or `C.new but role {...}`), an inherited class/base-role method was run with `self` bound to the **bare inner instance**. A nested `self.foo` inside that method therefore re-dispatched against the inner instance and missed the mixin role's override:

```raku
role R { method who() { "BASE" }; method call-who() { self.who } }
class C does R { }
my $obj = (C but role :: { method who() { "OVERRIDE" } }).new;
$obj.who       # OVERRIDE (already correct)
$obj.call-who  # raku: OVERRIDE ; mutsu(before): BASE  ← BUG
```

This is exactly the shape of zef's recommendation-manager mock, `(Zef::Repository but role { method plugins {...} }).new(:backends[])`: the inherited `Zef::Repository.candidates` calls `self.plugins`, which reached the base `Pluggable.plugins` (empty, since `:backends[]`) instead of the mixin override — so `candidates` returned `()` and `find-prereq-candidates` threw `X::Zef::UnsatisfiableDependency` (test 19 of `distribution-depends-parsing`, the 6th blocker on that chain).

## Fix

In the Mixin method-dispatch fallback (`methods_call_dispatch.rs`), when the method is a **user-declared** method on the inner class's MRO (`class_has_method`), run it via `run_instance_method` with the invocant bound to the **mixin wrapper** so a nested `self.foo` re-dispatches through the mixin roles and finds their overrides. Attribute mutations made by the method are committed back to the inner instance.

Auto-generated attribute accessors and native/builtin methods are **not** declared class methods, so they keep the plain inner-delegation path (which resolves them) — and they never do nested self-dispatch, so the invocant binding is irrelevant for them. This gate is what keeps `$t.x` (accessor) and the rest of `t/but-role-type-object-new.t` passing.

## Tests

`t/mixin-inherited-method-self-dispatch.t` (8 subtests): both mixin forms, multi-hop self-dispatch, args, and attribute mutation through an inherited method under a mixin.

`make test` passes (1613 files, 15880 tests). Role/mixin/construction roast files (S14-roles, S12-construction) pass locally with no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA