### PR TITLE
fix(vm): isolate the caller's loop-local scope in the light-call fast paths

### DIFF
--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -33,6 +33,16 @@ impl Interpreter {
         }
 
         let saved_locals = std::mem::take(&mut self.locals);
+        // Isolate the caller's loop-body-local declaration scope (mirrors
+        // `call_compiled_function` in vm_call_fast.rs). This fast path bypasses
+        // `push_call_frame`/`run()`, so without clearing these a callee's
+        // body-local `my $x` — e.g. a recursive call from inside the caller's
+        // `while`/`for` loop — would register in the *caller's* active loop-local
+        // scope and be restored (clobbered) at the caller's loop exit. Repro:
+        // `sub f($n){ my $r=0; my @w=(1,); while @w.splice { f($n-1) if $n>0; $r+=10 }; $r }`
+        // returned 0 instead of 10. Restored on every exit path.
+        let saved_loop_local_vars = std::mem::take(&mut self.loop_local_vars);
+        let saved_loop_local_saved_env = std::mem::take(&mut self.loop_local_saved_env);
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / local env writes land in a
@@ -74,6 +84,8 @@ impl Interpreter {
                     self.restore_readonly_vars(saved_readonly);
                     self.set_env(caller_env);
                     self.locals = saved_locals;
+                    self.loop_local_vars = saved_loop_local_vars;
+                    self.loop_local_saved_env = saved_loop_local_saved_env;
                     {
                         let param_name = &cf.param_defs[param_idx].name;
                         let got = runtime::value_type_name(&val);
@@ -170,6 +182,8 @@ impl Interpreter {
         self.stack.truncate(saved_stack_depth);
 
         self.locals = saved_locals;
+        self.loop_local_vars = saved_loop_local_vars;
+        self.loop_local_saved_env = saved_loop_local_saved_env;
         self.restore_readonly_vars(saved_readonly);
 
         // Restore the caller env and merge the overlay (the callee's own writes)

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -18,6 +18,13 @@ impl Interpreter {
         self.record_cf_deprecation(cf);
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
+        // Isolate the caller's loop-body-local declaration scope (mirrors
+        // vm_call_fast.rs / the positional-light path). Without this a callee's
+        // body-local `my $x` — e.g. a recursive call from inside the caller's
+        // `while` loop — registers in the caller's active loop-local scope and is
+        // clobbered at the caller's loop exit. Restored on every exit path.
+        let saved_loop_local_vars = std::mem::take(&mut self.loop_local_vars);
+        let saved_loop_local_saved_env = std::mem::take(&mut self.loop_local_saved_env);
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / alias / @_ env writes below
@@ -121,6 +128,8 @@ impl Interpreter {
                 } else if pd.required {
                     self.set_env(caller_env);
                     self.locals = saved_locals;
+                    self.loop_local_vars = saved_loop_local_vars;
+                    self.loop_local_saved_env = saved_loop_local_saved_env;
                     // Missing required named parameter is a runtime X::AdHoc in
                     // Raku (see binding.rs); carry the typed exception so it does
                     // not fall back to the bare "Exception" default.
@@ -147,6 +156,8 @@ impl Interpreter {
                 } else if pd.required {
                     self.set_env(caller_env);
                     self.locals = saved_locals;
+                    self.loop_local_vars = saved_loop_local_vars;
+                    self.loop_local_saved_env = saved_loop_local_saved_env;
                     return Err(RuntimeError::new(format!(
                         "Too few positionals passed; expected {} arguments but got {}",
                         cf.param_defs.iter().filter(|p| !p.named).count(),
@@ -322,6 +333,8 @@ impl Interpreter {
 
         // Restore locals
         self.locals = saved_locals;
+        self.loop_local_vars = saved_loop_local_vars;
+        self.loop_local_saved_env = saved_loop_local_saved_env;
 
         // Restore readonly vars
         self.restore_readonly_vars(saved_readonly);

--- a/t/while-recursion-loop-local-leak.t
+++ b/t/while-recursion-loop-local-leak.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+# A routine that recurses from inside its own `while` loop body must not have the
+# callee's body-local `my $x` register in the CALLER's active loop-local
+# declaration scope. Previously the positional/typed light-call fast paths (which
+# bypass `push_call_frame`) failed to isolate `loop_local_vars`/
+# `loop_local_saved_env`, so the callee's `my $r` polluted the caller's while
+# loop, and the caller's loop-exit restore reverted its own `$r`.
+
+plan 5;
+
+# Accumulator declared before the loop, mutated after the recursive call.
+sub w($n) {
+    my $r = 0;
+    my @work = (1,);
+    while @work.splice {
+        w($n - 1) if $n > 0;
+        $r += 10;
+    }
+    $r
+}
+is w(1), 10, 'while-body recursion does not clobber a scalar accumulator (depth 1)';
+is w(3), 10, 'while-body recursion does not clobber a scalar accumulator (depth 3)';
+
+# Explicit return path.
+sub v($n) {
+    my $r = 0;
+    my @work = (1,);
+    while @work.splice {
+        v($n - 1) if $n > 0;
+        $r += 5;
+    }
+    return $r;
+}
+is v(2), 5, 'explicit return after while-body recursion keeps the accumulator';
+
+# Array accumulator (was already correct; guard against regression).
+sub a($n) {
+    my @acc;
+    my @work = (1, 2);
+    while @work.splice(0, 1) -> @batch {
+        a($n - 1) if $n > 0;
+        @acc.push(@batch[0]);
+    }
+    @acc
+}
+is a(1).elems, 2, 'array accumulator across while-body recursion is intact';
+
+# Mutual recursion with differently-named accumulators.
+sub p($n) { my $rp = 0; my @w = (1,); while @w.splice { q($n-1) if $n > 0; $rp += 10 }; $rp }
+sub q($n) { my $rq = 0; my @w = (1,); while @w.splice { p($n-1) if $n > 0; $rq += 10 }; $rq }
+is p(2), 10, 'mutual recursion through while loops keeps each accumulator';


### PR DESCRIPTION
## Problem

A routine that recurses from inside its own `while` loop clobbered a scalar accumulator declared before the loop:

```raku
sub w($n) { my $r = 0; my @w = (1,);
    while @w.splice { w($n-1) if $n > 0; $r += 10 }; $r }
say w(1);   # raku: 10 ; mutsu(before): 0
```

## Root cause

The positional and typed light-call fast paths (`call_compiled_function_positional_light`, `call_compiled_function_light`) bypass `push_call_frame`, and unlike `push_call_frame` / `call_compiled_function` (vm_call_fast.rs) they did not save+clear+restore `loop_local_vars` / `loop_local_saved_env`. So a callee's body-local `my $r` registered in the **caller's** active while-loop declaration scope; the caller's loop-exit `pop_loop_local_scope` then reverted its own `$r` to the pre-loop value. `for` loops already worked because vm_call_fast.rs had been fixed for them; the light paths were the remaining gap.

## Fix

Take and clear both loop-local stacks for the callee and restore them on every exit path (arity/type-check early returns and normal return), mirroring vm_call_fast.rs.

## Scope

This fixes recursion from a plain `while` loop. A separate, deeper slot-vs-env desync still affects recursion from a **bare-block-wrapped** / **pointy** (`while … -> $x { }`) loop — tracked as a follow-up; it reproduces even when the accumulator is mutated *before* the recursive call, so it is a distinct mechanism, not this loop-local leak.

Regression test: `t/while-recursion-loop-local-leak.t`. `make test` green (15977 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA