### PR TITLE
fix(parser): keep a trailing comma in a `:name[...]` colonpair-bracket value

### DIFF
--- a/src/parser/primary/misc/colonpair.rs
+++ b/src/parser/primary/misc/colonpair.rs
@@ -472,6 +472,12 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = parse_char(rest, '[')?;
         let (r, _) = ws(r)?;
         let mut items = Vec::new();
+        // Track a trailing comma: `:name[X,]` is an itemized 1-list (the element
+        // is not flattened, so a single-pair Hash stays a Hash), matching a plain
+        // `[X,]` literal. Without it, `:name[X]` flattens the element in list
+        // context (a single-pair Hash collapses to a Pair) — see the
+        // `single_with_trailing_comma` branch in `compile_expr_bracket_array`.
+        let mut trailing_comma = false;
         let mut r = r;
         while !r.starts_with(']') {
             let (r2, item) = expression(r)?;
@@ -481,8 +487,10 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
                 let (r2, _) = parse_char(r2, ',')?;
                 let (r2, _) = ws(r2)?;
                 r = r2;
+                trailing_comma = true;
             } else {
                 r = r2;
+                trailing_comma = false;
             }
         }
         let (r, _) = parse_char(r, ']')?;
@@ -491,7 +499,7 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
             Expr::Binary {
                 left: Box::new(Expr::Literal(Value::str(name.to_string()))),
                 op: crate::token_kind::TokenKind::FatArrow,
-                right: Box::new(Expr::BracketArray(items, false)),
+                right: Box::new(Expr::BracketArray(items, trailing_comma)),
             },
         ));
     }

--- a/t/colonpair-bracket-trailing-comma.t
+++ b/t/colonpair-bracket-trailing-comma.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# A colonpair with a bracketed value and a trailing comma, `:name[X,]`, is an
+# itemized 1-element list: the single element is NOT flattened in list context,
+# so a single-pair Hash element stays a Hash (matching a plain `[X,]` literal).
+# Previously the colonpair-bracket parser dropped the trailing comma and always
+# emitted a flattening array, so `:depends[{:any["a","b"]},]` collapsed the Hash
+# element into a Pair. (zef distribution-depends-parsing test 27:
+# Zef::Distribution::DependencySpecification.new got a Pair instead of a Hash.)
+
+plan 9;
+
+my $a = :depends[{:a(1)},];       # trailing comma -> itemized, keep Hash
+is $a.value.elems, 1,             'trailing comma: 1 element';
+is $a.value[0].^name, 'Hash',     'trailing comma: element is a Hash';
+
+my $b = :depends[{:a(1)}];        # no trailing comma -> flatten single Hash to Pair
+is $b.value[0].^name, 'Pair',     'no trailing comma: single Hash flattens to Pair';
+
+my $c = :depends[{:a(1)}, {:b(2)}];  # multiple elements -> each kept
+is $c.value.elems, 2,             'two elements: 2 elements';
+is $c.value[0].^name, 'Hash',     'two elements: first is a Hash';
+is $c.value[1].^name, 'Hash',     'two elements: second is a Hash';
+
+# The fatarrow form has always kept the Hash; the colonpair form must match it.
+my $d = (depends => [{:a(1)},]);
+is $d.value[0].^name, 'Hash',     'fatarrow form keeps Hash (baseline)';
+
+# A scalar (non-pair) element with a trailing comma also stays itemized.
+my @arr = <a b c>;
+my $e = :list[@arr,];
+is $e.value.elems, 1,             'trailing comma: array kept as single itemized element';
+is $e.value[0].elems, 3,          'trailing comma: itemized array has its 3 elements';


### PR DESCRIPTION
## Problem

A colonpair with a bracketed value and a trailing comma — `:name[X,]` — is an itemized 1-element list: the single element is **not** flattened in list context, so a single-pair Hash element stays a Hash (matching a plain `[X,]` literal).

```raku
say (:depends[{:a(1)},]).value[0].^name;   # raku: Hash ; mutsu(before): Pair  BUG
say (:depends[{:a(1)}]).value[0].^name;     # both: Pair  (no trailing comma flattens)
say (:depends[{:a(1)}, {:b(2)}]).value>>.^name;  # both: (Hash Hash)
```

## Root cause

The colonpair-bracket parser hardcoded `Expr::BracketArray(items, false)`, dropping the trailing-comma information the source carried. The compiler uses that flag (`single_with_trailing_comma` → `MakeRealArrayNoFlatten`) to decide whether a single element is itemized or flattened, so `:depends[{:any["a","b"]},]` compiled as a flattening array and collapsed its single-pair Hash into a Pair. `:name[X]` (no trailing comma) still flattens, matching raku.

## Fix

Track the trailing comma in the bracket loop and pass it through to `BracketArray`.

## Impact

Surfaced by zef's own `distribution-depends-parsing` test: `Zef::Distribution::DependencySpecification.new` received a Pair instead of a Hash for an `{any:[...]}` alternation dep and fell to the default (named-only) constructor (`X::Constructor::Positional`). Combined with #4373, takes the test from 26/35 to **30/35** (test 31 is a separate downstream blocker). General parser bug, not zef-specific.

Regression test: `t/colonpair-bracket-trailing-comma.t`. `make test` green (15958 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA