### PR TITLE
refactor(value): internal-wall seam APIs + exemplar migrations (3b-1 B-wall-in slice 1)

### DIFF
--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use super::ValueRepr;
+use super::ValueView;
 use crate::symbol::Symbol;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -290,7 +290,7 @@ impl RuntimeError {
     /// Check if this error represents an X::CompUnit::UnsatisfiedDependency error.
     pub(crate) fn is_unsatisfied_dependency(&self) -> bool {
         if let Some(ref ex) = self.exception
-            && let Value(ValueRepr::Instance { class_name, .. }) = ex.as_ref()
+            && let ValueView::Instance { class_name, .. } = ex.view()
         {
             return class_name.resolve() == "X::CompUnit::UnsatisfiedDependency";
         }
@@ -300,7 +300,7 @@ impl RuntimeError {
     /// Check if this error represents a method-not-found error.
     pub(crate) fn is_method_not_found(&self) -> bool {
         if let Some(ref ex) = self.exception
-            && let Value(ValueRepr::Instance { class_name, .. }) = ex.as_ref()
+            && let ValueView::Instance { class_name, .. } = ex.view()
         {
             return class_name.resolve() == "X::Method::NotFound";
         }
@@ -314,7 +314,7 @@ impl RuntimeError {
     /// whether to fall back to a default candidate (e.g. `Mu.new`).
     pub(crate) fn is_multi_no_match(&self) -> bool {
         if let Some(ref ex) = self.exception
-            && let Value(ValueRepr::Instance { class_name, .. }) = ex.as_ref()
+            && let ValueView::Instance { class_name, .. } = ex.view()
         {
             return class_name.resolve() == "X::Multi::NoMatch";
         }
@@ -325,7 +325,7 @@ impl RuntimeError {
     /// Create a RuntimeError from an exception Value.
     /// Extracts the message from the exception's attributes and wraps it.
     pub(crate) fn from_exception_value(ex: Value) -> Self {
-        let msg = if let Value(ValueRepr::Instance { attributes, .. }) = &ex {
+        let msg = if let ValueView::Instance { attributes, .. } = ex.view() {
             attributes
                 .as_map()
                 .get("message")

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -1,7 +1,8 @@
 //! `RuntimeError` constructors for declaration/syntax/typecheck errors,
 //! plus JSON exception rendering (`to_json_exception`).
+use super::ValueView;
 use super::expected_type_object;
-use super::{RuntimeError, Value, ValueRepr};
+use super::{RuntimeError, Value};
 use std::collections::HashMap;
 
 impl RuntimeError {
@@ -433,12 +434,12 @@ impl RuntimeError {
     /// `message` key (null when the exception has no message attribute).
     pub fn to_json_exception(&self) -> String {
         let (class_name, attrs): (String, HashMap<String, Value>) = match &self.exception {
-            Some(boxed) => match boxed.as_ref() {
-                Value(ValueRepr::Instance {
+            Some(boxed) => match boxed.view() {
+                ValueView::Instance {
                     class_name,
                     attributes,
                     ..
-                }) => (
+                } => (
                     class_name.resolve(),
                     attributes
                         .as_map()
@@ -446,9 +447,9 @@ impl RuntimeError {
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
                 ),
-                other => ("X::AdHoc".to_string(), {
+                _ => ("X::AdHoc".to_string(), {
                     let mut m = HashMap::new();
-                    m.insert("message".to_string(), Value::str(other.to_string_value()));
+                    m.insert("message".to_string(), Value::str(boxed.to_string_value()));
                     m
                 }),
             },
@@ -503,23 +504,23 @@ fn json_string(s: &str) -> String {
 
 /// Encode a runtime Value as a JSON value for the exception handler.
 fn json_value(v: &Value) -> String {
-    match v {
-        Value(ValueRepr::Nil) => "null".to_string(),
-        Value(ValueRepr::Bool(b)) => b.to_string(),
-        Value(ValueRepr::Int(n)) => n.to_string(),
-        Value(ValueRepr::Num(f)) => {
+    match v.view() {
+        ValueView::Nil => "null".to_string(),
+        ValueView::Bool(b) => b.to_string(),
+        ValueView::Int(n) => n.to_string(),
+        ValueView::Num(f) => {
             if f.is_finite() {
                 f.to_string()
             } else {
                 "null".to_string()
             }
         }
-        Value(ValueRepr::Str(s)) => json_string(s),
-        Value(ValueRepr::Array(items, _)) => {
+        ValueView::Str(s) => json_string(s),
+        ValueView::Array(items, _) => {
             let elems: Vec<String> = items.iter().map(json_value).collect();
             format!("[{}]", elems.join(","))
         }
-        Value(ValueRepr::Hash(map, _)) => {
+        ValueView::Hash(map) => {
             let mut keys: Vec<&String> = map.keys().collect();
             keys.sort();
             let pairs: Vec<String> = keys
@@ -528,6 +529,6 @@ fn json_value(v: &Value) -> String {
                 .collect();
             format!("{{{}}}", pairs.join(","))
         }
-        other => json_string(&other.to_string_value()),
+        _ => json_string(&v.to_string_value()),
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1177,6 +1177,46 @@ impl Value {
     }
 }
 
+/// The 3b-1 step-B **internal wall** seam (see
+/// `docs/nanbox-3b1-step-b-design.md` §4). `src/value/` code that today names
+/// `ValueRepr::` in a *place* expression — a pattern on `.0`, a `&mut` into the
+/// enum — migrates onto these three entry points (or `view()` for borrowed
+/// reads), because after the representation flip there is no enum place to
+/// borrow: the storage is a packed 8-byte word. While the enum IS the storage
+/// these are identities, so each migration slice is byte-identical.
+///
+/// `ValueRepr` itself survives the flip as the transient *working* enum:
+/// naming it in owned expressions (constructing one to pass to `from_repr`,
+/// matching one returned by `into_repr`) stays valid forever.
+impl Value {
+    /// Decompose into the working representation enum (owned decode seam).
+    /// Post-flip: the NaN-box tag decode; pointer payloads move (no refcount
+    /// traffic), shared multi-field boxes clone field-wise.
+    #[inline]
+    pub(in crate::value) fn into_repr(self) -> ValueRepr {
+        self.0
+    }
+
+    /// Rebuild from the working representation enum (construction seam for
+    /// struct-like variants; tuple/unit variants keep their named shims
+    /// below). Post-flip: the NaN-box tag-packing encode.
+    #[inline]
+    pub(in crate::value) fn from_repr(repr: ValueRepr) -> Value {
+        Value(repr)
+    }
+
+    /// Edit the representation in place (mutation seam). Post-flip: decode to
+    /// the working enum, run `f`, re-pack — so `f` must not assume its edits
+    /// alias other holders (none of the migrated sites do; aliased container
+    /// mutation goes through the pointee, not the repr). Unused until the
+    /// `&mut`-shaped sites migrate (the exemplar batch had none).
+    #[inline]
+    #[allow(dead_code)]
+    pub(in crate::value) fn with_repr_mut<R>(&mut self, f: impl FnOnce(&mut ValueRepr) -> R) -> R {
+        f(&mut self.0)
+    }
+}
+
 /// Variant-named constructor shims for the tuple/unit variants of
 /// [`ValueRepr`], so the `Value::Int(..)` / `Value::Nil` *expression* sites
 /// inside `src/value/` compile unchanged across the newtype seal (patterns

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -113,9 +113,9 @@ impl HashData {
     /// a single scalar item). See t/bind-hash-value-pairs.t.
     pub fn typed_pair(&self, str_key: &str, value: Value) -> Value {
         let value = value.deref_container();
-        match self.typed_key(str_key) {
-            Value(ValueRepr::Str(s)) => Value::Pair((*s).clone(), Box::new(value)),
-            other => Value::ValuePair(Box::new(other), Box::new(value)),
+        match self.typed_key(str_key).into_repr() {
+            ValueRepr::Str(s) => Value::Pair((*s).clone(), Box::new(value)),
+            other => Value::ValuePair(Box::new(Value::from_repr(other)), Box::new(value)),
         }
     }
 }

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -69,7 +69,7 @@ impl Clone for InstanceAttrs {
         // independent copy must own distinct containers (rakudo `.clone`
         // clones each `has` container too).
         for v in map.values_mut() {
-            if let Value(ValueRepr::ContainerRef(cell)) = v {
+            if let ValueView::ContainerRef(cell) = v.view() {
                 let inner = cell.lock().unwrap().clone();
                 *v = inner;
             }
@@ -183,8 +183,10 @@ impl InstanceAttrs {
     pub(crate) fn promote_attr_to_container(&self, key: &str) -> Value {
         let mut guard = write_attrs(&self.attributes);
         match guard.get_mut(key) {
-            Some(Value(ValueRepr::ContainerRef(cell))) => Value::ContainerRef(cell.clone()),
             Some(slot) => {
+                if let ValueView::ContainerRef(cell) = slot.view() {
+                    return Value::ContainerRef(cell.clone());
+                }
                 let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(slot, Value::Nil)));
                 *slot = Value::ContainerRef(cell.clone());
                 Value::ContainerRef(cell)

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -59,8 +59,8 @@ impl LazyList {
     /// Whether this lazy list was assigned into an `@` array (see marker above).
     pub(crate) fn in_array_context(&self) -> bool {
         matches!(
-            self.env.get(Self::ARRAY_CONTEXT_MARKER),
-            Some(Value(ValueRepr::Bool(true)))
+            self.env.get(Self::ARRAY_CONTEXT_MARKER).map(Value::view),
+            Some(ValueView::Bool(true))
         )
     }
 
@@ -120,8 +120,10 @@ impl LazyList {
     /// `__mutsu_lazylist_from_gather` env marker).
     pub(crate) fn is_from_gather(&self) -> bool {
         matches!(
-            self.env.get("__mutsu_lazylist_from_gather"),
-            Some(Value(ValueRepr::Bool(true)))
+            self.env
+                .get("__mutsu_lazylist_from_gather")
+                .map(Value::view),
+            Some(ValueView::Bool(true))
         )
     }
 
@@ -194,8 +196,10 @@ impl LazyList {
     /// statement prefix / `.lazy` method).
     fn is_lazy_marked(&self) -> bool {
         matches!(
-            self.env.get("__mutsu_preserve_lazy_on_array_assign"),
-            Some(Value(ValueRepr::Bool(true)))
+            self.env
+                .get("__mutsu_preserve_lazy_on_array_assign")
+                .map(Value::view),
+            Some(ValueView::Bool(true))
         )
     }
 
@@ -214,8 +218,8 @@ impl LazyList {
     /// not the default `Seq`). Mutually exclusive with array context in practice.
     pub(crate) fn in_list_context(&self) -> bool {
         matches!(
-            self.env.get(Self::LIST_CONTEXT_MARKER),
-            Some(Value(ValueRepr::Bool(true)))
+            self.env.get(Self::LIST_CONTEXT_MARKER).map(Value::view),
+            Some(ValueView::Bool(true))
         )
     }
 
@@ -238,8 +242,8 @@ impl LazyList {
     /// Whether this list is a `.cache`-returned view whose sink is a no-op.
     pub(crate) fn is_cached_no_sink(&self) -> bool {
         matches!(
-            self.env.get(Self::CACHED_NO_SINK_MARKER),
-            Some(Value(ValueRepr::Bool(true)))
+            self.env.get(Self::CACHED_NO_SINK_MARKER).map(Value::view),
+            Some(ValueView::Bool(true))
         )
     }
 
@@ -459,23 +463,15 @@ impl LazyList {
         let negate = spec.negate;
 
         // Generate source values
-        let new_values: Vec<Value> = match &source {
-            Value(ValueRepr::Range(a, b)) => {
-                let start = *a + already as i64;
-                let end = if *b == i64::MAX {
-                    *a + needed as i64
-                } else {
-                    *b
-                };
+        let new_values: Vec<Value> = match source.view() {
+            ValueView::Range(a, b) => {
+                let start = a + already as i64;
+                let end = if b == i64::MAX { a + needed as i64 } else { b };
                 (start..=end).take(remaining).map(Value::Int).collect()
             }
-            Value(ValueRepr::RangeExcl(a, b)) => {
-                let start = *a + already as i64;
-                let end = if *b == i64::MAX {
-                    *a + needed as i64
-                } else {
-                    *b
-                };
+            ValueView::RangeExcl(a, b) => {
+                let start = a + already as i64;
+                let end = if b == i64::MAX { a + needed as i64 } else { b };
                 (start..end).take(remaining).map(Value::Int).collect()
             }
             _ => {


### PR DESCRIPTION
## Summary

First slice of **B-wall-in** ([docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md) §4, follows #4442): migrate `src/value/` internals off *place-based* `ValueRepr::` uses (patterns on the newtype field, `&mut` into the enum) — the shapes that cannot survive the NaN-box flip. `ValueRepr` named in **owned** expressions is fine forever (it survives the flip as the transient working enum), so the worklist is only the place-based borrows.

### Seam APIs (identity today, tag decode/encode at flip time)

- `Value::into_repr(self) -> ValueRepr` — owned-match seam
- `Value::from_repr(ValueRepr) -> Value` — struct-like-variant construction seam
- `Value::with_repr_mut(&mut self, f)` — in-place edit seam (unused yet; the exemplar batch had no `&mut` repr sites)

### Exemplar migrations (22 sites → place-based `ValueRepr::` = 0 per file)

| file | shapes proven |
|---|---|
| `value_collections.rs` | owned match → `into_repr()` / re-pack via `from_repr()` |
| `error.rs` | let-chain `Instance` patterns → `view()` |
| `error_typed.rs` | exhaustive JSON-renderer match → `view()` |
| `value_lazy.rs` | `matches!` on `Option<&Value>` → `.map(Value::view)`; borrowed `Range` match → by-value payloads |
| `value_instance.rs` | `&mut`-loop and `get_mut`-match shapes → `view()` with borrow-scoped restructuring |

### Remaining worklist (next slices, mechanical)

types_isa 142 · value_eq 97 · display 91 · types_eqv 70 · serde_support 62 · types_truthy 54 · mod 49 · value_gc 46 · types 40 · value_methods_a/c/b 38/37/20 · signature 12 · misc few. `view.rs` + constructor shims are the seam and stay direct.

## Test plan

Byte-identical refactor: `make test` green locally (16423 tests), clippy/fmt clean. CI runs the full roast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)