### PR TITLE
feat(value): NaN-boxing representation flip — Value becomes one 8-byte word (3b-1 step B-flip)

### DIFF
--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -117,7 +117,10 @@ impl Interpreter {
             }
             positionals.push(arg);
         }
-        let value = positionals.first().copied().unwrap_or(&Value::NIL);
+        let value = positionals
+            .first()
+            .copied()
+            .unwrap_or(&crate::value::NIL_VALUE);
         let type_name = match positionals.get(1).copied() {
             Some(v) => match v.view() {
                 ValueView::Package(name) => name.resolve(),

--- a/src/value/guards.rs
+++ b/src/value/guards.rs
@@ -37,12 +37,27 @@ impl<'a, P> RefGuard<'a, P> {
     /// borrowed from the `Value`. Post-flip, `view()` instead reconstructs
     /// the pointer from the packed payload address.
     #[inline]
+    #[allow(dead_code)]
     pub(crate) fn borrowed(source: &'a P) -> Self {
         // SAFETY: the copy is wrapped in ManuallyDrop and never dropped, so
         // the source keeps its unique ownership of the reference; the
         // PhantomData borrow keeps `source` alive and unmutated for 'a.
         Self {
             inner: ManuallyDrop::new(unsafe { std::ptr::read(source) }),
+            _borrow: PhantomData,
+        }
+    }
+
+    /// Packed-storage constructor: wrap a smart pointer reconstructed from a
+    /// NaN-box payload address. The caller (the `nanbox` decoder) guarantees
+    /// the word it decoded from stays alive and unmutated for `'a`, so the
+    /// wrapped pointer's referent cannot be released while the guard lives;
+    /// `ManuallyDrop` keeps this reconstruction from double-releasing the
+    /// word's owned reference.
+    #[inline]
+    pub(in crate::value) fn from_reconstructed(source: P) -> Self {
+        Self {
+            inner: ManuallyDrop::new(source),
             _borrow: PhantomData,
         }
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -288,10 +288,8 @@ mod error;
 mod error_construct;
 mod error_typed;
 mod guards;
-/// NaN-boxed 8-byte representation core (3b-1 step B). Not yet wired into
-/// `Value` — the flip lands after the internal wall migration; until then the
-/// unit tests keep the packing machinery honest.
-#[allow(dead_code)]
+/// NaN-boxed 8-byte representation core (3b-1 step B): the packed word that
+/// IS the `Value` storage. The only module that knows the bit layout.
 mod nanbox;
 mod serde_support;
 pub(crate) mod signature;
@@ -315,6 +313,13 @@ pub(crate) use crate::gc::gc_contents_mut;
 pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use aliased_mut::gc_data_mut;
 pub use guards::{ArcRef, GcRef, RefGuard, WeakGcRef};
+pub(in crate::value) use nanbox::NanBox;
+
+/// A `'static` Nil for call sites that keep a `&Value` beyond one expression:
+/// `&Value::NIL` stopped const-promoting once `Value` gained `Drop` (the
+/// NaN-box word releases its payload). Nil owns no payload, so a static is
+/// free.
+pub(crate) static NIL_VALUE: Value = Value(NanBox::NIL);
 pub(crate) use types::what_type_name;
 pub use view::ValueView;
 
@@ -958,24 +963,20 @@ pub enum EnumValue {
     Generic(Box<Value>),
 }
 
-/// The public `Value` type: a newtype **seal** over the representation enum
-/// (ADR-0005 §2.2/§2.3, 3b-1 step A). The field and [`ValueRepr`] itself are
-/// private to `crate::value`, so variant construction/matching outside
-/// `src/value/` is a compile error — the 3b-0 API wall
-/// (`docs/nanbox-3b0-api-wall.md`) is now enforced by the compiler, not just
-/// the `check-value-wall.sh` ratchet. Byte-identical to the old
-/// `pub enum Value`: `ValueRepr` is the same 48-byte enum, and the newtype
-/// adds no size, niche, or ABI change (`value_size_guard` still pins <= 48).
-///
-/// 3b-1 step B (the NaN-boxing representation flip, gated on ADR-0005
-/// acceptance) will replace `ValueRepr` behind this seal; call sites outside
-/// `src/value/` will not change.
+/// The public `Value` type: one NaN-boxed 8-byte word behind the newtype
+/// **seal** (ADR-0005, 3b-1 step B — the representation flip). The field and
+/// the [`NanBox`] encoding are private to `crate::value`; [`ValueRepr`]
+/// survives as the transient *working* enum crossed through
+/// [`Value::into_repr`] / [`Value::from_repr`], and borrowed reads decode
+/// through [`Value::view`]. Call sites outside `src/value/` see only the
+/// 3b-0 wall API, which is unchanged by the flip.
 #[derive(Clone)]
-pub struct Value(ValueRepr);
+pub struct Value(nanbox::NanBox);
 
 impl std::fmt::Debug for Value {
-    /// Forward to the repr so debug output is byte-identical to the pre-seal
-    /// derived output (trace logs and test expectations never see the wrapper).
+    /// Forward to the repr decode so debug output is byte-identical to the
+    /// pre-flip derived output (trace logs and test expectations never see
+    /// the packed word).
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
@@ -987,7 +988,7 @@ impl std::fmt::Debug for Value {
 /// inside `src/value/` goes through the variant-named constructor shims on
 /// `Value` below (which 3b-1 step B will turn into the NaN-box tag-packing
 /// constructors); struct-like variants and all patterns use
-/// `Value(ValueRepr::...)` / `.0` directly.
+/// `Value::from_repr(ValueRepr::...)` / `.0` directly.
 #[allow(private_interfaces)]
 #[derive(Debug, Clone)]
 pub(in crate::value) enum ValueRepr {
@@ -1171,11 +1172,13 @@ pub(in crate::value) enum ValueRepr {
 
 impl Value {
     /// Whether two values hold the same representation variant. Wall-safe
-    /// replacement for `std::mem::discriminant` on the pre-seal `enum Value`
-    /// (`Value` is a struct now, where `discriminant` is unspecified).
+    /// replacement for `std::mem::discriminant` on the pre-seal `enum Value`:
+    /// compares the NaN-box words' variant tags (companion-field kinds — the
+    /// six Array kinds, itemized Hash, mutable Set/Bag/Mix, the four Junction
+    /// kinds, boxed Int — collapse onto their `ValueRepr` discriminant).
     #[inline]
     pub fn same_variant(&self, other: &Value) -> bool {
-        std::mem::discriminant(&self.0) == std::mem::discriminant(&other.0)
+        self.0.variant_tag() == other.0.variant_tag()
     }
 }
 
@@ -1191,31 +1194,33 @@ impl Value {
 /// naming it in owned expressions (constructing one to pass to `from_repr`,
 /// matching one returned by `into_repr`) stays valid forever.
 impl Value {
-    /// Decompose into the working representation enum (owned decode seam).
-    /// Post-flip: the NaN-box tag decode; pointer payloads move (no refcount
-    /// traffic), shared multi-field boxes clone field-wise.
+    /// Decompose into the working representation enum (owned decode seam):
+    /// the NaN-box tag decode. Pointer payloads move (no refcount traffic);
+    /// shared multi-field boxes clone field-wise.
     #[inline]
     pub(in crate::value) fn into_repr(self) -> ValueRepr {
-        self.0
+        self.0.into_repr()
     }
 
     /// Rebuild from the working representation enum (construction seam for
     /// struct-like variants; tuple/unit variants keep their named shims
-    /// below). Post-flip: the NaN-box tag-packing encode.
+    /// below): the NaN-box tag-packing encode.
     #[inline]
     pub(in crate::value) fn from_repr(repr: ValueRepr) -> Value {
-        Value(repr)
+        Value(nanbox::NanBox::from_repr(repr))
     }
 
-    /// Edit the representation in place (mutation seam). Post-flip: decode to
-    /// the working enum, run `f`, re-pack — so `f` must not assume its edits
-    /// alias other holders (none of the migrated sites do; aliased container
-    /// mutation goes through the pointee, not the repr). Unused until the
-    /// `&mut`-shaped sites migrate (the exemplar batch had none).
+    /// Edit the representation in place (mutation seam): decode to the
+    /// working enum, run `f`, re-pack — so `f` must not assume its edits
+    /// alias other holders (no site does; aliased container mutation goes
+    /// through the pointee, not the repr). If `f` unwinds, `self` is left
+    /// `Nil` — acceptable, the value is torn mid-edit either way.
     #[inline]
-    #[allow(dead_code)]
     pub(in crate::value) fn with_repr_mut<R>(&mut self, f: impl FnOnce(&mut ValueRepr) -> R) -> R {
-        f(&mut self.0)
+        let mut repr = std::mem::replace(&mut self.0, nanbox::NanBox::NIL).into_repr();
+        let out = f(&mut repr);
+        self.0 = nanbox::NanBox::from_repr(repr);
+        out
     }
 }
 
@@ -1223,176 +1228,176 @@ impl Value {
 /// [`ValueRepr`], so the `Value::Int(..)` / `Value::Nil` *expression* sites
 /// inside `src/value/` compile unchanged across the newtype seal (patterns
 /// cannot resolve to functions/consts, so every pattern site was rewritten to
-/// `Value(ValueRepr::..)`). Private to `crate::value` like the repr itself —
+/// `Value::from_repr(ValueRepr::..)`). Private to `crate::value` like the repr itself —
 /// outside the module these do not exist, which is the seal. In 3b-1 step B
 /// these bodies become the NaN-box tag-packing constructors, so construction
 /// is already funneled through the single place the flip will edit.
 /// Struct-like variants (`Instance { .. }`, `Capture { .. }`, ...) cannot be
-/// shimmed as functions; their sites construct `Value(ValueRepr::.. { .. })`.
+/// shimmed as functions; their sites construct `Value::from_repr(ValueRepr::.. { .. })`.
 #[allow(non_snake_case, non_upper_case_globals, dead_code)]
 impl Value {
-    pub(in crate::value) const Nil: Value = Value(ValueRepr::Nil);
-    pub(in crate::value) const Whatever: Value = Value(ValueRepr::Whatever);
-    pub(in crate::value) const HyperWhatever: Value = Value(ValueRepr::HyperWhatever);
+    pub(in crate::value) const Nil: Value = Value(nanbox::NanBox::NIL);
+    pub(in crate::value) const Whatever: Value = Value(nanbox::NanBox::WHATEVER);
+    pub(in crate::value) const HyperWhatever: Value = Value(nanbox::NanBox::HYPER_WHATEVER);
 
     #[inline]
     pub(in crate::value) fn Int(v: i64) -> Value {
-        Value(ValueRepr::Int(v))
+        Value::from_repr(ValueRepr::Int(v))
     }
     #[inline]
     pub(in crate::value) fn BigInt(v: Arc<NumBigInt>) -> Value {
-        Value(ValueRepr::BigInt(v))
+        Value::from_repr(ValueRepr::BigInt(v))
     }
     #[inline]
     pub(in crate::value) fn Num(v: f64) -> Value {
-        Value(ValueRepr::Num(v))
+        Value::from_repr(ValueRepr::Num(v))
     }
     #[inline]
     pub(in crate::value) fn Str(v: Arc<String>) -> Value {
-        Value(ValueRepr::Str(v))
+        Value::from_repr(ValueRepr::Str(v))
     }
     #[inline]
     pub(in crate::value) fn Bool(v: bool) -> Value {
-        Value(ValueRepr::Bool(v))
+        Value::from_repr(ValueRepr::Bool(v))
     }
     #[inline]
     pub(in crate::value) fn Range(a: i64, b: i64) -> Value {
-        Value(ValueRepr::Range(a, b))
+        Value::from_repr(ValueRepr::Range(a, b))
     }
     #[inline]
     pub(in crate::value) fn RangeExcl(a: i64, b: i64) -> Value {
-        Value(ValueRepr::RangeExcl(a, b))
+        Value::from_repr(ValueRepr::RangeExcl(a, b))
     }
     #[inline]
     pub(in crate::value) fn RangeExclStart(a: i64, b: i64) -> Value {
-        Value(ValueRepr::RangeExclStart(a, b))
+        Value::from_repr(ValueRepr::RangeExclStart(a, b))
     }
     #[inline]
     pub(in crate::value) fn RangeExclBoth(a: i64, b: i64) -> Value {
-        Value(ValueRepr::RangeExclBoth(a, b))
+        Value::from_repr(ValueRepr::RangeExclBoth(a, b))
     }
     #[inline]
     pub(in crate::value) fn Array(data: crate::gc::Gc<ArrayData>, kind: ArrayKind) -> Value {
-        Value(ValueRepr::Array(data, kind))
+        Value::from_repr(ValueRepr::Array(data, kind))
     }
     #[inline]
     pub(in crate::value) fn Hash(data: Gc<HashData>, itemized: bool) -> Value {
-        Value(ValueRepr::Hash(data, itemized))
+        Value::from_repr(ValueRepr::Hash(data, itemized))
     }
     #[inline]
     pub(in crate::value) fn Rat(n: i64, d: i64) -> Value {
-        Value(ValueRepr::Rat(n, d))
+        Value::from_repr(ValueRepr::Rat(n, d))
     }
     #[inline]
     pub(in crate::value) fn FatRat(n: i64, d: i64) -> Value {
-        Value(ValueRepr::FatRat(n, d))
+        Value::from_repr(ValueRepr::FatRat(n, d))
     }
     #[inline]
     pub(in crate::value) fn BigRat(n: Box<NumBigInt>, d: Box<NumBigInt>) -> Value {
-        Value(ValueRepr::BigRat(n, d))
+        Value::from_repr(ValueRepr::BigRat(n, d))
     }
     #[inline]
     pub(in crate::value) fn Complex(re: f64, im: f64) -> Value {
-        Value(ValueRepr::Complex(re, im))
+        Value::from_repr(ValueRepr::Complex(re, im))
     }
     #[inline]
     pub(in crate::value) fn Set(data: crate::gc::Gc<SetData>, mutable: bool) -> Value {
-        Value(ValueRepr::Set(data, mutable))
+        Value::from_repr(ValueRepr::Set(data, mutable))
     }
     #[inline]
     pub(in crate::value) fn Bag(data: crate::gc::Gc<BagData>, mutable: bool) -> Value {
-        Value(ValueRepr::Bag(data, mutable))
+        Value::from_repr(ValueRepr::Bag(data, mutable))
     }
     #[inline]
     pub(in crate::value) fn Mix(data: crate::gc::Gc<MixData>, mutable: bool) -> Value {
-        Value(ValueRepr::Mix(data, mutable))
+        Value::from_repr(ValueRepr::Mix(data, mutable))
     }
     #[inline]
     pub(in crate::value) fn Package(sym: Symbol) -> Value {
-        Value(ValueRepr::Package(sym))
+        Value::from_repr(ValueRepr::Package(sym))
     }
     #[inline]
     pub(in crate::value) fn Pair(key: String, val: Box<Value>) -> Value {
-        Value(ValueRepr::Pair(key, val))
+        Value::from_repr(ValueRepr::Pair(key, val))
     }
     #[inline]
     pub(in crate::value) fn ValuePair(key: Box<Value>, val: Box<Value>) -> Value {
-        Value(ValueRepr::ValuePair(key, val))
+        Value::from_repr(ValueRepr::ValuePair(key, val))
     }
     #[inline]
     pub(in crate::value) fn Regex(pat: Arc<String>) -> Value {
-        Value(ValueRepr::Regex(pat))
+        Value::from_repr(ValueRepr::Regex(pat))
     }
     #[inline]
     pub(in crate::value) fn RegexWithAdverbs(adv: Box<RegexAdverbs>) -> Value {
-        Value(ValueRepr::RegexWithAdverbs(adv))
+        Value::from_repr(ValueRepr::RegexWithAdverbs(adv))
     }
     #[inline]
     pub(in crate::value) fn Sub(data: crate::gc::Gc<SubData>) -> Value {
-        Value(ValueRepr::Sub(data))
+        Value::from_repr(ValueRepr::Sub(data))
     }
     #[inline]
     pub(in crate::value) fn WeakSub(data: crate::gc::WeakGc<SubData>) -> Value {
-        Value(ValueRepr::WeakSub(data))
+        Value::from_repr(ValueRepr::WeakSub(data))
     }
     #[inline]
     pub(in crate::value) fn Seq(items: Arc<Vec<Value>>) -> Value {
-        Value(ValueRepr::Seq(items))
+        Value::from_repr(ValueRepr::Seq(items))
     }
     #[inline]
     pub(in crate::value) fn HyperSeq(items: Arc<Vec<Value>>) -> Value {
-        Value(ValueRepr::HyperSeq(items))
+        Value::from_repr(ValueRepr::HyperSeq(items))
     }
     #[inline]
     pub(in crate::value) fn RaceSeq(items: Arc<Vec<Value>>) -> Value {
-        Value(ValueRepr::RaceSeq(items))
+        Value::from_repr(ValueRepr::RaceSeq(items))
     }
     #[inline]
     pub(in crate::value) fn Slip(items: Arc<Vec<Value>>) -> Value {
-        Value(ValueRepr::Slip(items))
+        Value::from_repr(ValueRepr::Slip(items))
     }
     #[inline]
     pub(in crate::value) fn LazyList(data: crate::gc::Gc<LazyList>) -> Value {
-        Value(ValueRepr::LazyList(data))
+        Value::from_repr(ValueRepr::LazyList(data))
     }
     #[inline]
     pub(in crate::value) fn Promise(p: SharedPromise) -> Value {
-        Value(ValueRepr::Promise(p))
+        Value::from_repr(ValueRepr::Promise(p))
     }
     #[inline]
     pub(in crate::value) fn Channel(c: SharedChannel) -> Value {
-        Value(ValueRepr::Channel(c))
+        Value::from_repr(ValueRepr::Channel(c))
     }
     #[inline]
     pub(in crate::value) fn Mixin(
         inner: Arc<Value>,
         overrides: Arc<HashMap<String, Value>>,
     ) -> Value {
-        Value(ValueRepr::Mixin(inner, overrides))
+        Value::from_repr(ValueRepr::Mixin(inner, overrides))
     }
     #[inline]
     pub(in crate::value) fn Uni(data: Box<UniData>) -> Value {
-        Value(ValueRepr::Uni(data))
+        Value::from_repr(ValueRepr::Uni(data))
     }
     #[inline]
     pub(in crate::value) fn CustomType(data: Box<CustomTypeData>) -> Value {
-        Value(ValueRepr::CustomType(data))
+        Value::from_repr(ValueRepr::CustomType(data))
     }
     #[inline]
     pub(in crate::value) fn CustomTypeInstance(data: Box<CustomTypeInstanceData>) -> Value {
-        Value(ValueRepr::CustomTypeInstance(data))
+        Value::from_repr(ValueRepr::CustomTypeInstance(data))
     }
     #[inline]
     pub(in crate::value) fn Scalar(inner: Box<Value>) -> Value {
-        Value(ValueRepr::Scalar(inner))
+        Value::from_repr(ValueRepr::Scalar(inner))
     }
     #[inline]
     pub(in crate::value) fn ContainerRef(cell: Gc<Mutex<Value>>) -> Value {
-        Value(ValueRepr::ContainerRef(cell))
+        Value::from_repr(ValueRepr::ContainerRef(cell))
     }
     #[inline]
     pub(in crate::value) fn LazyThunk(data: Arc<LazyThunkData>) -> Value {
-        Value(ValueRepr::LazyThunk(data))
+        Value::from_repr(ValueRepr::LazyThunk(data))
     }
 }
 
@@ -1760,14 +1765,12 @@ mod value_size_guard {
     use super::*;
     #[test]
     fn value_stays_small() {
-        // Oversized variants used to hold their payloads inline, making `Value`
-        // 72 bytes (every clone/move pays for the largest variant). Boxing the
-        // big payloads shrank it: Capture+BigRat (72->64), CustomTypeInstance
-        // (64->56), Uni+RegexWithAdverbs+CustomType (56->48). Remaining 40-byte
-        // variants (Proxy, Enum, ...) are boxed in follow-up steps. Guard against
-        // layout regressions.
+        // Since the 3b-1 step-B representation flip, `Value` is one NaN-boxed
+        // 8-byte word (`NanBox`); `Option<Value>` keeps the same size via the
+        // NonZeroU64 niche. Guard against layout regressions.
         let sz = std::mem::size_of::<Value>();
-        assert!(sz <= 48, "size_of::<Value>() = {sz}, expected <= 48");
+        assert!(sz <= 8, "size_of::<Value>() = {sz}, expected <= 8");
+        assert_eq!(std::mem::size_of::<Option<Value>>(), sz);
     }
 }
 
@@ -1780,14 +1783,14 @@ mod hash_chokepoint_tests {
         let mut map = HashMap::new();
         map.insert("a".to_string(), Value::Int(1));
         Value::hash_insert_through(&mut map, "a".to_string(), Value::Int(2));
-        assert!(matches!(map.get("a"), Some(Value(ValueRepr::Int(2)))));
+        assert_eq!(map.get("a").and_then(Value::as_int), Some(2));
     }
 
     #[test]
     fn insert_through_creates_missing_entry() {
         let mut map = HashMap::new();
         Value::hash_insert_through(&mut map, "b".to_string(), Value::Int(7));
-        assert!(matches!(map.get("b"), Some(Value(ValueRepr::Int(7)))));
+        assert_eq!(map.get("b").and_then(Value::as_int), Some(7));
     }
 
     #[test]
@@ -1801,10 +1804,10 @@ mod hash_chokepoint_tests {
         Value::hash_insert_through(&mut map, "k".to_string(), Value::Int(99));
         // The entry is still the same cell (binding preserved)...
         assert!(matches!(
-            map.get("k"),
-            Some(Value(ValueRepr::ContainerRef(_)))
+            map.get("k").map(Value::view),
+            Some(ValueView::ContainerRef(_))
         ));
         // ...and the alias observes the new value through the cell.
-        assert!(matches!(*cell.lock().unwrap(), Value(ValueRepr::Int(99))));
+        assert_eq!(cell.lock().unwrap().as_int(), Some(99));
     }
 }

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -38,6 +38,7 @@ use super::*;
 mod boxes;
 mod decode;
 mod encode;
+mod peek;
 #[cfg(test)]
 mod tests;
 
@@ -189,13 +190,19 @@ fn kind_from_u8(k: u8) -> Kind {
 // ---- word assembly / disassembly ---------------------------------------------
 
 #[inline]
-fn word_for_kind(kind: Kind, payload: u64) -> NonZeroU64 {
-    debug_assert_eq!(payload & !PAYLOAD48_MASK, 0, "payload exceeds 48 bits");
-    debug_assert_eq!(payload & SUB_MASK, 0, "payload collides with subkind bits");
+const fn word_for_kind(kind: Kind, payload: u64) -> NonZeroU64 {
+    debug_assert!(payload & !PAYLOAD48_MASK == 0, "payload exceeds 48 bits");
+    debug_assert!(
+        payload & SUB_MASK == 0,
+        "payload collides with subkind bits"
+    );
     let k = kind as u64;
     let bits = ((KIND_PAGE_BASE + (k >> 3)) << TAG_SHIFT) | payload | ((k & 0x7) << SUB_SHIFT);
-    // SAFETY-free: the page is >= 0xFFF3, so the word is never 0.
-    NonZeroU64::new(bits).expect("kind words are always nonzero")
+    // The page is >= 0xFFF3, so the word is never 0.
+    match NonZeroU64::new(bits) {
+        Some(w) => w,
+        None => panic!("kind words are always nonzero"),
+    }
 }
 
 #[inline]
@@ -218,7 +225,7 @@ fn pack_num(f: f64) -> NonZeroU64 {
 }
 
 #[inline]
-fn pack_inline(kind: Kind, payload: u32) -> NonZeroU64 {
+const fn pack_inline(kind: Kind, payload: u32) -> NonZeroU64 {
     word_for_kind(kind, (payload as u64) << INLINE_SHIFT)
 }
 
@@ -460,9 +467,18 @@ unsafe impl Sync for NanBox {}
 impl NanBox {
     /// Raw word bits (tests / future tag-dispatch fast paths).
     #[inline]
+    #[allow(dead_code)]
     pub(in crate::value) fn bits(&self) -> u64 {
         self.0.get()
     }
+
+    // Inline-kind constants (no payload ownership, safe to duplicate freely) —
+    // the post-flip bodies of `Value::NIL` / `Value::TRUE` / `Value::WHATEVER`.
+    pub(in crate::value) const NIL: NanBox = NanBox(pack_inline(Kind::Nil, 0));
+    pub(in crate::value) const WHATEVER: NanBox = NanBox(pack_inline(Kind::Whatever, 0));
+    pub(in crate::value) const HYPER_WHATEVER: NanBox = NanBox(pack_inline(Kind::HyperWhatever, 0));
+    pub(in crate::value) const TRUE: NanBox = NanBox(pack_inline(Kind::Bool, 1));
+    pub(in crate::value) const FALSE: NanBox = NanBox(pack_inline(Kind::Bool, 0));
 }
 
 impl Clone for NanBox {

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -1,0 +1,434 @@
+//! `NanBox` -> `ValueView` borrowed decode (the post-flip `Value::view()`
+//! body), plus the word-level accessors behind the wall's `as_*` probes.
+//!
+//! Lifetimes: every `&'a` handed out here points into a payload allocation
+//! whose one strong reference is owned by the word itself. The caller borrows
+//! the `NanBox` for `'a`, so the payload cannot be released while the borrow
+//! lives; smart-pointer payloads are reconstructed by value inside
+//! [`RefGuard`]s (never dropped), pointee references are derived from the raw
+//! payload address.
+
+use super::*;
+
+/// Borrow the pointee of an `Arc`-kind word.
+///
+/// # Safety
+/// `bits` must be a live word packed with an `Arc<T>` payload, borrowed for `'a`.
+#[inline]
+unsafe fn peek_arc<'a, T>(bits: u64) -> &'a T {
+    unsafe { &*std::ptr::with_exposed_provenance::<T>(addr_of_payload(bits)) }
+}
+
+/// Borrow the pointee of a `Gc`-kind word.
+///
+/// # Safety
+/// `bits` must be a live word packed with a `Gc<T>` payload, borrowed for `'a`.
+#[inline]
+unsafe fn peek_gc<'a, T: Trace + 'static>(bits: u64) -> &'a T {
+    let g = ManuallyDrop::new(unsafe { take_gc::<T>(bits) });
+    // SAFETY: the pointee outlives 'a because the word owns a strong Gc
+    // reference for at least that long; `g` is only a borrow-shaped handle.
+    unsafe { std::mem::transmute::<&T, &'a T>(&g) }
+}
+
+/// # Safety
+/// `bits` must be a live word packed with an `Arc<T>` payload, borrowed for `'a`.
+#[inline]
+unsafe fn arc_guard<'a, T>(bits: u64) -> ArcRef<'a, T> {
+    RefGuard::from_reconstructed(unsafe { take_arc::<T>(bits) })
+}
+
+/// # Safety
+/// `bits` must be a live word packed with a `Gc<T>` payload, borrowed for `'a`.
+#[inline]
+unsafe fn gc_guard<'a, T: Trace + 'static>(bits: u64) -> GcRef<'a, T> {
+    RefGuard::from_reconstructed(unsafe { take_gc::<T>(bits) })
+}
+
+impl NanBox {
+    /// Decode into a borrowed [`ValueView`] — the post-flip `Value::view()`.
+    #[inline]
+    pub(in crate::value) fn view(&self) -> ValueView<'_> {
+        let bits = self.0.get();
+        match classify(bits) {
+            Classified::Int(v) => ValueView::Int(v),
+            Classified::Num(f) => ValueView::Num(f),
+            // SAFETY: the word is live for the duration of the &self borrow
+            // and was packed with exactly this kind -> payload-type mapping.
+            Classified::Kind(kind) => unsafe { view_kind(kind, bits) },
+        }
+    }
+
+    /// The payload if this is an `Int` (inline or boxed). No coercion.
+    #[inline]
+    pub(in crate::value) fn as_int(&self) -> Option<i64> {
+        let bits = self.0.get();
+        match classify(bits) {
+            Classified::Int(v) => Some(v),
+            // SAFETY: IntBoxed words carry an Arc<i64>.
+            Classified::Kind(Kind::IntBoxed) => Some(*unsafe { peek_arc::<i64>(bits) }),
+            _ => None,
+        }
+    }
+
+    /// The payload if this is a `Num`. No coercion.
+    #[inline]
+    pub(in crate::value) fn as_num(&self) -> Option<f64> {
+        match classify(self.0.get()) {
+            Classified::Num(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// The payload if this is a `Bool`. No coercion.
+    #[inline]
+    pub(in crate::value) fn as_bool(&self) -> Option<bool> {
+        let bits = self.0.get();
+        match classify(bits) {
+            Classified::Kind(Kind::Bool) => Some(inline_payload(bits) != 0),
+            _ => None,
+        }
+    }
+
+    /// The string slice if this is a `Str`. No coercion.
+    #[inline]
+    pub(in crate::value) fn as_str(&self) -> Option<&str> {
+        let bits = self.0.get();
+        match classify(bits) {
+            // SAFETY: Str words carry an Arc<String>.
+            Classified::Kind(Kind::Str) => Some(unsafe { peek_arc::<String>(bits) }),
+            _ => None,
+        }
+    }
+
+    /// Whether this word is `Nil`.
+    #[inline]
+    pub(in crate::value) fn is_nil(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::Nil))
+    }
+
+    /// The `SubData` pointee if this is a `Sub` (the `as_sub` probe).
+    #[inline]
+    pub(in crate::value) fn as_sub_data(&self) -> Option<&SubData> {
+        let bits = self.0.get();
+        match classify(bits) {
+            // SAFETY: Sub words carry a Gc<SubData>.
+            Classified::Kind(Kind::Sub) => Some(unsafe { peek_gc::<SubData>(bits) }),
+            _ => None,
+        }
+    }
+
+    /// Whether this word is an itemized `Hash` (the `hash_is_itemized` probe).
+    #[inline]
+    pub(in crate::value) fn is_hash_itemized(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::HashItemized))
+    }
+
+    /// Element slice if this is an Array/Seq/Slip (optionally Hyper/Race),
+    /// borrowed from the payload (the `as_list_items*` accessors).
+    #[inline]
+    pub(in crate::value) fn as_list_slice(&self, with_hyper: bool) -> Option<&[Value]> {
+        let bits = self.0.get();
+        let Classified::Kind(kind) = classify(bits) else {
+            return None;
+        };
+        // SAFETY (both arms): kind-checked payload types per `payload_op`.
+        match kind {
+            Kind::ArrayList
+            | Kind::ArrayArray
+            | Kind::ArrayItemList
+            | Kind::ArrayItemArray
+            | Kind::ArrayShaped
+            | Kind::ArrayLazy => Some(&unsafe { peek_gc::<ArrayData>(bits) }.items[..]),
+            Kind::Seq | Kind::Slip => Some(&unsafe { peek_arc::<Vec<Value>>(bits) }[..]),
+            Kind::HyperSeq | Kind::RaceSeq if with_hyper => {
+                Some(&unsafe { peek_arc::<Vec<Value>>(bits) }[..])
+            }
+            _ => None,
+        }
+    }
+
+    /// Whether this word's `Arc` payload — for the kinds whose payload is an
+    /// `Arc`-shared wrapper that can hold `Value`s (and therefore `Gc` edges)
+    /// — is uniquely owned. `true` for every other kind.
+    ///
+    /// The cycle collector inlines a non-node wrapper into every holder's
+    /// child list; for a wrapper shared by N holders that over-counts its
+    /// inner `Gc` edges N times, under-flowing strong counts during trial
+    /// deletion. Shared wrappers are treated as external root holders instead
+    /// (conservatively alive; see `value_gc::uniquely_owned`). Pre-flip the
+    /// multi-field payloads were `Box`-owned (always unique); post-flip they
+    /// share through one `Arc<...Box>`, so cloning any such `Value` makes the
+    /// wrapper shared and this gate is what keeps `gc_trace` sound.
+    pub(in crate::value) fn value_bearing_arc_payload_uniquely_owned(&self) -> bool {
+        let bits = self.0.get();
+        let Classified::Kind(kind) = classify(bits) else {
+            return true;
+        };
+        /// # Safety
+        /// `bits` must be a live word packed with an `Arc<T>` payload.
+        #[inline]
+        unsafe fn unique<T>(bits: u64) -> bool {
+            let a = ManuallyDrop::new(unsafe { take_arc::<T>(bits) });
+            Arc::strong_count(&a) == 1
+        }
+        // SAFETY (all arms): kind-checked payload types per `payload_op`.
+        unsafe {
+            match kind {
+                Kind::Scalar => unique::<Value>(bits),
+                Kind::Pair => unique::<PairBox>(bits),
+                Kind::ValuePair => unique::<ValuePairBox>(bits),
+                Kind::Capture => unique::<CaptureBox>(bits),
+                Kind::Proxy => unique::<ProxyBox>(bits),
+                Kind::GenericRange => unique::<GenericRangeBox>(bits),
+                Kind::LazyIoLines => unique::<LazyIoLinesBox>(bits),
+                Kind::Enum => unique::<EnumBox>(bits),
+                Kind::ParametricRole => unique::<ParametricRoleBox>(bits),
+                Kind::CustomType => unique::<CustomTypeData>(bits),
+                Kind::CustomTypeInstance => unique::<CustomTypeInstanceData>(bits),
+                Kind::Mixin => unique::<MixinBox>(bits),
+                // Seq/Slip/Junction/LazyThunk payloads are the shared Arc
+                // itself (not a box) — their existing `uniquely_owned` gates
+                // in `value_gc` read the same count. Node kinds (Array, Hash,
+                // Sub, ...) are real collector nodes: each holder legitimately
+                // owns one edge, no gate needed.
+                _ => true,
+            }
+        }
+    }
+
+    /// A representation-variant tag for `same_variant`: collapses the kind
+    /// space back onto `ValueRepr` discriminants (all six Array kinds are one
+    /// variant, IntBoxed is Int, the four Junction kinds are one, etc.).
+    #[inline]
+    pub(in crate::value) fn variant_tag(&self) -> u8 {
+        match classify(self.0.get()) {
+            Classified::Int(_) => VARIANT_INT,
+            Classified::Num(_) => VARIANT_NUM,
+            Classified::Kind(kind) => match kind {
+                Kind::IntBoxed => VARIANT_INT,
+                Kind::ArrayList
+                | Kind::ArrayArray
+                | Kind::ArrayItemList
+                | Kind::ArrayItemArray
+                | Kind::ArrayShaped
+                | Kind::ArrayLazy => VARIANT_ARRAY,
+                Kind::HashPlain | Kind::HashItemized => VARIANT_HASH,
+                Kind::SetImm | Kind::SetMut => VARIANT_SET,
+                Kind::BagImm | Kind::BagMut => VARIANT_BAG,
+                Kind::MixImm | Kind::MixMut => VARIANT_MIX,
+                Kind::JunctionAny | Kind::JunctionAll | Kind::JunctionOne | Kind::JunctionNone => {
+                    VARIANT_JUNCTION
+                }
+                other => VARIANT_KIND_BASE + other as u8,
+            },
+        }
+    }
+}
+
+const VARIANT_INT: u8 = 0;
+const VARIANT_NUM: u8 = 1;
+const VARIANT_ARRAY: u8 = 2;
+const VARIANT_HASH: u8 = 3;
+const VARIANT_SET: u8 = 4;
+const VARIANT_BAG: u8 = 5;
+const VARIANT_MIX: u8 = 6;
+const VARIANT_JUNCTION: u8 = 7;
+/// Every kind not collapsed above maps 1:1; offset past the collapsed tags.
+const VARIANT_KIND_BASE: u8 = 8;
+
+/// # Safety
+/// `bits` must be a live kind word of kind `kind`, borrowed for `'a`.
+unsafe fn view_kind<'a>(kind: Kind, bits: u64) -> ValueView<'a> {
+    // SAFETY (all arms): kind-checked payload types, same mapping as
+    // `payload_op` / `decode_kind`.
+    unsafe {
+        match kind {
+            Kind::Str => ValueView::Str(arc_guard(bits)),
+            Kind::Regex => ValueView::Regex(arc_guard(bits)),
+            Kind::BigInt => ValueView::BigInt(arc_guard(bits)),
+            Kind::IntBoxed => ValueView::Int(*peek_arc::<i64>(bits)),
+            Kind::Seq => ValueView::Seq(arc_guard(bits)),
+            Kind::HyperSeq => ValueView::HyperSeq(arc_guard(bits)),
+            Kind::RaceSeq => ValueView::RaceSeq(arc_guard(bits)),
+            Kind::Slip => ValueView::Slip(arc_guard(bits)),
+            Kind::JunctionAny | Kind::JunctionAll | Kind::JunctionOne | Kind::JunctionNone => {
+                ValueView::Junction {
+                    kind: match kind {
+                        Kind::JunctionAny => JunctionKind::Any,
+                        Kind::JunctionAll => JunctionKind::All,
+                        Kind::JunctionOne => JunctionKind::One,
+                        _ => JunctionKind::None,
+                    },
+                    values: arc_guard(bits),
+                }
+            }
+            Kind::Mixin => {
+                let b = peek_arc::<MixinBox>(bits);
+                ValueView::Mixin(&b.0, &b.1)
+            }
+            Kind::Scalar => ValueView::Scalar(peek_arc::<Value>(bits)),
+            Kind::LazyThunk => ValueView::LazyThunk(arc_guard(bits)),
+            Kind::Uni => ValueView::Uni(peek_arc::<UniData>(bits)),
+            Kind::RegexWithAdverbs => ValueView::RegexWithAdverbs(peek_arc::<RegexAdverbs>(bits)),
+            Kind::CustomType => ValueView::CustomType(peek_arc::<CustomTypeData>(bits)),
+            Kind::CustomTypeInstance => {
+                ValueView::CustomTypeInstance(peek_arc::<CustomTypeInstanceData>(bits))
+            }
+            Kind::Range => {
+                let p = peek_arc::<I64Pair>(bits);
+                ValueView::Range(p.0, p.1)
+            }
+            Kind::RangeExcl => {
+                let p = peek_arc::<I64Pair>(bits);
+                ValueView::RangeExcl(p.0, p.1)
+            }
+            Kind::RangeExclStart => {
+                let p = peek_arc::<I64Pair>(bits);
+                ValueView::RangeExclStart(p.0, p.1)
+            }
+            Kind::RangeExclBoth => {
+                let p = peek_arc::<I64Pair>(bits);
+                ValueView::RangeExclBoth(p.0, p.1)
+            }
+            Kind::Rat => {
+                let p = peek_arc::<I64Pair>(bits);
+                ValueView::Rat(p.0, p.1)
+            }
+            Kind::FatRat => {
+                let p = peek_arc::<I64Pair>(bits);
+                ValueView::FatRat(p.0, p.1)
+            }
+            Kind::BigRat => {
+                let b = peek_arc::<BigRatBox>(bits);
+                ValueView::BigRat(&b.0, &b.1)
+            }
+            Kind::Complex => {
+                let p = peek_arc::<F64Pair>(bits);
+                ValueView::Complex(p.0, p.1)
+            }
+            Kind::Pair => {
+                let p = peek_arc::<PairBox>(bits);
+                ValueView::Pair(&p.0, &p.1)
+            }
+            Kind::ValuePair => {
+                let p = peek_arc::<ValuePairBox>(bits);
+                ValueView::ValuePair(&p.0, &p.1)
+            }
+            Kind::Enum => {
+                let e = peek_arc::<EnumBox>(bits);
+                ValueView::Enum {
+                    enum_type: e.enum_type,
+                    key: e.key,
+                    value: &e.value,
+                    index: e.index,
+                }
+            }
+            Kind::GenericRange => {
+                let g = peek_arc::<GenericRangeBox>(bits);
+                ValueView::GenericRange {
+                    start: &g.start,
+                    end: &g.end,
+                    excl_start: g.excl_start,
+                    excl_end: g.excl_end,
+                }
+            }
+            Kind::Version => {
+                let v = peek_arc::<VersionBox>(bits);
+                ValueView::Version {
+                    parts: &v.parts,
+                    plus: v.plus,
+                    minus: v.minus,
+                }
+            }
+            Kind::Capture => {
+                let c = peek_arc::<CaptureBox>(bits);
+                ValueView::Capture {
+                    positional: &c.positional,
+                    named: &c.named,
+                }
+            }
+            Kind::Proxy => {
+                let p = peek_arc::<ProxyBox>(bits);
+                ValueView::Proxy {
+                    fetcher: &p.fetcher,
+                    storer: &p.storer,
+                    subclass: &p.subclass,
+                    decontainerized: p.decontainerized,
+                }
+            }
+            Kind::ParametricRole => {
+                let p = peek_arc::<ParametricRoleBox>(bits);
+                ValueView::ParametricRole {
+                    base_name: p.base_name,
+                    type_args: &p.type_args,
+                }
+            }
+            Kind::Routine => {
+                let r = peek_arc::<RoutineBox>(bits);
+                ValueView::Routine {
+                    package: r.package,
+                    name: r.name,
+                    is_regex: r.is_regex,
+                }
+            }
+            Kind::LazyIoLines => {
+                let l = peek_arc::<LazyIoLinesBox>(bits);
+                ValueView::LazyIoLines {
+                    handle: &l.handle,
+                    kv: l.kv,
+                    words: l.words,
+                }
+            }
+            Kind::HashEntryRef => {
+                let h = peek_arc::<HashEntryRefBox>(bits);
+                ValueView::HashEntryRef {
+                    hash: &h.hash,
+                    path: &h.path,
+                    eager: h.eager,
+                }
+            }
+            Kind::Sub => ValueView::Sub(gc_guard(bits)),
+            Kind::WeakSub => {
+                ValueView::WeakSub(RefGuard::from_reconstructed(take_weak::<SubData>(bits)))
+            }
+            Kind::LazyList => ValueView::LazyList(gc_guard(bits)),
+            Kind::ContainerRef => ValueView::ContainerRef(gc_guard(bits)),
+            Kind::Promise => ValueView::Promise(RefGuard::from_reconstructed(SharedPromise {
+                inner: take_gc(bits),
+            })),
+            Kind::Channel => ValueView::Channel(RefGuard::from_reconstructed(SharedChannel {
+                inner: take_gc(bits),
+            })),
+            Kind::Instance => {
+                let attrs = peek_gc::<InstanceAttrs>(bits);
+                ValueView::Instance {
+                    class_name: attrs.class_name,
+                    attributes: gc_guard(bits),
+                    id: attrs.id,
+                }
+            }
+            Kind::ArrayList => ValueView::Array(gc_guard(bits), ArrayKind::List),
+            Kind::ArrayArray => ValueView::Array(gc_guard(bits), ArrayKind::Array),
+            Kind::ArrayItemList => ValueView::Array(gc_guard(bits), ArrayKind::ItemList),
+            Kind::ArrayItemArray => ValueView::Array(gc_guard(bits), ArrayKind::ItemArray),
+            Kind::ArrayShaped => ValueView::Array(gc_guard(bits), ArrayKind::Shaped),
+            Kind::ArrayLazy => ValueView::Array(gc_guard(bits), ArrayKind::Lazy),
+            Kind::HashPlain | Kind::HashItemized => ValueView::Hash(gc_guard(bits)),
+            Kind::SetImm => ValueView::Set(gc_guard(bits), false),
+            Kind::SetMut => ValueView::Set(gc_guard(bits), true),
+            Kind::BagImm => ValueView::Bag(gc_guard(bits), false),
+            Kind::BagMut => ValueView::Bag(gc_guard(bits), true),
+            Kind::MixImm => ValueView::Mix(gc_guard(bits), false),
+            Kind::MixMut => ValueView::Mix(gc_guard(bits), true),
+            Kind::Nil => ValueView::Nil,
+            Kind::Whatever => ValueView::Whatever,
+            Kind::HyperWhatever => ValueView::HyperWhatever,
+            Kind::Bool => ValueView::Bool(inline_payload(bits) != 0),
+            Kind::Package => ValueView::Package(Symbol::from_id(inline_payload(bits))),
+            Kind::CompUnitDepSpec => ValueView::CompUnitDepSpec {
+                short_name: Symbol::from_id(inline_payload(bits)),
+            },
+        }
+    }
+}

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -205,7 +205,7 @@ fn container_ref_cell_identity_survives() {
         }
         other => panic!("decoded as {other:?}"),
     }
-    assert!(matches!(&*cell.lock().unwrap(), Value(ValueRepr::Int(9))));
+    assert_eq!(cell.lock().unwrap().as_int(), Some(9));
 }
 
 fn sample_sub() -> Gc<SubData> {
@@ -559,7 +559,7 @@ fn promise_and_channel_roundtrip_sharing_state() {
     match b.into_repr() {
         ValueRepr::Channel(back) => {
             back.send(Value::int(7));
-            assert!(matches!(c.receive_result(), Ok(Value(ValueRepr::Int(7)))));
+            assert_eq!(c.receive_result().ok().and_then(|v| v.as_int()), Some(7));
         }
         other => panic!("decoded as {other:?}"),
     }

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -70,6 +70,15 @@ impl Value {
     /// `Gc` node nested inside them is still reached (otherwise the wrapper is an
     /// invisible edge and a cycle through it is missed — an under-collect).
     pub(crate) fn gc_trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        // Post-flip, the multi-field payloads (Pair, Scalar, Capture, ...)
+        // live behind one shared `Arc<...Box>`: when that box is shared by
+        // N > 1 holders, tracing through every holder would over-count its
+        // inner `Gc` edges (trial-deletion underflow). Treat a shared box as
+        // an external root holder instead — same under-collect tradeoff as
+        // `uniquely_owned` below. Node kinds and inline kinds pass through.
+        if !self.0.value_bearing_arc_payload_uniquely_owned() {
+            return;
+        }
         match self.view() {
             // Migrated `Gc<T>` node variants: yield the node itself. The
             // collector traces the node's own children via its `Trace` impl, so

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -157,11 +157,10 @@ impl Value {
     /// variant, not in the shared `HashData`, so two holders of the same hash
     /// data can differ in itemization (`%x.raku` → `{...}`, `my $h = %x;
     /// $h.raku` → `${...}`).
-    /// Deliberately place-based (B-wall-in exemption): the per-holder
-    /// itemization flag is representation state that `ValueView` hides; at
-    /// flip time this reads the kind tag inside the seam.
+    /// The per-holder itemization flag is representation state that
+    /// `ValueView` hides; this reads the kind tag inside the seam.
     pub fn hash_is_itemized(&self) -> bool {
-        matches!(self.0, ValueRepr::Hash(_, true))
+        self.0.is_hash_itemized()
     }
 
     /// Return this value with its hash itemization flag set to `itemized`,

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -385,16 +385,12 @@ impl Value {
 
     /// Access SubData fields if this is a Sub (or upgraded WeakSub).
     ///
-    /// Deliberately still a place-based match (B-wall-in exemption): it hands
-    /// out a `&SubData` borrowed from `self`, which a `view()` guard cannot do
-    /// (the guard is a by-value temporary scoped to the match). At flip time
-    /// this body is reimplemented inside the seam as a pointee deref.
+    /// Hands out a `&SubData` borrowed from `self`, which a `view()` guard
+    /// cannot do (the guard is a by-value temporary scoped to the match);
+    /// implemented inside the seam as a payload-pointee deref.
     #[allow(dead_code)]
     pub(crate) fn as_sub(&self) -> Option<&SubData> {
-        match self {
-            Value(ValueRepr::Sub(data)) => Some(data),
-            _ => None,
-        }
+        self.0.as_sub_data()
     }
 
     /// Upgrade a WeakSub to a Sub, or return Nil if expired.

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -315,27 +315,16 @@ impl Value {
 
     /// Check if this value is a numeric type (Int, Num, Rat, FatRat, BigInt).
     /// Returns the inner items if this value is an Array, Seq, or Slip.
-    /// Matches the repr directly (inside the value wall) so the returned slice
-    /// borrows from `self`, not from a temporary view guard.
+    /// Decoded inside the seam so the returned slice borrows from `self`'s
+    /// payload, not from a temporary view guard.
     pub(crate) fn as_list_items(&self) -> Option<&[Value]> {
-        match &self.0 {
-            ValueRepr::Array(items, _) => Some(&items.items[..]),
-            ValueRepr::Seq(items) | ValueRepr::Slip(items) => Some(&items[..]),
-            _ => None,
-        }
+        self.0.as_list_slice(false)
     }
 
     /// Like [`Self::as_list_items`], but also accepts the parallel Seq
     /// variants (`HyperSeq` / `RaceSeq`). Used by list-comparison helpers.
     pub(crate) fn as_list_items_with_hyper(&self) -> Option<&[Value]> {
-        match &self.0 {
-            ValueRepr::Array(items, _) => Some(&items.items[..]),
-            ValueRepr::Seq(items)
-            | ValueRepr::HyperSeq(items)
-            | ValueRepr::RaceSeq(items)
-            | ValueRepr::Slip(items) => Some(&items[..]),
-            _ => None,
-        }
+        self.0.as_list_slice(true)
     }
 
     pub(crate) fn is_numeric(&self) -> bool {

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -131,142 +131,16 @@ impl Value {
     /// decode. Always cheap — call it freshly wherever a view is needed.
     #[inline]
     pub fn view(&self) -> ValueView<'_> {
-        match self {
-            Value(ValueRepr::Int(n)) => ValueView::Int(*n),
-            Value(ValueRepr::BigInt(n)) => ValueView::BigInt(ArcRef::borrowed(n)),
-            Value(ValueRepr::Num(f)) => ValueView::Num(*f),
-            Value(ValueRepr::Str(s)) => ValueView::Str(ArcRef::borrowed(s)),
-            Value(ValueRepr::Bool(b)) => ValueView::Bool(*b),
-            Value(ValueRepr::Range(a, b)) => ValueView::Range(*a, *b),
-            Value(ValueRepr::RangeExcl(a, b)) => ValueView::RangeExcl(*a, *b),
-            Value(ValueRepr::RangeExclStart(a, b)) => ValueView::RangeExclStart(*a, *b),
-            Value(ValueRepr::RangeExclBoth(a, b)) => ValueView::RangeExclBoth(*a, *b),
-            Value(ValueRepr::GenericRange {
-                start,
-                end,
-                excl_start,
-                excl_end,
-            }) => ValueView::GenericRange {
-                start,
-                end,
-                excl_start: *excl_start,
-                excl_end: *excl_end,
-            },
-            Value(ValueRepr::Array(items, kind)) => ValueView::Array(GcRef::borrowed(items), *kind),
-            Value(ValueRepr::Hash(h, _)) => ValueView::Hash(GcRef::borrowed(h)),
-            Value(ValueRepr::Rat(n, d)) => ValueView::Rat(*n, *d),
-            Value(ValueRepr::FatRat(n, d)) => ValueView::FatRat(*n, *d),
-            Value(ValueRepr::BigRat(n, d)) => ValueView::BigRat(n, d),
-            Value(ValueRepr::Complex(r, i)) => ValueView::Complex(*r, *i),
-            Value(ValueRepr::Set(s, m)) => ValueView::Set(GcRef::borrowed(s), *m),
-            Value(ValueRepr::Bag(b, m)) => ValueView::Bag(GcRef::borrowed(b), *m),
-            Value(ValueRepr::Mix(x, m)) => ValueView::Mix(GcRef::borrowed(x), *m),
-            Value(ValueRepr::CompUnitDepSpec { short_name }) => ValueView::CompUnitDepSpec {
-                short_name: *short_name,
-            },
-            Value(ValueRepr::Package(sym)) => ValueView::Package(*sym),
-            Value(ValueRepr::Routine {
-                package,
-                name,
-                is_regex,
-            }) => ValueView::Routine {
-                package: *package,
-                name: *name,
-                is_regex: *is_regex,
-            },
-            Value(ValueRepr::Pair(k, v)) => ValueView::Pair(k, v),
-            Value(ValueRepr::ValuePair(k, v)) => ValueView::ValuePair(k, v),
-            Value(ValueRepr::Enum {
-                enum_type,
-                key,
-                value,
-                index,
-            }) => ValueView::Enum {
-                enum_type: *enum_type,
-                key: *key,
-                value,
-                index: *index,
-            },
-            Value(ValueRepr::Regex(r)) => ValueView::Regex(ArcRef::borrowed(r)),
-            Value(ValueRepr::RegexWithAdverbs(adv)) => ValueView::RegexWithAdverbs(adv),
-            Value(ValueRepr::Sub(s)) => ValueView::Sub(GcRef::borrowed(s)),
-            Value(ValueRepr::WeakSub(w)) => ValueView::WeakSub(WeakGcRef::borrowed(w)),
-            Value(ValueRepr::Instance {
-                class_name,
-                attributes,
-                id,
-            }) => ValueView::Instance {
-                class_name: *class_name,
-                attributes: GcRef::borrowed(attributes),
-                id: *id,
-            },
-            Value(ValueRepr::Junction { kind, values }) => ValueView::Junction {
-                kind: *kind,
-                values: ArcRef::borrowed(values),
-            },
-            Value(ValueRepr::Seq(items)) => ValueView::Seq(ArcRef::borrowed(items)),
-            Value(ValueRepr::HyperSeq(items)) => ValueView::HyperSeq(ArcRef::borrowed(items)),
-            Value(ValueRepr::RaceSeq(items)) => ValueView::RaceSeq(ArcRef::borrowed(items)),
-            Value(ValueRepr::Slip(items)) => ValueView::Slip(ArcRef::borrowed(items)),
-            Value(ValueRepr::LazyList(l)) => ValueView::LazyList(GcRef::borrowed(l)),
-            Value(ValueRepr::Version { parts, plus, minus }) => ValueView::Version {
-                parts,
-                plus: *plus,
-                minus: *minus,
-            },
-            Value(ValueRepr::Promise(p)) => ValueView::Promise(RefGuard::borrowed(p)),
-            Value(ValueRepr::Channel(c)) => ValueView::Channel(RefGuard::borrowed(c)),
-            Value(ValueRepr::Nil) => ValueView::Nil,
-            Value(ValueRepr::Whatever) => ValueView::Whatever,
-            Value(ValueRepr::HyperWhatever) => ValueView::HyperWhatever,
-            Value(ValueRepr::Mixin(inner, overrides)) => ValueView::Mixin(inner, overrides),
-            Value(ValueRepr::Capture { positional, named }) => {
-                ValueView::Capture { positional, named }
-            }
-            Value(ValueRepr::Uni(u)) => ValueView::Uni(u),
-            Value(ValueRepr::Proxy {
-                fetcher,
-                storer,
-                subclass,
-                decontainerized,
-            }) => ValueView::Proxy {
-                fetcher,
-                storer,
-                subclass,
-                decontainerized: *decontainerized,
-            },
-            Value(ValueRepr::ParametricRole {
-                base_name,
-                type_args,
-            }) => ValueView::ParametricRole {
-                base_name: *base_name,
-                type_args,
-            },
-            Value(ValueRepr::CustomType(d)) => ValueView::CustomType(d),
-            Value(ValueRepr::CustomTypeInstance(d)) => ValueView::CustomTypeInstance(d),
-            Value(ValueRepr::Scalar(inner)) => ValueView::Scalar(inner),
-            Value(ValueRepr::ContainerRef(cell)) => ValueView::ContainerRef(GcRef::borrowed(cell)),
-            Value(ValueRepr::LazyThunk(t)) => ValueView::LazyThunk(ArcRef::borrowed(t)),
-            Value(ValueRepr::LazyIoLines { handle, kv, words }) => ValueView::LazyIoLines {
-                handle,
-                kv: *kv,
-                words: *words,
-            },
-            Value(ValueRepr::HashEntryRef { hash, path, eager }) => ValueView::HashEntryRef {
-                hash,
-                path,
-                eager: *eager,
-            },
-        }
+        self.0.view()
     }
 
     // ---- representation-independent scalar constructors ----
 
-    /// True boolean constant (post-box: a tag constant).
-    pub const TRUE: Value = Value(ValueRepr::Bool(true));
-    /// False boolean constant (post-box: a tag constant).
-    pub const FALSE: Value = Value(ValueRepr::Bool(false));
-    /// Nil constant (post-box: a tag constant).
+    /// True boolean constant (a tag constant).
+    pub const TRUE: Value = Value(NanBox::TRUE);
+    /// False boolean constant (a tag constant).
+    pub const FALSE: Value = Value(NanBox::FALSE);
+    /// Nil constant (a tag constant).
     pub const NIL: Value = Value::Nil;
 
     /// Construct an integer value.
@@ -331,7 +205,7 @@ impl Value {
     /// Construct a `Routine` stub value.
     #[inline]
     pub(crate) fn routine_parts(package: Symbol, name: Symbol, is_regex: bool) -> Self {
-        Value(ValueRepr::Routine {
+        Value::from_repr(ValueRepr::Routine {
             package,
             name,
             is_regex,
@@ -389,13 +263,13 @@ impl Value {
     /// Construct a `Version` value from its parts.
     #[inline]
     pub(crate) fn version(parts: Vec<VersionPart>, plus: bool, minus: bool) -> Self {
-        Value(ValueRepr::Version { parts, plus, minus })
+        Value::from_repr(ValueRepr::Version { parts, plus, minus })
     }
 
     /// Construct a `CompUnitDepSpec` from its short name.
     #[inline]
     pub(crate) fn comp_unit_dep_spec(short_name: Symbol) -> Self {
-        Value(ValueRepr::CompUnitDepSpec { short_name })
+        Value::from_repr(ValueRepr::CompUnitDepSpec { short_name })
     }
 
     /// Construct a `RegexWithAdverbs` from its adverb payload (boxing it).
@@ -474,14 +348,14 @@ impl Value {
     /// Construct a `Hash` from an existing backing store (non-itemized).
     #[inline]
     pub(crate) fn hash_with_data(h: Gc<HashData>) -> Self {
-        Value(ValueRepr::Hash(h, false))
+        Value::from_repr(ValueRepr::Hash(h, false))
     }
 
     /// Construct a `Hash` from an existing backing store, carrying the given
     /// per-holder itemization flag (mirrors `hash_with_data` + `.item`).
     #[inline]
     pub(crate) fn hash_with_data_itemized(h: Gc<HashData>, itemized: bool) -> Self {
-        Value(ValueRepr::Hash(h, itemized))
+        Value::from_repr(ValueRepr::Hash(h, itemized))
     }
 
     /// Construct a `Set` from an existing backing store and mutability flag.
@@ -510,7 +384,7 @@ impl Value {
         attributes: crate::gc::Gc<InstanceAttrs>,
         id: u64,
     ) -> Self {
-        Value(ValueRepr::Instance {
+        Value::from_repr(ValueRepr::Instance {
             class_name,
             attributes,
             id,
@@ -527,7 +401,7 @@ impl Value {
     /// — connects on read only through the cell a bound-var write installs).
     #[inline]
     pub(crate) fn hash_entry_ref(hash: Gc<HashData>, path: Vec<String>) -> Self {
-        Value(ValueRepr::HashEntryRef {
+        Value::from_repr(ValueRepr::HashEntryRef {
             hash,
             path,
             eager: false,
@@ -539,7 +413,7 @@ impl Value {
     /// `.value` must reflect an in-loop `%h{$p.key} = X`).
     #[inline]
     pub(crate) fn hash_entry_ref_eager(hash: Gc<HashData>, path: Vec<String>) -> Self {
-        Value(ValueRepr::HashEntryRef {
+        Value::from_repr(ValueRepr::HashEntryRef {
             hash,
             path,
             eager: true,
@@ -550,7 +424,7 @@ impl Value {
     /// handle internally, mirroring `Value::pair`/`Value::scalar`).
     #[inline]
     pub(crate) fn lazy_io_lines(handle: Value, kv: bool, words: bool) -> Self {
-        Value(ValueRepr::LazyIoLines {
+        Value::from_repr(ValueRepr::LazyIoLines {
             handle: Box::new(handle),
             kv,
             words,
@@ -579,7 +453,7 @@ impl Value {
         value: EnumValue,
         index: usize,
     ) -> Self {
-        Value(ValueRepr::Enum {
+        Value::from_repr(ValueRepr::Enum {
             enum_type,
             key,
             value,
@@ -595,7 +469,7 @@ impl Value {
         subclass: Option<(Symbol, ProxySubclassAttrs)>,
         decontainerized: bool,
     ) -> Self {
-        Value(ValueRepr::Proxy {
+        Value::from_repr(ValueRepr::Proxy {
             fetcher: Box::new(fetcher),
             storer: Box::new(storer),
             subclass,
@@ -606,7 +480,7 @@ impl Value {
     /// Construct a `ParametricRole` type object.
     #[inline]
     pub(crate) fn parametric_role(base_name: Symbol, type_args: Vec<Value>) -> Self {
-        Value(ValueRepr::ParametricRole {
+        Value::from_repr(ValueRepr::ParametricRole {
             base_name,
             type_args,
         })
@@ -621,71 +495,59 @@ impl Value {
     /// The payload if this is exactly an `Int`. No coercion.
     #[inline]
     pub fn as_int(&self) -> Option<i64> {
-        match self {
-            Value(ValueRepr::Int(n)) => Some(*n),
-            _ => None,
-        }
+        self.0.as_int()
     }
 
     /// The payload if this is exactly a `Num`. No coercion.
     #[inline]
     pub fn as_num(&self) -> Option<f64> {
-        match self {
-            Value(ValueRepr::Num(f)) => Some(*f),
-            _ => None,
-        }
+        self.0.as_num()
     }
 
     /// The payload if this is exactly a `Bool`. No coercion.
     #[inline]
     pub fn as_bool(&self) -> Option<bool> {
-        match self {
-            Value(ValueRepr::Bool(b)) => Some(*b),
-            _ => None,
-        }
+        self.0.as_bool()
     }
 
     /// The string slice if this is exactly a `Str`. No coercion.
     #[inline]
     pub fn as_str(&self) -> Option<&str> {
-        match self {
-            Value(ValueRepr::Str(s)) => Some(s),
-            _ => None,
-        }
+        self.0.as_str()
     }
 
     /// Whether this is `Nil`.
     #[inline]
     pub fn is_nil(&self) -> bool {
-        matches!(self, Value(ValueRepr::Nil))
+        self.0.is_nil()
     }
 
     // ---- consuming extractors (move the payload out) ----
 
     /// The backing store and kind if this is exactly an `Array`, consuming
-    /// `self` without touching the refcount. Post NaN-boxing: unpack + forget.
+    /// `self` without touching the refcount (unpack + forget).
     #[inline]
     pub(crate) fn into_array(self) -> Option<(Gc<ArrayData>, ArrayKind)> {
-        match self {
-            Value(ValueRepr::Array(items, kind)) => Some((items, kind)),
+        match self.into_repr() {
+            ValueRepr::Array(items, kind) => Some((items, kind)),
             _ => None,
         }
     }
 
     /// The proxy parts (fetcher, storer, subclass, decontainerized) if this
-    /// is exactly a `Proxy`, consuming `self`. Post NaN-boxing: unbox + move.
+    /// is exactly a `Proxy`, consuming `self` (unbox + move).
     #[inline]
     #[allow(clippy::type_complexity)]
     pub(crate) fn into_proxy_parts(
         self,
     ) -> Option<(Value, Value, Option<(Symbol, ProxySubclassAttrs)>, bool)> {
-        match self {
-            Value(ValueRepr::Proxy {
+        match self.into_repr() {
+            ValueRepr::Proxy {
                 fetcher,
                 storer,
                 subclass,
                 decontainerized,
-            }) => Some((*fetcher, *storer, subclass, decontainerized)),
+            } => Some((*fetcher, *storer, subclass, decontainerized)),
             _ => None,
         }
     }
@@ -705,10 +567,13 @@ impl Value {
         &mut self,
         f: impl FnOnce(&mut Gc<ArrayData>, &mut ArrayKind) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::Array(items, kind)) => Some(f(items, kind)),
-            _ => None,
+        if !matches!(self.view(), ValueView::Array(..)) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::Array(items, kind) => f(items, kind),
+            _ => unreachable!("with_array_mut probed an Array"),
+        }))
     }
 
     /// Container-identity in-place mutation (§3): run `f` on the SHARED
@@ -724,13 +589,13 @@ impl Value {
         &self,
         f: impl FnOnce(&mut ArrayData, ArrayKind) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::Array(gc, kind)) => {
+        match self.view() {
+            ValueView::Array(gc, kind) => {
                 // SAFETY: audited aliased in-place container write (see
                 // value::aliased_mut) — callers ensure no other borrow into
                 // this node is live across `f` and no cross-thread access.
-                let data = unsafe { crate::value::gc_contents_mut(gc) };
-                Some(f(data, *kind))
+                let data = unsafe { crate::value::gc_contents_mut(&gc) };
+                Some(f(data, kind))
             }
             _ => None,
         }
@@ -745,25 +610,31 @@ impl Value {
     /// node, so every place with copy semantics (`my @b = @a`, `is copy`
     /// params) must detach at copy time.
     pub(crate) fn detach_shared_container(self) -> Value {
-        match &self {
-            Value(ValueRepr::Array(gc, kind)) if gc.strong_count() > 1 => {
-                Value::array_with_kind(crate::gc::Gc::new((**gc).clone()), *kind)
-            }
-            Value(ValueRepr::Hash(gc, itemized)) if gc.strong_count() > 1 => Value(
-                ValueRepr::Hash(crate::gc::Gc::new((**gc).clone()), *itemized),
-            ),
-            _ => self,
-        }
+        let fresh = match self.view() {
+            ValueView::Array(gc, kind) if gc.strong_count() > 1 => Some(Value::array_with_kind(
+                crate::gc::Gc::new((**gc).clone()),
+                kind,
+            )),
+            ValueView::Hash(gc) if gc.strong_count() > 1 => Some(Value::hash_with_data_itemized(
+                crate::gc::Gc::new((**gc).clone()),
+                self.0.is_hash_itemized(),
+            )),
+            _ => None,
+        };
+        fresh.unwrap_or(self)
     }
 
     /// Run `f` on the hash payload if this is exactly a `Hash`.
     /// Returns `None` (without calling `f`) otherwise.
     #[inline]
     pub(crate) fn with_hash_mut<R>(&mut self, f: impl FnOnce(&mut Gc<HashData>) -> R) -> Option<R> {
-        match self {
-            Value(ValueRepr::Hash(h, _)) => Some(f(h)),
-            _ => None,
+        if !matches!(self.view(), ValueView::Hash(..)) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::Hash(h, _) => f(h),
+            _ => unreachable!("with_hash_mut probed a Hash"),
+        }))
     }
 
     /// Run `f` on the set payload (store + mutability flag) if this is
@@ -773,10 +644,13 @@ impl Value {
         &mut self,
         f: impl FnOnce(&mut Gc<SetData>, &mut bool) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::Set(s, is_mut)) => Some(f(s, is_mut)),
-            _ => None,
+        if !matches!(self.view(), ValueView::Set(..)) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::Set(s, is_mut) => f(s, is_mut),
+            _ => unreachable!("with_set_mut probed a Set"),
+        }))
     }
 
     /// Run `f` on the bag payload (store + mutability flag) if this is
@@ -786,10 +660,13 @@ impl Value {
         &mut self,
         f: impl FnOnce(&mut Gc<BagData>, &mut bool) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::Bag(b, is_mut)) => Some(f(b, is_mut)),
-            _ => None,
+        if !matches!(self.view(), ValueView::Bag(..)) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::Bag(b, is_mut) => f(b, is_mut),
+            _ => unreachable!("with_bag_mut probed a Bag"),
+        }))
     }
 
     /// Run `f` on the mix payload (store + mutability flag) if this is
@@ -799,10 +676,13 @@ impl Value {
         &mut self,
         f: impl FnOnce(&mut Gc<MixData>, &mut bool) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::Mix(m, is_mut)) => Some(f(m, is_mut)),
-            _ => None,
+        if !matches!(self.view(), ValueView::Mix(..)) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::Mix(m, is_mut) => f(m, is_mut),
+            _ => unreachable!("with_mix_mut probed a Mix"),
+        }))
     }
 
     /// Run `f` on the sub payload if this is exactly a `Sub`.
@@ -812,10 +692,13 @@ impl Value {
         &mut self,
         f: impl FnOnce(&mut crate::gc::Gc<SubData>) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::Sub(data)) => Some(f(data)),
-            _ => None,
+        if !matches!(self.view(), ValueView::Sub(..)) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::Sub(data) => f(data),
+            _ => unreachable!("with_sub_mut probed a Sub"),
+        }))
     }
 
     /// Run `f` on the hash-entry-ref payload (target hash + key path) if this
@@ -826,10 +709,13 @@ impl Value {
         &mut self,
         f: impl FnOnce(&mut Gc<HashData>, &mut Vec<String>) -> R,
     ) -> Option<R> {
-        match self {
-            Value(ValueRepr::HashEntryRef { hash, path, .. }) => Some(f(hash, path)),
-            _ => None,
+        if !matches!(self.view(), ValueView::HashEntryRef { .. }) {
+            return None;
         }
+        Some(self.with_repr_mut(|r| match r {
+            ValueRepr::HashEntryRef { hash, path, .. } => f(hash, path),
+            _ => unreachable!("with_hash_entry_ref_mut probed a HashEntryRef"),
+        }))
     }
 }
 

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -77,7 +77,7 @@ fn native_to_json(args: &[Value]) -> Result<Value, RuntimeError> {
             _ => {}
         }
     }
-    let subject = subject.unwrap_or(&Value::NIL);
+    let subject = subject.unwrap_or(&crate::value::NIL_VALUE);
     Ok(Value::str(json::to_json(subject, &opts)))
 }
 


### PR DESCRIPTION
## Summary

Layer 3b (NaN-boxing) final slice **B-flip** per [docs/nanbox-3b1-step-b-design.md](docs/nanbox-3b1-step-b-design.md) §4-4 / [ADR-0005](docs/adr/0005-nanbox-representation-encoding.md): `Value(ValueRepr)` → `Value(NanBox)`. **`size_of::<Value>()` drops 48 → 8 bytes** (`value_size_guard` updated; `Option<Value>` stays 8 via the NonZeroU64 niche). Every clone/move/drop of a `Value` now handles one word instead of a 48-byte enum.

- **`nanbox/peek.rs` (new)**: the borrowed decode. `view()` classifies the word and hands out guard-type smart pointers (`ManuallyDrop` reconstructions from the payload address) for direct-pointer kinds, and payload-pointee `&'a` references for multi-field `Arc<...Box>` kinds. Word-level probes back the wall accessors (`as_int` — inline + boxed, `as_str`, `as_sub_data`, `as_list_slice`, `is_hash_itemized`, …).
- **Seams (`mod.rs`)**: `into_repr` = tag decode (pointer payloads move, no refcount traffic), `from_repr` = tag pack, `with_repr_mut` = decode-edit-repack. `same_variant` compares collapsed variant tags (six Array kinds / itemized Hash / mutable Set-Bag-Mix / four Junction kinds / boxed Int fold onto their `ValueRepr` discriminant). `Value::NIL`/`TRUE`/`FALSE` are const inline words.
- **Wall accessors (`view.rs`)**: `with_*_mut` probe the view then decode-edit-repack; `with_array_inplace` / `detach_shared_container` ride `view()` guards; `into_array` / `into_proxy_parts` ride `into_repr`.
- **GC soundness fix caught by gc-stress**: multi-field payloads that were `Box`-owned pre-flip now share one `Arc<...Box>`, so tracing a shared box from every holder over-counted its inner `Gc` edges (trial-deletion strong-count underflow). `gc_trace` now gates on `value_bearing_arc_payload_uniquely_owned()` — a shared wrapper is treated as an external root holder, the same under-collect tradeoff as the existing `uniquely_owned` gates for Seq/Mixin/LazyThunk.
- `&Value::NIL` stopped const-promoting (`Value` now has `Drop`): the two sites keeping such a borrow across an expression use a `'static NIL_VALUE`.

## Gates (ADR-0005 §3.2)

- `make test` PASS (1677 files / 16507 tests); `cargo test` + gc-stress (16) green; clippy `-D warnings` + fmt clean.
- **GC counters invariant vs main**: `candidate_pushes`/`roots_scanned` byte-identical on fib (13/13) and a class+array+hash workload (4031/2028); scalar hot paths stay GC-free by construction (scalar pages carry no `Gc` payload).
- Roast spot checks (junction autothreading, hash, pair, capture, mixin-6e, proxy, binding/scalars, split, operators/misc): all PASS. Full roast delegated to CI.
- Release micro-benchmarks (int-arith / fib / bench-class clone-drop share) will be posted as a PR comment once the release build finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni