### PR TITLE
fix(gc): close two STW soundness races that corrupted the cycle scan under threads

### DIFF
--- a/src/gc/stw.rs
+++ b/src/gc/stw.rs
@@ -122,7 +122,15 @@ pub(crate) fn test_reset() {
 }
 
 fn quiescent_enter() {
-    QUIESCENT.fetch_add(1, Ordering::AcqRel);
+    // SeqCst (not AcqRel): this store participates in the Dekker-style handshake
+    // with `try_stop_the_world` (which stores STOP then loads QUIESCENT). AcqRel
+    // does not order a store-then-load pair against another thread's store-then-
+    // load on the *other* location (StoreLoad reordering is permitted), so with
+    // AcqRel the collector could read a stale "quiescent" count for a worker that
+    // has already read a stale "no stop" and resumed mutating — corrupting trial
+    // deletion mid-scan. Making both sides' store+load SeqCst forces a single
+    // total order in which at least one side observes the other's write.
+    QUIESCENT.fetch_add(1, Ordering::SeqCst);
     // Wake a collector waiting for the count to reach its target.
     rendezvous().1.notify_all();
 }
@@ -149,8 +157,13 @@ pub(crate) fn notify_worker_exit() {
 /// collector B achieves a fresh stop with the stale count.
 fn quiescent_exit_checked() {
     loop {
-        QUIESCENT.fetch_sub(1, Ordering::AcqRel);
-        if !stw_requested() {
+        // Both the count decrement and the stop check are SeqCst: this is the
+        // mutator side of the Dekker handshake with `try_stop_the_world`. Ordering
+        // them SeqCst guarantees that if the collector achieved a stop by counting
+        // this thread quiescent, this thread observes the stop here and re-parks
+        // (below) instead of returning to mutate the `Gc` graph under the scan.
+        QUIESCENT.fetch_sub(1, Ordering::SeqCst);
+        if !STOP_REQUESTED.load(Ordering::SeqCst) {
             return;
         }
         quiescent_enter();
@@ -319,7 +332,11 @@ impl Drop for StwGuard {
 /// Only one stop can be in flight; a concurrent second caller fails fast (its
 /// suspects are re-queued and picked up later).
 pub(crate) fn try_stop_the_world(timeout: Duration) -> Option<StwGuard> {
-    if STOP_REQUESTED.swap(true, Ordering::AcqRel) {
+    // SeqCst: the collector side of the Dekker handshake. This store must be
+    // totally ordered against every mutator's `quiescent_exit_checked`
+    // (QUIESCENT store then STOP load) so a worker leaving quiescence cannot slip
+    // past the stop into `Gc` mutation while this collector counts it quiescent.
+    if STOP_REQUESTED.swap(true, Ordering::SeqCst) {
         return None;
     }
     let deadline = Instant::now() + timeout;
@@ -332,7 +349,9 @@ pub(crate) fn try_stop_the_world(timeout: Duration) -> Option<StwGuard> {
         // number of threads that must park. The collector's own thread, if
         // registered, is running this very function — exclude it.
         let needed = super::gc_ptr::mutator_worker_count().saturating_sub(self_counted);
-        if QUIESCENT.load(Ordering::Acquire) >= needed {
+        // SeqCst load (see the `swap` above): pairs with the mutators' SeqCst
+        // QUIESCENT stores to complete the handshake's total order.
+        if QUIESCENT.load(Ordering::SeqCst) >= needed {
             drop(guard);
             return Some(StwGuard { _private: () });
         }

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -32,6 +32,14 @@ where
             struct WorkerGuard;
             impl Drop for WorkerGuard {
                 fn drop(&mut self) {
+                    // Drop this thread's `Gc`-bearing thread-local state (pending
+                    // DESTROY queue, failure registry) BEFORE unregistering. Rust
+                    // runs TLS destructors after the closure returns — i.e. after
+                    // `exit_mutator_worker` below — so without this an unregistered
+                    // thread's TLS teardown would mutate the `Gc` graph while a
+                    // collector, believing this thread gone, runs trial deletion.
+                    // See `value::drop_thread_local_gc_state`.
+                    crate::value::drop_thread_local_gc_state();
                     crate::gc::mark_thread_registered(false);
                     crate::gc::exit_mutator_worker();
                 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -519,6 +519,40 @@ pub(crate) fn take_pending_instance_destroys() -> Vec<PendingInstanceDestroy> {
     PENDING_INSTANCE_DESTROYS.with(|pending| std::mem::take(&mut *pending.borrow_mut()))
 }
 
+/// Drop every `Gc`-bearing value held in this thread's thread-local state.
+///
+/// Worker threads accumulate `Gc` `Value`s in thread-local registries
+/// (`PENDING_INSTANCE_DESTROYS`, `FAILURE_PENDING_REGISTRY`). Rust runs a
+/// thread's TLS destructors *after* the thread closure returns — i.e. after the
+/// worker's `WorkerGuard` has already called `exit_mutator_worker` and
+/// unregistered the thread from the GC's stop-the-world accounting. A collector
+/// on another thread could then achieve STW (believing this thread gone) and run
+/// trial deletion while libc's TLS teardown concurrently drops these `Gc`s —
+/// corrupting the scan's refcount bookkeeping (freeing a live node). Draining
+/// them HERE, while the worker is still registered, closes that window: the drop
+/// happens under the normal counted-mutator discipline (a collector defers for
+/// this thread), and the later TLS destructor frees only empty collections. The
+/// leftover DESTROY items are dropped without running their Raku handlers, which
+/// matches the prior behavior (the TLS destructor never ran handlers either).
+pub(crate) fn drop_thread_local_gc_state() {
+    // Take each collection OUT of its RefCell before dropping it: an element's
+    // `Drop` re-enters these same thread-locals (an instance's `finalize_destroy`
+    // pushes to PENDING_INSTANCE_DESTROYS), so dropping in place while holding the
+    // `borrow_mut` would double-borrow the RefCell and panic — and a panic in a
+    // Drop during thread teardown aborts the process. Suppress the re-entrant
+    // DESTROY queuing too, so the drain terminates instead of re-filling the queue.
+    set_in_destroy_handler(true);
+    let pending = PENDING_INSTANCE_DESTROYS
+        .try_with(|pending| std::mem::take(&mut *pending.borrow_mut()))
+        .unwrap_or_default();
+    drop(pending);
+    let failures = FAILURE_PENDING_REGISTRY
+        .try_with(|reg| std::mem::take(&mut *reg.borrow_mut()))
+        .unwrap_or_default();
+    drop(failures);
+    set_in_destroy_handler(false);
+}
+
 // Global registry for Failure handled state. Maps Failure instance IDs to
 // their handled flag. This allows the handled state to be shared across
 // all clones of a Failure value (which share the same `id`).


### PR DESCRIPTION
## Problem

Under `MUTSU_GC=on`, worker-threaded programs (e.g. `roast/S17-lowlevel/semaphore.t`) intermittently drove a **live** node's GC strong count to 0 during trial deletion — a use-after-free surfacing as the **gc-stress CI job's sporadic SEGV** / `survivor invariant violation`. This is the flakiness recently seen blocking PRs (e.g. #4407 needed 3 gc-stress re-runs).

Reproduced deterministically (~11/20 runs) with `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=50 MUTSU_GC_VERIFY=1` and root-caused by instrumenting `Gc::clone`/`drop` with a foreign-thread backtrace probe.

## Two independent races

**1. STW handshake StoreLoad race** (`src/gc/stw.rs`). `try_stop_the_world` stores `STOP` then loads `QUIESCENT`; `quiescent_exit_checked` stores `QUIESCENT` then loads `STOP`. This Dekker-style mutual-flag pattern is **unsound under AcqRel/Acquire**, which permit StoreLoad reordering — the collector can read a stale "quiescent" count for a worker that has itself read a stale "no stop" and resumed mutating the `Gc` graph mid-scan. Fix: make the four handshake ops **SeqCst** (a single total order guarantees at least one side observes the other's write). ~11/20 → ~2/20.

**2. Thread-local `Gc` teardown after unregister** (`src/value/mod.rs`, `src/runtime/builtins_system.rs`). Workers accumulate `Gc`-bearing `Value`s in thread-local registries (`PENDING_INSTANCE_DESTROYS`, `FAILURE_PENDING_REGISTRY`). Rust runs TLS destructors **after** the thread closure returns — i.e. after `WorkerGuard::drop` already called `exit_mutator_worker` and unregistered the thread from STW accounting. A collector could then achieve STW believing the thread gone and run trial deletion while libc's TLS teardown concurrently dropped those `Gc`s. Fix: **drain the `Gc`-bearing thread-locals in `WorkerGuard::drop`** while still registered, so the later TLS teardown frees only empty collections (take-out-before-drop + suppress re-entrant DESTROY queuing to avoid a RefCell double-borrow, since a Drop panic aborts). ~2/20 → **0/20**.

## Verification

- `semaphore.t` ×20 all pass, **0 VERIFY_FAIL / 0 foreign mutations** under `EVERY_CANDIDATE=50 VERIFY=1` (was ~11/20 corrupting).
- `syntax.t` / `lock.t` / `handles-between-threads.t` clean under the same config.
- `make test` green (1653 files).

GC is default-off, so this only affects the gc-stress CI job and `MUTSU_GC=on` users — but it removes real flakiness from a BLOCKING check. Advances ADR-0001's cooperative-STW soundness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)