### PR TITLE
fix(roast): sweep with CWD=roast/ + BLOCKERS.md §6 triage

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -5,7 +5,13 @@
 個々の失敗を片端から潰すためではなく、
 **今どこを直せば何がまとめて動くか**を判断するために使う。
 
-**最終更新 2026-07-10**（旧 §3「第一級コンテナ / container identity」と旧 §2.3（hash
+**最終更新 2026-07-11**（§6「未 triage の孤立残件」を新設 — `roast-history.sh` の
+sweep 非 pass 集合を全数 triage し、大型共通根本原因を持たない個別残件 15 本を索引化。
+併せて `roast-history.sh` を `cd roast` してから実行するよう修正（CI の
+`run-roast-test.sh` と CWD を揃えた）ため、CWD 依存の encode 3 本
+（`S32-str/gb18030|gb2312|shiftjis-encode-decode.t`）は sweep でも通るようになり残件から除外。）
+
+**2026-07-10**（旧 §3「第一級コンテナ / container identity」と旧 §2.3（hash
 multislice）をセクションごと削除 — 全サブキャンペーン完了: element mutation in-place 化
 #4362/#4366・post-call writeback 全廃 #4370/#4372/#4377・attr accessor slot 化 #4360・
 multislice #4354/#4355・scalar itemization #4382・escaped our-sub lexical write #4385。
@@ -34,9 +40,15 @@ socket 系 whitelist 済み・cross-thread lexical writeback 解消（#4336/#434
 
 - whitelist は **1373**（2026-07-10 時点、`wc -l roast-whitelist.txt`）。
 - 安い 1 ファイル勝ちはほぼ枯渇している。roast 由来の大型ブロッカーは出尽くしており、
-  残件は本ファイルの §1/§2（深い基盤待ち・低優先）と §4（whitelist 非目標）のみ。
+  残件は本ファイルの §1/§2（深い基盤待ち・低優先）・§4（whitelist 非目標）・
+  §6（未 triage の孤立残件・共通根本原因なし）のみ。
   次の構造工事の選定は [PLAN.md](../PLAN.md)（lexical-scope slot campaign / GC post-3a /
   Batteries）を正とする。
+- **BLOCKERS.md は失敗集合の網羅リストではなく、根本原因単位の索引**である。
+  `roast-history.sh` の sweep 非 pass 集合との差は次で説明できる: (1) whitelist 済みは
+  ここから削除済み（news/ 送り）、(2) load 由来の flaky / timeout は sweep の見かけ上の
+  失敗、(3) 大型の共通根本原因を持たない小粒な個別残件は §6 に集約（per-file 詳細は
+  `TODO_roast/S*.md`）。
 - かつてここにあった「真の lazy 配列 / 無限列」「dispatch / 演算子 sugar の desugar surface」
   「並行・非同期（S17）」「第一級コンテナ / container identity（§3）」はいずれも完了済み
   （詳細は `news/2026-06.md` / `news/2026-07.md`）。
@@ -91,6 +103,35 @@ socket 系 whitelist 済み・cross-thread lexical writeback 解消（#4336/#434
 
 ---
 
+## 6. 未 triage の孤立残件（個別ブロッカー・共通根本原因なし）
+
+2026-07-11 の sweep（`c3cf84dd`, `cd roast` CWD で全数取り直し）で非 pass だが、
+§1/§2/§4 のいずれにも属さず、**互いに共通する大型根本原因を持たない**個別残件。
+それぞれ単独の調査が要る tail であり、campaign を組めないため BLOCKERS 大型索引には
+出していなかったもの。cheap win を拾う際の入口として一覧化する（per-file 詳細は
+`TODO_roast/S*.md`）。数字は執筆時点のスナップショット。
+
+| ファイル | 現状 | ブロッカー（一言） |
+|---|---|---|
+| `S02-names/pseudo-6d.t` | 91/159 で中断 | `::("CALLER")::<$*bar>` CALLER 疑似パッケージ deref 未対応 |
+| `S02-names/pseudo-6e.t` | 79/202 で中断 | 同上（6.e 版） |
+| `S02-names-vars/names.t` | 141/156・notok 3 | test 144 付近「Null PMC access when printing a var」edge |
+| `S02-types/array-shapes.t` | 34/43 で中断 | 未初期化 shaped array の `.map` 等、shaped-array の深い機能 |
+| `S05-capture/hash.t` | parse で 0/? | 「The use of hashes in regexes is reserved」= 正規表現内 `%h` 未対応 |
+| `S05-metasyntax/longest-alternative.t` | 56/62・notok 5 | LTM（longest-token-match）の tie-break edge |
+| `S06-advanced/return-prioritization.t` | 9/11・notok 2 | `return` の優先順位（phaser 絡み）edge |
+| `S10-packages/basic.t` | 50/83・notok 9 | package 宣言（`our`/ネスト）の edge |
+| `S12-attributes/class.t` | 19/28 で中断 | test 19 以降で attribute 機能ギャップにより abort |
+| `S12-attributes/trusts.t` | 9/15・notok 6 | `trusts` によるクラス間 private アクセス未対応 |
+| `S12-traits/basic.t` | parse で 0/? | 「Can only use : as invocant marker ... after the first parameter」= カスタム trait シグネチャ未対応 |
+| `S19-command-line-options/01-dash-uppercase-i.t` | 0/8 | `-I` + `@*INC` イントロスペクション（is-run サブプロセス）。`@*INC` 未populate |
+| `S32-basics/xxPOS.t` | 11/64 で中断 | test 11 以降で深い機能により abort |
+| `S32-hash/perl.t` | 43/55・notok 12 | `.perl`/`.raku` の Hash round-trip 整形 edge |
+| `S32-temporal/time.t` | 8/10・notok 2 | `time`/`gmtime` の整形 edge |
+
+これらは「次の 1 本」候補にはなり得るが、いずれも単発で共通利得が小さい。優先は
+引き続き [PLAN.md](../PLAN.md) の構造工事を正とする。
+
 ## 5. 今のおすすめ着手順
 
 **roast 由来の大型ブロッカーは出尽くした。** 第一級コンテナ / container identity
@@ -101,7 +142,8 @@ hash multislice #4354/#4355・scalar itemization #4382・escaped our-sub lexical
 も完了済み。
 
 残っているのは §1（RakuAST 待ち・据え置き）・§2.2（6.e generics・深い機能待ち）・
-§4（whitelist 非目標）のみで、いずれも「次の 1 本」には適さない。
+§4（whitelist 非目標）・§6（未 triage の孤立残件）のみで、いずれも「次の 1 本」には
+適さない（§6 は cheap win の入口として一覧化はしてある）。
 **次の構造工事の選定は [PLAN.md](../PLAN.md) を正とする**（lexical-scope slot campaign
 完遂〔PLAN §6〕/ GC post-3a ロードマップ〔PLAN §2〕/ Batteries〔PLAN §1〕）。
 

--- a/scripts/roast-history.sh
+++ b/scripts/roast-history.sh
@@ -15,6 +15,12 @@ for arg in "$@"; do
 done
 
 MUTSU=./target/release/mutsu
+# Absolute path so tests can be launched with CWD=roast/ (see the run loop):
+# many roast tests read data files via paths relative to the roast/ directory
+# (e.g. `"S32-str".IO.d ?? "S32-str" !! "t/spec/S32-str"`), so they only resolve
+# when run from inside roast/ -- exactly as `scripts/run-roast-test.sh` (used by
+# `make roast`) does. Running from the repo root would spuriously fail them.
+MUTSU_ABS="$PWD/target/release/mutsu"
 # Roast tests rely on fudge directives, which mutsu only processes when
 # MUTSU_FUDGE is set (so ordinary scripts are not affected by stray #? comments).
 export MUTSU_FUDGE=1
@@ -120,7 +126,10 @@ for f in "${TEST_FILES[@]}"; do
   # Run with timeout, capture stdout and stderr separately
   EXIT_CODE=0
   STDERR_FILE=$(mktemp)
-  OUTPUT=$(timeout "$FILE_TIMEOUT" "$MUTSU" "$f" 2>"$STDERR_FILE" | tr -d '\0') || EXIT_CODE=$?
+  # Run with CWD=roast/ and a roast-relative path, matching run-roast-test.sh,
+  # so tests that read sample data via roast-relative paths resolve correctly.
+  REL_F="${f#roast/}"
+  OUTPUT=$( (cd roast && timeout "$FILE_TIMEOUT" "$MUTSU_ABS" "$REL_F") 2>"$STDERR_FILE" | tr -d '\0') || EXIT_CODE=$?
   STDERR_CONTENT=$(<"$STDERR_FILE")
   rm -f "$STDERR_FILE"
 


### PR DESCRIPTION
## Background
While reviewing the remaining roast failures we found that several **whitelisted** tests appeared to fail in the `roast-history.sh` sweep even though `make roast` (CI) passes them. Root cause: the sweep ran mutsu from the **repo root**, but many roast tests resolve sample-data paths **relative to `roast/`** (e.g. `"S32-str".IO.d ?? "S32-str" !! "t/spec/S32-str"`). CI's `scripts/run-roast-test.sh` does `cd roast`; the history sweep did not.

## Changes
1. **`scripts/roast-history.sh`** — launch each test with `CWD=roast/` and a roast-relative path (absolute mutsu binary), matching CI. Verified `S32-str/{gb18030,gb2312,shiftjis}-encode-decode.t` now pass in the sweep (they were spuriously counted as failures before).
2. **`TODO_roast/BLOCKERS.md`** — clarify that the file is a **root-cause index, not an exhaustive failing-set list**, and add **§6 "未 triage の孤立残件"**: the 15 individual per-file blockers that share no common root cause (so they never fit the large-blocker index), each with a one-line blocker label. This closes the gap that prompted the question "why are there failing tests not in BLOCKERS.md?".

No code/behavior change to mutsu itself — tooling + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW