### PR TITLE
fix(parser): close the statement/expression parse gaps in the SORRY cluster

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -51,7 +51,7 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 | 根本原因クラスタ | 本数 | 該当ファイル（抜粋） | 症状 |
 |---|---|---|---|
 | **① スタックオーバーフローで abort**（★根本原因は 1 つではない — 下節参照） | 4 | `99problems-41-to-50.t`・`99problems-51-to-60.t`・`man-or-boy.t`・`deep-recursion-initing-native-array.t` | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**症状は同じだが原因は 4 つ別々**で、うち「本当に深い再帰」は 1 本だけだった |
-| **② パース不能（`===SORRY!===`）** | 10 | `advent2009-day16.t`(:58 `{`)・`advent2009-day23.t`(:122 `gather {`)・`advent2010-day11.t`(:24 `q \| … \|` = `\|` デリミタの q)・`advent2012-day04.t`(:22 `do {…} … *` 連番列)・`advent2012-day19.t`(:11 `4.7k` = ユーザ定義 postfix)・`advent2013-day04.t`(:31 heredoc インデント)・`advent2014-day16.t`(:99 `{`)・`advent2012-day15.t`（`Unexpected block in infix position`）・`6.c/MISC/bug-coverage.t`(:287 `subtest … => {`)・`6.c/APPENDICES/A04-experimental/01-misc.t` | 個別の構文が未対応。1 本ずつ潰す（安い ★ が混じっている可能性が高い） |
+| **② パース不能（`===SORRY!===`）** | 残 2 | **残: `advent2012-day04.t`・`advent2012-day19.t`** | 個別の構文が未対応。**8 本は解消済み（#4511 / #4514）** — 下の「② の内訳」参照 |
 | **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
 | **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張）・`advent2010-day14.t`（`nextsame` の継承/mixin）・`advent2010-day22.t`（`Rat` の `$!numerator`/`$!denominator` 属性）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2009-day20.t`（signature の introspection/stringification）・`advent2009-day18.t`（パラメタ化 role の mixin）・`advent2013-day10.t`（`:round` 等の演算子 adverb）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。★の近道はここ |
@@ -73,6 +73,22 @@ test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、
 教訓: **abort の形（`stack overflow`）は原因を意味しない。** 深さを数えて raku と突き合わせ、
 無限再帰か有限の深い再帰かを先に分けること（`raku` 側は 8 呼び出しで終わるのに mutsu が
 1900 行トレースを吐く、で一発で分かる）。
+
+### ② の内訳（2026-07-14 実測・#4511 / #4514 後）
+
+**whitelist 到達（5 本）**: `advent2010-day11.t`・`advent2013-day04.t`・`advent2014-day16.t`（#4511:
+`qto`/`qqto` fused adverb、quote 語とデリミタ間の空白・改行、heredoc 本体の開始行、`q:to:c` の
+選択的 adverb、lazy gather Seq の多引数 `for`）／`advent2009-day16.t`・`advent2009-day23.t`（#4514:
+`when` 文修飾子、Match を RHS とする smartmatch、`(with …)`/`(given …)` の式化、`my@i` の
+空白なし宣言）。
+
+**パースは通ったが subtest が残る（3 本）** — ②ではなく機能ギャップに移行:
+
+| ファイル | 残 | ブロッカー |
+|---|---|---|
+| `integration/advent2012-day15.t` | 2/11 | phaser の文形式が独自スコープを作る（`NEXT (state $best) max= $_;` の `$best` が `LAST` から見えない）／`INIT` がメインラインより後に走る |
+| `6.c/MISC/bug-coverage.t` | 5/17 | `.count-only`/`.bool-only`、thunk のクロージャスコープ 等 |
+| `6.c/APPENDICES/A04-experimental/01-misc.t` | 3/19 | `:D`/`:U` DefiniteHow coercion（`Target:D(Source:U)`）。#4514 で 0/19 → 16/19 |
 
 ## S* 系の個別ファイル残件
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1318,10 +1318,12 @@ roast/integration/advent2009-day10.t
 roast/integration/advent2009-day13.t
 roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t
+roast/integration/advent2009-day16.t
 roast/integration/advent2009-day17.t
 roast/integration/advent2009-day19.t
 roast/integration/advent2009-day21.t
 roast/integration/advent2009-day22.t
+roast/integration/advent2009-day23.t
 roast/integration/advent2010-day04.t
 roast/integration/advent2010-day06.t
 roast/integration/advent2010-day07.t

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -573,9 +573,18 @@ pub(super) fn parse_or_or_op(input: &str) -> Option<(LogicalOp, usize)> {
         Some((LogicalOp::XorXor, 2))
     } else if input.starts_with("//") && !input.starts_with("///") && !input.starts_with("//=") {
         Some((LogicalOp::DefinedOr, 2))
-    } else if input.starts_with("min") && !is_ident_char(input.as_bytes().get(3).copied()) {
+    // `min=` / `max=` are compound assignments, not the infix followed by `=` — the same
+    // exclusion `||=` and `//=` get above. Without it, `(state $b) max= $_` eats the `max`
+    // here and then fails to find a right-hand expression.
+    } else if input.starts_with("min")
+        && !is_ident_char(input.as_bytes().get(3).copied())
+        && !input.starts_with("min=")
+    {
         Some((LogicalOp::Min, 3))
-    } else if input.starts_with("max") && !is_ident_char(input.as_bytes().get(3).copied()) {
+    } else if input.starts_with("max")
+        && !is_ident_char(input.as_bytes().get(3).copied())
+        && !input.starts_with("max=")
+    {
         Some((LogicalOp::Max, 3))
     } else {
         None

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -183,6 +183,7 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             && let Expr::BareWord(name) = &then_expr
             && !name.contains("::")
             && !crate::runtime::utils::is_known_type_constraint(name)
+            && !crate::parser::stmt::simple::is_user_declared_type(name)
         {
             // A bare identifier in then-position is usually the head of a listop
             // call (`?? is-deeply $x, $y !! ...`) whose comma args were not yet
@@ -190,9 +191,10 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             // (`1 ?? rt123115 !! 3` => X::Syntax::ConditionalOperator::
             // SecondPartGobbled). Erroring lets the caller retry/report it. A
             // bareword that names a known TYPE, though, is a complete
-            // then-expression -- a type object in `1 ?? Int !! Str` or a native
-            // type in `ptrsize == 4 ?? uint32 !! uint64` -- so types are excluded
-            // from this guard above and accepted.
+            // then-expression -- a type object in `1 ?? Int !! Str`, a native
+            // type in `ptrsize == 4 ?? uint32 !! uint64`, or a user-declared
+            // class/role/grammar/enum in `self.DEFINITE ?? Target !! Target.new`
+            // -- so types are excluded from this guard above and accepted.
             return Err(PError::expected("expected '!!' in ternary expression"));
         }
         let (input, _) = ws(input)?;

--- a/src/parser/primary/container/meta_ops.rs
+++ b/src/parser/primary/container/meta_ops.rs
@@ -463,7 +463,7 @@ pub(crate) fn try_inline_modifier<'a>(input: &'a str, expr: Expr) -> Option<PRes
     use crate::parser::stmt::modifier::parse_statement_modifier;
     // Check if the input starts with a modifier keyword
     let modifier_keywords = [
-        "if", "unless", "with", "without", "for", "while", "until", "given",
+        "if", "unless", "with", "without", "for", "while", "until", "given", "when",
     ];
     let is_modifier = modifier_keywords
         .iter()

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -484,6 +484,23 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 return Ok((r, Expr::DoStmt(Box::new(stmt))));
             }
         }
+        // `(with $x { ... })` / `(given $x { ... })` are statements used as expressions,
+        // exactly like `(for ...)` above. The `ws1` guard keeps a user-defined `sub with`
+        // callable as `with()`.
+        "with" | "without" => {
+            if ws1(rest).is_ok()
+                && let Ok((r, stmt)) = crate::parser::stmt::with_stmt_pub(input)
+            {
+                return Ok((r, Expr::DoStmt(Box::new(stmt))));
+            }
+        }
+        "given" => {
+            if ws1(rest).is_ok()
+                && let Ok((r, stmt)) = crate::parser::stmt::given_stmt_pub(input)
+            {
+                return Ok((r, Expr::DoStmt(Box::new(stmt))));
+            }
+        }
         "while" => {
             if let Ok((r, stmt)) = crate::parser::stmt::while_stmt_pub(input) {
                 return Ok((r, Expr::DoStmt(Box::new(stmt))));

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -179,6 +179,33 @@ pub(crate) fn build_compound_assign_expr(
             op: op.token_kind(),
             right: Box::new(rhs),
         },
+        // `(state $best) max= $score` / `(my $n) += 1`: the declaration *is* the lvalue.
+        // Unlike plain `=`, the new value has to read the variable back, so this cannot
+        // become a `VarDecl` with an initializer — a `state` initializer runs once, but the
+        // compound assignment must run on every pass. Route it through the same
+        // callable-lvalue helper the parenthesized `=` form uses: the declaration is
+        // evaluated first (declaring the variable and yielding its container), the value
+        // then reads it, and the helper assigns back into that container.
+        Expr::DoStmt(stmt)
+            if crate::parser::stmt::simple_expr_stmt::decl_target_var_name(&stmt).is_some() =>
+        {
+            let name = crate::parser::stmt::simple_expr_stmt::decl_target_var_name(&stmt)
+                .expect("guarded by the match arm");
+            let read_back = match name.as_bytes().first() {
+                Some(b'@') => Expr::ArrayVar(name[1..].to_string()),
+                Some(b'%') => Expr::HashVar(name[1..].to_string()),
+                _ => Expr::Var(name),
+            };
+            let assigned_value = compound_assigned_value_expr(read_back, op, rhs);
+            Expr::Call {
+                name: Symbol::intern("__mutsu_assign_callable_lvalue"),
+                args: vec![
+                    Expr::DoStmt(stmt),
+                    Expr::ArrayLiteral(Vec::new()),
+                    assigned_value,
+                ],
+            }
+        }
         other => {
             // For short-circuit operators (or=, and=, ||=, &&=, //=, orelse=,
             // andthen=), preserve short-circuit semantics so that when the LHS

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -94,7 +94,14 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
             return Err(PError::expected("my/our/state declaration"));
         }
     }
-    let (mut rest, _) = ws1(rest)?;
+    // A sigil needs no whitespace to separate it from the declarator: `my@i = 1, 2` is a
+    // declaration, and so is `<a b>[my$i = 0]`. Anything else — `my enum`, `my Int $x` —
+    // still needs the space, and `my(...)` stays a call to a keyword-named sub.
+    let (mut rest, _) = if rest.starts_with(['$', '@', '%', '&']) {
+        (rest, ())
+    } else {
+        ws1(rest)?
+    };
 
     // my enum Foo <...>
     // my Array enum Foo <...>  (typed enum — base type is accepted but currently ignored)

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -52,11 +52,11 @@ pub(super) use stmtlist::{block_inner, stmt_list_partial};
 // Re-export the thin public-accessor shims moved to `pub_shims`, all at their
 // original `pub(super)` visibility (consumed by `primary`/`expr`).
 pub(super) use pub_shims::{
-    constant_decl_pub, for_stmt_pub, ident_pub, if_stmt_pub, labeled_loop_stmt_pub,
+    constant_decl_pub, for_stmt_pub, given_stmt_pub, ident_pub, if_stmt_pub, labeled_loop_stmt_pub,
     lazy_for_stmt_pub, let_stmt_pub, loop_stmt_pub, my_decl_expr_pub, parse_param_list_pub,
     parse_param_list_with_return_pub, parse_pointy_param_pub, parse_return_type_annotation_pub,
     parse_sub_name_pub, parse_sub_traits_pub, statement_pub, sub_decl_with_semicolon_mode_pub,
-    temp_stmt_pub, until_stmt_pub, while_stmt_pub,
+    temp_stmt_pub, until_stmt_pub, while_stmt_pub, with_stmt_pub,
 };
 
 thread_local! {

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -160,12 +160,12 @@ fn leading_modifier_keyword(input: &str) -> Option<&'static str> {
 }
 
 /// Whether a second statement modifier `next` is legal after a first `first`.
-/// Raku only allows a *conditional* modifier (`if`/`unless`/`with`/`without`)
+/// Raku only allows a *conditional* modifier (`if`/`unless`/`with`/`without`/`when`)
 /// followed by a *loop* modifier (`for`/`while`/`until`/`given`), e.g.
-/// `EXPR if COND for LIST`. Everything else (two conditionals, two loops, a loop
-/// then a conditional) is X::Syntax::Confused.
+/// `EXPR if COND for LIST` or `EXPR when COND given TOPIC`. Everything else (two
+/// conditionals, two loops, a loop then a conditional) is X::Syntax::Confused.
 fn second_modifier_allowed(first: &str, next: &str) -> bool {
-    let first_is_cond = matches!(first, "if" | "unless" | "with" | "without");
+    let first_is_cond = matches!(first, "if" | "unless" | "with" | "without" | "when");
     let next_is_loop = matches!(next, "for" | "while" | "until" | "given");
     first_is_cond && next_is_loop
 }
@@ -532,6 +532,35 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             Stmt::Given {
                 topic,
                 body: vec![given_stmt],
+            },
+        )));
+    }
+
+    if let Some(r) = keyword("when", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, cond) = expression(r).map_err(|err| PError {
+            messages: merge_expected_messages(
+                "expected match expression after 'when'",
+                &err.messages,
+            ),
+            remaining_len: err.remaining_len.or(Some(r.len())),
+            exception: None,
+        })?;
+        // A real `when COND { ... }` statement is not a modifier — leave it to control::when_stmt.
+        if modified_ends_block && block_follows_modifier_condition(r) {
+            return Ok(None);
+        }
+        // `When` signals a match by raising `succeed`, which only an enclosing topicalizer
+        // catches. Wrapping in a `given $_` gives it that catcher without changing the topic,
+        // and composes with a following `given` modifier, which re-topicalizes `$_` first.
+        return Ok(Some((
+            r,
+            Stmt::Given {
+                topic: Expr::Var("_".to_string()),
+                body: vec![Stmt::When {
+                    cond,
+                    body: vec![stmt],
+                }],
             },
         )));
     }

--- a/src/parser/stmt/pub_shims.rs
+++ b/src/parser/stmt/pub_shims.rs
@@ -107,6 +107,18 @@ pub(crate) fn loop_stmt_pub(input: &str) -> PResult<'_, Stmt> {
     control::loop_stmt(input)
 }
 
+/// Public accessor for the `with`/`without` statement parser (used by the term parser
+/// so `(with $x { ... })` works as an expression, like `(for ...)` already does).
+pub(crate) fn with_stmt_pub(input: &str) -> PResult<'_, Stmt> {
+    control::with_stmt(input)
+}
+
+/// Public accessor for the `given` statement parser (used by the term parser for
+/// `(given $x { ... })` as an expression).
+pub(crate) fn given_stmt_pub(input: &str) -> PResult<'_, Stmt> {
+    control::given_stmt(input)
+}
+
 pub(crate) fn labeled_loop_stmt_pub(input: &str) -> PResult<'_, Stmt> {
     control::labeled_loop_stmt(input)
 }

--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+/// Parse the type named by `returns` / `of` / `-->`, including a coercion type's
+/// parenthesized source: `Str`, `Str()`, `Int(Str)`. Without this, `returns Str()`
+/// stopped at the `(` and the trailing `()` was left to be parsed as a sub body.
+fn parse_trait_type_name(input: &str) -> PResult<'_, String> {
+    let (rest, base) = take_while1(input, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
+    let Some(inner) = rest.strip_prefix('(') else {
+        return Ok((rest, base.to_string()));
+    };
+    let mut depth = 1usize;
+    for (idx, ch) in inner.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    let name = format!("{base}({})", &inner[..idx]);
+                    return Ok((&inner[idx + 1..], name));
+                }
+            }
+            _ => {}
+        }
+    }
+    Err(PError::expected("closing ')' of a coercion type"))
+}
+
 /// Result of parsing sub traits.
 pub(crate) struct SubTraits {
     pub is_export: bool,
@@ -189,9 +214,8 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
         }
         if let Some(r) = keyword("returns", r) {
             let (r, _) = ws(r)?;
-            let (r, type_name) =
-                take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
-            return_type = Some(type_name.to_string());
+            let (r, type_name) = parse_trait_type_name(r)?;
+            return_type = Some(type_name);
             // Mark that the return type came from a `returns`/`of` trait (not a
             // `-->` signature arrow): an undeclared one is X::InvalidType, while
             // an undeclared `-->` type is X::Undeclared.
@@ -203,13 +227,12 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
         }
         if let Some(r) = keyword("of", r) {
             let (r, _) = ws(r)?;
-            let (r, type_name) =
-                take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
+            let (r, type_name) = parse_trait_type_name(r)?;
             // `of` parameterizes a preceding `returns`/role type, e.g.
             // `returns Positional of Int` means return type `Positional[Int]`.
             return_type = Some(match return_type {
                 Some(base) if !base.contains('[') => format!("{base}[{type_name}]"),
-                _ => type_name.to_string(),
+                _ => type_name,
             });
             if !custom_traits.iter().any(|(t, _)| t == "__return_via_trait") {
                 custom_traits.push(("__return_via_trait".to_string(), None));
@@ -219,9 +242,8 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
         }
         if let Some(r) = r.strip_prefix("-->") {
             let (r, _) = ws(r)?;
-            let (r, type_name) =
-                take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
-            return_type = Some(type_name.to_string());
+            let (r, type_name) = parse_trait_type_name(r)?;
+            return_type = Some(type_name);
             input = r;
             continue;
         }

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -253,6 +253,17 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
             Some(left.eqv(right))
         }
 
+        // A Match on the right is an already-decided match result, so it passes through
+        // like a Bool does: `$_ ~~ ($str ~~ /a/)` is true whatever the topic is. This is
+        // what makes `EXPR when $x ~~ /re/` work with no `given` to set the topic.
+        (
+            _,
+            ValueView::Instance {
+                class_name: rhs_class,
+                ..
+            },
+        ) if rhs_class == "Match" => Some(right.truthy()),
+
         // Mu instances: Mu ~~ Mu.new is True
         (
             ValueView::Package(lhs_type),

--- a/t/decl-as-expression.t
+++ b/t/decl-as-expression.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 11;
+
+# `(with ...)` / `(without ...)` / `(given ...)` are statements usable as expressions,
+# just as `(for ...)` already was.
+is (with 1 -> $a { $a * 2 }), 2, 'with is usable as an expression';
+is (with 21 { $_ * 2 }), 42, 'with without a pointy binds the topic';
+is (without Nil { 'empty' }), 'empty', 'without is usable as an expression';
+is (given 6 { $_ * 7 }), 42, 'given is usable as an expression';
+is-deeply (for 1 -> $a { $a * 2 }), (2,), 'for is still usable as an expression';
+
+# A sigil needs no space after the declarator.
+my@i = 1, 2, 3;
+is-deeply @i, [1, 2, 3], 'my@i declares an array';
+is <a b c>[my$n = 1], 'b', 'my$n declares inside a subscript';
+
+# A declaration can be the lvalue of a compound assignment. Unlike `=`, the value has to
+# read the variable back, so a `state` initializer would be wrong here: the assignment
+# must run on every pass, not once.
+(my $n) += 5;
+is $n, 5, '(my $n) += 5 assigns to the fresh declaration';
+
+my @maxes;
+for 1, 5, 3 {
+    (state $best) max= $_;
+    @maxes.push($best);
+}
+is-deeply @maxes, [1, 5, 5], '(state $best) max= runs on every pass';
+
+# The state variable stays in the enclosing scope, so a later statement sees it.
+my $seen;
+for 1, 5, 3 {
+    (state $top) max= $_;
+    LAST $seen = $top;
+}
+is $seen, 5, 'a declaration in a compound assignment is visible to later statements';
+
+# `my(...)` is still a call to a keyword-named sub, not a declaration.
+sub my(|c) { 'called' }
+is my('x'), 'called', 'my(...) still calls a keyword-named sub';

--- a/t/returns-coercion-type.t
+++ b/t/returns-coercion-type.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 6;
+
+# `returns` / `of` accept a coercion type, the same way the `-->` arrow already did.
+my sub arrow (Int $x --> Str()) { $x }
+is-deeply arrow(42), '42', '--> Str() coerces the return value';
+
+my sub trait-form (Int $x) returns Str() { $x }
+is-deeply trait-form(42), '42', 'returns Str() coerces the return value';
+
+my sub of-form (Int $x) of Str() { $x }
+is-deeply of-form(42), '42', 'of Str() coerces the return value';
+
+my sub sourced (Str $x) returns Int(Str) { $x }
+is-deeply sourced('42'), 42, 'returns Int(Str) coerces from the named source type';
+
+# A plain (non-coercion) type still works.
+my sub plain (Int $x) returns Str { ~$x }
+is-deeply plain(42), '42', 'returns Str is unchanged';
+
+# A user-declared class is a complete then-expression in a ternary; it must not be parsed
+# as a listop that gobbles the `!!`.
+class Target {}
+class Source { method make-one { self.DEFINITE ?? Target !! Target.new } }
+isa-ok Source.make-one, Target, '?? UserClass !! ... parses in statement position';

--- a/t/when-statement-modifier.t
+++ b/t/when-statement-modifier.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 8;
+
+# `EXPR when COND` is a statement modifier, like `EXPR if COND`.
+my $vowels = 'aaaooouuu';
+is ('all vowels' when $vowels ~~ /^ <[aeiou]>+ $/), 'all vowels', 'when modifier on a match';
+
+# A Match on the right of a smartmatch is an already-decided result, so it passes through
+# like a Bool. That is what lets the above work with no `given` to set the topic.
+my $m = ('abc' ~~ /b/);
+ok (42 ~~ $m), 'smartmatch against a successful Match is true';
+ok (Any ~~ $m), 'smartmatch against a Match ignores the topic';
+nok ('abc' ~~ ('xyz' ~~ /b/)), 'smartmatch against a failed match is false';
+
+# `when` chains with a following `given`, which topicalizes first.
+my $castle = 'phantom';
+is ('Boo!' when /phantom/ given $castle), 'Boo!', 'when ... given ... chains';
+is ('Boo!' when /ghost/ given $castle), Nil, 'a non-matching when yields Nil';
+
+# The topic set by an enclosing `given` block is visible to a `when` modifier.
+my $found;
+given 'camelia' {
+    $found = 'bug' when /camelia/;
+}
+is $found, 'bug', 'when modifier sees the topic of an enclosing given';
+
+# A real `when COND { ... }` statement is still a statement, not a modifier.
+my $branch;
+given 3 {
+    when 3 { $branch = 'three' }
+    default { $branch = 'other' }
+}
+is $branch, 'three', 'when block statement still parses as a block';


### PR DESCRIPTION
The second half of `TODO_roast/BLOCKERS.md` §"② パース不能（===SORRY!===）". #4511 took the quoting bugs; these are all places where a statement construct was not accepted in expression position, or an expression swallowed a token that ends it.

## Parser fixes

- **`when` statement modifier.** It did not exist. `leading_modifier_keyword` already listed `when`, so `EXPR when COND` was recognized and then failed to parse. It lowers to `given $_ { when COND { EXPR } }` — `When` signals a match by raising `succeed`, which only a topicalizer catches, and the wrapper supplies one without changing the topic, so it still composes with a following `given` (`'Boo!' when /phantom/ given $castle`).
- **Smartmatch against a Match returned False.** In Raku a Match is an already-decided match result and passes through like a Bool, whatever the topic is — that is exactly what makes `EXPR when $x ~~ /re/` work with no `given` to set `$_`.
- **`(with ...)` / `(without ...)` / `(given ...)` as expressions.** `(for ...)` already worked; these get the same statement-shim treatment.
- **A declarator needed whitespace before its sigil.** `my@i = 1, 2` was not a declaration at all — it parsed as a sink bareword `my` plus an auto-declared assignment — and `<a b>[my@i = ...]` failed outright. `my(...)` stays a call to a keyword-named sub (there is a unit test pinning that).
- **`min=` / `max=` were eaten as the infix `min`/`max`** followed by a stray `=` — the same exclusion `||=` and `//=` already carried.
- **A declaration could not be the lvalue of a compound assignment.** `(state $best) max= $score` hit `__mutsu_assignment_ro`. It cannot become a `VarDecl` with an initializer (a `state` initializer runs *once*, but the assignment must run on every pass), so it routes through the same callable-lvalue helper the parenthesized `=` form already uses.
- **A user-declared class was rejected as a ternary's then-branch.** The guard that catches `1 ?? rt123115 !! 3` (a listop gobbling the `!!`) only exempted *builtin* types, so `self.DEFINITE ?? Target !! Target.new` was a parse error.
- **`returns` / `of` did not accept a coercion type.** `returns Str()` stopped at the `(` and left `()` to be parsed as a sub body. All three spellings — `returns`, `of`, `-->` — now share one type-name parser.

## Result

`roast/integration/advent2009-day16.t` and `advent2009-day23.t` pass in full and are whitelisted (1387 → 1389).

Three more files stop being parse failures and become feature gaps, recorded in BLOCKERS.md:

| file | now | what is left |
|---|---|---|
| `integration/advent2012-day15.t` | 9/11 | the statement form of a phaser makes its own scope (`NEXT (state $best) max= $_` is invisible to `LAST`); `INIT` runs after the mainline |
| `6.c/MISC/bug-coverage.t` | 12/17 | `.count-only`/`.bool-only`, thunk closure scoping |
| `6.c/APPENDICES/A04-experimental/01-misc.t` | 16/19 | `:D`/`:U` DefiniteHow coercions. **Was 0/19 — the file did not parse at all** |

New tests: `t/when-statement-modifier.t`, `t/decl-as-expression.t`, `t/returns-coercion-type.t`. `make test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tFv8btbbJZpJT6G2vCS2i