### PR TITLE
perf(compiler): constant folding of literal-only expressions (ADR-0006 §2.1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -269,6 +269,15 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       news/2026-07.md）。ベンチ数字の正本 = bench-data ブランチ（`+jit` 系列）。
 - [ ] **Lever 6: biased reference counting = ADR-0001 層3c（GC 後の独立 perf）**。凍結 — 着手トリガは
       「JIT J4 完了後の profile で atomic inc/dec が上位に残る」のみ（gc-post-3a-roadmap §4）。
+- [ ] **Lever 7: ベースライン（古典的）バイトコード最適化 = [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md)**。
+      JIT と直交（実行する opcode 列そのものを短くする）。ADR の実装順どおりに進める:
+      - [x] §2.1 定数畳み込み（#4485 — literal-only の算術/比較/連結を emit 時に評価。
+            time-parts の実行 opcode 7.60M→6.40M・`Mul` 1.0M→0.4M。
+            演算子オーバーライド安全条件は「宣言を見つけたらユニットごと fold なしで再コンパイル」）
+      - [ ] §2.4 定数プール dedup（`add_constant` の逆引き — `CompiledCode` のメモリ・locality）
+      - [ ] §2.2 `constant` 読みのインライン化 + 定数条件 DCE（debug-guard 2.2x の本命）
+      - [ ] §2.3 peephole（administrative op 列 — `SetSourceLine` 重複除去・`my $x = <expr>` 宣言列の融合。
+            ヒストグラム駆動で対象選定）
 - [ ] **opcode 残件（[docs/opcode-design-review.md](docs/opcode-design-review.md) §2/§5/§6・#4279 の続き）**:
       ラベル等の inline `Option<String>` payload（`Last`/`Next`/`Redo`/loop 系/`SmartMatchExpr.lhs_var`）
       の定数プール `Option<u32>` 化（`OpCode` を 48B 未満へ） / per-instruction 定数コスト

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,41 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-13: ベースライン最適化 第1弾 — 定数畳み込み（ADR-0006 §2.1）
+
+[ADR-0006](../docs/adr/0006-baseline-interpreter-optimizations.md) の採用施策のうち
+**§2.1 定数畳み込み**を実装（#4485）。リテラルのみからなる純粋式（`60 * 60 * 24`・
+`'a' ~ 'b'`・`-1`）を emit 時に評価し、`LoadConst` 1 個に畳む。
+
+- **実装**: `src/compiler/const_fold.rs`。評価は **VM と同じ native 演算**
+  （`builtins::arith_add/sub/mul/div/mod/pow`・`Interpreter::concat_values`）を
+  そのまま呼ぶため、`Int/Int → Rat`・`2 ** 100` の BigInt 昇格・Num の書式が
+  実行時と自動的に一致する（「コンパイル時演算」を別実装しない = ADR §2.1-2）。
+  対象は算術（数値オペランドのみ）・`~` 連結・数値比較（VM が fast-path を
+  持つ Int/Int・Num/Num のみ）。`'3' + 4` のような文字列オペランドは
+  VM の数値コアーション経路（X::Str::Numeric を投げうる）を保つため畳まない。
+- **演算子オーバーライドの安全条件（ADR §2.1-1）**: `sub infix:<+>` はネイティブな
+  `Int + Int` すら上書きし、mutsu は宣言をグローバルな `user_declared_infix_ops` に
+  登録するため、ユニット内のどこか（ネストしたブロック・sub 本体・クラス本体）に
+  宣言が 1 つでもあれば畳んではいけない。AST を静的に走査する方式は
+  「1 箇所見落とす = 誤畳み込み」なので採らず、**宣言が必ず通過するコンパイル箇所
+  （`SubDecl`/`ProtoDecl`/`VarDecl`）で共有 `FoldCtx` に印を付け、畳み込み済みなのに
+  宣言が出てきたらユニットごと fold なしで再コンパイルする**方式にした。
+  構造的に健全（走査の追従漏れが起こり得ない）で、二度手間は演算子を宣言する
+  ファイルだけが払う。加えて JIT の `USER_INFIX_DECLS`（プロセス全体のカウンタ）が
+  非ゼロなら畳まない（モジュール読み込み後に compile される EVAL/ブロックを覆う）。
+  pin = `t/const-fold-infix-override.t`（宣言より前に書かれた `1 + 2` も畳まれない）。
+- **実測**（release・median of 7・ローカル）: time-parts の実行 opcode が
+  **7.60M → 6.40M（−15.8%）**・`Mul` 1.0M→0.4M・`LoadConst` 1.7M→1.1M。
+  wall-clock は interp **0.65s → 0.61s（−6.2%）**、JIT on 0.60s → 0.59s
+  （JIT は元々この定数 `Mul` をネイティブに畳んでいるため差が小さい）。
+  opcode 削減率ほど時間が減らないのは、time-parts の残り時間が administrative op
+  （`SetSourceLine`・`MarkVarDeclContext`・`SetVarDynamic`・`CheckReadOnly`）に
+  支配されているため — これは ADR §2.3 peephole の担当で、次スライス以降の的。
+- debug-guard は本スライスでは不変（`constant DEBUG` の読み = §2.2 の担当）。
+- 副次効果: 畳み込みは JIT の入力 opcode 列も短くする（ADR §4）。
+- `MUTSU_CONST_FOLD=0` で畳み込みを無効化できる（A/B・切り分け用）。
+
 ## 2026-07-13: 層4 JIT J5 完了 — `MUTSU_JIT` 既定 on（ADR-0004 フェーズ完遂）
 
 ADR-0004 §2.5 の最終フェーズ **J5（既定 on 切替）を達成**。mutsu はデフォルトで

--- a/src/compiler/const_fold.rs
+++ b/src/compiler/const_fold.rs
@@ -1,0 +1,369 @@
+//! Compile-time constant folding of literal-only expressions (ADR-0006 §2.1).
+//!
+//! A binary/unary expression whose operands are all literal scalars is
+//! evaluated at emit time and replaced by a single `LoadConst`. The evaluation
+//! calls the *same* native operator implementations the VM uses
+//! (`builtins::arith_*`, `Interpreter::concat_values`), so Int→BigInt
+//! promotion, `Int/Int → Rat`, and Num formatting automatically agree with
+//! runtime semantics — no separate "compile-time arithmetic" exists.
+//!
+//! Safety (ADR-0006 §2.1):
+//!
+//! - **Operator overrides.** A user `sub infix:<op>` overrides even native
+//!   `Int + Int` (roast S06-operator-overloading/infix.t), and mutsu registers
+//!   those in a *global* set (`user_declared_infix_ops`), so a declaration
+//!   anywhere in the compilation unit can affect any expression in it. Rather
+//!   than statically walking the AST for such declarations (a walker that
+//!   misses one nested inside a block/sub/class body would fold *wrongly*),
+//!   the compiler notices them where they are unavoidably compiled — the
+//!   `SubDecl`/`ProtoDecl`/`VarDecl` arms call [`FoldCtx::note_operator_decl`]
+//!   — and the unit-level [`Compiler::compile`] simply **recompiles the whole
+//!   unit with folding off** if a declaration turned up after something was
+//!   folded. Sound by construction, no walker to keep in sync, and the double
+//!   compile is paid only by files that declare operators.
+//! - **`USER_INFIX_DECLS`.** Any unit compiled *after* a user operator was
+//!   registered at runtime (an `EVAL`, a `map` block, a module body) folds
+//!   nothing: the process-wide counter the JIT already maintains is non-zero.
+//! - **Exceptions are preserved.** An evaluation that fails (`1/0`, overflow to
+//!   an error) is simply not folded, so the VM raises it at runtime as before.
+//! - **Value types only.** Int/BigInt/Num/Rat/Str/Bool — immutable scalars whose
+//!   identity is not observable. Containers/Instances are never folded.
+//!
+//! Known gap: an operator override *imported from a module* is registered when
+//! the `use` executes, i.e. after the consuming unit has already been compiled,
+//! so a literal-only expression there is folded against the core operator. This
+//! matches what raku does for narrowly-typed multis (the core candidate wins
+//! anyway); it diverges only if a module supersedes the operator for the very
+//! literal types being folded.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use super::Compiler;
+use crate::ast::Expr;
+use crate::token_kind::TokenKind;
+use crate::value::{Value, ValueView};
+
+/// Per-compilation-unit constant-folding state, shared with every child
+/// (sub/closure body) compiler of the unit.
+#[derive(Debug, Default)]
+pub(crate) struct FoldCtx {
+    /// False during the retry pass: fold nothing.
+    enabled: AtomicBool,
+    /// A user operator (`infix:<+>`, `&infix:<+>`, a runtime-named sub) is
+    /// declared somewhere in this unit.
+    saw_operator_decl: AtomicBool,
+    /// At least one expression was folded in this unit.
+    folded: AtomicBool,
+}
+
+/// `MUTSU_CONST_FOLD=0` turns folding off process-wide (A/B benchmarking and
+/// bisecting a suspected fold-related behavior change).
+fn folding_allowed() -> bool {
+    static ALLOWED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ALLOWED.get_or_init(|| std::env::var("MUTSU_CONST_FOLD").as_deref() != Ok("0"))
+}
+
+impl FoldCtx {
+    pub(crate) fn enabled() -> Self {
+        Self {
+            enabled: AtomicBool::new(folding_allowed()),
+            saw_operator_decl: AtomicBool::new(false),
+            folded: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn disabled() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+            saw_operator_decl: AtomicBool::new(false),
+            folded: AtomicBool::new(false),
+        }
+    }
+
+    /// Record a declaration that may install a user operator. Called for every
+    /// sub/proto/variable declaration whose name mentions an operator category,
+    /// and for runtime-named subs (`sub ::($name)`), whose name is unknowable.
+    pub(crate) fn note_operator_decl(&self) {
+        self.saw_operator_decl.store(true, Ordering::Relaxed);
+    }
+
+    /// True when something was folded *and* an operator declaration turned up:
+    /// the unit must be recompiled with folding off.
+    pub(crate) fn needs_refold_pass(&self) -> bool {
+        self.folded.load(Ordering::Relaxed) && self.saw_operator_decl.load(Ordering::Relaxed)
+    }
+}
+
+/// Name of a declaration that could install a user-defined operator.
+pub(crate) fn declares_operator(name: &str) -> bool {
+    name.contains("infix:") || name.contains("prefix:") || name.contains("postfix:")
+}
+
+impl Compiler {
+    /// True when this unit may fold. Cheap enough to call per binary expression.
+    fn const_fold_enabled(&self) -> bool {
+        self.fold_ctx.enabled.load(Ordering::Relaxed)
+            && !self.fold_ctx.saw_operator_decl.load(Ordering::Relaxed)
+            // Any user operator registered anywhere in the process (a module
+            // loaded before this EVAL/block was compiled) disables folding.
+            && crate::vm::vm_jit::USER_INFIX_DECLS.load(Ordering::Relaxed) == 0
+    }
+
+    /// Fold `left op right` into a single value, or `None` to compile normally.
+    pub(super) fn try_const_fold_binary(
+        &mut self,
+        left: &Expr,
+        op: &TokenKind,
+        right: &Expr,
+    ) -> Option<Value> {
+        if !self.const_fold_enabled() {
+            return None;
+        }
+        let value = fold_binary(left, op, right)?;
+        self.fold_ctx.folded.store(true, Ordering::Relaxed);
+        Some(value)
+    }
+
+    /// Fold a unary literal expression (`-1`, `-(2*3)`).
+    pub(super) fn try_const_fold_unary(&mut self, op: &TokenKind, expr: &Expr) -> Option<Value> {
+        if !self.const_fold_enabled() {
+            return None;
+        }
+        let value = fold_unary(op, expr)?;
+        self.fold_ctx.folded.store(true, Ordering::Relaxed);
+        Some(value)
+    }
+
+    /// Share this unit's fold state with a child (sub/closure body) compiler.
+    pub(super) fn inherit_fold_ctx(&self, child: &mut Compiler) {
+        child.fold_ctx = Arc::clone(&self.fold_ctx);
+        child.fold_root = false;
+    }
+
+    /// Flag a declaration whose name may install a user-defined operator
+    /// (`sub infix:<+>`, `my &prefix:<!>`, ...), disabling folding for the unit.
+    pub(super) fn note_operator_decl(&self, name: &str) {
+        if declares_operator(name) {
+            self.fold_ctx.note_operator_decl();
+        }
+    }
+}
+
+/// Scalar whose value is fully determined at compile time and whose identity is
+/// not observable.
+fn const_scalar(value: &Value) -> bool {
+    matches!(
+        value.view(),
+        ValueView::Int(_)
+            | ValueView::BigInt(_)
+            | ValueView::Num(_)
+            | ValueView::Rat(..)
+            | ValueView::Str(_)
+            | ValueView::Bool(_)
+    )
+}
+
+/// Numeric scalar: arithmetic folds only accept these, so the VM's
+/// string→number / type-object coercion bridges (which can raise
+/// X::Str::Numeric) are never bypassed.
+fn const_numeric(value: &Value) -> bool {
+    matches!(
+        value.view(),
+        ValueView::Int(_) | ValueView::BigInt(_) | ValueView::Num(_) | ValueView::Rat(..)
+    )
+}
+
+/// Evaluate an expression to a constant scalar, or `None` if it is not one.
+fn const_operand(expr: &Expr) -> Option<Value> {
+    match expr {
+        Expr::Literal(v) | Expr::LiteralSrc(v, _) => const_scalar(v).then(|| v.clone()),
+        Expr::Grouped(inner) => const_operand(inner),
+        Expr::Unary { op, expr } => fold_unary(op, expr),
+        Expr::Binary { left, op, right } => fold_binary(left, op, right),
+        _ => None,
+    }
+}
+
+fn fold_unary(op: &TokenKind, expr: &Expr) -> Option<Value> {
+    let value = const_operand(expr)?;
+    match op {
+        // `-"3"` goes through the VM's string→numeric coercion (which can raise
+        // X::Str::Numeric), so only numeric literals fold.
+        TokenKind::Minus if const_numeric(&value) => crate::builtins::arith_negate(value).ok(),
+        _ => None,
+    }
+}
+
+fn fold_binary(left: &Expr, op: &TokenKind, right: &Expr) -> Option<Value> {
+    let l = const_operand(left)?;
+    let r = const_operand(right)?;
+    fold_values(op, l, r)
+}
+
+/// Apply `op` to two constant scalars using the VM's own operator
+/// implementations. `None` = do not fold (unsupported operator, operand type
+/// outside the proven-safe set, or an evaluation that raises).
+fn fold_values(op: &TokenKind, l: Value, r: Value) -> Option<Value> {
+    match op {
+        // Arithmetic: numeric operands only — matches the VM arms, which for
+        // Int/Num/Rat/BigInt reduce to exactly these calls (the numeric-bridge
+        // coercion in between is the identity for numeric values).
+        TokenKind::Plus if const_numeric(&l) && const_numeric(&r) => {
+            crate::builtins::arith_add(l, r).ok()
+        }
+        TokenKind::Minus if const_numeric(&l) && const_numeric(&r) => {
+            Some(crate::builtins::arith_sub(l, r))
+        }
+        TokenKind::Star if const_numeric(&l) && const_numeric(&r) => {
+            Some(crate::builtins::arith_mul(l, r))
+        }
+        TokenKind::Slash if const_numeric(&l) && const_numeric(&r) => {
+            crate::builtins::arith_div(l, r).ok()
+        }
+        TokenKind::Percent if const_numeric(&l) && const_numeric(&r) => {
+            crate::builtins::arith_mod(l, r).ok()
+        }
+        TokenKind::StarStar if const_numeric(&l) && const_numeric(&r) => {
+            Some(crate::builtins::arith_pow(l, r))
+        }
+        // Concatenation: `~` stringifies via `.Stringy`/`.Str`, which for scalar
+        // values is exactly what `concat_values` does (only Instances/Packages
+        // can dispatch a user method, and those never reach here).
+        TokenKind::Tilde => Some(crate::runtime::Interpreter::concat_values(l, r)),
+        // Numeric comparison: restricted to the Int/Int and Num/Num pairs the VM
+        // itself fast-paths, so the folded result is the same expression the VM
+        // would evaluate (no Rat/BigInt cross-type comparison logic duplicated).
+        TokenKind::EqEq
+        | TokenKind::BangEq
+        | TokenKind::Lt
+        | TokenKind::Lte
+        | TokenKind::Gt
+        | TokenKind::Gte => fold_compare(op, &l, &r),
+        _ => None,
+    }
+}
+
+fn fold_compare(op: &TokenKind, l: &Value, r: &Value) -> Option<Value> {
+    let ord = match (l.view(), r.view()) {
+        (ValueView::Int(a), ValueView::Int(b)) => a.cmp(&b),
+        (ValueView::Num(a), ValueView::Num(b)) => {
+            // NaN is unordered (`partial_cmp` → None): every comparison against
+            // it is False, except `!=`, which is True (`NaN != NaN`).
+            let Some(ord) = a.partial_cmp(&b) else {
+                return Some(Value::truth(matches!(op, TokenKind::BangEq)));
+            };
+            ord
+        }
+        _ => return None,
+    };
+    let result = match op {
+        TokenKind::EqEq => ord.is_eq(),
+        TokenKind::BangEq => ord.is_ne(),
+        TokenKind::Lt => ord.is_lt(),
+        TokenKind::Lte => ord.is_le(),
+        TokenKind::Gt => ord.is_gt(),
+        TokenKind::Gte => ord.is_ge(),
+        _ => return None,
+    };
+    Some(Value::truth(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn int(n: i64) -> Expr {
+        Expr::Literal(Value::int(n))
+    }
+
+    fn bin(l: Expr, op: TokenKind, r: Expr) -> Expr {
+        Expr::Binary {
+            left: Box::new(l),
+            op,
+            right: Box::new(r),
+        }
+    }
+
+    #[test]
+    fn folds_nested_int_arithmetic() {
+        // 60 * 60 * 24
+        let expr = bin(
+            bin(int(60), TokenKind::Star, int(60)),
+            TokenKind::Star,
+            int(24),
+        );
+        let folded = const_operand(&expr).expect("folds");
+        assert_eq!(folded.as_int(), Some(86400));
+    }
+
+    #[test]
+    fn folds_unary_minus() {
+        let expr = Expr::Unary {
+            op: TokenKind::Minus,
+            expr: Box::new(int(7)),
+        };
+        assert_eq!(const_operand(&expr).unwrap().as_int(), Some(-7));
+    }
+
+    #[test]
+    fn int_division_folds_to_rat() {
+        let folded = fold_values(&TokenKind::Slash, Value::int(1), Value::int(3)).expect("folds");
+        // 1/3 is a Rat in raku, not a Num.
+        assert!(matches!(folded.view(), ValueView::Rat(1, 3)));
+    }
+
+    #[test]
+    fn division_by_zero_folds_to_the_rat_the_vm_would_build() {
+        // `1/0` is a Rat in raku — it only fails when the value is *used*. The
+        // fold calls the same `arith_div` the VM calls, so it produces that same
+        // Rat rather than raising at compile time. An operator that does return
+        // an error (`Err`) is left unfolded, and the VM raises it at runtime.
+        let folded = fold_values(&TokenKind::Slash, Value::int(1), Value::int(0)).expect("folds");
+        assert!(matches!(folded.view(), ValueView::Rat(1, 0)));
+    }
+
+    #[test]
+    fn string_operands_do_not_fold_arithmetic() {
+        // `"3" + 4` must keep the VM's string→numeric coercion path.
+        assert!(
+            fold_values(&TokenKind::Plus, Value::str("3".to_string()), Value::int(4)).is_none()
+        );
+    }
+
+    #[test]
+    fn concat_folds() {
+        let folded = fold_values(
+            &TokenKind::Tilde,
+            Value::str("a".to_string()),
+            Value::int(1),
+        )
+        .expect("folds");
+        assert_eq!(folded.as_str(), Some("a1"));
+    }
+
+    #[test]
+    fn nan_comparisons_fold_as_unordered() {
+        let nan = Value::num(f64::NAN);
+        // Every comparison against NaN is False — except `!=`, which is True.
+        for (op, expected) in [
+            (TokenKind::EqEq, false),
+            (TokenKind::Lt, false),
+            (TokenKind::Gte, false),
+            (TokenKind::BangEq, true),
+        ] {
+            let folded = fold_values(&op, nan.clone(), nan.clone()).expect("folds");
+            assert_eq!(folded.truthy(), expected, "NaN {op:?} NaN");
+        }
+    }
+
+    #[test]
+    fn variables_do_not_fold() {
+        let expr = bin(Expr::Var("x".to_string()), TokenKind::Plus, int(1));
+        assert!(const_operand(&expr).is_none());
+    }
+}

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -117,6 +117,13 @@ impl Compiler {
         op: &TokenKind,
         right: &Expr,
     ) {
+        // Constant folding (ADR-0006 §2.1): a literal-only pure expression
+        // (`60 * 60 * 24`) is evaluated here and collapses to one LoadConst.
+        if let Some(folded) = self.try_const_fold_binary(left, op, right) {
+            let idx = self.code.add_constant(folded);
+            self.code.emit(OpCode::LoadConst(idx));
+            return;
+        }
         // `$var andthen/orelse/notandthen .=method` writes the `.=` result back to
         // the chain's root variable (the topic `$_` aliases it in raku).
         let retargeted_right;

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -3,6 +3,13 @@ use crate::symbol::Symbol;
 
 impl Compiler {
     pub(super) fn compile_expr_unary(&mut self, op: &TokenKind, expr: &Expr) {
+        // Constant folding (ADR-0006 §2.1): `-1` / `-(2 * 3)` collapse to one
+        // LoadConst instead of a LoadConst + Negate pair.
+        if let Some(folded) = self.try_const_fold_unary(op, expr) {
+            let idx = self.code.add_constant(folded);
+            self.code.emit(OpCode::LoadConst(idx));
+            return;
+        }
         match op {
             TokenKind::Minus => {
                 self.compile_expr(expr);

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -98,6 +98,7 @@ impl Compiler {
             .map(|s| Self::is_definite_return_spec(s))
             .unwrap_or(false);
         let mut sub_compiler = Compiler::new();
+        self.inherit_fold_ctx(&mut sub_compiler);
         sub_compiler.is_routine = true;
         sub_compiler.lexically_in_routine = true;
         // A method body carries the synthetic `?CLASS` parameter injected by the
@@ -587,6 +588,7 @@ impl Compiler {
         is_routine: bool,
     ) -> CompiledCode {
         let mut sub_compiler = Compiler::new();
+        self.inherit_fold_ctx(&mut sub_compiler);
         sub_compiler.is_routine = is_routine;
         // Make the names of all constants visible at this closure's definition
         // point known to the child compiler, so a `constant X` inside the body

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -29,6 +29,7 @@ pub(crate) fn shadow_slots_active() -> bool {
     static ACTIVE: OnceLock<bool> = OnceLock::new();
     *ACTIVE.get_or_init(|| std::env::var_os("MUTSU_NO_SHADOW_SLOTS").is_none())
 }
+mod const_fold;
 mod expr;
 mod expr_binary;
 mod expr_block;
@@ -53,6 +54,7 @@ mod helpers_stmt_analysis;
 mod helpers_sub_body;
 mod stmt;
 
+#[derive(Clone)]
 pub(crate) struct Compiler {
     code: CompiledCode,
     local_map: HashMap<String, u32>,
@@ -237,6 +239,13 @@ pub(crate) struct Compiler {
     /// Standalone Pair literals (`my $p = (k => $v)`) still capture for
     /// write-through (S02:1704).
     suppress_pair_capture: bool,
+    /// Constant-folding state (ADR-0006 §2.1), shared with every child compiler
+    /// of this compilation unit so an operator declaration found while compiling
+    /// a sub body disables folding for the whole unit.
+    fold_ctx: std::sync::Arc<const_fold::FoldCtx>,
+    /// True only for the compiler that owns `fold_ctx` (the unit-level one).
+    /// Child compilers inherit the Arc and must not trigger the refold pass.
+    fold_root: bool,
 }
 
 impl Compiler {
@@ -281,6 +290,8 @@ impl Compiler {
             suppress_pair_capture: false,
             synthetic_block_body: false,
             next_try_is_bare_block: false,
+            fold_ctx: std::sync::Arc::new(const_fold::FoldCtx::enabled()),
+            fold_root: true,
         }
     }
 
@@ -1207,10 +1218,35 @@ impl Compiler {
         }
     }
 
+    /// Compile a compilation unit.
+    ///
+    /// Constant folding (ADR-0006 §2.1) is only valid while no user-defined
+    /// operator is declared in the unit — a `sub infix:<+>` overrides even
+    /// native `Int + Int`. Declarations can hide anywhere (a nested block, a sub
+    /// body, a class body), so instead of statically walking the AST for them,
+    /// the declaration sites flag the shared `FoldCtx` as they are compiled and
+    /// the unit is recompiled here, folding disabled, if one turned up after
+    /// something had already been folded. Only files that declare operators pay
+    /// the second pass.
     pub(crate) fn compile(
-        mut self,
+        self,
         stmts: &[Stmt],
     ) -> (CompiledCode, HashMap<String, CompiledFunction>) {
+        if !self.fold_root || !self.fold_ctx.is_enabled() {
+            return self.compile_unit(stmts);
+        }
+        let pristine = self.clone();
+        let ctx = std::sync::Arc::clone(&self.fold_ctx);
+        let compiled = self.compile_unit(stmts);
+        if !ctx.needs_refold_pass() {
+            return compiled;
+        }
+        let mut retry = pristine;
+        retry.fold_ctx = std::sync::Arc::new(const_fold::FoldCtx::disabled());
+        retry.compile_unit(stmts)
+    }
+
+    fn compile_unit(mut self, stmts: &[Stmt]) -> (CompiledCode, HashMap<String, CompiledFunction>) {
         // Hoist top-level `use Test` declarations to the front (Raku `use` is
         // BEGIN-time, so test functions are available throughout the file even
         // when `plan`/`ok` appear textually before `use Test;`).

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -789,6 +789,9 @@ impl Compiler {
                 custom_traits,
                 where_constraint,
             } => {
+                // `my &infix:<+> = ...` installs a user operator just like a
+                // `sub infix:<+>` does — disable constant folding (ADR-0006 §2.1).
+                self.note_operator_decl(name);
                 // Record this declaration for an enclosing scope-isolating
                 // do-block (string-interpolation `{...}`) so it can revert
                 // exactly its own block-local declarations on exit.
@@ -2726,6 +2729,13 @@ impl Compiler {
                 custom_traits,
                 ..
             } => {
+                // A user-defined operator overrides even native `Int + Int`, so
+                // it disables constant folding for the whole unit (ADR-0006
+                // §2.1). A runtime-named sub (`sub ::($n)`) could be anything.
+                self.note_operator_decl(&name.resolve());
+                if name_expr.is_some() {
+                    self.fold_ctx.note_operator_decl();
+                }
                 // Reject overriding a reserved special-form operator
                 // (`infix:<=>`, `infix:<:=>`, `infix:<::=>`, `infix:<~~>`,
                 // `prefix:<|>`) — these are handled directly by the compiler and
@@ -2887,12 +2897,14 @@ impl Compiler {
                 self.code.emit(OpCode::RegisterToken(idx));
             }
             Stmt::ProtoDecl {
+                name,
                 params,
                 param_defs,
                 body,
                 ..
             } => {
                 let _ = (params.len(), param_defs.len(), body.len());
+                self.note_operator_decl(&name.resolve());
                 let idx = self.code.add_stmt(stmt.clone());
                 self.code.emit(OpCode::RegisterProtoSub(idx));
             }

--- a/t/const-fold-infix-override.t
+++ b/t/const-fold-infix-override.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+# Pin for the constant-folding safety condition (ADR-0006 §2.1): a user-defined
+# `infix:<op>` overrides even native `Int + Int`, so declaring one anywhere in
+# the compilation unit must disable folding for the whole file — including for
+# expressions that appear *before* the declaration, since mutsu registers the
+# operator globally.
+
+plan 5;
+
+# Compiled before the declaration below, yet the override must still win.
+is 1 + 2, 99, 'a literal-only expression before the declaration is not folded';
+
+sub infix:<+>($a, $b) { 99 }
+
+is 3 + 4, 99, 'a literal-only expression after the declaration is not folded';
+is 2 + 3 * 4, 99, 'a nested literal expression is not folded either';
+
+# Operators that are NOT overridden still fold, and still produce the right value.
+is 6 * 7, 42, 'an unrelated operator keeps working';
+is 'a' ~ 'b', 'ab', 'concatenation keeps working';
+
+done-testing;

--- a/t/const-fold.t
+++ b/t/const-fold.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# Constant folding (ADR-0006 §2.1): literal-only pure expressions are evaluated
+# at compile time. Every case here must keep the exact runtime semantics — the
+# folded value has to be indistinguishable from the value the VM would compute.
+
+plan 26;
+
+# --- integer arithmetic ---------------------------------------------------
+is 60 * 60 * 24, 86400, 'nested Int multiplication folds';
+is 2 + 3 * 4, 14, 'precedence is preserved when folding';
+is (2 + 3) * 4, 20, 'parenthesised subexpression folds';
+is 7 - 9, -2, 'subtraction folds to a negative Int';
+is 7 % 3, 1, 'modulo folds';
+is -1 + 2, 1, 'unary minus operand folds';
+is -(2 * 3), -6, 'unary minus of a folded subexpression';
+is 10 - -3, 13, 'subtraction of a negative literal';
+
+# --- type-preserving numeric promotion ------------------------------------
+# The fold calls the VM's own arithmetic, so Int/Int stays a Rat and an
+# overflowing power promotes to a big integer, exactly as at runtime.
+is (1 / 3).WHAT.^name, 'Rat', 'Int / Int folds to a Rat, not a Num';
+is 1 / 4, 0.25, 'Rat value is correct';
+is (1 / 3) + (1 / 6), 0.5, 'Rat arithmetic folds exactly';
+is 2 ** 100, 1267650600228229401496703205376, 'Int ** Int promotes to a big integer';
+is (2 ** 100).WHAT.^name, 'Int', 'the promoted value is still an Int';
+is 1.5 + 2.5, 4, 'Rat literals fold';
+is (1.5 + 2.5).WHAT.^name, 'Rat', 'Rat + Rat stays a Rat';
+is 1e2 + 1, 101e0, 'Num literal folds';
+is (1e2 + 1).WHAT.^name, 'Num', 'Num + Int stays a Num';
+
+# --- strings and comparisons ----------------------------------------------
+is 'a' ~ 'b' ~ 'c', 'abc', 'string concatenation folds';
+is 'x' ~ 1 ~ 2.5, 'x12.5', 'concatenation stringifies numeric literals';
+ok 1 < 2, 'numeric comparison folds';
+nok 2.0e0 > 3.0e0, 'Num comparison folds';
+ok 1 == 1, 'equality folds';
+
+# --- expressions that must NOT fold ---------------------------------------
+my $x = 10;
+is $x + 2, 12, 'an expression with a variable is not folded';
+is '3' + 4, 7, 'string operand keeps the numeric-coercion path';
+dies-ok { EVAL '1 div 0' }, 'a compile-time-evaluable error still dies at runtime';
+throws-like { '3x' + 1 }, X::Str::Numeric, 'invalid numeric string still throws';
+
+done-testing;


### PR DESCRIPTION
Implements the first adopted slice of [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md): **§2.1 constant folding**.

Literal-only pure expressions (`60 * 60 * 24`, `'a' ~ 'b'`, `-1`) are evaluated at emit time and collapse to a single `LoadConst`.

## How it evaluates

The fold calls the **same native operator implementations the VM uses** (`builtins::arith_add/sub/mul/div/mod/pow`, `Interpreter::concat_values`), so `Int/Int → Rat`, the BigInt promotion of `2 ** 100`, and Num formatting agree with runtime semantics by construction (ADR §2.1-2: no separate "compile-time arithmetic").

Folded: arithmetic on numeric literals, `~` concatenation, and the Int/Int + Num/Num comparisons the VM itself fast-paths.
Not folded: string operands in arithmetic (`'3' + 4` must keep the coercion path that can raise `X::Str::Numeric`), and any evaluation returning an error (the VM raises it at runtime as before).

## Safety: operator overrides

A user `sub infix:<+>` overrides even native `Int + Int`, and mutsu registers it in a *global* set, so a declaration **anywhere** in the compilation unit (nested block, sub body, class body) forbids folding in that unit.

Statically walking the AST for such declarations would be unsound the day the walker misses a nested variant. Instead, the declaration sites that a declaration must pass through (`SubDecl`/`ProtoDecl`/`VarDecl`) flag a shared `FoldCtx` as they are compiled, and `Compiler::compile` **recompiles the whole unit with folding off** if a declaration turned up after something had been folded. Sound by construction; only files that declare operators pay the second pass. Folding is additionally off whenever the JIT's process-wide `USER_INFIX_DECLS` counter is non-zero (covers EVAL/blocks compiled after a module registered an operator).

Pin: `t/const-fold-infix-override.t` — even a `1 + 2` written *before* the `sub infix:<+>` is not folded.

## Measurements (release, median of 7, local)

| | fold off | fold on |
|---|---|---|
| time-parts executed opcodes | 7.60M (`Mul` 1.0M) | **6.40M (-15.8%)** (`Mul` 0.4M) |
| time-parts wall-clock (interp) | 0.65s | **0.61s (-6.2%)** |
| time-parts wall-clock (JIT on, default) | 0.60s | **0.59s** |

The JIT already compiles the constant `Mul` into native code, hence its smaller delta. Wall-clock does not drop proportionally to the opcode count because time-parts' remaining time is dominated by administrative opcodes (`SetSourceLine`, `MarkVarDeclContext`, `SetVarDynamic`, `CheckReadOnly`) — that is exactly what ADR §2.3 (peephole) targets next. debug-guard is unchanged here (its `constant DEBUG` guard is §2.2's job).

`MUTSU_CONST_FOLD=0` disables folding (A/B, bisecting).

## Verification

- `make test` (1682 files) PASS — one real bug caught and fixed by it: `NaN != NaN` must fold to **True** (unordered), not False.
- `make roast` (1384 files, release) PASS.
- New: `t/const-fold.t` (26 semantics cases, verified to pass under `raku` as well), `t/const-fold-infix-override.t`, 8 Rust unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ