### PR TITLE
feat(version): implement Version.parts / .plus / .whatever

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -351,6 +351,38 @@ pub(crate) fn native_method_0arg(
         return native_method_0arg(inner, method_sym);
     }
 
+    // Version introspection: `.parts` (list of Int/Str/Whatever parts),
+    // `.plus` (trailing `+`), `.whatever` (any `*` part). Used by zef's
+    // DependencySpecification version matching.
+    if let ValueView::Version { parts, plus, .. } = target.view() {
+        match method {
+            "parts" => {
+                let items: Vec<Value> = parts
+                    .iter()
+                    .map(|p| match p {
+                        crate::value::VersionPart::Num(n) => Value::int(*n),
+                        crate::value::VersionPart::Str(s) => Value::str_from(s.as_str()),
+                        crate::value::VersionPart::Whatever => Value::WHATEVER,
+                    })
+                    .collect();
+                return Some(Ok(Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                    crate::value::ArrayKind::List,
+                )));
+            }
+            "plus" => {
+                return Some(Ok(if plus { Value::TRUE } else { Value::FALSE }));
+            }
+            "whatever" => {
+                let any_star = parts
+                    .iter()
+                    .any(|p| matches!(p, crate::value::VersionPart::Whatever));
+                return Some(Ok(if any_star { Value::TRUE } else { Value::FALSE }));
+            }
+            _ => {}
+        }
+    }
+
     // $!.pending returns a list of all tracked Failure values (S04 spec).
     if method == "pending" {
         let failures = crate::value::get_pending_failures();

--- a/t/version-parts-plus.t
+++ b/t/version-parts-plus.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 10;
+
+# Version introspection methods used by zef's DependencySpecification
+# version matching (spec-matcher pads .parts and checks .plus).
+
+my $v123 = v1.2.3;
+is-deeply $v123.parts, (1, 2, 3), 'v-literal .parts';
+is-deeply Version.new("6.d").parts, (6, "d"), 'string part';
+is-deeply Version.new("1.2+").parts, (1, 2), '.parts excludes the + suffix';
+is Version.new("2021.10.*").parts.raku, '(2021, 10, *)', 'Whatever part';
+
+ok Version.new("1.2+").plus, '.plus True with + suffix';
+nok Version.new("1.2").plus, '.plus False without suffix';
+nok $v123.parts === Nil, 'parts is defined';
+
+ok Version.new("1.2.*").whatever, '.whatever True with a * part';
+nok Version.new("1.2").whatever, '.whatever False without * part';
+
+# The zef spec-matcher padding idiom round-trips.
+my $v = Version.new("1.2");
+my $padded = Version.new((|$v.parts, |(0 xx 1), ("+" if $v.plus)).join('.'));
+is ~$padded, '1.2.0', 'padding idiom builds 1.2.0';
+
+done-testing;


### PR DESCRIPTION
## Summary

Next mzef blocker (PLAN §1 B2): after #4457 + #4460, `zef info Zef` runs end-to-end but reports **"Found no candidates matching identity: Zef"**. Root cause: zef's `DependencySpecification.spec-matcher` pads version parts before comparing (`$spec-version.parts.elems`, `("+" if $self-version.plus)`), and mutsu lacked `Version.parts` / `.plus` — the "No such method 'parts' for invocant of type 'Version'" error was swallowed by the surrounding `try`/grep, rejecting every candidate.

Implements natively on `ValueView::Version` (0-arg fast path):
- `.parts` — List of Int / Str / Whatever parts (excludes the `+`/`-` suffix)
- `.plus` — True iff the version carries a trailing `+`
- `.whatever` — True iff any part is `*`

All outputs byte-identical to raku for `v1.2.3`, `"6.d"`, `"1.2+"`, `"2021.10.*"`. With this, the `Ecosystems.search` repro over the real 7648-dist fez index matches 5 zef candidates, identical to raku.

## Test plan
- New pin: `t/version-parts-plus.t` (10 tests, passes under raku too, including the zef padding idiom)
- `make test` PASS (Files=1676)
- CI runs full `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)