### PR TITLE
refactor(scope): flip shadow-slot allocation to default ON (§1.4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -356,11 +356,14 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 - [ ] 生ポインタ aliased write の撤廃: 旧 `arc_contents_mut` は dead 化済みで、本番経路は
       `gc::gc_contents_mut` / `Gc::{get,make}_mut` に移動（unsoundness は解消でなく移動 —
       ANALYSIS rev8 §2.1）。完全解消 = §2 Track B 残スライス T4-T6 に統合済み（重複着手しない）。
-- [ ] **レキシカルスコープ slot キャンペーン完遂（ANALYSIS §1.4・
+- [~] **レキシカルスコープ slot キャンペーン完遂（ANALYSIS §1.4・
       [docs/lexical-scope-slot-campaign.md](docs/lexical-scope-slot-campaign.md)）**: writeback IR への
-      slot 焼き込みは部分着手済み（`SmartMatchExpr.lhs_slot`・RMW slot 引数・rw-arg `Pair(name, slot)`）。
-      残り = by-name フォールバック（`find_local_slot`）の撤廃 → `MUTSU_SHADOW_SLOTS` 既定 ON
-      （シャドウ衝突の実修正） → `BlockScope` の locals 全 clone/restore 撤去。
+      slot 焼き込み（S1–S17）完了。**shadow-slot 既定 ON 化 完了（2026-07-12）** — フル toggle-ON
+      サーベイ（1379 files）で genuine 回帰 0 を確認し `shadow_slots_active()` を default true に
+      flip（escape hatch `MUTSU_NO_SHADOW_SLOTS`・make test 16351 PASS）。残り = **`BlockScope` の
+      locals 全 clone/restore 撤去**（`exec_block_scope_op` の `self.locals.clone()`＝キャンペーンの
+      perf 本丸。`$OUTER::` 実行時 snapshot・GC roots・env 再同期と絡む load-bearing refactor で
+      専用セッション向き）。
 - [ ] エラー/制御のチャネル分離: bool 群の `enum Control` 統合と `RuntimeError` 縮小
       （cold Box 化・`result_large_err` 23→0）は完了。残る「制御を `Result::Err` で運ぶ」構造自体の
       分離は実害が消えたため優先度低（ANALYSIS rev8 §2.2）。

--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -325,10 +325,36 @@ three of these were missed until now — re-run the FULL survey periodically.
       variants (`IndexAssignExprNested`/`DeepNested`/`Generic`), computed-attr twigil
       cells, hyper `»=»` multi-key writeback, and the remaining `update_local_if_exists`
       callers — migrated onto `resolve_local_slot`/`write_local_slot_or_name`.
-- [~] §1.4 flip + `pop_local_scope` restore — **landed gated** behind
-      `MUTSU_SHADOW_SLOTS` (default off = byte-identical). See the
-      "shadow-slot activation, gated" section below. Default flip pends §1.3.
-- [ ] §1.3 slot-indexed locals + drop BlockScope clone.
+- [x] §1.4 flip + `pop_local_scope` restore — **DEFAULT ON since 2026-07-12.**
+      The gate (`shadow_slots_active`) now defaults true; `MUTSU_NO_SHADOW_SLOTS`
+      is a temporary opt-out escape hatch. Green light = the fresh full toggle-ON
+      survey below.
+- [ ] §1.3 slot-indexed locals + drop the `exec_block_scope_op` whole-`locals`
+      clone (`self.locals.clone()` @ vm_misc_scope.rs:178, plus the
+      `outer_scope_locals.push(saved_locals.clone())` @ :184 and the
+      `self.locals = saved_locals` restore @ :376). **This is the load-bearing
+      remaining refactor** — the clone feeds THREE entangled consumers: (a) the
+      block-exit locals restore (now largely redundant under shadow slots since
+      inner shadows own isolated slots, but the env re-sync at :377-381 and
+      `our_locals`/alias reconciliation still ride on it), (b) `$OUTER::` runtime
+      access (`outer_scope_locals`, read in `vm_var_get_ops.rs:381`), and (c) GC
+      root tracing (`gc_roots.rs:116`). Removing it safely means reworking the
+      block-exit reconciliation to not need a whole-array snapshot AND giving
+      `$OUTER::` a non-snapshot path (S14 baked the compile-time slots; the
+      runtime snapshot path remains). Deserves its own dedicated session with
+      full `make roast` validation, per the doc's per-slice rule.
+
+## Fresh full toggle-ON survey (2026-07-12, debug, 1379 whitelisted files)
+
+`MUTSU_SHADOW_SLOTS=1` (pre-flip) run of every whitelisted file, each ON failure
+re-run OFF: **on_fail=113, genuine toggle-ON regressions = 0.** Every file that
+fails ON also fails OFF (the on_fail count is inflated by `# TODO` not-ok lines,
+which are deterministic and identical ON/OFF). So flipping the default breaks
+nothing that currently passes — the §1.5 leaf-slot bakes (S1–S17) plus the
+2026-07-10 container-identity/cell campaign drove the §1.3 class-1 (name-keyed
+env dual-store) breakage, and every §1.4 survey #1–#3 regression, to zero.
+Validated with `make test` under the flip (16351 tests, PASS). The clone-removal
+perf payoff is the remaining unchecked box above.
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -9,25 +9,25 @@ use crate::value::Value;
 
 static STATE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-/// §1.4 shadow-slot activation gate (`MUTSU_SHADOW_SLOTS`).
+/// §1.4 shadow-slot activation gate.
 ///
-/// When set, [`Compiler::declare_local`] gives a shadowing inner-block `my $x`
+/// When active, [`Compiler::declare_local`] gives a shadowing inner-block `my $x`
 /// its **own** fresh local slot (instead of sharing the outer `$x`'s slot) and
 /// [`Compiler::pop_local_scope`] restores the outer binding in `local_map` on
-/// scope exit. The DEFAULT (unset) build is byte-identical: `declare_local`
-/// resolves like `alloc_local` (get-or-create by name), so shadowing correctness
-/// keeps relying on the runtime `BlockScope` env restore.
+/// scope exit, so shadowing correctness no longer relies on the runtime
+/// `BlockScope` whole-`locals` restore.
 ///
-/// Activation alone is NOT yet coherent: the name-keyed env store cannot hold two
-/// live `$x` (§1.3 dual-store) and ~80 by-name leaf writebacks resolve to the
-/// outer slot (§1.5 remaining leaf sites). This toggle is the development
-/// substrate the campaign greens slice-by-slice before the default is flipped —
-/// the same env-var-gated pattern the env_dirty campaign used. See
-/// docs/lexical-scope-slot-campaign.md and ANALYSIS.md §1.4.
+/// **Default ON since 2026-07-12.** A fresh full toggle-ON whitelist survey
+/// (1379 files) found **zero genuine regressions** — every file that fails ON
+/// also fails OFF — confirming the §1.5 leaf-slot bakes (S1–S17) plus the
+/// 2026-07-10 container-identity/cell work drove the §1.3 class-1 (name-keyed
+/// env dual-store) breakage to zero. `MUTSU_NO_SHADOW_SLOTS` is a temporary
+/// opt-out escape hatch (reverts to the old shared-slot + env-restore behavior).
+/// See docs/lexical-scope-slot-campaign.md and ANALYSIS.md §1.4.
 pub(crate) fn shadow_slots_active() -> bool {
     use std::sync::OnceLock;
     static ACTIVE: OnceLock<bool> = OnceLock::new();
-    *ACTIVE.get_or_init(|| std::env::var_os("MUTSU_SHADOW_SLOTS").is_some())
+    *ACTIVE.get_or_init(|| std::env::var_os("MUTSU_NO_SHADOW_SLOTS").is_none())
 }
 mod expr;
 mod expr_binary;

--- a/t/shadow-slots-default.t
+++ b/t/shadow-slots-default.t
@@ -1,0 +1,41 @@
+use Test;
+
+# Shadow-slot allocation is DEFAULT ON since 2026-07-12: a shadowing inner-block
+# `my $x` gets its own local slot, so mutating it never touches the outer binding
+# and the outer value is intact after the block. This pins the default-on
+# behaviour (was gated behind MUTSU_SHADOW_SLOTS; `MUTSU_NO_SHADOW_SLOTS` opts out).
+
+plan 8;
+
+{
+    my $x = 1;
+    { my $x = 2; $x++; is $x, 3, 'inner shadow mutates independently'; }
+    is $x, 1, 'outer scalar intact after shadowed block';
+}
+
+{
+    my @a = 1, 2, 3;
+    { my @a = <x y>; push @a, 'z'; is @a.elems, 3, 'inner @-shadow independent'; }
+    is @a.join(','), '1,2,3', 'outer array intact after shadowed block';
+}
+
+# Assigning to an OUTER (non-shadowed) variable inside a block DOES persist.
+{
+    my $outer = 10;
+    { $outer = 42; }
+    is $outer, 42, 'assignment to an outer var persists out of the block';
+}
+
+# Nested triple shadow, each level independent.
+{
+    my $v = 'a';
+    {
+        my $v = 'b';
+        {
+            my $v = 'c';
+            is $v, 'c', 'depth-2 shadow';
+        }
+        is $v, 'b', 'depth-1 shadow intact';
+    }
+    is $v, 'a', 'depth-0 intact';
+}


### PR DESCRIPTION
## What

A shadowing inner-block `my $x` now gets its **own** local slot by default,
instead of sharing the outer `$x`'s slot and relying on the runtime `BlockScope`
env restore for shadow correctness. Flips `shadow_slots_active()` from the
`MUTSU_SHADOW_SLOTS`-gated opt-in to **default true**; `MUTSU_NO_SHADOW_SLOTS`
is a temporary opt-out escape hatch.

This is the §1.4 default flip of the lexical-scope shadow-slot campaign
(`docs/lexical-scope-slot-campaign.md`).

## Green light

A fresh full toggle-ON whitelist survey (2026-07-12, **1379 files**, each ON
failure re-run OFF) found **zero genuine regressions** — every file that fails
ON also fails OFF (the raw on_fail=113 is inflated by deterministic `# TODO`
not-ok lines). The §1.5 leaf-slot bakes (S1–S17) plus the 2026-07-10
container-identity/cell campaign drove the §1.3 class-1 (name-keyed env
dual-store) breakage — and every §1.4 survey #1–#3 regression — to zero.

- `make test` under the flip: **16351 tests, PASS**.
- `MUTSU_NO_SHADOW_SLOTS=1` opt-out verified to restore the old behavior.
- New `t/shadow-slots-default.t` pins scalar/array shadows, outer-var
  persistence, and triple-nested shadows.

## Still open (next dedicated session)

The campaign's **perf payoff** — removing the `exec_block_scope_op` whole-`locals`
clone (`self.locals.clone()`) — is a load-bearing refactor entangled with
`$OUTER::` runtime snapshots, GC-root tracing, and the block-exit env
reconciliation. Left as a distinct slice per the doc's per-slice rule. Tracked
in `docs/lexical-scope-slot-campaign.md` §1.3 and `PLAN.md` §6.

CI `make roast` is the comprehensive gate for this default-behavior flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)