### PR TITLE
fix(parser): exempt EVAL's final statement from sink-context warnings

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -61,6 +61,23 @@ thread_local! {
     static PARSE_WARNINGS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
     /// 1-based line numbers of detected VCS conflict markers (`<<<<<<<` blocks).
     static VCS_CONFLICT_MARKERS: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
+    /// When set, the next `parse_program` call treats the unit's final
+    /// statement as a value (return) position, not sink context — the EVAL /
+    /// EVALFILE semantics, where the last expression is the EVAL's result.
+    /// Consumed (reset to false) by that call, so nested parses (e.g. a `use`
+    /// inside the EVAL'd code) fall back to mainline sink semantics.
+    static EVAL_VALUE_TAIL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Arm the value-tail sink semantics for the next `parse_program` call (see
+/// `EVAL_VALUE_TAIL`).
+fn set_eval_value_tail() {
+    EVAL_VALUE_TAIL.with(|f| f.set(true));
+}
+
+/// Consume the value-tail flag (one-shot).
+fn take_eval_value_tail() -> bool {
+    EVAL_VALUE_TAIL.with(|f| f.replace(false))
 }
 
 /// Add a warning message during parsing. Collected and emitted after parse completes.
@@ -283,6 +300,9 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
     // Clear any stale parse warnings from previous/backtracked parses
     PARSE_WARNINGS.with(|w| w.borrow_mut().clear());
     VCS_CONFLICT_MARKERS.with(|m| m.borrow_mut().clear());
+    // Consume the EVAL value-tail flag up front so any nested parse this
+    // program triggers (module loads, ...) uses plain mainline semantics.
+    let eval_value_tail = take_eval_value_tail();
     let memo_enabled = parse_memo_enabled();
     if memo_enabled {
         expr::reset_expression_memo();
@@ -331,7 +351,11 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                 // same scope is a compile-time X::Redeclaration::Outer in rakudo.
                 Err(build_outer_redeclaration_error(&symbol, line))
             } else {
-                sink_warn::add_sink_warnings(&stmts);
+                if eval_value_tail {
+                    sink_warn::add_sink_warnings_value_tail(&stmts);
+                } else {
+                    sink_warn::add_sink_warnings(&stmts);
+                }
                 Ok((stmts, finish_content))
             }
         }
@@ -438,6 +462,10 @@ pub(crate) fn parse_program_with_operators_and_user_subs(
     stmt::set_eval_operator_assoc_preseed(operator_assoc.clone());
     stmt::set_eval_imported_function_preseed(imported_function_names.to_vec());
     stmt::set_eval_user_sub_preseed(user_sub_names.to_vec());
+    // Every caller of this entry point evaluates the parsed unit for its value
+    // (EVAL / EVAL :check / throws-like code strings), so the final statement
+    // is a return position, not sink context.
+    set_eval_value_tail();
     let result = parse_program(input);
     stmt::set_eval_operator_preseed(Vec::new());
     stmt::set_eval_operator_assoc_preseed(std::collections::HashMap::new());

--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -27,6 +27,22 @@ pub(super) fn add_sink_warnings(stmts: &[Stmt]) {
     scan_gathers_stmts(stmts);
 }
 
+/// Like [`add_sink_warnings`], but for a unit evaluated for its value (EVAL /
+/// EVALFILE): the final statement is the unit's return value, not sink
+/// context, so it is exempt from the analysis. Raku warns on `EVAL '42; $x'`
+/// only for the `42`. Trailing `SetLine` markers are skipped when locating
+/// the final real statement.
+pub(super) fn add_sink_warnings_value_tail(stmts: &[Stmt]) {
+    let last_real = stmts.iter().rposition(|s| !matches!(s, Stmt::SetLine(_)));
+    for (i, stmt) in stmts.iter().enumerate() {
+        if Some(i) == last_real {
+            continue;
+        }
+        walk_stmt(stmt, false);
+    }
+    scan_gathers_stmts(stmts);
+}
+
 /// Walk the entire program looking for `gather` blocks. For each one, emit sink
 /// warnings for its body. Only `Gather` nodes trigger a warning; every other
 /// node is traversed purely to reach nested gathers, so an unhandled variant can

--- a/t/sink-warning.t
+++ b/t/sink-warning.t
@@ -2,7 +2,7 @@ use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
 use Test;
 use Test::Util;
 
-plan 30;
+plan 33;
 
 # A pure value evaluated in sink (void) context warns.
 is_run 'say "hi"; 42', { :0status, :out("hi\n"), :err(/"Useless use" .* 42/) },
@@ -84,6 +84,15 @@ is_run '6.02e23', { :0status, :err(/"Useless use" .* 'number' .* '6.02e23'/) },
     'sink warning keeps scientific notation';
 is_run '∞', { :0status, :err(/"Useless use" .* '∞'/) },
     'sink warning keeps Unicode infinity glyph';
+
+# EVAL: the final statement is the EVAL's return value, not sink context,
+# so only non-final statements warn.
+is_run 'my $x = 3; say EVAL q[$x + 5]', { :0status, :out("8\n"), :err('') },
+    'EVAL final expression is a value, not sink';
+is_run 'say EVAL "43"', { :0status, :out("43\n"), :err('') },
+    'single-statement EVAL does not warn';
+is_run 'say EVAL q[42; 5 + 5]', { :0status, :out("10\n"), :err(/"Useless use" .* 42/) },
+    'EVAL non-final statement still warns';
 
 # Double statement modifier ejects with X::Syntax::Confused carrying pre/post.
 throws-like 'say 1 if 2 if 3 { say 3 }', X::Syntax::Confused,


### PR DESCRIPTION
## Summary

First of the two EVAL-semantics prerequisite bugs recorded in PLAN §3
(#4432): an EVAL'd compilation unit returns its last expression's value,
so that statement is a **value position, not sink context**. raku warns
on `EVAL '42; $x + 5'` only for the `42`; mutsu also warned on the final
expression, emitting a spurious `Useless use of ... in sink context` for
every pure final expression inside EVAL.

## Implementation

- `parse_program_with_operators_and_user_subs` — the parse entry that
  all value-position evaluations go through (EVAL, EVAL `:check`,
  throws-like code strings; verified all 4 call sites) — arms a one-shot
  thread-local flag.
- `parse_program` consumes the flag up front, so nested parses (e.g. a
  `use` inside the EVAL'd code) keep mainline semantics.
- New `add_sink_warnings_value_tail` skips the final real statement
  (trailing `SetLine` markers ignored); everything before it is analysed
  as usual.
- Mainline programs are unchanged: their final statement is still sunk
  (`raku -e '3 + 5'` warns — verified).

## Tests

- 3 new pins in `t/sink-warning.t` (33 tests; new cases pass under real
  raku as well)
- `make test`: PASS
- EVAL-related whitelisted roast files all pass (S29-context/eval.t,
  evalfile.t, S04-phasers/in-eval.t, S01 eval_lex.t, S06 main-eval.t,
  integration/eval-and-threads.t)
- full roast delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)