### PR TITLE
perf(vm): skip O(n) for-loop topic writeback for unchanged object elements

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -88,7 +88,7 @@ bytecode.
 |------|-------|-------|
 | ~~per-call body fingerprint~~ | ~~6–15%~~ | **fixed in #3853** — `push_method_dispatch_frame` `format!("{:?}", body)`-hashed the whole method-body AST on every call; now short-circuited for the single-candidate case + allocation-free fingerprint. |
 | `Symbol::intern` + `memcmp` | ~14% | class/method names are `resolve()`d to `String` then re-`intern()`ed per call (a `Symbol → String → Symbol` round-trip); each intern takes a global `RwLock` read + `FxHashMap` lookup. **Next target.** |
-| `Value::clone` / `drop_in_place::<Value>` / `Vec::clone` | ~50% on bench-class | the 48-byte `Value` enum copied/dropped throughout dispatch + instance attribute handling. Addressed long-term by NaN-boxing (Lever 2 / ADR-0001 layer 3b, *after* GC). |
+| ~~`Value::clone` / `drop_in_place::<Value>` / `Vec::clone`~~ | ~~~50% on bench-class~~ | **fixed 2026-07-12** — a 2026-07-12 perf profile showed the bench-class share was NOT dispatch/attribute churn but the for-loop topic writeback: `loop_var_unchanged` had no `Instance` arm, so a read-only `for @instances { .method }` rebuilt (cloned) the whole backing array every iteration (O(n²)). Adding Instance/Package/Enum/Rat/Nil arms cut bench-class 1.06s → 0.38s (2.8x, now 0.58x vs raku). Residual `Value` clone/drop in dispatch is still addressed long-term by NaN-boxing (Lever 2 / ADR-0001 layer 3b). |
 
 **Why env clone is no longer the issue**: the single-store work made `locals`
 authoritative and `env` a cheap derived view; method calls no longer snapshot

--- a/PLAN.md
+++ b/PLAN.md
@@ -231,9 +231,14 @@ method-call ホットパスキャンペーン第 1 弾（#3853/#3857/#3859/#3867
 resolution cache・mro_readonly キャッシュ・FxHashMap・単一候補 memoize）と、単一ストア化による
 per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 
-- [ ] `Value` clone/drop（bench-class の ~50%）＋ `attributes.to_map()` の毎回クローン ＋
+- [ ] `Value` clone/drop ＋ `attributes.to_map()` の毎回クローン ＋
       `call_compiled_method` の属性キー `format!` ＋ instance 構築 HashMap ＋ `merge_method_env` —
       Lever 2（NaN-boxing・GC 後）待ち、ないし属性 materialization の作り直し（深い）。
+      **注（2026-07-12）**: 旧記述「bench-class の ~50% が Value clone/drop」の実体は
+      for ループ topic writeback の O(n²)（`loop_var_unchanged` が Instance 要素を判定できず
+      毎イテレーション全配列 clone）で、修正済み — bench-class 2.8x 高速化・raku 比 0.58x。
+      再プロファイル後の残ホットスポット（native ctor plan の毎構築再計算・
+      `dispatch_compiled_method` 入口 `to_map()`・`is default` 属性ループ）が次スライス。
 - [ ] **Lever 2: NaN-boxing = ADR-0001 層3b（JIT の地ならし・GC 後）**: `Value` 48→8 bytes。
       int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。
       進捗・次の着手単位（3b-1 step B・ADR-0005 Accepted 待ち）は **§2 に集約**。
@@ -256,7 +261,7 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       絶対 index を運ぶ encoding の是正 / per-opcode ヒストグラム駆動での特化 op 統合
       （`ContainerEq`×4・`IndexAssign*`×6 — 美学でなくデータで駆動）。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。
-- 目標: method-call <1.5x、bench-class <1.5x、bench-fib（型制約付き）<2x。
+- 目標: method-call <1.5x、bench-class <1.5x（✅ 0.58x・2026-07-12）、bench-fib（型制約付き）<2x。
 
 ---
 
@@ -303,7 +308,7 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 | GC | **default on ✅**（2026-07-05・ADR-0003） | 達成（残 perf は層 3b へ） |
 | fib(25) vs raku | **1.0x** | <10x ✅ |
 | method-call vs raku | **2.7x** | <1.5x |
-| bench-class vs raku | **2.3x** | <1.5x |
+| bench-class vs raku | **0.58x**（2026-07-12） | <1.5x ✅ |
 | bench-fib（型制約付き）vs raku | **3.2x** | <2x |
 | 起動時間 vs raku | **0.04x** | 0.04x ✅ 維持 |
 | tree-walk フォールバック（メソッド/関数） | **~1% / ~18.6%（大半 carrier）** | 0%（carrier 除く） |

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -96,6 +96,44 @@ impl Interpreter {
             (ValueView::Int(a), ValueView::Int(b)) => a == b,
             (ValueView::Num(a), ValueView::Num(b)) => a == b,
             (ValueView::Bool(a), ValueView::Bool(b)) => a == b,
+            // Same instance object (same `Gc<InstanceAttrs>`): attribute
+            // mutations write through the shared cell, so the source element
+            // already observes them — the O(n) array rebuild would only re-store
+            // the identical handle. A rebound loop var (`$_ = Other.new`) holds
+            // a different Gc and still falls through to the writeback. Without
+            // this arm, a read-only `for @instances { .method }` cloned the
+            // whole backing array every iteration (O(n^2) — the dominant cost
+            // of bench-class's polymorphism loop).
+            (
+                ValueView::Instance {
+                    class_name: ca,
+                    attributes: a,
+                    id: ia,
+                },
+                ValueView::Instance {
+                    class_name: cb,
+                    attributes: b,
+                    id: ib,
+                },
+            ) => ca == cb && ia == ib && crate::gc::Gc::ptr_eq(a, b),
+            // Immutable-by-value variants: equal means the writeback is a no-op.
+            (ValueView::Package(a), ValueView::Package(b)) => a == b,
+            (ValueView::Rat(a, b), ValueView::Rat(c, d)) => a == c && b == d,
+            (
+                ValueView::Enum {
+                    enum_type: ta,
+                    key: ka,
+                    index: ia,
+                    ..
+                },
+                ValueView::Enum {
+                    enum_type: tb,
+                    key: kb,
+                    index: ib,
+                    ..
+                },
+            ) => ta == tb && ka == kb && ia == ib,
+            (ValueView::Nil, ValueView::Nil) => true,
             _ => false,
         }
     }

--- a/t/for-loop-instance-writeback.t
+++ b/t/for-loop-instance-writeback.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Pin the for-loop topic writeback semantics for object elements
+# (loop_var_unchanged Instance/Package/Enum/Rat arms): a read-only or
+# attribute-mutating loop must not need the O(n) source rebuild, while a
+# topic rebind must still write back to the source array.
+
+class P { has $.x is rw }
+
+# Attribute mutation through the loop param propagates via the shared cell
+my @a = P.new(x => 1), P.new(x => 2);
+for @a -> $p { $p.x = $p.x * 10 }
+is @a.map(*.x).join(","), "10,20", "attribute mutation through loop param reaches source elements";
+
+# Attribute mutation through the topic
+my @t = P.new(x => 3), P.new(x => 4);
+for @t { .x += 1 }
+is @t.map(*.x).join(","), "4,5", "attribute mutation through topic reaches source elements";
+
+# Topic rebind writes back to the source array
+my @b = P.new(x => 1), P.new(x => 2);
+for @b { $_ = P.new(x => 99) }
+is @b.map(*.x).join(","), "99,99", "topic rebind writes back to source array";
+
+# Read-only loop leaves the array intact
+my @c = P.new(x => 5), P.new(x => 6);
+my $sum = 0;
+for @c { $sum += .x }
+is $sum, 11, "read-only loop over instances computes correctly";
+is @c.map(*.x).join(","), "5,6", "read-only loop leaves source elements intact";
+
+# Type-object elements survive iteration
+my @types = Int, Str;
+for @types { ; }
+is @types.raku, "[Int, Str]", "type-object elements survive read-only iteration";
+
+# Rat elements: rebind still writes back
+my @r = 1/2, 3/4;
+for @r { $_ = $_ + 1 }
+is @r.join(","), "1.5,1.75", "rat topic rebind writes back";
+
+# given topic: attribute mutation propagates
+my $p = P.new(x => 7);
+given $p { .x = 8 }
+is $p.x, 8, "given topic attribute mutation propagates";
+
+done-testing;


### PR DESCRIPTION
## Summary

PLAN §5 perf lever (`Value` clone/attrs). A perf profile of bench-class showed ~57% of all cycles under `write_back_for_topic_item`: a read-only `for @instances { .method }` loop cloned the whole backing `ArrayData` on **every iteration** because `loop_var_unchanged` had no `Instance` arm — O(n²) for any array-of-objects loop. (PERFORMANCE.md previously attributed this share to generic `Value::clone` dispatch cost; corrected.)

## Fix

Add provably-unchanged arms to `loop_var_unchanged` (`src/vm/vm_loop_writeback.rs`):

- **Instance**: same class/id + same `Gc<InstanceAttrs>` — attribute mutations write through the shared cell, so the source element already observes them; a rebound topic (`$_ = Other.new`) holds a different Gc and still writes back.
- **Package / Enum / Rat / Nil**: immutable-by-value compares.

Hash-values loops and `given`-topic writeback share the helper and benefit unchanged.

## Measurements (perf stat -r5, taskset 0-3, release)

| bench | before | after | raku | ratio |
|---|---|---|---|---|
| bench-class | 1.06s | **0.38s** | 0.655s | **0.58x — beats raku** (PLAN target <1.5x ✅) |
| method-call | — | 0.76s | — | unchanged |
| int-arith | — | 0.17s | — | unchanged |

## Testing

- `t/for-loop-instance-writeback.t` (new, 8 tests) — byte-identical output on raku and mutsu (attribute mutation propagation, topic rebind writeback, read-only intactness, type-object/Rat elements, given topic).
- `make test`: 1667 files / 16426 tests PASS.
- Loop-related roast subset (S04 for/given/loop, S12 topic, integration topic_in_double_loop): 11 files / 286 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni