### PR TITLE
fix(nativecall): accept `is native` in EVAL, Rakudo dlopen message, X::AdHoc.payload

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -835,6 +835,22 @@ impl Interpreter {
                     self.class_mro(&class_name.resolve()).contains(&target_name),
                 ));
             }
+            // `X::AdHoc.payload` returns the value passed to `die` (mutsu stores
+            // it under `payload`). An X::AdHoc synthesized from an internal
+            // `RuntimeError` — a native dlopen failure, a parse error inside
+            // EVAL, … — carries only a `message` attr (no `payload`), so fall
+            // back to that string so `.payload.starts-with(...)` / `.payload.Str`
+            // keep working (raku: `X::AdHoc` made from `die "msg"` has
+            // `.payload eq "msg"`).
+            if method == "payload" && args.is_empty() && class_name.resolve() == "X::AdHoc" {
+                let m = attributes.as_map();
+                if let Some(p) = m.get("payload") {
+                    return Ok(p.clone());
+                }
+                if let Some(msg) = m.get("message") {
+                    return Ok(Value::str(msg.to_string_value()));
+                }
+            }
             // An Exception instance stringifies (.Str/.gist/~) and reports via its
             // `.message` (raku: Exception.Str and .gist both return .message). Detect
             // it via the MRO so a user `class E is Exception` (whose name is not

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -154,8 +154,13 @@ fn load_library_cached(
             Err(e) => last_err = format!("{cand}: {e}"),
         }
     }
+    // Match Rakudo's message shape so code that inspects the failure text works
+    // (e.g. zef's `!native-library-is-installed` does
+    // `.payload.starts-with("Cannot locate native library")`). `candidates[0]`
+    // is the primary (unversioned) library file name.
+    let primary = candidates.first().map(String::as_str).unwrap_or("");
     Err(RuntimeError::new(format!(
-        "NativeCall: cannot load library {candidates:?}: {last_err}"
+        "Cannot locate native library '{primary}': {last_err}"
     )))
 }
 

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -908,12 +908,26 @@ impl Interpreter {
             self.env
                 .insert(format!("__mutsu_method_value::{}", name), Value::TRUE);
         }
+        // An `is native(...)` sub routes calls through NativeCall (libffi)
+        // instead of its body. The bytecode registration path
+        // (`vm_register_sub_ops`) records the C-FFI descriptor; the interpreter
+        // path (used by EVAL'd source, e.g. zef's `!native-library-is-installed`
+        // probe) must do the same, and must NOT reject `native`/`symbol`/… as
+        // unknown user traits.
+        if custom_traits.iter().any(|(t, _)| t == "native") {
+            self.register_native_call_sub(name, param_defs, return_type, custom_traits)?;
+        }
         // Apply custom trait_mod:<is> for each non-builtin trait
         let has_trait_mod =
             self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
         {
             for (trait_name, trait_arg) in custom_traits.iter().filter(|(t, _)| {
-                !t.starts_with("__") && t != "default" && !t.starts_with("DEPRECATED")
+                !t.starts_with("__")
+                    && t != "default"
+                    && !t.starts_with("DEPRECATED")
+                    // NativeCall traits are consumed by `register_native_call_sub`
+                    // above, not by `trait_mod:<is>`.
+                    && !matches!(t.as_str(), "native" | "symbol" | "nativeconv" | "encoded")
             }) {
                 if !has_trait_mod {
                     // In EVAL context, report the error. Outside EVAL

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -293,7 +293,7 @@ impl Interpreter {
     /// The library name comes from the `native` trait argument, the C symbol
     /// from an optional `is symbol('...')` trait (defaulting to the sub name),
     /// and the C signature from the parameter / return type constraints.
-    fn register_native_call_sub(
+    pub(crate) fn register_native_call_sub(
         &mut self,
         name: &str,
         param_defs: &[crate::ast::ParamDef],

--- a/t/nativecall-eval-trait-and-payload.t
+++ b/t/nativecall-eval-trait-and-payload.t
@@ -1,0 +1,54 @@
+# NativeCall + exception-payload fixes surfaced by zef's
+# `!native-library-is-installed` probe (distribution-depends-parsing test 35,
+# native `:any` dep case):
+#   1. A `sub ... is native('<missing>')` declared inside EVAL'd source must be
+#      accepted (the interpreter registration path previously rejected `native`
+#      as an unknown trait) and, when called, must die trying to load the
+#      library.
+#   2. The dlopen-failure message must match Rakudo's shape
+#      ("Cannot locate native library '<lib>': ...") so code that inspects it
+#      (`.payload.starts-with("Cannot locate native library")`) works.
+#   3. `X::AdHoc.payload` must return the die payload, falling back to the
+#      message string for an X::AdHoc synthesized from an internal error.
+
+use Test;
+plan 7;
+
+# --- .payload on a plain `die "string"` ---
+{
+    my $exc = do { try { die "boom-payload" }; $! };
+    is $exc.^name, 'X::AdHoc', 'die "str" produces X::AdHoc';
+    is $exc.payload, 'boom-payload', '.payload returns the die string';
+}
+
+# --- .payload on `die $typed-object` returns the object ---
+{
+    my $obj = [1, 2, 3];
+    my $exc = do { try { die $obj }; $! };
+    ok $exc.payload ~~ Positional, '.payload returns the thrown object';
+}
+
+# --- is native for a missing library: message shape + .payload fallback ---
+{
+    use NativeCall;
+    sub mutsu_missing_native_fn is native('mutsu-no-such-lib-xyz') { * }
+    my $exc = do { try { mutsu_missing_native_fn() }; $! };
+    ok $exc.defined, 'calling a missing native sub dies';
+    ok $exc.message.starts-with('Cannot locate native library'),
+        'dlopen failure message matches Rakudo shape';
+    ok $exc.payload.starts-with('Cannot locate native library'),
+        '.payload falls back to the message for an internal X::AdHoc';
+}
+
+# --- is native declared inside EVAL is accepted (not "unknown trait") ---
+{
+    use MONKEY-SEE-NO-EVAL;
+    my $exc = do {
+        try {
+            EVAL q[use NativeCall; sub eval_native is native('mutsu-no-such-lib-xyz') { !!! }; eval_native();];
+        };
+        $!;
+    };
+    ok $exc.defined && $exc.payload.starts-with('Cannot locate native library'),
+        'is native inside EVAL registers and dies locating the library';
+}


### PR DESCRIPTION
Three fixes surfaced by zef's `!native-library-is-installed` probe (the native `:any` dependency case of the `distribution-depends-parsing` compat test). That probe does `EVAL "use NativeCall; sub … is native('lib') {…}; …()"` and inspects the failure with `.payload.starts-with("Cannot locate native library")`.

## Fixes

1. **`is native` inside EVAL** — the interpreter sub-registration path (`register_sub_decl_fp`, used by EVAL'd source) rejected `native` as an unknown user trait (`Can't use unknown trait 'is' -> 'native'`); only the bytecode path recorded the NativeCall descriptor. Now the interpreter path also calls `register_native_call_sub` and excludes the NativeCall traits (`native`/`symbol`/`nativeconv`/`encoded`) from the unknown-trait check. `register_native_call_sub` becomes `pub(crate)`.

2. **dlopen-failure message shape** — was `NativeCall: cannot load library [..]`; Rakudo emits `Cannot locate native library '<lib>': <details>`. Matched so code inspecting the message text works. No roast test references the old text.

3. **`X::AdHoc.payload`** — returned nothing for an X::AdHoc synthesized from an internal `RuntimeError` (native dlopen failure, parse error inside EVAL, …), which carry only a `message` attr. Now `.payload` on an X::AdHoc returns the `payload` attr, falling back to the `message` string (raku: `X::AdHoc` from `die "msg"` has `.payload eq "msg"`).

Together these let zef's native-library probe conclude a fake native library is absent → the native dependency is unsatisfiable → `find-prereq-candidates` throws `X::Zef::UnsatisfiableDependency`, the last failing case of the depends-parsing test's `X::Zef::UnsatisfiableDependency` subtest (which now passes 19/19 in the isolated driver).

## Testing

- `t/nativecall-eval-trait-and-payload.t` (new regression, all 7 pass on both `raku` and mutsu)
- `make test`: PASS (1625 files, 16031 tests)
- roast `S32-exceptions/misc.t`, `S04-exception-handlers/catch.t`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)