### PR TITLE
fix(phasers): prioritize LEAVE-raised returns over same-routine in-flight returns

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,6 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 
 | 分類 | ファイル | mutsu | raku (v2026.06/6.d) | ブロッカー（一言） |
 |---|---|---|---|---|
-| ★達成可能 | `S06-advanced/return-prioritization.t` | 9/11・notok 2 | **11/11 満点**（v2022.12 は 4/11） | `return` in LEAVE phaser が戻り値を上書きできない（test 5）・別 lexical scope の LEAVE 内 `return`（test 9）。raku 更新で oracle 復活＝実バグ確定 |
 | 基盤待ち | `S32-str/format.t` | 26/49 で中断 | **49/49 満点**（v2022.12 は SORRY） | `Formatter::Syntax.parse`→Match、`Formatter.AST`→`RakuAST::Node` を要求＝**RakuAST サブシステム不在**。raku 更新で oracle は得られたが、stub 化は禁止のため据え置きのまま |
 | 基盤待ち | `S02-types/generics.t` | 0/1 | **1/1 満点**（v2022.12 は SORRY） | 6.e coercion type 項 + `Array[T]` サブクラス化が必要。raku 更新で参照検証は可能になったが、要求される基盤の大きさは不変 |
 | oracle 不能 | `S02-names/pseudo-6d.t` | 116/159 で中断 | SORRY（`::=` NYI） | `::("CALLER")::<$*bar>` CALLER 疑似パッケージ deref 未対応。v2026.06 でも rakudo が `::=` 束縛未実装で SORRY |
@@ -76,13 +75,10 @@ roast の失敗を「テストファイル単位」ではなく**根本原因単
 
 ## 今のおすすめ着手順
 
-- **★達成可能が 1 本復活**: raku を v2026.06 に更新した再測定（2026-07-12）で
-  `S06-advanced/return-prioritization.t` が raku 満点と判明（旧 raku は 4/11）。
-  mutsu 残 2 本はどちらも **LEAVE phaser 内の `return`**（戻り値上書き / 別 lexical
-  scope からの return）で、単一機能の edge。「次の 1 本」はこれ。
-- それ以外に「次の 1 本」に適する残件は無い。**構造工事の選定は
-  [PLAN.md](../PLAN.md) を正とする。**（直前の ★ 消化: `S32-hash/perl.t` は
-  2026-07-12 に whitelist 済み #4452）
+- 直前の ★ 消化: `S06-advanced/return-prioritization.t` は 2026-07-12 に whitelist 済み
+  （LEAVE phaser 内 `return` の優先規則を実装）。`S32-hash/perl.t` も同日 whitelist 済み #4452。
+- 現在、表に ★達成可能 の残件は無い。「次の 1 本」に適する残件も無く、**構造工事の選定は
+  [PLAN.md](../PLAN.md) を正とする。**
 - `S32-str/format.t`・`S02-types/generics.t` も raku 更新で oracle が得られたが、
   必要基盤（RakuAST / 6.e generics）の大きさは変わらないため 基盤待ち のまま。
 - 非目標・oracle 不能の項目は、mutsu 側の一般改善のついでに前進させるのはよいが、

--- a/TODO_roast/S06.md
+++ b/TODO_roast/S06.md
@@ -49,7 +49,11 @@
   - 0/? pass. Stack overflow crash. Recursive sub calls cause unbounded stack growth. Difficulty: Medium (need stack depth limit or tail-call optimization)
 - [ ] roast/S06-advanced/return_function.t
   - Not in spectest.data. Fails on Rakudo too: test expects old Pair-flattening behavior (`:x<1>` slip becoming positional `1`), but modern Raku keeps the Pair as a named argument. Tests 3-4 use `($rv1, $rv2) := |(t2)` which Rakudo rejects at compile time. Skip.
-- [ ] roast/S06-advanced/return-prioritization.t
+- [x] roast/S06-advanced/return-prioritization.t
+  - 11/11 pass. Fixed: a `return` raised inside a LEAVE phaser now overrides an
+    in-flight return targeting the same routine (and can redirect the unwind to
+    an outer routine via a closure), while an in-flight return to an outer
+    routine stays uninterruptible (block-scope queue merge in vm_misc_scope.rs).
 - [ ] roast/S06-advanced/return.t
 - [ ] roast/S06-advanced/stub.t
 - [x] roast/S06-advanced/wrap.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -486,6 +486,7 @@ roast/S06-advanced/callsame.t
 roast/S06-advanced/dispatching.t
 roast/S06-advanced/lexical-subs.t
 roast/S06-advanced/recurse.t
+roast/S06-advanced/return-prioritization.t
 roast/S06-advanced/return.t
 roast/S06-advanced/stub.t
 roast/S06-advanced/wrap.t

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -458,10 +458,34 @@ impl Interpreter {
                 return Err(e);
             }
         }
-        if let Err(e) = queue_res
-            && body_result.is_ok()
-        {
-            return Err(e);
+        if let Err(e) = queue_res {
+            if body_result.is_ok() {
+                return Err(e);
+            }
+            // Return prioritization (S06-advanced/return-prioritization.t):
+            // when both the body and the LEAVE queue exited via `return`, a
+            // return raised *inside* a LEAVE phaser overrides an in-flight
+            // return that targets this same routine (`LEAVE return 1; return
+            // 0` returns 1), and a closure called in LEAVE may redirect the
+            // unwind to an outer routine. But an in-flight return already
+            // unwinding to an *outer* routine is not interruptible by a
+            // LEAVE-side return aimed at this frame (tests 6/7).
+            if e.is_return()
+                && let Err(ref be) = body_result
+                && be.is_return()
+            {
+                let current_id = match self.env().get("__mutsu_callable_id").map(Value::view) {
+                    Some(ValueView::Int(id)) => Some(id as u64),
+                    _ => None,
+                };
+                let body_target = be.return_target_callable_id();
+                if body_target.is_none()
+                    || body_target == current_id
+                    || body_target == e.return_target_callable_id()
+                {
+                    return Err(e);
+                }
+            }
         }
         body_result?;
         *ip = end;

--- a/t/leave-return-prioritization.t
+++ b/t/leave-return-prioritization.t
@@ -1,0 +1,68 @@
+use Test;
+
+plan 6;
+
+# Pin for roast/S06-advanced/return-prioritization.t: a `return` raised inside
+# a LEAVE phaser overrides an in-flight return that targets the same routine,
+# and a closure called in LEAVE can redirect the unwind to an outer routine,
+# but an in-flight return to an outer routine is not interruptible.
+
+{
+    sub s() {
+        LEAVE return 1;
+        return 0;
+    }
+    is s(), 1, "LEAVE return overrides an explicit return of the same routine";
+}
+
+{
+    sub s() {
+        LEAVE return 1;
+        0;
+    }
+    is s(), 1, "LEAVE return overrides the implicit return value";
+}
+
+{
+    my $val = 0;
+    sub s(&code) {
+        LEAVE return 2;
+        code();
+    }
+    sub s2(&code) {
+        s(&code);
+        $val = 1;
+    }
+    sub s3() {
+        s2({ return 1 });
+        return 0;
+    }
+    is s3(), 1, "LEAVE return cannot interrupt a return unwinding to an outer routine";
+    is $val, 0, "the outer return keeps unwinding past the LEAVE frame";
+}
+
+{
+    sub s(&code) {
+        return 0;
+        LEAVE { code() }
+    }
+    sub s2() {
+        s({ return 1 });
+        return 2;
+    }
+    is s2(), 1, "closure called in LEAVE redirects the unwind to its own routine";
+}
+
+{
+    my $val;
+    sub inner() { return 5 }
+    sub s1(&code) {
+        code();
+        LEAVE { $val = inner }
+    }
+    sub s2() {
+        s1({ return 1 });
+        return 2;
+    }
+    is s2(), 1, "returns fully caught inside a LEAVE block don't disturb the unwind";
+}


### PR DESCRIPTION
## Summary

Fixes the two remaining failures in `roast/S06-advanced/return-prioritization.t` (now 11/11, whitelisted).

Raku's return-prioritization rule for LEAVE phasers:

- A `return` raised **inside a LEAVE phaser** overrides an in-flight return that targets the **same routine**: `sub s { LEAVE return 1; return 0 }` returns 1 (test 5).
- A closure called inside LEAVE can redirect the unwind to an **outer** routine (test 9).
- An in-flight return already unwinding to an *outer* routine is **not** interruptible by a LEAVE-side return aimed at the current frame (tests 6/7 — already passing, still passing).

## Root cause

`exec_block_scope_op` (`src/vm/vm_misc_scope.rs`) discarded the LEAVE queue's error (`queue_res`) whenever the body exited with an error, so a return raised in a LEAVE phaser could never replace the body's return.

## Fix

At the block-scope merge point, when both the body and the LEAVE queue exited via `Control::Return`, the LEAVE-side return wins iff the body's return targets the current routine (no `return_target_callable_id`, or it equals the current `__mutsu_callable_id`, or it equals the LEAVE-side target). Otherwise the in-flight outer-routine return keeps unwinding, as before.

## Tests

- `roast/S06-advanced/return-prioritization.t`: 9/11 → 11/11, added to whitelist
- New pin test `t/leave-return-prioritization.t` (6 assertions), verified byte-identical output on Rakudo v2026.06
- `make test`: all 1673 files / 16468 tests pass
- Related whitelisted roast files still pass: `S04-phasers/enter-leave.t`, `S06-advanced/return.t`
- `TODO_roast/S06.md` updated; `BLOCKERS.md` row removed (the old "oracle 不能" classification is stale — current local Rakudo v2026.06 passes the file 11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ