### PR TITLE
fix(vm,compiler): drop the post-call writeback for element mutating methods (container identity §3.2)

### DIFF
--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -131,8 +131,17 @@ impl Compiler {
         }
     }
 
-    /// Compile method call on indexed target with mutating method (needs writeback).
+    /// Compile method call on indexed target with mutating method.
     /// e.g., %hash<key>.push(4) or @array[0].push(5)
+    ///
+    /// Container identity (§3.2): the method mutates the element's shared
+    /// node in place, so there is NO post-call writeback. push/append/
+    /// unshift/prepend autovivify a missing element via `IndexElemAutoviv`
+    /// before the call (`my @a; @a[2].push(3)`); pop/shift/splice do not
+    /// autovivify (Raku dies without growing the container) and dispatch
+    /// through `CallMethodMut` on a temp binding so the full mut-path
+    /// semantics (WhateverCode splice offsets, X::OutOfRange, typed empty
+    /// Failures, ...) apply to the removed-element result.
     pub(super) fn compile_expr_method_on_index(
         &mut self,
         target: &Expr,
@@ -144,7 +153,7 @@ impl Compiler {
         if let Expr::Index {
             target: idx_target,
             index: idx_key,
-            ..
+            is_positional,
         } = target
         {
             let var_name = Self::postfix_index_name(idx_target).unwrap_or_default();
@@ -152,26 +161,23 @@ impl Compiler {
             let name_resolved = name.resolve();
             let arity = args.len() as u32;
             let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
-            // pop/shift/splice return something OTHER than the mutated array
-            // (the removed element(s)), so the writeback must store the
-            // mutated INVOCANT back into the element and yield the method
-            // result separately. push/append/unshift/prepend return the
-            // array itself, so the plain result-writeback branch suffices.
             if matches!(name_resolved.as_str(), "pop" | "shift" | "splice") {
                 let tmp_target_name = format!(
                     "__mutsu_tmp_index_method_target_{}",
                     self.code.constants.len()
                 );
-                let tmp_result_name = format!(
-                    "__mutsu_tmp_index_method_result_{}",
-                    self.code.constants.len()
-                );
-                let tmp_target_idx = self.code.add_constant(Value::str(tmp_target_name.clone()));
-                let tmp_result_idx = self.code.add_constant(Value::str(tmp_result_name.clone()));
+                let tmp_target_idx = self.code.add_constant(Value::str(tmp_target_name));
                 let name_idx = self.code.add_constant(Value::str(name_resolved));
                 let var_name_idx = self.code.add_constant(Value::str(var_name));
 
-                self.compile_expr(target);
+                self.compile_expr(idx_target);
+                self.compile_expr(idx_key);
+                self.code.emit(OpCode::IndexElemAutoviv {
+                    name_idx: var_name_idx,
+                    is_positional: *is_positional,
+                    target_slot,
+                    autoviv: false,
+                });
                 self.code.emit(OpCode::SetGlobal(tmp_target_idx));
                 self.code.emit(OpCode::GetGlobal(tmp_target_idx));
                 for arg in args {
@@ -186,18 +192,16 @@ impl Compiler {
                     quoted,
                     arg_sources_idx: None,
                 });
-                self.code.emit(OpCode::SetGlobal(tmp_result_idx));
-                self.code.emit(OpCode::GetGlobal(tmp_target_idx));
-                self.compile_expr(idx_key);
-                self.code.emit(OpCode::IndexAssignExprNamed {
-                    name_idx: var_name_idx,
-                    is_positional: true,
-                    target_slot,
-                });
-                self.code.emit(OpCode::Pop);
-                self.code.emit(OpCode::GetGlobal(tmp_result_idx));
             } else {
-                self.compile_expr(target);
+                let var_name_idx = self.code.add_constant(Value::str(var_name));
+                self.compile_expr(idx_target);
+                self.compile_expr(idx_key);
+                self.code.emit(OpCode::IndexElemAutoviv {
+                    name_idx: var_name_idx,
+                    is_positional: *is_positional,
+                    target_slot,
+                    autoviv: true,
+                });
                 for arg in args {
                     self.compile_method_arg(arg);
                 }
@@ -209,13 +213,6 @@ impl Compiler {
                     modifier_idx,
                     quoted,
                     arg_sources_idx: None,
-                });
-                self.compile_expr(idx_key);
-                let var_name_idx = self.code.add_constant(Value::str(var_name));
-                self.code.emit(OpCode::IndexAssignExprNamed {
-                    name_idx: var_name_idx,
-                    is_positional: true,
-                    target_slot,
                 });
             }
         } else {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -894,6 +894,25 @@ pub(crate) enum OpCode {
         stash_name_idx: u32,
         key_name_idx: u32,
     },
+    /// Element-for-mutation load for `@a[i].push(...)` / `%h<k>.pop` etc.:
+    /// read the element like a plain subscript; with `autoviv` set (push/
+    /// append/unshift/prepend), a missing element (Nil / Any / Mu hole) is
+    /// autovivified to a fresh empty Array through the normal index-assign
+    /// machinery and the stored shared node is yielded. Elements of a
+    /// parameterized container (`my Array of Int @x`) get the element type
+    /// tagged onto their node so the method's own type check fires. The
+    /// following method call mutates the element's node in place (container
+    /// identity §3.2), so no post-call writeback is emitted.
+    /// Stack: [container, key] → [element]
+    IndexElemAutoviv {
+        name_idx: u32,
+        is_positional: bool,
+        /// §1.4 shadow-slot (same contract as `IndexAssignExprNamed`).
+        target_slot: Option<u32>,
+        /// True for push/append/unshift/prepend (Raku autovivifies);
+        /// false for pop/shift/splice (Raku dies without growing).
+        autoviv: bool,
+    },
 
     // -- Assignment as expression --
     AssignExpr(u32),
@@ -1935,7 +1954,8 @@ impl CompiledCode {
         match op {
             OpCode::IndexAssignExprNamed { name_idx, .. }
             | OpCode::IndexAssignExprNested { name_idx, .. }
-            | OpCode::IndexAssignDeepNested { name_idx, .. } => Some(*name_idx),
+            | OpCode::IndexAssignDeepNested { name_idx, .. }
+            | OpCode::IndexElemAutoviv { name_idx, .. } => Some(*name_idx),
             OpCode::IndexAssignPseudoStashNamed { stash_name_idx, .. } => Some(*stash_name_idx),
             OpCode::ArrayPush {
                 target_name_idx, ..
@@ -2423,6 +2443,7 @@ impl CompiledCode {
                     | OpCode::IndexAssignDeepNested { .. }
                     | OpCode::IndexAssignGeneric
                     | OpCode::IndexAssignPseudoStashNamed { .. }
+                    | OpCode::IndexElemAutoviv { .. }
                     | OpCode::PostIncrement(..)
                     | OpCode::PostDecrement(..)
                     | OpCode::PostIncrementIndex(_)

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -936,6 +936,38 @@ impl Interpreter {
                             }
                         }
                     }
+                    // A subscripted element dispatched through a temp binding
+                    // (`@x[0].splice(...)` with `my Array of Int @x`) has no
+                    // name-based constraint; enforce the element type embedded
+                    // in the node's metadata instead (container identity §3.2 —
+                    // the post-call writeback that used to re-validate the
+                    // element is gone). Array replacement args are flattened
+                    // exactly like `do_splice` flattens them (so a self-splice
+                    // `@a.splice(10,0,@a)` checks the elements, not the array).
+                    if args.len() > 2
+                        && self.var_type_constraint(&key).is_none()
+                        && let Some(info) = self.container_type_metadata(&target)
+                        && !matches!(info.value_type.as_str(), "" | "Any" | "Mu")
+                    {
+                        let constraint = info.value_type;
+                        for arg in args.iter().skip(2) {
+                            let candidates: Vec<Value> = match arg.view() {
+                                ValueView::Array(items, ..) => items.to_vec(),
+                                _ => vec![arg.clone()],
+                            };
+                            for v in &candidates {
+                                if !v.is_nil() && !self.type_matches_value(&constraint, v) {
+                                    return Err(
+                                        crate::runtime::utils::type_check_element_typed_error(
+                                            "@_",
+                                            &constraint,
+                                            v,
+                                        ),
+                                    );
+                                }
+                            }
+                        }
+                    }
                     let mut resolved_args = args.clone();
                     // Resolve callable for offset (arg 0) with array length
                     if let Some(arg) = args.first()

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -39,14 +39,16 @@ impl Interpreter {
                 }
             }
         }
-        let result = Value::real_array(items);
+        let mut result = Value::real_array(items);
         if let Some(constraint) = inner {
             let info = ContainerTypeInfo {
                 value_type: constraint,
                 key_type: None,
                 declared_type: Some(type_name.to_string()),
             };
-            self.register_container_type_metadata(&result, info);
+            // Array metadata is embedded in `ArrayData`; the pointer-keyed
+            // `register_container_type_metadata` path panics for arrays.
+            result = self.tag_container_metadata(result, info);
         }
         Ok(Some(result))
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -227,6 +227,7 @@ mod vm_var_assign_post_incdec;
 mod vm_var_assign_set_local;
 mod vm_var_assign_typed;
 mod vm_var_delete_ops;
+mod vm_var_elem_mutate;
 mod vm_var_exists_ops;
 mod vm_var_get_ops;
 mod vm_var_index_ops;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1364,10 +1364,14 @@ impl Interpreter {
                     return Ok(());
                 }
                 // Fast path for shift/pop on array values in the non-mutating
-                // (CallMethod) path. Returns the removed element without modifying
-                // any variable. This handles cases like [1,2,3].shift where there
-                // is no variable to mutate. The CallMethodMut path handles variable
-                // targets separately.
+                // (CallMethod) path. Handles value invocants with no simple
+                // variable name to write back through: literals ([1,2,3].shift),
+                // function results (f().pop), element reads. Container identity
+                // (§3.2): the removal goes through the SHARED backing node (no
+                // COW), so when the invocant aliases a live container (`f()`
+                // returning `@a[0]`) the holder observes the removal, matching
+                // Raku. A literal's node has no other holder, so the in-place
+                // write is unobservable there.
                 // Slice 6.3: assume the dispatch dirties the caller env; only a
                 // proven-pure compiled method path clears this (sets it true),
                 // letting the opcode tail skip the env_dirty mark + per-call pull.
@@ -1376,24 +1380,31 @@ impl Interpreter {
                     && args.is_empty()
                     && matches!(target.view(), ValueView::Array(_, kind) if kind.is_real_array())
                 {
-                    // Native array read on a by-value target: env-pure.
+                    // Native array node mutation on a by-value target: env-pure
+                    // (no named binding is written).
                     self.method_dispatch_pure = true;
                     if let ValueView::Array(_, kind) = target.view()
                         && kind.is_lazy()
                     {
                         return Err(RuntimeError::cannot_lazy(method));
                     }
-                    if let ValueView::Array(items, _) = target.view() {
-                        Ok(if items.is_empty() {
+                    let mut invocant = target.clone();
+                    let removed = invocant.with_array_mut(|arc_items, _| {
+                        if arc_items.is_empty() {
                             crate::runtime::make_empty_array_failure(method)
-                        } else if method == "shift" {
-                            items[0].clone()
                         } else {
-                            items[items.len() - 1].clone()
-                        })
-                    } else {
-                        unreachable!()
-                    }
+                            // SAFETY: audited aliased in-place container write
+                            // (see value::aliased_mut); no other borrow into
+                            // this node is live across the mutation below.
+                            let items = unsafe { crate::value::gc_contents_mut(arc_items) };
+                            if method == "shift" {
+                                items.remove(0)
+                            } else {
+                                items.pop().unwrap_or(Value::NIL)
+                            }
+                        }
+                    });
+                    Ok(removed.unwrap_or(Value::NIL))
                 } else if !skip_native {
                     // Resolve hash sentinel entries (bound variable refs, self-refs)
                     // before passing to native methods that iterate hash values.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3054,6 +3054,21 @@ impl Interpreter {
                 self.mirror_array_hash_attr_to_cell(code, *name_idx, pre);
                 *ip += 1;
             }
+            OpCode::IndexElemAutoviv {
+                name_idx,
+                is_positional,
+                target_slot,
+                autoviv,
+            } => {
+                self.exec_index_elem_autoviv_op(
+                    code,
+                    *name_idx,
+                    *is_positional,
+                    *target_slot,
+                    *autoviv,
+                )?;
+                *ip += 1;
+            }
             OpCode::IndexAssignPseudoStashNamed {
                 stash_name_idx,
                 key_name_idx,

--- a/src/vm/vm_var_elem_mutate.rs
+++ b/src/vm/vm_var_elem_mutate.rs
@@ -1,0 +1,139 @@
+use super::*;
+
+impl Interpreter {
+    /// `@a[i].push(...)` / `%h<k>.pop` invocant load (container identity
+    /// §3.2, post-call writeback removal): read the element like a plain
+    /// subscript would. With `autoviv` (push/append/unshift/prepend), a
+    /// missing element (Nil / Any / Mu hole) is autovivified to a fresh empty
+    /// Array THROUGH the normal index-assign machinery (type checks, shapes,
+    /// hole filling, itemization) and re-read from the live variable so the
+    /// value pushed on the stack IS the stored shared node. Without `autoviv`
+    /// (pop/shift/splice), a missing element is pushed as-is so the method
+    /// dispatch raises the proper error without growing the container
+    /// (matching Raku). The following method call then mutates the element's
+    /// node in place and no post-call writeback is needed.
+    ///
+    /// Elements of a parameterized container (`my Array of Int @x`) get the
+    /// inner element type tagged onto their node: the post-call writeback
+    /// used to re-validate the whole element against the variable constraint,
+    /// so without it the method's own metadata-based check
+    /// (`check_array_value_element_types` / the splice replacement check)
+    /// must be able to see the declared type.
+    /// Stack: [container, key] → [element]
+    pub(super) fn exec_index_elem_autoviv_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        is_positional: bool,
+        target_slot: Option<u32>,
+        autoviv: bool,
+    ) -> Result<(), RuntimeError> {
+        let key = self.stack.pop().unwrap_or(Value::NIL);
+        let container = self.stack.pop().unwrap_or(Value::NIL);
+        self.stack.push(container);
+        self.stack.push(key.clone());
+        self.exec_index_op_with_positional(is_positional)?;
+        let mut elem = self.stack.pop().unwrap_or(Value::NIL);
+        let name = Self::const_str(code, name_idx).to_string();
+        let constraint = loan_env!(self, var_type_constraint(&name));
+        // Raku's Any:U autovivification applies to any undefined (type
+        // object) invocant whose type does not provide its own `push` —
+        // including typed-container holes (`my Array of Int @y` reads a hole
+        // as `(Array[Int])`) and scalar type objects (`(Int,)` → push
+        // autovivifies `[]`, and the store's type check then dies for a
+        // constrained element, exactly like Raku). Types with their own
+        // `push` raise their own errors instead (List is immutable,
+        // Hash.push wants pairs, ...).
+        let missing = elem.is_nil()
+            || matches!(elem.view(), ValueView::Package(p) if {
+                !matches!(
+                    p.resolve().split('[').next().unwrap_or(""),
+                    "List" | "Seq" | "Slip" | "Range" | "Hash" | "Map" | "Buf" | "Blob"
+                )
+            });
+        if missing && autoviv {
+            // Store a fresh empty Array into the element (same machinery as
+            // `@a[i] = []`), then re-read from the live variable: the store
+            // may itemize (hash elements), fill holes, or create the
+            // variable's container itself (`my $x; $x<k>.push(1)`), so the
+            // held container value can be stale.
+            self.stack.push(Value::real_array(Vec::new()));
+            self.stack.push(key.clone());
+            let pre = self.array_hash_attr_env_snapshot(code, name_idx);
+            self.exec_index_assign_expr_named_op(code, name_idx, is_positional, target_slot)?;
+            self.mirror_array_hash_attr_to_cell(code, name_idx, pre);
+            let assigned = self.stack.pop().unwrap_or(Value::NIL);
+            let mut container = self.get_env_with_main_alias(&name).unwrap_or(Value::NIL);
+            if let ValueView::ContainerRef(cell) = container.view() {
+                let inner = cell.lock().unwrap_or_else(|e| e.into_inner()).clone();
+                container = inner;
+            }
+            self.stack.push(container);
+            self.stack.push(key);
+            self.exec_index_op_with_positional(is_positional)?;
+            elem = self.stack.pop().unwrap_or(Value::NIL);
+            // Same-thread visibility gap: a shared-store element write inside
+            // `start` drops the thread's private env copy, so the re-read can
+            // miss the element that WAS stored in the shared canonical. The
+            // assignment's result value is node-shared with what the shared
+            // store inserted, so mutating it writes through to the canonical
+            // (the parent observes it after the join).
+            if self.shared_vars_active
+                && (elem.is_nil() || matches!(elem.view(), ValueView::Package(_)))
+            {
+                elem = assigned.descalarize().clone();
+            }
+        }
+        if let Some(constraint) = &constraint {
+            Self::tag_element_value_type_in_place(&elem, constraint);
+        }
+        self.stack.push(elem);
+        Ok(())
+    }
+
+    /// When a container variable's element type is itself a parameterized
+    /// container (`my Array of Int @x` → constraint `Array[Int]`), embed the
+    /// inner value type (`Int`) into the element's SHARED backing node so the
+    /// in-place mutating methods' metadata checks enforce it. Only fills a
+    /// node with no embedded value type yet; a declared type already on the
+    /// node wins.
+    fn tag_element_value_type_in_place(elem: &Value, constraint: &str) {
+        let (inner, is_array) = if let Some(rest) = constraint.strip_prefix("Array[") {
+            (rest.strip_suffix(']'), true)
+        } else if let Some(rest) = constraint.strip_prefix("Hash[") {
+            (rest.strip_suffix(']'), false)
+        } else {
+            return;
+        };
+        let Some(vt) = inner else { return };
+        if vt.is_empty() || vt == "Any" || vt == "Mu" {
+            return;
+        }
+        let mut holder = elem.clone();
+        if is_array {
+            holder.with_array_mut(|arc, _kind| {
+                if arc.value_type.is_none() {
+                    // SAFETY: audited aliased in-place container write (see
+                    // value::aliased_mut); no other borrow into this node is
+                    // live across the write below.
+                    let data = unsafe { crate::value::gc_contents_mut(arc) };
+                    data.value_type = Some(vt.to_string());
+                    if data.declared_type.is_none() {
+                        data.declared_type = Some(constraint.to_string());
+                    }
+                }
+            });
+        } else {
+            holder.with_hash_mut(|arc| {
+                if arc.value_type.is_none() {
+                    // SAFETY: see above.
+                    let data = unsafe { crate::value::gc_contents_mut(arc) };
+                    data.value_type = Some(vt.to_string());
+                    if data.declared_type.is_none() {
+                        data.declared_type = Some(constraint.to_string());
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/vm/vm_var_elem_mutate.rs
+++ b/src/vm/vm_var_elem_mutate.rs
@@ -30,6 +30,28 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let key = self.stack.pop().unwrap_or(Value::NIL);
         let container = self.stack.pop().unwrap_or(Value::NIL);
+        // A Junction key (`%h{ any ^2 }.push: 42`) threads the whole
+        // element-for-mutation load over its values, so every addressed
+        // element is autovivified and the following method call autothreads
+        // over a Junction of the stored shared nodes (the old post-call
+        // writeback stored through the junction subscript instead).
+        if let ValueView::Junction { kind, values } = key.view() {
+            let mut elems = Vec::with_capacity(values.len());
+            for v in values.iter() {
+                self.stack.push(container.clone());
+                self.stack.push(v.clone());
+                self.exec_index_elem_autoviv_op(
+                    code,
+                    name_idx,
+                    is_positional,
+                    target_slot,
+                    autoviv,
+                )?;
+                elems.push(self.stack.pop().unwrap_or(Value::NIL));
+            }
+            self.stack.push(Value::junction(kind.clone(), elems));
+            return Ok(());
+        }
         self.stack.push(container);
         self.stack.push(key.clone());
         self.exec_index_op_with_positional(is_positional)?;

--- a/t/index-method-no-writeback.t
+++ b/t/index-method-no-writeback.t
@@ -1,0 +1,148 @@
+use v6;
+use Test;
+
+plan 30;
+
+# Mutating methods on subscripted elements mutate the element's shared node
+# in place — no post-call writeback (container identity §3.2).
+# All expected values verified against raku 2024+.
+
+# --- push family on existing elements ---
+{
+    my @a = [1,2],;
+    @a[0].push(3);
+    is @a.raku, '[[1, 2, 3],]', 'push on array element';
+}
+{
+    my @a = [1,2],;
+    @a[0].append(3,4);
+    is @a.raku, '[[1, 2, 3, 4],]', 'append on array element';
+}
+{
+    my @a = [1,2],;
+    @a[0].unshift(0);
+    is @a.raku, '[[0, 1, 2],]', 'unshift on array element';
+}
+{
+    my @a = [1,2],;
+    @a[0].prepend(0);
+    is @a.raku, '[[0, 1, 2],]', 'prepend on array element';
+}
+{
+    my %h = k => [1,2];
+    %h<k>.push(3);
+    is %h.raku, '{:k($[1, 2, 3])}', 'push on hash element';
+}
+
+# --- autovivification (push family only) ---
+{
+    my @a;
+    @a[2].push(3);
+    is @a.raku, '[Any, Any, [3]]', 'push autovivifies a missing array element';
+}
+{
+    my %h;
+    %h<k>.push(1);
+    is %h.raku, '{:k($[1])}', 'push autovivifies a missing hash element';
+}
+{
+    my %h;
+    %h<k>.unshift(1);
+    is %h.raku, '{:k($[1])}', 'unshift autovivifies a missing hash element';
+}
+{
+    my @a;
+    @a[1].push();
+    is @a.raku, '[Any, []]', 'zero-arg push still autovivifies';
+}
+
+# --- element aliasing: by-value holders observe the mutation ---
+{
+    my @a = [1,2],;
+    my $c = @a[0];
+    @a[0].push(9);
+    is $c[2], 9, 'captured element sees push';
+}
+{
+    my @a = [1,2,3],;
+    my $c = @a[0];
+    my $x = @a[0].pop;
+    is $x, 3, 'pop returns the removed element';
+    is @a.raku, '[[1, 2],]', 'pop mutates the element';
+    is $c.elems, 2, 'captured element sees pop';
+}
+{
+    my @a = [1,2,3],;
+    my $y = @a[0].shift;
+    is $y, 1, 'shift returns the removed element';
+    is @a.raku, '[[2, 3],]', 'shift mutates the element';
+}
+{
+    my @a = [1,2,3],;
+    my @r = @a[0].splice(1,1);
+    is @r.raku, '[2]', 'splice returns the removed elements';
+    is @a.raku, '[[1, 3],]', 'splice mutates the element';
+}
+{
+    my %m = k => [1,2,3];
+    my $c = %m<k>;
+    my $x = %m<k>.pop;
+    is %m.raku, '{:k($[1, 2])}', 'pop mutates the hash element';
+    is $c.elems, 2, 'captured hash element sees pop';
+}
+{
+    my @w = [1,2,3,4],;
+    my @r = @w[0].splice(*-2, 1);
+    is @r.raku, '[3]', 'splice with WhateverCode offset returns removed';
+    is @w.raku, '[[1, 2, 4],]', 'splice with WhateverCode offset mutates';
+}
+
+# --- pop/shift/splice do NOT autovivify (raku dies; container unchanged) ---
+{
+    my @a;
+    try { @a[2].pop };
+    is @a.raku, '[]', 'pop on a missing element does not grow the array';
+}
+{
+    my %h;
+    try { %h<k>.splice(0,1) };
+    is %h.raku, '{}', 'splice on a missing hash key does not create it';
+}
+
+# --- push result is the element's array (aliases it) ---
+{
+    my %h = k => [1,2];
+    my $r = %h<k>.push(3);
+    $r.push(4);
+    is %h.raku, '{:k($[1, 2, 3, 4])}', 'push result aliases the element';
+}
+
+# --- non-variable invocants: the shared node is still mutated ---
+{
+    my @a = [1,2,3],;
+    sub f { @a[0] }
+    my $x = f().pop;
+    is $x, 3, 'pop on a function result returns the element';
+    is @a.raku, '[[1, 2],]', 'pop on a function result mutates the source';
+}
+{
+    my @a = [1,2,3],;
+    sub g { @a[0] }
+    my $x = g().shift;
+    is $x, 1, 'shift on a function result returns the element';
+    is @a.raku, '[[2, 3],]', 'shift on a function result mutates the source';
+}
+
+# --- defaults: raku does not store the pushed default into the container ---
+{
+    my %h is default([9]);
+    %h<k>.push(1);
+    is %h.raku, '{}', 'push on a defaulted missing hash key does not store';
+}
+{
+    my @a is default([8]);
+    @a[0].push(1);
+    is @a.raku, '[]', 'push on a defaulted missing array element does not store';
+}
+
+done-testing;

--- a/t/index-method-no-writeback.t
+++ b/t/index-method-no-writeback.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 30;
+plan 32;
 
 # Mutating methods on subscripted elements mutate the element's shared node
 # in place — no post-call writeback (container identity §3.2).
@@ -131,6 +131,18 @@ plan 30;
     my $x = g().shift;
     is $x, 1, 'shift on a function result returns the element';
     is @a.raku, '[[2, 3],]', 'shift on a function result mutates the source';
+}
+
+# --- Junction subscript: autovivify every addressed element ---
+{
+    my %h;
+    %h{ any ^2 }.push: 42;
+    is-deeply %h, %(0 => [42], 1 => [42]), 'junction hash subscript autovivifies all keys';
+}
+{
+    my @a;
+    @a[any(0,2)].push(9);
+    is @a.raku, '[[9], Any, [9]]', 'junction array subscript autovivifies all indices';
 }
 
 # --- defaults: raku does not store the pushed default into the container ---


### PR DESCRIPTION
## Summary

`@a[i].push(...)` / `%h<k>.pop` were compiled as method call + full `IndexAssignExprNamed` writeback (result writeback for the push family; invocant writeback via a temp-global dance for pop/shift/splice). With element mutations now writing through the shared node (#4362 / #4366), the writeback was redundant for existing elements — and actively wrong for missing ones. This removes it and fixes three raku divergences it caused (all raku-verified by probe):

- `my @a; try @a[2].pop` grew the array to `[Any, Any, Any]` via the writeback's autovivification (raku: dies, array stays `[]`).
- `my %h is default([9]); %h<k>.push(1)` stored the pushed default into the hash (raku: mutates the default value itself, hash stays empty).
- `f().pop` (no writeback name available) silently skipped mutating the shared array (raku: mutates it).

## Design

- New `IndexElemAutoviv` opcode: stack `[container, key] → [element]`. push/append/unshift/prepend use `autoviv: true` — a missing element is autovivified to a fresh `[]` THROUGH the normal index-assign machinery (type checks, shapes, itemization), then re-read so the invocant IS the stored shared node. pop/shift/splice use `autoviv: false` (raku dies without growing) and keep the temp-binding `CallMethodMut` so the full mut-path splice semantics (WhateverCode offsets, `X::OutOfRange`) apply. No writeback ops are emitted.
- Raku's autoviv rule (probed): any undefined type-object invocant without its own `push` autovivifies — including `Int:U`/`Str:U` (the store's type check then dies for a constrained element, matching raku's `Type check failed for an element of @t[0]; expected Int but got Array`) and typed-container holes (`my Array of Int @y` hole reads as `(Array[Int])`). Types with their own `push` (List, Hash, ...) fall through to their own errors.
- Since the writeback's re-validation is gone, elements of a parameterized container (`my Array of Int @x`) get the inner element type embedded into their node at load — enforced by the push family's existing metadata check and a new metadata-based splice replacement check (with `do_splice`-style Array-arg flattening so a self-splice `@a.splice(10,0,@a)` passes; caught by roast S32-array/splice.t). Previously the type error fired only AFTER the in-place mutation had already landed.
- The `CallMethod` pop/shift fast path now removes through the shared backing node and returns the removed element (was: read-only), fixing non-variable invocants (`f().pop`, `$obj.attr.pop`).
- `autoviv_typed_array_push` still called the pointer-keyed `register_container_type_metadata`, which panics for arrays since the embedded-metadata migration — migrated to `tag_container_metadata`.
- Threaded autoviv (`start { %h<k>.push(1) }`): the shared store's element write drops the thread's private env copy, so the re-read can miss; fall back to the assignment result, which is node-shared with the shared canonical. (The same-thread visibility gap itself — `start { %h<k> = []; say %h }` prints `{}` where raku shows the element — is a pre-existing issue, noted for a separate slice.)

## Tests

- NEW pin `t/index-method-no-writeback.t` (30 tests, every expectation verified against raku): push/append/unshift/prepend/pop/shift/splice on array & hash elements, autovivification, element aliasing through captures and function results, no-autoviv for pop/splice on missing elements, defaulted containers, WhateverCode splice offsets.
- `make test` green; roast locally green: S32-array (pop/shift/push/splice/unshift/multislice), S09-typed-arrays (arrays/hashes), S02/S03/S09 autovivification, S02-types (hash/array/sethash/baghash), S32-hash (adverbs/delete-adverb/push), S09-subscript, S17 (lock/atomic-ops/cas/start).

Remaining follow-ups (recorded in the campaign topic): nested `%h<a><b>.push` still uses the nested result-writeback path; `array_mutate_copy`'s pop/shift/splice value-path still mutates a copy (`f().splice` mutation loss on the slow path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW