### PR TITLE
fix(vm): keep (my @x)/(my %h) paren-decl assignment by-name under shadow slots (§1.3 S17)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -280,6 +280,29 @@ broadcast = touches every slot with the name.
       name-keyed `var_defaults` side table and the `trait_mod:<is>` fallback's
       `env().get(name)` are still by-name — §1.3 territory. *(this branch)*
 
+- [x] **S17 — `(my @x)`/`(my %h)` paren-decl assignment must stay by-name
+      (generalizes S15 from state aggregates to ALL aggregates).** Under
+      shadow slots the paren-decl lvalue store emitted `AssignExprLocal(slot)`
+      for `@`/`%` targets, which REPLACES the slot, while the by-name
+      `AssignExpr` assigns IN PLACE through container identity. The circular
+      `.raku.EVAL` roundtrip shape `((my @y) = [42, @y])` needs the in-place
+      write: the RHS captures the container the declaration just created, and
+      the in-place assign makes element 1 that SAME container (a cycle); the
+      slot replace left the captured container empty, broke the cycle, and
+      `S32-array/perl.t` #7 then aborted downstream indexing `Any` ("Any
+      cannot be parameterized" — a red herring; the plan abort was the
+      symptom). Fix: extend the `is_state` exception in
+      `compile_expr_call`'s paren-decl branch to any `@`/`%` target — always
+      emit the by-name `AssignExpr`, which is what the default build emits
+      anyway (byte-identical OFF). Aggregate shadowing stays coherent through
+      container/env identity (aggregate reads are env-first), not slot
+      position. ON green: `S32-array/perl.t` 9/9 — **the last remaining
+      toggle-ON failure from the 2026-07-10 full survey; the known ON
+      burndown list is now EMPTY** (a fresh full survey is the next step to
+      confirm). Pin: `t/shadow-slot-paren-decl-aggregate.t` (OFF, ON, real
+      raku — circular roundtrip, RHS self-reference identity, shadow
+      correctness for `@`/`%` paren-decls). *(this branch)*
+
 ## Fresh full toggle-ON survey (2026-07-10, post-S13, release, 1373 files)
 
 Only **4 genuine ON failures** remain; all were verified pre-existing on `main`

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -55,21 +55,30 @@ impl Compiler {
             self.code.emit(OpCode::Dup);
             // 4. Assign to the variable (prefer the baked slot so a `(my $a)`
             //    that shadows an enclosing `$a` writes its own slot — §1.4).
-            //    EXCEPTION: a `(state @x) = …` / `(state %x)` target must stay
-            //    on the by-name `AssignExpr` even under shadow slots (§1.3 S15):
-            //    a state aggregate lives in a shared `ContainerRef` cell
-            //    (StateVarInit) that the persisted state store, the slot, and
-            //    the env all alias, and the by-name assign writes THROUGH that
-            //    cell. `AssignExprLocal` deliberately REPLACES the slot for
-            //    `@`/`%` targets (whole-reassignment semantics), detaching the
-            //    slot from the persisted cell — the next call then restores the
-            //    stale cell and the per-call reassignment is lost
-            //    (S04-declarations/state.t #13). By-name is what the default
-            //    build emits anyway, so this is byte-identical OFF; state var
-            //    shadowing stays coherent through cell identity, not slot
-            //    position.
+            //    EXCEPTION: any AGGREGATE (`@`/`%`) paren-decl target must stay
+            //    on the by-name `AssignExpr` even under shadow slots (§1.3
+            //    S15/S17). `AssignExprLocal` deliberately REPLACES the slot for
+            //    `@`/`%` targets (whole-reassignment semantics), while the
+            //    by-name assign writes IN PLACE through container identity.
+            //    Two ways the replace breaks:
+            //    - `(state @x) = …`: a state aggregate lives in a shared
+            //      `ContainerRef` cell (StateVarInit) that the persisted state
+            //      store, the slot, and the env all alias; replacing the slot
+            //      detaches it from the persisted cell, so the next call
+            //      restores the stale cell and the per-call reassignment is
+            //      lost (S04-declarations/state.t #13).
+            //    - `(my @y) = [42, @y]` (the `.raku.EVAL` circular-roundtrip
+            //      shape): the RHS captures the container the declaration just
+            //      created; the in-place assign makes element 1 that SAME
+            //      container (a cycle), while the slot replace leaves the
+            //      captured container empty and the cycle broken
+            //      (S32-array/perl.t #7).
+            //    By-name is what the default build emits anyway, so this is
+            //    byte-identical OFF; aggregate shadowing stays coherent through
+            //    container/env identity (aggregate reads are env-first), not
+            //    slot position.
             let var_name = var_name.clone();
-            if is_state {
+            if is_state || var_name.starts_with('@') || var_name.starts_with('%') {
                 let name_idx = self.code.add_constant(Value::str(var_name));
                 self.code.emit(OpCode::AssignExpr(name_idx));
             } else {

--- a/t/shadow-slot-paren-decl-aggregate.t
+++ b/t/shadow-slot-paren-decl-aggregate.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# §1.3 S17 pin (docs/lexical-scope-slot-campaign.md): a parenthesized
+# aggregate declaration lvalue (`(my @x) = ...` / `(my %h) = ...`) must stay
+# on the by-name in-place assignment even under MUTSU_SHADOW_SLOTS=1.
+# `AssignExprLocal` REPLACES the slot for `@`/`%` targets, which detaches the
+# container the RHS captured — breaking the circular `.raku.EVAL` roundtrip
+# shape `((my @y) = [42, @y])` (roast/S32-array/perl.t #7). Both toggle modes
+# must pass this file.
+
+plan 7;
+
+{
+    my @a;
+    @a = 42, @a;
+    is @a.raku.EVAL[1][1][1][0], 42,
+        'circular array roundtrips through .raku.EVAL';
+}
+
+{
+    my $r = ((my @x) = [42, @x]);
+    is $r[0], 42, 'paren-decl assignment returns the assigned values';
+    is $r[1][1][1][0], 42,
+        'RHS self-reference aliases the declared container (cycle intact)';
+}
+
+my @x = 9, 9;
+my %h = a => 9;
+{
+    (my @x) = 1, 2;
+    is-deeply @x, [1, 2], 'inner paren-decl array shadow sees its own values';
+    (my %h) = b => 1;
+    is %h<b>, 1, 'inner paren-decl hash shadow sees its own values';
+}
+is-deeply @x, [9, 9], 'outer array is untouched after the shadow block';
+is-deeply %h, {a => 9}, 'outer hash is untouched after the shadow block';


### PR DESCRIPTION
## Summary

§1.3/§1.5 shadow-slot campaign slice S17 (see `docs/lexical-scope-slot-campaign.md`) — generalizes the S15 state-aggregate exception (#4393) to ALL aggregate paren-decl targets. **This closes the last remaining toggle-ON failure from the 2026-07-10 full survey.**

Under `MUTSU_SHADOW_SLOTS=1` the parenthesized-declaration lvalue store emitted `AssignExprLocal(slot)` for `@`/`%` targets. `AssignExprLocal` deliberately REPLACES the slot for aggregates, while the by-name `AssignExpr` assigns IN PLACE through container identity. The circular `.raku.EVAL` roundtrip shape `((my @y) = [42, @y])` needs the in-place write: the RHS captures the container the declaration just created, and the in-place assign makes element 1 that same container (a cycle). The slot replace left the captured container empty and broke the cycle — `roast/S32-array/perl.t` #7 then aborted downstream ("Any cannot be parameterized" while indexing into the broken cycle → bad-plan abort).

## Fix

Extend the `is_state` exception in `compile_expr_call`'s paren-decl branch to any `@`/`%` target: always emit the by-name `AssignExpr` — what the default build emits anyway, so **OFF is byte-identical**. Aggregate shadowing stays coherent through container/env identity (aggregate reads are env-first), not slot position.

## Verification

- `roast/S32-array/perl.t` 9/9 in **both** toggle modes (was: ON bad-plan abort at #7)
- `state.t` + `assign.t` PASS in both toggle modes (S15 / #4086 greens intact)
- All shadow-slot pin tests PASS ON
- `make test`: 1644 files PASS
- Pin added: `t/shadow-slot-paren-decl-aggregate.t` (passes OFF, ON, and real raku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW