### PR TITLE
fix(runtime): match raku CALLER:: frame semantics through EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -243,12 +243,15 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
       EVAL(CALLER context) は「共有問題」でなく「compiled 経路の再現問題」なので捕捉共有
       ボディでも直らない（捕捉も `compile_block_raw` = OTF 相当）。ゲート完全退役には EVAL の
       compiled 経路 correctness という別軸作業が必要。詳細 = memory `project-compiled-fns-expansion`。
-      **★EVAL の先行条件バグ 2 件（2026-07-12 実験で具体化・tree-walk 自体が raku と不一致）**:
-      ① EVAL 最終式（返り値位置）に過剰な "Useless use ... in sink context" warning を出す
-      （raku は出さない）。② EVAL 内 `CALLER::<$v>` のフレーム解決が EVAL 呼び出し元スコープで
-      止まらず外側 main まで透過し、非 dynamic 変数で "Cannot access ... not declared as dynamic"
-      エラーになる（raku は EVAL を呼んだ sub の body を見て、無ければ Nil）。
-      OTF 化以前にこの EVAL 意味論の修正が先行条件。
+      **★EVAL の先行条件バグ 2 件は解消済み（2026-07-12）**:
+      ① EVAL 最終式への過剰 sink warning → #4433。② EVAL 内 `CALLER::` フレーム解決 →
+      修正済み: raku 実測（try-free probe）で「EVAL は呼び出し元との間に中間フレーム 2 枚
+      （multi candidate + proto）を挟み、呼び出し元スコープは CALLER::CALLER::CALLER:: で到達。
+      CALLER:: lookup のミス（名前なし・スタック超過）は静かに Nil、存在するが非 dynamic のみ
+      X::Caller::NotDynamic throw」を確認し、`push_eval_caller_frames`（現 env + 空フレーム 2 枚）
+      + `get_caller_var` の quiet-Nil 化で一致（担保 = `t/eval-caller-frames.t`、rakudo 10/10 で
+      pin 検証済み）。旧メモの「非 EVAL non-dynamic は quiet Any」は try がフレームを 1 枚
+      挟む測定汚染で、実際は throw（mutsu 従来挙動が正）。→ 次 = EVAL の OTF 許可実験本体。
       標準 param trait（`is copy`/`is rw`/`is raw`/`is readonly`/`is required`）はゲートから外れた
       （旧 `pd.traits.is_empty()` の一律除外を解除。compiled binding は元々これらを処理していた＝
       builtin-shadow ゲート `def_is_otf_compilable` は trait 未チェック。加えて tree-walk fallback が

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -35,6 +35,32 @@ impl Interpreter {
         self.callframe_stack.pop();
     }
 
+    /// Push the caller frames an `EVAL` inserts between the EVAL'd unit's
+    /// mainline and the scope that invoked EVAL. Rakudo runs the compiled unit
+    /// behind two intermediate frames (the EVAL multi candidate and its proto),
+    /// so from EVAL'd mainline code `CALLER::` / `CALLER::CALLER::` see frames
+    /// with no user lexicals (lookups yield Nil) and the invoking scope is
+    /// reached at `CALLER::CALLER::CALLER::`. Mirror that: push the invoking
+    /// frame's env (the depth-3 target), then two empty frames.
+    pub(crate) fn push_eval_caller_frames(&mut self) {
+        self.push_caller_env();
+        for _ in 0..2 {
+            self.caller_env_stack.push(Env::new());
+            self.callframe_stack.push(CallFrameEntry {
+                file: "EVAL".to_string(),
+                line: 0,
+                code: None,
+                env: Env::new(),
+            });
+        }
+    }
+
+    pub(crate) fn pop_eval_caller_frames(&mut self) {
+        for _ in 0..3 {
+            self.pop_caller_env();
+        }
+    }
+
     /// Pop caller env and apply any dynamic variable writes back to the given env.
     /// Use this instead of `pop_caller_env()` at function return sites that restore `saved_env`.
     pub(crate) fn pop_caller_env_with_writeback(&mut self, restored_env: &mut Env) {
@@ -76,10 +102,10 @@ impl Interpreter {
     /// `name` is the bare variable name without sigil (e.g. "a" for $a).
     pub(crate) fn get_caller_var(&self, name: &str, depth: usize) -> Result<Value, RuntimeError> {
         let stack_len = self.caller_env_stack.len();
-        if depth > stack_len {
-            return Err(RuntimeError::new(format!(
-                "Cannot access caller variable '${name}' — not enough caller frames"
-            )));
+        if depth == 0 || depth > stack_len {
+            // Walking past the top of the call stack is not an error in Raku:
+            // the lookup just misses and yields Nil.
+            return Ok(Value::NIL);
         }
         let env = &self.caller_env_stack[stack_len - depth];
         if let Some(val) = env.get(name) {
@@ -89,9 +115,10 @@ impl Interpreter {
             }
             Ok(val.clone())
         } else {
-            Err(RuntimeError::new(format!(
-                "Cannot access '${name}' through CALLER"
-            )))
+            // A name the target frame does not have resolves to Nil quietly
+            // (rakudo's runtime pad lookup misses; only a *present* non-dynamic
+            // symbol throws X::Caller::NotDynamic).
+            Ok(Value::NIL)
         }
     }
 

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -275,6 +275,10 @@ impl Interpreter {
         }
         let previous_pod = self.env.get("=pod").cloned();
         let saved_in_eval = self.env.get("__mutsu_in_eval").cloned();
+        // CALLER:: from the EVAL'd unit's mainline must not resolve directly in
+        // the scope that invoked EVAL (see push_eval_caller_frames for the
+        // frame layout raku exposes).
+        self.push_eval_caller_frames();
         // Record the `&name` code-vars that already exist in the enclosing scope,
         // so a sub declared inside this EVAL may shadow them without being treated
         // as a redeclaration (see registration_sub.rs).
@@ -357,6 +361,7 @@ impl Interpreter {
                 self.env.remove("__mutsu_eval_wrapped_decls");
             }
         }
+        self.pop_eval_caller_frames();
         if let Some(saved) = previous_pod {
             self.env.insert("=pod".to_string(), saved);
         } else {

--- a/t/eval-caller-frames.t
+++ b/t/eval-caller-frames.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 10;
+
+# EVAL runs the compiled unit behind two intermediate caller frames (rakudo:
+# the EVAL multi candidate and its proto), so from EVAL'd mainline code the
+# scope that invoked EVAL is reached at CALLER::CALLER::CALLER::, and the
+# first two hops see frames with no user lexicals. A CALLER:: lookup that
+# misses (unknown name, or walking past the top of the stack) yields Nil
+# quietly; only a symbol that is present but not dynamic throws
+# X::Caller::NotDynamic. All pinned against rakudo (tmp/otf-eval probes,
+# 2026-07-12).
+
+# depth 1 = EVAL's own frame: the invoking sub's lexicals are invisible.
+sub d1() { my $z = 11; EVAL '(CALLER::<$z>).raku' }
+is d1(), 'Nil', 'EVAL CALLER:: does not see the invoking scope at depth 1';
+
+sub d2() { my $z = 11; EVAL '(CALLER::CALLER::<$z>).raku' }
+is d2(), 'Nil', 'EVAL CALLER::CALLER:: is still inside the EVAL frames';
+
+# depth 3 reaches the sub that invoked EVAL.
+sub d3-dyn() { my $*dz = 17; EVAL 'CALLER::CALLER::CALLER::<$*dz>' }
+is d3-dyn(), 17, 'EVAL depth 3 reaches the invoking sub (dynamic var)';
+
+throws-like { my $z = 11; $z++; EVAL 'CALLER::CALLER::CALLER::<$z>' },
+    X::Caller::NotDynamic, symbol => '$z',
+    'EVAL depth 3 non-dynamic lexical of the invoking scope throws';
+
+sub d4() { my $*dz = 17; EVAL '(CALLER::CALLER::CALLER::CALLER::<$*dz>).raku' }
+is d4(), 'Nil', 'EVAL depth 4 walks past the invoking sub';
+
+# EVAL invoked from mainline: same frame layout.
+my $*md = 42;
+is EVAL('CALLER::CALLER::CALLER::<$*md>'), 42,
+    'EVAL from mainline reaches mainline dynamics at depth 3';
+is EVAL('(CALLER::CALLER::CALLER::CALLER::<$*md>).raku'), 'Nil',
+    'EVAL from mainline: depth 4 walks past the top quietly';
+
+# Non-EVAL CALLER:: misses are quiet Nil, not errors.
+sub nf-angle() { (CALLER::<$nosuchvar>).raku }
+is nf-angle(), 'Nil', 'CALLER::<$x> miss yields Nil quietly';
+
+sub nf-sigil() { ($CALLER::nosuchvar2).raku }
+is nf-sigil(), 'Nil', '$CALLER::x miss yields Nil quietly';
+
+sub nf-deep() { (CALLER::CALLER::CALLER::CALLER::CALLER::<$xx>).raku }
+is nf-deep(), 'Nil', 'CALLER:: past the top of the stack yields Nil quietly';


### PR DESCRIPTION
## Summary

PLAN §3 — second (final) prerequisite bug for admitting `EVAL` to module-sub OTF. Prereq (1) was the sink-warning fix (#4433); this closes prereq (2): `CALLER::` frame resolution through `EVAL`.

### rakudo behavior (measured with try-free probes, `tmp/otf-eval/`)

- `EVAL` inserts **two intermediate frames** (the EVAL multi candidate and its proto) between the EVAL'd unit's mainline and the invoking scope: `CALLER::`/`CALLER::CALLER::` from EVAL'd mainline see frames with no user lexicals, and the invoking scope is reached at `CALLER::CALLER::CALLER::`.
- A `CALLER::` lookup that **misses** (unknown name, or walking past the top of the call stack) yields **Nil quietly**.
- A symbol that is **present but not dynamic** throws `X::Caller::NotDynamic` — in mainline, sub frames, and EVAL'd units alike. (The earlier survey's "non-EVAL non-dynamic returns quiet Any" was a measurement artifact: `try EXPR` inserts a thunk frame that shifts the CALLER chain by one, so those probes were looking at the wrong frame. mutsu's existing throw was already correct.)

### Changes

- `push_eval_caller_frames()`/`pop_eval_caller_frames()`: `eval_eval_string` now pushes the invoking frame's env plus two empty frames around evaluation, reproducing the depth-3 layout. Previously EVAL pushed nothing, so `CALLER::` from EVAL'd code leaked straight through to the outer mainline and threw on non-dynamic vars (raku: quiet Nil).
- `get_caller_var`: not-found and depth-past-top now return Nil quietly instead of throwing. Present-but-non-dynamic still throws.

### Testing

- New pin `t/eval-caller-frames.t` (10 assertions) — **verified 10/10 on rakudo first**, then on mutsu.
- `make test` green (1665 files / 16393 tests + cargo test 535).
- Targeted whitelisted roast: `S02-names/caller.t`, `S32-exceptions/misc.t`/`misc2.t`, `S01-perl-5-integration/eval_lex.t`, `S04-phasers/in-eval.t`, `S06-advanced/callframe.t`, `S06-other/main-eval.t`, `S12-enums/pseudo-functional.t`, `S29-context/eval.t`/`evalfile.t`, `integration/eval-and-threads.t` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)