### PR TITLE
docs(plan): record mzef 2026-07-12 session results and the hyper instance-attr frontier

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -107,19 +107,29 @@ HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny（end-to-end HTTP 配信）/ Tu
 `--version` が動作）/ ✅ CompUnit::Repository の install→use 橋（`repository-for-name` well-known 名・
 デフォルト site repo 自動登録・担保 `t/compunit-repository-for-name.t`）。残:
 
-- [ ] **実 zef バイナリの end-to-end 実行を阻むブロッカー（2026-07-12 再調査で全面更新）**:
-      旧 2 バグは解消済み — (a) `%`-sigil 属性への Associative ダックタイピング bind は
-      Hash へ正しく coerce される（#4452 で解消・repro = `tmp/assoc-attr-repro.raku` 相当）、
-      (b) upstream zef 1.1.3（`ugexe/zef` HEAD）は全モジュールがパース・ロードし
-      `bin/zef --version`/`--help`/MAIN dispatch まで動作（パーサエラーは再現せず）。
+- [ ] **実 zef バイナリの end-to-end 実行を阻むブロッカー（2026-07-12 セッションで大幅前進）**:
+      旧 2 バグは解消済み（(a) %-sigil Associative bind = #4452 / (b) パーサエラー = 再現せず）。
+      同日 landed: #4457（classify pair-iteration / hash-init contained-Pair / IO::Path.child 連結）・
+      #4460（grammar token 静的 fold — `REQUIRE.parse` が raku 比 ~70x → **1.1x**）・
+      #4462（`Version.parts/.plus/.whatever` — 候補 version 照合の真因）。
+      **`Zef::Repository.candidates` の `.hyper(:batch(1)).map` を素の `.map` に変えると
+      `zef info Zef` が実 fez index (7648 dists) で Identity 出力まで完全動作**（release ~3 分）。
       現フロンティア:
-      1. **grammar パース性能**（最大のブロッカー）: `Zef::Identity` の `REQUIRE.parse` が
-         1 回 ~43ms（release・raku 比 ~70x）。`populate-distributions`（fez index 7648 dist ×
-         `.name` ごとに parse）が release でも ~10 分超 → `zef info/list/search` が実用不能。
-         zef 非依存 repro = `tmp/require-grammar-bench.raku`（20 parses: raku 0.012s / mutsu-debug 6.1s）。
-      2. ネスト `.raku` 表示: コレクション内の Instance が `Sp()`（type object 風）に描画される
+      1. **★hyper worker 上のインスタンス属性書き込み喪失（最大のブロッカー・実バグ）**:
+         `.hyper(:batch(1)).map(-> $repo { $repo.search(...) })` の callback 内で走る
+         populate の `push %!short-name-lookup{$_}, $dist` が**一様に ~80% 喪失**する
+         （7646 dists → 1570 keys・期待 9256。`@!attr` 配列 push は無傷 = %-hash 属性特有）。
+         さらに GC on だと 2 個目の Ecosystems で `$!name` が読めなくなる別症状も併発
+         （MUTSU_GC=off で消える = GC×thread の状態破壊）。単純化 repro は未成立
+         （`tmp/hyper-attr-repro*.raku` / `tmp/gather-attr-repro.raku` は通る）—
+         実物 repro = `tmp/zef-dbg`（計装済み copy・Repository.rakumod の hyper 有無で切替）。
+         cross-thread lexical campaign の instance-attr 版とみられる。
+      2. populate 性能: fold 後 release で fez+rea 全 populate ~3-5 分（raku は数秒）。
+         残= plain Named subrule 呼び出しの per-call コスト + Distribution/Identity 構築。
+      3. ネスト `.raku` 表示: コレクション内の Instance が `Sp()`（type object 風）に描画される
          （`(C.new,).raku` → raku は `(C.new(...),)`）。実体は正常（semantic には無害・表示のみ）。
-      3. `zef list --installed` は exit 0・出力なしまで動作（mutsu 側 site repo が空なら妥当）。
+      4. `zef list --installed` は exit 0・出力なしまで動作（mutsu 側 site repo が空なら妥当）。
+      5. index 名数の微差: fez 7648 metas で raku 9259 keys / mutsu 9256（3 件・name-fail 2-3 dists）。
 - [ ] 既知の小差異: CLI 数値文字列の `Int $n` への coerce が raku より積極的（`MAIN(Int $n,…)` に `7` が
       マッチ・raku は slurpy fallback）。実用上は mutsu 側のほうが直感的。
 - [ ] **network fetch**: fez エコシステム（`https://360.zef.pm/`）への取得。堅牢な async TLS が前提。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,38 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-12: mzef end-to-end キャンペーン — zef info が実 fez index で動作圏内に（#4457/#4460/#4462）
+
+PLAN §1 B2（mzef north-star）の再調査セッション。**旧記録の 2 ブロッカー（%-sigil Associative bind /
+Zef::CLI パーサエラー）は共に解消済み**と確認して PLAN を更新し、upstream zef 1.1.3 の実走で見つかった
+一般バグを 3 PR で landed:
+
+- **#4457**: ① `Hash/Set/Bag/Mix.classify/categorize` が Pair 列を iterate せず invocant 丸ごとを
+  classifier に渡していた（+ 素の fat-arrow Pair リスト要素が named 引数として飲み込まれ block の
+  topic に入らないバグも positional `ValuePair` への decay で修正）② hash 初期化が itemized
+  （`$(:a(1))`）/ cell 保持の Pair を Pair と認識せず「Odd number of elements」で死ぬ（itemized
+  *hash* は raku 同様に死ぬまま維持）③ `IO::Path.child/.add` が先頭 `/` の子パスで base を捨てる
+  （Rust `Path::join` の絶対パス置換が漏出。`("$*HOME/.config").IO.child('/zef/config.json')` が
+  `/zef/config.json` になり zef の config 探索が壊れていた）。
+- **#4460（grammar token 静的 fold）**: `Zef::Identity` の REQUIRE grammar が 1 parse ~300ms
+  （debug）の真因は、enumerated char class（`<-restricted +name-sep>`）が参照する grammar token を
+  **入力 1 文字ごとに** token レジストリ全走査 + scratch Interpreter 新規構築で解決していたこと
+  （~6.7ms/char）。閉じた token をパース時に fold（1 文字候補 → ネイティブ CharClass・複数文字
+  リテラル → インライン分岐）し、健全性は `REGEX_PARSE_CACHE` の (pkg, pattern) キー化＋
+  `TOKEN_DEFS_GEN` 世代無効化で担保（pattern 文字列のみをキーにしていた潜在 unsoundness も修正）。
+  REQUIRE 20 parses 5.02s→0.19s（27x・debug）、release では **raku 比 1.1x**（元 ~70x）。
+  pin = `t/regex-charclass-token-fold.t`（同名 token 別 grammar・継承 override を含む）。
+- **#4462（`Version.parts/.plus/.whatever`）**: zef の DependencySpecification.spec-matcher が
+  version 部分配列を pad して比較するが、mutsu に `Version.parts` が無く「No such method」→
+  周囲の try/grep に握り潰され「Found no candidates matching identity: Zef」になっていた。
+  3 メソッドを native 実装（raku と全ケース一致）。pin = `t/version-parts-plus.t`。
+
+**到達点**: `Zef::Repository.candidates` の `.hyper(:batch(1)).map` を素の `.map` に変えた
+計装 copy では、実 fez index（7648 dists）で `zef info Zef` が **Identity 出力まで完全動作**
+（release ~3 分）。残る最大ブロッカーは **hyper worker 上のインスタンス %-hash 属性書き込みが
+一様に ~80% 喪失する実バグ**（`@!attr` 配列 push は無傷・GC on では別途 `$!name` 破壊も併発）＝
+次スライス（詳細は PLAN §1 B2）。
+
 ## 2026-07-12: `S32-hash/perl.t` 完全制覇（typed-hash `.raku` idempotence + `Associative[T]` 型キャプチャ束縛）— #4452
 
 `S32-hash/perl.t`（47/55 → 55/55、raku 満点）を whitelist 化。BLOCKERS.md 表に残っていた


### PR DESCRIPTION
## Summary

Documentation update for today's mzef (PLAN §1 B2) session:

- **news/2026-07.md**: new entry covering the three merged PRs — #4457 (classify pair-iteration / hash-init contained-Pair / IO::Path.child concat), #4460 (parse-time grammar-token fold: `Zef::Identity` REQUIRE grammar from ~70x raku to **1.1x** in release), #4462 (`Version.parts/.plus/.whatever`, the "Found no candidates" root cause).
- **PLAN.md §1 B2**: frontier refresh. Key finding: with `.hyper(:batch(1)).map` replaced by plain `.map` in `Zef::Repository.candidates`, **`zef info Zef` works end-to-end against the real 7648-dist fez index** (release, ~3 min). The top remaining blocker is a real correctness bug: instance `%`-hash attribute pushes inside a hyper worker are uniformly ~80% lost (array attribute pushes survive; with GC on, a second Ecosystems instance additionally loses `$!name`). Deterministic reproducer = instrumented zef copy; simplified repros don't reproduce yet.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)