### PR TITLE
perf(vm): admit EVAL/EVALFILE to module-sub OTF (PLAN §3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -214,7 +214,7 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
 残るのは multi-dispatch の fallback 除去のみ:
 
 - [ ] default-param OTF の builtin-shadow 単一候補（name-cache 汚染リスクがあるため意図的に除外を維持中）。
-- [ ] モジュール sub OTF に残る interpreter 結合構文: `EVAL` / `EVALFILE` / `start` /
+- [ ] モジュール sub OTF に残る interpreter 結合構文: `start` /
       sigilless scalar（`\x`）/ `is encoded(...)`（NativeCall marshalling）
       （ゲート実体 = `def_is_otf_compilable_module_single`、`vm/vm_call_func_ops.rs`）。
       **★2026-07-11/12 ゲート緩和**: `CATCH` / `CONTROL` / phaser /
@@ -251,7 +251,12 @@ White のまま取り残す」stranding を修正（VERIFY が検出・毎 run 5
       X::Caller::NotDynamic throw」を確認し、`push_eval_caller_frames`（現 env + 空フレーム 2 枚）
       + `get_caller_var` の quiet-Nil 化で一致（担保 = `t/eval-caller-frames.t`、rakudo 10/10 で
       pin 検証済み）。旧メモの「非 EVAL non-dynamic は quiet Any」は try がフレームを 1 枚
-      挟む測定汚染で、実際は throw（mutsu 従来挙動が正）。→ 次 = EVAL の OTF 許可実験本体。
+      挟む測定汚染で、実際は throw（mutsu 従来挙動が正）。
+      **★`EVAL`/`EVALFILE` は OTF 許可済み（2026-07-12・#4435 の直後スライス）**: #4435 で
+      compiled 経路の EVAL が tree-walk と同一挙動になったことを実験確認（param/lexical
+      read/write・EVAL 内 sub 宣言・CALLER:: d1/d3・topic・module-private sibling 呼び出し・
+      nested my sub 捕捉・die+CATCH・EVALFILE 全て raku 一致、fallback counter 0）。
+      担保 = `t/module-sub-otf-interpreter-constructs.t`（rakudo 40/40 検証済み）。
       標準 param trait（`is copy`/`is rw`/`is raw`/`is readonly`/`is required`）はゲートから外れた
       （旧 `pd.traits.is_empty()` の一律除外を解除。compiled binding は元々これらを処理していた＝
       builtin-shadow ゲート `def_is_otf_compilable` は trait 未チェック。加えて tree-walk fallback が

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1743,8 +1743,6 @@ impl Interpreter {
     ///     lives in a shared cell that a per-thread OTF recompile would sever —
     ///     t/concurrent-state-var; admitted via the cross-thread shared captured
     ///     body, `imported_state_body_for_def`),
-    ///   - `EVAL`/`EVALFILE` with a `CALLER::` context the standalone compile
-    ///     cannot reconstruct,
     ///   - a `start` block: a recursive sub whose start closure captures a param
     ///     gets its capture clobbered by the recursive call's param re-bind
     ///     under OTF (t/start-block-return-value.t test 3 — see
@@ -1761,6 +1759,15 @@ impl Interpreter {
     /// lexicals, inheritance, parameterized roles and grammar parsing all
     /// match raku). All run through the same VM ops the precompiled path
     /// uses; pinned by t/module-sub-otf-interpreter-constructs.t.
+    ///
+    /// `EVAL`/`EVALFILE` are also admitted (2026-07-12, after the #4435 EVAL
+    /// CALLER-frame fix): `eval_eval_string` runs on `self` with the live
+    /// `self.env`, so an EVAL inside an OTF-compiled body sees the same
+    /// lexical scope and CALLER:: frame layout as under the tree-walk path —
+    /// param/lexical reads and writes, nested sub declarations, CALLER::
+    /// depth resolution, `$_`, module-private sibling calls, and CATCH around
+    /// a dying EVAL all verified raku-identical OTF vs interpreter (pinned by
+    /// t/module-sub-otf-interpreter-constructs.t).
     ///
     /// `is rw`/`is raw`/`is copy`/`is readonly`/`is required` params are NOW
     /// allowed (§2 multi-dispatch VM-ization): the compiled binding already
@@ -1938,26 +1945,23 @@ impl Interpreter {
             }
             Expr::Call { name, args } => {
                 let n = name.resolve();
-                // EVAL/EVALFILE run on a sub-Interpreter with a CALLER:: context
-                // that the standalone OTF compile cannot reconstruct. `start`
-                // stays excluded: a *recursive* sub whose start closure captures
-                // a param breaks under OTF — the recursive call re-binds the
-                // same param name in the thread env the closure keeps reading,
-                // so after `await` the captured `$n` is clobbered by the deepest
-                // call's binding (t/start-block-return-value.t test 3,
-                // fib(5)=3; the tree-walk path save/restores the env around the
-                // call). Non-recursive start captures do work OTF, but the gate
-                // is an AST predicate that cannot see recursion, so all `start`
+                // `start` stays excluded: a *recursive* sub whose start closure
+                // captures a param breaks under OTF — the recursive call
+                // re-binds the same param name in the thread env the closure
+                // keeps reading, so after `await` the captured `$n` is
+                // clobbered by the deepest call's binding
+                // (t/start-block-return-value.t test 3, fib(5)=3; the
+                // tree-walk path save/restores the env around the call).
+                // Non-recursive start captures do work OTF, but the gate is an
+                // AST predicate that cannot see recursion, so all `start`
                 // bodies stay on the interpreter. `once` IS OTF-safe within a
                 // thread — its site key is stable across calls because the
                 // fingerprint-keyed `otf_compile_cache` reuses one compiled
                 // body. (Cross-thread `once` dedup is a pre-existing gap in the
                 // thread-cloned `once_values` store, identical under tree-walk
-                // — recorded in PLAN §3.)
-                n == "start"
-                    || n == "EVAL"
-                    || n == "EVALFILE"
-                    || args.iter().any(Self::module_otf_expr_needs_interpreter)
+                // — recorded in PLAN §3.) `EVAL`/`EVALFILE` are OTF-safe since
+                // the #4435 CALLER-frame fix — see the module-single gate doc.
+                n == "start" || args.iter().any(Self::module_otf_expr_needs_interpreter)
             }
             _ => false,
         }

--- a/t/lib/InterpConstructOtf.rakumod
+++ b/t/lib/InterpConstructOtf.rakumod
@@ -184,3 +184,66 @@ our sub oc-subtest($desc, $a, $b) is export {
         is $a, $b, "is equal";
     }
 }
+
+# EVAL inside a module sub (admitted to OTF 2026-07-12, after the #4435
+# EVAL CALLER-frame fix): the EVAL'd code shares the sub's live lexical
+# scope and sees raku's CALLER:: frame layout (invoking scope at depth 3).
+
+our sub oc-eval-param($x) is export {
+    EVAL '$x + 1'
+}
+
+our sub oc-eval-lexical() is export {
+    my $y = 10;
+    EVAL '$y * 2'
+}
+
+our sub oc-eval-write() is export {
+    my $y = 1;
+    EVAL '$y = 5';
+    $y
+}
+
+our sub oc-eval-decl-sub() is export {
+    EVAL 'sub oc-eval-helper($n) { $n + 100 }; oc-eval-helper(7)'
+}
+
+our sub oc-eval-caller-d3() is export {
+    my $*dz = 17;
+    EVAL 'CALLER::CALLER::CALLER::<$*dz>'
+}
+
+our sub oc-eval-caller-d1() is export {
+    my $z = 11;
+    $z++;
+    EVAL '(CALLER::<$z>).raku'
+}
+
+our sub oc-eval-topic() is export {
+    my @r;
+    for 1, 2, 3 {
+        @r.push(EVAL '$_ * 10');
+    }
+    @r.join(',')
+}
+
+# EVAL'd code calling a module-private (non-exported) sibling sub
+sub oc-eval-secret() { 'sekrit' }
+our sub oc-eval-sibling() is export {
+    EVAL 'oc-eval-secret() ~ "!"'
+}
+
+our sub oc-eval-nested($v) is export {
+    my sub wrap() { EVAL '$v ~ "-wrapped"' }
+    wrap()
+}
+
+our sub oc-eval-catch() is export {
+    EVAL 'die "boom"';
+    CATCH { default { return "caught:" ~ .message } }
+    "no-throw"
+}
+
+our sub oc-evalfile($path) is export {
+    EVALFILE $path
+}

--- a/t/lib/evalfile-fixture.raku
+++ b/t/lib/evalfile-fixture.raku
@@ -1,0 +1,5 @@
+# Fixture for t/module-sub-otf-interpreter-constructs.t (oc-evalfile):
+# EVALFILE'd from inside an OTF-compiled module sub; the last statement's
+# value is EVALFILE's return value.
+my $x = 20;
+$x * 2 + 2

--- a/t/module-sub-otf-interpreter-constructs.t
+++ b/t/module-sub-otf-interpreter-constructs.t
@@ -3,11 +3,11 @@ use Test;
 use InterpConstructOtf;
 
 # Pins that module subs containing formerly interpreter-gated constructs
-# (nested routine decls, CATCH/CONTROL, phasers, subtest, start, once, and
-# nested class/role/grammar decls) behave raku-identically when OTF-compiled
-# (def_is_otf_compilable_module_single).
+# (nested routine decls, CATCH/CONTROL, phasers, subtest, start, once,
+# nested class/role/grammar decls, and EVAL/EVALFILE) behave raku-identically
+# when OTF-compiled (def_is_otf_compilable_module_single).
 
-plan 28;
+plan 40;
 
 is oc-nested(42), "int:42|str:s", "nested sub decl with when+return";
 is oc-nested-when(7), "Iafter;", "nested sub when does not escape the nested routine";
@@ -43,5 +43,20 @@ is oc-class-recur(4), 10, "recursive sub with nested class decl";
 is oc-role(), 10, "parameterized nested role mixed into nested class";
 is oc-grammar("123"), "match:123", "nested grammar parses";
 is oc-grammar("ab"), "nomatch", "nested grammar rejects";
+
+is oc-eval-param(41), 42, "EVAL reads the sub's param";
+is oc-eval-lexical(), 20, "EVAL reads the sub's lexical";
+is oc-eval-write(), 5, "EVAL writes the sub's lexical";
+is oc-eval-decl-sub(), 107, "EVAL declares and calls a sub";
+is oc-eval-caller-d3(), 17, "EVAL CALLER:: depth 3 reaches the invoking sub";
+is oc-eval-caller-d1(), "Nil", "EVAL CALLER:: depth 1 is the EVAL frame (Nil)";
+is oc-eval-topic(), "10,20,30", "EVAL sees the loop topic";
+is oc-eval-sibling(), "sekrit!", "EVAL calls a module-private sibling sub";
+is oc-eval-nested("abc"), "abc-wrapped", "EVAL inside a nested my sub sees captures";
+is oc-eval-catch(), "caught:boom", "CATCH catches a die from EVAL'd code";
+is oc-evalfile($*PROGRAM.parent.child("lib/evalfile-fixture.raku").Str), 42,
+    "EVALFILE runs a file and returns its last value";
+# second call: the OTF-compiled body is cached; EVAL re-evaluates per call
+is oc-eval-write(), 5, "EVAL lexical write is fresh on a second call";
 
 oc-subtest("subtest inside a module sub", 3, 3);


### PR DESCRIPTION
## Summary

PLAN §3 module-sub OTF gate relaxation, continuing #4427/#4429/#4431. Prerequisites for this slice were the two EVAL semantics bugs, both now fixed: sink warning (#4433) and CALLER:: frame resolution (#4435). This removes the `EVAL`/`EVALFILE` exclusion from `module_otf_expr_needs_interpreter`.

### Why it's safe now

`eval_eval_string` runs on the same interpreter with the live `self.env`, so an EVAL inside an OTF-compiled body sees exactly what the tree-walk path sees. Verified experimentally with the gate off (probe module + raku comparison, all raku-identical):

- param / lexical reads and writes from EVAL'd code
- sub declaration + call inside EVAL
- `CALLER::` frame layout (invoking sub reached at depth 3, Nil at depths 1–2 — the #4435 semantics)
- loop topic `$_`
- module-private (non-exported) sibling sub calls
- captures inside a nested `my sub`
- `CATCH` catching a die from EVAL'd code
- `EVALFILE`

Fallback counter confirms the EVAL-bearing module subs actually take the OTF path: `interpreter_fallbacks` drops to only the intentionally-excluded `start`/`await`.

### Remaining gate exclusions (PLAN §3 updated)

`start` (recursive-capture clobber, proven unsafe), sigilless scalar `\x` (proven unsafe), `is encoded(...)` (NativeCall).

### Testing

- `t/module-sub-otf-interpreter-constructs.t` extended 28 → 40 assertions — **verified 40/40 on rakudo first**, then mutsu.
- `make test` green (1666 files / 16415 tests).
- Targeted whitelisted roast re-run green: EVAL set (`eval_lex.t`, `in-eval.t`, `callframe.t`, `main-eval.t`, `eval.t`, `evalfile.t`, `eval-and-threads.t`, `caller.t`, `misc.t`) + Test::Util EVAL-bearing-sub consumers (`in-loop.t`, `allomorphic.t`, `repeat.t`, `reduce.t`, `hash.t`, `array.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)