### PR TITLE
fix(bind): propagate `:=` writes across the whole bind group, and inherit readonly

### DIFF
--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1285,8 +1285,19 @@ impl Interpreter {
             let resolved_source = self.resolve_sigilless_alias_source_name(&source_name);
             self.env_mut()
                 .insert(alias_key.clone(), Value::str(resolved_source.clone()));
-            self.env_mut()
-                .insert(runtime::sigilless_readonly_key(name), Value::FALSE);
+            // Binding aliases the source, so the target inherits its readonly-ness:
+            // `sub f($ro) { my $c := $ro; $c = 3 }` is an assignment to a readonly
+            // variable, exactly as `$ro = 3` would be. Writing an unconditional
+            // `False` here made the alias writable and silently dropped the store.
+            // (The SetGlobal bind path already propagates this.)
+            let source_readonly = self.is_readonly(&resolved_source);
+            self.env_mut().insert(
+                runtime::sigilless_readonly_key(name),
+                Value::truth(source_readonly),
+            );
+            if source_readonly {
+                self.mark_readonly(name);
+            }
             self.mark_sigilless_alias_seen();
             // Create a shared ContainerRef for cross-scope binding (source in
             // outer call frame) OR same-scope rebinding (`:=` on existing vars).
@@ -1756,9 +1767,17 @@ impl Interpreter {
             None
         };
         let mut seen_aliases = std::collections::HashSet::new();
+        // Slots the forward walk writes. A `:=` records each alias's target as the
+        // *root* of the chain (`my $y := $x; my $z := $y` stores `alias::z == "x"`),
+        // so the walk from `z` reaches `x` but never the sibling alias `y`. Feeding
+        // these slots into the reverse propagation below closes the bind group.
+        let mut aliased_slots: Vec<usize> = Vec::new();
         while let Some(current_alias) = alias_name {
             if !seen_aliases.insert(current_alias.clone()) {
                 break;
+            }
+            if let Some(slot) = self.find_local_slot(code, &current_alias) {
+                aliased_slots.push(slot);
             }
             self.update_local_if_exists(code, &current_alias, &val);
             self.env_mut().insert(current_alias.clone(), val.clone());
@@ -1785,8 +1804,19 @@ impl Interpreter {
         // update $y's slot so it reads 3.
         // Uses local_bind_pairs recorded at binding time to avoid
         // cross-scope name collisions.
+        //
+        // The pairs point root -> alias, so writing the root reaches every alias
+        // directly. Writing an *alias* only reaches the root (through the forward
+        // chain walk above); the root's other aliases are its siblings, not its
+        // targets, and would keep a stale value (`my $y := $x; my $z := $y; $z = 9`
+        // left `$y` at its old value). Propagating from the slots the walk wrote —
+        // i.e. from the root as well as from `idx` — closes the group, so every name
+        // bound together observes the write regardless of which one is assigned.
+        // The pairs are per-frame (saved/restored across calls), but a frame torn
+        // down by an exception can leave a pair whose slot index does not address
+        // this frame's `locals`. Skip those rather than index out of bounds.
         for &(source, target) in &self.local_bind_pairs {
-            if source == idx {
+            if target < self.locals.len() && (source == idx || aliased_slots.contains(&source)) {
                 self.locals[target] = val.clone();
             }
         }

--- a/t/bind-alias-chain.t
+++ b/t/bind-alias-chain.t
@@ -1,0 +1,104 @@
+use v6;
+use Test;
+
+# `:=` binds a name to a container: every name in a bind group observes writes
+# through any of them, and binding to a readonly source makes the target readonly.
+
+plan 12;
+
+# --- A chain of binds is one group: writing ANY member updates them all. ---
+# The bind records each alias's target as the *root* of the chain, so a write to
+# a leaf used to reach the root but leave the sibling aliases stale.
+{
+    my $x = 1;
+    my $y := $x;
+    my $z := $y;
+    $z = 9;
+    is "$x $y $z", "9 9 9", 'writing the leaf of a bind chain updates the whole group';
+}
+{
+    my $x = 1;
+    my $y := $x;
+    my $z := $y;
+    $y = 9;
+    is "$x $y $z", "9 9 9", 'writing the middle of a bind chain updates the whole group';
+}
+{
+    my $x = 1;
+    my $y := $x;
+    my $z := $y;
+    $x = 9;
+    is "$x $y $z", "9 9 9", 'writing the root of a bind chain updates the whole group';
+}
+
+# A four-deep chain, written from each position.
+{
+    my $a = 1;
+    my $b := $a;
+    my $c := $b;
+    my $d := $c;
+    $c = 7;
+    is "$a $b $c $d", "7 7 7 7", 'writing an inner name of a 4-deep chain updates all';
+}
+{
+    my $a = 1;
+    my $b := $a;
+    my $c := $b;
+    my $d := $c;
+    $d = 7;
+    is "$a $b $c $d", "7 7 7 7", 'writing the last name of a 4-deep chain updates all';
+}
+
+# The two-name case (which always worked) must keep working.
+{
+    my $x = 1;
+    my $y := $x;
+    $y = 9;
+    is "$x $y", "9 9", 'a two-name bind still propagates';
+}
+
+# An unrelated variable must NOT join the group.
+{
+    my $p = 1;
+    my $q = 2;
+    my $r := $p;
+    $r = 5;
+    is "$p $q $r", "5 2 5", 'an unbound variable is untouched by a group write';
+}
+
+# --- Binding to a readonly source makes the target readonly. ---
+{
+    my $died = False;
+    sub ro-bind($ro) {
+        my $c := $ro;
+        $c = 3;
+    }
+    { CATCH { default { $died = True } }; ro-bind(7) }
+    ok $died, 'assigning through a bind to a readonly param dies';
+}
+{
+    my $msg = '';
+    sub ro-bind2($ro) {
+        my $c := $ro;
+        $c = 3;
+    }
+    { CATCH { default { $msg = .message } }; ro-bind2(7) }
+    like $msg, /readonly/, 'and the error says the variable is readonly';
+}
+
+# A bind to a writable lexical stays writable.
+{
+    my $w = 1;
+    my $b := $w;
+    lives-ok { $b = 5 }, 'a bind to a writable lexical stays writable';
+    is $w, 5, 'and the write reaches the source';
+}
+
+# Reading through a readonly bind still works -- only assignment is barred.
+{
+    sub ro-read($ro) {
+        my $c := $ro;
+        $c
+    }
+    is ro-read(42), 42, 'a readonly bind is still readable';
+}


### PR DESCRIPTION
Two bugs in scalar `:=` binding, both found while profiling `time-parts` and both reproducing on `main`.

## 1. A bind chain only propagated from its root

`:=` records a bind as a `local_bind_pairs` entry pointing **root → alias**, and it resolves the source to the chain's *root* first. So `my $y := $x; my $z := $y` records `(x,y)` and `(x,z)` — never `(y,z)`.

Writing the root therefore reached every alias, but writing an alias only reached the root (through the forward alias-chain walk). The root's *other* aliases are its siblings, not its targets, so they kept a stale value:

```raku
my $x = 1; my $y := $x; my $z := $y;
$z = 9;  say "$x $y $z";   # mutsu: "9 1 9"    raku: "9 9 9"
$y = 9;  say "$x $y $z";   # mutsu: "9 9 1"    raku: "9 9 9"
$x = 9;  say "$x $y $z";   # mutsu: "9 9 9"    (root write already worked)
```

**Fix:** feed the slots the forward walk writes — the root as well as `idx` — into the reverse propagation, so every name in the group observes the write whatever its position in the chain. The slot index is bounds-checked: a frame torn down by an exception can leave a pair that does not address the current frame's `locals`.

## 2. Binding to a readonly source produced a writable alias

The `SetLocal` bind path wrote an unconditional `False` to the target's `__mutsu_sigilless_readonly::*` key, so the alias came out writable and the store was silently accepted:

```raku
sub f($ro) { my $c := $ro; $c = 3 }; f(7)   # mutsu: no error   raku: dies
```

A bind aliases the source, so the target inherits its readonly-ness — assigning through the alias *is* an assignment to a readonly variable, exactly as `$ro = 3` would be. **Fix:** propagate it, as the `SetGlobal` bind path already did.

## Tests

New `t/bind-alias-chain.t` (12 tests) covers both: writes from the root / middle / leaf of 3- and 4-deep chains, an unbound variable staying out of the group, the readonly bind dying with a readonly message, a writable bind staying writable, and a readonly bind still being readable.

**The test file passes under `raku` as well**, so the expectations are the spec's rather than mutsu's.

`make test` passes (Files=1689, Tests=16654, all successful); roast `S03-operators/assign.t`, `S02-types/declare.t`, `S06-signature/passing-arrays.t`, `S04-declarations/constant.t` all pass.

## Not fixed here

Pre-existing and reproducing on `main`: a bind to an `is rw` param does not write back to the caller — `sub f($x is rw) { my $c := $x; $c = 3 }` leaves the caller's variable at its old value (raku updates it). That is a separate gap in rw-param writeback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw