### PR TITLE
perf(vm): pre-intern the per-assignment sigilless-alias/readonly env keys

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1585,6 +1585,17 @@ pub(crate) struct CompiledCode {
     /// Pre-interned Symbol for each local name. Avoids Symbol::intern()
     /// on every env sync in hot paths.
     pub(crate) locals_sym: Vec<Symbol>,
+    /// Pre-interned Symbol of the `__mutsu_sigilless_alias::<name>` env key for
+    /// each local. The scalar-assignment hot path probes that key on EVERY store
+    /// (to propagate the new value to a `:=` alias target); building the key with
+    /// `format!` per store cost a String allocation plus a `Symbol::intern` string
+    /// hash, which profiled as ~19% of bench-mandelbrot. Interned once here, the
+    /// probe is a plain `Env::get_sym`.
+    pub(crate) locals_alias_sym: Vec<Symbol>,
+    /// Pre-interned Symbol of the `__mutsu_sigilless_readonly::<name>` env key
+    /// for each local — the readonly half of the pair described above, probed on
+    /// every assignment for the same reason.
+    pub(crate) locals_readonly_sym: Vec<Symbol>,
     /// Bitmap: true if local[i] is eligible for SetLocal fast path
     /// (simple $-prefixed scalar, no twigils, no ::, no _ topic, no ./! attrs).
     pub(crate) simple_locals: Vec<bool>,
@@ -1904,6 +1915,8 @@ impl CompiledCode {
             stmt_pool: Vec::new(),
             locals: Vec::new(),
             locals_sym: Vec::new(),
+            locals_alias_sym: Vec::new(),
+            locals_readonly_sym: Vec::new(),
             simple_locals: Vec::new(),
             state_locals: Vec::new(),
             our_locals: Vec::new(),
@@ -2003,8 +2016,44 @@ impl CompiledCode {
     }
 
     /// Pre-intern all local names as Symbols.
+    /// The interned `__mutsu_sigilless_alias::<name>` env key of local `idx`.
+    /// Served from the pre-interned table; a hand-built chunk that never ran
+    /// `compute_locals_sym` falls back to interning it on the spot, so the probe
+    /// is never silently skipped.
+    pub(crate) fn alias_sym(&self, idx: usize) -> Option<Symbol> {
+        match self.locals_alias_sym.get(idx) {
+            Some(sym) => Some(*sym),
+            None => self
+                .locals
+                .get(idx)
+                .map(|n| Symbol::intern(&crate::runtime::sigilless_alias_key(n))),
+        }
+    }
+
+    /// The interned `__mutsu_sigilless_readonly::<name>` env key of local `idx`.
+    /// See [`CompiledCode::alias_sym`].
+    pub(crate) fn readonly_sym(&self, idx: usize) -> Option<Symbol> {
+        match self.locals_readonly_sym.get(idx) {
+            Some(sym) => Some(*sym),
+            None => self
+                .locals
+                .get(idx)
+                .map(|n| Symbol::intern(&crate::runtime::sigilless_readonly_key(n))),
+        }
+    }
+
     pub(crate) fn compute_locals_sym(&mut self) {
         self.locals_sym = self.locals.iter().map(|s| Symbol::intern(s)).collect();
+        self.locals_alias_sym = self
+            .locals
+            .iter()
+            .map(|s| Symbol::intern(&crate::runtime::sigilless_alias_key(s)))
+            .collect();
+        self.locals_readonly_sym = self
+            .locals
+            .iter()
+            .map(|s| Symbol::intern(&crate::runtime::sigilless_readonly_key(s)))
+            .collect();
     }
 
     /// Compute which locals need to be synced to env.

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -9,6 +9,22 @@ use num_traits::{Signed, ToPrimitive, Zero};
 /// Maximum number of elements when expanding an infinite range to a list.
 pub(crate) const MAX_RANGE_EXPAND: i64 = 1_000_000;
 
+/// The env key recording the `:=` alias target of the sigilless/aliased variable
+/// `name` (`my $b := $a` stores `a` under the key for `b`). The single definition
+/// of the key shape, so a hot path can pre-intern it instead of rebuilding it per
+/// store — see `CompiledCode::locals_alias_sym`.
+pub(crate) fn sigilless_alias_key(name: &str) -> String {
+    format!("__mutsu_sigilless_alias::{name}")
+}
+
+/// The env key marking the sigilless variable `name` as readonly (`my \x = 42`).
+/// Companion of [`sigilless_alias_key`]; both are only ever present once the
+/// program creates a sigilless/`:=` binding, which `closure_meta_keys_possible`
+/// reports.
+pub(crate) fn sigilless_readonly_key(name: &str) -> String {
+    format!("__mutsu_sigilless_readonly::{name}")
+}
+
 /// Build the `Failure` value raku yields when a count/numeric coercion is
 /// attempted on a lazy iterable (e.g. `(1..*).elems` / `.Int` / `+@a`):
 /// `X::Cannot::Lazy` with the message `Cannot .<action> a lazy list`.

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -346,15 +346,21 @@ impl Interpreter {
             // object Any (the reset guard is a no-op for `@`/`%` containers).
             val = self.reset_nil_untyped_scalar(name, val);
         }
-        let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
-        let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-        if matches!(
-            self.env().get(&readonly_key).map(Value::view),
-            Some(ValueView::Bool(true))
-        ) && !matches!(
-            self.env().get(&alias_key).map(Value::view),
-            Some(ValueView::Str(_))
-        ) {
+        // A sigilless-readonly binding can only exist once the program created a
+        // `__mutsu_sigilless_*` key, so skip the probe (and its two `format!`s)
+        // entirely otherwise — this runs on every expression-context assignment.
+        if crate::env::closure_meta_keys_possible()
+            && let Some(readonly_sym) = code.readonly_sym(idx)
+            && let Some(alias_sym) = code.alias_sym(idx)
+            && matches!(
+                self.env().get_sym(readonly_sym).map(Value::view),
+                Some(ValueView::Bool(true))
+            )
+            && !matches!(
+                self.env().get_sym(alias_sym).map(Value::view),
+                Some(ValueView::Str(_))
+            )
+        {
             return Err(RuntimeError::assignment_ro(None));
         }
         if !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&') {
@@ -410,13 +416,18 @@ impl Interpreter {
         }
         self.locals[idx] = val.clone();
         self.set_env_with_main_alias(name, val.clone());
-        if let Some(alias_name) = self.env().get(&alias_key).and_then(|v| {
-            if let ValueView::Str(name) = v.view() {
-                Some(name.to_string())
-            } else {
-                None
-            }
-        }) {
+        if crate::env::closure_meta_keys_possible()
+            && let Some(alias_name) = code
+                .alias_sym(idx)
+                .and_then(|sym| self.env().get_sym(sym))
+                .and_then(|v| {
+                    if let ValueView::Str(name) = v.view() {
+                        Some(name.to_string())
+                    } else {
+                        None
+                    }
+                })
+        {
             self.update_local_if_exists(code, &alias_name, &val);
             self.env_mut().insert(alias_name.clone(), val.clone());
             // Slice F: a sigilless param (`\target`) aliases a caller variable;

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -476,11 +476,12 @@ impl Interpreter {
             {
                 return Err(err);
             }
-            // Update env when shared_vars is active; otherwise write through to env.
+            // Update env when shared_vars is active. The non-shared write-through
+            // is the unconditional `flush_local_to_env` at the end of this path;
+            // `self.locals[idx]` is not touched in between, so flushing here too
+            // would be a second env insert (and a second COW fork) per store.
             if self.shared_vars_active {
                 loan_env!(self, set_shared_var(name, self.locals[idx].clone()));
-            } else {
-                self.flush_local_to_env(code, idx);
             }
             // When rebinding (`$x := expr`), remove old bind pairs and reverse aliases.
             if is_rebind {
@@ -511,20 +512,21 @@ impl Interpreter {
                 }
             }
             // Propagate to env-based alias targets (for `:=` bindings where
-            // the source is an env variable like `$_`).
-            {
-                let alias_key = format!("__mutsu_sigilless_alias::{}", name);
-                if let Some(target) = self.env().get(&alias_key).and_then(|v| match v.view() {
+            // the source is an env variable like `$_`). The alias key is
+            // pre-interned per local slot (`locals_alias_sym`) and the whole probe
+            // is skipped when no `__mutsu_sigilless_*` key has ever been created,
+            // so a program without `:=`/sigilless aliases pays nothing here.
+            if crate::env::closure_meta_keys_possible()
+                && let Some(alias_sym) = code.alias_sym(idx)
+                && let Some(target) = self.env().get_sym(alias_sym).and_then(|v| match v.view() {
                     ValueView::Str(s) => Some(s.clone()),
                     _ => None,
-                }) {
-                    let is_co_local = code.locals.iter().any(|n| n == target.as_str());
-                    if !is_co_local {
-                        {
-                            let __v = self.locals[idx].clone();
-                            self.env_mut().insert(target.to_string(), __v);
-                        }
-                    }
+                })
+            {
+                let is_co_local = code.locals.iter().any(|n| n == target.as_str());
+                if !is_co_local {
+                    let __v = self.locals[idx].clone();
+                    self.env_mut().insert(target.to_string(), __v);
                 }
             }
             // Track topic mutations for map rw writeback
@@ -1220,18 +1222,21 @@ impl Interpreter {
             // and internal temps.
             val = self.reset_nil_untyped_scalar(name, val);
         }
-        let readonly_key = format!("__mutsu_sigilless_readonly::{}", name);
-        let alias_key = format!("__mutsu_sigilless_alias::{}", name);
         // Only enforce sigilless-readonly when this is NOT a new variable
         // declaration (my $x = ...).  A `my` decl creates a fresh variable
-        // that shadows the sigilless one, so it must not be blocked.
+        // that shadows the sigilless one, so it must not be blocked. Skipped
+        // outright when no `__mutsu_sigilless_*` key has ever been created, so a
+        // program with no sigilless/`:=` binding pays no `format!` per store.
         if !is_vardecl
+            && crate::env::closure_meta_keys_possible()
+            && let Some(readonly_sym) = code.readonly_sym(idx)
+            && let Some(alias_sym) = code.alias_sym(idx)
             && matches!(
-                self.env().get(&readonly_key).map(Value::view),
+                self.env().get_sym(readonly_sym).map(Value::view),
                 Some(ValueView::Bool(true))
             )
             && !matches!(
-                self.env().get(&alias_key).map(Value::view),
+                self.env().get_sym(alias_sym).map(Value::view),
                 Some(ValueView::Str(_))
             )
         {
@@ -1262,10 +1267,12 @@ impl Interpreter {
             }
         }
         if let Some(source_name) = bind_source {
+            let alias_key = runtime::sigilless_alias_key(name);
             let resolved_source = self.resolve_sigilless_alias_source_name(&source_name);
             self.env_mut()
                 .insert(alias_key.clone(), Value::str(resolved_source.clone()));
-            self.env_mut().insert(readonly_key, Value::FALSE);
+            self.env_mut()
+                .insert(runtime::sigilless_readonly_key(name), Value::FALSE);
             self.mark_sigilless_alias_seen();
             // Create a shared ContainerRef for cross-scope binding (source in
             // outer call frame) OR same-scope rebinding (`:=` on existing vars).
@@ -1717,13 +1724,23 @@ impl Interpreter {
                     .insert(format!("{pkg}::term:<{symbol}>"), val.clone());
             }
         }
-        let mut alias_name = self.env().get(&alias_key).and_then(|v| {
-            if let ValueView::Str(name) = v.view() {
-                Some(name.to_string())
-            } else {
-                None
-            }
-        });
+        // Follow the `:=` alias chain from this variable, if it has one. No
+        // `__mutsu_sigilless_*` key can exist unless the program created a
+        // sigilless/`:=` binding, so the whole walk (and its `format!`) is skipped
+        // otherwise.
+        let mut alias_name = if crate::env::closure_meta_keys_possible() {
+            code.alias_sym(idx)
+                .and_then(|sym| self.env().get_sym(sym))
+                .and_then(|v| {
+                    if let ValueView::Str(name) = v.view() {
+                        Some(name.to_string())
+                    } else {
+                        None
+                    }
+                })
+        } else {
+            None
+        };
         let mut seen_aliases = std::collections::HashSet::new();
         while let Some(current_alias) = alias_name {
             if !seen_aliases.insert(current_alias.clone()) {


### PR DESCRIPTION
## What

Every scalar store ran two `format!("__mutsu_sigilless_{alias,readonly}::{name}")` calls plus the `Symbol::intern` string hash they feed — one to enforce a sigilless-readonly binding, one to propagate the new value to a `:=` alias target. Both sit on the **SetLocal fast path**, so a program that never creates a sigilless/`:=` binding still paid two String allocations and two string hashes on every assignment.

On `bench-mandelbrot` that was ~**19% of self time** (`format_inner` + `String::write_str` + `fmt::write`), plus a large share of the 10% `LocalKey::with` (the `Symbol::intern` thread-local cache) and the 4.4% `memcmp`.

## How

- `CompiledCode` pre-interns both env keys per local slot (`locals_alias_sym` / `locals_readonly_sym`, computed in `compute_locals_sym`), so each probe becomes a plain `Env::get_sym` on a `Copy` key. The `alias_sym()` / `readonly_sym()` accessors fall back to interning on the spot for a hand-built chunk that never ran the compute pass — the probe is never silently skipped.
- The probes are additionally skipped outright when no `__mutsu_sigilless_*` key has ever been created (`env::closure_meta_keys_possible()` — the existing monotonic flag whose documented purpose is exactly this).
- Drops a **duplicated `flush_local_to_env`** on the same path: the non-shared branch flushed the slot to env and the unconditional flush at the end of the path did it again, with `self.locals[idx]` untouched in between — i.e. a second env insert (and a second COW fork) per store.

Behavior-preserving: the same keys are probed, with the same semantics; only the key construction and the never-can-hit case change.

## Measured

`instructions:u`, release, JIT on (default config), `taskset -c 2` — the ADR-0006 protocol.

| bench | main | branch | delta |
|---|---|---|---|
| num-arith | 1,334,003,569 | 1,046,508,204 | **−21.6%** |
| bench-mandelbrot | 2,996,934,432 | 2,549,843,632 | **−14.9%** |
| time-parts | 8,132,381,002 | 7,397,952,194 | **−9.0%** |
| bench-hash | 273,605,175 | 258,401,936 | −5.6% |
| bench-string | 657,791,652 | 637,152,187 | −3.1% |
| bench-class | 1,945,471,080 | 1,900,461,886 | −2.3% |
| poly-call | 1,050,814,804 | 1,028,941,860 | −2.1% |
| method-call | 1,860,451,251 | 1,829,742,633 | −1.7% |
| bench-array | 420,216,258 | 419,182,180 | −0.3% |
| word-count | 1,043,640,603 | 1,035,565,780 | −0.8% |
| bench-fib | 4,133,602,986 | 4,149,574,211 | +0.4% (noise; call-bound, no hot SetLocal) |
| bench-tak | 6,615,370,303 | 6,625,708,357 | +0.2% (noise) |

## Validation

`make test`: 16606/16606 PASS. Alias/readonly semantics spot-checked (`my $b := $a; $a = 5` → `$b` is 5; `my \x = 42` reads back and stays readonly). CI runs the full `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ