### PR TITLE
refactor(value): B-wall-in slice 4 — display/serde/gc/methods (completes wall-in)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -161,12 +161,15 @@ sweep まで含めて完了 — 経緯と詳細は [news/2026-07.md](news/2026-0
       3b-1 step A `Value` newtype seal ✅（2026-07-11）・step B コア表現
       （`src/value/nanbox/`: 8B word・全 variant ロスレス pack/unpack・Clone/Drop・kind 表）✅。
       設計とスライス計画 = [docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md)
-      （[ADR-0005](docs/adr/0005-nanbox-representation-encoding.md) Accepted 2026-07-12）。残:
-      **B-wall-in**（`src/value/` 内部 866 サイトの `ValueRepr::` パターンを view()/into_repr()/
-      with_*_mut へ機械移行・byte-identical 複数 PR）→ **B-guards**（`ValueView` ポインタ
-      フィールドを guard 型 `ArcRef`/`GcRef` へ）→ **B-flip**（`Value(ValueRepr)` →
-      `Value(NanBox)`・`value_size_guard` 48→8）。ゲート = make test＋roast＋gc-stress green・
-      GC カウンタ不変・[docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.2 マイクロベンチ。
+      （[ADR-0005](docs/adr/0005-nanbox-representation-encoding.md) Accepted 2026-07-12）。
+      **B-wall-in ✅**（内部 ~740 place-based サイトを view()/into_repr()/from_repr() へ
+      機械移行済み。残 `ValueRepr::` は seam〔view.rs・mod.rs shim〕と owned-position 合法形、
+      ＋文書化済み例外 2 = `as_sub`/`hash_is_itemized`）。残:
+      **B-guards**（`ValueView` ポインタフィールドを guard 型 `ArcRef`/`GcRef` へ）→
+      **B-flip**（`Value(ValueRepr)` → `Value(NanBox)`・view()/shim/same_variant/Trace/serde の
+      seam 差し替え・mod.rs 内テストの追随・`value_size_guard` 48→8）。ゲート = make test＋
+      roast＋gc-stress green・GC カウンタ不変・
+      [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.2 マイクロベンチ。
 - [ ] 層3a hardening（H1 継続計測〜H5 background collect の着手トリガ）=
       [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) 参照。grammar パースの候補 push
       自体（~510k/200-parse）の抑制は未着手（実害＝メモリ保持は `Weak` 化で解消済み）。

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -22,14 +22,14 @@ pub(crate) fn user_facing_type_name(name: &str) -> &str {
 
 /// Format a value for display inside a Capture gist.
 fn capture_value_gist(v: &Value) -> String {
-    match v {
-        Value(ValueRepr::Str(s)) => format!("\"{}\"", s),
-        Value(ValueRepr::Mixin(inner, mixins)) => {
+    match v.view() {
+        ValueView::Str(s) => format!("\"{}\"", s),
+        ValueView::Mixin(inner, mixins) => {
             if let Some(str_val) = mixins.get("Str") {
                 let str_s = str_val.to_string_value();
-                let type_name = match inner.as_ref() {
-                    Value(ValueRepr::Int(_)) | Value(ValueRepr::BigInt(_)) => "IntStr",
-                    Value(ValueRepr::Num(_)) => "NumStr",
+                let type_name = match inner.view() {
+                    ValueView::Int(_) | ValueView::BigInt(_) => "IntStr",
+                    ValueView::Num(_) => "NumStr",
                     _ => "Allomorph",
                 };
                 format!(
@@ -352,27 +352,27 @@ fn has_terminating_decimal_bigint(denom: &NumBigInt) -> bool {
 
 impl Value {
     pub(crate) fn to_string_value(&self) -> String {
-        match self {
-            Value(ValueRepr::Int(i)) => i.to_string(),
-            Value(ValueRepr::BigInt(n)) => n.to_string(),
-            Value(ValueRepr::Num(f)) => {
+        match self.view() {
+            ValueView::Int(i) => i.to_string(),
+            ValueView::BigInt(n) => n.to_string(),
+            ValueView::Num(f) => {
                 if f.is_nan() {
                     "NaN".to_string()
                 } else if f.is_infinite() {
-                    if *f > 0.0 {
+                    if f > 0.0 {
                         "Inf".to_string()
                     } else {
                         "-Inf".to_string()
                     }
-                } else if *f == 0.0 && f.is_sign_negative() {
+                } else if f == 0.0 && f.is_sign_negative() {
                     "-0".to_string()
                 } else if f.fract() == 0.0 && f.is_finite() {
                     let abs = f.abs();
                     if abs >= 1e15 || (abs != 0.0 && abs < 1e-4) {
                         // Scientific notation for very large/small integer-valued Nums
-                        format_num_scientific(*f)
+                        format_num_scientific(f)
                     } else {
-                        format!("{}", *f as i64)
+                        format!("{}", f as i64)
                     }
                 } else {
                     // Fractional Num: Raku renders in scientific notation once the
@@ -381,76 +381,71 @@ impl Value {
                     // apply the same threshold as the integer-valued branch.
                     let abs = f.abs();
                     if !(1e-4..1e15).contains(&abs) {
-                        format_num_scientific(*f)
+                        format_num_scientific(f)
                     } else {
                         format!("{}", f)
                     }
                 }
             }
-            Value(ValueRepr::Str(s)) => (**s).clone(),
-            Value(ValueRepr::Bool(true)) => "True".to_string(),
-            Value(ValueRepr::Bool(false)) => "False".to_string(),
-            Value(ValueRepr::Range(a, b)) => {
+            ValueView::Str(s) => (**s).clone(),
+            ValueView::Bool(true) => "True".to_string(),
+            ValueView::Bool(false) => "False".to_string(),
+            ValueView::Range(a, b) => {
                 // .Str on a finite range iterates elements and joins with spaces.
                 // For infinite/very large ranges, fall back to range notation.
-                if b.saturating_sub(*a) > 1_000_000 || *b == i64::MAX || *a == i64::MIN {
+                if b.saturating_sub(a) > 1_000_000 || b == i64::MAX || a == i64::MIN {
                     format!("{}..{}", a, b)
                 } else {
-                    (*a..=*b)
-                        .map(|i| i.to_string())
-                        .collect::<Vec<_>>()
-                        .join(" ")
+                    (a..=b).map(|i| i.to_string()).collect::<Vec<_>>().join(" ")
                 }
             }
-            Value(ValueRepr::RangeExcl(a, b)) => {
-                if b.saturating_sub(*a) > 1_000_000 || *b == i64::MAX || *a == i64::MIN {
+            ValueView::RangeExcl(a, b) => {
+                if b.saturating_sub(a) > 1_000_000 || b == i64::MAX || a == i64::MIN {
                     format!("{}..^{}", a, b)
                 } else {
-                    (*a..*b)
-                        .map(|i| i.to_string())
-                        .collect::<Vec<_>>()
-                        .join(" ")
+                    (a..b).map(|i| i.to_string()).collect::<Vec<_>>().join(" ")
                 }
             }
-            Value(ValueRepr::RangeExclStart(a, b)) => {
-                if b.saturating_sub(*a) > 1_000_000 || *b == i64::MAX || *a == i64::MIN {
+            ValueView::RangeExclStart(a, b) => {
+                if b.saturating_sub(a) > 1_000_000 || b == i64::MAX || a == i64::MIN {
                     format!("{}^..{}", a, b)
                 } else {
-                    (*a + 1..=*b)
+                    (a + 1..=b)
                         .map(|i| i.to_string())
                         .collect::<Vec<_>>()
                         .join(" ")
                 }
             }
-            Value(ValueRepr::RangeExclBoth(a, b)) => {
-                if b.saturating_sub(*a) > 1_000_000 || *b == i64::MAX || *a == i64::MIN {
+            ValueView::RangeExclBoth(a, b) => {
+                if b.saturating_sub(a) > 1_000_000 || b == i64::MAX || a == i64::MIN {
                     format!("{}^..^{}", a, b)
                 } else {
-                    (*a + 1..*b)
+                    (a + 1..b)
                         .map(|i| i.to_string())
                         .collect::<Vec<_>>()
                         .join(" ")
                 }
             }
-            Value(ValueRepr::GenericRange {
+            ValueView::GenericRange {
                 start,
                 end,
                 excl_start,
                 excl_end,
-            }) => {
+            } => {
                 let is_infinite = matches!(
-                    end.as_ref(),
-                    Value(ValueRepr::Whatever)
-                        | Value(ValueRepr::HyperWhatever)
-                        | Value(ValueRepr::Sub(_))
-                ) || matches!(end.as_ref(), Value(ValueRepr::Num(n)) if n.is_infinite() && n.is_sign_positive());
+                    end.view(),
+                    ValueView::Whatever | ValueView::HyperWhatever | ValueView::Sub(_)
+                ) || matches!(end.view(), ValueView::Num(n) if n.is_infinite() && n.is_sign_positive());
                 if !is_infinite {
                     let items = crate::runtime::utils::value_to_list(self);
                     // `value_to_list` may return `[self.clone()]` for non-expandable ranges
                     // (e.g. NaN endpoints). Avoid recursive `.Str` by only expanding when
                     // the single returned item is not itself a GenericRange.
                     let single_generic_range = items.len() == 1
-                        && matches!(items.first(), Some(Value(ValueRepr::GenericRange { .. })));
+                        && matches!(
+                            items.first().map(Value::view),
+                            Some(ValueView::GenericRange { .. })
+                        );
                     if !single_generic_range {
                         return items
                             .iter()
@@ -459,8 +454,8 @@ impl Value {
                             .join(" ");
                     }
                 }
-                let start_sep = if *excl_start { "^.." } else { ".." };
-                let end_sep = if *excl_end { "^" } else { "" };
+                let start_sep = if excl_start { "^.." } else { ".." };
+                let end_sep = if excl_end { "^" } else { "" };
                 format!(
                     "{}{}{}{}",
                     start.to_string_value(),
@@ -469,8 +464,8 @@ impl Value {
                     end.to_string_value()
                 )
             }
-            Value(ValueRepr::Array(_, crate::value::ArrayKind::Lazy)) => "...".to_string(),
-            Value(ValueRepr::Array(items, ..)) => {
+            ValueView::Array(_, crate::value::ArrayKind::Lazy) => "...".to_string(),
+            ValueView::Array(items, ..) => {
                 // Cycle detection for recursive array structures
                 thread_local! {
                     static SEEN_ARR_PTRS: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
@@ -497,7 +492,7 @@ impl Value {
                 });
                 result
             }
-            Value(ValueRepr::LazyList(ll)) => {
+            ValueView::LazyList(ll) => {
                 if ll.is_genuinely_lazy() {
                     // Str/interpolation of a genuinely-lazy list renders `...`
                     // (Rakudo) rather than materializing the sequence.
@@ -517,9 +512,9 @@ impl Value {
                         })
                 }
             }
-            Value(ValueRepr::LazyIoLines { .. }) => "(...)".to_string(),
-            Value(ValueRepr::Uni(u)) => u.text.clone(),
-            Value(ValueRepr::Hash(items, _)) => {
+            ValueView::LazyIoLines { .. } => "(...)".to_string(),
+            ValueView::Uni(u) => u.text.clone(),
+            ValueView::Hash(items) => {
                 // Cycle detection for recursive hash structures
                 thread_local! {
                     static SEEN_HASH_PTRS: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
@@ -554,44 +549,43 @@ impl Value {
                 });
                 pairs.join("\n")
             }
-            Value(ValueRepr::Rat(n, d)) => {
-                if *d == 0 {
-                    if *n == 0 {
+            ValueView::Rat(n, d) => {
+                if d == 0 {
+                    if n == 0 {
                         "NaN".to_string()
-                    } else if *n > 0 {
+                    } else if n > 0 {
                         "Inf".to_string()
                     } else {
                         "-Inf".to_string()
                     }
-                } else if *n % *d == 0 {
+                } else if n % d == 0 {
                     // Exact integer: Rat(10, 2) => "5"
-                    format!("{}", *n / *d)
-                } else if has_terminating_decimal(*d) {
+                    format!("{}", n / d)
+                } else if has_terminating_decimal(d) {
                     // Exact decimal representation without f64 rounding.
-                    format_terminating_ratio_exact(*n, *d, false)
+                    format_terminating_ratio_exact(n, d, false)
                 } else {
-                    format_nonterminating_ratio(*n, *d)
+                    format_nonterminating_ratio(n, d)
                 }
             }
-            Value(ValueRepr::FatRat(a, b)) => {
-                if *b == 0 {
-                    if *a == 0 {
+            ValueView::FatRat(a, b) => {
+                if b == 0 {
+                    if a == 0 {
                         "NaN".to_string()
-                    } else if *a > 0 {
+                    } else if a > 0 {
                         "Inf".to_string()
                     } else {
                         "-Inf".to_string()
                     }
-                } else if *a % *b == 0 {
-                    format!("{}", *a / *b)
-                } else if has_terminating_decimal(*b) {
-                    format_terminating_ratio_exact(*a, *b, false)
+                } else if a % b == 0 {
+                    format!("{}", a / b)
+                } else if has_terminating_decimal(b) {
+                    format_terminating_ratio_exact(a, b, false)
                 } else {
-                    format_nonterminating_ratio(*a, *b)
+                    format_nonterminating_ratio(a, b)
                 }
             }
-            Value(ValueRepr::BigRat(n, d)) => {
-                let (n, d) = (n.as_ref(), d.as_ref());
+            ValueView::BigRat(n, d) => {
                 if d.is_zero() {
                     if n.is_zero() {
                         "NaN".to_string()
@@ -615,8 +609,8 @@ impl Value {
                     strip_trailing_zeros(&s)
                 }
             }
-            Value(ValueRepr::Complex(r, i)) => format_complex(*r, *i),
-            Value(ValueRepr::Set(s, _)) => {
+            ValueView::Complex(r, i) => format_complex(r, i),
+            ValueView::Set(s, _) => {
                 let mut keys: Vec<&String> = s.iter().collect();
                 keys.sort();
                 keys.iter()
@@ -624,7 +618,7 @@ impl Value {
                     .collect::<Vec<_>>()
                     .join(" ")
             }
-            Value(ValueRepr::Bag(b, _)) => {
+            ValueView::Bag(b, _) => {
                 let mut keys: Vec<(&String, &num_bigint::BigInt)> = b.iter().collect();
                 keys.sort_by_key(|(k, _)| (*k).clone());
                 keys.iter()
@@ -638,7 +632,7 @@ impl Value {
                     .collect::<Vec<_>>()
                     .join(" ")
             }
-            Value(ValueRepr::Mix(m, _)) => {
+            ValueView::Mix(m, _) => {
                 let mut keys: Vec<(&String, &f64)> = m.iter().collect();
                 keys.sort_by_key(|(k, _)| (*k).clone());
                 keys.iter()
@@ -660,15 +654,15 @@ impl Value {
             // `(B => Any).Str eq (B => Mu).Str` (both "B\t"), so `is %h<k>:!p,
             // (k => SomeType)` compares equal for any type-object default
             // (S32-hash/adverbs object-hash missing-key defaults).
-            Value(ValueRepr::Pair(k, v)) => format!("{}\t{}", k, v.to_str_context()),
-            Value(ValueRepr::ValuePair(k, v)) => {
+            ValueView::Pair(k, v) => format!("{}\t{}", k, v.to_str_context()),
+            ValueView::ValuePair(k, v) => {
                 format!("{}\t{}", k.to_str_context(), v.to_str_context())
             }
-            Value(ValueRepr::Enum { key, .. }) => key.resolve(),
-            Value(ValueRepr::CompUnitDepSpec { short_name }) => {
+            ValueView::Enum { key, .. } => key.resolve(),
+            ValueView::CompUnitDepSpec { short_name } => {
                 format!("CompUnit::DependencySpecification({})", short_name)
             }
-            Value(ValueRepr::Package(s)) => {
+            ValueView::Package(s) => {
                 let resolved = s.resolve();
                 if is_internal_anon_type_name(&resolved) {
                     "()".to_string()
@@ -676,44 +670,44 @@ impl Value {
                     format!("({})", user_facing_type_name(&resolved))
                 }
             }
-            Value(ValueRepr::ParametricRole {
+            ValueView::ParametricRole {
                 base_name,
                 type_args,
-            }) => {
+            } => {
                 let args: Vec<String> = type_args.iter().map(|a| a.to_string_value()).collect();
                 format!("({}[{}])", base_name, args.join(","))
             }
-            Value(ValueRepr::Routine { package, name, .. }) => format!("{}::{}", package, name),
-            Value(ValueRepr::Sub(data)) => data.name.resolve(),
-            Value(ValueRepr::WeakSub(weak)) => match weak.upgrade() {
+            ValueView::Routine { package, name, .. } => format!("{}::{}", package, name),
+            ValueView::Sub(data) => data.name.resolve(),
+            ValueView::WeakSub(weak) => match weak.upgrade() {
                 Some(data) => data.name.resolve(),
                 None => String::new(),
             },
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Backtrace" => attributes
+            } if class_name == "Backtrace" => attributes
                 .as_map()
                 .get("text")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "IO::Path" || class_name.resolve().starts_with("IO::Path::") => {
+            } if class_name == "IO::Path" || class_name.resolve().starts_with("IO::Path::") => {
                 attributes
                     .as_map()
                     .get("path")
                     .map(|v: &Value| v.to_string_value())
                     .unwrap_or_else(|| format!("{}()", class_name))
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Exception"
+            } if class_name == "Exception"
                 || class_name.resolve().starts_with("X::")
                 || class_name.resolve().starts_with("CX::") =>
             {
@@ -723,39 +717,41 @@ impl Value {
                     .map(|v: &Value| v.to_string_value())
                     .unwrap_or_else(|| format!("{}()", class_name))
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "ObjAt" || class_name == "ValueObjAt" => attributes
+            } if class_name == "ObjAt" || class_name == "ValueObjAt" => attributes
                 .as_map()
                 .get("WHICH")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Match" => attributes
+            } if class_name == "Match" => attributes
                 .as_map()
                 .get("str")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Proc" => attributes
+            } if class_name == "Proc" => attributes
                 .as_map()
                 .get("exitcode")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                if let Some(Value(ValueRepr::Array(bytes, ..))) = attributes.as_map().get("bytes") {
+            } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
+                if let Some(ValueView::Array(bytes, ..)) =
+                    attributes.as_map().get("bytes").map(Value::view)
+                {
                     if bytes.is_empty() {
                         format!("{}()", class_name)
                     } else {
@@ -772,16 +768,16 @@ impl Value {
                         };
                         let hex: Vec<String> = bytes
                             .iter()
-                            .map(|b| match b {
-                                Value(ValueRepr::Int(i)) => {
+                            .map(|b| match b.view() {
+                                ValueView::Int(i) => {
                                     if hex_width == 16 {
-                                        format!("{:016X}", *i as u64)
+                                        format!("{:016X}", i as u64)
                                     } else if hex_width == 8 {
-                                        format!("{:08X}", *i as u32)
+                                        format!("{:08X}", i as u32)
                                     } else if hex_width == 4 {
-                                        format!("{:04X}", *i as u16)
+                                        format!("{:04X}", i as u16)
                                     } else {
-                                        format!("{:02X}", *i as u8)
+                                        format!("{:02X}", i as u8)
                                     }
                                 }
                                 _ => "0".repeat(hex_width),
@@ -793,11 +789,11 @@ impl Value {
                     format!("{}()", class_name)
                 }
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Instant" => {
+            } if class_name == "Instant" => {
                 let val = attributes
                     .as_map()
                     .get("value")
@@ -805,11 +801,11 @@ impl Value {
                     .unwrap_or(0.0);
                 format!("Instant:{}", val)
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Duration" => {
+            } if class_name == "Duration" => {
                 let val = attributes
                     .as_map()
                     .get("value")
@@ -821,52 +817,54 @@ impl Value {
                     format!("{}", val)
                 }
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Signature" => attributes
+            } if class_name == "Signature" => attributes
                 .as_map()
                 .get("gist")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Stash" => attributes
+            } if class_name == "Stash" => attributes
                 .as_map()
                 .get("name")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Method" || class_name == "Sub" || class_name == "Routine" => {
+            } if class_name == "Method" || class_name == "Sub" || class_name == "Routine" => {
                 attributes
                     .as_map()
                     .get("name")
                     .map(|v: &Value| v.to_string_value())
                     .unwrap_or_else(|| format!("{}()", class_name))
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Format" => attributes
+            } if class_name == "Format" => attributes
                 .as_map()
                 .get("format")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
-            Value(ValueRepr::Instance { attributes, .. })
+            ValueView::Instance { attributes, .. }
                 if attributes.contains_key("year")
                     && attributes.contains_key("month")
                     && attributes.contains_key("day")
                     && !attributes.contains_key("hour") =>
             {
-                if let Some(Value(ValueRepr::Str(s))) =
-                    attributes.as_map().get("__formatter_rendered")
+                if let Some(ValueView::Str(s)) = attributes
+                    .as_map()
+                    .get("__formatter_rendered")
+                    .map(Value::view)
                 {
                     return s.to_string();
                 }
@@ -874,7 +872,7 @@ impl Value {
                     crate::builtins::methods_0arg::temporal::date_attrs(&(attributes).as_map());
                 crate::builtins::methods_0arg::temporal::format_date(y, m, d)
             }
-            Value(ValueRepr::Instance { attributes, .. })
+            ValueView::Instance { attributes, .. }
                 if attributes.contains_key("year")
                     && attributes.contains_key("month")
                     && attributes.contains_key("day")
@@ -883,8 +881,10 @@ impl Value {
                     && attributes.contains_key("second")
                     && attributes.contains_key("timezone") =>
             {
-                if let Some(Value(ValueRepr::Str(s))) =
-                    attributes.as_map().get("__formatter_rendered")
+                if let Some(ValueView::Str(s)) = attributes
+                    .as_map()
+                    .get("__formatter_rendered")
+                    .map(Value::view)
                 {
                     return s.to_string();
                 }
@@ -892,26 +892,26 @@ impl Value {
                     crate::builtins::methods_0arg::temporal::datetime_attrs(&(attributes).as_map());
                 crate::builtins::methods_0arg::temporal::format_datetime(y, mo, d, h, mi, s, tz)
             }
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Pod::Block::Declarator" => attributes
+            } if class_name == "Pod::Block::Declarator" => attributes
                 .as_map()
                 .get("contents")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "StrDistance" => attributes
+            } if class_name == "StrDistance" => attributes
                 .as_map()
                 .get("after")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_default(),
-            Value(ValueRepr::Instance { class_name, .. }) => format!("{}()", class_name),
-            Value(ValueRepr::Junction { kind, values }) => {
+            ValueView::Instance { class_name, .. } => format!("{}()", class_name),
+            ValueView::Junction { kind, values } => {
                 let kind_str = match kind {
                     JunctionKind::Any => "any",
                     JunctionKind::All => "all",
@@ -925,8 +925,8 @@ impl Value {
                     .join(", ");
                 format!("{}({})", kind_str, elems)
             }
-            Value(ValueRepr::Regex(pattern)) => format!("/{}/", pattern),
-            Value(ValueRepr::RegexWithAdverbs(a)) => {
+            ValueView::Regex(pattern) => format!("/{}/", pattern),
+            ValueView::RegexWithAdverbs(a) => {
                 let pattern = &a.pattern;
                 let global = &a.global;
                 let exhaustive = &a.exhaustive;
@@ -971,43 +971,43 @@ impl Value {
                 }
                 format!("m{prefix}/{pattern}/")
             }
-            Value(ValueRepr::Version { parts, plus, minus }) => {
+            ValueView::Version { parts, plus, minus } => {
                 let s = Self::version_parts_to_string(parts);
-                if *plus {
+                if plus {
                     format!("{}+", s)
-                } else if *minus {
+                } else if minus {
                     format!("{}-", s)
                 } else {
                     s
                 }
             }
-            Value(ValueRepr::Seq(items))
-            | Value(ValueRepr::HyperSeq(items))
-            | Value(ValueRepr::RaceSeq(items))
-            | Value(ValueRepr::Slip(items)) => items
+            ValueView::Seq(items)
+            | ValueView::HyperSeq(items)
+            | ValueView::RaceSeq(items)
+            | ValueView::Slip(items) => items
                 .iter()
                 .map(|v| v.to_str_context())
                 .collect::<Vec<_>>()
                 .join(" "),
-            Value(ValueRepr::Promise(p)) => format!("Promise({})", p.status()),
-            Value(ValueRepr::Channel(_)) => "Channel".to_string(),
-            Value(ValueRepr::Nil) => String::new(),
-            Value(ValueRepr::Whatever) => "*".to_string(),
-            Value(ValueRepr::HyperWhatever) => "**".to_string(),
-            Value(ValueRepr::Capture { positional, named }) => {
+            ValueView::Promise(p) => format!("Promise({})", p.status()),
+            ValueView::Channel(_) => "Channel".to_string(),
+            ValueView::Nil => String::new(),
+            ValueView::Whatever => "*".to_string(),
+            ValueView::HyperWhatever => "**".to_string(),
+            ValueView::Capture { positional, named } => {
                 let mut parts = Vec::new();
                 for v in positional.iter() {
-                    match v {
-                        Value(ValueRepr::Str(s)) => parts.push(format!("\"{}\"", s)),
+                    match v.view() {
+                        ValueView::Str(s) => parts.push(format!("\"{}\"", s)),
                         _ => parts.push(v.to_string_value()),
                     }
                 }
                 let mut named_entries: Vec<_> = named.iter().collect();
                 named_entries.sort_by_key(|(k, _)| (*k).clone());
                 for (k, v) in named_entries {
-                    if let Value(ValueRepr::Bool(true)) = v {
+                    if let ValueView::Bool(true) = v.view() {
                         parts.push(format!(":{}(Bool::True)", k));
-                    } else if let Value(ValueRepr::Bool(false)) = v {
+                    } else if let ValueView::Bool(false) = v.view() {
                         parts.push(format!(":{}(Bool::False)", k));
                     } else {
                         parts.push(format!(":{}({})", k, capture_value_gist(v)));
@@ -1015,31 +1015,31 @@ impl Value {
                 }
                 format!("\\({})", parts.join(", "))
             }
-            Value(ValueRepr::Mixin(inner, mixins)) => {
+            ValueView::Mixin(inner, mixins) => {
                 if let Some(str_val) = mixins.get("Str") {
                     str_val.to_string_value()
-                } else if let (Value(ValueRepr::Bool(_)), Some(Value(ValueRepr::Bool(b)))) =
-                    (inner.as_ref(), mixins.get("Bool"))
+                } else if let (ValueView::Bool(_), Some(ValueView::Bool(b))) =
+                    (inner.view(), mixins.get("Bool").map(Value::view))
                 {
                     // `True but False`: Bool stringifies from the effective
                     // boolean (`self ?? 'True' !! 'False'`), so follow `.Bool`.
-                    if *b { "True" } else { "False" }.to_string()
+                    if b { "True" } else { "False" }.to_string()
                 } else {
                     inner.to_string_value()
                 }
             }
-            Value(ValueRepr::Proxy { .. }) => "Proxy".to_string(),
-            Value(ValueRepr::CustomType(c)) => {
+            ValueView::Proxy { .. } => "Proxy".to_string(),
+            ValueView::CustomType(c) => {
                 if c.name.is_empty() {
                     "(CustomType)".to_string()
                 } else {
                     format!("({})", c.name)
                 }
             }
-            Value(ValueRepr::CustomTypeInstance(d)) => format!("{}()", d.type_name),
-            Value(ValueRepr::Scalar(inner)) => inner.to_string_value(),
-            Value(ValueRepr::ContainerRef(_)) => self.with_deref(Value::to_string_value),
-            Value(ValueRepr::LazyThunk(thunk_data)) => {
+            ValueView::CustomTypeInstance(d) => format!("{}()", d.type_name),
+            ValueView::Scalar(inner) => inner.to_string_value(),
+            ValueView::ContainerRef(_) => self.with_deref(Value::to_string_value),
+            ValueView::LazyThunk(thunk_data) => {
                 // If already forced, display the cached value
                 let cache = thunk_data.cache.lock().unwrap();
                 if let Some(ref cached) = *cache {
@@ -1049,15 +1049,15 @@ impl Value {
                     "lazy(...)".to_string()
                 }
             }
-            Value(ValueRepr::HashEntryRef { .. }) => self.hash_entry_read().to_string_value(),
+            ValueView::HashEntryRef { .. } => self.hash_entry_read().to_string_value(),
         }
     }
 
     /// Stringify a value in Raku's Str context.
     /// Type objects (Package) become empty string; everything else uses to_string_value.
     pub(crate) fn to_str_context(&self) -> String {
-        match self {
-            Value(ValueRepr::Package(_)) => String::new(),
+        match self.view() {
+            ValueView::Package(_) => String::new(),
             _ => self.to_string_value(),
         }
     }

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -4,7 +4,7 @@
 //! variants (Sub, WeakSub, Promise, Channel, LazyList, Proxy, CustomType, etc.)
 //! are rejected at serialization time with an error.
 
-use super::{ArrayKind, EnumValue, JunctionKind, Value, ValueRepr, VersionPart};
+use super::{ArrayKind, EnumValue, JunctionKind, Value, ValueRepr, ValueView, VersionPart};
 use crate::symbol::Symbol;
 use num_bigint::BigInt as NumBigInt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -116,76 +116,74 @@ enum SerJunctionKind {
 }
 
 fn value_to_ser(v: &Value) -> Result<SerValue, String> {
-    match v {
-        Value(ValueRepr::Int(n)) => Ok(SerValue::Int(*n)),
-        Value(ValueRepr::BigInt(n)) => Ok(SerValue::BigInt((**n).clone())),
-        Value(ValueRepr::Num(n)) => Ok(SerValue::Num(*n)),
-        Value(ValueRepr::Str(s)) => Ok(SerValue::Str((**s).clone())),
-        Value(ValueRepr::Bool(b)) => Ok(SerValue::Bool(*b)),
-        Value(ValueRepr::Range(a, b)) => Ok(SerValue::Range(*a, *b)),
-        Value(ValueRepr::RangeExcl(a, b)) => Ok(SerValue::RangeExcl(*a, *b)),
-        Value(ValueRepr::RangeExclStart(a, b)) => Ok(SerValue::RangeExclStart(*a, *b)),
-        Value(ValueRepr::RangeExclBoth(a, b)) => Ok(SerValue::RangeExclBoth(*a, *b)),
-        Value(ValueRepr::GenericRange {
+    match v.view() {
+        ValueView::Int(n) => Ok(SerValue::Int(n)),
+        ValueView::BigInt(n) => Ok(SerValue::BigInt((**n).clone())),
+        ValueView::Num(n) => Ok(SerValue::Num(n)),
+        ValueView::Str(s) => Ok(SerValue::Str((**s).clone())),
+        ValueView::Bool(b) => Ok(SerValue::Bool(b)),
+        ValueView::Range(a, b) => Ok(SerValue::Range(a, b)),
+        ValueView::RangeExcl(a, b) => Ok(SerValue::RangeExcl(a, b)),
+        ValueView::RangeExclStart(a, b) => Ok(SerValue::RangeExclStart(a, b)),
+        ValueView::RangeExclBoth(a, b) => Ok(SerValue::RangeExclBoth(a, b)),
+        ValueView::GenericRange {
             start,
             end,
             excl_start,
             excl_end,
-        }) => Ok(SerValue::GenericRange {
+        } => Ok(SerValue::GenericRange {
             start: Box::new(value_to_ser(start)?),
             end: Box::new(value_to_ser(end)?),
-            excl_start: *excl_start,
-            excl_end: *excl_end,
+            excl_start,
+            excl_end,
         }),
-        Value(ValueRepr::Array(items, kind)) => {
+        ValueView::Array(items, kind) => {
             let ser_items: Result<Vec<_>, _> = items.iter().map(value_to_ser).collect();
-            Ok(SerValue::Array(ser_items?, *kind))
+            Ok(SerValue::Array(ser_items?, kind))
         }
-        Value(ValueRepr::Hash(map, _)) => {
+        ValueView::Hash(map) => {
             let ser_map: Result<HashMap<_, _>, _> = map
                 .iter()
                 .map(|(k, v)| value_to_ser(v).map(|sv| (k.clone(), sv)))
                 .collect();
             Ok(SerValue::Hash(ser_map?))
         }
-        Value(ValueRepr::Rat(n, d)) => Ok(SerValue::Rat(*n, *d)),
-        Value(ValueRepr::FatRat(n, d)) => Ok(SerValue::FatRat(*n, *d)),
-        Value(ValueRepr::BigRat(n, d)) => Ok(SerValue::BigRat((**n).clone(), (**d).clone())),
-        Value(ValueRepr::Complex(r, i)) => Ok(SerValue::Complex(*r, *i)),
-        Value(ValueRepr::Set(s, _)) => Ok(SerValue::Set(s.elements.clone())),
-        Value(ValueRepr::Bag(b, _)) => Ok(SerValue::Bag(b.counts.clone())),
-        Value(ValueRepr::Mix(m, _)) => Ok(SerValue::Mix(m.weights.clone())),
-        Value(ValueRepr::CompUnitDepSpec { short_name }) => Ok(SerValue::CompUnitDepSpec {
-            short_name: *short_name,
-        }),
-        Value(ValueRepr::Package(s)) => Ok(SerValue::Package(*s)),
-        Value(ValueRepr::Routine {
+        ValueView::Rat(n, d) => Ok(SerValue::Rat(n, d)),
+        ValueView::FatRat(n, d) => Ok(SerValue::FatRat(n, d)),
+        ValueView::BigRat(n, d) => Ok(SerValue::BigRat(n.clone(), d.clone())),
+        ValueView::Complex(r, i) => Ok(SerValue::Complex(r, i)),
+        ValueView::Set(s, _) => Ok(SerValue::Set(s.elements.clone())),
+        ValueView::Bag(b, _) => Ok(SerValue::Bag(b.counts.clone())),
+        ValueView::Mix(m, _) => Ok(SerValue::Mix(m.weights.clone())),
+        ValueView::CompUnitDepSpec { short_name } => Ok(SerValue::CompUnitDepSpec { short_name }),
+        ValueView::Package(s) => Ok(SerValue::Package(s)),
+        ValueView::Routine {
             package,
             name,
             is_regex,
-        }) => Ok(SerValue::Routine {
-            package: *package,
-            name: *name,
-            is_regex: *is_regex,
+        } => Ok(SerValue::Routine {
+            package,
+            name,
+            is_regex,
         }),
-        Value(ValueRepr::Pair(k, v)) => Ok(SerValue::Pair(k.clone(), Box::new(value_to_ser(v)?))),
-        Value(ValueRepr::ValuePair(k, v)) => Ok(SerValue::ValuePair(
+        ValueView::Pair(k, v) => Ok(SerValue::Pair(k.clone(), Box::new(value_to_ser(v)?))),
+        ValueView::ValuePair(k, v) => Ok(SerValue::ValuePair(
             Box::new(value_to_ser(k)?),
             Box::new(value_to_ser(v)?),
         )),
-        Value(ValueRepr::Enum {
+        ValueView::Enum {
             enum_type,
             key,
             value,
             index,
-        }) => Ok(SerValue::Enum {
-            enum_type: *enum_type,
-            key: *key,
+        } => Ok(SerValue::Enum {
+            enum_type,
+            key,
             value: value.clone(),
-            index: *index,
+            index,
         }),
-        Value(ValueRepr::Regex(s)) => Ok(SerValue::Regex((**s).clone())),
-        Value(ValueRepr::RegexWithAdverbs(a)) => Ok(SerValue::RegexWithAdverbs {
+        ValueView::Regex(s) => Ok(SerValue::Regex((**s).clone())),
+        ValueView::RegexWithAdverbs(a) => Ok(SerValue::RegexWithAdverbs {
             pattern: (*a.pattern).clone(),
             global: a.global,
             exhaustive: a.exhaustive,
@@ -200,7 +198,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
             samecase: a.samecase,
             samespace: a.samespace,
         }),
-        Value(ValueRepr::Junction { kind, values }) => {
+        ValueView::Junction { kind, values } => {
             let ser_kind = match kind {
                 JunctionKind::Any => SerJunctionKind::Any,
                 JunctionKind::All => SerJunctionKind::All,
@@ -213,38 +211,36 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 values: ser_values?,
             })
         }
-        Value(ValueRepr::Seq(items))
-        | Value(ValueRepr::HyperSeq(items))
-        | Value(ValueRepr::RaceSeq(items)) => {
+        ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => {
             let ser_items: Result<Vec<_>, _> = items.iter().map(value_to_ser).collect();
             Ok(SerValue::Seq(ser_items?))
         }
-        Value(ValueRepr::Slip(items)) => {
+        ValueView::Slip(items) => {
             let ser_items: Result<Vec<_>, _> = items.iter().map(value_to_ser).collect();
             Ok(SerValue::Slip(ser_items?))
         }
-        Value(ValueRepr::Version { parts, plus, minus }) => Ok(SerValue::Version {
+        ValueView::Version { parts, plus, minus } => Ok(SerValue::Version {
             parts: parts.clone(),
-            plus: *plus,
-            minus: *minus,
+            plus,
+            minus,
         }),
-        Value(ValueRepr::Instance {
+        ValueView::Instance {
             class_name,
             attributes,
             id,
-        }) => {
+        } => {
             let ser_attrs: Result<HashMap<_, _>, _> = attributes
                 .as_map()
                 .iter()
                 .map(|(k, v)| value_to_ser(v).map(|sv| (k.clone(), sv)))
                 .collect();
             Ok(SerValue::Instance {
-                class_name: *class_name,
+                class_name,
                 attributes: ser_attrs?,
-                id: *id,
+                id,
             })
         }
-        Value(ValueRepr::Mixin(inner, overrides)) => {
+        ValueView::Mixin(inner, overrides) => {
             let ser_overrides: Result<HashMap<_, _>, _> = overrides
                 .iter()
                 .map(|(k, v)| value_to_ser(v).map(|sv| (k.clone(), sv)))
@@ -254,7 +250,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 ser_overrides?,
             ))
         }
-        Value(ValueRepr::Capture { positional, named }) => {
+        ValueView::Capture { positional, named } => {
             let ser_pos: Result<Vec<_>, _> = positional.iter().map(value_to_ser).collect();
             let ser_named: Result<HashMap<_, _>, _> = named
                 .iter()
@@ -265,39 +261,39 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
                 named: ser_named?,
             })
         }
-        Value(ValueRepr::Uni(u)) => Ok(SerValue::Uni {
+        ValueView::Uni(u) => Ok(SerValue::Uni {
             form: u.form.clone(),
             text: u.text.clone(),
         }),
-        Value(ValueRepr::ParametricRole {
+        ValueView::ParametricRole {
             base_name,
             type_args,
-        }) => {
+        } => {
             let ser_args: Result<Vec<_>, _> = type_args.iter().map(value_to_ser).collect();
             Ok(SerValue::ParametricRole {
-                base_name: *base_name,
+                base_name,
                 type_args: ser_args?,
             })
         }
-        Value(ValueRepr::Scalar(inner)) => Ok(SerValue::Scalar(Box::new(value_to_ser(inner)?))),
-        Value(ValueRepr::Nil) => Ok(SerValue::Nil),
-        Value(ValueRepr::Whatever) => Ok(SerValue::Whatever),
-        Value(ValueRepr::HyperWhatever) => Ok(SerValue::HyperWhatever),
+        ValueView::Scalar(inner) => Ok(SerValue::Scalar(Box::new(value_to_ser(inner)?))),
+        ValueView::Nil => Ok(SerValue::Nil),
+        ValueView::Whatever => Ok(SerValue::Whatever),
+        ValueView::HyperWhatever => Ok(SerValue::HyperWhatever),
         // Non-serializable variants
-        Value(ValueRepr::Sub(_))
-        | Value(ValueRepr::WeakSub(_))
-        | Value(ValueRepr::LazyList(_))
-        | Value(ValueRepr::Promise(_))
-        | Value(ValueRepr::Channel(_))
-        | Value(ValueRepr::Proxy { .. })
-        | Value(ValueRepr::CustomType { .. })
-        | Value(ValueRepr::CustomTypeInstance(_))
-        | Value(ValueRepr::LazyThunk(_))
-        | Value(ValueRepr::LazyIoLines { .. })
-        | Value(ValueRepr::HashEntryRef { .. })
-        | Value(ValueRepr::ContainerRef(_)) => Err(format!(
-            "cannot serialize Value variant: {:?}",
-            std::mem::discriminant(&v.0)
+        ValueView::Sub(_)
+        | ValueView::WeakSub(_)
+        | ValueView::LazyList(_)
+        | ValueView::Promise(_)
+        | ValueView::Channel(_)
+        | ValueView::Proxy { .. }
+        | ValueView::CustomType { .. }
+        | ValueView::CustomTypeInstance(_)
+        | ValueView::LazyThunk(_)
+        | ValueView::LazyIoLines { .. }
+        | ValueView::HashEntryRef { .. }
+        | ValueView::ContainerRef(_) => Err(format!(
+            "cannot serialize Value variant: {}",
+            super::what_type_name(v)
         )),
     }
 }
@@ -318,7 +314,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             end,
             excl_start,
             excl_end,
-        } => Value(ValueRepr::GenericRange {
+        } => Value::from_repr(ValueRepr::GenericRange {
             start: Arc::new(ser_to_value(*start)),
             end: Arc::new(ser_to_value(*end)),
             excl_start,
@@ -341,14 +337,14 @@ fn ser_to_value(sv: SerValue) -> Value {
         SerValue::Bag(b) => Value::bag_big(b),
         SerValue::Mix(m) => Value::mix(m),
         SerValue::CompUnitDepSpec { short_name } => {
-            Value(ValueRepr::CompUnitDepSpec { short_name })
+            Value::from_repr(ValueRepr::CompUnitDepSpec { short_name })
         }
         SerValue::Package(s) => Value::Package(s),
         SerValue::Routine {
             package,
             name,
             is_regex,
-        } => Value(ValueRepr::Routine {
+        } => Value::from_repr(ValueRepr::Routine {
             package,
             name,
             is_regex,
@@ -362,7 +358,7 @@ fn ser_to_value(sv: SerValue) -> Value {
             key,
             value,
             index,
-        } => Value(ValueRepr::Enum {
+        } => Value::from_repr(ValueRepr::Enum {
             enum_type,
             key,
             value,
@@ -405,7 +401,7 @@ fn ser_to_value(sv: SerValue) -> Value {
                 SerJunctionKind::One => JunctionKind::One,
                 SerJunctionKind::None => JunctionKind::None,
             };
-            Value(ValueRepr::Junction {
+            Value::from_repr(ValueRepr::Junction {
                 kind: jk,
                 values: Arc::new(values.into_iter().map(ser_to_value).collect()),
             })
@@ -415,13 +411,13 @@ fn ser_to_value(sv: SerValue) -> Value {
             Value::Slip(Arc::new(items.into_iter().map(ser_to_value).collect()))
         }
         SerValue::Version { parts, plus, minus } => {
-            Value(ValueRepr::Version { parts, plus, minus })
+            Value::from_repr(ValueRepr::Version { parts, plus, minus })
         }
         SerValue::Instance {
             class_name,
             attributes,
             id,
-        } => Value(ValueRepr::Instance {
+        } => Value::from_repr(ValueRepr::Instance {
             class_name,
             attributes: crate::gc::Gc::new(crate::value::InstanceAttrs::new(
                 class_name,
@@ -454,7 +450,7 @@ fn ser_to_value(sv: SerValue) -> Value {
         SerValue::ParametricRole {
             base_name,
             type_args,
-        } => Value(ValueRepr::ParametricRole {
+        } => Value::from_repr(ValueRepr::ParametricRole {
             base_name,
             type_args: type_args.into_iter().map(ser_to_value).collect(),
         }),

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -18,13 +18,14 @@
 //! variant (`Int`/`Str`/`Bool`/`Nil`/`Range`/`Version`/`Routine`/... and
 //! `WeakSub`, a WEAK edge) cannot reach a live `Gc` node and is a no-op.
 
+use super::ValueView;
 use std::sync::{Arc, Condvar, Mutex};
 
 use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
 use super::{
     ArrayData, BagData, ChannelState, EnumValue, HashData, InstanceAttrs, LazyList, MixData,
-    PromiseState, SetData, SharedChannel, SharedPromise, SubData, Value, ValueRepr,
+    PromiseState, SetData, SharedChannel, SharedPromise, SubData, Value,
 };
 
 /// Whether an `Arc`-shared wrapper is *uniquely owned* — its only holder is the
@@ -69,23 +70,23 @@ impl Value {
     /// `Gc` node nested inside them is still reached (otherwise the wrapper is an
     /// invisible edge and a cycle through it is missed — an under-collect).
     pub(crate) fn gc_trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
-        match self {
+        match self.view() {
             // Migrated `Gc<T>` node variants: yield the node itself. The
             // collector traces the node's own children via its `Trace` impl, so
             // we do NOT recurse into its contents here.
-            Value(ValueRepr::Hash(data, _)) => visit(&data.erased()),
-            Value(ValueRepr::Array(data, _)) => visit(&data.erased()),
-            Value(ValueRepr::Set(data, _)) => visit(&data.erased()),
-            Value(ValueRepr::Bag(data, _)) => visit(&data.erased()),
-            Value(ValueRepr::Mix(data, _)) => visit(&data.erased()),
-            Value(ValueRepr::ContainerRef(cell)) => visit(&cell.erased()),
-            Value(ValueRepr::Sub(data)) => visit(&data.erased()),
-            Value(ValueRepr::Instance { attributes, .. }) => visit(&attributes.erased()),
-            Value(ValueRepr::LazyList(ll)) => visit(&ll.erased()),
+            ValueView::Hash(data) => visit(&data.erased()),
+            ValueView::Array(data, _) => visit(&data.erased()),
+            ValueView::Set(data, _) => visit(&data.erased()),
+            ValueView::Bag(data, _) => visit(&data.erased()),
+            ValueView::Mix(data, _) => visit(&data.erased()),
+            ValueView::ContainerRef(cell) => visit(&cell.erased()),
+            ValueView::Sub(data) => visit(&data.erased()),
+            ValueView::Instance { attributes, .. } => visit(&attributes.erased()),
+            ValueView::LazyList(ll) => visit(&ll.erased()),
             // A hash-entry lvalue reference holds a strong `Gc<HashData>` node
             // (the hash it indexes into); yield it so a cycle routed through a
             // stored entry-ref is still reached.
-            Value(ValueRepr::HashEntryRef { hash, .. }) => visit(&hash.erased()),
+            ValueView::HashEntryRef { hash, .. } => visit(&hash.erased()),
 
             // Non-node wrappers that own/share `Value`s: recurse so a `Gc` node
             // nested inside is reached. `Box`-owned wrappers recurse
@@ -93,12 +94,12 @@ impl Value {
             // only when uniquely owned (see `uniquely_owned` for why a shared
             // wrapper would over-decrement). `WeakSub` is a WEAK edge — not
             // traced.
-            Value(ValueRepr::Pair(_, v)) | Value(ValueRepr::Scalar(v)) => v.gc_trace(visit),
-            Value(ValueRepr::ValuePair(k, v)) => {
+            ValueView::Pair(_, v) | ValueView::Scalar(v) => v.gc_trace(visit),
+            ValueView::ValuePair(k, v) => {
                 k.gc_trace(visit);
                 v.gc_trace(visit);
             }
-            Value(ValueRepr::Capture { positional, named }) => {
+            ValueView::Capture { positional, named } => {
                 for v in positional.iter() {
                     v.gc_trace(visit);
                 }
@@ -106,11 +107,11 @@ impl Value {
                     v.gc_trace(visit);
                 }
             }
-            Value(ValueRepr::Seq(items))
-            | Value(ValueRepr::HyperSeq(items))
-            | Value(ValueRepr::RaceSeq(items))
-            | Value(ValueRepr::Slip(items)) => trace_shared_slice(items, visit),
-            Value(ValueRepr::Mixin(inner, overrides)) => {
+            ValueView::Seq(items)
+            | ValueView::HyperSeq(items)
+            | ValueView::RaceSeq(items)
+            | ValueView::Slip(items) => trace_shared_slice(items, visit),
+            ValueView::Mixin(inner, overrides) => {
                 if uniquely_owned(inner) {
                     inner.gc_trace(visit);
                 }
@@ -120,32 +121,32 @@ impl Value {
                     }
                 }
             }
-            Value(ValueRepr::Junction { values, .. }) => trace_shared_slice(values, visit),
-            Value(ValueRepr::GenericRange { start, end, .. }) => {
+            ValueView::Junction { values, .. } => trace_shared_slice(values, visit),
+            ValueView::GenericRange { start, end, .. } => {
                 start.gc_trace(visit);
                 end.gc_trace(visit);
             }
-            Value(ValueRepr::Proxy {
+            ValueView::Proxy {
                 fetcher, storer, ..
-            }) => {
+            } => {
                 fetcher.gc_trace(visit);
                 storer.gc_trace(visit);
             }
             // Uniquely-owned `Box<Value>` wrappers: recurse (no sharing, so the
             // recursion visits each edge exactly once).
-            Value(ValueRepr::LazyIoLines { handle, .. }) => handle.gc_trace(visit),
+            ValueView::LazyIoLines { handle, .. } => handle.gc_trace(visit),
             // An enum value can carry an arbitrary `Value` payload.
-            Value(ValueRepr::Enum {
+            ValueView::Enum {
                 value: EnumValue::Generic(v),
                 ..
-            }) => v.gc_trace(visit),
-            Value(ValueRepr::ParametricRole { type_args, .. }) => {
+            } => v.gc_trace(visit),
+            ValueView::ParametricRole { type_args, .. } => {
                 for v in type_args.iter() {
                     v.gc_trace(visit);
                 }
             }
-            Value(ValueRepr::CustomType(data)) => data.how.gc_trace(visit),
-            Value(ValueRepr::CustomTypeInstance(data)) => {
+            ValueView::CustomType(data) => data.how.gc_trace(visit),
+            ValueView::CustomTypeInstance(data) => {
                 data.how.gc_trace(visit);
                 if uniquely_owned(&data.attributes) {
                     for v in data.attributes.values() {
@@ -155,7 +156,7 @@ impl Value {
             }
             // A lazy thunk holds its (possibly closure-capturing) block and any
             // cached forced result — both can close a cycle.
-            Value(ValueRepr::LazyThunk(data)) => {
+            ValueView::LazyThunk(data) => {
                 if uniquely_owned(data) {
                     data.thunk.gc_trace(visit);
                     if let Ok(cache) = data.cache.lock()
@@ -167,8 +168,8 @@ impl Value {
             }
             // Migrated async `Gc<T>` node variants (§11 steps 6-7): yield the
             // node; its `Trace` impl walks the held result / queue / callbacks.
-            Value(ValueRepr::Promise(p)) => visit(&p.erased()),
-            Value(ValueRepr::Channel(c)) => visit(&c.erased()),
+            ValueView::Promise(p) => visit(&p.erased()),
+            ValueView::Channel(c) => visit(&c.erased()),
             _ => {}
         }
     }
@@ -428,38 +429,38 @@ impl Trace for HashData {
 impl Value {
     #[allow(dead_code)]
     pub(crate) fn visit_gc_children(&self, visitor: &mut dyn RootVisitor) {
-        match self {
-            Value(ValueRepr::Array(data, _)) => data.visit_gc_children(visitor),
-            Value(ValueRepr::Hash(data, _)) => data.visit_gc_children(visitor),
-            Value(ValueRepr::Set(data, _)) => {
+        match self.view() {
+            ValueView::Array(data, _) => data.visit_gc_children(visitor),
+            ValueView::Hash(data) => data.visit_gc_children(visitor),
+            ValueView::Set(data, _) => {
                 if let Some(keys) = &data.original_keys {
                     visit_map_values(visitor, keys);
                 }
             }
-            Value(ValueRepr::Bag(data, _)) => {
+            ValueView::Bag(data, _) => {
                 if let Some(keys) = &data.original_keys {
                     visit_map_values(visitor, keys);
                 }
             }
-            Value(ValueRepr::Mix(data, _)) => {
+            ValueView::Mix(data, _) => {
                 if let Some(keys) = &data.original_keys {
                     visit_map_values(visitor, keys);
                 }
             }
-            Value(ValueRepr::Pair(_, v)) => visitor.visit_value(v),
-            Value(ValueRepr::ValuePair(k, v)) => {
+            ValueView::Pair(_, v) => visitor.visit_value(v),
+            ValueView::ValuePair(k, v) => {
                 visitor.visit_value(k);
                 visitor.visit_value(v);
             }
-            Value(ValueRepr::Sub(data)) => data.visit_gc_children(visitor),
-            Value(ValueRepr::Instance { attributes, .. }) => attributes.visit_gc_children(visitor),
-            Value(ValueRepr::ContainerRef(cell)) => {
+            ValueView::Sub(data) => data.visit_gc_children(visitor),
+            ValueView::Instance { attributes, .. } => attributes.visit_gc_children(visitor),
+            ValueView::ContainerRef(cell) => {
                 if let Ok(guard) = cell.lock() {
                     visitor.visit_value(&guard);
                 }
             }
-            Value(ValueRepr::Promise(p)) => p.visit_gc_children(visitor),
-            Value(ValueRepr::Channel(c)) => c.visit_gc_children(visitor),
+            ValueView::Promise(p) => p.visit_gc_children(visitor),
+            ValueView::Channel(c) => c.visit_gc_children(visitor),
             _ => {}
         }
     }
@@ -592,7 +593,7 @@ mod tests {
             map,
             ..Default::default()
         };
-        let value = Value(ValueRepr::Hash(crate::gc::Gc::new(data), false));
+        let value = Value::Hash(crate::gc::Gc::new(data), false);
 
         let mut visitor = CountingVisitor { count: 0 };
         value.visit_gc_children(&mut visitor);
@@ -633,10 +634,7 @@ mod tests {
     }
 
     fn fresh_hash_node() -> Value {
-        Value(ValueRepr::Hash(
-            crate::gc::Gc::new(HashData::default()),
-            false,
-        ))
+        Value::Hash(crate::gc::Gc::new(HashData::default()), false)
     }
 
     /// Build a minimal `SubData` capturing `env`, for the shared-env trace tests.
@@ -695,10 +693,7 @@ mod tests {
         // One env map holding the hash, shared by TWO closures (and kept
         // shared through the collect by `env` itself — 3 Arc holders).
         let mut env = crate::env::Env::new();
-        env.insert(
-            "%h".to_string(),
-            Value(ValueRepr::Hash(hash.clone(), false)),
-        );
+        env.insert("%h".to_string(), Value::Hash(hash.clone(), false));
 
         // The closures form a genuine garbage cycle through `ContainerRef`
         // cells in their (owned, always-traced) assumed args:
@@ -788,7 +783,7 @@ mod tests {
         // A HashEntryRef holds a strong `Gc<HashData>`; gc_trace must yield it
         // so a cycle routed through a stored entry-ref is reachable.
         let hash = crate::gc::Gc::new(HashData::default());
-        let value = Value(ValueRepr::HashEntryRef {
+        let value = Value::from_repr(crate::value::ValueRepr::HashEntryRef {
             hash,
             path: vec!["k".to_string()],
             eager: false,
@@ -810,7 +805,7 @@ mod tests {
 
     #[test]
     fn enum_generic_payload_is_traced() {
-        let value = Value(ValueRepr::Enum {
+        let value = Value::from_repr(crate::value::ValueRepr::Enum {
             enum_type: crate::symbol::Symbol::intern("E"),
             key: crate::symbol::Symbol::intern("A"),
             value: crate::value::EnumValue::Generic(Box::new(fresh_hash_node())),

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -4,19 +4,19 @@ impl Value {
     /// Create a decontainerized Proxy value (result of .VAR on a Proxy).
     /// This Proxy won't be auto-FETCHed by method dispatch.
     pub(crate) fn proxy_var_object(proxy: Value, _target_var: String) -> Self {
-        match proxy {
-            Value(ValueRepr::Proxy {
+        match proxy.into_repr() {
+            ValueRepr::Proxy {
                 fetcher,
                 storer,
                 subclass,
                 ..
-            }) => Value(ValueRepr::Proxy {
+            } => Value::from_repr(ValueRepr::Proxy {
                 fetcher,
                 storer,
                 subclass,
                 decontainerized: true,
             }),
-            other => other,
+            other => Value::from_repr(other),
         }
     }
 
@@ -37,7 +37,7 @@ impl Value {
         Value::Mixin(Arc::new(inner), Arc::new(overrides))
     }
     pub fn generic_range(start: Value, end: Value, excl_start: bool, excl_end: bool) -> Self {
-        Value(ValueRepr::GenericRange {
+        Value::from_repr(ValueRepr::GenericRange {
             start: Arc::new(start),
             end: Arc::new(end),
             excl_start,
@@ -50,7 +50,7 @@ impl Value {
     /// Create a Capture value. Boxes the positional/named payloads (the variant
     /// stores them behind `Box` to keep `Value` small).
     pub fn capture(positional: Vec<Value>, named: HashMap<String, Value>) -> Self {
-        Value(ValueRepr::Capture {
+        Value::from_repr(ValueRepr::Capture {
             positional: Box::new(positional),
             named: Box::new(named),
         })
@@ -63,17 +63,17 @@ impl Value {
     /// The HOW (meta-object) of a `CustomType` or `CustomTypeInstance`, if this
     /// is one. Centralizes access now that both are boxed payloads.
     pub fn custom_how(&self) -> Option<&Value> {
-        match self {
-            Value(ValueRepr::CustomType(d)) => Some(&d.how),
-            Value(ValueRepr::CustomTypeInstance(d)) => Some(&d.how),
+        match self.view() {
+            ValueView::CustomType(d) => Some(&d.how),
+            ValueView::CustomTypeInstance(d) => Some(&d.how),
             _ => None,
         }
     }
     /// The REPR name of a `CustomType` or `CustomTypeInstance`, if this is one.
     pub fn custom_repr(&self) -> Option<&str> {
-        match self {
-            Value(ValueRepr::CustomType(d)) => Some(&d.repr),
-            Value(ValueRepr::CustomTypeInstance(d)) => Some(&d.repr),
+        match self.view() {
+            ValueView::CustomType(d) => Some(&d.repr),
+            ValueView::CustomTypeInstance(d) => Some(&d.repr),
             _ => None,
         }
     }
@@ -149,7 +149,7 @@ impl Value {
     /// or a `HashData` (a cloned/rebuilt hash whose container metadata is then
     /// preserved) via `Into<HashData>`.
     pub fn hash(map: impl Into<HashData>) -> Self {
-        Value(ValueRepr::Hash(Gc::new(map.into()), false))
+        Value::from_repr(ValueRepr::Hash(Gc::new(map.into()), false))
     }
 
     /// True when this value is a `$`-scalar-itemized hash (`$(%h)` / `.item` /
@@ -157,17 +157,20 @@ impl Value {
     /// variant, not in the shared `HashData`, so two holders of the same hash
     /// data can differ in itemization (`%x.raku` → `{...}`, `my $h = %x;
     /// $h.raku` → `${...}`).
+    /// Deliberately place-based (B-wall-in exemption): the per-holder
+    /// itemization flag is representation state that `ValueView` hides; at
+    /// flip time this reads the kind tag inside the seam.
     pub fn hash_is_itemized(&self) -> bool {
-        matches!(self, Value(ValueRepr::Hash(_, true)))
+        matches!(self.0, ValueRepr::Hash(_, true))
     }
 
     /// Return this value with its hash itemization flag set to `itemized`,
     /// preserving the SAME `HashData` `Gc` (so `=`-shared mutation still tracks).
     /// A non-hash value is returned unchanged.
     pub fn with_hash_itemized(self, itemized: bool) -> Self {
-        match self {
-            Value(ValueRepr::Hash(gc, _)) => Value(ValueRepr::Hash(gc, itemized)),
-            other => other,
+        match self.into_repr() {
+            ValueRepr::Hash(gc, _) => Value::Hash(gc, itemized),
+            other => Value::from_repr(other),
         }
     }
 
@@ -183,13 +186,13 @@ impl Value {
     /// (mirroring `ArrayKind` — the value stays a `Value::Hash` so it never
     /// leaks a wrapper to value operations), other values get wrapped in Scalar.
     pub fn item(self) -> Self {
-        match self {
-            Value(ValueRepr::Array(items, kind)) => Value::Array(items, kind.itemize()),
+        match self.into_repr() {
+            ValueRepr::Array(items, kind) => Value::Array(items, kind.itemize()),
             // Itemization is a Value-level flag now, so `.item` keeps the SAME
             // `HashData` `Gc` (no copy-on-write, so `.WHICH` identity and
             // `=`-shared mutation are preserved).
-            Value(ValueRepr::Hash(h, _)) => Value(ValueRepr::Hash(h, true)),
-            other => other,
+            ValueRepr::Hash(h, _) => Value::Hash(h, true),
+            other => Value::from_repr(other),
         }
     }
 
@@ -198,9 +201,9 @@ impl Value {
     /// canonical non-cloning ContainerRef-read chokepoint (the ContainerRef axis of
     /// the decont family); prefer it over hand-rolled `arc.lock().unwrap()` reads.
     pub fn with_deref<R>(&self, f: impl FnOnce(&Value) -> R) -> R {
-        match self {
-            Value(ValueRepr::ContainerRef(arc)) => f(&arc.lock().unwrap()),
-            other => f(other),
+        match self.view() {
+            ValueView::ContainerRef(arc) => f(&arc.lock().unwrap()),
+            _ => f(self),
         }
     }
 
@@ -221,10 +224,10 @@ impl Value {
     /// `LazyThunk` nor strip an inner `Scalar` — matching the prior hand-rolled
     /// `arc.lock().unwrap().clone()` reads it replaces.
     pub fn into_deref(self) -> Value {
-        match self {
-            Value(ValueRepr::ContainerRef(arc)) => arc.lock().unwrap().clone(),
-            other => other,
+        if let ValueView::ContainerRef(arc) = self.view() {
+            return arc.lock().unwrap().clone();
         }
+        self
     }
 
     /// Store `val` through a `ContainerRef` cell. If the cell currently holds a
@@ -237,7 +240,7 @@ impl Value {
     /// overwrite the token and silently drop the hash alias.
     pub(crate) fn store_through_cell(arc: &crate::gc::Gc<Mutex<Value>>, val: &Value) {
         let mut inner = arc.lock().unwrap();
-        if matches!(&*inner, Value(ValueRepr::HashEntryRef { .. }))
+        if matches!(inner.view(), ValueView::HashEntryRef { .. })
             && let Some((hash_arc, key)) = inner.hash_entry_terminal()
         {
             // SAFETY: aliased in-place mutation of a shared container; see
@@ -251,7 +254,7 @@ impl Value {
     /// Assign a value into a `ContainerRef`.
     /// Returns `true` if the value was a ContainerRef and the assignment happened.
     pub fn assign_into_container(&self, new_val: Value) -> bool {
-        if let Value(ValueRepr::ContainerRef(arc)) = self {
+        if let ValueView::ContainerRef(arc) = self.view() {
             let mut inner = arc.lock().unwrap();
             *inner = new_val;
             true
@@ -271,7 +274,7 @@ impl Value {
     /// value; otherwise replace the slot in place. This is the single element
     /// write chokepoint that keeps a bound element's alias live across writes.
     pub fn assign_element_slot(slot: &mut Value, val: Value) {
-        if let Value(ValueRepr::ContainerRef(cell)) = slot {
+        if let ValueView::ContainerRef(cell) = slot.view() {
             *cell.lock().unwrap() = val;
         } else {
             *slot = val;
@@ -299,7 +302,7 @@ impl Value {
     }
 
     pub fn is_container_ref(&self) -> bool {
-        matches!(self, Value(ValueRepr::ContainerRef(_)))
+        matches!(self.view(), ValueView::ContainerRef(_))
     }
 
     /// Autovivify a hash entry: if the key doesn't exist, insert an empty Hash.
@@ -312,17 +315,17 @@ impl Value {
     ///
     /// Look up a key in a Hash value by string key.
     pub fn hash_get_str(&self, key: &str) -> Option<Value> {
-        match self {
-            Value(ValueRepr::Hash(arc, _)) => arc.get(key).cloned(),
-            Value(ValueRepr::Mixin(inner, _)) => inner.hash_get_str(key),
-            Value(ValueRepr::Scalar(inner)) => inner.hash_get_str(key),
+        match self.view() {
+            ValueView::Hash(arc) => arc.get(key).cloned(),
+            ValueView::Mixin(inner, _) => inner.hash_get_str(key),
+            ValueView::Scalar(inner) => inner.hash_get_str(key),
             _ => None,
         }
     }
 
     /// Returns `None` if `self` is not a `Value::Hash`.
     pub fn hash_autovivify(&self, key: &str) -> Option<Value> {
-        if let Value(ValueRepr::Hash(arc, _)) = self {
+        if let ValueView::Hash(arc) = self.view() {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
             let data = unsafe { crate::value::gc_contents_mut(arc) };
@@ -333,7 +336,7 @@ impl Value {
             // The entry exists (created just above if missing): an EAGER token,
             // whose reads see through to the plain entry value (`is raw`
             // reduce lvalue descent).
-            Some(Value(ValueRepr::HashEntryRef {
+            Some(Value::from_repr(ValueRepr::HashEntryRef {
                 hash: arc.clone(),
                 path: vec![key.to_string()],
                 eager: true,
@@ -355,18 +358,18 @@ impl Value {
     /// - a missing key is autovivified to an empty Hash (the old descent
     ///   behavior) and returned by value (shared Arc).
     pub fn hash_autovivify_cell(&self, key: &str) -> Option<Value> {
-        if let Value(ValueRepr::Hash(arc, _)) = self {
+        if let ValueView::Hash(arc) = self.view() {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
             let data = unsafe { crate::value::gc_contents_mut(arc) };
             match data.map.get_mut(key) {
-                Some(Value(ValueRepr::ContainerRef(cell))) => {
-                    Some(Value::ContainerRef(cell.clone()))
-                }
-                Some(elem @ (Value(ValueRepr::Array(..)) | Value(ValueRepr::Hash(..)))) => {
-                    Some(elem.clone())
-                }
                 Some(elem) => {
+                    if let ValueView::ContainerRef(cell) = elem.view() {
+                        return Some(Value::ContainerRef(cell.clone()));
+                    }
+                    if matches!(elem.view(), ValueView::Array(..) | ValueView::Hash(..)) {
+                        return Some(elem.clone());
+                    }
                     let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
                     *elem = Value::ContainerRef(cell.clone());
                     Some(Value::ContainerRef(cell))
@@ -400,30 +403,30 @@ impl Value {
     /// Reads decontainerize at the single chokepoint (`resolve_hash_entry`);
     /// writes go through `hash_insert_through` (Stage 0).
     pub fn hash_slot_ref(&self, key: &str, terminal: bool) -> Option<Value> {
-        if let Value(ValueRepr::Hash(arc, _)) = self {
+        if let ValueView::Hash(arc) = self.view() {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
             let data = unsafe { crate::value::gc_contents_mut(arc) };
             match data.map.get_mut(key) {
-                Some(Value(ValueRepr::ContainerRef(cell))) => {
-                    Some(Value::ContainerRef(cell.clone()))
-                }
-                Some(elem @ (Value(ValueRepr::Array(..)) | Value(ValueRepr::Hash(..))))
-                    if !terminal =>
-                {
-                    // Intermediate container: return the element value
-                    // itself — it shares the inner Arc, so the eventual
-                    // leaf promotion by the next index op lands in the
-                    // physical map the entry points to (Stage 2: no
-                    // `HashEntryRef` back-reference needed).
-                    Some(elem.clone())
-                }
                 Some(elem) => {
+                    if let ValueView::ContainerRef(cell) = elem.view() {
+                        return Some(Value::ContainerRef(cell.clone()));
+                    }
+                    if !terminal
+                        && matches!(elem.view(), ValueView::Array(..) | ValueView::Hash(..))
+                    {
+                        // Intermediate container: return the element value
+                        // itself — it shares the inner Arc, so the eventual
+                        // leaf promotion by the next index op lands in the
+                        // physical map the entry points to (Stage 2: no
+                        // `HashEntryRef` back-reference needed).
+                        return Some(elem.clone());
+                    }
                     let cell = crate::gc::Gc::new(Mutex::new(std::mem::replace(elem, Value::Nil)));
                     *elem = Value::ContainerRef(cell.clone());
                     Some(Value::ContainerRef(cell))
                 }
-                None => Some(Value(ValueRepr::HashEntryRef {
+                None => Some(Value::from_repr(ValueRepr::HashEntryRef {
                     hash: arc.clone(),
                     path: vec![key.to_string()],
                     eager: false,
@@ -439,7 +442,7 @@ impl Value {
     /// Returns the value stored at the key after the operation.
     /// Uses the same interior-mutation approach as `hash_autovivify`.
     pub fn hash_assign_at(&self, key: &str, val: Value) -> Option<Value> {
-        if let Value(ValueRepr::Hash(arc, _)) = self {
+        if let ValueView::Hash(arc) = self.view() {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `arc_contents_mut`. No borrow into the map is live across the write.
             let data = unsafe { crate::value::gc_contents_mut(arc) };
@@ -468,25 +471,26 @@ impl Value {
     /// through to the plain entry value — its entry was created with the
     /// token, so path existence IS the connection.
     pub fn hash_entry_read(&self) -> Value {
-        let Value(ValueRepr::HashEntryRef { hash, path, eager }) = self else {
+        let ValueView::HashEntryRef { hash, path, eager } = self.view() else {
             return self.clone();
         };
         let any = || Value::Package(crate::symbol::Symbol::intern("Any"));
         let mut cur = hash.clone();
         for k in &path[..path.len() - 1] {
             let ptr = crate::gc::Gc::as_ptr(&cur);
-            match unsafe { (*ptr).get(k.as_str()) } {
-                Some(Value(ValueRepr::Hash(inner, _))) => cur = inner.clone(),
+            match unsafe { (*ptr).get(k.as_str()) }.map(Value::view) {
+                Some(ValueView::Hash(inner)) => cur = inner.clone(),
                 _ => return any(),
             }
         }
         let last = path.last().unwrap();
         let ptr = crate::gc::Gc::as_ptr(&cur);
-        match unsafe { (*ptr).get(last.as_str()) } {
-            Some(Value(ValueRepr::ContainerRef(cell))) => {
+        let entry = unsafe { (*ptr).get(last.as_str()) };
+        match entry.map(Value::view) {
+            Some(ValueView::ContainerRef(cell)) => {
                 cell.lock().unwrap_or_else(|e| e.into_inner()).clone()
             }
-            Some(v) if *eager => v.clone(),
+            Some(_) if eager => entry.expect("entry is Some in this arm").clone(),
             _ => any(),
         }
     }
@@ -496,7 +500,7 @@ impl Value {
     /// Missing/non-hash intermediate levels are replaced with fresh empty hashes
     /// (interior mutation, so all holders of the shared Arc observe them).
     pub(crate) fn hash_entry_terminal(&self) -> Option<(Gc<HashData>, String)> {
-        let Value(ValueRepr::HashEntryRef { hash, path, .. }) = self else {
+        let ValueView::HashEntryRef { hash, path, .. } = self.view() else {
             return None;
         };
         let mut cur = hash.clone();
@@ -505,12 +509,12 @@ impl Value {
             // `gc_contents_mut`. No borrow into the map is live across the write.
             let next = {
                 let data = unsafe { gc_contents_mut(&cur) };
-                match data.map.get(k) {
-                    Some(Value(ValueRepr::Hash(inner, _))) => inner.clone(),
+                match data.map.get(k).map(Value::view) {
+                    Some(ValueView::Hash(inner)) => inner.clone(),
                     _ => {
                         let new_hash = Value::hash(HashMap::new());
-                        let arc = match &new_hash {
-                            Value(ValueRepr::Hash(a, _)) => a.clone(),
+                        let arc = match new_hash.view() {
+                            ValueView::Hash(a) => a.clone(),
                             _ => unreachable!(),
                         };
                         Value::hash_insert_through(&mut data.map, k.clone(), new_hash);

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -304,70 +304,70 @@ impl Value {
 
     pub(crate) fn is_range(&self) -> bool {
         matches!(
-            self,
-            Value(ValueRepr::Range(_, _))
-                | Value(ValueRepr::RangeExcl(_, _))
-                | Value(ValueRepr::RangeExclStart(_, _))
-                | Value(ValueRepr::RangeExclBoth(_, _))
-                | Value(ValueRepr::GenericRange { .. })
+            self.view(),
+            ValueView::Range(_, _)
+                | ValueView::RangeExcl(_, _)
+                | ValueView::RangeExclStart(_, _)
+                | ValueView::RangeExclBoth(_, _)
+                | ValueView::GenericRange { .. }
         )
     }
 
     /// Check if this value is a numeric type (Int, Num, Rat, FatRat, BigInt).
     /// Returns the inner items if this value is an Array, Seq, or Slip.
     pub(crate) fn as_list_items(&self) -> Option<&[Value]> {
-        match self {
-            Value(ValueRepr::Array(items, _)) => Some(&items.items[..]),
-            Value(ValueRepr::Seq(items)) | Value(ValueRepr::Slip(items)) => Some(&items[..]),
+        match self.view() {
+            ValueView::Array(items, _) => Some(&items.items[..]),
+            ValueView::Seq(items) | ValueView::Slip(items) => Some(&items[..]),
             _ => None,
         }
     }
 
     pub(crate) fn is_numeric(&self) -> bool {
         matches!(
-            self,
-            Value(ValueRepr::Int(_))
-                | Value(ValueRepr::BigInt(_))
-                | Value(ValueRepr::Num(_))
-                | Value(ValueRepr::Rat(_, _))
-                | Value(ValueRepr::FatRat(_, _))
-                | Value(ValueRepr::BigRat(_, _))
-                | Value(ValueRepr::Whatever)
+            self.view(),
+            ValueView::Int(_)
+                | ValueView::BigInt(_)
+                | ValueView::Num(_)
+                | ValueView::Rat(_, _)
+                | ValueView::FatRat(_, _)
+                | ValueView::BigRat(_, _)
+                | ValueView::Whatever
         )
     }
 
     /// Convert a numeric value to f64.
     pub(crate) fn to_f64(&self) -> f64 {
-        match self {
+        match self.view() {
             // Phase 2 element container: numify the inner value transparently
             // if a `:=`-bound element's cell leaks into a numeric context.
-            Value(ValueRepr::ContainerRef(cell)) => cell.lock().unwrap().to_f64(),
-            Value(ValueRepr::Int(i)) => *i as f64,
-            Value(ValueRepr::BigInt(n)) => n.to_f64().unwrap_or(0.0),
-            Value(ValueRepr::Num(f)) => *f,
-            Value(ValueRepr::Rat(n, d)) => {
-                if *d != 0 {
-                    *n as f64 / *d as f64
-                } else if *n == 0 {
+            ValueView::ContainerRef(cell) => cell.lock().unwrap().to_f64(),
+            ValueView::Int(i) => i as f64,
+            ValueView::BigInt(n) => n.to_f64().unwrap_or(0.0),
+            ValueView::Num(f) => f,
+            ValueView::Rat(n, d) => {
+                if d != 0 {
+                    n as f64 / d as f64
+                } else if n == 0 {
                     f64::NAN
-                } else if *n > 0 {
+                } else if n > 0 {
                     f64::INFINITY
                 } else {
                     f64::NEG_INFINITY
                 }
             }
-            Value(ValueRepr::FatRat(n, d)) => {
-                if *d != 0 {
-                    *n as f64 / *d as f64
-                } else if *n == 0 {
+            ValueView::FatRat(n, d) => {
+                if d != 0 {
+                    n as f64 / d as f64
+                } else if n == 0 {
                     f64::NAN
-                } else if *n > 0 {
+                } else if n > 0 {
                     f64::INFINITY
                 } else {
                     f64::NEG_INFINITY
                 }
             }
-            Value(ValueRepr::BigRat(n, d)) => {
+            ValueView::BigRat(n, d) => {
                 if !d.is_zero() {
                     n.to_f64().unwrap_or(0.0) / d.to_f64().unwrap_or(1.0)
                 } else if n.is_zero() {
@@ -378,29 +378,29 @@ impl Value {
                     f64::NEG_INFINITY
                 }
             }
-            Value(ValueRepr::Bool(b)) => {
-                if *b {
+            ValueView::Bool(b) => {
+                if b {
                     1.0
                 } else {
                     0.0
                 }
             }
-            Value(ValueRepr::Whatever) => f64::INFINITY,
-            Value(ValueRepr::Str(s)) => s.trim().parse::<f64>().unwrap_or(0.0),
-            Value(ValueRepr::Array(items, ..)) => items.len() as f64,
-            Value(ValueRepr::Hash(map, _)) => map.len() as f64,
-            Value(ValueRepr::Instance {
+            ValueView::Whatever => f64::INFINITY,
+            ValueView::Str(s) => s.trim().parse::<f64>().unwrap_or(0.0),
+            ValueView::Array(items, ..) => items.len() as f64,
+            ValueView::Hash(map) => map.len() as f64,
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Instant" || class_name == "Duration" => attributes
+            } if class_name == "Instant" || class_name == "Duration" => attributes
                 .as_map()
                 .get("value")
                 .map(|v| v.to_f64())
                 .unwrap_or(0.0),
             // A subclass of native Int (e.g. `class Foo is Int`) carries its
             // integer payload in the reserved `__mutsu_int_value` attribute.
-            Value(ValueRepr::Instance { attributes, .. })
+            ValueView::Instance { attributes, .. }
                 if attributes.contains_key("__mutsu_int_value") =>
             {
                 attributes
@@ -410,11 +410,11 @@ impl Value {
                     .unwrap_or(0.0)
             }
             // Match coerces to Numeric via its matched string
-            Value(ValueRepr::Instance {
+            ValueView::Instance {
                 class_name,
                 attributes,
                 ..
-            }) if class_name == "Match" => attributes
+            } if class_name == "Match" => attributes
                 .as_map()
                 .get("str")
                 .map(|v| v.to_string_value().trim().parse::<f64>().unwrap_or(0.0))
@@ -425,35 +425,35 @@ impl Value {
 
     /// Convert a Value to a num_bigint::BigInt for arbitrary-precision arithmetic.
     pub(crate) fn to_bigint(&self) -> NumBigInt {
-        match self {
-            Value(ValueRepr::Int(i)) => NumBigInt::from(*i),
-            Value(ValueRepr::BigInt(n)) => (**n).clone(),
-            Value(ValueRepr::Num(f)) => NumBigInt::from(*f as i64),
-            Value(ValueRepr::Rat(n, d)) => {
-                if *d != 0 {
+        match self.view() {
+            ValueView::Int(i) => NumBigInt::from(i),
+            ValueView::BigInt(n) => (**n).clone(),
+            ValueView::Num(f) => NumBigInt::from(f as i64),
+            ValueView::Rat(n, d) => {
+                if d != 0 {
                     NumBigInt::from(n / d)
                 } else {
                     NumBigInt::from(0)
                 }
             }
-            Value(ValueRepr::BigRat(n, d)) => {
+            ValueView::BigRat(n, d) => {
                 if !d.is_zero() {
-                    n.as_ref() / d.as_ref()
+                    n / d
                 } else {
                     NumBigInt::from(0)
                 }
             }
-            Value(ValueRepr::Str(s)) => s
+            ValueView::Str(s) => s
                 .parse::<NumBigInt>()
                 .unwrap_or_else(|_| NumBigInt::from(0)),
             // A subclass of native Int (e.g. `class Foo is Int`) carries its
             // integer payload in the reserved `__mutsu_int_value` attribute.
-            Value(ValueRepr::Instance { attributes, .. }) => attributes
+            ValueView::Instance { attributes, .. } => attributes
                 .as_map()
                 .get("__mutsu_int_value")
                 .map(|v| v.to_bigint())
                 .unwrap_or_else(|| NumBigInt::from(0)),
-            Value(ValueRepr::Mixin(inner, _)) => inner.to_bigint(),
+            ValueView::Mixin(inner, _) => inner.to_bigint(),
             _ => NumBigInt::from(0),
         }
     }


### PR DESCRIPTION
## Summary

Fourth and final **B-wall-in** slice ([docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md) §4, follows #4448): the remaining ~274 place-based `ValueRepr::` sites move onto the seam, **completing the internal wall migration**.

| file | sites | notes |
|---|---|---|
| `display.rs` | 91 | `to_string_value`/gist/raku render matches → `view()` |
| `serde_support.rs` | 62 | `value_to_ser` patterns → `view()`; `ser_to_value` constructions → `from_repr()`; the unsupported-variant error drops its `mem::discriminant(&v.0)` place-read for `what_type_name()` |
| `value_gc.rs` | 46 | `gc_trace`/`visit_gc_children` edge enumeration → `view()` (works unchanged across the flip); test constructions → `from_repr()` |
| `value_methods_a.rs` | 38 | hash autovivify/slot-ref `get_mut` matches restructured borrow-scoped; `item`/`with_hash_itemized`/`proxy_var_object` owned rebuilds → `into_repr()`/`from_repr()` |
| `value_methods_c.rs` | 37 | numeric coercion + range/numeric predicates |

Second documented exemption: `hash_is_itemized` reads the per-holder itemization flag, which `ValueView` deliberately hides — stays place-based and becomes a kind-tag read inside the seam at flip time.

**B-wall-in is now complete**: every remaining `ValueRepr::` outside the seam (`view.rs` + `mod.rs` constructor shims / seal machinery / tests) is an owned-position use that stays valid after the representation flip. PLAN.md §2 updated; next = **B-guards** (ArcRef/GcRef view fields), then **B-flip**.

## Test plan

Byte-identical refactor: `make test` green locally (16423 tests), clippy/fmt clean. CI runs the full roast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)