### PR TITLE
perf(vm): JIT J4c — variable-op helper hot paths: gated marker probes, symbol-keyed reads (ADR-0004 J4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,10 @@ Running the entire roast suite locally is wasteful and slow — **let CI run the
 
 The `MUTSU_VM_STATS=1` dual-store counters (`locals_pulls`, `env_flushes`, `env_deep_copies`, `clone_env`, ...) are **deterministic and independent of the optimization level** — they count VM events, not time. So when tuning a perf/decoupling change against those counters, **iterate with the debug build** (`cargo build`, ~30-70s) and read the counters off `target/debug/mutsu`; the numbers are identical to release. Reserve the slow `cargo build --release` (which here also emits debuginfo and can take 10-15 min) for the **final wall-clock measurement** only. Do NOT default to release just because the task is perf-related — that wastes ~10× the build time per iteration for byte-identical counter output.
 
+### Benchmark numbers in documents come from the bench CI, not local runs
+
+Numbers recorded in PERFORMANCE.md / PLAN.md / news must come from the **bench CI history** (`bench-history.tsv` on the `bench-data` branch, appended on every main push: median of 7 runs plus a same-runner raku ratio that normalizes runner speed), citing the main commit hash the row belongs to. Read it with `git show origin/bench-data:bench-history.tsv`. The `<bench>+jit` rows are the `MUTSU_JIT=on` series. Local `perf stat` A/B measurements are fine for PR descriptions and in-flight development decisions, but they drift with thermals and binary layout (±5% is common), so they are NOT the source of truth for documents.
+
 ## Checking `make test` / `make roast` results
 
 `make test` and `make roast` automatically save their full output to log files via `tee`:

--- a/scripts/bench-ci.sh
+++ b/scripts/bench-ci.sh
@@ -66,4 +66,17 @@ for bench in benchmarks/*.raku; do
         ratio=NA
     fi
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$name" "$m_med" "$m_min" "$r_med" "$ratio" "$RUNS"
+
+    # JIT-on pass (ADR-0004 layer 4): recorded as its own benchmark name so
+    # the history/regression tooling treats it as a separate series. The raku
+    # median from the plain pass above is reused for the ratio (same runner,
+    # same job — measuring raku twice would only add noise).
+    read -r j_med j_min <<<"$(export MUTSU_JIT=on; bench_binary "$MUTSU" "$bench")"
+    if [ "$j_med" != NA ] && [ "$r_med" != NA ]; then
+        j_ratio=$(awk -v m="$j_med" -v r="$r_med" \
+            'BEGIN{ if (r > 0) printf "%.2f", m / r; else print "NA" }')
+    else
+        j_ratio=NA
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$name+jit" "$j_med" "$j_min" "$r_med" "$j_ratio" "$RUNS"
 done

--- a/src/env.rs
+++ b/src/env.rs
@@ -113,6 +113,18 @@ pub(crate) fn is_plain_user_lexical(name: &str) -> bool {
 /// reads it, so `Relaxed` ordering suffices.
 static CLOSURE_META_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 
+/// Monotonic, process-global flag for `__mutsu_bound::*` keys (the `:=`-bound
+/// container markers consulted by `CheckReadOnly` on every whole-variable
+/// assignment). Same soundness argument as [`CLOSURE_META_KEY_SEEN`]: every
+/// creation site flows through the String-keyed [`Env::insert`], the flag is
+/// monotonic, and an over-set only makes the (correct) check run.
+static BOUND_KEY_SEEN: AtomicBool = AtomicBool::new(false);
+
+/// Monotonic, process-global flag for `__mutsu_bound_array_slice::*` markers
+/// (sigilless multi-dim slice binds), consulted by
+/// `distribute_bound_multidim_slice` on every scalar `SetLocal`/assignment.
+static BOUND_SLICE_KEY_SEEN: AtomicBool = AtomicBool::new(false);
+
 /// True if any closure-writeback metadata key may exist in some env. See
 /// [`CLOSURE_META_KEY_SEEN`].
 #[inline]
@@ -120,17 +132,36 @@ pub(crate) fn closure_meta_keys_possible() -> bool {
     CLOSURE_META_KEY_SEEN.load(Ordering::Relaxed)
 }
 
-/// Flip [`CLOSURE_META_KEY_SEEN`] if `key` is a closure-writeback metadata key.
-/// The outer `__mutsu_` gate keeps this ~1 byte compare for ordinary lexical
-/// names (which never start with `_`).
+/// True if any `__mutsu_bound::*` marker may exist in some env. See
+/// [`BOUND_KEY_SEEN`].
+#[inline]
+pub(crate) fn bound_marker_possible() -> bool {
+    BOUND_KEY_SEEN.load(Ordering::Relaxed)
+}
+
+/// True if any `__mutsu_bound_array_slice::*` marker may exist in some env.
+/// See [`BOUND_SLICE_KEY_SEEN`].
+#[inline]
+pub(crate) fn bound_array_slice_possible() -> bool {
+    BOUND_SLICE_KEY_SEEN.load(Ordering::Relaxed)
+}
+
+/// Flip [`CLOSURE_META_KEY_SEEN`] / [`BOUND_KEY_SEEN`] if `key` is one of the
+/// tracked metadata keys. The outer `__mutsu_` gate keeps this ~1 byte compare
+/// for ordinary lexical names (which never start with `_`).
 #[inline]
 fn note_closure_meta_key(key: &str) {
-    if key.as_bytes().starts_with(b"__mutsu_")
-        && (key.starts_with("__mutsu_sigilless_")
+    if key.as_bytes().starts_with(b"__mutsu_") {
+        if key.starts_with("__mutsu_sigilless_")
             || key.starts_with("__mutsu_state_key::")
-            || key.starts_with("__mutsu_predictive_seq_iter::"))
-    {
-        CLOSURE_META_KEY_SEEN.store(true, Ordering::Relaxed);
+            || key.starts_with("__mutsu_predictive_seq_iter::")
+        {
+            CLOSURE_META_KEY_SEEN.store(true, Ordering::Relaxed);
+        } else if key.starts_with("__mutsu_bound::") {
+            BOUND_KEY_SEEN.store(true, Ordering::Relaxed);
+        } else if key.starts_with("__mutsu_bound_array_slice::") {
+            BOUND_SLICE_KEY_SEEN.store(true, Ordering::Relaxed);
+        }
     }
 }
 

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -226,6 +226,11 @@ impl Interpreter {
 
     /// Resolve a variable name through bindings (follow aliases).
     pub(crate) fn resolve_binding(&self, name: &str) -> Option<&str> {
+        // Empty-map fast exit: this runs on every GetLocal, and the common
+        // program never creates a `$CALLER::x := ...` binding.
+        if self.var_bindings.is_empty() {
+            return None;
+        }
         self.var_bindings.get(name).map(|s| s.as_str())
     }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -216,6 +216,47 @@ impl Interpreter {
                     *ip += 1;
                     return Ok(());
                 }
+                // Fast scalar read (J4 helper hot path): the dominant GetGlobal
+                // shape is a plain env hit (topic `$_` reads in loop bodies,
+                // dynamic vars). Serve it through the memoized per-slot Symbol —
+                // no per-read intern, and no kebab-alias re-probe for the 1-char
+                // topic name `_` (whose underscore otherwise sends every read
+                // through the `_`->`-` pre-pass of get_env_with_main_alias).
+                // Gate order reproduces the slow chain's precedence: the stores
+                // consulted before env must be provably inactive (escaping-our
+                // captures empty, no real current package), @/% names keep the
+                // slow path's atomic/thread-clone arms, and Nil / LazyThunk /
+                // ContainerRef hits fall through for the slow tail's
+                // default/type-object, force and deref handling.
+                let fast_hit = {
+                    let b0 = name.as_bytes().first().copied();
+                    if !matches!(b0, Some(b'@' | b'%'))
+                        && (name == "_" || !name.contains('_'))
+                        && self.escaping_our_lexical_names.is_empty()
+                        && {
+                            let cur = self.current_package();
+                            cur.is_empty() || cur == "GLOBAL"
+                        }
+                    {
+                        match self.env().get_sym(code.const_sym(*name_idx)) {
+                            Some(val)
+                                if !val.is_nil()
+                                    && !val.is_container_ref()
+                                    && !matches!(val.view(), ValueView::LazyThunk(_)) =>
+                            {
+                                Some(val.clone())
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    }
+                };
+                if let Some(val) = fast_hit {
+                    self.stack.push(val);
+                    *ip += 1;
+                    return Ok(());
+                }
                 let val = self
                     // A package-block `my` lexical is stored in `package_lexicals`;
                     // it is the authoritative store for a bare free-variable read from
@@ -4155,25 +4196,34 @@ impl Interpreter {
                 // bind signal, but a whole reassignment (`%a = (...)`) is allowed
                 // — it writes through to the bound source. The `__mutsu_bound::`
                 // marker distinguishes it from a genuinely immutable `constant`.
-                let bound_key = format!("__mutsu_bound::{}", name);
-                if matches!(
-                    self.env().get(&bound_key).map(Value::view),
-                    Some(ValueView::Bool(true))
-                ) {
-                    *ip += 1;
-                    return Ok(());
+                // Both marker probes are gated on their process-global
+                // "ever created" flags: this opcode runs on every whole-variable
+                // assignment (per iteration in tight loops), and the common
+                // program never creates either marker — skipping the two
+                // `format!` allocations plus env lookups entirely.
+                if crate::env::bound_marker_possible() {
+                    let bound_key = format!("__mutsu_bound::{}", name);
+                    if matches!(
+                        self.env().get(&bound_key).map(Value::view),
+                        Some(ValueView::Bool(true))
+                    ) {
+                        *ip += 1;
+                        return Ok(());
+                    }
                 }
                 self.check_readonly_for_modify(name)?;
                 // Also check env-based readonly status set by cross-scope
                 // `:=` binding (e.g. binding to a readonly sub parameter
                 // in a closure).  The readonly_vars set is scope-local
                 // and gets restored on frame pop, but the env key persists.
-                let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
-                if matches!(
-                    self.env().get(&readonly_key).map(Value::view),
-                    Some(ValueView::Bool(true))
-                ) {
-                    return Err(RuntimeError::assignment_ro(Some(name)));
+                if crate::env::closure_meta_keys_possible() {
+                    let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
+                    if matches!(
+                        self.env().get(&readonly_key).map(Value::view),
+                        Some(ValueView::Bool(true))
+                    ) {
+                        return Err(RuntimeError::assignment_ro(Some(name)));
+                    }
                 }
                 *ip += 1;
             }

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -149,10 +149,16 @@ impl Interpreter {
                     | ValueView::Sub(..)
                     | ValueView::Instance { .. }
             )
-            && let Some(arc) = self.env().get(name).and_then(|v| match v.view() {
+            // Probe via the pre-interned Symbol (this read runs on every
+            // GetLocal — a by-name lookup would re-intern per read).
+            && let Some(env_hit) = code
+                .locals_sym
+                .get(idx)
+                .map_or_else(|| self.env().get(name), |sym| self.env().get_sym(*sym))
+            && let Some(arc) = match env_hit.view() {
                 ValueView::ContainerRef(arc) => Some(arc.clone()),
                 _ => None,
-            })
+            }
         {
             self.locals[idx] = Value::container_ref(arc);
         }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -31,6 +31,11 @@ impl Interpreter {
         if name.starts_with('@') || name.starts_with('%') || name.starts_with('&') {
             return None;
         }
+        // No `__mutsu_bound_array_slice::*` marker was ever created (the
+        // common program): skip the per-assignment `format!` + env probe.
+        if !crate::env::bound_array_slice_possible() {
+            return None;
+        }
         if !matches!(
             self.env()
                 .get(&Self::bound_array_slice_marker_key(name))
@@ -234,7 +239,14 @@ impl Interpreter {
         // `SetLocal` counterpart of the same write-through in
         // `exec_assign_expr_local_op_inner` / `exec_assign_expr_op_inner`.
         // Excluded for a `:=` bind / declaration, which replaces the binding.
-        if !is_bind && !is_vardecl && !is_rebind && !scalar_bind {
+        if !is_bind
+            && !is_vardecl
+            && !is_rebind
+            && !scalar_bind
+            // Gate before the String/holder clones: no slice marker was ever
+            // created in the common program.
+            && crate::env::bound_array_slice_possible()
+        {
             let name = code.locals[idx].clone();
             let holder = self.locals[idx].clone();
             if let Some(res) = self.distribute_bound_multidim_slice(&name, &holder, &raw_popped) {
@@ -332,10 +344,16 @@ impl Interpreter {
             if !is_rebind
                 && !self.locals[idx].is_container_ref()
                 && !is_vardecl
-                && let Some(arc) = self.env().get(name).and_then(|v| match v.view() {
+                // Probe via the pre-interned Symbol (this runs on every simple
+                // SetLocal — a by-name lookup would re-intern per write).
+                && let Some(env_hit) = code
+                    .locals_sym
+                    .get(idx)
+                    .map_or_else(|| self.env().get(name), |sym| self.env().get_sym(*sym))
+                && let Some(arc) = match env_hit.view() {
                     ValueView::ContainerRef(arc) => Some(arc.clone()),
                     _ => None,
-                })
+                }
             {
                 self.locals[idx] = Value::container_ref(arc);
             }


### PR DESCRIPTION
## Summary

Third J4 slice. After J4b put `int-arith`'s loop body on the JIT, the profile showed the remaining per-iteration cost was **not arithmetic but the variable-op helpers**: `format!`-built env marker keys, per-read `Symbol` interning, and ungated metadata probes. This fixes them at the interpreter level, so **both modes benefit**.

| fix | what it removes (per iteration in an int loop) |
|---|---|
| `CheckReadOnly` marker probes gated on process-global "ever created" flags (extends the existing `CLOSURE_META_KEY_SEEN` chokepoint in env.rs) | 2× `format!` alloc + 2× env lookup per whole-variable assignment |
| `GetGlobal` fast scalar read via the memoized `const_sym` | per-read intern; **and the `_`→`-` kebab re-probe: `"_"` contains an underscore, so every `$_` read ran the whole fallback chain twice** |
| `GetLocal`/`SetLocal` ContainerRef-adoption probe via `code.locals_sym` | per-op re-intern of the local's name |
| `distribute_bound_multidim_slice` gated on a `__mutsu_bound_array_slice::` flag | `format!` + env probe + String/holder clones per scalar assignment |
| `resolve_binding` empty-map fast exit | hash of the name per GetLocal |

Soundness of the flags: monotonic and process-global, set at the single String-keyed `Env::insert` chokepoint every creation site flows through; an over-set only makes the (correct) probe run — same argument as the existing `CLOSURE_META_KEY_SEEN`. The `GetGlobal` fast path's gates reproduce the slow chain's precedence, and Nil / LazyThunk / ContainerRef hits fall through to the unchanged slow tail.

## Also

- **`scripts/bench-ci.sh`**: every benchmark now also measured with `MUTSU_JIT=on` as its own `<bench>+jit` series (same TSV schema) — JIT-mode history accumulates on `bench-data` from the next main push.
- **CLAUDE.md**: documentation numbers come from the bench CI history (`bench-data`), citing the commit hash; local `perf stat` A/B stays for PR descriptions only.

## Verification

- `make test` green (JIT off); full `prove t/` green with `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2`.
- Touched-semantics pins green: S03-binding roast ×7 + assign ×2 + variables-and-packages, `t/sigilless-params.t`, `t/array-bind-cell.t`, `t/cas-multidim-cells.t`, `t/multidim-delete-after-ephemeral-block-coherence.t`, ...
- All benchmark outputs byte-identical JIT on/off.

## Measured locally (release, `perf stat -r5`, `taskset -c 0-3`; CI numbers land on `bench-data` after merge)

| bench | J4b baseline | J4c | Δ |
|---|---|---|---|
| int-arith, JIT off | 90.0 ms | 59.6 ms | **−34%** |
| int-arith, JIT on | 79.7 ms | 52.8 ms | **−34%** (≈0.39x of raku) |
| fib, JIT on | 116.1 ms | 110.3 ms | −5% |
| bench-fib, JIT on | 322.9 ms | 301.2 ms | −6.7% |
| method-call / bench-class, JIT on | — | — | −2〜3% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWpYJdKBYbT9fnimevhpQT