### PR TITLE
perf(vm): admit nested class/role/grammar decls to module-sub OTF (PLAN §3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -215,11 +215,13 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 - [ ] default-param OTF の builtin-shadow 単一候補（name-cache 汚染リスクがあるため意図的に除外を維持中）。
 - [ ] モジュール sub OTF に残る interpreter 結合構文: `EVAL` / `EVALFILE` / `start` /
-      sigilless scalar（`\x`）/ 戻り型 coercion / `is encoded(...)`（NativeCall marshalling）/
-      ネスト class/role 宣言
+      sigilless scalar（`\x`）/ 戻り型 coercion / `is encoded(...)`（NativeCall marshalling）
       （ゲート実体 = `def_is_otf_compilable_module_single`、`vm/vm_call_func_ops.rs`）。
-      **★2026-07-11 body 構文ゲート緩和**: `CATCH` / `CONTROL` / phaser /
-      ネスト sub/proto/token 宣言 / `subtest` / `once` は実験で raku 一致を確認し OTF 許可に変更
+      **★2026-07-11/12 body 構文ゲート緩和**: `CATCH` / `CONTROL` / phaser /
+      ネスト sub/proto/token 宣言 / `subtest` / `once`（2026-07-11）に加え、
+      **ネスト class/role/grammar 宣言**（2026-07-12 — 同名 `my` class の cross-sub 非汚染は
+      parse 時 `decl_id` で担保・捕捉 lexical/継承/parameterized role/grammar parse 全て raku 一致）
+      も実験で確認し OTF 許可に変更
       （担保 = `t/module-sub-otf-interpreter-constructs.t`）。tree-walk 既存バグ（body 直下
       `CATCH` があると非 die パスの戻り値が Nil になる）も OTF 化で修正。
       **★`start` は OTF 化不可を実験で確認（2026-07-11）**: 再帰 sub の start クロージャが param を

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1753,12 +1753,14 @@ impl Interpreter {
     ///     must survive across an `EVAL` boundary (t/sigilless-params).
     ///
     /// Formerly-excluded body constructs verified OTF-safe and now admitted
-    /// (§3 fallback removal, 2026-07-11): nested sub/proto/token decls
+    /// (§3 fallback removal, 2026-07-11/12): nested sub/proto/token decls
     /// (non-local `when` control flow stays inside the nested routine —
     /// Test::Util's `is-deeply-junction`), `subtest`, `CATCH`/`CONTROL`
-    /// handlers, phasers (ENTER/LEAVE), and `once`. All run through the same
-    /// VM ops the precompiled path uses; pinned by
-    /// t/module-sub-otf-interpreter-constructs.t.
+    /// handlers, phasers (ENTER/LEAVE), `once`, and nested class/role/grammar
+    /// decls (same-named `my` classes stay distinct via `decl_id`; captured
+    /// lexicals, inheritance, parameterized roles and grammar parsing all
+    /// match raku). All run through the same VM ops the precompiled path
+    /// uses; pinned by t/module-sub-otf-interpreter-constructs.t.
     ///
     /// `is rw`/`is raw`/`is copy`/`is readonly`/`is required` params are NOW
     /// allowed (§2 multi-dispatch VM-ization): the compiled binding already
@@ -1892,18 +1894,20 @@ impl Interpreter {
     fn module_otf_stmt_needs_interpreter(stmt: &crate::ast::Stmt) -> bool {
         use crate::ast::Stmt;
         match stmt {
-            // Nested class/role decls still couple to the interpreter's package
-            // registration context (same exclusion as
-            // `function_body_needs_interpreter`). Nested sub/proto/token decls,
-            // `subtest`, `CATCH`/`CONTROL` handlers and phasers are OTF-safe
-            // (verified 2026-07-11 against raku, incl. Test::Util's
-            // `is-deeply-junction` nested `when` control flow and
-            // `throws-like-any`'s CATCH+subtest): the compiled body registers
-            // nested routines and runs handlers/phasers through the same VM ops
-            // the precompiled path uses. OTF even fixes a tree-walk bug where a
-            // body-level CATCH swallowed the normal path's return value. Pinned
-            // by t/module-sub-otf-interpreter-constructs.t.
-            Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } => true,
+            // Nested sub/proto/token decls, `subtest`, `CATCH`/`CONTROL`
+            // handlers and phasers are OTF-safe (verified 2026-07-11 against
+            // raku, incl. Test::Util's `is-deeply-junction` nested `when`
+            // control flow and `throws-like-any`'s CATCH+subtest): the compiled
+            // body registers nested routines and runs handlers/phasers through
+            // the same VM ops the precompiled path uses. OTF even fixes a
+            // tree-walk bug where a body-level CATCH swallowed the normal
+            // path's return value. Nested class/role/grammar decls are also
+            // OTF-safe (verified 2026-07-12): RegisterClass/RegisterRole run
+            // identically under OTF — same-named `my` classes in different
+            // subs stay distinct via the parse-time `decl_id`, captured
+            // lexicals/params resolve per call, and inheritance/parameterized
+            // roles/grammar parsing all match raku. Pinned by
+            // t/module-sub-otf-interpreter-constructs.t.
             Stmt::If {
                 then_branch,
                 else_branch,

--- a/t/lib/InterpConstructOtf.rakumod
+++ b/t/lib/InterpConstructOtf.rakumod
@@ -117,6 +117,64 @@ our sub oc-leave-count() is export {
 }
 our sub oc-leave-read() is export { $leave-count }
 
+# nested `my class` with attributes, a method, and per-call construction
+our sub oc-class($x, $y) is export {
+    my class Point {
+        has $.x;
+        has $.y;
+        method sum() { $!x + $!y }
+    }
+    Point.new(:$x, :$y).sum;
+}
+
+# two subs declaring the SAME nested class name — must not pollute each other
+our sub oc-class-shape-a() is export {
+    my class Shape { method kind() { "a-shape" } }
+    Shape.new.kind;
+}
+our sub oc-class-shape-b() is export {
+    my class Shape { method kind() { "b-shape" } }
+    Shape.new.kind;
+}
+
+# nested class method mutating a captured lexical (fresh per call)
+our sub oc-class-capture() is export {
+    my $count = 0;
+    my class Bumper { method bump() { $count++ } }
+    my $b = Bumper.new;
+    $b.bump; $b.bump; $b.bump;
+    $count;
+}
+
+# inheritance between two nested classes + callsame
+our sub oc-class-inherit() is export {
+    my class Base { method greet() { "base" } }
+    my class Derived is Base { method greet() { "derived+" ~ callsame } }
+    Derived.new.greet;
+}
+
+# recursive sub declaring a class
+our sub oc-class-recur($n) is export {
+    my class Node { has $.v }
+    return Node.new(v => 0).v if $n <= 0;
+    oc-class-recur($n - 1) + Node.new(v => $n).v;
+}
+
+# parameterized role mixed into a nested class
+our sub oc-role() is export {
+    my role Sized[$max] { method max() { $max } }
+    my class Box does Sized[10] { }
+    Box.new.max;
+}
+
+# grammar declared inside a sub
+our sub oc-grammar($s) is export {
+    my grammar NumG {
+        token TOP { \d+ }
+    }
+    NumG.parse($s) ?? "match:$s" !! "nomatch";
+}
+
 # subtest inside a module sub
 use Test;
 our sub oc-subtest($desc, $a, $b) is export {

--- a/t/module-sub-otf-interpreter-constructs.t
+++ b/t/module-sub-otf-interpreter-constructs.t
@@ -3,10 +3,11 @@ use Test;
 use InterpConstructOtf;
 
 # Pins that module subs containing formerly interpreter-gated constructs
-# (nested routine decls, CATCH/CONTROL, phasers, subtest, start, once) behave
-# raku-identically when OTF-compiled (def_is_otf_compilable_module_single).
+# (nested routine decls, CATCH/CONTROL, phasers, subtest, start, once, and
+# nested class/role/grammar decls) behave raku-identically when OTF-compiled
+# (def_is_otf_compilable_module_single).
 
-plan 17;
+plan 28;
 
 is oc-nested(42), "int:42|str:s", "nested sub decl with when+return";
 is oc-nested-when(7), "Iafter;", "nested sub when does not escape the nested routine";
@@ -30,5 +31,17 @@ my @r = await (^4).map: { start oc-catch-in-thread($_) };
 is @r.sort.join("|"), "caught:t0|caught:t2|ok:1|ok:3", "CATCH inside start-threaded calls";
 await (^8).map: { start oc-leave-count() };
 is oc-leave-read(), 8, "LEAVE fires once per call across threads";
+
+is oc-class(3, 4), 7, "nested my class with attrs and method";
+is oc-class-shape-a(), "a-shape", "same-named nested class (a)";
+is oc-class-shape-b(), "b-shape", "same-named nested class (b)";
+is oc-class-shape-a(), "a-shape", "no cross-sub class pollution after b";
+is oc-class-capture(), 3, "nested class method mutates captured lexical";
+is oc-class-capture(), 3, "captured lexical is fresh per call";
+is oc-class-inherit(), "derived+base", "nested class inheritance with callsame";
+is oc-class-recur(4), 10, "recursive sub with nested class decl";
+is oc-role(), 10, "parameterized nested role mixed into nested class";
+is oc-grammar("123"), "match:123", "nested grammar parses";
+is oc-grammar("ab"), "nomatch", "nested grammar rejects";
 
 oc-subtest("subtest inside a module sub", 3, 3);


### PR DESCRIPTION
## Summary

Next slice of PLAN §3 fallback removal (follows #4427): remove the
`ClassDecl`/`RoleDecl` exclusion from the module-sub OTF body gate
(`module_otf_stmt_needs_interpreter` in `vm/vm_call_func_ops.rs`), so
module subs whose bodies declare nested classes, roles, or grammars now
compile OTF to bytecode instead of tree-walking.

## Verification (experiment-driven, raku byte-identical)

All of the following were compared against real `raku` before/after the
gate change, with `MUTSU_VM_STATS` confirming fallbacks 8→0:

- same-named nested `my class` in two different subs — no cross-sub
  pollution (parse-time `decl_id` keeps them distinct)
- nested class method mutating a captured sub lexical — fresh per call
- inheritance between two nested classes + `callsame`
- parameterized role (`my role Sized[$max]`) mixed into a nested class
- nested `my grammar` + `token TOP` parse
- recursive sub declaring a class
- attribute defaults, bare (non-`my`) class, `my enum`, `my subset`

## Tests

- 11 new pins in `t/module-sub-otf-interpreter-constructs.t` (now 28
  tests; the whole file passes under real raku as well)
- `make test`: PASS (Files=1663, Tests=16367)
- full roast delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)