### PR TITLE
fix(vm): mixin private-method self-dispatch + Nil-to-typed-array default

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3391,6 +3391,38 @@ impl Interpreter {
             } = inner.as_ref().view()
             {
                 let cls = class_name.resolve().to_string();
+                // A private method (`self!inner`) on the mixin: resolve it on the
+                // inner class MRO and run it with `self` bound to the MIXIN wrapper
+                // (not the bare inner instance) so a nested `self.foo` inside the
+                // private method re-dispatches through the mixin roles and finds
+                // their overrides — mirroring the public-method case below.
+                if let Some(private_rest) = method.strip_prefix('!') {
+                    let resolved = if let Some((owner_class, pm_name)) =
+                        private_rest.split_once("::")
+                    {
+                        self.resolve_private_method_with_owner(&cls, owner_class, pm_name, &args)
+                            .map(|r| (r, pm_name))
+                    } else {
+                        self.resolve_private_method_any_owner(&cls, private_rest, &args)
+                            .map(|r| (r, private_rest))
+                    };
+                    if let Some(((resolved_owner, method_def), pm_name)) = resolved {
+                        let attrs = attributes.to_map();
+                        let (result, updated) = self.run_resolved_method_compiled_or_treewalk(
+                            &cls,
+                            &resolved_owner,
+                            pm_name,
+                            method_def,
+                            attrs,
+                            args,
+                            Some(target.clone()),
+                        )?;
+                        if let ValueView::Instance { attributes, .. } = inner.as_ref().view() {
+                            attributes.commit_attrs(updated);
+                        }
+                        return Ok(result);
+                    }
+                }
                 if self.class_has_method(&cls, method) {
                     let attrs = attributes.to_map();
                     let (result, updated) =

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -157,7 +157,7 @@ impl Interpreter {
                 class_name
             )));
         }
-        let (raw_popped, bind_source) = Self::extract_varref_binding(raw_popped);
+        let (mut raw_popped, bind_source) = Self::extract_varref_binding(raw_popped);
         let is_bind = self.bind_context || bind_source.is_some();
         let is_rebind = self.rebind_context;
         let is_constant = self.constant_context;
@@ -663,17 +663,27 @@ impl Interpreter {
                 self.coerce_hash_var_value(name, raw_popped)?
             }
         } else if name.starts_with('@') {
-            if has_explicit_initializer
+            if (has_explicit_initializer || !is_vardecl)
                 && !is_constant
                 && !is_bind
                 && raw_popped.is_nil()
                 && let Some(constraint) = loan_env!(self, var_type_constraint(name))
             {
-                return Err(runtime::utils::type_check_assignment_typed_error(
-                    name,
-                    &constraint,
-                    &Value::NIL,
-                ));
+                // A bare Nil assigned to a typed `@` array reverts to the element
+                // type's default. A definite (`:D`) element type has no default
+                // type object, so it dies (`my Int:D @a = Nil`); a non-definite
+                // element type produces the element type object
+                // (`my Bool @a = Nil` -> `Array[Bool].new(Bool)`). Rewrite the
+                // bare Nil into a single-element `[Nil]` so the element coercion
+                // below turns it into that type object.
+                if self.is_definite_constraint(&constraint) {
+                    return Err(runtime::utils::type_check_assignment_typed_error(
+                        name,
+                        &constraint,
+                        &Value::NIL,
+                    ));
+                }
+                raw_popped = Value::real_array(vec![Value::NIL]);
             }
             // Native typed arrays cannot store lazy sequences — check before
             // eager evaluation so the error is raised even if the sequence is

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -314,8 +314,16 @@ impl Interpreter {
                     return Err(runtime::utils::type_check_element_typed_error(
                         var_name, constraint, item,
                     ));
+                } else if native_constraint {
+                    // A native element type has no type object; Nil reverts to the
+                    // array's numeric/string zero.
+                    coerced_items.push(Self::native_fill_for_constraint(Some(constraint)));
                 } else {
-                    coerced_items.push(item.clone());
+                    // Raku: Nil assigned to a typed container element reverts to the
+                    // element type's default, i.e. the type object itself
+                    // (`my Bool @a = Nil` -> Array[Bool].new(Bool)).
+                    let base = crate::runtime::types::strip_type_smiley(constraint).0;
+                    coerced_items.push(Value::package(crate::symbol::Symbol::intern(base)));
                 }
                 continue;
             }

--- a/t/mixin-private-method-self-dispatch.t
+++ b/t/mixin-private-method-self-dispatch.t
@@ -1,0 +1,43 @@
+use Test;
+
+# A private method called on a `but role` mixin must keep `self` bound to the
+# mixin wrapper, so a nested `self.foo` re-dispatches through the mixin roles
+# and finds their overrides (not the inner class's base method).
+
+plan 5;
+
+{
+    class Base {
+        method plugins() { () }
+        method !inner() { self.plugins }
+        method via-private() { my @m = self!inner; @m.elems }
+        method via-public()  { my @m = self.plugins; @m.elems }
+    }
+    my $o = Base.new but role :: { method plugins() { (1, 2) } };
+    is $o.plugins.elems, 2, 'direct mixin override reached';
+    is $o.via-public,    2, 'public method reaches mixin override via self.plugins';
+    is $o.via-private,   2, 'private method reaches mixin override via self.plugins';
+}
+
+{
+    # The private method itself grep/filters through the overridden method.
+    role Builder { }
+    class Repo does Builder {
+        method plugins() { () }
+        method !matching() { self.plugins.grep(*.so) }
+        method run() { my @m = self!matching; @m.elems }
+    }
+    my $o = Repo.new but role :: { method plugins() { (1, 0, 2) } };
+    is $o.run, 2, 'private method + grep sees mixin plugins';
+}
+
+{
+    # Owner-qualified private call (self!Class::method) on a mixin.
+    class C {
+        method who() { 'BASE' }
+        method !ask() { self.who }
+        method call() { self!C::ask }
+    }
+    my $o = C.new but role :: { method who() { 'OVERRIDE' } };
+    is $o.call, 'OVERRIDE', 'owner-qualified private call reaches mixin override';
+}

--- a/t/typed-array-nil-default.t
+++ b/t/typed-array-nil-default.t
@@ -1,0 +1,64 @@
+use Test;
+
+# Nil assigned to a typed array element reverts to the element type's default,
+# i.e. the element type object itself (Raku container semantics). A `:D`
+# element type has no default type object, so it dies.
+
+plan 13;
+
+{
+    my Bool @a = Nil;
+    is @a.raku, 'Array[Bool].new(Bool)', 'bare Nil initializer -> element type object';
+    is @a.elems, 1, 'bare Nil initializer yields one element';
+}
+
+{
+    my Int @a = Nil;
+    is @a.raku, 'Array[Int].new(Int)', 'Int typed array Nil -> Int type object';
+}
+
+{
+    my Bool @a = (Nil,);
+    is @a.raku, 'Array[Bool].new(Bool)', 'single-element list Nil -> type object';
+}
+
+{
+    my Bool @a = True, Nil, False;
+    is @a.raku, 'Array[Bool].new(Bool::True, Bool, Bool::False)',
+        'Nil in the middle of a typed list reverts to the type object';
+}
+
+{
+    my Int @a = 1, Nil, 3;
+    is @a.raku, 'Array[Int].new(1, Int, 3)', 'Nil hole in Int list';
+}
+
+{
+    my Bool @a;
+    @a = Nil;
+    is @a.raku, 'Array[Bool].new(Bool)', 'reassigning Nil to a typed array';
+}
+
+{
+    my Bool @a = (True,);
+    @a = Nil;
+    is @a.raku, 'Array[Bool].new(Bool)', 'reassigning Nil replaces populated array';
+}
+
+{
+    my Bool @a;
+    is @a.raku, 'Array[Bool].new()', 'no-initializer typed array stays empty';
+}
+
+{
+    # Untyped array keeps the Any default.
+    my @a = Nil;
+    is @a.raku, '[Any]', 'untyped array Nil -> Any';
+}
+
+# A definite element type has no default type object -> dies.
+dies-ok { my Int:D @a = Nil }, 'Nil into :D typed array dies';
+
+# An explicit non-Nil type object that fails the constraint still dies.
+dies-ok { my Bool @a = Int }, 'wrong type object into typed array dies';
+dies-ok { my Bool @a = Any }, 'Any type object into Bool array dies';


### PR DESCRIPTION
Two general interpreter bugs surfaced by running zef's own upstream
`t/build.rakutest` (`Zef::Build.build`) against mutsu. Both are general fixes,
not zef-specific.

## 1. Private method on a `but role` mixin lost the mixin binding

A private method called on a mixin (`$obj but role :: {...}`) ran with `self`
bound to the bare inner instance, so a nested `self.foo` inside the private
method reached the inner class's base method instead of the mixin role's
override.

`Zef::Build.build` (inherited) does `self!build-matcher($dist)` where the
private `!build-matcher` calls `self.plugins`; the test's mock overrides
`plugins` via the mixin, so mutsu saw an empty plugin list → "No building
backend available".

The Mixin fallback in `call_method_with_values` already handled public
inherited methods (#4369) but delegated *private* methods straight to the inner
instance. Now it resolves the private method on the inner class MRO and runs it
with `self` bound to the **mixin wrapper**, so nested `self.foo` re-dispatches
through the mixin roles.

## 2. `Nil` assigned to a typed array should revert to the element default

Raku: `my Bool @a = Nil` is `Array[Bool].new(Bool)` — Nil reverts to the
element type's default (the type object itself), it is not a type-check error.
mutsu errored. Fixed both:
- the list path (`coerce_typed_array_elements` kept `Nil` instead of the element
  type object), and
- the bare-scalar path (`my Bool @a = Nil` and `@a = Nil` errored early).

A definite (`:D`) element type still dies (no default type object), and a
wrong non-Nil type object (`my Bool @a = Int` / `= Any`) still dies.

## Tests
- `t/mixin-private-method-self-dispatch.t`
- `t/typed-array-nil-default.t`

`make test` passes (16081 tests). After both fixes, zef's `build.rakutest`
passes fully (4/4 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)