### PR TITLE
perf(vm): stop `my $x = ...` from re-interning, re-hashing and COW-ing the env

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -136,6 +136,16 @@ static BOUND_SLICE_KEY_SEEN: AtomicBool = AtomicBool::new(false);
 /// over-set only makes the (correct) probe run.
 static ELEM_INDEX_META_SEEN: AtomicBool = AtomicBool::new(false);
 
+/// Monotonic, process-global flag for `^name` placeholder-parameter keys (`$^a`
+/// & co, bound under their careted name). Every by-name env *write* and *read*
+/// (`set_env_with_main_alias` / `get_env_with_main_alias` — i.e. every mirrored
+/// local store) otherwise probes for a de-careted alias, costing a `format!` plus
+/// a `Symbol::intern`ing env lookup per store. Placeholder params are bound
+/// through the String-keyed [`Env::insert`], so the same soundness argument as
+/// [`CLOSURE_META_KEY_SEEN`] applies: monotonic, and an over-set only makes the
+/// (correct) probe run.
+static PLACEHOLDER_KEY_SEEN: AtomicBool = AtomicBool::new(false);
+
 /// True if any closure-writeback metadata key may exist in some env. See
 /// [`CLOSURE_META_KEY_SEEN`].
 #[inline]
@@ -164,11 +174,28 @@ pub(crate) fn elem_index_meta_possible() -> bool {
     ELEM_INDEX_META_SEEN.load(Ordering::Relaxed)
 }
 
-/// Flip [`CLOSURE_META_KEY_SEEN`] / [`BOUND_KEY_SEEN`] if `key` is one of the
-/// tracked metadata keys. The outer `__mutsu_` gate keeps this ~1 byte compare
-/// for ordinary lexical names (which never start with `_`).
+/// True if any `^name` placeholder-parameter key may exist in some env. See
+/// [`PLACEHOLDER_KEY_SEEN`].
 #[inline]
-fn note_closure_meta_key(key: &str) {
+pub(crate) fn placeholder_var_possible() -> bool {
+    PLACEHOLDER_KEY_SEEN.load(Ordering::Relaxed)
+}
+
+/// Flip [`CLOSURE_META_KEY_SEEN`] / [`BOUND_KEY_SEEN`] / [`PLACEHOLDER_KEY_SEEN`]
+/// if `key` is one of the tracked metadata keys. The outer `__mutsu_` / `^` gates
+/// keep this ~1 byte compare for ordinary lexical names (which never start with
+/// `_` or `^`).
+///
+/// `pub(crate)` because the Symbol-keyed [`Env::insert_sym`] does not run it (its
+/// callers write pre-interned lexical slots, never metadata keys); a caller that
+/// routes a *name-derived* write through `insert_sym` must call this itself to
+/// keep the latches sound.
+#[inline]
+pub(crate) fn note_env_key(key: &str) {
+    if key.as_bytes().starts_with(b"^") {
+        PLACEHOLDER_KEY_SEEN.store(true, Ordering::Relaxed);
+        return;
+    }
     if key.as_bytes().starts_with(b"__mutsu_") {
         if key.starts_with("__mutsu_sigilless_")
             || key.starts_with("__mutsu_state_key::")
@@ -445,7 +472,7 @@ impl Env {
 
     #[inline]
     pub fn insert(&mut self, key: String, value: Value) -> Option<Value> {
-        note_closure_meta_key(&key);
+        note_env_key(&key);
         let sym = Symbol::intern(&key);
         self.untombstone(sym);
         self.cow_mut().insert(sym, value)
@@ -462,6 +489,16 @@ impl Env {
     }
 
     pub fn remove_sym(&mut self, key: Symbol) -> Option<Value> {
+        // Absent from a flat env's overlay: nothing to remove and no parent tier
+        // to tombstone, so the result is `None` either way. Bail before
+        // `cow_mut()`, whose `Arc::make_mut` costs an atomic RMW -- and a full
+        // map clone whenever the env is shared (a live closure/`saved_env` holds
+        // a handle). Every `my` declaration speculatively removes several
+        // metadata keys that the common program never creates, so this no-op
+        // removal is on the hottest declaration path in the VM.
+        if self.parent.is_none() && !self.inner.contains_key(&key) {
+            return None;
+        }
         let from_overlay = self.cow_mut().remove(&key);
         // Scoped env: if the key still exists in the parent/base tier, record a
         // tombstone so it stops shadowing through. The visible value before

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -385,6 +385,12 @@ pub(crate) type ClassAttributeDef = (
 /// hasher's SipHash-over-the-name with a `u32` hash.
 pub(crate) type ReadonlySet = Arc<rustc_hash::FxHashSet<Symbol>>;
 
+/// A set of variable names (`block_declared_vars` / `loop_local_vars`). Every
+/// `my` declaration probes both, so they use the same non-cryptographic hasher
+/// as the env rather than std's SipHash — the keys are short lexical names and
+/// the maps are process-internal, never fed untrusted input.
+pub(crate) type NameSet = rustc_hash::FxHashSet<String>;
+
 /// Per-class plan for the native default constructor
 /// (`try_native_default_construct`): everything about the class shape that the
 /// constructor consulted on EVERY construction but that only changes when the
@@ -1854,8 +1860,8 @@ pub struct Interpreter {
     /// in the stored map and are not collected — so the accessor fallback still
     /// reads them.
     pub(crate) user_declared_classes: std::collections::HashSet<String>,
-    pub(crate) block_declared_vars: Vec<HashSet<String>>,
-    pub(crate) loop_local_vars: Vec<HashSet<String>>,
+    pub(crate) block_declared_vars: Vec<NameSet>,
+    pub(crate) loop_local_vars: Vec<NameSet>,
     pub(crate) loop_local_saved_env: Vec<HashMap<String, Value>>,
     pub(crate) loop_cond_active: bool,
     pub(crate) outer_scope_locals: Vec<Vec<Value>>,

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -292,7 +292,32 @@ impl Interpreter {
 
     /// Write a shared variable. Updates both the local env and shared_vars.
     pub(crate) fn set_shared_var(&mut self, key: &str, value: Value) {
-        self.env.insert(key.to_string(), value.clone());
+        self.set_shared_var_sym(key, None, value);
+    }
+
+    /// [`set_shared_var`] with a pre-interned `Symbol` for `key`. The env is
+    /// Symbol-keyed, so the String-keyed entry point pays a `key.to_string()`
+    /// allocation plus a `Symbol::intern` on *every* mirrored local store
+    /// (`flush_local_to_env` runs on each `my $x = ...`). Callers that already
+    /// hold the slot's interned Symbol (`CompiledCode::locals_sym`) pass it here
+    /// and skip both. The latch bookkeeping the String path gets from
+    /// `Env::insert` is done explicitly (`note_env_key`) so the metadata flags
+    /// stay sound.
+    pub(crate) fn set_shared_var_sym(
+        &mut self,
+        key: &str,
+        sym: Option<crate::symbol::Symbol>,
+        value: Value,
+    ) {
+        match sym {
+            Some(sym) => {
+                crate::env::note_env_key(key);
+                self.env.insert_sym(sym, value.clone());
+            }
+            None => {
+                self.env.insert(key.to_string(), value.clone());
+            }
+        }
         if self.shared_vars_active {
             // Ensure @-variables always store Array(true) (real Arrays) in the
             // cross-thread shared store, which backs the atomic-array CAS

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -108,6 +108,17 @@ impl Interpreter {
             // env-scoped `__mutsu_type::*` entry has ever been inserted, so when
             // it is false no such env entry can exist to remove. The two map
             // removes borrow `name` (`&str`) and never allocate.
+            // Both maps empty and no env-scoped constraint ever registered: there
+            // is nothing any of the three clears could find. Bail before the
+            // (SipHash-keyed) `remove` probes — this runs on every `my`
+            // declaration, so a hot loop body pays two string hashes per `my`
+            // just to look up keys that cannot exist.
+            if self.var_type_constraints.is_empty()
+                && self.var_hash_key_constraints.is_empty()
+                && !self.env_type_constraint_seen
+            {
+                return;
+            }
             let had_constraint = self.var_type_constraints.remove(name).is_some();
             let had_hash_key = self.var_hash_key_constraints.remove(name).is_some();
             if had_constraint || had_hash_key || self.env_type_constraint_seen {
@@ -243,6 +254,9 @@ impl Interpreter {
 
     /// Get the default value for a variable, if one was set with `is default(...)`.
     pub(crate) fn var_default(&self, name: &str) -> Option<&Value> {
+        if self.var_defaults.is_empty() {
+            return None;
+        }
         self.var_defaults.get(name)
     }
 
@@ -250,6 +264,11 @@ impl Interpreter {
     /// variable redeclaration so a new `my @a` does not inherit the
     /// default from an earlier same-named variable.
     pub(crate) fn clear_var_default(&mut self, name: &str) {
+        // Runs on every `my` declaration; `is default(...)` is rare, so the
+        // common program's map is empty and the (SipHash-keyed) probe is waste.
+        if self.var_defaults.is_empty() {
+            return;
+        }
         self.var_defaults.remove(name);
     }
 

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -158,6 +158,14 @@ impl Interpreter {
         }
     }
 
+    /// True when nothing at all is marked readonly. Lets a caller on the
+    /// declaration hot path skip the sigil-strip + `Symbol::intern` that
+    /// [`unmark_readonly`] would need just to miss.
+    #[inline]
+    pub(crate) fn no_readonly_vars(&self) -> bool {
+        self.readonly_vars.is_empty()
+    }
+
     /// Remove a variable from the readonly set.
     pub(crate) fn unmark_readonly(&mut self, name: &str) {
         self.unmark_readonly_sym(Symbol::intern(name));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -308,7 +308,7 @@ pub(crate) struct VmCallFrame {
     /// snapshotting them here a callee invoked from inside a loop body would
     /// register its own `my` declarations in the *caller's* active loop scope and
     /// have them clobbered at the caller's loop exit.
-    pub saved_loop_local_vars: Vec<HashSet<String>>,
+    pub saved_loop_local_vars: Vec<crate::runtime::NameSet>,
     pub saved_loop_local_saved_env: Vec<HashMap<String, Value>>,
     /// The caller's block-scope `my`-declaration tracking stack. A `BlockScope`
     /// pushes a frame here and, on exit, reverts every name it records to the
@@ -318,7 +318,7 @@ pub(crate) struct VmCallFrame {
     /// its own blocks) would register in the *caller's* active `BlockScope` frame
     /// and get reverted at the caller's block exit — clobbering a same-named
     /// caller variable across a recursive call.
-    pub saved_block_declared_vars: Vec<HashSet<String>>,
+    pub saved_block_declared_vars: Vec<crate::runtime::NameSet>,
 }
 
 // CP-3 collapse: the bytecode Interpreter has been fully dissolved into the `Interpreter`

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -149,7 +149,8 @@ impl Interpreter {
     /// per-iteration binding semantics. Must be balanced by `pop_loop_local_scope`
     /// on every exit path.
     pub(super) fn push_loop_local_scope(&mut self) {
-        self.loop_local_vars.push(std::collections::HashSet::new());
+        self.loop_local_vars
+            .push(crate::runtime::NameSet::default());
         self.loop_local_saved_env
             .push(std::collections::HashMap::new());
     }
@@ -219,7 +220,7 @@ impl Interpreter {
         self.push_loop_local_scope();
         // Track `my` declarations made directly in this branch.
         self.block_declared_vars
-            .push(std::collections::HashSet::new());
+            .push(crate::runtime::NameSet::default());
         let res = self.run_range(code, body_start, body_end, compiled_fns);
         let block_declared = self.block_declared_vars.pop().unwrap_or_default();
         // Restore shadowed outer bindings on every exit path (including errors

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -434,8 +434,10 @@ impl Interpreter {
             return self.env().get(&bare).cloned();
         }
         // Placeholder block parameters are stored as "^name". Allow lexical
-        // access by the de-careted name inside the same block.
-        if !name.starts_with('^') {
+        // access by the de-careted name inside the same block. Gated on the
+        // process-global latch: without a `^name` key anywhere, the `format!` +
+        // interning probe can only miss.
+        if crate::env::placeholder_var_possible() && !name.starts_with('^') {
             let placeholder = format!("^{name}");
             if let Some(val) = self.env().get(&placeholder) {
                 return Some(val.clone());
@@ -456,7 +458,7 @@ impl Interpreter {
     pub(super) fn set_env_with_main_alias_sym(
         &mut self,
         name: &str,
-        _name_sym: Option<Symbol>,
+        name_sym: Option<Symbol>,
         value: Value,
     ) {
         // Slice B (docs/vm-single-store.md): while a carrier (EVAL / interpreter
@@ -471,7 +473,11 @@ impl Interpreter {
             self.env_mut().insert(name.to_string(), value);
             return;
         }
-        if !name.starts_with('^') {
+        // A placeholder param (`$^a`) is bound under its careted name, so a write
+        // to the de-careted lexical must land on it. Skipped outright unless some
+        // `^name` key has ever been created (the common program), which otherwise
+        // costs a `format!` + an interning env probe on every mirrored local store.
+        if crate::env::placeholder_var_possible() && !name.starts_with('^') {
             let placeholder = format!("^{name}");
             if self.env().contains_key(&placeholder) {
                 loan_env!(self, set_shared_var(&placeholder, value.clone()));
@@ -479,7 +485,7 @@ impl Interpreter {
                 return;
             }
         }
-        loan_env!(self, set_shared_var(name, value.clone()));
+        loan_env!(self, set_shared_var_sym(name, name_sym, value.clone()));
         if let Some(alias) = Self::twigil_dynamic_alias(name) {
             self.env_mut().insert(alias, value.clone());
         }

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -179,7 +179,7 @@ impl Interpreter {
         let once_scope = self.next_once_scope_id();
         // Track variables declared within this block scope.
         self.block_declared_vars
-            .push(std::collections::HashSet::new());
+            .push(crate::runtime::NameSet::default());
         // Push saved locals for $OUTER:: variable access.
         self.outer_scope_locals.push(saved_locals.clone());
         // Baseline for the ENTER-result stack: any value captured by this block's

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -266,14 +266,21 @@ impl Interpreter {
             // Clear the deleted-index tracker left over from a previous
             // same-named variable in an outer scope. (Pre-interned key: this
             // whole block runs on every declaration, so a loop-body `my $t`
-            // pays it once per iteration.)
-            if let Some(sym) = code.deleted_index_sym(idx) {
+            // pays it once per iteration.) Skipped outright when no such key has
+            // ever been created -- the program never `:delete`d an index, so
+            // there is nothing to clear.
+            if crate::env::elem_index_meta_possible()
+                && let Some(sym) = code.deleted_index_sym(idx)
+            {
                 self.env_mut().remove_sym(sym);
             }
             // Clear any sigilless-readonly flag inherited from an outer
             // scope (e.g. a for-loop `\result` shouldn't block `my $result`
-            // in a called sub).
-            if let Some(sym) = code.readonly_sym(idx) {
+            // in a called sub). Same latch: the `__mutsu_sigilless_readonly::*`
+            // key only exists once the program creates a sigilless/`:=` alias.
+            if crate::env::closure_meta_keys_possible()
+                && let Some(sym) = code.readonly_sym(idx)
+            {
                 self.env_mut().remove_sym(sym);
             }
             // A fresh `my $x = ...` declaration (plain `=`, not `:=`) drops the
@@ -289,6 +296,7 @@ impl Interpreter {
             // their own alias bookkeeping and are excluded.
             if !is_bind
                 && !scalar_bind
+                && crate::env::closure_meta_keys_possible()
                 && let Some(sym) = code.alias_sym(idx)
             {
                 self.env_mut().remove_sym(sym);
@@ -304,7 +312,9 @@ impl Interpreter {
             // marking is set as part of the bind — unmarking it here would let a
             // subsequent `$y = 6` slip through. Strip the sigil to match the bare
             // key form used by check_readonly_for_modify.
-            if !is_bind && !scalar_bind {
+            // Nothing is readonly yet: skip the sigil-strip + `Symbol::intern` of
+            // the bare name (this runs on every declaration).
+            if !is_bind && !scalar_bind && !self.no_readonly_vars() {
                 let bare = name.trim_start_matches(['$', '@', '%', '&']);
                 self.unmark_readonly(bare);
             }
@@ -1881,6 +1891,11 @@ impl Interpreter {
         dynamic: bool,
     ) {
         let name = Self::const_str(code, name_idx);
+        // The env is Symbol-keyed and this op runs on *every* `my` declaration
+        // (five times per iteration of a loop body that declares five lexicals),
+        // so the name is interned once per constant slot instead of on each
+        // execution.
+        let name_sym = code.const_sym(name_idx);
         loan_env!(self, set_var_dynamic(name, dynamic));
         // A fresh declaration without an explicit type must not inherit stale
         // constraints from an earlier lexical with the same name.
@@ -1913,8 +1928,18 @@ impl Interpreter {
         // restored. Restoring it would wipe an accumulated `0,1,2` back to its
         // first-iteration value. Genuine body-local shadows (`for {...{ my @a }}`)
         // always get a slot, so this distinguishes the two reliably.
+        //
+        // `already_loop_local` is tested FIRST (it is a plain set probe): from the
+        // second iteration on it is true for every body-local `my`, which makes
+        // `has_coherent_slot` false regardless — so the env read and the O(locals)
+        // coherence scan below are pure waste on all but the first iteration.
+        let already_loop_local = self
+            .loop_local_vars
+            .last()
+            .is_some_and(|s| s.contains(name));
         if !self.loop_cond_active
-            && let Some(prev) = self.env().get(name).cloned()
+            && !already_loop_local
+            && let Some(prev) = self.env().get_sym(name_sym).cloned()
         {
             // Only record a *genuine, live* enclosing binding for restoration.
             // The restore writes back both env and the local slot, so the value
@@ -1928,21 +1953,17 @@ impl Interpreter {
             // at loop exit. Requiring slot==env restores only true shadows
             // (`my @a=1,2,3; for { my @a=7,8 }` keeps the outer `1,2,3`) and leaves
             // enclosing-scoped statement-modifier declarations alone.
-            // Also skip names this loop already declared in a prior iteration
-            // (`loop_local_vars`, populated below). After iteration 1 of an
+            // Names this loop already declared in a prior iteration
+            // (`loop_local_vars`, populated below) are excluded by the
+            // `already_loop_local` guard on the `if` above: after iteration 1 of an
             // accumulating statement-modifier loop, env and slot agree on the
             // partial result, which would spuriously look coherent; that value is
             // the loop's own, not an enclosing binding.
-            let already_loop_local = self
-                .loop_local_vars
-                .last()
-                .is_some_and(|s| s.contains(name));
-            let has_coherent_slot = !already_loop_local
-                && code
-                    .locals
-                    .iter()
-                    .enumerate()
-                    .any(|(i, n)| n.as_str() == name && self.locals.get(i) == Some(&prev));
+            let has_coherent_slot = code
+                .locals
+                .iter()
+                .enumerate()
+                .any(|(i, n)| n.as_str() == name && self.locals.get(i) == Some(&prev));
             if has_coherent_slot
                 && let Some(saved) = self.loop_local_saved_env.last_mut()
                 && !saved.contains_key(name)
@@ -1959,7 +1980,7 @@ impl Interpreter {
         // `&name = Any` before the RHS runs makes `EVAL(q[sub name() { ... }])`
         // look like a routine redeclaration instead of producing a callable to
         // bind into `my &name = ...`.
-        if !name.starts_with('&') && !self.env().contains_key(name) {
+        if !name.starts_with('&') && !self.env().contains_key_sym(name_sym) {
             let default = if name.starts_with('@') {
                 Value::real_array(Vec::new())
             } else if name.starts_with('%') {
@@ -1967,17 +1988,26 @@ impl Interpreter {
             } else {
                 Value::package(crate::symbol::Symbol::intern("Any"))
             };
-            self.env_mut().insert(name.to_string(), default);
+            crate::env::note_env_key(name);
+            self.env_mut().insert_sym(name_sym, default);
         }
         // Track this variable as declared within the current block scope.
         // BlockScope restoration uses this to avoid propagating block-local
         // variable values back to the outer scope.
-        if let Some(set) = self.block_declared_vars.last_mut() {
+        //
+        // Both sets are keyed by owned `String`s and both survive across loop
+        // iterations, so the `contains` probe (which borrows `name`) keeps a
+        // re-executed declaration from allocating a fresh key per iteration.
+        if let Some(set) = self.block_declared_vars.last_mut()
+            && !set.contains(name)
+        {
             set.insert(name.to_string());
         }
         // Track loop-body declarations so a closure created in the body can mark
         // this name as a per-iteration `owned_capture` (see Interpreter::loop_local_vars).
-        if let Some(set) = self.loop_local_vars.last_mut() {
+        if let Some(set) = self.loop_local_vars.last_mut()
+            && !set.contains(name)
+        {
             set.insert(name.to_string());
         }
     }


### PR DESCRIPTION
## What

Every `my` declaration ran a fixed preamble of metadata bookkeeping that the common program can never need, and each step paid for it in string hashing, `Symbol::intern`ing and copy-on-write env forks. A loop body with five `my` declarations paid it five times per iteration — `time-parts` is exactly that shape, and it was the last benchmark still slower than raku.

Profiling `time-parts` (release, `perf record -g`) showed the cost was almost entirely bookkeeping, not arithmetic:

| symbol | before |
|---|---|
| `exec_set_local_op_inner` | 12.6% |
| `Symbol::intern` (thread-local memo) | 8.0% + 1.6% |
| `__memcmp_avx2` (String-key probes) | 5.9% |
| SipHash (`hash_one` + `Sip::write`) | 6.7% |
| `Env::insert` / `cow_mut` | 5.2% |
| `format!` (`format_inner` + `fmt::write`) | 4.3% |
| `set_shared_var` | 2.7% |
| malloc/free/realloc | ~9.7% |

## Changes

Per declaration, the following are now skipped or made key-free:

- **Placeholder alias probe.** `set_env_with_main_alias` did `format!("^{name}")` + an interning env lookup on *every* mirrored local store, to find a de-careted `$^a` binding. Gated on a new `PLACEHOLDER_KEY_SEEN` latch alongside the existing metadata latches — `^name` keys are only ever created through the String-keyed `Env::insert`, so when none exists the probe can only miss. Same gate on the mirror-image read path.
- **The discarded Symbol.** `flush_local_to_env` already passed the slot's pre-interned Symbol, and `set_env_with_main_alias_sym` dropped it on the floor (`_name_sym`), then re-interned the name and allocated a `String` key for the write. `set_shared_var_sym` now takes it straight through to the Symbol-keyed env.
- **`SetVarDynamic`** re-interned the name for two env probes (now `const_sym`), allocated a fresh `String` per iteration for two decl-tracking sets (now `contains`-first), and ran an env read plus an O(locals) coherence scan that the `already_loop_local` guard makes dead from the second iteration on (now tested first).
- **Speculative metadata removes.** Clearing the `deleted_index` / `sigilless_readonly` / `sigilless_alias` env keys is gated on the latches that already say whether such a key can exist. `Env::remove_sym` also bails before `cow_mut()` when the key is absent from a flat env — a no-op remove was costing an `Arc::make_mut` (an atomic RMW, and a full map clone whenever a closure or `saved_env` shares the handle).
- **Empty-map probes.** `clear_var_default` / `var_default` / `var_type_constraint`'s clear path and the readonly unmark all probe SipHash-keyed String maps that are empty in a program with no `is default(...)`, no type constraints and nothing readonly. Each bails on the empty map.
- **`block_declared_vars` / `loop_local_vars`** are now `FxHashSet` (`NameSet`) rather than SipHash-keyed, matching the env. Both sets are only ever probed and iterated for order-independent per-name work, so the hasher swap is behaviour-identical.

## Result

`time-parts`, median of 7, same quiet window, `raku` measured in the same window (0.2213s):

| config | before | after | ratio vs raku |
|---|---|---|---|
| JIT on (default) | 0.2551s | **0.1409s** | 1.14 → **0.64** |
| interpreter only | 0.2379s | **0.2052s** | 1.46 (CI) → **0.93** |

`time-parts+jit` was the only benchmark above 1.0 against raku; it is now comfortably under, and the pure interpreter beats raku on it too. The other 12 benchmarks are unchanged within noise (these changes only remove work; `bench-mandelbrot` and `bench-hash` improved slightly).

Local numbers are for the PR description only — the bench CI history is the source of truth.

## Testing

- `t/`: 1690 files pass (the only failure is `io-socket-recv-limit.t`, the known `-j4`-load flake; it passes alone).
- roast: 781 whitelisted files across S02/S03-assign/S04/S05/S06/S09/S11/S12/S17/S32 pass — the declaration, scope, closure, regex, OO, concurrency and IO surfaces this touches. Full roast to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw