### PR TITLE
fix(vm): bake emit-point capture slots + cell-box shadowed captures (§1.3 S13)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -181,7 +181,38 @@ broadcast = touches every slot with the name.
       clobber at its source is the sound slice. Pin:
       `t/shadow-slot-env-broadcast.t` (passes OFF, ON, and real raku).
       *(this branch)*
-- [ ] S13+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+- [x] **S13 — closure-capture slot bake + shadow cell trigger (§1.3 slice 2:
+      "make closure capture slot-addressed").** Root cause of the `wrap.t`
+      toggle-ON failures (tests 63/66): a closure passed as a CALL ARGUMENT
+      (`.wrap({...})`, `@cs.push({...})`) is classified non-escaping by the
+      escape analysis, so `box_captured_lexicals` never gives its
+      captured-and-mutated lexical a shared `ContainerRef` cell; the non-cell
+      coherence path then writes the mutation back BY NAME (position = the
+      OUTER slot), so a closure over an inner shadow updated the wrong slot.
+      Two coupled fixes, both gated on `shadow_slots_active()`:
+      1. **Emit-point capture slots.** `Compiler::add_closure_code_baked` (the
+         single `add_closure_code` chokepoint, 6 call sites) bakes the parent
+         `local_map` slot for every child `free_var_syms`/`upvalue_syms` entry
+         into new `CompiledCode::free_var_parent_slots`/`upvalue_parent_slots`.
+         The four runtime capture resolvers (`capture_closure_env` ×2,
+         `capture_upvalues`, `box_captured_lexicals`) go through the shared
+         `resolve_capture_slot` helper: baked slot first (validated against the
+         slot name), `rposition` fallback. This also fixes the latent
+         pre-shadow hazard — `rposition` always picks the INNERMOST same-named
+         slot, wrong for a closure created before/outside the shadow block.
+      2. **Shadow boxing trigger (path C).** A captured-and-mutated scalar
+         whose baked slot is dup-named (`code.dup_named_locals`, S12) gets a
+         cell REGARDLESS of the escape analysis — by-name writeback cannot
+         disambiguate duplicate names, and the cell mechanism is the sound one
+         (per the roles-6e.t lesson). The early-return gate gains a matching
+         `dup_shadow_possible` arm. OFF is byte-identical: no duplicate names
+         exist, `resolve_capture_slot` reduces to the old `rposition`.
+      ON green: `S06-advanced/wrap.t` (90/90), and `S02-types/whatever.t` +
+      `S02-types/hash.t` now pass ON too (same capture root cause). `perl.t` #7
+      (AssignExprLocal `@`/`%` parity) remains, plus pre-existing
+      `outer-topic.t` #4. Pin: `t/shadow-slot-closure-capture.t` (OFF, ON, and
+      real raku). *(this branch)*
+- [ ] S14+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
       nested/deep/generic index-assign
       variants (`IndexAssignExprNested`/`DeepNested`/`Generic`), computed-attr twigil
       cells, hyper `»=»` multi-key writeback, and the remaining `update_local_if_exists`
@@ -451,6 +482,9 @@ Concrete first slices (each behavior-preserving with the gate OFF; roast is the 
    slot (or its `ContainerRef` cell), not `env[name]`, so a wrapper/closure over an
    inner shadow reads the inner cell (fixes `wrap.t`). This overlaps ADR-0001 layer-3a
    (container cells) — coordinate with GC, do NOT box scalars eagerly.
+   **DONE — see S13 in the slice checklist** (emit-point capture slots + the
+   dup-named shadow boxing trigger; boxing stays scoped to captured-and-mutated
+   scalars, no eager scalar boxing).
 3. **Slot-key the regex-interp / smartmatch env sync** so `$/`/`$0` and a shadowed
    `%h` don't collide (fixes `hash.t`).
 4. **Remove the `exec_block_scope_op` `locals.clone()`** once 1-3 hold, then flip the

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -665,7 +665,7 @@ impl Compiler {
             let placeholders = crate::ast::collect_placeholders_shallow(stmts);
             let compiled = self.compile_closure_body(&placeholders, &[], stmts);
             let esc = self.escaping_position;
-            let cc_idx = self.code.add_closure_code(compiled, esc);
+            let cc_idx = self.add_closure_code_baked(compiled, esc);
             let idx = self.code.add_stmt(Stmt::Block(stmts.to_vec()));
             self.code.emit(OpCode::MakeBlockClosure(idx, Some(cc_idx)));
         } else {

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -62,7 +62,7 @@ impl Compiler {
                 self.compile_routine_closure_body(&[], &[], body)
             };
             let esc = self.escaping_position;
-            let cc_idx = self.code.add_closure_code(compiled, esc);
+            let cc_idx = self.add_closure_code_baked(compiled, esc);
             let idx = self.code.add_stmt(Stmt::SubDecl {
                 name: Symbol::intern(""),
                 name_expr: None,
@@ -107,7 +107,7 @@ impl Compiler {
                 self.compile_routine_closure_body(&placeholders, &[], body)
             };
             let esc = self.escaping_position;
-            let cc_idx = self.code.add_closure_code(compiled, esc);
+            let cc_idx = self.add_closure_code_baked(compiled, esc);
             let idx = self.code.add_stmt(Stmt::Block(body.to_vec()));
             self.code
                 .emit(OpCode::MakeAnonSub(idx, Some(cc_idx), is_block));
@@ -192,7 +192,7 @@ impl Compiler {
             compiled.is_pointy_block = true;
         }
         let esc = self.escaping_position;
-        let cc_idx = self.code.add_closure_code(compiled, esc);
+        let cc_idx = self.add_closure_code_baked(compiled, esc);
         let idx = self.code.add_stmt(Stmt::SubDecl {
             name: Symbol::intern(""),
             name_expr: None,
@@ -269,7 +269,7 @@ impl Compiler {
             compiled.is_pointy_block = true;
         }
         let esc = self.escaping_position;
-        let cc_idx = self.code.add_closure_code(compiled, esc);
+        let cc_idx = self.add_closure_code_baked(compiled, esc);
         let idx = self.code.add_stmt(Stmt::SubDecl {
             name: Symbol::intern(""),
             name_expr: None,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -556,7 +556,7 @@ impl Compiler {
         let analysis = self.compile_closure_body(params, &[], body);
         self.compiled_functions
             .retain(|k, _| fn_keys_before.contains(k));
-        self.code.add_closure_code(analysis, true)
+        self.add_closure_code_baked(analysis, true)
     }
 
     /// Compile a closure body to a `CompiledCode` (not stored in compiled_functions).

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -418,6 +418,30 @@ impl Compiler {
         slot
     }
 
+    /// Store a finalized closure body in this frame's `closure_compiled_codes`,
+    /// first baking the CREATING frame's compile-time slot for each of the
+    /// closure's free variables / upvalues (`local_map` at this emit point) into
+    /// `free_var_parent_slots` / `upvalue_parent_slots`. Under
+    /// `MUTSU_SHADOW_SLOTS` a name can occupy several creator slots, so the
+    /// runtime capture paths must use the emit-point slot instead of an
+    /// `rposition` name search; with the gate off the baked data is inert
+    /// (§1.3 closure-capture slot bake). Scalar free vars are stored sigil-less
+    /// ("x") and `@`/`%`/`&` keep their sigil — the same convention `local_map`
+    /// uses, so a direct lookup lines up.
+    pub(super) fn add_closure_code_baked(&mut self, mut compiled: CompiledCode, esc: bool) -> u32 {
+        compiled.free_var_parent_slots = compiled
+            .free_var_syms
+            .iter()
+            .map(|sym| sym.with_str(|s| self.local_map.get(s).copied()))
+            .collect();
+        compiled.upvalue_parent_slots = compiled
+            .upvalue_syms
+            .iter()
+            .map(|sym| sym.with_str(|s| self.local_map.get(s).copied()))
+            .collect();
+        self.code.add_closure_code(compiled, esc)
+    }
+
     /// Record the compiler-authoritative positional-parameter → local-slot map
     /// into `code.param_local_slots`, so the VM's `precompute_param_local_slots`
     /// need not re-resolve parameter names by searching `locals` (§1.5).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1532,6 +1532,21 @@ pub(crate) struct CompiledCode {
     /// the entire (~100-entry) captured env. Empty until `compute_free_vars`
     /// runs (during `compute_needs_env_sync`).
     pub(crate) free_var_syms: Vec<Symbol>,
+    /// §1.3 closure-capture slot bake: parallel to `free_var_syms`, the CREATING
+    /// frame's compile-time local slot for each free variable (`local_map` at the
+    /// closure's emit point, baked by `Compiler::add_closure_code_baked`), or
+    /// `None` when the name is not a local there (an ancestor lexical / global).
+    /// Under `MUTSU_SHADOW_SLOTS` a name can occupy several creator slots, so the
+    /// runtime capture paths (`capture_closure_env`, `capture_upvalues`,
+    /// `box_captured_lexicals`) must resolve the emit-point slot, not an
+    /// `rposition` name search (which always picks the innermost shadow, wrong
+    /// for a closure created outside that shadow's block). Read only when shadow
+    /// slots are active; empty for hand-built chunks (falls back to the name
+    /// search).
+    pub(crate) free_var_parent_slots: Vec<Option<u32>>,
+    /// Parallel to `upvalue_syms`: the creating frame's compile-time local slot
+    /// for each upvalue, baked exactly like `free_var_parent_slots` (see there).
+    pub(crate) upvalue_parent_slots: Vec<Option<u32>>,
     /// Bare names this code reads through an `$OUTER::` reference (`$OUTER::x` →
     /// `x`). Populated by `compute_free_vars` from `GetOuterVar` ops. The closure
     /// snapshots each such name's captured enclosing value under a reserved
@@ -1703,6 +1718,8 @@ impl CompiledCode {
             needs_env_sync: Vec::new(),
             dup_named_locals: Vec::new(),
             free_var_syms: Vec::new(),
+            free_var_parent_slots: Vec::new(),
+            upvalue_parent_slots: Vec::new(),
             outer_ref_names: Vec::new(),
             free_var_writes: Vec::new(),
             free_var_container_writes: Vec::new(),

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -79,6 +79,32 @@ impl Interpreter {
         cc_idx.map(|i| code.closure_compiled_codes[i as usize].clone())
     }
 
+    /// Resolve the creating frame's local slot for a captured free var / upvalue
+    /// (`parent_slots[i]` parallel to the sym list, baked at the closure's emit
+    /// point by `Compiler::add_closure_code_baked`). With `MUTSU_SHADOW_SLOTS`
+    /// active the baked slot wins — a name can occupy several creator slots and
+    /// the `rposition` name search always picks the innermost shadow, which is
+    /// wrong for a closure created outside that shadow's block. Gated: with the
+    /// gate off (default / CI) this is byte-identical to the pre-campaign
+    /// `rposition` search. The baked slot is validated against the slot's name
+    /// (stale/hand-built chunks fall back to the search). §1.3 closure-capture
+    /// slot bake.
+    fn resolve_capture_slot(
+        code: &CompiledCode,
+        parent_slots: &[Option<u32>],
+        i: usize,
+        sym: crate::symbol::Symbol,
+    ) -> Option<usize> {
+        if crate::compiler::shadow_slots_active()
+            && let Some(baked) = parent_slots.get(i).copied().flatten()
+            && let Some(name) = code.locals.get(baked as usize)
+            && sym.with_str(|s| name == s)
+        {
+            return Some(baked as usize);
+        }
+        sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+    }
+
     pub(super) fn exec_make_anon_sub_op(
         &mut self,
         code: &CompiledCode,
@@ -342,8 +368,9 @@ impl Interpreter {
             // e.g. `-> $r { * ~~ /<$r>/ }` where `$r` is read only inside a stored
             // regex) can be missing from the cloned env. Pull this frame's
             // free-var slots from the live local store so such captures survive.
-            for sym in &cc.free_var_syms {
-                if let Some(slot) = sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+            for (i, sym) in cc.free_var_syms.iter().enumerate() {
+                if let Some(slot) =
+                    Self::resolve_capture_slot(code, &cc.free_var_parent_slots, i, *sym)
                     && let Some(val) = self.locals.get(slot)
                 {
                     flat.insert_sym(*sym, val.clone());
@@ -410,8 +437,8 @@ impl Interpreter {
         // Upvalue read: override this frame's own free-var slots with the live
         // local value. Authoritative even after the closure-driven env flush is
         // gone (a slot-only local is no longer mirrored into `env`).
-        for sym in &cc.free_var_syms {
-            if let Some(slot) = sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+        for (i, sym) in cc.free_var_syms.iter().enumerate() {
+            if let Some(slot) = Self::resolve_capture_slot(code, &cc.free_var_parent_slots, i, *sym)
                 && let Some(val) = self.locals.get(slot)
             {
                 map.insert(*sym, val.clone());
@@ -442,11 +469,12 @@ impl Interpreter {
         }
         cc.upvalue_syms
             .iter()
-            .map(|sym| {
+            .enumerate()
+            .map(|(i, sym)| {
                 // Resolve the creating frame's current binding: own local slot
                 // first (authoritative in the single-store model), then env.
                 let resolved = if let Some(slot) =
-                    sym.with_str(|s| code.locals.iter().rposition(|n| n == s))
+                    Self::resolve_capture_slot(code, &cc.upvalue_parent_slots, i, *sym)
                     && let Some(val) = self.locals.get(slot)
                 {
                     val.clone()
@@ -517,12 +545,24 @@ impl Interpreter {
         //       (`lives-ok {...}` / `map {...}`, call args / control blocks),
         //       bounding boxing cost and avoiding the broad-boxing perf blowup.
         // Read-only loop captures are handled by `owned_captures` (value-freeze).
+        // §1.3 (shadow slots only): a captured-and-mutated local whose name
+        // occupies MORE THAN ONE slot (a genuine inner-block shadow under
+        // `MUTSU_SHADOW_SLOTS`) must get a cell even when the closure does not
+        // escape: the non-cell coherence path writes the mutation back BY NAME
+        // (position = the outer slot), so a non-escaping closure over the inner
+        // shadow would update the wrong slot (S06-advanced/wrap.t). With the
+        // gate off `alloc_local` get-or-creates by name, so duplicates are
+        // structurally impossible and this is byte-identical.
+        let dup_shadow_possible =
+            crate::compiler::shadow_slots_active() && code.dup_named_locals.iter().any(|d| *d);
         if code.captured_mutated_locals.is_empty()
-            || (self.loop_local_vars.is_empty() && code.needs_cell_locals.is_empty())
+            || (self.loop_local_vars.is_empty()
+                && code.needs_cell_locals.is_empty()
+                && !dup_shadow_possible)
         {
             return;
         }
-        for sym in &cc.free_var_syms {
+        for (fv_i, sym) in cc.free_var_syms.iter().enumerate() {
             if !code.captured_mutated_locals.contains(sym) {
                 continue;
             }
@@ -541,9 +581,20 @@ impl Interpreter {
                 .loop_local_vars
                 .iter()
                 .any(|set| set.contains(s.as_str()));
+            // Emit-point slot (§1.3 slot bake, gated): the creator slot this
+            // closure actually captures. Falls back to the rposition name
+            // search (byte-identical with the gate off / for hand-built cc).
+            let baked_idx = Self::resolve_capture_slot(code, &cc.free_var_parent_slots, fv_i, *sym);
+            // Shadow trigger (C): the captured slot is one of several
+            // same-named slots — by-name writeback cannot disambiguate, so a
+            // cell is required regardless of the escape analysis (see the
+            // `dup_shadow_possible` gate above).
+            let is_dup_shadow = dup_shadow_possible
+                && baked_idx
+                    .is_some_and(|b| code.dup_named_locals.get(b).copied().unwrap_or(false));
             if !is_loop_local {
-                // Non-loop escaping path (B) only.
-                if !needs_cell {
+                // Non-loop escaping path (B) / shadow path (C) only.
+                if !needs_cell && !is_dup_shadow {
                     continue;
                 }
                 // A type/`where`-constrained scalar must keep flowing through
@@ -564,7 +615,7 @@ impl Interpreter {
                     continue;
                 }
             }
-            let Some(idx) = code.locals.iter().rposition(|n| *n == s) else {
+            let Some(idx) = baked_idx else {
                 continue;
             };
             let cur = &self.locals[idx];

--- a/t/shadow-slot-closure-capture.t
+++ b/t/shadow-slot-closure-capture.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# §1.3 closure-capture slot bake: a closure over a lexical that SHADOWS an
+# enclosing same-named binding must capture the inner (shadow) slot's cell,
+# even when the closure does not escape by the compiler's escape analysis
+# (e.g. passed as a call argument). Pin for S06-advanced/wrap.t tests 63/66.
+# Must pass with MUTSU_SHADOW_SLOTS unset (default) AND =1, and on real raku.
+
+plan 8;
+
+my $w = "outer-w";
+{
+    my $w;
+    my @cs;
+    @cs.push({ $w = "set-w"; });
+    @cs[0]();
+    is $w, "set-w", 'non-escaping closure (call arg) writes the inner shadow';
+}
+is $w, "outer-w", 'outer binding untouched by the inner-shadow write';
+
+# wrap.t shape: wrapper closure created in a for-loop body, invoked later
+# from the wrapped sub's call frame.
+my $wrapped = "outer-wrapped";
+{
+    sub meet($person)  { "meet $person" }
+    sub greet($person) { "greet $person" }
+    my $wrapped;
+    for &greet, &meet -> $wrap {
+        my $name = $wrap.name;
+        $wrap.wrap({ $wrapped = $name; callsame; });
+    }
+    is greet('a'), 'greet a', 'wrapped sub still works';
+    is $wrapped, 'greet', 'wrapper wrote the shadowed lexical (greet)';
+    is meet('b'), 'meet b', 'second wrapped sub still works';
+    is $wrapped, 'meet', 'wrapper wrote the shadowed lexical (meet)';
+}
+is $wrapped, "outer-wrapped", 'outer binding untouched by the wrappers';
+
+# Closure created BEFORE the shadow block captures the OUTER slot: the baked
+# emit-point slot must win over an innermost-name search.
+my $x = 1;
+my $c = { $x = 5; };
+{ my $x = 3; }
+$c();
+is $x, 5, 'pre-shadow closure writes the outer slot, not the later shadow';


### PR DESCRIPTION
## Summary

§1.3 slice 2 of the lexical-scope shadow-slot campaign ("make closure capture slot-addressed") — greens `S06-advanced/wrap.t` under `MUTSU_SHADOW_SLOTS=1`.

**Root cause of the wrap.t toggle-ON failures (tests 63/66):** a closure passed as a call argument (`.wrap({...})`, `@cs.push({...})`) is classified non-escaping by the escape analysis, so `box_captured_lexicals` never gives its captured-and-mutated lexical a shared `ContainerRef` cell. The non-cell coherence path writes the mutation back **by name** (position = the outer slot), so a closure over an inner shadow updates the wrong slot.

## Changes (all gated on `shadow_slots_active()`; OFF is byte-identical)

1. **Emit-point capture slots.** `Compiler::add_closure_code_baked` (the single `add_closure_code` chokepoint, 6 call sites) bakes the parent `local_map` slot for every child `free_var_syms`/`upvalue_syms` entry into new `CompiledCode::free_var_parent_slots`/`upvalue_parent_slots`. The four runtime capture resolvers (`capture_closure_env` ×2, `capture_upvalues`, `box_captured_lexicals`) resolve through the shared `resolve_capture_slot` helper: baked slot first (validated against the slot name), `rposition` fallback. This also fixes the latent pre-shadow hazard — `rposition` always picks the *innermost* same-named slot, wrong for a closure created before the shadow's block.
2. **Shadow boxing trigger (path C).** A captured-and-mutated scalar whose baked slot is dup-named (`code.dup_named_locals`, from S12) gets a cell regardless of the escape analysis — by-name writeback cannot disambiguate duplicate names, and the shared cell is the sound mechanism (the roles-6e.t lesson). The `box_captured_lexicals` early-return gate gains a matching `dup_shadow_possible` arm.

With the gate off, duplicate names are structurally impossible (`alloc_local` get-or-creates by name) and `resolve_capture_slot` reduces to the old `rposition` search.

## Toggle-ON results

- `S06-advanced/wrap.t` **90/90** (was 88/90)
- `S02-types/whatever.t` and `S02-types/hash.t` now pass ON too (same capture root cause)
- Remaining ON regressions: `S32-array/perl.t` #7 (AssignExprLocal `@`/`%` parity, known) and `t/outer-topic.t` #4 (pre-existing on main)

## Validation

- OFF: full `make test` PASS (Files=1636, release), plus 17 closure-heavy whitelisted roast files (S03-binding/closure.t, let/temp/pointy, S05 closure interpolation, S06 callsame/dispatching/lexical-subs/closure-params, perl.t, whatever.t, metaoperators.t) all PASS
- ON: full `prove t/` green except the pre-existing `outer-topic.t` #4 (fails on main ON too; `io-socket-recv-limit.t` failed once under `-j4` load, passes 3× standalone)
- Pin test `t/shadow-slot-closure-capture.t` passes OFF, ON, and on real raku

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW