### PR TITLE
perf(regex): resolve class-item token fallback statically, not via a scratch interp

### DIFF
--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -600,11 +600,22 @@ impl Interpreter {
                             if builtin_match {
                                 return true;
                             }
-                            // Fallback: try resolving as a grammar token in the current package
+                            // Fallback: try resolving as a grammar token in the current package.
+                            // This runs once per character checked against the class, so use the
+                            // cheap STATIC resolver (pattern extracted straight from the token def)
+                            // rather than the heavy `with_args` path, which builds a fresh scratch
+                            // `Interpreter` per call — catastrophic here (profiled ~20% of a grammar
+                            // parse: `token name { <-restricted>+ }` resolved `restricted` per char).
+                            // A non-literal token body is not statically extractable, so fall back to
+                            // evaluating it (empty args) only when the static resolver finds nothing.
                             if !pkg.is_empty() {
                                 let char_str = effective_c.to_string();
-                                let candidates =
-                                    self.resolve_token_patterns_with_args_in_pkg(n, pkg, &[]);
+                                let mut candidates =
+                                    self.resolve_token_patterns_static_in_pkg(n, pkg);
+                                if candidates.is_empty() {
+                                    candidates =
+                                        self.resolve_token_patterns_with_args_in_pkg(n, pkg, &[]);
+                                }
                                 for (sub_pat, sub_pkg, _sym_key) in &candidates {
                                     if self
                                         .regex_match_len_at_start_in_pkg(

--- a/t/regex-classitem-token-fallback.t
+++ b/t/regex-classitem-token-fallback.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# A named item inside a regex character class (e.g. `<-restricted>`, `<+foo>`)
+# that is not a built-in character class falls back to resolving it as a grammar
+# token. That fallback runs once per character checked against the class, so it
+# must use the cheap static token-pattern resolver (pattern read straight from
+# the token def) rather than building a fresh scratch interpreter per character.
+# This test pins that both a literal-body token (static path) and a
+# non-literal-body token (eval fallback) still resolve correctly.
+
+plan 6;
+
+grammar Lit {
+  token r   { <[a..f]> }        # literal body -> static resolver
+  token TOP { <-r>+ }           # negated class referencing the token
+}
+ok  Lit.parse('XYZ789').defined, 'negated literal-body token: all-out-of-class matches';
+nok Lit.parse('abc').defined,    'negated literal-body token: in-class chars fail';
+nok Lit.parse('aXY').defined,    'negated literal-body token: one in-class char fails';
+
+grammar Dyn {
+  token d   { <?{ True }> <[0..9]> }   # non-literal body (code assertion) -> eval fallback
+  token TOP { <+d>+ }                  # positive class referencing the token
+}
+ok  Dyn.parse('42').defined,  'positive non-literal-body token: digits match';
+nok Dyn.parse('4a').defined,  'positive non-literal-body token: non-digit fails';
+
+# The class-item token resolution must also see tokens inherited via MRO.
+grammar Base { token b { <[x..z]> } }
+grammar Derived is Base { token TOP { <-b>+ } }
+ok Derived.parse('ABC').defined, 'inherited token resolved in class-item fallback';


### PR DESCRIPTION
## Summary

When a regex character class contains a named item that is **not** a built-in character class (`<-restricted>`, `<+foo>`, ...), matching a character against the class falls back to resolving that name as a grammar token and testing it. That fallback runs **once per character checked**, and the call site (`regex_match_atom_simple.rs`) used the heavy `resolve_token_patterns_with_args_in_pkg(n, pkg, &[])` — which builds a fresh scratch `Interpreter` (`new_regex_scratch`), clones the env, and runs `eval_block_value` on the token body — even though the arg list is empty.

This is item 2 from the `mzef-cli-status` plan (profile-driven attack on the grammar-parse hot path that zef's dist-identity parsing hammers).

## Change

Every other empty-arg token resolution already routes through the cheap static resolver, which reads the pattern straight from the token def (`token_pattern_from_def`) with no interpreter. Use it here too, falling back to the eval path only when the static resolver finds nothing (a non-literal token body that is not statically extractable).

## Profiling & measurements

`perf --call-graph fp` on `token name { <-restricted>+ % '::' }` parsing dist identities showed the per-character scratch-interp construction (`new_regex_scratch`) at ~20% of the parse, plus ~54% of CPU dropping `HashMap<String,Value>` (scratch envs + GC).

zef-shape grammar microbench (200 parses, debug build):

| | wall time | env_deep_copies | GC candidate_pushes |
|---|---|---|---|
| before | 18.0s | 11002 | 725129 |
| after | **9.4s (~1.9x)** | 202 (54x fewer) | 365806 |

## Correctness

`t/regex-classitem-token-fallback.t` covers a negated literal-body token (static path), a positive non-literal-body token (eval fallback), and a token inherited via MRO — all matching raku. `make test` passes; `S05-grammar/*`, `S05-metasyntax/*` (incl. `charset.t`, `assertions.t`, `regex.t`) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA