### PR TITLE
perf(vm): key the block/loop declaration sets by Symbol, not String

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2065,6 +2065,16 @@ impl CompiledCode {
         }
     }
 
+    /// The interned name of local `idx`. Served from the pre-interned table; a
+    /// hand-built chunk that never ran `compute_locals_sym` falls back to
+    /// interning on the spot, so a by-Symbol slot match is never silently missed.
+    pub(crate) fn local_sym(&self, idx: usize) -> Option<Symbol> {
+        match self.locals_sym.get(idx) {
+            Some(sym) => Some(*sym),
+            None => self.locals.get(idx).map(|n| Symbol::intern(n)),
+        }
+    }
+
     /// Pre-intern all local names as Symbols.
     /// The interned `__mutsu_sigilless_alias::<name>` env key of local `idx`.
     /// Served from the pre-interned table; a hand-built chunk that never ran

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -385,11 +385,16 @@ pub(crate) type ClassAttributeDef = (
 /// hasher's SipHash-over-the-name with a `u32` hash.
 pub(crate) type ReadonlySet = Arc<rustc_hash::FxHashSet<Symbol>>;
 
-/// A set of variable names (`block_declared_vars` / `loop_local_vars`). Every
-/// `my` declaration probes both, so they use the same non-cryptographic hasher
-/// as the env rather than std's SipHash — the keys are short lexical names and
-/// the maps are process-internal, never fed untrusted input.
-pub(crate) type NameSet = rustc_hash::FxHashSet<String>;
+/// A set of variable names (`block_declared_vars` / `loop_local_vars`), keyed by
+/// the interned `Symbol` rather than an owned `String`.
+///
+/// Every `my` declaration probes both sets, and every consumer already holds the
+/// name's `Symbol` (env keys, `CompiledCode::locals_sym`, closure free vars) —
+/// the String keying made each probe hash the name's bytes and `memcmp` them on
+/// a hit, and each insert allocate. A `Symbol` is a `Copy` u32: the hash is
+/// free, the compare is an integer compare, and the (cold) consumers that need
+/// text call `resolve()`.
+pub(crate) type NameSet = rustc_hash::FxHashSet<Symbol>;
 
 /// Per-class plan for the native default constructor
 /// (`try_native_default_construct`): everything about the class shape that the

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -211,11 +211,9 @@ impl Interpreter {
         // removed fresh declaration's frame slot can be reset to its pre-branch
         // value. Both are cheap relative to a full `BlockScope` env restore and
         // are only paid when the branch actually declares a block-local.
-        let env_had_before: std::collections::HashSet<String> = self
-            .env()
-            .keys()
-            .map(|s| s.with_str(|x| x.to_string()))
-            .collect();
+        // The env is Symbol-keyed, so the snapshot is a set of `Copy` u32s — no
+        // per-key String allocation.
+        let env_had_before: crate::runtime::NameSet = self.env().keys().copied().collect();
         let saved_locals = self.locals.clone();
         self.push_loop_local_scope();
         // Track `my` declarations made directly in this branch.
@@ -231,15 +229,15 @@ impl Interpreter {
         // `pop_loop_local_scope` only restores names that shadowed an existing
         // outer binding, so remove the fresh declarations here, resetting their
         // env entry and frame slot to the pre-branch state.
-        for name in &block_declared {
+        for sym in &block_declared {
             // `our`/dynamic/package-qualified names have their own scoping and
             // must persist; only plain lexicals were recorded as block-local.
-            if env_had_before.contains(name) {
+            if env_had_before.contains(sym) {
                 continue;
             }
-            self.env_mut().remove(name);
-            for (idx, slot_name) in code.locals.iter().enumerate() {
-                if slot_name == name && idx < self.locals.len() {
+            self.env_mut().remove_sym(*sym);
+            for idx in 0..code.locals.len().min(self.locals.len()) {
+                if code.local_sym(idx) == Some(*sym) {
                     self.locals[idx] = saved_locals.get(idx).cloned().unwrap_or(Value::NIL);
                 }
             }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3743,8 +3743,9 @@ impl Interpreter {
                 self.mark_my_scoped_package_item(name.clone());
                 // Mark as block-declared so the name is cleaned up
                 // when the enclosing block scope exits.
+                let name_sym = code.const_sym(*name_idx);
                 if let Some(set) = self.block_declared_vars.last_mut() {
-                    set.insert(name);
+                    set.insert(name_sym);
                 }
                 *ip += 1;
             }

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -367,7 +367,7 @@ impl Interpreter {
                 // Variables declared with `my` inside this block should not
                 // propagate their values to the outer scope. Restore the outer
                 // scope's original value instead.
-                if k.with_str(|s| block_declared.contains(s)) {
+                if block_declared.contains(&k) {
                     continue;
                 }
                 restored_env.insert_sym(k, v);
@@ -430,8 +430,8 @@ impl Interpreter {
         // `my` redeclaration of the same name is not marked as readonly by
         // the now-gone binding (`my %h := SetHash.new(...)` inside a block
         // must not leave `%h` readonly in the outer scope).
-        for name in &block_declared {
-            self.unmark_readonly(name);
+        for sym in &block_declared {
+            self.unmark_readonly_sym(*sym);
         }
         // Note: `our`-scoped variables persist in our_vars and are accessible
         // via package-qualified names (e.g., $Pkg::var) after block exit.

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -308,7 +308,7 @@ impl Interpreter {
         };
         cc.free_var_syms
             .iter()
-            .filter(|sym| sym.with_str(|s| self.loop_local_vars.iter().any(|set| set.contains(s))))
+            .filter(|sym| self.loop_local_vars.iter().any(|set| set.contains(*sym)))
             .copied()
             .collect()
     }
@@ -574,10 +574,7 @@ impl Interpreter {
             if s.starts_with('@') || s.starts_with('%') || s.starts_with('&') {
                 continue;
             }
-            let is_loop_local = self
-                .loop_local_vars
-                .iter()
-                .any(|set| set.contains(s.as_str()));
+            let is_loop_local = self.loop_local_vars.iter().any(|set| set.contains(sym));
             // Emit-point slot (§1.3 slot bake, gated): the creator slot this
             // closure actually captures. Falls back to the rposition name
             // search (byte-identical with the gate off / for hand-built cc).

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1728,7 +1728,7 @@ impl Interpreter {
         let already_loop_local = self
             .loop_local_vars
             .last()
-            .is_some_and(|s| s.contains(name));
+            .is_some_and(|s| s.contains(&name_sym));
         if !self.loop_cond_active
             && !already_loop_local
             && let Some(prev) = self.env().get_sym(name_sym).cloned()
@@ -1786,21 +1786,13 @@ impl Interpreter {
         // Track this variable as declared within the current block scope.
         // BlockScope restoration uses this to avoid propagating block-local
         // variable values back to the outer scope.
-        //
-        // Both sets are keyed by owned `String`s and both survive across loop
-        // iterations, so the `contains` probe (which borrows `name`) keeps a
-        // re-executed declaration from allocating a fresh key per iteration.
-        if let Some(set) = self.block_declared_vars.last_mut()
-            && !set.contains(name)
-        {
-            set.insert(name.to_string());
+        if let Some(set) = self.block_declared_vars.last_mut() {
+            set.insert(name_sym);
         }
         // Track loop-body declarations so a closure created in the body can mark
         // this name as a per-iteration `owned_capture` (see Interpreter::loop_local_vars).
-        if let Some(set) = self.loop_local_vars.last_mut()
-            && !set.contains(name)
-        {
-            set.insert(name.to_string());
+        if let Some(set) = self.loop_local_vars.last_mut() {
+            set.insert(name_sym);
         }
     }
 


### PR DESCRIPTION
## What

`block_declared_vars` and `loop_local_vars` track which names a block or loop body declared. Both are probed on **every** `my` declaration — a five-lexical loop body probes them five times per iteration — and both were keyed by owned `String`s: each probe hashed the name's bytes and `memcmp`ed them on a hit, and each first insert allocated.

Every producer and consumer already holds the name's interned `Symbol`: the declaration site has `CompiledCode::const_sym`, the env is Symbol-keyed, closure free vars are `free_var_syms`. So the String keying was a pure round-trip — several consumers literally did `sym.with_str(|s| set.contains(s))` to look up a Symbol they already had.

## Changes

`NameSet` is now `FxHashSet<Symbol>`. A `Symbol` is a `Copy` u32: the hash is free, the compare is an integer compare, and nothing allocates. Every consumer gets *simpler*, not more complex:

- **`capture_closure_env` / `owned_captures`** — `set.contains(sym)` instead of resolving the Symbol back to a string to probe with.
- **`BlockScope` restore** — `block_declared.contains(&k)` directly against the Symbol-keyed env key.
- **Block exit** — `unmark_readonly_sym(sym)` instead of re-interning the name.
- **`BlockLocalScope`'s pre-branch env snapshot** (`env_had_before`) collects the env's Symbol keys directly. It was allocating a `String` for *every key in the env* on each branch entry.

`CompiledCode::local_sym(idx)` is added for the one slot-match consumer, with the same intern-on-the-spot fallback as its `alias_sym` / `readonly_sym` siblings, so a hand-built chunk cannot silently miss a match.

## Result

`time-parts` (median of 7, same quiet window, raku measured in the same window): ratio **0.646 → 0.624**.

The other benchmarks move within run-to-run drift. `fib` in particular cannot be affected — with no loop or block scope its `loop_local_vars` / `block_declared_vars` are empty and every touched path early-outs — so the few percent it wanders between builds is the binary-layout noise the CLAUDE.md bench guidance warns about, not signal. The bench CI history is the source of truth.

## Testing

- `t/`: 1690 files pass (only `io-socket-recv-limit.t`, the known `-j4`-load flake, which passes alone).
- roast: 781 whitelisted files (S02 / S03-assign / S04 / S05 / S06 / S09 / S11 / S12 / S17 / S32) pass — including the loop-local closure-capture surface (`owned_captures`) this touches directly. Full roast to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw