### PR TITLE
fix(vm): bake emit-point outer-binding slot onto GetOuterVar (§1.3 S14)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -212,7 +212,48 @@ broadcast = touches every slot with the name.
       (AssignExprLocal `@`/`%` parity) remains, plus pre-existing
       `outer-topic.t` #4. Pin: `t/shadow-slot-closure-capture.t` (OFF, ON, and
       real raku). *(this branch)*
-- [ ] S14+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
+- [x] **S14 — `$OUTER::name` slot bake.** Under shadow slots, `get_outer_var`'s
+      inline nested-block path searched `code.locals` by `position` (the
+      OUTERMOST same-named slot), so `$OUTER::a` at depth 1 of a triple shadow
+      returned the outermost binding (`variables-and-packages.t` #10/#15; the
+      depth-2 `$OUTER::OUTER::a` only passed by coincidence). The compiler now
+      resolves the emit-point slot of the binding visible `depth` scopes out by
+      unwinding the `local_scopes` shadow records (`resolve_outer_var_slot`:
+      each frame that declares the name stores its pre-declaration slot, so
+      unwinding the frames deeper than the target scope yields the target's
+      slot; `None` when the depth crosses the frame boundary or the name is
+      first-declared deeper) and bakes it onto `GetOuterVar`. The runtime
+      (gated ON) returns the LIVE `self.locals[slot]` — with shadow slots each
+      binding owns its slot, so the live value IS the outer binding, matching
+      raku's live-binding semantics with no snapshot indexing at all; OFF stays
+      on the existing snapshot/env paths byte-identically. ON green:
+      `variables-and-packages.t` 39/39 AND `t/outer-topic.t` #4 (the
+      `$OUTER::_` read — the toggle-ON `prove t/` suite is now fully green).
+      Pin: `t/shadow-slot-outer-var.t` (OFF, ON, real raku). Known pre-existing
+      default-build gaps left as-is (they fail OFF on main identically):
+      depth-2 access in a second block group, `$OUTER::` from a block that
+      doesn't declare the name, and `$OUTER::` seeing post-entry mutations
+      (raku reads the live binding; the OFF snapshot path reads block-entry
+      values). *(this branch)*
+
+## Fresh full toggle-ON survey (2026-07-10, post-S13, release, 1373 files)
+
+Only **4 genuine ON failures** remain; all were verified pre-existing on `main`
+(A/B via `git checkout main -- src/` + rebuild — S13 introduced zero
+regressions). Earlier surveys re-probed only the survey-#2 regression set, so
+three of these were missed until now — re-run the FULL survey periodically.
+
+- `S02-names-vars/variables-and-packages.t` #10/#15 — `$OUTER::a` × shadow
+  (**fixed by S14**, this branch)
+- `S04-declarations/state.t` #13 — `(state @foo) = @bar` paren-decl lvalue ×
+  shadow
+- `integration/advent2013-day12.t` #11/31-32 — `@a[2,3,4]` slice + `is default`
+  under ON returns the default for all elements
+- `S32-array/perl.t` #7 — known (#4086 AssignExprLocal `@`/`%` attr-mirror
+  parity; bad-plan abort)
+- (`t/` side: only `outer-topic.t` #4, pre-existing)
+
+- [ ] S15+ — remaining leaf `update_local_if_exists`/`find_local_slot` sites: the
       nested/deep/generic index-assign
       variants (`IndexAssignExprNested`/`DeepNested`/`Generic`), computed-attr twigil
       cells, hyper `»=»` multi-key writeback, and the remaining `update_local_if_exists`

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -549,10 +549,12 @@ impl Compiler {
         }
         // $OUTER:: / $OUTER::OUTER:: variable access
         if let Some((bare_name, depth)) = Self::parse_outer_prefix(name) {
+            let slot = self.resolve_outer_var_slot(&bare_name, depth);
             let name_idx = self.code.add_constant(Value::str(bare_name));
             self.code.emit(OpCode::GetOuterVar {
                 name_idx,
                 depth: depth as u32,
+                slot,
             });
             return;
         }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -442,6 +442,33 @@ impl Compiler {
         self.code.add_closure_code(compiled, esc)
     }
 
+    /// Resolve the local slot of the binding of `name` visible `depth` lexical
+    /// scopes out from the current one (`$OUTER::name` = depth 1), by unwinding
+    /// the shadow records in `local_scopes`: each frame that declares `name`
+    /// stores the pre-declaration slot (`Some(outer)` for a genuine ancestor
+    /// shadow, `None` for a first declaration), so unwinding the frames deeper
+    /// than the target scope leaves the slot the target scope sees. Returns
+    /// `None` when the depth crosses this frame's boundary or the name is not
+    /// a local binding at that scope (the runtime falls back to its existing
+    /// by-name / env resolution). §1.3 S14 (GetOuterVar slot bake) — only
+    /// meaningful under `MUTSU_SHADOW_SLOTS` (the default build records `None`
+    /// for every declaration, so this resolves `None` whenever a shadow is
+    /// involved, and the runtime read is gated anyway).
+    fn resolve_outer_var_slot(&self, name: &str, depth: usize) -> Option<u32> {
+        let n = self.local_scopes.len();
+        if depth >= n {
+            return None;
+        }
+        let target = n - 1 - depth;
+        let mut slot = self.local_map.get(name).copied();
+        for frame in self.local_scopes[target + 1..].iter().rev() {
+            if let Some(prev) = frame.get(name) {
+                slot = *prev;
+            }
+        }
+        slot
+    }
+
     /// Record the compiler-authoritative positional-parameter → local-slot map
     /// into `code.param_local_slots`, so the VM's `precompute_param_local_slots`
     /// need not re-resolve parameter names by searching `locals` (§1.5).

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1382,9 +1382,17 @@ pub(crate) enum OpCode {
 
     /// Get a variable from an outer lexical scope ($OUTER::varname).
     /// `depth` indicates how many OUTER:: prefixes (1 = $OUTER::x, 2 = $OUTER::OUTER::x).
+    /// `slot` is the emit-point local slot of the binding visible `depth` lexical
+    /// scopes out (resolved by walking the compiler's `local_scopes` shadow
+    /// records; §1.3 S14). `None` = the name is not a local binding there (it
+    /// crosses a frame boundary, or is first declared deeper than the target
+    /// scope). Read only under `MUTSU_SHADOW_SLOTS`: with shadow slots a name
+    /// occupies several `locals` slots and the runtime's position search always
+    /// picks the outermost, wrong for any depth short of the outermost binding.
     GetOuterVar {
         name_idx: u32,
         depth: u32,
+        slot: Option<u32>,
     },
 
     /// Get a variable by searching the dynamic call stack ($DYNAMIC::varname).

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4042,9 +4042,13 @@ impl Interpreter {
                 self.bind_caller_var(target, source, *depth as usize)?;
                 *ip += 1;
             }
-            OpCode::GetOuterVar { name_idx, depth } => {
+            OpCode::GetOuterVar {
+                name_idx,
+                depth,
+                slot,
+            } => {
                 let name = Self::const_str(code, *name_idx);
-                let val = self.get_outer_var(code, name, *depth as usize);
+                let val = self.get_outer_var(code, name, *depth as usize, *slot);
                 self.stack.push(val);
                 *ip += 1;
             }

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -349,9 +349,28 @@ impl Interpreter {
     /// Get a variable from an outer lexical scope.
     /// `depth` is the number of OUTER:: prefixes (1 = immediate outer, 2 = two levels up).
     /// Uses the `outer_scope_locals` stack which is populated by BlockScope operations.
-    pub(super) fn get_outer_var(&self, code: &CompiledCode, name: &str, depth: usize) -> Value {
+    pub(super) fn get_outer_var(
+        &self,
+        code: &CompiledCode,
+        name: &str,
+        depth: usize,
+        slot: Option<u32>,
+    ) -> Value {
         if depth == 0 {
             return Value::NIL;
+        }
+        // §1.3 S14 (shadow slots only): the compiler baked the emit-point slot
+        // of the binding visible `depth` scopes out (resolve_outer_var_slot).
+        // With shadow slots each binding owns its slot, so the LIVE local value
+        // IS the outer binding — no snapshot indexing, and no position search
+        // (which picks the outermost same-named slot, wrong for depth < max).
+        // Gated: the default build never bakes a meaningful slot for shadows
+        // (declaration records are all `None`), and stays on the paths below.
+        if crate::compiler::shadow_slots_active()
+            && let Some(b) = slot
+            && let Some(val) = self.locals.get(b as usize)
+        {
+            return val.clone();
         }
         let stack_len = self.outer_scope_locals.len();
         // Inline nested-block path: `outer_scope_locals` (runtime-saved slots)

--- a/t/shadow-slot-outer-var.t
+++ b/t/shadow-slot-outer-var.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# §1.3 S14: $OUTER::name must resolve the binding visible exactly `depth`
+# lexical scopes out. Under MUTSU_SHADOW_SLOTS each shadow owns a distinct
+# local slot and the runtime's by-name position search picks the OUTERMOST
+# slot, wrong for depth 1 of a triple shadow — the compiler now bakes the
+# emit-point slot onto GetOuterVar. Pin for
+# roast/S02-names-vars/variables-and-packages.t tests 10/15.
+# Must pass with MUTSU_SHADOW_SLOTS unset (default) AND =1, and on real raku.
+
+plan 5;
+
+{ my $a = 1; {
+   my $a=2; {
+      my $a=3;
+      is $a, 3,               'innermost shadow';
+      is $OUTER::a, 2,        '$OUTER::a is the middle binding';
+      is $OUTER::OUTER::a, 1, '$OUTER::OUTER::a is the outermost binding';
+}}}
+
+# same shape, different name + post-block restore check. (Depth-2 access in a
+# SECOND block group, and depth access from a block that does not itself
+# declare the name, both go through pre-existing default-build snapshot quirks
+# that are wrong even without shadow slots — out of scope for this pin.)
+{ my $b = 10; {
+    my $b = 20; {
+        my $b = 30;
+        is $OUTER::b, 20, '$OUTER::b sees the enclosing shadow';
+    }
+    is $b, 20, 'enclosing shadow unchanged after the inner block';
+}}


### PR DESCRIPTION
## Summary

§1.3 S14 of the lexical-scope shadow-slot campaign — greens `S02-names-vars/variables-and-packages.t` (39/39) and `t/outer-topic.t` under `MUTSU_SHADOW_SLOTS=1`, making the toggle-ON `prove t/` suite fully green.

**Root cause:** under shadow slots, `get_outer_var`'s inline nested-block path searched `code.locals` by `position` (the OUTERMOST same-named slot), so `$OUTER::a` at depth 1 of a triple shadow returned the outermost binding instead of the middle one (tests 10/15; the depth-2 `$OUTER::OUTER::a` only passed by coincidence).

## Changes (runtime read gated on `shadow_slots_active()`; OFF byte-identical)

- **Compiler:** `resolve_outer_var_slot` resolves the emit-point slot of the binding visible `depth` lexical scopes out by unwinding the `local_scopes` shadow records (each frame that declares the name stores its pre-declaration slot; unwinding the frames deeper than the target scope yields the slot the target scope sees; `None` when the depth crosses the frame boundary or the name is first declared deeper). Baked onto the `GetOuterVar` opcode.
- **VM:** the gated read returns the LIVE `self.locals[slot]` — with shadow slots each binding owns its own slot, so the live value IS the outer binding: no snapshot indexing, and matches raku's live-binding semantics. With the gate off the baked slot is never read and the existing snapshot/env paths run unchanged.
- Documents the fresh full toggle-ON survey (post-S13, 1373 files, 4 genuine failures — all verified pre-existing on main) and the known pre-existing default-build `$OUTER::` gaps (identical on main) in docs/lexical-scope-slot-campaign.md.

## Validation

- OFF: full `make test` PASS (Files=1638, release); all 7 whitelisted roast files that use `OUTER` PASS (`SETTING-6e.t`, `dollar-underscore.t`, `variables-and-packages.t`, `implicit-parameter.t`, `introspection.t`, `definite-return.t`, `misc2.t`)
- ON: full `prove t/` green (`io-socket-recv-limit.t` failed once under `-j4` load only, passes standalone); `variables-and-packages.t` 39/39; `outer-topic.t` #4 fixed (the `$OUTER::_` read), 3× stable
- Pin `t/shadow-slot-outer-var.t` passes OFF, ON, and on real raku

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW