### PR TITLE
fix(compiler,vm): drop the post-call writeback for nested-subscript mutating methods (container identity §3.2)

### DIFF
--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -411,8 +411,9 @@ impl Compiler {
                 self.code.emit(OpCode::LoadConst(idx));
                 self.code.emit(OpCode::Die);
             }
-            // Method call on nested-index target with mutating method -- writeback via IndexAssign.
-            // e.g. %h<a><b>.push(1, 2) => %h<a><b> = %h<a><b>.push(1, 2)
+            // Method call on nested-index target with mutating method — chained
+            // element-for-mutation loads, no writeback (container identity §3.2).
+            // e.g. %h<a><b>.push(1, 2)
             Expr::MethodCall {
                 target,
                 name,
@@ -420,7 +421,7 @@ impl Compiler {
                 modifier,
                 quoted,
             } if Self::is_nested_mutating_method_on_index(target, name) => {
-                self.compile_expr_nested_method_writeback(target, name, args, modifier, *quoted);
+                self.compile_expr_nested_method_on_index(target, name, args, modifier, *quoted);
             }
             // `lazy for ITERABLE { BODY }` => MakeGather wrapping the for loop
             // so the body is not evaluated prematurely.

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -177,6 +177,7 @@ impl Compiler {
                     is_positional: *is_positional,
                     target_slot,
                     autoviv: false,
+                    viv_hash: false,
                 });
                 self.code.emit(OpCode::SetGlobal(tmp_target_idx));
                 self.code.emit(OpCode::GetGlobal(tmp_target_idx));
@@ -201,6 +202,7 @@ impl Compiler {
                     is_positional: *is_positional,
                     target_slot,
                     autoviv: true,
+                    viv_hash: false,
                 });
                 for arg in args {
                     self.compile_method_arg(arg);
@@ -220,12 +222,18 @@ impl Compiler {
         }
     }
 
-    /// Compile mutating method on a nested Index target by rewriting as
-    /// IndexAssign writeback. E.g. `%h<a><b>.push(1,2)` becomes
-    /// `do { my $__tmp = %h<a><b>.push(1,2); %h<a><b> = $__tmp }`.
-    /// Uses compile_expr_method_generic for the method call to avoid
-    /// infinite recursion.
-    pub(super) fn compile_expr_nested_method_writeback(
+    /// Compile a mutating method on a *nested* Index target
+    /// (`%h<a><b>.push(1)`, `@a[0]<x>[1].pop`) with NO post-call writeback
+    /// (container identity §3.2), mirroring `compile_expr_method_on_index`:
+    /// each intermediate subscript is loaded as an element-for-mutation via
+    /// `IndexElemAutoviv` and bound to a temp, so a missing intermediate is
+    /// autovivified (push family only — Raku's pop/shift/splice die without
+    /// growing anything) through the named index-assign machinery into the
+    /// parent's shared node. The fresh intermediate's kind follows the NEXT
+    /// subscript (positional → Array, associative → Hash). The final level
+    /// reuses the single-level machinery on `tmp[last_key]`, whose CallMethod
+    /// mutates the element's shared node in place.
+    pub(super) fn compile_expr_nested_method_on_index(
         &mut self,
         target: &Expr,
         name: &Symbol,
@@ -233,33 +241,76 @@ impl Compiler {
         modifier: &Option<char>,
         quoted: bool,
     ) {
-        if let Expr::Index {
-            target: idx_target,
-            index: idx_key,
+        // Flatten the subscript chain: chain[0] is the innermost key
+        // (closest to the base expression).
+        let mut chain: Vec<(&Expr, bool)> = Vec::new();
+        let mut base = target;
+        while let Expr::Index {
+            target: inner,
+            index,
             is_positional,
-        } = target
+        } = base
         {
-            // Compile the method call (generic path, no recursion risk)
-            self.compile_expr_method_generic(target, name, args, modifier, quoted);
-            // Now stack has the method result. Write it back to the slot.
-            // Create an IndexAssign expression: target[key] = <stack top>.
-            // We store the result in a temp global, then compile the assignment.
-            let tmp_name = format!("__mutsu_nested_method_wb_{}", self.code.constants.len());
-            let tmp_idx = self.code.add_constant(Value::str(tmp_name.clone()));
-            self.code.emit(OpCode::SetGlobal(tmp_idx));
-            // Now compile the IndexAssign
-            let tmp_var = Expr::Var(tmp_name);
-            let writeback = Expr::IndexAssign {
-                target: idx_target.clone(),
-                index: idx_key.clone(),
-                value: Box::new(tmp_var),
-                is_positional: *is_positional,
-            };
-            self.compile_expr(&writeback);
-        } else {
-            // Fallback: compile normally
-            self.compile_expr_method_generic(target, name, args, modifier, quoted);
+            chain.push((index.as_ref(), *is_positional));
+            base = inner;
         }
+        chain.reverse();
+        debug_assert!(chain.len() >= 2);
+        let autoviv = !matches!(name.resolve().as_str(), "pop" | "shift" | "splice");
+
+        // Load the base container and pick the name the first level's
+        // autoviv stores through. A non-variable base (`f()<x><y>.push`,
+        // `$obj.attr<a><b>.push`) is bound to a temp: the temp's value is
+        // node-shared with the produced container, so a store through the
+        // temp name writes through to the real container.
+        let (mut cur_name, mut cur_slot) = match Self::postfix_index_name(base) {
+            Some(n) => {
+                let slot = self.local_map.get(&n).copied();
+                self.compile_expr(base);
+                (n, slot)
+            }
+            None => {
+                self.compile_expr(base);
+                let tmp = format!("__mutsu_tmp_nested_base_{}", self.code.constants.len());
+                let tmp_idx = self.code.add_constant(Value::str(tmp.clone()));
+                self.code.emit(OpCode::SetGlobal(tmp_idx));
+                self.code.emit(OpCode::GetGlobal(tmp_idx));
+                (tmp, None)
+            }
+        };
+
+        // Chain the intermediate levels (every key but the last): the stack
+        // holds the current container; load/autoviv the element and rebind
+        // the temp that the next level stores through.
+        let (&(last_key, last_positional), inters) = chain.split_last().unwrap();
+        for (j, &(key, is_positional)) in inters.iter().enumerate() {
+            let next_positional = chain[j + 1].1;
+            let name_idx = self.code.add_constant(Value::str(cur_name.clone()));
+            self.compile_expr(key);
+            self.code.emit(OpCode::IndexElemAutoviv {
+                name_idx,
+                is_positional,
+                target_slot: cur_slot,
+                autoviv,
+                viv_hash: !next_positional,
+            });
+            let tmp = format!("__mutsu_tmp_nested_lvl_{}", self.code.constants.len());
+            let tmp_idx = self.code.add_constant(Value::str(tmp.clone()));
+            self.code.emit(OpCode::SetGlobal(tmp_idx));
+            if j + 1 < inters.len() {
+                self.code.emit(OpCode::GetGlobal(tmp_idx));
+            }
+            cur_name = tmp;
+            cur_slot = None;
+        }
+
+        // Final level: single-level element-mutation machinery on the temp.
+        let final_target = Expr::Index {
+            target: Box::new(Expr::Var(cur_name)),
+            index: Box::new(last_key.clone()),
+            is_positional: last_positional,
+        };
+        self.compile_expr_method_on_index(&final_target, name, args, modifier, quoted);
     }
 
     /// Compile method call on non-variable target (no writeback needed).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -912,6 +912,12 @@ pub(crate) enum OpCode {
         /// True for push/append/unshift/prepend (Raku autovivifies);
         /// false for pop/shift/splice (Raku dies without growing).
         autoviv: bool,
+        /// Autovivify a missing element to an empty Hash instead of an
+        /// empty Array. Used for the *intermediate* levels of a nested
+        /// subscript chain (`%h<a><b>.push`): the fresh container's kind
+        /// follows the NEXT subscript (positional → Array, associative →
+        /// Hash), while the final level always vivifies an Array.
+        viv_hash: bool,
     },
 
     // -- Assignment as expression --

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3059,6 +3059,7 @@ impl Interpreter {
                 is_positional,
                 target_slot,
                 autoviv,
+                viv_hash,
             } => {
                 self.exec_index_elem_autoviv_op(
                     code,
@@ -3066,6 +3067,7 @@ impl Interpreter {
                     *is_positional,
                     *target_slot,
                     *autoviv,
+                    *viv_hash,
                 )?;
                 *ip += 1;
             }

--- a/src/vm/vm_var_elem_mutate.rs
+++ b/src/vm/vm_var_elem_mutate.rs
@@ -27,6 +27,7 @@ impl Interpreter {
         is_positional: bool,
         target_slot: Option<u32>,
         autoviv: bool,
+        viv_hash: bool,
     ) -> Result<(), RuntimeError> {
         let key = self.stack.pop().unwrap_or(Value::NIL);
         let container = self.stack.pop().unwrap_or(Value::NIL);
@@ -46,6 +47,7 @@ impl Interpreter {
                     is_positional,
                     target_slot,
                     autoviv,
+                    viv_hash,
                 )?;
                 elems.push(self.stack.pop().unwrap_or(Value::NIL));
             }
@@ -74,12 +76,19 @@ impl Interpreter {
                 )
             });
         if missing && autoviv {
-            // Store a fresh empty Array into the element (same machinery as
-            // `@a[i] = []`), then re-read from the live variable: the store
-            // may itemize (hash elements), fill holes, or create the
-            // variable's container itself (`my $x; $x<k>.push(1)`), so the
-            // held container value can be stale.
-            self.stack.push(Value::real_array(Vec::new()));
+            // Store a fresh empty Array (or Hash, for the intermediate level
+            // of a nested chain whose next subscript is associative) into the
+            // element (same machinery as `@a[i] = []`), then re-read from the
+            // live variable: the store may itemize (hash elements), fill
+            // holes, or create the variable's container itself
+            // (`my $x; $x<k>.push(1)`), so the held container value can be
+            // stale.
+            let fresh = if viv_hash {
+                Value::hash(std::collections::HashMap::new())
+            } else {
+                Value::real_array(Vec::new())
+            };
+            self.stack.push(fresh);
             self.stack.push(key.clone());
             let pre = self.array_hash_attr_env_snapshot(code, name_idx);
             self.exec_index_assign_expr_named_op(code, name_idx, is_positional, target_slot)?;

--- a/t/nested-index-method-no-writeback.t
+++ b/t/nested-index-method-no-writeback.t
@@ -1,0 +1,103 @@
+use v6;
+use Test;
+
+# Nested-subscript mutating methods (`%h<a><b>.push`) run with chained
+# element-for-mutation loads and NO post-call writeback (container
+# identity §3.2). All expectations verified against Rakudo.
+
+plan 27;
+
+# --- autoviv shapes: intermediate kind follows the NEXT subscript ---
+{
+    my %h; %h<a><b>.push(1,2);
+    is-deeply %h<a><b>, [1,2], 'hash-hash autoviv push';
+    my %g; %g<a>[1].push(9);
+    ok %g<a> ~~ Positional, 'assoc-then-positional vivifies an Array';
+    is-deeply %g<a>[1], [9], 'positional intermediate element pushed';
+    ok !%g<a>[0].defined, 'hole before positional index stays undefined';
+    my @a; @a[0]<x>.push(1);
+    is-deeply @a[0]<x>, [1], 'array-hash autoviv push';
+    my @b; @b[0][1].push(1);
+    is-deeply @b[0][1], [1], 'array-array autoviv push';
+    my %d; %d<a><b><c>.push(1);
+    is-deeply %d<a><b><c>, [1], 'three-level autoviv push';
+    my %e; %e<a>[0]<c>.push(5);
+    is-deeply %e<a>[0]<c>, [5], 'mixed three-level autoviv push';
+}
+
+# --- existing nested elements mutate in place ---
+{
+    my %h = a => {b => [1,2,3]};
+    %h<a><b>.push(4);
+    is-deeply %h<a><b>, [1,2,3,4], 'push onto existing nested array';
+    my %p = a => {b => [1,2,3]};
+    my $r = %p<a><b>.pop;
+    is $r, 3, 'pop returns the removed element';
+    is-deeply %p<a><b>, [1,2], 'pop removes from the nested array (no writeback of the result)';
+    my %s = a => {b => [1,2,3]};
+    is %s<a><b>.shift, 1, 'shift returns the removed element';
+    is-deeply %s<a><b>, [2,3], 'shift removes from the nested array';
+    my %u = a => {b => [1,2]};
+    %u<a><b>.unshift(0);
+    is-deeply %u<a><b>, [0,1,2], 'unshift onto existing nested array';
+    my %ap = a => {b => [1]};
+    %ap<a><b>.append(2,3);
+    is-deeply %ap<a><b>, [1,2,3], 'append onto existing nested array';
+    my %sp = a => {b => [1,2,3,4]};
+    %sp<a><b>.splice(1,2);
+    is-deeply %sp<a><b>, [1,4], 'splice removes the slice in place (result not written back)';
+}
+
+# --- missing elements: pop/shift/splice die without growing anything ---
+{
+    my %h;
+    try { %h<a><b>.pop };
+    is-deeply %h, {}, 'pop on missing nested element does not autovivify';
+    my %s;
+    try { %s<a><b>.shift };
+    is-deeply %s, {}, 'shift on missing nested element does not autovivify';
+    my %sp;
+    try { %sp<a><b>.splice(0,1) };
+    is-deeply %sp, {}, 'splice on missing nested element does not autovivify';
+}
+
+# --- non-container elements raise without modifying ---
+{
+    my %h = a => {b => 5};
+    try { %h<a><b>.push(1) };
+    is %h<a><b>, 5, 'push onto non-container nested element leaves it unchanged';
+    my %g = a => 5;
+    try { %g<a><b>.push(1) };
+    is %g<a>, 5, 'push through non-container intermediate leaves it unchanged';
+}
+
+# --- aliasing: reads share the mutated node ---
+{
+    my %h = a => {b => [1]};
+    my $t = %h<a>;
+    %h<a><b>.push(2);
+    is-deeply $t<b>, [1,2], 'earlier read of the intermediate sees the push';
+    my %g; my $r = %g<a><b>.push(1,2);
+    is-deeply $r, [1,2], 'push returns the array';
+}
+
+# --- junction final key vivifies every addressed element ---
+{
+    my %h; %h<a>{"x"|"y"}.push(1);
+    is-deeply %h<a><x>, [1], 'junction key vivifies x';
+    is-deeply %h<a><y>, [1], 'junction key vivifies y';
+}
+
+# --- non-variable bases write through the shared node ---
+{
+    my %g = x => {};
+    sub f() { %g }
+    f()<x><y>.push(2);
+    is-deeply %g<x><y>, [2], 'call-base nested push writes through';
+    my %m;
+    sub g() { %m }
+    g()<zz><y>.push(3);
+    is-deeply %m<zz><y>, [3], 'call-base nested push autovivifies the intermediate';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Nested `%h<a><b>.push(...)` compiled as "call the method generically, then IndexAssign the **result** back into the slot" (`compile_expr_nested_method_writeback`). With the element mutation in-place campaign (#4362/#4366/#4370) the method already mutates the element's shared node, so the writeback was both redundant and wrong — it stored the method's return value. This was the last result-writeback left in the element-mutation paths.

## Raku divergences fixed (all probe-verified against Rakudo)

| case | before | after / Rakudo |
|---|---|---|
| `%h<a><b>.pop` | `{b => 3}` (slot clobbered with removed elem) | `{b => [1,2]}` |
| `%h<a><b>.shift` | `{b => 1}` | `{b => [2,3]}` |
| `%h<a><b>.splice(1,2)` | `{b => [2,3]}` (removed slice stored) | `{b => [1,4]}` |
| missing `.pop` | grew container with a `Failure` | dies, no growth |
| `%h<a>[1].push(9)` | `Runtime error: Any cannot be parameterized` | `{a => [Any, [9]]}` |
| `$obj.h<a><b>.push(1)` | mutation lost (`{}`) | `{a => {b => [1]}}` |
| `f()<zz><y>.push(2)` | missing intermediate lost | autovivified into the shared node |

## Design

Mirrors the single-level design from #4370: each intermediate subscript is loaded as an element-for-mutation via `IndexElemAutoviv` and bound to a temp (node-shared, so the named index-assign machinery — type checks, itemization, hole filling — writes through), then the final level reuses `compile_expr_method_on_index` unchanged. A new `viv_hash` flag on `IndexElemAutoviv` picks the vivified intermediate's kind from the **next** subscript (positional → Array, associative → Hash); pop/shift/splice never autovivify intermediates. Non-variable bases (call results, accessors) bind the base to a temp and use the same chain.

## Tests

- New pin: `t/nested-index-method-no-writeback.t` (27 tests, passes under Rakudo too)
- `make test` (1616 files) green locally
- Targeted roast green: S02 subscript/autoviv/nested/hash, S03 autoviv/subscript-adverbs/junctions-misc, S09 autoviv/slice/multidim/typed-arrays/objecthash, S32-array push/pop/shift/splice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW