### PR TITLE
perf(vm): fuse the `my $x = <expr>` declaration markers into one opcode (ADR-0006 §2.3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -280,8 +280,15 @@ per-call env deep clone 撤廃は完了（news/2026-06.md）。残レバー:
       - [x] §2.2 `constant` 読みのインライン化 + 定数条件 DCE（#4487 — `constant DEBUG = False;
             if DEBUG {...}` がブロックごと消える。debug-guard 実行 opcode 3.00M→2.60M・
             raku 比 **2.2x→1.3x**。死んだ分岐に宣言があるときは消さず通常コンパイル）
-      - [ ] §2.3 peephole（administrative op 列 — `SetSourceLine` 重複除去・`my $x = <expr>` 宣言列の融合。
-            ヒストグラム駆動で対象選定）
+      - [x] §2.3-a peephole 宣言列融合（#4488 — `my $x = <expr>` の
+            `MarkExplicitInitializerContext`+`MarkVarDeclContext`+`SetLocal` を
+            `SetLocalDecl` 1 命令に。time-parts 6.40M→5.40M opcode。emit 時に自分が積んだ
+            マーカーだけを書き換えるので jump index の再割当が不要）
+      - [ ] **§2.3-b `SetSourceLine` の廃止（ip→行の静的テーブル化）** — 残る最大の
+            administrative op。bench-fib の実行 opcode 8.9M 中 **1.9M（21%）**・time-parts 600k（11%）。
+            opcode を消して `CompiledCode` に per-ip 行テーブルを持ち、`cur_source_line` は
+            呼び出し境界とエラー生成時にだけ ip から引く。post-pass での op 削除は
+            jump/compound-op の index 書き換えを伴うので、テーブル化のほうが安全。
 - [ ] **opcode 残件（[docs/opcode-design-review.md](docs/opcode-design-review.md) §2/§5/§6・#4279 の続き）**:
       ラベル等の inline `Option<String>` payload（`Last`/`Next`/`Redo`/loop 系/`SmartMatchExpr.lhs_var`）
       の定数プール `Option<u32>` 化（`OpCode` を 48B 未満へ） / per-instruction 定数コスト

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,26 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-13: ベースライン最適化 第4弾 — 宣言列の融合（ADR-0006 §2.3 peephole 前半）
+
+`my $x = <expr>` は毎回 `MarkExplicitInitializerContext` + `MarkVarDeclContext` + `SetLocal` の
+3 命令を dispatch していた。マーカー 2 個の効果は「`SetLocal` 本体が読んで消すフラグを立てる」
+だけなので、1 命令 `SetLocalDecl { slot, explicit_init }` に融合した（#4488）。
+
+- **安全性**: 融合は `CompiledCode::emit()` の中で **今まさに自分が積んだマーカー列**だけを
+  書き換える。ジャンプ先はステートメント境界にしか記録されず、3 命令は連続 emit されるので
+  「マーカーの途中に飛び込む」経路が構造的に存在しない（最初のマーカーへ飛ぶ経路があっても、
+  融合命令はそのマーカー列＋`SetLocal` と同じことをするので同値）。post-pass で op を削除する
+  方式なら jump/compound-op の index 再割当が必要になるが、それを完全に回避している。
+- `compute_free_vars` の「宣言 vs 再代入」判定（`MarkVarDeclContext` の有無で区別）と
+  JIT（専用 helper `set_local_decl` を追加）も新命令に対応。JIT は引き続きホットループを
+  コンパイルする（compiles=1 / bailouts=0）。
+- **実測**: time-parts の実行 opcode **6.40M→5.40M（−15.6%）**。§2.1 と合わせて 7.60M→5.40M（−29%）。
+  wall-clock は release で time-parts 0.63→0.58s（interp）・0.58→0.55s（JIT on）。
+- pin = `t/decl-marker-fusion.t`（宣言 vs 再代入・explicit initializer の有無・クロージャ捕捉。raku でも同結果）。
+- **次の的**: `SetSourceLine` が bench-fib の実行 opcode 8.9M 中 **1.9M（21%）**、time-parts で 600k（11%）。
+  これは opcode を消して ip→行の静的テーブルに移すのが本筋（PLAN §5 Lever 7 §2.3-b）。
+
 ## 2026-07-13: ベースライン最適化 第3弾 — `constant` インライン化 + 定数条件 DCE（ADR-0006 §2.2）
 
 `constant DEBUG = False; if DEBUG { note ... }` というガード付きロギングは実コードの頻出

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -234,6 +234,17 @@ pub(crate) enum OpCode {
     /// Used by `=:=` to compare raw container references.
     GetLocalRaw(u32),
     SetLocal(u32),
+    /// `SetLocal` fused with the declaration markers that always precede it in a
+    /// `my $x = <expr>` (ADR-0006 §2.3 peephole): `MarkExplicitInitializerContext`
+    /// (only when `explicit_init`) + `MarkVarDeclContext` + `SetLocal(slot)`.
+    /// Three dispatches per declaration collapse into one; the VM sets the same
+    /// two context flags before running the identical `SetLocal` body, so the
+    /// semantics are unchanged. Fusion happens in `emit()`, which can only see —
+    /// and therefore only ever rewrite — a marker pair it just emitted itself.
+    SetLocalDecl {
+        slot: u32,
+        explicit_init: bool,
+    },
     GetGlobal(u32),
     /// Read a captured read-only scalar free variable by index from this frame's
     /// upvalue array (`self.upvalues`). Emitted in place of `GetGlobal` for a
@@ -2441,6 +2452,9 @@ impl CompiledCode {
                     }
                     pending_decl = false;
                 }
+                // The fused declaration (ADR-0006 §2.3) carries the marker with
+                // it, so it is a declaration, never a reassignment.
+                OpCode::SetLocalDecl { .. } => pending_decl = false,
                 OpCode::AssignExprLocal(slot) => {
                     if let Some(name) = self.locals.get(*slot as usize) {
                         self_mutated.insert(Symbol::intern(name));
@@ -2798,9 +2812,44 @@ impl CompiledCode {
                     | OpCode::RegisterPackageMy { .. }
             );
         }
+        // Peephole (ADR-0006 §2.3): a `my $x = <expr>` declaration always ends in
+        // `MarkExplicitInitializerContext; MarkVarDeclContext; SetLocal(slot)` —
+        // two dispatches whose only effect is to set two flags the `SetLocal` body
+        // reads and clears. Fuse them into one instruction.
+        //
+        // Safe because the fusion only ever rewrites markers this `emit()` just
+        // appended, with nothing in between: no jump can target the middle of the
+        // pair (a target is only ever recorded at the tail *between* statements,
+        // and the three ops are emitted back-to-back), and a jump landing on the
+        // first marker lands on the fused instruction instead, which does exactly
+        // what falling through the pair into `SetLocal` did.
+        if let OpCode::SetLocal(slot) = op
+            && let Some(fused) = self.fuse_decl_markers(slot)
+        {
+            return fused;
+        }
         let idx = self.ops.len();
         self.ops.push(op);
         idx
+    }
+
+    /// Replace a just-emitted trailing declaration-marker run with the fused
+    /// `SetLocalDecl`. Returns the index of the fused instruction, or `None` when
+    /// the tail is not a declaration (an ordinary assignment `$x = 1`).
+    fn fuse_decl_markers(&mut self, slot: u32) -> Option<usize> {
+        let n = self.ops.len();
+        if n == 0 || !matches!(self.ops[n - 1], OpCode::MarkVarDeclContext) {
+            return None;
+        }
+        let explicit_init =
+            n >= 2 && matches!(self.ops[n - 2], OpCode::MarkExplicitInitializerContext);
+        self.ops.truncate(if explicit_init { n - 2 } else { n - 1 });
+        let idx = self.ops.len();
+        self.ops.push(OpCode::SetLocalDecl {
+            slot,
+            explicit_init,
+        });
+        Some(idx)
     }
 
     /// Patch a jump instruction at `idx` to point to the current position.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4128,6 +4128,19 @@ impl Interpreter {
                 self.exec_set_local_op(code, *idx)?;
                 *ip += 1;
             }
+            OpCode::SetLocalDecl {
+                slot,
+                explicit_init,
+            } => {
+                // The fused form of `MarkExplicitInitializerContext;
+                // MarkVarDeclContext; SetLocal` (ADR-0006 §2.3): set the very
+                // flags those markers set, then run the identical SetLocal body
+                // (which reads and clears them).
+                self.explicit_initializer_context = *explicit_init;
+                self.vardecl_context = true;
+                self.exec_set_local_op(code, *slot)?;
+                *ip += 1;
+            }
             OpCode::SetVarDynamic { name_idx, dynamic } => {
                 self.exec_set_var_dynamic_op(code, *name_idx, *dynamic);
                 *ip += 1;

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -60,6 +60,7 @@ pub(super) fn compile_range(code: &CompiledCode, start: usize, end: usize) -> Op
             OpCode::LoadConst(_)
             | OpCode::GetLocal(_)
             | OpCode::SetLocal(_)
+            | OpCode::SetLocalDecl { .. }
             | OpCode::ContainerizePair
             | OpCode::SetSourceLine(_)
             | OpCode::CallFunc { .. }
@@ -101,6 +102,8 @@ struct Sigs {
     v_code_u32: SigRef,
     /// `(interp, code, u32) -> i32`
     s_code_u32: SigRef,
+    /// `(interp, code, u32, u32) -> i32`
+    s_code_u32_u32: SigRef,
     /// `(interp, code, u32, fns) -> i32`
     s_call: SigRef,
 }
@@ -122,6 +125,7 @@ fn make_sigs(module: &JITModule, b: &mut FunctionBuilder, ptr: Type) -> Sigs {
         v_i64: sig(&[ptr, types::I64], None),
         v_code_u32: sig(&[ptr, ptr, types::I32], None),
         s_code_u32: sig(&[ptr, ptr, types::I32], Some(types::I32)),
+        s_code_u32_u32: sig(&[ptr, ptr, types::I32, types::I32], Some(types::I32)),
         s_call: sig(&[ptr, ptr, types::I32, ptr], Some(types::I32)),
     }
 }
@@ -334,6 +338,20 @@ fn build(
                     sigs.s_code_u32,
                     helpers::set_local as *const () as usize,
                     &[interp, codep, idxv],
+                )?;
+                check_status(&mut b, status);
+            }
+            OpCode::SetLocalDecl {
+                slot,
+                explicit_init,
+            } => {
+                let slotv = b.ins().iconst(types::I32, *slot as i64);
+                let initv = b.ins().iconst(types::I32, i64::from(*explicit_init));
+                let status = call_helper(
+                    &mut b,
+                    sigs.s_code_u32_u32,
+                    helpers::set_local_decl as *const () as usize,
+                    &[interp, codep, slotv, initv],
                 )?;
                 check_status(&mut b, status);
             }

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -90,6 +90,23 @@ pub(super) unsafe extern "C" fn set_local(
     }
 }
 
+/// `OpCode::SetLocalDecl` — the fused `my $x = <expr>` store (ADR-0006 §2.3).
+/// `marks` is 1 when the declaration had an explicit initializer.
+pub(super) unsafe extern "C" fn set_local_decl(
+    interp: *mut Interpreter,
+    code: *const CompiledCode,
+    idx: u32,
+    explicit_init: u32,
+) -> u32 {
+    let (interp, code) = unsafe { (&mut *interp, &*code) };
+    interp.explicit_initializer_context = explicit_init != 0;
+    interp.vardecl_context = true;
+    match interp.exec_set_local_op(code, idx) {
+        Ok(()) => JIT_STATUS_OK,
+        Err(e) => park_err(interp, e),
+    }
+}
+
 /// Dedicated shims for the payload-free fallible opcodes (arith / compare /
 /// string): each delegates to the interpreter's own `exec_*_op`, skipping the
 /// dispatch match entirely. These are the hot loop-body opcodes, so they get

--- a/t/decl-marker-fusion.t
+++ b/t/decl-marker-fusion.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+# Pin for the declaration-marker peephole (ADR-0006 §2.3): `my $x = <expr>`
+# compiles to one fused `SetLocalDecl` instead of
+# `MarkExplicitInitializerContext; MarkVarDeclContext; SetLocal`. The fused
+# instruction must set exactly the same two context flags, so every behaviour
+# that depends on "this store is a declaration, and it had an initializer" has
+# to be unchanged.
+
+plan 12;
+
+# --- a declaration is not a reassignment ----------------------------------
+# A `my` inside a loop re-declares a fresh variable each iteration; it must not
+# be treated as a mutation of the outer one.
+my $outer = 'outer';
+for 1..2 {
+    my $outer = 'inner';
+    is $outer, 'inner', 'the inner declaration shadows the outer one';
+}
+is $outer, 'outer', 'the outer variable is untouched by the shadowing declaration';
+
+# --- explicit initializer vs bare declaration -----------------------------
+my $bare;
+ok !$bare.defined, 'a bare declaration leaves the variable undefined';
+
+my Int $typed = 3;
+is $typed, 3, 'a typed declaration with an initializer stores its value';
+
+my Int $untyped_bare;
+ok !$untyped_bare.defined, 'a typed bare declaration is undefined, not 0';
+
+# Redeclaring without an initializer keeps the value; with one, it re-runs.
+my $keep = 1;
+{
+    my $keep = 2;
+    is $keep, 2, 'an initialized redeclaration in an inner block takes the new value';
+}
+is $keep, 1, 'the outer value survives';
+
+# --- declarations captured by a closure -----------------------------------
+# The free-variable analysis distinguishes declaration from mutation by the
+# marker the fused instruction now carries.
+my $counter = 0;
+my &bump = -> { $counter++ };
+bump(); bump();
+is $counter, 2, 'a closure still mutates the captured outer variable';
+
+sub make-counter() {
+    my $n = 0;             # declaration inside the routine
+    return -> { ++$n };    # captured and mutated
+}
+my &c = make-counter();
+c();
+is c(), 2, 'a captured routine-local declaration keeps its own cell';
+
+# --- a declaration whose initializer is a container ------------------------
+my @list = 1, 2, 3;
+is @list.elems, 3, 'an array declaration with an initializer';
+my %h = a => 1;
+is %h<a>, 1, 'a hash declaration with an initializer';
+
+done-testing;


### PR DESCRIPTION
First half of the last adopted slice of [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md): **§2.3 peephole — administrative opcodes**. Follows #4485 (folding), #4486 (pool dedup), #4487 (`constant` inlining + DCE).

A `my $x = <expr>` compiled to `MarkExplicitInitializerContext; MarkVarDeclContext; SetLocal(slot)` — three dispatches whose first two only set two flags that the `SetLocal` body reads and clears. They now fuse into a single `SetLocalDecl { slot, explicit_init }`.

## Why this is safe without remapping any jump target

The fusion happens inside `CompiledCode::emit()` and can only ever rewrite a marker run **it just appended itself**, with nothing emitted in between. Every instruction index therefore stays stable — no jump / compound-loop / block-scope target has to be remapped, which is exactly what makes a general op-deleting peephole pass risky in this VM (targets live in ~25 different opcode fields).

A jump cannot land in the middle of the run either: targets are only ever recorded at statement boundaries and the three ops are emitted back-to-back. A jump onto the first marker lands on the fused instruction, which does exactly what falling through the markers into `SetLocal` did.

Two consumers had to learn the fused form:
- `compute_free_vars` distinguishes a declaration from a reassignment by the preceding `MarkVarDeclContext` — it now reads that off the fused instruction.
- The JIT gets a `set_local_decl` helper, so hot loops containing `my` declarations keep compiling (verified: `compiles=1 bailouts=0` on time-parts, unchanged).

## Measured

| time-parts | before | after |
|---|---|---|
| executed opcodes | 6.40M | **5.40M (-15.6%)** |
| wall-clock, interpreted | 0.63s | 0.58s |
| wall-clock, JIT on (default) | 0.58s | 0.55s |

Together with §2.1 folding, time-parts is down from 7.60M to 5.40M executed opcodes (-29%).

## Next administrative target (recorded in PLAN.md)

`SetSourceLine` is **1.9M of bench-fib's 8.9M executed opcodes (21%)** and 600k of time-parts' (11%). Removing it wants a per-ip line table in `CompiledCode` (with `cur_source_line` resolved at call boundaries and error creation) rather than a peephole — a deleting pass would have to remap every jump target. Filed as §2.3-b.

## Verification

- `make test` (1683 files) PASS
- `make roast` (1384 files, 219,806 tests, release) PASS
- New `t/decl-marker-fusion.t` (12 cases: declaration-vs-reassignment shadowing, bare vs initialized declarations, closure capture of a declared local) — passes under `raku` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ