### PR TITLE
perf(env): fix the fib 2.3x regression — ?LINE as an Interpreter field + empty-overlay-tier reuse

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -9,50 +9,60 @@ cargo build --release
 ./benchmarks/run-all.sh
 ```
 
-## Current Status (benchmarks: 2026-07-12)
+## Current Status (benchmarks: 2026-07-12, post ?LINE/overlay fix)
 
-> Measured 2026-07-12 with `perf stat -r5` (or `-r3` for the sub-0.1s ones) under
-> `taskset -c 0-3` on a quiet machine, release build (`opt + debuginfo`), rakudo
-> v2022.12. Includes the July perf slices #4447 (for-loop topic writeback O(n^2)
-> fix), #4451 (native-ctor plan cache + is-default gate), and the
-> `method_local_keys` predicate. **Caution: verify machine quietness before
-> benchmarking** — a single stray `mutsu` process inflated earlier same-day
-> measurements by 2-3x (both mutsu's and raku's), which briefly put wrong
-> ratios (bench-class "0.58x") into PR #4447/#4451 text. The table below is the
-> corrected record.
+> Measured 2026-07-12 with `perf stat -r5` under `taskset -c 0-3` on a quiet
+> machine, release build (`opt + debuginfo`), rakudo v2022.12. Includes the July
+> perf slices #4447/#4451/#4454 and the `?LINE`-field + empty-overlay-tier fix
+> (see below). **Caution: verify machine quietness before benchmarking** — a
+> single stray `mutsu`/`raku`-adjacent process inflates both sides' numbers 2-3x
+> (it corrupted two same-day measurement rounds on 2026-07-12 alone).
 
 | Benchmark | mutsu | raku | ratio | notes |
 |-----------|-------|------|-------|-------|
-| fib(25) | 0.85s | 0.18s | 4.8x | recursive function calls — **regressed ~2.3x vs 2026-05 (0.37s), see below** |
-| bench-fib | 2.51s | 0.24s | 10.5x | fib with type constraint (`Int $n --> Int`) — **regressed ~2.3x vs 2026-05 (1.09s)** |
+| fib(25) | 0.155s | 0.164s | **0.94x** | recursive function calls (was 4.8x before the ?LINE/overlay fix) |
+| bench-fib | 0.548s | 0.207s | 2.6x | fib with type constraint (`Int $n --> Int`) (was 10.5x) |
 | int-arith | 0.12s | 0.15s | **0.85x** | `for ^100000 { $sum += $_ * 3 + 1 }` |
 | string-concat | 0.03s | 0.17s | **0.18x** | `$s ~= 'x'` × 10000 |
 | hash-access | 0.03s | 0.18s | **0.16x** | 10K hash inserts + value iteration |
-| method-call | 0.22s | 0.17s | 1.31x | Point.distance-to × 10000 (was 2.7x on 2026-05) |
+| method-call | 0.182s | 0.160s | 1.14x | Point.distance-to × 10000 (was 2.7x on 2026-05) |
 | array-ops | 0.10s | 0.23s | **0.44x** | grep+map on 1000-elem array × 100 |
-| bench-array | 0.05s | 0.23s | **0.22x** | push+map+grep+sort+reverse on 10K |
-| bench-hash | 0.04s | 0.25s | **0.14x** | 10K insert+lookup+delete+keys+values |
-| bench-class | 0.23s | 0.20s | 1.15x | class instantiation + method calls + inheritance (was 2.3x on 2026-05; 1.06s → 0.23s across the July slices) |
+| bench-array | 0.043s | 0.23s | **0.19x** | push+map+grep+sort+reverse on 10K |
+| bench-hash | 0.027s | 0.25s | **0.11x** | 10K insert+lookup+delete+keys+values |
+| bench-class | 0.181s | 0.194s | **0.93x** | class instantiation + method calls + inheritance (1.06s → 0.18s across the July slices) |
 | bench-startup | 0.004s | 0.12s | **0.03x** | startup overhead |
-| bench-string | 0.08s | 0.27s | **0.28x** | string operations |
+| bench-string | 0.064s | 0.27s | **0.24x** | string operations |
 
 Note: raku times include ~120ms startup overhead. mutsu startup is ~4ms.
 
 ### Summary
 
-- **Faster than raku (9/12)**: startup, string-concat, bench-string, int-arith, array-ops, hash-access, bench-hash, bench-array
-- **Near parity, target `<1.5x` met (2/12)**: bench-class (1.15x), method-call (1.31x)
-- **Regressed / far from target (2/12)**: fib (4.8x), bench-fib (10.5x)
+- **Faster than raku (11/12)**: startup, string-concat, bench-string, int-arith,
+  array-ops, hash-access, bench-hash, bench-array, bench-class, fib, method-call*
+  (*1.14x, within noise of parity)
+- **Above parity (1/12)**: bench-fib (2.6x — per-call type-constraint checking,
+  see "bench-fib specific" below)
 
-### ⚠ fib / bench-fib absolute regression (2026-07-12 finding)
+### ✔ fib / bench-fib absolute regression — RESOLVED (2026-07-12)
 
-`fib` (0.37s → 0.85s) and `bench-fib` (1.09s → 2.51s) both slowed ~2.3x in
-absolute terms since the 2026-05-24 measurement, on the same benchmark files.
-The May-era table predates GC-default-on (2026-07-05, ADR-0003) and the layer-3a
-Track B churn, which are the prime suspects — but this is unbisected. Needs a
-dedicated investigation (bisect over the GC-enable range, `MUTSU_VM_STATS`
-counter diff) before NaN-boxing (layer 3b) work banks its expected fib gains on
-top of a regressed baseline.
+The ~2.3x absolute slowdown vs 2026-05 (fib 0.37s → 0.85s) was **not GC**:
+`MUTSU_GC=off` measured identical to GC-on (the #4420 buffered-flag fast path
+already reduced per-drop cost to one relaxed load; fib does 1 collection, 86µs
+total pause). A `perf record` profile showed >40% of fib wall time in
+`Env::flattened` HashMap deep clones (+ ~28% dropping the clones): every
+recursive call stacked a scoped-overlay tier, and each call past
+`MAX_OVERLAY_DEPTH` (16) re-flattened the whole chain. The overlays were only
+non-empty because the per-statement `SetSourceLine` opcode inserted `?LINE`
+into the env (728k inserts on fib(25), each potentially forking the CoW map).
+
+Fix (two parts): (1) `?LINE` moved from the env to an `Interpreter` field
+(`cur_source_line`), saved/restored at frame boundaries (`VmCallFrame` /
+`CallFrameEntry`); (2) `Env::scoped_child` reuses the parent chain instead of
+stacking when the parent tier's overlay is empty (no writes, no tombstones), so
+pure recursion runs at constant chain depth and never flattens. Container-`Gc`
+drop churn on fib(25) went from 17.5M to 14; fib beat the 2026-05 record by
+2.4x. Pin: `t/source-line-deep-recursion.t`,
+`env::tests::empty_tiers_are_reused_not_stacked`.
 
 ## Architecture Overview
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -244,11 +244,6 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       1.06s→0.23s（raku 比 2.3x→**1.15x** ✅）・method-call 2.7x→**1.31x** ✅。
       残: `dispatch_compiled_method` 入口の `to_map()` 除去（中規模リファクタ）と
       attrs の `HashMap<String,Value>`/SipHash 起因の malloc 群（＝作り直し本体）。
-- [ ] **fib/bench-fib の絶対回帰調査（2026-07-12 発見）**: 同一ベンチファイルで
-      fib 0.37s→0.85s・bench-fib 1.09s→2.51s（2026-05-24 比 ~2.3x 遅化・raku 比 4.8x/10.5x）。
-      GC 既定 on（2026-07-05）＋Track B churn が第一容疑だが未 bisect。層3b が回帰した
-      ベースラインの上に fib 利得を計上する前に、bisect＋`MUTSU_VM_STATS` diff で要因特定する。
-      詳細 = [PERFORMANCE.md](PERFORMANCE.md) の 2026-07-12 表と注記。
 - [ ] **Lever 2: NaN-boxing = ADR-0001 層3b（JIT の地ならし・GC 後）**: `Value` 48→8 bytes。
       int-arith 2x・fib ~30% 狙い。`value_size_guard` テストでサイズ監視中。
       進捗・次の着手単位（3b-1 step B・ADR-0005 Accepted 待ち）は **§2 に集約**。
@@ -271,9 +266,10 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       絶対 index を運ぶ encoding の是正 / per-opcode ヒストグラム駆動での特化 op 統合
       （`ContainerEq`×4・`IndexAssign*`×6 — 美学でなくデータで駆動）。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。
-- 目標: method-call <1.5x（✅ 1.31x・2026-07-12）、bench-class <1.5x（✅ 1.15x・2026-07-12 —
-  同日中の「0.58x」記載は迷子プロセス負荷下の raku 計測による誤り・訂正済み）、
-  bench-fib（型制約付き）<2x（❌ 10.5x — 上記回帰調査が前提）。
+- 目標: method-call <1.5x（✅ 1.14x・2026-07-12）、bench-class <1.5x（✅ 0.93x・2026-07-12）、
+  fib <10x（✅ **0.94x** — ?LINE-field＋empty-overlay-tier 修正で絶対 2.3x 回帰ごと解消・
+  経緯は PERFORMANCE.md「RESOLVED」節）、bench-fib（型制約付き）<2x（❌ 2.6x —
+  残りは per-call 型制約チェック圏 = Lever 5）。
 
 ---
 
@@ -318,9 +314,9 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 | バイナリ配布 | なし | mise / GitHub Releases で単一コマンド導入 |
 | Whitelist | **1373**（全 .t 1463 中） | 1300+ ✅ 達成済み・現状維持以上 |
 | GC | **default on ✅**（2026-07-05・ADR-0003） | 達成（残 perf は層 3b へ） |
-| fib(25) vs raku | **4.8x**（2026-07-12・絶対 2.3x 回帰 — §5 要調査） | <10x ✅（回帰監視中） |
-| method-call vs raku | **1.31x**（2026-07-12） | <1.5x ✅ |
-| bench-class vs raku | **1.15x**（2026-07-12・同日の 0.58x 記載は計測誤りで訂正） | <1.5x ✅ |
-| bench-fib（型制約付き）vs raku | **10.5x**（2026-07-12・絶対 2.3x 回帰 — §5 要調査） | <2x |
+| fib(25) vs raku | **0.94x**（2026-07-12・?LINE/overlay 修正で回帰解消） | <10x ✅ |
+| method-call vs raku | **1.14x**（2026-07-12） | <1.5x ✅ |
+| bench-class vs raku | **0.93x**（2026-07-12） | <1.5x ✅ |
+| bench-fib（型制約付き）vs raku | **2.6x**（2026-07-12・残 = per-call 型制約チェック） | <2x |
 | 起動時間 vs raku | **0.04x** | 0.04x ✅ 維持 |
 | tree-walk フォールバック（メソッド/関数） | **~1% / ~18.6%（大半 carrier）** | 0%（carrier 除く） |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -1391,6 +1391,32 @@ Symbol キー化ではなく **intern 文字列の leak** で解消した。symb
   method-call **-2.7% cycles / -5.5% instructions**（880M→856M / 2403M→2271M）、
   bench-class **-2.2% cycles**（2995M→2928M）。
 
+## 2026-07-12: fib の絶対 2.3x 回帰を解消 — ?LINE を env から field へ＋空 overlay 層の再利用（fib が raku 超え 0.94x）
+
+同日朝に発見した fib/bench-fib の絶対回帰（2026-05-24 比 ~2.3x 遅化）を計測から根治まで完了。
+
+- **GC は無罪だった**: `MUTSU_GC=off` と on で fib/bench-fib とも誤差内（#4420 の
+  buffered-flag fast path が per-drop コストを relaxed load 1 回に抑済み。fib(25) は
+  collections=1・総 pause 86µs）。第一容疑「GC 既定 on」は棄却。
+- **真犯人 = `Env::flattened` の再帰 deep clone**: `perf record` で fib 実行時間の
+  >40% が `Env::flattened` の HashMap 全 clone（＋~28% がその drop）。再帰呼び出しごとに
+  scoped-overlay 層が積まれ、`MAX_OVERLAY_DEPTH`(16) 到達ごとにチェーン全体を再帰 flatten
+  していた。overlay を非空にしていた唯一の犯人は per-statement の `SetSourceLine` opcode が
+  env に insert する `?LINE`（fib(25) で 728k 回 = 全 opcode の 21%、CoW map fork も誘発）。
+- **修正 2 点**: ① `?LINE` を env エントリから `Interpreter::cur_source_line` field へ移設
+  （`VmCallFrame`/`CallFrameEntry` でフレーム境界 save/restore、読者 ~10 箇所を field 読みへ）
+  ② `Env::scoped_child` が「overlay 空＋tombstone 無し」の親層をスキップして親チェーンを
+  再利用 — 純粋な再帰は chain depth 一定になり flatten が原理的に消滅。
+- **結果**（release・静音・`perf stat -r5`・taskset 0-3、raku 同条件再計測）:
+  fib **0.85s→0.155s**（raku 0.164s — **0.94x で raku 超え**、2026-05 の最速 0.37s も 2.4x 更新）、
+  bench-fib **2.51s→0.548s**（10.5x→**2.6x**）、bench-class 0.23s→**0.181s**（**0.93x**）、
+  method-call 0.22s→**0.182s**（**1.14x**）。fib(25) の container-`Gc` drop churn 17.5M→**14**。
+- **pin**: `t/source-line-deep-recursion.t`（深さ 40 再帰・return 後の callframe line・
+  非空 overlay 再帰・`$?LINE` 定数）＋ `env::tests::empty_tiers_are_reused_not_stacked`。
+- **計測の罠（再発・記録）**: 同日 2 回目の汚染事故 — 並走する別セッションのビルド/テストが
+  raku 側基準値を 2.4x 膨らませ（0.164s→0.393s）、一時「mutsu 2.2x」と誤読しかけた。
+  ベンチは mutsu/raku **両方**を同一静音ウィンドウで取り直すこと。
+
 ## 参考
 
 - whitelist は本稿執筆時点で **1338**（2026-07-01、`4c311c71` 時点）。

--- a/src/env.rs
+++ b/src/env.rs
@@ -232,7 +232,23 @@ impl Env {
     /// chain from growing unbounded under deep recursion, the parent is flattened
     /// to a single tier once it reaches [`MAX_OVERLAY_DEPTH`]. See
     /// docs/vm-dual-store.md.
-    pub(crate) fn scoped_child(parent: Env) -> Self {
+    pub(crate) fn scoped_child(mut parent: Env) -> Self {
+        // Empty-tier reuse: a scoped parent whose overlay never received a
+        // write (and has no tombstones) is invisible to lookups, so chain the
+        // new child over the parent's own parent instead of stacking another
+        // tier. A pure recursive function (no env-synced params, no by-name
+        // writes) then runs at constant chain depth and never triggers the
+        // MAX_OVERLAY_DEPTH flatten — which was measured at >40% of fib(25)
+        // wall time (HashMap deep clone + drop per flatten).
+        while parent.inner.is_empty() && parent.tombstones.is_none() {
+            match &parent.parent {
+                Some(gp) => {
+                    let gp = Env::clone(gp);
+                    parent = gp;
+                }
+                None => break,
+            }
+        }
         let parent = if parent.depth >= MAX_OVERLAY_DEPTH {
             parent.flattened()
         } else {
@@ -752,6 +768,34 @@ mod tests {
         assert_eq!(flat.get_sym(s("b")), Some(&Value::int(2)));
         assert_eq!(flat.get_sym(s("c")), Some(&Value::int(3)));
         assert!(flat.get_sym(s("gone")).is_none());
+    }
+
+    #[test]
+    fn empty_tiers_are_reused_not_stacked() {
+        // A scoped parent whose overlay never received a write is invisible to
+        // lookups; scoped_child must chain over its parent instead of stacking
+        // (pure recursion then runs at constant depth — no flatten churn).
+        let mut root = Env::new();
+        root.insert("root".into(), Value::int(42));
+        let mut env = Env::scoped_child(root);
+        for _ in 0..(MAX_OVERLAY_DEPTH as usize * 4) {
+            env = Env::scoped_child(env);
+            assert_eq!(env.depth, 1, "empty tiers must not grow the chain");
+        }
+        assert_eq!(env.get_sym(s("root")), Some(&Value::int(42)));
+        // A written tier is NOT skipped: its entry stays visible in the child.
+        let written = scoped_with(env, &[("b", 2)]);
+        let child = Env::scoped_child(written);
+        assert_eq!(child.depth, 2);
+        assert_eq!(child.get_sym(s("b")), Some(&Value::int(2)));
+        // A tombstoned (remove-only) tier is NOT skipped either.
+        let mut root2 = Env::new();
+        root2.insert("a".into(), Value::int(1));
+        let mut tomb = Env::scoped_child(root2);
+        tomb.remove("a");
+        let child2 = Env::scoped_child(tomb);
+        assert_eq!(child2.depth, 2);
+        assert!(child2.get_sym(s("a")).is_none());
     }
 
     #[test]

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -301,13 +301,7 @@ impl Interpreter {
             .unwrap_or_else(|| "-e".to_string());
         let line = self
             .test_pending_callsite_line
-            .or_else(|| {
-                self.env().get("?LINE").and_then(|v| match v.view() {
-                    ValueView::Int(n) => Some(n),
-                    _ => None,
-                })
-            })
-            .unwrap_or(1);
+            .unwrap_or(self.cur_source_line);
         message.push_str(&format!("\n  in block <unit> at {} line {}", file, line));
         // When no CONTROL handler is active (`control_handler_depth == 0`), this
         // warn's only possible fate is the default handler: print to stderr and

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -434,7 +434,7 @@ impl Interpreter {
             let saved_env = self.env.clone();
             let saved_readonly = self.save_readonly_vars();
             if let Some(line) = self.test_pending_callsite_line {
-                self.env.insert("?LINE".to_string(), Value::int(line));
+                self.cur_source_line = line;
             }
             self.push_caller_env();
             // When the function has where constraints and there is a &name Sub

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -272,15 +272,7 @@ impl Interpreter {
 
     pub(crate) fn inject_pending_callsite_line(&mut self) {
         if let Some(line) = self.test_pending_callsite_line {
-            // Only insert if ?LINE differs, to avoid triggering Arc::make_mut
-            // deep clone on the CoW env in tight function call loops.
-            let needs_update = self
-                .env
-                .get("?LINE")
-                .is_none_or(|v| !matches!(v.view(), ValueView::Int(l) if l == line));
-            if needs_update {
-                self.env.insert("?LINE".to_string(), Value::int(line));
-            }
+            self.cur_source_line = line;
         }
     }
 

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -20,14 +20,7 @@ impl Interpreter {
                 .get("*PROGRAM-NAME")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
-            let line = callsite_line
-                .or_else(|| {
-                    self.env.get("?LINE").and_then(|v| match v.view() {
-                        ValueView::Int(i) => Some(i),
-                        _ => None,
-                    })
-                })
-                .unwrap_or(0);
+            let line = callsite_line.unwrap_or(self.cur_source_line);
             let kind = if def.is_method { "Method" } else { "Sub" };
             let pkg = def.package.resolve();
             super::deprecation::record_deprecation(
@@ -59,14 +52,7 @@ impl Interpreter {
             .get("*PROGRAM-NAME")
             .map(|v| v.to_string_value())
             .unwrap_or_default();
-        let line = callsite_line
-            .or_else(|| {
-                self.env.get("?LINE").and_then(|v| match v.view() {
-                    ValueView::Int(i) => Some(i),
-                    _ => None,
-                })
-            })
-            .unwrap_or(0);
+        let line = callsite_line.unwrap_or(self.cur_source_line);
         super::deprecation::record_deprecation("Method", name, package, message, &file, line);
     }
 
@@ -129,7 +115,7 @@ impl Interpreter {
         let saved_env = self.env.clone();
         let saved_readonly = self.save_readonly_vars();
         if let Some(line) = self.test_pending_callsite_line {
-            self.env.insert("?LINE".to_string(), Value::int(line));
+            self.cur_source_line = line;
         }
         self.push_caller_env();
         // Set current_package to the function's defining package so that default
@@ -325,7 +311,7 @@ impl Interpreter {
                     let saved_env = self.env.clone();
                     let saved_readonly = self.save_readonly_vars();
                     if let Some(line) = self.test_pending_callsite_line {
-                        self.env.insert("?LINE".to_string(), Value::int(line));
+                        self.cur_source_line = line;
                     }
                     self.push_caller_env();
                     let saved_package = self.current_package().to_string();

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -344,11 +344,19 @@ impl Interpreter {
         if method == "nextwith" {
             // Tail-style dispatch: call target with caller frame and return from current frame.
             let saved_env = self.env.clone();
+            let saved_line = self.cur_source_line;
             if let Some(parent_env) = self.caller_env_stack.last().cloned() {
                 self.env = parent_env;
+                // Frame elimination must also apply to the line tracking: the
+                // target's $?CALLER::LINE is the *eliminated* frame's callsite
+                // (recorded in the frame entry at push), not the nextwith line.
+                if let Some(entry) = self.callframe_stack.last() {
+                    self.cur_source_line = entry.line;
+                }
             }
             let call_result = self.call_sub_value(target.clone(), args, false);
             self.env = saved_env;
+            self.cur_source_line = saved_line;
             let value = match call_result {
                 Ok(v) => v,
                 Err(e) if e.return_value.is_some() => e.return_value.unwrap(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1110,6 +1110,15 @@ pub struct Interpreter {
     /// resolution, so the write lands on the LIVE (inner shadow) caller slot.
     pub(crate) pending_rw_writeback_slots: std::collections::HashMap<String, u32>,
     test_pending_callsite_line: Option<i64>,
+    /// Current source line of the executing statement (`$?LINE` for internal
+    /// consumers: backtraces, warn/die locations, callframe records). Lives as
+    /// a plain field — NOT an env entry — so the per-statement `SetSourceLine`
+    /// opcode is a scalar store instead of an env insert (which forked the
+    /// CoW overlay map on every statement and kept callee overlays non-empty,
+    /// defeating the empty-tier reuse in `Env::scoped_child`). Call paths that
+    /// push a `CallFrameEntry` restore it on pop from the entry's `line`; the
+    /// frame-less VM fast paths save/restore it manually.
+    pub(crate) cur_source_line: i64,
     /// Number of active CONTROL handlers in the current VM stack. Tracked
     /// on the interpreter (rather than per-VM) so that nested VMs (e.g.
     /// EVAL) can observe handlers installed by the outer VM and propagate

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -285,7 +285,7 @@ impl Interpreter {
             let saved_env = self.env.clone();
             let saved_readonly = self.save_readonly_vars();
             if let Some(line) = self.test_pending_callsite_line {
-                self.env.insert("?LINE".to_string(), Value::int(line));
+                self.cur_source_line = line;
             }
             self.push_caller_env();
             let persist_closure_env =

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -57,7 +57,7 @@ impl Interpreter {
             .clone()
             .unwrap_or_else(|| "<unknown>".to_string());
         self.env.insert("?FILE".to_string(), Value::str(file_name));
-        self.env.insert("?LINE".to_string(), Value::int(1));
+        self.cur_source_line = 1;
         crate::parser::set_parser_lib_paths(self.lib_paths.clone());
         crate::parser::set_parser_program_path(self.program_path.clone());
         let parse_result = crate::parse_dispatch::parse_source(&preprocessed);

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -13,14 +13,7 @@ impl Interpreter {
             .get("?FILE")
             .map(|v| v.to_string_value())
             .unwrap_or_default();
-        let line = self
-            .env
-            .get("?LINE")
-            .and_then(|v| match v.view() {
-                ValueView::Int(i) => Some(i),
-                _ => None,
-            })
-            .unwrap_or(0);
+        let line = self.cur_source_line;
         let code = code.or_else(|| self.block_stack.last().cloned());
         self.callframe_stack.push(CallFrameEntry {
             file,
@@ -32,7 +25,12 @@ impl Interpreter {
 
     pub(crate) fn pop_caller_env(&mut self) {
         self.caller_env_stack.pop();
-        self.callframe_stack.pop();
+        // Restore the caller's current line (recorded at push time). The
+        // env-based `?LINE` got this for free from the `saved_env` restore;
+        // the field must be rolled back explicitly.
+        if let Some(entry) = self.callframe_stack.pop() {
+            self.cur_source_line = entry.line;
+        }
     }
 
     /// Push the caller frames an `EVAL` inserts between the EVAL'd unit's
@@ -84,17 +82,19 @@ impl Interpreter {
                 });
             }
         }
-        self.callframe_stack.pop();
+        if let Some(entry) = self.callframe_stack.pop() {
+            self.cur_source_line = entry.line;
+        }
     }
 
     pub(crate) fn get_caller_line(&self, depth: usize) -> Option<Value> {
-        let stack_len = self.caller_env_stack.len();
+        let stack_len = self.callframe_stack.len();
         if depth == 0 || depth > stack_len {
             return None;
         }
-        self.caller_env_stack
+        self.callframe_stack
             .get(stack_len - depth)
-            .and_then(|env| env.get("?LINE").cloned())
+            .map(|entry| Value::int(entry.line))
     }
 
     /// Look up a variable through the $CALLER:: chain.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1805,6 +1805,7 @@ impl Interpreter {
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,
+            cur_source_line: 1,
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -176,6 +176,7 @@ impl Interpreter {
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,
+            cur_source_line: 1,
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -269,6 +269,9 @@ pub(crate) struct ControlHandlerCode {
 
 pub(crate) struct VmCallFrame {
     pub saved_env: Env,
+    /// The caller's `cur_source_line` at frame push, restored on pop (the
+    /// callee body's SetSourceLine updates must not leak into the caller).
+    pub saved_cur_line: i64,
     pub saved_locals: Vec<Value>,
     pub saved_upvalues: Vec<Option<Value>>,
     pub saved_stack_depth: usize,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -11,14 +11,7 @@ impl Interpreter {
                 .get("*PROGRAM-NAME")
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
-            let line = cl
-                .or_else(|| {
-                    self.env().get("?LINE").and_then(|v| match v.view() {
-                        ValueView::Int(i) => Some(i),
-                        _ => None,
-                    })
-                })
-                .unwrap_or(0);
+            let line = cl.unwrap_or(self.cur_source_line);
             crate::runtime::deprecation::record_deprecation(kind, name, package, msg, &file, line);
         }
     }

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -112,6 +112,8 @@ impl Interpreter {
         // lose package-var reads/writes.
         let saved_package = self.enter_routine_package(cf);
         let let_mark = self.let_saves_len();
+        // Frame-less path: roll back the body's SetSourceLine updates manually.
+        let saved_line = self.cur_source_line;
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -168,6 +170,7 @@ impl Interpreter {
 
         self.stack.truncate(saved_stack_depth);
 
+        self.cur_source_line = saved_line;
         // Sync state variables back to persistent storage. Prefer the env
         // value over locals because methods like .push() mutate the Value
         // in the env in-place, and the locals copy may be stale.

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -128,6 +128,10 @@ impl Interpreter {
 
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
+        // This path skips push_caller_env, so roll back the callee body's
+        // SetSourceLine updates manually (env-based ?LINE got this for free
+        // from the overlay drop).
+        let saved_line = self.cur_source_line;
         // Run the body under the routine's declaring package (set after the
         // arity/type-check early returns above, which run under the caller's
         // package). Restored after the env merge below.
@@ -189,6 +193,7 @@ impl Interpreter {
 
         self.stack.truncate(saved_stack_depth);
 
+        self.cur_source_line = saved_line;
         self.locals = saved_locals;
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -277,6 +277,8 @@ impl Interpreter {
 
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
+        // Frame-less path: roll back the body's SetSourceLine updates manually.
+        let saved_line = self.cur_source_line;
         // Run the body under the routine's declaring package (set after the
         // required-param early returns above). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
@@ -338,6 +340,7 @@ impl Interpreter {
 
         self.stack.truncate(saved_stack_depth);
 
+        self.cur_source_line = saved_line;
         // Restore locals
         self.locals = saved_locals;
         self.loop_local_vars = saved_loop_local_vars;

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -28,6 +28,7 @@ impl Interpreter {
         // phasers, threads) still flatten via `clone_env` at the capture site.
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
+            saved_cur_line: self.cur_source_line,
             saved_readonly: Some(self.save_readonly_vars()),
             readonly_added: Vec::new(),
             readonly_removed: Vec::new(),
@@ -50,6 +51,7 @@ impl Interpreter {
         crate::vm::vm_stats::record_clone_env();
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
+            saved_cur_line: self.cur_source_line,
             saved_readonly: None,
             readonly_added: Vec::new(),
             readonly_removed: Vec::new(),
@@ -74,6 +76,7 @@ impl Interpreter {
             .call_frames
             .pop()
             .expect("pop_call_frame: no frame to pop");
+        self.cur_source_line = frame.saved_cur_line;
         self.locals = std::mem::take(&mut frame.saved_locals);
         self.upvalues = std::mem::take(&mut frame.saved_upvalues);
         self.local_bind_pairs = std::mem::take(&mut frame.saved_local_bind_pairs);

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4200,8 +4200,7 @@ impl Interpreter {
                 self.exec_let_block_op(code, *body_end, ip, compiled_fns)?;
             }
             OpCode::SetSourceLine(line) => {
-                self.env_mut()
-                    .insert("?LINE".to_string(), Value::int(*line));
+                self.cur_source_line = *line;
                 *ip += 1;
             }
         }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -26,10 +26,7 @@ impl Interpreter {
         self.pending_rw_writeback_sources.clear();
         // Check for `is DEPRECATED` trait on the method
         if let Some(ref msg) = method_def.deprecated_message {
-            let cl = self.env().get("?LINE").and_then(|v| match v.view() {
-                ValueView::Int(i) => Some(i),
-                _ => None,
-            });
+            let cl = Some(self.cur_source_line);
             loan_env!(
                 self,
                 check_deprecation_for_method_with_line(method_name, owner_class, msg, cl,)

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -3,12 +3,9 @@ use crate::compiler::Compiler;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    /// Get the current source line number from the interpreter env.
+    /// Get the current source line number from the interpreter.
     pub(super) fn current_source_line(&self) -> Option<u32> {
-        self.env().get("?LINE").and_then(|v| match v.view() {
-            ValueView::Int(n) => Some(n as u32),
-            _ => None,
-        })
+        Some(self.cur_source_line as u32)
     }
 
     /// Get the current source file from the interpreter env.

--- a/t/source-line-deep-recursion.t
+++ b/t/source-line-deep-recursion.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# Pin for the ?LINE-as-field + empty-overlay-tier reuse change:
+# the per-statement source-line tracking must survive deep recursion
+# (chain depth > MAX_OVERLAY_DEPTH) and frame returns, both on the
+# frame-less VM fast paths and the slow dispatch paths.
+
+plan 6;
+
+# 1. Deep recursion (depth 40 > MAX_OVERLAY_DEPTH 16) still computes correctly.
+sub deep(Int $n --> Int) {
+    if $n <= 0 { return 0 }
+    return 1 + deep($n - 1);
+}
+is deep(40), 40, 'deep recursion works past the overlay-depth limit';
+
+# 2. After a deep recursive call returns, the current-line tracking must be
+#    back at the caller: callframe(1).line seen by a sub called right after
+#    the recursion is the callsite line below, not a callee-body line.
+sub caller-line { callframe(1).line }
+deep(20);
+my $after-line = caller-line();    # <-- must report THIS line
+is $after-line, 23, 'caller line restored after deep recursion';
+
+# 3. callframe(0).line inside a sub called from a loop reflects the sub body line.
+my @lines;
+sub probe { @lines.push(callframe(0).line) }
+for 1..2 { probe() }
+is @lines.elems, 2, 'probe ran twice';
+is @lines[0], @lines[1], 'callframe(0).line is stable across calls';
+
+# 4. A callee that *writes* an outer variable (non-empty overlay tier) still
+#    recurses correctly (the empty-tier reuse must not skip non-empty tiers).
+my $acc = 0;
+sub bump(Int $n) {
+    $acc = $acc + 1;
+    bump($n - 1) if $n > 0;
+}
+bump(30);
+is $acc, 31, 'captured-outer writes survive deep recursion';
+
+# 5. $?LINE is still the compile-time constant.
+is $?LINE, 44, '$?LINE compile-time constant';


### PR DESCRIPTION
## Summary

Resolves the fib/bench-fib absolute ~2.3x regression flagged in PERFORMANCE.md (2026-07-12 finding).

**Root cause (measured, not the suspected GC):**
- `MUTSU_GC=off` measured identical to GC-on — GC acquitted (the #4420 buffered-flag fast path already made per-drop cost one relaxed load; fib(25) does 1 collection, 86µs total pause).
- `perf record` showed >40% of fib wall time in `Env::flattened` HashMap deep clones (+~28% dropping the clones): every recursive call stacked a scoped-overlay tier and re-flattened the whole chain past `MAX_OVERLAY_DEPTH` (16).
- The overlays were only non-empty because the per-statement `SetSourceLine` opcode inserted `?LINE` into the env — 728k inserts on fib(25) (21% of all opcodes), each potentially forking the CoW overlay map.

**Fix (two parts):**
1. `?LINE` moves from the env to `Interpreter::cur_source_line`. `SetSourceLine` becomes a scalar store; readers (deprecation, warn/die locations, callframe records, CALLER line) read the field. `VmCallFrame`/`CallFrameEntry` save/restore it at frame boundaries; the frame-less VM fast paths save/restore manually.
2. `Env::scoped_child` reuses the parent chain when the parent tier's overlay is empty (no writes, no tombstones) instead of stacking — pure recursion runs at constant chain depth and never flattens. Non-empty and tombstoned tiers are never skipped.

## Results

Release build, quiet machine, `perf stat -r5` + `taskset -c 0-3`, raku re-measured in the same window:

| bench | before | after | raku | ratio |
|---|---|---|---|---|
| fib(25) | 0.85s | **0.155s** | 0.164s | **0.94x** |
| bench-fib | 2.51s | **0.548s** | 0.207s | 2.6x |
| bench-class | 0.23s | **0.181s** | 0.194s | **0.93x** |
| method-call | 0.22s | **0.182s** | 0.160s | 1.14x |

Container-`Gc` drop churn on fib(25): 17,524,996 → 14.

## Test plan

- `make test` full pass locally (1670 files / 16,443 tests)
- New pins: `t/source-line-deep-recursion.t` (deep recursion past the overlay limit, callframe line restored after return, non-empty-overlay recursion, `$?LINE` constant — validated against raku), `env::tests::empty_tiers_are_reused_not_stacked`
- Line-number/backtrace/caller/EVAL suites re-run locally (132+61 tests), roast `S02-magicals/file_line.t` + `block.t` pass
- CI runs the full roast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni