### PR TITLE
fix(runtime): CompUnit::Repository role does not require a `load` method

### DIFF
--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1930,7 +1930,10 @@ impl Interpreter {
                             is_submethod: false,
                         };
                         let mut methods = HashMap::new();
-                        for name in ["id", "need", "load", "loaded"] {
+                        // Rakudo's CompUnit::Repository role requires exactly
+                        // `id`, `need`, and `loaded` (a class doing the role must
+                        // implement those three). `load` is NOT a required method.
+                        for name in ["id", "need", "loaded"] {
                             methods.insert(name.to_string(), vec![stub_method(stub_body.clone())]);
                         }
                         roles.insert(

--- a/t/compunit-repository-required-methods.t
+++ b/t/compunit-repository-required-methods.t
@@ -1,0 +1,26 @@
+use Test;
+
+# The CompUnit::Repository role requires exactly `id`, `need`, and `loaded`
+# (matching Rakudo). `load` is NOT a required method — a class doing the role
+# without a `load` method must still compose.
+
+plan 4;
+
+lives-ok {
+    my $cur = (class :: does CompUnit::Repository {
+        method need { }; method loaded { }; method id { }
+    }).new;
+    $cur;
+}, 'class with id/need/loaded composes CompUnit::Repository (no load required)';
+
+throws-like {
+    (class :: does CompUnit::Repository { method need { }; method loaded { } }).new;
+}, X::Role::Composition::Unimplemented, 'missing id is still required';
+
+throws-like {
+    (class :: does CompUnit::Repository { method loaded { }; method id { } }).new;
+}, X::Role::Composition::Unimplemented, 'missing need is still required';
+
+throws-like {
+    (class :: does CompUnit::Repository { method need { }; method id { } }).new;
+}, X::Role::Composition::Unimplemented, 'missing loaded is still required';


### PR DESCRIPTION
Rakudo's `CompUnit::Repository` role requires exactly `id`, `need`, and
`loaded` — a class that does the role must implement those three. mutsu's
built-in stub role also required `load`, so an anon class providing only
`id`/`need`/`loaded` (as in zef's `install.rakutest`, line 9) failed
composition with:

```
X::Role::Composition::Unimplemented: required method 'load'
```

Verified against raku: dropping any of `id`/`need`/`loaded` still fails
composition, but a class without `load` composes fine. This drops `load` from
the required stub set to match.

With this fix, zef's upstream `install.rakutest` passes fully (4/4 subtests) —
completing all 10 zef upstream test files (build/extract/test/repository/fetch/
install all green after this + #4383).

## Test
- `t/compunit-repository-required-methods.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)