### PR TITLE
perf(vm): make the per-call readonly snapshot and the return merge allocation-free (fib -32%, tak -24%)

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -387,12 +387,14 @@ impl Compiler {
             named_param_slots: None,
             deprecated_info,
             declared_locals: None,
+            param_name_syms: Vec::new(),
             // The declaring package, matching the package component of this
             // function's `compiled_fns` key (built from `self.current_package`).
             package: self.current_package.clone(),
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_param_slots();
+        cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();
         // Contribute this directly-nested named sub's WRITE set to the enclosing

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3212,7 +3212,15 @@ pub(crate) struct CompiledFunction {
     /// Used by the positional light call path to distinguish function-local vars
     /// (which should be restored after recursive calls) from captured outer vars
     /// (which should keep their modified values).
-    pub(crate) declared_locals: Option<std::collections::HashSet<String>>,
+    ///
+    /// `Symbol`-keyed: the call paths test it against the callee's env-overlay
+    /// keys, which are already `Symbol`s, so the return merge compares `u32`s
+    /// instead of rebuilding a `HashSet<&str>` (SipHash) on every call.
+    pub(crate) declared_locals: Option<rustc_hash::FxHashSet<Symbol>>,
+    /// Pre-interned `param_defs[i].name`, parallel to `param_defs`. The call
+    /// paths mark every param read-only on entry; without this each mark would
+    /// re-hash the parameter name string on every call.
+    pub(crate) param_name_syms: Vec<Symbol>,
     /// The package this routine was declared in (e.g. `"P"` for a sub in
     /// `package P { ... }`, `"GLOBAL"` for a top-level sub). The dispatch sets
     /// `current_package` from this on entry so package-scoped variable
@@ -3348,7 +3356,7 @@ impl CompiledFunction {
     /// Also includes parameter names. Used to distinguish function-local vars
     /// from captured outer vars in the positional light call path.
     pub(crate) fn compute_declared_locals(&mut self) {
-        let mut declared = std::collections::HashSet::new();
+        let mut declared: std::collections::HashSet<String> = std::collections::HashSet::new();
         // Parameters are always function-local (including sub-signature params)
         Self::collect_param_names(&self.param_defs, &mut declared);
         for p in &self.params {
@@ -3390,7 +3398,40 @@ impl CompiledFunction {
                 _ => {}
             }
         }
-        self.declared_locals = Some(declared);
+        self.declared_locals = Some(declared.iter().map(|n| Symbol::intern(n)).collect());
+    }
+
+    /// Pre-intern the parameter names (see `param_name_syms`).
+    pub(crate) fn precompute_param_name_syms(&mut self) {
+        self.param_name_syms = self
+            .param_defs
+            .iter()
+            .map(|pd| Symbol::intern(&pd.name))
+            .collect();
+    }
+
+    /// True if `sym` names a *callee-local* of this function — a parameter, a
+    /// `my` declaration, or a `for`-loop parameter. The scoped-overlay return
+    /// merge uses this to decide which of the callee's env writes are its own
+    /// (dropped with the overlay) and which target a captured outer variable
+    /// (merged back into the caller).
+    ///
+    /// Prefers the precomputed `declared_locals`; a hand-built chunk that never
+    /// ran `compute_declared_locals` falls back to the code's own local names,
+    /// exactly as the call sites did before.
+    #[inline]
+    pub(crate) fn is_callee_local_sym(&self, sym: Symbol) -> bool {
+        match &self.declared_locals {
+            Some(declared) => declared.contains(&sym),
+            None if self.code.locals_sym.len() == self.code.locals.len() => {
+                self.code.locals_sym.contains(&sym)
+            }
+            // Unfinalized chunk: `locals_sym` was never computed, so compare by name.
+            None => {
+                let name = sym.as_str();
+                self.code.locals.iter().any(|n| n == name)
+            }
+        }
     }
 
     /// Recursively collect parameter names from param_defs, including

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -373,6 +373,18 @@ pub(crate) type ClassAttributeDef = (
     Option<Expr>,
 );
 
+/// The set of read-only variable names (`readonly_vars`), and the type of a
+/// snapshot taken by `save_readonly_vars`.
+///
+/// `Symbol`-keyed and copy-on-write: every user function call snapshots this set
+/// on entry and restores it on return, so a `HashSet<String>` cost one table
+/// allocation plus one heap `String` per entry *per call*. Behind an `Arc` the
+/// snapshot is a refcount bump, and a mutation (`mark_readonly` /
+/// `unmark_readonly`) pays a `memcpy` of `u32`s only when it actually changes
+/// the set while a snapshot is alive. `Symbol` keys also replace the default
+/// hasher's SipHash-over-the-name with a `u32` hash.
+pub(crate) type ReadonlySet = Arc<rustc_hash::FxHashSet<Symbol>>;
+
 /// Per-class plan for the native default constructor
 /// (`try_native_default_construct`): everything about the class shape that the
 /// constructor consulted on EVERY construction but that only changes when the
@@ -1548,7 +1560,8 @@ pub struct Interpreter {
     /// Pending env updates from regex code blocks, to be synced to VM locals.
     pub(crate) pending_local_updates: Vec<(String, Value)>,
     /// Set of variable names that are readonly (default parameter binding).
-    readonly_vars: HashSet<String>,
+    /// Copy-on-write and `Symbol`-keyed — see [`ReadonlySet`].
+    readonly_vars: ReadonlySet,
     /// Metadata for Seq values produced by `squish` with callbacks, used to
     /// provide callback-aware iterator behavior.
     pub(crate) squish_iterator_meta: HashMap<usize, SquishIteratorMeta>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2148,7 +2148,7 @@ impl Interpreter {
             lexical_class_owner_scopes: Vec::new(),
             last_value: None,
             pending_local_updates: Vec::new(),
-            readonly_vars: HashSet::new(),
+            readonly_vars: crate::runtime::ReadonlySet::default(),
             squish_iterator_meta: HashMap::new(),
             custom_type_data: HashMap::new(),
             rebless_map: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -308,7 +308,7 @@ impl Interpreter {
             lexical_class_owner_scopes: self.lexical_class_owner_scopes.clone(),
             last_value: None,
             pending_local_updates: Vec::new(),
-            readonly_vars: HashSet::new(),
+            readonly_vars: crate::runtime::ReadonlySet::default(),
             squish_iterator_meta: HashMap::new(),
             custom_type_data: self.custom_type_data.clone(),
             rebless_map: self.rebless_map.clone(),

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1922,7 +1922,7 @@ impl Interpreter {
             let is_container_param = pd.name.starts_with('@') || pd.name.starts_with('%');
             if !is_container_param {
                 if !has_mutable_trait || raw_nonlvalue_params.contains(&pd.name) {
-                    self.readonly_vars.insert(pd.name.clone());
+                    self.mark_readonly(&pd.name);
                 } else {
                     // Writable `is copy`/`is rw`/`is raw` scalar param: the
                     // readonly set is keyed by bare name and shared across frames,
@@ -1930,7 +1930,7 @@ impl Interpreter {
                     // would otherwise leak in and make this writable param appear
                     // readonly. Drop the mark; the surrounding call path restores
                     // the caller's readonly state via `restore_readonly_vars`.
-                    self.readonly_vars.remove(&pd.name);
+                    self.unmark_readonly(&pd.name);
                 }
             }
         }

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -116,45 +116,67 @@ pub(crate) fn value_is_defined(value: &Value) -> bool {
 
 impl Interpreter {
     /// Save the current readonly_vars set (call before function body execution).
-    pub(crate) fn save_readonly_vars(&self) -> HashSet<String> {
-        self.readonly_vars.clone()
+    ///
+    /// O(1): an `Arc` bump, not a deep copy. The set is copy-on-write (see
+    /// [`ReadonlySet`]), so the snapshot only materializes if the callee
+    /// actually changes the set — and a callee whose params are already marked
+    /// (the monomorphic/recursive steady state) changes nothing, so a call pays
+    /// no allocation at all.
+    pub(crate) fn save_readonly_vars(&self) -> ReadonlySet {
+        ReadonlySet::clone(&self.readonly_vars)
     }
 
     /// Restore the readonly_vars set (call after function body execution).
-    pub(crate) fn restore_readonly_vars(&mut self, saved: HashSet<String>) {
+    pub(crate) fn restore_readonly_vars(&mut self, saved: ReadonlySet) {
         self.readonly_vars = saved;
-    }
-
-    /// Get read access to readonly_vars set.
-    pub(crate) fn readonly_vars(&self) -> &HashSet<String> {
-        &self.readonly_vars
-    }
-
-    /// Get mutable access to readonly_vars set.
-    pub(crate) fn readonly_vars_mut(&mut self) -> &mut HashSet<String> {
-        &mut self.readonly_vars
     }
 
     /// Check if a variable is readonly.
     pub(crate) fn is_readonly(&self, name: &str) -> bool {
-        self.readonly_vars.contains(name)
+        self.is_readonly_sym(Symbol::intern(name))
+    }
+
+    /// Check if an already-interned name is readonly.
+    #[inline]
+    pub(crate) fn is_readonly_sym(&self, sym: Symbol) -> bool {
+        self.readonly_vars.contains(&sym)
     }
 
     /// Mark a variable as readonly.
     pub(crate) fn mark_readonly(&mut self, name: &str) {
-        self.readonly_vars.insert(name.to_string());
+        self.mark_readonly_sym(Symbol::intern(name));
+    }
+
+    /// Mark an already-interned name as readonly. The membership test comes
+    /// first so a no-op mark (the common case: a recursive/monomorphic call
+    /// re-marking a param the caller's frame already marked) does not trigger
+    /// the copy-on-write clone.
+    #[inline]
+    pub(crate) fn mark_readonly_sym(&mut self, sym: Symbol) {
+        if !self.readonly_vars.contains(&sym) {
+            std::sync::Arc::make_mut(&mut self.readonly_vars).insert(sym);
+        }
     }
 
     /// Remove a variable from the readonly set.
     pub(crate) fn unmark_readonly(&mut self, name: &str) {
-        self.readonly_vars.remove(name);
+        self.unmark_readonly_sym(Symbol::intern(name));
+    }
+
+    /// Remove an already-interned name from the readonly set. Like
+    /// `mark_readonly_sym`, a no-op unmark skips the copy-on-write clone.
+    #[inline]
+    pub(crate) fn unmark_readonly_sym(&mut self, sym: Symbol) {
+        if self.readonly_vars.contains(&sym) {
+            std::sync::Arc::make_mut(&mut self.readonly_vars).remove(&sym);
+        }
     }
 
     /// Check if a variable is readonly and return an error if so.
     /// Returns Ok(()) if writable, Err with X::Multi::NoMatch for increment/decrement,
     /// or Err with a generic message for assignment.
     pub(crate) fn check_readonly_for_modify(&self, name: &str) -> Result<(), RuntimeError> {
-        if self.readonly_vars.contains(name) {
+        if self.is_readonly(name) {
             let msg = format!("Cannot assign to a readonly variable ({}) or a value", name);
             let mut err = RuntimeError::new(msg.clone());
             let mut attrs = std::collections::HashMap::new();
@@ -184,7 +206,7 @@ impl Interpreter {
         name: &str,
         op: &str,
     ) -> Result<(), RuntimeError> {
-        if self.readonly_vars.contains(name) {
+        if self.is_readonly(name) {
             let msg = format!(
                 "Cannot resolve caller {op}({}); the parameter requires mutable arguments",
                 name

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -289,7 +289,7 @@ pub(crate) struct VmCallFrame {
     pub saved_upvalues: Vec<Option<Value>>,
     pub saved_stack_depth: usize,
     /// None when using light call frame (simple methods that don't use `:=` binding).
-    pub saved_readonly: Option<HashSet<String>>,
+    pub saved_readonly: Option<crate::runtime::ReadonlySet>,
     /// Read-only var names this frame *newly* added to `readonly_vars` (used by
     /// the light-frame method path, which marks `$` scalar params read-only
     /// without cloning the whole set). Removed on `pop_call_frame`. Empty for the

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -167,10 +167,12 @@ impl Interpreter {
             named_param_slots: None,
             deprecated_info,
             declared_locals: None,
+            param_name_syms: Vec::new(),
             package: pkg.clone(),
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_param_slots();
+        cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();
         self.otf_compile_cache.insert(cache_key, cf.clone());

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -91,9 +91,19 @@ impl Interpreter {
         // Reuse a pooled locals vec to avoid per-call allocation
         let num_locals = cf.code.locals.len();
         self.locals = self.take_locals_from_pool(num_locals);
-        for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if let Some(val) = self.env().get(local_name) {
-                self.locals[i] = val.clone();
+        // Seed from the pre-interned local names (see the matching comment in
+        // `call_compiled_function_positional_light`).
+        if cf.code.locals_sym.len() == num_locals {
+            for (i, sym) in cf.code.locals_sym.iter().enumerate() {
+                if let Some(val) = self.env().get_sym(*sym) {
+                    self.locals[i] = val.clone();
+                }
+            }
+        } else {
+            for (i, local_name) in cf.code.locals.iter().enumerate() {
+                if let Some(val) = self.env().get(local_name) {
+                    self.locals[i] = val.clone();
+                }
             }
         }
         // Load persisted state variable values
@@ -213,12 +223,9 @@ impl Interpreter {
         if let Some(caller_env) = caller_env {
             // Scoped path: restore the caller env, then merge the callee's
             // overlay (its own writes only) back, dropping callee-local writes.
-            let local_names: std::collections::HashSet<&str> =
-                if let Some(ref declared) = cf.declared_locals {
-                    declared.iter().map(|s| s.as_str()).collect()
-                } else {
-                    cf.code.locals.iter().map(|s| s.as_str()).collect()
-                };
+            // The callee-local test reads the compile-time `Symbol` set instead
+            // of building a `HashSet<&str>` on every call (see
+            // `call_compiled_function_positional_light`).
             let scoped = std::mem::replace(self.env_mut(), caller_env);
             for (k, v) in scoped.overlay_iter() {
                 // The callee's private topic / arg array / routine-id must not
@@ -226,7 +233,7 @@ impl Interpreter {
                 if *k == "_" || *k == "@_" || *k == "%_" || *k == "__mutsu_callable_id" {
                     continue;
                 }
-                if !k.with_str(|s| local_names.contains(s)) {
+                if !cf.is_callee_local_sym(*k) {
                     self.env_mut().insert_sym(*k, v.clone());
                 }
             }
@@ -236,15 +243,9 @@ impl Interpreter {
             } else {
                 // Use declared_locals to only filter out function-local vars.
                 // Captured outer variables should propagate their modifications.
-                let local_names: std::collections::HashSet<&str> =
-                    if let Some(ref declared) = cf.declared_locals {
-                        declared.iter().map(|s| s.as_str()).collect()
-                    } else {
-                        cf.code.locals.iter().map(|s| s.as_str()).collect()
-                    };
                 let mut restored_env = saved_env;
                 for (k, v) in self.env().iter() {
-                    if !k.with_str(|s| local_names.contains(s)) {
+                    if !cf.is_callee_local_sym(*k) {
                         restored_env.insert_sym(*k, v.clone());
                     }
                 }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -66,10 +66,21 @@ impl Interpreter {
 
         // Read-through to the caller (parent tier) for the initial value of a
         // local that shadows a same-named caller variable, matching the prior
-        // env().get() semantics.
-        for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if let Some(val) = self.env().get(local_name) {
-                self.locals[i] = val.clone();
+        // env().get() semantics. `locals_sym` is `locals` pre-interned at
+        // finalize(), so the seed loop hashes a `u32` per local instead of
+        // re-interning the name string on every call.
+        if cf.code.locals_sym.len() == num_locals {
+            for (i, sym) in cf.code.locals_sym.iter().enumerate() {
+                if let Some(val) = self.env().get_sym(*sym) {
+                    self.locals[i] = val.clone();
+                }
+            }
+        } else {
+            // Hand-built chunk with no pre-interned locals: resolve by name.
+            for (i, local_name) in cf.code.locals.iter().enumerate() {
+                if let Some(val) = self.env().get(local_name) {
+                    self.locals[i] = val.clone();
+                }
             }
         }
 
@@ -116,7 +127,10 @@ impl Interpreter {
                 if needs_env {
                     self.env_mut().insert(param_name.clone(), val);
                 }
-                self.mark_readonly(&cf.param_defs[param_idx].name);
+                match cf.param_name_syms.get(param_idx) {
+                    Some(sym) => self.mark_readonly_sym(*sym),
+                    None => self.mark_readonly(&cf.param_defs[param_idx].name),
+                }
             }
         }
         // Bind-time param values that a name-based reader can observe were
@@ -219,12 +233,11 @@ impl Interpreter {
         // this function) persists in the caller; the function's params/locals are
         // dropped with the overlay. This replaces the prior per-name save/restore.
         {
-            let local_names: std::collections::HashSet<&str> =
-                if let Some(ref declared) = cf.declared_locals {
-                    declared.iter().map(|s| s.as_str()).collect()
-                } else {
-                    cf.code.locals.iter().map(|s| s.as_str()).collect()
-                };
+            // The callee-local test reads the compile-time `Symbol` set
+            // (`is_callee_local_sym`) instead of materializing a `HashSet<&str>`
+            // per call: the old set was built even when the overlay was empty
+            // (a body whose params/locals are all slot-resolved never writes
+            // env), and hashed every local name with SipHash to build it.
             let scoped = std::mem::replace(self.env_mut(), caller_env);
             for (k, v) in scoped.overlay_iter() {
                 // The callee's private topic / arg array / routine id, and the
@@ -240,7 +253,7 @@ impl Interpreter {
                 {
                     continue;
                 }
-                if !k.with_str(|s| local_names.contains(s)) {
+                if !cf.is_callee_local_sym(*k) {
                     self.env_mut().insert_sym(*k, v.clone());
                 }
             }

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -193,7 +193,7 @@ impl Interpreter {
         // Mark parameters as readonly (by default, params are immutable in Raku).
         // Save existing readonly state so we can restore it after the call.
         let saved_readonly = self.save_readonly_vars();
-        for pd in &cf.param_defs {
+        for (i, pd) in cf.param_defs.iter().enumerate() {
             if !pd.name.is_empty()
                 && !pd.sigilless
                 && !pd.name.starts_with('!')
@@ -203,8 +203,14 @@ impl Interpreter {
                     .traits
                     .iter()
                     .any(|t| t == "rw" || t == "copy" || t == "raw");
+                // `param_name_syms` is `param_defs[i].name` pre-interned; fall
+                // back to interning for a chunk that never precomputed it.
+                let sym = cf.param_name_syms.get(i).copied();
                 if !has_mutable_trait {
-                    self.mark_readonly(&pd.name);
+                    match sym {
+                        Some(sym) => self.mark_readonly_sym(sym),
+                        None => self.mark_readonly(&pd.name),
+                    }
                 } else {
                     // `is copy`/`is rw`/`is raw` params are writable. The readonly
                     // set is keyed by bare name and shared across frames, so a
@@ -212,7 +218,10 @@ impl Interpreter {
                     // otherwise leak in and make this writable param appear readonly.
                     // Unmark it; `restore_readonly_vars` reinstates the caller's
                     // state after the call.
-                    self.unmark_readonly(&pd.name);
+                    match sym {
+                        Some(sym) => self.unmark_readonly_sym(sym),
+                        None => self.unmark_readonly(&pd.name),
+                    }
                 }
             }
         }
@@ -371,12 +380,6 @@ impl Interpreter {
         // params/locals/aliases are dropped with the overlay. This replaces the
         // per-key `modified_env_keys` save/restore.
         {
-            let local_names: std::collections::HashSet<&str> =
-                if let Some(ref declared) = cf.declared_locals {
-                    declared.iter().map(|s| s.as_str()).collect()
-                } else {
-                    cf.code.locals.iter().map(|s| s.as_str()).collect()
-                };
             let scoped = std::mem::replace(self.env_mut(), caller_env);
             for (k, v) in scoped.overlay_iter() {
                 if *k == "_"
@@ -387,7 +390,7 @@ impl Interpreter {
                 {
                     continue;
                 }
-                if !k.with_str(|s| local_names.contains(s)) {
+                if !cf.is_callee_local_sym(*k) {
                     self.env_mut().insert_sym(*k, v.clone());
                 }
             }

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -444,12 +444,6 @@ impl Interpreter {
             // Use declared_locals (vars declared via `my` or as params) instead
             // of all locals. Captured outer variables should propagate their
             // modifications back to the caller.
-            let local_names: std::collections::HashSet<&str> =
-                if let Some(ref declared) = cf.declared_locals {
-                    declared.iter().map(|s| s.as_str()).collect()
-                } else {
-                    cf.code.locals.iter().map(|s| s.as_str()).collect()
-                };
             for (k, v) in self.env().iter() {
                 if *k == "_" || *k == "@_" || *k == "%_" {
                     continue;
@@ -461,7 +455,7 @@ impl Interpreter {
                     continue;
                 }
                 if restored_env.contains_key_sym(*k)
-                    && !k.with_str(|s| local_names.contains(s))
+                    && !cf.is_callee_local_sym(*k)
                     && !k.with_str(|s| rw_sources.contains(s))
                 {
                     restored_env.insert_sym(*k, v.clone());
@@ -481,11 +475,11 @@ impl Interpreter {
                 if restored_env.contains_key_sym(*sym) {
                     continue;
                 }
-                let skip = sym.with_str(|s| {
-                    s == "_"
+                let skip = cf.is_callee_local_sym(*sym)
+                    || sym.with_str(|s| {
+                        s == "_"
                         || s == "@_"
                         || s == "%_"
-                        || local_names.contains(s)
                         || rw_sources.contains(s)
                         // Compiler-internal bookkeeping symbols (e.g. the
                         // `__mutsu_sigilless_readonly::p` marker emitted for a
@@ -496,7 +490,7 @@ impl Interpreter {
                         // Dynamic vars (`$*x`) are reconciled by
                         // pop_caller_env_with_writeback, not the lexical merge.
                         || s.as_bytes().get(1) == Some(&b'*')
-                });
+                    });
                 if skip {
                     continue;
                 }

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -146,7 +146,7 @@ impl Interpreter {
             .iter()
             .map(|name| {
                 let val = self.env().get(name).cloned();
-                let was_readonly = self.readonly_vars().contains(name);
+                let was_readonly = self.is_readonly(name);
                 let sigilless_key = format!("__mutsu_sigilless_readonly::{}", name);
                 let sigilless_ro = self.env().get(&sigilless_key).cloned();
                 (name.clone(), val, was_readonly, sigilless_ro)
@@ -573,7 +573,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         self.topic_source_var = saved_topic_source;
                         self.quanthash_bind_params = saved_quanthash_bind.clone();
@@ -599,7 +599,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         if spec.restore_topic {
                             match saved_topic.clone() {
@@ -629,7 +629,7 @@ impl Interpreter {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.readonly_vars_mut().remove(name);
+            self.unmark_readonly(name);
         }
         // Restore saved multi-param values and readonly state
         for (name, saved_val, was_readonly, sigilless_ro) in saved_multi_params {

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -27,7 +27,7 @@ impl Interpreter {
             .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
-        let was_topic_readonly = self.readonly_vars().contains("_");
+        let was_topic_readonly = self.is_readonly("_");
 
         // Save the single named loop param (`for ... -> $x`) prior binding so it
         // does not leak past the loop into the enclosing scope. Without this, a
@@ -157,7 +157,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         if !was_topic_readonly {
                             self.unmark_readonly("_");
@@ -181,7 +181,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         if !was_topic_readonly {
                             self.unmark_readonly("_");
@@ -214,7 +214,7 @@ impl Interpreter {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.readonly_vars_mut().remove(name);
+            self.unmark_readonly(name);
         }
         if !was_topic_readonly {
             self.unmark_readonly("_");

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -44,7 +44,7 @@ impl Interpreter {
             .then(|| self.env().get("_").cloned())
             .flatten();
         let saved_topic_source = self.topic_source_var.take();
-        let was_topic_readonly = self.readonly_vars().contains("_");
+        let was_topic_readonly = self.is_readonly("_");
 
         if !spec.is_rw {
             if let Some(ref name) = param_name {
@@ -126,7 +126,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         if !was_topic_readonly {
                             self.unmark_readonly("_");
@@ -148,7 +148,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         if !was_topic_readonly {
                             self.unmark_readonly("_");
@@ -175,7 +175,7 @@ impl Interpreter {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.readonly_vars_mut().remove(name);
+            self.unmark_readonly(name);
         }
         if !was_topic_readonly {
             self.unmark_readonly("_");
@@ -331,7 +331,7 @@ impl Interpreter {
                         if !spec.is_rw
                             && let Some(ref name) = param_name
                         {
-                            self.readonly_vars_mut().remove(name);
+                            self.unmark_readonly(name);
                         }
                         if spec.restore_topic {
                             match saved_topic.clone() {
@@ -356,7 +356,7 @@ impl Interpreter {
         if !spec.is_rw
             && let Some(ref name) = param_name
         {
-            self.readonly_vars_mut().remove(name);
+            self.unmark_readonly(name);
         }
         self.topic_source_var = saved_topic_source;
         if spec.restore_topic {

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -64,8 +64,7 @@ impl Interpreter {
         // `@p[0]=v`, and `@p.push` all propagate). So when a pointy param is
         // present, don't mark `$_` read-only: that would propagate read-only to
         // `@p` through its `@p := $_` bind and block element assignment.
-        let mark_ro =
-            topic_readonly && pointy_param.is_none() && !self.readonly_vars().contains("_");
+        let mark_ro = topic_readonly && pointy_param.is_none() && !self.is_readonly("_");
         if mark_ro {
             self.mark_readonly("_");
         }

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -30,7 +30,7 @@ impl Interpreter {
                 target.view(),
                 ValueView::Mixin(_, overrides) if overrides.contains_key("__mutsu_topic_ro__")
             );
-            if mixin_ro || self.readonly_vars().contains("_") {
+            if mixin_ro || self.is_readonly("_") {
                 let type_name = match target.view() {
                     ValueView::Int(_) => "Int",
                     ValueView::Num(_) => "Num",

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -984,7 +984,7 @@ impl Interpreter {
                 // variable (the readonly set is keyed by bare name, shared across
                 // frames). Drop the mark and record it so `pop_call_frame`
                 // restores the caller's state.
-                if self.readonly_vars().contains(pd.name.as_str()) {
+                if self.is_readonly(&pd.name) {
                     self.unmark_readonly(&pd.name);
                     if let Some(frame) = self.call_frames.last_mut() {
                         frame.readonly_removed.push(pd.name.clone());
@@ -992,7 +992,7 @@ impl Interpreter {
                 }
                 continue;
             }
-            if self.readonly_vars().contains(pd.name.as_str()) {
+            if self.is_readonly(&pd.name) {
                 continue; // already read-only (e.g. caller-owned same name)
             }
             self.mark_readonly(&pd.name);

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -431,7 +431,7 @@ impl Interpreter {
         // the now-gone binding (`my %h := SetHash.new(...)` inside a block
         // must not leave `%h` readonly in the outer scope).
         for name in &block_declared {
-            self.readonly_vars_mut().remove(name);
+            self.unmark_readonly(name);
         }
         // Note: `our`-scoped variables persist in our_vars and are accessible
         // via package-qualified names (e.g., $Pkg::var) after block exit.

--- a/src/vm/vm_subst_exec.rs
+++ b/src/vm/vm_subst_exec.rs
@@ -247,7 +247,7 @@ impl Interpreter {
         code: &CompiledCode,
         result: Value,
     ) -> Result<(), RuntimeError> {
-        if self.readonly_vars().contains("_") {
+        if self.is_readonly("_") {
             let mut attrs = std::collections::HashMap::new();
             attrs.insert(
                 "message".to_string(),

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -56,7 +56,7 @@ impl Interpreter {
         if self.var_type_constraint_fast(var_name).is_some()
             || self.var_default(var_name).is_some()
             || self.var_hash_key_constraint_fast(var_name)
-            || self.readonly_vars().contains(var_name)
+            || self.is_readonly(var_name)
         {
             return None;
         }
@@ -130,7 +130,7 @@ impl Interpreter {
         // the full path's native-fill, hole, and shape handling.
         if self.var_type_constraint_fast(var_name).is_some()
             || self.var_default(var_name).is_some()
-            || self.readonly_vars().contains(var_name)
+            || self.is_readonly(var_name)
         {
             return None;
         }
@@ -232,7 +232,7 @@ impl Interpreter {
         if self.var_type_constraint_fast(var_name).is_some()
             || self.var_default(var_name).is_some()
             || self.var_hash_key_constraint_fast(var_name)
-            || self.readonly_vars().contains(var_name)
+            || self.is_readonly(var_name)
         {
             return None;
         }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1353,8 +1353,7 @@ impl Interpreter {
                 // marker (see `Stmt::MarkBoundContainer`), which distinguishes a
                 // writable bound hash from a `constant %M` — both are readonly,
                 // but only the former may be mutated in place.
-                let is_readonly_hash_var =
-                    var_name.starts_with('%') && self.readonly_vars().contains(&var_name);
+                let is_readonly_hash_var = var_name.starts_with('%') && self.is_readonly(&var_name);
                 let is_bound_hash_var = is_readonly_hash_var
                     && self
                         .env()

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -97,9 +97,7 @@ impl Interpreter {
         ) {
             return None;
         }
-        if self.var_type_constraint_fast(var_name).is_some()
-            || self.readonly_vars().contains(var_name)
-        {
+        if self.var_type_constraint_fast(var_name).is_some() || self.is_readonly(var_name) {
             return None;
         }
         let env = self.env();


### PR DESCRIPTION
## What

Removes the per-call overhead in the positional light-call path
(`call_compiled_function_positional_light`), which runs on **every monomorphic
user function call** and was 10.9% of bench-fib self time, surrounded by 11.8%
malloc/free, 4.1% SipHash `Hasher::write` and 3.7% `hashbrown RawTable::clone`.

Three concrete per-call costs, none of them inherent to the call:

### 1. `save_readonly_vars()` deep-cloned the readonly set on every call

`readonly_vars` was a `HashSet<String>` with the **default hasher**, and every
call snapshotted it (`self.readonly_vars.clone()`) — a `RawTable` allocation plus
a heap `String` per entry — then `mark_readonly(&name)` did `name.to_string()` +
a SipHash insert per parameter.

It is now `Arc<FxHashSet<Symbol>>` (`runtime::ReadonlySet`): copy-on-write and
`Symbol`-keyed. `save` is an `Arc` bump (O(1)); mutation goes through
`Arc::make_mut` (a `memcpy` of `u32`s, no per-key allocation). `mark_readonly_sym`
/ `unmark_readonly_sym` test membership **first**, so the steady state of a
recursive/monomorphic call — re-marking a parameter the caller's frame already
marked — allocates nothing at all.

**Semantics are exactly preserved**: the set holds the same names (a `Symbol` is
1:1 with its string), and `restore_readonly_vars` still reinstates the caller's
set wholesale. `CheckReadOnly` / the `X::Assignment::RO` path are unaffected.

### 2. The exit-time merge built a `HashSet<&str>` per call

The scoped-overlay return merge built a `std::collections::HashSet<&str>`
(SipHash!) of the callee's local names on **every call**, even when the overlay
was empty and the loop body never ran. `CompiledFunction::declared_locals` is now
an `FxHashSet<Symbol>` and the merge asks `is_callee_local_sym(k)` directly — the
overlay's keys are already `Symbol`s, so nothing is built and nothing is hashed as
a string.

### 3. The local-seed loop re-interned every local name per call

`self.env().get(local_name)` takes a `&str` and interns it. `CompiledCode` already
carries `locals_sym` (the pre-interned local names), so the seed loop now uses
`get_sym`.

The same three patterns are fixed in the sibling paths (`vm_call_fast.rs`,
`vm_call_light_typed.rs`, `vm_call_named_inner.rs`).

## Measurement

Per the [ADR-0006 protocol](docs/adr/0006-baseline-interpreter-optimizations.md):
`perf stat -r 5 -e instructions:u` under `taskset -c 2` (a P-core), release build,
**default config (JIT on)**, `main` vs this branch. Reproducible to within 0.03%
across repeated runs.

| bench       | main          | branch        | delta      |
|-------------|---------------|---------------|------------|
| bench-fib   | 4,132,278,951 | 2,798,773,986 | **-32.3%** |
| bench-tak   | 6,613,314,073 | 5,033,629,085 | **-23.9%** |
| method-call | 1,861,589,830 | 1,858,620,949 | -0.2%      |
| poly-call   | 1,050,875,639 | 1,049,290,771 | -0.2%      |

bench-fib and bench-tak are the call-dominated benchmarks (tak binds three params
per call, so it pays the readonly marking three times over). method-call and
poly-call go through the method-dispatch path and are unchanged — confirming the
change adds no cost anywhere.

Re-profiling bench-fib on the new binary confirms the mechanism:

- `hashbrown RawTable::clone` (3.7%) — **gone entirely**
- `malloc` + `_int_free`: 11.8% → **7.2%**
- SipHash `Hasher::write`: 4.1% → **2.1%** (the residual is the `compiled_fns`
  `HashMap<String, _>` lookup — a separate slice, §2.1 of the call-path scouting)

What is left on top of fib is now `Env::scoped_child` / `drop_in_place<Env>` —
i.e. the lexical-scope slot campaign, which is the next target.

## Validation

- `make test`: 16606 tests, **all pass**
- `roast/S06-traits/is-rw.t` + `roast/S06-signature/*.t` (the readonly/rw
  semantics surface): 36 files, 874 subtests, **all pass**
- `roast/S02-names-vars/*.t`: same result as `main` (`names.t` has 3 pre-existing
  failures on `main` too; it is not whitelisted)
- Full `make roast` delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ
