### PR TITLE
perf(vm): drop the SetSourceLine opcode for a static ip -> line table (ADR-0006 §2.3)

### DIFF
--- a/docs/adr/0006-baseline-interpreter-optimizations.md
+++ b/docs/adr/0006-baseline-interpreter-optimizations.md
@@ -128,8 +128,25 @@ time-parts の per-iteration 64 op のうち約 27% が administrative
 `SetVarDynamic`・`CheckReadOnly`）。古典的な push/pop 除去より、
 この mutsu 固有の administrative 列の静的化・融合の方が実測上大きい:
 
-- 連続する `SetSourceLine` の重複除去（値が変わらない限り 1 個）、
-  および `my $x = <expr>` の宣言 3-4 op 列の複合 op 化ないし静的フラグ化。
+- `my $x = <expr>` の宣言 3-4 op 列の複合 op 化ないし静的フラグ化（`SetLocalDecl`, #4488）。
+- **`SetSourceLine` は「重複除去」ではなく opcode ごと廃止する（実装済み）**:
+  行番号は命令ごとの**静的データ**であり、それを運ぶために dispatch される命令は要らない。
+  `CompiledCode` に ip→行の静的テーブル（`op_lines`、`ops` と平行な `Vec<u32>`）を持たせ、
+  `Stmt::SetLine` は opcode を emit せず emit カーソル（`set_emit_line`）を進めるだけにする。
+  `cur_source_line` は**行を観測し得る命令だけ**が `sync_source_line(code, ip)` で引く
+  （呼び出し/ユーザコードへの再入・フレーム push・宣言登録・raise site の各 arm と、
+  ネイティブ実行される JIT の call shim）。算術・ローカル・分岐といった純粋な hot op は
+  一切払わない。
+  - **毎命令リフレッシュは駄目**（実測）: `exec_one` プロローグで全命令に対して
+    テーブル参照 + ストアを行う版は、削減した dispatch より高くつき fib で
+    **命令数 +7.8%**。「観測点のみ」に絞ると fib で **-3.4%**（インタプリタ経路）。
+  - 実行 opcode 数自体は fib で -21%（1.91M/8.90M が `SetSourceLine` だった）、
+    time-parts で -11% 減るが、**opcode 数の削減幅と時間の削減幅は一致しない**
+    （`SetSourceLine` は 1 命令ストアの最安 op で、mutsu の平均 op は桁違いに重い）。
+    JIT 経路（既定構成）では ±0%。bytecode のメモリは ~15% 減る。
+  - 行番号はむしろ**より正確**になる（従来はブロック/ループ本体の実行後に行が古いまま
+    残るため、メソッド呼び出し前に `SetSourceLine` を防御的に再 emit していた
+    `emit_source_line_if_known` が必要だった。これも削除）。pin: `t/source-line-table.t`。
 - jump-to-jump は複合ループ op のおかげで現状ほぼ発生しないため優先しない。
 - 対象の選定は**ヒストグラム駆動**（`MUTSU_VM_STATS=1` の opcode_histogram）で行い、
   美学による書き換えはしない — [opcode-design-review.md](../opcode-design-review.md) §6

--- a/docs/opcode-design-review.md
+++ b/docs/opcode-design-review.md
@@ -78,10 +78,23 @@ per-opcode histogram (discriminant-keyed; variant name derived once via
 stats are off (one cached bool load).
 
 First data point (`my $s = 0; for 1..1000 { $s += $_ }`): one iteration of
-`$s += $_` executes 6 ops — `SetSourceLine`, `GetLocal`, `SetLocal`, `Add`,
-`CheckReadOnly`, `GetGlobal`. That immediately suggests follow-up targets:
-`SetSourceLine` fires per statement even in hot loops, and a compound-assign
+`$s += $_` executed 6 ops — `SetSourceLine`, `GetLocal`, `SetLocal`, `Add`,
+`CheckReadOnly`, `GetGlobal`. That immediately suggested follow-up targets:
+`SetSourceLine` fired per statement even in hot loops, and a compound-assign
 to a local still pays a `CheckReadOnly` + env-path `GetGlobal` pair.
+
+`SetSourceLine` is now gone (ADR-0006 §2.3): the source line is static
+per-instruction data, so `CompiledCode` carries an ip -> line table
+(`op_lines`) and `cur_source_line` is refreshed by `sync_source_line(code, ip)`
+in the arms that can *observe* a line (calls/reentry into user code, frame
+pushes, declaration registrations, raise sites) plus the JIT call shims. That
+removed 11% (time-parts) to 21% (fib) of executed opcodes, for -3.4%
+instructions on fib in the interpreter — refreshing on *every* op instead cost
+more than the dispatch it saved (+7.8% instructions), which is why the sync is
+opcode-selective. **When adding an opcode whose handler can call user code, push
+a frame, register a declaration, or raise a warning/error, call
+`sync_source_line` at the top of its arm.** `CheckReadOnly` / `GetGlobal` on a
+compound-assign remain open.
 
 ### 5. Per-instruction dispatch overhead — OPEN (deferred)
 

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -39,7 +39,6 @@ impl Compiler {
             // the accessor method to validate it exists.
             self.emit_load_self_for_accessor(&format!("${}", name));
             let method_idx = self.code.add_constant(Value::str(attr_name.to_string()));
-            self.emit_source_line_if_known();
             self.code.emit(OpCode::CallMethod {
                 name_idx: method_idx,
                 arity: 0,

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -91,7 +91,6 @@ impl Compiler {
                 _ => None,
             };
             let target_name_idx = self.code.add_constant(Value::str(target_name));
-            self.emit_source_line_if_known();
             self.code.emit(OpCode::ArrayPush {
                 target_name_idx,
                 value_source_idx,
@@ -109,7 +108,6 @@ impl Compiler {
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
         // Use CallMethod (non-mut) for read-only special variables like $!
         // so they benefit from the Nil dispatch path in CallMethod.
-        self.emit_source_line_if_known();
         if target_name == "!" {
             self.code.emit(OpCode::CallMethod {
                 name_idx,
@@ -184,7 +182,6 @@ impl Compiler {
                 for arg in args {
                     self.compile_method_arg(arg);
                 }
-                self.emit_source_line_if_known();
                 self.code.emit(OpCode::CallMethodMut {
                     name_idx,
                     arity,
@@ -208,7 +205,6 @@ impl Compiler {
                     self.compile_method_arg(arg);
                 }
                 let name_idx = self.code.add_constant(Value::str(name_resolved));
-                self.emit_source_line_if_known();
                 self.code.emit(OpCode::CallMethod {
                     name_idx,
                     arity,
@@ -484,7 +480,6 @@ impl Compiler {
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
-        self.emit_source_line_if_known();
         self.code.emit(OpCode::CallMethod {
             name_idx,
             arity,
@@ -515,7 +510,6 @@ impl Compiler {
             self.compile_method_arg(arg);
         }
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));
-        self.emit_source_line_if_known();
         if let Some(var_name) = target_var_name {
             let target_name_idx = self.code.add_constant(Value::str(var_name));
             self.code.emit(OpCode::CallMethodDynamicMut {

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -320,7 +320,11 @@ impl Compiler {
             match &self.code.ops[i - 1] {
                 OpCode::Decont | OpCode::ContainerizePair => i -= 1,
                 OpCode::CallMethod { .. } | OpCode::CallMethodMut { .. } => {
+                    // Keep the ip -> line table (`op_lines`) aligned with `ops`:
+                    // the marker inherits the call's line.
+                    let line = self.code.op_lines[i - 1];
                     self.code.ops.insert(i - 1, OpCode::MarkAccessorRefContext);
+                    self.code.op_lines.insert(i - 1, line);
                     return;
                 }
                 _ => return,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -178,10 +178,11 @@ impl Compiler {
         sub_compiler.record_param_local_slots(params, param_defs);
         // Hoist sub declarations within the sub body
         sub_compiler.hoist_sub_decls(body, true);
-        // Emit SetSourceLine at the start of the function body so that
-        // ?LINE is set to the sub's definition line on entry.
+        // Seed the body chunk's ip -> line table with the sub's definition line so
+        // its prologue ops (before the body's first statement marker) already
+        // carry a line.
         if let Some(line) = sub_compiler.last_source_line {
-            sub_compiler.code.emit(OpCode::SetSourceLine(line));
+            sub_compiler.code.set_emit_line(line);
         }
         // If sub body contains CATCH/CONTROL, wrap in implicit try. compile_try
         // leaves the body's final-expression value on the stack; for a normal
@@ -615,8 +616,11 @@ impl Compiler {
         sub_compiler.current_distribution = self.current_distribution.clone();
         // Propagate last_source_line so closures inside blocks that
         // lack their own SetLine can still inherit the line from the
-        // enclosing statement.
+        // enclosing statement, and seed the body chunk's ip -> line table with it.
         sub_compiler.last_source_line = self.last_source_line;
+        if let Some(line) = self.last_source_line {
+            sub_compiler.code.set_emit_line(line);
+        }
         // Give closures a unique package name so their state variables don't
         // collide with state variables in the enclosing code that happen to
         // share the same variable name.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -202,7 +202,8 @@ pub(crate) struct Compiler {
     /// consumes it so the emitted `TryCatch` is marked as a bare-block
     /// callframe. Other `compile_try` callers (e.g. `try { }`) leave it false.
     next_try_is_bare_block: bool,
-    /// Last source line emitted via SetSourceLine (for tracking block definition lines).
+    /// Line of the `Stmt::SetLine` marker last seen (the line attached to the ops
+    /// emitted since; also the definition line of a block/sub compiled here).
     last_source_line: Option<i64>,
     /// Pending writebacks for Index expressions passed to function calls.
     /// After the call returns, if the `is rw` parameter was written to,
@@ -331,15 +332,6 @@ impl Compiler {
         let r = f(self);
         self.escaping_position = saved;
         r
-    }
-
-    /// Emit a SetSourceLine opcode for the current source line, if known.
-    /// Used before method/function calls to ensure ?LINE is up-to-date for
-    /// deprecation tracking and error reporting.
-    pub(super) fn emit_source_line_if_known(&mut self) {
-        if let Some(line) = self.last_source_line {
-            self.code.emit(OpCode::SetSourceLine(line));
-        }
     }
 
     pub(crate) fn set_current_package(&mut self, package: String) {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3257,8 +3257,11 @@ impl Compiler {
                 self.code.emit(OpCode::Pop);
             }
             Stmt::SetLine(line) => {
+                // No instruction: the line is static data. Attach it to every op
+                // emitted for the statements that follow (`CompiledCode::op_lines`),
+                // and let the VM read it back from `ip` where a line is observable.
                 self.last_source_line = Some(*line);
-                self.code.emit(OpCode::SetSourceLine(*line));
+                self.code.set_emit_line(*line);
             }
         }
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1486,9 +1486,6 @@ pub(crate) enum OpCode {
     LetBlock {
         body_end: u32,
     },
-
-    /// Set the current source line number (for deprecation tracking, error messages, etc.).
-    SetSourceLine(i64),
 }
 
 #[cfg(test)]
@@ -1567,6 +1564,16 @@ mod const_pool_dedup {
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledCode {
     pub(crate) ops: Vec<OpCode>,
+    /// Static ip -> source line table, parallel to `ops` (0 = unknown). Replaces
+    /// the former per-statement `SetSourceLine` opcode: the line an instruction
+    /// belongs to is compile-time data, so it does not need a dispatched
+    /// instruction to carry it. The VM reads it with `line_at()` at the points
+    /// that can *observe* a line (call/reentry boundaries, error and warning
+    /// raise sites) instead of maintaining `cur_source_line` on every statement.
+    pub(crate) op_lines: Vec<u32>,
+    /// Compile-time cursor: the source line attached to every op emitted from
+    /// now on (set by the `Stmt::SetLine` marker). Not used at runtime.
+    emit_line: u32,
     pub(crate) constants: Vec<Value>,
     /// Reverse index over `constants` for pool dedup (ADR-0006 §2.4): the same
     /// literal or name string emitted at N sites shares one slot instead of
@@ -1890,6 +1897,8 @@ impl CompiledCode {
     pub(crate) fn new() -> Self {
         Self {
             ops: Vec::new(),
+            op_lines: Vec::new(),
+            emit_line: 0,
             constants: Vec::new(),
             const_index: rustc_hash::FxHashMap::default(),
             stmt_pool: Vec::new(),
@@ -2003,6 +2012,17 @@ impl CompiledCode {
     /// in this code. Locals only accessed via GetLocal don't need env sync,
     /// which reduces env size and makes method call env clones cheaper.
     pub(crate) fn compute_needs_env_sync(&mut self) {
+        // The ip -> line table must stay index-aligned with `ops`: a code path
+        // that pushes/removes an op without going through `emit()` (or without
+        // mirroring the change into `op_lines`) would shift every later line.
+        // A chunk built entirely by hand never calls `emit()`, so an empty table
+        // is also valid — `line_at` then reports "no line information".
+        debug_assert!(
+            self.op_lines.is_empty() || self.op_lines.len() == self.ops.len(),
+            "op_lines desynced from ops ({} vs {})",
+            self.op_lines.len(),
+            self.ops.len()
+        );
         // This chunk is finalized: drop the constant-pool dedup index, which is
         // compile-time scaffolding (ADR-0006 §2.4). A constant added afterwards
         // (a runtime-built chunk being patched) simply takes a fresh slot.
@@ -2830,6 +2850,7 @@ impl CompiledCode {
         }
         let idx = self.ops.len();
         self.ops.push(op);
+        self.op_lines.push(self.emit_line);
         idx
     }
 
@@ -2843,13 +2864,36 @@ impl CompiledCode {
         }
         let explicit_init =
             n >= 2 && matches!(self.ops[n - 2], OpCode::MarkExplicitInitializerContext);
-        self.ops.truncate(if explicit_init { n - 2 } else { n - 1 });
+        let keep = if explicit_init { n - 2 } else { n - 1 };
+        self.ops.truncate(keep);
+        self.op_lines.truncate(keep);
         let idx = self.ops.len();
         self.ops.push(OpCode::SetLocalDecl {
             slot,
             explicit_init,
         });
+        self.op_lines.push(self.emit_line);
         Some(idx)
+    }
+
+    /// Attach `line` to every op emitted from now on (the compile-time half of
+    /// the ip -> line table). Called for the `Stmt::SetLine` marker the parser
+    /// inserts before each statement, and once at a sub/block body's start so
+    /// its prologue ops carry the declaration line.
+    pub(crate) fn set_emit_line(&mut self, line: i64) {
+        self.emit_line = u32::try_from(line).unwrap_or(0);
+    }
+
+    /// The source line of the instruction at `ip`, or `None` when this chunk has
+    /// no line information for it (a hand-built chunk, or a prologue emitted
+    /// before any line marker). `None` means "leave the current line alone" —
+    /// never report line 0.
+    #[inline]
+    pub(crate) fn line_at(&self, ip: usize) -> Option<i64> {
+        match self.op_lines.get(ip) {
+            Some(&0) | None => None,
+            Some(&line) => Some(line as i64),
+        }
     }
 
     /// Patch a jump instruction at `idx` to point to the current position.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1112,12 +1112,14 @@ pub struct Interpreter {
     test_pending_callsite_line: Option<i64>,
     /// Current source line of the executing statement (`$?LINE` for internal
     /// consumers: backtraces, warn/die locations, callframe records). Lives as
-    /// a plain field — NOT an env entry — so the per-statement `SetSourceLine`
-    /// opcode is a scalar store instead of an env insert (which forked the
-    /// CoW overlay map on every statement and kept callee overlays non-empty,
-    /// defeating the empty-tier reuse in `Env::scoped_child`). Call paths that
-    /// push a `CallFrameEntry` restore it on pop from the entry's `line`; the
-    /// frame-less VM fast paths save/restore it manually.
+    /// a plain field — NOT an env entry — so refreshing it is a scalar store
+    /// instead of an env insert (which forked the CoW overlay map on every
+    /// statement and kept callee overlays non-empty, defeating the empty-tier
+    /// reuse in `Env::scoped_child`). The value is derived from the executing
+    /// chunk's static ip -> line table (`CompiledCode::op_lines`, refreshed by
+    /// `sync_source_line`), so it costs no instruction of its own. Call paths
+    /// that push a `CallFrameEntry` restore it on pop from the entry's `line`;
+    /// the frame-less VM fast paths save/restore it manually.
     pub(crate) cur_source_line: i64,
     /// Recycled `locals` backing vectors. The frame-less VM fast paths take the
     /// caller's `locals` aside and need a fresh Vec per call; popping one here

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -282,8 +282,8 @@ pub(crate) struct ControlHandlerCode {
 
 pub(crate) struct VmCallFrame {
     pub saved_env: Env,
-    /// The caller's `cur_source_line` at frame push, restored on pop (the
-    /// callee body's SetSourceLine updates must not leak into the caller).
+    /// The caller's `cur_source_line` at frame push, restored on pop (the line
+    /// the callee body's ops advanced to must not leak into the caller).
     pub saved_cur_line: i64,
     pub saved_locals: Vec<Value>,
     pub saved_upvalues: Vec<Option<Value>>,

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -111,7 +111,7 @@ impl Interpreter {
         // lose package-var reads/writes.
         let saved_package = self.enter_routine_package(cf);
         let let_mark = self.let_saves_len();
-        // Frame-less path: roll back the body's SetSourceLine updates manually.
+        // Frame-less path: roll back the line the body's ops advanced to manually.
         let saved_line = self.cur_source_line;
         let mut ip = 0;
         let mut result = Ok(());

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -128,8 +128,8 @@ impl Interpreter {
 
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
-        // This path skips push_caller_env, so roll back the callee body's
-        // SetSourceLine updates manually (env-based ?LINE got this for free
+        // This path skips push_caller_env, so roll back the line the callee
+        // body's ops advanced to manually (env-based ?LINE got this for free
         // from the overlay drop).
         let saved_line = self.cur_source_line;
         // Run the body under the routine's declaring package (set after the

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -279,7 +279,7 @@ impl Interpreter {
 
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
-        // Frame-less path: roll back the body's SetSourceLine updates manually.
+        // Frame-less path: roll back the line the body's ops advanced to manually.
         let saved_line = self.cur_source_line;
         // Run the body under the routine's declaring package (set after the
         // required-param early returns above). Restored after the env merge below.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1743,6 +1743,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::BoolCoerce => {
+                self.sync_source_line(code, *ip);
                 self.exec_bool_coerce_op();
                 *ip += 1;
             }
@@ -1794,6 +1795,7 @@ impl Interpreter {
 
             // -- String --
             OpCode::Concat => {
+                self.sync_source_line(code, *ip);
                 self.exec_concat_op()?;
                 *ip += 1;
             }
@@ -1931,6 +1933,7 @@ impl Interpreter {
                 lhs_is_literal,
                 rhs_pure_regex,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_smart_match_expr_op(
                     code,
                     ip,
@@ -1995,6 +1998,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::FunctionCompose => {
+                self.sync_source_line(code, *ip);
                 self.exec_function_compose_op();
                 *ip += 1;
             }
@@ -2170,6 +2174,7 @@ impl Interpreter {
 
             // -- Sequence --
             OpCode::Sequence { exclude_end } => {
+                self.sync_source_line(code, *ip);
                 let right = self.stack.pop().unwrap();
                 let left = self.stack.pop().unwrap();
                 let out = loan_env!(self, eval_sequence_values(left, right, *exclude_end))?;
@@ -2224,6 +2229,7 @@ impl Interpreter {
             }
 
             OpCode::CallDefined => {
+                self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap();
                 // Check if the value has a user-defined .defined method
                 let class_name = match val.view() {
@@ -2332,6 +2338,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::CoerceToList => {
+                self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 let list_val = match val.view() {
                     // Explicit Arrays ([1,2,3]) are preserved as-is.
@@ -2472,6 +2479,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::ThrowIfFailure => {
+                self.sync_source_line(code, *ip);
                 // Peek (do not pop): a trailing unhandled Failure must be thrown
                 // so the enclosing CATCH handler (or `try`) sees it, while a
                 // normal value remains on the stack as the block's return value.
@@ -2499,6 +2507,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::SinkPop(user_sink) => {
+                self.sync_source_line(code, *ip);
                 let user_sink = *user_sink;
                 if let Some(val) = self.stack.pop() {
                     // A bare statement value whose class defines its own `sink`
@@ -2731,21 +2740,25 @@ impl Interpreter {
 
             // -- I/O --
             OpCode::Say(n) => {
+                self.sync_source_line(code, *ip);
                 self.sync_env_from_locals(code);
                 self.exec_say_op(*n)?;
                 *ip += 1;
             }
             OpCode::Put(n) => {
+                self.sync_source_line(code, *ip);
                 self.sync_env_from_locals(code);
                 self.exec_put_op(*n)?;
                 *ip += 1;
             }
             OpCode::Print(n) => {
+                self.sync_source_line(code, *ip);
                 self.sync_env_from_locals(code);
                 self.exec_print_op(*n)?;
                 *ip += 1;
             }
             OpCode::Note(n) => {
+                self.sync_source_line(code, *ip);
                 self.sync_env_from_locals(code);
                 self.exec_note_op(*n)?;
                 *ip += 1;
@@ -2757,6 +2770,7 @@ impl Interpreter {
                 arity,
                 arg_sources_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_call_func_op(
                     code,
                     *name_idx,
@@ -2783,6 +2797,7 @@ impl Interpreter {
                 arg_sources_idx,
                 slip_pos,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_call_func_slip_op(
                     code,
                     *name_idx,
@@ -2800,6 +2815,7 @@ impl Interpreter {
                 quoted,
                 arg_sources_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_call_method_op(
                     code,
                     *name_idx,
@@ -2834,6 +2850,7 @@ impl Interpreter {
                 arity,
                 modifier_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_call_method_dynamic_op(code, *arity, *modifier_idx) {
                     Ok(()) => {}
                     Err(e) => {
@@ -2856,6 +2873,7 @@ impl Interpreter {
                 target_name_idx,
                 modifier_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
                 match self.exec_call_method_dynamic_mut_op(
                     code,
@@ -2880,6 +2898,7 @@ impl Interpreter {
                 target_name_idx,
                 value_source_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
                 self.exec_array_push_op(code, *target_name_idx, *value_source_idx)?;
                 self.mirror_array_hash_attr_to_cell(code, *target_name_idx, pre);
@@ -2893,6 +2912,7 @@ impl Interpreter {
                 quoted,
                 arg_sources_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
                 match self.exec_call_method_mut_op(
                     code,
@@ -2935,6 +2955,7 @@ impl Interpreter {
                 arity,
                 arg_sources_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 // Set a resume point before propagating a control signal so an
                 // enclosing `CONTROL {}` can `.resume` after this call — e.g.
                 // `my $w = &warn; $w.("x")` raises a resumable `warn` signal from
@@ -2956,6 +2977,7 @@ impl Interpreter {
                 arity,
                 arg_sources_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_call_on_code_var_op(
                     code,
                     *name_idx,
@@ -2978,6 +3000,7 @@ impl Interpreter {
                 arity,
                 arg_sources_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_exec_call_op(
                     code,
                     *name_idx,
@@ -2996,6 +3019,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::ExecCallPairs { name_idx, arity } => {
+                self.sync_source_line(code, *ip);
                 self.exec_exec_call_pairs_op(code, compiled_fns, *name_idx, *arity)?;
                 *ip += 1;
             }
@@ -3005,6 +3029,7 @@ impl Interpreter {
                 arg_sources_idx,
                 slip_pos,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_exec_call_slip_op(
                     code,
                     compiled_fns,
@@ -3063,6 +3088,7 @@ impl Interpreter {
             }
             // -- String interpolation --
             OpCode::StringConcat(n) => {
+                self.sync_source_line(code, *ip);
                 self.exec_string_concat_op(*n)?;
                 *ip += 1;
             }
@@ -3253,10 +3279,12 @@ impl Interpreter {
 
             // -- Unary coercion --
             OpCode::NumCoerce => {
+                self.sync_source_line(code, *ip);
                 self.exec_num_coerce_op()?;
                 *ip += 1;
             }
             OpCode::StrCoerce => {
+                self.sync_source_line(code, *ip);
                 self.exec_str_coerce_op()?;
                 *ip += 1;
             }
@@ -3315,6 +3343,7 @@ impl Interpreter {
                 collect,
                 isolate_topic,
             } => {
+                self.sync_source_line(code, *ip);
                 let spec = vm_control_ops::WhileLoopSpec {
                     cond_end: *cond_end,
                     body_end: *body_end,
@@ -3325,6 +3354,7 @@ impl Interpreter {
                 self.exec_while_loop_op(code, &spec, ip, compiled_fns)?;
             }
             OpCode::ForLoop(spec) => {
+                self.sync_source_line(code, *ip);
                 self.exec_for_loop_op(code, spec, ip, compiled_fns)?;
             }
             OpCode::RestoreForParam => {
@@ -3351,6 +3381,7 @@ impl Interpreter {
                 label,
                 collect,
             } => {
+                self.sync_source_line(code, *ip);
                 let spec = vm_control_ops::CStyleLoopSpec {
                     cond_end: *cond_end,
                     step_start: *step_start,
@@ -3367,6 +3398,7 @@ impl Interpreter {
                 topic_readonly,
                 pointy_param_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_given_op(
                     code,
                     *body_end,
@@ -3377,9 +3409,11 @@ impl Interpreter {
                 )?;
             }
             OpCode::When { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_when_op(code, *body_end, ip, compiled_fns)?;
             }
             OpCode::Default { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_default_op(code, *body_end, ip, compiled_fns)?;
             }
 
@@ -3389,6 +3423,7 @@ impl Interpreter {
                 body_end,
                 label,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_repeat_loop_op(code, *cond_end, *body_end, label, ip, compiled_fns)?;
             }
 
@@ -3401,6 +3436,7 @@ impl Interpreter {
                 resume_safe,
                 is_bare_block,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_try_catch_op(
                     code,
                     *catch_start,
@@ -3450,6 +3486,7 @@ impl Interpreter {
                 }
             }
             OpCode::Die => {
+                self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 // Store the resume point (instruction after Die) for .resume support
                 self.resume_ip = Some(*ip + 1);
@@ -3490,6 +3527,7 @@ impl Interpreter {
                 return Err(err);
             }
             OpCode::Fail => {
+                self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 // When fail() receives a Failure:D, extract the inner exception
                 // and re-arm it (Raku behavior: fail(Failure:D) re-arms)
@@ -3587,6 +3625,7 @@ impl Interpreter {
 
             // -- Reduction --
             OpCode::Reduction(op_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_reduction_op(code, *op_idx)?;
                 *ip += 1;
             }
@@ -3614,6 +3653,7 @@ impl Interpreter {
                 x_idx,
                 perl5,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_subst_op(
                     code,
                     *pattern_idx,
@@ -3641,6 +3681,7 @@ impl Interpreter {
                 x_idx,
                 perl5,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_non_destructive_subst_op(
                     code,
                     *pattern_idx,
@@ -3664,6 +3705,7 @@ impl Interpreter {
                 squash,
                 non_destructive,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_transliterate_op(
                     code,
                     *from_idx,
@@ -3678,12 +3720,14 @@ impl Interpreter {
 
             // -- Take --
             OpCode::Take => {
+                self.sync_source_line(code, *ip);
                 self.exec_take_op()?;
                 *ip += 1;
             }
 
             // -- Package scope --
             OpCode::PackageScope { name_idx, body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_package_scope_op(code, *name_idx, *body_end, ip, compiled_fns)?;
             }
             OpCode::RegisterPackage { name_idx } => {
@@ -3725,12 +3769,14 @@ impl Interpreter {
 
             // -- Phaser END --
             OpCode::PhaserEnd { idx, site_id } => {
+                self.sync_source_line(code, *ip);
                 self.exec_phaser_end_op(code, *idx, *site_id);
                 *ip += 1;
             }
 
             // -- CHECK Phaser scope --
             OpCode::CheckPhaserStart { .. } => {
+                self.sync_source_line(code, *ip);
                 self.check_phaser_depth += 1;
                 *ip += 1;
             }
@@ -3747,6 +3793,7 @@ impl Interpreter {
                 quoted,
                 target_name_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_hyper_method_call_op(
                     code,
                     *name_idx,
@@ -3772,6 +3819,7 @@ impl Interpreter {
                 arity,
                 modifier_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 match self.exec_hyper_method_call_dynamic_op(code, *arity, *modifier_idx) {
                     Ok(()) => {}
                     Err(e) => {
@@ -3790,6 +3838,7 @@ impl Interpreter {
                 dwim_left,
                 dwim_right,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_hyper_op(code, *op_idx, *dwim_left, *dwim_right)?;
                 *ip += 1;
             }
@@ -3801,6 +3850,7 @@ impl Interpreter {
                 dwim_right,
                 writeback,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_hyper_func_op(
                     code,
                     *name_idx,
@@ -3814,6 +3864,7 @@ impl Interpreter {
 
             // -- MetaOp --
             OpCode::MetaOp { meta_idx, op_idx } => {
+                self.sync_source_line(code, *ip);
                 self.exec_meta_op(code, *meta_idx, *op_idx)?;
                 *ip += 1;
             }
@@ -3823,6 +3874,7 @@ impl Interpreter {
                 op_idx,
                 count,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_meta_op_nary(code, *meta_idx, *op_idx, *count)?;
                 *ip += 1;
             }
@@ -3833,6 +3885,7 @@ impl Interpreter {
                 right_arity,
                 modifier_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_infix_func_op(code, *name_idx, *right_arity, modifier_idx, compiled_fns)?;
                 *ip += 1;
             }
@@ -3859,10 +3912,12 @@ impl Interpreter {
 
             // -- Type checking --
             OpCode::TypeCheck(tc_idx, var_name_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_type_check_op(code, *tc_idx, *var_name_idx)?;
                 *ip += 1;
             }
             OpCode::TypeCheckBind(tc_idx, var_name_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_type_check_bind_op(code, *tc_idx, *var_name_idx)?;
                 *ip += 1;
             }
@@ -3928,6 +3983,7 @@ impl Interpreter {
                 end,
                 is_bare_block,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_block_scope_op(
                     code,
                     [
@@ -3945,12 +4001,14 @@ impl Interpreter {
                 )?;
             }
             OpCode::BlockLocalScope { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_block_local_scope_op(code, *body_end, ip, compiled_fns)?;
             }
             OpCode::CheckPhaser {
                 is_pre,
                 condition_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 let condition = condition_idx.map(|idx| Self::const_str(code, idx).to_string());
                 self.exec_check_phaser_op(*is_pre, condition)?;
                 *ip += 1;
@@ -3966,6 +4024,7 @@ impl Interpreter {
                 scope_isolate,
                 isolate_decls_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_do_block_expr_op(
                     code,
                     *body_end,
@@ -3977,18 +4036,22 @@ impl Interpreter {
                 )?;
             }
             OpCode::OnceExpr { key_idx, body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_once_expr_op(code, *key_idx, *body_end, ip, compiled_fns)?;
             }
             OpCode::DoGivenExpr { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_do_given_expr_op(code, *body_end, ip, compiled_fns)?;
             }
 
             // -- Closures and registration --
             OpCode::MakeGather(idx, cc_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_make_gather_op(code, *idx, *cc_idx)?;
                 *ip += 1;
             }
             OpCode::Eager => {
+                self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap_or(Value::NIL);
                 let result = match val.view() {
                     ValueView::LazyList(ll) => {
@@ -4017,14 +4080,17 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::MakeAnonSub(idx, cc_idx, is_block) => {
+                self.sync_source_line(code, *ip);
                 self.exec_make_anon_sub_op(code, *idx, *cc_idx, *is_block)?;
                 *ip += 1;
             }
             OpCode::MakeAnonSubParams(idx, cc_idx, is_wc) => {
+                self.sync_source_line(code, *ip);
                 self.exec_make_anon_sub_params_op(code, *idx, *cc_idx, *is_wc)?;
                 *ip += 1;
             }
             OpCode::MakeLambda(idx, cc_idx, is_wc) => {
+                self.sync_source_line(code, *ip);
                 self.exec_make_lambda_op(code, *idx, *cc_idx, *is_wc)?;
                 *ip += 1;
             }
@@ -4033,38 +4099,47 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::MakeBlockClosure(idx, cc_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_make_block_closure_op(code, *idx, *cc_idx)?;
                 *ip += 1;
             }
             OpCode::RegisterSub(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_sub_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterToken(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_token_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterProtoSub(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_proto_sub_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterProtoToken(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_proto_token_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::UseModule { name_idx, tags_idx } => {
+                self.sync_source_line(code, *ip);
                 self.exec_use_module_op(code, *name_idx, *tags_idx)?;
                 *ip += 1;
             }
             OpCode::ImportModule { name_idx, tags_idx } => {
+                self.sync_source_line(code, *ip);
                 self.exec_import_module_op(code, *name_idx, *tags_idx)?;
                 *ip += 1;
             }
             OpCode::NoModule(name_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_no_module_op(code, *name_idx)?;
                 *ip += 1;
             }
             OpCode::NeedModule(name_idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_need_module_op(code, *name_idx)?;
                 *ip += 1;
             }
@@ -4081,29 +4156,36 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::RegisterEnum(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_enum_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterClass(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_class_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::AugmentClass(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_augment_class_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterRole(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_role_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterSubset(idx) => {
+                self.sync_source_line(code, *ip);
                 self.exec_register_subset_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::SubtestScope { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_subtest_scope_op(code, *body_end, ip, compiled_fns)?;
             }
             OpCode::ReactScope { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_react_scope_op(code, *body_end, ip, compiled_fns)?;
             }
             OpCode::WheneverScope {
@@ -4111,6 +4193,7 @@ impl Interpreter {
                 param_idx,
                 target_var_idx,
             } => {
+                self.sync_source_line(code, *ip);
                 self.exec_whenever_scope_op(code, *body_idx, param_idx, target_var_idx)?;
                 *ip += 1;
             }
@@ -4257,14 +4340,32 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::LetBlock { body_end } => {
+                self.sync_source_line(code, *ip);
                 self.exec_let_block_op(code, *body_end, ip, compiled_fns)?;
-            }
-            OpCode::SetSourceLine(line) => {
-                self.cur_source_line = *line;
-                *ip += 1;
             }
         }
         Ok(())
+    }
+
+    /// Adopt the source line of the instruction at `ip` as the current line.
+    ///
+    /// The line is static per-instruction data (`CompiledCode::op_lines`), so no
+    /// dispatched instruction is needed to carry it (the former `SetSourceLine`).
+    /// Instead this is called from the instructions that can *observe* a line —
+    /// every call/reentry into user code, frame push, declaration registration
+    /// and raise site — and from the JIT call shims, whose native code has no
+    /// interpreter loop to refresh anything. Instructions that cannot observe it
+    /// (arithmetic, local slots, jumps, stack shuffling) pay nothing at all,
+    /// which is the point: refreshing on every op costs more than the dispatch it
+    /// saves (measured: +7.8% instructions on fib).
+    ///
+    /// A chunk with no line information for `ip` (hand-built bytecode) leaves the
+    /// current line untouched.
+    #[inline]
+    pub(crate) fn sync_source_line(&mut self, code: &CompiledCode, ip: usize) {
+        if let Some(line) = code.line_at(ip) {
+            self.cur_source_line = line;
+        }
     }
 
     /// Check if a value represents a "successful" block exit for `let` purposes.

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -62,7 +62,6 @@ pub(super) fn compile_range(code: &CompiledCode, start: usize, end: usize) -> Op
             | OpCode::SetLocal(_)
             | OpCode::SetLocalDecl { .. }
             | OpCode::ContainerizePair
-            | OpCode::SetSourceLine(_)
             | OpCode::CallFunc { .. }
             | OpCode::CallMethod { .. }
             | OpCode::CallMethodMut { .. } => {}
@@ -96,8 +95,6 @@ struct Sigs {
     v1: SigRef,
     /// `(interp) -> i32`
     s1: SigRef,
-    /// `(interp, i64) -> ()`
-    v_i64: SigRef,
     /// `(interp, code, u32) -> ()`
     v_code_u32: SigRef,
     /// `(interp, code, u32) -> i32`
@@ -122,7 +119,6 @@ fn make_sigs(module: &JITModule, b: &mut FunctionBuilder, ptr: Type) -> Sigs {
     Sigs {
         v1: sig(&[ptr], None),
         s1: sig(&[ptr], Some(types::I32)),
-        v_i64: sig(&[ptr, types::I64], None),
         v_code_u32: sig(&[ptr, ptr, types::I32], None),
         s_code_u32: sig(&[ptr, ptr, types::I32], Some(types::I32)),
         s_code_u32_u32: sig(&[ptr, ptr, types::I32, types::I32], Some(types::I32)),
@@ -252,19 +248,6 @@ fn build(
                         sigs.v_code_u32,
                         helpers::load_const as *const () as usize,
                         &[interp, codep, idxv],
-                    );
-                }
-            }
-            OpCode::SetSourceLine(line) => {
-                if let Some(tb) = &tier_b {
-                    tb.emit_set_source_line(&mut b, *line);
-                } else {
-                    let linev = b.ins().iconst(types::I64, *line);
-                    call_helper(
-                        &mut b,
-                        sigs.v_i64,
-                        helpers::set_source_line as *const () as usize,
-                        &[interp, linev],
                     );
                 }
             }

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -28,11 +28,6 @@ pub(super) unsafe extern "C" fn load_const(
     interp.stack.push(code.constants[idx as usize].clone());
 }
 
-/// `OpCode::SetSourceLine`
-pub(super) unsafe extern "C" fn set_source_line(interp: *mut Interpreter, line: i64) {
-    unsafe { &mut *interp }.cur_source_line = line;
-}
-
 /// `OpCode::ContainerizePair`
 pub(super) unsafe extern "C" fn containerize_pair(interp: *mut Interpreter) {
     let interp = unsafe { &mut *interp };
@@ -263,6 +258,9 @@ pub(super) unsafe extern "C" fn call_method(
     else {
         unreachable!("jit call_method shim on a non-CallMethod opcode")
     };
+    // Native code runs no per-op line update, so the callee's frame/backtrace
+    // line must be pulled from the static ip -> line table at the call site.
+    interp.sync_source_line(code, op_idx as usize);
     let r = interp.exec_call_method_op(
         code,
         *name_idx,
@@ -311,6 +309,7 @@ pub(super) unsafe extern "C" fn call_method_mut(
     else {
         unreachable!("jit call_method_mut shim on a non-CallMethodMut opcode")
     };
+    interp.sync_source_line(code, op_idx as usize);
     let pre = interp.array_hash_attr_env_snapshot(code, *target_name_idx);
     let r = interp.exec_call_method_mut_op(
         code,
@@ -370,6 +369,7 @@ pub(super) unsafe extern "C" fn call_func(
     else {
         unreachable!("jit call_func shim on a non-CallFunc opcode")
     };
+    interp.sync_source_line(code, op_idx as usize);
     let r = interp.exec_call_func_op(code, *name_idx, *arity, *arg_sources_idx, fns);
     interp.current_code = code as *const CompiledCode as usize;
     match r {

--- a/src/vm/vm_jit_layout.rs
+++ b/src/vm/vm_jit_layout.rs
@@ -15,8 +15,6 @@ use super::*;
 pub(super) struct JitLayout {
     /// Byte offset of `Interpreter::stack` (a `Vec<Value>`).
     pub(super) stack: i32,
-    /// Byte offset of `Interpreter::cur_source_line` (an `i64`).
-    pub(super) cur_source_line: i32,
     /// Byte offsets of the data pointer / length / capacity words inside
     /// `Vec<Value>` (relative to the start of the `Vec`).
     pub(super) vec_ptr: i32,
@@ -62,7 +60,6 @@ pub(super) fn layout() -> Option<&'static JitLayout> {
             let (vec_ptr, vec_len, vec_cap) = probe_vec_layout()?;
             Some(JitLayout {
                 stack: std::mem::offset_of!(Interpreter, stack) as i32,
-                cur_source_line: std::mem::offset_of!(Interpreter, cur_source_line) as i32,
                 vec_ptr,
                 vec_len,
                 vec_cap,

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -407,13 +407,6 @@ impl TierB {
         b.switch_to_block(done);
     }
 
-    /// `SetSourceLine`: a single immediate store to the interpreter field.
-    pub(super) fn emit_set_source_line(&self, b: &mut FunctionBuilder, line: i64) {
-        let v = b.ins().iconst(types::I64, line);
-        b.ins()
-            .store(Self::mf(), v, self.interp, self.lay.cur_source_line);
-    }
-
     /// `ContainerizePair`: a no-op unless the top word is a `Pair` (the only
     /// shape the interpreter arm rewrites), which goes to the Tier A shim.
     pub(super) fn emit_containerize_pair(&self, b: &mut FunctionBuilder, slow_fn: usize) {

--- a/t/source-line-table.t
+++ b/t/source-line-table.t
@@ -1,0 +1,60 @@
+use v6;
+use Test;
+
+# Pin for the ip -> line table (ADR-0006 2.3): the per-statement `SetSourceLine`
+# opcode is gone; `CompiledCode` carries a static ip -> line table instead and
+# the VM derives the current line from the executing instruction. Every consumer
+# of the current line (callframe records, backtraces) must still see the exact
+# statement line — including after an inner loop/block body has run, which the
+# opcode-based scheme only got right because call sites re-emitted
+# `SetSourceLine` defensively.
+
+plan 7;
+
+sub caller-line { callframe(1).line }
+
+# 1. Plain call site.
+is caller-line(), 17, 'call site line at the top level';
+
+# 2. Call site inside a loop body.
+my @in-loop;
+for 1..2 {
+    @in-loop.push(caller-line());
+}
+is @in-loop.join(','), '22,22', 'call site line inside a for body';
+
+# 3. Call site AFTER an inner loop body ran in the same block: the line must be
+#    the call's own, not the loop body's last line.
+my @after-loop;
+{
+    for 1..2 { my $tmp = 1 }
+    @after-loop.push(caller-line());
+}
+is @after-loop.join(','), '31', 'call site line after an inner loop body';
+
+# 4. Call site in an expression that also contains a `do` block.
+my $mixed = do { my $z = 0; $z } + caller-line();
+is $mixed, 36, 'call site line in an expression containing a do block';
+
+# 5. A call from inside a sub, after that sub ran a loop of its own.
+sub outer {
+    for 1..2 { my $tmp = 1 }
+    caller-line();
+}
+is outer(), 42, 'call site line inside a sub body after a loop';
+
+# 6. A sub-to-sub call site: the callee's caller frame carries the inner line.
+sub middle { caller-line() }
+is middle(), 47, 'call site line inside another sub';
+
+# 7. A backtrace records the throwing sub's own body line.
+sub thrower { die "boom" }
+try {
+    thrower();
+    CATCH {
+        default {
+            is .backtrace.list.first({ .subname eq 'thrower' }).line, 51,
+                'the throwing sub frame carries its die line';
+        }
+    }
+}


### PR DESCRIPTION
## What

The source line of an instruction is **compile-time data**, so it does not need a dispatched instruction to carry it. `SetSourceLine` fired once per statement — **21% of all executed opcodes on bench-fib** (1.91M of 8.90M), 11% on time-parts — purely to store a constant into `Interpreter::cur_source_line`.

This replaces it with a static ip → line table:

- `CompiledCode::op_lines: Vec<u32>`, parallel to `ops`, filled by `emit()` from a compile-time cursor that `Stmt::SetLine` advances (`set_emit_line`) instead of emitting an opcode.
- `cur_source_line` is refreshed by `sync_source_line(code, ip)` in the arms that can **observe** a line — calls and other reentry into user code, frame pushes, declaration registrations, raise sites — and by the JIT call shims (`call_func` / `call_method` / `call_method_mut`), whose native code has no interpreter loop to refresh anything.
- Pure hot opcodes (arithmetic, local slots, jumps, stack shuffling) pay nothing.

## Why observation-point-only, and not a per-op refresh

Measured, not assumed. Refreshing the line on *every* op in the `exec_one` prologue is simpler and exact, but it **costs more than the dispatch it saves**:

| variant | fib instructions (interp) |
|---|---|
| refresh in the `exec_one` prologue (every op) | **+7.8%** |
| refresh only at observation points | **-3.4%** |

The opcode *count* drops 11–21%, but `SetSourceLine` was the cheapest opcode in the set, so the time/instruction win is much smaller than the count suggests. On the JIT path (the default configuration) the delta is ~0. Bytecode shrinks ~15% (a 48-byte `OpCode` per statement replaced by 4 bytes per instruction).

## Line reporting gets *more* accurate

The old scheme left `cur_source_line` stale after a loop/block body ran — which is exactly why call sites had to defensively re-emit `SetSourceLine` before method calls (`emit_source_line_if_known`). That band-aid is deleted; each instruction now knows its own line.

## Safety

- `debug_assert` in `compute_needs_env_sync` pins `op_lines` index-alignment with `ops`, so a future direct `ops.push` cannot silently shift every later line (the two existing non-`emit()` mutation sites — the `SetLocalDecl` fusion and the `MarkAccessorRefContext` insert — mirror the change into `op_lines`).
- New pin `t/source-line-table.t`: call-site lines at the top level, inside a loop body, after an inner body ran, inside a `do`-block expression, sub-to-sub, and the backtrace line of a throwing sub — **all 7 agree with rakudo**.
- Verified unchanged against `main` on exotic reentry paths (user-defined `infix`, `Proxy` FETCH, user `AT-POS`, `sort` comparator, `is DEPRECATED` callsite line).
- `make test` green; roast subset (106 whitelisted files: S04, S32-exceptions, S06-operator-overloading, S02-magicals) green.

Docs: ADR-0006 §2.3 updated (this supersedes its "dedup consecutive `SetSourceLine`" plan), plus `docs/opcode-design-review.md` §4 with the rule for new opcodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ