### PR TITLE
perf(symbol): dissolve the intern round-trip via leaked-str Symbol::as_str (PLAN §5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -299,12 +299,13 @@ method-call ホットパスキャンペーン第 1 弾（#3853/#3857/#3859/#3867
 resolution cache・mro_readonly キャッシュ・FxHashMap・単一候補 memoize）と、単一ストア化による
 per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 
-- [ ] **symbol intern round-trip の残り（大型リファクタ）**: dispatch hot path の `cn = class_sym.resolve()`
-      String 確保（perf の malloc ~17% の一角）が downstream の `&str` API（`call_compiled_method`/
-      `push_method_dispatch_frame`/`check_method_wrap_chain`＋ registry の String キー lookup）のため残る。
-      `with_str` の長期保持はグローバル symbol-table read-lock デッドロックで不可＝registry/dispatch API を
-      Symbol キー化する必要。`Symbol::intern(method)` も毎回 ~3.5%（method 名は CompiledCode 定数の
-      `Value::Str`・事前 intern は precomp 直列化に波及）。
+- [ ] **symbol 残コスト（小）**: round-trip 本体は解消済み（2026-07-12 — intern 文字列を leak して
+      `Symbol::as_str() -> &'static str`（ロックなし・alloc なし）を導入、dispatch hot path の
+      String 確保＋再 intern を除去。method-call -6% cycles。旧記述の「registry/dispatch API の
+      Symbol キー化（大型リファクタ）」は前提のデッドロック制約ごと消滅＝不要。news/2026-07.md 参照）。
+      残る小レバー: `Symbol::intern(method)`（flat ~0.8% — CompiledCode 定数の事前 intern は
+      serde skip＋lazy 側テーブルなら precomp 直列化に波及しない）／ registry String キーの
+      SipHash（cache-miss 時のみ）。
 - [ ] `Value` clone/drop（bench-class の ~50%）＋ `attributes.to_map()` の毎回クローン ＋
       `call_compiled_method` の属性キー `format!` ＋ instance 構築 HashMap ＋ `merge_method_env` —
       Lever 2（NaN-boxing・GC 後）待ち、ないし属性 materialization の作り直し（深い）。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -1188,6 +1188,28 @@ itemization（rvalue の item-container 化）まわりの一連の修正で 270
 - メトリクス表に battery included 軸（同梱ライブラリ数=現在 0/目標 10+・mzef・バイナリ配布・GC）を
   追加し、whitelist を 1350/1463 に更新。
 
+## 2026-07-12: symbol intern round-trip 解消 — `Symbol::as_str()`（leak 方式）で「大型リファクタ」を不要化
+
+PLAN §5 の「symbol intern round-trip の残り（大型リファクタ）」を、registry/dispatch API の
+Symbol キー化ではなく **intern 文字列の leak** で解消した。symbol table は append-only で
+プロセス生涯有効なので、intern 時に `Box::leak` して `id_to_str: Vec<&'static str>` で持てば、
+`Symbol::as_str() -> &'static str` が**ロック保持なし・アロケーションなし**で返せる。
+旧 PLAN が前提としていた「`with_str` の長期保持は read-lock デッドロックで不可」という制約自体が
+消滅し、downstream の `&str` API（`call_compiled_method`/`push_method_dispatch_frame`/
+`check_method_wrap_chain`/registry lookup）はシグネチャ変更なしでそのまま使える。
+
+- **dispatch hot path 変換**: 主 dispatch prelude（interpret/mut）は receiver の class `Symbol` を
+  そのまま再利用＋`as_str` 借用（String 確保と再 intern の両方を除去）。fast_method_cache ヒット時の
+  `owner_class.resolve()`、private `!m`・metamethod `^m` prelude、native-new pure 判定、
+  IO instance prelude、`== "Failure"` 等の比較も変換。
+- **per-thread resolve cache**: as_str が hot になった結果 RwLock read が self 4.1% に浮上したため、
+  `INTERN_CACHE` の鏡像となる `id -> &'static str` の thread-local `Vec` memo を追加。
+- **計測**（release・P-core 固定・`perf stat -r 5`）: method-call **-6.1% cycles**（952M→894M）、
+  bench-class 横ばい（支配項は Value clone/attrs＝Lever 2 の領分）。
+- 残: `Symbol::intern(method)` は flat ~0.8% まで縮小（#4402 の TLS cache 効果込み）。
+  CompiledCode 定数の事前 intern（serde skip＋lazy 側テーブルなら precomp 直列化に波及しない）と
+  registry String キーの SipHash は別個の小レバーとして残置。
+
 ## 参考
 
 - whitelist は本稿執筆時点で **1338**（2026-07-01、`4c311c71` 時点）。

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -15,7 +15,7 @@ pub struct Symbol(u32);
 
 impl Serialize for Symbol {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.resolve().serialize(serializer)
+        self.as_str().serialize(serializer)
     }
 }
 
@@ -28,21 +28,23 @@ impl<'de> Deserialize<'de> for Symbol {
 
 impl PartialEq<&str> for Symbol {
     fn eq(&self, other: &&str) -> bool {
-        let table = global_table().read().unwrap();
-        table.id_to_str[self.0 as usize] == *other
+        self.as_str() == *other
     }
 }
 
 impl PartialEq<str> for Symbol {
     fn eq(&self, other: &str) -> bool {
-        let table = global_table().read().unwrap();
-        table.id_to_str[self.0 as usize] == other
+        self.as_str() == other
     }
 }
 
+/// Interned strings are leaked (`Box::leak`) so a `Symbol` can hand out a
+/// `&'static str` without holding the table lock. The table is append-only
+/// and lives for the whole process, so the leak is exactly the table's own
+/// lifetime — no unbounded growth beyond what `Vec<String>` storage had.
 struct SymbolTable {
-    str_to_id: FxHashMap<String, Symbol>,
-    id_to_str: Vec<String>,
+    str_to_id: FxHashMap<&'static str, Symbol>,
+    id_to_str: Vec<&'static str>,
 }
 
 static GLOBAL_TABLE: OnceLock<RwLock<SymbolTable>> = OnceLock::new();
@@ -105,15 +107,25 @@ impl Symbol {
         }
         let id = table.id_to_str.len() as u32;
         let sym = Symbol(id);
-        table.id_to_str.push(s.to_owned());
-        table.str_to_id.insert(s.to_owned(), sym);
+        let leaked: &'static str = Box::leak(s.to_owned().into_boxed_str());
+        table.id_to_str.push(leaked);
+        table.str_to_id.insert(leaked, sym);
         sym
     }
 
-    /// Resolve the symbol back to its string representation.
-    pub fn resolve(&self) -> String {
+    /// Borrow the symbol's string without allocating. The returned `&'static
+    /// str` is valid for the whole process (interned strings are never freed),
+    /// and no lock is held after this returns — safe to keep across arbitrary
+    /// downstream calls, unlike `with_str`'s old lock-scoped borrow.
+    pub fn as_str(&self) -> &'static str {
         let table = global_table().read().unwrap();
-        table.id_to_str[self.0 as usize].clone()
+        table.id_to_str[self.0 as usize]
+    }
+
+    /// Resolve the symbol back to its string representation.
+    /// Prefer `as_str()` on hot paths — this allocates a fresh `String`.
+    pub fn resolve(&self) -> String {
+        self.as_str().to_owned()
     }
 
     /// Return the internal numeric ID of this symbol (unique per interned string).
@@ -122,66 +134,58 @@ impl Symbol {
     }
 
     /// Execute a closure with a borrowed reference to the underlying string.
-    /// Holds the read lock only for the duration of the closure.
+    /// The lock is released before the closure runs (see `as_str`).
     pub fn with_str<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&str) -> R,
     {
-        let table = global_table().read().unwrap();
-        f(&table.id_to_str[self.0 as usize])
+        f(self.as_str())
     }
 
     pub fn starts_with(&self, prefix: &str) -> bool {
-        self.with_str(|s| s.starts_with(prefix))
+        self.as_str().starts_with(prefix)
     }
 
     pub fn ends_with(&self, suffix: &str) -> bool {
-        self.with_str(|s| s.ends_with(suffix))
+        self.as_str().ends_with(suffix)
     }
 
     pub fn contains_str(&self, needle: &str) -> bool {
-        self.with_str(|s| s.contains(needle))
+        self.as_str().contains(needle)
     }
 
     pub fn strip_prefix_str(&self, prefix: &str) -> Option<String> {
-        self.with_str(|s| s.strip_prefix(prefix).map(|r| r.to_owned()))
+        self.as_str().strip_prefix(prefix).map(|r| r.to_owned())
     }
 
     pub fn strip_prefix_char(&self, prefix: char) -> Option<String> {
-        self.with_str(|s| s.strip_prefix(prefix).map(|r| r.to_owned()))
+        self.as_str().strip_prefix(prefix).map(|r| r.to_owned())
     }
 
     pub fn rsplit_once_str(&self, delimiter: &str) -> Option<(String, String)> {
-        self.with_str(|s| {
-            s.rsplit_once(delimiter)
-                .map(|(a, b)| (a.to_owned(), b.to_owned()))
-        })
+        self.as_str()
+            .rsplit_once(delimiter)
+            .map(|(a, b)| (a.to_owned(), b.to_owned()))
     }
 
     pub fn len(&self) -> usize {
-        self.with_str(|s| s.len())
+        self.as_str().len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.with_str(|s| s.is_empty())
+        self.as_str().is_empty()
     }
 }
 
 impl fmt::Debug for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let table = global_table().read().unwrap();
-        write!(
-            f,
-            "Symbol({}: {:?})",
-            self.0, &table.id_to_str[self.0 as usize]
-        )
+        write!(f, "Symbol({}: {:?})", self.0, self.as_str())
     }
 }
 
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let table = global_table().read().unwrap();
-        f.write_str(&table.id_to_str[self.0 as usize])
+        f.write_str(self.as_str())
     }
 }
 
@@ -208,6 +212,16 @@ mod tests {
     fn resolve_roundtrip() {
         let sym = Symbol::intern("roundtrip_test");
         assert_eq!(sym.resolve(), "roundtrip_test");
+    }
+
+    #[test]
+    fn as_str_borrows_without_alloc() {
+        let sym = Symbol::intern("as_str_test");
+        let a: &'static str = sym.as_str();
+        let b: &'static str = sym.as_str();
+        assert_eq!(a, "as_str_test");
+        // Same interned symbol hands out the same leaked storage.
+        assert!(std::ptr::eq(a, b));
     }
 
     #[test]

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -64,6 +64,14 @@ thread_local! {
     /// Removes the global-`RwLock` read contention on the intern hot path (see
     /// `Symbol::intern`).
     static INTERN_CACHE: RefCell<FxHashMap<String, Symbol>> = RefCell::new(FxHashMap::default());
+
+    /// Per-thread `id -> &'static str` memo in front of `GLOBAL_TABLE`, the
+    /// mirror of `INTERN_CACHE` for the resolve direction. Interned strings are
+    /// leaked and ids never remapped, so a cached entry is valid forever.
+    /// Keeps `as_str` (the single hottest symbol operation — every dispatch
+    /// class-name borrow, `==` compare, `starts_with`, `Display`) off the
+    /// globally-shared `RwLock`.
+    static RESOLVE_CACHE: RefCell<Vec<Option<&'static str>>> = const { RefCell::new(Vec::new()) };
 }
 
 impl Symbol {
@@ -118,8 +126,19 @@ impl Symbol {
     /// and no lock is held after this returns — safe to keep across arbitrary
     /// downstream calls, unlike `with_str`'s old lock-scoped borrow.
     pub fn as_str(&self) -> &'static str {
-        let table = global_table().read().unwrap();
-        table.id_to_str[self.0 as usize]
+        let idx = self.0 as usize;
+        RESOLVE_CACHE.with(|c| {
+            let mut cache = c.borrow_mut();
+            if let Some(Some(s)) = cache.get(idx) {
+                return *s;
+            }
+            let s = global_table().read().unwrap().id_to_str[idx];
+            if cache.len() <= idx {
+                cache.resize(idx + 1, None);
+            }
+            cache[idx] = Some(s);
+            s
+        })
     }
 
     /// Resolve the symbol back to its string representation.

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -47,7 +47,7 @@ impl Interpreter {
         let [Stmt::Call { name, args }] = data.body.as_slice() else {
             return Ok(None);
         };
-        let method = name.resolve();
+        let method = name.as_str();
         if method != "push" {
             return Ok(None);
         }

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -38,7 +38,7 @@ impl Interpreter {
             // attribute, exactly as the interpreter's `dispatch_new` caller does
             // (`materialize_exception_message_in_result`). For built-in exceptions
             // and non-exceptions this is a no-op (no user `message` method).
-            let cn = class_name.resolve();
+            let cn = class_name.as_str();
             let result = self.materialize_exception_message_in_result(result);
             // Native construction of an attribute-only class is pure data assembly
             // (named args + defaults; writes nothing to the caller env, Slice 6.3).
@@ -51,8 +51,8 @@ impl Interpreter {
             // so treat that as impure too.
             let runs_message =
                 (cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::"))
-                    && self.has_user_method(&cn, "message");
-            self.method_dispatch_pure = !self.mro_has_build_or_tweak(&cn) && !runs_message;
+                    && self.has_user_method(cn, "message");
+            self.method_dispatch_pure = !self.mro_has_build_or_tweak(cn) && !runs_message;
             return result;
         }
         // Native built-in construction: `Buf`/`Blob` (byte overlay), `utf8`/
@@ -111,7 +111,7 @@ impl Interpreter {
         // `dispatch_new_and_constructors` arm also delegates to.
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
-            && class_name.resolve() == "Failure"
+            && class_name == "Failure"
         {
             self.method_dispatch_pure = true;
             return Ok(self.build_native_failure_value(&args));
@@ -124,7 +124,7 @@ impl Interpreter {
         // own class name and is left to the interpreter.)
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
-            && class_name.resolve() == "Seq"
+            && class_name == "Seq"
         {
             self.method_dispatch_pure = true;
             return Ok(self.try_native_seq_construct(&args));
@@ -137,7 +137,7 @@ impl Interpreter {
         // is left to the interpreter.)
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
-            && class_name.resolve() == "IO::Socket::INET"
+            && class_name == "IO::Socket::INET"
         {
             self.method_dispatch_pure = true;
             return self.dispatch_socket_inet_new(&args);
@@ -154,7 +154,7 @@ impl Interpreter {
             return result;
         }
         if let ValueView::Instance { class_name, .. } = target.view() {
-            let class = class_name.resolve();
+            let class = class_name.as_str();
             // Interpreter-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D):
             // resolve `IO::Handle`'s state-only methods (close/tell/eof/seek/
             // opened/t and the Tier-1 setters/getters chomp/nl-out/out-buffer/
@@ -195,16 +195,16 @@ impl Interpreter {
             // filesystem / cwd / env dependency (ledger §D). Single impl shared with
             // the interpreter's `native_io_path`. Filesystem / cwd-relative forms and
             // `child :secure` return `None` and fall through to the native fork below.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
-                    Self::try_io_path_lexical(&class, &attributes.as_map(), method, &args)
+                    Self::try_io_path_lexical(class, &attributes.as_map(), method, &args)
             {
                 return result;
             }
             // Interpreter-native `.absolute` / `.relative` (path + cwd, lexical — no
             // filesystem; the VM owns env/cwd). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
                     self.try_io_path_cwd_method(&attributes.as_map(), method, &args)
@@ -215,7 +215,7 @@ impl Interpreter {
             // (`e`/`f`/`d`/…/`s`/`modified`): resolve the path against the VM-owned
             // cwd, then `stat` only — no `io_handles`, no content read (ledger §D).
             // Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) = self.try_io_path_fs_stat(&attributes.as_map(), method)
             {
@@ -224,7 +224,7 @@ impl Interpreter {
             // Interpreter-native whole-file content reads (`slurp`/`lines`/`words`):
             // read the file + split/decode; no `io_handles` (ledger §D). Single impl
             // shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
                     self.try_io_path_content_read(&attributes.as_map(), method, &args)
@@ -234,17 +234,17 @@ impl Interpreter {
             // Interpreter-native single-path filesystem mutations (`spurt`/`mkdir`/
             // `rmdir`/`unlink`/`chmod`): one-shot syscall, no `io_handles` (ledger
             // §D). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
-                    self.try_io_path_fs_mutate(&attributes.as_map(), &class, method, &args)
+                    self.try_io_path_fs_mutate(&attributes.as_map(), class, method, &args)
             {
                 return result;
             }
             // Interpreter-native `open`: allocate an `io_handles` entry and return
             // the `IO::Handle`. The VM owns `io_handles`, so this is a native
             // dispatch (ledger §D ③). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) = self.try_io_path_open(&attributes.as_map(), method, &args)
             {
@@ -253,7 +253,7 @@ impl Interpreter {
             // Interpreter-native two-path FS ops (`copy`/`rename`/`move`/`symlink`/
             // `link`): resolve both paths against the VM-owned cwd, one-shot syscall,
             // no `io_handles` (ledger §D). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
                     self.try_io_path_two_path_op(&attributes.as_map(), method, &args)
@@ -262,7 +262,7 @@ impl Interpreter {
             }
             // Interpreter-native `comb`: read the file then comb the content (no
             // `io_handles`; ledger §D). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) = self.try_io_path_comb(&attributes.as_map(), method, &args)
             {
@@ -272,7 +272,7 @@ impl Interpreter {
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
             // class (via its MRO) provides its own method of this name.
-            if self.is_native_method(&class, method) && !self.has_user_method(&class, method) {
+            if self.is_native_method(class, method) && !self.has_user_method(class, method) {
                 // TODO: compile to bytecode — Instance native-method fork (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return loan_env!(self, call_method_with_values(target, method, args));
@@ -291,13 +291,14 @@ impl Interpreter {
         // Private method fast path: resolve private candidate and run compiled code
         // when caller context clearly allows direct dispatch.
         if method.starts_with('!') {
-            let class_name = match target.view() {
-                ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                ValueView::Package(name) => Some(name.resolve()),
+            let class_sym = match target.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name),
+                ValueView::Package(name) => Some(name),
                 _ => None,
             };
-            if let Some(cn) = class_name {
-                let resolved = loan_env!(self, resolve_private_method_for_vm(&cn, method, &args));
+            if let Some(class_sym) = class_sym {
+                let cn = class_sym.as_str();
+                let resolved = loan_env!(self, resolve_private_method_for_vm(cn, method, &args));
                 if let Some((owner_class, method_def)) = resolved {
                     let caller_allowed = self.can_fast_dispatch_private_method_vm(&owner_class);
                     if caller_allowed && let Some(ref cc) = method_def.compiled_code {
@@ -315,18 +316,18 @@ impl Interpreter {
                             _ => std::collections::HashMap::new(),
                         };
                         let invocant_for_dispatch = if attributes.is_empty() {
-                            Value::package(crate::symbol::Symbol::intern(&cn))
+                            Value::package(class_sym)
                         } else {
                             target.clone()
                         };
                         let pushed_dispatch = loan_env!(
                             self,
-                            push_method_dispatch_frame(&cn, method, &args, invocant_for_dispatch,)
+                            push_method_dispatch_frame(cn, method, &args, invocant_for_dispatch,)
                         );
                         let invocant = Some(target);
                         let empty_fns = HashMap::new();
                         let method_result = self.call_compiled_method(
-                            &cn,
+                            cn,
                             &owner_class,
                             method,
                             &method_def,
@@ -363,7 +364,7 @@ impl Interpreter {
                                 };
                                 return loan_env!(
                                     self,
-                                    proxy_fetch(fetcher, None, &cn, &proxy_attrs, id)
+                                    proxy_fetch(fetcher, None, cn, &proxy_attrs, id)
                                 );
                             }
                         }
@@ -379,12 +380,12 @@ impl Interpreter {
             && !crate::runtime::Interpreter::is_classhow_method(&method[1..])
         {
             let class_name = match target.view() {
-                ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                ValueView::Package(name) => Some(name.resolve()),
+                ValueView::Instance { class_name, .. } => Some(class_name.as_str()),
+                ValueView::Package(name) => Some(name.as_str()),
                 _ => None,
             };
             if let Some(cn) = class_name
-                && self.has_user_method(&cn, method)
+                && self.has_user_method(cn, method)
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
@@ -393,14 +394,17 @@ impl Interpreter {
                 return loan_env!(self, call_method_with_values(target, method, how_args));
             }
         }
-        // Only attempt compiled path for Instance or Package targets
-        let class_name = match target.view() {
-            ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-            ValueView::Package(name) => Some(name.resolve()),
+        // Only attempt compiled path for Instance or Package targets. Reuse the
+        // receiver's already-interned class Symbol and borrow its string
+        // (`as_str`) instead of the old `resolve()` String allocation plus
+        // re-intern round-trip.
+        let class_sym_opt = match target.view() {
+            ValueView::Instance { class_name, .. } => Some(class_name),
+            ValueView::Package(name) => Some(name),
             _ => None,
         };
-        if let Some(ref cn) = class_name {
-            let class_sym = crate::symbol::Symbol::intern(cn);
+        if let Some(class_sym) = class_sym_opt {
+            let cn = class_sym.as_str();
             let method_sym = crate::symbol::Symbol::intern(method);
             let cache_key = (class_sym, method_sym);
 
@@ -437,13 +441,13 @@ impl Interpreter {
                 let shares_scalar_container =
                     self.method_shares_container_into_scalar_param(&entry.method_def, &args);
                 if !needs_default_eval && !has_attr_aliases && !shares_scalar_container {
-                    let owner_class = entry.owner_class.resolve();
+                    let owner_class = entry.owner_class.as_str();
                     let method_def = entry.method_def.clone();
                     let cc = entry.compiled_code.clone();
                     let can_skip_merge = entry.can_skip_merge;
                     return self.dispatch_compiled_method(
                         cn,
-                        &owner_class,
+                        owner_class,
                         method,
                         &method_def,
                         &cc,

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -18,7 +18,7 @@ impl Interpreter {
             // a captured-outer caller lexical, in which case the dispatch is impure
             // and the call site must reconcile the caller slot (Slice F twin of the
             // non-mut path; `reconcile_locals_from_env_at_site`).
-            self.method_dispatch_pure = !self.mro_has_build_or_tweak(&class_name.resolve());
+            self.method_dispatch_pure = !self.mro_has_build_or_tweak(class_name.as_str());
             return result;
         }
         // Native built-in construction (mut path twin of the above).
@@ -57,7 +57,7 @@ impl Interpreter {
         // Native Failure construction (mut path twin of the above).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
-            && class_name.resolve() == "Failure"
+            && class_name == "Failure"
         {
             self.method_dispatch_pure = true;
             return Ok(self.build_native_failure_value(&args));
@@ -65,7 +65,7 @@ impl Interpreter {
         // Native Seq construction (mut path twin of the above).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
-            && class_name.resolve() == "Seq"
+            && class_name == "Seq"
         {
             self.method_dispatch_pure = true;
             return Ok(self.try_native_seq_construct(&args));
@@ -73,7 +73,7 @@ impl Interpreter {
         // Native IO::Socket::INET construction (mut path twin of the above).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
-            && class_name.resolve() == "IO::Socket::INET"
+            && class_name == "IO::Socket::INET"
         {
             self.method_dispatch_pure = true;
             return self.dispatch_socket_inet_new(&args);
@@ -88,7 +88,7 @@ impl Interpreter {
             return result;
         }
         if let ValueView::Instance { class_name, .. } = target.view() {
-            let class = class_name.resolve();
+            let class = class_name.as_str();
             // Interpreter-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D),
             // mut path: `$fh.method` on a variable receiver routes here, so the
             // same state-only `IO::Handle` methods must be intercepted before the
@@ -126,16 +126,16 @@ impl Interpreter {
             // non-mut path — produces a *new* IO::Path/string/bool and never mutates
             // the receiver, so no writeback. Filesystem / cwd-relative forms and
             // `child :secure` fall through to the native fork below.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
-                    Self::try_io_path_lexical(&class, &attributes.as_map(), method, &args)
+                    Self::try_io_path_lexical(class, &attributes.as_map(), method, &args)
             {
                 return result;
             }
             // Interpreter-native `.absolute` / `.relative` (path + cwd, lexical — no
             // filesystem; the VM owns env/cwd). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
                     self.try_io_path_cwd_method(&attributes.as_map(), method, &args)
@@ -146,7 +146,7 @@ impl Interpreter {
             // (`e`/`f`/`d`/…/`s`/`modified`): resolve the path against the VM-owned
             // cwd, then `stat` only — no `io_handles`, no content read (ledger §D).
             // Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) = self.try_io_path_fs_stat(&attributes.as_map(), method)
             {
@@ -155,7 +155,7 @@ impl Interpreter {
             // Interpreter-native whole-file content reads (`slurp`/`lines`/`words`):
             // read the file + split/decode; no `io_handles` (ledger §D). Single impl
             // shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
                     self.try_io_path_content_read(&attributes.as_map(), method, &args)
@@ -165,17 +165,17 @@ impl Interpreter {
             // Interpreter-native single-path filesystem mutations (`spurt`/`mkdir`/
             // `rmdir`/`unlink`/`chmod`): one-shot syscall, no `io_handles` (ledger
             // §D). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
-                    self.try_io_path_fs_mutate(&attributes.as_map(), &class, method, &args)
+                    self.try_io_path_fs_mutate(&attributes.as_map(), class, method, &args)
             {
                 return result;
             }
             // Interpreter-native `open`: allocate an `io_handles` entry and return
             // the `IO::Handle`. The VM owns `io_handles`, so this is a native
             // dispatch (ledger §D ③). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) = self.try_io_path_open(&attributes.as_map(), method, &args)
             {
@@ -184,7 +184,7 @@ impl Interpreter {
             // Interpreter-native two-path FS ops (`copy`/`rename`/`move`/`symlink`/
             // `link`): resolve both paths against the VM-owned cwd, one-shot syscall,
             // no `io_handles` (ledger §D). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) =
                     self.try_io_path_two_path_op(&attributes.as_map(), method, &args)
@@ -193,7 +193,7 @@ impl Interpreter {
             }
             // Interpreter-native `comb`: read the file then comb the content (no
             // `io_handles`; ledger §D). Single impl shared with `native_io_path`.
-            if Self::is_io_path_lexical_class(&class)
+            if Self::is_io_path_lexical_class(class)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && let Some(result) = self.try_io_path_comb(&attributes.as_map(), method, &args)
             {
@@ -203,7 +203,7 @@ impl Interpreter {
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the
             // class (via its MRO) provides its own method of this name.
-            if self.is_native_method(&class, method) && !self.has_user_method(&class, method) {
+            if self.is_native_method(class, method) && !self.has_user_method(class, method) {
                 // TODO: compile to bytecode — Instance native-method fork, mut (ledger §1).
                 crate::vm::vm_stats::record_method_fallback(method);
                 return self.vm_call_method_mut_with_values(target_name, target, method, args);
@@ -227,12 +227,12 @@ impl Interpreter {
             && !crate::runtime::Interpreter::is_classhow_method(&method[1..])
         {
             let class_name = match target.view() {
-                ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                ValueView::Package(name) => Some(name.resolve()),
+                ValueView::Instance { class_name, .. } => Some(class_name.as_str()),
+                ValueView::Package(name) => Some(name.as_str()),
                 _ => None,
             };
             if let Some(cn) = class_name
-                && self.has_user_method(&cn, method)
+                && self.has_user_method(cn, method)
             {
                 let mut how_args = vec![target.clone()];
                 how_args.extend(args);
@@ -242,13 +242,14 @@ impl Interpreter {
             }
         }
         if method.starts_with('!') {
-            let class_name = match target.view() {
-                ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                ValueView::Package(name) => Some(name.resolve()),
+            let class_sym = match target.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name),
+                ValueView::Package(name) => Some(name),
                 _ => None,
             };
-            if let Some(cn) = class_name {
-                let resolved = loan_env!(self, resolve_private_method_for_vm(&cn, method, &args));
+            if let Some(class_sym) = class_sym {
+                let cn = class_sym.as_str();
+                let resolved = loan_env!(self, resolve_private_method_for_vm(cn, method, &args));
                 if let Some((owner_class, method_def)) = resolved {
                     let caller_allowed = self.can_fast_dispatch_private_method_vm(&owner_class);
                     if caller_allowed && let Some(ref cc) = method_def.compiled_code {
@@ -266,18 +267,18 @@ impl Interpreter {
                             _ => std::collections::HashMap::new(),
                         };
                         let invocant_for_dispatch = if attributes.is_empty() {
-                            Value::package(crate::symbol::Symbol::intern(&cn))
+                            Value::package(class_sym)
                         } else {
                             target.clone()
                         };
                         let pushed_dispatch = loan_env!(
                             self,
-                            push_method_dispatch_frame(&cn, method, &args, invocant_for_dispatch,)
+                            push_method_dispatch_frame(cn, method, &args, invocant_for_dispatch,)
                         );
                         let invocant = Some(target);
                         let empty_fns = HashMap::new();
                         let method_result = self.call_compiled_method(
-                            &cn,
+                            cn,
                             &owner_class,
                             method,
                             &method_def,
@@ -314,7 +315,7 @@ impl Interpreter {
                                 };
                                 return loan_env!(
                                     self,
-                                    proxy_fetch(fetcher, None, &cn, &proxy_attrs, id)
+                                    proxy_fetch(fetcher, None, cn, &proxy_attrs, id)
                                 );
                             }
                         }
@@ -331,27 +332,27 @@ impl Interpreter {
             ValueView::Package(name) => Some(name),
             _ => None,
         };
-        let class_name = class_sym_opt.map(|s| s.resolve());
+        let class_name = class_sym_opt.map(|s| s.as_str());
         if let Some(cn) = class_name
             && let Some(class_sym) = class_sym_opt
             && let Some((owner_class, method_def)) = {
                 let method_sym = crate::symbol::Symbol::intern(method);
-                self.resolve_method_cached(&cn, method, class_sym, method_sym, &args, &target)
+                self.resolve_method_cached(cn, method, class_sym, method_sym, &args, &target)
             }
         {
             // Ambiguous multi dispatch: two or more candidates matched equally
             // well. Raise X::Multi::Ambiguous instead of silently picking one.
             if self.dispatch_ambiguous {
                 self.dispatch_ambiguous = false;
-                let sigs = self.format_method_candidate_signatures(&cn, method);
+                let sigs = self.format_method_candidate_signatures(cn, method);
                 return Err(
                     crate::runtime::methods_signature_errors::make_multi_ambiguous_error(
-                        method, &cn, &sigs,
+                        method, cn, &sigs,
                     ),
                 );
             }
             if let Some(result) =
-                self.check_method_wrap_chain(&cn, &owner_class, method, &method_def, &target, &args)
+                self.check_method_wrap_chain(cn, &owner_class, method, &method_def, &target, &args)
             {
                 return result;
             }
@@ -363,7 +364,7 @@ impl Interpreter {
                 if method_def.compiled_code.is_some() {
                     Some((owner_class, method_def))
                 } else if !method_def.body.is_empty() {
-                    self.populate_uncompiled_method(&cn, &owner_class, method, &args, &target)
+                    self.populate_uncompiled_method(cn, &owner_class, method, &args, &target)
                 } else {
                     None
                 };
@@ -388,12 +389,12 @@ impl Interpreter {
                 };
                 let pushed_dispatch = loan_env!(
                     self,
-                    push_method_dispatch_frame(&cn, method, &args, invocant_for_dispatch,)
+                    push_method_dispatch_frame(cn, method, &args, invocant_for_dispatch,)
                 );
                 let invocant = Some(target);
                 let empty_fns = HashMap::new();
                 let method_result = self.call_compiled_method(
-                    &cn,
+                    cn,
                     &owner_class,
                     method,
                     &method_def,
@@ -425,7 +426,7 @@ impl Interpreter {
                         } else {
                             new_attrs
                         };
-                        return loan_env!(self, proxy_fetch(fetcher, None, &cn, &proxy_attrs, id));
+                        return loan_env!(self, proxy_fetch(fetcher, None, cn, &proxy_attrs, id));
                     }
                 }
                 return Ok(result);


### PR DESCRIPTION
## Summary

PLAN §5 "symbol intern round-trip の残り（大型リファクタ)" — resolved **without** the large registry/dispatch Symbol-keying refactor.

The symbol table is append-only and lives for the whole process, so interned strings are now leaked (`Box::leak`) at intern time and stored as `&'static str`. This adds `Symbol::as_str() -> &'static str`: **no String allocation, and no lock held after return**. The premise that forced the "large refactor" — `with_str`'s lock-scoped borrow deadlocking if held across downstream calls — no longer exists; every `&str`-taking downstream API (`call_compiled_method` / `push_method_dispatch_frame` / `check_method_wrap_chain` / registry lookups) works unchanged.

### Changes

- `symbol.rs`: leak-based `&'static str` storage; `as_str()`; `resolve()`/`with_str`/`starts_with`/`PartialEq`/`Display`/`Debug` now borrow lock-free; per-thread `id -> &'static str` resolve cache (mirror of #4402's `INTERN_CACHE`) after perf showed the `as_str` RwLock read at 4.1% self time once it became the hot borrow.
- Method-dispatch hot path (`vm_call_method_compiled_{interpret,mut,cache}`): the primary compiled-dispatch prelude now reuses the receiver's already-interned class `Symbol` and borrows via `as_str` — removing both the per-call String allocation and the class-name re-intern. Also converted: fast_method_cache hit path (`owner_class.resolve()`), private `!m` / metamethod `^m` preludes, native-new pure check, IO instance prelude, and `== "Failure"`-style class-name compares.

### Measurements (release, P-core pinned, `perf stat -r 5`)

| bench | baseline (main) | this PR | delta |
|---|---|---|---|
| method-call cycles | 952M | 894M | **-6.1%** |
| bench-class cycles | 3031M | 3029M | flat (dominated by Value clone/attrs = Lever 2) |

### Testing

- `make test`: 16388 PASS
- `cargo test` symbol suite + new `as_str` leak/identity test; `gc_stress` 16 PASS
- Whitelisted dispatch-heavy roast files (S12 class/methods, S14 roles, S02 perl.t) + concurrency (t/lock.t, S17 start/batch/channel): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni