### PR TITLE
docs: record grammar-parse GC churn finding for the GC campaign

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -191,6 +191,17 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
   層3b NaN-boxing のスライス計画（3b-0 API 壁 → 3b-1 表現スイッチ → 3b-2 交通量刈り）・
   層3c 凍結条件は [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) 参照。
   続いて JIT（層4）= [ADR-0004（Accepted 2026-07-06）](docs/adr/0004-jit-strategy.md)。
+- [ ] **grammar パースの acyclic ゴミが cycle collector を無駄に回している**
+      （計測メモ = [docs/grammar-parse-gc-churn.md](docs/grammar-parse-gc-churn.md)）:
+      zef の dist-identity パースは `Match`/capture（`InstanceAttrs` =
+      `HashMap<String,Value>`）を大量に生むが全て非循環（Arc refcount で解放可能）。
+      にもかかわらず全 container Value が cycle 候補にバッファされ、collector は
+      全 collection で `reclaimed_cycles=0`。perf で CPU の ~54% が
+      `drop_in_place<HashMap<String,Value>>` under `collect_cycles_at`
+      （PR #4412 の char-class 修正後も候補 churn は依然 366k/200-parse）。
+      方向候補（GC owner 判断）: ① tree 形状/never-cyclic な instance 種を候補
+      バッファに入れない健全な基準 ② 候補集合の再 push 抑制/閾値調整
+      ③ `MUTSU_GC=0` で GC 分の天井を測る。
 - [ ] **層3a 監査性 sweep（ANALYSIS rev8 §2.1・低コスト・1 PR で済む）**:
       ① `gc/mod.rs`/`gc_ptr.rs`/`collect.rs` の stale な「default off / no production caller yet」
       ヘッダを default-on 後の実態に是正 ② `gc_ptr.rs`/`collect.rs` のモジュール全体

--- a/docs/grammar-parse-gc-churn.md
+++ b/docs/grammar-parse-gc-churn.md
@@ -1,0 +1,75 @@
+# Grammar-parse GC churn: acyclic Match garbage pushed as cycle candidates
+
+**Status:** finding / not-yet-actioned. Owner: GC campaign (PLAN.md §2).
+**Recorded:** 2026-07-11, from profiling zef's grammar dist-identity parse.
+
+## TL;DR
+
+Grammar parsing produces a large volume of **acyclic** garbage — `Match`
+objects and their capture trees, whose payload is `InstanceAttrs`
+(`HashMap<String, Value>`). Plain `Arc` refcounting already frees all of it
+(it is tree-shaped, no back-edges). Yet every container-kind `Value` is pushed
+into the GC cycle-candidate buffer on drop and processed by the trial-deletion
+collector, which then reclaims **zero cycles**. The cycle collector is doing
+substantial work for no reclaimed cycles on this workload.
+
+## Evidence
+
+`MUTSU_VM_STATS=1` on the zef-shape microbench (`tmp/zbench.raku`, 200 parses of
+`Foo::Bar::Baz:ver<1.2.3>` via a `grammar REQUIRE { token ... } :actions`),
+debug build, **after** the char-class-token static-resolve fix (PR #4412):
+
+```
+gc: collections=9 candidate_pushes=365806 dedup_hits=242807
+    reclaimed_nodes=177544 reclaimed_cycles=0
+    pause_ns_total=135334720 (135ms) pause_ns_max=30ms roots_scanned=188262
+```
+
+Before that fix the numbers were ~2x larger (candidate_pushes=725129,
+reclaimed_cycles=0). In both cases **`reclaimed_cycles=0`** across every
+collection — the collector never finds an actual cycle here.
+
+`perf --call-graph fp` (debug + `-Cforce-frame-pointers=yes`) on the same
+microbench showed **~54% of CPU in `drop_in_place<HashMap<String, Value>>`**,
+reached via `collect_cycles_at` -> drop `Arc<GcBox<dyn Trace>>` ->
+`InstanceAttrs` -> the map. So the collector is spending its time dropping
+`Match`/capture attribute maps that refcounting would have freed anyway.
+
+## Why it happens
+
+Per ADR-0001 the GC uses a scalar/container **type filter** so cycle-free scalar
+values (Int/Num/Str/...) pay zero GC cost. But `Match`/`Instance` are
+container-kind (`InstanceAttrs`), so they are always buffered as potential cycle
+roots when dropped with survivors — even though a `Match` capture tree is a pure
+tree (parent holds children; children never point back to the parent), so it can
+never form a cycle in this workload.
+
+## Possible directions (for the GC owner to weigh)
+
+- **Skip buffering tree-shaped / never-cyclic instance kinds.** `Match` (and
+  likely other parser-internal instances) are structurally acyclic; if they can
+  be marked so, their drops need not enter the candidate buffer at all. Needs a
+  sound criterion (a `Value`/class flag) so nothing that *could* cycle is
+  excluded.
+- **Threshold / batching tuning for buffer churn.** `candidate_pushes` and
+  `dedup_hits` are hundreds of thousands per 200 parses; even without a
+  collection the push+dedup hashing is real cost. A cheaper candidate set (or
+  not re-pushing an already-buffered node) may help.
+- **Measure with `MUTSU_GC=0`** to bound the ceiling: how much of the residual
+  ~9s/200-parses is GC vs. the regex engine itself.
+
+## Repro
+
+```
+# microbench (create if absent) — see the "NEXT SESSION" repro in memory
+#   grammar REQUIRE { token TOP {<name><verpart>?} token name {<-restricted>+ % '::'} ... }
+#   class Actions { method TOP($/){make ~$<name>} ... }
+#   for ^200 { REQUIRE.parse("Foo::Bar::Baz:ver<1.2.3>", :actions(Actions)) }
+MUTSU_VM_STATS=1 target/debug/mutsu tmp/zbench.raku 2>&1 | grep 'gc:'
+
+# perf (NOPASSWD at the exact path; build debug with frame pointers first):
+RUSTFLAGS="-Cforce-frame-pointers=yes" cargo build
+sudo -n /usr/lib/linux-tools/6.8.0-100-generic/perf record -g --call-graph fp \
+  -F 999 -o /tmp/p.data -- target/debug/mutsu tmp/zbench.raku
+sudo -n /usr/lib/linux-tools/6.8.0-100-generic/perf report -i /tmp/p.data --stdio -g none | head
+```


### PR DESCRIPTION
## Summary

While profiling zef's grammar dist-identity parse (item 2 in the `mzef` plan), I found that the GC cycle collector spends a large share of CPU dropping `HashMap<String,Value>` (Match/capture `InstanceAttrs`) while reclaiming **zero cycles** — the parse garbage is acyclic and freed by `Arc` refcounting anyway, yet every container `Value` is buffered as a cycle candidate.

Since GC is owned by the separate Phase-B campaign (PLAN.md §2), this PR just **records the finding** (evidence, repro, possible directions) in a new doc and links it from PLAN.md §2 so the GC owner can pick it up. **No code change.**

Evidence (zef-shape microbench, 200 parses, debug, after PR #4412's char-class fix):
```
gc: collections=9 candidate_pushes=365806 reclaimed_nodes=177544 reclaimed_cycles=0 ...
```
`perf` showed ~54% of CPU in `drop_in_place<HashMap<String,Value>>` under `collect_cycles_at`.

See `docs/grammar-parse-gc-churn.md` for the full writeup and repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA