### PR TITLE
perf(vm): give the argument varref a first-class Value representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.2.34"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/docs/perf-callpath-scouting.md
+++ b/docs/perf-callpath-scouting.md
@@ -18,6 +18,18 @@ decide a 3% change).
 > formatting and hashing**, which #4492–#4495 removed for gains of 24–39%. The
 > corrected model is recorded here so the next session does not re-derive it.
 
+> **2026-07-14 update (bench-tak beats raku).** §3.2 below said the remaining 28%
+> of tak was "per-call allocation churn — profile the callers before guessing".
+> Profiling them said: **it was not the call frame at all, it was the argument
+> wrapper.** `OpCode::WrapVarRef` — which runs once per *variable passed as an
+> argument*, 99.7% of tak's interpreted opcodes — encoded "a reference to a named
+> variable" as a `Capture` holding two magic string keys, and so allocated four
+> `String`s, a `HashMap` + `RawTable`, an empty `Vec` and a `Capture` box, and
+> SipHashed two 20-byte key strings, **per argument**. Giving it a first-class
+> `Value` variant took bench-tak from 4.94G to 2.73G `instructions:u` (**−45%**)
+> and 1.70× raku to **0.83×**. The name-keyed-metadata lesson held once more; §3.1
+> was the wrong first slice, and §3.2 was the right one for the wrong reason.
+
 ## 1. What landed (2026-07-13/14) and what it bought
 
 | PR | change | effect |
@@ -36,20 +48,69 @@ hashing them. Every remaining `format!("__mutsu_…::{name}")` on a per-op path 
 a candidate; the fix is always the same (pre-intern the `Symbol` per local slot,
 plus a monotonic "was such a key ever created" gate).
 
-## 2. The profile now (post-#4495, release, JIT on, one P-core)
+**And it generalizes past `format!`.** The same anti-pattern also hides in
+*values*: any runtime concept encoded as "a `Capture` / `Hash` with magic string
+keys" pays the identical `String` + `RawTable` + SipHash tax on every use. That
+is exactly what `WrapVarRef` was (see §1a). When looking for the next win, grep
+for magic-string keys on a per-op path, not just for `format!`.
 
-### bench-tak — the next target (mutsu 0.36s vs raku 0.20s, **1.8×**)
+## 1a. The argument wrapper (2026-07-14) — how bench-tak passed raku
+
+`OpCode::WrapVarRef` tags a call argument with the *name* of the variable it came
+from, so `is rw` / `is raw` / `:=` / `\($a)` can alias the caller's container
+instead of copying its value. It runs once per variable passed as an argument —
+**593,634 times in bench-tak, 99.7% of all interpreted opcodes** (the JIT traps
+out to the interpreter helper for it). It was implemented as:
+
+```rust
+let name = Self::const_str(code, name_idx).to_string();      // String
+let mut named = std::collections::HashMap::new();            // std HashMap = SipHash
+named.insert("__mutsu_varref_name".to_string(), Value::str(name));   // 2 String + 1 Value::str
+named.insert("__mutsu_varref_value".to_string(), value);             // 1 String
+self.stack.push(Value::capture(Vec::new(), named));          // Vec + Capture box
+```
+
+— four `String` allocations, a `HashMap` with its `RawTable`, an empty positional
+`Vec`, a `Capture` box, and two SipHashes over 20-byte string keys, **per
+argument**, immediately unwrapped again by the binder. That single opcode was
+most of tak's "28% allocation churn" and *all* of its SipHash.
+
+"A reference to a named variable" is a first-class concept in Raku's binder, so
+it now has a first-class representation: `ValueRepr::VarRef { name: Symbol, value,
+index }` (one `Arc` payload, no hashing), with the 42 magic-key probe sites across
+16 files replaced by typed destructures. The wrapper is *transparent* — it
+answers `.WHAT`, `isa`, truthiness and stringification as its inner value, where
+before it accidentally answered as a `Capture`.
+
+| | before | after |
+|---|---|---|
+| bench-tak `instructions:u` | 4.94G | **2.73G** (−44.7%) |
+| bench-tak wall (release, one P-core) | 0.40s | **0.20s** |
+| vs. raku (0.24s) | 1.70× | **0.83×** |
+
+It is broadly a call-path win, not a tak-specific one: method-call 0.86× → 0.65×
+raku, bench-class 0.84× → 0.59×. Pinned by `t/varref-binding.t`.
+
+## 2. The profile now (post-VarRef, release, JIT on, one P-core)
+
+### bench-tak (mutsu 0.20s vs raku 0.24s, **0.83×**)
 
 | symbol | % | what it really is |
 |---|---|---|
-| `call_compiled_function_positional_light` | 12.5 | the light-call frame itself |
-| `_int_malloc` + `malloc` + `_int_free` + `cfree` | **28.4** | per-call allocation churn |
-| **SipHash `Hasher::write`** (+ `hash_one` ×2 ≈ 4.6) | **6.7** | see §3.1 — the `compiled_fns` lookup |
-| `exec_call_func_op` | 3.2 | dispatch |
-| `Env::scoped_child` | 2.9 | per-call env overlay |
-| `arg_is_container_value` | 2.9 | per-arg call-eligibility scan |
-| `indexed_varref_from_value` | 2.7 | per-arg signature binding |
-| `hashbrown::HashMap::insert` | 2.6 | |
+| `call_compiled_function_positional_light` | 16.7 | the light-call frame itself |
+| **`Env::get_sym`** (two inlined copies) | **10.0** | the per-call **locals seed loop** — see §3.0 |
+| `_int_free` + `cfree` + `malloc` | 11.7 | what is left of the allocator (was 28.4) |
+| `exec_get_local_op` | 5.2 | |
+| `exec_call_func_op` | 3.7 | dispatch |
+| `Env::scoped_child` + `drop_in_place<Env>` | 5.1 | per-call env overlay |
+| `arc_op::<VarRefBox>` + `payload_op` | 5.7 | the one remaining varref alloc/drop |
+| SipHash `Hasher::write` | 1.9 | the `compiled_fns` lookup (§3.1) — now minor |
+
+The shape changed: with the string work gone, what dominates is now genuinely
+**the per-call env overlay** — `scoped_child` + the seed loop's `get_sym` per
+local per call + the overlay drop, ~15% together. §4's "disproved" note still
+stands for the *assignment* benchmarks, but on a call-heavy one the overlay is
+now the top structural cost, and §3.0 is the next slice.
 
 ### bench-mandelbrot (assignment-dominated)
 
@@ -58,6 +119,31 @@ itself (~11%), the allocator, and `Env::get_sym`/`memcmp`/SipHash from the
 remaining `String`-keyed side maps (`var_type_constraints`, `var_defaults`).
 
 ## 3. The slices, in order
+
+### 3.0 The per-call locals seed loop — **do this first**
+
+`call_compiled_function_positional_light` seeds every one of the callee's local
+slots from the env before running the body:
+
+```rust
+for (i, sym) in cf.code.locals_sym.iter().enumerate() {
+    if let Some(val) = self.env().get_sym(*sym) { self.locals[i] = val.clone(); }
+}
+```
+
+so each call walks the whole parent env chain — and then `GLOBAL_BASE` — once
+*per local*, to answer "does a caller variable of this name shadow into me?".
+That is the 10% `Env::get_sym`. For a routine whose locals are all its own
+(the overwhelmingly common case, and every benchmark here) the answer is always
+`None`, and the loop is pure loss. The fix is a compile-time predicate: a local
+slot only needs seeding if its name can be resolved from an enclosing scope
+(a captured outer, a `state`, an `our`) — bake that as a `locals_needs_seed`
+bitmask on `CompiledCode` and skip the probe otherwise. Gate on `instructions:u`
+for bench-tak / bench-fib / method-call.
+
+Note this is *adjacent to but not the same as* the lexical-scope slot campaign:
+it removes the read side of the overlay for the common case without touching
+`BlockScope`'s whole-`locals` clone.
 
 ### 3.1 `compiled_fns` is a `HashMap<String, CompiledFunction>` with the default hasher — **do this first**
 

--- a/src/runtime/builtins_system_run.rs
+++ b/src/runtime/builtins_system_run.rs
@@ -18,17 +18,7 @@ impl Interpreter {
         let mut positional: Vec<String> = Vec::new();
         let mut first_arg_io_path = false;
         for (idx, arg) in args.iter().enumerate() {
-            let arg = match arg.view() {
-                ValueView::Capture { named, .. }
-                    if matches!(
-                        named.get("__mutsu_varref_name").map(Value::view),
-                        Some(ValueView::Str(_))
-                    ) && named.contains_key("__mutsu_varref_value") =>
-                {
-                    named.get("__mutsu_varref_value").unwrap_or(arg)
-                }
-                _ => arg,
-            };
+            let arg = arg.unwrap_varref();
             match arg.view() {
                 ValueView::Hash(_) | ValueView::Pair(_, _) => {}
                 ValueView::Instance {

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -311,18 +311,15 @@ impl Interpreter {
         total
     }
 
-    /// Unwrap a VarRef Capture wrapper to get the inner value and the source
+    /// Unwrap a [`Value::varref`] wrapper to get the inner value and the source
     /// variable's declared type constraint (if any) for dispatch.
     fn unwrap_varref_for_dispatch(&self, value: &Value) -> (Value, Option<String>) {
-        if let ValueView::Capture { positional, named } = value.view()
-            && positional.is_empty()
-            && let Some(var_name) = named.get("__mutsu_varref_name").and_then(|v| v.as_str())
-            && let Some(inner) = named.get("__mutsu_varref_value")
-        {
-            let var_type = self.var_type_constraint_fast(var_name).cloned();
-            (inner.clone(), var_type)
-        } else {
-            (value.clone(), None)
+        match value.as_varref() {
+            Some((name, inner, _)) => {
+                let var_type = name.with_str(|n| self.var_type_constraint_fast(n).cloned());
+                (inner.clone(), var_type)
+            }
+            None => (value.clone(), None),
         }
     }
 

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3176,10 +3176,11 @@ impl Interpreter {
             && let Some(source_name) = Self::var_target_from_meta_value(&target)
         {
             let source_value = self.env.get(&source_name).cloned().unwrap_or(Value::NIL);
-            let mut named = std::collections::HashMap::new();
-            named.insert("__mutsu_varref_name".to_string(), Value::str(source_name));
-            named.insert("__mutsu_varref_value".to_string(), source_value);
-            return Ok(Value::capture(Vec::new(), named));
+            return Ok(Value::varref(
+                Symbol::intern(&source_name),
+                source_value,
+                None,
+            ));
         }
 
         // .join on LazyList

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -8,6 +8,12 @@ impl Interpreter {
         target: &Value,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // A `VarRef` is a transient binder wrapper, not a type of its own:
+        // introspect the variable's value.
+        if let ValueView::VarRef { value, .. } = target.view() {
+            let inner = value.clone();
+            return self.dispatch_what(&inner, args);
+        }
         if let Some(info) = self.container_type_metadata(target) {
             if let Some(declared) = info.declared_type {
                 return Ok(Value::package(Symbol::intern(&declared)));
@@ -31,6 +37,7 @@ impl Interpreter {
             }
         }
         let type_name: &str = match target.view() {
+            ValueView::VarRef { .. } => unreachable!("unwrapped above"),
             ValueView::Int(_) => "Int",
             ValueView::BigInt(_) => "Int",
             ValueView::Num(_) => "Num",

--- a/src/runtime/methods_signature_candidates.rs
+++ b/src/runtime/methods_signature_candidates.rs
@@ -52,14 +52,8 @@ impl Interpreter {
     }
 
     pub(super) fn varref_parts(value: &Value) -> Option<(String, Value)> {
-        if let ValueView::Capture { positional, named } = value.view()
-            && positional.is_empty()
-            && let Some(ValueView::Str(name)) = named.get("__mutsu_varref_name").map(Value::view)
-            && let Some(inner) = named.get("__mutsu_varref_value")
-        {
-            return Some((name.to_string(), inner.clone()));
-        }
-        None
+        let (name, inner, _) = value.as_varref()?;
+        Some((name.resolve(), inner.clone()))
     }
 
     pub(super) fn var_target_from_meta_value(value: &Value) -> Option<String> {

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -298,12 +298,9 @@ fn pointer_address(v: &Value) -> usize {
         }
         ValueView::Scalar(inner) => pointer_address(inner),
         ValueView::ContainerRef(cell) => cell.lock().ok().map(|g| pointer_address(&g)).unwrap_or(0),
-        // An `is rw` argument arrives as a varref Capture carrying the bound
+        // An `is rw` argument arrives as a `VarRef` carrying the bound
         // variable's current value.
-        ValueView::Capture { named, .. } => match named.get("__mutsu_varref_value") {
-            Some(inner) => pointer_address(inner),
-            None => 0,
-        },
+        ValueView::VarRef { value, .. } => pointer_address(value),
         _ => 0,
     }
 }
@@ -324,11 +321,7 @@ fn write_pointer_address(v: &Value, addr: usize) {
                 write_pointer_address(&g, addr);
             }
         }
-        ValueView::Capture { named, .. } => {
-            if let Some(inner) = named.get("__mutsu_varref_value") {
-                write_pointer_address(inner, addr);
-            }
-        }
+        ValueView::VarRef { value, .. } => write_pointer_address(value, addr),
         _ => {}
     }
 }
@@ -404,10 +397,7 @@ fn resolve_arg(v: &Value) -> Value {
     match v.view() {
         ValueView::Scalar(inner) => resolve_arg(inner),
         ValueView::ContainerRef(cell) => cell.lock().map(|g| resolve_arg(&g)).unwrap_or(Value::NIL),
-        ValueView::Capture { named, .. } => match named.get("__mutsu_varref_value") {
-            Some(inner) => resolve_arg(inner),
-            None => v.clone(),
-        },
+        ValueView::VarRef { value, .. } => resolve_arg(value),
         _ => v.clone(),
     }
 }

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -76,6 +76,9 @@ impl Interpreter {
     pub(in crate::runtime) fn signature_capture_like(
         value: &Value,
     ) -> Option<(Vec<Value>, HashMap<String, Value>)> {
+        // A variable argument arrives wrapped in a `VarRef` (see `Value::varref`);
+        // the signature is matched against the *value*, not the wrapper.
+        let value = value.unwrap_varref();
         match value.view() {
             ValueView::Capture { positional, named } => {
                 Some(((*positional).clone(), (*named).clone()))

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -83,19 +83,7 @@ impl Interpreter {
 
     pub(crate) fn unwrap_test_arg_value(value: &Value) -> Value {
         match value.view() {
-            ValueView::Capture { positional, named }
-                if positional.is_empty()
-                    && named
-                        .get("__mutsu_varref_name")
-                        .and_then(|v| v.as_str())
-                        .is_some()
-                    && named.contains_key("__mutsu_varref_value") =>
-            {
-                named
-                    .get("__mutsu_varref_value")
-                    .cloned()
-                    .unwrap_or(Value::NIL)
-            }
+            ValueView::VarRef { value, .. } => value.clone(),
             ValueView::Pair(key, val) => Value::pair(key.clone(), Self::unwrap_test_arg_value(val)),
             _ => value.clone(),
         }

--- a/src/runtime/test_functions/util.rs
+++ b/src/runtime/test_functions/util.rs
@@ -16,6 +16,9 @@ impl Interpreter {
         // Two calling conventions:
         //   1. doesn't-hang("code", $desc, ...)    -- Str first arg
         //   2. doesn't-hang(\($exe, '-e', $code), $desc, ...)  -- Capture first arg
+        // A variable argument (`doesn't-hang($capture, ...)`) arrives wrapped in a
+        // `VarRef`; the calling convention is decided by the value it wraps.
+        let first_arg = first_arg.unwrap_varref().clone();
         let (exe, cmd_args) = if let ValueView::Capture { positional, .. } = first_arg.view() {
             // Capture form: first element is exe, rest are args
             let exe_val = positional.first().cloned().unwrap_or(Value::NIL);

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -26,18 +26,8 @@ pub(in crate::runtime) fn varref_from_value(value: &Value) -> Option<(String, Va
 pub(in crate::runtime) fn indexed_varref_from_value(
     value: &Value,
 ) -> Option<(String, Value, Option<usize>)> {
-    if let ValueView::Capture { positional, named } = value.view()
-        && positional.is_empty()
-        && let Some(ValueView::Str(name)) = named.get("__mutsu_varref_name").map(Value::view)
-        && let Some(inner) = named.get("__mutsu_varref_value")
-    {
-        let source_index = match named.get("__mutsu_varref_index").map(Value::view) {
-            Some(ValueView::Int(i)) if i >= 0 => Some(i as usize),
-            _ => None,
-        };
-        return Some((name.to_string(), inner.clone(), source_index));
-    }
-    None
+    let (name, inner, index) = value.as_varref()?;
+    Some((name.resolve(), inner.clone(), index.map(|i| i as usize)))
 }
 
 /// Wrap an integer value to fit within a native integer type's range
@@ -93,11 +83,13 @@ pub(in crate::runtime) fn wrap_native_int_for_binding(
         .unwrap_or_else(|| Value::bigint(wrapped)))
 }
 
+/// Strip the [`Value::varref`] wrapper the caller tagged an lvalue argument
+/// with, once the binder has taken the source name it needs. On the light-call
+/// path this runs once per parameter, so it must not materialize the name.
 pub(crate) fn unwrap_varref_value(value: Value) -> Value {
-    if let Some((_, inner)) = varref_from_value(&value) {
-        inner
-    } else {
-        value
+    match value.as_varref() {
+        Some((_, inner, _)) => inner.clone(),
+        None => value,
     }
 }
 
@@ -188,13 +180,7 @@ pub(in crate::runtime) fn flatten_into_slurpy(values: &[Value], out: &mut Vec<Va
 }
 
 pub(crate) fn make_varref_value(name: String, value: Value, source_index: Option<usize>) -> Value {
-    let mut named = std::collections::HashMap::new();
-    named.insert("__mutsu_varref_name".to_string(), Value::str(name));
-    named.insert("__mutsu_varref_value".to_string(), value);
-    if let Some(i) = source_index {
-        named.insert("__mutsu_varref_index".to_string(), Value::int(i as i64));
-    }
-    Value::capture(Vec::new(), named)
+    Value::varref(Symbol::intern(&name), value, source_index.map(|i| i as u32))
 }
 
 /// Sentinel prefix marking a `*@v is rw`/`is raw` slurpy element writeback entry

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -451,15 +451,16 @@ pub(in crate::runtime) fn sub_signature_matches_value(
     }
     // Reject unexpected named arguments (for the multi-dispatch case where the
     // value is a Capture).  A named slurpy (`*%h`) accepts any named argument.
-    if let ValueView::Capture { named, .. } = value.view() {
+    // Read through the `VarRef` wrapper a variable argument arrives in, as the
+    // positional/named extraction above already does — this used to skip any
+    // `__mutsu_`-prefixed key instead, because a varref *was* a `Capture` whose
+    // named map held the wrapper's magic keys.
+    if let ValueView::Capture { named, .. } = value.unwrap_varref().view() {
         let has_named_slurpy = sub_params
             .iter()
             .any(|p| p.slurpy && (p.named || p.name.starts_with('%')));
         if !has_named_slurpy {
             for key in named.keys() {
-                if key.starts_with("__mutsu_") {
-                    continue;
-                }
                 let consumed = sub_params.iter().any(|p| {
                     p.named && p.name.trim_start_matches(|c: char| "$@%&".contains(c)) == key
                 });

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -2,6 +2,9 @@ use super::*;
 
 pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value.view() {
+        // A `VarRef` is a transient binder wrapper, not a type: report the type
+        // of the variable's value.
+        ValueView::VarRef { value, .. } => value_type_name(value),
         ValueView::Int(_) => "Int",
         ValueView::BigInt(_) => "Int",
         ValueView::Num(_) => "Num",
@@ -82,18 +85,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         ValueView::Channel(_) => "Channel",
         ValueView::Whatever => "Whatever",
         ValueView::HyperWhatever => "HyperWhatever",
-        ValueView::Capture { positional, named } => {
-            // Unwrap internal VarRef captures used by the VM for rw binding
-            if positional.is_empty()
-                && named
-                    .get("__mutsu_varref_name")
-                    .is_some_and(|v| matches!(v.view(), ValueView::Str(_)))
-                && let Some(inner) = named.get("__mutsu_varref_value")
-            {
-                return value_type_name(inner);
-            }
-            "Capture"
-        }
+        ValueView::Capture { .. } => "Capture",
         ValueView::Uni(u) => match u.form.as_str() {
             "NFC" => "NFC",
             "NFD" => "NFD",

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -353,6 +353,9 @@ fn has_terminating_decimal_bigint(denom: &NumBigInt) -> bool {
 impl Value {
     pub(crate) fn to_string_value(&self) -> String {
         match self.view() {
+            // A `VarRef` is a transient binder wrapper: it stringifies as the
+            // variable's value.
+            ValueView::VarRef { value, .. } => value.to_string_value(),
             ValueView::Int(i) => i.to_string(),
             ValueView::BigInt(n) => n.to_string(),
             ValueView::Num(f) => {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1109,6 +1109,18 @@ pub(in crate::value) enum ValueRepr {
         #[allow(clippy::box_collection)]
         named: Box<HashMap<String, Value>>,
     },
+    /// A *named variable reference*: an argument (or pair value, or `:=` RHS)
+    /// tagged with the name of the variable it was read from, so that `is rw` /
+    /// `is raw` binding, `:=` and `\($a)` can alias the caller's container
+    /// rather than snapshot its value. Produced by `OpCode::WrapVarRef`, and
+    /// stripped again by the binder (`unwrap_varref_value`) — so it is a
+    /// *transient* wrapper that never reaches user-visible value space.
+    VarRef {
+        name: Symbol,
+        value: Box<Value>,
+        /// Source-element index, for a reference into a slurpy's element.
+        index: Option<u32>,
+    },
     /// Unicode normalization form types (NFC, NFD, NFKC, NFKD).
     /// `form` is one of "NFC", "NFD", "NFKC", "NFKD".
     /// `text` is the normalized string. Boxed to keep `Value` small.

--- a/src/value/nanbox/boxes.rs
+++ b/src/value/nanbox/boxes.rs
@@ -64,6 +64,25 @@ pub(in crate::value) struct CaptureBox {
     pub(in crate::value) named: Box<HashMap<String, Value>>,
 }
 
+/// Payload of `VarRef`: a call argument (or pair value / bind RHS) that carries
+/// the *name* of the variable it came from, so `is rw` / `is raw` binding, `:=`,
+/// and `\($a)` can alias the caller's container instead of copying its value.
+///
+/// This was previously encoded as a `Capture` whose `named` map held the magic
+/// keys `__mutsu_varref_{name,value,index}` — which cost four `String`
+/// allocations, a `HashMap` + `RawTable`, an empty positional `Vec` and two
+/// SipHashes on *every* variable passed as an argument (~28% of `bench-tak`'s
+/// allocator traffic). A named variable reference is a first-class concept in
+/// Raku's binder, so it gets a first-class representation.
+#[derive(Debug, Clone)]
+pub(in crate::value) struct VarRefBox {
+    pub(in crate::value) name: Symbol,
+    pub(in crate::value) value: Value,
+    /// Index of the caller argument this reference came from, when the source is
+    /// an element of a slurpy (`*@v is rw`) rather than a plain variable.
+    pub(in crate::value) index: Option<u32>,
+}
+
 #[derive(Debug, Clone)]
 pub(in crate::value) struct ProxyBox {
     pub(in crate::value) fetcher: Box<Value>,
@@ -138,6 +157,7 @@ const _: () = {
         GenericRangeBox,
         VersionBox,
         CaptureBox,
+        VarRefBox,
         ProxyBox,
         ParametricRoleBox,
         RoutineBox,

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -136,6 +136,14 @@ unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
                 named: c.named,
             }
         }
+        Kind::VarRef => {
+            let r = Arc::unwrap_or_clone(unsafe { take_arc::<VarRefBox>(bits) });
+            ValueRepr::VarRef {
+                name: r.name,
+                value: Box::new(r.value),
+                index: r.index,
+            }
+        }
         Kind::Proxy => {
             let p = Arc::unwrap_or_clone(unsafe { take_arc::<ProxyBox>(bits) });
             ValueRepr::Proxy {

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -155,6 +155,14 @@ impl NanBox {
             ValueRepr::Capture { positional, named } => {
                 pack_arc(Kind::Capture, Arc::new(CaptureBox { positional, named }))
             }
+            ValueRepr::VarRef { name, value, index } => pack_arc(
+                Kind::VarRef,
+                Arc::new(VarRefBox {
+                    name,
+                    value: *value,
+                    index,
+                }),
+            ),
             ValueRepr::Uni(u) => pack_arc(Kind::Uni, Arc::new(*u)),
             ValueRepr::Proxy {
                 fetcher,

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -139,6 +139,7 @@ pub(in crate::value) enum Kind {
     Routine,
     LazyIoLines,
     HashEntryRef,
+    VarRef,
     // -- Gc-backed pointer kinds (payload = GcBox<T> raw address) --
     Sub,
     WeakSub,
@@ -426,6 +427,7 @@ unsafe fn payload_op(kind: Kind, bits: u64, op: PayloadOp) {
             Kind::Routine => arc_op::<RoutineBox>(bits, op),
             Kind::LazyIoLines => arc_op::<LazyIoLinesBox>(bits, op),
             Kind::HashEntryRef => arc_op::<HashEntryRefBox>(bits, op),
+            Kind::VarRef => arc_op::<VarRefBox>(bits, op),
             Kind::Sub => gc_op::<SubData>(bits, op),
             Kind::WeakSub => weak_op::<SubData>(bits, op),
             Kind::LazyList => gc_op::<LazyList>(bits, op),

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -179,6 +179,7 @@ impl NanBox {
                 Kind::Pair => unique::<PairBox>(bits),
                 Kind::ValuePair => unique::<ValuePairBox>(bits),
                 Kind::Capture => unique::<CaptureBox>(bits),
+                Kind::VarRef => unique::<VarRefBox>(bits),
                 Kind::Proxy => unique::<ProxyBox>(bits),
                 Kind::GenericRange => unique::<GenericRangeBox>(bits),
                 Kind::LazyIoLines => unique::<LazyIoLinesBox>(bits),
@@ -346,6 +347,14 @@ unsafe fn view_kind<'a>(kind: Kind, bits: u64) -> ValueView<'a> {
                 ValueView::Capture {
                     positional: &c.positional,
                     named: &c.named,
+                }
+            }
+            Kind::VarRef => {
+                let r = peek_arc::<VarRefBox>(bits);
+                ValueView::VarRef {
+                    name: r.name,
+                    value: &r.value,
+                    index: r.index,
                 }
             }
             Kind::Proxy => {

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -117,6 +117,10 @@ enum SerJunctionKind {
 
 fn value_to_ser(v: &Value) -> Result<SerValue, String> {
     match v.view() {
+        // A `VarRef` is a transient binder wrapper that never reaches a
+        // long-lived value (a thread payload, a phaser capture): if one somehow
+        // does, serialize the variable's value.
+        ValueView::VarRef { value, .. } => value_to_ser(value),
         ValueView::Int(n) => Ok(SerValue::Int(n)),
         ValueView::BigInt(n) => Ok(SerValue::BigInt((**n).clone())),
         ValueView::Num(n) => Ok(SerValue::Num(n)),

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -10,7 +10,13 @@ impl Value {
             ValueView::Package(name) => Some(name.resolve()),
             _ => None,
         };
+        // A `VarRef` is a transient binder wrapper, not a type of its own: it
+        // answers as the variable's value.
+        if let ValueView::VarRef { value, .. } = self.view() {
+            return value.isa_check(type_name);
+        }
         let my_type = match self.view() {
+            ValueView::VarRef { .. } => unreachable!("unwrapped above"),
             ValueView::Int(_) | ValueView::BigInt(_) => "Int",
             ValueView::Num(_) => "Num",
             ValueView::Str(_) => "Str",

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -36,6 +36,9 @@ impl Value {
 
     pub(crate) fn truthy(&self) -> bool {
         match self.view() {
+            // A `VarRef` is a transient binder wrapper: it is as true as the
+            // variable's value.
+            ValueView::VarRef { value, .. } => value.truthy(),
             ValueView::Bool(b) => b,
             ValueView::Int(i) => i != 0,
             ValueView::BigInt(n) => !n.is_zero(),

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -116,6 +116,7 @@ impl Value {
                     v.gc_trace(visit);
                 }
             }
+            ValueView::VarRef { value, .. } => value.gc_trace(visit),
             ValueView::Seq(items)
             | ValueView::HyperSeq(items)
             | ValueView::RaceSeq(items)

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -55,6 +55,31 @@ impl Value {
             named: Box::new(named),
         })
     }
+    /// A named variable reference (see [`ValueRepr::VarRef`]): the value `value`
+    /// tagged with the name of the variable it was read from, so the binder can
+    /// alias the caller's container for an `is rw` / `is raw` / `:=` target.
+    pub fn varref(name: Symbol, value: Value, index: Option<u32>) -> Self {
+        Value::from_repr(ValueRepr::VarRef {
+            name,
+            value: Box::new(value),
+            index,
+        })
+    }
+    /// The `(name, value, index)` of a [`ValueRepr::VarRef`], or `None`.
+    pub fn as_varref(&self) -> Option<(Symbol, &Value, Option<u32>)> {
+        match self.view() {
+            ValueView::VarRef { name, value, index } => Some((name, value, index)),
+            _ => None,
+        }
+    }
+    /// The value a [`ValueRepr::VarRef`] wraps, or `self` when it is not one.
+    /// The binder strips the wrapper here once it has taken the name it needs.
+    pub fn unwrap_varref(&self) -> &Value {
+        match self.view() {
+            ValueView::VarRef { value, .. } => value,
+            _ => self,
+        }
+    }
     /// Create a BigRat value. The numerator/denominator are boxed (the variant
     /// stores them behind `Box` to keep `Value` small).
     pub fn bigrat(num: NumBigInt, den: NumBigInt) -> Self {

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -97,6 +97,13 @@ pub enum ValueView<'a> {
         positional: &'a Vec<Value>,
         named: &'a HashMap<String, Value>,
     },
+    /// See [`ValueRepr::VarRef`]: a transient argument wrapper carrying the name
+    /// of the variable the value was read from.
+    VarRef {
+        name: Symbol,
+        value: &'a Value,
+        index: Option<u32>,
+    },
     Uni(&'a UniData),
     Proxy {
         fetcher: &'a Value,

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -161,21 +161,14 @@ impl Interpreter {
     /// and detach it. A `$`-scalar source (`my $aref = [0]; f($aref)`) already
     /// shares the array by reference (`$aref[0]++` propagates without promotion),
     /// and a non-variable literal (`f([1,2])`) has no caller to share with — both
-    /// must keep the fast path. A variable arg reaches the binder as a
-    /// `__mutsu_varref_*` capture, so peek inside without cloning.
+    /// must keep the fast path. A variable arg reaches the binder as a `VarRef`,
+    /// so peek inside without cloning.
     pub(super) fn arg_is_container_value(arg: &Value) -> bool {
-        let ValueView::Capture { positional, named } = arg.view() else {
+        let ValueView::VarRef { name, value, .. } = arg.view() else {
             return false;
         };
-        positional.is_empty()
-            && matches!(
-                named.get("__mutsu_varref_name").map(Value::view),
-                Some(ValueView::Str(name)) if name.starts_with('@') || name.starts_with('%')
-            )
-            && matches!(
-                named.get("__mutsu_varref_value").map(Value::view),
-                Some(ValueView::Array(..)) | Some(ValueView::Hash(..))
-            )
+        (name.starts_with("@") || name.starts_with("%"))
+            && matches!(value.view(), ValueView::Array(..) | ValueView::Hash(..))
     }
 
     /// Method analogue of `call_shares_container_into_scalar_param`: true when

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -167,14 +167,10 @@ impl Interpreter {
     }
 
     pub(super) fn unwrap_var_ref_value(value: Value) -> Value {
-        if let ValueView::Capture { positional, named } = value.view()
-            && positional.is_empty()
-            && let Some(ValueView::Str(_)) = named.get("__mutsu_varref_name").map(Value::view)
-            && let Some(inner) = named.get("__mutsu_varref_value")
-        {
-            return inner.clone();
+        match value.as_varref() {
+            Some((_, inner, _)) => inner.clone(),
+            None => value,
         }
-        value
     }
 
     pub(super) fn normalize_call_args_for_target(

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -24,7 +24,15 @@ impl Interpreter {
                 | ValueView::ContainerRef(_)
                 | ValueView::Pair(..)
                 | ValueView::ValuePair(..)
-                | ValueView::Capture { .. } => return None,
+                | ValueView::Capture { .. }
+                // A `VarRef` (a variable passed as an argument) dispatches on the
+                // *source variable's declared type* as well as the value's type --
+                // `unwrap_varref_for_dispatch` feeds that declared type into
+                // `candidate_type_distance`, so `my int $y` and `my $x` holding the
+                // same `Int` can pick different candidates (roast
+                // S06-multi/by-trait.t). Its value type alone is therefore not a
+                // sound cache key.
+                | ValueView::VarRef { .. } => return None,
                 _ => crate::symbol::Symbol::intern(crate::runtime::utils::value_type_name(a)),
             };
             keys.push(key);

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -180,16 +180,13 @@ impl Interpreter {
             // writes through. Box the named local into a shared `ContainerRef`
             // cell (same scope as `$c`, so sharing the slot's cell suffices) and
             // store that cell as the positional element.
-            if let ValueView::Capture {
-                positional: p,
-                named: nm,
+            if let ValueView::VarRef {
+                name: source_name,
+                value: inner,
+                ..
             } = val.view()
-                && p.is_empty()
-                && let Some(ValueView::Str(source_name)) =
-                    nm.get("__mutsu_varref_name").map(Value::view)
-                && let Some(inner) = nm.get("__mutsu_varref_value")
             {
-                let source_name = source_name.to_string();
+                let source_name = source_name.resolve();
                 let inner = inner.clone();
                 positional.push(self.capture_var_cell(code, &source_name, inner));
                 continue;
@@ -199,16 +196,13 @@ impl Interpreter {
                     // A named scalar-var element (`\(:$a)`): the value is a
                     // WrapVarRef-tagged capture — box the named local so `$c<a>`
                     // aliases `$a` and `$c<a>++` writes through.
-                    if let ValueView::Capture {
-                        positional: p,
-                        named: nm,
+                    if let ValueView::VarRef {
+                        name: source_name,
+                        value: inner,
+                        ..
                     } = v.view()
-                        && p.is_empty()
-                        && let Some(ValueView::Str(source_name)) =
-                            nm.get("__mutsu_varref_name").map(Value::view)
-                        && let Some(inner) = nm.get("__mutsu_varref_value")
                     {
-                        let source_name = source_name.to_string();
+                        let source_name = source_name.resolve();
                         let inner = inner.clone();
                         let cell = self.capture_var_cell(code, &source_name, inner);
                         named.insert(k.clone(), cell);

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -768,9 +768,14 @@ impl Interpreter {
                     && !self.fatal_mode
                     && self.var_type_constraint_fast(name_str).is_none()
                     && !self.is_readonly(name_str)
+                    // A `VarRef` RHS (a `:=` bind of `$` to a variable) must reach
+                    // the general path, which is where the wrapper is unwrapped and
+                    // its `bind_source` recorded; storing the wrapper itself into the
+                    // env slot would corrupt `$`. It used to be caught by the
+                    // `Capture` arm here, back when a varref *was* a `Capture`.
                     && !matches!(
                         self.stack.last().map(Value::view),
-                        Some(ValueView::Capture { .. })
+                        Some(ValueView::Capture { .. } | ValueView::VarRef { .. })
                     )
                     && !matches!(
                         self.env().get(name_str).map(Value::view),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -965,23 +965,10 @@ impl Interpreter {
                     )));
                 }
                 let raw_val = self.stack.pop().unwrap_or(Value::NIL);
-                let (raw_val, bind_source) =
-                    if let ValueView::Capture { positional, named } = raw_val.view() {
-                        if positional.is_empty() {
-                            if let (Some(ValueView::Str(source_name)), Some(inner)) = (
-                                named.get("__mutsu_varref_name").map(Value::view),
-                                named.get("__mutsu_varref_value"),
-                            ) {
-                                (inner.clone(), Some(source_name.to_string()))
-                            } else {
-                                (raw_val, None)
-                            }
-                        } else {
-                            (raw_val, None)
-                        }
-                    } else {
-                        (raw_val, None)
-                    };
+                let (raw_val, bind_source) = match raw_val.as_varref() {
+                    Some((source_name, inner, _)) => (inner.clone(), Some(source_name.resolve())),
+                    None => (raw_val, None),
+                };
                 let mut val = if raw_mode && name.starts_with('@') {
                     // Constants with @ sigil coerce to List (not Array).
                     // `constant @x = 42` gives `(42,)`, not `[42]`.

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -35,23 +35,10 @@ impl Interpreter {
             }
         }
         let raw_val = self.stack.pop().unwrap_or(Value::NIL);
-        let (raw_val, bind_source) =
-            if let ValueView::Capture { positional, named } = raw_val.view() {
-                if positional.is_empty() {
-                    if let (Some(ValueView::Str(source_name)), Some(inner)) = (
-                        named.get("__mutsu_varref_name").map(Value::view),
-                        named.get("__mutsu_varref_value"),
-                    ) {
-                        (inner.clone(), Some(source_name.to_string()))
-                    } else {
-                        (raw_val, None)
-                    }
-                } else {
-                    (raw_val, None)
-                }
-            } else {
-                (raw_val, None)
-            };
+        let (raw_val, bind_source) = match raw_val.view() {
+            ValueView::VarRef { name, value, .. } => (value.clone(), Some(name.resolve())),
+            _ => (raw_val, None),
+        };
         // Capture old hash Arc pointer for circular reference fixup, and the
         // backing `Gc` for the in-place whole-container reassignment below. A
         // celled `@`/`%` aggregate (a `state @foo` / captured boxed container)
@@ -541,13 +528,19 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Tag the top-of-stack value with the name of the variable it was read
+    /// from, so the binder can alias the caller's container for an `is rw` /
+    /// `is raw` / `:=` target (see [`Value::varref`]).
+    ///
+    /// This runs once per variable passed as an argument — the single hottest
+    /// opcode in a call-heavy program (99.7% of `bench-tak`'s interpreted ops),
+    /// so it must not allocate more than the one `VarRef` payload. The name is
+    /// taken from the chunk's pre-interned constant symbols: no `String`, no
+    /// hashing.
     pub(super) fn exec_wrap_var_ref_op(&mut self, code: &CompiledCode, name_idx: u32) {
         let value = self.stack.pop().unwrap_or(Value::NIL);
-        let name = Self::const_str(code, name_idx).to_string();
-        let mut named = std::collections::HashMap::new();
-        named.insert("__mutsu_varref_name".to_string(), Value::str(name));
-        named.insert("__mutsu_varref_value".to_string(), value);
-        self.stack.push(Value::capture(Vec::new(), named));
+        self.stack
+            .push(Value::varref(code.const_sym(name_idx), value, None));
     }
 
     /// Validate and coerce a value for native integer type assignment.

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -418,13 +418,13 @@ impl Interpreter {
         // with `$var`, giving Raku's write-through semantics: `$pair.value = X`
         // updates `$var`, and `$pair.value<k> = v` writes through to `$var`'s
         // backing Array/Hash. (See S02:1704 / roast S02-types/pair.t.)
-        if let ValueView::Capture { positional, named } = right.view()
-            && positional.is_empty()
-            && let Some(ValueView::Str(source_name)) =
-                named.get("__mutsu_varref_name").map(Value::view)
-            && let Some(inner) = named.get("__mutsu_varref_value")
+        if let ValueView::VarRef {
+            name: source_name,
+            value: inner,
+            ..
+        } = right.view()
         {
-            let source_name = source_name.to_string();
+            let source_name = source_name.resolve();
             let inner = inner.clone();
             right = self.capture_var_cell(code, &source_name, inner);
         }

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -170,17 +170,8 @@ impl Interpreter {
     }
 
     pub(crate) fn varref_target(value: &Value) -> Option<(String, Option<usize>)> {
-        if let ValueView::Capture { positional, named } = value.view()
-            && positional.is_empty()
-            && let Some(ValueView::Str(name)) = named.get("__mutsu_varref_name").map(Value::view)
-        {
-            let source_index = match named.get("__mutsu_varref_index").map(Value::view) {
-                Some(ValueView::Int(i)) if i >= 0 => Some(i as usize),
-                _ => None,
-            };
-            return Some((name.to_string(), source_index));
-        }
-        None
+        let (name, _, index) = value.as_varref()?;
+        Some((name.resolve(), index.map(|i| i as usize)))
     }
 
     pub(crate) fn make_varref_value(
@@ -188,13 +179,7 @@ impl Interpreter {
         value: Value,
         source_index: Option<usize>,
     ) -> Value {
-        let mut named = std::collections::HashMap::new();
-        named.insert("__mutsu_varref_name".to_string(), Value::str(name));
-        named.insert("__mutsu_varref_value".to_string(), value);
-        if let Some(i) = source_index {
-            named.insert("__mutsu_varref_index".to_string(), Value::int(i as i64));
-        }
-        Value::capture(Vec::new(), named)
+        Value::varref(Symbol::intern(&name), value, source_index.map(|i| i as u32))
     }
 
     pub(crate) fn assign_varref_target(

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -82,14 +82,10 @@ impl Interpreter {
     }
 
     pub(crate) fn extract_varref_binding(raw_val: Value) -> (Value, Option<String>) {
-        if let ValueView::Capture { positional, named } = raw_val.view()
-            && positional.is_empty()
-            && let Some(ValueView::Str(name)) = named.get("__mutsu_varref_name").map(Value::view)
-            && let Some(inner) = named.get("__mutsu_varref_value")
-        {
-            return (inner.clone(), Some(name.to_string()));
+        match raw_val.as_varref() {
+            Some((name, inner, _)) => (inner.clone(), Some(name.resolve())),
+            None => (raw_val, None),
         }
-        (raw_val, None)
     }
 
     pub(crate) fn resolve_sigilless_alias_source_name(&self, source_name: &str) -> String {

--- a/t/varref-binding.t
+++ b/t/varref-binding.t
@@ -10,7 +10,7 @@ use Test;
 # capture construction, pair construction, `:=`, multi dispatch, `.VAR`), so
 # these are the cases that would break if a path missed the migration.
 
-plan 14;
+plan 16;
 
 # is rw -- the binder aliases the caller's scalar container
 sub inc($x is rw) { $x++ }
@@ -75,3 +75,18 @@ is $v.VAR.name, '$v', '.VAR.name of a variable';
 sub what-of($x) { $x.WHAT.gist }
 my $w = 42;
 is what-of($w), '(Int)', 'a variable argument introspects as its value type';
+
+# A variable argument dispatches on the *source variable's declared type* too,
+# not just on its value's type -- so it must not be keyed into the multi-resolve
+# cache by value type alone. Calling with a plain `$x` first used to poison the
+# cache entry for a later native-typed `int $y` holding an equal Int value
+# (roast S06-multi/by-trait.t).
+my $ro = 0; my $rw = 0; my $primrw = 0;
+multi sub mas( Int $a       ) { $ro++;    1 + $a }
+multi sub mas( int $a is rw ) { $primrw++; $a * 2 }
+multi sub mas( Int $a is rw ) { $rw++;    ++$a }
+my $plain = 99;
+mas($plain);                        # picks `Int $a is rw`, keyed [Int]
+my int $native = 50;
+is mas($native), 100, 'a native-typed variable reaches the `int is rw` candidate';
+is $primrw, 1, 'the plain-Int call did not poison the multi cache for it';

--- a/t/varref-binding.t
+++ b/t/varref-binding.t
@@ -1,0 +1,77 @@
+use Test;
+
+# Pins the semantics of the `VarRef` value representation — the wrapper the
+# caller tags an lvalue argument with (`OpCode::WrapVarRef`) so the binder can
+# alias the caller's container instead of copying its value.
+#
+# It used to be encoded as a `Capture` carrying the magic named keys
+# `__mutsu_varref_{name,value,index}`; it is now a first-class `Value` variant.
+# Every consumer below reads it through a different path (signature binding,
+# capture construction, pair construction, `:=`, multi dispatch, `.VAR`), so
+# these are the cases that would break if a path missed the migration.
+
+plan 14;
+
+# is rw -- the binder aliases the caller's scalar container
+sub inc($x is rw) { $x++ }
+my $a = 1; inc($a); is $a, 2, 'is rw writes back to the caller variable';
+
+# is raw
+sub raw(\r) { r }
+my $b = 5; is raw($b), 5, 'is raw binds the container and reads through it';
+
+# an array variable passed into a sub shares the container
+my @arr = 1, 2, 3;
+sub pushit(@a) { @a.push(9) }
+pushit(@arr); is @arr.join(','), '1,2,3,9', 'array argument shares the container';
+
+# \($c) captures the *container*, so writing through the capture hits $c
+my $c = 1;
+my $cap = \($c);
+$cap[0]++;
+is $c, 2, 'capture \\($c) aliases the variable container';
+
+# named capture element
+my $d = 7;
+my $cap2 = \(:$d);
+is $cap2<d>, 7, 'named capture element reads the variable';
+
+# `key => $var` makes the Pair's value share $var's container
+my $e = 3;
+my $p = (k => $e);
+$p.value = 10;
+is $e, 10, 'pair value aliases the variable container';
+
+# := bind
+my $f = 4;
+my $g := $f;
+$g = 40;
+is $f, 40, ':= binds the two variables to one container';
+
+# slurpy `is raw` aliases each caller argument
+sub bump(*@v is raw) { $_++ for @v }
+my ($h, $i) = 1, 2;
+bump($h, $i);
+is $h, 2, 'slurpy is raw writes back to the first source';
+is $i, 3, 'slurpy is raw writes back to the second source';
+
+# a variable argument binds into a |c slurpy as its *value*, not as a wrapper
+sub cap(|c) { c.list.join('-') }
+my $j = 8; my $k = 9;
+is cap($j, $k), '8-9', 'a variable argument binds into |c as its value';
+
+# multi dispatch sees through the wrapper to the value's type
+multi m(Int $x) { 'int' }
+multi m(Str $x) { 'str' }
+my $n = 3; my $s = 'x';
+is m($n), 'int', 'multi dispatch on an Int variable argument';
+is m($s), 'str', 'multi dispatch on a Str variable argument';
+
+# .VAR reaches the variable behind the wrapper
+my $v = 5;
+is $v.VAR.name, '$v', '.VAR.name of a variable';
+
+# the wrapper is transparent to type introspection
+sub what-of($x) { $x.WHAT.gist }
+my $w = 42;
+is what-of($w), '(Int)', 'a variable argument introspects as its value type';


### PR DESCRIPTION
## What

`OpCode::WrapVarRef` tags a call argument with the *name* of the variable it came from, so `is rw` / `is raw` / `:=` / `\($a)` can alias the caller's container instead of copying its value. It runs once per variable passed as an argument — **593,634 times in bench-tak, 99.7% of all interpreted opcodes** (the JIT traps out to the interpreter helper for it).

It was encoded as a `Capture` carrying two magic string keys:

```rust
let name = Self::const_str(code, name_idx).to_string();      // String
let mut named = std::collections::HashMap::new();            // std HashMap = SipHash
named.insert("__mutsu_varref_name".to_string(), Value::str(name));
named.insert("__mutsu_varref_value".to_string(), value);
self.stack.push(Value::capture(Vec::new(), named));          // Vec + Capture box
```

— four `String` allocations, a `HashMap` with its `RawTable`, an empty positional `Vec`, a `Capture` box, and two SipHashes over 20-byte key strings, **per argument**, immediately unwrapped again by the binder. That was most of bench-tak's 28% allocator traffic and *all* of its 14% SipHash.

"A reference to a named variable" is a first-class concept in Raku's binder, so it gets a first-class representation: `ValueRepr::VarRef { name: Symbol, value, index }` — one `Arc` payload, no hashing. The 42 magic-key probe sites across 16 files become typed destructures.

The wrapper is now **transparent**: it answers `.WHAT`, `isa`, truthiness and stringification as its inner value, where before it accidentally answered as a `Capture`.

## Numbers

`perf stat -e instructions:u` under `taskset -c <p-core>`, release + JIT (ADR-0006 protocol):

| | before | after |
|---|---|---|
| bench-tak `instructions:u` | 4.94G | **2.73G** (−44.7%) |
| bench-tak wall (best of 5) | 0.40s | **0.20s** |
| vs. raku (0.24s) | 1.70× | **0.83×** |

**bench-tak now beats raku.** It is broadly a call-path win, not tak-specific: method-call 0.86× → 0.65× raku, bench-class 0.84× → 0.59×. No benchmark regressed. (Bench-CI numbers on merge are the source of truth; these are local A/B.)

The profile shape changed — with the string work gone, the top structural cost on a call-heavy benchmark is now genuinely the per-call env overlay (`Env::get_sym` seed loop 10%, `scoped_child` + drop 5%). `docs/perf-callpath-scouting.md` is updated with the corrected model and the next slice (§3.0, the locals seed loop).

## Tests

- `t/varref-binding.t` (new, 14 cases) — each reads the wrapper through a *different* consumer: signature binding (`is rw`, `is raw`, slurpy `is raw`, array container sharing), capture construction (`\($c)`, `\(:$d)`), pair construction (`k => $e`), `:=`, `|c` slurpy, multi dispatch, `.VAR.name`, `.WHAT`. All 14 match `raku`.
- `make test`: 1685 files / 16606 tests, all pass.