### PR TITLE
feat(grammar): method subrules, embedded-block outer lexicals, dup-token error

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -23,7 +23,7 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 
 ## 現在の前提
 
-- whitelist は **1380**（2026-07-12、`wc -l roast-whitelist.txt`）。
+- whitelist は **1382**（2026-07-12、`wc -l roast-whitelist.txt`）。
 - **roast 由来の大型共通ブロッカーは出尽くした。** かつての大型 campaign
   （真の lazy 配列 / dispatch・演算子 sugar の desugar / S17 並行・非同期 /
   第一級コンテナ container identity / cross-thread lexical writeback）はすべて完了済み。
@@ -47,7 +47,6 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 | 分類 | ファイル | mutsu | raku (v2022.12/6.d) | ブロッカー（一言） |
 |---|---|---|---|---|
 | ★達成可能 | `S32-hash/perl.t` | 47/55・notok 8 | 55/55 満点 | 残 8 は匿名 typed hash `$(my Any %)` の EVAL round-trip 型喪失＝パラメータ化ロール type-capture binding 待ち（匿名 typed 容器タグ付けが binding を壊す既存制限） |
-| ★達成可能 | `6.c/S05-grammar/methods.t` | 4/8・notok 4 | 8/8 満点 | grammar エンジンの深い複合: regex 内 die の伝播、埋め込みブロックの外側レキシカルキャプチャ、dup-token エラー |
 | ★達成可能 | `6.c/S06-other/main-refactored.t` | 0/501 | 501/501 満点 | 新 MAIN インターフェース全体（USAGE 生成・引数 coercion 等）が必要 |
 | 基盤待ち | `S32-str/format.t` | 26/49 で中断 | SORRY（6.e `Format`） | `Formatter::Syntax.parse`→Match、`Formatter.AST`→`RakuAST::Node` を要求＝**RakuAST サブシステム不在**。stub 化は禁止のため据え置き |
 | 基盤待ち | `S02-types/generics.t` | 0/1 | SORRY（6.e） | 6.e coercion type 項 + `Array[T]` サブクラス化が必要。ローカル raku 自身もコンパイル不能で参照検証すらできない |

--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -47,7 +47,6 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 | 分類 | ファイル | mutsu | raku (v2022.12/6.d) | ブロッカー（一言） |
 |---|---|---|---|---|
 | ★達成可能 | `S32-hash/perl.t` | 47/55・notok 8 | 55/55 満点 | 残 8 は匿名 typed hash `$(my Any %)` の EVAL round-trip 型喪失＝パラメータ化ロール type-capture binding 待ち（匿名 typed 容器タグ付けが binding を壊す既存制限） |
-| ★達成可能 | `6.c/S06-other/main-refactored.t` | 0/501 | 501/501 満点 | 新 MAIN インターフェース全体（USAGE 生成・引数 coercion 等）が必要 |
 | 基盤待ち | `S32-str/format.t` | 26/49 で中断 | SORRY（6.e `Format`） | `Formatter::Syntax.parse`→Match、`Formatter.AST`→`RakuAST::Node` を要求＝**RakuAST サブシステム不在**。stub 化は禁止のため据え置き |
 | 基盤待ち | `S02-types/generics.t` | 0/1 | SORRY（6.e） | 6.e coercion type 項 + `Array[T]` サブクラス化が必要。ローカル raku 自身もコンパイル不能で参照検証すらできない |
 | oracle 不能 | `S02-names/pseudo-6d.t` | 116/159 で中断 | SORRY（6.e 要） | `::("CALLER")::<$*bar>` CALLER 疑似パッケージ deref 未対応 |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,29 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-12: `6.c/S05-grammar/methods.t` 完全制覇（grammar メソッド subrule / 埋め込みブロック lexical / dup-token エラー）
+
+`6.c/S05-grammar/methods.t`（4/8 → 8/8、raku 満点）を whitelist 化。BLOCKERS.md の ★達成可能
+項目のうち「grammar エンジンの深い複合」を 3 つの独立した修正で解消した:
+
+- **subrule-as-method 呼び出し + 例外伝播**（test 1/2）: `rule TOP { <.panic> }` のように
+  token/regex/rule に解決しない subrule 名が grammar の**プレーンメソッド**を指す場合、そのメソッドを
+  呼び出す（`try_regex_subrule_as_method`、`regex_match_atom.rs`）。メソッド内の `die` は
+  `PENDING_REGEX_ERROR` 経由で parse の外へ伝播し、silent な非マッチとして握り潰されない。invocant は
+  grammar 型オブジェクト、`copy_full_registry_into` で scratch にメソッドを渡す。
+- **埋め込みブロックの外側 lexical 捕捉**（test 3）: `regex TOP { x { $x = 42 } }` が外側の
+  `my $x` を書き換える。コンパイラが自由変数を現在の grammar パッケージへ auto-qualify する
+  （`$x` → `SetGlobal("G::x")`）ため、`SetGlobal` に**外側 lexical write フォールバック**を追加
+  （GetGlobal の read フォールバックと対称）: qualifier == current_package かつ `our`/package 変数
+  でない qualified 名で、bare 名が env に lexical として存在する場合、bare 名へ書き戻す。
+  `in_regex_code_block` フラグで**埋め込み regex ブロック実行中のみ**に限定し、通常の `our` 書き込みは
+  不変。全長マッチ失敗時でも副作用が残るよう grammar parse で eager code block 収集を有効化
+  （`.parse('xxx')` が 1 文字ルールにマッチ）。メソッド呼び出し後は `pending_local_updates` を
+  呼び出し元スロットへ drain。
+- **dup-token エラーメッセージ**（test 6）: パッケージ内の token/regex 重複宣言のメッセージを raku 形式
+  `Package 'A' already has a regex 'a' (did you mean to declare a multi method?)` に統一
+  （`system_eval_redecl.rs`）。
+
 ## 2026-07-12: モジュール sub OTF ゲート緩和キャンペーン完了（#4427→#4429→#4431→#4437・PLAN §3）
 
 `def_is_otf_compilable_module_single`（`vm/vm_call_func_ops.rs`）の interpreter fallback 除外を

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -2,6 +2,7 @@ roast/6.c/MISC/misc-6.c.t
 roast/6.c/S02-names/SETTING-6c.t
 roast/6.c/S02-types/subset-6c.t
 roast/6.c/S03-operators/set_precedes.t
+roast/6.c/S05-grammar/methods.t
 roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S06-other/main-refactored.t
 roast/6.c/S12-class/mro-6c.t

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -197,16 +197,39 @@ impl Interpreter {
             // (e.g. fired a delimiter finalizer). Reset it so the real match
             // begins from the initial dynamic-var state in `self.env`.
             super::regex::regex_helpers::dynvar_overlay_reset_scan();
+            // Collect embedded `{ ... }` code blocks eagerly so their side effects
+            // (e.g. `regex TOP { x { $x = 42 } }` mutating an outer lexical) persist
+            // even when the OVERALL parse fails because the rule matched a prefix but
+            // not the whole string (`.parse('xxx')` on a rule matching one `x`).
+            // raku runs such blocks as the cursor reaches them, regardless of the
+            // final parse verdict.
+            let want_eager = (method == "parse" || method == "parsefile")
+                && self.has_code_block_in_prefix(&pattern);
+            if want_eager {
+                self.enable_eager_code_blocks();
+            }
             let captures = if method == "parse" || method == "parsefile" {
                 self.regex_match_with_captures_full_from_start(&pattern, &text)
             } else {
                 self.regex_match_with_captures(&pattern, &text)
+            };
+            // Always drain the eager buffer (resets the thread-local). Only run it
+            // on the FAILURE path; on success the winning `captures.code_blocks`
+            // (executed below) are authoritative — the eager buffer over-collects
+            // backtracked branches.
+            let eager_blocks = if want_eager {
+                self.drain_eager_code_blocks()
+            } else {
+                Vec::new()
             };
             // Check for pending regex error (e.g., <sym> used outside proto regex)
             if let Some(err) = Self::take_pending_regex_error() {
                 return Err(err);
             }
             let Some(mut captures) = captures else {
+                if !eager_blocks.is_empty() {
+                    self.execute_regex_code_blocks(&eager_blocks);
+                }
                 let goal = Self::take_pending_goal_failure().or_else(|| {
                     self.parse_regex(&pattern)
                         .and_then(|p| Self::first_goal_name(&p))

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1598,6 +1598,14 @@ pub struct Interpreter {
     /// Slice B.
     pub(crate) carrier_writes: Option<std::collections::HashSet<String>>,
     pub(crate) method_dispatch_pure: bool,
+    /// True while evaluating an embedded regex `{ ... }` code block from a grammar
+    /// rule (`execute_regex_code_blocks`). Such a block closes over the lexical
+    /// scope where the grammar was defined, so a bare free variable the compiler
+    /// auto-qualified to the grammar package (`$x` -> `SetGlobal("G::x")`) must
+    /// fall back to an existing outer lexical of the same bare name. Scopes that
+    /// outer-lexical-write fallback to exactly this context so ordinary `our`/
+    /// package-qualified writes elsewhere are unaffected.
+    pub(crate) in_regex_code_block: bool,
     pub(crate) resume_ip: Option<usize>,
     pub(crate) bind_context: bool,
     pub(crate) scalar_bind_context: bool,

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -296,7 +296,10 @@ impl Interpreter {
                 .iter()
                 .map(|(k, v)| (*k, format!("{:?}", v)))
                 .collect();
+            let saved_in_block = self.in_regex_code_block;
+            self.in_regex_code_block = true;
             let _ = self.eval_block_value(&stmts);
+            self.in_regex_code_block = saved_in_block;
             // Record changed env variables as pending local updates for the outer VM
             for (k, v) in &self.env {
                 let old_repr = snapshot.get(k).map(|s| s.as_str()).unwrap_or("");

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -325,6 +325,17 @@ impl Interpreter {
                 values
             };
             let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
+            // A subrule that resolves to no token/regex/rule but names a plain
+            // METHOD of the grammar (`rule TOP { <.panic> }` where `method panic`
+            // is defined) is a method-call subrule: invoke it. Its exception (e.g.
+            // `die` inside the method) must propagate out of the parse rather than
+            // being swallowed as a silent non-match.
+            if candidates.is_empty()
+                && let Some(result) =
+                    self.try_regex_subrule_as_method(&spec, chars, pos, current_caps, pkg)
+            {
+                return result;
+            }
             if !candidates.is_empty() {
                 let tail: Vec<char> = chars[pos..].to_vec();
                 // The subrule candidates match `tail` (a slice from `pos`) at
@@ -509,6 +520,94 @@ impl Interpreter {
             )
             .into_iter()
             .collect()
+        }
+    }
+
+    /// Dispatch a subrule that names a plain grammar METHOD (not a token/regex/rule).
+    /// `rule TOP { <.panic> }` where `method panic { die ... }` calls the method;
+    /// its exception propagates via `PENDING_REGEX_ERROR` (checked by the grammar
+    /// parse driver) instead of being swallowed as a silent non-match. Returns:
+    /// - `None` — not a method subrule; caller falls through to the normal path.
+    /// - `Some(vec![])` — dispatched but produced no match (method died → pending
+    ///   error set, or returned an undefined/false cursor).
+    /// - `Some(vec![(end, caps)])` — the method returned a defined Match/Cursor.
+    fn try_regex_subrule_as_method(
+        &self,
+        spec: &NamedRegexLookupSpec,
+        chars: &[char],
+        pos: usize,
+        current_caps: &RegexCaptures,
+        pkg: &str,
+    ) -> Option<Vec<(usize, RegexCaptures)>> {
+        // Only plain, argument-less identifier subrules dispatched against a real
+        // grammar package. `<::>` indirection, char-class specs, and builtin
+        // assertions are handled elsewhere.
+        if spec.token_lookup
+            || !spec.arg_exprs.is_empty()
+            || pkg.is_empty()
+            || spec.lookup_name.is_empty()
+            || spec.lookup_name.contains("::")
+            || !spec
+                .lookup_name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
+            return None;
+        }
+        // The name must be a user method declared directly on this grammar (not an
+        // inherited Cursor/Grammar builtin, which the normal subrule/builtin paths
+        // already cover).
+        let is_user_method = self
+            .registry()
+            .classes
+            .get(pkg)
+            .is_some_and(|cd| cd.methods.contains_key(&spec.lookup_name));
+        if !is_user_method {
+            return None;
+        }
+        // Run the method in a scratch interpreter (mirrors `eval_regex_code_assertion`).
+        // The invocant is the grammar type object so method resolution finds the
+        // grammar's own method (a Match cursor would resolve against `Match` and
+        // miss it). Full Cursor-self semantics are a deeper feature; a method used
+        // purely for its side effect / exception (`<.panic>`) does not need it.
+        let invocant = Value::package(crate::symbol::Symbol::intern(pkg));
+        let mut interp = Interpreter {
+            env: self.env.clone(),
+            current_package: Arc::new(RwLock::new(pkg.to_string())),
+            ..Self::new_regex_scratch()
+        };
+        // Full registry: the grammar's methods live in `Registry::classes`, which
+        // the lean `copy_decl_registry_into` omits.
+        self.copy_full_registry_into(&mut interp);
+        if self.test_module_loaded() {
+            interp.loaded_modules = self.loaded_modules.clone();
+            interp.tap.ensure_state();
+        }
+        match interp.call_method_with_values(invocant, &spec.lookup_name, Vec::new()) {
+            Err(e) => {
+                // Propagate the method's exception (e.g. `die`) out of the parse.
+                crate::runtime::regex_parse::PENDING_REGEX_ERROR.with(|slot| {
+                    *slot.borrow_mut() = Some(e);
+                });
+                Some(Vec::new())
+            }
+            Ok(v) => {
+                // A defined Match/Cursor return advances the parse by its extent.
+                if let ValueView::Instance { attributes, .. } = v.view()
+                    && let Some(to) = attributes
+                        .as_map()
+                        .get("to")
+                        .and_then(|t| t.as_int())
+                        .filter(|&t| t >= 0)
+                {
+                    let end = pos + to as usize;
+                    if end <= chars.len() {
+                        return Some(vec![(end, current_caps.clone())]);
+                    }
+                }
+                // Undefined / non-cursor return → treated as a non-match.
+                Some(Vec::new())
+            }
         }
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2178,6 +2178,7 @@ impl Interpreter {
             current_code: 0,
             carrier_writes: None,
             method_dispatch_pure: false,
+            in_regex_code_block: false,
             resume_ip: None,
             bind_context: false,
             scalar_bind_context: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -339,6 +339,7 @@ impl Interpreter {
             current_code: 0,
             carrier_writes: None,
             method_dispatch_pure: false,
+            in_regex_code_block: false,
             resume_ip: None,
             bind_context: false,
             scalar_bind_context: false,

--- a/src/runtime/system_eval_redecl.rs
+++ b/src/runtime/system_eval_redecl.rs
@@ -96,7 +96,7 @@ impl Interpreter {
         // (or two `token`s/`regex`es) of the same name are an X::Redeclaration,
         // just like at the top level. (`my`/`our`-scoped methods/tokens are
         // covered by `dup_scoped_method`; this covers plain `sub`/`token`.)
-        let dup_routine_in_body = |body: &[Stmt]| -> Option<RuntimeError> {
+        let dup_routine_in_body = |type_name: &str, body: &[Stmt]| -> Option<RuntimeError> {
             let mut seen_subs: HashMap<String, bool> = HashMap::new();
             let mut seen_tokens: HashSet<String> = HashSet::new();
             for s in body {
@@ -141,10 +141,18 @@ impl Interpreter {
                             let mut attrs = std::collections::HashMap::new();
                             attrs.insert("symbol".to_string(), Value::str(n.clone()));
                             attrs.insert("what".to_string(), Value::str("regex".to_string()));
-                            attrs.insert(
-                                "message".to_string(),
-                                Value::str(format!("Redeclaration of regex '{}'", n)),
-                            );
+                            // Rakudo phrases a token/regex redeclaration inside a
+                            // package as "Package 'X' already has a regex 'a' ...",
+                            // distinct from the plain "Redeclaration of ..." form.
+                            let msg = if type_name.is_empty() {
+                                format!("Redeclaration of regex '{}'", n)
+                            } else {
+                                format!(
+                                    "Package '{}' already has a regex '{}' (did you mean to declare a multi method?)",
+                                    type_name, n
+                                )
+                            };
+                            attrs.insert("message".to_string(), Value::str(msg));
                             return Some(RuntimeError::typed("X::Redeclaration", attrs));
                         }
                     }
@@ -239,7 +247,7 @@ impl Interpreter {
                     if let Some(err) = dup_scoped_method(body) {
                         return Err(err);
                     }
-                    if let Some(err) = dup_routine_in_body(body) {
+                    if let Some(err) = dup_routine_in_body(&name.resolve(), body) {
                         return Err(err);
                     }
                     let name = name.resolve().to_string();
@@ -284,7 +292,7 @@ impl Interpreter {
                     if let Some(err) = dup_scoped_method(body) {
                         return Err(err);
                     }
-                    if let Some(err) = dup_routine_in_body(body) {
+                    if let Some(err) = dup_routine_in_body(&name.resolve(), body) {
                         return Err(err);
                     }
                     (name.resolve().to_string(), body_is_stub(body))
@@ -307,13 +315,13 @@ impl Interpreter {
                     }
                     (name.resolve().to_string(), false)
                 }
-                Stmt::Package { body, .. } => {
+                Stmt::Package { name, body, .. } => {
                     // `package`/`module` bodies: a duplicate `sub` is the same
                     // X::Redeclaration as inside a class. (The package name itself
                     // shares the type namespace, but block-scoped leakage makes a
                     // registry-based check unsafe, so only the in-body routine
                     // check runs here.)
-                    if let Some(err) = dup_routine_in_body(body) {
+                    if let Some(err) = dup_routine_in_body(&name.resolve(), body) {
                         return Err(err);
                     }
                     continue;

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -967,6 +967,45 @@ impl Interpreter {
         self.pending_caller_var_writeback = retained;
     }
 
+    /// Drain `pending_local_updates` logged by an embedded regex `{ ... }` block
+    /// (via `execute_regex_code_blocks`) into the caller's local slots after a
+    /// method call. A `Grammar.parse` runs its rule's embedded code blocks inside
+    /// this same interpreter, writing caller lexicals straight into `env` (e.g.
+    /// `regex TOP { x { $x = 42 } }` mutating an outer `$x`); like the smartmatch
+    /// path (`vm_smartmatch_ops`), write those through to the caller's local slots
+    /// so the slot stays coherent, and record the miss for a caller-var writeback
+    /// when the owning slot lives further up the stack. No-op unless a block wrote.
+    pub(super) fn drain_pending_local_updates_after_call(&mut self, code: &CompiledCode) {
+        if self.pending_local_updates.is_empty() {
+            return;
+        }
+        // Only reconcile plain user variable names; internal/magic keys the block
+        // touches (`?LINE`, `__mutsu_*`, `$/`-derived, …) are not caller lexicals.
+        let is_user_var = |n: &str| -> bool {
+            !n.is_empty()
+                && !n.starts_with('?')
+                && !n.starts_with("__")
+                && n.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
+        };
+        let written: std::collections::HashSet<String> = self
+            .pending_local_updates
+            .iter()
+            .map(|(n, _)| n.clone())
+            .filter(|n| is_user_var(n))
+            .collect();
+        self.writeback_match_locals(code, &written);
+        for name in &written {
+            let is_match_name =
+                name == "/" || (!name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()));
+            if is_match_name || self.find_local_slot(code, name).is_some() {
+                continue;
+            }
+            self.record_caller_var_writeback(name);
+        }
+        self.pending_local_updates.clear();
+    }
+
     /// Slice F (multi-frame coherence): drain after a *cached fast-call* dispatch
     /// (positional-light / light / 0-arg fast / OTF), mirroring the slow path's
     /// post-`dispatch_func_call_inner` reconcile.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -748,7 +748,48 @@ impl Interpreter {
                     *ip += 1;
                     return Ok(());
                 }
-                let name = name_str.to_string();
+                let mut name = name_str.to_string();
+                // Outer-lexical write fallback (symmetric with the GetGlobal read
+                // fallback above): the compiler auto-qualifies a bare free variable
+                // with the current package (`$x` inside `grammar G { ... }` compiles
+                // to `SetGlobal("G::x")`). When that qualified name is NOT a real
+                // package/`our` variable but the BARE name IS a captured lexical in
+                // env (an outer `my $x` the block closes over — e.g. an embedded
+                // `regex TOP { x { $x = 42 } }` mutating a top-level lexical),
+                // redirect the write to the bare lexical so the outer variable is
+                // updated in place instead of stranding a stray `G::x` package var.
+                // Confined to embedded regex code blocks so ordinary `our`/
+                // package-qualified writes are never redirected.
+                if self.in_regex_code_block
+                    && !is_rebind
+                    && let Some(pos) = name.rfind("::")
+                {
+                    // Split an optional leading sigil, then `Qualifier::tail`.
+                    let sigil = match name.as_bytes().first().copied() {
+                        Some(b @ (b'$' | b'@' | b'%' | b'&')) => Some(b as char),
+                        _ => None,
+                    };
+                    let sig_len = sigil.map(|_| 1).unwrap_or(0);
+                    let qualifier = &name[sig_len..pos];
+                    let bare_after = &name[pos + 2..];
+                    if !qualifier.is_empty() && !bare_after.is_empty() && !bare_after.contains("::")
+                    {
+                        let cur = self.current_package();
+                        let bare = match sigil {
+                            Some(s) => format!("{s}{bare_after}"),
+                            None => bare_after.to_string(),
+                        };
+                        if !cur.is_empty()
+                            && cur != "GLOBAL"
+                            && qualifier == cur
+                            && self.get_our_var(&name).is_none()
+                            && !self.env().contains_key(&name)
+                            && self.env().contains_key(&bare)
+                        {
+                            name = bare;
+                        }
+                    }
+                }
                 // Reject private attribute twigil (!) assignment when no self is available
                 {
                     let bare = name.trim_start_matches(['$', '@', '%', '&']);
@@ -2742,6 +2783,9 @@ impl Interpreter {
                 // Slice F: write any `is rw` method-param writeback through to the
                 // caller's local slot (no-op unless the dispatch recorded one).
                 self.apply_pending_rw_writeback(code);
+                // A `Grammar.parse` may run embedded regex `{ ... }` blocks that
+                // wrote caller lexicals into `env`; reconcile them into slots.
+                self.drain_pending_local_updates_after_call(code);
                 *ip += 1;
             }
             OpCode::CallMethodDynamic {
@@ -2762,6 +2806,7 @@ impl Interpreter {
                 }
                 // Slice F: drain any `is rw` method-param writeback into the caller's slots.
                 self.apply_pending_rw_writeback(code);
+                self.drain_pending_local_updates_after_call(code);
                 *ip += 1;
             }
             OpCode::CallMethodDynamicMut {
@@ -2785,6 +2830,7 @@ impl Interpreter {
                     }
                 }
                 self.apply_pending_rw_writeback(code);
+                self.drain_pending_local_updates_after_call(code);
                 self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }
@@ -2839,6 +2885,7 @@ impl Interpreter {
                     }
                 }
                 self.apply_pending_rw_writeback(code);
+                self.drain_pending_local_updates_after_call(code);
                 self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
                 *ip += 1;
             }

--- a/t/grammar-method-subrule.t
+++ b/t/grammar-method-subrule.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A subrule that names a plain grammar method calls it; an exception thrown
+# inside the method propagates out of the parse instead of being swallowed.
+grammar WithMethod {
+    rule TOP { 'lorem' | <.panic> }
+    method panic { die "The sky is falling!"; }
+}
+
+dies-ok { WithMethod.parse('unrelated') },
+    'die() from a method-subrule propagates out of the parse';
+
+try { WithMethod.parse('unrelated') };
+ok ~$! ~~ /'The sky is falling!'/, 'and the exception message is preserved';
+
+# An embedded { ... } block in a grammar rule closes over the outer lexical
+# scope where the grammar was defined.
+my $x = 0;
+grammar WithOuterLex {
+    regex TOP { x { $x = 42 } }
+}
+WithOuterLex.parse('xxx');
+is $x, 42, 'regex code block in a grammar writes an outer lexical';
+
+# The write reaches the outer lexical even from inside a sub scope.
+sub in-sub {
+    my $y = 0;
+    grammar G { regex TOP { x { $y = 7 } } }
+    G.parse('x');
+    $y;
+}
+is in-sub(), 7, 'outer lexical write works from a sub-local scope';
+
+# A duplicate token/regex declaration in a package is a redeclaration error
+# phrased the Rakudo way ("already has a regex").
+try { EVAL 'grammar Dup { token a { ... }; token a { ... } }' };
+ok ~$! ~~ /:i 'already has a regex' /, 'duplicate token errors sanely';


### PR DESCRIPTION
Passes `6.c/S05-grammar/methods.t` (4/8 → 8/8, raku full marks) by resolving the three deep grammar-engine blockers recorded in `TODO_roast/BLOCKERS.md`.

## Changes

### 1. Method-call subrules + exception propagation (tests 1, 2)
`rule TOP { 'lorem' | <.panic> }` where `method panic { die ... }` — a subrule that resolves to no token/regex/rule but names a plain grammar **method** now invokes it (`try_regex_subrule_as_method` in `regex_match_atom.rs`). The method's exception propagates out of the parse via `PENDING_REGEX_ERROR` instead of being swallowed as a silent non-match. Invocant is the grammar type object; the scratch interp gets the full registry (`copy_full_registry_into`) so the method resolves.

### 2. Embedded `{ ... }` blocks capture outer lexicals (test 3)
`regex TOP { x { $x = 42 } }` writes the enclosing `my $x`. The compiler auto-qualifies a bare free variable to the grammar package (`$x` → `SetGlobal("G::x")`), so `SetGlobal` gains an **outer-lexical-write fallback** symmetric with the existing `GetGlobal` read fallback: a qualified name whose qualifier is the current package and that is not a real `our`/package var, but whose bare name is a captured lexical in `env`, is redirected to the bare name. Confined to embedded regex blocks via an `in_regex_code_block` flag so ordinary `our`/package writes are untouched. Grammar parse now collects code blocks eagerly so side effects persist even when the overall parse fails on a length mismatch (`.parse('xxx')` on a one-char rule), and drains `pending_local_updates` into caller slots after a method call.

### 3. Duplicate token error message (test 6)
Duplicate `token`/`regex` declaration in a package now uses the Rakudo wording: `Package 'A' already has a regex 'a' (did you mean to declare a multi method?)`.

## Testing
- `roast/6.c/S05-grammar/methods.t`: 8/8, added to `roast-whitelist.txt`.
- New `t/grammar-method-subrule.t` pins all three behaviors.
- `make test` green; all whitelisted S05 + S02 package/our/name tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)