### PR TITLE
perf(vm): JIT J3 — call-convention optimization: CallMethod shims, to_map removal, type-check fast path (ADR-0004 J3)

### DIFF
--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -339,13 +339,13 @@ impl Interpreter {
                             Some(invocant.clone()),
                             &empty_fns,
                         )
-                        .map(|(result, updated, adjusted)| {
-                            // Commit only an `adjusted` (`:=`-recovered) snapshot, exactly
+                        .map(|(result, reconciled)| {
+                            // Commit only an adjusted (`:=`-recovered) snapshot, exactly
                             // like `dispatch_compiled_method`: an unadjusted run already
                             // mutated the shared attribute cell in place, so writing the
                             // baseline snapshot back would clobber it (e.g. a parent
                             // `callsame` candidate's `self.x ~= ...`).
-                            let new_inv = if adjusted {
+                            let new_inv = if let Some(updated) = reconciled {
                                 Value::write_back_sharing(
                                     &attributes,
                                     class_name,
@@ -392,7 +392,7 @@ impl Interpreter {
                             Some(invocant.clone()),
                             &empty_fns,
                         )
-                        .map(|(result, _, _)| (result, None))
+                        .map(|(result, _)| (result, None))
                     } else {
                         self.forward_resolved_delegation(
                             &receiver_class,

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -301,6 +301,17 @@ impl Interpreter {
         }
         let cc = method_def.compiled_code.clone().unwrap();
         let inv_for_cell = invocant.clone();
+        // Non-instance invocant (no live cell): keep the entry snapshot as the
+        // unadjusted fallback map, mirroring the pre-Option return contract.
+        let fallback_attrs = if inv_for_cell
+            .as_ref()
+            .and_then(Self::self_instance_attrs)
+            .is_none()
+        {
+            Some(attributes.clone())
+        } else {
+            None
+        };
         let empty_fns: HashMap<String, crate::opcode::CompiledFunction> = HashMap::new();
         let saved_pending = std::mem::take(&mut self.pending_rw_writeback_sources);
         let call_result = self.call_compiled_method(
@@ -330,7 +341,7 @@ impl Interpreter {
         }
         self.pending_rw_writeback_sources = merged;
         match call_result {
-            Ok((v, updated, adjusted)) => {
+            Ok((v, reconciled)) => {
                 if method_def.is_submethod
                     && let Some(mut err) = self.failure_to_runtime_error_if_unhandled(&v)
                 {
@@ -339,16 +350,16 @@ impl Interpreter {
                 }
                 // Read the committed attribute map from the live cell of `self`,
                 // unwrapping a `Mixin` invocant to its inner instance (so a
-                // runtime-`does` mixin method's attribute mutations are captured, not
-                // the stale pre-call `updated` map). `adjusted` keeps the `:=`-recovered
-                // snapshot.
-                let final_attrs = if adjusted {
+                // runtime-`does` mixin method's attribute mutations are captured,
+                // not a stale entry snapshot). A `Some` reconcile keeps the
+                // `:=`-recovered snapshot.
+                let final_attrs = if let Some(updated) = reconciled {
                     updated
                 } else if let Some(cell) = inv_for_cell.as_ref().and_then(Self::self_instance_attrs)
                 {
                     cell.to_map()
                 } else {
-                    updated
+                    fallback_attrs.unwrap_or_default()
                 };
                 Ok((v, final_attrs))
             }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -290,6 +290,22 @@ impl Interpreter {
     }
 
     pub(crate) fn type_matches_value(&mut self, constraint: &str, value: &Value) -> bool {
+        // Hot-path fast accept (ADR-0004 J3): a concrete value whose exact tag /
+        // class matches the bare constraint name. Sound unless a user `subset`
+        // shadows the name (then the full checker below must run its predicate),
+        // so it is gated on the subset registry. This skips the long string-
+        // compare gauntlet for the ubiquitous `Int $n` / `Point $p` params.
+        let tag_match = match value.view() {
+            ValueView::Int(_) => constraint == "Int",
+            ValueView::Num(_) => constraint == "Num",
+            ValueView::Str(_) => constraint == "Str",
+            ValueView::Bool(_) => constraint == "Bool",
+            ValueView::Instance { class_name, .. } => class_name.as_str() == constraint,
+            _ => false,
+        };
+        if tag_match && !self.registry().subsets.contains_key(constraint) {
+            return true;
+        }
         if let ValueView::Scalar(inner) = value.view() {
             return self.type_matches_value(constraint, inner);
         }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -151,14 +151,13 @@ impl Interpreter {
         let skip_name_caches = if self.amp_param_shadowed_names.is_empty() {
             false
         } else {
-            let name_str = Self::const_str(code, name_idx);
             self.amp_param_shadowed_names
-                .contains(&Symbol::intern(name_str))
+                .contains(&code.const_sym(name_idx))
         };
         // Ultra-fast path: positional light-call cache for positional-only functions.
         if !skip_name_caches {
             let name_str = Self::const_str(code, name_idx);
-            let name_sym = Symbol::intern(name_str);
+            let name_sym = code.const_sym(name_idx);
             if self.pos_light_call_cache_gen == self.fn_resolve_gen {
                 if let Some((cached_key, cached_fp)) = self.pos_light_call_cache.get(&name_sym)
                     && let Some(cf) = compiled_fns.get(cached_key.as_str())
@@ -213,8 +212,7 @@ impl Interpreter {
 
         // Light-call cache check for named-param functions.
         if !skip_name_caches {
-            let name_str = Self::const_str(code, name_idx);
-            let name_sym = Symbol::intern(name_str);
+            let name_sym = code.const_sym(name_idx);
             if self.light_call_cache_gen == self.fn_resolve_gen {
                 if let Some((cached_key, cached_fp)) = self.light_call_cache.get(&name_sym)
                     && let Some(cf) = compiled_fns.get(cached_key.as_str())
@@ -272,7 +270,7 @@ impl Interpreter {
         // then put it back after the call.
         if !skip_name_caches {
             let name_str = Self::const_str(code, name_idx);
-            let name_sym = Symbol::intern(name_str);
+            let name_sym = code.const_sym(name_idx);
             if self.otf_call_cache_gen == self.fn_resolve_gen {
                 // Skip this type-blind name-keyed fast cache for multi names: the
                 // right candidate depends on argument types, which this cache
@@ -401,7 +399,7 @@ impl Interpreter {
         // Only the callsite line pair (if present) needs to be popped from the stack.
         if !has_lexical_override && arity <= 1 {
             let name_str = Self::const_str(code, name_idx);
-            let name_sym = Symbol::intern(name_str);
+            let name_sym = code.const_sym(name_idx);
             let cache_key = (name_sym, 0usize, Vec::<String>::new());
             let use_cache = !self.has_multi_candidates_cached(name_str);
             if use_cache

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -266,10 +266,7 @@ impl Interpreter {
             self.pop_method_samewith_context();
             result
         } else {
-            let attributes = attrs_cell
-                .as_ref()
-                .map(|c| c.to_map())
-                .unwrap_or_default();
+            let attributes = attrs_cell.as_ref().map(|c| c.to_map()).unwrap_or_default();
             let invocant_for_dispatch = if attrs_empty {
                 Value::package(crate::symbol::Symbol::intern(cn))
             } else {

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -234,14 +234,13 @@ impl Interpreter {
             ValueView::Instance { attributes, .. } => Some(attributes.clone()),
             _ => None,
         };
-        let attributes = match target.view() {
-            ValueView::Instance { attributes, .. } => attributes.to_map(),
-            _ => std::collections::HashMap::new(),
-        };
+        // No whole-map `to_map()` snapshot here: the fast path reads attributes
+        // through the live cell, and the slow path materializes its own map.
+        let attrs_empty = attrs_cell.as_ref().is_none_or(|c| c.as_map().is_empty());
         let empty_fns = HashMap::new();
         let method_result = if let Some(csm) = can_skip_merge {
             // Fast path: move target directly as base (avoid extra clone).
-            let invocant_for_dispatch = if attributes.is_empty() {
+            let invocant_for_dispatch = if attrs_empty {
                 Value::package(crate::symbol::Symbol::intern(cn))
             } else {
                 target.clone()
@@ -256,7 +255,6 @@ impl Interpreter {
                 method,
                 method_def,
                 cc,
-                attributes,
                 args,
                 target,
                 &empty_fns,
@@ -268,7 +266,11 @@ impl Interpreter {
             self.pop_method_samewith_context();
             result
         } else {
-            let invocant_for_dispatch = if attributes.is_empty() {
+            let attributes = attrs_cell
+                .as_ref()
+                .map(|c| c.to_map())
+                .unwrap_or_default();
+            let invocant_for_dispatch = if attrs_empty {
                 Value::package(crate::symbol::Symbol::intern(cn))
             } else {
                 target.clone()
@@ -295,24 +297,23 @@ impl Interpreter {
             self.pop_method_samewith_context();
             result
         };
-        let (result, new_attrs, attrs_adjusted) = method_result?;
+        let (result, reconciled) = method_result?;
         if let Some(id) = target_id {
             // Commit only a `:=`-adjusted snapshot: an unadjusted one equals the
             // cell and the whole-map write would race with concurrent cell-CAS
             // from another thread (lost updates).
-            if attrs_adjusted && let Some(cell) = &attrs_cell {
-                cell.commit_attrs(new_attrs.clone());
+            if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
+                cell.commit_attrs(m.clone());
             }
             if !self.in_lvalue_assignment
                 && let ValueView::Proxy { fetcher, .. } = result.view()
             {
-                // Without a `:=` adjustment the triple's map is the stale entry
-                // snapshot (the lazy reconcile skips the cell clone) —
+                // Without a `:=` adjustment the returned map is absent —
                 // re-snapshot the live cell for the proxy fetcher.
-                let proxy_attrs = if !attrs_adjusted && let Some(cell) = &attrs_cell {
-                    cell.to_map()
-                } else {
-                    new_attrs
+                let proxy_attrs = match (&reconciled, &attrs_cell) {
+                    (Some(m), _) => m.clone(),
+                    (None, Some(cell)) => cell.to_map(),
+                    (None, None) => HashMap::new(),
                 };
                 return loan_env!(self, proxy_fetch(fetcher, None, cn, &proxy_attrs, id));
             }

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -358,26 +358,24 @@ impl Interpreter {
                             self.pop_method_dispatch();
                         }
                         self.pop_method_samewith_context();
-                        let (result, new_attrs, attrs_adjusted) = method_result?;
+                        let (result, reconciled) = method_result?;
                         if let Some(id) = target_id {
                             // Commit only a `:=`-adjusted snapshot: an unadjusted
                             // one equals the cell and the whole-map write would
                             // race with concurrent cell-CAS (lost updates).
-                            if attrs_adjusted && let Some(cell) = &attrs_cell {
-                                cell.commit_attrs(new_attrs.clone());
+                            if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
+                                cell.commit_attrs(m.clone());
                             }
                             if !self.in_lvalue_assignment
                                 && let ValueView::Proxy { fetcher, .. } = result.view()
                             {
-                                // Without a `:=` adjustment the triple's map is
-                                // the stale entry snapshot (the lazy reconcile
-                                // skips the cell clone) — re-snapshot the live
-                                // cell for the proxy fetcher.
-                                let proxy_attrs = if !attrs_adjusted && let Some(cell) = &attrs_cell
-                                {
-                                    cell.to_map()
-                                } else {
-                                    new_attrs
+                                // Without a `:=` adjustment the returned map is
+                                // absent — re-snapshot the live cell for the
+                                // proxy fetcher.
+                                let proxy_attrs = match (&reconciled, &attrs_cell) {
+                                    (Some(m), _) => m.clone(),
+                                    (None, Some(cell)) => cell.to_map(),
+                                    (None, None) => std::collections::HashMap::new(),
                                 };
                                 return loan_env!(
                                     self,

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -294,26 +294,24 @@ impl Interpreter {
                             self.pop_method_dispatch();
                         }
                         self.pop_method_samewith_context();
-                        let (result, new_attrs, attrs_adjusted) = method_result?;
+                        let (result, reconciled) = method_result?;
                         if let Some(id) = target_id {
                             // Commit only a `:=`-adjusted snapshot: an unadjusted
                             // one equals the cell and the whole-map write would
                             // race with concurrent cell-CAS (lost updates).
-                            if attrs_adjusted && let Some(cell) = &attrs_cell {
-                                cell.commit_attrs(new_attrs.clone());
+                            if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
+                                cell.commit_attrs(m.clone());
                             }
                             if !self.in_lvalue_assignment
                                 && let ValueView::Proxy { fetcher, .. } = result.view()
                             {
-                                // Without a `:=` adjustment the triple's map is
-                                // the stale entry snapshot (the lazy reconcile
-                                // skips the cell clone) — re-snapshot the live
-                                // cell for the proxy fetcher.
-                                let proxy_attrs = if !attrs_adjusted && let Some(cell) = &attrs_cell
-                                {
-                                    cell.to_map()
-                                } else {
-                                    new_attrs
+                                // Without a `:=` adjustment the returned map is
+                                // absent — re-snapshot the live cell for the
+                                // proxy fetcher.
+                                let proxy_attrs = match (&reconciled, &attrs_cell) {
+                                    (Some(m), _) => m.clone(),
+                                    (None, Some(cell)) => cell.to_map(),
+                                    (None, None) => std::collections::HashMap::new(),
                                 };
                                 return loan_env!(
                                     self,
@@ -408,23 +406,22 @@ impl Interpreter {
                     self.pop_method_dispatch();
                 }
                 self.pop_method_samewith_context();
-                let (result, new_attrs, attrs_adjusted) = method_result?;
+                let (result, reconciled) = method_result?;
                 if let Some(id) = target_id {
                     // Commit only a `:=`-adjusted snapshot (cell-CAS race
                     // avoidance — see the primary dispatch site).
-                    if attrs_adjusted && let Some(cell) = &attrs_cell {
-                        cell.commit_attrs(new_attrs.clone());
+                    if let (Some(m), Some(cell)) = (&reconciled, &attrs_cell) {
+                        cell.commit_attrs(m.clone());
                     }
                     if !self.in_lvalue_assignment
                         && let ValueView::Proxy { fetcher, .. } = result.view()
                     {
-                        // Without a `:=` adjustment the triple's map is the stale
-                        // entry snapshot (lazy reconcile) — re-snapshot the live
-                        // cell for the proxy fetcher.
-                        let proxy_attrs = if !attrs_adjusted && let Some(cell) = &attrs_cell {
-                            cell.to_map()
-                        } else {
-                            new_attrs
+                        // Without a `:=` adjustment the returned map is absent —
+                        // re-snapshot the live cell for the proxy fetcher.
+                        let proxy_attrs = match (&reconciled, &attrs_cell) {
+                            (Some(m), _) => m.clone(),
+                            (None, Some(cell)) => cell.to_map(),
+                            (None, None) => std::collections::HashMap::new(),
                         };
                         return loan_env!(self, proxy_fetch(fetcher, None, cn, &proxy_attrs, id));
                     }

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -377,8 +377,7 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
                     helpers::call_method_mut as *const () as usize
                 };
                 let opidx = b.ins().iconst(types::I32, i as i64);
-                let status =
-                    call_helper(&mut b, sigs.s_code_u32, f, &[interp, codep, opidx])?;
+                let status = call_helper(&mut b, sigs.s_code_u32, f, &[interp, codep, opidx])?;
                 check_status(&mut b, status);
             }
             OpCode::Jump(t) => {

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -107,9 +107,6 @@ fn step_supported(op: &OpCode) -> bool {
             | OpCode::PreDecrement(..)
             | OpCode::PreIncrementIndex(_)
             | OpCode::PreDecrementIndex(_)
-            // Method calls (re-entrant; `step` restores current_code)
-            | OpCode::CallMethod { .. }
-            | OpCode::CallMethodMut { .. }
             // Arith predicates
             | OpCode::DivisibleBy
             | OpCode::NotDivisibleBy
@@ -182,7 +179,9 @@ pub(super) fn compile_chunk(code: &CompiledCode) -> Option<JitEntryFn> {
             | OpCode::SetLocal(_)
             | OpCode::ContainerizePair
             | OpCode::SetSourceLine(_)
-            | OpCode::CallFunc { .. } => {}
+            | OpCode::CallFunc { .. }
+            | OpCode::CallMethod { .. }
+            | OpCode::CallMethodMut { .. } => {}
             OpCode::Jump(t)
             | OpCode::JumpIfFalse(t)
             | OpCode::JumpIfTrue(t)
@@ -369,6 +368,17 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
                     helpers::call_func as *const () as usize,
                     &[interp, codep, opidx, fnsp],
                 )?;
+                check_status(&mut b, status);
+            }
+            OpCode::CallMethod { .. } | OpCode::CallMethodMut { .. } => {
+                let f = if matches!(op, OpCode::CallMethod { .. }) {
+                    helpers::call_method as *const () as usize
+                } else {
+                    helpers::call_method_mut as *const () as usize
+                };
+                let opidx = b.ins().iconst(types::I32, i as i64);
+                let status =
+                    call_helper(&mut b, sigs.s_code_u32, f, &[interp, codep, opidx])?;
                 check_status(&mut b, status);
             }
             OpCode::Jump(t) => {

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -218,6 +218,113 @@ pub(super) unsafe extern "C" fn ret(interp: *mut Interpreter) -> u32 {
     park_err(interp, RuntimeError::return_signal(val))
 }
 
+/// `OpCode::CallMethod`. `op_idx` addresses the opcode in `code.ops` so the
+/// payload is read in place. Reproduces the dispatch arm exactly: resume-point
+/// recording on error, and the `is rw` writeback / pending-local drain on
+/// success. Restores `current_code` after the re-entrant dispatch.
+pub(super) unsafe extern "C" fn call_method(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    op_idx: u32,
+) -> u32 {
+    let (interp, code) = unsafe { (&mut *interp, &*code) };
+    let OpCode::CallMethod {
+        name_idx,
+        arity,
+        modifier_idx,
+        quoted,
+        arg_sources_idx,
+    } = &code.ops[op_idx as usize]
+    else {
+        unreachable!("jit call_method shim on a non-CallMethod opcode")
+    };
+    let r = interp.exec_call_method_op(
+        code,
+        *name_idx,
+        *arity,
+        *modifier_idx,
+        *quoted,
+        *arg_sources_idx,
+    );
+    interp.current_code = code as *const CompiledCode as usize;
+    match r {
+        Ok(()) => {
+            interp.apply_pending_rw_writeback(code);
+            interp.drain_pending_local_updates_after_call(code);
+            if interp.is_halted() {
+                JIT_STATUS_HALT
+            } else {
+                JIT_STATUS_OK
+            }
+        }
+        Err(e) => {
+            if !e.is_resume() && interp.resume_ip.is_none() {
+                interp.resume_ip = Some(op_idx as usize + 1);
+            }
+            park_err(interp, e)
+        }
+    }
+}
+
+/// `OpCode::CallMethodMut`. Mirrors the dispatch arm: attr-cell snapshot
+/// before, receiver writeback + rw writeback + pending-local drain + attr-cell
+/// mirror after, resume-point recording on error.
+pub(super) unsafe extern "C" fn call_method_mut(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    op_idx: u32,
+) -> u32 {
+    let (interp, code) = unsafe { (&mut *interp, &*code) };
+    let OpCode::CallMethodMut {
+        name_idx,
+        arity,
+        target_name_idx,
+        modifier_idx,
+        quoted,
+        arg_sources_idx,
+    } = &code.ops[op_idx as usize]
+    else {
+        unreachable!("jit call_method_mut shim on a non-CallMethodMut opcode")
+    };
+    let pre = interp.array_hash_attr_env_snapshot(code, *target_name_idx);
+    let r = interp.exec_call_method_mut_op(
+        code,
+        *name_idx,
+        *arity,
+        *target_name_idx,
+        *modifier_idx,
+        *quoted,
+        *arg_sources_idx,
+    );
+    interp.current_code = code as *const CompiledCode as usize;
+    match r {
+        Ok(()) => {
+            {
+                let target_name = Interpreter::const_str(code, *target_name_idx);
+                if !target_name.is_empty() {
+                    interp
+                        .pending_rw_writeback_sources
+                        .push(target_name.to_string());
+                }
+            }
+            interp.apply_pending_rw_writeback(code);
+            interp.drain_pending_local_updates_after_call(code);
+            interp.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
+            if interp.is_halted() {
+                JIT_STATUS_HALT
+            } else {
+                JIT_STATUS_OK
+            }
+        }
+        Err(e) => {
+            if !e.is_resume() && interp.resume_ip.is_none() {
+                interp.resume_ip = Some(op_idx as usize + 1);
+            }
+            park_err(interp, e)
+        }
+    }
+}
+
 /// `OpCode::CallFunc`. `op_idx` addresses the opcode in `code.ops` so the
 /// payload (`name_idx`/`arity`/`arg_sources_idx`) is read in place instead of
 /// being marshalled through the native frame. Restores `current_code` after

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -854,11 +854,7 @@ impl Interpreter {
     /// consumer that needs the post-method map (proxy_fetch) re-snapshots the
     /// live cell on demand instead — so the common exit pays no `to_map()`
     /// (full attr-map clone) at all.
-    fn reconcile_attrs(
-        &self,
-        base: &Value,
-        code: &CompiledCode,
-    ) -> Option<HashMap<String, Value>> {
+    fn reconcile_attrs(&self, base: &Value, code: &CompiledCode) -> Option<HashMap<String, Value>> {
         let ValueView::Instance {
             attributes: cell, ..
         } = base.view()

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -17,7 +17,7 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
-    ) -> Result<(Value, HashMap<String, Value>, bool), RuntimeError> {
+    ) -> Result<(Value, Option<HashMap<String, Value>>), RuntimeError> {
         // Slice F: the rw-writeback source list is drained by the CallMethod /
         // CallMethodMut op right after this dispatch returns, so it must hold
         // only this call's sources. Clear any leftover from a sibling whose call
@@ -213,7 +213,6 @@ impl Interpreter {
                     method_name,
                     method_def,
                     cc,
-                    attributes,
                     args,
                     base,
                     compiled_fns,
@@ -649,7 +648,12 @@ impl Interpreter {
             // against the live cell + local/env writes before the env is torn
             // down. The cell-direct reads + per-op mirrors make the cell the
             // single source; the legacy attribute writeback is gone.
-            attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
+            if let Some(m) = self.reconcile_attrs(&base, cc) {
+                attributes = m;
+                attrs_adjusted = true;
+            } else {
+                attrs_adjusted = false;
+            }
 
             let method_var_bindings = self.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -673,7 +677,12 @@ impl Interpreter {
 
             // Phase 3 Stage 2: reconcile all attributes against the live cell +
             // local/env writes before the env is merged away.
-            attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
+            if let Some(m) = self.reconcile_attrs(&base, cc) {
+                attributes = m;
+                attrs_adjusted = true;
+            } else {
+                attrs_adjusted = false;
+            }
             // Callee-frame key predicate for the merge (formerly a per-call
             // materialized HashSet<String>): the method's params and locals,
             // the frame fixtures, the attribute twigil forms and sigilless
@@ -814,7 +823,7 @@ impl Interpreter {
                 }
                 _ => v,
             };
-            (adjusted, attributes, attrs_adjusted)
+            (adjusted, attrs_adjusted.then_some(attributes))
         })
     }
 
@@ -834,10 +843,11 @@ impl Interpreter {
     /// cell-direct write path does not carry that binding, so recover it from
     /// env/locals here and let it win, keeping the alias alive past method exit.
     ///
-    /// Returns `true` when the map was adjusted beyond the raw cell snapshot
-    /// (a `:=` ContainerRef was recovered). When `false`, the cell's current
-    /// contents are authoritative and `attributes` is left as the (stale) entry
-    /// snapshot — committing a snapshot back would be a no-op at best, and a
+    /// Returns `Some(map)` when the post-method attribute map was adjusted
+    /// beyond the raw cell snapshot (a `:=` ContainerRef was recovered) — the
+    /// returned map is the cell snapshot with the recovered bindings applied.
+    /// Returns `None` otherwise: the cell's current contents are authoritative
+    /// and committing a snapshot back would be a no-op at best, and a
     /// lost-update race at worst: a concurrent cell-CAS / cell-direct write
     /// from another thread between snapshot and commit would be clobbered by
     /// the stale whole-map write. Callers skip the commit then, and the rare
@@ -848,13 +858,12 @@ impl Interpreter {
         &self,
         base: &Value,
         code: &CompiledCode,
-        attributes: &mut HashMap<String, Value>,
-    ) -> bool {
+    ) -> Option<HashMap<String, Value>> {
         let ValueView::Instance {
             attributes: cell, ..
         } = base.view()
         else {
-            return false;
+            return None;
         };
         // Cheap pre-check: a `:=` attr override can only be observed as a
         // ContainerRef value in THIS frame's locals or env overlay (the bind
@@ -873,7 +882,7 @@ impl Interpreter {
                 .overlay_iter()
                 .any(|(_, v)| matches!(v.view(), ValueView::ContainerRef(_)));
         if !frame_has_container_ref {
-            return false;
+            return None;
         }
         // Scan for `:=`-bound attributes: their authoritative value is the
         // shared ContainerRef in env/locals, not the cell. Key iteration runs
@@ -910,13 +919,13 @@ impl Interpreter {
             }
         }
         if overrides.is_empty() {
-            return false;
+            return None;
         }
-        *attributes = cell.to_map();
+        let mut attributes = cell.to_map();
         for (k, v) in overrides {
             attributes.insert(k, v);
         }
-        true
+        Some(attributes)
     }
 
     /// Read the current value of `name` from the method's local slot if present,
@@ -999,7 +1008,11 @@ impl Interpreter {
 
     /// Fast path for read-only compiled methods. Bypasses all env_mut() calls
     /// to avoid the ~12μs Arc::make_mut deep clone. Populates locals directly
-    /// from source data (attributes, args, special variables).
+    /// from source data (the invocant's attribute cell, args, special
+    /// variables). Attribute reads go through `base`'s live cell (no per-call
+    /// `to_map()` snapshot — the whole-map clone dominated method-heavy
+    /// profiles); the returned map is `Some` only when the `:=` reconcile
+    /// adjusted it beyond the cell contents.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn call_compiled_method_fast(
         &mut self,
@@ -1008,12 +1021,15 @@ impl Interpreter {
         method_name: &str,
         method_def: &crate::runtime::MethodDef,
         cc: &CompiledCode,
-        mut attributes: HashMap<String, Value>,
         args: Vec<Value>,
         base: Value,
         compiled_fns: &HashMap<String, CompiledFunction>,
         can_skip_merge: bool,
-    ) -> Result<(Value, HashMap<String, Value>, bool), RuntimeError> {
+    ) -> Result<(Value, Option<HashMap<String, Value>>), RuntimeError> {
+        let attrs_cell = match base.view() {
+            ValueView::Instance { attributes, .. } => Some(attributes.clone()),
+            _ => None,
+        };
         if let Some(ref msg) = method_def.deprecated_message {
             loan_env!(
                 self,
@@ -1042,14 +1058,21 @@ impl Interpreter {
         let saved_var_bindings = self.take_var_bindings();
         self.push_method_class(owner_class.to_string());
 
-        let saved_package = self.current_package().to_string();
-        if self.has_class_scoped_subs(receiver_class_name) {
+        // Save/restore the current package only when this dispatch actually
+        // switches it (rare) — the unconditional save cloned a String per call.
+        let saved_package: Option<String> = if self.has_class_scoped_subs(receiver_class_name) {
+            let saved = self.current_package();
             self.set_current_package(receiver_class_name.to_string());
+            Some(saved)
         } else if self.class_has_package_lexicals(owner_class) {
             // The class body declared `my` statics; set current_package to the
             // owner class so a method read resolves them via package_scope_lexical.
+            let saved = self.current_package();
             self.set_current_package(owner_class.to_string());
-        }
+            Some(saved)
+        } else {
+            None
+        };
 
         // Compute role context without touching env
         let role_context: Option<String> = if self.is_role(owner_class) {
@@ -1089,7 +1112,9 @@ impl Interpreter {
                     // Type mismatch — fall back to slow path for proper error
                     self.restore_var_bindings(saved_var_bindings);
                     self.pop_method_class();
-                    self.set_current_package(saved_package);
+                    if let Some(pkg) = saved_package {
+                        self.set_current_package(pkg);
+                    }
                     self.stack.truncate(saved_stack_depth);
                     let frame = self.pop_call_frame();
                     self.set_env(frame.saved_env);
@@ -1200,57 +1225,63 @@ impl Interpreter {
         // path binds params directly, so mark `$` scalar params read-only here.
         self.mark_fast_method_params_readonly(method_def);
 
-        // Populate locals directly
+        // Populate locals directly. Attribute reads take one read guard over
+        // the live cell for the whole loop (dropped before the body runs) —
+        // no whole-map snapshot is materialized.
         self.locals = vec![Value::NIL; cc.locals.len()];
 
-        for (i, local_name) in cc.locals.iter().enumerate() {
-            self.locals[i] = match local_name.as_str() {
-                "self" | "__ANON_STATE__" => base.clone(),
-                "?CLASS" => class_val.clone(),
-                "?ROLE" => {
-                    if let Some(ref role_name) = role_context {
-                        Value::package(crate::symbol::Symbol::intern(role_name))
-                    } else {
-                        Value::NIL
-                    }
-                }
-                "!" => Value::NIL,
-                "__mutsu_callable_id" => Value::int(method_callable_id as i64),
-                name => {
-                    // Check params first (handles $_ invocant binding too)
-                    if let Some((_, val)) = param_values.iter().find(|(n, _)| *n == name) {
-                        val.clone()
-                    } else if name == "_" {
-                        any_val.clone()
-                    }
-                    // Private attribute: !attr_name
-                    else if let Some(attr_name) = name.strip_prefix('!') {
-                        let qualified_key = format!("{}\0{}", owner_class, attr_name);
-                        attributes
-                            .get(&qualified_key)
-                            .or_else(|| attributes.get(attr_name))
-                            .cloned()
-                            .unwrap_or(Value::NIL)
-                    }
-                    // Public attribute: .attr_name
-                    else if let Some(attr_name) = name.strip_prefix('.') {
-                        attributes.get(attr_name).cloned().unwrap_or(Value::NIL)
-                    }
-                    // Array/hash attributes: @!name, @.name, %!name, %.name
-                    else if ((name.starts_with("@!") || name.starts_with("@."))
-                        || (name.starts_with("%!") || name.starts_with("%.")))
-                        && name.len() > 2
-                    {
-                        attributes.get(&name[2..]).cloned().unwrap_or(Value::NIL)
-                    }
-                    // Outer env (read-only, no deep clone)
-                    else if let Some(val) = self.env().get(name) {
-                        val.clone()
-                    } else {
-                        Value::NIL
-                    }
-                }
+        {
+            let attrs_guard = attrs_cell.as_ref().map(|c| c.as_map());
+            let attr_get = |key: &str| -> Option<Value> {
+                attrs_guard.as_ref().and_then(|g| g.get(key).cloned())
             };
+            for (i, local_name) in cc.locals.iter().enumerate() {
+                self.locals[i] = match local_name.as_str() {
+                    "self" | "__ANON_STATE__" => base.clone(),
+                    "?CLASS" => class_val.clone(),
+                    "?ROLE" => {
+                        if let Some(ref role_name) = role_context {
+                            Value::package(crate::symbol::Symbol::intern(role_name))
+                        } else {
+                            Value::NIL
+                        }
+                    }
+                    "!" => Value::NIL,
+                    "__mutsu_callable_id" => Value::int(method_callable_id as i64),
+                    name => {
+                        // Check params first (handles $_ invocant binding too)
+                        if let Some((_, val)) = param_values.iter().find(|(n, _)| *n == name) {
+                            val.clone()
+                        } else if name == "_" {
+                            any_val.clone()
+                        }
+                        // Private attribute: !attr_name
+                        else if let Some(attr_name) = name.strip_prefix('!') {
+                            let qualified_key = format!("{}\0{}", owner_class, attr_name);
+                            attr_get(&qualified_key)
+                                .or_else(|| attr_get(attr_name))
+                                .unwrap_or(Value::NIL)
+                        }
+                        // Public attribute: .attr_name
+                        else if let Some(attr_name) = name.strip_prefix('.') {
+                            attr_get(attr_name).unwrap_or(Value::NIL)
+                        }
+                        // Array/hash attributes: @!name, @.name, %!name, %.name
+                        else if ((name.starts_with("@!") || name.starts_with("@."))
+                            || (name.starts_with("%!") || name.starts_with("%.")))
+                            && name.len() > 2
+                        {
+                            attr_get(&name[2..]).unwrap_or(Value::NIL)
+                        }
+                        // Outer env (read-only, no deep clone)
+                        else if let Some(val) = self.env().get(name) {
+                            val.clone()
+                        } else {
+                            Value::NIL
+                        }
+                    }
+                };
+            }
         }
 
         // Load persisted state variable values
@@ -1263,11 +1294,14 @@ impl Interpreter {
         // Register `is default(...)` values for attribute variables. Gated on
         // the program declaring ANY attribute default (see the slow path).
         let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
-        if any_attr_defaults {
-            for attr_name in attributes.keys() {
-                if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
-                    continue;
-                }
+        if any_attr_defaults && let Some(cell) = &attrs_cell {
+            let attr_names: Vec<String> = cell
+                .as_map()
+                .keys()
+                .filter(|k| !k.contains('\0') && !k.starts_with(ATTR_ALIAS_META_PREFIX))
+                .cloned()
+                .collect();
+            for attr_name in &attr_names {
                 let default_val = self
                     .class_attribute_default(owner_class, attr_name)
                     .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
@@ -1406,7 +1440,7 @@ impl Interpreter {
         }
         // Phase 3 Stage 2: reconcile all attributes against the live cell +
         // local/env writes before the env is torn down.
-        let attrs_adjusted = self.reconcile_attrs(&base, cc, &mut attributes);
+        let reconciled = self.reconcile_attrs(&base, cc);
 
         let method_var_bindings = self.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;
@@ -1417,7 +1451,9 @@ impl Interpreter {
 
         self.pop_routine();
         self.pop_method_class();
-        self.set_current_package(saved_package);
+        if let Some(pkg) = saved_package {
+            self.set_current_package(pkg);
+        }
 
         if can_skip_merge {
             // No env writes possible — just restore saved env (pure: caller
@@ -1443,7 +1479,9 @@ impl Interpreter {
                     matches!(s, "self" | "__ANON_STATE__" | "?CLASS" | "?ROLE" | "_")
                         || method_def.params.iter().any(|p| p == s)
                         || cc.locals.iter().any(|l| !l.is_empty() && l == s)
-                        || attr_twigil_local(&attributes, s)
+                        || attrs_cell
+                            .as_ref()
+                            .is_some_and(|c| attr_twigil_local(&c.as_map(), s))
                 };
                 // Own both envs (frame already popped above; take the live callee
                 // env) so the merge mutates the caller env in place, no deep copy.
@@ -1493,20 +1531,15 @@ impl Interpreter {
                     },
                     ValueView::Instance { id: ret_id, .. },
                 ) if base_id == ret_id => {
-                    if attrs_adjusted {
-                        Value::write_back_sharing(
-                            &base_attrs,
-                            class_name,
-                            attributes.clone(),
-                            base_id,
-                        )
+                    if let Some(ref m) = reconciled {
+                        Value::write_back_sharing(&base_attrs, class_name, m.clone(), base_id)
                     } else {
                         Value::instance_sharing_cell(&base_attrs, class_name, base_id)
                     }
                 }
                 _ => v,
             };
-            (adjusted, attributes, attrs_adjusted)
+            (adjusted, reconciled)
         })
     }
 }


### PR DESCRIPTION
## Summary

ADR-0004 phase **J3 (call convention / inline-cache)**. J2 measured that method-heavy chunks got *slower* under `MUTSU_JIT=on` (generic `step` shim re-enters the interpreter dispatch per opcode) and that the per-call bind/env/return-merge cost dominates method dispatch. This PR attacks both:

### JIT side
- **Dedicated `CallMethod` / `CallMethodMut` shims** (`vm_jit_helpers.rs`), same shape as J2's `call_func`: payload read in place, resume-point recording, `is rw` writeback + pending-local drain, attr-cell snapshot/mirror (Mut), `current_code` restore. Replaces the generic `step`'s per-op interpreter dispatch on the hottest re-entrant opcodes.

### Call convention (shared by interpreter + JIT)
- **Removed the per-call `attributes.to_map()` whole-map clone** from the compiled-method fast path. `call_compiled_method_fast` no longer takes a materialized attribute map: locals init reads through the invocant's live attr cell under one read guard, and `reconcile_attrs` returns `Some(map)` only when `:=` recovery adjusted it (return shape is now `(Value, Option<HashMap>)`; all 7 call sites adapted, commit-only-when-adjusted semantics unchanged). perf showed malloc/free at ~27% of the method-call profile; the whole-map clone per dispatch was the main feeder.
- **`current_package` save/restore is now conditional** on the dispatch actually switching packages (was an unconditional String clone per call).
- **`type_matches_value` fast accept**: a concrete tag/class exact match (`Int` arg for `Int $n`, `Point` instance for `Point $other`) returns true immediately, gated on the subset registry so a user `subset` shadowing the name still runs the full checker.
- **`CallFunc` name Symbol memoized** via the per-chunk `const_sym` table (was up to 4 global intern hash lookups per call).

## Measurements (release, perf stat -r5, taskset 0-3, same quiet window, 10-20x scaled benches)

| bench (scaled) | main off | J3 off | J3 on |
|---|---|---|---|
| method-call | 3.70s | 3.67s | **3.56s** |
| bench-class | 1.84s | 1.88s | 1.88s |
| bench-fib | 2.63s | 2.49s | **2.30s** |

- method-call: JIT on was **-6% vs off** after J2; now **+3%** (and +3.9% vs main).
- bench-fib: +5.4% interpreter-side, **+12.5%** with JIT on vs main.
- bench-class: within binary-layout noise (±2%).

JIT→JIT direct calls already flow through the light-call caches + `try_enter` at the callee; inlining the per-call bind itself is J4 (Tier B) territory.

## Validation

- `t/` full suite green under `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2` **and** default JIT-off (known `io-socket-recv-limit.t` -j4 flake only; passes standalone in both modes).
- **Full roast whitelist (1384 files) green** with `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2` on the release build.
- JIT on/off differential output identical on all benchmarks.
- cargo clippy -D warnings / cargo fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWpYJdKBYbT9fnimevhpQT