### PR TITLE
docs: record the declaration-path perf slice and the `needs_env_sync` blocker

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -324,9 +324,25 @@ S\* 系で唯一残る実機能ギャップ（whitelist には直結しない）
       return マージの allocation-free 化（#4492 — **bench-fib -32.3% / bench-tak -23.9%**）／
       sigilless-alias・readonly の env キー事前 intern（#4493 — num-arith -21.6% /
       bench-mandelbrot -14.9%）／属性の `Symbol` キー化（#4494 — 上記 ✅）／宣言・store ごとの
-      メタデータキー再構築の停止（#4495 — time-parts -37.2% / bench-mandelbrot -33.7%）。
+      メタデータキー再構築の停止（#4495 — time-parts -37.2% / bench-mandelbrot -33.7%）／
+      **宣言パス（`my $x = ...`）の intern・SipHash・COW 撤去**（#4506/#4507/#4508 — time-parts
+      は **JIT on で raku 比 1.17 → 0.62**、interp 単体でも 1.46 → 0.93 と raku 超え。
+      内訳 = placeholder `^name` プローブのラッチ化・`flush_local_to_env` が捨てていた
+      事前 intern 済み Symbol の活用・`SetVarDynamic` の再 intern/String 確保撤去・
+      不在キー削除での `Arc::make_mut` 回避・空マップへの SipHash プローブ撤去・
+      宣言追跡セットの `Symbol` キー化。あわせて**到達不能だった `simple_locals`
+      fast path 約 310 行を削除**（scalar local はシジル無しで格納されるため
+      `name.starts_with('$')` が常に false ＝ 一度も実行されていなかった））。
 
       **残（着手順）**:
+      0. **★`needs_env_sync` のブランケット解除（次の本命・専用セッション向き）** — 現状
+         `captures_env_by_name`（frame に `ForLoop`/`BlockScope`/`MakeGather`/`WheneverScope`
+         が 1 つでもあれば true）が **frame の全 local を env ミラー対象にする**ため、
+         ループ本体の `my $ts` のように名前で読まれない local まで毎ストア env へ書いている
+         （time-parts 残プロファイルの最上位）。精密化するには `exec_do_block_op` の
+         「全 local を env から pull」する復元・ループの shadow save/restore・
+         closure capture の 3 つの env 名前依存を同時に外す必要があり、
+         **§1.3/§1.5 と一体のキャンペーン**（memory: 単独変更は 5 機構を壊す実績あり）。
       1. **`compiled_fns` の SipHash 撤去**（scouting §2.1 — 関数テーブルが今も
          `HashMap<String, CompiledFunction>`（`vm.rs:280`）で、**light-call キャッシュに当たった
          呼び出しでも毎回関数名を SipHash + memcmp している**）。FxHashMap 化 →`Symbol` キー化 →

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,53 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-14: `my $x = ...` が intern・SipHash・COW を払うのをやめた — time-parts が raku 比 1.17 → 0.62（#4506 / #4507 / #4508）
+
+time-parts は **JIT on でも raku より遅い唯一のベンチ**（比 1.17）として残っていた。profile を
+取ると、遅さは算術ではなく**宣言そのもの**にあった。ループ本体の `my` 5 本 × 10 万回、
+つまり 50 万回の宣言が、それぞれ固定のメタデータ簿記を実行していた:
+
+| 症状 | 犯人 |
+|---|---|
+| `Symbol::intern` 9.6% | env は Symbol キーなのに、ミラー書き込みが毎回名前を intern し直していた |
+| `format!` 4.3% | 全ミラーストアで `format!("^{name}")` を組み、placeholder 別名の有無を env に問い合わせていた |
+| SipHash 6.7% | 空の `HashMap<String, _>`（型制約・`is default`・readonly）を毎宣言プローブ |
+| `Env::insert`/`cow_mut` 5.2% | **存在しないキーの削除**が `Arc::make_mut`（＝ env が共有されていれば map 全体の clone）を起こしていた |
+| `__memcmp_avx2` 5.9% | 宣言追跡セットが `String` キー（ハッシュ＋一致時の memcmp） |
+
+対処（すべて既存のラッチ機構の踏襲・新機構なし）:
+
+- **#4506** — `^name` placeholder キー用のラッチ（`PLACEHOLDER_KEY_SEEN`）を追加し、
+  プローブ自体を消滅させた。`flush_local_to_env` が持っていながら `_name_sym` として
+  捨てていた事前 intern 済み Symbol を `set_shared_var_sym` まで通した。`SetVarDynamic` の
+  再 intern／per-iteration の `String` 確保／2 周目以降は無意味な O(locals) 走査を除去。
+  `Env::remove_sym` は不在キーなら `cow_mut()` 前に return。空マップへの SipHash プローブを全廃。
+- **#4507** — **到達不能だった `simple_locals` fast path 約 310 行を削除**。コンパイラは
+  `name.starts_with('$')` で立てていたが、**scalar local はシジル無しで格納される**
+  （`my $x` → `"x"`）ため常に false。`--dump-bytecode` が `locals: ["*d", "x", "@a", "%h"]` と
+  示すとおり、`$` 始まりの local 名は存在しない。代わりに正直な `plain_locals`
+  （シジル・twigil・`::`・属性マーカのいずれも持たない名前）を導入し、別名維持が原理的に
+  不要なミラー書き込みを 1 回の Symbol 挿入に落とした。
+- **#4508** — 宣言追跡セット（`block_declared_vars` / `loop_local_vars`）を `Symbol` キー化。
+  消費側は元々 Symbol を持っていて `sym.with_str(|s| set.contains(s))` と往復していたので、
+  全消費側が同時に簡潔になった。`BlockLocalScope` の分岐前 env スナップショットが
+  **env の全キーを `String` 化していた**のも解消。
+
+結果（median of 7・同一静音ウィンドウ・raku を同ウィンドウで実測）:
+
+| 構成 | before | after | raku 比 |
+|---|---|---|---|
+| JIT on（既定） | 0.255s | **0.136s** | 1.17 → **0.62** |
+| interpreter のみ | 0.238s | 0.205s | 1.46 → **0.93** |
+
+**raku 比 1.0 超えのベンチはこれで消えた**（interp 単体でも超えた）。他ベンチに退行なし。
+
+**次の的**（PLAN §5 に記載）: 残プロファイル最上位は依然 env ミラーだが、その根は
+`needs_env_sync` のブランケット（frame に `ForLoop` が 1 つでもあれば全 local を
+ミラー対象にする）。解除には `exec_do_block_op` の復元・ループ shadow save/restore・
+closure capture の 3 つの env 名前依存を同時に外す必要があり、**§1.3/§1.5 と一体の
+キャンペーン**。
+
 ## 2026-07-14: PLAN / BLOCKERS の棚卸し — roast のフロンティアは `integration/`（実プログラム 41 本）だった
 
 PLAN.md §4「roast backlog」に並んでいた項目を 1 つずつ実測したところ、**大半が実装済み**だった


### PR DESCRIPTION
Records #4506 / #4507 / #4508 in `news/2026-07.md` (what the profile showed, what each PR removed, the before/after numbers) and updates PLAN.md §5:

- The declaration-path work is listed under the completed levers, with the headline: `time-parts` went from **raku 1.17 → 0.62** with JIT on, and **1.46 → 0.93** interpreter-only. No benchmark is above 1.0 against raku any more.
- A new item **0** heads the remaining perf list: the blanket `needs_env_sync` (any frame containing a `ForLoop` / `BlockScope` / `MakeGather` / `WheneverScope` mirrors *every* local into env on every store) is what the remaining profile is dominated by, and narrowing it means untangling three name-keyed env dependencies at once — `exec_do_block_op`'s restore, the loop shadow save/restore, and closure capture. Flagged as a §1.3/§1.5-coupled campaign needing its own session, not a drive-by.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw