### PR TITLE
perf(vm): latch-gate the per-element index metadata probes

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -125,6 +125,17 @@ static BOUND_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 /// `distribute_bound_multidim_slice` on every scalar `SetLocal`/assignment.
 static BOUND_SLICE_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 
+/// Monotonic, process-global flag for the per-element index metadata keys
+/// (`__mutsu_bound_index::*`, `__mutsu_elem_share::*`, `__mutsu_deleted_index::*`).
+/// Their probes run on *every* element write (`@a[i] = x`) and on `:exists`, and
+/// each would otherwise cost a `format!` plus a `Symbol::intern`ing env lookup.
+/// The keys only ever appear once the program `:=`-binds an element, `=`-shares a
+/// container into one, or `:delete`s an index — none of which the common program
+/// does. Same soundness argument as [`CLOSURE_META_KEY_SEEN`]: every creation site
+/// flows through the String-keyed [`Env::insert`], the flag is monotonic, and an
+/// over-set only makes the (correct) probe run.
+static ELEM_INDEX_META_SEEN: AtomicBool = AtomicBool::new(false);
+
 /// True if any closure-writeback metadata key may exist in some env. See
 /// [`CLOSURE_META_KEY_SEEN`].
 #[inline]
@@ -146,6 +157,13 @@ pub(crate) fn bound_array_slice_possible() -> bool {
     BOUND_SLICE_KEY_SEEN.load(Ordering::Relaxed)
 }
 
+/// True if any per-element index metadata key may exist in some env. See
+/// [`ELEM_INDEX_META_SEEN`].
+#[inline]
+pub(crate) fn elem_index_meta_possible() -> bool {
+    ELEM_INDEX_META_SEEN.load(Ordering::Relaxed)
+}
+
 /// Flip [`CLOSURE_META_KEY_SEEN`] / [`BOUND_KEY_SEEN`] if `key` is one of the
 /// tracked metadata keys. The outer `__mutsu_` gate keeps this ~1 byte compare
 /// for ordinary lexical names (which never start with `_`).
@@ -161,6 +179,11 @@ fn note_closure_meta_key(key: &str) {
             BOUND_KEY_SEEN.store(true, Ordering::Relaxed);
         } else if key.starts_with("__mutsu_bound_array_slice::") {
             BOUND_SLICE_KEY_SEEN.store(true, Ordering::Relaxed);
+        } else if key.starts_with("__mutsu_bound_index::")
+            || key.starts_with("__mutsu_elem_share::")
+            || key.starts_with("__mutsu_deleted_index::")
+        {
+            ELEM_INDEX_META_SEEN.store(true, Ordering::Relaxed);
         }
     }
 }

--- a/src/vm/vm_var_index_tracking.rs
+++ b/src/vm/vm_var_index_tracking.rs
@@ -15,6 +15,11 @@ impl Interpreter {
     }
 
     pub(super) fn is_bound_index(&self, var_name: &str, encoded: &str) -> bool {
+        // Runs on every element write. With no `:=` element bind anywhere in the
+        // program no such key can exist, so skip the `format!` + interned env probe.
+        if !crate::env::elem_index_meta_possible() {
+            return false;
+        }
         let key = format!("__mutsu_bound_index::{}", var_name);
         if let Some(ValueView::Hash(map)) = self.env().get(&key).map(Value::view) {
             map.contains_key(encoded)
@@ -63,6 +68,10 @@ impl Interpreter {
     }
 
     pub(super) fn is_element_share(&self, var_name: &str, encoded: &str) -> bool {
+        // Runs on every element write; see `is_bound_index`.
+        if !crate::env::elem_index_meta_possible() {
+            return false;
+        }
         let key = format!("__mutsu_elem_share::{}", var_name);
         if let Some(ValueView::Hash(map)) = self.env().get(&key).map(Value::view) {
             map.contains_key(encoded)
@@ -72,6 +81,10 @@ impl Interpreter {
     }
 
     pub(super) fn clear_element_share(&mut self, var_name: &str, encoded: &str) {
+        // Runs on every element write; nothing to clear if no marker can exist.
+        if !crate::env::elem_index_meta_possible() {
+            return;
+        }
         let key = format!("__mutsu_elem_share::{}", var_name);
         if let Some(entry) = self.env_mut().get_mut(&key) {
             entry.with_hash_mut(|map| {
@@ -82,6 +95,9 @@ impl Interpreter {
 
     /// Remove a bound-index marker (e.g. after splice breaks the binding).
     pub(super) fn remove_bound_index(&mut self, var_name: &str, encoded: &str) {
+        if !crate::env::elem_index_meta_possible() {
+            return;
+        }
         let key = format!("__mutsu_bound_index::{}", var_name);
         if let Some(entry) = self.env_mut().get_mut(&key) {
             entry.with_hash_mut(|map| {
@@ -92,8 +108,10 @@ impl Interpreter {
 
     pub(super) fn mark_initialized_index(&mut self, var_name: &str, encoded: String) {
         // Assigning a slot clears any deleted-index marker so subsequent
-        // `:exists` checks report the slot as present again.
-        {
+        // `:exists` checks report the slot as present again. Skipped entirely when
+        // the program has never `:delete`d an index — this runs on every element
+        // write and would otherwise cost a `format!` + an interned env lookup.
+        if crate::env::elem_index_meta_possible() {
             let deleted_key = format!("__mutsu_deleted_index::{}", var_name);
             if let Some(entry) = self.env_mut().get_mut(&deleted_key) {
                 entry.with_hash_mut(|map| {
@@ -169,6 +187,11 @@ impl Interpreter {
     }
 
     pub(super) fn is_deleted_index(&self, var_name: &str, idx: i64) -> bool {
+        // Consulted per element by `:exists`; no marker can exist unless the program
+        // has `:delete`d an index. Skips the `format!` + the `idx.to_string()`.
+        if !crate::env::elem_index_meta_possible() {
+            return false;
+        }
         let key = format!("__mutsu_deleted_index::{}", var_name);
         matches!(
             self.env().get(&key).map(Value::view),

--- a/t/elem-index-meta.t
+++ b/t/elem-index-meta.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+# Per-element index metadata (`:=` element binds, `=` container shares into an
+# element, and `:delete`d indices) is probed on every element write. Those probes
+# are gated on a monotonic "any such key was ever created" latch; these tests pin
+# the semantics that must survive the gate.
+
+plan 12;
+
+# --- :delete / :exists, and reassignment clearing the deleted marker ---
+{
+    my @a = 1, 2, 3;
+    @a[1]:delete;
+    nok @a[1]:exists, 'deleted index reports not-exists';
+    ok  @a[0]:exists, 'a sibling index still exists';
+    @a[1] = 9;
+    ok  @a[1]:exists, 'reassigning a deleted index clears the deleted marker';
+    is  @a[1], 9, 'the reassigned value is stored';
+}
+
+# --- element `:=` bind writes through in both directions ---
+{
+    my $x = 1;
+    my @a = 0, 0;
+    @a[0] := $x;
+    $x = 7;
+    is @a[0], 7, 'element bind sees a write to the bound scalar';
+    @a[0] = 5;
+    is $x, 5, 'writing the bound element writes through to the scalar';
+}
+
+# --- element `=` container share: shares, but reassignment REPLACES ---
+{
+    my @row = 1, 2;
+    my @aoa;
+    @aoa[0] = @row;
+    @row.push(3);
+    is @aoa[0].elems, 3, 'element = share sees a push to the shared container';
+    @aoa[0] = 42;
+    is @aoa[0], 42, 'reassigning a shared element replaces it';
+    is @row.elems, 3, 'the source container is untouched by the replace';
+}
+
+# --- hash :delete / :exists ---
+{
+    my %h = a => 1, b => 2;
+    %h<a>:delete;
+    nok %h<a>:exists, 'deleted hash key reports not-exists';
+    ok  %h<b>:exists, 'a sibling hash key still exists';
+}
+
+# --- a plain element-write program (the latch-off path) still stores ---
+{
+    my @p;
+    @p[$_] = $_ * 2 for ^5;
+    is @p.join(","), "0,2,4,6,8", 'plain element writes work with no element metadata';
+}


### PR DESCRIPTION
## Problem

Every element write (`@a[i] = x`) probed three env-keyed side tables:

- `__mutsu_bound_index::*` — `:=`-bound element markers
- `__mutsu_elem_share::*` — `=`-container-share markers
- `__mutsu_deleted_index::*` — the `:delete`d-index set

Each probe built its key with `format!` and looked it up in the **`Symbol`-keyed** env, so each also interned the freshly-formatted string. `mark_initialized_index` — which runs on *every* element assignment — paid the same cost just to clear a deleted-index marker that almost never exists.

`perf` on a 300×1000 element-write loop showed this metadata path as the top cost: `Symbol::intern` 6.4%, `malloc` 5.5%, `String` building 4.5%.

## Fix

None of those keys can exist unless the program `:=`-binds an element, `=`-shares a container into one, or `:delete`s an index — none of which the common array-writing program does.

Gate the probes on a monotonic, process-global latch (`ELEM_INDEX_META_SEEN`) set by `Env::insert` whenever such a key is created. This is exactly the pattern the existing `CLOSURE_META_KEY_SEEN` / `BOUND_KEY_SEEN` / `BOUND_SLICE_KEY_SEEN` flags already use, and it reuses their `note_closure_meta_key` hook.

Soundness is the same argument those flags rely on: every creation site flows through the String-keyed `Env::insert`, so the latch cannot miss one; it is monotonic; and an over-set only makes the (correct) probe run — never wrong, only slower.

## Results

`tmp/arr-write.raku` (a 300×1000 `@a[i] = @a[i] + i` loop), release, best of 5:

| | before | after |
|---|---|---|
| element-write loop | 0.42s | **0.38s** (~10%) |

Other benchmarks unchanged.

## Tests

`make test` passes (Files=1687, Tests=16630, all successful).

New `t/elem-index-meta.t` pins the semantics the gate must preserve: `:delete` / `:exists` on arrays and hashes, reassignment clearing a deleted marker, element `:=` write-through in both directions, and `=`-share followed by a replacing reassignment.

## Context

Follow-up to #4501, which removed the same class of waste (unguarded `format!` + interned env probe) from the `my`-declaration path and made `benchmarks/time-parts.raku` ~2x faster. This PR applies the audit's next finding: the element-write path was the remaining unguarded hot probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw