### PR TITLE
refactor(value): NaN-box 8-byte representation core (3b-1 step B kickoff)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -158,11 +158,15 @@ sweep まで含めて完了 — 経緯と詳細は [news/2026-07.md](news/2026-0
 エントリあり）。残:
 
 - [ ] **層3b NaN-boxing（= §5 Lever 2・JIT の地ならし）**: 3b-0 API 壁 ✅（#4315/#4316）・
-      3b-1 step A `Value` newtype seal ✅（2026-07-11）。**次 = 3b-1 step B（着手可能 —
-      [ADR-0005](docs/adr/0005-nanbox-representation-encoding.md) は 2026-07-12 Accepted）**:
-      `ValueRepr` を pointer-favored NaN-box（8B）へ差し替え（`view()`/constructor/accessor の
-      中身のみ変更。小整数幅は int-arith bench で決定）。ゲート = make test＋roast＋gc-stress
-      green・[docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.2 マイクロベンチ。
+      3b-1 step A `Value` newtype seal ✅（2026-07-11）・step B コア表現
+      （`src/value/nanbox/`: 8B word・全 variant ロスレス pack/unpack・Clone/Drop・kind 表）✅。
+      設計とスライス計画 = [docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md)
+      （[ADR-0005](docs/adr/0005-nanbox-representation-encoding.md) Accepted 2026-07-12）。残:
+      **B-wall-in**（`src/value/` 内部 866 サイトの `ValueRepr::` パターンを view()/into_repr()/
+      with_*_mut へ機械移行・byte-identical 複数 PR）→ **B-guards**（`ValueView` ポインタ
+      フィールドを guard 型 `ArcRef`/`GcRef` へ）→ **B-flip**（`Value(ValueRepr)` →
+      `Value(NanBox)`・`value_size_guard` 48→8）。ゲート = make test＋roast＋gc-stress green・
+      GC カウンタ不変・[docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.2 マイクロベンチ。
 - [ ] 層3a hardening（H1 継続計測〜H5 background collect の着手トリガ）=
       [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) 参照。grammar パースの候補 push
       自体（~510k/200-parse）の抑制は未着手（実害＝メモリ保持は `Weak` 化で解消済み）。

--- a/docs/nanbox-3b1-step-b-design.md
+++ b/docs/nanbox-3b1-step-b-design.md
@@ -1,0 +1,140 @@
+# 3b-1 step B: NaN-box representation — concrete design and campaign plan
+
+Status: **In progress** (core representation landed; flip pending).
+Related: [ADR-0005](adr/0005-nanbox-representation-encoding.md) (encoding decision, Accepted
+2026-07-12), [nanbox-3b0-api-wall.md](nanbox-3b0-api-wall.md) (wall API + guard-type exit),
+[gc-post-3a-roadmap.md](gc-post-3a-roadmap.md) §3 (gates), [PLAN.md](../PLAN.md) §2.
+
+This document fixes the decisions ADR-0005 deferred to implementation time
+(§3.1 small-int width, §3.3 companion-field placement, exact bit allocation)
+and lays out the slice plan for the representation flip. The bit layout lives
+in code in `src/value/nanbox/` — that module is the single owner of the
+encoding; this document explains the *why*.
+
+## 1. Bit layout (implemented in `src/value/nanbox/mod.rs`)
+
+One 64-bit word (`NonZeroU64`, so `Option<Value>` keeps the 8-byte niche):
+
+| page (high 16 bits) | meaning | payload (low 48 bits) |
+|---|---|---|
+| `0x0000` | never constructed (the `NonZeroU64` niche lives here) | — |
+| `0x0001` | inline `Int` | 48-bit two's complement (±2^47) |
+| `0x0002..=0xFFF2` | `Num` | word = `f64::to_bits` + `0x0002_0000_0000_0000` |
+| `0xFFF3..=0xFFFF` | kind pages | kind = (page − 0xFFF3)·8 + subkind; 13×8 = **104 kinds** |
+
+- **Doubles are offset-encoded** (pointer-favored, ADR-0005 §2.1): one `add`
+  on pack, one `sub` on unpack. NaN is **canonicalized to +qNaN** at pack time
+  — raw negative-NaN pages (`0xFFF1..=0xFFFF`) would collide with the kind
+  pages. Raku never exposes NaN payload bits, so this is unobservable.
+- **Subkind = 3 payload bits.** On 64-bit targets they are the pointer's low
+  (alignment) bits: every payload allocation is ≥8-aligned (const-asserted in
+  `boxes.rs`), so a pointer deref is a single AND with
+  `0x0000_FFFF_FFFF_FFF8`. On 32-bit targets (wasm32) allocations may be
+  4-aligned, so the subkind moves to payload bits 40..43, above any address.
+- **Inline payloads** (`Bool`, `Symbol` ids for `Package`/`CompUnitDepSpec`)
+  sit in bits 8..40 — clear of the subkind under both placements.
+- **48-bit address assumption**: debug-asserted at every pack. This is the
+  same assumption every production NaN-boxing JS engine makes; wasm32 (32-bit)
+  is trivially within range.
+
+Deviation from ADR-0005 to record: the ADR hoped pointer-favored would let
+`view()` keep returning `&'a Arc<T>` / `&'a Gc<T>` by transmuting `&self.0`.
+That only works if the *whole word* equals the pointer bits — impossible here,
+because several variants share a pointee type (`Str`/`Regex` are both
+`Arc<String>`; `Seq`/`HyperSeq`/`RaceSeq`/`Slip`/`Junction` are all
+`Arc<Vec<Value>>`), so the variant tag **must** live in the word and the view
+must reconstruct smart pointers by value. The flip therefore uses the **guard
+types** (`ArcRef<'a,T>`/`GcRef<'a,T>`: `ManuallyDrop` reconstructions that
+`Deref` without touching refcounts) that the wall kept as the documented exit
+(wall doc §2, ADR-0005 §2.1 "両出口"). Call sites are already deref-compatible
+by the 3b-0 migration rule and `ValueView` is deliberately non-`Copy`, so this
+does not disturb the wall. The *rest* of the pointer-favored rationale stands:
+pointer deref pays one AND (vs. the Num-favored layout's win on `Num` only),
+and Int/pointer traffic dominates mutsu's hot paths.
+
+## 2. Kind table decisions (the ADR §3.1/§3.3 deferred points)
+
+- **Small-int width = 48 bits inline** (±2^47). An `i64` outside that range
+  packs as `Kind::IntBoxed` (`Arc<i64>`) and still decodes to
+  `ValueRepr::Int` — **lossless**, no coupling to the `BigInt` semantic path
+  (`.WHAT`, `as_int()` behavior unchanged). If int-arith benches at flip time
+  show the range check hurting, narrowing to 32-bit inline is a two-constant
+  change in `nanbox/mod.rs`.
+- **Companion fields ride the tag** (ADR §3.3 "spare tag bits" option):
+  `ArrayKind` → 6 kinds, `Hash` itemization → 2, `Set`/`Bag`/`Mix` mutability
+  → 2 each, `JunctionKind` → 4. Kind space used: 66 of 104.
+- **`Instance` stores only the `Gc<InstanceAttrs>` pointer.** The variant's
+  `class_name`/`id` copies are always equal to the pointee's own fields:
+  rebless goes through `instance_sharing_cell`, which forks a fresh
+  `InstanceAttrs` node when the class differs (and `debug_assert`s the id).
+  `from_repr` debug-asserts this invariant; `into_repr` reads both back from
+  the pointee. No per-value heap box, so Instance clone stays one refcount op.
+- **Multi-field variants move behind one `Arc<...Box>`** (`Pair`, `Capture`,
+  `Proxy`, `Version`, `Routine`, `GenericRange`, …, defined in
+  `nanbox/boxes.rs`). `Rat`/`FatRat`/`Range*` (2×i64) and `Complex` (2×f64)
+  also box — they exceed 48 bits. Consequences, accepted per ADR:
+  - constructing one allocates (today they are inline in the 48-byte enum);
+  - `Value::clone` of one becomes a refcount bump (today: deep copy for
+    `Box`-payload variants like `BigRat`/`Capture` — cheaper now);
+  - owned decode (`into_repr`) moves the payload out when the box is uniquely
+    owned (`Arc::unwrap_or_clone`), clones field-wise when shared. Sharing is
+    never observable: the boxes are immutable-by-convention — mutation decodes,
+    edits, re-packs a fresh box (same visibility semantics as today's `&mut`
+    on an unshared enum payload).
+  - If a boxed-variant hot path shows up in benches (e.g. `Rat` arithmetic,
+    `Range` loop headers), the fix is a dedicated inline kind (e.g. small-Rat
+    with 22-bit num/den) — kind space has 38 free slots.
+- **`Scalar(Box<Value>)` → `Arc<Value>`**: clone drops from deep-copy to bump;
+  decode gives `Box` back via unwrap-or-clone.
+- **`Promise`/`Channel`** pack the `Gc` inside `SharedPromise`/`SharedChannel`
+  directly (the wrapper structs are just a `Gc` newtype).
+
+## 3. Ownership model (`src/value/nanbox/`)
+
+A kind word **owns exactly one strong reference** of its payload
+(`Arc::into_raw` / `Gc::into_raw` / `WeakGc::into_raw` at pack;
+`from_raw` at consume). `Clone`/`Drop` reconstruct the smart pointer and call
+its own `clone`/`drop`, so **all Bacon-Rajan bookkeeping is preserved
+verbatim** — `Gc::drop`'s survivor-buffering, `finalize` (DESTROY queueing),
+the buffered-bit dedup, and the `collecting()` reclaim-window gate all run
+exactly as they do for the enum. GC counters must be invariant across the flip
+(ADR-0005 step-B gate); the type filter (scalars GC-free) becomes "scalar
+pages/kinds have no `Gc` payload".
+
+Raw-pointer round-trips use `expose_provenance`/`with_exposed_provenance`, so
+the module is Miri-checkable (`cargo miri test value::nanbox`).
+
+`Gc`/`WeakGc` gained `into_raw`/`from_raw` (`src/gc/gc_ptr.rs`); `Symbol`
+gained `from_id` (inline payload round-trip).
+
+## 4. Campaign plan (remaining slices)
+
+The flip cannot be one PR: 866 sites inside `src/value/` still name
+`ValueRepr::` in patterns (they were sealed relative to the *outside* in step
+A, but the *inside* still assumes the enum is the storage). Plan, each slice
+gated on `make test` byte-identical + CI roast:
+
+1. **B-core (this slice)**: `src/value/nanbox/` — the packed word, lossless
+   `from_repr`/`into_repr`, Clone/Drop, exhaustive round-trip tests. Unwired.
+2. **B-wall-in (multiple mechanical PRs)**: migrate `src/value/` internals off
+   direct `ValueRepr::` patterns onto the same wall the outside already uses:
+   - borrowed reads → `view()` matches;
+   - owned matches (`match self.0`) → `match self.into_repr()` (identity while
+     the enum is still the storage; zero refcount traffic after the flip);
+   - in-place payload mutation → `with_*_mut` closures / decode-edit-repack.
+   Worklist = `grep -c 'ValueRepr::'` per file (types_isa 142, value_eq 97,
+   display 91, …). The step-A error-span fixer technique applies. `view.rs`
+   and the `mod.rs` constructor shims are the seam and stay direct.
+3. **B-guards**: switch `ValueView`'s pointer fields from `&'a Arc<T>` /
+   `&'a Gc<T>` to the guard types. Call sites are deref-compatible already;
+   fallout is expected to be explicit type annotations only. Still enum
+   storage; byte-identical.
+4. **B-flip**: `Value(ValueRepr)` → `Value(NanBox)`; constructor shims call
+   `NanBox::from_repr`-shaped packers, `view()` decodes tags into guard-type
+   views, `same_variant` compares tag/kind, Trace/serde/Debug ride the seam.
+   `value_size_guard` 48→8. Gates (ADR-0005 §3.2): make test + full roast +
+   gc-stress green, GC counters invariant, int-arith 2x / fib +30%,
+   bench-class clone/drop share 50%→≤20%, GC-on residual +8%→≤+3%, and the
+   Num-regression check (offset must cost ~1 ALU; otherwise the NaN-favored
+   fallback re-opens per ADR §2.1).
+5. **3b-2 traffic pruning** (roadmap §3.3) once clone/drop is an 8-byte copy.

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -214,6 +214,26 @@ impl<T: Trace + 'static> WeakGc<T> {
         }
     }
 
+    /// Consume the weak handle and return the raw `GcBox` address (the
+    /// `Weak::into_raw` analogue), for the NaN-boxed `Value` payload
+    /// (layer 3b-1). The address owns this handle's weak-count contribution
+    /// until [`WeakGc::from_raw`] reconstitutes it.
+    pub(crate) fn into_raw(this: WeakGc<T>) -> *const GcBox<T> {
+        std::sync::Weak::into_raw(this.inner)
+    }
+
+    /// Reconstitute a weak handle from [`WeakGc::into_raw`] output.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must come from `WeakGc::into_raw` and carry exactly one
+    /// outstanding weak ownership.
+    pub(crate) unsafe fn from_raw(ptr: *const GcBox<T>) -> WeakGc<T> {
+        WeakGc {
+            inner: unsafe { std::sync::Weak::from_raw(ptr) },
+        }
+    }
+
     /// Reconstitute a strong [`Gc`] handle if the node is still alive. Bumps the
     /// GC-visible strong count and marks the node live (`Black`) — upgrading a
     /// weak reference *is* taking a new temporary strong reference.
@@ -381,6 +401,40 @@ impl<T: Trace + 'static> Gc<T> {
     #[cfg(test)]
     pub(crate) fn buffer_as_candidate(&self) {
         buffer_candidate(self.inner.clone());
+    }
+
+    // ---- raw-pointer round-trip (NaN-boxing, layer 3b-1) --------------------
+    //
+    // The packed 8-byte `Value` representation stores a `Gc<T>` as the raw
+    // address of its backing `GcBox<T>` allocation inside the box payload
+    // (`src/value/nanbox`). These are the `Arc::into_raw`/`from_raw` analogues
+    // that carry the handle's ownership (its GC-visible strong-count
+    // contribution) across the integer round-trip. All Bacon-Rajan bookkeeping
+    // stays in `Gc::clone`/`Gc::drop`, which the nanbox reconstructs and calls.
+
+    /// Consume the handle and return the raw `GcBox` address, WITHOUT touching
+    /// any refcount: the returned pointer owns this handle's strong-count
+    /// contribution until [`Gc::from_raw`] reconstitutes it.
+    pub(crate) fn into_raw(this: Gc<T>) -> *const GcBox<T> {
+        // `Gc` has a `Drop` impl, so the field cannot be moved out directly;
+        // suppress the drop and read the inner `Arc` out raw.
+        let this = std::mem::ManuallyDrop::new(this);
+        // SAFETY: `this` is never dropped, so the inner `Arc`'s ownership
+        // transfers uniquely to the returned pointer.
+        let inner = unsafe { std::ptr::read(&this.inner) };
+        Arc::into_raw(inner)
+    }
+
+    /// Reconstitute a handle from [`Gc::into_raw`] output.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must come from `Gc::into_raw` and carry exactly one outstanding
+    /// ownership (each `into_raw` result may be passed here at most once).
+    pub(crate) unsafe fn from_raw(ptr: *const GcBox<T>) -> Gc<T> {
+        Gc {
+            inner: unsafe { Arc::from_raw(ptr) },
+        }
     }
 }
 

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -30,8 +30,8 @@ pub(crate) use collect::collect_cycles;
 #[cfg(test)]
 pub(crate) use gc_ptr::drain_candidates;
 pub(crate) use gc_ptr::{
-    ContainerMakeMut, ErasedGc, Gc, Trace, WeakGc, enter_mutator_worker, exit_mutator_worker,
-    gc_contents_mut,
+    ContainerMakeMut, ErasedGc, Gc, GcBox, Trace, WeakGc, enter_mutator_worker,
+    exit_mutator_worker, gc_contents_mut,
 };
 pub(crate) use root_visitor::{RootVisitor, visit_map_values, visit_opt, visit_slice};
 pub(crate) use safepoint::{

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -121,6 +121,14 @@ impl Symbol {
         self.0
     }
 
+    /// Rebuild a `Symbol` from an ID previously obtained via [`Symbol::id`].
+    /// For the NaN-boxed `Value` payload round-trip (layer 3b-1) only: the ID
+    /// must come from a real interned symbol, or later resolution will index
+    /// out of bounds.
+    pub(crate) fn from_id(id: u32) -> Symbol {
+        Symbol(id)
+    }
+
     /// Execute a closure with a borrowed reference to the underlying string.
     /// Holds the read lock only for the duration of the closure.
     pub fn with_str<F, R>(&self, f: F) -> R

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -287,6 +287,11 @@ mod display;
 mod error;
 mod error_construct;
 mod error_typed;
+/// NaN-boxed 8-byte representation core (3b-1 step B). Not yet wired into
+/// `Value` — the flip lands after the internal wall migration; until then the
+/// unit tests keep the packing machinery honest.
+#[allow(dead_code)]
+mod nanbox;
 mod serde_support;
 pub(crate) mod signature;
 pub(crate) mod types;

--- a/src/value/nanbox/boxes.rs
+++ b/src/value/nanbox/boxes.rs
@@ -1,0 +1,148 @@
+//! Heap payload structs for multi-field / oversized `ValueRepr` variants.
+//!
+//! A NaN-box payload is one 48-bit pointer, so every variant whose fields
+//! exceed that moves behind a single `Arc<...Box>` allocation. The boxes are
+//! immutable-by-convention: mutation decodes to `ValueRepr` (via
+//! `Arc::try_unwrap`-or-clone in `decode.rs`) and re-packs, so sharing a box
+//! between clones of a `Value` is never observable.
+//!
+//! On 64-bit targets the subkind lives in the pointer's low 3 bits, so every
+//! payload allocation must be at least 8-aligned — asserted per type below
+//! (only `RoutineBox` needs an explicit `repr(align)`; the rest carry a
+//! pointer-sized field already).
+
+use super::super::*;
+
+/// Payload of `Range`/`RangeExcl`/`RangeExclStart`/`RangeExclBoth`/`Rat`/
+/// `FatRat` (the kind disambiguates).
+#[derive(Debug, Clone)]
+pub(in crate::value) struct I64Pair(pub(in crate::value) i64, pub(in crate::value) i64);
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct F64Pair(pub(in crate::value) f64, pub(in crate::value) f64);
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct BigRatBox(
+    pub(in crate::value) NumBigInt,
+    pub(in crate::value) NumBigInt,
+);
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct PairBox(pub(in crate::value) String, pub(in crate::value) Value);
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct ValuePairBox(pub(in crate::value) Value, pub(in crate::value) Value);
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct EnumBox {
+    pub(in crate::value) enum_type: Symbol,
+    pub(in crate::value) key: Symbol,
+    pub(in crate::value) value: EnumValue,
+    pub(in crate::value) index: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct GenericRangeBox {
+    pub(in crate::value) start: Arc<Value>,
+    pub(in crate::value) end: Arc<Value>,
+    pub(in crate::value) excl_start: bool,
+    pub(in crate::value) excl_end: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct VersionBox {
+    pub(in crate::value) parts: Vec<VersionPart>,
+    pub(in crate::value) plus: bool,
+    pub(in crate::value) minus: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct CaptureBox {
+    #[allow(clippy::box_collection)]
+    pub(in crate::value) positional: Box<Vec<Value>>,
+    #[allow(clippy::box_collection)]
+    pub(in crate::value) named: Box<HashMap<String, Value>>,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct ProxyBox {
+    pub(in crate::value) fetcher: Box<Value>,
+    pub(in crate::value) storer: Box<Value>,
+    pub(in crate::value) subclass: Option<(Symbol, ProxySubclassAttrs)>,
+    pub(in crate::value) decontainerized: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct ParametricRoleBox {
+    pub(in crate::value) base_name: Symbol,
+    pub(in crate::value) type_args: Vec<Value>,
+}
+
+/// Two `Symbol`s + flag = 65 bits, just over the inline budget. 8-aligned
+/// explicitly: its natural alignment is only 4 (no pointer-sized field).
+#[derive(Debug, Clone)]
+#[repr(align(8))]
+pub(in crate::value) struct RoutineBox {
+    pub(in crate::value) package: Symbol,
+    pub(in crate::value) name: Symbol,
+    pub(in crate::value) is_regex: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct MixinBox(
+    pub(in crate::value) Arc<Value>,
+    pub(in crate::value) Arc<HashMap<String, Value>>,
+);
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct LazyIoLinesBox {
+    pub(in crate::value) handle: Box<Value>,
+    pub(in crate::value) kv: bool,
+    pub(in crate::value) words: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::value) struct HashEntryRefBox {
+    pub(in crate::value) hash: Gc<HashData>,
+    pub(in crate::value) path: Vec<String>,
+    pub(in crate::value) eager: bool,
+}
+
+/// On 64-bit targets the pointer's low 3 bits carry the subkind, so every
+/// `Arc<T>` payload type must be >= 8-aligned (`Arc::into_raw` points at the
+/// value, aligned to `align_of::<T>()`).
+#[cfg(target_pointer_width = "64")]
+const _: () = {
+    macro_rules! assert_align8 {
+        ($($t:ty),+ $(,)?) => {
+            $(assert!(std::mem::align_of::<$t>() >= 8);)+
+        };
+    }
+    assert_align8!(
+        String,
+        NumBigInt,
+        i64,
+        Vec<Value>,
+        Value,
+        LazyThunkData,
+        UniData,
+        RegexAdverbs,
+        CustomTypeData,
+        CustomTypeInstanceData,
+        I64Pair,
+        F64Pair,
+        BigRatBox,
+        PairBox,
+        ValuePairBox,
+        EnumBox,
+        GenericRangeBox,
+        VersionBox,
+        CaptureBox,
+        ProxyBox,
+        ParametricRoleBox,
+        RoutineBox,
+        MixinBox,
+        LazyIoLinesBox,
+        HashEntryRefBox,
+    );
+};

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -1,0 +1,230 @@
+//! `NanBox` -> `ValueRepr` owned decode (the future `into_repr` seam for
+//! owned matches; borrowed reads will go through `view()` guard types).
+
+use super::*;
+
+impl NanBox {
+    /// Decode into the working enum, consuming this word's payload ownership
+    /// (no refcount traffic for pointer kinds; a shared multi-field box is
+    /// cloned, a uniquely-owned one is moved out).
+    pub(in crate::value) fn into_repr(self) -> ValueRepr {
+        let bits = self.0.get();
+        // The payload ownership transfers to the decoded repr below.
+        std::mem::forget(self);
+        match classify(bits) {
+            Classified::Int(v) => ValueRepr::Int(v),
+            Classified::Num(f) => ValueRepr::Num(f),
+            // SAFETY (all arms): `bits` was packed with exactly this kind ->
+            // payload-type mapping (see `encode.rs` / `payload_op`), and the
+            // ownership consumed here is the one `forget(self)` released.
+            Classified::Kind(kind) => unsafe { decode_kind(kind, bits) },
+        }
+    }
+}
+
+/// # Safety
+/// `bits` must be a live kind word of kind `kind` whose payload ownership is
+/// being consumed exactly once.
+unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
+    match kind {
+        Kind::Str => ValueRepr::Str(unsafe { take_arc::<String>(bits) }),
+        Kind::Regex => ValueRepr::Regex(unsafe { take_arc::<String>(bits) }),
+        Kind::BigInt => ValueRepr::BigInt(unsafe { take_arc::<NumBigInt>(bits) }),
+        Kind::IntBoxed => ValueRepr::Int(*unsafe { take_arc::<i64>(bits) }),
+        Kind::Seq => ValueRepr::Seq(unsafe { take_arc::<Vec<Value>>(bits) }),
+        Kind::HyperSeq => ValueRepr::HyperSeq(unsafe { take_arc::<Vec<Value>>(bits) }),
+        Kind::RaceSeq => ValueRepr::RaceSeq(unsafe { take_arc::<Vec<Value>>(bits) }),
+        Kind::Slip => ValueRepr::Slip(unsafe { take_arc::<Vec<Value>>(bits) }),
+        Kind::JunctionAny | Kind::JunctionAll | Kind::JunctionOne | Kind::JunctionNone => {
+            ValueRepr::Junction {
+                kind: match kind {
+                    Kind::JunctionAny => JunctionKind::Any,
+                    Kind::JunctionAll => JunctionKind::All,
+                    Kind::JunctionOne => JunctionKind::One,
+                    _ => JunctionKind::None,
+                },
+                values: unsafe { take_arc::<Vec<Value>>(bits) },
+            }
+        }
+        Kind::Mixin => {
+            let b = Arc::unwrap_or_clone(unsafe { take_arc::<MixinBox>(bits) });
+            ValueRepr::Mixin(b.0, b.1)
+        }
+        Kind::Scalar => {
+            let v = Arc::unwrap_or_clone(unsafe { take_arc::<Value>(bits) });
+            ValueRepr::Scalar(Box::new(v))
+        }
+        Kind::LazyThunk => ValueRepr::LazyThunk(unsafe { take_arc::<LazyThunkData>(bits) }),
+        Kind::Uni => {
+            let u = Arc::unwrap_or_clone(unsafe { take_arc::<UniData>(bits) });
+            ValueRepr::Uni(Box::new(u))
+        }
+        Kind::RegexWithAdverbs => {
+            let a = Arc::unwrap_or_clone(unsafe { take_arc::<RegexAdverbs>(bits) });
+            ValueRepr::RegexWithAdverbs(Box::new(a))
+        }
+        Kind::CustomType => {
+            let d = Arc::unwrap_or_clone(unsafe { take_arc::<CustomTypeData>(bits) });
+            ValueRepr::CustomType(Box::new(d))
+        }
+        Kind::CustomTypeInstance => {
+            let d = Arc::unwrap_or_clone(unsafe { take_arc::<CustomTypeInstanceData>(bits) });
+            ValueRepr::CustomTypeInstance(Box::new(d))
+        }
+        Kind::Range
+        | Kind::RangeExcl
+        | Kind::RangeExclStart
+        | Kind::RangeExclBoth
+        | Kind::Rat
+        | Kind::FatRat => {
+            let p = Arc::unwrap_or_clone(unsafe { take_arc::<I64Pair>(bits) });
+            match kind {
+                Kind::Range => ValueRepr::Range(p.0, p.1),
+                Kind::RangeExcl => ValueRepr::RangeExcl(p.0, p.1),
+                Kind::RangeExclStart => ValueRepr::RangeExclStart(p.0, p.1),
+                Kind::RangeExclBoth => ValueRepr::RangeExclBoth(p.0, p.1),
+                Kind::Rat => ValueRepr::Rat(p.0, p.1),
+                _ => ValueRepr::FatRat(p.0, p.1),
+            }
+        }
+        Kind::BigRat => {
+            let b = Arc::unwrap_or_clone(unsafe { take_arc::<BigRatBox>(bits) });
+            ValueRepr::BigRat(Box::new(b.0), Box::new(b.1))
+        }
+        Kind::Complex => {
+            let p = Arc::unwrap_or_clone(unsafe { take_arc::<F64Pair>(bits) });
+            ValueRepr::Complex(p.0, p.1)
+        }
+        Kind::Pair => {
+            let p = Arc::unwrap_or_clone(unsafe { take_arc::<PairBox>(bits) });
+            ValueRepr::Pair(p.0, Box::new(p.1))
+        }
+        Kind::ValuePair => {
+            let p = Arc::unwrap_or_clone(unsafe { take_arc::<ValuePairBox>(bits) });
+            ValueRepr::ValuePair(Box::new(p.0), Box::new(p.1))
+        }
+        Kind::Enum => {
+            let e = Arc::unwrap_or_clone(unsafe { take_arc::<EnumBox>(bits) });
+            ValueRepr::Enum {
+                enum_type: e.enum_type,
+                key: e.key,
+                value: e.value,
+                index: e.index,
+            }
+        }
+        Kind::GenericRange => {
+            let g = Arc::unwrap_or_clone(unsafe { take_arc::<GenericRangeBox>(bits) });
+            ValueRepr::GenericRange {
+                start: g.start,
+                end: g.end,
+                excl_start: g.excl_start,
+                excl_end: g.excl_end,
+            }
+        }
+        Kind::Version => {
+            let v = Arc::unwrap_or_clone(unsafe { take_arc::<VersionBox>(bits) });
+            ValueRepr::Version {
+                parts: v.parts,
+                plus: v.plus,
+                minus: v.minus,
+            }
+        }
+        Kind::Capture => {
+            let c = Arc::unwrap_or_clone(unsafe { take_arc::<CaptureBox>(bits) });
+            ValueRepr::Capture {
+                positional: c.positional,
+                named: c.named,
+            }
+        }
+        Kind::Proxy => {
+            let p = Arc::unwrap_or_clone(unsafe { take_arc::<ProxyBox>(bits) });
+            ValueRepr::Proxy {
+                fetcher: p.fetcher,
+                storer: p.storer,
+                subclass: p.subclass,
+                decontainerized: p.decontainerized,
+            }
+        }
+        Kind::ParametricRole => {
+            let p = Arc::unwrap_or_clone(unsafe { take_arc::<ParametricRoleBox>(bits) });
+            ValueRepr::ParametricRole {
+                base_name: p.base_name,
+                type_args: p.type_args,
+            }
+        }
+        Kind::Routine => {
+            let r = Arc::unwrap_or_clone(unsafe { take_arc::<RoutineBox>(bits) });
+            ValueRepr::Routine {
+                package: r.package,
+                name: r.name,
+                is_regex: r.is_regex,
+            }
+        }
+        Kind::LazyIoLines => {
+            let l = Arc::unwrap_or_clone(unsafe { take_arc::<LazyIoLinesBox>(bits) });
+            ValueRepr::LazyIoLines {
+                handle: l.handle,
+                kv: l.kv,
+                words: l.words,
+            }
+        }
+        Kind::HashEntryRef => {
+            let h = Arc::unwrap_or_clone(unsafe { take_arc::<HashEntryRefBox>(bits) });
+            ValueRepr::HashEntryRef {
+                hash: h.hash,
+                path: h.path,
+                eager: h.eager,
+            }
+        }
+        Kind::Sub => ValueRepr::Sub(unsafe { take_gc::<SubData>(bits) }),
+        Kind::WeakSub => ValueRepr::WeakSub(unsafe { take_weak::<SubData>(bits) }),
+        Kind::LazyList => ValueRepr::LazyList(unsafe { take_gc::<LazyList>(bits) }),
+        Kind::ContainerRef => ValueRepr::ContainerRef(unsafe { take_gc::<Mutex<Value>>(bits) }),
+        Kind::Promise => ValueRepr::Promise(SharedPromise {
+            inner: unsafe { take_gc::<(Mutex<PromiseState>, Condvar)>(bits) },
+        }),
+        Kind::Channel => ValueRepr::Channel(SharedChannel {
+            inner: unsafe { take_gc::<(Mutex<ChannelState>, Condvar)>(bits) },
+        }),
+        Kind::Instance => {
+            let attributes = unsafe { take_gc::<InstanceAttrs>(bits) };
+            ValueRepr::Instance {
+                class_name: attributes.class_name,
+                id: attributes.id,
+                attributes,
+            }
+        }
+        Kind::ArrayList
+        | Kind::ArrayArray
+        | Kind::ArrayItemList
+        | Kind::ArrayItemArray
+        | Kind::ArrayShaped
+        | Kind::ArrayLazy => ValueRepr::Array(
+            unsafe { take_gc::<ArrayData>(bits) },
+            match kind {
+                Kind::ArrayList => ArrayKind::List,
+                Kind::ArrayArray => ArrayKind::Array,
+                Kind::ArrayItemList => ArrayKind::ItemList,
+                Kind::ArrayItemArray => ArrayKind::ItemArray,
+                Kind::ArrayShaped => ArrayKind::Shaped,
+                _ => ArrayKind::Lazy,
+            },
+        ),
+        Kind::HashPlain => ValueRepr::Hash(unsafe { take_gc::<HashData>(bits) }, false),
+        Kind::HashItemized => ValueRepr::Hash(unsafe { take_gc::<HashData>(bits) }, true),
+        Kind::SetImm => ValueRepr::Set(unsafe { take_gc::<SetData>(bits) }, false),
+        Kind::SetMut => ValueRepr::Set(unsafe { take_gc::<SetData>(bits) }, true),
+        Kind::BagImm => ValueRepr::Bag(unsafe { take_gc::<BagData>(bits) }, false),
+        Kind::BagMut => ValueRepr::Bag(unsafe { take_gc::<BagData>(bits) }, true),
+        Kind::MixImm => ValueRepr::Mix(unsafe { take_gc::<MixData>(bits) }, false),
+        Kind::MixMut => ValueRepr::Mix(unsafe { take_gc::<MixData>(bits) }, true),
+        Kind::Nil => ValueRepr::Nil,
+        Kind::Whatever => ValueRepr::Whatever,
+        Kind::HyperWhatever => ValueRepr::HyperWhatever,
+        Kind::Bool => ValueRepr::Bool(inline_payload(bits) != 0),
+        Kind::Package => ValueRepr::Package(Symbol::from_id(inline_payload(bits))),
+        Kind::CompUnitDepSpec => ValueRepr::CompUnitDepSpec {
+            short_name: Symbol::from_id(inline_payload(bits)),
+        },
+    }
+}

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -1,0 +1,199 @@
+//! `ValueRepr` -> `NanBox` packing (the future constructor-shim bodies).
+
+use super::*;
+
+impl NanBox {
+    /// Pack a `ValueRepr` into one word, taking ownership of its payloads.
+    /// Lossless: `into_repr` returns an equivalent `ValueRepr` (pointer
+    /// payloads identical, multi-field payloads moved through one heap box).
+    pub(in crate::value) fn from_repr(repr: ValueRepr) -> NanBox {
+        let word = match repr {
+            ValueRepr::Int(v) => {
+                if small_int_fits(v) {
+                    pack_small_int(v)
+                } else {
+                    pack_arc(Kind::IntBoxed, Arc::new(v))
+                }
+            }
+            ValueRepr::Num(f) => pack_num(f),
+            ValueRepr::Str(s) => pack_arc(Kind::Str, s),
+            ValueRepr::Regex(s) => pack_arc(Kind::Regex, s),
+            ValueRepr::BigInt(n) => pack_arc(Kind::BigInt, n),
+            ValueRepr::Bool(b) => pack_inline(Kind::Bool, b as u32),
+            ValueRepr::Nil => pack_inline(Kind::Nil, 0),
+            ValueRepr::Whatever => pack_inline(Kind::Whatever, 0),
+            ValueRepr::HyperWhatever => pack_inline(Kind::HyperWhatever, 0),
+            ValueRepr::Package(sym) => pack_inline(Kind::Package, sym.id()),
+            ValueRepr::CompUnitDepSpec { short_name } => {
+                pack_inline(Kind::CompUnitDepSpec, short_name.id())
+            }
+            ValueRepr::Range(a, b) => pack_arc(Kind::Range, Arc::new(I64Pair(a, b))),
+            ValueRepr::RangeExcl(a, b) => pack_arc(Kind::RangeExcl, Arc::new(I64Pair(a, b))),
+            ValueRepr::RangeExclStart(a, b) => {
+                pack_arc(Kind::RangeExclStart, Arc::new(I64Pair(a, b)))
+            }
+            ValueRepr::RangeExclBoth(a, b) => {
+                pack_arc(Kind::RangeExclBoth, Arc::new(I64Pair(a, b)))
+            }
+            ValueRepr::Rat(n, d) => pack_arc(Kind::Rat, Arc::new(I64Pair(n, d))),
+            ValueRepr::FatRat(n, d) => pack_arc(Kind::FatRat, Arc::new(I64Pair(n, d))),
+            ValueRepr::BigRat(n, d) => pack_arc(Kind::BigRat, Arc::new(BigRatBox(*n, *d))),
+            ValueRepr::Complex(re, im) => pack_arc(Kind::Complex, Arc::new(F64Pair(re, im))),
+            ValueRepr::GenericRange {
+                start,
+                end,
+                excl_start,
+                excl_end,
+            } => pack_arc(
+                Kind::GenericRange,
+                Arc::new(GenericRangeBox {
+                    start,
+                    end,
+                    excl_start,
+                    excl_end,
+                }),
+            ),
+            ValueRepr::Array(data, kind) => pack_gc(
+                match kind {
+                    ArrayKind::List => Kind::ArrayList,
+                    ArrayKind::Array => Kind::ArrayArray,
+                    ArrayKind::ItemList => Kind::ArrayItemList,
+                    ArrayKind::ItemArray => Kind::ArrayItemArray,
+                    ArrayKind::Shaped => Kind::ArrayShaped,
+                    ArrayKind::Lazy => Kind::ArrayLazy,
+                },
+                data,
+            ),
+            ValueRepr::Hash(data, itemized) => pack_gc(
+                if itemized {
+                    Kind::HashItemized
+                } else {
+                    Kind::HashPlain
+                },
+                data,
+            ),
+            ValueRepr::Set(data, mutable) => {
+                pack_gc(if mutable { Kind::SetMut } else { Kind::SetImm }, data)
+            }
+            ValueRepr::Bag(data, mutable) => {
+                pack_gc(if mutable { Kind::BagMut } else { Kind::BagImm }, data)
+            }
+            ValueRepr::Mix(data, mutable) => {
+                pack_gc(if mutable { Kind::MixMut } else { Kind::MixImm }, data)
+            }
+            ValueRepr::Pair(k, v) => pack_arc(Kind::Pair, Arc::new(PairBox(k, *v))),
+            ValueRepr::ValuePair(k, v) => pack_arc(Kind::ValuePair, Arc::new(ValuePairBox(*k, *v))),
+            ValueRepr::Enum {
+                enum_type,
+                key,
+                value,
+                index,
+            } => pack_arc(
+                Kind::Enum,
+                Arc::new(EnumBox {
+                    enum_type,
+                    key,
+                    value,
+                    index,
+                }),
+            ),
+            ValueRepr::Routine {
+                package,
+                name,
+                is_regex,
+            } => pack_arc(
+                Kind::Routine,
+                Arc::new(RoutineBox {
+                    package,
+                    name,
+                    is_regex,
+                }),
+            ),
+            ValueRepr::RegexWithAdverbs(adv) => pack_arc(Kind::RegexWithAdverbs, Arc::new(*adv)),
+            ValueRepr::Sub(data) => pack_gc(Kind::Sub, data),
+            ValueRepr::WeakSub(w) => pack_weak(Kind::WeakSub, w),
+            ValueRepr::Instance {
+                class_name,
+                attributes,
+                id,
+            } => {
+                // The variant's copies must mirror the pointee (rebless goes
+                // through `instance_sharing_cell`, which forks the node when
+                // the class differs) — the pointee is the single stored source.
+                debug_assert_eq!(
+                    attributes.class_name, class_name,
+                    "Instance class_name diverged from its InstanceAttrs"
+                );
+                debug_assert_eq!(
+                    attributes.id, id,
+                    "Instance id diverged from its InstanceAttrs"
+                );
+                pack_gc(Kind::Instance, attributes)
+            }
+            ValueRepr::Junction { kind, values } => pack_arc(
+                match kind {
+                    JunctionKind::Any => Kind::JunctionAny,
+                    JunctionKind::All => Kind::JunctionAll,
+                    JunctionKind::One => Kind::JunctionOne,
+                    JunctionKind::None => Kind::JunctionNone,
+                },
+                values,
+            ),
+            ValueRepr::Seq(items) => pack_arc(Kind::Seq, items),
+            ValueRepr::HyperSeq(items) => pack_arc(Kind::HyperSeq, items),
+            ValueRepr::RaceSeq(items) => pack_arc(Kind::RaceSeq, items),
+            ValueRepr::Slip(items) => pack_arc(Kind::Slip, items),
+            ValueRepr::LazyList(l) => pack_gc(Kind::LazyList, l),
+            ValueRepr::Version { parts, plus, minus } => {
+                pack_arc(Kind::Version, Arc::new(VersionBox { parts, plus, minus }))
+            }
+            ValueRepr::Promise(p) => pack_gc(Kind::Promise, p.inner),
+            ValueRepr::Channel(c) => pack_gc(Kind::Channel, c.inner),
+            ValueRepr::Mixin(inner, overrides) => {
+                pack_arc(Kind::Mixin, Arc::new(MixinBox(inner, overrides)))
+            }
+            ValueRepr::Capture { positional, named } => {
+                pack_arc(Kind::Capture, Arc::new(CaptureBox { positional, named }))
+            }
+            ValueRepr::Uni(u) => pack_arc(Kind::Uni, Arc::new(*u)),
+            ValueRepr::Proxy {
+                fetcher,
+                storer,
+                subclass,
+                decontainerized,
+            } => pack_arc(
+                Kind::Proxy,
+                Arc::new(ProxyBox {
+                    fetcher,
+                    storer,
+                    subclass,
+                    decontainerized,
+                }),
+            ),
+            ValueRepr::ParametricRole {
+                base_name,
+                type_args,
+            } => pack_arc(
+                Kind::ParametricRole,
+                Arc::new(ParametricRoleBox {
+                    base_name,
+                    type_args,
+                }),
+            ),
+            ValueRepr::CustomType(d) => pack_arc(Kind::CustomType, Arc::new(*d)),
+            ValueRepr::CustomTypeInstance(d) => pack_arc(Kind::CustomTypeInstance, Arc::new(*d)),
+            ValueRepr::Scalar(inner) => pack_arc(Kind::Scalar, Arc::new(*inner)),
+            ValueRepr::ContainerRef(cell) => pack_gc(Kind::ContainerRef, cell),
+            ValueRepr::LazyThunk(t) => pack_arc(Kind::LazyThunk, t),
+            ValueRepr::LazyIoLines { handle, kv, words } => pack_arc(
+                Kind::LazyIoLines,
+                Arc::new(LazyIoLinesBox { handle, kv, words }),
+            ),
+            ValueRepr::HashEntryRef { hash, path, eager } => pack_arc(
+                Kind::HashEntryRef,
+                Arc::new(HashEntryRefBox { hash, path, eager }),
+            ),
+        };
+        NanBox(word)
+    }
+}

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -1,0 +1,497 @@
+//! NaN-boxed 8-byte `Value` representation (layer 3b-1 step B core).
+//!
+//! [`NanBox`] is the packed storage the representation flip will put behind
+//! the `Value(...)` newtype seal: one 64-bit word encoding every [`ValueRepr`]
+//! variant. This module is the **only** place that knows the bit layout;
+//! everything else converses in `ValueRepr` (the decode/working enum) through
+//! [`NanBox::from_repr`] / [`NanBox::into_repr`].
+//!
+//! Encoding (pointer-favored per ADR-0005 §2.1, bit allocation fixed here —
+//! see `docs/nanbox-3b1-step-b-design.md`):
+//!
+//! ```text
+//! word = [ page: 16 bits ][ payload: 48 bits ]
+//!
+//! page 0x0000          : never constructed (0 stays the NonZeroU64 niche)
+//! page 0x0001          : small Int — payload = 48-bit two's complement
+//! page 0x0002..=0xFFF2 : f64 — word = f64::to_bits(n) + 0x0002_0000_0000_0000
+//!                        (NaN canonicalized to +qNaN at pack time)
+//! page 0xFFF3..=0xFFFF : kind pages — kind = (page - 0xFFF3)*8 + subkind,
+//!                        subkind = 3 payload bits (the pointer's tag-free
+//!                        alignment bits on 64-bit targets)
+//! ```
+//!
+//! Payload ownership: a pointer-kind word **owns** one strong reference of its
+//! `Arc<T>` / `Gc<T>` / `WeakGc<T>` payload (moved in via `into_raw`, moved
+//! out via `from_raw`). `Clone`/`Drop` reconstruct the smart pointer and use
+//! its own `clone`/`drop`, so all refcount and Bacon-Rajan candidate
+//! bookkeeping (`Gc::drop`'s buffered-bit path) is preserved exactly.
+
+use std::mem::ManuallyDrop;
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
+use crate::gc::{Gc, GcBox, Trace, WeakGc};
+
+use super::*;
+
+mod boxes;
+mod decode;
+mod encode;
+#[cfg(test)]
+mod tests;
+
+pub(in crate::value) use boxes::*;
+
+// ---- bit layout -------------------------------------------------------------
+
+const TAG_SHIFT: u32 = 48;
+/// Page of the inline small-Int encoding.
+const INT_PAGE: u64 = 0x0001;
+/// Added to `f64::to_bits` at pack time. Raw (NaN-canonicalized) doubles span
+/// pages `0x0000..=0xFFF0`, so encoded doubles span `0x0002..=0xFFF2` — leaving
+/// page 0 (niche), page 1 (Int) and `0xFFF3..=0xFFFF` (kinds) free.
+const DOUBLE_OFFSET: u64 = 0x0002 << TAG_SHIFT;
+/// First page of the kind space: 13 pages x 8 subkinds = 104 encodable kinds.
+const KIND_PAGE_BASE: u64 = 0xFFF3;
+const PAYLOAD48_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+/// Where the 3 subkind bits live inside the payload. On 64-bit targets they
+/// are the pointer's low (alignment) bits — every payload allocation is
+/// 8-aligned (checked in `boxes`), so the pointer address itself is tag-free
+/// and deref needs a single AND. On 32-bit targets (wasm32) allocations may be
+/// only 4-aligned, but pointers fit in 32 bits, so the subkind moves to bits
+/// 40..43, far above any address bit.
+#[cfg(target_pointer_width = "64")]
+const SUB_SHIFT: u32 = 0;
+#[cfg(not(target_pointer_width = "64"))]
+const SUB_SHIFT: u32 = 40;
+const SUB_MASK: u64 = 0x7 << SUB_SHIFT;
+/// Payload bits that hold a pointer-kind's address.
+const PTR_MASK: u64 = PAYLOAD48_MASK & !SUB_MASK;
+/// Inline (non-pointer) kind payloads sit in bits 8..40: clear of the subkind
+/// bits under BOTH `SUB_SHIFT` choices, and 32 bits is enough for every inline
+/// payload (`Symbol` id, bool).
+const INLINE_SHIFT: u32 = 8;
+
+/// Smallest/largest i64 that inline-encode in the 48-bit Int payload.
+const SMALL_INT_MIN: i64 = -(1 << 47);
+const SMALL_INT_MAX: i64 = (1 << 47) - 1;
+
+#[inline]
+fn small_int_fits(v: i64) -> bool {
+    (SMALL_INT_MIN..=SMALL_INT_MAX).contains(&v)
+}
+
+/// The canonical quiet NaN every packed NaN collapses to. Raw negative-NaN bit
+/// patterns (pages 0xFFF1..=0xFFFF) would collide with the kind pages after the
+/// double offset, so NaN payload/sign bits are NOT representable — Raku never
+/// exposes them.
+const CANONICAL_NAN: u64 = 0x7FF8_0000_0000_0000;
+
+// ---- kinds ------------------------------------------------------------------
+
+/// Discriminates every non-Int, non-Num variant. Discriminants are contiguous
+/// from 0 (checked by `KIND_COUNT` fitting the 104-kind capacity in a const
+/// assert below, and round-tripped exhaustively in tests).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(in crate::value) enum Kind {
+    // -- Arc-backed pointer kinds (payload = Arc<T> raw address) --
+    Str = 0,
+    Regex,
+    BigInt,
+    /// An `i64` outside the 48-bit inline range, boxed (`ValueRepr::Int` is
+    /// lossless: the boxed form still decodes to `Int`, never `BigInt`).
+    IntBoxed,
+    Seq,
+    HyperSeq,
+    RaceSeq,
+    Slip,
+    JunctionAny,
+    JunctionAll,
+    JunctionOne,
+    JunctionNone,
+    Mixin,
+    Scalar,
+    LazyThunk,
+    Uni,
+    RegexWithAdverbs,
+    CustomType,
+    CustomTypeInstance,
+    Range,
+    RangeExcl,
+    RangeExclStart,
+    RangeExclBoth,
+    Rat,
+    FatRat,
+    BigRat,
+    Complex,
+    Pair,
+    ValuePair,
+    Enum,
+    GenericRange,
+    Version,
+    Capture,
+    Proxy,
+    ParametricRole,
+    Routine,
+    LazyIoLines,
+    HashEntryRef,
+    // -- Gc-backed pointer kinds (payload = GcBox<T> raw address) --
+    Sub,
+    WeakSub,
+    LazyList,
+    ContainerRef,
+    Promise,
+    Channel,
+    /// `class_name` and `id` are NOT stored: `Value::Instance` keeps them equal
+    /// to the pointee's own fields (`instance_sharing_cell` reblesses into a
+    /// fresh `InstanceAttrs` node), so the pointee is the single source.
+    Instance,
+    ArrayList,
+    ArrayArray,
+    ArrayItemList,
+    ArrayItemArray,
+    ArrayShaped,
+    ArrayLazy,
+    HashPlain,
+    HashItemized,
+    SetImm,
+    SetMut,
+    BagImm,
+    BagMut,
+    MixImm,
+    MixMut,
+    // -- inline kinds (payload in bits 8..40) --
+    Nil,
+    Whatever,
+    HyperWhatever,
+    Bool,
+    Package,
+    CompUnitDepSpec,
+}
+
+pub(in crate::value) const KIND_COUNT: u8 = Kind::CompUnitDepSpec as u8 + 1;
+
+// 13 kind pages x 8 subkinds.
+const _: () = assert!(KIND_COUNT as u64 <= (0xFFFF - KIND_PAGE_BASE + 1) * 8);
+
+#[inline]
+fn kind_from_u8(k: u8) -> Kind {
+    debug_assert!(k < KIND_COUNT, "invalid nanbox kind {k}");
+    // SAFETY: `Kind` is a fieldless #[repr(u8)] enum with contiguous
+    // discriminants 0..KIND_COUNT, and every word carrying a kind was packed
+    // by `word_for_kind` from a valid `Kind`.
+    unsafe { std::mem::transmute::<u8, Kind>(k) }
+}
+
+// ---- word assembly / disassembly ---------------------------------------------
+
+#[inline]
+fn word_for_kind(kind: Kind, payload: u64) -> NonZeroU64 {
+    debug_assert_eq!(payload & !PAYLOAD48_MASK, 0, "payload exceeds 48 bits");
+    debug_assert_eq!(payload & SUB_MASK, 0, "payload collides with subkind bits");
+    let k = kind as u64;
+    let bits = ((KIND_PAGE_BASE + (k >> 3)) << TAG_SHIFT) | payload | ((k & 0x7) << SUB_SHIFT);
+    // SAFETY-free: the page is >= 0xFFF3, so the word is never 0.
+    NonZeroU64::new(bits).expect("kind words are always nonzero")
+}
+
+#[inline]
+fn pack_small_int(v: i64) -> NonZeroU64 {
+    debug_assert!(small_int_fits(v));
+    let bits = (INT_PAGE << TAG_SHIFT) | ((v as u64) & PAYLOAD48_MASK);
+    NonZeroU64::new(bits).expect("int words carry page 1")
+}
+
+#[inline]
+fn pack_num(f: f64) -> NonZeroU64 {
+    let raw = if f.is_nan() {
+        CANONICAL_NAN
+    } else {
+        f.to_bits()
+    };
+    // raw <= 0xFFF0.. (-Inf) after canonicalization, so no wrap: encoded page
+    // is 0x0002..=0xFFF2 and the word is never 0.
+    NonZeroU64::new(raw.wrapping_add(DOUBLE_OFFSET)).expect("num words carry page >= 2")
+}
+
+#[inline]
+fn pack_inline(kind: Kind, payload: u32) -> NonZeroU64 {
+    word_for_kind(kind, (payload as u64) << INLINE_SHIFT)
+}
+
+#[inline]
+fn inline_payload(bits: u64) -> u32 {
+    (((bits & PAYLOAD48_MASK) & !SUB_MASK) >> INLINE_SHIFT) as u32
+}
+
+/// What a word's tag bits say it is, before touching any payload.
+enum Classified {
+    Int(i64),
+    Num(f64),
+    Kind(Kind),
+}
+
+#[inline]
+fn classify(bits: u64) -> Classified {
+    let page = bits >> TAG_SHIFT;
+    if page == INT_PAGE {
+        // Sign-extend the 48-bit payload.
+        Classified::Int(((bits << 16) as i64) >> 16)
+    } else if page < KIND_PAGE_BASE {
+        debug_assert!(page >= 2, "page 0 is the niche; page 1 handled above");
+        Classified::Num(f64::from_bits(bits.wrapping_sub(DOUBLE_OFFSET)))
+    } else {
+        let k = ((page - KIND_PAGE_BASE) << 3) | ((bits & SUB_MASK) >> SUB_SHIFT);
+        Classified::Kind(kind_from_u8(k as u8))
+    }
+}
+
+// ---- pointer payload round-trip ----------------------------------------------
+
+#[inline]
+fn addr_of_payload(bits: u64) -> usize {
+    (bits & PTR_MASK) as usize
+}
+
+#[inline]
+fn pack_addr(kind: Kind, addr: usize) -> NonZeroU64 {
+    let a = addr as u64;
+    debug_assert_eq!(
+        a & !PTR_MASK,
+        0,
+        "payload pointer outside the encodable address space"
+    );
+    word_for_kind(kind, a)
+}
+
+#[inline]
+fn pack_arc<T>(kind: Kind, a: Arc<T>) -> NonZeroU64 {
+    pack_addr(kind, Arc::into_raw(a).expose_provenance())
+}
+
+/// # Safety
+/// `bits` must be a word packed by `pack_arc::<T>` whose ownership is being
+/// consumed (at most once per packed word).
+#[inline]
+unsafe fn take_arc<T>(bits: u64) -> Arc<T> {
+    unsafe {
+        Arc::from_raw(std::ptr::with_exposed_provenance::<T>(addr_of_payload(
+            bits,
+        )))
+    }
+}
+
+#[inline]
+fn pack_gc<T: Trace + 'static>(kind: Kind, g: Gc<T>) -> NonZeroU64 {
+    pack_addr(kind, Gc::into_raw(g).expose_provenance())
+}
+
+/// # Safety
+/// `bits` must be a word packed by `pack_gc::<T>` whose ownership is being
+/// consumed (at most once per packed word).
+#[inline]
+unsafe fn take_gc<T: Trace + 'static>(bits: u64) -> Gc<T> {
+    unsafe {
+        Gc::from_raw(std::ptr::with_exposed_provenance::<GcBox<T>>(
+            addr_of_payload(bits),
+        ))
+    }
+}
+
+#[inline]
+fn pack_weak<T: Trace + 'static>(kind: Kind, w: WeakGc<T>) -> NonZeroU64 {
+    pack_addr(kind, WeakGc::into_raw(w).expose_provenance())
+}
+
+/// # Safety
+/// `bits` must be a word packed by `pack_weak::<T>` whose ownership is being
+/// consumed (at most once per packed word).
+#[inline]
+unsafe fn take_weak<T: Trace + 'static>(bits: u64) -> WeakGc<T> {
+    unsafe {
+        WeakGc::from_raw(std::ptr::with_exposed_provenance::<GcBox<T>>(
+            addr_of_payload(bits),
+        ))
+    }
+}
+
+// ---- clone / drop dispatch -----------------------------------------------------
+
+enum PayloadOp {
+    /// Add one owned reference to the payload (the cloned word becomes a
+    /// second owner).
+    CloneBump,
+    /// Release this word's owned reference.
+    Release,
+}
+
+/// # Safety
+/// `bits` must be a live word whose payload matches `T` under `pack_arc`.
+unsafe fn arc_op<T>(bits: u64, op: PayloadOp) {
+    match op {
+        PayloadOp::CloneBump => unsafe {
+            Arc::increment_strong_count(std::ptr::with_exposed_provenance::<T>(addr_of_payload(
+                bits,
+            )));
+        },
+        PayloadOp::Release => drop(unsafe { take_arc::<T>(bits) }),
+    }
+}
+
+/// # Safety
+/// `bits` must be a live word whose payload matches `T` under `pack_gc`.
+unsafe fn gc_op<T: Trace + 'static>(bits: u64, op: PayloadOp) {
+    match op {
+        PayloadOp::CloneBump => {
+            // Reconstruct without consuming, clone through `Gc::clone` (which
+            // does the Bacon-Rajan strong-count + Black recolor bookkeeping),
+            // and forget the handle wrapper: the new word owns the bump.
+            let g = ManuallyDrop::new(unsafe { take_gc::<T>(bits) });
+            let dup = Gc::clone(&g);
+            let addr = Gc::into_raw(dup).expose_provenance();
+            debug_assert_eq!(addr, addr_of_payload(bits));
+        }
+        // Full `Gc::drop` semantics: candidate buffering, finalize, sweep.
+        PayloadOp::Release => drop(unsafe { take_gc::<T>(bits) }),
+    }
+}
+
+/// # Safety
+/// `bits` must be a live word whose payload matches `T` under `pack_weak`.
+unsafe fn weak_op<T: Trace + 'static>(bits: u64, op: PayloadOp) {
+    match op {
+        PayloadOp::CloneBump => {
+            let w = ManuallyDrop::new(unsafe { take_weak::<T>(bits) });
+            let dup = WeakGc::clone(&w);
+            let addr = WeakGc::into_raw(dup).expose_provenance();
+            debug_assert_eq!(addr, addr_of_payload(bits));
+        }
+        PayloadOp::Release => drop(unsafe { take_weak::<T>(bits) }),
+    }
+}
+
+/// Apply `op` to the payload reference owned by `bits`. The single
+/// kind -> payload-type map for `Clone`/`Drop`; `decode` has its own exhaustive
+/// match because it also moves the payload into `ValueRepr` fields.
+///
+/// # Safety
+/// `bits` must be a live kind word (not yet released).
+unsafe fn payload_op(kind: Kind, bits: u64, op: PayloadOp) {
+    unsafe {
+        match kind {
+            Kind::Str | Kind::Regex => arc_op::<String>(bits, op),
+            Kind::BigInt => arc_op::<NumBigInt>(bits, op),
+            Kind::IntBoxed => arc_op::<i64>(bits, op),
+            Kind::Seq
+            | Kind::HyperSeq
+            | Kind::RaceSeq
+            | Kind::Slip
+            | Kind::JunctionAny
+            | Kind::JunctionAll
+            | Kind::JunctionOne
+            | Kind::JunctionNone => arc_op::<Vec<Value>>(bits, op),
+            Kind::Mixin => arc_op::<MixinBox>(bits, op),
+            Kind::Scalar => arc_op::<Value>(bits, op),
+            Kind::LazyThunk => arc_op::<LazyThunkData>(bits, op),
+            Kind::Uni => arc_op::<UniData>(bits, op),
+            Kind::RegexWithAdverbs => arc_op::<RegexAdverbs>(bits, op),
+            Kind::CustomType => arc_op::<CustomTypeData>(bits, op),
+            Kind::CustomTypeInstance => arc_op::<CustomTypeInstanceData>(bits, op),
+            Kind::Range
+            | Kind::RangeExcl
+            | Kind::RangeExclStart
+            | Kind::RangeExclBoth
+            | Kind::Rat
+            | Kind::FatRat => arc_op::<I64Pair>(bits, op),
+            Kind::BigRat => arc_op::<BigRatBox>(bits, op),
+            Kind::Complex => arc_op::<F64Pair>(bits, op),
+            Kind::Pair => arc_op::<PairBox>(bits, op),
+            Kind::ValuePair => arc_op::<ValuePairBox>(bits, op),
+            Kind::Enum => arc_op::<EnumBox>(bits, op),
+            Kind::GenericRange => arc_op::<GenericRangeBox>(bits, op),
+            Kind::Version => arc_op::<VersionBox>(bits, op),
+            Kind::Capture => arc_op::<CaptureBox>(bits, op),
+            Kind::Proxy => arc_op::<ProxyBox>(bits, op),
+            Kind::ParametricRole => arc_op::<ParametricRoleBox>(bits, op),
+            Kind::Routine => arc_op::<RoutineBox>(bits, op),
+            Kind::LazyIoLines => arc_op::<LazyIoLinesBox>(bits, op),
+            Kind::HashEntryRef => arc_op::<HashEntryRefBox>(bits, op),
+            Kind::Sub => gc_op::<SubData>(bits, op),
+            Kind::WeakSub => weak_op::<SubData>(bits, op),
+            Kind::LazyList => gc_op::<LazyList>(bits, op),
+            Kind::ContainerRef => gc_op::<Mutex<Value>>(bits, op),
+            Kind::Promise => gc_op::<(Mutex<PromiseState>, Condvar)>(bits, op),
+            Kind::Channel => gc_op::<(Mutex<ChannelState>, Condvar)>(bits, op),
+            Kind::Instance => gc_op::<InstanceAttrs>(bits, op),
+            Kind::ArrayList
+            | Kind::ArrayArray
+            | Kind::ArrayItemList
+            | Kind::ArrayItemArray
+            | Kind::ArrayShaped
+            | Kind::ArrayLazy => gc_op::<ArrayData>(bits, op),
+            Kind::HashPlain | Kind::HashItemized => gc_op::<HashData>(bits, op),
+            Kind::SetImm | Kind::SetMut => gc_op::<SetData>(bits, op),
+            Kind::BagImm | Kind::BagMut => gc_op::<BagData>(bits, op),
+            Kind::MixImm | Kind::MixMut => gc_op::<MixData>(bits, op),
+            Kind::Nil
+            | Kind::Whatever
+            | Kind::HyperWhatever
+            | Kind::Bool
+            | Kind::Package
+            | Kind::CompUnitDepSpec => {}
+        }
+    }
+}
+
+// ---- NanBox --------------------------------------------------------------------
+
+/// The packed 8-byte value word. Owns one reference of any pointer payload.
+pub(in crate::value) struct NanBox(NonZeroU64);
+
+// SAFETY: a NanBox is semantically one `ValueRepr` (all of whose payloads are
+// `Send + Sync` — asserted on `Value` in `value::mod`); the packed form adds
+// no thread affinity.
+unsafe impl Send for NanBox {}
+unsafe impl Sync for NanBox {}
+
+impl NanBox {
+    /// Raw word bits (tests / future tag-dispatch fast paths).
+    #[inline]
+    pub(in crate::value) fn bits(&self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl Clone for NanBox {
+    fn clone(&self) -> Self {
+        let bits = self.0.get();
+        if let Classified::Kind(kind) = classify(bits) {
+            // SAFETY: `self` is live, so the word owns its payload reference;
+            // CloneBump adds one for the new word.
+            unsafe { payload_op(kind, bits, PayloadOp::CloneBump) };
+        }
+        NanBox(self.0)
+    }
+}
+
+impl Drop for NanBox {
+    fn drop(&mut self) {
+        let bits = self.0.get();
+        if let Classified::Kind(kind) = classify(bits) {
+            // SAFETY: dropping consumes this word's payload ownership exactly
+            // once.
+            unsafe { payload_op(kind, bits, PayloadOp::Release) };
+        }
+    }
+}
+
+impl std::fmt::Debug for NanBox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Decode through a clone so Debug (used by tests and trace logs)
+        // matches the repr's output byte-for-byte.
+        self.clone().into_repr().fmt(f)
+    }
+}

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -1,0 +1,578 @@
+//! NaN-box invariants: size/niche, exhaustive lossless round-trips, pointer
+//! identity, refcount neutrality (Arc + Gc header bookkeeping), encoding edge
+//! cases. These are the step-B ground truth BEFORE the representation flip
+//! wires `NanBox` into `Value` — run under Miri to validate the raw-pointer
+//! round-trips (`cargo miri test value::nanbox`).
+
+use super::*;
+use crate::ast::ParamDef;
+use crate::env::Env;
+
+fn roundtrip(repr: ValueRepr) -> ValueRepr {
+    NanBox::from_repr(repr).into_repr()
+}
+
+/// Debug output is the equality proxy: `ValueRepr` has no `PartialEq`, and
+/// `Debug` prints through to every payload (Gc/Arc Debug delegate to the
+/// pointee), so equal output means an equal decoded structure.
+fn assert_roundtrip(repr: ValueRepr) {
+    let expect = format!("{repr:?}");
+    let got = format!("{:?}", roundtrip(repr));
+    assert_eq!(got, expect);
+}
+
+#[test]
+fn word_is_8_bytes_with_a_niche() {
+    assert_eq!(std::mem::size_of::<NanBox>(), 8);
+    assert_eq!(std::mem::size_of::<Option<NanBox>>(), 8);
+}
+
+#[test]
+fn kind_tags_roundtrip_exhaustively() {
+    for k in 0..KIND_COUNT {
+        let kind = kind_from_u8(k);
+        let word = word_for_kind(kind, 0);
+        match classify(word.get()) {
+            Classified::Kind(back) => assert_eq!(back, kind, "kind {k} corrupted"),
+            _ => panic!("kind {k} classified as Int/Num"),
+        }
+    }
+}
+
+#[test]
+fn small_ints_inline_and_big_ints_box_losslessly() {
+    for v in [
+        0,
+        1,
+        -1,
+        42,
+        SMALL_INT_MIN,
+        SMALL_INT_MAX,
+        SMALL_INT_MIN - 1,
+        SMALL_INT_MAX + 1,
+        i64::MIN,
+        i64::MAX,
+    ] {
+        match roundtrip(ValueRepr::Int(v)) {
+            ValueRepr::Int(back) => assert_eq!(back, v),
+            other => panic!("Int({v}) decoded as {other:?}"),
+        }
+    }
+    // Inline vs boxed split is where the design says it is.
+    let inline = NanBox::from_repr(ValueRepr::Int(SMALL_INT_MAX));
+    assert_eq!(inline.bits() >> TAG_SHIFT, INT_PAGE);
+    let boxed = NanBox::from_repr(ValueRepr::Int(SMALL_INT_MAX + 1));
+    assert!(boxed.bits() >> TAG_SHIFT >= KIND_PAGE_BASE);
+}
+
+#[test]
+fn nums_roundtrip_bit_exactly_and_nan_canonicalizes() {
+    for f in [
+        0.0,
+        -0.0,
+        1.5,
+        -1.5,
+        std::f64::consts::PI,
+        1e300,
+        -1e300,
+        f64::MIN_POSITIVE,
+        5e-324, // subnormal
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::MAX,
+        f64::MIN,
+    ] {
+        match roundtrip(ValueRepr::Num(f)) {
+            ValueRepr::Num(back) => {
+                assert_eq!(back.to_bits(), f.to_bits(), "bits changed for {f}")
+            }
+            other => panic!("Num({f}) decoded as {other:?}"),
+        }
+    }
+    // Every NaN (sign/payload included) collapses to a NaN.
+    for nan_bits in [
+        CANONICAL_NAN,
+        0x7FF8_0000_0000_0001,
+        0xFFF8_0000_0000_0000,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0x7FF0_0000_0000_0001, // signaling
+    ] {
+        match roundtrip(ValueRepr::Num(f64::from_bits(nan_bits))) {
+            ValueRepr::Num(back) => assert!(back.is_nan()),
+            other => panic!("NaN decoded as {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn str_pointer_identity_and_refcounts_survive() {
+    let s = Arc::new("shared".to_string());
+    assert_eq!(Arc::strong_count(&s), 1);
+    let b = NanBox::from_repr(ValueRepr::Str(s.clone()));
+    assert_eq!(Arc::strong_count(&s), 2, "the word owns one reference");
+    let b2 = b.clone();
+    assert_eq!(Arc::strong_count(&s), 3, "clone bumps");
+    drop(b2);
+    assert_eq!(Arc::strong_count(&s), 2, "drop releases");
+    match b.into_repr() {
+        ValueRepr::Str(back) => {
+            assert!(Arc::ptr_eq(&back, &s), "identity preserved");
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+    // `into_repr` consumed the word's reference and `back` dropped with the
+    // match arm — only the local `s` remains.
+    assert_eq!(Arc::strong_count(&s), 1);
+}
+
+#[test]
+fn gc_container_identity_and_header_bookkeeping_survive() {
+    let data = Gc::new(ArrayData {
+        items: vec![Value::int(1), Value::int(2)],
+        ..Default::default()
+    });
+    assert_eq!(data.strong_count(), 1);
+    let b = NanBox::from_repr(ValueRepr::Array(data.clone(), ArrayKind::Array));
+    assert_eq!(
+        data.strong_count(),
+        2,
+        "the word owns one GC-visible handle"
+    );
+    let b2 = b.clone();
+    assert_eq!(
+        data.strong_count(),
+        3,
+        "NanBox::clone goes through Gc::clone"
+    );
+    drop(b2);
+    assert_eq!(data.strong_count(), 2, "NanBox::drop goes through Gc::drop");
+    match b.into_repr() {
+        ValueRepr::Array(back, kind) => {
+            assert_eq!(kind, ArrayKind::Array);
+            assert!(Gc::ptr_eq(&back, &data), "container identity preserved");
+            assert_eq!(back.items.len(), 2);
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+    assert_eq!(data.strong_count(), 1, "all transferred handles released");
+}
+
+#[test]
+fn array_kind_and_container_flags_travel_in_the_tag() {
+    for kind in [
+        ArrayKind::List,
+        ArrayKind::Array,
+        ArrayKind::ItemList,
+        ArrayKind::ItemArray,
+        ArrayKind::Shaped,
+        ArrayKind::Lazy,
+    ] {
+        match roundtrip(ValueRepr::Array(Gc::new(ArrayData::default()), kind)) {
+            ValueRepr::Array(_, back) => assert_eq!(back, kind),
+            other => panic!("decoded as {other:?}"),
+        }
+    }
+    for itemized in [false, true] {
+        match roundtrip(ValueRepr::Hash(Gc::new(HashData::default()), itemized)) {
+            ValueRepr::Hash(_, back) => assert_eq!(back, itemized),
+            other => panic!("decoded as {other:?}"),
+        }
+    }
+    for mutable in [false, true] {
+        match roundtrip(ValueRepr::Set(
+            Gc::new(SetData {
+                elements: HashSet::new(),
+                original_keys: None,
+                value_type: None,
+                key_type: None,
+                declared_type: None,
+            }),
+            mutable,
+        )) {
+            ValueRepr::Set(_, back) => assert_eq!(back, mutable),
+            other => panic!("decoded as {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn container_ref_cell_identity_survives() {
+    let cell = Gc::new(Mutex::new(Value::int(7)));
+    match roundtrip(ValueRepr::ContainerRef(cell.clone())) {
+        ValueRepr::ContainerRef(back) => {
+            assert!(Gc::ptr_eq(&back, &cell), ":= binding identity preserved");
+            *back.lock().unwrap() = Value::int(9);
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+    assert!(matches!(&*cell.lock().unwrap(), Value(ValueRepr::Int(9))));
+}
+
+fn sample_sub() -> Gc<SubData> {
+    Gc::new(SubData {
+        package: Symbol::intern("Main"),
+        name: Symbol::intern("nanbox-test-sub"),
+        params: vec![],
+        param_defs: Vec::<ParamDef>::new(),
+        body: vec![],
+        is_rw: false,
+        is_raw: false,
+        env: Env::new(),
+        assumed_positional: vec![],
+        assumed_named: HashMap::new(),
+        id: 12345,
+        empty_sig: false,
+        is_bare_block: false,
+        compiled_code: None,
+        deprecated_message: None,
+        source_line: None,
+        source_file: None,
+        owned_captures: vec![],
+        upvalues: vec![],
+    })
+}
+
+#[test]
+fn weak_sub_stays_weak_and_expires() {
+    let sub = sample_sub();
+    let weak = Gc::downgrade(&sub);
+    let b = NanBox::from_repr(ValueRepr::WeakSub(weak));
+    assert_eq!(
+        sub.strong_count(),
+        1,
+        "a weak payload adds no strong handle"
+    );
+    let b2 = b.clone();
+    match b2.into_repr() {
+        ValueRepr::WeakSub(w) => {
+            let up = w.upgrade().expect("still alive");
+            assert!(Gc::ptr_eq(&up, &sub));
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+    drop(sub);
+    match b.into_repr() {
+        ValueRepr::WeakSub(w) => assert!(w.upgrade().is_none(), "expired after drop"),
+        other => panic!("decoded as {other:?}"),
+    }
+}
+
+#[test]
+fn instance_reads_class_and_id_back_from_the_pointee() {
+    let class = Symbol::intern("NanboxTestClass");
+    let mut attrs = HashMap::new();
+    attrs.insert("x".to_string(), Value::int(1));
+    // queue_destroy=false: keep the DESTROY registry out of a unit test.
+    let node = Gc::new(InstanceAttrs::new(class, attrs, 777, false));
+    match roundtrip(ValueRepr::Instance {
+        class_name: class,
+        attributes: node.clone(),
+        id: 777,
+    }) {
+        ValueRepr::Instance {
+            class_name,
+            attributes,
+            id,
+        } => {
+            assert_eq!(class_name, class);
+            assert_eq!(id, 777);
+            assert!(Gc::ptr_eq(&attributes, &node));
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+}
+
+#[test]
+fn shared_multifield_box_decodes_by_clone_unique_by_move() {
+    // Unique word: decode moves the payload (no clone) — observable via the
+    // inner Arc's count staying 1 through the round-trip.
+    let inner = Arc::new(Value::int(5));
+    let b = NanBox::from_repr(ValueRepr::GenericRange {
+        start: inner.clone(),
+        end: Arc::new(Value::int(9)),
+        excl_start: false,
+        excl_end: true,
+    });
+    assert_eq!(Arc::strong_count(&inner), 2);
+    match b.into_repr() {
+        ValueRepr::GenericRange {
+            start,
+            excl_start,
+            excl_end,
+            ..
+        } => {
+            assert!(Arc::ptr_eq(&start, &inner), "field identity preserved");
+            assert!(!excl_start);
+            assert!(excl_end);
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+    // Shared word: both clones decode to the same field pointers.
+    let b = NanBox::from_repr(ValueRepr::Mixin(inner.clone(), Arc::new(HashMap::new())));
+    let b2 = b.clone();
+    let (r1, r2) = (b.into_repr(), b2.into_repr());
+    match (r1, r2) {
+        (ValueRepr::Mixin(a1, _), ValueRepr::Mixin(a2, _)) => {
+            assert!(Arc::ptr_eq(&a1, &a2), "shared box decodes to shared fields");
+            assert!(Arc::ptr_eq(&a1, &inner));
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+}
+
+/// One sample per remaining variant, Debug-compared through the round-trip.
+#[test]
+fn every_variant_roundtrips_losslessly() {
+    let samples: Vec<ValueRepr> = vec![
+        ValueRepr::Int(42),
+        ValueRepr::Int(i64::MIN),
+        ValueRepr::BigInt(Arc::new(NumBigInt::from(10).pow(30))),
+        ValueRepr::Num(2.5),
+        ValueRepr::Str(Arc::new("hello".to_string())),
+        ValueRepr::Bool(true),
+        ValueRepr::Bool(false),
+        ValueRepr::Range(1, 10),
+        ValueRepr::RangeExcl(-3, 7),
+        ValueRepr::RangeExclStart(0, 5),
+        ValueRepr::RangeExclBoth(i64::MIN, i64::MAX),
+        ValueRepr::GenericRange {
+            start: Arc::new(Value::str("a".to_string())),
+            end: Arc::new(Value::str("z".to_string())),
+            excl_start: true,
+            excl_end: false,
+        },
+        ValueRepr::Array(
+            Gc::new(ArrayData {
+                items: vec![Value::int(1), Value::str("two".to_string())],
+                value_type: Some("Int".to_string()),
+                default: Some(Box::new(Value::int(0))),
+                ..Default::default()
+            }),
+            ArrayKind::List,
+        ),
+        ValueRepr::Hash(
+            Gc::new(HashData {
+                map: HashMap::from([("k".to_string(), Value::int(1))]),
+                ..Default::default()
+            }),
+            false,
+        ),
+        ValueRepr::Rat(3, 4),
+        ValueRepr::FatRat(-7, 2),
+        ValueRepr::BigRat(
+            Box::new(NumBigInt::from(10).pow(25)),
+            Box::new(NumBigInt::from(3)),
+        ),
+        ValueRepr::Complex(1.5, -2.5),
+        ValueRepr::Set(
+            Gc::new(SetData {
+                elements: HashSet::from(["a".to_string()]),
+                original_keys: None,
+                value_type: None,
+                key_type: None,
+                declared_type: Some("SetHash".to_string()),
+            }),
+            true,
+        ),
+        ValueRepr::Bag(
+            Gc::new(BagData {
+                counts: HashMap::from([("b".to_string(), NumBigInt::from(2))]),
+                original_keys: None,
+                value_type: None,
+                key_type: None,
+                declared_type: None,
+            }),
+            false,
+        ),
+        ValueRepr::Mix(
+            Gc::new(MixData {
+                weights: HashMap::from([("m".to_string(), 0.5)]),
+                original_keys: None,
+                value_type: None,
+                key_type: None,
+                declared_type: None,
+            }),
+            true,
+        ),
+        ValueRepr::CompUnitDepSpec {
+            short_name: Symbol::intern("Test::Module"),
+        },
+        ValueRepr::Package(Symbol::intern("Foo::Bar")),
+        ValueRepr::Routine {
+            package: Symbol::intern("Main"),
+            name: Symbol::intern("frobnicate"),
+            is_regex: true,
+        },
+        ValueRepr::Pair("key".to_string(), Box::new(Value::int(9))),
+        ValueRepr::ValuePair(
+            Box::new(Value::int(1)),
+            Box::new(Value::str("v".to_string())),
+        ),
+        ValueRepr::Enum {
+            enum_type: Symbol::intern("Color"),
+            key: Symbol::intern("Red"),
+            value: EnumValue::Int(0),
+            index: 0,
+        },
+        ValueRepr::Regex(Arc::new("\\d+".to_string())),
+        ValueRepr::RegexWithAdverbs(Box::new(RegexAdverbs {
+            pattern: Arc::new("a.b".to_string()),
+            global: true,
+            exhaustive: false,
+            overlap: false,
+            repeat: Some(2),
+            nth: None,
+            perl5: false,
+            pos: false,
+            continue_: false,
+            ignore_case: true,
+            sigspace: false,
+            samecase: false,
+            samespace: false,
+        })),
+        ValueRepr::Sub(sample_sub()),
+        ValueRepr::Junction {
+            kind: JunctionKind::Any,
+            values: Arc::new(vec![Value::int(1), Value::int(2)]),
+        },
+        ValueRepr::Junction {
+            kind: JunctionKind::None,
+            values: Arc::new(vec![]),
+        },
+        ValueRepr::Seq(Arc::new(vec![Value::int(1)])),
+        ValueRepr::HyperSeq(Arc::new(vec![Value::int(2)])),
+        ValueRepr::RaceSeq(Arc::new(vec![Value::int(3)])),
+        ValueRepr::Slip(Arc::new(vec![Value::int(4)])),
+        ValueRepr::Version {
+            parts: vec![
+                VersionPart::Num(1),
+                VersionPart::Str("beta".to_string()),
+                VersionPart::Whatever,
+            ],
+            plus: true,
+            minus: false,
+        },
+        ValueRepr::Nil,
+        ValueRepr::Whatever,
+        ValueRepr::HyperWhatever,
+        ValueRepr::Mixin(
+            Arc::new(Value::int(1)),
+            Arc::new(HashMap::from([("Bool".to_string(), Value::truth(true))])),
+        ),
+        ValueRepr::Capture {
+            positional: Box::new(vec![Value::int(1)]),
+            named: Box::new(HashMap::from([("n".to_string(), Value::int(2))])),
+        },
+        ValueRepr::Uni(Box::new(UniData {
+            form: "NFC".to_string(),
+            text: "abc".to_string(),
+        })),
+        ValueRepr::Proxy {
+            fetcher: Box::new(Value::NIL),
+            storer: Box::new(Value::NIL),
+            subclass: Some((
+                Symbol::intern("MyProxy"),
+                Arc::new(Mutex::new(HashMap::new())),
+            )),
+            decontainerized: true,
+        },
+        ValueRepr::ParametricRole {
+            base_name: Symbol::intern("R1"),
+            type_args: vec![Value::str("C1".to_string())],
+        },
+        ValueRepr::CustomType(Box::new(CustomTypeData {
+            how: Box::new(Value::NIL),
+            repr: "P6opaque".to_string(),
+            name: Symbol::intern("CustomT"),
+            id: 1,
+        })),
+        ValueRepr::CustomTypeInstance(Box::new(CustomTypeInstanceData {
+            type_id: 1,
+            how: Box::new(Value::NIL),
+            repr: "P6opaque".to_string(),
+            type_name: Symbol::intern("CustomT"),
+            attributes: Arc::new(HashMap::new()),
+            id: 2,
+        })),
+        ValueRepr::Scalar(Box::new(Value::int(11))),
+        ValueRepr::ContainerRef(Gc::new(Mutex::new(Value::int(3)))),
+        ValueRepr::LazyThunk(Arc::new(LazyThunkData {
+            thunk: Value::NIL,
+            cache: Mutex::new(Some(Value::int(5))),
+        })),
+        ValueRepr::LazyIoLines {
+            handle: Box::new(Value::NIL),
+            kv: true,
+            words: false,
+        },
+        ValueRepr::HashEntryRef {
+            hash: Gc::new(HashData::default()),
+            path: vec!["a".to_string(), "b".to_string()],
+            eager: false,
+        },
+    ];
+    for repr in samples {
+        assert_roundtrip(repr);
+    }
+}
+
+#[test]
+fn lazy_list_roundtrips_by_identity() {
+    // `LazyList` has interior Mutex state and no meaningful Debug shape, so
+    // check node identity instead of Debug equality.
+    let node = Gc::new(LazyList {
+        body: vec![],
+        env: Env::new(),
+        cache: Mutex::new(Some(vec![Value::int(1)])),
+        compiled_code: None,
+        compiled_fns: None,
+        elems_count: None,
+        scan_spec: None,
+        sequence_spec: None,
+        coroutine: None,
+        lazy_pipe: None,
+        closure_seq: None,
+        walk_pending: None,
+        cat_pull: None,
+    });
+    match roundtrip(ValueRepr::LazyList(node.clone())) {
+        ValueRepr::LazyList(back) => assert!(Gc::ptr_eq(&back, &node)),
+        other => panic!("decoded as {other:?}"),
+    }
+    assert_eq!(node.strong_count(), 1);
+}
+
+#[test]
+fn promise_and_channel_roundtrip_sharing_state() {
+    let p = SharedPromise::new();
+    let b = NanBox::from_repr(ValueRepr::Promise(p.clone()));
+    match b.into_repr() {
+        ValueRepr::Promise(back) => {
+            back.keep(Value::int(42), String::new(), String::new());
+            assert_eq!(p.status(), "Kept", "decoded promise shares state");
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+
+    let c = SharedChannel::new();
+    let b = NanBox::from_repr(ValueRepr::Channel(c.clone()));
+    match b.into_repr() {
+        ValueRepr::Channel(back) => {
+            back.send(Value::int(7));
+            assert!(matches!(c.receive_result(), Ok(Value(ValueRepr::Int(7)))));
+        }
+        other => panic!("decoded as {other:?}"),
+    }
+}
+
+#[test]
+fn debug_matches_the_repr_debug() {
+    let b = NanBox::from_repr(ValueRepr::Pair("k".to_string(), Box::new(Value::int(1))));
+    assert_eq!(
+        format!("{b:?}"),
+        format!(
+            "{:?}",
+            ValueRepr::Pair("k".to_string(), Box::new(Value::int(1)))
+        )
+    );
+}


### PR DESCRIPTION
## Summary

Kicks off **3b-1 step B** (the `Value` 48B→8B representation flip, [ADR-0005](docs/adr/0005-nanbox-representation-encoding.md) Accepted 2026-07-12) by landing the packed representation core as an **unwired, fully-tested module** — `src/value/nanbox/` — plus the design doc that fixes every decision the ADR deferred to implementation time ([docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md)).

### What's in the module

- `NanBox` (`NonZeroU64`, 8 bytes, `Option<Value>` niche preserved) with **lossless bidirectional conversion** to/from the existing 48B `ValueRepr` enum for **all 54 variants**, plus `Clone`/`Drop`.
- Bit layout: page `0x0001` = inline 48-bit Int; pages `0x0002..0xFFF2` = offset-encoded f64 (NaN canonicalized to +qNaN — negative-NaN pages would collide with the kind space); pages `0xFFF3..0xFFFF` = 104 kind slots (66 used), subkind in the pointer's alignment bits on 64-bit targets (deref = one AND), bits 40..43 on wasm32.
- Companion fields ride the tag (`ArrayKind`, Hash itemization, Set/Bag/Mix mutability, `JunctionKind`); `Instance` packs as its `Gc<InstanceAttrs>` pointer alone (class_name/id read back from the pointee — invariant guaranteed by `instance_sharing_cell`, debug-asserted at pack); out-of-range i64 boxes as `Arc<i64>` and still decodes to `Int` (no BigInt coupling).
- `Clone`/`Drop` reconstruct the smart pointers and call their own clone/drop, so **all Bacon-Rajan GC bookkeeping is preserved verbatim** (survivor-buffering, finalize/DESTROY, buffered-bit dedup). Raw round-trips use `expose_provenance`, so `cargo miri test value::nanbox` is meaningful.

### Design finding recorded

ADR-0005 hoped pointer-favored encoding would let `view()` keep `&'a Arc<T>` fields via transmute. That cannot hold: several variants share a pointee type (`Str`/`Regex` = `Arc<String>`; `Seq`/`HyperSeq`/`RaceSeq`/`Slip`/`Junction` = `Arc<Vec<Value>>`), so the tag must live in the word and the view must use the **guard types** the wall kept as its documented exit (`ValueView` is already deliberately non-`Copy`). The rest of the pointer-favored rationale stands.

### Remaining campaign slices (design doc §4)

1. **B-wall-in** — migrate the 866 internal `src/value/` `ValueRepr::` pattern sites onto `view()`/`into_repr()`/`with_*_mut` (byte-identical, multiple mechanical PRs)
2. **B-guards** — `ValueView` pointer fields → `ArcRef`/`GcRef`
3. **B-flip** — `Value(ValueRepr)` → `Value(NanBox)`, `value_size_guard` 48→8, bench gates (int-arith 2x, fib +30%, GC counters invariant)

### Support changes

`Gc`/`WeakGc::{into_raw,from_raw}` (`gc_ptr.rs`), `GcBox` re-export, `Symbol::from_id`.

## Test plan

- 15 new unit tests: exhaustive per-variant lossless round-trips (Debug-compared), pointer identity (`Arc::ptr_eq`/`Gc::ptr_eq`), Arc **and** Gc-header refcount neutrality across clone/drop, weak expiry, promise/channel state sharing, f64 edge cases (±0, subnormal, ±Inf, NaN canonicalization), int boundary (±2^47), size/niche guards, exhaustive kind-tag round-trip.
- `make test` green locally (16423 tests); no production code path touches the module yet (`#[allow(dead_code)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)