### PR TITLE
fix(vm): bake declared-var slot onto ApplyVarTrait (§1.5 S16)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -253,6 +253,33 @@ broadcast = touches every slot with the name.
       ON green: `S04-declarations/state.t` 46/46. Pin:
       `t/shadow-slot-state-paren-decl.t` (OFF, ON, real raku). *(this branch)*
 
+- [x] **S16 — `ApplyVarTrait` slot bake (`is default` / QuantHash / Buf / Map
+      traits on a shadowing declaration).** The earlier survey note guessed the
+      hazard was the initializer's `AssignExprLocal` hitting the outer slot via
+      an env-only (`SetVarDynamic`) declaration; the actual root cause is
+      simpler: `exec_apply_var_trait_op` resolved the declared variable by
+      NAME (`locals_get_by_name`/`locals_set_by_name` = `position` = the
+      OUTER same-named slot). For `my @a is default(42) = ^10` shadowing an
+      outer `@a`, the `default` branch read the OUTER container, tagged it,
+      wrote it back to the outer slot AND broadcast it to env — so the
+      env-first `GetArrayVar` read returned the outer contents with the inner
+      default (`advent2013-day12.t` #11/31-32: slice reads returned 42 for
+      every element). Fix: bake `slot: Option<u32>` onto `ApplyVarTrait` at
+      the three emit sites (statement-position VarDecl bakes `local_map` right
+      after `declare_local`, so it carries the fresh shadow slot; the
+      expression-position sites bake what `emit_set_named_var` stored to, or
+      `None` for the pure-`SetGlobal` path) and route all eleven declared-var
+      resolver sites in `vm_var_trait_ops.rs` through the slot-preferring
+      helpers (`read_local_slot_or_name`, a new read mirror of
+      `write_local_slot_or_name`, + the existing write helper), gated on
+      `shadow_slots_active()` — OFF passes `None` and stays on the by-name
+      path byte-identically. ON green: `integration/advent2013-day12.t` 32/32.
+      Pin: `t/shadow-slot-var-trait.t` (OFF, ON, real raku — covers
+      `is default` on `@`/`%` shadows, `:delete` holes, outer intactness, and
+      an `is Bag` QuantHash shadow). Residual (pre-existing, both modes): the
+      name-keyed `var_defaults` side table and the `trait_mod:<is>` fallback's
+      `env().get(name)` are still by-name — §1.3 territory. *(this branch)*
+
 ## Fresh full toggle-ON survey (2026-07-10, post-S13, release, 1373 files)
 
 Only **4 genuine ON failures** remain; all were verified pre-existing on `main`

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -108,10 +108,13 @@ impl Compiler {
                         }
                         let trait_name_idx =
                             self.code.add_constant(Value::str("default".to_string()));
+                        // Expression-position declarations are env-only (stored
+                        // via SetGlobal, no local slot) — nothing to bake.
                         self.code.emit(OpCode::ApplyVarTrait {
                             name_idx,
                             trait_name_idx,
                             has_arg: trait_arg.is_some(),
+                            slot: None,
                         });
                     }
                     // Tag the container's element-type metadata so `.of` survives
@@ -358,10 +361,13 @@ impl Compiler {
                         self.compile_expr(arg);
                     }
                     let trait_name_idx = self.code.add_constant(Value::str(trait_name.clone()));
+                    // Bake the same slot `emit_set_named_var` stored to (None
+                    // when the value went to env via SetGlobal instead).
                     self.code.emit(OpCode::ApplyVarTrait {
                         name_idx,
                         trait_name_idx,
                         has_arg: trait_arg.is_some(),
+                        slot: self.local_map.get(name.as_str()).copied(),
                     });
                 }
                 // An uninitialized scalar declared `is default(V)` used as an

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1383,6 +1383,7 @@ impl Compiler {
                         name_idx,
                         trait_name_idx,
                         has_arg: trait_arg.is_some(),
+                        slot: self.local_map.get(name.as_str()).copied(),
                     });
                 }
                 // Deferred type constraint registration after traits are applied

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1352,10 +1352,14 @@ pub(crate) enum OpCode {
     },
     /// Apply a custom variable trait via trait_mod:<is>.
     /// When `has_arg` is true, pops trait argument value from stack.
+    /// `slot` is the compile-time-baked local slot of the declared variable
+    /// (§1.5; scope-correct under shadow slots). `None` for env-only
+    /// expression-position declarations, which have no local slot to bake.
     ApplyVarTrait {
         name_idx: u32,
         trait_name_idx: u32,
         has_arg: bool,
+        slot: Option<u32>,
     },
 
     /// Get a variable from the caller's scope ($CALLER::varname).

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1086,6 +1086,18 @@ impl Interpreter {
         }
     }
 
+    /// Read the local resolved by [`Self::resolve_local_slot`] when it exists.
+    /// §1.5 slot-preferring mirror of [`Self::locals_get_by_name`].
+    pub(super) fn read_local_slot_or_name(
+        &self,
+        code: &CompiledCode,
+        slot: Option<u32>,
+        name: &str,
+    ) -> Option<Value> {
+        self.resolve_local_slot(code, slot, name)
+            .map(|s| self.locals[s].clone())
+    }
+
     /// Write `val` into the slot resolved by [`Self::resolve_local_slot`] when it
     /// exists (no-op otherwise). §1.5 slot-preferring mirror write.
     pub(super) fn write_local_slot_or_name(

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4016,8 +4016,9 @@ impl Interpreter {
                 name_idx,
                 trait_name_idx,
                 has_arg,
+                slot,
             } => {
-                self.exec_apply_var_trait_op(code, *name_idx, *trait_name_idx, *has_arg)?;
+                self.exec_apply_var_trait_op(code, *name_idx, *trait_name_idx, *has_arg, *slot)?;
                 *ip += 1;
             }
             OpCode::GetCallerVar { name_idx, depth } => {

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -8,9 +8,20 @@ impl Interpreter {
         name_idx: u32,
         trait_name_idx: u32,
         has_arg: bool,
+        slot: Option<u32>,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx);
         let trait_name = Self::const_str(code, trait_name_idx).to_string();
+        // Under shadow slots a by-name `position` search resolves to the OUTER
+        // same-named slot, so the trait would tag/replace the wrong container
+        // (e.g. `my @a is default(42)` shadowing an outer `@a` tagged the outer
+        // array and clobbered env with it). Prefer the compile-time-baked slot
+        // of the declared variable; OFF keeps the by-name path byte-identical.
+        let eff_slot = if crate::compiler::shadow_slots_active() {
+            slot
+        } else {
+            None
+        };
 
         // Handle `is default(...)` as a built-in variable trait.
         if trait_name == "default" {
@@ -29,11 +40,11 @@ impl Interpreter {
             // otherwise be skipped and lost when the value flows out.
             if (name.starts_with('@') || name.starts_with('%'))
                 && let Some(container) = self
-                    .locals_get_by_name(code, &name)
+                    .read_local_slot_or_name(code, eff_slot, &name)
                     .or_else(|| self.get_env_with_main_alias(&name))
             {
                 let container = self.tag_container_default(container, default_value.clone());
-                self.locals_set_by_name(code, &name, container.clone());
+                self.write_local_slot_or_name(code, eff_slot, &name, container.clone());
                 self.set_env_with_main_alias(&name, container.clone());
                 // Replace existing Nil and uninitialized (Package("Any"))
                 // elements with the default value (Raku container semantics:
@@ -62,19 +73,19 @@ impl Interpreter {
                             kind,
                         );
                         let new_arr = self.tag_container_default(new_arr, default_value.clone());
-                        self.locals_set_by_name(code, &name, new_arr.clone());
+                        self.write_local_slot_or_name(code, eff_slot, &name, new_arr.clone());
                         self.set_env_with_main_alias(&name, new_arr);
                     }
                 }
             }
             // If the variable is currently Nil (uninitialized scalar), set it to the default.
             if !name.starts_with('@') && !name.starts_with('%') {
-                let current = self.locals_get_by_name(code, &name);
+                let current = self.read_local_slot_or_name(code, eff_slot, &name);
                 if matches!(
                     current.as_ref().map(Value::view),
                     Some(ValueView::Nil) | None
                 ) {
-                    self.locals_set_by_name(code, &name, default_value.clone());
+                    self.write_local_slot_or_name(code, eff_slot, &name, default_value.clone());
                     self.set_env_with_main_alias(&name, default_value);
                 }
             }
@@ -137,7 +148,9 @@ impl Interpreter {
                 // The value might be an Array (from the initializer) or already
                 // a Buf/Blob Instance (if SetLocal coerced through an old Buf
                 // container in the same slot, e.g. in a loop redeclaration).
-                let current = self.locals_get_by_name(code, name).unwrap_or(Value::NIL);
+                let current = self
+                    .read_local_slot_or_name(code, eff_slot, name)
+                    .unwrap_or(Value::NIL);
                 let items = match current.view() {
                     ValueView::Array(items, ..) => items
                         .iter()
@@ -160,7 +173,7 @@ impl Interpreter {
                 };
                 let buf = self.try_compiled_method_or_interpret(buf_type, "new", items)?;
                 let name_str = name.to_string();
-                self.locals_set_by_name(code, &name_str, buf.clone());
+                self.write_local_slot_or_name(code, eff_slot, &name_str, buf.clone());
                 self.set_env_with_main_alias(&name_str, buf);
                 return Ok(());
             }
@@ -174,7 +187,7 @@ impl Interpreter {
             }
             let name_str = name.to_string();
             // Register container type metadata with declared_type "Map"
-            if let Some(container) = self.locals_get_by_name(code, &name_str) {
+            if let Some(container) = self.read_local_slot_or_name(code, eff_slot, &name_str) {
                 let info = crate::runtime::ContainerTypeInfo {
                     value_type: String::new(),
                     key_type: None,
@@ -183,7 +196,7 @@ impl Interpreter {
                 // Hashes embed metadata in `HashData`; store the tagged value
                 // back into both the local slot and env.
                 let tagged = self.tag_container_metadata(container, info);
-                self.locals_set_by_name(code, &name_str, tagged.clone());
+                self.write_local_slot_or_name(code, eff_slot, &name_str, tagged.clone());
                 self.set_env_with_main_alias(&name_str, tagged);
             }
             // Mark the variable read-only to prevent mutation
@@ -208,7 +221,7 @@ impl Interpreter {
                 // Check if the variable already has initial values from the declaration.
                 // If so, construct the QuantHash from those values instead of creating
                 // an empty one. This handles `my %h is Bag = <a b b c>`.
-                let current_val = self.locals_get_by_name(code, &name_str);
+                let current_val = self.read_local_slot_or_name(code, eff_slot, &name_str);
                 let has_init_values = match current_val.as_ref().map(Value::view) {
                     Some(ValueView::Hash(h)) => !h.is_empty(),
                     Some(ValueView::Array(a, _)) => !a.is_empty(),
@@ -336,7 +349,7 @@ impl Interpreter {
                     declared_type: Some(trait_name.clone()),
                 };
                 let instance = self.tag_container_metadata(instance, info);
-                self.locals_set_by_name(code, &name_str, instance.clone());
+                self.write_local_slot_or_name(code, eff_slot, &name_str, instance.clone());
                 self.set_env_with_main_alias(&name_str, instance.clone());
                 // Set type constraint so future assignments are coerced correctly
                 self.vm_set_var_type_constraint(&name_str, Some(trait_name.clone()));

--- a/t/shadow-slot-var-trait.t
+++ b/t/shadow-slot-var-trait.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# §1.5 S16 pin (docs/lexical-scope-slot-campaign.md): ApplyVarTrait must
+# resolve the DECLARED variable's slot from the compile-time-baked slot, not
+# a by-name `position` search. Under MUTSU_SHADOW_SLOTS=1 the by-name search
+# hits the OUTER same-named slot, so `my @a is default(42)` inside a block
+# tagged the outer array and clobbered env with it (the inner shadow then
+# read the outer contents plus the inner default). Both toggle modes must
+# pass this file. Regressed shape: roast/integration/advent2013-day12.t.
+
+plan 8;
+
+my @a = 7, 8, 9;
+my %h = x => 9;
+
+{
+    my @a is default(42) = ^10;
+    is @a[1], 1, 'inner shadowed array with is default reads its own elements';
+    @a[3]:delete;
+    is-deeply @a[2, 3, 4], (2, 42, 4), 'deleted element returns the inner default';
+    is-deeply (@a[2, 3, 4]:exists), (True, False, True), ':exists sees the deleted hole';
+}
+
+{
+    my %h is default(42) = a => 1, b => 2;
+    is %h<a>, 1, 'inner shadowed hash with is default reads its own elements';
+    is %h<c>, 42, 'missing key returns the inner default';
+}
+
+is-deeply @a, [7, 8, 9], 'outer array is untouched after the shadow block';
+is-deeply %h, {x => 9}, 'outer hash is untouched after the shadow block';
+
+{
+    my %h is Bag = <a b b>;
+    is %h<b>, 2, 'QuantHash trait applies to the inner shadow, not the outer hash';
+}


### PR DESCRIPTION
## Summary

§1.3/§1.5 shadow-slot campaign slice S16 (see `docs/lexical-scope-slot-campaign.md`) — the last toggle-ON regression with a dedicated leaf site.

Under `MUTSU_SHADOW_SLOTS=1`, `exec_apply_var_trait_op` resolved the declared variable **by name** (`locals_get_by_name`/`locals_set_by_name` = `position` = the OUTER same-named slot). For `my @a is default(42) = ^10` shadowing an outer `@a`, the `default` branch read the outer container, tagged it with the inner default, wrote it back to the outer slot AND broadcast it to env — so the env-first `GetArrayVar` read returned the outer contents plus the inner default (`roast/integration/advent2013-day12.t` #11/31-32: every slice element read 42).

## Fix

- Add `slot: Option<u32>` to `ApplyVarTrait`, baked at the three emit sites:
  - statement-position `VarDecl` bakes `local_map` right after `declare_local`, so it carries the fresh shadow slot;
  - the two expression-position sites bake what `emit_set_named_var` stored to (or `None` on the pure-`SetGlobal` path).
- Route all eleven declared-var resolver sites in `vm_var_trait_ops.rs` (`is default` / Buf / Map / QuantHash traits) through slot-preferring helpers: the existing `write_local_slot_or_name` plus a new read mirror `read_local_slot_or_name`.
- Gated on `shadow_slots_active()` — the default build passes `None` and stays on the by-name path **byte-identically**.

## Verification

- `make test`: 1644 files PASS
- 42 trait-using whitelisted roast files: PASS in **both** toggle modes
- `roast/integration/advent2013-day12.t`: 32/32 OFF and ON
- All shadow-slot pin tests + `state.t` + `variables-and-packages.t` PASS ON
- Pin added: `t/shadow-slot-var-trait.t` (passes OFF, ON, and real raku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW