### PR TITLE
feat(vm): JIT J2 — Tier A opcode coverage + all call paths + jit-stress CI (ADR-0004 J2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,3 +299,75 @@ jobs:
             tmp/gc-stress-roast.log
           retention-days: 7
           if-no-files-found: ignore
+
+  jit-stress:
+    # Runs the whole test + roast suite with the Cranelift JIT ON (ADR-0004
+    # §2.5 J2, same shape as gc-stress). MUTSU_JIT_THRESHOLD=2 compiles every
+    # Tier A-eligible chunk on its second call, so JIT-compiled bodies (not
+    # the interpreter) execute for essentially all repeatedly-called code in
+    # the suite. The JIT's correctness contract is byte-identical output to
+    # the interpreter, so every step is a BLOCKING gate: any failure here that
+    # does not reproduce with MUTSU_JIT=off is a JIT codegen/shim bug.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MUTSU_JIT: "on"
+      MUTSU_JIT_THRESHOLD: "2"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-jitstress-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-jitstress-${{ runner.os }}-
+
+      - name: Install prove
+        run: sudo apt-get update && sudo apt-get install -y perl
+
+      - name: Build (debug, for TAP tests)
+        run: cargo build
+
+      - name: TAP tests (prove t/, JIT on)
+        run: |
+          set -o pipefail
+          mkdir -p tmp
+          prove --merge -e 'timeout 60 target/debug/mutsu' t/ 2>&1 | tee tmp/jit-stress-t.log
+
+      - name: Build (release, for roast)
+        run: cargo build --release
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "false"
+
+      - name: Clean precomp cache and restore roast files
+        run: |
+          rm -rf ~/.cache/mutsu/precomp
+          git checkout -- roast/
+
+      - name: Roast tests (make roast, JIT on)
+        run: |
+          set -o pipefail
+          mkdir -p tmp
+          prove -j4 --merge -e 'scripts/run-roast-test.sh' \
+            $(cat roast-whitelist.txt) 2>&1 | tee tmp/jit-stress-roast.log
+        env:
+          MUTSU_BIN: target/release/mutsu
+
+      - name: Upload JIT stress logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jit-stress-logs
+          path: |
+            tmp/jit-stress-t.log
+            tmp/jit-stress-roast.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -118,7 +118,19 @@ impl Interpreter {
         let mut explicit_return: Option<Value> = None;
         let mut fail_bypass = false;
         while ip < cf.code.ops.len() {
-            match self.exec_one(&cf.code, &mut ip, compiled_fns) {
+            // JIT entry (ADR-0004 J2): same hook as vm_call_light.rs — at body
+            // start, run the whole body natively when the chunk is hot and
+            // Tier A-compilable; the native outcome threads through the same
+            // match arms below.
+            let step = if ip == 0
+                && let Some(r) = crate::vm::vm_jit::try_enter(self, &cf.code, compiled_fns)
+            {
+                ip = cf.code.ops.len();
+                r
+            } else {
+                self.exec_one(&cf.code, &mut ip, compiled_fns)
+            };
+            match step {
                 Ok(()) => {}
                 Err(e) if e.return_value.is_some() => {
                     let ret_val = e.return_value.unwrap();

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -291,7 +291,19 @@ impl Interpreter {
         let mut explicit_return: Option<Value> = None;
         let mut fail_bypass = false;
         while ip < cf.code.ops.len() {
-            match self.exec_one(&cf.code, &mut ip, compiled_fns) {
+            // JIT entry (ADR-0004 J2): same hook as vm_call_light.rs — at body
+            // start, run the whole body natively when the chunk is hot and
+            // Tier A-compilable; the native outcome threads through the same
+            // match arms below.
+            let step = if ip == 0
+                && let Some(r) = crate::vm::vm_jit::try_enter(self, &cf.code, compiled_fns)
+            {
+                ip = cf.code.ops.len();
+                r
+            } else {
+                self.exec_one(&cf.code, &mut ip, compiled_fns)
+            };
+            match step {
                 Ok(()) => {}
                 Err(e) if e.return_value.is_some() => {
                     let ret_val = e.return_value.unwrap();

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -228,7 +228,19 @@ impl Interpreter {
         let mut explicit_return: Option<Value> = None;
         let mut fail_bypass = false;
         while ip < cf.code.ops.len() {
-            match self.exec_one(&cf.code, &mut ip, compiled_fns) {
+            // JIT entry (ADR-0004 J2): same hook as vm_call_light.rs — at body
+            // start, run the whole body natively when the chunk is hot and
+            // Tier A-compilable; the native outcome threads through the same
+            // match arms below.
+            let step = if ip == 0
+                && let Some(r) = crate::vm::vm_jit::try_enter(self, &cf.code, compiled_fns)
+            {
+                ip = cf.code.ops.len();
+                r
+            } else {
+                self.exec_one(&cf.code, &mut ip, compiled_fns)
+            };
+            match step {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{fn_package}::{fn_name}");

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -34,6 +34,137 @@ unsafe impl Send for Engine {}
 
 static ENGINE: Mutex<Option<Engine>> = Mutex::new(None);
 
+/// Payload-free fallible opcodes with a dedicated `(interp) -> status` shim
+/// (the hot arith / compare / string family, plus `Return`). Returns the shim
+/// address for emission, `None` when the opcode is not in this family.
+fn noarg_shim(op: &OpCode) -> Option<usize> {
+    let f: unsafe extern "C" fn(*mut Interpreter) -> u32 = match op {
+        OpCode::Add => helpers::add,
+        OpCode::Sub => helpers::sub,
+        OpCode::Mul => helpers::mul,
+        OpCode::Div => helpers::div,
+        OpCode::Mod => helpers::modulo,
+        OpCode::Pow => helpers::pow,
+        OpCode::Negate => helpers::negate,
+        OpCode::NumLt => helpers::num_lt,
+        OpCode::NumLe => helpers::num_le,
+        OpCode::NumGt => helpers::num_gt,
+        OpCode::NumGe => helpers::num_ge,
+        OpCode::NumEq => helpers::num_eq,
+        OpCode::NumNe => helpers::num_ne,
+        OpCode::Concat => helpers::concat,
+        OpCode::StrEq => helpers::str_eq,
+        OpCode::StrNe => helpers::str_ne,
+        OpCode::Return => helpers::ret,
+        _ => return None,
+    };
+    Some(f as *const () as usize)
+}
+
+/// Straight-line opcodes without a dedicated shim, executed through the
+/// generic `helpers::step` (one interpreter dispatch per opcode). Every entry
+/// is verified against its `exec_one` arm to unconditionally leave
+/// `ip == start + 1` on Ok — no jumps, no compound-loop bodies, no arms that
+/// consult or rewrite `ip` beyond the increment. Anything not provably
+/// straight-line stays OFF this list and bails the chunk out.
+fn step_supported(op: &OpCode) -> bool {
+    matches!(
+        op,
+        // Constants / stack shape
+        OpCode::LoadNil
+            | OpCode::LoadTrue
+            | OpCode::LoadFalse
+            | OpCode::Dup
+            | OpCode::Pop
+            // Variable reads
+            | OpCode::GetGlobal(_)
+            | OpCode::GetOurVar(_)
+            | OpCode::GetArrayVar(_)
+            | OpCode::GetHashVar(_)
+            | OpCode::GetBareWord(_)
+            | OpCode::GetCaptureVar(_)
+            | OpCode::GetCodeVar(_)
+            | OpCode::GetSelfOrNoSelf(_)
+            | OpCode::GetUpvalue { .. }
+            // Variable writes / declarations
+            | OpCode::SetGlobal(_)
+            | OpCode::SetGlobalRaw(_)
+            | OpCode::SetVarDynamic { .. }
+            | OpCode::SetVarType { .. }
+            | OpCode::AssignExpr(_)
+            | OpCode::TopicDotAssign(_)
+            | OpCode::AtomicCompoundVar { .. }
+            | OpCode::IndexAssignExprNamed { .. }
+            | OpCode::WrapVarRef(_)
+            | OpCode::LetSave { .. }
+            | OpCode::CheckReadOnly(_)
+            | OpCode::MarkVarReadonly(_)
+            | OpCode::CheckDynamicVarDeclared(_)
+            // Increment / decrement
+            | OpCode::PostIncrement(..)
+            | OpCode::PostDecrement(..)
+            | OpCode::PreIncrement(..)
+            | OpCode::PreDecrement(..)
+            | OpCode::PreIncrementIndex(_)
+            | OpCode::PreDecrementIndex(_)
+            // Method calls (re-entrant; `step` restores current_code)
+            | OpCode::CallMethod { .. }
+            | OpCode::CallMethodMut { .. }
+            // Arith predicates
+            | OpCode::DivisibleBy
+            | OpCode::NotDivisibleBy
+            // Closure construction
+            | OpCode::MakeLambda(..)
+            | OpCode::MakeAnonSub(..)
+            | OpCode::MakeAnonSubParams(..)
+            | OpCode::MakeGather(..)
+            // Calls through a code variable (re-entrant, like CallMethod)
+            | OpCode::CallOnCodeVar { .. }
+            | OpCode::ExecCallPairs { .. }
+            // In-place container mutation
+            | OpCode::ArrayPush { .. }
+            | OpCode::TagContainerRef(..)
+            | OpCode::TagContainerRefReversed(..)
+            | OpCode::MarkAccessorRefContext
+            // List / hash construction, indexing and coercion
+            | OpCode::MakeArray(_)
+            | OpCode::MakeRealArray(_)
+            | OpCode::MakeRealArrayNoFlatten(_)
+            | OpCode::MakeHash(_)
+            | OpCode::MakePair
+            | OpCode::CoerceToList
+            | OpCode::Itemize
+            | OpCode::DeitemizeZen
+            | OpCode::Decont
+            | OpCode::Index { .. }
+            | OpCode::IndexAutovivifyLazy
+            // String / bool / numeric helpers
+            | OpCode::StringConcat(_)
+            | OpCode::StrCoerce
+            | OpCode::BoolCoerce
+            | OpCode::Not
+            | OpCode::Gcd
+            | OpCode::Lcm
+            | OpCode::IntDiv
+            | OpCode::IntMod
+            | OpCode::NumCoerce
+            // Sink context (forces lazies / throws unhandled Failures)
+            | OpCode::SinkPop(_)
+            // Topic / context markers
+            | OpCode::MarkBindContext
+            | OpCode::MarkVarDeclContext
+            | OpCode::MarkExplicitInitializerContext
+            | OpCode::MarkShapedDeclContext
+            | OpCode::SetTopic
+            | OpCode::SaveTopic
+            | OpCode::RestoreTopic
+            | OpCode::PushEnterResult
+            | OpCode::LoadEnterResult
+            // Always-throwing terminator (records its own resume point)
+            | OpCode::Die
+    )
+}
+
 /// Compile `code` to a native Tier A body. `None` = bailout (unsupported
 /// opcode, or an internal Cranelift failure): the caller marks the chunk so
 /// it is never scanned again.
@@ -42,21 +173,20 @@ pub(super) fn compile_chunk(code: &CompiledCode) -> Option<JitEntryFn> {
     // Tier A set rejects the whole chunk (no partial compilation).
     let mut targets: std::collections::HashSet<usize> = std::collections::HashSet::new();
     for op in code.ops.iter() {
+        if noarg_shim(op).is_some() || step_supported(op) {
+            continue;
+        }
         match op {
             OpCode::LoadConst(_)
             | OpCode::GetLocal(_)
             | OpCode::SetLocal(_)
-            | OpCode::Add
-            | OpCode::Sub
-            | OpCode::NumLt
             | OpCode::ContainerizePair
             | OpCode::SetSourceLine(_)
-            | OpCode::Return
             | OpCode::CallFunc { .. } => {}
-            OpCode::Jump(t) => {
-                targets.insert(*t as usize);
-            }
-            OpCode::JumpIfFalse(t) => {
+            OpCode::Jump(t)
+            | OpCode::JumpIfFalse(t)
+            | OpCode::JumpIfTrue(t)
+            | OpCode::JumpIfNotNil(t) => {
                 targets.insert(*t as usize);
             }
             other => {
@@ -231,45 +361,6 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
                 )?;
                 check_status(&mut b, status);
             }
-            OpCode::Add => {
-                let status = call_helper(
-                    &mut b,
-                    sigs.s1,
-                    helpers::add as *const () as usize,
-                    &[interp],
-                )?;
-                check_status(&mut b, status);
-            }
-            OpCode::Sub => {
-                let status = call_helper(
-                    &mut b,
-                    sigs.s1,
-                    helpers::sub as *const () as usize,
-                    &[interp],
-                )?;
-                check_status(&mut b, status);
-            }
-            OpCode::NumLt => {
-                let status = call_helper(
-                    &mut b,
-                    sigs.s1,
-                    helpers::num_lt as *const () as usize,
-                    &[interp],
-                )?;
-                check_status(&mut b, status);
-            }
-            OpCode::Return => {
-                // OK status = a rebound `&return` ran; fall through to the
-                // next opcode. Otherwise the return signal is parked and the
-                // nonzero status exits the native body.
-                let status = call_helper(
-                    &mut b,
-                    sigs.s1,
-                    helpers::ret as *const () as usize,
-                    &[interp],
-                )?;
-                check_status(&mut b, status);
-            }
             OpCode::CallFunc { .. } => {
                 let opidx = b.ins().iconst(types::I32, i as i64);
                 let status = call_helper(
@@ -295,14 +386,17 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
                 b.ins().jump(block_at[&t], &[]);
                 open = false;
             }
-            OpCode::JumpIfFalse(t) => {
+            OpCode::JumpIfFalse(t) | OpCode::JumpIfTrue(t) | OpCode::JumpIfNotNil(t) => {
+                // Conditional branch: the cond helper returns 1 when the jump
+                // must be taken (JumpIfFalse pops the tested value; the other
+                // two peek, mirroring their interpreter arms).
+                let cond_fn = match op {
+                    OpCode::JumpIfFalse(_) => helpers::jump_if_false_cond as *const () as usize,
+                    OpCode::JumpIfTrue(_) => helpers::jump_if_true_cond as *const () as usize,
+                    _ => helpers::jump_if_not_nil_cond as *const () as usize,
+                };
                 let t = *t as usize;
-                let cond = call_helper(
-                    &mut b,
-                    sigs.s1,
-                    helpers::jump_if_false_cond as *const () as usize,
-                    &[interp],
-                )?;
+                let cond = call_helper(&mut b, sigs.s1, cond_fn, &[interp])?;
                 let next = b.create_block();
                 if t <= i {
                     let poll = b.create_block();
@@ -320,8 +414,29 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
                 }
                 b.switch_to_block(next);
             }
-            // The support scan rejected everything else.
-            _ => unreachable!("unsupported opcode reached JIT emission"),
+            op => {
+                if let Some(f) = noarg_shim(op) {
+                    // Dedicated payload-free shim (arith / compare / Return —
+                    // for Return, OK status = a rebound `&return` ran and
+                    // execution falls through; otherwise the parked return
+                    // signal exits the native body via the status check).
+                    let status = call_helper(&mut b, sigs.s1, f, &[interp])?;
+                    check_status(&mut b, status);
+                } else if step_supported(op) {
+                    // Generic straight-line step: one interpreter dispatch.
+                    let opidx = b.ins().iconst(types::I32, i as i64);
+                    let status = call_helper(
+                        &mut b,
+                        sigs.s_call,
+                        helpers::step as *const () as usize,
+                        &[interp, codep, opidx, fnsp],
+                    )?;
+                    check_status(&mut b, status);
+                } else {
+                    // The support scan rejected everything else.
+                    unreachable!("unsupported opcode reached JIT emission")
+                }
+            }
         }
     }
     // Fall off the end of the chunk: OK status (result is on the stack).

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -82,29 +82,75 @@ pub(super) unsafe extern "C" fn set_local(
     }
 }
 
-/// `OpCode::Add`
-pub(super) unsafe extern "C" fn add(interp: *mut Interpreter) -> u32 {
-    let interp = unsafe { &mut *interp };
-    match interp.exec_add_op() {
-        Ok(()) => JIT_STATUS_OK,
-        Err(e) => park_err(interp, e),
-    }
+/// Dedicated shims for the payload-free fallible opcodes (arith / compare /
+/// string): each delegates to the interpreter's own `exec_*_op`, skipping the
+/// dispatch match entirely. These are the hot loop-body opcodes, so they get
+/// a direct shim instead of the generic `step` below.
+macro_rules! fallible_noarg_shims {
+    ($($shim:ident => $method:ident),+ $(,)?) => {$(
+        #[doc = concat!("Shim delegating to `", stringify!($method), "`.")]
+        pub(super) unsafe extern "C" fn $shim(interp: *mut Interpreter) -> u32 {
+            let interp = unsafe { &mut *interp };
+            match interp.$method() {
+                Ok(()) => JIT_STATUS_OK,
+                Err(e) => park_err(interp, e),
+            }
+        }
+    )+};
 }
 
-/// `OpCode::Sub`
-pub(super) unsafe extern "C" fn sub(interp: *mut Interpreter) -> u32 {
-    let interp = unsafe { &mut *interp };
-    match interp.exec_sub_op() {
-        Ok(()) => JIT_STATUS_OK,
-        Err(e) => park_err(interp, e),
-    }
+fallible_noarg_shims! {
+    add => exec_add_op,
+    sub => exec_sub_op,
+    mul => exec_mul_op,
+    div => exec_div_op,
+    modulo => exec_mod_op,
+    pow => exec_pow_op,
+    negate => exec_negate_op,
+    num_lt => exec_num_lt_op,
+    num_le => exec_num_le_op,
+    num_gt => exec_num_gt_op,
+    num_ge => exec_num_ge_op,
+    num_eq => exec_num_eq_op,
+    num_ne => exec_num_ne_op,
+    concat => exec_concat_op,
+    str_eq => exec_str_eq_op,
+    str_ne => exec_str_ne_op,
 }
 
-/// `OpCode::NumLt`
-pub(super) unsafe extern "C" fn num_lt(interp: *mut Interpreter) -> u32 {
-    let interp = unsafe { &mut *interp };
-    match interp.exec_num_lt_op() {
-        Ok(()) => JIT_STATUS_OK,
+/// Generic single-opcode step for straight-line opcodes without a dedicated
+/// shim: runs the interpreter's own dispatch arm at `op_idx` via `exec_one`,
+/// so the arm's full behavior (resume-point recording, rw writeback, ...) is
+/// reproduced verbatim. Only opcodes on the `step_supported` whitelist
+/// (vm_jit_compile.rs) are emitted through here — each is verified to always
+/// leave `ip == op_idx + 1` on Ok (no control flow), so the native caller's
+/// fall-through to the next opcode matches the interpreter exactly.
+/// `current_code` is restored afterwards: a re-entrant arm (CallMethod, ...)
+/// overwrites it, and unlike the interpreter loop the following native
+/// opcodes do not reset it per step.
+pub(super) unsafe extern "C" fn step(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    op_idx: u32,
+    fns: *const HashMap<String, CompiledFunction>,
+) -> u32 {
+    let (interp, code, fns) = unsafe { (&mut *interp, &*code, &*fns) };
+    let mut ip = op_idx as usize;
+    let r = interp.exec_one(code, &mut ip, fns);
+    interp.current_code = code as *const CompiledCode as usize;
+    match r {
+        Ok(()) => {
+            debug_assert_eq!(
+                ip,
+                op_idx as usize + 1,
+                "non-straight-line opcode on the Tier A step whitelist"
+            );
+            if interp.is_halted() {
+                JIT_STATUS_HALT
+            } else {
+                JIT_STATUS_OK
+            }
+        }
         Err(e) => park_err(interp, e),
     }
 }
@@ -118,6 +164,30 @@ pub(super) unsafe extern "C" fn jump_if_false_cond(interp: *mut Interpreter) -> 
     let val = interp.stack.pop().unwrap();
     if !interp.eval_truthy(&val) {
         Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
+        1
+    } else {
+        0
+    }
+}
+
+/// `OpCode::JumpIfTrue` condition: PEEKS the tested value (the interpreter
+/// arm keeps it on the stack on both paths — `||`-style short-circuit);
+/// returns 1 when the jump must be taken (truthy), 0 to fall through.
+pub(super) unsafe extern "C" fn jump_if_true_cond(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
+    let val = interp.stack.last().unwrap().clone();
+    if interp.eval_truthy(&val) { 1 } else { 0 }
+}
+
+/// `OpCode::JumpIfNotNil` condition: PEEKS the tested value (kept on the
+/// stack on both paths — `//`-style short-circuit); returns 1 when the jump
+/// must be taken (defined), 0 to fall through.
+pub(super) unsafe extern "C" fn jump_if_not_nil_cond(interp: *mut Interpreter) -> u32 {
+    let interp = unsafe { &mut *interp };
+    Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
+    let val = interp.stack.last().unwrap();
+    if crate::runtime::types::value_is_defined(val) {
         1
     } else {
         0

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -543,7 +543,19 @@ impl Interpreter {
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
         while ip < cc.ops.len() {
-            match self.exec_one(cc, &mut ip, compiled_fns) {
+            // JIT entry (ADR-0004 J2): same hook as vm_call_light.rs — at body
+            // start, run the whole body natively when the chunk is hot and
+            // Tier A-compilable; the native outcome threads through the same
+            // match arms below.
+            let step = if ip == 0
+                && let Some(r) = crate::vm::vm_jit::try_enter(self, cc, compiled_fns)
+            {
+                ip = cc.ops.len();
+                r
+            } else {
+                self.exec_one(cc, &mut ip, compiled_fns)
+            };
+            match step {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", owner_class, method_name);
@@ -1283,7 +1295,19 @@ impl Interpreter {
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
         while ip < cc.ops.len() {
-            match self.exec_one(cc, &mut ip, compiled_fns) {
+            // JIT entry (ADR-0004 J2): same hook as vm_call_light.rs — at body
+            // start, run the whole body natively when the chunk is hot and
+            // Tier A-compilable; the native outcome threads through the same
+            // match arms below.
+            let step = if ip == 0
+                && let Some(r) = crate::vm::vm_jit::try_enter(self, cc, compiled_fns)
+            {
+                ip = cc.ops.len();
+                r
+            } else {
+                self.exec_one(cc, &mut ip, compiled_fns)
+            };
+            match step {
                 Ok(()) => {}
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", owner_class, method_name);

--- a/tests/jit_diff.rs
+++ b/tests/jit_diff.rs
@@ -72,13 +72,51 @@ fn jit_actually_compiles_and_enters() {
     }
 }
 
+/// J2 coverage: a hot METHOD body (the `call_compiled_method*` entry hooks)
+/// built from J2 Tier A opcodes — comparisons (`NumLe`), arith (`Mul`),
+/// string concat (`Concat`), and attribute access via the generic `step` shim
+/// (`CallMethod`/`GetGlobal`) — must compile, enter, and produce
+/// interpreter-identical output.
+#[test]
+fn hot_method_body_compiles_and_matches() {
+    let src = "class Counter { has $.n is rw; method bump() { $.n = $.n * 2 <= 64 ?? $.n * 2 !! $.n + 1; } method label() { \"n=\" ~ $.n } }\nmy $c = Counter.new(n => 1);\nfor ^30 { $c.bump() }\nsay $c.label();";
+    let (off_out, off_err, off_ok) = run(src, &[("MUTSU_JIT", "off")]);
+    let (on_out, on_err, on_ok) = run(
+        src,
+        &[
+            ("MUTSU_JIT", "on"),
+            ("MUTSU_JIT_THRESHOLD", "1"),
+            ("MUTSU_VM_STATS", "1"),
+        ],
+    );
+    assert!(off_ok, "JIT-off run failed: {off_err}");
+    assert!(on_ok, "JIT-on run failed: {on_err}");
+    assert_eq!(off_out, on_out, "JIT on/off outputs diverge");
+    if cfg!(feature = "jit") {
+        let jit_line = on_err
+            .lines()
+            .find(|l| l.contains("jit: compiles="))
+            .expect("no jit stats line");
+        let compiles: u64 = jit_line
+            .split_whitespace()
+            .find_map(|w| w.strip_prefix("compiles="))
+            .and_then(|v| v.parse().ok())
+            .expect("missing compiles=");
+        assert!(
+            compiles >= 1,
+            "hot method chunk was not compiled: {jit_line}"
+        );
+    }
+}
+
 /// A function whose chunk contains an unsupported opcode must be counted as a
 /// bailout and keep producing interpreter-identical output.
 #[test]
 fn unsupported_opcode_bails_out_cleanly() {
-    // `~` string concat compiles to an opcode outside the J1 Tier A set.
-    let src =
-        "sub cat($a) { return $a ~ \"!\" }\nmy $s = \"\";\nfor ^50 { $s = cat(\"x\") }\nsay $s;";
+    // A `while` loop compiles to the compound `WhileLoop` opcode, which is
+    // outside the Tier A set (loop bodies run through the interpreter until
+    // J4 hot-loop entry).
+    let src = "sub count($n) { my $i = 0; while $i < $n { $i = $i + 1 } return $i }\nmy $s = 0;\nfor ^50 { $s = count(3) }\nsay $s;";
     let (off_out, _, off_ok) = run(src, &[("MUTSU_JIT", "off")]);
     let (on_out, on_err, on_ok) = run(
         src,


### PR DESCRIPTION
## Summary

ADR-0004 §2.5 **J2**: expand the Cranelift Tier A JIT from the J1 fib-shaped skeleton to broad function-body coverage.

- **Entry hooks in all remaining call paths**: `vm_call_fast`, `vm_call_light_typed`, `vm_call_named_inner`, and both compiled-method body loops (`call_compiled_method` / `call_compiled_method_fast`), same `ip == 0` shape as the J1 hook in `vm_call_light`. Method bodies now compile and enter native code.
- **Dedicated helper shims** (macro-generated) for the payload-free fallible family: `Mul/Div/Mod/Pow/Negate`, `NumLe/NumGt/NumGe/NumEq/NumNe`, `Concat/StrEq/StrNe` alongside the existing `Add/Sub/NumLt/Return`.
- **Generic `step` shim**: straight-line opcodes with complex payloads (`CallMethod`, `CallMethodMut`, `CallOnCodeVar`, `GetGlobal`/`SetGlobal` and the other variable ops, `SinkPop`, `MakeArray`/`MakeHash`, inc/dec, closure construction, ...) execute as one interpreter dispatch step, reproducing the arm's behavior (resume-point recording, rw writeback, attr-cell mirroring) verbatim, restoring `current_code` after re-entrant arms. Every whitelist entry was verified against its `exec_one` arm to unconditionally end at `ip + 1`; a `debug_assert` trips otherwise.
- **`JumpIfTrue` / `JumpIfNotNil`** lowered to native branches (peeking cond helpers; backedge safepoint polls as in J1).
- **jit-stress CI job** (gc-stress shape): `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2` over `prove t/` + the full roast whitelist.
- **jit_diff tests**: the bailout test moved from `~` (Concat is now Tier A) to the compound `WhileLoop` opcode; new hot-method differential test covering the method-path hooks + generic step opcodes.

## Verification

- t/ (1677 files) green under `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2` (debug; the only failure was the known `t/io-socket-recv-limit.t` -j4 flake, passes solo).
- Full roast whitelist (1384 files) green under JIT stress (release, threshold=2).
- on/off byte-identical output across all `benchmarks/*.raku`.
- `make test` green with JIT off (default path untouched — hooks are inert without `MUTSU_JIT=on`).
- Coverage counters: bench-fib / method-call / bench-class / fib now compile with **bailouts=0** (J1: only fib compiled).

## Measurements (release, `perf stat -r5`, `taskset -c 0-3`, quiet machine)

| bench | JIT off | JIT on | delta |
|---|---|---|---|
| fib | 0.1376s | 0.1276s | **+7.3%** |
| bench-fib | 0.3846s | 0.3684s | **+4.2%** |
| method-call | 0.1726s | 0.1732s | flat |
| bench-class | 0.1831s | 0.1863s | −1.7% |

The fib-family improvement is the dispatch-removal share (the ADR's 3.2x→2.5x J2 target predates the July perf slices that took bench-fib to 1.92x; the dispatch loop is no longer the dominant cost). method-call/bench-class are flat because their hot opcodes run through the generic `step` shim, which retains one interpreter dispatch per op — removing that is exactly J3 (call convention / inline caches) and J4 (Tier B inlining). JIT remains **default off**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWpYJdKBYbT9fnimevhpQT