### PR TITLE
perf(vm): JIT J4a — Tier B inline arithmetic (NaN-box tag-dispatched Int/Num fast paths, ADR-0004 J4)

### DIFF
--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -494,6 +494,7 @@ impl Interpreter {
     ) -> Result<SubRegisterOutcome, RuntimeError> {
         if name.starts_with("infix:<") {
             self.user_declared_infix_ops.insert(name.to_string());
+            crate::vm::vm_jit::note_user_infix_decl();
         }
         let is_method_value_decl = custom_traits
             .iter()
@@ -1119,6 +1120,7 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         if name.starts_with("infix:<") {
             self.user_declared_infix_ops.insert(name.to_string());
+            crate::vm::vm_jit::note_user_infix_decl();
         }
         Self::validate_callable_param_return_redeclaration(param_defs)?;
         if let Some(spec) = return_type

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -230,6 +230,7 @@ impl Interpreter {
             }
             if name.starts_with("infix:<") {
                 self.user_declared_infix_ops.insert(name.clone());
+                crate::vm::vm_jit::note_user_infix_decl();
             }
             let source_single = format!("{module}::{name}");
             let source_prefix = format!("{module}::{name}/");

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -291,6 +291,8 @@ mod guards;
 /// NaN-boxed 8-byte representation core (3b-1 step B): the packed word that
 /// IS the `Value` storage. The only module that knows the bit layout.
 mod nanbox;
+#[cfg(feature = "jit")]
+pub(crate) use nanbox::jit_words;
 mod serde_support;
 pub(crate) mod signature;
 pub(crate) mod types;
@@ -979,6 +981,16 @@ impl std::fmt::Debug for Value {
     /// the packed word).
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+/// Raw NaN-box word access for the JIT Tier B inline emitter (see
+/// [`jit_words`]). Read-only: exposing the bits does not breach the newtype
+/// seal's ownership rules (the word still owns its payload reference).
+#[cfg(feature = "jit")]
+impl Value {
+    pub(crate) fn nanbox_bits(&self) -> u64 {
+        self.0.bits()
     }
 }
 

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -453,6 +453,62 @@ unsafe fn payload_op(kind: Kind, bits: u64, op: PayloadOp) {
     }
 }
 
+// ---- JIT Tier B raw-word exports ------------------------------------------------
+
+/// Word-level constants and probes for the Cranelift Tier B inline emitter
+/// (`vm/vm_jit_tier_b.rs`), which manipulates NaN-box words directly in
+/// native code (ADR-0004 §2.3 Tier B). This is the ONLY bit-layout knowledge
+/// exported outside `crate::value`; every item is derived from the layout
+/// constants above, so a layout change flows into the JIT automatically.
+#[cfg(feature = "jit")]
+pub(crate) mod jit_words {
+    use super::*;
+
+    /// `word >> PAGE_SHIFT` is the 16-bit page.
+    pub(crate) const PAGE_SHIFT: u32 = TAG_SHIFT;
+    /// Page of inline small Ints (48-bit two's complement payload).
+    pub(crate) const INT_PAGE: u64 = super::INT_PAGE;
+    /// Subtracted from an encoded Num word to recover `f64::to_bits`.
+    pub(crate) const DOUBLE_OFFSET: u64 = super::DOUBLE_OFFSET;
+    /// Encoded doubles span pages `NUM_PAGE_MIN..=NUM_PAGE_MAX`.
+    pub(crate) const NUM_PAGE_MIN: u64 = 0x0002;
+    pub(crate) const NUM_PAGE_MAX: u64 = 0xFFF2;
+    pub(crate) const PAYLOAD48_MASK: u64 = super::PAYLOAD48_MASK;
+
+    /// Full-word constants for the payload-free singletons.
+    pub(crate) const TRUE_BITS: u64 = pack_inline(Kind::Bool, 1).get();
+    pub(crate) const FALSE_BITS: u64 = pack_inline(Kind::Bool, 0).get();
+    /// The encoded word of the canonical quiet NaN (every packed NaN
+    /// collapses to this — the Tier B float-arith fast path selects it
+    /// whenever a native float op produces any NaN).
+    pub(crate) const NUM_CANONICAL_NAN_WORD: u64 = CANONICAL_NAN.wrapping_add(DOUBLE_OFFSET);
+
+    /// Kind probe: `word & KIND_MASK == <kind pattern>` ⟺ the word is that
+    /// exact kind (page bits + subkind bits, payload ignored).
+    pub(crate) const KIND_MASK: u64 = (0xFFFF << TAG_SHIFT) | SUB_MASK;
+    /// `Kind::Pair` probe pattern (for the `ContainerizePair` fast skip).
+    pub(crate) const PAIR_PATTERN: u64 = word_for_kind(Kind::Pair, 0).get();
+
+    /// True when duplicating/discarding this word needs no refcount or GC
+    /// bookkeeping: small Int, Num, or a payload-free inline kind. The Tier B
+    /// `LoadConst` emitter inlines the push of such a constant as a raw
+    /// immediate store.
+    pub(crate) fn is_refcount_free(bits: u64) -> bool {
+        match classify(bits) {
+            Classified::Int(_) | Classified::Num(_) => true,
+            Classified::Kind(k) => matches!(
+                k,
+                Kind::Nil
+                    | Kind::Whatever
+                    | Kind::HyperWhatever
+                    | Kind::Bool
+                    | Kind::Package
+                    | Kind::CompUnitDepSpec
+            ),
+        }
+    }
+}
+
 // ---- NanBox --------------------------------------------------------------------
 
 /// The packed 8-byte value word. Owns one reference of any pointer payload.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -178,6 +178,14 @@ pub(crate) mod vm_jit;
 mod vm_jit_compile;
 #[cfg(feature = "jit")]
 mod vm_jit_helpers;
+#[cfg(feature = "jit")]
+mod vm_jit_layout;
+#[cfg(feature = "jit")]
+mod vm_jit_support;
+#[cfg(feature = "jit")]
+mod vm_jit_tier_b;
+#[cfg(feature = "jit")]
+mod vm_jit_tier_b_flow;
 mod vm_loop_cstyle_repeat;
 mod vm_loop_writeback;
 mod vm_loop_writeback_quant;

--- a/src/vm/vm_jit.rs
+++ b/src/vm/vm_jit.rs
@@ -25,6 +25,24 @@ pub(crate) const JIT_STATUS_HALT: u32 = 2;
 /// any other value is the native entry pointer.
 pub(crate) const JIT_ENTRY_BAILOUT: u64 = 1;
 
+/// Process-wide, monotonic count of user-declared infix operator
+/// registrations (`sub infix:<+> ...` and module-exported infix ops). The
+/// Tier B inline `Add` fast path (vm_jit_tier_b.rs) loads this word and
+/// requires it to be zero: a per-interpreter `user_declared_infix_ops` set
+/// can only be non-empty after some registration bumped this counter, so
+/// zero proves no override exists anywhere and nonzero conservatively routes
+/// every inline fast path through the helper (which re-checks precisely).
+/// Never decremented — save/restore sites that shrink a set leave the
+/// counter high, which only costs speed, never correctness.
+pub(crate) static USER_INFIX_DECLS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Record one user infix-operator registration (see `USER_INFIX_DECLS`).
+#[inline]
+pub(crate) fn note_user_infix_decl() {
+    USER_INFIX_DECLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// Native entry signature: `(interp, code, compiled_fns) -> status`.
 #[cfg(feature = "jit")]
 pub(crate) type JitEntryFn = unsafe extern "C" fn(

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -9,6 +9,8 @@
 
 use super::vm_jit::JitEntryFn;
 use super::vm_jit_helpers as helpers;
+use super::vm_jit_support::{noarg_shim, step_supported};
+use super::vm_jit_tier_b::{IntArith, NumCmp, TierB};
 use super::*;
 
 use cranelift_codegen::ir::{AbiParam, Block, InstBuilder, SigRef, Type, types};
@@ -33,134 +35,6 @@ struct Engine {
 unsafe impl Send for Engine {}
 
 static ENGINE: Mutex<Option<Engine>> = Mutex::new(None);
-
-/// Payload-free fallible opcodes with a dedicated `(interp) -> status` shim
-/// (the hot arith / compare / string family, plus `Return`). Returns the shim
-/// address for emission, `None` when the opcode is not in this family.
-fn noarg_shim(op: &OpCode) -> Option<usize> {
-    let f: unsafe extern "C" fn(*mut Interpreter) -> u32 = match op {
-        OpCode::Add => helpers::add,
-        OpCode::Sub => helpers::sub,
-        OpCode::Mul => helpers::mul,
-        OpCode::Div => helpers::div,
-        OpCode::Mod => helpers::modulo,
-        OpCode::Pow => helpers::pow,
-        OpCode::Negate => helpers::negate,
-        OpCode::NumLt => helpers::num_lt,
-        OpCode::NumLe => helpers::num_le,
-        OpCode::NumGt => helpers::num_gt,
-        OpCode::NumGe => helpers::num_ge,
-        OpCode::NumEq => helpers::num_eq,
-        OpCode::NumNe => helpers::num_ne,
-        OpCode::Concat => helpers::concat,
-        OpCode::StrEq => helpers::str_eq,
-        OpCode::StrNe => helpers::str_ne,
-        OpCode::Return => helpers::ret,
-        _ => return None,
-    };
-    Some(f as *const () as usize)
-}
-
-/// Straight-line opcodes without a dedicated shim, executed through the
-/// generic `helpers::step` (one interpreter dispatch per opcode). Every entry
-/// is verified against its `exec_one` arm to unconditionally leave
-/// `ip == start + 1` on Ok — no jumps, no compound-loop bodies, no arms that
-/// consult or rewrite `ip` beyond the increment. Anything not provably
-/// straight-line stays OFF this list and bails the chunk out.
-fn step_supported(op: &OpCode) -> bool {
-    matches!(
-        op,
-        // Constants / stack shape
-        OpCode::LoadNil
-            | OpCode::LoadTrue
-            | OpCode::LoadFalse
-            | OpCode::Dup
-            | OpCode::Pop
-            // Variable reads
-            | OpCode::GetGlobal(_)
-            | OpCode::GetOurVar(_)
-            | OpCode::GetArrayVar(_)
-            | OpCode::GetHashVar(_)
-            | OpCode::GetBareWord(_)
-            | OpCode::GetCaptureVar(_)
-            | OpCode::GetCodeVar(_)
-            | OpCode::GetSelfOrNoSelf(_)
-            | OpCode::GetUpvalue { .. }
-            // Variable writes / declarations
-            | OpCode::SetGlobal(_)
-            | OpCode::SetGlobalRaw(_)
-            | OpCode::SetVarDynamic { .. }
-            | OpCode::SetVarType { .. }
-            | OpCode::AssignExpr(_)
-            | OpCode::TopicDotAssign(_)
-            | OpCode::AtomicCompoundVar { .. }
-            | OpCode::IndexAssignExprNamed { .. }
-            | OpCode::WrapVarRef(_)
-            | OpCode::LetSave { .. }
-            | OpCode::CheckReadOnly(_)
-            | OpCode::MarkVarReadonly(_)
-            | OpCode::CheckDynamicVarDeclared(_)
-            // Increment / decrement
-            | OpCode::PostIncrement(..)
-            | OpCode::PostDecrement(..)
-            | OpCode::PreIncrement(..)
-            | OpCode::PreDecrement(..)
-            | OpCode::PreIncrementIndex(_)
-            | OpCode::PreDecrementIndex(_)
-            // Arith predicates
-            | OpCode::DivisibleBy
-            | OpCode::NotDivisibleBy
-            // Closure construction
-            | OpCode::MakeLambda(..)
-            | OpCode::MakeAnonSub(..)
-            | OpCode::MakeAnonSubParams(..)
-            | OpCode::MakeGather(..)
-            // Calls through a code variable (re-entrant, like CallMethod)
-            | OpCode::CallOnCodeVar { .. }
-            | OpCode::ExecCallPairs { .. }
-            // In-place container mutation
-            | OpCode::ArrayPush { .. }
-            | OpCode::TagContainerRef(..)
-            | OpCode::TagContainerRefReversed(..)
-            | OpCode::MarkAccessorRefContext
-            // List / hash construction, indexing and coercion
-            | OpCode::MakeArray(_)
-            | OpCode::MakeRealArray(_)
-            | OpCode::MakeRealArrayNoFlatten(_)
-            | OpCode::MakeHash(_)
-            | OpCode::MakePair
-            | OpCode::CoerceToList
-            | OpCode::Itemize
-            | OpCode::DeitemizeZen
-            | OpCode::Decont
-            | OpCode::Index { .. }
-            | OpCode::IndexAutovivifyLazy
-            // String / bool / numeric helpers
-            | OpCode::StringConcat(_)
-            | OpCode::StrCoerce
-            | OpCode::BoolCoerce
-            | OpCode::Not
-            | OpCode::Gcd
-            | OpCode::Lcm
-            | OpCode::IntDiv
-            | OpCode::IntMod
-            | OpCode::NumCoerce
-            // Sink context (forces lazies / throws unhandled Failures)
-            | OpCode::SinkPop(_)
-            // Topic / context markers
-            | OpCode::MarkBindContext
-            | OpCode::MarkVarDeclContext
-            | OpCode::MarkExplicitInitializerContext
-            | OpCode::MarkShapedDeclContext
-            | OpCode::SetTopic
-            | OpCode::SaveTopic
-            | OpCode::RestoreTopic
-            | OpCode::PushEnterResult
-            | OpCode::LoadEnterResult
-            // Always-throwing terminator (records its own resume point)
-            | OpCode::Die
-    )
-}
 
 /// Compile `code` to a native Tier A body. `None` = bailout (unsupported
 /// opcode, or an internal Cranelift failure): the caller marks the chunk so
@@ -274,6 +148,22 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
     let codep = b.block_params(entry)[1];
     let fnsp = b.block_params(entry)[2];
 
+    // Tier B inline emitter (ADR-0004 J4): available when the stack layout
+    // probe succeeded on this target. `None` degrades every opcode below to
+    // its Tier A helper-call form.
+    let tier_b = if ptr == types::I64 {
+        super::vm_jit_layout::layout().map(|lay| TierB {
+            interp,
+            ptr_ty: ptr,
+            lay,
+            s1: sigs.s1,
+            v1: sigs.v1,
+            v_code_u32: sigs.v_code_u32,
+        })
+    } else {
+        None
+    };
+
     let block_at: std::collections::HashMap<usize, Block> =
         targets.iter().map(|t| (*t, b.create_block())).collect();
 
@@ -315,30 +205,92 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
         }
         match op {
             OpCode::LoadConst(idx) => {
-                let idxv = b.ins().iconst(types::I32, *idx as i64);
-                call_helper(
-                    &mut b,
-                    sigs.v_code_u32,
-                    helpers::load_const as *const () as usize,
-                    &[interp, codep, idxv],
-                );
+                let word = code.constants[*idx as usize].nanbox_bits();
+                if let Some(tb) = &tier_b
+                    && crate::value::jit_words::is_refcount_free(word)
+                {
+                    tb.emit_load_const(
+                        &mut b,
+                        word,
+                        codep,
+                        *idx,
+                        helpers::load_const as *const () as usize,
+                    );
+                } else {
+                    let idxv = b.ins().iconst(types::I32, *idx as i64);
+                    call_helper(
+                        &mut b,
+                        sigs.v_code_u32,
+                        helpers::load_const as *const () as usize,
+                        &[interp, codep, idxv],
+                    );
+                }
             }
             OpCode::SetSourceLine(line) => {
-                let linev = b.ins().iconst(types::I64, *line);
-                call_helper(
-                    &mut b,
-                    sigs.v_i64,
-                    helpers::set_source_line as *const () as usize,
-                    &[interp, linev],
-                );
+                if let Some(tb) = &tier_b {
+                    tb.emit_set_source_line(&mut b, *line);
+                } else {
+                    let linev = b.ins().iconst(types::I64, *line);
+                    call_helper(
+                        &mut b,
+                        sigs.v_i64,
+                        helpers::set_source_line as *const () as usize,
+                        &[interp, linev],
+                    );
+                }
             }
             OpCode::ContainerizePair => {
-                call_helper(
-                    &mut b,
-                    sigs.v1,
-                    helpers::containerize_pair as *const () as usize,
-                    &[interp],
-                );
+                if let Some(tb) = &tier_b {
+                    tb.emit_containerize_pair(
+                        &mut b,
+                        helpers::containerize_pair as *const () as usize,
+                    );
+                } else {
+                    call_helper(
+                        &mut b,
+                        sigs.v1,
+                        helpers::containerize_pair as *const () as usize,
+                        &[interp],
+                    );
+                }
+            }
+            // Tier B inline arithmetic / comparison (Int and Num fast paths
+            // in native code; everything else through the Tier A shim).
+            OpCode::Add if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_int_num_arith(&mut b, IntArith::Add, helpers::add as *const () as usize);
+            }
+            OpCode::Sub if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_int_num_arith(&mut b, IntArith::Sub, helpers::sub as *const () as usize);
+            }
+            OpCode::Mul if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_int_num_arith(&mut b, IntArith::Mul, helpers::mul as *const () as usize);
+            }
+            OpCode::NumLt if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_compare(&mut b, NumCmp::Lt, helpers::num_lt as *const () as usize);
+            }
+            OpCode::NumLe if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_compare(&mut b, NumCmp::Le, helpers::num_le as *const () as usize);
+            }
+            OpCode::NumGt if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_compare(&mut b, NumCmp::Gt, helpers::num_gt as *const () as usize);
+            }
+            OpCode::NumGe if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_compare(&mut b, NumCmp::Ge, helpers::num_ge as *const () as usize);
+            }
+            OpCode::NumEq if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_compare(&mut b, NumCmp::Eq, helpers::num_eq as *const () as usize);
+            }
+            OpCode::NumNe if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_compare(&mut b, NumCmp::Ne, helpers::num_ne as *const () as usize);
             }
             OpCode::GetLocal(idx) => {
                 let idxv = b.ins().iconst(types::I32, *idx as i64);
@@ -394,6 +346,29 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
                 }
                 b.ins().jump(block_at[&t], &[]);
                 open = false;
+            }
+            OpCode::JumpIfFalse(t) if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                let t = *t as usize;
+                tb.emit_jump_if_false(
+                    &mut b,
+                    block_at[&t],
+                    t <= i,
+                    helpers::safepoint as *const () as usize,
+                    helpers::mark_failure_top as *const () as usize,
+                    helpers::jump_if_false_cond as *const () as usize,
+                );
+            }
+            OpCode::JumpIfTrue(t) if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                let t = *t as usize;
+                tb.emit_jump_if_true(
+                    &mut b,
+                    block_at[&t],
+                    t <= i,
+                    helpers::safepoint as *const () as usize,
+                    helpers::jump_if_true_cond as *const () as usize,
+                );
             }
             OpCode::JumpIfFalse(t) | OpCode::JumpIfTrue(t) | OpCode::JumpIfNotNil(t) => {
                 // Conditional branch: the cond helper returns 1 when the jump

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -49,6 +49,14 @@ pub(super) unsafe extern "C" fn safepoint(_interp: *mut Interpreter) {
     crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
 }
 
+/// Mark a `Failure` at the current top of stack as handled. The Tier B
+/// `JumpIfFalse` fast path calls this on the branch-taken path only,
+/// mirroring the interpreter arm's post-pop `mark_failure_handled_on_stack`.
+pub(super) unsafe extern "C" fn mark_failure_top(interp: *mut Interpreter) {
+    let interp = unsafe { &mut *interp };
+    Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
+}
+
 /// Park `e` in the interpreter's JIT error slot and report error status.
 #[inline]
 fn park_err(interp: &mut Interpreter, e: RuntimeError) -> u32 {

--- a/src/vm/vm_jit_layout.rs
+++ b/src/vm/vm_jit_layout.rs
@@ -1,0 +1,89 @@
+//! Runtime-discovered memory layout facts for the Tier B inline emitter
+//! (ADR-0004 §2.3 Tier B).
+//!
+//! Tier B native code manipulates the VM value stack (`Interpreter::stack`,
+//! a `Vec<Value>`) directly: it loads the data pointer / length words, reads
+//! and writes 8-byte NaN-box value words in place, and adjusts the length.
+//! `Interpreter` field offsets come from `offset_of!`; `Vec`'s internal field
+//! order is unspecified by Rust, so it is probed once per process from a live
+//! vector and self-verified. If the probe cannot pin all three words (an
+//! exotic future `Vec` layout), Tier B inlining is disabled and every opcode
+//! falls back to the Tier A helper-call form — never wrong, only slower.
+
+use super::*;
+
+pub(super) struct JitLayout {
+    /// Byte offset of `Interpreter::stack` (a `Vec<Value>`).
+    pub(super) stack: i32,
+    /// Byte offset of `Interpreter::cur_source_line` (an `i64`).
+    pub(super) cur_source_line: i32,
+    /// Byte offsets of the data pointer / length / capacity words inside
+    /// `Vec<Value>` (relative to the start of the `Vec`).
+    pub(super) vec_ptr: i32,
+    pub(super) vec_len: i32,
+    pub(super) vec_cap: i32,
+}
+
+/// Identify where `Vec<Value>`'s (ptr, len, cap) words live by building a
+/// vector whose three words are pairwise distinct and matching each by value.
+fn probe_vec_layout() -> Option<(i32, i32, i32)> {
+    const WORD: usize = std::mem::size_of::<usize>();
+    const {
+        assert!(std::mem::size_of::<Vec<Value>>() == 3 * WORD);
+    }
+    let mut v: Vec<Value> = Vec::with_capacity(7);
+    v.push(Value::int(1));
+    v.push(Value::int(2));
+    v.push(Value::int(3));
+    let data_ptr = v.as_ptr() as usize;
+    // SAFETY: plain read of the Vec's own 3-word header (no aliasing, no
+    // mutation); interpreting the words is what the value-matching below is
+    // for, and any mismatch returns None instead of guessing.
+    let words: [usize; 3] = unsafe { std::mem::transmute_copy(&v) };
+    let (mut ptr_off, mut len_off, mut cap_off) = (None, None, None);
+    for (i, w) in words.iter().enumerate() {
+        let off = (i * WORD) as i32;
+        if *w == data_ptr {
+            ptr_off = Some(off);
+        } else if *w == 3 {
+            len_off = Some(off);
+        } else if *w == 7 {
+            cap_off = Some(off);
+        }
+    }
+    Some((ptr_off?, len_off?, cap_off?))
+}
+
+/// The process-wide layout table, or `None` when Tier B must stay disabled.
+pub(super) fn layout() -> Option<&'static JitLayout> {
+    static LAYOUT: std::sync::OnceLock<Option<JitLayout>> = std::sync::OnceLock::new();
+    LAYOUT
+        .get_or_init(|| {
+            let (vec_ptr, vec_len, vec_cap) = probe_vec_layout()?;
+            Some(JitLayout {
+                stack: std::mem::offset_of!(Interpreter, stack) as i32,
+                cur_source_line: std::mem::offset_of!(Interpreter, cur_source_line) as i32,
+                vec_ptr,
+                vec_len,
+                vec_cap,
+            })
+        })
+        .as_ref()
+}
+
+#[cfg(test)]
+mod tests {
+    /// The probe must succeed on the running std: Tier B silently degrading
+    /// to helper calls on a mainstream toolchain would be a perf regression
+    /// nobody notices, so pin it.
+    #[test]
+    fn vec_layout_probe_resolves() {
+        let l = super::layout().expect("Vec<Value> layout probe failed");
+        let offs = [l.vec_ptr, l.vec_len, l.vec_cap];
+        for o in offs {
+            assert!(o >= 0 && o <= 16 && o % 8 == 0, "weird offset {o}");
+        }
+        assert_ne!(l.vec_ptr, l.vec_len);
+        assert_ne!(l.vec_len, l.vec_cap);
+    }
+}

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -1,0 +1,136 @@
+//! Tier A opcode support tables (ADR-0004 §2.3): which opcodes the JIT can
+//! translate, and through which shim. Split out of `vm_jit_compile.rs` purely
+//! by size; the acceptance rules are unchanged — a chunk containing any
+//! opcode outside these tables (and the explicit arms in `compile_chunk`)
+//! bails out and stays on the interpreter forever.
+
+use super::vm_jit_helpers as helpers;
+use super::*;
+
+/// Payload-free fallible opcodes with a dedicated `(interp) -> status` shim
+/// (the hot arith / compare / string family, plus `Return`). Returns the shim
+/// address for emission, `None` when the opcode is not in this family.
+pub(super) fn noarg_shim(op: &OpCode) -> Option<usize> {
+    let f: unsafe extern "C" fn(*mut Interpreter) -> u32 = match op {
+        OpCode::Add => helpers::add,
+        OpCode::Sub => helpers::sub,
+        OpCode::Mul => helpers::mul,
+        OpCode::Div => helpers::div,
+        OpCode::Mod => helpers::modulo,
+        OpCode::Pow => helpers::pow,
+        OpCode::Negate => helpers::negate,
+        OpCode::NumLt => helpers::num_lt,
+        OpCode::NumLe => helpers::num_le,
+        OpCode::NumGt => helpers::num_gt,
+        OpCode::NumGe => helpers::num_ge,
+        OpCode::NumEq => helpers::num_eq,
+        OpCode::NumNe => helpers::num_ne,
+        OpCode::Concat => helpers::concat,
+        OpCode::StrEq => helpers::str_eq,
+        OpCode::StrNe => helpers::str_ne,
+        OpCode::Return => helpers::ret,
+        _ => return None,
+    };
+    Some(f as *const () as usize)
+}
+
+/// Straight-line opcodes without a dedicated shim, executed through the
+/// generic `helpers::step` (one interpreter dispatch per opcode). Every entry
+/// is verified against its `exec_one` arm to unconditionally leave
+/// `ip == start + 1` on Ok — no jumps, no compound-loop bodies, no arms that
+/// consult or rewrite `ip` beyond the increment. Anything not provably
+/// straight-line stays OFF this list and bails the chunk out.
+pub(super) fn step_supported(op: &OpCode) -> bool {
+    matches!(
+        op,
+        // Constants / stack shape
+        OpCode::LoadNil
+            | OpCode::LoadTrue
+            | OpCode::LoadFalse
+            | OpCode::Dup
+            | OpCode::Pop
+            // Variable reads
+            | OpCode::GetGlobal(_)
+            | OpCode::GetOurVar(_)
+            | OpCode::GetArrayVar(_)
+            | OpCode::GetHashVar(_)
+            | OpCode::GetBareWord(_)
+            | OpCode::GetCaptureVar(_)
+            | OpCode::GetCodeVar(_)
+            | OpCode::GetSelfOrNoSelf(_)
+            | OpCode::GetUpvalue { .. }
+            // Variable writes / declarations
+            | OpCode::SetGlobal(_)
+            | OpCode::SetGlobalRaw(_)
+            | OpCode::SetVarDynamic { .. }
+            | OpCode::SetVarType { .. }
+            | OpCode::AssignExpr(_)
+            | OpCode::TopicDotAssign(_)
+            | OpCode::AtomicCompoundVar { .. }
+            | OpCode::IndexAssignExprNamed { .. }
+            | OpCode::WrapVarRef(_)
+            | OpCode::LetSave { .. }
+            | OpCode::CheckReadOnly(_)
+            | OpCode::MarkVarReadonly(_)
+            | OpCode::CheckDynamicVarDeclared(_)
+            // Increment / decrement
+            | OpCode::PostIncrement(..)
+            | OpCode::PostDecrement(..)
+            | OpCode::PreIncrement(..)
+            | OpCode::PreDecrement(..)
+            | OpCode::PreIncrementIndex(_)
+            | OpCode::PreDecrementIndex(_)
+            // Arith predicates
+            | OpCode::DivisibleBy
+            | OpCode::NotDivisibleBy
+            // Closure construction
+            | OpCode::MakeLambda(..)
+            | OpCode::MakeAnonSub(..)
+            | OpCode::MakeAnonSubParams(..)
+            | OpCode::MakeGather(..)
+            // Calls through a code variable (re-entrant, like CallMethod)
+            | OpCode::CallOnCodeVar { .. }
+            | OpCode::ExecCallPairs { .. }
+            // In-place container mutation
+            | OpCode::ArrayPush { .. }
+            | OpCode::TagContainerRef(..)
+            | OpCode::TagContainerRefReversed(..)
+            | OpCode::MarkAccessorRefContext
+            // List / hash construction, indexing and coercion
+            | OpCode::MakeArray(_)
+            | OpCode::MakeRealArray(_)
+            | OpCode::MakeRealArrayNoFlatten(_)
+            | OpCode::MakeHash(_)
+            | OpCode::MakePair
+            | OpCode::CoerceToList
+            | OpCode::Itemize
+            | OpCode::DeitemizeZen
+            | OpCode::Decont
+            | OpCode::Index { .. }
+            | OpCode::IndexAutovivifyLazy
+            // String / bool / numeric helpers
+            | OpCode::StringConcat(_)
+            | OpCode::StrCoerce
+            | OpCode::BoolCoerce
+            | OpCode::Not
+            | OpCode::Gcd
+            | OpCode::Lcm
+            | OpCode::IntDiv
+            | OpCode::IntMod
+            | OpCode::NumCoerce
+            // Sink context (forces lazies / throws unhandled Failures)
+            | OpCode::SinkPop(_)
+            // Topic / context markers
+            | OpCode::MarkBindContext
+            | OpCode::MarkVarDeclContext
+            | OpCode::MarkExplicitInitializerContext
+            | OpCode::MarkShapedDeclContext
+            | OpCode::SetTopic
+            | OpCode::SaveTopic
+            | OpCode::RestoreTopic
+            | OpCode::PushEnterResult
+            | OpCode::LoadEnterResult
+            // Always-throwing terminator (records its own resume point)
+            | OpCode::Die
+    )
+}

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -1,0 +1,436 @@
+//! Tier B inline emission (ADR-0004 §2.3, J4): NaN-box tag-dispatched fast
+//! paths compiled directly into the CLIF body, with the Tier A helper shim as
+//! the slow path.
+//!
+//! Values on the VM stack are 8-byte NaN-box words (`docs/nanbox-3b1-step-b`
+//! layout, exported to this module through `crate::value::jit_words`). The
+//! emitted fast paths cover exactly the type combinations the interpreter's
+//! own `exec_*_op` fast paths cover — small Int (+ small Int) and Num (+ Num)
+//! — and route every other word shape (boxed Int, BigInt, Rat, Junction,
+//! overloaded operators, ...) to the unchanged Tier A shim, which re-runs the
+//! full interpreter arm on the still-untouched stack. Small Int and Num words
+//! carry no payload ownership, so the inline paths move raw bits with **zero
+//! refcount or GC traffic** (the ADR-0004 J4 gate).
+//!
+//! Stack access: the data pointer / length words of `Interpreter::stack` are
+//! loaded through offsets discovered by `vm_jit_layout` — reloaded at each
+//! opcode (never cached across a helper call, which may reallocate the Vec).
+
+use super::vm_jit_layout::JitLayout;
+use crate::value::jit_words as w;
+use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
+use cranelift_codegen::ir::{InstBuilder, MemFlags, SigRef, Type, types};
+use cranelift_frontend::FunctionBuilder;
+
+type CVal = cranelift_codegen::ir::Value;
+
+#[derive(Clone, Copy)]
+pub(super) enum IntArith {
+    Add,
+    Sub,
+    Mul,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum NumCmp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+pub(super) struct TierB {
+    pub(super) interp: CVal,
+    pub(super) ptr_ty: Type,
+    pub(super) lay: &'static JitLayout,
+    /// `(interp) -> i32` — fallible slow-path shims.
+    pub(super) s1: SigRef,
+    /// `(interp) -> ()` — infallible helpers.
+    pub(super) v1: SigRef,
+    /// `(interp, code, u32) -> ()` — the `load_const` slow path.
+    pub(super) v_code_u32: SigRef,
+}
+
+impl TierB {
+    #[inline]
+    pub(super) fn mf() -> MemFlags {
+        MemFlags::trusted()
+    }
+
+    pub(super) fn stack_ptr(&self, b: &mut FunctionBuilder) -> CVal {
+        b.ins().load(
+            self.ptr_ty,
+            Self::mf(),
+            self.interp,
+            self.lay.stack + self.lay.vec_ptr,
+        )
+    }
+
+    pub(super) fn stack_len(&self, b: &mut FunctionBuilder) -> CVal {
+        b.ins().load(
+            types::I64,
+            Self::mf(),
+            self.interp,
+            self.lay.stack + self.lay.vec_len,
+        )
+    }
+
+    fn stack_cap(&self, b: &mut FunctionBuilder) -> CVal {
+        b.ins().load(
+            types::I64,
+            Self::mf(),
+            self.interp,
+            self.lay.stack + self.lay.vec_cap,
+        )
+    }
+
+    /// Address of the stack slot `back` entries below the top (`back` = 1 is
+    /// the top of the stack): `ptr + (len - back) * 8`.
+    pub(super) fn slot_addr(
+        &self,
+        b: &mut FunctionBuilder,
+        ptr: CVal,
+        len: CVal,
+        back: i64,
+    ) -> CVal {
+        let idx = b.ins().iadd_imm(len, -back);
+        let off = b.ins().ishl_imm(idx, 3);
+        b.ins().iadd(ptr, off)
+    }
+
+    /// Store `len + delta` back into the stack's length word.
+    pub(super) fn adjust_len(&self, b: &mut FunctionBuilder, len: CVal, delta: i64) {
+        let new_len = b.ins().iadd_imm(len, delta);
+        b.ins().store(
+            Self::mf(),
+            new_len,
+            self.interp,
+            self.lay.stack + self.lay.vec_len,
+        );
+    }
+
+    /// `word >> 48` — the 16-bit page.
+    fn page(&self, b: &mut FunctionBuilder, word: CVal) -> CVal {
+        b.ins().ushr_imm(word, w::PAGE_SHIFT as i64)
+    }
+
+    /// `page == INT_PAGE` (small inline Int; boxed Ints go slow-path).
+    fn is_int_page(&self, b: &mut FunctionBuilder, page: CVal) -> CVal {
+        b.ins().icmp_imm(IntCC::Equal, page, w::INT_PAGE as i64)
+    }
+
+    /// `NUM_PAGE_MIN <= page <= NUM_PAGE_MAX` (encoded f64).
+    fn is_num_page(&self, b: &mut FunctionBuilder, page: CVal) -> CVal {
+        let shifted = b.ins().iadd_imm(page, -(w::NUM_PAGE_MIN as i64));
+        b.ins().icmp_imm(
+            IntCC::UnsignedLessThanOrEqual,
+            shifted,
+            (w::NUM_PAGE_MAX - w::NUM_PAGE_MIN) as i64,
+        )
+    }
+
+    /// Sign-extend the 48-bit Int payload to i64.
+    fn sx48(&self, b: &mut FunctionBuilder, word: CVal) -> CVal {
+        let hi = b.ins().ishl_imm(word, 16);
+        b.ins().sshr_imm(hi, 16)
+    }
+
+    /// Pack an in-range i64 back into a small-Int word.
+    fn pack_int(&self, b: &mut FunctionBuilder, v: CVal) -> CVal {
+        let payload = b.ins().band_imm(v, w::PAYLOAD48_MASK as i64);
+        b.ins()
+            .bor_imm(payload, (w::INT_PAGE << w::PAGE_SHIFT) as i64)
+    }
+
+    /// Decode an encoded Num word to an f64 SSA value.
+    fn decode_num(&self, b: &mut FunctionBuilder, word: CVal) -> CVal {
+        let bits = b.ins().iadd_imm(word, -(w::DOUBLE_OFFSET as i64));
+        b.ins().bitcast(types::F64, MemFlags::new(), bits)
+    }
+
+    /// Encode an f64 SSA value to a Num word (NaN collapsed to the canonical
+    /// quiet-NaN word, exactly like `Value::num`).
+    fn encode_num(&self, b: &mut FunctionBuilder, f: CVal) -> CVal {
+        let bits = b.ins().bitcast(types::I64, MemFlags::new(), f);
+        let word = b.ins().iadd_imm(bits, w::DOUBLE_OFFSET as i64);
+        let not_nan = b.ins().fcmp(FloatCC::Equal, f, f);
+        let nan_word = b.ins().iconst(types::I64, w::NUM_CANONICAL_NAN_WORD as i64);
+        b.ins().select(not_nan, word, nan_word)
+    }
+
+    /// Load the process-wide user-infix-declaration counter (zero ⟺ no user
+    /// `infix:<op>` override can exist anywhere — see `USER_INFIX_DECLS`).
+    fn no_user_infix(&self, b: &mut FunctionBuilder) -> CVal {
+        let addr = std::ptr::addr_of!(super::vm_jit::USER_INFIX_DECLS) as usize;
+        let addr = b.ins().iconst(self.ptr_ty, addr as i64);
+        let ctr = b.ins().load(types::I32, Self::mf(), addr, 0);
+        b.ins().icmp_imm(IntCC::Equal, ctr, 0)
+    }
+
+    /// Call a fallible `(interp) -> status` shim and return-from-function on a
+    /// nonzero status. Leaves the builder in a fresh continuation block.
+    fn call_status(&self, b: &mut FunctionBuilder, f: usize) {
+        let callee = b.ins().iconst(self.ptr_ty, f as i64);
+        let call = b.ins().call_indirect(self.s1, callee, &[self.interp]);
+        let status = b.inst_results(call)[0];
+        let err = b.create_block();
+        let cont = b.create_block();
+        b.ins().brif(status, err, &[], cont, &[]);
+        b.switch_to_block(err);
+        b.ins().return_(&[status]);
+        b.switch_to_block(cont);
+    }
+
+    /// Call an infallible `(interp) -> ()` helper.
+    pub(super) fn call_v1(&self, b: &mut FunctionBuilder, f: usize) {
+        let callee = b.ins().iconst(self.ptr_ty, f as i64);
+        b.ins().call_indirect(self.v1, callee, &[self.interp]);
+    }
+
+    /// `Add`/`Sub`/`Mul`: pop two Int (or two Num) words, push the result.
+    /// Fast-path conditions mirror the interpreter arm exactly: small Int
+    /// operands whose result stays in the small-Int range (else the helper
+    /// boxes it), or two Num operands; `Add` additionally requires no user
+    /// `infix:<+>` declaration (the only arith arm with an override check).
+    pub(super) fn emit_int_num_arith(&self, b: &mut FunctionBuilder, op: IntArith, slow_fn: usize) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let a_addr = self.slot_addr(b, ptr, len, 2);
+        let b_addr = self.slot_addr(b, ptr, len, 1);
+        let wa = b.ins().load(types::I64, Self::mf(), a_addr, 0);
+        let wb = b.ins().load(types::I64, Self::mf(), b_addr, 0);
+        let pa = self.page(b, wa);
+        let pb = self.page(b, wb);
+        let a_int = self.is_int_page(b, pa);
+        let b_int = self.is_int_page(b, pb);
+        let mut both_int = b.ins().band(a_int, b_int);
+        let no_override = if matches!(op, IntArith::Add) {
+            let no = self.no_user_infix(b);
+            both_int = b.ins().band(both_int, no);
+            Some(no)
+        } else {
+            None
+        };
+
+        let int_blk = b.create_block();
+        let num_chk = b.create_block();
+        let num_blk = b.create_block();
+        let slow_blk = b.create_block();
+        let done = b.create_block();
+        b.ins().brif(both_int, int_blk, &[], num_chk, &[]);
+
+        // -- Int fast path --
+        b.switch_to_block(int_blk);
+        let av = self.sx48(b, wa);
+        let bv = self.sx48(b, wb);
+        let (res, mul_of) = match op {
+            // 48-bit operands cannot overflow an i64 add/sub; only the
+            // result's small-Int range needs checking.
+            IntArith::Add => (b.ins().iadd(av, bv), None),
+            IntArith::Sub => (b.ins().isub(av, bv), None),
+            IntArith::Mul => {
+                let (r, of) = b.ins().smul_overflow(av, bv);
+                (r, Some(of))
+            }
+        };
+        let hi = b.ins().ishl_imm(res, 16);
+        let back = b.ins().sshr_imm(hi, 16);
+        let fits = b.ins().icmp(IntCC::Equal, back, res);
+        let ok = match mul_of {
+            Some(of) => {
+                let no_of = b.ins().icmp_imm(IntCC::Equal, of, 0);
+                b.ins().band(fits, no_of)
+            }
+            None => fits,
+        };
+        let int_store = b.create_block();
+        b.ins().brif(ok, int_store, &[], slow_blk, &[]);
+        b.switch_to_block(int_store);
+        let word = self.pack_int(b, res);
+        b.ins().store(Self::mf(), word, a_addr, 0);
+        self.adjust_len(b, len, -1);
+        b.ins().jump(done, &[]);
+
+        // -- Num fast path --
+        b.switch_to_block(num_chk);
+        let a_num = self.is_num_page(b, pa);
+        let b_num = self.is_num_page(b, pb);
+        let mut both_num = b.ins().band(a_num, b_num);
+        if let Some(no) = no_override {
+            both_num = b.ins().band(both_num, no);
+        }
+        b.ins().brif(both_num, num_blk, &[], slow_blk, &[]);
+        b.switch_to_block(num_blk);
+        let fa = self.decode_num(b, wa);
+        let fb = self.decode_num(b, wb);
+        let fr = match op {
+            IntArith::Add => b.ins().fadd(fa, fb),
+            IntArith::Sub => b.ins().fsub(fa, fb),
+            IntArith::Mul => b.ins().fmul(fa, fb),
+        };
+        let word = self.encode_num(b, fr);
+        b.ins().store(Self::mf(), word, a_addr, 0);
+        self.adjust_len(b, len, -1);
+        b.ins().jump(done, &[]);
+
+        // -- Slow path: the Tier A shim reruns the full interpreter arm --
+        b.switch_to_block(slow_blk);
+        self.call_status(b, slow_fn);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(done);
+    }
+
+    /// `NumLt`/`NumLe`/`NumGt`/`NumGe`/`NumEq`/`NumNe`: pop two Int (or two
+    /// Num) words, push True/False. Small-Int words are canonical, so Eq/Ne
+    /// compare raw words; the ordered comparisons compare the sign-extended
+    /// payloads (via a 16-bit left shift, which preserves order). Float
+    /// comparisons use the ordered/unordered CC that matches the interpreter
+    /// fast path's Rust `f64` operator semantics (NaN → False, except `!=`).
+    pub(super) fn emit_compare(&self, b: &mut FunctionBuilder, op: NumCmp, slow_fn: usize) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let a_addr = self.slot_addr(b, ptr, len, 2);
+        let b_addr = self.slot_addr(b, ptr, len, 1);
+        let wa = b.ins().load(types::I64, Self::mf(), a_addr, 0);
+        let wb = b.ins().load(types::I64, Self::mf(), b_addr, 0);
+        let pa = self.page(b, wa);
+        let pb = self.page(b, wb);
+        let a_int = self.is_int_page(b, pa);
+        let b_int = self.is_int_page(b, pb);
+        let both_int = b.ins().band(a_int, b_int);
+
+        let int_blk = b.create_block();
+        let num_chk = b.create_block();
+        let num_blk = b.create_block();
+        let slow_blk = b.create_block();
+        let done = b.create_block();
+        b.ins().brif(both_int, int_blk, &[], num_chk, &[]);
+
+        b.switch_to_block(int_blk);
+        let cond = match op {
+            NumCmp::Eq => b.ins().icmp(IntCC::Equal, wa, wb),
+            NumCmp::Ne => b.ins().icmp(IntCC::NotEqual, wa, wb),
+            _ => {
+                let sa = b.ins().ishl_imm(wa, 16);
+                let sb = b.ins().ishl_imm(wb, 16);
+                let cc = match op {
+                    NumCmp::Lt => IntCC::SignedLessThan,
+                    NumCmp::Le => IntCC::SignedLessThanOrEqual,
+                    NumCmp::Gt => IntCC::SignedGreaterThan,
+                    NumCmp::Ge => IntCC::SignedGreaterThanOrEqual,
+                    NumCmp::Eq | NumCmp::Ne => unreachable!(),
+                };
+                b.ins().icmp(cc, sa, sb)
+            }
+        };
+        self.store_truth(b, cond, a_addr, len);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(num_chk);
+        let a_num = self.is_num_page(b, pa);
+        let b_num = self.is_num_page(b, pb);
+        let both_num = b.ins().band(a_num, b_num);
+        b.ins().brif(both_num, num_blk, &[], slow_blk, &[]);
+        b.switch_to_block(num_blk);
+        let fa = self.decode_num(b, wa);
+        let fb = self.decode_num(b, wb);
+        let cc = match op {
+            NumCmp::Lt => FloatCC::LessThan,
+            NumCmp::Le => FloatCC::LessThanOrEqual,
+            NumCmp::Gt => FloatCC::GreaterThan,
+            NumCmp::Ge => FloatCC::GreaterThanOrEqual,
+            // Interpreter: NaN operands force False for ==, True for !=;
+            // FloatCC::Equal is ordered and FloatCC::NotEqual is unordered,
+            // matching exactly.
+            NumCmp::Eq => FloatCC::Equal,
+            NumCmp::Ne => FloatCC::NotEqual,
+        };
+        let cond = b.ins().fcmp(cc, fa, fb);
+        self.store_truth(b, cond, a_addr, len);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(slow_blk);
+        self.call_status(b, slow_fn);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(done);
+    }
+
+    /// Store True/False (selected by `cond`) into the slot at `a_addr` and
+    /// shrink the stack by one (the two operands collapse into the result).
+    fn store_truth(&self, b: &mut FunctionBuilder, cond: CVal, a_addr: CVal, len: CVal) {
+        let t = b.ins().iconst(types::I64, w::TRUE_BITS as i64);
+        let f = b.ins().iconst(types::I64, w::FALSE_BITS as i64);
+        let word = b.ins().select(cond, t, f);
+        b.ins().store(Self::mf(), word, a_addr, 0);
+        self.adjust_len(b, len, -1);
+    }
+
+    /// `LoadConst` of a refcount-free constant (small Int / Num / Bool / Nil
+    /// / ...): push the 8-byte word as a raw immediate. Only the full-stack
+    /// (grow) case calls the Tier A shim.
+    pub(super) fn emit_load_const(
+        &self,
+        b: &mut FunctionBuilder,
+        word: u64,
+        codep: CVal,
+        idx: u32,
+        slow_fn: usize,
+    ) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let cap = self.stack_cap(b);
+        let full = b.ins().icmp(IntCC::Equal, len, cap);
+        let fast = b.create_block();
+        let slow = b.create_block();
+        let done = b.create_block();
+        b.ins().brif(full, slow, &[], fast, &[]);
+
+        b.switch_to_block(fast);
+        let off = b.ins().ishl_imm(len, 3);
+        let addr = b.ins().iadd(ptr, off);
+        let wv = b.ins().iconst(types::I64, word as i64);
+        b.ins().store(Self::mf(), wv, addr, 0);
+        self.adjust_len(b, len, 1);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(slow);
+        let callee = b.ins().iconst(self.ptr_ty, slow_fn as i64);
+        let idxv = b.ins().iconst(types::I32, idx as i64);
+        b.ins()
+            .call_indirect(self.v_code_u32, callee, &[self.interp, codep, idxv]);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(done);
+    }
+
+    /// `SetSourceLine`: a single immediate store to the interpreter field.
+    pub(super) fn emit_set_source_line(&self, b: &mut FunctionBuilder, line: i64) {
+        let v = b.ins().iconst(types::I64, line);
+        b.ins()
+            .store(Self::mf(), v, self.interp, self.lay.cur_source_line);
+    }
+
+    /// `ContainerizePair`: a no-op unless the top word is a `Pair` (the only
+    /// shape the interpreter arm rewrites), which goes to the Tier A shim.
+    pub(super) fn emit_containerize_pair(&self, b: &mut FunctionBuilder, slow_fn: usize) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let top_addr = self.slot_addr(b, ptr, len, 1);
+        let wt = b.ins().load(types::I64, Self::mf(), top_addr, 0);
+        let masked = b.ins().band_imm(wt, w::KIND_MASK as i64);
+        let is_pair = b
+            .ins()
+            .icmp_imm(IntCC::Equal, masked, w::PAIR_PATTERN as i64);
+        let slow = b.create_block();
+        let done = b.create_block();
+        b.ins().brif(is_pair, slow, &[], done, &[]);
+        b.switch_to_block(slow);
+        self.call_v1(b, slow_fn);
+        b.ins().jump(done, &[]);
+        b.switch_to_block(done);
+    }
+}

--- a/src/vm/vm_jit_tier_b_flow.rs
+++ b/src/vm/vm_jit_tier_b_flow.rs
@@ -1,0 +1,126 @@
+//! Tier B conditional-branch emission (`JumpIfFalse` / `JumpIfTrue` Bool
+//! fast paths) — the control-flow half of `vm_jit_tier_b.rs`, split out
+//! purely by file size. See that module's header for the fast-path
+//! correctness contract.
+
+use super::vm_jit_tier_b::TierB;
+use crate::value::jit_words as w;
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::{InstBuilder, types};
+use cranelift_frontend::FunctionBuilder;
+
+impl TierB {
+    /// `JumpIfFalse` with a Bool-word fast path: True pops and falls through,
+    /// False pops, mirrors the interpreter's post-pop Failure marking, polls
+    /// the safepoint on a backedge and jumps; every other word goes through
+    /// the Tier A cond shim. Leaves the builder in the fall-through block.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn emit_jump_if_false(
+        &self,
+        b: &mut FunctionBuilder,
+        target: cranelift_codegen::ir::Block,
+        backedge: bool,
+        safepoint_fn: usize,
+        mark_fn: usize,
+        cond_fn: usize,
+    ) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let top_addr = self.slot_addr(b, ptr, len, 1);
+        let wt = b.ins().load(types::I64, Self::mf(), top_addr, 0);
+
+        let pop_fall = b.create_block();
+        let chk_false = b.create_block();
+        let pop_take = b.create_block();
+        let slow = b.create_block();
+        let fall = b.create_block();
+
+        let is_true = b.ins().icmp_imm(IntCC::Equal, wt, w::TRUE_BITS as i64);
+        b.ins().brif(is_true, pop_fall, &[], chk_false, &[]);
+
+        b.switch_to_block(pop_fall);
+        self.adjust_len(b, len, -1);
+        b.ins().jump(fall, &[]);
+
+        b.switch_to_block(chk_false);
+        let is_false = b.ins().icmp_imm(IntCC::Equal, wt, w::FALSE_BITS as i64);
+        b.ins().brif(is_false, pop_take, &[], slow, &[]);
+
+        b.switch_to_block(pop_take);
+        self.adjust_len(b, len, -1);
+        // The interpreter arm marks a Failure at the new stack top when the
+        // branch is taken; the shim is a cheap top-of-stack check.
+        self.call_v1(b, mark_fn);
+        if backedge {
+            self.call_v1(b, safepoint_fn);
+        }
+        b.ins().jump(target, &[]);
+
+        b.switch_to_block(slow);
+        let callee = b.ins().iconst(self.ptr_ty, cond_fn as i64);
+        let call = b.ins().call_indirect(self.s1, callee, &[self.interp]);
+        let cond = b.inst_results(call)[0];
+        if backedge {
+            let poll = b.create_block();
+            b.ins().brif(cond, poll, &[], fall, &[]);
+            b.switch_to_block(poll);
+            self.call_v1(b, safepoint_fn);
+            b.ins().jump(target, &[]);
+        } else {
+            b.ins().brif(cond, target, &[], fall, &[]);
+        }
+
+        b.switch_to_block(fall);
+    }
+
+    /// `JumpIfTrue` (peek semantics — the tested word stays on the stack on
+    /// both paths) with a Bool-word fast path. Leaves the builder in the
+    /// fall-through block.
+    pub(super) fn emit_jump_if_true(
+        &self,
+        b: &mut FunctionBuilder,
+        target: cranelift_codegen::ir::Block,
+        backedge: bool,
+        safepoint_fn: usize,
+        cond_fn: usize,
+    ) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let top_addr = self.slot_addr(b, ptr, len, 1);
+        let wt = b.ins().load(types::I64, Self::mf(), top_addr, 0);
+
+        let take = b.create_block();
+        let chk_false = b.create_block();
+        let slow = b.create_block();
+        let fall = b.create_block();
+
+        let is_true = b.ins().icmp_imm(IntCC::Equal, wt, w::TRUE_BITS as i64);
+        b.ins().brif(is_true, take, &[], chk_false, &[]);
+
+        b.switch_to_block(take);
+        if backedge {
+            self.call_v1(b, safepoint_fn);
+        }
+        b.ins().jump(target, &[]);
+
+        b.switch_to_block(chk_false);
+        let is_false = b.ins().icmp_imm(IntCC::Equal, wt, w::FALSE_BITS as i64);
+        b.ins().brif(is_false, fall, &[], slow, &[]);
+
+        b.switch_to_block(slow);
+        let callee = b.ins().iconst(self.ptr_ty, cond_fn as i64);
+        let call = b.ins().call_indirect(self.s1, callee, &[self.interp]);
+        let cond = b.inst_results(call)[0];
+        if backedge {
+            let poll = b.create_block();
+            b.ins().brif(cond, poll, &[], fall, &[]);
+            b.switch_to_block(poll);
+            self.call_v1(b, safepoint_fn);
+            b.ins().jump(target, &[]);
+        } else {
+            b.ins().brif(cond, target, &[], fall, &[]);
+        }
+
+        b.switch_to_block(fall);
+    }
+}

--- a/t/jit-tier-b-arith.t
+++ b/t/jit-tier-b-arith.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+# JIT Tier B inline arithmetic edge cases (ADR-0004 J4, vm_jit_tier_b.rs).
+# Each helper sub is called in a hot loop so that a JIT-enabled run
+# (MUTSU_JIT=on, any threshold <= 300 — e.g. the jit-stress CI job) compiles
+# it and executes the Tier B fast paths; with the JIT off the same
+# assertions pin the interpreter fast paths, so the file passes either way.
+# The interesting inputs are exactly the fast-path boundaries: the 48-bit
+# small-Int range, Int overflow into big integers, NaN/-0e0 float semantics,
+# mixed Int/Num operands, and user-declared infix overrides.
+
+plan 21;
+
+sub add2($a, $b) { $a + $b }
+sub sub2($a, $b) { $a - $b }
+sub mul2($a, $b) { $a * $b }
+sub less2($a, $b) { $a < $b }
+sub le2($a, $b) { $a <= $b }
+sub eq2($a, $b) { $a == $b }
+sub ne2($a, $b) { $a != $b }
+sub sel2($a, $b) { if $a && $b { "both" } elsif $a || $b { "one" } else { "none" } }
+
+my $sink;
+for ^300 {
+    $sink = add2(1, 2);
+    $sink = sub2(5, 3);
+    $sink = mul2(3, 4);
+    $sink = less2(1, 2);
+    $sink = le2(1, 1);
+    $sink = eq2(1, 1);
+    $sink = ne2(1, 2);
+    $sink = sel2(True, False);
+}
+
+# -- small-Int boundary: results leaving the 48-bit inline range must box --
+is add2(2**47 - 1, 1), 2**47, 'Int add crossing the small-int boundary';
+is add2(-(2**47), -1), -(2**47) - 1, 'Int add crossing the negative boundary';
+is sub2(-(2**47), 1), -(2**47) - 1, 'Int sub crossing the negative boundary';
+is add2(2**47 - 1, -(2**47)), -1, 'boundary operands with in-range result';
+is mul2(2**40, 2**40), 2**80, 'Int mul overflowing to big integers';
+is mul2(2**24, 2**24), 2**48, 'Int mul just past the small-int range';
+is mul2(-(2**23), 2**24), -(2**47), 'Int mul landing exactly on the boundary';
+
+# -- Num semantics: NaN, -0e0, infinities --
+is add2(1.5e0, 2.5e0), 4e0, 'Num + Num';
+ok add2(Inf, -Inf).isNaN, 'Inf + -Inf is NaN';
+ok eq2(-0e0, 0e0), '-0e0 == 0e0';
+nok eq2(NaN, NaN), 'NaN == NaN is False';
+ok ne2(NaN, NaN), 'NaN != NaN is True';
+nok less2(NaN, 1e0), 'NaN < Num is False';
+nok less2(1e0, NaN), 'Num < NaN is False';
+
+# -- mixed Int/Num falls through to the exact slow path --
+is add2(1, 2.5e0), 3.5, 'Int + Num';
+ok less2(1, 1.5e0), 'Int < Num';
+
+# -- Bool-driven branches (JumpIfFalse / JumpIfTrue fast paths) --
+is sel2(True, True), 'both', '&& chain with both true';
+is sel2(True, False), 'one', '|| chain after failed &&';
+is sel2(False, False), 'none', 'both branches false';
+
+# -- comparisons across the full small-int range --
+ok less2(-(2**47), 2**47 - 1), 'ordered compare across the whole range';
+ok le2(2**47 - 1, 2**47 - 1), 'boundary value <= itself';

--- a/t/jit-tier-b-infix-override.t
+++ b/t/jit-tier-b-infix-override.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+# A user-declared infix:<+> must be honored by JIT-compiled code: the Tier B
+# inline Add fast path is guarded by the process-wide USER_INFIX_DECLS
+# counter (vm_jit.rs), so once this declaration registers, every JIT'd `+`
+# routes through the interpreter helper, which dispatches to the override.
+# Kept separate from t/jit-tier-b-arith.t: the counter is process-wide and
+# monotonic, so this file must not share a process with fast-path pins.
+
+plan 2;
+
+multi sub infix:<+>(Str $a, Str $b) { $a ~ "|" ~ $b }
+
+sub cat2($a, $b) { $a + $b }
+
+my $sink;
+for ^300 { $sink = cat2("x", "y") }
+
+is cat2("x", "y"), "x|y", 'user infix:<+> dispatches from hot (JIT-eligible) code';
+is cat2(3, 4), 7, 'Int + Int still native when the override does not match';


### PR DESCRIPTION
## Summary

First slice of ADR-0004 §2.5 **J4 (Tier B)**: the hot arithmetic/comparison opcodes are now lowered **directly into CLIF** with NaN-box tag dispatch, instead of one helper call per opcode. The inline fast paths cover exactly the interpreter arms' own fast paths — small-Int⊕small-Int and Num⊕Num — and every other word shape (boxed Int, BigInt, Rat, Junction, user overloads, ...) falls back to the unchanged Tier A shim, which re-runs the full interpreter arm on the still-untouched stack. Small Int and Num words carry no payload ownership, so the inlined loop-body ops execute with **zero refcount and zero GC traffic** (the ADR-0004 J4 gate direction).

### What is inlined

| Opcode | Fast path | Slow path trigger |
|---|---|---|
| `Add`/`Sub`/`Mul` | Int⊕Int (48-bit range check; `smul_overflow` for Mul), Num⊕Num (canonical-NaN select) | boxed/big/mixed operands, result leaving the small-Int range, any user infix declared (`Add` only, per the interpreter arm) |
| `NumLt/Le/Gt/Ge/Eq/Ne` | Int ordered compare via shifted words / canonical-word equality; Num via ordered/unordered `FloatCC` matching Rust `f64` semantics | non-Int/Num operands |
| `LoadConst` | refcount-free constants (Int/Num/Bool/Nil/...) pushed as one raw immediate store | pointer-kind constants; stack grow |
| `SetSourceLine` | single inline store | — |
| `ContainerizePair` | non-Pair top = no-op (kind probe) | Pair top |
| `JumpIfFalse`/`JumpIfTrue` | Bool-word compare + native branch (+ backedge safepoint poll) | non-Bool tested value (incl. Failure marking) |

### Mechanism

- **`vm_jit_layout.rs`**: `Interpreter` field offsets via `offset_of!`, plus a runtime probe of `Vec<Value>`'s (ptr, len, cap) word order (unspecified by Rust), self-verified per process and pinned by a unit test. Probe failure degrades Tier B to the Tier A helper-call form — never wrong, only slower.
- **`nanbox::jit_words`**: the only bit-layout export outside `crate::value`; all constants derive from the layout definitions, so a layout change flows into the JIT automatically.
- **`USER_INFIX_DECLS`** (process-wide monotonic counter): registration sites bump it; the inline `Add` fast path proves "no user `infix:<+>` anywhere" with one load+test. Nonzero conservatively routes through the helper, which re-checks precisely.
- `vm_jit_support.rs` / `vm_jit_tier_b_flow.rs` are file-size splits (500-line rule), no behavior change.

### Verification

- `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2` × full `prove t/` (1677 files): green (only `t/io-socket-recv-limit.t` flaked under `-j4` port contention; passes 3/3 isolated, on and off).
- Arithmetic-heavy roast subset (S03-operators/arith.t, S02-types/num.t, S32-num/*) with JIT on: green. Full roast = CI jit-stress.
- 3-way output diff (JIT off / JIT on / real `raku`) byte-identical on fib, bench-fib, int-arith and the edge-case probe (48-bit boundaries, NaN, −0e0, Inf, mixed Int/Num, `multi sub infix:<+>` override).
- New pins: `t/jit-tier-b-arith.t` (21 assertions on the fast-path boundaries), `t/jit-tier-b-infix-override.t`.

### Measured (release, `perf stat -r5`, `taskset -c 0-3`, same quiet window, same binary)

| bench | JIT off | JIT on | Δ |
|---|---|---|---|
| fib | 134.2 ms | 112.5 ms | **−16.2%** |
| bench-fib | 371.3 ms | 315.0 ms | **−15.2%** |
| int-arith | 90.4 ms | 88.9 ms | ±noise (expected: top-level compound loop never enters the JIT — that is the J4b hot-loop-entry slice) |
| method-call | 177.3 ms | 181.4 ms | +2.3% (≈ J3 noise band) |
| bench-class | 193.1 ms | 192.0 ms | ±noise |

A main-worktree A/B (same window) will be added as a comment.

### Next (J4b)

Hot-loop entry for compound-loop bodies via a `run_range` hook (per-range call counter + sub-range compilation) — brings `int-arith`-class top-level loops into the JIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWpYJdKBYbT9fnimevhpQT