### PR TITLE
fix(roles): class attribute accessor prioritized over composed role method

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -3,6 +3,7 @@ roast/6.c/S02-names/SETTING-6c.t
 roast/6.c/S02-types/subset-6c.t
 roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S12-class/mro-6c.t
+roast/6.c/S14-roles/attributes.t
 roast/6.c/S14-roles/submethods.t
 roast/6.c/S32-io/file-tests.t
 roast/6.d/S02-literals/version.t

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -218,6 +218,26 @@ impl Interpreter {
         false
     }
 
+    /// Whether the class hierarchy defines `method_name` *directly* (a method
+    /// written in a class body), as opposed to only inheriting it from a
+    /// composed role. Entities defined in a class are prioritized over role
+    /// entities: a role method must NOT shadow the class's own attribute
+    /// accessor of the same name (6.c S14-roles/attributes.t "Class
+    /// prioritization"). `role_origin.is_none()` marks a class-local method.
+    pub(crate) fn has_class_local_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        let mro = self.class_mro(class_name);
+        for cn in mro {
+            if let Some(class_def) = self.registry().classes.get(&cn)
+                && let Some(defs) = class_def.methods.get(method_name)
+            {
+                return defs
+                    .iter()
+                    .any(|d| !d.is_private && d.role_origin.is_none());
+            }
+        }
+        false
+    }
+
     /// Check if a class has a public attribute accessor for the given name.
     pub(crate) fn has_public_accessor(&mut self, class_name: &str, method_name: &str) -> bool {
         let attrs = self.collect_class_attributes(class_name);

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1065,8 +1065,16 @@ impl Interpreter {
                 };
                 return self.call_method_with_values(bridged, "log", vec![base]);
             }
-            // User-defined methods take priority over auto-generated accessors
-            if self.has_user_method(&class_name.resolve(), method) {
+            // User-defined methods take priority over auto-generated accessors,
+            // EXCEPT a method that comes ONLY from a composed role does not
+            // shadow the class's own attribute accessor of the same name
+            // (class entities are prioritized over role entities). In that case
+            // fall through to the accessor block below; a role method with no
+            // competing accessor still runs here.
+            let cn_resolved = class_name.resolve();
+            let role_only_shadowing_accessor = !self.has_class_local_method(&cn_resolved, method)
+                && self.has_public_accessor(&cn_resolved, method);
+            if !role_only_shadowing_accessor && self.has_user_method(&cn_resolved, method) {
                 let (result, updated) = self.run_instance_method(
                     &class_name.resolve(),
                     attributes.to_map(),

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -516,6 +516,21 @@ impl Interpreter {
                     result
                 }
             } {
+                // Entities defined in a class are prioritized over role
+                // entities: when resolution lands on a method that comes ONLY
+                // from a composed role (`role_origin` set) but the class has a
+                // public attribute accessor of the same name, the accessor wins.
+                // (If a class-local method of that name existed, resolution would
+                // have picked it and `role_origin` would be None.) Defer to the
+                // slow path, whose `run_instance_method` accessor block resolves
+                // it — 6.c S14-roles/attributes.t "Class prioritization".
+                if method_def.role_origin.is_some()
+                    && !method_def.is_private
+                    && matches!(target.view(), ValueView::Instance { .. })
+                    && self.has_public_accessor(cn, method)
+                {
+                    return self.call_method_with_values(target, method, args);
+                }
                 if let Some(result) = self.check_method_wrap_chain(
                     cn,
                     &owner_class,

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -123,7 +123,12 @@ impl Interpreter {
             return None;
         }
         let cn = class_name.resolve();
-        if self.has_user_method(&cn, method) {
+        // A class-locally-defined method of this name overrides the accessor, so
+        // bail to full dispatch. A method that comes ONLY from a composed role
+        // does NOT: class entities (here, the public attribute accessor) are
+        // prioritized over role entities, so the fast accessor read proceeds
+        // (6.c S14-roles/attributes.t "Class prioritization").
+        if self.has_class_local_method(&cn, method) {
             return None;
         }
         // Only a *public* accessor reads through the fast path. Gating on this

--- a/t/role-class-prioritization.t
+++ b/t/role-class-prioritization.t
@@ -1,0 +1,38 @@
+use Test;
+
+# Entities defined in a class are prioritized over entities from a composed
+# role: a role method must not shadow the class's own attribute accessor of the
+# same name, and a class method overrides a role's attribute accessor.
+# (6.c S14-roles/attributes.t "Class prioritization".)
+
+plan 6;
+
+my role R {
+    has $.r1 = 100;
+    method c1 { 666 }
+}
+my class C does R {
+    has $.c1 = 42;
+    method r1 { 7 }
+}
+
+my $inst = C.new;
+
+# accessor (class) beats method (role), through a variable holder ...
+is $inst.c1, 42, 'class attribute accessor wins over role method (var form)';
+# ... and through a chained call (different dispatch path)
+is C.new.c1, 42, 'class attribute accessor wins over role method (chained form)';
+
+# method (class) beats accessor (role)
+is $inst.r1, 7, 'class method wins over role attribute accessor (var form)';
+is C.new.r1, 7, 'class method wins over role attribute accessor (chained form)';
+
+# A role method with NO competing class entity still dispatches normally.
+my role R2 { method only-role { 'from-role' } }
+my class C2 does R2 { }
+is C2.new.only-role, 'from-role', 'role method still runs when unshadowed';
+
+# A role accessor with no competing class entity still works.
+my role R3 { has $.rx = 'roleattr' }
+my class C3 does R3 { }
+is C3.new.rx, 'roleattr', 'role attribute accessor still runs when unshadowed';


### PR DESCRIPTION
## What

Entities defined in a class take precedence over entities from a composed role.
In particular a **role method must not shadow the class's own public attribute
accessor** of the same name (while a class-defined method *does* override a
role's attribute accessor).

```raku
role R { has $.r1 = pi; method c1 { 666 } }
class C does R { has $.c1 = 42; method r1 { e } }
C.new.c1   # was 666 (role method), now 42 (class accessor)
C.new.r1   # e (class method beats role accessor) — already correct
```

## How

Keys on method origin: `role_origin.is_none()` marks a class-local method
(class body / inherited from a parent), while a role-composed method carries
`role_origin = Some(role)`. New `has_class_local_method` helper; the three
dispatch paths that could run a role method ahead of the accessor now defer to
the accessor when the only same-named method is role-only:

- `try_fast_accessor_read` — the 0-arg `$var.acc` fast path (this was the one
  the variable form hit).
- the compiled-method resolution path — a resolved method with `role_origin`
  set + a public accessor routes to the slow path.
- `run_instance_method` — same guard in the interpreter slow path.

A role method with no competing class entity still dispatches normally.

## Result

- `roast/6.c/S14-roles/attributes.t`: 2/3 → **3/3**, whitelisted.
- New `t/role-class-prioritization.t` (6 subtests): both dispatch forms
  (`$var.m` and chained `C.new.m`), both directions, and the unshadowed cases.
- `make test` green (16318 tests); role/attribute roast sweep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)