### PR TITLE
perf(jit): inline `div` / `mod` into Tier B native code

### DIFF
--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -10,7 +10,7 @@
 use super::vm_jit::JitEntryFn;
 use super::vm_jit_helpers as helpers;
 use super::vm_jit_support::{noarg_shim, step_supported};
-use super::vm_jit_tier_b::{IntArith, NumCmp, TierB};
+use super::vm_jit_tier_b::{IntArith, IntDivMod, NumCmp, TierB};
 use super::*;
 
 use cranelift_codegen::ir::{AbiParam, Block, InstBuilder, SigRef, Type, types};
@@ -279,6 +279,22 @@ fn build(
             OpCode::Mul if tier_b.is_some() => {
                 let tb = tier_b.as_ref().unwrap();
                 tb.emit_int_num_arith(&mut b, IntArith::Mul, helpers::mul as *const () as usize);
+            }
+            OpCode::IntDiv if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_int_divmod(
+                    &mut b,
+                    IntDivMod::Div,
+                    helpers::int_div as *const () as usize,
+                );
+            }
+            OpCode::IntMod if tier_b.is_some() => {
+                let tb = tier_b.as_ref().unwrap();
+                tb.emit_int_divmod(
+                    &mut b,
+                    IntDivMod::Mod,
+                    helpers::int_mod as *const () as usize,
+                );
             }
             OpCode::NumLt if tier_b.is_some() => {
                 let tb = tier_b.as_ref().unwrap();

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -125,6 +125,8 @@ fallible_noarg_shims! {
     mul => exec_mul_op,
     div => exec_div_op,
     modulo => exec_mod_op,
+    int_div => exec_int_div_op,
+    int_mod => exec_int_mod_op,
     pow => exec_pow_op,
     negate => exec_negate_op,
     num_lt => exec_num_lt_op,

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -17,6 +17,8 @@ pub(super) fn noarg_shim(op: &OpCode) -> Option<usize> {
         OpCode::Mul => helpers::mul,
         OpCode::Div => helpers::div,
         OpCode::Mod => helpers::modulo,
+        OpCode::IntDiv => helpers::int_div,
+        OpCode::IntMod => helpers::int_mod,
         OpCode::Pow => helpers::pow,
         OpCode::Negate => helpers::negate,
         OpCode::NumLt => helpers::num_lt,
@@ -115,8 +117,6 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::Not
             | OpCode::Gcd
             | OpCode::Lcm
-            | OpCode::IntDiv
-            | OpCode::IntMod
             | OpCode::NumCoerce
             // Sink context (forces lazies / throws unhandled Failures)
             | OpCode::SinkPop(_)

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -31,6 +31,14 @@ pub(super) enum IntArith {
     Mul,
 }
 
+/// `div` / `mod` — Raku's *floor* integer division and modulo (`-7 div 3 == -3`,
+/// `-7 mod 3 == 2`), as opposed to `/` and `%`.
+#[derive(Clone, Copy)]
+pub(super) enum IntDivMod {
+    Div,
+    Mod,
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum NumCmp {
     Lt,
@@ -271,6 +279,87 @@ impl TierB {
             IntArith::Mul => b.ins().fmul(fa, fb),
         };
         let word = self.encode_num(b, fr);
+        b.ins().store(Self::mf(), word, a_addr, 0);
+        self.adjust_len(b, len, -1);
+        b.ins().jump(done, &[]);
+
+        // -- Slow path: the Tier A shim reruns the full interpreter arm --
+        b.switch_to_block(slow_blk);
+        self.call_status(b, slow_fn);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(done);
+    }
+
+    /// `IntDiv`/`IntMod` (`div` / `mod`): pop two Int words, push the *floor*
+    /// quotient / remainder. The interpreter arm uses `Integer::div_floor` /
+    /// `mod_floor`, so the native path must match: Cranelift's `sdiv`/`srem`
+    /// truncate toward zero, so a floor correction is applied when the remainder
+    /// is non-zero and the operand signs differ.
+    ///
+    /// Fast-path conditions mirror the interpreter's Int/Int arm exactly: two
+    /// small-Int operands with a non-zero divisor. Everything else — a zero
+    /// divisor (which must raise `X::Numeric::DivideByZero`), `BigInt`, `Num`
+    /// (which the arm coerces via `to_int`), junctions — falls to the shim.
+    pub(super) fn emit_int_divmod(&self, b: &mut FunctionBuilder, op: IntDivMod, slow_fn: usize) {
+        let ptr = self.stack_ptr(b);
+        let len = self.stack_len(b);
+        let a_addr = self.slot_addr(b, ptr, len, 2);
+        let b_addr = self.slot_addr(b, ptr, len, 1);
+        let wa = b.ins().load(types::I64, Self::mf(), a_addr, 0);
+        let wb = b.ins().load(types::I64, Self::mf(), b_addr, 0);
+        let pa = self.page(b, wa);
+        let pb = self.page(b, wb);
+        let a_int = self.is_int_page(b, pa);
+        let b_int = self.is_int_page(b, pb);
+        let both_int = b.ins().band(a_int, b_int);
+
+        let int_blk = b.create_block();
+        let slow_blk = b.create_block();
+        let done = b.create_block();
+        b.ins().brif(both_int, int_blk, &[], slow_blk, &[]);
+
+        // -- Int fast path (divisor must be non-zero; `sdiv` would trap) --
+        b.switch_to_block(int_blk);
+        let av = self.sx48(b, wa);
+        let bv = self.sx48(b, wb);
+        let nonzero = b.ins().icmp_imm(IntCC::NotEqual, bv, 0);
+        let calc_blk = b.create_block();
+        b.ins().brif(nonzero, calc_blk, &[], slow_blk, &[]);
+
+        b.switch_to_block(calc_blk);
+        // Operands are sign-extended 48-bit, so `a == i64::MIN` is impossible and
+        // `sdiv` cannot trap on the INT_MIN / -1 overflow.
+        let rem = b.ins().srem(av, bv);
+        // Floor correction applies exactly when the truncated remainder is
+        // non-zero and the operand signs differ.
+        let rem_nz = b.ins().icmp_imm(IntCC::NotEqual, rem, 0);
+        let sign_xor = b.ins().bxor(av, bv);
+        let signs_differ = b.ins().icmp_imm(IntCC::SignedLessThan, sign_xor, 0);
+        let correct = b.ins().band(rem_nz, signs_differ);
+        let zero = b.ins().iconst(types::I64, 0);
+        let res = match op {
+            IntDivMod::Div => {
+                let q = b.ins().sdiv(av, bv);
+                let one = b.ins().iconst(types::I64, 1);
+                let adj = b.ins().select(correct, one, zero);
+                b.ins().isub(q, adj)
+            }
+            IntDivMod::Mod => {
+                let adj = b.ins().select(correct, bv, zero);
+                b.ins().iadd(rem, adj)
+            }
+        };
+        // `mod`'s result is bounded by the divisor and `div`'s by the dividend, so
+        // both fit the small-Int range for every input except `MIN_48 div -1`.
+        // Check anyway, and let the shim box the one case that does not.
+        let hi = b.ins().ishl_imm(res, 16);
+        let back = b.ins().sshr_imm(hi, 16);
+        let fits = b.ins().icmp(IntCC::Equal, back, res);
+        let int_store = b.create_block();
+        b.ins().brif(fits, int_store, &[], slow_blk, &[]);
+        b.switch_to_block(int_store);
+        let word = self.pack_int(b, res);
         b.ins().store(Self::mf(), word, a_addr, 0);
         self.adjust_len(b, len, -1);
         b.ins().jump(done, &[]);

--- a/t/jit-int-divmod.t
+++ b/t/jit-int-divmod.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# `div` / `mod` are inlined by the JIT's Tier B (native sdiv/srem plus a floor
+# correction). The loops below are hot enough to be JIT-compiled, so these pin
+# the native path against the interpreter's `div_floor` / `mod_floor` semantics.
+
+plan 9;
+
+# Raku's `div`/`mod` floor toward negative infinity (unlike C's truncation),
+# and `mod` takes the sign of the divisor.
+is (7 div 3, -7 div 3, 7 div -3, -7 div -3).join(","), "2,-3,-3,2", 'div floors';
+is (7 mod 3, -7 mod 3, 7 mod -3, -7 mod -3).join(","), "1,2,-2,-1", 'mod takes the divisor sign';
+
+# Hot loop: the JIT compiles this, so the native path must agree with the
+# interpreter on every sign combination.
+{
+    my @cases = (7, 3), (-7, 3), (7, -3), (-7, -3), (0, 5), (100, 7), (-100, 7), (5, 1), (1, -1);
+    my $bad = 0;
+    for ^200 {
+        for @cases -> ($a, $b) {
+            # The defining identity of floor division.
+            $bad++ unless $a == $b * ($a div $b) + ($a mod $b);
+            # `mod` lies in [0, b) for b > 0 and (b, 0] for b < 0.
+            my $m = $a mod $b;
+            $bad++ if $b > 0 && !(0 <= $m < $b);
+            $bad++ if $b < 0 && !($b < $m <= 0);
+        }
+    }
+    is $bad, 0, 'div/mod identity and range hold over a JIT-hot loop';
+}
+
+# Edge values around the small-Int boundary still round-trip.
+is 0 div 5, 0, 'zero dividend';
+is 0 mod 5, 0, 'zero dividend mod';
+
+# A zero divisor must not be handled by the native path -- it falls to the
+# interpreter, which produces a Failure rather than a wrong number.
+{
+    my $v = 1 div 0;
+    ok $v ~~ Failure, 'div by zero yields a Failure';
+    $v.so;  # mark handled
+}
+{
+    my $v = 1 mod 0;
+    ok $v ~~ Failure, 'mod by zero yields a Failure';
+    $v.so;  # mark handled
+}
+
+# Values beyond the small-Int (48-bit) range fall to the interpreter's BigInt arm.
+is (10 ** 20) div 3, 33333333333333333333, 'big dividend divs correctly';
+is (10 ** 20) mod 7, (10 ** 20) - 7 * ((10 ** 20) div 7), 'big dividend mods consistently';


### PR DESCRIPTION
## Problem

`div` and `mod` compile to `IntDiv` / `IntMod`, which the JIT did **not** inline. They sat on the `step_supported` whitelist, so a JIT-compiled loop bounced back into the interpreter through the generic `step` shim — a full `exec_one` dispatch plus a `current_code` save/restore — for every one of them.

On `benchmarks/time-parts.raku`, an integer loop built out of `div`/`mod`, this left almost nothing for the JIT to accelerate: turning the JIT on bought only ~10%.

## Fix

Give them a Tier B inline path alongside `Add`/`Sub`/`Mul`.

**Floor semantics.** Raku's `div`/`mod` floor toward negative infinity (`-7 div 3 == -3`, `-7 mod 3 == 2` — `mod` takes the sign of the *divisor*), while Cranelift's `sdiv`/`srem` truncate toward zero. `emit_int_divmod` therefore applies the floor correction: subtract 1 from the quotient (respectively add the divisor to the remainder) exactly when the truncated remainder is non-zero and the operand signs differ. That reproduces the interpreter arm's `Integer::div_floor` / `mod_floor` bit for bit.

**Fast-path guard.** The native path is entered only for two small-Int operands with a **non-zero** divisor (`sdiv` would otherwise trap). A zero divisor, `BigInt`, `Num`, junctions, and the single `MIN_48 div -1` result that overflows the small-Int range all fall to the shim, which reruns the full interpreter arm — so the divide-by-zero `Failure` and the BigInt/`to_int` coercions are unchanged. (The 48-bit sign-extended operands make `sdiv`'s other trap, `INT_MIN / -1`, unreachable.)

Both opcodes also get a dedicated `fallible_noarg_shim` (`int_div` / `int_mod`) instead of the generic `step`; that is what the Tier B slow path calls.

## Results

`benchmarks/time-parts.raku`, release, best of 5:

| | before | after |
|---|---|---|
| JIT on | 0.28s | **0.25s** |
| JIT off | 0.31s | 0.31s (unchanged, as expected) |

The JIT's speedup on that loop grows from ~10% to ~19%. Cumulatively with #4501 the benchmark goes 0.54s → 0.25s (**2.2x**), against raku's 0.21s.

## Tests

`make test` passes (Files=1689, Tests=16651, all successful).

New `t/jit-int-divmod.t` pins the native path against the interpreter: floor semantics for every sign combination, the defining `a == b*(a div b) + (a mod b)` identity and the `mod` range checked over a JIT-hot loop, the divide-by-zero `Failure`, and the BigInt fallback.

Verified to produce **identical output with `MUTSU_JIT=on` and `MUTSU_JIT=off`** across all sign combinations, zero divisors, BigInt and Num operands. roast `S03-operators/arith.t` and `div.t` pass in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw