### PR TITLE
fix(vm): skip shadow-duplicated names in whole-locals env broadcasts + bake container-writeback slot (§1.4 S12)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -153,10 +153,36 @@ broadcast = touches every slot with the name.
       byte-identical. `roast/S13-overloading/metaoperators.t` #14-16 green ON.
       Validated OFF with `make roast` (map.t/hash.t transient failures were CPU-
       starvation flaky, not this change). *(#4090-pending)*
-- [ ] S12+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
-      for-loop *container* source writeback (`write_back_container_source`,
-      `write_back_for_topic_item`, resolved by the runtime-derived
-      `container_ref_var` name — a §1.3 concern); the nested/deep/generic index-assign
+- [x] **S12 — env-broadcast duplicate-name skip + for/given container-writeback
+      slot bake.** Root cause of the `reverse.t`/`hash.t`/`native-str.t` toggle-ON
+      regressions: the whole-locals env broadcasts (`sync_env_from_locals`, run
+      unconditionally by `Say`/`Put`/`Print`/`Note`, and
+      `sync_regex_interpolation_env_from_locals`) push EVERY slot into the
+      name-keyed env, so with shadow slots a later same-named sibling slot
+      (uninitialized `Nil`, or a stale copy) clobbers the live value — reads
+      (`GetArrayVar`/`GetHashVar` are env-first) then observe it. Fix:
+      `CompiledCode::dup_named_locals` (computed in `compute_needs_env_sync`)
+      flags every slot whose name occupies >1 slot; both broadcasts skip flagged
+      slots (the per-write `flush_local_to_env` mirror keeps env tracking the
+      live slot). Intrinsically byte-identical OFF — without the gate,
+      `alloc_local` get-or-creates by name so no duplicates exist. Also bakes a
+      compile-time slot onto `TagContainerRef`/`TagContainerRefReversed`
+      (`container_ref_var` is now `(name, Option<slot>)`) and threads it through
+      `write_back_for_topic_item`/`write_back_container_source`/
+      `write_back_given_topic` (gated ON), so the `$_ = ++$i for @a.reverse`
+      rebuild reads and writes the shadowed source's own slot instead of the
+      by-name `position` (outer) slot. ★**Rejected approach (tried first): a
+      baked-slot-first READ on `GetArrayVar`/`GetHashVar`.** It fixed the same
+      files but broke 4 `t/` files ON (`shared-array-push`, `shared-elem-assign`,
+      `slurpy-is-raw`, `subscript-adverbs`): many writeback paths (rw-arg drain,
+      pair-lvalue `.value =`, cross-thread `__mutsu_atomic_arr::` stores) still
+      write env-only, so a slot-first read observes stale slots. Reads must stay
+      env-first until §1.3 makes writes slot-complete — fixing the broadcast
+      clobber at its source is the sound slice. Pin:
+      `t/shadow-slot-env-broadcast.t` (passes OFF, ON, and real raku).
+      *(this branch)*
+- [ ] S13+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+      nested/deep/generic index-assign
       variants (`IndexAssignExprNested`/`DeepNested`/`Generic`), computed-attr twigil
       cells, hyper `»=»` multi-key writeback, and the remaining `update_local_if_exists`
       callers — migrated onto `resolve_local_slot`/`write_local_slot_or_name`.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -22,8 +22,10 @@ impl Compiler {
                     Expr::HashVar(name) => Some(format!("%{}", name)),
                     _ => None,
                 } {
+                    let source_slot = self.local_map.get(source_name.as_str()).copied();
                     let name_idx = self.code.add_constant(Value::str(source_name));
-                    self.code.emit(OpCode::TagContainerRef(name_idx));
+                    self.code
+                        .emit(OpCode::TagContainerRef(name_idx, source_slot));
                 }
                 let given_idx = self.code.emit(OpCode::DoGivenExpr { body_end: 0 });
                 self.compile_block_inline(body);

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -22,8 +22,10 @@ impl Compiler {
                 self.code.emit(OpCode::GetGlobal(name_idx));
             }
             // Tag for container-ref consumers.
+            let source_slot = self.local_map.get(name).copied();
             let name_idx = self.code.add_constant(Value::str(name.to_string()));
-            self.code.emit(OpCode::TagContainerRef(name_idx));
+            self.code
+                .emit(OpCode::TagContainerRef(name_idx, source_slot));
             return;
         }
         // $.attr = expr — In Raku, this first resolves self.attr (method call),
@@ -55,8 +57,10 @@ impl Compiler {
         // plain env-named scalars; the fused op leaves the new value on the
         // stack, exactly what expression context wants.
         if self.try_compile_fused_compound_assign(name, expr) {
+            let source_slot = self.local_map.get(name).copied();
             let name_idx = self.code.add_constant(Value::str(name.to_string()));
-            self.code.emit(OpCode::TagContainerRef(name_idx));
+            self.code
+                .emit(OpCode::TagContainerRef(name_idx, source_slot));
             return;
         }
         self.compile_expr(expr);
@@ -68,8 +72,10 @@ impl Compiler {
         }
         // Preserve lvalue container identity for expression-context consumers
         // (e.g. collected postfix `for` results).
+        let source_slot = self.local_map.get(name).copied();
         let name_idx = self.code.add_constant(Value::str(name.to_string()));
-        self.code.emit(OpCode::TagContainerRef(name_idx));
+        self.code
+            .emit(OpCode::TagContainerRef(name_idx, source_slot));
     }
 
     /// Compile CaptureVar ($0, $1, etc.).

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -19,8 +19,10 @@ impl Compiler {
             Stmt::Expr(expr) => {
                 self.compile_expr(expr);
                 if let Expr::Var(name) = expr {
+                    let source_slot = self.local_map.get(name.as_str()).copied();
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
-                    self.code.emit(OpCode::TagContainerRef(name_idx));
+                    self.code
+                        .emit(OpCode::TagContainerRef(name_idx, source_slot));
                 }
                 true
             }

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -207,8 +207,10 @@ impl Compiler {
         let normalized_iterable = self.normalize_for_iterable(iterable);
         self.compile_expr(&normalized_iterable);
         if let Some(source_name) = Self::for_iterable_source_name(iterable) {
+            let source_slot = self.local_map.get(source_name.as_str()).copied();
             let source_idx = self.code.add_constant(Value::str(source_name));
-            self.code.emit(OpCode::TagContainerRef(source_idx));
+            self.code
+                .emit(OpCode::TagContainerRef(source_idx, source_slot));
         }
         let param_local = param
             .as_ref()

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1756,11 +1756,14 @@ impl Compiler {
                 let normalized_iterable = self.normalize_for_iterable(iterable);
                 self.compile_expr(&normalized_iterable);
                 if let Some(source_name) = Self::for_iterable_source_name(iterable) {
+                    let source_slot = self.local_map.get(source_name.as_str()).copied();
                     let source_idx = self.code.add_constant(Value::str(source_name));
                     if Self::for_iterable_is_reversed(iterable) {
-                        self.code.emit(OpCode::TagContainerRefReversed(source_idx));
+                        self.code
+                            .emit(OpCode::TagContainerRefReversed(source_idx, source_slot));
                     } else {
-                        self.code.emit(OpCode::TagContainerRef(source_idx));
+                        self.code
+                            .emit(OpCode::TagContainerRef(source_idx, source_slot));
                     }
                 }
                 // If the for-loop parameter name already has a local slot
@@ -2222,8 +2225,10 @@ impl Compiler {
                         }
                     };
                     if let Some(source_name) = source_name {
+                        let source_slot = self.local_map.get(source_name.as_str()).copied();
                         let name_idx = self.code.add_constant(Value::str(source_name));
-                        self.code.emit(OpCode::TagContainerRef(name_idx));
+                        self.code
+                            .emit(OpCode::TagContainerRef(name_idx, source_slot));
                     }
                     // The topic is read-only unless it is a bare scalar variable
                     // (`given $x` aliases `$x` rw), a scalar declaration topic

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -833,10 +833,15 @@ pub(crate) enum OpCode {
     Succeed,
     /// `done` — terminate the innermost react event loop
     ReactDone,
-    /// Tag the current value as coming from a named container (for Scalar binding)
-    TagContainerRef(u32),
-    /// Tag the current value as coming from a reversed named container (for `@a.reverse` writeback)
-    TagContainerRefReversed(u32),
+    /// Tag the current value as coming from a named container (for Scalar binding).
+    /// The second field is the compile-time-resolved local slot for the source
+    /// name (§1.5 slot baking; `None` = non-local): with shadow slots active the
+    /// container writeback targets `locals[slot]` instead of the ambiguous
+    /// by-name (`position`) resolution.
+    TagContainerRef(u32, Option<u32>),
+    /// Tag the current value as coming from a reversed named container (for
+    /// `@a.reverse` writeback); same slot-baking contract as `TagContainerRef`.
+    TagContainerRefReversed(u32, Option<u32>),
     /// Topicalize a container *element* (`given %h<k>` / `given @a[i]`) as an
     /// lvalue: pop the index from the stack, read element `container[index]`,
     /// push it as the topic value, and record the (container, index) source so
@@ -1509,6 +1514,16 @@ pub(crate) struct CompiledCode {
     /// Locals that are only accessed via GetLocal don't need env sync,
     /// reducing env size and clone cost.
     pub(crate) needs_env_sync: Vec<bool>,
+    /// Bitmap: true if local[i]'s NAME occupies more than one `locals` slot —
+    /// a genuine inner-block shadow under the `MUTSU_SHADOW_SLOTS` gate (§1.4).
+    /// The name-keyed env can hold only ONE value per name, so the whole-locals
+    /// env broadcast (`sync_env_from_locals` and the regex-interpolation sync)
+    /// must skip these slots: pushing an arbitrary (last-iterated) same-named
+    /// slot clobbers the live value with an uninitialized/stale sibling's. The
+    /// per-write mirror (`flush_local_to_env`) keeps env tracking the live
+    /// slot's writes instead. With the gate off `alloc_local` get-or-creates by
+    /// name, so names are unique and this is all-false (byte-identical).
+    pub(crate) dup_named_locals: Vec<bool>,
     /// Free variables this code (and its nested closures) reference from an
     /// enclosing scope: names used via GetGlobal-family ops that are not this
     /// code's own locals. For a closure body this is the set of captured
@@ -1686,6 +1701,7 @@ impl CompiledCode {
             has_env_writes: false,
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),
+            dup_named_locals: Vec::new(),
             free_var_syms: Vec::new(),
             outer_ref_names: Vec::new(),
             free_var_writes: Vec::new(),
@@ -1814,6 +1830,31 @@ impl CompiledCode {
         });
         let n = self.locals.len();
         self.needs_env_sync = vec![false; n];
+        // §1.4 shadow slots: flag every slot whose name occupies more than one
+        // `locals` slot (a genuine inner-block shadow under MUTSU_SHADOW_SLOTS)
+        // so the whole-locals env broadcasts skip them — see `dup_named_locals`.
+        // Computed before the early returns below so it is populated for
+        // BlockScope-carrying frames too (the very frames that shadow).
+        self.dup_named_locals = vec![false; n];
+        {
+            let mut first_seen: std::collections::HashMap<&str, usize> =
+                std::collections::HashMap::with_capacity(n);
+            let mut dups: Vec<usize> = Vec::new();
+            for (i, name) in self.locals.iter().enumerate() {
+                match first_seen.get(name.as_str()) {
+                    Some(&first) => {
+                        dups.push(first);
+                        dups.push(i);
+                    }
+                    None => {
+                        first_seen.insert(name.as_str(), i);
+                    }
+                }
+            }
+            for i in dups {
+                self.dup_named_locals[i] = true;
+            }
+        }
         if n == 0 {
             return;
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1485,7 +1485,12 @@ pub struct Interpreter {
     pub(crate) substitution_in_smartmatch: bool,
     pub(crate) last_topic_value: Option<Value>,
     pub(crate) topic_save_stack: Vec<Value>,
-    pub(crate) container_ref_var: Option<String>,
+    /// The named container the current topic/loop source came from
+    /// (`TagContainerRef`), paired with its compile-time-baked local slot
+    /// (§1.5; `None` = non-local or runtime-derived). The slot lets the
+    /// for/given container writeback target the exact `locals` slot when
+    /// shadow slots are active, instead of the by-name `position` search.
+    pub(crate) container_ref_var: Option<(String, Option<u32>)>,
     pub(crate) container_ref_reversed: bool,
     pub(crate) topic_source_var: Option<String>,
     /// The `@`/`%` source variable when `$_` is a whole-container topic

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -774,6 +774,15 @@ impl Interpreter {
 
     pub(super) fn sync_env_from_locals(&mut self, code: &CompiledCode) {
         for (i, name) in code.locals.iter().enumerate() {
+            // §1.4 shadow slots: a name occupying several slots (an inner-block
+            // shadow under MUTSU_SHADOW_SLOTS) cannot be broadcast — env holds
+            // one value per name, and pushing an arbitrary (last-iterated)
+            // same-named slot clobbers the live value with an uninitialized
+            // sibling's. The per-write mirror (`flush_local_to_env`) keeps env
+            // tracking the live slot instead. All-false with the gate off.
+            if code.dup_named_locals.get(i).copied().unwrap_or(false) {
+                continue;
+            }
             self.set_env_with_main_alias(name, self.locals[i].clone());
         }
     }
@@ -786,6 +795,11 @@ impl Interpreter {
                 || name == "\u{a2}"
                 || name.chars().all(|ch| ch.is_ascii_digit())
             {
+                continue;
+            }
+            // A shadow-duplicated name cannot be broadcast by name — see
+            // `sync_env_from_locals` above.
+            if code.dup_named_locals.get(i).copied().unwrap_or(false) {
                 continue;
             }
             // Only sync locals that already exist in the env.  This prevents

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3004,15 +3004,15 @@ impl Interpreter {
             OpCode::ReactDone => {
                 return Err(RuntimeError::react_done_signal());
             }
-            OpCode::TagContainerRef(name_idx) => {
+            OpCode::TagContainerRef(name_idx, slot) => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.container_ref_var = Some(name);
+                self.container_ref_var = Some((name, *slot));
                 self.container_ref_reversed = false;
                 *ip += 1;
             }
-            OpCode::TagContainerRefReversed(name_idx) => {
+            OpCode::TagContainerRefReversed(name_idx, slot) => {
                 let name = Self::const_str(code, *name_idx).to_string();
-                self.container_ref_var = Some(name);
+                self.container_ref_var = Some((name, *slot));
                 self.container_ref_reversed = true;
                 *ip += 1;
             }

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -66,7 +66,13 @@ impl Interpreter {
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
         let saved_quanthash_bind = std::mem::take(&mut self.quanthash_bind_params);
-        let container_binding = self.container_ref_var.take();
+        // The tagged source name plus its compile-time-baked local slot (§1.5):
+        // the slot lets the topic writeback target the exact `locals` slot when
+        // shadow slots are active (a shadowed name occupies several slots and
+        // the by-name `position` search resolves to the outer one).
+        let container_binding_full = self.container_ref_var.take();
+        let container_source_slot = container_binding_full.as_ref().and_then(|(_, s)| *s);
+        let container_binding = container_binding_full.map(|(n, _)| n);
         // A sigilless/`is rw` for-param aliases the source element, but an
         // *immutable* Mix/Set/Bag yields immutable weights — assigning to the
         // alias must throw X::Assignment::RO, and no writeback may run (it would
@@ -335,6 +341,7 @@ impl Interpreter {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                container_source_slot,
                                 &param_name,
                                 idx,
                                 container_reversed,
@@ -366,7 +373,7 @@ impl Interpreter {
                             let base = stack_base.unwrap();
                             if self.stack.len() > base {
                                 let val = self.stack.pop().unwrap();
-                                let deferred_ref = self.container_ref_var.take();
+                                let deferred_ref = self.container_ref_var.take().map(|(n, _)| n);
                                 let coll_start_len = coll.len();
                                 Self::collect_loop_value(coll, val);
                                 if let Some(name) = deferred_ref
@@ -385,6 +392,7 @@ impl Interpreter {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                container_source_slot,
                                 &param_name,
                                 idx,
                                 container_reversed,
@@ -436,6 +444,7 @@ impl Interpreter {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                container_source_slot,
                                 &param_name,
                                 idx,
                                 container_reversed,
@@ -481,6 +490,7 @@ impl Interpreter {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                container_source_slot,
                                 &param_name,
                                 idx,
                                 container_reversed,
@@ -516,6 +526,7 @@ impl Interpreter {
                             self.write_back_for_topic_item(
                                 code,
                                 &container_binding,
+                                container_source_slot,
                                 &param_name,
                                 idx,
                                 container_reversed,

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -31,7 +31,9 @@ impl Interpreter {
         let saved_topic_source = self.topic_source_var.take();
         let saved_container_source = self.topic_container_source.take();
         let saved_element_source = self.element_source.take();
-        let container_binding = self.container_ref_var.take();
+        let container_binding_full = self.container_ref_var.take();
+        let container_source_slot = container_binding_full.as_ref().and_then(|(_, s)| *s);
+        let container_binding = container_binding_full.map(|(n, _)| n);
         // An element-source topic (`given %h<k>` / `given @a[i]`) aliases an
         // lvalue element: the final `$_` is written back to that element below,
         // so `$_ = ...` (whole reassign) AND `.push` both propagate. Don't set
@@ -76,7 +78,12 @@ impl Interpreter {
                 if let Some(src) = &element_source {
                     this.write_back_element_source(code, src, &pointy_param);
                 } else {
-                    this.write_back_given_topic(code, &container_binding, &pointy_param);
+                    this.write_back_given_topic(
+                        code,
+                        &container_binding,
+                        container_source_slot,
+                        &pointy_param,
+                    );
                 }
             }
             this.set_when_matched(saved_when);
@@ -185,7 +192,8 @@ impl Interpreter {
             Err(mut e) if e.is_succeed() => {
                 // Take the container name before moving `return_value` out (a
                 // method borrow of `e` cannot coexist with a partial move).
-                self.container_ref_var = e.take_container_name();
+                // The signal carries only the name — no compile-time slot.
+                self.container_ref_var = e.take_container_name().map(|n| (n, None));
                 if let Some(v) = e.return_value {
                     last = v;
                 }
@@ -295,7 +303,7 @@ impl Interpreter {
                 let last = self.stack.last().cloned().unwrap_or(Value::NIL);
                 let mut sig = RuntimeError::succeed_signal();
                 sig.return_value = Some(last);
-                sig.set_container_name(self.container_ref_var.take());
+                sig.set_container_name(self.container_ref_var.take().map(|(n, _)| n));
                 return Err(sig);
             }
         }
@@ -324,7 +332,7 @@ impl Interpreter {
         let last = self.stack.last().cloned().unwrap_or(Value::NIL);
         let mut sig = RuntimeError::succeed_signal();
         sig.return_value = Some(last);
-        sig.set_container_name(self.container_ref_var.take());
+        sig.set_container_name(self.container_ref_var.take().map(|(n, _)| n));
         *ip = end;
         Err(sig)
     }

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -10,6 +10,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         source: &Option<String>,
+        source_slot: Option<u32>,
         pointy_param: &Option<String>,
     ) {
         let Some(source) = source else {
@@ -18,6 +19,14 @@ impl Interpreter {
         if !source.starts_with('@') && !source.starts_with('%') {
             return;
         }
+        // §1.4: with shadow slots active, target the compile-time-baked slot —
+        // the by-name `position` search resolves a shadowed source to the OUTER
+        // slot. OFF keeps `None` = the by-name path, byte-identical.
+        let eff_slot = if crate::compiler::shadow_slots_active() {
+            source_slot
+        } else {
+            None
+        };
         // For a pointy block, write back the bound parameter's final value
         // (`@p` after `@p.push`); otherwise the topic `$_`.
         let current = match pointy_param {
@@ -33,7 +42,7 @@ impl Interpreter {
             return;
         }
         self.set_env_with_main_alias(source, current.clone());
-        self.update_local_if_exists(code, source, &current);
+        self.write_local_slot_or_name(code, eff_slot, source, current);
     }
 
     /// Write the final `$_` back to an lvalue container element (`given %h<k>`
@@ -134,14 +143,24 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         source: &str,
+        source_slot: Option<u32>,
         raw_source: &Option<Value>,
         updated_value: Value,
     ) {
         if let Some(ValueView::ContainerRef(arc)) = raw_source.as_ref().map(Value::view) {
             arc.lock().unwrap().clone_from(&updated_value);
         } else {
+            // §1.4: prefer the compile-time-baked slot under the shadow-slot
+            // gate (a shadowed source name occupies several slots and the
+            // by-name `position` search hits the outer one); OFF passes `None`
+            // = the original by-name update, byte-identical.
+            let eff_slot = if crate::compiler::shadow_slots_active() {
+                source_slot
+            } else {
+                None
+            };
             self.set_env_with_main_alias(source, updated_value.clone());
-            self.update_local_if_exists(code, source, &updated_value);
+            self.write_local_slot_or_name(code, eff_slot, source, updated_value);
         }
     }
 
@@ -150,6 +169,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         source_var: &Option<String>,
+        source_slot: Option<u32>,
         param_name: &Option<String>,
         idx: usize,
         reversed: bool,
@@ -190,7 +210,19 @@ impl Interpreter {
         // share one outer cell (Stage 1 / env-locals coherence). Deref to inspect
         // the inner Array; when present, the rebuilt array must be written THROUGH
         // the cell so the bound source (`@b`) observes the topic mutation.
-        let raw_source = self.get_env_with_main_alias(source);
+        // §1.4: under the shadow-slot gate, read the baked slot first — the env
+        // entry for a shadowed name may hold a stale/other-slot Arc (clobbered
+        // by the whole-locals `sync_env_from_locals` broadcast), so rebuilding
+        // from it would base the writeback on the wrong array.
+        let slot_source = if crate::compiler::shadow_slots_active() {
+            source_slot
+                .and_then(|s| self.locals.get(s as usize))
+                .filter(|v| !v.is_nil())
+                .cloned()
+        } else {
+            None
+        };
+        let raw_source = slot_source.or_else(|| self.get_env_with_main_alias(source));
         let Some((items, kind)) = raw_source
             .as_ref()
             .and_then(|v| v.deref_container().into_array())
@@ -223,6 +255,6 @@ impl Interpreter {
         let mut new_data = (*items).clone();
         new_data.items[actual_idx] = current_topic;
         let updated_value = Value::array_with_kind(crate::gc::Gc::new(new_data), kind);
-        self.write_back_container_source(code, source, &raw_source, updated_value);
+        self.write_back_container_source(code, source, source_slot, &raw_source, updated_value);
     }
 }

--- a/src/vm/vm_loop_writeback_quant.rs
+++ b/src/vm/vm_loop_writeback_quant.rs
@@ -173,7 +173,7 @@ impl Interpreter {
         let mut updated = hash_items.as_ref().clone();
         updated.insert(key.clone(), current);
         let updated_value = Value::hash_with_data(Value::hash_arc(updated));
-        self.write_back_container_source(code, source, &raw_source, updated_value);
+        self.write_back_container_source(code, source, None, &raw_source, updated_value);
     }
 
     /// Write back modified loop variable to the original scalar variable.
@@ -262,7 +262,13 @@ impl Interpreter {
                         let key_str = key.to_string_value();
                         updated.insert(key_str, val);
                         let updated_value = Value::hash_with_data(Value::hash_arc(updated));
-                        self.write_back_container_source(code, source, &source_val, updated_value);
+                        self.write_back_container_source(
+                            code,
+                            source,
+                            None,
+                            &source_val,
+                            updated_value,
+                        );
                     }
                 } else if !kv_mode {
                     // %hash.values -> $val is rw: positional writeback using pre-captured key order
@@ -281,7 +287,13 @@ impl Interpreter {
                         let mut updated = hash_items.as_ref().clone();
                         updated.insert(keys[idx].clone(), val);
                         let updated_value = Value::hash_with_data(Value::hash_arc(updated));
-                        self.write_back_container_source(code, source, &source_val, updated_value);
+                        self.write_back_container_source(
+                            code,
+                            source,
+                            None,
+                            &source_val,
+                            updated_value,
+                        );
                     }
                 }
                 return;
@@ -298,7 +310,13 @@ impl Interpreter {
                         crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                         kind,
                     );
-                    self.write_back_container_source(code, source, &source_val, updated_value);
+                    self.write_back_container_source(
+                        code,
+                        source,
+                        None,
+                        &source_val,
+                        updated_value,
+                    );
                 }
             } else if arity > 1 && !rw_param_names.is_empty() {
                 // Multi-param rw: read each named param and write back to the array
@@ -315,7 +333,7 @@ impl Interpreter {
                     crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                     kind,
                 );
-                self.write_back_container_source(code, source, &source_val, updated_value);
+                self.write_back_container_source(code, source, None, &source_val, updated_value);
             } else {
                 // Single-param rw: read the named param (or $_) and write back
                 let var_name = param_name.as_deref().unwrap_or("_");
@@ -337,7 +355,7 @@ impl Interpreter {
                     crate::gc::Gc::new(crate::value::ArrayData::new(updated)),
                     kind,
                 );
-                self.write_back_container_source(code, source, &source_val, updated_value);
+                self.write_back_container_source(code, source, None, &source_val, updated_value);
             }
         } else if source.starts_with('%') {
             // Hash writeback: not straightforward by index; skip for now

--- a/t/shadow-slot-env-broadcast.t
+++ b/t/shadow-slot-env-broadcast.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 8;
+
+# §1.4 shadow slots (docs/lexical-scope-slot-campaign.md, S12): a shadowing
+# inner-block `my @a`/`my %h` occupies its own locals slot under
+# MUTSU_SHADOW_SLOTS, so the whole-locals env broadcast that `say` (and the
+# regex-interpolation sync) runs must NOT push an uninitialized same-named
+# sibling slot over the live value (env is name-keyed and holds one value per
+# name). Must pass identically with the gate OFF (no duplicate slots exist)
+# and ON (`dup_named_locals` skips the ambiguous names).
+
+my @a = 1, 2;
+{
+    my @a = "foo";
+    my @b = @a.reverse;
+    my $b = @a.reverse;
+    # `say` triggers the whole-locals env broadcast; with a later sibling
+    # `my @a` below, an unskipped broadcast clobbered env<@a> with Nil.
+    say "# probe=", @b[0];
+    is @a[0], "foo", 'shadowed @a survives the say env broadcast';
+    is ~$b, "foo", 'Seq over the shadowed @a reads the live value';
+    say "# probe2=", $b;
+    is @a[0], "foo", 'shadowed @a survives a second broadcast';
+}
+{
+    my @a = "x", "y";
+    say "# probe3=", @a[0];
+    is @a[0], "x", 'sibling shadow block sees its own @a';
+}
+is @a[0], 1, 'outer @a restored after the shadow blocks';
+
+# The regex-interpolation env sync has the same broadcast shape: a shadowed
+# %h must stay readable with $/ / $0 hash keys right after a match
+# (roast/S02-types/hash.t #80-81).
+my %h;
+{
+    my %h = (ab => 'x', 'a' => 'y');
+    'abc' ~~ /^(.)./;
+    is %h{$/}, 'x', 'shadowed %h readable with $/ as hash key';
+    is %h{$0}, 'y', 'shadowed %h readable with $0 as hash key';
+}
+
+# For-topic container writeback targets the shadowed source's own slot via
+# the slot baked on TagContainerRef (roast/S32-list/reverse.t #21).
+{
+    my @a = 1..3;
+    {
+        my Int @a = ^5;
+        @a[2]:delete;
+        my int $i = 0;
+        $_ = ++$i for @a.reverse;
+        is-deeply @a, Array[Int].new(5, 4, 3, 2, 1),
+            'for-topic writeback lands on the shadowed @a';
+    }
+}


### PR DESCRIPTION
## Summary

Lexical-scope shadow-slot campaign S12 (docs/lexical-scope-slot-campaign.md, ANALYSIS §1.4/§1.5). Burns down three of the remaining `MUTSU_SHADOW_SLOTS` toggle-ON roast regressions at their root cause, with the gate OFF byte-identical.

### Root cause

With shadow slots on, a shadowing inner-block `my @a` / `my %h` gets its own locals slot, so one name can occupy several slots. The whole-locals env broadcasts — `sync_env_from_locals` (run unconditionally by `Say`/`Put`/`Print`/`Note`) and `sync_regex_interpolation_env_from_locals` — push **every** slot into the name-keyed env in slot order, so a later same-named sibling slot (uninitialized `Nil`, or a stale copy) clobbers the live value. The env-first `GetArrayVar`/`GetHashVar` reads then observe the clobber.

### Fix

- **`CompiledCode::dup_named_locals`** (computed in `compute_needs_env_sync`): flags every slot whose name occupies more than one `locals` slot. Both broadcasts skip flagged slots — the per-write `flush_local_to_env` mirror already keeps env tracking the live slot's writes. Intrinsically byte-identical with the gate off (`alloc_local` get-or-creates by name, so duplicates cannot exist; the bitmap is all-false).
- **`TagContainerRef`/`TagContainerRefReversed` carry a compile-time slot** (`container_ref_var` is now `(name, Option<slot>)`), threaded through `write_back_for_topic_item` / `write_back_container_source` / `write_back_given_topic` (gated on `shadow_slots_active()`): the `$_ = ++$i for @a.reverse` rebuild reads and writes the shadowed source's own slot instead of the by-name `position` (outer) slot.

### Rejected approach (documented in the campaign doc)

A baked-slot-first **read** on `GetArrayVar`/`GetHashVar` fixed the same files but broke 4 `t/` files ON: rw-arg drains, pair-lvalue `.value =` writes and cross-thread `__mutsu_atomic_arr::` stores still write env-only, so slot-first reads observed stale slots. Reads must stay env-first until §1.3 makes writes slot-complete.

### Validation

- Toggle-ON: `roast/S32-list/reverse.t`, `roast/S02-types/hash.t`, `roast/S09-typed-arrays/native-str.t` all flip green; no new ON failures vs main (`t/outer-topic.t` #4 fails ON on main too — pre-existing burndown target).
- Gate OFF: full `prove t/` green (only the known-flaky `t/io-socket-recv-limit.t` under `-j4`, passes 3/3 standalone); targeted roast batch green (given/when/for/assign/array/hash/metaoperators/perl/zip/cross).
- `cargo test` 551 passed, clippy `-D warnings` clean.
- Pin: `t/shadow-slot-env-broadcast.t` — passes gate OFF, gate ON, and real `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW