### PR TITLE
perf(vm): stop allocating constant prefixes in the var-name hot path

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -107,13 +107,16 @@ impl Interpreter {
     }
 
     fn main_unqualified_name(name: &str) -> Option<String> {
-        for sigil in ["$", "@", "%", "&"] {
-            let prefix = format!("{sigil}Main::");
-            if let Some(rest) = name.strip_prefix(&prefix) {
-                return Some(format!("{sigil}{rest}"));
-            }
+        // Sigils are single-byte ASCII, so `name[1..]` is a valid boundary once
+        // the first char is one of them. Check the constant `Main::` prefix
+        // directly instead of building `"{sigil}Main::"` for all four sigils on
+        // every call -- this runs on the variable-access hot path.
+        let sigil = name.chars().next()?;
+        if !matches!(sigil, '$' | '@' | '%' | '&') {
+            return None;
         }
-        None
+        let rest = name[1..].strip_prefix("Main::")?;
+        Some(format!("{sigil}{rest}"))
     }
 
     /// Look up an `our`-scoped variable by trying the bare (unqualified) name
@@ -267,21 +270,22 @@ impl Interpreter {
     /// sigiled variable name, returning the bare variable name.
     /// e.g. "$GLOBAL::x" → Some("x"), "$OUR::x" → Some("x")
     fn pseudo_package_unqualified_name(name: &str) -> Option<String> {
-        let pseudo = ["GLOBAL", "OUR", "MY"];
-        for sigil in ["$", "@", "%", "&"] {
-            if let Some(rest) = name.strip_prefix(sigil) {
-                for pkg in &pseudo {
-                    let prefix = format!("{pkg}::");
-                    if let Some(bare) = rest.strip_prefix(&prefix) {
-                        return Some(format!("{sigil}{bare}"));
-                    }
+        // The pseudo-package prefixes are constants -- match them directly
+        // rather than re-formatting `"{pkg}::"` on every variable access.
+        const PSEUDO: [&str; 3] = ["GLOBAL::", "OUR::", "MY::"];
+        let sigil = name.chars().next();
+        if matches!(sigil, Some('$' | '@' | '%' | '&')) {
+            // Sigils are single-byte ASCII, so `name[1..]` is a valid boundary.
+            let rest = &name[1..];
+            for prefix in PSEUDO {
+                if let Some(bare) = rest.strip_prefix(prefix) {
+                    return Some(format!("{}{bare}", sigil.unwrap()));
                 }
             }
         }
         // Also handle unsigiled forms (e.g. "GLOBAL::x")
-        for pkg in &pseudo {
-            let prefix = format!("{pkg}::");
-            if let Some(bare) = name.strip_prefix(&prefix) {
+        for prefix in PSEUDO {
+            if let Some(bare) = name.strip_prefix(prefix) {
                 return Some(bare.to_string());
             }
         }


### PR DESCRIPTION
## Context
Follow-on from the symbol-intern thread-local cache (#4402). With intern off the hot path, the next profiled bottleneck in an 8-thread `$i++` loop was `core::fmt::write` + malloc/free (~30% combined), inside two helpers that run on **every variable access**:

- `main_unqualified_name` rebuilt `"{sigil}Main::"` for all four sigils on each call, even though it never matches an ordinary `$i`.
- `pseudo_package_unqualified_name` rebuilt `"{pkg}::"` for GLOBAL/OUR/MY — all **constants** — up to six times per call.

## Change
Match the constant prefixes directly (sigils are single-byte ASCII, so `name[1..]` is a valid boundary) and allocate only on an actual match.

| workload | before | after |
|---|---|---|
| single-thread 8M `$i++` | 6.04s | **4.75s** (~21%) |

No behavior change — pseudo-package / `Main::` / package-var resolution verified (`$GLOBAL::x`, `$OUR::x`, `$MY::y`, `$P::z`, `$*D`). `make test`: PASS (1650 files, 16224 tests). stress.t / cas-int.t still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW