### PR TITLE
perf(compiler): inline `constant` reads and resolve constant conditions (ADR-0006 §2.2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -277,7 +277,9 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       - [x] §2.4 定数プール dedup（#4486 — `add_constant` に逆引き index。
             同値スカラ定数がスロットを共有し、実測で add_constant の 29〜45% が dedup。
             `MUTSU_VM_STATS` の `const-pool:` 行で追跡）
-      - [ ] §2.2 `constant` 読みのインライン化 + 定数条件 DCE（debug-guard 2.2x の本命）
+      - [x] §2.2 `constant` 読みのインライン化 + 定数条件 DCE（#4487 — `constant DEBUG = False;
+            if DEBUG {...}` がブロックごと消える。debug-guard 実行 opcode 3.00M→2.60M・
+            raku 比 **2.2x→1.3x**。死んだ分岐に宣言があるときは消さず通常コンパイル）
       - [ ] §2.3 peephole（administrative op 列 — `SetSourceLine` 重複除去・`my $x = <expr>` 宣言列の融合。
             ヒストグラム駆動で対象選定）
 - [ ] **opcode 残件（[docs/opcode-design-review.md](docs/opcode-design-review.md) §2/§5/§6・#4279 の続き）**:

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,29 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-13: ベースライン最適化 第3弾 — `constant` インライン化 + 定数条件 DCE（ADR-0006 §2.2）
+
+`constant DEBUG = False; if DEBUG { note ... }` というガード付きロギングは実コードの頻出
+パターンだが、mutsu はこれを毎回 `GetBareWord`＋`JumpIfFalse` として**実行して**いた（#4487）。
+
+- **実装**: 初期化子がコンパイル時定数スカラである `constant` の値を追跡し、
+  読みを `LoadConst` に置換（子コンパイラ = sub/closure 本体にも伝播するので、
+  sub の中から読むファイルレベル `constant` もインラインされる）。
+  条件式がそれで定数になった `if`/`unless` は分岐をコンパイル時に解決する。
+- **安全設計**:
+  - **死んだ分岐に宣言があれば消さない**。Raku は分岐を通らなくても宣言をコンパイル時に
+    設置するため、消してよいのは「素の式文だけ」の分岐（= ロギングガードの形）に限る。
+  - **同名の非 constant ローカルがあればインラインしない**。mutsu は AST でシジルを剥がすので
+    `my $DEBUG` と sigilless `constant DEBUG` が `local_map` の同じキーに載る。
+    `local_map` にあって `constant_vars_in_scope` にない名前＝シャドウとみなして通常解決に落とす。
+  - スコープ生存期間は `constant_vars_in_scope` と同一（ブロックを出た constant は
+    `our` スコープのパッケージシンボルに戻るのでインライン対象外）。
+  - コンテナ値の constant は同一性が観測可能なので対象外（ADR §2.2 どおり）。
+- **実測**（release・median of 5）: debug-guard の実行 opcode **3.00M→2.60M（−13.3%）**で
+  `GetBareWord`・`JumpIfFalse` 各 200k が完全消滅。wall-clock は
+  **JIT on 0.34s→0.25s（−26%）**・interp 0.32s→0.26s。raku 比 **2.2x → 1.3x**。
+- pin = `t/const-inline-dce.t`（16 ケース・raku でも同じ結果になることを確認）。
+
 ## 2026-07-13: ベースライン最適化 第2弾 — 定数プール dedup（ADR-0006 §2.4）
 
 `CompiledCode::add_constant` は無条件に `constants.push` していたため、同じ名前文字列・

--- a/src/compiler/const_fold.rs
+++ b/src/compiler/const_fold.rs
@@ -1,11 +1,19 @@
-//! Compile-time constant folding of literal-only expressions (ADR-0006 §2.1).
+//! Compile-time constant folding and `constant` inlining (ADR-0006 §2.1/§2.2).
 //!
-//! A binary/unary expression whose operands are all literal scalars is
+//! A binary/unary expression whose operands are all constant scalars is
 //! evaluated at emit time and replaced by a single `LoadConst`. The evaluation
 //! calls the *same* native operator implementations the VM uses
 //! (`builtins::arith_*`, `Interpreter::concat_values`), so Int→BigInt
 //! promotion, `Int/Int → Rat`, and Num formatting automatically agree with
 //! runtime semantics — no separate "compile-time arithmetic" exists.
+//!
+//! An operand may also be an in-scope `constant` whose own initializer was a
+//! constant scalar (§2.2): its reads compile to `LoadConst` rather than a
+//! package lookup, and an `if`/`unless` whose condition becomes constant that
+//! way resolves its branch at compile time (`constant DEBUG = False;
+//! if DEBUG { note ... }` emits nothing). A branch proved unreachable is only
+//! dropped when it declares nothing — raku installs declarations even in a
+//! never-taken branch — see [`Compiler::branch_is_droppable`].
 //!
 //! Safety (ADR-0006 §2.1):
 //!
@@ -40,7 +48,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::Compiler;
-use crate::ast::Expr;
+use crate::ast::{Expr, Stmt};
 use crate::token_kind::TokenKind;
 use crate::value::{Value, ValueView};
 
@@ -124,7 +132,9 @@ impl Compiler {
         if !self.const_fold_enabled() {
             return None;
         }
-        let value = fold_binary(left, op, right)?;
+        let l = self.const_operand(left)?;
+        let r = self.const_operand(right)?;
+        let value = fold_values(op, l, r)?;
         self.fold_ctx.folded.store(true, Ordering::Relaxed);
         Some(value)
     }
@@ -134,15 +144,133 @@ impl Compiler {
         if !self.const_fold_enabled() {
             return None;
         }
-        let value = fold_unary(op, expr)?;
+        let value = self.fold_unary(op, expr)?;
         self.fold_ctx.folded.store(true, Ordering::Relaxed);
         Some(value)
     }
 
+    /// The compile-time value of an in-scope `constant` NAME, if it has one
+    /// (ADR-0006 §2.2). Only constants whose initializer is itself a constant
+    /// *scalar* are tracked; a container constant keeps an observable identity
+    /// and is never inlined.
+    pub(super) fn constant_value(&self, name: &str) -> Option<&Value> {
+        if !self.const_fold_enabled() {
+            return None;
+        }
+        // mutsu strips sigils in the AST, so a `my $DEBUG` / a parameter `$DEBUG`
+        // and a sigilless `constant DEBUG` collide on the same `local_map` key.
+        // Anything holding that key which is not the constant itself shadows it:
+        // fall back to the ordinary (GetLocal/GetBareWord) resolution.
+        if self.local_map.contains_key(name) && !self.constant_vars_in_scope.contains(name) {
+            return None;
+        }
+        if self.sigilless_locals.contains(name) {
+            return None;
+        }
+        self.constant_values
+            .get(name)
+            .or_else(|| self.outer_constant_values.get(name))
+    }
+
+    /// Record `constant NAME = <expr>` when its value is a constant scalar, so
+    /// later reads compile to `LoadConst` instead of a package/global lookup.
+    pub(super) fn note_constant_decl(&mut self, name: &str, init: &Expr) {
+        if !self.const_fold_enabled() {
+            return;
+        }
+        match self.const_operand(init) {
+            Some(value) => {
+                self.constant_values.insert(name.to_string(), value);
+            }
+            // A non-constant initializer (`constant NOW = now`) shadows any outer
+            // same-named constant's value: reads of it must not inline.
+            None => self.forget_constant(name),
+        }
+    }
+
+    /// An ordinary declaration of `name` (a `my`/`state` variable) shadows a
+    /// same-named constant — stop inlining it.
+    pub(super) fn forget_constant(&mut self, name: &str) {
+        self.constant_values.remove(name);
+        self.outer_constant_values.remove(name);
+    }
+
+    /// Evaluate an expression to a constant scalar, resolving in-scope
+    /// `constant` reads. `None` = not a compile-time constant.
+    pub(super) fn const_operand(&self, expr: &Expr) -> Option<Value> {
+        match expr {
+            Expr::Literal(v) | Expr::LiteralSrc(v, _) => const_scalar(v).then(|| v.clone()),
+            Expr::Grouped(inner) => self.const_operand(inner),
+            Expr::Unary { op, expr } => self.fold_unary(op, expr),
+            Expr::Binary { left, op, right } => {
+                let l = self.const_operand(left)?;
+                let r = self.const_operand(right)?;
+                fold_values(op, l, r)
+            }
+            // Only sigilless constant reads (`constant DEBUG = False`) resolve
+            // here. A `constant $x` is read as `Expr::Var`, which shares its
+            // `local_map` key with an ordinary `my $x`, so it is left alone.
+            Expr::BareWord(name) => self.constant_value(name).cloned(),
+            _ => None,
+        }
+    }
+
+    fn fold_unary(&self, op: &TokenKind, expr: &Expr) -> Option<Value> {
+        let value = self.const_operand(expr)?;
+        match op {
+            // `-"3"` goes through the VM's string→numeric coercion (which can
+            // raise X::Str::Numeric), so only numeric constants fold.
+            TokenKind::Minus if const_numeric(&value) => crate::builtins::arith_negate(value).ok(),
+            TokenKind::Bang => Some(Value::truth(!value.truthy())),
+            _ => None,
+        }
+    }
+
     /// Share this unit's fold state with a child (sub/closure body) compiler.
+    /// The child also inherits the constants visible at its definition point, so
+    /// a `constant DEBUG` read inside a sub body still inlines.
     pub(super) fn inherit_fold_ctx(&self, child: &mut Compiler) {
         child.fold_ctx = Arc::clone(&self.fold_ctx);
         child.fold_root = false;
+        child.outer_constant_values = self
+            .outer_constant_values
+            .iter()
+            .chain(self.constant_values.iter())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+    }
+
+    /// The `if`/`unless` condition's compile-time truth value, if it has one
+    /// (ADR-0006 §2.2 — `constant DEBUG = False; if DEBUG {...}`).
+    pub(super) fn const_condition(&self, cond: &Expr) -> Option<bool> {
+        self.const_operand(cond).map(|v| v.truthy())
+    }
+
+    /// Whether a branch that a constant condition proved unreachable may simply
+    /// not be emitted.
+    ///
+    /// Raku *compiles* declarations regardless of the branch being taken — a
+    /// `sub` or `constant` inside `if False {...}` is still installed — so a
+    /// branch is only dropped when it holds nothing but plain expression
+    /// statements (the `if DEBUG { note ... }` logging-guard shape). Anything
+    /// else (declarations, phasers, control flow, `use`) compiles normally and
+    /// the runtime branch stays.
+    pub(super) fn branch_is_droppable(stmts: &[Stmt]) -> bool {
+        stmts.iter().all(|s| match s {
+            Stmt::SetLine(_) => true,
+            Stmt::Expr(e) => expr_is_droppable(e),
+            Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
+                es.iter().all(expr_is_droppable)
+            }
+            Stmt::Call { args, .. } => args.iter().all(|a| match a {
+                crate::ast::CallArg::Positional(e)
+                | crate::ast::CallArg::Invocant(e)
+                | crate::ast::CallArg::Slip(e)
+                | crate::ast::CallArg::Named { value: Some(e), .. } => expr_is_droppable(e),
+                crate::ast::CallArg::Named { value: None, .. } => true,
+            }),
+            _ => false,
+        })
     }
 
     /// Flag a declaration whose name may install a user-defined operator
@@ -151,6 +279,27 @@ impl Compiler {
         if declares_operator(name) {
             self.fold_ctx.note_operator_decl();
         }
+    }
+}
+
+/// Whether an expression is free of anything Raku installs at *compile* time
+/// (a declaration, an embedded block that could hold one, a phaser), so a
+/// constant-false branch containing it can simply not be emitted. Deliberately
+/// a small whitelist: an expression form not listed here keeps the branch.
+fn expr_is_droppable(expr: &Expr) -> bool {
+    match expr {
+        Expr::Literal(_)
+        | Expr::LiteralSrc(..)
+        | Expr::Var(_)
+        | Expr::ArrayVar(_)
+        | Expr::HashVar(_)
+        | Expr::BareWord(_) => true,
+        Expr::Grouped(inner) => expr_is_droppable(inner),
+        Expr::StringInterpolation(parts) => parts.iter().all(expr_is_droppable),
+        Expr::Unary { expr, .. } => expr_is_droppable(expr),
+        Expr::Binary { left, right, .. } => expr_is_droppable(left) && expr_is_droppable(right),
+        Expr::Call { args, .. } => args.iter().all(expr_is_droppable),
+        _ => false,
     }
 }
 
@@ -176,33 +325,6 @@ fn const_numeric(value: &Value) -> bool {
         value.view(),
         ValueView::Int(_) | ValueView::BigInt(_) | ValueView::Num(_) | ValueView::Rat(..)
     )
-}
-
-/// Evaluate an expression to a constant scalar, or `None` if it is not one.
-fn const_operand(expr: &Expr) -> Option<Value> {
-    match expr {
-        Expr::Literal(v) | Expr::LiteralSrc(v, _) => const_scalar(v).then(|| v.clone()),
-        Expr::Grouped(inner) => const_operand(inner),
-        Expr::Unary { op, expr } => fold_unary(op, expr),
-        Expr::Binary { left, op, right } => fold_binary(left, op, right),
-        _ => None,
-    }
-}
-
-fn fold_unary(op: &TokenKind, expr: &Expr) -> Option<Value> {
-    let value = const_operand(expr)?;
-    match op {
-        // `-"3"` goes through the VM's string→numeric coercion (which can raise
-        // X::Str::Numeric), so only numeric literals fold.
-        TokenKind::Minus if const_numeric(&value) => crate::builtins::arith_negate(value).ok(),
-        _ => None,
-    }
-}
-
-fn fold_binary(left: &Expr, op: &TokenKind, right: &Expr) -> Option<Value> {
-    let l = const_operand(left)?;
-    let r = const_operand(right)?;
-    fold_values(op, l, r)
 }
 
 /// Apply `op` to two constant scalars using the VM's own operator
@@ -297,7 +419,7 @@ mod tests {
             TokenKind::Star,
             int(24),
         );
-        let folded = const_operand(&expr).expect("folds");
+        let folded = Compiler::new().const_operand(&expr).expect("folds");
         assert_eq!(folded.as_int(), Some(86400));
     }
 
@@ -307,7 +429,10 @@ mod tests {
             op: TokenKind::Minus,
             expr: Box::new(int(7)),
         };
-        assert_eq!(const_operand(&expr).unwrap().as_int(), Some(-7));
+        assert_eq!(
+            Compiler::new().const_operand(&expr).unwrap().as_int(),
+            Some(-7)
+        );
     }
 
     #[test]
@@ -364,6 +489,6 @@ mod tests {
     #[test]
     fn variables_do_not_fold() {
         let expr = bin(Expr::Var("x".to_string()), TokenKind::Plus, int(1));
-        assert!(const_operand(&expr).is_none());
+        assert!(Compiler::new().const_operand(&expr).is_none());
     }
 }

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -155,6 +155,14 @@ impl Compiler {
                 self.code.emit(OpCode::ReactDone);
             }
             Expr::BareWord(name) => {
+                // An in-scope `constant` with a compile-time scalar value is read
+                // straight from the constant pool (ADR-0006 §2.2) instead of a
+                // GetLocal / GetBareWord package lookup.
+                if let Some(value) = self.constant_value(name).cloned() {
+                    let idx = self.code.add_constant(value);
+                    self.code.emit(OpCode::LoadConst(idx));
+                    return;
+                }
                 // Only resolve to GetLocal for sigilless bindings (e.g. `my \Foo = ...`)
                 // or builtin-type-safe locals.  `$`-sigiled variables whose `$` was
                 // stripped share the same key in local_map but must NOT shadow type

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -299,6 +299,26 @@ impl Compiler {
         self.code.patch_block_local_body_end(idx);
     }
 
+    /// Emit the branch a compile-time-constant `if` condition selected, with no
+    /// condition evaluation and no jumps around it (ADR-0006 §2.2). Mirrors how
+    /// the ordinary `Stmt::If` arm compiles the branch it jumps to, including the
+    /// `elsif` chain (which arrives as a lone nested `If` in the else position).
+    pub(super) fn compile_resolved_branch(&mut self, stmts: &[Stmt]) {
+        if stmts.is_empty() {
+            return;
+        }
+        if stmts.len() == 1 && matches!(stmts[0], Stmt::If { .. }) {
+            self.compile_stmt(&stmts[0]);
+        } else if Self::body_mutates_topic(stmts) {
+            self.synthetic_block_body = true;
+            self.compile_stmt(&Stmt::Block(stmts.to_vec()));
+        } else if Self::branch_declares_block_local(stmts) {
+            self.compile_block_local_branch(stmts);
+        } else {
+            self.compile_body_with_implicit_try(stmts);
+        }
+    }
+
     /// Compile a block body, automatically wrapping in implicit try if it contains
     /// CATCH or CONTROL blocks. This should be used for any block context (bare blocks,
     /// if branches, loop bodies, sub bodies) to ensure CATCH/CONTROL are not silently ignored.

--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -9,6 +9,7 @@ pub(super) struct LexicalScopeSnapshot {
     dynamic_scope_names: Option<std::collections::HashSet<String>>,
     constant_vars_in_scope: std::collections::HashSet<String>,
     constant_vars_current_scope: std::collections::HashSet<String>,
+    constant_values: std::collections::HashMap<String, Value>,
     my_vars_current_scope: std::collections::HashSet<String>,
     class_names_current_scope: std::collections::HashSet<String>,
 }
@@ -30,6 +31,11 @@ impl Compiler {
             dynamic_scope_names: self.dynamic_scope_names.clone(),
             constant_vars_in_scope: self.constant_vars_in_scope.clone(),
             constant_vars_current_scope: std::mem::take(&mut self.constant_vars_current_scope),
+            // Inlinable constant values follow the same lifecycle: one declared
+            // inside the entered block stops being inlined once it exits (it is
+            // then reached as an `our`-scoped package symbol), and an inner
+            // constant may shadow an outer one for the block's duration.
+            constant_values: self.constant_values.clone(),
             // The entered block starts with no `my` vars of its own, so a same-named
             // `my` inside it shadows (rather than redeclares) an outer one.
             my_vars_current_scope: std::mem::take(&mut self.my_vars_current_scope),
@@ -50,6 +56,7 @@ impl Compiler {
         // then resolves them via GetBareWord (package/global lookup).
         self.constant_vars_in_scope = saved.constant_vars_in_scope;
         self.constant_vars_current_scope = saved.constant_vars_current_scope;
+        self.constant_values = saved.constant_values;
         self.my_vars_current_scope = saved.my_vars_current_scope;
         self.class_names_current_scope = saved.class_names_current_scope;
     }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -246,6 +246,16 @@ pub(crate) struct Compiler {
     /// True only for the compiler that owns `fold_ctx` (the unit-level one).
     /// Child compilers inherit the Arc and must not trigger the refold pass.
     fold_root: bool,
+    /// Compile-time values of in-scope `constant`s whose initializer is itself a
+    /// constant scalar (ADR-0006 §2.2). Reads of these compile to `LoadConst`
+    /// instead of a package lookup, and an `if`/`unless` on one resolves its
+    /// branch at compile time. Follows `constant_vars_in_scope`'s lifecycle: a
+    /// constant leaving its declaring block stops being inlined (it is then an
+    /// `our`-scoped package symbol again).
+    constant_values: HashMap<String, Value>,
+    /// Same, for constants declared in an *enclosing* compiler — a sub body must
+    /// still inline the file-level `constant DEBUG` it reads.
+    outer_constant_values: HashMap<String, Value>,
 }
 
 impl Compiler {
@@ -292,6 +302,8 @@ impl Compiler {
             next_try_is_bare_block: false,
             fold_ctx: std::sync::Arc::new(const_fold::FoldCtx::enabled()),
             fold_root: true,
+            constant_values: HashMap::new(),
+            outer_constant_values: HashMap::new(),
         }
     }
 

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -902,6 +902,14 @@ impl Compiler {
                     }
                     self.constant_vars.insert(name.clone());
                     self.constant_vars_in_scope.insert(name.clone());
+                    // A `constant` with a compile-time-constant scalar value is
+                    // inlined at its read sites (ADR-0006 §2.2).
+                    self.note_constant_decl(name, expr);
+                } else {
+                    // An ordinary `my`/`state` of the same bare name shadows the
+                    // constant — mutsu strips sigils, so `my $DEBUG` and a
+                    // sigilless `constant DEBUG` collide. Stop inlining it.
+                    self.forget_constant(name);
                 }
                 // X::ParametricConstant: typed @/% constants are forbidden
                 if is_constant_decl
@@ -1553,6 +1561,26 @@ impl Compiler {
                 // the condition value as @_ in Raku).
                 let needs_at_underscore =
                     binding_var.is_none() && Self::body_uses_legacy_args(then_branch);
+                // A condition that is a compile-time constant resolves the branch
+                // here (ADR-0006 §2.2): `constant DEBUG = False; if DEBUG { note
+                // ... }` emits nothing at all. The unreachable branch is only
+                // dropped when it declares nothing (raku installs declarations
+                // even in a never-taken branch) — otherwise the runtime branch is
+                // compiled as usual.
+                if binding_var.is_none()
+                    && !needs_at_underscore
+                    && let Some(taken) = self.const_condition(cond)
+                {
+                    let (live, dead) = if taken {
+                        (then_branch, else_branch)
+                    } else {
+                        (else_branch, then_branch)
+                    };
+                    if Self::branch_is_droppable(dead) {
+                        self.compile_resolved_branch(live);
+                        return;
+                    }
+                }
                 if let Some(var_name) = binding_var {
                     // Desugar: if EXPR -> $var { BODY } else { ELSE }
                     // into: { my $var = EXPR; if $var { BODY } else { ELSE } }

--- a/t/const-inline-dce.t
+++ b/t/const-inline-dce.t
@@ -1,0 +1,79 @@
+use v6;
+use Test;
+
+# `constant` inlining + constant-condition branch resolution (ADR-0006 §2.2).
+# A constant whose value is a compile-time scalar is read straight from the
+# constant pool, and an if/unless on one resolves its branch at compile time.
+# Every case here must be indistinguishable from the un-inlined compilation.
+
+plan 16;
+
+constant DEBUG = False;
+constant LIMIT = 60 * 60;
+constant NAME  = 'mutsu';
+
+# --- reads ----------------------------------------------------------------
+is LIMIT, 3600, 'a constant folds its own initializer';
+is LIMIT + 1, 3601, 'an inlined constant folds into the surrounding expression';
+is NAME ~ '!', 'mutsu!', 'a Str constant inlines';
+is DEBUG, False, 'a Bool constant inlines';
+is LIMIT.WHAT.^name, 'Int', 'the inlined value keeps its type';
+
+# A constant read inside a sub body (a child compiler) still inlines.
+sub step($x) {
+    if DEBUG {
+        die 'the dead branch must never run';
+    }
+    $x * 2 + LIMIT
+}
+is step(1), 3602, 'a sub body inlines an outer constant';
+
+# --- constant conditions --------------------------------------------------
+my $ran = 0;
+if DEBUG { $ran = 1 }
+is $ran, 0, 'if on a False constant does not run its body';
+
+if DEBUG { $ran = 1 } else { $ran = 2 }
+is $ran, 2, 'the else branch of a False constant runs';
+
+unless DEBUG { $ran = 3 }
+is $ran, 3, 'unless on a False constant runs its body';
+
+constant ON = True;
+if ON { $ran = 4 } else { $ran = 5 }
+is $ran, 4, 'if on a True constant runs the then branch';
+
+# An elsif chain still resolves.
+if DEBUG      { $ran = 6 }
+elsif LIMIT   { $ran = 7 }
+else          { $ran = 8 }
+is $ran, 7, 'an elsif chain resolves through a constant condition';
+
+# --- a dead branch that declares something is still compiled ---------------
+# raku installs declarations at compile time, so a never-taken branch must not
+# simply be discarded when it contains one.
+if DEBUG {
+    my $never = 1;
+    $ran = $never;
+}
+is $ran, 7, 'a dead branch with a declaration does not run, and does not disturb the rest';
+
+# --- shadowing ------------------------------------------------------------
+{
+    constant DEBUG = True;
+    my $inner = 0;
+    if DEBUG { $inner = 1 }
+    is $inner, 1, 'an inner constant shadows the outer one inside its block';
+}
+my $outer = 0;
+if DEBUG { $outer = 1 }
+is $outer, 0, 'the outer constant is back in effect after the block';
+
+constant SHADOW = 1;
+{
+    my $SHADOW = 2;
+    is $SHADOW, 2, 'an ordinary `my` of the same bare name is not replaced by the constant';
+}
+is SHADOW, 1, 'the constant is unaffected by the shadowing `my`';
+
+done-testing;


### PR DESCRIPTION
Third adopted slice of [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md): **§2.2 `constant` inlining + constant-condition DCE**. Follows #4485 (§2.1 folding) and #4486 (§2.4 pool dedup).

`constant DEBUG = False; if DEBUG { note ... }` — the guarded-logging shape that is everywhere in real code — was *executed* every iteration as a `GetBareWord` + `JumpIfFalse`. A `constant` whose initializer is a compile-time constant scalar is now read straight from the constant pool, and an `if`/`unless` whose condition becomes constant that way resolves its branch at compile time, emitting nothing at all for the dead one.

Child compilers inherit the constants visible at their definition point, so a sub body still inlines the file-level `constant` it reads.

## Safety

- **A dead branch is only dropped when it declares nothing.** Raku installs declarations at compile time even in a never-taken branch, so the drop is limited to branches holding plain expression statements (the logging-guard shape); anything else compiles the runtime branch exactly as before.
- **Inlining is skipped when a non-constant local of the same bare name is in scope.** mutsu strips sigils in the AST, so `my $DEBUG` and a sigilless `constant DEBUG` share a `local_map` key; a key held by something that is not the constant itself is treated as shadowing it.
- Constants follow `constant_vars_in_scope`'s lifecycle: one that leaves its declaring block stops being inlined (it is an `our`-scoped package symbol again), and an inner constant shadows an outer one for its block.
- Container-valued constants keep an observable identity and are never inlined.
- Everything is still under the §2.1 operator-override guard (a unit that declares an operator folds/inlines nothing), and `MUTSU_CONST_FOLD=0` turns it all off.

## Measured (release, median of 5)

| debug-guard | fold off | fold on | raku |
|---|---|---|---|
| executed opcodes | 3.00M | **2.60M (-13.3%)** | — |
| wall-clock (JIT on, default) | 0.34s | **0.25s (-26%)** | 0.19s |
| wall-clock (interp) | 0.32s | **0.26s** | — |

`GetBareWord` and `JumpIfFalse` (200k each) disappear entirely. Against raku the benchmark goes from **2.2x to 1.3x** — ADR-0006 §1.2 flagged debug-guard as one of the two worst benchmarks in the suite; this closes it.

## Verification

- `make test` (1683 files) PASS
- `make roast` (1384 files, 219,806 tests, release) PASS
- New `t/const-inline-dce.t` (16 cases: reads, inlining inside a sub, elsif chains, dead branch with a declaration, inner-constant shadowing, `my $X` shadowing a sigilless `constant X`) — verified to pass under `raku` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ