### PR TITLE
fix(bind): make `:=` onto an `is rw` parameter reach the caller

### DIFF
--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1283,8 +1283,24 @@ impl Interpreter {
         if let Some(source_name) = bind_source {
             let alias_key = runtime::sigilless_alias_key(name);
             let resolved_source = self.resolve_sigilless_alias_source_name(&source_name);
+            // The write path walks `__mutsu_sigilless_alias::<name>` hop by hop, so
+            // recording the *immediate* source keeps every intermediate name on the
+            // path. Pre-resolving straight to the chain's root skips them, and an
+            // `is rw` parameter is itself an alias of the caller's variable: in
+            // `sub f($x is rw) { my $c := $x; $c = 3 }` the source `x` resolved to
+            // the caller's `v`, a name with no slot in this frame, so neither `$x`
+            // nor the caller was ever updated. Redirect only when the immediate
+            // source really is a local here; otherwise keep the resolved root, as
+            // before (the walk reaches it either way).
+            let alias_target = if source_name != resolved_source
+                && code.locals.iter().any(|n| n == &source_name)
+            {
+                source_name.clone()
+            } else {
+                resolved_source.clone()
+            };
             self.env_mut()
-                .insert(alias_key.clone(), Value::str(resolved_source.clone()));
+                .insert(alias_key.clone(), Value::str(alias_target));
             // Binding aliases the source, so the target inherits its readonly-ness:
             // `sub f($ro) { my $c := $ro; $c = 3 }` is an assignment to a readonly
             // variable, exactly as `$ro = 3` would be. Writing an unconditional
@@ -1462,10 +1478,30 @@ impl Interpreter {
                 && !name.starts_with('%')
                 && !name.starts_with('&')
             {
-                let container = if let ValueView::ContainerRef(arc) = val.view() {
-                    Value::container_ref(arc.clone())
-                } else {
-                    val.clone().into_container_ref()
+                // Reuse the source's existing cell when it already has one, so a
+                // further bind joins the same cell instead of minting a rival.
+                // Reading the source derefs its cell, so `val` is the plain value
+                // and the `ContainerRef` arm below cannot catch this: without the
+                // lookup, `my $c := $x; my $d := $c` gave `$d` a fresh cell and cut
+                // it off from `$x`'s, so a write through `$d` never reached `$x`
+                // (nor, for an rw param, the caller). Mirrors the whole-container
+                // bind path, which already reuses the source cell.
+                let source_cell = code
+                    .locals
+                    .iter()
+                    .rposition(|n| n == &source_name)
+                    .and_then(|s| match self.locals[s].view() {
+                        ValueView::ContainerRef(arc) => Some(arc.clone()),
+                        _ => None,
+                    })
+                    .or_else(|| match self.env().get(&resolved_source).map(Value::view) {
+                        Some(ValueView::ContainerRef(arc)) => Some(arc.clone()),
+                        _ => None,
+                    });
+                let container = match (val.view(), source_cell) {
+                    (ValueView::ContainerRef(arc), _) => Value::container_ref(arc.clone()),
+                    (_, Some(arc)) => Value::container_ref(arc),
+                    _ => val.clone().into_container_ref(),
                 };
                 self.locals[idx] = container.clone();
                 // Update source in locals if present

--- a/t/bind-alias-chain.t
+++ b/t/bind-alias-chain.t
@@ -4,7 +4,7 @@ use Test;
 # `:=` binds a name to a container: every name in a bind group observes writes
 # through any of them, and binding to a readonly source makes the target readonly.
 
-plan 12;
+plan 16;
 
 # --- A chain of binds is one group: writing ANY member updates them all. ---
 # The bind records each alias's target as the *root* of the chain, so a write to
@@ -101,4 +101,43 @@ plan 12;
         $c
     }
     is ro-read(42), 42, 'a readonly bind is still readable';
+}
+
+# --- Binding to an `is rw` parameter writes through to the caller. ---
+# An `is rw` param is itself an alias of the caller's variable, so a bind onto it
+# must keep the param on the alias path rather than resolving straight past it to
+# the caller's name (which has no slot in the callee's frame).
+{
+    sub rw-bind($x is rw) {
+        my $c := $x;
+        $c = 3;
+        "$c $x"
+    }
+    my $v = 1;
+    my $inside = rw-bind($v);
+    is $inside, "3 3", 'a bind onto an rw param updates the param inside the sub';
+    is $v, 3, 'and the write reaches the caller';
+}
+
+# The same, one level deeper: a chain built on top of an rw param.
+{
+    sub rw-bind2($x is rw) {
+        my $c := $x;
+        my $d := $c;
+        $d = 8;
+    }
+    my $v = 1;
+    rw-bind2($v);
+    is $v, 8, 'a bind chain rooted at an rw param reaches the caller';
+}
+
+# A plain (non-rw) param is readonly, so the caller is NOT modified.
+{
+    sub ro-param($x) {
+        my $c := $x;
+        try { $c = 3 };
+    }
+    my $v = 1;
+    ro-param($v);
+    is $v, 1, 'a bind onto a readonly param cannot modify the caller';
 }


### PR DESCRIPTION
```raku
sub f($x is rw) { my $c := $x; $c = 3 }
my $v = 1; f($v); say $v;   # mutsu: 1    raku: 3
```

The write reached neither `$x` inside the sub nor the caller's `$v`. Two independent causes, each on the `SetLocal` bind path. (Follow-up to #4504, which fixed the plain-lexical bind chain and readonly inheritance.)

## 1. The bind resolved straight past the parameter

An `is rw` parameter is itself a sigilless alias of the caller's variable (`alias::x == "v"`), and a bind pre-resolved its source to the **root** of that chain. So `my $c := $x` recorded `alias::c == "v"` — a name with no slot in the callee's frame. The write walk follows the alias links hop by hop, so it skipped `$x` entirely and updated nothing:

```
in: 3 1     # $c updated, $x untouched   (raku: "in: 3 3")
```

**Fix:** record the *immediate* source when it is a local in this frame, so the walk visits every name on the path (`c` → `x` → `v`) and updates each. When the immediate source is not a local here, the resolved root is kept as before — the walk reaches it either way.

## 2. A second bind minted a rival cell

The scalar bind path wraps the bound value in a shared `ContainerRef` cell, but built that cell from `val` — and *reading* the source derefs its cell, so `val` is the plain value and the existing-cell arm never fired. `my $c := $x; my $d := $c` therefore gave `$d` a **fresh** cell, cutting it off from `$x`'s, and a write through `$d` reached neither `$x` nor the caller.

**Fix:** look the source's cell up (its local slot, else its env entry) and reuse it, so a further bind joins the same cell. This mirrors the whole-container bind path, which already reuses the source cell.

## Tests

`t/bind-alias-chain.t` grows four cases:

- a bind onto an rw param updates the param inside the sub, and the caller outside it
- a two-deep chain rooted at an rw param reaches the caller
- a bind onto a plain (readonly) param cannot modify the caller

**The file passes under `raku` as well** (16/16), so the expectations are the spec's rather than mutsu's.

`make test` passes (Files=1689, Tests=16658, all successful); roast `S03-operators/assign.t`, `S06-signature/passing-arrays.t`, `S02-types/declare.t`, `S04-declarations/constant.t` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw