### PR TITLE
docs(plan): B2 hyper blocker solved by #4466 — zef info works with hyper enabled

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -111,25 +111,21 @@ HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny（end-to-end HTTP 配信）/ Tu
       旧 2 バグは解消済み（(a) %-sigil Associative bind = #4452 / (b) パーサエラー = 再現せず）。
       同日 landed: #4457（classify pair-iteration / hash-init contained-Pair / IO::Path.child 連結）・
       #4460（grammar token 静的 fold — `REQUIRE.parse` が raku 比 ~70x → **1.1x**）・
-      #4462（`Version.parts/.plus/.whatever` — 候補 version 照合の真因）。
-      **`Zef::Repository.candidates` の `.hyper(:batch(1)).map` を素の `.map` に変えると
-      `zef info Zef` が実 fez index (7648 dists) で Identity 出力まで完全動作**（release ~3 分）。
+      #4462（`Version.parts/.plus/.whatever` — 候補 version 照合の真因）・
+      **#4466（★旧最大ブロッカー根治: worker thread 上の shared 配列で append/prepend/pop/shift/
+      splice が `__mutsu_atomic_arr::` store を迂回し黙って喪失 — 「%-hash 属性 push 喪失」の
+      真因は populate の `append @short-names-to-index` 全滅だった。news/2026-07.md 参照）**。
+      → **`zef info Zef` が未改変 upstream・hyper 有効・GC 既定 on・実 fez index (7648 dists) で
+      Identity/Provides/Depends 出力まで完全動作**（release 2 runs 安定・pin t/hyper-array-mutators.t）。
       現フロンティア:
-      1. **★hyper worker 上のインスタンス属性書き込み喪失（最大のブロッカー・実バグ）**:
-         `.hyper(:batch(1)).map(-> $repo { $repo.search(...) })` の callback 内で走る
-         populate の `push %!short-name-lookup{$_}, $dist` が**一様に ~80% 喪失**する
-         （7646 dists → 1570 keys・期待 9256。`@!attr` 配列 push は無傷 = %-hash 属性特有）。
-         さらに GC on だと 2 個目の Ecosystems で `$!name` が読めなくなる別症状も併発
-         （MUTSU_GC=off で消える = GC×thread の状態破壊）。単純化 repro は未成立
-         （`tmp/hyper-attr-repro*.raku` / `tmp/gather-attr-repro.raku` は通る）—
-         実物 repro = `tmp/zef-dbg`（計装済み copy・Repository.rakumod の hyper 有無で切替）。
-         cross-thread lexical campaign の instance-attr 版とみられる。
-      2. populate 性能: fold 後 release で fez+rea 全 populate ~3-5 分（raku は数秒）。
+      1. populate 性能: fold 後 release で fez+rea 全 populate ~3-5 分（raku は数秒）。
          残= plain Named subrule 呼び出しの per-call コスト + Distribution/Identity 構築。
-      3. ネスト `.raku` 表示: コレクション内の Instance が `Sp()`（type object 風）に描画される
+      2. ネスト `.raku` 表示: コレクション内の Instance が `Sp()`（type object 風）に描画される
          （`(C.new,).raku` → raku は `(C.new(...),)`）。実体は正常（semantic には無害・表示のみ）。
-      4. `zef list --installed` は exit 0・出力なしまで動作（mutsu 側 site repo が空なら妥当）。
-      5. index 名数の微差: fez 7648 metas で raku 9259 keys / mutsu 9256（3 件・name-fail 2-3 dists）。
+      3. `zef list --installed` は exit 0・出力なしまで動作（mutsu 側 site repo が空なら妥当）。
+      4. index 名数の微差: fez 7648 metas で raku 9259 keys / mutsu 9256（3 件・name-fail 2-3 dists）。
+      5. （監視）旧観測「GC on だと 2 個目の Ecosystems で `$!name` 空読み」は #4466 後の release
+         2 runs で再現せず。再発したら GC×thread の状態破壊として独立調査。
 - [ ] 既知の小差異: CLI 数値文字列の `Int $n` への coerce が raku より積極的（`MAIN(Int $n,…)` に `7` が
       マッチ・raku は slurpy fallback）。実用上は mutsu 側のほうが直感的。
 - [ ] **network fetch**: fez エコシステム（`https://360.zef.pm/`）への取得。堅牢な async TLS が前提。

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -1464,6 +1464,35 @@ range ループ内部の比較にも効いた）。bench-class/method-call/bench
   raku 側基準値を 2.4x 膨らませ（0.164s→0.393s）、一時「mutsu 2.2x」と誤読しかけた。
   ベンチは mutsu/raku **両方**を同一静音ウィンドウで取り直すこと。
 
+## 2026-07-12: zef `info` が hyper 有効のまま完全動作 — 「%-hash 属性 push 喪失」の真因は shared 配列 `append` の atomic-store 迂回だった（#4466）
+
+PLAN §1 B2 の最大ブロッカー「hyper worker 上のインスタンス %-hash 属性 push ~80% 喪失」を根治。
+**%-hash もインスタンス属性も無罪だった** — 真因は worker thread 上の plain lexical `@array`：
+
+- worker 上の `push @a` は #4167 以来 `__mutsu_atomic_arr::` store へ funnel し、以後の読みは
+  atomic entry を優先する。だが funnel していたのは **push/unshift だけ**で、
+  `append`/`prepend`/`pop`/`shift`/`splice` は stale な base/env コピーに書くため**黙って全喪失**
+  （pop/shift は「値は返るが削除が反映されない」）。最小 repro:
+  `hyper.map(-> $x { my @a; push @a,"n"; append @a,("p1","p2"); @a.elems })` → 1（期待 3）。
+- zef では populate の `append @short-names-to-index, $dist.meta<provides>.keys` が全滅し、
+  `%!short-name-lookup` のキーが「unique dist 名の数」1570 に崩壊していた（期待 9256 — 差分が
+  ちょうど全 provides キー）。hash への push 自体は正常だった。
+- **fix**: `shared_array_extend` を汎用 `shared_array_mutate`（atomic entry を seed し write-lock 下で
+  `ArrayData` に closure 適用）に一般化し、CallMethodMut の shared fast path を全 mutator に拡張。
+  append/prepend は push 同様常時 funnel、pop/shift/splice は「atomic entry が base を shadow
+  している時のみ」route し、非 shadow 時は従来 slow path のエラー系（arity/lazy/immutable）を温存。
+  splice 本体は `array_mutate_copy` から `splice_array_data` として抽出・共有。
+- **結果**: 未改変 upstream zef の `zef info Zef` が **hyper 有効・GC 既定 on・実 fez index
+  (7648 dists) で Identity/Provides/Depends 出力まで完全動作**（release 2 runs 安定）。従来観測の
+  「GC on だと 2 個目の Ecosystems で `$!name` 空読み」も fix 後は再現せず（要監視）。
+- pin: `t/hyper-array-mutators.t`（12 件・rakudo でも green）。
+- **デバッグ教訓**: (1) 「hash が壊れた」ように見えても、**キーを生成する側**（lexical 配列）の
+  破壊を疑え — 計装は hash に入れる直前の各段の値を出す（`idx=[...]` の note が決定打）。
+  (2) 合成 repro が通り続けたのは provides キー名を dist 名と同一にしていて喪失が不可視だった
+  から — repro の各データ経路には**互いに識別可能な値**を流せ。(3) 実データ依存に見えたら
+  データを 1/150 に切り詰めて（jq で fez.json 500→50 件）実物モジュールを直接駆動する repro が
+  bisect を分速に変えた。
+
 ## 参考
 
 - whitelist は本稿執筆時点で **1338**（2026-07-01、`4c311c71` 時点）。


### PR DESCRIPTION
Record the #4466 root-cause analysis (shared-array mutators bypassing the __mutsu_atomic_arr:: store — the "instance %-hash attribute push loss" was actually append loss on the key-building lexical array) in news/2026-07.md, and update the PLAN §1 B2 frontier: `zef info Zef` now runs end-to-end on unpatched upstream zef with hyper enabled and default GC (2 stable release runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)