### PR TITLE
refactor(value): B-wall-in slice 3 — types_* + value_eq (403 sites)

### DIFF
--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -2,61 +2,61 @@ use super::*;
 
 /// Returns the Raku type name for a value (used in error messages).
 pub(crate) fn what_type_name(val: &Value) -> String {
-    match val {
-        Value(ValueRepr::Int(_)) | Value(ValueRepr::BigInt(_)) => "Int".to_string(),
-        Value(ValueRepr::Num(_)) => "Num".to_string(),
-        Value(ValueRepr::Str(_)) => "Str".to_string(),
-        Value(ValueRepr::Bool(_)) => "Bool".to_string(),
-        Value(ValueRepr::Rat(_, _)) | Value(ValueRepr::BigRat(_, _)) => "Rat".to_string(),
-        Value(ValueRepr::FatRat(_, _)) => "FatRat".to_string(),
-        Value(ValueRepr::Complex(_, _)) => "Complex".to_string(),
-        Value(ValueRepr::Array(..)) | Value(ValueRepr::LazyList(_)) => "Array".to_string(),
-        Value(ValueRepr::Seq(_)) => "Seq".to_string(),
-        Value(ValueRepr::HyperSeq(_)) => "HyperSeq".to_string(),
-        Value(ValueRepr::RaceSeq(_)) => "RaceSeq".to_string(),
-        Value(ValueRepr::Hash(..)) => "Hash".to_string(),
-        Value(ValueRepr::Set(_, is_mutable)) => {
-            if *is_mutable {
+    match val.view() {
+        ValueView::Int(_) | ValueView::BigInt(_) => "Int".to_string(),
+        ValueView::Num(_) => "Num".to_string(),
+        ValueView::Str(_) => "Str".to_string(),
+        ValueView::Bool(_) => "Bool".to_string(),
+        ValueView::Rat(_, _) | ValueView::BigRat(_, _) => "Rat".to_string(),
+        ValueView::FatRat(_, _) => "FatRat".to_string(),
+        ValueView::Complex(_, _) => "Complex".to_string(),
+        ValueView::Array(..) | ValueView::LazyList(_) => "Array".to_string(),
+        ValueView::Seq(_) => "Seq".to_string(),
+        ValueView::HyperSeq(_) => "HyperSeq".to_string(),
+        ValueView::RaceSeq(_) => "RaceSeq".to_string(),
+        ValueView::Hash(..) => "Hash".to_string(),
+        ValueView::Set(_, is_mutable) => {
+            if is_mutable {
                 "SetHash".to_string()
             } else {
                 "Set".to_string()
             }
         }
-        Value(ValueRepr::Bag(_, is_mutable)) => {
-            if *is_mutable {
+        ValueView::Bag(_, is_mutable) => {
+            if is_mutable {
                 "BagHash".to_string()
             } else {
                 "Bag".to_string()
             }
         }
-        Value(ValueRepr::Mix(_, is_mutable)) => {
-            if *is_mutable {
+        ValueView::Mix(_, is_mutable) => {
+            if is_mutable {
                 "MixHash".to_string()
             } else {
                 "Mix".to_string()
             }
         }
-        Value(ValueRepr::Pair(_, _)) | Value(ValueRepr::ValuePair(_, _)) => "Pair".to_string(),
-        Value(ValueRepr::Range(_, _))
-        | Value(ValueRepr::RangeExcl(_, _))
-        | Value(ValueRepr::RangeExclStart(_, _))
-        | Value(ValueRepr::RangeExclBoth(_, _))
-        | Value(ValueRepr::GenericRange { .. }) => "Range".to_string(),
-        Value(ValueRepr::Nil) => "Nil".to_string(),
-        Value(ValueRepr::Instance { class_name, .. }) => class_name.resolve(),
-        Value(ValueRepr::Package(name)) => name.resolve(),
-        Value(ValueRepr::Enum { enum_type, .. }) => enum_type.resolve(),
-        Value(ValueRepr::Sub(_)) | Value(ValueRepr::WeakSub(_)) => "Sub".to_string(),
-        Value(ValueRepr::Routine { .. }) => "Sub".to_string(),
-        Value(ValueRepr::Regex(_)) => "Regex".to_string(),
-        Value(ValueRepr::Junction { .. }) => "Junction".to_string(),
-        Value(ValueRepr::Slip(_)) => "Slip".to_string(),
-        Value(ValueRepr::Uni(u)) if !u.form.is_empty() => u.form.clone(),
-        Value(ValueRepr::Uni(_)) => "Uni".to_string(),
-        Value(ValueRepr::Mixin(inner, mixins)) => {
+        ValueView::Pair(_, _) | ValueView::ValuePair(_, _) => "Pair".to_string(),
+        ValueView::Range(_, _)
+        | ValueView::RangeExcl(_, _)
+        | ValueView::RangeExclStart(_, _)
+        | ValueView::RangeExclBoth(_, _)
+        | ValueView::GenericRange { .. } => "Range".to_string(),
+        ValueView::Nil => "Nil".to_string(),
+        ValueView::Instance { class_name, .. } => class_name.resolve(),
+        ValueView::Package(name) => name.resolve(),
+        ValueView::Enum { enum_type, .. } => enum_type.resolve(),
+        ValueView::Sub(_) | ValueView::WeakSub(_) => "Sub".to_string(),
+        ValueView::Routine { .. } => "Sub".to_string(),
+        ValueView::Regex(_) => "Regex".to_string(),
+        ValueView::Junction { .. } => "Junction".to_string(),
+        ValueView::Slip(_) => "Slip".to_string(),
+        ValueView::Uni(u) if !u.form.is_empty() => u.form.clone(),
+        ValueView::Uni(_) => "Uni".to_string(),
+        ValueView::Mixin(inner, mixins) => {
             allomorph_type_name(inner, mixins).unwrap_or_else(|| what_type_name(inner))
         }
-        Value(ValueRepr::ContainerRef(_)) => val.with_deref(what_type_name),
+        ValueView::ContainerRef(_) => val.with_deref(what_type_name),
         _ => "Any".to_string(),
     }
 }
@@ -70,13 +70,13 @@ pub(crate) fn allomorph_type_name(
     if !mixins.contains_key("Str") {
         return None;
     }
-    match inner {
-        Value(ValueRepr::Int(_)) | Value(ValueRepr::BigInt(_)) => Some("IntStr".to_string()),
-        Value(ValueRepr::Num(_)) => Some("NumStr".to_string()),
-        Value(ValueRepr::Rat(_, _))
-        | Value(ValueRepr::FatRat(_, _))
-        | Value(ValueRepr::BigRat(_, _)) => Some("RatStr".to_string()),
-        Value(ValueRepr::Complex(_, _)) => Some("ComplexStr".to_string()),
+    match inner.view() {
+        ValueView::Int(_) | ValueView::BigInt(_) => Some("IntStr".to_string()),
+        ValueView::Num(_) => Some("NumStr".to_string()),
+        ValueView::Rat(_, _) | ValueView::FatRat(_, _) | ValueView::BigRat(_, _) => {
+            Some("RatStr".to_string())
+        }
+        ValueView::Complex(_, _) => Some("ComplexStr".to_string()),
         _ => None,
     }
 }

--- a/src/value/types_eqv.rs
+++ b/src/value/types_eqv.rs
@@ -12,25 +12,25 @@ impl Value {
     ///   [1,2] eqv (1,2)  → False  (Array vs List)
     pub(crate) fn eqv(&self, other: &Self) -> bool {
         // Unwrap Scalar/ContainerRef containers: eqv looks through containerization
-        if let Value(ValueRepr::Scalar(inner)) = self {
+        if let ValueView::Scalar(inner) = self.view() {
             return inner.eqv(other);
         }
-        if let Value(ValueRepr::Scalar(inner)) = other {
+        if let ValueView::Scalar(inner) = other.view() {
             return self.eqv(inner);
         }
         // Deref to an OWNED clone (releasing the cell lock) before recursing:
         // when both sides alias the SAME cell (e.g. two pairs built from the same
         // `key => $var`), holding the lock across the recursive `eqv` would lock
         // the same non-reentrant Mutex twice and deadlock.
-        if matches!(self, Value(ValueRepr::ContainerRef(_))) {
+        if matches!(self.view(), ValueView::ContainerRef(_)) {
             return self.deref_container().eqv(other);
         }
-        if matches!(other, Value(ValueRepr::ContainerRef(_))) {
+        if matches!(other.view(), ValueView::ContainerRef(_)) {
             return self.eqv(&other.deref_container());
         }
         // Junction threading: if either side is a junction, thread eqv
         // through it and return the boolean result of the junction.
-        if let Value(ValueRepr::Junction { kind, values }) = other {
+        if let ValueView::Junction { kind, values } = other.view() {
             let results: Vec<bool> = values.iter().map(|v| self.eqv(v)).collect();
             return match kind {
                 crate::value::JunctionKind::Any => results.iter().any(|&b| b),
@@ -39,7 +39,7 @@ impl Value {
                 crate::value::JunctionKind::None => results.iter().all(|&b| !b),
             };
         }
-        if let Value(ValueRepr::Junction { kind, values }) = self {
+        if let ValueView::Junction { kind, values } = self.view() {
             let results: Vec<bool> = values.iter().map(|v| v.eqv(other)).collect();
             return match kind {
                 crate::value::JunctionKind::Any => results.iter().any(|&b| b),
@@ -48,41 +48,39 @@ impl Value {
                 crate::value::JunctionKind::None => results.iter().all(|&b| !b),
             };
         }
-        match (self, other) {
+        match (self.view(), other.view()) {
             // Arrays/Lists: must be same container type (Array vs List) and recursively eqv
             // eqv ignores Scalar wrapping — only Array vs List distinction matters
-            (Value(ValueRepr::Array(a, a_kind)), Value(ValueRepr::Array(b, b_kind))) => {
+            (ValueView::Array(a, a_kind), ValueView::Array(b, b_kind)) => {
                 a_kind.is_real_array() == b_kind.is_real_array()
                     && a.len() == b.len()
                     && a.iter().zip(b.iter()).all(|(x, y)| x.eqv(y))
             }
             // Hashes: recursively use eqv for values
-            (Value(ValueRepr::Hash(a, _)), Value(ValueRepr::Hash(b, _))) => {
+            (ValueView::Hash(a), ValueView::Hash(b)) => {
                 a.len() == b.len() && a.iter().all(|(k, v)| b.get(k).is_some_and(|bv| v.eqv(bv)))
             }
             // Pairs: recursively use eqv for values (Pair and ValuePair are equivalent)
-            (Value(ValueRepr::Pair(ak, av)), Value(ValueRepr::Pair(bk, bv))) => {
-                ak == bk && av.eqv(bv)
-            }
-            (Value(ValueRepr::ValuePair(ak, av)), Value(ValueRepr::ValuePair(bk, bv))) => {
+            (ValueView::Pair(ak, av), ValueView::Pair(bk, bv)) => ak == bk && av.eqv(bv),
+            (ValueView::ValuePair(ak, av), ValueView::ValuePair(bk, bv)) => {
                 ak.eqv(bk) && av.eqv(bv)
             }
-            (Value(ValueRepr::Pair(ak, av)), Value(ValueRepr::ValuePair(bk, bv))) => {
-                matches!(bk.as_ref(), Value(ValueRepr::Str(s)) if s.as_str() == ak) && av.eqv(bv)
+            (ValueView::Pair(ak, av), ValueView::ValuePair(bk, bv)) => {
+                matches!(bk.view(), ValueView::Str(s) if s.as_str() == ak) && av.eqv(bv)
             }
-            (Value(ValueRepr::ValuePair(ak, av)), Value(ValueRepr::Pair(bk, bv))) => {
-                matches!(ak.as_ref(), Value(ValueRepr::Str(s)) if s.as_str() == bk) && av.eqv(bv)
+            (ValueView::ValuePair(ak, av), ValueView::Pair(bk, bv)) => {
+                matches!(ak.view(), ValueView::Str(s) if s.as_str() == bk) && av.eqv(bv)
             }
             // Captures: recursively use eqv for positional and named elements
             (
-                Value(ValueRepr::Capture {
+                ValueView::Capture {
                     positional: ap,
                     named: an,
-                }),
-                Value(ValueRepr::Capture {
+                },
+                ValueView::Capture {
                     positional: bp,
                     named: bn,
-                }),
+                },
             ) => {
                 ap.len() == bp.len()
                     && ap.iter().zip(bp.iter()).all(|(x, y)| x.eqv(y))
@@ -92,16 +90,16 @@ impl Value {
                         .all(|(k, v)| bn.get(k).is_some_and(|bv| v.eqv(bv)))
             }
             // Slips: recursively use eqv for elements
-            (Value(ValueRepr::Slip(a)), Value(ValueRepr::Slip(b))) => {
+            (ValueView::Slip(a), ValueView::Slip(b)) => {
                 a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.eqv(y))
             }
             // Seqs: recursively use eqv for elements
-            (Value(ValueRepr::Seq(a)), Value(ValueRepr::Seq(b))) => {
+            (ValueView::Seq(a), ValueView::Seq(b)) => {
                 a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.eqv(y))
             }
             // Num: use bit-exact comparison to distinguish signed zeros,
             // but treat all NaN bit patterns as identical (Raku considers all NaN equal).
-            (Value(ValueRepr::Num(a)), Value(ValueRepr::Num(b))) => {
+            (ValueView::Num(a), ValueView::Num(b)) => {
                 if a.is_nan() && b.is_nan() {
                     true
                 } else {
@@ -110,7 +108,7 @@ impl Value {
             }
             // Complex: use bit-exact comparison for both components,
             // treating all NaN bit patterns as identical.
-            (Value(ValueRepr::Complex(ar, ai)), Value(ValueRepr::Complex(br, bi))) => {
+            (ValueView::Complex(ar, ai), ValueView::Complex(br, bi)) => {
                 let re_eq = if ar.is_nan() && br.is_nan() {
                     true
                 } else {
@@ -125,15 +123,13 @@ impl Value {
             }
             // Same-type scalar comparisons delegate to PartialEq
             // BigInt: both sides BigInt — use PartialEq
-            (Value(ValueRepr::BigInt(_)), Value(ValueRepr::BigInt(_))) => self == other,
+            (ValueView::BigInt(_), ValueView::BigInt(_)) => self == other,
             // Cross-representation Int/BigInt: compare numerically
-            (Value(ValueRepr::Int(a)), Value(ValueRepr::BigInt(b))) => NumBigInt::from(*a) == **b,
-            (Value(ValueRepr::BigInt(a)), Value(ValueRepr::Int(b))) => **a == NumBigInt::from(*b),
+            (ValueView::Int(a), ValueView::BigInt(b)) => NumBigInt::from(a) == **b,
+            (ValueView::BigInt(a), ValueView::Int(b)) => **a == NumBigInt::from(b),
             // Rat/FatRat: structural equality (n == n, d == d), including NaN (0/0)
-            (Value(ValueRepr::Rat(n1, d1)), Value(ValueRepr::Rat(n2, d2)))
-            | (Value(ValueRepr::FatRat(n1, d1)), Value(ValueRepr::FatRat(n2, d2))) => {
-                n1 == n2 && d1 == d2
-            }
+            (ValueView::Rat(n1, d1), ValueView::Rat(n2, d2))
+            | (ValueView::FatRat(n1, d1), ValueView::FatRat(n2, d2)) => n1 == n2 && d1 == d2,
             // Sets: eqv must distinguish elements that share a string key but
             // differ in type — specifically an allomorph (e.g. the IntStr <42>)
             // from a plain value (Int 42), which rakudo separates by `.WHICH`.
@@ -146,12 +142,10 @@ impl Value {
             // Raku's set operators (`(|)`/`(&)` etc.) always yield an immutable
             // Set regardless of operand mutability, so comparing the flag here
             // matches values produced by those operators too.
-            (Value(ValueRepr::Set(a, a_mut)), Value(ValueRepr::Set(b, b_mut))) => {
+            (ValueView::Set(a, a_mut), ValueView::Set(b, b_mut)) => {
                 fn allomorph_kind(v: &Value) -> Option<String> {
-                    match v {
-                        Value(ValueRepr::Mixin(inner, mixins)) => {
-                            allomorph_type_name(inner, mixins)
-                        }
+                    match v.view() {
+                        ValueView::Mixin(inner, mixins) => allomorph_type_name(inner, mixins),
                         _ => None,
                     }
                 }
@@ -165,24 +159,17 @@ impl Value {
             // Bag/Mix: like Set, eqv distinguishes the immutable variant from
             // its mutable QuantHash (Bag vs BagHash, Mix vs MixHash). The data
             // comparison is delegated to PartialEq, which ignores the flag.
-            (Value(ValueRepr::Bag(a, a_mut)), Value(ValueRepr::Bag(b, b_mut))) => {
-                a_mut == b_mut && a == b
-            }
-            (Value(ValueRepr::Mix(a, a_mut)), Value(ValueRepr::Mix(b, b_mut))) => {
-                a_mut == b_mut && a == b
-            }
-            (Value(ValueRepr::Int(_)), Value(ValueRepr::Int(_)))
-            | (Value(ValueRepr::Str(_)), Value(ValueRepr::Str(_)))
-            | (Value(ValueRepr::Bool(_)), Value(ValueRepr::Bool(_)))
-            | (Value(ValueRepr::BigRat(_, _)), Value(ValueRepr::BigRat(_, _)))
-            | (Value(ValueRepr::Enum { .. }), Value(ValueRepr::Enum { .. }))
-            | (Value(ValueRepr::Regex(_)), Value(ValueRepr::Regex(_)))
-            | (
-                Value(ValueRepr::RegexWithAdverbs { .. }),
-                Value(ValueRepr::RegexWithAdverbs { .. }),
-            )
-            | (Value(ValueRepr::Routine { .. }), Value(ValueRepr::Routine { .. })) => self == other,
-            (Value(ValueRepr::Sub(a)), Value(ValueRepr::Sub(b))) => {
+            (ValueView::Bag(a, a_mut), ValueView::Bag(b, b_mut)) => a_mut == b_mut && a == b,
+            (ValueView::Mix(a, a_mut), ValueView::Mix(b, b_mut)) => a_mut == b_mut && a == b,
+            (ValueView::Int(_), ValueView::Int(_))
+            | (ValueView::Str(_), ValueView::Str(_))
+            | (ValueView::Bool(_), ValueView::Bool(_))
+            | (ValueView::BigRat(_, _), ValueView::BigRat(_, _))
+            | (ValueView::Enum { .. }, ValueView::Enum { .. })
+            | (ValueView::Regex(_), ValueView::Regex(_))
+            | (ValueView::RegexWithAdverbs { .. }, ValueView::RegexWithAdverbs { .. })
+            | (ValueView::Routine { .. }, ValueView::Routine { .. }) => self == other,
+            (ValueView::Sub(a), ValueView::Sub(b)) => {
                 if crate::gc::Gc::ptr_eq(a, b) {
                     return true;
                 }
@@ -192,19 +179,19 @@ impl Value {
             }
             // Signature instances: compare by .raku string (structural equality)
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name: cn_a, ..
-                }),
-                Value(ValueRepr::Instance {
+                },
+                ValueView::Instance {
                     class_name: cn_b, ..
-                }),
+                },
             ) if cn_a == "Signature" && cn_b == "Signature" => {
-                let raku_a = if let Value(ValueRepr::Instance { attributes, .. }) = self {
+                let raku_a = if let ValueView::Instance { attributes, .. } = self.view() {
                     attributes.as_map().get("raku").map(|v| v.to_string_value())
                 } else {
                     None
                 };
-                let raku_b = if let Value(ValueRepr::Instance { attributes, .. }) = other {
+                let raku_b = if let ValueView::Instance { attributes, .. } = other.view() {
                     attributes.as_map().get("raku").map(|v| v.to_string_value())
                 } else {
                     None
@@ -212,16 +199,16 @@ impl Value {
                 raku_a == raku_b
             }
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name: cn_a,
                     attributes: a_attrs,
                     ..
-                }),
-                Value(ValueRepr::Instance {
+                },
+                ValueView::Instance {
                     class_name: cn_b,
                     attributes: b_attrs,
                     ..
-                }),
+                },
             ) if cn_a == cn_b
                 && a_attrs.contains_key("year")
                 && a_attrs.contains_key("month")
@@ -252,16 +239,16 @@ impl Value {
             }
             // Date instances: compare only year/month/day (ignore formatter attrs)
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name: cn_a,
                     attributes: a_attrs,
                     ..
-                }),
-                Value(ValueRepr::Instance {
+                },
+                ValueView::Instance {
                     class_name: cn_b,
                     attributes: b_attrs,
                     ..
-                }),
+                },
             ) if cn_a == cn_b
                 && a_attrs.contains_key("year")
                 && a_attrs.contains_key("month")
@@ -280,16 +267,16 @@ impl Value {
             }
             // StrDistance instances: structural equality on before/after
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name: cn_a,
                     attributes: a_attrs,
                     ..
-                }),
-                Value(ValueRepr::Instance {
+                },
+                ValueView::Instance {
                     class_name: cn_b,
                     attributes: b_attrs,
                     ..
-                }),
+                },
             ) if cn_a == "StrDistance" && cn_b == "StrDistance" => {
                 let before_eq = match (
                     a_attrs.as_map().get("before"),
@@ -308,46 +295,43 @@ impl Value {
                 before_eq && after_eq
             }
             // Other Instance types: use identity comparison
-            (Value(ValueRepr::Instance { .. }), Value(ValueRepr::Instance { .. })) => self == other,
+            (ValueView::Instance { .. }, ValueView::Instance { .. }) => self == other,
             // Nil and Package("Any") are eqv: both represent the undefined type object Any.
             // This matters for containerized contexts (e.g. hash values).
-            (Value(ValueRepr::Nil), Value(ValueRepr::Package(name)))
-            | (Value(ValueRepr::Package(name)), Value(ValueRepr::Nil))
+            (ValueView::Nil, ValueView::Package(name))
+            | (ValueView::Package(name), ValueView::Nil)
                 if name == "Any" =>
             {
                 true
             }
-            (Value(ValueRepr::Range(_, _)), Value(ValueRepr::Range(_, _)))
-            | (Value(ValueRepr::RangeExcl(_, _)), Value(ValueRepr::RangeExcl(_, _)))
-            | (Value(ValueRepr::RangeExclStart(_, _)), Value(ValueRepr::RangeExclStart(_, _)))
-            | (Value(ValueRepr::RangeExclBoth(_, _)), Value(ValueRepr::RangeExclBoth(_, _)))
-            | (Value(ValueRepr::GenericRange { .. }), Value(ValueRepr::GenericRange { .. }))
-            | (Value(ValueRepr::LazyList(_)), Value(ValueRepr::LazyList(_)))
-            | (Value(ValueRepr::Version { .. }), Value(ValueRepr::Version { .. }))
-            | (Value(ValueRepr::Nil), Value(ValueRepr::Nil))
-            | (Value(ValueRepr::Package(_)), Value(ValueRepr::Package(_)))
-            | (
-                Value(ValueRepr::CompUnitDepSpec { .. }),
-                Value(ValueRepr::CompUnitDepSpec { .. }),
-            )
-            | (Value(ValueRepr::Junction { .. }), Value(ValueRepr::Junction { .. }))
-            | (Value(ValueRepr::Promise(_)), Value(ValueRepr::Promise(_)))
-            | (Value(ValueRepr::Channel(_)), Value(ValueRepr::Channel(_)))
-            | (Value(ValueRepr::Uni { .. }), Value(ValueRepr::Uni { .. })) => self == other,
+            (ValueView::Range(_, _), ValueView::Range(_, _))
+            | (ValueView::RangeExcl(_, _), ValueView::RangeExcl(_, _))
+            | (ValueView::RangeExclStart(_, _), ValueView::RangeExclStart(_, _))
+            | (ValueView::RangeExclBoth(_, _), ValueView::RangeExclBoth(_, _))
+            | (ValueView::GenericRange { .. }, ValueView::GenericRange { .. })
+            | (ValueView::LazyList(_), ValueView::LazyList(_))
+            | (ValueView::Version { .. }, ValueView::Version { .. })
+            | (ValueView::Nil, ValueView::Nil)
+            | (ValueView::Package(_), ValueView::Package(_))
+            | (ValueView::CompUnitDepSpec { .. }, ValueView::CompUnitDepSpec { .. })
+            | (ValueView::Junction { .. }, ValueView::Junction { .. })
+            | (ValueView::Promise(_), ValueView::Promise(_))
+            | (ValueView::Channel(_), ValueView::Channel(_))
+            | (ValueView::Uni { .. }, ValueView::Uni { .. }) => self == other,
             // Mixin with only the read-only topic marker is transparent
             // (used by `with literal { ... }` to flag immutable $_).
-            (Value(ValueRepr::Mixin(inner, mix)), other)
+            (ValueView::Mixin(inner, mix), _)
                 if mix.len() == 1 && mix.contains_key("__mutsu_topic_ro__") =>
             {
                 inner.eqv(other)
             }
-            (other, Value(ValueRepr::Mixin(inner, mix)))
+            (_, ValueView::Mixin(inner, mix))
                 if mix.len() == 1 && mix.contains_key("__mutsu_topic_ro__") =>
             {
-                other.eqv(inner)
+                self.eqv(inner)
             }
             // Mixin (allomorphs): compare both base values and mixin maps with eqv
-            (Value(ValueRepr::Mixin(a, a_mix)), Value(ValueRepr::Mixin(b, b_mix))) => {
+            (ValueView::Mixin(a, a_mix), ValueView::Mixin(b, b_mix)) => {
                 if !a.eqv(b) {
                     return false;
                 }

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -5,78 +5,74 @@ impl Value {
     /// Check if this value is an instance of the given type name (Raku `isa` operator).
     pub(crate) fn isa_check(&self, type_name: &str) -> bool {
         // For Instance/Package, extract name as owned String for later comparison
-        let owned_name: Option<String> = match self {
-            Value(ValueRepr::Instance { class_name, .. }) => Some(class_name.resolve()),
-            Value(ValueRepr::Package(name)) => Some(name.resolve()),
+        let owned_name: Option<String> = match self.view() {
+            ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+            ValueView::Package(name) => Some(name.resolve()),
             _ => None,
         };
-        let my_type = match self {
-            Value(ValueRepr::Int(_)) | Value(ValueRepr::BigInt(_)) => "Int",
-            Value(ValueRepr::Num(_)) => "Num",
-            Value(ValueRepr::Str(_)) => "Str",
-            Value(ValueRepr::Bool(_)) => "Bool",
-            Value(ValueRepr::Rat(_, _)) => "Rat",
-            Value(ValueRepr::FatRat(_, _)) => "FatRat",
-            Value(ValueRepr::BigRat(_, _)) => "Rat",
-            Value(ValueRepr::Complex(_, _)) => "Complex",
-            Value(ValueRepr::Array(..)) | Value(ValueRepr::LazyList(_)) => "Array",
-            Value(ValueRepr::Seq(_)) => "Seq",
-            Value(ValueRepr::HyperSeq(_)) => "HyperSeq",
-            Value(ValueRepr::RaceSeq(_)) => "RaceSeq",
-            Value(ValueRepr::Hash(..)) => "Hash",
-            Value(ValueRepr::Set(_, is_mutable)) => {
-                if *is_mutable {
+        let my_type = match self.view() {
+            ValueView::Int(_) | ValueView::BigInt(_) => "Int",
+            ValueView::Num(_) => "Num",
+            ValueView::Str(_) => "Str",
+            ValueView::Bool(_) => "Bool",
+            ValueView::Rat(_, _) => "Rat",
+            ValueView::FatRat(_, _) => "FatRat",
+            ValueView::BigRat(_, _) => "Rat",
+            ValueView::Complex(_, _) => "Complex",
+            ValueView::Array(..) | ValueView::LazyList(_) => "Array",
+            ValueView::Seq(_) => "Seq",
+            ValueView::HyperSeq(_) => "HyperSeq",
+            ValueView::RaceSeq(_) => "RaceSeq",
+            ValueView::Hash(..) => "Hash",
+            ValueView::Set(_, is_mutable) => {
+                if is_mutable {
                     "SetHash"
                 } else {
                     "Set"
                 }
             }
-            Value(ValueRepr::Bag(_, is_mutable)) => {
-                if *is_mutable {
+            ValueView::Bag(_, is_mutable) => {
+                if is_mutable {
                     "BagHash"
                 } else {
                     "Bag"
                 }
             }
-            Value(ValueRepr::Mix(_, is_mutable)) => {
-                if *is_mutable {
+            ValueView::Mix(_, is_mutable) => {
+                if is_mutable {
                     "MixHash"
                 } else {
                     "Mix"
                 }
             }
-            Value(ValueRepr::Pair(_, _)) | Value(ValueRepr::ValuePair(_, _)) => "Pair",
-            Value(ValueRepr::Range(_, _))
-            | Value(ValueRepr::RangeExcl(_, _))
-            | Value(ValueRepr::RangeExclStart(_, _))
-            | Value(ValueRepr::RangeExclBoth(_, _))
-            | Value(ValueRepr::GenericRange { .. }) => "Range",
-            Value(ValueRepr::Nil) => "Nil",
-            Value(ValueRepr::Instance { .. }) | Value(ValueRepr::Package(_)) => {
-                owned_name.as_deref().unwrap()
-            }
-            Value(ValueRepr::Enum { enum_type, .. }) => {
+            ValueView::Pair(_, _) | ValueView::ValuePair(_, _) => "Pair",
+            ValueView::Range(_, _)
+            | ValueView::RangeExcl(_, _)
+            | ValueView::RangeExclStart(_, _)
+            | ValueView::RangeExclBoth(_, _)
+            | ValueView::GenericRange { .. } => "Range",
+            ValueView::Nil => "Nil",
+            ValueView::Instance { .. } | ValueView::Package(_) => owned_name.as_deref().unwrap(),
+            ValueView::Enum { enum_type, .. } => {
                 return enum_type.resolve() == type_name;
             }
-            Value(ValueRepr::Sub(data)) => match data.env.get("__mutsu_callable_type") {
-                Some(Value(ValueRepr::Str(kind))) if kind.as_str() == "Method" => "Method",
-                Some(Value(ValueRepr::Str(kind))) if kind.as_str() == "Submethod" => "Submethod",
-                Some(Value(ValueRepr::Str(kind))) if kind.as_str() == "WhateverCode" => {
-                    "WhateverCode"
-                }
+            ValueView::Sub(data) => match data.env.get("__mutsu_callable_type").map(Value::view) {
+                Some(ValueView::Str(kind)) if kind.as_str() == "Method" => "Method",
+                Some(ValueView::Str(kind)) if kind.as_str() == "Submethod" => "Submethod",
+                Some(ValueView::Str(kind)) if kind.as_str() == "WhateverCode" => "WhateverCode",
                 _ => "Sub",
             },
-            Value(ValueRepr::WeakSub(_)) => "Sub",
-            Value(ValueRepr::Routine {
+            ValueView::WeakSub(_) => "Sub",
+            ValueView::Routine {
                 is_regex: false, ..
-            }) => "Sub",
-            Value(ValueRepr::Regex(_))
-            | Value(ValueRepr::RegexWithAdverbs { .. })
-            | Value(ValueRepr::Routine { is_regex: true, .. }) => "Regex",
-            Value(ValueRepr::Junction { .. }) => "Junction",
-            Value(ValueRepr::Version { .. }) => "Version",
-            Value(ValueRepr::Slip(_)) => "Slip",
-            Value(ValueRepr::Promise(p)) => {
+            } => "Sub",
+            ValueView::Regex(_)
+            | ValueView::RegexWithAdverbs { .. }
+            | ValueView::Routine { is_regex: true, .. } => "Regex",
+            ValueView::Junction { .. } => "Junction",
+            ValueView::Version { .. } => "Version",
+            ValueView::Slip(_) => "Slip",
+            ValueView::Promise(p) => {
                 let cn = p.class_name();
                 if cn != "Promise" && cn == type_name {
                     return true;
@@ -87,13 +83,13 @@ impl Value {
                 }
                 "Promise"
             }
-            Value(ValueRepr::Channel(_)) => "Channel",
-            Value(ValueRepr::CompUnitDepSpec { .. }) => "CompUnit::DependencySpecification",
-            Value(ValueRepr::Whatever) => "Whatever",
-            Value(ValueRepr::HyperWhatever) => "HyperWhatever",
-            Value(ValueRepr::Capture { .. }) => "Capture",
-            Value(ValueRepr::Uni(u)) => u.form.as_str(),
-            Value(ValueRepr::Mixin(inner, mixins)) => {
+            ValueView::Channel(_) => "Channel",
+            ValueView::CompUnitDepSpec { .. } => "CompUnit::DependencySpecification",
+            ValueView::Whatever => "Whatever",
+            ValueView::HyperWhatever => "HyperWhatever",
+            ValueView::Capture { .. } => "Capture",
+            ValueView::Uni(u) => u.form.as_str(),
+            ValueView::Mixin(inner, mixins) => {
                 // Check allomorphic type names (IntStr, NumStr, RatStr, ComplexStr, Allomorph)
                 if matches!(
                     type_name,
@@ -112,29 +108,29 @@ impl Value {
                 // Also check mixin type keys (e.g., allomorphic "Str" mixin)
                 return mixins.contains_key(type_name);
             }
-            Value(ValueRepr::Proxy { .. }) => "Proxy",
-            Value(ValueRepr::ParametricRole { base_name, .. }) => {
+            ValueView::Proxy { .. } => "Proxy",
+            ValueView::ParametricRole { base_name, .. } => {
                 return base_name.resolve() == type_name;
             }
-            Value(ValueRepr::CustomType(c)) => {
+            ValueView::CustomType(c) => {
                 return c.name.resolve() == type_name;
             }
-            Value(ValueRepr::CustomTypeInstance(d)) => {
+            ValueView::CustomTypeInstance(d) => {
                 return d.type_name.resolve() == type_name;
             }
-            Value(ValueRepr::Scalar(inner)) => return inner.isa_check(type_name),
-            Value(ValueRepr::ContainerRef(_)) => {
+            ValueView::Scalar(inner) => return inner.isa_check(type_name),
+            ValueView::ContainerRef(_) => {
                 return self.with_deref(|inner| inner.isa_check(type_name));
             }
-            Value(ValueRepr::LazyThunk(thunk_data)) => {
+            ValueView::LazyThunk(thunk_data) => {
                 let cache = thunk_data.cache.lock().unwrap();
                 if let Some(ref cached) = *cache {
                     return cached.isa_check(type_name);
                 }
                 "Scalar" // unforced lazy thunk
             }
-            Value(ValueRepr::LazyIoLines { .. }) => "Seq",
-            Value(ValueRepr::HashEntryRef { .. }) => {
+            ValueView::LazyIoLines { .. } => "Seq",
+            ValueView::HashEntryRef { .. } => {
                 return self.hash_entry_read().isa_check(type_name);
             }
         };
@@ -145,10 +141,13 @@ impl Value {
         // `await` observes a broken Promise (see `await_died_error`): the cause
         // keeps its own class but also does X::Await::Died.
         if type_name == "X::Await::Died"
-            && let Value(ValueRepr::Instance { attributes, .. }) = self
+            && let ValueView::Instance { attributes, .. } = self.view()
             && matches!(
-                attributes.as_map().get("__mutsu_does_await_died"),
-                Some(Value(ValueRepr::Bool(true)))
+                attributes
+                    .as_map()
+                    .get("__mutsu_does_await_died")
+                    .map(Value::view),
+                Some(ValueView::Bool(true))
             )
         {
             return true;
@@ -168,166 +167,162 @@ impl Value {
         match type_name {
             "Any" => true,
             "Mu" => true,
-            "SetHash" => matches!(self, Value(ValueRepr::Set(_, true))),
-            "BagHash" => matches!(self, Value(ValueRepr::Bag(_, true))),
-            "MixHash" => matches!(self, Value(ValueRepr::Mix(_, true))),
+            "SetHash" => matches!(self.view(), ValueView::Set(_, true)),
+            "BagHash" => matches!(self.view(), ValueView::Bag(_, true)),
+            "MixHash" => matches!(self.view(), ValueView::Mix(_, true)),
             "Cool" => {
                 matches!(
-                    self,
-                    Value(ValueRepr::Int(_))
-                        | Value(ValueRepr::BigInt(_))
-                        | Value(ValueRepr::Num(_))
-                        | Value(ValueRepr::Str(_))
-                        | Value(ValueRepr::Bool(_))
-                        | Value(ValueRepr::Rat(_, _))
-                        | Value(ValueRepr::FatRat(_, _))
-                        | Value(ValueRepr::BigRat(_, _))
-                        | Value(ValueRepr::Complex(_, _))
-                        | Value(ValueRepr::Array(..))
-                        | Value(ValueRepr::Hash(..))
+                    self.view(),
+                    ValueView::Int(_)
+                        | ValueView::BigInt(_)
+                        | ValueView::Num(_)
+                        | ValueView::Str(_)
+                        | ValueView::Bool(_)
+                        | ValueView::Rat(_, _)
+                        | ValueView::FatRat(_, _)
+                        | ValueView::BigRat(_, _)
+                        | ValueView::Complex(_, _)
+                        | ValueView::Array(..)
+                        | ValueView::Hash(..)
                 ) || matches!(
-                    self,
-                    Value(ValueRepr::Instance { class_name, .. })
+                    self.view(),
+                    ValueView::Instance { class_name, .. }
                         if class_name == "Match" || class_name == "Capture"
                 )
             }
             "Capture" => {
-                matches!(self, Value(ValueRepr::Capture { .. }))
+                matches!(self.view(), ValueView::Capture { .. })
                     || matches!(
-                        self,
-                        Value(ValueRepr::Instance { class_name, .. })
+                        self.view(),
+                        ValueView::Instance { class_name, .. }
                             if class_name == "Match" || class_name == "Capture"
                     )
             }
             "Numeric" => matches!(
-                self,
-                Value(ValueRepr::Int(_))
-                    | Value(ValueRepr::BigInt(_))
-                    | Value(ValueRepr::Num(_))
-                    | Value(ValueRepr::Rat(_, _))
-                    | Value(ValueRepr::FatRat(_, _))
-                    | Value(ValueRepr::BigRat(_, _))
-                    | Value(ValueRepr::Complex(_, _))
+                self.view(),
+                ValueView::Int(_)
+                    | ValueView::BigInt(_)
+                    | ValueView::Num(_)
+                    | ValueView::Rat(_, _)
+                    | ValueView::FatRat(_, _)
+                    | ValueView::BigRat(_, _)
+                    | ValueView::Complex(_, _)
             ),
             "Real" => matches!(
-                self,
-                Value(ValueRepr::Int(_))
-                    | Value(ValueRepr::BigInt(_))
-                    | Value(ValueRepr::Num(_))
-                    | Value(ValueRepr::Rat(_, _))
-                    | Value(ValueRepr::FatRat(_, _))
-                    | Value(ValueRepr::BigRat(_, _))
+                self.view(),
+                ValueView::Int(_)
+                    | ValueView::BigInt(_)
+                    | ValueView::Num(_)
+                    | ValueView::Rat(_, _)
+                    | ValueView::FatRat(_, _)
+                    | ValueView::BigRat(_, _)
             ),
             "Rational" => matches!(
-                self,
-                Value(ValueRepr::Rat(_, _))
-                    | Value(ValueRepr::FatRat(_, _))
-                    | Value(ValueRepr::BigRat(_, _))
+                self.view(),
+                ValueView::Rat(_, _) | ValueView::FatRat(_, _) | ValueView::BigRat(_, _)
             ),
             "Dateish" => matches!(
-                self,
-                Value(ValueRepr::Instance { class_name, .. }) if class_name == "Date" || class_name == "DateTime"
+                self.view(),
+                ValueView::Instance { class_name, .. } if class_name == "Date" || class_name == "DateTime"
             ),
             "FatRat" => matches!(
-                self,
-                Value(ValueRepr::FatRat(_, _)) | Value(ValueRepr::BigRat(_, _))
+                self.view(),
+                ValueView::FatRat(_, _) | ValueView::BigRat(_, _)
             ),
-            "Int" => matches!(self, Value(ValueRepr::Bool(_))),
-            "Stringy" => matches!(self, Value(ValueRepr::Str(_))),
+            "Int" => matches!(self.view(), ValueView::Bool(_)),
+            "Stringy" => matches!(self.view(), ValueView::Str(_)),
             "Block" | "Routine" | "Code" | "Callable" => {
                 matches!(
-                    self,
-                    Value(ValueRepr::Sub(_))
-                        | Value(ValueRepr::WeakSub(_))
-                        | Value(ValueRepr::Routine { .. })
+                    self.view(),
+                    ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }
                 ) || matches!(
-                    self,
-                    Value(ValueRepr::Package(name))
+                    self.view(),
+                    ValueView::Package(name)
                         if matches!(name.resolve().as_str(), "Sub" | "Routine" | "Method" | "Block" | "Code")
                 )
             }
             "Method" => {
                 matches!(
-                    self,
-                    Value(ValueRepr::Sub(data))
+                    self.view(),
+                    ValueView::Sub(data)
                         if matches!(
-                            data.env.get("__mutsu_callable_type"),
-                            Some(Value(ValueRepr::Str(kind))) if kind.as_str() == "Method"
+                            data.env.get("__mutsu_callable_type").map(Value::view),
+                            Some(ValueView::Str(kind)) if kind.as_str() == "Method"
                         )
                 ) || matches!(
-                    self,
-                    Value(ValueRepr::Instance { class_name, .. }) if class_name == "Method"
-                ) || matches!(self, Value(ValueRepr::Package(name)) if name == "Method")
+                    self.view(),
+                    ValueView::Instance { class_name, .. } if class_name == "Method"
+                ) || matches!(self.view(), ValueView::Package(name) if name == "Method")
             }
             "Exception" => {
-                if let Value(ValueRepr::Instance { class_name, .. }) = self {
+                if let ValueView::Instance { class_name, .. } = self.view() {
                     class_name.resolve().starts_with("X::") || class_name == "Exception"
                 } else {
                     false
                 }
             }
             "X::AdHoc" | "CX::Warn" | "CX::Return" | "X::OS" => {
-                if let Value(ValueRepr::Instance { class_name, .. }) = self {
+                if let ValueView::Instance { class_name, .. } = self.view() {
                     class_name == type_name
                 } else {
                     false
                 }
             }
             "HyperSeq" => {
-                matches!(self, Value(ValueRepr::HyperSeq(_)))
+                matches!(self.view(), ValueView::HyperSeq(_))
             }
             "RaceSeq" => {
-                matches!(self, Value(ValueRepr::RaceSeq(_)))
+                matches!(self.view(), ValueView::RaceSeq(_))
             }
             "Seq" | "List" => {
                 matches!(
-                    self,
-                    Value(ValueRepr::Array(..))
-                        | Value(ValueRepr::LazyList(_))
-                        | Value(ValueRepr::Slip(_))
-                        | Value(ValueRepr::HyperSeq(_))
-                        | Value(ValueRepr::RaceSeq(_))
+                    self.view(),
+                    ValueView::Array(..)
+                        | ValueView::LazyList(_)
+                        | ValueView::Slip(_)
+                        | ValueView::HyperSeq(_)
+                        | ValueView::RaceSeq(_)
                 )
             }
             "Positional" => {
                 matches!(
-                    self,
-                    Value(ValueRepr::Array(..))
-                        | Value(ValueRepr::LazyList(_))
-                        | Value(ValueRepr::HyperSeq(_))
-                        | Value(ValueRepr::RaceSeq(_))
-                        | Value(ValueRepr::Range(_, _))
-                        | Value(ValueRepr::RangeExcl(_, _))
-                        | Value(ValueRepr::RangeExclStart(_, _))
-                        | Value(ValueRepr::RangeExclBoth(_, _))
-                        | Value(ValueRepr::GenericRange { .. })
-                        | Value(ValueRepr::Capture { .. })
+                    self.view(),
+                    ValueView::Array(..)
+                        | ValueView::LazyList(_)
+                        | ValueView::HyperSeq(_)
+                        | ValueView::RaceSeq(_)
+                        | ValueView::Range(_, _)
+                        | ValueView::RangeExcl(_, _)
+                        | ValueView::RangeExclStart(_, _)
+                        | ValueView::RangeExclBoth(_, _)
+                        | ValueView::GenericRange { .. }
+                        | ValueView::Capture { .. }
                 ) || matches!(
-                    self,
-                    Value(ValueRepr::Package(name))
+                    self.view(),
+                    ValueView::Package(name)
                         if matches!(
                             name.resolve().as_str(),
                             "Array" | "List" | "Range" | "Buf" | "Blob" | "Capture"
                         )
                 ) || matches!(
-                    self,
-                    Value(ValueRepr::Instance { attributes, .. })
+                    self.view(),
+                    ValueView::Instance { attributes, .. }
                         if attributes.contains_key("__mutsu_array_storage")
                 )
             }
             "Map" | "Associative" => {
                 matches!(
-                    self,
-                    Value(ValueRepr::Hash(..))
-                        | Value(ValueRepr::Pair(_, _))
-                        | Value(ValueRepr::ValuePair(_, _))
-                        | Value(ValueRepr::Set(_, _))
-                        | Value(ValueRepr::Bag(_, _))
-                        | Value(ValueRepr::Mix(_, _))
-                        | Value(ValueRepr::Capture { .. })
+                    self.view(),
+                    ValueView::Hash(..)
+                        | ValueView::Pair(_, _)
+                        | ValueView::ValuePair(_, _)
+                        | ValueView::Set(_, _)
+                        | ValueView::Bag(_, _)
+                        | ValueView::Mix(_, _)
+                        | ValueView::Capture { .. }
                 ) || matches!(
-                    self,
-                    Value(ValueRepr::Package(name))
+                    self.view(),
+                    ValueView::Package(name)
                         if matches!(
                             name.resolve().as_str(),
                             "Hash" | "Map" | "Pair" | "Set" | "Bag" | "Mix" | "QuantHash" | "Capture"
@@ -335,23 +330,23 @@ impl Value {
                 )
             }
             "Iterable" => matches!(
-                self,
-                Value(ValueRepr::Array(..))
-                    | Value(ValueRepr::LazyList(_))
-                    | Value(ValueRepr::Hash(..))
-                    | Value(ValueRepr::Seq(_))
+                self.view(),
+                ValueView::Array(..)
+                    | ValueView::LazyList(_)
+                    | ValueView::Hash(..)
+                    | ValueView::Seq(_)
             ),
             "ObjAt" => {
                 // ValueObjAt is a subclass of ObjAt
                 matches!(
-                    self,
-                    Value(ValueRepr::Instance { class_name, .. })
+                    self.view(),
+                    ValueView::Instance { class_name, .. }
                         if class_name == "ObjAt" || class_name == "ValueObjAt"
                 )
             }
             "Pod::Block" => matches!(
-                self,
-                Value(ValueRepr::Instance { class_name, .. })
+                self.view(),
+                ValueView::Instance { class_name, .. }
                     if class_name == "Pod::Block"
                         || class_name == "Pod::Block::Comment"
                         || class_name == "Pod::Block::Para"
@@ -361,8 +356,8 @@ impl Value {
                         || class_name == "Pod::Item"
             ),
             "Pod::Config" => matches!(
-                self,
-                Value(ValueRepr::Instance { class_name, .. })
+                self.view(),
+                ValueView::Instance { class_name, .. }
                     if class_name == "Pod::Config"
             ),
             _ => false,
@@ -371,7 +366,7 @@ impl Value {
 
     /// Check if this value does (composes) the given role name.
     pub(crate) fn does_check(&self, role_name: &str) -> bool {
-        if let Value(ValueRepr::Mixin(inner, mixins)) = self {
+        if let ValueView::Mixin(inner, mixins) = self.view() {
             let key = format!("__mutsu_role__{}", role_name);
             if mixins.contains_key(&key) {
                 return true;
@@ -380,12 +375,12 @@ impl Value {
         }
         // Check built-in role compositions
         if role_name == "Encoding" {
-            if let Value(ValueRepr::Instance { class_name, .. }) = self
+            if let ValueView::Instance { class_name, .. } = self.view()
                 && class_name == "Encoding::Builtin"
             {
                 return true;
             }
-            if let Value(ValueRepr::Package(name)) = self
+            if let ValueView::Package(name) = self.view()
                 && name == "Encoding::Builtin"
             {
                 return true;

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -5,16 +5,16 @@ impl Value {
     /// Returns true if handled, false otherwise.
     /// Panics if called on a non-Failure.
     pub(crate) fn is_failure_handled(&self) -> bool {
-        if let Value(ValueRepr::Instance {
+        if let ValueView::Instance {
             class_name,
             attributes,
             id,
             ..
-        }) = self
+        } = self.view()
             && class_name.resolve() == "Failure"
         {
             // Check the global registry first (shared across clones)
-            if let Some(handled) = super::is_failure_handled(*id) {
+            if let Some(handled) = super::is_failure_handled(id) {
                 return handled;
             }
             // Fall back to the attribute
@@ -29,51 +29,51 @@ impl Value {
 
     /// Mark this Failure as handled in the global registry.
     pub(crate) fn mark_failure_handled(&self) {
-        if let Value(ValueRepr::Instance { id, .. }) = self {
-            super::mark_failure_handled(*id);
+        if let ValueView::Instance { id, .. } = self.view() {
+            super::mark_failure_handled(id);
         }
     }
 
     pub(crate) fn truthy(&self) -> bool {
-        match self {
-            Value(ValueRepr::Bool(b)) => *b,
-            Value(ValueRepr::Int(i)) => *i != 0,
-            Value(ValueRepr::BigInt(n)) => !n.is_zero(),
-            Value(ValueRepr::Num(f)) => *f != 0.0 || f.is_nan(),
-            Value(ValueRepr::Str(s)) => !s.is_empty(),
-            Value(ValueRepr::Range(_, _)) => true,
-            Value(ValueRepr::RangeExcl(_, _)) => true,
-            Value(ValueRepr::RangeExclStart(_, _)) => true,
-            Value(ValueRepr::RangeExclBoth(_, _)) => true,
-            Value(ValueRepr::GenericRange { .. }) => true,
-            Value(ValueRepr::Array(items, ..)) => !items.is_empty(),
-            Value(ValueRepr::Hash(items, _)) => !items.is_empty(),
-            Value(ValueRepr::Rat(n, _)) => *n != 0,
-            Value(ValueRepr::FatRat(n, _)) => !n.is_zero(),
-            Value(ValueRepr::BigRat(n, _)) => !n.is_zero(),
-            Value(ValueRepr::Complex(r, i)) => *r != 0.0 || *i != 0.0,
-            Value(ValueRepr::Set(s, _)) => !s.is_empty(),
-            Value(ValueRepr::Bag(b, _)) => !b.is_empty(),
-            Value(ValueRepr::Mix(m, _)) => !m.is_empty(),
-            Value(ValueRepr::Pair(_, _)) | Value(ValueRepr::ValuePair(_, _)) => true,
-            Value(ValueRepr::Enum { value, .. }) => match value {
+        match self.view() {
+            ValueView::Bool(b) => b,
+            ValueView::Int(i) => i != 0,
+            ValueView::BigInt(n) => !n.is_zero(),
+            ValueView::Num(f) => f != 0.0 || f.is_nan(),
+            ValueView::Str(s) => !s.is_empty(),
+            ValueView::Range(_, _) => true,
+            ValueView::RangeExcl(_, _) => true,
+            ValueView::RangeExclStart(_, _) => true,
+            ValueView::RangeExclBoth(_, _) => true,
+            ValueView::GenericRange { .. } => true,
+            ValueView::Array(items, ..) => !items.is_empty(),
+            ValueView::Hash(items) => !items.is_empty(),
+            ValueView::Rat(n, _) => n != 0,
+            ValueView::FatRat(n, _) => n != 0,
+            ValueView::BigRat(n, _) => !n.is_zero(),
+            ValueView::Complex(r, i) => r != 0.0 || i != 0.0,
+            ValueView::Set(s, _) => !s.is_empty(),
+            ValueView::Bag(b, _) => !b.is_empty(),
+            ValueView::Mix(m, _) => !m.is_empty(),
+            ValueView::Pair(_, _) | ValueView::ValuePair(_, _) => true,
+            ValueView::Enum { value, .. } => match value {
                 EnumValue::Int(i) => *i != 0,
                 EnumValue::Str(s) => !s.is_empty(),
                 EnumValue::Generic(v) => v.as_ref().truthy(),
             },
-            Value(ValueRepr::CompUnitDepSpec { .. }) => true,
-            Value(ValueRepr::Package(_)) | Value(ValueRepr::ParametricRole { .. }) => false,
-            Value(ValueRepr::Routine { .. }) => true,
-            Value(ValueRepr::Sub(_)) | Value(ValueRepr::WeakSub(_)) => true,
-            Value(ValueRepr::Instance {
+            ValueView::CompUnitDepSpec { .. } => true,
+            ValueView::Package(_) | ValueView::ParametricRole { .. } => false,
+            ValueView::Routine { .. } => true,
+            ValueView::Sub(_) | ValueView::WeakSub(_) => true,
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) => {
+            } => {
                 if class_name == "Proc" {
                     // Proc is truthy when exitcode == 0
-                    return match attributes.as_map().get("exitcode") {
-                        Some(Value(ValueRepr::Int(code))) => *code == 0,
+                    return match attributes.as_map().get("exitcode").map(Value::view) {
+                        Some(ValueView::Int(code)) => code == 0,
                         _ => false,
                     };
                 }
@@ -89,48 +89,46 @@ impl Value {
                     || cn.starts_with("buf")
                     || cn.starts_with("blob")
                 {
-                    return match attributes.as_map().get("bytes") {
-                        Some(Value(ValueRepr::Array(items, ..))) => !items.is_empty(),
+                    return match attributes.as_map().get("bytes").map(Value::view) {
+                        Some(ValueView::Array(items, ..)) => !items.is_empty(),
                         _ => false,
                     };
                 }
                 true
             }
-            Value(ValueRepr::Junction { kind, values }) => match kind {
+            ValueView::Junction { kind, values } => match kind {
                 JunctionKind::Any => values.iter().any(|v| v.truthy()),
                 JunctionKind::All => values.iter().all(|v| v.truthy()),
                 JunctionKind::One => values.iter().filter(|v| v.truthy()).count() == 1,
                 JunctionKind::None => values.iter().all(|v| !v.truthy()),
             },
-            Value(ValueRepr::Slip(items)) => !items.is_empty(),
-            Value(ValueRepr::Seq(items))
-            | Value(ValueRepr::HyperSeq(items))
-            | Value(ValueRepr::RaceSeq(items)) => !items.is_empty(),
-            Value(ValueRepr::LazyList(_)) => true,
-            Value(ValueRepr::Promise(p)) => p.is_resolved(),
-            Value(ValueRepr::Channel(_)) => true,
-            Value(ValueRepr::Regex(_)) | Value(ValueRepr::RegexWithAdverbs { .. }) => true,
-            Value(ValueRepr::Version { .. }) => true,
-            Value(ValueRepr::Nil) => false,
-            Value(ValueRepr::Whatever) => true,
-            Value(ValueRepr::HyperWhatever) => true,
-            Value(ValueRepr::Capture { positional, named }) => {
-                !positional.is_empty() || !named.is_empty()
+            ValueView::Slip(items) => !items.is_empty(),
+            ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => {
+                !items.is_empty()
             }
-            Value(ValueRepr::Uni(u)) => !u.text.is_empty(),
-            Value(ValueRepr::Mixin(inner, mixins)) => {
+            ValueView::LazyList(_) => true,
+            ValueView::Promise(p) => p.is_resolved(),
+            ValueView::Channel(_) => true,
+            ValueView::Regex(_) | ValueView::RegexWithAdverbs { .. } => true,
+            ValueView::Version { .. } => true,
+            ValueView::Nil => false,
+            ValueView::Whatever => true,
+            ValueView::HyperWhatever => true,
+            ValueView::Capture { positional, named } => !positional.is_empty() || !named.is_empty(),
+            ValueView::Uni(u) => !u.text.is_empty(),
+            ValueView::Mixin(inner, mixins) => {
                 if let Some(bool_val) = mixins.get("Bool") {
                     bool_val.truthy()
                 } else {
                     inner.truthy()
                 }
             }
-            Value(ValueRepr::Proxy { .. }) => true,
-            Value(ValueRepr::CustomType { .. }) => false,
-            Value(ValueRepr::CustomTypeInstance(_)) => true,
-            Value(ValueRepr::Scalar(inner)) => inner.truthy(),
-            Value(ValueRepr::ContainerRef(_)) => self.with_deref(Value::truthy),
-            Value(ValueRepr::LazyThunk(thunk_data)) => {
+            ValueView::Proxy { .. } => true,
+            ValueView::CustomType { .. } => false,
+            ValueView::CustomTypeInstance(_) => true,
+            ValueView::Scalar(inner) => inner.truthy(),
+            ValueView::ContainerRef(_) => self.with_deref(Value::truthy),
+            ValueView::LazyThunk(thunk_data) => {
                 let cache = thunk_data.cache.lock().unwrap();
                 if let Some(ref cached) = *cache {
                     cached.truthy()
@@ -139,10 +137,10 @@ impl Value {
                     true
                 }
             }
-            Value(ValueRepr::LazyIoLines { .. }) => true,
+            ValueView::LazyIoLines { .. } => true,
             // An unmaterialized deferred bind token is undefined (and hence
             // falsy) until written through — see `value_is_defined`.
-            Value(ValueRepr::HashEntryRef { .. }) => false,
+            ValueView::HashEntryRef { .. } => false,
         }
     }
 }

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -13,155 +13,135 @@ impl PartialEq for Value {
                 };
                 arr[0] == *from && arr[1] == *matched
             };
-        match (self, other) {
-            (Value(ValueRepr::Int(a)), Value(ValueRepr::Int(b))) => a == b,
-            (Value(ValueRepr::BigInt(a)), Value(ValueRepr::BigInt(b))) => a == b,
-            (Value(ValueRepr::BigInt(a)), Value(ValueRepr::Int(b)))
-            | (Value(ValueRepr::Int(b)), Value(ValueRepr::BigInt(a))) => **a == NumBigInt::from(*b),
-            (Value(ValueRepr::Num(a)), Value(ValueRepr::Num(b))) => {
-                (a.is_nan() && b.is_nan()) || a == b
-            }
-            (Value(ValueRepr::Int(a)), Value(ValueRepr::Num(b))) => (*a as f64) == *b,
-            (Value(ValueRepr::Num(a)), Value(ValueRepr::Int(b))) => *a == (*b as f64),
-            (Value(ValueRepr::Str(a)), Value(ValueRepr::Str(b))) => a == b,
-            (Value(ValueRepr::Bool(a)), Value(ValueRepr::Bool(b))) => a == b,
-            (Value(ValueRepr::Range(a1, b1)), Value(ValueRepr::Range(a2, b2))) => {
+        match (self.view(), other.view()) {
+            (ValueView::Int(a), ValueView::Int(b)) => a == b,
+            (ValueView::BigInt(a), ValueView::BigInt(b)) => a == b,
+            (ValueView::BigInt(a), ValueView::Int(b))
+            | (ValueView::Int(b), ValueView::BigInt(a)) => **a == NumBigInt::from(b),
+            (ValueView::Num(a), ValueView::Num(b)) => (a.is_nan() && b.is_nan()) || a == b,
+            (ValueView::Int(a), ValueView::Num(b)) => (a as f64) == b,
+            (ValueView::Num(a), ValueView::Int(b)) => a == (b as f64),
+            (ValueView::Str(a), ValueView::Str(b)) => a == b,
+            (ValueView::Bool(a), ValueView::Bool(b)) => a == b,
+            (ValueView::Range(a1, b1), ValueView::Range(a2, b2)) => a1 == a2 && b1 == b2,
+            (ValueView::RangeExcl(a1, b1), ValueView::RangeExcl(a2, b2)) => a1 == a2 && b1 == b2,
+            (ValueView::RangeExclStart(a1, b1), ValueView::RangeExclStart(a2, b2)) => {
                 a1 == a2 && b1 == b2
             }
-            (Value(ValueRepr::RangeExcl(a1, b1)), Value(ValueRepr::RangeExcl(a2, b2))) => {
-                a1 == a2 && b1 == b2
-            }
-            (
-                Value(ValueRepr::RangeExclStart(a1, b1)),
-                Value(ValueRepr::RangeExclStart(a2, b2)),
-            ) => a1 == a2 && b1 == b2,
-            (Value(ValueRepr::RangeExclBoth(a1, b1)), Value(ValueRepr::RangeExclBoth(a2, b2))) => {
+            (ValueView::RangeExclBoth(a1, b1), ValueView::RangeExclBoth(a2, b2)) => {
                 a1 == a2 && b1 == b2
             }
             (
-                Value(ValueRepr::GenericRange {
+                ValueView::GenericRange {
                     start: s1,
                     end: e1,
                     excl_start: es1,
                     excl_end: ee1,
-                }),
-                Value(ValueRepr::GenericRange {
+                },
+                ValueView::GenericRange {
                     start: s2,
                     end: e2,
                     excl_start: es2,
                     excl_end: ee2,
-                }),
+                },
             ) => es1 == es2 && ee1 == ee2 && s1 == s2 && e1 == e2,
-            (Value(ValueRepr::Array(a, ..)), Value(ValueRepr::Array(b, ..))) => a == b,
-            (Value(ValueRepr::Seq(a)), Value(ValueRepr::Seq(b))) => a == b,
-            (Value(ValueRepr::Slip(a)), Value(ValueRepr::Slip(b))) => a == b,
-            (Value(ValueRepr::Array(a, ..)), Value(ValueRepr::Seq(b)))
-            | (Value(ValueRepr::Seq(b)), Value(ValueRepr::Array(a, ..)))
-            | (Value(ValueRepr::Array(a, ..)), Value(ValueRepr::Slip(b)))
-            | (Value(ValueRepr::Slip(b)), Value(ValueRepr::Array(a, ..))) => a.items == **b,
-            (Value(ValueRepr::Seq(a)), Value(ValueRepr::Slip(b)))
-            | (Value(ValueRepr::Slip(b)), Value(ValueRepr::Seq(a))) => a.as_ref() == b.as_ref(),
-            (Value(ValueRepr::Hash(a, _)), Value(ValueRepr::Hash(b, _))) => a == b,
-            (Value(ValueRepr::Rat(a1, b1)), Value(ValueRepr::Rat(a2, b2))) => {
-                if *b1 == 0 && *b2 == 0 && *a1 == 0 && *a2 == 0 {
+            (ValueView::Array(a, ..), ValueView::Array(b, ..)) => a == b,
+            (ValueView::Seq(a), ValueView::Seq(b)) => a == b,
+            (ValueView::Slip(a), ValueView::Slip(b)) => a == b,
+            (ValueView::Array(a, ..), ValueView::Seq(b))
+            | (ValueView::Seq(b), ValueView::Array(a, ..))
+            | (ValueView::Array(a, ..), ValueView::Slip(b))
+            | (ValueView::Slip(b), ValueView::Array(a, ..)) => a.items == **b,
+            (ValueView::Seq(a), ValueView::Slip(b)) | (ValueView::Slip(b), ValueView::Seq(a)) => {
+                a.as_ref() == b.as_ref()
+            }
+            (ValueView::Hash(a), ValueView::Hash(b)) => a == b,
+            (ValueView::Rat(a1, b1), ValueView::Rat(a2, b2)) => {
+                if b1 == 0 && b2 == 0 && a1 == 0 && a2 == 0 {
                     return false; // NaN != NaN
                 }
                 a1 == a2 && b1 == b2
             }
-            (Value(ValueRepr::Rat(n, d)), Value(ValueRepr::Int(i)))
-            | (Value(ValueRepr::Int(i)), Value(ValueRepr::Rat(n, d))) => *d != 0 && *n == *i * *d,
-            (Value(ValueRepr::Rat(n, d)), Value(ValueRepr::Num(f)))
-            | (Value(ValueRepr::Num(f)), Value(ValueRepr::Rat(n, d))) => {
-                if *d == 0 {
+            (ValueView::Rat(n, d), ValueView::Int(i))
+            | (ValueView::Int(i), ValueView::Rat(n, d)) => d != 0 && n == i * d,
+            (ValueView::Rat(n, d), ValueView::Num(f))
+            | (ValueView::Num(f), ValueView::Rat(n, d)) => {
+                if d == 0 {
                     return false;
                 }
-                (*n as f64 / *d as f64) == *f
+                (n as f64 / d as f64) == f
             }
-            (Value(ValueRepr::BigRat(an, ad)), Value(ValueRepr::BigRat(bn, bd))) => {
-                an == bn && ad == bd
+            (ValueView::BigRat(an, ad), ValueView::BigRat(bn, bd)) => an == bn && ad == bd,
+            (ValueView::BigRat(n, d), ValueView::Int(i))
+            | (ValueView::Int(i), ValueView::BigRat(n, d)) => {
+                !d.is_zero() && *n == NumBigInt::from(i) * d
             }
-            (Value(ValueRepr::BigRat(n, d)), Value(ValueRepr::Int(i)))
-            | (Value(ValueRepr::Int(i)), Value(ValueRepr::BigRat(n, d))) => {
-                let (n, d) = (n.as_ref(), d.as_ref());
-                !d.is_zero() && *n == NumBigInt::from(*i) * d
-            }
-            (Value(ValueRepr::BigRat(n, d)), Value(ValueRepr::Rat(rn, rd)))
-            | (Value(ValueRepr::Rat(rn, rd)), Value(ValueRepr::BigRat(n, d))) => {
-                let (n, d) = (n.as_ref(), d.as_ref());
+            (ValueView::BigRat(n, d), ValueView::Rat(rn, rd))
+            | (ValueView::Rat(rn, rd), ValueView::BigRat(n, d)) => {
                 !d.is_zero()
-                    && *rd != 0
-                    && n.clone() * NumBigInt::from(*rd) == NumBigInt::from(*rn) * d
+                    && rd != 0
+                    && n.clone() * NumBigInt::from(rd) == NumBigInt::from(rn) * d
             }
-            (Value(ValueRepr::BigRat(n, d)), Value(ValueRepr::Num(f)))
-            | (Value(ValueRepr::Num(f)), Value(ValueRepr::BigRat(n, d))) => {
-                let (n, d) = (n.as_ref(), d.as_ref());
+            (ValueView::BigRat(n, d), ValueView::Num(f))
+            | (ValueView::Num(f), ValueView::BigRat(n, d)) => {
                 if d.is_zero() {
                     return false;
                 }
-                (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)) == *f
+                (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)) == f
             }
-            (Value(ValueRepr::Complex(r1, i1)), Value(ValueRepr::Complex(r2, i2))) => {
-                let f_eq = |a: &f64, b: &f64| (a.is_nan() && b.is_nan()) || a == b;
+            (ValueView::Complex(r1, i1), ValueView::Complex(r2, i2)) => {
+                let f_eq = |a: f64, b: f64| (a.is_nan() && b.is_nan()) || a == b;
                 f_eq(r1, r2) && f_eq(i1, i2)
             }
-            (Value(ValueRepr::Complex(r, i)), Value(ValueRepr::Int(n)))
-            | (Value(ValueRepr::Int(n)), Value(ValueRepr::Complex(r, i))) => {
-                *i == 0.0 && *r == *n as f64
+            (ValueView::Complex(r, i), ValueView::Int(n))
+            | (ValueView::Int(n), ValueView::Complex(r, i)) => i == 0.0 && r == n as f64,
+            (ValueView::Complex(r, i), ValueView::Num(f))
+            | (ValueView::Num(f), ValueView::Complex(r, i)) => i == 0.0 && r == f,
+            (ValueView::Complex(r, i), ValueView::Rat(n, d))
+            | (ValueView::Rat(n, d), ValueView::Complex(r, i)) => {
+                d != 0 && i == 0.0 && r == (n as f64 / d as f64)
             }
-            (Value(ValueRepr::Complex(r, i)), Value(ValueRepr::Num(f)))
-            | (Value(ValueRepr::Num(f)), Value(ValueRepr::Complex(r, i))) => *i == 0.0 && *r == *f,
-            (Value(ValueRepr::Complex(r, i)), Value(ValueRepr::Rat(n, d)))
-            | (Value(ValueRepr::Rat(n, d)), Value(ValueRepr::Complex(r, i))) => {
-                *d != 0 && *i == 0.0 && *r == (*n as f64 / *d as f64)
+            (ValueView::Complex(r, i), ValueView::FatRat(n, d))
+            | (ValueView::FatRat(n, d), ValueView::Complex(r, i)) => {
+                d != 0 && i == 0.0 && r == (n as f64 / d as f64)
             }
-            (Value(ValueRepr::Complex(r, i)), Value(ValueRepr::FatRat(n, d)))
-            | (Value(ValueRepr::FatRat(n, d)), Value(ValueRepr::Complex(r, i))) => {
-                *d != 0 && *i == 0.0 && *r == (*n as f64 / *d as f64)
-            }
-            (Value(ValueRepr::Complex(r, i)), Value(ValueRepr::BigRat(n, d)))
-            | (Value(ValueRepr::BigRat(n, d)), Value(ValueRepr::Complex(r, i))) => {
-                let (n, d) = (n.as_ref(), d.as_ref());
+            (ValueView::Complex(r, i), ValueView::BigRat(n, d))
+            | (ValueView::BigRat(n, d), ValueView::Complex(r, i)) => {
                 !d.is_zero()
-                    && *i == 0.0
-                    && *r == (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0))
+                    && i == 0.0
+                    && r == (n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0))
             }
-            (Value(ValueRepr::FatRat(a1, b1)), Value(ValueRepr::FatRat(a2, b2))) => {
-                a1 == a2 && b1 == b2
-            }
-            (Value(ValueRepr::Set(a, _)), Value(ValueRepr::Set(b, _))) => a == b,
-            (Value(ValueRepr::Bag(a, _)), Value(ValueRepr::Bag(b, _))) => a == b,
-            (Value(ValueRepr::Mix(a, _)), Value(ValueRepr::Mix(b, _))) => a == b,
+            (ValueView::FatRat(a1, b1), ValueView::FatRat(a2, b2)) => a1 == a2 && b1 == b2,
+            (ValueView::Set(a, _), ValueView::Set(b, _)) => a == b,
+            (ValueView::Bag(a, _), ValueView::Bag(b, _)) => a == b,
+            (ValueView::Mix(a, _), ValueView::Mix(b, _)) => a == b,
             (
-                Value(ValueRepr::CompUnitDepSpec { short_name: a }),
-                Value(ValueRepr::CompUnitDepSpec { short_name: b }),
+                ValueView::CompUnitDepSpec { short_name: a },
+                ValueView::CompUnitDepSpec { short_name: b },
             ) => a == b,
-            (Value(ValueRepr::Package(a)), Value(ValueRepr::Package(b))) => a == b,
-            (Value(ValueRepr::Pair(ak, av)), Value(ValueRepr::Pair(bk, bv))) => {
-                ak == bk && av == bv
+            (ValueView::Package(a), ValueView::Package(b)) => a == b,
+            (ValueView::Pair(ak, av), ValueView::Pair(bk, bv)) => ak == bk && av == bv,
+            (ValueView::ValuePair(ak, av), ValueView::ValuePair(bk, bv)) => ak == bk && av == bv,
+            (ValueView::Pair(ak, av), ValueView::ValuePair(bk, bv)) => {
+                matches!(bk.view(), ValueView::Str(s) if s.as_str() == ak) && av == bv
             }
-            (Value(ValueRepr::ValuePair(ak, av)), Value(ValueRepr::ValuePair(bk, bv))) => {
-                ak == bk && av == bv
-            }
-            (Value(ValueRepr::Pair(ak, av)), Value(ValueRepr::ValuePair(bk, bv))) => {
-                matches!(bk.as_ref(), Value(ValueRepr::Str(s)) if s.as_str() == ak) && av == bv
-            }
-            (Value(ValueRepr::ValuePair(ak, av)), Value(ValueRepr::Pair(bk, bv))) => {
-                matches!(ak.as_ref(), Value(ValueRepr::Str(s)) if s.as_str() == bk) && av == bv
+            (ValueView::ValuePair(ak, av), ValueView::Pair(bk, bv)) => {
+                matches!(ak.view(), ValueView::Str(s) if s.as_str() == bk) && av == bv
             }
             (
-                Value(ValueRepr::Enum {
+                ValueView::Enum {
                     enum_type: at,
                     key: ak,
                     ..
-                }),
-                Value(ValueRepr::Enum {
+                },
+                ValueView::Enum {
                     enum_type: bt,
                     key: bk,
                     ..
-                }),
+                },
             ) => at == bt && ak == bk,
-            (Value(ValueRepr::Regex(a)), Value(ValueRepr::Regex(b))) => a == b,
-            (Value(ValueRepr::RegexWithAdverbs(a)), Value(ValueRepr::RegexWithAdverbs(b))) => {
+            (ValueView::Regex(a), ValueView::Regex(b)) => a == b,
+            (ValueView::RegexWithAdverbs(a), ValueView::RegexWithAdverbs(b)) => {
                 a.pattern == b.pattern
                     && a.global == b.global
                     && a.exhaustive == b.exhaustive
@@ -177,16 +157,16 @@ impl PartialEq for Value {
                     && a.samespace == b.samespace
             }
             (
-                Value(ValueRepr::Routine {
+                ValueView::Routine {
                     package: ap,
                     name: an,
                     ..
-                }),
-                Value(ValueRepr::Routine {
+                },
+                ValueView::Routine {
                     package: bp,
                     name: bn,
                     ..
-                }),
+                },
             ) => ap == bp && an == bn,
             // `IO::Handle` carries internal open-state attributes (`handle` — an
             // opaque integer indexing this process's open-file registry; `mode`
@@ -202,16 +182,16 @@ impl PartialEq for Value {
             // (mirrors the class-specific carve-outs for Date/DateTime/Signature
             // in `Value::eqv`).
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name: a,
                     attributes: aa,
                     ..
-                }),
-                Value(ValueRepr::Instance {
+                },
+                ValueView::Instance {
                     class_name: b,
                     attributes: ba,
                     ..
-                }),
+                },
             ) if a == "IO::Handle" && b == "IO::Handle" => {
                 let a_map = aa.as_map();
                 let b_map = ba.as_map();
@@ -222,58 +202,56 @@ impl PartialEq for Value {
                     .all(|k| a_map.get(*k) == b_map.get(*k))
             }
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name: a,
                     attributes: aa,
                     ..
-                }),
-                Value(ValueRepr::Instance {
+                },
+                ValueView::Instance {
                     class_name: b,
                     attributes: ba,
                     ..
-                }),
+                },
             ) => a == b && aa == ba,
             (
-                Value(ValueRepr::Instance {
+                ValueView::Instance {
                     class_name,
                     attributes,
                     ..
-                }),
-                Value(ValueRepr::Array(items, ..)),
+                },
+                ValueView::Array(items, ..),
             ) if class_name == "Match" => match_equals_pair_array(attributes, items),
             (
-                Value(ValueRepr::Array(items, ..)),
-                Value(ValueRepr::Instance {
+                ValueView::Array(items, ..),
+                ValueView::Instance {
                     class_name,
                     attributes,
                     ..
-                }),
+                },
             ) if class_name == "Match" => match_equals_pair_array(attributes, items),
             (
-                Value(ValueRepr::Junction {
+                ValueView::Junction {
                     kind: ak,
                     values: av,
-                }),
-                Value(ValueRepr::Junction {
+                },
+                ValueView::Junction {
                     kind: bk,
                     values: bv,
-                }),
+                },
             ) => ak == bk && av == bv,
-            (Value(ValueRepr::Sub(a)), Value(ValueRepr::Sub(b))) => a.id == b.id,
-            (Value(ValueRepr::LazyList(a)), Value(ValueRepr::LazyList(b))) => {
-                crate::gc::Gc::ptr_eq(a, b)
-            }
+            (ValueView::Sub(a), ValueView::Sub(b)) => a.id == b.id,
+            (ValueView::LazyList(a), ValueView::LazyList(b)) => crate::gc::Gc::ptr_eq(a, b),
             (
-                Value(ValueRepr::Version {
+                ValueView::Version {
                     parts: ap,
                     plus: aplus,
                     minus: aminus,
-                }),
-                Value(ValueRepr::Version {
+                },
+                ValueView::Version {
                     parts: bp,
                     plus: bplus,
                     minus: bminus,
-                }),
+                },
             ) => {
                 if aplus != bplus || aminus != bminus {
                     return false;
@@ -283,33 +261,33 @@ impl PartialEq for Value {
                 let b_norm = Self::version_strip_trailing_zeros(bp);
                 a_norm == b_norm
             }
-            (Value(ValueRepr::Promise(a)), Value(ValueRepr::Promise(b))) => a == b,
-            (Value(ValueRepr::Channel(a)), Value(ValueRepr::Channel(b))) => a == b,
-            (Value(ValueRepr::Nil), Value(ValueRepr::Nil)) => true,
+            (ValueView::Promise(a), ValueView::Promise(b)) => a == b,
+            (ValueView::Channel(a), ValueView::Channel(b)) => a == b,
+            (ValueView::Nil, ValueView::Nil) => true,
             (
-                Value(ValueRepr::Capture {
+                ValueView::Capture {
                     positional: ap,
                     named: an,
-                }),
-                Value(ValueRepr::Capture {
+                },
+                ValueView::Capture {
                     positional: bp,
                     named: bn,
-                }),
+                },
             ) => ap == bp && an == bn,
             // Mixin (allomorphic types): compare inner values and mixin maps
-            (Value(ValueRepr::Mixin(a_inner, a_mix)), Value(ValueRepr::Mixin(b_inner, b_mix))) => {
+            (ValueView::Mixin(a_inner, a_mix), ValueView::Mixin(b_inner, b_mix)) => {
                 a_inner == b_inner && a_mix == b_mix
             }
             // Mixin vs non-Mixin: delegate to the inner value
-            (Value(ValueRepr::Mixin(inner, _)), other)
-            | (other, Value(ValueRepr::Mixin(inner, _))) => inner.as_ref() == other,
+            (ValueView::Mixin(inner, _), _) => inner.as_ref() == other,
+            (_, ValueView::Mixin(inner, _)) => self == inner.as_ref(),
             // LazyThunk: compare cached values if available. Check Arc pointer
             // identity first — the same thunk compared to itself must short-circuit
             // before locking, since `a.cache` and `b.cache` are the *same* mutex
             // and a non-reentrant std `Mutex` would deadlock on the second lock.
             // (Hit by the END-phaser overlay's `v != orig_v` on a lexical bound to
             // a `lazy { … }` thunk: captured and live env hold the same Arc.)
-            (Value(ValueRepr::LazyThunk(a)), Value(ValueRepr::LazyThunk(b))) => {
+            (ValueView::LazyThunk(a), ValueView::LazyThunk(b)) => {
                 if Arc::ptr_eq(a, b) {
                     return true;
                 }
@@ -320,8 +298,7 @@ impl PartialEq for Value {
                     _ => false,
                 }
             }
-            (Value(ValueRepr::LazyThunk(thunk)), other)
-            | (other, Value(ValueRepr::LazyThunk(thunk))) => {
+            (ValueView::LazyThunk(thunk), _) => {
                 let cache = thunk.cache.lock().unwrap();
                 if let Some(ref cached) = *cache {
                     cached == other
@@ -329,12 +306,18 @@ impl PartialEq for Value {
                     false
                 }
             }
-            (Value(ValueRepr::Uni(a)), Value(ValueRepr::Uni(b))) => {
-                a.form == b.form && a.text == b.text
+            (_, ValueView::LazyThunk(thunk)) => {
+                let cache = thunk.cache.lock().unwrap();
+                if let Some(ref cached) = *cache {
+                    self == cached
+                } else {
+                    false
+                }
             }
+            (ValueView::Uni(a), ValueView::Uni(b)) => a.form == b.form && a.text == b.text,
             // ContainerRef: deref and compare inner values.
             // Check Arc pointer identity first to avoid deadlock on same-Arc comparison.
-            (Value(ValueRepr::ContainerRef(a)), Value(ValueRepr::ContainerRef(b))) => {
+            (ValueView::ContainerRef(a), ValueView::ContainerRef(b)) => {
                 if crate::gc::Gc::ptr_eq(a, b) {
                     return true;
                 }
@@ -342,10 +325,13 @@ impl PartialEq for Value {
                 let b_val = b.lock().unwrap().clone();
                 a_val == b_val
             }
-            (Value(ValueRepr::ContainerRef(a)), other)
-            | (other, Value(ValueRepr::ContainerRef(a))) => {
+            (ValueView::ContainerRef(a), _) => {
                 let a_val = a.lock().unwrap().clone();
-                a_val == *other
+                &a_val == other
+            }
+            (_, ValueView::ContainerRef(a)) => {
+                let a_val = a.lock().unwrap().clone();
+                self == &a_val
             }
             _ => false,
         }


### PR DESCRIPTION
## Summary

Third **B-wall-in** slice ([docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md) §4, follows #4446): 403 place-based `ValueRepr::` pattern sites across the type-predicate and equality modules migrate onto `view()`.

| file | sites | notes |
|---|---|---|
| `types_isa.rs` | 142 | `isa_check` classification + named-type `matches!` chains |
| `value_eq.rs` | 97 | `PartialEq` paired match; BigRat arms drop `Box::as_ref` shims (view yields `&NumBigInt`); Mixin/LazyThunk/ContainerRef "either side" arms split per-side so the plain side stays `&Value` |
| `types_eqv.rs` | 70 | `eqv()` paired match → `(self.view(), other.view())` |
| `types_truthy.rs` | 54 | `truthy()` exhaustive match, Failure-handled if-lets |
| `types.rs` | 40 | `what_type_name` / `allomorph_type_name` |

Nested attribute probes go through `.map(Value::view)`; by-value scalar payloads (i64/f64/bool/Symbol) lose their derefs. Migration was driven by two reusable scripts (paren-matching pattern rewriter + cargo-JSON span-driven deref stripper, kept in `tmp/` for the remaining slices).

Remaining worklist: display 91 · serde_support 62 · mod 50 · value_gc 46 · value_methods_a/c 38/37 · value_methods_b 8 (as_sub exemption) · value_collections 1 (owned-position, allowed).

## Test plan

Byte-identical refactor: `make test` green locally (16423 tests), clippy/fmt clean. CI runs the full roast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)