### PR TITLE
docs(perf): re-measure the full benchmark table (2026-07-12); flag fib regression

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -9,34 +9,50 @@ cargo build --release
 ./benchmarks/run-all.sh
 ```
 
-## Current Status (benchmarks: 2026-05-24)
+## Current Status (benchmarks: 2026-07-12)
 
-> The benchmark table below was measured on 2026-05-24 and has not been re-run
-> since (Value layout shrank to 48 bytes and the VM was unified into a single
-> struct in the meantime). Re-measure with `./benchmarks/run-all.sh` before
-> relying on these exact numbers.
+> Measured 2026-07-12 with `perf stat -r5` (or `-r3` for the sub-0.1s ones) under
+> `taskset -c 0-3` on a quiet machine, release build (`opt + debuginfo`), rakudo
+> v2022.12. Includes the July perf slices #4447 (for-loop topic writeback O(n^2)
+> fix), #4451 (native-ctor plan cache + is-default gate), and the
+> `method_local_keys` predicate. **Caution: verify machine quietness before
+> benchmarking** — a single stray `mutsu` process inflated earlier same-day
+> measurements by 2-3x (both mutsu's and raku's), which briefly put wrong
+> ratios (bench-class "0.58x") into PR #4447/#4451 text. The table below is the
+> corrected record.
 
 | Benchmark | mutsu | raku | ratio | notes |
 |-----------|-------|------|-------|-------|
-| fib(25) | 0.37s | 0.36s | 1.0x | recursive function calls |
-| bench-fib | 1.09s | 0.34s | 3.2x | fib with type constraint (`Int $n --> Int`) |
-| int-arith | 0.16s | 0.22s | **0.7x** | `for ^100000 { $sum += $_ * 3 + 1 }` |
-| string-concat | 0.02s | 0.21s | **0.09x** | `$s ~= 'x'` × 10000 |
-| hash-access | 0.04s | 0.23s | **0.17x** | 10K hash inserts + value iteration |
-| method-call | 0.71s | 0.27s | 2.7x | Point.distance-to × 10000 |
-| array-ops | 0.16s | 0.26s | **0.6x** | grep+map on 1000-elem array × 100 |
-| bench-array | 0.03s | 0.29s | **0.1x** | push+map+grep+sort+reverse on 10K |
-| bench-hash | 0.03s | 0.29s | **0.1x** | 10K insert+lookup+delete+keys+values |
-| bench-class | 0.79s | 0.34s | 2.3x | class instantiation + method calls + inheritance |
-| bench-startup | 0.005s | 0.14s | **0.04x** | startup overhead |
-| bench-string | 0.08s | 0.33s | **0.2x** | string operations |
+| fib(25) | 0.85s | 0.18s | 4.8x | recursive function calls — **regressed ~2.3x vs 2026-05 (0.37s), see below** |
+| bench-fib | 2.51s | 0.24s | 10.5x | fib with type constraint (`Int $n --> Int`) — **regressed ~2.3x vs 2026-05 (1.09s)** |
+| int-arith | 0.12s | 0.15s | **0.85x** | `for ^100000 { $sum += $_ * 3 + 1 }` |
+| string-concat | 0.03s | 0.17s | **0.18x** | `$s ~= 'x'` × 10000 |
+| hash-access | 0.03s | 0.18s | **0.16x** | 10K hash inserts + value iteration |
+| method-call | 0.22s | 0.17s | 1.31x | Point.distance-to × 10000 (was 2.7x on 2026-05) |
+| array-ops | 0.10s | 0.23s | **0.44x** | grep+map on 1000-elem array × 100 |
+| bench-array | 0.05s | 0.23s | **0.22x** | push+map+grep+sort+reverse on 10K |
+| bench-hash | 0.04s | 0.25s | **0.14x** | 10K insert+lookup+delete+keys+values |
+| bench-class | 0.23s | 0.20s | 1.15x | class instantiation + method calls + inheritance (was 2.3x on 2026-05; 1.06s → 0.23s across the July slices) |
+| bench-startup | 0.004s | 0.12s | **0.03x** | startup overhead |
+| bench-string | 0.08s | 0.27s | **0.28x** | string operations |
 
-Note: raku times include ~170ms startup overhead. mutsu startup is ~4ms.
+Note: raku times include ~120ms startup overhead. mutsu startup is ~4ms.
 
 ### Summary
 
-- **Faster than raku (9/12)**: startup, string-concat, bench-string, int-arith, array-ops, hash-access, fib, bench-hash, bench-array
-- **~2-3x slower (3/12)**: bench-fib (3.2x), bench-class (2.3x), method-call (2.7x)
+- **Faster than raku (9/12)**: startup, string-concat, bench-string, int-arith, array-ops, hash-access, bench-hash, bench-array
+- **Near parity, target `<1.5x` met (2/12)**: bench-class (1.15x), method-call (1.31x)
+- **Regressed / far from target (2/12)**: fib (4.8x), bench-fib (10.5x)
+
+### ⚠ fib / bench-fib absolute regression (2026-07-12 finding)
+
+`fib` (0.37s → 0.85s) and `bench-fib` (1.09s → 2.51s) both slowed ~2.3x in
+absolute terms since the 2026-05-24 measurement, on the same benchmark files.
+The May-era table predates GC-default-on (2026-07-05, ADR-0003) and the layer-3a
+Track B churn, which are the prime suspects — but this is unbisected. Needs a
+dedicated investigation (bisect over the GC-enable range, `MUTSU_VM_STATS`
+counter diff) before NaN-boxing (layer 3b) work banks its expected fib gains on
+top of a regressed baseline.
 
 ## Architecture Overview
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -235,13 +235,20 @@ resolution cache・mro_readonly キャッシュ・FxHashMap・単一候補 memoi
 per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 
 - [ ] `Value` clone/drop ＋ `attributes.to_map()` の毎回クローン ＋
-      `call_compiled_method` の属性キー `format!` ＋ instance 構築 HashMap ＋ `merge_method_env` —
+      `call_compiled_method` の属性キー `format!` ＋ instance 構築 HashMap —
       Lever 2（NaN-boxing・GC 後）待ち、ないし属性 materialization の作り直し（深い）。
-      **注（2026-07-12）**: 旧記述「bench-class の ~50% が Value clone/drop」の実体は
-      for ループ topic writeback の O(n²)（`loop_var_unchanged` が Instance 要素を判定できず
-      毎イテレーション全配列 clone）で、修正済み — bench-class 2.8x 高速化・raku 比 0.58x。
-      再プロファイル後の残ホットスポット（native ctor plan の毎構築再計算・
-      `dispatch_compiled_method` 入口 `to_map()`・`is default` 属性ループ）が次スライス。
+      **2026-07-12 スライス実績**: ① for ループ topic writeback O(n²) 修正（#4447 —
+      旧記述「bench-class の ~50% が Value clone/drop」の実体）② native ctor plan の
+      per-class キャッシュ＋`is default` ループのゲート（#4451）③ `merge_method_env` の
+      `method_local_keys` HashSet を allocation-free 述語化 — 合計で bench-class
+      1.06s→0.23s（raku 比 2.3x→**1.15x** ✅）・method-call 2.7x→**1.31x** ✅。
+      残: `dispatch_compiled_method` 入口の `to_map()` 除去（中規模リファクタ）と
+      attrs の `HashMap<String,Value>`/SipHash 起因の malloc 群（＝作り直し本体）。
+- [ ] **fib/bench-fib の絶対回帰調査（2026-07-12 発見）**: 同一ベンチファイルで
+      fib 0.37s→0.85s・bench-fib 1.09s→2.51s（2026-05-24 比 ~2.3x 遅化・raku 比 4.8x/10.5x）。
+      GC 既定 on（2026-07-05）＋Track B churn が第一容疑だが未 bisect。層3b が回帰した
+      ベースラインの上に fib 利得を計上する前に、bisect＋`MUTSU_VM_STATS` diff で要因特定する。
+      詳細 = [PERFORMANCE.md](PERFORMANCE.md) の 2026-07-12 表と注記。
 - [ ] **Lever 2: NaN-boxing = ADR-0001 層3b（JIT の地ならし・GC 後）**: `Value` 48→8 bytes。
       int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。
       進捗・次の着手単位（3b-1 step B・ADR-0005 Accepted 待ち）は **§2 に集約**。
@@ -264,7 +271,9 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       絶対 index を運ぶ encoding の是正 / per-opcode ヒストグラム駆動での特化 op 統合
       （`ContainerEq`×4・`IndexAssign*`×6 — 美学でなくデータで駆動）。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。
-- 目標: method-call <1.5x、bench-class <1.5x（✅ 0.58x・2026-07-12）、bench-fib（型制約付き）<2x。
+- 目標: method-call <1.5x（✅ 1.31x・2026-07-12）、bench-class <1.5x（✅ 1.15x・2026-07-12 —
+  同日中の「0.58x」記載は迷子プロセス負荷下の raku 計測による誤り・訂正済み）、
+  bench-fib（型制約付き）<2x（❌ 10.5x — 上記回帰調査が前提）。
 
 ---
 
@@ -309,9 +318,9 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 | バイナリ配布 | なし | mise / GitHub Releases で単一コマンド導入 |
 | Whitelist | **1373**（全 .t 1463 中） | 1300+ ✅ 達成済み・現状維持以上 |
 | GC | **default on ✅**（2026-07-05・ADR-0003） | 達成（残 perf は層 3b へ） |
-| fib(25) vs raku | **1.0x** | <10x ✅ |
-| method-call vs raku | **2.7x** | <1.5x |
-| bench-class vs raku | **0.58x**（2026-07-12） | <1.5x ✅ |
-| bench-fib（型制約付き）vs raku | **3.2x** | <2x |
+| fib(25) vs raku | **4.8x**（2026-07-12・絶対 2.3x 回帰 — §5 要調査） | <10x ✅（回帰監視中） |
+| method-call vs raku | **1.31x**（2026-07-12） | <1.5x ✅ |
+| bench-class vs raku | **1.15x**（2026-07-12・同日の 0.58x 記載は計測誤りで訂正） | <1.5x ✅ |
+| bench-fib（型制約付き）vs raku | **10.5x**（2026-07-12・絶対 2.3x 回帰 — §5 要調査） | <2x |
 | 起動時間 vs raku | **0.04x** | 0.04x ✅ 維持 |
 | tree-walk フォールバック（メソッド/関数） | **~1% / ~18.6%（大半 carrier）** | 0%（carrier 除く） |


### PR DESCRIPTION
## Summary

- Replaces the stale 2026-05-24 PERFORMANCE.md benchmark table with fresh 2026-07-12 numbers (perf stat -r5, taskset 0-3, quiet machine, release, rakudo v2022.12), reflecting the July perf slices #4447 / #4451 / #4454.
- **bench-class 1.15x / method-call 1.31x** — both now under the PLAN `<1.5x` target; PLAN metrics table updated.
- **Correction**: the "0.58x vs raku" bench-class ratio recorded earlier today was a measurement artifact (a stray hung mutsu process was loading the machine during the raku baseline run). PERFORMANCE.md now carries a machine-quietness caveat; PLAN corrected to 1.15x.
- **New finding**: `fib` (0.37s → 0.85s) and `bench-fib` (1.09s → 2.51s) regressed ~2.3x in **absolute** terms since 2026-05-24 (now 4.8x / 10.5x vs raku). Prime suspect: GC-default-on (2026-07-05, ADR-0003) + Track B churn — unbisected. Recorded as a PLAN §5 investigation item that gates how layer-3b (NaN-boxing) banks its expected fib gains.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni