### PR TITLE
feat(vm): Cranelift JIT skeleton — hot Tier A chunks run native (ADR-0004 J1)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: dtolnay/rust-toolchain@1.93.0
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: dtolnay/rust-toolchain@1.93.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -25,7 +25,7 @@ jobs:
 
       # tagpr bumps the version in Cargo.toml; keep Cargo.lock's `mutsu` entry in
       # sync so the release PR (and merged main) carries a coherent lockfile.
-      - uses: dtolnay/rust-toolchain@b5826f8eb73f40ac7c19ef631dce17a9680f8129 # 1.92.0
+      - uses: dtolnay/rust-toolchain@45f5412a0cc5dee553bb061a37369fc8e63fa137 # 1.93.0
 
       - uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +61,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -52,6 +76,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "cc"
@@ -97,6 +124,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+dependencies = [
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+dependencies = [
+ "cranelift-bitset",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7def01f2b14f97421558d1db33e396b97b97ab2ed40dedc8165ba00d13088e6"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "memmap2",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985df7eceefc91cb75bf7f51b32b7f1739d0fc0e25ddf023b1de407cb3c93d77"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +325,12 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -176,6 +377,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +410,39 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
@@ -341,6 +587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libffi"
@@ -392,6 +648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,10 +672,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mutsu"
@@ -421,6 +701,11 @@ version = "0.2.34"
 dependencies = [
  "bincode",
  "console_error_panic_hook",
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
  "emojis",
  "encoding_rs",
  "fancy-regex",
@@ -459,7 +744,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -669,6 +954,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +997,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,7 +1020,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -728,7 +1039,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -832,6 +1143,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tinystr"
@@ -985,10 +1302,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-core"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,27 @@
 name = "mutsu"
 version = "0.2.34"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.93.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["native"]
+default = ["native", "jit"]
 native = ["rustyline", "libc", "pcre2", "libloading", "libffi"]
 wasm = ["wasm-bindgen", "console_error_panic_hook"]
 # NativeCall (C FFI) support — gated under `native`; wasm builds cannot do FFI.
 libloading = ["dep:libloading"]
 libffi = ["dep:libffi"]
+# Cranelift method JIT (ADR-0004, layer 4). Compiled in by default but inert
+# unless MUTSU_JIT=on at runtime. Disable for targets Cranelift can't build on.
+jit = [
+    "dep:cranelift-codegen",
+    "dep:cranelift-frontend",
+    "dep:cranelift-jit",
+    "dep:cranelift-module",
+    "dep:cranelift-native",
+]
 
 [dependencies]
 regex = "1.12.3"
@@ -39,6 +48,11 @@ icu_collator = "2.1"
 icu_collator_data = "2.1"
 libloading = { version = "0.8", optional = true }
 libffi = { version = "3", optional = true }
+cranelift-codegen = { version = "0.132", optional = true }
+cranelift-frontend = { version = "0.132", optional = true }
+cranelift-jit = { version = "0.132", optional = true }
+cranelift-module = { version = "0.132", optional = true }
+cranelift-native = { version = "0.132", optional = true }
 
 [profile.release]
 debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,42 @@ pub fn dump_ast(input: &str) -> Result<String, RuntimeError> {
     Ok(format!("{:#?}", stmts))
 }
 
+/// Parse and compile source code, returning a disassembly of the compiled
+/// bytecode: the mainline followed by each compiled function. Used for
+/// compiler/JIT debugging (`--dump-bytecode`).
+pub fn dump_bytecode(input: &str) -> Result<String, RuntimeError> {
+    use std::fmt::Write;
+    let (stmts, _) = parse_dispatch::parse_source(input)?;
+    let mut compiler = compiler::Compiler::new();
+    compiler.is_mainline = true;
+    let (code, compiled_fns) = compiler.compile(&stmts);
+    let mut out = String::new();
+    let disasm = |out: &mut String, code: &opcode::CompiledCode| {
+        for (i, op) in code.ops.iter().enumerate() {
+            let _ = writeln!(out, "  {:4}: {:?}", i, op);
+        }
+        if !code.constants.is_empty() {
+            let _ = writeln!(out, "  constants:");
+            for (i, c) in code.constants.iter().enumerate() {
+                let _ = writeln!(out, "    {:4}: {:?}", i, c);
+            }
+        }
+        if !code.locals.is_empty() {
+            let _ = writeln!(out, "  locals: {:?}", code.locals);
+        }
+    };
+    let _ = writeln!(out, "== mainline ==");
+    disasm(&mut out, &code);
+    let mut names: Vec<&String> = compiled_fns.keys().collect();
+    names.sort();
+    for name in names {
+        let cf = &compiled_fns[name];
+        let _ = writeln!(out, "== sub {} ==", name);
+        disasm(&mut out, &cf.code);
+    }
+    Ok(out)
+}
+
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn print_help(program: &str) {
     println!("  -I PATH        Add PATH to the module search path");
     println!("  -M MODULE      use MODULE before executing program (repeatable)");
     println!("  --dump-ast     Dump the AST instead of executing");
+    println!("  --dump-bytecode  Dump compiled bytecode instead of executing");
     println!("  --doc          Render Pod documentation from the source");
     println!("  --repl         Start the interactive REPL");
     println!("  --no-precomp   Disable module precompilation cache");
@@ -255,6 +256,7 @@ fn run_main() {
     let args: Vec<String> = env::args().collect();
 
     let mut dump_ast = false;
+    let mut dump_bytecode = false;
     let mut doc_mode = false;
     let mut repl_flag = false;
     let mut no_precomp = false;
@@ -298,6 +300,8 @@ fn run_main() {
             return;
         } else if arg == "--dump-ast" {
             dump_ast = true;
+        } else if arg == "--dump-bytecode" {
+            dump_bytecode = true;
         } else if arg == "--doc" {
             doc_mode = true;
         } else if arg == "--repl" {
@@ -448,6 +452,17 @@ fn run_main() {
     if dump_ast {
         match mutsu::dump_ast(&input) {
             Ok(ast) => println!("{}", ast),
+            Err(err) => {
+                print_error("Parse error", &err, Some(&input), Some(&program_name));
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    if dump_bytecode {
+        match mutsu::dump_bytecode(&input) {
+            Ok(listing) => println!("{}", listing),
             Err(err) => {
                 print_error("Parse error", &err, Some(&input), Some(&program_name));
                 std::process::exit(1);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1747,6 +1747,26 @@ pub(crate) struct CompiledCode {
     /// first use; each slot interns on first access. Cloning a chunk clones the
     /// already-resolved entries (cheap: `Symbol` is a `u32`).
     pub(crate) const_syms: std::sync::OnceLock<Box<[std::sync::OnceLock<Symbol>]>>,
+    /// Per-chunk JIT hotness counter and compiled-entry cache (ADR-0004 J1).
+    pub(crate) jit: JitCodeState,
+}
+
+/// JIT hotness/entry state carried on each `CompiledCode` (ADR-0004 layer 4).
+/// `entry` caches the compiled native entry so the per-call cost once compiled
+/// is a single atomic load: 0 = cold (counting), `JIT_ENTRY_BAILOUT` = chunk
+/// contains an unsupported opcode (never retry), any other value = the native
+/// function pointer. Cloning a chunk resets the state — a clone is a distinct
+/// compilation identity (the global fingerprint cache still avoids recompiles).
+#[derive(Debug, Default)]
+pub(crate) struct JitCodeState {
+    pub(crate) calls: std::sync::atomic::AtomicU32,
+    pub(crate) entry: std::sync::atomic::AtomicU64,
+}
+
+impl Clone for JitCodeState {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
 }
 
 impl CompiledCode {
@@ -1791,6 +1811,7 @@ impl CompiledCode {
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
             const_syms: std::sync::OnceLock::new(),
+            jit: JitCodeState::default(),
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1641,6 +1641,11 @@ pub struct Interpreter {
     /// package-qualified writes elsewhere are unaffected.
     pub(crate) in_regex_code_block: bool,
     pub(crate) resume_ip: Option<usize>,
+    /// Error slot for JIT-compiled bodies (ADR-0004 J1): an `extern "C"` opcode
+    /// helper cannot return a `RuntimeError` by value across the native-code
+    /// boundary, so it parks the error here and returns a nonzero status; the
+    /// JIT entry wrapper takes it back out. Always `None` outside a JIT call.
+    pub(crate) jit_error: Option<RuntimeError>,
     pub(crate) bind_context: bool,
     pub(crate) scalar_bind_context: bool,
     pub(crate) bound_decont_active: bool,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2182,6 +2182,7 @@ impl Interpreter {
             method_dispatch_pure: false,
             in_regex_code_block: false,
             resume_ip: None,
+            jit_error: None,
             bind_context: false,
             scalar_bind_context: false,
             bound_decont_active: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -343,6 +343,7 @@ impl Interpreter {
             method_dispatch_pure: false,
             in_regex_code_block: false,
             resume_ip: None,
+            jit_error: None,
             bind_context: false,
             scalar_bind_context: false,
             bound_decont_active: false,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -173,6 +173,11 @@ pub(crate) mod vm_hyper_func;
 mod vm_hyper_method_ops;
 pub(crate) mod vm_hyper_ops;
 mod vm_hyper_race_parallel;
+pub(crate) mod vm_jit;
+#[cfg(feature = "jit")]
+mod vm_jit_compile;
+#[cfg(feature = "jit")]
+mod vm_jit_helpers;
 mod vm_loop_cstyle_repeat;
 mod vm_loop_writeback;
 mod vm_loop_writeback_quant;

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -142,7 +142,20 @@ impl Interpreter {
         let mut explicit_return: Option<Value> = None;
         let mut fail_bypass = false;
         while ip < cf.code.ops.len() {
-            match self.exec_one(&cf.code, &mut ip, compiled_fns) {
+            // JIT entry (ADR-0004 J1): at body start, run the whole body
+            // natively when the chunk is hot and Tier A-compilable. The
+            // native outcome has the same shape as one `exec_one` step
+            // (explicit return / fail / error travel as `Err`), so it
+            // threads through the same match arms below.
+            let step = if ip == 0
+                && let Some(r) = crate::vm::vm_jit::try_enter(self, &cf.code, compiled_fns)
+            {
+                ip = cf.code.ops.len();
+                r
+            } else {
+                self.exec_one(&cf.code, &mut ip, compiled_fns)
+            };
+            match step {
                 Ok(()) => {}
                 Err(e) if e.return_value.is_some() => {
                     let ret_val = e.return_value.unwrap();

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl Interpreter {
-    fn mark_failure_handled_on_stack(stack: &mut [Value]) {
+    pub(super) fn mark_failure_handled_on_stack(stack: &mut [Value]) {
         if let Some(ValueView::Instance {
             class_name,
             id,

--- a/src/vm/vm_jit.rs
+++ b/src/vm/vm_jit.rs
@@ -1,0 +1,127 @@
+//! JIT entry point and hotness tracking (ADR-0004 layer 4, phase J1).
+//!
+//! Method JIT on Cranelift: a `CompiledCode` chunk whose opcodes all belong to
+//! the supported Tier A set is translated, once hot, into a native function
+//! that calls the interpreter's opcode helpers in sequence (subroutine
+//! threading) with branches lowered to native control flow. A chunk containing
+//! any unsupported opcode is marked bailout and stays on the interpreter
+//! forever — no guards, no deopt, no OSR (ADR-0004 §2.3).
+//!
+//! Off by default: compiled in under the `jit` cargo feature, activated at
+//! runtime with `MUTSU_JIT=on` (threshold tunable via `MUTSU_JIT_THRESHOLD`).
+
+use super::*;
+
+/// Status codes returned by JIT-compiled bodies and fallible opcode helpers.
+/// `ERR` means the `RuntimeError` (including the `&return` signal and `fail`)
+/// is parked in `Interpreter::jit_error`; `HALT` means `exit`-style halt with
+/// no error (the caller loop re-checks `is_halted()`).
+pub(crate) const JIT_STATUS_OK: u32 = 0;
+pub(crate) const JIT_STATUS_ERR: u32 = 1;
+pub(crate) const JIT_STATUS_HALT: u32 = 2;
+
+/// `CompiledCode::jit.entry` sentinel: the chunk was scanned and rejected
+/// (contains an unsupported opcode); never retry. `0` means cold/counting;
+/// any other value is the native entry pointer.
+pub(crate) const JIT_ENTRY_BAILOUT: u64 = 1;
+
+/// Native entry signature: `(interp, code, compiled_fns) -> status`.
+#[cfg(feature = "jit")]
+pub(crate) type JitEntryFn = unsafe extern "C" fn(
+    *mut Interpreter,
+    *const CompiledCode,
+    *const HashMap<String, CompiledFunction>,
+) -> u32;
+
+/// True when the JIT is switched on for this process (`MUTSU_JIT=on|1`).
+#[cfg(feature = "jit")]
+#[inline]
+pub(crate) fn jit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MUTSU_JIT")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("on"))
+            .unwrap_or(false)
+    })
+}
+
+/// Call-count threshold before a chunk is considered hot and compiled.
+#[cfg(feature = "jit")]
+fn jit_threshold() -> u32 {
+    static THRESHOLD: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        std::env::var("MUTSU_JIT_THRESHOLD")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100)
+    })
+}
+
+/// Try to run a function body natively. Returns `None` when the body must run
+/// on the interpreter (JIT off / still cold / bailout chunk); `Some(result)`
+/// when the whole body ran natively — the result has the same shape as the
+/// interpreter's body loop outcome (`Err` carries explicit return / fail /
+/// error exactly like `exec_one`), so the caller threads it through the same
+/// match arms.
+#[cfg(feature = "jit")]
+pub(crate) fn try_enter(
+    interp: &mut Interpreter,
+    code: &CompiledCode,
+    compiled_fns: &HashMap<String, CompiledFunction>,
+) -> Option<Result<(), RuntimeError>> {
+    use std::sync::atomic::Ordering;
+    if !jit_enabled() {
+        return None;
+    }
+    let entry = code.jit.entry.load(Ordering::Acquire);
+    let f: JitEntryFn = if entry == 0 {
+        let calls = code.jit.calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if calls < jit_threshold() {
+            return None;
+        }
+        match super::vm_jit_compile::compile_chunk(code) {
+            Some(f) => {
+                code.jit.entry.store(f as usize as u64, Ordering::Release);
+                crate::vm::vm_stats::record_jit_compile();
+                f
+            }
+            None => {
+                code.jit.entry.store(JIT_ENTRY_BAILOUT, Ordering::Release);
+                return None;
+            }
+        }
+    } else if entry == JIT_ENTRY_BAILOUT {
+        return None;
+    } else {
+        // The entry word only ever transitions 0 -> fn-pointer (never back),
+        // and the pointee is a finalized function in the leaked JIT module,
+        // so reconstructing the pointer from the atomic is sound.
+        unsafe { std::mem::transmute::<usize, JitEntryFn>(entry as usize) }
+    };
+    crate::vm::vm_stats::record_jit_entry();
+    interp.current_code = code as *const CompiledCode as usize;
+    let status = unsafe { f(interp, code, compiled_fns) };
+    match status {
+        JIT_STATUS_ERR => {
+            let e = interp
+                .jit_error
+                .take()
+                .expect("JIT returned error status without a parked error");
+            Some(Err(e))
+        }
+        // OK (fell off the end; result on the stack) or HALT (the caller
+        // loop re-checks `is_halted()` right after this step).
+        _ => Some(Ok(())),
+    }
+}
+
+/// JIT-less builds: never enters native code.
+#[cfg(not(feature = "jit"))]
+#[inline(always)]
+pub(crate) fn try_enter(
+    _interp: &mut Interpreter,
+    _code: &CompiledCode,
+    _compiled_fns: &HashMap<String, CompiledFunction>,
+) -> Option<Result<(), RuntimeError>> {
+    None
+}

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -1,0 +1,355 @@
+//! Tier A bytecode-to-native translation on Cranelift (ADR-0004 §2.3, J1).
+//!
+//! A supported chunk is lowered opcode-by-opcode into a sequence of calls to
+//! the `vm_jit_helpers` shims (subroutine threading); `Jump`/`JumpIfFalse`
+//! become native branches between basic blocks, with a GC safepoint poll on
+//! every backedge (ADR-0004 §2.4). No guards, no deopt: a chunk containing
+//! any opcode outside the Tier A set is rejected up front and permanently
+//! left to the interpreter.
+
+use super::vm_jit::JitEntryFn;
+use super::vm_jit_helpers as helpers;
+use super::*;
+
+use cranelift_codegen::ir::{AbiParam, Block, InstBuilder, SigRef, Type, types};
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{Linkage, Module};
+use std::sync::Mutex;
+
+/// The one process-wide JIT module. Compiled code lives for the process
+/// lifetime (entries are cached in `CompiledCode::jit.entry` as raw function
+/// pointers), so the module is created once and never dropped.
+struct Engine {
+    module: JITModule,
+    fn_counter: u64,
+}
+
+// SAFETY: `JITModule` is only manipulated under the `ENGINE` mutex; the
+// finalized code memory it owns is immutable after `finalize_definitions`
+// and is executed (not mutated) from any thread, which is sound regardless
+// of which thread performed the compilation.
+unsafe impl Send for Engine {}
+
+static ENGINE: Mutex<Option<Engine>> = Mutex::new(None);
+
+/// Compile `code` to a native Tier A body. `None` = bailout (unsupported
+/// opcode, or an internal Cranelift failure): the caller marks the chunk so
+/// it is never scanned again.
+pub(super) fn compile_chunk(code: &CompiledCode) -> Option<JitEntryFn> {
+    // Static support scan + jump-target collection. Any opcode outside the
+    // Tier A set rejects the whole chunk (no partial compilation).
+    let mut targets: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for op in code.ops.iter() {
+        match op {
+            OpCode::LoadConst(_)
+            | OpCode::GetLocal(_)
+            | OpCode::SetLocal(_)
+            | OpCode::Add
+            | OpCode::Sub
+            | OpCode::NumLt
+            | OpCode::ContainerizePair
+            | OpCode::SetSourceLine(_)
+            | OpCode::Return
+            | OpCode::CallFunc { .. } => {}
+            OpCode::Jump(t) => {
+                targets.insert(*t as usize);
+            }
+            OpCode::JumpIfFalse(t) => {
+                targets.insert(*t as usize);
+            }
+            other => {
+                crate::vm::vm_stats::record_jit_bailout(other);
+                return None;
+            }
+        }
+    }
+    build(code, &targets)
+}
+
+/// Helper-call signatures used by the emitted code, imported once per
+/// function. All shims take the interpreter pointer first; fallible ones
+/// return an `i32` status (see `vm_jit::JIT_STATUS_*`).
+struct Sigs {
+    /// `(interp) -> ()`
+    v1: SigRef,
+    /// `(interp) -> i32`
+    s1: SigRef,
+    /// `(interp, i64) -> ()`
+    v_i64: SigRef,
+    /// `(interp, code, u32) -> ()`
+    v_code_u32: SigRef,
+    /// `(interp, code, u32) -> i32`
+    s_code_u32: SigRef,
+    /// `(interp, code, u32, fns) -> i32`
+    s_call: SigRef,
+}
+
+fn make_sigs(module: &JITModule, b: &mut FunctionBuilder, ptr: Type) -> Sigs {
+    let mut sig = |params: &[Type], ret: Option<Type>| {
+        let mut s = module.make_signature();
+        for p in params {
+            s.params.push(AbiParam::new(*p));
+        }
+        if let Some(r) = ret {
+            s.returns.push(AbiParam::new(r));
+        }
+        b.import_signature(s)
+    };
+    Sigs {
+        v1: sig(&[ptr], None),
+        s1: sig(&[ptr], Some(types::I32)),
+        v_i64: sig(&[ptr, types::I64], None),
+        v_code_u32: sig(&[ptr, ptr, types::I32], None),
+        s_code_u32: sig(&[ptr, ptr, types::I32], Some(types::I32)),
+        s_call: sig(&[ptr, ptr, types::I32, ptr], Some(types::I32)),
+    }
+}
+
+fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Option<JitEntryFn> {
+    let mut guard = ENGINE.lock().unwrap();
+    let engine = match guard.as_mut() {
+        Some(e) => e,
+        None => {
+            let mut flags = settings::builder();
+            flags.set("opt_level", "speed").ok()?;
+            let isa = cranelift_native::builder()
+                .ok()?
+                .finish(settings::Flags::new(flags))
+                .ok()?;
+            let builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+            guard.insert(Engine {
+                module: JITModule::new(builder),
+                fn_counter: 0,
+            })
+        }
+    };
+    let module = &mut engine.module;
+
+    let ptr = module.target_config().pointer_type();
+    let mut ctx = module.make_context();
+    ctx.func.signature.params.push(AbiParam::new(ptr)); // interp
+    ctx.func.signature.params.push(AbiParam::new(ptr)); // code
+    ctx.func.signature.params.push(AbiParam::new(ptr)); // compiled_fns
+    ctx.func.signature.returns.push(AbiParam::new(types::I32));
+
+    let mut fb_ctx = FunctionBuilderContext::new();
+    let mut b = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
+    let sigs = make_sigs(module, &mut b, ptr);
+
+    let entry = b.create_block();
+    b.append_block_params_for_function_params(entry);
+    b.switch_to_block(entry);
+    let interp = b.block_params(entry)[0];
+    let codep = b.block_params(entry)[1];
+    let fnsp = b.block_params(entry)[2];
+
+    let block_at: std::collections::HashMap<usize, Block> =
+        targets.iter().map(|t| (*t, b.create_block())).collect();
+
+    // Emits `call helper(args)`, with the callee address as an inline
+    // constant (no symbol table needed for a process-local JIT).
+    let call_helper = |b: &mut FunctionBuilder,
+                       sig: SigRef,
+                       f: usize,
+                       args: &[cranelift_codegen::ir::Value]|
+     -> Option<cranelift_codegen::ir::Value> {
+        let callee = b.ins().iconst(ptr, f as i64);
+        let call = b.ins().call_indirect(sig, callee, args);
+        b.inst_results(call).first().copied()
+    };
+    // status != 0 -> return status; else continue in a fresh block.
+    let check_status = |b: &mut FunctionBuilder, status: cranelift_codegen::ir::Value| {
+        let err = b.create_block();
+        let cont = b.create_block();
+        b.ins().brif(status, err, &[], cont, &[]);
+        b.switch_to_block(err);
+        b.ins().return_(&[status]);
+        b.switch_to_block(cont);
+    };
+
+    // `open` = the current block still needs a terminator.
+    let mut open = true;
+    for (i, op) in code.ops.iter().enumerate() {
+        if let Some(&blk) = block_at.get(&i) {
+            if open {
+                b.ins().jump(blk, &[]);
+            }
+            b.switch_to_block(blk);
+            open = true;
+        }
+        if !open {
+            // Straight-line code right after a terminator with no incoming
+            // jump: unreachable, skip.
+            continue;
+        }
+        match op {
+            OpCode::LoadConst(idx) => {
+                let idxv = b.ins().iconst(types::I32, *idx as i64);
+                call_helper(
+                    &mut b,
+                    sigs.v_code_u32,
+                    helpers::load_const as *const () as usize,
+                    &[interp, codep, idxv],
+                );
+            }
+            OpCode::SetSourceLine(line) => {
+                let linev = b.ins().iconst(types::I64, *line);
+                call_helper(
+                    &mut b,
+                    sigs.v_i64,
+                    helpers::set_source_line as *const () as usize,
+                    &[interp, linev],
+                );
+            }
+            OpCode::ContainerizePair => {
+                call_helper(
+                    &mut b,
+                    sigs.v1,
+                    helpers::containerize_pair as *const () as usize,
+                    &[interp],
+                );
+            }
+            OpCode::GetLocal(idx) => {
+                let idxv = b.ins().iconst(types::I32, *idx as i64);
+                let status = call_helper(
+                    &mut b,
+                    sigs.s_code_u32,
+                    helpers::get_local as *const () as usize,
+                    &[interp, codep, idxv],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::SetLocal(idx) => {
+                let idxv = b.ins().iconst(types::I32, *idx as i64);
+                let status = call_helper(
+                    &mut b,
+                    sigs.s_code_u32,
+                    helpers::set_local as *const () as usize,
+                    &[interp, codep, idxv],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::Add => {
+                let status = call_helper(
+                    &mut b,
+                    sigs.s1,
+                    helpers::add as *const () as usize,
+                    &[interp],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::Sub => {
+                let status = call_helper(
+                    &mut b,
+                    sigs.s1,
+                    helpers::sub as *const () as usize,
+                    &[interp],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::NumLt => {
+                let status = call_helper(
+                    &mut b,
+                    sigs.s1,
+                    helpers::num_lt as *const () as usize,
+                    &[interp],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::Return => {
+                // OK status = a rebound `&return` ran; fall through to the
+                // next opcode. Otherwise the return signal is parked and the
+                // nonzero status exits the native body.
+                let status = call_helper(
+                    &mut b,
+                    sigs.s1,
+                    helpers::ret as *const () as usize,
+                    &[interp],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::CallFunc { .. } => {
+                let opidx = b.ins().iconst(types::I32, i as i64);
+                let status = call_helper(
+                    &mut b,
+                    sigs.s_call,
+                    helpers::call_func as *const () as usize,
+                    &[interp, codep, opidx, fnsp],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::Jump(t) => {
+                let t = *t as usize;
+                if t <= i {
+                    // Backedge: poll the GC safepoint so a native loop keeps
+                    // participating in cooperative STW (ADR-0004 §2.4).
+                    call_helper(
+                        &mut b,
+                        sigs.v1,
+                        helpers::safepoint as *const () as usize,
+                        &[interp],
+                    );
+                }
+                b.ins().jump(block_at[&t], &[]);
+                open = false;
+            }
+            OpCode::JumpIfFalse(t) => {
+                let t = *t as usize;
+                let cond = call_helper(
+                    &mut b,
+                    sigs.s1,
+                    helpers::jump_if_false_cond as *const () as usize,
+                    &[interp],
+                )?;
+                let next = b.create_block();
+                if t <= i {
+                    let poll = b.create_block();
+                    b.ins().brif(cond, poll, &[], next, &[]);
+                    b.switch_to_block(poll);
+                    call_helper(
+                        &mut b,
+                        sigs.v1,
+                        helpers::safepoint as *const () as usize,
+                        &[interp],
+                    );
+                    b.ins().jump(block_at[&t], &[]);
+                } else {
+                    b.ins().brif(cond, block_at[&t], &[], next, &[]);
+                }
+                b.switch_to_block(next);
+            }
+            // The support scan rejected everything else.
+            _ => unreachable!("unsupported opcode reached JIT emission"),
+        }
+    }
+    // Fall off the end of the chunk: OK status (result is on the stack).
+    if open {
+        let zero = b.ins().iconst(types::I32, 0);
+        b.ins().return_(&[zero]);
+    }
+    // A jump target one past the last opcode is a normal fall-through exit.
+    if let Some(&blk) = block_at.get(&code.ops.len()) {
+        b.switch_to_block(blk);
+        let zero = b.ins().iconst(types::I32, 0);
+        b.ins().return_(&[zero]);
+    }
+    b.seal_all_blocks();
+    b.finalize();
+
+    engine.fn_counter += 1;
+    let name = format!("mutsu_jit_{}", engine.fn_counter);
+    let module = &mut engine.module;
+    let id = module
+        .declare_function(&name, Linkage::Local, &ctx.func.signature)
+        .ok()?;
+    module.define_function(id, &mut ctx).ok()?;
+    module.clear_context(&mut ctx);
+    module.finalize_definitions().ok()?;
+    let addr = module.get_finalized_function(id);
+    // SAFETY: `addr` is the finalized code for the signature declared above,
+    // which matches `JitEntryFn` exactly; the module (and thus the code
+    // memory) lives for the process lifetime.
+    Some(unsafe { std::mem::transmute::<*const u8, JitEntryFn>(addr) })
+}

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -1,0 +1,188 @@
+//! `extern "C"` opcode helper shims called from JIT-compiled code (Tier A).
+//!
+//! Each shim reproduces exactly one `exec_one` dispatch arm. Values travel on
+//! `Interpreter::stack` as in interpreted execution, so no `Value` crosses the
+//! FFI boundary; errors are parked in `Interpreter::jit_error` and signalled
+//! by a nonzero status (see `vm_jit::JIT_STATUS_*`).
+//!
+//! Safety contract for every shim: `interp`, `code` and `fns` are the live
+//! `&mut Interpreter` / `&CompiledCode` / `&HashMap` the JIT entry wrapper
+//! (`vm_jit::try_enter`) received, valid and unaliased for the duration of
+//! the native call.
+//!
+//! TODO(J2): a Rust panic inside a shim aborts the process at the `extern
+//! "C"` boundary instead of being converted to X::AdHoc by the run-loop
+//! `catch_unwind`; decide between `extern "C-unwind"` + JIT unwind info or
+//! per-shim `catch_unwind` once Tier A coverage grows.
+
+use super::vm_jit::{JIT_STATUS_ERR, JIT_STATUS_HALT, JIT_STATUS_OK};
+use super::*;
+
+/// `OpCode::LoadConst`
+pub(super) unsafe extern "C" fn load_const(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    idx: u32,
+) {
+    let (interp, code) = unsafe { (&mut *interp, &*code) };
+    interp.stack.push(code.constants[idx as usize].clone());
+}
+
+/// `OpCode::SetSourceLine`
+pub(super) unsafe extern "C" fn set_source_line(interp: *mut Interpreter, line: i64) {
+    unsafe { &mut *interp }.cur_source_line = line;
+}
+
+/// `OpCode::ContainerizePair`
+pub(super) unsafe extern "C" fn containerize_pair(interp: *mut Interpreter) {
+    let interp = unsafe { &mut *interp };
+    let val = interp.stack.pop().unwrap();
+    let containerized = match val.view() {
+        ValueView::Pair(k, v) => Value::value_pair(Value::str(k.clone()), v.clone()),
+        _ => val,
+    };
+    interp.stack.push(containerized);
+}
+
+/// GC safepoint poll emitted on native backedges (ADR-0004 §2.4).
+pub(super) unsafe extern "C" fn safepoint(_interp: *mut Interpreter) {
+    crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
+}
+
+/// Park `e` in the interpreter's JIT error slot and report error status.
+#[inline]
+fn park_err(interp: &mut Interpreter, e: RuntimeError) -> u32 {
+    interp.jit_error = Some(e);
+    JIT_STATUS_ERR
+}
+
+/// `OpCode::GetLocal`
+pub(super) unsafe extern "C" fn get_local(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    idx: u32,
+) -> u32 {
+    let (interp, code) = unsafe { (&mut *interp, &*code) };
+    match interp.exec_get_local_op(code, idx) {
+        Ok(()) => JIT_STATUS_OK,
+        Err(e) => park_err(interp, e),
+    }
+}
+
+/// `OpCode::SetLocal`
+pub(super) unsafe extern "C" fn set_local(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    idx: u32,
+) -> u32 {
+    let (interp, code) = unsafe { (&mut *interp, &*code) };
+    match interp.exec_set_local_op(code, idx) {
+        Ok(()) => JIT_STATUS_OK,
+        Err(e) => park_err(interp, e),
+    }
+}
+
+/// `OpCode::Add`
+pub(super) unsafe extern "C" fn add(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    match interp.exec_add_op() {
+        Ok(()) => JIT_STATUS_OK,
+        Err(e) => park_err(interp, e),
+    }
+}
+
+/// `OpCode::Sub`
+pub(super) unsafe extern "C" fn sub(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    match interp.exec_sub_op() {
+        Ok(()) => JIT_STATUS_OK,
+        Err(e) => park_err(interp, e),
+    }
+}
+
+/// `OpCode::NumLt`
+pub(super) unsafe extern "C" fn num_lt(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    match interp.exec_num_lt_op() {
+        Ok(()) => JIT_STATUS_OK,
+        Err(e) => park_err(interp, e),
+    }
+}
+
+/// `OpCode::JumpIfFalse` condition: pops the tested value; returns 1 when the
+/// jump must be taken (falsy), 0 to fall through. Mirrors the dispatch arm's
+/// Failure-handled marking on both paths.
+pub(super) unsafe extern "C" fn jump_if_false_cond(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
+    let val = interp.stack.pop().unwrap();
+    if !interp.eval_truthy(&val) {
+        Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
+        1
+    } else {
+        0
+    }
+}
+
+/// `OpCode::Return`. Status OK means a rebound `&return` ran and execution
+/// continues at the next opcode; otherwise the return signal (or the rebound
+/// call's error) is parked and reported as ERR, exactly like the interpreter
+/// arm's `Err(RuntimeError::return_signal(..))`.
+pub(super) unsafe extern "C" fn ret(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    let val = interp.stack.pop().unwrap_or(Value::NIL);
+    if let Some(rebound) = interp.env().get("&return").cloned()
+        && matches!(
+            rebound.view(),
+            ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }
+        )
+    {
+        return match interp.vm_call_on_value(rebound, vec![val], None) {
+            Ok(result) => {
+                interp.stack.push(result);
+                JIT_STATUS_OK
+            }
+            Err(e) => park_err(interp, e),
+        };
+    }
+    park_err(interp, RuntimeError::return_signal(val))
+}
+
+/// `OpCode::CallFunc`. `op_idx` addresses the opcode in `code.ops` so the
+/// payload (`name_idx`/`arity`/`arg_sources_idx`) is read in place instead of
+/// being marshalled through the native frame. Restores `current_code` after
+/// the call (the callee's dispatch overwrote it) and reproduces the dispatch
+/// arm's resume-point recording.
+pub(super) unsafe extern "C" fn call_func(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    op_idx: u32,
+    fns: *const HashMap<String, CompiledFunction>,
+) -> u32 {
+    let (interp, code, fns) = unsafe { (&mut *interp, &*code, &*fns) };
+    let OpCode::CallFunc {
+        name_idx,
+        arity,
+        arg_sources_idx,
+    } = &code.ops[op_idx as usize]
+    else {
+        unreachable!("jit call_func shim on a non-CallFunc opcode")
+    };
+    let r = interp.exec_call_func_op(code, *name_idx, *arity, *arg_sources_idx, fns);
+    interp.current_code = code as *const CompiledCode as usize;
+    match r {
+        Ok(()) => {
+            if interp.is_halted() {
+                JIT_STATUS_HALT
+            } else {
+                JIT_STATUS_OK
+            }
+        }
+        Err(e) => {
+            if !e.is_resume() && interp.resume_ip.is_none() {
+                interp.resume_ip = Some(op_idx as usize + 1);
+            }
+            park_err(interp, e)
+        }
+    }
+}

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -101,6 +101,54 @@ static GC_PAUSE_NS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static GC_PAUSE_NS_MAX: AtomicU64 = AtomicU64::new(0);
 static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
 
+// JIT (ADR-0004 layer 4) counters: how many chunks compiled to native code,
+// how many body executions entered native code, and how many chunks bailed
+// out (contain a not-yet-supported opcode; see `jit_bailout_by_opcode` for
+// which opcode blocked them — the empirical basis for Tier A coverage work).
+static JIT_COMPILES: AtomicU64 = AtomicU64::new(0);
+static JIT_ENTRIES: AtomicU64 = AtomicU64::new(0);
+static JIT_BAILOUTS: AtomicU64 = AtomicU64::new(0);
+
+/// Per-opcode-name histogram of JIT bailout causes (first unsupported opcode
+/// seen in each rejected chunk; only populated when stats are on).
+fn jit_bailout_by_opcode() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_NAME: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one chunk compiled to native code by the JIT.
+#[inline]
+pub(crate) fn record_jit_compile() {
+    if enabled() {
+        JIT_COMPILES.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record one body execution entering JIT-compiled native code.
+#[inline]
+pub(crate) fn record_jit_entry() {
+    if enabled() {
+        JIT_ENTRIES.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record a chunk rejected by the JIT because it contains `op` (the first
+/// unsupported opcode encountered during the static scan).
+#[inline]
+pub(crate) fn record_jit_bailout(op: &crate::opcode::OpCode) {
+    if enabled() {
+        JIT_BAILOUTS.fetch_add(1, Ordering::Relaxed);
+        let dbg = format!("{op:?}");
+        let name: String = dbg
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if let Ok(mut map) = jit_bailout_by_opcode().lock() {
+            *map.entry(name).or_insert(0) += 1;
+        }
+    }
+}
+
 /// Whether instrumentation is active. Resolved once from the environment so the
 /// hot path is a single cached boolean load when the feature is off.
 #[inline]
@@ -338,6 +386,28 @@ pub(crate) fn dump() {
     eprintln!(
         "[mutsu vm-stats] gc: collections={gc_collections} candidate_pushes={gc_candidate_pushes} dedup_hits={gc_dedup_hits} reclaimed_nodes={gc_reclaimed_nodes} reclaimed_cycles={gc_reclaimed_cycles} pause_ns_total={gc_pause_ns_total} pause_ns_max={gc_pause_ns_max} roots_scanned={gc_roots_scanned} gc_threshold={gc_threshold}"
     );
+    let jit_compiles = JIT_COMPILES.load(Ordering::Relaxed);
+    let jit_entries = JIT_ENTRIES.load(Ordering::Relaxed);
+    let jit_bailouts = JIT_BAILOUTS.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] jit: compiles={jit_compiles} entries={jit_entries} bailouts={jit_bailouts}"
+    );
+    if let Ok(map) = jit_bailout_by_opcode().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(20)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] jit bailout opcodes (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
     if let Ok(map) = opcode_histogram().lock()
         && !map.is_empty()
     {

--- a/tests/jit_diff.rs
+++ b/tests/jit_diff.rs
@@ -1,0 +1,103 @@
+//! Differential coverage for the Cranelift JIT (ADR-0004 J1): the same
+//! program run with `MUTSU_JIT=off` and `MUTSU_JIT=on` must produce
+//! byte-identical output (gc-stress methodology, ADR-0004 §2.6), and a hot
+//! Tier A-compilable function must actually enter native code.
+
+use std::process::Command;
+
+/// Run a Raku snippet through the built `mutsu` with the given extra
+/// environment. Returns (stdout, stderr, success).
+fn run(src: &str, envs: &[(&str, &str)]) -> (String, String, bool) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg("-e").arg(src);
+    for k in ["MUTSU_JIT", "MUTSU_JIT_THRESHOLD", "MUTSU_VM_STATS"] {
+        cmd.env_remove(k);
+    }
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("failed to spawn mutsu");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+const FIB: &str =
+    "sub fib($n) { if $n < 2 { return $n } return fib($n - 1) + fib($n - 2); }\nsay fib(18);";
+
+/// Recursive fib: the J1 Tier A target shape (LoadConst / GetLocal / NumLt /
+/// JumpIfFalse / Sub / Add / CallFunc / Return). Output must not depend on
+/// whether the body runs interpreted or native.
+#[test]
+fn fib_output_is_identical_with_jit_on() {
+    let (off_out, off_err, off_ok) = run(FIB, &[("MUTSU_JIT", "off")]);
+    let (on_out, on_err, on_ok) = run(FIB, &[("MUTSU_JIT", "on"), ("MUTSU_JIT_THRESHOLD", "1")]);
+    assert!(off_ok, "JIT-off run failed: {off_err}");
+    assert!(on_ok, "JIT-on run failed: {on_err}");
+    assert_eq!(off_out, on_out, "JIT on/off outputs diverge");
+    assert_eq!(off_out, "2584\n");
+}
+
+/// Explicit `return` inside the native body must unwind exactly like the
+/// interpreter's return signal (the `Err(return_value)` arm), including from
+/// the recursive fall-through-plus-return mix in `fib`.
+#[test]
+fn jit_actually_compiles_and_enters() {
+    let (out, err, ok) = run(
+        FIB,
+        &[
+            ("MUTSU_JIT", "on"),
+            ("MUTSU_JIT_THRESHOLD", "1"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+    assert!(ok, "JIT-on run failed: {err}");
+    assert_eq!(out, "2584\n");
+    if cfg!(feature = "jit") {
+        let jit_line = err
+            .lines()
+            .find(|l| l.contains("jit: compiles="))
+            .unwrap_or_else(|| panic!("no jit stats line in stderr: {err}"));
+        let field = |key: &str| -> u64 {
+            jit_line
+                .split_whitespace()
+                .find_map(|w| w.strip_prefix(key))
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(|| panic!("missing {key} in: {jit_line}"))
+        };
+        assert!(field("compiles=") >= 1, "hot fib chunk was not compiled");
+        assert!(field("entries=") >= 1, "compiled fib chunk never entered");
+    }
+}
+
+/// A function whose chunk contains an unsupported opcode must be counted as a
+/// bailout and keep producing interpreter-identical output.
+#[test]
+fn unsupported_opcode_bails_out_cleanly() {
+    // `~` string concat compiles to an opcode outside the J1 Tier A set.
+    let src =
+        "sub cat($a) { return $a ~ \"!\" }\nmy $s = \"\";\nfor ^50 { $s = cat(\"x\") }\nsay $s;";
+    let (off_out, _, off_ok) = run(src, &[("MUTSU_JIT", "off")]);
+    let (on_out, on_err, on_ok) = run(
+        src,
+        &[
+            ("MUTSU_JIT", "on"),
+            ("MUTSU_JIT_THRESHOLD", "1"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+    assert!(off_ok && on_ok, "runs failed: {on_err}");
+    assert_eq!(off_out, on_out);
+    if cfg!(feature = "jit") {
+        let jit_line = on_err
+            .lines()
+            .find(|l| l.contains("jit: compiles="))
+            .expect("no jit stats line");
+        assert!(
+            jit_line.contains("bailouts=1"),
+            "expected exactly one bailout chunk: {jit_line}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Layer 4 phase **J1** (ADR-0004 §2.5): the minimal end-to-end Cranelift method-JIT pipeline — feature flag, per-chunk hotness counter, Tier A translation, and native entry swap. Off by default: compiled in under the `jit` cargo feature but inert until `MUTSU_JIT=on` at runtime (`MUTSU_JIT_THRESHOLD` tunes the hot threshold, default 100 calls).

## Design (per ADR-0004 §2.3)

- **Tier A = subroutine threading**: a supported chunk lowers each opcode to a call of an `extern "C"` helper shim that reproduces exactly one `exec_one` dispatch arm; values stay on `Interpreter::stack`, so no `Value` crosses the FFI boundary. `Jump`/`JumpIfFalse` become native branches, with a **GC safepoint poll on every backedge** (§2.4).
- **No guards, no deopt, no OSR**: a chunk containing any opcode outside the Tier A set is rejected up front (`jit_bailouts` counter + per-opcode histogram) and permanently stays on the interpreter.
- **Error/return carriage unchanged**: helpers park the `RuntimeError` (including the return signal and `fail`) in `Interpreter::jit_error` and return a nonzero status; the entry wrapper feeds it through the same match arms as the interpreter loop, so semantics are identical by construction.
- **J1 opcode set** (the `fib` shape): `LoadConst GetLocal SetLocal Add Sub NumLt JumpIfFalse Jump ContainerizePair SetSourceLine Return CallFunc`.
- Entry point: `call_compiled_function_positional_light` (fib's actual call path). The other three body-exec paths are J2 territory.
- Also adds `--dump-bytecode` (static disassembly of mainline + each compiled function) — used to derive the opcode set, permanently useful for J2+ coverage work.

## Gate evidence (J1)

| check | result |
|---|---|
| `MUTSU_JIT=on/off` byte-identical output (fib) | ✅ (`diff` clean; also int-arith) |
| fib actually runs native | ✅ `jit: compiles=1 entries=242686 bailouts=0` |
| `make test` green with `MUTSU_JIT=on` | ✅ (full suite incl. release prove) |
| `MUTSU_JIT_THRESHOLD=1` aggressive stress on `t/` | ✅ (single `-j4` failure `t/io-socket-recv-limit.t` reproduces identically with JIT **off** — pre-existing parallel-load socket flake, not a JIT regression; CI's prove is serial) |
| release fib(25) | 0.14s → **0.13s** (raku 0.16s) |

int-arith note: it is top-level `ForLoop` compound-op code, out of reach of a *function-entry* JIT by design (ADR-0004 §2.2 「entry 置換だけで大半を回収」); loop bodies are J4 hot-loop-entry territory.

## MSRV: 1.92 → 1.93

cranelift 0.132 requires rustc 1.93 (0.133 wants 1.94). CI main jobs already run 1.96; `release`/`pages`/`tagpr` workflows bumped from 1.92 to 1.93. The wasm build (`--no-default-features`) is unaffected.

## Next (J2)

Tier A opcode coverage expansion + `jit-stress` CI job (make test + roast under `MUTSU_JIT=on`), gate: bench-fib 3.2x → ~2.5x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkSj6GsxHMpcvDcg1kj6ni