### PR TITLE
fix(vm): roll back a hyper/race op's ephemeral env->shared lexical migrations

### DIFF
--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -167,6 +167,24 @@ impl Interpreter {
         sv.get(key).cloned()
     }
 
+    /// Snapshot the set of keys currently present in `shared_vars`. Used by the
+    /// synchronous hyper/race parallel path to record the pre-op shared state so
+    /// its ephemeral env->shared migrations can be rolled back after all batch
+    /// threads join (see `retain_shared_var_keys`).
+    pub(crate) fn shared_var_keys_snapshot(&self) -> std::collections::HashSet<String> {
+        let sv = self.shared_vars.read().unwrap();
+        sv.keys().cloned().collect()
+    }
+
+    /// Drop every `shared_vars` entry whose key is not in `keep`. Used by the
+    /// hyper/race path to remove the read-only lexicals a completed synchronous
+    /// parallel op migrated in, so a later op's freshly-bound same-named lexical
+    /// isn't shadowed by the stale value.
+    pub(crate) fn retain_shared_var_keys(&mut self, keep: &std::collections::HashSet<String>) {
+        let mut sv = self.shared_vars.write().unwrap();
+        sv.retain(|k, _| keep.contains(k));
+    }
+
     /// Returns true if the given key is in the shared_vars_dirty set
     /// (i.e., was modified by an atomic/CAS operation).
     pub(crate) fn is_shared_var_dirty(&self, key: &str) -> bool {

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -37,6 +37,17 @@ impl Interpreter {
             .map(|chunk| chunk.to_vec())
             .collect();
         let num_batches = batches.len();
+        // Snapshot the shared-var keys that exist *before* this op migrates the
+        // parent's lexicals into `shared_vars` (each `clone_for_thread` below
+        // copies the current env in). Because every batch thread is JOINED before
+        // this method returns (unlike a detached `start`/Promise), the read-only
+        // lexicals this op migrates — e.g. the map block's captured `@search-for`
+        // — are dead once the op completes. `clone_for_thread` inserts with
+        // `.or_insert_with`, so if left behind they shadow a *later* hyper op's
+        // freshly-bound same-named lexical (thread-clone `@`/`%` reads prefer
+        // `shared_vars`), freezing it at this op's value. We roll back the keys
+        // this op added after joining + syncing dirty mutations back to env.
+        let pre_shared_keys = self.shared_var_keys_snapshot();
         type ThreadResult = (
             crate::runtime::Interpreter,
             Result<Vec<Value>, RuntimeError>,
@@ -144,6 +155,13 @@ impl Interpreter {
         crate::gc::gc_safepoint(crate::gc::SafepointKind::ThreadJoin);
         // Sync any shared variable updates from threads back to our env
         self.sync_shared_vars_to_env();
+        // Roll back this op's ephemeral env->shared migrations (see
+        // `pre_shared_keys`). Dirty mutations were just synced to env, so
+        // dropping their shared entries is safe; pre-existing shared vars — and
+        // any concurrent sibling's updates to them — are preserved (their keys
+        // are in the pre-op snapshot). This keeps a later hyper op from reading a
+        // stale value for a same-named but freshly-bound lexical.
+        self.retain_shared_var_keys(&pre_shared_keys);
         if let Some(e) = first_error {
             return Err(e);
         }

--- a/t/hyper-map-fresh-captured-lexical.t
+++ b/t/hyper-map-fresh-captured-lexical.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A `.hyper(:batch(1)).map` block that reads an outer lexical must observe that
+# lexical's CURRENT value on every invocation. Previously the batch-thread env
+# migration cached the first invocation's value in `shared_vars` and thread-clone
+# `@`/`%` reads preferred that stale copy, freezing the captured lexical at its
+# first-ever value across independent hyper ops. (zef
+# distribution-depends-parsing test 21: Repository.candidates' per-call search
+# args were frozen.)
+
+plan 8;
+
+sub via-hyper(@items, @filter) {
+    my $results := @items.hyper(:batch(1)).map: -> $x {
+        $x ~~ any(@filter) ?? $x !! Empty;
+    }
+    my @out;
+    for $results.flat -> $v { @out.push($v) }
+    @out;
+}
+
+my @items = <a b c>;
+
+is via-hyper(@items, ['a']).sort,      <a>,   'first call: filter [a]';
+is via-hyper(@items, ['b']).sort,      <b>,   'second call: filter [b] (was frozen at [a])';
+is via-hyper(@items, ['c']).sort,      <c>,   'third call: filter [c]';
+is via-hyper(@items, []).elems,        0,     'fourth call: empty filter';
+is via-hyper(@items, <a b>).sort,      <a b>, 'fifth call: filter [a b]';
+
+# Same shape, but the first call is the empty-result one.
+is via-hyper(@items, ['z']).elems,     0,     'no-match first call';
+is via-hyper(@items, ['a']).sort,      <a>,   'match after a no-match first call';
+
+# A scalar captured lexical must also refresh per call.
+sub scalar-hyper(@items, $needle) {
+    my $r := @items.hyper(:batch(1)).map(-> $x { $x eq $needle ?? $x !! Empty });
+    my @o; for $r.flat -> $v { @o.push($v) }; @o;
+}
+scalar-hyper(@items, 'a');
+is scalar-hyper(@items, 'b'), <b>, 'scalar captured lexical refreshes per hyper call';


### PR DESCRIPTION
## Problem

A `.hyper(:batch(1)).map` / `.race.map` block that reads an outer lexical **froze that lexical at its first-ever value** across independent hyper ops.

Minimal repro (no zef — plain `class`/`gather`):

```raku
class Cand { has $.name; method so { True } }
class Plugin {
    method search(*@ids) { gather for @ids -> $as { take Cand.new(:name($as)) if $as eq 'Available' } }
}
sub via-hyper(@group, @search-for) {
    my $r := @group.hyper(:batch(1)).map: -> $repo { $repo.search(@search-for).grep(*.so) };
    my @o; for $r.flat -> $d { @o.push($d.name) }; @o;
}
my @g = [Plugin.new,];
say via-hyper(@g, ["Available"]);    # [Available]
say via-hyper(@g, ["Unavailable"]);  # raku: []  ;  mutsu(before): [Available]  BUG
```

## Root cause

`clone_for_thread` migrates the parent's env lexicals into the persistent `shared_vars` with `.or_insert_with` (insert only if absent), and thread-clone `@`/`%` reads prefer `shared_vars` over the cloned env (so a batch thread sees concurrent sibling mutations). Read-only captured lexicals are never marked dirty, so `sync_shared_vars_to_env` never refreshes them. The first hyper op's value for a captured lexical sticks in `shared_vars`, and every later op with a freshly-bound same-named lexical reads the stale copy.

## Fix

Unlike a detached `start`/Promise, the hyper/race batch threads are all **joined** before the op returns, so those env→shared migrations are ephemeral. Snapshot the pre-op shared keys and, after joining + syncing dirty mutations back to env, drop the keys this op added. Pre-existing shared vars (and any concurrent sibling's updates to them) are preserved because their keys are in the snapshot.

## Impact

Surfaced by zef's own `distribution-depends-parsing` test (`Zef::Repository.candidates`' per-call search args were frozen); took it from **20/35 → 26/35**. Test 27 is a separate downstream blocker.

Regression test: `t/hyper-map-fresh-captured-lexical.t`. `make test` green (15930 tests); all whitelisted hyper/race roast tests pass (`S07-hyperrace/{basics,for,stress}.t`, `S03-metaops/{hyper,eager-hyper}.t`, `S12-methods/parallel-dispatch.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA