### PR TITLE
perf(jit): add numeric/call-kernel benchmarks + MarkArrayShareSource step coverage

### DIFF
--- a/benchmarks/bench-mandelbrot.raku
+++ b/benchmarks/bench-mandelbrot.raku
@@ -1,0 +1,20 @@
+# Mandelbrot escape-time on a 60x60 grid (classic benchmarks-game kernel):
+# nested loops around a data-dependent while loop of Num multiply/add/compare.
+my $total = 0;
+for ^60 -> $py {
+    my $ci = $py.Num * 0.05e0 - 1.5e0;
+    for ^60 -> $px {
+        my $cr = $px.Num * 0.05e0 - 2.2e0;
+        my $zr = 0e0;
+        my $zi = 0e0;
+        my $iter = 0;
+        while $zr * $zr + $zi * $zi <= 4e0 && $iter < 100 {
+            my $t = $zr * $zr - $zi * $zi + $cr;
+            $zi = 2e0 * $zr * $zi + $ci;
+            $zr = $t;
+            $iter = $iter + 1;
+        }
+        $total = $total + $iter;
+    }
+}
+say $total;

--- a/benchmarks/bench-tak.raku
+++ b/benchmarks/bench-tak.raku
@@ -1,0 +1,10 @@
+# Takeuchi function (the classic Gabriel/LISP call benchmark): three
+# recursive calls per level with three arguments each — measures function
+# call and argument binding overhead more heavily than fib.
+sub tak($x, $y, $z) {
+    if $y < $x {
+        return tak(tak($x - 1, $y, $z), tak($y - 1, $z, $x), tak($z - 1, $x, $y));
+    }
+    return $z;
+}
+say tak(21, 14, 7);

--- a/benchmarks/num-arith.raku
+++ b/benchmarks/num-arith.raku
@@ -1,0 +1,8 @@
+# Floating-point (Num) counterpart of int-arith: iterate the logistic map
+# (a classic chaotic-dynamics kernel) in a tight loop — pure Num
+# multiply/subtract with no allocation.
+my $x = 0.5e0;
+for ^200000 {
+    $x = 3.9e0 * $x * (1e0 - $x);
+}
+say $x;

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -125,6 +125,7 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::MarkVarDeclContext
             | OpCode::MarkExplicitInitializerContext
             | OpCode::MarkShapedDeclContext
+            | OpCode::MarkArrayShareSource(_)
             | OpCode::SetTopic
             | OpCode::SaveTopic
             | OpCode::RestoreTopic


### PR DESCRIPTION
## Summary

Adds three benchmark kernels covering shapes the suite did not measure, plus the JIT coverage fix the new kernels exposed. All three are standard cross-language benchmark kernels (not JIT-tailored constructions), at the same workload scale as the existing suite (~0.2s on raku).

| new benchmark | kernel | what it measures |
|---|---|---|
| `num-arith` | logistic map | pure Num (float) arithmetic loop — the suite had int-arith but no float counterpart |
| `bench-mandelbrot` | 60×60 Mandelbrot escape-time (benchmarks-game classic) | nested loops around a data-dependent `while` of Num multiply/add/compare |
| `bench-tak` | Takeuchi function (Gabriel/LISP classic) | 3 recursive calls × 3 args per level — heavier per-call binding than fib |

## Coverage fix

bench-mandelbrot initially showed **0%** JIT effect: the `while` body bailed out of the range JIT because `$zr = $t` (scalar-to-scalar assignment) emits `MarkArrayShareSource`, which was missing from `step_supported()`. It is a straight-line context marker (sets two interpreter fields, `ip += 1`) exactly like the `Mark*` ops already on the list. With it supported the body compiles (mandelbrot compiles=1→2, entries 79k→155k) and the kernel gains −11%.

## Measurements (release, `perf stat -r7`, `taskset -c 0-3`, off → on)

- num-arith: 0.112s → 0.096s (**−14%**)
- bench-mandelbrot: 0.254s → 0.227s (**−11%**, was ±0% before the fix)
- bench-tak: 0.582s → 0.528s (**−9%**)
- existing benches unaffected (fib −17%, int-arith −9% off→on, consistent with bench-CI history)

Canonical numbers will accrue in the bench CI `+jit` series once merged.

## Validation

- off/on outputs byte-identical for all three, and match raku (`0.9649654926657113` / `76089` / `14`).
- `cargo test` green; jit_diff 4/4; JIT pin files green.
- Full `t/` under `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2`: green except `t/io-socket-recv-limit.t`, a **pre-existing parallel-load flake** — it fails identically under `-j4` stress with the change stashed (A/B verified), passes ×3 in isolation, and CI's jit-stress runs `t/` serially so it does not affect CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWpYJdKBYbT9fnimevhpQT