### PR TITLE
chore(gc): post-default-on audit sweep (ANALYSIS rev8 §2.1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -202,15 +202,10 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
       方向候補（GC owner 判断）: ① tree 形状/never-cyclic な instance 種を候補
       バッファに入れない健全な基準 ② 候補集合の再 push 抑制/閾値調整
       ③ `MUTSU_GC=0` で GC 分の天井を測る。
-- [ ] **層3a 監査性 sweep（ANALYSIS rev8 §2.1・低コスト・1 PR で済む）**:
-      ① `gc/mod.rs`/`gc_ptr.rs`/`collect.rs` の stale な「default off / no production caller yet」
-      ヘッダを default-on 後の実態に是正 ② `gc_ptr.rs`/`collect.rs` のモジュール全体
-      `#![allow(dead_code)]` 撤去（「step 8 で外す」と書かれたまま・step 8 は完了済みで真の dead
-      surface を隠しうる） ③ `get_mut`/`make_mut` の uniqueness（`header.strong == 1`）と candidate
-      バッファのカウント外 `Arc` clone が共存できる不変条件（buffered clone は collect safepoint
-      でのみ deref・`Gc::drop` は `collecting()` 中 early-return）を散文でなく debug assert に
-      ④ `Gc::make_mut` の `header.strong` 手動付け替え（全 `Relaxed`）の並行 clone/drop 競合時
-      ordering を検討。
+- ✅ **層3a 監査性 sweep 完了（2026-07-11）**: stale ヘッダ是正・モジュール全体
+      `#![allow(dead_code)]` 撤去（dead API 5 件削除・test 専用 API `#[cfg(test)]` 化）・
+      不変条件 debug assert 化・`make_mut` `Relaxed` ordering 検討（結論=健全、
+      詳細 news/2026-07.md）。
 
 ---
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,32 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-11: GC 層3a 監査性 sweep（ANALYSIS rev8 §2.1）
+
+PLAN §2 の残タスク「層3a 監査性 sweep」を 1 PR で完了:
+
+- **stale ヘッダ是正**: `gc/mod.rs` / `gc_ptr.rs` / `collect.rs` / `safepoint.rs` /
+  `root_visitor.rs` / `builtins_system.rs` / `vm_run_loop.rs` の「default off /
+  collector 未着地 / cross-thread STW 未実装 / Sub・Instance は Arc のまま」等の
+  記述を default-on（ADR-0003 §5）・STW 実装済み・層3a 完了の実態に更新。
+- **モジュール全体 `#![allow(dead_code)]` 撤去**（`gc_ptr.rs` / `collect.rs`）。隠れていた
+  真の dead surface を整理: `gc_debug_collect_now` / `collect_if_enabled` /
+  `mutator_workers_active` / `GcBox::gc_buffered` / `gc_set_buffered` を削除、
+  test 専用 API（`collect_cycles` / `WeakGc::new` / `Gc::{get_mut,weak_count,color,trace_children}` /
+  `drain_candidates` re-export）を `#[cfg(test)]` 化。`mod.rs` の
+  `#[allow(unused_imports)]` も全廃し、dead な re-export（`CollectStats`/`Color`/
+  `stw_requested` 等 9 件）を削除。
+- **不変条件の debug assert 化**: `Gc::drop` / `Gc::make_mut` の strong-count
+  underflow（VERIFY の survivor invariant violation の発生源）、trial-deletion
+  scratch decrement の underflow（#4135 の over-trace バグクラスの最早検出点）、
+  `CollectGuard` の再入禁止、reclaim window 中の `get_mut`/`make_mut` 禁止。
+- **`make_mut` の `Relaxed` ordering 検討（④）**: 結論 = 健全。`== 1` uniqueness 判定は
+  自スレッドが唯一の live handle を持つ時のみ作用し、collector（唯一の cross-thread
+  reader）は SeqCst STW ハンドシェイクが全 mutator の relaxed write を scan に先行させる。
+  理論上の残 gap = cross-thread `WeakGc::upgrade` と `== 1` fast path の check-then-act
+  窓（`Arc::get_mut` は weak-lock で閉じている）だが、現状 `WeakGc` の唯一の利用者
+  `WeakSub` は env 所有スレッド上でのみ upgrade するため到達不能 — コメントに明記。
+
 ## 2026-07-10: 第一級コンテナ / container identity 完了 — BLOCKERS §3 をクローズ
 
 BLOCKERS.md の §3「第一級コンテナ / container identity」を（§2.3 hash multislice とともに）

--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -1,25 +1,25 @@
 //! GC Level 1a synchronous cycle collector (ADR-0001 §3-8,
 //! `docs/gc-level1-detailed-design.md` §5 / §9.4 / §9.5 / §11 step 8).
 //!
-//! Bacon-Rajan trial-deletion over the process-global candidate buffer. This is
-//! the first slice that actually *reclaims* garbage: everything before it
-//! (§11 steps 1-7) only built the `Gc` node graph and the candidate buffer.
+//! Bacon-Rajan trial-deletion over the process-global candidate buffer built by
+//! the `Gc` node graph (`gc_ptr`, §11 steps 1-7).
 //!
 //! Debug surface: `MUTSU_GC_LOG=summary|detail|trace` emits per-collect log
 //! lines (§9.4); `MUTSU_GC_VERIFY=1` checks the collector's soundness invariants
-//! around every collect (§9.5). Both are opt-in and cost nothing on the default
-//! (GC-off) path.
+//! around every collect (§9.5). Both are opt-in and cost nothing when unset.
 //!
-//! Scope of this cut:
-//! - **Opt-in.** Reclaim runs from [`collect_cycles`], invoked either manually
-//!   (`gc_debug_collect_now`) or automatically at VM safepoints when a
-//!   `MUTSU_GC` trigger is set (see [`super::safepoint`]). With `MUTSU_GC` unset
-//!   (default) the candidate buffer stays empty, so a call reclaims nothing and
-//!   normal execution is unaffected.
-//! - **Container cycles.** It walks whatever `Trace` exposes, so it already
-//!   handles the migrated container types (`Array`/`Hash`/`Set`/`Bag`/`Mix`/
-//!   `ContainerRef`). Async graphs (`Promise`/`Channel`/supply registries, §11
-//!   steps 6-7) are covered once those migrate and gain `Trace`/`drop_gc_edges`.
+//! Scope:
+//! - **Default on.** Reclaim runs from [`collect_cycles_at`], invoked at VM
+//!   safepoints under the ADR-0003 adaptive size threshold (see
+//!   [`super::safepoint`]) and once at program end
+//!   ([`collect_at_program_end`]). `MUTSU_GC=off` disarms safepoints and keeps
+//!   the candidate buffer empty, so a call reclaims nothing.
+//! - **Container cycles.** It walks whatever `Trace` exposes — all migrated
+//!   container kinds (`Array`/`Hash`/`Set`/`Bag`/`Mix`/`ContainerRef`/`Sub`/
+//!   `Instance`/`LazyList`) and the async graph (`Promise`/`Channel`, §11
+//!   steps 6-7).
+//! - **Cross-thread.** A collect first brings every other mutator to
+//!   quiescence via the cooperative stop-the-world (`gc::stw`, §6.1).
 //!
 //! ## Algorithm (Bacon & Rajan, "Concurrent Cycle Collection in Reference
 //! Counted Systems", synchronous variant)
@@ -37,12 +37,6 @@
 //! The GC strong count (`GcBox::gc_strong*`) is the scratch count trial-deletion
 //! mutates; `scan_black` restores it for every survivor, so the heap's refcounts
 //! are pristine afterward (only genuine garbage is disturbed).
-
-// The collector has no production caller yet: it runs only via the manual
-// `gc_debug_collect_now` hook / unit tests until safepoint wiring lands (§11
-// step 8, second half). Module-wide dead-code allow until then, mirroring
-// `gc_ptr`; removed when a safepoint / builtin invokes `collect_cycles`.
-#![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
@@ -499,26 +493,10 @@ pub(crate) fn collect_cycles_at(reason: &str) -> CollectStats {
     }
 }
 
-/// Run one collection attributed to `manual` (used by the debug hook / tests).
+/// Run one collection attributed to `manual` (unit tests' entry point).
+#[cfg(test)]
 pub(crate) fn collect_cycles() -> CollectStats {
     collect_cycles_at("manual")
-}
-
-/// Debug hook (design doc §9.5): force a collect now, regardless of triggers.
-/// The entry point a future `gc_debug_collect_now` builtin / REPL command and
-/// the integration tests call.
-pub(crate) fn gc_debug_collect_now() -> CollectStats {
-    collect_cycles_at("manual")
-}
-
-/// Run a collection at a named safepoint if `MUTSU_GC=on`. No-op with GC off, so
-/// the wired call sites are free on the default path. Logging/verify happen
-/// inside [`collect_cycles_at`] under `MUTSU_GC_LOG` / `MUTSU_GC_VERIFY`.
-pub(crate) fn collect_if_enabled(safepoint: &str) {
-    if !super::gc_ptr::gc_enabled() {
-        return;
-    }
-    collect_cycles_at(safepoint);
 }
 
 /// The program-end collect. Its only *observable* effect is delivering Raku

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -3,8 +3,8 @@
 //! (ADR-0001 / ADR-0002, `docs/gc-level1-detailed-design.md` §5.1 / §9.1 /
 //! §11 step 4).
 //!
-//! This lands the *type machinery* a Bacon-Rajan synchronous cycle collector
-//! needs, "compiled in, default off" per the design doc §9.1:
+//! The *type machinery* the Bacon-Rajan synchronous cycle collector
+//! (`gc::collect`) runs on:
 //!
 //! - [`Gc<T>`] — an `Arc`-backed managed pointer. `Arc` supplies allocation,
 //!   `Send + Sync`, and the unsizing coercion to the type-erased [`ErasedGc`];
@@ -16,27 +16,17 @@
 //! - the process-global candidate buffer — where a drop that leaves the node
 //!   with surviving handles records it as a possible cycle root (§4.2 / §5.2).
 //!
-//! State of the migration (§11 step 5):
-//! - The whole first wave is migrated to `Gc<_>`: `Hash` → `Gc<HashData>`
-//!   (5b), `Array` → `Gc<ArrayData>` (5c), `ContainerRef` →
-//!   `Gc<Mutex<Value>>` (5d). So `Gc`'s `Clone`/`Drop`/`make_mut`/... run in
-//!   production. Candidate buffering still only happens under `MUTSU_GC=on`
-//!   (default off), so ordinary runs pay just an atomic refcount op per
-//!   container clone/drop and push nothing.
-//! - `Set`/`Bag`/`Mix` are also `Gc<_>` now (#4117). `Sub`/`Instance`/`LazyList`
-//!   remain `Arc` (later waves); the [`ContainerMakeMut`] bridge lets shared
-//!   container macros work across the still-mixed state meanwhile.
-//! - The synchronous trial-deletion collector (`gc::collect`, §11 step 8)
-//!   reclaims cycles from the candidate buffer, run at VM safepoints
-//!   (`gc::safepoint`) under a `MUTSU_GC` trigger, or manually. With `MUTSU_GC`
-//!   unset the buffer stays empty and safepoints are disarmed, so a collect is a
-//!   no-op and normal execution is unaffected.
-
-// The collector-facing surface (Color scan states, drain_candidates,
-// buffer_as_candidate, trace_children, ...) is not exercised until the
-// synchronous collector lands (§11 step 8), so keep a module-wide dead-code
-// allow rather than sprinkling per-item ones; drop it when step 8 wires them up.
-#![allow(dead_code)]
+//! State of the migration (§11 step 5 — COMPLETE, layer 3a shipped):
+//! - Every container-kind variant is `Gc<_>`: `Hash`/`Array`/`ContainerRef`
+//!   (first wave), `Set`/`Bag`/`Mix` (#4117), `Sub`/`Instance` attributes
+//!   (#4123), `Promise`/`Channel` (#4127), `LazyList` (#4125). Scalar variants
+//!   stay GC-free per the ADR-0001 type filter. The [`ContainerMakeMut`] bridge
+//!   remains for shared macros generic over `Arc` (immutable wrappers) and `Gc`.
+//! - The synchronous trial-deletion collector (`gc::collect`) runs at VM
+//!   safepoints (`gc::safepoint`) under the ADR-0003 adaptive threshold.
+//!   **`MUTSU_GC` defaults to on** (ADR-0003 §5, 2026-07-05); `MUTSU_GC=off`
+//!   disarms safepoints and leaves the candidate buffer empty, so a run pays
+//!   just an atomic refcount op per container clone/drop.
 
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -48,8 +38,7 @@ use crate::vm::vm_stats::{record_gc_candidate_dedup_hit, record_gc_candidate_pus
 /// Only `Black`/`Purple` are set outside a collection: a live node is `Black`,
 /// and a node flagged as a possible cycle root when a `Gc` handle to it is
 /// dropped is `Purple`. `Gray`/`White` are the transient trial-deletion states
-/// the future collector (§11 step 8) will use while scanning a candidate
-/// subgraph; they are defined now so the header layout is stable.
+/// the collector (`gc::collect`) uses while scanning a candidate subgraph.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub(crate) enum Color {
@@ -92,9 +81,9 @@ pub(crate) trait Trace: Send + Sync {
     /// be unreachable garbage, and ONLY inside a `CollectGuard` window (so the
     /// resulting `Gc::drop`s are inert — see `Gc`'s `Drop`). The `&mut self` is
     /// obtained by the collector through the backing `Arc` (see
-    /// [`gc_drop_edges`]). The default clears nothing (scalar leaves and
-    /// not-yet-migrated nodes have no `Gc` edges); container nodes override it to
-    /// clear their `Value`-holding collections.
+    /// [`gc_drop_edges`]). The default clears nothing (scalar leaves have no
+    /// `Gc` edges); container nodes override it to clear their `Value`-holding
+    /// collections.
     fn drop_gc_edges(&mut self) {}
 
     /// Run this node's *value-level* finalizer (Raku `DESTROY` queueing), once
@@ -181,6 +170,7 @@ impl<T: Trace + 'static> WeakGc<T> {
     /// cycle never keeps itself alive.
     ///
     /// [`upgrade`]: WeakGc::upgrade
+    #[cfg(test)]
     pub(crate) fn new() -> WeakGc<T> {
         WeakGc {
             inner: std::sync::Weak::new(),
@@ -268,6 +258,7 @@ impl<T: Trace + 'static> Gc<T> {
     /// observers but no strong handle keeps only its *allocation* alive (its
     /// value is dropped when the strong count hits 0), so an outstanding weak
     /// reference never resurrects reclaimed data — `upgrade` returns `None`.
+    #[cfg(test)]
     pub(crate) fn weak_count(this: &Gc<T>) -> usize {
         Arc::weak_count(&this.inner)
     }
@@ -286,7 +277,16 @@ impl<T: Trace + 'static> Gc<T> {
     /// make an `Arc::get_mut` check return `None` spuriously and, via
     /// [`Gc::make_mut`], sever container identity (Raku aliasing). Returns `None`
     /// when genuinely shared.
+    ///
+    /// Production container mutation goes through [`gc_contents_mut`] /
+    /// [`Gc::make_mut`]; this `Arc::get_mut` mirror is exercised by unit tests
+    /// only (it documents the uniqueness contract `make_mut` shares).
+    #[cfg(test)]
     pub(crate) fn get_mut(&mut self) -> Option<&mut T> {
+        // Mutators never take `&mut` inside a collect's reclaim window: the
+        // collector runs at a safepoint (no interpreter frame is mid-mutation)
+        // and only its own `drop_gc_edges` runs under `CollectGuard`.
+        debug_assert!(!collecting(), "Gc::get_mut during a collect reclaim window");
         if self.inner.header.strong.load(Ordering::Relaxed) == 1 {
             // SAFETY: sole live handle, so no other live-handle borrow into the
             // value exists. A buffered node's retained `Arc` never dereferences
@@ -317,13 +317,18 @@ impl<T: Trace + 'static> Gc<T> {
         unsafe { std::ptr::addr_of!((*box_ptr).value) }
     }
 
-    /// This node's current [`Color`].
+    /// This node's current [`Color`]. Production code reads colors through the
+    /// type-erased [`GcBox<dyn Trace>::gc_color`]; this typed mirror is for tests.
+    #[cfg(test)]
     pub(crate) fn color(&self) -> Color {
         Color::from_u8(self.inner.header.color.load(Ordering::Relaxed))
     }
 
     /// Hand each direct `Gc` child of the pointee to `visit` (delegates to the
     /// value's [`Trace`] impl). Named to avoid clashing with `Trace::trace`.
+    /// The collector traverses via the type-erased
+    /// [`GcBox<dyn Trace>::gc_visit_children`]; this typed mirror is for tests.
+    #[cfg(test)]
     pub(crate) fn trace_children(&self, visit: &mut dyn FnMut(&ErasedGc)) {
         self.inner.value.trace(visit);
     }
@@ -358,8 +363,7 @@ impl<T: Trace + 'static> Gc<T> {
     // Stacked-Borrows clean.)
 
     /// Offer this node to the candidate buffer as a possible cycle root,
-    /// bypassing the `MUTSU_GC` gate. Used by tests and (later) by an explicit
-    /// `gc_debug_collect_now`-style hook.
+    /// bypassing the `MUTSU_GC` gate, so tests can seed a collect directly.
     #[cfg(test)]
     pub(crate) fn buffer_as_candidate(&self) {
         buffer_candidate(self.inner.clone());
@@ -382,14 +386,34 @@ impl<T: Trace + Clone + 'static> Gc<T> {
     /// distribution even though the retarget goes through the backing `Arc`
     /// directly rather than `Gc::clone`/`Gc::drop`.
     pub(crate) fn make_mut(&mut self) -> &mut T {
+        // See `Gc::get_mut`: no `&mut` inside a collect's reclaim window.
+        debug_assert!(
+            !collecting(),
+            "Gc::make_mut during a collect reclaim window"
+        );
         // Uniqueness by GC-visible strong count, NOT the `Arc` count: the
         // candidate buffer (MUTSU_GC on) holds an extra `Arc` clone of a
         // possibly-cyclic node, so an `Arc::get_mut` check would COW spuriously
         // and sever container identity (Raku aliasing broke on e.g. slice-
         // assignment lvalues). `header.strong` excludes the buffer's ref.
+        //
+        // Ordering: `Relaxed` everywhere on `header.strong` is sound because no
+        // decision ever *reads another thread's count concurrently*. The `== 1`
+        // uniqueness test only acts when this thread holds the sole live handle
+        // (`&mut self`), so no other thread can be cloning/dropping THIS node
+        // through a strong handle; and the collector — the only cross-thread
+        // reader of `header.strong` — runs under the cooperative STW whose
+        // SeqCst handshake (`gc::stw`) orders every mutator's prior relaxed
+        // writes before the scan. The one theoretical gap is a cross-thread
+        // `WeakGc::upgrade` racing the `== 1` fast path (a check-then-act window
+        // `Arc::get_mut` closes with its weak-lock protocol); mutsu's only
+        // `WeakGc` user is `WeakSub`, whose upgrades happen on the thread that
+        // owns the sub's env, so the race is not reachable today. If `WeakGc`
+        // grows a cross-thread consumer, port the weak-lock (see ADR-0001 §3-8).
         if self.inner.header.strong.load(Ordering::Relaxed) != 1 {
             // Shared: this handle is moving off the old node onto a fresh copy.
-            self.inner.header.strong.fetch_sub(1, Ordering::Relaxed);
+            let prev = self.inner.header.strong.fetch_sub(1, Ordering::Relaxed);
+            debug_assert!(prev > 1, "Gc::make_mut strong-count underflow");
             let cloned = self.inner.value.clone();
             self.inner = Arc::new(GcBox {
                 header: GcHeader::fresh(),
@@ -448,6 +472,10 @@ impl<T: Trace + 'static> Drop for Gc<T> {
             return;
         }
         let prev = self.inner.header.strong.fetch_sub(1, Ordering::Relaxed);
+        // Underflow here (a drop with no live handle on the books) is the
+        // corruption signature MUTSU_GC_VERIFY reports as a survivor-invariant
+        // violation; catch it at the source in debug builds.
+        debug_assert!(prev >= 1, "Gc::drop strong-count underflow");
         // `prev > 1`: after this drop the node still has live handles, so it may
         // be reachable only through a cycle that outlives every stack root —
         // record it as a candidate. `prev == 1`: this was the last handle; the
@@ -626,14 +654,11 @@ fn buffer_candidate(node: ErasedGc) {
 ///
 /// The level-1a collector's trial deletion (`mark_gray` decrements each node's
 /// strong count, `scan_black` restores it) is **not** safe against concurrent
-/// mutation: a worker thread that clones/drops a `Gc` or CAS-swaps a pointer
-/// mid-collect races the collector's refcount bookkeeping, which manifests as
-/// strong-count underflow and freed-but-live nodes (design doc §13.3 — the
-/// cross-thread STW protocol is the deferred open question). Until a real
-/// stop-the-world lands, the collector simply declines to run while any worker
-/// thread is active (see `collect::collect_cycles_at`): candidates keep
-/// accumulating and are reclaimed at the next safepoint after the threads join.
-/// Reclaim is deferred, never unsound.
+/// mutation, so a collect first brings every other mutator to quiescence via
+/// the cooperative stop-the-world (`gc::stw`, design doc §6.1). This count is
+/// the STW's quiescence target: `stw` waits until this many threads (minus the
+/// collecting one, if it is itself a worker) are parked at a safepoint or
+/// inside a registered blocking wait.
 static MUTATOR_WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
 
 /// Register that a user worker thread is about to start (or is running). Called
@@ -652,12 +677,6 @@ pub(crate) fn enter_mutator_worker() {
 pub(crate) fn exit_mutator_worker() {
     MUTATOR_WORKER_THREADS.fetch_sub(1, Ordering::AcqRel);
     super::stw::notify_worker_exit();
-}
-
-/// Whether any user worker thread may currently be mutating the `Gc` graph.
-/// The collector gates on this to preserve stop-the-world.
-pub(crate) fn mutator_workers_active() -> bool {
-    MUTATOR_WORKER_THREADS.load(Ordering::Acquire) > 0
 }
 
 /// Current number of registered user worker threads. With exactly one
@@ -730,7 +749,11 @@ pub(crate) struct CollectGuard;
 
 impl CollectGuard {
     pub(crate) fn new() -> CollectGuard {
-        COLLECTING.store(true, Ordering::Relaxed);
+        let was = COLLECTING.swap(true, Ordering::Relaxed);
+        // Nested reclaim windows would let an inner guard's drop re-enable
+        // `Gc::drop` bookkeeping while the outer reclaim is still clearing
+        // edges — the counts are mid-scan scratch at that point.
+        debug_assert!(!was, "nested CollectGuard (re-entrant reclaim window)");
         CollectGuard
     }
 }
@@ -762,16 +785,15 @@ impl GcBox<dyn Trace> {
         self.header.strong.load(Ordering::Relaxed)
     }
     pub(crate) fn gc_strong_dec(&self) {
-        self.header.strong.fetch_sub(1, Ordering::Relaxed);
+        let prev = self.header.strong.fetch_sub(1, Ordering::Relaxed);
+        // Trial deletion removes each internal edge once, so the scratch count
+        // can reach 0 but never go below it. Underflow means the tracer
+        // reported a phantom edge (e.g. the shared-Arc-wrapper over-trace
+        // fixed in #4135) — the earliest observable point of that bug class.
+        debug_assert!(prev >= 1, "trial-deletion strong-count underflow");
     }
     pub(crate) fn gc_strong_inc(&self) {
         self.header.strong.fetch_add(1, Ordering::Relaxed);
-    }
-    pub(crate) fn gc_buffered(&self) -> bool {
-        self.header.buffered.load(Ordering::Relaxed)
-    }
-    pub(crate) fn gc_set_buffered(&self, b: bool) {
-        self.header.buffered.store(b, Ordering::Relaxed);
     }
     /// Visit each direct `Gc` child (delegates to the node's [`Trace`] impl).
     pub(crate) fn gc_visit_children(&self, visit: &mut dyn FnMut(&ErasedGc)) {

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -1,28 +1,48 @@
-//! GC Level 1a infrastructure (ADR-0001 / ADR-0002,
-//! `docs/gc-level1-detailed-design.md`).
+//! GC Level 1a: the Bacon-Rajan cycle collector on `Arc` (ADR-0001 / ADR-0002 /
+//! ADR-0003, `docs/gc-level1-detailed-design.md`). **Default on** since
+//! 2026-07-05 (ADR-0003 §5); `MUTSU_GC=off` disarms it.
 //!
-//! Two concerns live here, both "compiled in, default off" (design doc §9.1)
-//! ahead of a running collector:
-//!
+//! - [`gc_ptr`] — [`Gc<T>`], its Bacon-Rajan node header, the [`Trace`] trait,
+//!   and the process-global cycle-candidate buffer. Every container-kind
+//!   `Value` variant is a `Gc<_>` node (layer 3a migration, complete).
+//! - [`collect`] — the synchronous trial-deletion collector that reclaims
+//!   cycles from the candidate buffer.
+//! - [`safepoint`] — the trigger policy (ADR-0003 adaptive size threshold, or
+//!   the `MUTSU_GC_EVERY_CANDIDATE` stress period) and the `gc_safepoint`
+//!   entry point the VM calls at re-entry boundaries (dispatch backedge).
+//! - [`stw`] — the cooperative stop-the-world (design §6.1): a collect waits
+//!   until every other mutator thread is parked at a safepoint or inside a
+//!   registered blocking wait, then scans.
 //! - [`root_visitor`] — the [`RootVisitor`] trait and `visit_*` helpers used by
 //!   `Interpreter::visit_roots` / `Env::visit_values` to enumerate every
-//!   `Value` reachable from execution state (§11 steps 1-2).
-//! - [`gc_ptr`] — [`Gc<T>`], its Bacon-Rajan node header, the [`Trace`] trait,
-//!   and the process-global cycle-candidate buffer (§11 step 4). The first wave
-//!   is migrated to `Gc<_>`: `Hash` (5b), `Array` (5c),
-//!   `ContainerRef` (5d).
-//! - [`collect`] — the synchronous Bacon-Rajan trial-deletion collector (§11
-//!   step 8) that reclaims cycles from the candidate buffer.
-//! - [`safepoint`] — the trigger policy and the `gc_safepoint` entry point the
-//!   VM calls at re-entry boundaries (dispatch backedge) to run a collect under
-//!   a `MUTSU_GC` stress mode. With `MUTSU_GC` unset, safepoints are disarmed
-//!   (one cached load) and a collect is a no-op — normal execution is unaffected.
+//!   `Value` reachable from execution state (§11 steps 1-2; verification /
+//!   future tracing infra — the candidate-buffer collector does not consume it).
 
 mod collect;
 mod gc_ptr;
 mod root_visitor;
 mod safepoint;
 mod stw;
+
+pub(crate) use collect::collect_at_program_end;
+#[cfg(test)]
+pub(crate) use collect::collect_cycles;
+#[cfg(test)]
+pub(crate) use gc_ptr::drain_candidates;
+pub(crate) use gc_ptr::{
+    ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, enter_mutator_worker, exit_mutator_worker,
+    gc_contents_mut,
+};
+pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};
+pub(crate) use safepoint::{
+    SafepointKind, armed as gc_safepoints_armed,
+    current_size_threshold as gc_current_size_threshold, gc_safepoint,
+    startup_collect_if_requested,
+};
+pub(crate) use stw::{
+    block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point,
+    preregister_worker_quiescent, stw_aware_wait, worker_started,
+};
 
 /// Test-only serialization for every unit test that touches the process-global
 /// GC statics (candidate buffer, worker count, STW flags, cooldown). The
@@ -49,26 +69,3 @@ pub(crate) mod test_support {
         g
     }
 }
-
-#[allow(unused_imports)]
-pub(crate) use collect::{
-    CollectStats, LogMode, collect_at_program_end, collect_cycles, collect_cycles_at,
-    collect_if_enabled, gc_debug_collect_now, log_mode, verify_enabled,
-};
-#[allow(unused_imports)]
-pub(crate) use gc_ptr::{
-    Color, ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, drain_candidates, enter_mutator_worker,
-    exit_mutator_worker, gc_contents_mut, gc_enabled, mutator_workers_active,
-};
-pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};
-#[allow(unused_imports)]
-pub(crate) use safepoint::{
-    SafepointKind, armed as gc_safepoints_armed,
-    current_size_threshold as gc_current_size_threshold, gc_safepoint,
-    startup_collect_if_requested,
-};
-#[allow(unused_imports)]
-pub(crate) use stw::{
-    block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point,
-    preregister_worker_quiescent, stw_aware_wait, stw_requested, worker_started,
-};

--- a/src/gc/root_visitor.rs
+++ b/src/gc/root_visitor.rs
@@ -3,9 +3,16 @@
 //!
 //! This submodule holds the `RootVisitor` trait and its `visit_*` helpers. Root
 //! enumeration (`Interpreter::visit_roots`, `Env::visit_values`) lives in
-//! exactly one place through this trait instead of being duplicated per future
-//! call site. The managed-pointer machinery (`Gc<T>`, candidate buffer, the
-//! future collector) lives in the sibling `gc_ptr` submodule.
+//! exactly one place through this trait instead of being duplicated per
+//! call site. The managed-pointer machinery (`Gc<T>`, candidate buffer,
+//! collector) lives in the sibling `gc_ptr` / `collect` submodules.
+//!
+//! The shipped collector is candidate-buffer Bacon-Rajan and does NOT consume
+//! roots, so this whole surface is exercised only by the `gc_roots.rs` unit
+//! tests today (hence the `#[allow(dead_code)]`s). It is retained deliberately:
+//! the H4 hardening item (full-root VERIFY mode, `docs/gc-post-3a-roadmap.md`
+//! §1) and any future tracing/moving design need exactly this enumeration, and
+//! keeping it compiling keeps root coverage honest as interpreter state grows.
 
 use std::collections::HashMap;
 use std::hash::BuildHasher;
@@ -22,10 +29,8 @@ use crate::value::Value;
 /// method (needed for the `HashMap`'s hasher parameter) would make the trait
 /// object-unsafe.
 ///
-/// No implementor exists yet outside `#[cfg(test)]`: this is GC Level 1a step
-/// 1 (root visitor only, `docs/gc-level1-detailed-design.md` §11). The
-/// candidate-buffer/collector implementor lands in step 4, at which point
-/// these become live production callers — see ADR-0001/ADR-0002.
+/// No implementor exists outside `#[cfg(test)]` — see the module doc for why
+/// this infrastructure is retained without a production consumer.
 #[allow(dead_code)]
 pub(crate) trait RootVisitor {
     fn visit_value(&mut self, value: &Value);

--- a/src/gc/safepoint.rs
+++ b/src/gc/safepoint.rs
@@ -1,15 +1,16 @@
 //! GC safepoint wiring (ADR-0001 §1.1, `docs/gc-level1-detailed-design.md`
 //! §1.2 / §9.2 / §9.2a / §11 step 8 second half).
 //!
-//! The collector ([`super::collect::collect_cycles`]) may only run at a
+//! The collector ([`super::collect::collect_cycles_at`]) may only run at a
 //! *re-entry boundary* — a point holding no long borrow / lock / `gc_contents_mut`
 //! (design doc §1.2). This module holds the trigger policy and the one hot-path
 //! entry point ([`gc_safepoint`]) the VM calls at those boundaries.
 //!
 //! ## Triggers (design doc §9.2)
-//! - `MUTSU_GC=off` (default / unset) disables everything: [`armed`] is `false`,
-//!   so the VM's safepoint check is a single relaxed load that early-returns —
-//!   normal execution pays essentially nothing and never collects.
+//! - `MUTSU_GC=off` disables everything: [`armed`] is `false`, so the VM's
+//!   safepoint check is a single relaxed load that early-returns — execution
+//!   pays essentially nothing and never collects. Unset means **on**
+//!   (ADR-0003 §5) with the production size-threshold trigger below.
 //! - `MUTSU_GC=on` + `MUTSU_GC_EVERY_SAFEPOINT=1` — collect at *every* safepoint
 //!   (deterministic stress; §9.2).
 //! - `MUTSU_GC=on` + `MUTSU_GC_EVERY_CANDIDATE=N` — arm a pending collect once

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -15,9 +15,9 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    // Mark a mutator worker as active so the GC collector declines to run while
-    // this thread may be touching the `Gc` graph (trial deletion needs
-    // stop-the-world; see `gc::mutator_workers_active`). Raised here on the
+    // Register a mutator worker with the GC: the worker count is the
+    // cooperative stop-the-world's quiescence target (trial deletion must not
+    // race this thread's `Gc` mutations; see `gc::stw`). Raised here on the
     // parent — before the thread exists — so the count is up the instant this
     // returns, then dropped by the worker's RAII guard (panic-safe).
     crate::gc::enter_mutator_worker();

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -114,16 +114,16 @@ impl Interpreter {
         let mut ip = 0;
         while ip < code.ops.len() {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
-            // container borrow, so a cycle collect may run here. Off by default —
-            // `gc_safepoints_armed()` is a single cached load unless `MUTSU_GC`
-            // enables an automatic trigger. Fires on worker threads too: the
-            // collector itself splits the work by thread-safety — the dead sweep
-            // (refcount-dead candidates, plain `Arc` drops) runs even while other
-            // mutators are live, while the trial-deletion cycle scan defers until
-            // `mutator_workers_active()` clears (cross-thread cooperative STW is
-            // not implemented yet, design §6). Without in-thread sweeps, threaded
-            // mutation-heavy loops grew the candidate buffer — and their dead
-            // snapshots' memory — unboundedly until the post-join collect.
+            // container borrow, so a cycle collect may run here.
+            // `gc_safepoints_armed()` is a single cached load (false only with
+            // `MUTSU_GC=off`). Fires on worker threads too: the collector splits
+            // the work by thread-safety — the dead sweep (refcount-dead
+            // candidates, plain `Arc` drops) runs even while other mutators are
+            // live, while the trial-deletion cycle scan first brings them to
+            // quiescence via the cooperative stop-the-world (`gc::stw`, design
+            // §6.1). Without in-thread sweeps, threaded mutation-heavy loops grew
+            // the candidate buffer — and their dead snapshots' memory —
+            // unboundedly until the post-join collect.
             if crate::gc::gc_safepoints_armed() {
                 crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
             }
@@ -371,16 +371,16 @@ impl Interpreter {
         let mut ip = 0;
         while ip < code.ops.len() {
             // GC safepoint (design doc §1.2): the dispatch backward edge holds no
-            // container borrow, so a cycle collect may run here. Off by default —
-            // `gc_safepoints_armed()` is a single cached load unless `MUTSU_GC`
-            // enables an automatic trigger. Fires on worker threads too: the
-            // collector itself splits the work by thread-safety — the dead sweep
-            // (refcount-dead candidates, plain `Arc` drops) runs even while other
-            // mutators are live, while the trial-deletion cycle scan defers until
-            // `mutator_workers_active()` clears (cross-thread cooperative STW is
-            // not implemented yet, design §6). Without in-thread sweeps, threaded
-            // mutation-heavy loops grew the candidate buffer — and their dead
-            // snapshots' memory — unboundedly until the post-join collect.
+            // container borrow, so a cycle collect may run here.
+            // `gc_safepoints_armed()` is a single cached load (false only with
+            // `MUTSU_GC=off`). Fires on worker threads too: the collector splits
+            // the work by thread-safety — the dead sweep (refcount-dead
+            // candidates, plain `Arc` drops) runs even while other mutators are
+            // live, while the trial-deletion cycle scan first brings them to
+            // quiescence via the cooperative stop-the-world (`gc::stw`, design
+            // §6.1). Without in-thread sweeps, threaded mutation-heavy loops grew
+            // the candidate buffer — and their dead snapshots' memory —
+            // unboundedly until the post-join collect.
             if crate::gc::gc_safepoints_armed() {
                 crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
             }


### PR DESCRIPTION
Closes the "layer 3a auditability sweep" item from PLAN.md §2 (low-cost, single PR).

## What

1. **Stale header/comment corrections** across `gc/mod.rs`, `gc_ptr.rs`, `collect.rs`, `safepoint.rs`, `root_visitor.rs`, `builtins_system.rs`, `vm_run_loop.rs`: the collector is **default-on** (ADR-0003 §5), the cooperative cross-thread STW **is implemented**, and the layer-3a container migration **is complete**. The old "default off / no production caller yet / STW not implemented yet / `Sub`/`Instance` remain `Arc`" claims all described a pre-ship state.

2. **Module-wide `#![allow(dead_code)]` removed** from `gc_ptr.rs` / `collect.rs` (their stated removal condition — step 8 landing — was met long ago). Genuinely dead surface deleted: `gc_debug_collect_now`, `collect_if_enabled`, `mutator_workers_active`, `GcBox::{gc_buffered, gc_set_buffered}`. Test-only APIs (`collect_cycles`, `WeakGc::new`, `Gc::{get_mut, weak_count, color, trace_children}`, the `drain_candidates` re-export) are now `#[cfg(test)]`. The blanket `#[allow(unused_imports)]` on `gc/mod.rs` re-exports is gone, along with nine dead re-exports. `root_visitor.rs`'s per-item allows are kept but now carry an honest justification (H4 full-root VERIFY / future tracing infra; the candidate-buffer collector does not consume roots).

3. **Prose invariants → debug asserts**: strong-count underflow in `Gc::drop` / `Gc::make_mut` (the source of what `MUTSU_GC_VERIFY` reports as survivor-invariant violations), trial-deletion scratch underflow in `gc_strong_dec` (earliest observable point of the #4135 over-trace bug class), `CollectGuard` re-entry, and `&mut` acquisition inside a reclaim window. The CI gc-stress job's `prove t/` step runs the **debug** binary, so these asserts get real coverage there.

4. **`make_mut` `Relaxed`-ordering review (item ④)**: concluded sound — the `== 1` uniqueness test only acts when this thread holds the sole live handle, and the collector (the only cross-thread reader of `header.strong`) runs under the STW whose SeqCst handshake (#4410) orders every mutator's prior relaxed writes before the scan. The one theoretical gap — a cross-thread `WeakGc::upgrade` racing the `== 1` fast path — is unreachable today (`WeakSub` upgrades on the env-owning thread) and now documented at the decision point.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` (535 lib tests) green
- `make test` PASS (1655 files / 16260 tests)
- GC stress smoke with the new asserts armed (debug build, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=50-200 MUTSU_GC_VERIFY=1`): `S17-lowlevel/semaphore.t` ×5, `S17-lowlevel/cas-loop.t`, `t/lock.t` — all clean, no VERIFY FAIL, no assert hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW