### PR TITLE
fix(vm): make a thread's own shared-hash element writes visible to its re-reads

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -321,11 +321,18 @@ impl Interpreter {
     }
 
     fn get_env_with_main_alias_inner(&self, name: &str) -> Option<Value> {
-        // Atomic array CAS stores the authoritative copy under an internal key.
-        // Always check it first so both thread-clone and non-clone reads
-        // observe the latest CAS'd value.
+        // Atomic array/hash CAS stores the authoritative copy under an internal
+        // key. Always check it first so both thread-clone and non-clone reads
+        // observe the latest CAS'd value. Without the hash arm, a thread's own
+        // `%h{$k} = $v` (routed through `shared_hash_elem_set`) was invisible
+        // to its own re-read: the base-key snapshot below is stale.
         if name.starts_with('@') {
             let atomic_key = format!("__mutsu_atomic_arr::{name}");
+            if let Some(v) = self.get_shared_var(&atomic_key) {
+                return Some(v);
+            }
+        } else if name.starts_with('%') {
+            let atomic_key = format!("__mutsu_atomic_hash::{name}");
             if let Some(v) = self.get_shared_var(&atomic_key) {
                 return Some(v);
             }

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -106,10 +106,19 @@ impl Interpreter {
                 return Ok(());
             }
         }
-        // Atomic array CAS stores the authoritative array under an internal
-        // shared key.  Check it first so reads pick up the latest CAS'd value.
+        // Atomic array/hash CAS stores the authoritative container under an
+        // internal shared key. Check it first so reads pick up the latest
+        // CAS'd value (for `%`: a thread's own `%h{$k} = $v` lands in the
+        // atomic entry, and the base-key snapshot below is stale).
         if name.starts_with('@') {
             let atomic_key = format!("__mutsu_atomic_arr::{name}");
+            if let Some(shared_val) = self.get_shared_var(&atomic_key) {
+                self.locals[idx] = shared_val.clone();
+                self.stack.push(shared_val);
+                return Ok(());
+            }
+        } else if name.starts_with('%') {
+            let atomic_key = format!("__mutsu_atomic_hash::{name}");
             if let Some(shared_val) = self.get_shared_var(&atomic_key) {
                 self.locals[idx] = shared_val.clone();
                 self.stack.push(shared_val);

--- a/t/thread-hash-elem-visibility.t
+++ b/t/thread-hash-elem-visibility.t
@@ -1,0 +1,79 @@
+use v6;
+use Test;
+
+# Same-thread visibility of shared-hash element writes: a `%h{$k} = $v`
+# performed inside a `start` block lands in the __mutsu_atomic_hash:: shared
+# store, and the writing thread's own re-read of %h must observe it
+# (the base-key snapshot in shared_vars is stale). Behavior verified
+# against raku.
+
+plan 12;
+
+{
+    my %h;
+    my $inside;
+    my $inside-elem;
+    my $inside-exists;
+    await start {
+        %h<k> = [1, 2, 3];
+        $inside = %h.elems;
+        $inside-elem = %h<k>[1];
+        $inside-exists = %h<k>:exists;
+    };
+    is $inside, 1, 'writing thread sees its own hash element write via %h';
+    is $inside-elem, 2, 'writing thread reads the stored element back';
+    ok $inside-exists, ':exists sees the element inside the thread';
+    is %h.elems, 1, 'parent sees the write after await';
+    is-deeply %h<k>, $[1, 2, 3], 'parent reads the stored value';
+}
+
+{
+    my %m;
+    my $keys;
+    await start {
+        %m<p> = 1;
+        %m<q> = 2;
+        $keys = %m.keys.sort.join(',');
+    };
+    is $keys, 'p,q', 'keys/iteration inside the thread sees both writes';
+    is %m.elems, 2, 'parent sees both writes';
+}
+
+{
+    my %c;
+    await (^10).map: -> $i { start { %c{"k$i"} = $i } };
+    is %c.elems, 10, 'concurrent element writes from sibling threads all land';
+}
+
+{
+    my @fresh;
+    for ^2 {
+        my %f;
+        await start { %f<x> = $_; };
+        @fresh.push(%f.elems, %f<x>);
+    }
+    is-deeply @fresh, [1, 0, 1, 1], 'loop re-declaration gets a fresh hash each iteration';
+}
+
+{
+    my %n;
+    my $nested;
+    await start {
+        %n<a> = {};
+        %n<a><b> = 5;
+        $nested = %n<a><b>;
+    };
+    is $nested, 5, 'nested element write is visible inside the thread';
+    is %n<a><b>, 5, 'nested element write is visible to the parent';
+}
+
+{
+    my %d;
+    my $after-delete;
+    await start {
+        %d<x> = 1;
+        %d<x>:delete;
+        $after-delete = %d.elems;
+    };
+    is $after-delete, 0, ':delete after a shared element write is visible in-thread';
+}


### PR DESCRIPTION
## Problem

`start { %h<k> = [1,2,3]; say %h }` printed `{}` in mutsu while raku prints the stored element — the known "same-thread visibility gap" noted as a leftover in the element-mutation in-place campaign (#4370/#4372/#4377).

## Root cause

A `%h{$k} = $v` inside a `start` block routes through the `__mutsu_atomic_hash::` shared store (`shared_hash_elem_set`), which becomes the authoritative copy. But the variable read paths only consulted the atomic entry for `@` names (`__mutsu_atomic_arr::`): a thread-clone read of `%h` preferred the *stale base-key snapshot* in `shared_vars` (seeded by `clone_for_thread`), so the writing thread's own re-read missed its write. Arrays already worked because their atomic entry is checked first.

## Fix

Add the `%` → `__mutsu_atomic_hash::` arm to both read sites, symmetric to the existing array handling:

- `get_env_with_main_alias_inner` (`src/vm/vm_env_helpers.rs`)
- the locals fast read path (`src/vm/vm_var_assign_local_get.rs`)

## Tests

- New pin: `t/thread-hash-elem-visibility.t` (12 subtests, output verified identical to raku): same-thread element/`.keys`/`:exists`/`:delete` visibility, nested writes, 10-way concurrent sibling writes, loop re-declaration freshness.
- `make test` full pass (1624 files / 16021 tests).
- Local roast spot checks pass: S17-promise/start.t, S17-lowlevel/lock.t, S17-procasync/basic.t, S17-supply/syntax.t, S17-channel/basic.t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW