### PR TITLE
fix: dispatch EXISTS-KEY for associative subscript :exists on user objects

### DIFF
--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -148,11 +148,26 @@ impl Interpreter {
     }
 
     fn call_exists_pos(&mut self, instance: &Value, idx: Value) -> Result<bool, RuntimeError> {
-        match self.try_compiled_method_or_interpret(instance.clone(), "EXISTS-POS", vec![idx]) {
-            Ok(value) => Ok(value.truthy()),
-            Err(err) if Self::is_method_not_found(&err) => Ok(false),
-            Err(err) => Err(err),
+        // Choose the associative vs positional existence method by the index type,
+        // mirroring the AT-KEY/AT-POS read dispatch (vm_var_index_ops): a string
+        // index is an associative subscript (`$o<k>` / `$o{'k'}`) -> EXISTS-KEY;
+        // any other (typically Int) index is positional (`$o[i]`) -> EXISTS-POS,
+        // falling back to EXISTS-KEY for an object that only does Associative
+        // (e.g. zef's config object, which `handles <... EXISTS-KEY ...>` to a Hash
+        // attribute and defines no EXISTS-POS).
+        let method_order: &[&str] = match idx.view() {
+            ValueView::Str(_) => &["EXISTS-KEY"],
+            _ => &["EXISTS-POS", "EXISTS-KEY"],
+        };
+        for method in method_order {
+            match self.try_compiled_method_or_interpret(instance.clone(), method, vec![idx.clone()])
+            {
+                Ok(value) => return Ok(value.truthy()),
+                Err(err) if Self::is_method_not_found(&err) => continue,
+                Err(err) => return Err(err),
+            }
         }
+        Ok(false)
     }
 
     pub(super) fn instance_exists_pos_result(

--- a/t/exists-key-delegated-subscript.t
+++ b/t/exists-key-delegated-subscript.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# `$obj<key>:exists` (associative subscript with the :exists adverb) on a user
+# object must dispatch the object's EXISTS-KEY method, mirroring how `$obj<key>`
+# dispatches AT-KEY. Previously the subscript :exists path only ever tried
+# EXISTS-POS, so an object that does Associative (or `handles` EXISTS-KEY to a
+# Hash attribute, as zef's config object does) always reported False.
+# A positional subscript (`$obj[i]:exists`) must still dispatch EXISTS-POS.
+
+plan 13;
+
+# --- explicit associative methods ---
+class Assoc {
+    has %.h;
+    method AT-KEY($k)     { %!h{$k} }
+    method EXISTS-KEY($k) { %!h{$k}:exists }
+}
+my $a = Assoc.new(h => {a => 1, b => 2});
+ok  ($a<a>:exists),   'EXISTS-KEY via subscript: present key';
+nok ($a<z>:exists),   'EXISTS-KEY via subscript: absent key';
+nok ($a<a>:!exists),  'EXISTS-KEY via subscript: :!exists negation';
+ok  $a.EXISTS-KEY('a'), 'direct EXISTS-KEY still works';
+
+# --- `handles` delegation to a Hash attribute (the zef Zef::CLI config shape) ---
+my %hash = (a => 1, b => 2, foo => 3);
+my $cfg = class :: {
+    has %.hash handles <AT-KEY EXISTS-KEY DELETE-KEY keys values>;
+}.new(:%hash);
+ok  ($cfg<foo>:exists), 'handles-delegated EXISTS-KEY: present key';
+nok ($cfg<nope>:exists), 'handles-delegated EXISTS-KEY: absent key';
+is  $cfg<foo>, 3,        'handles-delegated AT-KEY still works';
+
+# --- a Positional object must still use EXISTS-POS for `[i]` ---
+class Pos {
+    has @.items;
+    method AT-POS($i)     { @!items[$i] }
+    method EXISTS-POS($i) { 0 <= $i < @!items.elems }
+    method elems          { @!items.elems }
+}
+my $p = Pos.new(items => [10, 20, 30]);
+ok  ($p[0]:exists),  'EXISTS-POS via positional subscript: present index';
+nok ($p[9]:exists),  'EXISTS-POS via positional subscript: absent index';
+
+# --- native hash / array unaffected ---
+my %nh = (x => 1);
+my @na = 1, 2, 3;
+ok  (%nh<x>:exists), 'native hash subscript :exists (present)';
+nok (%nh<y>:exists), 'native hash subscript :exists (absent)';
+ok  (@na[2]:exists), 'native array subscript :exists (present)';
+nok (@na[9]:exists), 'native array subscript :exists (absent)';


### PR DESCRIPTION
## Summary

`$obj<key>:exists` (and `$obj{'key'}:exists`) on a user object always reported **False**, even when the object does `Associative` or `handles` its `EXISTS-KEY` to a Hash attribute — as zef's config object does:

```raku
class :: { has %.hash handles <AT-KEY EXISTS-KEY DELETE-KEY ...> }.new(:%hash)
```

Found while investigating the `Zef::Client` `%`-attr ducktyping item on the mzef north-star (PLAN.md §1 B2a).

## Root cause

The subscript-`:exists` path routed every user `Instance` through `call_exists_pos` (`vm_var_ops.rs`), which only ever tried `EXISTS-POS`. An associative object defines `EXISTS-KEY` (not `EXISTS-POS`), so the call was method-not-found and fell back to `False`. A direct `$o.EXISTS-KEY(k)` already worked (normal method dispatch) — only the subscript path was wrong.

## Fix

Choose the existence method by index type, mirroring the `AT-KEY`/`AT-POS` **read** dispatch in `vm_var_index_ops`:
- string index (`$o<k>` / `$o{'k'}`) → `EXISTS-KEY`
- other (typically Int, `$o[i]`) → `EXISTS-POS`, falling back to `EXISTS-KEY` for an object that only does Associative.

## Tests

`t/exists-key-delegated-subscript.t` covers explicit `EXISTS-KEY` methods, `handles`-delegated `EXISTS-KEY` (the zef shape), a Positional object still using `EXISTS-POS` for `[i]`, and native hash/array subscripts. `make test` passes; roast `S32-basics/xxKEY.t`, `S32-hash/exists.t`, `S32-hash/exists-adverb.t`, `S02-types/hash.t` all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyPteGAwSnRTEkZxA6f2WA