### PR TITLE
docs(adr): accept ADR-0005 — NaN-boxing encoding (pointer-favored)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -158,12 +158,11 @@ sweep まで含めて完了 — 経緯と詳細は [news/2026-07.md](news/2026-0
 エントリあり）。残:
 
 - [ ] **層3b NaN-boxing（= §5 Lever 2・JIT の地ならし）**: 3b-0 API 壁 ✅（#4315/#4316）・
-      3b-1 step A `Value` newtype seal ✅（2026-07-11）。**次 = 3b-1 step B**: `ValueRepr` を
-      pointer-favored NaN-box（8B）へ差し替え（`view()`/constructor/accessor の中身のみ変更。
-      小整数幅は int-arith bench で決定）。ゲート = make test＋roast＋gc-stress green・
-      [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.2 マイクロベンチ。
-      **着手は [ADR-0005](docs/adr/0005-nanbox-representation-encoding.md)（Proposed・
-      pointer-favored 推奨）が Accepted になってから**。
+      3b-1 step A `Value` newtype seal ✅（2026-07-11）。**次 = 3b-1 step B（着手可能 —
+      [ADR-0005](docs/adr/0005-nanbox-representation-encoding.md) は 2026-07-12 Accepted）**:
+      `ValueRepr` を pointer-favored NaN-box（8B）へ差し替え（`view()`/constructor/accessor の
+      中身のみ変更。小整数幅は int-arith bench で決定）。ゲート = make test＋roast＋gc-stress
+      green・[docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.2 マイクロベンチ。
 - [ ] 層3a hardening（H1 継続計測〜H5 background collect の着手トリガ）=
       [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) 参照。grammar パースの候補 push
       自体（~510k/200-parse）の抑制は未着手（実害＝メモリ保持は `Weak` 化で解消済み）。

--- a/docs/adr/0005-nanbox-representation-encoding.md
+++ b/docs/adr/0005-nanbox-representation-encoding.md
@@ -1,7 +1,7 @@
 # ADR-0005: NaN-boxing 表現スイッチ（3b-1）のエンコーディング選択と newtype seal 統合
 
-- **Status**: Proposed（承認待ち）
-- **Date**: 2026-07-07
+- **Status**: **Accepted**（2026-07-12 tokuhirom 承認）
+- **Date**: 2026-07-07（Proposed）/ 2026-07-12（Accepted）
 - **Deciders**: tokuhirom, Claude
 - **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（層3b の位置づけ・順序 3a→3b→4）,
   [ADR-0004](0004-jit-strategy.md)（JIT は 8B 固定幅 `Value` を前提）,
@@ -173,5 +173,6 @@ inline `Int` の幅（48bit inline / 32bit inline / 範囲外は `Gc<i64>` 箱 o
 
 ---
 
-*本 ADR は Proposed。承認後、3b-1 step A（newtype seal・byte-identical）から着手し、
-step B（pointer-favored 表現差し替え）を §3.2 のベンチゲートで受け入れる。*
+*本 ADR は 2026-07-12 に Accepted。3b-1 step A（newtype seal・byte-identical）は先行完了済み
+（2026-07-11・news/2026-07.md）。承認により **step B（pointer-favored 表現差し替え）が着手可能** —
+§3.2 のベンチゲート（make test＋roast＋gc-stress green・マイクロベンチ）で受け入れる。*


### PR DESCRIPTION
## Summary

ADR-0005 (NaN-boxing representation encoding for 3b-1) approved by tokuhirom on 2026-07-12 — Status **Proposed → Accepted**.

- ADR header + footer updated: step A (newtype seal) already landed byte-identical (#4422); acceptance **unblocks 3b-1 step B** — `ValueRepr` 48B enum → 8B pointer-favored NaN-box, changing only `src/value/` internals (constructor shims → tag-packing, `view()`/accessors).
- PLAN §2 updated: step B listed as startable (gate = make test + roast + gc-stress green + gc-post-3a-roadmap §3.2 microbenches; small-int width decided by int-arith bench).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)