### PR TITLE
fix(parser): support destructuring sub-signatures in pointy-block expressions

### DIFF
--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -29,6 +29,20 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             },
         ));
     }
+    // Positional destructuring sub-signature: `-> [$a, $b] { ... }`.
+    // A bare `[...]` binds a single Positional argument and unpacks it — an
+    // anonymous `@` param carrying the sub-signature (mirrors `sub f([$a,$b])`).
+    if input.starts_with('[') {
+        let (r, _) = parse_char(input, '[')?;
+        let (r, _) = ws(r)?;
+        let (r, sub_params) = super::sub::parse_param_list(r)?;
+        let (r, _) = ws(r)?;
+        let (r, _) = parse_char(r, ']')?;
+        let mut p = crate::parser::stmt::sub_param::make_param("@".to_string());
+        p.sub_signature = Some(sub_params);
+        return Ok((r, p));
+    }
+
     // Optional type constraint before the variable
     // Use parse_type_constraint_expr to handle coercion types (e.g., Numeric(Cool)),
     // qualified names (Int::Odd), definedness markers (:D/:U), etc.
@@ -374,7 +388,9 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
     }
 
     // Optional unpacking sub-signature: `-> Pair $p (:$key, :$value) { ... }`
-    // Parse and preserve the sub-signature for runtime binding.
+    // Also the bracket form used for hash/positional destructure of the bound
+    // value: `-> % [:$k, :@v] { ... }` / `-> @a [$x, $y] { ... }` (mirrors the
+    // `sub f(% [:$k])` path in sub_param). Parse and preserve for runtime binding.
     let mut sub_signature = None;
     let (r, _) = ws(rest)?;
     if r.starts_with('(') {
@@ -383,6 +399,14 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         let (r, sub_params) = super::sub::parse_param_list(r)?;
         let (r, _) = ws(r)?;
         let (r, _) = parse_char(r, ')')?;
+        sub_signature = Some(sub_params);
+        rest = r;
+    } else if r.starts_with('[') {
+        let (r, _) = parse_char(r, '[')?;
+        let (r, _) = ws(r)?;
+        let (r, sub_params) = super::sub::parse_param_list(r)?;
+        let (r, _) = ws(r)?;
+        let (r, _) = parse_char(r, ']')?;
         sub_signature = Some(sub_params);
         rest = r;
     } else {

--- a/t/pointy-block-destructure-expr.t
+++ b/t/pointy-block-destructure-expr.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# Pointy blocks used as an *expression* (assigned to a variable or called
+# inline) must support destructuring sub-signatures, exactly like the `for`
+# loop pointy form and like `sub f([$a,$b])` / `sub f(% [:$k])`.
+
+plan 12;
+
+# Hash destructure assigned to a &-sigil variable (the original zef-surfaced bug).
+my &hb = -> % [:$k, :@v] { "$k @v[]" };
+is hb(%(k => 1, v => [2, 3])), "1 2 3", 'hash destructure -> &var';
+
+# Hash destructure assigned to a $-sigil variable.
+my $sb = -> % [:$k] { $k };
+is $sb(%(k => 42)), 42, 'hash destructure -> $var';
+
+# Array (positional) destructure assigned to a &-sigil variable.
+my &ab = -> [$a, $b] { "$a $b" };
+is ab([1, 2]), "1 2", 'array destructure -> &var';
+
+# Standalone inline-called pointy with array destructure.
+is (-> [$a, $b] { "$a $b" })([9, 8]), "9 8", 'inline array destructure';
+
+# Standalone inline-called pointy with hash destructure.
+is (-> % [:$k] { $k })(%(k => 7)), 7, 'inline hash destructure';
+
+# Named-array destructure inside the hash sub-signature.
+my &nb = -> % [:$name, :@deps] { "$name: @deps[]" };
+is nb(%(name => 'Foo', deps => <a b c>)), "Foo: a b c", 'hash destructure with named array';
+
+# @-sigil param followed by a bracket sub-signature.
+my &mb = -> @a [$x, $y] { "$x/$y" };
+is mb([5, 6]), "5/6", 'array param with bracket sub-signature';
+
+# Mixed: destructure param followed by a plain param.
+my &gb = -> [$a, $b], $c { "$a $b $c" };
+is gb([1, 2], 3), "1 2 3", 'destructure param plus plain param';
+
+# .map with an array-destructuring pointy block.
+is-deeply [[1, 2], [3, 4]].map(-> [$a, $b] { $a + $b }).List, (3, 7),
+    '.map array destructure';
+
+# Paren sub-signature still works (regression guard).
+my &pb = -> ($a, $b) { "$a $b" };
+is pb((1, 2)), "1 2", 'paren sub-signature still works';
+
+# Plain single/multi params still work (regression guard).
+my &f1 = -> $x { $x * 2 };
+is f1(21), 42, 'plain single param still works';
+my &f2 = -> $a, $b { $a + $b };
+is f2(3, 4), 7, 'plain multi param still works';


### PR DESCRIPTION
## Problem

A pointy block used as an *expression* (assigned to a variable or called inline) failed to parse when its signature used a destructuring sub-signature:

```raku
my &b = -> % [:$k, :@v] { "$k @v[]" };   # parse error
my $f = -> [$a, $b] { "$a $b" };          # parse error
(-> % [:$k] { $k })(%(k => 1));           # parse error
```

All failed with `expected right-hand expression after '='`. The pointy-param parser only understood the `(...)` sub-signature form, not the bracket forms (`% [...]`, bare `[...]`), so the block body was never reached.

This was surfaced while driving the real Zef CLI as `mzef`: zef uses `for ... -> % [:@dists] { ... }` (which already worked via the for-loop parser), but the equivalent expression form did not.

## Fix

The `for`-loop pointy form and `sub f([$a,$b])` / `sub f(% [:$k])` already handled these. This brings the **expression** pointy form in line by teaching `parse_pointy_param` to:

- treat a bare leading `[...]` as an anonymous `@` param carrying the positional-destructure sub-signature (mirrors `sub f([$a,$b])`), and
- accept a trailing `[...]` sub-signature after a variable/sigil, alongside the existing `(...)` form (mirrors `sub f(% [:$k])`).

`@a[3]` shape constraints (no space) are unaffected — they are consumed earlier and never reach the sub-signature check. All outputs verified against `raku`.

## Test

`t/pointy-block-destructure-expr.t` (12 subtests): hash/array/nested destructure assigned to `&`/`$` vars, inline-called, `.map` block, mixed destructure + plain param, plus regression guards for `(...)` sub-signatures and plain params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)