### PR TITLE
perf(symbol): thread-local intern cache — unserialize CPU-bound threads

### DIFF
--- a/scripts/roast-history.sh
+++ b/scripts/roast-history.sh
@@ -74,6 +74,13 @@ per_file_timeout() {
       # VM perf gap tracked separately.
       echo 30
       ;;
+    roast/S32-io/lock.t)
+      # File-lock contention test built around real `sleep 1` blocks in several
+      # `start` threads: inherently slow -- raku itself takes ~26s. Not a mutsu
+      # perf gap (mutsu runs it in ~21s). Bump the budget so it is categorized
+      # as pass rather than a spurious 10s timeout.
+      echo 60
+      ;;
     *)
       echo "$TIMEOUT"
       ;;

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,5 +1,6 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
 use std::fmt;
 use std::sync::{OnceLock, RwLock};
 
@@ -55,10 +56,40 @@ fn global_table() -> &'static RwLock<SymbolTable> {
     })
 }
 
+thread_local! {
+    /// Per-thread `str -> Symbol` memo in front of `GLOBAL_TABLE`. Valid for the
+    /// whole process because interned ids are append-only and never remapped.
+    /// Removes the global-`RwLock` read contention on the intern hot path (see
+    /// `Symbol::intern`).
+    static INTERN_CACHE: RefCell<FxHashMap<String, Symbol>> = RefCell::new(FxHashMap::default());
+}
+
 impl Symbol {
     /// Intern a string and return its `Symbol`.  If the string has already been
     /// interned, the existing symbol is returned (idempotent).
     pub fn intern(s: &str) -> Symbol {
+        // Thread-local memo first: interned symbols are global and append-only
+        // (an id, once assigned to a string, is never reused or remapped), so a
+        // cached `str -> Symbol` mapping is valid for the life of the process
+        // and can never go stale. Serving repeat interns from here keeps the hot
+        // path (re-interning the same variable/package names every loop
+        // iteration) entirely off the globally-shared `RwLock`, which otherwise
+        // read-contends across worker threads and serializes CPU-bound `start`
+        // blocks (profiled: `Symbol::intern` was 90% of an 8-thread run, 43% of
+        // it in `RwLock::read_contended`).
+        if let Some(sym) = INTERN_CACHE.with(|c| c.borrow().get(s).copied()) {
+            return sym;
+        }
+        let sym = Self::intern_global(s);
+        INTERN_CACHE.with(|c| {
+            c.borrow_mut().insert(s.to_owned(), sym);
+        });
+        sym
+    }
+
+    /// Intern via the globally-shared table (the source of truth for id
+    /// assignment). Only reached on a thread-local cache miss.
+    fn intern_global(s: &str) -> Symbol {
         // Fast path: read lock only.
         {
             let table = global_table().read().unwrap();


### PR DESCRIPTION
## Investigation
Chasing the roast-history sweep timeouts (`S17-promise/stress.t`, `S17-lowlevel/cas-int.t`, `S32-io/lock.t`), I found CPU-bound work across `start` threads was serialized — **worse than serial**:

| workload | before |
|---|---|
| 1 thread × 1M `$i++` | 0.77s |
| 1 thread × 8M | 5.86s |
| 8 threads × 1M (8M total) | **6.67s** |
| 8 threads × `sleep 1` | 1.02s ✅ (I/O parallelizes fine) |

So real OS threads run, but a hot lock throttled compute. `perf` pinned it: **`Symbol::intern` = 90%** of the 8-thread run, **43% in `RwLock::read_contended`**. Every variable/package access in the loop re-interned its name through the process-global `RwLock<SymbolTable>`; 8 threads hammering the read lock bounced its futex cache line.

## Fix
Front `Symbol::intern` with a **thread-local `str → Symbol` memo**. Interned ids are append-only and never remapped, so a cached mapping is valid for the whole process and can never go stale (cross-thread and EVAL-created symbols still resolve correctly — verified). Repeat interns never touch the shared lock.

| workload | before | after |
|---|---|---|
| 8 threads × 1M | 6.67s | **1.92s** (3.5×) |
| stress.t | 7.2s | **1.7s** |
| cas-int.t | 10.5s | **7.6s** |

`read_contended` is gone from the profile. Single-thread time is unchanged (no contention there; the remaining per-op cost is variable-name string formatting — a separate gap tracked for the lexical-slot campaign).

## Also
`roast-history.sh`: give `S32-io/lock.t` a 60s per-file budget. It is inherently slow — real `sleep 1` blocks in several `start` threads, raku itself takes ~26s — not a mutsu perf gap, so the 10s default was a spurious timeout.

`make test`: PASS (1646 files, 16197 tests). Correctness spot-checked for cross-thread / EVAL / class / dynamic-var symbol creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW