### PR TITLE
fix(vm): don't panic on a non-finite array index (@a[Inf] = ...)

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1617,6 +1617,14 @@ impl Interpreter {
                                 )?;
                                 range_initialized_marks.push(Self::encode_bound_index(&key));
                             }
+                        } else if matches!(idx.view(), ValueView::Num(f) if !f.is_finite()) {
+                            // `@a[Inf] = ...` / `@a[NaN] = ...`: a non-finite
+                            // positional index cannot be converted to an Int.
+                            // raku throws X::Numeric::CannotConvert here.
+                            return Err(RuntimeError::new(format!(
+                                "X::Numeric::CannotConvert: Cannot convert {} to Int",
+                                idx.to_string_value()
+                            )));
                         } else if let Some(i) = Self::index_to_usize(&idx) {
                             container
                                     .with_array_mut(|items, _| -> Result<(), RuntimeError> {

--- a/src/vm/vm_var_multidim_helpers.rs
+++ b/src/vm/vm_var_multidim_helpers.rs
@@ -25,20 +25,24 @@ impl Interpreter {
     }
 
     pub(super) fn index_to_usize(idx: &Value) -> Option<usize> {
+        // A non-finite index (Inf/NaN) has no valid `usize` representation.
+        // Rust's `f as usize` saturates Inf to `usize::MAX` rather than failing,
+        // which would later index far out of bounds and panic; reject it here so
+        // every caller sees `None` (see `@a[Inf] = ...` in S02-types/array.t).
         match idx.view() {
             ValueView::Int(i) if i >= 0 => Some(i as usize),
-            ValueView::Num(f) if f >= 0.0 => Some(f as usize),
+            ValueView::Num(f) if f >= 0.0 && f.is_finite() => Some(f as usize),
             ValueView::Rat(n, d) if d != 0 => {
                 let f = n as f64 / d as f64;
-                (f >= 0.0).then_some(f as usize)
+                (f >= 0.0 && f.is_finite()).then_some(f as usize)
             }
             ValueView::FatRat(n, d) if d != 0 => {
                 let f = n as f64 / d as f64;
-                (f >= 0.0).then_some(f as usize)
+                (f >= 0.0 && f.is_finite()).then_some(f as usize)
             }
             ValueView::BigRat(_, d) if !d.is_zero() => {
                 let f = runtime::to_float_value(idx)?;
-                (f >= 0.0).then_some(f as usize)
+                (f >= 0.0 && f.is_finite()).then_some(f as usize)
             }
             _ => idx.to_string_value().parse::<usize>().ok(),
         }

--- a/t/array-index-inf.t
+++ b/t/array-index-inf.t
@@ -1,0 +1,38 @@
+use Test;
+
+# A non-finite positional index (Inf/NaN) must not panic the VM.
+# raku throws when converting Inf to an Int index; mutsu must raise a
+# catchable exception (not an out-of-bounds Rust panic) and leave the
+# array untouched. Regression for S02-types/array.t `@a[Inf] = "dog"`.
+
+plan 6;
+
+{
+    my @a = 1..10;
+    my $threw = False;
+    { @a[Inf] = "dog"; CATCH { default { $threw = True } } }
+    ok $threw, 'assigning to @a[Inf] throws instead of panicking';
+    is @a.elems, 10, '... and the array is left unmodified';
+}
+
+{
+    my @a = 1..10;
+    my $threw = False;
+    { @a[NaN] = "dog"; CATCH { default { $threw = True } } }
+    ok $threw, 'assigning to @a[NaN] throws instead of panicking';
+    is @a.elems, 10, '... and the array is left unmodified';
+}
+
+{
+    # A finite in-range index still works after the guard.
+    my @a = 1..10;
+    @a[3] = 99;
+    is @a[3], 99, 'finite index assignment still works';
+}
+
+{
+    # Autovivifying assignment on a fresh variable with a finite index works.
+    my @b;
+    @b[5] = 'x';
+    is @b[5], 'x', 'autoviv assignment at a finite index still works';
+}


### PR DESCRIPTION
## Symptom
`roast/S02-types/array.t` (whitelisted) reproducibly panicked in the roast-history sweep:
```
thread '<unnamed>' panicked at src/vm/vm_var_assign_index_named.rs:...:
index out of bounds: the len is 100000 but the index is 18446744073709551615
```
The panic was on a background thread, so the main test still exited 0 — it never showed up as a test *failure*, only as a spurious "panic" in the sweep classification. It reproduces 60/60 on the `@a[Inf] = "dog"` line.

## Root cause
`index_to_usize` converted a `Num` index with `f as usize`. Rust's float→int cast **saturates**, so `Inf as usize == usize::MAX (18446744073709551615)`. That bogus index then flowed into `arr[i]` and panicked.

## Fix (two layers)
1. **`index_to_usize`** — reject non-finite floats (Inf/NaN) in the `Num`/`Rat`/`FatRat`/`BigRat` arms, so every caller (reads, autoviv, slices) gets `None` instead of a saturated `usize::MAX`.
2. **Array positional assignment** — when the index is a non-finite `Num`, raise `X::Numeric::CannotConvert` (matching raku, which errors `Cannot convert Inf to Int`) instead of silently no-oping. The array is left unmodified.

Adds `t/array-index-inf.t`. No whitelist change (array.t was already whitelisted; this removes the sweep-noise panic and makes it genuinely clean). Regression checked against S09-typed-arrays/native-int.t (1840/1840) and S09-subscript/slice.t (56/56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW