### PR TITLE
perf(vm): gate var_type_constraint format!+env lookup behind monotonic flag

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1299,6 +1299,16 @@ pub struct Interpreter {
     /// which removes that cost from the hot variable-read path. Never cleared, so
     /// a program that stops using an atomic still resolves correctly.
     atomic_var_seen: bool,
+    /// Monotonic flag: set once any *env-scoped* variable type constraint has been
+    /// written (via `set_var_type_constraint`'s `env.insert` branch or
+    /// `bind_param_type_constraint`). The hot `var_type_constraint` read does a
+    /// `format!("__mutsu_type::{}")` + `env.get` on every variable write-back to
+    /// support env-first, block-scoped constraints (typed params shadowing
+    /// lexicals). When this flag is clear no env constraint exists, so the
+    /// name-keyed global `var_type_constraints` map is authoritative and the
+    /// `format!`+env lookup can be skipped entirely. Never cleared, so a program
+    /// that stops using env-scoped constraints still resolves correctly.
+    env_type_constraint_seen: bool,
     /// Variable default values set by `is default(...)` trait.
     var_defaults: HashMap<String, Value>,
     // Array/Hash element defaults are embedded in `ArrayData.default` /

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2064,6 +2064,7 @@ impl Interpreter {
             attributes_pragma: String::new(),
             var_type_constraints: HashMap::new(),
             atomic_var_seen: false,
+            env_type_constraint_seen: false,
             var_defaults: HashMap::new(),
             var_hash_key_constraints: HashMap::new(),
             instance_type_metadata: Arc::new(RwLock::new(HashMap::new())),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -249,6 +249,9 @@ impl Interpreter {
             // the child (which shares the atomic storage via shared_vars) must keep
             // running the atomic-variable read check.
             atomic_var_seen: self.atomic_var_seen,
+            // Inherit monotonically: the parent's env-scoped constraints are copied
+            // into the child's env, so the child must keep consulting env-first.
+            env_type_constraint_seen: self.env_type_constraint_seen,
             var_defaults: self.var_defaults.clone(),
             var_hash_key_constraints: self.var_hash_key_constraints.clone(),
             // Per-thread snapshot (not a shared-handle clone): deep-copy the map

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -66,6 +66,7 @@ impl Interpreter {
                 .insert(key.clone(), info.value_type.clone());
             self.env
                 .insert(meta_key, Value::str(info.value_type.clone()));
+            self.env_type_constraint_seen = true;
             let hash_key_meta_key = format!("__mutsu_hash_key_type::{}", key);
             if let Some(key_type) = info.key_type.clone() {
                 self.var_hash_key_constraints
@@ -118,6 +119,7 @@ impl Interpreter {
                     self.atomic_var_seen = true;
                 }
                 self.env.insert(meta_key, Value::str(info.value_type));
+                self.env_type_constraint_seen = true;
             }
             None => {
                 // An untyped scalar parameter shadows any same-named lexical: it
@@ -138,6 +140,13 @@ impl Interpreter {
 
     pub(crate) fn var_type_constraint(&self, name: &str) -> Option<String> {
         let key = name;
+        // Fast path: if no env-scoped constraint has ever been registered, the
+        // name-keyed global map is authoritative — skip the `format!` + env lookup.
+        // env-first ordering only matters once a param has shadowed a lexical, which
+        // requires an env constraint (flag=true). See `env_type_constraint_seen`.
+        if !self.env_type_constraint_seen {
+            return self.var_type_constraints.get(key).cloned();
+        }
         let meta_key = format!("__mutsu_type::{}", key);
         if let Some(ValueView::Str(tc)) = self.env.get(&meta_key).map(Value::view) {
             return Some(tc.to_string());


### PR DESCRIPTION
## Summary

Removes the single largest per-assignment cost identified by profiling `$i++` x20M: `var_type_constraint()` unconditionally built `format!(\"__mutsu_type::\$name\")` + did an env lookup on every variable write-back, even for untyped hot loops that never register an env-scoped constraint (~11% of write-back time).

## Change

Adds `env_type_constraint_seen`, a monotonic flag (same pattern as `atomic_var_seen`) set whenever an env-scoped type constraint is written. When clear, the name-keyed global `var_type_constraints` map is authoritative and the `format!`+env lookup is skipped. Inherited across thread spawns.

Correctness: env-first ordering only matters once a typed param shadows a same-named lexical, which requires an env constraint (flag=true); the fast path only triggers when no env constraint has ever been registered. Verified `roast/S02-types/nil.t` (the param-shadows-lexical f4 case) and all 63 whitelisted S02-types tests pass; `make test` green (1652 files).

Continues [[project_thread_and_varaccess_perf]] — the "次の一手" var-access micro-opt slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)