### PR TITLE
feat(class): compile-time attribute decl via BEGIN EVAL in class body (S12-attributes/class.t 28/28)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -23,7 +23,7 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 
 ## 現在の前提
 
-- whitelist は **1379**（2026-07-12、`wc -l roast-whitelist.txt`）。
+- whitelist は **1380**（2026-07-12、`wc -l roast-whitelist.txt`）。
 - **roast 由来の大型共通ブロッカーは出尽くした。** かつての大型 campaign
   （真の lazy 配列 / dispatch・演算子 sugar の desugar / S17 並行・非同期 /
   第一級コンテナ container identity / cross-thread lexical writeback）はすべて完了済み。
@@ -46,7 +46,6 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 
 | 分類 | ファイル | mutsu | raku (v2022.12/6.d) | ブロッカー（一言） |
 |---|---|---|---|---|
-| ★達成可能 | `S12-attributes/class.t` | 19/28 で中断 | 28/28 満点 | 複数機能が必要: クラス内 `BEGIN EVAL` のコンパイル時属性宣言 (test 20)、`EVAL` attr→NotFound (21)、`is_run` エラーメッセージ (22-23)、`where` 節での属性アクセス `X::Syntax::NoSelf` (24-28) |
 | ★達成可能 | `S32-hash/perl.t` | 47/55・notok 8 | 55/55 満点 | 残 8 は匿名 typed hash `$(my Any %)` の EVAL round-trip 型喪失＝パラメータ化ロール type-capture binding 待ち（匿名 typed 容器タグ付けが binding を壊す既存制限） |
 | ★達成可能 | `6.c/S05-grammar/methods.t` | 4/8・notok 4 | 8/8 満点 | grammar エンジンの深い複合: regex 内 die の伝播、埋め込みブロックの外側レキシカルキャプチャ、dup-token エラー |
 | ★達成可能 | `6.c/S06-other/main-refactored.t` | 0/501 | 501/501 満点 | 新 MAIN インターフェース全体（USAGE 生成・引数 coercion 等）が必要 |

--- a/TODO_roast/S12.md
+++ b/TODO_roast/S12.md
@@ -1,10 +1,17 @@
 # S12 - attributes, class, coercion, construction, enums, introspection, methods, subset
 
 - [ ] roast/S12-attributes/augment-and-initialization.t
-- [ ] roast/S12-attributes/class.t
-  - 26/28 pass. Fixed: test 19 (role `method b()` now shadows the auto-generated accessor for `has $.b`), tests 22-23 (`our $.a` / `my $.a` in mainline now emit a "Useless generation of accessor method" warning instead of dying), test 24 (a `where` constraint on an attribute referencing another attribute twigil `$!a` now throws X::Syntax::NoSelf at parse time).
-  - Test 14 deferred: `$!a` at the mainline / inside `EVAL` should throw X::Syntax::NoSelf, but currently yields Nil silently. The compiler emits GetLocal for `$!attr` (perf commit #2391); switching to GetGlobal at the mainline to trigger the VM NoSelf check breaks class methods declared inside subs (e.g. PredictiveIterator `count-only`), where the compiler context flags (`local_map["self"]`, `is_routine`, `lexically_in_routine`) do not reliably indicate the routine/self context. A proper fix needs the method-body compiler to always establish a known self/routine context. NOTE: t/tail-function.t #4/#5, t/placeholder.t #8 and t/wrap.t already fail on pristine main (unrelated pre-existing failures).
-  - Test 21 deferred: `class RT102478_2 { EVAL q[has $.x] }` declares an attribute via a runtime EVAL inside a class body. In Raku the class is already composed by the time the EVAL runs, so the attribute is NOT added and `.x` throws X::Method::NotFound. In mutsu the class genuinely has 0 attributes, but `.new(x => 3)` stores the unknown named arg in the instance attribute map and the no-arg accessor read falls back to `attributes.get(method)` when `collect_class_attributes` is empty (methods_instance_ops.rs ~line 776). Removing that permissive fallback risks broad regressions.
+- [x] roast/S12-attributes/class.t
+  - 28/28 pass, whitelisted. Final blocker was test 20: `class RT102478_1 { BEGIN EVAL q[has $.x] }`
+    declares an attribute at *compile time* via a `BEGIN`-phaser EVAL inside a class body.
+    A `has` that reaches the VM (mainline / EVAL'd source) now compiles to the `RuntimeHasDecl`
+    opcode: when a class body is being registered by a compile-time phaser (tracked by
+    `Interpreter::defining_class`, set only around `BEGIN`/`CHECK` phaser execution in
+    `register_class_decl`), the op registers the attribute onto that class via
+    `register_runtime_attribute`; otherwise it throws the original `X::Attribute::NoPackage` /
+    `X::Attribute::Package` error. Test 21 (`class RT102478_2 { EVAL q[has $.x] }`, a *runtime*
+    plain EVAL) correctly does NOT register — `defining_class` is only armed for compile-time
+    phasers — so `.x` still throws X::Method::NotFound.
 - [ ] roast/S12-attributes/clone.t
   - 38/44 pass. Failures 25-38 depend on reference/container semantics for `has @.arr`/`has %.hsh` attributes: `push $obj.arr, 'c'`, `$obj.arr.push('c')`, and `my @b := $obj.arr; @b.push('c')` must write through to the attribute slot, and assignment `$obj.arr = ...` must not detach. mutsu's Array is `Arc<Vec<Value>>` with value semantics, so accessor results are decoupled from the attribute. Fix requires interior-mutability refactor of Array/Hash (Arc<RefCell<...>> or Proxy/container layer) across VM, method dispatch, builtins.
 - [ ] roast/S12-attributes/defaults.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -628,6 +628,7 @@ roast/S11-repository/cur-candidates.t
 roast/S11-repository/cur-current-distribution.t
 roast/S11-repository/curli-install.t
 roast/S12-attributes/augment-and-initialization.t
+roast/S12-attributes/class.t
 roast/S12-attributes/clone.t
 roast/S12-attributes/defaults.t
 roast/S12-attributes/delegation.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2370,6 +2370,13 @@ impl Compiler {
                 is_public,
                 is_our,
                 is_my,
+                is_rw,
+                is_readonly,
+                is_required,
+                is_built,
+                type_constraint,
+                type_smiley,
+                default,
                 ..
             } => {
                 // `our $.x` / `my $.x` in the mainline is not a fatal error in
@@ -2419,9 +2426,26 @@ impl Compiler {
                     attrs.insert("message".to_string(), Value::str(message));
                     Value::make_instance(Symbol::intern("X::Attribute::NoPackage"), attrs)
                 };
-                let idx = self.code.add_constant(err);
-                self.code.emit(OpCode::LoadConst(idx));
-                self.code.emit(OpCode::Die);
+                // A `has` reaching the VM only arises from mainline / EVAL'd
+                // source (a `has` in a normal class body is collected
+                // declaratively by `register_class_decl`, never compiled). Emit a
+                // runtime op that, when a class is currently being defined
+                // (`class Foo { BEGIN EVAL q[has $.x] }`), registers the
+                // attribute onto that class; otherwise it throws the error above.
+                let spec = crate::opcode::RuntimeHasDeclSpec {
+                    attr_name: bare.to_string(),
+                    is_public: *is_public,
+                    sigil: sigil_ch,
+                    is_rw: *is_rw,
+                    is_readonly: *is_readonly,
+                    is_required: is_required.clone(),
+                    is_built: *is_built,
+                    type_constraint: type_constraint.clone(),
+                    type_smiley: type_smiley.clone(),
+                    default: default.clone(),
+                    error: err,
+                };
+                self.code.emit(OpCode::RuntimeHasDecl(Box::new(spec)));
             }
             // DoesDecl/TrustsDecl outside class context are no-ops
             Stmt::DoesDecl { .. } | Stmt::TrustsDecl { .. } => {}

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -187,6 +187,30 @@ pub(crate) struct ForLoopSpec {
     pub(crate) single_array_source_local: Option<u32>,
 }
 
+/// Payload of `OpCode::RuntimeHasDecl`. A `has $.x` that reaches the VM (rather
+/// than being collected declaratively by `register_class_decl`) only arises from
+/// mainline / EVAL'd source — e.g. `class Foo { BEGIN EVAL q[has $.x] }`. At
+/// runtime the op checks whether a class is currently being defined
+/// (`Interpreter::defining_class`): if so it registers the attribute onto that
+/// class; otherwise it throws the pre-built `error` (`X::Attribute::NoPackage`
+/// or `X::Attribute::Package`). Boxed to keep `size_of::<OpCode>()` small.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeHasDeclSpec {
+    pub(crate) attr_name: String,
+    pub(crate) is_public: bool,
+    pub(crate) sigil: char,
+    pub(crate) is_rw: bool,
+    pub(crate) is_readonly: bool,
+    pub(crate) is_required: Option<Option<String>>,
+    pub(crate) is_built: Option<bool>,
+    pub(crate) type_constraint: Option<String>,
+    pub(crate) type_smiley: Option<String>,
+    pub(crate) default: Option<crate::ast::Expr>,
+    /// The `X::Attribute::*` error to throw when this `has` runs outside a
+    /// class-definition context.
+    pub(crate) error: Value,
+}
+
 /// Bytecode operations for the VM.
 #[derive(Debug, Clone)]
 pub(crate) enum OpCode {
@@ -1265,6 +1289,11 @@ pub(crate) enum OpCode {
     // -- Error handling --
     Die,
     Fail,
+
+    /// A `has`-attribute declaration that reaches runtime (mainline / EVAL'd
+    /// source). Registers the attribute onto the class currently being defined,
+    /// or throws the boxed `X::Attribute::*` error when not in a class body.
+    RuntimeHasDecl(Box<RuntimeHasDeclSpec>),
 
     // -- Functions --
     Return,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1060,6 +1060,13 @@ pub struct Interpreter {
     /// evaluating typed-attribute default type objects so a suppressed nested
     /// class name resolves within its owning class (see `resolve_suppressed_type`).
     constructing_class: Option<String>,
+    /// The class whose body is currently being registered, set only while
+    /// executing `BEGIN`/`EVAL` code inside a class body (see
+    /// `register_class_decl`). Lets a `has`-attribute declaration that reaches
+    /// the VM at runtime (`class Foo { BEGIN EVAL q[has $.x] }`) attach the
+    /// attribute to the class still under construction rather than throwing
+    /// `X::Attribute::NoPackage`.
+    pub(crate) defining_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
     /// Companion to `pending_call_arg_sources` (§1.4/§1.5): the compiler-baked
     /// `arg-source name -> caller local slot` for the current call, decoded from the

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -156,6 +156,57 @@ impl Interpreter {
         }
     }
 
+    /// Register an attribute onto a class whose body is still being defined,
+    /// driven by a `has`-declaration that reached the VM at runtime (mainline /
+    /// EVAL'd source: `class Foo { BEGIN EVAL q[has $.x] }`). This mirrors the
+    /// per-instance-attribute branch of `register_class_decl` for the common
+    /// case (name/type/smiley/built + accessor visibility); traits, `handles`,
+    /// `where`, `is default`, and role composition are not supported here
+    /// (an EVAL'd `has` carrying those is exceedingly rare).
+    pub(crate) fn register_runtime_attribute(
+        &mut self,
+        class_name: &str,
+        spec: &crate::opcode::RuntimeHasDeclSpec,
+    ) -> Result<(), RuntimeError> {
+        let attr_name = &spec.attr_name;
+        let Some(mut class_def) = self.registry().classes.get(class_name).cloned() else {
+            return Ok(());
+        };
+        // Already declared (e.g. a duplicate EVAL): no-op rather than abort.
+        if class_def.attributes.iter().any(|(n, ..)| n == attr_name) {
+            return Ok(());
+        }
+        let effective_is_rw = !spec.is_readonly && spec.is_rw;
+        class_def.attributes.push((
+            attr_name.clone(),
+            spec.is_public,
+            spec.default.clone(),
+            effective_is_rw,
+            spec.is_required.clone(),
+            spec.sigil,
+            None,
+        ));
+        if let Some(tc) = &spec.type_constraint {
+            let resolved_tc = tc.replace("::?CLASS", class_name);
+            class_def
+                .attribute_types
+                .insert(attr_name.clone(), resolved_tc);
+        }
+        if let Some(ts) = &spec.type_smiley {
+            class_def
+                .attribute_smileys
+                .insert(attr_name.clone(), ts.clone());
+        }
+        if let Some(built) = spec.is_built {
+            class_def.attribute_built.insert(attr_name.clone(), built);
+        }
+        self.registry_mut()
+            .classes
+            .insert(class_name.to_string(), class_def);
+        self.clear_private_zeroarg_method_cache();
+        Ok(())
+    }
+
     pub(crate) fn register_class_decl(
         &mut self,
         name: &str,
@@ -2013,7 +2064,31 @@ impl Interpreter {
                     self.registry_mut()
                         .classes
                         .insert(name.to_string(), class_def.clone());
+                    // Mark this class as "being defined" so a `has`-attribute
+                    // declaration executed by a *compile-time* phaser
+                    // (`class Foo { BEGIN EVAL q[has $.x] }`) attaches to it
+                    // instead of throwing X::Attribute::NoPackage. Restored (not
+                    // cleared) to support nested class-in-BEGIN definitions.
+                    // Only BEGIN/CHECK phasers qualify: a *plain* runtime `EVAL
+                    // q[has $.x]` runs after the class is composed, so its
+                    // attribute must NOT take (roast S12-attributes/class.t
+                    // test 21 asserts `.x` then throws X::Method::NotFound).
+                    let is_compile_time_phaser = matches!(
+                        stmt,
+                        Stmt::Phaser {
+                            kind: PhaserKind::Begin | PhaserKind::Check,
+                            ..
+                        }
+                    );
+                    let saved_defining = if is_compile_time_phaser {
+                        Some(self.defining_class.replace(name.to_string()))
+                    } else {
+                        None
+                    };
                     let result = self.run_block_raw(std::slice::from_ref(stmt));
+                    if let Some(saved) = saved_defining {
+                        self.defining_class = saved;
+                    }
                     if let Err(e) = result {
                         if !is_swallowable {
                             return Err(e);

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1798,6 +1798,7 @@ impl Interpreter {
             callframe_stack: Vec::new(),
             method_class_stack: Vec::new(),
             constructing_class: None,
+            defining_class: None,
             pending_call_arg_sources: None,
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -169,6 +169,7 @@ impl Interpreter {
             callframe_stack: Vec::new(),
             method_class_stack: Vec::new(),
             constructing_class: None,
+            defining_class: None,
             pending_call_arg_sources: None,
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3326,6 +3326,40 @@ impl Interpreter {
             }
 
             // -- Error handling --
+            OpCode::RuntimeHasDecl(spec) => {
+                // A `has`-attribute declaration that reached the VM (mainline /
+                // EVAL'd source). If a class body is currently being registered
+                // (`class Foo { BEGIN EVAL q[has $.x] }`), attach the attribute
+                // to that class; otherwise throw the pre-built X::Attribute error.
+                if let Some(class_name) = self.defining_class.clone() {
+                    self.register_runtime_attribute(&class_name, spec)?;
+                    *ip += 1;
+                } else {
+                    let val = spec.error.clone();
+                    self.resume_ip = Some(*ip + 1);
+                    let backtrace_str = self.build_backtrace_string();
+                    let backtrace_val = self.build_backtrace_value();
+                    let current_line = self.current_source_line();
+                    let current_file = self.current_source_file();
+                    let mut err = self.runtime_error_from_exception_value(val, "Died", false);
+                    if !backtrace_str.is_empty() {
+                        err.set_backtrace(Some(backtrace_str));
+                    }
+                    if let Some(ref exc_box) = err.exception
+                        && let ValueView::Instance { attributes, .. } = exc_box.view()
+                    {
+                        attributes.insert("backtrace".to_string(), backtrace_val);
+                        if let Some(line) = current_line {
+                            attributes
+                                .insert_if_absent("line".to_string(), Value::int(line as i64));
+                        }
+                        if let Some(ref file) = current_file {
+                            attributes.insert_if_absent("file".to_string(), Value::str_from(file));
+                        }
+                    }
+                    return Err(err);
+                }
+            }
             OpCode::Die => {
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 // Store the resume point (instruction after Die) for .resume support

--- a/t/class-attr-begin-eval.t
+++ b/t/class-attr-begin-eval.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 8;
+
+# A `has` declared at compile time via a BEGIN-phaser EVAL inside a class body
+# attaches to the class (the class is still open at BEGIN time).
+class C1 { BEGIN EVAL q[has $.x] };
+is C1.new(x => 3).x, 3, 'BEGIN EVAL q[has $.x] declares a usable attribute';
+
+# A BEGIN block (no EVAL) containing `has` also declares the attribute.
+class C2 { BEGIN { has $.y } };
+is C2.new(y => 7).y, 7, 'BEGIN { has $.y } declares a usable attribute';
+
+# A CHECK-phaser EVAL is also compile time and declares the attribute.
+class C3 { CHECK EVAL q[has $.z] };
+is C3.new(z => 9).z, 9, 'CHECK EVAL q[has $.z] declares a usable attribute';
+
+# A *plain* runtime EVAL inside a class body runs after the class is composed,
+# so the attribute is NOT added and the accessor throws X::Method::NotFound.
+class C4 { EVAL q[has $.w] };
+throws-like { C4.new(w => 1).w }, X::Method::NotFound,
+    'plain runtime EVAL q[has $.w] does NOT declare an attribute';
+
+# Mainline `has $.x` (no package) throws X::Attribute::NoPackage.
+throws-like 'has $.a', X::Attribute::NoPackage,
+    'mainline has $.a throws X::Attribute::NoPackage';
+
+# `has` inside a module body throws X::Attribute::Package.
+throws-like 'module M { has $.a }', X::Attribute::Package,
+    'has inside a module body throws X::Attribute::Package';
+
+# A compile-time-declared attribute honors its type constraint via .new.
+class C5 { BEGIN EVAL q[has Int $.n] };
+is C5.new(n => 42).n, 42, 'typed attribute from BEGIN EVAL works';
+
+# The compile-time attribute also gets a default when none is passed.
+class C6 { BEGIN EVAL q[has $.d = 100] };
+is C6.new.d, 100, 'default value on BEGIN EVAL attribute works';


### PR DESCRIPTION
## Summary

`class Foo { BEGIN EVAL q[has $.x] }` declares an attribute at **compile time** (the class is still open at `BEGIN`-phaser time), so `Foo.new(x => 3).x` must work. This was the last blocker for `roast/S12-attributes/class.t`, which now passes **28/28** and is whitelisted.

## Mechanism

A `has` that reaches the VM only arises from mainline / EVAL'd source — a plain class-body `has` is collected declaratively by `register_class_decl` and never compiled. Such a `has` now compiles to the new `RuntimeHasDecl` opcode instead of an unconditional `Die`:

- When a class body is being registered by a **compile-time phaser** (`BEGIN`/`CHECK`) — tracked by the new `Interpreter::defining_class` field, armed only around that phaser's execution in `register_class_decl` — the op registers the attribute onto that class via `register_runtime_attribute`.
- Otherwise it throws the original `X::Attribute::NoPackage` / `X::Attribute::Package` error, preserving mainline and module-body behavior exactly.

A **plain** runtime `EVAL q[has $.x]` inside a class body is deliberately **not** armed (it runs after the class is composed), so the attribute is not added and the accessor correctly throws `X::Method::NotFound` (test 21).

## Verification

- `roast/S12-attributes/class.t`: 28/28 (was 19/28, aborted at test 20). Whitelisted.
- `make test`: PASS (16396 tests).
- New `t/class-attr-begin-eval.t` (8 subtests): `BEGIN`/`CHECK` EVAL, `BEGIN` block, plain runtime EVAL non-registration, mainline/module error paths, typed + defaulted attributes.
- Behavior matches reference `raku` on all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)