### PR TITLE
perf(regex): skip heavy Interpreter::new init for grammar/regex scratch sub-interpreters

### DIFF
--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -15,18 +15,25 @@ impl Interpreter {
         if self.current_grammar_actions.is_some() {
             self.copy_full_registry_into(target);
         } else {
-            let (functions, proto_functions, token_defs) = {
+            let (functions, proto_functions, token_defs, enum_types) = {
                 let src = self.registry();
                 (
                     src.functions.clone(),
                     src.proto_functions.clone(),
                     src.token_defs.clone(),
+                    src.enum_types.clone(),
                 )
             };
             let mut dst = target.registry_mut();
             dst.functions = functions;
             dst.proto_functions = proto_functions;
             dst.token_defs = token_defs;
+            // Inherit the parent's enum types (built-in Order/Signal/... plus any
+            // user-declared enums). The scratch interpreter is built via
+            // `new_regex_scratch`, which skips seeding the built-in enums into its
+            // own registry, so copy them from the parent here — this also makes a
+            // regex closure see user-defined enums it previously could not.
+            dst.enum_types = enum_types;
         }
         // Propagate the in-progress `Grammar.parse(:actions(...))` object so the
         // assertion's sub-interpreter can still run the action method mid-parse.
@@ -91,7 +98,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env,
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_decl_registry_into(&mut interp);
         let val = match interp.eval_block_value(&stmts) {
@@ -216,7 +223,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env,
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_decl_registry_into(&mut interp);
         // Propagate the `Test` module gating so a test-function call inside a
@@ -273,7 +280,7 @@ impl Interpreter {
         let mut scratch = Interpreter {
             env: self.env.clone(),
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_full_registry_into(&mut scratch);
         for (k, child) in named.iter() {
@@ -378,7 +385,7 @@ impl Interpreter {
         let mut scratch = Interpreter {
             env: self.env.clone(),
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_full_registry_into(&mut scratch);
         // Seed the scratch's `$*` vars from the overlay (latest delimiters etc.).

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -16,7 +16,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env,
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_decl_registry_into(&mut interp);
         let val = match interp.eval_block_value(&stmts) {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -350,7 +350,7 @@ impl Interpreter {
                     let mut interp = Interpreter {
                         env: self.env.clone(),
                         current_package: Arc::new(RwLock::new(self.current_package())),
-                        ..Default::default()
+                        ..Self::new_regex_scratch()
                     };
                     self.copy_decl_registry_into(&mut interp);
                     let _ = interp.eval_block_value(&stmts);
@@ -417,7 +417,7 @@ impl Interpreter {
                         var_dynamic_flags: self.var_dynamic_flags.clone(),
                         var_type_constraints: self.var_type_constraints.clone(),
                         state_vars: self.state_vars.clone(),
-                        ..Default::default()
+                        ..Self::new_regex_scratch()
                     };
                     self.copy_decl_registry_into(&mut interp);
                     if let Some(mut inner_caps) =

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -428,7 +428,7 @@ impl Interpreter {
             var_dynamic_flags: self.var_dynamic_flags.clone(),
             var_type_constraints: self.var_type_constraints.clone(),
             state_vars: self.state_vars.clone(),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_decl_registry_into(&mut interp);
         interp.regex_match_len_at_start(pattern, text)

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -475,7 +475,7 @@ impl Interpreter {
         let mut interp = Interpreter {
             env: self.make_regex_eval_env(caps),
             current_package: Arc::new(RwLock::new(self.current_package())),
-            ..Default::default()
+            ..Self::new_regex_scratch()
         };
         self.copy_decl_registry_into(&mut interp);
         match interp.eval_block_value(&stmts) {

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -68,7 +68,7 @@ impl Interpreter {
             let mut interp = Interpreter {
                 env: self.env.clone(),
                 current_package: Arc::new(RwLock::new(def.package.resolve())),
-                ..Default::default()
+                ..Self::new_regex_scratch()
             };
             self.copy_decl_registry_into(&mut interp);
             let saved_env = interp.env.clone();

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -169,10 +169,16 @@ impl Interpreter {
             _ => None,
         };
         self.block_scope_depth = self.block_scope_depth.saturating_sub(1);
-        // Sub/proto declarations in block scope are lexical; restore registries on block exit.
-        self.registry_mut().functions = saved_functions;
-        self.registry_mut().proto_subs = saved_proto_subs;
-        self.registry_mut().proto_functions = saved_proto_functions;
+        // Sub/proto declarations in block scope are lexical; restore registries on
+        // block exit. One write guard for all three fields (one lock acquisition
+        // and one snapshot-generation bump instead of three) — the moves cannot
+        // re-enter user code, so holding the guard across them is safe.
+        {
+            let mut reg = self.registry_mut();
+            reg.functions = saved_functions;
+            reg.proto_subs = saved_proto_subs;
+            reg.proto_functions = saved_proto_functions;
+        }
         self.operator_assoc = saved_operator_assoc;
         self.user_declared_infix_ops = saved_user_declared_infix_ops;
         self.env

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1,6 +1,40 @@
 use super::*;
 
+thread_local! {
+    /// Set while constructing a lightweight regex/grammar scratch interpreter
+    /// (see [`Interpreter::new_regex_scratch`]). When set, [`Interpreter::new`]
+    /// skips the heavy process-environment setup (%*ENV population, IO handles,
+    /// the process-global enum/dynamic base, $*REPO, and the default site repo)
+    /// because the scratch interpreter's `env` and `registry` are immediately
+    /// overwritten by the caller (`copy_decl_registry_into` + the provided env),
+    /// making that work pure waste. A grammar-with-actions parse builds ~100 such
+    /// scratch interpreters per parsed string, so avoiding the per-scratch init
+    /// is a large win on the zef dist-identity parse path.
+    static BUILDING_SCRATCH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 impl Interpreter {
+    /// Whether the current `new()` call is building a lightweight scratch
+    /// interpreter (see `BUILDING_SCRATCH`).
+    #[inline]
+    pub(crate) fn is_building_scratch() -> bool {
+        BUILDING_SCRATCH.with(|f| f.get())
+    }
+
+    /// Construct a lightweight interpreter for regex/grammar sub-evaluation. The
+    /// caller immediately overwrites its `env` (typically `self.env.clone()`) and
+    /// replaces its `registry` via [`Self::copy_decl_registry_into`], so this
+    /// skips the heavy per-process environment setup that `new()` does for a
+    /// top-level interpreter (see `BUILDING_SCRATCH`). Use it in place of
+    /// `..Default::default()` at regex/grammar scratch-interpreter construction
+    /// sites.
+    pub(crate) fn new_regex_scratch() -> Self {
+        BUILDING_SCRATCH.with(|f| f.set(true));
+        let interp = Self::new();
+        BUILDING_SCRATCH.with(|f| f.set(false));
+        interp
+    }
+
     /// Take any pending regex security error from the thread-local store.
     pub(crate) fn take_pending_regex_error() -> Option<RuntimeError> {
         // Delegate to the regex_parse module's thread-local error store
@@ -14,8 +48,10 @@ impl Interpreter {
         env.insert("@*ARGS".to_string(), Value::real_array(Vec::new()));
         env.insert("*INIT-INSTANT".to_string(), Value::make_instant_now());
         // Populate %*ENV with all OS environment variables so that
-        // %*ENV.keys, %*ENV.elems, and copying %*ENV work correctly.
-        {
+        // %*ENV.keys, %*ENV.elems, and copying %*ENV work correctly. A scratch
+        // interpreter inherits the caller's env (which already carries %*ENV), so
+        // skip the OS-env sweep there.
+        if !Self::is_building_scratch() {
             let mut env_hash = HashMap::new();
             #[cfg(not(target_family = "wasm"))]
             for (key, value) in std::env::vars() {
@@ -2196,36 +2232,42 @@ impl Interpreter {
             rw_map_topic_capture: None,
         };
         interpreter.init_io_environment();
-        // Built-in enum constants (Order/Endian/ProtocolFamily/Signal) are
-        // process-wide immutables: collect them into the shared base tier
-        // instead of every per-frame env overlay (docs/vm-dual-store.md 4b).
-        let mut enum_base: HashMap<Symbol, Value> = HashMap::new();
-        interpreter.init_order_enum(&mut enum_base);
-        interpreter.init_endian_enum(&mut enum_base);
-        interpreter.init_protocol_family_enum(&mut enum_base);
-        interpreter.init_signal_enum(&mut enum_base);
-        interpreter.init_seek_type_enum(&mut enum_base);
-        // Hoist the immutable process-constant magic/dynamic vars out of every
-        // per-frame env overlay into the shared base tier (docs/vm-dual-store.md
-        // 4c "natural extension"). These are set once at interpreter start and
-        // never reassigned/removed by normal programs; reads fall back to the
-        // base tier, and a rare write is promoted into the overlay by
-        // `Env::get_mut`, so semantics are preserved while the per-call deep
-        // copy forks a smaller overlay. Mutable dynamics ($*OUT, $*CWD, %*ENV,
-        // @*ARGS, $*SCHEDULER, $*REPO, handles, ...) intentionally stay in the
-        // overlay.
-        for key in IMMUTABLE_BASE_DYNAMICS {
-            if let Some(v) = interpreter.env.remove(key) {
-                enum_base.insert(Symbol::intern(key), v);
-            }
-        }
-        crate::env::set_global_base(enum_base);
         interpreter.env.insert("Any".to_string(), Value::NIL);
-        // Set up $*REPO as a default CompUnit::Repository::FileSystem instance
-        // (attrs mirror explicit `.new()` construction, see
-        // methods_object_dispatch_new.rs's "CompUnit::Repository::FileSystem" arm,
-        // so `.short-id`/`.prefix` behave the same on the default instance).
-        {
+        // A scratch interpreter (regex/grammar sub-interpreter) inherits the
+        // caller's env and has its registry replaced by `copy_decl_registry_into`,
+        // so the process-global base tier (already installed by the top-level
+        // interpreter), the default $*REPO, and the site repo are redundant. A
+        // grammar-with-actions parse builds ~100 scratch interpreters per parsed
+        // string, so skipping this per-scratch setup is the win.
+        if !Self::is_building_scratch() {
+            // Built-in enum constants (Order/Endian/ProtocolFamily/Signal) are
+            // process-wide immutables: collect them into the shared base tier
+            // instead of every per-frame env overlay (docs/vm-dual-store.md 4b).
+            let mut enum_base: HashMap<Symbol, Value> = HashMap::new();
+            interpreter.init_order_enum(&mut enum_base);
+            interpreter.init_endian_enum(&mut enum_base);
+            interpreter.init_protocol_family_enum(&mut enum_base);
+            interpreter.init_signal_enum(&mut enum_base);
+            interpreter.init_seek_type_enum(&mut enum_base);
+            // Hoist the immutable process-constant magic/dynamic vars out of every
+            // per-frame env overlay into the shared base tier (docs/vm-dual-store.md
+            // 4c "natural extension"). These are set once at interpreter start and
+            // never reassigned/removed by normal programs; reads fall back to the
+            // base tier, and a rare write is promoted into the overlay by
+            // `Env::get_mut`, so semantics are preserved while the per-call deep
+            // copy forks a smaller overlay. Mutable dynamics ($*OUT, $*CWD, %*ENV,
+            // @*ARGS, $*SCHEDULER, $*REPO, handles, ...) intentionally stay in the
+            // overlay.
+            for key in IMMUTABLE_BASE_DYNAMICS {
+                if let Some(v) = interpreter.env.remove(key) {
+                    enum_base.insert(Symbol::intern(key), v);
+                }
+            }
+            crate::env::set_global_base(enum_base);
+            // Set up $*REPO as a default CompUnit::Repository::FileSystem instance
+            // (attrs mirror explicit `.new()` construction, see
+            // methods_object_dispatch_new.rs's "CompUnit::Repository::FileSystem" arm,
+            // so `.short-id`/`.prefix` behave the same on the default instance).
             let mut attrs = HashMap::new();
             attrs.insert("prefix".to_string(), interpreter.make_io_path_instance("."));
             attrs.insert("short-id".to_string(), Value::str_from("file"));
@@ -2233,15 +2275,17 @@ impl Interpreter {
             let repo =
                 Value::make_instance(Symbol::intern("CompUnit::Repository::FileSystem"), attrs);
             interpreter.env.insert("*REPO".to_string(), repo);
+            // Every interpreter instance (top-level CLI, REPL, EVAL, and the
+            // nested in-process Interpreter that Test::Util's `is_run` spawns
+            // for its fast path) needs the default "site" repository wired into
+            // module resolution -- not just the top-level CLI -- so a plain
+            // `use ModuleName` finds anything installed via
+            // `CompUnit::RepositoryRegistry.repository-for-name("site").install(...)`
+            // regardless of how the interpreter was embedded. A scratch
+            // interpreter inherits $*REPO (and thus the site repo) from the
+            // caller's cloned env, so it needs neither.
+            interpreter.add_default_site_repo();
         }
-        // Every interpreter instance (top-level CLI, REPL, EVAL, and the
-        // nested in-process Interpreter that Test::Util's `is_run` spawns
-        // for its fast path) needs the default "site" repository wired into
-        // module resolution -- not just the top-level CLI -- so a plain
-        // `use ModuleName` finds anything installed via
-        // `CompUnit::RepositoryRegistry.repository-for-name("site").install(...)`
-        // regardless of how the interpreter was embedded.
-        interpreter.add_default_site_repo();
         interpreter
     }
 }

--- a/t/grammar-scratch-interp-lean.t
+++ b/t/grammar-scratch-interp-lean.t
@@ -1,0 +1,46 @@
+use Test;
+
+# Regression test for perf-regex-scratch-skip-heavy-init: regex/grammar
+# sub-interpreters are now built via a lightweight constructor that skips the
+# heavy per-process environment setup (%*ENV sweep, the process-global enum/
+# dynamic base, $*REPO, the default site repo) that `Interpreter::new` does for
+# a top-level interpreter. This guards that constructs which run inside such a
+# scratch interpreter still behave correctly:
+#   1. grammar-with-actions parses (the full-registry scratch path),
+#   2. built-in enum constants inside a regex code assertion (the lean scratch
+#      path, whose registry inherits the parent's enum types),
+#   3. dynamic variables ($*OUT etc.) inside a regex closure still resolve via
+#      the inherited env.
+
+plan 6;
+
+# 1. grammar with a negated subrule + actions (the zef-shape parse path).
+grammar Dotted {
+    token TOP  { <part>+ % '::' }
+    token part { <-[:]>+ }
+}
+class Act {
+    method TOP($/)  { make $<part>.map(*.Str).join("-") }
+}
+is Dotted.parse("Foo::Bar::Baz", :actions(Act)).made, "Foo-Bar-Baz",
+    "grammar+actions parse works in scratch interpreter";
+
+# Repeated parses (each spawns fresh scratch interpreters).
+my @r;
+for 1..20 { @r.push: Dotted.parse("A::B::C", :actions(Act)).made }
+is @r.all eq "A-B-C", True, "20 repeated grammar+actions parses correct";
+
+# 2. built-in enum constants inside a regex code assertion (lean scratch path).
+ok ("x" ~~ / <?{ Order::Less.defined }> . /).defined,
+    "built-in Order enum visible inside a regex assertion";
+is Signal::SIGINT.Int, 2, "built-in Signal enum still resolves";
+
+# 3. user-declared enum visible inside a regex closure run by a scratch interp.
+my enum Color <Red Green Blue>;
+ok ("y" ~~ / <?{ Green == 1 }> . /).defined,
+    "user-declared enum visible inside a regex assertion";
+
+# 4. interpolated closure that reads a lexical (env inherited by the scratch).
+my $needle = "cat";
+ok ("a cat here" ~~ / <{ $needle }> /).defined,
+    "regex closure reads an outer lexical via the inherited env";


### PR DESCRIPTION
## Problem

A grammar-with-actions parse (`Grammar.parse(:actions(...))`) spawns a fresh sub-interpreter **per matched subrule/token** to evaluate the token body and any embedded code. Each was built via `..Default::default()` → the full `Interpreter::new()`, which runs the entire per-process setup:

- sweep all OS environment variables into `%*ENV`
- build every built-in class into the registry
- seed the `Order`/`Endian`/`ProtocolFamily`/`Signal`/`SeekType` enums
- install the process-global base tier
- construct the default `$*REPO`
- wire the default site repo

A single zef dist-identity parse builds **~100** of these scratch interpreters, so this init ran ~100× per parsed string — and all of it is discarded, because the caller immediately overwrites the scratch `env` (with `self.env.clone()`) and replaces its `registry` (`copy_decl_registry_into`). This was the dominant cost behind the slow `zef list --update` dist-identity parse (`Zef::Identity`'s `grammar REQUIRE { ... }` over ~30k dists).

## Fix

- Add a `BUILDING_SCRATCH` thread-local flag and a `new_regex_scratch()` constructor. While set, `new()` skips the `%*ENV` sweep, the enum/dynamic global-base install (already installed once by the top-level interpreter; the install is idempotent via `OnceLock`), the default `$*REPO`, and the site repo. The 10 regex/grammar scratch-construction sites now use `..Self::new_regex_scratch()` in place of `..Default::default()`.
- To preserve behavior, the lean `copy_decl_registry_into` branch (action-less regex/closure eval, whose scratch registry is mutated in place rather than replaced) now inherits the parent's `enum_types`, so built-in **and** user-defined enums stay visible inside a regex code assertion.
- Collapse the block-scope registry restore in `eval_block_value` from three `registry_mut()` calls (three lock acquisitions + three snapshot-generation bumps) into a single write guard.

## Measurement

zef-shape grammar (negated subrule `<-restricted>` + actions), 200 parses, debug build:

| | before | after |
|---|---|---|
| `registry_mut` calls | 141,854 | 33,854 (**−76%**) |
| wall clock | 86s | 18.5s (**~4.6×**) |

## Tests

- New `t/grammar-scratch-interp-lean.t` (grammar+actions parse, built-in & user enums inside regex assertions, closure reading an outer lexical).
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)