### PR TITLE
perf(regex): parse-time fold of static grammar tokens in enumerated char classes

### DIFF
--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -188,6 +188,10 @@ impl Interpreter {
         for pt in new_proto_tokens {
             registry.proto_tokens.insert(pt);
         }
+        // token_defs was rewritten wholesale: invalidate regex parses that may
+        // have folded token content in.
+        crate::runtime::regex_parse::TOKEN_DEFS_GEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // Re-apply only newly added our-scoped functions so they survive block scope exit.
         // In EVAL context, our-scoped functions should NOT leak into the outer lexical
         // scope — they remain accessible only via OUR:: pseudo-package resolution.

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -180,7 +180,7 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn resolve_token_patterns_static_in_pkg(
+    pub(crate) fn resolve_token_patterns_static_in_pkg(
         &self,
         name: &str,
         pkg: &str,

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -30,9 +30,22 @@ thread_local! {
     /// Cached as `Arc<RegexPattern>` so a cache hit is a cheap refcount bump
     /// rather than a deep clone of the whole token tree — the hot match loop
     /// re-fetches the same compiled pattern on every step / every iteration.
-    pub(crate) static REGEX_PARSE_CACHE: RefCell<HashMap<String, std::sync::Arc<RegexPattern>>> =
+    ///
+    /// Keyed by `(current package, pattern)` because parsing resolves grammar
+    /// tokens against the current package (`parse_combined_class` both decides
+    /// token-ness and — since the static fold — inlines simple token bodies).
+    /// Each entry records the `TOKEN_DEFS_GEN` it was parsed under; a hit with
+    /// a stale generation re-parses so a token (re)definition after the first
+    /// parse is picked up.
+    pub(crate) static REGEX_PARSE_CACHE: RefCell<HashMap<String, (u64, std::sync::Arc<RegexPattern>)>> =
         RefCell::new(HashMap::new());
 }
+
+/// Generation counter for the grammar-token registry (`Registry.token_defs`).
+/// Bumped on every token (re)definition / wholesale restore; used to invalidate
+/// `REGEX_PARSE_CACHE` entries whose parse folded token content in.
+pub(crate) static TOKEN_DEFS_GEN: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 /// A pattern is cacheable iff parsing it does not depend on runtime variable
 /// state. Interpolation (`interpolate_regex_scalars`) only substitutes when the

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -1,6 +1,15 @@
 use super::regex_parse::*;
 use super::*;
 
+/// Result of statically folding a grammar token referenced in an enumerated
+/// char class (see `token_class_fold`).
+enum TokenClassFold {
+    /// Every candidate matches exactly one char: fold to plain class items.
+    Chars(Vec<ClassItem>),
+    /// Candidates are closed but multi-char: inline as alternation branches.
+    Inline(Vec<RegexPattern>),
+}
+
 impl Interpreter {
     pub(super) fn parse_raku_char_class(&self, inner: &str, negated: bool) -> Option<CharClass> {
         // Parse Raku-style character class: a..z, \n, \t, \c[NAME], \x[HEX], etc.
@@ -531,6 +540,162 @@ impl Interpreter {
         }
     }
 
+    /// Parse-time fold of a user grammar token referenced inside an enumerated
+    /// char class (`<-restricted +name-sep>`). Without it every such reference
+    /// is re-resolved and re-matched *per input character* through a scratch
+    /// interpreter (catastrophic: a `token name { <-restricted>+ }` costs
+    /// several ms per char). When the token's candidates are all statically
+    /// closed patterns, the content is folded into the class at parse time:
+    /// single-char candidates become plain `ClassItem`s, multi-char closed
+    /// candidates become inline alternation branches. Sound because the parse
+    /// cache is keyed by package and invalidated by `TOKEN_DEFS_GEN`.
+    fn token_class_fold(&self, name: &str) -> Option<TokenClassFold> {
+        let pkg = self.current_package();
+        if pkg.is_empty() {
+            return None;
+        }
+        let candidates = self.resolve_token_patterns_static_in_pkg(name, &pkg);
+        if candidates.is_empty() {
+            return None;
+        }
+        // A failed sub-parse may set PENDING_REGEX_ERROR; a fold attempt must
+        // never surface an error the symbolic fallback path wouldn't.
+        let saved_err = PENDING_REGEX_ERROR.with(|e| e.borrow_mut().take());
+        let result = (|| {
+            let mut parsed: Vec<RegexPattern> = Vec::new();
+            for (pat, _pkg, _sym) in &candidates {
+                match self.parse_regex_uncached(pat, RegexParseMode::Match) {
+                    Some(p) if Self::regex_pattern_is_closed(&p) => parsed.push(p),
+                    _ => return None,
+                }
+            }
+            let mut items = Vec::new();
+            if parsed
+                .iter()
+                .all(|p| Self::pattern_single_char_items(p, &mut items))
+            {
+                return Some(TokenClassFold::Chars(items));
+            }
+            Some(TokenClassFold::Inline(parsed))
+        })();
+        PENDING_REGEX_ERROR.with(|e| *e.borrow_mut() = saved_err);
+        result
+    }
+
+    /// Whether a parsed pattern is fully static ("closed"): matching it needs
+    /// no runtime resolution (no subrules, code, backrefs) and produces no
+    /// captures — so it can be inlined verbatim where the token was referenced.
+    fn regex_pattern_is_closed(p: &RegexPattern) -> bool {
+        p.tokens.iter().all(Self::regex_token_is_closed)
+    }
+
+    fn regex_token_is_closed(t: &RegexToken) -> bool {
+        t.named_capture.is_none()
+            && t.secondary_named_capture.is_none()
+            && t.hash_capture.is_none()
+            && !matches!(t.quant, RegexQuant::RepeatCode(_))
+            && t.separator
+                .as_ref()
+                .is_none_or(|s| Self::regex_pattern_is_closed(&s.pattern))
+            && Self::regex_atom_is_closed(&t.atom)
+    }
+
+    fn regex_atom_is_closed(a: &RegexAtom) -> bool {
+        match a {
+            RegexAtom::Literal(_)
+            | RegexAtom::Any
+            | RegexAtom::Newline
+            | RegexAtom::NotNewline
+            | RegexAtom::ZeroWidth
+            | RegexAtom::WsRule
+            | RegexAtom::StartOfLine
+            | RegexAtom::EndOfLine
+            | RegexAtom::LeftWordBoundary
+            | RegexAtom::RightWordBoundary
+            | RegexAtom::UnicodeProp { .. }
+            | RegexAtom::UnicodePropAssert { .. }
+            | RegexAtom::SameAssertion { .. }
+            | RegexAtom::AtPosition(_)
+            | RegexAtom::CharClass(_) => true,
+            // A CompositeClass item may itself reference a user grammar token
+            // (match-time resolution) — only builtin names are closed.
+            RegexAtom::CompositeClass { positive, negative } => positive
+                .iter()
+                .chain(negative.iter())
+                .all(|item| match item {
+                    ClassItem::NamedBuiltin(n) => Self::is_builtin_char_class_name(n),
+                    _ => true,
+                }),
+            RegexAtom::Group(inner) => Self::regex_pattern_is_closed(inner),
+            RegexAtom::Alternation(branches)
+            | RegexAtom::SequentialAlternation(branches)
+            | RegexAtom::Conjunction(branches) => {
+                branches.iter().all(Self::regex_pattern_is_closed)
+            }
+            RegexAtom::Lookaround { pattern, .. } => Self::regex_pattern_is_closed(pattern),
+            // Everything else (subrules, captures, code, backrefs, markers…)
+            // needs runtime context or changes capture shape: not closed.
+            _ => false,
+        }
+    }
+
+    pub(super) fn is_builtin_char_class_name(name: &str) -> bool {
+        matches!(
+            name,
+            "alpha"
+                | "upper"
+                | "lower"
+                | "digit"
+                | "xdigit"
+                | "space"
+                | "alnum"
+                | "blank"
+                | "cntrl"
+                | "punct"
+                | "graph"
+                | "print"
+                | "ws"
+        )
+    }
+
+    /// If `p` matches exactly one character per match (a literal or a
+    /// non-negated char class, possibly behind grouping/alternation), append
+    /// its `ClassItem`s to `out` and return true.
+    fn pattern_single_char_items(p: &RegexPattern, out: &mut Vec<ClassItem>) -> bool {
+        if p.anchor_start || p.anchor_end || p.ignore_case || p.ignore_mark {
+            return false;
+        }
+        if p.tokens.len() != 1 {
+            return false;
+        }
+        let t = &p.tokens[0];
+        if !matches!(t.quant, RegexQuant::One)
+            || t.named_capture.is_some()
+            || t.secondary_named_capture.is_some()
+            || t.hash_capture.is_some()
+            || t.separator.is_some()
+        {
+            return false;
+        }
+        match &t.atom {
+            RegexAtom::Literal(c) => {
+                out.push(ClassItem::Char(*c));
+                true
+            }
+            RegexAtom::CharClass(class) if !class.negated => {
+                out.extend(class.items.iter().cloned());
+                true
+            }
+            RegexAtom::Group(inner) => Self::pattern_single_char_items(inner, out),
+            RegexAtom::Alternation(branches) | RegexAtom::SequentialAlternation(branches) => {
+                branches
+                    .iter()
+                    .all(|b| Self::pattern_single_char_items(b, out))
+            }
+            _ => false,
+        }
+    }
+
     /// Parse combined character class like `+ xdigit - lower` or `+ :HexDigit - :Upper`.
     /// Also handles bracket classes: `+ [a..z] - [aeiou]`.
     pub(super) fn parse_combined_class(
@@ -544,6 +709,9 @@ impl Interpreter {
         // matched as whole subrules (they may consume >1 char) rather than as
         // single-char class items. Desugared into an alternation at the end.
         let mut subrule_branches: Vec<String> = Vec::new();
+        // Statically-folded token bodies inlined as alternation branches
+        // (closed multi-char tokens, e.g. `token name-sep { '::' }`).
+        let mut inline_branches: Vec<RegexPattern> = Vec::new();
         // Whether a *negated* item resolves to a user grammar token (`<-restricted>`).
         // A plain negated `CharClass` cannot resolve such a token at match time, so
         // route the class through `CompositeClass` (which does) instead.
@@ -602,22 +770,7 @@ impl Interpreter {
                     }
                 } else {
                     // Check if this is a known built-in character class name
-                    let is_known_builtin = matches!(
-                        class_name,
-                        "alpha"
-                            | "upper"
-                            | "lower"
-                            | "digit"
-                            | "xdigit"
-                            | "space"
-                            | "alnum"
-                            | "blank"
-                            | "cntrl"
-                            | "punct"
-                            | "graph"
-                            | "print"
-                            | "ws"
-                    );
+                    let is_known_builtin = Self::is_builtin_char_class_name(class_name);
                     // Check if the name resolves as a grammar token in the current package
                     let is_grammar_token = !is_known_builtin
                         && !self.current_package().is_empty()
@@ -640,32 +793,56 @@ impl Interpreter {
                     }
                     // A *positive* user-defined grammar token may match a
                     // MULTI-character sequence (e.g. `token name-sep { '::' }`),
-                    // which a single-char char class cannot express. Collect it as
-                    // an alternation branch (desugared below) so the subrule is
-                    // matched as a whole unit. Builtins stay as efficient
-                    // single-char class items; a *negated* user token keeps the
-                    // single-char CompositeClass negation (all the enumerated-class
-                    // negative form supports).
-                    if adding && is_grammar_token {
-                        subrule_branches.push(class_name.to_string());
+                    // which a single-char char class cannot express. Try the
+                    // parse-time static fold first (plain class items / inline
+                    // branches — no per-char match-time resolution); when the
+                    // token is not statically closed, fall back to the symbolic
+                    // forms: positive tokens become subrule alternation branches,
+                    // a negated token keeps the single-char CompositeClass
+                    // negation (all the enumerated-class negative form supports).
+                    let fold = if is_grammar_token && mode == RegexParseMode::Match {
+                        self.token_class_fold(class_name)
                     } else {
-                        let item = ClassItem::NamedBuiltin(class_name.to_string());
-                        if adding {
-                            positive_items.push(item);
-                        } else {
-                            if is_grammar_token {
-                                negative_has_grammar_token = true;
+                        None
+                    };
+                    match fold {
+                        Some(TokenClassFold::Chars(items)) => {
+                            if adding {
+                                positive_items.extend(items);
+                            } else {
+                                negative_items.extend(items);
                             }
-                            negative_items.push(item);
+                        }
+                        Some(TokenClassFold::Inline(patterns)) if adding => {
+                            inline_branches.extend(patterns);
+                        }
+                        _ => {
+                            if adding && is_grammar_token {
+                                subrule_branches.push(class_name.to_string());
+                            } else {
+                                let item = ClassItem::NamedBuiltin(class_name.to_string());
+                                if adding {
+                                    positive_items.push(item);
+                                } else {
+                                    if is_grammar_token {
+                                        negative_has_grammar_token = true;
+                                    }
+                                    negative_items.push(item);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-        if positive_items.is_empty() && negative_items.is_empty() && subrule_branches.is_empty() {
+        if positive_items.is_empty()
+            && negative_items.is_empty()
+            && subrule_branches.is_empty()
+            && inline_branches.is_empty()
+        {
             return None;
         }
-        if subrule_branches.is_empty() {
+        if subrule_branches.is_empty() && inline_branches.is_empty() {
             // No user-subrule parts — the original char-class atoms.
             if positive_items.is_empty() {
                 // A negated user grammar token (`<-restricted>`) must resolve at
@@ -726,6 +903,9 @@ impl Interpreter {
             // capture) — a character class never captures.
             .map(|name| make_pattern(RegexAtom::Named(format!(".{name}"))))
             .collect();
+        // Statically-folded token bodies join the alternation directly (they
+        // are closed patterns: no captures, no runtime resolution).
+        branches.extend(inline_branches);
         if let Some(atom) = class_atom {
             branches.push(make_pattern(atom));
         }

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -1116,7 +1116,18 @@ impl Interpreter {
     /// cache cloned the tree on every hit — ANALYSIS §8.4).
     pub(super) fn parse_regex(&self, pattern: &str) -> Option<std::sync::Arc<RegexPattern>> {
         if regex_pattern_is_static(pattern) {
-            if let Some(cached) = REGEX_PARSE_CACHE.with(|c| c.borrow().get(pattern).cloned()) {
+            // Parsing resolves grammar tokens against the current package (and
+            // may fold their bodies in), so the cache key includes the package;
+            // a stale token-registry generation forces a re-parse.
+            let tok_gen = crate::runtime::regex_parse::TOKEN_DEFS_GEN
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let key = format!("{}\u{0}{}", self.current_package(), pattern);
+            if let Some(cached) = REGEX_PARSE_CACHE.with(|c| {
+                c.borrow()
+                    .get(&key)
+                    .filter(|(cached_gen, _)| *cached_gen == tok_gen)
+                    .map(|(_, p)| std::sync::Arc::clone(p))
+            }) {
                 return Some(cached);
             }
             let parsed = self
@@ -1125,7 +1136,7 @@ impl Interpreter {
             if let Some(ref p) = parsed {
                 REGEX_PARSE_CACHE.with(|c| {
                     c.borrow_mut()
-                        .insert(pattern.to_string(), std::sync::Arc::clone(p));
+                        .insert(key, (tok_gen, std::sync::Arc::clone(p)));
                 });
             }
             return parsed;

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -80,6 +80,10 @@ impl Interpreter {
         } else {
             self.registry_mut().token_defs.insert(key, vec![def]);
         }
+        // Regex parses may fold token bodies in (parse_combined_class); a new /
+        // redefined token must invalidate those cached parses.
+        crate::runtime::regex_parse::TOKEN_DEFS_GEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Collect token defs for a given scope (exact + :sym<> variants).

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -68,6 +68,8 @@ impl Interpreter {
             self.registry_mut().functions = saved_functions;
             self.registry_mut().proto_functions = saved_proto_functions;
             self.registry_mut().token_defs = saved_token_defs;
+            crate::runtime::regex_parse::TOKEN_DEFS_GEN
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.registry_mut().proto_subs = saved_proto_subs;
             self.registry_mut().proto_tokens = saved_proto_tokens;
             self.registry_mut().classes = saved_classes;
@@ -96,6 +98,8 @@ impl Interpreter {
         self.registry_mut().functions = saved_functions;
         self.registry_mut().proto_functions = saved_proto_functions;
         self.registry_mut().token_defs = saved_token_defs;
+        crate::runtime::regex_parse::TOKEN_DEFS_GEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.registry_mut().proto_subs = saved_proto_subs;
         self.registry_mut().proto_tokens = saved_proto_tokens;
         self.registry_mut().classes = saved_classes;
@@ -157,6 +161,8 @@ impl Interpreter {
         self.registry_mut().functions = saved_functions;
         self.registry_mut().proto_functions = saved_proto_functions;
         self.registry_mut().token_defs = saved_token_defs;
+        crate::runtime::regex_parse::TOKEN_DEFS_GEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.registry_mut().proto_subs = saved_proto_subs;
         self.registry_mut().proto_tokens = saved_proto_tokens;
         self.registry_mut().classes = saved_classes;

--- a/t/regex-charclass-token-fold.t
+++ b/t/regex-charclass-token-fold.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 11;
+
+# Parse-time static fold of grammar tokens referenced in enumerated char
+# classes (`<-restricted +name-sep>`). These pin the fold's soundness: the
+# parse cache is per-package and invalidated on token (re)definition.
+
+# 1. Basic fold: negated single-char token + positive multi-char token.
+grammar Ident {
+    regex TOP  { ^ <name> $ }
+    regex name { <-restricted +name-sep>+ }
+    token restricted { [':' | '<' | '>' | '(' | ')'] }
+    token name-sep   { < :: > }
+}
+ok Ident.parse('Zef::Distribution'), 'name with :: separator parses';
+is ~Ident.parse('Zef::Distribution')<name>, 'Zef::Distribution', 'full name captured';
+nok Ident.parse('Zef(Bad)'), 'restricted chars rejected';
+ok Ident.parse('Plain'), 'plain name parses';
+
+# 2. Two grammars, same-looking pattern text, DIFFERENT token content —
+#    the parse cache must not leak one grammar's fold into the other.
+grammar StopAtColon {
+    regex TOP { ^ <-stopper>+ $ }
+    token stopper { ':' }
+}
+grammar StopAtComma {
+    regex TOP { ^ <-stopper>+ $ }
+    token stopper { ',' }
+}
+ok StopAtColon.parse('a,b'), 'grammar A: comma allowed';
+nok StopAtColon.parse('a:b'), 'grammar A: colon rejected';
+ok StopAtComma.parse('a:b'), 'grammar B: colon allowed';
+nok StopAtComma.parse('a,b'), 'grammar B: comma rejected';
+
+# 3. Inherited grammar overriding the token — the subgrammar's definition
+#    must win when parsing through the subgrammar (virtual dispatch).
+grammar BaseG {
+    regex TOP { ^ <-stopper>+ $ }
+    token stopper { 'x' }
+}
+grammar SubG is BaseG {
+    token stopper { 'y' }
+}
+ok BaseG.parse('aya'), 'base grammar allows y';
+ok SubG.parse('axa'), 'subgrammar allows x (override wins)';
+nok SubG.parse('aya'), 'subgrammar rejects y (override wins)';
+
+done-testing;


### PR DESCRIPTION
## Summary

Next mzef frontier (PLAN §1 B2): zef's `Zef::Identity` REQUIRE grammar took ~300ms per parse under mutsu (debug; ~43ms release, ~70x raku), making `populate-distributions` over the 7648-dist fez index impractically slow for `zef info/list/search`.

**Root cause**: an enumerated char class referencing a user grammar token (`<-restricted +name-sep>`, `<-restricted>`) resolved and matched the token **per input character** at match time — each character ran a full `token_defs` registry scan (with per-key `Symbol::resolve` String allocs) plus `regex_match_len_at_start_in_pkg`, which **builds a fresh scratch `Interpreter` per call**. `token name { <-restricted>+ }` cost ~6.7ms/char.

**Fix**: parse-time static fold in `parse_combined_class`. When the token's candidates all parse to *closed* patterns (no subrules, captures, code assertions, backrefs, code-count quantifiers):
- single-char candidates (literals / char classes / alternations thereof) fold into plain `ClassItem`s — `<-restricted>` becomes a native negated `CharClass`;
- closed multi-char candidates (`token name-sep { '::' }`) inline as alternation branches, replacing the per-iteration silent subrule call.

Non-closed tokens keep the existing symbolic fallback unchanged.

**Soundness**: folded parses embed package-resolved content, so `REGEX_PARSE_CACHE` is now keyed by `(current package, pattern)` — fixing a latent unsoundness (token-ness decisions were already package-sensitive while the cache was package-agnostic) — and a new `TOKEN_DEFS_GEN` generation counter (bumped on token registration and wholesale `token_defs` restores) invalidates stale entries. Grammar inheritance dispatches virtually: the fold resolves through the parse-time package's MRO and each package keys its own entry.

## Measurements (debug build, same base)

| bench | before | after | |
|---|---|---|---|
| Zef REQUIRE grammar, 20 parses | 5.02s | 0.19s | **27x** |
| `Zef::Distribution.name` ×100 (fez metas) | 18.0s | 3.5s | **5.2x** |
| `token TOP { <-stopper>+ }` ×100 | 10.1s | 0.15s | **68x** |

Captures of the full REQUIRE grammar verified byte-identical to raku.

## Test plan
- New pin: `t/regex-charclass-token-fold.t` (11 tests, also passes under raku) — basic fold, **same-looking pattern text in two grammars with different token bodies** (per-package cache), **subgrammar token override** (MRO virtual dispatch), restricted-char rejection.
- `make test` PASS (Files=1674)
- Targeted roast green: `S05-mass/charsets.t`, `S05-mass/stdrules.t`, `S05-metasyntax/charset.t`, `S05-metasyntax/regex.t`, `S05-grammar/{inheritance,polymorphism,protoregex,example}.t`, `S05-transliteration/trans.t`, `S05-match/capturing-contexts.t`
- CI runs full `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)