### PR TITLE
fix(vm): route all mutating array ops through the atomic shared store

### DIFF
--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -239,6 +239,51 @@ impl Interpreter {
         items: Vec<Value>,
         prepend: bool,
     ) -> Value {
+        let (_, updated) = self.shared_array_mutate(arr_name, |elements, kind| {
+            if prepend {
+                for (i, it) in items.into_iter().enumerate() {
+                    elements.insert(i, it);
+                }
+            } else {
+                elements.extend(items);
+            }
+            if *kind == crate::value::ArrayKind::List {
+                *kind = crate::value::ArrayKind::Array;
+            }
+        });
+        updated
+    }
+
+    /// Whether `@arr` already has an authoritative `__mutsu_atomic_arr::`
+    /// entry (created by a prior shared push/extend/CAS). Once it exists,
+    /// reads prefer it, so every subsequent mutation must go through
+    /// `shared_array_mutate` or it is silently lost.
+    pub(crate) fn atomic_array_entry_exists(&self, arr_name: &str) -> bool {
+        let atomic_key = format!("__mutsu_atomic_arr::{arr_name}");
+        matches!(
+            self.shared_vars
+                .read()
+                .unwrap()
+                .get(&atomic_key)
+                .map(Value::view),
+            Some(ValueView::Array(..))
+        )
+    }
+
+    /// Generic thread-safe read-modify-write of a plain lexical `@arr` through
+    /// the `__mutsu_atomic_arr::` shared store: seeds the atomic entry (same
+    /// contract as `shared_array_extend`), applies `f` to the `ArrayData`
+    /// under the `shared_vars` write lock, and marks the user-visible name
+    /// dirty. Returns `f`'s result (e.g. a popped element) plus the updated
+    /// array value. Every mutating array op in shared context must funnel
+    /// through here: once the atomic entry exists, reads prefer it, so a
+    /// mutation applied anywhere else (a stale base/env copy) is invisible —
+    /// the zef `populate-distributions` append-loss bug.
+    pub(crate) fn shared_array_mutate<R>(
+        &mut self,
+        arr_name: &str,
+        f: impl FnOnce(&mut crate::value::ArrayData, &mut crate::value::ArrayKind) -> R,
+    ) -> (R, Value) {
         let atomic_key = format!("__mutsu_atomic_arr::{arr_name}");
         let is_thread_clone = self.is_thread_clone();
         if is_thread_clone {
@@ -247,7 +292,7 @@ impl Interpreter {
             // (O(1) amortized) instead of a full-array COW per push.
             self.env.remove(arr_name);
         }
-        let updated = {
+        let (result, updated) = {
             let mut shared = self.shared_vars.write().unwrap();
             // Seed the atomic entry once from the base key (or this thread's
             // local snapshot), preserving ArrayData metadata (default/
@@ -278,17 +323,11 @@ impl Interpreter {
             };
             slot.with_array_mut(|arc_items, kind| {
                 let elements = crate::gc::Gc::make_mut(arc_items);
-                if prepend {
-                    for (i, it) in items.into_iter().enumerate() {
-                        elements.insert(i, it);
-                    }
-                } else {
-                    elements.extend(items);
-                }
-                if *kind == crate::value::ArrayKind::List {
-                    *kind = crate::value::ArrayKind::Array;
-                }
-                Value::array_with_kind(crate::gc::Gc::clone(arc_items), *kind)
+                let result = f(elements, kind);
+                (
+                    result,
+                    Value::array_with_kind(crate::gc::Gc::clone(arc_items), *kind),
+                )
             })
             .expect("atomic array entry seeded just above")
         };
@@ -308,7 +347,7 @@ impl Interpreter {
             // immediately even on direct env reads.
             self.env.insert(arr_name.to_string(), updated.clone());
         }
-        updated
+        (result, updated)
     }
 
     /// Thread-safe `@arr[$i] = $v` in shared (threaded) context.

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -277,55 +277,60 @@ impl Interpreter {
             }
             "splice" => {
                 let removed = target
-                    .with_array_inplace(|data, _| {
-                        let len = data.items.len();
-                        let resolve = |v: &Value| -> i64 {
-                            match v.view() {
-                                ValueView::Int(i) => i,
-                                ValueView::Whatever => len as i64,
-                                ValueView::Num(n) => n as i64,
-                                ValueView::Str(s) => s.parse::<i64>().unwrap_or(0),
-                                ValueView::Mixin(inner, _) => match inner.as_ref().view() {
-                                    ValueView::Int(i) => i,
-                                    _ => 0,
-                                },
-                                _ => 0,
-                            }
-                        };
-                        let start =
-                            (args.first().map(&resolve).unwrap_or(0).max(0) as usize).min(len);
-                        let count = args
-                            .get(1)
-                            .map(&resolve)
-                            .unwrap_or((len - start) as i64)
-                            .max(0) as usize;
-                        let end = (start + count).min(len);
-                        // Snapshot the replacement BEFORE draining: a
-                        // self-splice (`f().splice(1, 0, f())`) aliases the
-                        // items being mutated in place.
-                        let mut replacement: Vec<Value> = Vec::new();
-                        for arg in args.iter().skip(2) {
-                            match arg.view() {
-                                ValueView::Array(arr, ..) => {
-                                    replacement.extend(arr.iter().cloned())
-                                }
-                                ValueView::Seq(arr) | ValueView::Slip(arr) => {
-                                    replacement.extend(arr.iter().cloned())
-                                }
-                                _ => replacement.push(arg.clone()),
-                            }
-                        }
-                        let removed: Vec<Value> = data.items.drain(start..end).collect();
-                        for (i, item) in replacement.into_iter().enumerate() {
-                            data.items.insert(start + i, item);
-                        }
-                        removed
-                    })
+                    .with_array_inplace(|data, _| Self::splice_array_data(data, &args))
                     .unwrap_or_default();
                 Ok(Value::real_array(removed))
             }
             _ => unreachable!(),
         }
+    }
+
+    /// Apply `@a.splice($start?, $count?, *@replacement)` to an `ArrayData` in
+    /// place, returning the removed elements. Shared by the by-value invocant
+    /// path (`array_mutate_copy`) and the shared-context atomic-store path
+    /// (`shared_array_mutate` callers in the VM).
+    pub(crate) fn splice_array_data(
+        data: &mut crate::value::ArrayData,
+        args: &[Value],
+    ) -> Vec<Value> {
+        let len = data.items.len();
+        let resolve = |v: &Value| -> i64 {
+            match v.view() {
+                ValueView::Int(i) => i,
+                ValueView::Whatever => len as i64,
+                ValueView::Num(n) => n as i64,
+                ValueView::Str(s) => s.parse::<i64>().unwrap_or(0),
+                ValueView::Mixin(inner, _) => match inner.as_ref().view() {
+                    ValueView::Int(i) => i,
+                    _ => 0,
+                },
+                _ => 0,
+            }
+        };
+        let start = (args.first().map(&resolve).unwrap_or(0).max(0) as usize).min(len);
+        let count = args
+            .get(1)
+            .map(&resolve)
+            .unwrap_or((len - start) as i64)
+            .max(0) as usize;
+        let end = (start + count).min(len);
+        // Snapshot the replacement BEFORE draining: a self-splice
+        // (`f().splice(1, 0, f())`) aliases the items being mutated in place.
+        let mut replacement: Vec<Value> = Vec::new();
+        for arg in args.iter().skip(2) {
+            match arg.view() {
+                ValueView::Array(arr, ..) => replacement.extend(arr.iter().cloned()),
+                ValueView::Seq(arr) | ValueView::Slip(arr) => {
+                    replacement.extend(arr.iter().cloned())
+                }
+                _ => replacement.push(arg.clone()),
+            }
+        }
+        let removed: Vec<Value> = data.items.drain(start..end).collect();
+        for (i, item) in replacement.into_iter().enumerate() {
+            data.items.insert(start + i, item);
+        }
+        removed
     }
 
     /// Normalize push/unshift arguments (unwrap Scalar containers, deitemize).

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -767,14 +767,12 @@ impl Interpreter {
             return Ok(());
         }
 
-        // Fast path for push/unshift on shared @-arrays.
+        // Fast path for mutating array methods on shared @-arrays.
         // Bypasses the full method dispatch chain (try_native_method →
         // call_method_mut_with_values → push_to_shared_var) for the common case
         // of pushing simple values to a shared array inside a tight loop
         // (e.g. Lock::Async.protect { push @target, $i }).
-        if matches!(method.as_str(), "push" | "unshift")
-            && !args.is_empty()
-            && target_name.starts_with('@')
+        if target_name.starts_with('@')
             && matches!(target.view(), ValueView::Array(..))
             && self.shared_vars_active
         {
@@ -785,7 +783,8 @@ impl Interpreter {
             // keyed by name — that would accumulate pushes across every object
             // (roles-6e.t DESTROY: each `C1` instance's `@!order` doubled). They
             // keep the original base-key / interior-mutation path.
-            if Self::is_plain_lexical_array_name(&target_name) {
+            let plain = Self::is_plain_lexical_array_name(&target_name);
+            match method.as_str() {
                 // Route through the atomic shared store. The base-key
                 // `push_to_existing_shared_array`/`push_to_shared_var` write the
                 // plain `@a` shared entry, which `set_shared_var` can clobber with
@@ -794,18 +793,75 @@ impl Interpreter {
                 // base-key path also `extend`ed for `unshift`, appending instead
                 // of prepending.) The `__mutsu_atomic_arr::` store is exempt from
                 // that clobber, so concurrent push/unshift serialize and all land.
-                let norm = crate::runtime::Interpreter::normalize_push_unshift_args(args.clone());
-                let result = self.shared_array_extend(&target_name, norm, method == "unshift");
-                self.stack.push(result);
-                return Ok(());
+                //
+                // append/prepend MUST funnel here too: once a push created the
+                // atomic entry, reads prefer it, so an append applied to the
+                // stale base/env copy is silently invisible — the zef
+                // `populate-distributions` bug (`push @idx, ...; append @idx,
+                // ...` on a hyper worker lost every appended element).
+                "push" | "unshift" | "append" | "prepend" if plain && !args.is_empty() => {
+                    let items = if matches!(method.as_str(), "push" | "unshift") {
+                        crate::runtime::Interpreter::normalize_push_unshift_args(args.clone())
+                    } else {
+                        crate::runtime::flatten_append_args(args.clone())
+                    };
+                    let front = matches!(method.as_str(), "unshift" | "prepend");
+                    let result = self.shared_array_extend(&target_name, items, front);
+                    self.stack.push(result);
+                    return Ok(());
+                }
+                "push" | "unshift" if !args.is_empty() => {
+                    let result = loan_env!(
+                        self,
+                        push_to_existing_shared_array(&target_name, args.clone())
+                    )
+                    .unwrap_or_else(|| {
+                        loan_env!(self, push_to_shared_var(&target_name, args, &target))
+                    });
+                    self.stack.push(result);
+                    return Ok(());
+                }
+                // Removal ops only lose updates once the atomic entry shadows
+                // the base copy, so gate on its existence and keep the richer
+                // slow path (arity/lazy/immutable errors, callable splice
+                // args) for the unshadowed case.
+                "pop" | "shift"
+                    if plain
+                        && args.is_empty()
+                        && matches!(
+                            target.view(),
+                            ValueView::Array(_, crate::value::ArrayKind::Array)
+                        )
+                        && self.atomic_array_entry_exists(&target_name) =>
+                {
+                    let (result, _) = self.shared_array_mutate(&target_name, |data, _| {
+                        if data.items.is_empty() {
+                            crate::runtime::utils::make_empty_array_failure_what(&method, "Array")
+                        } else if method == "shift" {
+                            data.items.remove(0)
+                        } else {
+                            data.items.pop().unwrap_or(Value::NIL)
+                        }
+                    });
+                    self.stack.push(result);
+                    return Ok(());
+                }
+                "splice"
+                    if plain
+                        && matches!(
+                            target.view(),
+                            ValueView::Array(_, crate::value::ArrayKind::Array)
+                        )
+                        && self.atomic_array_entry_exists(&target_name) =>
+                {
+                    let (removed, _) = self.shared_array_mutate(&target_name, |data, _| {
+                        crate::runtime::Interpreter::splice_array_data(data, &args)
+                    });
+                    self.stack.push(Value::real_array(removed));
+                    return Ok(());
+                }
+                _ => {}
             }
-            let result = loan_env!(
-                self,
-                push_to_existing_shared_array(&target_name, args.clone())
-            )
-            .unwrap_or_else(|| loan_env!(self, push_to_shared_var(&target_name, args, &target)));
-            self.stack.push(result);
-            return Ok(());
         }
 
         let mut skip_native = quoted

--- a/t/hyper-array-mutators.t
+++ b/t/hyper-array-mutators.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# Once a `push` routes a plain lexical array into the cross-thread
+# `__mutsu_atomic_arr::` store (any mutation on a worker thread does this),
+# every other mutating array op must go through the same store: reads prefer
+# the atomic entry, so a mutation applied to the stale base copy is silently
+# lost. The zef `populate-distributions` bug: on a hyper worker,
+# `push @idx, $name; append @idx, @provides` lost every appended element,
+# so ~80% of `%!short-name-lookup` keys vanished.
+
+plan 12;
+
+my @one = (1,);
+
+sub on-hyper-worker(&body) {
+    @one.hyper(:batch(1)).map(-> $x { body() }).List[0];
+}
+
+is on-hyper-worker({ my @a; push @a, "n"; append @a, ("p1", "p2"); @a.join(",") }),
+    "n,p1,p2", "append (listop) after push lands on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n"; @a.append: ("p1", "p2"); @a.join(",") }),
+    "n,p1,p2", "append (method) after push lands on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n"; prepend @a, ("p1", "p2"); @a.join(",") }),
+    "p1,p2,n", "prepend after push lands on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n"; unshift @a, "p0"; @a.join(",") }),
+    "p0,n", "unshift after push lands on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n", "m"; my $p = @a.pop; "{@a.join(',')}|$p" }),
+    "n|m", "pop after push removes the element on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n", "m"; my $s = @a.shift; "{@a.join(',')}|$s" }),
+    "m|n", "shift after push removes the element on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n"; @a.splice(0, 0, "p1"); @a.join(",") }),
+    "p1,n", "splice insertion after push lands on a hyper worker";
+
+is on-hyper-worker({ my @a; push @a, "n", "m"; my @r = @a.splice(0, 1); "{@a.join(',')}|{@r.join(',')}" }),
+    "m|n", "splice removal after push lands on a hyper worker";
+
+is on-hyper-worker({ my @a; append @a, ("p1", "p2"); push @a, "n"; @a.join(",") }),
+    "p1,p2,n", "append before push also lands on a hyper worker";
+
+is on-hyper-worker({
+    my @a;
+    push @a, "n";
+    @a.pop;
+    my $r = @a.pop;
+    $r.defined ?? "defined" !! "undefined"
+}), "undefined", "pop on emptied shared array still returns a Failure";
+
+# The original shape: statement-modifier for over a Seq mixing pushed and
+# appended keys, accumulated into a hash (the zef short-name index).
+is on-hyper-worker({
+    my %lookup;
+    for <A B> -> $name {
+        my @idx;
+        push @idx, $name;
+        append @idx, ("{$name}::P1", "{$name}::P2");
+        push %lookup{$_}, $name for @idx.grep(*.so).unique;
+    }
+    %lookup.keys.elems
+}), 6, "hash keyed by pushed+appended names sees every key (zef populate shape)";
+
+# start-block workers exercise the same store.
+is (await start { my @a; push @a, "n"; append @a, ("p1", "p2"); @a.join(",") }),
+    "n,p1,p2", "append after push lands inside start block";
+
+done-testing;


### PR DESCRIPTION
## Summary

Once a `push` on a worker thread funnels a plain lexical `@array` into the `__mutsu_atomic_arr::` store (#4167), reads prefer the atomic entry — but only push/unshift wrote to it. `append`/`prepend`/`pop`/`shift`/`splice` mutated the stale base/env copy, so their effects were **silently lost** on hyper workers and inside `start` blocks:

```raku
hyper.map(-> $x { my @a; push @a, "n"; append @a, ("p1","p2"); @a.elems })
# => 1 (expected 3)
```

This was the real root cause of the PLAN §1 B2 "hyper worker instance %-hash attribute push loss" (zef `populate-distributions`): the hash was innocent — `append @short-names-to-index, $dist.meta<provides>.keys` lost every appended element, collapsing `%!short-name-lookup` from 9256 keys to the 1570 bare dist names. With this fix the **unpatched upstream zef populate path indexes the full key set under hyper** (verified against the real fez index via the instrumented `tmp/zef-dbg` harness: hyper keys == plain keys == 353 @ 500 dists, search results 5 == 5).

## Changes

- Generalize `shared_array_extend` into `shared_array_mutate` (seed the atomic entry, apply a closure to the `ArrayData` under the `shared_vars` write lock); rebuild `extend` on top.
- `CallMethodMut` shared fast path: funnel `append`/`prepend` (flattened args) like push/unshift; route `pop`/`shift`/`splice` through `shared_array_mutate` when an atomic entry already shadows the base copy, keeping the richer slow path (arity/lazy/immutable errors, callable splice args) for the unshadowed case.
- Extract `splice_array_data` from `array_mutate_copy` and share the implementation.

## Testing

- New pin `t/hyper-array-mutators.t` (12 cases: listop + method forms, hyper + start, pop/shift/splice removal visibility, the zef populate shape) — also passes on rakudo.
- `make test` PASS locally; S32-array pop/push/shift/splice/unshift + S32-hash/push + S17 (supply batch/syntax, promise start, lowlevel lock, channel basic) roast files pass; pin test stable across 5 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)