### PR TITLE
perf(vm): key instance attributes by Symbol instead of String (ADR-0006 §2.4)

### DIFF
--- a/src/builtins/exception_message.rs
+++ b/src/builtins/exception_message.rs
@@ -1,13 +1,10 @@
+use crate::value::AttrMap;
 use crate::value::{Value, ValueView};
-use std::collections::HashMap;
 
 /// Construct the `.message` string for a structured exception from its class
 /// name and attribute map.  Returns `None` when the class name is not
 /// recognised (caller should fall back to the generic behaviour).
-pub fn format_exception_message(
-    class_name: &str,
-    attrs: &HashMap<String, Value>,
-) -> Option<String> {
+pub fn format_exception_message(class_name: &str, attrs: &AttrMap) -> Option<String> {
     match class_name {
         "X::Str::Numeric" => {
             let reason = attr_str(attrs, "reason");
@@ -158,7 +155,7 @@ pub fn format_exception_message(
 }
 
 /// Extract a string attribute, defaulting to "" if absent.
-fn attr_str(attrs: &HashMap<String, Value>, key: &str) -> String {
+fn attr_str(attrs: &AttrMap, key: &str) -> String {
     attrs
         .get(key)
         .map(|v| v.to_string_value())
@@ -166,7 +163,7 @@ fn attr_str(attrs: &HashMap<String, Value>, key: &str) -> String {
 }
 
 /// Extract a string attribute with a custom default.
-fn attr_str_or(attrs: &HashMap<String, Value>, key: &str, default: &str) -> String {
+fn attr_str_or(attrs: &AttrMap, key: &str, default: &str) -> String {
     attrs
         .get(key)
         .map(|v| v.to_string_value())

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -1002,7 +1002,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
         ValueView::Instance { attributes, .. } => {
             let mut named = HashMap::new();
             for (k, v) in attributes.as_map().iter() {
-                named.insert(k.clone(), v.clone());
+                named.insert(k.resolve(), v.clone());
             }
             Ok(Value::capture(vec![], named))
         }

--- a/src/builtins/methods_0arg/match_helpers.rs
+++ b/src/builtins/methods_0arg/match_helpers.rs
@@ -1,10 +1,10 @@
 use crate::value::{Value, ValueView};
-use std::collections::HashMap;
 
 use super::raku_repr::raku_value;
+use crate::value::AttrMap;
 
 /// Produce Raku-compatible `.raku` representation for a Match object.
-pub(super) fn match_raku_repr(attributes: &HashMap<String, Value>) -> String {
+pub(super) fn match_raku_repr(attributes: &AttrMap) -> String {
     let orig = attributes
         .get("orig")
         .map(|v| v.to_string_value())
@@ -100,7 +100,7 @@ pub(super) fn match_value_to(val: &Value) -> i64 {
 /// Collect all captures from a Match object sorted by position.
 /// Positional captures use `ValuePair(Int => Match)` and named captures use
 /// `Pair(Str => Match)` to preserve the Raku-visible key types.
-pub(super) fn match_caps(attributes: &HashMap<String, Value>) -> Value {
+pub(super) fn match_caps(attributes: &AttrMap) -> Value {
     let mut pairs: Vec<(i64, i64, Value)> = Vec::new();
 
     // Collect named capture positions to filter out shadowed positional captures
@@ -168,7 +168,7 @@ fn expand_capture_items(val: &Value) -> Vec<Value> {
 }
 
 /// Like `.caps` but also includes non-captured text between captures as `~ => text` pairs.
-pub(super) fn match_chunks(attributes: &HashMap<String, Value>) -> Value {
+pub(super) fn match_chunks(attributes: &AttrMap) -> Value {
     // Collect named capture positions to filter out shadowed positional captures
     let mut named_positions: Vec<(i64, i64)> = Vec::new();
     if let Some(ValueView::Hash(named)) = attributes.get("named").map(Value::view) {

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1561,7 +1561,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         let map: HashMap<String, Value> = attributes
             .as_map()
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, v)| (k.resolve(), v.clone()))
             .collect();
         return Some(Ok(Value::hash(map)));
     }

--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -1,4 +1,5 @@
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::{RuntimeError, Value, ValueView};
 use std::collections::HashMap;
 
@@ -480,7 +481,7 @@ fn parse_tz_offset(s: &str) -> Result<i64, RuntimeError> {
 }
 
 /// Extract (year, month, day) from a Date instance's attributes.
-pub fn date_attrs(attributes: &HashMap<String, Value>) -> (i64, i64, i64) {
+pub fn date_attrs(attributes: &AttrMap) -> (i64, i64, i64) {
     // New format: year/month/day as separate attributes
     if let Some(ValueView::Int(y)) = attributes.get("year").map(Value::view) {
         let m = match attributes.get("month").map(Value::view) {
@@ -501,7 +502,7 @@ pub fn date_attrs(attributes: &HashMap<String, Value>) -> (i64, i64, i64) {
 }
 
 /// Extract DateTime components from attributes.
-pub fn datetime_attrs(attributes: &HashMap<String, Value>) -> (i64, i64, i64, i64, i64, f64, i64) {
+pub fn datetime_attrs(attributes: &AttrMap) -> (i64, i64, i64, i64, i64, f64, i64) {
     let year = match attributes.get("year").map(Value::view) {
         Some(ValueView::Int(y)) => y,
         _ => 1970,

--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -1,5 +1,6 @@
 use super::temporal::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::{RuntimeError, Value, ValueView};
 use std::collections::HashMap;
 
@@ -34,10 +35,7 @@ pub(crate) fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
 }
 
 /// Dispatch 0-arg methods for Date instances.
-pub fn date_method_0arg(
-    attributes: &HashMap<String, Value>,
-    method: &str,
-) -> Option<Result<Value, RuntimeError>> {
+pub fn date_method_0arg(attributes: &AttrMap, method: &str) -> Option<Result<Value, RuntimeError>> {
     let (year, month, day) = date_attrs(attributes);
     let days = civil_to_epoch_days(year, month, day);
 
@@ -123,7 +121,7 @@ pub fn date_method_0arg(
 
 /// Dispatch 0-arg methods for DateTime instances.
 pub fn datetime_method_0arg(
-    attributes: &HashMap<String, Value>,
+    attributes: &AttrMap,
     method: &str,
 ) -> Option<Result<Value, RuntimeError>> {
     let (year, month, day, hour, minute, second, timezone) = datetime_attrs(attributes);

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -443,7 +443,7 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
                         ("range".to_string(), Value::str_from("-Inf^..^Inf")),
                     ]
                     .into_iter()
-                    .collect(),
+                    .collect::<crate::value::AttrMap>(),
                 )));
                 Err(err)
             } else if n.is_nan() {
@@ -457,7 +457,7 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
                         ("range".to_string(), Value::str_from("-Inf^..^Inf")),
                     ]
                     .into_iter()
-                    .collect(),
+                    .collect::<crate::value::AttrMap>(),
                 )));
                 Err(err)
             } else {
@@ -481,7 +481,7 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
                     ("target".to_string(), Value::str_from("Real")),
                 ]
                 .into_iter()
-                .collect(),
+                .collect::<crate::value::AttrMap>(),
             )));
             Err(err)
         }
@@ -505,7 +505,7 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
                             ),
                         ]
                         .into_iter()
-                        .collect(),
+                        .collect::<crate::value::AttrMap>(),
                     )));
                     return Err(err);
                 }
@@ -525,7 +525,7 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
                         ),
                     ]
                     .into_iter()
-                    .collect(),
+                    .collect::<crate::value::AttrMap>(),
                 )));
                 Err(err)
             }
@@ -639,7 +639,7 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
             crate::symbol::Symbol::intern("X::Cannot::Lazy"),
             [("what".to_string(), Value::str_from(what))]
                 .into_iter()
-                .collect(),
+                .collect::<crate::value::AttrMap>(),
         )));
         return Err(err);
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1821,9 +1821,20 @@ pub(crate) struct CompiledCode {
     /// first use; each slot interns on first access. Cloning a chunk clones the
     /// already-resolved entries (cheap: `Symbol` is a `u32`).
     pub(crate) const_syms: std::sync::OnceLock<Box<[std::sync::OnceLock<Symbol>]>>,
+    /// Lazily-built attribute-cell key per local slot (see `local_attr_key`):
+    /// `Some((bare attribute Symbol, is_private))` when the slot's name is an
+    /// attribute twigil (`!x`, `$.x`, `@!a`, …), `None` otherwise. Resolving it
+    /// once per chunk keeps the twigil string parse *and* `Symbol::intern` off
+    /// the per-access `$!x` / `$.x` read-write path (ADR-0006 §2.4).
+    pub(crate) local_attr_keys: std::sync::OnceLock<LocalAttrKeys>,
     /// Per-chunk JIT hotness counter and compiled-entry cache (ADR-0004 J1).
     pub(crate) jit: JitCodeState,
 }
+
+/// The per-local-slot attribute-key table of a chunk (see
+/// [`CompiledCode::local_attr_keys`]): one entry per slot, `Some((bare attribute
+/// `Symbol`, is_private))` for an attribute twigil and `None` otherwise.
+pub(crate) type LocalAttrKeys = Box<[Option<(Symbol, bool)>]>;
 
 /// JIT hotness/entry state carried on each `CompiledCode` (ADR-0004 layer 4).
 /// `entry` caches the compiled native entry so the per-call cost once compiled
@@ -1938,8 +1949,26 @@ impl CompiledCode {
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
             const_syms: std::sync::OnceLock::new(),
+            local_attr_keys: std::sync::OnceLock::new(),
             jit: JitCodeState::default(),
         }
+    }
+
+    /// The attribute-cell key of local slot `idx`, or `None` when that slot is
+    /// not an attribute twigil. Built once per chunk (see `local_attr_keys`): the
+    /// VM's `$!x` / `$.x` read and write paths would otherwise re-parse the
+    /// twigil and re-intern the bare name on every access.
+    pub(crate) fn local_attr_key(&self, idx: usize) -> Option<(Symbol, bool)> {
+        let slots = self.local_attr_keys.get_or_init(|| {
+            self.locals
+                .iter()
+                .map(|name| {
+                    crate::value::attr_twigil_base(name)
+                        .map(|(bare, is_private)| (Symbol::intern(bare), is_private))
+                })
+                .collect()
+        });
+        slots.get(idx).copied().flatten()
     }
 
     /// The `Symbol` for the string constant at `idx`, interned once per slot

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -410,6 +410,13 @@ impl Interpreter {
         self.method_class_stack.last().cloned()
     }
 
+    /// Borrowing form of [`Self::method_class_stack_top`]. The attribute cell-key
+    /// resolution consults this on every `$!x` read, where the owned clone was a
+    /// per-access heap allocation.
+    pub(crate) fn method_class_stack_top_str(&self) -> Option<&str> {
+        self.method_class_stack.last().map(String::as_str)
+    }
+
     /// Set up a method dispatch frame for nextsame/callsame support.
     /// Returns true if a frame was pushed (caller must call pop_method_dispatch).
     /// Also pushes a samewith context unconditionally for samewith() support.

--- a/src/runtime/builtins_atomic_cas.rs
+++ b/src/runtime/builtins_atomic_cas.rs
@@ -247,11 +247,24 @@ impl Interpreter {
                 // but the variable itself was modified (e.g., `{ $x = expr }`),
                 // use the variable's current value from the env. This handles
                 // blocks that modify the variable as a side effect.
-                let effective_new = if new_val == current || new_val.is_nil() {
-                    self.env.get(&name).cloned().unwrap_or(new_val)
-                } else {
-                    new_val
-                };
+                //
+                // "Same as the old value" must be judged with the *identity*
+                // rule the CAS compare itself uses (`cas_retry_matches`): for a
+                // reference type the question is whether the block handed back
+                // the very object it was given, not whether it built a distinct
+                // object that happens to compare equal. A structural `==` here
+                // deep-walks the object graph — on the linked-list CAS idiom
+                // (`cas $head, -> $orig { Node.new(value => $i, next => $orig) }`)
+                // that recursed through the whole list on every iteration, which
+                // is quadratic and also just wrong (a freshly built node is not
+                // the old head). Scalars keep the value comparison, since
+                // `cas_retry_matches` falls back to `==` for them.
+                let effective_new =
+                    if Self::cas_retry_matches(&new_val, &current) || new_val.is_nil() {
+                        self.env.get(&name).cloned().unwrap_or(new_val)
+                    } else {
+                        new_val
+                    };
                 let coerced = self.atomic_assign_coerced_value(&name, effective_new)?;
                 // Restore the env variable to `current` before the CAS comparison,
                 // so that atomic_current_value (which falls back to env) reads the

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -387,7 +387,7 @@ impl Interpreter {
                             &method_name_for_dispatch,
                             &method_def,
                             &cc,
-                            HashMap::new(),
+                            AttrMap::new(),
                             call_args,
                             Some(invocant.clone()),
                             &empty_fns,
@@ -398,7 +398,7 @@ impl Interpreter {
                             &receiver_class,
                             &owner_class,
                             method_def,
-                            HashMap::new(),
+                            AttrMap::new(),
                             call_args,
                             Some(invocant.clone()),
                         )

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -669,7 +669,7 @@ impl Interpreter {
                 let mut new_attrs: std::collections::HashMap<String, Value> = attributes
                     .as_map()
                     .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .map(|(k, v)| (k.resolve(), v.clone()))
                     .collect();
                 new_attrs.insert("message".to_string(), Value::str(enhanced_msg));
                 enhanced.exception = Some(Box::new(Value::make_instance(class_name, new_attrs)));

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -5,16 +5,17 @@
 
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(crate) fn run_instance_method(
         &mut self,
         receiver_class_name: &str,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method_name: &str,
         args: Vec<Value>,
         invocant: Option<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         crate::vm::vm_stats::record_resolver_method_dispatch(method_name);
         let inv_value = if let Some(inv) = &invocant {
             inv.clone()
@@ -99,7 +100,7 @@ impl Interpreter {
             remaining
         };
         let make_invocant_for_dispatch =
-            |invocant: &Option<Value>, attributes: &HashMap<String, Value>| -> Value {
+            |invocant: &Option<Value>, attributes: &AttrMap| -> Value {
                 if let Some(inv) = invocant {
                     inv.clone()
                 } else if attributes.is_empty() {
@@ -252,10 +253,10 @@ impl Interpreter {
         owner_class: &str,
         method_name: &str,
         method_def: MethodDef,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         args: Vec<Value>,
         invocant: Option<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         // Writeback-safety gate (§B, #3658 step 4 — free_var_writes filter REMOVED).
         // Any resolved candidate that has compiled bytecode and is not a delegation
         // forwarder now runs compiled, regardless of what free vars it writes:
@@ -377,10 +378,10 @@ impl Interpreter {
         receiver_class_name: &str,
         owner_class: &str,
         method_def: MethodDef,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         args: Vec<Value>,
         invocant: Option<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         if let Some((ref attr_var_name, ref target_method)) = method_def.delegation {
             // Clear skip_pseudo_method_native: the outer call set it for the
             // delegator's own method name, but we're about to forward to a

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -390,11 +390,7 @@ impl Interpreter {
 
     /// Add `__mutsu_attr_alias::x` metadata for attributes declared with `has $x`
     /// (no twigil), so the method call dispatch can set up bidirectional aliases.
-    pub(super) fn add_alias_attribute_metadata(
-        &mut self,
-        class_name: &str,
-        attrs: &mut HashMap<String, Value>,
-    ) {
+    pub(super) fn add_alias_attribute_metadata(&mut self, class_name: &str, attrs: &mut AttrMap) {
         let mro = self.class_mro(class_name);
         for cn in &mro {
             if let Some(class_def) = self.registry().classes.get(cn) {

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -266,7 +266,7 @@ impl Interpreter {
         };
         let attributes = match invocant.view() {
             ValueView::Instance { attributes, .. } => attributes.as_map().clone(),
-            _ => std::collections::HashMap::new(),
+            _ => crate::value::AttrMap::new(),
         };
         self.proto_dispatch_stack.push((
             method_name.to_string(),

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -271,7 +271,7 @@ impl Interpreter {
             if let Some(cn) = class_name
                 && self.has_user_method(&cn, method)
             {
-                let attrs = std::collections::HashMap::new();
+                let attrs = AttrMap::new();
                 let (result, _) = self.run_instance_method(&cn, attrs, method, args, None)?;
                 return Ok(result);
             }
@@ -1047,7 +1047,7 @@ impl Interpreter {
             && name.resolve() == "IO::Special"
             && method == "new"
         {
-            return self.native_io_special(&HashMap::new(), "new", args);
+            return self.native_io_special(&AttrMap::new(), "new", args);
         }
         // IO::Spec::* class methods
         if let ValueView::Package(name) = target.view() {

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -42,7 +43,7 @@ impl Interpreter {
 
     pub(super) fn supply_list_values(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         wait_until_done: bool,
     ) -> Result<Vec<Value>, RuntimeError> {
         // An on-demand supply (`supply { ... }` block) materializes by running
@@ -118,9 +119,7 @@ impl Interpreter {
         )
     }
 
-    pub(super) fn iterator_supports_predictive_methods(
-        attributes: &HashMap<String, Value>,
-    ) -> bool {
+    pub(super) fn iterator_supports_predictive_methods(attributes: &AttrMap) -> bool {
         matches!(
             attributes.get("items").map(Value::view),
             Some(ValueView::Array(..))
@@ -132,7 +131,7 @@ impl Interpreter {
 
     pub(super) fn iterator_count_only_from_attrs(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
     ) -> Result<Option<Value>, RuntimeError> {
         // A known logical count (set for `LHS xx N` lazy repeats) takes priority:
         // the materialized `items` are only a bounded prefix of the true length.
@@ -210,7 +209,7 @@ impl Interpreter {
 
     pub(super) fn iterator_bool_only_from_attrs(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
     ) -> Result<Option<Value>, RuntimeError> {
         let Some(count) = self.iterator_count_only_from_attrs(attributes)? else {
             return Ok(None);

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(in crate::runtime) fn dispatch_first(
@@ -111,7 +112,7 @@ impl Interpreter {
 
     fn dispatch_supply_first(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         func: Option<Value>,
         has_end: bool,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -443,7 +444,7 @@ impl Interpreter {
     /// Thread.finish -- join the thread (block until it completes)
     pub(in crate::runtime) fn dispatch_thread_finish(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
     ) -> Result<Value, RuntimeError> {
         let thread_id = attributes
             .get("id")

--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -115,7 +115,8 @@ impl Interpreter {
                 if let Some(updated_iter) = self.env.get(iter_slot).cloned() {
                     if let ValueView::Instance { attributes, .. } = updated_iter.view() {
                         for (meta_key, source_name) in attributes.as_map().iter() {
-                            let Some(attr_name) = meta_key.strip_prefix("__mutsu_attr_alias::")
+                            let Some(attr_name) =
+                                meta_key.as_str().strip_prefix("__mutsu_attr_alias::")
                             else {
                                 continue;
                             };

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -113,7 +113,7 @@ impl Interpreter {
                     Symbol::intern("X::Cannot::Lazy"),
                     [("what".to_string(), Value::str(what.to_string()))]
                         .into_iter()
-                        .collect(),
+                        .collect::<AttrMap>(),
                 )));
                 return Err(err);
             }
@@ -240,7 +240,7 @@ impl Interpreter {
             ));
         }
         // Initialize with default attribute values
-        let mut attributes = HashMap::new();
+        let mut attributes = AttrMap::new();
         if self.registry().classes.contains_key(&class_name.resolve()) {
             for (attr_name, _is_public, default, _is_rw, _, sigil, _) in
                 self.collect_class_attributes(&class_name.resolve())
@@ -416,9 +416,9 @@ impl Interpreter {
     pub(crate) fn run_tweak_phase(
         &mut self,
         class_name: Symbol,
-        mut attributes: HashMap<String, Value>,
+        mut attributes: AttrMap,
         tweak_args: &[Value],
-    ) -> Result<HashMap<String, Value>, RuntimeError> {
+    ) -> Result<AttrMap, RuntimeError> {
         let cn = class_name.resolve();
         let mro = self.class_mro(&cn);
         let class_lang_rev = self
@@ -521,9 +521,9 @@ impl Interpreter {
     pub(crate) fn run_build_phase(
         &mut self,
         class_name: Symbol,
-        mut attributes: HashMap<String, Value>,
+        mut attributes: AttrMap,
         build_args: &[Value],
-    ) -> Result<Result<HashMap<String, Value>, Value>, RuntimeError> {
+    ) -> Result<Result<AttrMap, Value>, RuntimeError> {
         let cn = class_name.resolve();
         let mro = self.class_mro(&cn);
         let class_lang_rev = self
@@ -694,8 +694,8 @@ impl Interpreter {
     /// attribute keyed by its bare name with a type-default empty value (native
     /// numerics → 0, `str` → "", everything else → `Nil`). Unlike `bless`, this
     /// does not evaluate `has $.x = EXPR` default expressions.
-    fn create_default_attr_slots(&mut self, class_name: &str) -> HashMap<String, Value> {
-        let mut attributes = HashMap::new();
+    fn create_default_attr_slots(&mut self, class_name: &str) -> AttrMap {
+        let mut attributes = AttrMap::new();
         if self.registry().classes.contains_key(class_name) {
             for (attr_name, _is_public, _default, _is_rw, _, _, _) in
                 self.collect_class_attributes(class_name)

--- a/src/runtime/methods_distribution.rs
+++ b/src/runtime/methods_distribution.rs
@@ -9,6 +9,7 @@ use crate::value::{RuntimeError, Value, ValueView};
 use std::collections::HashMap;
 
 use super::methods_distribution_helpers::{hash_strings, parse_json_value};
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Parse a JSON string into a Hash.
@@ -62,7 +63,7 @@ impl Interpreter {
     pub(crate) fn dispatch_distribution_method(
         &self,
         _class_name: &str,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
@@ -119,7 +120,7 @@ impl Interpreter {
     /// CUR::Installation method dispatch.
     pub(crate) fn dispatch_cur_installation_method(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -3,6 +3,7 @@ use super::methods_signature_errors::{
 };
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -982,7 +983,7 @@ impl Interpreter {
                     .unwrap_or(Value::NIL));
             }
             if method == "clone" {
-                let mut attrs: HashMap<String, Value> = attributes.to_map();
+                let mut attrs: AttrMap = attributes.to_map();
                 // A slot promoted to a `ContainerRef` cell (a `:=`-bound
                 // attribute) must not leak its cell into the clone: snapshot
                 // the inner value so a write to the clone's attribute stays
@@ -1416,7 +1417,7 @@ impl Interpreter {
                             caller_class.as_deref().unwrap_or("GLOBAL"),
                         ));
                     }
-                    let attrs = HashMap::new();
+                    let attrs = AttrMap::new();
                     let (result, _updated) = self.run_resolved_method_compiled_or_treewalk(
                         &name.resolve(),
                         &resolved_owner,
@@ -1432,7 +1433,7 @@ impl Interpreter {
             }
             // Package (type object) dispatch -- check user-defined methods
             if self.has_user_method(&name.resolve(), method) {
-                let attrs = HashMap::new();
+                let attrs = AttrMap::new();
                 let (result, _updated) =
                     self.run_instance_method(&name.resolve(), attrs, method, args, None)?;
                 return Ok(result);
@@ -1468,7 +1469,7 @@ impl Interpreter {
                 None
             };
             if let Some(dispatch_class) = dispatch_class {
-                let attrs = HashMap::new();
+                let attrs = AttrMap::new();
                 let (result, _updated) = self.run_instance_method(
                     dispatch_class,
                     attrs,
@@ -2162,11 +2163,7 @@ impl Interpreter {
 
     /// Collect public attribute representations for `.raku` output.
     /// Returns a list of `"name => value.raku"` strings for public attributes.
-    fn collect_public_raku_attrs(
-        &mut self,
-        class_name: &str,
-        attributes: &HashMap<String, Value>,
-    ) -> Vec<String> {
+    fn collect_public_raku_attrs(&mut self, class_name: &str, attributes: &AttrMap) -> Vec<String> {
         let class_attrs = self.collect_class_attributes(class_name);
         let mut parts = Vec::new();
         for (attr_name, is_public, _default, _is_rw, _is_required, _sigil, _where) in &class_attrs {

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -113,11 +113,11 @@ impl Interpreter {
                     ValueView::Instance { attributes, .. } => {
                         (Some(attributes.clone()), attributes.to_map())
                     }
-                    _ => (None, HashMap::new()),
+                    _ => (None, AttrMap::new()),
                 };
                 for (key, value) in mixins.iter() {
                     if let Some(attr) = key.strip_prefix("__mutsu_attr__") {
-                        method_attrs.insert(attr.to_string(), value.clone());
+                        method_attrs.insert(attr, value.clone());
                     }
                 }
                 // Set up a method-dispatch frame so `nextsame`/`callsame` inside

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use num_bigint::BigInt;
 
 impl Interpreter {
@@ -97,7 +98,7 @@ impl Interpreter {
     /// single-class case, no qualified key) fall back to the bare key as before.
     pub(crate) fn store_qualified_attr(
         &mut self,
-        updated: &mut std::collections::HashMap<String, Value>,
+        updated: &mut AttrMap,
         instance_class: &str,
         qualifier: &str,
         attr: &str,
@@ -322,14 +323,14 @@ impl Interpreter {
         needle: &crate::gc::Gc<crate::value::ArrayData>,
         replacement: &Value,
     ) {
-        let mut updates: Vec<(Symbol, String)> = Vec::new();
+        let mut updates: Vec<(Symbol, Symbol)> = Vec::new();
         for (var_name, value) in self.env.iter() {
             if let ValueView::Instance { attributes, .. } = value.view() {
                 for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let ValueView::Array(arc, ..) = attr_val.view()
                         && crate::gc::Gc::ptr_eq(&arc, needle)
                     {
-                        updates.push((*var_name, attr_key.clone()));
+                        updates.push((*var_name, *attr_key));
                     }
                 }
             }
@@ -351,14 +352,14 @@ impl Interpreter {
         needle: &crate::gc::Gc<crate::value::HashData>,
         replacement: &Value,
     ) {
-        let mut updates: Vec<(Symbol, String)> = Vec::new();
+        let mut updates: Vec<(Symbol, Symbol)> = Vec::new();
         for (var_name, value) in self.env.iter() {
             if let ValueView::Instance { attributes, .. } = value.view() {
                 for (attr_key, attr_val) in attributes.as_map().iter() {
                     if let ValueView::Hash(arc) = attr_val.view()
                         && crate::gc::Gc::ptr_eq(&arc, needle)
                     {
-                        updates.push((*var_name, attr_key.clone()));
+                        updates.push((*var_name, *attr_key));
                     }
                 }
             }

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -974,13 +974,13 @@ impl Interpreter {
                 }
                 let attr_key = if attributes.contains_key(method) {
                     method.to_string()
-                } else if attributes.contains_key(&format!("@{}", method)) {
+                } else if attributes.contains_key(format!("@{}", method)) {
                     format!("@{}", method)
-                } else if attributes.contains_key(&format!("%{}", method)) {
+                } else if attributes.contains_key(format!("%{}", method)) {
                     format!("%{}", method)
-                } else if attributes.contains_key(&format!("${}", method)) {
+                } else if attributes.contains_key(format!("${}", method)) {
                     format!("${}", method)
-                } else if attributes.contains_key(&format!("!{}", method)) {
+                } else if attributes.contains_key(format!("!{}", method)) {
                     format!("!{}", method)
                 } else {
                     method.to_string()
@@ -1036,7 +1036,7 @@ impl Interpreter {
                 // Write through an existing `ContainerRef` slot (preserving any
                 // `:=`-bound alias of the attribute container); otherwise replace
                 // the entry as a bare value.
-                Value::hash_insert_through(&mut updated, attr_key.clone(), assigned_value.clone());
+                updated.insert_through(attr_key.as_str(), assigned_value.clone());
                 // Always propagate the change into this instance's live shared
                 // cell. This handles chained accessor assignment like
                 // `$outer.inner.arr = ...` where target_var may be None but the

--- a/src/runtime/methods_mut_proxy.rs
+++ b/src/runtime/methods_mut_proxy.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::InstanceAttrs;
 use crate::value::ValueView;
 
@@ -8,8 +9,8 @@ impl Interpreter {
         &mut self,
         callback: &Value,
         args: Vec<Value>,
-        instance_attrs: &HashMap<String, Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+        instance_attrs: &AttrMap,
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         if let ValueView::Sub(data) = callback.view() {
             let saved_env = self.env.clone();
             let mut new_env = saved_env.clone();
@@ -49,7 +50,7 @@ impl Interpreter {
             let mut updated_attrs = instance_attrs.clone();
             for attr_name in instance_attrs.keys() {
                 if let Some(val) = self.env.get(&format!("!{}", attr_name)) {
-                    updated_attrs.insert(attr_name.clone(), val.clone());
+                    updated_attrs.insert(*attr_name, val.clone());
                 }
             }
             // Propagate outer variable changes (e.g., our variables, closured scalars).
@@ -95,7 +96,7 @@ impl Interpreter {
         fetcher: &Value,
         target_var: Option<&str>,
         class_name: &str,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         target_id: u64,
     ) -> Result<Value, RuntimeError> {
         let proxy_val = Value::proxy_parts(fetcher.clone(), Value::NIL, None, false);
@@ -117,7 +118,7 @@ impl Interpreter {
         storer: &Value,
         target_var: Option<&str>,
         class_name: Symbol,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         attrs_cell: &crate::gc::Gc<InstanceAttrs>,
         new_value: Value,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -358,7 +359,7 @@ impl Interpreter {
     pub(crate) fn apply_attribute_does_role_mixins(
         &mut self,
         class_key: &str,
-        attrs: &mut HashMap<String, Value>,
+        attrs: &mut AttrMap,
     ) {
         let mro = self.class_mro(class_key);
         let does_attrs: Vec<(String, Vec<String>)> = self

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     fn check_attribute_where_constraint(&mut self, pred: &Expr, value: &Value) -> bool {
@@ -115,7 +116,7 @@ impl Interpreter {
         &mut self,
         class_name: &str,
         class_attrs_info: &[ClassAttributeDef],
-        attrs: &HashMap<String, Value>,
+        attrs: &AttrMap,
     ) -> Result<(), RuntimeError> {
         let type_constraints = self.collect_attribute_type_constraints(class_name);
         for (attr_name, _is_public, _default, _is_rw, _is_required, sigil, where_constraint) in
@@ -165,7 +166,7 @@ impl Interpreter {
     pub(crate) fn enforce_attribute_smiley_constraints(
         &mut self,
         class_name: &str,
-        attrs: &HashMap<String, Value>,
+        attrs: &AttrMap,
     ) -> Result<(), RuntimeError> {
         // Collect smileys and required status from this class and all parent classes in the MRO
         let mut smileys: HashMap<String, String> = HashMap::new();
@@ -269,7 +270,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let mut fetcher = Value::NIL;
         let mut storer = Value::NIL;
-        let mut extra_attrs = HashMap::new();
+        let mut extra_attrs = AttrMap::new();
 
         for arg in args {
             if let ValueView::Pair(key, value) = arg.view() {
@@ -304,7 +305,8 @@ impl Interpreter {
         }
         self.enforce_attribute_where_constraints(class_name, &class_attrs_info, &extra_attrs)?;
 
-        let subclass_attrs = std::sync::Arc::new(std::sync::Mutex::new(extra_attrs));
+        let subclass_attrs =
+            std::sync::Arc::new(std::sync::Mutex::new(HashMap::from(&extra_attrs)));
         Ok(Value::proxy_parts(
             fetcher,
             storer,

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -44,7 +44,7 @@ impl Interpreter {
         // still filled below and BUILD runs afterward.
         let has_build = plan.has_build;
 
-        let mut attrs = HashMap::new();
+        let mut attrs = AttrMap::new();
         for arg in args {
             if has_build {
                 break;

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -503,7 +503,7 @@ impl Interpreter {
                     // Now build the subclass instance with all Date attrs plus any custom named attrs
                     let mut new_args = Vec::new();
                     for (k, v) in attributes.as_map().iter() {
-                        new_args.push(Value::pair(k.clone(), v.clone()));
+                        new_args.push(Value::pair(k.resolve(), v.clone()));
                     }
                     // Add any non-Date named args from the original call
                     for arg in &args {
@@ -1315,7 +1315,7 @@ impl Interpreter {
                 }
                 // Check for user-defined .new method first
                 if self.has_user_method(class_key, "new") {
-                    let empty_attrs = HashMap::new();
+                    let empty_attrs = AttrMap::new();
                     match self.run_instance_method(
                         &class_name.resolve(),
                         empty_attrs,
@@ -1370,7 +1370,7 @@ impl Interpreter {
                         }
                     }
                 }
-                let mut attrs = HashMap::new();
+                let mut attrs = AttrMap::new();
                 let mut positional_ctor_args: Vec<Value> = Vec::new();
                 let saved_default_env = self.env.clone();
                 let role_bindings = {
@@ -1488,7 +1488,7 @@ impl Interpreter {
                             ..
                         } if class_mro.iter().any(|name| name == &src_class.resolve()) => {
                             for (attr, value) in src_attrs.as_map().iter() {
-                                attrs.insert(attr.clone(), value.clone());
+                                attrs.insert(*attr, value.clone());
                             }
                         }
                         _ => {

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(crate) fn as_exception_value(value: Value) -> Value {
@@ -301,7 +302,7 @@ impl Interpreter {
 
     pub(super) fn dispatch_promise_vow_method(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -528,11 +528,11 @@ impl Interpreter {
                 // Start from the inner instance's attributes (for compose-time
                 // roles whose state lives on the class), then layer mixin-stored
                 // role attributes on top (for run-time-applied roles).
-                let mut role_attrs: HashMap<String, Value> =
+                let mut role_attrs: AttrMap =
                     if let ValueView::Instance { attributes, .. } = inner.as_ref().view() {
                         attributes.to_map()
                     } else {
-                        HashMap::new()
+                        AttrMap::new()
                     };
                 for (key, value) in mixins.iter() {
                     if let Some(attr) = key.strip_prefix("__mutsu_attr__") {
@@ -604,7 +604,7 @@ impl Interpreter {
                     if let ValueView::Instance { attributes, .. } = inner.as_ref().view() {
                         attributes.to_map()
                     } else {
-                        HashMap::new()
+                        AttrMap::new()
                     };
                 let res = self.run_resolved_method_compiled_or_treewalk(
                     &inst_cn_str,

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Supply.merge(...) as a class method
@@ -350,7 +351,7 @@ impl Interpreter {
     /// Handle Supply instance .grab method
     pub(super) fn dispatch_supply_grab(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let values = match attributes.get("values").map(Value::view) {
@@ -371,7 +372,7 @@ impl Interpreter {
     /// Handle Supply instance .skip method
     pub(super) fn dispatch_supply_skip(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let n = if args.is_empty() {
@@ -404,7 +405,7 @@ impl Interpreter {
     /// Handle Supply.elems method
     pub(super) fn dispatch_supply_elems(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let interval = args.first().map(Value::to_f64).unwrap_or(0.0).max(0.0);
@@ -450,7 +451,7 @@ impl Interpreter {
     /// Handle Supply.map method
     pub(super) fn dispatch_supply_map(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let mapper = args.first().cloned().unwrap_or(Value::NIL);
@@ -499,7 +500,7 @@ impl Interpreter {
     /// eagerly instead.
     pub(in crate::runtime) fn make_live_transform_supply(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         callable: Value,
         mode: crate::runtime::native_methods::TransformMode,
     ) -> Option<Value> {
@@ -523,7 +524,7 @@ impl Interpreter {
     pub(super) fn dispatch_supply_reduce(
         &mut self,
         target: Value,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         callable: Value,
     ) -> Result<Value, RuntimeError> {
         if !matches!(

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -299,7 +299,7 @@ impl Interpreter {
         };
         let attributes_map = match invocant.view() {
             ValueView::Instance { attributes, .. } => attributes.to_map(),
-            _ => std::collections::HashMap::new(),
+            _ => AttrMap::new(),
         };
         let mut order: Vec<String> = targets;
         if reversed {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -27,8 +27,8 @@ use crate::opcode::{CompiledCode, CompiledFunction};
 use crate::parse_dispatch;
 use crate::value::ValueView;
 use crate::value::{
-    ArrayKind, EnumValue, JunctionKind, LazyList, RuntimeError, SharedChannel, SharedPromise,
-    Value, make_rat, take_pending_instance_destroys,
+    ArrayKind, AttrMap, EnumValue, JunctionKind, LazyList, RuntimeError, SharedChannel,
+    SharedPromise, Value, make_rat, take_pending_instance_destroys,
 };
 
 /// Flatten arguments for `append` using Raku's "one-arg rule":

--- a/src/runtime/native_io/io_cathandle.rs
+++ b/src/runtime/native_io/io_cathandle.rs
@@ -14,6 +14,7 @@
 //! - `closed`   — Bool, set by `.close`/`.DESTROY` (reads then yield `Nil`)
 //! - `on-switch`— Callable invoked when the active handle changes, or `Nil`
 use super::*;
+use crate::value::AttrMap;
 use std::collections::HashMap;
 
 /// Extract an integer from an `Int` value (allomorphs/strings yield `None`).
@@ -59,7 +60,7 @@ impl Interpreter {
                 _ => sources.push(arg.clone()),
             }
         }
-        let mut attrs: HashMap<String, Value> = HashMap::new();
+        let mut attrs: AttrMap = AttrMap::new();
         attrs.insert("sources".to_string(), Value::array(sources));
         attrs.insert("pos".to_string(), Value::int(0));
         attrs.insert("active".to_string(), Value::NIL);
@@ -108,7 +109,7 @@ impl Interpreter {
     }
 
     /// The currently-open active `IO::Handle` value, if any.
-    fn cat_active_handle(attrs: &HashMap<String, Value>) -> Option<Value> {
+    fn cat_active_handle(attrs: &AttrMap) -> Option<Value> {
         let active = attrs.get("active")?;
         match active.view() {
             ValueView::Instance { class_name, .. } if class_name == "IO::Handle" => {
@@ -124,7 +125,7 @@ impl Interpreter {
     /// the live handle, but mutsu's accessor-assignment path writes the attribute
     /// without notifying the handle, so we re-sync before every read instead.
     /// Re-pushing an unchanged value is a harmless idempotent field set.
-    fn cat_sync_active_settings(&mut self, attrs: &HashMap<String, Value>) {
+    fn cat_sync_active_settings(&mut self, attrs: &AttrMap) {
         let Some(active) = Self::cat_active_handle(attrs) else {
             return;
         };
@@ -141,7 +142,7 @@ impl Interpreter {
 
     /// Open one source value into a read handle, applying the cat's `chomp` /
     /// `nl-in` / `encoding`. Returns `None` when the source cannot be opened.
-    fn cat_open_source(&mut self, src: &Value, attrs: &HashMap<String, Value>) -> Option<Value> {
+    fn cat_open_source(&mut self, src: &Value, attrs: &AttrMap) -> Option<Value> {
         let chomp = attrs.get("chomp").cloned().unwrap_or(Value::TRUE);
         let nl_in = attrs
             .get("nl-in")
@@ -195,7 +196,7 @@ impl Interpreter {
                     _ => src.to_string_value(),
                 };
                 let io_path = self.make_io_path_instance(&path_str);
-                let mut h_attrs: HashMap<String, Value> = HashMap::new();
+                let mut h_attrs: AttrMap = AttrMap::new();
                 h_attrs.insert("path".to_string(), io_path);
                 let open_args = vec![
                     Value::pair("r".to_string(), Value::TRUE),
@@ -229,7 +230,7 @@ impl Interpreter {
 
     /// Close the active handle (if any) and open the next source. Returns the new
     /// active handle, or `Nil` when the sources are exhausted.
-    fn cat_next_handle(&mut self, attrs: &mut HashMap<String, Value>) -> Value {
+    fn cat_next_handle(&mut self, attrs: &mut AttrMap) -> Value {
         // Remember the previously-active handle: it becomes the `$old` argument
         // to `on-switch` and must be closed before we open the next source.
         let old = match attrs.get("active").cloned() {
@@ -286,7 +287,7 @@ impl Interpreter {
 
     /// Ensure there is an active handle, opening the first/next source if needed.
     /// Returns `Nil` when nothing more can be read.
-    fn cat_ensure_active(&mut self, attrs: &mut HashMap<String, Value>) -> Value {
+    fn cat_ensure_active(&mut self, attrs: &mut AttrMap) -> Value {
         let active = attrs.get("active").cloned();
         if let Some(active) = &active
             && matches!(active.view(), ValueView::Instance { class_name, .. } if class_name == "IO::Handle")
@@ -302,7 +303,7 @@ impl Interpreter {
     }
 
     /// Read the next line across all handles, switching when one is exhausted.
-    fn cat_get(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+    fn cat_get(&mut self, attrs: &mut AttrMap) -> Result<Value, RuntimeError> {
         loop {
             let active = self.cat_ensure_active(attrs);
             if active.is_nil() {
@@ -322,7 +323,7 @@ impl Interpreter {
     }
 
     /// Read one character across all handles.
-    fn cat_getc(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+    fn cat_getc(&mut self, attrs: &mut AttrMap) -> Result<Value, RuntimeError> {
         loop {
             let active = self.cat_ensure_active(attrs);
             if active.is_nil() {
@@ -342,7 +343,7 @@ impl Interpreter {
     }
 
     /// Slurp the remaining content of all handles into one string.
-    fn cat_slurp(&mut self, attrs: &mut HashMap<String, Value>) -> Result<Value, RuntimeError> {
+    fn cat_slurp(&mut self, attrs: &mut AttrMap) -> Result<Value, RuntimeError> {
         if attrs.get("closed").is_some_and(|v| v.truthy()) {
             return Ok(Value::NIL);
         }
@@ -383,11 +384,7 @@ impl Interpreter {
 
     /// Collect remaining lines into a Seq, honouring an optional positional
     /// `$limit` (max number of lines) and a `:close` named arg.
-    fn cat_lines(
-        &mut self,
-        attrs: &mut HashMap<String, Value>,
-        args: &[Value],
-    ) -> Result<Value, RuntimeError> {
+    fn cat_lines(&mut self, attrs: &mut AttrMap, args: &[Value]) -> Result<Value, RuntimeError> {
         let mut limit: Option<i64> = None;
         let mut close = false;
         for arg in args {
@@ -420,7 +417,7 @@ impl Interpreter {
 
     /// Close the active handle and all `IO::Handle` sources, marking the cat
     /// closed. Shared by `.close`/`.DESTROY` and `:close` read adverbs.
-    fn cat_close(&mut self, attrs: &mut HashMap<String, Value>) {
+    fn cat_close(&mut self, attrs: &mut AttrMap) {
         let active = attrs.get("active").cloned();
         if let Some(active) = &active
             && matches!(active.view(), ValueView::Instance { class_name, .. } if class_name == "IO::Handle")
@@ -486,10 +483,10 @@ impl Interpreter {
     pub(crate) fn native_io_cathandle_mut(
         &mut self,
         class_name: Symbol,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         let mut attrs = attributes;
         // Character-oriented reads are illegal on a binary-mode cat handle.
         if attrs.get("bin").is_some_and(|v| v.truthy())

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 /// Decode bytes as strict UTF-8, mirroring `IO::Path.slurp`: an invalid byte
 /// sequence is an error (surfaced as an `X::AdHoc`), not a lossy U+FFFD
@@ -26,10 +27,10 @@ impl Interpreter {
     /// via the sentinel "No native mutable method" error.
     pub(crate) fn native_io_handle_mut(
         &mut self,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         if method == "open" {
             let result = self.native_io_handle(&attributes, "open", args)?;
             // A successful open returns an `IO::Handle` instance carrying the new
@@ -55,7 +56,7 @@ impl Interpreter {
 
     pub(crate) fn native_io_handle(
         &mut self,
-        target: &HashMap<String, Value>,
+        target: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -199,11 +200,12 @@ impl Interpreter {
                 }
                 // Add instance attributes as pairs (only if not overridden by open args)
                 for (key, value) in target.iter() {
+                    let key = key.as_str();
                     if key == "handle" || key == "path" || key == "mode" {
                         continue;
                     }
                     if !explicit_keys.contains(key) {
-                        merged_args.push(Value::pair(key.clone(), value.clone()));
+                        merged_args.push(Value::pair(key.to_string(), value.clone()));
                     }
                 }
                 merged_args.extend(args.iter().cloned());
@@ -782,11 +784,7 @@ impl Interpreter {
         }
     }
 
-    fn handle_supply(
-        &mut self,
-        target: &HashMap<String, Value>,
-        args: &[Value],
-    ) -> Result<Value, RuntimeError> {
+    fn handle_supply(&mut self, target: &AttrMap, args: &[Value]) -> Result<Value, RuntimeError> {
         // Extract :size named parameter (default 65536)
         let size = args
             .iter()

--- a/src/runtime/native_io/io_path_lexical.rs
+++ b/src/runtime/native_io/io_path_lexical.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Whether `class_name` is one of the built-in `IO::Path` family classes
@@ -35,7 +36,7 @@ impl Interpreter {
     /// receiver class (`IO::Path::Win32.parent` stays `IO::Path::Win32`).
     pub(crate) fn try_io_path_lexical(
         class_name: &str,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {

--- a/src/runtime/native_io/io_path_mutate.rs
+++ b/src/runtime/native_io/io_path_mutate.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Single-path filesystem *mutations* on an `IO::Path`
@@ -13,7 +14,7 @@ impl Interpreter {
     /// and handle-opening `open` return `None` and stay in `native_io_path`.
     pub(crate) fn try_io_path_fs_mutate(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         class_name: &str,
         method: &str,
         args: &[Value],
@@ -29,7 +30,7 @@ impl Interpreter {
     /// previously held.
     fn io_path_fs_mutate(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         class_name: &str,
         method: &str,
         args: &[Value],
@@ -215,7 +216,7 @@ impl Interpreter {
     /// `None` for any other method.
     pub(crate) fn try_io_path_two_path_op(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
@@ -230,7 +231,7 @@ impl Interpreter {
     /// previously held.
     fn io_path_two_path_op(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_io/io_path_read.rs
+++ b/src/runtime/native_io/io_path_read.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 use unicode_segmentation::UnicodeSegmentation;
 
 impl Interpreter {
@@ -14,7 +15,7 @@ impl Interpreter {
     /// `native_io_path`. Behavior-invariant (same read + split/decode logic).
     pub(crate) fn try_io_path_content_read(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
@@ -30,7 +31,7 @@ impl Interpreter {
     /// previously held.
     fn io_path_content_read(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
@@ -114,7 +115,7 @@ impl Interpreter {
     /// method.
     pub(crate) fn try_io_path_open(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
@@ -183,7 +184,7 @@ impl Interpreter {
     /// for any other method.
     pub(crate) fn try_io_path_comb(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {

--- a/src/runtime/native_io/io_path_stat.rs
+++ b/src/runtime/native_io/io_path_stat.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// `.absolute` / `.relative` on an `IO::Path`: like [`try_io_path_lexical`],
@@ -11,7 +12,7 @@ impl Interpreter {
     /// real filesystem and stays in `native_io_path`).
     pub(crate) fn try_io_path_cwd_method(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
@@ -142,7 +143,7 @@ impl Interpreter {
     /// `io_handles` and stay in `native_io_path`).
     pub(crate) fn try_io_path_fs_stat(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
     ) -> Option<Result<Value, RuntimeError>> {
         if !matches!(
@@ -178,11 +179,7 @@ impl Interpreter {
     /// the process cwd), applying any chroot. Purely lexical (no filesystem
     /// access) — shared by the `&self` native IO::Path methods
     /// (`try_io_path_fs_stat` / `try_io_path_content_read`) and `native_io_path`.
-    pub(crate) fn resolve_io_path_buf(
-        &self,
-        attributes: &HashMap<String, Value>,
-        p: &str,
-    ) -> PathBuf {
+    pub(crate) fn resolve_io_path_buf(&self, attributes: &AttrMap, p: &str) -> PathBuf {
         let instance_cwd = attributes.get("cwd").map(|v| v.to_string_value());
         if Path::new(p).is_absolute() {
             self.resolve_path(p)

--- a/src/runtime/native_io/io_pipe.rs
+++ b/src/runtime/native_io/io_pipe.rs
@@ -1,9 +1,10 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(crate) fn native_io_pipe(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_io/native_io_path.rs
+++ b/src/runtime/native_io/native_io_path.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Build a `Failure` value wrapping an `X::IO::*` exception with the given
@@ -19,7 +20,7 @@ impl Interpreter {
 
     pub(crate) fn native_io_path(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         class_name: &str,
         method: &str,
         args: Vec<Value>,

--- a/src/runtime/native_io/path_spec.rs
+++ b/src/runtime/native_io/path_spec.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Join a `child`/`add` name onto a path lexically (no filesystem access),
@@ -7,7 +8,7 @@ impl Interpreter {
     /// (the pure fast path) and `native_io_path`'s `child :secure` arm so the
     /// join is implemented once.
     pub(crate) fn io_path_join_child(
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         p: &str,
         child_name: &str,
     ) -> Result<String, RuntimeError> {
@@ -48,7 +49,7 @@ impl Interpreter {
     }
 
     pub(crate) fn clone_io_path_with_path(
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         class: Symbol,
         path: String,
     ) -> Value {
@@ -58,7 +59,7 @@ impl Interpreter {
     }
 
     /// Check if the IO::Path instance has a Win32 SPEC attribute.
-    pub(crate) fn is_win32_spec(attributes: &HashMap<String, Value>) -> bool {
+    pub(crate) fn is_win32_spec(attributes: &AttrMap) -> bool {
         attributes
             .get("SPEC")
             .map(|s| {
@@ -75,7 +76,7 @@ impl Interpreter {
     /// Whether the path's SPEC is `IO::Spec::Cygwin`. Cygwin uses Win32-style
     /// volume/absoluteness semantics (UNC, drive letters) but normalizes all
     /// backslashes to forward slashes in its output.
-    pub(crate) fn is_cygwin_spec(attributes: &HashMap<String, Value>) -> bool {
+    pub(crate) fn is_cygwin_spec(attributes: &AttrMap) -> bool {
         attributes
             .get("SPEC")
             .map(|s| {
@@ -92,11 +93,7 @@ impl Interpreter {
     /// Whether `p` is absolute under the receiver's SPEC. Win32/Cygwin use
     /// drive-letter / UNC / leading-separator rules; other SPECs defer to the
     /// platform's `Path::is_absolute`.
-    pub(crate) fn io_path_is_absolute_spec(
-        attributes: &HashMap<String, Value>,
-        p: &str,
-        original: &Path,
-    ) -> bool {
+    pub(crate) fn io_path_is_absolute_spec(attributes: &AttrMap, p: &str, original: &Path) -> bool {
         if Self::is_win32_spec(attributes) {
             Self::io_path_is_absolute_win32(p)
         } else if Self::is_cygwin_spec(attributes) {
@@ -109,10 +106,7 @@ impl Interpreter {
     /// Split a path into (volume, dirname, basename), honoring the Cygwin SPEC
     /// by first converting backslashes to forward slashes (Cygwin treats `\`
     /// and `/` interchangeably and emits forward slashes).
-    pub(crate) fn io_path_parts_spec(
-        path: &str,
-        attributes: &HashMap<String, Value>,
-    ) -> (String, String, String) {
+    pub(crate) fn io_path_parts_spec(path: &str, attributes: &AttrMap) -> (String, String, String) {
         if Self::is_cygwin_spec(attributes) {
             Self::io_path_parts(&path.replace('\\', "/"))
         } else {
@@ -121,7 +115,7 @@ impl Interpreter {
     }
 
     /// Get the directory separator based on the SPEC attribute.
-    pub(crate) fn io_path_sep(attributes: &HashMap<String, Value>) -> char {
+    pub(crate) fn io_path_sep(attributes: &AttrMap) -> char {
         if Self::is_win32_spec(attributes) {
             '\\'
         } else {

--- a/src/runtime/native_io_special.rs
+++ b/src/runtime/native_io_special.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 use std::collections::HashMap;
 
 impl Interpreter {
@@ -12,7 +13,7 @@ impl Interpreter {
     /// Handle method dispatch on IO::Special instances.
     pub(super) fn native_io_special(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_methods/concurrency.rs
+++ b/src/runtime/native_methods/concurrency.rs
@@ -3,11 +3,12 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 
 use super::state_lock::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(in crate::runtime) fn native_lock(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -109,7 +110,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_semaphore(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         _args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -157,7 +158,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_condition_variable(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -248,10 +249,10 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_promise_mut(
         &mut self,
-        mut attrs: HashMap<String, Value>,
+        mut attrs: AttrMap,
         method: &str,
         _args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "keep" => {
                 let value = _args.first().cloned().unwrap_or(Value::NIL);
@@ -270,10 +271,10 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_channel_mut(
         &mut self,
-        mut attrs: HashMap<String, Value>,
+        mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "send" => {
                 let value = args.first().cloned().unwrap_or(Value::NIL);
@@ -312,7 +313,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_promise(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -345,7 +346,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_promise_vow(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -402,11 +403,7 @@ impl Interpreter {
 
     // --- Channel immutable ---
 
-    pub(in crate::runtime) fn native_channel(
-        &self,
-        attributes: &HashMap<String, Value>,
-        method: &str,
-    ) -> Value {
+    pub(in crate::runtime) fn native_channel(&self, attributes: &AttrMap, method: &str) -> Value {
         match method {
             "closed" => attributes.get("closed").cloned().unwrap_or(Value::FALSE),
             _ => Value::NIL,
@@ -417,7 +414,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_thread(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
     ) -> Result<Value, RuntimeError> {
         match method {

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -3,8 +3,9 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 
 use super::state::SupplyEvent;
+use crate::value::AttrMap;
 
-fn decoder_buffer(attrs: &HashMap<String, Value>) -> Vec<u8> {
+fn decoder_buffer(attrs: &AttrMap) -> Vec<u8> {
     let mut out = Vec::new();
     if let Some(v) = attrs.get("buffer") {
         extend_buffer_from_value(&mut out, v);
@@ -81,7 +82,7 @@ fn decode_available(bytes: &[u8], encoding: &str) -> (String, Vec<u8>) {
 
 impl Interpreter {
     pub(in crate::runtime) fn native_encoding_builtin(
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Value {
@@ -143,7 +144,7 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn native_encoding_encoder(
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
@@ -207,7 +208,7 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn native_encoding_decoder(
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Value {
@@ -233,10 +234,10 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn native_encoding_decoder_mut(
-        mut attributes: HashMap<String, Value>,
+        mut attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "add-bytes" => {
                 let mut buf = decoder_buffer(&attributes);

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -70,6 +70,7 @@ pub(in crate::runtime) use state_supplier::{
 };
 
 use super::*;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 use std::time::Duration;
 
@@ -93,7 +94,7 @@ impl Interpreter {
         Ok(delay.max(0.0))
     }
 
-    pub(super) fn supply_delay_seconds(attributes: &HashMap<String, Value>) -> f64 {
+    pub(super) fn supply_delay_seconds(attributes: &AttrMap) -> f64 {
         attributes
             .get("delay_seconds")
             .map(Value::to_f64)
@@ -265,10 +266,10 @@ impl Interpreter {
     pub(super) fn call_native_instance_method_mut(
         &mut self,
         class_name: &str,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         let dispatch_class = if matches!(
             class_name,
             "Promise"
@@ -326,7 +327,7 @@ impl Interpreter {
     pub(super) fn call_native_instance_method(
         &mut self,
         class_name: &str,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_methods/proc.rs
+++ b/src/runtime/native_methods/proc.rs
@@ -2,6 +2,7 @@ use crate::runtime::*;
 use crate::symbol::Symbol;
 
 use super::state::proc_stdin_map;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Mutating Proc methods (`.spawn`, `.run`, `.shell`) re-run a command and
@@ -12,10 +13,10 @@ impl Interpreter {
     /// always starts a shell, so its `.pid` updates even for a missing command.
     pub(in crate::runtime) fn native_proc_mut(
         &mut self,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         let new_proc = match method {
             "spawn" | "run" => self.builtin_run(&args)?,
             "shell" => self.builtin_shell(&args)?,
@@ -64,7 +65,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_proc_async(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -170,11 +171,7 @@ impl Interpreter {
 
     // --- Proc immutable ---
 
-    pub(in crate::runtime) fn native_proc(
-        &self,
-        attributes: &HashMap<String, Value>,
-        method: &str,
-    ) -> Value {
+    pub(in crate::runtime) fn native_proc(&self, attributes: &AttrMap, method: &str) -> Value {
         // For live procs (with :in), finalize the child on exitcode/out/err/signal access
         let is_live = matches!(
             attributes.get("live").map(Value::view),

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -7,6 +7,7 @@ use super::state::*;
 use super::state_lock::*;
 use super::state_scheduler::{self, *};
 use super::state_supplier::{close_supplier_tap, take_supplier_close_callbacks};
+use crate::value::AttrMap;
 
 /// Parameters for a scheduled cue operation.
 struct CueParams {
@@ -121,7 +122,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_tap(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
     ) -> Result<Value, RuntimeError> {
         match method {
@@ -168,7 +169,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_cancellation(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
     ) -> Result<Value, RuntimeError> {
         match method {
@@ -190,7 +191,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_scheduler(
         &mut self,
-        _attributes: &HashMap<String, Value>,
+        _attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
         is_current_thread: bool,
@@ -294,10 +295,10 @@ impl Interpreter {
     /// Mutable dispatch for Scheduler: handles uncaught_handler setter.
     /// Returns (result_value, updated_attributes).
     pub(in crate::runtime) fn native_scheduler_mut(
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "uncaught_handler" => {
                 let handler = args.into_iter().next().unwrap_or(Value::NIL);
@@ -468,7 +469,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_fake_scheduler(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc;
 
 use super::state::*;
 use super::state_supplier::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     fn async_socket_status_result(status: &str, result: Value, cause: Value) -> Value {
@@ -235,7 +236,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_socket_async_listener(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -484,7 +485,7 @@ impl Interpreter {
     /// Handle instance methods on UDP sockets (created by bind-udp / udp).
     pub(super) fn native_socket_async_udp(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -4,11 +4,12 @@ use crate::symbol::Symbol;
 use std::sync::mpsc;
 
 use super::state::*;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(in crate::runtime) fn native_socket_async(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -165,7 +166,7 @@ impl Interpreter {
         &mut self,
         conn_id: Option<u64>,
         args: &[Value],
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
     ) -> Result<Value, RuntimeError> {
         let id = conn_id.ok_or_else(|| RuntimeError::new("Missing async conn-id"))?;
         let is_bin = Self::named_bool(args, "bin");

--- a/src/runtime/native_methods/socket_inet.rs
+++ b/src/runtime/native_methods/socket_inet.rs
@@ -1,4 +1,5 @@
 use crate::runtime::*;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -6,7 +7,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_socket_inet(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -1,4 +1,5 @@
 use crate::runtime::*;
+use crate::value::AttrMap;
 use std::net::TcpStream;
 use std::process::ChildStdin;
 use std::sync::OnceLock;
@@ -184,9 +185,7 @@ fn supplier_state_map() -> &'static SupplierStateMap {
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
-pub(in crate::runtime) fn supplier_id_from_attrs(
-    attributes: &HashMap<String, Value>,
-) -> Option<u64> {
+pub(in crate::runtime) fn supplier_id_from_attrs(attributes: &AttrMap) -> Option<u64> {
     match attributes.get("supplier_id").and_then(|v| v.as_int()) {
         Some(id) if id > 0 => Some(id as u64),
         _ => None,

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -1,5 +1,6 @@
 use crate::runtime::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -7,7 +8,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_distro(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
     ) -> Result<Value, RuntimeError> {
         match method {
@@ -84,7 +85,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_kernel(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -167,7 +168,7 @@ impl Interpreter {
 
     pub(in crate::runtime) fn native_vm(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
@@ -226,11 +227,7 @@ impl Interpreter {
 
     // --- Perl ---
 
-    pub(in crate::runtime) fn native_perl(
-        &self,
-        attributes: &HashMap<String, Value>,
-        method: &str,
-    ) -> Value {
+    pub(in crate::runtime) fn native_perl(&self, attributes: &AttrMap, method: &str) -> Value {
         match method {
             "compiler" => {
                 let mut compiler_attrs = HashMap::new();

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -1,6 +1,7 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use std::io::{Read, Write};
 use std::sync::mpsc;
 
@@ -76,10 +77,10 @@ pub(in crate::runtime) fn malformed_utf8_quit_value() -> Value {
 impl Interpreter {
     pub(super) fn native_proc_async_mut(
         &mut self,
-        mut attrs: HashMap<String, Value>,
+        mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         let proc_async_error = |class_name: &str, attrs: &[(&str, Value)]| {
             let mut ex_attrs = HashMap::new();
             for (k, v) in attrs {
@@ -729,7 +730,7 @@ impl Interpreter {
                 };
                 if attrs.get("supply_selected").is_some_and(|v| v.truthy())
                     || attrs
-                        .get(&format!("{}_selected", handle_name))
+                        .get(format!("{}_selected", handle_name))
                         .is_some_and(|v| v.truthy())
                 {
                     return Err(proc_async_error(
@@ -760,7 +761,7 @@ impl Interpreter {
             }
             "stdout" | "stderr" => {
                 if attrs
-                    .get(&format!("{}_bind", method))
+                    .get(format!("{}_bind", method))
                     .is_some_and(|v| !v.is_nil())
                 {
                     return Err(proc_async_error(

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -4,11 +4,12 @@ use super::native_methods::*;
 use super::native_supply_methods::QuitOutcome;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(super) fn native_supplier(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -436,10 +437,10 @@ impl Interpreter {
 
     pub(super) fn native_supplier_mut(
         &mut self,
-        mut attrs: HashMap<String, Value>,
+        mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "emit" => {
                 let value = args.first().cloned().unwrap_or(Value::NIL);

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -3,12 +3,13 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use unicode_segmentation::UnicodeSegmentation;
 
 impl Interpreter {
     pub(super) fn native_supply(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
@@ -977,8 +978,7 @@ impl Interpreter {
 
                         // Collect all sources (self + others). Own each map so we
                         // don't hold attribute read guards across the loop below.
-                        let mut all_supplies: Vec<HashMap<String, Value>> =
-                            vec![attributes.clone()];
+                        let mut all_supplies: Vec<AttrMap> = vec![attributes.clone()];
                         for supply in &other_supplies {
                             if let ValueView::Instance { attributes: a, .. } = supply.view() {
                                 all_supplies.push(a.to_map());

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -1,6 +1,7 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use crate::value::ValueView;
 
 /// How a `whenever` QUIT phaser handled (or did not handle) an exception.
@@ -125,7 +126,7 @@ impl Interpreter {
         err
     }
 
-    pub(super) fn supply_is_terminated(attributes: &HashMap<String, Value>) -> bool {
+    pub(super) fn supply_is_terminated(attributes: &AttrMap) -> bool {
         supplier_id_from_attrs(attributes)
             .map(|supplier_id| {
                 let (_, done, quit_reason) = supplier_snapshot(supplier_id);

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -3,14 +3,15 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     pub(super) fn native_supply_mut(
         &mut self,
-        mut attrs: HashMap<String, Value>,
+        mut attrs: AttrMap,
         method: &str,
         args: Vec<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         match method {
             "emit" => {
                 let value = args.first().cloned().unwrap_or(Value::NIL);

--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -5,6 +5,7 @@ use super::subtest::ReactSubscription;
 use super::*;
 use crate::runtime::native_methods::take_supply_channel;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use std::collections::HashMap;
 
 impl Interpreter {
@@ -143,7 +144,7 @@ impl Interpreter {
     // Helpers that duplicate subtest.rs private helpers (to avoid
     // visibility issues).
 
-    fn extract_supply_head_limit(attributes: &HashMap<String, Value>) -> Option<usize> {
+    fn extract_supply_head_limit(attributes: &AttrMap) -> Option<usize> {
         if let Some(ValueView::Int(n)) = attributes.get("head_limit").map(Value::view) {
             Some(n as usize)
         } else {
@@ -151,7 +152,7 @@ impl Interpreter {
         }
     }
 
-    fn extract_supply_on_close_cbs(attributes: &HashMap<String, Value>) -> Vec<Value> {
+    fn extract_supply_on_close_cbs(attributes: &AttrMap) -> Vec<Value> {
         if let Some(ValueView::Array(callbacks, ..)) =
             attributes.get("on_close_callbacks").map(Value::view)
         {
@@ -169,10 +170,7 @@ impl Interpreter {
         }
     }
 
-    fn resolve_supply_channel_id_for_react(
-        &self,
-        attributes: &HashMap<String, Value>,
-    ) -> Option<u64> {
+    fn resolve_supply_channel_id_for_react(&self, attributes: &AttrMap) -> Option<u64> {
         if let Some(ValueView::Int(parent_id)) = attributes.get("parent_supply_id").map(Value::view)
         {
             return Some(parent_id as u64);

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -263,12 +263,12 @@ impl Interpreter {
     pub(crate) fn apply_container_attribute_defaults(
         &mut self,
         class_name: &str,
-        attributes: &mut std::collections::HashMap<String, Value>,
+        attributes: &mut crate::value::AttrMap,
     ) {
-        let names: Vec<String> = attributes.keys().cloned().collect();
+        let names: Vec<crate::symbol::Symbol> = attributes.keys().copied().collect();
         for attr_name in names {
             if !matches!(
-                attributes.get(&attr_name).map(Value::view),
+                attributes.get(attr_name).map(Value::view),
                 Some(ValueView::Array(..)) | Some(ValueView::Hash(_))
             ) {
                 continue;
@@ -277,17 +277,17 @@ impl Interpreter {
             // to a deferred expression carried from a parametric role, evaluated now
             // (the caller has bound the role's type params in `self.env`).
             let def = self
-                .class_attribute_default(class_name, &attr_name)
+                .class_attribute_default(class_name, attr_name.as_str())
                 .or_else(|| {
                     let expr = self
                         .registry()
                         .class_attribute_default_exprs
-                        .get(&(class_name.to_string(), attr_name.clone()))
+                        .get(&(class_name.to_string(), attr_name.resolve()))
                         .cloned()?;
                     self.eval_block_value(&[crate::ast::Stmt::Expr(expr)]).ok()
                 });
             if let Some(def) = def
-                && let Some(val) = attributes.remove(&attr_name)
+                && let Some(val) = attributes.remove(attr_name)
             {
                 let tagged = self.tag_container_default(val, def);
                 attributes.insert(attr_name, tagged);

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -122,7 +122,9 @@ impl Interpreter {
                 named.insert(k.clone(), v.clone());
                 Some((Vec::new(), named))
             }
-            ValueView::Instance { attributes, .. } => Some((Vec::new(), (attributes.to_map()))),
+            ValueView::Instance { attributes, .. } => {
+                Some((Vec::new(), HashMap::from(&*attributes.as_map())))
+            }
             ValueView::Mixin(inner, _) => Self::signature_capture_like(inner),
             _ => None,
         }

--- a/src/runtime/supply_classify.rs
+++ b/src/runtime/supply_classify.rs
@@ -3,13 +3,14 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Supply.unique implementation — filters duplicate values.
     /// Supports `:as`, `:with`, and `:expires` named parameters.
     pub(super) fn supply_unique(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let as_fn = Self::named_value(args, "as");
@@ -94,7 +95,7 @@ impl Interpreter {
     /// classification group. The mapper can be a Block, Hash, or Array.
     pub(super) fn supply_classify(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: &[Value],
         categorize: bool,
     ) -> Result<Value, RuntimeError> {

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -3,6 +3,7 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Phase A of the on-demand supply runtime, shared by `tap`/`act`, the react
@@ -36,7 +37,7 @@ impl Interpreter {
     /// Extract source values from a Supply's attributes.
     pub(super) fn supply_get_values(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
     ) -> Result<Vec<Value>, RuntimeError> {
         if let Some(on_demand_cb) = attributes.get("on_demand_callback") {
             let (_, emitted, _) = self.run_on_demand_body(on_demand_cb.clone(), None);
@@ -96,7 +97,7 @@ impl Interpreter {
     /// Keeps the promise with the last emitted value when done.
     pub(super) fn supply_promise_on_demand(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         promise: &crate::value::SharedPromise,
     ) -> Result<(), RuntimeError> {
         use crate::runtime::native_methods::take_supply_channel;

--- a/src/runtime/supply_transform.rs
+++ b/src/runtime/supply_transform.rs
@@ -3,12 +3,13 @@
 use super::native_methods::*;
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 
 impl Interpreter {
     /// Implement Supply.throttle($limit, $seconds-or-block, :$control, :$status)
     pub(super) fn supply_throttle(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         use crate::value::SharedPromise;
@@ -220,7 +221,7 @@ impl Interpreter {
     pub(super) fn make_supply_from_values(
         &self,
         values: Vec<Value>,
-        _source_attrs: &HashMap<String, Value>,
+        _source_attrs: &AttrMap,
     ) -> Value {
         let mut attrs = HashMap::new();
         attrs.insert("values".to_string(), Value::array(values));

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -291,7 +291,7 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
         // params `(:$a, :$b)` binds each pair's key to its value.
         ValueView::Array(data, _) => pairs_in_list_to_named(&data.items),
         ValueView::Seq(items) | ValueView::Slip(items) => pairs_in_list_to_named(&items),
-        ValueView::Instance { attributes, .. } => attributes.to_map(),
+        ValueView::Instance { attributes, .. } => HashMap::from(&*attributes.as_map()),
         _ => std::collections::HashMap::new(),
     }
 }

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 /// Render the `.gist` form of a Set/Bag/Mix (and their mutable `*Hash`
 /// variants): `Set(a b c)`, `Bag(a b(2))`, `Mix(a(1.5) b)`. Keys are sorted
@@ -241,7 +242,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
 ///
 /// A quantified capture (`(\w)+`) is a list of Match values, each emitted under
 /// the same index. `depth` controls indentation (one leading space per level).
-pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> String {
+pub(crate) fn match_gist(attributes: &AttrMap, depth: usize) -> String {
     let matched = attributes
         .get("str")
         .map(|s| s.to_string_value())
@@ -335,7 +336,7 @@ pub(crate) fn match_gist(attributes: &HashMap<String, Value>, depth: usize) -> S
 }
 
 /// The `from` (start offset) of a Match's attributes, or 0 when absent.
-fn match_from(attributes: &HashMap<String, Value>) -> i64 {
+fn match_from(attributes: &AttrMap) -> i64 {
     match attributes.get("from").map(Value::view) {
         Some(ValueView::Int(n)) => n,
         _ => 0,

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -97,6 +97,26 @@ impl Symbol {
         sym
     }
 
+    /// Look a string up *without* interning it: `Some` only if the string has
+    /// already been interned by someone. Used by [`crate::value::AttrMap`]'s
+    /// string-keyed convenience lookups (`attrs.get("name")`), where a name that
+    /// was never interned cannot possibly be a key in the map — so a miss must
+    /// not grow the (append-only, leaked) symbol table with a name nothing else
+    /// uses.
+    pub fn lookup(s: &str) -> Option<Symbol> {
+        if let Some(sym) = INTERN_CACHE.with(|c| c.borrow().get(s).copied()) {
+            return Some(sym);
+        }
+        let sym = {
+            let table = global_table().read().unwrap();
+            table.str_to_id.get(s).copied()
+        }?;
+        INTERN_CACHE.with(|c| {
+            c.borrow_mut().insert(s.to_owned(), sym);
+        });
+        Some(sym)
+    }
+
     /// Intern via the globally-shared table (the source of truth for id
     /// assignment). Only reached on a thread-local cache miss.
     fn intern_global(s: &str) -> Symbol {

--- a/src/value/attr_map.rs
+++ b/src/value/attr_map.rs
@@ -1,0 +1,300 @@
+//! `AttrMap` — the instance-attribute map (ADR-0006 §2.4).
+//!
+//! Instance attributes used to be a `HashMap<String, Value>`: every lookup
+//! hashed the attribute name with SipHash and then `memcmp`'d it, every
+//! construction heap-allocated one `String` per attribute, and every
+//! `to_map()`/`commit_attrs()` snapshot cloned all of those `String`s again.
+//! On `benchmarks/bench-class.raku` that showed up as 5.2% `__memcmp_avx2` plus
+//! a large share of the ~20% spent in the allocator.
+//!
+//! The keys are now [`Symbol`]s: hashing is a `u32` through `FxHashMap`, key
+//! comparison is an integer compare, and cloning a key is a `Copy`.
+//!
+//! To keep the blast radius of the migration sane, `AttrMap` is a newtype whose
+//! inherent `get`/`insert`/`contains_key`/`remove`/`entry` accept anything that
+//! implements [`AttrKey`] — a `Symbol` (the hot paths, which already hold one)
+//! *or* a `&str`/`String` (the many cold construction sites: exception attrs,
+//! native-type constructors, introspection). A `&str` key is interned on the
+//! spot, so those sites keep their `"literal"` spelling and pay one intern
+//! lookup; a `Symbol` key skips interning entirely.
+
+use super::Value;
+use crate::symbol::Symbol;
+use rustc_hash::FxHashMap;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+/// Anything usable as an attribute key. `Symbol` is the native (hot) form; the
+/// string forms intern on the fly for cold call sites.
+pub(crate) trait AttrKey {
+    /// The key as a `Symbol`, interning it if necessary.
+    fn into_symbol(self) -> Symbol;
+    /// The key as a `Symbol` *if it is already interned*. Lookups use this so a
+    /// miss on a never-interned name does not pollute the symbol table.
+    fn lookup_symbol(&self) -> Option<Symbol>;
+}
+
+impl AttrKey for Symbol {
+    #[inline]
+    fn into_symbol(self) -> Symbol {
+        self
+    }
+    #[inline]
+    fn lookup_symbol(&self) -> Option<Symbol> {
+        Some(*self)
+    }
+}
+
+impl AttrKey for &Symbol {
+    #[inline]
+    fn into_symbol(self) -> Symbol {
+        *self
+    }
+    #[inline]
+    fn lookup_symbol(&self) -> Option<Symbol> {
+        Some(**self)
+    }
+}
+
+impl AttrKey for &str {
+    #[inline]
+    fn into_symbol(self) -> Symbol {
+        Symbol::intern(self)
+    }
+    #[inline]
+    fn lookup_symbol(&self) -> Option<Symbol> {
+        Symbol::lookup(self)
+    }
+}
+
+impl AttrKey for &String {
+    #[inline]
+    fn into_symbol(self) -> Symbol {
+        Symbol::intern(self)
+    }
+    #[inline]
+    fn lookup_symbol(&self) -> Option<Symbol> {
+        Symbol::lookup(self)
+    }
+}
+
+impl AttrKey for String {
+    #[inline]
+    fn into_symbol(self) -> Symbol {
+        Symbol::intern(&self)
+    }
+    #[inline]
+    fn lookup_symbol(&self) -> Option<Symbol> {
+        Symbol::lookup(self)
+    }
+}
+
+/// If `name` is an attribute-twigil variable name — scalar (`!x`/`.x`), array
+/// (`@!x`/`@.x`) or hash (`%!x`/`%.x`) — return `(bare attribute name,
+/// is_private)`. Excludes the bare `!`/`.` special vars and internal names. The
+/// attribute cell stores attributes under the bare name, so all six twigil forms
+/// of an attribute resolve to the same cell slot.
+///
+/// Lives here (rather than on `Interpreter`) so the compiled-code local-slot
+/// attribute cache (`CompiledCode::local_attr_key`) can pre-resolve it at
+/// compile time and hand the VM a ready `Symbol`.
+pub(crate) fn attr_twigil_base(name: &str) -> Option<(&str, bool)> {
+    // Optional `@`/`%` sigil, then the `!` (private) / `.` (public) twigil.
+    let rest = name
+        .strip_prefix('@')
+        .or_else(|| name.strip_prefix('%'))
+        .unwrap_or(name);
+    let (bare, is_private) = if let Some(b) = rest.strip_prefix('!') {
+        (b, true)
+    } else if let Some(b) = rest.strip_prefix('.') {
+        (b, false)
+    } else {
+        return None;
+    };
+    // Attribute names are ordinary identifiers (start alpha/underscore). This
+    // filters out `!=`, the bare `!`/`.` special vars, and `__mutsu_` keys.
+    match bare.chars().next() {
+        Some(c) if c.is_alphabetic() || c == '_' => Some((bare, is_private)),
+        _ => None,
+    }
+}
+
+/// The attribute map of an instance: `Symbol -> Value`, hashed with `FxHash`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct AttrMap(FxHashMap<Symbol, Value>);
+
+impl AttrMap {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub(crate) fn get<K: AttrKey>(&self, key: K) -> Option<&Value> {
+        let sym = key.lookup_symbol()?;
+        self.0.get(&sym)
+    }
+
+    #[inline]
+    pub(crate) fn get_mut<K: AttrKey>(&mut self, key: K) -> Option<&mut Value> {
+        let sym = key.lookup_symbol()?;
+        self.0.get_mut(&sym)
+    }
+
+    #[inline]
+    pub(crate) fn contains_key<K: AttrKey>(&self, key: K) -> bool {
+        match key.lookup_symbol() {
+            Some(sym) => self.0.contains_key(&sym),
+            None => false,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn insert<K: AttrKey>(&mut self, key: K, value: Value) -> Option<Value> {
+        self.0.insert(key.into_symbol(), value)
+    }
+
+    #[inline]
+    pub(crate) fn remove<K: AttrKey>(&mut self, key: K) -> Option<Value> {
+        let sym = key.lookup_symbol()?;
+        self.0.remove(&sym)
+    }
+
+    #[inline]
+    pub(crate) fn entry<K: AttrKey>(&mut self, key: K) -> Entry<'_, Symbol, Value> {
+        self.0.entry(key.into_symbol())
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    #[inline]
+    pub(crate) fn iter(&self) -> std::collections::hash_map::Iter<'_, Symbol, Value> {
+        self.0.iter()
+    }
+
+    #[inline]
+    pub(crate) fn keys(&self) -> std::collections::hash_map::Keys<'_, Symbol, Value> {
+        self.0.keys()
+    }
+
+    #[inline]
+    pub(crate) fn values(&self) -> std::collections::hash_map::Values<'_, Symbol, Value> {
+        self.0.values()
+    }
+
+    #[inline]
+    pub(crate) fn values_mut(
+        &mut self,
+    ) -> std::collections::hash_map::ValuesMut<'_, Symbol, Value> {
+        self.0.values_mut()
+    }
+
+    /// Assign into the slot at `key`, writing *through* an existing
+    /// `ContainerRef` cell (a `:=`-bound attribute) instead of replacing the
+    /// entry — the attribute-map analogue of `Value::hash_insert_through`, which
+    /// does the same for the `Value::Hash` element map.
+    pub(crate) fn insert_through<K: AttrKey + Copy>(&mut self, key: K, val: Value) {
+        match self.get_mut(key) {
+            Some(slot) => Value::assign_element_slot(slot, val),
+            None => {
+                self.insert(key, val);
+            }
+        }
+    }
+}
+
+impl Extend<(Symbol, Value)> for AttrMap {
+    fn extend<T: IntoIterator<Item = (Symbol, Value)>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl FromIterator<(Symbol, Value)> for AttrMap {
+    fn from_iter<T: IntoIterator<Item = (Symbol, Value)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl FromIterator<(String, Value)> for AttrMap {
+    fn from_iter<T: IntoIterator<Item = (String, Value)>>(iter: T) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(k, v)| (Symbol::intern(&k), v))
+                .collect(),
+        )
+    }
+}
+
+impl<'a> FromIterator<(&'a str, Value)> for AttrMap {
+    fn from_iter<T: IntoIterator<Item = (&'a str, Value)>>(iter: T) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(k, v)| (Symbol::intern(k), v))
+                .collect(),
+        )
+    }
+}
+
+impl IntoIterator for AttrMap {
+    type Item = (Symbol, Value);
+    type IntoIter = std::collections::hash_map::IntoIter<Symbol, Value>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a AttrMap {
+    type Item = (&'a Symbol, &'a Value);
+    type IntoIter = std::collections::hash_map::Iter<'a, Symbol, Value>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl From<HashMap<String, Value>> for AttrMap {
+    fn from(map: HashMap<String, Value>) -> Self {
+        map.into_iter().collect()
+    }
+}
+
+impl From<&AttrMap> for HashMap<String, Value> {
+    fn from(map: &AttrMap) -> Self {
+        map.iter().map(|(k, v)| (k.resolve(), v.clone())).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn str_and_symbol_keys_agree() {
+        let mut m = AttrMap::new();
+        m.insert("alpha", Value::int(1));
+        assert!(m.contains_key(Symbol::intern("alpha")));
+        assert_eq!(m.get("alpha"), m.get(Symbol::intern("alpha")));
+        assert_eq!(m.iter().count(), 1);
+    }
+
+    #[test]
+    fn missing_str_key_does_not_intern() {
+        let m = AttrMap::new();
+        // A never-interned name must miss without creating a symbol for it.
+        assert!(m.get("attr_map_never_interned_name_xyz").is_none());
+        assert!(Symbol::lookup("attr_map_never_interned_name_xyz").is_none());
+    }
+
+    #[test]
+    fn from_string_hashmap_roundtrips() {
+        let mut src: HashMap<String, Value> = HashMap::new();
+        src.insert("beta".to_string(), Value::int(7));
+        let m: AttrMap = src.into();
+        assert_eq!(m.get("beta"), Some(&Value::int(7)));
+    }
+}

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -444,7 +444,7 @@ impl RuntimeError {
                     attributes
                         .as_map()
                         .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .map(|(k, v)| (k.resolve(), v.clone()))
                         .collect(),
                 ),
                 _ => ("X::AdHoc".to_string(), {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -283,6 +283,8 @@ pub(crate) struct MixData {
 }
 
 mod aliased_mut;
+/// The instance-attribute map (`Symbol -> Value`); see [`AttrMap`].
+mod attr_map;
 mod display;
 mod error;
 mod error_construct;
@@ -314,6 +316,7 @@ mod view;
 pub(crate) use crate::gc::gc_contents_mut;
 pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use aliased_mut::gc_data_mut;
+pub(crate) use attr_map::{AttrKey, AttrMap, attr_twigil_base};
 pub use guards::{ArcRef, GcRef, RefGuard, WeakGcRef};
 pub(in crate::value) use nanbox::NanBox;
 
@@ -352,7 +355,7 @@ static INSTANCE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 #[derive(Debug, Clone)]
 pub(crate) struct PendingInstanceDestroy {
     pub(crate) class_name: Symbol,
-    pub(crate) attributes: HashMap<String, Value>,
+    pub(crate) attributes: AttrMap,
 }
 
 thread_local! {
@@ -390,7 +393,7 @@ fn live_instance_refcounts(id: u64) -> &'static Mutex<HashMap<u64, usize>> {
 }
 
 /// The shared mutable attribute cell of an instance (Phase 3, Stage 1).
-pub(crate) type AttrCell = Arc<RwLock<HashMap<String, Value>>>;
+pub(crate) type AttrCell = Arc<RwLock<AttrMap>>;
 
 thread_local! {
     /// Addresses of attribute cells this thread is currently holding a read
@@ -413,15 +416,15 @@ thread_local! {
 
 /// A deferred cell write: `(cell address, cell, new map)`. See
 /// [`PENDING_CELL_WRITES`].
-type PendingCellWrite = (usize, AttrCell, HashMap<String, Value>);
+type PendingCellWrite = (usize, AttrCell, AttrMap);
 
-fn cell_addr(cell: &RwLock<HashMap<String, Value>>) -> usize {
-    cell as *const RwLock<HashMap<String, Value>> as usize
+fn cell_addr(cell: &RwLock<AttrMap>) -> usize {
+    cell as *const RwLock<AttrMap> as usize
 }
 
-/// A read guard over an instance's attribute map. Derefs to `&HashMap`, so the
+/// A read guard over an instance's attribute map. Derefs to `&AttrMap`, so the
 /// vast majority of read sites (`.get`, `.iter`, `.len`, `for (k, v) in ...`)
-/// and `&guard` argument coercions to `&HashMap` keep working unchanged. On
+/// and `&guard` argument coercions to `&AttrMap` keep working unchanged. On
 /// construction it records the cell address in [`HELD_READ_CELLS`]; on drop it
 /// removes it and, when this was the last read guard on the cell, applies any
 /// write that was deferred while the cell was read-locked.
@@ -429,7 +432,7 @@ pub(crate) struct AttrReadGuard<'a> {
     // `Option` so `Drop` can release the read lock *before* flushing deferred
     // writes — otherwise the flush's blocking write lock would deadlock against
     // this guard's own still-held read lock (struct fields drop after `drop`).
-    guard: Option<std::sync::RwLockReadGuard<'a, HashMap<String, Value>>>,
+    guard: Option<std::sync::RwLockReadGuard<'a, AttrMap>>,
     addr: usize,
 }
 
@@ -501,7 +504,7 @@ pub fn lookup_container_constraint(cell: &crate::gc::Gc<Mutex<Value>>) -> Option
 /// When this thread is *not* reading the cell we take a blocking write lock,
 /// which is required for correctness under genuine cross-thread contention
 /// (e.g. concurrent `cas` on a shared instance attribute must not drop updates).
-fn write_cell_respecting_reads(cell: &AttrCell, map: HashMap<String, Value>) {
+fn write_cell_respecting_reads(cell: &AttrCell, map: AttrMap) {
     let addr = cell_addr(cell);
     if HELD_READ_CELLS.with(|c| c.borrow().contains(&addr)) {
         PENDING_CELL_WRITES.with(|p| p.borrow_mut().push((addr, cell.clone(), map)));
@@ -514,14 +517,12 @@ fn write_cell_respecting_reads(cell: &AttrCell, map: HashMap<String, Value>) {
 /// poisoned attribute lock only means some thread panicked mid-mutation; the
 /// map itself is still a valid `HashMap`, and matching the codebase's other
 /// `lock().unwrap()` sites would just turn a poison into a second panic.
-fn read_attrs(cell: &RwLock<HashMap<String, Value>>) -> AttrReadGuard<'_> {
+fn read_attrs(cell: &RwLock<AttrMap>) -> AttrReadGuard<'_> {
     let guard = cell.read().unwrap_or_else(|e| e.into_inner());
     AttrReadGuard::new(guard, cell_addr(cell))
 }
 
-fn write_attrs(
-    cell: &RwLock<HashMap<String, Value>>,
-) -> std::sync::RwLockWriteGuard<'_, HashMap<String, Value>> {
+fn write_attrs(cell: &RwLock<AttrMap>) -> std::sync::RwLockWriteGuard<'_, AttrMap> {
     cell.write().unwrap_or_else(|e| e.into_inner())
 }
 
@@ -1648,7 +1649,7 @@ pub(crate) struct WalkPendingState {
     pub(crate) targets: Vec<String>,
     pub(crate) args: Vec<Value>,
     pub(crate) invocant: Value,
-    pub(crate) attributes: std::collections::HashMap<String, Value>,
+    pub(crate) attributes: AttrMap,
     pub(crate) quiet: bool,
     pub(crate) idx: usize,
 }

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -260,7 +260,7 @@ fn weak_sub_stays_weak_and_expires() {
 #[test]
 fn instance_reads_class_and_id_back_from_the_pointee() {
     let class = Symbol::intern("NanboxTestClass");
-    let mut attrs = HashMap::new();
+    let mut attrs = AttrMap::new();
     attrs.insert("x".to_string(), Value::int(1));
     // queue_destroy=false: keep the DESTROY registry out of a unit test.
     let node = Gc::new(InstanceAttrs::new(class, attrs, 777, false));

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -232,7 +232,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
             let ser_attrs: Result<HashMap<_, _>, _> = attributes
                 .as_map()
                 .iter()
-                .map(|(k, v)| value_to_ser(v).map(|sv| (k.clone(), sv)))
+                .map(|(k, v)| value_to_ser(v).map(|sv| (k.resolve(), sv)))
                 .collect();
             Ok(SerValue::Instance {
                 class_name,

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -2,6 +2,7 @@ use super::Value;
 use super::ValueView;
 use crate::ast::{Expr, ParamDef, Stmt};
 use crate::symbol::Symbol;
+use crate::value::AttrMap;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -381,7 +382,7 @@ fn build_parameter_attrs(p: &SigParam) -> HashMap<String, Value> {
 }
 
 /// Construct the `.raku` string for a Parameter instance from its attributes.
-pub(crate) fn parameter_to_raku(attrs: &HashMap<String, Value>) -> String {
+pub(crate) fn parameter_to_raku(attrs: &AttrMap) -> String {
     let mut parts = Vec::new();
 
     // Type constraint

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -1,10 +1,7 @@
 use super::*;
 
 impl<'a> AttrReadGuard<'a> {
-    pub(super) fn new(
-        guard: std::sync::RwLockReadGuard<'a, HashMap<String, Value>>,
-        addr: usize,
-    ) -> Self {
+    pub(super) fn new(guard: std::sync::RwLockReadGuard<'a, AttrMap>, addr: usize) -> Self {
         HELD_READ_CELLS.with(|c| c.borrow_mut().push(addr));
         Self {
             guard: Some(guard),
@@ -14,7 +11,7 @@ impl<'a> AttrReadGuard<'a> {
 }
 
 impl std::ops::Deref for AttrReadGuard<'_> {
-    type Target = HashMap<String, Value>;
+    type Target = AttrMap;
     fn deref(&self) -> &Self::Target {
         self.guard.as_ref().expect("attr read guard live")
     }
@@ -37,7 +34,7 @@ impl Drop for AttrReadGuard<'_> {
         }
         let flush = PENDING_CELL_WRITES.with(|p| {
             let mut v = p.borrow_mut();
-            let mut mine: Vec<(AttrCell, HashMap<String, Value>)> = Vec::new();
+            let mut mine: Vec<(AttrCell, AttrMap)> = Vec::new();
             v.retain(|(a, cell, map)| {
                 if *a == self.addr {
                     mine.push((cell.clone(), map.clone()));
@@ -88,7 +85,7 @@ impl Clone for InstanceAttrs {
 impl InstanceAttrs {
     pub(crate) fn new(
         class_name: Symbol,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         id: u64,
         queue_destroy: bool,
     ) -> Self {
@@ -133,7 +130,7 @@ impl InstanceAttrs {
     }
 
     /// An owned clone of the backing map.
-    pub(crate) fn to_map(&self) -> HashMap<String, Value> {
+    pub(crate) fn to_map(&self) -> AttrMap {
         self.as_map().clone()
     }
 
@@ -142,12 +139,12 @@ impl InstanceAttrs {
         self.id
     }
 
-    pub(crate) fn contains_key(&self, key: &str) -> bool {
+    pub(crate) fn contains_key<K: AttrKey>(&self, key: K) -> bool {
         self.as_map().contains_key(key)
     }
 
     /// In-place insert through the shared cell (visible to all aliases).
-    pub(crate) fn insert(&self, key: String, value: Value) -> Option<Value> {
+    pub(crate) fn insert<K: AttrKey>(&self, key: K, value: Value) -> Option<Value> {
         write_attrs(&self.attributes).insert(key, value)
     }
 
@@ -162,14 +159,18 @@ impl InstanceAttrs {
     /// Mutate one attribute in place under the write lock, returning the
     /// closure's result. Returns `None` if the key is absent. Replaces the old
     /// `get_mut` (which cannot hand out a `&mut` past the guard).
-    pub(crate) fn with_attr_mut<R>(&self, key: &str, f: impl FnOnce(&mut Value) -> R) -> Option<R> {
+    pub(crate) fn with_attr_mut<K: AttrKey, R>(
+        &self,
+        key: K,
+        f: impl FnOnce(&mut Value) -> R,
+    ) -> Option<R> {
         let mut guard = write_attrs(&self.attributes);
         guard.get_mut(key).map(f)
     }
 
     /// Insert `value` only if `key` is absent (the `entry(..).or_insert(..)`
     /// idiom), in place under the write lock.
-    pub(crate) fn insert_if_absent(&self, key: String, value: Value) {
+    pub(crate) fn insert_if_absent<K: AttrKey>(&self, key: K, value: Value) {
         write_attrs(&self.attributes).entry(key).or_insert(value);
     }
 
@@ -180,7 +181,7 @@ impl InstanceAttrs {
     /// absent key materializes as a fresh cell holding `Nil`. This gives an
     /// accessor result container identity: writes through the accessor and reads
     /// through the bound alias observe the same slot.
-    pub(crate) fn promote_attr_to_container(&self, key: &str) -> Value {
+    pub(crate) fn promote_attr_to_container<K: AttrKey + Copy>(&self, key: K) -> Value {
         let mut guard = write_attrs(&self.attributes);
         match guard.get_mut(key) {
             Some(slot) => {
@@ -193,7 +194,7 @@ impl InstanceAttrs {
             }
             None => {
                 let cell = crate::gc::Gc::new(Mutex::new(Value::Nil));
-                guard.insert(key.to_string(), Value::ContainerRef(cell.clone()));
+                guard.insert(key, Value::ContainerRef(cell.clone()));
                 Value::ContainerRef(cell)
             }
         }
@@ -208,7 +209,7 @@ impl InstanceAttrs {
     /// the in-place replacement for the legacy id→cell registry writeback
     /// (`overwrite_instance_bindings_by_identity` / `update_instance_cell`), which
     /// computed an updated `HashMap` and looked the cell up by id.
-    pub(crate) fn commit_attrs(&self, map: HashMap<String, Value>) {
+    pub(crate) fn commit_attrs(&self, map: AttrMap) {
         write_cell_respecting_reads(&self.attributes, map);
     }
 
@@ -218,9 +219,9 @@ impl InstanceAttrs {
     /// atomic primitive for cross-thread `cas`/atomic ops on instance
     /// attributes — every alias of the instance shares this cell, so the swap
     /// is immediately visible everywhere (no shared_vars side channel).
-    pub(crate) fn compare_and_swap(
+    pub(crate) fn compare_and_swap<K: AttrKey + Copy>(
         &self,
-        key: &str,
+        key: K,
         matches: impl FnOnce(&Value) -> bool,
         new: Value,
     ) -> (Value, bool) {
@@ -228,7 +229,7 @@ impl InstanceAttrs {
         let current = guard.get(key).cloned().unwrap_or(Value::Nil);
         let swapped = matches(&current);
         if swapped {
-            guard.insert(key.to_string(), new);
+            guard.insert(key, new);
         }
         (current, swapped)
     }
@@ -236,15 +237,15 @@ impl InstanceAttrs {
     /// Phase 3 cell-CAS: atomically read-modify-write one attribute under a
     /// single write lock (atomic add / increment / decrement). Returns
     /// `(old, new)`; an error from `f` leaves the attribute unchanged.
-    pub(crate) fn fetch_update(
+    pub(crate) fn fetch_update<K: AttrKey + Copy>(
         &self,
-        key: &str,
+        key: K,
         f: impl FnOnce(&Value) -> Result<Value, RuntimeError>,
     ) -> Result<(Value, Value), RuntimeError> {
         let mut guard = write_attrs(&self.attributes);
         let current = guard.get(key).cloned().unwrap_or(Value::Nil);
         let next = f(&current)?;
-        guard.insert(key.to_string(), next.clone());
+        guard.insert(key, next.clone());
         Ok((current, next))
     }
 

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -405,14 +405,19 @@ impl Value {
         }
     }
 
-    pub(crate) fn make_instance(class_name: Symbol, attributes: HashMap<String, Value>) -> Self {
+    /// Build a fresh instance. `attributes` is an [`AttrMap`] (the `Symbol`-keyed
+    /// storage) or anything convertible into one — notably a
+    /// `HashMap<String, Value>`, which the many cold construction sites (typed
+    /// exceptions, native-type constructors) still build; those keys are interned
+    /// here, once, at construction.
+    pub(crate) fn make_instance(class_name: Symbol, attributes: impl Into<AttrMap>) -> Self {
         let id = next_instance_id();
         Self::make_instance_with_id(class_name, attributes, id)
     }
 
     pub(crate) fn make_instance_without_destroy(
         class_name: Symbol,
-        attributes: HashMap<String, Value>,
+        attributes: impl Into<AttrMap>,
     ) -> Self {
         Self::make_instance_with_destroy(class_name, attributes, false)
     }
@@ -457,12 +462,17 @@ impl Value {
     /// not from this constructor — so this never reuses another holder's cell.
     pub(crate) fn make_instance_with_id(
         class_name: Symbol,
-        attributes: HashMap<String, Value>,
+        attributes: impl Into<AttrMap>,
         id: u64,
     ) -> Self {
         Value::from_repr(ValueRepr::Instance {
             class_name,
-            attributes: crate::gc::Gc::new(InstanceAttrs::new(class_name, attributes, id, true)),
+            attributes: crate::gc::Gc::new(InstanceAttrs::new(
+                class_name,
+                attributes.into(),
+                id,
+                true,
+            )),
             id,
         })
     }
@@ -498,10 +508,10 @@ impl Value {
     pub(crate) fn write_back_sharing(
         attrs: &crate::gc::Gc<InstanceAttrs>,
         class_name: Symbol,
-        map: HashMap<String, Value>,
+        map: impl Into<AttrMap>,
         id: u64,
     ) -> Value {
-        attrs.commit_attrs(map);
+        attrs.commit_attrs(map.into());
         Value::instance_sharing_cell(attrs, class_name, id)
     }
 
@@ -528,7 +538,7 @@ impl Value {
 
     fn make_instance_with_destroy(
         class_name: Symbol,
-        attributes: HashMap<String, Value>,
+        attributes: impl Into<AttrMap>,
         queue_destroy: bool,
     ) -> Self {
         let id = next_instance_id();
@@ -536,7 +546,7 @@ impl Value {
             class_name,
             attributes: crate::gc::Gc::new(InstanceAttrs::new(
                 class_name,
-                attributes,
+                attributes.into(),
                 id,
                 queue_destroy,
             )),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -8,8 +8,8 @@ use crate::opcode::{CompiledCode, CompiledFunction, OpCode};
 use crate::runtime;
 use crate::symbol::Symbol;
 use crate::value::{
-    ArrayKind, EnumValue, GatherCoroutineState, JunctionKind, LazyList, RuntimeError, Value,
-    ValueView, make_rat,
+    ArrayKind, AttrMap, EnumValue, GatherCoroutineState, JunctionKind, LazyList, RuntimeError,
+    Value, ValueView, make_rat,
 };
 use num_traits::{Signed, Zero};
 

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -310,7 +310,7 @@ impl Interpreter {
                 let proxy_attrs = match (&reconciled, &attrs_cell) {
                     (Some(m), _) => m.clone(),
                     (None, Some(cell)) => cell.to_map(),
-                    (None, None) => HashMap::new(),
+                    (None, None) => AttrMap::new(),
                 };
                 return loan_env!(self, proxy_fetch(fetcher, None, cn, &proxy_attrs, id));
             }

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -330,7 +330,7 @@ impl Interpreter {
                         };
                         let attributes = match target.view() {
                             ValueView::Instance { attributes, .. } => attributes.to_map(),
-                            _ => std::collections::HashMap::new(),
+                            _ => AttrMap::new(),
                         };
                         let invocant_for_dispatch = if attributes.is_empty() {
                             Value::package(class_sym)
@@ -375,7 +375,7 @@ impl Interpreter {
                                 let proxy_attrs = match (&reconciled, &attrs_cell) {
                                     (Some(m), _) => m.clone(),
                                     (None, Some(cell)) => cell.to_map(),
-                                    (None, None) => std::collections::HashMap::new(),
+                                    (None, None) => AttrMap::new(),
                                 };
                                 return loan_env!(
                                     self,

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -266,7 +266,7 @@ impl Interpreter {
                         };
                         let attributes = match target.view() {
                             ValueView::Instance { attributes, .. } => attributes.to_map(),
-                            _ => std::collections::HashMap::new(),
+                            _ => AttrMap::new(),
                         };
                         let invocant_for_dispatch = if attributes.is_empty() {
                             Value::package(class_sym)
@@ -311,7 +311,7 @@ impl Interpreter {
                                 let proxy_attrs = match (&reconciled, &attrs_cell) {
                                     (Some(m), _) => m.clone(),
                                     (None, Some(cell)) => cell.to_map(),
-                                    (None, None) => std::collections::HashMap::new(),
+                                    (None, None) => AttrMap::new(),
                                 };
                                 return loan_env!(
                                     self,
@@ -378,7 +378,7 @@ impl Interpreter {
                 };
                 let attributes = match target.view() {
                     ValueView::Instance { attributes, .. } => attributes.to_map(),
-                    _ => std::collections::HashMap::new(),
+                    _ => AttrMap::new(),
                 };
                 let invocant_for_dispatch = if attributes.is_empty() {
                     Value::package(class_sym)
@@ -421,7 +421,7 @@ impl Interpreter {
                         let proxy_attrs = match (&reconciled, &attrs_cell) {
                             (Some(m), _) => m.clone(),
                             (None, Some(cell)) => cell.to_map(),
-                            (None, None) => std::collections::HashMap::new(),
+                            (None, None) => AttrMap::new(),
                         };
                         return loan_env!(self, proxy_fetch(fetcher, None, cn, &proxy_attrs, id));
                     }

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -98,11 +98,11 @@ impl Interpreter {
     pub(crate) fn vm_run_instance_method(
         &mut self,
         receiver_class_name: &str,
-        attributes: HashMap<String, Value>,
+        attributes: AttrMap,
         method_name: &str,
         args: Vec<Value>,
         invocant: Option<Value>,
-    ) -> Result<(Value, HashMap<String, Value>), RuntimeError> {
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         self.loan_env_for(|i| {
             i.run_instance_method(receiver_class_name, attributes, method_name, args, invocant)
         })

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2267,7 +2267,7 @@ impl Interpreter {
                     let cn = class_name.unwrap();
                     let attrs = match val.view() {
                         ValueView::Instance { attributes, .. } => attributes.to_map(),
-                        _ => std::collections::HashMap::new(),
+                        _ => AttrMap::new(),
                     };
                     match self.vm_run_instance_method(
                         &cn.resolve(),
@@ -2544,7 +2544,7 @@ impl Interpreter {
                     if let Some(cn) = sink_class {
                         let attrs = match val.view() {
                             ValueView::Instance { attributes, .. } => attributes.to_map(),
-                            _ => std::collections::HashMap::new(),
+                            _ => AttrMap::new(),
                         };
                         // `sink` can mutate a captured-outer caller lexical by
                         // name (`my @reg; method sink { @reg.push(...) }`) via

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::AttrMap;
 
 pub(super) const ATTR_ALIAS_META_PREFIX: &str = "__mutsu_attr_alias::";
 
@@ -13,11 +14,11 @@ impl Interpreter {
         method_name: &str,
         method_def: &crate::runtime::MethodDef,
         cc: &CompiledCode,
-        mut attributes: HashMap<String, Value>,
+        mut attributes: AttrMap,
         args: Vec<Value>,
         invocant: Option<Value>,
         compiled_fns: &HashMap<String, CompiledFunction>,
-    ) -> Result<(Value, Option<HashMap<String, Value>>), RuntimeError> {
+    ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
         // Slice F: the rw-writeback source list is drained by the CallMethod /
         // CallMethodMut op right after this dispatch returns, so it must hold
         // only this call's sources. Clear any leftover from a sibling whose call
@@ -413,6 +414,7 @@ impl Interpreter {
 
         // Bind attributes
         for (attr_name, attr_val) in &attributes {
+            let attr_name = attr_name.as_str();
             // Skip class-qualified private attribute entries (ClassName\0attrName)
             // — these are handled below when binding $!attr for the owner class.
             if attr_name.contains('\0') {
@@ -465,6 +467,7 @@ impl Interpreter {
         let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
         if any_attr_defaults {
             for attr_name in attributes.keys() {
+                let attr_name = attr_name.as_str();
                 if attr_name.contains('\0') || attr_name.starts_with(ATTR_ALIAS_META_PREFIX) {
                     continue;
                 }
@@ -854,7 +857,7 @@ impl Interpreter {
     /// consumer that needs the post-method map (proxy_fetch) re-snapshots the
     /// live cell on demand instead — so the common exit pays no `to_map()`
     /// (full attr-map clone) at all.
-    fn reconcile_attrs(&self, base: &Value, code: &CompiledCode) -> Option<HashMap<String, Value>> {
+    fn reconcile_attrs(&self, base: &Value, code: &CompiledCode) -> Option<AttrMap> {
         let ValueView::Instance {
             attributes: cell, ..
         } = base.view()
@@ -885,14 +888,15 @@ impl Interpreter {
         // under the cell's read guard (attr_env_or_local touches only
         // env/locals, never the cell), so no map clone is materialized when —
         // as in the overwhelmingly common case — no `:=` binding exists.
-        let mut overrides: Vec<(String, Value)> = Vec::new();
+        let mut overrides: Vec<(crate::symbol::Symbol, Value)> = Vec::new();
         {
             let cell_map = cell.as_map();
             for k in cell_map.keys() {
-                if k.starts_with(ATTR_ALIAS_META_PREFIX) {
+                let ks = k.as_str();
+                if ks.starts_with(ATTR_ALIAS_META_PREFIX) {
                     continue;
                 }
-                let bare = k.rsplit('\0').next().unwrap_or(k);
+                let bare = ks.rsplit('\0').next().unwrap_or(ks);
                 // Sigilless (`has $x` → bare `x`) and twigil (`$!x`/`@.x`/…) keys
                 // may hold the `:=` ContainerRef alias.
                 let candidates = [
@@ -908,7 +912,7 @@ impl Interpreter {
                     if let Some(v) = self.attr_env_or_local(code, &key)
                         && v.is_container_ref()
                     {
-                        overrides.push((k.clone(), v));
+                        overrides.push((*k, v));
                         break;
                     }
                 }
@@ -1021,7 +1025,7 @@ impl Interpreter {
         base: Value,
         compiled_fns: &HashMap<String, CompiledFunction>,
         can_skip_merge: bool,
-    ) -> Result<(Value, Option<HashMap<String, Value>>), RuntimeError> {
+    ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
         let attrs_cell = match base.view() {
             ValueView::Instance { attributes, .. } => Some(attributes.clone()),
             _ => None,
@@ -1291,11 +1295,11 @@ impl Interpreter {
         // the program declaring ANY attribute default (see the slow path).
         let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
         if any_attr_defaults && let Some(cell) = &attrs_cell {
-            let attr_names: Vec<String> = cell
+            let attr_names: Vec<&'static str> = cell
                 .as_map()
                 .keys()
+                .map(|k| k.as_str())
                 .filter(|k| !k.contains('\0') && !k.starts_with(ATTR_ALIAS_META_PREFIX))
-                .cloned()
                 .collect();
             for attr_name in &attr_names {
                 let default_val = self
@@ -1591,7 +1595,7 @@ pub(crate) fn cheaply_unchanged(old: &Value, new: &Value) -> bool {
 /// form of the former per-call set build, which inserted all 6 twigil forms
 /// for every attribute key (skipping class-qualified `"C\0attr"` storage keys
 /// and `__mutsu_attr_alias::` metadata keys).
-fn attr_twigil_local(attributes: &HashMap<String, Value>, s: &str) -> bool {
+fn attr_twigil_local(attributes: &AttrMap, s: &str) -> bool {
     let bare = match s.as_bytes() {
         [b'@' | b'%', b'!' | b'.', ..] => &s[2..],
         [b'!' | b'.', ..] => &s[1..],
@@ -1607,8 +1611,9 @@ fn attr_twigil_local(attributes: &HashMap<String, Value>, s: &str) -> bool {
 /// or the `<attr>` suffix of such a key. Predicate form of the former set
 /// build's alias branch (slow path only — the fast path gate excludes
 /// alias-carrying instances).
-fn attr_alias_local(attributes: &HashMap<String, Value>, s: &str) -> bool {
+fn attr_alias_local(attributes: &AttrMap, s: &str) -> bool {
     attributes.iter().any(|(k, v)| {
+        let k = k.as_str();
         !k.contains('\0')
             && k.strip_prefix(ATTR_ALIAS_META_PREFIX)
                 .is_some_and(|actual| {

--- a/src/vm/vm_react_supply_helpers.rs
+++ b/src/vm/vm_react_supply_helpers.rs
@@ -3,9 +3,10 @@
 use super::*;
 use crate::runtime::native_methods::next_supplier_id;
 use crate::runtime::subtest::{ReactSubscription, StreamConsumer};
+use crate::value::AttrMap;
 
 impl Interpreter {
-    pub(super) fn extract_head_limit(attributes: &HashMap<String, Value>) -> Option<usize> {
+    pub(super) fn extract_head_limit(attributes: &AttrMap) -> Option<usize> {
         if let Some(ValueView::Int(n)) = attributes.get("head_limit").map(Value::view) {
             Some(n as usize)
         } else {
@@ -13,9 +14,7 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn extract_supply_on_close_callbacks(
-        attributes: &HashMap<String, Value>,
-    ) -> Vec<Value> {
+    pub(super) fn extract_supply_on_close_callbacks(attributes: &AttrMap) -> Vec<Value> {
         if let Some(ValueView::Array(callbacks, ..)) =
             attributes.get("on_close_callbacks").map(Value::view)
         {
@@ -35,10 +34,7 @@ impl Interpreter {
 
     /// Resolve the supply_id to use for channel lookup.
     /// For a "lines" supply, use the parent_supply_id.
-    pub(super) fn resolve_supply_channel_id(
-        &self,
-        attributes: &HashMap<String, Value>,
-    ) -> Option<u64> {
+    pub(super) fn resolve_supply_channel_id(&self, attributes: &AttrMap) -> Option<u64> {
         // If this is a "lines" supply, use the parent's supply_id
         if let Some(ValueView::Int(parent_id)) = attributes.get("parent_supply_id").map(Value::view)
         {
@@ -217,7 +213,7 @@ impl Interpreter {
 
     pub(super) fn replay_static_supply(
         &mut self,
-        attributes: &HashMap<String, Value>,
+        attributes: &AttrMap,
         callback: &Value,
         last_callbacks: &[Value],
     ) -> Result<bool, RuntimeError> {

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -1,4 +1,12 @@
 use super::*;
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+thread_local! {
+    /// Reusable scratch buffer for the qualified private-attribute key
+    /// (`Owner\0attr`). Assembling it here keeps the hot `$!x` read allocation-free.
+    static QUALIFIED_ATTR_KEY: RefCell<String> = const { RefCell::new(String::new()) };
+}
 
 impl Interpreter {
     /// Assign a single value into a stack-computed Hash/Array `target` at `key`
@@ -90,47 +98,42 @@ impl Interpreter {
     /// cell stores attributes under the bare name, so all six twigil forms of an
     /// attribute resolve to the same cell slot.
     pub(super) fn attr_twigil_base(name: &str) -> Option<(&str, bool)> {
-        // Optional `@`/`%` sigil, then the `!` (private) / `.` (public) twigil.
-        let rest = name
-            .strip_prefix('@')
-            .or_else(|| name.strip_prefix('%'))
-            .unwrap_or(name);
-        let (bare, is_private) = if let Some(b) = rest.strip_prefix('!') {
-            (b, true)
-        } else if let Some(b) = rest.strip_prefix('.') {
-            (b, false)
-        } else {
-            return None;
-        };
-        // Attribute names are ordinary identifiers (start alpha/underscore). This
-        // filters out `!=`, the bare `!`/`.` special vars, and `__mutsu_` keys.
-        match bare.chars().next() {
-            Some(c) if c.is_alphabetic() || c == '_' => Some((bare, is_private)),
-            _ => None,
-        }
+        crate::value::attr_twigil_base(name)
     }
 
-    /// Resolve the cell key for an attribute on the given instance, preferring
-    /// the method owner class's qualified private key when present (Parent/Child
-    /// same-named `$!priv` disambiguation), matching the order used when method
-    /// frames materialize attributes. Returns `None` when the attribute does not
-    /// exist in the cell (so non-attribute `.foo`/`!foo` lvalues fall through to
-    /// the normal local/env handling).
-    pub(crate) fn resolve_attr_cell_key(
+    /// The interned qualified private-attribute key `Owner\0bare`. Assembled in a
+    /// reusable thread-local buffer so the hot `$!x` read does not heap-allocate
+    /// a fresh key string on every access (it used to `format!` one).
+    fn qualified_attr_symbol(owner: &str, bare: &str) -> crate::symbol::Symbol {
+        QUALIFIED_ATTR_KEY.with(|buf| {
+            let mut buf = buf.borrow_mut();
+            buf.clear();
+            buf.push_str(owner);
+            buf.push('\0');
+            buf.push_str(bare);
+            crate::symbol::Symbol::intern(&buf)
+        })
+    }
+
+    /// Pick the cell key actually present in `map` for the attribute `(bare,
+    /// is_private)`, preferring the method owner class's qualified private key
+    /// when present (Parent/Child same-named `$!priv` disambiguation), matching
+    /// the order used when method frames materialize attributes. `None` when the
+    /// attribute does not exist in the cell.
+    fn attr_key_in_map(
         &self,
-        name: &str,
-        attrs: &crate::value::InstanceAttrs,
-    ) -> Option<String> {
-        let (bare, is_private) = Self::attr_twigil_base(name)?;
-        let map = attrs.as_map();
-        if is_private && let Some(owner) = self.method_class_stack_top() {
-            let qkey = format!("{}\0{}", owner, bare);
-            if map.contains_key(&qkey) {
-                return Some(qkey);
+        bare: crate::symbol::Symbol,
+        is_private: bool,
+        map: &crate::value::AttrMap,
+    ) -> Option<crate::symbol::Symbol> {
+        if is_private && let Some(owner) = self.method_class_stack_top_str() {
+            let qsym = Self::qualified_attr_symbol(owner, bare.as_str());
+            if map.contains_key(qsym) {
+                return Some(qsym);
             }
         }
         if map.contains_key(bare) {
-            Some(bare.to_string())
+            Some(bare)
         } else {
             None
         }
@@ -157,10 +160,43 @@ impl Interpreter {
     /// Mixin wrapping one), and the attribute exists in the cell.
     pub(super) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
         let twigil = self.canonical_attr_twigil(name)?;
+        let (bare, is_private) = Self::attr_twigil_base(&twigil)?;
+        self.read_attr_cell_by_key(crate::symbol::Symbol::intern(bare), is_private)
+    }
+
+    /// Slot form of [`Self::read_self_attr_cell`]: the attribute `Symbol` comes
+    /// pre-resolved from the chunk's local-slot table, so the hot `$!x` / `$.x`
+    /// read parses no twigil, interns no string and allocates nothing. Falls back
+    /// to the name-keyed path only for sigilless attributes (`has $x`), whose
+    /// alias must be followed through the runtime alias table.
+    pub(super) fn read_self_attr_cell_slot(
+        &self,
+        code: &CompiledCode,
+        idx: usize,
+    ) -> Option<Value> {
+        match code.local_attr_key(idx) {
+            Some((bare, is_private)) => self.read_attr_cell_by_key(bare, is_private),
+            None => {
+                if !self.sigilless_attrs_active {
+                    return None;
+                }
+                self.read_self_attr_cell(code.locals.get(idx)?)
+            }
+        }
+    }
+
+    /// The shared tail of both read paths: resolve `(bare, is_private)` against
+    /// `self`'s live cell under a single read guard and clone the value out.
+    fn read_attr_cell_by_key(
+        &self,
+        bare: crate::symbol::Symbol,
+        is_private: bool,
+    ) -> Option<Value> {
         let self_val = self.get_env_with_main_alias("self")?;
         let attributes = Self::self_instance_attrs(&self_val)?;
-        let key = self.resolve_attr_cell_key(&twigil, &attributes)?;
-        attributes.as_map().get(&key).cloned()
+        let map = attributes.as_map();
+        let key = self.attr_key_in_map(bare, is_private, &map)?;
+        map.get(key).cloned()
     }
 
     /// Map a variable name to its canonical attribute-twigil form for cell access:
@@ -169,14 +205,16 @@ impl Interpreter {
     /// `!x` twigil. Returns `None` for ordinary (non-attribute) names. The
     /// sigilless lookup is gated on `sigilless_attrs_active` so the common case
     /// (no sigilless attributes) costs only a string check on the hot read path.
-    pub(crate) fn canonical_attr_twigil(&self, name: &str) -> Option<String> {
+    pub(crate) fn canonical_attr_twigil<'n>(&self, name: &'n str) -> Option<Cow<'n, str>> {
         if Self::attr_twigil_base(name).is_some() {
-            return Some(name.to_string());
+            // The overwhelmingly common case: the name already *is* the twigil.
+            // Borrow it — this used to allocate a `String` on every attribute read.
+            return Some(Cow::Borrowed(name));
         }
         if !self.sigilless_attrs_active {
             return None;
         }
-        self.sigilless_attr_twigil(name)
+        self.sigilless_attr_twigil(name).map(Cow::Owned)
     }
 
     /// Follow the `__mutsu_sigilless_alias::` chain from a bare sigilless name
@@ -216,35 +254,45 @@ impl Interpreter {
     /// No-op when `name` is not a scalar attr-twigil, `self` is not a concrete
     /// instance, or the attribute does not exist on `self`.
     pub(super) fn write_self_attr_cell(&self, name: &str, val: Value) {
-        if Self::attr_twigil_base(name).is_none() {
+        let Some((bare, is_private)) = Self::attr_twigil_base(name) else {
             return;
-        }
+        };
+        self.write_attr_cell_by_key(crate::symbol::Symbol::intern(bare), is_private, val);
+    }
+
+    /// The shared tail of both write paths. Unwraps a `Mixin` self to the inner
+    /// instance's shared cell so a runtime-`does` mixin method's `$.attr`/`$!attr`
+    /// write persists (the cell is an `Arc<RwLock>` shared with the caller's
+    /// Mixin). No-op when `self` is not a concrete instance or the attribute does
+    /// not exist on it.
+    fn write_attr_cell_by_key(&self, bare: crate::symbol::Symbol, is_private: bool, val: Value) {
         let Some(self_val) = self.get_env_with_main_alias("self") else {
             return;
         };
-        // Unwrap a `Mixin` self to the inner instance's shared cell so a
-        // runtime-`does` mixin method's `$.attr`/`$!attr` write persists (the cell
-        // is an `Arc<RwLock>` shared with the caller's Mixin).
         let Some(attributes) = Self::self_instance_attrs(&self_val) else {
             return;
         };
-        if let Some(key) = self.resolve_attr_cell_key(name, &attributes) {
+        let key = {
+            let map = attributes.as_map();
+            self.attr_key_in_map(bare, is_private, &map)
+        };
+        if let Some(key) = key {
             attributes.insert(key, val);
         }
     }
 
     /// Mirror the current local slot value into `self`'s shared cell for a scalar
-    /// attribute, after the normal write logic has finalized the slot.
+    /// attribute, after the normal write logic has finalized the slot. The
+    /// attribute `Symbol` is pre-resolved per chunk, so a non-attribute slot (the
+    /// common case) costs one table load and an attribute slot allocates nothing.
     pub(super) fn mirror_attr_local_to_cell(&self, code: &CompiledCode, idx: usize) {
-        let Some(name) = code.locals.get(idx) else {
+        let Some((bare, is_private)) = code.local_attr_key(idx) else {
             return;
         };
-        if Self::attr_twigil_base(name).is_none()
-            || Self::is_non_mirrorable_attr_value(&self.locals[idx])
-        {
+        if Self::is_non_mirrorable_attr_value(&self.locals[idx]) {
             return;
         }
-        self.write_self_attr_cell(&name.clone(), self.locals[idx].clone());
+        self.write_attr_cell_by_key(bare, is_private, self.locals[idx].clone());
     }
 
     /// Mirror the finalized value of the variable named `name` into `self`'s

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1458,7 +1458,7 @@ impl Interpreter {
                         let display = format!("{}()", cn);
                         return Err(RuntimeError::assignment_ro_typename(&cn, &display));
                     }
-                    let hash_map: HashMap<String, Value> = HashMap::clone(&attributes.as_map());
+                    let hash_map: HashMap<String, Value> = HashMap::from(&*attributes.as_map());
                     let hash_val = Value::hash(hash_map);
                     self.env_mut().insert(var_name.clone(), hash_val);
                 }

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -168,7 +168,9 @@ impl Interpreter {
         // bindings keep their ContainerRef handling. The cell lookup returns None
         // for non-attribute names and when `self` is not an instance.
         if !self.locals[idx].is_container_ref()
-            && let Some(cell_val) = self.read_self_attr_cell(name)
+            // Slot form: the attribute `Symbol` is pre-resolved per chunk, so
+            // this read parses no twigil and interns no string (ADR-0006 §2.4).
+            && let Some(cell_val) = self.read_self_attr_cell_slot(code, idx)
         {
             self.locals[idx] = cell_val.clone();
             self.stack.push(cell_val);


### PR DESCRIPTION
Instance attributes were a `HashMap<String, Value>`: every lookup hashed the
attribute name with SipHash and then memcmp'd it, every construction
heap-allocated one `String` per attribute, and every `to_map()` / `commit_attrs()`
snapshot cloned all of those `String`s again. On `benchmarks/bench-class.raku`
that showed up as 5.2% `__memcmp_avx2` plus a large share of the ~20% spent in
the allocator (docs/perf-callpath-scouting.md §2.4).

The storage is now `AttrMap` — an `FxHashMap<Symbol, Value>` newtype: hashing is
a `u32`, key comparison is an integer compare, and cloning a key is a `Copy`.

To keep the blast radius bounded, `AttrMap`'s inherent `get` / `insert` /
`contains_key` / `remove` / `entry` are generic over a new `AttrKey` trait,
implemented for `Symbol` (the hot paths, which already hold one) *and* for
`&str` / `String` (the hundreds of cold construction sites: typed exceptions,
native-type constructors, introspection). Those sites keep their `"literal"`
spelling unchanged. `Value::make_instance` and friends take `impl Into<AttrMap>`,
so the ~800 `HashMap<String, Value>`-building call sites are untouched and intern
their keys once, at construction. A `&str` lookup uses the new
`Symbol::lookup` (a probe that does *not* intern), so a miss on a name nothing
else uses cannot grow the append-only symbol table.

The hot `$!x` / `$.x` paths are made Symbol-native rather than re-interning:

- `CompiledCode::local_attr_keys` resolves each local slot's attribute twigil to
  a `(bare Symbol, is_private)` pair once per chunk (mirroring the existing
  `const_sym` table), and `read_self_attr_cell_slot` / `mirror_attr_local_to_cell`
  read it directly — so an attribute access parses no twigil and interns no
  string.
- `canonical_attr_twigil` returns a `Cow` instead of allocating a `String` per read.
- The qualified private key (`Owner\0attr`) is assembled in a reusable
  thread-local buffer instead of a per-access `format!`.
- Added `method_class_stack_top_str`, so resolving a private attribute no longer
  clones the owner class name into a fresh `String` on every read.
- Read + key-resolve now share one attribute read guard instead of taking two.

Measured with the ADR-0006 protocol (`perf stat -e instructions:u`, release,
`taskset -c 0`, mean of 7 runs, cpu_core PMU):

| bench             | main          | this branch   | delta   |
|-------------------|---------------|---------------|---------|
| bench-class.raku  | 1,938,357,767 | 1,886,979,165 | -2.65%  |
| method-call.raku  | 1,859,526,176 | 1,644,228,765 | -11.58% |
| bench-fib.raku    | 4,132,450,120 | 4,059,443,553 | -1.77%  |

Attribute iteration order was already unspecified (it was a `HashMap`); the
declaration order that `.raku` / `.gist` print comes from `ClassDef.attributes`
(a `Vec`), so instance reprs are byte-identical to `main`.

## Validation

- `make test`: PASS (1685 files, 16606 tests)
- All 121 whitelisted `S12-*` / `S14-*` roast files: PASS
- `MUTSU_GC=on` on the whitelisted `S12-attributes` / `S12-class` / `S12-construction` set (42 files) and on `t/class*.t t/attribute*.t t/role*.t t/destroy*.t`: PASS
- `S12-attributes/trusts.t` and `S12-class/open_closed.t` still fail with exactly the same subtest counts as `main` (neither is whitelisted; pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxjMLiSGgdYKFw8a99HBTJ
