### PR TITLE
fix(vm): stop callee `my` declarations leaking into a caller's block/method scope across recursion

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -979,6 +979,95 @@ pub(crate) enum AssignOp {
 /// last value into the caller (the caller's loop variable / hash key is corrupted).
 /// Scalar names only (matching the caller's scalar-writeback filter); `@`/`%`
 /// binders are handled by the Array/Hash writeback path.
+/// Collect every `my`-declared lexical name (scalars, arrays, hashes) that a
+/// body introduces, recursing through the control-flow constructs whose bodies
+/// run in the *same* env scope (for/while/loop/if/block/given/when/gather/...),
+/// but NOT into nested `sub`/method/closure bodies (those are separate scopes).
+///
+/// Used to seed `CompiledCode::env_only_decls` so the method-dispatch return
+/// merge treats a `my @x` declared inside a deferred body (e.g. a `gather` block,
+/// stashed in `stmt_pool` and run by-name against the method env) as method-local
+/// and does not leak it into a same-named caller lexical across (self-)recursion.
+pub(crate) fn collect_all_my_decl_names(
+    stmts: &[Stmt],
+    out: &mut std::collections::HashSet<String>,
+) {
+    fn add(name: &str, out: &mut std::collections::HashSet<String>) {
+        let bare = name.strip_prefix('\\').unwrap_or(name);
+        if !bare.is_empty() {
+            out.insert(bare.to_string());
+        }
+    }
+    // A `my` declaration can hide inside a *condition* expression — e.g.
+    // `next unless my @x = ...` parses to `If { cond: !DoStmt(VarDecl @x) }`,
+    // and `while my $x = ...` puts the decl in the loop condition. Walk the
+    // condition Expr for embedded statement bodies (DoStmt/Block/Gather) so those
+    // env-only lexicals are collected too. Stops at closure boundaries (Lambda /
+    // AnonSub) — those are separate scopes.
+    fn add_from_expr(expr: &Expr, out: &mut std::collections::HashSet<String>) {
+        match expr {
+            Expr::DoStmt(s) => collect_all_my_decl_names(std::slice::from_ref(s), out),
+            Expr::Block(stmts) | Expr::Gather(stmts) => collect_all_my_decl_names(stmts, out),
+            Expr::DoBlock { body, .. } => collect_all_my_decl_names(body, out),
+            Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => add_from_expr(expr, out),
+            Expr::Binary { left, right, .. } => {
+                add_from_expr(left, out);
+                add_from_expr(right, out);
+            }
+            _ => {}
+        }
+    }
+    for stmt in stmts {
+        match stmt {
+            Stmt::VarDecl { name, .. } => add(name, out),
+            Stmt::For {
+                param,
+                params,
+                body,
+                ..
+            } => {
+                if let Some(p) = param {
+                    add(p, out);
+                }
+                for p in params {
+                    add(p, out);
+                }
+                collect_all_my_decl_names(body, out);
+            }
+            Stmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                binding_var,
+            } => {
+                add_from_expr(cond, out);
+                if let Some(v) = binding_var {
+                    add(v, out);
+                }
+                collect_all_my_decl_names(then_branch, out);
+                collect_all_my_decl_names(else_branch, out);
+            }
+            Stmt::While { cond, body, .. } => {
+                add_from_expr(cond, out);
+                collect_all_my_decl_names(body, out);
+            }
+            Stmt::Loop { body, .. }
+            | Stmt::React { body }
+            | Stmt::Block(body)
+            | Stmt::SyntheticBlock(body)
+            | Stmt::Default(body)
+            | Stmt::Catch(body)
+            | Stmt::Control(body) => collect_all_my_decl_names(body, out),
+            Stmt::Given { body, .. } | Stmt::When { body, .. } => {
+                collect_all_my_decl_names(body, out)
+            }
+            Stmt::Whenever { body, .. } => collect_all_my_decl_names(body, out),
+            Stmt::Label { stmt, .. } => collect_all_my_decl_names(std::slice::from_ref(stmt), out),
+            _ => {}
+        }
+    }
+}
+
 pub(crate) fn collect_routine_body_local_names(
     stmts: &[Stmt],
     out: &mut std::collections::HashSet<String>,
@@ -2228,5 +2317,65 @@ pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
             is_rw: false,
             is_whatever_code: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod env_only_decl_tests {
+    use super::*;
+
+    fn vardecl(name: &str) -> Stmt {
+        Stmt::VarDecl {
+            name: name.to_string(),
+            expr: Expr::Literal(crate::value::Value::NIL),
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        }
+    }
+
+    // `my @needed` declared inside a `next unless my @needed = ...` condition
+    // parses to `If { cond: !DoStmt(VarDecl @needed) }`. The declaration is in the
+    // condition Expr, not the then/else body, so the collector must walk the
+    // condition. Regression for the zef `!find-prereq-candidates` `@needed` leak.
+    #[test]
+    fn collects_my_decl_embedded_in_if_condition() {
+        let inner_if = Stmt::If {
+            cond: Expr::Unary {
+                op: crate::token_kind::TokenKind::Bang,
+                expr: Box::new(Expr::DoStmt(Box::new(vardecl("@needed")))),
+            },
+            then_branch: vec![Stmt::Next(None)],
+            else_branch: vec![],
+            binding_var: None,
+        };
+        // Wrapped in a gather-shaped Block([While { body: [...] }]).
+        let body = vec![Stmt::Block(vec![Stmt::While {
+            cond: Expr::Literal(crate::value::Value::NIL),
+            body: vec![inner_if],
+            label: None,
+        }])];
+        let mut out = std::collections::HashSet::new();
+        collect_all_my_decl_names(&body, &mut out);
+        assert!(
+            out.contains("@needed"),
+            "expected @needed to be collected from the If condition, got {out:?}"
+        );
+    }
+
+    // Array/hash `my` names in a plain body must be collected (not just scalars).
+    #[test]
+    fn collects_array_and_hash_decls() {
+        let body = vec![vardecl("@arr"), vardecl("%hash"), vardecl("$scalar")];
+        let mut out = std::collections::HashSet::new();
+        collect_all_my_decl_names(&body, &mut out);
+        assert!(out.contains("@arr"));
+        assert!(out.contains("%hash"));
+        assert!(out.contains("$scalar"));
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1649,6 +1649,16 @@ pub(crate) struct CompiledCode {
     /// for closures with no upvalue-eligible free variables. Populated by
     /// `compute_upvalues` (called only for anonymous-closure bodies).
     pub(crate) upvalue_syms: Vec<Symbol>,
+    /// Names declared with `my` in this body that have NO compiled local slot —
+    /// i.e. env-only lexicals emitted via `SetVarDynamic` (e.g. a `my @x`
+    /// declared inside a statement-modifier condition like
+    /// `next unless my @x = ...`). The scoped-overlay return merges exclude
+    /// slotted locals via `code.locals` and the light path also excludes these
+    /// via `CompiledFunction::declared_locals`; the method-dispatch merge
+    /// (`merge_method_env`) has no `CompiledFunction`, so it consults this set to
+    /// avoid leaking a callee's env-only `my` back into a same-named caller
+    /// lexical across (self-)recursion. Populated by `compute_needs_env_sync`.
+    pub(crate) env_only_decls: Vec<String>,
 }
 
 impl CompiledCode {
@@ -1688,6 +1698,7 @@ impl CompiledCode {
             captures_env_by_name: false,
             sub_fingerprints: std::collections::HashMap::new(),
             upvalue_syms: Vec::new(),
+            env_only_decls: Vec::new(),
         }
     }
 
@@ -1740,6 +1751,30 @@ impl CompiledCode {
     pub(crate) fn compute_needs_env_sync(&mut self) {
         self.compute_locals_sym();
         self.compute_free_vars();
+        // Collect env-only `my` declarations so the method-dispatch return merge
+        // can treat them as callee-local and not propagate them into a same-named
+        // caller lexical across (self-)recursion. Two sources:
+        //  (1) top-level `SetVarDynamic` ops (a `my $x`/`@x`/`%x` with no slot),
+        //  (2) `my` declarations inside a *deferred* body stashed in `stmt_pool`
+        //      (a `gather`/block/`while` body run by-name against the method env,
+        //      e.g. zef `!find-prereq-candidates`'s `my @needed`), which never
+        //      reaches the top-level op scan.
+        let mut decls: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for op in &self.ops {
+            if let OpCode::SetVarDynamic { name_idx, .. } = op
+                && let Some(crate::value::ValueView::Str(name)) =
+                    self.constants.get(*name_idx as usize).map(Value::view)
+            {
+                decls.insert(name.to_string());
+            }
+        }
+        crate::ast::collect_all_my_decl_names(&self.stmt_pool, &mut decls);
+        // Keep only names that are NOT compiled local slots (those are already
+        // excluded from the merge via `method_local_keys`/`code.locals`).
+        self.env_only_decls = decls
+            .into_iter()
+            .filter(|n| !self.locals.iter().any(|l| l == n))
+            .collect();
         // Always scan for reflective caller-lexical access (independent of the
         // needs_env_sync early returns below), so the global flag is set even for
         // loop/block or zero-local frames.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -294,6 +294,15 @@ pub(crate) struct VmCallFrame {
     /// have them clobbered at the caller's loop exit.
     pub saved_loop_local_vars: Vec<HashSet<String>>,
     pub saved_loop_local_saved_env: Vec<HashMap<String, Value>>,
+    /// The caller's block-scope `my`-declaration tracking stack. A `BlockScope`
+    /// pushes a frame here and, on exit, reverts every name it records to the
+    /// pre-block value (block-local `my` must not leak out). A compiled-function
+    /// body runs via its own `exec_one` mini-loop, so without snapshotting this a
+    /// callee's routine-level `my $x` (which runs before the callee enters any of
+    /// its own blocks) would register in the *caller's* active `BlockScope` frame
+    /// and get reverted at the caller's block exit — clobbering a same-named
+    /// caller variable across a recursive call.
+    pub saved_block_declared_vars: Vec<HashSet<String>>,
 }
 
 // CP-3 collapse: the bytecode Interpreter has been fully dissolved into the `Interpreter`

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -70,6 +70,11 @@ impl Interpreter {
         // the inner `my $r` polluted the outer loop's scope, resetting $r to 0.
         let saved_loop_local_vars = std::mem::take(&mut self.loop_local_vars);
         let saved_loop_local_saved_env = std::mem::take(&mut self.loop_local_saved_env);
+        // Isolate the caller's block-scope `my`-declaration tracking (see the
+        // matching comment in `call_compiled_function_positional_light`): a
+        // callee's routine-level `my $x` must not register in the caller's active
+        // `BlockScope` frame and be reverted at the caller's block exit.
+        let saved_block_declared_vars = std::mem::take(&mut self.block_declared_vars);
 
         // Raku: routines get their own $_ initialized to (Any).
         let saved_topic = if cf.code.is_routine {
@@ -184,6 +189,7 @@ impl Interpreter {
         self.locals = saved_locals;
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
+        self.block_declared_vars = saved_block_declared_vars;
 
         // Restore env: if env was mutated, merge non-local changes back.
         // When has_locals is false, saved_env is None and no restore is needed

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -43,6 +43,13 @@ impl Interpreter {
         // returned 0 instead of 10. Restored on every exit path.
         let saved_loop_local_vars = std::mem::take(&mut self.loop_local_vars);
         let saved_loop_local_saved_env = std::mem::take(&mut self.loop_local_saved_env);
+        // Isolate the caller's block-scope `my`-declaration tracking (mirrors the
+        // loop-local isolation above). Without this, the callee's routine-level
+        // `my $x` — which runs before the callee enters any of its own blocks —
+        // registers in the *caller's* active `BlockScope` frame and gets reverted
+        // to the pre-block value at the caller's block exit. Repro:
+        // `sub f($n){ my $r=0; { $r=10; f($n-1) if $n>0 }; $r }` returned 0.
+        let saved_block_declared_vars = std::mem::take(&mut self.block_declared_vars);
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / local env writes land in a
@@ -86,6 +93,7 @@ impl Interpreter {
                     self.locals = saved_locals;
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
+                    self.block_declared_vars = saved_block_declared_vars;
                     {
                         let param_name = &cf.param_defs[param_idx].name;
                         let got = runtime::value_type_name(&val);
@@ -184,6 +192,7 @@ impl Interpreter {
         self.locals = saved_locals;
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
+        self.block_declared_vars = saved_block_declared_vars;
         self.restore_readonly_vars(saved_readonly);
 
         // Restore the caller env and merge the overlay (the callee's own writes)

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -25,6 +25,11 @@ impl Interpreter {
         // clobbered at the caller's loop exit. Restored on every exit path.
         let saved_loop_local_vars = std::mem::take(&mut self.loop_local_vars);
         let saved_loop_local_saved_env = std::mem::take(&mut self.loop_local_saved_env);
+        // Isolate the caller's block-scope `my`-declaration tracking (see the
+        // matching comment in `call_compiled_function_positional_light`): a
+        // callee's routine-level `my $x` must not register in the caller's active
+        // `BlockScope` frame and be reverted at the caller's block exit.
+        let saved_block_declared_vars = std::mem::take(&mut self.block_declared_vars);
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / alias / @_ env writes below
@@ -130,6 +135,7 @@ impl Interpreter {
                     self.locals = saved_locals;
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
+                    self.block_declared_vars = saved_block_declared_vars;
                     // Missing required named parameter is a runtime X::AdHoc in
                     // Raku (see binding.rs); carry the typed exception so it does
                     // not fall back to the bare "Exception" default.
@@ -158,6 +164,7 @@ impl Interpreter {
                     self.locals = saved_locals;
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
+                    self.block_declared_vars = saved_block_declared_vars;
                     return Err(RuntimeError::new(format!(
                         "Too few positionals passed; expected {} arguments but got {}",
                         cf.param_defs.iter().filter(|p| !p.named).count(),
@@ -335,6 +342,7 @@ impl Interpreter {
         self.locals = saved_locals;
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
+        self.block_declared_vars = saved_block_declared_vars;
 
         // Restore readonly vars
         self.restore_readonly_vars(saved_readonly);

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -37,6 +37,7 @@ impl Interpreter {
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
             saved_loop_local_vars: std::mem::take(&mut self.loop_local_vars),
             saved_loop_local_saved_env: std::mem::take(&mut self.loop_local_saved_env),
+            saved_block_declared_vars: std::mem::take(&mut self.block_declared_vars),
         };
         self.call_frames.push(frame);
     }
@@ -58,6 +59,7 @@ impl Interpreter {
             saved_local_bind_pairs: std::mem::take(&mut self.local_bind_pairs),
             saved_loop_local_vars: std::mem::take(&mut self.loop_local_vars),
             saved_loop_local_saved_env: std::mem::take(&mut self.loop_local_saved_env),
+            saved_block_declared_vars: std::mem::take(&mut self.block_declared_vars),
         };
         self.call_frames.push(frame);
     }
@@ -77,6 +79,7 @@ impl Interpreter {
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);
         self.loop_local_vars = std::mem::take(&mut frame.saved_loop_local_vars);
         self.loop_local_saved_env = std::mem::take(&mut frame.saved_loop_local_saved_env);
+        self.block_declared_vars = std::mem::take(&mut frame.saved_block_declared_vars);
         if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
             // Slow path: restore the whole snapshot (covers any `:=` marking).
             self.restore_readonly_vars(readonly);

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -686,6 +686,15 @@ impl Interpreter {
                     method_local_keys.insert(local_name.clone());
                 }
             }
+            // Env-only `my` declarations (no compiled slot, e.g. a `my @x`
+            // declared in a `next unless my @x = ...` condition) are callee-local
+            // too: without excluding them, a self-recursive method leaks the
+            // callee's `my @x` value back into the caller's same-named `@x`
+            // (zef `!find-prereq-candidates` `@needed`). The light-call merge
+            // already excludes these via `declared_locals`.
+            for name in &cc.env_only_decls {
+                method_local_keys.insert(name.clone());
+            }
             let rw_writeback: Vec<(String, Value)> = rw_bindings
                 .iter()
                 .filter_map(|(param_name, source_name)| {

--- a/t/block-scope-recursion-decl-leak.t
+++ b/t/block-scope-recursion-decl-leak.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# A routine that recurses into itself from inside a bare `{ ... }` block (or a
+# pointy `while ... -> $x { }` loop, which compiles to a Block wrapping a While)
+# must not have the callee's routine-level `my $x` declaration register in the
+# caller's active `BlockScope` frame. Previously the callee's `my $r` was tracked
+# as block-local in the caller's block, so the caller's block exit reverted `$r`
+# to its pre-block value, dropping the caller's own accumulation across the call.
+# Regression for the zef `find-prereq-candidates` for-loop chain.
+
+plan 8;
+
+# --- bare block, mutate before the recursive call ---
+sub a($n) { my $r = 0; { $r = 10; a($n - 1) if $n > 0 }; $r }
+is a(1), 10, 'bare block, mutate-before, depth 1';
+is a(2), 10, 'bare block, mutate-before, depth 2';
+
+# --- bare block, mutate after the recursive call ---
+sub c($n) { my $r = 0; { c($n - 1) if $n > 0; $r += 10 }; $r }
+is c(1), 10, 'bare block, mutate-after, depth 1';
+
+# --- pointy while (compiles to Block([While ...])) ---
+sub b($n) { my $r = 0; my @w = (1,); while @w.splice -> @x { b($n - 1) if $n > 0; $r += 10 }; $r }
+is b(1), 10, 'pointy while, recursion';
+
+# --- bare block wrapping a while, accumulator ---
+sub d($n) { my $r = 0; my @w = (1,); { while @w.splice { $r += 10; d($n - 1) if $n > 0 } }; $r }
+is d(1), 10, 'bare block around while, recursion';
+
+# --- non-light call paths must be fixed too ---
+sub s2(*@a) { my $n = @a[0]; my $r = 0; { $r = 10; s2($n - 1) if $n > 0 }; $r }
+is s2(1), 10, 'slurpy-param sub (general call path)';
+
+sub nm(:$n) { my $r = 0; { $r = 10; nm(n => $n - 1) if $n > 0 }; $r }
+is nm(n => 1), 10, 'named-param sub (general call path)';
+
+# --- deeper recursion accumulates correctly (each frame owns its $r) ---
+sub e($n) { my $r = 0; { e($n - 1) if $n > 0; $r += 5 }; $r }
+is e(3), 5, 'each recursion frame keeps its own accumulator';


### PR DESCRIPTION
## Summary

Two related dual-store leaks let a callee's `my` declaration clobber a same-named caller lexical when a routine recurses (directly or via a nested `gather`/`.first`). This unblocks zef's `!find-prereq-candidates` — the upstream `distribution-depends-parsing` test goes from dying at test 31 (30/35) to passing tests 19–34 (the full 8-iteration prerequisite-resolution loop).

### 1. Block-scope declaration tracking not isolated at call boundaries

`block_declared_vars` (which a `BlockScope` uses to revert block-local `my` names on exit) was not saved/restored across a routine call. A callee's routine-level `my $x` runs *before* the callee enters any of its own blocks, so its declaration registered in the **caller's** active `BlockScope` frame; at the caller's block exit that `$x` was reverted to its pre-block value.

Fixed by isolating `block_declared_vars` in `push_call_frame`/`pop_call_frame` and the light/typed/fast call fast paths, mirroring the existing `loop_local_vars` isolation.

Repro (returned `0`, now `10`):
```raku
sub f($n){ my $r=0; { $r=10; f($n-1) if $n>0 }; $r }; say f(1)
```

### 2. Method merge did not exclude env-only `my` lexicals

`merge_method_env` excluded only slotted locals (`code.locals`), not env-only `my` lexicals — a `my @x` with no compiled slot, e.g. one declared in a `next unless my @x = ...` condition inside a `gather` body. Such a declaration leaked from a self-recursive method into the caller's same-named lexical (zef's `@needed`).

Fixed by collecting every `my`-declared name (including array/hash names and those embedded in condition expressions and deferred `gather`/block bodies) into a new cached `CompiledCode::env_only_decls`, and adding them to `method_local_keys`. This mirrors what the light-call path already gets via `CompiledFunction::declared_locals`.

## Tests

- `t/block-scope-recursion-decl-leak.t` — 8 cases (bare block, pointy `while`, light + general call paths, deep recursion).
- Rust unit tests for `collect_all_my_decl_names` covering the condition-embedded (`next unless my @x`) and array/hash declaration cases.
- `make test` passes (15985 tests); targeted whitelisted roast sample (supply/method/gather-heavy) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)