### PR TITLE
fix(vm): correct self binding in inline protect blocks + zef-fetch pipeline fixes

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -486,6 +486,15 @@ pub(crate) fn native_method_0arg(
         {
             return Some(Ok(Value::str(raku_repr::raku_value(target))));
         }
+        // A `.^set_name`-renamed anonymous mixin reports its friendly name for
+        // `.^name` (e.g. `Foo.new but role {...}` then `.^set_name('X')` — used
+        // by zef's plugin loader). Without this the caret-name would delegate to
+        // the inner value and report the un-renamed base type.
+        if method == "^name"
+            && let Some(name_val) = mixins.get("__mutsu_type_name__")
+        {
+            return Some(Ok(name_val.clone()));
+        }
         // Check for mixin key matching the method name (e.g. "Array", "List", "Int", etc.)
         // This handles `True but [1, 2]` where `.Array` should return the mixed-in array.
         if let Some(mixin_val) = mixins.get(method) {

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -178,6 +178,7 @@ impl Interpreter {
                 "name"
                     | "auth"
                     | "version"
+                    | "osname"
                     | "precomp-ext"
                     | "precomp-target"
                     | "prefix"

--- a/src/runtime/io_sysinfo.rs
+++ b/src/runtime/io_sysinfo.rs
@@ -374,6 +374,14 @@ impl Interpreter {
             }),
         );
         attrs.insert("desc".to_string(), Value::str_from("mutsu virtual machine"));
+        // osname mirrors the build-time OS name MoarVM exposes via `$*VM.osname`
+        // (e.g. "linux", "darwin", "mswin32"); zef branches on it (tar/CLI).
+        let osname = match std::env::consts::OS {
+            "macos" => "darwin",
+            "windows" => "mswin32",
+            other => other,
+        };
+        attrs.insert("osname".to_string(), Value::str_from(osname));
         attrs.insert("precomp-ext".to_string(), Value::str_from("mutsu"));
         attrs.insert("precomp-target".to_string(), Value::str_from("mutsu"));
         attrs.insert("prefix".to_string(), Value::str_from("mutsu"));

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -8,13 +8,66 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         match method {
+            "set_name" if args.len() == 2 => {
+                // `$type.^set_name($name)` renames a metaobject (Rakudo's ClassHOW
+                // method). It is most often applied to a freshly-composed
+                // anonymous type, e.g. `Foo.new but role {...}`, to give it a
+                // human-readable name for display. Persist the name so a later
+                // `.^name` returns it.
+                let new_name = args[1].to_string_value();
+                match args[0].view() {
+                    ValueView::Mixin(_, overrides) => {
+                        // Store the friendly name on the shared overrides map so a
+                        // later `.^name` on any alias of this mixed-in object
+                        // returns it. The metamethod receives a clone of the
+                        // invocant, but the clone shares the overrides `Arc`, so an
+                        // in-place write reaches the caller's value too — matching
+                        // Rakudo's in-place mutation of the anonymous metaobject.
+                        // SAFETY: aliased in-place mutation of a shared container
+                        // (see `arc_contents_mut`); no borrow into the map is live
+                        // across the insert.
+                        let map = unsafe { crate::value::arc_contents_mut(overrides) };
+                        map.insert(
+                            "__mutsu_type_name__".to_string(),
+                            Value::str(new_name.clone()),
+                        );
+                    }
+                    ValueView::Package(name) => {
+                        self.type_metadata
+                            .entry(name.resolve())
+                            .or_default()
+                            .insert("__set_name__".to_string(), Value::str(new_name.clone()));
+                    }
+                    ValueView::Instance { class_name, .. } => {
+                        self.type_metadata
+                            .entry(class_name.resolve())
+                            .or_default()
+                            .insert("__set_name__".to_string(), Value::str(new_name.clone()));
+                    }
+                    _ => {}
+                }
+                Ok(Value::str(new_name))
+            }
             "name" if args.len() == 1 => Ok(Value::str(match args[0].view() {
-                ValueView::Package(name) => {
-                    crate::value::user_facing_type_name(&name.resolve()).to_string()
+                ValueView::Mixin(_, overrides) if overrides.contains_key("__mutsu_type_name__") => {
+                    overrides["__mutsu_type_name__"].to_string_value()
                 }
-                ValueView::Instance { class_name, .. } => {
-                    crate::value::user_facing_type_name(&class_name.resolve()).to_string()
-                }
+                ValueView::Package(name) => self
+                    .type_metadata
+                    .get(&name.resolve())
+                    .and_then(|m| m.get("__set_name__"))
+                    .map(Value::to_string_value)
+                    .unwrap_or_else(|| {
+                        crate::value::user_facing_type_name(&name.resolve()).to_string()
+                    }),
+                ValueView::Instance { class_name, .. } => self
+                    .type_metadata
+                    .get(&class_name.resolve())
+                    .and_then(|m| m.get("__set_name__"))
+                    .map(Value::to_string_value)
+                    .unwrap_or_else(|| {
+                        crate::value::user_facing_type_name(&class_name.resolve()).to_string()
+                    }),
                 ValueView::ParametricRole {
                     base_name,
                     type_args,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -595,11 +595,17 @@ impl Interpreter {
                         return Err(RuntimeError::new("Cannot install on CUR::FileSystem"));
                     }
                     "need" => {
-                        let short_name = match args.first().map(Value::view) {
-                            Some(ValueView::CompUnitDepSpec { short_name }) => short_name,
-                            _ => return Ok(Value::NIL),
-                        };
-                        let short_name_str = short_name.resolve();
+                        // A depspec may arrive either as the native `CompUnitDepSpec`
+                        // value (short-name only) or as a full
+                        // `CompUnit::DependencySpecification` instance carrying
+                        // auth/api/version matchers (zef's plugin loader builds the
+                        // latter). Extract the short-name from either form; the
+                        // FileSystem repo resolves purely by name.
+                        let depspec = args.first().cloned().unwrap_or(Value::NIL);
+                        let (short_name_str, ..) = self.extract_depspec_fields(&depspec);
+                        if short_name_str.is_empty() {
+                            return Ok(Value::NIL);
+                        }
                         let prefix = attributes
                             .as_map()
                             .get("prefix")

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -29,6 +29,7 @@ impl Interpreter {
                 | "compose"
                 | "archetypes"
                 | "name"
+                | "set_name"
                 | "ver"
                 | "auth"
                 | "api"

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -173,7 +173,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "name" | "auth" | "version" | "precomp-ext" | "precomp-target" | "prefix" | "desc"
-            | "signature" | "config" | "properties" => {
+            | "signature" | "config" | "properties" | "osname" => {
                 Ok(attributes.get(method).cloned().unwrap_or(Value::NIL))
             }
             "raku" => {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1028,6 +1028,7 @@ impl Interpreter {
                     "name",
                     "auth",
                     "version",
+                    "osname",
                     "precomp-ext",
                     "precomp-target",
                     "request-garbage-collection",

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -306,6 +306,7 @@ mod value_methods_c;
 mod value_setbagmix;
 mod view;
 pub(crate) use crate::gc::gc_contents_mut;
+pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use aliased_mut::gc_data_mut;
 pub(crate) use types::what_type_name;
 pub use view::ValueView;

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -161,6 +161,25 @@ impl Interpreter {
             }
         }
 
+        // Bind `self` for the block to the *enclosing* method's invocant. The
+        // block runs inline in the current env, and a free `self` read
+        // (GetSelfOrNoSelf / a bare `self!priv` invocant) consults env "self".
+        // Without this, env "self" still holds the OUTER caller's self — e.g.
+        // `Repo.update` calls `$fetcher.fetch`, whose `$lock.protect: {...}`
+        // block does `self!try-load`, and self would wrongly resolve to the Repo
+        // rather than the Fetch that lexically encloses the block. Prefer the
+        // enclosing frame's `self` local, then the block's captured env.
+        let enclosing_self = outer_local_slots
+            .get("self")
+            .and_then(|s| saved_locals.get(*s))
+            .filter(|v| !matches!(v.view(), ValueView::Nil))
+            .cloned()
+            .or_else(|| captured_env.and_then(|e| e.get("self").cloned()));
+        let saved_self = self.get_env_with_main_alias("self");
+        if let Some(ref s) = enclosing_self {
+            self.set_env_with_main_alias("self", s.clone());
+        }
+
         // Execute the block's opcodes inline
         let mut sub_ip = 0;
         let mut exec_err = None;
@@ -213,6 +232,14 @@ impl Interpreter {
                         self.env_mut().insert(name.clone(), __v);
                     }
                 }
+            }
+        }
+
+        // Restore the caller's `self` binding (see the enclosing-self setup above).
+        match saved_self {
+            Some(s) => self.set_env_with_main_alias("self", s),
+            None => {
+                self.env_mut().remove("self");
             }
         }
 

--- a/t/lib-need-instance/NeedMe.rakumod
+++ b/t/lib-need-instance/NeedMe.rakumod
@@ -1,0 +1,2 @@
+unit module NeedMe;
+sub need-me-marker() is export { 42 }

--- a/t/metamodel-set-name.t
+++ b/t/metamodel-set-name.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 6;
+
+# `.^set_name` renames a metaobject; most often applied to a freshly-composed
+# anonymous type (e.g. `Foo.new but role {...}`) to give it a readable name.
+
+class Foo { has $.x = 1; }
+
+my $obj = Foo.new but role :: { has $.tag = 'hello' };
+is $obj.^name, 'Foo', 'mixed-in object reports its base name before set_name';
+
+my $ret = $obj.^set_name('MyFriendlyName');
+is $ret, 'MyFriendlyName', 'set_name returns the new name';
+is $obj.^name, 'MyFriendlyName', '.^name reflects the set name';
+is $obj.HOW.name($obj), 'MyFriendlyName', 'HOW.name reflects the set name';
+
+# The mixed-in attribute still works after renaming.
+is $obj.tag, 'hello', 'mixed-in role attribute survives set_name';
+
+# An alias sharing the same object observes the rename (in-place metaobject).
+my $alias = $obj;
+is $alias.^name, 'MyFriendlyName', 'aliased object observes the rename';

--- a/t/protect-block-self.t
+++ b/t/protect-block-self.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+plan 3;
+
+# A block passed to `Lock.protect` runs inline, but `self` inside it must bind
+# to the method that lexically encloses the block — not to whatever outer caller
+# invoked the method. This mirrors zef's Pluggable role: `Repo.update` calls
+# `$fetcher.plugins`, whose `$lock.protect: { ... self!try-load ... }` must see
+# the Fetch as `self`, not the Repo.
+
+role Pluggable {
+    has @.backends;
+    has $!plugins;
+    has $!lock = Lock.new;
+    method plugins { return self!list-plugins }
+    method !list-plugins(@backends = @!backends) {
+        $!lock.protect: {
+            return $!plugins if $!plugins.so;
+            my @plugins;
+            for @backends -> $b {
+                if self!try-load($b) -> $c { push @plugins, $c }
+            }
+            return $!plugins := @plugins;
+        }
+    }
+    method !try-load($plugin) { return "{$plugin}-loaded"; }
+}
+
+class Fetch does Pluggable {
+    method fetch { return self.plugins }
+    method whoami-in-protect {
+        my $lock = Lock.new;
+        return $lock.protect: { self.^name };
+    }
+}
+
+class Repo {
+    has $.fetcher;
+    method update { return $.fetcher.fetch }
+    method who { return $.fetcher.whoami-in-protect }
+}
+
+my $r = Repo.new(fetcher => Fetch.new(backends => ['a', 'b']));
+is-deeply $r.update, ['a-loaded', 'b-loaded'],
+    'private method called via self inside a nested protect block resolves on the enclosing invocant';
+
+is $r.who, 'Fetch',
+    '`self` inside a protect block is the enclosing method invocant, not the outer caller';
+
+# Direct call (no outer wrapper) still works.
+is $r.fetcher.whoami-in-protect, 'Fetch',
+    '`self` inside a protect block is correct on a direct call too';

--- a/t/repo-need-depspec.t
+++ b/t/repo-need-depspec.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 4;
+
+# `$*REPO.need($spec)` must accept a CompUnit::DependencySpecification that
+# carries auth/api/version matchers (an object instance), not only the bare
+# short-name form. zef's plugin loader builds the matcher-bearing form for every
+# plugin, so a FileSystem repo that rejected it left zef unable to load any
+# fetch/repository backend.
+
+use lib $?FILE.IO.parent.add('lib-need-instance').Str;
+
+my $spec = CompUnit::DependencySpecification.new(
+    short-name      => 'NeedMe',
+    auth-matcher    => True,
+    api-matcher     => '*',
+    version-matcher => '*',
+);
+
+isa-ok $spec, CompUnit::DependencySpecification,
+    'a matcher-bearing depspec is a CompUnit::DependencySpecification';
+is $spec.short-name, 'NeedMe', 'the depspec exposes its short-name';
+
+my $cu = $*REPO.need($spec);
+ok $cu.defined, '$*REPO.need resolves a matcher-bearing depspec from the FileSystem repo';
+
+# The bare short-name form keeps working too.
+my $cu2 = $*REPO.need(CompUnit::DependencySpecification.new(short-name => 'NeedMe'));
+ok $cu2.defined, '$*REPO.need still resolves the bare short-name form';

--- a/t/vm-osname.t
+++ b/t/vm-osname.t
@@ -1,0 +1,9 @@
+use v6;
+use Test;
+
+plan 3;
+
+# `$*VM.osname` exposes the build-time OS name (zef branches on it).
+ok $*VM.osname.defined, '$*VM.osname is defined';
+isa-ok $*VM.osname, Str, '$*VM.osname is a Str';
+ok $*VM.osname.chars > 0, '$*VM.osname is non-empty';


### PR DESCRIPTION
Driving the real zef CLI (`zef list`) toward a live network fetch surfaced a chain of four general interpreter bugs. Each is a standalone correctness fix, verified with a new focused test.

## Fixes

1. **`self` mis-bound inside inline `Lock.protect` blocks** (`vm_call_method_compiled.rs`)
   `exec_protect_block_inline` runs the block inline in the current env, but a free `self` read (or a bare `self!priv` invocant) consulted env `"self"`, which still held the *outer* caller's self. So `Repo.update` → `$fetcher.plugins`, whose `$lock.protect: { ... self!try-load ... }` block does a private-method self-dispatch, resolved `self` to the `Repo` rather than the `Fetch` that lexically encloses the block (`No such private method 'try-load'`). Now binds the block's `self` to the enclosing frame's invocant (falling back to the block's captured env) and restores it afterwards. This is the load-bearing fix for zef's `Pluggable` role.

2. **`CompUnit::Repository::FileSystem.need` rejected matcher-bearing depspecs** (`methods_instance_ops.rs`)
   The handler only matched the native `CompUnitDepSpec` (short-name only) and returned `Nil` for a full `CompUnit::DependencySpecification` instance carrying auth/api/version matchers — exactly what zef's plugin loader builds for every plugin. Now extracts the short-name from either form.

3. **`.^set_name` (`Perl6::Metamodel::ClassHOW`) was unimplemented** (`methods_classhow_dispatch.rs`, `methods_0arg/mod.rs`)
   Implemented so `$type.^set_name($name)` renames a metaobject. For a `Foo.new but role {...}` mixin the name is stored on the shared overrides map (so `.^name` on any alias observes the rename, matching Rakudo's in-place metaobject mutation); for a named type it lands in `type_metadata`.

4. **`$*VM.osname` was missing** (`io_sysinfo.rs`, `native_methods/system.rs`, …)
   Added, mirroring the build-time OS name MoarVM exposes (`macos`→`darwin`, `windows`→`mswin32`, else the raw OS). zef branches on it.

## Tests

- `t/protect-block-self.t`
- `t/repo-need-depspec.t` (+ `t/lib-need-instance/NeedMe.rakumod`)
- `t/metamodel-set-name.t`
- `t/vm-osname.t`

`make test` passes (1639 files, 16153 tests); local lock/protect + roast S12 private / S14 roles tests pass.

## Follow-ups (not in this PR)

`zef list` still doesn't complete the fetch; the next blockers are separate module-system issues: a tagged export (`is export(:internals)`) imported *inside* a module isn't visible to that module's own methods, and `$*HOME` interpolates literally in a config-derived cache path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)