### PR TITLE
fix(vm): itemize Array/List values assigned into $ scalar containers

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -389,6 +389,12 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 let items = crate::runtime::utils::value_to_list(target);
                 Some(Ok(Value::array(items)))
             }
+            // `$x<>` decontainerizes: an itemized Array/List drops its Scalar
+            // container (same backing data), matching rakudo's `postcircumfix:«< >»`.
+            ValueView::Array(items, kind) if kind.is_itemized() => Some(Ok(
+                Value::array_with_kind(items.clone(), kind.decontainerize()),
+            )),
+            ValueView::Scalar(inner) => Some(Ok((*inner).clone())),
             ValueView::Array(..) | ValueView::Seq(..) | ValueView::Slip(..) => {
                 Some(Ok(target.clone()))
             }

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -568,8 +568,11 @@ impl Compiler {
                 self.compile_expr_exists(target, *negated, *delete, arg, adverb);
             }
             Expr::ZenSlice(inner) => {
-                // Outside of :exists, zen slice is identity
+                // Outside of :exists, a zen slice decontainerizes: `$a[]` on an
+                // itemized `$a = (1,2,3)` yields the plain List (flattens in a
+                // following list context); non-containers pass through as-is.
                 self.compile_expr(inner);
+                self.code.emit(OpCode::DeitemizeZen);
             }
             // Reduction ([+] @arr)
             Expr::Reduction { op, expr } => {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -707,6 +707,11 @@ impl Compiler {
                     if let Stmt::VarDecl { name, .. } = s
                         && sigilless_readonly_names.contains(name)
                     {
+                        // Register the sigilless name BEFORE compiling its
+                        // VarDecl so the decl emits MarkConstantContext (a raw
+                        // `\x = ...` binds the value itself — no Scalar
+                        // container, so SetLocal must not itemize it).
+                        self.sigilless_locals.insert(name.clone());
                         let key = format!("__mutsu_sigilless_readonly::{}", name);
                         let key_idx = self.code.add_constant(Value::str(key));
                         let false_idx = self.code.add_constant(Value::FALSE);
@@ -1197,7 +1202,10 @@ impl Compiler {
                     }
                     // Mark constant context so SetLocal uses List coercion for @ and
                     // skips Hash coercion for %, matching Raku's constant semantics.
-                    if is_constant && (name.starts_with('@') || name.starts_with('%')) {
+                    // Scalar constants and sigilless declarations (`my \x = ...`)
+                    // also carry the mark: both bind the value itself (no Scalar
+                    // container), so SetLocal must not itemize it.
+                    if is_constant || self.sigilless_locals.contains(name.as_str()) {
                         self.code.emit(OpCode::MarkConstantContext);
                     }
                     if has_explicit_initializer {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -284,6 +284,11 @@ pub(crate) enum OpCode {
     /// array's element type (see `Expr::DeitemizeForBind`). Falls back to plain
     /// list flattening for non-array values.
     DeitemizeForBind,
+    /// Strip ONE level of itemization for a zen slice (`$a[]` / `$a<>`):
+    /// an itemized Array/List drops its Scalar container (kind flag) so a
+    /// following list context flattens it; a `Scalar` wrapper unwraps.
+    /// Everything else passes through unchanged.
+    DeitemizeZen,
     /// Like `Itemize`, but skips itemization when the named scalar variable is
     /// bound (`:=`) to a Positional value. A bound scalar is NOT a Scalar
     /// container, so `@a = $bound` must flatten (matching Raku). The argument is

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1244,6 +1244,10 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     rest = after;
                     continue;
                 }
+                // A bare zen slice (`$a[]`) decontainerizes — keep the node so
+                // the compiler can emit the deitemization (it is NOT a plain
+                // identity for an itemized scalar-held array).
+                expr = Expr::ZenSlice(Box::new(expr));
                 rest = after;
                 continue;
             }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -99,6 +99,19 @@ impl Interpreter {
             let inner = inner.clone();
             return self.call_method_with_values(inner, method, args);
         }
+        // An itemized Array/List invocant is likewise a Scalar container:
+        // method dispatch decontainerizes it (`$list.tail` reaches the last
+        // element, not the container treated as one item by `value_to_list`).
+        // The kind flip keeps the same backing data, so mutators (`.push`)
+        // still write through. `.raku`/`.perl`/`.item`/`.VAR`/`.self` must
+        // see the container itself (the `$` sigil / itemization is the point).
+        if let ValueView::Array(items, kind) = target.view()
+            && kind.is_itemized()
+            && !matches!(method, "raku" | "perl" | "item" | "VAR" | "self")
+        {
+            let deconted = Value::array_with_kind(items.clone(), kind.decontainerize());
+            return self.call_method_with_values(deconted, method, args);
+        }
         // `Rakudo::Internals::JSON.from-json` / `.to-json`: a core Rakudo class
         // routed to the native JSON implementation (used by OpenSSL, JSON::JWT).
         if let Some(result) = self.try_rakudo_internals_json_method(&target, method, &args) {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -544,6 +544,12 @@ impl Interpreter {
                 let val = val.into_deref();
                 // When @-sigil dereferences a Hash, convert to a list of pairs
                 let val = match val.view() {
+                    // An `@`-sigil read strips the Scalar container: `@$x` on an
+                    // itemized `$x = [1,2,3]` yields the plain Array (flattens /
+                    // iterates element-wise).
+                    ValueView::Array(items, kind) if kind.is_itemized() => {
+                        Value::array_with_kind(items.clone(), kind.decontainerize())
+                    }
                     ValueView::Hash(map) => {
                         let pairs: Vec<Value> = map
                             .iter()
@@ -1539,6 +1545,18 @@ impl Interpreter {
             OpCode::Itemize => {
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 self.stack.push(Self::itemize_value(val));
+                *ip += 1;
+            }
+            OpCode::DeitemizeZen => {
+                let val = self.stack.pop().unwrap_or(Value::NIL);
+                let deitemized = match val.view() {
+                    ValueView::Array(items, kind) if kind.is_itemized() => {
+                        Value::array_with_kind(items.clone(), kind.decontainerize())
+                    }
+                    ValueView::Scalar(inner) => (*inner).clone(),
+                    _ => val,
+                };
+                self.stack.push(deitemized);
                 *ip += 1;
             }
             OpCode::DeitemizeForBind => {

--- a/src/vm/vm_hyper_func.rs
+++ b/src/vm/vm_hyper_func.rs
@@ -12,6 +12,11 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap_or(Value::NIL);
         let left = self.stack.pop().unwrap_or(Value::NIL);
+        let left_itemized = Self::is_itemized_operand(&left);
+        let right_itemized = Self::is_itemized_operand(&right);
+        // Hyper descends through Scalar containers (see deitemize_hyper_operand).
+        let right = Self::deitemize_hyper_operand(&right);
+        let left = Self::deitemize_hyper_operand(&left);
         let name = Self::const_str(code, name_idx).to_string();
         // QuantHash (Set/Bag/Mix) operands: reuse the plain-Hash hyper logic by
         // projecting each to a `key => weight` Hash, then convert the result
@@ -198,6 +203,16 @@ impl Interpreter {
         // For writeback, push the mutated-left value first (consumed by the
         // store op) and leave the function results on top as the expression
         // value.
+        // The result inherits the itemization of the structure-donating operand
+        // (matching exec_hyper_op).
+        let itemize_result = left_itemized || (!Self::is_listy(&left) && right_itemized);
+        let finish = |v: Value| -> Value {
+            if itemize_result {
+                Self::itemize_value(v)
+            } else {
+                v
+            }
+        };
         if writeback {
             let writeback_val = if do_writeback {
                 wrap(mutated_left)
@@ -206,10 +221,10 @@ impl Interpreter {
                 // compiler-emitted store is a harmless no-op.
                 left.clone()
             };
-            self.stack.push(wrap(results));
+            self.stack.push(finish(wrap(results)));
             self.stack.push(writeback_val);
         } else {
-            self.stack.push(wrap(results));
+            self.stack.push(finish(wrap(results)));
         }
         Ok(())
     }

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -149,6 +149,22 @@ impl Interpreter {
         err
     }
 
+    /// Strip ONE level of itemization from a hyper operand. Hyper ops descend
+    /// into itemized Arrays/Lists at every depth (raku: `$i >>+>> 10` with
+    /// `$i = [[1,2],[3,4]]` distributes into the nested arrays), so the Scalar
+    /// container is transparent here. Without this an itemized operand is
+    /// kept single by `value_to_list`, which mis-numifies it (func form) or
+    /// recurses forever (`hyper_op_pair` sees the same listy value again).
+    pub(super) fn deitemize_hyper_operand(v: &Value) -> Value {
+        match v.view() {
+            ValueView::Array(items, kind) if kind.is_itemized() => {
+                Value::array_with_kind(items.clone(), kind.decontainerize())
+            }
+            ValueView::Scalar(inner) => (*inner).clone(),
+            _ => v.clone(),
+        }
+    }
+
     pub(super) fn exec_hyper_op(
         &mut self,
         code: &CompiledCode,
@@ -158,6 +174,10 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap_or(Value::NIL);
         let left = self.stack.pop().unwrap_or(Value::NIL);
+        let left_itemized = Self::is_itemized_operand(&left);
+        let right_itemized = Self::is_itemized_operand(&right);
+        let right = Self::deitemize_hyper_operand(&right);
+        let left = Self::deitemize_hyper_operand(&left);
         let op = Self::const_str(code, op_idx).to_string();
         // X::HyperOp::Infinite: when the result length is determined by an
         // infinite/lazy operand, the hyper op cannot produce a finite result.
@@ -180,8 +200,22 @@ impl Interpreter {
             }
         }
         let result = self.hyper_op_pair(&op, &left, &right, dwim_left, dwim_right)?;
+        // The result inherits the itemization of the operand that donated its
+        // structure (the left when listy, else the right): raku renders
+        // `($a >>+<< (2,4,6)).raku` as `$(3, 6, 9)` for an itemized `$a`.
+        let result = if left_itemized || (!Self::is_listy(&left) && right_itemized) {
+            Self::itemize_value(result)
+        } else {
+            result
+        };
         self.stack.push(result);
         Ok(())
+    }
+
+    /// Is this operand an itemized Array/List (Scalar-held container)?
+    pub(super) fn is_itemized_operand(v: &Value) -> bool {
+        matches!(v.view(), ValueView::Array(_, kind) if kind.is_itemized())
+            || matches!(v.view(), ValueView::Scalar(_))
     }
 
     /// Apply a hyper binary op to a pair of values, recursing into nested
@@ -195,6 +229,11 @@ impl Interpreter {
         dwim_left: bool,
         dwim_right: bool,
     ) -> Result<Value, RuntimeError> {
+        // Hyper descends through Scalar containers at every depth.
+        let (left, right) = (
+            &Self::deitemize_hyper_operand(left),
+            &Self::deitemize_hyper_operand(right),
+        );
         // Hyper op on two hashes: combine values key-by-key, with the dwim arrows
         // selecting the resulting key set. A missing value on either side uses the
         // operator's identity element (e.g. 0 for `+`).

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -231,7 +231,7 @@ impl Interpreter {
             }
             assigned
         } else {
-            Self::normalize_scalar_assignment_value(raw_val)
+            Self::itemize_scalar_store(&name, Self::normalize_scalar_assignment_value(raw_val))
         };
         if val.is_nil()
             && let Some(def) = self.var_default(&name)

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -156,7 +156,7 @@ impl Interpreter {
         // `$::('x') = 1, 2` is already parsed item-assignment (RHS is `1`), so a
         // list value here is a genuine `$::('x') = (1, 2)` and must be kept whole.
         let value = if sigil == "$" {
-            Self::normalize_scalar_assignment_value(raw_value)
+            Self::itemize_scalar_store(&name, Self::normalize_scalar_assignment_value(raw_value))
         } else {
             raw_value
         };

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -670,6 +670,47 @@ impl Interpreter {
         }
     }
 
+    /// Itemize an aggregate VALUE stored into a `$` scalar container by
+    /// assignment (`=`), so a later read reflects the Scalar container:
+    /// `my $x = [1,2,3]; $x.raku` is `$[1, 2, 3]` (rakudo checks
+    /// `nqp::iscont(SELF)` in `Array.raku`). Only the Value-level `ArrayKind`
+    /// flips (identity of the backing `ArrayData` is preserved, so `=`-shared
+    /// containers keep aliasing). Binds (`:=`) must NOT go through this — they
+    /// install the value itself, not a Scalar container. The topic `_` is
+    /// excluded (container-alias writeback, see `itemize_scalar_assign_result`),
+    /// as are `&`-sigiled and internal `__mutsu_` names.
+    ///
+    /// TODO: a Hash stored in a scalar should render `${...}` the same way,
+    /// but `HashData.itemized` lives INSIDE the shared data (flipping it via
+    /// `hash_arc_itemized` clones the `HashData`, silently detaching `=`-shared
+    /// hashes like `my $h = f(%x)`). Representing per-holder hash itemization
+    /// needs a Value-level flag (Value-repr rework, ADR-0001 layer 3b).
+    pub(crate) fn itemize_scalar_store(name: &str, val: Value) -> Value {
+        if name == "_" || name.starts_with('&') || name.starts_with("__mutsu") {
+            return val;
+        }
+        match val.view() {
+            ValueView::Array(items, kind) if !kind.is_itemized() => {
+                Value::array_with_kind(items.clone(), kind.itemize())
+            }
+            _ => val,
+        }
+    }
+
+    /// True when a scalar store is an identity restore: the incoming value is
+    /// the SAME backing array with the SAME kind the slot already holds (the
+    /// compiler-emitted hyper-func-op writeback re-storing an unmutated left
+    /// operand). Skipping itemization then preserves a `:=`-bound bare List —
+    /// re-storing what was read must not manufacture a Scalar container.
+    pub(crate) fn is_identity_scalar_restore(current: &Value, val: &Value) -> bool {
+        if let (ValueView::Array(cur, ck), ValueView::Array(new, nk)) = (current.view(), val.view())
+        {
+            crate::gc::Gc::ptr_eq(cur, new) && ck == nk
+        } else {
+            false
+        }
+    }
+
     /// The rvalue produced by a *scalar* assignment expression is the itemized
     /// container value, so a following list context sees it as one element:
     /// `@p = ($x = 3, 4)` gives `((3,4),)`. `@`/`%`/`&` names keep their value.

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1990,7 +1990,7 @@ impl Interpreter {
             } else if env_key.starts_with('%') {
                 self.coerce_hash_var_value(&env_key, val)?
             } else {
-                Self::normalize_scalar_assignment_value(val)
+                Self::itemize_scalar_store(&env_key, Self::normalize_scalar_assignment_value(val))
             };
             self.env_mut().insert(env_key, val.clone());
             // An assignment is an expression: leave the assigned value on the
@@ -2022,7 +2022,10 @@ impl Interpreter {
             } else if resolved_name.starts_with('%') {
                 self.coerce_hash_var_value(&resolved_name, val)?
             } else {
-                Self::normalize_scalar_assignment_value(val)
+                Self::itemize_scalar_store(
+                    &resolved_name,
+                    Self::normalize_scalar_assignment_value(val),
+                )
             };
 
             self.check_readonly_for_modify(&resolved_name)?;

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -117,7 +117,10 @@ impl Interpreter {
                 } else {
                     let arc = arc.clone();
                     if scalar {
-                        val = Self::normalize_scalar_assignment_value(val);
+                        val = Self::itemize_scalar_store(
+                            name,
+                            Self::normalize_scalar_assignment_value(val),
+                        );
                     }
                     self.check_container_cell_constraint(&arc, &val)?;
                     Value::store_through_cell(&arc, &val);
@@ -127,7 +130,8 @@ impl Interpreter {
                 }
             }
             if !name.starts_with('@') && !name.starts_with('%') {
-                val = Self::normalize_scalar_assignment_value(val);
+                val =
+                    Self::itemize_scalar_store(name, Self::normalize_scalar_assignment_value(val));
             }
             if val.is_nil()
                 && !self.locals[idx].is_nil()
@@ -306,7 +310,7 @@ impl Interpreter {
             }
             assigned
         } else {
-            Self::normalize_scalar_assignment_value(raw_val)
+            Self::itemize_scalar_store(name, Self::normalize_scalar_assignment_value(raw_val))
         };
         if val.is_nil()
             && let Some(def) = self.var_default(name)

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -354,6 +354,9 @@ impl Interpreter {
                     let arc = arc.clone();
                     if scalar {
                         val = Self::normalize_scalar_assignment_value(val);
+                        if !is_constant {
+                            val = Self::itemize_scalar_store(name, val);
+                        }
                     }
                     self.check_container_cell_constraint(&arc, &val)?;
                     Value::store_through_cell(&arc, &val);
@@ -387,6 +390,10 @@ impl Interpreter {
             }
             if !name.starts_with('@') && !name.starts_with('%') {
                 val = Self::normalize_scalar_assignment_value(val);
+                // `constant $c = [...]` binds the value itself, no Scalar container.
+                if !is_constant && !Self::is_identity_scalar_restore(&self.locals[idx], &val) {
+                    val = Self::itemize_scalar_store(name, val);
+                }
             }
             if val.is_nil()
                 && let Some(def) = self.var_default(name)
@@ -948,6 +955,11 @@ impl Interpreter {
                         let forced = self.force_if_lazy_io_lines(raw_popped.clone())?;
                         Value::real_array(runtime::value_to_list(&forced))
                     }
+                    // `@a := $x` strips the Scalar container: the @-var binds the
+                    // Array itself (same backing data, plain kind), not the item.
+                    ValueView::Array(items, kind) if kind.is_itemized() => {
+                        Value::array_with_kind(items.clone(), kind.decontainerize())
+                    }
                     _ => raw_popped.clone(),
                 }
             } else {
@@ -1094,7 +1106,19 @@ impl Interpreter {
             }
             assigned
         } else {
-            Self::normalize_scalar_assignment_value(raw_popped)
+            let v = Self::normalize_scalar_assignment_value(raw_popped);
+            // Only a plain `=` assignment installs a Scalar container; binds
+            // (`:=`), rebinds, and `constant` install the value itself.
+            if is_bind
+                || scalar_bind
+                || is_rebind
+                || is_constant
+                || Self::is_identity_scalar_restore(&self.locals[idx], &v)
+            {
+                v
+            } else {
+                Self::itemize_scalar_store(name, v)
+            }
         };
         if val.is_nil()
             && !self.locals[idx].is_nil()
@@ -1475,7 +1499,10 @@ impl Interpreter {
             } else {
                 let arc = arc.clone();
                 if scalar {
-                    val = Self::normalize_scalar_assignment_value(val);
+                    val = Self::itemize_scalar_store(
+                        name,
+                        Self::normalize_scalar_assignment_value(val),
+                    );
                 } else {
                     // Container identity (§3.1): re-apply the element-type +
                     // `array[T]` metadata so a typed native array written through

--- a/t/native-array-mut.t
+++ b/t/native-array-mut.t
@@ -11,7 +11,7 @@ plan 31;
     my @a = 1, 2, 3;
     my $r = @a.append(4, 5);
     is @a.raku, '[1, 2, 3, 4, 5]', 'append multiple scalars';
-    is $r.raku, '[1, 2, 3, 4, 5]', 'append returns the array';
+    is $r.raku, '$[1, 2, 3, 4, 5]', 'append returns the array';
 }
 {
     # one-arg rule: a single list argument is flattened
@@ -31,7 +31,7 @@ plan 31;
     my @a = 5, 6;
     my $r = @a.prepend((1, 2));
     is @a.raku, '[1, 2, 5, 6]', 'prepend flattening';
-    is $r.raku, '[1, 2, 5, 6]', 'prepend returns the array';
+    is $r.raku, '$[1, 2, 5, 6]', 'prepend returns the array';
 }
 
 # --- unshift ---
@@ -39,7 +39,7 @@ plan 31;
     my @a = 3;
     my $r = @a.unshift(1, 2);
     is @a.raku, '[1, 2, 3]', 'unshift multiple scalars';
-    is $r.raku, '[1, 2, 3]', 'unshift returns the array';
+    is $r.raku, '$[1, 2, 3]', 'unshift returns the array';
 }
 
 # --- pop ---

--- a/t/scalar-itemize-raku.t
+++ b/t/scalar-itemize-raku.t
@@ -1,0 +1,84 @@
+use Test;
+
+# Assignment into a `$` scalar container itemizes an Array/List value, and
+# `.raku` reflects the Scalar container (rakudo checks nqp::iscont(SELF)):
+#   my $x = [1,2,3];  $x.raku  # $[1, 2, 3]
+# Binds (`:=`), `constant`, and sigilless declarations install the value
+# itself (no Scalar container) and must NOT itemize.
+
+plan 26;
+
+# --- plain scalar assignment itemizes ---
+{
+    my $x = [1, 2, 3];
+    is $x.raku, '$[1, 2, 3]', 'my $x = [...] renders $[...]';
+    my $l = (1, 2, 3);
+    is $l.raku, '$(1, 2, 3)', 'my $l = (...) renders $(...)';
+    my $y;
+    $y = [9];
+    is $y.raku, '$[9]', 'plain reassignment itemizes';
+    my ($a, $b) = [1, 2], (3, 4);
+    is $a.raku, '$[1, 2]', 'list-assignment itemizes each scalar (array)';
+    is $b.raku, '$(3, 4)', 'list-assignment itemizes each scalar (list)';
+    my $r = do { my @arr = 1, 2, 3; @arr.append(4) };
+    is $r.raku, '$[1, 2, 3, 4]', 'method-return stored in scalar itemizes';
+}
+
+# --- itemized scalar stays single in list context, still fully usable ---
+{
+    my $x = [1, 2, 3];
+    my @a = 1, $x;
+    is @a.elems, 2, 'itemized array stays one element in list assignment';
+    is $x.elems, 3, '.elems still reaches the array';
+    is $x[1], 2, 'indexing still works';
+    $x.push(4);
+    is $x.raku, '$[1, 2, 3, 4]', 'push mutates through the container';
+}
+
+# --- binds and constants do NOT itemize ---
+{
+    my $z := [5, 6];
+    is $z.raku, '[5, 6]', ':= bind installs the bare value';
+    constant $c = [7];
+    is $c.raku, '[7]', 'constant binds the bare value';
+    my \raw = [1, 2];
+    is raw.raku, '[1, 2]', 'sigilless declaration binds the bare value';
+    my \lol = (1, 2), (3, 4);
+    is lol.raku, '((1, 2), (3, 4))', 'sigilless list declaration stays a bare List';
+}
+
+# --- @-sigil contexts strip the container ---
+{
+    my $x = [1, 2, 3];
+    is (@$x).raku, '[1, 2, 3]', '@$x decontainerizes';
+    my @b := $x;
+    is @b.raku, '[1, 2, 3]', '@a := $x binds the bare array';
+    my $out = '';
+    for @$x { $out ~= $_ }
+    is $out, '123', 'for @$x iterates elements';
+}
+
+# --- zen slice / <> decontainerize ---
+{
+    my $a = (1, 2, 3);
+    is ($a[] X~ 'a').join(' '), '1a 2a 3a', '$a[] decontainerizes for X';
+    my $x = [1, 2, 3];
+    is $x[].raku, '[1, 2, 3]', '$x[] strips the container';
+    is $x<>.raku, '[1, 2, 3]', '$x<> strips the container';
+}
+
+# --- hyper ops descend through the container ---
+{
+    my $a = (1, 2, 3);
+    my $b = (2, 4, 6);
+    is ($a >>+<< $b).raku, '$(3, 6, 9)', 'hyper op deconts operands, result inherits itemization';
+    is ((1, 2, 3) >>+<< $b).raku, '(3, 6, 9)', 'bare left operand keeps a bare result';
+    my $i = [[1, 2], [3, 4]];
+    is ($i >>+>> 10).raku, '$[[11, 12], [13, 14]]', 'hyper descends nested itemized arrays';
+    my $c := (1, 2, 3);
+    is ($c >>[&infix:<+>]<< $c).raku, '(2, 4, 6)', 'hyper func op on bound scalars';
+    is ($c >>[&infix:<+>]<< $c).raku, '(2, 4, 6)', 'writeback does not itemize a bound scalar';
+    is $c.raku, '(1, 2, 3)', 'bound scalar keeps its bare List after hyper func op';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

`my $x = [1,2,3]; say $x.raku` printed `[1, 2, 3]` instead of raku's `$[1, 2, 3]` — assignment into a `$` scalar container did not record the Scalar container (itemization) on the stored value.

Scalar assignment now flips the value to its itemized `ArrayKind` (`ItemArray`/`ItemList`). The kind lives on the `Value`, not the backing `ArrayData`, so `=`-shared container identity is preserved. Binds (`:=`), rebinds, `constant`, and sigilless declarations (`my \x = ...`) install the bare value and are excluded (sigilless VarDecls now emit `MarkConstantContext` so SetLocal can tell them apart from `$`-scalars).

## Fallout fixed (all raku-verified)

- **Zen slice** `$a[]` now decontainerizes (new `DeitemizeZen` opcode — the parser previously dropped a bare `[]` subscript entirely, so `($a[] X~ 'a')` failed in roast `S02-types/array.t` test 86); `$a<>` deconts via `__mutsu_zen_angle`.
- **`@`-sigil reads**: `@$x` strips itemization; `my @a := $x` binds the bare array.
- **Hyper ops** descend through Scalar containers at every depth (an itemized operand previously mis-numified in the func form and stack-overflowed `hyper_op_pair`); the result inherits the itemization of the structure-donating operand (`($a >>+<< $b).raku` is `$(3, 6, 9)`), and the hyper-func-op writeback detects an identity restore so a `:=`-bound bare List is not re-itemized.
- **Method dispatch** decontainerizes itemized Array/List invocants (except `.raku`/`.perl`/`.item`/`.VAR`/`.self`), fixing `$list.tail` / `.skip` which treated the container as one item.

Known remaining gap (documented as TODO): a Hash in a scalar still renders `{...}` instead of `${...}` — `HashData.itemized` lives inside the shared data, so flipping it on store would clone and silently detach `=`-shared hashes; a per-holder flag needs the Value-repr rework (ADR-0001 layer 3b).

## Testing

- New `t/scalar-itemize-raku.t` (26 tests) — passes under **both** mutsu and `raku` itself.
- `t/native-array-mut.t` expectations for `.append`/`.prepend`/`.unshift` return values updated to the raku-verified `$[...]` forms.
- Local: `make test` (1625 files) + 805 whitelisted roast files (all of S02/S03/S04/S05/S06/S09/S10/S11/S12/S13/S14/S29/S32-list/array/hash) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW