### PR TITLE
fix(vm): route all writes to an escaped our-sub lexical through its persisted cell

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -158,6 +158,7 @@ impl Interpreter {
             || self.routine_stack.is_empty()
             || name.contains("::")
             || !self.escaping_our_lexical_names.contains(name)
+            || !self.in_escaped_our_sub()
         {
             return None;
         }
@@ -169,21 +170,51 @@ impl Interpreter {
         )
     }
 
-    /// Resolve a bare-name increment/decrement (`$a++`, `--$a`) of a block
+    /// Whether the innermost NAMED routine frame is one of the `our`-scoped
+    /// subs recorded by `RegisterSub` (`escaped_our_sub_names`). Anonymous
+    /// block/closure frames (`<pointy-block>`, `<anon>`, empty names) are
+    /// transparent — a nested `if`/bare block inside the sub still counts.
+    /// Gates the escaped-cell resolution so a plain `my sub` that merely
+    /// shares a captured variable's name — called while its declaring block is
+    /// still live — keeps resolving through its own env capture instead of the
+    /// escaped sub's persisted cell. Note: an escaped sub reached through a
+    /// code var (`&OUR::f()`) is pushed as a *block* frame with its real name,
+    /// so the walk keys on the NAME, not `is_block`.
+    fn in_escaped_our_sub(&self) -> bool {
+        for frame in self.routine_stack.iter().rev() {
+            if self.escaped_our_sub_names.contains(&frame.name)
+                || frame
+                    .name
+                    .rsplit("::")
+                    .next()
+                    .is_some_and(|bare| self.escaped_our_sub_names.contains(bare))
+            {
+                return true;
+            }
+            // A real (named) routine that is NOT an escaped our sub: its own
+            // captures win — stop walking.
+            if !frame.name.is_empty() && !frame.name.starts_with('<') {
+                return false;
+            }
+        }
+        false
+    }
+
+    /// Resolve a bare-name WRITE (`$a = v`, `$a++`, `$a += v`) of a block
     /// lexical captured by an escaped `our` sub through its persisted shared
-    /// cell. Consulted as the LAST resort in the inc/dec read chain, AFTER the
-    /// env/package lookups: a plain `my sub` that merely shares the variable name
-    /// is called while its declaring block is still live, so its captured `$a`
-    /// resolves through the env cell earlier in the chain and never reaches here.
-    /// Only an escaped `our` sub — whose declaring block has exited, leaving no
-    /// env entry, yet which outlives it in the package registry — falls through
-    /// to the persisted cell. This mirrors what makes reads of such a capture
-    /// work (`escaping_our_read`).
+    /// cell. Consulted FIRST in the write chains, mirroring the read side
+    /// (`escaping_our_read` short-circuits the env lookup): the shared env may
+    /// hold a stale leaked value for the name (e.g. `sync_env_from_locals`
+    /// flushing the declaring block's dead top-level slot as Nil), which would
+    /// otherwise absorb the write into a plain env copy the next read (which
+    /// resolves through the cell) never sees.
     ///
     /// Returns the `ContainerRef` cell only when one is actually recorded (and
     /// `name` is neither a local nor an upvalue of `code`), so unrelated
-    /// same-named locals/captures and pre-block calls stay untouched.
-    pub(crate) fn escaping_our_incdec_cell(
+    /// same-named locals/captures and pre-block calls stay untouched. A plain
+    /// `my sub` sharing the variable name is called while its declaring block
+    /// is live, so its captured `$a` is an upvalue/local and is excluded here.
+    pub(crate) fn escaping_our_write_cell(
         &self,
         code: &crate::opcode::CompiledCode,
         name: &str,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1240,6 +1240,12 @@ pub struct Interpreter {
     /// a read before the block correctly yields the undefined value (the cell is not
     /// recorded yet). Empty for ordinary programs: zero cost.
     pub(crate) escaping_our_lexical_names: std::collections::HashSet<String>,
+    /// Names of the `our`-scoped subs declared in bare blocks (the subs whose
+    /// free-variable reads/writes may resolve through `escaped_our_lexical_cells`).
+    /// The cell resolution fires ONLY while the innermost named routine frame is
+    /// one of these subs — a plain `my sub` that merely shares a captured
+    /// variable's name must keep resolving through its own live env capture.
+    pub(crate) escaped_our_sub_names: std::collections::HashSet<String>,
     state_vars: HashMap<String, Value>,
     /// Per-closure-instance captured-variable state, keyed by
     /// (closure instance id, captured variable Symbol). This is the hot

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2045,6 +2045,7 @@ impl Interpreter {
             package_lexicals: HashMap::new(),
             escaped_our_lexical_cells: HashMap::new(),
             escaping_our_lexical_names: std::collections::HashSet::new(),
+            escaped_our_sub_names: std::collections::HashSet::new(),
             state_vars: HashMap::new(),
             closure_captured_state: HashMap::new(),
             once_values: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -228,6 +228,7 @@ impl Interpreter {
             package_lexicals: self.package_lexicals.clone(),
             escaped_our_lexical_cells: self.escaped_our_lexical_cells.clone(),
             escaping_our_lexical_names: self.escaping_our_lexical_names.clone(),
+            escaped_our_sub_names: self.escaped_our_sub_names.clone(),
             state_vars: HashMap::new(),
             // Mirror state_vars: a thread clone starts with no persisted
             // closure captured state (falls back to the captured-env initial

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1170,6 +1170,19 @@ impl Interpreter {
                         *ip += 1;
                         return Ok(());
                     }
+                    // A block `my` lexical captured by an escaped `our` sub: reads
+                    // resolve through the persisted shared cell (`escaping_our_read`
+                    // short-circuits env), so a plain assignment must reach the SAME
+                    // cell — a by-name env write would land only on this call's env
+                    // copy (or a stale leaked entry) and be dropped on return.
+                    if let Some(cell_val) = self.escaping_our_write_cell(code, &name)
+                        && let ValueView::ContainerRef(arc) = cell_val.view()
+                    {
+                        self.check_container_cell_constraint(arc, &val)?;
+                        Self::cell_store_preserving_container_identity(arc, &val);
+                        *ip += 1;
+                        return Ok(());
+                    }
                     // Also check alias target for sigilless attributes
                     let alias_key_check = format!("__mutsu_sigilless_alias::{}", name);
                     if let Some(alias_val) = self.env().get(&alias_key_check).cloned()

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -290,11 +290,11 @@ impl Interpreter {
             return Ok(());
         }
         let val = self
-            .package_scope_lexical(name)
+            .escaping_our_write_cell(code, name)
+            .or_else(|| self.package_scope_lexical(name))
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
-            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::int(0));
         // ContainerRef (box-on-capture / `:=`): mutate the shared cell in place so
         // closures over this lexical observe the change and the smart string/Int
@@ -407,11 +407,11 @@ impl Interpreter {
             return Ok(());
         }
         let val = self
-            .package_scope_lexical(name)
+            .escaping_our_write_cell(code, name)
+            .or_else(|| self.package_scope_lexical(name))
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
-            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::int(0));
         // ContainerRef (box-on-capture / `:=`): mutate the shared cell in place so
         // closures over this lexical observe the change and the smart string/Int

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -270,6 +270,12 @@ impl Interpreter {
             if custom_traits.iter().any(|(t, _)| t == "__our_scoped")
                 && !self.escaping_our_lexical_names.is_empty()
             {
+                // Record the sub itself: the cell resolution
+                // (`escaping_our_read`/`escaping_our_write_cell`) fires only while
+                // the innermost named routine frame is one of these subs, so a
+                // plain `my sub` sharing a captured variable's name keeps using
+                // its own live env capture.
+                self.escaped_our_sub_names.insert(resolved_name.clone());
                 let names: Vec<String> = self.escaping_our_lexical_names.iter().cloned().collect();
                 for name in names {
                     if let Some(cell) = self.env().get(&name).cloned()

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -73,13 +73,17 @@ impl Interpreter {
         // Default to Nil (NOT Int(0) like `++`) so `my $w; $w ~= "z"` yields "z",
         // not "0z"; the binary op descalarizes/numifies/stringifies Nil itself.
         let raw_val = self
+            // A block lexical captured by an escaped `our` sub resolves through
+            // its persisted shared cell FIRST, mirroring the read side — see
+            // `escaping_our_write_cell`.
+            .escaping_our_write_cell(code, name)
             // A package-scope free variable (`our $X` / `package { my $X }`)
             // reached by bare name from inside a named sub is not in the local
             // env; read it from the canonical package store so the fused RMW
             // operates on the current value, not Nil (mirrors `GetGlobal`). A
             // boxed lexical's cell is authoritative and must win over a stale
             // plain `env` copy left by a prior call's return-merge.
-            .package_scope_lexical(name)
+            .or_else(|| self.package_scope_lexical(name))
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
@@ -226,11 +230,11 @@ impl Interpreter {
             return Ok(());
         }
         let raw_val = self
-            .package_scope_lexical(name)
+            .escaping_our_write_cell(code, name)
+            .or_else(|| self.package_scope_lexical(name))
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
-            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::int(0));
         // ContainerRef: deref for increment, write back through the shared container.
         // Use an atomic read-modify-write under the cell lock so concurrent
@@ -320,11 +324,11 @@ impl Interpreter {
             return Ok(());
         }
         let raw_val = self
-            .package_scope_lexical(name)
+            .escaping_our_write_cell(code, name)
+            .or_else(|| self.package_scope_lexical(name))
             .or_else(|| self.get_env_with_main_alias(name))
             .or_else(|| self.read_package_scope_var(name))
             .or_else(|| self.anon_state_value(name))
-            .or_else(|| self.escaping_our_incdec_cell(code, name))
             .unwrap_or(Value::int(0));
         // ContainerRef: deref for decrement, write back through the shared container.
         // Atomic RMW under the cell lock for concurrent `start` blocks (Track C).

--- a/t/escaped-our-sub-lexical-write.t
+++ b/t/escaped-our-sub-lexical-write.t
@@ -1,0 +1,82 @@
+use v6;
+use Test;
+
+# Writes to a block `my` lexical captured by an escaped `our sub` must reach
+# the persisted shared cell across calls made AFTER the declaring block has
+# exited — mirroring the read side (`&OUR::f()` resolves the capture through
+# the cell). Regression pins for:
+#   * post-increment losing its write once an intervening `say` flushed the
+#     dead top-level slot into env as Nil (second call restarted from 0)
+#   * plain assignment (`$a = v`) landing only on the callee env copy and
+#     being dropped on return
+#   * compound assignment (`$a += v`) having no cell resolution at all
+# All expected values raku-verified (tmp probe, 2026-07-10).
+
+plan 21;
+
+# post-increment accumulates across escaped calls
+{ my $a = 3; our sub eosl-inc { $a++ } }
+is &OUR::eosl-inc(), 3, 'post-increment: first escaped call sees the block value';
+is &OUR::eosl-inc(), 4, 'post-increment: second escaped call continues from the cell';
+is &OUR::eosl-inc(), 5, 'post-increment: third escaped call continues from the cell';
+
+# an intervening say (which syncs top-level locals into env) must not
+# disturb the cell
+{ my $b = 10; our sub eosl-inc-b { $b++ } }
+is &OUR::eosl-inc-b(), 10, 'increment before intervening say';
+say '# noise';
+is &OUR::eosl-inc-b(), 11, 'increment survives an intervening say';
+
+# plain assignment through the escaped sub reaches the shared cell
+{ my $c = 3; our sub eosl-set { $c = 42 }; our sub eosl-peek-c { $c } }
+&OUR::eosl-set();
+is &OUR::eosl-peek-c(), 42, 'plain assignment reaches the cell';
+&OUR::eosl-set();
+is &OUR::eosl-peek-c(), 42, 'repeated assignment stays visible';
+
+# compound assignment (numeric)
+{ my $d = 5; our sub eosl-add { $d += 7 }; our sub eosl-peek-d { $d } }
+is &OUR::eosl-add(), 12, 'compound += first escaped call';
+is &OUR::eosl-add(), 19, 'compound += accumulates in the cell';
+is &OUR::eosl-peek-d(), 19, 'compound += result visible to a sibling reader';
+
+# compound assignment (string)
+{ my $e = "x"; our sub eosl-cat { $e ~= "y" } }
+is &OUR::eosl-cat(), 'xy', 'compound ~= first escaped call';
+is &OUR::eosl-cat(), 'xyy', 'compound ~= accumulates in the cell';
+
+# pre-increment
+{ my $f = 100; our sub eosl-preinc { ++$f } }
+is &OUR::eosl-preinc(), 101, 'pre-increment first escaped call';
+is &OUR::eosl-preinc(), 102, 'pre-increment accumulates in the cell';
+
+# post- and pre-decrement share the cell
+{ my $g = 50; our sub eosl-dec { $g-- }; our sub eosl-predec { --$g } }
+is &OUR::eosl-dec(), 50, 'post-decrement first escaped call';
+is &OUR::eosl-predec(), 48, 'pre-decrement continues from the cell';
+is &OUR::eosl-dec(), 48, 'post-decrement continues from the cell';
+
+# calls inside the block and after it agree on one cell
+my @order;
+{
+    my $h = 0;
+    our sub eosl-h { $h++ }
+    @order.push(&OUR::eosl-h());
+    @order.push(&OUR::eosl-h());
+}
+@order.push(&OUR::eosl-h());
+@order.push(&OUR::eosl-h());
+is @order.join(','), '0,1,2,3', 'inside-block and escaped calls share one cell';
+
+# assignment then increment through sibling escaped subs
+{ my $i = 1; our sub eosl-seti { $i = 20 }; our sub eosl-inci { $i++ } }
+&OUR::eosl-seti();
+is &OUR::eosl-inci(), 20, 'increment sees a prior escaped assignment';
+is &OUR::eosl-inci(), 21, 'increment accumulates after the assignment';
+
+# an unrelated top-level lexical with the same name is untouched
+my $a = 1000;
+&OUR::eosl-inc();
+is $a, 1000, 'same-named top-level lexical is not clobbered by the escaped write';
+
+done-testing;


### PR DESCRIPTION
## Problem

Reads of a block `my` lexical captured by an escaped `our sub` already resolve through the persisted shared cell (`escaping_our_read`), but the **write side was asymmetric**, losing mutations three ways (all raku-verified divergences):

1. **Plain assignment** (`$a = 42`) had no cell resolution at all — it landed on the callee env copy and was dropped on return:
   ```raku
   { my $c = 3; our sub setit { $c = 42 }; our sub peek { $c } }
   &OUR::setit(); say &OUR::peek();   # raku: 42 / mutsu: 3
   ```
2. **Compound assignment** (`$a += 7`, fused `AtomicCompoundVar`) likewise never consulted the cell.
3. **Inc/dec** consulted the cell only as the *last* resort, so any stale env entry won. `say` flushes ALL top-level local slots into env (`sync_env_from_locals`), including the declaring block's dead slot as Nil — so a `say` between calls reset the counter:
   ```raku
   { my $a = 3; our sub grtz { $a++ } }
   say &OUR::grtz();  # 3
   say &OUR::grtz();  # raku: 4 / mutsu: 0
   ```

## Fix

- Rename `escaping_our_incdec_cell` → `escaping_our_write_cell`; consult it **first** in the inc/dec and compound RMW chains (mirroring the read side), and add the matching `ContainerRef` write-through to `SetGlobal` for plain assignments.
- The old gate (any routine on the stack) was too coarse: it made the cell shadow a plain `my sub`'s own live capture of the same variable name (the read side had the same latent bug — `sub rmbl { $a }` returned the escaped cell's value instead of its own `$a`). `RegisterSub` now records the escaped sub's name (`escaped_our_sub_names`) and the cell resolution fires only while the innermost *named* routine frame is one of those subs; anonymous block/closure frames (`<pointy-block>`) are transparent.

## Tests

- New pin: `t/escaped-our-sub-lexical-write.t` (21 tests, all expected values verified against raku)
- `make test` passes (16089 tests), including the pre-existing `t/escaped-our-sub-incdec.t` same-name `my sub` cases
- Canaries: `roast/S02-names-vars/variables-and-packages.t` 39/39, `roast/S04-blocks-and-statements/pointy.t` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW