### PR TITLE
perf(vm): stop every `my` declaration from allocating env-metadata keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -47,8 +47,17 @@ impl Interpreter {
     }
 
     pub(crate) fn set_var_dynamic(&mut self, name: &str, dynamic: bool) {
-        let key = Self::normalize_var_meta_name(name).to_string();
-        self.var_dynamic_flags.insert(key, dynamic);
+        // `is_var_dynamic` reads this map as `.get(bare).copied().unwrap_or(false)`,
+        // so an absent entry already means "not dynamic". The common case — a plain
+        // non-dynamic `my $x` — therefore needs no owned-String key allocation +
+        // insert; only remove a stale `true` left by a same-named dynamic shadow
+        // (and only when the map is non-empty, avoiding the sigil-strip alloc).
+        let key = Self::normalize_var_meta_name(name);
+        if dynamic {
+            self.var_dynamic_flags.insert(key.to_string(), true);
+        } else if !self.var_dynamic_flags.is_empty() {
+            self.var_dynamic_flags.remove(key);
+        }
     }
 
     pub(crate) fn set_var_meta_value(&mut self, name: &str, value: Value) {
@@ -60,9 +69,9 @@ impl Interpreter {
     }
 
     pub(crate) fn set_var_type_constraint(&mut self, name: &str, constraint: Option<String>) {
-        let key = name.to_string();
-        let meta_key = format!("__mutsu_type::{}", key);
         if let Some(constraint) = constraint {
+            let key = name.to_string();
+            let meta_key = format!("__mutsu_type::{}", key);
             let info = Self::parse_container_constraint(name, &constraint);
             if info.value_type == "atomicint" || constraint.contains("atomicint") {
                 self.mark_atomic_var_seen();
@@ -90,10 +99,21 @@ impl Interpreter {
                 self.register_var_container_type_metadata(&key, &info);
             }
         } else {
-            self.var_type_constraints.remove(&key);
-            self.var_hash_key_constraints.remove(&key);
-            self.env.remove(&meta_key);
-            self.env.remove(&format!("__mutsu_hash_key_type::{}", key));
+            // Fast path for the overwhelmingly common case: a plain `my $x`
+            // declaration clearing a constraint that was never set. Every such
+            // declaration reaches here (via `SetVarDynamic`), so avoid the two
+            // `format!` key allocations + the `Symbol::intern`ing `env.remove`s
+            // (the env is Symbol-keyed) unless there is actually something to
+            // clear. `env_type_constraint_seen` latches true only once an
+            // env-scoped `__mutsu_type::*` entry has ever been inserted, so when
+            // it is false no such env entry can exist to remove. The two map
+            // removes borrow `name` (`&str`) and never allocate.
+            let had_constraint = self.var_type_constraints.remove(name).is_some();
+            let had_hash_key = self.var_hash_key_constraints.remove(name).is_some();
+            if had_constraint || had_hash_key || self.env_type_constraint_seen {
+                self.env.remove(&format!("__mutsu_type::{}", name));
+                self.env.remove(&format!("__mutsu_hash_key_type::{}", name));
+            }
         }
     }
 

--- a/t/var-decl-constraint-clear.t
+++ b/t/var-decl-constraint-clear.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# A fresh `my` declaration must not inherit a stale type constraint left by an
+# earlier same-named lexical. `SetVarDynamic` clears the constraint on every
+# declaration; the clear has a fast path that must not skip a real clear.
+
+plan 8;
+
+# A later untyped `my $x` must be free of the earlier `Int` constraint.
+my Int $x = 1;
+{
+    my $x;
+    $x = "free";
+    is $x, "free", 'fresh untyped my does not inherit the outer Int constraint';
+}
+is $x, 1, 'the outer typed lexical is untouched';
+
+# The constraint is still enforced on the typed lexical itself.
+{
+    my $failed = False;
+    { CATCH { default { $failed = True } }; $x = "bad" }
+    ok $failed, 'the Int constraint is still enforced after the clear fast path';
+}
+
+# Across routines: a typed lexical in one sub must not constrain a same-named
+# untyped lexical in another.
+sub typed() { my Int $v = 1; $v }
+sub untyped() { my $v; $v = "str"; $v }
+is typed(), 1, 'typed lexical works';
+is untyped(), "str", 'same-named untyped lexical in another sub is unconstrained';
+
+# Hash key-type constraints clear the same way.
+my %h{Int} = (1 => "a");
+is %h{1}, "a", 'typed hash key constraint works';
+{
+    my %h;
+    %h{"s"} = "t";
+    is %h{"s"}, "t", 'fresh untyped hash does not inherit the Int key constraint';
+}
+
+# A `my $d` must not inherit the dynamic flag of an outer `my $*d`.
+my $*d = 1;
+{
+    my $d = 99;
+    is $d, 99, 'plain my shadowing a same-named dynamic stays plain';
+}


### PR DESCRIPTION
## Problem

`benchmarks/time-parts.raku` (an integer `div`/`mod` loop) ran **3x slower than raku** — 0.60s vs 0.21s — and turning the JIT on barely helped (0.54s). A flat `perf` profile showed the loop was not bottlenecked on arithmetic at all:

- ~11% in string formatting (`alloc::fmt::format_inner`, `Formatter::pad`)
- ~12% in `Symbol::intern` (thread-local `HashMap<String, Symbol>`)
- ~17% in `malloc` / `realloc` / `memmove`

In a pure numeric loop. The culprit is the `my` declaration path.

## Root cause

Every `my $x` compiles to `SetVarDynamic` + `SetLocal`. `SetVarDynamic` clears the variable's type constraint via `set_var_type_constraint(name, None)`, which unconditionally built two `format!("__mutsu_type::{}")` / `__mutsu_hash_key_type::{}` keys and removed them from the env. The env is `Symbol`-keyed, so each of those removes *also* interned the freshly-formatted string. `set_var_dynamic` additionally inserted an owned `String` key into `var_dynamic_flags` even for a plain non-dynamic decl — whose only reader already treats an absent entry as "not dynamic" (`.get(bare).copied().unwrap_or(false)`).

None of this work is observable for the overwhelmingly common case (a plain untyped, non-dynamic `my`), and the loop body pays it once per declaration per iteration.

## Fix

- `set_var_type_constraint`: build the `format!` keys only in the branch that needs them. The clearing branch removes from the two name-keyed maps by `&str` (no allocation) and touches the env only when something was actually removed or `env_type_constraint_seen` says an env-scoped constraint can exist (that flag latches true only once such an env entry has been inserted, so `false` proves none exist).
- `set_var_dynamic`: skip the key allocation + insert when `dynamic == false`; remove a stale entry only when the map is non-empty.

Both are the same shape as the existing `atomic_var_seen_anywhere()` / `env_type_constraint_seen` guards already used elsewhere in this file.

## Results

`benchmarks/time-parts.raku`, release, best of 5:

| | before | after | raku |
|---|---|---|---|
| JIT off | 0.60s | **0.31s** | 0.21s |
| JIT on | 0.54s | **0.28s** | |

~2x faster; raku ratio goes from 3x slower to ~1.3x. No other benchmark regressed.

## Tests

`make test` passes (Files=1686, Tests=16622, all successful).

New `t/var-decl-constraint-clear.t` pins the semantics the fast path must preserve: a fresh `my` must not inherit a stale type constraint, hash key-type constraint, or dynamic flag from an earlier same-named lexical, and a real constraint must still be enforced.

## Follow-up (not in this PR)

The same unguarded-`format!`-probe pattern exists on the *assignment* path: `vm_exec_dispatch.rs` formats `__mutsu_sigilless_readonly::{name}` + `__mutsu_sigilless_alias::{name}` and does two interned env lookups on **every** variable assignment, even though a `sigilless_alias_seen()` latch already exists and most programs have no sigilless variables. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw