### PR TITLE
perf(dispatch): pre-interned method symbols + FxHash registry maps (PLAN §5 symbol follow-ups)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -227,13 +227,6 @@ method-call ホットパスキャンペーン第 1 弾（#3853/#3857/#3859/#3867
 resolution cache・mro_readonly キャッシュ・FxHashMap・単一候補 memoize）と、単一ストア化による
 per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 
-- [ ] **symbol 残コスト（小）**: round-trip 本体は解消済み（2026-07-12 — intern 文字列を leak して
-      `Symbol::as_str() -> &'static str`（ロックなし・alloc なし）を導入、dispatch hot path の
-      String 確保＋再 intern を除去。method-call -6% cycles。旧記述の「registry/dispatch API の
-      Symbol キー化（大型リファクタ）」は前提のデッドロック制約ごと消滅＝不要。news/2026-07.md 参照）。
-      残る小レバー: `Symbol::intern(method)`（flat ~0.8% — CompiledCode 定数の事前 intern は
-      serde skip＋lazy 側テーブルなら precomp 直列化に波及しない）／ registry String キーの
-      SipHash（cache-miss 時のみ）。
 - [ ] `Value` clone/drop（bench-class の ~50%）＋ `attributes.to_map()` の毎回クローン ＋
       `call_compiled_method` の属性キー `format!` ＋ instance 構築 HashMap ＋ `merge_method_env` —
       Lever 2（NaN-boxing・GC 後）待ち、ないし属性 materialization の作り直し（深い）。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -1326,6 +1326,25 @@ Symbol キー化ではなく **intern 文字列の leak** で解消した。symb
   CompiledCode 定数の事前 intern（serde skip＋lazy 側テーブルなら precomp 直列化に波及しない）と
   registry String キーの SipHash は別個の小レバーとして残置。
 
+## 2026-07-12: symbol 残レバー 2 件も完了 — method 名の per-call intern 除去＋registry FxHash 化
+
+上記エントリの「残置」2 レバーを同日中に回収（PLAN §5 の symbol 項目はこれで完了・削除）:
+
+- **method 名の事前 intern**: `CompiledCode` に定数プール並置の lazy Symbol 側テーブル
+  （`const_syms: OnceLock<Box<[OnceLock<Symbol>]>>`＋`const_sym(idx)`）を追加。
+  `CallMethod`/`CallMethodMut` opcode が method Symbol を定数スロットから 1 回で確定し
+  （`^`/`!` modifier で書き換えた名前のみ intern）、新設の `try_compiled_method_or_interpret_sym`/
+  `try_compiled_method_mut_or_interpret_sym` 経由で prelude まで通す。per-call の
+  `Symbol::intern`（TLS ハッシュ lookup）が Vec index に置き換わる。
+  **precomp 直列化への波及は無かった**: `CompiledCode` は serde 非対応（precomp キャッシュは
+  AST を保存）なので、旧 PLAN の懸念は前提から誤りだった。
+- **registry の FxHash 化**: `Registry` の全 map/set（~40 フィールド）を
+  `FxHashMap`/`FxHashSet` に切替（ファイル内 alias で宣言は不変更・外部シグネチャ ~10 箇所調整）。
+  registry キーはプログラム識別子で attacker-controlled でないため HashDoS 硬化は不要。
+- **計測**（release・P-core 固定・`perf stat -r 5`・#4441 バイナリ比）:
+  method-call **-2.7% cycles / -5.5% instructions**（880M→856M / 2403M→2271M）、
+  bench-class **-2.2% cycles**（2995M→2928M）。
+
 ## 参考
 
 - whitelist は本稿執筆時点で **1338**（2026-07-01、`4c311c71` 時点）。

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1735,6 +1735,10 @@ pub(crate) struct CompiledCode {
     /// avoid leaking a callee's env-only `my` back into a same-named caller
     /// lexical across (self-)recursion. Populated by `compute_needs_env_sync`.
     pub(crate) env_only_decls: Vec<String>,
+    /// Lazily-built `Symbol` per constant-pool slot (see `const_sym`). Sized on
+    /// first use; each slot interns on first access. Cloning a chunk clones the
+    /// already-resolved entries (cheap: `Symbol` is a `u32`).
+    pub(crate) const_syms: std::sync::OnceLock<Box<[std::sync::OnceLock<Symbol>]>>,
 }
 
 impl CompiledCode {
@@ -1778,6 +1782,30 @@ impl CompiledCode {
             sub_fingerprints: std::collections::HashMap::new(),
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
+            const_syms: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// The `Symbol` for the string constant at `idx`, interned once per slot
+    /// via a lazily-built side table. Keeps `Symbol::intern` (a thread-local
+    /// hash lookup) off the per-call dispatch path: method names are string
+    /// constants that would otherwise be re-interned on every `CallMethod`.
+    pub(crate) fn const_sym(&self, idx: u32) -> Symbol {
+        let resolve = |i: usize| match self.constants[i].view() {
+            ValueView::Str(s) => Symbol::intern(s.as_str()),
+            _ => unreachable!("expected string constant"),
+        };
+        let slots = self.const_syms.get_or_init(|| {
+            (0..self.constants.len())
+                .map(|_| std::sync::OnceLock::new())
+                .collect()
+        });
+        match slots.get(idx as usize) {
+            Some(slot) => *slot.get_or_init(|| resolve(idx as usize)),
+            // A constant appended after the table was sized (compile-time
+            // chunks are finalized before execution, so this is defensive):
+            // fall back to a plain intern.
+            None => resolve(idx as usize),
         }
     }
 

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -831,7 +831,7 @@ impl Interpreter {
     pub(crate) fn class_role_param_bindings(
         &self,
         class_name: &str,
-    ) -> Option<HashMap<String, Value>> {
+    ) -> Option<rustc_hash::FxHashMap<String, Value>> {
         self.registry()
             .class_role_param_bindings
             .get(class_name)

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -246,7 +246,7 @@ impl Interpreter {
     }
 
     pub(crate) fn remove_leaked_main_routines(
-        functions: &mut HashMap<Symbol, std::sync::Arc<FunctionDef>>,
+        functions: &mut rustc_hash::FxHashMap<Symbol, std::sync::Arc<FunctionDef>>,
         before_keys: &std::collections::HashSet<Symbol>,
         main_exported: bool,
     ) {

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -716,46 +716,47 @@ impl Interpreter {
                     |a| matches!(a.view(), ValueView::Pair(k, v) if k == "local" && v.truthy()),
                 );
                 // Check direct composed roles and transitive sub-roles
-                let check_transitive = |class_composed: &HashMap<String, Vec<String>>,
-                                        role_parents: &HashMap<String, Vec<String>>,
-                                        cn: &str|
-                 -> Option<Value> {
-                    let composed = class_composed.get(cn).cloned().unwrap_or_default();
-                    // Check direct matches
-                    for cr in &composed {
-                        let cr_base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
-                        if *cr == role_name || cr_base == base_role_name {
-                            return Some(Value::package(Symbol::intern(cr_base)));
-                        }
-                    }
-                    // Check transitive sub-roles
-                    let mut stack: Vec<String> = composed
-                        .iter()
-                        .map(|cr| {
-                            cr.split_once('[')
-                                .map(|(b, _)| b)
-                                .unwrap_or(cr.as_str())
-                                .to_string()
-                        })
-                        .collect();
-                    let mut seen = std::collections::HashSet::new();
-                    while let Some(rn) = stack.pop() {
-                        if !seen.insert(rn.clone()) {
-                            continue;
-                        }
-                        if let Some(rp) = role_parents.get(&rn) {
-                            for p in rp {
-                                let p_base =
-                                    p.split_once('[').map(|(b, _)| b).unwrap_or(p.as_str());
-                                if p_base == base_role_name || *p == role_name {
-                                    return Some(Value::package(Symbol::intern(p_base)));
-                                }
-                                stack.push(p_base.to_string());
+                let check_transitive =
+                    |class_composed: &rustc_hash::FxHashMap<String, Vec<String>>,
+                     role_parents: &rustc_hash::FxHashMap<String, Vec<String>>,
+                     cn: &str|
+                     -> Option<Value> {
+                        let composed = class_composed.get(cn).cloned().unwrap_or_default();
+                        // Check direct matches
+                        for cr in &composed {
+                            let cr_base = cr.split_once('[').map(|(b, _)| b).unwrap_or(cr.as_str());
+                            if *cr == role_name || cr_base == base_role_name {
+                                return Some(Value::package(Symbol::intern(cr_base)));
                             }
                         }
-                    }
-                    None
-                };
+                        // Check transitive sub-roles
+                        let mut stack: Vec<String> = composed
+                            .iter()
+                            .map(|cr| {
+                                cr.split_once('[')
+                                    .map(|(b, _)| b)
+                                    .unwrap_or(cr.as_str())
+                                    .to_string()
+                            })
+                            .collect();
+                        let mut seen = std::collections::HashSet::new();
+                        while let Some(rn) = stack.pop() {
+                            if !seen.insert(rn.clone()) {
+                                continue;
+                            }
+                            if let Some(rp) = role_parents.get(&rn) {
+                                for p in rp {
+                                    let p_base =
+                                        p.split_once('[').map(|(b, _)| b).unwrap_or(p.as_str());
+                                    if p_base == base_role_name || *p == role_name {
+                                        return Some(Value::package(Symbol::intern(p_base)));
+                                    }
+                                    stack.push(p_base.to_string());
+                                }
+                            }
+                        }
+                        None
+                    };
                 if let Some(result) = check_transitive(
                     &self.registry().class_composed_roles,
                     &self.registry().role_parents,

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -142,7 +142,7 @@ impl Interpreter {
             _ => value_type_name(invocant).to_string(),
         };
         // Collect hidden parent names for this class
-        let hidden_parents: HashSet<String> = self
+        let hidden_parents: rustc_hash::FxHashSet<String> = self
             .registry()
             .hidden_defer_parents
             .get(&class_name)

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -306,7 +306,7 @@ impl Interpreter {
         // carries `__mutsu_role__X` / `__mutsu_attr__X` keys; overlay them onto
         // the attribute value so `$o.attr.VAR does Role` (and the role's
         // accessors) resolve on the instance.
-        let container_mixins: Vec<(String, Vec<HashMap<String, Value>>)> = self
+        let container_mixins: Vec<(String, Vec<rustc_hash::FxHashMap<String, Value>>)> = self
             .registry()
             .class_attribute_container_mixins
             .iter()

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -226,7 +226,7 @@ impl Interpreter {
                                 .get(qualifier)
                                 .cloned();
                             {
-                                let bindings: std::collections::HashMap<String, Value> =
+                                let bindings: rustc_hash::FxHashMap<String, Value> =
                                     tparams.iter().cloned().zip(tvals.iter().cloned()).collect();
                                 self.registry_mut()
                                     .class_role_param_bindings

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1885,12 +1885,12 @@ pub(crate) struct SubtestContext {
 }
 
 pub(crate) type RoutineRegistrySnapshot = (
-    HashMap<Symbol, Arc<FunctionDef>>,
-    HashMap<Symbol, Arc<FunctionDef>>,
-    HashMap<Symbol, Vec<Arc<FunctionDef>>>,
-    HashSet<String>,
-    HashSet<String>,
-    HashSet<Symbol>,
+    rustc_hash::FxHashMap<Symbol, Arc<FunctionDef>>,
+    rustc_hash::FxHashMap<Symbol, Arc<FunctionDef>>,
+    rustc_hash::FxHashMap<Symbol, Vec<Arc<FunctionDef>>>,
+    rustc_hash::FxHashSet<String>,
+    rustc_hash::FxHashSet<String>,
+    rustc_hash::FxHashSet<Symbol>,
 );
 
 pub(crate) type ImportScopeSnapshot = (

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -600,7 +600,8 @@ impl Interpreter {
         let mut direct_composed_roles: Vec<String> = Vec::new();
         let mut punned_roles = Vec::new();
         let mut hidden_punned_role_bases: HashSet<String> = HashSet::new();
-        let mut class_role_param_bindings: HashMap<String, Value> = HashMap::new();
+        let mut class_role_param_bindings: rustc_hash::FxHashMap<String, Value> =
+            rustc_hash::FxHashMap::default();
         for parent in parents {
             let resolved_parent_name = self.resolve_declared_type_name(parent);
             let base_role_name = resolved_parent_name

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -24,7 +24,12 @@
 //! Always use a *temporary* guard (`self.registry().subsets.get(..)`), never a
 //! `let`-bound guard that lives across such a call.
 
-use std::collections::{HashMap, HashSet};
+// Registry maps are String-keyed and hit on dispatch cache-miss paths; use
+// FxHash instead of SipHash (registry keys are program identifiers, not
+// attacker-controlled data, so HashDoS hardening buys nothing here). The
+// `HashMap`/`HashSet` names are aliased so the ~40 field declarations below
+// stay textually unchanged.
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::ast::FunctionDef;
 use crate::symbol::Symbol;

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -16,7 +16,7 @@ impl Interpreter {
         class_name: &str,
         def: &MethodDef,
         arg_values: &[Value],
-        role_bindings: Option<&HashMap<String, Value>>,
+        role_bindings: Option<&rustc_hash::FxHashMap<String, Value>>,
         invocant: Option<&Value>,
     ) -> bool {
         let saved_env = self.env.clone();

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -66,7 +66,7 @@ impl Interpreter {
             "*SCHEDULER".to_string(),
             Value::make_instance(Symbol::intern("ThreadPoolScheduler"), HashMap::new()),
         );
-        let mut classes = HashMap::new();
+        let mut classes = rustc_hash::FxHashMap::default();
         classes.insert(
             "Mu".to_string(),
             ClassDef {
@@ -1858,7 +1858,7 @@ impl Interpreter {
                 // Built-in role definitions (PR-A slice 4: roles now live in the
                 // shared Registry instead of an Interpreter field).
                 registry.roles = {
-                    let mut roles = HashMap::new();
+                    let mut roles = rustc_hash::FxHashMap::default();
                     roles.insert(
                         "Encoding".to_string(),
                         RoleDef {

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -7,8 +7,24 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        self.try_compiled_method_or_interpret_sym(
+            target,
+            crate::symbol::Symbol::intern(method),
+            args,
+        )
+    }
+
+    /// Symbol-keyed entry: callers that already hold the method name as an
+    /// interned `Symbol` (the CallMethod opcode via `CompiledCode::const_sym`)
+    /// use this to keep the per-call `Symbol::intern` off the dispatch path.
+    pub(super) fn try_compiled_method_or_interpret_sym(
+        &mut self,
+        target: Value,
+        method_sym: crate::symbol::Symbol,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
         let saved_self = self.get_env_with_main_alias("self");
-        let result = self.try_compiled_method_or_interpret_inner(target, method, args);
+        let result = self.try_compiled_method_or_interpret_inner(target, method_sym, args);
         match saved_self {
             Some(s) => self.set_env_with_main_alias("self", s),
             None => {
@@ -21,9 +37,10 @@ impl Interpreter {
     fn try_compiled_method_or_interpret_inner(
         &mut self,
         target: Value,
-        method: &str,
+        method_sym: crate::symbol::Symbol,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        let method: &str = method_sym.as_str();
         // Native default construction: `Foo.new(...)` for a simple user-defined
         // class is pure data assembly (named args + attribute defaults), so the
         // Interpreter builds the instance directly instead of routing through the
@@ -405,7 +422,6 @@ impl Interpreter {
         };
         if let Some(class_sym) = class_sym_opt {
             let cn = class_sym.as_str();
-            let method_sym = crate::symbol::Symbol::intern(method);
             let cache_key = (class_sym, method_sym);
 
             // Fast method dispatch cache: skip wrap chain check, compiled_code

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -1,13 +1,15 @@
 use super::*;
 
 impl Interpreter {
-    pub(super) fn try_compiled_method_mut_or_interpret(
+    /// Symbol-keyed entry (see `try_compiled_method_or_interpret_sym`).
+    pub(super) fn try_compiled_method_mut_or_interpret_sym(
         &mut self,
         target_name: &str,
         target: Value,
-        method: &str,
+        method_sym: crate::symbol::Symbol,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        let method: &str = method_sym.as_str();
         // Native default construction (see `try_compiled_method_or_interpret`).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
@@ -335,10 +337,8 @@ impl Interpreter {
         let class_name = class_sym_opt.map(|s| s.as_str());
         if let Some(cn) = class_name
             && let Some(class_sym) = class_sym_opt
-            && let Some((owner_class, method_def)) = {
-                let method_sym = crate::symbol::Symbol::intern(method);
+            && let Some((owner_class, method_def)) =
                 self.resolve_method_cached(cn, method, class_sym, method_sym, &args, &target)
-            }
         {
             // Ambiguous multi dispatch: two or more candidates matched equally
             // well. Raise X::Multi::Ambiguous instead of silently picking one.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -391,6 +391,12 @@ impl Interpreter {
         let target_name = Self::const_str(code, target_name_idx).to_string();
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let method = Self::rewrite_method_name(method_raw, modifier);
+        // Interned once per call: the unrewritten name comes from the per-chunk
+        // constant-symbol table, so the hot path pays no re-intern.
+        let method_sym = match modifier {
+            Some("^") | Some("!") => crate::symbol::Symbol::intern(&method),
+            _ => code.const_sym(name_idx),
+        };
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
             return Err(RuntimeError::new(
@@ -674,10 +680,10 @@ impl Interpreter {
                     self.maybe_autothread_method_args(v, &method, &args)?
                 {
                     threaded
-                } else if let Some(nr) = self.try_native_method(v, Symbol::intern(&method), &args) {
+                } else if let Some(nr) = self.try_native_method(v, method_sym, &args) {
                     nr?
                 } else {
-                    self.try_compiled_method_or_interpret(v.clone(), &method, args.clone())?
+                    self.try_compiled_method_or_interpret_sym(v.clone(), method_sym, args.clone())?
                 };
                 results.push(r);
                 let pending: Vec<String> = self
@@ -1071,14 +1077,14 @@ impl Interpreter {
                         crate::value::ArrayKind::List,
                     );
                     let call_result = if let Some(native_result) =
-                        self.try_native_method(&array_target, Symbol::intern(&method), &args)
+                        self.try_native_method(&array_target, method_sym, &args)
                     {
                         native_result
                     } else {
-                        self.try_compiled_method_mut_or_interpret(
+                        self.try_compiled_method_mut_or_interpret_sym(
                             &target_name,
                             array_target,
-                            &method,
+                            method_sym,
                             args,
                         )
                     };
@@ -1714,8 +1720,7 @@ impl Interpreter {
                         // rw view into, nor a mutation of, the source), so the
                         // by-value `&storage` borrow is correct for the instance.
                         if Self::is_array_storage_native_safe(&method)
-                            && let Some(r) =
-                                self.try_native_method(&storage, Symbol::intern(&method), &args)
+                            && let Some(r) = self.try_native_method(&storage, method_sym, &args)
                         {
                             self.stack.push(r?);
                             return Ok(());
@@ -1778,7 +1783,7 @@ impl Interpreter {
                     };
                     let dispatch_target = effective_target.as_ref().unwrap_or(&target);
                     if let Some(native_result) =
-                        self.try_native_method(dispatch_target, Symbol::intern(&method), &args)
+                        self.try_native_method(dispatch_target, method_sym, &args)
                     {
                         // A native method reaching this tail returns a value and
                         // does not write the receiver back into env (mutating
@@ -1788,15 +1793,20 @@ impl Interpreter {
                         self.method_dispatch_pure = true;
                         native_result
                     } else {
-                        self.try_compiled_method_mut_or_interpret(
+                        self.try_compiled_method_mut_or_interpret_sym(
                             &target_name,
                             target,
-                            &method,
+                            method_sym,
                             args,
                         )
                     }
                 } else {
-                    self.try_compiled_method_mut_or_interpret(&target_name, target, &method, args)
+                    self.try_compiled_method_mut_or_interpret_sym(
+                        &target_name,
+                        target,
+                        method_sym,
+                        args,
+                    )
                 };
                 match modifier {
                     Some("?") => match call_result {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -337,6 +337,12 @@ impl Interpreter {
         let modifier = modifier_idx.map(|idx| Self::const_str(code, idx));
         let method_cow = Self::rewrite_method_name_cow(method_raw, modifier);
         let method = &*method_cow;
+        // Interned once per call: the unmodified (borrowed) name comes from the
+        // per-chunk constant-symbol table, so the hot path pays no re-intern.
+        let method_sym = match &method_cow {
+            std::borrow::Cow::Borrowed(_) => code.const_sym(name_idx),
+            std::borrow::Cow::Owned(m) => crate::symbol::Symbol::intern(m),
+        };
         let arity = arity as usize;
         if self.stack.len() < arity + 1 {
             return Err(RuntimeError::new(
@@ -565,10 +571,10 @@ impl Interpreter {
                     self.maybe_autothread_method_args(v, method, &args)?
                 {
                     threaded
-                } else if let Some(nr) = self.try_native_method(v, Symbol::intern(method), &args) {
+                } else if let Some(nr) = self.try_native_method(v, method_sym, &args) {
                     nr?
                 } else {
-                    self.try_compiled_method_or_interpret(v.clone(), method, args.clone())?
+                    self.try_compiled_method_or_interpret_sym(v.clone(), method_sym, args.clone())?
                 };
                 results.push(r);
                 let pending: Vec<String> = self
@@ -1216,15 +1222,18 @@ impl Interpreter {
                         // (the actual mutation is handled in the mut path)
                         if !skip_native
                             && let Some(native_result) =
-                                self.try_native_method(&storage, Symbol::intern(method), &args)
+                                self.try_native_method(&storage, method_sym, &args)
                         {
                             // Native method on the by-value backing storage is
                             // env-pure: no env_dirty mark needed.
                             self.stack.push(native_result?);
                             return Ok(());
                         }
-                        let result =
-                            self.try_compiled_method_or_interpret(storage, method, args.clone());
+                        let result = self.try_compiled_method_or_interpret_sym(
+                            storage,
+                            method_sym,
+                            args.clone(),
+                        );
                         if let Ok(val) = result {
                             self.stack.push(val);
                             return Ok(());
@@ -1302,7 +1311,7 @@ impl Interpreter {
                             let msg = "Use of Nil in numeric context".to_string();
                             return Err(RuntimeError::warn_signal_with_resume(
                                 msg,
-                                Value::package(Symbol::intern(method)),
+                                Value::package(method_sym),
                             ));
                         }
                         // `Nil.ords` warns ("Use of Nil in string context") and
@@ -1418,7 +1427,7 @@ impl Interpreter {
                     {
                         let resolved = self.resolve_hash_for_iteration(items);
                         if let Some(native_result) =
-                            self.try_native_method(&resolved, Symbol::intern(method), &args)
+                            self.try_native_method(&resolved, method_sym, &args)
                         {
                             let result = native_result;
                             // Native method on a by-value resolved hash is env-pure
@@ -1460,25 +1469,25 @@ impl Interpreter {
                             self.method_dispatch_pure = true;
                             Ok(Value::slip(converted))
                         } else if let Some(native_result) =
-                            self.try_native_method(&target, Symbol::intern(method), &args)
+                            self.try_native_method(&target, method_sym, &args)
                         {
                             // Native method on a by-value (read) target: env-pure.
                             self.method_dispatch_pure = true;
                             native_result
                         } else {
-                            self.try_compiled_method_or_interpret(target, method, args)
+                            self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                         }
                     } else if let Some(native_result) =
-                        self.try_native_method(&target, Symbol::intern(method), &args)
+                        self.try_native_method(&target, method_sym, &args)
                     {
                         // Native method on a by-value (read) target: env-pure.
                         self.method_dispatch_pure = true;
                         native_result
                     } else {
-                        self.try_compiled_method_or_interpret(target, method, args)
+                        self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                     }
                 } else {
-                    self.try_compiled_method_or_interpret(target, method, args)
+                    self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                 };
                 // Slice 6.3: mark env dirty only when the dispatch was not a
                 // proven-pure compiled method call.

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -263,7 +263,7 @@ impl Interpreter {
         };
         // Drop the sentinel descriptor's own tag keys; keep only the role/
         // attribute mixin keys that apply to a real attribute value.
-        let clean: std::collections::HashMap<String, Value> = overrides
+        let clean: rustc_hash::FxHashMap<String, Value> = overrides
             .iter()
             .filter(|(k, _)| !k.starts_with("__mutsu_attr_container_"))
             .map(|(k, v)| (k.clone(), v.clone()))


### PR DESCRIPTION
## Summary

The two small levers left after #4441, closing out the PLAN §5 symbol item:

### 1. Per-call `Symbol::intern(method)` removed from CallMethod/CallMethodMut

`CompiledCode` now carries a lazily-built per-constant Symbol side table (`const_syms` + `const_sym(idx)`). The CallMethod/CallMethodMut opcodes resolve the method Symbol once from the constant slot (interning only for `^`/`!` modifier-rewritten names) and pass it through new `try_compiled_method_or_interpret_sym` / `try_compiled_method_mut_or_interpret_sym` entries down to the dispatch prelude — a Vec index instead of a thread-local hash lookup per call. The same Symbol also feeds `try_native_method`, removing a second per-call intern on the mainline.

No precomp impact: `CompiledCode` is not serialized (the precomp cache stores AST), so the PLAN's serialization concern turned out to be moot.

### 2. Registry maps: SipHash → FxHash

All ~40 `Registry` maps/sets switch to `FxHashMap`/`FxHashSet` (in-file alias keeps the field declarations unchanged; ~10 external signatures adjusted). Registry keys are program identifiers, not attacker-controlled data, so HashDoS hardening buys nothing on these cache-miss lookup paths.

### Measurements (release, P-core pinned, `perf stat -r 5`, vs the #4441 binary)

| bench | #4441 | this PR | delta |
|---|---|---|---|
| method-call cycles | 880M | 856M | **-2.7%** |
| method-call instructions | 2403M | 2271M | **-5.5%** |
| bench-class cycles | 2995M | 2928M | **-2.2%** |

### Testing

- `make test`: 16418 PASS; `gc_stress` 16 PASS
- Whitelisted dispatch-heavy roast (S12 class/methods, S14 roles, S02 perl.t) + S17 start / t/lock.t: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni