### PR TITLE
fix(module): keep a nested module's tag-gated imports visible to its own methods

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1178,6 +1178,14 @@ pub struct Interpreter {
     /// `register_exported_sub` to mirror GLOBAL registrations into
     /// `unit_module_exported_subs`.
     unit_module_loading_stack: Vec<String>,
+    /// Exports each module registered while it was the module currently being
+    /// loaded (attributed via `module_load_stack`), mapping module -> name ->
+    /// tags. Unlike `exported_subs["GLOBAL"]`, which pools every unit-module
+    /// export ever hoisted, this correctly attributes an export to the module
+    /// that declared it. The `use MOD` tag-filter consults this so it only
+    /// hides MOD's *own* exports and never a symbol MOD imported from a
+    /// transitively-`use`d module (which MOD's methods must still resolve).
+    module_owned_exports: HashMap<String, HashMap<String, HashSet<String>>>,
     /// When true, `is export` trait is ignored (used by `need` to load without importing).
     pub(crate) suppress_exports: bool,
     /// When true, rw routine calls should not auto-FETCH Proxy return values.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2035,6 +2035,7 @@ impl Interpreter {
             exported_vars: HashMap::new(),
             unit_module_exported_subs: HashMap::new(),
             unit_module_loading_stack: Vec::new(),
+            module_owned_exports: HashMap::new(),
             suppress_exports: false,
             in_lvalue_assignment: false,
             in_does_rhs: false,

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -274,34 +274,49 @@ impl Interpreter {
                 tags.iter().cloned().collect()
             };
             let want_all = requested_tags.contains("ALL");
-            // Check exports registered under GLOBAL (for unit modules) and under module name
-            let export_sources = ["GLOBAL", module];
-            for source in &export_sources {
-                if let Some(subs) = self.exported_subs.get(*source) {
-                    for (name, symbol_tags) in subs {
-                        let is_mandatory = symbol_tags.contains("MANDATORY");
-                        if !want_all && !is_mandatory && symbol_tags.is_disjoint(&requested_tags) {
-                            // This export should NOT be imported — remove from GLOBAL
-                            let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
-                            if !func_keys_before.contains(&global_key) {
-                                self.registry_mut().functions.remove(&global_key);
-                            }
-                            // Also remove multi-dispatch variants
-                            let prefix = format!("GLOBAL::{}/", name);
-                            let multi_keys: Vec<Symbol> = self
-                                .registry()
-                                .functions
-                                .keys()
-                                .filter(|k| {
-                                    let ks = k.resolve();
-                                    ks.starts_with(&prefix) && !func_keys_before.contains(k)
-                                })
-                                .copied()
-                                .collect();
-                            for mk in multi_keys {
-                                self.registry_mut().functions.remove(&mk);
-                            }
-                        }
+            // Collect the exports THIS module owns: everything it registered
+            // while loading (attributed via `module_owned_exports`) plus any
+            // exports registered directly under its package name. Deliberately
+            // does NOT consult the blanket `exported_subs["GLOBAL"]`, which also
+            // pools exports pulled in by transitive `use`s inside this module
+            // (e.g. a nested `use Other :tag`). Those are legitimately imported
+            // into the inner module and its methods must still resolve them, so
+            // hiding them here would break the inner module.
+            let mut owned_exports: HashMap<String, HashSet<String>> = self
+                .module_owned_exports
+                .get(module)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(pkg_subs) = self.exported_subs.get(module) {
+                for (name, symbol_tags) in pkg_subs {
+                    owned_exports
+                        .entry(name.clone())
+                        .or_default()
+                        .extend(symbol_tags.iter().cloned());
+                }
+            }
+            for (name, symbol_tags) in &owned_exports {
+                let is_mandatory = symbol_tags.contains("MANDATORY");
+                if !want_all && !is_mandatory && symbol_tags.is_disjoint(&requested_tags) {
+                    // This export should NOT be imported — remove from GLOBAL
+                    let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
+                    if !func_keys_before.contains(&global_key) {
+                        self.registry_mut().functions.remove(&global_key);
+                    }
+                    // Also remove multi-dispatch variants
+                    let prefix = format!("GLOBAL::{}/", name);
+                    let multi_keys: Vec<Symbol> = self
+                        .registry()
+                        .functions
+                        .keys()
+                        .filter(|k| {
+                            let ks = k.resolve();
+                            ks.starts_with(&prefix) && !func_keys_before.contains(k)
+                        })
+                        .copied()
+                        .collect();
+                    for mk in multi_keys {
+                        self.registry_mut().functions.remove(&mk);
                     }
                 }
             }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -69,6 +69,21 @@ impl Interpreter {
                 mirror.insert(tag.clone());
             }
         }
+        // Attribute this export to the module currently being loaded (any kind:
+        // unit, package-block, or bare-file). The `use MOD` tag-filter uses this
+        // to hide only MOD's own exports, never a symbol MOD imported from a
+        // transitively-`use`d module.
+        if let Some(owner) = self.module_load_stack.last().cloned() {
+            let owned = self
+                .module_owned_exports
+                .entry(owner)
+                .or_default()
+                .entry(name.clone())
+                .or_default();
+            for tag in &tags {
+                owned.insert(tag.clone());
+            }
+        }
         let entry = self
             .exported_subs
             .entry(package)
@@ -185,7 +200,20 @@ impl Interpreter {
         // rather than polluting the GLOBAL namespace.
         let target_pkg = self.current_package();
 
-        for (name, symbol_tags) in subs {
+        // For a `unit module Foo`, the actual exports live in
+        // `unit_module_exported_subs[Foo]` (runtime registration used the
+        // GLOBAL package), while `exported_subs[Foo]` is empty. Merge both so a
+        // re-import (`use Foo; use Foo :tag`) of a unit-module export is
+        // actually re-installed, not just tag-validated.
+        let mut merged_subs = subs;
+        for (name, tags) in unit_global_subs.iter() {
+            merged_subs
+                .entry(name.clone())
+                .or_default()
+                .extend(tags.iter().cloned());
+        }
+
+        for (name, symbol_tags) in merged_subs {
             // MANDATORY exports are always imported regardless of requested tags
             let is_mandatory = symbol_tags.contains("MANDATORY");
             if !import_all && !is_mandatory && symbol_tags.is_disjoint(&requested) {
@@ -208,7 +236,7 @@ impl Interpreter {
             let target_single = format!("{target_pkg}::{name}");
             let target_prefix = format!("{target_pkg}::{name}/");
 
-            let function_entries: Vec<(Symbol, Arc<FunctionDef>)> = self
+            let mut function_entries: Vec<(Symbol, Arc<FunctionDef>)> = self
                 .registry()
                 .functions
                 .iter()
@@ -226,6 +254,29 @@ impl Interpreter {
                     }
                 })
                 .collect();
+            // Fallback for a re-import (`use Foo; use Foo :tag`) of a `unit
+            // module Foo` sub: the sub is registered under `GLOBAL::name`, not
+            // `Foo::name`, and an earlier default `use Foo` already stripped the
+            // `GLOBAL::name` alias for a non-DEFAULT export. Restore it from the
+            // stable `EXPORT::ALL::name` alias (registered for every non-ALL
+            // export) so the tagged re-import makes the sub callable again.
+            if function_entries.is_empty() {
+                for alias in [
+                    format!("{module}::EXPORT::ALL::{name}"),
+                    format!("GLOBAL::EXPORT::ALL::{name}"),
+                    format!("EXPORT::ALL::{name}"),
+                ] {
+                    if let Some(def) = self
+                        .registry()
+                        .functions
+                        .get(&Symbol::intern(&alias))
+                        .cloned()
+                    {
+                        function_entries.push((Symbol::intern(&target_single), def));
+                        break;
+                    }
+                }
+            }
             for (k, v) in function_entries {
                 self.registry_mut().functions.insert(k, v);
             }

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -214,6 +214,7 @@ impl Interpreter {
             exported_sub_values: self.exported_sub_values.clone(),
             unit_module_exported_subs: self.unit_module_exported_subs.clone(),
             unit_module_loading_stack: Vec::new(),
+            module_owned_exports: self.module_owned_exports.clone(),
             suppress_exports: false,
             in_lvalue_assignment: false,
             in_does_rhs: false,

--- a/t/lib-tagged-export/TagExp.rakumod
+++ b/t/lib-tagged-export/TagExp.rakumod
@@ -1,0 +1,3 @@
+unit module TagExp;
+sub always() is export { return "always" }
+sub internal($x) is export(:internals) { return "internal-$x" }

--- a/t/lib-tagged-export/UsesInternals.rakumod
+++ b/t/lib-tagged-export/UsesInternals.rakumod
@@ -1,0 +1,11 @@
+use v6.d;
+use TagExp :internals;
+
+# A nested module imports a tag-gated sub from another module. Its own methods
+# must be able to resolve that imported sub, even though the outer program that
+# `use`s this module never requested :internals.
+class UsesInternals is export {
+    method run($x) {
+        return internal($x);
+    }
+}

--- a/t/lib-tagged-export/UsesInternalsDouble.rakumod
+++ b/t/lib-tagged-export/UsesInternalsDouble.rakumod
@@ -1,0 +1,15 @@
+use v6.d;
+use TagExp;
+use TagExp :internals;
+
+# Same as UsesInternals, but does a plain `use` first and then a tagged
+# re-import. The default `use` strips the :internals export; the tagged
+# re-import must restore it so the module's own methods resolve it.
+class UsesInternalsDouble is export {
+    method run($x) {
+        return internal($x);
+    }
+    method plain() {
+        return always();
+    }
+}

--- a/t/module-tagged-export-default.t
+++ b/t/module-tagged-export-default.t
@@ -1,0 +1,19 @@
+use v6;
+use Test;
+
+plan 2;
+
+# A plain default `use Mod` must NOT import a sub that is only exported under a
+# non-DEFAULT tag. This is the leak-prevention direction that mutsu's
+# `module_owned_exports` attribution preserves: `internal` is tagged
+# `:internals`, so a tag-free `use TagExp` leaves it undeclared while the
+# default-tagged `always` is imported.
+
+use lib $?FILE.IO.parent.add('lib-tagged-export').Str;
+
+use TagExp;
+
+is always(), "always", 'a default-tagged export is imported by a plain `use`';
+
+my $leaked = (try internal("nope")).defined;
+nok $leaked, 'a :tag-only export is NOT imported by a plain `use`';

--- a/t/module-tagged-export-nested.t
+++ b/t/module-tagged-export-nested.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+plan 4;
+
+# A module that imports a tag-gated sub (`use Other :internals`) must be able to
+# call that sub from its own methods, even when the outer program `use`s the
+# module without requesting the tag. Previously mutsu hoisted every unit-module
+# export into a single GLOBAL bag and the outer `use` tag-filter stripped the
+# transitively-imported sub, breaking the inner module. Surfaced while driving
+# the real zef CLI: its git fetcher does `use Zef::Utils::URI :internals` and
+# calls `uri(...)` from its own methods.
+
+use lib $?FILE.IO.parent.add('lib-tagged-export').Str;
+
+use UsesInternals;
+my $o = UsesInternals.new;
+is $o.run("X"), "internal-X",
+    'a single tagged `use :internals` stays visible to the module methods';
+
+use UsesInternalsDouble;
+my $d = UsesInternalsDouble.new;
+is $d.run("Y"), "internal-Y",
+    'a `use; use :internals` re-import restores the tag-gated sub for module methods';
+is $d.plain(), "always",
+    'the default export from the same module also resolves';
+
+# A directly-requested tagged import DOES expose the sub.
+{
+    use TagExp :internals;
+    is internal("Z"), "internal-Z",
+        'a direct tagged import exposes the sub in the requesting scope';
+}
+
+# NOTE: leak-prevention (the tag-gated sub staying hidden from the OUTER program
+# when only the module class was imported) is a separate, broader limitation of
+# mutsu's flat GLOBAL function namespace and is not asserted here. See
+# t/module-tagged-export-default.t for the case that IS guaranteed: a plain
+# default `use` never exposes a :tag-only export.


### PR DESCRIPTION
## Summary

Driving the real zef CLI toward a live network fetch surfaced a general module-system bug: a module that imports a **tag-gated** sub (`use Other :internals`) could not call that sub from its own methods once the outer program `use`d the module *without* requesting the tag.

zef's git fetcher does `use Zef::Utils::URI :internals` and calls `uri(...)` from its own methods, so `use Zef::Service::Shell::git` stripped `uri` and broke the fetcher with `Unknown function`.

## Root cause

Unit-module exports are all hoisted into a single `GLOBAL` bag, and the `use MOD` tag-filter iterated that blanket `exported_subs["GLOBAL"]` — which also holds exports pulled in by *transitive* `use`s inside MOD. A default `use MOD` therefore stripped a transitively-imported `:tag`-only sub that MOD's own methods legitimately need.

## Fixes

1. **Attribute each export to the module currently being loaded** (via `module_load_stack`) in a new `module_owned_exports` table. The tag-filter now consults this so it hides only MOD's *own* exports, never a symbol MOD imported from a transitively-`use`d module.

2. **`import_module` (already-loaded fast path)** now iterates a `unit module`'s real exports (`unit_module_exported_subs`), not just the empty `exported_subs[Foo]`, and falls back to the stable `EXPORT::ALL::name` alias to re-install a `GLOBAL::name` alias that an earlier default `use Foo` stripped. This makes `use Foo; use Foo :tag` re-expose the tag-gated sub.

## Tests

- `t/module-tagged-export-nested.t` — single + double `use`, module methods resolve the tag-gated sub, direct tagged import works.
- `t/module-tagged-export-default.t` — a plain `use` still hides a `:tag`-only export.

Full lexical import scoping (the tag-gated sub staying hidden from the *outer* program) remains a separate limitation of mutsu's flat GLOBAL function namespace and is documented in the nested test rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)