### PR TITLE
refactor(value): B-wall-in slice 2 — signature.rs + value_methods_b.rs

### DIFF
--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use super::ValueRepr;
+use super::ValueView;
 use crate::ast::{Expr, ParamDef, Stmt};
 use crate::symbol::Symbol;
 use std::collections::HashMap;
@@ -101,12 +101,12 @@ pub(crate) fn param_def_to_sig_param(p: &ParamDef) -> SigParam {
 
     // Infer type from literal value if no explicit type constraint
     let type_constraint = p.type_constraint.clone().or_else(|| {
-        p.literal_value.as_ref().map(|lit| match lit {
-            Value(ValueRepr::Int(_)) | Value(ValueRepr::BigInt(_)) => "Int".to_string(),
-            Value(ValueRepr::Num(_)) => "Num".to_string(),
-            Value(ValueRepr::Str(_)) => "Str".to_string(),
-            Value(ValueRepr::Rat(_, _)) => "Rat".to_string(),
-            Value(ValueRepr::Bool(_)) => "Bool".to_string(),
+        p.literal_value.as_ref().map(|lit| match lit.view() {
+            ValueView::Int(_) | ValueView::BigInt(_) => "Int".to_string(),
+            ValueView::Num(_) => "Num".to_string(),
+            ValueView::Str(_) => "Str".to_string(),
+            ValueView::Rat(_, _) => "Rat".to_string(),
+            ValueView::Bool(_) => "Bool".to_string(),
             _ => "Any".to_string(),
         })
     });
@@ -214,8 +214,8 @@ pub(crate) fn make_signature_value_with_owner(info: SigInfo, owner_key: Option<S
     );
     let val = Value::make_instance(Symbol::intern("Signature"), attrs);
     // Register the SigInfo for later lookup (smartmatch, etc.)
-    if let Value(ValueRepr::Instance { id, .. }) = &val {
-        register_sig_info(*id, info);
+    if let ValueView::Instance { id, .. } = val.view() {
+        register_sig_info(id, info);
     }
     val
 }
@@ -387,8 +387,8 @@ pub(crate) fn parameter_to_raku(attrs: &HashMap<String, Value>) -> String {
     // Type constraint
     let type_name = attrs
         .get("type")
-        .map(|v| match v {
-            Value(ValueRepr::Package(sym)) => sym.resolve(),
+        .map(|v| match v.view() {
+            ValueView::Package(sym) => sym.resolve(),
             _ => v.to_string_value(),
         })
         .unwrap_or_default();
@@ -448,13 +448,11 @@ pub(crate) fn parameter_to_raku(attrs: &HashMap<String, Value>) -> String {
     // Default value
     if let Some(default_val) = attrs.get("default")
         && matches!(
-            default_val,
-            Value(ValueRepr::Sub(_))
-                | Value(ValueRepr::WeakSub(_))
-                | Value(ValueRepr::Routine { .. })
+            default_val.view(),
+            ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }
         )
     {
-        if let Some(Value(ValueRepr::Str(default_raku))) = attrs.get("default_raku") {
+        if let Some(ValueView::Str(default_raku)) = attrs.get("default_raku").map(Value::view) {
             parts.push(format!("= {}", default_raku));
         } else if name == "$_" || name == "$$_" {
             // Implicit topic parameter in a bare block defaults to OUTER::<$_>
@@ -527,11 +525,11 @@ pub(crate) fn make_params_value_from_param_defs(params: &[ParamDef]) -> Value {
 
 /// Extract SigInfo from a Signature Instance value.
 pub(crate) fn extract_sig_info(val: &Value) -> Option<SigInfo> {
-    if let Value(ValueRepr::Instance { class_name, id, .. }) = val {
+    if let ValueView::Instance { class_name, id, .. } = val.view() {
         if class_name != "Signature" {
             return None;
         }
-        if let Some(info) = lookup_sig_info(*id) {
+        if let Some(info) = lookup_sig_info(id) {
             return Some(info);
         }
         // Legacy signature (no structured data)

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -18,7 +18,7 @@ impl Value {
     /// Safety: same assumptions as hash_autovivify — callers ensure no
     /// concurrent reads/writes to the same Arc.
     pub fn array_push_in_place(&self, val: Value) -> bool {
-        if let Value(ValueRepr::Array(arc, _)) = self {
+        if let ValueView::Array(arc, _) = self.view() {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the items is live across the push.
             let data = unsafe { crate::value::gc_contents_mut(arc) };
@@ -37,7 +37,7 @@ impl Value {
     /// `None` if `self` is not an Array or the existing element is a non-array
     /// container (a Hash — a shape the caller cannot descend as an array index).
     pub fn ensure_array_child(&self, idx: usize) -> Option<Value> {
-        let Value(ValueRepr::Array(arc, _kind)) = self else {
+        let ValueView::Array(arc, _kind) = self.view() else {
             return None;
         };
         // SAFETY: aliased in-place mutation of a shared container; see
@@ -57,29 +57,28 @@ impl Value {
         // (`Int`/`Str`/…) or a `Hash` is NOT overwritten — returning `None` there
         // makes the caller fall back to a plain read, so a read-only use of the
         // subscript cannot corrupt existing data.
-        let is_hole =
-            |v: &Value| matches!(v, Value(ValueRepr::Nil) | Value(ValueRepr::Package(..)));
+        let is_hole = |v: &Value| matches!(v.view(), ValueView::Nil | ValueView::Package(..));
         // Deref an existing ContainerRef cell so we inspect/replace its inner value.
-        if let Value(ValueRepr::ContainerRef(cell)) = &data[idx] {
+        if let ValueView::ContainerRef(cell) = data[idx].view() {
             let inner = cell.lock().unwrap().clone();
-            match &inner {
-                Value(ValueRepr::Array(..)) => return Some(inner),
-                v if is_hole(v) => {
-                    let fresh = Value::real_array(Vec::new());
-                    *cell.lock().unwrap() = fresh.clone();
-                    return Some(fresh);
-                }
-                _ => return None,
+            if matches!(inner.view(), ValueView::Array(..)) {
+                return Some(inner);
             }
-        }
-        match &data[idx] {
-            Value(ValueRepr::Array(..)) => Some(data[idx].clone()),
-            v if is_hole(v) => {
+            if is_hole(&inner) {
                 let fresh = Value::real_array(Vec::new());
-                data[idx] = fresh.clone();
-                Some(fresh)
+                *cell.lock().unwrap() = fresh.clone();
+                return Some(fresh);
             }
-            _ => None,
+            return None;
+        }
+        if matches!(data[idx].view(), ValueView::Array(..)) {
+            Some(data[idx].clone())
+        } else if is_hole(&data[idx]) {
+            let fresh = Value::real_array(Vec::new());
+            data[idx] = fresh.clone();
+            Some(fresh)
+        } else {
+            None
         }
     }
 
@@ -93,7 +92,7 @@ impl Value {
     /// arbitrarily deep `$struct[..]<..>[..]` paths. Reads decontainerize the
     /// element at the single read chokepoint (`resolve_array_entry`).
     pub fn array_slot_ref(&self, idx: usize, terminal: bool) -> Option<Value> {
-        if let Value(ValueRepr::Array(arc, _kind)) = self {
+        if let ValueView::Array(arc, _kind) = self.view() {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the items is live across the
             // growth/promotion below.
@@ -113,7 +112,7 @@ impl Value {
                 data.push(hole.clone());
             }
             let elem = &mut data[idx];
-            if let Value(ValueRepr::ContainerRef(cell)) = elem {
+            if let ValueView::ContainerRef(cell) = elem.view() {
                 return Some(Value::ContainerRef(cell.clone()));
             }
             // Only promote a *scalar* leaf to a cell. A container element
@@ -123,12 +122,7 @@ impl Value {
             // the next index op lands in the same physical Vec/HashMap the
             // stored element points to (Stage 2: no array element back-reference
             // back-reference needed).
-            if !terminal
-                && matches!(
-                    elem,
-                    Value(ValueRepr::Array(..)) | Value(ValueRepr::Hash(..))
-                )
-            {
+            if !terminal && matches!(elem.view(), ValueView::Array(..) | ValueView::Hash(..)) {
                 return Some(elem.clone());
             }
             let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
@@ -142,11 +136,11 @@ impl Value {
     /// Encode a Value as a hash key string.
     /// Regex values are encoded with a special prefix to preserve their identity.
     pub fn hash_key_encode(val: &Value) -> String {
-        match val {
-            Value(ValueRepr::Regex(pattern)) => {
+        match val.view() {
+            ValueView::Regex(pattern) => {
                 format!("\0rx:{}", pattern)
             }
-            other => other.to_string_value(),
+            _ => val.to_string_value(),
         }
     }
 
@@ -175,9 +169,9 @@ impl Value {
     /// RECURSIVE: nested `$($(...))` are fully stripped. Non-Scalar values are
     /// returned as-is. See the decont family note above; this is the Scalar axis only.
     pub fn descalarize(&self) -> &Value {
-        match self {
-            Value(ValueRepr::Scalar(inner)) => inner.descalarize(),
-            other => other,
+        match self.view() {
+            ValueView::Scalar(inner) => inner.descalarize(),
+            _ => self,
         }
     }
 
@@ -186,9 +180,9 @@ impl Value {
     /// callers that already own the value). Canonical replacement for the former
     /// `runtime::methods_mut::strip_scalar`.
     pub fn into_descalarized(self) -> Value {
-        match self {
-            Value(ValueRepr::Scalar(inner)) => inner.into_descalarized(),
-            other => other,
+        match self.into_repr() {
+            ValueRepr::Scalar(inner) => inner.into_descalarized(),
+            other => Value::from_repr(other),
         }
     }
     pub fn set(s: HashSet<String>) -> Self {
@@ -315,7 +309,7 @@ impl Value {
         Value::Slip(Arc::new(items))
     }
     pub fn junction(kind: JunctionKind, values: Vec<Value>) -> Self {
-        Value(ValueRepr::Junction {
+        Value::from_repr(ValueRepr::Junction {
             kind,
             values: Arc::new(values),
         })
@@ -390,6 +384,11 @@ impl Value {
     }
 
     /// Access SubData fields if this is a Sub (or upgraded WeakSub).
+    ///
+    /// Deliberately still a place-based match (B-wall-in exemption): it hands
+    /// out a `&SubData` borrowed from `self`, which a `view()` guard cannot do
+    /// (the guard is a by-value temporary scoped to the match). At flip time
+    /// this body is reimplemented inside the seam as a pointee deref.
     #[allow(dead_code)]
     pub(crate) fn as_sub(&self) -> Option<&SubData> {
         match self {
@@ -401,12 +400,12 @@ impl Value {
     /// Upgrade a WeakSub to a Sub, or return Nil if expired.
     #[allow(dead_code)]
     pub(crate) fn upgrade_weak(&self) -> Value {
-        match self {
-            Value(ValueRepr::WeakSub(weak)) => match weak.upgrade() {
+        match self.view() {
+            ValueView::WeakSub(weak) => match weak.upgrade() {
                 Some(strong) => Value::Sub(strong),
                 None => Value::Nil,
             },
-            other => other.clone(),
+            _ => self.clone(),
         }
     }
 
@@ -465,7 +464,7 @@ impl Value {
         attributes: HashMap<String, Value>,
         id: u64,
     ) -> Self {
-        Value(ValueRepr::Instance {
+        Value::from_repr(ValueRepr::Instance {
             class_name,
             attributes: crate::gc::Gc::new(InstanceAttrs::new(class_name, attributes, id, true)),
             id,
@@ -489,7 +488,7 @@ impl Value {
         } else {
             crate::gc::Gc::new(attrs.with_class(class_name))
         };
-        Value(ValueRepr::Instance {
+        Value::from_repr(ValueRepr::Instance {
             class_name,
             attributes,
             id,
@@ -517,17 +516,17 @@ impl Value {
     /// CoW `Arc` (forked on first mutation), so a plain clone is already
     /// independent for them.
     pub(crate) fn into_temp_snapshot(self) -> Value {
-        match self {
-            Value(ValueRepr::Instance {
+        match self.into_repr() {
+            ValueRepr::Instance {
                 class_name,
                 attributes,
                 id,
-            }) => Value(ValueRepr::Instance {
+            } => Value::from_repr(ValueRepr::Instance {
                 class_name,
                 attributes: crate::gc::Gc::new((*attributes).clone()),
                 id,
             }),
-            other => other,
+            other => Value::from_repr(other),
         }
     }
 
@@ -537,7 +536,7 @@ impl Value {
         queue_destroy: bool,
     ) -> Self {
         let id = next_instance_id();
-        Value(ValueRepr::Instance {
+        Value::from_repr(ValueRepr::Instance {
             class_name,
             attributes: crate::gc::Gc::new(InstanceAttrs::new(
                 class_name,


### PR DESCRIPTION
## Summary

Second **B-wall-in** slice ([docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md) §4, follows #4445): 31 more place-based `ValueRepr::` sites inside `src/value/` migrate onto the slice-1 seam (`view()` / `into_repr()` / `from_repr()`), so they survive the NaN-box representation flip.

- **`signature.rs`** (12 sites): literal-type inference match, `Instance` id-registration if-lets, `Package` match, default-value `matches!` → `view()`; `Option<&Value>` pattern → `.map(Value::view)`.
- **`value_methods_b.rs`** (19 sites): array in-place mutation entry points (`view()` borrow of the `Gc` feeding the unchanged `gc_contents_mut`), hole/`ContainerRef` inspection restructured into borrow-scoped `matches!`, `descalarize` via `view()` recursion, `into_descalarized`/`into_temp_snapshot` via `into_repr()`, `Instance`/`Junction` construction via `from_repr()`.

**Deliberate exemption** (documented in-code): `as_sub()` hands out a `&SubData` borrowed from `self`, which a `view()` guard type cannot express — it stays a direct match and gets reimplemented inside the seam at flip time.

Remaining worklist: types_isa 142 · value_eq 97 · display 91 · types_eqv 70 · serde_support 62 · types_truthy 54 · mod 49 · value_gc 46 · types 40 · value_methods_a/c 38/37.

## Test plan

Byte-identical refactor: `make test` green locally (16423 tests), clippy/fmt clean. CI runs the full roast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)