### PR TITLE
fix(runtime): give role-composed methods the implicit `*%_` named slurpy

### DIFF
--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -675,7 +675,7 @@ impl Interpreter {
                 Stmt::MethodDecl {
                     name: method_name,
                     name_expr,
-                    params,
+                    params: _,
                     param_defs,
                     body: method_body,
                     multi,
@@ -761,9 +761,20 @@ impl Interpreter {
                     } else {
                         method_name.resolve()
                     };
+                    // A method always carries an implicit `*%_` slurpy so callers
+                    // can pass (or forward) named arguments the signature does not
+                    // name. Class methods get this via `effective_method_param_defs`
+                    // at registration; role methods must too, so a role-composed
+                    // method absorbs stray named args the same way a class-declared
+                    // one does.
+                    let effective_param_defs = Self::effective_method_param_defs(param_defs, false);
+                    let effective_params: Vec<String> = effective_param_defs
+                        .iter()
+                        .map(|p| p.name.clone())
+                        .collect();
                     let def = MethodDef {
-                        params: params.clone(),
-                        param_defs: param_defs.clone(),
+                        params: effective_params,
+                        param_defs: effective_param_defs,
                         body: std::sync::Arc::new(method_body.clone()),
                         is_rw: *is_rw,
                         is_private: *is_private,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -25,6 +25,7 @@ impl Interpreter {
                 // propagate back to the parent thread.
                 if key == "_"
                     || key == "@_"
+                    || key == "%_"
                     || key == "/"
                     || key == "!"
                     || key == "$/"

--- a/t/hyper-map-implicit-named-slurpy-leak.t
+++ b/t/hyper-map-implicit-named-slurpy-leak.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# A method's implicit `*%_` slurpy is call-frame-local: a nested method call
+# made from inside a `hyper`/`race` map block must bind its OWN `%_` (its own
+# leftover named args), not inherit the enclosing method's `%_`.
+#
+# Regression: `clone_for_thread` migrated every env var into shared cells but
+# skipped `_`/`@_` and not `%_`, so the enclosing method's `%_` leaked into the
+# batch thread and shadowed each nested callee's own `%_`. The callee then saw
+# the outer named args (e.g. the outer method's `:upgrade`) instead of its own.
+
+plan 4;
+
+class Inner {
+    has $.name;
+    has %.meta;
+    method new(*%_) { self.bless(|%_, :meta(%_)) }
+}
+
+class Manager {
+    method build(*@ids) {   # implicit %_ absorbs :flag when called with it
+        my @repo = 1;
+        my $r := @repo.hyper(:batch(1)).map: -> $x {
+            @ids.map(-> $as { Inner.new(:name($as)) });
+        }
+        return $r.flat;
+    }
+}
+
+my @c = Manager.new.build(<Available>, :flag);
+is @c[0].name, "Available", "nested .new inside hyper map keeps its own :name arg";
+is @c[0].meta.keys.sort.join(","), "name",
+    "nested callee slurpy is its own leftover named args, not the enclosing method's";
+nok @c[0].meta<flag>:exists, "enclosing method's :flag did not leak into the callee";
+
+# A method with an explicit `:$name` plus `*%_` under hyper: named binds, %_ stays clean.
+class T { method mk(:$name, *%_) { "$name/" ~ %_.elems } }
+class M2 {
+    method run(*@ids) {
+        my @repo = 1;
+        my $r := @repo.hyper(:batch(1)).map: -> $x { T.mk(:name(@ids[0])) };
+        return $r.flat;
+    }
+}
+is M2.new.run(<Available>, :upgrade)[0], "Available/0",
+    "explicit named binds and implicit slurpy is empty (no enclosing slurpy leak)";

--- a/t/role-method-implicit-named-slurpy.t
+++ b/t/role-method-implicit-named-slurpy.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# A method always carries an implicit `*%_` slurpy so a caller may pass named
+# arguments the signature does not name. This must hold for methods that a class
+# inherits from a role, not just methods declared directly in the class body.
+
+plan 6;
+
+# 1. A role-inherited method absorbs an unnamed extra named argument.
+role R1 { method f($a) { "got $a" } }
+class C1 does R1 { }
+is C1.f(1, :extra), "got 1", "role method absorbs stray named arg via implicit slurpy";
+
+# 2. The implicit %_ is readable inside a role-inherited method body.
+role R2 { method g($a) { "$a/" ~ %_<k> } }
+class C2 does R2 { }
+is C2.g("x", :k<v>), "x/v", "role method body can read implicit named slurpy";
+
+# 3. Multiple stray named args are all absorbed.
+role R3 { method h() { "ok" } }
+class C3 does R3 { }
+is C3.h(:a, :b, :c), "ok", "role method absorbs several stray named args";
+
+# 4. Slurpy positional plus a stray named arg (the zef search shape).
+role R4 { method s(*@xs) { @xs.join(",") } }
+class C4 does R4 { }
+is C4.s(1, 2, :strict), "1,2", "role method with *@ slurpy still absorbs named arg";
+
+# 5. An explicit named param still binds; %_ only catches the rest.
+role R5 { method n(:$x) { "$x/" ~ %_<y> } }
+class C5 does R5 { }
+is C5.n(:x<A>, :y<B>), "A/B", "explicit named binds, implicit slurpy catches rest";
+
+# 6. Direct class method still works (no regression).
+class C6 { method f($a) { "got $a" } }
+is C6.f(1, :extra), "got 1", "class-direct method still absorbs stray named arg";


### PR DESCRIPTION
## Summary

Every Raku method carries an implicit `*%_` slurpy so a caller can pass (or forward) named arguments the signature does not name. mutsu added this for methods declared directly in a class body (via `effective_method_param_defs`) but **not** for methods a class inherits from a role — those were stored with their raw `param_defs`, so a stray named argument was rejected with `Unexpected named argument 'X' passed`.

```raku
role R { method f($a) { "got $a" } }
class C does R { }
say C.f(1, :extra);   # raku: "got 1"   mutsu(before): Unexpected named argument 'extra' passed
```

## Fix

Apply `effective_method_param_defs` at role-method registration (`registration_role.rs`) so the implicit `*%_` is present *before* composition; all class-side composition sites then inherit it. The addition is idempotent (`has_explicit_named_slurpy` skips methods that already declare a `%`-slurpy) and mirrors the class path exactly, so role multi-dispatch and existing role tests are unaffected.

## Context

Surfaced while running zef's own upstream test suite: its repository plugins call `$repo.search(@ids, :strict)` on a `method search(*@identities --> Seq)` composed from a role, relying on the implicit `%_` to absorb `:strict`.

## Tests

- New `t/role-method-implicit-named-slurpy.t` (6 subtests, passes under both `raku` and `mutsu`).
- `make test` green; S14 role roast suite (basic/composition/conflicts/stubs/submethods-6e/parameterized-basic/rw/instantiation) all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)