### PR TITLE
fix(runtime): three general bugs surfaced by upstream zef 1.1.3 end-to-end run

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -107,11 +107,19 @@ HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny（end-to-end HTTP 配信）/ Tu
 `--version` が動作）/ ✅ CompUnit::Repository の install→use 橋（`repository-for-name` well-known 名・
 デフォルト site repo 自動登録・担保 `t/compunit-repository-for-name.t`）。残:
 
-- [ ] **実 zef バイナリの end-to-end 実行を阻む 2 バグ**:
-      (a) `Zef::Client` の `%`-sigil 属性に Associative をダックタイピングする非 Hash オブジェクト
-      （`has %.hash handles <AT-KEY EXISTS-KEY ...>`）を bind すると `coerce_attr_value_by_sigil`
-      （`methods_signature.rs`）の catch-all を素通りして raw Instance のまま格納される。
-      (b) 実 `Zef::CLI.rakumod` のコンパイルを止めるパーサエラー（未特定）。
+- [ ] **実 zef バイナリの end-to-end 実行を阻むブロッカー（2026-07-12 再調査で全面更新）**:
+      旧 2 バグは解消済み — (a) `%`-sigil 属性への Associative ダックタイピング bind は
+      Hash へ正しく coerce される（#4452 で解消・repro = `tmp/assoc-attr-repro.raku` 相当）、
+      (b) upstream zef 1.1.3（`ugexe/zef` HEAD）は全モジュールがパース・ロードし
+      `bin/zef --version`/`--help`/MAIN dispatch まで動作（パーサエラーは再現せず）。
+      現フロンティア:
+      1. **grammar パース性能**（最大のブロッカー）: `Zef::Identity` の `REQUIRE.parse` が
+         1 回 ~43ms（release・raku 比 ~70x）。`populate-distributions`（fez index 7648 dist ×
+         `.name` ごとに parse）が release でも ~10 分超 → `zef info/list/search` が実用不能。
+         zef 非依存 repro = `tmp/require-grammar-bench.raku`（20 parses: raku 0.012s / mutsu-debug 6.1s）。
+      2. ネスト `.raku` 表示: コレクション内の Instance が `Sp()`（type object 風）に描画される
+         （`(C.new,).raku` → raku は `(C.new(...),)`）。実体は正常（semantic には無害・表示のみ）。
+      3. `zef list --installed` は exit 0・出力なしまで動作（mutsu 側 site repo が空なら妥当）。
 - [ ] 既知の小差異: CLI 数値文字列の `Int $n` への coerce が raku より積極的（`MAIN(Int $n,…)` に `7` が
       マッチ・raku は slurpy fallback）。実用上は mutsu 側のほうが直感的。
 - [ ] **network fetch**: fez エコシステム（`https://360.zef.pm/`）への取得。堅牢な async TLS が前提。

--- a/src/builtins/map_hash_coerce.rs
+++ b/src/builtins/map_hash_coerce.rs
@@ -45,15 +45,36 @@ fn make_odd_number_error(items: &[Value]) -> RuntimeError {
     }
 }
 
+/// Unwrap an itemized Pair (`Scalar`) or a Pair held in a `:=` element cell
+/// (`ContainerRef`) for hash-initializer purposes. Non-Pair contents (e.g. an
+/// itemized hash, which must die "Odd number" like raku) pass through as-is.
+pub(crate) fn unwrap_contained_pair(v: &Value) -> Value {
+    let held = match v.view() {
+        ValueView::Scalar(inner) => inner.clone(),
+        ValueView::ContainerRef(cell) => cell.lock().unwrap().clone(),
+        _ => return v.clone(),
+    };
+    if matches!(held.view(), ValueView::Pair(..) | ValueView::ValuePair(..)) {
+        held
+    } else {
+        v.clone()
+    }
+}
+
 /// Convert a slice of items to a Hash, optionally checking for odd element count.
 fn items_to_hash(items: &[Value], check_odd: bool) -> Result<Value, RuntimeError> {
+    // An itemized Pair (`$(:a(1))` = `Scalar`) or a Pair held in a `:=` element
+    // cell (`ContainerRef`, e.g. a classify bucket element) still counts as a
+    // hash initializer pair; an itemized *hash* stays opaque (raku dies "Odd
+    // number"), so only Pair contents are unwrapped.
+    let items: Vec<Value> = items.iter().map(unwrap_contained_pair).collect();
     if check_odd {
         let non_pair_count = items
             .iter()
             .filter(|v| !matches!(v.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
             .count();
         if non_pair_count % 2 != 0 {
-            return Err(make_odd_number_error(items));
+            return Err(make_odd_number_error(&items));
         }
     }
     let mut map = HashMap::new();

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -158,6 +158,16 @@ impl Interpreter {
             return Ok(into_target.unwrap_or_else(|| Value::hash(HashMap::new())));
         };
 
+        // A list element that is a named-marker `Pair` is data here, not a
+        // call-site named argument — decay it to a positional `ValuePair` so
+        // the classifier block receives it as its topic.
+        fn callable_item(item: &Value) -> Value {
+            match item.view() {
+                ValueView::Pair(k, v) => Value::value_pair(Value::str_from(k), v.clone()),
+                _ => item.clone(),
+            }
+        }
+
         // Check for lazy lists — classify/categorize cannot operate on lazy lists
         for arg in &positional {
             let is_lazy = matches!(arg.view(), ValueView::LazyList(_));
@@ -191,6 +201,12 @@ impl Interpreter {
                     items.extend(values.iter().cloned())
                 }
                 ValueView::LazyList(ll) => items.extend(self.force_lazy_list_bridge(ll)?),
+                // Hash/Set/Bag/Mix classify their pairs (elem => True for Set,
+                // elem => count/weight for Bag/Mix), same as for-iteration.
+                ValueView::Hash(_)
+                | ValueView::Set(..)
+                | ValueView::Bag(..)
+                | ValueView::Mix(..) => items.extend(crate::runtime::utils::value_to_list(arg)),
                 _ if arg.is_range() => items.extend(crate::runtime::utils::value_to_list(arg)),
                 _ => items.push(arg.clone()),
             }
@@ -228,7 +244,7 @@ impl Interpreter {
         for item in &items {
             let mapped = match mapper.view() {
                 ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. } => {
-                    self.call_sub_value(mapper.clone(), vec![item.clone()], true)?
+                    self.call_sub_value(mapper.clone(), vec![callable_item(item)], true)?
                 }
                 ValueView::Hash(map) => map
                     .get(&item.to_string_value())
@@ -251,7 +267,7 @@ impl Interpreter {
             };
 
             let mapped_item = if let Some(as_fn) = &as_mapper {
-                self.call_sub_value(as_fn.clone(), vec![item.clone()], true)?
+                self.call_sub_value(as_fn.clone(), vec![callable_item(item)], true)?
             } else {
                 item.clone()
             };

--- a/src/runtime/native_io/path_spec.rs
+++ b/src/runtime/native_io/path_spec.rs
@@ -24,12 +24,17 @@ impl Interpreter {
             } else {
                 format!("{}\\{}", p, child_name)
             }
-        } else if p == "." {
+        } else if p == "." || p.is_empty() {
             child_name.to_string()
-        } else if p.ends_with('/') {
+        } else if p.ends_with('/') || child_name.starts_with('/') {
+            // Lexical concatenation, matching IO::Spec::Unix.join: a child with
+            // a leading `/` is appended, NOT treated as an absolute
+            // replacement ("$h/.config".IO.child('/zef/config.json') is
+            // "$h/.config/zef/config.json" in raku; Rust's Path::join would
+            // discard the base).
             format!("{}{}", p, child_name)
         } else {
-            Self::stringify_path(&Path::new(p).join(child_name))
+            format!("{}/{}", p, child_name)
         };
         Ok(joined)
     }

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -205,6 +205,13 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
         .unwrap_or_else(|| "Nil".to_string());
     let mut map = HashMap::new();
     let mut original_keys: HashMap<String, Value> = HashMap::new();
+    // An itemized Pair (`$(:a(1))`) or a Pair held in a `:=` element cell (e.g.
+    // a classify bucket element) still counts as a hash initializer pair; an
+    // itemized *hash* stays opaque and dies "Odd number" like raku.
+    let items: Vec<Value> = items
+        .iter()
+        .map(crate::builtins::map_hash_coerce::unwrap_contained_pair)
+        .collect();
     let mut iter = items.into_iter();
     while let Some(item) = iter.next() {
         match item.view() {

--- a/t/classify-pair-iteration.t
+++ b/t/classify-pair-iteration.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+plan 12;
+
+# Hash/Set/Bag/Mix invocants classify their pairs (surfaced by zef:
+# Zef::Repository::Ecosystems.search does
+# `%specs.classify({ .value.from-matcher })`).
+
+my %h = a => 1, b => 2;
+my %by-value = %h.classify({ .value });
+is %by-value{1}[0].key, 'a', 'Hash.classify iterates pairs (key)';
+is %by-value{1}[0].value, 1, 'Hash.classify iterates pairs (value)';
+is %by-value{2}[0].key, 'b', 'Hash.classify second bucket';
+
+my %cat = %h.categorize({ .value });
+is %cat{1}[0].key, 'a', 'Hash.categorize iterates pairs';
+
+my %set-buckets = set(<a b>).classify({ .key });
+is %set-buckets<a>[0].value, True, 'Set.classify gets elem => True pairs';
+
+my %bag-buckets = bag(<a a b>).classify({ .value });
+is %bag-buckets{2}[0].key, 'a', 'Bag.classify gets elem => count pairs';
+is %bag-buckets{1}[0].key, 'b', 'Bag.classify count-1 bucket';
+
+# A bare fat-arrow pair list element reaches the classifier as the topic
+# (it must not be swallowed as a named argument to the block).
+my %pairs = (a => 1, b => 2).classify({ .value });
+is %pairs{1}[0].key, 'a', 'list-of-pairs classify passes Pair as topic';
+is %pairs{2}[0].value, 2, 'list-of-pairs classify second bucket';
+
+my %single = (a => 1).classify({ .value });
+is %single{1}[0].key, 'a', 'single Pair invocant classify';
+
+# :as mapper also receives the Pair as its topic
+my %as-mapped = (a => 1, b => 2).classify({ .value }, :as({ .key.uc }));
+is %as-mapped{1}[0], 'A', ':as mapper receives Pair topic';
+is %as-mapped{2}[0], 'B', ':as mapper second bucket';
+
+done-testing;

--- a/t/hash-init-contained-pair.t
+++ b/t/hash-init-contained-pair.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+plan 7;
+
+# An itemized Pair (`$(:a(1))`) or a Pair held through an element cell (e.g. a
+# classify bucket element) still counts as a hash initializer pair — raku
+# accepts both. An itemized *hash* element still dies X::Hash::Store::OddNumber.
+# Surfaced by zef: Ecosystems.search does
+# `@raku-specs.grep(*.defined).hash` over classify bucket elements.
+
+my %m1 = ($(:a(1)),);
+is %m1<a>, 1, 'itemized Pair accepted by hash list-assignment';
+
+is ($(:a(1)),).hash<a>, 1, 'itemized Pair accepted by .hash';
+
+my %h = a => 1;
+my %bucket-hash = %h.classify({ "X" })<X>.grep(*.defined).hash;
+is %bucket-hash<a>, 1, 'classify bucket element (cell-held Pair) accepted by .hash';
+
+my %src = a => 1, b => 2;
+my %roundtrip = %src.classify({ "all" })<all>.hash;
+is %roundtrip.elems, 2, 'classify bucket of a whole hash rebuilds the hash';
+is %roundtrip<b>, 2, 'rebuilt hash keeps values';
+
+# itemized hash element still dies like raku
+my %h2 = x => 1;
+throws-like { my %m = ($%h2,); }, Exception,
+    message => /'Odd number of elements'/,
+    'itemized hash element still dies Odd number';
+
+# even count of non-pair elements still key/value-pairs up
+my %kv = ("k", "v").hash;
+is %kv<k>, 'v', 'flat key/value list still works';
+
+done-testing;

--- a/t/io-path-child-concat.t
+++ b/t/io-path-child-concat.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+plan 6;
+
+# .child/.add are lexical concatenation (IO::Spec::Unix.join): a child
+# fragment with a leading `/` is appended, not treated as an absolute
+# replacement. Surfaced by zef: Zef::Config::guess-path does
+# `("$*HOME/.config").IO.child('/zef/config.json')`.
+
+is "foo".IO.child("/bar").Str, "foo/bar",
+    'leading-slash child appends to relative base';
+is "/home/x/.config".IO.child("/zef/config.json").Str,
+    "/home/x/.config/zef/config.json",
+    'leading-slash child appends to absolute base';
+is "/a/".IO.child("/b").Str, "/a//b",
+    'trailing-slash base concatenates verbatim';
+is "/a".IO.child("b/").Str, "/a/b/",
+    'trailing slash on child is kept';
+is ".".IO.child("/x").Str, "/x",
+    'dot base yields the child fragment itself';
+is "a".IO.add("/c").Str, "a/c",
+    '.add joins the same way';
+
+done-testing;


### PR DESCRIPTION
## Summary

Running the real upstream zef 1.1.3 CLI under mutsu (PLAN §1 B2 mzef north-star) surfaced three general correctness bugs. All fixes are zef-independent general improvements, each pinned by a new `t/` test that also passes under raku.

### 1. classify/categorize over Hash/Set/Bag/Mix + Pair topic decay
- A Hash/Set/Bag/Mix invocant now classifies its **pairs** (elem => True for Set, elem => count/weight for Bag/Mix), same as for-iteration — previously the whole container was passed as one item to the classifier (`No such method 'value' for invocant of type 'Hash'` in `Zef::Repository::Ecosystems.search`).
- A bare fat-arrow Pair list element (named-marker representation) is decayed to a positional `ValuePair` before invoking the classifier/`:as` blocks, so it binds as the topic instead of being swallowed as a named argument. (`(a=>1, b=>2).classify({.value})` previously called the block with no positional args.)
- Pin: `t/classify-pair-iteration.t`

### 2. Hash initializer accepts contained Pairs
- An itemized Pair (`$(:a(1))`) or a Pair held through an element cell (e.g. a classify bucket element) counts as a hash initializer pair in `build_hash_from_items` / `items_to_hash`. An itemized *hash* element still dies `X::Hash::Store::OddNumber` like raku.
- zef symptom: `@raku-specs.grep(*.defined).hash` died "Odd number of elements found where hash initializer expected".
- Pin: `t/hash-init-contained-pair.t`

### 3. IO::Path.child/.add lexical concatenation
- `.child`/`.add` now match `IO::Spec::Unix.join`: a child fragment with a leading `/` is **appended**, not treated as an absolute replacement (Rust `Path::join` semantics were leaking through).
- zef symptom: `Zef::Config::guess-path` resolved `("$*HOME/.config").IO.child('/zef/config.json')` to `/zef/config.json`.
- Pin: `t/io-path-child-concat.t`

### PLAN.md §1 B2 refresh
The two previously-recorded mzef blockers no longer reproduce (the `%`-sigil Associative duck-type bind coerces correctly since #4452; upstream `Zef::CLI.rakumod` parses/loads and MAIN dispatch works). The new frontier recorded instead: `Zef::Identity` `REQUIRE.parse` grammar performance (~70x raku in release) makes `populate-distributions` (7648 fez dists) impractically slow — that is the next mzef work item.

## Test plan
- `make test` PASS (Files=1673, all successful)
- Targeted roast green: `S32-list/classify.t`, `classify-list.t`, `categorize.t`, `categorize-list.t`, `S32-io/io-path.t`, `io-path-unix.t`, `child-secure.t`, `S02-types/hash.t`
- New tests verified to pass under raku as well
- CI runs full `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)