### PR TITLE
fix(vm): keep class-body `my` statics alive across a require-in-sub; Slip satisfies List

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1225,6 +1225,15 @@ pub struct Interpreter {
     /// subs (where `current_package == Foo`), so it does not leak the lexical to
     /// bare references after the block (which run under `GLOBAL`).
     pub(crate) package_lexicals: HashMap<String, HashMap<String, Value>>,
+    /// Names in `package_lexicals` that are class-body `my` statics
+    /// (`class C { my $x = ...; method m { $x } }`), keyed by class. These are
+    /// stored in `package_lexicals` so a method's BARE `$x` read/write and the
+    /// `writeback_package_scope_var` mutation path reuse the existing machinery,
+    /// but — unlike a `package Foo { my $x }` block lexical — they must NOT be
+    /// reachable through a QUALIFIED `$C::x`, which is a distinct package variable
+    /// (see t/package-lookup.t). `package_scope_lexical`'s qualified branch skips
+    /// any (class, name) recorded here.
+    pub(crate) class_body_static_names: HashMap<String, std::collections::HashSet<String>>,
     /// Shared cells for block lexicals captured by an `our`-scoped named sub
     /// declared inside a *bare* block (not a package block). Unlike a `my sub`, an
     /// `our sub` is installed into the package registry and stays callable after

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -2065,6 +2065,58 @@ impl Interpreter {
                 }
             }
         }
+        // Persist the class body's own `my` lexicals (`class C { my $x = ...;
+        // method m { $x } }`) into `package_lexicals[C]` so a method that reads
+        // them still resolves after the class-body env is gone. On the success
+        // path the body env is normally left intact, so a top-level `class`/`use`
+        // keeps the values in the mainline env and this store is merely a mirror.
+        // But when the class is loaded via `require` *inside a sub*, the loading
+        // frame's env (holding the body statics) is discarded on return, and a
+        // later method read would otherwise miss the value entirely (e.g. an
+        // initialized `my Lock $lock = Lock.new` reads back as `Any`). Mirrors
+        // the package-block store in `exec_package_scope_op`. `current_package`
+        // is still `name` here, which is exactly when a method of this class
+        // reads these names, so the store is correctly scoped.
+        let body_lexicals: Vec<(String, Value)> = self
+            .env
+            .iter()
+            .filter_map(|(k, v)| {
+                if saved_env.contains_key_sym(*k) {
+                    return None;
+                }
+                let bare = k.resolve();
+                if bare.contains("::")
+                    || bare.starts_with("__")
+                    || bare.starts_with('?')
+                    || bare.starts_with('!')
+                    || bare == "self"
+                    || bare == "_"
+                {
+                    return None;
+                }
+                // Skip `our` package vars: their authoritative value lives in the
+                // qualified `our` store and can be set from outside the package;
+                // a bare declaration-time snapshot here would stale-shadow it.
+                let qualified = format!("{name}::{bare}");
+                if self.get_our_var(&qualified).is_some() || self.env.contains_key(&qualified) {
+                    return None;
+                }
+                Some((bare, v.clone()))
+            })
+            .collect();
+        if !body_lexicals.is_empty() {
+            let marks = self
+                .class_body_static_names
+                .entry(name.to_string())
+                .or_default();
+            for (bare, _) in &body_lexicals {
+                marks.insert(bare.clone());
+            }
+            let store = self.package_lexicals.entry(name.to_string()).or_default();
+            for (bare, v) in body_lexicals {
+                store.insert(bare, v);
+            }
+        }
         self.set_current_package(saved_package);
         if let Err(err) = self.resolve_class_stub_requirements(name, &mut class_def) {
             restore_previous_state(self);

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -166,6 +166,47 @@ impl Interpreter {
     }
 
     /// Check if a class has scoped subs declared in its body.
+    /// True if `class_name` has recorded class-body `my` lexicals (statics)
+    /// stored in `package_lexicals` by `register_class_decl`. A method reading
+    /// such a static (`class C { my $x = ...; method m { $x } }`) resolves it
+    /// via `package_scope_lexical`, which is gated on `current_package` being the
+    /// class — so method dispatch must set `current_package` to the class when
+    /// this returns true (mirrors the `has_class_scoped_subs` gate).
+    pub(crate) fn class_has_package_lexicals(&self, class_name: &str) -> bool {
+        self.class_body_static_names
+            .get(class_name)
+            .is_some_and(|m| !m.is_empty())
+    }
+
+    /// Inject `class_name`'s recorded class-body `my` statics into the current
+    /// (method) env so every read path — the GetGlobal opcode AND the many direct
+    /// `get_env_with_main_alias` reads used by metamethod/method-call fast paths —
+    /// resolves them, regardless of the call-site env. Values are pulled fresh
+    /// from `package_lexicals` on each method entry, so a prior call's assignment
+    /// (persisted there by `writeback_package_scope_var`, since dispatch sets
+    /// `current_package` to the class) is reflected. Only names not already bound
+    /// in the method env (params/attrs/`self` take precedence) are injected. This
+    /// is the load-bearing half of the fix for a class registered inside a
+    /// transient frame (`require` in a sub), whose body env — and thus its statics
+    /// — is gone by the time a method runs. Returns without work when the class has
+    /// no statics (the overwhelmingly common case).
+    pub(crate) fn inject_class_body_statics(&mut self, class_name: &str) {
+        let Some(statics) = self.package_lexicals.get(class_name) else {
+            return;
+        };
+        if statics.is_empty() {
+            return;
+        }
+        let to_inject: Vec<(String, Value)> = statics
+            .iter()
+            .filter(|(k, _)| !self.env.contains_key(k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        for (k, v) in to_inject {
+            self.env.insert(k, v);
+        }
+    }
+
     pub(crate) fn has_class_scoped_subs(&self, class_name: &str) -> bool {
         // Single guard for both reads (no user-code re-entry here, so let-binding
         // is safe and avoids a same-thread recursive read lock).

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2048,6 +2048,7 @@ impl Interpreter {
             fatal_mode: false,
             our_vars: HashMap::new(),
             package_lexicals: HashMap::new(),
+            class_body_static_names: HashMap::new(),
             escaped_our_lexical_cells: HashMap::new(),
             escaping_our_lexical_names: std::collections::HashSet::new(),
             escaped_our_sub_names: std::collections::HashSet::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -227,6 +227,7 @@ impl Interpreter {
             fatal_mode: self.fatal_mode,
             our_vars: HashMap::new(),
             package_lexicals: self.package_lexicals.clone(),
+            class_body_static_names: self.class_body_static_names.clone(),
             escaped_our_lexical_cells: self.escaped_our_lexical_cells.clone(),
             escaping_our_lexical_names: self.escaping_our_lexical_names.clone(),
             escaped_our_sub_names: self.escaped_our_sub_names.clone(),

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -156,6 +156,7 @@ impl Interpreter {
                     | "Complex"
                     | "Array"
                     | "List"
+                    | "Slip"
                     | "Hash"
                     | "Map"
                     | "Range"
@@ -216,6 +217,7 @@ impl Interpreter {
                 value_type,
                 "Array"
                     | "List"
+                    | "Slip"
                     | "Seq"
                     | "HyperSeq"
                     | "RaceSeq"
@@ -230,11 +232,11 @@ impl Interpreter {
             // `array[int]`, whose base name is `array`) does Positional.
             return true;
         }
-        // Array is-a List in Raku type hierarchy
+        // Array is-a List in Raku type hierarchy (and Slip is-a List)
         if constraint == "List"
             && matches!(
                 value_type,
-                "Array" | "List" | "Seq" | "HyperSeq" | "RaceSeq" | "array"
+                "Array" | "List" | "Slip" | "Seq" | "HyperSeq" | "RaceSeq" | "array"
             )
         {
             return true;

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -212,6 +212,16 @@ impl Interpreter {
             if pkg != cur {
                 return None;
             }
+            // A class-body `my` static lives in `package_lexicals` for BARE-name
+            // reuse, but a QUALIFIED `$C::x` is a distinct package variable, not
+            // the static — do not resolve it here (t/package-lookup.t).
+            if self
+                .class_body_static_names
+                .get(pkg)
+                .is_some_and(|s| s.contains(bare))
+            {
+                return None;
+            }
             match sigil {
                 // `@`/`%`/`&` lexicals are stored WITH their sigil; a scalar (`$`
                 // or sigil-less) is stored sigil-less.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -280,6 +280,10 @@ impl Interpreter {
         let saved_package = self.current_package().to_string();
         if self.has_class_scoped_subs(receiver_class_name) {
             self.set_current_package(receiver_class_name.to_string());
+        } else if self.class_has_package_lexicals(owner_class) {
+            // The class body declared `my` statics; set current_package to the
+            // owner class so a method read resolves them via package_scope_lexical.
+            self.set_current_package(owner_class.to_string());
         }
 
         // Set self and __ANON_STATE__ (used by `$.foo` desugaring inside methods)
@@ -498,6 +502,10 @@ impl Interpreter {
         };
 
         // Initialize locals from env
+        // Make class-body `my` statics visible to every read path in the body
+        // (params/self inserted above take precedence). No-op unless the owner
+        // class declared statics.
+        self.inject_class_body_statics(owner_class);
         self.locals = vec![Value::NIL; cc.locals.len()];
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
@@ -1049,6 +1057,10 @@ impl Interpreter {
         let saved_package = self.current_package().to_string();
         if self.has_class_scoped_subs(receiver_class_name) {
             self.set_current_package(receiver_class_name.to_string());
+        } else if self.class_has_package_lexicals(owner_class) {
+            // The class body declared `my` statics; set current_package to the
+            // owner class so a method read resolves them via package_scope_lexical.
+            self.set_current_package(owner_class.to_string());
         }
 
         // Compute role context without touching env
@@ -1189,6 +1201,11 @@ impl Interpreter {
         if let Some(slurpy) = &implicit_named_slurpy {
             self.env_mut().insert("%_".to_string(), slurpy.clone());
         }
+
+        // Make class-body `my` statics visible to every read path in the body
+        // (params/self already inserted above take precedence). No-op unless the
+        // owner class declared statics.
+        self.inject_class_body_statics(owner_class);
 
         // Raku: routine parameters are read-only by default (`method m($x) { $x = 5 }`
         // dies). The slow path does this in `bind_function_args_values`; the fast

--- a/t/class-body-static-in-sub.t
+++ b/t/class-body-static-in-sub.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+# A class's body `my` static (`class C { my $x = ...; method m { $x } }`) must
+# stay reachable from the class's methods even when the class is defined inside a
+# transient frame (a sub, or a runtime `require`) whose env is gone by the time a
+# method runs. Regression: an initialized `my Lock $lock = Lock.new` read back as
+# `Any` inside such a method (the zef fetch-plugin `!command` lock blocker).
+
+plan 8;
+
+# 1-2. Initialized static read after the defining sub returned.
+sub make-locked() {
+    class WithLock {
+        my Lock $lock = Lock.new;
+        method lock-name { return $lock.^name }
+    }
+    return WithLock.new;
+}
+my $wl = make-locked();
+is $wl.lock-name, 'Lock', 'initialized class-body static keeps its value after the defining sub returns';
+is $wl.lock-name, 'Lock', 'still correct on a second call';
+
+# 3-5. Mutable static persists across method calls (accumulator).
+sub make-counter() {
+    class Counter {
+        my Int $n = 0;
+        method inc { $n++; return $n }
+    }
+    return Counter.new;
+}
+my $c = make-counter();
+is $c.inc, 1, 'mutable class-body static: first increment';
+is $c.inc, 2, 'mutable class-body static: persists across calls';
+is $c.inc, 3, 'mutable class-body static: third increment';
+
+# 6-8. The static is shared across instances (Raku semantics), even for a
+# class defined inside a sub.
+sub make-shared-pair() {
+    class Shared {
+        my Int $count = 0;
+        method bump { $count++; return $count }
+    }
+    return (Shared.new, Shared.new);
+}
+my ($x, $y) = make-shared-pair();
+is $x.bump, 1, 'shared static across instances: first';
+is $y.bump, 2, 'shared static across instances: second instance sees the same static';
+is $x.bump, 3, 'shared static across instances: third';

--- a/t/slip-satisfies-list-return.t
+++ b/t/slip-satisfies-list-return.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# A Slip is-a List (does Positional, is-a Cool) in Raku's type hierarchy, so a
+# `|(...)` slip must satisfy a `--> List` / `--> Positional` return constraint and
+# a `List`/`Positional`/`Cool` parameter. Regression: mutsu's static type table
+# omitted Slip, so zef's `method !slurp-package-list(--> List) { ... try |from-json(...) }`
+# died with "expected List but got Slip".
+
+plan 8;
+
+sub ret-list(--> List) { return |(1, 2, 3) }
+is ret-list().join(','), '1,2,3', 'Slip satisfies a --> List return constraint';
+
+sub ret-positional(--> Positional) { return |(4, 5) }
+is ret-positional().join(','), '4,5', 'Slip satisfies a --> Positional return constraint';
+
+sub ret-cool(--> Cool) { return |(6, 7) }
+is ret-cool().elems, 2, 'Slip satisfies a --> Cool return constraint';
+
+my $s = |(8, 9, 10);
+ok $s ~~ List, 'Slip ~~ List';
+ok $s ~~ Positional, 'Slip ~~ Positional';
+ok $s ~~ Cool, 'Slip ~~ Cool';
+ok $s.isa(List), 'Slip.isa(List)';
+
+# Empty slip return still satisfies List.
+sub ret-empty(--> List) { return Empty }
+is ret-empty().elems, 0, 'empty Slip (Empty) satisfies --> List';


### PR DESCRIPTION
Two general interpreter bugs surfaced by driving the real **zef** CLI (`zef list --update`). With both fixed, the fetch pipeline runs past the plugin-lock and package-list-parse steps: both ecosystem mirrors now report `===> Updated ... mirror`.

## 1. Class-body `my` statics lost when the class is defined in a transient frame

`class C { my $x = ...; method m { $x } }` — the class body's `my` statics were only reachable while the class-body env stayed on the interpreter stack. On the success path of class registration that env is left intact, so a **top-level** `class`/`use` keeps the statics in the mainline env. But when the class is loaded via `require` **inside a sub** — exactly how zef loads its fetch plugins (`$*REPO.need` inside `Zef::Fetch`) — the loading frame's env is discarded on return, so a later method read got the type-object default instead. Concretely `my Lock $lock = Lock.new` read back as `Any`, so `$lock.protect { ... }` died with *"No such method 'protect' for invocant of type 'Any'"*, and both fetchers returned Nil ("Failed to update … mirror").

Fix:
- At class registration, record the class body's own `my` statics into `package_lexicals[C]` (reusing the package-block-lexical machinery for bare reads/writes and `writeback_package_scope_var` mutation persistence).
- A new field `class_body_static_names` marks those names so a **qualified** `$C::x` — which is a *distinct* package variable, not the static — does not resolve to the static (kept `t/package-lookup.t` green).
- During method dispatch, set `current_package` to the owner class when it has statics, and inject the statics into the method env so **every** read path resolves them — the `GetGlobal` opcode and the many direct `get_env_with_main_alias` reads used by metamethod/method-call fast paths (e.g. `$lock.^name`).

Test: `t/class-body-static-in-sub.t` (initialized static after the defining sub returns, mutable-static accumulator persistence, sharing across instances).

## 2. `Slip` did not satisfy a `--> List` / `--> Positional` return constraint

zef's `method !slurp-package-list(--> List) { ... try |Zef::from-json(...) }` returns a `Slip` (the `|` prefix), which died with *"expected List but got Slip"*. `Slip` is-a `List` (does `Positional`, is-a `Cool`) in Raku's hierarchy; added `Slip` to those arms of the static type table.

Test: `t/slip-satisfies-list-return.t`.

## Validation
- `make test`: **PASS** (1649 files, 16221 tests) — no regressions.
- `cargo clippy -- -D warnings` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)