### PR TITLE
perf(vm): skip current_package RwLock+clone in write-back when no package-scope vars

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -274,6 +274,10 @@ impl Interpreter {
         self.our_vars.iter()
     }
 
+    pub(crate) fn our_vars_is_empty(&self) -> bool {
+        self.our_vars.is_empty()
+    }
+
     pub(crate) fn set_our_var(&mut self, key: String, value: Value) {
         self.our_vars.insert(key, value);
     }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -248,6 +248,15 @@ impl Interpreter {
     /// package-scope var (a fresh global, a dynamic var, `$_`, ...) returns
     /// `false` and the caller's normal store path applies unchanged.
     pub(super) fn writeback_package_scope_var(&mut self, name: &str, val: &Value) -> bool {
+        // Both branches below require a hit in `our_vars` (package-qualified `our`
+        // var) or `package_lexicals` (package-block `my` static). When both stores
+        // are empty — the common case for a plain-lexical hot loop — there is
+        // nothing to write back, so skip the `current_package()` RwLock read +
+        // `String` clone entirely. This is the dominant cost of the inc-dec
+        // write-back path once the type-constraint check is gated away.
+        if self.our_vars_is_empty() && self.package_lexicals.is_empty() {
+            return false;
+        }
         let cur = self.current_package();
         if let Some(candidate) = Self::package_qualified_candidate(name, &cur)
             && self.get_our_var(&candidate).is_some()


### PR DESCRIPTION
## Summary

Follow-up to #4405 on the variable write-back hot path ([[project_thread_and_varaccess_perf]]).

`writeback_package_scope_var` runs on every inc-dec / compound-assign write-back and unconditionally called `current_package()` — an `Arc<RwLock<String>>` read plus a `String` clone (profiled at ~6.4% of the write-back path, and a multi-thread contention point) — before checking either of its two stores.

Both of its branches require a hit in `our_vars` (package-qualified \`our\` var) or \`package_lexicals\` (package-block \`my\` static). When both are empty — the common case for a plain-lexical hot loop — the function can only return false. This gates on \`our_vars.is_empty() && package_lexicals.is_empty()\` to skip the lock read + heap alloc entirely.

## Verification

- One-shot probe confirmed a top-level \`while \$i < N { \$i++ }\` loop hits \`our_vars.len=0 package_lexicals.len=0\`, so the gate fires.
- \`make test\` green (1652 files).
- All whitelisted S02-names-vars / S02-packages / S10-packages / S11-modules / S14-traits/package / S22-package-format tests pass (the cases that exercise the non-empty path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)