### PR TITLE
perf(vm): admit coercion return types to module-sub OTF (PLAN §3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -215,13 +215,16 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 
 - [ ] default-param OTF の builtin-shadow 単一候補（name-cache 汚染リスクがあるため意図的に除外を維持中）。
 - [ ] モジュール sub OTF に残る interpreter 結合構文: `EVAL` / `EVALFILE` / `start` /
-      sigilless scalar（`\x`）/ 戻り型 coercion / `is encoded(...)`（NativeCall marshalling）
+      sigilless scalar（`\x`）/ `is encoded(...)`（NativeCall marshalling）
       （ゲート実体 = `def_is_otf_compilable_module_single`、`vm/vm_call_func_ops.rs`）。
-      **★2026-07-11/12 body 構文ゲート緩和**: `CATCH` / `CONTROL` / phaser /
+      **★2026-07-11/12 ゲート緩和**: `CATCH` / `CONTROL` / phaser /
       ネスト sub/proto/token 宣言 / `subtest` / `once`（2026-07-11）に加え、
-      **ネスト class/role/grammar 宣言**（2026-07-12 — 同名 `my` class の cross-sub 非汚染は
-      parse 時 `decl_id` で担保・捕捉 lexical/継承/parameterized role/grammar parse 全て raku 一致）
-      も実験で確認し OTF 許可に変更
+      **ネスト class/role/grammar 宣言**（2026-07-12 #4429 — 同名 `my` class の cross-sub 非汚染は
+      parse 時 `decl_id` で担保・捕捉 lexical/継承/parameterized role/grammar parse 全て raku 一致）と
+      **戻り型 coercion（`--> Foo:D()`）**（2026-07-12 — 旧不一致 coercion-return.t は compiled 経路の
+      改善で解消済みを実験確認。カスタム COERCE multi・Nil/Failure as-is・X::TypeCheck::Return /
+      X::Coerce::Impossible 失敗系・複数 coercion sub 共存全て raku 一致。
+      担保 = `t/module-sub-otf-coercion-return.t`）も OTF 許可に変更
       （担保 = `t/module-sub-otf-interpreter-constructs.t`）。tree-walk 既存バグ（body 直下
       `CATCH` があると非 die パスの戻り値が Nil になる）も OTF 化で修正。
       **★`start` は OTF 化不可を実験で確認（2026-07-11）**: 再帰 sub の start クロージャが param を

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1786,16 +1786,14 @@ impl Interpreter {
     /// shared `state` cell), but which the cross-thread shared captured body
     /// handles correctly.
     fn def_module_single_sig_body_ok_ignoring_state(def: &crate::ast::FunctionDef) -> bool {
-        def.return_type.as_ref().is_none_or(|rt| !rt.contains('('))
-            && def.param_defs.iter().all(|pd| {
-                let is_capture = pd.slurpy && pd.sigilless;
-                let traits_otf_safe = pd
-                    .traits
-                    .iter()
-                    .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
-                (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
-            })
-            && !Self::module_otf_body_needs_interpreter(&def.body)
+        def.param_defs.iter().all(|pd| {
+            let is_capture = pd.slurpy && pd.sigilless;
+            let traits_otf_safe = pd
+                .traits
+                .iter()
+                .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
+            (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
+        }) && !Self::module_otf_body_needs_interpreter(&def.body)
     }
 
     /// Return the shared captured body for a resolved module sub def IF routing it
@@ -1853,21 +1851,19 @@ impl Interpreter {
         // caller slot (#4091), so the compiled binding refreshes the caller variable
         // identically to the interpreter — including across an EVAL call boundary.
         //
-        // A *coercion* return (`--> Foo:D()`, the parens) drives extra
-        // return-time COERCE dispatch that the standalone OTF compile does
-        // not reproduce identically when several such subs coexist
-        // (roast/S12-coercion/coercion-return.t), so it stays on the
-        // interpreter. A plain / definite / subset return (`--> Str:D`,
-        // `--> IO::Path:D`) is fine: the compiled binding re-checks it the
-        // same way the interpreter does. This lets Test::Util's
+        // Return types — plain, definite, subset AND coercion (`--> Foo:D()`)
+        // — are all OTF-safe. The coercion exclusion was lifted 2026-07-12:
+        // the compiled return path now drives the same COERCE dispatch the
+        // interpreter does (custom COERCE multis, Nil/Failure passed as-is,
+        // X::TypeCheck::Return / X::Coerce::Impossible on failure), verified
+        // against raku with several coercion subs coexisting
+        // (roast/S12-coercion/coercion-return.t + t/module-sub-otf-coercion-
+        // return.t). Plain/definite returns already let Test::Util's
         // `make-temp-file`/`make-rand-path` (`--> IO::Path:D`, calling a
         // module-private sibling) OTF-compile (PR closure-env #3899/#3902
         // made module-level lexical + private-sibling reads work under OTF;
         // the chmod-IntStr allomorph fix unblocked S32-io/chdir.t).
         // Signature/body gates (shared with the cross-thread shared-body path):
-        //   - a *coercion* return (`--> Foo:D()`, the parens) drives extra
-        //     return-time COERCE dispatch the standalone OTF compile does not
-        //     reproduce identically (roast/S12-coercion/coercion-return.t);
         //   - a capture parameter (`|c`) binds read-only and is fine, but a
         //     sigilless *scalar* (`\x`) / non-capture sub-signature stays excluded
         //     (caller-alias writeback across an EVAL boundary — see the doc above);

--- a/t/lib/CoercionReturnOtf.rakumod
+++ b/t/lib/CoercionReturnOtf.rakumod
@@ -1,0 +1,21 @@
+unit module CoercionReturnOtf;
+
+# Module subs with coercion return types, formerly excluded from OTF
+# compilation (def_is_otf_compilable_module_single). Pinned by
+# t/module-sub-otf-coercion-return.t.
+
+class Wrapped is export {
+    has $.val;
+    multi method COERCE($val) { self.new(:$val) }
+}
+
+our sub cr-str($x --> Str()) is export { $x }
+
+our sub cr-int($x --> Int()) is export { $x }
+
+our sub cr-str-numeric($x --> Str(Numeric:D)) is export { $x }
+
+our sub cr-custom($x --> Wrapped:D()) is export { $x }
+
+my subset SmallVal of Rat where { .abs < 0.5 };
+our sub cr-subset($x --> SmallVal:D()) is export { $x }

--- a/t/module-sub-otf-coercion-return.t
+++ b/t/module-sub-otf-coercion-return.t
@@ -1,0 +1,36 @@
+use lib $*PROGRAM.parent.child("lib").Str;
+use Test;
+use CoercionReturnOtf;
+
+# Pins that module subs with coercion return types (`--> Str()`,
+# `--> Foo:D()`, coercive subsets) behave raku-identically when
+# OTF-compiled (def_is_otf_compilable_module_single) — the coercion
+# exclusion was lifted 2026-07-12 (PLAN §3 fallback removal).
+
+plan 15;
+
+is cr-str(42), "42", "Str() coerces an Int";
+isa-ok cr-str(42), Str, "Str() result is a Str";
+is cr-int("17") + 1, 18, "Int() coerces a Str";
+isa-ok cr-int("17"), Int, "Int() result is an Int";
+
+# interleaved calls to several coexisting coercion subs
+is (cr-str(1), cr-int("2"), cr-str(3)).join("|"), "1|2|3",
+    "several coercion subs coexist without cross-pollution";
+
+is cr-str-numeric(42.12), "42.12", "Str(Numeric:D) coerces a Rat";
+is cr-str-numeric("keep"), "keep", "matching value bypassed as-is";
+is-deeply cr-str-numeric(Nil), Nil, "Nil is returned as-is";
+throws-like { cr-str-numeric([1,2]) }, X::TypeCheck::Return,
+    "non-Numeric throws X::TypeCheck::Return";
+throws-like { cr-str-numeric(Int) }, X::TypeCheck::Return,
+    "type object throws X::TypeCheck::Return";
+
+isa-ok cr-custom(42), Wrapped, "custom COERCE dispatches";
+is cr-custom(42).val, 42, "custom COERCE receives the value";
+
+is cr-subset("0.2"), 0.2, "coercive subset coerces";
+throws-like { cr-subset("1.3") }, X::Coerce::Impossible,
+    "coercive subset rejects out-of-range via X::Coerce::Impossible";
+throws-like { cr-subset(1.3) }, X::Coerce::Impossible,
+    "value failing subset constraint throws";


### PR DESCRIPTION
## Summary

Next slice of PLAN §3 fallback removal (follows #4427, #4429): remove the
coercion-return exclusion (`return_type` containing parens, e.g.
`--> Foo:D()`) from the module-sub OTF gate
(`def_module_single_sig_body_ok_ignoring_state` in `vm/vm_call_func_ops.rs`).

The exclusion dated from an era when the standalone OTF compile did not
reproduce return-time COERCE dispatch identically when several coercion
subs coexisted (roast/S12-coercion/coercion-return.t). The compiled
return path has since caught up — verified by experiment before lifting
the gate.

## Verification (experiment-driven, raku byte-identical)

- built-in coercions: `--> Str()`, `--> Int()`, `--> Str(Numeric:D)`
- custom `COERCE` multis (`--> Foo:D()`) and coercive subsets
  (`--> SmallVal:D()`)
- `Nil` and `Failure` returned as-is
- failure modes match raku: `X::TypeCheck::Return` (non-matching value /
  type object) and `X::Coerce::Impossible` (subset constraint violation)
- several coercion subs interleaved — no cross-pollution
- `MUTSU_VM_STATS`: probe-script fallbacks 6→0
- `roast/S12-coercion/coercion-return.t` and all whitelisted
  S12-coercion files PASS with the gate lifted

## Tests

- new pin: `t/module-sub-otf-coercion-return.t` (15 tests; the file
  passes under real raku as well)
- `make test`: PASS (Files=1664, Tests=16382)
- full roast delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)