### PR TITLE
fix(parser): don't swallow `if`/`for` after `my @x = gather {...}` as a statement modifier

### DIFF
--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -188,6 +188,22 @@ fn expr_ends_with_block(expr: &Expr) -> bool {
     }
 }
 
+/// Like [`expr_ends_with_block`] but for a whole statement: it also unwraps a
+/// `my $x = EXPR` / `$x = EXPR` whose initializer expression ends in a block
+/// (`my @a = gather { ... }`, `my @a = do for ... { ... }`). Such a declaration
+/// or assignment is equally self-terminating when its trailing `}` sits at the
+/// end of a line, so the next line's `if`/`for`/etc. must NOT be swallowed as a
+/// postfix modifier. Without this, `my @a = gather { ... }\nif COND { ... }`
+/// mis-parses `if COND` as a modifier (rewriting the decl to run its init only
+/// when COND) and turns the `{ ... }` into a separate bare block.
+fn stmt_ends_with_block(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Expr(e) => expr_ends_with_block(e),
+        Stmt::VarDecl { expr, .. } | Stmt::Assign { expr, .. } => expr_ends_with_block(expr),
+        _ => false,
+    }
+}
+
 /// After a statement-modifier keyword's condition, a `{` block (or `-> ... {`
 /// pointy header) means this is actually a full control statement (`if COND
 /// { ... }`), not a postfix modifier — modifiers never take a block. Mirrors
@@ -208,13 +224,12 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
             return Ok((input, stmt));
         }
     }
-    // Block-valued expressions (`try { ... }`, `do { ... }`, etc.):
-    // a newline after the closing brace should terminate the statement,
+    // Block-valued expressions (`try { ... }`, `do { ... }`, etc.), including a
+    // `my @a = gather { ... }` / `$x = do { ... }` whose initializer ends in a
+    // block: a newline after the closing brace should terminate the statement,
     // preventing the next line's `if`/`for`/etc. from being treated as a
     // statement modifier.
-    if let Stmt::Expr(ref expr) = stmt
-        && expr_ends_with_block(expr)
-    {
+    if stmt_ends_with_block(&stmt) {
         let consumed_len = input.len().saturating_sub(rest.len());
         if input[..consumed_len].contains('\n') {
             return Ok((input, stmt));
@@ -289,11 +304,12 @@ pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, S
 /// Try to parse a single statement modifier. Returns None if no modifier matched.
 fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>, PError> {
     // Whether the statement being modified itself ends in a `{ ... }` block
-    // (`$lock.protect: { ... }`). Only then does a `{` after the modifier's
-    // condition mean "this `if` starts a new control statement" rather than a
-    // postfix modifier. For a non-block statement (`die X if COND { ... }`) the
-    // `if` IS a modifier and the trailing block is a separate statement.
-    let modified_ends_block = matches!(&stmt, Stmt::Expr(e) if expr_ends_with_block(e));
+    // (`$lock.protect: { ... }`, `my @a = gather { ... }`). Only then does a `{`
+    // after the modifier's condition mean "this `if` starts a new control
+    // statement" rather than a postfix modifier. For a non-block statement
+    // (`die X if COND { ... }`) the `if` IS a modifier and the trailing block is
+    // a separate statement.
+    let modified_ends_block = stmt_ends_with_block(&stmt);
     // Try statement modifiers
     if let Some(r) = keyword("if", rest) {
         let (r, _) = ws1(r)?;

--- a/t/decl-block-init-not-stmt-modifier.t
+++ b/t/decl-block-init-not-stmt-modifier.t
@@ -1,0 +1,51 @@
+# A `my @x = <block-valued expression>` whose initializer ends in a `}` block
+# (gather {...}, do {...}, do for {...}) is self-terminating at end of line: the
+# next line's `if`/`for`/etc. must start a NEW statement, NOT be swallowed as a
+# postfix statement modifier. Regression for a parser bug where only `Stmt::Expr`
+# (not `Stmt::VarDecl`/`Stmt::Assign`) block-final statements were guarded, so
+# `my @a = gather {...}\nif COND {...}` mis-parsed `if COND` as a modifier
+# (making the assignment conditional) and turned `{...}` into a separate bare
+# block. Surfaced by zef's distribution-depends-parsing test (die propagation
+# through a nested gather reification back to a `.first` block's CATCH).
+
+use Test;
+plan 6;
+
+# --- my @x = gather {...} then a separate if ---
+{
+    my $branch = 0;
+    my @alt = gather {
+        take 1; take 2;
+    }
+    if False {
+        $branch = 1;
+    }
+    is @alt.join(","), "1,2", "my @x = gather {} keeps its value (if not a modifier)";
+    is $branch, 0, "the following if COND {} is a separate statement, not a modifier";
+}
+
+# --- my @x = gather for LIST -> $g {...} then a separate if ---
+{
+    my $branch = 0;
+    my @alt = gather for (1, 2, 3) -> $g {
+        take $g if $g %% 1;
+    }
+    if False {
+        $branch = 1;
+    }
+    is @alt.join(","), "1,2,3", "my @x = gather for {} keeps its value";
+    is $branch, 0, "if after gather-for block is a separate statement";
+}
+
+# --- my $x = do {...} then a separate if ---
+{
+    my $branch = 0;
+    my $v = do {
+        41 + 1;
+    }
+    if False {
+        $branch = 1;
+    }
+    is $v, 42, "my \$x = do {} keeps its value";
+    is $branch, 0, "if after do block is a separate statement";
+}


### PR DESCRIPTION
## Problem

A block-valued initializer in a declaration or assignment (`my @a = gather {...}`, `my @a = do for ... {...}`, `$x = do {...}`) is self-terminating when its closing `}` sits at end of line — just like a bare `gather {...}` / `do {...}` expression statement. The next line's `if`/`unless`/`for`/etc. must start a **new** statement, not be attached as a postfix statement modifier.

mutsu's self-termination guard in `parse_statement_modifier` (and the `modified_ends_block` check) only recognized `Stmt::Expr` block-final statements, so a `Stmt::VarDecl` / `Stmt::Assign` whose initializer ended in a block slipped through:

```raku
my @alt = gather for LIST -> $g { ... }
if COND { die }
```

mis-parsed `if COND` as a modifier on the declaration (via the `my $x = INIT if COND` decl-split, so the init runs only when COND) and turned `{ die }` into a separate **unconditional** bare block — so `@alt` was left empty and the `die` fired regardless of COND.

## Fix

Add a `stmt_ends_with_block` helper that also unwraps `VarDecl`/`Assign` initializers, and use it at both guard sites (the newline self-termination guard and `modified_ends_block`).

## How it surfaced

zef's `distribution-depends-parsing` test (13th blocker in the zef compat campaign): a `die` raised during a nested `gather` reification in a self-recursive `find-prereq-candidates` failed to be caught by a `.first` block's `CATCH`, because the enclosing `my @alt = gather for ... { ... $group.first(...) ... }` was mis-parsed, restructuring the `.first`/`CATCH` region and the following `if ... { die }`. Minimal repro:

```raku
my @alt = gather for (1,2) -> $g { take $g; }
if False { say "WRONG" }     # was parsed as `my @alt = ... if False` + bare `{ say }`
say @alt.join(",");          # was empty, now "1,2"
```

## Testing

- `t/decl-block-init-not-stmt-modifier.t` (new regression, verified against `raku`)
- `make test`: PASS (1625 files, 16030 tests)
- roast `S04-statements/{if,unless,for}.t`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)