### PR TITLE
fix(vm): preserve exception type when `die`ing a `but role` mixin

### DIFF
--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -238,12 +238,19 @@ impl Interpreter {
         let (type_ok, exception_val, err_message) = match &result {
             Ok(_) => (false, None, String::new()),
             Err(err) => {
-                // Check exception field first for structured exceptions
+                // Check exception field first for structured exceptions. See
+                // through a `but role` mixin (`X::Foo.new but role {…}`) to the
+                // wrapped instance so a mixed-in exception is matched by its type.
                 let ex_class = err.exception.as_ref().and_then(|ex| {
-                    if let ValueView::Instance { class_name, .. } = ex.as_ref().view() {
-                        Some(class_name.resolve())
-                    } else {
-                        None
+                    let mut cur = ex.as_ref().clone();
+                    loop {
+                        match cur.view() {
+                            ValueView::Instance { class_name, .. } => {
+                                break Some(class_name.resolve());
+                            }
+                            ValueView::Mixin(inner, _) => cur = inner.as_ref().clone(),
+                            _ => break None,
+                        }
                     }
                 });
                 let type_matched = if expected_normalized.is_empty()

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -39,6 +39,21 @@ impl Interpreter {
             return err;
         }
 
+        // See through a `but role` mixin (`X::Foo.new but role { … }`) to the
+        // wrapped instance so a mixed-in exception is still recognized as an
+        // exception (and matched by `CATCH { when X::Foo }`) instead of being
+        // wrapped in X::AdHoc. Walk nested mixins to the innermost instance.
+        let underlying_class: Option<Symbol> = {
+            let mut cur = value.clone();
+            loop {
+                match cur.view() {
+                    ValueView::Instance { class_name, .. } => break Some(class_name),
+                    ValueView::Mixin(inner, _) => cur = inner.as_ref().clone(),
+                    _ => break None,
+                }
+            }
+        };
+
         let message = if let ValueView::Instance { attributes, .. } = value.view() {
             attributes
                 .as_map()
@@ -50,6 +65,13 @@ impl Interpreter {
                         .map(|v| v.to_string_value())
                         .unwrap_or_else(|_| value.to_string_value())
                 })
+        } else if matches!(value.view(), ValueView::Mixin(..)) {
+            // A mixed-in exception may override `.message`/`.Str`; dispatch through
+            // the mixin so the override is honored, falling back to stringification.
+            self.vm_call_method_with_values(value.clone(), "message", vec![])
+                .or_else(|_| self.vm_call_method_with_values(value.clone(), "Str", vec![]))
+                .map(|v| v.to_string_value())
+                .unwrap_or_else(|_| value.to_string_value())
         } else if let ValueView::Array(items, _) = value.view() {
             // Multi-arg die: concatenate .Str of each element
             let mut parts = Vec::new();
@@ -68,7 +90,7 @@ impl Interpreter {
         if is_fail {
             err.control = Some(crate::value::Control::Fail);
         }
-        if let ValueView::Instance { class_name, .. } = value.view() {
+        if let Some(class_name) = underlying_class {
             let cn = class_name.resolve();
             let is_exception = cn == "Exception"
                 || cn.starts_with("X::")
@@ -78,6 +100,9 @@ impl Interpreter {
                     .iter()
                     .any(|p| p == "Exception" || p.starts_with("X::") || p.starts_with("CX::"));
             if is_exception {
+                // Preserve the value verbatim (including a `but role` mixin) so its
+                // type still matches `when X::Foo` and any overridden `.message`
+                // dispatches through the mixin.
                 err.exception = Some(Box::new(value));
             } else {
                 // Non-exception instance: wrap in X::AdHoc with payload

--- a/t/die-mixin-exception.t
+++ b/t/die-mixin-exception.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+# `die`ing a `but role` mixin of an Exception must preserve the exception type,
+# so `CATCH { when X::Type }` still matches it (and an overridden `.message`
+# dispatches through the mixin). Previously mutsu wrapped the mixin value in
+# X::AdHoc, losing the type — `when` failed and the exception escaped. (zef
+# find-prereq-candidates dies with `X::Zef::UnsatisfiableDependency.new but
+# role { method message {...} }` and expects the alternative-spec CATCH to catch
+# it.)
+
+plan 6;
+
+class X::Boom is Exception { method message { "base boom" } }
+
+# 1. `when` on the base type catches a mixed-in exception.
+my $caught-by-type = False;
+{
+    CATCH { when X::Boom { $caught-by-type = True; } }
+    die X::Boom.new but role :: { method message { "mixed" } };
+}
+ok $caught-by-type, 'CATCH when BaseType catches a `but role` mixin exception';
+
+# 2. The caught topic reports the real type, not X::AdHoc.
+my $topic-type;
+{
+    CATCH { default { $topic-type = $_ ~~ X::Boom; } }
+    die X::Boom.new but role :: { method x { 1 } };
+}
+ok $topic-type, 'caught topic smartmatches the base exception type';
+
+# 3. An overridden `.message` on the mixin is honored.
+my $msg;
+{
+    CATCH { when X::Boom { $msg = $_.message; } }
+    die X::Boom.new but role :: { method message { "overridden" } };
+}
+is $msg, 'overridden', 'overridden .message dispatches through the mixin';
+
+# 4. throws-like sees the mixed-in exception as its base type.
+throws-like { die X::Boom.new but role :: { method message { "m" } } },
+    X::Boom, 'throws-like matches a `but role` mixin exception';
+
+# 5. A plain (non-mixin) exception still works (no regression).
+my $plain = False;
+{
+    CATCH { when X::Boom { $plain = True; } }
+    die X::Boom.new;
+}
+ok $plain, 'plain exception still caught by type';
+
+# 6. A `but role` mixin of a NON-exception still stringifies via X::AdHoc.
+class Plain { method Str { "plain-str" } }
+my $adhoc-msg;
+{
+    CATCH { default { $adhoc-msg = $_.message; } }
+    die Plain.new but role :: { method Str { "mixed-str" } };
+}
+is $adhoc-msg, 'mixed-str', 'non-exception mixin dies as X::AdHoc with its Str';


### PR DESCRIPTION
## Problem

`die (X::Foo.new but role { ... })` wrapped the value in `X::AdHoc`, losing the exception type, so `CATCH { when X::Foo }` / `throws-like` no longer matched it and the exception escaped.

```raku
class X::Boom is Exception { method message { "base" } }
{
    CATCH { when X::Boom { say "caught" } }
    die X::Boom.new but role :: { method message { "mixed" } };  # raku: caught ; mutsu(before): escapes
}
```

## Root cause

`runtime_error_from_exception_value` only recognized a `ValueView::Instance` as an exception; a `but role` mixin is a `ValueView::Mixin` wrapping the instance, so it fell to the non-exception `X::AdHoc` branch. `throws-like`'s type check had the same `Instance`-only blind spot.

## Fix

See through nested mixins to the inner instance to decide exception-hood, and keep the value verbatim (including the mixin) so its type still matches `when`/`throws-like` and any overridden `.message` dispatches through the mixin. Render the die message via the mixin's `.message`/`.Str`. Apply the same unwrap in `throws-like`.

## Impact

On the zef `find-prereq-candidates` path, which throws `X::Zef::UnsatisfiableDependency.new but role { method message {...} }` and relies on the alternative-spec `CATCH { when X::Zef::UnsatisfiableDependency }` catching it. General bug (plain `die X::Foo.new but role {}` escaped a `CATCH when X::Foo`).

Regression test: `t/die-mixin-exception.t` (6 subtests). `make test` green (15955 tests); whitelisted exception/`throws-like` roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA