### PR TITLE
fix(runtime): mutate the shared node in place for value-path array methods (container identity §3.2)

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -896,6 +896,21 @@ impl Interpreter {
             if matches!(method, "push" | "append" | "unshift" | "prepend") {
                 self.check_array_value_element_types(&target, &args)?;
             }
+            // Splice replacements land in the shared node in place now, so
+            // type-check them up front (flattened like do_splice flattens).
+            if method == "splice" && args.len() > 2 {
+                let mut replacement: Vec<Value> = Vec::new();
+                for arg in args.iter().skip(2) {
+                    match arg.view() {
+                        ValueView::Array(items, ..) => replacement.extend(items.iter().cloned()),
+                        ValueView::Seq(items) | ValueView::Slip(items) => {
+                            replacement.extend(items.iter().cloned())
+                        }
+                        _ => replacement.push(arg.clone()),
+                    }
+                }
+                self.check_array_value_element_types(&target, &replacement)?;
+            }
             return self.array_mutate_copy(target, method, args);
         }
         // push/append on Hash: merge Pairs into the hash.

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -218,68 +218,40 @@ impl Interpreter {
         Ok(Some(Value::truth(super::to_int(&count) > 0)))
     }
 
-    /// Produce a modified copy of an Array value for push/pop/shift/unshift/append/prepend.
-    /// Used when the target is not a named variable (e.g., a hash or array element).
+    /// Mutate an Array value in place for push/pop/shift/unshift/append/
+    /// prepend/splice on a by-value invocant (function results, element
+    /// reads, literals). Container identity (§3.2): the mutation writes
+    /// through the SHARED backing node, so any live holder of the same
+    /// container (`f()` returning `@a`, an element holding the array)
+    /// observes it; a literal's node has no other holder, so the in-place
+    /// write is unobservable there.
     pub(super) fn array_mutate_copy(
         &self,
         target: Value,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
-        // Interior mutation: if the target Array has shared references
-        // (Arc refcount > 1), mutate in-place so all references see the
-        // change. This matches Raku's container semantics.
-        if matches!(method, "push" | "append" | "unshift" | "prepend")
-            && matches!(target.view(), ValueView::Array(arc, _) if crate::gc::Gc::strong_count(arc) > 1)
-        {
-            let vals: Vec<Value> = match method {
-                "push" => Self::normalize_push_args_for_copy(args),
-                "append" => flatten_append_args(args),
-                "unshift" => Self::normalize_push_args_for_copy(args),
-                "prepend" => flatten_append_args(args),
-                _ => unreachable!(),
-            };
-            if let ValueView::Array(arc, _) = target.view() {
-                // SAFETY: aliased in-place mutation of a shared array (guarded by
-                // strong_count > 1, the exact case that needs the shared write); see
-                // `arc_contents_mut`. No borrow into the items is live across this.
-                let data = unsafe { crate::value::gc_contents_mut(arc) };
-                if matches!(method, "unshift" | "prepend") {
-                    let mut combined = vals;
-                    combined.append(&mut data.items);
-                    data.items = combined;
-                } else {
-                    data.items.extend(vals);
-                }
-            }
-            return Ok(target);
-        }
-        let mut items = match target.view() {
-            ValueView::Array(v, ..) => v.to_vec(),
-            _ => Vec::new(),
-        };
         let kind = match target.view() {
             ValueView::Array(_, k) => k,
             _ => crate::value::ArrayKind::Array,
         };
         match method {
-            "push" => {
-                let normalized = Self::normalize_push_args_for_copy(args);
-                items.extend(normalized);
-                Ok(Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                    kind,
-                ))
+            "push" | "append" | "unshift" | "prepend" => {
+                let vals: Vec<Value> = match method {
+                    "push" | "unshift" => Self::normalize_push_args_for_copy(args),
+                    _ => flatten_append_args(args),
+                };
+                let front = matches!(method, "unshift" | "prepend");
+                target.with_array_inplace(|data, _| {
+                    if front {
+                        data.items.splice(0..0, vals);
+                    } else {
+                        data.items.extend(vals);
+                    }
+                });
+                Ok(target)
             }
-            "append" => {
-                let flat = flatten_append_args(args);
-                items.extend(flat);
-                Ok(Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                    kind,
-                ))
-            }
-            "pop" => {
+            "pop" | "shift" => {
                 if !args.is_empty() {
                     return Err(RuntimeError::new(format!(
                         "Too many positionals passed; expected 1 argument but got {}",
@@ -287,90 +259,69 @@ impl Interpreter {
                     )));
                 }
                 if kind.is_lazy() {
-                    return Err(RuntimeError::cannot_lazy("pop"));
+                    return Err(RuntimeError::cannot_lazy(method));
                 }
-                if items.is_empty() {
-                    Ok(Value::array_with_kind(
-                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                        kind,
-                    ))
-                } else {
-                    items.pop();
-                    Ok(Value::array_with_kind(
-                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                        kind,
-                    ))
-                }
-            }
-            "shift" => {
-                if !args.is_empty() {
-                    return Err(RuntimeError::new(format!(
-                        "Too many positionals passed; expected 1 argument but got {}",
-                        args.len() + 1
-                    )));
-                }
-                if items.is_empty() {
-                    Ok(Value::array_with_kind(
-                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                        kind,
-                    ))
-                } else {
-                    items.remove(0);
-                    Ok(Value::array_with_kind(
-                        crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                        kind,
-                    ))
-                }
-            }
-            "unshift" | "prepend" => {
-                let normalized = Self::normalize_push_args_for_copy(args);
-                for (i, arg) in normalized.into_iter().enumerate() {
-                    items.insert(i, arg);
-                }
-                Ok(Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
-                    kind,
-                ))
+                let removed = target
+                    .with_array_inplace(|data, _| {
+                        if data.items.is_empty() {
+                            None
+                        } else if method == "shift" {
+                            Some(data.items.remove(0))
+                        } else {
+                            data.items.pop()
+                        }
+                    })
+                    .flatten();
+                Ok(removed
+                    .unwrap_or_else(|| crate::runtime::utils::make_empty_array_failure(method)))
             }
             "splice" => {
-                // On a bare Array value (not a named variable) there is no
-                // container to write back to, so return the removed elements as
-                // a List, matching `@a.splice(...)`'s return value.
-                let len = items.len();
-                let resolve = |v: &Value| -> i64 {
-                    match v.view() {
-                        ValueView::Int(i) => i,
-                        ValueView::Whatever => len as i64,
-                        ValueView::Num(n) => n as i64,
-                        ValueView::Str(s) => s.parse::<i64>().unwrap_or(0),
-                        ValueView::Mixin(inner, _) => match inner.as_ref().view() {
-                            ValueView::Int(i) => i,
-                            _ => 0,
-                        },
-                        _ => 0,
-                    }
-                };
-                let start = (args.first().map(&resolve).unwrap_or(0).max(0) as usize).min(len);
-                let count = args
-                    .get(1)
-                    .map(&resolve)
-                    .unwrap_or((len - start) as i64)
-                    .max(0) as usize;
-                let end = (start + count).min(len);
-                let removed: Vec<Value> = items.drain(start..end).collect();
-                let mut replacement: Vec<Value> = Vec::new();
-                for arg in args.iter().skip(2) {
-                    match arg.view() {
-                        ValueView::Array(arr, ..) => replacement.extend(arr.iter().cloned()),
-                        ValueView::Seq(arr) | ValueView::Slip(arr) => {
-                            replacement.extend(arr.iter().cloned())
+                let removed = target
+                    .with_array_inplace(|data, _| {
+                        let len = data.items.len();
+                        let resolve = |v: &Value| -> i64 {
+                            match v.view() {
+                                ValueView::Int(i) => i,
+                                ValueView::Whatever => len as i64,
+                                ValueView::Num(n) => n as i64,
+                                ValueView::Str(s) => s.parse::<i64>().unwrap_or(0),
+                                ValueView::Mixin(inner, _) => match inner.as_ref().view() {
+                                    ValueView::Int(i) => i,
+                                    _ => 0,
+                                },
+                                _ => 0,
+                            }
+                        };
+                        let start =
+                            (args.first().map(&resolve).unwrap_or(0).max(0) as usize).min(len);
+                        let count = args
+                            .get(1)
+                            .map(&resolve)
+                            .unwrap_or((len - start) as i64)
+                            .max(0) as usize;
+                        let end = (start + count).min(len);
+                        // Snapshot the replacement BEFORE draining: a
+                        // self-splice (`f().splice(1, 0, f())`) aliases the
+                        // items being mutated in place.
+                        let mut replacement: Vec<Value> = Vec::new();
+                        for arg in args.iter().skip(2) {
+                            match arg.view() {
+                                ValueView::Array(arr, ..) => {
+                                    replacement.extend(arr.iter().cloned())
+                                }
+                                ValueView::Seq(arr) | ValueView::Slip(arr) => {
+                                    replacement.extend(arr.iter().cloned())
+                                }
+                                _ => replacement.push(arg.clone()),
+                            }
                         }
-                        _ => replacement.push(arg.clone()),
-                    }
-                }
-                for (i, item) in replacement.into_iter().enumerate() {
-                    items.insert(start + i, item);
-                }
+                        let removed: Vec<Value> = data.items.drain(start..end).collect();
+                        for (i, item) in replacement.into_iter().enumerate() {
+                            data.items.insert(start + i, item);
+                        }
+                        removed
+                    })
+                    .unwrap_or_default();
                 Ok(Value::real_array(removed))
             }
             _ => unreachable!(),

--- a/t/array-value-path-mutation.t
+++ b/t/array-value-path-mutation.t
@@ -1,0 +1,151 @@
+use v6;
+use Test;
+
+# Value-path (non-variable-invocant) array mutations must write through the
+# shared backing node (container identity §3.2): f().splice / f()."pop"() etc.
+# reach the runtime slow path, which used to mutate a copy and lose the
+# mutation. All expectations raku-verified.
+
+plan 27;
+
+# --- splice via a function result ---
+{
+    my @a = 1,2,3;
+    sub f() { @a }
+    my $removed = f().splice(0,1);
+    is-deeply $removed, [1], 'f().splice returns the removed elements';
+    is-deeply @a, [2,3], 'f().splice mutates the underlying array';
+}
+
+{
+    my @b = 1,2,3,4;
+    sub g() { @b }
+    my $removed = g().splice(1,2);
+    is-deeply $removed, [2,3], 'splice(1,2) returns two removed elements';
+    is-deeply @b, [1,4], 'splice(1,2) removes from the underlying array';
+}
+
+{
+    my @c = 1,2,3;
+    sub h() { @c }
+    h().splice(1,1,<x y>);
+    is-deeply @c, [1,'x','y',3], 'splice with replacement mutates in place';
+}
+
+{
+    my @s = 1,2,3;
+    sub fs() { @s }
+    fs().splice(1,0,fs());
+    is-deeply @s, [1,1,2,3,2,3], 'self-splice snapshots the replacement before draining';
+}
+
+{
+    my @n = 1,2,3;
+    sub fn2() { @n }
+    my $rem = fn2().splice;
+    is-deeply $rem, [1,2,3], 'splice with no args returns everything';
+    is @n.elems, 0, 'splice with no args clears the array';
+}
+
+{
+    my @w = 1,2,3;
+    sub fw() { @w }
+    fw().splice(*,0,9);
+    is-deeply @w, [1,2,3,9], 'splice with Whatever start appends';
+}
+
+# --- typed array: splice replacement type check before mutating ---
+{
+    my Int @t = 1,2,3;
+    sub ft() { @t }
+    my $died = False;
+    try { ft().splice(1,0,"x"); CATCH { default { $died = True } } }
+    ok $died, 'splice of a Str into Int array dies';
+    is-deeply @t.List, (1,2,3), 'typed array unchanged after failed splice';
+}
+
+# --- pop/shift via an indirect method name (slow dispatch path) ---
+{
+    my @a = 1,2,3;
+    sub f2() { @a }
+    my $m = "pop";
+    my $r = f2()."$m"();
+    is $r, 3, 'indirect ."pop"() returns the removed element';
+    is-deeply @a, [1,2], 'indirect ."pop"() mutates the underlying array';
+}
+
+{
+    my @a = 1,2,3;
+    sub f3() { @a }
+    my $m = "shift";
+    my $r = f3()."$m"();
+    is $r, 1, 'indirect ."shift"() returns the removed element';
+    is-deeply @a, [2,3], 'indirect ."shift"() mutates the underlying array';
+}
+
+{
+    my @z;
+    sub fz() { @z }
+    my $m = "pop";
+    my $v = fz()."$m"();
+    isa-ok $v, Failure, 'indirect pop on empty array returns a Failure';
+    is @z.elems, 0, 'empty array does not grow on failed pop';
+    $v.so;   # defuse the Failure
+}
+
+# --- push family via an indirect method name ---
+{
+    my @u = 3,4;
+    sub fu() { @u }
+    my $m = "unshift";
+    fu()."$m"(1,2);
+    is-deeply @u, [1,2,3,4], 'indirect unshift mutates in place preserving order';
+}
+
+{
+    my @p = 3,4;
+    sub fp() { @p }
+    my $m = "prepend";
+    fp()."$m"((1,2));
+    is-deeply @p, [1,2,3,4], 'indirect prepend flattens and mutates in place';
+}
+
+{
+    my @g = 1,2;
+    sub fg() { @g }
+    my $m = "push";
+    my $r = fg()."$m"(9);
+    is-deeply @g, [1,2,9], 'indirect push mutates in place';
+    is-deeply $r, [1,2,9], 'indirect push returns the array';
+}
+
+{
+    my @g = 1,2;
+    sub fa() { @g }
+    my $m = "append";
+    fa()."$m"((3,4));
+    is-deeply @g, [1,2,3,4], 'indirect append flattens and mutates in place';
+}
+
+# --- literal invocants still behave (no observable holder) ---
+{
+    is [1,2,3].splice(0,1), [1], 'literal splice returns removed elements';
+    my $m = "pop";
+    is [1,2,3]."$m"(), 3, 'literal indirect pop returns the last element';
+}
+
+# --- map over inner arrays (slow-path per-element dispatch) ---
+{
+    my @d = ([1,2,3],[4,5,6]);
+    @d.map(*.splice(0,1));
+    is-deeply @d, [[2,3],[5,6]], 'map(*.splice) mutates each inner array';
+}
+
+{
+    my @e = ([1,2],[3,4]);
+    my @popped = @e.map(*.pop);
+    is-deeply @popped, [2,4], 'map(*.pop) returns popped elements';
+    is-deeply @e, [[1,],[3,]], 'map(*.pop) mutates the inner arrays';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

`array_mutate_copy` — the runtime slow-path handler for `push`/`pop`/`shift`/`unshift`/`append`/`prepend`/`splice` on a **by-value Array invocant** (`f().splice(...)`, indirect `."pop"()`, per-element dispatch) — mutated a **copy** of the items for pop/shift/splice (and for the push family when the node was unshared), losing the mutation for every live holder of the container. This is the last remaining value-path gap from the element-mutation in-place campaign (#4362/#4366/#4370/#4372).

Raku-verified divergences fixed:

| case | before | after (= raku) |
|---|---|---|
| `f().splice(0,1)` | removed elements returned but `@a` untouched | `@a` mutated in place |
| `f()."pop"()` / `."shift"()` | returned the mutated array **copy**, `@a` unchanged | returns the removed element, `@a` mutated |
| `f()."pop"()` on empty | empty array copy | `Failure` (Cannot pop from an empty Array), no growth |
| `ft().splice(1,0,"x")` on `my Int @t` | replacement silently discarded | dies up front, array unchanged |
| `fs().splice(1,0,fs())` self-splice | n/a (copy path) | replacement snapshotted pre-drain |

## Implementation

- All branches of `array_mutate_copy` now write through the **shared backing node** via `with_array_inplace`, matching the CallMethod fast path from #4370. The push family drops its `strong_count > 1` guard — in-place is correct for an unshared node too and preserves identity.
- The dispatch site type-checks splice replacements up front against the node's embedded element-type metadata (flattened Array/Seq/Slip args, like `do_splice`), since they now land for real.

## Testing

- Pin: `t/array-value-path-mutation.t` (27 tests, all expectations verified against `raku`)
- `make test` (1619 files) all pass; S32-array roast (splice/pop/shift/push/unshift/create, 607 tests) all pass; container-identity pin tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW