### PR TITLE
fix(vm): keep (state @x) = ... paren-decl assignment by-name under shadow slots (§1.3 S15)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -236,6 +236,23 @@ broadcast = touches every slot with the name.
       (raku reads the live binding; the OFF snapshot path reads block-entry
       values). *(this branch)*
 
+- [x] **S15 — `(state @foo) = @bar` paren-decl assignment must stay by-name.**
+      Under shadow slots the parenthesized-declaration lvalue store
+      (`__mutsu_assign_callable_lvalue` branch 1, from #4086) emitted
+      `AssignExprLocal(slot)` — but a state AGGREGATE lives in a shared
+      `ContainerRef` cell (StateVarInit) aliased by the persisted state store,
+      and `exec_assign_expr_local_op` deliberately REPLACES the slot for
+      `@`/`%` targets (whole-reassignment semantics; cell write-through is
+      scalar-only, `vm_var_assign_local.rs`). The replace detached the slot
+      from the persisted cell, so the next call restored the stale cell and
+      the per-call reassignment was lost (`state.t` #13 ON: second call
+      returned the mutated previous contents). Fix: when the paren-decl is
+      `is_state`, always emit the by-name `AssignExpr` (what the default build
+      emits anyway — byte-identical OFF), which writes through the state cell;
+      state shadowing stays coherent via cell identity, not slot position.
+      ON green: `S04-declarations/state.t` 46/46. Pin:
+      `t/shadow-slot-state-paren-decl.t` (OFF, ON, real raku). *(this branch)*
+
 ## Fresh full toggle-ON survey (2026-07-10, post-S13, release, 1373 files)
 
 Only **4 genuine ON failures** remain; all were verified pre-existing on `main`
@@ -246,7 +263,7 @@ three of these were missed until now — re-run the FULL survey periodically.
 - `S02-names-vars/variables-and-packages.t` #10/#15 — `$OUTER::a` × shadow
   (**fixed by S14**, this branch)
 - `S04-declarations/state.t` #13 — `(state @foo) = @bar` paren-decl lvalue ×
-  shadow
+  shadow (**fixed by S15**, this branch)
 - `integration/advent2013-day12.t` #11/31-32 — `@a[2,3,4]` slice + `is default`
   under ON returns the default for all elements
 - `S32-array/perl.t` #7 — known (#4086 AssignExprLocal `@`/`%` attr-mirror

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -39,8 +39,13 @@ impl Compiler {
         if name == "__mutsu_assign_callable_lvalue"
             && args.len() == 3
             && let Expr::DoStmt(stmt) = &args[0]
-            && let Stmt::VarDecl { name: var_name, .. } = stmt.as_ref()
+            && let Stmt::VarDecl {
+                name: var_name,
+                is_state,
+                ..
+            } = stmt.as_ref()
         {
+            let is_state = *is_state;
             // 1. Compile the VarDecl (handles state init)
             self.compile_stmt(stmt);
             // VarDecl doesn't push to stack, so no pop needed.
@@ -50,8 +55,26 @@ impl Compiler {
             self.code.emit(OpCode::Dup);
             // 4. Assign to the variable (prefer the baked slot so a `(my $a)`
             //    that shadows an enclosing `$a` writes its own slot — §1.4).
+            //    EXCEPTION: a `(state @x) = …` / `(state %x)` target must stay
+            //    on the by-name `AssignExpr` even under shadow slots (§1.3 S15):
+            //    a state aggregate lives in a shared `ContainerRef` cell
+            //    (StateVarInit) that the persisted state store, the slot, and
+            //    the env all alias, and the by-name assign writes THROUGH that
+            //    cell. `AssignExprLocal` deliberately REPLACES the slot for
+            //    `@`/`%` targets (whole-reassignment semantics), detaching the
+            //    slot from the persisted cell — the next call then restores the
+            //    stale cell and the per-call reassignment is lost
+            //    (S04-declarations/state.t #13). By-name is what the default
+            //    build emits anyway, so this is byte-identical OFF; state var
+            //    shadowing stays coherent through cell identity, not slot
+            //    position.
             let var_name = var_name.clone();
-            self.emit_assign_local_or_name(&var_name);
+            if is_state {
+                let name_idx = self.code.add_constant(Value::str(var_name));
+                self.code.emit(OpCode::AssignExpr(name_idx));
+            } else {
+                self.emit_assign_local_or_name(&var_name);
+            }
             return;
         } else if name == "__mutsu_assign_callable_lvalue"
             && args.len() == 3

--- a/t/shadow-slot-state-paren-decl.t
+++ b/t/shadow-slot-state-paren-decl.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# §1.3 S15: `(state @foo) = @bar` reassigns the state aggregate on EVERY call
+# (unlike `state @foo = @bar`, which initializes once). The state aggregate
+# lives in a shared ContainerRef cell aliased by the persisted state store;
+# the parenthesized-declaration assignment must write THROUGH that cell, not
+# replace the local slot (which detaches it from the store, so the next call
+# restores the stale cell and the reassignment is lost). Pin for
+# roast/S04-declarations/state.t #13 under MUTSU_SHADOW_SLOTS=1.
+# Must pass with MUTSU_SHADOW_SLOTS unset (default) AND =1, and on real raku.
+
+plan 5;
+
+my @bar = 1, 2, 3;
+sub swatest {
+    (state @foo) = @bar;
+    my $x = @foo.join('|');
+    @foo[0]++;
+    return $x;
+}
+is swatest(), '1|2|3', '(state @foo) = @bar assigns on first call';
+is swatest(), '1|2|3', '(state @foo) = @bar reassigns on second call';
+is swatest(), '1|2|3', '(state @foo) = @bar reassigns on third call';
+
+my %src = a => 1;
+sub hwatest {
+    (state %h) = %src;
+    my $x = %h<a>;
+    %h<a> = 99;
+    return $x;
+}
+is hwatest(), 1, '(state %h) = %src assigns on first call';
+is hwatest(), 1, '(state %h) = %src reassigns on second call';


### PR DESCRIPTION
## Summary

§1.3 S15 of the lexical-scope shadow-slot campaign — greens `S04-declarations/state.t` (46/46) under `MUTSU_SHADOW_SLOTS=1`.

**Root cause:** under shadow slots the parenthesized-declaration lvalue store (`__mutsu_assign_callable_lvalue` branch 1, from #4086) emitted `AssignExprLocal(slot)` — but a state **aggregate** lives in a shared `ContainerRef` cell (`StateVarInit`) aliased by the persisted state store, and `exec_assign_expr_local_op` deliberately REPLACES the slot for `@`/`%` targets (whole-reassignment semantics; cell write-through is scalar-only). The replace detached the slot from the persisted cell, so the next call restored the stale cell and the per-call reassignment was lost: `(state @foo) = @bar` returned the previous call's mutated contents (test #13 toggle-ON).

## Change

When the paren-decl is `is_state`, always emit the by-name `AssignExpr` — exactly what the default build emits, so **OFF is byte-identical** — which writes through the state cell. State var shadowing stays coherent through cell identity, not slot position.

## Toggle-ON burndown status

After S13 (#4390), S14 (#4391), and this: remaining toggle-ON failures are down to `integration/advent2013-day12.t` (env-only trait'd declarations × slot bake — scoped as S16 in docs/lexical-scope-slot-campaign.md) and `S32-array/perl.t` #7 (known AssignExprLocal `@`/`%` parity).

## Validation

- OFF: full `make test` PASS (Files=1639, release)
- ON: `state.t` 46/46; full `prove t/` green (`io-socket-recv-limit.t` fails only under `-j4` load, passes 3× standalone — same known socket flake as before)
- Pin `t/shadow-slot-state-paren-decl.t` passes OFF, ON, and on real raku

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW