### PR TITLE
perf(ctor): cache the per-class native-constructor plan; gate the is-default attr loop

### DIFF
--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -207,6 +207,7 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
         self.func_multi_resolve_cache.clear();

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -463,6 +463,9 @@ impl Interpreter {
                 if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     class_def.methods.insert(method_name, vec![def]);
                 }
+                // Class shape changed (an added BUILD/TWEAK/new flips ctor
+                // eligibility) — drop cached construction plans.
+                self.native_ctor_plan_cache.clear();
                 // Return Nil even if the class was not found (e.g. built-in types
                 // like Rat that are not in the user-defined class registry).
                 // Raku's add_method returns the method name; returning Nil is
@@ -502,8 +505,15 @@ impl Interpreter {
                     deprecated_message: None,
                     is_submethod: false,
                 };
-                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                    class_def.methods.entry(method_name).or_default().push(def);
+                let inserted =
+                    if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
+                        class_def.methods.entry(method_name).or_default().push(def);
+                        true
+                    } else {
+                        false
+                    };
+                if inserted {
+                    self.native_ctor_plan_cache.clear();
                     return Ok(Value::NIL);
                 }
                 Err(RuntimeError::new(format!(
@@ -546,6 +556,7 @@ impl Interpreter {
                 if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     class_def.mro = mro;
                 }
+                self.native_ctor_plan_cache.clear();
                 Ok(Value::NIL)
             }
             "add_attribute" if args.len() >= 2 => {
@@ -606,6 +617,8 @@ impl Interpreter {
                             class_def.attribute_types.insert(bare_name, tc);
                         }
                     }
+                    // Attribute set changed — drop cached construction plans.
+                    self.native_ctor_plan_cache.clear();
                 }
                 Ok(Value::NIL)
             }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -287,6 +287,9 @@ impl Interpreter {
                         self.registry_mut()
                             .attribute_build_overrides
                             .insert((owner, attr_name), build);
+                        // A build override disqualifies the class from the native
+                        // default constructor — drop any cached plan for it.
+                        self.native_ctor_plan_cache.clear();
                         return Ok(target.clone());
                     }
                     "name" => {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -243,6 +243,83 @@ impl Interpreter {
         })
     }
 
+    /// Compute (or fetch the memoized) per-class plan for the native default
+    /// constructor. The eligibility gate, the MRO-collected attribute defs, the
+    /// attribute type constraints, and the BUILD/TWEAK/smiley probes are all
+    /// pure functions of the registry's class shape, yet they were re-derived
+    /// (with Vec/HashMap clones and multiple MRO walks) on EVERY construction.
+    /// The cache is invalidated with the method-dispatch caches at every
+    /// registry/type mutation site plus the MOP class-shape mutators.
+    pub(crate) fn native_ctor_plan(
+        &mut self,
+        class_name: Symbol,
+    ) -> std::sync::Arc<super::NativeCtorPlan> {
+        if let Some(plan) = self.native_ctor_plan_cache.get(&class_name) {
+            return plan.clone();
+        }
+        let cn_resolved = class_name.as_str();
+        let is_cunion = self.registry().cunion_classes.contains(cn_resolved);
+        let registered = self.registry().classes.contains_key(cn_resolved);
+        let eligible = !is_cunion && self.is_native_default_constructible(cn_resolved);
+        let (class_attrs, type_constraints, has_build, has_tweak, has_smiley) = if eligible {
+            let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
+            let type_constraints =
+                std::sync::Arc::new(self.collect_attribute_type_constraints(cn_resolved));
+            let mro = self.mro_readonly(cn_resolved);
+            let registry = self.registry();
+            let has_build = mro.iter().any(|cls| {
+                registry
+                    .classes
+                    .get(cls)
+                    .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+            });
+            let has_tweak = mro.iter().any(|cls| {
+                registry
+                    .classes
+                    .get(cls)
+                    .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
+            });
+            let has_smiley = mro.iter().any(|cls| {
+                registry
+                    .classes
+                    .get(cls)
+                    .is_some_and(|cd| !cd.attribute_smileys.is_empty())
+            });
+            drop(registry);
+            (
+                class_attrs,
+                type_constraints,
+                has_build,
+                has_tweak,
+                has_smiley,
+            )
+        } else {
+            (
+                std::sync::Arc::new(Vec::new()),
+                std::sync::Arc::new(HashMap::new()),
+                false,
+                false,
+                false,
+            )
+        };
+        let plan = std::sync::Arc::new(super::NativeCtorPlan {
+            is_cunion,
+            eligible,
+            class_attrs,
+            type_constraints,
+            has_build,
+            has_tweak,
+            has_smiley,
+        });
+        // Don't freeze a plan for a class that is not (yet) registered: e.g. a
+        // role punned to a class on first use would otherwise keep a stale
+        // negative plan without passing any invalidation site.
+        if registered || is_cunion {
+            self.native_ctor_plan_cache.insert(class_name, plan.clone());
+        }
+        plan
+    }
+
     /// Default-construct `class_name` natively when it is eligible (see
     /// `is_native_default_constructible`). Returns `None` for ineligible
     /// classes so callers fall through to the full constructor dispatch.
@@ -252,7 +329,7 @@ impl Interpreter {
         class_name: Symbol,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        let cn_resolved = class_name.resolve();
+        let plan = self.native_ctor_plan(class_name);
         // A `repr('CUnion')` class constructs via a byte overlay
         // (`construct_cunion_instance`): its native-int fields share the same
         // underlying bytes. The interpreter's `dispatch_new` does *nothing else*
@@ -261,13 +338,13 @@ impl Interpreter {
         // constructible` still rejects CUnion classes, keeping
         // `build_native_default_instance` (plain per-attribute assignment) from
         // ever touching the byte overlay.
-        if self.registry().cunion_classes.contains(&cn_resolved) {
-            return Some(self.construct_cunion_instance(&cn_resolved, args));
+        if plan.is_cunion {
+            return Some(self.construct_cunion_instance(class_name.as_str(), args));
         }
-        if !self.is_native_default_constructible(&cn_resolved) {
+        if !plan.eligible {
             return None;
         }
-        self.build_native_default_instance(class_name, &cn_resolved, args)
+        self.build_native_default_instance(class_name, class_name.as_str(), args, &plan)
     }
 
     /// Apply `has $.x does Role` attribute traits: mix each declared role into

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -6,6 +6,7 @@ impl Interpreter {
         class_name: Symbol,
         cn_resolved: &str,
         args: &[Value],
+        plan: &super::NativeCtorPlan,
     ) -> Option<Result<Value, RuntimeError>> {
         // The default `.new` accepts only named arguments (`method new(*%_)`); a
         // positional argument is an error (`X::Constructor::Positional`). The
@@ -20,12 +21,11 @@ impl Interpreter {
         {
             return None;
         }
-        let class_attrs = self.collect_class_attributes(cn_resolved);
-        // Attribute type constraints (MRO-wide) live in `attribute_types`, not in
-        // the `ClassAttributeDef` tuple's constraint slot — and the gate already
-        // guaranteed every one is a simple `type_matches_value`-checkable class
-        // type. Owned map, so it can be read while `self` is borrowed mutably.
-        let type_constraints = self.collect_attribute_type_constraints(cn_resolved);
+        // Class-shape facts (attribute defs, MRO-wide type constraints, the
+        // BUILD/TWEAK/smiley probes) come precomputed from the per-class
+        // `NativeCtorPlan` instead of being re-derived on every construction.
+        let class_attrs = &*plan.class_attrs;
+        let type_constraints = &*plan.type_constraints;
 
         let sigil_of = |name: &str| -> char {
             class_attrs
@@ -42,12 +42,7 @@ impl Interpreter {
         // `class P { has $.x = 42; submethod BUILD() {} }; P.new(:666x).x` is 42.
         // Skip the auto-assignment loop when the class has a BUILD; defaults are
         // still filled below and BUILD runs afterward.
-        let has_build = self.mro_readonly(cn_resolved).iter().any(|cls| {
-            self.registry()
-                .classes
-                .get(cls)
-                .is_some_and(|cd| cd.methods.contains_key("BUILD"))
-        });
+        let has_build = plan.has_build;
 
         let mut attrs = HashMap::new();
         for arg in args {
@@ -110,7 +105,7 @@ impl Interpreter {
         // `is_rw`, which must NOT gate construction (an unprovided `is rw`
         // attribute just gets its normal default, so it stays native).
         if !has_build {
-            for (attr_name, _, _, _is_rw, is_required, _, _) in &class_attrs {
+            for (attr_name, _, _, _is_rw, is_required, _, _) in class_attrs.iter() {
                 if let Some(reason) = is_required
                     && !attrs.contains_key(attr_name)
                 {
@@ -135,7 +130,7 @@ impl Interpreter {
         // the interpreter's construction — fall through whether or not it was
         // provided (a shaped attribute must stay shaped even when assigned).
         // Only the empty-default `@`/`%` case (handled below) is native.
-        for (_attr_name, _, default_expr, _, _, sigil, _) in &class_attrs {
+        for (_attr_name, _, default_expr, _, _, sigil, _) in class_attrs.iter() {
             if matches!(sigil, '@' | '%') && default_expr.is_some() {
                 return None;
             }
@@ -153,7 +148,7 @@ impl Interpreter {
         // that fast path made a 20k-iteration native-attr loop time out.
         let mut eval_error: Option<RuntimeError> = None;
         let mut typed_default_mismatch = false;
-        for (attr_name, _is_public, default_expr, _, _, sigil, _) in &class_attrs {
+        for (attr_name, _is_public, default_expr, _, _, sigil, _) in class_attrs.iter() {
             if attrs.contains_key(attr_name) {
                 continue;
             }
@@ -294,7 +289,7 @@ impl Interpreter {
         // `coerce_value_for_constraint` is the exact path the interpreter uses, so
         // the result is identical; the gate already excluded user-class targets,
         // so only built-in coercion logic runs here.
-        for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
+        for (attr_name, _, _, _, _, sigil, _) in class_attrs.iter() {
             if *sigil != '$' {
                 continue;
             }
@@ -318,7 +313,7 @@ impl Interpreter {
         // container flattens it (just like `my @a = |@x` yields an `Array`, not a
         // `Slip`), so materialize it into a plain mutable `Array` here. Without
         // this the attribute keeps a `Slip` whose `.^name` is `Slip`.
-        for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
+        for (attr_name, _, _, _, _, sigil, _) in class_attrs.iter() {
             if *sigil != '@' {
                 continue;
             }
@@ -332,7 +327,7 @@ impl Interpreter {
                 attrs.insert(attr_name.clone(), flattened);
             }
         }
-        for (attr_name, _, _, _, _, sigil, _) in &class_attrs {
+        for (attr_name, _, _, _, _, sigil, _) in class_attrs.iter() {
             if !matches!(sigil, '@' | '%') {
                 continue;
             }
@@ -360,12 +355,7 @@ impl Interpreter {
         // applies defaults before BUILD). `has_build` was computed above (it
         // gates the named-arg auto-assignment); the TWEAK check is cheap so the
         // common no-submethod case pays nothing extra.
-        let has_tweak = self.mro_readonly(cn_resolved).iter().any(|cls| {
-            self.registry()
-                .classes
-                .get(cls)
-                .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
-        });
+        let has_tweak = plan.has_tweak;
         // Enforce `where` constraints at attribute-assignment time, i.e. *before*
         // BUILD/TWEAK run (matches the interpreter's pre-BUILD enforcement): a
         // provided/defaulted value that fails its `where` is rejected here, and a
@@ -374,7 +364,7 @@ impl Interpreter {
         let has_where = class_attrs.iter().any(|(.., where_c)| where_c.is_some());
         if has_where
             && let Err(e) =
-                self.enforce_attribute_where_constraints(cn_resolved, &class_attrs, &attrs)
+                self.enforce_attribute_where_constraints(cn_resolved, class_attrs, &attrs)
         {
             return Some(Err(e));
         }
@@ -383,12 +373,7 @@ impl Interpreter {
         // definedness does not match its `:D`/`:U` smiley is rejected here, exactly
         // as the full constructor does (`enforce_attribute_smiley_constraints`,
         // which itself skips `is required` attributes). `:_` imposes no constraint.
-        let has_smiley = self.mro_readonly(cn_resolved).iter().any(|cls| {
-            self.registry()
-                .classes
-                .get(cls)
-                .is_some_and(|cd| !cd.attribute_smileys.is_empty())
-        });
+        let has_smiley = plan.has_smiley;
         if has_smiley && let Err(e) = self.enforce_attribute_smiley_constraints(cn_resolved, &attrs)
         {
             return Some(Err(e));
@@ -405,7 +390,7 @@ impl Interpreter {
             // exactly where the full constructor does its post-BUILD required
             // check. A still-unset attribute (`None` or `Nil`) raises
             // `X::Attribute::Required` with the same message and reason.
-            for (attr_name, _, _, _, is_required, _, _) in &class_attrs {
+            for (attr_name, _, _, _, is_required, _, _) in class_attrs.iter() {
                 if let Some(reason) = is_required {
                     let is_set = !matches!(
                         attrs.get(attr_name).map(Value::view),
@@ -447,7 +432,7 @@ impl Interpreter {
         if has_where
             && (has_build || has_tweak)
             && let Err(e) =
-                self.enforce_attribute_where_constraints(cn_resolved, &class_attrs, &attrs)
+                self.enforce_attribute_where_constraints(cn_resolved, class_attrs, &attrs)
         {
             return Some(Err(e));
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -363,7 +363,7 @@ pub(crate) use methods_collection_ops::{current_mutsu_thread_id, is_initial_thre
 
 use self::unicode::{check_unicode_property, check_unicode_property_with_args};
 
-pub(super) type ClassAttributeDef = (
+pub(crate) type ClassAttributeDef = (
     String,
     bool,
     Option<Expr>,
@@ -372,6 +372,25 @@ pub(super) type ClassAttributeDef = (
     char,
     Option<Expr>,
 );
+
+/// Per-class plan for the native default constructor
+/// (`try_native_default_construct`): everything about the class shape that the
+/// constructor consulted on EVERY construction but that only changes when the
+/// registry's class shape changes — eligibility, the MRO-collected attribute
+/// defs, attribute type constraints, and the BUILD/TWEAK/smiley MRO probes.
+/// Cached in `Interpreter::native_ctor_plan_cache`; invalidated together with
+/// the method-dispatch caches at every registry/type mutation site, plus the
+/// MOP mutators that alter class shape without passing those sites
+/// (`Attribute.set_build`, `^add_attribute`, `^add_method`, `^compose`).
+pub(crate) struct NativeCtorPlan {
+    pub(crate) is_cunion: bool,
+    pub(crate) eligible: bool,
+    pub(crate) class_attrs: Arc<Vec<ClassAttributeDef>>,
+    pub(crate) type_constraints: Arc<HashMap<String, String>>,
+    pub(crate) has_build: bool,
+    pub(crate) has_tweak: bool,
+    pub(crate) has_smiley: bool,
+}
 
 /// Kind of declaration a doc comment is attached to.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -1708,6 +1727,12 @@ pub struct Interpreter {
     pub(crate) last_method_resolve: Option<(Symbol, Symbol, String, Arc<MethodDef>)>,
     pub(crate) fast_method_cache:
         rustc_hash::FxHashMap<(Symbol, Symbol), crate::vm::FastMethodCacheEntry>,
+    /// Memoized `class -> NativeCtorPlan` for the native default constructor.
+    /// Cleared wherever `fast_method_cache` is cleared, plus the MOP class-shape
+    /// mutators (`Attribute.set_build`, `^add_attribute`, `^add_method`,
+    /// `^compose`). A class not yet registered is never cached (a role punned
+    /// to a class on first use must not freeze a negative plan).
+    pub(crate) native_ctor_plan_cache: rustc_hash::FxHashMap<Symbol, Arc<NativeCtorPlan>>,
     /// Sound multi-method resolution cache (§B): for a multi whose dispatch is
     /// purely type+arity based (no `where` / literal / subset / `:D`/`:U` smiley /
     /// coercion candidate), the resolved candidate is a function of the receiver

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2213,6 +2213,7 @@ impl Interpreter {
             method_resolve_cache: rustc_hash::FxHashMap::default(),
             last_method_resolve: None,
             fast_method_cache: rustc_hash::FxHashMap::default(),
+            native_ctor_plan_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -377,6 +377,7 @@ impl Interpreter {
             method_resolve_cache: rustc_hash::FxHashMap::default(),
             last_method_resolve: None,
             fast_method_cache: rustc_hash::FxHashMap::default(),
+            native_ctor_plan_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -462,25 +462,31 @@ impl Interpreter {
         }
 
         // Register `is default(...)` values for attribute variables so that
-        // .VAR.default returns the correct value inside methods.
-        for attr_name in attributes.keys() {
-            if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
-                continue;
-            }
-            // Check both the owner class and the receiver class for defaults
-            let default_val = self
-                .class_attribute_default(owner_class, attr_name)
-                .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
-            if let Some(def) = default_val {
-                // Register for $!attr and $.attr variable names
-                self.set_var_default(&format!("!{}", attr_name), def.clone());
-                self.set_var_default(&format!(".{}", attr_name), def.clone());
-                // Also register for @!attr/@.attr and %!attr/%.attr so
-                // .VAR.default works on array/hash attributes.
-                self.set_var_default(&format!("@!{}", attr_name), def.clone());
-                self.set_var_default(&format!("@.{}", attr_name), def.clone());
-                self.set_var_default(&format!("%!{}", attr_name), def.clone());
-                self.set_var_default(&format!("%.{}", attr_name), def);
+        // .VAR.default returns the correct value inside methods. Gated on the
+        // program declaring ANY attribute default: the common no-default case
+        // otherwise paid 2 lookups (each allocating a (String, String) key)
+        // per attribute on every method call.
+        let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
+        if any_attr_defaults {
+            for attr_name in attributes.keys() {
+                if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
+                    continue;
+                }
+                // Check both the owner class and the receiver class for defaults
+                let default_val = self
+                    .class_attribute_default(owner_class, attr_name)
+                    .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
+                if let Some(def) = default_val {
+                    // Register for $!attr and $.attr variable names
+                    self.set_var_default(&format!("!{}", attr_name), def.clone());
+                    self.set_var_default(&format!(".{}", attr_name), def.clone());
+                    // Also register for @!attr/@.attr and %!attr/%.attr so
+                    // .VAR.default works on array/hash attributes.
+                    self.set_var_default(&format!("@!{}", attr_name), def.clone());
+                    self.set_var_default(&format!("@.{}", attr_name), def.clone());
+                    self.set_var_default(&format!("%!{}", attr_name), def.clone());
+                    self.set_var_default(&format!("%.{}", attr_name), def);
+                }
             }
         }
 
@@ -1272,21 +1278,25 @@ impl Interpreter {
             }
         }
 
-        // Register `is default(...)` values for attribute variables
-        for attr_name in attributes.keys() {
-            if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
-                continue;
-            }
-            let default_val = self
-                .class_attribute_default(owner_class, attr_name)
-                .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
-            if let Some(def) = default_val {
-                self.set_var_default(&format!("!{}", attr_name), def.clone());
-                self.set_var_default(&format!(".{}", attr_name), def.clone());
-                self.set_var_default(&format!("@!{}", attr_name), def.clone());
-                self.set_var_default(&format!("@.{}", attr_name), def.clone());
-                self.set_var_default(&format!("%!{}", attr_name), def.clone());
-                self.set_var_default(&format!("%.{}", attr_name), def);
+        // Register `is default(...)` values for attribute variables. Gated on
+        // the program declaring ANY attribute default (see the slow path).
+        let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
+        if any_attr_defaults {
+            for attr_name in attributes.keys() {
+                if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
+                    continue;
+                }
+                let default_val = self
+                    .class_attribute_default(owner_class, attr_name)
+                    .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
+                if let Some(def) = default_val {
+                    self.set_var_default(&format!("!{}", attr_name), def.clone());
+                    self.set_var_default(&format!(".{}", attr_name), def.clone());
+                    self.set_var_default(&format!("@!{}", attr_name), def.clone());
+                    self.set_var_default(&format!("@.{}", attr_name), def.clone());
+                    self.set_var_default(&format!("%!{}", attr_name), def.clone());
+                    self.set_var_default(&format!("%.{}", attr_name), def);
+                }
             }
         }
 

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -27,6 +27,7 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
         self.func_multi_resolve_cache.clear();
@@ -65,6 +66,7 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
         self.func_multi_resolve_cache.clear();
@@ -94,6 +96,7 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
         self.func_multi_resolve_cache.clear();
@@ -119,6 +122,7 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
         self.func_multi_resolve_cache.clear();

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -191,6 +191,7 @@ impl Interpreter {
                 self.method_resolve_cache.clear();
                 self.last_method_resolve = None;
                 self.fast_method_cache.clear();
+                self.native_ctor_plan_cache.clear();
                 self.multi_resolve_cache.clear();
                 self.multi_type_cacheable.clear();
                 self.func_multi_resolve_cache.clear();

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -49,6 +49,7 @@ impl Interpreter {
         self.method_resolve_cache.clear();
         self.last_method_resolve = None;
         self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
         self.func_multi_resolve_cache.clear();
@@ -305,6 +306,8 @@ impl Interpreter {
             loan_env!(self, augment_class(&name_str, body))?;
             // Recompile augmented class methods for the fast path
             self.compile_class_methods(&name_str);
+            // Augment can add methods/attributes — drop cached construction plans.
+            self.native_ctor_plan_cache.clear();
             Ok(())
         } else {
             Err(RuntimeError::new("AugmentClass expects AugmentClass stmt"))

--- a/t/native-ctor-plan-invalidation.t
+++ b/t/native-ctor-plan-invalidation.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+plan 6;
+
+# Pin the native-constructor plan cache invalidation (native_ctor_plan_cache):
+# a class-shape mutation AFTER a construction already cached the class's plan
+# must be visible to the next construction.
+
+# Attribute.set_build after a construction (drops eligibility -> interpreter
+# path applies the override). NOTE: rakudo ignores a post-first-`.new`
+# set_build (its BUILDPLAN is cached at first construction); mutsu applies it
+# dynamically — pre-existing, deliberately pinned divergence.
+{
+    class B { has $.v = 1 }
+    is B.new.v, 1, "construction before set_build uses the default";
+    B.^attributes.head.set_build(-> |c { 99 });
+    is B.new.v, 99, "construction after set_build applies the override";
+}
+
+# augment class after a construction: the added method is callable on a
+# fresh instance (the cached plan for the class is dropped, not stale).
+{
+    use MONKEY-TYPING;
+    class C { has $.x }
+    is C.new(x => 1).x, 1, "construction before augment";
+    augment class C { method double() { $.x * 2 } }
+    my $c = C.new(x => 21);
+    is $c.x, 21, "construction after augment still binds named args";
+    is $c.double, 42, "augment-added method works on a post-augment instance";
+}
+
+# Same-named class redeclared via EVAL (registry re-registration) is not
+# served a stale plan from the earlier class of the same name.
+{
+    my $first = EVAL 'class D { has $.a }; D.new(a => 5).a';
+    my $second = EVAL 'class D { has $.a; has $.b = 7 }; my $d = D.new(a => 1); $d.a + $d.b';
+    is $first + $second, 13, "redeclared same-named class constructs with its own shape";
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Two bounded PLAN §5 attrs-materialization levers, driven by a post-#4447 bench-class re-profile (construction ~6% inclusive; dispatch dominated by per-call rederivation):

1. **`NativeCtorPlan` cache** — `try_native_default_construct` re-derived the whole class-shape analysis on **every construction**: the `is_native_default_constructible` registry walk, `collect_class_attributes` (cloning every `ClassAttributeDef` incl. default `Expr`s), `collect_attribute_type_constraints`, and three separate BUILD/TWEAK/smiley MRO probes. All are pure functions of the registry's class shape → memoized per class Symbol (`native_ctor_plan_cache`, Arc-shared).
   - Invalidation: every `fast_method_cache.clear()` site (typedecl / module ops / sub registration / block-scope teardown) **plus** the MOP class-shape mutators that bypass those sites: `Attribute.set_build`, `^add_attribute`, `^add_method`, `^add_multi_method`, `^compose`, `augment class`.
   - An unregistered class (e.g. a role punned on first use) is never cached, so late registration cannot freeze a stale negative plan.
2. **is-default gate** — both compiled-method entry paths ran a per-call loop over ALL instance attributes doing 2 `class_attribute_default` lookups each (each allocating a `(String, String)` key) to register `is default(...)` values — even when the program declares zero attribute defaults. Now gated on `registry().class_attribute_defaults` being non-empty.

## Measurements (controlled A/B, perf stat -r5, taskset 0-3, release, back-to-back builds)

| bench | main (#4447) | this PR | delta |
|---|---|---|---|
| bench-class | 0.314s | 0.288s | **-8.3%** |
| method-call | 0.275s | 0.260s | **-5.5%** |

vs raku, bench-class is now ~0.44x (raku 0.655s).

## Testing

- `t/native-ctor-plan-invalidation.t` (new, 6 tests): set_build after a construction (pins mutsu's dynamic-application behavior; rakudo ignores post-first-`.new` set_build — pre-existing divergence, noted in the test), augment after a construction, same-named class redeclared via EVAL.
- `make test`: 1668 files / 16432 tests PASS.
- Roast S12 class/attributes/construction subset: 43 files / 871 tests PASS.
- Behavior comparison vs main on set_build-after-new: byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni