### PR TITLE
perf(vm): admit CATCH/CONTROL/phasers/nested decls/subtest/once to module-sub OTF (PLAN §3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -215,9 +215,22 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 - [ ] default-param OTF の builtin-shadow 単一候補（name-cache 汚染リスクがあるため意図的に除外を維持中）。
 - [ ] モジュール sub OTF に残る interpreter 結合構文: `EVAL` / `EVALFILE` / `start` /
-      `CATCH` / `CONTROL` / phaser / ネスト宣言 / subtest / sigilless scalar（`\x`）/ 戻り型 coercion /
-      `is encoded(...)`（NativeCall marshalling）
+      sigilless scalar（`\x`）/ 戻り型 coercion / `is encoded(...)`（NativeCall marshalling）/
+      ネスト class/role 宣言
       （ゲート実体 = `def_is_otf_compilable_module_single`、`vm/vm_call_func_ops.rs`）。
+      **★2026-07-11 body 構文ゲート緩和**: `CATCH` / `CONTROL` / phaser /
+      ネスト sub/proto/token 宣言 / `subtest` / `once` は実験で raku 一致を確認し OTF 許可に変更
+      （担保 = `t/module-sub-otf-interpreter-constructs.t`）。tree-walk 既存バグ（body 直下
+      `CATCH` があると非 die パスの戻り値が Nil になる）も OTF 化で修正。
+      **★`start` は OTF 化不可を実験で確認（2026-07-11）**: 再帰 sub の start クロージャが param を
+      捕捉する場合、再帰呼び出しの param re-bind が thread env 上の捕捉値を clobber し
+      `await` 復帰後に最深呼び出しの値が見える（`t/start-block-return-value.t` test 3、
+      fib(5)=3 に退行。tree-walk は呼び出し前後の env save/restore で保護）。非再帰の start 捕捉は
+      OTF でも正しいが、AST ゲートでは再帰を判定できないため `start` 全体を除外維持。
+      **既知の別軸バグ（今回悪化なし・tree-walk でも同挙動）**: `once` の cross-thread 重複発火
+      — `once_values` ストアが thread クローン時に値コピーされるため、`await (^N).map:{start f()}`
+      で各 thread が once を再発火する（raku は全 thread で 1 回）。修正には `once_values` の
+      共有セル化（state セルと同型）が必要。
       **★compiled_fns 拡充 slice 1（#4312）で `state` は解決**: `use`d モジュールの compiled sub body を
       fingerprint キーで `imported_compiled_fns` に捕捉→スレッドクローンへ Arc 共有→`state` 持ちモジュール
       sub を共有ボディ経由で dispatch（`state_scope_id` を None リセット）。`await (^N).map:{start f()}` の
@@ -335,6 +348,11 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       言語保証外。mutsu は不壊で優位 — 仕様外のまま維持）と、非 state の escaped aggregate
       probe（gc-post-3a-roadmap §2 T6）。
 - [ ] Semaphore / nonblocking await / lock 競合（S17・hard・別軸）。
+- [ ] **再帰 start/await sub を 2 連続実行すると 2 つ目がハング（2026-07-11 発見・main ef5cd62e で再現）**:
+      `sub f($n){ start { $n<=0 ?? "b" !! await(f($n-1)) ~ "|$n" } }; await(f(3));` を実行した後に
+      2 分岐再帰（`await(fib($n-2)) + await(fib($n-1))`）の start sub を await すると決定的にハング
+      （fib 単独・単発再帰 2 連続は OK）。先行 start チェーンが thread-pool worker を解放しない疑い。
+      raku は両方 4/8 を返す。
 - [ ] 生ポインタ aliased write の撤廃: 旧 `arc_contents_mut` は dead 化済みで、本番経路は
       `gc::gc_contents_mut` / `Gc::{get,make}_mut` に移動（unsoundness は解消でなく移動 —
       ANALYSIS rev8 §2.1）。完全解消 = §2 Track B 残スライス T4-T6 に統合済み（重複着手しない）。

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1739,16 +1739,26 @@ impl Interpreter {
     /// an ordinary module sub may contain interpreter-coupled constructs that
     /// `def_is_otf_compilable` does not catch, whose semantics are NOT preserved
     /// when the def is compiled standalone on-the-fly:
-    ///   - a nested routine decl whose non-local control flow must target the
-    ///     nested routine, not escape it (Test::Util's `is-deeply-junction`'s
-    ///     nested `junction-guts` + `when`),
     ///   - a `state` variable shared across `start` threads (a routine's state
-    ///     lives in a shared cell that the tree-walk path owns — t/concurrent-state-var),
-    ///   - `EVAL`/`EVALFILE` with a `CALLER::` context, `subtest`, `CATCH`/
-    ///     `CONTROL` handlers, phasers, `start` (all couple to the interpreter's
-    ///     caller / test / dispatch context — Test::Util's `throws-like-any`),
+    ///     lives in a shared cell that a per-thread OTF recompile would sever —
+    ///     t/concurrent-state-var; admitted via the cross-thread shared captured
+    ///     body, `imported_state_body_for_def`),
+    ///   - `EVAL`/`EVALFILE` with a `CALLER::` context the standalone compile
+    ///     cannot reconstruct,
+    ///   - a `start` block: a recursive sub whose start closure captures a param
+    ///     gets its capture clobbered by the recursive call's param re-bind
+    ///     under OTF (t/start-block-return-value.t test 3 — see
+    ///     `module_otf_expr_needs_interpreter`),
     ///   - a sigilless *scalar* (`\x`) param whose alias writeback to the caller
     ///     must survive across an `EVAL` boundary (t/sigilless-params).
+    ///
+    /// Formerly-excluded body constructs verified OTF-safe and now admitted
+    /// (§3 fallback removal, 2026-07-11): nested sub/proto/token decls
+    /// (non-local `when` control flow stays inside the nested routine —
+    /// Test::Util's `is-deeply-junction`), `subtest`, `CATCH`/`CONTROL`
+    /// handlers, phasers (ENTER/LEAVE), and `once`. All run through the same
+    /// VM ops the precompiled path uses; pinned by
+    /// t/module-sub-otf-interpreter-constructs.t.
     ///
     /// `is rw`/`is raw`/`is copy`/`is readonly`/`is required` params are NOW
     /// allowed (§2 multi-dispatch VM-ization): the compiled binding already
@@ -1882,17 +1892,18 @@ impl Interpreter {
     fn module_otf_stmt_needs_interpreter(stmt: &crate::ast::Stmt) -> bool {
         use crate::ast::Stmt;
         match stmt {
-            // Nested decls, subtests, catch/control handlers, and phasers couple
-            // to the interpreter's dispatch / caller / test context.
-            Stmt::ClassDecl { .. }
-            | Stmt::RoleDecl { .. }
-            | Stmt::SubDecl { .. }
-            | Stmt::ProtoDecl { .. }
-            | Stmt::TokenDecl { .. }
-            | Stmt::Subtest { .. }
-            | Stmt::Catch(_)
-            | Stmt::Control(_)
-            | Stmt::Phaser { .. } => true,
+            // Nested class/role decls still couple to the interpreter's package
+            // registration context (same exclusion as
+            // `function_body_needs_interpreter`). Nested sub/proto/token decls,
+            // `subtest`, `CATCH`/`CONTROL` handlers and phasers are OTF-safe
+            // (verified 2026-07-11 against raku, incl. Test::Util's
+            // `is-deeply-junction` nested `when` control flow and
+            // `throws-like-any`'s CATCH+subtest): the compiled body registers
+            // nested routines and runs handlers/phasers through the same VM ops
+            // the precompiled path uses. OTF even fixes a tree-walk bug where a
+            // body-level CATCH swallowed the normal path's return value. Pinned
+            // by t/module-sub-otf-interpreter-constructs.t.
+            Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } => true,
             Stmt::If {
                 then_branch,
                 else_branch,
@@ -1919,7 +1930,6 @@ impl Interpreter {
     fn module_otf_expr_needs_interpreter(expr: &crate::ast::Expr) -> bool {
         use crate::ast::Expr;
         match expr {
-            Expr::PhaserExpr { .. } | Expr::Once { .. } => true,
             Expr::DoStmt(stmt) => Self::module_otf_stmt_needs_interpreter(stmt),
             Expr::Block(body) => Self::module_otf_body_needs_interpreter(body),
             Expr::MethodCall { target, args, .. } => {
@@ -1928,9 +1938,22 @@ impl Interpreter {
             }
             Expr::Call { name, args } => {
                 let n = name.resolve();
-                // start spawns a thread; EVAL/EVALFILE run on a sub-Interpreter
-                // with a CALLER:: context that the standalone OTF compile cannot
-                // reconstruct.
+                // EVAL/EVALFILE run on a sub-Interpreter with a CALLER:: context
+                // that the standalone OTF compile cannot reconstruct. `start`
+                // stays excluded: a *recursive* sub whose start closure captures
+                // a param breaks under OTF — the recursive call re-binds the
+                // same param name in the thread env the closure keeps reading,
+                // so after `await` the captured `$n` is clobbered by the deepest
+                // call's binding (t/start-block-return-value.t test 3,
+                // fib(5)=3; the tree-walk path save/restores the env around the
+                // call). Non-recursive start captures do work OTF, but the gate
+                // is an AST predicate that cannot see recursion, so all `start`
+                // bodies stay on the interpreter. `once` IS OTF-safe within a
+                // thread — its site key is stable across calls because the
+                // fingerprint-keyed `otf_compile_cache` reuses one compiled
+                // body. (Cross-thread `once` dedup is a pre-existing gap in the
+                // thread-cloned `once_values` store, identical under tree-walk
+                // — recorded in PLAN §3.)
                 n == "start"
                     || n == "EVAL"
                     || n == "EVALFILE"

--- a/t/lib/InterpConstructOtf.rakumod
+++ b/t/lib/InterpConstructOtf.rakumod
@@ -1,0 +1,128 @@
+unit module InterpConstructOtf;
+
+# Constructs formerly excluded from module-sub OTF compilation
+# (def_is_otf_compilable_module_single). Each sub exercises one construct;
+# t/module-sub-otf-interpreter-constructs.t pins raku-identical behavior.
+
+# nested sub decl + when non-local control flow (is-deeply-junction pattern)
+our sub oc-nested($x) is export {
+    sub guts($v) {
+        given $v {
+            when Int { return "int:$v" }
+            when Str { return "str:$v" }
+        }
+        return "other";
+    }
+    guts($x) ~ "|" ~ guts("s");
+}
+
+# nested when without return: control must not escape the nested routine
+our sub oc-nested-when($x) is export {
+    my $r = "";
+    sub inner($v) {
+        given $v {
+            when Int { $r ~= "I"; }
+            when Str { $r ~= "S"; }
+        }
+        $r ~= "after;";
+    }
+    inner($x);
+    $r;
+}
+
+# nested proto + multi decls
+our sub oc-proto($x) is export {
+    proto sub inner($) {*}
+    multi sub inner(Int $v) { "int:$v" }
+    multi sub inner(Str $v) { "str:$v" }
+    inner($x);
+}
+
+# nested token decl used via regex match
+our sub oc-token($s) is export {
+    my token word { \w+ }
+    ($s ~~ /<word>/) ?? ~$/<word> !! "no-match";
+}
+
+# block-level CATCH handler
+our sub oc-catch($x) is export {
+    my $r = "start";
+    {
+        die "boom $x";
+        CATCH { default { $r = "caught: " ~ .message; } }
+    }
+    $r;
+}
+
+# body-level CATCH with return from the handler; the non-dying path must
+# still return the body's last value (tree-walk used to lose it)
+our sub oc-catch-top($x) is export {
+    CATCH { default { return "caught: " ~ .message } }
+    die "boom $x" if $x;
+    "no-die";
+}
+
+# CONTROL handler (warn + resume)
+our sub oc-control() is export {
+    my @msgs;
+    {
+        warn "w1";
+        @msgs.push("resumed");
+        CONTROL { when CX::Warn { @msgs.push(.message); .resume } }
+    }
+    @msgs.join(",");
+}
+
+# ENTER/LEAVE phasers observed via an outer lexical
+my $phaser-log = "";
+our sub oc-phaser($x) is export {
+    ENTER { $phaser-log ~= "enter;" }
+    LEAVE { $phaser-log ~= "leave;" }
+    $phaser-log ~= "body:$x;";
+    "ret";
+}
+our sub oc-phaser-read() is export { $phaser-log }
+
+# once block: fires exactly once across calls (within a thread)
+my $once-count = 0;
+our sub oc-once() is export {
+    once { $once-count++ }
+    $once-count;
+}
+
+# start block capturing a param, a local, and a module lexical. NOTE: a body
+# with `start` stays on the interpreter fallback (recursive start captures
+# break under OTF — t/start-block-return-value.t test 3); this pins the
+# behavior either way.
+my $mod-lex = 100;
+our sub oc-start($x) is export {
+    my $local = $x + $mod-lex;
+    my $p = start { $local * 2 };
+    await $p;
+}
+
+# CATCH inside a sub called from start-threads
+our sub oc-catch-in-thread($x) is export {
+    CATCH { default { return "caught:" ~ .message } }
+    die "t$x" if $x %% 2;
+    "ok:$x";
+}
+
+# LEAVE phaser accumulation across threads
+my $leave-lock = Lock.new;
+my $leave-count = 0;
+our sub oc-leave-count() is export {
+    LEAVE { $leave-lock.protect: { $leave-count++ } }
+    1;
+}
+our sub oc-leave-read() is export { $leave-count }
+
+# subtest inside a module sub
+use Test;
+our sub oc-subtest($desc, $a, $b) is export {
+    subtest $desc => {
+        plan 2;
+        ok $a == $b, "values equal";
+        is $a, $b, "is equal";
+    }
+}

--- a/t/module-sub-otf-interpreter-constructs.t
+++ b/t/module-sub-otf-interpreter-constructs.t
@@ -1,0 +1,34 @@
+use lib $*PROGRAM.parent.child("lib").Str;
+use Test;
+use InterpConstructOtf;
+
+# Pins that module subs containing formerly interpreter-gated constructs
+# (nested routine decls, CATCH/CONTROL, phasers, subtest, start, once) behave
+# raku-identically when OTF-compiled (def_is_otf_compilable_module_single).
+
+plan 17;
+
+is oc-nested(42), "int:42|str:s", "nested sub decl with when+return";
+is oc-nested-when(7), "Iafter;", "nested sub when does not escape the nested routine";
+is oc-proto(5), "int:5", "nested proto+multi dispatch (Int)";
+is oc-proto("x"), "str:x", "nested proto+multi dispatch (Str)";
+is oc-token("hello world"), "hello", "nested token decl matches";
+
+is oc-catch(1), "caught: boom 1", "block-level CATCH catches die";
+is oc-catch-top(1), "caught: boom 1", "body-level CATCH return from handler";
+is oc-catch-top(0), "no-die", "body-level CATCH keeps normal-path return value";
+is oc-control(), "w1,resumed", "CONTROL handler resumes a warn";
+
+is oc-phaser(3), "ret", "phaser sub returns body value";
+is oc-phaser-read(), "enter;body:3;leave;", "ENTER/LEAVE order observed via outer lexical";
+
+is oc-once(), 1, "once fires on first call";
+is oc-once(), 1, "once does not fire on second call";
+
+is oc-start(5), 210, "start captures param, local and module lexical";
+my @r = await (^4).map: { start oc-catch-in-thread($_) };
+is @r.sort.join("|"), "caught:t0|caught:t2|ok:1|ok:3", "CATCH inside start-threaded calls";
+await (^8).map: { start oc-leave-count() };
+is oc-leave-read(), 8, "LEAVE fires once per call across threads";
+
+oc-subtest("subtest inside a module sub", 3, 3);


### PR DESCRIPTION
## Summary

PLAN §3 (substrate — multi-dispatch tree-walk fallback removal): relax the `def_is_otf_compilable_module_single` body gate. Nested `sub`/`proto`/`token` decls, `subtest`, `CATCH`/`CONTROL` handlers, phasers (ENTER/LEAVE), and `once` no longer force a module sub onto the tree-walk interpreter fallback — they OTF-compile and run through the same VM ops the precompiled path uses.

Every admitted construct was verified raku-identical by direct experiment before relaxing the gate, including the two Test::Util functions the exclusions were originally added for:
- `is-deeply-junction` (nested routine + `when` non-local control flow) — now dispatches with **zero** interpreter fallbacks
- `throws-like-any` (CATCH + subtest) — likewise zero fallbacks

## Bug fixed by the OTF path

A body-level `CATCH { default { return ... } }` used to swallow the normal (non-dying) path's return value under tree-walk (raku returns the body's last value; the fallback returned `Nil`). OTF-compiling the body fixes this; pinned in the new test.

## What stays excluded (verified, not assumed)

- **`start`** — NOT OTF-safe: a recursive sub whose start closure captures a param gets the capture clobbered by the recursive call's param re-bind in the thread env; `t/start-block-return-value.t` test 3 regresses fib(5)=8→3 deterministically. The AST gate cannot see recursion, so all `start` bodies stay on the interpreter.
- Nested class/role decls, `EVAL`/`EVALFILE`, and the signature-level exclusions (sigilless scalar, coercion return, `is encoded`) — unchanged.

## Pre-existing bugs found while probing (recorded in PLAN, not touched here)

- Cross-thread `once` re-fires per thread (`once_values` is value-copied on thread clone) — identical under tree-walk, no regression.
- Deterministic hang: a two-branch recursive start/await sub hangs if a *different* recursive start sub ran before it (reproduces on main `ef5cd62e`).

## Testing

- New pin: `t/module-sub-otf-interpreter-constructs.t` (17 tests; passes under real raku too)
- `make test` full suite: PASS (1662 files / 16350 tests)
- Roast spot-check (Test::Util-heavy whitelisted files, 8 files / 258 tests): PASS
- `cargo fmt` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYzLgNeFvbQucTjEVzq4sW