### PR TITLE
fix(vm): make `for %h` iteration pairs live so an in-loop %h{key}=X is visible

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -169,7 +169,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             _ => None,
         },
         "value" => match target.view() {
-            ValueView::Pair(_, v) | ValueView::ValuePair(_, v) => Some(Ok(v.clone())),
+            // `hash_entry_read` returns the live node value for a `for %h -> $p`
+            // pair's HashEntryRef (so `$p.value` in arithmetic sees the plain
+            // value and tracks in-loop `%h{$p.key} = X` writes), and is a plain
+            // clone for any other pair value.
+            ValueView::Pair(_, v) | ValueView::ValuePair(_, v) => Some(Ok(v.hash_entry_read())),
             ValueView::Instance {
                 class_name,
                 attributes,

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -337,6 +337,20 @@ impl Interpreter {
                 _ => None,
             };
             if let Some((key, current_value)) = pair_data {
+                // A Pair whose value is a live `HashEntryRef` (a `for %h -> $p`
+                // loop pair) writes `.value` straight through to the shared hash
+                // node in place, so `$p.value = X` updates `%h{$p.key}` and the
+                // ref keeps reading the new value.
+                if let ValueView::HashEntryRef { .. } = current_value.as_ref().view()
+                    && let Some((node, last_key)) = current_value.hash_entry_terminal()
+                {
+                    // SAFETY: aliased in-place mutation of a shared hash node;
+                    // mirrors `hash_entry_terminal`'s own interior mutation. No
+                    // borrow into the map is held across the write.
+                    let data = unsafe { crate::value::gc_contents_mut(&node) };
+                    data.map.insert(last_key, value.clone());
+                    return Ok(value);
+                }
                 // A Pair whose value is a shared `ContainerRef` (built by `key =>
                 // $var`) aliases the source variable's container. Writing `.value`
                 // updates the cell in place, so `$pair.value = X` writes through to

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -522,6 +522,18 @@ impl Value {
         }
     }
 
+    /// Construct an EAGER `HashEntryRef` that reads the current node value on
+    /// each access (used for live `for %h -> $p` iteration pairs, whose
+    /// `.value` must reflect an in-loop `%h{$p.key} = X`).
+    #[inline]
+    pub(crate) fn hash_entry_ref_eager(hash: Gc<HashData>, path: Vec<String>) -> Self {
+        Value::HashEntryRef {
+            hash,
+            path,
+            eager: true,
+        }
+    }
+
     /// Construct a `LazyIoLines` iterator over a file handle (boxing the
     /// handle internally, mirroring `Value::pair`/`Value::scalar`).
     #[inline]

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -59,6 +59,31 @@ impl Interpreter {
         None
     }
 
+    /// Expand a plain (non-itemized) `Hash` into the `Pair` items a `for %h`
+    /// loop iterates, but with each pair's value bound to an *eager*
+    /// `HashEntryRef` into the shared hash node (rather than a decontainerized
+    /// snapshot). Raku's hash-iteration pairs are live: a `%h{$p.key} = X` in
+    /// the loop body is observable through `$p.value` on a later read (zef's
+    /// `Zef::Config::parse-file` chains `%config{k} = $node.value.subst(...)`
+    /// this way). The ref reads the current node value on each access; hash
+    /// element writes mutate the same `Gc` node in place, so the read tracks
+    /// them. Falls back to the plain snapshot pairs (`typed_pair`) for an
+    /// itemized hash, which iterates as a single element.
+    pub(super) fn hash_live_pairs(gc: &crate::gc::Gc<crate::value::HashData>) -> Vec<Value> {
+        if gc.itemized {
+            return vec![Value::hash_with_data(gc.clone())];
+        }
+        gc.keys()
+            .map(|k| {
+                let vref = Value::hash_entry_ref_eager(gc.clone(), vec![k.clone()]);
+                match gc.typed_key(k).view() {
+                    ValueView::Str(s) => Value::pair((**s).clone(), vref),
+                    _ => Value::value_pair(gc.typed_key(k), vref),
+                }
+            })
+            .collect()
+    }
+
     pub(crate) fn control_signal_topic_value(signal: &RuntimeError) -> Option<Value> {
         // User-defined classes doing X::Control carry their original
         // exception instance. Surface it directly so CONTROL blocks see the

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -180,6 +180,11 @@ impl Interpreter {
             // also expands here — a corner not exercised by any roast Buf/Blob
             // test.
             bytes
+        } else if let ValueView::Hash(gc) = iterable.view() {
+            // `for %h` / `for %h -> $p`: bind each pair's value to a live
+            // `HashEntryRef` so an in-loop `%h{$p.key} = X` is observable through
+            // a later `$p.value` read (raku's live hash-iteration pairs).
+            Self::hash_live_pairs(gc)
         } else {
             runtime::value_to_list(&iterable)
         };

--- a/t/hash-iteration-live-pair.t
+++ b/t/hash-iteration-live-pair.t
@@ -1,0 +1,82 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Raku's hash-iteration pairs are LIVE: a `%h{$p.key} = X` inside the loop body
+# is observable through a later `$p.value` read, and a `$p.value = X` writes back
+# to the hash. Surfaced while driving the real zef CLI: Zef::Config::parse-file
+# chains `%config{k} = $node.value.subst(...)` over `for %config -> $node`, which
+# only interpolates `$*HOME` correctly when `$node.value` reflects the prior
+# subst write.
+
+# 1. hash write is visible through a later $p.value read (the zef pattern)
+{
+    my %h = a => "orig";
+    for %h -> $p {
+        %h{$p.key} = "changed";
+        is $p.value, "changed", 'a %h{key}=X write is visible through $p.value';
+    }
+}
+
+# 2. writing $p.value updates the hash
+{
+    my %h = a => "orig";
+    for %h -> $p {
+        $p.value = "via-pair";
+    }
+    is %h<a>, "via-pair", '$p.value = X writes back to the hash';
+}
+
+# 3. chained substitution (the exact Zef::Config shape)
+{
+    my %config = StoreDir => '$*HOME/.zef/store';
+    my $home = "/home/user";
+    for %config -> $node {
+        if $node.key.ends-with('Dir') {
+            %config{$node.key} = $node.value.subst(/'$*HOME'/, $home, :g);
+            %config{$node.key} = $node.value.subst(/'{time}'/, '0', :g);
+        }
+    }
+    is %config<StoreDir>, "/home/user/.zef/store",
+        'chained subst over a hash-iteration pair interpolates correctly';
+}
+
+# 4. $p.value participates in arithmetic (must deref, not stay a raw ref)
+{
+    my %h = a => 3, b => 4;
+    my $sum = 0;
+    for %h -> $p { $sum += $p.value; }
+    is $sum, 7, '$p.value coerces to a number in arithmetic';
+}
+
+# 5. the whole pair still gists correctly
+{
+    my %h = a => 1;
+    for %h -> $p { is $p.gist, "a => 1", 'the pair still gists with its value'; }
+}
+
+# 6. object-hash (typed) keys still iterate live
+{
+    my %o{Int} = 1 => "x";
+    for %o -> $p {
+        is $p.value, "x", 'a typed-key hash iterates live pairs too';
+    }
+}
+
+# 7. topic form ($_) is live as well
+{
+    my %h = a => "orig";
+    for %h {
+        %h{.key} = "topic-changed";
+        is .value, "topic-changed", 'the topic $_ pair is live too';
+    }
+}
+
+# 8. a pair that escapes the loop keeps reading its value
+{
+    my %h = a => 5;
+    my $escaped;
+    for %h -> $p { $escaped = $p; }
+    is $escaped.value, 5, 'an escaped pair still reads its value';
+}


### PR DESCRIPTION
## Summary

Raku's hash-iteration pairs are **live**: inside `for %h -> $p { ... }` a `%h{$p.key} = X` write is observable through a later `$p.value` read, and `$p.value = X` writes back to the hash. mutsu materialized each pair with a decontainerized *snapshot* value (`typed_pair`), so the two diverged during a single loop body.

Surfaced while driving the real zef CLI: `Zef::Config::parse-file` interpolates config paths by chaining substitutions:

```raku
for %config -> $node {
    %config{$node.key} = $node.value.subst(/'$*HOME'/, $home, :g);
    %config{$node.key} = $node.value.subst(/'{time}'/, time, :g);
}
```

Each line re-reads `$node.value`, relying on it reflecting the previous line's write. With snapshot pairs the last `subst` re-ran on the **original** value, so `StoreDir` came out as the literal `$*HOME/.zef/store` instead of an interpolated path.

## Fix

`for %h` now binds each pair's value to an eager `HashEntryRef` into the shared hash node:
- **read** (`hash_entry_read`) returns the current node value, and hash element writes mutate the same `Gc` node in place, so the ref tracks them;
- `$p.value` read derefs the ref (so arithmetic/coercion see the plain value);
- `$p.value = X` writes straight through the ref into the node.

**Scope:** only a bare `for %h` / `for %h -> $p` (iterable is a `Hash`) takes this path — `.pairs`/`.kv`/`.values` sequences are unchanged.

## Tests

`t/hash-iteration-live-pair.t` — live read, writeback, the chained-subst zef shape, arithmetic on `$p.value`, gist, typed keys, topic form, and an escaped pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)