### PR TITLE
perf(vm): Int/Num fast paths for <=/>/>=, GetLocal without String clone, pooled locals vecs

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -20,9 +20,9 @@ cargo build --release
 
 | Benchmark | mutsu | raku | ratio | notes |
 |-----------|-------|------|-------|-------|
-| fib(25) | 0.155s | 0.164s | **0.94x** | recursive function calls (was 4.8x before the ?LINE/overlay fix) |
-| bench-fib | 0.548s | 0.207s | 2.6x | fib with type constraint (`Int $n --> Int`) (was 10.5x) |
-| int-arith | 0.12s | 0.15s | **0.85x** | `for ^100000 { $sum += $_ * 3 + 1 }` |
+| fib(25) | 0.150s | 0.164s | **0.91x** | recursive function calls (was 4.8x before the ?LINE/overlay fix) |
+| bench-fib | 0.398s | 0.207s | 1.92x | fib with type constraint (`Int $n --> Int`) (was 10.5x; `<=`/`>`/`>=` Int fast paths landed the <2x target) |
+| int-arith | 0.089s | 0.15s | **0.60x** | `for ^100000 { $sum += $_ * 3 + 1 }` |
 | string-concat | 0.03s | 0.17s | **0.18x** | `$s ~= 'x'` × 10000 |
 | hash-access | 0.03s | 0.18s | **0.16x** | 10K hash inserts + value iteration |
 | method-call | 0.182s | 0.160s | 1.14x | Point.distance-to × 10000 (was 2.7x on 2026-05) |
@@ -40,8 +40,8 @@ Note: raku times include ~120ms startup overhead. mutsu startup is ~4ms.
 - **Faster than raku (11/12)**: startup, string-concat, bench-string, int-arith,
   array-ops, hash-access, bench-hash, bench-array, bench-class, fib, method-call*
   (*1.14x, within noise of parity)
-- **Above parity (1/12)**: bench-fib (2.6x — per-call type-constraint checking,
-  see "bench-fib specific" below)
+- **Above parity (1/12)**: bench-fib (1.92x — `<2x` target met; the residual is
+  per-call param/return type checking plus dispatch overhead)
 
 ### ✔ fib / bench-fib absolute regression — RESOLVED (2026-07-12)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -275,9 +275,9 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       （`ContainerEq`×4・`IndexAssign*`×6 — 美学でなくデータで駆動）。
 - [ ] 正規表現: 量指定子反復ごとの `RegexCaptures.clone()` 削減。
 - 目標: method-call <1.5x（✅ 1.14x・2026-07-12）、bench-class <1.5x（✅ 0.93x・2026-07-12）、
-  fib <10x（✅ **0.94x** — ?LINE-field＋empty-overlay-tier 修正で絶対 2.3x 回帰ごと解消・
-  経緯は PERFORMANCE.md「RESOLVED」節）、bench-fib（型制約付き）<2x（❌ 2.6x —
-  残りは per-call 型制約チェック圏 = Lever 5）。
+  fib <10x（✅ **0.91x** — ?LINE-field＋empty-overlay-tier 修正で絶対 2.3x 回帰ごと解消・
+  経緯は PERFORMANCE.md「RESOLVED」節）、bench-fib（型制約付き）<2x
+  （✅ **1.92x** — `<=`/`>`/`>=` の Int/Num fast path で達成・2026-07-12）。
 
 ---
 
@@ -322,9 +322,9 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
 | バイナリ配布 | なし | mise / GitHub Releases で単一コマンド導入 |
 | Whitelist | **1373**（全 .t 1463 中） | 1300+ ✅ 達成済み・現状維持以上 |
 | GC | **default on ✅**（2026-07-05・ADR-0003） | 達成（残 perf は層 3b へ） |
-| fib(25) vs raku | **0.94x**（2026-07-12・?LINE/overlay 修正で回帰解消） | <10x ✅ |
+| fib(25) vs raku | **0.91x**（2026-07-12・?LINE/overlay 修正で回帰解消） | <10x ✅ |
 | method-call vs raku | **1.14x**（2026-07-12） | <1.5x ✅ |
 | bench-class vs raku | **0.93x**（2026-07-12） | <1.5x ✅ |
-| bench-fib（型制約付き）vs raku | **2.6x**（2026-07-12・残 = per-call 型制約チェック） | <2x |
+| bench-fib（型制約付き）vs raku | **1.92x**（2026-07-12・`<=`/`>`/`>=` Int fast path） | <2x ✅ |
 | 起動時間 vs raku | **0.04x** | 0.04x ✅ 維持 |
 | tree-walk フォールバック（メソッド/関数） | **~1% / ~18.6%（大半 carrier）** | 0%（carrier 除く） |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -1391,6 +1391,21 @@ Symbol キー化ではなく **intern 文字列の leak** で解消した。symb
   method-call **-2.7% cycles / -5.5% instructions**（880M→856M / 2403M→2271M）、
   bench-class **-2.2% cycles**（2995M→2928M）。
 
+## 2026-07-12: bench-fib <2x 目標達成 — `<=`/`>`/`>=` の Int/Num fast path＋GetLocal の String clone 除去
+
+fib 回帰解消（下記）の直後の追い打ちスライス。`perf record`（bench-fib）で
+「Int しか使わないのに `to_big_rat_parts` が 2.3%」を発見 — `exec_num_lt_op` には
+Int/Num fast path があるのに **`<=`/`>`/`>=` には無く**、hot loop の `$n <= 1` が毎回
+generic compare（BigRat 変換＋alloc）に落ちていた。`exec_num_le_op`/`exec_num_gt_op`/
+`exec_num_ge_op` に NumLt と同じ fast path を追加（Junction/型オブジェクト/BigInt は
+従来どおり generic 経路 = 意味論不変）。あわせて `exec_get_local_op` の
+per-GetLocal `code.locals[idx].cloned()`（fib で 606k String alloc/run）を `&str` 借用に、
+frame-less fast path 3 本の per-call locals `Vec` を `locals_pool` で再利用化。
+
+**結果**（release・静音・perf stat -r5）: bench-fib 0.548→**0.398s**（raku 比 **1.92x** —
+`<2x` 目標 ✅）、fib 0.155→**0.150s**（**0.91x**）、int-arith 0.12→**0.089s**（**0.60x** —
+range ループ内部の比較にも効いた）。bench-class/method-call/bench-hash/bench-array は不変。
+
 ## 2026-07-12: fib の絶対 2.3x 回帰を解消 — ?LINE を env から field へ＋空 overlay 層の再利用（fib が raku 超え 0.94x）
 
 同日朝に発見した fib/bench-fib の絶対回帰（2026-05-24 比 ~2.3x 遅化）を計測から根治まで完了。

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1119,6 +1119,12 @@ pub struct Interpreter {
     /// push a `CallFrameEntry` restore it on pop from the entry's `line`; the
     /// frame-less VM fast paths save/restore it manually.
     pub(crate) cur_source_line: i64,
+    /// Recycled `locals` backing vectors. The frame-less VM fast paths take the
+    /// caller's `locals` aside and need a fresh Vec per call; popping one here
+    /// instead of allocating removes a malloc/free pair per call (recursion
+    /// otherwise allocates one per frame down the whole chain). Entries are
+    /// cleared before being returned to the pool; bounded by `LOCALS_POOL_MAX`.
+    pub(crate) locals_pool: Vec<Vec<Value>>,
     /// Number of active CONTROL handlers in the current VM stack. Tracked
     /// on the interpreter (rather than per-VM) so that nested VMs (e.g.
     /// EVAL) can observe handlers installed by the outer VM and propagate

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1806,6 +1806,7 @@ impl Interpreter {
             pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,
             cur_source_line: 1,
+            locals_pool: Vec::new(),
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -177,6 +177,7 @@ impl Interpreter {
             pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,
             cur_source_line: 1,
+            locals_pool: Vec::new(),
             control_handler_depth: 0,
             test_assertion_line_stack: Vec::new(),
             block_stack: Vec::new(),

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -88,10 +88,9 @@ impl Interpreter {
             None
         };
 
-        // Reuse locals vec to avoid per-call allocation
+        // Reuse a pooled locals vec to avoid per-call allocation
         let num_locals = cf.code.locals.len();
-        self.locals.clear();
-        self.locals.resize(num_locals, Value::NIL);
+        self.locals = self.take_locals_from_pool(num_locals);
         for (i, local_name) in cf.code.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
                 self.locals[i] = val.clone();
@@ -189,7 +188,8 @@ impl Interpreter {
         // are visible in env for the merge step below.
 
         // Restore state
-        self.locals = saved_locals;
+        let used = std::mem::replace(&mut self.locals, saved_locals);
+        self.recycle_locals(used);
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.block_declared_vars = saved_block_declared_vars;

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -62,8 +62,7 @@ impl Interpreter {
         let caller_env = std::mem::replace(self.env_mut(), crate::env::Env::scoped_child(parent));
 
         let num_locals = cf.code.locals.len();
-        self.locals.clear();
-        self.locals.resize(num_locals, Value::NIL);
+        self.locals = self.take_locals_from_pool(num_locals);
 
         // Read-through to the caller (parent tier) for the initial value of a
         // local that shadows a same-named caller variable, matching the prior
@@ -90,7 +89,8 @@ impl Interpreter {
                 {
                     self.restore_readonly_vars(saved_readonly);
                     self.set_env(caller_env);
-                    self.locals = saved_locals;
+                    let used = std::mem::replace(&mut self.locals, saved_locals);
+                    self.recycle_locals(used);
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
                     self.block_declared_vars = saved_block_declared_vars;
@@ -194,7 +194,8 @@ impl Interpreter {
         self.stack.truncate(saved_stack_depth);
 
         self.cur_source_line = saved_line;
-        self.locals = saved_locals;
+        let used = std::mem::replace(&mut self.locals, saved_locals);
+        self.recycle_locals(used);
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.block_declared_vars = saved_block_declared_vars;

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -40,7 +40,7 @@ impl Interpreter {
         let caller_env = std::mem::replace(self.env_mut(), crate::env::Env::scoped_child(parent));
 
         let num_locals = cf.code.locals.len();
-        self.locals = vec![Value::NIL; num_locals];
+        self.locals = self.take_locals_from_pool(num_locals);
 
         // Bind parameters directly to locals slots and the overlay env.
         let mut positional_idx = 0usize;
@@ -132,7 +132,8 @@ impl Interpreter {
                     Some(v)
                 } else if pd.required {
                     self.set_env(caller_env);
-                    self.locals = saved_locals;
+                    let used = std::mem::replace(&mut self.locals, saved_locals);
+                    self.recycle_locals(used);
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
                     self.block_declared_vars = saved_block_declared_vars;
@@ -161,7 +162,8 @@ impl Interpreter {
                     Some(val)
                 } else if pd.required {
                     self.set_env(caller_env);
-                    self.locals = saved_locals;
+                    let used = std::mem::replace(&mut self.locals, saved_locals);
+                    self.recycle_locals(used);
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
                     self.block_declared_vars = saved_block_declared_vars;
@@ -342,7 +344,8 @@ impl Interpreter {
 
         self.cur_source_line = saved_line;
         // Restore locals
-        self.locals = saved_locals;
+        let used = std::mem::replace(&mut self.locals, saved_locals);
+        self.recycle_locals(used);
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.block_declared_vars = saved_block_declared_vars;

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -399,6 +399,20 @@ impl Interpreter {
     pub(super) fn exec_num_le_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        // Fast paths mirroring exec_num_lt_op: without them every `<=` in a
+        // hot loop pays the generic compare (BigRat conversion + alloc).
+        if let ValueView::Int(a) = left.view()
+            && let ValueView::Int(b) = right.view()
+        {
+            self.stack.push(Value::truth(a <= b));
+            return Ok(());
+        }
+        if let ValueView::Num(a) = left.view()
+            && let ValueView::Num(b) = right.view()
+        {
+            self.stack.push(Value::truth(a <= b));
+            return Ok(());
+        }
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
             check_type_object_in_numeric_context(&l)?;
             check_type_object_in_numeric_context(&r)?;
@@ -412,6 +426,19 @@ impl Interpreter {
     pub(super) fn exec_num_gt_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        // Fast paths mirroring exec_num_lt_op (see exec_num_le_op).
+        if let ValueView::Int(a) = left.view()
+            && let ValueView::Int(b) = right.view()
+        {
+            self.stack.push(Value::truth(a > b));
+            return Ok(());
+        }
+        if let ValueView::Num(a) = left.view()
+            && let ValueView::Num(b) = right.view()
+        {
+            self.stack.push(Value::truth(a > b));
+            return Ok(());
+        }
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
             check_type_object_in_numeric_context(&l)?;
             check_type_object_in_numeric_context(&r)?;
@@ -425,6 +452,19 @@ impl Interpreter {
     pub(super) fn exec_num_ge_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        // Fast paths mirroring exec_num_lt_op (see exec_num_le_op).
+        if let ValueView::Int(a) = left.view()
+            && let ValueView::Int(b) = right.view()
+        {
+            self.stack.push(Value::truth(a >= b));
+            return Ok(());
+        }
+        if let ValueView::Num(a) = left.view()
+            && let ValueView::Num(b) = right.view()
+        {
+            self.stack.push(Value::truth(a >= b));
+            return Ok(());
+        }
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
             check_type_object_in_numeric_context(&l)?;
             check_type_object_in_numeric_context(&r)?;

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -13,6 +13,28 @@ impl Interpreter {
         }
     }
 
+    /// Grab a locals vector from the recycle pool (or allocate the first time),
+    /// sized to `num_locals` with `Nil` slots. Pair with [`Self::recycle_locals`].
+    #[inline]
+    pub(super) fn take_locals_from_pool(&mut self, num_locals: usize) -> Vec<Value> {
+        let mut v = self.locals_pool.pop().unwrap_or_default();
+        v.clear();
+        v.resize(num_locals, Value::NIL);
+        v
+    }
+
+    /// Return a used locals vector to the recycle pool (bounded; excess is
+    /// simply dropped). Clearing here also drops the callee's slot values at a
+    /// well-defined point instead of inside the pool.
+    #[inline]
+    pub(super) fn recycle_locals(&mut self, mut used: Vec<Value>) {
+        const LOCALS_POOL_MAX: usize = 64;
+        if self.locals_pool.len() < LOCALS_POOL_MAX {
+            used.clear();
+            self.locals_pool.push(used);
+        }
+    }
+
     /// Save the current env, locals, stack depth, and readonly vars into a new
     /// call frame.
     pub(super) fn push_call_frame(&mut self) {

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -64,8 +64,10 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let idx = idx as usize;
         // Check if this variable has a binding alias (e.g. from $CALLER::foo := $other_var)
-        let name = code.locals.get(idx).cloned().unwrap_or_default();
-        if let Some(bound_to) = self.resolve_binding(&name) {
+        // Borrow the name from the compiled code (it is independent of `self`),
+        // avoiding a String clone on every GetLocal.
+        let name: &str = code.locals.get(idx).map(|s| s.as_str()).unwrap_or("");
+        if let Some(bound_to) = self.resolve_binding(name) {
             let bound_to = bound_to.to_string();
             if let Some(val) = self.env().get(&bound_to).cloned() {
                 self.stack.push(val);
@@ -75,8 +77,8 @@ impl Interpreter {
         // Attribute locals (!attr) modified by CAS: env holds the authoritative
         // value since sync_locals_from_env skips !-prefixed names for performance.
         if name.starts_with('!')
-            && self.is_shared_var_dirty(&name)
-            && let Some(val) = self.env().get(&name).cloned()
+            && self.is_shared_var_dirty(name)
+            && let Some(val) = self.env().get(name).cloned()
         {
             self.locals[idx] = val.clone();
             self.stack.push(val);
@@ -86,7 +88,7 @@ impl Interpreter {
         // `var_type_constraint` lookups) when no atomic storage has ever been
         // registered — the common case on this hot local-read path.
         if self.atomic_var_seen() {
-            let atomic_name = name.strip_prefix('$').unwrap_or(&name);
+            let atomic_name = name.strip_prefix('$').unwrap_or(name);
             let atomic_name_key = format!("__mutsu_atomic_name::{atomic_name}");
             // Only use the scalar atomic fast path for scalar ($) variables.
             // Array (@) variables with `atomicint` constraint are element-wise
@@ -129,7 +131,7 @@ impl Interpreter {
         // still holds an old local snapshot. Prefer the shared copy so reads
         // observe the latest value without forcing array COW on every push.
         if (name.starts_with('@') || name.starts_with('%'))
-            && let Some(shared_val) = self.get_shared_var(&name)
+            && let Some(shared_val) = self.get_shared_var(name)
         {
             self.stack.push(shared_val);
             return Ok(());
@@ -147,7 +149,7 @@ impl Interpreter {
                     | ValueView::Sub(..)
                     | ValueView::Instance { .. }
             )
-            && let Some(arc) = self.env().get(&name).and_then(|v| match v.view() {
+            && let Some(arc) = self.env().get(name).and_then(|v| match v.view() {
                 ValueView::ContainerRef(arc) => Some(arc.clone()),
                 _ => None,
             })
@@ -160,7 +162,7 @@ impl Interpreter {
         // bindings keep their ContainerRef handling. The cell lookup returns None
         // for non-attribute names and when `self` is not an instance.
         if !self.locals[idx].is_container_ref()
-            && let Some(cell_val) = self.read_self_attr_cell(&name)
+            && let Some(cell_val) = self.read_self_attr_cell(name)
         {
             self.locals[idx] = cell_val.clone();
             self.stack.push(cell_val);
@@ -191,28 +193,28 @@ impl Interpreter {
         }
         // Fast path: non-Nil values are always valid — skip env lookup
         if val.is_nil() {
-            if let Some(shared_val) = self.get_shared_var(&name) {
+            if let Some(shared_val) = self.get_shared_var(name) {
                 self.stack.push(shared_val);
                 return Ok(());
             }
             let is_internal = name.starts_with("__");
-            let is_special = matches!(name.as_str(), "_" | "/" | "!" | "¢");
+            let is_special = matches!(name, "_" | "/" | "!" | "¢");
             // Private attribute locals (!attr) are populated directly from
             // instance attributes in fast-path method calls; they may not be
             // in the env (when skip_env_setup is active) but are still valid.
             let is_private_attr =
                 name.starts_with('!') && name.len() > 1 && !name.starts_with("__");
-            if !is_internal && !is_special && !is_private_attr && !self.env().contains_key(&name) {
+            if !is_internal && !is_special && !is_private_attr && !self.env().contains_key(name) {
                 return Err(RuntimeError::new(format!(
                     "X::Undeclared::Symbols: Variable '{name}' is not declared"
                 )));
             }
             // `is default(...)`: return the default value instead of Nil.
-            if let Some(def) = self.var_default(&name) {
+            if let Some(def) = self.var_default(name) {
                 self.stack.push(def.clone());
                 return Ok(());
             }
-            if let Some(constraint) = self.var_type_constraint_fast(&name).cloned() {
+            if let Some(constraint) = self.var_type_constraint_fast(name).cloned() {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
                 // Nil type constraint: the type object for Nil is the Nil value
                 // itself, not a "Nil" Package type object.


### PR DESCRIPTION
## Summary

Follow-up perf slice after #4463 (fib regression fix), targeting the remaining bench-fib gap (2.6x vs the <2x goal).

- **`<=` / `>` / `>=` Int/Num fast paths**: a bench-fib profile showed `to_big_rat_parts` at 2.3% on an Int-only benchmark — `exec_num_lt_op` has Int/Num fast paths but the other three comparison ops fell through to the generic compare (BigRat conversion + allocation) on every hot-loop iteration. Junctions, type objects, BigInt and mixed operands keep the generic path, so semantics are unchanged (verified against raku, including junction threading and type-object errors).
- **GetLocal without String clone**: `exec_get_local_op` cloned the variable-name `String` from the compiled code on every execution (606k allocations per fib(25) run); it now borrows `&str`.
- **Pooled locals vecs**: the frame-less call paths (positional-light, light, fast) reuse locals vectors via a bounded `Interpreter::locals_pool` instead of allocating one per call (recursion allocated one per frame down the whole chain).

## Results

Release build, quiet machine, `perf stat -r5` + `taskset -c 0-3`:

| bench | before | after | vs raku |
|---|---|---|---|
| bench-fib | 0.548s | **0.398s** | **1.92x — `<2x` target met** |
| fib(25) | 0.155s | **0.150s** | **0.91x** |
| int-arith | 0.12s | **0.089s** | **0.60x** |

bench-class / method-call / bench-hash / bench-array unchanged.

## Test plan

- `make test` full pass locally (1676 files / 16,495 tests)
- Comparison semantics spot-checked against raku (Int/Num/BigInt/junction/type-object)
- CI runs the full roast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni