### PR TITLE
perf(vm): JIT J4b — hot-loop entry: compound-loop bodies JIT via run_range hook (ADR-0004 J4)

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1761,6 +1761,24 @@ pub(crate) struct CompiledCode {
 pub(crate) struct JitCodeState {
     pub(crate) calls: std::sync::atomic::AtomicU32,
     pub(crate) entry: std::sync::atomic::AtomicU64,
+    /// Per-sub-range JIT state for compound-loop bodies (ADR-0004 J4b
+    /// hot-loop entry): `(start, end) -> state`, resolved and populated by
+    /// `vm_jit::try_enter_range` on each `run_range` call once the JIT is on.
+    /// A linear-scan Vec: chunks hold only a handful of distinct hot ranges.
+    pub(crate) ranges: std::sync::Mutex<JitRangeTable>,
+}
+
+/// The per-chunk range table: `(start, end)` keys to shared range states.
+pub(crate) type JitRangeTable = Vec<((u32, u32), std::sync::Arc<JitRangeState>)>;
+
+/// Hotness counter and compiled-entry cache for one `[start, end)` opcode
+/// sub-range (a compound loop's body/cond), same encoding as the chunk-level
+/// `JitCodeState` (`entry`: 0 = cold, `JIT_ENTRY_BAILOUT` = rejected, other =
+/// native function pointer).
+#[derive(Debug, Default)]
+pub(crate) struct JitRangeState {
+    pub(crate) calls: std::sync::atomic::AtomicU32,
+    pub(crate) entry: std::sync::atomic::AtomicU64,
 }
 
 impl Clone for JitCodeState {

--- a/src/vm/vm_jit.rs
+++ b/src/vm/vm_jit.rs
@@ -133,6 +133,79 @@ pub(crate) fn try_enter(
     }
 }
 
+/// Range flavor of [`try_enter`] (ADR-0004 J4b hot-loop entry): run the
+/// opcode sub-range `[start, end)` — a compound loop's body or condition —
+/// natively once it is hot. `None` means the range must run on the
+/// interpreter (JIT off / cold / bailout); `Some(result)` has the exact
+/// shape of `run_range`'s interpreter-loop outcome for a body that never
+/// resumes in place (the caller re-enters the interpreter for the two
+/// resumable signals, goto and warn).
+#[cfg(feature = "jit")]
+pub(crate) fn try_enter_range(
+    interp: &mut Interpreter,
+    code: &CompiledCode,
+    start: usize,
+    end: usize,
+    compiled_fns: &HashMap<String, CompiledFunction>,
+) -> Option<Result<(), RuntimeError>> {
+    use std::sync::atomic::Ordering;
+    if !jit_enabled() || start >= end || end > code.ops.len() {
+        return None;
+    }
+    let st = {
+        let mut ranges = code.jit.ranges.lock().unwrap();
+        let key = (start as u32, end as u32);
+        match ranges.iter().find(|(k, _)| *k == key) {
+            Some((_, s)) => s.clone(),
+            None => {
+                let s = std::sync::Arc::new(crate::opcode::JitRangeState::default());
+                ranges.push((key, s.clone()));
+                s
+            }
+        }
+    };
+    let entry = st.entry.load(Ordering::Acquire);
+    let f: JitEntryFn = if entry == 0 {
+        let calls = st.calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if calls < jit_threshold() {
+            return None;
+        }
+        match super::vm_jit_compile::compile_range(code, start, end) {
+            Some(f) => {
+                st.entry.store(f as usize as u64, Ordering::Release);
+                crate::vm::vm_stats::record_jit_compile();
+                f
+            }
+            None => {
+                st.entry.store(JIT_ENTRY_BAILOUT, Ordering::Release);
+                return None;
+            }
+        }
+    } else if entry == JIT_ENTRY_BAILOUT {
+        return None;
+    } else {
+        // Same soundness argument as `try_enter`: 0 -> fn-pointer only.
+        unsafe { std::mem::transmute::<usize, JitEntryFn>(entry as usize) }
+    };
+    crate::vm::vm_stats::record_jit_entry();
+    // The interpreter loop polls the GC safepoint once per opcode; a native
+    // body polls only its own backedges. The enclosing compound loop's
+    // per-iteration poll therefore lands here, before each native body run.
+    crate::gc::gc_safepoint(crate::gc::SafepointKind::Backedge);
+    interp.current_code = code as *const CompiledCode as usize;
+    let status = unsafe { f(interp, code, compiled_fns) };
+    match status {
+        JIT_STATUS_ERR => {
+            let e = interp
+                .jit_error
+                .take()
+                .expect("JIT returned error status without a parked error");
+            Some(Err(e))
+        }
+        _ => Some(Ok(())),
+    }
+}
+
 /// JIT-less builds: never enters native code.
 #[cfg(not(feature = "jit"))]
 #[inline(always)]

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -40,10 +40,19 @@ static ENGINE: Mutex<Option<Engine>> = Mutex::new(None);
 /// opcode, or an internal Cranelift failure): the caller marks the chunk so
 /// it is never scanned again.
 pub(super) fn compile_chunk(code: &CompiledCode) -> Option<JitEntryFn> {
+    compile_range(code, 0, code.ops.len())
+}
+
+/// Compile the opcode sub-range `[start, end)` of `code` to a native body
+/// (ADR-0004 J4b hot-loop entry: a compound loop's body/cond executed by
+/// `run_range`). Same acceptance rules as a whole chunk, plus: every jump
+/// must stay inside the range (a target of exactly `end` is the normal
+/// fall-through exit). `None` = bailout, cached per range by the caller.
+pub(super) fn compile_range(code: &CompiledCode, start: usize, end: usize) -> Option<JitEntryFn> {
     // Static support scan + jump-target collection. Any opcode outside the
-    // Tier A set rejects the whole chunk (no partial compilation).
+    // Tier A set rejects the whole range (no partial compilation).
     let mut targets: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    for op in code.ops.iter() {
+    for op in &code.ops[start..end] {
         if noarg_shim(op).is_some() || step_supported(op) {
             continue;
         }
@@ -60,7 +69,14 @@ pub(super) fn compile_chunk(code: &CompiledCode) -> Option<JitEntryFn> {
             | OpCode::JumpIfFalse(t)
             | OpCode::JumpIfTrue(t)
             | OpCode::JumpIfNotNil(t) => {
-                targets.insert(*t as usize);
+                let t = *t as usize;
+                if t < start || t > end {
+                    // A jump escaping the range (can only come from a
+                    // mis-shaped range request, not a loop body).
+                    crate::vm::vm_stats::record_jit_bailout(op);
+                    return None;
+                }
+                targets.insert(t);
             }
             other => {
                 crate::vm::vm_stats::record_jit_bailout(other);
@@ -68,7 +84,7 @@ pub(super) fn compile_chunk(code: &CompiledCode) -> Option<JitEntryFn> {
             }
         }
     }
-    build(code, &targets)
+    build(code, start, end, &targets)
 }
 
 /// Helper-call signatures used by the emitted code, imported once per
@@ -110,7 +126,12 @@ fn make_sigs(module: &JITModule, b: &mut FunctionBuilder, ptr: Type) -> Sigs {
     }
 }
 
-fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Option<JitEntryFn> {
+fn build(
+    code: &CompiledCode,
+    start: usize,
+    end: usize,
+    targets: &std::collections::HashSet<usize>,
+) -> Option<JitEntryFn> {
     let mut guard = ENGINE.lock().unwrap();
     let engine = match guard.as_mut() {
         Some(e) => e,
@@ -190,7 +211,11 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
 
     // `open` = the current block still needs a terminator.
     let mut open = true;
-    for (i, op) in code.ops.iter().enumerate() {
+    for (i, op) in code.ops[start..end]
+        .iter()
+        .enumerate()
+        .map(|(k, op)| (start + k, op))
+    {
         if let Some(&blk) = block_at.get(&i) {
             if open {
                 b.ins().jump(blk, &[]);
@@ -428,8 +453,9 @@ fn build(code: &CompiledCode, targets: &std::collections::HashSet<usize>) -> Opt
         let zero = b.ins().iconst(types::I32, 0);
         b.ins().return_(&[zero]);
     }
-    // A jump target one past the last opcode is a normal fall-through exit.
-    if let Some(&blk) = block_at.get(&code.ops.len()) {
+    // A jump target one past the range's last opcode is a normal
+    // fall-through exit (`end == code.ops.len()` for a whole chunk).
+    if let Some(&blk) = block_at.get(&end) {
         b.switch_to_block(blk);
         let zero = b.ins().iconst(types::I32, 0);
         b.ins().return_(&[zero]);

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -523,7 +523,65 @@ impl Interpreter {
         end: usize,
         compiled_fns: &HashMap<String, CompiledFunction>,
     ) -> Result<(), RuntimeError> {
-        let mut ip = start;
+        // Hot-loop entry (ADR-0004 J4b): compound-loop bodies/conds call
+        // run_range once per iteration, so a hot sub-range gets JIT-compiled
+        // and runs natively. On a native-body error, the two signals the
+        // interpreter loop resumes in place — goto to an in-range label and a
+        // resumable warn — re-enter the interpreter loop below mid-range (all
+        // state lives on the Interpreter, so continuing at the recorded ip is
+        // exactly what the interpreter would have done); everything else
+        // (control signals, exceptions) propagates to the caller unchanged.
+        #[cfg(feature = "jit")]
+        if let Some(r) = crate::vm::vm_jit::try_enter_range(self, code, start, end, compiled_fns) {
+            match r {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    if e.is_goto()
+                        && let Some(label) = e.label.as_deref()
+                        && let Some(target_ip) = self.find_label_target(code, label)
+                        && (start..end).contains(&target_ip)
+                    {
+                        return self.run_range_from(code, target_ip, start, end, compiled_fns);
+                    }
+                    if e.is_warn() && self.control_handler_depth == 0 {
+                        if !self.warning_suppressed() {
+                            self.write_warn_to_stderr(&e.message);
+                        }
+                        if let Some(v) = e.return_value.clone() {
+                            self.stack.push(v);
+                        }
+                        // Every JIT shim that can surface a warn (CallFunc /
+                        // CallMethod / step) records a resume point; without
+                        // one there is no way to know where to continue, so
+                        // propagate loudly instead of guessing.
+                        if let Some(resume_point) = self.resume_ip.take() {
+                            return self.run_range_from(
+                                code,
+                                resume_point,
+                                start,
+                                end,
+                                compiled_fns,
+                            );
+                        }
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        self.run_range_from(code, start, start, end, compiled_fns)
+    }
+
+    /// The interpreter loop of [`run_range`], entered at `from` (== `start`
+    /// except when resuming mid-range after a JIT'd body's goto/warn).
+    fn run_range_from(
+        &mut self,
+        code: &CompiledCode,
+        from: usize,
+        start: usize,
+        end: usize,
+        compiled_fns: &HashMap<String, CompiledFunction>,
+    ) -> Result<(), RuntimeError> {
+        let mut ip = from;
         while ip < end {
             // GC safepoint on the inner dispatch backedge too: compound-loop
             // ops (for/while bodies) iterate entirely inside ONE `exec_one` of

--- a/t/jit-hot-loop.t
+++ b/t/jit-hot-loop.t
@@ -1,0 +1,73 @@
+use v6;
+use Test;
+
+# JIT J4b hot-loop entry (ADR-0004, vm_jit::try_enter_range): compound-loop
+# bodies at the top level run through run_range once per iteration and get
+# JIT-compiled when hot. Every loop here runs >= 300 iterations so a
+# MUTSU_JIT=on run (any threshold <= 300) executes the native body; with the
+# JIT off the same assertions pin the interpreter. Cases cover the fast
+# paths plus the bail/resume seams: `last`/`next` (body bails out of the
+# JIT), branches, nested loops, and accumulation across iterations.
+
+plan 10;
+
+my $sum = 0;
+for ^1000 {
+    $sum += $_ * 3 + 1;
+}
+is $sum, 1_499_500, 'for ^N accumulation (int-arith shape)';
+
+my $i = 0;
+my $acc = 0;
+while $i < 500 {
+    $acc = $acc + $i;
+    $i = $i + 1;
+}
+is $acc, 124_750, 'while loop with JIT-eligible cond and body';
+
+my $evens = 0;
+my $odds = 0;
+for ^600 {
+    if $_ %% 2 { $evens++ } else { $odds++ }
+}
+is $evens, 300, 'branchy body: even count';
+is $odds, 300, 'branchy body: odd count';
+
+my $stopped = 0;
+for ^1000 {
+    last if $_ == 400;
+    $stopped = $_;
+}
+is $stopped, 399, 'last aborts a hot loop (body stays interpreted)';
+
+my $kept = 0;
+for ^500 {
+    next if $_ %% 2;
+    $kept++;
+}
+is $kept, 250, 'next skips iterations correctly';
+
+my $nested = 0;
+for ^100 {
+    for ^100 {
+        $nested++;
+    }
+}
+is $nested, 10_000, 'nested loops: inner body JIT-compiles independently';
+
+my $s = '';
+for ^300 {
+    $s ~= 'x';
+}
+is $s.chars, 300, 'string building in a hot body';
+
+my $n = 0e0;
+for ^400 {
+    $n += 0.5e0;
+}
+is $n, 200e0, 'Num accumulation in a hot body';
+
+loop (my $j = 0; $j < 350; $j++) {
+    $sum++;
+}
+is $sum, 1_499_850, 'C-style loop body/cond/step through the range JIT';


### PR DESCRIPTION
## Summary

Second slice of ADR-0004 §2.5 **J4**: hot-loop entry. Stacked on #4478 (J4a).

Top-level and compound loops (`for`/`while`/`loop`/`repeat`) never reach the function-level `try_enter` hook, so their bodies always ran interpreted — `int-arith` executed 0% native even with the JIT on. All compound loops run their body/cond through `run_range` once per iteration, so this slice hooks there:

- **`try_enter_range`** (vm_jit.rs): same hotness/bailout protocol as `try_enter`, keyed per `(start, end)` sub-range in a per-chunk table, plus one backedge-cadence GC safepoint poll per native body run.
- **`compile_range`** (vm_jit_compile.rs): `compile_chunk` generalized to sub-ranges; jumps must stay inside the range (`target == end` = fall-through exit). Bodies containing `Last`/`Next`/`Redo` bail out and stay interpreted.
- **`run_range`** (vm_run_loop.rs) tries the range JIT first; on a native-body error the two in-place-resumable signals (goto to an in-range label, resumable warn) re-enter the interpreter loop mid-range at the recorded ip — everything else propagates to the loop arm unchanged.
- Pin: `t/jit-hot-loop.t` (accumulation / branches / nested loops / `last`/`next` / Num / string building), passing identically on and off.

## Verification

- Full `prove t/` with `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2`: green (known `t/io-socket-recv-limit.t` `-j4` port flake only; 3/3 isolated).
- Loop-family roast (S04 `for`/`while`/`loop`/`last`/`next`/`gather`, S03 arith) with JIT on: green. Full roast = CI jit-stress.
- All benchmark outputs byte-identical JIT on/off.

## Measured (release, `perf stat -r5`, `taskset -c 0-3`)

- `int-arith` now compiles (`compiles=1, entries=99901, bailouts=0`): **90.0 → 79.7 ms (−11.5%)** with JIT on, 0.58x of raku.
- fib / bench-fib / method-call / bench-class: unchanged within the layout-noise band.

The remaining per-iteration cost in `int-arith` is the `GetGlobal($_)` / `CheckReadOnly` / `GetLocal` / `SetLocal` helper calls — variable-op Tier B fast paths are the next slice (J4c), which is where the ADR "int loop 5–10x" gate gets its leverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWpYJdKBYbT9fnimevhpQT