### PR TITLE
ci(bench): measure benchmarks on every push to main; record history on bench-data branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,139 @@
+name: Bench
+
+# Measure the benchmarks/ suite on every push to main and append the results
+# to the `bench-data` branch (bench-history.tsv), so performance changes are
+# recorded per merged commit and regressions become visible as a trend.
+#
+# Non-blocking by design (PLAN §1 B1 precedent: report-only, never gates main):
+# shared runners are noisy, so a single red delta is not proof of a regression.
+# Both absolute medians and the mutsu/raku ratio are recorded — raku runs on
+# the same runner in the same job, so the ratio normalizes runner speed.
+# A >1.5x slowdown vs the previous recorded run emits a warning annotation.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Serialize runs so two quick merges don't race their pushes to bench-data.
+concurrency:
+  group: bench-history
+  cancel-in-progress: false
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-bench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-bench-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Install rakudo (for the ratio baseline)
+        # Best-effort: if the package is unavailable the script records NA
+        # ratios and the absolute mutsu numbers are still appended.
+        run: sudo apt-get update && sudo apt-get install -y rakudo || true
+
+      - name: Build (release)
+        run: cargo build --release
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "false"
+
+      - name: Run benchmarks
+        run: |
+          mkdir -p tmp
+          scripts/bench-ci.sh | tee tmp/bench-results.tsv
+
+      - name: Compare with previous run and render summary
+        # Read-only look at the existing history BEFORE appending: warn when a
+        # benchmark's mutsu median slowed >1.5x vs its most recent recorded
+        # run. Warning only — noise happens; the trend is the signal.
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/bench-prev
+          git fetch --depth 1 origin bench-data 2>/dev/null \
+            && git worktree add /tmp/bench-prev FETCH_HEAD 2>/dev/null \
+            || true
+          HIST=/tmp/bench-prev/bench-history.tsv
+          {
+            echo "## Benchmark results ($(git rev-parse --short HEAD))"
+            echo ""
+            echo "| benchmark | mutsu median (s) | mutsu min (s) | raku median (s) | ratio | prev mutsu (s) | change |"
+            echo "|---|---|---|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          while IFS=$'\t' read -r name m_med m_min r_med ratio runs; do
+            prev="NA"; change="—"
+            if [ -f "$HIST" ]; then
+              prev=$(awk -F'\t' -v b="$name" '$3==b {v=$4} END {print (v=="" ? "NA" : v)}' "$HIST")
+            fi
+            if [ "$prev" != "NA" ] && [ "$m_med" != "NA" ]; then
+              change=$(awk -v n="$m_med" -v p="$prev" 'BEGIN{
+                if (p > 0) printf "%+.1f%%", (n/p - 1) * 100; else print "—"
+              }')
+              slow=$(awk -v n="$m_med" -v p="$prev" 'BEGIN{print (p > 0 && n > p * 1.5) ? 1 : 0}')
+              if [ "$slow" = 1 ]; then
+                echo "::warning title=bench regression?::$name mutsu median ${prev}s -> ${m_med}s ($change) vs previous recorded run"
+              fi
+            fi
+            echo "| $name | $m_med | $m_min | $r_med | $ratio | $prev | $change |" >> "$GITHUB_STEP_SUMMARY"
+          done < tmp/bench-results.tsv
+          git worktree remove --force /tmp/bench-prev 2>/dev/null || true
+
+      - name: Append to bench-data branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SHA=$(git rev-parse HEAD)
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          RUNNER_INFO="$(nproc)c-$(uname -m)-${ImageOS:-unknown}"
+          RAKUDO_VER=$(raku --version 2>/dev/null | head -1 | tr '\t' ' ' || echo none)
+          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Retry loop: re-clone fresh each attempt so a concurrent writer's
+          # push (from another repo clone / manual run) only costs a retry.
+          for attempt in 1 2 3 4 5; do
+            cd "$GITHUB_WORKSPACE"
+            rm -rf /tmp/bench-data
+            if ! git clone -q --depth 1 --branch bench-data "$REPO_URL" /tmp/bench-data 2>/dev/null; then
+              mkdir -p /tmp/bench-data
+              git -C /tmp/bench-data init -q -b bench-data
+              git -C /tmp/bench-data remote add origin "$REPO_URL"
+            fi
+            cd /tmp/bench-data
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            if [ ! -f bench-history.tsv ]; then
+              printf 'date\tcommit\tbenchmark\tmutsu_median_s\tmutsu_min_s\traku_median_s\tratio_mutsu_over_raku\truns\trunner\trakudo\n' > bench-history.tsv
+            fi
+            while IFS=$'\t' read -r name m_med m_min r_med ratio runs; do
+              printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "$DATE" "$SHA" "$name" "$m_med" "$m_min" "$r_med" "$ratio" "$runs" "$RUNNER_INFO" "$RAKUDO_VER" \
+                >> bench-history.tsv
+            done < "$GITHUB_WORKSPACE/tmp/bench-results.tsv"
+            git add bench-history.tsv
+            git commit -q -m "bench: ${SHA} (${DATE})"
+            if git push -q origin bench-data; then
+              echo "Appended $(wc -l < "$GITHUB_WORKSPACE/tmp/bench-results.tsv") rows for $SHA"
+              exit 0
+            fi
+            echo "push conflict, retrying ($attempt)"
+            sleep $((attempt * 5))
+          done
+          echo "::error::failed to push bench-data after 5 attempts"
+          exit 1

--- a/scripts/bench-ci.sh
+++ b/scripts/bench-ci.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# CI benchmark runner: measure every benchmarks/*.raku with 1 warmup + N timed
+# runs and print one TSV row per benchmark to stdout.
+#
+# Columns: benchmark  mutsu_median_s  mutsu_min_s  raku_median_s  ratio  runs
+#
+# Notes for consumers (.github/workflows/bench.yml):
+# - Shared CI runners are noisy; single absolute numbers are not comparable
+#   across runs. The workflow therefore records BOTH the median-of-N absolute
+#   time and the mutsu/raku ratio (raku measured on the same runner in the
+#   same job), which normalizes runner-speed differences. Trends across many
+#   commits are the signal; a single-run delta is not.
+# - A missing/failed measurement is recorded as NA rather than failing the
+#   job (bench history must not gate main).
+set -euo pipefail
+
+MUTSU=${MUTSU_BIN:-target/release/mutsu}
+RAKU=${RAKU_BIN:-raku}
+RUNS=${BENCH_RUNS:-7}
+TIMEOUT=${BENCH_TIMEOUT:-120}
+
+measure_once() { # cmd... -> wall seconds (4 decimals), non-zero on failure
+    local start end
+    start=$(date +%s%N)
+    timeout "$TIMEOUT" "$@" >/dev/null 2>&1 || return 1
+    end=$(date +%s%N)
+    awk -v s="$start" -v e="$end" 'BEGIN{printf "%.4f\n", (e-s)/1e9}'
+}
+
+stats() { # stdin: one seconds value per line -> "median min"
+    sort -n | awk '{a[NR]=$1} END {
+        if (NR==0) { print "NA NA"; exit }
+        m = (NR%2) ? a[(NR+1)/2] : (a[NR/2]+a[NR/2+1])/2
+        printf "%.4f %.4f\n", m, a[1]
+    }'
+}
+
+bench_binary() { # $1=binary $2=bench-file -> "median min" (or "NA NA")
+    local bin=$1 bench=$2 i t times=""
+    # Warmup run (page cache, precomp); its time is discarded.
+    measure_once "$bin" "$bench" >/dev/null || { echo "NA NA"; return; }
+    for i in $(seq "$RUNS"); do
+        t=$(measure_once "$bin" "$bench") || { echo "NA NA"; return; }
+        times+="$t"$'\n'
+    done
+    printf '%s' "$times" | stats
+}
+
+have_raku=0
+if command -v "$RAKU" >/dev/null 2>&1; then
+    have_raku=1
+fi
+
+for bench in benchmarks/*.raku; do
+    name=$(basename "$bench" .raku)
+    read -r m_med m_min <<<"$(bench_binary "$MUTSU" "$bench")"
+    if [ "$have_raku" = 1 ]; then
+        read -r r_med _ <<<"$(bench_binary "$RAKU" "$bench")"
+    else
+        r_med=NA
+    fi
+    if [ "$m_med" != NA ] && [ "$r_med" != NA ]; then
+        ratio=$(awk -v m="$m_med" -v r="$r_med" \
+            'BEGIN{ if (r > 0) printf "%.2f", m / r; else print "NA" }')
+    else
+        ratio=NA
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$name" "$m_med" "$m_min" "$r_med" "$ratio" "$RUNS"
+done


### PR DESCRIPTION
## Summary

ユーザー提案「ベンチマーク計測は CI で main に push 時に取るようにして、変化を記録したほうがいい」の実装。

New **non-blocking** workflow (PLAN §1 B1 の report-only 方針に準拠): on each push to main (+ `workflow_dispatch`):

1. Build release, run `scripts/bench-ci.sh` — 1 warmup + 7 timed runs per `benchmarks/*.raku`, recording **median + min**.
2. Install rakudo in the same job and record the **mutsu/raku ratio** — the ratio normalizes runner-speed differences, which absolute times on shared runners cannot (both are recorded).
3. Append one TSV row per benchmark to `bench-history.tsv` on the dedicated **`bench-data` branch**, keyed by date / commit / runner / rakudo version. Concurrency group + re-clone retry loop handle racing merges.
4. Render a comparison table into the **job summary**; a benchmark whose mutsu median slowed **>1.5x vs its most recent recorded run** emits a `::warning` annotation (never fails the job — noise happens; the trend is the signal).

## Motivation

The 2026-07-12 remeasure (#4455) found fib/bench-fib had silently regressed ~2.3x in absolute terms since 2026-05 — with no record of *which commit* caused it, forcing an expensive future bisect. Continuous per-merge history pins the next such regression to the commit that introduced it.

## Testing

- `scripts/bench-ci.sh` run locally (BENCH_RUNS=3): correct TSV for all 12 benchmarks incl. ratio computation.
- YAML validated; `bash -n` clean. First real run happens on merge (this workflow only triggers on push to main / manual dispatch); will verify the `bench-data` branch appears and re-run via dispatch if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni