### PR TITLE
fix(vm): flatten Seq in run(), type-object identity coercion, nested-:: default type

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -150,6 +150,22 @@ pub(super) fn dispatch(
             attrs,
         ))));
     }
+    // A numeric coercion method invoked on a *type object* of the same type
+    // (`Int.Int`, `Num.Num`, `Complex.Complex`) is the identity coercion: raku
+    // defines e.g. `method Int() { self }`, so for an undefined invocant (a
+    // type object) the result is that same type object rather than a "No such
+    // method" error. Zef's URI parser relies on `($auth<port> // Int).Int`
+    // yielding the `Int` type object when the port is absent.
+    //
+    // Only `Int`/`Num`/`Complex` are handled here: raku returns the type object
+    // cleanly for these, but `Rat.Rat`/`FatRat.FatRat` throw "must be an object
+    // instance" (no `method Rat() { self }`), so those are left to fall through.
+    if let ValueView::Package(name) = target.view()
+        && matches!(method, "Int" | "Num" | "Complex")
+        && name.resolve() == method
+    {
+        return Some(Some(Ok(target.clone())));
+    }
     match method {
         "self" => {
             // For unhandled Failures, .self throws the exception

--- a/src/runtime/builtins_system_run.rs
+++ b/src/runtime/builtins_system_run.rs
@@ -49,6 +49,17 @@ impl Interpreter {
                         positional.push(Value::to_string_value(elem));
                     }
                 }
+                // A Seq/Slip (e.g. from `run (|@cmd).grep(...)`) is an iterable and
+                // flattens into the argument list just like an Array, matching Raku's
+                // slurpy `*@args` behavior for `run`.
+                ValueView::Seq(elems)
+                | ValueView::HyperSeq(elems)
+                | ValueView::RaceSeq(elems)
+                | ValueView::Slip(elems) => {
+                    for elem in elems.iter() {
+                        positional.push(Value::to_string_value(elem));
+                    }
+                }
                 _ => {
                     positional.push(arg.to_string_value());
                 }

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -357,11 +357,27 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn optional_type_object_name(constraint: &str) -> String {
+        let bytes = constraint.as_bytes();
         let mut end = constraint.len();
-        for (idx, ch) in constraint.char_indices() {
-            if ch == '[' || ch == '(' || ch == ':' {
-                end = idx;
-                break;
+        let mut idx = 0;
+        while idx < bytes.len() {
+            match bytes[idx] {
+                b'[' | b'(' => {
+                    end = idx;
+                    break;
+                }
+                b':' => {
+                    // `::` is a namespace separator (e.g. `IO::Path`), NOT a type
+                    // smiley — keep it as part of the name. A lone `:` starts a
+                    // smiley (`:D`/`:U`/`:_`), so truncate there.
+                    if bytes.get(idx + 1) == Some(&b':') {
+                        idx += 2;
+                        continue;
+                    }
+                    end = idx;
+                    break;
+                }
+                _ => idx += 1,
             }
         }
         constraint[..end].to_string()

--- a/t/type-object-coercion-nested.t
+++ b/t/type-object-coercion-nested.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+# Regression tests for three bugs surfaced while driving the real Zef CLI
+# under mutsu (Zef::Utils::URI parsing path):
+#   1. `run(Seq)` must flatten an iterable command list like Raku's slurpy args.
+#   2. `Int.Int` / `Num.Num` / `Complex.Complex` on a *type object* return the
+#      type object (identity coercion), not a "No such method" error.
+#   3. A scalar typed with a nested `::` type name (`IO::Path`) defaults to that
+#      exact type object, not its outer namespace (`IO`).
+
+plan 13;
+
+# --- 1. run() flattens a Seq/List first argument -----------------------------
+{
+    my @cmd = 'true',;
+    my $seq = (|@cmd).grep(*.?chars);
+    my $proc = run($seq, :!out, :!err);
+    is $proc.exitcode, 0, 'run(Seq) flattens the command list and runs it';
+
+    my $proc2 = run(('true',).Seq, :!out, :!err);
+    is $proc2.exitcode, 0, 'run(Seq literal) flattens too';
+}
+
+# --- 2. identity coercion on numeric type objects ----------------------------
+is Int.Int.^name, 'Int', 'Int.Int returns the Int type object';
+nok Int.Int.defined, 'Int.Int is undefined (a type object)';
+is Num.Num.^name, 'Num', 'Num.Num returns the Num type object';
+is Complex.Complex.^name, 'Complex', 'Complex.Complex returns the Complex type object';
+
+# The exact value that broke Zef's URI parser: `($missing // Int).Int`.
+{
+    my $port = (Any // Int).Int;
+    is $port.^name, 'Int', '(Any // Int).Int yields the Int type object';
+}
+
+# --- 3. nested-`::` type name default type object ----------------------------
+{
+    my IO::Path $x;
+    is $x.^name, 'IO::Path', 'uninitialized IO::Path scalar defaults to IO::Path';
+}
+{
+    my IO::Path $x = Nil;
+    is $x.^name, 'IO::Path', 'IO::Path scalar reset by Nil defaults to IO::Path';
+}
+{
+    my IO::Path $x = '/tmp'.IO;
+    is $x.^name, 'IO::Path', 'IO::Path scalar accepts an IO::Path value';
+}
+# A smiley on a nested type name must still be stripped for the default.
+{
+    my IO::Path:D $x = '/tmp'.IO;
+    is $x.^name, 'IO::Path', 'IO::Path:D scalar keeps the nested type name';
+}
+# Optional parameter of a nested type defaults to the nested type object.
+{
+    sub f(IO::Path $p?) { $p.^name }
+    is f(), 'IO::Path', 'optional IO::Path param defaults to IO::Path';
+}
+# Plain smiley stripping unaffected.
+{
+    sub g(Int:D $n) { $n }
+    is g(5), 5, 'Int:D param still binds a plain Int';
+}


### PR DESCRIPTION
Three general mutsu bugs surfaced while driving the real Zef CLI (`zef list --update`) under mutsu, all on the `Zef::Utils::URI` parsing path. Together they clear the `zef list --update` "Type check failed for return value; expected Str but got Bool" → "expected IO::Path but got IO" error chain, so the fetch now proceeds to the actual download step.

### 1. `run(Seq)` did not flatten an iterable command list
Zef's `zrun` is `run (|@_).grep(*.?chars), |%_`, passing a `Seq` as the sole positional. mutsu only flattened `ValueView::Array`, so a `Seq` stringified to one bogus program name (exitcode -1) → curl `probe` returned False. Now Seq/HyperSeq/RaceSeq/Slip flatten like Array, matching Raku's slurpy `*@args`.

### 2. `Int.Int` on a *type object* errored "No such method 'Int'"
Raku defines `method Int() { self }` on `Int`/`Num`/`Complex`, so the identity coercion on an undefined invocant returns that type object. Zef's URI parser relies on `($auth<port> // Int).Int`. Added a `Package`-invocant guard for `Int|Num|Complex` where the method name equals the type. (`Rat.Rat`/`FatRat.FatRat` throw "must be an object instance" in raku, so those are deliberately left to fall through.)

### 3. `my IO::Path $x` defaulted to the `IO` type object instead of `IO::Path`
`optional_type_object_name` truncated the constraint at the first `:` to strip a `:D` smiley, but that also cut `IO::Path` at the `::` → `IO`. Rewrote the scan to skip `::` namespace separators and only break on a lone `:` (smiley) / `[` / `(`. This surfaced as `Zef::Fetch.fetch --> IO::Path` returning the `IO` type object from `.map(*.IO).head` on an empty list (Nil-reset picked the wrong default type object).

## Tests
- `t/type-object-coercion-nested.t` (13 subtests) covering all three fixes.
- `make test`: PASS (16213 tests).
- Related roast (`S12-coercion/*`, `S32-io/io-path-*`, `S32-num/int.t`, `S02-types/num.t`): PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA