### PR TITLE
fix(vm): resolve a closure's free variables in its own captured scope

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -324,9 +324,25 @@ S\* 系で唯一残る実機能ギャップ（whitelist には直結しない）
       return マージの allocation-free 化（#4492 — **bench-fib -32.3% / bench-tak -23.9%**）／
       sigilless-alias・readonly の env キー事前 intern（#4493 — num-arith -21.6% /
       bench-mandelbrot -14.9%）／属性の `Symbol` キー化（#4494 — 上記 ✅）／宣言・store ごとの
-      メタデータキー再構築の停止（#4495 — time-parts -37.2% / bench-mandelbrot -33.7%）。
+      メタデータキー再構築の停止（#4495 — time-parts -37.2% / bench-mandelbrot -33.7%）／
+      **宣言パス（`my $x = ...`）の intern・SipHash・COW 撤去**（#4506/#4507/#4508 — time-parts
+      は **JIT on で raku 比 1.17 → 0.62**、interp 単体でも 1.46 → 0.93 と raku 超え。
+      内訳 = placeholder `^name` プローブのラッチ化・`flush_local_to_env` が捨てていた
+      事前 intern 済み Symbol の活用・`SetVarDynamic` の再 intern/String 確保撤去・
+      不在キー削除での `Arc::make_mut` 回避・空マップへの SipHash プローブ撤去・
+      宣言追跡セットの `Symbol` キー化。あわせて**到達不能だった `simple_locals`
+      fast path 約 310 行を削除**（scalar local はシジル無しで格納されるため
+      `name.starts_with('$')` が常に false ＝ 一度も実行されていなかった））。
 
       **残（着手順）**:
+      0. **★`needs_env_sync` のブランケット解除（次の本命・専用セッション向き）** — 現状
+         `captures_env_by_name`（frame に `ForLoop`/`BlockScope`/`MakeGather`/`WheneverScope`
+         が 1 つでもあれば true）が **frame の全 local を env ミラー対象にする**ため、
+         ループ本体の `my $ts` のように名前で読まれない local まで毎ストア env へ書いている
+         （time-parts 残プロファイルの最上位）。精密化するには `exec_do_block_op` の
+         「全 local を env から pull」する復元・ループの shadow save/restore・
+         closure capture の 3 つの env 名前依存を同時に外す必要があり、
+         **§1.3/§1.5 と一体のキャンペーン**（memory: 単独変更は 5 機構を壊す実績あり）。
       1. **`compiled_fns` の SipHash 撤去**（scouting §2.1 — 関数テーブルが今も
          `HashMap<String, CompiledFunction>`（`vm.rs:280`）で、**light-call キャッシュに当たった
          呼び出しでも毎回関数名を SipHash + memcmp している**）。FxHashMap 化 →`Symbol` キー化 →

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,53 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-14: `my $x = ...` が intern・SipHash・COW を払うのをやめた — time-parts が raku 比 1.17 → 0.62（#4506 / #4507 / #4508）
+
+time-parts は **JIT on でも raku より遅い唯一のベンチ**（比 1.17）として残っていた。profile を
+取ると、遅さは算術ではなく**宣言そのもの**にあった。ループ本体の `my` 5 本 × 10 万回、
+つまり 50 万回の宣言が、それぞれ固定のメタデータ簿記を実行していた:
+
+| 症状 | 犯人 |
+|---|---|
+| `Symbol::intern` 9.6% | env は Symbol キーなのに、ミラー書き込みが毎回名前を intern し直していた |
+| `format!` 4.3% | 全ミラーストアで `format!("^{name}")` を組み、placeholder 別名の有無を env に問い合わせていた |
+| SipHash 6.7% | 空の `HashMap<String, _>`（型制約・`is default`・readonly）を毎宣言プローブ |
+| `Env::insert`/`cow_mut` 5.2% | **存在しないキーの削除**が `Arc::make_mut`（＝ env が共有されていれば map 全体の clone）を起こしていた |
+| `__memcmp_avx2` 5.9% | 宣言追跡セットが `String` キー（ハッシュ＋一致時の memcmp） |
+
+対処（すべて既存のラッチ機構の踏襲・新機構なし）:
+
+- **#4506** — `^name` placeholder キー用のラッチ（`PLACEHOLDER_KEY_SEEN`）を追加し、
+  プローブ自体を消滅させた。`flush_local_to_env` が持っていながら `_name_sym` として
+  捨てていた事前 intern 済み Symbol を `set_shared_var_sym` まで通した。`SetVarDynamic` の
+  再 intern／per-iteration の `String` 確保／2 周目以降は無意味な O(locals) 走査を除去。
+  `Env::remove_sym` は不在キーなら `cow_mut()` 前に return。空マップへの SipHash プローブを全廃。
+- **#4507** — **到達不能だった `simple_locals` fast path 約 310 行を削除**。コンパイラは
+  `name.starts_with('$')` で立てていたが、**scalar local はシジル無しで格納される**
+  （`my $x` → `"x"`）ため常に false。`--dump-bytecode` が `locals: ["*d", "x", "@a", "%h"]` と
+  示すとおり、`$` 始まりの local 名は存在しない。代わりに正直な `plain_locals`
+  （シジル・twigil・`::`・属性マーカのいずれも持たない名前）を導入し、別名維持が原理的に
+  不要なミラー書き込みを 1 回の Symbol 挿入に落とした。
+- **#4508** — 宣言追跡セット（`block_declared_vars` / `loop_local_vars`）を `Symbol` キー化。
+  消費側は元々 Symbol を持っていて `sym.with_str(|s| set.contains(s))` と往復していたので、
+  全消費側が同時に簡潔になった。`BlockLocalScope` の分岐前 env スナップショットが
+  **env の全キーを `String` 化していた**のも解消。
+
+結果（median of 7・同一静音ウィンドウ・raku を同ウィンドウで実測）:
+
+| 構成 | before | after | raku 比 |
+|---|---|---|---|
+| JIT on（既定） | 0.255s | **0.136s** | 1.17 → **0.62** |
+| interpreter のみ | 0.238s | 0.205s | 1.46 → **0.93** |
+
+**raku 比 1.0 超えのベンチはこれで消えた**（interp 単体でも超えた）。他ベンチに退行なし。
+
+**次の的**（PLAN §5 に記載）: 残プロファイル最上位は依然 env ミラーだが、その根は
+`needs_env_sync` のブランケット（frame に `ForLoop` が 1 つでもあれば全 local を
+ミラー対象にする）。解除には `exec_do_block_op` の復元・ループ shadow save/restore・
+closure capture の 3 つの env 名前依存を同時に外す必要があり、**§1.3/§1.5 と一体の
+キャンペーン**。
+
 ## 2026-07-14: PLAN / BLOCKERS の棚卸し — roast のフロンティアは `integration/`（実プログラム 41 本）だった
 
 PLAN.md §4「roast backlog」に並んでいた項目を 1 つずつ実測したところ、**大半が実装済み**だった

--- a/src/env.rs
+++ b/src/env.rs
@@ -93,6 +93,30 @@ pub(crate) fn is_plain_user_lexical(name: &str) -> bool {
     matches!(decider, Some(c) if c.is_ascii_lowercase())
 }
 
+/// True for a dynamic variable's env key (the `*` twigil): `$*x` → `"*x"` (scalars
+/// are stored sigil-less), `@*x` → `"@*x"`, `%*VAR` → `"%*VAR"`, `&*f` → `"&*f"`.
+///
+/// A dynamic variable is resolved through the *caller* chain at call time, never
+/// from a lexical capture. Closure machinery that freezes a captured value per
+/// closure instance (`closure_captured_state`) must therefore skip these names:
+/// persisting one pins the closure to the value seen on its first call, so a later
+/// re-assignment by the caller becomes invisible (`our %*VAR = ...` re-set per row
+/// of a truth table left every row reading row 1's bindings — roast
+/// integration/99problems-41-to-50.t P46).
+#[inline]
+pub(crate) fn is_dynamic_var_name(name: &str) -> bool {
+    let b = name.as_bytes();
+    let Some(&first) = b.first() else {
+        return false;
+    };
+    let decider = if matches!(first, b'@' | b'%' | b'&') {
+        b.get(1).copied()
+    } else {
+        Some(first)
+    };
+    decider == Some(b'*')
+}
+
 /// Monotonic, process-global flag: set the first time any closure-writeback
 /// metadata key is inserted into *any* env. These keys --
 /// `__mutsu_sigilless_readonly::*`, `__mutsu_sigilless_alias::*`,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1791,6 +1791,22 @@ pub(crate) struct CompiledCode {
     /// call args / control blocks) non-boxed, avoiding the broad-boxing
     /// perf/correctness regression (see #2749).
     pub(crate) needs_cell_locals: Vec<Symbol>,
+    /// The subset of this code's own `free_var_syms` whose captured value is
+    /// **authoritative**: the CREATING frame declares them as plain lexicals and
+    /// provably never mutates them after this closure captured them, so the
+    /// by-value snapshot in the closure's env can never go stale.
+    ///
+    /// Baked by the creator's `compute_free_vars` (which is the only place that
+    /// knows its own `captured_mutated` set) into each nested closure it embeds.
+    ///
+    /// The closure dispatch installs exactly these with OVERWRITE semantics, so a
+    /// same-named lexical in whatever frame happens to be calling can no longer
+    /// shadow the closure's own binding. Everything else — a capture the creator
+    /// mutates (its snapshot may be stale, so the live value must come from the
+    /// shared cell or the env chain), a free var inherited from an ancestor rather
+    /// than declared by the creator, and all non-plain-lexical names (dynamics,
+    /// the topic, `self`, `__mutsu_*`) — keeps the don't-overwrite merge.
+    pub(crate) authoritative_free_vars: Vec<Symbol>,
     /// Locals whose own `my $x = ...` *initializer* creates a closure that
     /// captures `$x` itself — the self-recursive closure (`my $f = -> $n { ...
     /// $f($n-1) ... }`). The capture op runs BEFORE the declaration's store, so
@@ -1988,6 +2004,7 @@ impl CompiledCode {
             needs_cell_escaping_our_sub_free: Vec::new(),
             captured_mutated_locals: Vec::new(),
             needs_cell_locals: Vec::new(),
+            authoritative_free_vars: Vec::new(),
             self_capture_decl_locals: Vec::new(),
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
@@ -2523,6 +2540,42 @@ impl CompiledCode {
         names
     }
 
+    /// The constant-pool index of a call op's *argument source names*. A lexical
+    /// that reaches a call as an argument can be written through by an `is rw` /
+    /// `is raw` parameter (`cas($x, $old, $new)` is the canonical sink), and that
+    /// write is invisible to the name-write op scan — the arg is only ever *read*
+    /// by name at the call site. So a local that appears here can go stale behind
+    /// the analysis's back and must never be vouched for.
+    fn op_arg_sources_idx(op: &OpCode) -> Option<u32> {
+        match op {
+            OpCode::CallFunc {
+                arg_sources_idx, ..
+            }
+            | OpCode::CallFuncSlip {
+                arg_sources_idx, ..
+            }
+            | OpCode::CallMethod {
+                arg_sources_idx, ..
+            }
+            | OpCode::CallMethodMut {
+                arg_sources_idx, ..
+            }
+            | OpCode::ExecCall {
+                arg_sources_idx, ..
+            }
+            | OpCode::ExecCallSlip {
+                arg_sources_idx, ..
+            }
+            | OpCode::CallOnValue {
+                arg_sources_idx, ..
+            }
+            | OpCode::CallOnCodeVar {
+                arg_sources_idx, ..
+            } => *arg_sources_idx,
+            _ => None,
+        }
+    }
+
     /// The `closure_compiled_codes` index an op embeds, for the ops that create a
     /// closure value (and so snapshot the creating frame's env at that point).
     fn op_closure_code_idx(op: &OpCode) -> Option<u32> {
@@ -2550,6 +2603,18 @@ impl CompiledCode {
         // Free `@`/`%` containers mutated in place (push/append/element-assign).
         let mut free_container_writes: std::collections::HashSet<Symbol> =
             std::collections::HashSet::new();
+        // OWN `@`/`%` containers mutated in place. A container write is not a
+        // name-write, so `self_mutated` never sees it — but it still makes a
+        // closure's by-value capture go stale (a `BagHash` element-assign
+        // copy-on-writes, so the captured Gc stops tracking the local). Tracked
+        // separately so `authoritative_free_vars` can refuse to vouch for them.
+        let mut own_container_writes: std::collections::HashSet<Symbol> =
+            std::collections::HashSet::new();
+        // Own locals that reach a call as an argument, and so may be written
+        // through an `is rw` / `is raw` parameter (`cas($x, ...)`). See
+        // `op_arg_sources_idx`.
+        let mut own_call_arg_sources: std::collections::HashSet<Symbol> =
+            std::collections::HashSet::new();
         // Bare names read via `$OUTER::` (order-preserving, de-duplicated).
         let mut outer_ref_names: Vec<String> = Vec::new();
         // Own locals captured by a closure created since the last store/decl
@@ -2569,6 +2634,35 @@ impl CompiledCode {
                 && !own.contains(name.as_str())
             {
                 free.insert(Symbol::intern(&name));
+            }
+            // Own locals reaching a call as arguments: an `is rw` parameter can
+            // write straight back into them without any name-write op here.
+            if let Some(idx) = Self::op_arg_sources_idx(op)
+                && let Some(ValueView::Array(items, ..)) =
+                    self.constants.get(idx as usize).map(Value::view)
+            {
+                for item in items.iter() {
+                    // Entries are either `Str(name)` or `Pair(name, Int(slot))`.
+                    let name = match item.view() {
+                        ValueView::Str(s) => Some(s.to_string()),
+                        ValueView::Pair(k, _) => Some(k.to_string()),
+                        _ => None,
+                    };
+                    if let Some(name) = name
+                        && own.contains(name.as_str())
+                    {
+                        own_call_arg_sources.insert(Symbol::intern(&name));
+                    }
+                }
+            }
+            // Own-container in-place mutation: not a name-write, so `self_mutated`
+            // misses it, but it still invalidates a closure's by-value capture.
+            if let Some(idx) = self.op_container_mutate_const_idx(op)
+                && let Some(ValueView::Str(name)) =
+                    self.constants.get(idx as usize).map(Value::view)
+                && own.contains(name.as_str())
+            {
+                own_container_writes.insert(Symbol::intern(&name));
             }
             // Free-var container in-place mutation (push/append/element-assign):
             // NOT a name-write, so tracked separately for cell boxing.
@@ -2728,7 +2822,9 @@ impl CompiledCode {
             // container free here unless we own it (it stays a container-write
             // contribution either way — own ones are handled by the cell at decl).
             for sym in &nested.free_var_container_writes {
-                if !sym.with_str(|s| own.contains(s)) {
+                if sym.with_str(|s| own.contains(s)) {
+                    own_container_writes.insert(*sym);
+                } else {
                     free_container_writes.insert(*sym);
                 }
             }
@@ -2864,6 +2960,39 @@ impl CompiledCode {
             .filter(|sym| self.needs_cell_locals.contains(sym))
             .collect();
         self.needs_cell_free_vars = needs_cell_free.into_iter().collect();
+        // Tell each closure we embed which of ITS free variables we (the creating
+        // frame) vouch for: a plain lexical we declare and never mutate after the
+        // capture op runs. Only such a capture can be installed with overwrite
+        // semantics at call time — see `authoritative_free_vars`. This is the one
+        // place that knows `captured_mutated`, and the nested codes are still
+        // uniquely owned here, so `make_mut` does not clone.
+        let vouched: std::collections::HashSet<Symbol> = self
+            .locals
+            .iter()
+            .filter(|name| crate::env::is_plain_user_lexical(name))
+            .map(|name| Symbol::intern(name))
+            .filter(|sym| {
+                // Reassigned / inc-dec'd by name (directly or by a nested closure).
+                !self.captured_mutated_locals.contains(sym)
+                    // Mutated in place as a container — invisible to `self_mutated`,
+                    // but a `%h<k> = v` that copy-on-writes still strands the capture.
+                    && !own_container_writes.contains(sym)
+                    // Handed to a call, where an `is rw` param can write it back.
+                    && !own_call_arg_sources.contains(sym)
+            })
+            .collect();
+        for nested in &mut self.closure_compiled_codes {
+            let authoritative: Vec<Symbol> = nested
+                .free_var_syms
+                .iter()
+                .filter(|sym| vouched.contains(sym))
+                .copied()
+                .collect();
+            if authoritative.is_empty() && nested.authoritative_free_vars.is_empty() {
+                continue;
+            }
+            Arc::make_mut(nested).authoritative_free_vars = authoritative;
+        }
     }
 
     /// The constant-pool index of a *pure scalar read* of a lexical by name — the

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1791,6 +1791,18 @@ pub(crate) struct CompiledCode {
     /// call args / control blocks) non-boxed, avoiding the broad-boxing
     /// perf/correctness regression (see #2749).
     pub(crate) needs_cell_locals: Vec<Symbol>,
+    /// Locals whose own `my $x = ...` *initializer* creates a closure that
+    /// captures `$x` itself — the self-recursive closure (`my $f = -> $n { ...
+    /// $f($n-1) ... }`). The capture op runs BEFORE the declaration's store, so
+    /// the closure snapshots `$x` while it is still unset; only a shared cell can
+    /// carry the value the store is about to write. They are therefore boxed (the
+    /// store-after-capture rule adds them to `captured_mutated_locals`), and the
+    /// declaration's usual "clear the stale ContainerRef, this is a fresh binding"
+    /// step must be SKIPPED for them — that step exists for a loop redeclaration
+    /// re-boxing a *previous iteration's* cell, but here the cell was boxed by
+    /// this very declaration's initializer, so clearing it orphans the closure's
+    /// capture and `$f` reads back as `Any`.
+    pub(crate) self_capture_decl_locals: Vec<Symbol>,
     /// Free variables (names NOT in this code's own locals) that must become a
     /// shared `ContainerRef` cell in whichever *ancestor* frame declares them,
     /// because they are captured-and-mutated by an ESCAPING closure somewhere in
@@ -1976,6 +1988,7 @@ impl CompiledCode {
             needs_cell_escaping_our_sub_free: Vec::new(),
             captured_mutated_locals: Vec::new(),
             needs_cell_locals: Vec::new(),
+            self_capture_decl_locals: Vec::new(),
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
             captures_env_by_name: false,
@@ -2510,6 +2523,19 @@ impl CompiledCode {
         names
     }
 
+    /// The `closure_compiled_codes` index an op embeds, for the ops that create a
+    /// closure value (and so snapshot the creating frame's env at that point).
+    fn op_closure_code_idx(op: &OpCode) -> Option<u32> {
+        match op {
+            OpCode::MakeAnonSub(_, cc, _)
+            | OpCode::MakeAnonSubParams(_, cc, _)
+            | OpCode::MakeLambda(_, cc, _)
+            | OpCode::MakeBlockClosure(_, cc)
+            | OpCode::MakeGather(_, cc) => *cc,
+            _ => None,
+        }
+    }
+
     pub(crate) fn compute_free_vars(&mut self) {
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let mut free: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
@@ -2526,6 +2552,14 @@ impl CompiledCode {
             std::collections::HashSet::new();
         // Bare names read via `$OUTER::` (order-preserving, de-duplicated).
         let mut outer_ref_names: Vec<String> = Vec::new();
+        // Own locals captured by a closure created since the last store/decl
+        // marker — i.e. by the initializer currently being evaluated. Consumed by
+        // the store that ends it (see the self-capture rule below).
+        let mut captured_in_decl: std::collections::HashSet<Symbol> =
+            std::collections::HashSet::new();
+        // Own locals whose declaration's own initializer captured them.
+        let mut self_capture_decl: std::collections::HashSet<Symbol> =
+            std::collections::HashSet::new();
         let mut pending_decl = false;
         for op in &self.ops {
             // Read+write free-var set (names referenced from an enclosing scope).
@@ -2594,6 +2628,44 @@ impl CompiledCode {
                 if !own.contains(name) {
                     free.insert(Symbol::intern(name));
                 }
+            }
+            // Self-capturing declaration: `my $f = -> $n { ... $f($n-1) ... }`.
+            // The initializer's closure-creation op snapshots the env BEFORE the
+            // declaration's store runs, so the closure captures `$f` while it is
+            // still unset. `pending_decl` cannot see this — it only separates
+            // `my $x = e` from `$x = e`, and both are "declarations" here. Treat
+            // the store as a mutation *from the closure's point of view*, which is
+            // what earns the local a shared cell (`captured_mutated` → the escape
+            // analysis then puts it in `needs_cell`, since an assigned closure
+            // escapes). The window is deliberately narrow: only closures created
+            // by the initializer that this very store completes.
+            if let Some(cc_idx) = Self::op_closure_code_idx(op)
+                && let Some(nested) = self.closure_compiled_codes.get(cc_idx as usize)
+            {
+                for sym in &nested.free_var_syms {
+                    if sym.with_str(|s| own.contains(s)) {
+                        captured_in_decl.insert(*sym);
+                    }
+                }
+            }
+            let store_slot = match op {
+                OpCode::SetLocal(slot) | OpCode::AssignExprLocal(slot) => Some(*slot),
+                OpCode::SetLocalDecl { slot, .. } => Some(*slot),
+                _ => None,
+            };
+            if let Some(slot) = store_slot {
+                if (matches!(op, OpCode::SetLocalDecl { .. }) || pending_decl)
+                    && let Some(name) = self.locals.get(slot as usize)
+                {
+                    let sym = Symbol::intern(name);
+                    if captured_in_decl.contains(&sym) {
+                        self_mutated.insert(sym);
+                        self_capture_decl.insert(sym);
+                    }
+                }
+                // The store ends this initializer: later closures belong to the
+                // next one.
+                captured_in_decl.clear();
             }
             match op {
                 OpCode::MarkVarDeclContext => pending_decl = true,
@@ -2785,6 +2857,12 @@ impl CompiledCode {
         self.free_var_container_writes = free_container_writes.into_iter().collect();
         self.captured_mutated_locals = captured_mutated.into_iter().collect();
         self.needs_cell_locals = needs_cell.into_iter().collect();
+        // A self-capturing declaration only matters when the local actually gets a
+        // cell — otherwise there is no cell for the declaration to preserve.
+        self.self_capture_decl_locals = self_capture_decl
+            .into_iter()
+            .filter(|sym| self.needs_cell_locals.contains(sym))
+            .collect();
         self.needs_cell_free_vars = needs_cell_free.into_iter().collect();
     }
 

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -236,28 +236,26 @@ impl Interpreter {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
             }
         }
-        // A closure's *free variables* are lexically bound in its captured env, so
-        // the captured value must OVERWRITE whatever the caller env happens to hold
-        // under the same name. The frame env is a scoped child of the *caller's*
-        // env, so without this a caller lexical that merely shares a name shadows
-        // the closure's own binding — lexical scoping degrading into dynamic
-        // scoping. It bites whenever one closure calls another that was built by a
+        // A closure's free variables are lexically bound in its captured env, so an
+        // *authoritative* capture must OVERWRITE whatever the caller env happens to
+        // hold under the same name. The frame env is a scoped child of the
+        // *caller's* env, so without this a caller lexical that merely shares a
+        // name shadows the closure's own binding — lexical scoping degrading into
+        // dynamic scoping. It bites whenever one closure calls another built by a
         // sibling invocation of the same factory (both frames declare `$me`), e.g.
         // a grammar-actions AST of nested closures: the callee re-read the caller's
-        // `@args` and recursed into itself until the Rust stack blew (roast
-        // integration/99problems-41-to-50.t P46/P47/P48).
+        // `@args`, which holds the callee itself, and recursed until the Rust stack
+        // blew (roast integration/99problems-41-to-50.t P46).
         //
-        // Restricted to plain user lexicals: dynamics (`$*OUT`), the topic (`$_`),
-        // `self`, positional captures and `__mutsu_*` metadata are deliberately
-        // resolved against the *live caller* env, and `capture_closure_env` keeps
-        // them in `data.env` only as a stale snapshot — overwriting those would
-        // break dynamic scoping. Mutation of a captured lexical still wins, because
-        // it flows through the `ContainerRef` cell above and the per-instance
-        // `closure_captured_state` override below, both applied after this.
-        for sym in &cc.free_var_syms {
-            if !sym.with_str(crate::env::is_plain_user_lexical) {
-                continue;
-            }
+        // Only `authoritative_free_vars` — plain lexicals the creating frame
+        // declares and never mutates after capture — can be installed this way. A
+        // capture the creator DOES mutate has a possibly-stale snapshot (mutsu
+        // captures by value), so its live value must keep coming from the shared
+        // `ContainerRef` cell or, when the escape analysis left it unboxed, the env
+        // chain: `my $s = 0; for 1..3 { @cb.push({ $s }) }; $s = 42` must still see
+        // 42. Dynamics, the topic, `self` and `__mutsu_*` metadata are excluded for
+        // the same reason — they are resolved against the live caller by design.
+        for sym in &cc.authoritative_free_vars {
             if let Some(val) = data.env.get_sym(*sym).cloned() {
                 self.env_mut().insert_sym(*sym, val);
             }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -236,6 +236,32 @@ impl Interpreter {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
             }
         }
+        // A closure's *free variables* are lexically bound in its captured env, so
+        // the captured value must OVERWRITE whatever the caller env happens to hold
+        // under the same name. The frame env is a scoped child of the *caller's*
+        // env, so without this a caller lexical that merely shares a name shadows
+        // the closure's own binding — lexical scoping degrading into dynamic
+        // scoping. It bites whenever one closure calls another that was built by a
+        // sibling invocation of the same factory (both frames declare `$me`), e.g.
+        // a grammar-actions AST of nested closures: the callee re-read the caller's
+        // `@args` and recursed into itself until the Rust stack blew (roast
+        // integration/99problems-41-to-50.t P46/P47/P48).
+        //
+        // Restricted to plain user lexicals: dynamics (`$*OUT`), the topic (`$_`),
+        // `self`, positional captures and `__mutsu_*` metadata are deliberately
+        // resolved against the *live caller* env, and `capture_closure_env` keeps
+        // them in `data.env` only as a stale snapshot — overwriting those would
+        // break dynamic scoping. Mutation of a captured lexical still wins, because
+        // it flows through the `ContainerRef` cell above and the per-instance
+        // `closure_captured_state` override below, both applied after this.
+        for sym in &cc.free_var_syms {
+            if !sym.with_str(crate::env::is_plain_user_lexical) {
+                continue;
+            }
+            if let Some(val) = data.env.get_sym(*sym).cloned() {
+                self.env_mut().insert_sym(*sym, val);
+            }
+        }
         // Per-iteration loop captures (Raku fresh-binding semantics): these free
         // variables were declared in an enclosing loop body when this closure was
         // created, so each iteration's closure froze a distinct value in its
@@ -271,6 +297,12 @@ impl Interpreter {
                     data.env.get_sym(*k).map(Value::view),
                     Some(ValueView::ContainerRef(_))
                 ) {
+                    return None;
+                }
+                // Skip dynamic variables: they are resolved through the caller
+                // chain at call time, so they carry no per-instance state (see
+                // `is_dynamic_var_name`). Nothing persists them either.
+                if k.with_str(crate::env::is_dynamic_var_name) {
                     return None;
                 }
                 self.get_closure_captured_state(data.id, *k)
@@ -698,8 +730,13 @@ impl Interpreter {
         // Persist captured variable state so this closure instance retains
         // its own mutable state across calls (independent from other closures).
         // Mirror of `cap_overrides` above: only free variables can be mutated by
-        // the body, so only those need persisting.
+        // the body, so only those need persisting — and dynamic variables are
+        // excluded there, so persisting them here would only pin the closure to
+        // the first call's value.
         for k in &cc.free_var_syms {
+            if k.with_str(crate::env::is_dynamic_var_name) {
+                continue;
+            }
             if let Some(val) = self.env().get_sym(*k).cloned() {
                 self.set_closure_captured_state(data.id, *k, val);
             }
@@ -822,6 +859,25 @@ impl Interpreter {
                 cc.locals_sym.iter().copied().collect();
             let underscore_sym = Symbol::intern("_");
             let at_underscore_sym = Symbol::intern("@_");
+            // Free variables the body did NOT touch. Their value in this frame is
+            // the closure's *own captured binding*, force-installed at entry (see
+            // the free-var overwrite in the merge above) — not a mutation the
+            // caller must observe. Propagating them would overwrite a same-named
+            // caller lexical that is a *different* binding, which is precisely how
+            // a tree of sibling closures corrupted each other: an inner node's
+            // `$func`/`@args` leaked into the outer node's frame on return, got
+            // persisted as the outer's per-instance state, and every later call ran
+            // the outer node as if it were the inner one (roast
+            // integration/99problems-41-to-50.t P46 evaluated `and(...)` as `or(...)`
+            // from the second truth-table row on). A free var the body *did* change
+            // is still written back — that check is what `free_at_entry` is for.
+            let unchanged_free: std::collections::HashSet<Symbol> = cc
+                .free_var_syms
+                .iter()
+                .zip(free_at_entry.iter())
+                .filter(|(k, old)| self.env().get_sym(**k) == old.as_ref())
+                .map(|(k, _)| *k)
+                .collect();
             // Caller lexicals this scan writes back with a *changed* value. They are
             // recorded (after the loop, to avoid borrowing `self` while iterating
             // `self.env()`) on the retain-on-miss writeback list so the call site
@@ -831,6 +887,9 @@ impl Interpreter {
             // free_var recording below misses it.
             let mut caller_writeback: Vec<Symbol> = Vec::new();
             for (k, v) in self.env().iter() {
+                if unchanged_free.contains(k) {
+                    continue;
+                }
                 if *k != underscore_sym
                     && *k != at_underscore_sym
                     && !rw_sources.contains(k)

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -318,12 +318,24 @@ impl Interpreter {
                 let bare = name.trim_start_matches(['$', '@', '%', '&']);
                 self.unmark_readonly(bare);
             }
+            // A self-recursive closure declaration (`my $f = -> $n { $f($n-1) }`)
+            // boxed this very local into a cell while evaluating its own
+            // initializer, and the closure captured that cell. Both clears below
+            // would orphan it — leaving `$f` as `Any` inside the closure — so keep
+            // the cell and let the store below write THROUGH it. See
+            // `CompiledCode::self_capture_decl_locals`.
+            let self_captured_decl = !code.self_capture_decl_locals.is_empty()
+                && code
+                    .locals_sym
+                    .get(idx)
+                    .is_some_and(|sym| code.self_capture_decl_locals.contains(sym));
             // Replace stale ContainerRef in env with Nil so a new `my $var`
             // doesn't inherit a binding from an earlier scope. Keep the key
             // so saved frame propagation can still find it. Probed through the
             // pre-interned local Symbol (a by-name `get` would re-intern on every
             // declaration).
-            if let Some(sym) = code.locals_sym.get(idx).copied()
+            if !self_captured_decl
+                && let Some(sym) = code.locals_sym.get(idx).copied()
                 && matches!(
                     self.env().get_sym(sym).map(Value::view),
                     Some(ValueView::ContainerRef(_))
@@ -337,7 +349,8 @@ impl Interpreter {
             // *fresh binding* — clear the stale cell so the assignment below
             // writes a new plain value instead of writing *through* the old Arc
             // (which would corrupt the prior iteration's captured closure).
-            if matches!(self.locals[idx].view(), ValueView::ContainerRef(_)) {
+            if !self_captured_decl && matches!(self.locals[idx].view(), ValueView::ContainerRef(_))
+            {
                 self.locals[idx] = Value::NIL;
             }
             // Clear a stale bound-array-slice marker (§4 BLOCKERS.md test 15)

--- a/t/closure-free-var-scope.t
+++ b/t/closure-free-var-scope.t
@@ -1,0 +1,125 @@
+use Test;
+
+plan 14;
+
+# A closure's free variables are bound in the scope where the closure was
+# *created*. When one closure calls another, the callee must read its own
+# captured binding — never a same-named lexical that happens to live in the
+# caller's frame. mutsu used to merge the captured env with "don't overwrite"
+# into a child of the *caller's* env, so a caller lexical shadowed the callee's
+# own capture: lexical scoping silently degraded into dynamic scoping.
+
+{
+    sub mk-leaf()   { my $me = 'LEAF'; return sub { $me } }
+    sub mk-node($k) { my $me = 'NODE'; return sub { $me ~ '(' ~ $k.() ~ ')' } }
+    is mk-node(mk-leaf()).(), 'NODE(LEAF)',
+        'callee closure reads its own $me, not the calling closure\'s';
+}
+
+{
+    # Same shape, one level deeper, with an array-typed capture: the merge had a
+    # separate "never overwrite an Array with an Array" rule.
+    sub mk-leaf($tag) { my @args; return sub { $tag } }
+    sub mk-node($tag, @kids) {
+        my @args = @kids;
+        return sub { $tag ~ '[' ~ @args.map({ .() }).join(',') ~ ']' };
+    }
+    my $a = mk-leaf('a');
+    my $b = mk-leaf('b');
+    my $inner = mk-node('in', [$a, $b]);
+    my $outer = mk-node('out', [$a, $inner]);
+    is $outer.(), 'out[a,in[a,b]]',
+        'sibling closures from one factory keep independent @args';
+}
+
+{
+    # The self-recursion this used to cause blew the Rust stack instead of
+    # terminating: the inner node re-read the outer node's @args (containing
+    # itself) and recursed forever.
+    sub mk-rec($depth) {
+        my $d = $depth;
+        return sub { $d <= 0 ?? 'end' !! $d ~ '>' ~ mk-rec($d - 1).() };
+    }
+    is mk-rec(4).(), '4>3>2>1>end', 'closure recursing through a fresh closure terminates';
+}
+
+# --- the existing capture semantics these fixes must not break ---
+
+{
+    my $g = 1;
+    sub named-g() { $g }
+    my $anon-g = sub { $g };
+    $g = 99;
+    is named-g(), 99, 'named sub sees a later mutation of a captured lexical';
+    is $anon-g(), 99, 'anon closure sees a later mutation of a captured lexical';
+}
+
+{
+    sub factory() { my $x = 1; my $f = sub { $x }; $x = 2; return $f }
+    is factory().(), 2, 'closure sees mutation made after its creation';
+}
+
+{
+    sub mk-counter() { my $c = 0; return sub { ++$c } }
+    my $c1 = mk-counter();
+    my $c2 = mk-counter();
+    $c1(); $c1();
+    is $c1(), 3, 'counter keeps its own per-instance mutable state';
+    is $c2(), 1, 'a sibling counter has independent state';
+}
+
+{
+    my @cl;
+    for 1..3 -> $i { my $v = $i * 10; @cl.push(sub { $v }) }
+    is @cl.map({ .() }).join(','), '10,20,30', 'per-iteration loop captures stay distinct';
+}
+
+# A dynamic variable is resolved through the caller chain on every call, so a
+# closure must never freeze the value it saw on its first call.
+{
+    my $leaf = sub { $*TVAR };
+    my @seen;
+    for 1..3 -> $i {
+        my $*TVAR = $i;
+        @seen.push($leaf());
+    }
+    is @seen.join(','), '1,2,3', 'closure re-reads a dynamic var on every call';
+}
+
+{
+    my @vars = <A B>;
+    my $leafA = sub { %*VMAP<A> };
+    sub row(@vals) {
+        my %*VMAP = @vars Z=> @vals;
+        $leafA();
+    }
+    is (row([1, 0]), row([0, 1]), row([0, 0])).join(','), '1,0,0',
+        'closure re-reads a dynamic hash re-assigned per call';
+}
+
+# A self-recursive closure captures the variable it is being assigned to, so the
+# capture runs before the declaration's store: only a shared cell can carry the
+# value. Installing the (still unset) captured snapshot would make $rec read Any.
+{
+    my $rec = -> $n { $n <= 0 ?? 0 !! $n + $rec($n - 1) };
+    is $rec(4), 10, 'self-recursive closure resolves itself';
+
+    # ... and it must still resolve itself when invoked from an unrelated scope,
+    # where the caller has no $rec of its own to fall back on.
+    sub call-it(&f) { f(4) }
+    is call-it($rec), 10, 'self-recursive closure works when called from another scope';
+}
+
+{
+    # The declaration that captures must not be confused with a *later*
+    # same-named redeclaration in an inner block: the closure keeps the outer $a.
+    my $a = 3;
+    my $bump = { $a++ };
+    {
+        my $a = -10;
+        is ($bump(), $bump(), $a).join(','), '3,4,-10',
+            'inner redeclaration does not write through the captured cell';
+    }
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## What

A closure's frame env is a scoped child of the **caller's** env, and the captured env was merged into it with *don't overwrite*. A caller lexical that merely shared a name therefore shadowed the closure's own captured binding — lexical scoping silently degraded into dynamic scoping.

Grammar-free repro (raku prints `NODE(LEAF)`):

```raku
sub mk-leaf()   { my $me = 'LEAF'; return sub { $me } }
sub mk-node($k) { my $me = 'NODE'; return sub { $me ~ '(' ~ $k.() ~ ')' } }
say mk-node(mk-leaf()).();   # mutsu printed NODE(NODE)
```

## Why it looked like "deep recursion"

`TODO_roast/BLOCKERS.md` cluster ① files this as *"深い再帰で Rust スタックが溢れる"*. For `roast/integration/99problems-41-to-50.t` it is **not** a deep recursion — it is an infinite one.

P46's actions build one closure per parse-tree node:

```raku
method term:sym<func>($/) {
    my $func = $<op>.ast;
    my @args = @<expr>>>.ast;
    make sub () { $func( |@args.map: {.()} ) }
}
```

Both the `or(A,B)` node and the `and(A, or(A,B))` node declare `@args`. When the outer node called the inner one, the inner re-read the **outer's** `@args` — which contains the inner node itself — and recursed into itself until the Rust stack blew.

## Changes

Three coupled fixes in the closure dispatch path:

1. **Free variables install with overwrite.** `cc.free_var_syms` is exactly the set of names the body reads from an enclosing scope, so the captured binding must win over any same-named caller lexical. Restricted to plain user lexicals — dynamics (`$*OUT`), the topic, `self` and `__mutsu_*` metadata deliberately stay resolved against the live caller env.

2. **Dynamic variables carry no per-instance state.** They are resolved through the caller chain on every call, so freezing one in `closure_captured_state` pinned the closure to the value it saw on its *first* call. P46's `our %*VAR = @vars Z=> @vals`, re-set per truth-table row, left every row reading row 1's bindings.

3. **An unchanged free variable is not written back to the caller.** With (1), a callee's frame now holds its own captured binding, and the blanket exit writeback pushed that into a same-named caller lexical: the inner node's `$func`/`@args` leaked into the outer node's frame, got persisted as *its* per-instance state, and from the second call on the outer node ran as if it were the inner one. A free var the body *did* change is still written back — that is what `free_at_entry` is for.

### Fallout fixed: self-recursive closures

(1) exposed a real gap in the capture-mutation analysis. `my $f = -> $n { ... $f($n-1) ... }` captures the variable it is being assigned to, so the capture op snapshots `$f` while it is still unset. Only a shared cell can carry the value the declaration is about to store — but `self_mutated` counts a declaration as "not a mutation", so `$f` was never boxed. It previously worked only *by accident*, via the same dynamic-scoping fallback this PR removes (`roast/S02-names-vars/variables-and-packages.t` test 21).

Closed properly: a store completing an initializer that captured its own target is a mutation from the closure's point of view (so the local earns a cell), and the declaration's usual "clear the stale `ContainerRef`" step is skipped for it (`CompiledCode::self_capture_decl_locals`) — that step exists for a *loop* redeclaration re-boxing a previous iteration's cell, and here it would orphan the cell the initializer just boxed.

## Result

`roast/integration/99problems-41-to-50.t` goes from **aborting the process at test 1** (`fatal runtime error: stack overflow`) to passing P41 and P46. It now stops at P47, which needs parameterized `multi rule`s — a separate feature, so the file is not whitelisted yet.

## Tests

- New `t/closure-free-var-scope.t` (14 subtests, all verified against `raku`): the shadowing bug, sibling-closure `@args` independence, closure-through-closure recursion, self-recursive closures (same scope *and* called from another scope), dynamic-var re-reads, plus the existing capture semantics that must not regress (late mutation, per-instance counters, loop fresh-binding, inner redeclaration not writing through a captured cell).
- `make test`: green.
- Local roast subset of **952 whitelisted files** (S02/S03/S04/S05/S06/S09/S11/S12/S32): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw
