### PR TITLE
perf(vm): gate propagate_sigilless_alias_chain behind a monotonic flag

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1309,6 +1309,16 @@ pub struct Interpreter {
     /// `format!`+env lookup can be skipped entirely. Never cleared, so a program
     /// that stops using env-scoped constraints still resolves correctly.
     env_type_constraint_seen: bool,
+    /// Monotonic flag: set once any sigilless-parameter alias
+    /// (`__mutsu_sigilless_alias::name` env key, created when binding a `\target`
+    /// raw/sigilless parameter or a `:=`-style alias) has been registered. The hot
+    /// write-back path calls `propagate_sigilless_alias_chain` on every inc-dec /
+    /// compound-assign, which builds `format!("__mutsu_sigilless_alias::{name}")`
+    /// plus an env lookup to walk the alias chain. Sigilless aliases are rare; when
+    /// this flag is clear no alias key exists, the chain is empty, and the whole
+    /// walk (and its `format!`) is skipped. Set at every alias-insert site (see
+    /// `sigilless_alias_key`). Never cleared, so removing an alias still resolves.
+    sigilless_alias_seen: bool,
     /// Variable default values set by `is default(...)` trait.
     var_defaults: HashMap<String, Value>,
     // Array/Hash element defaults are embedded in `ArrayData.default` /

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2065,6 +2065,7 @@ impl Interpreter {
             var_type_constraints: HashMap::new(),
             atomic_var_seen: false,
             env_type_constraint_seen: false,
+            sigilless_alias_seen: false,
             var_defaults: HashMap::new(),
             var_hash_key_constraints: HashMap::new(),
             instance_type_metadata: Arc::new(RwLock::new(HashMap::new())),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -252,6 +252,9 @@ impl Interpreter {
             // Inherit monotonically: the parent's env-scoped constraints are copied
             // into the child's env, so the child must keep consulting env-first.
             env_type_constraint_seen: self.env_type_constraint_seen,
+            // Inherit monotonically: the parent's sigilless-alias env keys are
+            // copied into the child env, so the child must keep walking the chain.
+            sigilless_alias_seen: self.sigilless_alias_seen,
             var_defaults: self.var_defaults.clone(),
             var_hash_key_constraints: self.var_hash_key_constraints.clone(),
             // Per-thread snapshot (not a shared-handle clone): deep-copy the map

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -178,6 +178,21 @@ impl Interpreter {
         self.atomic_var_seen = true;
     }
 
+    /// Whether any sigilless-parameter alias (`__mutsu_sigilless_alias::name` env
+    /// key) has ever been registered (monotonic). When false, the write-back path
+    /// can skip the entire `propagate_sigilless_alias_chain` walk (which otherwise
+    /// costs a `format!` + env lookup on every inc-dec / compound-assign).
+    #[inline(always)]
+    pub(crate) fn sigilless_alias_seen(&self) -> bool {
+        self.sigilless_alias_seen
+    }
+
+    /// Mark that a sigilless-parameter alias env key has been registered. Called at
+    /// every `__mutsu_sigilless_alias::*` insert site (see `sigilless_alias_key`).
+    pub(crate) fn mark_sigilless_alias_seen(&mut self) {
+        self.sigilless_alias_seen = true;
+    }
+
     /// Set the default value for a variable declared with `is default(...)`.
     pub(crate) fn set_var_default(&mut self, name: &str, value: Value) {
         self.var_defaults.insert(name.to_string(), value);

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1137,6 +1137,7 @@ impl Interpreter {
                             // caller's variable.
                             let alias_key = format!("__mutsu_sigilless_alias::{}", pd.name);
                             self.env.insert(alias_key, Value::str(source_name));
+                            self.sigilless_alias_seen = true;
                         } else if matches!(args[positional_idx].view(), ValueView::ContainerRef(_))
                         {
                             // A bare `ContainerRef` cell (e.g. the leaf container
@@ -1280,6 +1281,7 @@ impl Interpreter {
                             value = inner;
                             self.env.insert(alias_key, Value::str(resolved_source));
                             self.env.insert(readonly_key, Value::FALSE);
+                            self.sigilless_alias_seen = true;
                         } else if let Some(source_name) = arg_sources
                             .as_ref()
                             .and_then(|names| names.get(positional_idx))
@@ -1301,6 +1303,7 @@ impl Interpreter {
                                 value = source_val;
                                 self.env.insert(alias_key, Value::str(resolved_source));
                                 self.env.insert(readonly_key, Value::FALSE);
+                                self.sigilless_alias_seen = true;
                             } else {
                                 self.env.remove(&alias_key);
                                 self.env.insert(readonly_key, Value::TRUE);

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -905,6 +905,7 @@ impl Interpreter {
                 let alias_key = format!("__mutsu_sigilless_alias::{}", captured_name);
                 if let Some(v) = self.env().get(&alias_key).cloned() {
                     restored_env.insert(alias_key, v);
+                    self.mark_sigilless_alias_seen();
                 }
             }
             self.merge_sigilless_alias_writes(&mut restored_env, self.env());

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1056,6 +1056,7 @@ impl Interpreter {
                     }
                     self.env_mut()
                         .insert(alias_key.clone(), Value::str(resolved_source.clone()));
+                    self.mark_sigilless_alias_seen();
                     // Propagate readonly status from the source variable.
                     // Binding to a readonly parameter should make the target
                     // readonly as well (persisted in env for cross-scope survival).

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -302,6 +302,7 @@ impl Interpreter {
             self.env_mut()
                 .insert(alias_key.clone(), Value::str(resolved_source));
             self.env_mut().insert(readonly_key, Value::FALSE);
+            self.mark_sigilless_alias_seen();
         }
         // If the current value is a Proxy (in locals or env), invoke STORE instead of overwriting
         {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1248,6 +1248,7 @@ impl Interpreter {
             self.env_mut()
                 .insert(alias_key.clone(), Value::str(resolved_source.clone()));
             self.env_mut().insert(readonly_key, Value::FALSE);
+            self.mark_sigilless_alias_seen();
             // Create a shared ContainerRef for cross-scope binding (source in
             // outer call frame) OR same-scope rebinding (`:=` on existing vars).
             // ContainerRef ensures bidirectional container sharing: writing to
@@ -1296,6 +1297,7 @@ impl Interpreter {
             if scalar_source.is_some() {
                 self.env_mut()
                     .insert(alias_key.clone(), Value::str(effective_source.clone()));
+                self.mark_sigilless_alias_seen();
             }
             // Whole-container `:=` bind (`my @b := @a`, `my %h2 := %h`,
             // `my $ref := @a`): share a single `ContainerRef` cell between the

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -709,6 +709,11 @@ impl Interpreter {
         name: &str,
         val: &Value,
     ) {
+        // Fast path: no sigilless-parameter alias has ever been registered, so the
+        // chain is empty — skip the `format!` + env lookup entirely.
+        if !self.sigilless_alias_seen() {
+            return;
+        }
         let alias_key = format!("__mutsu_sigilless_alias::{}", name);
         let mut alias_name = self.env().get(&alias_key).and_then(|v| {
             if let ValueView::Str(n) = v.view() {


### PR DESCRIPTION
## Summary

Third slice on the variable write-back hot path (follows #4405, #4406; [[project_thread_and_varaccess_perf]]).

`store_named_scalar_rmw_result` calls `propagate_sigilless_alias_chain` on every inc-dec / compound-assign, which builds \`format!("__mutsu_sigilless_alias::{name}")\` + an env lookup to walk the alias chain — even though sigilless-parameter aliases (\`\target\` raw params, \`:=\` binds) are exotic and absent from a plain-lexical hot loop (profiled at ~5.3% of the write-back path).

## Change

Adds \`sigilless_alias_seen\`, a monotonic flag (same pattern as the existing \`atomic_var_seen\` / \`env_type_constraint_seen\`) set at **every** \`__mutsu_sigilless_alias::*\` env-key insert site — all 8 enumerated: 3 in \`binding_signature\`, plus \`vm_misc_assign\`, \`vm_closure_dispatch\`, \`vm_exec_dispatch\`, and 2 in \`vm_var_assign_set_local\`. When clear, no alias key exists so the chain is empty and the whole walk (and its \`format!\`) is skipped. Inherited across thread spawns.

## Verification

- All sigilless / rw-param \`t/\` tests pass (closure-rw-param-writeback, for-sigilless-rw, method-rw-param-writeback-coherence, multiframe-sigilless-for-rebind-coherence, rw-param-shared-cell, rw-param-writeback-coherence, sigilless-alias-writeback-coherence, sigilless-params, ...).
- Gate confirmed to fire for a top-level \`while \$i < N { \$i++ }\` loop.
- \`make test\` green (1652 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)