### PR TITLE
perf(regex): cache registry snapshot for grammar/regex sub-interpreters

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1093,6 +1093,20 @@ pub struct Interpreter {
     /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
     registry: Arc<RwLock<Registry>>,
+    /// Monotonic counter bumped on every `registry_mut()` acquisition, i.e. every
+    /// time the declaration registry may have been mutated. Used to invalidate
+    /// [`Self::regex_registry_snapshot`] so a cached snapshot is only reused while
+    /// the registry is unchanged. `AtomicU64` (not `Cell`) so `Interpreter` stays
+    /// `Send`/`Sync` — `registry_mut()` takes `&self`.
+    registry_write_gen: std::sync::atomic::AtomicU64,
+    /// Cached deep-clone snapshot of the registry (paired with the
+    /// `registry_write_gen` it was taken at) shared into the short-lived
+    /// sub-interpreters built for regex/grammar evaluation. In a hot loop that
+    /// matches many regexes/grammar tokens without declaring anything new (e.g.
+    /// zef parsing thousands of dist identities via a `grammar ... :actions`),
+    /// this collapses a full-registry deep clone *per token match* into a single
+    /// clone reused by `Arc::clone`. See `copy_full_registry_into`.
+    regex_registry_snapshot: Mutex<Option<(u64, Arc<RwLock<Registry>>)>>,
     /// Active `{*}` proto dispatch frames: (proto_name, args, method_ctx).
     /// `method_ctx` is `Some` when the active proto is a `proto method` body, so
     /// `{*}` redispatches to a multi *method* candidate on the invocant rather

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -42,8 +42,34 @@ impl Interpreter {
     /// the action class's methods live in `Registry::classes`, which the leaner
     /// `copy_decl_registry_into` omits.
     pub(crate) fn copy_full_registry_into(&self, target: &mut Interpreter) {
-        let snapshot = self.registry().clone();
-        *target.registry_mut() = snapshot;
+        // The sub-interpreter only READS the registry during regex/grammar
+        // evaluation (dispatching methods, resolving tokens/actions); it never
+        // declares new classes into it. So rather than deep-cloning the entire
+        // registry (all classes/roles/methods) on every call — catastrophic in a
+        // hot loop matching thousands of grammar tokens, each triggering a full
+        // clone — reuse a single cached snapshot behind an `Arc<RwLock>`, rebuilt
+        // only when the registry actually changed (tracked by `registry_write_gen`).
+        //
+        // Isolation is preserved: the snapshot is a SEPARATE `Arc<RwLock>` from
+        // `self.registry`, so any (rare) write a sub-interpreter makes lands on the
+        // shared snapshot, never leaking back into the parent's registry. Each
+        // thread has its own `Interpreter` (and thus its own cache), so the shared
+        // snapshot lock is never contended across threads.
+        let cur_gen = self
+            .registry_write_gen
+            .load(std::sync::atomic::Ordering::Relaxed);
+        {
+            let cache = self.regex_registry_snapshot.lock().unwrap();
+            if let Some((cached_gen, snapshot)) = &*cache
+                && *cached_gen == cur_gen
+            {
+                target.registry = Arc::clone(snapshot);
+                return;
+            }
+        }
+        let snapshot = Arc::new(RwLock::new(self.registry().clone()));
+        *self.regex_registry_snapshot.lock().unwrap() = Some((cur_gen, Arc::clone(&snapshot)));
+        target.registry = snapshot;
     }
 
     /// Evaluate a closure interpolation `<{ code }>` inside a regex.

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -238,6 +238,11 @@ impl Interpreter {
     /// as [`Self::registry`].
     #[inline]
     pub(crate) fn registry_mut(&self) -> crate::runtime::registry::RegistryWriteGuard<'_> {
+        // Any write access may mutate the registry, so invalidate the cached
+        // regex/grammar snapshot (see `regex_registry_snapshot`). Cheap relaxed
+        // bump; the snapshot cache compares this generation before reusing.
+        self.registry_write_gen
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         crate::runtime::registry::RegistryWriteGuard::new(&self.registry, "registry")
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2009,6 +2009,8 @@ impl Interpreter {
                 };
                 Arc::new(RwLock::new(registry))
             },
+            registry_write_gen: std::sync::atomic::AtomicU64::new(0),
+            regex_registry_snapshot: Mutex::new(None),
             proto_dispatch_stack: Vec::new(),
             proto_method_skip: None,
             pending_dispatch_error: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -188,6 +188,10 @@ impl Interpreter {
             // independent snapshot (matches prior per-field clone semantics: the
             // child sees parent declarations but its own new ones don't leak back).
             registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
+            // Fresh per-thread: the snapshot cache must not be shared across
+            // threads (each thread's `Interpreter` owns its own registry).
+            registry_write_gen: std::sync::atomic::AtomicU64::new(0),
+            regex_registry_snapshot: Mutex::new(None),
             proto_dispatch_stack: Vec::new(),
             proto_method_skip: None,
             pending_dispatch_error: None,

--- a/t/grammar-registry-snapshot-cache.t
+++ b/t/grammar-registry-snapshot-cache.t
@@ -1,0 +1,45 @@
+use Test;
+
+# Regression test for the regex/grammar registry-snapshot cache
+# (perf-regex-registry-snapshot-cache): a grammar-with-actions parse builds a
+# sub-interpreter per matched subrule/token and copies the declaration registry
+# into it. That copy is now served from a per-interpreter cached snapshot, reused
+# by Arc::clone while the registry is unchanged, instead of a full deep clone per
+# token match. This guards that:
+#   1. grammar+actions still produce correct results (cache preserves semantics),
+#   2. repeated parses stay correct (cache reuse across many calls), and
+#   3. declaring a NEW class between parses is reflected (cache invalidation).
+
+plan 5;
+
+# Uses a negated SUBRULE (<-sep>) so token resolution copies the registry into a
+# sub-interpreter (the path the snapshot cache accelerates).
+grammar Words {
+    token TOP  { <word>+ % <sep> }
+    token word { <-sep>+ }
+    token sep  { ' ' }
+}
+class UpperActions {
+    method TOP($/)  { make $<word>.map(*.made).join("-") }
+    method word($/) { make $/.Str.uc }
+}
+
+is Words.parse("hello world", :actions(UpperActions)).made, "HELLO-WORLD",
+    "grammar+actions correct";
+is Words.parse("a b c d", :actions(UpperActions)).made, "A-B-C-D",
+    "grammar+actions correct (more words)";
+
+# Repeated parses (exercises snapshot cache reuse across many calls).
+my @results;
+for 1..50 {
+    @results.push: Words.parse("foo bar baz", :actions(UpperActions)).made;
+}
+is @results.elems, 50, "50 repeated parses ran";
+is @results.all eq "FOO-BAR-BAZ", True, "every repeated parse correct";
+
+# Declaring more classes (bumps the registry generation -> cache invalidated) must
+# not change parse results.
+class Extra1 { method x { 1 } }
+class Extra2 { method y { 2 } }
+is Words.parse("still works", :actions(UpperActions)).made, "STILL-WORKS",
+    "parse still correct after new class declarations (cache invalidation)";


### PR DESCRIPTION
## Problem

`zef list` / `zef list --update` never completes within minutes — not a correctness
bug, a **perf explosion**. Profiling the CPU-bound worker (mutsu runs zef in a child
process; the parent blocks in `sigsuspend`) with `perf --call-graph fp` on a
frame-pointer debug build pinned the hot path:

```
regex_match_atom_in_pkg
  -> resolve_token_patterns_with_args_in_pkg
    -> copy_decl_registry_into
      -> copy_full_registry_into
        -> Registry::clone   (full deep clone of ALL classes/roles/methods)
```

Zef parses every dist identity via `Zef::Identity`'s
`grammar REQUIRE { token ... } ; REQUIRE.parse($id, :actions(REQUIRE::Actions))`.
`current_grammar_actions.is_some()` forces the FULL registry clone, and the negated
subrule `<-restricted>` triggers `copy_decl_registry_into` **~120x per parse**. So
parsing ~30k dist identities was `O(dists x tokens x registry_size)` full deep
clones of the entire declaration registry.

## Fix

Serve the sub-interpreter's registry copy from a **per-interpreter cached snapshot**
gated by a `registry_write_gen` counter (bumped in `registry_mut()`).
`copy_full_registry_into` reuses the cached `Arc<RwLock<Registry>>` by `Arc::clone`
while the generation is unchanged, rebuilding the deep clone only when the registry
actually changed. This collapses the ~120 deep clones/parse into **1 deep clone +
119 Arc-bumps**.

**Measured 2.1x faster** on a zef-shape microbench (60 classes, negated-subrule
grammar+actions, 300 parses: 158.7s -> 75.2s debug). The win scales with registry
size, so real zef (many modules loaded) benefits more.

Isolation is preserved: the snapshot is a SEPARATE `Arc<RwLock>` from
`self.registry`, so a sub-interpreter's writes land on the shared snapshot and never
leak back to the parent. Each thread has its own `Interpreter` (own cache), so the
snapshot lock is never contended across threads.

## Tests

- `t/grammar-registry-snapshot-cache.t` — grammar+actions correctness under 50
  repeated parses and after mid-stream class declarations (cache invalidation).
- `make test`: all 1652 files / 16240 tests pass.
- 20 sampled S05 grammar/capture/metasyntax roast tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)