### PR TITLE
feat(operators): 6.c baggy set precedes/succeeds operators (<+) ≼ (>+) ≽

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1,5 +1,6 @@
 roast/6.c/S02-names/SETTING-6c.t
 roast/6.c/S02-types/subset-6c.t
+roast/6.c/S03-operators/set_precedes.t
 roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S12-class/mro-6c.t
 roast/6.c/S14-roles/submethods.t

--- a/src/parser/expr/precedence_meta_ops/set_ops.rs
+++ b/src/parser/expr/precedence_meta_ops/set_ops.rs
@@ -42,10 +42,22 @@ fn parse_set_op(input: &str) -> Option<(TokenKind, usize)> {
         Some((TokenKind::SetSubset, 4))
     } else if input.starts_with('⊆') {
         Some((TokenKind::SetSubset, '⊆'.len_utf8()))
+    // 6.c "precedes" (baggy subset) operators `(<+)` / `≼`: deprecated aliases
+    // of `(<=)` / `⊆`, removed in 6.d. mutsu's `SetSubset` already compares
+    // Bag/Mix multiplicities, so they map to the same TokenKind.
+    } else if input.starts_with("(<+)") {
+        Some((TokenKind::SetSubset, 4))
+    } else if input.starts_with('≼') {
+        Some((TokenKind::SetSubset, '≼'.len_utf8()))
     } else if input.starts_with("(>=)") {
         Some((TokenKind::SetSuperset, 4))
     } else if input.starts_with('⊇') {
         Some((TokenKind::SetSuperset, '⊇'.len_utf8()))
+    // 6.c "succeeds" (baggy superset) operators `(>+)` / `≽`.
+    } else if input.starts_with("(>+)") {
+        Some((TokenKind::SetSuperset, 4))
+    } else if input.starts_with('≽') {
+        Some((TokenKind::SetSuperset, '≽'.len_utf8()))
     } else if input.starts_with("!(<)") {
         Some((TokenKind::Ident("⊄".to_string()), 4))
     } else if input.starts_with("(<)") {

--- a/t/set-precedes-ops.t
+++ b/t/set-precedes-ops.t
@@ -1,0 +1,40 @@
+use v6.c;
+use Test;
+
+# 6.c "precedes"/"succeeds" baggy set operators: (<+) ≼ (>+) ≽.
+# Deprecated aliases of (<=)/⊆ and (>=)/⊇ (removed in 6.d); they compare
+# Bag/Mix multiplicities, not just element presence.
+
+plan 16;
+
+my $bb = bag <a a b>;       # a:2 b:1
+my $b2 = bag <a b>;         # a:1 b:1
+my $b3 = bag <a a a b>;     # a:3 b:1
+
+# (<+) / ≼ : baggy subset (multiplicity-wise <=)
+ok  $b2 (<+) $bb, 'bag (<+) : proper baggy subset';
+ok  $b2 ≼    $bb, 'bag ≼ : proper baggy subset';
+ok  $bb (<+) $bb, 'bag (<+) : subset of itself';
+nok $b3 (<+) $bb, 'bag (<+) : too many copies is NOT a subset';
+nok $b3 ≼    $bb, 'bag ≼ : too many copies is NOT a subset';
+
+# (>+) / ≽ : baggy superset
+ok  $bb (>+) $b2, 'bag (>+) : proper baggy superset';
+ok  $bb ≽    $b2, 'bag ≽ : proper baggy superset';
+ok  $bb (>+) $bb, 'bag (>+) : superset of itself';
+nok $bb (>+) $b3, 'bag (>+) : missing copies is NOT a superset';
+
+# Mixes (fractional weights)
+my $m1 = (a => 1.5, b => 2).Mix;
+my $m2 = (a => 1.0, b => 1).Mix;
+ok  $m2 (<+) $m1, 'mix (<+) : baggy subset with weights';
+ok  $m2 ≼    $m1, 'mix ≼ : baggy subset with weights';
+nok $m1 (<+) $m2, 'mix (<+) : larger weights not a subset';
+ok  $m1 (>+) $m2, 'mix (>+) : baggy superset with weights';
+
+# Sets degrade to multiplicity 1
+my $s1 = set <a b>;
+my $s2 = set <a b c>;
+ok  $s1 (<+) $s2, 'set (<+) : subset';
+ok  $s1 ≼    $s2, 'set ≼ : subset';
+nok $s2 ≼    $s1, 'set ≼ : superset is not a subset';


### PR DESCRIPTION
## What

`(<+)` / `≼` (precedes) and `(>+)` / `≽` (succeeds) are the 6.c *baggy*
subset/superset operators — deprecated aliases of `(<=)`/`⊆` and `(>=)`/`⊇`
that were removed in 6.d. They compare Bag/Mix **multiplicities** (e.g.
`bag(a,a,a) (<+) bag(a,a)` is `False`), which mutsu's `SetSubset`/`SetSuperset`
already implement, so the parser simply maps the four new spellings to the
existing `TokenKind`s. No VM change.

## Result

- `roast/6.c/S03-operators/set_precedes.t`: 0 (parse error) → **40/40**, whitelisted.
- New `t/set-precedes-ops.t` (16 subtests) covers Bag/Mix/Set operands, ASCII
  and Unicode spellings, both directions.
- `make test` green (16328 tests).

## Note on versioning

These operators were removed in 6.d; the roast test opens with `use v6.c`.
mutsu does not version-gate operators, so recognizing them unconditionally is
the pragmatic choice (matches how the existing set operators are handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)